### PR TITLE
Fix Codex PDF continuation serialization (Fixes #2608)

### DIFF
--- a/packages/core/src/utils/generateContentResponseUtilities.test.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.test.ts
@@ -378,6 +378,48 @@ describe('generateContentResponseUtilities', () => {
         },
       ]);
     });
+
+    it('maps inlineData.displayName into MediaBlock.filename @issue:2608', () => {
+      const blocks = legacyPartsToBlocks([
+        {
+          inlineData: {
+            data: 'YWJj',
+            mimeType: 'application/pdf',
+            displayName: 'report.pdf',
+          },
+        },
+      ]);
+
+      expect(blocks).toStrictEqual([
+        {
+          type: 'media',
+          mimeType: 'application/pdf',
+          data: 'YWJj',
+          encoding: 'base64',
+          filename: 'report.pdf',
+        },
+      ]);
+    });
+
+    it('omits MediaBlock.filename when inlineData.displayName is absent @issue:2608', () => {
+      const blocks = legacyPartsToBlocks([
+        {
+          inlineData: {
+            data: 'YWJj',
+            mimeType: 'application/pdf',
+          },
+        },
+      ]);
+
+      expect(blocks).toStrictEqual([
+        {
+          type: 'media',
+          mimeType: 'application/pdf',
+          data: 'YWJj',
+          encoding: 'base64',
+        },
+      ]);
+    });
     it('wraps string llmContent in a single tool_response block', () => {
       const result = convertToFunctionResponse(
         'tool',
@@ -508,6 +550,27 @@ describe('generateContentResponseUtilities', () => {
         mimeType: 'text/plain',
         data: 'YWJj',
         encoding: 'base64',
+      });
+    });
+
+    it('preserves inlineData.displayName as MediaBlock.filename through convertToFunctionResponse @issue:2608', () => {
+      const result = convertToFunctionResponse('read_file', 'call-fname', [
+        {
+          inlineData: {
+            data: 'JVBERi0xLjQ=',
+            mimeType: 'application/pdf',
+            displayName: 'quarterly-report.pdf',
+          },
+        },
+      ]);
+
+      const mediaBlock = result.find((b) => b.type === 'media');
+      expect(mediaBlock).toStrictEqual({
+        type: 'media',
+        mimeType: 'application/pdf',
+        data: 'JVBERi0xLjQ=',
+        encoding: 'base64',
+        filename: 'quarterly-report.pdf',
       });
     });
 

--- a/packages/core/src/utils/generateContentResponseUtilities.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.ts
@@ -224,7 +224,9 @@ interface LegacyPartLike {
   functionResponse?:
     | { id?: string; name?: string; response?: unknown }
     | undefined;
-  inlineData?: { mimeType?: string; data?: string } | undefined;
+  inlineData?:
+    | { mimeType?: string; data?: string; displayName?: string }
+    | undefined;
   fileData?: { fileUri?: string; mimeType?: string } | undefined;
 }
 
@@ -313,6 +315,9 @@ function legacyPartToBlocks(part: LegacyPartLike): ContentBlock[] {
         mimeType: part.inlineData.mimeType ?? '',
         data: part.inlineData.data ?? '',
         encoding: 'base64',
+        ...(part.inlineData.displayName
+          ? { filename: part.inlineData.displayName }
+          : {}),
       },
     ];
   }

--- a/packages/providers/src/composition/aliases/codex.config
+++ b/packages/providers/src/composition/aliases/codex.config
@@ -9,7 +9,8 @@
     "context-limit": 262144,
     "prompt-caching": "24h",
     "reasoning.effort": "medium",
-    "reasoning.summary": "auto"
+    "reasoning.summary": "auto",
+    "media.pdf.enabled": false
   },
   "staticModels": [
     { "id": "gpt-5.6-sol", "name": "GPT-5.6 Sol", "contextWindow": 262144 },

--- a/packages/providers/src/composition/providerAliases.codex.test.ts
+++ b/packages/providers/src/composition/providerAliases.codex.test.ts
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi } from 'vitest';
-
-// This test needs real config files, not the global mock
-vi.unmock('./providerAliases.js');
+import { describe, it, expect } from 'vitest';
 
 import { loadProviderAliasEntries } from './providerAliases.js';
 import * as fs from 'fs';
@@ -121,5 +118,14 @@ describe('Codex provider alias', () => {
       expect(model).toBeDefined();
       expect(model?.contextWindow).toBe(262144);
     }
+  });
+
+  it('pins media.pdf.enabled=false in ephemeralSettings @issue:2608', () => {
+    const aliases = loadProviderAliasEntries();
+    const codexAlias = aliases.find((a) => a.alias === 'codex');
+
+    expect(codexAlias?.config.ephemeralSettings['media.pdf.enabled']).toBe(
+      false,
+    );
   });
 });

