### PR TITLE
fix(providers): allow keyless auth for local endpoints in openai-vercel (Fixes #2506)

### DIFF
--- a/packages/providers/src/openai-vercel/OpenAIVercelProvider.localAuth.test.ts
+++ b/packages/providers/src/openai-vercel/OpenAIVercelProvider.localAuth.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * End-to-end behavioral tests for the openai-vercel local-endpoint auth
+ * exemption (issue #2506). These exercise the full OpenAIVercelProvider path
+ * (generateChatCompletion -> createConfiguredModel -> createOpenAIClient) and
+ * assert that @ai-sdk/openai's `createOpenAI` receives a non-undefined apiKey
+ * for local endpoints, so `loadApiKey` does not throw before the request fires.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { OpenAIVercelProvider } from './OpenAIVercelProvider.js';
+import { AuthenticationError } from './errors.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+
+vi.mock('ai', () => ({
+  generateText: vi.fn(),
+  streamText: vi.fn(),
+  extractReasoningMiddleware: vi.fn(() => ({})),
+  wrapLanguageModel: vi.fn((model) => model),
+}));
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() => vi.fn((modelId: string) => ({ modelId }))),
+}));
+
+async function collectResults(
+  iterator: AsyncIterableIterator<IContent>,
+): Promise<IContent[]> {
+  const results: IContent[] = [];
+  for await (const content of iterator) {
+    results.push(content);
+  }
+  return results;
+}
+
+describe('OpenAIVercelProvider local-endpoint keyless auth (issue #2506)', () => {
+  let settingsService: SettingsService;
+  let config: ReturnType<typeof createRuntimeConfigStub>;
+  let originalOpenAiKey: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalOpenAiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    settingsService = new SettingsService();
+    settingsService.set('activeProvider', 'openaivercel');
+    config = createRuntimeConfigStub(settingsService);
+  });
+
+  afterEach(() => {
+    if (originalOpenAiKey !== undefined) {
+      process.env.OPENAI_API_KEY = originalOpenAiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('constructs createOpenAI with a non-undefined apiKey for a local Ollama endpoint with no key', async () => {
+    const { generateText } = await import('ai');
+    (generateText as ReturnType<typeof vi.fn>).mockResolvedValue({
+      text: 'ok',
+      toolCalls: [],
+      finishReason: 'stop',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    });
+
+    const provider = new OpenAIVercelProvider(
+      undefined,
+      'http://127.0.0.1:11434/v1/',
+      { settingsService },
+    );
+
+    const options = createProviderCallOptions({
+      config,
+      contents: [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'hi' }],
+        },
+      ],
+      settings: settingsService,
+      resolved: {
+        streaming: false,
+        baseURL: 'http://127.0.0.1:11434/v1/',
+        model: 'llama3',
+        authToken: undefined,
+      },
+      providerName: 'openaivercel',
+    });
+
+    await collectResults(provider.generateChatCompletion(options));
+
+    const { createOpenAI } = await import('@ai-sdk/openai');
+    const mockCreateOpenAI = createOpenAI as ReturnType<typeof vi.fn>;
+    expect(mockCreateOpenAI).toHaveBeenCalledTimes(1);
+    const callArgs = mockCreateOpenAI.mock.calls[0][0] as {
+      apiKey: unknown;
+    };
+    expect(typeof callArgs.apiKey).toBe('string');
+  });
+
+  it('throws AuthenticationError for a remote endpoint with no key (no regression)', async () => {
+    const provider = new OpenAIVercelProvider(undefined, undefined, {
+      settingsService,
+    });
+
+    const options = createProviderCallOptions({
+      config,
+      contents: [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'hi' }],
+        },
+      ],
+      settings: settingsService,
+      resolved: {
+        streaming: false,
+        baseURL: 'https://api.openai.com/v1',
+        model: 'gpt-4o',
+        authToken: undefined,
+      },
+      providerName: 'openaivercel',
+    });
+
+    const { createOpenAI } = await import('@ai-sdk/openai');
+    const mockCreateOpenAI = createOpenAI as ReturnType<typeof vi.fn>;
+
+    await expect(
+      collectResults(provider.generateChatCompletion(options)),
+    ).rejects.toThrow(AuthenticationError);
+
+    expect(mockCreateOpenAI).not.toHaveBeenCalled();
+  });
+
+  it('constructs createOpenAI with a non-undefined apiKey for a remote endpoint when requires-auth is false', async () => {
+    const { generateText } = await import('ai');
+    (generateText as ReturnType<typeof vi.fn>).mockResolvedValue({
+      text: 'ok',
+      toolCalls: [],
+      finishReason: 'stop',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    });
+
+    const provider = new OpenAIVercelProvider(undefined, undefined, {
+      settingsService,
+    });
+
+    const options = createProviderCallOptions({
+      config,
+      contents: [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'hi' }],
+        },
+      ],
+      settings: settingsService,
+      resolved: {
+        streaming: false,
+        baseURL: 'https://api.openai.com/v1',
+        model: 'gpt-4o',
+        authToken: undefined,
+      },
+      providerName: 'openaivercel',
+      settingsOverrides: {
+        provider: { 'requires-auth': false },
+      },
+    });
+
+    await collectResults(provider.generateChatCompletion(options));
+
+    const { createOpenAI } = await import('@ai-sdk/openai');
+    const mockCreateOpenAI = createOpenAI as ReturnType<typeof vi.fn>;
+    expect(mockCreateOpenAI).toHaveBeenCalledTimes(1);
+    const callArgs = mockCreateOpenAI.mock.calls[0][0] as {
+      apiKey: unknown;
+    };
+    expect(typeof callArgs.apiKey).toBe('string');
+  });
+});

