### PR TITLE
Reject incomplete OCR reviews with immutable reviewed-range manifest (Fixes #2575)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -424,6 +424,7 @@ jobs:
       comments_skipped: ${{ steps.post-ocr-results.outputs.comments_skipped }}
       comments_failed: ${{ steps.post-ocr-results.outputs.comments_failed }}
       summary_comment_url: ${{ steps.post-ocr-results.outputs.summary_comment_url }}
+      completeness: ${{ steps.ocr-classification.outputs.completeness }}
     # The code-review job runs only when the mergeability gate and the
     # auto-review gate both permit it.
     needs:
@@ -548,6 +549,11 @@ jobs:
           : > ocr-phase.txt
           : > ocr-infrastructure-failure.txt
           : > ocr-policy-failure.txt
+          : > ocr-selected-files.txt
+          : > ocr-status.txt
+          : > ocr-reviewed-range-manifest.json
+          : > ocr-manifest-hashes.json
+          : > ocr-manifest-sha256.txt
           cat > ocr-workflow-helpers.sh <<'EOF'
           mark_infrastructure_failure() {
             echo "phase=$1; reason=$2" > ocr-infrastructure-failure.txt
@@ -831,6 +837,15 @@ jobs:
               /^[[:alpha:] ]+[[:space:]]*\([0-9]+\):/ { in_section = 0 }
               in_section { print }
             ' ocr-preview.txt || true)"
+            # Issue #2575: persist the selected (Will review) file list for
+            # the reviewed-range manifest. Extract one path per line,
+            # stripping bullet markers, checkboxes, and surrounding quotes.
+            printf '%s\n' "$reviewed" | sed -e 's/^[[:space:]]*//' \
+              -e 's/^[-*][[:space:]]*//' \
+              -e 's/^\[[^]]*\][[:space:]]*//' \
+              -e 's/^"\(.*\)"$/\1/' \
+              -e "s/^'\(.*\)'$/\1/" \
+              | grep -v '^[[:space:]]*$' > ocr-selected-files.txt || true
             excluded="$(awk '
               BEGIN { IGNORECASE = 1; in_section = 0 }
               /^Excluded[[:space:]]*\(/ { in_section = 1; next }
@@ -954,6 +969,21 @@ jobs:
           if ! cp ocr-stdout.raw ocr-result.json; then
             : > ocr-result.json
           fi
+          # Issue #2575: capture the upstream OCR JSON status field (e.g.
+          # "success" vs "completed_with_errors") so the manifest can
+          # classify partial coverage correctly.
+          ocr_status=""
+          if [ -s ocr-result.json ]; then
+            ocr_status="$(node -e '
+              try {
+                const data = JSON.parse(require("fs").readFileSync("ocr-result.json", "utf8"));
+                if (data && typeof data === "object" && typeof data.status === "string") {
+                  process.stdout.write(data.status);
+                }
+              } catch (_) { /* best-effort; empty status means unknown */ }
+            ' 2>/dev/null || true)"
+          fi
+          printf '%s' "$ocr_status" > ocr-status.txt
           echo "$status" > ocr-exit-code.txt
           if [ "$status" -ne 0 ]; then
             if grep -Eqi "429|rate limit" ocr-stderr.log; then
@@ -1381,6 +1411,213 @@ jobs:
                   body: comment.body,
                 })));
             }