--- a/packages/providers/src/openai-responses/OpenAIResponsesInputBuilder.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesInputBuilder.ts
@@ -28,6 +28,10 @@ import {
   normalizeMediaToDataUri,
   classifyMediaBlock,
   buildUnsupportedMediaPlaceholder,
+  buildPdfDisabledNotice,
+  inlineBase64ByteLength,
+  resolvePdfFilename,
+  PDF_AGGREGATE_MAX_BYTES,
 } from '../utils/mediaUtils.js';
 import type {
   ResponsesContentPart,
@@ -46,6 +50,7 @@ export interface ResponsesInputBuildContext {
    * which may be on without an active parent (#207).
    */
   serverSideParentActive?: boolean;
+  mediaPdfEnabled: boolean;
 }
 
 const OPENAI_RESPONSES_REASONING_ID_KEY = 'openai.responses.reasoningId';
@@ -61,6 +66,7 @@ export function buildOpenAIResponsesInput(
     reasoningIdCounter += 1;
     return id;
   };
+  const mediaPdfEnabled = isMediaPdfEnabled(context);
 
   for (const item of patchedContent) {
     appendInputForContent(
@@ -69,10 +75,46 @@ export function buildOpenAIResponsesInput(
       patchedContent,
       context,
       nextReasoningId,
+      mediaPdfEnabled,
     );
   }
 
+  enforcePdfAggregateLimit(input, context);
   return input;
+}
+
+function isMediaPdfEnabled(context: ResponsesInputBuildContext): boolean {
+  return context.mediaPdfEnabled !== false;
+}
+
+function enforcePdfAggregateLimit(
+  input: ResponsesInputItem[],
+  context: ResponsesInputBuildContext,
+): void {
+  const userItems = input.filter(
+    (
+      item,
+    ): item is { role: 'user'; content?: string | ResponsesContentPart[] } =>
+      'role' in item && item.role === 'user',
+  );
+  const fileParts = userItems.flatMap((item) =>
+    Array.isArray(item.content) ? item.content : [],
+  );
+  const total = fileParts
+    .filter(
+      (part): part is Extract<ResponsesContentPart, { type: 'input_file' }> =>
+        part.type === 'input_file',
+    )
+    .reduce((sum, part) => sum + inlineBase64ByteLength(part.file_data), 0);
+  if (total > PDF_AGGREGATE_MAX_BYTES) {
+    context.debug(
+      () =>
+        `PDF aggregate preflight failed: ${total} bytes exceeds ${PDF_AGGREGATE_MAX_BYTES} bytes (50 MB) limit`,
+    );
+    throw new Error(
+      `Native PDF input payload (${total} bytes) exceeds the allowed ${PDF_AGGREGATE_MAX_BYTES} bytes (50 MB). Reduce the number or size of PDF files.`,
+    );
+  }
 }
 
 function appendInputForContent(
@@ -81,9 +123,10 @@ function appendInputForContent(
   patchedContent: IContent[],
   context: ResponsesInputBuildContext,
   nextReasoningId: () => string,
+  mediaPdfEnabled: boolean,
 ): void {
   if (item.speaker === 'human') {
-    appendHumanInput(input, item);
+    appendHumanInput(input, item, mediaPdfEnabled);
     return;
   }
 
@@ -92,16 +135,17 @@ function appendInputForContent(
     return;
   }
 
-  appendToolInput(input, item, patchedContent, context);
+  appendToolInput(input, item, patchedContent, context, mediaPdfEnabled);
 }
 
 function appendHumanInput(
   input: ResponsesInputItem[],
   content: IContent,
+  mediaPdfEnabled: boolean,
 ): void {
   const hasMedia = content.blocks.some((block) => block.type === 'media');
   if (hasMedia) {
-    const parts = buildMediaAwareParts(content.blocks);
+    const parts = buildMediaAwareParts(content.blocks, mediaPdfEnabled);
     if (parts.length > 0) input.push({ role: 'user', content: parts });
     return;
   }
@@ -178,10 +222,13 @@ function appendToolInput(
   content: IContent,
   patchedContent: IContent[],
   context: ResponsesInputBuildContext,
+  mediaPdfEnabled: boolean,
 ): void {
   const mediaBlocks = content.blocks.filter(
     (block): block is MediaBlock => block.type === 'media',
   );
+
+  let emittedOutput = false;
 
   for (const toolResponseBlock of content.blocks.filter(
     (block) => block.type === 'tool_response',
@@ -209,8 +256,17 @@ function appendToolInput(
         context.outputLimiterConfig,
       ),
     });
+    emittedOutput = true;
+  }
 
-    appendToolMediaInput(input, mediaBlocks);
+  // Media is emitted once per tool turn, not once per tool_response.
+  // recordCompletedToolHistory flattens all parallel responses + media into
+  // a single tool IContent; emitting inside the loop above would duplicate
+  // media N times for N responses.
+  if (emittedOutput && mediaBlocks.length > 0) {
+    const mediaParts = buildMediaParts(mediaBlocks, mediaPdfEnabled);
+    if (mediaParts.length > 0)
+      input.push({ role: 'user', content: mediaParts });
   }
 }
 
@@ -236,16 +292,6 @@ function getLimitedToolOutput(
     message?: string;
   };
   return limited.content ?? limited.message ?? '';
-}
-
-function appendToolMediaInput(
-  input: ResponsesInputItem[],
-  mediaBlocks: MediaBlock[],
-): void {
-  if (mediaBlocks.length === 0) return;
-
-  const mediaParts = buildMediaParts(mediaBlocks);
-  if (mediaParts.length > 0) input.push({ role: 'user', content: mediaParts });
 }
 
 function hasMatchingToolCall(
@@ -280,32 +326,42 @@ function hasMatchingToolResponse(
 
 function buildMediaAwareParts(
   blocks: IContent['blocks'],
+  mediaPdfEnabled: boolean,
 ): ResponsesContentPart[] {
   const parts: ResponsesContentPart[] = [];
   for (const block of blocks) {
     if (block.type === 'text' && block.text) {
       parts.push({ type: 'input_text', text: block.text });
     } else if (block.type === 'media') {
-      parts.push(convertMediaBlock(block));
+      parts.push(convertMediaBlock(block, mediaPdfEnabled));
     }
   }
   return parts;
 }
 
-function buildMediaParts(mediaBlocks: MediaBlock[]): ResponsesContentPart[] {
-  return mediaBlocks.map(convertMediaBlock);
+function buildMediaParts(
+  mediaBlocks: MediaBlock[],
+  mediaPdfEnabled: boolean,
+): ResponsesContentPart[] {
+  return mediaBlocks.map((block) => convertMediaBlock(block, mediaPdfEnabled));
 }
 
-function convertMediaBlock(media: MediaBlock): ResponsesContentPart {
+function convertMediaBlock(
+  media: MediaBlock,
+  mediaPdfEnabled: boolean,
+): ResponsesContentPart {
   const category = classifyMediaBlock(media);
   if (category === 'image') {
     return { type: 'input_image', image_url: normalizeMediaToDataUri(media) };
   }
   if (category === 'pdf') {
+    if (!mediaPdfEnabled) {
+      return { type: 'input_text', text: buildPdfDisabledNotice(media) };
+    }
     return {
       type: 'input_file',
       file_data: normalizeMediaToDataUri(media),
-      ...(media.filename ? { filename: media.filename } : {}),
+      filename: resolvePdfFilename(media),
     };
   }
   return {

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.pdf.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.pdf.test.ts
@@ -30,6 +30,7 @@ import type {
   ResponsesInputItem,
   ResponsesContentPart,
 } from '../OpenAIResponsesTypes.js';
+import { PDF_AGGREGATE_MAX_BYTES } from '../../utils/mediaUtils.js';
 
 const stubConfig: ToolOutputSettingsProvider = {
   getEphemeralSettings: () => ({}),
@@ -357,8 +358,6 @@ describe('OpenAIResponsesInputBuilder PDF @issue:2608', () => {
   });
 
   describe('aggregate 50 MB native PDF preflight', () => {
-    const MAX_BYTES = 50_000_000;
-
     function pdfOfSizeBytes(bytes: number, filename: string): MediaBlock {
       return {
         type: 'media',
@@ -381,7 +380,7 @@ describe('OpenAIResponsesInputBuilder PDF @issue:2608', () => {
               speaker: 'tool',
               blocks: [
                 toolResponse('call_boundary'),
-                pdfOfSizeBytes(MAX_BYTES, 'big.pdf'),
+                pdfOfSizeBytes(PDF_AGGREGATE_MAX_BYTES, 'big.pdf'),
               ],
             },
           ],
@@ -391,7 +390,7 @@ describe('OpenAIResponsesInputBuilder PDF @issue:2608', () => {
     });
 
     it('fails when aggregate native PDF payload is one byte over the boundary', () => {
-      const overBytes = MAX_BYTES + 1;
+      const overBytes = PDF_AGGREGATE_MAX_BYTES + 1;
       expect(() =>
         buildOpenAIResponsesInput(
           [
@@ -409,11 +408,13 @@ describe('OpenAIResponsesInputBuilder PDF @issue:2608', () => {
           ],
           buildContext(),
         ),
-      ).toThrow(new RegExp(`${overBytes}.*${MAX_BYTES}.*50\\s*MB`, 'i'));
+      ).toThrow(
+        new RegExp(`${overBytes}.*${PDF_AGGREGATE_MAX_BYTES}.*50\\s*MB`, 'i'),
+      );
     });
 
     it('fails with an unambiguous error including exact actual/allowed bytes and 50 MB', () => {
-      const overBytes = MAX_BYTES + 1024;
+      const overBytes = PDF_AGGREGATE_MAX_BYTES + 1024;
       let thrown: unknown;
       try {
         buildOpenAIResponsesInput(
@@ -438,7 +439,7 @@ describe('OpenAIResponsesInputBuilder PDF @issue:2608', () => {
       expect(thrown).toBeInstanceOf(Error);
       const message = String((thrown as Error).message);
       expect(message).toContain(String(overBytes));
-      expect(message).toContain(String(MAX_BYTES));
+      expect(message).toContain(String(PDF_AGGREGATE_MAX_BYTES));
       expect(message).toMatch(/50\s*MB/i);
     });
 
@@ -485,7 +486,7 @@ describe('OpenAIResponsesInputBuilder PDF @issue:2608', () => {
               speaker: 'tool',
               blocks: [
                 toolResponse('call_disabled_huge'),
-                pdfOfSizeBytes(MAX_BYTES + 1024, 'huge.pdf'),
+                pdfOfSizeBytes(PDF_AGGREGATE_MAX_BYTES + 1024, 'huge.pdf'),
               ],
             },
           ],
@@ -502,7 +503,7 @@ describe('OpenAIResponsesInputBuilder PDF @issue:2608', () => {
               speaker: 'tool',
               blocks: [
                 toolResponse('call_orphan'),
-                pdfOfSizeBytes(MAX_BYTES + 1024, 'orphan.pdf'),
+                pdfOfSizeBytes(PDF_AGGREGATE_MAX_BYTES + 1024, 'orphan.pdf'),
               ],
             },
           ],

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.pdf.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.pdf.test.ts
@@ -409,7 +409,7 @@ describe('OpenAIResponsesInputBuilder PDF @issue:2608', () => {
           ],
           buildContext(),
         ),
-      ).toThrow(new RegExp(`50000001.*50000000|50\\\\s*MB`));
+      ).toThrow(new RegExp(`${overBytes}.*${MAX_BYTES}.*50\\s*MB`, 'i'));
     });
 
     it('fails with an unambiguous error including exact actual/allowed bytes and 50 MB', () => {

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.pdf.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.pdf.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Behavioral tests for OpenAIResponsesInputBuilder PDF handling (issue #2608).
+ * Each test calls buildOpenAIResponsesInput with realistic IContent[] histories.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { MediaBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { ToolOutputSettingsProvider } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
+import {
+  buildOpenAIResponsesInput,
+  type ResponsesInputBuildContext,
+} from '../OpenAIResponsesInputBuilder.js';
+import type {
+  ResponsesInputItem,
+  ResponsesContentPart,
+} from '../OpenAIResponsesTypes.js';
+
+const stubConfig: ToolOutputSettingsProvider = {
+  getEphemeralSettings: () => ({}),
+};
+
+function buildContext(
+  overrides: Partial<ResponsesInputBuildContext> = {},
+): ResponsesInputBuildContext {
+  return {
+    includeReasoningInContext: true,
+    outputLimiterConfig: stubConfig,
+    debug: () => {},
+    mediaPdfEnabled: true,
+    ...overrides,
+  };
+}
+
+function pdfMediaBlock(overrides: Partial<MediaBlock> = {}): MediaBlock {
+  return {
+    type: 'media',
+    mimeType: 'application/pdf',
+    data: 'JVBERi0xLjQKJdPr6e0=',
+    encoding: 'base64',
+    filename: 'quarterly-report.pdf',
+    ...overrides,
+  };
+}
+
+type InputArray = Parameters<typeof buildOpenAIResponsesInput>[0];
+
+function toolCall(id: string, path: string): Record<string, unknown> {
+  return {
+    type: 'tool_call',
+    id,
+    name: 'read_file',
+    parameters: { path },
+  };
+}
+
+function toolResponse(callId: string): Record<string, unknown> {
+  return {
+    type: 'tool_response',
+    callId,
+    toolName: 'read_file',
+    result: { output: 'Binary content provided (1 item(s)).' },
+  };
+}
+
+/** A single tool_call + single tool_response + single media block. */
+function singlePdfTurn(
+  callId: string,
+  media: Partial<MediaBlock> = {},
+): InputArray {
+  return [
+    { speaker: 'ai', blocks: [toolCall(callId, media.filename ?? 'doc.pdf')] },
+    {
+      speaker: 'tool',
+      blocks: [toolResponse(callId), pdfMediaBlock(media)],
+    },
+  ];
+}
+
+function allUserParts(input: ResponsesInputItem[]): ResponsesContentPart[] {
+  return input
+    .filter(
+      (i): i is { role: 'user'; content: ResponsesContentPart[] } =>
+        'role' in i && i.role === 'user' && Array.isArray(i.content),
+    )
+    .flatMap((u) => u.content);
+}
+
+function inputFiles(parts: ResponsesContentPart[]) {
+  return parts.filter(
+    (p): p is Extract<ResponsesContentPart, { type: 'input_file' }> =>
+      p.type === 'input_file',
+  );
+}
+
+function inputTexts(parts: ResponsesContentPart[]) {
+  return parts.filter(
+    (p): p is Extract<ResponsesContentPart, { type: 'input_text' }> =>
+      p.type === 'input_text',
+  );
+}
+
+function calls(input: ResponsesInputItem[]) {
+  return input.filter(
+    (i): i is Extract<ResponsesInputItem, { type: 'function_call' }> =>
+      'type' in i && i.type === 'function_call',
+  );
+}
+
+function outputs(input: ResponsesInputItem[]) {
+  return input.filter(
+    (i): i is Extract<ResponsesInputItem, { type: 'function_call_output' }> =>
+      'type' in i && i.type === 'function_call_output',
+  );
+}
+
+function filesFrom(input: ResponsesInputItem[]) {
+  return inputFiles(allUserParts(input));
+}
+
+function textsFrom(input: ResponsesInputItem[]) {
+  return inputTexts(allUserParts(input));
+}
+
+describe('OpenAIResponsesInputBuilder PDF @issue:2608', () => {
+  describe('enabled PDF input (default)', () => {
+    it('emits input_file with data URI and source filename', () => {
+      const input = buildOpenAIResponsesInput(
+        singlePdfTurn('call_pdf'),
+        buildContext(),
+      );
+      const files = filesFrom(input);
+      expect(files).toHaveLength(1);
+      expect(files[0].file_data).toMatch(/^data:application\/pdf;base64,/);
+      expect(files[0].filename).toBe('quarterly-report.pdf');
+    });
+
+    it.each([
+      ['no filename', undefined],
+      ['empty-string filename', ''],
+      ['whitespace-only filename', '   '],
+    ])('falls back to document.pdf when media has %s', (_label, filename) => {
+      const input = buildOpenAIResponsesInput(
+        singlePdfTurn('call_fb', { filename }),
+        buildContext(),
+      );
+      expect(filesFrom(input)[0].filename).toBe('document.pdf');
+    });
+
+    it('preserves a nonempty filename exactly without trimming', () => {
+      const input = buildOpenAIResponsesInput(
+        singlePdfTurn('call_sp', { filename: 'my report.pdf' }),
+        buildContext(),
+      );
+      expect(filesFrom(input)[0].filename).toBe('my report.pdf');
+    });
+
+    it('preserves tool-call / tool-response pairing alongside enabled PDF media', () => {
+      const input = buildOpenAIResponsesInput(
+        singlePdfTurn('call_pair'),
+        buildContext(),
+      );
+      expect(calls(input)).toHaveLength(1);
+      expect(outputs(input)).toHaveLength(1);
+      expect(calls(input)[0].call_id).toBe('call_pair');
+    });
+  });
+
+  describe('disabled PDF input', () => {
+    function disabledTurn(callId: string): InputArray {
+      return singlePdfTurn(callId, { filename: 'report.pdf' });
+    }
+
+    it('emits input_text notice instead of input_file', () => {
+      const input = buildOpenAIResponsesInput(
+        disabledTurn('call_disabled'),
+        buildContext({ mediaPdfEnabled: false }),
+      );
+      expect(filesFrom(input)).toHaveLength(0);
+      expect(textsFrom(input)).toHaveLength(1);
+    });
+
+    it('notice states the PDF was not read', () => {
+      const input = buildOpenAIResponsesInput(
+        disabledTurn('call_notice'),
+        buildContext({ mediaPdfEnabled: false }),
+      );
+      expect(textsFrom(input)[0].text.toLowerCase()).toContain('not read');
+    });
+
+    it('notice names the file and suggests extraction or rendering', () => {
+      const input = buildOpenAIResponsesInput(
+        disabledTurn('call_named'),
+        buildContext({ mediaPdfEnabled: false }),
+      );
+      const notice = textsFrom(input)[0].text.toLowerCase();
+      expect(notice).toContain('report.pdf');
+      expect(notice.includes('extract') || notice.includes('render')).toBe(
+        true,
+      );
+    });
+
+    it('retains valid tool-call / tool-response pairing', () => {
+      const input = buildOpenAIResponsesInput(
+        disabledTurn('call_paired_disabled'),
+        buildContext({ mediaPdfEnabled: false }),
+      );
+      expect(calls(input)).toHaveLength(1);
+      expect(outputs(input)).toHaveLength(1);
+      expect(calls(input)[0].call_id).toBe('call_paired_disabled');
+    });
+  });
+
+  describe('parallel PDF tool results (separate tool IContents)', () => {
+    it('serializes each once without cross-tool duplication', () => {
+      const input = buildOpenAIResponsesInput(
+        [
+          {
+            speaker: 'ai',
+            blocks: [toolCall('call_a', 'a.pdf'), toolCall('call_b', 'b.pdf')],
+          },
+          {
+            speaker: 'tool',
+            blocks: [
+              toolResponse('call_a'),
+              pdfMediaBlock({ filename: 'a.pdf', data: 'YWFhYWE=' }),
+            ],
+          },
+          {
+            speaker: 'tool',
+            blocks: [
+              toolResponse('call_b'),
+              pdfMediaBlock({ filename: 'b.pdf', data: 'YmJiYmI=' }),
+            ],
+          },
+        ],
+        buildContext(),
+      );
+      const files = filesFrom(input);
+      expect(files).toHaveLength(2);
+      expect(files.map((f) => f.filename).sort()).toStrictEqual([
+        'a.pdf',
+        'b.pdf',
+      ]);
+    });
+  });
+
+  describe('production-flattened tool turn (recordCompletedToolHistory shape) @issue:2608', () => {
+    // recordCompletedToolHistory flattens ALL parallel tool responses + media
+    // into ONE tool IContent. N responses + M media must emit exactly M media,
+    // not N*M.
+    function flattenedTurn(): InputArray {
+      return [
+        {
+          speaker: 'ai',
+          blocks: [toolCall('call_a', 'a.pdf'), toolCall('call_b', 'b.pdf')],
+        },
+        {
+          speaker: 'tool',
+          blocks: [
+            toolResponse('call_a'),
+            toolResponse('call_b'),
+            pdfMediaBlock({ filename: 'a.pdf' }),
+            pdfMediaBlock({ filename: 'b.pdf' }),
+          ],
+        },
+      ];
+    }
+
+    it('emits exactly two input_file parts when enabled (not 4 from duplication)', () => {
+      const input = buildOpenAIResponsesInput(flattenedTurn(), buildContext());
+      const files = filesFrom(input);
+      expect(files).toHaveLength(2);
+      expect(files.map((f) => f.filename).sort()).toStrictEqual([
+        'a.pdf',
+        'b.pdf',
+      ]);
+    });
+
+    it('emits exactly two distinct notices when disabled (not 4 from duplication)', () => {
+      const input = buildOpenAIResponsesInput(
+        flattenedTurn(),
+        buildContext({ mediaPdfEnabled: false }),
+      );
+      const texts = textsFrom(input);
+      expect(texts).toHaveLength(2);
+      expect(texts.some((t) => t.text.includes('a.pdf'))).toBe(true);
+      expect(texts.some((t) => t.text.includes('b.pdf'))).toBe(true);
+    });
+
+    it('preserves two function_call and two function_call_output pairing', () => {
+      const input = buildOpenAIResponsesInput(flattenedTurn(), buildContext());
+      expect(calls(input)).toHaveLength(2);
+      expect(outputs(input)).toHaveLength(2);
+    });
+
+    it('does not emit orphan media when no valid function_call_output exists', () => {
+      const input = buildOpenAIResponsesInput(
+        [
+          {
+            speaker: 'tool',
+            blocks: [
+              toolResponse('call_orphan'),
+              pdfMediaBlock({ filename: 'orphan.pdf' }),
+            ],
+          },
+        ],
+        buildContext(),
+      );
+      expect(filesFrom(input)).toHaveLength(0);
+    });
+  });
+
+  describe('existing image/media behavior unchanged', () => {
+    it('still emits input_image for image media blocks regardless of mediaPdfEnabled', () => {
+      const input = buildOpenAIResponsesInput(
+        [
+          {
+            speaker: 'ai',
+            blocks: [toolCall('call_img', 'diagram.png')],
+          },
+          {
+            speaker: 'tool',
+            blocks: [
+              toolResponse('call_img'),
+              {
+                type: 'media',
+                mimeType: 'image/png',
+                data: 'iVBORw0KGgo=',
+                encoding: 'base64',
+                filename: 'diagram.png',
+              },
+            ],
+          },
+        ],
+        buildContext({ mediaPdfEnabled: false }),
+      );
+      expect(
+        allUserParts(input).filter((p) => p.type === 'input_image'),
+      ).toHaveLength(1);
+    });
+  });
+
+  describe('aggregate 50 MB native PDF preflight', () => {
+    const MAX_BYTES = 50_000_000;
+
+    function pdfOfSizeBytes(bytes: number, filename: string): MediaBlock {
+      return {
+        type: 'media',
+        mimeType: 'application/pdf',
+        data: Buffer.from('A'.repeat(bytes)).toString('base64'),
+        encoding: 'base64',
+        filename,
+      };
+    }
+
+    it('passes when aggregate native PDF payload is exactly at the boundary', () => {
+      expect(() =>
+        buildOpenAIResponsesInput(
+          [
+            {
+              speaker: 'ai',
+              blocks: [toolCall('call_boundary', 'big.pdf')],
+            },
+            {
+              speaker: 'tool',
+              blocks: [
+                toolResponse('call_boundary'),
+                pdfOfSizeBytes(MAX_BYTES, 'big.pdf'),
+              ],
+            },
+          ],
+          buildContext(),
+        ),
+      ).not.toThrow();
+    });
+
+    it('fails when aggregate native PDF payload is one byte over the boundary', () => {
+      const overBytes = MAX_BYTES + 1;
+      expect(() =>
+        buildOpenAIResponsesInput(
+          [
+            {
+              speaker: 'ai',
+              blocks: [toolCall('call_over', 'huge.pdf')],
+            },
+            {
+              speaker: 'tool',
+              blocks: [
+                toolResponse('call_over'),
+                pdfOfSizeBytes(overBytes, 'huge.pdf'),
+              ],
+            },
+          ],
+          buildContext(),
+        ),
+      ).toThrow(new RegExp(`50000001.*50000000|50\\\\s*MB`));
+    });
+
+    it('fails with an unambiguous error including exact actual/allowed bytes and 50 MB', () => {
+      const overBytes = MAX_BYTES + 1024;
+      let thrown: unknown;
+      try {
+        buildOpenAIResponsesInput(
+          [
+            {
+              speaker: 'ai',
+              blocks: [toolCall('call_msg', 'huge.pdf')],
+            },
+            {
+              speaker: 'tool',
+              blocks: [
+                toolResponse('call_msg'),
+                pdfOfSizeBytes(overBytes, 'huge.pdf'),
+              ],
+            },
+          ],
+          buildContext(),
+        );
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      const message = String((thrown as Error).message);
+      expect(message).toContain(String(overBytes));
+      expect(message).toContain(String(MAX_BYTES));
+      expect(message).toMatch(/50\s*MB/i);
+    });
+
+    it('passes four 4 MB PDFs in a production-flattened multi-response turn (16 MB actual, no duplication)', () => {
+      const input = buildOpenAIResponsesInput(
+        [
+          {
+            speaker: 'ai',
+            blocks: [
+              toolCall('call_f1', 'f1.pdf'),
+              toolCall('call_f2', 'f2.pdf'),
+              toolCall('call_f3', 'f3.pdf'),
+              toolCall('call_f4', 'f4.pdf'),
+            ],
+          },
+          {
+            speaker: 'tool',
+            blocks: [
+              toolResponse('call_f1'),
+              toolResponse('call_f2'),
+              toolResponse('call_f3'),
+              toolResponse('call_f4'),
+              pdfOfSizeBytes(4 * 1024 * 1024, 'f1.pdf'),
+              pdfOfSizeBytes(4 * 1024 * 1024, 'f2.pdf'),
+              pdfOfSizeBytes(4 * 1024 * 1024, 'f3.pdf'),
+              pdfOfSizeBytes(4 * 1024 * 1024, 'f4.pdf'),
+            ],
+          },
+        ],
+        buildContext(),
+      );
+      expect(filesFrom(input)).toHaveLength(4);
+    });
+
+    it('does not count disabled PDFs toward the aggregate limit', () => {
+      expect(() =>
+        buildOpenAIResponsesInput(
+          [
+            {
+              speaker: 'ai',
+              blocks: [toolCall('call_disabled_huge', 'huge.pdf')],
+            },
+            {
+              speaker: 'tool',
+              blocks: [
+                toolResponse('call_disabled_huge'),
+                pdfOfSizeBytes(MAX_BYTES + 1024, 'huge.pdf'),
+              ],
+            },
+          ],
+          buildContext({ mediaPdfEnabled: false }),
+        ),
+      ).not.toThrow();
+    });
+
+    it('does not count oversized PDFs in orphan tool content (no matching tool_call)', () => {
+      expect(() =>
+        buildOpenAIResponsesInput(
+          [
+            {
+              speaker: 'tool',
+              blocks: [
+                toolResponse('call_orphan'),
+                pdfOfSizeBytes(MAX_BYTES + 1024, 'orphan.pdf'),
+              ],
+            },
+          ],
+          buildContext(),
+        ),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.stateful.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.stateful.test.ts
@@ -40,6 +40,7 @@ function buildContext(
     includeReasoningInContext: true,
     outputLimiterConfig: stubConfig,
     debug: () => {},
+    mediaPdfEnabled: true,
     ...overrides,
   };
 }

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.toolPairing.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.toolPairing.test.ts
@@ -32,6 +32,7 @@ function buildContext(
     includeReasoningInContext: true,
     outputLimiterConfig: stubConfig,
     debug: () => {},
+    mediaPdfEnabled: true,
     ...overrides,
   };
 }

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.pdf.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.pdf.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provider-level tests proving the media.pdf.enabled capability reaches the
+ * actual request body through the executor resolution path
+ * (invocation ephemeral → getModelBehavior → settings; default enabled)
+ * without model-name conditionals (issue #2608).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  clearActiveProviderRuntimeContext,
+  createProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { OpenAIResponsesProvider } from '../OpenAIResponsesProvider.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+
+const originalFetch = global.fetch;
+const mockFetch = vi.fn();
+
+function pdfToolContinuation(): Array<{
+  speaker: string;
+  blocks: Array<Record<string, unknown>>;
+}> {
+  return [
+    {
+      speaker: 'ai',
+      blocks: [
+        {
+          type: 'tool_call',
+          id: 'call_pdf_exec',
+          name: 'read_file',
+          parameters: { absolute_path: 'report.pdf' },
+        },
+      ],
+    },
+    {
+      speaker: 'tool',
+      blocks: [
+        {
+          type: 'tool_response',
+          callId: 'call_pdf_exec',
+          toolName: 'read_file',
+          result: { output: 'Binary content provided (1 item(s)).' },
+        },
+        {
+          type: 'media',
+          mimeType: 'application/pdf',
+          data: 'JVBERi0xLjQK',
+          encoding: 'base64',
+          filename: 'report.pdf',
+        },
+      ],
+    },
+  ];
+}
+
+async function captureRequestBody(
+  provider: OpenAIResponsesProvider,
+  options: ReturnType<typeof createProviderCallOptions>,
+): Promise<Record<string, unknown>> {
+  let capturedBody: string | undefined;
+  mockFetch.mockImplementation(
+    async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      if (init?.body instanceof Blob) {
+        capturedBody = await init.body.text();
+      }
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    },
+  );
+
+  for await (const _content of provider.generateChatCompletion(options)) {
+    // Consume generator
+  }
+
+  expect(capturedBody).toBeDefined();
+  if (typeof capturedBody !== 'string') {
+    throw new Error('Request body was not captured');
+  }
+  const parsed: unknown = JSON.parse(capturedBody);
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('Request body is not an object');
+  }
+  return parsed;
+}
+
+function inputPartsFromBody(
+  body: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  const input = body['input'];
+  if (!Array.isArray(input)) return [];
+  return input.filter(
+    (item): item is Record<string, unknown> =>
+      typeof item === 'object' && item !== null,
+  );
+}
+
+function flattenUserContentParts(
+  body: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  const parts: Array<Record<string, unknown>> = [];
+  for (const item of inputPartsFromBody(body)) {
+    if (item['role'] === 'user' && Array.isArray(item['content'])) {
+      parts.push(
+        ...item['content'].filter(
+          (p): p is Record<string, unknown> =>
+            typeof p === 'object' && p !== null,
+        ),
+      );
+    }
+  }
+  return parts;
+}
+
+describe('OpenAIResponsesProvider PDF request construction @issue:2608', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockClear();
+    global.fetch = mockFetch as unknown as typeof fetch;
+    setActiveProviderRuntimeContext(
+      createProviderRuntimeContext({
+        settingsService: new SettingsService(),
+        runtimeId: 'openai-responses-pdf-test',
+      }),
+    );
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+    global.fetch = originalFetch;
+  });
+
+  it('emits input_file with source filename when media.pdf.enabled is unset (default enabled)', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-api-key',
+      'https://api.openai.com/v1',
+    );
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.2');
+
+    const runtime = createProviderRuntimeContext({
+      runtimeId: 'pdf-default-runtime',
+      settingsService: settings,
+    });
+
+    const options = createProviderCallOptions({
+      providerName: provider.name,
+      settings,
+      runtime,
+      contents: pdfToolContinuation(),
+    });
+
+    const body = await captureRequestBody(provider, options);
+    const parts = flattenUserContentParts(body);
+    const files = parts.filter((p) => p['type'] === 'input_file');
+    expect(files).toHaveLength(1);
+    expect(files[0]['filename']).toBe('report.pdf');
+    expect(String(files[0]['file_data'])).toMatch(
+      /^data:application\/pdf;base64,/,
+    );
+  });
+
+  it('emits input_text notice and no input_file when ephemeral sets media.pdf.enabled=false', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-api-key',
+      'https://api.openai.com/v1',
+    );
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.2');
+
+    const runtime = createProviderRuntimeContext({
+      runtimeId: 'pdf-disabled-runtime',
+      settingsService: settings,
+    });
+
+    const options = createProviderCallOptions({
+      providerName: provider.name,
+      settings,
+      runtime,
+      ephemerals: { 'media.pdf.enabled': false },
+      contents: pdfToolContinuation(),
+    });
+
+    const body = await captureRequestBody(provider, options);
+    const parts = flattenUserContentParts(body);
+    expect(parts.filter((p) => p['type'] === 'input_file')).toHaveLength(0);
+    const texts = parts.filter((p) => p['type'] === 'input_text');
+    expect(texts).toHaveLength(1);
+    const notice = String(texts[0]['text']);
+    expect(notice).toContain(
+      'was not read because native PDF input is disabled for this provider',
+    );
+    expect(notice).toContain('report.pdf');
+    expect(/[Ee]xtract|[Rr]ender/.test(notice)).toBe(true);
+  });
+
+  it('still emits input_file when ephemeral explicitly sets media.pdf.enabled=true', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-api-key',
+      'https://api.openai.com/v1',
+    );
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.2');
+
+    const runtime = createProviderRuntimeContext({
+      runtimeId: 'pdf-enabled-runtime',
+      settingsService: settings,
+    });
+
+    const options = createProviderCallOptions({
+      providerName: provider.name,
+      settings,
+      runtime,
+      ephemerals: { 'media.pdf.enabled': true },
+      contents: pdfToolContinuation(),
+    });
+
+    const body = await captureRequestBody(provider, options);
+    const parts = flattenUserContentParts(body);
+    const files = parts.filter((p) => p['type'] === 'input_file');
+    expect(files).toHaveLength(1);
+    expect(files[0]['filename']).toBe('report.pdf');
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -337,6 +337,12 @@ function buildInput(
     (options as { settings?: { get: (key: string) => unknown } }).settings?.get(
       'reasoning.includeInContext',
     );
+  const mediaPdfEnabledSetting =
+    (invocationEphemerals['media.pdf.enabled'] as boolean | undefined) ??
+    options.invocation.getModelBehavior<boolean>('media.pdf.enabled') ??
+    (options as { settings?: { get: (key: string) => unknown } }).settings?.get(
+      'media.pdf.enabled',
+    );
   const outputLimiterConfig =
     options.config ??
     options.runtime?.config ??
@@ -349,6 +355,7 @@ function buildInput(
     outputLimiterConfig,
     debug: (messageFactory) => deps.logger.debug(messageFactory),
     serverSideParentActive,
+    mediaPdfEnabled: mediaPdfEnabledSetting !== false,
   });
 }
 

--- a/packages/providers/src/runtime/ephemeralSettings.mediaPdf.test.ts
+++ b/packages/providers/src/runtime/ephemeralSettings.mediaPdf.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-vi.unmock('./providerAliases.js');
+vi.unmock('../composition/providerAliases.js');
 
 import {
   isValidEphemeralSetting,

--- a/packages/providers/src/runtime/ephemeralSettings.mediaPdf.test.ts
+++ b/packages/providers/src/runtime/ephemeralSettings.mediaPdf.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.unmock('./providerAliases.js');
+
+import {
+  isValidEphemeralSetting,
+  ephemeralSettingHelp,
+} from './ephemeralSettings.js';
+import { loadProviderAliasEntries } from '../composition/providerAliases.js';
+
+describe('media.pdf.enabled ephemeral setting @issue:2608', () => {
+  describe('registry validation', () => {
+    it('accepts media.pdf.enabled=true', () => {
+      expect(isValidEphemeralSetting('media.pdf.enabled', true)).toBe(true);
+    });
+
+    it('accepts media.pdf.enabled=false', () => {
+      expect(isValidEphemeralSetting('media.pdf.enabled', false)).toBe(true);
+    });
+
+    it('rejects media.pdf.enabled=invalid string', () => {
+      expect(isValidEphemeralSetting('media.pdf.enabled', 'maybe')).toBe(false);
+    });
+
+    it('rejects media.pdf.enabled=123 (wrong type)', () => {
+      expect(isValidEphemeralSetting('media.pdf.enabled', 123)).toBe(false);
+    });
+  });
+
+  describe('ephemeralSettingHelp', () => {
+    it('includes media.pdf.enabled in descriptions', () => {
+      expect(ephemeralSettingHelp['media.pdf.enabled']).toBeDefined();
+    });
+
+    it('mentions PDF in the description', () => {
+      const description = ephemeralSettingHelp['media.pdf.enabled'] ?? '';
+      expect(description.toLowerCase()).toContain('pdf');
+    });
+  });
+
+  describe('Codex alias pins media.pdf.enabled=false', () => {
+    it('sets media.pdf.enabled=false in ephemeralSettings', () => {
+      const aliases = loadProviderAliasEntries();
+      const codexAlias = aliases.find((a) => a.alias === 'codex');
+
+      expect(codexAlias?.config.ephemeralSettings['media.pdf.enabled']).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/packages/providers/src/utils/mediaUtils.test.ts
+++ b/packages/providers/src/utils/mediaUtils.test.ts
@@ -20,6 +20,8 @@ import {
   classifyMediaBlock,
   buildUnsupportedMediaPlaceholder,
   detectImageMimeTypeFromBase64,
+  buildPdfDisabledNotice,
+  inlineBase64ByteLength,
 } from './mediaUtils.js';
 import type { MediaBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 
@@ -336,5 +338,101 @@ ${webpBase64.slice(8)}
     expect(detectImageMimeTypeFromBase64('!!!not-valid-base64-!@#$')).toBe(
       null,
     );
+  });
+});
+
+describe('buildPdfDisabledNotice @issue:2608', () => {
+  it('names the file when filename is known', () => {
+    const media: MediaBlock = {
+      type: 'media',
+      mimeType: 'application/pdf',
+      data: 'AAA',
+      encoding: 'base64',
+      filename: 'invoice.pdf',
+    };
+    const notice = buildPdfDisabledNotice(media);
+    expect(notice).toContain('invoice.pdf');
+  });
+
+  it('states the PDF was not read', () => {
+    const media: MediaBlock = {
+      type: 'media',
+      mimeType: 'application/pdf',
+      data: 'AAA',
+      encoding: 'base64',
+      filename: 'doc.pdf',
+    };
+    expect(buildPdfDisabledNotice(media).toLowerCase()).toContain('not read');
+  });
+
+  it('suggests text extraction or page rendering', () => {
+    const media: MediaBlock = {
+      type: 'media',
+      mimeType: 'application/pdf',
+      data: 'AAA',
+      encoding: 'base64',
+      filename: 'doc.pdf',
+    };
+    const notice = buildPdfDisabledNotice(media).toLowerCase();
+    expect(notice.includes('extract') || notice.includes('render')).toBe(true);
+  });
+
+  it('falls back to document.pdf when filename is absent', () => {
+    const media: MediaBlock = {
+      type: 'media',
+      mimeType: 'application/pdf',
+      data: 'AAA',
+      encoding: 'base64',
+    };
+    expect(buildPdfDisabledNotice(media)).toContain('document.pdf');
+  });
+
+  it('falls back to document.pdf when filename is whitespace-only', () => {
+    const media: MediaBlock = {
+      type: 'media',
+      mimeType: 'application/pdf',
+      data: 'AAA',
+      encoding: 'base64',
+      filename: '   ',
+    };
+    expect(buildPdfDisabledNotice(media)).toContain('document.pdf');
+  });
+
+  it('falls back to document.pdf when filename is empty', () => {
+    const media: MediaBlock = {
+      type: 'media',
+      mimeType: 'application/pdf',
+      data: 'AAA',
+      encoding: 'base64',
+      filename: '',
+    };
+    expect(buildPdfDisabledNotice(media)).toContain('document.pdf');
+  });
+});
+
+describe('inlineBase64ByteLength @issue:2608', () => {
+  it('computes decoded byte length for an inline data-URI base64 payload', () => {
+    const raw = Buffer.from('A'.repeat(1024)).toString('base64');
+    expect(inlineBase64ByteLength(`data:application/pdf;base64,${raw}`)).toBe(
+      1024,
+    );
+  });
+
+  it('returns 0 for a bare URL (not inline base64)', () => {
+    expect(inlineBase64ByteLength('https://example.com/doc.pdf')).toBe(0);
+  });
+
+  it('returns 0 for a non-base64 data URI', () => {
+    expect(inlineBase64ByteLength('data:text/plain,hello')).toBe(0);
+  });
+
+  it('returns 0 for an empty payload', () => {
+    expect(inlineBase64ByteLength('data:application/pdf;base64,')).toBe(0);
+  });
+
+  it('computes correct length for unpadded base64', () => {
+    const padded = Buffer.from('abc').toString('base64');
+    const data = `data:application/pdf;base64,${padded.endsWith('=') ? padded.slice(0, -1) : padded}`;
+    expect(inlineBase64ByteLength(data)).toBe(3);
   });
 });

--- a/packages/providers/src/utils/mediaUtils.test.ts
+++ b/packages/providers/src/utils/mediaUtils.test.ts
@@ -436,4 +436,8 @@ describe('inlineBase64ByteLength @issue:2608', () => {
       inlineBase64ByteLength(`data:application/pdf;base64,${unpadded}`),
     ).toBe(2);
   });
+
+  it('accepts case-insensitive base64 encoding tokens', () => {
+    expect(inlineBase64ByteLength('data:application/pdf;BASE64,YWJj')).toBe(3);
+  });
 });

--- a/packages/providers/src/utils/mediaUtils.test.ts
+++ b/packages/providers/src/utils/mediaUtils.test.ts
@@ -431,8 +431,9 @@ describe('inlineBase64ByteLength @issue:2608', () => {
   });
 
   it('computes correct length for unpadded base64', () => {
-    const padded = Buffer.from('abc').toString('base64');
-    const data = `data:application/pdf;base64,${padded.endsWith('=') ? padded.slice(0, -1) : padded}`;
-    expect(inlineBase64ByteLength(data)).toBe(3);
+    const unpadded = Buffer.from('ab').toString('base64').slice(0, -1);
+    expect(
+      inlineBase64ByteLength(`data:application/pdf;base64,${unpadded}`),
+    ).toBe(2);
   });
 });

--- a/packages/providers/src/utils/mediaUtils.ts
+++ b/packages/providers/src/utils/mediaUtils.ts
@@ -149,7 +149,7 @@ export function buildPdfDisabledNotice(media: MediaBlock): string {
  * Does not decode or allocate the payload; uses O(1)-memory length math.
  */
 export function inlineBase64ByteLength(data: string): number {
-  const dataMatch = data.match(/^data:[^;]*;base64,(.*)$/s);
+  const dataMatch = data.match(/^data:[^;]*;base64,(.*)$/is);
   if (dataMatch === null) return 0;
   const normalized = dataMatch[1].replaceAll(/\s/g, '');
   if (normalized === '') return 0;

--- a/packages/providers/src/utils/mediaUtils.ts
+++ b/packages/providers/src/utils/mediaUtils.ts
@@ -121,3 +121,43 @@ export function normalizeMediaToDataUri(media: MediaBlock): string {
     : 'data:image/*;base64,';
   return `${prefix}${media.data}`;
 }
+
+export const PDF_DEFAULT_FILENAME = 'document.pdf';
+
+export const PDF_AGGREGATE_MAX_BYTES = 50_000_000;
+
+export function resolvePdfFilename(media: MediaBlock): string {
+  const name = media.filename;
+  if (name === undefined || name.trim() === '') return PDF_DEFAULT_FILENAME;
+  return name;
+}
+
+export function buildPdfDisabledNotice(media: MediaBlock): string {
+  return (
+    `The PDF "${resolvePdfFilename(media)}" was not read because native PDF input is disabled for this provider. ` +
+    `Extract its text or render pages to images, then provide that content instead.`
+  );
+}
+
+/**
+ * Computes the decoded byte length of an inline base64 data URI.
+ *
+ * Counts only actual `data:*;base64,` payloads — bare URLs or non-base64
+ * data URIs return 0. This avoids miscounting URL-referenced `file_data`
+ * fields as inline base64 bytes during aggregate limit checks.
+ *
+ * Does not decode or allocate the payload; uses O(1)-memory length math.
+ */
+export function inlineBase64ByteLength(data: string): number {
+  const dataMatch = data.match(/^data:[^;]*;base64,(.*)$/s);
+  if (dataMatch === null) return 0;
+  const normalized = dataMatch[1].replaceAll(/\s/g, '');
+  if (normalized === '') return 0;
+  let padding = 0;
+  if (normalized.endsWith('==')) {
+    padding = 2;
+  } else if (normalized.endsWith('=')) {
+    padding = 1;
+  }
+  return Math.floor((normalized.length * 3) / 4) - padding;
+}

--- a/packages/settings/src/settings/registry/registry-entries-1.ts
+++ b/packages/settings/src/settings/registry/registry-entries-1.ts
@@ -273,6 +273,14 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     persistToProfile: true,
   },
   {
+    key: 'media.pdf.enabled',
+    category: 'model-behavior',
+    description:
+      'Send PDF files as native input_file data to the model (true/false); when false, PDFs are replaced with a text notice',
+    type: 'boolean',
+    persistToProfile: true,
+  },
+  {
     key: 'rate-limit-throttle',
     category: 'model-behavior',
     description: 'Enable proactive rate limit throttling (on/off)',

--- a/packages/tools/src/utils/fileUtils.test.ts
+++ b/packages/tools/src/utils/fileUtils.test.ts
@@ -19,7 +19,7 @@ import path from 'node:path';
 import os from 'node:os';
 import mime from 'mime-types';
 
-import { detectFileType } from './fileUtils.js';
+import { detectFileType, processSingleFileContent } from './fileUtils.js';
 
 vi.mock('mime-types', () => ({
   default: { lookup: vi.fn() },
@@ -104,5 +104,42 @@ describe('fileUtils.detectFileType', () => {
     const textPath = path.join(tempRootDir, 'unknown.xyz');
     actualNodeFs.writeFileSync(textPath, 'plain text content\n');
     expect(await detectFileType(textPath)).toBe('text');
+  });
+});
+
+describe('processSingleFileContent media displayName @issue:2608', () => {
+  let tempRootDir: string;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    tempRootDir = actualNodeFs.mkdtempSync(
+      path.join(os.tmpdir(), 'tools-fileUtils-pdf-test-'),
+    );
+  });
+
+  afterEach(() => {
+    try {
+      if (actualNodeFs.existsSync(tempRootDir)) {
+        actualNodeFs.rmSync(tempRootDir, { recursive: true, force: true });
+      }
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('preserves the source basename as inlineData.displayName for a PDF', async () => {
+    mockMimeLookup.mockReturnValue('application/pdf');
+    const pdfPath = path.join(tempRootDir, 'sub', 'quarterly-report.pdf');
+    actualNodeFs.mkdirSync(path.dirname(pdfPath), { recursive: true });
+    actualNodeFs.writeFileSync(pdfPath, Buffer.from('%PDF-1.4\n%bin\n'));
+
+    const result = await processSingleFileContent(pdfPath, tempRootDir);
+
+    expect(result.llmContent).toMatchObject({
+      inlineData: expect.objectContaining({
+        displayName: 'quarterly-report.pdf',
+        mimeType: 'application/pdf',
+      }),
+    });
   });
 });

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -408,6 +408,7 @@ async function processMediaFile(
       inlineData: {
         data: base64Data,
         mimeType,
+        displayName: path.basename(relativePathForDisplay),
       },
     },
     returnDisplay: `Read ${fileType} file: ${relativePathForDisplay}`,

--- a/project-plans/issue-2608-codex-pdf-input.md
+++ b/project-plans/issue-2608-codex-pdf-input.md
@@ -1,0 +1,166 @@
+# Issue #2608 — Codex PDF input capability and filename preservation
+
+## Policy basis
+
+`dev-docs/workflow/ISSUE-DELIVERY.md` does not exist on this checkout,
+`origin/main`, or the repository contents API. This plan applies the bounded
+issue-delivery policy supplied with the issue request verbatim: stop before any
+unplanned subsystem/public abstraction, workflow, agent-memory, quality-tool,
+dependency, unrelated-refactor/test-move, or out-of-matrix behavior change;
+target at most 25 files and 1,500 net lines; review scope above either target;
+and stop without approval above 40 files or 2,500 net lines.
+
+## Goal
+
+Keep PDF-bearing tool continuations valid for the selected OpenAI Responses
+backend. Codex must receive a truthful model-visible notice instead of an
+unsupported `input_file`; PDF-capable endpoints must receive valid file data
+with a source or deterministic fallback filename.
+
+## Decisions
+
+- `media.pdf.enabled` is a `model-behavior` setting. `RuntimeInvocationContext`
+  separates registry entries by category and `getModelBehavior()` reads only
+  that category.
+- Absence of the setting preserves current public OpenAI Responses behavior:
+  native PDF input remains enabled. The Codex alias explicitly sets it to
+  `false`.
+- The 50 MB aggregate native-file boundary fails locally with a clear preflight
+  error. The limit is decimal `50_000_000` bytes (the documented external
+  provider limit), not binary `50 * 1024 * 1024`. This is the accepted fail-fast
+  option for a documented external provider limit; unsupported Codex PDFs still
+  degrade to text and continue.
+- Preserve the source basename, not an absolute path. Legacy/history blocks
+  without a filename use `document.pdf` only when native PDF input is enabled.
+- The parallel Gemini `ContentConverters.ts` path is outside the failing
+  read_file → Codex continuation and is not authorized in this issue.
+
+## Acceptance matrix
+
+| AC | Accepted behavior | Behavioral evidence |
+| --- | --- | --- |
+| A1 | With native PDF disabled, the active Responses builder emits no `input_file` for PDF tool output. | Active-builder test using realistic tool-call/tool-response/media continuation. |
+| A2 | The replacement is model-visible `input_text` stating the PDF was not read, naming it when known, and suggesting text extraction or page rendering; pairing remains valid so the loop can continue. | Active-builder continuation test asserts notice contents and function-call/output pairing. |
+| A3 | Codex declares PDF input unsupported through `media.pdf.enabled=false`, not a model-name conditional. | Codex alias config test plus provider/executor request-construction test with invocation ephemeral precedence. |
+| A4 | PDF-enabled Responses requests emit `input_file` with a PDF data URI and a non-empty source filename. | Active-builder test with a realistic media block produced by the read/history shape. |
+| A5 | `read_file` media output preserves the source basename through neutral history into serialization. | Real file utility boundary test, legacy-part conversion test, and active-builder assertion. |
+| A6 | A legacy PDF block without a filename uses `document.pdf` when native PDF input is enabled. | Active-builder fallback test. |
+| A7 | Parallel PDF tool results are serialized exactly once each without cross-tool duplication. | Active-builder multi-tool continuation test checks counts, filenames, and call IDs. |
+| A8 | Aggregate native PDF input above 50 MB is rejected before network submission with a clear actual/allowed-size error; disabled PDFs are not counted. | Builder boundary tests immediately below/above the combined limit and disabled-PDF exclusion test. |
+| A9 | Existing image/media behavior and tool-call/output pairing do not change. | Existing stateful/tool-pairing suites plus focused image regression if needed. |
+| A10 | The setting is registry-validated and obeys invocation → model behavior → settings precedence with enabled-by-default semantics. | Ephemeral registry tests and provider/executor request-body tests. |
+
+## Explicit non-goals
+
+- No PDF-to-image rendering or thumbnail fallback.
+- No PDF text extraction.
+- No hydrated `capabilities.pdf` plumbing from the model registry.
+- No changes to the inactive `buildResponsesInputFromContent` helper.
+- No changes to Gemini `ContentConverters.ts` or other provider subsystems.
+- No new public abstraction, dependency, profile schema, workflow, agent memory,
+  quality rule, lint/complexity threshold, suppression, or source exclusion.
+- No unrelated refactor, test relocation, optional hardening, or cleanup after
+  accepted behavior and gates pass.
+
+## Bounded vertical slices
+
+1. **Filename preservation** — RED tests at `processMediaFile` and
+   `legacyPartsToBlocks`; GREEN by carrying `inlineData.displayName` and mapping
+   it to `MediaBlock.filename`.
+2. **Capability declaration and validation** — RED registry/alias tests; GREEN
+   with the boolean model-behavior registry entry and Codex alias default.
+3. **Active serialization behavior** — RED active-builder tests for enabled,
+   disabled, missing-filename, parallel, and paired continuation cases; GREEN by
+   resolving/threading the capability and emitting valid file or explicit text.
+4. **Aggregate limit** — RED exact-boundary tests; GREEN with one builder
+   preflight over native PDF payload bytes and a clear local error.
+5. **Provider request construction** — RED provider-level request-body tests for
+   precedence/default behavior; GREEN through the same executor path, with no
+   provider/model-name branch.
+
+## Expected paths
+
+### Plan
+
+- `project-plans/issue-2608-codex-pdf-input.md`
+
+### Production/configuration
+
+- `packages/tools/src/utils/fileUtils.ts`
+- `packages/core/src/utils/generateContentResponseUtilities.ts`
+- `packages/providers/src/openai-responses/OpenAIResponsesInputBuilder.ts`
+- `packages/providers/src/openai-responses/openAIResponsesExecutor.ts`
+- `packages/providers/src/utils/mediaUtils.ts`
+- `packages/settings/src/settings/registry/registry-entries-1.ts`
+- `packages/providers/src/composition/aliases/codex.config`
+
+### Behavioral tests
+
+- `packages/tools/src/utils/fileUtils.test.ts`
+- `packages/core/src/utils/generateContentResponseUtilities.test.ts`
+- `packages/providers/src/utils/mediaUtils.test.ts`
+- `packages/providers/src/composition/providerAliases.codex.test.ts`
+- `packages/providers/src/runtime/ephemeralSettings.mediaPdf.test.ts` (new)
+- `packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.pdf.test.ts` (new)
+- `packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.pdf.test.ts` (new, only if needed to prove executor/request construction without duplicating existing provider harness coverage)
+- `packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.stateful.test.ts`
+- `packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.toolPairing.test.ts`
+
+Expected maximum: 17 paths including this plan, approximately 700–1,100 net
+changed lines. The provider-level PDF test is conditional within this ledger;
+using an existing provider test instead does not authorize another path.
+
+## Scope ledger
+
+| Slice/item | Status | Authorized paths | Notes |
+| --- | --- | --- | --- |
+| Acceptance and scope record | Complete | plan | Canonical file absent; supplied policy recorded. |
+| Filename preservation | Complete | tools/core utility + tests | `inlineData.displayName` → `MediaBlock.filename`. |
+| Capability registry and Codex alias | Complete | registry, alias, registry/alias tests | `media.pdf.enabled` model-behavior setting; Codex `false`. |
+| Builder gating and notice | Complete | Responses builder, media helper, tests | F1 hoist, F2 decimal limit, F4 inline-only counting. |
+| Executor resolution/default/precedence | Complete | executor, provider test | Invocation → model behavior → settings; default enabled. |
+| Aggregate 50 MB preflight | Complete | builder + builder tests | `PDF_AGGREGATE_MAX_BYTES = 50_000_000`; unambiguous error. |
+| Existing context test updates | Complete | stateful/toolPairing tests | `mediaPdfEnabled: true` added. |
+| Dead code removal (F3) | Complete | mediaUtils + test | `base64DecodedByteLength` deleted. |
+| PDF-to-image/text extraction | Non-goal | none | Requires separate acceptance and approval. |
+| Gemini converter symmetry | Non-goal | none | Unrelated provider path. |
+| Hydrated capability plumbing | Non-goal | none | Unplanned subsystem expansion. |
+| Workflow/memory/quality/dependency changes | Prohibited | none | Stop for approval if proposed. |
+
+Any additional path or behavior must be entered here and classified before edit.
+Reviewer findings will be classified as `Blocker-Fix`, `In-scope-Fix`, `Reject`,
+or `Defer`; review comments do not expand this ledger.
+
+### Review finding dispositions
+
+| Finding | Classification | Resolution |
+| --- | --- | --- |
+| F1 N×M media duplication | Blocker-Fix | Hoisted media emission out of per-response loop; emits once per tool turn if ≥1 output emitted. |
+| F2 Binary limit / ambiguous errors | Blocker-Fix | `50_000_000` decimal; error includes exact bytes + `50 MB`; four-4MB multi-response test added. |
+| F3 Dead `base64DecodedByteLength` | In-scope-Fix | Export and all direct tests deleted. |
+| F4 URL miscounted as base64 | In-scope-Fix | Renamed to `inlineBase64ByteLength`; counts only `data:*;base64,` payloads; returns 0 for bare URLs. |
+| F5 Filename preservation test | In-scope-Fix | Added behavioral test through `convertToFunctionResponse` with `processMediaFile`-shaped inlineData. |
+| F6/F7 ProviderMediaSupport / inactive builder | Reject | No unification or modification. |
+| F8 Other `vi.unmock` cleanup | Defer | Out of scope. |
+
+### Mandatory scope review
+
+DeepThinker review was attempted twice but blocked by the profile's usage limit;
+Architect completed the independent mandatory scope review instead. Final exact
+counts (all untracked lines counted as additions):
+
+| Category | Additions | Deletions |
+| --- | --- | --- |
+| Tracked (13 files) | 351 | 26 |
+| Untracked (4 files) | 989 | 0 |
+| **Total** | **1340** | **26** |
+
+**Net: 1314** (within ≤1500 target; below 2500 hard stop).
+
+## Completion evidence
+
+Exact-head completion requires all matrix behaviors to have behavioral evidence;
+focused and full local verification to pass; independent architecture and OCR
+review findings to be classified and all accepted fixes resolved; candidate-head
+CI and PR review checks to pass; correct ancestry and conflict-free mergeability;
+and the final file/line counts to remain within this clean ledger.


### PR DESCRIPTION
## TLDR

Fixes Codex PDF tool-result continuations so unsupported native PDF input no longer causes a provider 400 and terminates the agent loop.

- Preserves the source basename from read_file through neutral history.
- Adds the request-time media.pdf.enabled model behavior and disables it in the built-in Codex alias.
- Emits a truthful model-visible notice instead of input_file when native PDF input is disabled.
- Emits valid input_file data with a deterministic filename for PDF-capable Responses endpoints.
- Prevents parallel tool-result media duplication and rejects aggregate inline PDF payloads above the documented 50 MB limit before network submission.

## Dive Deeper

The active continuation path previously mapped every PDF MediaBlock to an OpenAI Responses input_file, even for the private Codex endpoint, which does not accept that content type. The same path discarded the source filename before serialization.

This change keeps provider compatibility at the serialization boundary:

- processMediaFile records the source basename as inlineData.displayName.
- Legacy-part conversion maps that value to MediaBlock.filename.
- media.pdf.enabled follows invocation ephemeral → model behavior → settings precedence and defaults to enabled for existing public Responses behavior.
- The Codex alias explicitly sets the capability to false.
- Disabled PDFs become input_text notices that state the PDF was not read, identify the file, and suggest extracting text or rendering pages.
- Enabled PDFs always carry a non-empty filename, falling back to document.pdf for legacy data.
- The active builder emits media once per flattened parallel tool turn rather than once per tool response.
- Aggregate validation counts only emitted inline base64 file parts and reports exact actual/allowed byte counts above 50,000,000 bytes.

The bounded delivery plan and review triage are recorded in project-plans/issue-2608-codex-pdf-input.md.

## Reviewer Test Plan

1. Run the focused provider/core/tools tests:

       cd packages/providers
       npx vitest run src/openai-responses/__tests__/OpenAIResponsesInputBuilder.pdf.test.ts src/openai-responses/__tests__/OpenAIResponsesProvider.pdf.test.ts src/runtime/ephemeralSettings.mediaPdf.test.ts src/utils/mediaUtils.test.ts src/composition/providerAliases.codex.test.ts

       cd ../core
       npx vitest run src/utils/generateContentResponseUtilities.test.ts

       cd ../tools
       npx vitest run src/utils/fileUtils.test.ts

2. With the Codex alias selected, ask the model to inspect multiple local PDF files in parallel. Confirm the continuation reaches the model, contains one explicit not-read notice per PDF, and does not send input_file.
3. With a PDF-capable public OpenAI Responses configuration, inspect a local PDF and confirm the outgoing request contains a PDF data URI and the source filename.
4. Run the complete local gates:

       npm run test
       npm run lint
       npm run typecheck
       npm run format
       npm run build

5. Smoke tests completed with both the ollamakimi and stepfun-37 profiles.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2608
