### PR TITLE
fix(pr-review): harden walkthrough pipeline against LLM parse failures (Fixes #2742)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -380,7 +380,10 @@ jobs:
         uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'walkthrough-diagnostics-${{ github.run_attempt }}'
-          path: 'review/walkthrough-error.log'
+          path: |
+            review/walkthrough-error.log
+            review/parse-failure-raw-*.txt
+            review/parse-failure-info-*.json
           if-no-files-found: 'ignore'
           retention-days: 3
 

--- a/scripts/pr-review-artifacts.mjs
+++ b/scripts/pr-review-artifacts.mjs
@@ -6,7 +6,28 @@
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { mapWithConcurrency } from './pr-review-walkthrough.mjs';
+
+async function readWithConcurrency(items, concurrencyLimit, asyncFn) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = await asyncFn(items[index]);
+      } catch (error) {
+        results[index] = {
+          error: error instanceof Error ? error.message : String(error),
+          filePath: items[index],
+        };
+      }
+    }
+  };
+  const workerCount = Math.min(concurrencyLimit, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
 
 export async function readArtifacts(reviewDir) {
   const prPath = path.join(reviewDir, 'pr.json');
@@ -31,7 +52,7 @@ async function readIssueFiles(reviewDir) {
   const issuesDir = path.join(reviewDir, 'issues');
   const files = await fs.readdir(issuesDir).catch(() => []);
   const issueFiles = files.filter((file) => file.endsWith('.json'));
-  const results = await mapWithConcurrency(issueFiles, 8, async (file) => ({
+  const results = await readWithConcurrency(issueFiles, 8, async (file) => ({
     filePath: file,
     issue: JSON.parse(await fs.readFile(path.join(issuesDir, file), 'utf8')),
   }));
@@ -50,7 +71,7 @@ async function readDiffFiles(reviewDir) {
   const manifest = await parseDiffManifest(manifestPath);
   const files = await fs.readdir(diffsDir).catch(() => []);
   const diffFiles = files.filter((file) => file.endsWith('.diff'));
-  const results = await mapWithConcurrency(diffFiles, 8, async (file) => ({
+  const results = await readWithConcurrency(diffFiles, 8, async (file) => ({
     filePath: file,
     diff: {
       filePath: resolveOriginalPath(file, manifest),

--- a/scripts/pr-review-artifacts.mjs
+++ b/scripts/pr-review-artifacts.mjs
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { mapWithConcurrency } from './pr-review-walkthrough.mjs';
+
+export async function readArtifacts(reviewDir) {
+  const prPath = path.join(reviewDir, 'pr.json');
+  try {
+    await fs.access(prPath);
+  } catch {
+    throw new Error(`Required artifact missing: ${prPath}`);
+  }
+  const pr = JSON.parse(await fs.readFile(prPath, 'utf8'));
+  const issues = await readIssueFiles(reviewDir);
+  if (issues.length === 0) {
+    throw new Error(
+      'No linked issue files found in review/issues — the issue_gate should have blocked this PR. Infrastructure problem.',
+    );
+  }
+  const diffs = await readDiffFiles(reviewDir);
+  const numstat = await readNumstat(reviewDir);
+  return buildArtifactContext(pr, issues, diffs, numstat);
+}
+
+async function readIssueFiles(reviewDir) {
+  const issuesDir = path.join(reviewDir, 'issues');
+  const files = await fs.readdir(issuesDir).catch(() => []);
+  const issueFiles = files.filter((file) => file.endsWith('.json'));
+  const results = await mapWithConcurrency(issueFiles, 8, async (file) => ({
+    filePath: file,
+    issue: JSON.parse(await fs.readFile(path.join(issuesDir, file), 'utf8')),
+  }));
+  const issues = collectArtifactReads(results, 'issue');
+  if (issueFiles.length > 0 && issues.length === 0) {
+    throw new Error(
+      `All ${issueFiles.length} issue file(s) failed to parse in ${issuesDir}`,
+    );
+  }
+  return issues.sort((a, b) => a.number - b.number);
+}
+
+async function readDiffFiles(reviewDir) {
+  const diffsDir = path.join(reviewDir, 'diffs');
+  const manifestPath = path.join(reviewDir, 'diff-manifest.txt');
+  const manifest = await parseDiffManifest(manifestPath);
+  const files = await fs.readdir(diffsDir).catch(() => []);
+  const diffFiles = files.filter((file) => file.endsWith('.diff'));
+  const results = await mapWithConcurrency(diffFiles, 8, async (file) => ({
+    filePath: file,
+    diff: {
+      filePath: resolveOriginalPath(file, manifest),
+      safeName: file,
+      content: await fs.readFile(path.join(diffsDir, file), 'utf8'),
+    },
+  }));
+  const diffs = collectArtifactReads(results, 'diff');
+  if (diffFiles.length > 0 && diffs.length === 0) {
+    throw new Error(
+      `All ${diffFiles.length} diff file(s) failed to read in ${diffsDir}`,
+    );
+  }
+  return diffs;
+}
+
+function collectArtifactReads(results, valueKey) {
+  const values = [];
+  for (const result of results) {
+    if ('error' in result) {
+      console.error(`Failed to read ${result.filePath}: ${result.error}`);
+    } else {
+      values.push(result[valueKey]);
+    }
+  }
+  return values;
+}
+
+export async function parseDiffManifest(manifestPath) {
+  let raw;
+  try {
+    raw = await fs.readFile(manifestPath, 'utf8');
+  } catch {
+    return null;
+  }
+  const map = new Map();
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    const tabIdx = line.indexOf('\t');
+    if (trimmed === '' || tabIdx === -1) {
+      continue;
+    }
+    const safeName = line.slice(0, tabIdx).trim();
+    const originalPath = line.slice(tabIdx + 1).trim();
+    if (safeName && originalPath) {
+      map.set(safeName, originalPath);
+    }
+  }
+  return map;
+}
+
+export function resolveOriginalPath(safeDiffName, manifest) {
+  if (manifest && manifest.has(safeDiffName)) {
+    return manifest.get(safeDiffName);
+  }
+  return safeDiffName.replace(/__/g, '/').replace(/\.diff$/, '');
+}
+
+async function readNumstat(reviewDir) {
+  const numstatPath = path.join(reviewDir, 'numstat.txt');
+  const raw = await fs.readFile(numstatPath, 'utf8').catch(() => '');
+  return raw
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      const [additions, deletions, filename] = line.split('\t');
+      return {
+        additions: Number(additions) || 0,
+        deletions: Number(deletions) || 0,
+        filename,
+      };
+    });
+}
+
+export function buildArtifactContext(pr, issues, diffs, numstat) {
+  const totalAdditions = numstat.reduce((sum, n) => sum + n.additions, 0);
+  const totalDeletions = numstat.reduce((sum, n) => sum + n.deletions, 0);
+  const changedFiles = pr.changedFiles ?? numstat.length;
+  const changedFilePaths = deriveChangedFilePaths(numstat, diffs);
+  return {
+    prContext: {
+      number: pr.number,
+      title: pr.title,
+      author: pr.author?.login,
+      body: pr.body,
+      baseRefName: pr.baseRefName,
+      headRefName: pr.headRefName,
+      additions: pr.additions ?? totalAdditions,
+      deletions: pr.deletions ?? totalDeletions,
+      changedFiles,
+      commits: pr.commits,
+    },
+    issues,
+    diffs,
+    numstat,
+    changedFilePaths,
+    magnitudeInput: {
+      additions: totalAdditions,
+      deletions: totalDeletions,
+      changedFiles,
+      packageCount: countPackages(changedFilePaths),
+      criteriaCount: countAcceptanceCriteria(issues),
+    },
+  };
+}
+
+function deriveChangedFilePaths(numstat, diffs) {
+  const fromNumstat = numstat.map((n) => n.filename).filter(Boolean);
+  return fromNumstat.length > 0
+    ? fromNumstat
+    : diffs.map((d) => d.filePath).filter(Boolean);
+}
+
+function countPackages(filenames) {
+  const packages = new Set(
+    filenames
+      .filter((f) => f.startsWith('packages/'))
+      .map((f) => f.split('/')[1]),
+  );
+  return packages.size;
+}
+
+function countAcceptanceCriteria(issues) {
+  return issues.reduce((sum, issue) => {
+    const body = String(issue.body ?? '').toLowerCase();
+    const matches = body.match(/acceptance criteri[\s\S]*?(?=\n#|\n##|$)/i);
+    if (!matches) {
+      return sum;
+    }
+    const checkboxCount = (matches[0].match(/-\s*\[/g) || []).length;
+    return sum + Math.max(1, checkboxCount);
+  }, 0);
+}

--- a/scripts/pr-review-llm-helpers.mjs
+++ b/scripts/pr-review-llm-helpers.mjs
@@ -1,0 +1,180 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+// Issue #2742: 4000 was too small — the LLM's JSON output for large diffs or
+// complex prompts could be truncated mid-object, causing unparseable JSON.
+// 16384 (16k) is large enough for any walkthrough JSON payload without being
+// wasteful. step-3.7-flash supports up to 256K output tokens, so 16k is well
+// within the model's capacity.
+export const DEFAULT_MAX_TOKENS = 16384;
+
+// Issue #2742: step-3.7-flash has a 256K context window. If no LLXPRT_CONTEXT_LIMIT
+// env var is set, fall back to 256000 (the documented context length) rather
+// than the 200000 default that only applies to models not in the catalog.
+export const DEFAULT_CONTEXT_LIMIT = 256000;
+
+const TRANSIENT_ERROR_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENETUNREACH',
+  'ETIMEDOUT',
+]);
+
+export function isRetryableLlxprtError(error) {
+  const code = typeof error?.code === 'string' ? error.code.toUpperCase() : '';
+  if (TRANSIENT_ERROR_CODES.has(code)) {
+    return true;
+  }
+  if (code === 'ENOENT') {
+    return false;
+  }
+  const message = String(error?.message ?? error).toLowerCase();
+  if (
+    /\b(401|403)\b|unauthorized|forbidden|authentication|invalid api key/.test(
+      message,
+    )
+  ) {
+    return false;
+  }
+  return /\b(408|425|429|500|502|503|504|529)\b|rate.?limit|overload|timed?out|temporar|connection reset/.test(
+    message,
+  );
+}
+
+/**
+ * Issue #2742: Classify whether an error is a JSON-parse or response-validation
+ * failure (as opposed to a network/spawn error). Parse errors should trigger
+ * a fresh LLM call — the model may return valid JSON on retry.
+ */
+export function isParseError(error) {
+  if (!error) {
+    return false;
+  }
+  const message = String(error.message ?? error);
+  return (
+    message === 'Cannot parse JSON from response' ||
+    message === 'Empty response: cannot parse JSON' ||
+    /^Invalid (map|group) response:/.test(message) ||
+    /^[A-Z][a-z]+: expected JSON object but got/.test(message)
+  );
+}
+
+function defaultBackoffDelay(attempt) {
+  return 1000 * 2 ** attempt;
+}
+
+/**
+ * Issue #2742: Wrap an LLM call + parse in a retry loop that retries on
+ * parse errors (not just spawn-level errors). When a parse failure occurs
+ * after the final retry, the raw LLM response is saved to a diagnostics
+ * artifact so the failure can be debugged post-hoc.
+ *
+ * @param {function(string): Promise<string>} llmFn - async function that
+ *   takes a prompt and returns the raw LLM response string.
+ * @param {function(string): Promise<object>} parser - parser function
+ *   (e.g. parseMapResponse, parseGroupResponse) that may throw on bad input.
+ * @param {object} opts - { maxRetries, delayMs, phase, saveParseFailure,
+ *   promptLength }
+ * @returns {Promise<object>} the parsed result.
+ */
+export async function runLlxprtPromptWithParse(
+  llmFn,
+  parser,
+  {
+    maxRetries = 2,
+    delayMs = defaultBackoffDelay,
+    phase = 'unknown',
+    saveParseFailure = () => Promise.resolve(),
+    promptLength = 0,
+  } = {},
+) {
+  let lastRaw = '';
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      lastRaw = await llmFn();
+      return parser(lastRaw);
+    } catch (error) {
+      const canRetry =
+        attempt < maxRetries &&
+        (isParseError(error) || isRetryableLlxprtError(error));
+      if (!canRetry) {
+        await handleParseFailure(
+          error,
+          saveParseFailure,
+          phase,
+          lastRaw,
+          promptLength,
+        );
+        throw error;
+      }
+      await delayMs(attempt);
+    }
+  }
+  throw new Error('unreachable');
+}
+
+async function handleParseFailure(
+  error,
+  saveParseFailure,
+  phase,
+  lastRaw,
+  promptLength,
+) {
+  if (isParseError(error)) {
+    await saveParseFailure(phase, lastRaw, promptLength).catch(() => {});
+  }
+}
+
+/**
+ * Issue #2742: Save the raw LLM response to a diagnostics artifact when
+ * parsing fails. The raw response goes to the **artifact file**, not to
+ * the error message (which must stay clean for the public PR comment).
+ *
+ * Writes two files:
+ * - `parse-failure-raw-<phase>.txt` — the raw LLM response
+ * - `parse-failure-info.json` — metadata (phase, promptLength, timestamp)
+ */
+export async function saveParseFailureArtifact(
+  reviewDir,
+  phase,
+  rawResponse,
+  { promptLength = 0 } = {},
+) {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const rawPath = path.join(
+    reviewDir,
+    `parse-failure-raw-${phase}-${suffix}.txt`,
+  );
+  const infoPath = path.join(reviewDir, `parse-failure-info-${suffix}.json`);
+  const writes = [
+    fs
+      .mkdir(reviewDir, { recursive: true })
+      .then(() => fs.writeFile(rawPath, String(rawResponse ?? ''))),
+    fs.writeFile(
+      infoPath,
+      JSON.stringify(
+        {
+          phase,
+          promptLength,
+          timestamp: new Date().toISOString(),
+          rawLength: String(rawResponse ?? '').length,
+        },
+        null,
+        2,
+      ),
+    ),
+  ];
+  await Promise.all(writes).catch((writeError) => {
+    console.error(
+      `[pr-review] failed to write parse-failure artifact for phase ${phase}:`,
+      writeError,
+    );
+  });
+}

--- a/scripts/pr-review-llm-helpers.mjs
+++ b/scripts/pr-review-llm-helpers.mjs
@@ -153,11 +153,10 @@ export async function saveParseFailureArtifact(
     `parse-failure-raw-${phase}-${suffix}.txt`,
   );
   const infoPath = path.join(reviewDir, `parse-failure-info-${suffix}.json`);
-  const writes = [
-    fs
-      .mkdir(reviewDir, { recursive: true })
-      .then(() => fs.writeFile(rawPath, String(rawResponse ?? ''))),
-    fs.writeFile(
+  try {
+    await fs.mkdir(reviewDir, { recursive: true });
+    await fs.writeFile(rawPath, String(rawResponse ?? ''));
+    await fs.writeFile(
       infoPath,
       JSON.stringify(
         {
@@ -169,12 +168,11 @@ export async function saveParseFailureArtifact(
         null,
         2,
       ),
-    ),
-  ];
-  await Promise.all(writes).catch((writeError) => {
+    );
+  } catch (writeError) {
     console.error(
       `[pr-review] failed to write parse-failure artifact for phase ${phase}:`,
       writeError,
     );
-  });
+  }
 }

--- a/scripts/pr-review-walkthrough.mjs
+++ b/scripts/pr-review-walkthrough.mjs
@@ -642,7 +642,6 @@ async function runPipeline(reviewDir) {
     const comment = renderWalkthroughComment({
       releaseNotes: '',
       walkthrough: buildMinimalWalkthrough(
-        artifacts,
         artifacts.diffs.map((d) => ({
           filePath: d.filePath,
           summary: d.filePath,
@@ -788,7 +787,7 @@ async function runSynthesisPhases(reviewDir, artifacts, summaries, themes) {
       `Synthesis phase failed, producing minimal walkthrough: ${error.message}`,
     );
     return {
-      walkthrough: buildMinimalWalkthrough(artifacts, summaries),
+      walkthrough: buildMinimalWalkthrough(summaries),
       releaseNotes: '',
       sequenceDiagram: '',
       related: '',
@@ -819,7 +818,7 @@ async function buildSynthesisTail(
   };
 }
 
-function buildMinimalWalkthrough(artifacts, summaries) {
+function buildMinimalWalkthrough(summaries) {
   const fileList = summaries
     .map((s) => `- \`${s.filePath}\`: ${s.summary}`)
     .join('\n');

--- a/scripts/pr-review-walkthrough.mjs
+++ b/scripts/pr-review-walkthrough.mjs
@@ -17,6 +17,18 @@ import {
   TRIAGE_TAGS,
   DEFAULT_PR_TEMPLATE_SECTIONS,
 } from './pr-review-prompts.mjs';
+import {
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_CONTEXT_LIMIT,
+  isParseError,
+  runLlxprtPromptWithParse,
+  saveParseFailureArtifact,
+} from './pr-review-llm-helpers.mjs';
+import {
+  readArtifacts,
+  parseDiffManifest,
+  resolveOriginalPath,
+} from './pr-review-artifacts.mjs';
 
 export {
   buildMapPrompt,
@@ -24,6 +36,14 @@ export {
   buildSynthesisPrompts,
   buildPreMergeChecksPrompt,
 };
+export {
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_CONTEXT_LIMIT,
+  isParseError,
+  runLlxprtPromptWithParse,
+  saveParseFailureArtifact,
+};
+export { parseDiffManifest, resolveOriginalPath };
 
 const COMMENT_TAG = '<!-- llxprt-walkthrough -->';
 const PLANNER_ISSUE = '#2256';
@@ -436,7 +456,8 @@ export async function runLlxprtPrompt(
       'Missing required configuration: LLXPRT_DEFAULT_PROVIDER, OPENAI_API_KEY, OPENAI_BASE_URL, and a model must all be set',
     );
   }
-  const contextLimit = process.env.LLXPRT_CONTEXT_LIMIT || '200000';
+  const contextLimit =
+    process.env.LLXPRT_CONTEXT_LIMIT || String(DEFAULT_CONTEXT_LIMIT);
   const args = [
     '--provider',
     provider,
@@ -447,7 +468,7 @@ export async function runLlxprtPrompt(
     '--set',
     'modelparam.temperature=0.7',
     '--set',
-    'modelparam.max_tokens=4000',
+    `modelparam.max_tokens=${DEFAULT_MAX_TOKENS}`,
     '--set',
     `context-limit=${contextLimit}`,
     '--prompt',
@@ -588,9 +609,18 @@ async function runPipeline(reviewDir) {
     return;
   }
   const summaries = await runMapPhase(reviewDir, artifacts);
-  const themes = await runGroupPhase(artifacts, summaries);
-  const synthesis = await runSynthesisPhases(artifacts, summaries, themes);
-  const preMergeChecks = await runPreMergeChecksPhase(artifacts, summaries);
+  const themes = await runGroupPhase(reviewDir, artifacts, summaries);
+  const synthesis = await runSynthesisPhases(
+    reviewDir,
+    artifacts,
+    summaries,
+    themes,
+  );
+  const preMergeChecks = await runPreMergeChecksPhase(
+    reviewDir,
+    artifacts,
+    summaries,
+  );
   const magnitude = computeMagnitude(artifacts.magnitudeInput);
   const comment = renderWalkthroughComment({
     releaseNotes: synthesis.releaseNotes,
@@ -606,217 +636,15 @@ async function runPipeline(reviewDir) {
   console.log('Walkthrough written to review/comment.md');
 }
 
-async function readArtifacts(reviewDir) {
-  const prPath = path.join(reviewDir, 'pr.json');
-  try {
-    await fs.access(prPath);
-  } catch {
-    throw new Error(`Required artifact missing: ${prPath}`);
-  }
-  const pr = JSON.parse(await fs.readFile(prPath, 'utf8'));
-  const issues = await readIssueFiles(reviewDir);
-  if (issues.length === 0) {
-    throw new Error(
-      'No linked issue files found in review/issues — the issue_gate should have blocked this PR. Infrastructure problem.',
-    );
-  }
-  const diffs = await readDiffFiles(reviewDir);
-  const numstat = await readNumstat(reviewDir);
-  return buildArtifactContext(pr, issues, diffs, numstat);
-}
-
-async function readIssueFiles(reviewDir) {
-  const issuesDir = path.join(reviewDir, 'issues');
-  const files = await fs.readdir(issuesDir).catch(() => []);
-  const issueFiles = files.filter((file) => file.endsWith('.json'));
-  const results = await mapWithConcurrency(issueFiles, 8, async (file) => ({
-    filePath: file,
-    issue: JSON.parse(await fs.readFile(path.join(issuesDir, file), 'utf8')),
-  }));
-  const issues = collectArtifactReads(results, 'issue');
-  if (issueFiles.length > 0 && issues.length === 0) {
-    throw new Error(
-      `All ${issueFiles.length} issue file(s) failed to parse in ${issuesDir}`,
-    );
-  }
-  return issues.sort((a, b) => a.number - b.number);
-}
-
-async function readDiffFiles(reviewDir) {
-  const diffsDir = path.join(reviewDir, 'diffs');
-  const manifestPath = path.join(reviewDir, 'diff-manifest.txt');
-  const manifest = await parseDiffManifest(manifestPath);
-  const files = await fs.readdir(diffsDir).catch(() => []);
-  const diffFiles = files.filter((file) => file.endsWith('.diff'));
-  const results = await mapWithConcurrency(diffFiles, 8, async (file) => ({
-    filePath: file,
-    diff: {
-      filePath: resolveOriginalPath(file, manifest),
-      safeName: file,
-      content: await fs.readFile(path.join(diffsDir, file), 'utf8'),
-    },
-  }));
-  const diffs = collectArtifactReads(results, 'diff');
-  if (diffFiles.length > 0 && diffs.length === 0) {
-    throw new Error(
-      `All ${diffFiles.length} diff file(s) failed to read in ${diffsDir}`,
-    );
-  }
-  return diffs;
-}
-
-function collectArtifactReads(results, valueKey) {
-  const values = [];
-  for (const result of results) {
-    if ('error' in result) {
-      console.error(`Failed to read ${result.filePath}: ${result.error}`);
-    } else {
-      values.push(result[valueKey]);
-    }
-  }
-  return values;
-}
-
-/**
- * Read review/diff-manifest.txt (lines of `<safeName>.diff\t<originalPath>`).
- * Returns a Map of safeName -> originalPath, or null if the file is missing.
- */
-export async function parseDiffManifest(manifestPath) {
-  let raw;
-  try {
-    raw = await fs.readFile(manifestPath, 'utf8');
-  } catch {
-    return null;
-  }
-  const map = new Map();
-  for (const line of raw.split('\n')) {
-    const trimmed = line.trim();
-    const tabIdx = line.indexOf('\t');
-    if (trimmed === '' || tabIdx === -1) {
-      continue;
-    }
-    const safeName = line.slice(0, tabIdx).trim();
-    const originalPath = line.slice(tabIdx + 1).trim();
-    if (safeName && originalPath) {
-      map.set(safeName, originalPath);
-    }
-  }
-  return map;
-}
-
-/**
- * Resolve a sanitized diff filename (e.g. `src__tests__foo.test.ts.diff`)
- * back to the original path. Prefer the authoritative manifest; fall back to
- * the naive `__` -> `/` replace only when no manifest is available.
- */
-export function resolveOriginalPath(safeDiffName, manifest) {
-  if (manifest && manifest.has(safeDiffName)) {
-    return manifest.get(safeDiffName);
-  }
-  return safeDiffName.replace(/__/g, '/').replace(/\.diff$/, '');
-}
-
-async function readNumstat(reviewDir) {
-  const numstatPath = path.join(reviewDir, 'numstat.txt');
-  const raw = await fs.readFile(numstatPath, 'utf8').catch(() => '');
-  return raw
-    .split('\n')
-    .filter((line) => line.trim())
-    .map((line) => {
-      const [additions, deletions, filename] = line.split('\t');
-      return {
-        additions: Number(additions) || 0,
-        deletions: Number(deletions) || 0,
-        filename,
-      };
-    });
-}
-
-function buildArtifactContext(pr, issues, diffs, numstat) {
-  const totalAdditions = numstat.reduce((sum, n) => sum + n.additions, 0);
-  const totalDeletions = numstat.reduce((sum, n) => sum + n.deletions, 0);
-  const changedFiles = pr.changedFiles || numstat.length;
-  const changedFilePaths = deriveChangedFilePaths(numstat, diffs);
-  return {
-    prContext: {
-      number: pr.number,
-      title: pr.title,
-      author: pr.author?.login,
-      body: pr.body,
-      baseRefName: pr.baseRefName,
-      headRefName: pr.headRefName,
-      additions: pr.additions ?? totalAdditions,
-      deletions: pr.deletions ?? totalDeletions,
-      changedFiles,
-      commits: pr.commits,
-    },
-    issues,
-    diffs,
-    numstat,
-    changedFilePaths,
-    magnitudeInput: {
-      additions: totalAdditions,
-      deletions: totalDeletions,
-      changedFiles,
-      packageCount: countPackages(changedFilePaths),
-      criteriaCount: countAcceptanceCriteria(issues),
-    },
-  };
-}
-
-function deriveChangedFilePaths(numstat, diffs) {
-  const fromNumstat = numstat.map((n) => n.filename).filter(Boolean);
-  return fromNumstat.length > 0
-    ? fromNumstat
-    : diffs.map((d) => d.filePath).filter(Boolean);
-}
-
-function countPackages(filenames) {
-  const packages = new Set(
-    filenames
-      .filter((f) => f.startsWith('packages/'))
-      .map((f) => f.split('/')[1]),
-  );
-  return packages.size;
-}
-
-function countAcceptanceCriteria(issues) {
-  return issues.reduce((sum, issue) => {
-    const body = String(issue.body ?? '').toLowerCase();
-    const matches = body.match(/acceptance criteri[\s\S]*?(?=\n#|\n##|$)/i);
-    if (!matches) {
-      return sum;
-    }
-    const checkboxCount = (matches[0].match(/-\s*\[/g) || []).length;
-    return sum + Math.max(1, checkboxCount);
-  }, 0);
-}
-
-const MAP_MODEL = process.env.LLXPRT_DEFAULT_MODEL;
-const STRONG_MODEL =
-  process.env.LLXPRT_STRONG_MODEL || process.env.LLXPRT_DEFAULT_MODEL;
-
-function placeholderSummary(filePath, reason) {
-  return { filePath, summary: reason, signature: '', triage: 'chore' };
-}
-
 async function runMapPhase(reviewDir, artifacts) {
   const mapItems = artifacts.diffs.map((d) => ({
     filePath: d.filePath,
     diff: d.content,
     prContext: artifacts.prContext,
   }));
-  const results = await mapWithConcurrency(mapItems, 3, async (item) => {
-    if (item.diff.length > MAX_DIFF_BYTES) {
-      return placeholderSummary(
-        item.filePath,
-        '(file too large for per-file summary, skipped)',
-      );
-    }
-    const prompt = buildMapPrompt(item.filePath, item.diff, item.prContext);
-    const raw = await runLlxprtPrompt(prompt, { model: MAP_MODEL });
-    return { filePath: item.filePath, ...parseMapResponse(raw) };
-  });
+  const results = await mapWithConcurrency(mapItems, 3, (item) =>
+    mapSingleItem(reviewDir, item),
+  );
   const summariesDir = path.join(reviewDir, 'summaries');
   await fs.mkdir(summariesDir, { recursive: true });
   for (const result of results) {
@@ -836,27 +664,121 @@ async function runMapPhase(reviewDir, artifacts) {
   );
 }
 
-async function runGroupPhase(artifacts, summaries) {
-  const prompt = buildGroupPrompt(summaries, artifacts.prContext);
-  const raw = await runLlxprtPrompt(prompt, { model: STRONG_MODEL });
-  const { themes } = parseGroupResponse(raw);
-  return themes;
+const MAP_MODEL = process.env.LLXPRT_DEFAULT_MODEL;
+const STRONG_MODEL =
+  process.env.LLXPRT_STRONG_MODEL || process.env.LLXPRT_DEFAULT_MODEL;
+
+function placeholderSummary(filePath, reason) {
+  return { filePath, summary: reason, signature: '', triage: 'chore' };
 }
 
-async function runSynthesisPhases(artifacts, summaries, themes) {
+async function mapSingleItem(reviewDir, item) {
+  if (item.diff.length > MAX_DIFF_BYTES) {
+    return placeholderSummary(
+      item.filePath,
+      '(file too large for per-file summary, skipped)',
+    );
+  }
+  const prompt = buildMapPrompt(item.filePath, item.diff, item.prContext);
+  const parsed = await runLlxprtPromptWithParse(
+    () => runLlxprtPrompt(prompt, { model: MAP_MODEL }),
+    parseMapResponse,
+    {
+      phase: 'map',
+      saveParseFailure: (phase, raw, promptLength) =>
+        saveParseFailureArtifact(reviewDir, phase, raw, { promptLength }),
+      promptLength: prompt.length,
+    },
+  );
+  return { filePath: item.filePath, ...parsed };
+}
+
+async function runGroupPhase(reviewDir, artifacts, summaries) {
+  const prompt = buildGroupPrompt(summaries, artifacts.prContext);
+  try {
+    const themes = await runLlxprtPromptWithParse(
+      () => runLlxprtPrompt(prompt, { model: STRONG_MODEL }),
+      parseGroupResponse,
+      {
+        phase: 'group',
+        saveParseFailure: (phase, raw, promptLength) =>
+          saveParseFailureArtifact(reviewDir, phase, raw, { promptLength }),
+        promptLength: prompt.length,
+      },
+    );
+    return themes.themes;
+  } catch (error) {
+    console.error(
+      `Group phase failed, falling back to directory grouping: ${error.message}`,
+    );
+    return fallbackGroupByDirectory(summaries);
+  }
+}
+
+function fallbackGroupByDirectory(summaries) {
+  const groups = new Map();
+  for (const s of summaries) {
+    const dir = path.dirname(s.filePath);
+    if (!groups.has(dir)) {
+      groups.set(dir, {
+        layer: dir,
+        files: [],
+        summary: `Changes in ${dir}`,
+        triage: 'chore',
+        signature: '',
+      });
+    }
+    groups.get(dir).files.push(s.filePath);
+  }
+  return Array.from(groups.values());
+}
+
+async function runSynthesisPhases(reviewDir, artifacts, summaries, themes) {
   const prompts = buildSynthesisPrompts({
     prContext: artifacts.prContext,
     summaries,
     themes,
     fullIssueBodies: artifacts.issues,
   });
-  const walkthroughRaw = await runLlxprtPrompt(
-    prompts.walkthroughReleaseNotes,
-    {
-      model: STRONG_MODEL,
-    },
-  );
-  const walkthroughParsed = extractJsonObject(walkthroughRaw);
+  try {
+    const walkthroughParsed = await runLlxprtPromptWithParse(
+      () =>
+        runLlxprtPrompt(prompts.walkthroughReleaseNotes, {
+          model: STRONG_MODEL,
+        }),
+      extractJsonObject,
+      {
+        phase: 'synthesis',
+        saveParseFailure: (phase, raw, promptLength) =>
+          saveParseFailureArtifact(reviewDir, phase, raw, { promptLength }),
+        promptLength: prompts.walkthroughReleaseNotes.length,
+      },
+    );
+    return await buildSynthesisTail(
+      prompts,
+      themes,
+      artifacts,
+      walkthroughParsed,
+    );
+  } catch (error) {
+    console.error(
+      `Synthesis phase failed, producing minimal walkthrough: ${error.message}`,
+    );
+    return {
+      walkthrough: buildMinimalWalkthrough(artifacts, summaries),
+      releaseNotes: '',
+      sequenceDiagram: '',
+      related: '',
+    };
+  }
+}
+
+async function buildSynthesisTail(
+  prompts,
+  themes,
+  artifacts,
+  walkthroughParsed,
+) {
   const validThemes = validateGroupThemes(themes);
   const shouldDiagram = gateSequenceDiagram(
     validThemes,
@@ -874,6 +796,13 @@ async function runSynthesisPhases(artifacts, summaries, themes) {
   };
 }
 
+function buildMinimalWalkthrough(artifacts, summaries) {
+  const fileList = summaries
+    .map((s) => `- \`${s.filePath}\`: ${s.summary}`)
+    .join('\n');
+  return `This PR changes ${summaries.length} file(s).\n\n${fileList}`;
+}
+
 async function runOptionalStage(prompt, key) {
   try {
     const raw = await runLlxprtPrompt(prompt, { model: STRONG_MODEL });
@@ -885,7 +814,7 @@ async function runOptionalStage(prompt, key) {
   }
 }
 
-async function runPreMergeChecksPhase(artifacts, summaries) {
+async function runPreMergeChecksPhase(reviewDir, artifacts, summaries) {
   const changeEvidence = summaries.map((s) => ({
     filePath: s.filePath,
     summary: s.summary,
@@ -897,8 +826,21 @@ async function runPreMergeChecksPhase(artifacts, summaries) {
     DEFAULT_PR_TEMPLATE_SECTIONS,
     changeEvidence,
   );
-  const raw = await runLlxprtPrompt(prompt, { model: STRONG_MODEL });
-  return extractJsonObject(raw);
+  try {
+    return await runLlxprtPromptWithParse(
+      () => runLlxprtPrompt(prompt, { model: STRONG_MODEL }),
+      extractJsonObject,
+      {
+        phase: 'pre-merge',
+        saveParseFailure: (phase, raw, promptLength) =>
+          saveParseFailureArtifact(reviewDir, phase, raw, { promptLength }),
+        promptLength: prompt.length,
+      },
+    );
+  } catch (error) {
+    console.error(`Pre-merge checks phase failed, skipping: ${error.message}`);
+    return null;
+  }
 }
 
 const isMainModule =

--- a/scripts/pr-review-walkthrough.mjs
+++ b/scripts/pr-review-walkthrough.mjs
@@ -608,32 +608,55 @@ async function runPipeline(reviewDir) {
     console.log('No diffs detected; minimal walkthrough written.');
     return;
   }
-  const summaries = await runMapPhase(reviewDir, artifacts);
-  const themes = await runGroupPhase(reviewDir, artifacts, summaries);
-  const synthesis = await runSynthesisPhases(
-    reviewDir,
-    artifacts,
-    summaries,
-    themes,
-  );
-  const preMergeChecks = await runPreMergeChecksPhase(
-    reviewDir,
-    artifacts,
-    summaries,
-  );
-  const magnitude = computeMagnitude(artifacts.magnitudeInput);
-  const comment = renderWalkthroughComment({
-    releaseNotes: synthesis.releaseNotes,
-    walkthrough: synthesis.walkthrough,
-    themes,
-    sequenceDiagram: synthesis.sequenceDiagram,
-    magnitude,
-    related: synthesis.related,
-    preMergeChecks,
-  });
-  await fs.writeFile(path.join(reviewDir, 'comment.md'), comment);
-  await fs.writeFile(path.join(reviewDir, 'walkthrough.md'), comment);
-  console.log('Walkthrough written to review/comment.md');
+  try {
+    const summaries = await runMapPhase(reviewDir, artifacts);
+    const themes = await runGroupPhase(reviewDir, artifacts, summaries);
+    const synthesis = await runSynthesisPhases(
+      reviewDir,
+      artifacts,
+      summaries,
+      themes,
+    );
+    const preMergeChecks = await runPreMergeChecksPhase(
+      reviewDir,
+      artifacts,
+      summaries,
+    );
+    const magnitude = computeMagnitude(artifacts.magnitudeInput);
+    const comment = renderWalkthroughComment({
+      releaseNotes: synthesis.releaseNotes,
+      walkthrough: synthesis.walkthrough,
+      themes,
+      sequenceDiagram: synthesis.sequenceDiagram,
+      magnitude,
+      related: synthesis.related,
+      preMergeChecks,
+    });
+    await fs.writeFile(path.join(reviewDir, 'comment.md'), comment);
+    await fs.writeFile(path.join(reviewDir, 'walkthrough.md'), comment);
+    console.log('Walkthrough written to review/comment.md');
+  } catch (pipelineError) {
+    console.error(
+      `Pipeline phase failed unexpectedly, writing minimal walkthrough: ${pipelineError.message}`,
+    );
+    const comment = renderWalkthroughComment({
+      releaseNotes: '',
+      walkthrough: buildMinimalWalkthrough(
+        artifacts,
+        artifacts.diffs.map((d) => ({
+          filePath: d.filePath,
+          summary: d.filePath,
+        })),
+      ),
+      themes: [],
+      sequenceDiagram: '',
+      magnitude: computeMagnitude(artifacts.magnitudeInput),
+      related: '',
+      preMergeChecks: null,
+    });
+    await fs.writeFile(path.join(reviewDir, 'comment.md'), comment);
+    await fs.writeFile(path.join(reviewDir, 'walkthrough.md'), comment);
+  }
 }
 
 async function runMapPhase(reviewDir, artifacts) {

--- a/scripts/tests/pr-review-llm-helpers.test.js
+++ b/scripts/tests/pr-review-llm-helpers.test.js
@@ -1,0 +1,274 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Tests for the issue #2742 hardening: retry-on-parse-failure, raw-response
+ * diagnostics capture, and graceful-degradation support helpers extracted
+ * into scripts/pr-review-llm-helpers.mjs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isParseError,
+  runLlxprtPromptWithParse,
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_CONTEXT_LIMIT,
+  saveParseFailureArtifact,
+} from '../pr-review-llm-helpers.mjs';
+import {
+  parseMapResponse,
+  mapWithConcurrency,
+} from '../pr-review-walkthrough.mjs';
+
+describe('isParseError', () => {
+  it('recognizes the "Cannot parse JSON from response" error', () => {
+    expect(isParseError(new Error('Cannot parse JSON from response'))).toBe(
+      true,
+    );
+  });
+
+  it('recognizes the "Empty response: cannot parse JSON" error', () => {
+    expect(isParseError(new Error('Empty response: cannot parse JSON'))).toBe(
+      true,
+    );
+  });
+
+  it('recognizes map/group validation errors as parse errors', () => {
+    expect(
+      isParseError(
+        new Error('Invalid map response: missing summary or triage'),
+      ),
+    ).toBe(true);
+    expect(
+      isParseError(new Error('Invalid group response: themes is not an array')),
+    ).toBe(true);
+  });
+
+  it('does not classify a network error as a parse error', () => {
+    expect(isParseError(new Error('HTTP 429 rate limit'))).toBe(false);
+  });
+
+  it('does not classify a generic error as a parse error', () => {
+    expect(isParseError(new Error('something else went wrong'))).toBe(false);
+  });
+
+  it('handles non-Error values without throwing', () => {
+    expect(isParseError(null)).toBe(false);
+    expect(isParseError(undefined)).toBe(false);
+    expect(isParseError('string error')).toBe(false);
+    expect(isParseError(42)).toBe(false);
+  });
+});
+
+describe('runLlxprtPromptWithParse', () => {
+  it('returns the parsed result when the LLM succeeds on the first try', async () => {
+    const llm = async () =>
+      '{"summary":"ok","signature":"foo()","triage":"fix"}';
+    const result = await runLlxprtPromptWithParse(llm, parseMapResponse, {
+      maxRetries: 2,
+    });
+    expect(result).toEqual({
+      summary: 'ok',
+      signature: 'foo()',
+      triage: 'fix',
+    });
+  });
+
+  it('retries when the first LLM response is unparseable and the second succeeds', async () => {
+    let calls = 0;
+    const llm = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return 'this is not json at all';
+      }
+      return '{"summary":"ok","signature":"foo()","triage":"fix"}';
+    };
+    const result = await runLlxprtPromptWithParse(llm, parseMapResponse, {
+      maxRetries: 2,
+      delayMs: () => 1,
+    });
+    expect(calls).toBe(2);
+    expect(result.summary).toBe('ok');
+  });
+
+  it('throws after exhausting retries when all responses are unparseable', async () => {
+    const llm = async () => 'garbage response';
+    await expect(
+      runLlxprtPromptWithParse(llm, parseMapResponse, {
+        maxRetries: 1,
+        delayMs: () => 1,
+      }),
+    ).rejects.toThrow('Cannot parse JSON from response');
+  });
+
+  it('does NOT retry on non-parse, non-retryable errors (e.g. auth)', async () => {
+    let calls = 0;
+    const llm = async () => {
+      calls += 1;
+      throw Object.assign(new Error('HTTP 401 unauthorized'), {
+        code: 'HTTP_401',
+      });
+    };
+    await expect(
+      runLlxprtPromptWithParse(llm, parseMapResponse, {
+        maxRetries: 2,
+        delayMs: () => 1,
+      }),
+    ).rejects.toThrow();
+    expect(calls).toBe(1);
+  });
+
+  it('retries on retryable network errors (e.g. 429) then succeeds', async () => {
+    let calls = 0;
+    const llm = async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error('HTTP 429 rate limit');
+      }
+      return '{"summary":"ok","signature":"foo()","triage":"fix"}';
+    };
+    const result = await runLlxprtPromptWithParse(llm, parseMapResponse, {
+      maxRetries: 2,
+      delayMs: () => 1,
+    });
+    expect(calls).toBe(2);
+    expect(result.summary).toBe('ok');
+  });
+
+  it('passes the raw response to the parse-failure artifact saver on final failure', async () => {
+    const llm = async () => 'totally not json';
+    let savedRaw = null;
+    let savedPhase = null;
+    const saveFn = async (phase, raw) => {
+      savedRaw = raw;
+      savedPhase = phase;
+    };
+    await expect(
+      runLlxprtPromptWithParse(llm, parseMapResponse, {
+        maxRetries: 1,
+        delayMs: () => 1,
+        phase: 'map',
+        saveParseFailure: saveFn,
+      }),
+    ).rejects.toThrow();
+    expect(savedRaw).toBe('totally not json');
+    expect(savedPhase).toBe('map');
+  });
+
+  it('does not call saveParseFailure when the LLM succeeds', async () => {
+    const llm = async () =>
+      '{"summary":"ok","signature":"foo()","triage":"fix"}';
+    let saved = false;
+    const saveFn = async () => {
+      saved = true;
+    };
+    await runLlxprtPromptWithParse(llm, parseMapResponse, {
+      maxRetries: 1,
+      delayMs: () => 1,
+      phase: 'map',
+      saveParseFailure: saveFn,
+    });
+    expect(saved).toBe(false);
+  });
+
+  it('respects maxRetries=0 (no retries, single attempt)', async () => {
+    let calls = 0;
+    const llm = async () => {
+      calls += 1;
+      return 'garbage';
+    };
+    await expect(
+      runLlxprtPromptWithParse(llm, parseMapResponse, {
+        maxRetries: 0,
+        delayMs: () => 1,
+      }),
+    ).rejects.toThrow();
+    expect(calls).toBe(1);
+  });
+});
+
+describe('DEFAULT_MAX_TOKENS and DEFAULT_CONTEXT_LIMIT', () => {
+  it('exports a DEFAULT_MAX_TOKENS constant greater than 4000', () => {
+    expect(typeof DEFAULT_MAX_TOKENS).toBe('number');
+    expect(DEFAULT_MAX_TOKENS).toBeGreaterThan(4000);
+  });
+
+  it('exports a DEFAULT_CONTEXT_LIMIT constant that is a positive number', () => {
+    expect(typeof DEFAULT_CONTEXT_LIMIT).toBe('number');
+    expect(DEFAULT_CONTEXT_LIMIT).toBeGreaterThan(0);
+  });
+
+  it('DEFAULT_MAX_TOKENS is 16384 (16k — large enough for JSON walkthrough output without being wasteful)', () => {
+    expect(DEFAULT_MAX_TOKENS).toBe(16384);
+  });
+});
+
+describe('saveParseFailureArtifact', () => {
+  it('writes raw response and phase to a file in the review directory', async () => {
+    const os = await import('node:os');
+    const nodeFs = await import('node:fs');
+    const pathMod = (await import('node:path')).default;
+    const reviewDir = pathMod.join(
+      os.tmpdir(),
+      `test-parse-failure-${Date.now()}`,
+    );
+    await nodeFs.promises.mkdir(reviewDir, { recursive: true });
+    try {
+      await saveParseFailureArtifact(reviewDir, 'map', 'not valid json', {
+        promptLength: 500,
+      });
+      // Filename now includes a unique suffix to avoid concurrent overwrites.
+      const files = await nodeFs.promises.readdir(reviewDir);
+      const rawFile = files.find((f) => f.startsWith('parse-failure-raw-map-'));
+      const infoFile = files.find((f) => f.startsWith('parse-failure-info-'));
+      expect(rawFile, 'raw artifact should exist').toBeTruthy();
+      expect(infoFile, 'info artifact should exist').toBeTruthy();
+      const rawContent = await nodeFs.promises.readFile(
+        pathMod.join(reviewDir, rawFile),
+        'utf8',
+      );
+      const infoContent = JSON.parse(
+        await nodeFs.promises.readFile(
+          pathMod.join(reviewDir, infoFile),
+          'utf8',
+        ),
+      );
+      expect(rawContent).toBe('not valid json');
+      expect(infoContent.phase).toBe('map');
+      expect(infoContent.promptLength).toBe(500);
+    } finally {
+      await nodeFs.promises
+        .rm(reviewDir, { recursive: true })
+        .catch((e) => console.error('test cleanup failed', e));
+    }
+  });
+});
+
+describe('graceful degradation (issue #2742)', () => {
+  it('mapWithConcurrency returns error objects when the mapper throws', async () => {
+    const items = [
+      { filePath: 'a.ts', diff: 'diff content' },
+      { filePath: 'b.ts', diff: 'diff content' },
+    ];
+    const results = await mapWithConcurrency(items, 3, async (_item) => {
+      throw new Error('Cannot parse JSON from response');
+    });
+    expect(results).toHaveLength(2);
+    expect(results[0]).toHaveProperty('error');
+    expect(results[1]).toHaveProperty('error');
+    const summaries = results.map((r) =>
+      'error' in r
+        ? {
+            filePath: r.filePath,
+            summary: `(failed: ${r.error})`,
+            signature: '',
+            triage: 'chore',
+          }
+        : r,
+    );
+    expect(summaries).toHaveLength(2);
+    expect(summaries[0].triage).toBe('chore');
+    expect(summaries[0].summary).toContain('Cannot parse JSON');
+  });
+});

--- a/scripts/tests/pr-review-walkthrough-workflow.test.js
+++ b/scripts/tests/pr-review-walkthrough-workflow.test.js
@@ -294,7 +294,12 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       expect(step, 'should upload the diagnostics log').toBeTruthy();
       expect(step.if).toBe('failure()');
       expect(step.uses).toContain('actions/upload-artifact@');
-      expect(step.with?.path).toBe('review/walkthrough-error.log');
+      // Issue #2742: the artifact now includes parse-failure diagnostics
+      // (raw LLM responses + metadata) alongside the error log.
+      const artifactPath = step.with?.path;
+      expect(artifactPath).toContain('review/walkthrough-error.log');
+      expect(artifactPath).toContain('review/parse-failure-raw-*.txt');
+      expect(artifactPath).toContain('review/parse-failure-info-*.json');
     });
 
     it('the fallback step runs before the post-comment step', () => {


### PR DESCRIPTION
## Summary

The `Run LLxprt review` CI job failed ~18% of runs (9/50) with `Cannot parse JSON from response`. A single unparseable LLM response from the fragile step-3.7-flash model crashed the entire walkthrough pipeline. This PR makes the pipeline resilient by adding retry-on-parse-error logic, capturing raw LLM output for diagnostics, degrading gracefully when individual phases fail, and increasing max_tokens / setting context-limit defaults.

## Root causes addressed (issue #2742)

1. **No retry on JSON parse failures** — runLlxprtPrompt only retried spawn-level network errors, not parse errors thrown after the LLM returned.
2. **No diagnostic capture of raw LLM output** — parse failures were swallowed, leaving only a generic error message with no raw response.
3. **max_tokens=4000** truncated large JSON payloads mid-object, guaranteeing unparseable output.
4. **No context-limit default** for step-3.7-flash (256K context window).
5. **No graceful degradation** — one bad LLM call out of 4-6 killed the whole walkthrough.

## Changes

### Retry + diagnostics (scripts/pr-review-llm-helpers.mjs — new)

- runLlxprtPromptWithParse(llmFn, parser, opts) — wraps an LLM call + parse in a retry loop that retries on parse errors (in addition to transient network errors). Saves the raw LLM response to a diagnostics artifact on final failure.
- isParseError(error) — classifies JSON-parse / response-validation errors vs. network errors.
- saveParseFailureArtifact(reviewDir, phase, rawResponse, opts) — writes parse-failure-raw-<phase>-<suffix>.txt and parse-failure-info-<suffix>.json with unique suffixes to avoid concurrent overwrites. Logs FS errors instead of silently swallowing them.
- DEFAULT_MAX_TOKENS = 16384 (was 4000) and DEFAULT_CONTEXT_LIMIT = 256000.

### Graceful degradation (scripts/pr-review-walkthrough.mjs)

- **Group phase**: falls back to directory-based grouping (fallbackGroupByDirectory) when the LLM fails entirely.
- **Synthesis phase**: falls back to a minimal file-list walkthrough (buildMinimalWalkthrough) when the LLM fails entirely.
- **Pre-merge checks**: returns null (skipped) on failure instead of crashing the pipeline.
- **Map phase**: per-file failures already produced placeholder summaries via mapWithConcurrency error handling; now also retried via runLlxprtPromptWithParse.

### Token + context limits

- runLlxprtPrompt now uses DEFAULT_MAX_TOKENS (16384) instead of hardcoded 4000, and DEFAULT_CONTEXT_LIMIT (256000) when no LLXPRT_CONTEXT_LIMIT env var is set.

### Artifact extraction (scripts/pr-review-artifacts.mjs — new)

- Moved readArtifacts, parseDiffManifest, resolveOriginalPath, buildArtifactContext and supporting helpers out of pr-review-walkthrough.mjs to keep the main orchestrator under the 800-line source-size lint limit. Also fixed changedFiles to use nullish coalescing (??) instead of logical OR (||).

### Workflow (.github/workflows/pr-review.yml)

- The walkthrough diagnostics artifact now includes parse-failure-raw-*.txt and parse-failure-info-*.json for post-mortem debugging.

### Tests

- 19 new behavioral tests in scripts/tests/pr-review-llm-helpers.test.js covering: isParseError classification, runLlxprtPromptWithParse retry behavior (success-first, retry-then-succeed, exhausted-retries, non-retryable errors, retryable network errors, artifact saving, maxRetries=0), DEFAULT_MAX_TOKENS/DEFAULT_CONTEXT_LIMIT values, saveParseFailureArtifact file writing, and graceful degradation via mapWithConcurrency.

## Verification

- npm run lint — passes
- tsc --project tsconfig.scripts.json — passes
- npm run format — passes
- 155 pr-review tests pass (89 walkthrough + 19 llm-helpers + 47 workflow)
- Open Code Review (ocr): 8 findings, 7 fixed (1 deferred as pre-existing/out-of-scope)
- Note: npm run build and npm run typecheck (full) fail on main due to a pre-existing AGENTS_DIR export error in packages/settings — confirmed identical on main, unrelated to this PR

Closes #2742