--- a/packages/providers/src/openai-vercel/vercelModelClient.localAuth.test.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.localAuth.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Behavioral tests for the openai-vercel local-endpoint auth exemption (issue #2506).
+ *
+ * The @ai-sdk/openai `createOpenAI` factory validates `apiKey` via `loadApiKey`,
+ * which throws `LoadAPIKeyError` for `undefined` but tolerates an empty/placeholder
+ * string. The classic openai provider passes `authToken || ''`; the vercel provider
+ * must behave the same for local endpoints so keyless servers (e.g. Ollama) work.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() => vi.fn((modelId: string) => ({ modelId }))),
+}));
+
+import { createOpenAI } from '@ai-sdk/openai';
+import { createOpenAIClient } from './vercelModelClient.js';
+import { AuthenticationError } from './errors.js';
+import type { ProviderClientConfig } from './vercelModelClient.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+
+function buildOptions(
+  baseURL: string | undefined,
+  authToken: string | undefined,
+): NormalizedGenerateChatOptions {
+  return {
+    settings: {
+      get: () => undefined,
+    } as unknown as NormalizedGenerateChatOptions['settings'],
+    invocation: {} as NormalizedGenerateChatOptions['invocation'],
+    metadata: {},
+    resolved: {
+      model: 'llama3',
+      baseURL,
+      authToken,
+      streaming: false,
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+}
+
+function buildClientConfig(
+  baseURL: string | undefined,
+  overrides?: Partial<ProviderClientConfig>,
+): ProviderClientConfig {
+  return {
+    baseURL,
+    providerName: 'openaivercel',
+    requiresAuth: undefined,
+    customHeaders: undefined,
+    ...overrides,
+  };
+}
+
+async function callClientAndExtractApiKey(
+  baseURL: string | undefined,
+  authToken: string | undefined,
+  clientOverrides?: Partial<ProviderClientConfig>,
+): Promise<unknown> {
+  const mockCreateOpenAI = createOpenAI as ReturnType<typeof vi.fn>;
+  await createOpenAIClient(
+    buildOptions(baseURL, authToken),
+    buildClientConfig(baseURL, clientOverrides),
+  );
+  return (mockCreateOpenAI.mock.calls[0][0] as { apiKey: unknown }).apiKey;
+}
+
+describe('createOpenAIClient local-endpoint auth exemption (issue #2506)', () => {
+  let originalOpenAiKey: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalOpenAiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalOpenAiKey !== undefined) {
+      process.env.OPENAI_API_KEY = originalOpenAiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('passes an empty-string apiKey for a local endpoint when no key is set', async () => {
+    const apiKey = await callClientAndExtractApiKey(
+      'http://127.0.0.1:11434/v1/',
+      undefined,
+    );
+    expect(apiKey).toBe('');
+  });
+
+  it('passes the real auth token when a key is provided for a local endpoint', async () => {
+    const apiKey = await callClientAndExtractApiKey(
+      'http://127.0.0.1:11434/v1/',
+      'real-key',
+    );
+    expect(apiKey).toBe('real-key');
+  });
+
+  it('passes an empty-string apiKey for localhost', async () => {
+    const apiKey = await callClientAndExtractApiKey(
+      'http://localhost:11434/v1/',
+      undefined,
+    );
+    expect(apiKey).toBe('');
+  });
+
+  it('passes an empty-string apiKey for a private IP range', async () => {
+    const apiKey = await callClientAndExtractApiKey(
+      'http://192.168.1.10:11434/v1/',
+      undefined,
+    );
+    expect(apiKey).toBe('');
+  });
+
+  it('passes an empty-string apiKey for an IPv6 loopback endpoint', async () => {
+    const apiKey = await callClientAndExtractApiKey(
+      'http://[::1]:11434/v1/',
+      undefined,
+    );
+    expect(apiKey).toBe('');
+  });
+
+  it('passes an empty-string apiKey when requiresAuth is false even for a remote endpoint', async () => {
+    const apiKey = await callClientAndExtractApiKey(
+      'https://api.openai.com/v1',
+      undefined,
+      { requiresAuth: false },
+    );
+    expect(apiKey).toBe('');
+  });
+
+  it('throws AuthenticationError for a non-local endpoint with no key (no regression)', async () => {
+    const mockCreateOpenAI = createOpenAI as ReturnType<typeof vi.fn>;
+
+    await expect(
+      createOpenAIClient(
+        buildOptions('https://api.openai.com/v1', undefined),
+        buildClientConfig('https://api.openai.com/v1'),
+      ),
+    ).rejects.toThrow(AuthenticationError);
+
+    expect(mockCreateOpenAI).not.toHaveBeenCalled();
+  });
+
+  it('passes the real key through to createOpenAI for a non-local endpoint', async () => {
+    const apiKey = await callClientAndExtractApiKey(
+      'https://api.openai.com/v1',
+      'sk-real',
+    );
+    expect(apiKey).toBe('sk-real');
+  });
+});

--- a/packages/providers/src/openai-vercel/vercelModelClient.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.ts
@@ -192,8 +192,16 @@ export async function createOpenAIClient(
     ? createDeveloperRoleToSystemFetch(customFetch ?? fetch)
     : customFetch;
 
+  // The @ai-sdk/openai factory validates `apiKey` via `loadApiKey`, which throws
+  // `LoadAPIKeyError` for `undefined` before any request is made. The guard above
+  // already throws when auth is required but no token is available, so at this
+  // point either a real token is present or the endpoint is auth-exempt (local /
+  // requiresAuth === false). `authToken` is coalesced to a string above, so
+  // passing it directly mirrors the classic openai provider's `authToken || ''`
+  // behavior and prevents `loadApiKey` from throwing for local servers like
+  // Ollama. See issue #2506.
   return createOpenAI({
-    apiKey: authToken !== '' ? authToken : undefined,
+    apiKey: authToken,
     baseURL: baseURL !== '' ? baseURL : undefined,
     headers: headers && Object.keys(headers).length > 0 ? headers : undefined,
     fetch: fetchWithCompatibility,


### PR DESCRIPTION
## Summary

The `openai-vercel` provider required an API key even for local endpoints (e.g. Ollama at `http://127.0.0.1:11434/v1/`), whereas the classic `openai` provider treats local endpoints as auth-exempt and works with no key. This PR makes the vercel provider match the classic provider's behavior.

## Root cause

The two providers construct the SDK client differently:

- **Classic** (`packages/providers/src/openai/OpenAIClientFactory.ts`): passes `apiKey: authToken || ''`. The OpenAI SDK tolerates an empty string. Combined with the auth-exempt check, local endpoints work with no key.
- **Vercel** (`packages/providers/src/openai-vercel/vercelModelClient.ts`): passed `apiKey: authToken !== '' ? authToken : undefined`. When no key was set, `undefined` was passed through to `@ai-sdk/openai`'s `createOpenAI`, whose `loadApiKey` helper (in `@ai-sdk/provider-utils`) throws `LoadAPIKeyError` for `undefined` **before any request is made** — even though the vercel provider had already computed `authExempt` and would not have enforced auth internally.

## Fix

`authToken` is coalesced to a string (`resolveRuntimeAuthToken(...) ?? ''`) earlier in `createOpenAIClient`, so it is now passed directly to `createOpenAI`:

```ts
return createOpenAI({
  apiKey: authToken,
  ...
});
```

This mirrors the classic provider's `authToken || ''` behavior. The existing guard that throws `AuthenticationError` when auth is required but no token is available is unchanged, so **non-local endpoints still require a key** (no regression to auth enforcement).

## Acceptance criteria

- [x] `openai-vercel` against a local endpoint (localhost / private IP / Ollama) works with no `--key` and no `OPENAI_API_KEY`.
- [x] Non-local endpoints still require a key (no regression to auth enforcement).
- [x] Behavior matches the classic `openai` provider for local endpoints.

## Tests

Added behavioral tests at two levels:

**Unit (`vercelModelClient.localAuth.test.ts`)** — 8 tests exercising `createOpenAIClient` directly:
- Local IPv4 loopback (`127.0.0.1`) with no key → empty-string `apiKey`
- Local endpoint with a real key → real key passed through
- `localhost` with no key → empty-string `apiKey`
- Private IP range (`192.168.1.10`) with no key → empty-string `apiKey`
- IPv6 loopback (`[::1]`) with no key → empty-string `apiKey`
- `requiresAuth: false` with a remote endpoint and no key → empty-string `apiKey`
- Remote endpoint with no key → throws `AuthenticationError`, `createOpenAI` not called
- Remote endpoint with a real key → real key passed through

**End-to-end (`OpenAIVercelProvider.localAuth.test.ts`)** — 3 tests through `OpenAIVercelProvider.generateChatCompletion`:
- Local Ollama endpoint with no key → `createOpenAI` receives a string `apiKey`
- Remote endpoint with no key → throws `AuthenticationError`, `createOpenAI` not called
- Remote endpoint with `requires-auth: false` and no key → `createOpenAI` receives a string `apiKey`

## Verification

- `npm run test --workspace @vybestack/llxprt-code-providers` — 4665 passed, 21 skipped (0 failed)
- `npm run lint --workspace @vybestack/llxprt-code-providers` — clean
- `tsc --noEmit` (providers) — clean
- `npm run build --workspace @vybestack/llxprt-code-providers` — clean
- `prettier --write` on all 3 files — no changes
- Smoke test: `bun scripts/start.ts --profile-load ollamakimi "write me a haiku and nothing else"` — success

Closes #2506