### PR TITLE
Add opt-in lazy MCP schema loading (Fixes #2327)

### DIFF
--- a/docs/reference/ephemerals.md
+++ b/docs/reference/ephemerals.md
@@ -129,6 +129,13 @@ Settings for multi-endpoint load balancing. Only apply when using load-balanced 
 | `tools.allowed`  | string[] | —       | yes     | Allowlist — if set, only these tools are available. Overrides `tools.disabled`. |
 | `tool_choice`    | string   | —       | yes     | Tool choice strategy sent to the API: `auto`, `required`, `none`.               |
 
+## MCP Lazy Schema Loading
+
+| Setting            | Type     | Default | Profile | Description                                                                                                                                                                                                                                                                                                                            |
+| ------------------ | -------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mcp.lazy`         | boolean  | `false` | yes     | Defer MCP server tool schemas from the model until a server is explicitly activated. The model receives an `activate_mcp_server` tool that lets it pick a server by name; only then are that server's full tool schemas published. MCP servers stay connected and discoverable — only the model-facing schema publication is deferred. |
+| `mcp.eagerServers` | string[] | —       | yes     | Names of MCP servers that remain eager while `mcp.lazy` is enabled. Their schemas are always published regardless of lazy mode. Unknown server names are silently ignored.                                                                                                                                                             |
+
 ## Prompt Configuration
 
 | Setting                    | Type    | Default | Profile | Description                                                                                                                                                           |

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -745,6 +745,47 @@ Use `/help` to see available MCP prompts alongside built-in commands.
 
 When running in a [sandbox](../sandbox.md), MCP servers must be available **inside the container**. If your server uses `npx`, the npm package must be installable within the sandbox environment.
 
+## Lazy MCP Schema Loading
+
+When you have many MCP servers with large tool schemas, every tool schema is sent to the model on each request. The `mcp.lazy` ephemeral setting defers those schemas so only the servers you actually need are published.
+
+### How It Works
+
+- **Servers stay connected.** MCP discovery, connection, tool registration, prompts, and resources all work exactly as before. Nothing is deferred except the model-facing schema publication.
+- **The model gets an `activate_mcp_server` tool.** Its compact description lists each deferred server's name, tool count, and up to 12 tool names — never full parameter schemas. The model calls this tool with a server name to activate it.
+- **Activation is session-scoped.** Once a server is activated, its full schemas are published for the rest of the session. There is no automatic un-activation; if you want to restart, create a new session.
+- **Eager exceptions.** Use `mcp.eagerServers` to pin specific servers as always-eager even when lazy mode is on.
+
+### Enabling Lazy Mode
+
+```
+/set mcp.lazy true
+```
+
+To keep specific servers eager:
+
+```
+/set mcp.eagerServers ["my-important-server","another-server"]
+```
+
+> `/set` updates the ephemeral settings but does not republish tools in an
+> already-initialized chat. To apply lazy mode, save and reload a named profile
+> (`/profile save lazy-mcp`, then `/profile load lazy-mcp`) or start a new
+> session with that profile. MCP tools are synchronized when the session
+> initializes and on each MCP lifecycle refresh.
+
+### Tradeoffs
+
+Lazy mode **reduces token overhead** for sessions with large MCP tool sets, but the model must spend a turn calling `activate_mcp_server` before it can use a deferred server's tools. For sessions where you always use all MCP tools, eager mode (the default) is better.
+
+### What Is Not Affected
+
+- MCP server connection, transport, and process lifecycle
+- OAuth, trust, and per-tool-call confirmation
+- `includeTools` and `excludeTools` filtering
+- MCP prompts, resources, and server instructions
+- Subagent tool whitelists (`getFunctionDeclarationsFiltered`)
+
 ## Common Issues
 
 **Server won't connect:**

--- a/packages/core/src/config/config.mcp-lazy.test.ts
+++ b/packages/core/src/config/config.mcp-lazy.test.ts
@@ -1,0 +1,288 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { Config } from './config.js';
+import {
+  registerSettingsService,
+  resetSettingsService,
+  SettingsService,
+} from '@vybestack/llxprt-code-settings';
+import { clearActiveProviderRuntimeContext } from '../runtime/providerRuntimeContext.js';
+import { initializeTestConfig } from '../test-utils/config.js';
+import {
+  ACTIVATE_MCP_SERVER_TOOL_NAME,
+  ActivateMcpServerTool,
+  BaseDeclarativeTool,
+  Kind,
+  ToolRegistry,
+  type ToolInvocation,
+  type ToolResult,
+  type IToolMessageBus,
+  type IToolRegistryHost,
+} from '@vybestack/llxprt-code-tools';
+import { syncActivateMcpServerTool } from './mcp-lazy-tool-sync.js';
+
+const NOOP = async (): Promise<void> => {};
+
+function createHost(ephemerals: Record<string, unknown>): IToolRegistryHost {
+  return {
+    getEphemeralSettings: () => ephemerals,
+    getCoreTools: () => [],
+    getExcludeTools: () => [],
+  };
+}
+
+function createMessageBus(): IToolMessageBus {
+  return {
+    publish: () => {},
+    subscribe: () => () => {},
+    unsubscribe: () => {},
+  };
+}
+
+class TestMcpTool extends BaseDeclarativeTool<
+  Record<string, unknown>,
+  ToolResult
+> {
+  readonly serverName: string;
+  constructor(name: string, serverName: string) {
+    super(
+      name,
+      name,
+      name,
+      Kind.Other,
+      zodToJsonSchema(z.object({ query: z.string() })),
+      true,
+      false,
+    );
+    this.serverName = serverName;
+  }
+  protected createInvocation(
+    _params: Record<string, unknown>,
+  ): ToolInvocation<Record<string, unknown>, ToolResult> {
+    throw new Error('not used');
+  }
+}
+
+class TestForeignTool extends BaseDeclarativeTool<
+  Record<string, unknown>,
+  ToolResult
+> {
+  constructor() {
+    super(
+      ACTIVATE_MCP_SERVER_TOOL_NAME,
+      'Foreign activate',
+      'foreign tool occupying the reserved name',
+      Kind.Other,
+      zodToJsonSchema(z.object({ x: z.string() })),
+      true,
+      false,
+    );
+  }
+  protected createInvocation(
+    _params: Record<string, unknown>,
+  ): ToolInvocation<Record<string, unknown>, ToolResult> {
+    throw new Error('not used');
+  }
+}
+
+function mcpTool(name: string, server: string): TestMcpTool {
+  return new TestMcpTool(name, server);
+}
+
+function isStringRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function extractNameEnum(schema: unknown): readonly string[] {
+  if (!isStringRecord(schema)) return [];
+  const properties = schema['properties'];
+  if (!isStringRecord(properties)) return [];
+  const nameProp = properties['name'];
+  if (!isStringRecord(nameProp)) return [];
+  const enumValues = nameProp['enum'];
+  if (!Array.isArray(enumValues)) return [];
+  return enumValues.filter((v): v is string => typeof v === 'string');
+}
+
+function findActivationTool(registry: ToolRegistry) {
+  return registry
+    .getAllTools()
+    .find((t) => t.name === ACTIVATE_MCP_SERVER_TOOL_NAME);
+}
+
+describe('syncActivateMcpServerTool — collision and default-mode preservation', () => {
+  it('preserves a foreign activate_mcp_server tool when lazy mode is off', async () => {
+    const registry = new ToolRegistry(createHost({}), createMessageBus());
+    registry.registerTool(new TestForeignTool());
+    const before = JSON.stringify(registry.getFunctionDeclarations());
+
+    await syncActivateMcpServerTool(registry, createMessageBus(), NOOP);
+
+    expect(JSON.stringify(registry.getFunctionDeclarations())).toBe(before);
+  });
+
+  it('fails fast when a foreign tool occupies the reserved name with deferred servers', async () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+    registry.registerTool(new TestForeignTool());
+
+    await expect(
+      syncActivateMcpServerTool(registry, createMessageBus(), NOOP),
+    ).rejects.toThrow('foreign tool');
+  });
+
+  it('rebuilds only an actual ActivateMcpServerTool on repeated syncs', async () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    await syncActivateMcpServerTool(registry, createMessageBus(), NOOP);
+    const first = findActivationTool(registry);
+    expect(first).toBeDefined();
+    expect(first instanceof ActivateMcpServerTool).toBe(true);
+
+    await syncActivateMcpServerTool(registry, createMessageBus(), NOOP);
+    expect(
+      registry
+        .getAllTools()
+        .filter((t) => t.name === ACTIVATE_MCP_SERVER_TOOL_NAME),
+    ).toHaveLength(1);
+  });
+
+  it('removes activation tool when all servers are activated (B6)', async () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    await syncActivateMcpServerTool(registry, createMessageBus(), NOOP);
+    expect(findActivationTool(registry)).toBeDefined();
+
+    registry.activateMcpServer('alpha');
+    await syncActivateMcpServerTool(registry, createMessageBus(), NOOP);
+    expect(findActivationTool(registry)).toBeUndefined();
+  });
+
+  it('no-ops when messageBus is undefined (pre-initialization lifecycle)', async () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    await expect(
+      syncActivateMcpServerTool(registry, undefined, NOOP),
+    ).resolves.toBeUndefined();
+    expect(findActivationTool(registry)).toBeUndefined();
+  });
+});
+
+describe('Config.refreshMcpContext — MCP lazy tool synchronization', () => {
+  let config: Config;
+
+  beforeEach(async () => {
+    resetSettingsService();
+    registerSettingsService(new SettingsService());
+    config = new Config({
+      model: 'test-model',
+      question: 'test',
+      embeddingModel: 'test-embedding',
+      targetDir: '.',
+      usageStatisticsEnabled: false,
+      sessionId: 'test-session-lazy',
+      debugMode: false,
+      cwd: '.',
+    });
+    await initializeTestConfig(config);
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+    resetSettingsService();
+  });
+
+  it('registers activation tool when deferred servers exist, absent when off (D2)', async () => {
+    const registry: ToolRegistry = config.getToolRegistry();
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    config.setEphemeralSetting('mcp.lazy', true);
+    await config.refreshMcpContext();
+    expect(findActivationTool(registry)).toBeDefined();
+
+    config.setEphemeralSetting('mcp.lazy', false);
+    await config.refreshMcpContext();
+    expect(findActivationTool(registry)).toBeUndefined();
+  });
+
+  it('rebuilds activation enum after tool list changes (C4)', async () => {
+    config.setEphemeralSetting('mcp.lazy', true);
+    const registry: ToolRegistry = config.getToolRegistry();
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    await config.refreshMcpContext();
+    const initialEnum = extractNameEnum(
+      findActivationTool(registry)?.schema.parametersJsonSchema,
+    );
+    expect(initialEnum).toContain('alpha');
+    expect(initialEnum).not.toContain('beta');
+
+    registry.registerTool(mcpTool('mcp__beta__lookup', 'beta'));
+    await config.refreshMcpContext();
+    const rebuiltEnum = extractNameEnum(
+      findActivationTool(registry)?.schema.parametersJsonSchema,
+    );
+    expect(rebuiltEnum).toContain('alpha');
+    expect(rebuiltEnum).toContain('beta');
+  });
+
+  it('removes activation tool when all servers become eager (C4)', async () => {
+    config.setEphemeralSetting('mcp.lazy', true);
+    const registry: ToolRegistry = config.getToolRegistry();
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    await config.refreshMcpContext();
+    expect(findActivationTool(registry)).toBeDefined();
+
+    config.setEphemeralSetting('mcp.eagerServers', ['alpha']);
+    await config.refreshMcpContext();
+    expect(findActivationTool(registry)).toBeUndefined();
+  });
+
+  it('nested profile-like mcp settings make activation behavior available (D2)', async () => {
+    const profileSettings = new SettingsService();
+    profileSettings.set('mcp.lazy', true);
+    registerSettingsService(profileSettings);
+    const nestedConfig = new Config({
+      model: 'test-model',
+      question: 'test',
+      embeddingModel: 'test-embedding',
+      targetDir: '.',
+      usageStatisticsEnabled: false,
+      sessionId: 'test-session-nested',
+      debugMode: false,
+      cwd: '.',
+      settingsService: profileSettings,
+    });
+    await initializeTestConfig(nestedConfig);
+
+    const registry: ToolRegistry = nestedConfig.getToolRegistry();
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+    await nestedConfig.refreshMcpContext();
+
+    expect(findActivationTool(registry)).toBeDefined();
+    expect(registry.listDeferredMcpServers()).toContain('alpha');
+  });
+});

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -45,6 +45,7 @@ import {
   requireAgentClientFactory,
   transferHistoryToNewClient,
 } from './agentClientLifecycle.js';
+import { syncActivateMcpServerTool } from './mcp-lazy-tool-sync.js';
 import {
   getOrCreateAsyncTaskManager,
   getOrCreateAsyncTaskReminderService,
@@ -197,6 +198,7 @@ export class Config extends ConfigBase {
         'Config.initialize requires an explicit session/runtime MessageBus dependency.',
       );
     }
+    this.setRuntimeMessageBus(initializationMessageBus);
     this.cachedEffectiveTrust = this.isTrustedFolder();
     this.ideClient = await IdeClient.getInstance();
     // Initialize centralized FileDiscoveryService
@@ -432,6 +434,11 @@ export class Config extends ConfigBase {
    */
   async refreshMcpContext(): Promise<void> {
     await this.refreshMemory();
+    await syncActivateMcpServerTool(
+      this.getToolRegistry(),
+      this.getRuntimeMessageBus(),
+      () => this.refreshMcpContext(),
+    );
     const client = this.getAgentClientIfReady();
     if (client) {
       await client.setTools();
@@ -884,8 +891,7 @@ export class Config extends ConfigBase {
   getHookSystem(): HookSystem | undefined {
     // @requirement:HOOK-002 - Return no hook system when hooks are disabled.
     if (!this.enableHooks) {
-      const disabledHookSystem = undefined;
-      return disabledHookSystem;
+      return undefined;
     }
 
     // @requirement:HOOK-001 - Lazy creation on first access

--- a/packages/core/src/config/configTestHarness.ts
+++ b/packages/core/src/config/configTestHarness.ts
@@ -83,6 +83,7 @@ export function buildToolsMockBody(actual: typeof ToolsModule) {
     getAllTools: vi.fn(() => []),
     getTool: vi.fn(),
     getFunctionDeclarations: vi.fn(() => []),
+    listDeferredMcpServers: vi.fn(() => []),
   }));
   ToolRegistryMock.prototype.registerTool = registerToolMock;
   ToolRegistryMock.prototype.unregisterTool = vi.fn();
@@ -91,6 +92,7 @@ export function buildToolsMockBody(actual: typeof ToolsModule) {
   ToolRegistryMock.prototype.getAllTools = vi.fn(() => []);
   ToolRegistryMock.prototype.getTool = vi.fn();
   ToolRegistryMock.prototype.getFunctionDeclarations = vi.fn(() => []);
+  ToolRegistryMock.prototype.listDeferredMcpServers = vi.fn(() => []);
   return {
     ...actual,
     ToolRegistry: ToolRegistryMock,

--- a/packages/core/src/config/mcp-lazy-tool-sync.ts
+++ b/packages/core/src/config/mcp-lazy-tool-sync.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ACTIVATE_MCP_SERVER_TOOL_NAME,
+  ActivateMcpServerTool,
+  type ToolRegistry,
+  type IToolMessageBus,
+} from '@vybestack/llxprt-code-tools';
+
+export async function syncActivateMcpServerTool(
+  registry: ToolRegistry,
+  messageBus: IToolMessageBus | undefined,
+  refreshMcpContext: () => Promise<void>,
+): Promise<void> {
+  if (messageBus === undefined) return;
+
+  const deferred = registry.listDeferredMcpServers();
+  const existing = registry
+    .getAllTools()
+    .find((tool) => tool.name === ACTIVATE_MCP_SERVER_TOOL_NAME);
+
+  if (existing instanceof ActivateMcpServerTool) {
+    registry.unregisterTool(ACTIVATE_MCP_SERVER_TOOL_NAME);
+  } else if (existing !== undefined && deferred.length > 0) {
+    throw new Error(
+      `Cannot register activation tool: a foreign tool named "${ACTIVATE_MCP_SERVER_TOOL_NAME}" is already registered.`,
+    );
+  }
+
+  if (deferred.length > 0) {
+    registry.registerTool(
+      new ActivateMcpServerTool(registry, messageBus, refreshMcpContext),
+    );
+  }
+}

--- a/packages/settings/src/__tests__/settingsRegistry.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.test.ts
@@ -845,3 +845,48 @@ describe('compression strategy values in registry', () => {
     }
   });
 });
+
+describe('mcp.lazy and mcp.eagerServers ephemeral settings', () => {
+  it('mcp.lazy has type boolean', () => {
+    const spec = getSettingSpec('mcp.lazy');
+    expect(spec).toBeDefined();
+    expect(spec?.type).toBe('boolean');
+  });
+
+  it('mcp.lazy is persistable to profile', () => {
+    const spec = getSettingSpec('mcp.lazy');
+    expect(spec?.persistToProfile).toBe(true);
+  });
+
+  it('mcp.lazy appears in profile persistable keys', () => {
+    const keys = getProfilePersistableKeys();
+    expect(keys).toContain('mcp.lazy');
+  });
+
+  it('mcp.eagerServers has type string-array', () => {
+    const spec = getSettingSpec('mcp.eagerServers');
+    expect(spec).toBeDefined();
+    expect(spec?.type).toBe('string-array');
+  });
+
+  it('mcp.eagerServers parses a JSON array value as a string array', () => {
+    const parsed = parseSetting('mcp.eagerServers', '["server-a","server-b"]');
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toStrictEqual(['server-a', 'server-b']);
+  });
+
+  it('mcp.eagerServers ignores malformed values', () => {
+    const parsed = parseSetting('mcp.eagerServers', 'not-valid-json');
+    expect(parsed).toBe('not-valid-json');
+  });
+
+  it('mcp.eagerServers is persistable to profile', () => {
+    const spec = getSettingSpec('mcp.eagerServers');
+    expect(spec?.persistToProfile).toBe(true);
+  });
+
+  it('mcp.eagerServers appears in profile persistable keys', () => {
+    const keys = getProfilePersistableKeys();
+    expect(keys).toContain('mcp.eagerServers');
+  });
+});

--- a/packages/settings/src/settings/registry/registry-entries-2.ts
+++ b/packages/settings/src/settings/registry/registry-entries-2.ts
@@ -405,6 +405,31 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
       { value: 'false', description: 'Disable per-turn token usage logging' },
     ],
   },
+  {
+    key: 'mcp.lazy',
+    category: 'cli-behavior',
+    description:
+      'Defer MCP server tool schemas from the model until a server is activated via the activate_mcp_server tool. ' +
+      'Reduces token overhead for large MCP tool sets.',
+    type: 'boolean',
+    default: false,
+    persistToProfile: true,
+    completionOptions: [
+      { value: 'true', description: 'Enable lazy MCP schema loading' },
+      {
+        value: 'false',
+        description: 'Publish all MCP schemas eagerly (default)',
+      },
+    ],
+  },
+  {
+    key: 'mcp.eagerServers',
+    category: 'cli-behavior',
+    description:
+      'List of MCP server names that stay eager (schemas always published) while mcp.lazy is enabled.',
+    type: 'string-array',
+    persistToProfile: true,
+  },
 ];
 
 function validateTaskMaxAsync(value: unknown): ValidationResult {

--- a/packages/tools/src/__tests__/tool-registry-mcp-lazy.test.ts
+++ b/packages/tools/src/__tests__/tool-registry-mcp-lazy.test.ts
@@ -1,0 +1,538 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { ToolRegistry } from '../tools/tool-registry.js';
+import { BaseDeclarativeTool, Kind } from '../tools/tools.js';
+import type {
+  IToolRegistryHost,
+  IToolMessageBus,
+  ToolInvocation,
+  ToolResult,
+} from '../index.js';
+import { ActivateMcpServerTool } from '../tools/activate-mcp-server.js';
+import { ACTIVATE_MCP_SERVER_TOOL_NAME } from '../types/tool-names.js';
+
+class TestMcpTool extends BaseDeclarativeTool<
+  Record<string, unknown>,
+  ToolResult
+> {
+  readonly serverName: string;
+
+  constructor(name: string, serverName: string, description: string) {
+    const schema = zodToJsonSchema(
+      z.object({
+        query: z.string().describe('the query to run'),
+        limit: z.number().optional().describe('max results'),
+        path: z.string().optional().describe('target path'),
+        selector: z.string().optional().describe('element selector'),
+        value: z.string().optional().describe('value to apply'),
+        timeout: z.number().optional().describe('operation timeout'),
+      }),
+    );
+    super(
+      name,
+      `${name} (${serverName})`,
+      description,
+      Kind.Other,
+      schema,
+      true,
+      false,
+    );
+    this.serverName = serverName;
+  }
+
+  protected createInvocation(
+    _params: Record<string, unknown>,
+  ): ToolInvocation<Record<string, unknown>, ToolResult> {
+    throw new Error('not used in registry declaration tests');
+  }
+}
+
+class TestBuiltinTool extends BaseDeclarativeTool<
+  Record<string, unknown>,
+  ToolResult
+> {
+  constructor(name: string, description: string) {
+    const schema = zodToJsonSchema(
+      z.object({ input: z.string().describe('the input') }),
+    );
+    super(name, name, description, Kind.Other, schema, true, false);
+  }
+
+  protected createInvocation(
+    _params: Record<string, unknown>,
+  ): ToolInvocation<Record<string, unknown>, ToolResult> {
+    throw new Error('not used in registry declaration tests');
+  }
+}
+
+function createHost(
+  ephemerals: Record<string, unknown> = {},
+): IToolRegistryHost {
+  return {
+    getEphemeralSettings: () => ephemerals,
+    getCoreTools: () => [],
+    getExcludeTools: () => [],
+  };
+}
+
+function createMessageBus(): IToolMessageBus {
+  return {
+    publish: () => {},
+    subscribe: () => () => {},
+    unsubscribe: () => {},
+  };
+}
+
+function namesOf(decls: Array<{ name?: string }>): string[] {
+  return decls.map((d) => d.name).sort();
+}
+
+function mcpTool(name: string, server: string, desc = name): TestMcpTool {
+  return new TestMcpTool(name, server, desc);
+}
+
+function builtinTool(name: string, desc = name): TestBuiltinTool {
+  return new TestBuiltinTool(name, desc);
+}
+
+function isStringRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasNameEnum(
+  schema: unknown,
+): schema is { properties: { name: { enum: string[] } } } {
+  if (!isStringRecord(schema)) return false;
+  const properties = schema['properties'];
+  if (!isStringRecord(properties)) return false;
+  const nameProp = properties['name'];
+  if (!isStringRecord(nameProp)) return false;
+  const enumValues = nameProp['enum'];
+  return (
+    Array.isArray(enumValues) &&
+    enumValues.every((v): v is string => typeof v === 'string')
+  );
+}
+
+describe('ToolRegistry — MCP lazy schema deferral', () => {
+  describe('A1-A5: lazy/eager/activation declaration behavior', () => {
+    const lazyOffCases: ReadonlyArray<[string, Record<string, unknown>]> = [
+      ['absent', {}],
+      ['false', { 'mcp.lazy': false }],
+      ['malformed', { 'mcp.lazy': 'yes' }],
+    ];
+
+    for (const [label, ephemerals] of lazyOffCases) {
+      it(`emits all declarations when mcp.lazy is ${label}`, () => {
+        const registry = new ToolRegistry(
+          createHost(ephemerals),
+          createMessageBus(),
+        );
+        registry.registerTool(builtinTool('read_file'));
+        registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+        const decls = registry.getFunctionDeclarations();
+        expect(namesOf(decls)).toEqual(['mcp__alpha__search', 'read_file']);
+      });
+    }
+
+    it('leaves builtins unchanged with lazy on and no MCP tools (A2)', () => {
+      const registry = new ToolRegistry(
+        createHost({ 'mcp.lazy': true }),
+        createMessageBus(),
+      );
+      registry.registerTool(builtinTool('read_file'));
+
+      const decls = registry.getFunctionDeclarations();
+      expect(namesOf(decls)).toEqual(['read_file']);
+      expect(
+        decls.find((d) => d.name === ACTIVATE_MCP_SERVER_TOOL_NAME),
+      ).toBeUndefined();
+    });
+
+    it('omits deferred alpha/beta schemas while keeping non-MCP (A3)', () => {
+      const registry = new ToolRegistry(
+        createHost({ 'mcp.lazy': true }),
+        createMessageBus(),
+      );
+      registry.registerTool(builtinTool('read_file'));
+      registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+      registry.registerTool(mcpTool('mcp__beta__lookup', 'beta'));
+
+      const decls = registry.getFunctionDeclarations();
+      expect(
+        decls.find((d) => d.name === 'mcp__alpha__search'),
+      ).toBeUndefined();
+      expect(decls.find((d) => d.name === 'mcp__beta__lookup')).toBeUndefined();
+      expect(namesOf(decls)).toContain('read_file');
+    });
+
+    it('keeps alpha eager while beta stays deferred (A4)', () => {
+      const registry = new ToolRegistry(
+        createHost({ 'mcp.lazy': true, 'mcp.eagerServers': ['alpha'] }),
+        createMessageBus(),
+      );
+      registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+      registry.registerTool(mcpTool('mcp__beta__lookup', 'beta'));
+
+      const decls = registry.getFunctionDeclarations();
+      expect(decls.find((d) => d.name === 'mcp__alpha__search')).toBeDefined();
+      expect(decls.find((d) => d.name === 'mcp__beta__lookup')).toBeUndefined();
+    });
+
+    const malformedEagerCases: ReadonlyArray<[string, unknown]> = [
+      ['absent', undefined],
+      ['malformed string', 'alpha'],
+      ['unknown server name', ['nonexistent']],
+    ];
+
+    for (const [label, value] of malformedEagerCases) {
+      it(`treats eagerServers ${label} as irrelevant/empty (A5)`, () => {
+        const ephemerals: Record<string, unknown> = { 'mcp.lazy': true };
+        if (value !== undefined) {
+          ephemerals['mcp.eagerServers'] = value;
+        }
+        const registry = new ToolRegistry(
+          createHost(ephemerals),
+          createMessageBus(),
+        );
+        registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+        const decls = registry.getFunctionDeclarations();
+        expect(
+          decls.find((d) => d.name === 'mcp__alpha__search'),
+        ).toBeUndefined();
+      });
+    }
+  });
+
+  it('omits a governance-disabled MCP tool even from an eager server (A6)', () => {
+    const registry = new ToolRegistry(
+      createHost({
+        'mcp.lazy': true,
+        'mcp.eagerServers': ['alpha'],
+        'tools.disabled': ['mcp__alpha__search'],
+      }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    const decls = registry.getFunctionDeclarations();
+    expect(decls.find((d) => d.name === 'mcp__alpha__search')).toBeUndefined();
+  });
+
+  it('getFunctionDeclarationsFiltered returns deferred tool by name (A7)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    const filtered = registry.getFunctionDeclarationsFiltered([
+      'mcp__alpha__search',
+    ]);
+    expect(filtered.find((d) => d.name === 'mcp__alpha__search')).toBeDefined();
+  });
+
+  it('listDeferredMcpServers returns non-eager/non-activated servers', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true, 'mcp.eagerServers': ['gamma'] }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+    registry.registerTool(mcpTool('mcp__beta__lookup', 'beta'));
+    registry.registerTool(mcpTool('mcp__gamma__compute', 'gamma'));
+
+    expect(registry.listDeferredMcpServers()).toEqual(['alpha', 'beta']);
+  });
+
+  it('listDeferredMcpServers returns empty when lazy mode is off', () => {
+    const registry = new ToolRegistry(createHost({}), createMessageBus());
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    expect(registry.listDeferredMcpServers()).toEqual([]);
+  });
+
+  it('a fresh registry starts with no activation state (C5)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    expect(registry.listDeferredMcpServers()).toEqual(['alpha']);
+  });
+});
+
+describe('ToolRegistry — activation lifecycle (B5, B7, C1-C3)', () => {
+  it('activateMcpServer throws for unknown server (B7)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    expect(() => registry.activateMcpServer('nonexistent')).toThrow(
+      'Unknown MCP server "nonexistent"',
+    );
+    expect(registry.listDeferredMcpServers()).toContain('alpha');
+  });
+
+  it('activation is idempotent and schemas stay published (B5, C1)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    registry.activateMcpServer('alpha');
+    registry.activateMcpServer('alpha');
+
+    const decls1 = registry.getFunctionDeclarations();
+    const decls2 = registry.getFunctionDeclarations();
+    expect(decls1.find((d) => d.name === 'mcp__alpha__search')).toBeDefined();
+    expect(decls2.find((d) => d.name === 'mcp__alpha__search')).toBeDefined();
+    expect(registry.listDeferredMcpServers()).not.toContain('alpha');
+  });
+
+  it('disconnect removes activated server schemas and clears stale activation (C2)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    registry.activateMcpServer('alpha');
+    registry.removeMcpToolsByServer('alpha');
+
+    const decls = registry.getFunctionDeclarations();
+    expect(decls.find((d) => d.name === 'mcp__alpha__search')).toBeUndefined();
+    expect(registry.listDeferredMcpServers()).not.toContain('alpha');
+  });
+
+  it('reconnect re-publishes activated server schemas in the same session (C3)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    registry.activateMcpServer('alpha');
+    registry.removeMcpToolsByServer('alpha');
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha', 'alpha v2'));
+
+    const decls = registry.getFunctionDeclarations();
+    expect(decls.find((d) => d.name === 'mcp__alpha__search')).toBeDefined();
+  });
+});
+
+describe('ActivateMcpServerTool — schema and description', () => {
+  it('name enum contains deferred servers (B2)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+    registry.registerTool(mcpTool('mcp__beta__lookup', 'beta'));
+
+    const tool = new ActivateMcpServerTool(
+      registry,
+      createMessageBus(),
+      async () => {},
+    );
+    const paramSchema = tool.schema.parametersJsonSchema;
+    expect(hasNameEnum(paramSchema)).toBe(true);
+    if (hasNameEnum(paramSchema)) {
+      expect(paramSchema.properties.name.enum).toContain('alpha');
+      expect(paramSchema.properties.name.enum).toContain('beta');
+    }
+  });
+
+  it('description contains server names, tool counts, and tool names without full schemas (B2)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+    registry.registerTool(mcpTool('mcp__alpha__insert', 'alpha'));
+    registry.registerTool(mcpTool('mcp__beta__lookup', 'beta'));
+
+    const tool = new ActivateMcpServerTool(
+      registry,
+      createMessageBus(),
+      async () => {},
+    );
+    const description = tool.description;
+    expect(description).toContain('alpha');
+    expect(description).toContain('beta');
+    expect(description).toContain('2 tool(s)');
+    expect(description).toContain('1 tool(s)');
+    expect(description).toContain('mcp__alpha__search');
+    expect(description).toContain('mcp__beta__lookup');
+    expect(description).not.toContain('"properties"');
+  });
+
+  it('shows 12 names and an omitted-count marker for >12 tools (B3)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    for (let i = 0; i < 15; i++) {
+      registry.registerTool(mcpTool(`mcp__alpha__tool_${i}`, 'alpha'));
+    }
+
+    const tool = new ActivateMcpServerTool(
+      registry,
+      createMessageBus(),
+      async () => {},
+    );
+    const description = tool.description;
+    expect(description).toContain('15 tool(s)');
+    expect(description).toContain('mcp__alpha__tool_0');
+    expect(description).toContain('mcp__alpha__tool_14');
+    expect(description).toMatch(/\+3/);
+  });
+
+  it('throws when constructed with no deferred servers', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+
+    expect(
+      () =>
+        new ActivateMcpServerTool(registry, createMessageBus(), async () => {}),
+    ).toThrow('at least one deferred MCP server');
+  });
+
+  it('unknown server name fails enum validation at build (B7)', () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+
+    const tool = new ActivateMcpServerTool(
+      registry,
+      createMessageBus(),
+      async () => {},
+    );
+
+    expect(() => tool.build({ name: 'nonexistent' })).toThrow(
+      /must be equal to one of/,
+    );
+  });
+
+  it('activation execution awaits refresh before resolving (B4)', async () => {
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(mcpTool('mcp__alpha__search', 'alpha'));
+    registry.registerTool(mcpTool('mcp__beta__lookup', 'beta'));
+
+    let refreshResolved = false;
+    const refreshPromise = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        refreshResolved = true;
+        resolve();
+      }, 10);
+    });
+    const refreshMcpContext = (): Promise<void> => refreshPromise;
+
+    const tool = new ActivateMcpServerTool(
+      registry,
+      createMessageBus(),
+      refreshMcpContext,
+    );
+    const invocation = tool.build({ name: 'alpha' });
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(refreshResolved).toBe(true);
+    expect(result.llmContent).toContain('alpha');
+    expect(result.llmContent).toContain('available');
+
+    const decls = registry.getFunctionDeclarations();
+    expect(decls.find((d) => d.name === 'mcp__alpha__search')).toBeDefined();
+    expect(decls.find((d) => d.name === 'mcp__beta__lookup')).toBeUndefined();
+  });
+});
+
+describe('E1/E2: lazy mode produces smaller serialized payload', () => {
+  it('lazy declarations are fewer and smaller than eager for the same tools', () => {
+    const builtin = builtinTool('read_file');
+    const alpha = mcpTool('mcp__alpha__search', 'alpha');
+    const beta = mcpTool('mcp__beta__lookup', 'beta');
+
+    const eagerRegistry = new ToolRegistry(createHost({}), createMessageBus());
+    eagerRegistry.registerTool(builtin);
+    eagerRegistry.registerTool(alpha);
+    eagerRegistry.registerTool(beta);
+    const eagerDecls = eagerRegistry.getFunctionDeclarations();
+
+    const lazyRegistry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    lazyRegistry.registerTool(builtin);
+    lazyRegistry.registerTool(alpha);
+    lazyRegistry.registerTool(beta);
+    lazyRegistry.registerTool(
+      new ActivateMcpServerTool(
+        lazyRegistry,
+        createMessageBus(),
+        async () => {},
+      ),
+    );
+    const lazyDecls = lazyRegistry.getFunctionDeclarations();
+
+    const eagerSize = JSON.stringify(eagerDecls).length;
+    const lazySize = JSON.stringify(lazyDecls).length;
+
+    expect(eagerDecls).toHaveLength(3);
+    expect(lazyDecls.length).toBeLessThan(eagerDecls.length);
+    expect(lazySize).toBeLessThan(eagerSize);
+  });
+
+  it('reduction is attributable to deferred alpha when beta is activated', () => {
+    const builtin = builtinTool('read_file');
+    const alphaSearch = mcpTool('mcp__alpha__search', 'alpha');
+    const alphaInsert = mcpTool('mcp__alpha__insert', 'alpha');
+    const beta = mcpTool('mcp__beta__lookup', 'beta');
+
+    const registry = new ToolRegistry(
+      createHost({ 'mcp.lazy': true }),
+      createMessageBus(),
+    );
+    registry.registerTool(builtin);
+    registry.registerTool(alphaSearch);
+    registry.registerTool(alphaInsert);
+    registry.registerTool(beta);
+    registry.activateMcpServer('beta');
+    registry.registerTool(
+      new ActivateMcpServerTool(registry, createMessageBus(), async () => {}),
+    );
+
+    const decls = registry.getFunctionDeclarations();
+    expect(decls.find((d) => d.name === 'mcp__beta__lookup')).toBeDefined();
+    expect(decls.find((d) => d.name === 'mcp__alpha__search')).toBeUndefined();
+
+    const eagerRegistry = new ToolRegistry(createHost({}), createMessageBus());
+    eagerRegistry.registerTool(builtin);
+    eagerRegistry.registerTool(alphaSearch);
+    eagerRegistry.registerTool(alphaInsert);
+    eagerRegistry.registerTool(beta);
+    const eagerDecls = eagerRegistry.getFunctionDeclarations();
+
+    expect(JSON.stringify(decls).length).toBeLessThan(
+      JSON.stringify(eagerDecls).length,
+    );
+  });
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -135,6 +135,7 @@ export {
   LS_TOOL_NAME,
   MEMORY_TOOL_NAME,
   ACTIVATE_SKILL_TOOL_NAME,
+  ACTIVATE_MCP_SERVER_TOOL_NAME,
   READ_FILE_TOOL,
   WRITE_FILE_TOOL,
   EDIT_TOOL,
@@ -331,6 +332,11 @@ export {
   ActivateSkillTool,
   type ActivateSkillToolParams,
 } from './tools/activate-skill.js';
+
+export {
+  ActivateMcpServerTool,
+  type ActivateMcpServerToolParams,
+} from './tools/activate-mcp-server.js';
 
 export {
   CodeSearchTool,

--- a/packages/tools/src/tools/activate-mcp-server.ts
+++ b/packages/tools/src/tools/activate-mcp-server.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { ToolResult, ToolInvocation } from './tools.js';
+import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import type { IToolMessageBus } from '../interfaces/IToolMessageBus.js';
+import { ACTIVATE_MCP_SERVER_TOOL_NAME } from '../types/tool-names.js';
+import { ToolErrorType } from '../types/tool-error.js';
+import type { ToolRegistry } from './tool-registry.js';
+
+const MAX_TOOL_NAMES_PER_SERVER = 12;
+
+export interface ActivateMcpServerToolParams {
+  name: string;
+}
+
+type RefreshMcpContextCallback = () => Promise<void>;
+
+function buildDescription(
+  deferredServers: readonly string[],
+  toolsByServer: ReadonlyMap<string, readonly string[]>,
+): string {
+  if (deferredServers.length === 0) {
+    return (
+      'Activates a deferred MCP server so its tools become available to you. ' +
+      'No servers are currently deferred.'
+    );
+  }
+
+  const lines: string[] = [
+    'Activates a deferred MCP server so its full tool schemas become available to you.',
+    'Deferred servers (call this tool with the server name to activate):',
+  ];
+
+  for (const server of deferredServers) {
+    const toolNames = toolsByServer.get(server) ?? [];
+    const shown = toolNames.slice(0, MAX_TOOL_NAMES_PER_SERVER);
+    const omitted = toolNames.length - shown.length;
+    const namesPart =
+      shown.length > 0 ? shown.join(', ') : '(no tools discovered)';
+    const omittedPart = omitted > 0 ? ` (+${omitted} more)` : '';
+    lines.push(
+      `- ${server}: ${toolNames.length} tool(s) [${namesPart}${omittedPart}]`,
+    );
+  }
+
+  lines.push(
+    "Activation persists for the current session. After activation the server's tool schemas are published on the next model request.",
+  );
+  return lines.join('\n');
+}
+
+class ActivateMcpServerToolInvocation extends BaseToolInvocation<
+  ActivateMcpServerToolParams,
+  ToolResult
+> {
+  constructor(
+    private readonly registry: ToolRegistry,
+    private readonly refreshMcpContext: RefreshMcpContextCallback,
+    params: ActivateMcpServerToolParams,
+    messageBus: IToolMessageBus,
+  ) {
+    super(params, messageBus);
+  }
+
+  getDescription(): string {
+    return `activate MCP server "${this.params.name}"`;
+  }
+
+  async execute(_signal: AbortSignal): Promise<ToolResult> {
+    const serverName = this.params.name;
+
+    try {
+      this.registry.activateMcpServer(serverName);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        llmContent: `Error: ${message}`,
+        returnDisplay: `Error: ${message}`,
+        error: {
+          message,
+          type: ToolErrorType.EXECUTION_FAILED,
+        },
+      };
+    }
+
+    await this.refreshMcpContext();
+
+    return {
+      llmContent: `MCP server "${serverName}" is now activated and available. Its tool schemas have been published.`,
+      returnDisplay: `MCP server **${serverName}** activated.`,
+    };
+  }
+}
+
+export class ActivateMcpServerTool extends BaseDeclarativeTool<
+  ActivateMcpServerToolParams,
+  ToolResult
+> {
+  static readonly Name = ACTIVATE_MCP_SERVER_TOOL_NAME;
+
+  private readonly refreshMcpContext: RefreshMcpContextCallback;
+
+  constructor(
+    private readonly registry: ToolRegistry,
+    messageBus: IToolMessageBus,
+    refreshMcpContext: RefreshMcpContextCallback,
+  ) {
+    const deferredServers = registry.listDeferredMcpServers();
+    const firstServer = deferredServers.shift();
+    if (firstServer === undefined) {
+      throw new Error(
+        'ActivateMcpServerTool requires at least one deferred MCP server.',
+      );
+    }
+    const availableServers = [firstServer, ...deferredServers];
+
+    const toolsByServer = new Map<string, string[]>();
+    for (const server of availableServers) {
+      toolsByServer.set(
+        server,
+        registry.getToolsByServer(server).map((t) => t.name),
+      );
+    }
+
+    const description = buildDescription(availableServers, toolsByServer);
+    const schema = z.object({
+      name: z
+        .enum([firstServer, ...deferredServers])
+        .describe('The name of the deferred MCP server to activate.'),
+    });
+
+    super(
+      ActivateMcpServerTool.Name,
+      'Activate MCP Server',
+      description,
+      Kind.Other,
+      zodToJsonSchema(schema),
+      true,
+      false,
+      messageBus,
+    );
+
+    this.refreshMcpContext = refreshMcpContext;
+  }
+
+  protected createInvocation(
+    params: ActivateMcpServerToolParams,
+    messageBus: IToolMessageBus,
+  ): ToolInvocation<ActivateMcpServerToolParams, ToolResult> {
+    return new ActivateMcpServerToolInvocation(
+      this.registry,
+      this.refreshMcpContext,
+      params,
+      messageBus,
+    );
+  }
+}

--- a/packages/tools/src/tools/tool-registry.ts
+++ b/packages/tools/src/tools/tool-registry.ts
@@ -279,6 +279,7 @@ export class ToolRegistry {
   private config: IToolRegistryHost;
   private logger = debugLogger;
   private discoveryLock: Promise<void> | null = null;
+  private readonly activatedMcpServers: Set<string> = new Set();
 
   private readonly messageBus: IToolMessageBus;
 
@@ -303,6 +304,96 @@ export class ToolRegistry {
 
   private isToolActive(toolName: string, governance: ToolGovernance): boolean {
     return !isToolBlocked(toolName, governance);
+  }
+
+  private getEphemeralPath(key: string): unknown {
+    const ephemerals: unknown = this.config.getEphemeralSettings?.();
+    if (
+      ephemerals === null ||
+      typeof ephemerals !== 'object' ||
+      Array.isArray(ephemerals)
+    ) {
+      return undefined;
+    }
+
+    if (Reflect.has(ephemerals, key)) {
+      return Reflect.get(ephemerals, key);
+    }
+
+    const parts = key.split('.');
+    let current: unknown = ephemerals;
+    for (const part of parts) {
+      if (current === null || typeof current !== 'object') {
+        return undefined;
+      }
+      if (Array.isArray(current) || !Reflect.has(current, part)) {
+        return undefined;
+      }
+      current = Reflect.get(current, part);
+    }
+    return current;
+  }
+
+  private isLazyMcpEnabled(): boolean {
+    return this.getEphemeralPath('mcp.lazy') === true;
+  }
+
+  private getEagerServers(): Set<string> {
+    const raw = this.getEphemeralPath('mcp.eagerServers');
+    if (
+      Array.isArray(raw) &&
+      raw.every((v): v is string => typeof v === 'string')
+    ) {
+      return new Set(raw);
+    }
+    return new Set();
+  }
+
+  private getMcpServerNames(): Set<string> {
+    const servers = new Set<string>();
+    for (const tool of this.tools.values()) {
+      if (isDiscoveredMcpTool(tool)) {
+        servers.add(tool.serverName);
+      }
+    }
+    return servers;
+  }
+
+  listDeferredMcpServers(): string[] {
+    if (!this.isLazyMcpEnabled()) {
+      return [];
+    }
+    const eager = this.getEagerServers();
+    const deferred: string[] = [];
+    for (const server of this.getMcpServerNames()) {
+      if (!eager.has(server) && !this.activatedMcpServers.has(server)) {
+        deferred.push(server);
+      }
+    }
+    return deferred.sort();
+  }
+
+  activateMcpServer(name: string): void {
+    const knownServers = this.getMcpServerNames();
+    if (!knownServers.has(name)) {
+      throw new Error(
+        `Unknown MCP server "${name}". Known servers: ${Array.from(knownServers).sort().join(', ')}.`,
+      );
+    }
+    this.activatedMcpServers.add(name);
+  }
+
+  private shouldDeferMcpTool(
+    tool: AnyDeclarativeTool,
+    lazy: boolean,
+    eager: ReadonlySet<string>,
+  ): boolean {
+    return (
+      lazy &&
+      isDiscoveredMcpTool(tool) &&
+      !eager.has(tool.serverName) &&
+      !this.activatedMcpServers.has(tool.serverName)
+    );
   }
 
   /**
@@ -607,10 +698,15 @@ export class ToolRegistry {
   getFunctionDeclarations(): FunctionDeclaration[] {
     const governance = this.getToolGovernance();
     const transforms = this.getSchemaTransforms();
+    const lazy = this.isLazyMcpEnabled();
+    const eager = lazy ? this.getEagerServers() : new Set<string>();
 
     const declarations: FunctionDeclaration[] = [];
     this.tools.forEach((tool) => {
       if (this.isToolActive(tool.name, governance)) {
+        if (this.shouldDeferMcpTool(tool, lazy, eager)) {
+          return;
+        }
         declarations.push(this.applySchemaTransforms(tool.schema, transforms));
       }
     });

--- a/packages/tools/src/types/tool-names.ts
+++ b/packages/tools/src/types/tool-names.ts
@@ -27,6 +27,7 @@ export const READ_FILE_TOOL_NAME = 'read_file';
 export const LS_TOOL_NAME = 'list_directory';
 export const MEMORY_TOOL_NAME = 'save_memory';
 export const ACTIVATE_SKILL_TOOL_NAME = 'activate_skill';
+export const ACTIVATE_MCP_SERVER_TOOL_NAME = 'activate_mcp_server';
 
 // File System Tools
 export const READ_FILE_TOOL = 'read_file';

--- a/project-plans/issue2327/plan.md
+++ b/project-plans/issue2327/plan.md
@@ -1,0 +1,191 @@
+# Issue 2327 Delivery Plan: Lazy MCP Tool Schemas
+
+Plan ID: PLAN-20260728-ISSUE2327
+Base: `533e6bb98` (`origin/main`)
+Issue: https://github.com/vybestack/llxprt-code/issues/2327
+
+## Policy provenance
+
+`dev-docs/workflow/ISSUE-DELIVERY.md` is not present on the candidate base. This plan applies the bounded issue-delivery rules supplied with the issue request directly. `dev-docs/RULES.md` governs TDD and behavioral evidence.
+
+## Problem and chosen architecture
+
+Every registered MCP tool's complete schema currently reaches the model through `ToolRegistry.getFunctionDeclarations()` and `AgentClient.setTools()`. The bounded implementation will continue connecting to and discovering configured MCP servers, but an opt-in registry filter will omit unused MCP schemas from the model-facing declaration list.
+
+The chosen design is:
+
+- `mcp.lazy` is an opt-in, profile-persisted ephemeral boolean. Missing, false, or malformed values preserve eager behavior.
+- `mcp.eagerServers` is an optional profile-persisted string array. It pins named servers to eager schema publication while lazy mode is enabled.
+- Lazy loading is server-granular. MCP tools remain registered and executable; only model-facing schema publication is deferred.
+- A concrete `activate_mcp_server` tool mirrors the existing `activate_skill` pattern. Its compact description lists deferred server names and up to 12 tool names per server, never full parameter schemas.
+- Activating a server records its name in the session's `ToolRegistry`, refreshes model tools through the existing MCP context refresh path, and remains active for the session.
+- `Config.refreshMcpContext()` rebuilds the activation tool after existing MCP lifecycle events, so connection, disconnection, restart, extension, trust, and tool-list changes reuse existing lifecycle plumbing.
+- No MCP discovery, transport, OAuth, trust, execution-confirmation, prompt, resource, or instruction behavior changes.
+
+This deliberately does not overload `MCPServerConfig.trust`; trust remains an execution-confirmation setting. No per-server config-schema field is needed because `mcp.eagerServers` supplies the bounded escape hatch.
+
+## Decision-complete acceptance matrix
+
+| ID | Given | When | Then | Evidence |
+| --- | --- | --- | --- | --- |
+| A1 | `mcp.lazy` is absent, false, or not boolean true | declarations are requested | all existing MCP and non-MCP declarations are byte-equivalent to the pre-feature path | tools behavioral test |
+| A2 | `mcp.lazy` is true and no MCP tools exist | declarations are requested | builtin/discovered declarations are unchanged and no activation tool is exposed | tools behavioral test |
+| A3 | `mcp.lazy` is true with MCP servers alpha and beta | declarations are requested | alpha and beta schemas are omitted while non-MCP schemas remain | tools behavioral test |
+| A4 | lazy mode is true and `mcp.eagerServers` contains alpha | declarations are requested | alpha schemas are present and beta remains deferred | tools behavioral test |
+| A5 | `mcp.eagerServers` is absent, malformed, or names an unknown server | declarations are requested | it is treated as empty/irrelevant without changing the remaining lazy decisions | tools behavioral test |
+| A6 | an MCP tool is disabled or excluded by existing governance | its server is eager or activated | the existing governance still omits it | tools behavioral test |
+| A7 | an explicitly configured subagent asks for a deferred MCP tool by name | filtered declarations are requested | the explicit filtered declaration path remains unchanged | tools behavioral test |
+| B1 | at least one MCP server is deferred after MCP refresh | declarations are requested | exactly one `activate_mcp_server` declaration is present | activation integration test |
+| B2 | alpha and beta are deferred | activation schema/description is inspected | the name enum contains alpha and beta and the description contains server names, tool counts, and tool names but no parameter schemas | activation tool test |
+| B3 | a deferred server has more than 12 tools | activation description is inspected | 12 names and an omitted-count marker are shown | activation tool test |
+| B4 | the model activates alpha | activation completes | alpha's complete schemas are published on the next model request, beta remains deferred, and the result explains that alpha is available | activation tool/integration test |
+| B5 | alpha was already activated | alpha is activated again | activation is idempotent and alpha stays published | tools behavioral test |
+| B6 | all servers are eager or activated, or lazy mode is off | activation tool is synchronized | `activate_mcp_server` is absent | activation integration test |
+| B7 | an unknown server name is supplied | tool parameters are built or registry activation is requested directly | validation fails with a clear error and no server is activated | activation tool/tools test |
+| C1 | alpha is activated | subsequent turns occur | alpha remains active for this `ToolRegistry` session | tools behavioral test |
+| C2 | alpha is activated and its tools are removed on disconnect | declarations are requested | no alpha schemas remain and no stale activation choice is exposed as deferred | tools behavioral test |
+| C3 | alpha is activated and reconnects/restarts under the same server name | tools are registered again | the replacement alpha schemas remain published in the same session | tools behavioral test |
+| C4 | a deferred/activated server's tool list changes | existing MCP refresh runs | new tools follow the server's current deferred/activated state and the activation enum is rebuilt | core integration test |
+| C5 | a fresh `ToolRegistry` is created | lazy declarations are requested | previous activation state is absent | tools behavioral test |
+| D1 | settings registry is queried | `mcp.lazy` and `mcp.eagerServers` are inspected | types are boolean and string-array and both persist to profiles | settings test |
+| D2 | a user enables lazy mode in a profile | a new session completes MCP discovery/refresh | activation behavior is available without any config schema or dependency change | core integration test |
+| E1 | equivalent real MCP-shaped schemas are registered in eager and lazy registries | declarations are serialized | the test records declaration count and serialized character count and proves lazy mode is smaller | tools behavioral measurement |
+| E2 | lazy mode defers only alpha while beta is activated/eager | declarations are serialized | the measured reduction is attributable only to alpha's omitted schemas | tools behavioral measurement |
+| F1 | the feature is documented | a user reads ephemeral and MCP docs | opt-in syntax, eager exceptions, server granularity, session scope, context tradeoff, and exclusions are stated | doc review |
+
+## Explicit non-goals
+
+- Auto-unload after idle turns. It requires turn-level usage tracking and a new subsystem; the issue describes it as optional.
+- Deferring server connection, process startup, authentication, or tool discovery.
+- Tool-level activation within one server. Existing `includeTools` and `excludeTools` provide static trimming.
+- Deferring MCP prompts, resources, or server instructions.
+- Changing `getAllTools()`, `getEnabledTools()`, `getToolsByServer()`, `getTool()`, or public agent/MCP control types.
+- Persisting activation state between sessions.
+- Adding `/mcp load`, `/mcp` status rendering, telemetry, runtime token accounting, or a tokenizer dependency.
+- A per-server `MCPServerConfig.lazy` field or any settings JSON-schema change.
+- Any workflow, agent-memory, quality-tool, package dependency, lint, complexity, coverage, safety, cross-platform, or CI change.
+- Unrelated refactors, test moves, cleanup, or optional hardening.
+
+## Bounded test-first vertical slices
+
+### Slice 1: registry schema deferral
+
+RED: add real-registry behavioral tests for A1-A7, B5, C1-C3/C5, and E1-E2. Use MCP-shaped real declarative tools and a structural registry host; do not mock the component under test.
+
+GREEN: add only the session activation set, lazy/eager setting interpretation, server validation/listing, and one model-declaration predicate to `ToolRegistry`.
+
+### Slice 2: model activation tool
+
+RED: add behavior tests for B1-B3, B4, B6-B7 using the real registry and tool.
+
+GREEN: add the concrete `ActivateMcpServerTool`, its name constant/export, and compact discoverability description. Activation must await the existing context refresh callback before returning.
+
+### Slice 3: existing lifecycle integration
+
+RED: add a real `Config.refreshMcpContext()` integration test covering D2 and dynamic enum/state behavior C4 without mock-call assertions.
+
+GREEN: add one concrete sync helper and call it from `refreshMcpContext()`. It may unregister/re-register only the activation tool; it must not alter MCP manager/discovery behavior.
+
+### Slice 4: configuration registration and documentation
+
+RED: extend settings registry tests for D1.
+
+GREEN: register the two ephemerals and document F1. No config schema, MCP server config class, or dependency changes.
+
+Each production change must be written after its failing behavioral test. Existing tests must remain unchanged except additive settings assertions.
+
+## Expected paths
+
+Planned new files:
+
+1. `project-plans/issue2327/plan.md`
+2. `packages/tools/src/tools/activate-mcp-server.ts`
+3. `packages/tools/src/__tests__/tool-registry-mcp-lazy.test.ts`
+4. `packages/tools/src/tools/activate-mcp-server.test.ts`
+5. `packages/core/src/config/mcp-lazy-tool-sync.ts`
+6. `packages/core/src/config/config.mcp-lazy.test.ts`
+
+Planned modified files:
+
+7. `packages/tools/src/tools/tool-registry.ts`
+8. `packages/tools/src/types/tool-names.ts`
+9. `packages/tools/src/index.ts`
+10. `packages/core/src/config/config.ts`
+11. `packages/settings/src/settings/registry/registry-entries-2.ts`
+12. `packages/settings/src/__tests__/settingsRegistry.test.ts`
+13. `docs/reference/ephemerals.md`
+14. `docs/tools/mcp-server.md`
+
+The two planned public registry methods are limited to `activateMcpServer(name)` and `listDeferredMcpServers()`. The concrete activation-tool export is planned feature surface, not a general-purpose abstraction. Any additional public method, interface, adapter, manager, service, or agent API field requires approval.
+
+## Scope ledger
+
+| Category | Planned net lines | Actual net lines |
+| --- | ---: | ---: |
+| Plan | 170 | 191 |
+| Production source | 260 | 337 |
+| Behavioral/settings tests | 575 | 860 |
+| Documentation | 55 | 48 |
+| Total (14 files) | 1,060 | 1,436 |
+
+Targets and stops:
+
+- Target ceiling: 25 files or 1,500 net changed lines.
+- Mandatory scope review if either target is exceeded.
+- Hard stop without approval: more than 40 files or 2,500 net changed lines.
+- This plan additionally stops at the 25/1,500 target rather than consuming the hard budget without approval.
+- Count generated or incidental tracked changes in the ledger; do not hide them as tooling output.
+
+## Review triage contract
+
+Every DeepThinker, OCR, CodeRabbit, CI, and human finding will be recorded as exactly one of:
+
+- **Blocker-Fix**: accepted behavior, safety, correctness, architecture, or required gate cannot complete without it.
+- **In-scope-Fix**: valid issue within this matrix and ledger.
+- **Reject**: factually incorrect, already covered, or harmful to accepted behavior.
+- **Defer**: valid but outside this issue's matrix; no implementation in this PR.
+
+Reviewer suggestions never expand scope. At most two local OCR and two PR OCR runs are allowed.
+
+## Stop conditions requiring approval
+## Review triage record
+
+DeepThinker findings:
+
+- **Blocker-Fix:** foreign activation-tool collision, documented eager-server value shape, prohibited assertions, acceptance evidence gaps, and the scope overrun were fixed.
+- **In-scope-Fix:** current-session `/set` limitations were documented, speculative exports were removed, and redundant comments were removed.
+- **Reject:** removing runtime MessageBus storage, removing flat/nested setting support, or replacing the established MCP refresh lifecycle were source-incompatible recommendations.
+- **Defer:** auto-unload, a hot-apply settings subsystem, generic parser/legacy-profile modernization, activation rollback, telemetry, status UI, tokenizer accounting, per-server config fields, tool-level activation, and connection/instruction deferral.
+
+Local OCR run `20260728T175051Z-2afc8ff7` (`complete_best_effort`) produced nine hypotheses:
+
+- **In-scope-Fix:** primitive ephemeral input handling, repeated eager-setting allocation, and execution-phase error classification were fixed.
+- **Reject:** duplicate partial-eager coverage, changing the accepted explicit subagent path, clearing session activation on reconnect, and claims that activated replacement tools remain deferred.
+- **Defer:** transactional activation rollback after refresh failure.
+
+All accepted findings are resolved without expanding the acceptance matrix.
+
+
+Stop before:
+
+- any new subsystem, general public abstraction, interface/adapter/manager/service, or extra public registry/API method;
+- any dependency, package graph, workflow, agent-memory, quality-tool, lint/complexity/coverage/CI/config-schema change;
+- any MCP connection, discovery, OAuth, trust, confirmation, prompt/resource/instruction, or auto-unload behavior change;
+- behavior not listed in the acceptance matrix;
+- moving an unrelated refactor or test into scope;
+- changing/deleting existing assertions to legitimize a default-path regression;
+- exceeding the target ledger after consolidating test setup, or exceeding the hard budget under any circumstance.
+
+## Required gates and exact-head completion
+
+The candidate head is complete only when:
+
+1. Every acceptance row has behavioral evidence on that exact head.
+2. `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build` pass.
+3. The prescribed llxprt smoke test passes.
+4. Local DeepThinker and OCR reviews are complete; every finding is classified; all Blocker-Fix and In-scope-Fix items are resolved.
+5. The exact committed head is pushed; CI and bounded PR reviews pass on it; CodeRabbit threads are evaluated, answered, and resolved.
+6. `git merge-base --is-ancestor origin/main HEAD` succeeds, the PR reports no conflicts, and the scope ledger is clean.
+7. No forbidden suppressions, weakened gates, optional cleanup, or out-of-matrix changes are present.
+
+Stop successfully at that point. Do not continue optional hardening or cleanup.


### PR DESCRIPTION
## TLDR

Adds opt-in MCP tool-schema deferral so sessions with many configured MCP servers do not send unused schemas to the model. The model receives activate_mcp_server and can publish a selected server’s schemas for the current session.

## Dive Deeper

- mcp.lazy defaults to false, preserving existing behavior.
- mcp.eagerServers keeps selected servers eagerly visible while lazy mode is active.
- Servers remain connected and discovered; only normal model-facing declarations are deferred.
- Activation state is session-local and survives same-name MCP reconnects.
- Existing tool governance and explicit subagent declaration filtering remain unchanged.
- Behavioral tests compare the real eager and lazy declaration payloads, including activate_mcp_server, and prove declaration count and serialized schema size decrease.
- Auto-unload, hot-applying settings to an existing chat, connection deferral, per-tool activation, telemetry, and status UI are explicit non-goals.

## Reviewer Test Plan

1. Save a profile with mcp.lazy set to true and at least two MCP servers.
2. Start a new session using that profile.
3. Confirm activate_mcp_server lists the deferred servers while their complete tool declarations are absent.
4. Invoke activate_mcp_server for one server and confirm its tools appear on the next model request while other servers remain deferred.
5. Add one server name to mcp.eagerServers and confirm it remains visible without activation.
6. Run the issue-focused suites:

       npx vitest run packages/tools/src/__tests__/tool-registry-mcp-lazy.test.ts packages/core/src/config/config.mcp-lazy.test.ts packages/core/src/config/config.a.test.ts packages/settings/src/__tests__/settingsRegistry.test.ts

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅ test, lint, typecheck, format, build | CI | CI |
| npx      | ✅ targeted Vitest suites | CI | CI |
| Docker   | CI | - | CI |
| Podman   | - | - | - |
| Seatbelt | ✅ tmux/UI workflow | - | - |

Additional local smoke tests passed with the stepfun-37 and ollamakimi profiles through scripts/start.ts. Full local tests and typecheck passed under Node 24.

## Linked issues / bugs

Fixes #2327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional lazy loading for MCP tool schemas to reduce initial context size.
  * Added `mcp.lazy` and `mcp.eagerServers` settings, with profile persistence support.
  * Added an activation tool that lets the model load schemas for selected MCP servers when needed.
  * Added documentation covering configuration, activation behavior, tradeoffs, and supported workflows.

* **Bug Fixes**
  * Preserved existing MCP filtering, governance, connection, authentication, and confirmation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->