### PR TITLE
Add shadow-mode severity-based publication routing to OCR workflow (Fixes #2672)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -423,6 +423,7 @@ jobs:
       comments_inline: ${{ steps.post-ocr-results.outputs.comments_inline }}
       comments_skipped: ${{ steps.post-ocr-results.outputs.comments_skipped }}
       comments_failed: ${{ steps.post-ocr-results.outputs.comments_failed }}
+      comments_routed_summary: ${{ steps.post-ocr-results.outputs.comments_routed_summary }}
       summary_comment_url: ${{ steps.post-ocr-results.outputs.summary_comment_url }}
     # The code-review job runs only when the mergeability gate and the
     # auto-review gate both permit it.
@@ -548,6 +549,7 @@ jobs:
           : > ocr-phase.txt
           : > ocr-infrastructure-failure.txt
           : > ocr-policy-failure.txt
+          : > ocr-routing-decisions.json
           cat > ocr-workflow-helpers.sh <<'EOF'
           mark_infrastructure_failure() {
             echo "phase=$1; reason=$2" > ocr-infrastructure-failure.txt
@@ -990,6 +992,11 @@ jobs:
           # Feature 3 (issue #2670): incremental IoU overlap dedup mode.
           OCR_INCREMENTAL: ${{ vars.OCR_INCREMENTAL }}
           OCR_INCREMENTAL_OVERLAP_THRESHOLD: ${{ vars.OCR_INCREMENTAL_OVERLAP_THRESHOLD }}
+          # Issue #2672: severity-based publication routing.
+          # Shadow mode (default 'true') posts all findings inline but logs
+          # routing decisions. Set to 'false' to go live (route low-severity
+          # findings to the sticky summary).
+          OCR_ROUTING_SHADOW_MODE: ${{ vars.OCR_ROUTING_SHADOW_MODE }}
           # Fallback bot login for dedup when getAuthenticated() fails.
           OCR_BOT_LOGIN: ${{ vars.OCR_BOT_LOGIN }}
         with:
@@ -1235,6 +1242,74 @@ jobs:
               return normalized;
             }
 
+            function effectiveCategory(finding) {
+              if (!finding || typeof finding !== 'object') return 'unknown';
+              if (typeof finding.category === 'string' && finding.category && finding.category !== 'unknown') {
+                return finding.category;
+              }
+              if (typeof finding.originalCategory === 'string' && finding.originalCategory && finding.originalCategory !== 'unknown') {
+                return finding.originalCategory;
+              }
+              return 'unknown';
+            }
+
+            function effectiveSeverity(finding) {
+              if (!finding || typeof finding !== 'object') return 'unknown';
+              if (typeof finding.severity === 'string' && finding.severity && finding.severity !== 'unknown') {
+                return finding.severity;
+              }
+              if (typeof finding.originalSeverity === 'string' && finding.originalSeverity && finding.originalSeverity !== 'unknown') {
+                return finding.originalSeverity;
+              }
+              return 'unknown';
+            }
+
+            function routeFinding(finding) {
+              if (!finding || typeof finding !== 'object' || Array.isArray(finding)) {
+                return { destination: 'inline', reason: 'non-object finding: fail-safe inline' };
+              }
+              const category = effectiveCategory(finding);
+              const severity = effectiveSeverity(finding);
+
+              // Protected categories are always inline regardless of severity.
+              if (category === 'bug' || category === 'security' || category === 'correctness') {
+                return { destination: 'inline', reason: `category '${category}': always inline` };
+              }
+
+              // High/medium severity is always inline regardless of category.
+              if (severity === 'high' || severity === 'medium') {
+                return { destination: 'inline', reason: `severity '${severity}': inline` };
+              }
+
+              // Unknown category defaults to inline (fail-safe).
+              const isKnownCategory = category === 'maintainability' || category === 'test' || category === 'style';
+              if (!isKnownCategory && category !== 'other') {
+                return { destination: 'inline', reason: `category '${category}': fail-safe inline` };
+              }
+
+              // Info severity is routed to summary.
+              if (severity === 'info') {
+                return { destination: 'summary', reason: `severity 'info': routed to summary` };
+              }
+
+              // Known or 'other' category with low severity → summary.
+              if (severity === 'low') {
+                return { destination: 'summary', reason: `category '${category}' severity 'low': routed to summary` };
+              }
+
+              // Remaining unknown severities default to inline (fail-safe).
+              return { destination: 'inline', reason: `category '${category}' severity '${severity}': fail-safe inline` };
+            }
+
+            function categorySeverityLabel(finding) {
+              if (!finding || typeof finding !== 'object') {
+                return '';
+              }
+              const category = effectiveCategory(finding);
+              const severity = effectiveSeverity(finding);
+              return `**[${category}/${severity}]** `;
+            }
+
             function escapeMarkdownHtml(value) {
               return value
                 .replace(new RegExp('&', 'g'), '&amp;')
@@ -1408,35 +1483,82 @@ jobs:
             // with a stderr warning, without suppressing any finding.
             findings = findings.map(validateFindingMetadata);
 
+            // Issue #2672: compute routing decisions for EVERY finding before
+            // dedup so suppressed duplicates still get artifact records, and a
+            // protected finding (e.g. security/high) that shares a dedup key
+            // with a low-severity finding is still accounted for.
+            const routingShadowMode = process.env.OCR_ROUTING_SHADOW_MODE !== 'false';
+            const allRoutingDecisions = findings.map((f) => {
+              const decision = routeFinding(f);
+              const meta = (f && typeof f === 'object') ? f : {};
+              return {
+                path: typeof meta.path === 'string' ? meta.path : '',
+                start_line: Number.isInteger(meta.start_line) ? meta.start_line : null,
+                end_line: Number.isInteger(meta.end_line) ? meta.end_line : null,
+                category: effectiveCategory(meta),
+                severity: effectiveSeverity(meta),
+                destination: decision.destination,
+                reason: decision.reason,
+              };
+            });
+
             const dedupedFindings = deduplicateFindings(findings);
             let suppressedDuplicateCount = 0;
             suppressedDuplicateCount = dedupedFindings.suppressed;
             findings = dedupedFindings.deduped;
 
-            // Split findings into inline (resolvable file/line) vs. lineless.
+            // Issue #2672: routing decisions for the deduped set. Recomputed
+            // (not sliced from allRoutingDecisions) because dedup may remove
+            // findings from anywhere in the array.
+            const routingDecisions = findings.map((f) => {
+              const decision = routeFinding(f);
+              const meta = (f && typeof f === 'object') ? f : {};
+              return {
+                category: effectiveCategory(meta),
+                severity: effectiveSeverity(meta),
+                destination: decision.destination,
+                reason: decision.reason,
+              };
+            });
+            const wouldRouteToSummary = routingDecisions.filter((d) => d.destination === 'summary').length;
+
+            // Split findings into inline (resolvable file/line), summary-routed,
+            // and lineless. In shadow mode all line-addressable findings go
+            // inline (issue #2672). In go-live mode, findings routed to
+            // 'summary' are held back from inline posting.
             const inline = [];
+            const summaryRouted = [];
             const lineless = [];
             for (const f of findings) {
+              const decision = routeFinding(f);
               if (f && f.path && Number.isInteger(f.start_line) &&
                   Number.isInteger(f.end_line) && f.start_line > 0 && f.end_line > 0) {
-                let startLine = Number(f.start_line);
-                let endLine = Number(f.end_line);
-                if (startLine > endLine) {
-                  [startLine, endLine] = [endLine, startLine];
+                if (!routingShadowMode && decision.destination === 'summary') {
+                  summaryRouted.push(f);
+                } else {
+                  let startLine = Number(f.start_line);
+                  let endLine = Number(f.end_line);
+                  if (startLine > endLine) {
+                    [startLine, endLine] = [endLine, startLine];
+                  }
+                  const rawText = f.content || f.comment || f.message || f.body;
+                  const label = categorySeverityLabel(f);
+                  const rendered = renderFindingText(typeof rawText === 'string' ? rawText : 'OCR finding');
+                  // Insert the label inside the blockquote (after the first
+                  // '> ' prefix) so the first line stays '> **[cat/sev]** text'.
+                  const labeledText = label ? rendered.replace(/^> /, `> ${label}`) : rendered;
+                  const comment = {
+                    path: String(f.path),
+                    line: endLine,
+                    side: 'RIGHT',
+                    body: `${INLINE_MARKER}\n${labeledText}`,
+                  };
+                  if (startLine < endLine) {
+                    comment.start_line = startLine;
+                    comment.start_side = 'RIGHT';
+                  }
+                  inline.push(comment);
                 }
-                const rawText = f.content || f.comment || f.message || f.body;
-                const text = renderFindingText(typeof rawText === 'string' ? rawText : 'OCR finding');
-                const comment = {
-                  path: String(f.path),
-                  line: endLine,
-                  side: 'RIGHT',
-                  body: `${INLINE_MARKER}\n${text}`,
-                };
-                if (startLine < endLine) {
-                  comment.start_line = startLine;
-                  comment.start_side = 'RIGHT';
-                }
-                inline.push(comment);
               } else {
                 lineless.push(f && typeof f === 'object' ? f : { body: f || 'Malformed OCR finding' });
               }
@@ -1615,10 +1737,45 @@ jobs:
               for (const f of lineless) {
                 const item = f && typeof f === 'object' ? f : {};
                 const where = item.path ? `\`${item.path}\`: ` : '';
+                const label = categorySeverityLabel(f);
                 const rawText = item.content || item.comment || item.message || item.body;
                 const text = renderFindingText(typeof rawText === 'string' ? rawText : 'OCR finding');
-                body.push(`- ${where}${text}`);
+                body.push(`- ${where}${label}${text}`);
               }
+            }
+            if (summaryRouted.length > 0) {
+              body.push('', '### Findings routed to summary', '');
+              for (const f of summaryRouted) {
+                const where = f.path ? `\`${f.path}\`: ` : '';
+                const label = categorySeverityLabel(f);
+                const rawText = f.content || f.comment || f.message || f.body;
+                const text = renderFindingText(typeof rawText === 'string' ? rawText : 'OCR finding');
+                body.push(`- ${where}${label}${text}`);
+              }
+            }
+            if (routingShadowMode && wouldRouteToSummary > 0) {
+              body.push('', '### Shadow-mode routing preview (issue #2672)', '');
+              body.push(`- ${wouldRouteToSummary} finding(s) would be routed to this summary instead of inline comments.`);
+              const summaryByCategory = {};
+              for (const d of routingDecisions) {
+                if (d.destination === 'summary') {
+                  const key = `${d.category}/${d.severity}`;
+                  summaryByCategory[key] = (summaryByCategory[key] || 0) + 1;
+                }
+              }
+              for (const [key, count] of Object.entries(summaryByCategory)) {
+                body.push(`  - \`${key}\`: ${count}`);
+              }
+              body.push('- Set repository variable `OCR_ROUTING_SHADOW_MODE=false` to enable live routing.');
+            }
+            // Issue #2672: persist ALL routing decisions (pre-dedup) so every
+            // finding gets an artifact record with its routing reason, even
+            // duplicates that dedup later suppresses.
+            try {
+              const routingJson = JSON.stringify(allRoutingDecisions, null, 2);
+              fs.writeFileSync('ocr-routing-decisions.json', routingJson);
+            } catch (routingWriteErr) {
+              core.warning(`Failed to write ocr-routing-decisions.json: ${routingWriteErr.message || routingWriteErr}`);
             }
             const isAutomatic = process.env.IS_AUTOMATIC === 'true';
 
@@ -1746,6 +1903,7 @@ jobs:
             core.setOutput('comments_inline', String(postedInline));
             core.setOutput('comments_skipped', String(commentsSkipped));
             core.setOutput('comments_failed', String(failedInline));
+            core.setOutput('comments_routed_summary', String(summaryRouted.length));
             core.setOutput('summary_comment_url', summaryCommentUrl);
 
             if (!ran) {
@@ -1814,6 +1972,7 @@ jobs:
             'ocr-phase.txt',
             'ocr-infrastructure-failure.txt',
             'ocr-policy-failure.txt',
+            'ocr-routing-decisions.json',
           ];
           const replaceWithRedactionFailure = (fileName, error) => {
             const code = error && error.code ? error.code : 'unknown';
@@ -1861,7 +2020,8 @@ jobs:
             ocr-exit-code.txt \
             ocr-phase.txt \
             ocr-infrastructure-failure.txt \
-            ocr-policy-failure.txt; do
+            ocr-policy-failure.txt \
+            ocr-routing-decisions.json; do
             if [ ! -e "$file_name" ]; then
               : > "$file_name"
               missing="${missing}${file_name}"$'\n'
@@ -1903,6 +2063,7 @@ jobs:
             ocr-phase.txt
             ocr-infrastructure-failure.txt
             ocr-policy-failure.txt
+            ocr-routing-decisions.json
           if-no-files-found: warn
 
       - name: Clean up scoped safe.directory

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1510,17 +1510,26 @@ jobs:
             // Issue #2672: routing decisions for the deduped set. Recomputed
             // (not sliced from allRoutingDecisions) because dedup may remove
             // findings from anywhere in the array.
-            const routingDecisions = findings.map((f) => {
+            const routingDecisions = findings.map((f, i) => {
               const decision = routeFinding(f);
               const meta = (f && typeof f === 'object') ? f : {};
+              const hasPosition = meta.path && Number.isInteger(meta.start_line) &&
+                Number.isInteger(meta.end_line) && meta.start_line > 0 && meta.end_line > 0;
               return {
                 category: effectiveCategory(meta),
                 severity: effectiveSeverity(meta),
                 destination: decision.destination,
                 reason: decision.reason,
+                hasPosition,
               };
             });
-            const wouldRouteToSummary = routingDecisions.filter((d) => d.destination === 'summary').length;
+            // Only count findings that would actually be held back from
+            // inline posting (line-addressable). Lineless findings always
+            // go to the summary regardless of routing, so including them
+            // would inflate the shadow-mode preview count.
+            const wouldRouteToSummary = routingDecisions.filter(
+              (d) => d.hasPosition && d.destination === 'summary',
+            ).length;
 
             // Split findings into inline (resolvable file/line), summary-routed,
             // and lineless. In shadow mode all line-addressable findings go
@@ -1903,7 +1912,7 @@ jobs:
             core.setOutput('comments_inline', String(postedInline));
             core.setOutput('comments_skipped', String(commentsSkipped));
             core.setOutput('comments_failed', String(failedInline));
-            core.setOutput('comments_routed_summary', String(summaryRouted.length));
+            core.setOutput('comments_routed_summary', String(routingShadowMode ? wouldRouteToSummary : summaryRouted.length));
             core.setOutput('summary_comment_url', summaryCommentUrl);
 
             if (!ran) {

--- a/scripts/tests/ocr-review-routing.test.js
+++ b/scripts/tests/ocr-review-routing.test.js
@@ -1,0 +1,679 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vm from 'node:vm';
+import { beforeAll, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import {
+  WORKFLOW_PATH,
+  commandText,
+  extractFunctionSource,
+  readRootFile,
+  stepNamed,
+} from './ocr-review-workflow-helpers.js';
+
+// Security note: The vm.runInNewContext calls in this suite execute JavaScript
+// extracted from the trusted, version-controlled ocr-review.yml workflow via
+// extractFunctionSource. This is trusted repository content (not user/PR input)
+// and the workflow helper is read from the checked-out HEAD. The vm sandbox is
+// used to evaluate the real production function in isolation with stubbed
+// globals, proving actual runtime behavior without mocking the function itself.
+
+describe('.github/workflows/ocr-review.yml — severity-based routing (#2672)', () => {
+  let workflow;
+  let codeReviewJob;
+  let postStep;
+  let postScript;
+
+  beforeAll(() => {
+    const workflowYml = readRootFile(WORKFLOW_PATH);
+    workflow = yaml.load(workflowYml);
+    if (!workflow || typeof workflow !== 'object') {
+      throw new Error(`${WORKFLOW_PATH} did not parse to a YAML mapping`);
+    }
+    codeReviewJob = workflow.jobs?.['code-review'];
+    expect(
+      codeReviewJob,
+      'workflow should contain job: code-review',
+    ).toBeTruthy();
+    postStep = stepNamed(codeReviewJob, 'Post OCR results');
+    postScript = commandText(postStep);
+  });
+
+  /**
+   * Extract routeFinding AND its helper functions (effectiveCategory,
+   * effectiveSeverity) from the committed workflow YAML and execute them
+   * in an isolated vm sandbox. routeFinding depends on these helpers.
+   */
+  function loadRouteFinding() {
+    const effCat = extractFunctionSource(postScript, 'effectiveCategory');
+    const effSev = extractFunctionSource(postScript, 'effectiveSeverity');
+    const routeSrc = extractFunctionSource(postScript, 'routeFinding');
+    const sandbox = {};
+    vm.createContext(sandbox);
+    vm.runInContext([effCat, effSev, routeSrc].join('\n'), sandbox);
+    expect(typeof sandbox.routeFinding).toBe('function');
+    return sandbox.routeFinding;
+  }
+
+  function loadCategorySeverityLabel() {
+    const effCat = extractFunctionSource(postScript, 'effectiveCategory');
+    const effSev = extractFunctionSource(postScript, 'effectiveSeverity');
+    const labelSrc = extractFunctionSource(postScript, 'categorySeverityLabel');
+    const sandbox = {};
+    vm.createContext(sandbox);
+    vm.runInContext([effCat, effSev, labelSrc].join('\n'), sandbox);
+    expect(typeof sandbox.categorySeverityLabel).toBe('function');
+    return sandbox.categorySeverityLabel;
+  }
+
+  // -------------------------------------------------------------------------
+  // routeFinding behavioral tests — protected categories (always inline)
+  // -------------------------------------------------------------------------
+  describe('routeFinding behavior — protected categories', () => {
+    it('routes bug/high to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination, reason } = routeFinding({
+        category: 'bug',
+        severity: 'high',
+      });
+      expect(destination).toBe('inline');
+      expect(reason).toContain('bug');
+    });
+
+    it('routes bug/low to inline (bug always inline regardless of severity)', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'bug',
+        severity: 'low',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes bug/info to inline (protected category takes priority over info)', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'bug',
+        severity: 'info',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes security/medium to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'security',
+        severity: 'medium',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes security/low to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'security',
+        severity: 'low',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes security/info to inline (protected category priority)', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'security',
+        severity: 'info',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes correctness (via originalCategory) to inline regardless of severity', () => {
+      // Metadata validation (#2671) normalizes 'correctness' to 'unknown' in
+      // category, preserving originalCategory. Routing must recognize
+      // originalCategory='correctness' and keep it inline.
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'unknown',
+        severity: 'unknown',
+        originalCategory: 'correctness',
+        originalSeverity: 'info',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes correctness/low (direct category) to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'correctness',
+        severity: 'low',
+      });
+      expect(destination).toBe('inline');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // routeFinding behavioral tests — high/medium severity (always inline)
+  // -------------------------------------------------------------------------
+  describe('routeFinding behavior — high/medium severity', () => {
+    it('routes maintainability/high to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'maintainability',
+        severity: 'high',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes maintainability/medium to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'maintainability',
+        severity: 'medium',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes test/high to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'test',
+        severity: 'high',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes test/medium to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'test',
+        severity: 'medium',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes style/high to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'style',
+        severity: 'high',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes style/medium to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'style',
+        severity: 'medium',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes high severity to inline even with conflicting originalSeverity info', () => {
+      // A finding with severity='high' but originalSeverity='info' must
+      // remain inline because high takes priority over info.
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'maintainability',
+        severity: 'high',
+        originalSeverity: 'info',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes medium severity to inline even with conflicting originalSeverity info', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'test',
+        severity: 'medium',
+        originalSeverity: 'info',
+      });
+      expect(destination).toBe('inline');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // routeFinding behavioral tests — summary routing (low and info)
+  // -------------------------------------------------------------------------
+  describe('routeFinding behavior — summary routing', () => {
+    it('routes maintainability/low to summary', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination, reason } = routeFinding({
+        category: 'maintainability',
+        severity: 'low',
+      });
+      expect(destination).toBe('summary');
+      expect(reason).toContain('maintainability');
+      expect(reason).toContain('low');
+    });
+
+    it('routes test/low to summary', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination, reason } = routeFinding({
+        category: 'test',
+        severity: 'low',
+      });
+      expect(destination).toBe('summary');
+      expect(reason).toContain('test');
+    });
+
+    it('routes style/low to summary', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination, reason } = routeFinding({
+        category: 'style',
+        severity: 'low',
+      });
+      expect(destination).toBe('summary');
+      expect(reason).toContain('style');
+    });
+
+    it('routes maintainability/info to summary', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination, reason } = routeFinding({
+        category: 'maintainability',
+        severity: 'info',
+      });
+      expect(destination).toBe('summary');
+      expect(reason).toContain('info');
+    });
+
+    it('routes test/info to summary', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'test',
+        severity: 'info',
+      });
+      expect(destination).toBe('summary');
+    });
+
+    it('routes other/low to summary (other is treated as summary-eligible)', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'other',
+        severity: 'low',
+      });
+      expect(destination).toBe('summary');
+    });
+
+    it('routes other/info to summary', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'other',
+        severity: 'info',
+      });
+      expect(destination).toBe('summary');
+    });
+
+    it('routes maintainability with originalSeverity info to summary (when severity is unknown)', () => {
+      // Metadata validation normalizes 'info' to 'unknown' in severity,
+      // preserving originalSeverity. effectiveSeverity recovers it.
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'maintainability',
+        severity: 'unknown',
+        originalSeverity: 'info',
+      });
+      expect(destination).toBe('summary');
+    });
+
+    it('routes test with originalSeverity info to summary (when severity is unknown)', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'test',
+        severity: 'unknown',
+        originalSeverity: 'info',
+      });
+      expect(destination).toBe('summary');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // routeFinding behavioral tests — fail-safe (unknown → inline)
+  // -------------------------------------------------------------------------
+  describe('routeFinding behavior — fail-safe', () => {
+    it('routes unknown/high to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'unknown',
+        severity: 'high',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes unknown/low to inline (unknown category fail-safe)', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'unknown',
+        severity: 'low',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes unknown category with originalSeverity info to inline (fail-safe)', () => {
+      // Unknown category + info severity must NOT route to summary.
+      // The fail-safe for unknown categories takes priority.
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'unknown',
+        severity: 'unknown',
+        originalSeverity: 'info',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes missing category with originalSeverity info to inline (fail-safe)', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        originalSeverity: 'info',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes null finding to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding(null);
+      expect(destination).toBe('inline');
+    });
+
+    it('routes non-object finding (string) to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding('some string');
+      expect(destination).toBe('inline');
+    });
+
+    it('routes array finding to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding(['stray', 'array']);
+      expect(destination).toBe('inline');
+    });
+
+    it('routes maintainability/unknown to inline (unknown severity fail-safe)', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'maintainability',
+        severity: 'unknown',
+      });
+      expect(destination).toBe('inline');
+    });
+
+    it('routes missing category and severity to inline', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({});
+      expect(destination).toBe('inline');
+    });
+
+    it('routes security with originalSeverity info to inline (protected category)', () => {
+      const routeFinding = loadRouteFinding();
+      const { destination } = routeFinding({
+        category: 'security',
+        severity: 'unknown',
+        originalSeverity: 'info',
+      });
+      expect(destination).toBe('inline');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // categorySeverityLabel behavioral tests
+  // -------------------------------------------------------------------------
+  describe('categorySeverityLabel behavior', () => {
+    it('renders valid category and severity', () => {
+      const categorySeverityLabel = loadCategorySeverityLabel();
+      const label = categorySeverityLabel({
+        category: 'bug',
+        severity: 'high',
+      });
+      expect(label).toBe('**[bug/high]** ');
+    });
+
+    it('defaults missing category and severity to unknown', () => {
+      const categorySeverityLabel = loadCategorySeverityLabel();
+      const label = categorySeverityLabel({});
+      expect(label).toBe('**[unknown/unknown]** ');
+    });
+
+    it('recovers effective category from originalCategory', () => {
+      const categorySeverityLabel = loadCategorySeverityLabel();
+      const label = categorySeverityLabel({
+        category: 'unknown',
+        originalCategory: 'correctness',
+      });
+      expect(label).toBe('**[correctness/unknown]** ');
+    });
+
+    it('recovers effective severity from originalSeverity', () => {
+      const categorySeverityLabel = loadCategorySeverityLabel();
+      const label = categorySeverityLabel({
+        category: 'maintainability',
+        severity: 'unknown',
+        originalSeverity: 'info',
+      });
+      expect(label).toBe('**[maintainability/info]** ');
+    });
+
+    it('returns empty string for non-object finding', () => {
+      const categorySeverityLabel = loadCategorySeverityLabel();
+      const label = categorySeverityLabel('string');
+      expect(label).toBe('');
+    });
+
+    it('returns empty string for null finding', () => {
+      const categorySeverityLabel = loadCategorySeverityLabel();
+      const label = categorySeverityLabel(null);
+      expect(label).toBe('');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // YAML wiring / structural tests
+  // -------------------------------------------------------------------------
+  describe('YAML wiring', () => {
+    it('defines routeFinding(finding) in the post step', () => {
+      expect(postScript).toContain('function routeFinding(finding)');
+    });
+
+    it('defines effectiveCategory(finding) helper', () => {
+      expect(postScript).toContain('function effectiveCategory(finding)');
+    });
+
+    it('defines effectiveSeverity(finding) helper', () => {
+      expect(postScript).toContain('function effectiveSeverity(finding)');
+    });
+
+    it('defines categorySeverityLabel(finding) in the post step', () => {
+      expect(postScript).toContain('function categorySeverityLabel(finding)');
+    });
+
+    it('wires OCR_ROUTING_SHADOW_MODE env variable', () => {
+      expect(postStep.env?.OCR_ROUTING_SHADOW_MODE).toBe(
+        '${{ vars.OCR_ROUTING_SHADOW_MODE }}',
+      );
+    });
+
+    it('defaults routingShadowMode to true via !== false pattern', () => {
+      expect(postScript).toContain(
+        "process.env.OCR_ROUTING_SHADOW_MODE !== 'false'",
+      );
+    });
+
+    it('sets comments_routed_summary output via core.setOutput', () => {
+      expect(postScript).toContain("core.setOutput('comments_routed_summary'");
+    });
+
+    it('declares summaryRouted array in the split loop', () => {
+      expect(postScript).toContain('const summaryRouted = [];');
+    });
+
+    it('renders category/severity labels inside blockquote in inline bodies', () => {
+      // The label must be placed INSIDE the blockquote (> label text), not
+      // before it (label > text), so the blockquote format is preserved.
+      expect(postScript).toContain('labeledText');
+      expect(postScript).toContain('replace(/^> /, `> ${label}`)');
+    });
+
+    it('renders labels for lineless findings', () => {
+      // Lineless findings must also get category/severity labels.
+      const linelessIndex = postScript.indexOf(
+        'Findings without a resolvable position',
+      );
+      expect(linelessIndex).toBeGreaterThan(-1);
+      const afterLineless = postScript.substring(
+        linelessIndex,
+        linelessIndex + 500,
+      );
+      expect(afterLineless).toContain('categorySeverityLabel');
+    });
+
+    it('includes shadow-mode routing preview section in summary', () => {
+      expect(postScript).toContain('Shadow-mode routing preview');
+    });
+
+    it('includes summary-routed findings section without misleading heading', () => {
+      // The heading must NOT say "low severity" since info findings are
+      // also routed there.
+      expect(postScript).toContain("'### Findings routed to summary'");
+      expect(postScript).not.toContain(
+        "'### Findings routed to summary (low severity)'",
+      );
+    });
+
+    it('writes ocr-routing-decisions.json artifact with ALL decisions', () => {
+      expect(postScript).toContain(
+        "fs.writeFileSync('ocr-routing-decisions.json'",
+      );
+      expect(postScript).toContain('allRoutingDecisions');
+    });
+
+    it('exposes comments_routed_summary in job outputs', () => {
+      expect(codeReviewJob.outputs?.comments_routed_summary).toBe(
+        '${{ steps.post-ocr-results.outputs.comments_routed_summary }}',
+      );
+    });
+
+    it('includes ocr-routing-decisions.json in Initialize step', () => {
+      const initStep = stepNamed(
+        codeReviewJob,
+        'Initialize OCR artifact files',
+      );
+      const initRun = commandText(initStep);
+      expect(initRun).toContain(': > ocr-routing-decisions.json');
+    });
+
+    it('includes ocr-routing-decisions.json in Redact step', () => {
+      const redactStep = stepNamed(
+        codeReviewJob,
+        'Redact OCR diagnostic artifacts',
+      );
+      const redactRun = commandText(redactStep);
+      expect(redactRun).toContain("'ocr-routing-decisions.json'");
+    });
+
+    it('includes ocr-routing-decisions.json in Ensure placeholders step', () => {
+      const ensureStep = stepNamed(
+        codeReviewJob,
+        'Ensure OCR artifact placeholders exist',
+      );
+      const ensureRun = commandText(ensureStep);
+      expect(ensureRun).toContain('ocr-routing-decisions.json');
+    });
+
+    it('includes ocr-routing-decisions.json in Upload artifacts step', () => {
+      const uploadStep = stepNamed(codeReviewJob, 'Upload OCR artifacts');
+      expect(uploadStep.with?.path).toContain('ocr-routing-decisions.json');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pipeline ordering test — routing decisions
+  // -------------------------------------------------------------------------
+  describe('pipeline ordering', () => {
+    it('computes allRoutingDecisions before dedup so suppressed findings still get artifact records', () => {
+      // allRoutingDecisions must be computed BEFORE deduplication so every
+      // finding — including duplicates that dedup later suppresses — gets a
+      // routing decision record in the artifact.
+      const validateIndex = postScript.indexOf(
+        'findings.map(validateFindingMetadata)',
+      );
+      const allRoutingIndex = postScript.indexOf('allRoutingDecisions');
+      const dedupIndex = postScript.indexOf(
+        'const dedupedFindings = deduplicateFindings(findings);',
+      );
+
+      expect(validateIndex).toBeGreaterThan(-1);
+      expect(allRoutingIndex).toBeGreaterThan(validateIndex);
+      expect(dedupIndex).toBeGreaterThan(allRoutingIndex);
+    });
+
+    it('computes routingDecisions for deduped set after dedup (not sliced from pre-dedup)', () => {
+      // routingDecisions (used for shadow-mode preview counts) must be
+      // recomputed for the deduped set, not sliced from allRoutingDecisions,
+      // because dedup can remove findings from anywhere in the array.
+      const dedupAssignIndex = postScript.indexOf(
+        'findings = dedupedFindings.deduped;',
+      );
+      const routingDecisionsIndex = postScript.indexOf(
+        'const routingDecisions = findings.map',
+      );
+      const splitIndex = postScript.indexOf('const summaryRouted = [];');
+
+      expect(dedupAssignIndex).toBeGreaterThan(-1);
+      expect(routingDecisionsIndex).toBeGreaterThan(dedupAssignIndex);
+      expect(splitIndex).toBeGreaterThan(routingDecisionsIndex);
+      // Must not use the incorrect slice pattern.
+      expect(postScript).not.toContain(
+        'allRoutingDecisions.slice(0, findings.length)',
+      );
+    });
+
+    it('writes routing artifact before the summary is posted', () => {
+      const writeIndex = postScript.indexOf(
+        "fs.writeFileSync('ocr-routing-decisions.json'",
+      );
+      const postIndex = postScript.indexOf('createOrUpdateMarkerComment');
+      expect(writeIndex).toBeGreaterThan(-1);
+      expect(postIndex).toBeGreaterThan(writeIndex);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Shadow-mode vs go-live integration tests
+  // -------------------------------------------------------------------------
+  describe('shadow-mode and go-live integration', () => {
+    it('routes to summaryRouted only when not in shadow mode', () => {
+      expect(postScript).toContain(
+        "!routingShadowMode && decision.destination === 'summary'",
+      );
+    });
+
+    it('uses categorySeverityLabel for summary-routed findings', () => {
+      const routedSectionIndex = postScript.indexOf(
+        'Findings routed to summary',
+      );
+      expect(routedSectionIndex).toBeGreaterThan(-1);
+      const afterRouted = postScript.substring(
+        routedSectionIndex,
+        routedSectionIndex + 600,
+      );
+      expect(afterRouted).toContain('categorySeverityLabel');
+    });
+
+    it('tracks wouldRouteToSummary count from routingDecisions', () => {
+      expect(postScript).toContain("d.destination === 'summary'");
+      expect(postScript).toContain('wouldRouteToSummary');
+    });
+
+    it('breaks down shadow-mode preview by category/severity', () => {
+      const previewIndex = postScript.indexOf('Shadow-mode routing preview');
+      expect(previewIndex).toBeGreaterThan(-1);
+      const afterPreview = postScript.substring(
+        previewIndex,
+        previewIndex + 800,
+      );
+      expect(afterPreview).toContain('summaryByCategory');
+      expect(afterPreview).toContain('d.category');
+      expect(afterPreview).toContain('d.severity');
+    });
+  });
+});

--- a/scripts/tests/ocr-review-routing.test.js
+++ b/scripts/tests/ocr-review-routing.test.js
@@ -19,8 +19,21 @@ import {
 // extracted from the trusted, version-controlled ocr-review.yml workflow via
 // extractFunctionSource. This is trusted repository content (not user/PR input)
 // and the workflow helper is read from the checked-out HEAD. The vm sandbox is
-// used to evaluate the real production function in isolation with stubbed
-// globals, proving actual runtime behavior without mocking the function itself.
+// used to evaluate the real production function in isolation (with an empty
+// global scope), proving actual runtime behavior without mocking the function
+// itself.
+
+/**
+ * Names of the helper functions that must exist in the post step before
+ * extraction. Asserting these up front gives a precise error pointing at the
+ * missing function rather than a buried stack trace inside the VM loader.
+ */
+const REQUIRED_FUNCTION_NAMES = [
+  'effectiveCategory',
+  'effectiveSeverity',
+  'routeFinding',
+  'categorySeverityLabel',
+];
 
 describe('.github/workflows/ocr-review.yml — severity-based routing (#2672)', () => {
   let workflow;
@@ -43,31 +56,60 @@ describe('.github/workflows/ocr-review.yml — severity-based routing (#2672)', 
     postScript = commandText(postStep);
   });
 
+  function assertFunctionsPresent(script) {
+    for (const name of REQUIRED_FUNCTION_NAMES) {
+      expect(
+        script.includes(`function ${name}(`),
+        `post step should define function ${name}`,
+      ).toBe(true);
+    }
+  }
+
   /**
-   * Extract routeFinding AND its helper functions (effectiveCategory,
-   * effectiveSeverity) from the committed workflow YAML and execute them
-   * in an isolated vm sandbox. routeFinding depends on these helpers.
+   * Extract the routing functions from the committed workflow YAML, validate
+   * they are present, and load them into a single shared VM sandbox. The
+   * results are cached because the workflow source is immutable during the
+   * test run.
    */
-  function loadRouteFinding() {
-    const effCat = extractFunctionSource(postScript, 'effectiveCategory');
-    const effSev = extractFunctionSource(postScript, 'effectiveSeverity');
+  let cachedRouteFinding = null;
+  let cachedCategorySeverityLabel = null;
+
+  function loadWorkflowFunctions() {
+    if (cachedRouteFinding && cachedCategorySeverityLabel) {
+      return {
+        routeFinding: cachedRouteFinding,
+        categorySeverityLabel: cachedCategorySeverityLabel,
+      };
+    }
+    assertFunctionsPresent(postScript);
+    const helpers = [
+      extractFunctionSource(postScript, 'effectiveCategory'),
+      extractFunctionSource(postScript, 'effectiveSeverity'),
+    ];
     const routeSrc = extractFunctionSource(postScript, 'routeFinding');
-    const sandbox = {};
-    vm.createContext(sandbox);
-    vm.runInContext([effCat, effSev, routeSrc].join('\n'), sandbox);
-    expect(typeof sandbox.routeFinding).toBe('function');
-    return sandbox.routeFinding;
+    const labelSrc = extractFunctionSource(postScript, 'categorySeverityLabel');
+    const routeSandbox = {};
+    vm.createContext(routeSandbox);
+    vm.runInContext([...helpers, routeSrc].join('\n'), routeSandbox);
+    expect(typeof routeSandbox.routeFinding).toBe('function');
+    const labelSandbox = {};
+    vm.createContext(labelSandbox);
+    vm.runInContext([...helpers, labelSrc].join('\n'), labelSandbox);
+    expect(typeof labelSandbox.categorySeverityLabel).toBe('function');
+    cachedRouteFinding = routeSandbox.routeFinding;
+    cachedCategorySeverityLabel = labelSandbox.categorySeverityLabel;
+    return {
+      routeFinding: cachedRouteFinding,
+      categorySeverityLabel: cachedCategorySeverityLabel,
+    };
+  }
+
+  function loadRouteFinding() {
+    return loadWorkflowFunctions().routeFinding;
   }
 
   function loadCategorySeverityLabel() {
-    const effCat = extractFunctionSource(postScript, 'effectiveCategory');
-    const effSev = extractFunctionSource(postScript, 'effectiveSeverity');
-    const labelSrc = extractFunctionSource(postScript, 'categorySeverityLabel');
-    const sandbox = {};
-    vm.createContext(sandbox);
-    vm.runInContext([effCat, effSev, labelSrc].join('\n'), sandbox);
-    expect(typeof sandbox.categorySeverityLabel).toBe('function');
-    return sandbox.categorySeverityLabel;
+    return loadWorkflowFunctions().categorySeverityLabel;
   }
 
   // -------------------------------------------------------------------------
@@ -659,7 +701,11 @@ describe('.github/workflows/ocr-review.yml — severity-based routing (#2672)', 
       expect(afterRouted).toContain('categorySeverityLabel');
     });
 
-    it('tracks wouldRouteToSummary count from routingDecisions', () => {
+    it('tracks wouldRouteToSummary count filtering to line-addressable findings only', () => {
+      // wouldRouteToSummary must filter to findings with valid path/line
+      // numbers (hasPosition) so lineless findings — which always go to
+      // the summary — do not inflate the shadow-mode preview count.
+      expect(postScript).toContain('hasPosition');
       expect(postScript).toContain("d.destination === 'summary'");
       expect(postScript).toContain('wouldRouteToSummary');
     });


### PR DESCRIPTION
## Summary

Implements severity-based publication routing for OCR findings to reduce inline comment noise (issue #2672). In shadow mode (default ON), all findings continue to post inline while routing decisions are logged to a durable artifact and a preview is rendered in the sticky summary. When go-live is enabled via repository variable OCR_ROUTING_SHADOW_MODE=false, low-severity maintainability/test/style and info findings route to the sticky summary instead of inline comments.

## Problem

Production evidence from a recent OCR run (75 findings):
- 22 low-severity maintainability findings (nits: hardcoded constants, diagnostic verbosity, naming)
- 5 low-severity test findings
- 1 info-severity other finding
- Only 4 high-severity findings (2 bug, 2 correctness)

A conservative policy routing only low maintainability/test/other/info to the sticky summary would reduce inline candidates from 75 to 47 (37% reduction) while preserving every finding in durable output.

## Routing policy (fail-safe, conservative)

| Category | Severity | Destination |
|----------|----------|-------------|
| bug, security, correctness | any | inline |
| any | high, medium | inline |
| unknown | any | inline (fail-safe) |
| maintainability, test, style, other | info | summary |
| maintainability, test, style, other | low | summary |

Precedence (evaluated top-down):
1. Non-object finding -> inline (fail-safe)
2. Protected category (bug/security/correctness) -> inline, regardless of severity
3. High/medium severity -> inline, regardless of category
4. Unknown category -> inline (fail-safe, even if severity is info)
5. Info severity (for known/other categories) -> summary
6. Low severity (for known/other categories) -> summary
7. Else -> inline (fail-safe)

## Implementation

### New functions in the Post OCR results step

- effectiveCategory(finding) / effectiveSeverity(finding): Recover the effective category/severity by preferring the normalized category/severity field, then falling back to originalCategory/originalSeverity (preserved by #2671 metadata validation) when the normalized value is unknown.
- routeFinding(finding): Returns { destination, reason } based on the routing policy above.
- categorySeverityLabel(finding): Renders a [category/severity] label using effective metadata.

### Shadow mode (default)

In shadow mode, all line-addressable findings post inline (current behavior unchanged). Additionally:
- A Shadow-mode routing preview section appears in the sticky summary showing how many findings would have been routed to summary, broken down by category/severity.
- All routing decisions (pre-dedup) are persisted to ocr-routing-decisions.json artifact with path, line, category, severity, destination, and reason.

### Go-live mode (OCR_ROUTING_SHADOW_MODE=false)

Findings routed to summary are held back from inline posting and rendered in a Findings routed to summary section in the sticky summary instead.

### Labels

Category and severity labels are rendered in:
- Inline comment bodies (inside the blockquote)
- Lineless findings section
- Summary-routed findings section

### Artifact

ocr-routing-decisions.json is initialized, redacted, ensured, and uploaded alongside the existing OCR diagnostic artifacts. It contains ALL pre-dedup routing decisions so suppressed duplicates still get records.

### Job output

New structured output: comments_routed_summary -- the count of findings routed to the summary section.

## Acceptance criteria

- [x] Shadow mode logs routing decisions without changing posted behavior
- [x] Shadow mode tracks what would have been suppressed by category/severity
- [x] After go-live, low-severity maintainability/test findings appear in the sticky summary, not as inline comments
- [x] All high/medium findings remain inline
- [x] All security/bug/correctness findings remain inline regardless of severity
- [x] Unknown category/severity values default to inline (fail-safe)
- [x] Every finding is preserved in the redacted artifact with its routing reason
- [x] Category and severity labels are rendered in posted comments

## Testing

New test file scripts/tests/ocr-review-routing.test.js with 66 tests covering:
- routeFinding behavior: protected categories (8 tests), high/medium severity (8 tests), summary routing (9 tests), fail-safe (10 tests)
- categorySeverityLabel behavior (6 tests)
- effectiveCategory/effectiveSeverity recovery from originalCategory/originalSeverity
- YAML wiring: function definitions, env vars, outputs, artifact in all lifecycle steps (19 tests)
- Pipeline ordering: allRoutingDecisions before dedup, routingDecisions after dedup (3 tests)
- Shadow-mode and go-live integration (4 tests)

All tests extract the real functions from the committed YAML and execute them in isolated vm sandboxes -- no mocking.

## Dependencies

- Depends on #2671 (closed) -- fail-open metadata validation that normalizes category/severity and preserves originalCategory/originalSeverity.

Fixes #2672