+
+            // Issue #2575: reviewed-range manifest for completeness tracking.
+            // A partial OCR run must never be mistaken for complete coverage.
+
+            function resolveCompleteness(params) {
+              const skipped = params.skipped === true;
+              if (skipped) {
+                return 'skipped';
+              }
+              // C1: exitCode must be a valid non-negative integer. NaN/missing
+              // or negative values mean we cannot trust the OCR result, so
+              // treat them as failures rather than silently coercing to 0.
+              const rawExitCode = params.ocrExitCode;
+              if (!Number.isInteger(rawExitCode) || rawExitCode < 0) {
+                return 'failed';
+              }
+              if (rawExitCode !== 0) {
+                return 'failed';
+              }
+              // C1: fail-closed. Only recognized success statuses ("success"
+              // or "completed") can ever yield "complete". Every other value
+              // (including empty/null/unknown) yields "partial" because we
+              // lack positive proof of completeness.
+              const status = typeof params.ocrStatus === 'string' ? params.ocrStatus : '';
+              if (status !== 'success' && status !== 'completed') {
+                return 'partial';
+              }
+              // C3: set-based completeness. Normalize (trim), deduplicate,
+              // then verify that every selected file is covered.
+              const normalize = (arr) =>
+                Array.isArray(arr)
+                  ? [...new Set(arr.map((p) => String(p || '').trim()).filter((p) => p.length > 0))]
+                  : [];
+              const selectedSet = normalize(params.selectedFiles);
+              const completedSet = normalize(params.completedFiles);
+              const failedSet = normalize(params.failedFiles);
+              const reusedSet = normalize(params.reusedFiles);
+              // C10: a waiver only counts if it has a non-empty trimmed
+              // reason AND its path is in the failed set (C3: a waiver for
+              // a file that didn't fail is irrelevant).
+              const rawWaived = Array.isArray(params.waivedFiles) ? params.waivedFiles : [];
+              const failedLookup = new Set(failedSet);
+              const validWaiverPaths = new Set();
+              for (const entry of rawWaived) {
+                let pathStr = '';
+                let reasonStr = '';
+                if (typeof entry === 'string') {
+                  pathStr = entry.trim();
+                } else if (entry && typeof entry === 'object') {
+                  pathStr = String(entry.path || '').trim();
+                  reasonStr = String(entry.reason || '').trim();
+                } else {
+                  pathStr = String(entry || '').trim();
+                }
+                if (pathStr.length > 0 && reasonStr.length > 0 && failedLookup.has(pathStr)) {
+                  validWaiverPaths.add(pathStr);
+                }
+              }
+              const resolvedSet = new Set([
+                ...completedSet,
+                ...reusedSet,
+                ...validWaiverPaths,
+              ]);
+              // Every selected file must be resolved.
+              for (const sel of selectedSet) {
+                if (!resolvedSet.has(sel)) {
+                  return 'partial';
+                }
+              }
+              // C3: no unresolved failed files (a failed file not covered by
+              // a valid waiver). A file in both completed and failed is
+              // considered resolved (completed wins).
+              for (const failedPath of failedSet) {
+                if (!resolvedSet.has(failedPath) && !validWaiverPaths.has(failedPath)) {
+                  return 'partial';
+                }
+              }
+              // C3: no completed files outside the selected set (prevents
+              // an inflated completed set from masking a missing selected
+              // file).
+              const selectedLookup = new Set(selectedSet);
+              for (const completedPath of completedSet) {
+                if (!selectedLookup.has(completedPath)) {
+                  return 'partial';
+                }
+              }
+              return 'complete';
+            }
+
+            function computeCoverage(params) {
+              const selected = Number(params.selected) || 0;
+              const completed = Number(params.completed) || 0;
+              const ratio = selected === 0 ? 1 : completed / selected;
+              return { completed, selected, ratio: String(ratio) };
+            }
+
+            // Issue #2575: computeArtifactHashes is retained for testability
+            // and local CLI parity. The production hash computation runs in
+            // the dedicated "Compute reviewed-range manifest hashes" step
+            // (post-redaction), but this function is exercised by tests and
+            // serves as the canonical implementation.
+            function computeArtifactHashes(fileNames) {
+              const hashModule = typeof require === 'function' ? require('crypto') : crypto;
+              const fileSystem = typeof require === 'function' ? require('fs') : fs;
+              const hashes = {};
+              for (const fileName of fileNames) {
+                try {
+                  const content = fileSystem.readFileSync(fileName, 'utf8');
+                  const hash = hashModule.createHash('sha256').update(content).digest('hex');
+                  hashes[fileName] = `sha256:${hash}`;
+                } catch (_) {
+                  hashes[fileName] = null;
+                }
+              }
+              return hashes;
+            }
+
+            function buildReviewedRangeManifest(params) {
+              const selectedFiles = Array.isArray(params.selectedFiles) ? params.selectedFiles : [];
+              const rawCompletedFiles = Array.isArray(params.completedFiles) ? params.completedFiles : [];
+              const failedFiles = Array.isArray(params.failedFiles) ? params.failedFiles : [];
+              const reusedFiles = Array.isArray(params.reusedFiles) ? params.reusedFiles : [];
+              const rawWaivedFiles = Array.isArray(params.waivedFiles) ? params.waivedFiles : [];
+              const waivedFiles = rawWaivedFiles.map((entry) => {
+                if (typeof entry === 'string') {
+                  return { path: entry, reason: '' };
+                }
+                if (entry && typeof entry === 'object') {
+                  return { path: String(entry.path || ''), reason: String(entry.reason || '') };
+                }
+                return { path: String(entry), reason: '' };
+              });
+              const validWaivers = waivedFiles.filter((w) => w.path && w.reason.trim().length > 0);
+              // C2: completed_with_errors must not mark all selected files as
+              // completed. When the upstream OCR status indicates partial
+              // failure, we cannot trust that any specific file completed.
+              const ocrStatus = params.ocrStatus || '';
+              const isPartialStatus = ocrStatus === 'completed_with_errors';
+              const completedFiles = isPartialStatus ? [] : rawCompletedFiles;
+              const completeness = resolveCompleteness({
+                ocrExitCode: Number(params.ocrExitCode) || 0,
+                ocrStatus: params.ocrStatus || null,
+                selectedFiles,
+                completedFiles,
+                failedFiles,
+                reusedFiles,
+                waivedFiles,
+                skipped: params.skipped === true,
+              });
+              const coverage = computeCoverage({
+                completed: completedFiles.length,
+                selected: selectedFiles.length,
+              });
+              return {
+                schema_version: '1.0.0',
+                repository: params.repository || '',
+                pr_number: Number(params.prNumber) || 0,
+                head_sha: params.headSha || '',
+                merge_base_sha: params.mergeBaseSha || '',
+                trigger: params.trigger || '',
+                run_id: params.runId || '',
+                run_attempt: params.runAttempt || '',
+                ocr_version: params.ocrVersion || 'unknown',
+                ocr_session_id: params.ocrSessionId || '',
+                ocr_parent_session_id: params.ocrParentSessionId || '',
+                provider_model: params.providerModel || '',
+                concurrency: Number(params.concurrency) || 0,
+                rule_config_hash: params.ruleConfigHash || '',
+                selected_files: selectedFiles,
+                completed_files: completedFiles,
+                failed_files: failedFiles,
+                reused_files: reusedFiles,
+                waived_files: waivedFiles,
+                completeness,
+                coverage,
+                ocr_status: params.ocrStatus || '',
+                artifact_hashes: params.artifactHashes || {},
+              };
+            }
+
+            function serializeManifest(manifest) {
+              const json = JSON.stringify(manifest, null, 2);
+              return redactSecretDiagnostics(json);
+            }
+
+            function buildStatusLine(params) {
+              if (!params.ran) {
+                if (params.policyFailure) {
+                  return `OCR policy failure: ${params.policyFailure}`;
+                }
+                return 'OCR failed to run or parse output.';
+              }
+              if (params.completeness !== 'complete') {
+                const coverage = params.coverage || { completed: 0, selected: 0 };
+                const failedCount = Array.isArray(params.failedFiles)
+                  ? params.failedFiles.length
+                  : 0;
+                const findingNote = params.findingsCount > 0
+                  ? `; ${params.findingsCount} finding(s) (${params.postedInline} posted inline).`
+                  : '.';
+                return `Partial review: ${coverage.completed} of ${coverage.selected} files completed (${failedCount} failed)${findingNote}`;
+              }
+              if (params.findingsCount === 0) {
+                return 'No findings.';
+              }
+              return `${params.findingsCount} finding(s) (${params.postedInline} posted inline).`;
+            }
             if (policyFailure) {
               ran = false;
               core.warning('Skipping OCR output parsing because OCR policy failure was recorded.');
@@ -1563,16 +1800,49 @@ jobs:
             // Build the sticky summary, including lineless findings.
             const artifactLine =
               'Artifacts: `ocr-review-output` contains raw JSON, stdout, stderr, preview, phase, and exit-code diagnostics.';
-            let statusLine;
-            if (!ran) {
-              statusLine = policyFailure
-                ? `OCR policy failure: ${policyFailure}`
-                : 'OCR failed to run or parse output.';
-            } else if (findings.length === 0) {
-              statusLine = 'No findings.';
-            } else {
-              statusLine = `${findings.length} finding(s) (${postedInline} posted inline).`;
-            }
+            // Issue #2575: build the reviewed-range manifest for completeness
+            // tracking. The manifest records selected/completed/failed/waived
+            // file sets and a terminal completeness state.
+            const ocrStatusValue = readTrimmed('ocr-status.txt', '') || '';
+            const selectedFilesContent = readTrimmed('ocr-selected-files.txt', '');
+            const selectedFilesList = selectedFilesContent
+              ? selectedFilesContent.split(String.fromCharCode(10)).filter((l) => l.trim().length > 0)
+              : [];
+            // C2: completedFiles must only be set to all selected files when
+            // the OCR status is a recognized success AND exit code is 0.
+            // For completed_with_errors we do not know which files actually
+            // completed, so leave completedFiles empty (conservative).
+            const manifestCompletedFiles =
+              ran && (ocrStatusValue === 'success' || ocrStatusValue === 'completed') && exitCode === 0
+                ? selectedFilesList
+                : [];
+            // C7: isSkipped heuristic removed. When the post step runs, the
+            // review was NOT skipped (the gate let it through). Missing
+            // evidence is "failed"/"partial", never inferred as "skipped".
+            const manifestCompleteness = resolveCompleteness({
+              ocrExitCode: exitCode,
+              ocrStatus: ocrStatusValue || null,
+              selectedFiles: selectedFilesList,
+              completedFiles: manifestCompletedFiles,
+              failedFiles: [],
+              reusedFiles: [],
+              waivedFiles: [],
+              skipped: false,
+            });
+            const manifestCoverage = computeCoverage({
+              completed: manifestCompletedFiles.length,
+              selected: selectedFilesList.length,
+            });
+            const manifestFailedFiles = [];
+            const statusLine = buildStatusLine({
+              ran,
+              findingsCount: findings.length,
+              postedInline,
+              completeness: manifestCompleteness,
+              coverage: manifestCoverage,
+              failedFiles: manifestFailedFiles,
+              policyFailure,
+            });
             const infrastructureFailure = readTrimmed(INFRA_FAILURE_FILE, '');
             let body = [
               MARKER,
@@ -1734,6 +2004,49 @@ jobs:
               core.warning(redactSecretDiagnostics(`Failed to post OCR sticky summary; continuing without failing the workflow: ${summaryError.message || summaryError}`));
             }
 
+            // Issue #2575: persist the reviewed-range manifest.
+            // Artifact hashes are computed AFTER redaction in the dedicated
+            // "Compute reviewed-range manifest hashes" step; here we just
+            // write the manifest with placeholder empty hashes.
+            const manifest = buildReviewedRangeManifest({
+              repository: `${owner}/${repo}`,
+              prNumber: number,
+              headSha,
+              mergeBaseSha: process.env.BASE_SHA || '',
+              trigger: process.env.GITHUB_EVENT_NAME || '',
+              runId: String(context.runId || ''),
+              runAttempt: String(process.env.GITHUB_RUN_ATTEMPT || '1'),
+              ocrVersion,
+              ocrSessionId: process.env.OCR_SESSION_ID || '',
+              ocrParentSessionId: process.env.OCR_PARENT_SESSION_ID || '',
+              providerModel: readTrimmed('ocr-preflight.txt', '').split(String.fromCharCode(10))[0] || '',
+              concurrency: Number(process.env.OCR_CONCURRENCY) || 0,
+              ruleConfigHash: process.env.OCR_RULE_CONFIG_HASH || '',
+              selectedFiles: selectedFilesList,
+              completedFiles: manifestCompletedFiles,
+              failedFiles: manifestFailedFiles,
+              reusedFiles: [],
+              waivedFiles: [],
+              ocrExitCode: exitCode,
+              ocrStatus: ocrStatusValue,
+              skipped: false,
+              artifactHashes: {},
+            });
+            try {
+              const serialized = serializeManifest(manifest);
+              fs.writeFileSync('ocr-reviewed-range-manifest.json', serialized);
+            } catch (manifestErr) {
+              // C9: a manifest persistence failure must not be silently
+              // swallowed. Record it as an infrastructure failure so the
+              // downstream classification and notifier pick it up.
+              core.warning(redactSecretDiagnostics(`Failed to write reviewed-range manifest: ${manifestErr.message || manifestErr}`));
+              const infraMessage = 'phase=manifest; reason=reviewed-range manifest persistence failed: '
+                + redactSecretDiagnostics(String(manifestErr.message || manifestErr))
+                + String.fromCharCode(10);
+              fs.writeFileSync(INFRA_FAILURE_FILE, infraMessage);
+              fs.writeFileSync('ocr-phase.txt', 'manifest\n');
+            }
+
             // Feature 5 (issue #2670): structured step outputs.
             const commentsTotal = findings.length + suppressedDuplicateCount;
             // comments_skipped counts ONLY inline comments skipped by
@@ -1772,6 +2085,21 @@ jobs:
           else
             echo "infrastructure_failure=false" >> "$GITHUB_OUTPUT"
           fi
+          # C8: extract completeness from the reviewed-range manifest so the
+          # record-ocr-outcome job can distinguish partial/failed reviews
+          # from complete successes.
+          completeness="unknown"
+          if [ -s ocr-reviewed-range-manifest.json ]; then
+            completeness="$(node -e '
+              try {
+                const data = JSON.parse(require("fs").readFileSync("ocr-reviewed-range-manifest.json", "utf8"));
+                if (data && typeof data === "object" && typeof data.completeness === "string") {
+                  process.stdout.write(data.completeness);
+                }
+              } catch (_) { /* best-effort */ }
+            ' 2>/dev/null || true)"
+          fi
+          echo "completeness=${completeness}" >> "$GITHUB_OUTPUT"
 
       - name: Redact OCR diagnostic artifacts
         shell: bash
@@ -1814,6 +2142,11 @@ jobs:
             'ocr-phase.txt',
             'ocr-infrastructure-failure.txt',
             'ocr-policy-failure.txt',
+            'ocr-selected-files.txt',
+            'ocr-status.txt',
+            'ocr-reviewed-range-manifest.json',
+            'ocr-manifest-hashes.json',
+            'ocr-manifest-sha256.txt',
           ];
           const replaceWithRedactionFailure = (fileName, error) => {
             const code = error && error.code ? error.code : 'unknown';
@@ -1844,6 +2177,67 @@ jobs:
             }
           }
           NODE
+      - name: Compute reviewed-range manifest hashes
+        # C4/C5/C6: compute SHA-256 hashes of post-redaction artifacts.
+        # This runs AFTER "Redact OCR diagnostic artifacts" so the hashes
+        # describe the actual (redacted) bytes that are uploaded. The
+        # manifest itself is hashed last (after its artifact_hashes field
+        # is filled) and written to a detached ocr-manifest-sha256.txt.
+        shell: bash
+        if: always()
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const crypto = require('crypto');
+          // C5/C6: all diagnostic artifacts are hashed, including status
+          // and failure markers.
+          const hashableArtifacts = [
+            'ocr-result.json',
+            'ocr-stdout.raw',
+            'ocr-stderr.log',
+            'ocr-preflight.txt',
+            'ocr-version.txt',
+            'ocr-preview.txt',
+            'ocr-preview-stderr.log',
+            'ocr-exit-code.txt',
+            'ocr-phase.txt',
+            'ocr-selected-files.txt',
+            'ocr-status.txt',
+            'ocr-infrastructure-failure.txt',
+            'ocr-policy-failure.txt',
+          ];
+          const hashes = {};
+          for (const name of hashableArtifacts) {
+            try {
+              const content = fs.readFileSync(name, 'utf8');
+              const hash = crypto.createHash('sha256').update(content).digest('hex');
+              hashes[name] = `sha256:${hash}`;
+            } catch (_) {
+              hashes[name] = null;
+            }
+          }
+          // Write the per-artifact hashes.
+          fs.writeFileSync('ocr-manifest-hashes.json', JSON.stringify(hashes, null, 2));
+          // Re-read the manifest, inject the post-redaction hashes, and
+          // re-serialize so the manifest itself carries verified hashes.
+          try {
+            const manifestRaw = fs.readFileSync('ocr-reviewed-range-manifest.json', 'utf8');
+            const manifest = JSON.parse(manifestRaw);
+            manifest.artifact_hashes = hashes;
+            fs.writeFileSync('ocr-reviewed-range-manifest.json', JSON.stringify(manifest, null, 2));
+          } catch (manifestErr) {
+            process.stderr.write('Could not update manifest artifact_hashes: ' + (manifestErr.message || manifestErr) + String.fromCharCode(10));
+          }
+          // Hash the manifest LAST (after its own hashes are filled in) and
+          // write the detached manifest hash.
+          try {
+            const manifestContent = fs.readFileSync('ocr-reviewed-range-manifest.json', 'utf8');
+            const manifestHash = crypto.createHash('sha256').update(manifestContent).digest('hex');
+            fs.writeFileSync('ocr-manifest-sha256.txt', 'sha256:' + manifestHash + String.fromCharCode(10));
+          } catch (manifestErr) {
+            process.stderr.write('Could not compute manifest hash: ' + (manifestErr.message || manifestErr) + String.fromCharCode(10));
+          }
+          NODE
       - name: Ensure OCR artifact placeholders exist
         shell: bash
         if: always()
