### PR TITLE
ci: compute coverage on a single leg instead of every matrix leg (Fixes #2708)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,6 +820,12 @@ jobs:
           CI: true
           # Allow OpenAI integration tests to exceed Vitest's 5s default timeout (issue #338)
           VITEST_TEST_TIMEOUT: 15000
+          # Compute coverage only on the cli+core shards on ubuntu-latest —
+          # the exact legs whose coverage artifacts post_coverage_comment
+          # downloads. All other shard/os combinations waste instrumentation
+          # time since their coverage is never consumed (#2708). Default-on
+          # so local runs keep the signal; the env var is only set in CI.
+          LLXPRT_COVERAGE: ${{ (matrix.shard == 'cli' || matrix.shard == 'core') && matrix.os == 'ubuntu-latest' && 'true' || 'false' }}
         # The orchestrator expands --shard to the shard's workspaces (or runs
         # npm run test:scripts for the scripts shard). Each workspace's tests
         # still run under Vitest, preserving per-package config/reporters.
@@ -877,11 +883,12 @@ jobs:
           path: 'packages/*/junit.xml'
 
       - name: 'Upload coverage reports'
-        # Only the cli and core shards produce coverage summaries consumed by
-        # post_coverage_comment. Uploading coverage from other shards would
-        # waste storage and compute, so skip them.
+        # Only the cli and core shards on ubuntu-latest produce coverage
+        # summaries consumed by post_coverage_comment. Coverage is disabled on
+        # all other shard/os combinations (#2708), so uploading from them
+        # would waste storage and compute.
         if: |-
-          ${{ always() && (matrix.shard == 'cli' || matrix.shard == 'core') }}
+          ${{ always() && (matrix.shard == 'cli' || matrix.shard == 'core') && matrix.os == 'ubuntu-latest' }}
         uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'coverage-${{ matrix.shard }}-${{ matrix.node-version }}-${{ matrix.os }}'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,6 +109,9 @@ jobs:
           CI: true
           # Allow OpenAI integration tests to exceed Vitest's 5s default timeout (issue #338)
           VITEST_TEST_TIMEOUT: 15000
+          # Windows coverage is never consumed (no post_coverage_comment in
+          # nightly), so skip the instrumentation cost (#2708).
+          LLXPRT_COVERAGE: 'false'
         run: 'npm run test'
 
       - name: 'Run script harness tests (macOS)'
@@ -140,14 +143,6 @@ jobs:
         with:
           name: 'test-results-fork-${{ matrix.node-version }}-${{ matrix.os }}'
           path: 'packages/*/junit.xml'
-
-      - name: 'Upload coverage reports'
-        if: |-
-          ${{ always() }}
-        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
-        with:
-          name: 'coverage-reports-${{ matrix.node-version }}-${{ matrix.os }}'
-          path: 'packages/*/coverage'
 
   e2e_full:
     name: 'E2E Full - ${{ matrix.os }} - ${{ matrix.sandbox }}'

--- a/packages/agents/vitest.config.ts
+++ b/packages/agents/vitest.config.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { defineConfig, configDefaults } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const require = createRequire(import.meta.url);
 
@@ -267,7 +268,7 @@ export default defineConfig({
       junit: 'junit.xml',
     },
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/auth/vitest.config.ts
+++ b/packages/auth/vitest.config.ts
@@ -10,6 +10,7 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const isWindows = process.platform === 'win32';
 const isMacCi = process.platform === 'darwin' && process.env.CI === 'true';
@@ -50,7 +51,7 @@ export default defineConfig({
       junit: 'junit.xml',
     },
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -10,6 +10,7 @@ import { defineConfig } from 'vitest/config';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -344,7 +345,7 @@ export default defineConfig({
       },
     },
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -9,6 +9,7 @@ import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const require = createRequire(import.meta.url);
 
@@ -221,7 +222,7 @@ export default defineConfig({
       },
     },
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/ide-integration/vitest.config.ts
+++ b/packages/ide-integration/vitest.config.ts
@@ -5,6 +5,7 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const isWindows = process.platform === 'win32';
 const isMacCi = process.platform === 'darwin' && process.env.CI === 'true';
@@ -45,7 +46,7 @@ export default defineConfig({
       junit: 'junit.xml',
     },
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -7,6 +7,7 @@
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
 import { defineConfig } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const corePackagePrefix = '@vybestack/llxprt-code-core/';
 const coreEntry = fileURLToPath(new URL('../core/index.ts', import.meta.url));
@@ -108,7 +109,7 @@ export default defineConfig({
         }
       : undefined,
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/providers/vitest.config.ts
+++ b/packages/providers/vitest.config.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const require = createRequire(import.meta.url);
 
@@ -227,7 +228,7 @@ export default defineConfig({
       junit: 'junit.xml',
     },
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/settings/vitest.config.ts
+++ b/packages/settings/vitest.config.ts
@@ -6,6 +6,7 @@
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const settingsPackagePrefix = '@vybestack/llxprt-code-settings/';
 const settingsEntry = fileURLToPath(new URL('./index.ts', import.meta.url));
@@ -110,7 +111,7 @@ export default defineConfig({
       junit: 'junit.xml',
     },
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -5,6 +5,7 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const isWindows = process.platform === 'win32';
 const isMacCi = process.platform === 'darwin' && process.env.CI === 'true';
@@ -45,7 +46,7 @@ export default defineConfig({
       junit: 'junit.xml',
     },
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -8,6 +8,7 @@ import { existsSync } from 'node:fs';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const storagePackagePrefix = '@vybestack/llxprt-code-storage/';
 const storageEntry = fileURLToPath(
@@ -110,7 +111,7 @@ export default defineConfig({
         }
       : undefined,
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/packages/tools/vitest.config.ts
+++ b/packages/tools/vitest.config.ts
@@ -12,6 +12,7 @@
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+import { isCoverageEnabled } from '../../vitest.coverage.js';
 
 const isWindows = process.platform === 'win32';
 const isMacCi = process.platform === 'darwin' && process.env.CI === 'true';
@@ -110,7 +111,7 @@ export default defineConfig({
       junit: 'junit.xml',
     },
     coverage: {
-      enabled: true,
+      enabled: isCoverageEnabled,
       provider: 'v8',
       reportsDirectory: './coverage',
       include: ['src/**/*'],

--- a/scripts/tests/vitest-coverage.test.ts
+++ b/scripts/tests/vitest-coverage.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The helper evaluates process.env['LLXPRT_COVERAGE'] exactly once at
+// module-evaluation time, so each test must get a FRESH module instance.
+// vi.resetModules() clears the module registry; combined with vi.stubEnv this
+// forces a re-evaluation of the const on every dynamic import.
+describe('isCoverageEnabled', () => {
+  // Snapshot the original env state so the "unset" test (which performs a real
+  // deletion to verify genuine unset semantics) cannot leak into sibling test
+  // files in the same worker. vi.unstubAllEnvs only restores stubEnv mutations,
+  // not a key deleted directly off process.env.
+  const originalValue = process.env['LLXPRT_COVERAGE'];
+  const hadKey = Object.prototype.hasOwnProperty.call(
+    process.env,
+    'LLXPRT_COVERAGE',
+  );
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    if (hadKey) {
+      process.env['LLXPRT_COVERAGE'] = originalValue;
+    } else {
+      delete process.env['LLXPRT_COVERAGE'];
+    }
+  });
+
+  async function loadHelper(): Promise<{ isCoverageEnabled: boolean }> {
+    return (await import('../../vitest.coverage.js')) as {
+      isCoverageEnabled: boolean;
+    };
+  }
+
+  it('defaults to enabled (true) when LLXPRT_COVERAGE is unset', async () => {
+    delete process.env['LLXPRT_COVERAGE'];
+    const mod = await loadHelper();
+    expect(mod.isCoverageEnabled).toBe(true);
+  });
+
+  it('returns false when LLXPRT_COVERAGE === "false"', async () => {
+    vi.stubEnv('LLXPRT_COVERAGE', 'false');
+    const mod = await loadHelper();
+    expect(mod.isCoverageEnabled).toBe(false);
+  });
+
+  it('returns true when LLXPRT_COVERAGE === "true"', async () => {
+    vi.stubEnv('LLXPRT_COVERAGE', 'true');
+    const mod = await loadHelper();
+    expect(mod.isCoverageEnabled).toBe(true);
+  });
+
+  it('returns true for any value other than "false"', async () => {
+    vi.stubEnv('LLXPRT_COVERAGE', '1');
+    const mod = await loadHelper();
+    expect(mod.isCoverageEnabled).toBe(true);
+  });
+});

--- a/vitest.coverage.ts
+++ b/vitest.coverage.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Single source of truth for whether Vitest coverage instrumentation is enabled.
+ *
+ * Before #2708, every package's `vitest.config.ts` hardcoded
+ * `coverage.enabled: true`, so CI computed coverage on every test matrix leg
+ * even though only the Ubuntu artifact is consumed by `post_coverage_comment`.
+ * All 11 package coverage settings now read this flag instead.
+ *
+ * Defaults to ENABLED when the env var is unset so local runs keep the coverage
+ * signal; set `LLXPRT_COVERAGE=false` to disable (e.g. on non-designated CI legs).
+ */
+export const isCoverageEnabled: boolean =
+  process.env['LLXPRT_COVERAGE'] !== 'false';


### PR DESCRIPTION
## Summary

Coverage instrumentation was hardcoded `enabled: true` in all 11 package Vitest configs, so the test job computed coverage on every matrix leg even though `post_coverage_comment` only ever downloads the cli/core coverage artifacts from one OS. The redundant coverage computation and uploads were pure waste (~19s/package/leg per the issue measurement). This PR makes coverage conditional — computed on exactly one designated CI leg (ubuntu-latest, cli+core shards) — while keeping it on by default for local runs, and removes the redundant per-leg coverage artifact uploads.

## Note on the issue framing and rebase

The issue body and its CodeRabbit plan reference "keyring" legs and 4 matrix legs. That framing is stale: there is no `secure-store-mode` dimension in the test job (that dimension lives only in the separate `secure_store_backend` job, which does not upload coverage). This PR was rebased onto main after PR #2731 (issue #2707) merged, which restructured the monolithic `test` job into a `test_shard` matrix with 6 shards (cli, agents, providers, core, rest, scripts) × 2 OS (ubuntu-latest, macos-latest). The resolution composes cleanly: coverage is now enabled only on the `cli` and `core` shards on `ubuntu-latest` — the exact legs whose artifacts `post_coverage_comment` downloads.

## Changes

- **New `vitest.coverage.ts` (repo root):** a single shared, dependency-free helper exporting `isCoverageEnabled = process.env.LLXPRT_COVERAGE !== 'false'`. Defaults to **enabled** when the env var is unset, preserving the local-run coverage signal.
- **11 package `vitest.config.ts`:** `coverage.enabled: true` → `coverage.enabled: isCoverageEnabled` (with a `../../vitest.coverage.js` import, correct for NodeNext module resolution). The unrelated `typecheck.enabled: true` sites in `core`, `mcp`, and `tools` are left **untouched**.
- **`.github/workflows/ci.yml` (rebased onto #2707 sharding):** set `LLXPRT_COVERAGE` on the shard test step to `true` only on the `cli`/`core` shards on `ubuntu-latest`, and `false` on every other shard/os combination; gate the coverage-artifact upload to `always() && (matrix.shard == 'cli' || matrix.shard == 'core') && matrix.os == 'ubuntu-latest'` so only the consumed legs upload. `always()` is retained so a partial coverage report still uploads when an earlier test step fails (the comment job is `continue-on-error` and only needs the report).
- **`.github/workflows/nightly.yml`:** set `LLXPRT_COVERAGE=false` on the windows_ci test step (its coverage is never consumed) and remove the unconsumed coverage-upload step (confirmed no nightly job downloads it).

## Coverage comment data flow (unchanged, verified)

The `cli` and `core` shards on `ubuntu-latest` compute coverage → CLI/Core produce `coverage-summary.json` + `full-text-summary.txt` → only those legs upload `coverage-cli-24.x-ubuntu-latest` and `coverage-core-24.x-ubuntu-latest` → `post_coverage_comment` downloads those exact names → reads the CLI/Core report files → posts the tagged comment. The artifact names match exactly (verified structurally and via the CI workflow test suite). Nothing in this flow changed.

No enforced coverage threshold exists today (coverage is informational), so none is dropped.

## Acceptance criteria

- [x] Coverage is computed on exactly one CI leg — `LLXPRT_COVERAGE` is true only on the `cli`/`core` shards on `ubuntu-latest`.
- [x] The coverage comment and any coverage gate continue to function — surviving ubuntu artifact names match what `post_coverage_comment` downloads; data flow traced end-to-end and verified by `ci-secure-store-workflow.test.js`.
- [x] Redundant coverage artifacts are no longer uploaded — non-cli/core shards and macOS legs gated off; nightly windows upload removed.
- [x] Before/after timings recorded for the largest package — see below (and the issue already records cli 138s on / 119s off at full scale).

## Behavioral evidence (test counts unchanged, duration reduced)

Same machine, `vitest run --reporter=dot`:

| package / run | tests | coverage on | coverage off |
|---|---|---|---|
| telemetry (full suite) | 236 passed | 2.95s | 2.17s |
| cli (`useTodoContinuation.spec`) | 22 passed | 12.42s | 8.29s |
| storage (full suite, coverage on) | 437 passed \| 4 skipped | 10.65s | — |

The helper unit test (`scripts/tests/vitest-coverage.test.ts`) covers the default-on, `false`-disables, `true`-enables, and "any other value stays on" behaviors: 4/4 pass.

## Scope ledger

15 files changed (2 new, 13 modified), ~121 insertions / 23 deletions. Within the 25-file / 1,500-line budget. No unrelated refactors, no public abstraction added beyond the single root helper the issue explicitly requested.

## Non-goals

- Did not change the coverage reporter / junit / provider / include / reportsDirectory config in any package.
- Did not touch the `typecheck.enabled` sites in core/mcp/tools.
- Did not modify `post_coverage_comment` or the composite action.
- Did not change the `secure_store_backend` job (it does not upload coverage).

## Verification

- Helper unit test: 4/4 pass.
- CI workflow tests (`ci-secure-store-workflow.test.js`, `runner-image-consistency.test.js`): 16/16 pass.
- Typecheck: new files clean (the cli-package `FileSystemCapabilities` error pre-exists on main and is unrelated — confirmed by checkout).
- ESLint on all changed/new files: clean.
- Prettier: clean.
- YAML syntax (ci.yml, nightly.yml): valid (parsed + structure verified programmatically).
- Open Code Review (local, v1.7.16, 15 files): 0 comments.

Fixes #2708
