### PR TITLE
fix(cli): write /bug transcripts with exclusive 0600 temp files

### DIFF
--- a/packages/cli/src/ui/utils/historyExportUtils.test.ts
+++ b/packages/cli/src/ui/utils/historyExportUtils.test.ts
@@ -6,10 +6,26 @@
 
 import type { IContent } from '@vybestack/llxprt-code-core';
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFile, unlink, stat, open } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+const { mockRandomBytes } = vi.hoisted(() => ({
+  mockRandomBytes: vi.fn(),
+}));
+
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:crypto')>();
+  mockRandomBytes.mockImplementation((size: number) =>
+    actual.randomBytes(size),
+  );
+  return {
+    ...actual,
+    randomBytes: mockRandomBytes,
+  };
+});
+
 import {
   sanitizeTranscript,
   exportHistoryForBugReport,
@@ -309,30 +325,50 @@ describe('historyExportUtils', () => {
       await unlink(result2.filePath).catch(() => {});
     });
 
-    it('should refuse to overwrite an existing path (exclusive create)', async () => {
-      const existingPath = join(
-        tmpdir(),
-        `llxprt-bug-report-collision-${Date.now()}.md`,
+    it('should retry when the exporter candidate path already exists', async () => {
+      const actualCrypto = await vi.importActual<typeof import('node:crypto')>(
+        'node:crypto',
       );
-      const handle = await open(existingPath, 'wx', 0o600);
-      await handle.writeFile('preexisting', 'utf-8');
-      await handle.close();
+      const fixedTime = '2026-07-28T12:34:56.789Z';
+      const firstRandom = Buffer.alloc(8, 1);
+      const secondRandom = Buffer.alloc(8, 2);
+      const stamped = fixedTime.replace(/[:.]/g, '-');
+      const collidedPath = join(
+        tmpdir(),
+        `llxprt-bug-report-${stamped}-${firstRandom.toString('hex')}.md`,
+      );
 
-      await expect(open(existingPath, 'wx', 0o600)).rejects.toMatchObject({
-        code: 'EEXIST',
-      });
+      const dateSpy = vi
+        .spyOn(Date.prototype, 'toISOString')
+        .mockReturnValue(fixedTime);
+      mockRandomBytes
+        .mockImplementationOnce(() => firstRandom)
+        .mockImplementationOnce(() => secondRandom);
 
-      const history: IContent[] = [
-        {
-          speaker: 'human',
-          blocks: [{ type: 'text', text: 'Test' }],
-        },
-      ];
-      const result = await exportHistoryForBugReport(history);
-      exportedFilePath = result.filePath;
-      expect(result.filePath).not.toBe(existingPath);
+      const preexisting = await open(collidedPath, 'wx', 0o600);
+      await preexisting.writeFile('preexisting', 'utf-8');
+      await preexisting.close();
 
-      await unlink(existingPath).catch(() => {});
+      try {
+        const history: IContent[] = [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'Test' }],
+          },
+        ];
+        const result = await exportHistoryForBugReport(history);
+        exportedFilePath = result.filePath;
+
+        expect(result.filePath).not.toBe(collidedPath);
+        expect(result.filePath).toContain(secondRandom.toString('hex'));
+        expect(await readFile(collidedPath, 'utf-8')).toBe('preexisting');
+      } finally {
+        dateSpy.mockRestore();
+        mockRandomBytes.mockImplementation((size: number) =>
+          actualCrypto.randomBytes(size),
+        );
+        await unlink(collidedPath).catch(() => {});
+      }
     });
   });
 });

