### PR TITLE
fix(core): escalate hung hooks to SIGKILL after SIGTERM

### DIFF
--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -322,11 +322,11 @@ describe('HookRunner', () => {
           );
 
           await vi.advanceTimersByTimeAsync(50);
-          expect(signals).toEqual(['SIGTERM']);
+          expect(signals).toStrictEqual(['SIGTERM']);
           expect(mockSpawn.killed).toBe(true);
 
           await vi.advanceTimersByTimeAsync(5000);
-          expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+          expect(signals).toStrictEqual(['SIGTERM', 'SIGKILL']);
 
           const result = await resultPromise;
           expect(result.success).toBe(false);

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -277,6 +277,65 @@ describe('HookRunner', () => {
         expect(mockSpawn.kill).toHaveBeenCalledWith('SIGTERM');
       });
 
+      it('should escalate to SIGKILL when the process ignores SIGTERM', async () => {
+        vi.useFakeTimers();
+        const shortTimeoutConfig: HookConfig = {
+          type: HookType.Command,
+          command: './hooks/slow.sh',
+          timeout: 50,
+        };
+
+        let closeCallback: ((code: number) => void) | undefined;
+        const signals: string[] = [];
+
+        Object.assign(mockSpawn, {
+          exitCode: null,
+          signalCode: null,
+          killed: false,
+        });
+
+        mockSpawn.mockProcessOn.mockImplementation(
+          (event: string, callback: (code: number) => void) => {
+            if (event === 'close') {
+              closeCallback = callback;
+            }
+          },
+        );
+
+        mockSpawn.kill = vi.fn().mockImplementation((signal: string) => {
+          signals.push(signal);
+          // Node sets killed=true when the signal is sent, even if ignored.
+          mockSpawn.killed = true;
+          if (signal === 'SIGKILL' && closeCallback) {
+            mockSpawn.exitCode = null;
+            mockSpawn.signalCode = 'SIGKILL';
+            queueMicrotask(() => closeCallback!(137));
+          }
+          return true;
+        });
+
+        try {
+          const resultPromise = hookRunner.executeHook(
+            shortTimeoutConfig,
+            HookEventName.BeforeTool,
+            mockInput,
+          );
+
+          await vi.advanceTimersByTimeAsync(50);
+          expect(signals).toEqual(['SIGTERM']);
+          expect(mockSpawn.killed).toBe(true);
+
+          await vi.advanceTimersByTimeAsync(5000);
+          expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+
+          const result = await resultPromise;
+          expect(result.success).toBe(false);
+          expect(result.error?.message).toContain('timed out');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
       it('should expand environment variables in commands', async () => {
         const configWithEnvVar: HookConfig = {
           type: HookType.Command,

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -299,7 +299,7 @@ export class HookRunner {
 
       const child = this.spawnHookProcess(hookConfig, input);
 
-      const timeoutHandle = this.setupKillTimeout(child, timeout, () => {
+      const timeoutControl = this.setupKillTimeout(child, timeout, () => {
         timedOut = true;
       });
 
@@ -314,7 +314,7 @@ export class HookRunner {
       });
 
       child.on('close', (exitCode) => {
-        clearTimeout(timeoutHandle);
+        timeoutControl.clear();
         const duration = Date.now() - startTime;
         if (timedOut) {
           resolve(
@@ -342,7 +342,7 @@ export class HookRunner {
       });
 
       child.on('error', (error) => {
-        clearTimeout(timeoutHandle);
+        timeoutControl.clear();
         resolve(
           this.errorResult(
             hookConfig,
@@ -373,20 +373,37 @@ export class HookRunner {
     };
   }
 
+  /**
+   * Sends SIGTERM after `timeout`, then escalates to SIGKILL if the child is
+   * still running. Do not use `child.killed` for escalation — Node sets that
+   * when a signal is *sent*, not when the process exits, so SIGTERM-ignoring
+   * hooks would never receive SIGKILL and could hang forever.
+   */
   private setupKillTimeout(
     child: ReturnType<typeof spawn>,
     timeout: number,
     onTimeout: () => void,
-  ): NodeJS.Timeout {
-    return setTimeout(() => {
+  ): { clear: () => void } {
+    let forceKillHandle: NodeJS.Timeout | undefined;
+    const timeoutHandle = setTimeout(() => {
       onTimeout();
       child.kill('SIGTERM');
-      setTimeout(() => {
-        if (!child.killed) {
+      forceKillHandle = setTimeout(() => {
+        // Still running only when both exit indicators remain null.
+        if (child.exitCode === null && child.signalCode === null) {
           child.kill('SIGKILL');
         }
       }, 5000);
     }, timeout);
+
+    return {
+      clear: () => {
+        clearTimeout(timeoutHandle);
+        if (forceKillHandle !== undefined) {
+          clearTimeout(forceKillHandle);
+        }
+      },
+    };
   }
 
   private timeoutResult(


### PR DESCRIPTION
## TLDR

Fix hung hook timeout escalation: processes that ignore `SIGTERM` now get `SIGKILL` after the grace period, so timed-out hooks cannot block the agent forever.

## Dive Deeper

`setupKillTimeout` previously checked `child.killed` before sending `SIGKILL`. In Node.js that flag is set when a signal is *sent*, not when the child exits, so SIGTERM-ignoring hooks never escalated. The timeout controller now checks `exitCode`/`signalCode` and clears both kill timers on close/error.

## Reviewer Test Plan

1. Pull the branch and run:
   `npm run test -w @vybestack/llxprt-code-core -- src/hooks/hookRunner.test.ts`
2. Confirm the new test proves `SIGTERM` then `SIGKILL` when the mock process ignores the first signal.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved command-hook timeout handling for processes that ignore termination signals.
  * Added reliable escalation from graceful termination to forced termination after the additional timeout window.
  * Hook failures now consistently report timeout-related errors.
* **Tests**
  * Added coverage for timeout escalation behavior and verified signal order using fake timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->