### PR TITLE
Fix ast_edit summary counts for all languages via AST declarations (Fixes #2806)

### DIFF
--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-summary-counts.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-summary-counts.test.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for ast_edit preview summary counts across languages
+ * (issue #2806).
+ *
+ * The preview header reports `- Functions: N` and `- Classes: N`. These
+ * counts are derived from the AST declaration list, NOT from per-language
+ * regex extractors, so they must be accurate for every supported language.
+ *
+ * Tests behavior, not implementation: uses real files on disk and real
+ * ASTEditTool instances. No mocking of the tool under test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  useTempDir,
+  createFakeToolHost,
+  executePreview,
+} from './test-helpers.js';
+import { ASTEditTool } from '../../ast-edit.js';
+
+/**
+ * Escapes a literal string for safe embedding in a RegExp.
+ */
+function escapeRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Extracts the numeric count from a preview header line like
+ * "- Functions: 3". Throws with the surrounding output when the label is
+ * absent so output-format regressions surface the actual content.
+ */
+function countFrom(output: string, label: string): number {
+  const match = output.match(new RegExp(`${escapeRegex(label)}: (\\d+)`));
+  if (!match) {
+    throw new Error(
+      `Expected preview header "${label}: N" but it was not found.\nOutput:\n${output}`,
+    );
+  }
+  return Number(match[1]);
+}
+
+/**
+ * Fails fast with a clear diagnostic if the preview produced an error,
+ * so subsequent assertions don't report confusing NaN/undefined failures.
+ */
+function requireNoError(result: {
+  error?: unknown;
+  llmContent: unknown;
+}): void {
+  if (result.error !== undefined) {
+    throw new Error(
+      `Preview returned an error: ${JSON.stringify(result.error)}`,
+    );
+  }
+}
+
+describe('ast_edit summary counts: TypeScript', () => {
+  const ctx = useTempDir();
+
+  it('counts functions and classes from AST declarations', async () => {
+    const filePath = join(ctx.tempDir, 'counts.ts');
+    writeFileSync(
+      filePath,
+      [
+        'function alpha(): void {}',
+        'function beta(): void {}',
+        'class Greeter {',
+        '  greet() {}',
+        '}',
+        'const x = 1;',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'function alpha()',
+      new_string: 'function alphaRenamed()',
+    });
+
+    requireNoError(result);
+    const output = String(result.llmContent);
+    // 2 top-level functions + 1 method inside the class
+    expect(countFrom(output, 'Functions')).toBe(3);
+    expect(countFrom(output, 'Classes')).toBe(1);
+  });
+});
+
+describe('ast_edit summary counts: Rust', () => {
+  const ctx = useTempDir();
+
+  it('counts functions, structs, traits, enums, and impls (not 0)', async () => {
+    const filePath = join(ctx.tempDir, 'counts.rs');
+    writeFileSync(
+      filePath,
+      [
+        'fn free_function() {}',
+        '',
+        'struct Point {',
+        '    x: f64,',
+        '    y: f64,',
+        '}',
+        '',
+        'impl Point {',
+        '    fn new() -> Self { Self { x: 0.0, y: 0.0 } }',
+        '}',
+        '',
+        'trait Drawable {',
+        '    fn draw(&self);',
+        '}',
+        '',
+        'enum Color {',
+        '    Red,',
+        '    Green,',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'fn free_function() {}',
+      new_string: 'fn free_function() { /* noop */ }',
+    });
+
+    requireNoError(result);
+    const output = String(result.llmContent);
+    // free_function + new (impl method) = 2 functions
+    expect(countFrom(output, 'Functions')).toBe(2);
+    // struct Point + trait Drawable + enum Color + impl Point = 4
+    expect(countFrom(output, 'Classes')).toBe(4);
+  });
+});
+
+describe('ast_edit summary counts: C', () => {
+  const ctx = useTempDir();
+
+  it('counts functions, structs, unions, and enums (not 0)', async () => {
+    const filePath = join(ctx.tempDir, 'counts.c');
+    writeFileSync(
+      filePath,
+      [
+        'struct Point {',
+        '    int x;',
+        '    int y;',
+        '};',
+        '',
+        'union Data {',
+        '    int i;',
+        '    float f;',
+        '};',
+        '',
+        'enum Status { OK, FAIL };',
+        '',
+        'int compute(void) {',
+        '    return 0;',
+        '}',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'return 0;',
+      new_string: 'return 1;',
+    });
+
+    requireNoError(result);
+    const output = String(result.llmContent);
+    expect(countFrom(output, 'Functions')).toBe(1);
+    // struct Point + union Data + enum Status = 3
+    expect(countFrom(output, 'Classes')).toBe(3);
+  });
+});
+
+describe('ast_edit summary counts: consistency with declarations', () => {
+  const ctx = useTempDir();
+
+  it('Rust function/class counts match the ENHANCED CONTEXT declarations', async () => {
+    const filePath = join(ctx.tempDir, 'consistent.rs');
+    writeFileSync(
+      filePath,
+      [
+        'fn handler() {}',
+        'struct Config {',
+        '    enabled: bool,',
+        '}',
+        'enum Mode { Fast, Slow }',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'fn handler() {}',
+      new_string: 'fn handler() { /* done */ }',
+    });
+
+    requireNoError(result);
+    const output = String(result.llmContent);
+
+    // Count the declaration lines under ENHANCED CONTEXT ANALYSIS
+    const header = 'ENHANCED CONTEXT ANALYSIS:';
+    const headerIdx = output.indexOf(header);
+    expect(headerIdx).toBeGreaterThan(-1);
+    const declSection = output.slice(headerIdx + header.length);
+    const declLines = declSection.split('\n');
+    const functionDecls = declLines.filter((l) =>
+      l.trim().startsWith('- function:'),
+    ).length;
+    const classLikePrefixes = [
+      '- struct:',
+      '- enum:',
+      '- trait:',
+      '- union:',
+      '- impl:',
+    ];
+    const classLikeDecls = declLines.filter((l) =>
+      classLikePrefixes.some((p) => l.trim().startsWith(p)),
+    ).length;
+
+    expect(countFrom(output, 'Functions')).toBe(functionDecls);
+    expect(countFrom(output, 'Classes')).toBe(classLikeDecls);
+  });
+});

--- a/packages/tools/src/tools/ast-edit/context-collector.ts
+++ b/packages/tools/src/tools/ast-edit/context-collector.ts
@@ -84,19 +84,20 @@ export class ASTContextCollector {
 
   async collectContext(filePath: string, content: string): Promise<ASTContext> {
     const language = detectLanguage(filePath);
+    const declarations = await this.astExtractor.extractDeclarations(
+      filePath,
+      content,
+    );
 
     return {
       filePath,
       language,
       fileSize: content.length,
       astNodes: await parseAST(content, language),
-      declarations: await this.astExtractor.extractDeclarations(
-        filePath,
-        content,
-      ),
+      declarations,
       imports: extractImports(content, language),
       relevantSnippets: collectSnippets(content),
-      languageContext: buildLanguageContext(content, language),
+      languageContext: buildLanguageContext(declarations),
     };
   }
 

--- a/packages/tools/src/tools/ast-edit/local-context-analyzer.ts
+++ b/packages/tools/src/tools/ast-edit/local-context-analyzer.ts
@@ -6,15 +6,7 @@
  * Local context analysis functions for AST parsing and code snippet collection.
  */
 
-import type {
-  ASTNode,
-  CodeSnippet,
-  Declaration,
-  FunctionInfo,
-  ClassInfo,
-  VariableInfo,
-  ASTContext,
-} from './types.js';
+import type { ASTNode, CodeSnippet, Declaration, ASTContext } from './types.js';
 import { ASTConfig } from './ast-config.js';
 import { KEYWORDS, COMMENT_PREFIXES } from './constants.js';
 import { ContextOptimizer } from './context-optimizer.js';
@@ -95,20 +87,59 @@ export function collectSnippets(content: string): CodeSnippet[] {
 }
 
 /**
- * Build language-specific context by extracting functions, classes, and variables.
- * @param content - Source code content
- * @param language - Programming language
- * @returns Language context with extracted elements
+ * Declaration types that represent struct-like / aggregate types for the
+ * "classes" summary category, across all supported languages.
+ */
+const CLASS_LIKE_TYPES: ReadonlySet<Declaration['type']> = new Set([
+  'class',
+  'struct',
+  'union',
+  'enum',
+  'trait',
+  'impl',
+]);
+
+/**
+ * Build language-specific context by deriving function, class, and variable
+ * counts from AST declarations.
+ *
+ * The summary counts are derived from the declaration list produced by
+ * {@link ASTQueryExtractor.extractDeclarations} (the tree-sitter-backed AST
+ * path) rather than from per-language regex extractors. This keeps the
+ * counts consistent with the `ENHANCED CONTEXT ANALYSIS` section shown to
+ * the LLM and accurate for every supported language.
+ *
+ * @param declarations - AST declarations already parsed for the file
+ * @returns Language context with one entry per matching declaration
  */
 export function buildLanguageContext(
-  content: string,
-  language: string,
+  declarations: Declaration[],
 ): ASTContext['languageContext'] {
-  return {
-    functions: extractFunctions(content, language),
-    classes: extractClasses(content, language),
-    variables: extractVariables(content, language),
-  };
+  const functions: ASTContext['languageContext']['functions'] = [];
+  const classes: ASTContext['languageContext']['classes'] = [];
+  const variables: ASTContext['languageContext']['variables'] = [];
+
+  for (const decl of declarations) {
+    if (decl.type === 'function') {
+      functions.push({
+        name: decl.name,
+        parameters: [],
+        returnType: 'unknown',
+        line: decl.line,
+      });
+    } else if (CLASS_LIKE_TYPES.has(decl.type)) {
+      classes.push({
+        name: decl.name,
+        methods: [],
+        properties: [],
+        line: decl.line,
+      });
+    } else if (decl.type === 'variable') {
+      variables.push({ name: decl.name, type: 'unknown', line: decl.line });
+    }
+  }
+
+  return { functions, classes, variables };
 }
 
 /**
@@ -165,94 +196,6 @@ export function calculateRelevance(line: string): number {
 }
 
 /**
- * Extract function declarations from content using regex.
- * @param content - Source code content
- * @param _language - Programming language
- * @returns Array of function information
- */
-export function extractFunctions(
-  content: string,
-  _language: string,
-): FunctionInfo[] {
-  const functions: FunctionInfo[] = [];
-  const lines = content.split('\n');
-
-  lines.forEach((line, index) => {
-    const trimmed = line.trim();
-    if (_language === 'typescript' || _language === 'javascript') {
-      const info = extractJsFunction(trimmed);
-      if (info) {
-        functions.push({ ...info, line: index + 1 });
-      }
-    } else if (_language === 'python') {
-      const info = extractPythonFunction(trimmed);
-      if (info) {
-        functions.push({ ...info, line: index + 1 });
-      }
-    }
-  });
-
-  return functions;
-}
-
-/**
- * Extract class declarations from content using regex.
- * @param content - Source code content
- * @param _language - Programming language
- * @returns Array of class information
- */
-export function extractClasses(
-  content: string,
-  _language: string,
-): ClassInfo[] {
-  const classes: ClassInfo[] = [];
-  const lines = content.split('\n');
-
-  lines.forEach((line, index) => {
-    const trimmed = line.trim();
-    if (trimmed.includes(KEYWORDS.CLASS)) {
-      const name = extractWordAfterPrefix(trimmed, KEYWORDS.CLASS);
-      if (name) {
-        classes.push({
-          name,
-          methods: [], // Simplified implementation
-          properties: [], // Simplified implementation
-          line: index + 1,
-        });
-      }
-    }
-  });
-
-  return classes;
-}
-
-/**
- * Extract variable declarations from content using regex.
- * @param content - Source code content
- * @param _language - Programming language
- * @returns Array of variable information
- */
-export function extractVariables(
-  content: string,
-  _language: string,
-): VariableInfo[] {
-  const variables: VariableInfo[] = [];
-  const lines = content.split('\n');
-
-  lines.forEach((line, index) => {
-    const trimmed = line.trim();
-    if (_language === 'typescript' || _language === 'javascript') {
-      const info = extractTypedVariable(trimmed);
-      if (info) {
-        variables.push({ ...info, line: index + 1 });
-      }
-    }
-  });
-
-  return variables;
-}
-
-/**
  * Optimize context collection by gathering declaration and local snippets.
  * @param declarations - Array of declarations
  * @param content - Source code content
@@ -290,137 +233,4 @@ export function optimizeContextCollection(
   );
 
   return ContextOptimizer.optimizeSnippets(allSnippets);
-}
-
-const WORD_PATTERN = /^[A-Za-z_$][\w$]*/;
-
-/**
- * Extracts a word identifier immediately following a prefix string using
- * linear scanning (avoids regex backtracking).
- */
-function extractWordAfterPrefix(line: string, prefix: string): string | null {
-  const idx = line.indexOf(prefix);
-  if (idx === -1) {
-    return null;
-  }
-  const after = line.slice(idx + prefix.length).trimStart();
-  const match = after.match(WORD_PATTERN);
-  return match ? match[0] : null;
-}
-
-/**
- * Parses parameters from a parenthesis-delimited string.
- */
-function parseParameters(paramStr: string): string[] {
-  return paramStr
-    .split(',')
-    .map((p) => p.trim())
-    .filter((p) => p);
-}
-
-/**
- * Extract a JS/TS function declaration: `function name(params): ReturnType`
- */
-function extractJsFunction(trimmed: string): Omit<FunctionInfo, 'line'> | null {
-  if (!trimmed.startsWith('function ')) {
-    return null;
-  }
-  const name = extractWordAfterPrefix(trimmed, 'function ');
-  if (!name) {
-    return null;
-  }
-  const openParen = trimmed.indexOf('(', 'function '.length + name.length);
-  if (openParen === -1) {
-    return null;
-  }
-  const closeParen = trimmed.indexOf(')', openParen + 1);
-  if (closeParen === -1) {
-    return null;
-  }
-  const params = parseParameters(trimmed.slice(openParen + 1, closeParen));
-
-  let returnType = 'unknown';
-  const afterParens = trimmed.slice(closeParen + 1);
-  if (afterParens.startsWith(':')) {
-    const typeMatch = afterParens.slice(1).trimStart().match(WORD_PATTERN);
-    if (typeMatch) {
-      returnType = typeMatch[0];
-    }
-  }
-  return { name, parameters: params, returnType };
-}
-
-/**
- * Extract a Python function declaration: `def name(params) -> ReturnType`
- */
-function extractPythonFunction(
-  trimmed: string,
-): Omit<FunctionInfo, 'line'> | null {
-  if (!trimmed.startsWith('def ')) {
-    return null;
-  }
-  const name = extractWordAfterPrefix(trimmed, 'def ');
-  if (!name) {
-    return null;
-  }
-  const openParen = trimmed.indexOf('(', 'def '.length + name.length);
-  if (openParen === -1) {
-    return null;
-  }
-  const closeParen = trimmed.indexOf(')', openParen + 1);
-  if (closeParen === -1) {
-    return null;
-  }
-  const params = parseParameters(trimmed.slice(openParen + 1, closeParen));
-
-  let returnType = 'unknown';
-  const afterParens = trimmed.slice(closeParen + 1).trimStart();
-  if (afterParens.startsWith('->')) {
-    const typeMatch = afterParens.slice(2).trimStart().match(WORD_PATTERN);
-    if (typeMatch) {
-      returnType = typeMatch[0];
-    }
-  }
-  return { name, parameters: params, returnType };
-}
-
-/**
- * Extract a typed variable declaration: `const name: Type`
- */
-function extractTypedVariable(
-  trimmed: string,
-): Omit<VariableInfo, 'line'> | null {
-  for (const keyword of ['const ', 'let ', 'var ']) {
-    const result = tryTypedVariable(trimmed, keyword);
-    if (result) {
-      return result;
-    }
-  }
-  return null;
-}
-
-function tryTypedVariable(
-  trimmed: string,
-  keyword: string,
-): Omit<VariableInfo, 'line'> | null {
-  if (!trimmed.startsWith(keyword)) {
-    return null;
-  }
-  const name = extractWordAfterPrefix(trimmed, keyword);
-  if (!name) {
-    return null;
-  }
-  const nameEnd = keyword.length + name.length;
-  const colonIdx = trimmed.indexOf(':', nameEnd);
-  if (colonIdx === -1) {
-    return null;
-  }
-  const typeMatch = trimmed
-    .slice(colonIdx + 1)
-    .trimStart()
-    .match(WORD_PATTERN);
-  if (!typeMatch) {
-    return null;
-  }
-  return { name, type: typeMatch[0] };
 }


### PR DESCRIPTION
## Summary

The `ast_edit` preview header reported misleading `- Functions: 0` and `- Classes: 0` counts for every non-JS/Python language (Rust, C, Go, Java, Ruby, C++) because `buildLanguageContext` used per-language regex extractors that only handled TypeScript, JavaScript, and Python.

This PR rewrites `buildLanguageContext` to derive summary counts from the AST declaration list already computed by `extractDeclarations` — the tree-sitter-backed path that parses all supported languages. The counts are now consistent with the `ENHANCED CONTEXT ANALYSIS` section shown to the LLM and accurate for every language.

Fixes #2806

## Changes

**`buildLanguageContext(declarations)`** — now consumes the AST declaration array instead of re-parsing source via regex:
- `functions` count = declarations where `type` is `function`
- `classes` count = declarations where `type` is `class`, `struct`, `union`, `enum`, `trait`, or `impl`
- `variables` count = declarations where `type` is `variable`

**`context-collector.ts`** — `collectContext` now computes declarations once and passes them to both the `declarations` field and `buildLanguageContext`, eliminating the parallel parse.

**Dead code removed** — the three regex extractors (`extractFunctions`, `extractClasses`, `extractVariables`) and their six private helpers (`extractJsFunction`, `extractPythonFunction`, `extractTypedVariable`, `tryTypedVariable`, `extractWordAfterPrefix`, `parseParameters`) plus the `WORD_PATTERN` constant are no longer needed and have been deleted (~190 lines removed).

## Why This Approach

The issue explicitly asked to derive counts from the AST declarations rather than maintain per-language regex extractors. This benefits all supported languages at once — not just one — and eliminates the disconnected dual-path where the summary used the inferior regex path while the `ENHANCED CONTEXT ANALYSIS` section (which the LLM reads) already used the accurate AST path.

## Verification

- 161/161 ast-edit tests pass (including new behavioral tests)
- 727/727 tools package tests pass
- Lint clean (eslint + eslint-guard policy check)
- Typecheck: no new errors (pre-existing MCP errors in unrelated packages confirmed via stash diff)
- Build passes
- Smoke test passes

## Test Coverage

New behavioral test file `ast-edit-summary-counts.test.ts` with 4 tests:
- **TypeScript regression**: counts functions (including class methods) and classes from AST declarations
- **Rust**: counts functions, structs, traits, enums, and impls (previously all 0)
- **C**: counts functions, structs, unions, and enums (previously all 0)
- **Consistency**: verifies summary counts match the `ENHANCED CONTEXT ANALYSIS` declaration list
