### PR TITLE
test(secure-store): restore real keyring-vs-fallback coverage via DI (Fixes #2704)

### DIFF
--- a/packages/auth/src/__tests__/keyring-token-store.di.test.ts
+++ b/packages/auth/src/__tests__/keyring-token-store.di.test.ts
@@ -650,7 +650,7 @@ const DUAL_MODES: readonly SecureStoreMode[] = [
 
 describe.sequential.each(DUAL_MODES)(
   'KeyringTokenStore ISecureStore backend conformance [$mode]',
-  ({ makeStore, mode }) => {
+  ({ makeStore }) => {
     // This suite owns its own temp-dir tracker so file-backed stores get
     // isolated, cleaned-up directories. Sequential execution keeps the
     // mutable `dirs` array race-free within the suite.
@@ -705,35 +705,6 @@ describe.sequential.each(DUAL_MODES)(
       await tokenStore.saveToken('dual', VALID_TOKEN);
       await tokenStore.removeToken('dual');
       expect(await tokenStore.getToken('dual')).toBeNull();
-    });
-
-    it('file-backed store persists across distinct ISecureStore instances (cross-instance consistency)', async () => {
-      // This test only applies to the file-backed double (it verifies the
-      // durable-persistence distinction from the in-memory Map). For the
-      // in-memory mode, the same assertion is trivially true within one
-      // instance and not meaningful across instances.
-      if (mode === 'in-memory') return;
-
-      const dir = locks.freshLockDir();
-      const writerStore = makeStore(dir);
-      const tokenStore = new KeyringTokenStore({
-        secureStore: writerStore,
-        lockDir: locks.freshLockDir(),
-        logger: createNoOpLogger(),
-      });
-      await tokenStore.saveToken('persistent', VALID_TOKEN);
-
-      // A second KeyringTokenStore backed by a new ISecureStore instance
-      // pointing at the same dir must see the saved token.
-      const readerStore = makeStore(dir);
-      const readerTokenStore = new KeyringTokenStore({
-        secureStore: readerStore,
-        lockDir: locks.freshLockDir(),
-        logger: createNoOpLogger(),
-      });
-      const loaded = await readerTokenStore.getToken('persistent');
-      expect(loaded).not.toBeNull();
-      expect(loaded!.access_token).toBe('test-access-token');
     });
 
     it('listProviders returns saved providers in sorted order', async () => {
@@ -792,6 +763,42 @@ describe.sequential.each(DUAL_MODES)(
       await expect(tokenStore.getToken('dual')).rejects.toThrow(
         'Permission denied',
       );
+    });
+  },
+);
+
+// ─── File-backed persistence (fallback-path distinction) ────────────────────
+//
+// The cross-instance persistence property distinguishes the file-backed double
+// (simulating the encrypted-file fallback's durable on-disk artifacts) from
+// the in-memory Map double (simulating the keyring path). It lives outside the
+// shared describe.each because it is only meaningful for the file-backed store.
+
+describe.sequential(
+  'KeyringTokenStore file-backed cross-instance persistence',
+  () => {
+    const locks = createLockDirTracker();
+    afterEach(() => locks.cleanupLockDirs());
+
+    it('a token saved by one KeyringTokenStore is visible to a second instance backed by the same dir', async () => {
+      const dir = locks.freshLockDir();
+      const writerStore = createFileBackedSecureStore(dir);
+      const writer = new KeyringTokenStore({
+        secureStore: writerStore,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+      await writer.saveToken('persistent', VALID_TOKEN);
+
+      const readerStore = createFileBackedSecureStore(dir);
+      const reader = new KeyringTokenStore({
+        secureStore: readerStore,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+      const loaded = await reader.getToken('persistent');
+      expect(loaded).not.toBeNull();
+      expect(loaded!.access_token).toBe('test-access-token');
     });
   },
 );

--- a/packages/auth/src/__tests__/keyring-token-store.di.test.ts
+++ b/packages/auth/src/__tests__/keyring-token-store.di.test.ts
@@ -7,9 +7,10 @@
  * @requirement REQ-AUTH-001.1, REQ-TEST-001.1, REQ-TEST-001.3
  *
  * KeyringTokenStore DI behavioral tests.
- * All tests use in-memory ISecureStore test doubles.
- * Assertions are on stored/retrieved token data and observable state,
- * not on mock call counts (no toHaveBeenCalled theater).
+ * Tests use ISecureStore test doubles (in-memory and file-backed) to verify
+ * KeyringTokenStore behavior independently of any concrete SecureStore
+ * implementation. Assertions are on stored/retrieved token data and
+ * observable state, not on mock call counts (no toHaveBeenCalled theater).
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -61,6 +62,69 @@ function createFailingSecureStore(
     },
     has: async () => {
       throw errorFactory('has');
+    },
+  };
+}
+
+/**
+ * File-backed ISecureStore double that simulates durable on-disk persistence:
+ * writes survive across distinct double instances pointing at the same dir
+ * (cross-instance consistency). Distinct from the in-memory Map double (which
+ * has no on-disk artifacts). Both satisfy ISecureStore, so the backend
+ * conformance describe.each verifies KeyringTokenStore against both shapes.
+ */
+function createFileBackedSecureStore(dir: string): ISecureStore & {
+  readonly baseDir: string;
+} {
+  // Reversible filename encoding so the original key (including the ':'
+  // separator KeyringTokenStore relies on) round-trips through list(),
+  // mirroring how the real SecureStore fallback decodes filenames back to keys.
+  const encodeKey = (key: string): string => encodeURIComponent(key) + '.dat';
+  const decodeName = (name: string): string =>
+    decodeURIComponent(name.slice(0, -4));
+  const resolve = (key: string): string => path.join(dir, encodeKey(key));
+  return {
+    baseDir: dir,
+    get: async (key) => {
+      try {
+        return await fs.readFile(resolve(key), 'utf8');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+        throw err;
+      }
+    },
+    set: async (key, value) => {
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(resolve(key), value, 'utf8');
+    },
+    delete: async (key) => {
+      try {
+        await fs.unlink(resolve(key));
+        return true;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+        throw err;
+      }
+    },
+    list: async () => {
+      try {
+        const entries = await fs.readdir(dir);
+        return entries
+          .filter((f) => f.endsWith('.dat'))
+          .map((f) => decodeName(f));
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw err;
+      }
+    },
+    has: async (key) => {
+      try {
+        await fs.access(resolve(key));
+        return true;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+        throw err;
+      }
     },
   };
 }
@@ -556,3 +620,178 @@ describe.sequential('KeyringTokenStore lockDir contract (P8)', () => {
     await tokenStore.releaseAuthLock('gemini');
   });
 });
+
+// ─── ISecureStore backend conformance (in-memory vs file-backed) ────────────
+//
+// KeyringTokenStore consumes any ISecureStore via DI. This suite verifies that
+// KeyringTokenStore behaves correctly regardless of which ISecureStore backend
+// is injected: an in-memory Map double (simulating a keyring-style store with
+// no on-disk artifacts) and a file-backed double (simulating durable on-disk
+// persistence). Both satisfy the ISecureStore contract. This is NOT coverage
+// of the real SecureStore keyring/fallback implementations — that coverage
+// lives in packages/storage and packages/core — but rather confirms
+// KeyringTokenStore's backend-agnostic DI contract.
+
+interface SecureStoreMode {
+  readonly mode: string;
+  readonly makeStore: (dir: string) => ISecureStore;
+}
+
+const DUAL_MODES: readonly SecureStoreMode[] = [
+  {
+    mode: 'in-memory',
+    makeStore: () => createInMemorySecureStore(),
+  },
+  {
+    mode: 'file-backed',
+    makeStore: (dir) => createFileBackedSecureStore(dir),
+  },
+];
+
+describe.sequential.each(DUAL_MODES)(
+  'KeyringTokenStore ISecureStore backend conformance [$mode]',
+  ({ makeStore, mode }) => {
+    // This suite owns its own temp-dir tracker so file-backed stores get
+    // isolated, cleaned-up directories. Sequential execution keeps the
+    // mutable `dirs` array race-free within the suite.
+    const locks = createLockDirTracker();
+    afterEach(() => locks.cleanupLockDirs());
+
+    it('saveToken → getToken round-trips through the injected store', async () => {
+      const store = makeStore(locks.freshLockDir());
+      const tokenStore = new KeyringTokenStore({
+        secureStore: store,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+
+      await tokenStore.saveToken('dual', VALID_TOKEN);
+      const loaded = await tokenStore.getToken('dual');
+      expect(loaded).not.toBeNull();
+      expect(loaded!.access_token).toBe('test-access-token');
+      expect(loaded!.refresh_token).toBe('test-refresh-token');
+      expect(loaded!.token_type).toBe('Bearer');
+      expect(loaded!.scope).toBe('openid profile');
+    });
+
+    it('saveToken overwrites a previous token for the same provider+bucket', async () => {
+      const store = makeStore(locks.freshLockDir());
+      const tokenStore = new KeyringTokenStore({
+        secureStore: store,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+
+      await tokenStore.saveToken('dual', {
+        ...VALID_TOKEN,
+        access_token: 'first',
+      });
+      await tokenStore.saveToken('dual', {
+        ...VALID_TOKEN,
+        access_token: 'second',
+      });
+      const loaded = await tokenStore.getToken('dual');
+      expect(loaded!.access_token).toBe('second');
+    });
+
+    it('removeToken deletes the token; subsequent getToken returns null', async () => {
+      const store = makeStore(locks.freshLockDir());
+      const tokenStore = new KeyringTokenStore({
+        secureStore: store,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+
+      await tokenStore.saveToken('dual', VALID_TOKEN);
+      await tokenStore.removeToken('dual');
+      expect(await tokenStore.getToken('dual')).toBeNull();
+    });
+
+    it('file-backed store persists across distinct ISecureStore instances (cross-instance consistency)', async () => {
+      // This test only applies to the file-backed double (it verifies the
+      // durable-persistence distinction from the in-memory Map). For the
+      // in-memory mode, the same assertion is trivially true within one
+      // instance and not meaningful across instances.
+      if (mode === 'in-memory') return;
+
+      const dir = locks.freshLockDir();
+      const writerStore = makeStore(dir);
+      const tokenStore = new KeyringTokenStore({
+        secureStore: writerStore,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+      await tokenStore.saveToken('persistent', VALID_TOKEN);
+
+      // A second KeyringTokenStore backed by a new ISecureStore instance
+      // pointing at the same dir must see the saved token.
+      const readerStore = makeStore(dir);
+      const readerTokenStore = new KeyringTokenStore({
+        secureStore: readerStore,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+      const loaded = await readerTokenStore.getToken('persistent');
+      expect(loaded).not.toBeNull();
+      expect(loaded!.access_token).toBe('test-access-token');
+    });
+
+    it('listProviders returns saved providers in sorted order', async () => {
+      const store = makeStore(locks.freshLockDir());
+      const tokenStore = new KeyringTokenStore({
+        secureStore: store,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+
+      await tokenStore.saveToken('gemini', VALID_TOKEN);
+      await tokenStore.saveToken('anthropic', VALID_TOKEN);
+      const providers = await tokenStore.listProviders();
+      expect(providers).toStrictEqual(['anthropic', 'gemini']);
+    });
+
+    it('getToken returns null for invalid JSON in the store', async () => {
+      const store = makeStore(locks.freshLockDir());
+      // Seed corrupt data via the store's own set() (works for both doubles).
+      await store.set('dual:default', 'not-valid-json{{{');
+      const tokenStore = new KeyringTokenStore({
+        secureStore: store,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+
+      expect(await tokenStore.getToken('dual')).toBeNull();
+    });
+
+    it('getToken returns null when the store has no entry', async () => {
+      const store = makeStore(locks.freshLockDir());
+      const tokenStore = new KeyringTokenStore({
+        secureStore: store,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+
+      expect(await tokenStore.getToken('absent')).toBeNull();
+    });
+
+    it('getToken re-throws non-CORRUPT errors from the injected store', async () => {
+      const base = makeStore(locks.freshLockDir());
+      // Override get to throw a DENIED (non-CORRUPT) error.
+      base.get = async () => {
+        const error = new Error('Permission denied') as ISecureStoreError;
+        error.code = 'DENIED';
+        error.remediation = 'Check credentials';
+        throw error;
+      };
+      const tokenStore = new KeyringTokenStore({
+        secureStore: base,
+        lockDir: locks.freshLockDir(),
+        logger: createNoOpLogger(),
+      });
+
+      await expect(tokenStore.getToken('dual')).rejects.toThrow(
+        'Permission denied',
+      );
+    });
+  },
+);

--- a/packages/auth/src/__tests__/keyring-token-store.di.test.ts
+++ b/packages/auth/src/__tests__/keyring-token-store.di.test.ts
@@ -73,9 +73,7 @@ function createFailingSecureStore(
  * has no on-disk artifacts). Both satisfy ISecureStore, so the backend
  * conformance describe.each verifies KeyringTokenStore against both shapes.
  */
-function createFileBackedSecureStore(dir: string): ISecureStore & {
-  readonly baseDir: string;
-} {
+function createFileBackedSecureStore(dir: string): ISecureStore {
   // Reversible filename encoding so the original key (including the ':'
   // separator KeyringTokenStore relies on) round-trips through list(),
   // mirroring how the real SecureStore fallback decodes filenames back to keys.
@@ -84,7 +82,6 @@ function createFileBackedSecureStore(dir: string): ISecureStore & {
     decodeURIComponent(name.slice(0, -4));
   const resolve = (key: string): string => path.join(dir, encodeKey(key));
   return {
-    baseDir: dir,
     get: async (key) => {
       try {
         return await fs.readFile(resolve(key), 'utf8');

--- a/packages/core/src/auth-factories.keyring.test.ts
+++ b/packages/core/src/auth-factories.keyring.test.ts
@@ -241,8 +241,17 @@ describe('core-factory keyring-primary OAuth (issue2704 #1)', () => {
     };
     await tokenStore.saveToken('anthropic', token);
 
-    // The legacy tree under the faked HOME must not exist.
+    // The legacy tree under the faked HOME must not exist. Capture the
+    // rejection and assert on the errno code rather than matching an
+    // error-message string fragment, which is brittle across Node versions.
     const legacyDir = path.join(fakeHome, '.llxprt');
-    await expect(fs.stat(legacyDir)).rejects.toThrow('ENOENT');
+    let statError: unknown;
+    try {
+      await fs.stat(legacyDir);
+    } catch (error) {
+      statError = error;
+    }
+    expect(statError).toBeDefined();
+    expect((statError as NodeJS.ErrnoException).code).toBe('ENOENT');
   });
 });

--- a/packages/core/src/auth-factories.keyring.test.ts
+++ b/packages/core/src/auth-factories.keyring.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Real core-factory keyring-primary OAuth behavior test (companion to
+ * auth-factories.fallback.test.ts).
+ *
+ * Issue #2704: the existing fallback test injected `createKeyringTokenStore(
+ * async () => null)` to force the encrypted file fallback path. There was no
+ * matching test that injects a WORKING keyring adapter, so the keyring-primary
+ * code path was unexercised at the factory layer. This suite injects a
+ * Map-backed mock adapter via the same `keyringLoader` DI seam and verifies:
+ *
+ * - Token save/load/remove round-trips through the KEYRING path (not the
+ *   encrypted file fallback).
+ * - No encrypted `.enc` fallback artifacts are written to the canonical
+ *   `<data>/secure-store/llxprt-code-oauth/` directory.
+ *
+ * Determinism: the keyring seam is made deterministically available via an
+ * explicit mock adapter; no OS keychain and no process-global env-var toggle
+ * is used.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs, mkdtempSync, mkdirSync } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { createKeyringTokenStore } from './auth-factories.js';
+import type { KeyringAdapter } from './storage/secure-store.js';
+import type { OAuthToken } from '@vybestack/llxprt-code-auth';
+
+const ENV_KEYS = [
+  'LLXPRT_DATA_HOME',
+  'LLXPRT_CONFIG_HOME',
+  'LLXPRT_CACHE_HOME',
+  'LLXPRT_LOG_HOME',
+  'HOME',
+] as const;
+
+/** Service name used by the production createKeyringTokenStore factory. */
+const AUTH_SECURE_STORE_SERVICE = 'llxprt-code-oauth';
+
+/**
+ * Map-backed mock keyring adapter (reuses the pattern from
+ * packages/storage/src/secure-store/secure-store.basic.test.ts). Injected via
+ * the keyringLoader DI seam so the real keyring code path executes without
+ * touching the OS keychain.
+ */
+function createMockKeyring(): KeyringAdapter & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getPassword: async (service, account) =>
+      store.get(`${service}:${account}`) ?? null,
+    setPassword: async (service, account, password) => {
+      store.set(`${service}:${account}`, password);
+    },
+    deletePassword: async (service, account) =>
+      store.delete(`${service}:${account}`),
+    findCredentials: async (service) => {
+      const results: Array<{ account: string; password: string }> = [];
+      for (const [key, value] of store.entries()) {
+        if (key.startsWith(`${service}:`)) {
+          results.push({
+            account: key.slice(service.length + 1),
+            password: value,
+          });
+        }
+      }
+      return results;
+    },
+  };
+}
+
+describe('core-factory keyring-primary OAuth (issue2704 #1)', () => {
+  let root: string;
+  let dataHome: string;
+  let logHome: string;
+  let fakeHome: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), 'core-auth-keyring-'));
+    dataHome = path.join(root, 'data');
+    logHome = path.join(root, 'log');
+    fakeHome = path.join(root, 'fake-home');
+    mkdirSync(dataHome, { recursive: true });
+    mkdirSync(logHome, { recursive: true });
+    mkdirSync(fakeHome, { recursive: true });
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env['LLXPRT_DATA_HOME'] = dataHome;
+    process.env['LLXPRT_LOG_HOME'] = logHome;
+    process.env['HOME'] = fakeHome;
+  });
+
+  afterEach(async () => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('round-trips a token through the KEYRING path when a keyring adapter is available', async () => {
+    const mockKeyring = createMockKeyring();
+    const tokenStore = createKeyringTokenStore(async () => mockKeyring);
+
+    const token: OAuthToken = {
+      access_token: 'keyring-access-token',
+      refresh_token: 'keyring-refresh-token',
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+      scope: 'openid profile',
+    };
+
+    await tokenStore.saveToken('gemini', token);
+
+    // Assert the token is retrievable through the factory wiring.
+    const loaded = await tokenStore.getToken('gemini');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.access_token).toBe('keyring-access-token');
+    expect(loaded!.refresh_token).toBe('keyring-refresh-token');
+    expect(loaded!.expiry).toBe(token.expiry);
+    expect(loaded!.token_type).toBe('Bearer');
+    expect(loaded!.scope).toBe('openid profile');
+
+    // Remove round-trips through the keyring path too.
+    await tokenStore.removeToken('gemini');
+    expect(await tokenStore.getToken('gemini')).toBeNull();
+  });
+
+  it('stores token data in the keyring adapter, not the fallback dir', async () => {
+    const mockKeyring = createMockKeyring();
+    const tokenStore = createKeyringTokenStore(async () => mockKeyring);
+
+    const token: OAuthToken = {
+      access_token: 'no-enc-at',
+      refresh_token: 'no-enc-rt',
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+      scope: null,
+    };
+
+    await tokenStore.saveToken('codex', token);
+
+    // The token data must be reachable via the injected keyring adapter state.
+    const storedInKeyring = mockKeyring.store.get(
+      `${AUTH_SECURE_STORE_SERVICE}:codex:default`,
+    );
+    expect(storedInKeyring).toBeDefined();
+    // And must be a JSON object (the KeyringTokenStore serializes the token).
+    const parsed = JSON.parse(storedInKeyring!) as { access_token: string };
+    expect(parsed.access_token).toBe('no-enc-at');
+  });
+
+  it('getToken returns the keyring value even when a conflicting fallback artifact exists (keyring-authoritative read)', async () => {
+    // On Linux, production writes an encrypted fallback backup after a
+    // successful keyring write. To prove getToken reads from the keyring
+    // (not the backup), write via the keyring path, then tamper with the
+    // adapter so the keyring holds a DIFFERENT value than any fallback
+    // artifact. The loaded token must match the keyring value, proving the
+    // keyring read path is exercised and authoritative.
+    const mockKeyring = createMockKeyring();
+    const tokenStore = createKeyringTokenStore(async () => mockKeyring);
+
+    const token: OAuthToken = {
+      access_token: 'keyring-authoritative-at',
+      refresh_token: 'keyring-authoritative-rt',
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+      scope: 'openid',
+    };
+    await tokenStore.saveToken('openai', token);
+
+    // Now overwrite the keyring entry directly with a different valid token
+    // JSON. If getToken reads from the keyring, it returns THIS value.
+    const tampered: OAuthToken = {
+      ...token,
+      access_token: 'tampered-keyring-at',
+    };
+    mockKeyring.store.set(
+      `${AUTH_SECURE_STORE_SERVICE}:openai:default`,
+      JSON.stringify(tampered),
+    );
+
+    const loaded = await tokenStore.getToken('openai');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.access_token).toBe('tampered-keyring-at');
+  });
+
+  // On Linux, a successful keyring write also keeps an encrypted backup copy,
+  // so asserting "no .enc fallback artifacts" is only valid on non-Linux.
+  it.skipIf(process.platform === 'linux')(
+    'does NOT write any encrypted .enc fallback artifacts when the keyring is available (non-Linux)',
+    async () => {
+      const mockKeyring = createMockKeyring();
+      const tokenStore = createKeyringTokenStore(async () => mockKeyring);
+
+      const token: OAuthToken = {
+        access_token: 'no-enc-at',
+        refresh_token: 'no-enc-rt',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        token_type: 'Bearer',
+        scope: null,
+      };
+
+      await tokenStore.saveToken('codex', token);
+
+      const fallbackDir = path.join(
+        dataHome,
+        'secure-store',
+        AUTH_SECURE_STORE_SERVICE,
+      );
+      const exists = await fs
+        .stat(fallbackDir)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(false);
+    },
+  );
+
+  it('token data does not leak into the legacy ~/.llxprt tree', async () => {
+    const mockKeyring = createMockKeyring();
+    const tokenStore = createKeyringTokenStore(async () => mockKeyring);
+
+    const token: OAuthToken = {
+      access_token: 'no-legacy-keyring',
+      refresh_token: 'no-legacy-keyring-rt',
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+      scope: 'openid',
+    };
+    await tokenStore.saveToken('anthropic', token);
+
+    // The legacy tree under the faked HOME must not exist.
+    const legacyDir = path.join(fakeHome, '.llxprt');
+    await expect(fs.stat(legacyDir)).rejects.toThrow('ENOENT');
+  });
+});

--- a/packages/storage/src/secure-store/secure-store.dual-mode.test.ts
+++ b/packages/storage/src/secure-store/secure-store.dual-mode.test.ts
@@ -1,0 +1,416 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Dual-mode contract harness for SecureStore.
+ *
+ * Issue #2704: CI ran both "keyring" and "fallback" SecureStore test legs,
+ * but an env-var mode selector (LLXPRT_SECURE_STORE_FORCE_FALLBACK) lost its
+ * only reader during a package move, so both legs exercised the SAME code.
+ * This suite restores real divergence coverage by driving BOTH code paths
+ * through the existing `keyringLoader` DI seam — explicitly injecting either
+ * a working mock adapter (keyring-present) or `null` (keyring-absent). No
+ * process-global env var is used; removing the fallback implementation must
+ * break these tests.
+ *
+ * @plan PLAN-20260211-SECURESTORE.P05
+ * @requirement R1.1, R3.1-R3.8, R4.1, R4.2
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  SecureStore,
+  SecureStoreError,
+  type KeyringAdapter,
+} from './secure-store.js';
+
+// ─── Keyring vs Fallback Behavioral Difference Matrix ───────────────────────
+//
+// These divergences are drawn directly from packages/storage/src/secure-store/
+// secure-store.ts. They are the behaviors that differ between the two code
+// paths and therefore MUST be covered by distinct, explicitly-injected tests
+// (not a single path exercised twice via an env-var toggle).
+//
+// 1. On-disk artifacts:
+//    - Fallback (keyring-absent): set() writes an encrypted `.enc` file via
+//      atomic temp+rename with 0o600 permissions.
+//    - Keyring (keyring-present, non-Linux): set() writes ONLY to the keyring;
+//      the fallback dir stays empty. (On Linux, a backup fallback copy is also
+//      written after a successful keyring write.)
+//
+// 2. Envelope / machine-secret dependence (fallback only):
+//    - Fallback files are AES-256-GCM envelopes (v:1 or v:2). v:2 incorporates
+//      a machine secret as the dominant KDF entropy; v:1 derives from
+//      serviceName + machineId. Decryption fails closed (CORRUPT) on mismatch.
+//    - Keyring stores opaque strings with no envelope/machine-secret concept.
+//
+// 3. fallbackPolicy:
+//    - 'deny' + keyring-absent → set() throws SecureStoreError(UNAVAILABLE).
+//    - 'allow' + keyring-absent → set() writes the encrypted fallback file.
+//
+// 4. delete() OR-semantics:
+//    - delete() tries the keyring AND the fallback file; returns true if
+//      EITHER succeeded. A keyring-present store can delete a fallback-only
+//      artifact (and vice versa) because both paths are attempted.
+//
+// 5. list()/has() merging:
+//    - list() merges keyring findCredentials accounts with fallback-dir
+//      filenames (deduped, sorted). has() checks keyring then fallback file.
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Creates an in-memory mock keyring adapter. Injected via keyringLoader so the
+ * real SecureStore keyring code path executes against a deterministic,
+ * host-independent adapter (not the real OS keychain).
+ */
+function createMockKeyring(): KeyringAdapter & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getPassword: async (service: string, account: string) =>
+      store.get(`${service}:${account}`) ?? null,
+    setPassword: async (service: string, account: string, password: string) => {
+      store.set(`${service}:${account}`, password);
+    },
+    deletePassword: async (service: string, account: string) =>
+      store.delete(`${service}:${account}`),
+    findCredentials: async (service: string) => {
+      const results: Array<{ account: string; password: string }> = [];
+      for (const [key, value] of store.entries()) {
+        if (key.startsWith(`${service}:`)) {
+          results.push({
+            account: key.slice(service.length + 1),
+            password: value,
+          });
+        }
+      }
+      return results;
+    },
+  };
+}
+
+async function createTempFallbackDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'secure-store-dual-'));
+}
+
+// Deterministic v1 envelopes: no machine secret, so writes are reproducible
+// without touching the global machine-secret cache or the real keychain.
+const NULL_MACHINE_SECRET_LOADER = async (): Promise<Buffer | null> => null;
+
+// ─── Shared Contract (both modes) ────────────────────────────────────────────
+
+interface ContractMode {
+  readonly mode: string;
+  readonly fallbackPolicy: 'allow' | 'deny';
+  readonly makeLoader: () => () => Promise<KeyringAdapter | null>;
+}
+
+// The keyring-present mode uses fallbackPolicy 'deny' so that on Linux (where
+// production writes an encrypted backup after a successful keyring write) the
+// keyring code path is exercised in isolation — reads, list, and has must be
+// satisfied by the keyring, not masked by a fallback artifact. The keyring-
+// absent mode uses 'allow' so the encrypted-file fallback path is engaged.
+const SHARED_CONTRACT_MODES: readonly ContractMode[] = [
+  {
+    mode: 'keyring-present',
+    fallbackPolicy: 'deny',
+    makeLoader: () => async () => createMockKeyring(),
+  },
+  {
+    mode: 'keyring-absent',
+    fallbackPolicy: 'allow',
+    makeLoader: () => async () => null,
+  },
+];
+
+describe.each(SHARED_CONTRACT_MODES)(
+  'SecureStore shared contract [$mode]',
+  ({ makeLoader, fallbackPolicy }) => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await createTempFallbackDir();
+    });
+
+    afterEach(async () => {
+      if (tempDir) {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('round-trips a value via get/set', async () => {
+      const store = new SecureStore('dual-service', {
+        keyringLoader: makeLoader(),
+        fallbackDir: tempDir,
+        fallbackPolicy,
+        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+      });
+
+      await store.set('round-trip', 'secret-value');
+      expect(await store.get('round-trip')).toBe('secret-value');
+    });
+
+    it('overwrites a previous value on re-set', async () => {
+      const store = new SecureStore('dual-service', {
+        keyringLoader: makeLoader(),
+        fallbackDir: tempDir,
+        fallbackPolicy,
+        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+      });
+
+      await store.set('overwrite', 'first');
+      await store.set('overwrite', 'second');
+      expect(await store.get('overwrite')).toBe('second');
+    });
+
+    it('isolates independent keys', async () => {
+      const store = new SecureStore('dual-service', {
+        keyringLoader: makeLoader(),
+        fallbackDir: tempDir,
+        fallbackPolicy,
+        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+      });
+
+      await store.set('a', '1');
+      await store.set('b', '2');
+      expect(await store.get('a')).toBe('1');
+      expect(await store.get('b')).toBe('2');
+    });
+
+    it('delete() returns true for an existing key', async () => {
+      const store = new SecureStore('dual-service', {
+        keyringLoader: makeLoader(),
+        fallbackDir: tempDir,
+        fallbackPolicy,
+        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+      });
+
+      await store.set('delete-me', 'val');
+      expect(await store.delete('delete-me')).toBe(true);
+    });
+
+    it('delete() returns false for a nonexistent key', async () => {
+      const store = new SecureStore('dual-service', {
+        keyringLoader: makeLoader(),
+        fallbackDir: tempDir,
+        fallbackPolicy,
+        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+      });
+
+      expect(await store.delete('never-set')).toBe(false);
+    });
+
+    it('list() includes set keys', async () => {
+      const store = new SecureStore('dual-service', {
+        keyringLoader: makeLoader(),
+        fallbackDir: tempDir,
+        fallbackPolicy,
+        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+      });
+
+      await store.set('alpha', '1');
+      await store.set('beta', '2');
+      const keys = await store.list();
+      expect(keys).toStrictEqual(['alpha', 'beta']);
+    });
+
+    it('has() returns true for a set key and false otherwise', async () => {
+      const store = new SecureStore('dual-service', {
+        keyringLoader: makeLoader(),
+        fallbackDir: tempDir,
+        fallbackPolicy,
+        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+      });
+
+      await store.set('present', 'val');
+      expect(await store.has('present')).toBe(true);
+      expect(await store.has('absent')).toBe(false);
+    });
+
+    it('get() returns null for a key that was never set', async () => {
+      const store = new SecureStore('dual-service', {
+        keyringLoader: makeLoader(),
+        fallbackDir: tempDir,
+        fallbackPolicy,
+        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+      });
+
+      expect(await store.get('nonexistent')).toBeNull();
+    });
+  },
+);
+
+// ─── Divergence Assertions (keyring-present vs keyring-absent) ───────────────
+
+describe('SecureStore keyring-vs-fallback divergence', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempFallbackDir();
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keyring-absent mode writes an encrypted .enc artifact', async () => {
+    const fallbackStore = new SecureStore('diverge', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+    });
+
+    await fallbackStore.set('fallback-only', 'fb');
+
+    const files = await fs.readdir(tempDir);
+    const encFiles = files.filter((f) => f.endsWith('.enc'));
+
+    // Fallback path always produces a .enc file.
+    expect(encFiles).toContain('fallback-only.enc');
+  });
+
+  // On Linux, a successful keyring write also keeps an encrypted backup copy
+  // in the fallback dir, so the "no fallback artifact" assertion is only valid
+  // on non-Linux platforms. Split into its own skipIf-guarded test so the
+  // unconditional divergence above stays platform-independent.
+  it.skipIf(process.platform === 'linux')(
+    'keyring-present mode leaves no .enc fallback artifact (non-Linux)',
+    async () => {
+      const keyringStore = new SecureStore('diverge', {
+        keyringLoader: async () => createMockKeyring(),
+        fallbackDir: tempDir,
+        fallbackPolicy: 'allow',
+        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+      });
+
+      await keyringStore.set('keyring-only-no-artifact', 'kr');
+
+      const files = await fs.readdir(tempDir);
+      const encFiles = files.filter((f) => f.endsWith('.enc'));
+      expect(encFiles).not.toContain('keyring-only-no-artifact.enc');
+    },
+  );
+
+  it('keyring-absent write produces an encrypted envelope (cleartext absent, AES-256-GCM)', async () => {
+    const fallbackStore = new SecureStore('diverge', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+    });
+
+    const secret = 'super-secret-plaintext-token';
+    await fallbackStore.set('envelope-key', secret);
+
+    // Removing the fallback implementation breaks this: no .enc file would
+    // exist and the cleartext would never be encrypted.
+    const encPath = path.join(tempDir, 'envelope-key.enc');
+    const raw = await fs.readFile(encPath, 'utf8');
+    const envelope = JSON.parse(raw) as {
+      v: number;
+      crypto: { alg: string; kdf: string };
+      data: string;
+    };
+
+    expect(envelope.v).toBe(1);
+    expect(envelope.crypto.alg).toBe('aes-256-gcm');
+    expect(envelope.crypto.kdf).toBe('scrypt');
+    // Cleartext must NOT appear in the encrypted envelope.
+    expect(raw).not.toContain(secret);
+
+    // Round-trip proves the fallback decrypt path executes end-to-end.
+    expect(await fallbackStore.get('envelope-key')).toBe(secret);
+  });
+
+  it("fallbackPolicy 'deny' + absent keyring throws UNAVAILABLE", async () => {
+    const store = new SecureStore('diverge', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'deny',
+    });
+
+    let err: unknown;
+    try {
+      await store.set('denied', 'val');
+    } catch (__caught) {
+      err = __caught;
+    }
+    expect(err).toBeDefined();
+    expect(err).toBeInstanceOf(SecureStoreError);
+    expect((err as SecureStoreError).code).toBe('UNAVAILABLE');
+  });
+
+  it('delete() removes a fallback-only artifact via a keyring-present store (OR-semantics)', async () => {
+    // Write via fallback only.
+    const fallbackStore = new SecureStore('diverge', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+    });
+    await fallbackStore.set('or-delete', 'fb-val');
+
+    // The keyring-present store has an empty keyring but shares the fallback dir.
+    const keyringStore = new SecureStore('diverge', {
+      keyringLoader: async () => createMockKeyring(),
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+    });
+
+    // delete() tries keyring (nothing there) AND fallback file — returns true.
+    expect(await keyringStore.delete('or-delete')).toBe(true);
+    // The fallback file is gone.
+    expect(await fallbackStore.get('or-delete')).toBeNull();
+  });
+
+  it('list()/has() merge keyring accounts with fallback-dir filenames', async () => {
+    const mockKeyring = createMockKeyring();
+    // 'a' lives only in the keyring. fallbackPolicy 'deny' ensures no fallback
+    // artifact is written for 'a' on any platform (including Linux, which
+    // otherwise writes an encrypted backup after a keyring success).
+    const keyringStore = new SecureStore('diverge', {
+      keyringLoader: async () => mockKeyring,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'deny',
+      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+    });
+    await keyringStore.set('a', 'kr-val');
+
+    // 'b' lives only in the fallback file (written by an absent-keyring store).
+    const fallbackStore = new SecureStore('diverge', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+    });
+    await fallbackStore.set('b', 'fb-val');
+
+    // A merge-capable store (keyring present + fallback allowed) sees BOTH:
+    // keyring account 'a' + fallback filename 'b'. `mergeStore` reuses the
+    // populated `mockKeyring` (shared with `keyringStore`) so that 'a' is
+    // present in the keyring, while 'b' exists only as a fallback artifact.
+    const mergeStore = new SecureStore('diverge', {
+      keyringLoader: async () => mockKeyring,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+    });
+    const keys = await mergeStore.list();
+    expect(keys).toStrictEqual(['a', 'b']);
+
+    // has() also checks both stores.
+    expect(await mergeStore.has('a')).toBe(true);
+    expect(await mergeStore.has('b')).toBe(true);
+  });
+});

--- a/packages/storage/src/secure-store/secure-store.dual-mode.test.ts
+++ b/packages/storage/src/secure-store/secure-store.dual-mode.test.ts
@@ -104,6 +104,34 @@ async function createTempFallbackDir(): Promise<string> {
 // without touching the global machine-secret cache or the real keychain.
 const NULL_MACHINE_SECRET_LOADER = async (): Promise<Buffer | null> => null;
 
+// Mode-specific keyring loaders. `presentLoader` returns a fresh in-memory
+// mock each call (per-store isolation); `absentLoader` simulates a host with
+// no keyring backend. Used at call sites so per-mode intent stays obvious.
+const presentLoader = async (): Promise<KeyringAdapter | null> =>
+  createMockKeyring();
+const absentLoader = async (): Promise<KeyringAdapter | null> => null;
+
+/**
+ * Factory that constructs a SecureStore wired for dual-mode testing. Always
+ * injects NULL_MACHINE_SECRET_LOADER so fallback writes produce deterministic
+ * v1 envelopes without touching the global machine-secret cache or the real
+ * keychain. The mode-specific `keyringLoader` and `fallbackPolicy` are passed
+ * explicitly to keep per-mode intent obvious at every call site.
+ */
+function createStore(
+  serviceName: string,
+  fallbackDir: string,
+  keyringLoader: () => Promise<KeyringAdapter | null>,
+  fallbackPolicy: 'allow' | 'deny',
+): SecureStore {
+  return new SecureStore(serviceName, {
+    fallbackDir,
+    keyringLoader,
+    fallbackPolicy,
+    machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
+  });
+}
+
 // ─── Shared Contract (both modes) ────────────────────────────────────────────
 
 interface ContractMode {
@@ -121,12 +149,12 @@ const SHARED_CONTRACT_MODES: readonly ContractMode[] = [
   {
     mode: 'keyring-present',
     fallbackPolicy: 'deny',
-    makeLoader: () => async () => createMockKeyring(),
+    makeLoader: () => presentLoader,
   },
   {
     mode: 'keyring-absent',
     fallbackPolicy: 'allow',
-    makeLoader: () => async () => null,
+    makeLoader: () => absentLoader,
   },
 ];
 
@@ -146,24 +174,24 @@ describe.each(SHARED_CONTRACT_MODES)(
     });
 
     it('round-trips a value via get/set', async () => {
-      const store = new SecureStore('dual-service', {
-        keyringLoader: makeLoader(),
-        fallbackDir: tempDir,
+      const store = createStore(
+        'dual-service',
+        tempDir,
+        makeLoader(),
         fallbackPolicy,
-        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-      });
+      );
 
       await store.set('round-trip', 'secret-value');
       expect(await store.get('round-trip')).toBe('secret-value');
     });
 
     it('overwrites a previous value on re-set', async () => {
-      const store = new SecureStore('dual-service', {
-        keyringLoader: makeLoader(),
-        fallbackDir: tempDir,
+      const store = createStore(
+        'dual-service',
+        tempDir,
+        makeLoader(),
         fallbackPolicy,
-        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-      });
+      );
 
       await store.set('overwrite', 'first');
       await store.set('overwrite', 'second');
@@ -171,12 +199,12 @@ describe.each(SHARED_CONTRACT_MODES)(
     });
 
     it('isolates independent keys', async () => {
-      const store = new SecureStore('dual-service', {
-        keyringLoader: makeLoader(),
-        fallbackDir: tempDir,
+      const store = createStore(
+        'dual-service',
+        tempDir,
+        makeLoader(),
         fallbackPolicy,
-        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-      });
+      );
 
       await store.set('a', '1');
       await store.set('b', '2');
@@ -185,35 +213,35 @@ describe.each(SHARED_CONTRACT_MODES)(
     });
 
     it('delete() returns true for an existing key', async () => {
-      const store = new SecureStore('dual-service', {
-        keyringLoader: makeLoader(),
-        fallbackDir: tempDir,
+      const store = createStore(
+        'dual-service',
+        tempDir,
+        makeLoader(),
         fallbackPolicy,
-        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-      });
+      );
 
       await store.set('delete-me', 'val');
       expect(await store.delete('delete-me')).toBe(true);
     });
 
     it('delete() returns false for a nonexistent key', async () => {
-      const store = new SecureStore('dual-service', {
-        keyringLoader: makeLoader(),
-        fallbackDir: tempDir,
+      const store = createStore(
+        'dual-service',
+        tempDir,
+        makeLoader(),
         fallbackPolicy,
-        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-      });
+      );
 
       expect(await store.delete('never-set')).toBe(false);
     });
 
     it('list() includes set keys', async () => {
-      const store = new SecureStore('dual-service', {
-        keyringLoader: makeLoader(),
-        fallbackDir: tempDir,
+      const store = createStore(
+        'dual-service',
+        tempDir,
+        makeLoader(),
         fallbackPolicy,
-        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-      });
+      );
 
       await store.set('alpha', '1');
       await store.set('beta', '2');
@@ -222,12 +250,12 @@ describe.each(SHARED_CONTRACT_MODES)(
     });
 
     it('has() returns true for a set key and false otherwise', async () => {
-      const store = new SecureStore('dual-service', {
-        keyringLoader: makeLoader(),
-        fallbackDir: tempDir,
+      const store = createStore(
+        'dual-service',
+        tempDir,
+        makeLoader(),
         fallbackPolicy,
-        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-      });
+      );
 
       await store.set('present', 'val');
       expect(await store.has('present')).toBe(true);
@@ -235,12 +263,12 @@ describe.each(SHARED_CONTRACT_MODES)(
     });
 
     it('get() returns null for a key that was never set', async () => {
-      const store = new SecureStore('dual-service', {
-        keyringLoader: makeLoader(),
-        fallbackDir: tempDir,
+      const store = createStore(
+        'dual-service',
+        tempDir,
+        makeLoader(),
         fallbackPolicy,
-        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-      });
+      );
 
       expect(await store.get('nonexistent')).toBeNull();
     });
@@ -263,12 +291,12 @@ describe('SecureStore keyring-vs-fallback divergence', () => {
   });
 
   it('keyring-absent mode writes an encrypted .enc artifact', async () => {
-    const fallbackStore = new SecureStore('diverge', {
-      keyringLoader: async () => null,
-      fallbackDir: tempDir,
-      fallbackPolicy: 'allow',
-      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-    });
+    const fallbackStore = createStore(
+      'diverge',
+      tempDir,
+      absentLoader,
+      'allow',
+    );
 
     await fallbackStore.set('fallback-only', 'fb');
 
@@ -286,12 +314,12 @@ describe('SecureStore keyring-vs-fallback divergence', () => {
   it.skipIf(process.platform === 'linux')(
     'keyring-present mode leaves no .enc fallback artifact (non-Linux)',
     async () => {
-      const keyringStore = new SecureStore('diverge', {
-        keyringLoader: async () => createMockKeyring(),
-        fallbackDir: tempDir,
-        fallbackPolicy: 'allow',
-        machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-      });
+      const keyringStore = createStore(
+        'diverge',
+        tempDir,
+        presentLoader,
+        'allow',
+      );
 
       await keyringStore.set('keyring-only-no-artifact', 'kr');
 
@@ -301,13 +329,58 @@ describe('SecureStore keyring-vs-fallback divergence', () => {
     },
   );
 
+  // Deterministic Linux-only counterpart to the skipIf test above: on Linux a
+  // successful keyring write with fallbackPolicy 'allow' ALSO keeps an
+  // encrypted backup copy in the fallback dir. Asserts the .enc backup is
+  // created, is encrypted (no cleartext), and is decryptable by a separate
+  // keyring-absent SecureStore sharing the same fallback dir.
+  it.runIf(process.platform === 'linux')(
+    'Linux: keyring-present + fallbackPolicy allow creates an encrypted .enc backup that is decryptable cross-store',
+    async () => {
+      const secret = 'linux-keyring-backup-plaintext';
+      const backupKey = 'linux-backup-key';
+
+      // keyring-present + allow → triggers the Linux backup-after-success path.
+      const keyringStore = createStore(
+        'diverge',
+        tempDir,
+        presentLoader,
+        'allow',
+      );
+      await keyringStore.set(backupKey, secret);
+
+      // The backup .enc artifact must exist alongside the keyring write.
+      const files = await fs.readdir(tempDir);
+      const encFiles = files.filter((f) => f.endsWith('.enc'));
+      expect(encFiles).toContain(`${backupKey}.enc`);
+
+      // The backup must be encrypted — cleartext must not appear on disk.
+      const raw = await fs.readFile(
+        path.join(tempDir, `${backupKey}.enc`),
+        'utf8',
+      );
+      expect(raw).not.toContain(secret);
+
+      // A separate keyring-absent SecureStore sharing the fallback dir must be
+      // able to decrypt the backup (proves it is a well-formed envelope, not a
+      // stray artifact). This is the cross-store decryptability contract.
+      const readerStore = createStore(
+        'diverge',
+        tempDir,
+        absentLoader,
+        'allow',
+      );
+      expect(await readerStore.get(backupKey)).toBe(secret);
+    },
+  );
+
   it('keyring-absent write produces an encrypted envelope (cleartext absent, AES-256-GCM)', async () => {
-    const fallbackStore = new SecureStore('diverge', {
-      keyringLoader: async () => null,
-      fallbackDir: tempDir,
-      fallbackPolicy: 'allow',
-      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-    });
+    const fallbackStore = createStore(
+      'diverge',
+      tempDir,
+      absentLoader,
+      'allow',
+    );
 
     const secret = 'super-secret-plaintext-token';
     await fallbackStore.set('envelope-key', secret);
@@ -333,17 +406,13 @@ describe('SecureStore keyring-vs-fallback divergence', () => {
   });
 
   it("fallbackPolicy 'deny' + absent keyring throws UNAVAILABLE", async () => {
-    const store = new SecureStore('diverge', {
-      keyringLoader: async () => null,
-      fallbackDir: tempDir,
-      fallbackPolicy: 'deny',
-    });
+    const store = createStore('diverge', tempDir, absentLoader, 'deny');
 
     let err: unknown;
     try {
       await store.set('denied', 'val');
-    } catch (__caught) {
-      err = __caught;
+    } catch (caught) {
+      err = caught;
     }
     expect(err).toBeDefined();
     expect(err).toBeInstanceOf(SecureStoreError);
@@ -352,21 +421,21 @@ describe('SecureStore keyring-vs-fallback divergence', () => {
 
   it('delete() removes a fallback-only artifact via a keyring-present store (OR-semantics)', async () => {
     // Write via fallback only.
-    const fallbackStore = new SecureStore('diverge', {
-      keyringLoader: async () => null,
-      fallbackDir: tempDir,
-      fallbackPolicy: 'allow',
-      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-    });
+    const fallbackStore = createStore(
+      'diverge',
+      tempDir,
+      absentLoader,
+      'allow',
+    );
     await fallbackStore.set('or-delete', 'fb-val');
 
     // The keyring-present store has an empty keyring but shares the fallback dir.
-    const keyringStore = new SecureStore('diverge', {
-      keyringLoader: async () => createMockKeyring(),
-      fallbackDir: tempDir,
-      fallbackPolicy: 'allow',
-      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-    });
+    const keyringStore = createStore(
+      'diverge',
+      tempDir,
+      presentLoader,
+      'allow',
+    );
 
     // delete() tries keyring (nothing there) AND fallback file — returns true.
     expect(await keyringStore.delete('or-delete')).toBe(true);
@@ -379,33 +448,33 @@ describe('SecureStore keyring-vs-fallback divergence', () => {
     // 'a' lives only in the keyring. fallbackPolicy 'deny' ensures no fallback
     // artifact is written for 'a' on any platform (including Linux, which
     // otherwise writes an encrypted backup after a keyring success).
-    const keyringStore = new SecureStore('diverge', {
-      keyringLoader: async () => mockKeyring,
-      fallbackDir: tempDir,
-      fallbackPolicy: 'deny',
-      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-    });
+    const keyringStore = createStore(
+      'diverge',
+      tempDir,
+      async () => mockKeyring,
+      'deny',
+    );
     await keyringStore.set('a', 'kr-val');
 
     // 'b' lives only in the fallback file (written by an absent-keyring store).
-    const fallbackStore = new SecureStore('diverge', {
-      keyringLoader: async () => null,
-      fallbackDir: tempDir,
-      fallbackPolicy: 'allow',
-      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-    });
+    const fallbackStore = createStore(
+      'diverge',
+      tempDir,
+      absentLoader,
+      'allow',
+    );
     await fallbackStore.set('b', 'fb-val');
 
     // A merge-capable store (keyring present + fallback allowed) sees BOTH:
     // keyring account 'a' + fallback filename 'b'. `mergeStore` reuses the
     // populated `mockKeyring` (shared with `keyringStore`) so that 'a' is
     // present in the keyring, while 'b' exists only as a fallback artifact.
-    const mergeStore = new SecureStore('diverge', {
-      keyringLoader: async () => mockKeyring,
-      fallbackDir: tempDir,
-      fallbackPolicy: 'allow',
-      machineSecretLoader: NULL_MACHINE_SECRET_LOADER,
-    });
+    const mergeStore = createStore(
+      'diverge',
+      tempDir,
+      async () => mockKeyring,
+      'allow',
+    );
     const keys = await mergeStore.list();
     expect(keys).toStrictEqual(['a', 'b']);
 

--- a/scripts/tests/aggregate-historical-isolation.test.js
+++ b/scripts/tests/aggregate-historical-isolation.test.js
@@ -7,6 +7,15 @@
 import { describe, it, expect } from 'vitest';
 import { loadHistoricalModule, writeAttempt } from './aggregate-helpers.js';
 
+// A workflow-run createdAt safely inside the 7-day retention window relative
+// to the current clock (computed at module load). The behavior under test is
+// per-run exception isolation, not retention age, so the run fixtures must not
+// be excluded by fetchHistoricalData's retention filter as the wall clock
+// advances past a hard-coded boundary timestamp.
+const RECENT_RUN_CREATED_AT = new Date(
+  Date.now() - 24 * 60 * 60 * 1000,
+).toISOString();
+
 /**
  * Issue #2605 (per-run exception isolation): Historical retrieval is best
  * effort: a single run that throws during processing (e.g. an unexpected
@@ -60,8 +69,8 @@ describe('aggregate_evals: per-run exception isolation in historical fetch', () 
     // exception escaping processHistoricalRun's internal catch); run B is
     // valid and MUST still be included. This proves the loop isolates per-run
     // exceptions: one bad run cannot abort the remaining runs.
-    const runA = { databaseId: 99001, createdAt: '2026-07-19T02:00:00Z' };
-    const runB = { databaseId: 99002, createdAt: '2026-07-19T02:00:00Z' };
+    const runA = { databaseId: 99001, createdAt: RECENT_RUN_CREATED_AT };
+    const runB = { databaseId: 99002, createdAt: RECENT_RUN_CREATED_AT };
 
     const listRunsPage = () => ({
       runs: [runA, runB],


### PR DESCRIPTION
## Summary

CI ran both 'keyring' and 'fallback' SecureStore test legs, but the env-var mode selector (`LLXPRT_SECURE_STORE_FORCE_FALLBACK`) lost its only reader during a package move, so both legs exercised the SAME code. This is a test-coverage regression tracked in #2704 (part of umbrella #2702).

This PR restores real divergence coverage through explicit dependency injection via the existing `keyringLoader` seam — no process-global env var.

## Changes

### Phase 1 — Storage dual-mode contract (`secure-store.dual-mode.test.ts`)

New test module `packages/storage/src/secure-store/secure-store.dual-mode.test.ts`:

- **Behavioral difference matrix** documented as structured comments at the top (on-disk artifacts, envelope/machine-secret dependence, fallbackPolicy, delete OR-semantics, list/has merge).
- **Shared contract** via `describe.each` for two modes:
  - **keyring-present**: Map-backed mock adapter, `fallbackPolicy: 'deny'` (isolates keyring path on all platforms including Linux, which otherwise writes an encrypted backup after keyring success)
  - **keyring-absent**: `async () => null`, `fallbackPolicy: 'allow'` (engages the encrypted-file fallback)
  - Asserts identical behavior: round-trip, overwrite, multi-key isolation, delete return semantics, list, has, NOT_FOUND-returns-null.
- **Divergence block** with distinct adapters (not a flag-toggled adapter):
  - fallback writes encrypted `.enc` artifacts (keyring doesn't on non-Linux)
  - `fallbackPolicy: 'deny'` + absent keyring throws `UNAVAILABLE`
  - delete OR-semantics (keyring-present store deletes a fallback-only artifact)
  - list/has merge behavior (keyring accounts + fallback filenames)
  - encrypted envelope structure assertion (v:1, AES-256-GCM, cleartext absent, round-trip)

### Phase 2 — Factory/token-store layer

- **`packages/core/src/auth-factories.keyring.test.ts`** (new): companion to the existing `auth-factories.fallback.test.ts`. Injects a Map-backed mock keyring via `createKeyringTokenStore(async () => mockKeyring)`, verifies token save/load/remove round-trips through the KEYRING path, asserts no `.enc` fallback artifacts (non-Linux), asserts keyring-authoritative reads (tamper test — overwrites the keyring entry with a different valid token and confirms `getToken` returns the keyring value, not any fallback backup), no legacy `~/.llxprt` tree.
- **`packages/auth/src/__tests__/keyring-token-store.di.test.ts`** (extended): added a file-backed `ISecureStore` double and a backend-conformance `describe.sequential.each` (in-memory vs file-backed) verifying `KeyringTokenStore`'s DI contract against both backend shapes, including cross-instance persistence for the file-backed double. Reframed as generic ISecureStore backend conformance (not keyring-vs-fallback implementation coverage, which lives in the storage and core suites).

### Phase 3 — Sensitivity verification

- Temporarily broke `writeFallbackFile` with an early `return`; confirmed **10 dual-mode tests + 1 core fallback test failed**, then reverted the break.
- No new tests reference `LLXPRT_SECURE_STORE_FORCE_FALLBACK` or any `process.env`-based mode selector. The env vars in `auth-factories.keyring.test.ts` (`LLXPRT_DATA_HOME`, `HOME`, `LLXPRT_LOG_HOME`) are for path isolation only, mirroring the existing fallback test — NOT for mode selection.

## Acceptance criteria

- [x] Both secure-store implementations are exercised by tests that fail if either implementation regresses.
- [x] Fallback coverage does not depend on a CI matrix dimension or a process-global environment variable.
- [x] Removing the fallback implementation causes test failures (verified via sensitivity break).
- [x] The behaviors that differ between the two paths are documented in the tests (difference matrix).

## Design constraint

No process-global env var mode selector was reintroduced. Mode selection is performed exclusively via the `keyringLoader` DI seam (`async () => mockKeyring` for keyring-present, `async () => null` for keyring-absent).

## Verification

- `npm run format` — passed
- `npm run typecheck` (storage, auth, core) — passed
- `npm run build` — passed
- `npx vitest run` in packages/storage (413 passed, 3 skipped), packages/auth (446 passed, 2 skipped), packages/core (5305 passed, 36 skipped) — all passed
- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` — passed
- `ocr review --audience agent --timeout 20` — 3 findings addressed (afterEach undefined guard, misleading comment fix, has() error narrowing)

Closes #2704