### PR TITLE
fix(ide-integration): identify real Windows IDE ancestor instead of fixed offset (Fixes #2656)

### DIFF
--- a/packages/ide-integration/src/ide/constants.ts
+++ b/packages/ide-integration/src/ide/constants.ts
@@ -5,3 +5,35 @@
  */
 
 export const LLXPRT_CODE_COMPANION_EXTENSION_NAME = 'LLxprt Code Companion';
+
+/**
+ * Process executable names (basenames) that reliably identify an IDE ancestor
+ * on Windows. Used by `getIdeProcessInfoForWindows()` to walk the ancestor
+ * chain and select the real IDE process instead of a fixed tree offset.
+ * Matching is case-insensitive and basename-based.
+ *
+ * This list contains VS Code and known VS Code-like / Electron IDE executable
+ * basenames whose process name is a reliable identification signal. It is NOT
+ * a mirror of `detectIdeFromEnv()`: several IDEs (Antigravity, Codespaces,
+ * Replit, Cloud Shell, Firebase Studio) are detected via environment variables
+ * or substring matching (see detect-ide.ts and terminalSetup.ts) rather than
+ * by executable basename. Antigravity in particular is a VS Code fork whose
+ * GUI process basename has not been confirmed in this repository; it is
+ * env-detected via `ANTIGRAVITY_CLI_ALIAS` and substring matching in
+ * terminalSetup.ts, so it is intentionally omitted here.
+ */
+export const IDE_EXECUTABLE_NAMES: readonly string[] = [
+  'code.exe',
+  'code',
+  'code-insiders.exe',
+  'code-insiders',
+  'codium.exe',
+  'codium',
+  'cursor.exe',
+  'cursor',
+  'windsurf.exe',
+  'windsurf',
+  'trae.exe',
+  'trae',
+  'sublime_text.exe',
+] as const;

--- a/packages/ide-integration/src/ide/constants.ts
+++ b/packages/ide-integration/src/ide/constants.ts
@@ -36,4 +36,5 @@ export const IDE_EXECUTABLE_NAMES: readonly string[] = [
   'trae.exe',
   'trae',
   'sublime_text.exe',
+  'sublime_text',
 ] as const;

--- a/packages/ide-integration/src/ide/ide-client.test.ts
+++ b/packages/ide-integration/src/ide/ide-client.test.ts
@@ -103,6 +103,7 @@ describe('IdeClient', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    delete process.env['LLXPRT_CODE_IDE_SERVER_PORT'];
   });
 
   describe('connect', () => {
@@ -346,6 +347,66 @@ describe('IdeClient', () => {
             },
           },
         }),
