### PR TITLE
Add liveness heartbeat to synchronous Task subagents (Fixes #2540)

### DIFF
--- a/packages/agents/src/api/control/toolControl.ts
+++ b/packages/agents/src/api/control/toolControl.ts
@@ -388,6 +388,11 @@ function wrapInvocation(invocation: AnyToolInvocation): AgentToolInvocation {
                       .join('\n'),
                   );
                   break;
+                case 'status':
+                  // Non-content liveness signal (issue #2540); the public
+                  // string-only callback carries rendered content only, so the
+                  // heartbeat is intentionally not forwarded here.
+                  break;
                 default: {
                   const _exhaustive: never = update;
                   throw new Error(

--- a/packages/agents/src/core/subagentExecution.ts
+++ b/packages/agents/src/core/subagentExecution.ts
@@ -449,6 +449,10 @@ export function createCompletionChannel(
         ctx.onMessage(textOutput);
         break;
       }
+      case 'status':
+        // Non-content liveness signal (issue #2540); not forwarded to the
+        // message channel, which is append-only model-facing text.
+        break;
       default: {
         const _exhaustive: never = update;
         throw new Error(

--- a/packages/agents/src/tools/task.heartbeat.test.ts
+++ b/packages/agents/src/tools/task.heartbeat.test.ts
@@ -1,0 +1,463 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * TaskTool liveness heartbeat tests (issue #2540).
+ *
+ * Verifies that a healthy synchronous Task emits typed `status` liveness
+ * events across the public live-output boundary during silent nested-tool
+ * waits, that real progress resets liveness timing, that timers are cleared
+ * on every terminal path, and that heartbeats never pollute content/history.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TaskTool } from './task.js';
+import {
+  createLivenessStatus,
+  startTaskHeartbeat,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+} from './taskHeartbeat.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
+import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-tools';
+
+function createConfig(): Config {
+  return {
+    getSessionId: () => 'session-123',
+    getEphemeralSettings: () => ({
+      'task-default-timeout-seconds': 60,
+      'task-max-timeout-seconds': 120,
+    }),
+  } as unknown as Config;
+}
+
+interface PendingScope {
+  output: {
+    emitted_vars: Record<string, string>;
+    terminate_reason: SubagentTerminateMode;
+  };
+  cancel: ReturnType<typeof vi.fn>;
+  runInteractive: ReturnType<typeof vi.fn>;
+  runNonInteractive: ReturnType<typeof vi.fn>;
+  onMessage: ((message: string) => void) | undefined;
+}
+
+/**
+ * Builds a mock scope whose run method never resolves until the test drives
+ * it, simulating a subagent blocked on a long-running nested tool. `mode`
+ * selects which run method the scope reports as pending.
+ */
+function createPendingScope(
+  mode: 'interactive' | 'non-interactive' = 'interactive',
+): {
+  scope: PendingScope;
+  resolve: () => void;
+  reject: (error: Error) => void;
+} {
+  let resolveFn: (() => void) | null = null;
+  let rejectFn: ((error: Error) => void) | null = null;
+  const runPromise = new Promise<void>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  const pending = vi.fn(() => runPromise);
+  const noop = vi.fn();
+  const scope: PendingScope = {
+    output: {
+      emitted_vars: {},
+      terminate_reason: SubagentTerminateMode.GOAL,
+    },
+    cancel: vi.fn(),
+    runInteractive: mode === 'interactive' ? pending : noop,
+    runNonInteractive: mode === 'non-interactive' ? pending : noop,
+    onMessage: undefined,
+  };
+  return {
+    scope,
+    resolve: () => resolveFn?.(),
+    reject: (error: Error) => rejectFn?.(error),
+  };
+}
+
+function buildTool(scope: PendingScope): TaskTool {
+  const launch = vi.fn().mockResolvedValue({
+    agentId: 'agent-heartbeat',
+    scope,
+    dispose: vi.fn().mockResolvedValue(undefined),
+    prompt: {},
+    profile: {},
+    config: {},
+    runtime: {},
+  });
+  const orchestrator = { launch } as unknown as SubagentOrchestrator;
+  return new TaskTool(createConfig(), {
+    orchestratorFactory: () => orchestrator,
+    isInteractiveEnvironment: () => true,
+  });
+}
+
+describe('TaskHeartbeat unit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits typed status liveness snapshots at the configured interval', () => {
+    const updates: LiveOutputUpdate[] = [];
+    const hb = startTaskHeartbeat(
+      (u) => updates.push(u),
+      DEFAULT_HEARTBEAT_INTERVAL_MS,
+    );
+    vi.advanceTimersByTime(DEFAULT_HEARTBEAT_INTERVAL_MS * 3);
+    hb.stop();
+    expect(updates).toHaveLength(3);
+    for (const u of updates) {
+      expect(u.mode).toBe('status');
+    }
+    expect(updates[0]).toStrictEqual({
+      mode: 'status',
+      status: { kind: 'liveness', seq: 1 },
+    });
+    expect(updates[2]).toStrictEqual({
+      mode: 'status',
+      status: { kind: 'liveness', seq: 3 },
+    });
+  });
+
+  it('reset() defers the next heartbeat until after a fresh quiet period', () => {
+    const updates: LiveOutputUpdate[] = [];
+    const hb = startTaskHeartbeat((u) => updates.push(u), 100);
+    vi.advanceTimersByTime(90);
+    hb.reset();
+    vi.advanceTimersByTime(99);
+    expect(updates).toHaveLength(0);
+    vi.advanceTimersByTime(1);
+    expect(updates).toHaveLength(1);
+    hb.stop();
+  });
+
+  it('stop() is idempotent and prevents any further emission', () => {
+    const updates: LiveOutputUpdate[] = [];
+    const hb = startTaskHeartbeat((u) => updates.push(u), 100);
+    vi.advanceTimersByTime(100);
+    expect(updates).toHaveLength(1);
+    hb.stop();
+    hb.stop();
+    vi.advanceTimersByTime(1000);
+    expect(updates).toHaveLength(1);
+  });
+
+  it('returns a no-op handle when updateOutput is undefined', () => {
+    const hb = startTaskHeartbeat(undefined, 100);
+    expect(() => {
+      hb.reset();
+      hb.stop();
+      vi.advanceTimersByTime(1000);
+    }).not.toThrow();
+  });
+
+  it('returns a no-op handle when interval is non-positive', () => {
+    const updates: LiveOutputUpdate[] = [];
+    const hb = startTaskHeartbeat((u) => updates.push(u), 0);
+    vi.advanceTimersByTime(1000);
+    expect(updates).toHaveLength(0);
+    hb.stop();
+  });
+
+  it('returns a no-op handle for a negative interval without throwing', () => {
+    const updates: LiveOutputUpdate[] = [];
+    const hb = startTaskHeartbeat((u) => updates.push(u), -50);
+    vi.advanceTimersByTime(1000);
+    expect(updates).toHaveLength(0);
+    hb.stop();
+  });
+
+  it('createLivenessStatus produces the typed snapshot shape', () => {
+    expect(createLivenessStatus(7)).toStrictEqual({
+      mode: 'status',
+      status: { kind: 'liveness', seq: 7 },
+    });
+  });
+});
+
+describe('TaskTool heartbeat integration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits heartbeat status events while the subagent is silently pending', async () => {
+    const { scope, resolve } = createPendingScope();
+    const tool = buildTool(scope);
+    const updates: LiveOutputUpdate[] = [];
+
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'do work',
+    });
+    const resultPromise = invocation.execute(
+      new AbortController().signal,
+      (u) => updates.push(u),
+    );
+
+    // Allow launch + opening tag to flush.
+    await vi.advanceTimersByTimeAsync(0);
+    // Advance well past several heartbeat intervals while still pending.
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS * 4);
+
+    const statusUpdates = updates.filter((u) => u.mode === 'status');
+    expect(statusUpdates.length).toBeGreaterThanOrEqual(3);
+
+    resolve();
+    await resultPromise;
+
+    const tail = updates.slice(-1)[0];
+    expect(tail).toBeDefined();
+    expect(tail.mode).not.toBe('status');
+  });
+
+  it('does not emit heartbeat status events when no updateOutput is supplied', async () => {
+    const { scope, resolve } = createPendingScope();
+    const tool = buildTool(scope);
+
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'do work',
+    });
+    const resultPromise = invocation.execute(
+      new AbortController().signal,
+      undefined,
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS * 3);
+
+    resolve();
+    await resultPromise;
+    // No throw is the contract; no observer means no heartbeat path.
+    expect(scope.runInteractive).toHaveBeenCalled();
+  });
+
+  it('resets heartbeat timing when real subagent messages arrive', async () => {
+    const { scope, resolve } = createPendingScope();
+    const tool = buildTool(scope);
+    const updates: LiveOutputUpdate[] = [];
+
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'do work',
+    });
+    const resultPromise = invocation.execute(
+      new AbortController().signal,
+      (u) => updates.push(u),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    // Nearly at the heartbeat boundary, then push a real message.
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS - 1);
+    scope.onMessage?.('real progress text\n');
+
+    const statusBefore = updates.filter((u) => u.mode === 'status').length;
+    expect(statusBefore).toBe(0);
+
+    // Advance less than a full interval from the message; no heartbeat yet.
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS - 1);
+    const statusMid = updates.filter((u) => u.mode === 'status').length;
+    expect(statusMid).toBe(0);
+
+    // Now the quiet window elapses and a heartbeat fires.
+    await vi.advanceTimersByTimeAsync(1);
+    const statusAfter = updates.filter((u) => u.mode === 'status').length;
+    expect(statusAfter).toBe(1);
+
+    resolve();
+    await resultPromise;
+  });
+
+  it('stops the heartbeat on successful completion with no post-terminal status', async () => {
+    const { scope, resolve } = createPendingScope();
+    const tool = buildTool(scope);
+    const updates: LiveOutputUpdate[] = [];
+
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'do work',
+    });
+    const resultPromise = invocation.execute(
+      new AbortController().signal,
+      (u) => updates.push(u),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS * 2);
+    resolve();
+    const result = await resultPromise;
+
+    const statusCountAtCompletion = updates.filter(
+      (u) => u.mode === 'status',
+    ).length;
+
+    // Advance further after completion; no additional heartbeats.
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS * 3);
+    const statusCountAfter = updates.filter((u) => u.mode === 'status').length;
+    expect(statusCountAfter).toBe(statusCountAtCompletion);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('stops the heartbeat on Task timeout with no post-terminal status', async () => {
+    const { scope, reject } = createPendingScope();
+    const tool = buildTool(scope);
+    const updates: LiveOutputUpdate[] = [];
+
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'do work',
+      timeout_seconds: 0.05,
+    });
+    const resultPromise = invocation.execute(
+      new AbortController().signal,
+      (u) => updates.push(u),
+    );
+
+    await vi.advanceTimersByTimeAsync(5);
+    expect(scope.runInteractive).toHaveBeenCalled();
+
+    // Advance past the 50ms task timeout.
+    await vi.advanceTimersByTimeAsync(60);
+    const abortError = new Error('Aborted');
+    abortError.name = 'AbortError';
+    reject(abortError);
+
+    const result = await resultPromise;
+    expect(result.error?.type).toBe('timeout');
+
+    const statusAtTerminal = updates.filter((u) => u.mode === 'status').length;
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS * 3);
+    const statusAfter = updates.filter((u) => u.mode === 'status').length;
+    expect(statusAfter).toBe(statusAtTerminal);
+  });
+
+  it('stops the heartbeat on user abort with no post-terminal status', async () => {
+    const { scope, reject } = createPendingScope();
+    const tool = buildTool(scope);
+    const updates: LiveOutputUpdate[] = [];
+
+    const abortController = new AbortController();
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'do work',
+      timeout_seconds: 60,
+    });
+    const resultPromise = invocation.execute(abortController.signal, (u) =>
+      updates.push(u),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS);
+    abortController.abort();
+    // The scope's abort handler cancels; the pending runInteractive must
+    // reject (mirroring the real subagent detecting the cancel).
+    const abortError = new Error('Aborted');
+    abortError.name = 'AbortError';
+    reject(abortError);
+
+    const result = await resultPromise;
+    expect(result.error?.type).toBe('execution_failed');
+    expect(scope.cancel).toHaveBeenCalledWith('User aborted task execution.');
+
+    const statusAtTerminal = updates.filter((u) => u.mode === 'status').length;
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS * 3);
+    const statusAfter = updates.filter((u) => u.mode === 'status').length;
+    expect(statusAfter).toBe(statusAtTerminal);
+  });
+
+  it('does not pollute append content: heartbeat status events are never append data', async () => {
+    const { scope, resolve } = createPendingScope();
+    const tool = buildTool(scope);
+    const captured = {
+      appends: [] as string[],
+      statuses: 0,
+    };
+    let xmlCloseSeen = false;
+
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'do work',
+    });
+    const resultPromise = invocation.execute(
+      new AbortController().signal,
+      (u) => {
+        if (u.mode === 'append') {
+          captured.appends.push(u.data);
+          if (u.data.includes('</subagent')) {
+            xmlCloseSeen = true;
+          }
+        } else if (u.mode === 'status') {
+          captured.statuses += 1;
+        }
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    // Inject a real content message and let several heartbeats fire.
+    scope.onMessage?.('real content\n');
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS * 3);
+    resolve();
+    await resultPromise;
+
+    // The concatenated content must contain only opening tag, the real
+    // message, and the closing tag — never any heartbeat text.
+    const joined = captured.appends.join('');
+    expect(joined).toContain('<subagent name="helper"');
+    expect(joined).toContain('real content');
+    expect(joined).toContain('</subagent name="helper"');
+    expect(xmlCloseSeen).toBe(true);
+    expect(joined).not.toMatch(/liveness|status/i);
+    expect(captured.statuses).toBeGreaterThanOrEqual(2);
+  });
+
+  it('non-interactive path also receives heartbeats', async () => {
+    const { scope, resolve } = createPendingScope('non-interactive');
+    const launch = vi.fn().mockResolvedValue({
+      agentId: 'agent-ni',
+      scope,
+      dispose: vi.fn().mockResolvedValue(undefined),
+      prompt: {},
+      profile: {},
+      config: {},
+      runtime: {},
+    });
+    const orchestrator = { launch } as unknown as SubagentOrchestrator;
+    const tool = new TaskTool(createConfig(), {
+      orchestratorFactory: () => orchestrator,
+      isInteractiveEnvironment: () => false,
+    });
+    const updates: LiveOutputUpdate[] = [];
+
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'do work',
+    });
+    const resultPromise = invocation.execute(
+      new AbortController().signal,
+      (u) => updates.push(u),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(scope.runNonInteractive).toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(DEFAULT_HEARTBEAT_INTERVAL_MS * 2);
+    resolve();
+    await resultPromise;
+
+    const statusCount = updates.filter((u) => u.mode === 'status').length;
+    expect(statusCount).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/agents/src/tools/task.heartbeat.test.ts
+++ b/packages/agents/src/tools/task.heartbeat.test.ts
@@ -206,6 +206,50 @@ describe('TaskHeartbeat unit', () => {
     expect(updates).toHaveLength(3);
     hb.stop();
   });
+
+  it('returns a no-op handle when interval is Infinity', () => {
+    const updates: LiveOutputUpdate[] = [];
+    const hb = startTaskHeartbeat(
+      (u) => updates.push(u),
+      Number.POSITIVE_INFINITY,
+    );
+    vi.advanceTimersByTime(DEFAULT_HEARTBEAT_INTERVAL_MS * 3);
+    expect(updates).toHaveLength(0);
+    hb.stop();
+  });
+
+  it('honors a synchronous stop() invoked during the updateOutput callback', () => {
+    const updates: LiveOutputUpdate[] = [];
+    const hb = startTaskHeartbeat((u) => {
+      updates.push(u);
+      if (updates.length === 1) {
+        hb.stop();
+      }
+    }, 100);
+
+    vi.advanceTimersByTime(100);
+    expect(updates).toHaveLength(1);
+    vi.advanceTimersByTime(1000);
+    expect(updates).toHaveLength(1);
+  });
+
+  it('honors a synchronous reset() invoked during the updateOutput callback', () => {
+    const updates: LiveOutputUpdate[] = [];
+    const hb = startTaskHeartbeat((u) => {
+      updates.push(u);
+      if (updates.length === 1) {
+        hb.reset();
+      }
+    }, 100);
+
+    vi.advanceTimersByTime(100);
+    expect(updates).toHaveLength(1);
+    vi.advanceTimersByTime(99);
+    expect(updates).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(updates).toHaveLength(2);
+    hb.stop();
+  });
 });
 
 describe('TaskTool heartbeat integration', () => {

--- a/packages/agents/src/tools/task.heartbeat.test.ts
+++ b/packages/agents/src/tools/task.heartbeat.test.ts
@@ -184,6 +184,28 @@ describe('TaskHeartbeat unit', () => {
       status: { kind: 'liveness', seq: 7 },
     });
   });
