### PR TITLE
ci(e2e): add missing permissions for mergeability gate (Fixes #2696)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,18 @@ on:
         default: 'main'
         type: 'string'
 
+# An explicit top-level block is required because the mergeability-gate job
+# calls the reusable ./.github/workflows/_pr-mergeability-gate.yml, which
+# declares `pull-requests: read`. A called workflow cannot grant itself a
+# scope the caller lacks; without `pull-requests` here the run is rejected at
+# graph-construction time (startup_failure, zero jobs). `actions: read` is
+# required by fkirc/skip-duplicate-actions, and `contents: read` by the
+# checkouts and the doc-change filter.
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
 jobs:
   skip_check:
     name: 'Skip Duplicate Check'


### PR DESCRIPTION
## Summary

Fixes #2696.

Every `Testing: E2E` run on `main` has been a `startup_failure` (zero jobs, no check-run published) since db19bc25e. The suite has been silently absent rather than visibly failing.

## Root cause

db19bc25e (Fixes #2587 / #2661) added a `mergeability-gate` job to `.github/workflows/e2e.yml` that calls the reusable workflow `./.github/workflows/_pr-mergeability-gate.yml`. That reusable workflow declares a top-level:

    permissions:
      pull-requests: read

A **called** (reusable) workflow cannot grant itself permissions — its `permissions` block is validated against, and capped by, the **calling** workflow's token. The caller must itself hold the scope.

`e2e.yml` had **no** `permissions:` block at all, so it inherited the repository default (the repo's `actions/permissions/workflow` API returns `default_workflow_permissions: read`), which does **not** include `pull-requests`. The reusable workflow requests a scope the caller lacks, so the run is rejected at graph-construction time — before any job is created. Hence zero jobs, no logs, and no check-run (so it never shows as a red X in PR checks).

The other two callers of the same reusable workflow are unaffected because both declare `pull-requests` explicitly:

- `pr-review.yml`: contents: read, pull-requests: write, issues: read, actions: read
- `ocr-review.yml`: contents: read, pull-requests: write, issues: write

`actionlint` passes cleanly on this defect — the permission cap is only evaluated by the Actions service at run start.

## Fix

Add an explicit top-level `permissions:` block to `.github/workflows/e2e.yml`:

    permissions:
      contents: read
      actions: read
      pull-requests: read

### Why three scopes rather than the two the issue literally suggested

The issue suggested only `contents: read` + `pull-requests: read`. That would **re-break `skip_check`**, because an explicit `permissions:` block zeroes out every unlisted scope.

- **`pull-requests: read`** — required by the reusable mergeability gate. This is the direct fix.
- **`actions: read`** — **required to avoid re-breaking `skip_check`.** `skip_check` uses `fkirc/skip-duplicate-actions` with `skip_after_successful_duplicate: 'true'` and `concurrent_skipping: 'same_content'`, both of which query the Workflow Runs API. That action's own README documents that on read-only-default repos `actions` access is required. Today the inherited default masks this; an explicit block unmasks it. The issue itself anticipates this: "confirm the remaining jobs still have every scope they need."
- **`contents: read`** — required by the checkouts and the doc-change filter; preserves the prior inherited-default behavior for the e2e jobs.

This matches the established pattern in `pr-review.yml` and `ocr-review.yml`.

## Verification

- Local `actionlint` 1.7.10: clean (no errors) — same version used in CI.
- YAML parses correctly; `permissions` block verified to be exactly `{contents: read, actions: read, pull-requests: read}`; all 5 jobs (`skip_check`, `mergeability-gate`, `e2e_doc_change_filter`, `e2e_linux`, `e2e_mac`) intact.
- CI `yamllint`/`actionlint` jobs will run on this PR.

Note: the `startup_failure` class itself cannot be exercised on a PR branch because the e2e workflow only triggers on `push`/`merge_group`/`pull_request`/`pull_request_target`. The definitive verification is the **post-merge push run on `main`** producing jobs rather than `startup_failure`.

## Non-goals (out of scope)

- The issue's "follow-up worth considering" — a scheduled check or required status that makes a `startup_failure` visible — is a separate subsystem and out of scope for this fix.
- Auditing other workflows' permissions.
- Changing the reusable gate or other workflows.

## Scope

1 file changed, +12 lines (purely additive `permissions:` block with an explanatory comment). Well within scope budget.
