### PR TITLE
Fix load-balancer mixed-aggregate retryability (Fixes #2712)

### DIFF
--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -1001,10 +1001,13 @@ describe('isRetryableError - self-classifying aggregate marker (issue #2450)', (
 
   it('aggregate isRetryable === false is AUTHORITATIVE even when its flattened message contains a network-transient phrase', () => {
     // Regression guard (issue #2450): the aggregate message flattens child
-    // messages. A mixed aggregate (one network-transient backend + one
-    // permanent failure) is correctly non-retryable, and must NOT be rescued
-    // by the message-based network-transient heuristic seeing the sibling's
-    // "socket hang up" text.
+    // messages. This test directly constructs an aggregate with
+    // isRetryable === false to prove PRIORITY 0 honors that marker regardless
+    // of message content — the message-based network-transient heuristic must
+    // NOT override the aggregate's own precomputed decision, even when the
+    // flattened message contains a transient phrase like "socket hang up".
+    // (Note: the load balancer's actual mixed-aggregate policy is tested in the
+    // providers package; this test isolates the core PRIORITY 0 mechanism.)
     const error = makeAggregate(
       false,
       'zai: socket hang up; makoraglm51: bad request (status: 400)',

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -245,14 +245,13 @@ export function isNetworkTransientError(error: unknown): boolean {
 export function isRetryableError(error: Error | unknown): boolean {
   // PRIORITY 0: Self-classifying aggregate errors (e.g. the load balancer
   // LoadBalancerFailoverError). An aggregate-of-failures has already computed
-  // its own retryability from EACH underlying backend failure, so it is
+  // its own retryability from its underlying backend failures, so it is
   // authoritative. Its human-readable message flattens the child messages,
   // which means the message-based heuristics below (network-transient, overload)
   // would otherwise re-interpret a sibling backend's text and override the
-  // precise per-child decision (e.g. a mixed "socket hang up" + HTTP 400
-  // aggregate must NOT be retried). Identified structurally — a `failures`
+  // precise per-child decision. Identified structurally — a `failures`
   // array plus a boolean `isRetryable` — so core does not import from
-  // providers. (issue #2450)
+  // providers. (issue #2450, updated #2712)
   if (
     typeof error === 'object' &&
     error !== null &&

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
@@ -248,37 +248,47 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
     expect(counter.value).toBe(3);
   });
 
-  it('classifies a mixed (429 + 400) aggregate as NON-retryable', async () => {
+  it('classifies a mixed (429 + 400) aggregate as RETRYABLE (issue #2712)', async () => {
     const { error, counter } = await captureFailoverError(function* (
       attempt: number,
     ): AsyncGenerator<IContent> {
-      if (attempt <= 2) {
+      if (attempt === 1) {
+        // One backend fails transiently (429).
         throw statusError('rate limited', 429);
       }
+      // Two backends fail permanently (400).
       throw statusError('bad request', 400);
       yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
     }, 'glm-mixed');
 
-    expect(error.isRetryable).toBe(false);
-    expect(isRetryableError(error)).toBe(false);
+    // Only ONE backend failed transiently; the other two failed permanently
+    // (400). Because the load balancer re-attempts the rotation, the single
+    // transient backend may recover on the next pass, so the aggregate is
+    // retryable (issue #2712).
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
     expect(counter.value).toBe(3);
   });
 
-  it('classifies a mixed (429 + 401 auth) aggregate as NON-retryable', async () => {
+  it('classifies a mixed (429 + 401 auth) aggregate as RETRYABLE (issue #2712)', async () => {
     const { error, counter } = await captureFailoverError(function* (
       attempt: number,
     ): AsyncGenerator<IContent> {
-      if (attempt <= 2) {
+      if (attempt === 1) {
+        // One backend fails transiently (429).
         throw statusError('rate limited', 429);
       }
+      // Two backends fail with auth errors (401), which are non-transient.
       throw statusError('unauthorized', 401);
       yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
     }, 'glm-mixed-auth');
 
-    // A 401 is an auth/config problem, not transient load, so the whole
-    // aggregate is non-retryable.
-    expect(error.isRetryable).toBe(false);
-    expect(isRetryableError(error)).toBe(false);
+    // Only ONE backend failed transiently; the other two are auth/config
+    // errors (non-transient). Because the load balancer re-attempts the
+    // rotation, the single transient backend may recover on the next pass,
+    // so the aggregate is retryable (issue #2712).
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
     expect(counter.value).toBe(3);
   });
 
@@ -339,23 +349,23 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
   });
 
   /**
-   * Blocking regression guard (issue #2450): a MIXED aggregate where one
-   * backend fails transiently at the NETWORK layer (e.g. "socket hang up") and
-   * another fails permanently (HTTP 400). Because the aggregate flattens each
-   * child message into its own `.message`, a naive classifier that scans the
-   * message for network-transient phrases BEFORE consulting the aggregate's own
-   * decision would wrongly retry it. The aggregate is correctly non-retryable,
-   * and `isRetryableError` must honor that despite the leaked "socket hang up"
-   * text.
+   * Regression guard (issue #2712): a MIXED aggregate where one backend fails
+   * transiently at the NETWORK layer (e.g. "socket hang up") and others fail
+   * permanently (HTTP 400). Because the load balancer re-attempts the
+   * rotation, the transient backend may recover, so the aggregate is
+   * retryable. The flattened message still contains the transient phrase;
+   * the authoritative decision comes from the aggregate's `isRetryable`
+   * marker (PRIORITY 0 in core's isRetryableError), not from message scanning.
    */
-  it('classifies a mixed (network-transient + 400) aggregate as NON-retryable despite the transient phrase leaking into the message', async () => {
+  it('classifies a mixed (network-transient + 400) aggregate as RETRYABLE (issue #2712) despite the transient phrase leaking into the message', async () => {
     const { error, counter } = await captureFailoverError(function* (
       attempt: number,
     ): AsyncGenerator<IContent> {
-      if (attempt <= 2) {
+      if (attempt === 1) {
         // A network-transient failure whose message trips the phrase heuristic.
         throw new Error('socket hang up');
       }
+      // Two backends fail permanently (400).
       throw statusError('bad request', 400);
       yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
     }, 'glm-mixed-network-transient');
@@ -366,9 +376,9 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
     // assertion is coupled to isNetworkTransientError's phrase heuristic; if
     // that heuristic changes, update the phrase here accordingly.
     expect(isRetryableError(new Error('socket hang up'))).toBe(true);
-    // But the mixed aggregate is authoritatively non-retryable.
-    expect(error.isRetryable).toBe(false);
-    expect(isRetryableError(error)).toBe(false);
+    // The mixed aggregate is retryable because one backend failed transiently.
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
     expect(counter.value).toBe(3);
   });
 
@@ -399,6 +409,81 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
     expect(isRetryableError(error)).toBe(false);
     expect(counter.value).toBe(3);
   });
+
+  /**
+   * Regression guard (issue #2712): a MIXED aggregate where one backend fails
+   * transiently (e.g. "Connection error" / 502 Bad Gateway) and another fails
+   * with a status-less non-transient error (e.g. an OpenAI SDK APIError whose
+   * message is "undefined is not a function" — a backend bug that surfaces no
+   * HTTP status) MUST be classified as retryable. The transient backends may
+   * recover on the next rotation, so a single non-transient failure must not
+   * poison the whole rotation and fatally drop the agent to the prompt.
+   *
+   * This reproduces the issue #2712 failure categories across the shared
+   * three-backend config (zai, makoraglm51, ollamaglm51):
+   *   attempt 1 (zai):          Connection error  (network-transient)
+   *   attempt 2 (makoraglm51):  undefined is not a function  (status-less, non-transient)
+   *   attempt 3 (ollamaglm51):  502 Bad Gateway   (5xx, transient)
+   */
+  it('classifies a mixed aggregate (transient + status-less non-transient) as RETRYABLE (issue #2712)', async () => {
+    const { error, counter } = await captureFailoverError(function* (
+      attempt: number,
+    ): AsyncGenerator<IContent> {
+      if (attempt === 1) {
+        // zai: network-transient connection error (matches TRANSIENT_ERROR_PHRASES).
+        throw new Error('Connection error');
+      }
+      if (attempt === 2) {
+        // makoraglm51: backend-originated status-less error, NOT transient.
+        throw new Error('undefined is not a function');
+      }
+      // ollamaglm51: 502 Bad Gateway (5xx, transient).
+      throw statusError('502 Bad Gateway', 502);
+      yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+    }, 'glm');
+
+    // Sanity: the non-transient failure in isolation is indeed non-transient.
+    expect(isRetryableError(new Error('undefined is not a function'))).toBe(
+      false,
+    );
+    // But the MIXED aggregate is retryable because the transient backends may
+    // recover on the next rotation.
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
+    expect(counter.value).toBe(3);
+  });
+
+  /**
+   * Coverage for the 401/403 override in isTransientBackendFailure. These
+   * statuses ARE classified retryable by core's isRetryableError, but the
+   * load balancer intentionally treats them as non-transient (auth/config
+   * problems, not transient load). An all-401 or all-403 aggregate must
+   * therefore be NON-retryable — this guards against accidentally removing
+   * the override, which the mixed tests can no longer catch because the 429
+   * siblings alone satisfy some().
+   */
+  it.each([
+    ['401', 401, 'unauthorized'],
+    ['403', 403, 'forbidden'],
+  ])(
+    'classifies an all-%s aggregate as NON-retryable (auth/config override)',
+    async (_label, status, message) => {
+      const { error, counter } = await captureFailoverError(
+        function* (): AsyncGenerator<IContent> {
+          throw statusError(message, status);
+          yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+        },
+        'glm-all-auth',
+      );
+
+      // Sanity: core considers 401/403 retryable in isolation, but the load
+      // balancer override must mark them non-transient for aggregation.
+      expect(isRetryableError(statusError(message, status))).toBe(true);
+      expect(error.isRetryable).toBe(false);
+      expect(isRetryableError(error)).toBe(false);
+      expect(counter.value).toBe(3);
+    },
+  );
 
   it('preserves immediate failover-to-next-backend behavior on a single 429 (issue #902 regression guard)', async () => {
     const { provider, counter } = makeFakeProvider(function* (

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -283,13 +283,25 @@ function isTransientBackendFailure(error: Error): boolean {
   return true;
 }
 
+/**
+ * Determine whether the aggregate rotation is retryable.
+ *
+ * A load balancer re-attempts the rotation (subject to transport-budget and
+ * backend-eligibility checks), so the aggregate is retryable when AT LEAST ONE
+ * backend failed transiently — that backend may recover on the next pass.
+ * Requiring ALL backends to be transient (the original #2450 design) meant a
+ * single non-transient failure (e.g. a backend bug that surfaces a status-less
+ * error) poisoned the whole rotation and fatally dropped the agent to the
+ * prompt (issue #2712). An all-non-transient aggregate is still correctly
+ * non-retryable (`some()` returns false when no element matches).
+ */
 function computeAggregateRetryable(
   failures: ReadonlyArray<{ readonly error: Error }>,
 ): boolean {
   if (failures.length === 0) {
     return false;
   }
-  return failures.every((f) => isTransientBackendFailure(f.error));
+  return failures.some((f) => isTransientBackendFailure(f.error));
 }
 
 function getHomogeneousValue<T>(


### PR DESCRIPTION
## Summary

A load-balancer failover rotation was marked **non-retryable** when a single backend failed non-transiently, even though other backends in the same rotation failed transiently and could recover on the next pass. This caused the agent to fatally drop back to the prompt instead of retrying the rotation.

## Root Cause

`computeAggregateRetryable` in `packages/providers/src/errors.ts` used `failures.every()`, requiring **ALL** backend failures to be transient before marking the aggregate retryable. In the issue #2712 scenario:

- **zai**: Connection error -> network-transient
- **ollamaglm51**: "undefined is not a function" -> status-less backend error (the OpenAI SDK wraps this as an APIError with no HTTP status), classified **non-transient**
- **chutesglm52**: 502 Bad Gateway -> transient (5xx)

Because ollamaglm51's failure was non-transient, `every()` returned `false`, so the entire rotation's `LoadBalancerFailoverError.isRetryable` was `false`. Core's `retryWithBackoff` honored that marker (PRIORITY 0 in `isRetryableError`) and fatally dropped the agent.

Note: "undefined is not a function" is **not** a bug in our code — it is a backend-originated error returned by the Ollama server in an SSE stream, which the OpenAI SDK converts to a status-less APIError. The failover machinery itself worked correctly (all 3 backends were tried). The bug was purely in how the aggregate retryability was computed.

## Fix

Change `every()` to `some()` in `computeAggregateRetryable`. The aggregate is now retryable when **at least one** backend failed transiently — that backend may recover on the next rotation pass. All-non-transient aggregates remain non-retryable (`some()` returns `false` when no element matches).

A load balancer re-attempts the rotation (subject to transport-budget and backend-eligibility checks), so a mixed aggregate should be retried. The transient backends have a real chance of succeeding on the next pass.

## Behavior changes

| Scenario | Before | After |
|----------|--------|-------|
| All backends transient (429/5xx/network) | retryable | retryable (unchanged) |
| All backends non-transient (400/plain) | non-retryable | non-retryable (unchanged) |
| All backends 401/403 | non-retryable | non-retryable (unchanged — auth override preserved) |
| **Mixed: 1 transient + N non-transient** | **non-retryable (BUG)** | **retryable (FIXED)** |

## Changes

- `packages/providers/src/errors.ts`: Changed `failures.every()` to `failures.some()` in `computeAggregateRetryable`. Updated JSDoc.
- `packages/core/src/utils/retry.ts`: Updated PRIORITY 0 comment (removed stale "mixed must NOT be retried" example).
- `packages/core/src/utils/retry.test.ts`: Updated test comment to clarify it tests the PRIORITY 0 structural mechanism, not mixed-aggregate policy.
- `packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts`:
  - Updated 3 existing mixed-aggregate tests to assert retryable (the new correct semantics), using minimal cases (1 transient + 2 non-transient).
  - Added issue #2712 regression test reproducing the exact failure categories (Connection error + status-less error + 502).
  - Added all-401 and all-403 aggregate tests verifying these remain non-retryable (the auth override guard).

## Verification

- Core tests: 5301 passed, 0 failed
- Providers tests: 4448 passed, 0 failed
- Lint, typecheck, format, build: all pass
- Smoke test: haiku generated successfully
- Open Code Review: clean (1 comment about comment/code mismatch was addressed)

Fixes #2712


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load-balancer failover retry handling when at least one backend failure is transient.
  * Mixed failures involving transient network, rate-limit, or server errors can now be retried appropriately.
  * Preserved non-retryable behavior for aggregates containing only authorization failures.
  * Added regression coverage for mixed and edge-case failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->