### PR TITLE
Recover context before preflight overflow guard (Fixes #2755)

### DIFF
--- a/dev-docs/plans/2026-07-27-issue-2755-preflight-overflow-recovery.md
+++ b/dev-docs/plans/2026-07-27-issue-2755-preflight-overflow-recovery.md
@@ -1,0 +1,135 @@
+# Issue #2755 — Recover preflight context overflow before surfacing the guard
+
+The requested canonical file, `dev-docs/workflow/ISSUE-DELIVERY.md`, is not
+present on current `origin/main` or through the repository contents API. This
+plan applies the bounded issue-delivery requirements supplied with the issue.
+
+## Problem and decision
+
+The screenshot shows the CLI's `ContextWindowWillOverflow` preflight message,
+not the hard-limit error fixed for #2588. Its values are internally consistent:
+251,971 used of 262,144 leaves 10,173 tokens, while the pending request was
+estimated at 32,275 tokens.
+
+The preflight path attempts one automatic compression and bails when the result
+is a no-op or is insufficient. It does not then use the existing
+`ChatSession.enforceContextWindow()` path, which already owns density,
+compression, retry, deterministic top-down truncation, and final hard-limit
+enforcement. In addition, the initial check derives remaining capacity from
+`getLastPromptTokenCount()`, which returns zero after compression clears the API
+observation, while the recovery recheck uses the history-derived projected
+baseline. That inconsistency can make a subsequent `continue` appear to fit.
+
+Decision: use the projected prompt baseline for both checks and delegate an
+insufficient preflight compression to the existing context-window enforcer. Do
+not add a new fallback API or public abstraction.
+
+## Acceptance matrix
+
+| ID  | Given                                                                                                                                            | When                                              | Then                                                                                                            | Behavioral evidence                                                                                                                                      |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | A request exceeds the preflight threshold and ordinary compression is a no-op, but existing context-window enforcement can reduce history enough | `sendMessageStream` checks session limits         | The turn proceeds without `ContextWindowWillOverflow`                                                           | Extend `client.sendMessageStream-overflow-compression.test.ts` with a stateful overflow scenario whose enforced reduction changes the projected baseline |
+| A2  | Ordinary compression reports success but the projected baseline still leaves too little room, and existing enforcement can reduce further        | Preflight rechecks the request                    | Existing enforcement is attempted and the recovered turn proceeds                                               | Add a behavioral insufficient-compression recovery case in the same test file                                                                            |
+| A3  | Compression and existing context-window enforcement cannot make the request fit                                                                  | Preflight recovery runs                           | Exactly one `ContextWindowWillOverflow` event is emitted and the turn does not run                              | Adapt the existing insufficient-reduction case to remain unrecoverable after enforcement                                                                 |
+| A4  | Compression cleared the last API-observed prompt count but current history remains too large                                                     | A later turn performs its initial preflight check | Capacity is based on `getProjectedPromptBaseline()`, so the turn does not receive a false full-window allowance | Add a consecutive-check regression scenario that supplies zero as the last observed count and a large projected baseline                                 |
+| A5  | Ordinary compression makes sufficient room                                                                                                       | Preflight rechecks the request                    | The turn proceeds without invoking extra reduction behavior                                                     | Existing issue #2402 recovery test remains green and observes the emitted stream behavior                                                                |
+| A6  | History is empty or compression throws and recovery cannot apply                                                                                 | Preflight recovery runs                           | The existing guard behavior remains intact                                                                      | Existing skipped-empty and throwing scenarios remain green                                                                                               |
+| A7  | Initial and post-recovery checks evaluate the same request                                                                                       | Both checks calculate available capacity          | Both use the same projected baseline and `CONTEXT_OVERFLOW_THRESHOLD`                                           | A4 plus existing threshold-boundary coverage                                                                                                             |
+
+## Non-goals
+
+- Do not change the #2588 hard-limit margin policy or error construction.
+- Do not change compression strategies, retry counts, thresholds, model limits,
+  tool-response truncation, or the `/compress` command UI.
+- Do not promise that an intrinsically oversized pending request can be sent;
+  unrecoverable requests must still emit the guard.
+- Do not add a subsystem, public abstraction, workflow, dependency, quality-tool
+  change, agent-memory change, lint suppression, threshold increase, or ignore.
+- Do not move tests or perform unrelated compression/context refactors.
+
+## Bounded vertical slices
+
+1. **Projected-baseline parity (RED/GREEN):** prove the initial check cannot use
+   a cleared observed count as a zero baseline, then switch it to the existing
+   projected baseline.
+2. **No-op/insufficient recovery (RED/GREEN):** prove both recoverable outcomes,
+   then delegate to the existing `enforceContextWindow()` only after ordinary
+   compression did not make sufficient room.
+3. **Unrecoverable integrity (RED/GREEN):** prove the guard remains the final
+   outcome when existing enforcement cannot recover.
+4. **Regression verification:** run the focused overflow suites and all required
+   project gates.
+
+## Expected paths and scope ledger
+
+| Path                                                                             | Planned change                                                                                       | Acceptance   | Estimated net lines | Status      |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------ | ------------------- | ----------- |
+| `dev-docs/plans/2026-07-27-issue-2755-preflight-overflow-recovery.md`            | This bounded plan and ledger                                                                         | Policy gate  | +90                 | In scope    |
+| `packages/agents/src/core/MessageStreamOrchestrator.ts`                          | Use projected baseline for initial remaining capacity                                                | A4, A7       | 0                   | In scope    |
+| `packages/agents/src/core/preflightRecovery.ts`                                  | Escalate insufficient ordinary compression through existing context-window enforcement, then recheck | A1-A3, A5-A6 | +20                 | In scope    |
+| `packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts` | Behavioral recovery, unrecoverable, and baseline regressions                                         | A1-A7        | +120                | In scope    |
+| `packages/agents/src/core/client.sendMessageStream-overflow.test.ts`             | Adjust only if the baseline correction exposes a fixture with an inaccurate projected count          | A4, A6       | ±10                 | Conditional |
+
+Expected implementation: at most 5 files and about 240 net lines, including
+this plan. This is below the 25-file/1,500-line target and does not trigger a
+mandatory scope review. Stop for approval before any unlisted production path,
+new public surface, or behavior outside A1-A7. Hard stop above 40 files or 2,500
+net lines.
+
+### Final scope reconciliation
+
+The initial estimate intentionally counted only behavioral files. Replacing the
+baseline method required existing `ChatSession` fixture objects to implement the
+same already-public method. Those are mechanical test-contract updates, not new
+behavior, public surface, or subsystem scope.
+
+| Final scope entry                          | Files | Net lines                        | Classification                             |
+| ------------------------------------------ | ----- | -------------------------------- | ------------------------------------------ |
+| Production behavior                        | 2     | +14                              | A1-A7 implementation                       |
+| Behavioral overflow evidence               | 2     | +287                             | A1-A7 tests, including real enforcement    |
+| Agents fixture contract updates            | 11    | +30                              | Required by baseline method replacement    |
+| A2A real-pipeline fixture contract updates | 2     | +2                               | Required after full-suite runtime evidence |
+| Delivery plan                              | 1     | +103 before scope reconciliation | Policy evidence                            |
+
+The candidate remains at 18 files and about 457 net changed lines including
+this plan. It is below the 25-file/1,500-line target, so no mandatory scope
+review or hard stop is triggered. There are no unlisted production paths, new
+public APIs, dependencies, workflows, quality-tool changes, agent-memory
+changes, test moves, or unrelated refactors.
+
+## Review finding classifications
+
+Every finding must be recorded as one of:
+
+- **Blocker-Fix:** violates an accepted behavior or required gate.
+- **In-scope-Fix:** improves correctness or maintainability within the listed
+  paths and A1-A7.
+- **Reject:** factually incorrect or contradicts the accepted design.
+- **Defer:** valid but outside the matrix or scope ledger; requires separate work.
+
+Reviewer suggestions do not expand this ledger.
+
+### Review triage
+
+| Finding                                                        | Classification | Resolution                                                                                                                   |
+| -------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Non-throwing compression failure bypassed hard-limit reduction | Blocker-Fix    | Failure is logged and now continues into existing context enforcement; behavioral fallback coverage added                    |
+| Recovery re-resolved a different token limit                   | Blocker-Fix    | The orchestrator computes one configured limit and passes it to every recheck; injected-resolver regression added            |
+| Recovery evidence mocked the enforcer and asserted mock calls  | Blocker-Fix    | Proceed paths assert stream output; A1 uses a real `ChatSession`, real pending enforcer, and real top-down history reduction |
+| New code comments restated control flow                        | In-scope-Fix   | Newly added explanatory comments were removed                                                                                |
+| Broader rewrite of pre-existing mock-heavy client fixtures     | Defer          | Outside A1-A7; the issue-defining enforcement path now has real integration evidence                                         |
+| OCR review                                                     | Reject         | No findings were generated across the 17 reviewed source/test files                                                          |
+
+## Verification and completion gate
+
+Required local evidence: focused overflow tests, `npm run test`, `npm run lint`,
+`npm run typecheck`, `npm run format`, `npm run build`, and the configured smoke
+test. Because the failure is visible in terminal UI, exercise the tmux harness
+before PR creation. Run DeepThinker and local OCR (maximum two local OCR runs),
+triage every finding, and stop optional hardening once accepted behavior and
+required gates pass.
+
+Exact-head completion additionally requires green CI on the candidate commit,
+completed and triaged PR reviews (maximum two PR OCR runs), all Blocker-Fix and
+In-scope-Fix findings resolved, correct ancestry, a conflict-free PR, and this
+scope ledger reconciled to the final diff.

--- a/packages/a2a-server/src/agent/task.factory-migration.integration.test.ts
+++ b/packages/a2a-server/src/agent/task.factory-migration.integration.test.ts
@@ -152,6 +152,7 @@ function injectStubModelResponse(
     getHistory: () => [],
     addHistory: () => {},
     getLastPromptTokenCount: () => 0,
+    getProjectedPromptBaseline: () => 0,
   };
 }
 

