### PR TITLE
ci: make LLxprt PR reviewer non-blocking (Fixes #2778)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -187,11 +187,14 @@ jobs:
 
       - name: 'Install LLxprt CLI nightly'
         if: steps.issue_gate.outputs.should_review == 'true'
+        id: 'install'
+        continue-on-error: true
         run: npm install -g @vybestack/llxprt-code@nightly
 
       - name: 'Check API quota and select optimal key'
         if: steps.issue_gate.outputs.should_review == 'true'
         id: 'quota'
+        continue-on-error: true
         run: node scripts/ci-quota-check.js
         env:
           KEY_VAR_NAME: '${{ vars.KEY_VAR_NAME }}'
@@ -364,7 +367,9 @@ jobs:
           '
 
       - name: 'Run walkthrough pipeline'
-        if: steps.issue_gate.outputs.should_review == 'true'
+        if: ${{ steps.issue_gate.outputs.should_review == 'true' && steps.install.outcome == 'success' && steps.quota.outcome == 'success' }}
+        id: 'walkthrough'
+        continue-on-error: true
         env:
           OPENAI_API_KEY: ${{ steps.quota.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.quota.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || '' }}
         run: |
@@ -376,7 +381,8 @@ jobs:
           node scripts/pr-review-walkthrough.mjs 2> >(tee review/walkthrough-error.log >&2)
 
       - name: 'Upload walkthrough diagnostics'
-        if: failure()
+        if: always()
+        continue-on-error: true
         uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'walkthrough-diagnostics-${{ github.run_attempt }}'
@@ -389,6 +395,7 @@ jobs:
 
       - name: 'Ensure fallback comment'
         if: always()
+        continue-on-error: true
         run: |
           if [[ ! -s review/comment.md ]]; then
             {
@@ -400,6 +407,7 @@ jobs:
 
       - name: 'Post walkthrough comment'
         if: always()
+        continue-on-error: true
         uses: 'thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b' # v3.0.1
         with:
           file-path: 'review/comment.md'

--- a/scripts/no-new-js-allowlist.json
+++ b/scripts/no-new-js-allowlist.json
@@ -149,7 +149,6 @@
     "scripts/tests/pr-mergeability-workflow-wiring.test.js",
     "scripts/tests/pr-review-llm-helpers.test.js",
     "scripts/tests/pr-review-walkthrough-prompts.test.js",
-    "scripts/tests/pr-review-walkthrough-workflow.test.js",
     "scripts/tests/pr-review-walkthrough.test.js",
     "scripts/tests/pr-workflow-concurrency.test.js",
     "scripts/tests/preflight-ci.test.js",

--- a/scripts/tests/ocr-review-workflow-helpers.d.ts
+++ b/scripts/tests/ocr-review-workflow-helpers.d.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function readRootFile(relPath: string): string;
+export function normalize(value: unknown): string;
+export function commandText(step: unknown): string;
+export function stepNamed(job: unknown, name: string): unknown;
+export function expectContainsAll(value: string, snippets: string[]): void;
+export function hasPerl(): boolean;
+export function hasBashAndPerl(): boolean;
+export function commonCredentialInput(): string;
+export function expectCommonCredentialsRedacted(sanitized: string): void;
+export function extractFunctionSource(
+  source: string,
+  functionName: string,
+): string;
+export function makePostSanitizer(
+  postScript: string,
+  token: string,
+  url?: string,
+  context?: Record<string, unknown>,
+): unknown;
+export function executeNotifySanitizer(
+  notifyRun: string,
+  input: string,
+  token: string,
+  extraEnv?: Record<string, string>,
+): string;
+export function runNotifySanitizer(
+  notifyRun: string,
+  input: string,
+  token: string,
+  extraEnv?: Record<string, string>,
+): string;
+export const WORKFLOW_PATH: string;

--- a/scripts/tests/pr-review-walkthrough-workflow.test.js
+++ b/scripts/tests/pr-review-walkthrough-workflow.test.js
@@ -119,9 +119,12 @@ function evalBoolean(expr) {
       pos += 1;
       const value = parseOr();
       skipSpaces();
-      if (expr[pos] === ')') {
-        pos += 1;
+      if (expr[pos] !== ')') {
+        throw new Error(
+          `Invalid boolean expression: expected ')' at ${pos} in "${expr}"`,
+        );
       }
+      pos += 1;
       return value;
     }
     if (expr[pos] === '!') {
@@ -129,7 +132,9 @@ function evalBoolean(expr) {
       skipSpaces();
       return !parsePrimary();
     }
-    return false;
+    throw new Error(
+      `Invalid boolean expression: unexpected token at ${pos} in "${expr}"`,
+    );
   }
   function parseAnd() {
     let value = parsePrimary();

--- a/scripts/tests/pr-review-walkthrough-workflow.test.js
+++ b/scripts/tests/pr-review-walkthrough-workflow.test.js
@@ -36,6 +36,133 @@ function allStepText(job) {
   return JSON.stringify(job.steps);
 }
 
+function continueOnError(step) {
+  const value = step?.['continue-on-error'] ?? step?.continue_on_error;
+  return value === true || value === '${{ true }}';
+}
+
+/**
+ * Evaluate a GitHub Actions `if:` expression against a map of step outcomes.
+ * Supports the limited subset used by pr-review.yml: step.outcome equality,
+ * &&, ||, !cancelled(), always(), failure(), success().
+ */
+function evalStepIf(expr, stepOutcomes = {}) {
+  if (expr === undefined || expr === null) {
+    return true;
+  }
+  let normalized = String(expr).trim();
+  if (normalized.startsWith('${{') && normalized.endsWith('}}')) {
+    normalized = normalized.slice(3, -2).trim();
+  }
+  normalized = normalized.replace(/\s+/g, ' ');
+  normalized = normalized.replace(
+    /steps\.([a-zA-Z0-9_-]+)\.outcome\s*==\s*'([^']*)'/g,
+    (match, id, value) => {
+      const outcome = stepOutcomes[id] ?? 'skipped';
+      return outcome === value ? 'TRUE' : 'FALSE';
+    },
+  );
+  // Output comparisons (steps.X.outputs.Y == 'value') are resolved from the
+  // optional `outputs` map (stepOutcomes.outputs[stepId][outputName]). When an
+  // output is not provided, it resolves to TRUE so install/quota gating logic
+  // can be tested in isolation without modeling every upstream gate.
+  const outputs = stepOutcomes.outputs ?? {};
+  normalized = normalized.replace(
+    /steps\.([a-zA-Z0-9_-]+)\.outputs\.([a-zA-Z0-9_-]+)\s*==\s*'([^']*)'/g,
+    (match, stepId, outputName, expected) => {
+      const actual = outputs[stepId]?.[outputName];
+      if (actual === undefined) {
+        return 'TRUE';
+      }
+      return actual === expected ? 'TRUE' : 'FALSE';
+    },
+  );
+  const anyFailure = Object.values(stepOutcomes).some((o) => o === 'failure');
+  const anyCancelled = Object.values(stepOutcomes).some(
+    (o) => o === 'cancelled',
+  );
+  normalized = normalized.replace(/\balways\(\)/g, 'TRUE');
+  // success() is true only when no prior step failed and the job is not cancelled.
+  normalized = normalized.replace(
+    /\bsuccess\(\)/g,
+    anyFailure || anyCancelled ? 'FALSE' : 'TRUE',
+  );
+  normalized = normalized.replace(
+    /\bfailure\(\)/g,
+    anyFailure ? 'TRUE' : 'FALSE',
+  );
+  normalized = normalized.replace(
+    /!cancelled\(\)/g,
+    anyCancelled ? 'FALSE' : 'TRUE',
+  );
+  return evalBoolean(normalized);
+}
+
+function evalBoolean(expr) {
+  let pos = 0;
+  function skipSpaces() {
+    while (pos < expr.length && expr[pos] === ' ') {
+      pos += 1;
+    }
+  }
+  function parsePrimary() {
+    skipSpaces();
+    if (expr.startsWith('TRUE', pos)) {
+      pos += 4;
+      return true;
+    }
+    if (expr.startsWith('FALSE', pos)) {
+      pos += 5;
+      return false;
+    }
+    if (expr[pos] === '(') {
+      pos += 1;
+      const value = parseOr();
+      skipSpaces();
+      if (expr[pos] === ')') {
+        pos += 1;
+      }
+      return value;
+    }
+    if (expr[pos] === '!') {
+      pos += 1;
+      skipSpaces();
+      return !parsePrimary();
+    }
+    return false;
+  }
+  function parseAnd() {
+    let value = parsePrimary();
+    skipSpaces();
+    while (expr.startsWith('&&', pos)) {
+      pos += 2;
+      const right = parsePrimary();
+      value = value && right;
+      skipSpaces();
+    }
+    return value;
+  }
+  function parseOr() {
+    let value = parseAnd();
+    skipSpaces();
+    while (expr.startsWith('||', pos)) {
+      pos += 2;
+      const right = parseAnd();
+      value = value || right;
+      skipSpaces();
+    }
+    return value;
+  }
+  const result = parseOr();
+  skipSpaces();
+  if (pos !== expr.length) {
+    throw new Error(
+      `Invalid boolean expression: trailing input at ${pos} in "${expr}"`,
+    );
+  }
+  return result;
+}
+
 describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', () => {
   let workflow;
   let reviewJob;
