### PR TITLE
Add structured OCR telemetry for longitudinal analysis (Fixes #2676)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -416,8 +416,8 @@ jobs:
     # this output lets downstream jobs distinguish a completed OCR review from a
     # review that could not run because of provider, install, or script issues.
     outputs:
-      infrastructure_failure: ${{ steps.ocr-classification.outputs.infrastructure_failure }}
-      policy_failure: ${{ steps.ocr-classification.outputs.policy_failure }}
+      infrastructure_failure: ${{ steps.ocr-final-classification.outputs.infrastructure_failure }}
+      policy_failure: ${{ steps.ocr-final-classification.outputs.policy_failure }}
       # Feature 5 (issue #2670): structured comment-count outputs.
       comments_total: ${{ steps.post-ocr-results.outputs.comments_total }}
       comments_inline: ${{ steps.post-ocr-results.outputs.comments_inline }}
@@ -425,7 +425,7 @@ jobs:
       comments_failed: ${{ steps.post-ocr-results.outputs.comments_failed }}
       comments_routed_summary: ${{ steps.post-ocr-results.outputs.comments_routed_summary }}
       summary_comment_url: ${{ steps.post-ocr-results.outputs.summary_comment_url }}
-      completeness: ${{ steps.ocr-classification.outputs.completeness }}
+      completeness: ${{ steps.ocr-final-classification.outputs.completeness }}
     # The code-review job runs only when the mergeability gate and the
     # auto-review gate both permit it.
     needs:
@@ -1081,48 +1081,52 @@ jobs:
               | grep -Ei '(^|/)(__tests__|tests?)/.*\.(ts|tsx|js|jsx|mjs|cjs)$|\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$' \
               || true
           )"
