### PR TITLE
Fix macOS CI flake: run release-install smoke test separately (Fixes #2780)

### DIFF
--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -254,8 +254,19 @@ function createRunnerWithPATH(rootDir: string): CommandRunner {
 // Orchestration
 // ---------------------------------------------------------------------------
 
-const SCRIPTS_TEST_COMMAND =
-  'vitest run --config ./scripts/tests/vitest.config.ts';
+// The release-install smoke test (issue #2603) takes ~175–195s because it
+// packs a CLI tarball and runs three npm installs. Running it inside the same
+// vitest worker pool as the ~169 fast script tests congests the vitest main
+// process: the worker's onTaskUpdate RPC call cannot get a response within
+// birpc's hardcoded 60s timeout (DEFAULT_TIMEOUT in vitest's birpc), causing a
+// spurious `[vitest-worker]: Timeout calling "onTaskUpdate"` error and exit
+// code 1 even though every test passed. This is not configurable via vitest
+// config. (issue #2780)
+const RELEASE_INSTALL_SLOW_TEST =
+  'scripts/tests/issue-2603-release-install.test.ts';
+
+const SCRIPTS_TEST_COMMAND = `vitest run --config ./scripts/tests/vitest.config.ts --exclude ${RELEASE_INSTALL_SLOW_TEST}`;
+const SCRIPTS_SLOW_TEST_COMMAND = `vitest run --config ./scripts/tests/vitest.config.ts ${RELEASE_INSTALL_SLOW_TEST}`;
 const SCRIPTS_TEST_CONFIG = 'scripts/tests/vitest.config.ts';
 
 function matchesFilter(workspace: WorkspaceInfo, filter: string): boolean {
@@ -464,14 +475,29 @@ function runScriptTests(
   if (!existsSync(scriptConfigPath)) {
     return;
   }
-  const scriptResult = runPhase(
+  const mainResult = runPhase(
     'scripts',
     'scripts',
     SCRIPTS_TEST_COMMAND,
     rootDir,
     runner,
   );
-  results.push(scriptResult);
+  results.push(mainResult);
+
+  // The release-install smoke test runs as a separate vitest invocation so it
+  // never shares a worker pool with the fast script tests. This eliminates the
+  // vitest worker RPC timeout (issue #2780). Fail-fast: skip it if the main
+  // suite already failed.
+  if (mainResult.success) {
+    const slowResult = runPhase(
+      'scripts',
+      'scripts',
+      SCRIPTS_SLOW_TEST_COMMAND,
+      rootDir,
+      runner,
+    );
+    results.push(slowResult);
+  }
 }
 
 function buildSummary(

--- a/scripts/tests/test-shard-orchestrator.test.ts
+++ b/scripts/tests/test-shard-orchestrator.test.ts
@@ -275,4 +275,101 @@ describe('orchestrateTests (--shard)', () => {
     expect(scriptsResult!.success).toBe(false);
     expect(summary.results.some((r) => !r.success)).toBe(true);
   });
+
+  // Issue #2780: the long-running release-install smoke test
+  // (issue-2603-release-install.test.ts) must run as a SEPARATE vitest
+  // invocation so it does not share a worker pool with the ~169 fast script
+  // tests. When it did, the vitest worker RPC (onTaskUpdate) timed out under
+  // main-process congestion on macOS runners (3 vCPUs), causing a spurious
+  // exit code 1 even though every test passed.
+  it('runs the release-install smoke test as a separate vitest invocation', () => {
+    const { runner, commands } = createRecordingRunner();
+
+    const fixtureRoot = createFixtureRepo([
+      {
+        dir: 'packages/cli',
+        name: '@scope/cli',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+    mkdirSync(join(fixtureRoot, 'scripts', 'tests'), { recursive: true });
+    writeFileSync(
+      join(fixtureRoot, 'scripts', 'tests', 'vitest.config.ts'),
+      'export default {};',
+    );
+
+    orchestrateTests(
+      fixtureRoot,
+      { ...parseArgs(['--shard', 'scripts']) },
+      runner,
+    );
+
+    const scriptsCommands = commands.filter((c) =>
+      c.command.includes('scripts/tests/vitest.config.ts'),
+    );
+    // Two invocations: the main scripts suite (excluding the slow smoke) and
+    // a dedicated invocation for the release-install smoke test.
+    expect(scriptsCommands).toHaveLength(2);
+
+    // The main invocation must exclude the slow release-install test so it
+    // never shares a worker pool with the fast tests, and the slow test must
+    // run as a separate invocation without --exclude.
+    const hasExcludedInvocation = scriptsCommands.some(
+      (c) =>
+        c.command.includes('--exclude') &&
+        c.command.includes('issue-2603-release-install.test.ts'),
+    );
+    const hasDirectInvocation = scriptsCommands.some(
+      (c) =>
+        !c.command.includes('--exclude') &&
+        c.command.includes('issue-2603-release-install.test.ts'),
+    );
+    expect(hasExcludedInvocation).toBe(true);
+    expect(hasDirectInvocation).toBe(true);
+  });
+
+  it('skips the release-install smoke invocation when the main scripts suite fails', () => {
+    const commands: Array<{ command: string; cwd: string }> = [];
+    const runner: CommandRunner = (command, cwd) => {
+      commands.push({ command, cwd });
+      // Fail only the main scripts suite (the one with --exclude); pass
+      // everything else so the slow invocation is the only thing that could
+      // run.
+      if (
+        command.includes('scripts/tests/vitest.config.ts') &&
+        command.includes('--exclude')
+      ) {
+        return { success: false, exitCode: 1 };
+      }
+      return { success: true, exitCode: 0 };
+    };
+
+    const fixtureRoot = createFixtureRepo([
+      {
+        dir: 'packages/cli',
+        name: '@scope/cli',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+    mkdirSync(join(fixtureRoot, 'scripts', 'tests'), { recursive: true });
+    writeFileSync(
+      join(fixtureRoot, 'scripts', 'tests', 'vitest.config.ts'),
+      'export default {};',
+    );
+
+    orchestrateTests(
+      fixtureRoot,
+      { ...parseArgs(['--shard', 'scripts']) },
+      runner,
+    );
+
+    // The slow smoke invocation must NOT run when the main suite failed
+    // (fail-fast semantics).
+    const slowCommand = commands.filter(
+      (c) =>
+        c.command.includes('issue-2603-release-install.test.ts') &&
+        !c.command.includes('--exclude'),
+    );
+    expect(slowCommand).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

The macOS CI scripts shard was intermittently failing with a `vitest-worker: Timeout calling "onTaskUpdate"` error and spurious exit code 1, even though every test passed.

## Root cause

The release-install smoke test (`scripts/tests/issue-2603-release-install.test.ts`) takes ~175–195s because it packs a CLI tarball and runs three npm installs. Running it inside the same vitest worker pool as the ~169 fast script tests congested the vitest main process: the worker's `onTaskUpdate` RPC call could not get a response within birpc's hardcoded 60s timeout (`DEFAULT_TIMEOUT = 6e4` in vitest's birpc), causing the spurious timeout error.

This timeout is **not configurable** via vitest config or env vars. The birpc `DEFAULT_TIMEOUT` is hardcoded and pool modules call `createBirpc()` without passing a `timeout` option.

## The fix

Run the slow test as a **separate vitest invocation** so it never shares a worker pool with the fast tests:

1. The main scripts suite (`SCRIPTS_TEST_COMMAND`) now uses `--exclude` to omit `issue-2603-release-install.test.ts`.
2. A dedicated second invocation (`SCRIPTS_SLOW_TEST_COMMAND`) runs the slow test directly.
3. **Fail-fast**: the slow invocation is skipped if the main suite fails.

This is scoped to the scripts shard only.

## Files changed

- `scripts/test.ts` — added `SCRIPTS_SLOW_TEST_COMMAND` constant and modified `runScriptTests` to run two invocations (main suite with `--exclude`, then the slow test separately if the main suite passed).
- `scripts/tests/test-shard-orchestrator.test.ts` — added two behavioral tests verifying (a) the scripts shard produces two vitest invocations with the correct `--exclude` / direct-run structure, and (b) the slow invocation is skipped when the main suite fails (fail-fast).

## Test plan

- [x] TDD: wrote failing behavioral tests first (RED), then implemented to make them pass (GREEN).
- [x] All orchestrator tests pass (12/12 shard-orchestrator, 54/54 orchestrator+shards).
- [x] ESLint clean on changed files.
- [x] Prettier clean.
- [x] Smoke test passes.
- [x] Open Code Review (ocr) run — addressed the one finding (strengthened a weak assertion).

## Notes

- Pre-existing typecheck errors (`LiveOutputUpdate` from PR #2750) and build errors (`FileSystemCapabilities` in zed-integration) are unrelated to this change — confirmed present on main.
- The `VITEST_MAX_FORKS=1` workaround (added in PR #2775) is left in place; it remains a useful belt-and-suspenders mitigation for the broader worker-pool congestion. This PR addresses the root cause for the scripts shard specifically.

Fixes #2780