--- a/packages/a2a-server/src/config/config.factory-migration.test.ts
+++ b/packages/a2a-server/src/config/config.factory-migration.test.ts
@@ -146,6 +146,7 @@ function injectStubModelResponse(
     performCompression: async () => PerformCompressionResult.SKIPPED_EMPTY,
     recordCompletedToolCalls: () => {},
     getLastPromptTokenCount: () => 0,
+    getProjectedPromptBaseline: () => 0,
   };
 }
 

--- a/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
@@ -131,6 +131,7 @@ function buildOrchestrator(options: BuildOptions = {}): {
   const tokenUsageLogger = new RecordingTokenUsageLogger();
   const mockChat = {
     getLastPromptTokenCount: vi.fn().mockReturnValue(100),
+    getProjectedPromptBaseline: vi.fn().mockReturnValue(100),
     addHistory: vi.fn(),
     getHistory: vi.fn().mockReturnValue([]),
     getTokenUsageLogger: () => tokenUsageLogger,

--- a/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
@@ -101,6 +101,7 @@ function buildOrchestrator(options: BuildOptions = {}): {
 } {
   const mockChat = {
     getLastPromptTokenCount: vi.fn().mockReturnValue(100),
+    getProjectedPromptBaseline: vi.fn().mockReturnValue(100),
     addHistory: vi.fn(),
     getHistory: vi.fn().mockReturnValue([]),
   };

--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -305,12 +305,13 @@ export class MessageStreamOrchestrator {
 
     const chat = getChat();
     const effectiveIdentity = getEffectiveModelIdentity();
+    const configuredContextLimit = getTokenLimitForConfiguredContext(
+      effectiveIdentity.model,
+      config,
+      this.deps.resolveTokenLimit,
+    );
     const remainingTokenCount =
-      getTokenLimitForConfiguredContext(
-        effectiveIdentity.model,
-        config,
-        this.deps.resolveTokenLimit,
-      ) - chat.getLastPromptTokenCount();
+      configuredContextLimit - chat.getProjectedPromptBaseline();
 
     const fallback = estimateStructuredTokens(initialRequest);
     const recordEstimate = (estimatedTokens: number): void => {
@@ -345,6 +346,7 @@ export class MessageStreamOrchestrator {
       promptId: ctx.prompt_id,
       estimatedRequestTokenCount,
       remainingTokenCount,
+      configuredContextLimit,
     });
     if (proceed) return undefined;
     yield {

--- a/packages/agents/src/core/client-test-helpers.ts
+++ b/packages/agents/src/core/client-test-helpers.ts
@@ -219,6 +219,7 @@ async function createAndInitClient(
     clearHistory: vi.fn(),
     sendMessageStream: vi.fn(),
     getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+    getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
     getTokenUsageLogger: vi.fn().mockReturnValue({
       isEnabled: () => false,
     }),

--- a/packages/agents/src/core/client.editor-context.test.ts
+++ b/packages/agents/src/core/client.editor-context.test.ts
@@ -237,6 +237,7 @@ describe('Agent Client (client.ts)', () => {
             },
           ]),
           getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+          getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
         };
         client['chat'] = mockChat as ChatSession;
 

--- a/packages/agents/src/core/client.hooks.test.ts
+++ b/packages/agents/src/core/client.hooks.test.ts
@@ -249,6 +249,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -320,6 +321,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 

--- a/packages/agents/src/core/client.ide-context.test.ts
+++ b/packages/agents/src/core/client.ide-context.test.ts
@@ -229,6 +229,7 @@ describe('AgentClient (client.ts)', () => {
           setHistory: vi.fn(),
           sendMessage: vi.fn().mockResolvedValue({ text: 'summary' }),
           getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+          getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
         };
         client['chat'] = mockChat as ChatSession;
 

--- a/packages/agents/src/core/client.model-profile.test.ts
+++ b/packages/agents/src/core/client.model-profile.test.ts
@@ -372,6 +372,7 @@ describe('AgentClient (client.ts)', () => {
               getTotalTokens: vi.fn().mockReturnValue(0),
             }),
             getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+            getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
             setTools: vi.fn(),
           } as unknown as ChatSession;
         });
@@ -408,6 +409,7 @@ describe('AgentClient (client.ts)', () => {
           getTotalTokens: vi.fn().mockReturnValue(0),
         }),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
       getModelSpy = vi.spyOn(client['config'], 'getModel');

--- a/packages/agents/src/core/client.sendMessageStream-errors.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-errors.test.ts
@@ -246,6 +246,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -331,6 +332,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       } as unknown as ChatSession;
 
       const events = await fromAsync(
@@ -393,6 +395,7 @@ describe('Agent Client (client.ts)', () => {
           addHistory: vi.fn(),
           getHistory: vi.fn().mockReturnValue([]),
           getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+          getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
         } as unknown as ChatSession;
 
         const events = await fromAsync(
@@ -428,6 +431,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -482,6 +486,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 

--- a/packages/agents/src/core/client.sendMessageStream-invalid-stream.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-invalid-stream.test.ts
@@ -246,6 +246,7 @@ describe('AgentClient (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -313,6 +314,7 @@ describe('AgentClient (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       } as unknown as ChatSession;
 
       const events = await fromAsync(
@@ -345,6 +347,7 @@ describe('AgentClient (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -401,6 +404,7 @@ describe('AgentClient (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -468,6 +472,7 @@ describe('AgentClient (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 

--- a/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
@@ -15,9 +15,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ContentBlock } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import { AgentClient } from './client.js';
 import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
-import type { ChatSession } from './chatSession.js';
+import { ChatSession } from './chatSession.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { AgentEventType, PerformCompressionResult } from './turn.js';
 import { uiTelemetryService } from '@vybestack/llxprt-code-core/telemetry/uiTelemetry.js';
+import {
+  buildRuntimeContext,
+  buildMockContentGenerator,
+  makeUserMessage,
+  makeAiText,
+} from './__tests__/chatSession-density-helpers.js';
 import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
 import {
   fromAsync,
@@ -175,11 +182,17 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
   return {
     tokenLimit,
     resolveEffectiveContextLimit: vi.fn(
-      (model: string, userCtx?: number, provCtx?: number) => {
+      (
+        model: string,
+        userCtx?: number,
+        provCtx?: number,
+        resolveTokenLimit?: (model: string) => number,
+      ) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
         if (ok(userCtx)) return userCtx;
         if (ok(provCtx)) return provCtx;
+        if (resolveTokenLimit) return resolveTokenLimit(model);
         return tokenLimit(model);
       },
     ),
@@ -198,66 +211,81 @@ vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
 const MOCKED_TOKEN_LIMIT = 1000;
 const PREFLIGHT_BASELINE = 900;
 const OVERFLOW_REQUEST_CHARS = 400;
+const THRESHOLD = 0.95;
 
 interface OverflowScenario {
-  /** Post-compression projected baseline; omit when recovery never rechecks. */
-  projectedBaseline?: number;
-  /** Compression outcome: a result enum value, or an Error to reject with. */
   compressionResult: PerformCompressionResult | Error;
-  /** Whether the turn should proceed (sets up a content stream on Turn.run). */
-  proceeds: boolean;
+  postCompressionBaseline?: number;
+  postEnforcementBaseline?: number;
+  enforcementError?: Error;
+  initialProjectedBaseline?: number;
+  lastPromptTokenCount?: number;
 }
 
 interface OverflowScenarioHandle {
-  mockChat: Partial<ChatSession>;
   request: ContentBlock[];
   estimatedRequestTokenCount: number;
   remainingTokenCount: number;
 }
 
-/** Builds the shared mockChat/generator/request scaffolding for one scenario. */
 function buildOverflowScenario(
   client: AgentClient,
   scenario: OverflowScenario,
 ): OverflowScenarioHandle {
   vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+  const initialBaseline =
+    scenario.initialProjectedBaseline ?? PREFLIGHT_BASELINE;
+  const observedCount = scenario.lastPromptTokenCount ?? initialBaseline;
   vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-    PREFLIGHT_BASELINE,
+    observedCount,
   );
+
+  let currentBaseline = initialBaseline;
 
   const mockChat: Partial<ChatSession> = {
     addHistory: vi.fn(),
     getHistory: vi.fn().mockReturnValue([]),
-    getLastPromptTokenCount: vi.fn().mockReturnValue(PREFLIGHT_BASELINE),
+    getLastPromptTokenCount: vi.fn().mockReturnValue(observedCount),
+    getProjectedPromptBaseline: vi
+      .fn()
+      .mockImplementation(() => currentBaseline),
     performCompression:
       scenario.compressionResult instanceof Error
         ? vi.fn().mockRejectedValue(scenario.compressionResult)
-        : vi.fn().mockResolvedValue(scenario.compressionResult),
+        : vi.fn().mockImplementation(() => {
+            if (scenario.postCompressionBaseline !== undefined) {
+              currentBaseline = scenario.postCompressionBaseline;
+            }
+            return Promise.resolve(
+              scenario.compressionResult as PerformCompressionResult,
+            );
+          }),
+    enforceContextWindow: scenario.enforcementError
+      ? vi.fn().mockRejectedValue(scenario.enforcementError)
+      : vi.fn().mockImplementation(() => {
+          if (scenario.postEnforcementBaseline !== undefined) {
+            currentBaseline = scenario.postEnforcementBaseline;
+          }
+          return Promise.resolve();
+        }),
   };
-  if (scenario.projectedBaseline !== undefined) {
-    mockChat.getProjectedPromptBaseline = vi
-      .fn()
-      .mockReturnValue(scenario.projectedBaseline);
-  }
   client['chat'] = mockChat as ChatSession;
   client['contentGenerator'] = {
     countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
   } as Partial<ContentGenerator> as ContentGenerator;
 
-  if (scenario.proceeds) {
-    mockTurnRunFn.mockReturnValue(
-      (async function* () {
-        yield { type: AgentEventType.Content, value: 'ok' };
-      })(),
-    );
-  }
+  mockTurnRunFn.mockReturnValue(
+    (async function* () {
+      yield { type: AgentEventType.Content, value: 'ok' };
+    })(),
+  );
 
   const longText = 'a'.repeat(OVERFLOW_REQUEST_CHARS);
   return {
-    mockChat,
     request: [{ type: 'text' as const, text: longText }],
     estimatedRequestTokenCount: Math.floor(longText.length / 4),
-    remainingTokenCount: MOCKED_TOKEN_LIMIT - PREFLIGHT_BASELINE,
+    remainingTokenCount: MOCKED_TOKEN_LIMIT - initialBaseline,
   };
 }
 
@@ -297,12 +325,9 @@ describe('AgentClient — preflight compression recovery (issue 2402)', () => {
     });
 
     it('should recover via automatic compression and proceed instead of bailing on a small overflow (issue 2402)', async () => {
-      // Initial preflight baseline (900) overflows; the post-compression
-      // projected baseline (100) fits, so the turn proceeds.
-      const { mockChat, request } = buildOverflowScenario(client, {
-        projectedBaseline: 100,
+      const { request } = buildOverflowScenario(client, {
+        postCompressionBaseline: 100,
         compressionResult: PerformCompressionResult.COMPRESSED,
-        proceeds: true,
       });
 
       const events = await fromAsync(
@@ -313,75 +338,19 @@ describe('AgentClient — preflight compression recovery (issue 2402)', () => {
         ),
       );
 
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: AgentEventType.Content, value: 'ok' }),
+      );
       expect(events).not.toContainEqual(
         expect.objectContaining({
           type: AgentEventType.ContextWindowWillOverflow,
         }),
       );
-      expect(mockTurnRunFn).toHaveBeenCalled();
-      // The recovery is an automatic compression, reported as 'auto' (matching
-      // the downstream hard-limit paths), not 'manual'.
-      expect(mockChat.performCompression).toHaveBeenCalledWith(
-        'prompt-id-overflow-recovered',
-        { bypassCooldown: true, trigger: 'auto' },
-      );
     });
 
-    it('should bail with ContextWindowWillOverflow when compression fails (issue 2402)', async () => {
-      const handle = buildOverflowScenario(client, {
-        compressionResult: PerformCompressionResult.FAILED,
-        proceeds: false,
-      });
-
-      const events = await fromAsync(
-        client.sendMessageStream(
-          handle.request,
-          new AbortController().signal,
-          'prompt-id-overflow-compression-failed',
-        ),
-      );
-
-      expect(events).toContainEqual({
-        type: AgentEventType.ContextWindowWillOverflow,
-        value: {
-          estimatedRequestTokenCount: handle.estimatedRequestTokenCount,
-          remainingTokenCount: handle.remainingTokenCount,
-        },
-      });
-      expect(mockTurnRunFn).not.toHaveBeenCalled();
-    });
-
-    it('should still bail when compression does not reduce enough (issue 2402)', async () => {
-      // Partial reduction (900 → 950) but not enough: newRemaining = 50,
-      // estimated 100 > 50 * 0.95 → still overflows → bail.
-      const handle = buildOverflowScenario(client, {
-        projectedBaseline: 950,
-        compressionResult: PerformCompressionResult.COMPRESSED,
-        proceeds: false,
-      });
-
-      const events = await fromAsync(
-        client.sendMessageStream(
-          handle.request,
-          new AbortController().signal,
-          'prompt-id-overflow-compression-insufficient',
-        ),
-      );
-
-      expect(events).toContainEqual({
-        type: AgentEventType.ContextWindowWillOverflow,
-        value: {
-          estimatedRequestTokenCount: handle.estimatedRequestTokenCount,
-          remainingTokenCount: handle.remainingTokenCount,
-        },
-      });
-      expect(mockTurnRunFn).not.toHaveBeenCalled();
-    });
-
-    it('should bail when performCompression throws during recovery (issue 2402)', async () => {
+    it('should bail with ContextWindowWillOverflow when compression throws during recovery (issue 2402)', async () => {
       const handle = buildOverflowScenario(client, {
         compressionResult: new Error('boom'),
-        proceeds: false,
       });
 
       const events = await fromAsync(
@@ -392,23 +361,24 @@ describe('AgentClient — preflight compression recovery (issue 2402)', () => {
         ),
       );
 
-      expect(events).toContainEqual({
-        type: AgentEventType.ContextWindowWillOverflow,
+      const overflowEvents = events.filter(
+        (e) => e.type === AgentEventType.ContextWindowWillOverflow,
+      );
+      expect(overflowEvents).toHaveLength(1);
+      expect(overflowEvents[0]).toMatchObject({
         value: {
           estimatedRequestTokenCount: handle.estimatedRequestTokenCount,
           remainingTokenCount: handle.remainingTokenCount,
         },
       });
-      expect(mockTurnRunFn).not.toHaveBeenCalled();
+      expect(events.some((e) => e.type === AgentEventType.Content)).toBe(false);
     });
 
     it('should bail when compression is skipped because history is empty (issue 2402)', async () => {
-      // SKIPPED_EMPTY: nothing to compress → baseline unchanged → still
-      // overflows. Must not falsely recover.
       const handle = buildOverflowScenario(client, {
-        projectedBaseline: PREFLIGHT_BASELINE,
+        postCompressionBaseline: PREFLIGHT_BASELINE,
         compressionResult: PerformCompressionResult.SKIPPED_EMPTY,
-        proceeds: false,
+        enforcementError: new Error('unrecoverable'),
       });
 
       const events = await fromAsync(
@@ -419,43 +389,365 @@ describe('AgentClient — preflight compression recovery (issue 2402)', () => {
         ),
       );
 
-      expect(events).toContainEqual({
-        type: AgentEventType.ContextWindowWillOverflow,
-        value: {
-          estimatedRequestTokenCount: handle.estimatedRequestTokenCount,
-          remainingTokenCount: handle.remainingTokenCount,
-        },
-      });
-      expect(mockTurnRunFn).not.toHaveBeenCalled();
+      const overflowEvents = events.filter(
+        (e) => e.type === AgentEventType.ContextWindowWillOverflow,
+      );
+      expect(overflowEvents).toHaveLength(1);
+      expect(events.some((e) => e.type === AgentEventType.Content)).toBe(false);
     });
 
-    it('should proceed when compression drives remaining capacity non-positive, deferring to the downstream path (issue 2402)', async () => {
-      // After compression the projected baseline (1005) exceeds the 1000-token
-      // limit, making remaining capacity negative → defer to downstream,
-      // mirroring the negative-remaining guard (issue #2139).
-      buildOverflowScenario(client, {
-        projectedBaseline: 1005,
-        compressionResult: PerformCompressionResult.COMPRESSED,
-        proceeds: true,
+    it('should recover via context-window enforcement when ordinary compression is a no-op (issue 2755 A1)', async () => {
+      const ENFORCEMENT_TOKEN_LIMIT = 10_000;
+      vi.mocked(tokenLimit).mockReturnValue(ENFORCEMENT_TOKEN_LIMIT);
+
+      const historyService = new HistoryService();
+      const fillText = 'x'.repeat(12_000);
+      historyService.add(makeUserMessage(fillText), 'test-model');
+      historyService.add(makeAiText(fillText), 'test-model');
+      historyService.add(makeUserMessage(fillText), 'test-model');
+      await historyService.waitForTokenUpdates();
+
+      const runtimeContext = buildRuntimeContext(historyService, {
+        compressionStrategy: 'one-shot',
+        contextLimit: ENFORCEMENT_TOKEN_LIMIT,
       });
+
+      const realChat = new ChatSession(
+        runtimeContext,
+        buildMockContentGenerator(),
+        { maxOutputTokens: 100 },
+        [],
+      );
+      client['chat'] = realChat;
+      client['contentGenerator'] = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      } as Partial<ContentGenerator> as ContentGenerator;
+
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: AgentEventType.Content, value: 'ok' };
+        })(),
+      );
+
       const request: ContentBlock[] = [
-        { type: 'text', text: 'a'.repeat(OVERFLOW_REQUEST_CHARS) },
+        { type: 'text', text: 'x'.repeat(4_000) },
       ];
 
       const events = await fromAsync(
         client.sendMessageStream(
           request,
           new AbortController().signal,
-          'prompt-id-overflow-defer',
+          'prompt-id-enforcement-recover-noop',
         ),
       );
 
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: AgentEventType.Content, value: 'ok' }),
+      );
       expect(events).not.toContainEqual(
         expect.objectContaining({
           type: AgentEventType.ContextWindowWillOverflow,
         }),
       );
-      expect(mockTurnRunFn).toHaveBeenCalled();
+      expect(realChat.getHistory().length).toBe(2);
+    });
+
+    it('should recover via enforcement when compression succeeded but was insufficient (issue 2755 A2)', async () => {
+      const { request } = buildOverflowScenario(client, {
+        postCompressionBaseline: 950,
+        compressionResult: PerformCompressionResult.COMPRESSED,
+        postEnforcementBaseline: 100,
+      });
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          request,
+          new AbortController().signal,
+          'prompt-id-enforcement-recover-insufficient',
+        ),
+      );
+
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: AgentEventType.Content, value: 'ok' }),
+      );
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: AgentEventType.ContextWindowWillOverflow,
+        }),
+      );
+    });
+
+    it('should recover via enforcement even when ordinary compression returns FAILED (issue 2755 A1 FAILED fallback)', async () => {
+      const { request } = buildOverflowScenario(client, {
+        postCompressionBaseline: PREFLIGHT_BASELINE,
+        compressionResult: PerformCompressionResult.FAILED,
+        postEnforcementBaseline: 100,
+      });
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          request,
+          new AbortController().signal,
+          'prompt-id-enforcement-recover-failed',
+        ),
+      );
+
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: AgentEventType.Content, value: 'ok' }),
+      );
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: AgentEventType.ContextWindowWillOverflow,
+        }),
+      );
+    });
+
+    it('should bail with exactly one overflow guard when enforcement cannot recover (issue 2755 A3)', async () => {
+      const handle = buildOverflowScenario(client, {
+        postCompressionBaseline: 950,
+        compressionResult: PerformCompressionResult.COMPRESSED,
+        enforcementError: new Error('unrecoverable'),
+      });
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          handle.request,
+          new AbortController().signal,
+          'prompt-id-enforcement-unrecoverable',
+        ),
+      );
+
+      const overflowEvents = events.filter(
+        (e) => e.type === AgentEventType.ContextWindowWillOverflow,
+      );
+      expect(overflowEvents).toHaveLength(1);
+      expect(events.some((e) => e.type === AgentEventType.Content)).toBe(false);
+    });
+
+    it('should bail with exactly one overflow guard when compression is insufficient and enforcement leaves the baseline too large (issue 2755 A7)', async () => {
+      const handle = buildOverflowScenario(client, {
+        postCompressionBaseline: 950,
+        compressionResult: PerformCompressionResult.COMPRESSED,
+        postEnforcementBaseline: 950,
+      });
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          handle.request,
+          new AbortController().signal,
+          'prompt-id-enforcement-still-too-large',
+        ),
+      );
+
+      const overflowEvents = events.filter(
+        (e) => e.type === AgentEventType.ContextWindowWillOverflow,
+      );
+      expect(overflowEvents).toHaveLength(1);
+      expect(events.some((e) => e.type === AgentEventType.Content)).toBe(false);
+    });
+
+    it('should bail when the projected baseline exceeds the configured limit even after enforcement (issue 2755 A3 negative-remaining)', async () => {
+      const handle = buildOverflowScenario(client, {
+        postCompressionBaseline: MOCKED_TOKEN_LIMIT + 50,
+        compressionResult: PerformCompressionResult.COMPRESSED,
+        postEnforcementBaseline: MOCKED_TOKEN_LIMIT + 50,
+      });
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          handle.request,
+          new AbortController().signal,
+          'prompt-id-negative-remaining',
+        ),
+      );
+
+      const overflowEvents = events.filter(
+        (e) => e.type === AgentEventType.ContextWindowWillOverflow,
+      );
+      expect(overflowEvents).toHaveLength(1);
+      expect(events.some((e) => e.type === AgentEventType.Content)).toBe(false);
+    });
+
+    it('should not grant a false full-window allowance when the last observed count is cleared but history is large (issue 2755 A4 consecutive)', async () => {
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(0);
+
+      const currentBaseline = PREFLIGHT_BASELINE;
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi
+          .fn()
+          .mockImplementation(() => currentBaseline),
+        performCompression: vi
+          .fn()
+          .mockImplementation(() =>
+            Promise.resolve(PerformCompressionResult.NOOP),
+          ),
+        enforceContextWindow: vi
+          .fn()
+          .mockRejectedValue(new Error('unrecoverable')),
+      };
+      client['chat'] = mockChat as ChatSession;
+      client['contentGenerator'] = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      } as Partial<ContentGenerator> as ContentGenerator;
+
+      const longText = 'a'.repeat(OVERFLOW_REQUEST_CHARS);
+      const request: ContentBlock[] = [{ type: 'text', text: longText }];
+      const signal = new AbortController().signal;
+
+      const events1 = await fromAsync(
+        client.sendMessageStream(request, signal, 'prompt-id-first-turn'),
+      );
+
+      const overflowEvents1 = events1.filter(
+        (e) => e.type === AgentEventType.ContextWindowWillOverflow,
+      );
+      expect(overflowEvents1).toHaveLength(1);
+      expect(overflowEvents1[0]).toMatchObject({
+        value: {
+          remainingTokenCount: MOCKED_TOKEN_LIMIT - PREFLIGHT_BASELINE,
+        },
+      });
+      expect(events1.some((e) => e.type === AgentEventType.Content)).toBe(
+        false,
+      );
+
+      const events2 = await fromAsync(
+        client.sendMessageStream(request, signal, 'prompt-id-second-turn'),
+      );
+
+      const overflowEvents2 = events2.filter(
+        (e) => e.type === AgentEventType.ContextWindowWillOverflow,
+      );
+      expect(overflowEvents2).toHaveLength(1);
+      expect(overflowEvents2[0]).toMatchObject({
+        value: {
+          remainingTokenCount: MOCKED_TOKEN_LIMIT - PREFLIGHT_BASELINE,
+        },
+      });
+    });
+
+    it('should use the same configured context limit for initial capacity and post-recovery recheck (issue 2755 A7 exact-limit parity)', async () => {
+      const injectedLimit = 842;
+      const injectedResolver = vi.fn(() => injectedLimit);
+
+      client = (
+        await setupAgentClient({
+          mockChatCreateFn,
+          mockGenerateContentFn,
+          mockEmbedContentFn,
+          resolveTokenLimit: injectedResolver,
+        })
+      ).client;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      (
+        client as unknown as {
+          todoContinuationService: { todoToolsAvailable: boolean };
+        }
+      ).todoContinuationService.todoToolsAvailable = true;
+
+      const baselineForRecovery = 750;
+      const currentBaseline = baselineForRecovery;
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi
+          .fn()
+          .mockImplementation(() => currentBaseline),
+        performCompression: vi
+          .fn()
+          .mockImplementation(() =>
+            Promise.resolve(PerformCompressionResult.COMPRESSED),
+          ),
+        enforceContextWindow: vi
+          .fn()
+          .mockRejectedValue(new Error('unrecoverable')),
+      };
+      client['chat'] = mockChat as ChatSession;
+      client['contentGenerator'] = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      } as Partial<ContentGenerator> as ContentGenerator;
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: AgentEventType.Content, value: 'ok' };
+        })(),
+      );
+
+      const requestCharsForParity = 540;
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ type: 'text', text: 'a'.repeat(requestCharsForParity) }],
+          new AbortController().signal,
+          'prompt-id-parity',
+        ),
+      );
+
+      const overflowEvents = events.filter(
+        (e) => e.type === AgentEventType.ContextWindowWillOverflow,
+      );
+      expect(overflowEvents).toHaveLength(1);
+      expect(events.some((e) => e.type === AgentEventType.Content)).toBe(false);
+    });
+
+    it('should proceed exactly at the threshold boundary where estimated equals remaining * 0.95 (issue 2755 A7 exact threshold)', async () => {
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      const fitBaseline = 500;
+      const requestChars = Math.floor(
+        (MOCKED_TOKEN_LIMIT - fitBaseline) * THRESHOLD * 4,
+      );
+      const exactEstimate = Math.floor(requestChars / 4);
+
+      let currentBaseline = PREFLIGHT_BASELINE;
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(PREFLIGHT_BASELINE),
+        getProjectedPromptBaseline: vi
+          .fn()
+          .mockImplementation(() => currentBaseline),
+        performCompression: vi.fn().mockImplementation(() => {
+          currentBaseline = fitBaseline;
+          return Promise.resolve(PerformCompressionResult.COMPRESSED);
+        }),
+        enforceContextWindow: vi.fn().mockResolvedValue(undefined),
+      };
+      client['chat'] = mockChat as ChatSession;
+      client['contentGenerator'] = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      } as Partial<ContentGenerator> as ContentGenerator;
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: AgentEventType.Content, value: 'ok' };
+        })(),
+      );
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ type: 'text', text: 'a'.repeat(requestChars) }],
+          new AbortController().signal,
+          'prompt-id-threshold-exact',
+        ),
+      );
+
+      const fitRemaining = MOCKED_TOKEN_LIMIT - fitBaseline;
+      expect(exactEstimate).toBe(Math.floor(fitRemaining * THRESHOLD));
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: AgentEventType.Content, value: 'ok' }),
+      );
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: AgentEventType.ContextWindowWillOverflow,
+        }),
+      );
     });
   });
 });

