### PR TITLE
Remove the dead secure-store-mode CI matrix dimension (Fixes #2703)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,7 +704,7 @@ jobs:
   # service when bun is absent from PATH. Pinning to .bun-version reconciles the
   # CI toolchain with dev-docs/bun.md and avoids a floating Bun version.
   test:
-    name: 'Test (${{ matrix.os }}, ${{ matrix.secure-store-mode }})'
+    name: 'Test (${{ matrix.os }})'
     runs-on: '${{ matrix.os }}'
     needs:
       - 'lint'
@@ -723,9 +723,6 @@ jobs:
           - 'macos-latest'
         node-version:
           - '24.x'
-        secure-store-mode:
-          - 'keyring'
-          - 'fallback'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
@@ -792,8 +789,6 @@ jobs:
           CI: true
           # Allow OpenAI integration tests to exceed Vitest's 5s default timeout (issue #338)
           VITEST_TEST_TIMEOUT: 15000
-          # Force SecureStore to use encrypted-file fallback instead of keyring (R15.2)
-          LLXPRT_SECURE_STORE_FORCE_FALLBACK: ${{ matrix.secure-store-mode == 'fallback' && 'true' || '' }}
         run: 'npm run test'
 
       - name: 'Report harness toolchain versions'
@@ -838,7 +833,7 @@ jobs:
           ${{ always() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
         uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
-          name: 'test-results-fork-${{ matrix.node-version }}-${{ matrix.os }}-${{ matrix.secure-store-mode }}'
+          name: 'test-results-fork-${{ matrix.node-version }}-${{ matrix.os }}'
           path: 'packages/*/junit.xml'
 
       - name: 'Upload coverage reports'
@@ -846,7 +841,7 @@ jobs:
           ${{ always() }}
         uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
-          name: 'coverage-reports-${{ matrix.node-version }}-${{ matrix.os }}-${{ matrix.secure-store-mode }}'
+          name: 'coverage-reports-${{ matrix.node-version }}-${{ matrix.os }}'
           path: 'packages/*/coverage'
 
   post_coverage_comment:
@@ -873,7 +868,7 @@ jobs:
       - name: 'Download coverage reports artifact'
         uses: 'actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0' # ratchet:actions/download-artifact@v5
         with:
-          name: 'coverage-reports-${{ matrix.node-version }}-${{ matrix.os }}-keyring'
+          name: 'coverage-reports-${{ matrix.node-version }}-${{ matrix.os }}'
           path: 'coverage_artifact' # Download to a specific directory
 
       - name: 'Post Coverage Comment using Composite Action'


### PR DESCRIPTION
## Summary

Removes the dead `secure-store-mode` matrix dimension from the `test` job in `.github/workflows/ci.yml`. The `fallback` leg set `LLXPRT_SECURE_STORE_FORCE_FALLBACK`, but nothing in the repository reads that variable, so the two modes (`keyring`/`fallback`) executed an identical test suite with identical outcomes. Half the test matrix (~52 of 110 runner-minutes per run) was duplicated cost with no distinct coverage signal.

Closes #2703 (part of #2702). Supersedes #2147.

## Changes

Single file: `.github/workflows/ci.yml` (+4/-9)

- **Matrix dimension removed**: the `secure-store-mode: [keyring, fallback]` matrix key is deleted. The `test` job now runs `os x node-version` (2 jobs instead of 4).
- **Job name simplified**: `Test (${{ matrix.os }}, ${{ matrix.secure-store-mode }})` -> `Test (${{ matrix.os }})`.
- **Orphaned env var deleted**: the `LLXPRT_SECURE_STORE_FORCE_FALLBACK` env entry and its `# Force SecureStore... (R15.2)` comment are removed from the "Run tests and generate reports" step. A repo-wide grep across `ts/tsx/js/cjs/mjs/yml/sh` (excluding `node_modules`, `dist`, `bundle`) found zero production or test readers; the only other hits are historical planning docs under `project-plans/issue1351_1352/`.
- **Artifact names updated consistently**:
  - Producer `test-results-fork-${node}-${os}-${secure-store-mode}` -> `test-results-fork-${node}-${os}`
  - Producer `coverage-reports-${node}-${os}-${secure-store-mode}` -> `coverage-reports-${node}-${os}`
  - Consumer in `post_coverage_comment` (which hardcoded `-keyring`) updated to `coverage-reports-${node}-${os}` to match. Without this the download would 404 once the producer name changed.
- Artifact names remain unique because the matrix now varies only by `os` and `node-version`.

## Branch-protection note

The job display name changes from `Test (ubuntu-latest, keyring)` to `Test (ubuntu-latest)`. Verified via the GitHub branch-protection and branch-rulesets APIs that `main` has **no** required status checks configured (branch protection returns 404; the only branch ruleset is a disabled `blockforcedelete`), so no required-check rename coordination is needed. The issue's step-4 risk does not apply here.

## Verification

- `actionlint` on `.github/workflows/ci.yml`: no new errors (only a pre-existing shellcheck style note on an unrelated `run:` block, present on `main` too).
- `prettier --check .github/workflows/ci.yml`: passes.
- `npm run build`: passes.
- CLI smoke: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` -> haiku printed.
- `npm run lint` and `npm run typecheck`: `typecheck` has pre-existing failures in `packages/a2a-server` / `src/config/extension.ts` that are unrelated to this change (the only file touched is `.github/workflows/ci.yml`; confirmed the failing files are byte-identical to `main`).
- Open Code Review (agent, 20-min timeout, scoped to `main..issue2703`): 1 file reviewed, 0 comments.
- The definitive before/after runner-minute comparison will be visible on this PR run: expect 2 `Test` jobs instead of 4.

## Acceptance criteria

- [x] The `test` matrix has no `secure-store-mode` dimension.
- [x] No workflow sets `LLXPRT_SECURE_STORE_FORCE_FALLBACK`.
- [x] Artifact names remain unique and do not reference the removed dimension.
- [ ] Test matrix runner-minutes drop by approximately half, evidenced by a before/after run comparison. (Pending this PR run.)

## Non-goals

- Restoring genuine keyring-vs-fallback coverage is the sibling issue referenced in #2702; it is out of scope here.
- No production/test source changes, no new abstractions, no dependency changes.