### PR TITLE
Stop classifying .fh-family files as images (Fixes #2719)

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -285,6 +285,32 @@ describe('fileUtils', () => {
       expect(await detectFileType('image.icon.svg')).toBe('svg');
     });
 
+    it.each([
+      { ext: '.fh', file: 'shader.fh' },
+      { ext: '.fh4', file: 'shader.fh4' },
+      { ext: '.fh5', file: 'shader.fh5' },
+      { ext: '.fh7', file: 'shader.fh7' },
+      { ext: '.fhc', file: 'shader.fhc' },
+    ])(
+      'should classify text $ext as text, not image, despite image/x-freehand mime (#2719)',
+      async ({ file }) => {
+        const fhPath = path.join(tempRootDir, file);
+        actualNodeFs.writeFileSync(fhPath, '// fragment shader text\n');
+        mockMimeLookup.mockReturnValueOnce('image/x-freehand');
+        expect(await detectFileType(fhPath)).toBe('text');
+      },
+    );
+
+    it('should classify binary .fh content as binary, not image (#2719)', async () => {
+      const fhPath = path.join(tempRootDir, 'binary.fh');
+      actualNodeFs.writeFileSync(
+        fhPath,
+        Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
+      );
+      mockMimeLookup.mockReturnValueOnce('image/x-freehand');
+      expect(await detectFileType(fhPath)).toBe('binary');
+    });
+
     it('should use isBinaryFile for unknown extensions and detect as binary', async () => {
       mockMimeLookup.mockReturnValueOnce(false); // Unknown mime type
       // Create a file that isBinaryFile will identify as binary

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -269,8 +269,18 @@ export async function detectFileType(
     return 'svg';
   }
 
+  // mime-db maps the FreeHand family (.fh, .fh4, .fh5, .fh7, .fhc) to
+  // image/x-freehand, but these extensions are commonly shader/source text.
+  // Exclude them from the image short-circuit below so they fall through to
+  // content-based detection (text or binary).
+  const freehandExtensions = ['.fh', '.fh4', '.fh5', '.fh7', '.fhc'];
+
   const lookedUpMimeType = mime.lookup(filePath); // Returns false if not found, or the mime type string
-  if (typeof lookedUpMimeType === 'string' && lookedUpMimeType !== '') {
+  if (
+    typeof lookedUpMimeType === 'string' &&
+    lookedUpMimeType !== '' &&
+    !freehandExtensions.includes(ext)
+  ) {
     if (lookedUpMimeType.startsWith('image/')) {
       return 'image';
     }

--- a/packages/tools/src/utils/fileUtils.test.ts
+++ b/packages/tools/src/utils/fileUtils.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+
+import * as actualNodeFs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import mime from 'mime-types';
+
+import { detectFileType } from './fileUtils.js';
+
+vi.mock('mime-types', () => ({
+  default: { lookup: vi.fn() },
+  lookup: vi.fn(),
+}));
+
+const mockMimeLookup = mime.lookup as Mock;
+
+describe('fileUtils.detectFileType', () => {
+  let tempRootDir: string;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    tempRootDir = actualNodeFs.mkdtempSync(
+      path.join(os.tmpdir(), 'tools-fileUtils-test-'),
+    );
+  });
+
+  afterEach(() => {
+    try {
+      if (actualNodeFs.existsSync(tempRootDir)) {
+        actualNodeFs.rmSync(tempRootDir, { recursive: true, force: true });
+      }
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('should detect typescript extensions as text (ts, mts, cts, tsx)', async () => {
+    expect(await detectFileType('file.ts')).toBe('text');
+    expect(await detectFileType('file.mts')).toBe('text');
+    expect(await detectFileType('file.cts')).toBe('text');
+    expect(await detectFileType('component.tsx')).toBe('text');
+  });
+
+  it('should detect svg by extension', async () => {
+    expect(await detectFileType('image.svg')).toBe('svg');
+    expect(await detectFileType('image.icon.svg')).toBe('svg');
+  });
+
+  it.each([
+    { ext: '.fh', file: 'shader.fh' },
+    { ext: '.fh4', file: 'shader.fh4' },
+    { ext: '.fh5', file: 'shader.fh5' },
+    { ext: '.fh7', file: 'shader.fh7' },
+    { ext: '.fhc', file: 'shader.fhc' },
+  ])(
+    'should classify text $ext as text, not image, despite image/x-freehand mime (#2719)',
+    async ({ file }) => {
+      const fhPath = path.join(tempRootDir, file);
+      actualNodeFs.writeFileSync(fhPath, '// fragment shader text\n');
+      mockMimeLookup.mockReturnValueOnce('image/x-freehand');
+      expect(await detectFileType(fhPath)).toBe('text');
+    },
+  );
+
+  it('should classify binary .fh content as binary, not image (#2719)', async () => {
+    const fhPath = path.join(tempRootDir, 'binary.fh');
+    actualNodeFs.writeFileSync(
+      fhPath,
+      Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
+    );
+    mockMimeLookup.mockReturnValueOnce('image/x-freehand');
+    expect(await detectFileType(fhPath)).toBe('binary');
+  });
+
+  it.each([
+    { type: 'image', file: 'file.png', mime: 'image/png' },
+    { type: 'pdf', file: 'file.pdf', mime: 'application/pdf' },
+    { type: 'audio', file: 'song.mp3', mime: 'audio/mpeg' },
+    { type: 'video', file: 'movie.mp4', mime: 'video/mp4' },
+  ])(
+    'should detect $type type for $file by mime',
+    async ({ file, mime: mimeType, type }) => {
+      mockMimeLookup.mockReturnValueOnce(mimeType);
+      expect(await detectFileType(file)).toBe(type);
+    },
+  );
+
+  it('should default to text if mime is unknown and content is not binary', async () => {
+    mockMimeLookup.mockReturnValueOnce(false);
+    const textPath = path.join(tempRootDir, 'unknown.xyz');
+    actualNodeFs.writeFileSync(textPath, 'plain text content\n');
+    expect(await detectFileType(textPath)).toBe('text');
+  });
+});

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -222,8 +222,18 @@ export async function detectFileType(
     return 'svg';
   }
 
+  // mime-db maps the FreeHand family (.fh, .fh4, .fh5, .fh7, .fhc) to
+  // image/x-freehand, but these extensions are commonly shader/source text.
+  // Exclude them from the image short-circuit below so they fall through to
+  // content-based detection (text or binary).
+  const freehandExtensions = ['.fh', '.fh4', '.fh5', '.fh7', '.fhc'];
+
   const lookedUpMimeType = mime.lookup(filePath);
-  if (typeof lookedUpMimeType === 'string' && lookedUpMimeType !== '') {
+  if (
+    typeof lookedUpMimeType === 'string' &&
+    lookedUpMimeType !== '' &&
+    !freehandExtensions.includes(ext)
+  ) {
     if (lookedUpMimeType.startsWith('image/')) return 'image';
     if (lookedUpMimeType.startsWith('audio/')) return 'audio';
     if (lookedUpMimeType.startsWith('video/')) return 'video';


### PR DESCRIPTION
## What

`detectFileType()` short-circuited to `'image'` for the FreeHand extension family (`.fh`, `.fh4`, `.fh5`, `.fh7`, `.fhc`) because `mime-db` maps them to `image/x-freehand`. On Windows these are commonly shader/source text files, so `read_file` base64-encoded them as image data and the provider rejected the request with a 400 ("The image data you provided does not represent a valid image"). The model ended up shelling out to `cat` as a workaround.

This PR excludes the FreeHand family from the mime `image/*` short-circuit so they fall through to the existing `BINARY_EXTENSIONS` + `isBinaryFile()` content detection — yielding `'text'` for shader/source and `'binary'` for genuine binaries. It follows the existing narrow-allowlist precedent (`.ts`/`.mts`/`.cts` for the MPEG transport stream collision, `.svg` for SVG).

## Why

Following the CodeRabbit plan in the issue: a narrow allowlist matching the established convention is minimal and low-risk, and falling through to content detection (rather than forcing `'text'`) correctly handles both the reported text case and hypothetical genuine FreeHand binaries.

## Changes

- `packages/tools/src/utils/fileUtils.ts` — `detectFileType()`: add `freehandExtensions` allowlist, exclude from mime short-circuit.
- `packages/core/src/utils/fileUtils.ts` — mirror the same change in the hand-synced copy.
- `packages/core/src/utils/fileUtils.test.ts` — `.fh`-family regression tests (text + binary, all sibling extensions).
- `packages/tools/src/utils/fileUtils.test.ts` — new colocated test file (previously untested), with `.fh` regression tests and `afterEach` resilient cleanup.

## Follow-on issues

Per the issue comments, two follow-on feature issues were filed (same labels `Loopbreaker`, `Tooling`, type `Feature`, project `LLxprt Roadmap`, status `Todo`):

- #2722 — Detect tool-related 400 errors and advise the model to try a different approach.
- #2723 — Content-signature verification before trusting media mime classification (the holistic fix; the narrow allowlist here is the immediate, low-risk fix).

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run build` — pass
- `npx prettier --check` on changed files — pass
- `packages/core` `fileUtils.test.ts` — 56/56 pass
- `packages/tools` `fileUtils.test.ts` — 13/13 pass
- Smoke test (`bun scripts/start.ts --profile-load ollamakimi "write me a haiku and nothing else"`) — pass
- ocr (Open Code Review, `--timeout 20`) — clean on final pass
- DeepThinker design review — no high/medium findings; one low-severity test-coverage note (public `ReadFileTool` end-to-end test) acknowledged as future hardening.

Closes #2719.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FreeHand file detection for `.fh`, `.fh4`, `.fh5`, `.fh7`, and `.fhc` files.
  * Text-based FreeHand files are now correctly recognized as text instead of images.
  * Binary FreeHand files are now correctly identified as binary content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->