### PR TITLE
fix(core): restore claude-opus-5 token-limit entries lost in 0.11 integration (Fixes #2737)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored the **`claude-opus-5`** and **`claude-opus-5-latest`** entries, and the `claude-opus-5` case-insensitive rule covering dated snapshots, to the core model-limits catalog (`packages/core/src/core/model-limits.json`). They were dropped during the `dev/0.11.0` → `main` integration, which took the dev branch's catalog wholesale rather than the union of both sides; the dev tip predated Opus 5's addition. Because the restored value (`200000`) equals the catalog `defaultLimit`, `tokenLimit('claude-opus-5')` still returned the correct number by fallthrough, making this a latent regression that would have surfaced only if the default changed. Opus 5's 200K subscription context window is now pinned explicitly again, matching the provider layer and `anthropic.config`, which were unaffected (#2737).
+
 ### Changed
 
 - **Installed command launches Bun directly (issue #2603):** The `llxprt` bin entry is now `packages/cli/bin/llxprt`, a POSIX sh launcher with a valid `#!/bin/sh` shebang (directly execve-compatible). On Windows, the CLI workspace `postinstall` (`packages/cli/scripts/install-native-launchers.cjs`) replaces npm's cmd-shim with native `.cmd` and `.ps1` launchers. No Node process is started on the installed command path. The old Node launcher (`packages/cli/bin/llxprt.cjs`) has been removed. The POSIX launcher validates the Bun executable's native binary magic (ELF/Mach-O) before exec, producing an actionable exit 43 for a corrupt or unusable binary without double-starting Bun. The Windows cmd launcher preserves the child exit code exactly (no errorlevel remapping); the PowerShell launcher wraps the invocation in try/catch to surface launch failures as exit 43 while propagating normal nonzero exits via `$LASTEXITCODE`.

--- a/packages/core/src/core/legacy-model-limits.expected.txt
+++ b/packages/core/src/core/legacy-model-limits.expected.txt
@@ -17,6 +17,8 @@
     "gemini-2.5-flash-lite": 1048576,
     "gemini-2.0-flash": 1048576,
     "gemini-2.0-flash-preview-image-generation": 32000,
+    "claude-opus-5": 200000,
+    "claude-opus-5-latest": 200000,
     "claude-opus-4-8": 200000,
     "claude-opus-4-7": 200000,
     "claude-opus-4-6": 200000,
@@ -78,6 +80,11 @@
     {
       "type": "substringCaseInsensitive",
       "substring": "claude-sonnet-5",
+      "limit": 200000
+    },
+    {
+      "type": "substringCaseInsensitive",
+      "substring": "claude-opus-5",
       "limit": 200000
     },
     {

--- a/packages/core/src/core/model-limits.json
+++ b/packages/core/src/core/model-limits.json
@@ -17,6 +17,8 @@
     "gemini-2.5-flash-lite": 1048576,
     "gemini-2.0-flash": 1048576,
     "gemini-2.0-flash-preview-image-generation": 32000,
+    "claude-opus-5": 200000,
+    "claude-opus-5-latest": 200000,
     "claude-opus-4-8": 200000,
     "claude-opus-4-7": 200000,
     "claude-opus-4-6": 200000,
@@ -78,6 +80,11 @@
     {
       "type": "substringCaseInsensitive",
       "substring": "claude-sonnet-5",
+      "limit": 200000
+    },
+    {
+      "type": "substringCaseInsensitive",
+      "substring": "claude-opus-5",
       "limit": 200000
     },
     {

--- a/packages/core/src/core/modelLimitsParity.test.ts
+++ b/packages/core/src/core/modelLimitsParity.test.ts
@@ -91,7 +91,11 @@ describe('model-limits catalog exhaustive parity (@issue:2280)', () => {
 });
 
 describe('substringCaseInsensitive normalizes both sides (@issue:2280)', () => {
-  it.each(['Claude-Sonnet-5-20260630', 'CLAUDE-FABLE-5-20260701'])(
+  it.each([
+    'Claude-Sonnet-5-20260630',
+    'CLAUDE-FABLE-5-20260701',
+    'Claude-Opus-5-20260724',
+  ])(
     'matches mixed-case model %s against its lowercase catalog rule',
     (model) => {
       const catalog = ModelLimitsCatalogSchema.parse(catalogData);

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -9,7 +9,9 @@ import {
   tokenLimit,
   DEFAULT_TOKEN_LIMIT,
   resolveEffectiveContextLimit,
+  resolveOrderedRuleFromCatalog,
 } from './tokenLimits.js';
+import catalogData from './model-limits.json' with { type: 'json' };
 
 describe('tokenLimit', () => {
   describe('Gemini models', () => {
@@ -81,6 +83,29 @@ describe('tokenLimit', () => {
 
     it('should return 200K limit for a claude-opus-5 dated snapshot', () => {
       expect(tokenLimit('claude-opus-5-20260724')).toBe(200_000);
+    });
+
+    // The three assertions above cannot fail while defaultLimit is also
+    // 200_000: they pass via fallthrough even with the catalog entries
+    // missing, which is how #2737 went undetected. These pin the catalog
+    // itself so a dropped entry fails regardless of the default.
+    it('declares claude-opus-5 independently of defaultLimit', () => {
+      expect(catalogData.exactLimits['claude-opus-5']).toBe(200_000);
+    });
+
+    it('declares claude-opus-5-latest independently of defaultLimit', () => {
+      expect(catalogData.exactLimits['claude-opus-5-latest']).toBe(200_000);
+    });
+
+    it('resolves a dated claude-opus-5 snapshot through an ordered rule', () => {
+      // Returns undefined rather than defaultLimit when no rule matches.
+      expect(
+        resolveOrderedRuleFromCatalog(
+          catalogData,
+          'claude-opus-5-20260724',
+          '',
+        ),
+      ).toBe(200_000);
     });
 
     it('should return 200K (auth default) limit for claude-opus-4-7', () => {


### PR DESCRIPTION
## Summary

Restores the `claude-opus-5` and `claude-opus-5-latest` context-window entries, and the case-insensitive rule covering dated snapshots, to the core model-limits catalog. They were silently dropped during the `dev/0.11.0` to `main` integration.

Fixes #2737

## Root cause

The dev branch refactored the hardcoded token-limit table into a data-driven JSON catalog (`packages/core/src/core/model-limits.json`). The merge correctly adopted that architecture but took dev's catalog **wholesale** rather than the union of both sides' model entries, which the merge plan explicitly mandated (`project-plans/20260725merge/README.md` section 4/C3, and conflict ledger CD-C3-003/004 which recorded the resolution as a verified union).

Dev's tip (`527101d14f`, 2026-07-16) predates `e7824192a2`, the commit that introduced Opus 5, so dev's catalog never contained those entries.

Verified independently:

    git rev-parse 527101d14f:packages/core/src/core/model-limits.json  # ce5d2477fd...
    git rev-parse 7256438614:packages/core/src/core/model-limits.json  # ce5d2477fd...
    git rev-parse HEAD~1:packages/core/src/core/model-limits.json      # ce5d2477fd...

The catalog blob is byte-identical at dev, at the merge, and at main's head, confirming it was taken wholesale.

A full key-set diff of pre-merge main's table against the shipped catalog confirms these two keys are the **only** losses. No other model entry or prefix rule differs.

## Why nothing caught it

The regression is latent rather than user-visible. The catalog's `defaultLimit` is `200000`, and both lost entries were also `200000`, so `tokenLimit('claude-opus-5')` continued returning the correct number by accidental fallthrough.

Two layers of protection failed for the same reason:

1. The existing tests in `tokenLimits.test.ts` asserted only `tokenLimit('claude-opus-5') === 200_000`. That passes whether the entry is present or absent. They passed for the wrong reason.
2. `modelLimitsParity.test.ts` compares the catalog against a checked-in fixture (`legacy-model-limits.expected.txt`) specifically to detect dropped entries. But that fixture was itself migrated from the same incomplete dev-side baseline, so it agreed with the gap.

Whole-repo `npm test` returning 0 is structurally incapable of detecting a dropped catalog entry whose value coincides with the default.

## Changes

**`packages/core/src/core/model-limits.json`**
- Added `claude-opus-5: 200000` and `claude-opus-5-latest: 200000` to `exactLimits`.
- Added a `substringCaseInsensitive` ordered rule for `claude-opus-5`, covering dated snapshot variants.

**`packages/core/src/core/legacy-model-limits.expected.txt`**
- Repaired the parity baseline to match. The correct baseline is the effective main-side table at the point the data-driven architecture landed on main, which included Opus 5.

**`packages/core/src/core/tokenLimits.test.ts` / `modelLimitsParity.test.ts`**
- Added regression coverage that cannot pass via default fallthrough.

## Ordered-rule placement

The new rule sits between the `claude-sonnet-5` and `claude-fable-5` rules, matching main's original ordering.

`orderedRules` is first-match-wins, so placement was checked deliberately. The three Claude tier substrings are mutually exclusive: no model id contains more than one of `claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`, so their relative order cannot affect any resolution. The preceding rules (codex-spark, codex, the o-series and gpt-4o prefix groups) cannot match a `claude-opus-5*` id, so the new rule is reachable and shadows nothing. Resolution is unchanged for every model id outside the intended Opus 5 match set.

## Test strategy

The central difficulty is that the obvious test cannot fail. `expect(tokenLimit('claude-opus-5')).toBe(200_000)` passes today with the entries missing. Any test of that shape is incapable of driving or protecting this fix.

The new tests are therefore **default-independent**:

- Two assert the catalog's `exactLimits` contents directly, so a missing entry fails regardless of what `defaultLimit` is.
- One resolves a dated snapshot through `resolveOrderedRuleFromCatalog`, which returns `undefined` when no ordered rule matches and never consults `defaultLimit`. Before this fix it returned `undefined` for Opus 5 while returning `200000` for the Sonnet 5 and Fable 5 siblings.
- The parity test's case-normalization cases now include an Opus 5 dated snapshot.

Verified genuinely RED by reverting only the catalog and fixture while keeping the tests, producing 4 failures. Restoring them returns all green. The pre-existing behavioral tests were kept, since they still document the observable 200K result, but they are explicitly not the regression guard.

## Cross-layer consistency

The restored 200K agrees with the two layers that survived the merge and were deliberately **not** modified:

- `AnthropicModelData.getContextWindowForModel` returns 200000 for Opus 5 via the anchored `OPUS_46_PLUS_PATTERN`.
- `anthropic.config` declares a `claude-opus-5` rule with `context-limit: 200000`.

Only the core fallback catalog was broken.

## Verification

All gates green:

| Gate | Result |
|---|---|
| `npm run test` | pass, 0 failures |
| `npm run lint` | pass |
| `npm run lint:eslint-guard` | pass |
| `npm run typecheck` | pass |
| `npm run format` | pass, no diff |
| `npm run build` | pass |
| smoke (`bun scripts/start.ts --profile-load ollamakimi`) | pass |

No lint suppressions, type suppressions, severity downgrades, or threshold increases were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored explicit 200,000-token limits for Claude Opus 5 and its latest variant.
  * Added support for dated Claude Opus 5 snapshots, including case-insensitive model names.
  * Ensured model-specific limits are applied directly rather than relying on default settings.

* **Tests**
  * Added coverage verifying exact model limits and dated snapshot resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->