@@ -1861,7 +2255,12 @@ jobs:
             ocr-exit-code.txt \
             ocr-phase.txt \
             ocr-infrastructure-failure.txt \
-            ocr-policy-failure.txt; do
+            ocr-policy-failure.txt \
+            ocr-selected-files.txt \
+            ocr-status.txt \
+            ocr-reviewed-range-manifest.json \
+            ocr-manifest-hashes.json \
+            ocr-manifest-sha256.txt; do
             if [ ! -e "$file_name" ]; then
               : > "$file_name"
               missing="${missing}${file_name}"$'\n'
@@ -1903,6 +2302,11 @@ jobs:
             ocr-phase.txt
             ocr-infrastructure-failure.txt
             ocr-policy-failure.txt
+            ocr-selected-files.txt
+            ocr-status.txt
+            ocr-reviewed-range-manifest.json
+            ocr-manifest-hashes.json
+            ocr-manifest-sha256.txt
           if-no-files-found: warn
 
       - name: Clean up scoped safe.directory
@@ -1940,11 +2344,23 @@ jobs:
         shell: bash
         run: echo 'Non-blocking OCR infrastructure failure recorded.'
 
+      - name: 'Record OCR outcome: partial'
+        if: >-
+          ${{ needs.code-review.result == 'success' &&
+              needs.code-review.outputs.policy_failure != 'true' &&
+              needs.code-review.outputs.infrastructure_failure != 'true' &&
+              (needs.code-review.outputs.completeness == 'partial' ||
+               needs.code-review.outputs.completeness == 'failed') }}
+        shell: bash
+        run: echo 'Partial/incomplete OCR review recorded — not all selected files completed.'
+
       - name: 'Record OCR outcome: success'
         if: >-
           ${{ needs.code-review.result == 'success' &&
               needs.code-review.outputs.policy_failure != 'true' &&
-              needs.code-review.outputs.infrastructure_failure != 'true' }}
+              needs.code-review.outputs.infrastructure_failure != 'true' &&
+              needs.code-review.outputs.completeness != 'partial' &&
+              needs.code-review.outputs.completeness != 'failed' }}
         shell: bash
         run: echo 'Successful OCR review recorded.'
 

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1155,6 +1155,7 @@ jobs:
 
             let ran = true;
             let findings = [];
+            let ocrResultEnvelope = null;
             const policyFailure = readTrimmed(POLICY_FAILURE_FILE, '');
             const exitCode = readExitCode('ocr-exit-code.txt');
             if (exitCode !== 0) {
@@ -1671,6 +1672,38 @@ jobs:
               return redactSecretDiagnostics(json);
             }
 
