### PR TITLE
Fix OCR business context printf failing on leading dashes (Fixes #2738)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1263,7 +1263,7 @@ jobs:
           # unchanged unless the repository variable opts in.
           REVIEW_ARGS=()
           if [ "${OCR_BACKGROUND:-}" = 'true' ]; then
-            BACKGROUND_TEXT=$(printf '---BEGIN BUSINESS CONTEXT---\nPR %s: %s\n\n%s\n---END BUSINESS CONTEXT---' "${PR_NUMBER}" "${PR_TITLE}" "${PR_BODY}")
+            BACKGROUND_TEXT=$(printf -- '---BEGIN BUSINESS CONTEXT---\nPR %s: %s\n\n%s\n---END BUSINESS CONTEXT---' "${PR_NUMBER}" "${PR_TITLE}" "${PR_BODY}")
             if [ -n "${PR_TITLE}" ] || [ -n "${PR_BODY}" ]; then
               REVIEW_ARGS+=(--background "$BACKGROUND_TEXT")
             fi


### PR DESCRIPTION
## Summary

Fixes #2738.

The OCR review GitHub Actions workflow throws a `printf` error when `OCR_BACKGROUND=true`, silently breaking issue #2670's LLM business context feature.

### Root cause

`.github/workflows/ocr-review.yml`, in the "Run OpenCodeReview" step:

    BACKGROUND_TEXT=$(printf '---BEGIN BUSINESS CONTEXT---\nPR %s: %s\n\n%s\n---END BUSINESS CONTEXT---' "${PR_NUMBER}" "${PR_TITLE}" "${PR_BODY}")

The `printf` format string starts with literal dashes (`---BEGIN...`). Bash's `printf` builtin interprets a leading-dash argument as an option flag, so it tries to parse `--` and fails:

    printf: --: invalid option
    printf: usage: printf [-v var] format [arguments]

Because the call sits in a command substitution, the surrounding assignment still exits 0 with `BACKGROUND_TEXT` empty, so the `--background` flag is dropped from the OCR invocation and the feature silently does nothing on every run that opts into `OCR_BACKGROUND`.

### Fix

Pass `--` to terminate option parsing before the format string:

    BACKGROUND_TEXT=$(printf -- '---BEGIN BUSINESS CONTEXT---\nPR %s: %s\n\n%s\n---END BUSINESS CONTEXT---' "${PR_NUMBER}" "${PR_TITLE}" "${PR_BODY}")

### Verification

Behavioral evidence (run locally against the exact statement shape):

**Before fix (current main):**

    bash: line 0: printf: --: invalid option
    printf: usage: printf [-v var] format [arguments]
    EXIT=2
    LEN=0          # BACKGROUND_TEXT empty -> --background flag dropped

**After fix (this PR):**

    EXIT=0
    LEN=102
    ---BEGIN BUSINESS CONTEXT---
    PR 123: Add foo

    We needed foo because reasons
    ---END BUSINESS CONTEXT---

Also confirmed via repo-wide scan that this is the only leading-dash `printf` format string in any workflow (the other 29 `printf '...'` call sites start with `%s`, letters, or otherwise safe characters).

### Scope

One-token change, single line, single file. No new behavior, no API/abstraction/dependency/workflow/agent-memory/quality-tool changes. Behavior when `OCR_BACKGROUND` is unset/false is unchanged.

### Checklist

- [x] Reproduced the failure on `main`
- [x] Verified the fix produces correct, non-empty `BACKGROUND_TEXT`
- [x] Confirmed no other leading-dash `printf` format strings exist
- [x] CI gates (yamllint, shellcheck via actionlint) cover this change