--- a/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
@@ -220,6 +220,16 @@ describe('AgentClient (client.ts)', () => {
   });
 
   describe('sendMessageStream', () => {
+    const baselineFns = (
+      n: number,
+    ): Pick<
+      ChatSession,
+      'getLastPromptTokenCount' | 'getProjectedPromptBaseline'
+    > => ({
+      getLastPromptTokenCount: vi.fn().mockReturnValue(n),
+      getProjectedPromptBaseline: vi.fn().mockReturnValue(n),
+    });
+
     beforeEach(() => {
       (
         client as unknown as {
@@ -243,7 +253,7 @@ describe('AgentClient (client.ts)', () => {
       const mockChat: Partial<ChatSession> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
         performCompression: vi
           .fn()
           .mockResolvedValue(PerformCompressionResult.FAILED),
@@ -308,7 +318,7 @@ describe('AgentClient (client.ts)', () => {
       const mockChat: Partial<ChatSession> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
         convertPartListUnionToIContent: vi
           .fn()
           .mockReturnValue({ speaker: 'human', blocks: [] }),
@@ -361,7 +371,7 @@ describe('AgentClient (client.ts)', () => {
       const mockChat: Partial<ChatSession> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
         convertPartListUnionToIContent: vi.fn().mockReturnValue({
           speaker: 'tool',
           blocks: [],
@@ -421,7 +431,7 @@ describe('AgentClient (client.ts)', () => {
       const mockChat: Partial<ChatSession> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
         estimatePendingTokens: estimateSpy,
       };
       client['chat'] = mockChat as ChatSession;
@@ -469,7 +479,7 @@ describe('AgentClient (client.ts)', () => {
       const mockChat: Partial<ChatSession> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
         convertPartListUnionToIContent: convertSpy,
         estimatePendingTokens: estimateSpy,
       };
@@ -513,7 +523,7 @@ describe('AgentClient (client.ts)', () => {
       const mockChat: Partial<ChatSession> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -569,7 +579,7 @@ describe('AgentClient (client.ts)', () => {
       const mockChat: Partial<ChatSession> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
         estimatePendingTokens: vi
           .fn()
           .mockRejectedValue(new Error('tokenizer unavailable')),
@@ -614,7 +624,7 @@ describe('AgentClient (client.ts)', () => {
       const mockChat: Partial<ChatSession> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -675,7 +685,7 @@ describe('AgentClient (client.ts)', () => {
       const mockChat: Partial<ChatSession> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -721,7 +731,7 @@ describe('AgentClient (client.ts)', () => {
 
       const lastPromptTokenCount = 10000;
       const mockChat: Partial<ChatSession> = {
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        ...baselineFns(lastPromptTokenCount),
         getHistory: vi.fn().mockReturnValue([]),
       };
       client['chat'] = mockChat as ChatSession;
@@ -784,9 +794,8 @@ describe('AgentClient (client.ts)', () => {
         .mockReturnValueOnce(mockStream2);
 
       const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        ...baselineFns(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -853,9 +862,8 @@ describe('AgentClient (client.ts)', () => {
       mockTurnRunFn.mockReturnValueOnce(mockStream1);
 
       const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        ...baselineFns(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -908,9 +916,8 @@ describe('AgentClient (client.ts)', () => {
       vi.spyOn(client['config'], 'getIdeMode').mockReturnValue(false);
 
       const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        ...baselineFns(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -975,9 +982,8 @@ describe('AgentClient (client.ts)', () => {
       );
 
       const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        ...baselineFns(0),
       };
       client['chat'] = mockChat as ChatSession;
 

--- a/packages/agents/src/core/client.sendMessageStream-thinking.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-thinking.test.ts
@@ -266,6 +266,7 @@ describe('AgentClient (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -334,6 +335,7 @@ describe('AgentClient (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -382,6 +384,7 @@ describe('AgentClient (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -423,6 +426,7 @@ describe('AgentClient (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 

--- a/packages/agents/src/core/client.sendMessageStream.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream.test.ts
@@ -325,6 +325,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -381,6 +382,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -423,6 +425,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -510,6 +513,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -558,6 +562,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -600,6 +605,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -648,6 +654,7 @@ describe('Agent Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
       };
       client['chat'] = mockChat as ChatSession;
 

--- a/packages/agents/src/core/preflightRecovery.ts
+++ b/packages/agents/src/core/preflightRecovery.ts
@@ -8,7 +8,6 @@ import type { ChatSession } from './chatSession.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { PerformCompressionResult } from './turn.js';
-import { getTokenLimitForConfiguredContext } from './contextLimitResolver.js';
 
 /**
  * Shared overflow threshold: the guard trips when the estimated request
@@ -31,6 +30,7 @@ export interface PreflightOverflowContext {
   promptId: string;
   estimatedRequestTokenCount: number;
   remainingTokenCount: number;
+  configuredContextLimit: number;
 }
 
 /**
@@ -58,8 +58,18 @@ export async function resolvePreflightOverflow(
     return true;
   }
 
-  const { getChat, getEffectiveModelIdentity, config, logger } = deps;
+  const { getChat, logger } = deps;
   const chat = getChat();
+
+  const fitsProjectedBaseline = (): boolean => {
+    const newRemaining =
+      ctx.configuredContextLimit - chat.getProjectedPromptBaseline();
+    return (
+      ctx.estimatedRequestTokenCount <=
+      newRemaining * CONTEXT_OVERFLOW_THRESHOLD
+    );
+  };
+
   try {
     const result = await chat.performCompression(ctx.promptId, {
       bypassCooldown: true,
@@ -70,24 +80,16 @@ export async function resolvePreflightOverflow(
         () =>
           '[preflight] automatic compression failed during context-overflow recovery',
       );
-      return false;
     }
-    // Recompute remaining capacity from the (possibly reduced) baseline. Use
-    // the projected baseline (API-observed count, or the history-derived
-    // estimate when compression just nulled lastPromptTokenCount) — NOT
-    // getLastPromptTokenCount(), which returns 0 right after compression.
-    const newRemaining =
-      getTokenLimitForConfiguredContext(
-        getEffectiveModelIdentity().model,
-        config,
-      ) - chat.getProjectedPromptBaseline();
-    if (newRemaining <= 0) {
+    if (fitsProjectedBaseline()) {
       return true;
     }
-    return (
-      ctx.estimatedRequestTokenCount <=
-      newRemaining * CONTEXT_OVERFLOW_THRESHOLD
+
+    await chat.enforceContextWindow(
+      ctx.estimatedRequestTokenCount,
+      ctx.promptId,
     );
+    return fitsProjectedBaseline();
   } catch (error) {
     logger.warn(
       () =>


### PR DESCRIPTION
## TLDR

Fixes the preflight context-overflow path so LLxprt exhausts its existing real context-reduction enforcement before showing `ContextWindowWillOverflow`.

The fix also uses one configured context limit and the projected prompt baseline consistently across the initial check and every post-recovery recheck.

## Dive Deeper

The issue screenshot came from the client preflight guard rather than the safety-adjusted hard-limit path fixed by issue 2588.

Previously, preflight attempted ordinary compression once and could bail when that attempt returned a no-op, a non-throwing failure, or an insufficient reduction. It also used `getLastPromptTokenCount()` initially but `getProjectedPromptBaseline()` after recovery, allowing a cleared observed count to look like a full empty context window.

This change:

- resolves the effective context limit once through the orchestrator's injected resolver;
- computes remaining capacity from the projected prompt baseline;
- keeps ordinary automatic compression as the first recovery attempt;
- delegates any still-insufficient non-throwing outcome to existing `ChatSession.enforceContextWindow()`;
- rechecks the projected baseline against the same original limit and 0.95 threshold;
- emits the overflow guard only when recovery remains impossible.

Behavioral coverage includes a real `ChatSession` and `HistoryService` integration path where ordinary one-shot compression is structurally unable to run, then the real pending-context enforcer invokes deterministic top-down truncation and reduces history before the turn proceeds.

Scope is bounded to two production files, direct behavioral tests, fixture-contract updates, and the recorded issue-delivery plan. No public API, dependency, workflow, quality-tool, threshold, or compression-policy changes are included.

## Reviewer Test Plan

1. Run the focused regression suites:

       npm exec vitest -- run packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts packages/agents/src/core/client.sendMessageStream-overflow.test.ts packages/agents/src/compression/__tests__/compression-retry-hardlimit.test.ts

2. Confirm the real enforcement integration case:
   - starts with three real history messages;
   - ordinary one-shot compression is a structural no-op;
   - the streamed turn emits content rather than `ContextWindowWillOverflow`;
   - real history is reduced from three messages to two.

3. Run full verification:

       npm run test
       npm run build
       npm run lint
       npm run typecheck
       npm run format
       bun scripts/start.ts --profile-load ollamakimi "write me a haiku and nothing else"
       node scripts/tmux-harness.js --scenario haiku

Local results on the candidate head:

- full test suite passed;
- build, lint, typecheck, and format passed;
- Ollama Kimi smoke test returned a valid haiku;
- tmux harness exited successfully;
- DeepThinker findings were remediated;
- final independent review found no issues;
- two local OCR reviews completed, with the final OCR suggestion rejected as contradicting the acceptance matrix and verified FAILED-recovery behavior.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2755