--- a/packages/cli/src/ui/utils/historyExportUtils.test.ts
+++ b/packages/cli/src/ui/utils/historyExportUtils.test.ts
@@ -326,9 +326,8 @@ describe('historyExportUtils', () => {
     });
 
     it('should retry when the exporter candidate path already exists', async () => {
-      const actualCrypto = await vi.importActual<typeof import('node:crypto')>(
-        'node:crypto',
-      );
+      const actualCrypto =
+        await vi.importActual<typeof import('node:crypto')>('node:crypto');
       const fixedTime = '2026-07-28T12:34:56.789Z';
       const firstRandom = Buffer.alloc(8, 1);
       const secondRandom = Buffer.alloc(8, 2);

--- a/packages/cli/src/ui/utils/historyExportUtils.test.ts
+++ b/packages/cli/src/ui/utils/historyExportUtils.test.ts
@@ -7,8 +7,9 @@
 import type { IContent } from '@vybestack/llxprt-code-core';
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFile, unlink } from 'node:fs/promises';
+import { readFile, unlink, stat, open } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   sanitizeTranscript,
   exportHistoryForBugReport,
@@ -282,6 +283,56 @@ describe('historyExportUtils', () => {
 
       // Clean up second file
       await unlink(result2.filePath).catch(() => {});
+    });
+
+    it('should create owner-only files and avoid colliding exports', async () => {
+      const history: IContent[] = [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'secret path /home/user/.ssh' }],
+        },
+      ];
+
+      const [result1, result2] = await Promise.all([
+        exportHistoryForBugReport(history),
+        exportHistoryForBugReport(history),
+      ]);
+      exportedFilePath = result1.filePath;
+
+      expect(result1.filePath).not.toBe(result2.filePath);
+
+      if (process.platform !== 'win32') {
+        const mode = (await stat(result1.filePath)).mode & 0o777;
+        expect(mode).toBe(0o600);
+      }
+
+      await unlink(result2.filePath).catch(() => {});
+    });
+
+    it('should refuse to overwrite an existing path (exclusive create)', async () => {
+      const existingPath = join(
+        tmpdir(),
+        `llxprt-bug-report-collision-${Date.now()}.md`,
+      );
+      const handle = await open(existingPath, 'wx', 0o600);
+      await handle.writeFile('preexisting', 'utf-8');
+      await handle.close();
+
+      await expect(open(existingPath, 'wx', 0o600)).rejects.toMatchObject({
+        code: 'EEXIST',
+      });
+
+      const history: IContent[] = [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+      const result = await exportHistoryForBugReport(history);
+      exportedFilePath = result.filePath;
+      expect(result.filePath).not.toBe(existingPath);
+
+      await unlink(existingPath).catch(() => {});
     });
   });
 });

--- a/packages/cli/src/ui/utils/historyExportUtils.test.ts
+++ b/packages/cli/src/ui/utils/historyExportUtils.test.ts
@@ -301,7 +301,7 @@ describe('historyExportUtils', () => {
       await unlink(result2.filePath).catch(() => {});
     });
 