+            function resultEnvelopeFromRaw(raw) {
+              try {
+                const parsed = JSON.parse(String(raw || '').trim());
+                return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+                  ? parsed
+                  : null;
+              } catch (_) {
+                return null;
+              }
+            }
+
+            function failedFilesFromResult(envelope) {
+              const warnings = envelope && Array.isArray(envelope.warnings)
+                ? envelope.warnings
+                : [];
+              const failedFiles = [];
+              const seen = new Set();
+              for (const warning of warnings) {
+                if (!warning || warning.type !== 'subtask_error') {
+                  continue;
+                }
+                const filePath = typeof warning.file === 'string'
+                  ? warning.file.trim()
+                  : '';
+                if (filePath && !seen.has(filePath)) {
+                  seen.add(filePath);
+                  failedFiles.push(filePath);
+                }
+              }
+              return failedFiles;
+            }
+
             function buildStatusLine(params) {
               if (!params.ran) {
                 if (params.policyFailure) {
@@ -1699,6 +1732,7 @@ jobs:
             } else if (exitCode === 0) {
               try {
                 const raw = fs.readFileSync('ocr-result.json', 'utf8');
+                ocrResultEnvelope = resultEnvelopeFromRaw(raw);
                 const parsed = parseFindings(raw);
                 if (parsed) {
                   findings = parsed;
@@ -1947,6 +1981,7 @@ jobs:
               ran && (ocrStatusValue === 'success' || ocrStatusValue === 'completed') && exitCode === 0
                 ? selectedFilesList
                 : [];
+            const manifestFailedFiles = failedFilesFromResult(ocrResultEnvelope);
             // C7: isSkipped heuristic removed. When the post step runs, the
             // review was NOT skipped (the gate let it through). Missing
             // evidence is "failed"/"partial", never inferred as "skipped".
@@ -1955,7 +1990,7 @@ jobs:
               ocrStatus: ocrStatusValue || null,
               selectedFiles: selectedFilesList,
               completedFiles: manifestCompletedFiles,
-              failedFiles: [],
+              failedFiles: manifestFailedFiles,
               reusedFiles: [],
               waivedFiles: [],
               skipped: false,
@@ -1964,7 +1999,6 @@ jobs:
               completed: manifestCompletedFiles.length,
               selected: selectedFilesList.length,
             });
-            const manifestFailedFiles = [];
             const statusLine = buildStatusLine({
               ran,
               findingsCount: findings.length,

--- a/scripts/tests/ocr-manifest-test-helpers.js
+++ b/scripts/tests/ocr-manifest-test-helpers.js
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vm from 'node:vm';
+import { beforeAll, expect } from 'vitest';
+import yaml from 'js-yaml';
+import {
+  WORKFLOW_PATH,
+  commandText,
+  extractFunctionSource,
+  readRootFile,
+  stepNamed,
+} from './ocr-review-workflow-helpers.js';
+
+const VM_TIMEOUT_MS = 2000;
+
+function defaultSandboxGlobals() {
+  return {
+    Number,
+    Math,
+    JSON,
+    String,
+    Object,
+    Array,
+    Boolean,
+    Error,
+    Set,
+    Map,
+  };
+}
+
+export const BASE_MANIFEST_PARAMS = {
+  repository: 'acme/widget',
+  prNumber: 42,
+  headSha: 'abc123def456',
+  mergeBaseSha: 'fed654cba321',
+  trigger: 'pull_request_target',
+  runId: '999888777',
+  runAttempt: '1',
+  ocrVersion: '1.7.16',
+  providerModel: 'gpt-4o',
+  concurrency: 2,
+  ocrSessionId: 'sess-abc',
+  ocrParentSessionId: 'parent-sess-xyz',
+  ruleConfigHash: 'sha256:deadbeef',
+  selectedFiles: ['src/a.ts', 'src/b.ts'],
+  completedFiles: ['src/a.ts', 'src/b.ts'],
+  failedFiles: [],
+  reusedFiles: [],
+  waivedFiles: [],
+  ocrExitCode: 0,
+  ocrStatus: 'success',
+  skipped: false,
+  artifactHashes: {},
+};
+
+export function useWorkflowFixture() {
+  const ctx = {};
+  beforeAll(() => {
+    const workflowYml = readRootFile(WORKFLOW_PATH);
+    const workflow = yaml.load(workflowYml);
+    if (!workflow || typeof workflow !== 'object') {
+      throw new Error(`${WORKFLOW_PATH} did not parse to a YAML mapping`);
+    }
+    const codeReviewJob = workflow.jobs?.['code-review'];
+    expect(
+      codeReviewJob,
+      'workflow should contain job: code-review',
+    ).toBeTruthy();
+    const postStep = stepNamed(codeReviewJob, 'Post OCR results');
+    const postScript = commandText(postStep);
+    ctx.workflow = workflow;
+    ctx.codeReviewJob = codeReviewJob;
+    ctx.postStep = postStep;
+    ctx.postScript = postScript;
+  });
+  return ctx;
+}
+
+export function makeLoadFunction(ctx) {
+  return function loadFunction(funcName, sandboxGlobals = {}) {
+    const source = extractFunctionSource(ctx.postScript, funcName);
+    const sandbox = {
+      ...defaultSandboxGlobals(),
+      ...sandboxGlobals,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { timeout: VM_TIMEOUT_MS });
+    const fn = sandbox[funcName];
+    expect(typeof fn, `${funcName} should be defined after vm execution`).toBe(
+      'function',
+    );
+    return fn;
+  };
+}
+
+export function makeLoadFunctionsTogether(ctx) {
+  return function loadFunctionsTogether(funcNames, sandboxGlobals = {}) {
+    const sources = funcNames.map((name) =>
+      extractFunctionSource(ctx.postScript, name),
+    );
+    const sandbox = {
+      ...defaultSandboxGlobals(),
+      ...sandboxGlobals,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(sources.join('\n'), sandbox, {
+      timeout: VM_TIMEOUT_MS,
+    });
+    for (const name of funcNames) {
+      expect(
+        typeof sandbox[name],
+        `${name} should be defined after vm execution`,
+      ).toBe('function');
+    }
+    return sandbox;
+  };
+}

--- a/scripts/tests/ocr-manifest-test-helpers.js
+++ b/scripts/tests/ocr-manifest-test-helpers.js
@@ -88,7 +88,13 @@ export function makeLoadFunction(ctx) {
       ...sandboxGlobals,
     };
     vm.createContext(sandbox);
-    vm.runInContext(source, sandbox, { timeout: VM_TIMEOUT_MS });
+    try {
+      vm.runInContext(source, sandbox, { timeout: VM_TIMEOUT_MS });
+    } catch (error) {
+      throw new Error(`Failed to load workflow function ${funcName}`, {
+        cause: error,
+      });
+    }
     const fn = sandbox[funcName];
     expect(typeof fn, `${funcName} should be defined after vm execution`).toBe(
       'function',
@@ -107,9 +113,16 @@ export function makeLoadFunctionsTogether(ctx) {
       ...sandboxGlobals,
     };
     vm.createContext(sandbox);
-    vm.runInContext(sources.join('\n'), sandbox, {
-      timeout: VM_TIMEOUT_MS,
-    });
+    try {
+      vm.runInContext(sources.join('\n'), sandbox, {
+        timeout: VM_TIMEOUT_MS,
+      });
+    } catch (error) {
+      throw new Error(
+        `Failed to load workflow functions ${funcNames.join(', ')}`,
+        { cause: error },
+      );
+    }
     for (const name of funcNames) {
       expect(
         typeof sandbox[name],

--- a/scripts/tests/ocr-reviewed-range-manifest-wiring.test.js
+++ b/scripts/tests/ocr-reviewed-range-manifest-wiring.test.js
@@ -118,6 +118,39 @@ describe('.github/workflows/ocr-review.yml — manifest artifacts & YAML wiring 
     });
   });
 
+  describe('OCR result coverage metadata', () => {
+    it('parses an object envelope without changing array fallback behavior', () => {
+      const fn = loadFunction('resultEnvelopeFromRaw');
+      expect(fn('{"status":"success","comments":[]}')).toEqual({
+        status: 'success',
+        comments: [],
+      });
+    });
+
+    it('returns null for output that is not a JSON object envelope', () => {
+      const fn = loadFunction('resultEnvelopeFromRaw');
+      expect(fn('progress\n[]')).toBeNull();
+    });
+
+    it('extracts unique failed paths from OCR subtask errors', () => {
+      const fn = loadFunction('failedFilesFromResult');
+      const result = fn({
+        warnings: [
+          { type: 'subtask_error', file: 'src/a.ts', message: 'timeout' },
+          { type: 'warning', file: 'src/b.ts', message: 'large file' },
+          { type: 'subtask_error', file: 'src/a.ts', message: 'retry failed' },
+          { type: 'subtask_error', file: ' src/c.ts ', message: 'error' },
+        ],
+      });
+      expect(result).toEqual(['src/a.ts', 'src/c.ts']);
+    });
+
+    it('returns no failed paths when the OCR envelope has no warnings', () => {
+      const fn = loadFunction('failedFilesFromResult');
+      expect(fn(null)).toEqual([]);
+    });
+  });
+
   // -----------------------------------------------------------------------
   // serializeManifest (redaction)
   // -----------------------------------------------------------------------

--- a/scripts/tests/ocr-reviewed-range-manifest-wiring.test.js
+++ b/scripts/tests/ocr-reviewed-range-manifest-wiring.test.js
@@ -1,0 +1,522 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import crypto from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  BASE_MANIFEST_PARAMS,
+  makeLoadFunction,
+  makeLoadFunctionsTogether,
+  useWorkflowFixture,
+} from './ocr-manifest-test-helpers.js';
+import { commandText, stepNamed } from './ocr-review-workflow-helpers.js';
+
+describe('.github/workflows/ocr-review.yml — manifest artifacts & YAML wiring (issue #2575)', () => {
+  const ctx = useWorkflowFixture();
+  const loadFunction = makeLoadFunction(ctx);
+  const loadFunctionsTogether = makeLoadFunctionsTogether(ctx);
+
+  // -----------------------------------------------------------------------
+  // computeArtifactHashes
+  // -----------------------------------------------------------------------
+  describe('computeArtifactHashes behavior', () => {
+    function makeFakeFs(files) {
+      return {
+        readFileSync: (name) => {
+          if (!(name in files)) {
+            const err = new Error(`ENOENT: ${name}`);
+            err.code = 'ENOENT';
+            throw err;
+          }
+          return files[name];
+        },
+      };
+    }
+
+    it('computes SHA-256 hashes for each artifact file (AC #8)', () => {
+      const content = 'hello world';
+      const expectedHash = `sha256:${crypto.createHash('sha256').update(content).digest('hex')}`;
+      const fakeFs = makeFakeFs({ 'ocr-result.json': content });
+      const fn = loadFunction('computeArtifactHashes', {
+        require: (mod) => {
+          if (mod === 'crypto') return crypto;
+          if (mod === 'fs') return fakeFs;
+          throw new Error(`unknown module: ${mod}`);
+        },
+        fs: fakeFs,
+      });
+      const hashes = fn(['ocr-result.json']);
+      expect(hashes['ocr-result.json']).toBe(expectedHash);
+    });
+
+    it('prefixes each hash with sha256:', () => {
+      const fakeFs = makeFakeFs({ 'ocr-stdout.raw': 'data' });
+      const fn = loadFunction('computeArtifactHashes', {
+        require: (mod) => {
+          if (mod === 'crypto') return crypto;
+          if (mod === 'fs') return fakeFs;
+          throw new Error(`unknown module: ${mod}`);
+        },
+        fs: fakeFs,
+      });
+      const hashes = fn(['ocr-stdout.raw']);
+      expect(hashes['ocr-stdout.raw']).toMatch(/^sha256:[0-9a-f]{64}$/);
+    });
+
+    it('returns null for a missing file instead of throwing', () => {
+      const fakeFs = makeFakeFs({});
+      const fn = loadFunction('computeArtifactHashes', {
+        require: (mod) => {
+          if (mod === 'crypto') return crypto;
+          if (mod === 'fs') return fakeFs;
+          throw new Error(`unknown module: ${mod}`);
+        },
+        fs: fakeFs,
+      });
+      const hashes = fn(['nonexistent.txt']);
+      expect(hashes['nonexistent.txt']).toBeNull();
+    });
+
+    it('hashes multiple files independently', () => {
+      const fakeFs = makeFakeFs({
+        'a.txt': 'content-a',
+        'b.txt': 'content-b',
+      });
+      const fn = loadFunction('computeArtifactHashes', {
+        require: (mod) => {
+          if (mod === 'crypto') return crypto;
+          if (mod === 'fs') return fakeFs;
+          throw new Error(`unknown module: ${mod}`);
+        },
+        fs: fakeFs,
+      });
+      const hashes = fn(['a.txt', 'b.txt']);
+      expect(hashes['a.txt']).not.toBe(hashes['b.txt']);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // serializeManifest (redaction)
+  // -----------------------------------------------------------------------
+  describe('serializeManifest behavior', () => {
+    function loadSerializer(token = '', url = '') {
+      const sandbox = loadFunctionsTogether(
+        ['escapeRegExp', 'redactSecretDiagnostics', 'serializeManifest'],
+        {
+          REDACTION: '[REDACTED]',
+          ocrTokenForRedaction: token,
+          ocrUrlForRedaction: url,
+        },
+      );
+      return sandbox.serializeManifest;
+    }
+
+    it('produces valid JSON that round-trips', () => {
+      const serialize = loadSerializer();
+      const manifest = { schema_version: '1', completeness: 'complete' };
+      const result = serialize(manifest);
+      expect(JSON.parse(result)).toEqual(manifest);
+    });
+
+    it('redacts a secret token that appears in the manifest (AC #8)', () => {
+      const secret = 'super-secret-token-1234567890';
+      const serialize = loadSerializer(secret);
+      const manifest = { provider_model: `model-${secret}` };
+      const result = serialize(manifest);
+      expect(result).not.toContain(secret);
+      expect(result).toContain('[REDACTED]');
+    });
+
+    it('redacts a secret URL that appears in the manifest (AC #8)', () => {
+      const url = 'https://internal-provider.example.com/v1/chat';
+      const serialize = loadSerializer('', url);
+      const manifest = { notes: `endpoint: ${url}` };
+      const result = serialize(manifest);
+      expect(result).not.toContain(url);
+      expect(result).toContain('[REDACTED]');
+    });
+
+    it('preserves hash values through redaction', () => {
+      const serialize = loadSerializer('secret123');
+      const hash = 'sha256:abcdef0123456789';
+      const manifest = { artifact_hashes: { 'ocr-result.json': hash } };
+      const result = serialize(manifest);
+      expect(result).toContain(hash);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildStatusLine
+  // -----------------------------------------------------------------------
+  describe('buildStatusLine behavior', () => {
+    function loadStatusLine() {
+      return loadFunction('buildStatusLine');
+    }
+
+    it('emits "No findings." for a complete run with zero findings', () => {
+      const fn = loadStatusLine();
+      const result = fn({
+        ran: true,
+        findingsCount: 0,
+        postedInline: 0,
+        completeness: 'complete',
+        coverage: { completed: 5, selected: 5 },
+        failedFiles: [],
+        policyFailure: '',
+      });
+      expect(result).toBe('No findings.');
+    });
+
+    it('emits a finding count for a complete run with findings', () => {
+      const fn = loadStatusLine();
+      const result = fn({
+        ran: true,
+        findingsCount: 3,
+        postedInline: 2,
+        completeness: 'complete',
+        coverage: { completed: 5, selected: 5 },
+        failedFiles: [],
+        policyFailure: '',
+      });
+      expect(result).toContain('3 finding(s)');
+    });
+
+    it('does NOT emit "No findings." for a partial run with zero findings (AC #7)', () => {
+      const fn = loadStatusLine();
+      const result = fn({
+        ran: true,
+        findingsCount: 0,
+        postedInline: 0,
+        completeness: 'partial',
+        coverage: { completed: 5, selected: 10 },
+        failedFiles: ['c.ts', 'd.ts'],
+        policyFailure: '',
+      });
+      expect(result).not.toBe('No findings.');
+      expect(result).toContain('Partial review');
+    });
+
+    it('does NOT emit a plain finding count for a partial run with findings (AC #7)', () => {
+      const fn = loadStatusLine();
+      const result = fn({
+        ran: true,
+        findingsCount: 3,
+        postedInline: 2,
+        completeness: 'partial',
+        coverage: { completed: 5, selected: 10 },
+        failedFiles: ['c.ts'],
+        policyFailure: '',
+      });
+      expect(result).not.toMatch(/^\d+ finding\(s\)\./);
+      expect(result).toContain('Partial review');
+    });
+
+    it('includes coverage info (completed/selected) in partial status (AC #5)', () => {
+      const fn = loadStatusLine();
+      const result = fn({
+        ran: true,
+        findingsCount: 0,
+        postedInline: 0,
+        completeness: 'partial',
+        coverage: { completed: 5, selected: 10 },
+        failedFiles: ['c.ts', 'd.ts', 'e.ts'],
+        policyFailure: '',
+      });
+      expect(result).toContain('5');
+      expect(result).toContain('10');
+    });
+
+    it('safely identifies failed files count in partial status (AC #5)', () => {
+      const fn = loadStatusLine();
+      const result = fn({
+        ran: true,
+        findingsCount: 0,
+        postedInline: 0,
+        completeness: 'partial',
+        coverage: { completed: 5, selected: 10 },
+        failedFiles: ['c.ts', 'd.ts', 'e.ts'],
+        policyFailure: '',
+      });
+      expect(result).toContain('3');
+      expect(result.toLowerCase()).toContain('fail');
+    });
+
+    it('emits policy failure message when ran is false and policyFailure is set', () => {
+      const fn = loadStatusLine();
+      const result = fn({
+        ran: false,
+        findingsCount: 0,
+        postedInline: 0,
+        completeness: 'failed',
+        coverage: { completed: 0, selected: 0 },
+        failedFiles: [],
+        policyFailure: 'changed test files were missing',
+      });
+      expect(result).toContain('OCR policy failure');
+    });
+
+    it('emits failure message when ran is false without policy failure', () => {
+      const fn = loadStatusLine();
+      const result = fn({
+        ran: false,
+        findingsCount: 0,
+        postedInline: 0,
+        completeness: 'failed',
+        coverage: { completed: 0, selected: 0 },
+        failedFiles: [],
+        policyFailure: '',
+      });
+      expect(result).toContain('failed');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // YAML wiring
+  // -----------------------------------------------------------------------
+  describe('YAML wiring', () => {
+    it('defines function buildReviewedRangeManifest(params)', () => {
+      expect(ctx.postScript).toContain(
+        'function buildReviewedRangeManifest(params)',
+      );
+    });
+
+    it('defines function resolveCompleteness', () => {
+      expect(ctx.postScript).toContain('function resolveCompleteness(');
+    });
+
+    it('defines function computeCoverage', () => {
+      expect(ctx.postScript).toContain('function computeCoverage(');
+    });
+
+    it('defines function computeArtifactHashes', () => {
+      expect(ctx.postScript).toContain('function computeArtifactHashes(');
+    });
+
+    it('defines function serializeManifest', () => {
+      expect(ctx.postScript).toContain('function serializeManifest(');
+    });
+
+    it('defines function buildStatusLine', () => {
+      expect(ctx.postScript).toContain('function buildStatusLine(');
+    });
+
+    it('writes the manifest to ocr-reviewed-range-manifest.json', () => {
+      expect(ctx.postScript).toContain('ocr-reviewed-range-manifest.json');
+    });
+
+    it('initializes ocr-reviewed-range-manifest.json in the Initialize step', () => {
+      const initStep = stepNamed(
+        ctx.codeReviewJob,
+        'Initialize OCR artifact files',
+      );
+      const initRun = commandText(initStep);
+      expect(initRun).toContain(': > ocr-reviewed-range-manifest.json');
+    });
+
+    it('adds ocr-reviewed-range-manifest.json to the Redact step artifacts', () => {
+      const redactStep = stepNamed(
+        ctx.codeReviewJob,
+        'Redact OCR diagnostic artifacts',
+      );
+      const redactRun = commandText(redactStep);
+      expect(redactRun).toContain("'ocr-reviewed-range-manifest.json'");
+    });
+
+    it('adds ocr-reviewed-range-manifest.json to the Ensure placeholders step', () => {
+      const ensureStep = stepNamed(
+        ctx.codeReviewJob,
+        'Ensure OCR artifact placeholders exist',
+      );
+      const ensureRun = commandText(ensureStep);
+      expect(ensureRun).toContain('ocr-reviewed-range-manifest.json');
+    });
+
+    it('adds ocr-reviewed-range-manifest.json to the Upload artifacts step', () => {
+      const uploadStep = stepNamed(ctx.codeReviewJob, 'Upload OCR artifacts');
+      expect(uploadStep.with?.path).toContain(
+        'ocr-reviewed-range-manifest.json',
+      );
+    });
+
+    it('captures the OCR JSON status field in the Run OpenCodeReview step', () => {
+      const reviewStep = stepNamed(ctx.codeReviewJob, 'Run OpenCodeReview');
+      const reviewRun = commandText(reviewStep);
+      expect(reviewRun).toMatch(/ocr-status|OCR_STATUS|status.*json/i);
+    });
+
+    it('writes selected files to ocr-selected-files.txt in the preview step', () => {
+      const previewStep = stepNamed(
+        ctx.codeReviewJob,
+        'Verify review scope includes changed tests',
+      );
+      const previewRun = commandText(previewStep);
+      expect(previewRun).toContain('ocr-selected-files.txt');
+    });
+
+    // --- C2: completedFiles inference for completed_with_errors ---
+    it('does NOT set completedFiles to all selected files when ocrStatus is completed_with_errors (C2)', () => {
+      const { buildReviewedRangeManifest } = loadFunctionsTogether(
+        [
+          'buildReviewedRangeManifest',
+          'resolveCompleteness',
+          'computeCoverage',
+        ],
+        {},
+      );
+      const manifest = buildReviewedRangeManifest({
+        ...BASE_MANIFEST_PARAMS,
+        selectedFiles: ['a.ts', 'b.ts'],
+        completedFiles: ['a.ts', 'b.ts'],
+        failedFiles: [],
+        ocrExitCode: 0,
+        ocrStatus: 'completed_with_errors',
+        skipped: false,
+      });
+      expect(manifest.completed_files).toEqual([]);
+    });
+
+    // --- C7: isSkipped heuristic removed ---
+    it('does NOT infer skipped from missing evidence (C7)', () => {
+      expect(ctx.postScript).not.toContain('const isSkipped');
+      expect(ctx.postScript).not.toContain('skipped: isSkipped');
+    });
+
+    // --- C4: hash computation step runs AFTER redaction ---
+    it('has a "Compute reviewed-range manifest hashes" step after Redact and before Ensure placeholders (C4)', () => {
+      const stepNames = ctx.codeReviewJob.steps.map((s) => s.name);
+      const redactIndex = stepNames.indexOf('Redact OCR diagnostic artifacts');
+      const hashIndex = stepNames.indexOf(
+        'Compute reviewed-range manifest hashes',
+      );
+      const ensureIndex = stepNames.indexOf(
+        'Ensure OCR artifact placeholders exist',
+      );
+      expect(redactIndex, 'Redact step should exist').toBeGreaterThanOrEqual(0);
+      expect(
+        hashIndex,
+        'Compute reviewed-range manifest hashes step should exist',
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        ensureIndex,
+        'Ensure placeholders step should exist',
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        hashIndex,
+        'hash step must come after redact step',
+      ).toBeGreaterThan(redactIndex);
+      expect(
+        hashIndex,
+        'hash step must come before ensure placeholders step',
+      ).toBeLessThan(ensureIndex);
+    });
+
+    it('the hash computation step computes SHA-256 for post-redaction artifacts (C4)', () => {
+      const hashStep = stepNamed(
+        ctx.codeReviewJob,
+        'Compute reviewed-range manifest hashes',
+      );
+      const hashRun = commandText(hashStep);
+      expect(hashRun).toMatch(/sha256|createHash/i);
+      expect(hashRun).toContain('ocr-manifest-hashes.json');
+    });
+
+    // --- C5: ocr-status.txt in hash list ---
+    it('the hash computation includes ocr-status.txt (C5)', () => {
+      const hashStep = stepNamed(
+        ctx.codeReviewJob,
+        'Compute reviewed-range manifest hashes',
+      );
+      const hashRun = commandText(hashStep);
+      expect(hashRun).toContain('ocr-status.txt');
+    });
+
+    // --- C6: ocr-infrastructure-failure.txt and ocr-policy-failure.txt in hash list ---
+    it('the hash computation includes ocr-infrastructure-failure.txt (C6)', () => {
+      const hashStep = stepNamed(
+        ctx.codeReviewJob,
+        'Compute reviewed-range manifest hashes',
+      );
+      const hashRun = commandText(hashStep);
+      expect(hashRun).toContain('ocr-infrastructure-failure.txt');
+    });
+
+    it('the hash computation includes ocr-policy-failure.txt (C6)', () => {
+      const hashStep = stepNamed(
+        ctx.codeReviewJob,
+        'Compute reviewed-range manifest hashes',
+      );
+      const hashRun = commandText(hashStep);
+      expect(hashRun).toContain('ocr-policy-failure.txt');
+    });
+
+    // --- C8: completeness output + partial outcome branch ---
+    it('exposes completeness as a job output from the classification step (C8)', () => {
+      const classifyStep = stepNamed(
+        ctx.codeReviewJob,
+        'Resolve OCR failure classification',
+      );
+      const classifyRun = commandText(classifyStep);
+      expect(classifyRun).toContain('completeness');
+    });
+
+    it('exposes completeness in the code-review job outputs (C8)', () => {
+      expect(ctx.codeReviewJob.outputs?.completeness).toBeDefined();
+    });
+
+    it('has a "Record OCR outcome: partial" step in record-ocr-outcome (C8)', () => {
+      const recordJob = ctx.workflow.jobs?.['record-ocr-outcome'];
+      expect(recordJob, 'record-ocr-outcome job should exist').toBeTruthy();
+      const partialStep = recordJob.steps.find(
+        (s) => s.name === 'Record OCR outcome: partial',
+      );
+      expect(partialStep, 'should have a partial outcome step').toBeTruthy();
+    });
+
+    it('the partial outcome step runs when completeness is partial or failed (C8)', () => {
+      const recordJob = ctx.workflow.jobs?.['record-ocr-outcome'];
+      const partialStep = recordJob.steps.find(
+        (s) => s.name === 'Record OCR outcome: partial',
+      );
+      const condition = String(partialStep?.if || '');
+      expect(condition).toContain('partial');
+      expect(condition).toContain('failed');
+      expect(condition).not.toContain("completeness == 'complete'");
+    });
+
+    it('the success outcome step excludes partial/failed completeness (C8)', () => {
+      const recordJob = ctx.workflow.jobs?.['record-ocr-outcome'];
+      const successStep = recordJob.steps.find(
+        (s) => s.name === 'Record OCR outcome: success',
+      );
+      const condition = String(successStep?.if || '');
+      expect(condition).toContain("completeness != 'partial'");
+      expect(condition).toContain("completeness != 'failed'");
+    });
+
+    // --- C9: manifest write failure → infrastructure failure ---
+    it('writes to ocr-infrastructure-failure.txt when manifest write fails (C9)', () => {
+      expect(ctx.postScript).toMatch(
+        /manifest.*infrastructure|infrastructure.*manifest|markInfrastructureFailure.*manifest|manifest.*persistence/i,
+      );
+    });
+
+    it('the hash computation step writes a detached manifest hash to ocr-manifest-sha256.txt (C4)', () => {
+      const hashStep = stepNamed(
+        ctx.codeReviewJob,
+        'Compute reviewed-range manifest hashes',
+      );
+      const hashRun = commandText(hashStep);
+      expect(hashRun).toContain('ocr-manifest-sha256.txt');
+    });
+
+    it('uploads ocr-manifest-hashes.json and ocr-manifest-sha256.txt (C4)', () => {
+      const uploadStep = stepNamed(ctx.codeReviewJob, 'Upload OCR artifacts');
+      const uploadPath = String(uploadStep.with?.path || '');
+      expect(uploadPath).toContain('ocr-manifest-hashes.json');
+      expect(uploadPath).toContain('ocr-manifest-sha256.txt');
+    });
+  });
+});

--- a/scripts/tests/ocr-reviewed-range-manifest-wiring.test.js
+++ b/scripts/tests/ocr-reviewed-range-manifest-wiring.test.js
@@ -80,6 +80,26 @@ describe('.github/workflows/ocr-review.yml — manifest artifacts & YAML wiring 
       expect(hashes['nonexistent.txt']).toBeNull();
     });
 
+    it('returns null when a file cannot be read', () => {
+      const fakeFs = {
+        readFileSync: () => {
+          const error = new Error('EACCES: denied');
+          error.code = 'EACCES';
+          throw error;
+        },
+      };
+      const fn = loadFunction('computeArtifactHashes', {
+        require: (mod) => {
+          if (mod === 'crypto') return crypto;
+          if (mod === 'fs') return fakeFs;
+          throw new Error(`unknown module: ${mod}`);
+        },
+        fs: fakeFs,
+      });
+      const hashes = fn(['restricted.txt']);
+      expect(hashes['restricted.txt']).toBeNull();
+    });
+
     it('hashes multiple files independently', () => {
       const fakeFs = makeFakeFs({
         'a.txt': 'content-a',
@@ -277,32 +297,6 @@ describe('.github/workflows/ocr-review.yml — manifest artifacts & YAML wiring 
   // YAML wiring
   // -----------------------------------------------------------------------
   describe('YAML wiring', () => {
-    it('defines function buildReviewedRangeManifest(params)', () => {
-      expect(ctx.postScript).toContain(
-        'function buildReviewedRangeManifest(params)',
-      );
-    });
-
-    it('defines function resolveCompleteness', () => {
-      expect(ctx.postScript).toContain('function resolveCompleteness(');
-    });
-
-    it('defines function computeCoverage', () => {
-      expect(ctx.postScript).toContain('function computeCoverage(');
-    });
-
-    it('defines function computeArtifactHashes', () => {
-      expect(ctx.postScript).toContain('function computeArtifactHashes(');
-    });
-
-    it('defines function serializeManifest', () => {
-      expect(ctx.postScript).toContain('function serializeManifest(');
-    });
-
-    it('defines function buildStatusLine', () => {
-      expect(ctx.postScript).toContain('function buildStatusLine(');
-    });
-
     it('writes the manifest to ocr-reviewed-range-manifest.json', () => {
       expect(ctx.postScript).toContain('ocr-reviewed-range-manifest.json');
     });

--- a/scripts/tests/ocr-reviewed-range-manifest.test.js
+++ b/scripts/tests/ocr-reviewed-range-manifest.test.js
@@ -1,0 +1,818 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  BASE_MANIFEST_PARAMS,
+  makeLoadFunction,
+  makeLoadFunctionsTogether,
+  useWorkflowFixture,
+} from './ocr-manifest-test-helpers.js';
+
+describe('.github/workflows/ocr-review.yml — reviewed-range manifest functions (issue #2575)', () => {
+  const ctx = useWorkflowFixture();
+  const loadFunction = makeLoadFunction(ctx);
+  const loadFunctionsTogether = makeLoadFunctionsTogether(ctx);
+
+  // -----------------------------------------------------------------------
+  // resolveCompleteness — core behavior (count-free, file-array based)
+  // -----------------------------------------------------------------------
+  describe('resolveCompleteness behavior', () => {
+    it('returns "complete" when completedFiles equals selectedFiles', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts'],
+          completedFiles: ['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('complete');
+    });
+
+    it('returns "partial" when some files failed and were not waived', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: [
+            'f0',
+            'f1',
+            'f2',
+            'f3',
+            'f4',
+            'f5',
+            'f6',
+            'f7',
+            'f8',
+            'f9',
+          ],
+          completedFiles: ['f0', 'f1', 'f2', 'f3', 'f4', 'f5', 'f6'],
+          failedFiles: ['f7', 'f8', 'f9'],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('returns "failed" when OCR exited non-zero', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 1,
+          ocrStatus: '',
+          selectedFiles: Array.from({ length: 10 }, (_, i) => `f${i}`),
+          completedFiles: [],
+          failedFiles: Array.from({ length: 10 }, (_, i) => `f${i}`),
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('failed');
+    });
+
+    it('returns "skipped" when skipped flag is true', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: '',
+          selectedFiles: [],
+          completedFiles: [],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: true,
+        }),
+      ).toBe('skipped');
+    });
+
+    it('maps completed_with_errors OCR status to "partial" (AC #6)', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'completed_with_errors',
+          selectedFiles: Array.from({ length: 90 }, (_, i) => `f${i}`),
+          completedFiles: Array.from({ length: 74 }, (_, i) => `f${i}`),
+          failedFiles: Array.from({ length: 16 }, (_, i) => `f${74 + i}`),
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('returns "complete" when failed files are all explicitly waived with reasons', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts'],
+          completedFiles: ['a.ts', 'b.ts', 'c.ts'],
+          failedFiles: ['d.ts', 'e.ts'],
+          reusedFiles: [],
+          waivedFiles: [
+            { path: 'd.ts', reason: 'generated file' },
+            { path: 'e.ts', reason: 'vendor file' },
+          ],
+          skipped: false,
+        }),
+      ).toBe('complete');
+    });
+
+    it('returns "complete" when selectedFiles is empty (success status)', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: [],
+          completedFiles: [],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('complete');
+    });
+
+    it('skipped takes precedence over non-zero exit code', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 1,
+          ocrStatus: '',
+          selectedFiles: [],
+          completedFiles: [],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: true,
+        }),
+      ).toBe('skipped');
+    });
+
+    it('non-zero exit code takes precedence over completed_with_errors status', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 1,
+          ocrStatus: 'completed_with_errors',
+          selectedFiles: Array.from({ length: 10 }, (_, i) => `f${i}`),
+          completedFiles: Array.from({ length: 5 }, (_, i) => `f${i}`),
+          failedFiles: Array.from({ length: 5 }, (_, i) => `f${5 + i}`),
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('failed');
+    });
+
+    it('recognizes "completed" as a valid success status', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'completed',
+          selectedFiles: ['a.ts', 'b.ts'],
+          completedFiles: ['a.ts', 'b.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('complete');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveCompleteness — fail-closed (C1)
+  // -----------------------------------------------------------------------
+  describe('resolveCompleteness fail-closed (C1)', () => {
+    it('returns "partial" for unknown/empty OCR status with exit 0, even when counts match', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: '',
+          selectedFiles: ['a.ts', 'b.ts'],
+          completedFiles: ['a.ts', 'b.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('returns "partial" for null OCR status with exit 0', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: null,
+          selectedFiles: ['a.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('returns "partial" for unrecognized OCR status with exit 0', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'who_knows',
+          selectedFiles: ['a.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('returns "failed" when exitCode is NaN/undefined', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: undefined,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('failed');
+    });
+
+    it('returns "failed" when exitCode is a non-numeric string', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 'abc',
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('failed');
+    });
+
+    it('returns "failed" when exitCode is negative', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: -1,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('failed');
+    });
+
+    it('returns "failed" when exitCode is a float', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0.5,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('failed');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveCompleteness — set-based completeness (C3)
+  // -----------------------------------------------------------------------
+  describe('resolveCompleteness set-based completeness (C3)', () => {
+    it('an unrelated waiver does NOT satisfy a failure', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: ['b.ts'],
+          reusedFiles: [],
+          waivedFiles: [{ path: 'x.ts', reason: 'unrelated' }],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('a waiver whose path is not in the failed set does not count', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts', 'c.ts'],
+          completedFiles: ['a.ts', 'c.ts'],
+          failedFiles: ['b.ts'],
+          reusedFiles: [],
+          waivedFiles: [
+            { path: 'c.ts', reason: 'should not waive a completed file' },
+          ],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('duplicate entries do not inflate completeness', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts', 'a.ts', 'b.ts'],
+          completedFiles: ['a.ts', 'b.ts', 'a.ts', 'b.ts', 'a.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('complete');
+    });
+
+    it('duplicate completed entries cannot mask a missing selected file', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts', 'c.ts'],
+          completedFiles: ['a.ts', 'a.ts', 'a.ts', 'b.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('a file in both completed and failed is resolved (handled correctly)', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts'],
+          completedFiles: ['a.ts', 'b.ts'],
+          failedFiles: ['b.ts'],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('complete');
+    });
+
+    it('a completed file NOT in selected yields partial', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts'],
+          completedFiles: ['a.ts', 'extra.ts'],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('reused files count toward resolution', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: [],
+          reusedFiles: ['b.ts'],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('complete');
+    });
+
+    it('paths are trimmed before comparison', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['  a.ts  ', 'b.ts'],
+          completedFiles: ['a.ts', ' b.ts '],
+          failedFiles: [],
+          reusedFiles: [],
+          waivedFiles: [],
+          skipped: false,
+        }),
+      ).toBe('complete');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveCompleteness — waiver reason trimming (C10)
+  // -----------------------------------------------------------------------
+  describe('resolveCompleteness waiver reason trimming (C10)', () => {
+    it('a whitespace-only reason does not count as a valid waiver', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: ['b.ts'],
+          reusedFiles: [],
+          waivedFiles: [{ path: 'b.ts', reason: '   ' }],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('a tab/newline-only reason does not count as a valid waiver', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: ['b.ts'],
+          reusedFiles: [],
+          waivedFiles: [{ path: 'b.ts', reason: '\t\n  ' }],
+          skipped: false,
+        }),
+      ).toBe('partial');
+    });
+
+    it('a trimmed non-empty reason counts as a valid waiver', () => {
+      const fn = loadFunction('resolveCompleteness');
+      expect(
+        fn({
+          ocrExitCode: 0,
+          ocrStatus: 'success',
+          selectedFiles: ['a.ts', 'b.ts'],
+          completedFiles: ['a.ts'],
+          failedFiles: ['b.ts'],
+          reusedFiles: [],
+          waivedFiles: [{ path: 'b.ts', reason: '  generated file  ' }],
+          skipped: false,
+        }),
+      ).toBe('complete');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // computeCoverage
+  // -----------------------------------------------------------------------
+  describe('computeCoverage behavior', () => {
+    it('returns completed and selected counts with a ratio string', () => {
+      const fn = loadFunction('computeCoverage');
+      const result = fn({ completed: 8, selected: 10 });
+      expect(result.completed).toBe(8);
+      expect(result.selected).toBe(10);
+      expect(typeof result.ratio).toBe('string');
+    });
+
+    it('computes ratio as a decimal fraction of completed/selected', () => {
+      const fn = loadFunction('computeCoverage');
+      const result = fn({ completed: 5, selected: 10 });
+      expect(Number(result.ratio)).toBe(0.5);
+    });
+
+    it('returns ratio 1 when selected is zero', () => {
+      const fn = loadFunction('computeCoverage');
+      const result = fn({ completed: 0, selected: 0 });
+      expect(Number(result.ratio)).toBe(1);
+    });
+
+    it('returns ratio 1 when all files completed', () => {
+      const fn = loadFunction('computeCoverage');
+      const result = fn({ completed: 10, selected: 10 });
+      expect(Number(result.ratio)).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildReviewedRangeManifest
+  // -----------------------------------------------------------------------
+  describe('buildReviewedRangeManifest behavior', () => {
+    function buildManifest(overrides = {}) {
+      const params = { ...BASE_MANIFEST_PARAMS, ...overrides };
+      const sandbox = loadFunctionsTogether([
+        'resolveCompleteness',
+        'computeCoverage',
+        'buildReviewedRangeManifest',
+      ]);
+      return sandbox.buildReviewedRangeManifest(params);
+    }
+
+    it('includes schema_version as a string', () => {
+      const manifest = buildManifest();
+      expect(typeof manifest.schema_version).toBe('string');
+      expect(manifest.schema_version.length).toBeGreaterThan(0);
+    });
+
+    it('persists repository, pr_number, head_sha, and merge_base_sha (AC #1)', () => {
+      const manifest = buildManifest();
+      expect(manifest.repository).toBe('acme/widget');
+      expect(manifest.pr_number).toBe(42);
+      expect(manifest.head_sha).toBe('abc123def456');
+      expect(manifest.merge_base_sha).toBe('fed654cba321');
+    });
+
+    it('persists trigger, run_id, and run_attempt (AC #2)', () => {
+      const manifest = buildManifest();
+      expect(manifest.trigger).toBe('pull_request_target');
+      expect(manifest.run_id).toBe('999888777');
+      expect(manifest.run_attempt).toBe('1');
+    });
+
+    it('persists ocr_version, provider_model, and concurrency (AC #2)', () => {
+      const manifest = buildManifest();
+      expect(manifest.ocr_version).toBe('1.7.16');
+      expect(manifest.provider_model).toBe('gpt-4o');
+      expect(manifest.concurrency).toBe(2);
+    });
+
+    it('persists ocr_session_id and ocr_parent_session_id (AC #2)', () => {
+      const manifest = buildManifest();
+      expect(manifest.ocr_session_id).toBe('sess-abc');
+      expect(manifest.ocr_parent_session_id).toBe('parent-sess-xyz');
+    });
+
+    it('persists rule_config_hash (AC #2)', () => {
+      const manifest = buildManifest();
+      expect(manifest.rule_config_hash).toBe('sha256:deadbeef');
+    });
+
+    it('records selected_files, completed_files, failed_files, reused_files, and waived_files (AC #3)', () => {
+      const manifest = buildManifest({
+        selectedFiles: ['a.ts', 'b.ts', 'c.ts'],
+        completedFiles: ['a.ts'],
+        failedFiles: ['b.ts'],
+        reusedFiles: ['c.ts'],
+        waivedFiles: [],
+      });
+      expect(manifest.selected_files).toEqual(['a.ts', 'b.ts', 'c.ts']);
+      expect(manifest.completed_files).toEqual(['a.ts']);
+      expect(manifest.failed_files).toEqual(['b.ts']);
+      expect(manifest.reused_files).toEqual(['c.ts']);
+      expect(manifest.waived_files).toEqual([]);
+    });
+
+    it('sets completeness to "complete" when all selected files completed (AC #4)', () => {
+      const manifest = buildManifest();
+      expect(manifest.completeness).toBe('complete');
+    });
+
+    it('sets completeness to "partial" when some files failed and not waived (AC #4)', () => {
+      const manifest = buildManifest({
+        selectedFiles: ['a.ts', 'b.ts', 'c.ts'],
+        completedFiles: ['a.ts'],
+        failedFiles: ['b.ts', 'c.ts'],
+        waivedFiles: [],
+      });
+      expect(manifest.completeness).toBe('partial');
+    });
+
+    it('sets completeness to "failed" when OCR exited non-zero (AC #4)', () => {
+      const manifest = buildManifest({
+        ocrExitCode: 1,
+        ocrStatus: '',
+        completedFiles: [],
+        failedFiles: ['a.ts', 'b.ts'],
+      });
+      expect(manifest.completeness).toBe('failed');
+    });
+
+    it('sets completeness to "skipped" when skipped is true (AC #4)', () => {
+      const manifest = buildManifest({
+        skipped: true,
+        ocrStatus: '',
+        completedFiles: [],
+        selectedFiles: [],
+      });
+      expect(manifest.completeness).toBe('skipped');
+    });
+
+    it('maps completed_with_errors to "partial" completeness in manifest (AC #6)', () => {
+      const manifest = buildManifest({
+        ocrStatus: 'completed_with_errors',
+        selectedFiles: ['a.ts', 'b.ts', 'c.ts'],
+        completedFiles: ['a.ts'],
+        failedFiles: ['b.ts', 'c.ts'],
+      });
+      expect(manifest.completeness).toBe('partial');
+      expect(manifest.ocr_status).toBe('completed_with_errors');
+    });
+
+    it('records ocr_status in the manifest', () => {
+      const manifest = buildManifest({ ocrStatus: 'success' });
+      expect(manifest.ocr_status).toBe('success');
+    });
+
+    it('records artifact_hashes in the manifest (AC #8)', () => {
+      const hashes = { 'ocr-result.json': 'sha256:abc' };
+      const manifest = buildManifest({ artifactHashes: hashes });
+      expect(manifest.artifact_hashes).toEqual(hashes);
+    });
+
+    it('waived files include a reason field (AC #6)', () => {
+      const manifest = buildManifest({
+        selectedFiles: ['a.ts', 'b.ts'],
+        completedFiles: ['a.ts'],
+        failedFiles: ['b.ts'],
+        waivedFiles: [
+          { path: 'b.ts', reason: 'generated file; no review needed' },
+        ],
+      });
+      expect(manifest.waived_files).toHaveLength(1);
+      expect(manifest.waived_files[0].path).toBe('b.ts');
+      expect(manifest.waived_files[0].reason).toBe(
+        'generated file; no review needed',
+      );
+    });
+
+    it('treats a waiver without a reason as invalid (does not count toward complete)', () => {
+      const manifest = buildManifest({
+        selectedFiles: ['a.ts', 'b.ts'],
+        completedFiles: ['a.ts'],
+        failedFiles: ['b.ts'],
+        waivedFiles: [{ path: 'b.ts', reason: '' }],
+      });
+      expect(manifest.completeness).toBe('partial');
+    });
+
+    it('treats a whitespace-only waiver reason as invalid (C10)', () => {
+      const manifest = buildManifest({
+        selectedFiles: ['a.ts', 'b.ts'],
+        completedFiles: ['a.ts'],
+        failedFiles: ['b.ts'],
+        waivedFiles: [{ path: 'b.ts', reason: '   ' }],
+      });
+      expect(manifest.completeness).toBe('partial');
+    });
+
+    it('does not mutate the input params object', () => {
+      const params = { ...BASE_MANIFEST_PARAMS };
+      const snapshot = JSON.parse(JSON.stringify(params));
+      buildManifest();
+      expect(params).toEqual(snapshot);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Pipeline integration: resolveCompleteness + buildReviewedRangeManifest
+  // -----------------------------------------------------------------------
+  describe('manifest pipeline integration', () => {
+    it('a completed_with_errors run produces a partial manifest that cannot be confused for complete', () => {
+      const sandbox = loadFunctionsTogether([
+        'resolveCompleteness',
+        'computeCoverage',
+        'buildReviewedRangeManifest',
+        'buildStatusLine',
+      ]);
+
+      const manifest = sandbox.buildReviewedRangeManifest({
+        ...BASE_MANIFEST_PARAMS,
+        ocrStatus: 'completed_with_errors',
+        selectedFiles: Array.from({ length: 90 }, (_, i) => `file${i}.ts`),
+        completedFiles: Array.from({ length: 74 }, (_, i) => `file${i}.ts`),
+        failedFiles: Array.from({ length: 16 }, (_, i) => `file${74 + i}.ts`),
+      });
+
+      expect(manifest.completeness).toBe('partial');
+      expect(manifest.ocr_status).toBe('completed_with_errors');
+      // C2: completed_with_errors must clear completedFiles since we cannot
+      // trust per-file completion from the upstream tool.
+      expect(manifest.completed_files).toEqual([]);
+
+      const coverage = sandbox.computeCoverage({
+        completed: manifest.completed_files.length,
+        selected: manifest.selected_files.length,
+      });
+      const statusLine = sandbox.buildStatusLine({
+        ran: true,
+        findingsCount: 20,
+        postedInline: 15,
+        completeness: manifest.completeness,
+        coverage,
+        failedFiles: manifest.failed_files,
+        policyFailure: '',
+      });
+
+      expect(statusLine).not.toBe('No findings.');
+      expect(statusLine).toContain('Partial review');
+      expect(statusLine).toContain('90');
+      expect(statusLine).toContain('16 failed');
+    });
+
+    it('a full success produces a complete manifest with a clean status line', () => {
+      const sandbox = loadFunctionsTogether([
+        'resolveCompleteness',
+        'computeCoverage',
+        'buildReviewedRangeManifest',
+        'buildStatusLine',
+      ]);
+
+      const manifest = sandbox.buildReviewedRangeManifest({
+        ...BASE_MANIFEST_PARAMS,
+        selectedFiles: ['a.ts', 'b.ts'],
+        completedFiles: ['a.ts', 'b.ts'],
+      });
+
+      expect(manifest.completeness).toBe('complete');
+
+      const statusLine = sandbox.buildStatusLine({
+        ran: true,
+        findingsCount: 0,
+        postedInline: 0,
+        completeness: manifest.completeness,
+        coverage: { completed: 2, selected: 2 },
+        failedFiles: [],
+        policyFailure: '',
+      });
+
+      expect(statusLine).toBe('No findings.');
+    });
+
+    it('a waiver with a reason allows completeness to be complete despite failures (AC #6)', () => {
+      const sandbox = loadFunctionsTogether([
+        'resolveCompleteness',
+        'computeCoverage',
+        'buildReviewedRangeManifest',
+      ]);
+
+      const manifest = sandbox.buildReviewedRangeManifest({
+        ...BASE_MANIFEST_PARAMS,
+        selectedFiles: ['a.ts', 'b.ts', 'c.ts'],
+        completedFiles: ['a.ts'],
+        failedFiles: ['b.ts', 'c.ts'],
+        waivedFiles: [
+          { path: 'b.ts', reason: 'auto-generated; skipped' },
+          { path: 'c.ts', reason: 'vendor file; reviewed separately' },
+        ],
+      });
+
+      expect(manifest.completeness).toBe('complete');
+    });
+
+    it('an unrelated waiver does not allow completeness to be complete (C3)', () => {
+      const sandbox = loadFunctionsTogether([
+        'resolveCompleteness',
+        'computeCoverage',
+        'buildReviewedRangeManifest',
+      ]);
+
+      const manifest = sandbox.buildReviewedRangeManifest({
+        ...BASE_MANIFEST_PARAMS,
+        selectedFiles: ['a.ts', 'b.ts'],
+        completedFiles: ['a.ts'],
+        failedFiles: ['b.ts'],
+        waivedFiles: [{ path: 'unrelated.ts', reason: 'not relevant' }],
+      });
+
+      expect(manifest.completeness).toBe('partial');
+    });
+  });
+});

--- a/scripts/tests/ocr-reviewed-range-manifest.test.js
+++ b/scripts/tests/ocr-reviewed-range-manifest.test.js
@@ -696,7 +696,7 @@ describe('.github/workflows/ocr-review.yml — reviewed-range manifest functions
     it('does not mutate the input params object', () => {
       const params = { ...BASE_MANIFEST_PARAMS };
       const snapshot = JSON.parse(JSON.stringify(params));
-      buildManifest();
+      buildManifest(params);
       expect(params).toEqual(snapshot);
     });
   });


### PR DESCRIPTION
## Summary

The PR OCR (Open Code Review) workflow could publish useful findings from a partial run without proving that every selected file completed review. Parseable output was easy to mistake for complete review coverage. This PR adopts a versioned immutable reviewed-range manifest and fails closed on incomplete coverage.

Closes #2575

## Problem

A cross-repository study observed 117 fully successful OCR runs out of 145 attempts (80.7%), while 142 produced some usable output (97.9%). In a matched same-commit comparison, a run over 90 selected files reported 16 provider-concurrency subtask failures. Useful findings and complete coverage are different states — but the workflow treated any parseable exit-zero output as complete.

## Solution

### Fail-closed completeness classification

`resolveCompleteness()` now uses a **positive allowlist** approach:
- `complete` requires a recognized success OCR status (`success` or `completed`), exit code 0, AND set-identity proof that every selected file is resolved
- Unknown, empty, or missing OCR status yields `partial`, not `complete`
- `completed_with_errors` always yields `partial` — it can never be `complete` even with matching counts
- Invalid exit codes (NaN, negative, float) yield `failed`

### Set-based identity, not arithmetic counts

Completeness is now resolved using `Set` operations on normalized, deduplicated paths:
- `resolved = completed ∪ reused ∪ validWaiverPaths`
- `complete` iff every selected path is in `resolved` AND no unresolved failed paths remain AND no unselected completed paths exist
- Unrelated waivers cannot satisfy failures
- Waiver reasons are trimmed — whitespace-only reasons are invalid

### completed_with_errors handling (AC #6)

When OCR returns `completed_with_errors`, `completedFiles` is cleared to `[]` since per-file completion cannot be trusted from the upstream tool. The manifest records `completeness: "partial"` regardless of the file counts supplied.

### Immutable reviewed-range manifest

`buildReviewedRangeManifest()` persists:
- `schema_version` (`"1.0.0"`), repository, PR number, head SHA, merge base SHA
- Trigger, GitHub run/attempt, OCR version, session/parent session IDs, provider/model, concurrency, rule config hash
- Selected, completed, failed, reused, and waived file sets
- Terminal completeness state (`complete`/`partial`/`failed`/`skipped`)
- Coverage (completed/selected counts)
- OCR status, artifact hashes

### Post-redaction artifact hashing

A new `Compute reviewed-range manifest hashes` step runs AFTER the `Redact OCR diagnostic artifacts` step and BEFORE `Ensure OCR artifact placeholders exist`. It:
- Computes SHA-256 of all post-redaction artifact files
- Writes `ocr-manifest-hashes.json` with all hashes
- Updates the manifest's `artifact_hashes` field with post-redaction hashes
- Writes a detached `ocr-manifest-sha256.txt` with the manifest's own hash

### Sticky summary

`buildStatusLine()` prevents partial runs from emitting `No findings.` or a plain finding count. Partial runs show:
```
Partial review: X of Y files completed (Z failed); N finding(s) (M posted inline).
```

### Downstream outcome classification

- The `Resolve OCR failure classification` step now exposes a `completeness` job output
- The `record-ocr-outcome` job has a new `Record OCR outcome: partial` branch
- The `success` branch excludes `completeness == 'partial'` and `completeness == 'failed'`

### Manifest persistence failure

If the manifest write fails, the workflow writes to `ocr-infrastructure-failure.txt` with reason `reviewed-range manifest persistence failed`, integrating with the existing failure classification.

### Removed isSkipped inference

The `isSkipped` heuristic was removed — missing evidence (cancellation, setup failure) is classified as `failed`, not `skipped`. The `skipped` state is only set by explicit gate decisions.

## Acceptance Criteria Coverage

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Repository, PR, head, merge base, reviewed range | ✅ Persisted in manifest |
| 2 | Trigger, run/attempt, sessions, version, provider/model, concurrency, config hashes | ✅ Persisted (sessions/config hash wired for upstream adoption) |
| 3 | Selected/completed/reused/failed/waived file sets | ✅ All sets recorded |
| 4 | Terminal complete/partial/failed/skipped | ✅ Fail-closed classification |
| 5 | Sticky summary coverage and failed-file identification | ✅ buildStatusLine shows coverage + failed count |
| 6 | completed_with_errors not complete unless resumed/waived | ✅ Always partial; waivers with reasons can resolve |
| 7 | Partial findings allowed, no complete/no-findings status | ✅ buildStatusLine guards against this |
| 8 | Immutable redacted manifest/raw hashes | ✅ Post-redaction hashing + detached manifest hash |
| 9 | Local and PR same schema | ⏳ Schema designed for parity; local adapter is future work |
| 10 | Tests cover all scenarios | ✅ 93 tests covering fail-closed, set-identity, waivers, partial, redaction |

## Tests

- `scripts/tests/ocr-reviewed-range-manifest.test.js` (54 tests): fail-closed completeness, set-based identity, waiver trimming, completed_with_errors handling, manifest immutability, redaction
- `scripts/tests/ocr-reviewed-range-manifest-wiring.test.js` (39 tests): artifact pipeline consistency, hash step ordering, completeness output, partial outcome branch, C2 completedFiles behavior
- `scripts/tests/ocr-manifest-test-helpers.js`: shared test fixtures with VM timeout and function verification
- All 163 existing OCR workflow tests pass with 0 regressions

## Verification

- [x] 93 new tests pass
- [x] 163 existing OCR tests pass (no regressions)
- [x] ESLint clean (no errors, no eslint-disable directives)
- [x] Prettier formatting clean
- [x] ESLint guard policy passed
- [x] YAML syntax valid
- [x] Open Code Review (ocr) run completed — findings addressed

## Dependencies

- Upstream manifest contract: https://github.com/alibaba/open-code-review/issues/367
- Sibling implementations: jefe #309, luther #138
- This PR is the llxprt-code adopter; it implements a documented adapter that can migrate cleanly once the upstream schema lands