@@ -292,7 +419,9 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
     it('uploads the private diagnostics log for post-mortem inspection', () => {
       const step = findStepByName(reviewJob, 'Upload walkthrough diagnostics');
       expect(step, 'should upload the diagnostics log').toBeTruthy();
-      expect(step.if).toBe('failure()');
+      // Issue #2778: upload runs under always() so parse artifacts from
+      // gracefully degraded zero-exit runs are captured alongside failure logs.
+      expect(step.if).toBe('always()');
       expect(step.uses).toContain('actions/upload-artifact@');
       // Issue #2742: the artifact now includes parse-failure diagnostics
       // (raw LLM responses + metadata) alongside the error log.
@@ -332,6 +461,299 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
         step.uses?.includes('actions-comment-pull-request'),
       );
       expect(postStep.if).toBe('always()');
+    });
+  });
+
+  // =========================================================================
+  // Issue #2778: Non-blocking advisory review boundaries
+  // =========================================================================
+
+  describe('non-blocking review job (Issue #2778)', () => {
+    function stepById(id) {
+      const step = reviewJob.steps.find((s) => s.id === id);
+      expect(
+        step,
+        `review job should have a step with id "${id}"`,
+      ).toBeTruthy();
+      return step;
+    }
+
+    function stepByName(name) {
+      const step = reviewJob.steps.find((s) => s.name === name);
+      expect(
+        step,
+        `review job should have a step named "${name}"`,
+      ).toBeTruthy();
+      return step;
+    }
+
+    // --- A1: Every advisory step has continue-on-error: true ---
+
+    it('Install LLxprt CLI nightly has id "install" and continue-on-error', () => {
+      const step = stepByName('Install LLxprt CLI nightly');
+      expect(step.id).toBe('install');
+      expect(continueOnError(step)).toBe(true);
+    });
+
+    it('Check API quota and select optimal key has id "quota" and continue-on-error', () => {
+      const step = stepByName('Check API quota and select optimal key');
+      expect(step.id).toBe('quota');
+      expect(continueOnError(step)).toBe(true);
+    });
+
+    it('Run walkthrough pipeline has id "walkthrough" and continue-on-error', () => {
+      const step = stepByName('Run walkthrough pipeline');
+      expect(step.id).toBe('walkthrough');
+      expect(continueOnError(step)).toBe(true);
+    });
+
+    it('Upload walkthrough diagnostics has continue-on-error', () => {
+      const step = stepByName('Upload walkthrough diagnostics');
+      expect(continueOnError(step)).toBe(true);
+    });
+
+    it('Ensure fallback comment has continue-on-error', () => {
+      const step = stepByName('Ensure fallback comment');
+      expect(continueOnError(step)).toBe(true);
+    });
+
+    it('Post walkthrough comment has continue-on-error', () => {
+      const step = reviewJob.steps.find((s) =>
+        s.uses?.includes('actions-comment-pull-request'),
+      );
+      expect(continueOnError(step)).toBe(true);
+    });
+
+    // --- A2/A3: Install/quota failure is visible and skips walkthrough ---
+
+    it('walkthrough step is skipped when install fails', () => {
+      const walkthrough = stepById('walkthrough');
+      expect(
+        evalStepIf(walkthrough.if, { install: 'failure', quota: 'success' }),
+      ).toBe(false);
+    });
+
+    it('walkthrough step is skipped when quota fails', () => {
+      const walkthrough = stepById('walkthrough');
+      expect(
+        evalStepIf(walkthrough.if, { install: 'success', quota: 'failure' }),
+      ).toBe(false);
+    });
+
+    it('walkthrough step runs when both install and quota succeed', () => {
+      const walkthrough = stepById('walkthrough');
+      expect(
+        evalStepIf(walkthrough.if, { install: 'success', quota: 'success' }),
+      ).toBe(true);
+    });
+
+    // --- A5: Diagnostics upload under always(), capturing zero-exit parse artifacts ---
+
+    it('diagnostics upload step uses if: always()', () => {
+      const upload = stepByName('Upload walkthrough diagnostics');
+      expect(upload.if).toBe('always()');
+    });
+
+    it('diagnostics upload runs even when walkthrough succeeds (zero-exit parse artifacts)', () => {
+      const upload = stepByName('Upload walkthrough diagnostics');
+      expect(evalStepIf(upload.if, { walkthrough: 'success' })).toBe(true);
+    });
+
+    it('diagnostics upload runs when walkthrough fails', () => {
+      const upload = stepByName('Upload walkthrough diagnostics');
+      expect(evalStepIf(upload.if, { walkthrough: 'failure' })).toBe(true);
+    });
+
+    // --- A7: Fallback and posting always attempted, non-blocking ---
+
+    it('Ensure fallback comment runs under always()', () => {
+      const fallback = stepByName('Ensure fallback comment');
+      expect(evalStepIf(fallback.if, { walkthrough: 'failure' })).toBe(true);
+      expect(evalStepIf(fallback.if, { walkthrough: 'success' })).toBe(true);
+    });
+
+    it('Post walkthrough comment runs under always()', () => {
+      const post = reviewJob.steps.find((s) =>
+        s.uses?.includes('actions-comment-pull-request'),
+      );
+      expect(evalStepIf(post.if, { walkthrough: 'failure' })).toBe(true);
+      expect(evalStepIf(post.if, { walkthrough: 'success' })).toBe(true);
+    });
+
+    // --- A8: Cancellation is not disguised as success ---
+    //
+    // When the workflow run is cancelled, GitHub Actions marks the job
+    // conclusion as 'cancelled'. Steps with `if: always()` may execute, but
+    // the job conclusion is not changed to success by that. The invariant
+    // here: no step in the review job sets `continue-on-error` to a value
+    // that would force the *job* to succeed on cancellation, and no step
+    // uses an expression that references cancelled() == false to fabricate
+    // success. We verify the advisory steps use `continue-on-error: true`
+    // (which only masks step failures, not cancellation).
+
+    it('no advisory step uses an expression that fabricates success on cancellation', () => {
+      for (const step of reviewJob.steps) {
+        const ifExpr = String(step.if ?? '');
+        // No step should negate cancelled() to claim success.
+        expect(ifExpr).not.toMatch(/cancelled\s*\(\s*\)\s*==\s*'?false'?/);
+      }
+    });
+
+    it('issue gate and fetch steps (pre-advisory) do not use continue-on-error', () => {
+      const gate = stepByName('Collect PR metadata and ensure linked issue');
+      const fetch = stepByName('Fetch pull request head');
+      // These structural steps must not be masked — their failure is real.
+      expect(continueOnError(gate)).toBe(false);
+      expect(continueOnError(fetch)).toBe(false);
+    });
+
+    // --- A9: Linked-issue gate and mergeability gate unchanged ---
+
+    it('the issue_gate step does NOT have continue-on-error', () => {
+      const gate = stepByName('Collect PR metadata and ensure linked issue');
+      expect(continueOnError(gate)).toBe(false);
+    });
+
+    it('the issue_gate step is NOT id-gated by install/quota', () => {
+      const gate = stepByName('Collect PR metadata and ensure linked issue');
+      // The gate runs before install/quota, so its if should not reference them
+      const gateIf = String(gate.if ?? '');
+      expect(gateIf).not.toContain('steps.install');
+      expect(gateIf).not.toContain('steps.quota');
+    });
+
+    it('mergeability-gate job is unchanged and still required', () => {
+      expect(reviewJob.needs).toContain('mergeability-gate');
+    });
+  });
+
+  describe('injected-failure scenario coverage (Issue #2778)', () => {
+    function stepByName(name) {
+      return reviewJob.steps.find((s) => s.name === name);
+    }
+
+    function stepById(id) {
+      return reviewJob.steps.find((s) => s.id === id);
+    }
+
+    // Simulate each injected-failure scenario and verify:
+    // 1. The failing step's outcome remains visible (continue-on-error preserves outcome)
+    // 2. Downstream finalization still runs
+    // 3. The job does not block merge (all advisory steps are continue-on-error)
+
+    it('install failure: walkthrough skipped, fallback+post still run', () => {
+      const scenarios = {
+        install: 'failure',
+        quota: 'skipped',
+        walkthrough: 'skipped',
+      };
+      const fallback = stepByName('Ensure fallback comment');
+      const post = reviewJob.steps.find((s) =>
+        s.uses?.includes('actions-comment-pull-request'),
+      );
+      expect(evalStepIf(fallback.if, scenarios)).toBe(true);
+      expect(evalStepIf(post.if, scenarios)).toBe(true);
+      expect(continueOnError(stepByName('Install LLxprt CLI nightly'))).toBe(
+        true,
+      );
+    });
+
+    it('quota failure: walkthrough skipped, fallback+post still run', () => {
+      const scenarios = {
+        install: 'success',
+        quota: 'failure',
+        walkthrough: 'skipped',
+      };
+      const fallback = stepByName('Ensure fallback comment');
+      const post = reviewJob.steps.find((s) =>
+        s.uses?.includes('actions-comment-pull-request'),
+      );
+      expect(evalStepIf(fallback.if, scenarios)).toBe(true);
+      expect(evalStepIf(post.if, scenarios)).toBe(true);
+      expect(
+        continueOnError(stepByName('Check API quota and select optimal key')),
+      ).toBe(true);
+    });
+
+    it('walkthrough failure: diagnostics uploaded, fallback+post still run', () => {
+      const scenarios = {
+        install: 'success',
+        quota: 'success',
+        walkthrough: 'failure',
+      };
+      const upload = stepByName('Upload walkthrough diagnostics');
+      const fallback = stepByName('Ensure fallback comment');
+      const post = reviewJob.steps.find((s) =>
+        s.uses?.includes('actions-comment-pull-request'),
+      );
+      expect(evalStepIf(upload.if, scenarios)).toBe(true);
+      expect(evalStepIf(fallback.if, scenarios)).toBe(true);
+      expect(evalStepIf(post.if, scenarios)).toBe(true);
+      expect(continueOnError(stepById('walkthrough'))).toBe(true);
+    });
+
+    it('JSON parse failure on zero-exit: parse artifacts uploaded via always()', () => {
+      // A gracefully degraded pipeline may exit 0 while producing parse-failure
+      // artifacts. The upload must run under always() to capture them.
+      const scenarios = {
+        install: 'success',
+        quota: 'success',
+        walkthrough: 'success',
+      };
+      const upload = stepByName('Upload walkthrough diagnostics');
+      expect(evalStepIf(upload.if, scenarios)).toBe(true);
+      const artifactPath = upload.with?.path;
+      expect(artifactPath).toContain('review/parse-failure-raw-*.txt');
+      expect(artifactPath).toContain('review/parse-failure-info-*.json');
+    });
+
+    it('upload failure is non-blocking (continue-on-error on upload)', () => {
+      const upload = stepByName('Upload walkthrough diagnostics');
+      expect(continueOnError(upload)).toBe(true);
+    });
+
+    it('comment-posting failure is non-blocking (continue-on-error on post)', () => {
+      const post = reviewJob.steps.find((s) =>
+        s.uses?.includes('actions-comment-pull-request'),
+      );
+      expect(continueOnError(post)).toBe(true);
+    });
+
+    it('fallback comment failure is non-blocking (continue-on-error)', () => {
+      const fallback = stepByName('Ensure fallback comment');
+      expect(continueOnError(fallback)).toBe(true);
+    });
+  });
+
+  describe('secrets never leaked into public comments (Issue #2778 non-goal)', () => {
+    it('walkthrough stderr is never appended to comment.md', () => {
+      const walkthrough = reviewJob.steps.find(
+        (s) => s.name === 'Run walkthrough pipeline',
+      );
+      // Strip shell comments so we only inspect actual commands, not
+      // explanatory comments that reference the file name.
+      const run = String(walkthrough.run ?? '')
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('#'))
+        .join('\n');
+      expect(run).not.toMatch(/review\/comment\.md/);
+    });
+
+    it('fallback comment is generic and contains no diagnostic content', () => {
+      const fallback = reviewJob.steps.find(
+        (s) => s.name === 'Ensure fallback comment',
+      );
+      const run = String(fallback.run ?? '');
+      expect(run).not.toContain('walkthrough-error.log');
+      expect(run).not.toContain('parse-failure');
+    });
+
+    it('upload artifact path excludes comment.md', () => {
+      const upload = reviewJob.steps.find(
+        (s) => s.name === 'Upload walkthrough diagnostics',
+      );
+      const artifactPath = String(upload.with?.path ?? '');
+      expect(artifactPath).not.toContain('comment.md');
     });
   });
 });

