### PR TITLE
docs: verify issue #1605 (Zed ACP ToolKind mapping + history recording) already delivered

### DIFF
--- a/dev-docs/merge-notes/issue-1605-verification.md
+++ b/dev-docs/merge-notes/issue-1605-verification.md
@@ -90,15 +90,15 @@ End-to-end replay is verified by the issue #1604 loadSession replay suite:
 
 ## Test Results Summary
 
-| Suite | Tests | Result |
-|-------|-------|--------|
-| `zed-tool-kind.test.ts` | 43 | ✅ all pass |
-| `zedIntegration.toolCall.test.ts` | 6 | ✅ all pass |
-| `zedIntegration.prompt.test.ts` | 21 | ✅ all pass |
-| `sessionControl.recording.behavior.test.ts` | 5 | ✅ all pass |
-| `zedIntegration.loadSession.test.ts` | 18 | ✅ all pass |
-| `zed-session-replay.test.ts` | 24 | ✅ all pass |
-| **Total** | **117** | **✅ all pass** |
+| Suite                                       | Tests   | Result          |
+| ------------------------------------------- | ------- | --------------- |
+| `zed-tool-kind.test.ts`                     | 43      | ✅ all pass     |
+| `zedIntegration.toolCall.test.ts`           | 6       | ✅ all pass     |
+| `zedIntegration.prompt.test.ts`             | 21      | ✅ all pass     |
+| `sessionControl.recording.behavior.test.ts` | 5       | ✅ all pass     |
+| `zedIntegration.loadSession.test.ts`        | 18      | ✅ all pass     |
+| `zed-session-replay.test.ts`                | 24      | ✅ all pass     |
+| **Total**                                   | **117** | **✅ all pass** |
 
 ## Conclusion
 

