### PR TITLE
Add Codex Responses WebSocket streaming (Fixes #2041)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -510,6 +510,7 @@
         "comment-json": "^4.5.0",
         "openai": "^5.10.1",
         "strip-json-comments": "^3.1.1",
+        "undici": "^7.28.0",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -3449,7 +3450,13 @@
 
     "@vybestack/llxprt-code/@vybestack/llxprt-code-auth": ["@vybestack/llxprt-code-auth@file:packages/auth", { "dependencies": { "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.8.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.219.0", "@opentelemetry/core": "^2.8.0", "@opentelemetry/exporter-logs-otlp-grpc": "^0.219.0", "@opentelemetry/exporter-logs-otlp-http": "^0.219.0", "@opentelemetry/exporter-metrics-otlp-grpc": "^0.219.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-grpc": "^0.219.0", "@opentelemetry/exporter-trace-otlp-http": "^0.219.0", "@opentelemetry/instrumentation-http": "^0.219.0", "@opentelemetry/resources": "^2.8.0", "@opentelemetry/sdk-logs": "^0.219.0", "@opentelemetry/sdk-metrics": "^2.8.0", "@opentelemetry/sdk-node": "^0.219.0", "@opentelemetry/sdk-trace-base": "^2.8.0", "@opentelemetry/sdk-trace-node": "^2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0", "@vybestack/llxprt-code-storage": "file:../storage", "debug": "^4.3.4" }, "devDependencies": { "@types/debug": "^4.1.12", "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-a2a-server/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
 
@@ -3459,6 +3466,10 @@
 
     "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-policy": ["@vybestack/llxprt-code-policy@file:packages/policy", { "dependencies": { "@iarna/toml": "^2.2.5", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-agents/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
     "@vybestack/llxprt-code-auth/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
@@ -3467,11 +3478,21 @@
 
     "@vybestack/llxprt-code-core/@vybestack/llxprt-code-policy": ["@vybestack/llxprt-code-policy@file:packages/policy", { "dependencies": { "@iarna/toml": "^2.2.5", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-core/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.219.0", "@opentelemetry/core": "^2.8.0", "@opentelemetry/exporter-logs-otlp-grpc": "^0.219.0", "@opentelemetry/exporter-logs-otlp-http": "^0.219.0", "@opentelemetry/exporter-metrics-otlp-grpc": "^0.219.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-grpc": "^0.219.0", "@opentelemetry/exporter-trace-otlp-http": "^0.219.0", "@opentelemetry/instrumentation-http": "^0.219.0", "@opentelemetry/resources": "^2.8.0", "@opentelemetry/sdk-logs": "^0.219.0", "@opentelemetry/sdk-metrics": "^2.8.0", "@opentelemetry/sdk-node": "^0.219.0", "@opentelemetry/sdk-trace-base": "^2.8.0", "@opentelemetry/sdk-trace-node": "^2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0", "@vybestack/llxprt-code-storage": "file:../storage", "debug": "^4.3.4" }, "devDependencies": { "@types/debug": "^4.1.12", "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-core/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
+    "@vybestack/llxprt-code-ide-integration/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.219.0", "@opentelemetry/core": "^2.8.0", "@opentelemetry/exporter-logs-otlp-grpc": "^0.219.0", "@opentelemetry/exporter-logs-otlp-http": "^0.219.0", "@opentelemetry/exporter-metrics-otlp-grpc": "^0.219.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0", "@opentelemetry/exporter-trace-otlp-grpc": "^0.219.0", "@opentelemetry/exporter-trace-otlp-http": "^0.219.0", "@opentelemetry/instrumentation-http": "^0.219.0", "@opentelemetry/resources": "^2.8.0", "@opentelemetry/sdk-logs": "^0.219.0", "@opentelemetry/sdk-metrics": "^2.8.0", "@opentelemetry/sdk-node": "^0.219.0", "@opentelemetry/sdk-trace-base": "^2.8.0", "@opentelemetry/sdk-trace-node": "^2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0", "@vybestack/llxprt-code-storage": "file:../storage", "debug": "^4.3.4" }, "devDependencies": { "@types/debug": "^4.1.12", "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-ide-integration/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
 
@@ -3481,7 +3502,11 @@
 
     "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-auth": ["@vybestack/llxprt-code-auth@file:packages/auth", { "dependencies": { "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.8.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-providers/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
@@ -3492,6 +3517,8 @@
     "@vybestack/llxprt-code-telemetry/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
     "@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
+
+    "@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@x70102/ink/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -3861,23 +3888,51 @@
 
     "@vscode/vsce/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
     "@vybestack/llxprt-code-agents/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "@vybestack/llxprt-code-auth/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-telemetry/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
     "@vybestack/llxprt-code-core/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
+    "@vybestack/llxprt-code-ide-integration/@vybestack/llxprt-code-telemetry/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
     "@vybestack/llxprt-code-ide-integration/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
+
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
 
     "@vybestack/llxprt-code-mcp/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "@vybestack/llxprt-code-policy/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
     "@vybestack/llxprt-code-providers/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "@vybestack/llxprt-code-telemetry/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
+    "@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
     "@vybestack/llxprt-code/@vybestack/llxprt-code-auth/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -4110,6 +4165,8 @@
     "@vscode/vsce/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@vybestack/llxprt-code/@vybestack/llxprt-code-auth/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/dev-docs/plans/issue-2041-websocket-support.md
+++ b/dev-docs/plans/issue-2041-websocket-support.md
@@ -35,17 +35,15 @@ Codex mode automatically uses protocol v2 at `/responses` with flat `response.cr
 2. Streaming lifecycle, exclusive reuse, and failures (A3, A4, A8).
 3. Sticky fallback and cancellation (A5, A6).
 4. Verification, review, and delivery.
-   - Run scoped tests after each slice, then all required local gates, reviews, scope review, PR CI, and exact-head checks.
 
 ## Expected paths
 
-`dev-docs/plans/issue-2041-websocket-support.md`, provider package/lockfiles, `OpenAIResponsesProviderCore.ts`, `openAIResponsesExecutor.ts`, and new transport, HTTP-stream, and two test files. The HTTP extraction was discovered as necessary to preserve the enforced 800-line executor limit. Total expected: 10 files.
-Expected maximum: 10 files, below the 25-file review threshold and 40-file hard stop. The hard budgets remain 25 files/1,500 net lines for mandatory scope review and 40 files/2,500 net lines for an approval stop.
+Expected: this plan, provider package/lockfiles, provider core/executor, and new transport, HTTP-stream, and two test files. The HTTP extraction preserves the enforced 800-line executor limit. Maximum: 10 files, below the 25-file review threshold and 40-file hard stop. Hard budgets remain 25 files/1,500 net lines and 40 files/2,500 net lines.
 
 ## Actual delivery
 
-All 10 expected paths changed. The discovered `openAIResponsesHttpStream.ts` extraction keeps the executor below the enforced 800-line limit without weakening lint. Final measured scope is 10 files and 1,498 net changed lines, including forced-text lockfile changes and untracked files. Behavioral evidence is 17 focused WebSocket tests plus the passing full root test suite.
-The Codex handshake requires bearer/account/custom HTTP headers. Node's global WHATWG `WebSocket` does not accept custom handshake headers. The existing OpenAI SDK's Realtime client authenticates with a Realtime-specific subprotocol and is not a Responses WebSocket transport. `undici` 7.28.0 is already standardized elsewhere in this monorepo and exposes a header-capable `WebSocket`, but `packages/providers` does not declare it. Correct package isolation therefore requires adding `undici` as a direct providers dependency and updating lockfiles.
+All 10 expected paths changed. The HTTP extraction keeps the executor below the enforced 800-line limit without weakening lint. Final measured scope is 10 files and 1,498 net changed lines, including forced-text lockfile changes; 17 focused tests and the full root suite provide behavioral evidence.
+The Codex handshake requires bearer/account/custom HTTP headers. Node's global `WebSocket` cannot supply them, while the existing OpenAI Realtime client uses a different protocol. The approved direct `undici ^7.28.0` providers dependency supplies a header-capable client; lockfiles are updated.
 
 ## Scope ledger
 
@@ -59,20 +57,6 @@ The Codex handshake requires bearer/account/custom HTTP headers. Node's global W
 | Incremental `previous_response_id` payloads               | Non-goal              | Excluded                | Conflicts with bounded stateless scope                             |
 | Unrelated refactors/findings                              | Out of scope          | Must be Reject or Defer | Reviewer suggestions do not expand scope                           |
 
-## Review finding classification
-
-Every finding will be recorded as exactly one of:
-
-- **Blocker-Fix**: prevents accepted behavior, safety, correctness, required verification, or mergeability.
-- **In-scope-Fix**: improves or corrects implementation inside A1-A8 and expected paths/budget.
-- **Reject**: factually incorrect or outside the accepted issue behavior.
-- **Defer**: valid but requires a separate issue or explicit approval because it expands scope.
-
-Open Code Review is capped at two local and two PR runs. Total code/design review cycles are capped at two; DeepThinker participates in at least one.
-
 ## Review, verification, and completion
 
-DeepThinker found no actionable issue. OCR's nested-payload claim is **Reject** because source sends flat `response.create`. Focused tests (17) and root test/lint/typecheck/format/build pass. Smoke reached the provider but external quota returned HTTP 429; tmux is not applicable. Exact-head completion additionally requires green CI, resolved review threads, correct ancestry, no conflicts, and a clean scope ledger.
-
-- Final `git diff --stat` and numstat remain inside the hard scope budget and every changed path is accounted for in this ledger.
-- No optional hardening or cleanup continues after these gates are satisfied.
+Findings use **Blocker-Fix**, **In-scope-Fix**, **Reject**, or **Defer** without expanding scope. DeepThinker found no actionable issue. Local OCR's nested-payload claim is **Reject** because source sends flat `response.create`. PR OCR's session-header parity and deterministic-test findings are **In-scope-Fix** and addressed. Its HTTP partial-retry findings are **Defer** because they describe unchanged pre-existing behavior outside A1-A8. The narrow fetch type, empty harness, CLOSING constant, and callback findings are **Reject** as factually incorrect, speculative test hardening, or incompatible with fail-fast internal callbacks. Focused tests and root test/lint/typecheck/format/build pass. Smoke reached the provider but external quota returned HTTP 429; tmux is not applicable. Exact-head completion requires green CI, resolved threads, correct ancestry, no conflicts, and a clean scope ledger.

--- a/dev-docs/plans/issue-2041-websocket-support.md
+++ b/dev-docs/plans/issue-2041-websocket-support.md
@@ -1,0 +1,78 @@
+# Issue 2041 Delivery Plan: Codex Responses WebSocket Support
+
+Issue: https://github.com/vybestack/llxprt-code/issues/2041
+Branch: `issue2041`
+Base: `e83eb8f12`
+
+## Acceptance matrix
+
+| ID  | Given                                                                                                          | When                                                                            | Then                                                                                                                                                                           | Behavioral evidence                                                                                                      |
+| --- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| A1  | The OpenAI Responses provider is operating against the Codex ChatGPT backend                                   | A streaming generation starts                                                   | It first opens `ws://` or `wss://` at the existing `/responses` URL and sends the existing request as a JSON `response.create` message                                         | Provider/executor test observes the WebSocket URL, handshake headers, and request payload                                |
+| A2  | A Codex WebSocket handshake is attempted                                                                       | Authentication and provider headers are built                                   | The handshake carries the same Authorization, ChatGPT account, originator, session, and configured custom headers as HTTP, plus `OpenAI-Beta: responses_websockets=2026-02-06` | Transport boundary test inspects all handshake headers without exposing secrets in logs                                  |
+| A3  | The WebSocket server emits Responses API JSON events                                                           | Text, reasoning, tool-call, usage, liveness, completion, or error events arrive | Existing Responses event parsing produces the same provider-neutral output and errors as SSE streaming                                                                         | Executor behavioral tests run real Responses parsing over WebSocket event frames                                         |
+| A4  | One Codex provider instance completes a WebSocket response and the connection remains open                     | A later generation starts with the same endpoint and authentication context     | The existing connection is reused and requests remain serialized until each `response.completed` event                                                                         | Transport test completes two requests over one connection and observes ordered output                                    |
+| A5  | The WebSocket endpoint cannot connect or fails before producing response events                                | The Codex request is still pending                                              | The provider falls back once to the existing HTTP Responses path and keeps HTTP as the sticky transport for that provider instance                                             | Executor/provider test observes one failed WebSocket attempt and successful HTTP output, then no later WebSocket attempt |
+| A6  | A request is aborted while connecting or streaming over WebSocket                                              | The invocation abort signal fires                                               | The pending generation rejects with `AbortError`, the unusable connection is closed, and a later request may establish a fresh connection                                      | Abort behavioral test verifies rejection, close, and reconnectability                                                    |
+| A7  | The Responses provider is not in Codex mode, including OpenAI Responses routing through `OpenAIProvider`       | A streaming generation starts                                                   | Existing HTTP/SSE behavior is unchanged                                                                                                                                        | Regression test observes HTTP fetch and no WebSocket connector use                                                       |
+| A8  | The WebSocket receives non-text data, malformed JSON, a top-level error, or closes before `response.completed` | The frame is processed                                                          | The request fails explicitly; it does not silently report a complete response                                                                                                  | Transport/parser tests verify fail-fast errors                                                                           |
+
+## Decisions
+
+Codex mode automatically uses protocol v2 at `/responses` with flat `response.create` and the dated beta header. A provider owns one serialized, identity-keyed reusable connection. Each turn sends full history; incremental IDs, generic endpoint support, and public transport API are excluded. Pre-event failures cause sticky HTTP fallback; partial responses fail without replay.
+
+## Explicit non-goals
+
+- Realtime audio/voice WebSockets or the OpenAI Realtime API.
+- WebSocket support for arbitrary OpenAI-compatible Responses endpoints.
+- User-facing transport configuration, feature flags, profile schema, or settings UI.
+- Incremental turn payloads, `previous_response_id` optimization, prewarming, connection pools, or concurrent multiplexing.
+- Other providers/transports, telemetry, parser refactors beyond adaptation, workflow/memory/quality-tool changes, and unrelated cleanup.
+
+## Bounded vertical slices
+
+1. Protocol selection and handshake (A1, A2, A7).
+2. Streaming lifecycle, exclusive reuse, and failures (A3, A4, A8).
+3. Sticky fallback and cancellation (A5, A6).
+4. Verification, review, and delivery.
+   - Run scoped tests after each slice, then all required local gates, reviews, scope review, PR CI, and exact-head checks.
+
+## Expected paths
+
+`dev-docs/plans/issue-2041-websocket-support.md`, provider package/lockfiles, `OpenAIResponsesProviderCore.ts`, `openAIResponsesExecutor.ts`, and new transport, HTTP-stream, and two test files. The HTTP extraction was discovered as necessary to preserve the enforced 800-line executor limit. Total expected: 10 files.
+Expected maximum: 10 files, below the 25-file review threshold and 40-file hard stop. The hard budgets remain 25 files/1,500 net lines for mandatory scope review and 40 files/2,500 net lines for an approval stop.
+
+## Actual delivery
+
+All 10 expected paths changed. The discovered `openAIResponsesHttpStream.ts` extraction keeps the executor below the enforced 800-line limit without weakening lint. Final measured scope is 10 files and 1,498 net changed lines, including forced-text lockfile changes and untracked files. Behavioral evidence is 17 focused WebSocket tests plus the passing full root test suite.
+The Codex handshake requires bearer/account/custom HTTP headers. Node's global WHATWG `WebSocket` does not accept custom handshake headers. The existing OpenAI SDK's Realtime client authenticates with a Realtime-specific subprotocol and is not a Responses WebSocket transport. `undici` 7.28.0 is already standardized elsewhere in this monorepo and exposes a header-capable `WebSocket`, but `packages/providers` does not declare it. Correct package isolation therefore requires adding `undici` as a direct providers dependency and updating lockfiles.
+
+## Scope ledger
+
+| Entry                                                     | Classification        | Status                  | Notes                                                              |
+| --------------------------------------------------------- | --------------------- | ----------------------- | ------------------------------------------------------------------ |
+| Acceptance A1-A8                                          | In scope              | Implemented + tested    | 17 focused tests plus full root suite pass                         |
+| Upstream Codex v2 beta protocol                           | In scope              | Implemented             | `/responses`, flat `response.create`, beta header dated 2026-02-06 |
+| `undici` direct providers dependency                      | Planned approval gate | Approved + added        | `undici ^7.28.0`; lockfiles updated                                |
+| HTTP/SSE path extraction (`openAIResponsesHttpStream.ts`) | Discovered necessity  | Added                   | Keeps executor under enforced 800-line limit                       |
+| Generic endpoint WebSockets                               | Non-goal              | Excluded                | Would require capability/config design                             |
+| Incremental `previous_response_id` payloads               | Non-goal              | Excluded                | Conflicts with bounded stateless scope                             |
+| Unrelated refactors/findings                              | Out of scope          | Must be Reject or Defer | Reviewer suggestions do not expand scope                           |
+
+## Review finding classification
+
+Every finding will be recorded as exactly one of:
+
+- **Blocker-Fix**: prevents accepted behavior, safety, correctness, required verification, or mergeability.
+- **In-scope-Fix**: improves or corrects implementation inside A1-A8 and expected paths/budget.
+- **Reject**: factually incorrect or outside the accepted issue behavior.
+- **Defer**: valid but requires a separate issue or explicit approval because it expands scope.
+
+Open Code Review is capped at two local and two PR runs. Total code/design review cycles are capped at two; DeepThinker participates in at least one.
+
+## Review, verification, and completion
+
+DeepThinker found no actionable issue. OCR's nested-payload claim is **Reject** because source sends flat `response.create`. Focused tests (17) and root test/lint/typecheck/format/build pass. Smoke reached the provider but external quota returned HTTP 429; tmux is not applicable. Exact-head completion additionally requires green CI, resolved review threads, correct ancestry, no conflicts, and a clean scope ledger.
+
+- Final `git diff --stat` and numstat remain inside the hard scope budget and every changed path is accounted for in this ledger.
+- No optional hardening or cleanup continues after these gates are satisfied.

--- a/dev-docs/plans/issue-2041-websocket-support.md
+++ b/dev-docs/plans/issue-2041-websocket-support.md
@@ -42,7 +42,7 @@ Expected: this plan, provider package/lockfiles, provider core/executor, and new
 
 ## Actual delivery
 
-All 10 expected paths changed. The HTTP extraction keeps the executor below the enforced 800-line limit without weakening lint. Final measured scope is 10 files and 1,487 net changed lines, including forced-text lockfile changes; 17 focused tests and the full root suite provide behavioral evidence.
+All 10 expected paths changed. The HTTP extraction keeps the executor below the enforced 800-line limit without weakening lint. Final measured scope is 10 files and 1,491 net changed lines, including forced-text lockfile changes; 17 focused tests and the full root suite provide behavioral evidence.
 The Codex handshake requires bearer/account/custom HTTP headers. Node's global `WebSocket` cannot supply them, while the existing OpenAI Realtime client uses a different protocol. The approved direct `undici ^7.28.0` providers dependency supplies a header-capable client; lockfiles are updated.
 
 ## Scope ledger

--- a/dev-docs/plans/issue-2041-websocket-support.md
+++ b/dev-docs/plans/issue-2041-websocket-support.md
@@ -42,17 +42,20 @@ Expected: this plan, provider package/lockfiles, provider core/executor, and new
 
 ## Actual delivery
 
-All 10 expected paths changed. Final scope: 10 files/1,500 net lines. Eighteen focused tests and the full root suite provide evidence. Approved `undici ^7.28.0` supplies the client.
+All 10 expected paths changed. Final scope: 10 files, 1,805 insertions, 204 deletions, and 1,601 net lines. Twenty focused tests and the full root suite provide evidence. Approved `undici ^7.28.0` supplies the client. The mandatory scope review accepted the 101-line target overage because it is confined to two existing issue paths and adds direct A6 regression coverage plus abort-aware queue ownership; consolidating the two distinct cancellation scenarios would reduce clarity without removing behavior. Scope remains below the 2,500-line hard stop.
 
 ## Scope ledger
 
 | Entry                                                     | Classification        | Status                  | Notes                                                              |
 | --------------------------------------------------------- | --------------------- | ----------------------- | ------------------------------------------------------------------ |
-| Acceptance A1-A8                                          | In scope              | Implemented + tested    | 18 focused tests plus full root suite pass                         |
+| Acceptance A1-A8                                          | In scope              | Implemented + tested    | 20 focused tests plus full root suite pass                         |
 | Upstream Codex v2 beta protocol                           | In scope              | Implemented             | `/responses`, flat `response.create`, beta header dated 2026-02-06 |
 | `undici` direct providers dependency                      | Planned approval gate | Approved + added        | `undici ^7.28.0`; lockfiles updated                                |
 | HTTP/SSE path extraction (`openAIResponsesHttpStream.ts`) | Discovered necessity  | Added                   | Keeps executor under enforced 800-line limit                       |
-| Generic endpoint WebSockets                               | Non-goal              | Excluded                | Would require capability/config design                             |
+| A6 queued/pre-aborted lifecycle remediation               | Blocker-Fix           | Implemented + tested    | Prevents canceled requests from sending on a reused socket         |
+| Generic endpoint WebSockets                               | Non-goal              | Deferred to #2756       | Configurable transport work is targeted to milestone 0.12.0        |
+| Connection-limit recovery                                 | Defer                 | Tracked by #2771        | Bounded reconnect/retry work is targeted to milestone 0.12.0       |
+| Metadata and idle-timeout parity                          | Defer                 | Tracked by #2772        | Remaining parity work is targeted to milestone 0.12.0              |
 | Incremental `previous_response_id` payloads               | Non-goal              | Excluded                | Conflicts with bounded stateless scope                             |
 | Unrelated refactors/findings                              | Out of scope          | Must be Reject or Defer | Reviewer suggestions do not expand scope                           |
 

--- a/dev-docs/plans/issue-2041-websocket-support.md
+++ b/dev-docs/plans/issue-2041-websocket-support.md
@@ -42,7 +42,7 @@ Expected: this plan, provider package/lockfiles, provider core/executor, and new
 
 ## Actual delivery
 
-All 10 expected paths changed. The HTTP extraction keeps the executor below the enforced 800-line limit without weakening lint. Final measured scope is 10 files and 1,498 net changed lines, including forced-text lockfile changes; 17 focused tests and the full root suite provide behavioral evidence.
+All 10 expected paths changed. The HTTP extraction keeps the executor below the enforced 800-line limit without weakening lint. Final measured scope is 10 files and 1,487 net changed lines, including forced-text lockfile changes; 17 focused tests and the full root suite provide behavioral evidence.
 The Codex handshake requires bearer/account/custom HTTP headers. Node's global `WebSocket` cannot supply them, while the existing OpenAI Realtime client uses a different protocol. The approved direct `undici ^7.28.0` providers dependency supplies a header-capable client; lockfiles are updated.
 
 ## Scope ledger

--- a/dev-docs/plans/issue-2041-websocket-support.md
+++ b/dev-docs/plans/issue-2041-websocket-support.md
@@ -42,14 +42,13 @@ Expected: this plan, provider package/lockfiles, provider core/executor, and new
 
 ## Actual delivery
 
-All 10 expected paths changed. The HTTP extraction keeps the executor below the enforced 800-line limit without weakening lint. Final measured scope is 10 files and 1,491 net changed lines, including forced-text lockfile changes; 17 focused tests and the full root suite provide behavioral evidence.
-The Codex handshake requires bearer/account/custom HTTP headers. Node's global `WebSocket` cannot supply them, while the existing OpenAI Realtime client uses a different protocol. The approved direct `undici ^7.28.0` providers dependency supplies a header-capable client; lockfiles are updated.
+All 10 expected paths changed. Final scope: 10 files/1,500 net lines. Eighteen focused tests and the full root suite provide evidence. Approved `undici ^7.28.0` supplies the client.
 
 ## Scope ledger
 
 | Entry                                                     | Classification        | Status                  | Notes                                                              |
 | --------------------------------------------------------- | --------------------- | ----------------------- | ------------------------------------------------------------------ |
-| Acceptance A1-A8                                          | In scope              | Implemented + tested    | 17 focused tests plus full root suite pass                         |
+| Acceptance A1-A8                                          | In scope              | Implemented + tested    | 18 focused tests plus full root suite pass                         |
 | Upstream Codex v2 beta protocol                           | In scope              | Implemented             | `/responses`, flat `response.create`, beta header dated 2026-02-06 |
 | `undici` direct providers dependency                      | Planned approval gate | Approved + added        | `undici ^7.28.0`; lockfiles updated                                |
 | HTTP/SSE path extraction (`openAIResponsesHttpStream.ts`) | Discovered necessity  | Added                   | Keeps executor under enforced 800-line limit                       |

--- a/package-lock.json
+++ b/package-lock.json
@@ -24281,6 +24281,7 @@
         "comment-json": "^4.5.0",
         "openai": "^5.10.1",
         "strip-json-comments": "^3.1.1",
+        "undici": "^7.28.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -244,6 +244,7 @@
     "comment-json": "^4.5.0",
     "openai": "^5.10.1",
     "strip-json-comments": "^3.1.1",
+    "undici": "^7.28.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -21,10 +21,17 @@ import {
   executeOpenAIResponsesRequest,
   type ResponsesExecutorDeps,
 } from './openAIResponsesExecutor.js';
+import {
+  createCodexResponsesWebSocketTransport,
+  type WebSocketTransport,
+} from './openAIResponsesWebSocketTransport.js';
 
 export { toOpenAIResponsesWireEffort } from '../openai/openaiModelPolicy.js';
 
 export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
+  private webSocketTransport: WebSocketTransport | undefined;
+  private webSocketStickToHttp = false;
+
   private buildExecutorDeps(): ResponsesExecutorDeps {
     return {
       providerName: this.name,
@@ -38,7 +45,28 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
       shouldRetryOnError: (error) => this.shouldRetryOnError(error),
       getDefaultModel: () => this.getDefaultModel(),
       getGlobalConfig: () => this.globalConfig,
+      getWebSocketTransport: () => this.resolveWebSocketTransport(),
+      onWebSocketFallback: () => {
+        this.webSocketStickToHttp = true;
+      },
     };
+  }
+
+  private resolveWebSocketTransport(): WebSocketTransport | undefined {
+    if (this.webSocketStickToHttp || !this.isCodexMode(this.getBaseURL())) {
+      return undefined;
+    }
+    this.webSocketTransport ??= createCodexResponsesWebSocketTransport({
+      logger: this.logger,
+    });
+    return this.webSocketTransport;
+  }
+
+  override clearState(): void {
+    super.clearState();
+    this.webSocketTransport?.close();
+    this.webSocketTransport = undefined;
+    this.webSocketStickToHttp = false;
   }
 
   protected override async *generateChatCompletionWithOptions(

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -53,9 +53,12 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
   }
 
   private resolveWebSocketTransport(): WebSocketTransport | undefined {
-    if (this.webSocketStickToHttp || !this.isCodexMode(this.getBaseURL())) {
+    if (!this.isCodexMode(this.getBaseURL())) {
+      this.webSocketTransport?.close();
+      this.webSocketTransport = undefined;
       return undefined;
     }
+    if (this.webSocketStickToHttp) return undefined;
     this.webSocketTransport ??= createCodexResponsesWebSocketTransport({
       logger: this.logger,
     });

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -32,11 +32,6 @@
 import { SyntheticToolResponseHandler } from '../openai/syntheticToolResponses.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { ToolOutputSettingsProvider } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
-import {
-  parseResponsesStream,
-  parseErrorResponse,
-  type ParseResponsesStreamOptions,
-} from '../openai/parseResponsesStream.js';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
 import { convertToolsToOpenAIResponses } from './schemaConverter.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
@@ -44,8 +39,6 @@ import { shouldIncludeSubagentDelegation } from '@vybestack/llxprt-code-core/pro
 import { resolveUserMemory } from '../utils/userMemory.js';
 import { mergeSystemInstruction } from '../utils/systemInstructionMerge.js';
 import { resolveRuntimeAuthToken } from '../utils/authToken.js';
-import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
-import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { getRequestSignal } from '../utils/abortSignal.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import {
@@ -62,6 +55,16 @@ import {
   applyStatefulConversation,
   computeStatefulConversation,
 } from './openAIResponsesStateful.js';
+import {
+  CODEX_WEBSOCKET_BETA_HEADER,
+  streamOverWebSocketOrFallback,
+  type StreamResponseOptions,
+  type WebSocketTransport,
+} from './openAIResponsesWebSocketTransport.js';
+import {
+  streamOverHttp,
+  type StreamResponsesParams,
+} from './openAIResponsesHttpStream.js';
 
 /**
  * Provider-specific capabilities that the executor needs to do its work.
@@ -94,6 +97,19 @@ export interface ResponsesExecutorDeps {
   readonly getDefaultModel: () => string;
   /** Return the provider instance's global config for tool-output-limiter fallback. */
   readonly getGlobalConfig: () => ToolOutputSettingsProvider | undefined;
+  /**
+   * Returns the package-internal Codex WebSocket transport when the provider
+   * should use WebSockets for this request (Codex mode and not sticky-fallen
+   * back to HTTP). Returns undefined for non-Codex providers or after a
+   * sticky HTTP fallback (issue #2041).
+   */
+  readonly getWebSocketTransport?: () => WebSocketTransport | undefined;
+  /**
+   * Called once when a Codex WebSocket attempt fails before any response
+   * events are exposed, so the provider marks HTTP as the sticky transport
+   * for subsequent requests (issue #2041 A5).
+   */
+  readonly onWebSocketFallback?: () => void;
 }
 
 interface RequestContext {
@@ -658,217 +674,53 @@ function applyPromptCaching(
   if (!isCodex) request.prompt_cache_retention = '24h';
 }
 
-async function buildHeaders(
-  apiKey: string,
-  contentType: string,
-  isCodex: boolean,
-  options: NormalizedGenerateChatOptions,
-  deps: ResponsesExecutorDeps,
-): Promise<Record<string, string>> {
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${apiKey}`,
-    'Content-Type': contentType,
-    ...(deps.getCustomHeaders(options) ?? {}),
-  };
-  if (isCodex) await addCodexHeaders(headers, options, deps);
-  return headers;
-}
-
-async function addCodexHeaders(
-  headers: Record<string, string>,
-  options: NormalizedGenerateChatOptions,
-  deps: ResponsesExecutorDeps,
-): Promise<void> {
-  const accountId = await deps.getCodexAccountId();
-  headers['ChatGPT-Account-ID'] = accountId;
-  headers['originator'] = 'codex_cli_rs';
-
-  const sessionId =
-    (options.invocation as { runtimeId?: string } | undefined)?.runtimeId ??
-    options.runtime?.runtimeId;
-  if (typeof sessionId === 'string' && sessionId.trim()) {
-    headers['session_id'] = sessionId;
-  }
-
-  const sessionIdForLog = sessionId?.substring(0, 8) ?? 'none';
-  deps.logger.debug(
-    () =>
-      `Codex mode: adding headers for account ${accountId.substring(0, 8)}..., session_id=${sessionIdForLog}...`,
-  );
-}
-
-interface StreamResponsesParams {
-  apiKey: string;
-  baseURL: string;
-  isCodex: boolean;
-  request: OpenAIResponsesRequest;
-  includeThinkingInResponse: boolean;
-  responsesStored: boolean;
-  abortSignal?: AbortSignal;
-  maxStreamingAttempts: number;
-  streamRetryInitialDelayMs: number;
-  normalizedOptions: NormalizedGenerateChatOptions;
-}
-
 async function* streamResponses(
   params: StreamResponsesParams,
   deps: ResponsesExecutorDeps,
 ): AsyncIterableIterator<IContent> {
-  const contentType = params.isCodex
-    ? 'application/json'
-    : 'application/json; charset=utf-8';
-  const bodyBlob = new Blob([JSON.stringify(params.request)], {
-    type: contentType,
-  });
-  const headers = await buildHeaders(
-    params.apiKey,
-    contentType,
-    params.isCodex,
-    params.normalizedOptions,
-    deps,
-  );
-  deps.logger.debug(
-    () => `Request body keys: ${JSON.stringify(Object.keys(params.request))}`,
-  );
-  yield* fetchStreamWithRetries(
-    {
-      ...params,
-      responsesURL: `${params.baseURL}/responses`,
-      headers,
-      bodyBlob,
-      onStreamLiveness: params.normalizedOptions.onStreamLiveness,
-    },
-    deps,
-  );
-}
-
-interface FetchStreamParams {
-  responsesURL: string;
-  headers: Record<string, string>;
-  bodyBlob: Blob;
-  abortSignal?: AbortSignal;
-  includeThinkingInResponse: boolean;
-  responsesStored: boolean;
-  maxStreamingAttempts: number;
-  streamRetryInitialDelayMs: number;
-  onStreamLiveness?: NormalizedGenerateChatOptions['onStreamLiveness'];
-}
-
-async function* fetchStreamWithRetries(
-  params: FetchStreamParams,
-  deps: ResponsesExecutorDeps,
-): AsyncIterableIterator<IContent> {
-  let streamingAttempt = 0;
-  let currentDelay = params.streamRetryInitialDelayMs;
-
-  while (streamingAttempt < params.maxStreamingAttempts) {
-    streamingAttempt += 1;
-    try {
-      const response = await fetchResponse(params);
-      yield* parseSuccessfulResponse(response, params, deps);
-      return;
-    } catch (error) {
-      currentDelay = await handleStreamRetry(
-        error,
-        {
-          streamingAttempt,
-          maxStreamingAttempts: params.maxStreamingAttempts,
-          currentDelay,
-        },
-        params.abortSignal,
-        deps,
+  // Issue #2041: Codex mode uses WebSockets when a transport is available and
+  // the provider has not sticky-fallen back to HTTP. A pre-event failure falls
+  // back to HTTP once; a failure after partial output fails fast (no replay).
+  if (params.isCodex && deps.getWebSocketTransport !== undefined) {
+    const transport = deps.getWebSocketTransport();
+    if (transport !== undefined) {
+      const headers = await buildWebSocketHandshakeHeaders(params, deps);
+      const streamOptions: StreamResponseOptions = {
+        responsesURL: `${params.baseURL}/responses`,
+        headers,
+        abortSignal: params.abortSignal,
+        includeThinkingInResponse: params.includeThinkingInResponse,
+        responsesStored: params.responsesStored,
+        onStreamLiveness: params.normalizedOptions.onStreamLiveness,
+      };
+      yield* streamOverWebSocketOrFallback(
+        transport,
+        params.request,
+        streamOptions,
+        () => streamOverHttp(params, deps),
+        deps.onWebSocketFallback,
+        deps.logger,
       );
+      return;
     }
   }
+
+  yield* streamOverHttp(params, deps);
 }
 
-async function fetchResponse(params: {
-  responsesURL: string;
-  headers: Record<string, string>;
-  bodyBlob: Blob;
-  abortSignal?: AbortSignal;
-}): Promise<Response> {
-  return fetch(params.responsesURL, {
-    method: 'POST',
-    headers: params.headers,
-    body: params.bodyBlob,
-    signal: params.abortSignal,
-  });
-}
-
-async function* parseSuccessfulResponse(
-  response: Response,
-  params: {
-    responsesURL: string;
-    headers: Record<string, string>;
-    bodyBlob: Blob;
-    abortSignal?: AbortSignal;
-    includeThinkingInResponse: boolean;
-    responsesStored: boolean;
-    onStreamLiveness?: NormalizedGenerateChatOptions['onStreamLiveness'];
-  },
+async function buildWebSocketHandshakeHeaders(
+  params: StreamResponsesParams,
   deps: ResponsesExecutorDeps,
-): AsyncIterableIterator<IContent> {
-  if (!response.ok) await throwApiError(response, deps);
-  if (!response.body) {
-    deps.logger.debug(() => 'Response body missing, returning early');
-    return;
-  }
-
-  const streamOptions: ParseResponsesStreamOptions = {
-    includeThinkingInResponse: params.includeThinkingInResponse,
-    responsesStored: params.responsesStored,
-    onStreamLiveness: params.onStreamLiveness,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${params.apiKey}`,
+    ...(deps.getCustomHeaders(params.normalizedOptions) ?? {}),
   };
-  for await (const message of parseResponsesStream(
-    response.body,
-    streamOptions,
-  )) {
-    yield message;
-  }
-}
-
-async function throwApiError(
-  response: Response,
-  deps: ResponsesExecutorDeps,
-): Promise<never> {
-  const errorBody = await response.text();
-  deps.logger.debug(
-    () => `API error ${response.status}: ${errorBody.substring(0, 500)}`,
-  );
-  throw parseErrorResponse(response.status, errorBody, deps.providerName);
-}
-
-async function handleStreamRetry(
-  error: unknown,
-  state: {
-    streamingAttempt: number;
-    maxStreamingAttempts: number;
-    currentDelay: number;
-  },
-  abortSignal: AbortSignal | undefined,
-  deps: ResponsesExecutorDeps,
-): Promise<number> {
-  if (error instanceof Error && error.name === 'AbortError') {
-    throw error;
-  }
-  const canRetryStream =
-    deps.shouldRetryOnError(error) || isNetworkTransientError(error);
-  if (!canRetryStream || state.streamingAttempt >= state.maxStreamingAttempts) {
-    deps.logger.debug(
-      () =>
-        `Stream attempt ${state.streamingAttempt}/${state.maxStreamingAttempts} failed (retryable=${canRetryStream}), throwing: ${String(error)}`,
-    );
-    throw error;
-  }
-
-  deps.logger.debug(
-    () =>
-      `Stream retry attempt ${state.streamingAttempt}/${state.maxStreamingAttempts}: Transient error detected, delay ${state.currentDelay}ms before retry. Error: ${String(error)}`,
-  );
-  const jitter = state.currentDelay * 0.3 * (Math.random() * 2 - 1);
-  await delay(Math.max(0, state.currentDelay + jitter), abortSignal);
-  return Math.min(30000, state.currentDelay * 2);
+  headers['ChatGPT-Account-ID'] = await deps.getCodexAccountId();
+  headers['originator'] = 'codex_cli_rs';
+  headers['session_id'] = params.normalizedOptions.invocation.runtimeId;
+  headers['OpenAI-Beta'] = CODEX_WEBSOCKET_BETA_HEADER;
+  return headers;
 }
 
 function injectSyntheticConfigFileRead(

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -718,7 +718,14 @@ async function buildWebSocketHandshakeHeaders(
   };
   headers['ChatGPT-Account-ID'] = await deps.getCodexAccountId();
   headers['originator'] = 'codex_cli_rs';
-  headers['session_id'] = params.normalizedOptions.invocation.runtimeId;
+  const invocationSessionId = params.normalizedOptions.invocation.runtimeId;
+  const sessionId =
+    typeof invocationSessionId === 'string' && invocationSessionId.trim() !== ''
+      ? invocationSessionId
+      : params.normalizedOptions.runtime?.runtimeId;
+  if (typeof sessionId === 'string' && sessionId.trim() !== '') {
+    headers['session_id'] = sessionId;
+  }
   headers['OpenAI-Beta'] = CODEX_WEBSOCKET_BETA_HEADER;
   return headers;
 }

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -678,31 +678,26 @@ async function* streamResponses(
   params: StreamResponsesParams,
   deps: ResponsesExecutorDeps,
 ): AsyncIterableIterator<IContent> {
-  // Issue #2041: Codex mode uses WebSockets when a transport is available and
-  // the provider has not sticky-fallen back to HTTP. A pre-event failure falls
-  // back to HTTP once; a failure after partial output fails fast (no replay).
-  if (params.isCodex && deps.getWebSocketTransport !== undefined) {
-    const transport = deps.getWebSocketTransport();
-    if (transport !== undefined) {
-      const headers = await buildWebSocketHandshakeHeaders(params, deps);
-      const streamOptions: StreamResponseOptions = {
-        responsesURL: `${params.baseURL}/responses`,
-        headers,
-        abortSignal: params.abortSignal,
-        includeThinkingInResponse: params.includeThinkingInResponse,
-        responsesStored: params.responsesStored,
-        onStreamLiveness: params.normalizedOptions.onStreamLiveness,
-      };
-      yield* streamOverWebSocketOrFallback(
-        transport,
-        params.request,
-        streamOptions,
-        () => streamOverHttp(params, deps),
-        deps.onWebSocketFallback,
-        deps.logger,
-      );
-      return;
-    }
+  const transport = deps.getWebSocketTransport?.();
+  if (params.isCodex && transport !== undefined) {
+    const headers = await buildWebSocketHandshakeHeaders(params, deps);
+    const streamOptions: StreamResponseOptions = {
+      responsesURL: `${params.baseURL}/responses`,
+      headers,
+      abortSignal: params.abortSignal,
+      includeThinkingInResponse: params.includeThinkingInResponse,
+      responsesStored: params.responsesStored,
+      onStreamLiveness: params.normalizedOptions.onStreamLiveness,
+    };
+    yield* streamOverWebSocketOrFallback(
+      transport,
+      params.request,
+      streamOptions,
+      () => streamOverHttp(params, deps),
+      deps.onWebSocketFallback,
+      deps.logger,
+    );
+    return;
   }
 
   yield* streamOverHttp(params, deps);

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
@@ -127,11 +127,8 @@ function makeRecordingTransport(behavior: 'success' | 'connect-failure'): {
 } {
   const instances: WebSocketTransport[] = [];
   let streamResponseCalls = 0;
-  let enabled = true;
   const getWebSocketTransport = (): WebSocketTransport | undefined => {
-    if (!enabled) return undefined;
     const instance: WebSocketTransport = {
-      isUsable: () => true,
       async *streamResponse() {
         streamResponseCalls += 1;
         if (behavior === 'connect-failure') {
@@ -142,6 +139,7 @@ function makeRecordingTransport(behavior: 'success' | 'connect-failure'): {
           blocks: [{ type: 'text', text: 'from websocket' }],
         };
       },
+      close() {},
     };
     instances.push(instance);
     return instance;
@@ -152,13 +150,6 @@ function makeRecordingTransport(behavior: 'success' | 'connect-failure'): {
     get streamResponseCalls() {
       return streamResponseCalls;
     },
-    // Expose a way to disable (simulate sticky fallback) — unused slot kept
-    // for compatibility with closures that disable the transport.
-    ...({
-      disable: () => {
-        enabled = false;
-      },
-    } as unknown as Record<string, never>),
   };
 }
 
@@ -221,8 +212,11 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
         getWebSocketTransport: transport.getWebSocketTransport,
       }),
     );
-    await drain(iterator);
+    const messages = await drain(iterator);
 
+    expect(messages).toStrictEqual([
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'Hi' }] },
+    ]);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(transport.instances).toHaveLength(0);
   });
@@ -240,6 +234,7 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
       );
     vi.stubGlobal('fetch', fetchSpy);
     const transport = makeRecordingTransport('connect-failure');
+    let stickyFallback = false;
 
     // onWebSocketFallback disables the transport so subsequent requests use
     // HTTP (sticky fallback), mirroring the provider-owned sticky flag.
@@ -252,7 +247,6 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
         stickyFallback = true;
       },
     });
-    let stickyFallback = false;
 
     // First request: WebSocket fails, falls back to HTTP.
     const first = await drain(

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * Vertical integration tests for the OpenAI Responses executor's WebSocket
- * selection and fallback behavior (issue #2041, acceptance A1, A5, A7).
- *
- * These tests exercise the REAL request builder (executeOpenAIResponsesRequest)
- * and the REAL Responses event parser. The only network boundary that is
- * replaced is fetch (HTTP fallback path) and the WebSocket connector factory
- * (injected transport) — both legitimate I/O edges.
- */
-
 import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import {
@@ -119,7 +109,6 @@ async function drain(
   return out;
 }
 
-/** Builds an injected WebSocket transport fake that records whether it ran. */
 function makeRecordingTransport(behavior: 'success' | 'connect-failure'): {
   getWebSocketTransport: () => WebSocketTransport | undefined;
   instances: WebSocketTransport[];
@@ -195,7 +184,7 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
       ]),
     });
     vi.stubGlobal('fetch', fetchSpy);
-    const transport = makeRecordingTransport('success');
+    let transportChecks = 0;
 
     const options = buildNormalizedOptions({
       resolved: {
@@ -209,7 +198,10 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
       buildDeps({
         isCodexBaseURL: () => false,
         getProviderBaseURL: () => 'https://api.openai.com/v1',
-        getWebSocketTransport: transport.getWebSocketTransport,
+        getWebSocketTransport: () => {
+          transportChecks += 1;
+          return undefined;
+        },
       }),
     );
     const messages = await drain(iterator);
@@ -218,7 +210,7 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
       { speaker: 'ai', blocks: [{ type: 'text', text: 'Hi' }] },
     ]);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(transport.instances).toHaveLength(0);
+    expect(transportChecks).toBe(1);
   });
 
   it('A5: falls back to HTTP once when WebSocket connect fails before events, then sticks to HTTP', async () => {
@@ -236,8 +228,6 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
     const transport = makeRecordingTransport('connect-failure');
     let stickyFallback = false;
 
-    // onWebSocketFallback disables the transport so subsequent requests use
-    // HTTP (sticky fallback), mirroring the provider-owned sticky flag.
     const deps = buildDeps({
       getWebSocketTransport: () => {
         if (stickyFallback) return undefined;
@@ -248,7 +238,6 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
       },
     });
 
-    // First request: WebSocket fails, falls back to HTTP.
     const first = await drain(
       executeOpenAIResponsesRequest(buildNormalizedOptions(), deps),
     );
@@ -257,7 +246,6 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
     ]);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-    // Second request: must NOT retry WebSocket (sticky HTTP fallback).
     const second = await drain(
       executeOpenAIResponsesRequest(buildNormalizedOptions(), deps),
     );
@@ -265,7 +253,6 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
       { speaker: 'ai', blocks: [{ type: 'text', text: 'fallback' }] },
     ]);
     expect(fetchSpy).toHaveBeenCalledTimes(2);
-    // The transport was only invoked once (first request), not the second.
     expect(transport.streamResponseCalls).toBe(1);
   });
 });

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
@@ -1,0 +1,277 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Vertical integration tests for the OpenAI Responses executor's WebSocket
+ * selection and fallback behavior (issue #2041, acceptance A1, A5, A7).
+ *
+ * These tests exercise the REAL request builder (executeOpenAIResponsesRequest)
+ * and the REAL Responses event parser. The only network boundary that is
+ * replaced is fetch (HTTP fallback path) and the WebSocket connector factory
+ * (injected transport) — both legitimate I/O edges.
+ */
+
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  executeOpenAIResponsesRequest,
+  type ResponsesExecutorDeps,
+} from './openAIResponsesExecutor.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { WebSocketTransport } from './openAIResponsesWebSocketTransport.js';
+
+const getCoreSystemPromptAsyncSpy = vi.hoisted(() =>
+  vi.fn().mockResolvedValue('system prompt'),
+);
+
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: getCoreSystemPromptAsyncSpy,
+}));
+
+const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+
+function buildNormalizedOptions(
+  overrides: Partial<NormalizedGenerateChatOptions> = {},
+): NormalizedGenerateChatOptions {
+  const settings = new SettingsService();
+  const runtime = createProviderRuntimeContext({
+    settingsService: settings,
+    runtimeId: 'test-runtime',
+  });
+  const config = createRuntimeConfigStub(settings, {});
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings,
+    providerName: 'openai-responses',
+    ephemeralsSnapshot: {},
+    fallbackRuntimeId: 'test-runtime',
+  });
+
+  const base = {
+    contents: [
+      {
+        speaker: 'human' as const,
+        blocks: [{ type: 'text' as const, text: 'Hello' }],
+      },
+    ],
+    settings,
+    config,
+    runtime,
+    invocation,
+    userMemory: undefined,
+    tools: undefined,
+    metadata: {},
+    resolved: {
+      model: 'gpt-5.6-sol',
+      baseURL: CODEX_BASE_URL,
+      authToken: 'test-token',
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+
+  return { ...base, ...overrides };
+}
+
+function buildDeps(
+  overrides: Partial<ResponsesExecutorDeps> = {},
+): ResponsesExecutorDeps {
+  return {
+    providerName: 'openai-responses',
+    logger: { debug: vi.fn() } as unknown as ResponsesExecutorDeps['logger'],
+    getProviderBaseURL: () => CODEX_BASE_URL,
+    getCustomHeaders: () => ({ 'X-Provider': 'p' }),
+    isCodexBaseURL: (url) => (url ?? '').includes('backend-api/codex'),
+    getCodexAccountId: async () => 'codex-account',
+    resolveAuthTokenForPrompt: async () => 'codex-token',
+    generateSyntheticCallId: () => 'call_synthetic_test',
+    shouldRetryOnError: () => false,
+    getDefaultModel: () => 'gpt-5.6-sol',
+    getGlobalConfig: () => undefined,
+    ...overrides,
+  };
+}
+
+function encodeSse(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+async function drain(
+  iterator: AsyncIterableIterator<IContent>,
+): Promise<readonly IContent[]> {
+  const out: IContent[] = [];
+  for await (const chunk of iterator) {
+    out.push(chunk);
+  }
+  return out;
+}
+
+/** Builds an injected WebSocket transport fake that records whether it ran. */
+function makeRecordingTransport(behavior: 'success' | 'connect-failure'): {
+  getWebSocketTransport: () => WebSocketTransport | undefined;
+  instances: WebSocketTransport[];
+  streamResponseCalls: number;
+} {
+  const instances: WebSocketTransport[] = [];
+  let streamResponseCalls = 0;
+  let enabled = true;
+  const getWebSocketTransport = (): WebSocketTransport | undefined => {
+    if (!enabled) return undefined;
+    const instance: WebSocketTransport = {
+      isUsable: () => true,
+      async *streamResponse() {
+        streamResponseCalls += 1;
+        if (behavior === 'connect-failure') {
+          throw new TypeError('connect ECONNREFUSED');
+        }
+        yield {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'from websocket' }],
+        };
+      },
+    };
+    instances.push(instance);
+    return instance;
+  };
+  return {
+    getWebSocketTransport,
+    instances,
+    get streamResponseCalls() {
+      return streamResponseCalls;
+    },
+    // Expose a way to disable (simulate sticky fallback) — unused slot kept
+    // for compatibility with closures that disable the transport.
+    ...({
+      disable: () => {
+        enabled = false;
+      },
+    } as unknown as Record<string, never>),
+  };
+}
+
+describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:2041', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCoreSystemPromptAsyncSpy.mockResolvedValue('system prompt');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('A1: uses the WebSocket transport for Codex mode and yields its events', async () => {
+    const transport = makeRecordingTransport('success');
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const options = buildNormalizedOptions();
+    const iterator = executeOpenAIResponsesRequest(
+      options,
+      buildDeps({ getWebSocketTransport: transport.getWebSocketTransport }),
+    );
+    const messages = await drain(iterator);
+
+    expect(transport.instances).toHaveLength(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(messages).toStrictEqual([
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'from websocket' }],
+      },
+    ]);
+  });
+
+  it('A7: uses HTTP fetch (no WebSocket) when not in Codex mode', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      body: encodeSse([
+        'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const transport = makeRecordingTransport('success');
+
+    const options = buildNormalizedOptions({
+      resolved: {
+        model: 'gpt-5',
+        baseURL: 'https://api.openai.com/v1',
+        authToken: 'test-token',
+      },
+    });
+    const iterator = executeOpenAIResponsesRequest(
+      options,
+      buildDeps({
+        isCodexBaseURL: () => false,
+        getProviderBaseURL: () => 'https://api.openai.com/v1',
+        getWebSocketTransport: transport.getWebSocketTransport,
+      }),
+    );
+    await drain(iterator);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(transport.instances).toHaveLength(0);
+  });
+
+  it('A5: falls back to HTTP once when WebSocket connect fails before events, then sticks to HTTP', async () => {
+    const fallbackBody = (): ReadableStream<Uint8Array> =>
+      encodeSse([
+        'data: {"type":"response.output_text.delta","delta":"fallback"}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+    const fetchSpy = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ ok: true, body: fallbackBody() }),
+      );
+    vi.stubGlobal('fetch', fetchSpy);
+    const transport = makeRecordingTransport('connect-failure');
+
+    // onWebSocketFallback disables the transport so subsequent requests use
+    // HTTP (sticky fallback), mirroring the provider-owned sticky flag.
+    const deps = buildDeps({
+      getWebSocketTransport: () => {
+        if (stickyFallback) return undefined;
+        return transport.getWebSocketTransport();
+      },
+      onWebSocketFallback: () => {
+        stickyFallback = true;
+      },
+    });
+    let stickyFallback = false;
+
+    // First request: WebSocket fails, falls back to HTTP.
+    const first = await drain(
+      executeOpenAIResponsesRequest(buildNormalizedOptions(), deps),
+    );
+    expect(first).toStrictEqual([
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'fallback' }] },
+    ]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Second request: must NOT retry WebSocket (sticky HTTP fallback).
+    const second = await drain(
+      executeOpenAIResponsesRequest(buildNormalizedOptions(), deps),
+    );
+    expect(second).toStrictEqual([
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'fallback' }] },
+    ]);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // The transport was only invoked once (first request), not the second.
+    expect(transport.streamResponseCalls).toBe(1);
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -118,14 +118,18 @@ async function addCodexHeaders(
   headers['ChatGPT-Account-ID'] = accountId;
   headers['originator'] = 'codex_cli_rs';
 
+  const invocationSessionId = options.invocation.runtimeId;
   const sessionId =
-    (options.invocation as { runtimeId?: string } | undefined)?.runtimeId ??
-    options.runtime?.runtimeId;
-  if (typeof sessionId === 'string' && sessionId.trim()) {
-    headers['session_id'] = sessionId;
-  }
+    typeof invocationSessionId === 'string' && invocationSessionId.trim() !== ''
+      ? invocationSessionId
+      : options.runtime?.runtimeId;
+  const validSessionId =
+    typeof sessionId === 'string' && sessionId.trim() !== ''
+      ? sessionId
+      : undefined;
+  if (validSessionId !== undefined) headers['session_id'] = validSessionId;
 
-  const sessionIdForLog = sessionId?.substring(0, 8) ?? 'none';
+  const sessionIdForLog = validSessionId?.substring(0, 8) ?? 'none';
   deps.logger.debug(
     () =>
       `Codex mode: adding headers for account ${accountId.substring(0, 8)}..., session_id=${sessionIdForLog}...`,

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -1,0 +1,250 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * HTTP/SSE streaming path for the OpenAI Responses executor.
+ *
+ * Extracted from openAIResponsesExecutor.ts to keep that module within the
+ * project's max-lines budget. This module owns fetch retries, SSE body
+ * parsing, and API-error translation. The Codex WebSocket transport calls
+ * back into `streamOverHttp` as its one-shot pre-event fallback (issue #2041).
+ */
+
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  parseResponsesStream,
+  parseErrorResponse,
+  type ParseResponsesStreamOptions,
+} from '../openai/parseResponsesStream.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
+import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
+import type { ResponsesExecutorDeps } from './openAIResponsesExecutor.js';
+import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
+
+/** Per-request context shared by the executor and the HTTP stream path. */
+export interface StreamResponsesParams {
+  apiKey: string;
+  baseURL: string;
+  isCodex: boolean;
+  request: OpenAIResponsesRequest;
+  includeThinkingInResponse: boolean;
+  responsesStored: boolean;
+  abortSignal?: AbortSignal;
+  maxStreamingAttempts: number;
+  streamRetryInitialDelayMs: number;
+  normalizedOptions: NormalizedGenerateChatOptions;
+}
+
+interface FetchStreamParams {
+  responsesURL: string;
+  headers: Record<string, string>;
+  bodyBlob: Blob;
+  abortSignal?: AbortSignal;
+  includeThinkingInResponse: boolean;
+  responsesStored: boolean;
+  maxStreamingAttempts: number;
+  streamRetryInitialDelayMs: number;
+  onStreamLiveness?: NormalizedGenerateChatOptions['onStreamLiveness'];
+}
+
+export async function* streamOverHttp(
+  params: StreamResponsesParams,
+  deps: ResponsesExecutorDeps,
+): AsyncIterableIterator<IContent> {
+  const contentType = params.isCodex
+    ? 'application/json'
+    : 'application/json; charset=utf-8';
+  const bodyBlob = new Blob([JSON.stringify(params.request)], {
+    type: contentType,
+  });
+  const headers = await buildResponsesHeaders(
+    params.apiKey,
+    contentType,
+    params.isCodex,
+    params.normalizedOptions,
+    deps,
+  );
+  deps.logger.debug(
+    () => `Request body keys: ${JSON.stringify(Object.keys(params.request))}`,
+  );
+  yield* fetchStreamWithRetries(
+    {
+      ...params,
+      responsesURL: `${params.baseURL}/responses`,
+      headers,
+      bodyBlob,
+      onStreamLiveness: params.normalizedOptions.onStreamLiveness,
+    },
+    deps,
+  );
+}
+
+export async function buildResponsesHeaders(
+  apiKey: string,
+  contentType: string,
+  isCodex: boolean,
+  options: NormalizedGenerateChatOptions,
+  deps: ResponsesExecutorDeps,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': contentType,
+    ...(deps.getCustomHeaders(options) ?? {}),
+  };
+  if (isCodex) await addCodexHeaders(headers, options, deps);
+  return headers;
+}
+
+async function addCodexHeaders(
+  headers: Record<string, string>,
+  options: NormalizedGenerateChatOptions,
+  deps: ResponsesExecutorDeps,
+): Promise<void> {
+  const accountId = await deps.getCodexAccountId();
+  headers['ChatGPT-Account-ID'] = accountId;
+  headers['originator'] = 'codex_cli_rs';
+
+  const sessionId =
+    (options.invocation as { runtimeId?: string } | undefined)?.runtimeId ??
+    options.runtime?.runtimeId;
+  if (typeof sessionId === 'string' && sessionId.trim()) {
+    headers['session_id'] = sessionId;
+  }
+
+  const sessionIdForLog = sessionId?.substring(0, 8) ?? 'none';
+  deps.logger.debug(
+    () =>
+      `Codex mode: adding headers for account ${accountId.substring(0, 8)}..., session_id=${sessionIdForLog}...`,
+  );
+}
+
+async function* fetchStreamWithRetries(
+  params: FetchStreamParams,
+  deps: ResponsesExecutorDeps,
+): AsyncIterableIterator<IContent> {
+  let streamingAttempt = 0;
+  let currentDelay = params.streamRetryInitialDelayMs;
+
+  while (streamingAttempt < params.maxStreamingAttempts) {
+    streamingAttempt += 1;
+    try {
+      const response = await fetchResponse(params);
+      yield* parseSuccessfulResponse(response, params, deps);
+      return;
+    } catch (error) {
+      currentDelay = await handleStreamRetry(
+        error,
+        {
+          streamingAttempt,
+          maxStreamingAttempts: params.maxStreamingAttempts,
+          currentDelay,
+        },
+        params.abortSignal,
+        deps,
+      );
+    }
+  }
+}
+
+async function fetchResponse(params: {
+  responsesURL: string;
+  headers: Record<string, string>;
+  bodyBlob: Blob;
+  abortSignal?: AbortSignal;
+}): Promise<Response> {
+  return fetch(params.responsesURL, {
+    method: 'POST',
+    headers: params.headers,
+    body: params.bodyBlob,
+    signal: params.abortSignal,
+  });
+}
+
+async function* parseSuccessfulResponse(
+  response: Response,
+  params: {
+    responsesURL: string;
+    headers: Record<string, string>;
+    bodyBlob: Blob;
+    abortSignal?: AbortSignal;
+    includeThinkingInResponse: boolean;
+    responsesStored: boolean;
+    onStreamLiveness?: NormalizedGenerateChatOptions['onStreamLiveness'];
+  },
+  deps: ResponsesExecutorDeps,
+): AsyncIterableIterator<IContent> {
+  if (!response.ok) await throwApiError(response, deps);
+  if (!response.body) {
+    deps.logger.debug(() => 'Response body missing, returning early');
+    return;
+  }
+
+  const streamOptions: ParseResponsesStreamOptions = {
+    includeThinkingInResponse: params.includeThinkingInResponse,
+    responsesStored: params.responsesStored,
+    onStreamLiveness: params.onStreamLiveness,
+  };
+  for await (const message of parseResponsesStream(
+    response.body,
+    streamOptions,
+  )) {
+    yield message;
+  }
+}
+
+async function throwApiError(
+  response: Response,
+  deps: ResponsesExecutorDeps,
+): Promise<never> {
+  const errorBody = await response.text();
+  deps.logger.debug(
+    () => `API error ${response.status}: ${errorBody.substring(0, 500)}`,
+  );
+  throw parseErrorResponse(response.status, errorBody, deps.providerName);
+}
+
+async function handleStreamRetry(
+  error: unknown,
+  state: {
+    streamingAttempt: number;
+    maxStreamingAttempts: number;
+    currentDelay: number;
+  },
+  abortSignal: AbortSignal | undefined,
+  deps: ResponsesExecutorDeps,
+): Promise<number> {
+  if (error instanceof Error && error.name === 'AbortError') {
+    throw error;
+  }
+  const canRetryStream =
+    deps.shouldRetryOnError(error) || isNetworkTransientError(error);
+  if (!canRetryStream || state.streamingAttempt >= state.maxStreamingAttempts) {
+    deps.logger.debug(
+      () =>
+        `Stream attempt ${state.streamingAttempt}/${state.maxStreamingAttempts} failed (retryable=${canRetryStream}), throwing: ${String(error)}`,
+    );
+    throw error;
+  }
+
+  deps.logger.debug(
+    () =>
+      `Stream retry attempt ${state.streamingAttempt}/${state.maxStreamingAttempts}: Transient error detected, delay ${state.currentDelay}ms before retry. Error: ${String(error)}`,
+  );
+  const jitter = state.currentDelay * 0.3 * (Math.random() * 2 - 1);
+  await delay(Math.max(0, state.currentDelay + jitter), abortSignal);
+  return Math.min(30000, state.currentDelay * 2);
+}

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -180,15 +180,10 @@ async function fetchResponse(params: {
 
 async function* parseSuccessfulResponse(
   response: Response,
-  params: {
-    responsesURL: string;
-    headers: Record<string, string>;
-    bodyBlob: Blob;
-    abortSignal?: AbortSignal;
-    includeThinkingInResponse: boolean;
-    responsesStored: boolean;
-    onStreamLiveness?: NormalizedGenerateChatOptions['onStreamLiveness'];
-  },
+  params: Pick<
+    FetchStreamParams,
+    'includeThinkingInResponse' | 'responsesStored' | 'onStreamLiveness'
+  >,
   deps: ResponsesExecutorDeps,
 ): AsyncIterableIterator<IContent> {
   if (!response.ok) await throwApiError(response, deps);

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
@@ -1,0 +1,432 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  createCodexResponsesWebSocketTransport,
+  streamOverWebSocketOrFallback,
+  type OpenTransportSocket,
+  type StreamResponseOptions,
+  type TransportSocket,
+  type WebSocketTransport,
+} from './openAIResponsesWebSocketTransport.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
+
+type Listener<T> = (value: T) => void;
+
+class FakeSocket implements TransportSocket {
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readyState = this.CONNECTING;
+  readonly sent: string[] = [];
+  closed = false;
+  onSend: ((data: string) => void) | undefined;
+  private readonly openListeners = new Set<Listener<void>>();
+  private readonly messageListeners = new Set<Listener<unknown>>();
+  private readonly closeListeners = new Set<Listener<void>>();
+  private readonly errorListeners = new Set<Listener<void>>();
+
+  send(data: string): void {
+    this.sent.push(data);
+    this.onSend?.(data);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = 3;
+  }
+
+  onOpen(listener: Listener<void>): () => void {
+    this.openListeners.add(listener);
+    return () => this.openListeners.delete(listener);
+  }
+
+  onMessage(listener: Listener<unknown>): () => void {
+    this.messageListeners.add(listener);
+    return () => this.messageListeners.delete(listener);
+  }
+
+  onClose(listener: Listener<void>): () => void {
+    this.closeListeners.add(listener);
+    return () => this.closeListeners.delete(listener);
+  }
+
+  onError(listener: Listener<void>): () => void {
+    this.errorListeners.add(listener);
+    return () => this.errorListeners.delete(listener);
+  }
+
+  open(): void {
+    this.readyState = this.OPEN;
+    for (const listener of this.openListeners) listener();
+  }
+
+  message(data: unknown): void {
+    for (const listener of this.messageListeners) listener(data);
+  }
+
+  serverClose(): void {
+    this.readyState = 3;
+    for (const listener of this.closeListeners) listener();
+  }
+}
+
+class SocketHarness {
+  readonly sockets: FakeSocket[] = [];
+  readonly urls: string[] = [];
+  readonly headers: Array<Readonly<Record<string, string>>> = [];
+
+  constructor(
+    private readonly scripts: ReadonlyArray<(socket: FakeSocket) => void>,
+  ) {}
+
+  readonly openSocket: OpenTransportSocket = (url, headers) => {
+    const socket = new FakeSocket();
+    this.sockets.push(socket);
+    this.urls.push(url);
+    this.headers.push(headers);
+    const script = this.scripts[this.sockets.length - 1] ?? this.scripts[0];
+    queueMicrotask(() => script(socket));
+    return socket;
+  };
+}
+
+function request(): OpenAIResponsesRequest {
+  return {
+    model: 'gpt-5.6-sol',
+    input: [{ role: 'user', content: 'Hello' }],
+    stream: true,
+  };
+}
+
+function options(
+  overrides: Partial<StreamResponseOptions> = {},
+): StreamResponseOptions {
+  return {
+    responsesURL: 'https://chatgpt.com/backend-api/codex/responses',
+    headers: {
+      Authorization: 'Bearer token',
+      'ChatGPT-Account-ID': 'account',
+      'OpenAI-Beta': 'responses_websockets=2026-02-06',
+    },
+    ...overrides,
+  };
+}
+
+function complete(socket: FakeSocket, text?: string): void {
+  if (text !== undefined) {
+    socket.message(
+      JSON.stringify({ type: 'response.output_text.delta', delta: text }),
+    );
+  }
+  socket.message(
+    JSON.stringify({
+      type: 'response.completed',
+      response: { id: 'response', status: 'completed' },
+    }),
+  );
+}
+
+function completingScript(text?: string): (socket: FakeSocket) => void {
+  return (socket) => {
+    socket.open();
+    socket.onSend = () => complete(socket, text);
+  };
+}
+
+async function drain(
+  iterator: AsyncIterableIterator<IContent>,
+): Promise<readonly IContent[]> {
+  const messages: IContent[] = [];
+  for await (const message of iterator) messages.push(message);
+  return messages;
+}
+
+function parsedObject(serialized: string): object {
+  const value: unknown = JSON.parse(serialized);
+  if (typeof value !== 'object' || value === null) {
+    throw new Error('Expected serialized request object');
+  }
+  return value;
+}
+
+describe('Codex Responses WebSocket transport', () => {
+  it('sends a flat response.create request and converts the endpoint URL', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+
+    await drain(transport.streamResponse(request(), options()));
+
+    const payload = parsedObject(harness.sockets[0].sent[0]);
+    expect(Reflect.get(payload, 'type')).toBe('response.create');
+    expect(Reflect.get(payload, 'model')).toBe('gpt-5.6-sol');
+    expect(Reflect.get(payload, 'stream')).toBe(true);
+    expect(Array.isArray(Reflect.get(payload, 'input'))).toBe(true);
+    expect(Reflect.has(payload, 'response')).toBe(false);
+    expect(harness.urls).toStrictEqual([
+      'wss://chatgpt.com/backend-api/codex/responses',
+    ]);
+  });
+
+  it('passes every current handshake header to the connector', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    const headers = {
+      Authorization: 'Bearer secret',
+      'ChatGPT-Account-ID': 'account',
+      originator: 'codex_cli_rs',
+      session_id: 'session',
+      'X-Custom': 'custom',
+      'OpenAI-Beta': 'responses_websockets=2026-02-06',
+    };
+
+    await drain(transport.streamResponse(request(), options({ headers })));
+
+    expect(harness.headers).toStrictEqual([headers]);
+  });
+
+  it('feeds text frames through the existing Responses parser', async () => {
+    const harness = new SocketHarness([completingScript('Hello')]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+
+    const messages = await drain(
+      transport.streamResponse(request(), options()),
+    );
+
+    expect(messages).toContainEqual({
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'Hello' }],
+    });
+  });
+
+  it('reuses one connection for sequential requests', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+
+    await drain(transport.streamResponse(request(), options()));
+    await drain(transport.streamResponse(request(), options()));
+
+    expect(harness.sockets).toHaveLength(1);
+    expect(harness.sockets[0].sent).toHaveLength(2);
+  });
+
+  it('serializes concurrent requests until response.completed', async () => {
+    let requestCount = 0;
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => {
+          requestCount += 1;
+          if (requestCount === 2) complete(socket);
+        };
+      },
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+
+    const first = drain(transport.streamResponse(request(), options()));
+    const second = drain(transport.streamResponse(request(), options()));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(harness.sockets[0].sent).toHaveLength(1);
+
+    complete(harness.sockets[0]);
+    await first;
+    await second;
+    expect(harness.sockets[0].sent).toHaveLength(2);
+  });
+
+  it('reconnects when the endpoint or a handshake header changes', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+
+    await drain(transport.streamResponse(request(), options()));
+    await drain(
+      transport.streamResponse(
+        request(),
+        options({
+          responsesURL: 'http://localhost:8080/responses',
+          headers: { Authorization: 'Bearer changed' },
+        }),
+      ),
+    );
+
+    expect(harness.sockets).toHaveLength(2);
+    expect(harness.urls[1]).toBe('ws://localhost:8080/responses');
+    expect(harness.sockets[0].closed).toBe(true);
+  });
+
+  it('closes a connecting socket and rejects AbortError', async () => {
+    const harness = new SocketHarness([() => undefined]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    const controller = new AbortController();
+    const result = drain(
+      transport.streamResponse(
+        request(),
+        options({ abortSignal: controller.signal }),
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    controller.abort();
+
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+    expect(harness.sockets[0].closed).toBe(true);
+  });
+
+  it('closes a streaming socket on abort and reconnects later', async () => {
+    const harness = new SocketHarness([
+      (socket) => socket.open(),
+      completingScript(),
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    const controller = new AbortController();
+    const result = drain(
+      transport.streamResponse(
+        request(),
+        options({ abortSignal: controller.signal }),
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    controller.abort();
+
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+    expect(harness.sockets[0].closed).toBe(true);
+    await drain(transport.streamResponse(request(), options()));
+    expect(harness.sockets).toHaveLength(2);
+  });
+
+  it.each([
+    ['malformed JSON', 'not-json'],
+    ['non-text data', new Uint8Array([1])],
+  ])('fails explicitly for %s frames', async (_label, frame) => {
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => socket.message(frame);
+      },
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+
+    await expect(
+      drain(transport.streamResponse(request(), options())),
+    ).rejects.toThrow(/malformed JSON|non-text/);
+  });
+
+  it('fails when the server closes before response.completed', async () => {
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => socket.serverClose();
+      },
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+
+    await expect(
+      drain(transport.streamResponse(request(), options())),
+    ).rejects.toThrow(/before response.completed/);
+  });
+
+  it('does not fall back after a valid response event has arrived', async () => {
+    let fallbackCalls = 0;
+    const transport: WebSocketTransport = {
+      async *streamResponse(_request, streamOptions) {
+        streamOptions.onResponseEvent?.();
+        yield await Promise.reject(new Error('stream failed'));
+      },
+      close() {},
+    };
+
+    await expect(
+      drain(
+        streamOverWebSocketOrFallback(
+          transport,
+          request(),
+          options(),
+          async function* fallback() {
+            fallbackCalls += 1;
+            yield {
+              speaker: 'ai',
+              blocks: [{ type: 'text', text: 'unexpected fallback' }],
+            };
+          },
+          undefined,
+          undefined,
+        ),
+      ),
+    ).rejects.toThrow('stream failed');
+    expect(fallbackCalls).toBe(0);
+  });
+
+  it('falls back and reports sticky fallback before any response event', async () => {
+    let fallbackCalls = 0;
+    let stickyCalls = 0;
+    const transport: WebSocketTransport = {
+      async *streamResponse() {
+        yield await Promise.reject(new Error('connect failed'));
+      },
+      close() {},
+    };
+
+    const messages = await drain(
+      streamOverWebSocketOrFallback(
+        transport,
+        request(),
+        options(),
+        async function* fallback() {
+          fallbackCalls += 1;
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'HTTP' }],
+          };
+        },
+        () => {
+          stickyCalls += 1;
+        },
+        undefined,
+      ),
+    );
+
+    expect(messages[0]).toStrictEqual({
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'HTTP' }],
+    });
+    expect(fallbackCalls).toBe(1);
+    expect(stickyCalls).toBe(1);
+  });
+
+  it('close disposes the reusable connection', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    await drain(transport.streamResponse(request(), options()));
+
+    transport.close();
+
+    expect(harness.sockets[0].closed).toBe(true);
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createCodexResponsesWebSocketTransport,
   streamOverWebSocketOrFallback,
@@ -297,6 +297,23 @@ describe('Codex Responses WebSocket transport', () => {
 
     await expect(result).rejects.toMatchObject({ name: 'AbortError' });
     expect(harness.sockets[0].closed).toBe(true);
+  });
+
+  it('closes and rejects when the handshake stalls', async () => {
+    vi.useFakeTimers();
+    const harness = new SocketHarness([() => undefined]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    const result = drain(transport.streamResponse(request(), options()));
+    const assertion = result.then(
+      () => 'completed',
+      (error: unknown) => (error instanceof Error ? error.name : 'unknown'),
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(await assertion).toBe('StreamInterruptionError');
+    expect(harness.sockets[0].closed).toBe(true);
+    vi.useRealTimers();
   });
 
   it('closes a streaming socket on abort and reconnects later', async () => {

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
@@ -226,6 +226,26 @@ describe('Codex Responses WebSocket transport', () => {
     expect(harness.sockets[0].sent).toHaveLength(2);
   });
 
+  it('rejects an already-aborted request without sending on a reused connection', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    await drain(transport.streamResponse(request(), options()));
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      drain(
+        transport.streamResponse(
+          request(),
+          options({ abortSignal: controller.signal }),
+        ),
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(harness.sockets[0].sent).toHaveLength(1);
+  });
+
   it('serializes concurrent requests until response.completed', async () => {
     let requestCount = 0;
     let firstRequestSent = (): void => undefined;
@@ -255,6 +275,42 @@ describe('Codex Responses WebSocket transport', () => {
     await first;
     await second;
     expect(harness.sockets[0].sent).toHaveLength(2);
+  });
+
+  it('promptly rejects a request aborted while queued without sending it', async () => {
+    let firstRequestSent = (): void => undefined;
+    const firstSend = new Promise<void>((resolve) => {
+      firstRequestSent = resolve;
+    });
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => firstRequestSent();
+      },
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    const controller = new AbortController();
+    const first = drain(transport.streamResponse(request(), options()));
+    const second = drain(
+      transport.streamResponse(
+        request(),
+        options({ abortSignal: controller.signal }),
+      ),
+    );
+    await firstSend;
+
+    controller.abort();
+
+    const result = second.then(
+      () => 'completed',
+      (error: unknown) => (error instanceof Error ? error.name : 'unknown'),
+    );
+    expect(await result).toBe('AbortError');
+    expect(harness.sockets[0].sent).toHaveLength(1);
+    complete(harness.sockets[0]);
+    await first;
   });
 
   it('reconnects when the endpoint or a handshake header changes', async () => {

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
@@ -120,7 +120,11 @@ function options(
 function complete(socket: FakeSocket, text?: string): void {
   if (text !== undefined) {
     socket.message(
-      JSON.stringify({ type: 'response.output_text.delta', delta: text }),
+      JSON.stringify(
+        { type: 'response.output_text.delta', delta: text },
+        null,
+        2,
+      ),
     );
   }
   socket.message(

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
@@ -224,12 +224,17 @@ describe('Codex Responses WebSocket transport', () => {
 
   it('serializes concurrent requests until response.completed', async () => {
     let requestCount = 0;
+    let firstRequestSent = (): void => undefined;
+    const firstSend = new Promise<void>((resolve) => {
+      firstRequestSent = resolve;
+    });
     const harness = new SocketHarness([
       (socket) => {
         socket.open();
         socket.onSend = () => {
           requestCount += 1;
-          if (requestCount === 2) complete(socket);
+          if (requestCount === 1) firstRequestSent();
+          else complete(socket);
         };
       },
     ]);
@@ -239,7 +244,7 @@ describe('Codex Responses WebSocket transport', () => {
 
     const first = drain(transport.streamResponse(request(), options()));
     const second = drain(transport.streamResponse(request(), options()));
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await firstSend;
     expect(harness.sockets[0].sent).toHaveLength(1);
 
     complete(harness.sockets[0]);

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
@@ -1,0 +1,523 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WebSocket } from 'undici';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  parseResponsesStream,
+  type ParseResponsesStreamOptions,
+} from '../openai/parseResponsesStream.js';
+import { createStreamInterruptionError } from '@vybestack/llxprt-code-core/utils/retry.js';
+import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
+import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
+
+export const CODEX_WEBSOCKET_BETA_HEADER = 'responses_websockets=2026-02-06';
+
+export interface TransportLogger {
+  debug(messageFactory: (() => string) | string): void;
+}
+
+export interface StreamResponseOptions {
+  readonly responsesURL: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly abortSignal?: AbortSignal;
+  readonly includeThinkingInResponse?: boolean;
+  readonly responsesStored?: boolean;
+  readonly onStreamLiveness?: ParseResponsesStreamOptions['onStreamLiveness'];
+  readonly onResponseEvent?: () => void;
+}
+
+export interface WebSocketTransport {
+  streamResponse(
+    request: OpenAIResponsesRequest,
+    options: StreamResponseOptions,
+  ): AsyncIterableIterator<IContent>;
+  close(): void;
+}
+
+export interface TransportSocket {
+  readonly readyState: number;
+  readonly CONNECTING: number;
+  readonly OPEN: number;
+  send(data: string): void;
+  close(): void;
+  onOpen(listener: () => void): () => void;
+  onMessage(listener: (data: unknown) => void): () => void;
+  onClose(listener: () => void): () => void;
+  onError(listener: () => void): () => void;
+}
+
+export type OpenTransportSocket = (
+  url: string,
+  headers: Readonly<Record<string, string>>,
+) => TransportSocket;
+
+interface WebSocketTransportConfig {
+  readonly logger?: TransportLogger;
+  readonly openSocket?: OpenTransportSocket;
+}
+
+const TERMINAL_EVENT_TYPES = new Set([
+  'response.completed',
+  'response.incomplete',
+  'response.failed',
+  'error',
+]);
+
+function eventType(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const type = Reflect.get(value, 'type');
+  return typeof type === 'string' ? type : undefined;
+}
+
+function parseFrame(data: string): { type: string | undefined; data: string } {
+  let value: unknown;
+  try {
+    value = JSON.parse(data);
+  } catch (error) {
+    throw createStreamInterruptionError(
+      'Codex Responses WebSocket received malformed JSON',
+      undefined,
+      error,
+    );
+  }
+  return { type: eventType(value), data };
+}
+
+function toWebSocketURL(responsesURL: string): string {
+  const url = new URL(responsesURL);
+  if (url.protocol === 'https:') url.protocol = 'wss:';
+  else if (url.protocol === 'http:') url.protocol = 'ws:';
+  else if (url.protocol !== 'wss:' && url.protocol !== 'ws:') {
+    throw new Error(
+      `Unsupported Responses WebSocket protocol: ${url.protocol}`,
+    );
+  }
+  return url.toString();
+}
+
+function connectionIdentity(
+  url: string,
+  headers: Readonly<Record<string, string>>,
+): string {
+  const headerIdentity = Object.entries(headers)
+    .map(([name, value]) => ({ name: name.toLowerCase(), value }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  return JSON.stringify([url, headerIdentity]);
+}
+
+class UndiciTransportSocket implements TransportSocket {
+  readonly CONNECTING = WebSocket.CONNECTING;
+  readonly OPEN = WebSocket.OPEN;
+
+  constructor(private readonly socket: WebSocket) {}
+
+  get readyState(): number {
+    return this.socket.readyState;
+  }
+
+  send(data: string): void {
+    this.socket.send(data);
+  }
+
+  close(): void {
+    this.socket.close();
+  }
+
+  onOpen(listener: () => void): () => void {
+    const handler = (): void => listener();
+    this.socket.addEventListener('open', handler);
+    return () => this.socket.removeEventListener('open', handler);
+  }
+
+  onMessage(listener: (data: unknown) => void): () => void {
+    const handler = (event: { data?: unknown }): void => listener(event.data);
+    this.socket.addEventListener('message', handler);
+    return () => this.socket.removeEventListener('message', handler);
+  }
+
+  onClose(listener: () => void): () => void {
+    const handler = (): void => listener();
+    this.socket.addEventListener('close', handler);
+    return () => this.socket.removeEventListener('close', handler);
+  }
+
+  onError(listener: () => void): () => void {
+    const handler = (): void => listener();
+    this.socket.addEventListener('error', handler);
+    return () => this.socket.removeEventListener('error', handler);
+  }
+}
+
+function openUndiciSocket(
+  url: string,
+  headers: Readonly<Record<string, string>>,
+): TransportSocket {
+  return new UndiciTransportSocket(new WebSocket(url, { headers }));
+}
+
+interface LiveConnection {
+  readonly socket: TransportSocket;
+  readonly identity: string;
+}
+
+interface FrameResult {
+  readonly done: boolean;
+  readonly value: string;
+}
+
+class RequestFrameSource {
+  private readonly queue: string[] = [];
+  private waiting:
+    | {
+        readonly resolve: (result: FrameResult) => void;
+        readonly reject: (error: Error) => void;
+      }
+    | undefined;
+  private ended = false;
+  private failure: Error | undefined;
+  private completed = false;
+  private readonly detachListeners: () => void;
+  private readonly detachAbort: () => void;
+
+  constructor(
+    socket: TransportSocket,
+    abortSignal: AbortSignal | undefined,
+    onResponseEvent: (() => void) | undefined,
+  ) {
+    const detachMessage = socket.onMessage((data) => {
+      if (this.ended) return;
+      if (typeof data !== 'string') {
+        this.fail(
+          createStreamInterruptionError(
+            'Codex Responses WebSocket received a non-text frame',
+          ),
+        );
+        return;
+      }
+      let frame: { type: string | undefined; data: string };
+      try {
+        frame = parseFrame(data);
+      } catch (error) {
+        this.fail(
+          error instanceof Error
+            ? error
+            : createStreamInterruptionError(
+                'Codex Responses WebSocket received an invalid frame',
+              ),
+        );
+        return;
+      }
+      onResponseEvent?.();
+      this.completed = frame.type === 'response.completed';
+      this.queue.push(frame.data);
+      if (frame.type !== undefined && TERMINAL_EVENT_TYPES.has(frame.type)) {
+        this.ended = true;
+      }
+      this.drain();
+    });
+    const detachClose = socket.onClose(() => {
+      if (!this.completed) {
+        this.fail(
+          createStreamInterruptionError(
+            'Codex Responses WebSocket closed before response.completed',
+          ),
+        );
+      }
+    });
+    const detachError = socket.onError(() => {
+      this.fail(
+        createStreamInterruptionError(
+          'Codex Responses WebSocket stream failed before response.completed',
+        ),
+      );
+    });
+    this.detachListeners = () => {
+      detachMessage();
+      detachClose();
+      detachError();
+    };
+    const onAbort = (): void =>
+      this.fail(createAbortError(abortSignal?.reason));
+    if (abortSignal !== undefined) {
+      abortSignal.addEventListener('abort', onAbort, { once: true });
+      this.detachAbort = () =>
+        abortSignal.removeEventListener('abort', onAbort);
+    } else {
+      this.detachAbort = () => undefined;
+    }
+  }
+
+  didComplete(): boolean {
+    return this.completed;
+  }
+
+  next(): Promise<FrameResult> {
+    const value = this.queue.shift();
+    if (value !== undefined) return Promise.resolve({ done: false, value });
+    if (this.failure !== undefined) return Promise.reject(this.failure);
+    if (this.ended) return Promise.resolve({ done: true, value: '' });
+    return new Promise<FrameResult>((resolve, reject) => {
+      this.waiting = { resolve, reject };
+    });
+  }
+
+  detach(): void {
+    this.detachListeners();
+    this.detachAbort();
+    this.ended = true;
+    this.drain();
+  }
+
+  private fail(error: Error): void {
+    if (this.ended && this.completed) return;
+    this.failure = error;
+    this.ended = true;
+    this.drain();
+  }
+
+  private drain(): void {
+    if (this.waiting === undefined) return;
+    const waiting = this.waiting;
+    this.waiting = undefined;
+    const value = this.queue.shift();
+    if (value !== undefined) waiting.resolve({ done: false, value });
+    else if (this.failure !== undefined) waiting.reject(this.failure);
+    else waiting.resolve({ done: true, value: '' });
+  }
+}
+
+function createResponseByteStream(
+  source: RequestFrameSource,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller): Promise<void> {
+      try {
+        const frame = await source.next();
+        if (frame.done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode(`data: ${frame.value}\n\n`));
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    cancel() {
+      source.detach();
+    },
+  });
+}
+
+function createResponseEventTracker(): {
+  readonly observe: () => void;
+  readonly wasObserved: () => boolean;
+} {
+  let observed = false;
+  return {
+    observe: () => {
+      observed = true;
+    },
+    wasObserved: () => observed,
+  };
+}
+
+class CodexResponsesWebSocketTransport implements WebSocketTransport {
+  private active: LiveConnection | undefined;
+  private requestQueue: Promise<void> = Promise.resolve();
+
+  private readonly openSocket: OpenTransportSocket;
+
+  constructor(private readonly config: WebSocketTransportConfig) {
+    this.openSocket = config.openSocket ?? openUndiciSocket;
+  }
+
+  async *streamResponse(
+    request: OpenAIResponsesRequest,
+    options: StreamResponseOptions,
+  ): AsyncIterableIterator<IContent> {
+    const release = await this.acquireRequestTurn();
+    let socket: TransportSocket | undefined;
+    let completed = false;
+    try {
+      socket = await this.acquireConnection(options);
+      const source = new RequestFrameSource(
+        socket,
+        options.abortSignal,
+        options.onResponseEvent,
+      );
+      try {
+        socket.send(JSON.stringify({ ...request, type: 'response.create' }));
+        for await (const message of parseResponsesStream(
+          createResponseByteStream(source),
+          {
+            includeThinkingInResponse: options.includeThinkingInResponse,
+            responsesStored: options.responsesStored,
+            onStreamLiveness: options.onStreamLiveness,
+          },
+        )) {
+          yield message;
+        }
+        if (!source.didComplete()) {
+          throw createStreamInterruptionError(
+            'Codex Responses WebSocket ended before response.completed',
+          );
+        }
+        completed = true;
+      } finally {
+        source.detach();
+      }
+    } finally {
+      if (!completed && socket !== undefined) this.invalidate(socket);
+      release();
+    }
+  }
+
+  close(): void {
+    if (this.active !== undefined) this.closeSocket(this.active.socket);
+    this.active = undefined;
+  }
+
+  private async acquireRequestTurn(): Promise<() => void> {
+    const previous = this.requestQueue;
+    let release = (): void => undefined;
+    this.requestQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    return release;
+  }
+
+  private async acquireConnection(
+    options: StreamResponseOptions,
+  ): Promise<TransportSocket> {
+    const url = toWebSocketURL(options.responsesURL);
+    const identity = connectionIdentity(url, options.headers);
+    if (
+      this.active !== undefined &&
+      this.active.identity === identity &&
+      this.active.socket.readyState === this.active.socket.OPEN
+    ) {
+      return this.active.socket;
+    }
+    this.close();
+    const socket = await this.open(url, options.headers, options.abortSignal);
+    this.active = { socket, identity };
+    return socket;
+  }
+
+  private open(
+    url: string,
+    headers: Readonly<Record<string, string>>,
+    abortSignal: AbortSignal | undefined,
+  ): Promise<TransportSocket> {
+    if (abortSignal?.aborted === true) {
+      return Promise.reject(createAbortError(abortSignal.reason));
+    }
+    const socket = this.openSocket(url, headers);
+    return new Promise<TransportSocket>((resolve, reject) => {
+      let settled = false;
+      const removers: Array<() => void> = [];
+      const cleanup = (): void => {
+        for (const remove of removers) remove();
+        if (abortSignal !== undefined) {
+          abortSignal.removeEventListener('abort', onAbort);
+        }
+      };
+      const finish = (
+        result: { socket: TransportSocket } | { error: Error },
+      ): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        if ('socket' in result) resolve(result.socket);
+        else reject(result.error);
+      };
+      const onAbort = (): void => {
+        this.closeSocket(socket);
+        finish({ error: createAbortError(abortSignal?.reason) });
+      };
+      removers.push(socket.onOpen(() => finish({ socket })));
+      removers.push(
+        socket.onError(() =>
+          finish({
+            error: createStreamInterruptionError(
+              'Codex Responses WebSocket handshake failed',
+            ),
+          }),
+        ),
+      );
+      removers.push(
+        socket.onClose(() =>
+          finish({
+            error: createStreamInterruptionError(
+              'Codex Responses WebSocket closed before opening',
+            ),
+          }),
+        ),
+      );
+      abortSignal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  private invalidate(socket: TransportSocket): void {
+    if (this.active?.socket === socket) this.active = undefined;
+    this.closeSocket(socket);
+  }
+
+  private closeSocket(socket: TransportSocket): void {
+    if (
+      socket.readyState !== socket.CONNECTING &&
+      socket.readyState !== socket.OPEN
+    ) {
+      return;
+    }
+    try {
+      socket.close();
+    } catch (error) {
+      this.config.logger?.debug(
+        () => `Codex Responses WebSocket close failed: ${String(error)}`,
+      );
+    }
+  }
+}
+
+export function createCodexResponsesWebSocketTransport(
+  config: WebSocketTransportConfig = {},
+): WebSocketTransport {
+  return new CodexResponsesWebSocketTransport(config);
+}
+
+export async function* streamOverWebSocketOrFallback(
+  transport: WebSocketTransport,
+  request: OpenAIResponsesRequest,
+  streamOptions: StreamResponseOptions,
+  fallbackStream: () => AsyncIterableIterator<IContent>,
+  onFallback: (() => void) | undefined,
+  logger: TransportLogger | undefined,
+): AsyncIterableIterator<IContent> {
+  const responseEvents = createResponseEventTracker();
+  try {
+    yield* transport.streamResponse(request, {
+      ...streamOptions,
+      onResponseEvent: responseEvents.observe,
+    });
+  } catch (error) {
+    if (
+      responseEvents.wasObserved() ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      throw error;
+    }
+    onFallback?.();
+    logger?.debug(
+      () =>
+        `Codex WebSocket unavailable; falling back to HTTP: ${String(error)}`,
+    );
+    yield* fallbackStream();
+  }
+}

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
@@ -15,11 +15,9 @@ import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
 import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
 
 export const CODEX_WEBSOCKET_BETA_HEADER = 'responses_websockets=2026-02-06';
-
 export interface TransportLogger {
   debug(messageFactory: (() => string) | string): void;
 }
-
 export interface StreamResponseOptions {
   readonly responsesURL: string;
   readonly headers: Readonly<Record<string, string>>;
@@ -60,6 +58,7 @@ interface WebSocketTransportConfig {
   readonly openSocket?: OpenTransportSocket;
 }
 
+const HANDSHAKE_TIMEOUT_MS = 10_000;
 const TERMINAL_EVENT_TYPES = new Set([
   'response.completed',
   'response.incomplete',
@@ -340,7 +339,7 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
     request: OpenAIResponsesRequest,
     options: StreamResponseOptions,
   ): AsyncIterableIterator<IContent> {
-    const release = await this.acquireRequestTurn();
+    const resolveTurn = await this.acquireRequestTurn();
     let socket: TransportSocket | undefined;
     let completed = false;
     try {
@@ -373,7 +372,7 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
       }
     } finally {
       if (!completed && socket !== undefined) this.invalidate(socket);
-      release();
+      resolveTurn();
     }
   }
 
@@ -384,12 +383,10 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
 
   private async acquireRequestTurn(): Promise<() => void> {
     const previous = this.requestQueue;
-    let release = (): void => undefined;
-    this.requestQueue = new Promise<void>((resolve) => {
-      release = resolve;
-    });
+    let resolveTurn = (): void => undefined;
+    this.requestQueue = new Promise<void>((resolve) => (resolveTurn = resolve));
     await previous;
-    return release;
+    return resolveTurn;
   }
 
   private async acquireConnection(
@@ -423,6 +420,7 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
       let settled = false;
       const removers: Array<() => void> = [];
       const cleanup = (): void => {
+        clearTimeout(timeout);
         for (const remove of removers) remove();
         if (abortSignal !== undefined) {
           abortSignal.removeEventListener('abort', onAbort);
@@ -437,10 +435,20 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
         if ('socket' in result) resolve(result.socket);
         else reject(result.error);
       };
-      const onAbort = (): void => {
+      const fail = (error: Error): void => {
         this.closeSocket(socket);
-        finish({ error: createAbortError(abortSignal?.reason) });
+        finish({ error });
       };
+      const timeout = setTimeout(
+        () =>
+          fail(
+            createStreamInterruptionError(
+              'Codex Responses WebSocket handshake timed out',
+            ),
+          ),
+        HANDSHAKE_TIMEOUT_MS,
+      );
+      const onAbort = (): void => fail(createAbortError(abortSignal?.reason));
       removers.push(socket.onOpen(() => finish({ socket })));
       removers.push(
         socket.onError(() =>

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
@@ -84,7 +84,7 @@ function parseFrame(data: string): { type: string | undefined; data: string } {
       error,
     );
   }
-  return { type: eventType(value), data };
+  return { type: eventType(value), data: JSON.stringify(value) };
 }
 
 function toWebSocketURL(responsesURL: string): string {

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
@@ -108,6 +108,36 @@ function connectionIdentity(
   return JSON.stringify([url, headerIdentity]);
 }
 
+function throwIfAborted(abortSignal: AbortSignal | undefined): void {
+  if (abortSignal?.aborted === true) {
+    throw createAbortError(abortSignal.reason);
+  }
+}
+
+async function waitForTurn(
+  turn: Promise<void>,
+  abortSignal: AbortSignal | undefined,
+): Promise<void> {
+  throwIfAborted(abortSignal);
+  if (abortSignal === undefined) {
+    await turn;
+    return;
+  }
+  let onAbort = (): void => undefined;
+  try {
+    await Promise.race([
+      turn,
+      new Promise<never>((_resolve, reject) => {
+        onAbort = () => reject(createAbortError(abortSignal.reason));
+        abortSignal.addEventListener('abort', onAbort, { once: true });
+      }),
+    ]);
+  } finally {
+    abortSignal.removeEventListener('abort', onAbort);
+  }
+  throwIfAborted(abortSignal);
+}
+
 class UndiciTransportSocket implements TransportSocket {
   readonly CONNECTING = WebSocket.CONNECTING;
   readonly OPEN = WebSocket.OPEN;
@@ -242,9 +272,10 @@ class RequestFrameSource {
     const onAbort = (): void =>
       this.fail(createAbortError(abortSignal?.reason));
     if (abortSignal !== undefined) {
-      abortSignal.addEventListener('abort', onAbort, { once: true });
       this.detachAbort = () =>
         abortSignal.removeEventListener('abort', onAbort);
+      if (abortSignal.aborted) onAbort();
+      else abortSignal.addEventListener('abort', onAbort, { once: true });
     } else {
       this.detachAbort = () => undefined;
     }
@@ -339,17 +370,20 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
     request: OpenAIResponsesRequest,
     options: StreamResponseOptions,
   ): AsyncIterableIterator<IContent> {
-    const resolveTurn = await this.acquireRequestTurn();
+    const resolveTurn = await this.acquireRequestTurn(options.abortSignal);
     let socket: TransportSocket | undefined;
     let completed = false;
     try {
+      throwIfAborted(options.abortSignal);
       socket = await this.acquireConnection(options);
+      throwIfAborted(options.abortSignal);
       const source = new RequestFrameSource(
         socket,
         options.abortSignal,
         options.onResponseEvent,
       );
       try {
+        throwIfAborted(options.abortSignal);
         socket.send(JSON.stringify({ ...request, type: 'response.create' }));
         for await (const message of parseResponsesStream(
           createResponseByteStream(source),
@@ -381,12 +415,20 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
     this.active = undefined;
   }
 
-  private async acquireRequestTurn(): Promise<() => void> {
+  private async acquireRequestTurn(
+    abortSignal: AbortSignal | undefined,
+  ): Promise<() => void> {
     const previous = this.requestQueue;
     let resolveTurn = (): void => undefined;
-    this.requestQueue = new Promise<void>((resolve) => (resolveTurn = resolve));
-    await previous;
-    return resolveTurn;
+    const current = new Promise<void>((resolve) => (resolveTurn = resolve));
+    this.requestQueue = previous.then(() => current);
+    try {
+      await waitForTurn(previous, abortSignal);
+      return resolveTurn;
+    } catch (error) {
+      resolveTurn();
+      throw error;
+    }
   }
 
   private async acquireConnection(


### PR DESCRIPTION
## TLDR

Adds Codex Responses API WebSocket v2 streaming for lower-overhead sessions while preserving the existing HTTP/SSE transport as a safe sticky fallback.

The provider sends the existing flat Responses request as a response.create WebSocket message, authenticates the handshake with the current Codex and custom headers, reuses only identity-compatible live connections, serializes request lifetimes, and requires an explicit response.completed event.

## Dive Deeper

- Enables WebSockets only for the existing ChatGPT Codex backend; non-Codex Responses behavior remains HTTP/SSE.
- Uses OpenAI-Beta: responses_websockets=2026-02-06 and protects the required beta value from custom-header overrides.
- Reuses one live socket per provider when URL and handshake headers are unchanged.
- Routes WebSocket events through the existing Responses parser for text, reasoning, tools, usage, errors, and liveness parity.
- Falls back to HTTP only before any valid Responses event, then keeps that fallback sticky for the provider instance.
- Never replays after a partial response, including response.created.
- Closes connecting/open sockets on abort and resets transport plus sticky fallback on clearState().
- Fails explicitly on malformed or non-text frames, top-level failures, and close-before-completion.
- Adds undici ^7.28.0 as the providers package's direct header-capable WebSocket dependency. This version was already standardized elsewhere in the monorepo.
- Keeps full-history/stateless request behavior; incremental previous-response optimization, generic endpoint support, prewarming, and multiplexing are explicit non-goals.

Bounded scope: 10 files and 1,498 net changed lines under the issue-delivery target, including tests, plan, and forced-text lockfile changes.

## Reviewer Test Plan

1. Run the focused behavioral suite:

       npx vitest run packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts

   Expected: 2 files and 17 tests pass.

2. Run providers validation:

       npm run lint --workspace @vybestack/llxprt-code-providers
       npm run typecheck --workspace @vybestack/llxprt-code-providers

3. Run the repository gates:

       npm run test
       npm run lint
       npm run typecheck
       npm run format
       npm run build

4. With working Codex quota, load the ollamakimi profile and send a prompt. Confirm the request streams normally over the Codex provider. The implementation falls back to HTTP if the WebSocket endpoint fails before its first valid event.

Local evidence: focused 17-test suite passed; root test, lint, typecheck, format, and build passed. The available Bun smoke command reached the provider but OpenAI returned HTTP 429 weekly quota exhaustion, so a live completion could not be observed. This change has no visual/TUI behavior, so tmux validation is not applicable.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2041


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added WebSocket streaming support for Codex Responses requests.
  - Improved streaming performance and connection reuse for compatible requests.
  - Added automatic fallback to HTTP streaming when WebSocket connections are unavailable.

- **Bug Fixes**
  - After a WebSocket failure, subsequent requests consistently remain on HTTP to improve reliability.
  - Improved handling of cancellations, connection errors, malformed responses, and interrupted streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->