--- a/scripts/tests/pr-review-walkthrough-workflow.test.ts
+++ b/scripts/tests/pr-review-walkthrough-workflow.test.ts
@@ -63,6 +63,12 @@ function findStepByName(
   return job.steps.find((step) => step.name === name);
 }
 
+function requireStepByName(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps.find((s) => s.name === name);
+  expect(step, `review job should have a step named "${name}"`).toBeTruthy();
+  return step as WorkflowStep;
+}
+
 function requireStepById(job: WorkflowJob, id: string): WorkflowStep {
   const step = job.steps.find((s) => s.id === id);
   expect(step, `review job should have a step with id "${id}"`).toBeTruthy();
@@ -105,6 +111,9 @@ function evalStepIf(
   let normalized = String(expr).trim();
   if (normalized.startsWith('${{') && normalized.endsWith('}}')) {
     normalized = normalized.slice(3, -2).trim();
+  }
+  if (normalized === '') {
+    return true;
   }
   normalized = normalized.replace(/\s+/g, ' ');
   normalized = normalized.replace(
@@ -530,12 +539,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
     }
 
     function stepByName(name: string): WorkflowStep {
-      const step = reviewJob.steps.find((s) => s.name === name);
-      expect(
-        step,
-        `review job should have a step named "${name}"`,
-      ).toBeTruthy();
-      return step as WorkflowStep;
+      return requireStepByName(reviewJob, name);
     }
 
     // --- A1: Every advisory step has continue-on-error: true ---
@@ -582,6 +586,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       expect(
         evalStepIf(walkthrough.if, {
           outcomes: { install: 'failure', quota: 'success' },
+          outputs: { issue_gate: { should_review: 'true' } },
         }),
       ).toBe(false);
     });
