### PR TITLE
Make live-output append and replace semantics explicit (Fixes #2586)

### DIFF
--- a/packages/agents/src/agents/invocation.test.ts
+++ b/packages/agents/src/agents/invocation.test.ts
@@ -181,7 +181,10 @@ describe('SubagentInvocation', () => {
         expect.anything(),
         expect.any(Function),
       );
-      expect(updateOutput).toHaveBeenCalledWith('Subagent starting...\n');
+      expect(updateOutput).toHaveBeenCalledWith({
+        mode: 'append',
+        data: 'Subagent starting...\n',
+      });
 
       expect(mockExecutorInstance.run).toHaveBeenCalledWith(params, signal);
 
@@ -219,9 +222,18 @@ describe('SubagentInvocation', () => {
 
       await invocation.execute(signal, updateOutput);
 
-      expect(updateOutput).toHaveBeenCalledWith('Subagent starting...\n');
-      expect(updateOutput).toHaveBeenCalledWith('🤖💭 Analyzing...');
-      expect(updateOutput).toHaveBeenCalledWith('🤖💭  Still thinking.');
+      expect(updateOutput).toHaveBeenCalledWith({
+        mode: 'append',
+        data: 'Subagent starting...\n',
+      });
+      expect(updateOutput).toHaveBeenCalledWith({
+        mode: 'append',
+        data: '🤖💭 Analyzing...',
+      });
+      expect(updateOutput).toHaveBeenCalledWith({
+        mode: 'append',
+        data: '🤖💭  Still thinking.',
+      });
       expect(updateOutput).toHaveBeenCalledTimes(3); // Initial message + 2 thoughts
     });
 
@@ -250,7 +262,10 @@ describe('SubagentInvocation', () => {
 
       // Should only contain the initial "Subagent starting..." message
       expect(updateOutput).toHaveBeenCalledTimes(1);
-      expect(updateOutput).toHaveBeenCalledWith('Subagent starting...\n');
+      expect(updateOutput).toHaveBeenCalledWith({
+        mode: 'append',
+        data: 'Subagent starting...\n',
+      });
     });
 
     it('should run successfully without an updateOutput callback', async () => {

--- a/packages/agents/src/agents/invocation.ts
+++ b/packages/agents/src/agents/invocation.ts
@@ -9,6 +9,7 @@ import { AgentExecutor } from './executor.js';
 import {
   BaseToolInvocation,
   type ToolResult,
+  type LiveOutputUpdate,
 } from '@vybestack/llxprt-code-tools';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
 import type {
@@ -85,11 +86,11 @@ export class SubagentInvocation<
    */
   async execute(
     signal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     try {
       if (updateOutput) {
-        updateOutput('Subagent starting...\n');
+        updateOutput({ mode: 'append', data: 'Subagent starting...\n' });
       }
 
       // Create an activity callback to bridge the executor's events to the
@@ -101,7 +102,10 @@ export class SubagentInvocation<
           activity.type === 'THOUGHT_CHUNK' &&
           typeof activity.data['text'] === 'string'
         ) {
-          updateOutput(`🤖💭 ${activity.data['text']}`);
+          updateOutput({
+            mode: 'append',
+            data: `🤖💭 ${activity.data['text']}`,
+          });
         }
       };
 

--- a/packages/agents/src/api/control/toolControl.ts
+++ b/packages/agents/src/api/control/toolControl.ts
@@ -367,24 +367,33 @@ function wrapInvocation(invocation: AnyToolInvocation): AgentToolInvocation {
     getDescription: () => invocation.getDescription(),
     execute: async (signal, updateOutput) => {
       // The public AgentToolInvocation.execute contract accepts only string
-      // chunks, but the real ToolInvocation.execute delivers string |
-      // AnsiOutput. When the caller supplies an updateOutput callback, forward
-      // string chunks directly and losslessly flatten AnsiOutput (an
-      // AnsiToken[][]) to its plain text so rich terminal output is preserved
-      // rather than silently dropped — honoring the public (string-only)
-      // contract without a cast.
+      // chunks, but the real ToolInvocation.execute delivers a tagged
+      // LiveOutputUpdate. When the caller supplies an updateOutput callback,
+      // forward append deltas directly and losslessly flatten replace
+      // AnsiOutput (an AnsiToken[][]) to its plain text so rich terminal
+      // output is preserved rather than silently dropped — honoring the
+      // public (string-only) contract without a cast.
       const result: ToolResult = await invocation.execute(
         signal,
         updateOutput !== undefined
-          ? (chunk) => {
-              if (typeof chunk === 'string') {
-                updateOutput(chunk);
-              } else {
-                updateOutput(
-                  chunk
-                    .map((line) => line.map((token) => token.text).join(''))
-                    .join('\n'),
-                );
+          ? (update) => {
+              switch (update.mode) {
+                case 'append':
+                  updateOutput(update.data);
+                  break;
+                case 'replace':
+                  updateOutput(
+                    update.data
+                      .map((line) => line.map((token) => token.text).join(''))
+                      .join('\n'),
+                  );
+                  break;
+                default: {
+                  const _exhaustive: never = update;
+                  throw new Error(
+                    `Unhandled live-output mode: ${JSON.stringify(_exhaustive)}`,
+                  );
+                }
               }
             }
           : undefined,

--- a/packages/agents/src/core/agenticLoop/AgenticLoop.ts
+++ b/packages/agents/src/core/agenticLoop/AgenticLoop.ts
@@ -658,14 +658,14 @@ export class AgenticLoop {
     return this.config.getOrCreateScheduler(
       sessionId,
       {
-        outputUpdateHandler: (callId, chunk) => {
+        outputUpdateHandler: (callId, update) => {
           if (!forwardingState.active) {
             return;
           }
-          if (typeof chunk === 'string') {
-            queue.push({ kind: 'tool_output', callId, chunk });
+          if (update.mode === 'append') {
+            queue.push({ kind: 'tool_output', callId, chunk: update.data });
           }
-          display?.outputUpdateHandler?.(callId, chunk);
+          display?.outputUpdateHandler?.(callId, update);
         },
         onToolCallsUpdate: (toolCalls) => {
           if (!forwardingState.active) {

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.cancellation.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.cancellation.test.ts
@@ -12,6 +12,7 @@ import { clearAllSchedulers } from '@vybestack/llxprt-code-core/config/scheduler
 import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
 import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools/types/tool-confirmation-types.js';
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-core';
 import {
   type ApprovalHandler,
   createScriptedAgentClient,
@@ -337,8 +338,12 @@ describe('AgenticLoop integration - Cancellation via AbortSignal', () => {
       canUpdateOutput: true,
     });
     tool.executeFn.mockImplementation(
-      async (_params, _signal, updateOutput?: (chunk: string) => void) => {
-        updateOutput?.('streaming-chunk');
+      async (
+        _params,
+        _signal,
+        updateOutput?: (update: LiveOutputUpdate) => void,
+      ) => {
+        updateOutput?.({ mode: 'append', data: 'streaming-chunk' });
         return {
           llmContent: 'final-output',
           returnDisplay: 'final-output',

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.display-callbacks.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.display-callbacks.test.ts
@@ -17,6 +17,7 @@ import type {
   CompletedToolCall,
   ToolCall,
 } from '@vybestack/llxprt-code-core/scheduler/types.js';
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-core';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { ServerAgentStreamEvent } from '@vybestack/llxprt-code-core/core/turn.js';
 import {
@@ -53,10 +54,10 @@ describe('AgenticLoop with caller display callbacks', () => {
       async (
         _params: Record<string, unknown>,
         _signal: AbortSignal,
-        updateOutput?: (output: string) => void,
+        updateOutput?: (update: LiveOutputUpdate) => void,
       ) => {
-        updateOutput?.('chunk-1');
-        updateOutput?.('chunk-2');
+        updateOutput?.({ mode: 'append', data: 'chunk-1' });
+        updateOutput?.({ mode: 'append', data: 'chunk-2' });
         return { llmContent: 'done', returnDisplay: 'done' };
       },
     );
@@ -74,7 +75,7 @@ describe('AgenticLoop with caller display callbacks', () => {
     const displayToolUpdates: ToolCall[] = [];
     const displayOutputChunks: Array<{
       callId: string;
-      chunk: string | unknown;
+      chunk: LiveOutputUpdate;
     }> = [];
 
     const { client } = createScriptedAgentClient([
@@ -141,7 +142,7 @@ describe('AgenticLoop with caller display callbacks', () => {
     }));
     const dispStringChunks = displayOutputChunks.map((c) => ({
       callId: c.callId,
-      chunk: c.chunk,
+      chunk: c.chunk.data,
     }));
     expect(dispStringChunks).toStrictEqual(emittedOutputData);
     expect(dispStringChunks.every((c) => c.callId === 'call-disp')).toBe(true);
@@ -497,11 +498,11 @@ describe('AgenticLoop with caller display callbacks', () => {
       async (
         _params: Record<string, unknown>,
         _signal: AbortSignal,
-        updateOutput?: (output: string) => void,
+        updateOutput?: (update: LiveOutputUpdate) => void,
       ) => {
-        updateOutput?.('Hello ');
-        updateOutput?.('world');
-        updateOutput?.('!');
+        updateOutput?.({ mode: 'append', data: 'Hello ' });
+        updateOutput?.({ mode: 'append', data: 'world' });
+        updateOutput?.({ mode: 'append', data: '!' });
         return { llmContent: 'done', returnDisplay: 'done' };
       },
     );

--- a/packages/agents/src/core/agenticLoop/types.ts
+++ b/packages/agents/src/core/agenticLoop/types.ts
@@ -86,7 +86,7 @@ export type ApprovalHandler = (
 export interface DisplayCallbacks {
   /** Forwarded after the loop records its own tool_update/awaiting_approval events. */
   onToolCallsUpdate?: ToolCallsUpdateHandler;
-  /** Forwarded after the loop records its own tool_output event (string chunks only). */
+  /** Forwarded after the loop records its own tool_output event (the loop routes only `append` updates into the tool_output queue, but the handler receives the full {@link LiveOutputUpdate}). */
   outputUpdateHandler?: OutputUpdateHandler;
   /**
    * Forwarded once per turn with the same rich CompletedToolCall[] batch the

--- a/packages/agents/src/core/agenticLoop/types.ts
+++ b/packages/agents/src/core/agenticLoop/types.ts
@@ -86,7 +86,13 @@ export type ApprovalHandler = (
 export interface DisplayCallbacks {
   /** Forwarded after the loop records its own tool_update/awaiting_approval events. */
   onToolCallsUpdate?: ToolCallsUpdateHandler;
-  /** Forwarded after the loop records its own tool_output event (the loop routes only `append` updates into the tool_output queue, but the handler receives the full {@link LiveOutputUpdate}). */
+  /**
+   * Forwarded to the display after the scheduler accumulates the update.
+   * The loop queues only `append` updates as `tool_output` events before
+   * forwarding; `replace` updates are forwarded directly without a queued
+   * event. In both cases the handler receives the full
+   * {@link LiveOutputUpdate}.
+   */
   outputUpdateHandler?: OutputUpdateHandler;
   /**
    * Forwarded once per turn with the same rich CompletedToolCall[] batch the

--- a/packages/agents/src/core/coreToolScheduler.ts
+++ b/packages/agents/src/core/coreToolScheduler.ts
@@ -25,7 +25,7 @@ import { DEFAULT_AGENT_ID } from '@vybestack/llxprt-code-core/core/turn.js';
 import { createErrorResponse } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { buildToolGovernance, canonicalizeToolName } from './toolGovernance.js';
-import type { AnsiOutput } from '@vybestack/llxprt-code-core/utils/terminalSerializer.js';
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-core/utils/terminalSerializer.js';
 import { triggerToolNotificationHook } from '@vybestack/llxprt-code-core/core/coreToolHookTriggers.js';
 import { ToolExecutor } from '../scheduler/tool-executor.js';
 import { ToolDispatcher } from '../scheduler/tool-dispatcher.js';
@@ -596,10 +596,10 @@ export class CoreToolScheduler implements ToolSchedulerContract {
         call: scheduledCall,
         signal,
         onLiveOutput: scheduledCall.tool.canUpdateOutput
-          ? (id: string, chunk: string | AnsiOutput) => {
+          ? (id: string, update: LiveOutputUpdate) => {
               if (this.outputUpdateHandler) {
                 try {
-                  this.outputUpdateHandler(id, chunk);
+                  this.outputUpdateHandler(id, update);
                 } catch (error) {
                   toolSchedulerLogger.debug(
                     () =>
@@ -611,7 +611,7 @@ export class CoreToolScheduler implements ToolSchedulerContract {
                 tc.request.callId === id && tc.status === 'executing'
                   ? {
                       ...tc,
-                      liveOutput: accumulateLiveOutput(tc.liveOutput, chunk),
+                      liveOutput: accumulateLiveOutput(tc.liveOutput, update),
                     }
                   : tc,
               );

--- a/packages/agents/src/core/subagentExecution.test.ts
+++ b/packages/agents/src/core/subagentExecution.test.ts
@@ -312,53 +312,40 @@ describe('subagentExecution', () => {
       };
     }
 
-    it('should forward string output to onMessage', () => {
+    it('should forward append output data to onMessage', () => {
       const onMessage = vi.fn();
       const channel = createCompletionChannel({ onMessage });
-      channel.outputUpdateHandler('call-1', 'hello world');
+      channel.outputUpdateHandler('call-1', {
+        mode: 'append',
+        data: 'hello world',
+      });
       expect(onMessage).toHaveBeenCalledWith('hello world');
     });
 
-    it('should convert well-formed AnsiOutput to text', () => {
+    it('should convert well-formed replace AnsiOutput to text', () => {
       const onMessage = vi.fn();
       const channel = createCompletionChannel({ onMessage });
       const ansiOutput = [
         [makeToken('line one')],
         [makeToken('line '), makeToken('two')],
       ];
-      channel.outputUpdateHandler('call-1', ansiOutput);
+      channel.outputUpdateHandler('call-1', {
+        mode: 'replace',
+        data: ansiOutput,
+      });
       const result = onMessage.mock.calls[0][0] as string;
       expect(result).toContain('line one');
       expect(result).toContain('line two');
       expect(result.split(String.fromCharCode(10))).toHaveLength(2);
     });
 
-    it('should skip undefined line entries in AnsiOutput without crashing', () => {
-      const onMessage = vi.fn();
-      const channel = createCompletionChannel({ onMessage });
-      const ansiOutput = [
-        [makeToken('valid')],
-        undefined as never,
-        null as never,
-        { content: 'bad' } as never,
-        [makeToken('also valid')],
-      ];
-      channel.outputUpdateHandler('call-1', ansiOutput);
-      const result = onMessage.mock.calls[0][0] as string;
-      expect(result).toBe('valid\nalso valid');
-    });
-
-    it('should not call onMessage when output is falsy', () => {
-      const onMessage = vi.fn();
-      const channel = createCompletionChannel({ onMessage });
-      channel.outputUpdateHandler('call-1', undefined as never);
-      expect(onMessage).not.toHaveBeenCalled();
-    });
-
-    it('should not throw when onMessage is not provided', () => {
+    it('should not call onMessage when onMessage is not provided', () => {
       const channel = createCompletionChannel({});
       expect(() =>
-        channel.outputUpdateHandler('call-1', 'some output'),
+        channel.outputUpdateHandler('call-1', {
+          mode: 'append',
+          data: 'some output',
+        }),
       ).not.toThrow();
     });
 

--- a/packages/agents/src/core/subagentExecution.test.ts
+++ b/packages/agents/src/core/subagentExecution.test.ts
@@ -19,7 +19,10 @@ import {
   type OutputObject,
 } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
-import type { AnsiToken } from '@vybestack/llxprt-code-core/utils/terminalSerializer.js';
+import type {
+  AnsiOutput,
+  AnsiToken,
+} from '@vybestack/llxprt-code-core/utils/terminalSerializer.js';
 
 function makeOutput(): OutputObject {
   return { emitted_vars: {}, terminate_reason: SubagentTerminateMode.ERROR };
@@ -325,7 +328,7 @@ describe('subagentExecution', () => {
     it('should convert well-formed replace AnsiOutput to text', () => {
       const onMessage = vi.fn();
       const channel = createCompletionChannel({ onMessage });
-      const ansiOutput = [
+      const ansiOutput: AnsiOutput = [
         [makeToken('line one')],
         [makeToken('line '), makeToken('two')],
       ];
@@ -347,6 +350,20 @@ describe('subagentExecution', () => {
           data: 'some output',
         }),
       ).not.toThrow();
+    });
+
+    it('should throw on malformed replace payload (null line)', () => {
+      const onMessage = vi.fn();
+      const channel = createCompletionChannel({ onMessage });
+      // Malformed AnsiOutput: a null line entry. The replace branch accesses
+      // token.text without a null guard, so this throws at runtime — proving
+      // the type system contract (well-formed AnsiOutput) is enforced.
+      expect(() =>
+        channel.outputUpdateHandler('call-1', {
+          mode: 'replace',
+          data: [null] as unknown as AnsiOutput,
+        }),
+      ).toThrow(TypeError);
     });
 
     it('should reject awaitCompletedCalls when the abort signal fires first', async () => {

--- a/packages/agents/src/core/subagentExecution.test.ts
+++ b/packages/agents/src/core/subagentExecution.test.ts
@@ -352,18 +352,6 @@ describe('subagentExecution', () => {
       ).not.toThrow();
     });
 
-    it('should not invoke onMessage when onMessage is not provided', () => {
-      const channel = createCompletionChannel({});
-      channel.outputUpdateHandler('call-1', {
-        mode: 'append',
-        data: 'some output',
-      });
-      // No onMessage callback was supplied, so nothing to assert against
-      // beyond not throwing; the guard `if (ctx.onMessage == null) return`
-      // ensures the append path is skipped entirely.
-      expect(true).toBe(true);
-    });
-
     it('should throw on malformed replace payload (null line)', () => {
       const onMessage = vi.fn();
       const channel = createCompletionChannel({ onMessage });

--- a/packages/agents/src/core/subagentExecution.test.ts
+++ b/packages/agents/src/core/subagentExecution.test.ts
@@ -342,7 +342,7 @@ describe('subagentExecution', () => {
       expect(result.split(String.fromCharCode(10))).toHaveLength(2);
     });
 
-    it('should not call onMessage when onMessage is not provided', () => {
+    it('should not throw when onMessage is not provided', () => {
       const channel = createCompletionChannel({});
       expect(() =>
         channel.outputUpdateHandler('call-1', {
@@ -350,6 +350,18 @@ describe('subagentExecution', () => {
           data: 'some output',
         }),
       ).not.toThrow();
+    });
+
+    it('should not invoke onMessage when onMessage is not provided', () => {
+      const channel = createCompletionChannel({});
+      channel.outputUpdateHandler('call-1', {
+        mode: 'append',
+        data: 'some output',
+      });
+      // No onMessage callback was supplied, so nothing to assert against
+      // beyond not throwing; the guard `if (ctx.onMessage == null) return`
+      // ensures the append path is skipped entirely.
+      expect(true).toBe(true);
     });
 
     it('should throw on malformed replace payload (null line)', () => {
@@ -364,6 +376,19 @@ describe('subagentExecution', () => {
           data: [null] as unknown as AnsiOutput,
         }),
       ).toThrow(TypeError);
+    });
+
+    it('should throw on unexpected mode values (exhaustive switch)', () => {
+      const onMessage = vi.fn();
+      const channel = createCompletionChannel({ onMessage });
+      // The switch on update.mode is exhaustive with a never default that
+      // throws. A malformed mode value must throw rather than silently pass.
+      expect(() =>
+        channel.outputUpdateHandler('call-1', {
+          mode: 'invalid',
+          data: '',
+        } as unknown as never),
+      ).toThrow('Unhandled live-output mode');
     });
 
     it('should reject awaitCompletedCalls when the abort signal fires first', async () => {

--- a/packages/agents/src/core/subagentExecution.ts
+++ b/packages/agents/src/core/subagentExecution.ts
@@ -41,7 +41,6 @@ import {
   type RunConfig,
 } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
-import type { AnsiLine } from '@vybestack/llxprt-code-core/utils/terminalSerializer.js';
 import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { isToolNameRestricted } from './hookToolRestrictions.js';
 
@@ -437,16 +436,25 @@ export function createCompletionChannel(
     return completionPromise;
   };
 
-  const outputUpdateHandler: OutputUpdateHandler = (_toolCallId, output) => {
-    if ((output as unknown) != null && ctx.onMessage != null) {
-      const textOutput =
-        typeof output === 'string'
-          ? output
-          : output
-              .filter((line): line is AnsiLine => Array.isArray(line))
-              .map((line) => line.map((token) => token.text).join(''))
-              .join('\n');
-      ctx.onMessage(textOutput);
+  const outputUpdateHandler: OutputUpdateHandler = (_toolCallId, update) => {
+    if (ctx.onMessage == null) return;
+    switch (update.mode) {
+      case 'append':
+        ctx.onMessage(update.data);
+        break;
+      case 'replace': {
+        const textOutput = update.data
+          .map((line) => line.map((token) => token.text).join(''))
+          .join('\n');
+        ctx.onMessage(textOutput);
+        break;
+      }
+      default: {
+        const _exhaustive: never = update;
+        throw new Error(
+          `Unhandled live-output mode: ${JSON.stringify(_exhaustive)}`,
+        );
+      }
     }
   };
 

--- a/packages/agents/src/scheduler/tool-executor.ts
+++ b/packages/agents/src/scheduler/tool-executor.ts
@@ -22,7 +22,7 @@ import {
   triggerBeforeToolHook,
   triggerAfterToolHook,
 } from '@vybestack/llxprt-code-core/core/coreToolHookTriggers.js';
-import type { AnsiOutput } from '@vybestack/llxprt-code-core/utils/terminalSerializer.js';
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-core/utils/terminalSerializer.js';
 import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
 
 /**
@@ -31,7 +31,7 @@ import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
 export interface ToolExecutionContext {
   call: ScheduledToolCall;
   signal: AbortSignal;
-  onLiveOutput?: (callId: string, chunk: string | AnsiOutput) => void;
+  onLiveOutput?: (callId: string, update: LiveOutputUpdate) => void;
   onPid?: (callId: string, pid: number) => void;
 }
 
@@ -164,8 +164,8 @@ export class ToolExecutor {
     }
 
     const liveOutputCallback = scheduledCall.tool.canUpdateOutput
-      ? (outputChunk: string | AnsiOutput) => {
-          onLiveOutput?.(callId, outputChunk);
+      ? (update: LiveOutputUpdate) => {
+          onLiveOutput?.(callId, update);
         }
       : undefined;
     const setPidCallback = (pid: number) => {

--- a/packages/agents/src/tools/task.issues.test.ts
+++ b/packages/agents/src/tools/task.issues.test.ts
@@ -76,19 +76,26 @@ describe('TaskTool', () => {
       await invocation.execute(new AbortController().signal, updateOutput);
 
       // Verify opening tag is sent first
-      expect(updateOutput).toHaveBeenNthCalledWith(
-        1,
-        '<subagent name="test-agent" id="agent-xml-001">\n',
-      );
+      expect(updateOutput).toHaveBeenNthCalledWith(1, {
+        mode: 'append',
+        data: '<subagent name="test-agent" id="agent-xml-001">\n',
+      });
 
       // Verify messages are sent without [agentId] prefix
-      expect(updateOutput).toHaveBeenNthCalledWith(2, 'First message');
-      expect(updateOutput).toHaveBeenNthCalledWith(3, 'Second message');
+      expect(updateOutput).toHaveBeenNthCalledWith(2, {
+        mode: 'append',
+        data: 'First message',
+      });
+      expect(updateOutput).toHaveBeenNthCalledWith(3, {
+        mode: 'append',
+        data: 'Second message',
+      });
 
       // Verify closing tag is sent last
-      expect(updateOutput).toHaveBeenLastCalledWith(
-        '</subagent name="test-agent" id="agent-xml-001">\n',
-      );
+      expect(updateOutput).toHaveBeenLastCalledWith({
+        mode: 'append',
+        data: '</subagent name="test-agent" id="agent-xml-001">\n',
+      });
     });
 
     it('should wrap interactive output with XML tags', async () => {
@@ -136,14 +143,18 @@ describe('TaskTool', () => {
 
       await invocation.execute(new AbortController().signal, updateOutput);
 
-      expect(updateOutput).toHaveBeenNthCalledWith(
-        1,
-        '<subagent name="interactive-agent" id="agent-xml-002">\n',
-      );
-      expect(updateOutput).toHaveBeenNthCalledWith(2, 'Interactive message');
-      expect(updateOutput).toHaveBeenLastCalledWith(
-        '</subagent name="interactive-agent" id="agent-xml-002">\n',
-      );
+      expect(updateOutput).toHaveBeenNthCalledWith(1, {
+        mode: 'append',
+        data: '<subagent name="interactive-agent" id="agent-xml-002">\n',
+      });
+      expect(updateOutput).toHaveBeenNthCalledWith(2, {
+        mode: 'append',
+        data: 'Interactive message',
+      });
+      expect(updateOutput).toHaveBeenLastCalledWith({
+        mode: 'append',
+        data: '</subagent name="interactive-agent" id="agent-xml-002">\n',
+      });
     });
 
     it('should send closing XML tag even when subagent errors', async () => {
@@ -180,14 +191,15 @@ describe('TaskTool', () => {
       await invocation.execute(new AbortController().signal, updateOutput);
 
       // Should still send opening tag
-      expect(updateOutput).toHaveBeenNthCalledWith(
-        1,
-        '<subagent name="error-agent" id="agent-xml-err">\n',
-      );
+      expect(updateOutput).toHaveBeenNthCalledWith(1, {
+        mode: 'append',
+        data: '<subagent name="error-agent" id="agent-xml-err">\n',
+      });
       // And closing tag despite error
-      expect(updateOutput).toHaveBeenLastCalledWith(
-        '</subagent name="error-agent" id="agent-xml-err">\n',
-      );
+      expect(updateOutput).toHaveBeenLastCalledWith({
+        mode: 'append',
+        data: '</subagent name="error-agent" id="agent-xml-err">\n',
+      });
     });
 
     it('should send XML tags even when subagent produces no output', async () => {
@@ -225,14 +237,14 @@ describe('TaskTool', () => {
 
       // Should still send opening and closing tags
       expect(updateOutput).toHaveBeenCalledTimes(2);
-      expect(updateOutput).toHaveBeenNthCalledWith(
-        1,
-        '<subagent name="silent-agent" id="agent-xml-empty">\n',
-      );
-      expect(updateOutput).toHaveBeenNthCalledWith(
-        2,
-        '</subagent name="silent-agent" id="agent-xml-empty">\n',
-      );
+      expect(updateOutput).toHaveBeenNthCalledWith(1, {
+        mode: 'append',
+        data: '<subagent name="silent-agent" id="agent-xml-empty">\n',
+      });
+      expect(updateOutput).toHaveBeenNthCalledWith(2, {
+        mode: 'append',
+        data: '</subagent name="silent-agent" id="agent-xml-empty">\n',
+      });
     });
 
     it('should send opening and closing XML tags for async tasks', async () => {
@@ -280,16 +292,17 @@ describe('TaskTool', () => {
       await invocation.execute(new AbortController().signal, updateOutput);
 
       // Async tasks should send opening tag immediately
-      expect(updateOutput).toHaveBeenNthCalledWith(
-        1,
-        '<subagent name="async-helper" id="async-xml-agent">\n',
-      );
+      expect(updateOutput).toHaveBeenNthCalledWith(1, {
+        mode: 'append',
+        data: '<subagent name="async-helper" id="async-xml-agent">\n',
+      });
 
       // Wait for background execution to complete and emit closing tag
       await backgroundExecutionPromise;
-      expect(updateOutput).toHaveBeenLastCalledWith(
-        '</subagent name="async-helper" id="async-xml-agent">\n',
-      );
+      expect(updateOutput).toHaveBeenLastCalledWith({
+        mode: 'append',
+        data: '</subagent name="async-helper" id="async-xml-agent">\n',
+      });
     });
   });
 
@@ -352,7 +365,9 @@ describe('TaskTool', () => {
 
       await invocation.execute(new AbortController().signal, updateOutput);
 
-      const calls = updateOutput.mock.calls.map((c) => c[0] as string);
+      const calls = updateOutput.mock.calls.map(
+        (c) => (c[0] as { data: string }).data,
+      );
       // Slice off opening tag (first) and closing tag (last)
       const textChunks = calls.slice(1, -1);
       const accumulated = textChunks.join('');
@@ -411,7 +426,9 @@ describe('TaskTool', () => {
 
       await invocation.execute(new AbortController().signal, updateOutput);
 
-      const calls = updateOutput.mock.calls.map((c) => c[0] as string);
+      const calls = updateOutput.mock.calls.map(
+        (c) => (c[0] as { data: string }).data,
+      );
       const textChunks = calls.slice(1, -1);
       const accumulated = textChunks.join('');
 

--- a/packages/agents/src/tools/task.issues.test.ts
+++ b/packages/agents/src/tools/task.issues.test.ts
@@ -18,6 +18,7 @@ import {
   SubagentTerminateMode,
 } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-core/utils/terminalSerializer.js';
 
 describe('TaskTool', () => {
   let config: Config;
@@ -366,7 +367,7 @@ describe('TaskTool', () => {
       await invocation.execute(new AbortController().signal, updateOutput);
 
       const calls = updateOutput.mock.calls.map(
-        (c) => (c[0] as { data: string }).data,
+        (c) => (c[0] as LiveOutputUpdate).data as string,
       );
       // Slice off opening tag (first) and closing tag (last)
       const textChunks = calls.slice(1, -1);
@@ -427,7 +428,7 @@ describe('TaskTool', () => {
       await invocation.execute(new AbortController().signal, updateOutput);
 
       const calls = updateOutput.mock.calls.map(
-        (c) => (c[0] as { data: string }).data,
+        (c) => (c[0] as LiveOutputUpdate).data as string,
       );
       const textChunks = calls.slice(1, -1);
       const accumulated = textChunks.join('');

--- a/packages/agents/src/tools/task.max-turns.test.ts
+++ b/packages/agents/src/tools/task.max-turns.test.ts
@@ -71,7 +71,9 @@ describe('TaskTool', () => {
 
     await invocation.execute(new AbortController().signal, updateOutput);
 
-    return updateOutput.mock.calls.map((c) => c[0] as string).slice(1, -1);
+    return updateOutput.mock.calls
+      .map((c) => (c[0] as { data: string }).data)
+      .slice(1, -1);
   }
 
   describe('max_turns handling', () => {
@@ -397,7 +399,9 @@ describe('TaskTool', () => {
 
     await invocation.execute(new AbortController().signal, updateOutput);
 
-    const calls = updateOutput.mock.calls.map((c) => c[0] as string);
+    const calls = updateOutput.mock.calls.map(
+      (c) => (c[0] as { data: string }).data,
+    );
     expect(calls[0]).toBe('<subagent name="helper" id="agent-42">\n');
     expect(calls[calls.length - 1]).toBe(
       '</subagent name="helper" id="agent-42">\n',

--- a/packages/agents/src/tools/task.test.ts
+++ b/packages/agents/src/tools/task.test.ts
@@ -127,15 +127,18 @@ describe('TaskTool', () => {
     expect(scope.runInteractive).toHaveBeenCalledTimes(1);
     expect(scope.runNonInteractive).not.toHaveBeenCalled();
     // Verify XML wrapping: opening tag, message without prefix, closing tag
-    expect(updateOutput).toHaveBeenNthCalledWith(
-      1,
-      '<subagent name="helper" id="agent-42">\n',
-    );
-    expect(updateOutput).toHaveBeenNthCalledWith(2, 'progress update');
-    expect(updateOutput).toHaveBeenNthCalledWith(
-      3,
-      '</subagent name="helper" id="agent-42">\n',
-    );
+    expect(updateOutput).toHaveBeenNthCalledWith(1, {
+      mode: 'append',
+      data: '<subagent name="helper" id="agent-42">\n',
+    });
+    expect(updateOutput).toHaveBeenNthCalledWith(2, {
+      mode: 'append',
+      data: 'progress update',
+    });
+    expect(updateOutput).toHaveBeenNthCalledWith(3, {
+      mode: 'append',
+      data: '</subagent name="helper" id="agent-42">\n',
+    });
     expect(dispose).toHaveBeenCalledTimes(1);
     expect(result.metadata).toStrictEqual({
       agentId: 'agent-42',

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -9,6 +9,7 @@ import {
   BaseToolInvocation,
   Kind,
   type ToolResult,
+  type LiveOutputUpdate,
 } from '@vybestack/llxprt-code-tools';
 import { createStreamNormalizer } from '@vybestack/llxprt-code-tools/utils/textDelta.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
@@ -246,7 +247,7 @@ class TaskToolInvocation extends BaseToolInvocation<
 
   override async execute(
     signal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     if (this.normalized.async) {
       return this.executeAsync(signal, updateOutput);
@@ -316,7 +317,7 @@ class TaskToolInvocation extends BaseToolInvocation<
     timeoutSeconds: number | undefined,
     onUserAbort: () => void,
     timeoutId: ReturnType<typeof setTimeout> | null,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     const abortState = this.createAbortState(launchRequest, signal);
 
@@ -461,7 +462,7 @@ class TaskToolInvocation extends BaseToolInvocation<
         result: Awaited<ReturnType<SubagentOrchestrator['launch']>>,
       ) => void;
     },
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     const { scope, agentId, dispose } = launchResult;
     taskLogger.debug(
@@ -547,33 +548,36 @@ class TaskToolInvocation extends BaseToolInvocation<
     launchResult: Awaited<ReturnType<SubagentOrchestrator['launch']>>,
     agentId: string,
     scope: SubAgentScope,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): { emitClosingSubagentTag: () => void } {
     const subagentName =
       launchRequestName(launchResult) || this.normalized.subagentName;
     let xmlOutputOpen = false;
     const normalizer = createStreamNormalizer();
+    const emitAppend = (data: string): void => {
+      updateOutput?.({ mode: 'append', data });
+    };
     const emitClosingSubagentTag = () => {
       if (!xmlOutputOpen || !updateOutput) {
         return;
       }
       const flushed = normalizer.flush();
       if (flushed !== undefined) {
-        updateOutput(flushed);
+        emitAppend(flushed);
       }
-      updateOutput(`</subagent name="${subagentName}" id="${agentId}">\n`);
+      emitAppend(`</subagent name="${subagentName}" id="${agentId}">\n`);
       xmlOutputOpen = false;
     };
 
     if (updateOutput) {
-      updateOutput(`<subagent name="${subagentName}" id="${agentId}">\n`);
+      emitAppend(`<subagent name="${subagentName}" id="${agentId}">\n`);
       xmlOutputOpen = true;
 
       const existingHandler = scope.onMessage;
       scope.onMessage = (message: string) => {
         const delta = normalizer.push(message);
         if (delta !== undefined) {
-          updateOutput(delta);
+          emitAppend(delta);
         }
         existingHandler?.(message);
       };
@@ -703,7 +707,7 @@ class TaskToolInvocation extends BaseToolInvocation<
   }
   private async executeAsync(
     signal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     return executeAsyncTask(
       {

--- a/packages/agents/src/tools/taskAsyncExecution.ts
+++ b/packages/agents/src/tools/taskAsyncExecution.ts
@@ -15,7 +15,10 @@ import type { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyn
 import type { SubagentSchedulerFactory } from '../core/subagentScheduler.js';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
 import { createStreamNormalizer } from '@vybestack/llxprt-code-tools/utils/textDelta.js';
-import { type ToolResult } from '@vybestack/llxprt-code-tools';
+import {
+  type ToolResult,
+  type LiveOutputUpdate,
+} from '@vybestack/llxprt-code-tools';
 import { type TaskToolInvocationParams } from './taskToolGovernance.js';
 import {
   handleBackgroundAbort,
@@ -290,32 +293,35 @@ export function setupAsyncStreaming(
   subagentName: string,
   scope: SubAgentScope,
   agentId: string,
-  updateOutput?: (output: string) => void,
+  updateOutput?: (update: LiveOutputUpdate) => void,
 ): { emitAsyncClosingSubagentTag: () => void } | undefined {
   if (!updateOutput) return undefined;
 
   const normalizer = createStreamNormalizer();
   let asyncXmlOutputOpen = false;
+  const emitAppend = (data: string): void => {
+    updateOutput({ mode: 'append', data });
+  };
   const emitAsyncClosingSubagentTag = () => {
     if (!asyncXmlOutputOpen) {
       return;
     }
     const flushed = normalizer.flush();
     if (flushed !== undefined) {
-      updateOutput(flushed);
+      emitAppend(flushed);
     }
-    updateOutput(`</subagent name="${subagentName}" id="${agentId}">\n`);
+    emitAppend(`</subagent name="${subagentName}" id="${agentId}">\n`);
     asyncXmlOutputOpen = false;
   };
 
-  updateOutput(`<subagent name="${subagentName}" id="${agentId}">\n`);
+  emitAppend(`<subagent name="${subagentName}" id="${agentId}">\n`);
   asyncXmlOutputOpen = true;
 
   const existingHandler = scope.onMessage;
   scope.onMessage = (message: string) => {
     const delta = normalizer.push(message);
     if (delta !== undefined) {
-      updateOutput(delta);
+      emitAppend(delta);
     }
     existingHandler?.(message);
   };
@@ -404,7 +410,7 @@ export function executeInBackground(
 export async function executeAsyncTask(
   collaborators: AsyncTaskCollaborators,
   signal: AbortSignal,
-  updateOutput?: (output: string) => void,
+  updateOutput?: (update: LiveOutputUpdate) => void,
 ): Promise<ToolResult> {
   const ctx = resolveAsyncContext(collaborators);
   if (!('asyncTaskManager' in ctx)) {

--- a/packages/agents/src/tools/taskAsyncStreaming.test.ts
+++ b/packages/agents/src/tools/taskAsyncStreaming.test.ts
@@ -137,14 +137,17 @@ function createAsyncStreamingHarness(
 }
 
 /** Asserts the exact XML wrapper tags then returns the interior deltas only. */
-function extractMessageDeltas(outputs: string[]): string[] {
-  const [opening] = outputs;
+function extractMessageDeltas(
+  outputs: Array<{ mode: 'append'; data: string }>,
+): string[] {
+  const all = outputs.map((u) => u.data);
+  const [opening] = all;
   expect(opening.startsWith('<subagent name="')).toBe(true);
   expect(opening.endsWith('">\n')).toBe(true);
-  const closing = outputs[outputs.length - 1];
+  const closing = all[all.length - 1];
   expect(closing.startsWith('</subagent name="')).toBe(true);
   expect(closing.endsWith('">\n')).toBe(true);
-  return outputs.slice(1, -1);
+  return all.slice(1, -1);
 }
 
 describe('TaskTool async streaming through real async path', () => {
@@ -158,7 +161,7 @@ describe('TaskTool async streaming through real async path', () => {
         scope.onMessage?.('1. Missing import');
       });
 
-    const outputs: string[] = [];
+    const outputs: Array<{ mode: 'append'; data: string }> = [];
     const invocation = tool.build({
       subagent_name: 'reviewer',
       goal_prompt: 'Review the code',
@@ -193,7 +196,7 @@ describe('TaskTool async streaming through real async path', () => {
       },
     );
 
-    const outputs: string[] = [];
+    const outputs: Array<{ mode: 'append'; data: string }> = [];
     const invocation = tool.build({
       subagent_name: 'reviewer',
       goal_prompt: 'Review',
@@ -221,7 +224,7 @@ describe('TaskTool async streaming through real async path', () => {
       { existingHandler: (msg) => receivedRaw.push(msg) },
     );
 
-    const outputs: string[] = [];
+    const outputs: Array<{ mode: 'append'; data: string }> = [];
     const invocation = tool.build({
       subagent_name: 'reviewer',
       goal_prompt: 'Review',
@@ -248,7 +251,7 @@ describe('TaskTool async streaming through real async path', () => {
       { agentId: 'async-xml-stream' },
     );
 
-    const outputs: string[] = [];
+    const outputs: Array<{ mode: 'append'; data: string }> = [];
     const invocation = tool.build({
       subagent_name: 'reviewer',
       goal_prompt: 'Review',
@@ -261,10 +264,10 @@ describe('TaskTool async streaming through real async path', () => {
 
     await expectCompletionWithin(completionPromise);
 
-    expect(outputs[0]).toBe(
+    expect(outputs[0].data).toBe(
       '<subagent name="reviewer" id="async-xml-stream">\n',
     );
-    expect(outputs[outputs.length - 1]).toBe(
+    expect(outputs[outputs.length - 1].data).toBe(
       '</subagent name="reviewer" id="async-xml-stream">\n',
     );
   });
@@ -277,7 +280,7 @@ describe('TaskTool async streaming through real async path', () => {
       },
     );
 
-    const outputs: string[] = [];
+    const outputs: Array<{ mode: 'append'; data: string }> = [];
     const invocation = tool.build({
       subagent_name: 'reviewer',
       goal_prompt: 'Review',
@@ -301,7 +304,7 @@ describe('TaskTool async streaming through real async path', () => {
       },
     );
 
-    const outputs: string[] = [];
+    const outputs: Array<{ mode: 'append'; data: string }> = [];
     const invocation = tool.build({
       subagent_name: 'reviewer',
       goal_prompt: 'Review',
@@ -325,7 +328,7 @@ describe('TaskTool async streaming through real async path', () => {
       },
     );
 
-    const outputs: string[] = [];
+    const outputs: Array<{ mode: 'append'; data: string }> = [];
     const invocation = tool.build({
       subagent_name: 'reviewer',
       goal_prompt: 'Review',

--- a/packages/cli/src/runtime/interactiveToolScheduler.ts
+++ b/packages/cli/src/runtime/interactiveToolScheduler.ts
@@ -28,7 +28,7 @@ import {
   type ToolSchedulerContract,
   hasInteractiveSubagentScheduler,
   DEFAULT_AGENT_ID,
-  type AnsiOutput,
+  type LiveOutputUpdate,
   type MessageBus,
 } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-telemetry';
@@ -149,7 +149,7 @@ export type SchedulerRefs = {
   updateToolCallOutput: (
     schedulerId: symbol,
     toolCallId: string,
-    chunk: string | AnsiOutput,
+    update: LiveOutputUpdate,
   ) => void;
   replaceToolCallsForScheduler: (
     schedulerId: symbol,

--- a/packages/cli/src/runtime/interactiveToolScheduler.ts
+++ b/packages/cli/src/runtime/interactiveToolScheduler.ts
@@ -179,9 +179,9 @@ function createMainSchedulerCallbacks(
   SchedulerConfigWithExplicitMessageBus['getOrCreateScheduler']
 >[1] {
   return {
-    outputUpdateHandler: (toolCallId, chunk) => {
+    outputUpdateHandler: (toolCallId, update) => {
       if (!mounted.current) return;
-      refs.updateToolCallOutput(mainSchedulerId, toolCallId, chunk);
+      refs.updateToolCallOutput(mainSchedulerId, toolCallId, update);
       refs.setLastToolOutputTime(Date.now());
     },
     onAllToolCallsComplete: async (completedToolCalls) => {
@@ -214,8 +214,8 @@ function createSubagentCallbacks(
   SchedulerConfigWithExplicitMessageBus['getOrCreateScheduler']
 >[1] {
   return {
-    outputUpdateHandler: (toolCallId, chunk) => {
-      refs.updateToolCallOutput(schedulerId, toolCallId, chunk);
+    outputUpdateHandler: (toolCallId, update) => {
+      refs.updateToolCallOutput(schedulerId, toolCallId, update);
       refs.setLastToolOutputTime(Date.now());
     },
     onToolCallsUpdate: (calls) => {

--- a/packages/cli/src/ui/hooks/agentStream/useAgentEventStream.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentEventStream.ts
@@ -27,7 +27,7 @@ import type {
   AgentInput,
 } from '@vybestack/llxprt-code-agents';
 import type {
-  AnsiOutput,
+  LiveOutputUpdate,
   CompletedToolCall,
   EditorType,
   ToolCall,
@@ -77,7 +77,7 @@ export interface UseAgentEventStreamArgs {
   markToolsAsDisplayCleared?: (callIds: string[]) => void;
   /** Display callbacks for tool-call display state. */
   onToolCallsUpdate?: (toolCalls: ToolCall[]) => void;
-  outputUpdateHandler?: (callId: string, chunk: string | AnsiOutput) => void;
+  outputUpdateHandler?: (callId: string, update: LiveOutputUpdate) => void;
   getPreferredEditor?: () => EditorType | undefined;
   onEditorOpen?: () => void;
   onEditorClose?: () => void;
@@ -161,8 +161,8 @@ export function useAgentEventStream(
     agent.tools.setDisplayCallbacks({
       onToolCallsUpdate: (toolCalls) =>
         latestArgs.current.onToolCallsUpdate?.(toolCalls),
-      outputUpdateHandler: (callId, chunk) =>
-        latestArgs.current.outputUpdateHandler?.(callId, chunk),
+      outputUpdateHandler: (callId, update) =>
+        latestArgs.current.outputUpdateHandler?.(callId, update),
       onAllToolCallsComplete: (completed) => {
         const userMessageTimestamp =
           currentTurnTimestampRef.current ?? Date.now();

--- a/packages/cli/src/ui/hooks/agentStream/useAgentStreamOrchestration.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentStreamOrchestration.ts
@@ -7,7 +7,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import {
   type EditorType,
-  type AnsiOutput,
+  type LiveOutputUpdate,
   type MessageBus,
   type RecordingIntegration,
   type ToolCall,
@@ -85,7 +85,7 @@ interface ToolSchedulerState {
   interactiveRuntimeReady: boolean;
   /** Bound display-state updaters for the AgenticLoop's displayCallbacks. */
   replaceToolCalls: (calls: ToolCall[]) => void;
-  updateToolOutput: (callId: string, chunk: string | AnsiOutput) => void;
+  updateToolOutput: (callId: string, update: LiveOutputUpdate) => void;
 }
 
 export function useAgentStreamOrchestration(

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -14,7 +14,7 @@ import {
   type CancelledToolCall,
   type ToolCall,
   type EditorType,
-  type AnsiOutput,
+  type LiveOutputUpdate,
   type MessageBus,
   accumulateLiveOutput,
 } from '@vybestack/llxprt-code-core';
@@ -86,7 +86,7 @@ export type CancelAllFn = () => void;
 export type ReplaceToolCallsFn = (calls: ToolCall[]) => void;
 export type UpdateToolOutputFn = (
   toolCallId: string,
-  chunk: string | AnsiOutput,
+  update: LiveOutputUpdate,
 ) => void;
 export type ReactToolSchedulerResult = readonly [
   TrackedToolCall[],
@@ -104,7 +104,7 @@ export type ReactToolSchedulerResult = readonly [
 function updatePendingItemWithOutput(
   prevItem: HistoryItemWithoutId | null,
   toolCallId: string,
-  outputChunk: string | AnsiOutput,
+  update: LiveOutputUpdate,
 ): HistoryItemWithoutId | null {
   if (prevItem?.type !== 'tool_group') return prevItem;
   return {
@@ -116,7 +116,7 @@ function updatePendingItemWithOutput(
             ...toolDisplay,
             resultDisplay: accumulateLiveOutput(
               toolDisplay.resultDisplay,
-              outputChunk,
+              update,
             ),
           }
         : toolDisplay,
@@ -148,13 +148,13 @@ function mapCallsWithDisplayClearedFlag(
 function updateCallsWithLiveOutput(
   prevCalls: TrackedToolCall[],
   toolCallId: string,
-  outputChunk: string | AnsiOutput,
+  update: LiveOutputUpdate,
 ): TrackedToolCall[] {
   return prevCalls.map((call) =>
     call.request.callId === toolCallId && call.status === 'executing'
       ? {
           ...call,
-          liveOutput: accumulateLiveOutput(call.liveOutput, outputChunk),
+          liveOutput: accumulateLiveOutput(call.liveOutput, update),
         }
       : call,
   );
@@ -209,7 +209,7 @@ function useToolCallUpdaters(
   updateToolCallOutput: (
     schedulerId: symbol,
     toolCallId: string,
-    outputChunk: string | AnsiOutput,
+    update: LiveOutputUpdate,
   ) => void;
   replaceToolCallsForScheduler: (
     schedulerId: symbol,
@@ -240,23 +240,19 @@ function useToolCallUpdaters(
   );
 
   const updateToolCallOutput = useCallback(
-    (
-      schedulerId: symbol,
-      toolCallId: string,
-      outputChunk: string | AnsiOutput,
-    ) => {
+    (schedulerId: symbol, toolCallId: string, update: LiveOutputUpdate) => {
       updateToolCallsForScheduler(schedulerId, (prevCalls) => {
         const nextCalls = updateCallsWithLiveOutput(
           prevCalls,
           toolCallId,
-          outputChunk,
+          update,
         );
         return nextCalls.some((call, index) => call !== prevCalls[index])
           ? nextCalls
           : prevCalls;
       });
       setPendingHistoryItem((prev) =>
-        updatePendingItemWithOutput(prev, toolCallId, outputChunk),
+        updatePendingItemWithOutput(prev, toolCallId, update),
       );
     },
     [updateToolCallsForScheduler, setPendingHistoryItem],
@@ -378,7 +374,7 @@ function useSchedulerRefs(
     updateToolCallOutput: (
       schedulerId: symbol,
       toolCallId: string,
-      chunk: string | AnsiOutput,
+      update: LiveOutputUpdate,
     ) => void;
     replaceToolCallsForScheduler: (
       schedulerId: symbol,
@@ -470,8 +466,8 @@ function useBoundDisplayUpdaters(
     [replaceToolCallsForScheduler, mainSchedulerId],
   );
   const updateToolOutput = useCallback(
-    (toolCallId: string, chunk: string | AnsiOutput) =>
-      updateToolCallOutput(mainSchedulerId, toolCallId, chunk),
+    (toolCallId: string, update: LiveOutputUpdate) =>
+      updateToolCallOutput(mainSchedulerId, toolCallId, update),
     [updateToolCallOutput, mainSchedulerId],
   );
   return { replaceToolCalls, updateToolOutput };

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -87,7 +87,7 @@ describe('Zed terminal execution', () => {
       preparedEcho,
       '/project',
       (event) => {
-        if (event.type === 'data' && event.chunk !== undefined) {
+        if (event.type === 'data' && typeof event.chunk === 'string') {
           chunks.push(event.chunk);
         }
       },

--- a/packages/core/src/config/schedulerSingleton.ts
+++ b/packages/core/src/config/schedulerSingleton.ts
@@ -18,16 +18,13 @@ import type {
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
 import type { EditorType } from '../utils/editor.js';
-import type { AnsiOutput } from '../utils/terminalSerializer.js';
+import type { LiveOutputUpdate } from '../utils/terminalSerializer.js';
 import { DebugLogger } from '../debug/DebugLogger.js';
 
 const debugLog = new DebugLogger('llxprt:schedulerSingleton');
 
 export interface SchedulerCallbacks {
-  outputUpdateHandler?: (
-    toolCallId: string,
-    outputChunk: string | AnsiOutput,
-  ) => void;
+  outputUpdateHandler?: (toolCallId: string, update: LiveOutputUpdate) => void;
   onAllToolCallsComplete?: (
     completedToolCalls: CompletedToolCall[],
   ) => Promise<void>;

--- a/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
+++ b/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
@@ -98,4 +98,44 @@ describe('Live-output accumulation behavioral scenarios', () => {
     // discards it and returns just the new string data.
     expect(result).toBe('fresh');
   });
+
+  it('empty string append preserves prior accumulated text', () => {
+    // An empty string is a valid append delta (e.g. a whitespace-only normalized
+    // to empty); it must not wipe prior content.
+    const result = replay([
+      { mode: 'append', data: 'prior' },
+      { mode: 'append', data: '' },
+    ]);
+    expect(result).toBe('prior');
+  });
+
+  it('empty AnsiOutput replace clears any prior accumulated state', () => {
+    // An empty snapshot is a valid replace that should reset the accumulator.
+    const empty: AnsiOutput = [];
+    const result = replay([
+      { mode: 'append', data: 'prior text' },
+      { mode: 'replace', data: empty },
+    ]);
+    expect(result).toBe(empty);
+  });
+
+  it('consecutive replace operations keep only the latest snapshot', () => {
+    const first = snapshot('snap-1');
+    const second = snapshot('snap-2');
+    const third = snapshot('snap-3');
+    const result = replay([
+      { mode: 'replace', data: first },
+      { mode: 'replace', data: second },
+      { mode: 'replace', data: third },
+    ]);
+    expect(result).toBe(third);
+  });
+
+  it('replace as the very first update (no prior state) returns the snapshot', () => {
+    // When no prior append has occurred, a replace from undefined must
+    // return the AnsiOutput snapshot directly.
+    const snap = snapshot('initial');
+    const result = replay([{ mode: 'replace', data: snap }]);
+    expect(result).toBe(snap);
+  });
 });

--- a/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
+++ b/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
@@ -37,11 +37,11 @@ function snapshot(text: string): AnsiOutput {
  * real producer sequences (shell PTY replace after task append, etc.) rather
  * than the isolated single-step unit assertions in liveOutput.test.ts.
  */
-function replay(updates: LiveOutputUpdate[]): string | AnsiOutput {
-  return updates.reduce<string | AnsiOutput | undefined>((acc, update) => {
-    const next = accumulateLiveOutput(acc, update);
-    return next;
-  }, undefined) as string | AnsiOutput;
+function replay(updates: LiveOutputUpdate[]): string | AnsiOutput | undefined {
+  return updates.reduce<string | AnsiOutput | undefined>(
+    (acc, update) => accumulateLiveOutput(acc, update),
+    undefined,
+  );
 }
 
 describe('Live-output accumulation behavioral scenarios', () => {

--- a/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
+++ b/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { accumulateLiveOutput } from '../../liveOutput.js';
+import type {
+  AnsiOutput,
+  AnsiToken,
+  LiveOutputUpdate,
+} from '../../../utils/terminalSerializer.js';
+
+/** Builds a minimal valid AnsiToken for test fixtures. */
+function makeToken(text: string): AnsiToken {
+  return {
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    dim: false,
+    inverse: false,
+    fg: '',
+    bg: '',
+  };
+}
+
+/** Builds an AnsiOutput snapshot from a single token text. */
+function snapshot(text: string): AnsiOutput {
+  return [[makeToken(text)]];
+}
+
+/** Drives a sequence of updates through the accumulator and returns the result. */
+function replay(updates: LiveOutputUpdate[]): string | AnsiOutput {
+  return updates.reduce<string | AnsiOutput | undefined>((acc, update) => {
+    const next = accumulateLiveOutput(acc, update);
+    return next;
+  }, undefined) as string | AnsiOutput;
+}
+
+describe('Live-output accumulation behavioral scenarios', () => {
+  it('interleaved append (text) and replace (AnsiOutput) updates accumulate correctly', () => {
+    const result = replay([
+      { mode: 'append', data: 'first ' },
+      { mode: 'append', data: 'second ' },
+      { mode: 'replace', data: snapshot('terminal-snap') },
+      { mode: 'append', data: ' after' },
+    ]);
+    // The replace wipes prior text; the append starts fresh on top of the
+    // returned AnsiOutput (existing is non-string, so append returns just data).
+    expect(result).toBe(' after');
+  });
+
+  it('append streams contain no inserted separators between consecutive appends', () => {
+    const result = replay([
+      { mode: 'append', data: 'a' },
+      { mode: 'append', data: 'b' },
+      { mode: 'append', data: 'c' },
+    ]);
+    expect(result).toBe('abc');
+  });
+
+  it('final accumulated result shape is string after only appends', () => {
+    const result = replay([
+      { mode: 'append', data: 'one ' },
+      { mode: 'append', data: 'two' },
+    ]);
+    expect(typeof result).toBe('string');
+    expect(result).toBe('one two');
+  });
+
+  it('final accumulated result shape is AnsiOutput after a final replace', () => {
+    const snap = snapshot('final');
+    const result = replay([
+      { mode: 'append', data: 'text' },
+      { mode: 'replace', data: snap },
+    ]);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toBe(snap);
+  });
+
+  it('mixed transition: append, append, replace, append wipes prior text then starts fresh', () => {
+    const result = replay([
+      { mode: 'append', data: 'hello ' },
+      { mode: 'append', data: 'world' },
+      { mode: 'replace', data: snapshot('buffer') },
+      { mode: 'append', data: 'fresh' },
+    ]);
+    // After replace the accumulated value is AnsiOutput; the next append drops
+    // it and returns just the new string data.
+    expect(result).toBe('fresh');
+  });
+});

--- a/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
+++ b/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
@@ -47,8 +47,8 @@ describe('Live-output accumulation behavioral scenarios', () => {
       { mode: 'replace', data: snapshot('terminal-snap') },
       { mode: 'append', data: ' after' },
     ]);
-    // The replace wipes prior text; the append starts fresh on top of the
-    // returned AnsiOutput (existing is non-string, so append returns just data).
+    // The replace wipes prior text; the append discards the AnsiOutput
+    // (existing is non-string) and returns just the new string data.
     expect(result).toBe(' after');
   });
 
@@ -87,8 +87,8 @@ describe('Live-output accumulation behavioral scenarios', () => {
       { mode: 'replace', data: snapshot('buffer') },
       { mode: 'append', data: 'fresh' },
     ]);
-    // After replace the accumulated value is AnsiOutput; the next append drops
-    // it and returns just the new string data.
+    // After replace the accumulated value is AnsiOutput; the next append
+    // discards it and returns just the new string data.
     expect(result).toBe('fresh');
   });
 });

--- a/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
+++ b/packages/core/src/scheduler/__tests__/behavioral/live-output.behavioral.spec.ts
@@ -31,7 +31,12 @@ function snapshot(text: string): AnsiOutput {
   return [[makeToken(text)]];
 }
 
-/** Drives a sequence of updates through the accumulator and returns the result. */
+/**
+ * Drives a sequence of updates through the accumulator and returns the result.
+ * These behavioral scenarios exercise end-to-end mode transitions that mirror
+ * real producer sequences (shell PTY replace after task append, etc.) rather
+ * than the isolated single-step unit assertions in liveOutput.test.ts.
+ */
 function replay(updates: LiveOutputUpdate[]): string | AnsiOutput {
   return updates.reduce<string | AnsiOutput | undefined>((acc, update) => {
     const next = accumulateLiveOutput(acc, update);
@@ -41,6 +46,7 @@ function replay(updates: LiveOutputUpdate[]): string | AnsiOutput {
 
 describe('Live-output accumulation behavioral scenarios', () => {
   it('interleaved append (text) and replace (AnsiOutput) updates accumulate correctly', () => {
+    // Mirrors a shell PTY snapshot arriving mid-stream of subagent text.
     const result = replay([
       { mode: 'append', data: 'first ' },
       { mode: 'append', data: 'second ' },
@@ -53,6 +59,7 @@ describe('Live-output accumulation behavioral scenarios', () => {
   });
 
   it('append streams contain no inserted separators between consecutive appends', () => {
+    // Producer contract: append must not invent newlines or separators.
     const result = replay([
       { mode: 'append', data: 'a' },
       { mode: 'append', data: 'b' },

--- a/packages/core/src/scheduler/liveOutput.test.ts
+++ b/packages/core/src/scheduler/liveOutput.test.ts
@@ -25,42 +25,94 @@ function makeToken(text: string): AnsiToken {
 const ansiSnapshot: AnsiOutput = [[makeToken('full')]];
 
 describe('accumulateLiveOutput', () => {
-  it('appends a string delta to an existing string', () => {
-    expect(accumulateLiveOutput('Hello ', 'world')).toBe('Hello world');
+  describe('append mode', () => {
+    it('appends a string delta to an existing string', () => {
+      expect(
+        accumulateLiveOutput('Hello ', { mode: 'append', data: 'world' }),
+      ).toBe('Hello world');
+    });
+
+    it('returns the data when existing is undefined', () => {
+      expect(
+        accumulateLiveOutput(undefined, { mode: 'append', data: 'first' }),
+      ).toBe('first');
+    });
+
+    it('returns the data when existing is null or other non-string type', () => {
+      expect(
+        accumulateLiveOutput(null, { mode: 'append', data: 'delta' }),
+      ).toBe('delta');
+      expect(accumulateLiveOutput(42, { mode: 'append', data: 'delta' })).toBe(
+        'delta',
+      );
+    });
+
+    it('preserves existing output when the data is an empty string', () => {
+      expect(accumulateLiveOutput('Hello ', { mode: 'append', data: '' })).toBe(
+        'Hello ',
+      );
+    });
+
+    it('accumulates multiple string deltas in sequence', () => {
+      let acc: string | AnsiOutput | undefined = undefined;
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'one ' });
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'two ' });
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'three' });
+      expect(acc).toBe('one two three');
+    });
   });
 
-  it('returns the chunk when existing is undefined', () => {
-    expect(accumulateLiveOutput(undefined, 'first')).toBe('first');
+  describe('replace mode', () => {
+    it('replaces with the latest AnsiOutput snapshot', () => {
+      const first: AnsiOutput = [[makeToken('snap-1')]];
+      const second: AnsiOutput = [[makeToken('snap-2')]];
+      expect(
+        accumulateLiveOutput(first, { mode: 'replace', data: second }),
+      ).toBe(second);
+    });
+
+    it('supersedes an existing AnsiOutput snapshot', () => {
+      expect(
+        accumulateLiveOutput(ansiSnapshot, {
+          mode: 'replace',
+          data: ansiSnapshot,
+        }),
+      ).toBe(ansiSnapshot);
+    });
   });
 
-  it('returns the chunk when existing is null or other non-string type', () => {
-    expect(accumulateLiveOutput(null, 'delta')).toBe('delta');
-    expect(accumulateLiveOutput(42, 'delta')).toBe('delta');
-  });
+  describe('mode transitions', () => {
+    it('replace after append transitions correctly', () => {
+      let acc: string | AnsiOutput | undefined = undefined;
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'partial' });
+      acc = accumulateLiveOutput(acc, { mode: 'replace', data: ansiSnapshot });
+      expect(acc).toBe(ansiSnapshot);
+    });
 
-  it('preserves existing output when the delta is an empty string', () => {
-    expect(accumulateLiveOutput('Hello ', '')).toBe('Hello ');
-  });
+    it('append after replace drops the AnsiOutput and starts fresh with the string data', () => {
+      let acc: string | AnsiOutput = ansiSnapshot;
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'delta' });
+      expect(acc).toBe('delta');
+    });
 
-  it('accumulates multiple string deltas in sequence', () => {
-    let acc: string | AnsiOutput | undefined = undefined;
-    acc = accumulateLiveOutput(acc, 'one ');
-    acc = accumulateLiveOutput(acc, 'two ');
-    acc = accumulateLiveOutput(acc, 'three');
-    expect(acc).toBe('one two three');
-  });
+    it('multiple sequential appends concatenate exactly', () => {
+      let acc: string | AnsiOutput | undefined = undefined;
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'a' });
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'b' });
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'c' });
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'd' });
+      expect(acc).toBe('abcd');
+    });
 
-  it('replaces with the latest AnsiOutput snapshot', () => {
-    const first: AnsiOutput = [[makeToken('snap-1')]];
-    const second: AnsiOutput = [[makeToken('snap-2')]];
-    expect(accumulateLiveOutput(first, second)).toBe(second);
-  });
-
-  it('does not append when the chunk is AnsiOutput even if existing is a string', () => {
-    expect(accumulateLiveOutput('partial', ansiSnapshot)).toBe(ansiSnapshot);
-  });
-
-  it('does not append when the existing is AnsiOutput even if the chunk is a string', () => {
-    expect(accumulateLiveOutput(ansiSnapshot, 'delta')).toBe('delta');
+    it('multiple sequential replaces keep only the last snapshot', () => {
+      const first: AnsiOutput = [[makeToken('1')]];
+      const second: AnsiOutput = [[makeToken('2')]];
+      const third: AnsiOutput = [[makeToken('3')]];
+      let acc: string | AnsiOutput | undefined = undefined;
+      acc = accumulateLiveOutput(acc, { mode: 'replace', data: first });
+      acc = accumulateLiveOutput(acc, { mode: 'replace', data: second });
+      acc = accumulateLiveOutput(acc, { mode: 'replace', data: third });
+      expect(acc).toBe(third);
+    });
   });
 });

--- a/packages/core/src/scheduler/liveOutput.ts
+++ b/packages/core/src/scheduler/liveOutput.ts
@@ -4,36 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AnsiOutput } from '../utils/terminalSerializer.js';
+import type {
+  AnsiOutput,
+  LiveOutputUpdate,
+} from '../utils/terminalSerializer.js';
 
 /**
- * Accumulates a live-output chunk onto an existing value.
+ * Accumulates a live-output update onto an existing accumulated value using
+ * the explicit tagged {@link LiveOutputUpdate} protocol.
  *
- * Tools that stream via `canUpdateOutput` deliver chunks in one of two
- * semantics:
- *
- * - **`AnsiOutput`** (e.g. the shell tool) — a full terminal-buffer snapshot.
- *   Each chunk supersedes the previous one, so the latest snapshot replaces
- *   the old value.
- * - **`string`** (e.g. the task tool streaming subagent text) — an incremental
- *   delta.  Each chunk must be appended to the existing text so the display
- *   grows rather than showing only the latest token.
+ * - **`append`** (text deltas) — concatenated onto the existing value when it
+ *   is a string; otherwise the prior non-string value is dropped and the
+ *   delta starts a fresh string.
+ * - **`replace`** (terminal-buffer snapshots) — supersedes any prior value.
  *
  * The `existing` parameter is typed `unknown` because callers may pass values
  * drawn from a broader display union (e.g. `ToolResultDisplay`, which also
- * includes `FileDiff` / `FileRead`).  The function only ever appends when both
- * values are strings; any other combination replaces with the incoming chunk.
- *
- * Note: the append-vs-replace distinction is currently inferred from the
- * payload type.  Migrating to an explicit tagged update protocol (e.g.
- * `{ mode: 'append'; data: string } | { mode: 'replace'; data: AnsiOutput }`)
- * is tracked in follow-up #2586.
+ * includes `FileDiff` / `FileRead`). The returned type is the narrow
+ * `string | AnsiOutput` union the live-output channel actually produces.
  */
 export function accumulateLiveOutput(
   existing: unknown,
-  chunk: string | AnsiOutput,
+  update: LiveOutputUpdate,
 ): string | AnsiOutput {
-  return typeof chunk === 'string' && typeof existing === 'string'
-    ? existing + chunk
-    : chunk;
+  switch (update.mode) {
+    case 'append':
+      return typeof existing === 'string'
+        ? existing + update.data
+        : update.data;
+    case 'replace':
+      return update.data;
+    default: {
+      const _exhaustive: never = update;
+      return _exhaustive;
+    }
+  }
 }

--- a/packages/core/src/scheduler/types.ts
+++ b/packages/core/src/scheduler/types.ts
@@ -22,7 +22,10 @@ import type {
   ToolCallResponseInfo,
 } from '../core/turn.js';
 import type { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
-import type { AnsiOutput } from '../utils/terminalSerializer.js';
+import type {
+  AnsiOutput,
+  LiveOutputUpdate,
+} from '../utils/terminalSerializer.js';
 import type { SerializableConfirmationDetails } from '../confirmation-bus/types.js';
 
 /**
@@ -142,7 +145,7 @@ export type ConfirmHandler = (
 
 export type OutputUpdateHandler = (
   toolCallId: string,
-  outputChunk: string | AnsiOutput,
+  update: LiveOutputUpdate,
 ) => void;
 
 export type AllToolCallsCompleteHandler = (

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -9,6 +9,7 @@ import type {
   ToolCallConfirmationDetails,
   ToolInvocation,
   ToolResult,
+  LiveOutputUpdate,
 } from '@vybestack/llxprt-code-tools';
 import {
   BaseDeclarativeTool,
@@ -33,7 +34,7 @@ interface MockToolOptions {
   execute?: (
     params: { [key: string]: unknown },
     signal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ) => Promise<ToolResult>;
   params?: object;
   messageBus?: IToolMessageBus;
@@ -64,7 +65,7 @@ class MockToolInvocation extends BaseToolInvocation<
 
   execute(
     signal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     return this.tool.executeFn(this.params, signal, updateOutput);
   }
@@ -86,7 +87,7 @@ class MockToolInvocation extends BaseToolInvocation<
 type ExecuteFn = (
   params: { [key: string]: unknown },
   signal: AbortSignal,
-  updateOutput?: (output: string) => void,
+  updateOutput?: (update: LiveOutputUpdate) => void,
 ) => Promise<ToolResult>;
 
 type ExecuteMock = ReturnType<typeof vi.fn<ExecuteFn>>;

--- a/packages/core/src/test-utils/tools.ts
+++ b/packages/core/src/test-utils/tools.ts
@@ -12,6 +12,7 @@ import {
   type ToolCallConfirmationDetails,
   type ToolInvocation,
   type ToolResult,
+  type LiveOutputUpdate,
   Kind,
 } from '@vybestack/llxprt-code-tools';
 import { MessageBus } from '../confirmation-bus/message-bus.js';
@@ -61,7 +62,7 @@ async function executeMockTool(
   tool: { name: string; executeFn: ToolSpy },
   params: Record<string, unknown>,
   abortSignal: AbortSignal,
-  updateOutput?: (output: string) => void,
+  updateOutput?: (update: LiveOutputUpdate) => void,
 ): Promise<ToolResult> {
   const result = await tool.executeFn(params, abortSignal, updateOutput);
   if (isToolResultLike(result)) {
@@ -87,7 +88,7 @@ class MockToolInvocation extends BaseToolInvocation<
 
   async execute(
     abortSignal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     return executeMockTool(this.tool, this.params, abortSignal, updateOutput);
   }
@@ -168,7 +169,7 @@ export class MockModifiableToolInvocation extends BaseToolInvocation<
 
   async execute(
     abortSignal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     return executeMockTool(this.tool, this.params, abortSignal, updateOutput);
   }

--- a/packages/core/src/tools-adapters/CoreShellToolHostAdapter.ts
+++ b/packages/core/src/tools-adapters/CoreShellToolHostAdapter.ts
@@ -224,13 +224,7 @@ export class CoreShellToolHostAdapter implements IShellToolHost {
   private mapOutputEvent(event: ShellOutputEvent): ToolsShellOutputEvent {
     switch (event.type) {
       case 'data':
-        return {
-          type: 'data',
-          chunk:
-            typeof event.chunk === 'string'
-              ? event.chunk
-              : JSON.stringify(event.chunk),
-        };
+        return { type: 'data', chunk: event.chunk };
       case 'binary_detected':
         return { type: 'binary_detected' };
       case 'binary_progress':

--- a/packages/core/src/utils/terminalSerializer.ts
+++ b/packages/core/src/utils/terminalSerializer.ts
@@ -19,6 +19,15 @@ export interface AnsiToken {
 export type AnsiLine = AnsiToken[];
 export type AnsiOutput = AnsiLine[];
 
+/**
+ * Explicit tagged update protocol for live-output streaming. Discriminated
+ * by `mode`: text stream producers emit `append` (incremental deltas);
+ * terminal-buffer producers emit `replace` (full snapshots).
+ */
+export type LiveOutputUpdate =
+  | { mode: 'append'; data: string }
+  | { mode: 'replace'; data: AnsiOutput };
+
 const enum Attribute {
   inverse = 1,
   bold = 2,

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -236,6 +236,7 @@ export type {
   ToolInfoConfirmationDetails,
   ToolCallConfirmationDetails,
   ToolLocation,
+  LiveOutputUpdate,
 } from './tools/tools.js';
 
 export {

--- a/packages/tools/src/interfaces/IShellToolHost.ts
+++ b/packages/tools/src/interfaces/IShellToolHost.ts
@@ -9,6 +9,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { AnsiOutput } from '../utils/terminalSerializer.js';
+
 /**
  * Tools-owned interface for shell tool host dependencies.
  *
@@ -210,6 +212,6 @@ export interface IShellToolHost {
  */
 export interface ShellOutputEvent {
   type: 'data' | 'binary_detected' | 'binary_progress';
-  chunk?: string;
+  chunk?: string | AnsiOutput;
   bytesReceived?: number;
 }

--- a/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
+++ b/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
@@ -32,7 +32,7 @@ import { toIdeConnectionStatus } from '../edit-utils.js';
 import { hasLspCap } from '../../interfaces/host-capabilities.js';
 import { DEFAULT_CREATE_PATCH_OPTIONS } from '../../utils/diffOptions.js';
 import { collectLspDiagnosticsBlock } from '../../utils/lsp-diagnostics-helper.js';
-import type { AnsiOutput } from '../../utils/terminalSerializer.js';
+import type { LiveOutputUpdate } from '../../utils/terminalSerializer.js';
 import { ensureParentDirectoriesExist } from '../../utils/ensure-dirs.js';
 
 import type { ASTEditToolParams } from './types.js';
@@ -186,7 +186,7 @@ export class ASTEditToolInvocation
 
   async execute(
     signal: AbortSignal,
-    _updateOutput?: (output: string | AnsiOutput) => void,
+    _updateOutput?: (update: LiveOutputUpdate) => void,
     _terminalColumns?: number,
     _terminalRows?: number,
     _setPidCallback?: (pid: number) => void,

--- a/packages/tools/src/tools/ast-edit/ast-read-file-invocation.ts
+++ b/packages/tools/src/tools/ast-edit/ast-read-file-invocation.ts
@@ -18,7 +18,7 @@ import { makeRelative, shortenPath } from '../../utils/paths.js';
 import { isNodeError } from '../../utils/errors.js';
 import { countLines } from '../../utils/fileUtils.js';
 import type { IToolHost } from '../../interfaces/index.js';
-import type { AnsiOutput } from '../../utils/terminalSerializer.js';
+import type { LiveOutputUpdate } from '../../utils/terminalSerializer.js';
 
 import type { ASTReadFileToolParams } from './types.js';
 import { ASTConfig } from './ast-config.js';
@@ -51,7 +51,7 @@ export class ASTReadFileToolInvocation
 
   async execute(
     _signal?: AbortSignal,
-    _updateOutput?: (output: string | AnsiOutput) => void,
+    _updateOutput?: (update: LiveOutputUpdate) => void,
     _terminalColumns?: number,
     _terminalRows?: number,
     _setPidCallback?: (pid: number) => void,

--- a/packages/tools/src/tools/codesearch.ts
+++ b/packages/tools/src/tools/codesearch.ts
@@ -23,6 +23,7 @@ import {
   Kind,
   type ToolInvocation,
   type ToolResult,
+  type LiveOutputUpdate,
 } from './tools.js';
 
 const API_CONFIG = {
@@ -140,7 +141,7 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
 
   async execute(
     signal: AbortSignal,
-    _updateOutput?: (output: string) => void,
+    _updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     const codeRequest: McpCodeRequest = {
       jsonrpc: '2.0',

--- a/packages/tools/src/tools/direct-web-fetch.ts
+++ b/packages/tools/src/tools/direct-web-fetch.ts
@@ -14,6 +14,7 @@ import {
   Kind,
   type ToolInvocation,
   type ToolResult,
+  type LiveOutputUpdate,
 } from './tools.js';
 import { DIRECT_WEB_FETCH_TOOL } from '../types/tool-names.js';
 import { ToolErrorType } from '../types/tool-error.js';
@@ -103,7 +104,7 @@ class DirectWebFetchToolInvocation extends BaseToolInvocation<
 
   async execute(
     signal: AbortSignal,
-    _updateOutput?: (output: string) => void,
+    _updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     const protocolError = this.validateUrlProtocol();
     if (protocolError) return protocolError;

--- a/packages/tools/src/tools/exa-web-search.ts
+++ b/packages/tools/src/tools/exa-web-search.ts
@@ -19,6 +19,7 @@ import {
   Kind,
   type ToolInvocation,
   type ToolResult,
+  type LiveOutputUpdate,
 } from './tools.js';
 
 const API_CONFIG = {
@@ -154,7 +155,7 @@ class ExaWebSearchToolInvocation extends BaseToolInvocation<
 
   async execute(
     signal: AbortSignal,
-    _updateOutput?: (output: string) => void,
+    _updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     const searchRequest: McpSearchRequest = {
       jsonrpc: '2.0',

--- a/packages/tools/src/tools/shell.ts
+++ b/packages/tools/src/tools/shell.ts
@@ -358,7 +358,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
             if (isBinaryStream) break;
             cumulativeOutput = chunk;
             shouldUpdate = true;
-          } else {
+          } else if (chunk !== undefined) {
             // PTY terminal-buffer snapshot — replace semantics.
             updateOutput({ mode: 'replace', data: chunk });
             lastUpdateTime = Date.now();

--- a/packages/tools/src/tools/shell.ts
+++ b/packages/tools/src/tools/shell.ts
@@ -353,16 +353,16 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
       switch (event.type) {
         case 'data': {
+          if (isBinaryStream) break;
           const chunk = event.chunk;
           if (typeof chunk === 'string') {
-            if (isBinaryStream) break;
             cumulativeOutput = chunk;
             shouldUpdate = true;
           } else if (chunk !== undefined) {
             // PTY terminal-buffer snapshot — replace semantics.
             updateOutput({ mode: 'replace', data: chunk });
             lastUpdateTime = Date.now();
-          } else if (!isBinaryStream) {
+          } else {
             // Preserve pre-migration behavior: an undefined chunk on a data
             // event forwards the (empty) cumulative output as an append.
             cumulativeOutput = '';

--- a/packages/tools/src/tools/shell.ts
+++ b/packages/tools/src/tools/shell.ts
@@ -358,7 +358,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
             if (isBinaryStream) break;
             cumulativeOutput = chunk;
             shouldUpdate = true;
-          } else if (chunk !== undefined) {
+          } else {
             // PTY terminal-buffer snapshot — replace semantics.
             updateOutput({ mode: 'replace', data: chunk });
             lastUpdateTime = Date.now();

--- a/packages/tools/src/tools/shell.ts
+++ b/packages/tools/src/tools/shell.ts
@@ -362,6 +362,11 @@ export class ShellToolInvocation extends BaseToolInvocation<
             // PTY terminal-buffer snapshot — replace semantics.
             updateOutput({ mode: 'replace', data: chunk });
             lastUpdateTime = Date.now();
+          } else if (!isBinaryStream) {
+            // Preserve pre-migration behavior: an undefined chunk on a data
+            // event forwards the (empty) cumulative output as an append.
+            cumulativeOutput = '';
+            shouldUpdate = true;
           }
           break;
         }

--- a/packages/tools/src/tools/shell.ts
+++ b/packages/tools/src/tools/shell.ts
@@ -23,6 +23,7 @@ import {
   type ToolCallConfirmationDetails,
   type ToolExecuteConfirmationDetails,
   type PolicyUpdateOptions,
+  type LiveOutputUpdate,
 } from './tools.js';
 import { ToolErrorType } from '../types/tool-error.js';
 import { stringOrDefault } from '../utils/stringCoalescing.js';
@@ -184,7 +185,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
   async execute(
     signal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     this.validateFilterParams();
 
@@ -243,7 +244,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
     timeoutSeconds: number | undefined,
     defaultTimeoutSeconds: number,
     _timeoutId: ReturnType<typeof setTimeout> | null,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     const combinedSignal = timeoutController.signal;
     const cwd = this.resolveCwd();
@@ -340,7 +341,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
   }
 
   private createOutputEventHandler(
-    updateOutput: ((output: string) => void) | undefined,
+    updateOutput: ((update: LiveOutputUpdate) => void) | undefined,
   ): (event: ShellOutputEvent) => void {
     let cumulativeOutput = '';
     let lastUpdateTime = 0;
@@ -352,9 +353,16 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
       switch (event.type) {
         case 'data': {
-          if (isBinaryStream) break;
-          cumulativeOutput = event.chunk ?? '';
-          shouldUpdate = true;
+          const chunk = event.chunk;
+          if (typeof chunk === 'string') {
+            if (isBinaryStream) break;
+            cumulativeOutput = chunk;
+            shouldUpdate = true;
+          } else if (chunk !== undefined) {
+            // PTY terminal-buffer snapshot — replace semantics.
+            updateOutput({ mode: 'replace', data: chunk });
+            lastUpdateTime = Date.now();
+          }
           break;
         }
         case 'binary_detected':
@@ -375,7 +383,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
 
       if (shouldUpdate) {
-        updateOutput(cumulativeOutput);
+        updateOutput({ mode: 'append', data: cumulativeOutput });
         lastUpdateTime = Date.now();
       }
     };

--- a/packages/tools/src/tools/todo-pause.ts
+++ b/packages/tools/src/tools/todo-pause.ts
@@ -5,7 +5,12 @@
  */
 
 import { Type } from '../types/schema-type.js';
-import { BaseTool, type ToolResult, Kind } from './tools.js';
+import {
+  BaseTool,
+  type ToolResult,
+  Kind,
+  type LiveOutputUpdate,
+} from './tools.js';
 import type { ITodoService } from '../interfaces/ITodoService.js';
 import type { IToolHost } from '../interfaces/IToolHost.js';
 import { EmojiFilter, isEmojiFilterMode } from '../utils/EmojiFilter.js';
@@ -118,7 +123,7 @@ export class TodoPause extends BaseTool<TodoPauseParams, ToolResult> {
   async execute(
     params: TodoPauseParams,
     _signal: AbortSignal,
-    _updateOutput?: (output: string) => void,
+    _updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     const reasonResult = this.filterReason(params.reason);
     if (reasonResult.blocked) {

--- a/packages/tools/src/tools/todo-read.ts
+++ b/packages/tools/src/tools/todo-read.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BaseTool, type ToolResult, Kind } from './tools.js';
+import {
+  BaseTool,
+  type ToolResult,
+  Kind,
+  type LiveOutputUpdate,
+} from './tools.js';
 import { type Todo } from '../types/todo-schemas.js';
 import { Type } from '../types/schema-type.js';
 import { TodoReminderService } from '../utils/todoReminderService.js';
@@ -39,7 +44,7 @@ export class TodoRead extends BaseTool<TodoReadParams, ToolResult> {
   async execute(
     _params: TodoReadParams,
     _signal: AbortSignal,
-    _updateOutput?: (output: string) => void,
+    _updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     // Get session and agent IDs from context
     const sessionId = this.context?.sessionId ?? 'default';

--- a/packages/tools/src/tools/todo-write.ts
+++ b/packages/tools/src/tools/todo-write.ts
@@ -5,7 +5,12 @@
  */
 
 import { Type } from '../types/schema-type.js';
-import { BaseTool, type ToolResult, Kind } from './tools.js';
+import {
+  BaseTool,
+  type ToolResult,
+  Kind,
+  type LiveOutputUpdate,
+} from './tools.js';
 import { type Todo, TodoArraySchema } from '../types/todo-schemas.js';
 import { DEFAULT_AGENT_ID } from './todo-store.js';
 import { TodoReminderService } from '../utils/todoReminderService.js';
@@ -147,7 +152,7 @@ export class TodoWrite extends BaseTool<TodoWriteParams, ToolResult> {
   async execute(
     params: TodoWriteParams,
     _signal: AbortSignal,
-    _updateOutput?: (output: string) => void,
+    _updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     const normalizedTodos = this.normalizeTodos(params.todos);
     const validation = this.validateAndFilterTodos(normalizedTodos);

--- a/packages/tools/src/tools/tool-registry.ts
+++ b/packages/tools/src/tools/tool-registry.ts
@@ -11,6 +11,7 @@ import {
   type ToolResult,
   BaseTool,
   BaseToolInvocation,
+  type LiveOutputUpdate,
 } from './tools.js';
 import { type ToolContext, isContextAwareTool } from '../types/tool-context.js';
 import type { IToolRegistryHost } from '../interfaces/IToolRegistryHost.js';
@@ -120,7 +121,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
   async execute(
     params: ToolParams,
     signal: AbortSignal,
-    _updateOutput?: (output: string) => void,
+    _updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     const callCommand = this.config.getToolCallCommand?.() ?? '';
     const child = spawn(callCommand, [this.name]);
@@ -267,7 +268,7 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
 
   async execute(
     signal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<ToolResult> {
     return this.tool.execute(this.params, signal, updateOutput);
   }

--- a/packages/tools/src/tools/tools.ts
+++ b/packages/tools/src/tools/tools.ts
@@ -18,7 +18,10 @@ import {
 } from '../interfaces/IToolMessageBus.js';
 import type { DiffUpdateResult } from '../interfaces/IIdeService.js';
 import { SchemaValidator } from '../utils/schemaValidator.js';
-import type { AnsiOutput } from '../utils/terminalSerializer.js';
+import type {
+  AnsiOutput,
+  LiveOutputUpdate,
+} from '../utils/terminalSerializer.js';
 import type { ContextAwareTool, ToolContext } from '../types/tool-context.js';
 import {
   ToolConfirmationOutcome,
@@ -28,6 +31,7 @@ import { ToolErrorType } from '../types/tool-error.js';
 
 export { ToolConfirmationOutcome } from '../types/tool-confirmation-types.js';
 export type { ToolConfirmationPayload } from '../types/tool-confirmation-types.js';
+export type { LiveOutputUpdate } from '../utils/terminalSerializer.js';
 
 /**
  * Represents a validated and ready-to-execute tool call.
@@ -74,7 +78,7 @@ export interface ToolInvocation<
    */
   execute(
     signal: AbortSignal,
-    updateOutput?: (output: string | AnsiOutput) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
     terminalColumns?: number,
     terminalRows?: number,
     setPidCallback?: (pid: number) => void,
@@ -419,7 +423,7 @@ export abstract class BaseToolInvocation<
 
   abstract execute(
     signal: AbortSignal,
-    updateOutput?: (output: string | AnsiOutput) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
     terminalColumns?: number,
     terminalRows?: number,
     setPidCallback?: (pid: number) => void,
@@ -577,7 +581,7 @@ export abstract class DeclarativeTool<
   async buildAndExecute(
     params: TParams,
     signal: AbortSignal,
-    updateOutput?: (output: string | AnsiOutput) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<TResult> {
     const invocation = this.build(params);
     return invocation.execute(signal, updateOutput);
@@ -1002,7 +1006,7 @@ export abstract class BaseTool<
   abstract execute(
     params: TParams,
     signal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
   ): Promise<TResult>;
 
   /**
@@ -1043,7 +1047,7 @@ class BaseToolLegacyInvocation<
 
   async execute(
     signal: AbortSignal,
-    updateOutput?: (output: string) => void,
+    updateOutput?: (update: LiveOutputUpdate) => void,
     _terminalColumns?: number,
     _terminalRows?: number,
     _setPidCallback?: (pid: number) => void,

--- a/packages/tools/src/utils/terminalSerializer.ts
+++ b/packages/tools/src/utils/terminalSerializer.ts
@@ -35,3 +35,12 @@ export interface AnsiToken {
 
 export type AnsiLine = AnsiToken[];
 export type AnsiOutput = AnsiLine[];
+
+/**
+ * Explicit tagged update protocol for live-output streaming. Discriminated
+ * by `mode`: text stream producers emit `append` (incremental deltas);
+ * terminal-buffer producers emit `replace` (full snapshots).
+ */
+export type LiveOutputUpdate =
+  | { mode: 'append'; data: string }
+  | { mode: 'replace'; data: AnsiOutput };


### PR DESCRIPTION
## Summary

Replaces the implicit live-output update contract (where string=append and AnsiOutput=replace were inferred from payload shape) with an explicit tagged discriminated union:

    type LiveOutputUpdate =
      | { mode: 'append'; data: string }
      | { mode: 'replace'; data: AnsiOutput }

The append/replace distinction is now declared by producers and switched on exhaustively by accumulators, rather than inferred from the runtime type of the chunk. This eliminates the ambiguity documented in issue #2555, where intermediate layers could accidentally trim, append, replace, or frame output under the wrong contract.

Follow-up to #2555.

## Changes

### Type Foundation
- Define `LiveOutputUpdate` in both `packages/core` and `packages/tools` `terminalSerializer.ts`, mirroring the existing `AnsiOutput` mirroring convention (tools cannot depend on core)
- Thread `LiveOutputUpdate` through `OutputUpdateHandler`, `ToolInvocation.execute`, and all scheduler/agent/CLI callback contracts
- Export from both package entry points

### Mode Switching (accumulators and handlers)
- Rewrite `accumulateLiveOutput` to switch on `update.mode` with an exhaustive `never` default
- Convert all hand-rolled `typeof`-based branches to explicit mode switches:
  - `AgenticLoop.ts`: routes `append` updates into the `tool_output` event queue, forwards both modes to display callback
  - `subagentExecution.ts`: switches on mode, forwards `append` text directly, flattens `replace` AnsiOutput to text
  - `toolControl.wrapInvocation`: down-converts `LiveOutputUpdate` to string for the public `AgentToolInvocation.execute` contract
- Update CLI relay chain (`useReactToolScheduler`, `interactiveToolScheduler`, `useAgentEventStream`, `useAgentStreamOrchestration`) to tagged shape

### Concrete Producers
- Shell tool emits `{ mode: 'replace', data: AnsiOutput }` for PTY snapshots and `{ mode: 'append', data: string }` for non-PTY string deltas
- `CoreShellToolHostAdapter` no longer JSON-stringifies `AnsiOutput` (pre-existing bug fix — the genuine AnsiOutput replace path was effectively unreachable for shell because it was stringified at the adapter)
- Task/subagent text producers (`task.ts`, `taskAsyncExecution.ts`, `invocation.ts`) emit `{ mode: 'append', data }` with no inserted separators

### Tests
- Rewrite `liveOutput.test.ts` with 11 tagged-union tests covering append/append concatenation, replace/replace supersession, and append/reverse transitions
- Add `live-output.behavioral.spec.ts` with 5 behavioral tests for mixed append/replace transitions
- Update all existing producer/scheduler tests to the tagged payload shape

## Non-goals (explicitly preserved)
- `ISubagentService.updateOutput` stays string-only (wrapped at boundary adapter, not migrated to tagged union — subagent streaming is semantically always append-text)
- `AgentToolInvocation.execute` public contract stays string-only (`toolControl.wrapInvocation` down-converts)
- `ExecutingToolCall.liveOutput` stays `string | AnsiOutput` (accumulated result shape, unchanged)
- `ToolResultDisplay.tsx` not modified (renders from accumulated result, unchanged shape)
- Stream adapter consolidation not attempted (separate concern from #2555)

## Acceptance criteria

- [x] Append and replace semantics are represented explicitly in the type system (`LiveOutputUpdate` discriminated union)
- [x] Text stream producers emit append updates without inserted separators
- [x] Terminal-buffer producers emit replace updates
- [x] Scheduler and UI accumulators exhaustively handle both modes (exhaustive `switch` with `never` default)
- [x] Behavioral tests cover mixed append and replace transitions
- [x] Migration does not change rendered output behavior (accumulated result shape unchanged)

## Verification

- `npm run typecheck`: no new errors (68 pre-existing errors on HEAD, all unrelated to this change)
- `npm run lint` + `npm run lint:eslint-guard`: clean (no eslint-disable, @ts-ignore, complexity increases)
- `prettier --check` on all 45 changed files: clean
- Targeted tests: all pass (core scheduler 51 tests, agents 151 tests, CLI 40 tests)
- Pre-existing test failures (12 tests in agents API) and build failure (`FileSystemCapabilities`) confirmed identical on HEAD via git stash

Closes #2586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured live-output updates that distinguish incremental text from full terminal-output replacements.
  * Improved streaming support for tool, shell, and subagent output, including ANSI-formatted content.
* **Bug Fixes**
  * Preserved streamed output correctly across append and replace updates.
  * Improved terminal output handling and validation for streamed chunks.
* **Tests**
  * Expanded coverage for streaming, cancellation, output accumulation, and mode transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->