+      );
+      expect(ideClient.getConnectionStatus().status).toBe(
+        IDEConnectionStatus.Connected,
+      );
+    });
+  });
+
+  describe('issue #2656 — Windows stale-env + live-port-file recovery', () => {
+    // This composed behavioral test proves the end-to-end recovery path:
+    // the real IDE PID (29396, Code.exe main) is identified, the live port
+    // file keyed to that PID is found in the temp dir, and its metadata
+    // (port 64365 + auth token + workspace) is used INSTEAD of the stale
+    // LLXPRT_CODE_IDE_SERVER_PORT env value (49975, a dead port).
+    //
+    // The client test harness mocks `getIdeProcessInfo` directly (the
+    // established pattern in this file), so we inject {pid: 29396} here.
+    // process-utils.test.ts already proves the REAL getIdeProcessInfo walks
+    // the issue's exact process tree and returns 29396; this test focuses on
+    // the downstream PID→port-file resolution and stale-env bypass.
+    it('uses the live port file keyed to the Code main PID instead of the stale env port', async () => {
+      vi.mocked(getIdeProcessInfo).mockResolvedValue({
+        pid: 29396,
+        command: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+      });
+      process.env['LLXPRT_CODE_IDE_SERVER_PORT'] = '49975';
+
+      const liveFile = {
+        port: 64365,
+        workspacePath: '/test/workspace',
+        authToken: 'token-xyz',
+        ideInfo: { name: 'vscode', displayName: 'VS Code' },
+      };
+      (
+        vi.mocked(fs.promises.readdir) as Mock<
+          (path: fs.PathLike) => Promise<string[]>
+        >
+      ).mockResolvedValue(['llxprt-ide-server-29396-64365.json']);
+      vi.mocked(fs.promises.readFile).mockResolvedValue(
+        JSON.stringify(liveFile),
+      );
+
+      IdeClient.resetInstance();
+      const ideClient = await IdeClient.getInstance();
+      await ideClient.connect();
+
+      // The live file (port 64365) must be selected; the stale env port
+      // (49975) must NOT be used.
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL('http://127.0.0.1:64365/mcp'),
+        expect.objectContaining({
+          requestInit: {
+            headers: {
+              Authorization: 'Bearer token-xyz',
+            },
+          },
+        }),
+      );
+      expect(StreamableHTTPClientTransport).not.toHaveBeenCalledWith(
+        new URL('http://127.0.0.1:49975/mcp'),
+        expect.anything(),
       );
       expect(ideClient.getConnectionStatus().status).toBe(
         IDEConnectionStatus.Connected,

--- a/packages/ide-integration/src/ide/process-utils.test.ts
+++ b/packages/ide-integration/src/ide/process-utils.test.ts
@@ -68,11 +68,12 @@ describe('getIdeProcessInfo', () => {
   });
 
   describe('on Windows', () => {
-    it('should traverse up and find the great-grandchild of the root process', async () => {
+    it('should return the IDE executable ancestor instead of a fixed great-grandchild offset', async () => {
       (os.platform as Mock).mockReturnValue('win32');
       // process (1000) -> powershell (900) -> code (800) -> wininit (700) -> root (0)
-      // Ancestors: [1000, 900, 800, 700]
-      // Target (great-grandchild of root): 900
+      // Ancestors (nearest first): [1000, 900, 800, 700]
+      // The IDE executable is code.exe at PID 800; it must win over the
+      // previously-returned great-grandchild offset (which yielded 900/powershell).
       const processes = [
         {
           ProcessId: 1000,
@@ -102,11 +103,309 @@ describe('getIdeProcessInfo', () => {
       mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
 
       const result = await getIdeProcessInfo();
-      expect(result).toStrictEqual({ pid: 900, command: 'powershell.exe' });
+      expect(result).toStrictEqual({ pid: 800, command: 'code.exe' });
       expect(mockedExec).toHaveBeenCalledWith(
         expect.stringContaining('Get-CimInstance Win32_Process'),
         expect.anything(),
       );
+    });
+
+    it('should return the real IDE process (Code.exe main) when wrapper and shell sit between CLI and Code main (issue #2656)', async () => {
+      (os.platform as Mock).mockReturnValue('win32');
+      // Tree from the issue (CLI is process.pid):
+      //   CLI(15604) -> start.ts(23676) -> pwsh(29180) -> Code util(26336)
+      //     -> Code main(29396) -> wininit(1000) -> root(0)
+      // 26336 is a VS Code utility child process (Code.exe --type=utility);
+      // 29396 is the Code main process (plain Code.exe) that owns the
+      // companion server / port file. The result must be 29396, NOT pwsh
+      // (29180) and NOT the utility child (26336).
+      const codeMainCmd =
+        'C:\\Users\\someone\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe';
+      const codeUtilityCmd = `${codeMainCmd} --type=utility`;
+      const processes = [
+        {
+          ProcessId: 15604,
+          ParentProcessId: 23676,
+          Name: 'bun.exe',
+          CommandLine: 'bun scripts/start.ts',
+        },
+        {
+          ProcessId: 23676,
+          ParentProcessId: 29180,
+          Name: 'bun.exe',
+          CommandLine: 'bun scripts/start.ts',
+        },
+        {
+          ProcessId: 29180,
+          ParentProcessId: 26336,
+          Name: 'pwsh.exe',
+          CommandLine:
+            '"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -NoProfile -Command',
+        },
+        {
+          ProcessId: 26336,
+          ParentProcessId: 29396,
+          Name: 'Code.exe',
+          CommandLine: codeUtilityCmd,
+        },
+        {
+          ProcessId: 29396,
+          ParentProcessId: 1000,
+          Name: 'Code.exe',
+          CommandLine: codeMainCmd,
+        },
+        {
+          ProcessId: 1000,
+          ParentProcessId: 0,
+          Name: 'wininit.exe',
+          CommandLine: 'wininit.exe',
+        },
+      ];
+      const originalPid = process.pid;
+      Object.defineProperty(process, 'pid', {
+        value: 15604,
+        configurable: true,
+      });
+      mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
+
+      try {
+        const result = await getIdeProcessInfo();
+        expect(result).toStrictEqual({ pid: 29396, command: codeMainCmd });
+      } finally {
+        Object.defineProperty(process, 'pid', {
+          value: originalPid,
+          configurable: true,
+        });
+      }
+    });
+
+    it('should pick the nearest main IDE ancestor when multiple Code.exe main windows exist in the tree', async () => {
+      (os.platform as Mock).mockReturnValue('win32');
+      // process(1000) -> shell(900) -> Code main window A(800, plain Code.exe)
+      //   -> Code main window B(700, plain Code.exe) -> root(0)
+      // Neither Code.exe is a VS Code child process (no --type=), so both are
+      // valid main candidates; the one closer to the CLI (800) must win for
+      // determinism. VS Code child/utility processes (which carry --type=) are
+      // excluded as non-main, see the issue #2656 test.
+      const nearCmd =
+        'C:\\Users\\x\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe';
+      const farCmd =
+        'C:\\Users\\y\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe';
+      const processes = [
+        {
+          ProcessId: 1000,
+          ParentProcessId: 900,
+          Name: 'node.exe',
+          CommandLine: 'node.exe',
+        },
+        {
+          ProcessId: 900,
+          ParentProcessId: 800,
+          Name: 'pwsh.exe',
+          CommandLine: 'pwsh.exe',
+        },
+        {
+          ProcessId: 800,
+          ParentProcessId: 700,
+          Name: 'Code.exe',
+          CommandLine: nearCmd,
+        },
+        {
+          ProcessId: 700,
+          ParentProcessId: 0,
+          Name: 'Code.exe',
+          CommandLine: farCmd,
+        },
+      ];
+      mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
+
+      const result = await getIdeProcessInfo();
+      expect(result).toStrictEqual({ pid: 800, command: nearCmd });
+    });
+
+    it('should match IDE executables case-insensitively', async () => {
+      (os.platform as Mock).mockReturnValue('win32');
+      // process(1000) -> shell(900) -> code.exe (lowercase, 800) -> root(0)
+      const processes = [
+        {
+          ProcessId: 1000,
+          ParentProcessId: 900,
+          Name: 'node.exe',
+          CommandLine: 'node.exe',
+        },
+        {
+          ProcessId: 900,
+          ParentProcessId: 800,
+          Name: 'pwsh.exe',
+          CommandLine: 'pwsh.exe',
+        },
+        {
+          ProcessId: 800,
+          ParentProcessId: 0,
+          Name: 'code.exe',
+          CommandLine: 'code.exe',
+        },
+      ];
+      mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
+
+      const result = await getIdeProcessInfo();
+      expect(result).toStrictEqual({ pid: 800, command: 'code.exe' });
+    });
+
+    it('should match an IDE ancestor whose CommandLine is a quoted Windows path with spaces (Name does not match)', async () => {
+      (os.platform as Mock).mockReturnValue('win32');
+      // process(1000) -> shell(900) -> Code main(800) -> wininit(700) -> root(0).
+      // The Code process has an empty/non-IDE Name and a *quoted* CommandLine
+      // containing spaces:
+      //   "C:\Program Files\Microsoft VS Code\Code.exe" --reuse-window
+      // The bare split(/\s+/)[0] would yield `"C:\Program` (basename `program`),
+      // failing to match. Tokenization must respect the leading quote so the
+      // real basename `Code.exe` is extracted and PID 800 is selected. Without
+      // the fix, no ancestor matches and the fallback returns wininit (700).
+      const quotedCmd = `"C:\\Program Files\\Microsoft VS Code\\Code.exe" --reuse-window`;
+      const processes = [
+        {
+          ProcessId: 1000,
+          ParentProcessId: 900,
+          Name: 'node.exe',
+          CommandLine: 'node.exe',
+        },
+        {
+          ProcessId: 900,
+          ParentProcessId: 800,
+          Name: 'pwsh.exe',
+          CommandLine: 'pwsh.exe',
+        },
+        {
+          ProcessId: 800,
+          ParentProcessId: 700,
+          Name: '',
+          CommandLine: quotedCmd,
+        },
+        {
+          ProcessId: 700,
+          ParentProcessId: 0,
+          Name: 'wininit.exe',
+          CommandLine: 'wininit.exe',
+        },
+      ];
+      mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
+
+      const result = await getIdeProcessInfo();
+      expect(result).toStrictEqual({ pid: 800, command: quotedCmd });
+    });
+
+    it('should not exclude a main IDE whose command path contains --type= as a substring but not as a switch', async () => {
+      (os.platform as Mock).mockReturnValue('win32');
+      // process(1000) -> shell(900) -> Code main(800) -> wininit(700) -> root(0).
+      // The Code CommandLine includes the substring `--type=` inside an
+      // unrelated argument (`C:\work\project--type=demo-notes`), which is NOT
+      // the Electron process-type switch. The main window must still be
+      // selected. With the old loose `--type=` substring test, the Code
+      // process is wrongly excluded and the fallback returns wininit (700).
+      const substringCmd = `Code.exe C:\\work\\project--type=demo-notes`;
+      const processes = [
+        {
+          ProcessId: 1000,
+          ParentProcessId: 900,
+          Name: 'node.exe',
+          CommandLine: 'node.exe',
+        },
+        {
+          ProcessId: 900,
+          ParentProcessId: 800,
+          Name: 'pwsh.exe',
+          CommandLine: 'pwsh.exe',
+        },
+        {
+          ProcessId: 800,
+          ParentProcessId: 700,
+          Name: 'Code.exe',
+          CommandLine: substringCmd,
+        },
+        {
+          ProcessId: 700,
+          ParentProcessId: 0,
+          Name: 'wininit.exe',
+          CommandLine: 'wininit.exe',
+        },
+      ];
+      mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
+
+      const result = await getIdeProcessInfo();
+      expect(result).toStrictEqual({ pid: 800, command: substringCmd });
+    });
+
+    it('should still exclude a VS Code utility child whose command has --type= as a real switch', async () => {
+      (os.platform as Mock).mockReturnValue('win32');
+      // process(1000) -> Code utility(900, Code.exe --type=utility)
+      //   -> Code main(800, Code.exe) -> root(0)
+      // The utility child carries the real `--type=utility` switch (a distinct
+      // token preceded by whitespace); it must be excluded so the main window
+      // (800) is selected.
+      const utilityCmd = `C:\\app\\Code.exe --type=utility`;
+      const mainCmd = `C:\\app\\Code.exe`;
+      const processes = [
+        {
+          ProcessId: 1000,
+          ParentProcessId: 900,
+          Name: 'node.exe',
+          CommandLine: 'node.exe',
+        },
+        {
+          ProcessId: 900,
+          ParentProcessId: 800,
+          Name: 'Code.exe',
+          CommandLine: utilityCmd,
+        },
+        {
+          ProcessId: 800,
+          ParentProcessId: 0,
+          Name: 'Code.exe',
+          CommandLine: mainCmd,
+        },
+      ];
+      mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
+
+      const result = await getIdeProcessInfo();
+      expect(result).toStrictEqual({ pid: 800, command: mainCmd });
+    });
+
+    it('should fall back to the top-level ancestor when no IDE executable matches', async () => {
+      (os.platform as Mock).mockReturnValue('win32');
+      // process(1000) -> foo(900) -> bar(800) -> wininit(700, root)
+      // No name matches a known IDE; fall back to the top-level reachable
+      // ancestor (700), preserving current best-effort behavior.
+      const processes = [
+        {
+          ProcessId: 1000,
+          ParentProcessId: 900,
+          Name: 'foo.exe',
+          CommandLine: 'foo.exe',
+        },
+        {
+          ProcessId: 900,
+          ParentProcessId: 800,
+          Name: 'bar.exe',
+          CommandLine: 'bar.exe',
+        },
+        {
+          ProcessId: 800,
+          ParentProcessId: 700,
+          Name: 'baz.exe',
+          CommandLine: 'baz.exe',
+        },
+        {
+          ProcessId: 700,
+          ParentProcessId: 0,
+          Name: 'wininit.exe',
+          CommandLine: 'wininit.exe',
+        },
+      ];
+      mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
+
+      const result = await getIdeProcessInfo();
+      expect(result).toStrictEqual({ pid: 700, command: 'wininit.exe' });
     });
 
     it('should handle short process chains', async () => {
@@ -180,7 +479,8 @@ describe('getIdeProcessInfo', () => {
       mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
 
       const result = await getIdeProcessInfo();
-      // Ancestors: [1000, 900]. Length < 3, returns last (900)
+      // Ancestors: [1000, 900] (800 is missing). No IDE match, so the
+      // top-level reachable ancestor (900) is returned as best-effort.
       expect(result).toStrictEqual({ pid: 900, command: 'parent.exe' });
     });
   });

--- a/packages/ide-integration/src/ide/process-utils.ts
+++ b/packages/ide-integration/src/ide/process-utils.ts
@@ -66,12 +66,17 @@ function tokenizeCommand(command: string): readonly string[] {
  * does not exist (the issue #2656 regression).
  */
 function isIdeProcess(processInfo: ProcessInfo): boolean {
-  const nameBase = path.basename(processInfo.name).toLowerCase();
+  // Use path.win32.basename because this function only ever inspects Windows
+  // process data (it is called exclusively from getIdeProcessInfoForWindows).
+  // On a POSIX host (e.g. Linux CI), path.basename does not treat `` as a
+  // separator, so a Windows path like `C:\Program Files\Code.exe` would not
+  // reduce to `Code.exe` and matching would silently fail.
+  const nameBase = path.win32.basename(processInfo.name).toLowerCase();
   const matchesByName =
     Boolean(nameBase) && IDE_EXECUTABLE_BASENAMES.has(nameBase);
   const tokens = tokenizeCommand(processInfo.command);
   const commandFirstToken = tokens[0] ?? '';
-  const commandBase = path.basename(commandFirstToken).toLowerCase();
+  const commandBase = path.win32.basename(commandFirstToken).toLowerCase();
   const matchesByCommand =
     Boolean(commandBase) && IDE_EXECUTABLE_BASENAMES.has(commandBase);
   if (!matchesByName && !matchesByCommand) {

--- a/packages/ide-integration/src/ide/process-utils.ts
+++ b/packages/ide-integration/src/ide/process-utils.ts
@@ -9,10 +9,80 @@ import { promisify } from 'util';
 import os from 'os';
 import path from 'path';
 import { debugLogger } from '@vybestack/llxprt-code-telemetry/utils/debugLogger.js';
+import { IDE_EXECUTABLE_NAMES } from './constants.js';
 
 const execAsync = promisify(exec);
 
 const MAX_TRAVERSAL_DEPTH = 32;
+
+/** Lowercased IDE executable basenames for case-insensitive matching. */
+const IDE_EXECUTABLE_BASENAMES: ReadonlySet<string> = new Set(
+  IDE_EXECUTABLE_NAMES.map((name) => name.toLowerCase()),
+);
+
+/**
+ * Splits a Windows process command line into argv-style tokens, respecting
+ * double-quoted segments. A leading quoted path like
+ * `"C:\Program Files\VS Code\Code.exe" --reuse-window` is split so that the
+ * first token is `C:\Program Files\VS Code\Code.exe` (without the quotes),
+ * not the broken `"C:\Program` that a naive whitespace split would yield.
+ */
+function tokenizeCommand(command: string): readonly string[] {
+  const trimmed = command.trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+  const tokens: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (const char of trimmed) {
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (/\s/.test(char) && !inQuotes) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+/**
+ * Returns true when a process's name or command identifies it as a supported
+ * IDE. Matching is case-insensitive and basename-based so that fully-qualified
+ * Windows paths (e.g. `C:\...\Code.exe`) still match `code.exe`.
+ *
+ * VS Code (and forks) spawn child/utility processes that share the IDE
+ * executable name but carry a `--type=` flag (e.g. `--type=utility`,
+ * `--type=extensionHost`). Only the main window process — which never has
+ * `--type=` as a distinct argv token — owns the companion server / port file,
+ * so child processes are excluded to avoid selecting a PID whose port file
+ * does not exist (the issue #2656 regression).
+ */
+function isIdeProcess(processInfo: ProcessInfo): boolean {
+  const nameBase = path.basename(processInfo.name).toLowerCase();
+  const matchesByName =
+    Boolean(nameBase) && IDE_EXECUTABLE_BASENAMES.has(nameBase);
+  const tokens = tokenizeCommand(processInfo.command);
+  const commandFirstToken = tokens[0] ?? '';
+  const commandBase = path.basename(commandFirstToken).toLowerCase();
+  const matchesByCommand =
+    Boolean(commandBase) && IDE_EXECUTABLE_BASENAMES.has(commandBase);
+  if (!matchesByName && !matchesByCommand) {
+    return false;
+  }
+  // Exclude VS Code fork child/utility processes; the main window has no
+  // --type= token. Matching as a distinct argv token avoids wrongly rejecting
+  // a main process whose path or an unrelated arg contains `--type=` as a
+  // substring (e.g. `Code.exe C:\work\project--type=demo`).
+  return !tokens.some((token) => token.startsWith('--type='));
+}
 
 interface ProcessInfo {
   pid: number;
@@ -220,7 +290,10 @@ async function getIdeProcessInfoForWindows(): Promise<{
   }
 
   // Perform tree traversal in memory.
-  // Strategy: Find the great-grandchild of the root process (pid 0 or non-existent parent).
+  // ancestors[0] is the CLI itself (not an IDE candidate). Walk from the
+  // nearest non-CLI ancestor toward the root, returning the first process
+  // whose name or command identifies a supported IDE. If none match, fall
+  // back to the top-level reachable ancestor to preserve best-effort behavior.
   const ancestors: ProcessInfo[] = [];
   let curr: ProcessInfo | undefined = myProc;
 
@@ -232,10 +305,15 @@ async function getIdeProcessInfoForWindows(): Promise<{
     curr = processMap.get(curr.parentPid);
   }
 
-  if (ancestors.length >= 3) {
-    const target = ancestors[ancestors.length - 3];
-    return { pid: target.pid, command: target.command };
-  } else if (ancestors.length > 0) {
+  // ancestors[0] is the CLI; start matching from its first parent.
+  for (let i = 1; i < ancestors.length; i++) {
+    const ancestor = ancestors[i];
+    if (isIdeProcess(ancestor)) {
+      return { pid: ancestor.pid, command: ancestor.command };
+    }
+  }
+
+  if (ancestors.length > 0) {
     const target = ancestors[ancestors.length - 1];
     return { pid: target.pid, command: target.command };
   }

--- a/project-plans/issue-2656-windows-stale-ide-port.md
+++ b/project-plans/issue-2656-windows-stale-ide-port.md
@@ -1,0 +1,117 @@
+# Issue #2656 — Windows IDE connection cannot recover from stale terminal port metadata
+
+## Scope Ledger
+
+### In scope
+- `packages/ide-integration/src/ide/process-utils.ts`: replace fixed-offset
+  (`ancestors[ancestors.length - 3]`) Windows heuristic with executable/command
+  matching that walks the ancestor chain and selects the real IDE ancestor.
+- `packages/ide-integration/src/ide/process-utils.test.ts`: new Windows
+  behavioral test mirroring the issue's process tree
+  (CLI → wrapper → shell → Code utility → Code main), plus update of any
+  existing Windows assertions that encode the buggy fixed-offset behavior.
+- `packages/ide-integration/src/ide/constants.ts`: additive IDE executable-name
+  match list (small additive constant, not a new subsystem/public abstraction).
+
+### Explicit non-goals
+- NOT modifying `getIdeProcessInfoForUnix()` (Unix strategy unchanged).
+- NOT changing `connect()` fallback ordering, `establishConnection()`, the
+  epoch/generation ownership machinery, or auth-token / workspace-path
+  validation.
+- NOT connecting to an arbitrary port file — discovery must stay scoped to the
+  current IDE/workspace PID and preserve auth-token validation.
+- NOT introducing a new public abstraction, subsystem, or dependency.
+- NOT changing workflow / agent-memory / quality-tool / CI configuration.
+- NOT moving unrelated refactors or tests into scope.
+- NOT validating candidate PIDs against port files from inside process-utils
+  (process-utils is a pure process-tree utility; PID→port-file resolution stays
+  in `IdeClient.getConnectionConfigFromFile()`). Candidate PID validation is a
+  signal *available to* the caller, not a coupling introduced here.
+
+### Hard scope budget
+- Target: ≤ 4 files, ≤ 400 net changed lines (well under 25-file / 1500-line
+  soft cap and 40-file / 2500-line hard cap).
+- Mandatory scope review if either soft threshold is crossed; STOP without
+  approval above the hard caps.
+
+## Root cause (confirmed)
+
+`getIdeProcessInfoForWindows()` returns
+`ancestors[ancestors.length - 3]` (great-grandchild of the root process). For
+the real VS Code integrated-terminal tree:
+
+```
+bun CLI (15604) → bun scripts/start.ts (23676) → pwsh (29180)
+  → Code utility / extension host (26336) → Code main (29396)
+```
+
+the fixed offset returns PID `29180` (`pwsh.exe`), not PID `29396`
+(`Code.exe`). `IdeClient.getConnectionConfigFromFile()` then searches for
+`llxprt-ide-server-29180-*.json`, finds nothing, and falls back to the stale
+environment port `LLXPRT_CODE_IDE_SERVER_PORT=49975`, where no listener exists.
+
+A direct `IdeClient` diagnostic connects successfully when given the live
+port-file metadata, proving the companion server is healthy — the only
+broken link is Windows IDE-process identification.
+
+## Architectural decision
+
+Replace the fixed-offset heuristic with an **executable/command match walk**:
+
+1. Build the full ancestor chain (current behavior: walk until root/unknown).
+2. Walk from the *nearest* ancestor toward the root, returning the first
+   ancestor whose process name / command matches a supported IDE executable
+   (e.g. `Code.exe`, `code`, `Cursor`, `VSCodium`, plus the existing Sublime /
+   Antigravity class names as appropriate). Matching is case-insensitive and
+   basename-based.
+3. If no ancestor matches a known IDE, fall back to the existing top-level
+   ancestor (preserves current best-effort behavior for unknown launchers).
+
+This keeps `process-utils.ts` a pure process-tree utility — it does NOT read
+port files or know about the companion. PID→port-file resolution stays in
+`IdeClient.getConnectionConfigFromFile()`, which already keys on
+`this.ideProcessInfo.pid`. Once the correct PID (`Code.exe` = 29396) is
+identified, the existing port-file lookup finds the live
+`llxprt-ide-server-29396-64365.json` and recovery works end-to-end without
+touching the connection state machine.
+
+## Acceptance Matrix
+
+| AC | Behavior | Trigger / State | Expected outcome |
+|----|----------|-----------------|------------------|
+| 1 | Windows picks real IDE ancestor (deep tree) | Tree: CLI(1000)→wrapper(900)→pwsh(800)→Code util(700)→Code main(600)→wininit(500)→root(0); names match `Code.exe` at 600 | returns `{pid:600, command:<Code.exe cmd>}` |
+| 2 | Recovery from stale env port | AC1 PID + live port file `llxprt-ide-server-600-*.json` present; env `LLXPRT_CODE_IDE_SERVER_PORT` points at a dead port | `getConnectionConfigFromFile()` finds the 600-keyed file (port + authToken + workspacePath) — env fallback not reached |
+| 3 | Nearest IDE ancestor wins when multiple match | Two `Code.exe` ancestors (extension host + main) | returns the one closer to the CLI (first match walking up) — deterministic |
+| 4 | Falls back to top-level ancestor when no IDE match | Tree with no `code`/`cursor`/etc. names | returns top-level ancestor (current best-effort behavior preserved) |
+| 5 | Case-insensitive executable matching | `code.exe` lowercase vs `Code.exe` | matches |
+| 6 | Unix path unchanged | linux/mac trees | existing Unix tests pass unmodified |
+| 7 | Backward-compat single-process / short chains | Tree length 1-2 | returns self/top ancestor (no regression) |
+
+## Bounded vertical slices (TDD)
+1. **Slice 1 — RED**: Write the failing Windows behavioral test from the issue
+   (AC1): deep VS Code tree with wrapper+shell between CLI and `Code.exe`,
+   asserting the returned PID is the `Code.exe` PID, not the shell's. Also
+   update the existing Windows "great-grandchild" assertion that currently
+   encodes the bug (it asserts `pid:900` for `powershell.exe` — that is the
+   bug enshrined as a test; per RULES.md it must be corrected to assert the
+   IDE process).
+2. **Slice 2 — GREEN**: Implement executable/command match walk in
+   `process-utils.ts` + the IDE executable-name constant list in
+   `constants.ts`. Minimal code to make AC1-AC7 pass.
+3. **Slice 3 — REFACTOR** (only if valuable): dedupe match logic, ensure
+   immutability, no public API surface added beyond the existing
+   `getIdeProcessInfo()` signature.
+
+## Expected paths (verification)
+- `cd packages/ide-integration && bun run test`
+- `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+  `npm run build`
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+
+## Review-finding classification policy
+Every OCR / CodeRabbit / deepthinker finding is classified as:
+**Blocker-Fix** | **In-scope-Fix** | **Reject** | **Defer**.
+Reviewer suggestions do NOT authorize scope expansion. Any finding that would
+require a new public abstraction, subsystem, workflow change, dependency
+change, or unrelated refactor is **Reject** or **Defer** and requires user
+approval before action.


### PR DESCRIPTION
## Summary

On Windows, `/ide enable` could not recover when an already-open VS Code integrated terminal contained stale `LLXPRT_CODE_IDE_*` metadata after the companion server restarted. The Windows IDE-process heuristic in `getIdeProcessInfoForWindows()` used a fixed great-grandchild-of-root offset (`ancestors[length - 3]`), which for a real VS Code tree (CLI -> wrapper -> pwsh -> Code utility -> Code main) returned the `pwsh.exe` shell PID instead of the `Code.exe` main process PID. `getConnectionConfigFromFile()` then found no port file for the wrong PID and fell back to the stale, dead `LLXPRT_CODE_IDE_SERVER_PORT` env value, leaving `/ide status` disconnected.

This PR replaces the fixed offset with an **executable/command match walk** that identifies the actual IDE ancestor, so the existing port-file lookup recovers the live companion automatically.

Fixes #2656

## Root cause

`packages/ide-integration/src/ide/process-utils.ts` -> `getIdeProcessInfoForWindows()`:

```ts
// BUG: fixed offset returns the shell, not Code.exe
if (ancestors.length >= 3) {
  const target = ancestors[ancestors.length - 3];
  return { pid: target.pid, command: target.command };
}
```

For the issue's process tree (15604 -> 23676 -> 29180 -> 26336 -> 29396 -> wininit -> root), `ancestors` is `[15604, 23676, 29180, 26336, 29396]` (length 5), so `[length - 3]` = index 2 = PID `29180` (`pwsh.exe`). The correct PID is `29396` (`Code.exe` main).

## The fix

1. **Executable/command match walk** (`process-utils.ts`): walk the ancestor chain from the nearest ancestor toward the root, returning the first ancestor whose process `Name` or `CommandLine` identifies a supported IDE (case-insensitive basename match against `IDE_EXECUTABLE_NAMES`).
2. **VS Code child-process exclusion**: VS Code forks spawn child/utility processes that share the `Code.exe` name but carry a `--type=` switch (e.g. `--type=utility`, `--type=extensionHost`). These are excluded (matched as a distinct argv token, not a substring) so the main window process — which owns the companion port file — is selected. This is why PID `26336` (`Code.exe --type=utility`) is correctly skipped and `29396` (plain `Code.exe`) wins.
3. **Quoting-aware command tokenizer** (`tokenizeCommand`): handles realistic Windows quoted paths like `"C:\Program Files\Microsoft VS Code\Code.exe" --reuse-window` so the executable basename is extracted correctly rather than truncated at the first space.
4. **IDE executable-name list** (`constants.ts`): additive readonly constant of reliable IDE executable basenames (VS Code, Code Insiders, VSCodium, Cursor, Windsurf, Trae, Sublime Text). The comment accurately documents that env-detected IDEs (Antigravity, Codespaces, Replit, etc.) are not included.

Once the correct PID (`29396`) is identified, the **unchanged** `IdeClient.getConnectionConfigFromFile()` finds the live `llxprt-ide-server-29396-*.json` port file and recovers the companion — no caller, connection-state-machine, auth-token, or workspace-path changes required.

## Behavioral tests (TDD)

- **`process-utils.test.ts`** (15 tests): the issue's exact process tree (CLI -> wrapper -> pwsh -> Code utility -> Code main) asserting PID `29396`; nearest-main determinism when multiple `Code.exe` mains exist; case-insensitive matching; no-IDE-match fallback to top-level ancestor; quoted-path command matching; `--type=` substring non-exclusion vs real-switch exclusion.
- **`ide-client.test.ts`** (11 tests): composed end-to-end recovery test — stale `LLXPRT_CODE_IDE_SERVER_PORT=49975` env + live `llxprt-ide-server-29396-64365.json` port file -> asserts the transport connects to port `64365` with `Bearer token-xyz`, NOT the stale `49975`.

## Architectural boundary preserved

`process-utils.ts` remains a **pure process-tree utility** — it does not read port files or know about the companion server. PID -> port-file resolution stays in `IdeClient.getConnectionConfigFromFile()`. No new public abstraction, subsystem, or dependency. `ide-client.ts`, `connect()`, `establishConnection()`, the epoch/generation ownership machinery, auth-token validation, workspace-path validation, and the Unix code path are all **unchanged**.

## Scope

- **Files changed:** 4 source/test files + 1 plan (`project-plans/issue-2656-windows-stale-ide-port.md`)
- **Net lines:** ~598 insertions, ~10 deletions
- Well within the 25-file / 1,500-line soft cap and 40-file / 2,500-line hard cap.

## Verification

- `packages/ide-integration` tests: **128 passed | 1 skipped** (pre-existing skip)
- `npm run lint`: clean for ide-integration (pre-existing unrelated errors in `a2a-server`/`agents` on `main`)
- `tsc --noEmit`: clean for ide-integration (pre-existing unrelated errors on `main`)
- `bun run build`: pass
- `npm run format`: applied
- deepthinker compliance review: **no blockers**; 5 In-scope-Fix findings, all remediated
- Open Code Review (ocr v1.8.0): **3 comments** — 2 In-scope-Fix (test isolation, remediated), 1 Defer (optional combinatorial boundary hardening)
