### PR TITLE
Add C (.c, .h) language support for ast_edit AST validation (Fixes #1761)

### DIFF
--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-c-validation.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-c-validation.test.ts
@@ -1,0 +1,449 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for ast_edit C language support (issue #1761).
+ *
+ * Covers four acceptance areas:
+ * 1. AST validation: valid C passes, broken C fails with line/column
+ * 2. C-specific constructs parse correctly (preprocessor, pointers,
+ *    function pointers, unions, structs)
+ * 3. .h header files use the same language mapping as .c files
+ * 4. Context collection: C declarations (functions, structs, enums,
+ *    unions, typedefs) and imports (#include) are extracted
+ */
+
+import { describe, it, expect } from 'vitest';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  useTempDir,
+  createFakeToolHost,
+  executePreview,
+} from './test-helpers.js';
+import { ASTEditTool } from '../../ast-edit.js';
+import { ASTQueryExtractor } from '../ast-query-extractor.js';
+import { extractImports } from '../language-analysis.js';
+
+const cFilePath = join('test.c');
+
+describe('ast_edit AST validation: C', () => {
+  const ctx = useTempDir();
+
+  it('reports AST PASSED for valid C', async () => {
+    const filePath = join(ctx.tempDir, 'valid.c');
+    writeFileSync(
+      filePath,
+      'int add(int a, int b) {\n    return a + b;\n}\n',
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'return a + b;',
+      new_string: 'return a + b + 0;',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+  });
+
+  it('reports AST FAILED with line/column for missing semicolon', async () => {
+    const filePath = join(ctx.tempDir, 'missing-semicolon.c');
+    writeFileSync(
+      filePath,
+      'int main(void) {\n    int x = 42;\n    return 0;\n}\n',
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'int x = 42;',
+      new_string: 'int x = 42',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('AST validation: FAILED');
+    expect(output).toContain('AST errors:');
+    expect(output).toMatch(/Syntax error at line \d+, column \d+/);
+  });
+
+  it('reports AST FAILED for missing closing brace', async () => {
+    const filePath = join(ctx.tempDir, 'missing-brace.c');
+    writeFileSync(filePath, 'int main(void) {\n    return 0;\n}\n', 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const brokenResult = await executePreview(tool, {
+      file_path: filePath,
+      old_string: '    return 0;\n}',
+      new_string: '    return 0;\n',
+    });
+
+    expect(brokenResult.error).toBeUndefined();
+    expect(String(brokenResult.llmContent)).toContain('AST validation: FAILED');
+  });
+});
+
+describe('ast_edit C-specific constructs', () => {
+  const ctx = useTempDir();
+
+  it('reports AST PASSED for preprocessor directives (#include, #define)', async () => {
+    const filePath = join(ctx.tempDir, 'preproc.c');
+    writeFileSync(
+      filePath,
+      [
+        '#include <stdio.h>',
+        '#define MAX 100',
+        'int main(void) {',
+        '    printf("%d", MAX);',
+        '    return 0;',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'printf("%d", MAX);',
+      new_string: 'printf("%d", MAX + 1);',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+  });
+
+  it('reports AST PASSED for pointer declarations', async () => {
+    const filePath = join(ctx.tempDir, 'pointers.c');
+    writeFileSync(
+      filePath,
+      [
+        'int main(void) {',
+        '    int x = 10;',
+        '    int *p = &x;',
+        '    return *p;',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'int *p = &x;',
+      new_string: 'int *p = &x; int *q = p;',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+  });
+
+  it('reports AST PASSED for function pointers', async () => {
+    const filePath = join(ctx.tempDir, 'fnptr.c');
+    writeFileSync(
+      filePath,
+      [
+        'typedef int (*compare_fn)(int, int);',
+        'int ascending(int a, int b) { return a - b; }',
+        'int main(void) {',
+        '    compare_fn cmp = ascending;',
+        '    return cmp(1, 2);',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'cmp(1, 2);',
+      new_string: 'cmp(3, 4);',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+  });
+
+  it('reports AST PASSED for unions', async () => {
+    const filePath = join(ctx.tempDir, 'union.c');
+    writeFileSync(
+      filePath,
+      [
+        'union Data {',
+        '    int i;',
+        '    float f;',
+        '};',
+        'int main(void) {',
+        '    union Data d;',
+        '    d.i = 42;',
+        '    return d.i;',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'd.i = 42;',
+      new_string: 'd.i = 100;',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+  });
+
+  it('reports AST PASSED for struct definitions', async () => {
+    const filePath = join(ctx.tempDir, 'struct.c');
+    writeFileSync(
+      filePath,
+      [
+        'struct Point {',
+        '    int x;',
+        '    int y;',
+        '};',
+        'int main(void) {',
+        '    struct Point p;',
+        '    p.x = 1;',
+        '    p.y = 2;',
+        '    return p.x + p.y;',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'p.x = 1;',
+      new_string: 'p.x = 10;',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+  });
+});
+
+describe('ast_edit .h header files', () => {
+  const ctx = useTempDir();
+
+  it('reports AST PASSED for valid .h header file', async () => {
+    const filePath = join(ctx.tempDir, 'header.h');
+    writeFileSync(
+      filePath,
+      [
+        '#ifndef HEADER_H',
+        '#define HEADER_H',
+        'typedef struct {',
+        '    int x;',
+        '    int y;',
+        '} Point;',
+        'Point create_point(int x, int y);',
+        '#endif',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'int x;',
+      new_string: 'int x; int z;',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+  });
+
+  it('reports AST FAILED for broken .h header file', async () => {
+    const filePath = join(ctx.tempDir, 'broken.h');
+    writeFileSync(
+      filePath,
+      'typedef struct {\n    int x;\n} Point;\n',
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'int x;',
+      new_string: 'int x',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('AST validation: FAILED');
+    expect(output).toMatch(/Syntax error at line \d+, column \d+/);
+  });
+});
+
+describe('ast_edit C declaration extraction', () => {
+  it('extracts C functions with signatures', async () => {
+    const extractor = new ASTQueryExtractor();
+    const code = 'int add(int a, int b) {\n    return a + b;\n}\n';
+
+    const declarations = await extractor.extractDeclarations(cFilePath, code);
+
+    const functions = declarations.filter((d) => d.type === 'function');
+    expect(functions).toHaveLength(1);
+    expect(functions[0].name).toBe('add');
+    expect(functions[0].line).toBe(1);
+    expect(functions[0].signature).toBe('(int a, int b)');
+  });
+
+  it('extracts struct definitions', async () => {
+    const extractor = new ASTQueryExtractor();
+    const code = 'struct Point {\n    int x;\n    int y;\n};\n';
+
+    const declarations = await extractor.extractDeclarations(cFilePath, code);
+
+    const structs = declarations.filter((d) => d.type === 'struct');
+    expect(structs).toHaveLength(1);
+    expect(structs[0].name).toBe('Point');
+  });
+
+  it('extracts union definitions', async () => {
+    const extractor = new ASTQueryExtractor();
+    const code = 'union Data {\n    int i;\n    float f;\n};\n';
+
+    const declarations = await extractor.extractDeclarations(cFilePath, code);
+
+    const unions = declarations.filter((d) => d.type === 'union');
+    expect(unions).toHaveLength(1);
+    expect(unions[0].name).toBe('Data');
+  });
+
+  it('extracts enum definitions', async () => {
+    const extractor = new ASTQueryExtractor();
+    const code = 'enum Color { RED, GREEN, BLUE };\n';
+
+    const declarations = await extractor.extractDeclarations(cFilePath, code);
+
+    const enums = declarations.filter((d) => d.type === 'enum');
+    expect(enums).toHaveLength(1);
+    expect(enums[0].name).toBe('Color');
+  });
+
+  it('extracts simple typedefs', async () => {
+    const extractor = new ASTQueryExtractor();
+    const code = 'typedef unsigned long size_t;\n';
+
+    const declarations = await extractor.extractDeclarations(cFilePath, code);
+
+    const typedefs = declarations.filter((d) => d.type === 'typedef');
+    expect(typedefs).toHaveLength(1);
+    expect(typedefs[0].name).toBe('size_t');
+  });
+
+  it('extracts function pointer typedefs', async () => {
+    const extractor = new ASTQueryExtractor();
+    const code = 'typedef int (*compare_fn)(int, int);\n';
+
+    const declarations = await extractor.extractDeclarations(cFilePath, code);
+
+    const typedefs = declarations.filter((d) => d.type === 'typedef');
+    expect(typedefs).toHaveLength(1);
+    expect(typedefs[0].name).toBe('compare_fn');
+  });
+
+  it('extracts array typedefs', async () => {
+    const extractor = new ASTQueryExtractor();
+    const code = 'typedef int buffer[10];\n';
+
+    const declarations = await extractor.extractDeclarations(cFilePath, code);
+
+    const typedefs = declarations.filter((d) => d.type === 'typedef');
+    expect(typedefs).toHaveLength(1);
+    expect(typedefs[0].name).toBe('buffer');
+  });
+
+  it('does not classify function pointer variables as function prototypes', async () => {
+    const extractor = new ASTQueryExtractor();
+    const code = 'void (*callback)(int);\n';
+
+    const declarations = await extractor.extractDeclarations(cFilePath, code);
+
+    const functions = declarations.filter((d) => d.type === 'function');
+    expect(functions).toHaveLength(0);
+  });
+
+  it('extracts declarations from a full C module', async () => {
+    const extractor = new ASTQueryExtractor();
+    const code = [
+      '#include <stdio.h>',
+      'typedef struct { int x; int y; } Point;',
+      'struct Rectangle { int w; int h; };',
+      'union Data { int i; float f; };',
+      'enum Status { OK, FAIL };',
+      'int compute(Point p) { return p.x + p.y; }',
+      '',
+    ].join('\n');
+
+    const declarations = await extractor.extractDeclarations(cFilePath, code);
+    const names = declarations.map((d) => d.name);
+    const types = declarations.map((d) => d.type);
+
+    expect(names).toContain('Point');
+    expect(types).toContain('typedef');
+    expect(names).toContain('Rectangle');
+    expect(types).toContain('struct');
+    expect(names).toContain('Data');
+    expect(types).toContain('union');
+    expect(names).toContain('Status');
+    expect(types).toContain('enum');
+    expect(names).toContain('compute');
+    expect(types).toContain('function');
+  });
+
+  it('works with .h header files for declaration extraction', async () => {
+    const extractor = new ASTQueryExtractor();
+    const headerPath = join('header.h');
+    const code = 'typedef struct { int x; } Vec;\nvoid init(Vec *v);\n';
+
+    const declarations = await extractor.extractDeclarations(headerPath, code);
+
+    const names = declarations.map((d) => d.name);
+    expect(names).toContain('Vec');
+    expect(names).toContain('init');
+  });
+});
+
+describe('ast_edit C import extraction', () => {
+  it('extracts system #include directives', () => {
+    const code = '#include <stdio.h>\n#include <stdlib.h>\n';
+    const imports = extractImports(code, 'c');
+
+    expect(imports).toHaveLength(2);
+    expect(imports[0].module).toBe('stdio.h');
+    expect(imports[0].items).toEqual([]);
+    expect(imports[0].line).toBe(1);
+    expect(imports[1].module).toBe('stdlib.h');
+    expect(imports[1].line).toBe(2);
+  });
+
+  it('extracts local #include directives with quotes', () => {
+    const code = '#include "myheader.h"\n';
+    const imports = extractImports(code, 'c');
+
+    expect(imports).toHaveLength(1);
+    expect(imports[0].module).toBe('myheader.h');
+    expect(imports[0].items).toEqual([]);
+  });
+
+  it('ignores non-include lines', () => {
+    const code = 'int main(void) { return 0; }\n// #include <fake.h>\n';
+    const imports = extractImports(code, 'c');
+
+    expect(imports).toHaveLength(0);
+  });
+});

--- a/packages/tools/src/tools/ast-edit/ast-config.ts
+++ b/packages/tools/src/tools/ast-edit/ast-config.ts
@@ -66,6 +66,7 @@ export class ASTConfig {
     java: 'java',
     cpp: 'cpp',
     c: 'c',
+    h: 'c',
     html: 'html',
     css: 'css',
     json: 'json',

--- a/packages/tools/src/tools/ast-edit/ast-query-extractor.ts
+++ b/packages/tools/src/tools/ast-edit/ast-query-extractor.ts
@@ -43,6 +43,8 @@ export class ASTQueryExtractor {
         this.extractPythonDeclarations(sgRoot, declarations);
       } else if (extension === 'rs') {
         this.extractRustDeclarations(sgRoot, declarations);
+      } else if (extension === 'c' || extension === 'h') {
+        this.extractCDeclarations(sgRoot, declarations);
       } else {
         return this.fallbackExtraction(content, extension);
       }
@@ -183,6 +185,68 @@ export class ASTQueryExtractor {
     });
   }
 
+  private extractCDeclarations(
+    sgRoot: ReturnType<ReturnType<typeof parse>['root']>,
+    declarations: EnhancedDeclaration[],
+  ): void {
+    sgRoot.findAll({ rule: { kind: 'function_definition' } }).forEach((n) => {
+      const fdec = n.find({ rule: { kind: 'function_declarator' } });
+      const nameNode = fdec?.find({ rule: { kind: 'identifier' } });
+      const paramsNode = fdec?.find({ rule: { kind: 'parameter_list' } });
+      if (nameNode != null) {
+        const signature = paramsNode != null ? paramsNode.text() : '()';
+        declarations.push(
+          this.nodeToDeclaration(n, nameNode.text(), 'function', signature),
+        );
+      }
+    });
+
+    // Function prototypes: `void init(Vec *v);` parse as `declaration` nodes
+    // containing a `function_declarator` child (no body). Function-pointer
+    // variables (`void (*fp)(int);`) also contain a `function_declarator`, but
+    // its name sits inside a `parenthesized_declarator` rather than a direct
+    // `identifier` child — those are variables, not prototypes, so skip them.
+    sgRoot.findAll({ rule: { kind: 'declaration' } }).forEach((n) => {
+      const fdec = n.find({ rule: { kind: 'function_declarator' } });
+      if (fdec == null) return;
+      const nameNode = fdec.children().find((c) => c.kind() === 'identifier');
+      if (nameNode == null) return;
+      const paramsNode = fdec.find({ rule: { kind: 'parameter_list' } });
+      const signature = paramsNode != null ? paramsNode.text() : '()';
+      declarations.push(
+        this.nodeToDeclaration(n, nameNode.text(), 'function', signature),
+      );
+    });
+
+    sgRoot.findAll({ rule: { kind: 'struct_specifier' } }).forEach((n) => {
+      const nameNode = n.children().find((c) => c.kind() === 'type_identifier');
+      if (nameNode != null) {
+        declarations.push(this.nodeToDeclaration(n, nameNode.text(), 'struct'));
+      }
+    });
+
+    sgRoot.findAll({ rule: { kind: 'union_specifier' } }).forEach((n) => {
+      const nameNode = n.children().find((c) => c.kind() === 'type_identifier');
+      if (nameNode != null) {
+        declarations.push(this.nodeToDeclaration(n, nameNode.text(), 'union'));
+      }
+    });
+
+    sgRoot.findAll({ rule: { kind: 'enum_specifier' } }).forEach((n) => {
+      const nameNode = n.children().find((c) => c.kind() === 'type_identifier');
+      if (nameNode != null) {
+        declarations.push(this.nodeToDeclaration(n, nameNode.text(), 'enum'));
+      }
+    });
+
+    sgRoot.findAll({ rule: { kind: 'type_definition' } }).forEach((n) => {
+      const name = findCTypedefName(n);
+      if (name !== null) {
+        declarations.push(this.nodeToDeclaration(n, name, 'typedef'));
+      }
+    });
+  }
+
   private buildSignature(
     paramsNode: ReturnType<ReturnType<typeof parse>['root']> | null,
     returnTypeNode: ReturnType<ReturnType<typeof parse>['root']> | null,
@@ -307,4 +371,56 @@ function extractWordAfterKeyword(line: string, keyword: string): string | null {
   const after = line.slice(idx + keyword.length);
   const match = after.trimStart().match(/^[A-Za-z_$][\w$]*/);
   return match ? match[0] : null;
+}
+
+/**
+ * Resolves the declared name of a C typedef.
+ *
+ * Tree-sitter C represents the declarator differently depending on the
+ * typedef form:
+ * - Simple: `typedef unsigned long size_t;` → a `type_identifier` child
+ *   is the declared name.
+ * - Function pointer: `typedef int (*compare_fn)(int, int);` → the name
+ *   sits inside a nested `pointer_declarator`→`type_identifier`.
+ * Returns null for anonymous typedefs without a declarator name.
+ */
+function findCTypedefName(
+  typedefNode: ReturnType<ReturnType<typeof parse>['root']>,
+): string | null {
+  const direct = typedefNode
+    .children()
+    .find((c) => c.kind() === 'type_identifier');
+  if (direct != null) {
+    return direct.text();
+  }
+  const pointerDeclarator = typedefNode.find({
+    rule: { kind: 'pointer_declarator' },
+  });
+  const pointerName = pointerDeclarator?.find({
+    rule: { kind: 'type_identifier' },
+  });
+  if (pointerName != null) {
+    return pointerName.text();
+  }
+  const arrayDeclarator = typedefNode.find({
+    rule: { kind: 'array_declarator' },
+  });
+  const arrayName = arrayDeclarator?.find({
+    rule: { kind: 'type_identifier' },
+  });
+  if (arrayName != null) {
+    return arrayName.text();
+  }
+  // `typedef unsigned long size_t;` — the grammar assigns the declared
+  // name to a trailing `primitive_type` (not `type_identifier`). The last
+  // primitive_type child before the semicolon is the typedef name.
+  const primitiveChildren = typedefNode
+    .children()
+    .filter(
+      (c) => c.kind() === 'primitive_type' || c.kind() === 'type_identifier',
+    );
+  if (primitiveChildren.length > 0) {
+    return primitiveChildren[primitiveChildren.length - 1].text();
+  }
+  return null;
 }

--- a/packages/tools/src/tools/ast-edit/language-analysis.ts
+++ b/packages/tools/src/tools/ast-edit/language-analysis.ts
@@ -58,6 +58,9 @@ export function extractImports(content: string, language: string): Import[] {
       if (parsed) {
         imports.push({ ...parsed, line: index + 1 });
       }
+    } else if (language === 'c' && isCIncludeDirective(trimmed)) {
+      const module = extractCIncludeModule(trimmed);
+      imports.push({ module, items: [], line: index + 1 });
     }
   });
 
@@ -306,4 +309,45 @@ function splitRustImportItems(itemsStr: string): string[] {
   }
   items.push(itemsStr.slice(start));
   return items;
+}
+
+/**
+ * Detects a C #include preprocessor directive.
+ * Matches `#include <stdio.h>` and `#include "myheader.h"`.
+ * Uses linear scanning to avoid regex backtracking.
+ */
+function isCIncludeDirective(line: string): boolean {
+  const hashIdx = line.indexOf('#');
+  if (hashIdx === -1) return false;
+  // Reject lines where the #include is inside a comment (e.g., `// #include <x.h>`)
+  const beforeHash = line.slice(0, hashIdx).trim();
+  if (beforeHash.length > 0) return false;
+  const includeIdx = line.indexOf('include');
+  if (includeIdx === -1 || includeIdx < hashIdx) return false;
+  const afterInclude = line.slice(includeIdx + 'include'.length);
+  const trimmed = afterInclude.trimStart();
+  return trimmed.startsWith('<') || trimmed.startsWith('"');
+}
+
+/**
+ * Extracts the module path from a C #include directive.
+ * Strips the angle brackets or double quotes, leaving the bare header name
+ * (e.g., `stdio.h` or `myheader.h`).
+ */
+function extractCIncludeModule(line: string): string {
+  const angleOpen = line.indexOf('<');
+  if (angleOpen !== -1) {
+    const angleClose = line.indexOf('>', angleOpen + 1);
+    if (angleClose !== -1) {
+      return line.slice(angleOpen + 1, angleClose);
+    }
+  }
+  const quoteOpen = line.indexOf('"');
+  if (quoteOpen !== -1) {
+    const quoteClose = line.indexOf('"', quoteOpen + 1);
+    if (quoteClose !== -1) {
+      return line.slice(quoteOpen + 1, quoteClose);
+    }
+  }
+  return 'unknown';
 }

--- a/packages/tools/src/tools/ast-edit/types.ts
+++ b/packages/tools/src/tools/ast-edit/types.ts
@@ -38,7 +38,9 @@ export interface Declaration {
     | 'struct'
     | 'trait'
     | 'enum'
-    | 'impl';
+    | 'impl'
+    | 'typedef'
+    | 'union';
   line: number;
   column: number;
   signature?: string;

--- a/packages/tools/src/utils/ast-grep-utils.ts
+++ b/packages/tools/src/utils/ast-grep-utils.ts
@@ -76,6 +76,7 @@ export const LANGUAGE_MAP: Record<string, string | Lang> = {
   java: 'java',
   cpp: 'cpp',
   c: 'c',
+  h: 'c',
   html: Lang.Html,
   css: Lang.Css,
   json: 'json',


### PR DESCRIPTION
Fixes #1761

## Summary

Adds C language support (.c and .h files) to the ast_edit tool AST validation and context collection pipeline.

The @ast-grep/lang-c grammar package was already installed and registered, and .c was already mapped in LANGUAGE_MAP, so generic AST validation (ERROR/MISSING node detection) already worked for .c files. This PR completes the integration by:

1. **Mapping .h header files** to the C language in both LANGUAGE_MAP and ASTConfig.SUPPORTED_LANGUAGES, so .h files get the same AST validation and context collection as .c files.
2. **Adding C declaration extraction** to ASTQueryExtractor - functions (definitions and prototypes), structs, unions, enums, and typedefs (including function-pointer and array typedefs) are now extracted via tree-sitter rather than falling back to regex.
3. **Adding C include import extraction** to extractImports - both system (<stdio.h>) and local ("myheader.h") includes are parsed.
4. **Adding typedef and union types** to the Declaration type union.

## Scope

6 files changed (~165 net production lines, ~470 test lines). No new dependencies added - @ast-grep/lang-c was already installed and registered.

**Non-goals:** No changes to cpp functionality, no macro expansion, no changes to the generic validateASTSyntax logic (it already worked for .c).

## Test plan

23 behavioral tests in ast-edit-c-validation.test.ts covering all acceptance areas. All 157 ast-edit tests pass.