### PR TITLE
Bump OCR pin in CI from 1.7.16 to 1.7.17 (Fixes #2773)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -88,7 +88,7 @@ env:
   # Disable colorized CLI output so text parsers (e.g. the changed-test
   # scope guard) always see plain text.
   NO_COLOR: '1'
-  OCR_VERSION: '1.7.16'
+  OCR_VERSION: '1.7.17'
   # Issue #2673: workflow_dispatch canaries select OCR concurrency (2, 3, or
   # 4). All other (automatic/comment) triggers resolve to the evidence-backed
   # default of 3 (canary 3 showed 43% speedup over 2 with zero 429s/retries).

--- a/scripts/tests/ocr-concurrency-canary-2673.test.js
+++ b/scripts/tests/ocr-concurrency-canary-2673.test.js
@@ -69,7 +69,7 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
     it('does not alter the review pin, model, range, timeout, audience, or format', () => {
       const reviewStep = stepNamed(codeReviewJob, 'Run OpenCodeReview');
       const reviewRun = commandText(reviewStep);
-      expect(workflow.env?.OCR_VERSION).toBe('1.7.16');
+      expect(workflow.env?.OCR_VERSION).toBe('1.7.17');
       expect(reviewStep.env?.OCR_LLM_MODEL).toBe('${{ vars.OCR_LLM_MODEL }}');
       expect(reviewStep.env?.FROM_SHA).toBe(
         "${{ github.event_name == 'workflow_dispatch' && env.MERGE_BASE_SHA || steps.resolve-range.outputs.FROM_SHA }}",


### PR DESCRIPTION
## Summary

Bumps the OpenCodeReview (OCR) version pin in the CI workflow from `1.7.16` to `1.7.17`, the latest patch release published to npm on 2026-07-26.

## Context

The `ocr-review.yml` workflow pins OCR via `OCR_VERSION` (with `OCR_NO_UPDATE: '1'`) to keep CI reviews deterministic. The pin must be bumped explicitly to pick up upstream patches.

- Latest published: `@alibaba-group/open-code-review@1.7.17`
- Previous pin: `1.7.16`
- The 1.7.17 release updates both the main package and the platform-specific native binaries (e.g. `@alibaba-group/ocr-darwin-arm64@1.7.17`).

## Changes

- `.github/workflows/ocr-review.yml`: `OCR_VERSION: '1.7.16'` → `OCR_VERSION: '1.7.17'`

## Verification

- Confirmed `@alibaba-group/open-code-review@1.7.17` is the `latest` dist-tag on npm.
- Verified locally that `ocr --version` reports `v1.7.17` after install.
- Single-line change to the env var; no workflow logic or rule config changes.

Fixes #2773