-    it('should create owner-only files and avoid colliding exports', async () => {
+    it('should create distinct files for concurrent exports', async () => {
       const history: IContent[] = [
         {
           speaker: 'human',
@@ -317,13 +317,26 @@ describe('historyExportUtils', () => {
 
       expect(result1.filePath).not.toBe(result2.filePath);
 
-      if (process.platform !== 'win32') {
-        const mode = (await stat(result1.filePath)).mode & 0o777;
-        expect(mode).toBe(0o600);
-      }
-
       await unlink(result2.filePath).catch(() => {});
     });
+
+    it.skipIf(process.platform === 'win32')(
+      'should set owner-only permissions on exported transcripts',
+      async () => {
+        const history: IContent[] = [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'permission check' }],
+          },
+        ];
+
+        const result = await exportHistoryForBugReport(history);
+        exportedFilePath = result.filePath;
+
+        const mode = (await stat(result.filePath)).mode & 0o777;
+        expect(mode).toBe(0o600);
+      },
+    );
 
     it('should retry when the exporter candidate path already exists', async () => {
       const actualCrypto =

--- a/packages/cli/src/ui/utils/historyExportUtils.ts
+++ b/packages/cli/src/ui/utils/historyExportUtils.ts
@@ -190,8 +190,7 @@ export async function exportHistoryForBugReport(
   // residual credentials/paths in the transcript from being world-readable.
   // Retry a few times if another process raced us for the same name.
   const maxAttempts = 3;
-  let lastError: unknown;
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+  for (let attempt = 0; ; attempt++) {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const random = nodeCrypto.randomBytes(8).toString('hex');
     const filename = `llxprt-bug-report-${timestamp}-${random}.md`;
@@ -206,7 +205,6 @@ export async function exportHistoryForBugReport(
       }
       return { filePath, sanitized };
     } catch (error) {
-      lastError = error;
       if (
         error instanceof Error &&
         'code' in error &&
@@ -218,8 +216,4 @@ export async function exportHistoryForBugReport(
       throw error;
     }
   }
-
-  throw lastError instanceof Error
-    ? lastError
-    : new Error('Failed to create exclusive bug report file');
 }

--- a/packages/cli/src/ui/utils/historyExportUtils.ts
+++ b/packages/cli/src/ui/utils/historyExportUtils.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { writeFile } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { open } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ContentBlock, IContent } from '@vybestack/llxprt-code-core';
@@ -184,13 +185,20 @@ export async function exportHistoryForBugReport(
   // Sanitize the transcript
   const sanitized = sanitizeTranscript(markdown);
 
-  // Generate filename with timestamp
+  // Exclusive create with a random suffix so concurrent exports cannot
+  // collide or follow a pre-existing path/symlink. Owner-only mode keeps
+  // residual credentials/paths in the transcript from being world-readable.
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const filename = `llxprt-bug-report-${timestamp}.md`;
+  const random = randomBytes(8).toString('hex');
+  const filename = `llxprt-bug-report-${timestamp}-${random}.md`;
   const filePath = join(tmpdir(), filename);
 
-  // Write to temp directory
-  await writeFile(filePath, sanitized, 'utf-8');
+  const handle = await open(filePath, 'wx', 0o600);
+  try {
+    await handle.writeFile(sanitized, 'utf-8');
+  } finally {
+    await handle.close();
+  }
 
   return { filePath, sanitized };
 }

--- a/packages/cli/src/ui/utils/historyExportUtils.ts
+++ b/packages/cli/src/ui/utils/historyExportUtils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomBytes } from 'node:crypto';
+import * as nodeCrypto from 'node:crypto';
 import { open } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -188,17 +188,38 @@ export async function exportHistoryForBugReport(
   // Exclusive create with a random suffix so concurrent exports cannot
   // collide or follow a pre-existing path/symlink. Owner-only mode keeps
   // residual credentials/paths in the transcript from being world-readable.
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const random = randomBytes(8).toString('hex');
-  const filename = `llxprt-bug-report-${timestamp}-${random}.md`;
-  const filePath = join(tmpdir(), filename);
+  // Retry a few times if another process raced us for the same name.
+  const maxAttempts = 3;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const random = nodeCrypto.randomBytes(8).toString('hex');
+    const filename = `llxprt-bug-report-${timestamp}-${random}.md`;
+    const filePath = join(tmpdir(), filename);
 
-  const handle = await open(filePath, 'wx', 0o600);
-  try {
-    await handle.writeFile(sanitized, 'utf-8');
-  } finally {
-    await handle.close();
+    try {
+      const handle = await open(filePath, 'wx', 0o600);
+      try {
+        await handle.writeFile(sanitized, 'utf-8');
+      } finally {
+        await handle.close();
+      }
+      return { filePath, sanitized };
+    } catch (error) {
+      lastError = error;
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        error.code === 'EEXIST' &&
+        attempt < maxAttempts - 1
+      ) {
+        continue;
+      }
+      throw error;
+    }
   }
 
-  return { filePath, sanitized };
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Failed to create exclusive bug report file');
 }


### PR DESCRIPTION
## TLDR

Harden `/bug` transcript export: exclusive create, owner-only `0600` permissions, random suffix, and retry on path collision so transcripts are not world-readable or overwritten.

## Dive Deeper

Previously exports used a timestamp-only name in the shared temp dir with default permissions. This PR writes with `open(..., 'wx', 0o600)`, adds a cryptographically random suffix, and retries on `EEXIST` without following/overwriting a pre-existing path.

## Reviewer Test Plan

1. `npm run test -w @vybestack/llxprt-code -- src/ui/utils/historyExportUtils.test.ts`
2. Confirm the collision test pre-creates the exporter’s exact candidate path and proves a retry to a new file without overwriting the preexisting content.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bug-report history exports to prevent file-name collisions during simultaneous exports.
  * Export now avoids overwriting existing export files; collisions trigger a new generated path instead.
  * Temporary exported files are created with owner-only permissions for better privacy.
  * Added retry handling when temporary file creation encounters conflicts.
* **Tests**
  * Strengthened coverage for deterministic collision behavior, distinct outputs under concurrency, and permission settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->