### PR TITLE
fix(cli): fall back to fresh session on restoreHistory failure in continue mode (Fixes #1873)

### DIFF
--- a/packages/cli/src/cli.provider-init.test.ts
+++ b/packages/cli/src/cli.provider-init.test.ts
@@ -300,7 +300,7 @@ describe('cli main provider initialization', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('warns and continues to interactive startup when restoreHistory fails during --continue flow', async () => {
+  it('falls back to a fresh session and does not adopt corrupted session ID when restoreHistory fails during --continue flow (issue #1873)', async () => {
     const providerManager = {
       getActiveProvider: vi.fn().mockReturnValue({ name: 'gemini' }),
       getActiveProviderName: vi.fn().mockReturnValue('gemini'),
@@ -312,8 +312,10 @@ describe('cli main provider initialization', () => {
     const restoreHistory = vi
       .fn()
       .mockRejectedValue(new Error('restore failed on purpose'));
-    const getAgentClient = vi.fn(() => ({ restoreHistory }));
+    const resetChat = vi.fn().mockResolvedValue(undefined);
+    const getAgentClient = vi.fn(() => ({ restoreHistory, resetChat }));
 
+    const adoptSessionId = vi.fn();
     const mockConfig = {
       initialize: vi.fn().mockResolvedValue(undefined),
       refreshAuth: vi.fn().mockResolvedValue(undefined),
@@ -337,7 +339,7 @@ describe('cli main provider initialization', () => {
       getProjectRoot: vi.fn(() => '/tmp/project'),
       isInteractive: vi.fn(() => true),
       getSessionId: vi.fn(() => 'session-1'),
-      adoptSessionId: vi.fn(),
+      adoptSessionId,
       getQuestion: vi.fn(() => ''),
       getExperimentalZedIntegration: vi.fn(() => false),
       getZedIntegrationEnabled: vi.fn(() => false),
@@ -355,11 +357,17 @@ describe('cli main provider initialization', () => {
       getPolicyEngine: vi.fn(() => null),
     } as unknown as Config;
 
+    const resumeResult = makeResumeResult('restored user content');
+    const recordingDisposeSpy = resumeResult.recording.dispose as ReturnType<
+      typeof vi.fn
+    >;
+    const lockReleaseSpy = resumeResult.lockHandle.release as ReturnType<
+      typeof vi.fn
+    >;
+
     const coreModule = await import('@vybestack/llxprt-code-core');
     const resumeSessionMock = vi.mocked(coreModule.resumeSession);
-    resumeSessionMock.mockResolvedValueOnce(
-      makeResumeResult('restored user content'),
-    );
+    resumeSessionMock.mockResolvedValueOnce(resumeResult);
 
     const { loadCliConfig } = await import('./config/config.js');
     const { parseArguments } = await import('./config/cliArgParser.js');
@@ -389,16 +397,148 @@ describe('cli main provider initialization', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {});
 
-    // main() flow: resume → restoreHistory throws → catch swallows error →
-    // continues startup. If the try/catch didn't swallow the restore error,
-    // main() would throw 'restore failed on purpose'.
+    // Issue #1873: main() must NOT throw — it should fall back to a fresh
+    // session. If the try/catch didn't handle the restore error, main()
+    // would throw 'restore failed on purpose'.
     await expect(cli.main()).resolves.toBeUndefined();
 
     // resumeSession was called to load the session
     expect(resumeSessionMock).toHaveBeenCalledTimes(1);
-    // restoreHistory was called with the resumed content
+    // restoreHistory was attempted with the resumed content
     expect(restoreHistory).toHaveBeenCalledTimes(1);
-    // The rejection from restoreHistory did NOT propagate.
+
+    // Issue #1873 ACC-1: The corrupted session's ID must NOT be adopted.
+    // Previously adoptSessionId was called BEFORE restoreHistory, leaving
+    // the agent in a half-restored state (adopted session ID but history
+    // never restored) that hangs when the user sends a prompt.
+    expect(adoptSessionId).not.toHaveBeenCalled();
+
+    // Issue #1873 ACC-3: Resources from the failed resume must be released
+    // so the corrupted session file is unlocked and the recording closed.
+    expect(recordingDisposeSpy).toHaveBeenCalled();
+    expect(lockReleaseSpy).toHaveBeenCalled();
+
+    // Issue #1873: restoreHistory is not atomic — it may partially populate
+    // the AgentClient before throwing. resetChat ensures no half-restored
+    // items persist into the fresh session.
+    expect(resetChat).toHaveBeenCalledTimes(1);
+
+    resumeSessionMock.mockReset();
+    exitSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('adopts the resumed session ID and does not release resources when restoreHistory succeeds during --continue flow (issue #1873)', async () => {
+    const providerManager = {
+      getActiveProvider: vi.fn().mockReturnValue({ name: 'gemini' }),
+      getActiveProviderName: vi.fn().mockReturnValue('gemini'),
+      getServerToolsProvider: vi.fn().mockReturnValue(null),
+      hasActiveProvider: vi.fn().mockReturnValue(true),
+      setActiveProvider: vi.fn().mockReturnValue(undefined),
+    };
+
+    const restoreHistory = vi.fn().mockResolvedValue(undefined);
+    const resetChat = vi.fn().mockResolvedValue(undefined);
+    const getAgentClient = vi.fn(() => ({ restoreHistory, resetChat }));
+
+    const adoptSessionId = vi.fn();
+    const mockConfig = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      refreshAuth: vi.fn().mockResolvedValue(undefined),
+      getProviderManager: vi.fn(() => providerManager),
+      getProvider: vi.fn(() => 'gemini'),
+      getConversationLoggingEnabled: vi.fn(() => false),
+      getMcpServers: vi.fn(() => ({})),
+      getDebugMode: vi.fn(() => false),
+      getIdeMode: vi.fn(() => false),
+      getIdeClient: vi.fn(() => null),
+      getListExtensions: vi.fn(() => false),
+      getOutputFormat: vi.fn(() => OutputFormat.TEXT),
+      getToolRegistryInfo: vi.fn(() => ({
+        registered: [],
+        unregistered: [],
+      })),
+      getSandbox: vi.fn(() => false),
+      getModel: vi.fn(() => 'gemini-2.5-pro'),
+      getEphemeralSetting: vi.fn(() => undefined),
+      setEphemeralSetting: vi.fn(),
+      getProjectRoot: vi.fn(() => '/tmp/project'),
+      isInteractive: vi.fn(() => true),
+      getSessionId: vi.fn(() => 'session-1'),
+      adoptSessionId,
+      getQuestion: vi.fn(() => ''),
+      getExperimentalZedIntegration: vi.fn(() => false),
+      getZedIntegrationEnabled: vi.fn(() => false),
+      getTrustedFolder: vi.fn(() => true),
+      getProjectTempDir: vi.fn(() => '/tmp/project-temp'),
+      getContinueSessionRef: vi.fn(() => '__CONTINUE_LATEST__'),
+      getWorkspaceContext: vi.fn(() => ({
+        getDirectories: () => ['/tmp/project'],
+      })),
+      getScreenReader: vi.fn(() => false),
+      getTerminalBackground: vi.fn(() => undefined),
+
+      getAgentClient,
+      setTerminalBackground: vi.fn(),
+      getPolicyEngine: vi.fn(() => null),
+    } as unknown as Config;
+
+    const resumeResult = makeResumeResult('restored user content');
+    const recordingDisposeSpy = resumeResult.recording.dispose as ReturnType<
+      typeof vi.fn
+    >;
+    const lockReleaseSpy = resumeResult.lockHandle.release as ReturnType<
+      typeof vi.fn
+    >;
+
+    const coreModule = await import('@vybestack/llxprt-code-core');
+    const resumeSessionMock = vi.mocked(coreModule.resumeSession);
+    resumeSessionMock.mockResolvedValueOnce(resumeResult);
+
+    const { loadCliConfig } = await import('./config/config.js');
+    const { parseArguments } = await import('./config/cliArgParser.js');
+    vi.mocked(loadCliConfig).mockResolvedValueOnce(mockConfig);
+    vi.mocked(parseArguments).mockResolvedValueOnce({
+      promptInteractive: undefined,
+      prompt: undefined,
+      promptWords: [],
+      experimentalAcp: false,
+      experimentalUi: true,
+      provider: 'gemini',
+      profileLoad: undefined,
+      outputFormat: OutputFormat.TEXT,
+      extensions: [],
+      sessionSummary: undefined,
+    } as unknown as import('./config/cliArgParser.js').CliArgs);
+
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: string | number | null | undefined) => {
+        throw new Error(`EXIT_${code ?? 'unknown'}`);
+      });
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    await expect(cli.main()).resolves.toBeUndefined();
+
+    expect(resumeSessionMock).toHaveBeenCalledTimes(1);
+    expect(restoreHistory).toHaveBeenCalledTimes(1);
+
+    // On success, the resumed session ID IS adopted (correct behavior).
+    expect(adoptSessionId).toHaveBeenCalledWith('resumed-session');
+
+    // On success, resetChat is NOT called — the restored history is kept.
+    expect(resetChat).not.toHaveBeenCalled();
+
+    // On success, the resumed recording and lock are NOT disposed during
+    // startup — they are held for the session lifecycle.
+    expect(recordingDisposeSpy).not.toHaveBeenCalled();
+    expect(lockReleaseSpy).not.toHaveBeenCalled();
 
     resumeSessionMock.mockReset();
     exitSpy.mockRestore();

--- a/packages/cli/src/cliSessionBootstrap.ts
+++ b/packages/cli/src/cliSessionBootstrap.ts
@@ -87,6 +87,8 @@ export interface ResolvedRecording {
   recordingService: SessionRecordingService;
   resumedHistory: IContent[] | null;
   resumedLockHandle: LockHandle | null;
+  /** The resumed session's ID, or null for new/fallback sessions. */
+  resumedSessionId: string | null;
 }
 
 export interface SessionRecordingSetup extends ResolvedRecording {
@@ -154,6 +156,39 @@ export async function bootstrapRuntimeAndConfig(
 }
 
 /**
+ * Release resumed recording and lock after a failed restoreHistory. Each
+ * step is independently caught so cleanup failures never prevent the
+ * fresh-session fallback (issue #1873).
+ */
+async function releaseResumedResources(
+  recordingService: SessionRecordingService,
+  lockHandle: LockHandle | null,
+): Promise<void> {
+  try {
+    await recordingService.dispose();
+  } catch (err) {
+    debugLogger.warn(
+      chalk.yellow(
+        `Failed to dispose resumed recording during fallback: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      ),
+    );
+  }
+  try {
+    await lockHandle?.release();
+  } catch (err) {
+    debugLogger.warn(
+      chalk.yellow(
+        `Failed to release session lock during fallback: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      ),
+    );
+  }
+}
+
+/**
  * @plan:PLAN-20260211-SESSIONRECORDING.P26
  * @pseudocode recording-integration.md lines 115-132
  *
@@ -173,37 +208,74 @@ export async function setupSessionRecording(
   // --list-sessions / --delete-session: handle early exits.
   await handleSessionListAndDelete(argv, chatsDir, projectHash);
 
-  const { recordingService, resumedHistory, resumedLockHandle } =
-    await createOrResumeRecording(config, projectHash, chatsDir);
+  const {
+    recordingService,
+    resumedHistory,
+    resumedLockHandle,
+    resumedSessionId,
+  } = await createOrResumeRecording(config, projectHash, chatsDir);
 
-  const recordingIntegration = new RecordingIntegration(recordingService);
+  let activeRecordingService = recordingService;
+  let activeLockHandle = resumedLockHandle;
+  let didFallback = false;
 
   if (resumedHistory && resumedHistory.length > 0) {
+    const agentClient = config.getAgentClient();
     try {
-      const agentClient = config.getAgentClient();
       await agentClient.restoreHistory(resumedHistory);
+      // Adoption happens here — AFTER a successful restoreHistory — so a
+      // corrupted session's ID is never adopted. TodoStore and other
+      // session-scoped services see only a successfully-resumed session ID.
+      if (resumedSessionId !== null) {
+        config.adoptSessionId(resumedSessionId);
+      }
     } catch (err) {
       const messageText = err instanceof Error ? err.message : String(err);
       debugLogger.warn(
-        chalk.yellow('Could not restore conversation history: ' + messageText),
+        chalk.yellow(
+          `Could not restore conversation history (session ${resumedSessionId ?? 'unknown'}): ${messageText}. ` +
+            'Falling back to a new session.',
+        ),
       );
+      // restoreHistory is not atomic — it may have partially populated the
+      // AgentClient's history before throwing. Reset so no half-restored
+      // items persist into the fresh session.
+      await agentClient.resetChat();
+      await releaseResumedResources(recordingService, resumedLockHandle);
+      // Fresh session with a new UUID in the same project's chatsDir.
+      // buildNewRecordingService generates a new sessionId so the recording
+      // is fully isolated from the corrupted resumed session.
+      activeRecordingService = buildNewRecordingService(
+        config,
+        projectHash,
+        chatsDir,
+      );
+      activeLockHandle = null;
+      didFallback = true;
     }
+  } else if (resumedSessionId !== null) {
+    // Resume succeeded with no restorable content — still adopt the session ID
+    // so future events append to the resumed session's file.
+    config.adoptSessionId(resumedSessionId);
   }
+
+  const recordingIntegration = new RecordingIntegration(activeRecordingService);
 
   registerCleanup(async () => {
     recordingIntegration.dispose();
     try {
-      await recordingService.dispose();
+      await activeRecordingService.dispose();
     } finally {
-      await resumedLockHandle?.release();
+      await activeLockHandle?.release();
     }
   });
 
   return {
-    recordingService,
+    recordingService: activeRecordingService,
     recordingIntegration,
-    resumedHistory,
-    resumedLockHandle,
+    resumedHistory: didFallback ? null : resumedHistory,
+    resumedLockHandle: activeLockHandle,
+    resumedSessionId: didFallback ? null : resumedSessionId,
   };
 }
 
@@ -238,6 +310,7 @@ export async function createOrResumeRecording(
       recordingService: buildNewRecordingService(config, projectHash, chatsDir),
       resumedHistory: null,
       resumedLockHandle: null,
+      resumedSessionId: null,
     };
   }
 
@@ -260,11 +333,10 @@ export async function createOrResumeRecording(
       recordingService: buildNewRecordingService(config, projectHash, chatsDir),
       resumedHistory: null,
       resumedLockHandle: null,
+      resumedSessionId: null,
     };
   }
 
-  // FIX-1336: Adopt the restored session's ID so TodoStore uses the correct file
-  config.adoptSessionId(resumeResult.metadata.sessionId);
   for (const warning of resumeResult.warnings) {
     debugLogger.warn(chalk.yellow(warning));
   }
@@ -272,5 +344,6 @@ export async function createOrResumeRecording(
     recordingService: resumeResult.recording,
     resumedHistory: resumeResult.history,
     resumedLockHandle: resumeResult.lockHandle,
+    resumedSessionId: resumeResult.metadata.sessionId,
   };
 }

--- a/packages/cli/src/cliSessionBootstrap.ts
+++ b/packages/cli/src/cliSessionBootstrap.ts
@@ -237,19 +237,42 @@ export async function setupSessionRecording(
             'Falling back to a new session.',
         ),
       );
+      // Release resources FIRST so cleanup runs even if resetChat or
+      // buildNewRecordingService throw (issue #1873).
+      await releaseResumedResources(recordingService, resumedLockHandle);
       // restoreHistory is not atomic — it may have partially populated the
       // AgentClient's history before throwing. Reset so no half-restored
       // items persist into the fresh session.
-      await agentClient.resetChat();
-      await releaseResumedResources(recordingService, resumedLockHandle);
+      try {
+        await agentClient.resetChat();
+      } catch (resetErr) {
+        debugLogger.warn(
+          chalk.yellow(
+            `Failed to reset chat after restoreHistory failure: ${
+              resetErr instanceof Error ? resetErr.message : String(resetErr)
+            }`,
+          ),
+        );
+      }
       // Fresh session with a new UUID in the same project's chatsDir.
       // buildNewRecordingService generates a new sessionId so the recording
       // is fully isolated from the corrupted resumed session.
-      activeRecordingService = buildNewRecordingService(
-        config,
-        projectHash,
-        chatsDir,
-      );
+      try {
+        activeRecordingService = buildNewRecordingService(
+          config,
+          projectHash,
+          chatsDir,
+        );
+      } catch (buildErr) {
+        // This should be unreachable (construction just stores config),
+        // but if it throws we must not leave the session without a
+        // recording service — rethrow so startup fails loudly.
+        throw new Error(
+          `Failed to create fallback recording service: ${
+            buildErr instanceof Error ? buildErr.message : String(buildErr)
+          }`,
+        );
+      }
       activeLockHandle = null;
       didFallback = true;
     }


### PR DESCRIPTION
## Summary

Fixes #1873: Continue mode (`--continue`) can hang indefinitely after context corruption because `restoreHistory` errors were swallowed, leaving the AgentClient in a half-restored state.

## Root Cause

In `cliSessionBootstrap.ts`, `createOrResumeRecording()` called `config.adoptSessionId()` **before** `restoreHistory()` was attempted. When `restoreHistory` failed on corrupted session data, the error was caught and only logged as a warning. The session continued startup with:
- The corrupted session ID adopted into config (affecting TodoStore and other session-scoped services)
- The AgentClient's history never actually restored (or partially restored)

When the user then sent any prompt, the provider call received malformed or empty history from the half-restored state, causing an indefinite hang regardless of model selection.

## Fix

1. **Move `adoptSessionId()` after successful `restoreHistory()`** — a corrupted session's ID is never adopted
2. **On `restoreHistory` failure**: reset the agent chat (`resetChat()`), dispose the resumed recording, release the lock, and fall back to a fresh recording session with a new UUID
3. **Extract `releaseResumedResources()` helper** — each cleanup step (dispose, release) is independently caught so cleanup failures never prevent the fresh-session fallback
4. **Explicit `didFallback` boolean** instead of inferring fallback state from proxy variables

This matches the existing fallback pattern already used when `resumeSession` itself fails (line 324 of `cliSessionBootstrap.ts`).

## Acceptance Criteria

| ID | Criterion | Status |
|---|---|---|
| ACC-1 | Corrupted session ID must NOT be adopted on restore failure | ✅ `adoptSessionId` called only after successful `restoreHistory` |
| ACC-2 | Startup must NOT crash — must fall back to fresh session | ✅ `buildNewRecordingService` called on failure path |
| ACC-3 | Resources (recording service, lock handle) from failed resume must be released | ✅ `releaseResumedResources` called, independently caught |

## Test Plan

- Updated existing test to verify fallback behavior: `adoptSessionId` NOT called, `recordingDispose` called, `lockRelease` called, `resetChat` called
- Added new test verifying success path: `adoptSessionId` called with resumed session ID, resources held (NOT disposed/released), `resetChat` NOT called
- All 5 provider-init tests pass
- Build, lint, typecheck, format all clean
- Smoke test passes

## Non-Goals

- Provider timing issues from #1872 (separate issue)
- The `/continue` slash-command path in `slashCommandHandlers.ts` (separate code path, not the `--continue` CLI flag)
- ReplayEngine corruption detection improvements (ReplayEngine already handles corruption gracefully)
- New timeout mechanisms