+
+  it('survives a throwing updateOutput and keeps ticking', () => {
+    const updates: LiveOutputUpdate[] = [];
+    let callCount = 0;
+    const hb = startTaskHeartbeat((u) => {
+      callCount += 1;
+      updates.push(u);
+      if (callCount === 2) {
+        throw new Error('downstream stream error');
+      }
+    }, 100);
+
+    vi.advanceTimersByTime(100);
+    expect(updates).toHaveLength(1);
+    // Second tick throws; the heartbeat must reschedule anyway.
+    vi.advanceTimersByTime(100);
+    expect(updates).toHaveLength(2);
+    // Third tick proves the timer chain survived the exception.
+    vi.advanceTimersByTime(100);
+    expect(updates).toHaveLength(3);
+    hb.stop();
+  });
 });
 
 describe('TaskTool heartbeat integration', () => {
@@ -313,6 +335,12 @@ describe('TaskTool heartbeat integration', () => {
   });
 
   it('stops the heartbeat on Task timeout with no post-terminal status', async () => {
+    // timeout_seconds is shorter than one heartbeat interval (50ms << 10s),
+    // so the timeout fires before any heartbeat. The mock scope's
+    // runInteractive returns a plain Promise that does not observe the
+    // timeout controller's abort signal on its own, so the test drives the
+    // rejection to mirror the real subagent detecting the abort. This matches
+    // the established convention in task.timeout.test.ts.
     const { scope, reject } = createPendingScope();
     const tool = buildTool(scope);
     const updates: LiveOutputUpdate[] = [];
@@ -330,7 +358,7 @@ describe('TaskTool heartbeat integration', () => {
     await vi.advanceTimersByTimeAsync(5);
     expect(scope.runInteractive).toHaveBeenCalled();
 
-    // Advance past the 50ms task timeout.
+    // Advance past the 50ms task timeout; the timeout controller aborts.
     await vi.advanceTimersByTimeAsync(60);
     const abortError = new Error('Aborted');
     abortError.name = 'AbortError';

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -11,7 +11,6 @@ import {
   type ToolResult,
   type LiveOutputUpdate,
 } from '@vybestack/llxprt-code-tools';
-import { createStreamNormalizer } from '@vybestack/llxprt-code-tools/utils/textDelta.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import {
   SubagentOrchestrator,
@@ -47,6 +46,8 @@ import {
   formatSuccessDisplay,
 } from './taskResultHelpers.js';
 import { executeAsyncTask } from './taskAsyncExecution.js';
+import { startTaskHeartbeat, type TaskHeartbeat } from './taskHeartbeat.js';
+import { setupTaskStreaming } from './taskStreaming.js';
 
 const taskLogger = new DebugLogger('llxprt:task');
 
@@ -488,7 +489,7 @@ class TaskToolInvocation extends BaseToolInvocation<
       );
     }
 
-    const { emitClosingSubagentTag } = this.setupStreaming(
+    const { emitClosingSubagentTag, heartbeat } = this.setupStreaming(
       launchResult,
       agentId,
       scope,
@@ -519,6 +520,7 @@ class TaskToolInvocation extends BaseToolInvocation<
         abortState.aborted,
       );
     } finally {
+      heartbeat.stop();
       emitClosingSubagentTag();
     }
   }
@@ -549,41 +551,16 @@ class TaskToolInvocation extends BaseToolInvocation<
     agentId: string,
     scope: SubAgentScope,
     updateOutput?: (update: LiveOutputUpdate) => void,
-  ): { emitClosingSubagentTag: () => void } {
+  ): { emitClosingSubagentTag: () => void; heartbeat: TaskHeartbeat } {
     const subagentName =
       launchRequestName(launchResult) || this.normalized.subagentName;
-    let xmlOutputOpen = false;
-    const normalizer = createStreamNormalizer();
-    const emitAppend = (data: string): void => {
-      updateOutput?.({ mode: 'append', data });
-    };
-    const emitClosingSubagentTag = () => {
-      if (!xmlOutputOpen || !updateOutput) {
-        return;
-      }
-      const flushed = normalizer.flush();
-      if (flushed !== undefined) {
-        emitAppend(flushed);
-      }
-      emitAppend(`</subagent name="${subagentName}" id="${agentId}">\n`);
-      xmlOutputOpen = false;
-    };
-
-    if (updateOutput) {
-      emitAppend(`<subagent name="${subagentName}" id="${agentId}">\n`);
-      xmlOutputOpen = true;
-
-      const existingHandler = scope.onMessage;
-      scope.onMessage = (message: string) => {
-        const delta = normalizer.push(message);
-        if (delta !== undefined) {
-          emitAppend(delta);
-        }
-        existingHandler?.(message);
-      };
-    }
-
-    return { emitClosingSubagentTag };
+    return setupTaskStreaming(
+      subagentName,
+      agentId,
+      scope,
+      updateOutput,
+      startTaskHeartbeat,
+    );
   }
 
   private async runSubagent(

--- a/packages/agents/src/tools/taskHeartbeat.ts
+++ b/packages/agents/src/tools/taskHeartbeat.ts
@@ -72,7 +72,10 @@ export function startTaskHeartbeat(
   updateOutput: ((update: LiveOutputUpdate) => void) | undefined,
   intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
 ): TaskHeartbeat {
-  if (updateOutput === undefined || !(intervalMs > 0)) {
+  if (
+    updateOutput === undefined ||
+    !(Number.isFinite(intervalMs) && intervalMs > 0)
+  ) {
     return { reset: () => {}, stop: () => {} };
   }
 
@@ -80,8 +83,22 @@ export function startTaskHeartbeat(
   let stopped = false;
   let timerId: ReturnType<typeof setTimeout> | null = null;
 
+  const arm = (): void => {
+    timerId = setTimeout(tick, intervalMs);
+  };
+
+  // Reading closure flags through these indirections defeats the linter's
+  // cross-callback narrowing so post-callback checks are not flagged as
+  // always-false/true. reset()/stop() invoked synchronously within
+  // updateOutput mutate these closures; tick() must respect that.
+  const readTimerId = (): ReturnType<typeof setTimeout> | null => timerId;
+  const isStopped = (): boolean => stopped;
+
   const tick = (): void => {
-    if (stopped) return;
+    if (isStopped()) return;
+    // This timer has fired; clear the id so a synchronous reset()/stop()
+    // invoked from within updateOutput is detectable after the callback.
+    timerId = null;
     seq += 1;
     heartbeatLogger.debug(() => `emit liveness seq=${seq}`);
     // The updateOutput callback is consumer-supplied and may throw on a
@@ -97,7 +114,11 @@ export function startTaskHeartbeat(
           `liveness updateOutput threw (seq=${seq}); continuing: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-    timerId = setTimeout(tick, intervalMs);
+    // Re-check after the callback: if reset() armed a new timer (timerId no
+    // longer null), do not overwrite it. If stop() was called, do not arm.
+    if (!isStopped() && readTimerId() === null) {
+      arm();
+    }
   };
 
   const reset = (): void => {
@@ -105,7 +126,7 @@ export function startTaskHeartbeat(
     if (timerId !== null) {
       clearTimeout(timerId);
     }
-    timerId = setTimeout(tick, intervalMs);
+    arm();
   };
 
   const stop = (): void => {
@@ -116,6 +137,6 @@ export function startTaskHeartbeat(
     }
   };
 
-  timerId = setTimeout(tick, intervalMs);
+  arm();
   return { reset, stop };
 }

--- a/packages/agents/src/tools/taskHeartbeat.ts
+++ b/packages/agents/src/tools/taskHeartbeat.ts
@@ -84,7 +84,19 @@ export function startTaskHeartbeat(
     if (stopped) return;
     seq += 1;
     heartbeatLogger.debug(() => `emit liveness seq=${seq}`);
-    updateOutput(createLivenessStatus(seq));
+    // The updateOutput callback is consumer-supplied and may throw on a
+    // downstream stream/serialization error. Such an error must not kill the
+    // timer chain: the heartbeat's whole purpose is to keep ticking across
+    // silent waits. Swallow the error (logged) and reschedule so an isolated
+    // callback failure cannot cause a false-positive outer-inactivity timeout.
+    try {
+      updateOutput(createLivenessStatus(seq));
+    } catch (error) {
+      heartbeatLogger.warn(
+        () =>
+          `liveness updateOutput threw (seq=${seq}); continuing: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
     timerId = setTimeout(tick, intervalMs);
   };
 

--- a/packages/agents/src/tools/taskHeartbeat.ts
+++ b/packages/agents/src/tools/taskHeartbeat.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-tools';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+
+const heartbeatLogger = new DebugLogger('llxprt:task');
+
+/**
+ * Default liveness interval. A healthy synchronous Task must emit at least one
+ * status event before any supported outer stream-inactivity guard expires.
+ * Provider-side stream-idle watchdogs (issue #1905) operate on first-response
+ * and inter-chunk cadence at the model layer and are intentionally much
+ * shorter; this heartbeat concerns only the public Task live-output boundary
+ * while a subagent waits on a long-running nested tool.
+ *
+ * 10s keeps heartbeat volume bounded (<=6/min) while comfortably below the
+ * shortest configured interactive inactivity budget.
+ */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 10_000;
+
+/**
+ * Creates the typed `status` live-output update for a given sequence number.
+ * Exported so tests can assert the exact snapshot shape without duplicating
+ * the literal.
+ */
+export function createLivenessStatus(seq: number): LiveOutputUpdate {
+  return { mode: 'status', status: { kind: 'liveness', seq } };
+}
+
+/**
+ * Handle returned by {@link startTaskHeartbeat}. `stop()` is idempotent and
+ * clears the pending timer; `reset()` (re)arms the timer after real activity.
+ */
+export interface TaskHeartbeat {
+  /**
+   * (Re)arms the heartbeat timer. Real progress (subagent messages, nested
+   * tool output) supersedes liveness timing and should call this to defer the
+   * next heartbeat until after a fresh quiet period.
+   */
+  reset: () => void;
+  /**
+   * Clears the pending timer and marks the heartbeat stopped so no further
+   * status events fire. Idempotent; safe to call from any terminal path.
+   */
+  stop: () => void;
+}
+
+/**
+ * Starts a periodic liveness heartbeat that emits non-content `status`
+ * live-output updates across the public stream boundary (issue #2540).
+ *
+ * The heartbeat is structurally distinct from model text and tool-result
+ * content: {@link accumulateLiveOutput} ignores `status` updates, the
+ * subagent message channel skips them, and the public AgentToolInvocation
+ * adapter does not forward them as text. A snapshot consumer that tracks the
+ * latest `status.seq` therefore holds a constant-size view regardless of how
+ * many heartbeats fire.
+ *
+ * The heartbeat does NOT extend `timeout_seconds`/`max_time_minutes` and does
+ * NOT reset provider first-response/inter-chunk watchdogs — it only emits
+ * across the Task tool's own `updateOutput` boundary.
+ *
+ * The interval defaults to {@link DEFAULT_HEARTBEAT_INTERVAL_MS} and must be
+ * strictly positive; an invalid interval disables the heartbeat (returns a
+ * no-op handle) rather than firing in a tight loop.
+ */
+export function startTaskHeartbeat(
+  updateOutput: ((update: LiveOutputUpdate) => void) | undefined,
+  intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): TaskHeartbeat {
+  if (updateOutput === undefined || !(intervalMs > 0)) {
+    return { reset: () => {}, stop: () => {} };
+  }
+
+  let seq = 0;
+  let stopped = false;
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+
+  const tick = (): void => {
+    if (stopped) return;
+    seq += 1;
+    heartbeatLogger.debug(() => `emit liveness seq=${seq}`);
+    updateOutput(createLivenessStatus(seq));
+    timerId = setTimeout(tick, intervalMs);
+  };
+
+  const reset = (): void => {
+    if (stopped) return;
+    if (timerId !== null) {
+      clearTimeout(timerId);
+    }
+    timerId = setTimeout(tick, intervalMs);
+  };
+
+  const stop = (): void => {
+    stopped = true;
+    if (timerId !== null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+  };
+
+  timerId = setTimeout(tick, intervalMs);
+  return { reset, stop };
+}

--- a/packages/agents/src/tools/taskStreaming.ts
+++ b/packages/agents/src/tools/taskStreaming.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-tools';
+import { createStreamNormalizer } from '@vybestack/llxprt-code-tools/utils/textDelta.js';
+import type { SubAgentScope } from '../core/subagent.js';
+import type { startTaskHeartbeat, TaskHeartbeat } from './taskHeartbeat.js';
+
+/**
+ * Result of {@link setupTaskStreaming}: the closing-tag emitter (flushes the
+ * stream normalizer and emits `</subagent>`), plus the liveness heartbeat
+ * handle whose lifecycle is tied to the streaming session.
+ */
+export interface TaskStreamingHandle {
+  emitClosingSubagentTag: () => void;
+  heartbeat: TaskHeartbeat;
+}
+
+/**
+ * Wires the public live-output stream for a synchronous Task: emits the
+ * opening `<subagent>` tag, installs the `scope.onMessage` relay (which
+ * forwards normalized deltas and resets the heartbeat on real progress), and
+ * starts the periodic liveness heartbeat (issue #2540).
+ *
+ * The heartbeat emits typed `status` snapshots distinct from content:
+ * `accumulateLiveOutput` ignores them, the subagent message channel skips
+ * them, and the public AgentToolInvocation adapter does not forward them as
+ * text. Real progress resets heartbeat timing so the next quiet window
+ * (not the just-arrived message) schedules the next heartbeat.
+ *
+ * Returns a no-op-shaped handle when no `updateOutput` observer is supplied
+ * (the heartbeat start helper already short-circuits in that case).
+ */
+export function setupTaskStreaming(
+  subagentName: string,
+  agentId: string,
+  scope: SubAgentScope,
+  updateOutput: ((update: LiveOutputUpdate) => void) | undefined,
+  startHeartbeat: typeof startTaskHeartbeat,
+): TaskStreamingHandle {
+  let xmlOutputOpen = false;
+  const normalizer = createStreamNormalizer();
+  const emitAppend = (data: string): void => {
+    updateOutput?.({ mode: 'append', data });
+  };
+  const emitClosingSubagentTag = (): void => {
+    if (!xmlOutputOpen || !updateOutput) {
+      return;
+    }
+    const flushed = normalizer.flush();
+    if (flushed !== undefined) {
+      emitAppend(flushed);
+    }
+    emitAppend(`</subagent name="${subagentName}" id="${agentId}">\n`);
+    xmlOutputOpen = false;
+  };
+
+  const heartbeat = startHeartbeat(updateOutput);
+
+  if (updateOutput) {
+    emitAppend(`<subagent name="${subagentName}" id="${agentId}">\n`);
+    xmlOutputOpen = true;
+
+    const existingHandler = scope.onMessage;
+    scope.onMessage = (message: string) => {
+      heartbeat.reset();
+      const delta = normalizer.push(message);
+      if (delta !== undefined) {
+        emitAppend(delta);
+      }
+      existingHandler?.(message);
+    };
+  }
+
+  return { emitClosingSubagentTag, heartbeat };
+}

--- a/packages/agents/src/tools/taskStreaming.ts
+++ b/packages/agents/src/tools/taskStreaming.ts
@@ -47,7 +47,7 @@ export function setupTaskStreaming(
     updateOutput?.({ mode: 'append', data });
   };
   const emitClosingSubagentTag = (): void => {
-    if (!xmlOutputOpen || !updateOutput) {
+    if (!xmlOutputOpen) {
       return;
     }
     const flushed = normalizer.flush();
@@ -57,8 +57,6 @@ export function setupTaskStreaming(
     emitAppend(`</subagent name="${subagentName}" id="${agentId}">\n`);
     xmlOutputOpen = false;
   };
-
-  const heartbeat = startHeartbeat(updateOutput);
 
   if (updateOutput) {
     emitAppend(`<subagent name="${subagentName}" id="${agentId}">\n`);
@@ -74,6 +72,11 @@ export function setupTaskStreaming(
       existingHandler?.(message);
     };
   }
+
+  // Start the heartbeat AFTER stream initialization so an exception during
+  // opening-tag emission cannot leave a running timer with no handle to
+  // stop it.
+  const heartbeat = startHeartbeat(updateOutput);
 
   return { emitClosingSubagentTag, heartbeat };
 }

--- a/packages/core/src/scheduler/liveOutput.test.ts
+++ b/packages/core/src/scheduler/liveOutput.test.ts
@@ -115,4 +115,56 @@ describe('accumulateLiveOutput', () => {
       expect(acc).toBe(third);
     });
   });
+
+  describe('status mode (liveness, issue #2540)', () => {
+    const status = {
+      mode: 'status' as const,
+      status: { kind: 'liveness' as const, seq: 1 },
+    };
+
+    it('preserves an existing string accumulator unchanged', () => {
+      expect(accumulateLiveOutput('existing', status)).toBe('existing');
+    });
+
+    it('preserves an existing AnsiOutput accumulator unchanged', () => {
+      expect(accumulateLiveOutput(ansiSnapshot, status)).toBe(ansiSnapshot);
+    });
+
+    it('returns empty string for an undefined accumulator', () => {
+      expect(accumulateLiveOutput(undefined, status)).toBe('');
+    });
+
+    it('does not grow the accumulator across repeated status updates', () => {
+      let acc: string | AnsiOutput | undefined = 'base';
+      for (let seq = 1; seq <= 50; seq++) {
+        acc = accumulateLiveOutput(undefined, {
+          mode: 'status',
+          status: { kind: 'liveness', seq },
+        });
+      }
+      // Re-run against a real accumulator to prove no growth.
+      acc = 'base';
+      for (let seq = 1; seq <= 50; seq++) {
+        acc = accumulateLiveOutput(acc, {
+          mode: 'status',
+          status: { kind: 'liveness', seq },
+        });
+      }
+      expect(acc).toBe('base');
+    });
+
+    it('status after append keeps the accumulated text', () => {
+      let acc: string | AnsiOutput | undefined = undefined;
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: 'kept' });
+      acc = accumulateLiveOutput(acc, status);
+      expect(acc).toBe('kept');
+    });
+
+    it('append after status appends onto the preserved text', () => {
+      let acc: string | AnsiOutput | undefined = 'pre';
+      acc = accumulateLiveOutput(acc, status);
+      acc = accumulateLiveOutput(acc, { mode: 'append', data: '-post' });
+      expect(acc).toBe('pre-post');
+    });
+  });
 });

--- a/packages/core/src/scheduler/liveOutput.test.ts
+++ b/packages/core/src/scheduler/liveOutput.test.ts
@@ -137,14 +137,6 @@ describe('accumulateLiveOutput', () => {
     it('does not grow the accumulator across repeated status updates', () => {
       let acc: string | AnsiOutput | undefined = 'base';
       for (let seq = 1; seq <= 50; seq++) {
-        acc = accumulateLiveOutput(undefined, {
-          mode: 'status',
-          status: { kind: 'liveness', seq },
-        });
-      }
-      // Re-run against a real accumulator to prove no growth.
-      acc = 'base';
-      for (let seq = 1; seq <= 50; seq++) {
         acc = accumulateLiveOutput(acc, {
           mode: 'status',
           status: { kind: 'liveness', seq },

--- a/packages/core/src/scheduler/liveOutput.ts
+++ b/packages/core/src/scheduler/liveOutput.ts
@@ -10,6 +10,22 @@ import type {
 } from '../utils/terminalSerializer.js';
 
 /**
+ * Narrows an arbitrary `existing` accumulator value to the live-output union
+ * (`string | AnsiOutput`), returning an empty string for values that are not
+ * valid live-output content (e.g. `FileDiff` drawn from a broader display
+ * union). Used by the `status` path, which must not invent new content.
+ */
+function preserveLiveOutput(existing: unknown): string | AnsiOutput {
+  if (typeof existing === 'string') {
+    return existing;
+  }
+  if (Array.isArray(existing)) {
+    return existing as AnsiOutput;
+  }
+  return '';
+}
+
+/**
  * Accumulates a live-output update onto an existing accumulated value using
  * the explicit tagged {@link LiveOutputUpdate} protocol.
  *
@@ -17,6 +33,9 @@ import type {
  *   is a string; otherwise the prior non-string value is dropped and the
  *   delta starts a fresh string.
  * - **`replace`** (terminal-buffer snapshots) — supersedes any prior value.
+ * - **`status`** (liveness snapshot, issue #2540) — non-content; the existing
+ *   accumulated value is returned unchanged so retained output never grows
+ *   with heartbeat strings.
  *
  * The `existing` parameter is typed `unknown` because callers may pass values
  * drawn from a broader display union (e.g. `ToolResultDisplay`, which also
@@ -34,6 +53,10 @@ export function accumulateLiveOutput(
         : update.data;
     case 'replace':
       return update.data;
+    case 'status':
+      // Liveness snapshots carry no content; keep the existing accumulator
+      // value verbatim without inventing new output.
+      return preserveLiveOutput(existing);
     default: {
       const _exhaustive: never = update;
       return _exhaustive;

--- a/packages/core/src/utils/terminalSerializer.ts
+++ b/packages/core/src/utils/terminalSerializer.ts
@@ -20,13 +20,40 @@ export type AnsiLine = AnsiToken[];
 export type AnsiOutput = AnsiLine[];
 
 /**
+ * A non-content liveness/status snapshot emitted across the public live-output
+ * stream boundary (issue #2540). Unlike `append` (text deltas) and `replace`
+ * (terminal snapshots), a `status` update carries no rendered content: it is
+ * a periodic liveness signal that keeps an outer stream-inactivity guard from
+ * firing while a healthy, otherwise-silent subagent waits on a long-running
+ * nested tool.
+ *
+ * Status is a snapshot, not an append — `accumulateLiveOutput` ignores it so
+ * retained output never grows with heartbeat strings.
+ */
+export interface LiveOutputStatus {
+  /**
+   * Kind of status signal. `liveness` is the periodic "still running"
+   * heartbeat; reserved for future non-liveness status without changing the
+   * union shape.
+   */
+  kind: 'liveness';
+  /**
+   * Monotonic counter so a snapshot consumer can coalesce or detect the most
+   * recent signal without storing an unbounded history.
+   */
+  seq: number;
+}
+
+/**
  * Explicit tagged update protocol for live-output streaming. Discriminated
  * by `mode`: text stream producers emit `append` (incremental deltas);
- * terminal-buffer producers emit `replace` (full snapshots).
+ * terminal-buffer producers emit `replace` (full snapshots);
+ * `status` emits a non-content liveness signal (issue #2540).
  */
 export type LiveOutputUpdate =
   | { mode: 'append'; data: string }
-  | { mode: 'replace'; data: AnsiOutput };
+  | { mode: 'replace'; data: AnsiOutput }
+  | { mode: 'status'; status: LiveOutputStatus };
 
 const enum Attribute {
   inverse = 1,

--- a/packages/tools/src/utils/terminalSerializer.ts
+++ b/packages/tools/src/utils/terminalSerializer.ts
@@ -37,10 +37,23 @@ export type AnsiLine = AnsiToken[];
 export type AnsiOutput = AnsiLine[];
 
 /**
+ * A non-content liveness/status snapshot emitted across the public live-output
+ * stream boundary (issue #2540). See the equivalent definition in
+ * packages/core — kept structurally identical so tool files do not need the
+ * @xterm/headless dependency.
+ */
+export interface LiveOutputStatus {
+  kind: 'liveness';
+  seq: number;
+}
+
+/**
  * Explicit tagged update protocol for live-output streaming. Discriminated
  * by `mode`: text stream producers emit `append` (incremental deltas);
- * terminal-buffer producers emit `replace` (full snapshots).
+ * terminal-buffer producers emit `replace` (full snapshots);
+ * `status` emits a non-content liveness signal (issue #2540).
  */
 export type LiveOutputUpdate =
   | { mode: 'append'; data: string }
-  | { mode: 'replace'; data: AnsiOutput };
+  | { mode: 'replace'; data: AnsiOutput }
+  | { mode: 'status'; status: LiveOutputStatus };


### PR DESCRIPTION
## Summary

A foreground synchronous Task could remain healthy for many minutes while its subagent waited on a long-running nested tool (e.g., detached OCR followed by polling), emitting only an opening progress update and then silence. An outer stream-inactivity guard with a deadline shorter than the Task timeout could therefore report that the call did not return in time, even though the subagent and nested tool were still running within their configured budget.

This adds a typed, non-content liveness signal that flows across the same public stream boundary the guard observes.

## Changes

- **New `status` mode in `LiveOutputUpdate`** (both `packages/core` and `packages/tools` `terminalSerializer.ts`): a `LiveOutputStatus` snapshot with `kind: "liveness"` and a monotonic `seq`. Structurally distinct from `append` (text deltas) and `replace` (terminal snapshots).
- **`accumulateLiveOutput` ignores `status`**: the existing accumulator value is returned unchanged, so retained output never grows with heartbeat strings (byte-identical content).
- **Exhaustive switches updated**: `subagentExecution.ts` (subagent message channel) and `toolControl.ts` (public AgentToolInvocation adapter) skip `status` so it is never forwarded as model text or tool-result content.
- **`taskHeartbeat.ts`**: lifecycle module exposing `startTaskHeartbeat` / `reset` / `stop`. Emits periodic `status` snapshots at a 10s default interval; returns a no-op handle when there is no observer or a non-positive interval; `stop()` is idempotent.
- **`taskStreaming.ts`**: extracted the streaming+heartbeat setup (opening/closing tags, message relay, heartbeat wiring) from `task.ts` so the file stays within the 800-line `max-lines` budget.
- **`task.ts`**: starts the heartbeat after streaming begins, stops it in the `finally` block (every terminal path), and resets it when real subagent messages arrive.

## Acceptance criteria

- [x] A healthy synchronous Task can run longer than the outer stream-inactivity interval, while remaining within its Task timeout, without triggering the outer timeout guard.
- [x] Silent running Tasks emit a typed status/liveness event through the same public stream boundary observed by the guard.
- [x] Liveness is structurally distinct from model text and tool result content.
- [x] Liveness does not change subagent output, model history, final Task content, emitted variables, XML structure, or retained user-visible transcript text.
- [x] Status is coalesced/snapshot; it does not append unbounded heartbeat strings.
- [x] Real progress preserves its current ordering and resets/supersedes liveness timing.
- [x] Timers are cleared on success, launch failure, execution failure, user abort, Task timeout, and disposal, with no post-terminal updates.
- [x] Heartbeats do not extend timeout_seconds/max_time_minutes or reset provider first-response/inter-chunk watchdogs.
- [x] Interactive, fallback-scheduler (non-interactive), and applicable non-interactive behavior are explicitly covered by tests.

## Tests

- `packages/agents/src/tools/task.heartbeat.test.ts` (15 tests): unit tests for the heartbeat lifecycle (delivery, reset, stop idempotency, no-op handles, negative interval) and integration tests proving heartbeat emission during silent pending, reset on real messages, cleanup on success/timeout/user-abort, no content pollution, and non-interactive path coverage.
- `packages/core/src/scheduler/liveOutput.test.ts`: 6 new tests for the `status` mode (preserves string/AnsiOutput accumulators, no growth across repeated status updates, transitions with append/replace).

## Verification

- `npm run test` — all related suites pass (heartbeat, liveOutput, task, task.timeout, task.max-turns, task.issues).
- `npm run lint` — clean on all changed files.
- `npm run typecheck` — clean (agents + core packages; the a2a-server pre-existing `FileSystemCapabilities` error is unrelated and present on main).
- `npm run format` — applied.
- Open Code Review run with `--timeout 20`; 2 in-scope findings addressed (negative interval test case, cancel assertion on abort path), remaining findings classified as Defer/Reject (pre-existing patterns, out-of-scope cross-file cleanup).

## Non-goals

- Does not change provider stream-idle watchdog semantics (issue #1905).
- Does not change Task `timeout_seconds` / `max_time_minutes` resolution.
- Does not add heartbeats to the async Task path (it returns immediately to the foreground caller; the long silent wait only affects synchronous Tasks).

Closes #2540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added liveness status signals for long-running tasks, emitted periodically during quiet periods.
  - Heartbeats reset when task activity resumes and stop when tasks complete, time out, or are canceled.
  - Status updates remain separate from task text and do not alter displayed content or history.

- **Bug Fixes**
  - Prevented liveness signals from causing streaming errors or being treated as text output.

- **Tests**
  - Added comprehensive coverage for heartbeat timing, reset and stop behavior, error handling, and task termination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->