### PR TITLE
fix(cli): validate extension-enablement.json before use

### DIFF
--- a/packages/cli/src/config/extensions/extensionEnablement.test.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.test.ts
@@ -426,6 +426,59 @@ describe('ExtensionEnablementManager', () => {
       expect(manager.isEnabled('ext-b', '/any/path')).toBe(false);
     });
   });
+
+  describe('malformed enablement config', () => {
+    let coreEventsEmitSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      coreEventsEmitSpy = vi.spyOn(coreEvents, 'emitFeedback');
+    });
+
+    afterEach(() => {
+      coreEventsEmitSpy.mockRestore();
+    });
+
+    function writeEnablementConfig(content: string): void {
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(configDir, 'extension-enablement.json'),
+        content,
+      );
+    }
+
+    it.each([
+      ['null root', 'null'],
+      ['array root', '[]'],
+      ['string root', '"oops"'],
+      ['non-object extension entry', '{"ext-test":"bad"}'],
+      ['non-array overrides', '{"ext-test":{"overrides":{}}}'],
+      ['non-string override rules', '{"ext-test":{"overrides":[1,2]}}'],
+    ])(
+      'should ignore %s and keep extensions enabled by default',
+      (_label, content) => {
+        writeEnablementConfig(content);
+        const localManager = new ExtensionEnablementManager(configDir);
+
+        expect(localManager.isEnabled('ext-test', '/any/path')).toBe(true);
+        expect(coreEventsEmitSpy).toHaveBeenCalledWith(
+          'error',
+          'Invalid extension enablement config; ignoring malformed file.',
+        );
+      },
+    );
+
+    it('should still apply valid config shapes', () => {
+      writeEnablementConfig(
+        JSON.stringify({
+          'ext-test': { overrides: ['!/any/path/'] },
+        }),
+      );
+      const localManager = new ExtensionEnablementManager(configDir);
+
+      expect(localManager.isEnabled('ext-test', '/any/path')).toBe(false);
+      expect(coreEventsEmitSpy).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('Override', () => {

--- a/packages/cli/src/config/extensions/extensionEnablement.test.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.test.ts
@@ -471,20 +471,17 @@ describe('ExtensionEnablementManager', () => {
       ['truncated JSON', '{bad'],
       ['empty file', ''],
       ['whitespace only', '   '],
-    ])(
-      'should fall back when the file has %s',
-      (_label, content) => {
-        writeEnablementConfig(content);
-        const localManager = new ExtensionEnablementManager(configDir);
+    ])('should fall back when the file has %s', (_label, content) => {
+      writeEnablementConfig(content);
+      const localManager = new ExtensionEnablementManager(configDir);
 
-        expect(localManager.isEnabled('ext-test', '/any/path')).toBe(true);
-        expect(coreEventsEmitSpy).toHaveBeenCalledWith(
-          'error',
-          'Failed to read extension enablement config.',
-          expect.anything(),
-        );
-      },
-    );
+      expect(localManager.isEnabled('ext-test', '/any/path')).toBe(true);
+      expect(coreEventsEmitSpy).toHaveBeenCalledWith(
+        'error',
+        'Failed to read extension enablement config.',
+        expect.anything(),
+      );
+    });
 
     it('should still apply valid config shapes', () => {
       writeEnablementConfig(

--- a/packages/cli/src/config/extensions/extensionEnablement.test.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.test.ts
@@ -467,6 +467,25 @@ describe('ExtensionEnablementManager', () => {
       },
     );
 
+    it.each([
+      ['truncated JSON', '{bad'],
+      ['empty file', ''],
+      ['whitespace only', '   '],
+    ])(
+      'should fall back when the file has %s',
+      (_label, content) => {
+        writeEnablementConfig(content);
+        const localManager = new ExtensionEnablementManager(configDir);
+
+        expect(localManager.isEnabled('ext-test', '/any/path')).toBe(true);
+        expect(coreEventsEmitSpy).toHaveBeenCalledWith(
+          'error',
+          'Failed to read extension enablement config.',
+          expect.anything(),
+        );
+      },
+    );
+
     it('should still apply valid config shapes', () => {
       writeEnablementConfig(
         JSON.stringify({

--- a/packages/cli/src/config/extensions/extensionEnablement.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.ts
@@ -300,6 +300,32 @@ export class ExtensionEnablementManager {
 }
 
 /**
+ * Validates a single extension enablement entry.
+ * Returns `undefined` to skip, `null` if invalid, otherwise the entry.
+ */
+function parseExtensionEntry(
+  entry: unknown,
+): ExtensionEnablementConfig | null | undefined {
+  if (entry === undefined) {
+    return undefined;
+  }
+  if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+    return null;
+  }
+  const overrides = (entry as { overrides?: unknown }).overrides;
+  if (overrides === undefined) {
+    return { overrides: [] };
+  }
+  if (
+    !Array.isArray(overrides) ||
+    !overrides.every((rule) => typeof rule === 'string')
+  ) {
+    return null;
+  }
+  return { overrides };
+}
+
+/**
  * Validates extension-enablement.json. Returns null for structurally invalid
  * JSON so callers can fall back safely instead of throwing at startup.
  */
@@ -314,24 +340,13 @@ function parseRuntimeEnablementConfig(
   for (const [name, entry] of Object.entries(
     value as Record<string, unknown>,
   )) {
-    if (entry === undefined) {
-      continue;
-    }
-    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+    const parsed = parseExtensionEntry(entry);
+    if (parsed === null) {
       return null;
     }
-    const overrides = (entry as { overrides?: unknown }).overrides;
-    if (overrides === undefined) {
-      result[name] = { overrides: [] };
-      continue;
+    if (parsed !== undefined) {
+      result[name] = parsed;
     }
-    if (
-      !Array.isArray(overrides) ||
-      !overrides.every((rule) => typeof rule === 'string')
-    ) {
-      return null;
-    }
-    result[name] = { overrides };
   }
   return result;
 }

--- a/packages/cli/src/config/extensions/extensionEnablement.ts
+++ b/packages/cli/src/config/extensions/extensionEnablement.ts
@@ -202,7 +202,16 @@ export class ExtensionEnablementManager {
   private readRuntimeConfig(): RuntimeAllExtensionsEnablementConfig {
     try {
       const content = fs.readFileSync(this.configFilePath, 'utf-8');
-      return JSON.parse(content) as RuntimeAllExtensionsEnablementConfig;
+      const parsed: unknown = JSON.parse(content);
+      const validated = parseRuntimeEnablementConfig(parsed);
+      if (validated === null) {
+        coreEvents.emitFeedback(
+          'error',
+          'Invalid extension enablement config; ignoring malformed file.',
+        );
+        return {};
+      }
+      return validated;
     } catch (error) {
       if (
         error instanceof Error &&
@@ -288,4 +297,41 @@ export class ExtensionEnablementManager {
   resetSessionState(): void {
     this.sessionState.clear();
   }
+}
+
+/**
+ * Validates extension-enablement.json. Returns null for structurally invalid
+ * JSON so callers can fall back safely instead of throwing at startup.
+ */
+function parseRuntimeEnablementConfig(
+  value: unknown,
+): RuntimeAllExtensionsEnablementConfig | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const result: RuntimeAllExtensionsEnablementConfig = {};
+  for (const [name, entry] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
+    if (entry === undefined) {
+      continue;
+    }
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      return null;
+    }
+    const overrides = (entry as { overrides?: unknown }).overrides;
+    if (overrides === undefined) {
+      result[name] = { overrides: [] };
+      continue;
+    }
+    if (
+      !Array.isArray(overrides) ||
+      !overrides.every((rule) => typeof rule === 'string')
+    ) {
+      return null;
+    }
+    result[name] = { overrides };
+  }
+  return result;
 }

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -454,8 +454,10 @@ describe('recorded ACP session listing', () => {
       const updatedAt = result.sessions[0].updatedAt;
       expect(updatedAt).toBeDefined();
       expect(new Date(updatedAt ?? '').toISOString()).toBe(updatedAt);
+      // Allow 1ms of clock granularity: Date.now() around construction can
+      // otherwise flake with "expected T to be >= T+1" under load.
       expect(new Date(updatedAt ?? '').getTime()).toBeGreaterThanOrEqual(
-        startedAt,
+        startedAt - 1,
       );
       expect(new Date(updatedAt ?? '').getTime()).toBeLessThanOrEqual(
         Date.now(),


### PR DESCRIPTION
## TLDR

Validate `extension-enablement.json` before use so malformed-but-parseable JSON cannot crash CLI startup when extensions are loaded.

## Dive Deeper

`readRuntimeConfig` previously cast any successful `JSON.parse` result. Values like `null`, arrays, or non-array `overrides` then threw inside `isEnabled()`. The manager now validates the structure and falls back to `{}` with error feedback when invalid.

## Reviewer Test Plan

1. `npm run test -w @vybestack/llxprt-code -- src/config/extensions/extensionEnablement.test.ts`
2. Write `null` / `{"ext":{"overrides":{}}}` into `extension-enablement.json` and confirm `isEnabled` stays safe and emits feedback.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or unreadable extension configuration files.
  * Extensions now remain enabled when configuration data is invalid or cannot be read.
  * Added clearer error feedback when an extension configuration is ignored.
  * Valid configuration overrides continue to be applied correctly.
* **Tests**
  * Reduced test flakiness by relaxing a timestamp assertion for session listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->