--- a/dev-docs/merge-notes/issue-1605-verification.md
+++ b/dev-docs/merge-notes/issue-1605-verification.md
@@ -1,0 +1,107 @@
+# Issue #1605: Zed ACP ToolKind Mapping and Chat History Recording — Verification
+
+**Date:** 2026-07-28
+**Issue:** vybestack/llxprt-code#1605
+**Verified against:** `main` (commit `4fd465c4b`)
+**Outcome:** Already fully delivered by PR #2502 — no code changes required.
+
+## Summary
+
+Issue #1605 requested two things: (1) a `toAcpToolKind()` mapping function that
+converts internal `Kind` values to valid ACP `ToolKind` values with an `'other'`
+fallback, and (2) recording completed tool calls into chat history for session
+persistence and resumption. Both were implemented and are present on `main`.
+
+## Acceptance Criteria Verification
+
+### 1. `toAcpToolKind()` maps all `Kind` values to valid ACP `ToolKind` — MET
+
+`packages/cli/src/zed-integration/zed-tool-handler.ts` defines:
+
+- `ACP_TOOL_KINDS` — the set of valid ACP `ToolKind` values.
+- `toAcpToolKind(kind: string | undefined): acp.ToolKind` — passes through
+  values in `ACP_TOOL_KINDS`, maps anything else (including `undefined` and
+  future non-ACP kinds like `Kind.Communicate`) to `'other'`.
+
+The internal `Kind` enum (`packages/tools/src/tools/tools.ts`) has exactly 9
+values — `read`, `edit`, `delete`, `move`, `search`, `execute`, `think`,
+`fetch`, `other` — all string-identical to ACP's `ToolKind` union, so every
+`Kind` passes through correctly.
+
+**Test evidence:** `zed-tool-kind.test.ts` — 43 tests, all pass. Covers every
+`TOOL_KIND_BY_NAME` entry, every `Kind` value pass-through, and the
+`undefined`/`'communicate'` → `'other'` fallback.
+
+### 2. All `tool_call` and `tool_call_update` notifications use mapped kind — MET
+
+`resolveToolKind(name, registeredKind)` is called in:
+
+- `emitToolCallStart` (produces `tool_call` notifications)
+- `emitToolStatus` (produces `tool_call_update` notifications)
+- `emitToolResult` (produces `tool_call_update` notifications)
+- `requestToolConfirmation` (produces permission requests)
+
+The registry-sourced kind is resolved via `agent.tools.get(name)?.kind` at all
+call sites in `zed-agent-event-handler.ts` (`handleToolEvent`,
+`handleToolUpdate`, `handleToolResultEvent`) and `zedIntegration.ts`
+(`handleToolConfirmation`). When no registered kind exists, the name-based
+`inferToolKind(name)` fallback applies.
+
+**Test evidence:** `zedIntegration.toolCall.test.ts` —
+`'uses the registered tool kind on every live tool notification'` drives a tool
+through `tool-call`, `tool-status`, and `tool-result` events with a registered
+kind of `'search'` and asserts all three notifications carry `kind: 'search'`.
+
+### 3. Tool history recording after each tool execution — MET (architecturally)
+
+The issue's original premise (`call chat.recordCompletedToolCalls() in runTool`)
+predates the Agent API port (#2385). In the current architecture:
+
+- Tool execution and history recording are owned by `AgenticLoop`
+  (`packages/agents/src/core/agenticLoop/AgenticLoop.ts`), which `agent.stream()`
+  drives internally.
+- `recordCompletedToolHistory()` (`AgenticLoop.ts:744`) persists completed tool
+  calls; `recordCancelledToolHistory()` (`AgenticLoop.ts:733`) persists cancelled
+  ones.
+- The Zed integration consumes events via `agent.stream()` but does not (and
+  cannot) reconstruct `CompletedToolCall[]` from the lossy public
+  `AgentEvent`/`AgentToolResult` projections. A zed-side recording call would
+  double-record.
+
+**Test evidence:** `sessionControl.recording.behavior.test.ts` —
+`'records COMPLETED TOOL CALLS (call + response) into the session JSONL for later
+replay (issue #1605 verification)'` drives a real agent through a confirmed
+`read_file` tool turn with recording enabled and asserts the on-disk JSONL
+carries the `tool_call` block, its paired `tool_response`
+(`response.callId === call.id`), and post-tool assistant text.
+
+### 4. Session history correctly records tool calls for later resumption — MET
+
+End-to-end replay is verified by the issue #1604 loadSession replay suite:
+
+- `zedIntegration.loadSession.test.ts` (18 tests) — `loadSession` orchestration,
+  disk-resume path, live re-attach, concurrent serialization, partial-failure
+  cleanup.
+- `zed-session-replay.test.ts` (24 tests) — `mapHistoryToSessionUpdates` pairing
+  of `tool_call`/`tool_response`, orphan handling, duplicate response dropping,
+  callId reuse across turns, trailing-failure synthesis.
+
+**Test evidence:** 42 tests, all pass.
+
+## Test Results Summary
+
+| Suite | Tests | Result |
+|-------|-------|--------|
+| `zed-tool-kind.test.ts` | 43 | ✅ all pass |
+| `zedIntegration.toolCall.test.ts` | 6 | ✅ all pass |
+| `zedIntegration.prompt.test.ts` | 21 | ✅ all pass |
+| `sessionControl.recording.behavior.test.ts` | 5 | ✅ all pass |
+| `zedIntegration.loadSession.test.ts` | 18 | ✅ all pass |
+| `zed-session-replay.test.ts` | 24 | ✅ all pass |
+| **Total** | **117** | **✅ all pass** |
+
+## Conclusion
+
+All four acceptance criteria are satisfied by code already present on `main`.
+No implementation work was required — this was a pure verification effort
+confirming PR #2502 correctly delivered the issue's intent.


### PR DESCRIPTION
## Summary

Issue #1605 requested two things for the Zed ACP integration:
1. A \	oAcpToolKind()\ mapping function converting internal \Kind\ values to valid ACP \ToolKind\ with an \'other'\ fallback.
2. Recording completed tool calls into chat history for session persistence and resumption.

**Both were already delivered by PR #2502 and are present on \main\.** This PR adds a verification note documenting that all four acceptance criteria are met, with full behavioral test evidence.

## Verification Evidence

All 117 tests across 6 suites pass on the current \main\ head:

| Suite | Tests | Covers |
|-------|-------|--------|
| \zed-tool-kind.test.ts\ | 43 | \	oAcpToolKind()\ pass-through for all 9 \Kind\ values + \'other'\ fallback |
| \zedIntegration.toolCall.test.ts\ | 6 | Mapped kind on every \	ool_call\/\	ool_call_update\ notification |
| \zedIntegration.prompt.test.ts\ | 21 | Streaming, permission round-trips, cancellation, session info |
| \sessionControl.recording.behavior.test.ts\ | 5 | Completed tool calls recorded to session JSONL (explicit \#1605 verification\ test) |
| \zedIntegration.loadSession.test.ts\ | 18 | Session resumption replay orchestration |
| \zed-session-replay.test.ts\ | 24 | \mapHistoryToSessionUpdates\ tool_call/tool_response pairing |

## Acceptance Criteria

- [x] \	oAcpToolKind()\ maps all \Kind\ values to valid ACP \ToolKind\ — \zed-tool-handler.ts\
- [x] All \	ool_call\ and \	ool_call_update\ notifications use mapped kind — \esolveToolKind()\ in all emit functions
- [x] Tool history recording after each tool execution — \AgenticLoop.recordCompletedToolHistory()\ (architecturally, not zed-side)
- [x] Session history correctly records tool calls for later resumption — verified end-to-end by #1604 replay suite

## Architectural Note

The issue's original premise (\call chat.recordCompletedToolCalls() in runTool\) predates the Agent API port (#2385). Tool execution and history recording now flow through the \AgenticLoop\ runtime — the Zed integration consumes events via \gent.stream()\ but does not own recording. The public \AgentEvent\/\AgentToolResult\ shapes are lossy projections that cannot reconstruct a \CompletedToolCall[]\, so a zed-side recording call would be infeasible and a double-recording regression.

Closes #1605