@@ -591,6 +596,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       expect(
         evalStepIf(walkthrough.if, {
           outcomes: { install: 'success', quota: 'failure' },
+          outputs: { issue_gate: { should_review: 'true' } },
         }),
       ).toBe(false);
     });
@@ -600,8 +606,19 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       expect(
         evalStepIf(walkthrough.if, {
           outcomes: { install: 'success', quota: 'success' },
+          outputs: { issue_gate: { should_review: 'true' } },
         }),
       ).toBe(true);
+    });
+
+    it('walkthrough step does not run when issue_gate says false', () => {
+      const walkthrough = stepById('walkthrough');
+      expect(
+        evalStepIf(walkthrough.if, {
+          outcomes: { install: 'success', quota: 'success' },
+          outputs: { issue_gate: { should_review: 'false' } },
+        }),
+      ).toBe(false);
     });
 
     // --- A5: Diagnostics upload under always(), capturing zero-exit parse artifacts ---
@@ -697,6 +714,11 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
   });
 
   describe('injected-failure scenario coverage (Issue #2778)', () => {
+    // These tests use optional find (returning WorkflowStep | undefined)
+    // because they pass results to continueOnError(), which handles
+    // undefined by returning false. This is intentionally different from the
+    // non-blocking block's requireStepByName/requireStepById which assert
+    // step existence.
     function stepByName(name: string): WorkflowStep | undefined {
       return reviewJob.steps.find((s) => s.name === name);
     }

--- a/scripts/tests/pr-review-walkthrough-workflow.test.ts
+++ b/scripts/tests/pr-review-walkthrough-workflow.test.ts
@@ -10,34 +10,77 @@ import { normalize, readRootFile } from './ocr-review-workflow-helpers.js';
 
 const WORKFLOW_PATH = '.github/workflows/pr-review.yml';
 
-function loadWorkflow(relPath) {
+interface WorkflowStep {
+  name?: string;
+  id?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string>;
+  env?: Record<string, string>;
+  'continue-on-error'?: boolean | string;
+  continue_on_error?: boolean | string;
+}
+
+interface WorkflowJob {
+  steps: WorkflowStep[];
+  needs?: string[];
+  env?: Record<string, string>;
+  'timeout-minutes'?: number;
+  'runs-on'?: string;
+}
+
+interface WorkflowFile {
+  on?: Record<string, { types?: string[] }> & {
+    pull_request_target?: { types?: string[] };
+  };
+  concurrency?: { group?: string; 'cancel-in-progress'?: boolean };
+  permissions?: Record<string, string>;
+  env?: Record<string, string>;
+  jobs?: Record<string, WorkflowJob>;
+}
+
+type StepOutcome = 'success' | 'failure' | 'skipped' | 'cancelled';
+
+interface StepOutcomes {
+  outcomes: Record<string, StepOutcome>;
+  outputs?: Record<string, Record<string, string>>;
+}
+
+function loadWorkflow(relPath: string): WorkflowFile {
   const source = readRootFile(relPath);
   const parsed = yaml.load(source);
   if (!parsed || typeof parsed !== 'object') {
     throw new Error(`${relPath} did not parse to a YAML mapping`);
   }
-  return parsed;
+  return parsed as WorkflowFile;
 }
 
-function findStepByName(job, name) {
+function findStepByName(
+  job: WorkflowJob,
+  name: string,
+): WorkflowStep | undefined {
   return job.steps.find((step) => step.name === name);
 }
 
-function stepRunText(job, name) {
+function stepRunText(job: WorkflowJob, name: string): string {
   const step = findStepByName(job, name);
-  return step ? String(step.run ?? step.with?.script ?? '') : '';
+  return step ? String(step.run ?? step.with?.['script'] ?? '') : '';
 }
 
-function allStepNames(job) {
-  return job.steps.map((step) => step.name);
+function allStepNames(job: WorkflowJob): string[] {
+  return job.steps.map((step) => step.name ?? '');
 }
 
-function allStepText(job) {
+function allStepText(job: WorkflowJob): string {
   return JSON.stringify(job.steps);
 }
 
-function continueOnError(step) {
-  const value = step?.['continue-on-error'] ?? step?.continue_on_error;
+function continueOnError(step: WorkflowStep | undefined): boolean {
+  if (!step) {
+    return false;
+  }
+  const value = step['continue-on-error'] ?? step.continue_on_error;
   return value === true || value === '${{ true }}';
 }
 
@@ -46,7 +89,10 @@ function continueOnError(step) {
  * Supports the limited subset used by pr-review.yml: step.outcome equality,
  * &&, ||, !cancelled(), always(), failure(), success().
  */
-function evalStepIf(expr, stepOutcomes = {}) {
+function evalStepIf(
+  expr: string | undefined,
+  stepOutcomes: StepOutcomes = { outcomes: {} },
+): boolean {
   if (expr === undefined || expr === null) {
     return true;
   }
@@ -57,8 +103,8 @@ function evalStepIf(expr, stepOutcomes = {}) {
   normalized = normalized.replace(/\s+/g, ' ');
   normalized = normalized.replace(
     /steps\.([a-zA-Z0-9_-]+)\.outcome\s*==\s*'([^']*)'/g,
-    (match, id, value) => {
-      const outcome = stepOutcomes[id] ?? 'skipped';
+    (_match, id: string, value: string) => {
+      const outcome = stepOutcomes.outcomes[id] ?? 'skipped';
       return outcome === value ? 'TRUE' : 'FALSE';
     },
   );
@@ -69,7 +115,7 @@ function evalStepIf(expr, stepOutcomes = {}) {
   const outputs = stepOutcomes.outputs ?? {};
   normalized = normalized.replace(
     /steps\.([a-zA-Z0-9_-]+)\.outputs\.([a-zA-Z0-9_-]+)\s*==\s*'([^']*)'/g,
-    (match, stepId, outputName, expected) => {
+    (_match, stepId: string, outputName: string, expected: string) => {
       const actual = outputs[stepId]?.[outputName];
       if (actual === undefined) {
         return 'TRUE';
@@ -77,10 +123,9 @@ function evalStepIf(expr, stepOutcomes = {}) {
       return actual === expected ? 'TRUE' : 'FALSE';
     },
   );
-  const anyFailure = Object.values(stepOutcomes).some((o) => o === 'failure');
-  const anyCancelled = Object.values(stepOutcomes).some(
-    (o) => o === 'cancelled',
-  );
+  const outcomeValues = Object.values(stepOutcomes.outcomes);
+  const anyFailure = outcomeValues.some((o) => o === 'failure');
+  const anyCancelled = outcomeValues.some((o) => o === 'cancelled');
   normalized = normalized.replace(/\balways\(\)/g, 'TRUE');
   // success() is true only when no prior step failed and the job is not cancelled.
   normalized = normalized.replace(
@@ -98,14 +143,14 @@ function evalStepIf(expr, stepOutcomes = {}) {
   return evalBoolean(normalized);
 }
 
-function evalBoolean(expr) {
+function evalBoolean(expr: string): boolean {
   let pos = 0;
-  function skipSpaces() {
+  function skipSpaces(): void {
     while (pos < expr.length && expr[pos] === ' ') {
       pos += 1;
     }
   }
-  function parsePrimary() {
+  function parsePrimary(): boolean {
     skipSpaces();
     if (expr.startsWith('TRUE', pos)) {
       pos += 4;
@@ -136,7 +181,7 @@ function evalBoolean(expr) {
       `Invalid boolean expression: unexpected token at ${pos} in "${expr}"`,
     );
   }
-  function parseAnd() {
+  function parseAnd(): boolean {
     let value = parsePrimary();
     skipSpaces();
     while (expr.startsWith('&&', pos)) {
@@ -147,7 +192,7 @@ function evalBoolean(expr) {
     }
     return value;
   }
-  function parseOr() {
+  function parseOr(): boolean {
     let value = parseAnd();
     skipSpaces();
     while (expr.startsWith('||', pos)) {
@@ -169,12 +214,12 @@ function evalBoolean(expr) {
 }
 
 describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', () => {
-  let workflow;
-  let reviewJob;
+  let workflow: WorkflowFile;
+  let reviewJob: WorkflowJob;
 
   beforeAll(() => {
     workflow = loadWorkflow(WORKFLOW_PATH);
-    reviewJob = workflow.jobs?.review;
+    reviewJob = workflow.jobs?.['review'] as WorkflowJob;
     expect(reviewJob, 'workflow should contain a review job').toBeTruthy();
   });
 
@@ -203,33 +248,33 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
 
   describe('permissions (unchanged)', () => {
     it('preserves contents: read, pull-requests: write, issues: read, actions: read', () => {
-      expect(workflow.permissions?.contents).toBe('read');
+      expect(workflow.permissions?.['contents']).toBe('read');
       expect(workflow.permissions?.['pull-requests']).toBe('write');
-      expect(workflow.permissions?.issues).toBe('read');
-      expect(workflow.permissions?.actions).toBe('read');
+      expect(workflow.permissions?.['issues']).toBe('read');
+      expect(workflow.permissions?.['actions']).toBe('read');
     });
   });
 
   describe('env vars (unchanged)', () => {
     it('preserves KEY_VAR_NAME and REPO at workflow level', () => {
       const env = workflow.env ?? {};
-      expect(env.KEY_VAR_NAME).toBeTruthy();
-      expect(env.REPO).toBeTruthy();
+      expect(env['KEY_VAR_NAME']).toBeTruthy();
+      expect(env['REPO']).toBeTruthy();
     });
 
     it('preserves provider env vars in the review job', () => {
       const env = reviewJob.env ?? {};
-      expect(env.OPENAI_BASE_URL).toBeTruthy();
-      expect(env.LLXPRT_DEFAULT_MODEL).toBeTruthy();
-      expect(env.LLXPRT_DEFAULT_PROVIDER).toBeTruthy();
-      expect(env.LLXPRT_CONTEXT_LIMIT).toBeTruthy();
-      expect(env.DEBUG_OUTPUT).toBeTruthy();
+      expect(env['OPENAI_BASE_URL']).toBeTruthy();
+      expect(env['LLXPRT_DEFAULT_MODEL']).toBeTruthy();
+      expect(env['LLXPRT_DEFAULT_PROVIDER']).toBeTruthy();
+      expect(env['LLXPRT_CONTEXT_LIMIT']).toBeTruthy();
+      expect(env['DEBUG_OUTPUT']).toBeTruthy();
     });
 
     it('wires the strong model tier from repository variables', () => {
       const env = reviewJob.env ?? {};
-      expect(env.LLXPRT_STRONG_MODEL).toContain('vars.LLXPRT_STRONG_MODEL');
-      expect(env.LLXPRT_STRONG_MODEL).toContain('vars.LLXPRT_DEFAULT_MODEL');
+      expect(env['LLXPRT_STRONG_MODEL']).toContain('vars.LLXPRT_STRONG_MODEL');
+      expect(env['LLXPRT_STRONG_MODEL']).toContain('vars.LLXPRT_DEFAULT_MODEL');
     });
   });
 
@@ -239,14 +284,14 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
         step.uses?.includes('actions-comment-pull-request'),
       );
       expect(postStep, 'should have a comment-post step').toBeTruthy();
-      expect(postStep.with?.['comment-tag']).toBe('llxprt-walkthrough');
+      expect(postStep?.with?.['comment-tag']).toBe('llxprt-walkthrough');
     });
 
     it('does not use the old llxprt-pr-review comment tag in the post step', () => {
       const postStep = reviewJob.steps.find((step) =>
         step.uses?.includes('actions-comment-pull-request'),
       );
-      expect(postStep.with?.['comment-tag']).not.toBe('llxprt-pr-review');
+      expect(postStep?.with?.['comment-tag']).not.toBe('llxprt-pr-review');
     });
 
     it('the issue_gate blocked comment uses the new tag', () => {
@@ -277,9 +322,9 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
 
     it('does not reference Ready/Needs-Work verdict logic', () => {
       const combined = allStepText(reviewJob);
-      const normalized = normalize(combined);
-      expect(normalized).not.toMatch(/verdict\s*==\s*.?needs_work/);
-      expect(normalized).not.toContain('needs_work');
+      const normalizedText = normalize(combined);
+      expect(normalizedText).not.toMatch(/verdict\s*==\s*.?needs_work/);
+      expect(normalizedText).not.toContain('needs_work');
     });
 
     it('does not reference the luther remediate label logic', () => {
@@ -306,7 +351,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
           s.run.includes('scripts/pr-review-walkthrough.mjs'),
       );
       expect(step, 'should run the walkthrough orchestrator').toBeTruthy();
-      expect(step.run).toMatch(/node\s+scripts\/pr-review-walkthrough\.mjs/);
+      expect(step?.run).toMatch(/node\s+scripts\/pr-review-walkthrough\.mjs/);
     });
 
     it('the walkthrough step name is "Run walkthrough pipeline"', () => {
@@ -315,7 +360,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
           typeof s.run === 'string' &&
           s.run.includes('scripts/pr-review-walkthrough.mjs'),
       );
-      expect(step.name).toBe('Run walkthrough pipeline');
+      expect(step?.name).toBe('Run walkthrough pipeline');
     });
   });
 
@@ -363,7 +408,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       const postStep = reviewJob.steps.find((step) =>
         step.uses?.includes('actions-comment-pull-request'),
       );
-      expect(postStep.uses, 'should use the pinned comment action').toContain(
+      expect(postStep?.uses, 'should use the pinned comment action').toContain(
         'thollander/actions-comment-pull-request',
       );
     });
@@ -405,7 +450,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
   describe('ensure fallback comment (MEDIUM 10)', () => {
     it('has an Ensure fallback comment step with if: always()', () => {
       const step = findStepByName(reviewJob, 'Ensure fallback comment');
-      expect(step.if).toBe('always()');
+      expect(step?.if).toBe('always()');
     });
 
     it('the fallback step writes a generic comment when comment.md is empty', () => {
@@ -426,11 +471,11 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       expect(step, 'should upload the diagnostics log').toBeTruthy();
       // Issue #2778: upload runs under always() so parse artifacts from
       // gracefully degraded zero-exit runs are captured alongside failure logs.
-      expect(step.if).toBe('always()');
-      expect(step.uses).toContain('actions/upload-artifact@');
+      expect(step?.if).toBe('always()');
+      expect(step?.uses).toContain('actions/upload-artifact@');
       // Issue #2742: the artifact now includes parse-failure diagnostics
       // (raw LLM responses + metadata) alongside the error log.
-      const artifactPath = step.with?.path;
+      const artifactPath = step?.with?.['path'] ?? '';
       expect(artifactPath).toContain('review/walkthrough-error.log');
       expect(artifactPath).toContain('review/parse-failure-raw-*.txt');
       expect(artifactPath).toContain('review/parse-failure-info-*.json');
@@ -465,7 +510,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       const postStep = reviewJob.steps.find((step) =>
         step.uses?.includes('actions-comment-pull-request'),
       );
-      expect(postStep.if).toBe('always()');
+      expect(postStep?.if).toBe('always()');
     });
   });
 
@@ -474,22 +519,22 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
   // =========================================================================
 
   describe('non-blocking review job (Issue #2778)', () => {
-    function stepById(id) {
+    function stepById(id: string): WorkflowStep {
       const step = reviewJob.steps.find((s) => s.id === id);
       expect(
         step,
         `review job should have a step with id "${id}"`,
       ).toBeTruthy();
-      return step;
+      return step as WorkflowStep;
     }
 
-    function stepByName(name) {
+    function stepByName(name: string): WorkflowStep {
       const step = reviewJob.steps.find((s) => s.name === name);
       expect(
         step,
         `review job should have a step named "${name}"`,
       ).toBeTruthy();
-      return step;
+      return step as WorkflowStep;
     }
 
     // --- A1: Every advisory step has continue-on-error: true ---
@@ -534,21 +579,27 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
     it('walkthrough step is skipped when install fails', () => {
       const walkthrough = stepById('walkthrough');
       expect(
-        evalStepIf(walkthrough.if, { install: 'failure', quota: 'success' }),
+        evalStepIf(walkthrough.if, {
+          outcomes: { install: 'failure', quota: 'success' },
+        }),
       ).toBe(false);
     });
 
     it('walkthrough step is skipped when quota fails', () => {
       const walkthrough = stepById('walkthrough');
       expect(
-        evalStepIf(walkthrough.if, { install: 'success', quota: 'failure' }),
+        evalStepIf(walkthrough.if, {
+          outcomes: { install: 'success', quota: 'failure' },
+        }),
       ).toBe(false);
     });
 
     it('walkthrough step runs when both install and quota succeed', () => {
       const walkthrough = stepById('walkthrough');
       expect(
-        evalStepIf(walkthrough.if, { install: 'success', quota: 'success' }),
+        evalStepIf(walkthrough.if, {
+          outcomes: { install: 'success', quota: 'success' },
+        }),
       ).toBe(true);
     });
 
@@ -561,28 +612,40 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
 
     it('diagnostics upload runs even when walkthrough succeeds (zero-exit parse artifacts)', () => {
       const upload = stepByName('Upload walkthrough diagnostics');
-      expect(evalStepIf(upload.if, { walkthrough: 'success' })).toBe(true);
+      expect(
+        evalStepIf(upload.if, { outcomes: { walkthrough: 'success' } }),
+      ).toBe(true);
     });
 
     it('diagnostics upload runs when walkthrough fails', () => {
       const upload = stepByName('Upload walkthrough diagnostics');
-      expect(evalStepIf(upload.if, { walkthrough: 'failure' })).toBe(true);
+      expect(
+        evalStepIf(upload.if, { outcomes: { walkthrough: 'failure' } }),
+      ).toBe(true);
     });
 
     // --- A7: Fallback and posting always attempted, non-blocking ---
 
     it('Ensure fallback comment runs under always()', () => {
       const fallback = stepByName('Ensure fallback comment');
-      expect(evalStepIf(fallback.if, { walkthrough: 'failure' })).toBe(true);
-      expect(evalStepIf(fallback.if, { walkthrough: 'success' })).toBe(true);
+      expect(
+        evalStepIf(fallback.if, { outcomes: { walkthrough: 'failure' } }),
+      ).toBe(true);
+      expect(
+        evalStepIf(fallback.if, { outcomes: { walkthrough: 'success' } }),
+      ).toBe(true);
     });
 
     it('Post walkthrough comment runs under always()', () => {
       const post = reviewJob.steps.find((s) =>
         s.uses?.includes('actions-comment-pull-request'),
       );
-      expect(evalStepIf(post.if, { walkthrough: 'failure' })).toBe(true);
-      expect(evalStepIf(post.if, { walkthrough: 'success' })).toBe(true);
+      expect(
+        evalStepIf(post?.if, { outcomes: { walkthrough: 'failure' } }),
+      ).toBe(true);
+      expect(
+        evalStepIf(post?.if, { outcomes: { walkthrough: 'success' } }),
+      ).toBe(true);
     });
 
     // --- A8: Cancellation is not disguised as success ---
@@ -633,11 +696,11 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
   });
 
   describe('injected-failure scenario coverage (Issue #2778)', () => {
-    function stepByName(name) {
+    function stepByName(name: string): WorkflowStep | undefined {
       return reviewJob.steps.find((s) => s.name === name);
     }
 
-    function stepById(id) {
+    function stepById(id: string): WorkflowStep | undefined {
       return reviewJob.steps.find((s) => s.id === id);
     }
 
@@ -647,67 +710,75 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
     // 3. The job does not block merge (all advisory steps are continue-on-error)
 
     it('install failure: walkthrough skipped, fallback+post still run', () => {
-      const scenarios = {
-        install: 'failure',
-        quota: 'skipped',
-        walkthrough: 'skipped',
+      const scenarios: StepOutcomes = {
+        outcomes: {
+          install: 'failure',
+          quota: 'skipped',
+          walkthrough: 'skipped',
+        },
       };
       const fallback = stepByName('Ensure fallback comment');
       const post = reviewJob.steps.find((s) =>
         s.uses?.includes('actions-comment-pull-request'),
       );
-      expect(evalStepIf(fallback.if, scenarios)).toBe(true);
-      expect(evalStepIf(post.if, scenarios)).toBe(true);
+      expect(evalStepIf(fallback?.if, scenarios)).toBe(true);
+      expect(evalStepIf(post?.if, scenarios)).toBe(true);
       expect(continueOnError(stepByName('Install LLxprt CLI nightly'))).toBe(
         true,
       );
     });
 
     it('quota failure: walkthrough skipped, fallback+post still run', () => {
-      const scenarios = {
-        install: 'success',
-        quota: 'failure',
-        walkthrough: 'skipped',
+      const scenarios: StepOutcomes = {
+        outcomes: {
+          install: 'success',
+          quota: 'failure',
+          walkthrough: 'skipped',
+        },
       };
       const fallback = stepByName('Ensure fallback comment');
       const post = reviewJob.steps.find((s) =>
         s.uses?.includes('actions-comment-pull-request'),
       );
-      expect(evalStepIf(fallback.if, scenarios)).toBe(true);
-      expect(evalStepIf(post.if, scenarios)).toBe(true);
+      expect(evalStepIf(fallback?.if, scenarios)).toBe(true);
+      expect(evalStepIf(post?.if, scenarios)).toBe(true);
       expect(
         continueOnError(stepByName('Check API quota and select optimal key')),
       ).toBe(true);
     });
 
     it('walkthrough failure: diagnostics uploaded, fallback+post still run', () => {
-      const scenarios = {
-        install: 'success',
-        quota: 'success',
-        walkthrough: 'failure',
+      const scenarios: StepOutcomes = {
+        outcomes: {
+          install: 'success',
+          quota: 'success',
+          walkthrough: 'failure',
+        },
       };
       const upload = stepByName('Upload walkthrough diagnostics');
       const fallback = stepByName('Ensure fallback comment');
       const post = reviewJob.steps.find((s) =>
         s.uses?.includes('actions-comment-pull-request'),
       );
-      expect(evalStepIf(upload.if, scenarios)).toBe(true);
-      expect(evalStepIf(fallback.if, scenarios)).toBe(true);
-      expect(evalStepIf(post.if, scenarios)).toBe(true);
+      expect(evalStepIf(upload?.if, scenarios)).toBe(true);
+      expect(evalStepIf(fallback?.if, scenarios)).toBe(true);
+      expect(evalStepIf(post?.if, scenarios)).toBe(true);
       expect(continueOnError(stepById('walkthrough'))).toBe(true);
     });
 
     it('JSON parse failure on zero-exit: parse artifacts uploaded via always()', () => {
       // A gracefully degraded pipeline may exit 0 while producing parse-failure
       // artifacts. The upload must run under always() to capture them.
-      const scenarios = {
-        install: 'success',
-        quota: 'success',
-        walkthrough: 'success',
+      const scenarios: StepOutcomes = {
+        outcomes: {
+          install: 'success',
+          quota: 'success',
+          walkthrough: 'success',
+        },
       };
       const upload = stepByName('Upload walkthrough diagnostics');
-      expect(evalStepIf(upload.if, scenarios)).toBe(true);
-      const artifactPath = upload.with?.path;
+      expect(evalStepIf(upload?.if, scenarios)).toBe(true);
+      const artifactPath = upload?.with?.['path'] ?? '';
       expect(artifactPath).toContain('review/parse-failure-raw-*.txt');
       expect(artifactPath).toContain('review/parse-failure-info-*.json');
     });
@@ -737,7 +808,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       );
       // Strip shell comments so we only inspect actual commands, not
       // explanatory comments that reference the file name.
-      const run = String(walkthrough.run ?? '')
+      const run = String(walkthrough?.run ?? '')
         .split('\n')
         .filter((line) => !line.trim().startsWith('#'))
         .join('\n');
@@ -748,7 +819,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       const fallback = reviewJob.steps.find(
         (s) => s.name === 'Ensure fallback comment',
       );
-      const run = String(fallback.run ?? '');
+      const run = String(fallback?.run ?? '');
       expect(run).not.toContain('walkthrough-error.log');
       expect(run).not.toContain('parse-failure');
     });
@@ -757,7 +828,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
       const upload = reviewJob.steps.find(
         (s) => s.name === 'Upload walkthrough diagnostics',
       );
-      const artifactPath = String(upload.with?.path ?? '');
+      const artifactPath = String(upload?.with?.['path'] ?? '');
       expect(artifactPath).not.toContain('comment.md');
     });
   });

--- a/scripts/tests/pr-review-walkthrough-workflow.test.ts
+++ b/scripts/tests/pr-review-walkthrough-workflow.test.ts
@@ -63,6 +63,12 @@ function findStepByName(
   return job.steps.find((step) => step.name === name);
 }
 
+function requireStepById(job: WorkflowJob, id: string): WorkflowStep {
+  const step = job.steps.find((s) => s.id === id);
+  expect(step, `review job should have a step with id "${id}"`).toBeTruthy();
+  return step as WorkflowStep;
+}
+
 function stepRunText(job: WorkflowJob, name: string): string {
   const step = findStepByName(job, name);
   return step ? String(step.run ?? step.with?.['script'] ?? '') : '';
@@ -108,15 +114,15 @@ function evalStepIf(
       return outcome === value ? 'TRUE' : 'FALSE';
     },
   );
-  // Output comparisons (steps.X.outputs.Y == 'value') are resolved from the
-  // optional `outputs` map (stepOutcomes.outputs[stepId][outputName]). When an
-  // output is not provided, it resolves to TRUE so install/quota gating logic
-  // can be tested in isolation without modeling every upstream gate.
   const outputs = stepOutcomes.outputs ?? {};
   normalized = normalized.replace(
     /steps\.([a-zA-Z0-9_-]+)\.outputs\.([a-zA-Z0-9_-]+)\s*==\s*'([^']*)'/g,
     (_match, stepId: string, outputName: string, expected: string) => {
       const actual = outputs[stepId]?.[outputName];
+      // Missing outputs default to TRUE so that install/quota gating
+      // expressions can be tested in isolation without modeling every
+      // upstream gate. Critical outputs (should_review, selected_key)
+      // are always provided by tests that exercise those paths.
       if (actual === undefined) {
         return 'TRUE';
       }
@@ -520,12 +526,7 @@ describe('.github/workflows/pr-review.yml — repurposed walkthrough pipeline', 
 
   describe('non-blocking review job (Issue #2778)', () => {
     function stepById(id: string): WorkflowStep {
-      const step = reviewJob.steps.find((s) => s.id === id);
-      expect(
-        step,
-        `review job should have a step with id "${id}"`,
-      ).toBeTruthy();
-      return step as WorkflowStep;
+      return requireStepById(reviewJob, id);
     }
 
     function stepByName(name: string): WorkflowStep {

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -76,6 +76,7 @@
     "scripts/tests/affected-lint-targets.test.ts",
     "scripts/tests/run-lint.test.ts",
     "scripts/tests/telemetry-doc-accuracy.test.ts",
+    "scripts/tests/pr-review-walkthrough-workflow.test.ts",
     "test-setup/stub-helpers.ts",
     "test-setup/stub-helpers.bun.test.ts",
     "test-setup/augment-bun-vi.ts",


### PR DESCRIPTION
## Summary

The LLxprt walkthrough reviewer is advisory, but `.github/workflows/pr-review.yml` let infrastructure and reviewer-service failures conclude the `Run LLxprt review` job as failed. On PR 2750, both attempts successfully wrote and posted the generic fallback comment, yet the nonzero walkthrough process left the PR with a failed check and `UNSTABLE` merge state.

This PR adds a job-level non-blocking boundary so internal command failures remain visible in step outcomes and logs without becoming a merge gate.

## Changes

### `.github/workflows/pr-review.yml`
- **`continue-on-error: true`** on all advisory steps: install, quota, walkthrough, upload, fallback, and comment-post. This preserves each step's real `outcome` (visible in the Actions UI and logs) while preventing any single advisory failure from failing the job.
- **Gate walkthrough on install/quota success**: the `Run walkthrough pipeline` step now has `if: ${{ steps.issue_gate.outputs.should_review == 'true' && steps.install.outcome == 'success' && steps.quota.outcome == 'success' }}`. When install or quota fails, model invocation is skipped entirely, avoiding misleading secondary errors.
- **Change diagnostics upload from `failure()` to `always()`**: a gracefully degraded pipeline may exit 0 while producing parse-failure artifacts. Running the upload under `always()` ensures those artifacts are captured alongside failure logs.
- **IDs added**: `install`, `walkthrough` step IDs for outcome gating.

### `scripts/tests/pr-review-walkthrough-workflow.test.js`
- Updated the existing upload-condition test from `failure()` to `always()`.
- Added 29 new tests covering:
  - Every advisory step has `continue-on-error: true`
  - Walkthrough is skipped when install or quota fails
  - Walkthrough runs when both install and quota succeed
  - Diagnostics upload runs under `always()` for both success and failure
  - Fallback and comment-post always attempted and non-blocking
  - Cancellation is not disguised as success (no fabricated success expressions)
  - Issue gate and mergeability gate remain unchanged
  - Injected-failure scenarios for install, quota, walkthrough, JSON parse, upload, and comment-post failures
  - Secrets/diagnostics never leaked into public comments
- Added a `evalStepIf` helper that evaluates GitHub Actions `if:` expressions against a map of step outcomes, with strict trailing-input validation and correct `success()`/`failure()`/`cancelled()` semantics.

## Acceptance criteria

- [x] The LLxprt reviewer does not conclude as a blocking failure or destabilize the PR.
- [x] The original failing command's nonzero outcome remains visible in step outcome and logs.
- [x] Installation or quota failure skips model invocation.
- [x] A generic fallback comment is generated whenever no substantive walkthrough exists.
- [x] Tagged comment posting is attempted after earlier failures.
- [x] Comment-posting failure is non-blocking.
- [x] Available installation, quota, walkthrough, and raw parse diagnostics are uploaded with the existing bounded retention.
- [x] Parse artifacts from gracefully degraded zero-exit runs are uploaded.
- [x] Raw responses, secrets, and internal diagnostics are never copied into public comments.
- [x] Linked-issue gating and mergeability-gate behavior remain unchanged.
- [x] Cancellation remains cancellation; the workflow does not attempt to disguise explicit cancellation as review success.
- [x] Workflow tests verify exact conditions, ordering, pinned actions, and comment tag behavior.

## Non-goals (unchanged)

- No script changes to `pr-review-walkthrough.mjs` or `ci-quota-check.js`
- No changes to linked-issue requirements or the separate mergeability gate
- No changes to OCR, CodeRabbit, main CI, branch protection, or repository-wide required-check policy
- No retries beyond the existing bounded parsing/network policy

## Test plan

- [x] `npm run test:scripts` — 76 workflow tests pass
- [x] `npm run lint` — clean (no suppressions or weakened rules)
- [x] `npm run format` — clean
- [x] `npm run build` — passes
- [x] Open Code Review (ocr) — 3 findings addressed (trailing-input validation, success() semantics, output comparison modeling)

Closes #2778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated review reliability when installation or quota checks fail.
  * Review walkthroughs now run only when required setup steps succeed.
  * Diagnostics are uploaded even when walkthrough processing fails.
  * Commenting and fallback actions no longer block the overall review process.
  * Preserved generic fallback comments and prevented diagnostic output from appearing in review comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->