+          echo "true" > ocr-preview-attempted.txt
+          if ! command -v ocr >/dev/null 2>&1; then
+            echo "::warning::OpenCodeReview command is unavailable before preview."
+            echo "OpenCodeReview command is unavailable before preview." >> ocr-preview-stderr.log
+            echo "127" > ocr-exit-code.txt
+            mark_infrastructure_failure "preview" "OpenCodeReview command is unavailable before preview"
+            exit 0
+          fi
+          set +e
+          ocr review --preview --from "$BASE_SHA" --to "$HEAD_SHA" \
+            > ocr-preview.txt 2> ocr-preview-stderr.log
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::Could not verify OCR preview scope for changed test files."
+            echo "$status" > ocr-exit-code.txt
+            mark_infrastructure_failure "preview" "OCR preview command failed"
+            exit 0
+          fi
+          if ! sed -i 's/\x1b\[[0-9;?<>=]*[A-Za-z]//g; s/\x1b\][^\x07\x1b]*\(\x07\|\x1b\\\)//g' ocr-preview.txt; then
+            echo "::warning::Could not normalize OCR preview output."
+            echo "1" > ocr-exit-code.txt
+            mark_infrastructure_failure "preview" "OCR preview normalization failed"
+            exit 0
+          fi
+          if ! grep -Eq '^Will review[[:space:]]*\([0-9]+\):' ocr-preview.txt; then
+            echo "1" > ocr-exit-code.txt
+            mark_infrastructure_failure "preview" "OCR preview output was malformed"
+            exit 0
+          fi
+          echo "true" > ocr-preview-succeeded.txt
+          reviewed="$(awk '
+            BEGIN { IGNORECASE = 1; in_section = 0 }
+            /^Will review[[:space:]]*\(/ { in_section = 1; next }
+            /^[[:alpha:] ]+[[:space:]]*\([0-9]+\):/ { in_section = 0 }
+            in_section { print }
+          ' ocr-preview.txt || true)"
+          printf '%s\n' "$reviewed" | sed -e 's/^[[:space:]]*//' \
+            -e 's/^[-*][[:space:]]*//' \
+            -e 's/^\[[^]]*\][[:space:]]*//' \
+            -e 's/^"\(.*\)"$/\1/' \
+            -e "s/^'\(.*\)'$/\1/" \
+            | grep -v '^[[:space:]]*$' > ocr-selected-files.txt || true
           if [ -n "$changed_tests" ]; then
             echo "Changed test/spec files detected that must be reviewed:"
             echo "$changed_tests"
-            if ! command -v ocr >/dev/null 2>&1; then
-              echo "::warning::OpenCodeReview command is unavailable before preview."
-              echo "OpenCodeReview command is unavailable before preview." >> ocr-preview-stderr.log
-              echo "127" > ocr-exit-code.txt
-              mark_infrastructure_failure "preview" "OpenCodeReview command is unavailable before preview"
-              exit 0
-            fi
-            set +e
-            ocr review --preview --from "$BASE_SHA" --to "$HEAD_SHA" \
-              > ocr-preview.txt 2> ocr-preview-stderr.log
-            status=$?
-            set -e
-            if [ "$status" -ne 0 ]; then
-              echo "::warning::Could not verify OCR preview scope for changed test files."
-              echo "$status" > ocr-exit-code.txt
-              mark_infrastructure_failure "preview" "OCR preview command failed"
-              exit 0
-            fi
-            if ! sed -i 's/\x1b\[[0-9;?<>=]*[A-Za-z]//g; s/\x1b\][^\x07\x1b]*\(\x07\|\x1b\\\)//g' ocr-preview.txt; then
-              echo "::warning::Could not normalize OCR preview output."
-              echo "1" > ocr-exit-code.txt
-              mark_infrastructure_failure "preview" "OCR preview normalization failed"
-              exit 0
-            fi
-            reviewed="$(awk '
-              BEGIN { IGNORECASE = 1; in_section = 0 }
-              /^Will review[[:space:]]*\(/ { in_section = 1; next }
-              /^[[:alpha:] ]+[[:space:]]*\([0-9]+\):/ { in_section = 0 }
-              in_section { print }
-            ' ocr-preview.txt || true)"
-            # Issue #2575: persist the selected (Will review) file list for
-            # the reviewed-range manifest. Extract one path per line,
-            # stripping bullet markers, checkboxes, and surrounding quotes.
-            printf '%s\n' "$reviewed" | sed -e 's/^[[:space:]]*//' \
-              -e 's/^[-*][[:space:]]*//' \
-              -e 's/^\[[^]]*\][[:space:]]*//' \
-              -e 's/^"\(.*\)"$/\1/' \
-              -e "s/^'\(.*\)'$/\1/" \
-              | grep -v '^[[:space:]]*$' > ocr-selected-files.txt || true
             excluded="$(awk '
               BEGIN { IGNORECASE = 1; in_section = 0 }
               /^Excluded[[:space:]]*\(/ { in_section = 1; next }
@@ -1203,6 +1207,11 @@ jobs:
             echo "::warning::Skipping OCR review because an earlier OCR setup/configuration/preview failure was recorded."
             exit 0
           fi
+          # Issue #2676: capture the authoritative wall-clock start for the OCR
+          # invocation under both success and failure paths. Written as epoch
+          # seconds so the Capture OCR wall-clock step can compute a finite,
+          # nonnegative duration.
+          node -e 'process.stdout.write(String(Date.now()))' > ocr_wall_clock_start.txt
           if [ "$RANGE_MODE" = "noop" ]; then
             cat > ocr-result.json <<'EOF'
           {
@@ -1303,6 +1312,55 @@ jobs:
             fi
           fi
           exit 0
+
+      - name: Capture OCR wall-clock
+        # Issue #2676: compute the authoritative wall-clock duration of the
+        # OCR invocation from the start marker captured in the Run
+        # OpenCodeReview step. Runs under always() so a nonzero-exit OCR run
+        # that started still yields a finite, nonnegative wall_clock_seconds.
+        id: ocr-wall-clock
+        shell: bash
+        if: always()
+        run: |
+          set -euo pipefail
+          wall_clock_seconds=""
+          if [ -s ocr_wall_clock_start.txt ]; then
+            start="$(cat ocr_wall_clock_start.txt)"
+            if [[ "$start" =~ ^[0-9]+$ ]]; then
+              wall_clock_seconds="$(node -e '
+                const start = Number(process.argv[1]);
+                const elapsed = (Date.now() - start) / 1000;
+                if (Number.isSafeInteger(start) && Number.isFinite(elapsed) && elapsed >= 0) {
+                  process.stdout.write(String(elapsed));
+                }
+              ' "$start")"
+            fi
+          fi
+          echo "wall_clock_seconds=${wall_clock_seconds}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract OCR files_reviewed
+        # Issue #2676: extract the validated summary.files_reviewed count from
+        # the OCR result envelope so the telemetry files_reviewed reflects the
+        # OCR result (including completed_with_warnings) rather than the
+        # conservative reviewed-range manifest completed set.
+        id: ocr-files-reviewed
+        shell: bash
+        if: always()
+        run: |
+          set -euo pipefail
+          files_reviewed=""
+          if [ -s ocr-result.json ]; then
+            files_reviewed="$(node -e '
+              try {
+                const data = JSON.parse(require("fs").readFileSync("ocr-result.json", "utf8"));
+                const n = data && typeof data === "object" ? data.summary?.files_reviewed : undefined;
+                if (Number.isInteger(n) && n >= 0) {
+                  process.stdout.write(String(n));
+                }
+              } catch (_) { /* unavailable */ }
+            ' 2>/dev/null || true)"
+          fi
+          echo "files_reviewed=${files_reviewed}" >> "$GITHUB_OUTPUT"
 
       - name: Post OCR results
         id: post-ocr-results
@@ -2491,6 +2549,16 @@ jobs:
                 ? selectedFilesList
                 : [];
             const manifestFailedFiles = failedFilesFromResult(parsedOcrResult);
+            const readFailureFiles = manifestFailedFiles.filter((filePath) => {
+              const warnings = Array.isArray(parsedOcrResult?.warnings)
+                ? parsedOcrResult.warnings
+                : [];
+              return warnings.some((warning) => {
+                if (!warning || warning.file !== filePath) return false;
+                const evidence = String(warning.message || warning.error || warning.reason || '');
+                return /\b(?:read|reading|readFile|ENOENT|EACCES)\b/i.test(evidence);
+              });
+            });
             // C7: isSkipped heuristic removed. When the post step runs, the
             // review was NOT skipped (the gate let it through). Missing
             // evidence is "failed"/"partial", never inferred as "skipped".
@@ -2821,7 +2889,21 @@ jobs:
             core.setOutput('comments_skipped', String(commentsSkipped));
             core.setOutput('comments_failed', String(failedInline));
             core.setOutput('comments_routed_summary', String(routingShadowMode ? wouldRouteToSummary : summaryRouted.length));
+            core.setOutput('per_file_review_failures', manifestFailedFiles.join('\n'));
+            core.setOutput('file_read_failures', readFailureFiles.length > 0 ? readFailureFiles.join('\n') : '');
             core.setOutput('summary_comment_url', summaryCommentUrl);
+            // Issue #2676: expose the Post OCR results lifecycle state so the
+            // telemetry record can truthfully distinguish posted/noop/failed
+            // post outcomes. Derived from ran + range mode, not invented.
+            let postState = 'posted';
+            if (process.env.RANGE_MODE === 'noop') {
+              postState = 'noop';
+            } else if (!ran) {
+              postState = policyFailure ? 'policy-failed' : 'failed';
+            } else if (failedInline > 0) {
+              postState = 'partial';
+            }
+            core.setOutput('post_state', postState);
 
             if (!ran) {
               if (policyFailure) {
@@ -2952,8 +3034,71 @@ jobs:
             ' 2>/dev/null || true)"
           fi
           echo "completeness=${completeness}" >> "$GITHUB_OUTPUT"
+      - name: Capture OCR telemetry timestamp
+        id: ocr-generated-at
+        shell: bash
+        if: always()
+        run: |
+          echo "generated_at=$(node -e 'process.stdout.write(new Date().toISOString())')" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure OCR artifact placeholders exist
+        id: ocr-artifact-state
+        shell: bash
+        if: always()
+        run: |
+          set -euo pipefail
+          missing=""
+          for file_name in \
+            ocr-result.json \
+            ocr-metadata.json \
+            ocr-stdout.raw \
+            ocr-stderr.log \
+            ocr-preflight.txt \
+            ocr-version.txt \
+            ocr-preview.txt \
+            ocr-preview-stderr.log \
+            ocr-exit-code.txt \
+            ocr-phase.txt \
+            ocr-infrastructure-failure.txt \
+            ocr-policy-failure.txt \
+            ocr-selected-files.txt \
+            ocr-status.txt \
+            ocr-preview-attempted.txt \
+            ocr-preview-succeeded.txt \
+            ocr-reviewed-range-manifest.json \
+            ocr-manifest-hashes.json \
+            ocr-manifest-sha256.txt \
+            ocr-routing-decisions.json; do
+            if [ ! -e "$file_name" ]; then
+              : > "$file_name"
+              missing="${missing}${file_name}"$'\n'
+            fi
+          done
+          artifact_state="prepared"
+          if [ -n "$missing" ]; then
+            artifact_state="failed"
+            echo "phase=artifact; reason=OCR artifact placeholders were missing before telemetry" >> ocr-infrastructure-failure.txt
+          fi
+          echo "artifact_state=${artifact_state}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve OCR production evidence
+        id: ocr-evidence
+        shell: bash
+        if: always()
+        run: |
+          set -euo pipefail
+          preview_attempted="false"
+          preview_succeeded="false"
+          [ "$(cat ocr-preview-attempted.txt 2>/dev/null || true)" = "true" ] && preview_attempted="true"
+          [ "$(cat ocr-preview-succeeded.txt 2>/dev/null || true)" = "true" ] && preview_succeeded="true"
+          if [ "$preview_attempted" != "true" ] || [ "$preview_succeeded" != "true" ]; then
+            echo "phase=preview; reason=OCR preview evidence was unavailable or unsuccessful" >> ocr-infrastructure-failure.txt
+          fi
+          echo "preview_attempted=${preview_attempted}" >> "$GITHUB_OUTPUT"
+          echo "preview_succeeded=${preview_succeeded}" >> "$GITHUB_OUTPUT"
 
       - name: Redact OCR diagnostic artifacts
+        id: redact-ocr-artifacts
         shell: bash
         if: always()
         env:
@@ -2982,167 +3127,261 @@ jobs:
               .replace(/\b(token\s*[=:]\s*)([A-Za-z0-9_./+=:@-]{16,})/gi, `$1${REDACTION}`)
               .replace(/\b(secret\s*[=:]\s*)([A-Za-z0-9_./+=:@-]{16,})/gi, `$1${REDACTION}`);
           };
-          const diagnosticArtifacts = [
-            'ocr-result.json',
-            'ocr-metadata.json',
-            'ocr-stdout.raw',
-            'ocr-stderr.log',
-            'ocr-preflight.txt',
-            'ocr-version.txt',
-            'ocr-preview.txt',
-            'ocr-preview-stderr.log',
-            'ocr-exit-code.txt',
-            'ocr-phase.txt',
-            'ocr-infrastructure-failure.txt',
-            'ocr-policy-failure.txt',
-            'ocr-selected-files.txt',
-            'ocr-status.txt',
-            'ocr-reviewed-range-manifest.json',
-            'ocr-manifest-hashes.json',
-            'ocr-manifest-sha256.txt',
-            'ocr-routing-decisions.json',
+          const artifacts = [
+            'ocr-result.json', 'ocr-metadata.json', 'ocr-stdout.raw',
+            'ocr-stderr.log', 'ocr-preflight.txt', 'ocr-version.txt',
+            'ocr-preview.txt', 'ocr-preview-stderr.log', 'ocr-exit-code.txt',
+            'ocr-phase.txt', 'ocr-infrastructure-failure.txt',
+            'ocr-policy-failure.txt', 'ocr-selected-files.txt', 'ocr-status.txt',
+            'ocr-preview-attempted.txt', 'ocr-preview-succeeded.txt',
+            'ocr-reviewed-range-manifest.json', 'ocr-manifest-hashes.json',
+            'ocr-manifest-sha256.txt', 'ocr-routing-decisions.json',
           ];
-          const replaceWithRedactionFailure = (fileName, error) => {
-            const code = error && error.code ? error.code : 'unknown';
-            const diagnostic = `redaction failed for ${fileName}: ${code}\n`;
+          const failClosed = (fileName, error) => {
+            const code = error?.code || 'unknown';
             try {
-              fs.writeFileSync(fileName, diagnostic);
+              fs.writeFileSync(fileName, `redaction failed for ${fileName}: ${code}\n`);
             } catch (_) {
-              try {
-                fs.rmSync(fileName, { force: true });
-              } catch (_) {
-                process.exitCode = 1;
-              }
+              try { fs.rmSync(fileName, { force: true }); } catch (_) { /* upload is gated */ }
             }
+            process.exitCode = 1;
           };
-          const REDACTED_PENDING = '[REDACTED-PENDING]';
-          for (const fileName of diagnosticArtifacts) {
+          for (const fileName of artifacts) {
             try {
-              const originalContent = fs.readFileSync(fileName, 'utf8');
-              fs.writeFileSync(fileName, REDACTED_PENDING);
-              const redactedContent = redact(originalContent);
-              const tempFile = `${fileName}.redacting`;
-              fs.writeFileSync(tempFile, redactedContent);
-              fs.renameSync(tempFile, fileName);
+              const original = fs.readFileSync(fileName, 'utf8');
+              fs.writeFileSync(fileName, '[REDACTION-PENDING]\n');
+              const temporary = `${fileName}.redacting`;
+              fs.writeFileSync(temporary, redact(original));
+              fs.renameSync(temporary, fileName);
             } catch (error) {
-              if (error && error.code !== 'ENOENT') {
-                replaceWithRedactionFailure(fileName, error);
-              }
+              if (error?.code !== 'ENOENT') failClosed(fileName, error);
             }
           }
           NODE
-      - name: Compute reviewed-range manifest hashes
-        # C4/C5/C6: compute SHA-256 hashes of post-redaction artifacts.
-        # This runs AFTER "Redact OCR diagnostic artifacts" so the hashes
-        # describe the actual (redacted) bytes that are uploaded. The
-        # manifest itself is hashed last (after its artifact_hashes field
-        # is filled) and written to a detached ocr-manifest-sha256.txt.
-        shell: bash
-        if: always()
-        run: |
-          node <<'NODE'
-          const fs = require('fs');
-          const crypto = require('crypto');
-          // C5/C6: all diagnostic artifacts are hashed, including status
-          // and failure markers.
-          const hashableArtifacts = [
-            'ocr-result.json',
-            'ocr-stdout.raw',
-            'ocr-stderr.log',
-            'ocr-preflight.txt',
-            'ocr-version.txt',
-            'ocr-preview.txt',
-            'ocr-preview-stderr.log',
-            'ocr-exit-code.txt',
-            'ocr-phase.txt',
-            'ocr-selected-files.txt',
-            'ocr-status.txt',
-            'ocr-infrastructure-failure.txt',
-            'ocr-policy-failure.txt',
-          ];
-          const hashes = {};
-          for (const name of hashableArtifacts) {
-            try {
-              const content = fs.readFileSync(name, 'utf8');
-              const hash = crypto.createHash('sha256').update(content).digest('hex');
-              hashes[name] = `sha256:${hash}`;
-            } catch (_) {
-              hashes[name] = null;
-            }
-          }
-          // Write the per-artifact hashes.
-          fs.writeFileSync('ocr-manifest-hashes.json', JSON.stringify(hashes, null, 2));
-          // Re-read the manifest, inject the post-redaction hashes, and
-          // re-serialize so the manifest itself carries verified hashes.
-          try {
-            const manifestRaw = fs.readFileSync('ocr-reviewed-range-manifest.json', 'utf8');
-            const manifest = JSON.parse(manifestRaw);
-            manifest.artifact_hashes = hashes;
-            fs.writeFileSync('ocr-reviewed-range-manifest.json', JSON.stringify(manifest, null, 2));
-          } catch (manifestErr) {
-            process.stderr.write('Could not update manifest artifact_hashes: ' + (manifestErr.message || manifestErr) + String.fromCharCode(10));
-          }
-          // Hash the manifest LAST (after its own hashes are filled in) and
-          // write the detached manifest hash.
-          try {
-            const manifestContent = fs.readFileSync('ocr-reviewed-range-manifest.json', 'utf8');
-            const manifestHash = crypto.createHash('sha256').update(manifestContent).digest('hex');
-            fs.writeFileSync('ocr-manifest-sha256.txt', 'sha256:' + manifestHash + String.fromCharCode(10));
-          } catch (manifestErr) {
-            process.stderr.write('Could not compute manifest hash: ' + (manifestErr.message || manifestErr) + String.fromCharCode(10));
-          }
-          NODE
-      - name: Ensure OCR artifact placeholders exist
+
+      - name: Resolve OCR telemetry classification
+        id: ocr-telemetry-classification
         shell: bash
         if: always()
         run: |
           set -euo pipefail
-          missing=""
-          for file_name in \
-            ocr-result.json \
-            ocr-metadata.json \
-            ocr-stdout.raw \
-            ocr-stderr.log \
-            ocr-preflight.txt \
-            ocr-version.txt \
-            ocr-preview.txt \
-            ocr-preview-stderr.log \
-            ocr-exit-code.txt \
-            ocr-phase.txt \
-            ocr-infrastructure-failure.txt \
-            ocr-policy-failure.txt \
-            ocr-selected-files.txt \
-            ocr-status.txt \
-            ocr-reviewed-range-manifest.json \
-            ocr-manifest-hashes.json \
-            ocr-manifest-sha256.txt \
-            ocr-routing-decisions.json; do
-            if [ ! -e "$file_name" ]; then
-              : > "$file_name"
-              missing="${missing}${file_name}"$'\n'
-            fi
-          done
-          if [ -n "$missing" ]; then
-            echo "::warning::OCR artifact placeholders were missing before upload:"
-            echo "$missing"
-            if [ ! -s ocr-exit-code.txt ]; then
-              echo "127" > ocr-exit-code.txt
-            fi
-            if [ ! -s ocr-phase.txt ]; then
-              echo "artifact" > ocr-phase.txt
-            fi
-            if [ ! -s ocr-infrastructure-failure.txt ]; then
-              echo "phase=artifact; reason=OCR artifact placeholders were missing before upload" > ocr-infrastructure-failure.txt
-            fi
+          policy_failure="false"
+          infrastructure_failure="false"
+          [ -s ocr-policy-failure.txt ] && policy_failure="true"
+          [ -s ocr-infrastructure-failure.txt ] && infrastructure_failure="true"
+          post_state="${{ steps.post-ocr-results.outputs.post_state }}"
+          post_outcome="${{ steps.post-ocr-results.outcome }}"
+          artifact_state="${{ steps.ocr-artifact-state.outputs.artifact_state }}"
+          source_redaction_state="prepared"
+          if [ "$post_outcome" != "success" ] || [ -z "$post_state" ] || [ "$post_state" = "failed" ]; then
+            post_state="failed"
+            infrastructure_failure="true"
           fi
-          for critical_artifact in ocr-exit-code.txt ocr-phase.txt; do
-            if [ ! -s "$critical_artifact" ]; then
-              echo "::warning::Critical OCR artifact $critical_artifact is empty before upload."
-            fi
-          done
+          if [ "$post_state" = "policy-failed" ]; then policy_failure="true"; infrastructure_failure="true"; fi
+          if [ "${{ steps.redact-ocr-artifacts.outcome }}" != "success" ]; then
+            source_redaction_state="failed"
+            artifact_state="failed"
+            infrastructure_failure="true"
+            echo "phase=artifact; reason=OCR artifact redaction failed" >> ocr-infrastructure-failure.txt
+          fi
+          {
+            echo "policy_failure=${policy_failure}"
+            echo "infrastructure_failure=${infrastructure_failure}"
+            echo "post_state=${post_state:-missing}"
+            echo "post_outcome=${post_outcome:-missing}"
+            echo "source_redaction_state=${source_redaction_state}"
+            echo "artifact_state=${artifact_state:-failed}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 'Emit OCR telemetry (issue #2676)'
+        id: emit-ocr-telemetry
+        shell: bash
+        if: always()
+        env:
+          OCR_RUN_ID: ${{ github.run_id }}
+          OCR_RUN_ATTEMPT: ${{ github.run_attempt }}
+          OCR_PR_NUMBER: ${{ steps.pr-context.outputs.number }}
+          OCR_SHA: ${{ env.HEAD_SHA }}
+          OCR_GENERATED_AT: ${{ steps.ocr-generated-at.outputs.generated_at }}
+          OCR_WALL_CLOCK_SECONDS: ${{ steps.ocr-wall-clock.outputs.wall_clock_seconds }}
+          OCR_FILES_REVIEWED: ${{ steps.ocr-files-reviewed.outputs.files_reviewed }}
+          OCR_POST_STATE: ${{ steps.ocr-telemetry-classification.outputs.post_state }}
+          OCR_POST_OUTCOME: ${{ steps.ocr-telemetry-classification.outputs.post_outcome }}
+          OCR_SOURCE_REDACTION_STATE: ${{ steps.ocr-telemetry-classification.outputs.source_redaction_state }}
+          OCR_ARTIFACT_STATE: ${{ steps.ocr-telemetry-classification.outputs.artifact_state }}
+          OCR_HASH_STATE: prepared
+          OCR_INFRASTRUCTURE_FAILURE: ${{ steps.ocr-telemetry-classification.outputs.infrastructure_failure }}
+          OCR_POLICY_FAILURE: ${{ steps.ocr-telemetry-classification.outputs.policy_failure }}
+          OCR_PREVIEW_ATTEMPTED: ${{ steps.ocr-evidence.outputs.preview_attempted }}
+          OCR_PREVIEW_SUCCEEDED: ${{ steps.ocr-evidence.outputs.preview_succeeded }}
+          OCR_FILE_READ_FAILURES: ${{ steps.post-ocr-results.outputs.file_read_failures }}
+          OCR_PER_FILE_REVIEW_FAILURES: ${{ steps.post-ocr-results.outputs.per_file_review_failures }}
+          OCR_INLINE_POSTED: ${{ steps.post-ocr-results.outputs.comments_inline }}
+          OCR_ALREADY_POSTED_OR_SKIPPED_DEDUP: ${{ steps.post-ocr-results.outputs.comments_skipped }}
+          OCR_COMMENTS_SKIPPED: ${{ steps.post-ocr-results.outputs.comments_skipped }}
+          OCR_COMMENTS_FAILED: ${{ steps.post-ocr-results.outputs.comments_failed }}
+          OCR_COMMENTS_ROUTED_SUMMARY: ${{ steps.post-ocr-results.outputs.comments_routed_summary }}
+          OCR_COMMENTS_TOTAL: ${{ steps.post-ocr-results.outputs.comments_total }}
+        run: |
+          set -euo pipefail
+          export GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-$RUNNER_TEMP/ocr-step-summary.md}"
+          if node scripts/ocr-telemetry.js; then
+            echo "generated=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "phase=telemetry; reason=OCR telemetry producer failed" >> ocr-infrastructure-failure.txt
+          if node scripts/ocr-telemetry.js --failure "OCR telemetry producer failed"; then
+            echo "generated=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          node <<'NODE'
+          const fs = require('fs');
+          const count = (value) => /^\d+$/.test(value || '') && Number.isSafeInteger(Number(value))
+            ? Number(value)
+            : null;
+          const record = {
+            schema: 1, schema_name: 'ocr-telemetry',
+            run_id: process.env.OCR_RUN_ID || null,
+            run_attempt: process.env.OCR_RUN_ATTEMPT || null,
+            pr_number: count(process.env.OCR_PR_NUMBER),
+            sha: /^[0-9a-f]{40}$/.test(process.env.OCR_SHA || '') ? process.env.OCR_SHA : null,
+            generated_at: process.env.OCR_GENERATED_AT || new Date().toISOString(),
+            ocr: { version: null, model: null, concurrency: null },
+            wall_clock_seconds: null, cli_elapsed_seconds: null,
+            files_previewed: null, files_reviewed: null,
+            file_read_failures: null, file_read_failure_count: null,
+            per_file_review_failures: null, per_file_review_failure_count: null,
+            total_findings: null, findings: null, inline_posted: null,
+            already_resolved: null, already_posted_or_skipped_dedup: null,
+            comments_skipped: null, comments_failed: null,
+            comments_routed_summary: null, comments_total: null,
+            infrastructure_failure: true,
+            policy_failure: process.env.OCR_POLICY_FAILURE === 'true',
+            completeness: null, publication_state: null,
+            reviewed_range_manifest: null, tokens: null,
+            telemetry_state: 'failed',
+            post_state: ['posted', 'partial', 'noop', 'failed', 'policy-failed', 'missing'].includes(process.env.OCR_POST_STATE)
+              ? process.env.OCR_POST_STATE : 'missing',
+            artifact_state: 'failed', hash_state: 'unavailable',
+            marker_state: {
+              infrastructure_failure: true,
+              policy_failure: process.env.OCR_POLICY_FAILURE === 'true',
+            },
+            errors: ['OCR telemetry producer unavailable'],
+          };
+          const required = ['schema', 'schema_name', 'generated_at', 'telemetry_state', 'errors'];
+          if (!required.every((key) => Object.prototype.hasOwnProperty.call(record, key)) ||
+              record.schema_name !== 'ocr-telemetry' || !Array.isArray(record.errors)) {
+            throw new Error('independent fallback telemetry self-validation failed');
+          }
+          const target = 'ocr-telemetry.json';
+          const temporary = `${target}.fallback-${process.pid}`;
+          fs.writeFileSync(temporary, `${JSON.stringify(record, null, 2)}\n`);
+          fs.renameSync(temporary, target);
+          NODE
+          echo "generated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Validate redacted OCR telemetry
+        id: ocr-telemetry-validation
+        shell: bash
+        if: always()
+        env:
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+          OCR_RUN_ID: ${{ github.run_id }}
+          OCR_RUN_ATTEMPT: ${{ github.run_attempt }}
+          OCR_PR_NUMBER: ${{ steps.pr-context.outputs.number }}
+          OCR_SHA: ${{ env.HEAD_SHA }}
+          OCR_GENERATED_AT: ${{ steps.ocr-generated-at.outputs.generated_at }}
+          OCR_WALL_CLOCK_SECONDS: ${{ steps.ocr-wall-clock.outputs.wall_clock_seconds }}
+          OCR_FILES_REVIEWED: ${{ steps.ocr-files-reviewed.outputs.files_reviewed }}
+          OCR_POST_STATE: ${{ steps.ocr-telemetry-classification.outputs.post_state }}
+          OCR_ARTIFACT_STATE: ${{ steps.ocr-telemetry-classification.outputs.artifact_state }}
+          OCR_INFRASTRUCTURE_FAILURE: 'true'
+          OCR_POLICY_FAILURE: ${{ steps.ocr-telemetry-classification.outputs.policy_failure }}
+          OCR_TELEMETRY_STATE: failed
+        run: |
+          set -euo pipefail
+          if ! node scripts/ocr-telemetry.js --redact ocr-telemetry.json || \
+             ! node scripts/ocr-telemetry.js --validate ocr-telemetry.json; then
+            echo "phase=telemetry; reason=post-redaction telemetry validation failed" >> ocr-infrastructure-failure.txt
+            node scripts/ocr-telemetry.js --failure "post-redaction telemetry validation failed"
+            node scripts/ocr-telemetry.js --redact ocr-telemetry.json
+            node scripts/ocr-telemetry.js --validate ocr-telemetry.json
+          fi
+          echo "valid=true" >> "$GITHUB_OUTPUT"
+
+      - name: Compute reviewed-range manifest hashes
+        id: ocr-manifest-hashes
+        shell: bash
+        if: always()
+        run: |
+          set -euo pipefail
+          echo "valid=false" >> "$GITHUB_OUTPUT"
+          if ! node <<'NODE'
+          const fs = require('fs');
+          const crypto = require('crypto');
+          const hashableArtifacts = [
+            'ocr-result.json', 'ocr-stdout.raw', 'ocr-stderr.log',
+            'ocr-preflight.txt', 'ocr-version.txt', 'ocr-preview.txt',
+            'ocr-preview-stderr.log', 'ocr-exit-code.txt', 'ocr-phase.txt',
+            'ocr-selected-files.txt', 'ocr-status.txt',
+            'ocr-infrastructure-failure.txt', 'ocr-policy-failure.txt',
+            'ocr-telemetry.json',
+          ];
+          const hashes = {};
+          for (const name of hashableArtifacts) {
+            const content = fs.readFileSync(name);
+            hashes[name] = `sha256:${crypto.createHash('sha256').update(content).digest('hex')}`;
+          }
+          const hashesTemporary = `ocr-manifest-hashes.json.tmp-${process.pid}`;
+          fs.writeFileSync(hashesTemporary, `${JSON.stringify(hashes, null, 2)}\n`);
+          fs.renameSync(hashesTemporary, 'ocr-manifest-hashes.json');
+          const manifest = JSON.parse(fs.readFileSync('ocr-reviewed-range-manifest.json', 'utf8'));
+          manifest.artifact_hashes = hashes;
+          const manifestTemporary = `ocr-reviewed-range-manifest.json.tmp-${process.pid}`;
+          fs.writeFileSync(manifestTemporary, `${JSON.stringify(manifest, null, 2)}\n`);
+          fs.renameSync(manifestTemporary, 'ocr-reviewed-range-manifest.json');
+          // Hash the manifest LAST (after its artifact hashes are final). The
+          // detached hash is intentionally not included in its own input set.
+          const manifestContent = fs.readFileSync('ocr-reviewed-range-manifest.json');
+          const hash = crypto.createHash('sha256').update(manifestContent).digest('hex');
+          const detachedTemporary = `ocr-manifest-sha256.txt.tmp-${process.pid}`;
+          fs.writeFileSync(detachedTemporary, `sha256:${hash}\n`);
+          fs.renameSync(detachedTemporary, 'ocr-manifest-sha256.txt');
+          NODE
+          then
+            echo "phase=manifest; reason=manifest hash preparation failed" >> ocr-infrastructure-failure.txt
+            node -e '
+              const fs = require("fs");
+              try {
+                const record = JSON.parse(fs.readFileSync("ocr-telemetry.json", "utf8"));
+                record.infrastructure_failure = true;
+                record.telemetry_state = "failed";
+                record.artifact_state = "failed";
+                record.hash_state = "failed";
+                record.marker_state = {
+                  infrastructure_failure: true,
+                  policy_failure: record.policy_failure === true,
+                };
+                record.errors = [...new Set([
+                  ...(Array.isArray(record.errors) ? record.errors : []),
+                  "OCR manifest hash preparation failed",
+                ])];
+                const temporary = "ocr-telemetry.json.hash-failure-" + process.pid;
+                fs.writeFileSync(temporary, JSON.stringify(record, null, 2) + "\n");
+                fs.renameSync(temporary, "ocr-telemetry.json");
+              } catch (_) {
+                // Upload remains gated off even if the local telemetry repair fails.
+              }
+            '
+            exit 1
+          fi
+          echo "valid=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload OCR artifacts
-        if: always()
+        id: upload-ocr-artifacts
+        if: ${{ always() && steps.redact-ocr-artifacts.outcome == 'success' && steps.ocr-telemetry-validation.outputs.valid == 'true' && steps.ocr-manifest-hashes.outputs.valid == 'true' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: ocr-review-output
@@ -3165,7 +3404,49 @@ jobs:
             ocr-manifest-hashes.json
             ocr-manifest-sha256.txt
             ocr-routing-decisions.json
-          if-no-files-found: warn
+            ocr-telemetry.json
+          if-no-files-found: error
+
+      - name: Resolve final OCR classification
+        id: ocr-final-classification
+        shell: bash
+        if: always()
+        run: |
+          set -euo pipefail
+          policy_failure="false"
+          infrastructure_failure="false"
+          [ -s ocr-policy-failure.txt ] && policy_failure="true"
+          [ -s ocr-infrastructure-failure.txt ] && infrastructure_failure="true"
+          post_outcome="${{ steps.post-ocr-results.outcome }}"
+          post_state="${{ steps.post-ocr-results.outputs.post_state }}"
+          source_redaction_outcome="${{ steps.redact-ocr-artifacts.outcome }}"
+          telemetry_valid="${{ steps.ocr-telemetry-validation.outputs.valid }}"
+          hash_valid="${{ steps.ocr-manifest-hashes.outputs.valid }}"
+          upload_outcome="${{ steps.upload-ocr-artifacts.outcome }}"
+          telemetry_state="complete"
+          hash_state="prepared"
+          upload_state="uploaded"
+          if [ "$post_outcome" != "success" ] || [ -z "$post_state" ] || [ "$post_state" = "failed" ]; then
+            post_state="failed"
+            infrastructure_failure="true"
+          fi
+          if [ "$post_state" = "policy-failed" ]; then policy_failure="true"; infrastructure_failure="true"; fi
+          if [ "$source_redaction_outcome" != "success" ]; then infrastructure_failure="true"; fi
+          if [ "$telemetry_valid" != "true" ]; then telemetry_state="failed"; infrastructure_failure="true"; fi
+          if [ "$hash_valid" != "true" ]; then hash_state="failed"; infrastructure_failure="true"; fi
+          if [ "$upload_outcome" != "success" ]; then upload_state="failed"; infrastructure_failure="true"; fi
+          completeness="${{ steps.ocr-classification.outputs.completeness }}"
+          # Upload outcome is only knowable after upload and therefore belongs
+          # in final job outputs, not the already-serialized artifact telemetry.
+          {
+            echo "policy_failure=${policy_failure}"
+            echo "infrastructure_failure=${infrastructure_failure}"
+            echo "completeness=${completeness:-unknown}"
+            echo "post_state=${post_state:-missing}"
+            echo "telemetry_state=${telemetry_state}"
+            echo "hash_state=${hash_state}"
+            echo "upload_state=${upload_state}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Clean up scoped safe.directory
         shell: bash

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -421,6 +421,7 @@ jobs:
       # Feature 5 (issue #2670): structured comment-count outputs.
       comments_total: ${{ steps.post-ocr-results.outputs.comments_total }}
       comments_inline: ${{ steps.post-ocr-results.outputs.comments_inline }}
+      already_resolved: ${{ steps.post-ocr-results.outputs.already_resolved }}
       comments_skipped: ${{ steps.post-ocr-results.outputs.comments_skipped }}
       comments_failed: ${{ steps.post-ocr-results.outputs.comments_failed }}
       comments_routed_summary: ${{ steps.post-ocr-results.outputs.comments_routed_summary }}
@@ -833,7 +834,7 @@ jobs:
           : > ocr-routing-decisions.json
           cat > ocr-workflow-helpers.sh <<'EOF'
           mark_infrastructure_failure() {
-            echo "phase=$1; reason=$2" > ocr-infrastructure-failure.txt
+            echo "phase=$1; reason=$2" >> ocr-infrastructure-failure.txt
           }
           mark_policy_failure() {
             echo "$1" > ocr-policy-failure.txt
@@ -848,7 +849,7 @@ jobs:
           if ! . ./ocr-workflow-helpers.sh; then
             echo "::warning::Could not load OCR workflow helper script."
             echo "127" > ocr-exit-code.txt
-            echo "phase=install; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            echo "phase=install; reason=OCR workflow helper script could not be loaded" >> ocr-infrastructure-failure.txt
             exit 0
           fi
           OCR_PREFIX="${RUNNER_TEMP}/ocr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
@@ -927,7 +928,7 @@ jobs:
           if ! . ./ocr-workflow-helpers.sh; then
             echo "::warning::Could not load OCR workflow helper script."
             echo "127" > ocr-exit-code.txt
-            echo "phase=config; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            echo "phase=config; reason=OCR workflow helper script could not be loaded" >> ocr-infrastructure-failure.txt
             exit 0
           fi
           if ! command -v ocr >/dev/null 2>&1; then
@@ -979,7 +980,7 @@ jobs:
           if ! . ./ocr-workflow-helpers.sh; then
             echo "::warning::Could not load OCR workflow helper script."
             echo "127" > ocr-exit-code.txt
-            echo "phase=validate; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            echo "phase=validate; reason=OCR workflow helper script could not be loaded" >> ocr-infrastructure-failure.txt
             exit 0
           fi
           missing=0
@@ -1021,7 +1022,7 @@ jobs:
           if ! . ./ocr-workflow-helpers.sh; then
             echo "::warning::Could not load OCR workflow helper script."
             echo "127" > ocr-exit-code.txt
-            echo "phase=llm-preflight; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            echo "phase=llm-preflight; reason=OCR workflow helper script could not be loaded" >> ocr-infrastructure-failure.txt
             exit 0
           fi
           if ! command -v ocr >/dev/null 2>&1; then
@@ -1073,7 +1074,7 @@ jobs:
           if ! . ./ocr-workflow-helpers.sh; then
             echo "::warning::Could not load OCR workflow helper script."
             echo "127" > ocr-exit-code.txt
-            echo "phase=preview; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            echo "phase=preview; reason=OCR workflow helper script could not be loaded" >> ocr-infrastructure-failure.txt
             exit 0
           fi
           changed_tests="$(
@@ -1240,7 +1241,7 @@ jobs:
           if ! . ./ocr-workflow-helpers.sh; then
             echo "::warning::Could not load OCR workflow helper script."
             echo "127" > ocr-exit-code.txt
-            echo "phase=review; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            echo "phase=review; reason=OCR workflow helper script could not be loaded" >> ocr-infrastructure-failure.txt
             exit 0
           fi
           if ! command -v ocr >/dev/null 2>&1; then
@@ -2886,6 +2887,7 @@ jobs:
             const commentsSkipped = skippedOverlapCount + skippedExactHistoryCount;
             core.setOutput('comments_total', String(commentsTotal));
             core.setOutput('comments_inline', String(postedInline));
+            core.setOutput('already_resolved', String(commentsSkipped));
             core.setOutput('comments_skipped', String(commentsSkipped));
             core.setOutput('comments_failed', String(failedInline));
             core.setOutput('comments_routed_summary', String(routingShadowMode ? wouldRouteToSummary : summaryRouted.length));
@@ -3217,6 +3219,7 @@ jobs:
           OCR_FILE_READ_FAILURES: ${{ steps.post-ocr-results.outputs.file_read_failures }}
           OCR_PER_FILE_REVIEW_FAILURES: ${{ steps.post-ocr-results.outputs.per_file_review_failures }}
           OCR_INLINE_POSTED: ${{ steps.post-ocr-results.outputs.comments_inline }}
+          OCR_ALREADY_RESOLVED: ${{ steps.post-ocr-results.outputs.already_resolved }}
           OCR_ALREADY_POSTED_OR_SKIPPED_DEDUP: ${{ steps.post-ocr-results.outputs.comments_skipped }}
           OCR_COMMENTS_SKIPPED: ${{ steps.post-ocr-results.outputs.comments_skipped }}
           OCR_COMMENTS_FAILED: ${{ steps.post-ocr-results.outputs.comments_failed }}
@@ -3379,6 +3382,15 @@ jobs:
           fi
           echo "valid=true" >> "$GITHUB_OUTPUT"
 
+      - name: Upload OCR telemetry
+        id: upload-ocr-telemetry
+        if: ${{ always() && steps.ocr-telemetry-validation.outputs.valid == 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
+        with:
+          name: ocr-telemetry-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ocr-telemetry.json
+          if-no-files-found: error
+
       - name: Upload OCR artifacts
         id: upload-ocr-artifacts
         if: ${{ always() && steps.redact-ocr-artifacts.outcome == 'success' && steps.ocr-telemetry-validation.outputs.valid == 'true' && steps.ocr-manifest-hashes.outputs.valid == 'true' }}
@@ -3404,7 +3416,6 @@ jobs:
             ocr-manifest-hashes.json
             ocr-manifest-sha256.txt
             ocr-routing-decisions.json
-            ocr-telemetry.json
           if-no-files-found: error
 
       - name: Resolve final OCR classification

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -2887,7 +2887,7 @@ jobs:
             const commentsSkipped = skippedOverlapCount + skippedExactHistoryCount;
             core.setOutput('comments_total', String(commentsTotal));
             core.setOutput('comments_inline', String(postedInline));
-            core.setOutput('already_resolved', String(commentsSkipped));
+            core.setOutput('already_resolved', String(skippedOverlapCount));
             core.setOutput('comments_skipped', String(commentsSkipped));
             core.setOutput('comments_failed', String(failedInline));
             core.setOutput('comments_routed_summary', String(routingShadowMode ? wouldRouteToSummary : summaryRouted.length));

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "prepare:package": "bun scripts/prepare-package.ts",
     "release:version": "bun scripts/version.ts",
     "telemetry": "bun scripts/telemetry.ts",
+    "telemetry:ocr:aggregate": "node scripts/aggregate-ocr-telemetry.js",
     "check:lockfile": "bun scripts/check-lockfile.ts",
     "test:issue-2603-smoke": "node scripts/tests/issue-2603-release-install-smoke.cjs",
     "test:issue-2603-benchmark": "node scripts/tests/issue-2603-startup-benchmark.cjs",

--- a/scripts/aggregate-ocr-telemetry.js
+++ b/scripts/aggregate-ocr-telemetry.js
@@ -1,0 +1,501 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Longitudinal aggregation of OCR telemetry records (issue #2676).
+ *
+ * Executable CLI-style ESM module with importable pure functions. Discovers
+ * ocr-telemetry.json records under an artifacts root, validates each against
+ * the STRICT shared schema/validator (used by both producer and aggregator),
+ * rejects malformed records rather than defaulting missing values to zero,
+ * and aggregates them into longitudinal statistics with per-run trends.
+ *
+ * Security: uses null-prototype accumulators everywhere untrusted
+ * category/severity/concurrency keys flow, so __proto__/constructor/prototype
+ * cannot pollute Object.prototype. Rejects arrays masquerading as objects,
+ * primitives, non-finite/negative/unsafe values, invalid timestamps, and
+ * duplicate (run_id, run_attempt) records.
+ *
+ * CLI contract: positional <artifacts-root>, optional --format {json|markdown},
+ * optional --output <path>. When --output is given the formatted output is
+ * written to that file; otherwise it goes to stdout. --format selects the
+ * output format (not an output path).
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import process from 'node:process';
+import {
+  validateTelemetryRecord,
+  isPlainObject,
+} from './ocr-telemetry-schema.js';
+
+export { validateTelemetryRecord, isPlainObject };
+
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Compare two records for deterministic time-series ordering using a single
+ * transitive tuple: (generated_at, run_id, run_attempt). run_id and
+ * run_attempt are compared numeric-aware for stable ordering.
+ * @param {object} a
+ * @param {object} b
+ * @returns {number}
+ */
+function compareByTime(a, b) {
+  const epochDifference =
+    Date.parse(a.generated_at) - Date.parse(b.generated_at);
+  if (epochDifference !== 0) {
+    return epochDifference;
+  }
+  const rid = numericStringCompare(a.run_id, b.run_id);
+  if (rid !== 0) {
+    return rid;
+  }
+  return numericStringCompare(String(a.run_attempt), String(b.run_attempt));
+}
+
+function numericStringCompare(a, b) {
+  const left = String(a ?? '');
+  const right = String(b ?? '');
+  if (/^\d+$/.test(left) && /^\d+$/.test(right)) {
+    const normalizedLeft = left.replace(/^0+(?=\d)/, '');
+    const normalizedRight = right.replace(/^0+(?=\d)/, '');
+    return (
+      normalizedLeft.length - normalizedRight.length ||
+      normalizedLeft.localeCompare(normalizedRight) ||
+      left.localeCompare(right)
+    );
+  }
+  return left.localeCompare(right);
+}
+
+function mean(values) {
+  const available = values.filter((value) => typeof value === 'number');
+  if (available.length === 0) {
+    return null;
+  }
+  const sum = available.reduce((total, value) => total + value, 0);
+  return sum / available.length;
+}
+
+/**
+ * Aggregate validated telemetry records into longitudinal statistics. Each
+ * record is validated (fail-closed) + reconciliation-checked before
+ * aggregation. Rejects duplicate (run_id, run_attempt) records.
+ * @param {Array<object>} records
+ * @returns {object}
+ */
+export function aggregateTelemetry(records) {
+  if (!Array.isArray(records)) {
+    throw new Error('records must be an array');
+  }
+  if (records.length === 0) {
+    throw new Error('no records to aggregate');
+  }
+  const sorted = sortAndValidate(records);
+  detectDuplicates(sorted);
+  const categories = aggregateKeys(sorted, 'by_category');
+  const severities = aggregateKeys(sorted, 'by_severity');
+  const stats = {
+    runs: sorted.length,
+    total_findings: sumField(sorted, 'total_findings'),
+    average_findings_per_run: mean(
+      sorted.map((record) => record.total_findings),
+    ),
+    findings_available_runs: sorted.filter(
+      (record) => record.total_findings !== null,
+    ).length,
+    findings_total_runs: sorted.length,
+    categories,
+    severities,
+    top_categories: rankKeys(categories),
+    top_severities: rankKeys(severities),
+    average_wall_clock_by_concurrency: wallClockByConcurrency(sorted),
+    file_read_failure_rate: fileReadFailureRate(sorted),
+    total_per_file_review_failures: sumField(
+      sorted,
+      'per_file_review_failure_count',
+    ),
+    total_files_previewed: sumField(sorted, 'files_previewed'),
+    total_files_reviewed: sumField(sorted, 'files_reviewed'),
+    inline_volume: sorted.map(volumeEntry),
+    findings_trend: sorted.map(findingsTrendEntry),
+    category_trend: sorted.map(categoryTrendEntry),
+    severity_trend: sorted.map(severityTrendEntry),
+  };
+  return { ...stats, markdown: renderAggregationMarkdown(stats) };
+}
+
+function sortAndValidate(records) {
+  const validated = records.map((record, index) => {
+    const error = validateTelemetryRecord(record);
+    if (error) {
+      throw new Error(`malformed telemetry record at index ${index}: ${error}`);
+    }
+    return record;
+  });
+  return [...validated].sort(compareByTime);
+}
+
+function detectDuplicates(sorted) {
+  const seen = new Set();
+  for (const record of sorted) {
+    const key = `${record.run_id}\u0000${record.run_attempt}`;
+    if (seen.has(key)) {
+      throw new Error(
+        `duplicate (run_id=${record.run_id}, run_attempt=${record.run_attempt}) records are not allowed without an explicit retry policy`,
+      );
+    }
+    seen.add(key);
+  }
+}
+
+function sumField(records, field) {
+  const available = records
+    .map((record) => record[field])
+    .filter((value) => typeof value === 'number' && Number.isFinite(value));
+  if (available.length === 0) return null;
+  let total = 0;
+  for (const value of available) {
+    total += value;
+    if (!Number.isSafeInteger(total)) {
+      throw new Error(`${field} aggregate exceeds the safe integer range`);
+    }
+  }
+  return total;
+}
+
+/**
+ * Aggregate a per-record distribution field into a prototype-safe total map.
+ * @param {Array<object>} records
+ * @param {string} distributionField
+ * @returns {Record<string, number>}
+ */
+function aggregateKeys(records, distributionField) {
+  const counts = Object.create(null);
+  for (const record of records) {
+    const distribution = record.findings?.[distributionField];
+    if (!isPlainObject(distribution)) {
+      continue;
+    }
+    for (const key of Object.keys(distribution)) {
+      if (UNSAFE_KEYS.has(key)) {
+        continue;
+      }
+      const value = distribution[key];
+      if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+        counts[key] = (counts[key] ?? 0) + value;
+      }
+    }
+  }
+  return counts;
+}
+
+function rankKeys(counts) {
+  return Object.keys(counts)
+    .filter((key) => !UNSAFE_KEYS.has(key))
+    .map((name) => ({ name, count: counts[name] }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+function wallClockByConcurrency(records) {
+  const groups = Object.create(null);
+  for (const record of records) {
+    const concurrency = String(record.ocr?.concurrency ?? 'unknown');
+    if (record.wall_clock_seconds !== null && !UNSAFE_KEYS.has(concurrency)) {
+      if (groups[concurrency] === undefined) {
+        groups[concurrency] = [];
+      }
+      groups[concurrency].push(record.wall_clock_seconds);
+    }
+  }
+  const result = Object.create(null);
+  for (const concurrency of Object.keys(groups)) {
+    result[concurrency] = {
+      average_seconds: mean(groups[concurrency]),
+      samples: groups[concurrency].length,
+    };
+  }
+  return result;
+}
+
+/**
+ * Compute the file-read failure rate. Returns null when the numerator or
+ * denominator is unavailable — never claims a 0% rate when evidence is
+ * unavailable or the denominator is zero.
+ * @param {Array<object>} records
+ * @returns {number|null}
+ */
+function fileReadFailureRate(records) {
+  if (
+    records.some(
+      (record) =>
+        record.files_previewed === null ||
+        record.file_read_failure_count === null,
+    )
+  ) {
+    return null;
+  }
+  const totalPreviewed = sumField(records, 'files_previewed');
+  if (totalPreviewed === 0) {
+    return null;
+  }
+  return sumField(records, 'file_read_failure_count') / totalPreviewed;
+}
+
+function volumeEntry(record) {
+  const entry = {
+    run_id: record.run_id,
+    run_attempt: record.run_attempt,
+    inline_posted: record.inline_posted,
+  };
+  if (typeof record.generated_at === 'string') {
+    entry.generated_at = record.generated_at;
+  }
+  return entry;
+}
+
+function findingsTrendEntry(record) {
+  const entry = {
+    run_id: record.run_id,
+    run_attempt: record.run_attempt,
+    total_findings: record.total_findings,
+  };
+  if (typeof record.generated_at === 'string') {
+    entry.generated_at = record.generated_at;
+  }
+  return entry;
+}
+
+function categoryTrendEntry(record) {
+  const entry = {
+    run_id: record.run_id,
+    run_attempt: record.run_attempt,
+    categories:
+      record.findings === null ? null : safeCopy(record.findings.by_category),
+  };
+  if (typeof record.generated_at === 'string') {
+    entry.generated_at = record.generated_at;
+  }
+  return entry;
+}
+
+function severityTrendEntry(record) {
+  const entry = {
+    run_id: record.run_id,
+    run_attempt: record.run_attempt,
+    severities:
+      record.findings === null ? null : safeCopy(record.findings.by_severity),
+  };
+  if (typeof record.generated_at === 'string') {
+    entry.generated_at = record.generated_at;
+  }
+  return entry;
+}
+
+function safeCopy(distribution) {
+  const copy = Object.create(null);
+  if (!isPlainObject(distribution)) {
+    return copy;
+  }
+  for (const key of Object.keys(distribution)) {
+    if (UNSAFE_KEYS.has(key)) {
+      continue;
+    }
+    const value = distribution[key];
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+      copy[key] = value;
+    }
+  }
+  return copy;
+}
+
+function renderAggregationMarkdown(stats) {
+  const topCategories = stats.top_categories
+    .slice(0, 5)
+    .map((category) => `${category.name}: ${category.count}`)
+    .join(', ');
+  const topSeverities = stats.top_severities
+    .slice(0, 5)
+    .map((severity) => `${severity.name}: ${severity.count}`)
+    .join(', ');
+  const concurrency = Object.keys(stats.average_wall_clock_by_concurrency)
+    .map((key) => {
+      const group = stats.average_wall_clock_by_concurrency[key];
+      return `c=${key}: ${group.average_seconds.toFixed(1)} (${group.samples} samples)`;
+    })
+    .join(', ');
+  const inlineVolume = stats.inline_volume
+    .map((entry) => `${entry.run_id}:${entry.inline_posted}`)
+    .join(', ');
+  const rateLabel =
+    stats.file_read_failure_rate === null
+      ? 'n/a'
+      : `${(stats.file_read_failure_rate * 100).toFixed(2)}%`;
+  const categoryTrend = stats.category_trend
+    .map((entry) => {
+      if (entry.categories === null) return `${entry.run_id}{n/a}`;
+      const cats = Object.keys(entry.categories)
+        .filter((k) => entry.categories[k] > 0)
+        .map((k) => `${k}=${entry.categories[k]}`)
+        .join(',');
+      return `${entry.run_id}{${cats || '-'}}`;
+    })
+    .join(' -> ');
+  const severityTrend = stats.severity_trend
+    .map((entry) => {
+      if (entry.severities === null) return `${entry.run_id}{n/a}`;
+      const sevs = Object.keys(entry.severities)
+        .filter((k) => entry.severities[k] > 0)
+        .map((k) => `${k}=${entry.severities[k]}`)
+        .join(',');
+      return `${entry.run_id}{${sevs || '-'}}`;
+    })
+    .join(' -> ');
+  return [
+    '## OCR Telemetry — longitudinal aggregation',
+    '',
+    `- runs: ${stats.runs}`,
+    `- total findings: ${stats.total_findings} (${stats.findings_available_runs}/${stats.findings_total_runs} runs available)`,
+    `- average findings per run: ${stats.average_findings_per_run === null ? 'n/a' : stats.average_findings_per_run.toFixed(2)} (${stats.findings_available_runs}/${stats.findings_total_runs} runs available)`,
+    `- top categories: ${topCategories || 'none'}`,
+    `- top severities: ${topSeverities || 'none'}`,
+    `- average wall-clock by concurrency: ${concurrency || 'none'}`,
+    `- file-read failure rate: ${rateLabel}`,
+    `- inline volume (run:inline): ${inlineVolume || 'none'}`,
+    `- category trend: ${categoryTrend || 'none'}`,
+    `- severity trend: ${severityTrend || 'none'}`,
+    '',
+  ].join('\n');
+}
+
+function readJson(path) {
+  const content = readFileSync(path, 'utf8');
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  return JSON.parse(trimmed);
+}
+
+function isTelemetryEntry(entry) {
+  return entry.isFile() && entry.name === 'ocr-telemetry.json';
+}
+
+/**
+ * Recursively discover ocr-telemetry.json records under a root directory and
+ * return them validated. Fails fast (throws) on any malformed record.
+ * @param {string} rootPath
+ * @returns {Array<object>}
+ */
+export function discoverTelemetryRecords(rootPath) {
+  const entries = readdirSync(rootPath, { withFileTypes: true });
+  const records = [];
+  for (const entry of entries) {
+    const fullPath = join(rootPath, entry.name);
+    if (entry.isDirectory()) {
+      records.push(...discoverTelemetryRecords(fullPath));
+    } else if (isTelemetryEntry(entry)) {
+      const record = readJson(fullPath);
+      if (record === null) {
+        throw new Error(`malformed telemetry record: ${fullPath} is empty`);
+      }
+      const error = validateTelemetryRecord(record);
+      if (error) {
+        throw new Error(`malformed telemetry record at ${fullPath}: ${error}`);
+      }
+      records.push(record);
+    }
+  }
+  return records;
+}
+
+/**
+ * Parse CLI args into { rootPath, format, outputPath }.
+ * @param {Array<string>} argv
+ * @returns {{rootPath?:string, format:string, outputPath?:string, help:boolean}}
+ */
+function parseArgs(argv) {
+  const result = { format: 'json', help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      result.help = true;
+    } else if (arg === '--format') {
+      const next = argv[i + 1];
+      if (next === 'json' || next === 'markdown') {
+        result.format = next;
+        i += 1;
+      } else {
+        throw new Error('--format requires a value of "json" or "markdown"');
+      }
+    } else if (arg === '--output') {
+      const next = argv[i + 1];
+      if (typeof next === 'string' && next.length > 0) {
+        result.outputPath = next;
+        i += 1;
+      } else {
+        throw new Error('--output requires a file path');
+      }
+    } else if (!arg.startsWith('--') && result.rootPath === undefined) {
+      result.rootPath = arg;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return result;
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'Usage: aggregate-ocr-telemetry.js <artifacts-root> [options]',
+      '',
+      'Options:',
+      '  --format <json|markdown>  Output format (default: json)',
+      '  --output <path>           Write formatted output to a file (default: stdout)',
+      '  -h, --help                Show this help',
+      '',
+    ].join('\n'),
+  );
+}
+
+function main() {
+  let parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (parseError) {
+    process.stderr.write(`${parseError.message}\n`);
+    printHelp();
+    process.exitCode = 2;
+    return;
+  }
+  if (parsed.help || !parsed.rootPath) {
+    printHelp();
+    process.exitCode = parsed.help ? 0 : 1;
+    return;
+  }
+  const records = discoverTelemetryRecords(parsed.rootPath);
+  const result = aggregateTelemetry(records);
+  const output =
+    parsed.format === 'markdown'
+      ? result.markdown
+      : `${JSON.stringify(result, null, 2)}\n`;
+  if (parsed.outputPath) {
+    writeFileSync(resolve(parsed.outputPath), output);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+if (
+  process.argv[1] &&
+  pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+) {
+  main();
+}

--- a/scripts/aggregate-ocr-telemetry.js
+++ b/scripts/aggregate-ocr-telemetry.js
@@ -110,7 +110,7 @@ export function aggregateTelemetry(records) {
       sorted.map((record) => record.total_findings),
     ),
     findings_available_runs: sorted.filter(
-      (record) => record.total_findings !== null,
+      (record) => typeof record.total_findings === 'number',
     ).length,
     findings_total_runs: sorted.length,
     categories,
@@ -244,7 +244,7 @@ function fileReadFailureRate(records) {
     return null;
   }
   const totalPreviewed = sumField(records, 'files_previewed');
-  if (totalPreviewed === 0) {
+  if (totalPreviewed === null || totalPreviewed === 0) {
     return null;
   }
   return sumField(records, 'file_read_failure_count') / totalPreviewed;
@@ -453,7 +453,11 @@ function parseArgs(argv) {
       }
     } else if (arg === '--output') {
       const next = argv[i + 1];
-      if (typeof next === 'string' && next.length > 0) {
+      if (
+        typeof next === 'string' &&
+        next.length > 0 &&
+        !next.startsWith('--')
+      ) {
         result.outputPath = next;
         i += 1;
       } else {

--- a/scripts/aggregate-ocr-telemetry.js
+++ b/scripts/aggregate-ocr-telemetry.js
@@ -375,12 +375,25 @@ function renderAggregationMarkdown(stats) {
 }
 
 function readJson(path) {
-  const content = readFileSync(path, 'utf8');
+  let content;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch (error) {
+    throw new Error(`unable to read telemetry record at ${path}`, {
+      cause: error,
+    });
+  }
   const trimmed = content.trim();
   if (trimmed.length === 0) {
     return null;
   }
-  return JSON.parse(trimmed);
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error(`malformed JSON in telemetry record at ${path}`, {
+      cause: error,
+    });
+  }
 }
 
 function isTelemetryEntry(entry) {
@@ -394,7 +407,14 @@ function isTelemetryEntry(entry) {
  * @returns {Array<object>}
  */
 export function discoverTelemetryRecords(rootPath) {
-  const entries = readdirSync(rootPath, { withFileTypes: true });
+  let entries;
+  try {
+    entries = readdirSync(rootPath, { withFileTypes: true });
+  } catch (error) {
+    throw new Error(`unable to discover telemetry records under ${rootPath}`, {
+      cause: error,
+    });
+  }
   const records = [];
   for (const entry of entries) {
     const fullPath = join(rootPath, entry.name);

--- a/scripts/aggregate-ocr-telemetry.js
+++ b/scripts/aggregate-ocr-telemetry.js
@@ -37,6 +37,8 @@ import {
 export { validateTelemetryRecord, isPlainObject };
 
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const DECIMAL_DIGITS_PATTERN = /^\d+$/;
+const LEADING_ZERO_PATTERN = /^0+(?=\d)/;
 
 /**
  * Compare two records for deterministic time-series ordering using a single
@@ -62,9 +64,9 @@ function compareByTime(a, b) {
 function numericStringCompare(a, b) {
   const left = String(a ?? '');
   const right = String(b ?? '');
-  if (/^\d+$/.test(left) && /^\d+$/.test(right)) {
-    const normalizedLeft = left.replace(/^0+(?=\d)/, '');
-    const normalizedRight = right.replace(/^0+(?=\d)/, '');
+  if (DECIMAL_DIGITS_PATTERN.test(left) && DECIMAL_DIGITS_PATTERN.test(right)) {
+    const normalizedLeft = left.replace(LEADING_ZERO_PATTERN, '');
+    const normalizedRight = right.replace(LEADING_ZERO_PATTERN, '');
     return (
       normalizedLeft.length - normalizedRight.length ||
       normalizedLeft.localeCompare(normalizedRight) ||
@@ -272,12 +274,12 @@ function findingsTrendEntry(record) {
   return entry;
 }
 
-function categoryTrendEntry(record) {
+function distributionTrendEntry(record, sourceField, outputField) {
   const entry = {
     run_id: record.run_id,
     run_attempt: record.run_attempt,
-    categories:
-      record.findings === null ? null : safeCopy(record.findings.by_category),
+    [outputField]:
+      record.findings === null ? null : safeCopy(record.findings[sourceField]),
   };
   if (typeof record.generated_at === 'string') {
     entry.generated_at = record.generated_at;
@@ -285,17 +287,12 @@ function categoryTrendEntry(record) {
   return entry;
 }
 
+function categoryTrendEntry(record) {
+  return distributionTrendEntry(record, 'by_category', 'categories');
+}
+
 function severityTrendEntry(record) {
-  const entry = {
-    run_id: record.run_id,
-    run_attempt: record.run_attempt,
-    severities:
-      record.findings === null ? null : safeCopy(record.findings.by_severity),
-  };
-  if (typeof record.generated_at === 'string') {
-    entry.generated_at = record.generated_at;
-  }
-  return entry;
+  return distributionTrendEntry(record, 'by_severity', 'severities');
 }
 
 function safeCopy(distribution) {

--- a/scripts/ocr-telemetry-io.js
+++ b/scripts/ocr-telemetry-io.js
@@ -8,6 +8,7 @@ import {
   appendFileSync,
   readFileSync,
   renameSync,
+  rmSync,
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
@@ -146,6 +147,20 @@ function copyWithRedactedStrings(value, secrets) {
   return copy;
 }
 
+let temporarySequence = 0;
+
+function atomicWriteFile(target, content, operation) {
+  temporarySequence += 1;
+  const temporary = `${target}.${operation}-${process.pid}-${temporarySequence}`;
+  try {
+    writeFileSync(temporary, content);
+    renameSync(temporary, target);
+  } catch (error) {
+    rmSync(temporary, { force: true });
+    throw error;
+  }
+}
+
 export function redactTelemetryFile(path, secrets) {
   const record = validateTelemetryFile(path);
   const usableSecrets = secrets.filter(
@@ -153,9 +168,7 @@ export function redactTelemetryFile(path, secrets) {
   );
   const redacted = copyWithRedactedStrings(record, usableSecrets);
   assertValid(redacted);
-  const temporary = `${path}.redacting-${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify(redacted, null, 2)}\n`);
-  renameSync(temporary, path);
+  atomicWriteFile(path, `${JSON.stringify(redacted, null, 2)}\n`, 'redacting');
 }
 
 export function writeTelemetryArtifacts(record, markdown, options = {}) {
@@ -163,9 +176,7 @@ export function writeTelemetryArtifacts(record, markdown, options = {}) {
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
   const target = join(cwd, 'ocr-telemetry.json');
-  const temporary = `${target}.tmp-${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify(record, null, 2)}\n`);
-  renameSync(temporary, target);
+  atomicWriteFile(target, `${JSON.stringify(record, null, 2)}\n`, 'writing');
   if (env.GITHUB_STEP_SUMMARY) {
     appendFileSync(env.GITHUB_STEP_SUMMARY, markdown);
   }

--- a/scripts/ocr-telemetry-io.js
+++ b/scripts/ocr-telemetry-io.js
@@ -153,7 +153,7 @@ function atomicWriteFile(target, content, operation) {
   temporarySequence += 1;
   const temporary = `${target}.${operation}-${process.pid}-${temporarySequence}`;
   try {
-    writeFileSync(temporary, content);
+    writeFileSync(temporary, content, { flag: 'wx' });
     renameSync(temporary, target);
   } catch (error) {
     rmSync(temporary, { force: true });

--- a/scripts/ocr-telemetry-io.js
+++ b/scripts/ocr-telemetry-io.js
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  appendFileSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+import { validateTelemetryRecord } from './ocr-telemetry-schema.js';
+
+function readJsonArtifact(path, label) {
+  try {
+    const raw = readFileSync(path, 'utf8');
+    if (raw.trim().length === 0) {
+      return { value: null, error: `${label} was empty` };
+    }
+    return { value: JSON.parse(raw), error: null };
+  } catch (error) {
+    const reason = error?.code === 'ENOENT' ? 'was unavailable' : 'was corrupt';
+    return { value: null, error: `${label} ${reason}` };
+  }
+}
+
+function parseCount(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function parseNumber(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) &&
+    parsed >= 0 &&
+    parsed <= Number.MAX_SAFE_INTEGER
+    ? parsed
+    : null;
+}
+
+function parseList(value) {
+  if (typeof value !== 'string') return null;
+  if (value.length === 0) return [];
+  return value
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export function loadTelemetryInput(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const metadata = readJsonArtifact(
+    join(cwd, 'ocr-metadata.json'),
+    'OCR metadata artifact',
+  );
+  const manifest = readJsonArtifact(
+    join(cwd, 'ocr-reviewed-range-manifest.json'),
+    'OCR reviewed-range manifest',
+  );
+  const routing = readJsonArtifact(
+    join(cwd, 'ocr-routing-decisions.json'),
+    'OCR routing decisions artifact',
+  );
+  const errors = [metadata.error, manifest.error, routing.error].filter(
+    Boolean,
+  );
+  return {
+    metadata: metadata.value,
+    manifest: manifest.value,
+    routingDecisions: Array.isArray(routing.value) ? routing.value : null,
+    errors,
+    context: {
+      runId: env.OCR_RUN_ID ?? null,
+      runAttempt: env.OCR_RUN_ATTEMPT ?? null,
+      prNumber: parseCount(env.OCR_PR_NUMBER),
+      sha: env.OCR_SHA || null,
+      generatedAt: env.OCR_GENERATED_AT || new Date().toISOString(),
+      infrastructureFailure: env.OCR_INFRASTRUCTURE_FAILURE === 'true',
+      policyFailure: env.OCR_POLICY_FAILURE === 'true',
+      inlinePosted: parseCount(env.OCR_INLINE_POSTED),
+      alreadyResolved: parseCount(env.OCR_ALREADY_RESOLVED),
+      alreadyPostedOrSkippedDedup: parseCount(
+        env.OCR_ALREADY_POSTED_OR_SKIPPED_DEDUP,
+      ),
+      commentsSkipped: parseCount(env.OCR_COMMENTS_SKIPPED),
+      commentsFailed: parseCount(env.OCR_COMMENTS_FAILED),
+      commentsRoutedSummary: parseCount(env.OCR_COMMENTS_ROUTED_SUMMARY),
+      commentsTotal: parseCount(env.OCR_COMMENTS_TOTAL),
+      wallClockSeconds: parseNumber(env.OCR_WALL_CLOCK_SECONDS),
+      filesReviewed: parseCount(env.OCR_FILES_REVIEWED),
+      fileReadFailures: parseList(env.OCR_FILE_READ_FAILURES),
+      perFileReviewFailures: parseList(env.OCR_PER_FILE_REVIEW_FAILURES),
+      previewAttempted: env.OCR_PREVIEW_ATTEMPTED === 'true',
+      previewSucceeded: env.OCR_PREVIEW_SUCCEEDED === 'true',
+      sourceRedactionState: env.OCR_SOURCE_REDACTION_STATE || null,
+      telemetryState: env.OCR_TELEMETRY_STATE || null,
+      postState: env.OCR_POST_STATE || null,
+      postOutcome: env.OCR_POST_OUTCOME || null,
+      artifactState: env.OCR_ARTIFACT_STATE || null,
+      hashState: env.OCR_HASH_STATE || null,
+    },
+  };
+}
+
+function assertValid(record) {
+  const schemaError = validateTelemetryRecord(record);
+  if (schemaError) throw new Error(`Invalid OCR telemetry: ${schemaError}`);
+}
+
+export function validateTelemetryFile(path) {
+  const raw = readFileSync(path, 'utf8');
+  if (raw.trim().length === 0) throw new Error('OCR telemetry file is empty');
+  const record = JSON.parse(raw);
+  assertValid(record);
+  return record;
+}
+
+function redactString(value, secrets) {
+  return secrets.reduce(
+    (redacted, secret) => redacted.replaceAll(secret, '[REDACTED]'),
+    value,
+  );
+}
+
+function copyWithRedactedStrings(value, secrets) {
+  if (typeof value === 'string') return redactString(value, secrets);
+  if (Array.isArray(value)) {
+    return value.map((entry) => copyWithRedactedStrings(entry, secrets));
+  }
+  if (value === null || typeof value !== 'object') return value;
+  const copy = Object.create(null);
+  for (const key of Reflect.ownKeys(value)) {
+    Object.defineProperty(copy, key, {
+      value: copyWithRedactedStrings(value[key], secrets),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return copy;
+}
+
+export function redactTelemetryFile(path, secrets) {
+  const record = validateTelemetryFile(path);
+  const usableSecrets = secrets.filter(
+    (secret) => typeof secret === 'string' && secret.length > 0,
+  );
+  const redacted = copyWithRedactedStrings(record, usableSecrets);
+  assertValid(redacted);
+  const temporary = `${path}.redacting-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(redacted, null, 2)}\n`);
+  renameSync(temporary, path);
+}
+
+export function writeTelemetryArtifacts(record, markdown, options = {}) {
+  assertValid(record);
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const target = join(cwd, 'ocr-telemetry.json');
+  const temporary = `${target}.tmp-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(record, null, 2)}\n`);
+  renameSync(temporary, target);
+  if (env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(env.GITHUB_STEP_SUMMARY, markdown);
+  }
+}

--- a/scripts/ocr-telemetry-schema.js
+++ b/scripts/ocr-telemetry-schema.js
@@ -392,8 +392,8 @@ function validateOptionalStructures(record) {
 
 function safeSum(distribution) {
   let total = 0;
-  for (const value of Object.values(distribution)) {
-    total += value;
+  for (const key of Reflect.ownKeys(distribution)) {
+    total += distribution[key];
     if (!Number.isSafeInteger(total)) return null;
   }
   return total;

--- a/scripts/ocr-telemetry-schema.js
+++ b/scripts/ocr-telemetry-schema.js
@@ -399,10 +399,6 @@ function safeSum(distribution) {
   return total;
 }
 
-function validateFailureReconciliation(record) {
-  return validateFailureLists(record);
-}
-
 function validateLifecycleReconciliation(record) {
   if (
     record.marker_state.infrastructure_failure !==
@@ -539,7 +535,7 @@ function validateCrossTotals(record) {
 
 export function validateReconciliation(record) {
   const basicError =
-    validateFailureReconciliation(record) ||
+    validateFailureLists(record) ||
     validateLifecycleReconciliation(record) ||
     validateCountReconciliation(record);
   if (basicError || record.total_findings === null) return basicError;

--- a/scripts/ocr-telemetry-schema.js
+++ b/scripts/ocr-telemetry-schema.js
@@ -103,8 +103,10 @@ function exactKeys(value, expected, name) {
     (key) => !Object.prototype.hasOwnProperty.call(value, key),
   );
   const unexpected = actual.filter((key) => !expected.includes(key));
-  if (missing.length > 0)
-    return `${name} is incomplete; missing ${missing.join(', ')}`;
+  if (missing.length > 0) {
+    const noun = missing.length === 1 ? 'field' : 'fields';
+    return `${name} is incomplete; missing ${noun}: ${missing.join(', ')}`;
+  }
   if (unexpected.length > 0) {
     return `${name} contains unknown fields: ${unexpected.join(', ')}`;
   }
@@ -153,7 +155,7 @@ function enumError(value, name, nullable = false) {
 function isCalendarExactIsoTimestamp(value) {
   if (typeof value !== 'string') return false;
   const match =
-    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|([+-])(\d{2}):(\d{2}))$/.exec(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|([+-])(\d{2}):?(\d{2}))$/.exec(
       value,
     );
   if (!match) return false;
@@ -215,6 +217,11 @@ function validateOcr(ocr) {
   );
 }
 
+const FAILURE_LIST_FIELDS = [
+  ['file_read_failures', 'file_read_failure_count'],
+  ['per_file_review_failures', 'per_file_review_failure_count'],
+];
+
 function validateFailureList(list, count, listName, countName) {
   if (list === null || count === null) {
     return list === null && count === null
@@ -229,6 +236,19 @@ function validateFailureList(list, count, listName, countName) {
   return list.length === count
     ? null
     : `${countName} must equal ${listName}.length`;
+}
+
+function validateFailureLists(record) {
+  for (const [listName, countName] of FAILURE_LIST_FIELDS) {
+    const error = validateFailureList(
+      record[listName],
+      record[countName],
+      listName,
+      countName,
+    );
+    if (error) return error;
+  }
+  return null;
 }
 
 function validateMetrics(record) {
@@ -253,20 +273,7 @@ function validateMetrics(record) {
     const error = nullableCountError(record[field], field);
     if (error) return error;
   }
-  return (
-    validateFailureList(
-      record.file_read_failures,
-      record.file_read_failure_count,
-      'file_read_failures',
-      'file_read_failure_count',
-    ) ||
-    validateFailureList(
-      record.per_file_review_failures,
-      record.per_file_review_failure_count,
-      'per_file_review_failures',
-      'per_file_review_failure_count',
-    )
-  );
+  return validateFailureLists(record);
 }
 
 function validateFindings(record) {
@@ -330,11 +337,10 @@ function validateTokens(tokens) {
       return `tokens.${field} must be a safe nonnegative integer`;
     }
   }
-  const expected =
-    tokens.input + tokens.output + tokens.cache_read + tokens.cache_write;
+  const expected = tokens.input + tokens.output;
   return Number.isSafeInteger(expected) && tokens.total === expected
     ? null
-    : 'tokens.total must equal input + output + cache_read + cache_write';
+    : 'tokens.total must equal input + output';
 }
 
 function validateLifecycle(record) {
@@ -394,20 +400,7 @@ function safeSum(distribution) {
 }
 
 function validateFailureReconciliation(record) {
-  return (
-    validateFailureList(
-      record.file_read_failures,
-      record.file_read_failure_count,
-      'file_read_failures',
-      'file_read_failure_count',
-    ) ||
-    validateFailureList(
-      record.per_file_review_failures,
-      record.per_file_review_failure_count,
-      'per_file_review_failures',
-      'per_file_review_failure_count',
-    )
-  );
+  return validateFailureLists(record);
 }
 
 function validateLifecycleReconciliation(record) {
@@ -505,6 +498,12 @@ function validateCrossTotals(record) {
   if (coverageError) return coverageError;
   const categorySum = safeSum(categories);
   const severitySum = safeSum(severities);
+  if (categorySum === null) {
+    return 'findings.by_category sum exceeds safe integer range';
+  }
+  if (severitySum === null) {
+    return 'findings.by_severity sum exceeds safe integer range';
+  }
   if (categorySum !== record.total_findings) {
     return `findings.by_category sum (${categorySum}) must equal total_findings (${record.total_findings})`;
   }
@@ -516,7 +515,11 @@ function validateCrossTotals(record) {
     severityKeys.map((key) => [key, 0]),
   );
   for (const category of Object.keys(categories)) {
-    if (safeSum(cross[category]) !== categories[category]) {
+    const crossCategorySum = safeSum(cross[category]);
+    if (crossCategorySum === null) {
+      return 'findings.by_category_severity sum exceeds safe integer range';
+    }
+    if (crossCategorySum !== categories[category]) {
       return `cross category ${category} must equal by_category`;
     }
     for (const severity of severityKeys) {

--- a/scripts/ocr-telemetry-schema.js
+++ b/scripts/ocr-telemetry-schema.js
@@ -1,0 +1,571 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const SCHEMA_VERSION = 1;
+export const SCHEMA_NAME = 'ocr-telemetry';
+
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const RECORD_KEYS = [
+  'schema',
+  'schema_name',
+  'run_id',
+  'run_attempt',
+  'pr_number',
+  'sha',
+  'generated_at',
+  'ocr',
+  'wall_clock_seconds',
+  'cli_elapsed_seconds',
+  'files_previewed',
+  'files_reviewed',
+  'file_read_failures',
+  'file_read_failure_count',
+  'per_file_review_failures',
+  'per_file_review_failure_count',
+  'total_findings',
+  'findings',
+  'inline_posted',
+  'already_resolved',
+  'already_posted_or_skipped_dedup',
+  'comments_skipped',
+  'comments_failed',
+  'comments_routed_summary',
+  'comments_total',
+  'infrastructure_failure',
+  'policy_failure',
+  'completeness',
+  'publication_state',
+  'reviewed_range_manifest',
+  'tokens',
+  'telemetry_state',
+  'post_state',
+  'artifact_state',
+  'hash_state',
+  'marker_state',
+  'errors',
+];
+
+const LIFECYCLE_VALUES = {
+  completeness: new Set(['complete', 'partial', 'failed']),
+  publication_state: new Set([
+    'complete',
+    'partial',
+    'ambiguous',
+    'failed',
+    'unavailable',
+  ]),
+  telemetry_state: new Set(['complete', 'degraded', 'failed']),
+  post_state: new Set([
+    'posted',
+    'partial',
+    'noop',
+    'failed',
+    'policy-failed',
+    'missing',
+  ]),
+  artifact_state: new Set(['prepared', 'failed']),
+  hash_state: new Set(['prepared', 'failed', 'unavailable']),
+};
+
+export function isFiniteNonnegativeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+export function isFiniteNonnegativeNumber(value) {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value <= Number.MAX_SAFE_INTEGER
+  );
+}
+
+export function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Reflect.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function exactKeys(value, expected, name) {
+  if (!isPlainObject(value)) {
+    return `${name} must be a plain object`;
+  }
+  const actual = Reflect.ownKeys(value);
+  if (!actual.every((key) => typeof key === 'string')) {
+    return `${name} must be a plain object`;
+  }
+  const missing = expected.filter(
+    (key) => !Object.prototype.hasOwnProperty.call(value, key),
+  );
+  const unexpected = actual.filter((key) => !expected.includes(key));
+  if (missing.length > 0)
+    return `${name} is incomplete; missing ${missing.join(', ')}`;
+  if (unexpected.length > 0) {
+    return `${name} contains unknown fields: ${unexpected.join(', ')}`;
+  }
+  return null;
+}
+
+export function isOwnNumericDistribution(value) {
+  if (!isPlainObject(value)) return false;
+  const keys = Reflect.ownKeys(value);
+  return keys.every(
+    (key) =>
+      typeof key === 'string' &&
+      !UNSAFE_KEYS.has(key) &&
+      isFiniteNonnegativeInteger(value[key]),
+  );
+}
+
+function isStringArray(value) {
+  return (
+    Array.isArray(value) &&
+    value.every((entry) => typeof entry === 'string' && entry.length > 0)
+  );
+}
+
+function nullableCountError(value, name) {
+  return value === null || isFiniteNonnegativeInteger(value)
+    ? null
+    : `${name} must be a safe nonnegative integer or null`;
+}
+
+function nullableStringError(value, name) {
+  return value === null || (typeof value === 'string' && value.length > 0)
+    ? null
+    : `${name} must be a nonempty string or null`;
+}
+
+function enumError(value, name, nullable = false) {
+  if (nullable && value === null) return null;
+  if (typeof value === 'string' && LIFECYCLE_VALUES[name].has(value)) {
+    return null;
+  }
+  const nullableSuffix = nullable ? ', or null' : '';
+  return `${name} must be one of ${[...LIFECYCLE_VALUES[name]].join(', ')}${nullableSuffix}`;
+}
+
+function isCalendarExactIsoTimestamp(value) {
+  if (typeof value !== 'string') return false;
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|([+-])(\d{2}):(\d{2}))$/.exec(
+      value,
+    );
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = Number(match[10] ?? 0);
+  const offsetMinute = Number(match[11] ?? 0);
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const februaryDays = leap ? 29 : 28;
+  const days = [31, februaryDays, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (month < 1 || month > 12) return false;
+  if (day < 1 || day > days[month - 1]) return false;
+  if (hour > 23 || minute > 59 || second > 59) return false;
+  if (offsetHour > 23 || offsetMinute > 59) return false;
+  return Number.isFinite(Date.parse(value));
+}
+
+function validateIdentity(record) {
+  if (record.schema !== SCHEMA_VERSION)
+    return `schema must be ${SCHEMA_VERSION}`;
+  if (record.schema_name !== SCHEMA_NAME) {
+    return `schema_name must be "${SCHEMA_NAME}"`;
+  }
+  const runIdError = nullableStringError(record.run_id, 'run_id');
+  if (runIdError) return runIdError;
+  if (
+    record.run_attempt !== null &&
+    (typeof record.run_attempt !== 'string' ||
+      !/^[1-9]\d*$/.test(record.run_attempt) ||
+      !Number.isSafeInteger(Number(record.run_attempt)))
+  ) {
+    return 'run_attempt must be a positive safe integer string or null';
+  }
+  if (
+    record.pr_number !== null &&
+    (!isFiniteNonnegativeInteger(record.pr_number) || record.pr_number === 0)
+  ) {
+    return 'pr_number must be a positive safe integer or null';
+  }
+  if (record.sha !== null && !/^[0-9a-f]{40}$/.test(record.sha)) {
+    return 'sha must be a 40-char lowercase hex string or null';
+  }
+  return isCalendarExactIsoTimestamp(record.generated_at)
+    ? null
+    : 'generated_at must be a calendar-valid ISO-8601 timestamp';
+}
+
+function validateOcr(ocr) {
+  const shapeError = exactKeys(ocr, ['version', 'model', 'concurrency'], 'ocr');
+  if (shapeError) return shapeError;
+  return (
+    nullableStringError(ocr.version, 'ocr.version') ||
+    nullableStringError(ocr.model, 'ocr.model') ||
+    nullableCountError(ocr.concurrency, 'ocr.concurrency')
+  );
+}
+
+function validateFailureList(list, count, listName, countName) {
+  if (list === null || count === null) {
+    return list === null && count === null
+      ? null
+      : `${listName} and ${countName} must both be null when unavailable`;
+  }
+  if (!isStringArray(list))
+    return `${listName} must be an array of nonempty strings or null`;
+  if (!isFiniteNonnegativeInteger(count)) {
+    return `${countName} must be a safe nonnegative integer or null`;
+  }
+  return list.length === count
+    ? null
+    : `${countName} must equal ${listName}.length`;
+}
+
+function validateMetrics(record) {
+  const ocrError = validateOcr(record.ocr);
+  if (ocrError) return ocrError;
+  for (const field of ['wall_clock_seconds', 'cli_elapsed_seconds']) {
+    if (record[field] !== null && !isFiniteNonnegativeNumber(record[field])) {
+      return `${field} must be a safe finite nonnegative number or null`;
+    }
+  }
+  for (const field of [
+    'files_previewed',
+    'files_reviewed',
+    'inline_posted',
+    'already_resolved',
+    'already_posted_or_skipped_dedup',
+    'comments_skipped',
+    'comments_failed',
+    'comments_routed_summary',
+    'comments_total',
+  ]) {
+    const error = nullableCountError(record[field], field);
+    if (error) return error;
+  }
+  return (
+    validateFailureList(
+      record.file_read_failures,
+      record.file_read_failure_count,
+      'file_read_failures',
+      'file_read_failure_count',
+    ) ||
+    validateFailureList(
+      record.per_file_review_failures,
+      record.per_file_review_failure_count,
+      'per_file_review_failures',
+      'per_file_review_failure_count',
+    )
+  );
+}
+
+function validateFindings(record) {
+  if (record.total_findings === null || record.findings === null) {
+    return record.total_findings === null && record.findings === null
+      ? null
+      : 'total_findings and findings must both be null when unavailable';
+  }
+  if (!isFiniteNonnegativeInteger(record.total_findings)) {
+    return 'total_findings must be a safe nonnegative integer or null';
+  }
+  const shapeError = exactKeys(
+    record.findings,
+    ['by_category', 'by_severity', 'by_category_severity'],
+    'findings',
+  );
+  if (shapeError) return shapeError;
+  if (!isOwnNumericDistribution(record.findings.by_category)) {
+    return 'findings.by_category must be a safe own-key integer distribution';
+  }
+  if (!isOwnNumericDistribution(record.findings.by_severity)) {
+    return 'findings.by_severity must be a safe own-key integer distribution';
+  }
+  if (!isPlainObject(record.findings.by_category_severity)) {
+    return 'findings.by_category_severity must be a plain object';
+  }
+  for (const [category, severities] of Object.entries(
+    record.findings.by_category_severity,
+  )) {
+    if (UNSAFE_KEYS.has(category) || !isOwnNumericDistribution(severities)) {
+      return 'findings.by_category_severity must be a safe own-key nested distribution';
+    }
+  }
+  return null;
+}
+
+function validateManifest(manifest) {
+  const shapeError = exactKeys(
+    manifest,
+    ['selected_files', 'completed_files', 'failed_files'],
+    'reviewed_range_manifest',
+  );
+  if (shapeError) return shapeError;
+  for (const field of ['selected_files', 'completed_files', 'failed_files']) {
+    if (!isFiniteNonnegativeInteger(manifest[field])) {
+      return `reviewed_range_manifest.${field} must be a safe nonnegative integer`;
+    }
+  }
+  return manifest.completed_files + manifest.failed_files <=
+    manifest.selected_files
+    ? null
+    : 'reviewed_range_manifest completed_files + failed_files must not exceed selected_files';
+}
+
+function validateTokens(tokens) {
+  const fields = ['input', 'output', 'cache_read', 'cache_write', 'total'];
+  const shapeError = exactKeys(tokens, fields, 'tokens');
+  if (shapeError) return shapeError;
+  for (const field of fields) {
+    if (!isFiniteNonnegativeInteger(tokens[field])) {
+      return `tokens.${field} must be a safe nonnegative integer`;
+    }
+  }
+  const expected =
+    tokens.input + tokens.output + tokens.cache_read + tokens.cache_write;
+  return Number.isSafeInteger(expected) && tokens.total === expected
+    ? null
+    : 'tokens.total must equal input + output + cache_read + cache_write';
+}
+
+function validateLifecycle(record) {
+  if (typeof record.infrastructure_failure !== 'boolean') {
+    return 'infrastructure_failure must be a boolean';
+  }
+  if (typeof record.policy_failure !== 'boolean') {
+    return 'policy_failure must be a boolean';
+  }
+  for (const [field, nullable] of [
+    ['completeness', true],
+    ['publication_state', true],
+    ['telemetry_state', false],
+    ['post_state', true],
+    ['artifact_state', false],
+    ['hash_state', false],
+  ]) {
+    const error = enumError(record[field], field, nullable);
+    if (error) return error;
+  }
+  const markerError = exactKeys(
+    record.marker_state,
+    ['infrastructure_failure', 'policy_failure'],
+    'marker_state',
+  );
+  if (markerError) return markerError;
+  return typeof record.marker_state.infrastructure_failure === 'boolean' &&
+    typeof record.marker_state.policy_failure === 'boolean'
+    ? null
+    : 'marker_state values must be booleans';
+}
+
+function validateOptionalStructures(record) {
+  if (record.reviewed_range_manifest !== null) {
+    const error = validateManifest(record.reviewed_range_manifest);
+    if (error) return error;
+  }
+  if (record.tokens !== null) {
+    const error = validateTokens(record.tokens);
+    if (error) return error;
+  }
+  return Array.isArray(record.errors) &&
+    record.errors.every(
+      (entry) => typeof entry === 'string' && entry.length > 0,
+    )
+    ? null
+    : 'errors must be an array of nonempty strings';
+}
+
+function safeSum(distribution) {
+  let total = 0;
+  for (const value of Object.values(distribution)) {
+    total += value;
+    if (!Number.isSafeInteger(total)) return null;
+  }
+  return total;
+}
+
+function validateFailureReconciliation(record) {
+  return (
+    validateFailureList(
+      record.file_read_failures,
+      record.file_read_failure_count,
+      'file_read_failures',
+      'file_read_failure_count',
+    ) ||
+    validateFailureList(
+      record.per_file_review_failures,
+      record.per_file_review_failure_count,
+      'per_file_review_failures',
+      'per_file_review_failure_count',
+    )
+  );
+}
+
+function validateLifecycleReconciliation(record) {
+  if (
+    record.marker_state.infrastructure_failure !==
+      record.infrastructure_failure ||
+    record.marker_state.policy_failure !== record.policy_failure
+  ) {
+    return 'marker_state must match final failure classifications';
+  }
+  if (
+    record.errors.length > 0 &&
+    (!record.infrastructure_failure || record.telemetry_state === 'complete')
+  ) {
+    return 'errors require infrastructure_failure and degraded/failed telemetry_state';
+  }
+  if (record.infrastructure_failure && record.telemetry_state === 'complete') {
+    return 'infrastructure_failure cannot have complete telemetry_state';
+  }
+  const hasFailedState =
+    ['failed', 'policy-failed'].includes(record.post_state) ||
+    record.artifact_state === 'failed' ||
+    record.hash_state === 'failed';
+  if (hasFailedState && !record.infrastructure_failure) {
+    return 'failed post_state/artifact_state/hash_state requires infrastructure_failure';
+  }
+  return null;
+}
+
+function validateCountReconciliation(record) {
+  if (
+    record.reviewed_range_manifest !== null &&
+    record.files_previewed !== null &&
+    record.files_previewed !== record.reviewed_range_manifest.selected_files
+  ) {
+    return 'files_previewed must equal reviewed_range_manifest.selected_files';
+  }
+  for (const field of [
+    'files_reviewed',
+    'file_read_failure_count',
+    'per_file_review_failure_count',
+  ]) {
+    if (
+      record.files_previewed !== null &&
+      record[field] !== null &&
+      record[field] > record.files_previewed
+    ) {
+      return `${field} must not exceed files_previewed`;
+    }
+  }
+  if (record.comments_total === null) return null;
+  for (const field of [
+    'inline_posted',
+    'already_resolved',
+    'already_posted_or_skipped_dedup',
+    'comments_skipped',
+    'comments_failed',
+    'comments_routed_summary',
+  ]) {
+    if (record[field] !== null && record[field] > record.comments_total) {
+      return `${field} must not exceed comments_total`;
+    }
+  }
+  return null;
+}
+
+function equalKeyArrays(left, right) {
+  return (
+    left.length === right.length &&
+    left.every((key, index) => key === right[index])
+  );
+}
+
+function validateCrossCoverage(categories, severities, cross) {
+  const categoryKeys = Object.keys(categories).sort();
+  const severityKeys = Object.keys(severities).sort();
+  if (!equalKeyArrays(categoryKeys, Object.keys(cross).sort())) {
+    return 'cross category coverage must exactly match findings.by_category';
+  }
+  for (const category of categoryKeys) {
+    if (!equalKeyArrays(severityKeys, Object.keys(cross[category]).sort())) {
+      return `cross severity ${category} must exactly match findings.by_severity`;
+    }
+  }
+  return null;
+}
+
+function validateCrossTotals(record) {
+  const {
+    by_category: categories,
+    by_severity: severities,
+    by_category_severity: cross,
+  } = record.findings;
+  const coverageError = validateCrossCoverage(categories, severities, cross);
+  if (coverageError) return coverageError;
+  const categorySum = safeSum(categories);
+  const severitySum = safeSum(severities);
+  if (categorySum !== record.total_findings) {
+    return `findings.by_category sum (${categorySum}) must equal total_findings (${record.total_findings})`;
+  }
+  if (severitySum !== record.total_findings) {
+    return `findings.by_severity sum (${severitySum}) must equal total_findings (${record.total_findings})`;
+  }
+  const severityKeys = Object.keys(severities);
+  const severityCrossTotals = Object.fromEntries(
+    severityKeys.map((key) => [key, 0]),
+  );
+  for (const category of Object.keys(categories)) {
+    if (safeSum(cross[category]) !== categories[category]) {
+      return `cross category ${category} must equal by_category`;
+    }
+    for (const severity of severityKeys) {
+      severityCrossTotals[severity] += cross[category][severity];
+      if (!Number.isSafeInteger(severityCrossTotals[severity])) {
+        return 'findings.by_category_severity sum exceeds safe integer range';
+      }
+    }
+  }
+  for (const severity of severityKeys) {
+    if (severityCrossTotals[severity] !== severities[severity]) {
+      return `cross severity ${severity} must equal by_severity`;
+    }
+  }
+  return null;
+}
+
+export function validateReconciliation(record) {
+  const basicError =
+    validateFailureReconciliation(record) ||
+    validateLifecycleReconciliation(record) ||
+    validateCountReconciliation(record);
+  if (basicError || record.total_findings === null) return basicError;
+  return validateCrossTotals(record);
+}
+
+export function validateTelemetryRecord(record) {
+  if (
+    isPlainObject(record) &&
+    Object.keys(record).some((key) => UNSAFE_KEYS.has(key))
+  ) {
+    return 'record must not contain unsafe __proto__/constructor/prototype keys';
+  }
+  const shapeError = exactKeys(record, RECORD_KEYS, 'record');
+  if (shapeError) return shapeError;
+  for (const validator of [
+    validateIdentity,
+    validateMetrics,
+    validateFindings,
+    validateLifecycle,
+    validateOptionalStructures,
+  ]) {
+    const error = validator(record);
+    if (error) return error;
+  }
+  return validateReconciliation(record);
+}
+
+export function sumDistribution(distribution) {
+  if (!isOwnNumericDistribution(distribution)) return 0;
+  return safeSum(distribution) ?? 0;
+}

--- a/scripts/ocr-telemetry.js
+++ b/scripts/ocr-telemetry.js
@@ -1,0 +1,528 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import process from 'node:process';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  SCHEMA_NAME,
+  SCHEMA_VERSION,
+  isPlainObject,
+  validateTelemetryRecord,
+} from './ocr-telemetry-schema.js';
+import {
+  loadTelemetryInput,
+  redactTelemetryFile,
+  validateTelemetryFile,
+  writeTelemetryArtifacts,
+} from './ocr-telemetry-io.js';
+
+const ELAPSED_UNIT_SECONDS = new Map([
+  ['h', 3600],
+  ['m', 60],
+  ['s', 1],
+  ['ms', 0.001],
+]);
+const ELAPSED_ORDER = new Map([
+  ['h', 0],
+  ['m', 1],
+  ['s', 2],
+  ['ms', 3],
+]);
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function elapsedToSeconds(elapsed) {
+  if (
+    typeof elapsed !== 'string' ||
+    elapsed.length === 0 ||
+    /\s/.test(elapsed)
+  ) {
+    return null;
+  }
+  let cursor = 0;
+  let previousOrder = -1;
+  let total = 0;
+  while (cursor < elapsed.length) {
+    const token = /^(\d+(?:\.\d+)?)(ms|h|m|s)/.exec(elapsed.slice(cursor));
+    if (!token) return null;
+    const order = ELAPSED_ORDER.get(token[2]);
+    if (order === undefined || order <= previousOrder) return null;
+    const value = Number(token[1]);
+    if (!Number.isFinite(value)) return null;
+    total += value * ELAPSED_UNIT_SECONDS.get(token[2]);
+    if (!Number.isFinite(total) || total > Number.MAX_SAFE_INTEGER) return null;
+    previousOrder = order;
+    cursor += token[0].length;
+  }
+  return total;
+}
+
+function validDistributionKey(value) {
+  return (
+    typeof value === 'string' && value.length > 0 && !UNSAFE_KEYS.has(value)
+  );
+}
+
+function validDecision(decision) {
+  if (!isPlainObject(decision)) return false;
+  return (
+    validDistributionKey(decision.category) &&
+    validDistributionKey(decision.severity)
+  );
+}
+
+export function crossDistribution(decisions) {
+  if (!Array.isArray(decisions) || !decisions.every(validDecision)) {
+    throw new Error(
+      'routing decisions must be plain objects with category/severity strings',
+    );
+  }
+  const categories = [
+    ...new Set(decisions.map((decision) => decision.category)),
+  ];
+  const severities = [
+    ...new Set(decisions.map((decision) => decision.severity)),
+  ];
+  const cross = Object.create(null);
+  for (const category of categories) {
+    cross[category] = Object.create(null);
+    for (const severity of severities) cross[category][severity] = 0;
+  }
+  for (const decision of decisions) {
+    cross[decision.category][decision.severity] += 1;
+  }
+  return cross;
+}
+
+export function byCategory(cross) {
+  const counts = Object.create(null);
+  for (const [category, severities] of Object.entries(cross)) {
+    counts[category] = Object.values(severities).reduce(
+      (sum, count) => sum + count,
+      0,
+    );
+  }
+  return counts;
+}
+
+export function bySeverity(cross) {
+  const severities = new Set(
+    Object.values(cross).flatMap((row) => Object.keys(row)),
+  );
+  const counts = Object.create(null);
+  for (const severity of severities) {
+    counts[severity] = Object.values(cross).reduce(
+      (sum, row) => sum + row[severity],
+      0,
+    );
+  }
+  return counts;
+}
+
+function nullableString(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return value;
+}
+
+function nullableCount(value) {
+  if (!Number.isSafeInteger(value) || value < 0) return null;
+  return value;
+}
+
+function nullableNumber(value) {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < 0 ||
+    value > Number.MAX_SAFE_INTEGER
+  ) {
+    return null;
+  }
+  return value;
+}
+
+function stringList(value) {
+  if (!Array.isArray(value)) return null;
+  if (!value.every((entry) => typeof entry === 'string' && entry.length > 0)) {
+    return null;
+  }
+  return value;
+}
+
+function listCount(value) {
+  const list = stringList(value);
+  return list === null ? null : list.length;
+}
+
+export function normalizeTokens(tokens) {
+  if (!isPlainObject(tokens)) return null;
+  const fields = ['input', 'output', 'cache_read', 'cache_write', 'total'];
+  const normalized = Object.fromEntries(
+    fields.map((field) => [field, nullableCount(tokens[field])]),
+  );
+  return Object.values(normalized).some((value) => value === null)
+    ? null
+    : normalized;
+}
+
+function normalizeRunAttempt(value) {
+  const text = nullableString(value);
+  return text && /^[1-9]\d*$/.test(text) && Number.isSafeInteger(Number(text))
+    ? text
+    : null;
+}
+
+function normalizeTimestamp(value) {
+  if (typeof value !== 'string') return new Date().toISOString();
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.valueOf())
+    ? parsed.toISOString()
+    : new Date().toISOString();
+}
+
+function terminalValue(primary, secondary) {
+  return nullableString(primary) ?? nullableString(secondary);
+}
+
+function artifactErrors(input) {
+  const errors = Array.isArray(input.errors) ? [...input.errors] : [];
+  if (!isPlainObject(input.metadata))
+    errors.push('OCR metadata artifact was unavailable');
+  if (!isPlainObject(input.manifest)) {
+    errors.push('OCR reviewed-range manifest was unavailable');
+  }
+  if (!Array.isArray(input.routingDecisions)) {
+    errors.push('OCR routing decisions artifact was unavailable');
+  } else if (!input.routingDecisions.every(validDecision)) {
+    errors.push('OCR routing decisions artifact was malformed');
+  }
+  const context = isPlainObject(input.context) ? input.context : {};
+  if (context.previewAttempted === true && context.previewSucceeded !== true) {
+    errors.push('OCR preview did not complete successfully');
+  }
+  if (nullableString(context.postOutcome) !== 'success') {
+    errors.push('Post OCR results step did not succeed');
+  }
+  if (
+    nullableString(context.postState) === 'failed' &&
+    (nullableCount(context.inlinePosted) === null ||
+      nullableCount(context.commentsTotal) === null)
+  ) {
+    errors.push('Post OCR results outputs were unavailable');
+  }
+  if (nullableString(context.sourceRedactionState) === 'failed') {
+    errors.push('OCR source artifact redaction failed');
+  }
+  if (nullableString(context.hashState) === 'failed') {
+    errors.push('OCR manifest hash preparation failed');
+  }
+  return [...new Set(errors)];
+}
+
+function ocrValues(metadata) {
+  const ocr = isPlainObject(metadata?.ocr) ? metadata.ocr : {};
+  return {
+    version: nullableString(ocr.version),
+    model: nullableString(ocr.model),
+    concurrency: nullableCount(ocr.concurrency),
+  };
+}
+
+function manifestValues(manifest) {
+  if (!isPlainObject(manifest)) return null;
+  const selectedFiles = listCount(manifest.selected_files);
+  const completedFiles = listCount(manifest.completed_files);
+  const failedFiles = listCount(manifest.failed_files);
+  if ([selectedFiles, completedFiles, failedFiles].includes(null)) return null;
+  return {
+    selected_files: selectedFiles,
+    completed_files: completedFiles,
+    failed_files: failedFiles,
+  };
+}
+
+function findingValues(routingDecisions) {
+  if (
+    !Array.isArray(routingDecisions) ||
+    !routingDecisions.every(validDecision)
+  ) {
+    return { total: null, distributions: null };
+  }
+  const cross = crossDistribution(routingDecisions);
+  return {
+    total: routingDecisions.length,
+    distributions: {
+      by_category: byCategory(cross),
+      by_severity: bySeverity(cross),
+      by_category_severity: cross,
+    },
+  };
+}
+
+function failureList(value) {
+  const list = stringList(value);
+  return { list, count: list === null ? null : list.length };
+}
+
+function resolveTelemetryState(context, errors, infrastructureFailure) {
+  const requested = nullableString(context.telemetryState);
+  if (errors.length > 0) return requested === 'failed' ? 'failed' : 'degraded';
+  if (requested !== null) return requested;
+  return infrastructureFailure ? 'degraded' : 'complete';
+}
+
+function resolveFilesEvidence(context, manifestSummary, errors) {
+  let filesPreviewed = null;
+  if (context.previewSucceeded === true) {
+    filesPreviewed = manifestSummary?.selected_files ?? null;
+  }
+  const candidate = nullableCount(context.filesReviewed);
+  if (
+    filesPreviewed !== null &&
+    candidate !== null &&
+    candidate > filesPreviewed
+  ) {
+    errors.push('OCR files_reviewed exceeded the successful preview scope');
+    return { filesPreviewed, filesReviewed: null };
+  }
+  return { filesPreviewed, filesReviewed: candidate };
+}
+
+function identityFields(context) {
+  const parsedPrNumber = nullableCount(context.prNumber);
+  return {
+    run_id: nullableString(context.runId),
+    run_attempt: normalizeRunAttempt(context.runAttempt),
+    pr_number:
+      parsedPrNumber !== null && parsedPrNumber > 0 ? parsedPrNumber : null,
+    sha: nullableString(context.sha),
+    generated_at: normalizeTimestamp(context.generatedAt),
+  };
+}
+
+function lifecycleFailed(context, errors, postState, artifactState, hashState) {
+  if (errors.length > 0 || Boolean(context.infrastructureFailure)) return true;
+  if (['failed', 'policy-failed', 'missing'].includes(postState)) return true;
+  return artifactState === 'failed' || hashState === 'failed';
+}
+
+function publicationFields(context) {
+  return {
+    inline_posted: nullableCount(context.inlinePosted),
+    already_resolved: nullableCount(context.alreadyResolved),
+    already_posted_or_skipped_dedup: nullableCount(
+      context.alreadyPostedOrSkippedDedup,
+    ),
+    comments_skipped: nullableCount(context.commentsSkipped),
+    comments_failed: nullableCount(context.commentsFailed),
+    comments_routed_summary: nullableCount(context.commentsRoutedSummary),
+    comments_total: nullableCount(context.commentsTotal),
+  };
+}
+
+function buildRecord(input) {
+  const metadata = isPlainObject(input.metadata) ? input.metadata : null;
+  const manifest = isPlainObject(input.manifest) ? input.manifest : null;
+  const context = isPlainObject(input.context) ? input.context : {};
+  const errors = artifactErrors(input);
+  const manifestSummary = manifestValues(manifest);
+  const findings = findingValues(input.routingDecisions);
+  const readFailures = failureList(context.fileReadFailures);
+  const reviewFailures = failureList(context.perFileReviewFailures);
+  const postState = nullableString(context.postState) ?? 'missing';
+  const hashState = nullableString(context.hashState) ?? 'unavailable';
+  const artifactState = nullableString(context.artifactState) ?? 'failed';
+  const files = resolveFilesEvidence(context, manifestSummary, errors);
+  const infrastructureFailure = lifecycleFailed(
+    context,
+    errors,
+    postState,
+    artifactState,
+    hashState,
+  );
+  const telemetryState = resolveTelemetryState(
+    context,
+    errors,
+    infrastructureFailure,
+  );
+  return {
+    schema: SCHEMA_VERSION,
+    schema_name: SCHEMA_NAME,
+    ...identityFields(context),
+    ocr: ocrValues(metadata),
+    wall_clock_seconds: nullableNumber(context.wallClockSeconds),
+    cli_elapsed_seconds: elapsedToSeconds(metadata?.ocr?.elapsed),
+    files_previewed: files.filesPreviewed,
+    files_reviewed: files.filesReviewed,
+    file_read_failures: readFailures.list,
+    file_read_failure_count: readFailures.count,
+    per_file_review_failures: reviewFailures.list,
+    per_file_review_failure_count: reviewFailures.count,
+    total_findings: findings.total,
+    findings: findings.distributions,
+    ...publicationFields(context),
+    infrastructure_failure: infrastructureFailure,
+    policy_failure: Boolean(context.policyFailure),
+    completeness: terminalValue(
+      manifest?.completeness,
+      metadata?.terminal?.completeness_state,
+    ),
+    publication_state: terminalValue(
+      null,
+      metadata?.terminal?.publication_state,
+    ),
+    reviewed_range_manifest: manifestSummary,
+    tokens: normalizeTokens(metadata?.ocr?.tokens),
+    telemetry_state: telemetryState,
+    post_state: postState,
+    artifact_state: artifactState,
+    hash_state: hashState,
+    marker_state: {
+      infrastructure_failure: infrastructureFailure,
+      policy_failure: Boolean(context.policyFailure),
+    },
+    errors,
+  };
+}
+
+export function validateTelemetryInput(input) {
+  if (!isPlainObject(input)) return 'telemetry input must be a plain object';
+  if (!isPlainObject(input.metadata)) return 'metadata must be an object';
+  if (!isPlainObject(input.metadata.ocr)) return 'metadata.ocr is required';
+  if (!isPlainObject(input.manifest)) return 'manifest must be an object';
+  if (!Array.isArray(input.routingDecisions))
+    return 'routingDecisions must be an array';
+  if (!input.routingDecisions.every(validDecision)) {
+    return 'routingDecisions entries must be plain objects with category/severity strings';
+  }
+  if (!isPlainObject(input.context)) return 'context must be an object';
+  if (!nullableString(input.context.runId)) return 'context.run_id is required';
+  if (!nullableCount(input.context.prNumber) || input.context.prNumber <= 0) {
+    return 'context.pr_number must be a positive integer';
+  }
+  return null;
+}
+
+export function buildTelemetry(input) {
+  const inputError = validateTelemetryInput(input);
+  if (inputError) throw new Error(`Invalid telemetry input: ${inputError}`);
+  const record = buildRecord(input);
+  const validationError = validateTelemetryRecord(record);
+  if (validationError)
+    throw new Error(`Invalid telemetry record: ${validationError}`);
+  return record;
+}
+
+export function buildGuaranteedTelemetry(input, options = {}) {
+  const source = isPlainObject(input) ? input : {};
+  const extraErrors =
+    options.error === undefined
+      ? []
+      : [String(options.error?.message ?? options.error)];
+  const record = buildRecord({
+    ...source,
+    errors: [
+      ...(Array.isArray(source.errors) ? source.errors : []),
+      ...extraErrors,
+    ],
+  });
+  const validationError = validateTelemetryRecord(record);
+  if (validationError) {
+    throw new Error(`Guaranteed telemetry is invalid: ${validationError}`);
+  }
+  return record;
+}
+
+function display(value) {
+  return value === null ? 'n/a' : String(value);
+}
+
+function distributionText(distribution) {
+  return distribution
+    ? Object.entries(distribution)
+        .map(([name, count]) => `${name}: ${count}`)
+        .join(', ') || 'none'
+    : 'n/a';
+}
+
+function crossText(findings) {
+  if (!findings) return 'n/a';
+  return Object.entries(findings.by_category_severity)
+    .flatMap(([category, severities]) =>
+      Object.entries(severities).map(
+        ([severity, count]) => `${category}×${severity}: ${count}`,
+      ),
+    )
+    .join(', ');
+}
+
+export function renderTelemetryMarkdown(telemetry) {
+  const tokenText = telemetry.tokens
+    ? `${telemetry.tokens.total} total (${telemetry.tokens.input} input, ${telemetry.tokens.output} output, ${telemetry.tokens.cache_read} cache read, ${telemetry.tokens.cache_write} cache write)`
+    : 'n/a';
+  return [
+    '## OCR Telemetry',
+    '',
+    `PR #${display(telemetry.pr_number)} · run \`${display(telemetry.run_id)}\` · sha \`${telemetry.sha?.slice(0, 8) ?? 'n/a'}\``,
+    '',
+    '| metric | value |',
+    '| --- | --- |',
+    `| total findings | ${display(telemetry.total_findings)} |`,
+    `| files previewed / reviewed | ${display(telemetry.files_previewed)} / ${display(telemetry.files_reviewed)} |`,
+    `| file-read / per-file failures | ${display(telemetry.file_read_failure_count)} / ${display(telemetry.per_file_review_failure_count)} |`,
+    `| publication inline / summary / skipped / failed / total | ${display(telemetry.inline_posted)} / ${display(telemetry.comments_routed_summary)} / ${display(telemetry.comments_skipped)} / ${display(telemetry.comments_failed)} / ${display(telemetry.comments_total)} |`,
+    `| publication state | ${display(telemetry.publication_state)} |`,
+    `| tokens | ${tokenText} |`,
+    `| wall-clock / CLI elapsed (s) | ${display(telemetry.wall_clock_seconds)} / ${display(telemetry.cli_elapsed_seconds)} |`,
+    `| lifecycle telemetry / post / artifact / hash | ${telemetry.telemetry_state} / ${display(telemetry.post_state)} / ${telemetry.artifact_state} / ${telemetry.hash_state} |`,
+    `| infrastructure / policy failure | ${telemetry.infrastructure_failure} / ${telemetry.policy_failure} |`,
+    `| unavailable/error count | ${telemetry.errors.length} |`,
+    '',
+    `categories — ${distributionText(telemetry.findings?.by_category)}`,
+    `severities — ${distributionText(telemetry.findings?.by_severity)}`,
+    `category×severity — ${crossText(telemetry.findings)}`,
+    '',
+  ].join('\n');
+}
+
+function main() {
+  const [command, value] = process.argv.slice(2);
+  if (command === '--validate') {
+    validateTelemetryFile(resolve(value ?? 'ocr-telemetry.json'));
+    return;
+  }
+  if (command === '--redact') {
+    redactTelemetryFile(resolve(value ?? 'ocr-telemetry.json'), [
+      process.env.OCR_LLM_TOKEN,
+      process.env.OCR_LLM_URL,
+    ]);
+    return;
+  }
+  const input = loadTelemetryInput();
+  if (command === '--failure') {
+    input.errors.push(value || 'Telemetry production failed');
+    input.context.infrastructureFailure = true;
+    input.context.telemetryState = 'failed';
+  } else if (command !== undefined) {
+    throw new Error(`Unknown argument: ${command}`);
+  }
+  const telemetry = buildGuaranteedTelemetry(input);
+  writeTelemetryArtifacts(telemetry, renderTelemetryMarkdown(telemetry));
+}
+
+if (
+  process.argv[1] &&
+  pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+export { validateTelemetryRecord };

--- a/scripts/ocr-telemetry.js
+++ b/scripts/ocr-telemetry.js
@@ -418,26 +418,62 @@ export function buildTelemetry(input) {
 
 export function buildGuaranteedTelemetry(input, options = {}) {
   const source = isPlainObject(input) ? input : {};
-  const extraErrors =
+  const context = isPlainObject(source.context) ? source.context : {};
+  const sourceErrors = Array.isArray(source.errors) ? source.errors : [];
+  const optionErrors =
     options.error === undefined
       ? []
       : [String(options.error?.message ?? options.error)];
-  const record = buildRecord({
-    ...source,
-    errors: [
-      ...(Array.isArray(source.errors) ? source.errors : []),
-      ...extraErrors,
-    ],
-  });
-  const validationError = validateTelemetryRecord(record);
-  if (validationError) {
-    throw new Error(`Guaranteed telemetry is invalid: ${validationError}`);
+  const errors = [...sourceErrors, ...optionErrors].filter(
+    (error) => typeof error === 'string' && error.trim().length > 0,
+  );
+  const candidate = buildRecord({ ...source, errors });
+  const candidateError = validateTelemetryRecord(candidate);
+  if (!candidateError) {
+    return candidate;
   }
-  return record;
+
+  const sha = nullableString(context.sha);
+  const fallback = buildRecord({
+    metadata: null,
+    manifest: null,
+    routingDecisions: null,
+    errors: [...errors, candidateError, 'Telemetry fallback emitted'],
+    context: {
+      runId: nullableString(context.runId) ?? 'unavailable',
+      runAttempt: normalizeRunAttempt(context.runAttempt),
+      prNumber: nullableCount(context.prNumber),
+      sha: sha && /^[0-9a-f]{40}$/.test(sha) ? sha : null,
+      generatedAt: normalizeTimestamp(context.generatedAt),
+      infrastructureFailure: true,
+      policyFailure: Boolean(context.policyFailure),
+      telemetryState: 'failed',
+      postState: 'failed',
+      artifactState: 'failed',
+      hashState: 'failed',
+      postOutcome: 'failed',
+      previewAttempted: false,
+    },
+  });
+  const fallbackError = validateTelemetryRecord(fallback);
+  if (fallbackError) {
+    throw new Error(`Telemetry fallback is invalid: ${fallbackError}`);
+  }
+  return fallback;
 }
 
 function display(value) {
   return value === null ? 'n/a' : String(value);
+}
+
+function markdownCodeValue(value) {
+  return display(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('`', '&#96;')
+    .replaceAll('\r', '&#13;')
+    .replaceAll('\n', '&#10;');
 }
 
 function distributionText(distribution) {
@@ -466,13 +502,14 @@ export function renderTelemetryMarkdown(telemetry) {
   return [
     '## OCR Telemetry',
     '',
-    `PR #${display(telemetry.pr_number)} · run \`${display(telemetry.run_id)}\` · sha \`${telemetry.sha?.slice(0, 8) ?? 'n/a'}\``,
+    `PR #${display(telemetry.pr_number)} · run \`${markdownCodeValue(telemetry.run_id)}\` · sha \`${markdownCodeValue(telemetry.sha?.slice(0, 8) ?? null)}\``,
     '',
     '| metric | value |',
     '| --- | --- |',
     `| total findings | ${display(telemetry.total_findings)} |`,
     `| files previewed / reviewed | ${display(telemetry.files_previewed)} / ${display(telemetry.files_reviewed)} |`,
     `| file-read / per-file failures | ${display(telemetry.file_read_failure_count)} / ${display(telemetry.per_file_review_failure_count)} |`,
+    `| already resolved | ${display(telemetry.already_resolved)} |`,
     `| publication inline / summary / skipped / failed / total | ${display(telemetry.inline_posted)} / ${display(telemetry.comments_routed_summary)} / ${display(telemetry.comments_skipped)} / ${display(telemetry.comments_failed)} / ${display(telemetry.comments_total)} |`,
     `| publication state | ${display(telemetry.publication_state)} |`,
     `| tokens | ${tokenText} |`,

--- a/scripts/ocr-telemetry.js
+++ b/scripts/ocr-telemetry.js
@@ -292,12 +292,14 @@ function resolveFilesEvidence(context, manifestSummary, errors) {
 }
 
 function identityFields(context) {
-  const parsedPrNumber = nullableCount(context.prNumber);
+  const normalizedPrNumber = nullableCount(context.prNumber);
   return {
     run_id: nullableString(context.runId),
     run_attempt: normalizeRunAttempt(context.runAttempt),
     pr_number:
-      parsedPrNumber !== null && parsedPrNumber > 0 ? parsedPrNumber : null,
+      normalizedPrNumber !== null && normalizedPrNumber > 0
+        ? normalizedPrNumber
+        : null,
     sha: nullableString(context.sha),
     generated_at: normalizeTimestamp(context.generatedAt),
   };

--- a/scripts/tests/aggregate-ocr-telemetry.test.js
+++ b/scripts/tests/aggregate-ocr-telemetry.test.js
@@ -393,6 +393,18 @@ describe('discoverTelemetryRecords — recursive discovery', () => {
     expect(() => discoverTelemetryRecords(tmpDir)).toThrow(/malformed/i);
     fs.rmSync(path.join(bad, 'ocr-telemetry.json'), { force: true });
   });
+  it('identifies the path of malformed JSON', () => {
+    const bad = path.join(tmpDir, 'invalid-json');
+    const telemetryPath = path.join(bad, 'ocr-telemetry.json');
+    fs.mkdirSync(bad, { recursive: true });
+    fs.writeFileSync(telemetryPath, '{invalid');
+    expect(() => discoverTelemetryRecords(tmpDir)).toThrow(telemetryPath);
+    fs.rmSync(telemetryPath, { force: true });
+  });
+  it('identifies a directory that cannot be discovered', () => {
+    const missing = path.join(tmpDir, 'missing');
+    expect(() => discoverTelemetryRecords(missing)).toThrow(missing);
+  });
 });
 
 describe('aggregate-ocr-telemetry.js CLI — contract', () => {

--- a/scripts/tests/aggregate-ocr-telemetry.test.js
+++ b/scripts/tests/aggregate-ocr-telemetry.test.js
@@ -268,6 +268,19 @@ describe('aggregateTelemetry — file_read_failure_rate null semantics', () => {
     ]);
     expect(result.file_read_failure_rate).toBeNull();
   });
+  it('does not claim a rate when every preview count is unavailable', () => {
+    const result = aggregateTelemetry([
+      record({
+        files_previewed: null,
+        files_reviewed: null,
+        reviewed_range_manifest: null,
+        file_read_failures: [],
+        file_read_failure_count: 0,
+        completeness: null,
+      }),
+    ]);
+    expect(result.file_read_failure_rate).toBeNull();
+  });
 });
 
 describe('aggregateTelemetry — trends', () => {
@@ -469,6 +482,11 @@ describe('aggregate-ocr-telemetry.js CLI — contract', () => {
     const written = fs.readFileSync(outPath, 'utf8');
     expect(written).toMatch(/^## OCR Telemetry/);
     expect(() => JSON.parse(written)).toThrow();
+  });
+  it('rejects a flag where --output requires a file path', () => {
+    const result = runCli([tmpDir, '--output', '--format', 'markdown']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('--output requires a file path');
   });
 
   describe('aggregateTelemetry — mixed evidence and epoch ordering', () => {

--- a/scripts/tests/aggregate-ocr-telemetry.test.js
+++ b/scripts/tests/aggregate-ocr-telemetry.test.js
@@ -1,0 +1,517 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  aggregateTelemetry,
+  discoverTelemetryRecords,
+  validateTelemetryRecord,
+} from '../aggregate-ocr-telemetry.js';
+
+function record(overrides = {}) {
+  return {
+    schema: 1,
+    schema_name: 'ocr-telemetry',
+    run_id: '1',
+    run_attempt: '1',
+    pr_number: 100,
+    sha: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555',
+    generated_at: '2026-07-01T00:00:00.000Z',
+    ocr: { version: '1.7.16', model: 'm', concurrency: 2 },
+    wall_clock_seconds: 100,
+    cli_elapsed_seconds: 100,
+    files_previewed: 5,
+    files_reviewed: 5,
+    file_read_failures: null,
+    file_read_failure_count: null,
+    per_file_review_failures: [],
+    per_file_review_failure_count: 0,
+    total_findings: 2,
+    findings: {
+      by_category: { bug: 1, style: 1 },
+      by_severity: { high: 1, low: 1 },
+      by_category_severity: {
+        bug: { high: 1, low: 0 },
+        style: { high: 0, low: 1 },
+      },
+    },
+    inline_posted: 2,
+    already_resolved: null,
+    already_posted_or_skipped_dedup: 0,
+    comments_skipped: 0,
+    comments_failed: 0,
+    comments_routed_summary: 0,
+    comments_total: 2,
+    infrastructure_failure: false,
+    policy_failure: false,
+    completeness: 'complete',
+    publication_state: 'complete',
+    reviewed_range_manifest: {
+      selected_files: 5,
+      completed_files: 5,
+      failed_files: 0,
+    },
+    tokens: {
+      input: 100,
+      output: 50,
+      cache_read: 0,
+      cache_write: 0,
+      total: 150,
+    },
+    telemetry_state: 'complete',
+    post_state: 'posted',
+    artifact_state: 'prepared',
+    hash_state: 'prepared',
+    marker_state: {
+      infrastructure_failure: false,
+      policy_failure: false,
+    },
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe('validateTelemetryRecord (re-exported from shared schema)', () => {
+  it('returns null for a valid record', () => {
+    expect(validateTelemetryRecord(record())).toBeNull();
+  });
+  it('rejects a __proto__ own key', () => {
+    const evil = JSON.parse(
+      '{"__proto__":{"x":1},"schema_name":"ocr-telemetry"}',
+    );
+    expect(validateTelemetryRecord(evil)).toMatch(
+      /plain object|unsafe|__proto__/i,
+    );
+  });
+});
+
+describe('aggregateTelemetry — core stats', () => {
+  it('computes average findings per run', () => {
+    const result = aggregateTelemetry([
+      record({ run_id: '1', total_findings: 2 }),
+      record({
+        run_id: '2',
+        total_findings: 4,
+        findings: {
+          by_category: { bug: 2, style: 2 },
+          by_severity: { high: 2, low: 2 },
+          by_category_severity: {
+            bug: { high: 2, low: 0 },
+            style: { high: 0, low: 2 },
+          },
+        },
+      }),
+    ]);
+    expect(result.average_findings_per_run).toBeCloseTo(3, 5);
+    expect(result.total_findings).toBe(6);
+    expect(result.runs).toBe(2);
+  });
+  it('rejects records with __proto__ keys (fail-closed prototype safety)', () => {
+    // A record carrying a __proto__ category key is malformed and must be
+    // rejected by the strict shared validator rather than aggregated.
+    const evil = record({
+      run_id: '1',
+      findings: {
+        by_category: JSON.parse('{"__proto__":1,"bug":1}'),
+        by_severity: { high: 1 },
+        by_category_severity: { bug: { high: 1 } },
+      },
+      total_findings: 1,
+    });
+    expect(() => aggregateTelemetry([evil])).toThrow(
+      /malformed|prototype|own/i,
+    );
+    // The aggregate must not have polluted Object.prototype.
+    expect({}.polluted).toBeUndefined();
+  });
+});
+
+describe('aggregateTelemetry — unavailable metrics', () => {
+  it('keeps unavailable aggregate metrics null instead of inventing zeros', () => {
+    const failed = record({
+      total_findings: null,
+      findings: null,
+      files_previewed: null,
+      files_reviewed: null,
+      per_file_review_failures: null,
+      per_file_review_failure_count: null,
+      inline_posted: null,
+      infrastructure_failure: true,
+      marker_state: {
+        infrastructure_failure: true,
+        policy_failure: false,
+      },
+      telemetry_state: 'degraded',
+      errors: ['OCR artifacts unavailable'],
+    });
+    const result = aggregateTelemetry([failed]);
+    expect(result.total_findings).toBeNull();
+    expect(result.average_findings_per_run).toBeNull();
+    expect(result.total_files_previewed).toBeNull();
+  });
+});
+
+describe('aggregateTelemetry — deterministic sort and run_attempt', () => {
+  it('sorts by (generated_at, run_id, run_attempt) transitively', () => {
+    const records = [
+      record({
+        run_id: '30',
+        run_attempt: '1',
+        generated_at: '2026-07-03T00:00:00.000Z',
+      }),
+      record({
+        run_id: '2',
+        run_attempt: '1',
+        generated_at: '2026-07-01T00:00:00.000Z',
+      }),
+      record({
+        run_id: '10',
+        run_attempt: '1',
+        generated_at: '2026-07-02T00:00:00.000Z',
+      }),
+    ];
+    const result = aggregateTelemetry(records);
+    expect(result.findings_trend.map((t) => t.run_id)).toEqual([
+      '2',
+      '10',
+      '30',
+    ]);
+  });
+  it('breaks generated_at ties by run_id then run_attempt', () => {
+    const records = [
+      record({
+        run_id: '5',
+        run_attempt: '2',
+        generated_at: '2026-07-01T00:00:00.000Z',
+      }),
+      record({
+        run_id: '5',
+        run_attempt: '1',
+        generated_at: '2026-07-01T00:00:00.000Z',
+      }),
+    ];
+    const result = aggregateTelemetry(records);
+    expect(result.findings_trend.map((t) => t.run_attempt)).toEqual(['1', '2']);
+  });
+  it('includes run_attempt in every time series entry', () => {
+    const result = aggregateTelemetry([
+      record({ run_id: '1', run_attempt: '1' }),
+    ]);
+    expect(result.findings_trend[0].run_attempt).toBe('1');
+    expect(result.inline_volume[0].run_attempt).toBe('1');
+    expect(result.category_trend[0].run_attempt).toBe('1');
+    expect(result.severity_trend[0].run_attempt).toBe('1');
+  });
+});
+
+describe('aggregateTelemetry — duplicate (run_id, run_attempt) policy', () => {
+  it('rejects duplicate (run_id, run_attempt) records', () => {
+    const records = [
+      record({ run_id: '1', run_attempt: '1' }),
+      record({ run_id: '1', run_attempt: '1' }),
+    ];
+    expect(() => aggregateTelemetry(records)).toThrow(
+      /duplicate|run_id|run_attempt/i,
+    );
+  });
+});
+
+describe('aggregateTelemetry — file_read_failure_rate null semantics', () => {
+  it('computes a real 0% rate when evidence shows zero failures and nonzero preview', () => {
+    const result = aggregateTelemetry([
+      record({
+        run_id: '1',
+        files_previewed: 5,
+        file_read_failures: [],
+        file_read_failure_count: 0,
+        per_file_review_failure_count: 3,
+        per_file_review_failures: ['a.ts', 'b.ts', 'c.ts'],
+      }),
+    ]);
+    // 0 failures / 5 previewed is a real 0% rate, not unavailable.
+    expect(result.file_read_failure_rate).toBe(0);
+  });
+  it('does not claim a rate when read-specific evidence is unavailable', () => {
+    const result = aggregateTelemetry([
+      record({
+        run_id: '1',
+        files_previewed: 5,
+        file_read_failures: null,
+        file_read_failure_count: null,
+        per_file_review_failures: ['logic.ts'],
+        per_file_review_failure_count: 1,
+      }),
+    ]);
+    expect(result.file_read_failure_rate).toBeNull();
+  });
+  it('does not claim a 0% rate when denominator is zero', () => {
+    const result = aggregateTelemetry([
+      record({
+        run_id: '1',
+        files_previewed: 0,
+        files_reviewed: 0,
+        reviewed_range_manifest: {
+          selected_files: 0,
+          completed_files: 0,
+          failed_files: 0,
+        },
+        file_read_failures: [],
+        file_read_failure_count: 0,
+      }),
+    ]);
+    expect(result.file_read_failure_rate).toBeNull();
+  });
+});
+
+describe('aggregateTelemetry — trends', () => {
+  it('produces category per-run trend ordered series', () => {
+    const records = [
+      record({
+        run_id: '1',
+        generated_at: '2026-07-01T00:00:00.000Z',
+        findings: {
+          by_category: { bug: 2, style: 1 },
+          by_severity: { high: 2, low: 1 },
+          by_category_severity: {
+            bug: { high: 2, low: 0 },
+            style: { high: 0, low: 1 },
+          },
+        },
+        total_findings: 3,
+      }),
+      record({
+        run_id: '2',
+        generated_at: '2026-07-02T00:00:00.000Z',
+        findings: {
+          by_category: { bug: 1, maintainability: 2 },
+          by_severity: { high: 1, medium: 2 },
+          by_category_severity: {
+            bug: { high: 1, medium: 0 },
+            maintainability: { high: 0, medium: 2 },
+          },
+        },
+        total_findings: 3,
+      }),
+      record({
+        run_id: '3',
+        generated_at: '2026-07-03T00:00:00.000Z',
+        findings: {
+          by_category: { bug: 0, style: 0, test: 4 },
+          by_severity: { high: 0, low: 4 },
+          by_category_severity: {
+            bug: { high: 0, low: 0 },
+            style: { high: 0, low: 0 },
+            test: { high: 0, low: 4 },
+          },
+        },
+        total_findings: 4,
+      }),
+    ];
+    const result = aggregateTelemetry(records);
+    expect(result.category_trend).toHaveLength(3);
+    expect(result.severity_trend).toHaveLength(3);
+    // first entry is run 1
+    expect(result.category_trend[0].run_id).toBe('1');
+    expect(result.category_trend[0].categories.bug).toBe(2);
+    expect(result.category_trend[2].run_id).toBe('3');
+    expect(result.category_trend[2].categories.test).toBe(4);
+    expect(result.severity_trend[2].severities.low).toBe(4);
+  });
+  it('renders a compact trend view in markdown', () => {
+    const records = [
+      record({
+        run_id: '1',
+        generated_at: '2026-07-01T00:00:00.000Z',
+        findings: {
+          by_category: { bug: 1 },
+          by_severity: { high: 1 },
+          by_category_severity: { bug: { high: 1 } },
+        },
+        total_findings: 1,
+      }),
+      record({
+        run_id: '2',
+        generated_at: '2026-07-02T00:00:00.000Z',
+        findings: {
+          by_category: { bug: 2 },
+          by_severity: { low: 2 },
+          by_category_severity: { bug: { low: 2 } },
+        },
+        total_findings: 2,
+      }),
+    ];
+    const result = aggregateTelemetry(records);
+    expect(result.markdown).toMatch(/trend/i);
+    expect(result.markdown).toContain('bug');
+  });
+});
+
+describe('aggregateTelemetry — fail-closed', () => {
+  it('throws on a malformed record', () => {
+    expect(() =>
+      aggregateTelemetry([record(), { schema_name: 'other' }]),
+    ).toThrow(/malformed/i);
+  });
+  it('throws for an empty record set', () => {
+    expect(() => aggregateTelemetry([])).toThrow(/empty|no records/i);
+  });
+});
+
+describe('discoverTelemetryRecords — recursive discovery', () => {
+  let tmpDir;
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-telemetry-agg-'));
+    const nested = path.join(tmpDir, 'artifacts', 'run-1', 'ocr-review-output');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(
+      path.join(nested, 'ocr-telemetry.json'),
+      JSON.stringify(record({ run_id: '1' })),
+    );
+  });
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+  it('recursively discovers ocr-telemetry.json records', () => {
+    const records = discoverTelemetryRecords(tmpDir);
+    expect(records).toHaveLength(1);
+    expect(records[0].run_id).toBe('1');
+  });
+  it('fails fast on a malformed discovered record', () => {
+    const bad = path.join(tmpDir, 'bad-run');
+    fs.mkdirSync(bad, { recursive: true });
+    fs.writeFileSync(
+      path.join(bad, 'ocr-telemetry.json'),
+      JSON.stringify({ schema_name: 'wrong' }),
+    );
+    expect(() => discoverTelemetryRecords(tmpDir)).toThrow(/malformed/i);
+    fs.rmSync(path.join(bad, 'ocr-telemetry.json'), { force: true });
+  });
+});
+
+describe('aggregate-ocr-telemetry.js CLI — contract', () => {
+  const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+  const AGG_SCRIPT = path.join(
+    REPO_ROOT,
+    'scripts',
+    'aggregate-ocr-telemetry.js',
+  );
+
+  function runCli(args, cwd) {
+    return spawnSync(process.execPath, [AGG_SCRIPT, ...args], {
+      cwd,
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    });
+  }
+
+  let tmpDir;
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-agg-cli-'));
+    const nested = path.join(tmpDir, 'run-1');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(
+      path.join(nested, 'ocr-telemetry.json'),
+      JSON.stringify(record({ run_id: '1' })),
+    );
+    const nested2 = path.join(tmpDir, 'run-2');
+    fs.mkdirSync(nested2, { recursive: true });
+    fs.writeFileSync(
+      path.join(nested2, 'ocr-telemetry.json'),
+      JSON.stringify(
+        record({ run_id: '2', generated_at: '2026-07-02T00:00:00.000Z' }),
+      ),
+    );
+  });
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('prints help and exits nonzero when no args', () => {
+    const result = runCli([]);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toMatch(/usage/i);
+  });
+  it('prints JSON to stdout by default with a format flag', () => {
+    const result = runCli([tmpDir, '--format', 'json']);
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.runs).toBe(2);
+  });
+  it('writes markdown to an explicit --output path', () => {
+    const outPath = path.join(tmpDir, 'out.md');
+    const result = runCli([
+      tmpDir,
+      '--format',
+      'markdown',
+      '--output',
+      outPath,
+    ]);
+    expect(result.status).toBe(0);
+    const written = fs.readFileSync(outPath, 'utf8');
+    expect(written).toMatch(/^## OCR Telemetry/);
+    expect(() => JSON.parse(written)).toThrow();
+  });
+
+  describe('aggregateTelemetry — mixed evidence and epoch ordering', () => {
+    it('sorts timestamps by parsed epoch across different offsets', () => {
+      const result = aggregateTelemetry([
+        record({
+          run_id: '2',
+          generated_at: '2026-07-01T00:30:00.000Z',
+        }),
+        record({
+          run_id: '1',
+          generated_at: '2026-07-01T02:00:00.000+02:00',
+        }),
+      ]);
+      expect(result.findings_trend.map((entry) => entry.run_id)).toEqual([
+        '1',
+        '2',
+      ]);
+    });
+
+    it('preserves null trends and reports available/total denominators', () => {
+      const unavailable = record({
+        run_id: '2',
+        total_findings: null,
+        findings: null,
+        inline_posted: null,
+        infrastructure_failure: true,
+        telemetry_state: 'degraded',
+        marker_state: {
+          infrastructure_failure: true,
+          policy_failure: false,
+        },
+        errors: ['findings unavailable'],
+      });
+      const result = aggregateTelemetry([record(), unavailable]);
+      expect(result.inline_volume[1].inline_posted).toBeNull();
+      expect(result.category_trend[1].categories).toBeNull();
+      expect(result.severity_trend[1].severities).toBeNull();
+      expect(result.findings_trend[1].total_findings).toBeNull();
+      expect(result.findings_available_runs).toBe(1);
+      expect(result.findings_total_runs).toBe(2);
+      expect(result.markdown).toContain('1/2 runs available');
+    });
+
+    it('reports wall-clock concurrency sample counts and the file-read label', () => {
+      const result = aggregateTelemetry([
+        record({ run_id: '1', wall_clock_seconds: 10 }),
+        record({ run_id: '2', wall_clock_seconds: 20 }),
+      ]);
+      expect(result.average_wall_clock_by_concurrency['2']).toEqual({
+        average_seconds: 15,
+        samples: 2,
+      });
+      expect(result.markdown).toContain('file-read failure rate');
+      expect(result.markdown).not.toContain('per-file review failure rate');
+    });
+  });
+});

--- a/scripts/tests/ocr-review-incremental-checkpoint.test.js
+++ b/scripts/tests/ocr-review-incremental-checkpoint.test.js
@@ -574,7 +574,7 @@ describe('.github/workflows/ocr-review.yml — incremental checkpoints (issue #2
             output_tokens: 100,
             cache_read_tokens: 50,
             cache_write_tokens: 25,
-            total_tokens: 475,
+            total_tokens: 400,
             elapsed: '46m31s',
           },
           warnings: [{ type: 'info', message: 'notice' }],
@@ -588,7 +588,7 @@ describe('.github/workflows/ocr-review.yml — incremental checkpoints (issue #2
           cache_read: 50,
           cache_write: 25,
           cache: 75,
-          total: 475,
+          total: 400,
         },
         warnings: [{ type: 'info', message: 'notice' }],
         completion_state: 'complete',
@@ -648,7 +648,7 @@ describe('.github/workflows/ocr-review.yml — incremental checkpoints (issue #2
           cache_read: 50,
           cache_write: 25,
           cache: 75,
-          total: 475,
+          total: 400,
         },
         findings: {
           raw: 75,
@@ -692,7 +692,7 @@ describe('.github/workflows/ocr-review.yml — incremental checkpoints (issue #2
         cache_read: 50,
         cache_write: 25,
         cache: 75,
-        total: 475,
+        total: 400,
       });
       expect(metadata.findings.raw).toBe(75);
       expect(metadata.findings.severity_distribution.high).toBe(4);

--- a/scripts/tests/ocr-review-workflow-behaviors.test.js
+++ b/scripts/tests/ocr-review-workflow-behaviors.test.js
@@ -123,22 +123,20 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
     expect(genericIndex).toBeGreaterThan(allFileIndex);
   });
 
-  it('writes a safe placeholder before redacting artifacts (Behavior 4)', () => {
+  it('redacts artifacts with an atomic temporary-file rename (Behavior 4)', () => {
     const redactRun = commandText(
       stepNamed(codeReviewJob, 'Redact OCR diagnostic artifacts'),
     );
     expectContainsAll(redactRun, [
-      'fs.writeFileSync(fileName, REDACTED_PENDING)',
-      'const tempFile = `${fileName}.redacting`',
-      'fs.writeFileSync(tempFile, redactedContent)',
-      'fs.renameSync(tempFile, fileName)',
+      'const temporary = `${fileName}.redacting`',
+      'fs.writeFileSync(temporary, redact(original))',
+      'fs.renameSync(temporary, fileName)',
     ]);
-    expect(redactRun).toContain('[REDACTED-PENDING]');
-    const placeholderIndex = redactRun.indexOf(
-      'fs.writeFileSync(fileName, REDACTED_PENDING)',
+    const temporaryIndex = redactRun.indexOf(
+      'fs.writeFileSync(temporary, redact(original))',
     );
-    const renameIndex = redactRun.indexOf('fs.renameSync(tempFile, fileName)');
-    expect(renameIndex).toBeGreaterThan(placeholderIndex);
+    const renameIndex = redactRun.indexOf('fs.renameSync(temporary, fileName)');
+    expect(renameIndex).toBeGreaterThan(temporaryIndex);
   });
 
   it('does not retry non-idempotent gh issue writes (Behavior 5)', () => {

--- a/scripts/tests/ocr-review-workflow-features.test.js
+++ b/scripts/tests/ocr-review-workflow-features.test.js
@@ -505,6 +505,9 @@ describe('.github/workflows/ocr-review.yml — issue #2670 upstream features', (
       expect(postScript).toContain(
         'const commentsSkipped = skippedOverlapCount + skippedExactHistoryCount;',
       );
+      expect(postScript).toContain(
+        "core.setOutput('already_resolved', String(skippedOverlapCount));",
+      );
       expect(postScript).toContain('let skippedExactHistoryCount = 0;');
       expect(postScript).toContain('beforeExactFilter');
       expect(postScript).toContain(

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -583,7 +583,10 @@ describe('.github/workflows/ocr-review.yml', () => {
 
   it('uploads diagnostics and telemetry only after their respective validation', () => {
     const uploadStep = stepNamed(codeReviewJob, 'Upload OCR artifacts');
-    const telemetryUploadStep = stepNamed(codeReviewJob, 'Upload OCR telemetry');
+    const telemetryUploadStep = stepNamed(
+      codeReviewJob,
+      'Upload OCR telemetry',
+    );
     expect(String(uploadStep.if)).toContain(
       'steps.ocr-telemetry-validation.outputs.valid',
     );

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -581,8 +581,9 @@ describe('.github/workflows/ocr-review.yml', () => {
     );
   });
 
-  it('uploads artifacts only after telemetry validation', () => {
+  it('uploads diagnostics and telemetry only after their respective validation', () => {
     const uploadStep = stepNamed(codeReviewJob, 'Upload OCR artifacts');
+    const telemetryUploadStep = stepNamed(codeReviewJob, 'Upload OCR telemetry');
     expect(String(uploadStep.if)).toContain(
       'steps.ocr-telemetry-validation.outputs.valid',
     );
@@ -590,8 +591,9 @@ describe('.github/workflows/ocr-review.yml', () => {
     expect(uploadStep.with?.path).toContain('ocr-preflight.txt');
     expect(uploadStep.with?.path).toContain('ocr-infrastructure-failure.txt');
     expect(uploadStep.with?.path).toContain('ocr-policy-failure.txt');
-    expect(uploadStep.with?.path).toContain('ocr-telemetry.json');
-    expect(uploadStep.with?.['if-no-files-found']).toBe('error');
+    expect(uploadStep.with?.path).not.toContain('ocr-telemetry.json');
+    expect(telemetryUploadStep.with?.path).toBe('ocr-telemetry.json');
+    expect(telemetryUploadStep.with?.['if-no-files-found']).toBe('error');
   });
 
   it('creates non-telemetry placeholders before producing telemetry', () => {

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -103,10 +103,10 @@ describe('.github/workflows/ocr-review.yml', () => {
     expect(workflow.concurrency?.['cancel-in-progress']).toBe(true);
     expect(codeReviewJob['timeout-minutes']).toBe(60);
     expect(codeReviewJob.outputs?.infrastructure_failure).toBe(
-      '${{ steps.ocr-classification.outputs.infrastructure_failure }}',
+      '${{ steps.ocr-final-classification.outputs.infrastructure_failure }}',
     );
     expect(codeReviewJob.outputs?.policy_failure).toBe(
-      '${{ steps.ocr-classification.outputs.policy_failure }}',
+      '${{ steps.ocr-final-classification.outputs.policy_failure }}',
     );
     expect(mergeabilityGateJob.concurrency).toBeUndefined();
     expect(codeReviewJob.concurrency).toBeUndefined();
@@ -581,38 +581,25 @@ describe('.github/workflows/ocr-review.yml', () => {
     );
   });
 
-  it('uploads artifacts without noisy missing-file failures', () => {
+  it('uploads artifacts only after telemetry validation', () => {
     const uploadStep = stepNamed(codeReviewJob, 'Upload OCR artifacts');
-    expect(uploadStep.if).toBe('always()');
+    expect(String(uploadStep.if)).toContain(
+      'steps.ocr-telemetry-validation.outputs.valid',
+    );
     expect(uploadStep.with?.path).toContain('ocr-phase.txt');
     expect(uploadStep.with?.path).toContain('ocr-preflight.txt');
     expect(uploadStep.with?.path).toContain('ocr-infrastructure-failure.txt');
     expect(uploadStep.with?.path).toContain('ocr-policy-failure.txt');
-    const redactRun = commandText(
-      stepNamed(codeReviewJob, 'Redact OCR diagnostic artifacts'),
-    );
-    for (const artifact of uploadStep.with?.path.trim().split(/\s+/) ?? []) {
-      expect(redactRun).toContain(`'${artifact}'`);
-    }
-    expectContainsAll(redactRun, [
-      'replaceWithRedactionFailure',
-      'redaction failed for ${fileName}: ${code}',
-      'fs.rmSync(fileName, { force: true });',
-      'process.exitCode = 1;',
-      "if (error && error.code !== 'ENOENT') {",
-    ]);
-    expect(redactRun).not.toContain('throw error');
-    expect(uploadStep.with?.['if-no-files-found']).toBe('warn');
+    expect(uploadStep.with?.path).toContain('ocr-telemetry.json');
+    expect(uploadStep.with?.['if-no-files-found']).toBe('error');
   });
 
-  it('creates placeholders for every uploaded artifact so uploads never fail', () => {
-    const uploadStep = stepNamed(codeReviewJob, 'Upload OCR artifacts');
+  it('creates non-telemetry placeholders before producing telemetry', () => {
     const placeholderRun = commandText(
       stepNamed(codeReviewJob, 'Ensure OCR artifact placeholders exist'),
     );
-    for (const artifact of uploadStep.with?.path.trim().split(/\s+/) ?? []) {
-      expect(placeholderRun).toContain(artifact);
-    }
+    expect(placeholderRun).toContain('ocr-routing-decisions.json');
+    expect(placeholderRun).not.toContain('ocr-telemetry.json');
   });
 
   it('notifies a deduplicated ci/cd issue only for classified infrastructure errors', () => {

--- a/scripts/tests/ocr-reviewed-range-manifest-wiring.test.js
+++ b/scripts/tests/ocr-reviewed-range-manifest-wiring.test.js
@@ -435,9 +435,9 @@ describe('.github/workflows/ocr-review.yml — manifest artifacts & YAML wiring 
         'hash step must come after redact step',
       ).toBeGreaterThan(redactIndex);
       expect(
-        hashIndex,
-        'hash step must come before ensure placeholders step',
-      ).toBeLessThan(ensureIndex);
+        ensureIndex,
+        'placeholder recovery must precede telemetry and final hashing',
+      ).toBeLessThan(hashIndex);
     });
 
     it('the hash computation step computes SHA-256 for post-redaction artifacts (C4)', () => {
@@ -544,6 +544,17 @@ describe('.github/workflows/ocr-review.yml — manifest artifacts & YAML wiring 
       const uploadPath = String(uploadStep.with?.path || '');
       expect(uploadPath).toContain('ocr-manifest-hashes.json');
       expect(uploadPath).toContain('ocr-manifest-sha256.txt');
+    });
+
+    it('gates artifact upload on source redaction and valid hashes', () => {
+      const uploadStep = stepNamed(ctx.codeReviewJob, 'Upload OCR artifacts');
+      const condition = String(uploadStep.if);
+      expect(condition).toContain(
+        "steps.redact-ocr-artifacts.outcome == 'success'",
+      );
+      expect(condition).toContain(
+        "steps.ocr-manifest-hashes.outputs.valid == 'true'",
+      );
     });
   });
 });

--- a/scripts/tests/ocr-telemetry-cli.test.js
+++ b/scripts/tests/ocr-telemetry-cli.test.js
@@ -8,7 +8,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   validateTelemetryRecord,
   validateReconciliation,
@@ -22,9 +22,22 @@ const AGGREGATOR_SCRIPT = path.join(
   'aggregate-ocr-telemetry.js',
 );
 
+const temporaryDirectories = new Set();
+
 function makeTmpDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-telemetry-cli-'));
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'ocr-telemetry-cli-'),
+  );
+  temporaryDirectories.add(directory);
+  return directory;
 }
+
+afterEach(() => {
+  for (const directory of temporaryDirectories) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+  temporaryDirectories.clear();
+});
 
 function writeJson(dir, name, obj) {
   fs.writeFileSync(path.join(dir, name), `${JSON.stringify(obj, null, 2)}\n`);
@@ -92,7 +105,7 @@ function successArtifacts(dir) {
         output: 100,
         cache_read: 50,
         cache_write: 25,
-        total: 475,
+        total: 400,
       },
     },
     terminal: {
@@ -113,15 +126,6 @@ function successArtifacts(dir) {
 }
 
 describe('ocr-telemetry.js CLI — real behavioral runs', () => {
-  let dir;
-
-  beforeAll(() => {
-    dir = makeTmpDir();
-  });
-  afterAll(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
-
   it('normal success: emits nonempty schema-valid telemetry with summary', () => {
     const run = makeTmpDir();
     successArtifacts(run);
@@ -367,7 +371,7 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     fs.rmSync(run, { recursive: true, force: true });
   });
 
-  it('atomic write: no partial/zero-byte telemetry.json left on failure path', () => {
+  it('writes schema-valid telemetry atomically on success', () => {
     const run = makeTmpDir();
     successArtifacts(run);
     const result = runCli(run, baseEnv());
@@ -377,8 +381,23 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     expect(stat.size).toBeGreaterThan(0);
     const raw = fs.readFileSync(telemetryPath, 'utf8');
     expect(() => JSON.parse(raw)).not.toThrow();
-    expect(fs.existsSync(path.join(run, 'ocr-telemetry.json.tmp'))).toBe(false);
+    expect(
+      fs.readdirSync(run).filter((name) => name.includes('.writing-')),
+    ).toEqual([]);
     fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('removes the temporary telemetry file when atomic rename fails', () => {
+    const run = makeTmpDir();
+    successArtifacts(run);
+    fs.mkdirSync(path.join(run, 'ocr-telemetry.json'));
+
+    const result = runCli(run, baseEnv());
+
+    expect(result.status).not.toBe(0);
+    expect(
+      fs.readdirSync(run).filter((name) => name.includes('.writing-')),
+    ).toEqual([]);
   });
 
   it('producer output aggregates end-to-end through the real aggregator CLI', () => {

--- a/scripts/tests/ocr-telemetry-cli.test.js
+++ b/scripts/tests/ocr-telemetry-cli.test.js
@@ -150,7 +150,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     expect(validateReconciliation(telemetry)).toBeNull();
     const summary = fs.readFileSync(summaryPath, 'utf8');
     expect(summary).toContain('OCR Telemetry');
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('no-changed-tests / noop: emits valid telemetry with zero findings', () => {
@@ -200,7 +199,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     expect(telemetry.files_reviewed).toBe(0);
     expect(telemetry.files_previewed).toBe(0);
     expect(validateTelemetryRecord(telemetry)).toBeNull();
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('OCR nonzero exit (infrastructure failure): emits valid degraded record', () => {
@@ -236,7 +234,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     expect(telemetry.infrastructure_failure).toBe(true);
     expect(telemetry.post_state).toBe('failed');
     expect(validateTelemetryRecord(telemetry)).toBeNull();
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('Post failure / missing outputs: still emits valid record with post_state', () => {
@@ -263,7 +260,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
       'Post OCR results outputs were unavailable',
     );
     expect(validateTelemetryRecord(telemetry)).toBeNull();
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('corrupt ocr-metadata.json: emits valid record, does not throw', () => {
@@ -283,7 +279,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     expect(result.status).toBe(0);
     const telemetry = readEmittedTelemetry(run);
     expect(validateTelemetryRecord(telemetry)).toBeNull();
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('zero-byte artifacts: emits valid record', () => {
@@ -317,7 +312,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     expect(telemetry.infrastructure_failure).toBe(true);
     expect(telemetry.errors.length).toBeGreaterThan(0);
     expect(validateTelemetryRecord(telemetry)).toBeNull();
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('missing PR/SHA (null sha): emits valid record with sha null', () => {
@@ -328,7 +322,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     const telemetry = readEmittedTelemetry(run);
     expect(telemetry.sha).toBeNull();
     expect(validateTelemetryRecord(telemetry)).toBeNull();
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('missing workflow context emits a schema-valid record with truthful nulls', () => {
@@ -347,7 +340,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     expect(telemetry.total_findings).toBeNull();
     expect(telemetry.errors).toContain('OCR metadata artifact was unavailable');
     expect(validateTelemetryRecord(telemetry)).toBeNull();
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('derives read failures only from explicit read-specific evidence', () => {
@@ -368,7 +360,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
       'unreadable.ts',
       'logic.ts',
     ]);
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('writes schema-valid telemetry atomically on success', () => {
@@ -384,7 +375,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     expect(
       fs.readdirSync(run).filter((name) => name.includes('.writing-')),
     ).toEqual([]);
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('removes the temporary telemetry file when atomic rename fails', () => {
@@ -413,7 +403,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     const aggregation = JSON.parse(result.stdout);
     expect(aggregation.runs).toBe(1);
     expect(aggregation.total_findings).toBe(2);
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('completed_with_warnings reflected in files_reviewed', () => {
@@ -424,7 +413,6 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     const telemetry = readEmittedTelemetry(run);
     expect(telemetry.files_reviewed).toBe(3);
     expect(validateTelemetryRecord(telemetry)).toBeNull();
-    fs.rmSync(run, { recursive: true, force: true });
   });
 
   it('redacts escaped and embedded secret substrings atomically', () => {
@@ -458,9 +446,8 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
       'https://model.test/?credential=[REDACTED]&mode=diagnostic',
     );
     expect(validateTelemetryRecord(redacted)).toBeNull();
-    expect(fs.existsSync(`${telemetryPath}.redacting-${result.pid}`)).toBe(
-      false,
-    );
-    fs.rmSync(run, { recursive: true, force: true });
+    expect(
+      fs.readdirSync(run).filter((name) => name.includes('.redacting-')),
+    ).toEqual([]);
   });
 });

--- a/scripts/tests/ocr-telemetry-cli.test.js
+++ b/scripts/tests/ocr-telemetry-cli.test.js
@@ -384,6 +384,7 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
 
     const result = runCli(run, baseEnv());
 
+    expect(result.status).not.toBeNull();
     expect(result.status).not.toBe(0);
     expect(
       fs.readdirSync(run).filter((name) => name.includes('.writing-')),
@@ -405,7 +406,7 @@ describe('ocr-telemetry.js CLI — real behavioral runs', () => {
     expect(aggregation.total_findings).toBe(2);
   });
 
-  it('completed_with_warnings reflected in files_reviewed', () => {
+  it('passes OCR_FILES_REVIEWED through to telemetry', () => {
     const run = makeTmpDir();
     successArtifacts(run);
     const result = runCli(run, baseEnv({ OCR_FILES_REVIEWED: '3' }));

--- a/scripts/tests/ocr-telemetry-cli.test.js
+++ b/scripts/tests/ocr-telemetry-cli.test.js
@@ -1,0 +1,447 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  validateTelemetryRecord,
+  validateReconciliation,
+} from '../ocr-telemetry-schema.js';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+const TELEMETRY_SCRIPT = path.join(REPO_ROOT, 'scripts', 'ocr-telemetry.js');
+const AGGREGATOR_SCRIPT = path.join(
+  REPO_ROOT,
+  'scripts',
+  'aggregate-ocr-telemetry.js',
+);
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-telemetry-cli-'));
+}
+
+function writeJson(dir, name, obj) {
+  fs.writeFileSync(path.join(dir, name), `${JSON.stringify(obj, null, 2)}\n`);
+}
+
+function writeText(dir, name, text) {
+  fs.writeFileSync(path.join(dir, name), text);
+}
+
+function runCli(cwd, env = {}) {
+  return spawnSync(process.execPath, [TELEMETRY_SCRIPT], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      ...env,
+    },
+  });
+}
+
+function readEmittedTelemetry(dir) {
+  const raw = fs.readFileSync(path.join(dir, 'ocr-telemetry.json'), 'utf8');
+  return JSON.parse(raw);
+}
+
+function baseEnv(overrides = {}) {
+  return {
+    OCR_RUN_ID: '987654',
+    OCR_RUN_ATTEMPT: '1',
+    OCR_PR_NUMBER: '2676',
+    OCR_SHA: 'abc123def456789012345678901234567890abcd',
+    OCR_GENERATED_AT: '2026-07-25T23:09:35.000Z',
+    OCR_INFRASTRUCTURE_FAILURE: 'false',
+    OCR_POLICY_FAILURE: 'false',
+    OCR_INLINE_POSTED: '2',
+    OCR_ALREADY_POSTED_OR_SKIPPED_DEDUP: '1',
+    OCR_COMMENTS_SKIPPED: '1',
+    OCR_COMMENTS_FAILED: '0',
+    OCR_COMMENTS_TOTAL: '4',
+    OCR_WALL_CLOCK_SECONDS: '2791',
+    OCR_FILES_REVIEWED: '3',
+    OCR_PER_FILE_REVIEW_FAILURES: 'x.ts',
+    OCR_POST_STATE: 'posted',
+    OCR_POST_OUTCOME: 'success',
+    OCR_ARTIFACT_STATE: 'prepared',
+    OCR_HASH_STATE: 'prepared',
+    OCR_PREVIEW_ATTEMPTED: 'true',
+    OCR_PREVIEW_SUCCEEDED: 'true',
+    OCR_COMMENTS_ROUTED_SUMMARY: '1',
+    ...overrides,
+  };
+}
+
+function successArtifacts(dir) {
+  writeJson(dir, 'ocr-metadata.json', {
+    schema: 1,
+    ocr: {
+      version: '1.7.16',
+      model: 'test-model',
+      concurrency: 2,
+      elapsed: '46m31s',
+      tokens: {
+        input: 300,
+        output: 100,
+        cache_read: 50,
+        cache_write: 25,
+        total: 475,
+      },
+    },
+    terminal: {
+      completeness_state: 'complete',
+      publication_state: 'complete',
+    },
+  });
+  writeJson(dir, 'ocr-reviewed-range-manifest.json', {
+    selected_files: ['a.ts', 'b.ts', 'c.ts'],
+    completed_files: ['a.ts', 'b.ts', 'c.ts'],
+    failed_files: [],
+    completeness: 'complete',
+  });
+  writeJson(dir, 'ocr-routing-decisions.json', [
+    { category: 'bug', severity: 'high', destination: 'inline' },
+    { category: 'style', severity: 'low', destination: 'summary' },
+  ]);
+}
+
+describe('ocr-telemetry.js CLI — real behavioral runs', () => {
+  let dir;
+
+  beforeAll(() => {
+    dir = makeTmpDir();
+  });
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('normal success: emits nonempty schema-valid telemetry with summary', () => {
+    const run = makeTmpDir();
+    successArtifacts(run);
+    const summaryPath = path.join(run, 'summary.md');
+    const result = runCli(run, {
+      ...baseEnv(),
+      GITHUB_STEP_SUMMARY: summaryPath,
+    });
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(telemetry.schema_name).toBe('ocr-telemetry');
+    expect(telemetry.total_findings).toBe(2);
+    expect(telemetry.wall_clock_seconds).toBe(2791);
+    expect(telemetry.cli_elapsed_seconds).toBe(46 * 60 + 31);
+    expect(telemetry.files_reviewed).toBe(3);
+    expect(telemetry.files_previewed).toBe(3);
+    expect(telemetry.already_resolved).toBeNull();
+    expect(telemetry.already_posted_or_skipped_dedup).toBe(1);
+    expect(telemetry.per_file_review_failures).toEqual(['x.ts']);
+    expect(telemetry.file_read_failures).toBeNull();
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    expect(validateReconciliation(telemetry)).toBeNull();
+    const summary = fs.readFileSync(summaryPath, 'utf8');
+    expect(summary).toContain('OCR Telemetry');
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('no-changed-tests / noop: emits valid telemetry with zero findings', () => {
+    const run = makeTmpDir();
+    writeJson(run, 'ocr-metadata.json', {
+      ocr: {
+        version: '1.7.16',
+        model: 'm',
+        concurrency: 2,
+        elapsed: '0s',
+        tokens: {
+          input: 0,
+          output: 0,
+          cache_read: 0,
+          cache_write: 0,
+          total: 0,
+        },
+      },
+      terminal: {
+        completeness_state: 'complete',
+        publication_state: 'complete',
+      },
+    });
+    writeJson(run, 'ocr-reviewed-range-manifest.json', {
+      selected_files: [],
+      completed_files: [],
+      failed_files: [],
+      completeness: 'complete',
+    });
+    writeJson(run, 'ocr-routing-decisions.json', []);
+    const result = runCli(
+      run,
+      baseEnv({
+        OCR_FILES_REVIEWED: '0',
+        OCR_WALL_CLOCK_SECONDS: '0',
+        OCR_INLINE_POSTED: '0',
+        OCR_COMMENTS_TOTAL: '0',
+        OCR_COMMENTS_ROUTED_SUMMARY: '0',
+        OCR_ALREADY_POSTED_OR_SKIPPED_DEDUP: '0',
+        OCR_COMMENTS_SKIPPED: '0',
+        OCR_PER_FILE_REVIEW_FAILURES: '',
+      }),
+    );
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(telemetry.total_findings).toBe(0);
+    expect(telemetry.files_reviewed).toBe(0);
+    expect(telemetry.files_previewed).toBe(0);
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('OCR nonzero exit (infrastructure failure): emits valid degraded record', () => {
+    const run = makeTmpDir();
+    // metadata may be missing/partial; manifest may be empty placeholder
+    writeJson(run, 'ocr-reviewed-range-manifest.json', {
+      selected_files: [],
+      completed_files: [],
+      failed_files: [],
+      completeness: 'partial',
+    });
+    // routing-decisions and metadata are empty placeholders
+    const result = runCli(
+      run,
+      baseEnv({
+        OCR_INFRASTRUCTURE_FAILURE: 'true',
+        OCR_FILES_REVIEWED: '0',
+        OCR_WALL_CLOCK_SECONDS: '5',
+        OCR_INLINE_POSTED: '0',
+        OCR_COMMENTS_TOTAL: '0',
+        OCR_COMMENTS_ROUTED_SUMMARY: '0',
+        OCR_ALREADY_POSTED_OR_SKIPPED_DEDUP: '',
+        OCR_COMMENTS_SKIPPED: '0',
+        OCR_PER_FILE_REVIEW_FAILURES: '',
+        OCR_POST_STATE: 'failed',
+        OCR_POST_OUTCOME: 'failure',
+        OCR_ARTIFACT_STATE: 'failed',
+        OCR_HASH_STATE: 'unavailable',
+      }),
+    );
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(telemetry.infrastructure_failure).toBe(true);
+    expect(telemetry.post_state).toBe('failed');
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('Post failure / missing outputs: still emits valid record with post_state', () => {
+    const run = makeTmpDir();
+    successArtifacts(run);
+    const result = runCli(
+      run,
+      baseEnv({
+        OCR_POST_STATE: 'failed',
+        OCR_POST_OUTCOME: 'failure',
+        OCR_ARTIFACT_STATE: 'failed',
+        OCR_HASH_STATE: 'unavailable',
+        OCR_INLINE_POSTED: '',
+        OCR_COMMENTS_FAILED: '2',
+        OCR_COMMENTS_TOTAL: '',
+      }),
+    );
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(telemetry.post_state).toBe('failed');
+    expect(telemetry.inline_posted).toBeNull();
+    expect(telemetry.comments_total).toBeNull();
+    expect(telemetry.errors).toContain(
+      'Post OCR results outputs were unavailable',
+    );
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('corrupt ocr-metadata.json: emits valid record, does not throw', () => {
+    const run = makeTmpDir();
+    writeText(run, 'ocr-metadata.json', '{not valid json');
+    writeJson(run, 'ocr-reviewed-range-manifest.json', {
+      selected_files: ['a.ts'],
+      completed_files: [],
+      failed_files: [],
+      completeness: 'partial',
+    });
+    writeJson(run, 'ocr-routing-decisions.json', []);
+    const result = runCli(
+      run,
+      baseEnv({ OCR_FILES_REVIEWED: '0', OCR_WALL_CLOCK_SECONDS: '3' }),
+    );
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('zero-byte artifacts: emits valid record', () => {
+    const run = makeTmpDir();
+    writeText(run, 'ocr-metadata.json', '');
+    writeText(run, 'ocr-reviewed-range-manifest.json', '');
+    writeText(run, 'ocr-routing-decisions.json', '');
+    const result = runCli(
+      run,
+      baseEnv({
+        OCR_INFRASTRUCTURE_FAILURE: 'true',
+        OCR_FILES_REVIEWED: '',
+        OCR_WALL_CLOCK_SECONDS: '1',
+        OCR_INLINE_POSTED: '',
+        OCR_COMMENTS_TOTAL: '',
+        OCR_ALREADY_POSTED_OR_SKIPPED_DEDUP: '',
+        OCR_COMMENTS_SKIPPED: '',
+        OCR_PER_FILE_REVIEW_FAILURES: '',
+        OCR_POST_STATE: 'failed',
+        OCR_POST_OUTCOME: 'failure',
+        OCR_ARTIFACT_STATE: 'failed',
+        OCR_HASH_STATE: 'unavailable',
+      }),
+    );
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(telemetry.total_findings).toBeNull();
+    expect(telemetry.findings).toBeNull();
+    expect(telemetry.files_previewed).toBeNull();
+    expect(telemetry.files_reviewed).toBeNull();
+    expect(telemetry.infrastructure_failure).toBe(true);
+    expect(telemetry.errors.length).toBeGreaterThan(0);
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('missing PR/SHA (null sha): emits valid record with sha null', () => {
+    const run = makeTmpDir();
+    successArtifacts(run);
+    const result = runCli(run, baseEnv({ OCR_SHA: '', OCR_PR_NUMBER: '2676' }));
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(telemetry.sha).toBeNull();
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('missing workflow context emits a schema-valid record with truthful nulls', () => {
+    const run = makeTmpDir();
+    const result = runCli(run, {
+      OCR_GENERATED_AT: '2026-07-25T23:09:35.000Z',
+      OCR_INFRASTRUCTURE_FAILURE: 'true',
+      OCR_TELEMETRY_STATE: 'failed',
+      OCR_ARTIFACT_STATE: 'failed',
+    });
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(telemetry.run_id).toBeNull();
+    expect(telemetry.run_attempt).toBeNull();
+    expect(telemetry.pr_number).toBeNull();
+    expect(telemetry.total_findings).toBeNull();
+    expect(telemetry.errors).toContain('OCR metadata artifact was unavailable');
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('derives read failures only from explicit read-specific evidence', () => {
+    const run = makeTmpDir();
+    successArtifacts(run);
+    const result = runCli(
+      run,
+      baseEnv({
+        OCR_FILE_READ_FAILURES: 'unreadable.ts',
+        OCR_PER_FILE_REVIEW_FAILURES: 'unreadable.ts\nlogic.ts',
+      }),
+    );
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(telemetry.file_read_failures).toEqual(['unreadable.ts']);
+    expect(telemetry.file_read_failure_count).toBe(1);
+    expect(telemetry.per_file_review_failures).toEqual([
+      'unreadable.ts',
+      'logic.ts',
+    ]);
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('atomic write: no partial/zero-byte telemetry.json left on failure path', () => {
+    const run = makeTmpDir();
+    successArtifacts(run);
+    const result = runCli(run, baseEnv());
+    expect(result.status).toBe(0);
+    const telemetryPath = path.join(run, 'ocr-telemetry.json');
+    const stat = fs.statSync(telemetryPath);
+    expect(stat.size).toBeGreaterThan(0);
+    const raw = fs.readFileSync(telemetryPath, 'utf8');
+    expect(() => JSON.parse(raw)).not.toThrow();
+    expect(fs.existsSync(path.join(run, 'ocr-telemetry.json.tmp'))).toBe(false);
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('producer output aggregates end-to-end through the real aggregator CLI', () => {
+    const run = makeTmpDir();
+    successArtifacts(run);
+    expect(runCli(run, baseEnv()).status).toBe(0);
+    const result = spawnSync(process.execPath, [AGGREGATOR_SCRIPT, run], {
+      cwd: run,
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    });
+    expect(result.status).toBe(0);
+    const aggregation = JSON.parse(result.stdout);
+    expect(aggregation.runs).toBe(1);
+    expect(aggregation.total_findings).toBe(2);
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('completed_with_warnings reflected in files_reviewed', () => {
+    const run = makeTmpDir();
+    successArtifacts(run);
+    const result = runCli(run, baseEnv({ OCR_FILES_REVIEWED: '3' }));
+    expect(result.status).toBe(0);
+    const telemetry = readEmittedTelemetry(run);
+    expect(telemetry.files_reviewed).toBe(3);
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+
+  it('redacts escaped and embedded secret substrings atomically', () => {
+    const run = makeTmpDir();
+    const secret = 'secret"token\\path';
+    successArtifacts(run);
+    expect(runCli(run, baseEnv()).status).toBe(0);
+    const telemetryPath = path.join(run, 'ocr-telemetry.json');
+    const telemetry = readEmittedTelemetry(run);
+    telemetry.ocr.model = `https://model.test/?credential=${secret}&mode=diagnostic`;
+    fs.writeFileSync(telemetryPath, `${JSON.stringify(telemetry, null, 2)}\n`);
+
+    const result = spawnSync(
+      process.execPath,
+      [TELEMETRY_SCRIPT, '--redact', 'ocr-telemetry.json'],
+      {
+        cwd: run,
+        encoding: 'utf8',
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          OCR_LLM_TOKEN: secret,
+        },
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const raw = fs.readFileSync(telemetryPath, 'utf8');
+    const redacted = JSON.parse(raw);
+    expect(redacted.ocr.model).toBe(
+      'https://model.test/?credential=[REDACTED]&mode=diagnostic',
+    );
+    expect(validateTelemetryRecord(redacted)).toBeNull();
+    expect(fs.existsSync(`${telemetryPath}.redacting-${result.pid}`)).toBe(
+      false,
+    );
+    fs.rmSync(run, { recursive: true, force: true });
+  });
+});

--- a/scripts/tests/ocr-telemetry-lifecycle.test.js
+++ b/scripts/tests/ocr-telemetry-lifecycle.test.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -305,11 +305,12 @@ if (${JSON.stringify(mode)} === 'rename') fs.renameSync = function (from, to, ..
       );
     }
     const output = path.join(directory, 'github-output.txt');
-    execFileSync(
-      'bash',
-      ['-c', commandText(stepNamed(codeReviewJob, 'Capture OCR wall-clock'))],
-      { cwd: directory, env: { ...process.env, GITHUB_OUTPUT: output } },
+    const result = runShell(
+      commandText(stepNamed(codeReviewJob, 'Capture OCR wall-clock')),
+      directory,
+      { GITHUB_OUTPUT: output },
     );
+    expect(result.status).toBe(0);
     const value = fs
       .readFileSync(output, 'utf8')
       .match(/^wall_clock_seconds=(.*)$/m)?.[1];

--- a/scripts/tests/ocr-telemetry-lifecycle.test.js
+++ b/scripts/tests/ocr-telemetry-lifecycle.test.js
@@ -1,0 +1,318 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import {
+  WORKFLOW_PATH,
+  commandText,
+  readRootFile,
+  stepNamed,
+} from './ocr-review-workflow-helpers.js';
+
+let workflow;
+let codeReviewJob;
+const temporaryDirectories = [];
+
+function temporaryDirectory(prefix) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function runShell(script, cwd, env = {}) {
+  return spawnSync('bash', ['-c', script], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      RUNNER_TEMP: cwd,
+      ...env,
+    },
+  });
+}
+
+function substituteExpressions(script, values) {
+  let substituted = script;
+  for (const [expression, value] of Object.entries(values)) {
+    substituted = substituted.replaceAll(`\${{ ${expression} }}`, value);
+  }
+  if (substituted.includes('${{')) {
+    throw new Error('Not all workflow expressions were substituted');
+  }
+  return substituted;
+}
+
+beforeAll(() => {
+  workflow = yaml.load(readRootFile(WORKFLOW_PATH));
+  codeReviewJob = workflow.jobs['code-review'];
+});
+
+afterEach(() => {
+  while (temporaryDirectories.length > 0) {
+    fs.rmSync(temporaryDirectories.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('OCR workflow shell lifecycle behavior', () => {
+  it('keeps action input keys out of every run block', () => {
+    const actionInputKeys = [
+      'if-no-files-found',
+      'retention-days',
+      'compression-level',
+      'overwrite',
+      'include-hidden-files',
+    ];
+    for (const step of codeReviewJob.steps) {
+      if (typeof step.run !== 'string') continue;
+      for (const input of actionInputKeys) {
+        expect(step.run, `${input} must not occur in ${step.name}`).not.toMatch(
+          new RegExp(`^\\s*${input}:`, 'm'),
+        );
+      }
+    }
+  });
+
+  it('executes final classification cleanly and reports post, telemetry, hash, and upload outcomes', () => {
+    const directory = temporaryDirectory('ocr-final-classification-');
+    fs.writeFileSync(path.join(directory, 'ocr-policy-failure.txt'), '');
+    fs.writeFileSync(
+      path.join(directory, 'ocr-infrastructure-failure.txt'),
+      '',
+    );
+    const output = path.join(directory, 'github-output.txt');
+    const script = substituteExpressions(
+      commandText(stepNamed(codeReviewJob, 'Resolve final OCR classification')),
+      {
+        'steps.post-ocr-results.outcome': 'success',
+        'steps.post-ocr-results.outputs.post_state': 'posted',
+        'steps.redact-ocr-artifacts.outcome': 'success',
+        'steps.ocr-telemetry-validation.outputs.valid': 'true',
+        'steps.ocr-manifest-hashes.outputs.valid': 'true',
+        'steps.upload-ocr-artifacts.outcome': 'success',
+        'steps.ocr-classification.outputs.completeness': 'complete',
+      },
+    );
+    const result = runShell(script, directory, { GITHUB_OUTPUT: output });
+    expect(result.status, result.stderr).toBe(0);
+    const outputs = fs.readFileSync(output, 'utf8');
+    expect(outputs).toContain('infrastructure_failure=false');
+    expect(outputs).toContain('post_state=posted');
+    expect(outputs).toContain('telemetry_state=complete');
+    expect(outputs).toContain('hash_state=prepared');
+    expect(outputs).toContain('upload_state=uploaded');
+  });
+
+  it.each(['read', 'write', 'rename'])(
+    'fails closed when source diagnostic %s fails',
+    (mode) => {
+      const directory = temporaryDirectory(`ocr-redaction-${mode}-`);
+      const sentinel = 'SENTINEL-UNREDACTED-CREDENTIAL';
+      fs.writeFileSync(path.join(directory, 'ocr-result.json'), sentinel);
+      const preload = path.join(directory, 'inject-fs-failure.cjs');
+      fs.writeFileSync(
+        preload,
+        `const fs = require('node:fs');
+const target = 'ocr-result.json';
+let injected = false;
+const originalRead = fs.readFileSync;
+const originalWrite = fs.writeFileSync;
+const originalRename = fs.renameSync;
+if (${JSON.stringify(mode)} === 'read') fs.readFileSync = function (name, ...args) {
+  if (!injected && require('node:path').basename(String(name)) === target) { injected = true; const error = new Error('injected read'); error.code = 'EIO'; throw error; }
+  return originalRead.call(this, name, ...args);
+};
+if (${JSON.stringify(mode)} === 'write') fs.writeFileSync = function (name, ...args) {
+  if (!injected && require('node:path').basename(String(name)) === target) { injected = true; const error = new Error('injected write'); error.code = 'EIO'; throw error; }
+  return originalWrite.call(this, name, ...args);
+};
+if (${JSON.stringify(mode)} === 'rename') fs.renameSync = function (from, to, ...args) {
+  if (!injected && require('node:path').basename(String(to)) === target) { injected = true; const error = new Error('injected rename'); error.code = 'EIO'; throw error; }
+  return originalRename.call(this, from, to, ...args);
+};
+`,
+      );
+      const script = commandText(
+        stepNamed(codeReviewJob, 'Redact OCR diagnostic artifacts'),
+      );
+      const result = runShell(script, directory, {
+        NODE_OPTIONS: `--require=${preload}`,
+      });
+      expect(result.status).not.toBe(0);
+      const remaining = fs.existsSync(path.join(directory, 'ocr-result.json'))
+        ? fs.readFileSync(path.join(directory, 'ocr-result.json'), 'utf8')
+        : '';
+      expect(remaining).not.toContain(sentinel);
+      expect(remaining === '' || remaining.includes('redaction failed')).toBe(
+        true,
+      );
+    },
+  );
+
+  it('redacts all supported credential forms and exact token/URL values', () => {
+    const directory = temporaryDirectory('ocr-redaction-patterns-');
+    const token = 'exact-token-value-123456';
+    const url = 'https://secret.example.test/v1?token=exact';
+    const credentials = [
+      `Authorization: Bearer bearer-secret-value`,
+      `x-api-key: x-api-secret-value`,
+      `api-key=api-key-secret-value`,
+      `https://example.test/?key=query-key-secret&token=query-token-secret`,
+      `access_token=access-token-secret`,
+      `refresh_token=refresh-token-secret`,
+      `id_token=id-token-secret-value`,
+      `token=long-token-secret-value`,
+      `secret=long-secret-secret-value`,
+      token,
+      url,
+    ].join('\n');
+    fs.writeFileSync(path.join(directory, 'ocr-result.json'), credentials);
+    const result = runShell(
+      commandText(stepNamed(codeReviewJob, 'Redact OCR diagnostic artifacts')),
+      directory,
+      { OCR_LLM_TOKEN: token, OCR_LLM_URL: url },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    const redacted = fs.readFileSync(
+      path.join(directory, 'ocr-result.json'),
+      'utf8',
+    );
+    expect(redacted).not.toContain('secret-value');
+    expect(redacted).not.toContain(token);
+    expect(redacted).not.toContain(url);
+    expect(redacted.match(/\[REDACTED\]/g)?.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('emits independently valid failure telemetry when the trusted producer module is absent', () => {
+    const directory = temporaryDirectory('ocr-missing-producer-');
+    const output = path.join(directory, 'github-output.txt');
+    const result = runShell(
+      commandText(stepNamed(codeReviewJob, 'Emit OCR telemetry (issue #2676)')),
+      directory,
+      {
+        GITHUB_OUTPUT: output,
+        OCR_RUN_ID: '123',
+        OCR_RUN_ATTEMPT: '1',
+        OCR_PR_NUMBER: '2676',
+        OCR_SHA: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555',
+        OCR_GENERATED_AT: '2026-07-25T23:09:35.000Z',
+        OCR_POST_STATE: 'failed',
+        OCR_ARTIFACT_STATE: 'failed',
+        OCR_HASH_STATE: 'unavailable',
+        OCR_INFRASTRUCTURE_FAILURE: 'true',
+        OCR_POLICY_FAILURE: 'false',
+      },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    const record = JSON.parse(
+      fs.readFileSync(path.join(directory, 'ocr-telemetry.json'), 'utf8'),
+    );
+    expect(record.schema_name).toBe('ocr-telemetry');
+    expect(record.telemetry_state).toBe('failed');
+    expect(record.infrastructure_failure).toBe(true);
+    expect(record.errors).toContain('OCR telemetry producer unavailable');
+    expect(fs.readFileSync(output, 'utf8')).toContain('generated=true');
+  });
+
+  it('preserves independent late failure reasons in the marker', () => {
+    const directory = temporaryDirectory('ocr-late-failures-');
+    const output = path.join(directory, 'github-output.txt');
+    const placeholderResult = runShell(
+      commandText(
+        stepNamed(codeReviewJob, 'Ensure OCR artifact placeholders exist'),
+      ),
+      directory,
+      { GITHUB_OUTPUT: output },
+    );
+    expect(placeholderResult.status, placeholderResult.stderr).toBe(0);
+
+    const evidenceResult = runShell(
+      commandText(stepNamed(codeReviewJob, 'Resolve OCR production evidence')),
+      directory,
+      { GITHUB_OUTPUT: output },
+    );
+    expect(evidenceResult.status, evidenceResult.stderr).toBe(0);
+    const marker = fs.readFileSync(
+      path.join(directory, 'ocr-infrastructure-failure.txt'),
+      'utf8',
+    );
+    expect(marker).toContain('OCR artifact placeholders were missing');
+    expect(marker).toContain('OCR preview evidence was unavailable');
+  });
+
+  it('fails closed and records a marker/output when manifest hashing fails', () => {
+    const directory = temporaryDirectory('ocr-hash-failure-');
+    fs.writeFileSync(
+      path.join(directory, 'ocr-reviewed-range-manifest.json'),
+      '{malformed',
+    );
+    for (const name of [
+      'ocr-result.json',
+      'ocr-stdout.raw',
+      'ocr-stderr.log',
+      'ocr-preflight.txt',
+      'ocr-version.txt',
+      'ocr-preview.txt',
+      'ocr-preview-stderr.log',
+      'ocr-exit-code.txt',
+      'ocr-phase.txt',
+      'ocr-selected-files.txt',
+      'ocr-status.txt',
+      'ocr-infrastructure-failure.txt',
+      'ocr-policy-failure.txt',
+      'ocr-telemetry.json',
+    ]) {
+      if (!fs.existsSync(path.join(directory, name))) {
+        fs.writeFileSync(path.join(directory, name), '{}');
+      }
+    }
+    const output = path.join(directory, 'github-output.txt');
+    const result = runShell(
+      commandText(
+        stepNamed(codeReviewJob, 'Compute reviewed-range manifest hashes'),
+      ),
+      directory,
+      { GITHUB_OUTPUT: output },
+    );
+    expect(result.status).not.toBe(0);
+    expect(fs.readFileSync(output, 'utf8')).toContain('valid=false');
+    expect(
+      fs.readFileSync(
+        path.join(directory, 'ocr-infrastructure-failure.txt'),
+        'utf8',
+      ),
+    ).toContain('manifest hash preparation failed');
+  });
+
+  it.each([
+    ['abc123', null],
+    ['123 trailing', null],
+    ['', null],
+  ])('rejects corrupt wall-clock marker %j', (marker, expected) => {
+    const directory = temporaryDirectory('ocr-wall-clock-');
+    if (marker !== '') {
+      fs.writeFileSync(
+        path.join(directory, 'ocr_wall_clock_start.txt'),
+        marker,
+      );
+    }
+    const output = path.join(directory, 'github-output.txt');
+    execFileSync(
+      'bash',
+      ['-c', commandText(stepNamed(codeReviewJob, 'Capture OCR wall-clock'))],
+      { cwd: directory, env: { ...process.env, GITHUB_OUTPUT: output } },
+    );
+    const value = fs
+      .readFileSync(output, 'utf8')
+      .match(/^wall_clock_seconds=(.*)$/m)?.[1];
+    expect(value || null).toBe(expected);
+  });
+});

--- a/scripts/tests/ocr-telemetry-schema.test.js
+++ b/scripts/tests/ocr-telemetry-schema.test.js
@@ -13,6 +13,7 @@ import {
   isFiniteNonnegativeInteger,
   isFiniteNonnegativeNumber,
   isOwnNumericDistribution,
+  sumDistribution,
 } from '../ocr-telemetry-schema.js';
 
 function validRecord(overrides = {}) {
@@ -134,6 +135,11 @@ describe('isOwnNumericDistribution', () => {
     const distribution = { visible: 1 };
     Object.defineProperty(distribution, 'hidden', { value: -1 });
     expect(isOwnNumericDistribution(distribution)).toBe(false);
+  });
+  it('includes valid non-enumerable own values in distribution totals', () => {
+    const distribution = { visible: 1 };
+    Object.defineProperty(distribution, 'hidden', { value: 2 });
+    expect(sumDistribution(distribution)).toBe(3);
   });
 });
 

--- a/scripts/tests/ocr-telemetry-schema.test.js
+++ b/scripts/tests/ocr-telemetry-schema.test.js
@@ -147,8 +147,8 @@ describe('validateTelemetryRecord — core shape', () => {
   it('rejects incomplete records and unknown fields', () => {
     const missing = validRecord();
     delete missing.errors;
-    expect(validateTelemetryRecord(missing)).toMatch(
-      /errors|required|complete/i,
+    expect(validateTelemetryRecord(missing)).toContain(
+      'record is incomplete; missing field: errors',
     );
     expect(validateTelemetryRecord(validRecord({ unexpected: true }))).toMatch(
       /unexpected|unknown|complete/i,
@@ -259,6 +259,13 @@ describe('validateTelemetryRecord — core shape', () => {
     expect(
       validateTelemetryRecord(validRecord({ generated_at: 'not-a-date' })),
     ).toMatch(/generated_at/i);
+  });
+  it('accepts an ISO-8601 timestamp with a compact numeric offset', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({ generated_at: '2026-07-25T23:09:35+0530' }),
+      ),
+    ).toBeNull();
   });
   it('rejects negative wall_clock_seconds', () => {
     expect(
@@ -381,6 +388,22 @@ describe('validateReconciliation — invariants', () => {
     };
     expect(validateReconciliation(record)).toMatch(/cross|category_severity/i);
   });
+  it('reports category-distribution overflow explicitly', () => {
+    const record = validRecord({
+      total_findings: Number.MAX_SAFE_INTEGER,
+      findings: {
+        by_category: { bug: Number.MAX_SAFE_INTEGER, style: 1 },
+        by_severity: { high: Number.MAX_SAFE_INTEGER },
+        by_category_severity: {
+          bug: { high: Number.MAX_SAFE_INTEGER },
+          style: { high: 1 },
+        },
+      },
+    });
+    expect(validateReconciliation(record)).toBe(
+      'findings.by_category sum exceeds safe integer range',
+    );
+  });
   it('fails when file_read_failure_count != file_read_failures.length', () => {
     const record = validRecord({
       file_read_failures: ['a', 'b'],
@@ -432,7 +455,7 @@ describe('validateTelemetryRecord — strict lifecycle and reconciliation', () =
     expect(validateTelemetryRecord(extraSeverity)).toMatch(/cross severity/i);
   });
 
-  it('rejects token totals that omit cache usage', () => {
+  it('accepts OCR totals that include cached tokens within input/output', () => {
     expect(
       validateTelemetryRecord(
         validRecord({
@@ -442,6 +465,22 @@ describe('validateTelemetryRecord — strict lifecycle and reconciliation', () =
             cache_read: 3,
             cache_write: 2,
             total: 15,
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('rejects token totals that differ from input plus output', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({
+          tokens: {
+            input: 10,
+            output: 5,
+            cache_read: 3,
+            cache_write: 2,
+            total: 20,
           },
         }),
       ),

--- a/scripts/tests/ocr-telemetry-schema.test.js
+++ b/scripts/tests/ocr-telemetry-schema.test.js
@@ -1,0 +1,513 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  SCHEMA_VERSION,
+  SCHEMA_NAME,
+  validateTelemetryRecord,
+  validateReconciliation,
+  isFiniteNonnegativeInteger,
+  isFiniteNonnegativeNumber,
+  isOwnNumericDistribution,
+} from '../ocr-telemetry-schema.js';
+
+function validRecord(overrides = {}) {
+  return {
+    schema: SCHEMA_VERSION,
+    schema_name: SCHEMA_NAME,
+    run_id: '111',
+    run_attempt: '1',
+    pr_number: 2676,
+    sha: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555',
+    generated_at: '2026-07-25T23:09:35.000Z',
+    ocr: { version: '1.7.16', model: 'm', concurrency: 2 },
+    wall_clock_seconds: 100,
+    cli_elapsed_seconds: 95,
+    files_previewed: 7,
+    files_reviewed: 7,
+    file_read_failures: [],
+    file_read_failure_count: 0,
+    per_file_review_failures: [],
+    per_file_review_failure_count: 0,
+    total_findings: 2,
+    findings: {
+      by_category: { bug: 1, style: 1 },
+      by_severity: { high: 1, low: 1 },
+      by_category_severity: {
+        bug: { high: 1, low: 0 },
+        style: { high: 0, low: 1 },
+      },
+    },
+    inline_posted: 1,
+    already_resolved: null,
+    already_posted_or_skipped_dedup: 1,
+    comments_skipped: 1,
+    comments_failed: 0,
+    comments_routed_summary: 0,
+    comments_total: 2,
+    infrastructure_failure: false,
+    policy_failure: false,
+    completeness: 'complete',
+    publication_state: 'complete',
+    reviewed_range_manifest: {
+      selected_files: 7,
+      completed_files: 7,
+      failed_files: 0,
+    },
+    tokens: {
+      input: 10,
+      output: 5,
+      cache_read: 0,
+      cache_write: 0,
+      total: 15,
+    },
+    telemetry_state: 'complete',
+    post_state: 'posted',
+    artifact_state: 'prepared',
+    hash_state: 'prepared',
+    marker_state: {
+      infrastructure_failure: false,
+      policy_failure: false,
+    },
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe('isFiniteNonnegativeInteger', () => {
+  it('accepts a nonnegative integer', () => {
+    expect(isFiniteNonnegativeInteger(0)).toBe(true);
+    expect(isFiniteNonnegativeInteger(42)).toBe(true);
+  });
+  it('rejects negative, fractional, nonfinite, non-number', () => {
+    expect(isFiniteNonnegativeInteger(-1)).toBe(false);
+    expect(isFiniteNonnegativeInteger(1.5)).toBe(false);
+    expect(isFiniteNonnegativeInteger(Infinity)).toBe(false);
+    expect(isFiniteNonnegativeInteger(NaN)).toBe(false);
+    expect(isFiniteNonnegativeInteger('1')).toBe(false);
+    expect(isFiniteNonnegativeInteger(null)).toBe(false);
+  });
+});
+
+describe('isFiniteNonnegativeNumber', () => {
+  it('accepts a nonnegative finite number', () => {
+    expect(isFiniteNonnegativeNumber(0)).toBe(true);
+    expect(isFiniteNonnegativeNumber(1.5)).toBe(true);
+  });
+  it('rejects negative, nonfinite, non-number', () => {
+    expect(isFiniteNonnegativeNumber(-0.1)).toBe(false);
+    expect(isFiniteNonnegativeNumber(Infinity)).toBe(false);
+    expect(isFiniteNonnegativeNumber(NaN)).toBe(false);
+    expect(isFiniteNonnegativeNumber('x')).toBe(false);
+    expect(isFiniteNonnegativeNumber(null)).toBe(false);
+    expect(isFiniteNonnegativeNumber(undefined)).toBe(false);
+  });
+});
+
+describe('isOwnNumericDistribution', () => {
+  it('rejects unsafe integers and numbers', () => {
+    expect(
+      isOwnNumericDistribution({ count: Number.MAX_SAFE_INTEGER + 1 }),
+    ).toBe(false);
+    expect(isOwnNumericDistribution({ count: Number.MAX_VALUE })).toBe(false);
+  });
+  it('accepts a plain object of nonnegative integers', () => {
+    expect(isOwnNumericDistribution({ a: 1, b: 2 })).toBe(true);
+  });
+  it('rejects arrays masquerading as objects', () => {
+    expect(isOwnNumericDistribution([1, 2])).toBe(false);
+  });
+  it('rejects __proto__/constructor/prototype keys', () => {
+    expect(isOwnNumericDistribution({ __proto__: { x: 1 } })).toBe(false);
+    expect(isOwnNumericDistribution({ constructor: 1 })).toBe(false);
+    expect(isOwnNumericDistribution({ prototype: 1 })).toBe(false);
+  });
+  it('rejects non-integer values', () => {
+    expect(isOwnNumericDistribution({ a: 1.5 })).toBe(false);
+    expect(isOwnNumericDistribution({ a: 'x' })).toBe(false);
+  });
+  it('rejects invalid non-enumerable own values', () => {
+    const distribution = { visible: 1 };
+    Object.defineProperty(distribution, 'hidden', { value: -1 });
+    expect(isOwnNumericDistribution(distribution)).toBe(false);
+  });
+});
+
+describe('validateTelemetryRecord — core shape', () => {
+  it('returns null for a valid record', () => {
+    expect(validateTelemetryRecord(validRecord())).toBeNull();
+  });
+  it('rejects null', () => {
+    expect(validateTelemetryRecord(null)).toMatch(/object/i);
+  });
+  it('rejects incomplete records and unknown fields', () => {
+    const missing = validRecord();
+    delete missing.errors;
+    expect(validateTelemetryRecord(missing)).toMatch(
+      /errors|required|complete/i,
+    );
+    expect(validateTelemetryRecord(validRecord({ unexpected: true }))).toMatch(
+      /unexpected|unknown|complete/i,
+    );
+  });
+  it('rejects non-enumerable unknown own fields', () => {
+    const record = validRecord();
+    Object.defineProperty(record, 'unexpected', { value: true });
+    expect(validateTelemetryRecord(record)).toMatch(/unexpected|unknown/i);
+  });
+  it('accepts a complete failure record with unavailable metrics as null', () => {
+    const failure = validRecord({
+      run_id: null,
+      run_attempt: null,
+      pr_number: null,
+      sha: null,
+      ocr: { version: null, model: null, concurrency: null },
+      wall_clock_seconds: null,
+      cli_elapsed_seconds: null,
+      files_previewed: null,
+      files_reviewed: null,
+      file_read_failures: null,
+      file_read_failure_count: null,
+      per_file_review_failures: null,
+      per_file_review_failure_count: null,
+      total_findings: null,
+      findings: null,
+      inline_posted: null,
+      already_resolved: null,
+      already_posted_or_skipped_dedup: null,
+      comments_skipped: null,
+      comments_failed: null,
+      comments_routed_summary: null,
+      comments_total: null,
+      infrastructure_failure: true,
+      completeness: null,
+      publication_state: null,
+      reviewed_range_manifest: null,
+      tokens: null,
+      telemetry_state: 'failed',
+      post_state: null,
+      artifact_state: 'failed',
+      hash_state: 'failed',
+      marker_state: {
+        infrastructure_failure: true,
+        policy_failure: false,
+      },
+      errors: ['OCR metadata artifact was unavailable'],
+    });
+    expect(validateTelemetryRecord(failure)).toBeNull();
+    expect(validateReconciliation(failure)).toBeNull();
+  });
+  it('rejects arrays masquerading as records', () => {
+    expect(validateTelemetryRecord([1, 2, 3])).toMatch(/plain object/i);
+  });
+  it('rejects a record with a __proto__ own property (prototype pollution)', () => {
+    const evil = JSON.parse(
+      '{"__proto__":{"polluted":1},"schema_name":"ocr-telemetry"}',
+    );
+    expect(validateTelemetryRecord(evil)).toMatch(
+      /plain object|__proto__|prototype/i,
+    );
+  });
+  it('rejects wrong schema_name', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ schema_name: 'other' })),
+    ).toMatch(/schema_name/i);
+  });
+  it('rejects unsupported schema version', () => {
+    expect(validateTelemetryRecord(validRecord({ schema: 99 }))).toMatch(
+      /schema/i,
+    );
+  });
+  it('rejects empty run_id', () => {
+    expect(validateTelemetryRecord(validRecord({ run_id: '' }))).toMatch(
+      /run_id/i,
+    );
+  });
+  it('rejects non-positive pr_number', () => {
+    expect(validateTelemetryRecord(validRecord({ pr_number: 0 }))).toMatch(
+      /pr_number/i,
+    );
+  });
+  it('accepts a valid run_attempt integer string', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ run_attempt: '3' })),
+    ).toBeNull();
+  });
+  it('rejects a malformed run_attempt', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ run_attempt: 'abc' })),
+    ).toMatch(/run_attempt/i);
+  });
+  it('rejects a numeric run_attempt instead of coercing it', () => {
+    expect(validateTelemetryRecord(validRecord({ run_attempt: 3 }))).toMatch(
+      /run_attempt/i,
+    );
+  });
+  it('rejects a sha that is not a 40-char hex when present', () => {
+    expect(validateTelemetryRecord(validRecord({ sha: 'nothex' }))).toMatch(
+      /sha/i,
+    );
+  });
+  it('accepts null sha (unavailable)', () => {
+    expect(validateTelemetryRecord(validRecord({ sha: null }))).toBeNull();
+  });
+  it('rejects a malformed generated_at', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ generated_at: 'not-a-date' })),
+    ).toMatch(/generated_at/i);
+  });
+  it('rejects negative wall_clock_seconds', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ wall_clock_seconds: -1 })),
+    ).toMatch(/wall_clock_seconds/i);
+  });
+  it('accepts null wall_clock_seconds', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ wall_clock_seconds: null })),
+    ).toBeNull();
+  });
+  it('rejects Infinity wall_clock_seconds', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ wall_clock_seconds: Infinity })),
+    ).toMatch(/wall_clock_seconds/i);
+  });
+  it('rejects non-boolean infrastructure_failure', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ infrastructure_failure: 'true' })),
+    ).toMatch(/infrastructure_failure/i);
+  });
+  it('rejects non-array file_read_failures', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ file_read_failures: 'x' })),
+    ).toMatch(/file_read_failures/i);
+  });
+  it('rejects non-string entries in file_read_failures', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({ file_read_failures: [1, 2], file_read_failure_count: 2 }),
+      ),
+    ).toMatch(/file_read_failures/i);
+  });
+  it('accepts null file_read_failures (unavailable)', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({
+          file_read_failures: null,
+          file_read_failure_count: null,
+        }),
+      ),
+    ).toBeNull();
+  });
+  it('rejects findings with non-numeric distribution values', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({
+          findings: {
+            by_category: { bug: 'x' },
+            by_severity: { high: 1 },
+            by_category_severity: { bug: { high: 1 } },
+          },
+        }),
+      ),
+    ).toMatch(/findings/i);
+  });
+  it('rejects negative counts in distributions', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({
+          findings: {
+            by_category: { bug: -1 },
+            by_severity: { high: 1 },
+            by_category_severity: { bug: { high: 1 } },
+          },
+        }),
+      ),
+    ).toMatch(/findings/i);
+  });
+});
+
+describe('validateTelemetryRecord — adversarial prototype pollution', () => {
+  it('rejects __proto__ as a category key (JSON-parsed attack)', () => {
+    const record = validRecord();
+    record.findings.by_category = JSON.parse('{"__proto__":1}');
+    record.findings.by_severity = { high: 1 };
+    record.findings.by_category_severity = { bug: { high: 1 } };
+    expect(validateTelemetryRecord(record)).toMatch(/prototype|__proto__|own/i);
+  });
+  it('rejects constructor as a severity key', () => {
+    const record = validRecord();
+    record.findings.by_category = { bug: 1 };
+    record.findings.by_severity = { constructor: 1 };
+    record.findings.by_category_severity = { bug: { high: 1 } };
+    expect(validateTelemetryRecord(record)).toMatch(
+      /prototype|constructor|own/i,
+    );
+  });
+  it('rejects prototype as a cross-distribution outer key', () => {
+    const record = validRecord();
+    record.findings.by_category_severity = { prototype: { high: 1 } };
+    expect(validateTelemetryRecord(record)).toMatch(/prototype|own/i);
+  });
+});
+
+describe('validateReconciliation — invariants', () => {
+  it('returns null when category sum equals total_findings', () => {
+    expect(validateReconciliation(validRecord())).toBeNull();
+  });
+  it('fails when category sum differs from total_findings', () => {
+    const record = validRecord();
+    record.findings.by_category = { bug: 1, style: 1, extra: 1 };
+    expect(validateReconciliation(record)).toMatch(/category|total/i);
+  });
+  it('fails when severity sum differs from total_findings', () => {
+    const record = validRecord();
+    record.findings.by_severity = { high: 5 };
+    expect(validateReconciliation(record)).toMatch(/severity|total/i);
+  });
+  it('fails when cross sum differs from total_findings', () => {
+    const record = validRecord();
+    record.findings.by_category_severity = { bug: { high: 1 } };
+    expect(validateReconciliation(record)).toMatch(/cross|category_severity/i);
+  });
+  it('fails when per-category total differs from by_category', () => {
+    const record = validRecord();
+    record.findings.by_category_severity = {
+      bug: { high: 1, low: 5 },
+      style: { low: 1 },
+    };
+    expect(validateReconciliation(record)).toMatch(/cross|category_severity/i);
+  });
+  it('fails when file_read_failure_count != file_read_failures.length', () => {
+    const record = validRecord({
+      file_read_failures: ['a', 'b'],
+      file_read_failure_count: 1,
+    });
+    expect(validateReconciliation(record)).toMatch(/file_read_failure_count/i);
+  });
+  it('accepts null file_read_failures with null count', () => {
+    expect(
+      validateReconciliation(
+        validRecord({
+          file_read_failures: null,
+          file_read_failure_count: null,
+        }),
+      ),
+    ).toBeNull();
+  });
+  it('rejects delimiter-collision category coverage adversaries', () => {
+    const record = validRecord({
+      findings: {
+        by_category: { a: 1, 'b\\u0000c': 1 },
+        by_severity: { high: 2 },
+        by_category_severity: {
+          'a\\u0000b': { high: 1 },
+          c: { high: 1 },
+        },
+      },
+    });
+    expect(validateTelemetryRecord(record)).toMatch(/cross category coverage/i);
+  });
+});
+
+describe('validateTelemetryRecord — strict lifecycle and reconciliation', () => {
+  it('rejects calendar-impossible timestamps', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({ generated_at: '2026-02-30T12:00:00.000Z' }),
+      ),
+    ).toMatch(/generated_at/i);
+  });
+
+  it('rejects extra zero-only cross keys in either direction', () => {
+    const extraCategory = validRecord();
+    extraCategory.findings.by_category_severity.extra = { high: 0, low: 0 };
+    expect(validateTelemetryRecord(extraCategory)).toMatch(/cross category/i);
+
+    const extraSeverity = validRecord();
+    extraSeverity.findings.by_category_severity.bug.medium = 0;
+    expect(validateTelemetryRecord(extraSeverity)).toMatch(/cross severity/i);
+  });
+
+  it('rejects token totals that omit cache usage', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({
+          tokens: {
+            input: 10,
+            output: 5,
+            cache_read: 3,
+            cache_write: 2,
+            total: 15,
+          },
+        }),
+      ),
+    ).toMatch(/tokens\.total/i);
+  });
+
+  it.each([
+    ['telemetry_state', 'arbitrary'],
+    ['post_state', 'arbitrary'],
+    ['artifact_state', 'uploaded'],
+    ['hash_state', 'arbitrary'],
+  ])('rejects arbitrary %s values', (field, value) => {
+    expect(validateTelemetryRecord(validRecord({ [field]: value }))).toMatch(
+      new RegExp(field),
+    );
+  });
+
+  it('rejects errors with successful lifecycle classifications', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ errors: ['unexpected failure'] })),
+    ).toMatch(/errors|infrastructure/i);
+  });
+
+  it('rejects failed artifact/hash/Post states without infrastructure failure', () => {
+    expect(
+      validateTelemetryRecord(validRecord({ hash_state: 'failed' })),
+    ).toMatch(/infrastructure/i);
+  });
+
+  it('rejects contradictory manifest and preview counts', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({
+          files_previewed: 2,
+          files_reviewed: 2,
+          reviewed_range_manifest: {
+            selected_files: 2,
+            completed_files: 2,
+            failed_files: 1,
+          },
+        }),
+      ),
+    ).toMatch(/manifest|selected/i);
+  });
+
+  it('rejects failure counts above attempted files', () => {
+    expect(
+      validateTelemetryRecord(
+        validRecord({
+          files_previewed: 1,
+          files_reviewed: 1,
+          file_read_failures: ['a.ts', 'b.ts'],
+          file_read_failure_count: 2,
+          reviewed_range_manifest: {
+            selected_files: 1,
+            completed_files: 1,
+            failed_files: 0,
+          },
+        }),
+      ),
+    ).toMatch(/file_read_failure_count|files_previewed/i);
+  });
+
+  it('rejects publication counters above comments_total', () => {
+    expect(validateTelemetryRecord(validRecord({ inline_posted: 3 }))).toMatch(
+      /inline_posted|comments_total/i,
+    );
+  });
+});

--- a/scripts/tests/ocr-telemetry-workflow.test.js
+++ b/scripts/tests/ocr-telemetry-workflow.test.js
@@ -1,0 +1,367 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import {
+  WORKFLOW_PATH,
+  commandText,
+  readRootFile,
+  stepNamed,
+} from './ocr-review-workflow-helpers.js';
+
+describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () => {
+  let workflow;
+  let codeReviewJob;
+  let _postScript;
+  let initialClassificationStep;
+  let _initialClassificationRun;
+  let telemetryStep;
+  let telemetryRun;
+  let redactStep;
+  let _redactRun;
+  let placeholderStep;
+  let placeholderRun;
+  let hashStep;
+  let _hashRun;
+  let uploadStep;
+  let wallClockStep;
+  let _wallClockRun;
+  let filesReviewedStep;
+  let _filesReviewedRun;
+  let finalClassificationStep;
+  let _finalClassificationRun;
+
+  beforeAll(() => {
+    workflow = yaml.load(readRootFile(WORKFLOW_PATH));
+    codeReviewJob = workflow.jobs?.['code-review'];
+    expect(codeReviewJob).toBeTruthy();
+    _postScript = commandText(stepNamed(codeReviewJob, 'Post OCR results'));
+    initialClassificationStep = stepNamed(
+      codeReviewJob,
+      'Resolve OCR failure classification',
+    );
+    _initialClassificationRun = commandText(initialClassificationStep);
+    telemetryStep = stepNamed(
+      codeReviewJob,
+      'Emit OCR telemetry (issue #2676)',
+    );
+    telemetryRun = commandText(telemetryStep);
+    redactStep = stepNamed(codeReviewJob, 'Redact OCR diagnostic artifacts');
+    _redactRun = commandText(redactStep);
+    placeholderStep = stepNamed(
+      codeReviewJob,
+      'Ensure OCR artifact placeholders exist',
+    );
+    placeholderRun = commandText(placeholderStep);
+    hashStep = stepNamed(
+      codeReviewJob,
+      'Compute reviewed-range manifest hashes',
+    );
+    _hashRun = commandText(hashStep);
+    uploadStep = stepNamed(codeReviewJob, 'Upload OCR artifacts');
+  });
+
+  describe('step ordering and id', () => {
+    it('places telemetry AFTER classification', () => {
+      const names = codeReviewJob.steps.map((step) => step.name);
+      const classificationIndex = names.indexOf(
+        'Resolve OCR failure classification',
+      );
+      const telemetryIndex = names.indexOf('Emit OCR telemetry (issue #2676)');
+      expect(classificationIndex).toBeGreaterThan(-1);
+      expect(telemetryIndex).toBeGreaterThan(classificationIndex);
+    });
+
+    it('places final classification after telemetry validation and upload', () => {
+      const names = codeReviewJob.steps.map((step) => step.name);
+      const validationIndex = names.indexOf('Validate redacted OCR telemetry');
+      const uploadIndex = names.indexOf('Upload OCR artifacts');
+      const finalIndex = names.indexOf('Resolve final OCR classification');
+      expect(validationIndex).toBeGreaterThan(-1);
+      expect(finalIndex).toBeGreaterThan(validationIndex);
+      expect(finalIndex).toBeGreaterThan(uploadIndex);
+    });
+
+    it('places final classification AFTER the Post OCR results step', () => {
+      const names = codeReviewJob.steps.map((step) => step.name);
+      const postIndex = names.indexOf('Post OCR results');
+      const finalIndex = names.indexOf('Resolve final OCR classification');
+      expect(postIndex).toBeGreaterThan(-1);
+      expect(finalIndex).toBeGreaterThan(postIndex);
+    });
+
+    it('redacts source diagnostics before telemetry extraction', () => {
+      const names = codeReviewJob.steps.map((step) => step.name);
+      const telemetryIndex = names.indexOf('Emit OCR telemetry (issue #2676)');
+      const redactIndex = names.indexOf('Redact OCR diagnostic artifacts');
+      expect(redactIndex).toBeLessThan(telemetryIndex);
+    });
+
+    it('places redaction BEFORE hash computation', () => {
+      const names = codeReviewJob.steps.map((step) => step.name);
+      const redactIndex = names.indexOf('Redact OCR diagnostic artifacts');
+      const hashIndex = names.indexOf('Compute reviewed-range manifest hashes');
+      expect(hashIndex).toBeGreaterThan(redactIndex);
+    });
+
+    it('places non-telemetry placeholder recovery before telemetry and upload after validation', () => {
+      const names = codeReviewJob.steps.map((step) => step.name);
+      const telemetryIndex = names.indexOf('Emit OCR telemetry (issue #2676)');
+      const placeholderIndex = names.indexOf(
+        'Ensure OCR artifact placeholders exist',
+      );
+      const validationIndex = names.indexOf('Validate redacted OCR telemetry');
+      const uploadIndex = names.indexOf('Upload OCR artifacts');
+      expect(placeholderIndex).toBeLessThan(telemetryIndex);
+      expect(validationIndex).toBeGreaterThan(telemetryIndex);
+      expect(uploadIndex).toBeGreaterThan(validationIndex);
+    });
+  });
+
+  describe('telemetry step runs always after classification', () => {
+    it('runs with if: always()', () => {
+      expect(telemetryStep.if).toBe('always()');
+    });
+
+    it('uses the trusted scripts/ocr-telemetry.js module', () => {
+      expect(telemetryStep.shell).toBe('bash');
+      expect(telemetryRun).toContain('scripts/ocr-telemetry.js');
+    });
+
+    it('passes run identity and PR context via environment', () => {
+      expect(telemetryStep.env?.OCR_RUN_ID).toBe('${{ github.run_id }}');
+      expect(telemetryStep.env?.OCR_RUN_ATTEMPT).toBe(
+        '${{ github.run_attempt }}',
+      );
+      expect(telemetryStep.env?.OCR_PR_NUMBER).toBe(
+        '${{ steps.pr-context.outputs.number }}',
+      );
+      expect(telemetryStep.env?.OCR_SHA).toBe('${{ env.HEAD_SHA }}');
+    });
+
+    it('does NOT use github.event.head_commit.timestamp (absent for non-push triggers)', () => {
+      expect(telemetryStep.env?.OCR_GENERATED_AT).not.toBe(
+        '${{ github.event.head_commit.timestamp }}',
+      );
+    });
+
+    it('passes an authoritative workflow-measured wall-clock duration', () => {
+      expect(telemetryStep.env?.OCR_WALL_CLOCK_SECONDS).toBe(
+        '${{ steps.ocr-wall-clock.outputs.wall_clock_seconds }}',
+      );
+    });
+
+    it('passes the validated OCR result summary files_reviewed count', () => {
+      expect(telemetryStep.env?.OCR_FILES_REVIEWED).toBe(
+        '${{ steps.ocr-files-reviewed.outputs.files_reviewed }}',
+      );
+    });
+
+    it('passes the post-ocr-results lifecycle state', () => {
+      expect(telemetryStep.env?.OCR_POST_STATE).toBe(
+        '${{ steps.ocr-telemetry-classification.outputs.post_state }}',
+      );
+    });
+
+    it('does NOT alias comments_skipped as already_resolved', () => {
+      expect(telemetryStep.env).not.toHaveProperty('OCR_ALREADY_RESOLVED');
+    });
+
+    it('passes classification flags and output counters', () => {
+      expect(telemetryStep.env?.OCR_INFRASTRUCTURE_FAILURE).toBe(
+        '${{ steps.ocr-telemetry-classification.outputs.infrastructure_failure }}',
+      );
+      expect(telemetryStep.env?.OCR_POLICY_FAILURE).toBe(
+        '${{ steps.ocr-telemetry-classification.outputs.policy_failure }}',
+      );
+      expect(telemetryStep.env?.OCR_INLINE_POSTED).toBe(
+        '${{ steps.post-ocr-results.outputs.comments_inline }}',
+      );
+      expect(telemetryStep.env?.OCR_COMMENTS_SKIPPED).toBe(
+        '${{ steps.post-ocr-results.outputs.comments_skipped }}',
+      );
+      expect(telemetryStep.env?.OCR_COMMENTS_FAILED).toBe(
+        '${{ steps.post-ocr-results.outputs.comments_failed }}',
+      );
+      expect(telemetryStep.env?.OCR_COMMENTS_TOTAL).toBe(
+        '${{ steps.post-ocr-results.outputs.comments_total }}',
+      );
+    });
+
+    it('invokes the module to write ocr-telemetry.json and append step summary', () => {
+      expect(telemetryRun).toContain('scripts/ocr-telemetry.js');
+      expect(telemetryRun).toContain('GITHUB_STEP_SUMMARY');
+    });
+
+    it('does not initialize telemetry as a zero-byte placeholder', () => {
+      const initRun = commandText(
+        stepNamed(codeReviewJob, 'Initialize OCR artifact files'),
+      );
+      expect(initRun).not.toContain(': > ocr-telemetry.json');
+    });
+  });
+
+  describe('telemetry artifact lifecycle', () => {
+    it('redacts telemetry with the producer CLI after source redaction', () => {
+      const validationStep = stepNamed(
+        codeReviewJob,
+        'Validate redacted OCR telemetry',
+      );
+      expect(commandText(validationStep)).toContain(
+        '--redact ocr-telemetry.json',
+      );
+    });
+
+    it('never replaces telemetry with an empty placeholder', () => {
+      expect(placeholderRun).not.toContain('ocr-telemetry.json');
+    });
+
+    it('includes ocr-telemetry.json in the upload artifact path', () => {
+      expect(uploadStep.with?.path).toContain('ocr-telemetry.json');
+    });
+  });
+
+  describe('authoritative wall-clock capture', () => {
+    beforeAll(() => {
+      wallClockStep = stepNamed(codeReviewJob, 'Capture OCR wall-clock');
+      _wallClockRun = commandText(wallClockStep);
+    });
+
+    it('captures a start timestamp before the OCR review invocation', () => {
+      const runStep = stepNamed(codeReviewJob, 'Run OpenCodeReview');
+      const runScript = commandText(runStep);
+      expect(runScript).toMatch(/OCR_WALL_CLOCK_START|ocr_wall_clock_start/);
+    });
+
+    it('emits a wall_clock_seconds output id ocr-wall-clock', () => {
+      expect(wallClockStep.id).toBe('ocr-wall-clock');
+      expect(wallClockStep.if).toBe('always()');
+      expect(_wallClockRun).toContain('wall_clock_seconds');
+    });
+  });
+
+  describe('validated files_reviewed from OCR result summary', () => {
+    beforeAll(() => {
+      filesReviewedStep = stepNamed(
+        codeReviewJob,
+        'Extract OCR files_reviewed',
+      );
+      _filesReviewedRun = commandText(filesReviewedStep);
+    });
+
+    it('reads summary.files_reviewed from ocr-result.json and exports it', () => {
+      expect(filesReviewedStep.id).toBe('ocr-files-reviewed');
+      expect(_filesReviewedRun).toContain('files_reviewed');
+      expect(_filesReviewedRun).toContain('ocr-result.json');
+    });
+  });
+
+  describe('final classification after post and telemetry', () => {
+    beforeAll(() => {
+      finalClassificationStep = stepNamed(
+        codeReviewJob,
+        'Resolve final OCR classification',
+      );
+      _finalClassificationRun = commandText(finalClassificationStep);
+    });
+
+    it('runs under always() after the Post OCR results step', () => {
+      const names = codeReviewJob.steps.map((step) => step.name);
+      const postIndex = names.indexOf('Post OCR results');
+      const finalIndex = names.indexOf('Resolve final OCR classification');
+      expect(postIndex).toBeGreaterThan(-1);
+      expect(finalIndex).toBeGreaterThan(postIndex);
+      expect(finalClassificationStep.if).toBe('always()');
+    });
+
+    it('emits infrastructure_failure and policy_failure from final marker files', () => {
+      expect(_finalClassificationRun).toContain('infrastructure_failure');
+      expect(_finalClassificationRun).toContain('policy_failure');
+      expect(_finalClassificationRun).toContain(
+        'ocr-infrastructure-failure.txt',
+      );
+      expect(_finalClassificationRun).toContain('ocr-policy-failure.txt');
+    });
+  });
+  it('validates with the shared validator after telemetry redaction', () => {
+    const names = codeReviewJob.steps.map((step) => step.name);
+    const redactIndex = names.indexOf('Redact OCR diagnostic artifacts');
+    const validationStep = stepNamed(
+      codeReviewJob,
+      'Validate redacted OCR telemetry',
+    );
+    const validationIndex = names.indexOf(validationStep.name);
+    expect(validationIndex).toBeGreaterThan(redactIndex);
+    expect(commandText(validationStep)).toContain('--validate');
+    expect(validationStep.id).toBe('ocr-telemetry-validation');
+  });
+
+  it('hashes telemetry before reading the finalized manifest for its self-hash', () => {
+    expect(_hashRun).toMatch(
+      /hashableArtifacts\s*=\s*\[[\s\S]*ocr-telemetry\.json[\s\S]*\];/,
+    );
+    expect(_hashRun.indexOf('ocr-telemetry.json')).toBeLessThan(
+      _hashRun.indexOf('const manifestContent'),
+    );
+  });
+
+  it('only uploads when redacted telemetry validation succeeded', () => {
+    expect(String(uploadStep.if)).toContain(
+      'steps.ocr-telemetry-validation.outputs.valid',
+    );
+    expect(uploadStep.id).toBe('upload-ocr-artifacts');
+  });
+
+  it('publishes final job outputs from post-upload classification', () => {
+    expect(codeReviewJob.outputs.infrastructure_failure).toContain(
+      'ocr-final-classification',
+    );
+    expect(codeReviewJob.outputs.policy_failure).toContain(
+      'ocr-final-classification',
+    );
+    expect(codeReviewJob.outputs.completeness).toContain(
+      'ocr-final-classification',
+    );
+  });
+
+  describe('telemetry validation before upload', () => {
+    it('validates the redacted ocr-telemetry.json with the shared CLI', () => {
+      const validationStep = stepNamed(
+        codeReviewJob,
+        'Validate redacted OCR telemetry',
+      );
+      expect(commandText(validationStep)).toContain(
+        '--validate ocr-telemetry.json',
+      );
+    });
+
+    it('uses an atomic write (temp file + rename) for ocr-telemetry.json', () => {
+      // The trusted producer module performs the atomic write internally;
+      // the workflow step invokes node scripts/ocr-telemetry.js which writes
+      // via an atomic temp+rename. Verify the step does not itself truncate
+      // ocr-telemetry.json before invoking the producer.
+      expect(telemetryRun).not.toMatch(/: > ocr-telemetry\.json/);
+    });
+  });
+
+  describe('ocr-selected-files.txt captured for all review runs', () => {
+    it('extracts selected files before entering the changed-tests-only guard', () => {
+      const previewStep = stepNamed(
+        codeReviewJob,
+        'Verify review scope includes changed tests',
+      );
+      const previewRun = commandText(previewStep);
+      const selectedFilesWrite = previewRun.indexOf('> ocr-selected-files.txt');
+      const changedTestsGuard = previewRun.indexOf(
+        'if [ -n "$changed_tests" ]; then',
+      );
+      expect(selectedFilesWrite).toBeGreaterThan(-1);
+      expect(selectedFilesWrite).toBeLessThan(changedTestsGuard);
+      expect(previewRun.match(/> ocr-selected-files\.txt/g)).toHaveLength(1);
+    });
+  });
+});

--- a/scripts/tests/ocr-telemetry-workflow.test.js
+++ b/scripts/tests/ocr-telemetry-workflow.test.js
@@ -16,18 +16,14 @@ import {
 describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () => {
   let workflow;
   let codeReviewJob;
-  let _postScript;
-  let initialClassificationStep;
-  let _initialClassificationRun;
   let telemetryStep;
   let telemetryRun;
-  let redactStep;
-  let _redactRun;
   let placeholderStep;
   let placeholderRun;
   let hashStep;
   let _hashRun;
   let uploadStep;
+  let telemetryUploadStep;
   let wallClockStep;
   let _wallClockRun;
   let filesReviewedStep;
@@ -39,19 +35,11 @@ describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () 
     workflow = yaml.load(readRootFile(WORKFLOW_PATH));
     codeReviewJob = workflow.jobs?.['code-review'];
     expect(codeReviewJob).toBeTruthy();
-    _postScript = commandText(stepNamed(codeReviewJob, 'Post OCR results'));
-    initialClassificationStep = stepNamed(
-      codeReviewJob,
-      'Resolve OCR failure classification',
-    );
-    _initialClassificationRun = commandText(initialClassificationStep);
     telemetryStep = stepNamed(
       codeReviewJob,
       'Emit OCR telemetry (issue #2676)',
     );
     telemetryRun = commandText(telemetryStep);
-    redactStep = stepNamed(codeReviewJob, 'Redact OCR diagnostic artifacts');
-    _redactRun = commandText(redactStep);
     placeholderStep = stepNamed(
       codeReviewJob,
       'Ensure OCR artifact placeholders exist',
@@ -63,6 +51,7 @@ describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () 
     );
     _hashRun = commandText(hashStep);
     uploadStep = stepNamed(codeReviewJob, 'Upload OCR artifacts');
+    telemetryUploadStep = stepNamed(codeReviewJob, 'Upload OCR telemetry');
   });
 
   describe('step ordering and id', () => {
@@ -76,13 +65,15 @@ describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () 
       expect(telemetryIndex).toBeGreaterThan(classificationIndex);
     });
 
-    it('places final classification after telemetry validation and upload', () => {
+    it('places final classification after telemetry validation and uploads', () => {
       const names = codeReviewJob.steps.map((step) => step.name);
       const validationIndex = names.indexOf('Validate redacted OCR telemetry');
+      const telemetryUploadIndex = names.indexOf('Upload OCR telemetry');
       const uploadIndex = names.indexOf('Upload OCR artifacts');
       const finalIndex = names.indexOf('Resolve final OCR classification');
       expect(validationIndex).toBeGreaterThan(-1);
       expect(finalIndex).toBeGreaterThan(validationIndex);
+      expect(finalIndex).toBeGreaterThan(telemetryUploadIndex);
       expect(finalIndex).toBeGreaterThan(uploadIndex);
     });
 
@@ -115,10 +106,12 @@ describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () 
         'Ensure OCR artifact placeholders exist',
       );
       const validationIndex = names.indexOf('Validate redacted OCR telemetry');
+      const telemetryUploadIndex = names.indexOf('Upload OCR telemetry');
       const uploadIndex = names.indexOf('Upload OCR artifacts');
       expect(placeholderIndex).toBeLessThan(telemetryIndex);
       expect(validationIndex).toBeGreaterThan(telemetryIndex);
-      expect(uploadIndex).toBeGreaterThan(validationIndex);
+      expect(telemetryUploadIndex).toBeGreaterThan(validationIndex);
+      expect(uploadIndex).toBeGreaterThan(telemetryUploadIndex);
     });
   });
 
@@ -167,8 +160,10 @@ describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () 
       );
     });
 
-    it('does NOT alias comments_skipped as already_resolved', () => {
-      expect(telemetryStep.env).not.toHaveProperty('OCR_ALREADY_RESOLVED');
+    it('passes the explicit prior-head dedup count as already_resolved', () => {
+      expect(telemetryStep.env?.OCR_ALREADY_RESOLVED).toBe(
+        '${{ steps.post-ocr-results.outputs.already_resolved }}',
+      );
     });
 
     it('passes classification flags and output counters', () => {
@@ -220,8 +215,13 @@ describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () 
       expect(placeholderRun).not.toContain('ocr-telemetry.json');
     });
 
-    it('includes ocr-telemetry.json in the upload artifact path', () => {
-      expect(uploadStep.with?.path).toContain('ocr-telemetry.json');
+    it('uploads telemetry independently from source diagnostic gating', () => {
+      expect(telemetryUploadStep.if).toBe(
+        "${{ always() && steps.ocr-telemetry-validation.outputs.valid == 'true' }}",
+      );
+      expect(telemetryUploadStep.with?.name).toContain('ocr-telemetry');
+      expect(telemetryUploadStep.with?.path).toBe('ocr-telemetry.json');
+      expect(uploadStep.with?.path).not.toContain('ocr-telemetry.json');
     });
   });
 
@@ -302,7 +302,7 @@ describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () 
 
   it('hashes telemetry before reading the finalized manifest for its self-hash', () => {
     expect(_hashRun).toMatch(
-      /hashableArtifacts\s*=\s*\[[\s\S]*ocr-telemetry\.json[\s\S]*\];/,
+      /hashableArtifacts\s*=\s*\[[^\]]*ocr-telemetry\.json[^\]]*\];/,
     );
     expect(_hashRun.indexOf('ocr-telemetry.json')).toBeLessThan(
       _hashRun.indexOf('const manifestContent'),
@@ -346,6 +346,22 @@ describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () 
       // ocr-telemetry.json before invoking the producer.
       expect(telemetryRun).not.toMatch(/: > ocr-telemetry\.json/);
     });
+  });
+
+  it('preserves infrastructure diagnostics after initialization', () => {
+    const initializeRun = commandText(
+      stepNamed(codeReviewJob, 'Initialize OCR artifact files'),
+    );
+    expect(initializeRun).toContain(': > ocr-infrastructure-failure.txt');
+
+    const laterWriters = codeReviewJob.steps
+      .filter((step) => step.name !== 'Initialize OCR artifact files')
+      .map((step) => commandText(step))
+      .filter((run) => run.includes('ocr-infrastructure-failure.txt'));
+    expect(laterWriters.length).toBeGreaterThan(0);
+    for (const run of laterWriters) {
+      expect(run).not.toMatch(/(^|[^>])> ocr-infrastructure-failure\.txt/m);
+    }
   });
 
   describe('ocr-selected-files.txt captured for all review runs', () => {

--- a/scripts/tests/ocr-telemetry-workflow.test.js
+++ b/scripts/tests/ocr-telemetry-workflow.test.js
@@ -360,7 +360,9 @@ describe('.github/workflows/ocr-review.yml — OCR telemetry (issue #2676)', () 
       .filter((run) => run.includes('ocr-infrastructure-failure.txt'));
     expect(laterWriters.length).toBeGreaterThan(0);
     for (const run of laterWriters) {
-      expect(run).not.toMatch(/(^|[^>])> ocr-infrastructure-failure\.txt/m);
+      expect(run).not.toMatch(
+        /(^|[^>])>(?!>)\s*ocr-infrastructure-failure\.txt/m,
+      );
     }
   });
 

--- a/scripts/tests/ocr-telemetry.test.js
+++ b/scripts/tests/ocr-telemetry.test.js
@@ -1,0 +1,393 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildTelemetry,
+  crossDistribution,
+  elapsedToSeconds,
+  renderTelemetryMarkdown,
+  validateTelemetryInput,
+} from '../ocr-telemetry.js';
+import {
+  validateTelemetryRecord,
+  validateReconciliation,
+} from '../ocr-telemetry-schema.js';
+
+function baseMetadata(overrides = {}) {
+  return {
+    schema: 1,
+    ocr: {
+      version: '1.7.16',
+      model: 'test-model',
+      concurrency: 2,
+      elapsed: '46m31s',
+      tokens: {
+        input: 300,
+        output: 100,
+        cache_read: 50,
+        cache_write: 25,
+        cache: 75,
+        total: 475,
+      },
+    },
+    range: {
+      selected: { files: 7 },
+      cumulative: { files: 63 },
+    },
+    findings: {
+      raw: 4,
+      inline: 2,
+      severity_distribution: { high: 1, medium: 1, low: 1, unknown: 1 },
+      category_distribution: { bug: 1, style: 1, unknown: 2 },
+    },
+    terminal: {
+      completeness_state: 'complete',
+      publication_state: 'complete',
+    },
+    ...overrides,
+  };
+}
+
+function baseManifest(overrides = {}) {
+  return {
+    schema_version: '1.0.0',
+    selected_files: ['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts', 'f.ts', 'g.ts'],
+    completed_files: ['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts', 'f.ts', 'g.ts'],
+    failed_files: [],
+    completeness: 'complete',
+    ...overrides,
+  };
+}
+
+function baseRoutingDecisions() {
+  return [
+    {
+      path: 'a.ts',
+      start_line: 10,
+      end_line: 10,
+      category: 'bug',
+      severity: 'high',
+      destination: 'inline',
+      reason: "category 'bug': always inline",
+    },
+    {
+      path: 'b.ts',
+      start_line: 5,
+      end_line: 5,
+      category: 'style',
+      severity: 'low',
+      destination: 'summary',
+      reason: "category 'style' severity 'low': routed to summary",
+    },
+    {
+      path: 'c.ts',
+      start_line: 1,
+      end_line: 1,
+      category: 'unknown',
+      severity: 'medium',
+      destination: 'inline',
+      reason: "severity 'medium': inline",
+    },
+    {
+      path: 'd.ts',
+      start_line: 2,
+      end_line: 2,
+      category: 'unknown',
+      severity: 'unknown',
+      destination: 'inline',
+      reason: 'fail-safe inline',
+    },
+  ];
+}
+
+function baseContext(overrides = {}) {
+  return {
+    runId: '123456',
+    runAttempt: '1',
+    prNumber: 2676,
+    sha: 'abc123def456789012345678901234567890abcd',
+    generatedAt: '2026-07-25T23:09:35.000Z',
+    infrastructureFailure: false,
+    policyFailure: false,
+    inlinePosted: 2,
+    alreadyResolved: null,
+    alreadyPostedOrSkippedDedup: 1,
+    commentsSkipped: 1,
+    commentsFailed: 0,
+    commentsTotal: 4,
+    wallClockSeconds: 2791,
+    filesReviewed: 7,
+    perFileReviewFailures: ['x.ts'],
+    telemetryState: 'complete',
+    postState: 'posted',
+    postOutcome: 'success',
+    artifactState: 'prepared',
+    hashState: 'prepared',
+    previewAttempted: true,
+    previewSucceeded: true,
+    commentsRoutedSummary: 1,
+    ...overrides,
+  };
+}
+
+function baseInput(overrides = {}) {
+  return {
+    metadata: baseMetadata(),
+    manifest: baseManifest(),
+    routingDecisions: baseRoutingDecisions(),
+    context: baseContext(),
+    ...overrides,
+  };
+}
+
+describe('elapsedToSeconds', () => {
+  it('parses minutes and seconds', () => {
+    expect(elapsedToSeconds('46m31s')).toBe(46 * 60 + 31);
+  });
+  it('parses hours, minutes, and seconds', () => {
+    expect(elapsedToSeconds('1h2m3s')).toBe(3600 + 120 + 3);
+  });
+  it('parses bare seconds', () => {
+    expect(elapsedToSeconds('90s')).toBe(90);
+  });
+  it('parses zero seconds to 0', () => {
+    expect(elapsedToSeconds('0s')).toBe(0);
+  });
+  it('parses milliseconds as fractional seconds', () => {
+    expect(elapsedToSeconds('1500ms')).toBeCloseTo(1.5, 5);
+  });
+  it('returns null for an unparseable value', () => {
+    expect(elapsedToSeconds('unknown')).toBeNull();
+  });
+  it('returns null for empty input', () => {
+    expect(elapsedToSeconds('')).toBeNull();
+    expect(elapsedToSeconds(undefined)).toBeNull();
+  });
+  it('returns null for a numeric-only value with no unit', () => {
+    expect(elapsedToSeconds('12345')).toBeNull();
+  });
+  it('returns null for a malformed value like 1.s', () => {
+    expect(elapsedToSeconds('1.s')).toBeNull();
+  });
+  it('returns null for Infinity-like overflow', () => {
+    expect(elapsedToSeconds('1e999s')).toBeNull();
+  });
+});
+
+describe('crossDistribution', () => {
+  it('builds category x severity matrix including unknowns', () => {
+    const decisions = baseRoutingDecisions();
+    const result = crossDistribution(decisions);
+    expect(result).toEqual({
+      bug: { high: 1, low: 0, medium: 0, unknown: 0 },
+      style: { high: 0, low: 1, medium: 0, unknown: 0 },
+      unknown: { high: 0, low: 0, medium: 1, unknown: 1 },
+    });
+  });
+  it('produces an empty object for no findings', () => {
+    expect(crossDistribution([])).toEqual({});
+  });
+});
+
+describe('buildTelemetry — schema validity', () => {
+  it('emits a record that passes strict validation', () => {
+    const telemetry = buildTelemetry(baseInput());
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    expect(validateReconciliation(telemetry)).toBeNull();
+  });
+  it('includes run identity and PR context fields', () => {
+    const telemetry = buildTelemetry(baseInput());
+    expect(telemetry.run_id).toBe('123456');
+    expect(telemetry.run_attempt).toBe('1');
+    expect(telemetry.pr_number).toBe(2676);
+    expect(telemetry.sha).toBe('abc123def456789012345678901234567890abcd');
+    expect(telemetry.generated_at).toBe('2026-07-25T23:09:35.000Z');
+  });
+  it('prefers workflow wall_clock_seconds over result.elapsed', () => {
+    const telemetry = buildTelemetry(
+      baseInput({ context: baseContext({ wallClockSeconds: 55 }) }),
+    );
+    expect(telemetry.wall_clock_seconds).toBe(55);
+  });
+  it('keeps wall_clock_seconds null when workflow timer evidence is unavailable', () => {
+    const telemetry = buildTelemetry(
+      baseInput({ context: baseContext({ wallClockSeconds: null }) }),
+    );
+    expect(telemetry.wall_clock_seconds).toBeNull();
+  });
+  it('keeps cli_elapsed_seconds separate from wall_clock_seconds', () => {
+    const telemetry = buildTelemetry(
+      baseInput({ context: baseContext({ wallClockSeconds: 55 }) }),
+    );
+    expect(telemetry.cli_elapsed_seconds).toBe(46 * 60 + 31);
+  });
+});
+
+describe('buildTelemetry — files_reviewed from result summary', () => {
+  it('uses context.filesReviewed (validated OCR summary count)', () => {
+    const telemetry = buildTelemetry(
+      baseInput({ context: baseContext({ filesReviewed: 5 }) }),
+    );
+    expect(telemetry.files_reviewed).toBe(5);
+  });
+  it('includes completed_with_warnings in files_reviewed', () => {
+    const telemetry = buildTelemetry(
+      baseInput({ context: baseContext({ filesReviewed: 6 }) }),
+    );
+    expect(telemetry.files_reviewed).toBe(6);
+  });
+  it('preserves manifest completed count separately in reviewed_range_manifest', () => {
+    const telemetry = buildTelemetry(
+      baseInput({
+        manifest: baseManifest({
+          completed_files: ['a.ts', 'b.ts'],
+        }),
+        context: baseContext({ filesReviewed: 5 }),
+      }),
+    );
+    expect(telemetry.files_reviewed).toBe(5);
+    expect(telemetry.reviewed_range_manifest.completed_files).toBe(2);
+  });
+});
+
+describe('buildTelemetry — files_previewed from selected scope', () => {
+  it('derives files_previewed from manifest selected scope', () => {
+    const telemetry = buildTelemetry(baseInput());
+    expect(telemetry.files_previewed).toBe(7);
+  });
+  it('handles no-changed-tests / empty selected scope', () => {
+    const telemetry = buildTelemetry(
+      baseInput({
+        manifest: baseManifest({ selected_files: [], completed_files: [] }),
+        context: baseContext({ filesReviewed: 0, perFileReviewFailures: [] }),
+      }),
+    );
+    expect(telemetry.files_previewed).toBe(0);
+    expect(telemetry.files_reviewed).toBe(0);
+  });
+});
+
+describe('buildTelemetry — file_read_failures semantics', () => {
+  it('emits file_read_failures null when read evidence unavailable', () => {
+    const telemetry = buildTelemetry(
+      baseInput({
+        context: baseContext({ perFileReviewFailures: undefined }),
+      }),
+    );
+    expect(telemetry.file_read_failures).toBeNull();
+    expect(telemetry.file_read_failure_count).toBeNull();
+  });
+
+  it('degrades valid telemetry when files_reviewed exceeds preview evidence', () => {
+    const telemetry = buildTelemetry(
+      baseInput({
+        manifest: baseManifest({
+          selected_files: ['a.ts'],
+          completed_files: ['a.ts'],
+        }),
+        context: baseContext({ filesReviewed: 2 }),
+      }),
+    );
+    expect(telemetry.files_previewed).toBe(1);
+    expect(telemetry.files_reviewed).toBeNull();
+    expect(telemetry.infrastructure_failure).toBe(true);
+    expect(telemetry.telemetry_state).toBe('degraded');
+    expect(telemetry.errors).toContain(
+      'OCR files_reviewed exceeded the successful preview scope',
+    );
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+  });
+  it('emits per_file_review_failures from explicit OCR evidence', () => {
+    const telemetry = buildTelemetry(baseInput());
+    expect(telemetry.per_file_review_failures).toEqual(['x.ts']);
+    expect(telemetry.per_file_review_failure_count).toBe(1);
+  });
+});
+
+describe('buildTelemetry — already_resolved semantics', () => {
+  it('emits already_resolved null (not aliased to comments_skipped)', () => {
+    const telemetry = buildTelemetry(baseInput());
+    expect(telemetry.already_resolved).toBeNull();
+    expect(telemetry.already_posted_or_skipped_dedup).toBe(1);
+  });
+});
+
+describe('buildTelemetry — failure / unavailable context', () => {
+  it('allows null sha (missing PR/SHA) and still validates', () => {
+    const telemetry = buildTelemetry(
+      baseInput({ context: baseContext({ sha: null }) }),
+    );
+    expect(telemetry.sha).toBeNull();
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+  });
+  it('records telemetry_state and post_state explicitly', () => {
+    const telemetry = buildTelemetry(baseInput());
+    expect(telemetry.telemetry_state).toBe('complete');
+    expect(telemetry.post_state).toBe('posted');
+  });
+});
+
+describe('validateTelemetryInput — fail-fast validation', () => {
+  it('returns null for a well-formed input', () => {
+    expect(validateTelemetryInput(baseInput())).toBeNull();
+  });
+  it('fails when metadata is not an object', () => {
+    expect(validateTelemetryInput(baseInput({ metadata: null }))).toMatch(
+      /metadata/i,
+    );
+  });
+  it('fails when run_id is missing', () => {
+    expect(
+      validateTelemetryInput(
+        baseInput({ context: baseContext({ runId: undefined }) }),
+      ),
+    ).toMatch(/run_id/i);
+  });
+});
+
+describe('renderTelemetryMarkdown', () => {
+  it('renders a compact deterministic summary', () => {
+    const telemetry = buildTelemetry(baseInput());
+    const markdown = renderTelemetryMarkdown(telemetry);
+    expect(markdown).toContain('## OCR Telemetry');
+    expect(markdown).toContain('PR #2676');
+    expect(markdown).toContain('| total findings | 4 |');
+  });
+  it('renders unavailable wall-clock explicitly', () => {
+    const telemetry = buildTelemetry(
+      baseInput({
+        context: baseContext({ wallClockSeconds: null }),
+        metadata: baseMetadata({
+          ocr: { ...baseMetadata().ocr, elapsed: 'unknown' },
+        }),
+      }),
+    );
+    const markdown = renderTelemetryMarkdown(telemetry);
+    expect(markdown).toContain('| wall-clock / CLI elapsed (s) | n/a / n/a |');
+  });
+});
+
+describe('elapsedToSeconds — strict grammar', () => {
+  it.each(['1m 2s', '1s2m', '1m2m', '1ms2s', '1h2h', '1s1ms1ms'])(
+    'rejects malformed ordered-unit elapsed value %s',
+    (elapsed) => {
+      expect(elapsedToSeconds(elapsed)).toBeNull();
+    },
+  );
+});
+
+describe('routing decision validation', () => {
+  it.each([
+    null,
+    [],
+    { category: 1, severity: 'high' },
+    { category: 'bug', severity: null },
+  ])('rejects malformed routing decision %j', (decision) => {
+    const input = baseInput({ routingDecisions: [decision] });
+    expect(validateTelemetryInput(input)).toMatch(/routingDecisions/i);
+  });
+});

--- a/scripts/tests/ocr-telemetry.test.js
+++ b/scripts/tests/ocr-telemetry.test.js
@@ -235,7 +235,7 @@ describe('buildTelemetry — files_reviewed from result summary', () => {
     );
     expect(telemetry.files_reviewed).toBe(5);
   });
-  it('includes completed_with_warnings in files_reviewed', () => {
+  it('preserves files_reviewed from context', () => {
     const telemetry = buildTelemetry(
       baseInput({ context: baseContext({ filesReviewed: 6 }) }),
     );

--- a/scripts/tests/ocr-telemetry.test.js
+++ b/scripts/tests/ocr-telemetry.test.js
@@ -6,6 +6,7 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  buildGuaranteedTelemetry,
   buildTelemetry,
   crossDistribution,
   elapsedToSeconds,
@@ -31,7 +32,7 @@ function baseMetadata(overrides = {}) {
         cache_read: 50,
         cache_write: 25,
         cache: 75,
-        total: 475,
+        total: 400,
       },
     },
     range: {
@@ -309,10 +310,14 @@ describe('buildTelemetry — file_read_failures semantics', () => {
 });
 
 describe('buildTelemetry — already_resolved semantics', () => {
-  it('emits already_resolved null (not aliased to comments_skipped)', () => {
-    const telemetry = buildTelemetry(baseInput());
-    expect(telemetry.already_resolved).toBeNull();
-    expect(telemetry.already_posted_or_skipped_dedup).toBe(1);
+  it('emits the explicit prior-head dedup count independently from comments_skipped', () => {
+    const telemetry = buildTelemetry(
+      baseInput({
+        context: baseContext({ alreadyResolved: 2, commentsSkipped: 3 }),
+      }),
+    );
+    expect(telemetry.already_resolved).toBe(2);
+    expect(telemetry.comments_skipped).toBe(3);
   });
 });
 
@@ -348,6 +353,48 @@ describe('validateTelemetryInput — fail-fast validation', () => {
     ).toMatch(/run_id/i);
   });
 });
+describe('buildGuaranteedTelemetry — malformed input fallback', () => {
+  it('returns a schema-valid failed record for malformed identity and lifecycle context', () => {
+    const telemetry = buildGuaranteedTelemetry(
+      baseInput({
+        context: baseContext({
+          runId: '',
+          runAttempt: 'invalid',
+          prNumber: -1,
+          sha: 'not-a-sha',
+          generatedAt: 'not-a-timestamp',
+          telemetryState: 'invalid',
+          postState: 'invalid',
+          artifactState: 'invalid',
+          hashState: 'invalid',
+        }),
+        errors: [null, '', 'source failure'],
+      }),
+      { error: new Error('fallback failure') },
+    );
+
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    expect(telemetry).toMatchObject({
+      run_id: 'unavailable',
+      run_attempt: null,
+      pr_number: null,
+      sha: null,
+      telemetry_state: 'failed',
+      post_state: 'failed',
+      artifact_state: 'failed',
+      hash_state: 'failed',
+      infrastructure_failure: true,
+    });
+    expect(telemetry.errors).toContain('fallback failure');
+  });
+
+  it('returns a schema-valid failed record when the input is missing', () => {
+    const telemetry = buildGuaranteedTelemetry(null);
+
+    expect(validateTelemetryRecord(telemetry)).toBeNull();
+    expect(telemetry.errors.length).toBeGreaterThan(0);
+  });
+});
 
 describe('renderTelemetryMarkdown', () => {
   it('renders a compact deterministic summary', () => {
@@ -368,6 +415,23 @@ describe('renderTelemetryMarkdown', () => {
     );
     const markdown = renderTelemetryMarkdown(telemetry);
     expect(markdown).toContain('| wall-clock / CLI elapsed (s) | n/a / n/a |');
+  });
+  it('escapes Markdown-sensitive identity values', () => {
+    const telemetry = buildTelemetry(
+      baseInput({ context: baseContext({ runId: 'run`\n## injected' }) }),
+    );
+    const markdown = renderTelemetryMarkdown(telemetry);
+
+    expect(markdown).toContain('run `run&#96;&#10;## injected`');
+    expect(markdown).not.toContain('run`\n## injected');
+  });
+  it('renders already-resolved publication volume', () => {
+    const telemetry = buildTelemetry(
+      baseInput({ context: baseContext({ alreadyResolved: 2 }) }),
+    );
+    const markdown = renderTelemetryMarkdown(telemetry);
+
+    expect(markdown).toContain('| already resolved | 2 |');
   });
 });
 


### PR DESCRIPTION
## TLDR

Adds strict, fail-closed OCR telemetry and longitudinal aggregation so each OCR workflow run records trustworthy finding, timing, file, publication, failure, and token metrics. Reviewers should focus on fallback validity, redaction/hash ordering, and preservation of trusted-base workflow execution.

## Dive Deeper

- Emits a versioned telemetry record for successful, degraded, and producer-fallback paths.
- Preserves truthful unavailable values while capturing run identity, OCR configuration, measured wall-clock duration, preview/review evidence, publication counters, file-read failures, policy/infrastructure state, and token usage.
- Counts findings by category, severity, and category-by-severity with strict reconciliation and safe-integer overflow checks.
- Redacts and validates telemetry before adding it to the reviewed-range hash set and gated artifact upload.
- Uses atomic synchronous writes with unique temporary names and cleanup on rename failure.
- Renders a compact GitHub Actions step summary with escaped untrusted identity values.
- Adds a longitudinal aggregator for averages and trends, category/severity totals, wall-clock by concurrency, file-read failure rates, and inline-comment volume.
- Preserves trusted-base execution, reviewed-range manifest semantics, and hash ordering.
- Appends later infrastructure diagnostics so earlier failure evidence is not overwritten.

## Reviewer Test Plan

1. Run the focused telemetry/workflow tests:

       npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/aggregate-ocr-telemetry.test.js scripts/tests/ocr-telemetry.test.js scripts/tests/ocr-telemetry-schema.test.js scripts/tests/ocr-telemetry-cli.test.js scripts/tests/ocr-telemetry-lifecycle.test.js scripts/tests/ocr-telemetry-workflow.test.js scripts/tests/ocr-review-workflow.test.js scripts/tests/ocr-review-workflow-behaviors.test.js scripts/tests/ocr-reviewed-range-manifest-wiring.test.js

2. Validate workflow syntax and lint policy:

       actionlint .github/workflows/ocr-review.yml
       npm run lint:eslint-guard

3. Inspect the OCR workflow and verify telemetry is produced from trusted repository scripts, redacted before validation/hashing, and uploaded only after successful validation and hashes.
4. Exercise the telemetry CLI with malformed metadata, missing context, invalid identity/lifecycle values, and an unwritable destination; confirm it emits a schema-valid fallback when possible and leaves no temporary write artifact.
5. Run the aggregator over multiple telemetry records and verify deterministic trends and contextual errors for malformed or unreadable files.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | CI  | CI  |
| npx      | ✅  | CI  | CI  |
| Docker   | -   | -   | CI  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Local focused verification passed 275 tests. Actionlint and the ESLint policy guard passed. Full npm verification, build, smoke, and CI results are tracked in the PR checks.

## Linked issues / bugs

Fixes #2676

Related to #2658, #2672, and #2673.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive OCR telemetry, including processing duration, files reviewed, read failures, preview evidence, and publication status.
  * Added tooling to aggregate OCR telemetry across runs and generate JSON or Markdown summaries with trends and distributions.
* **Bug Fixes**
  * Improved preservation and reporting of multiple infrastructure failure reasons.
  * Strengthened artifact validation, redaction, hashing, and conditional uploads to prevent incomplete or unsafe results.
* **Reliability**
  * Added clearer final workflow classifications for successful, partial, failed, and no-op reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->