### PR TITLE
fix(retry): classify Windows timeout as transient (Fixes #2557)

### DIFF
--- a/packages/core/src/utils/retry.quota.test.ts
+++ b/packages/core/src/utils/retry.quota.test.ts
@@ -107,6 +107,11 @@ describe('isRetryableError', () => {
     );
     expect(isRetryableError(error)).toBe(true);
   });
+
+  it('should retry Windows DOMException TimeoutError (issue #2557)', () => {
+    const error = new DOMException('The operation timed out.', 'TimeoutError');
+    expect(isRetryableError(error)).toBe(true);
+  });
 });
 
 describe('isNetworkTransientError', () => {
@@ -125,6 +130,26 @@ describe('isNetworkTransientError', () => {
 
   it('returns false for a non-transient error', () => {
     const error = new Error('some random error');
+    expect(isNetworkTransientError(error)).toBe(false);
+  });
+
+  it('returns true for DOMException TimeoutError "The operation timed out." (Windows API timeout, issue #2557)', () => {
+    const error = new DOMException('The operation timed out.', 'TimeoutError');
+    expect(isNetworkTransientError(error)).toBe(true);
+  });
+
+  it('returns true for a bare Error with the exact Windows timeout message (issue #2557)', () => {
+    const error = new Error('The operation timed out.');
+    expect(isNetworkTransientError(error)).toBe(true);
+  });
+
+  it('returns true for case-insensitive "OPERATION TIMED OUT" message', () => {
+    const error = new Error('OPERATION TIMED OUT');
+    expect(isNetworkTransientError(error)).toBe(true);
+  });
+
+  it('returns false for a non-timeout DOMException (issue #2557 regression guard)', () => {
+    const error = new DOMException('invalid syntax', 'SyntaxError');
     expect(isNetworkTransientError(error)).toBe(false);
   });
 });
@@ -410,5 +435,60 @@ describe('RetryableQuotaError with exponential backoff', () => {
       }
     }
     expect(foundConsoleWarnRetryMessage).toBe(false);
+  });
+});
+
+describe('retryWithBackoff Windows timeout retry (issue #2557)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setSimulate429(false);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('retries a DOMException TimeoutError and succeeds when a later attempt succeeds', async () => {
+    let attemptCount = 0;
+    const mockFn = vi.fn(async () => {
+      attemptCount++;
+      if (attemptCount <= 2) {
+        throw new DOMException('The operation timed out.', 'TimeoutError');
+      }
+      return 'success';
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 3,
+      initialDelayMs: 10,
+    });
+
+    await Promise.all([
+      expect(promise).resolves.toBe('success'),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws the original DOMException when the retry budget is exhausted (issue #2557)', async () => {
+    const mockFn = vi.fn(async () => {
+      throw new DOMException('The operation timed out.', 'TimeoutError');
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 2,
+      initialDelayMs: 10,
+    }).catch((error) => error);
+
+    await vi.runAllTimersAsync();
+    const error = await promise;
+
+    expect(mockFn).toHaveBeenCalledTimes(2);
+    expect(error).toBeInstanceOf(DOMException);
+    expect((error as DOMException).name).toBe('TimeoutError');
+    expect((error as Error).message).toContain('The operation timed out');
   });
 });

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -67,6 +67,8 @@ const TRANSIENT_ERROR_PHRASES = [
   'network error',
   'request aborted',
   'request timeout',
+  'the operation timed out',
+  'operation timed out',
   'stream closed',
   'stream prematurely closed',
   'read econnreset',


### PR DESCRIPTION
## Summary

Fixes #2557 — on Windows, an API request timeout stopped the agent loop instead of being retried.

On Windows, `fetch`/undici throws `new DOMException('The operation timed out.', 'TimeoutError')` when an API request times out. The central retry classifier `isNetworkTransientError()` in `packages/core/src/utils/retry.ts` did not recognize this error:

- The message `"The operation timed out."` matched **none** of the `TRANSIENT_ERROR_PHRASES` (which had `'socket timeout'`, `'network timeout'`, `'request timeout'` but not the Windows-specific wording).
- It matched **none** of the `TRANSIENT_ERROR_REGEXES`.
- `DOMException` exposes its kind via `.name === 'TimeoutError'`, not a string `.code` that `collectErrorDetails` collects — so `TRANSIENT_ERROR_CODES` never matched.

The error was therefore classified as non-retryable, the configured retry/backoff policy was bypassed, and the agent loop stopped immediately with `[API Error: The operation timed out.]`.

## Fix

Add `'the operation timed out'` and `'operation timed out'` to `TRANSIENT_ERROR_PHRASES` so the Windows timeout is recognized as a transient infrastructure failure and retried per the existing exponential-backoff policy. This follows the **same proven pattern** used when `'fetch failed'` was added for issue #2161. Budget exhaustion surfaces the original `DOMException` unchanged, producing a clear terminal error.

## Root cause trace (agent-loop path)

The classifier is wired into the actual retry boundary: the streaming agent path (`StreamProcessor.ts`) imports this core classifier, awaits the first chunk inside `retryWithBackoff`, and the outer turn path (`TurnProcessor.ts`) retries transient stream failures only before any output has been yielded. A timeout before any response output therefore reaches the retry mechanism and is now retried.

## Behavioral evidence (TDD)

RED → GREEN, against the **real** `isNetworkTransientError` / `isRetryableError` / `retryWithBackoff` (no `vi.mock` of `retry.js`):

- `isNetworkTransientError(new DOMException('The operation timed out.', 'TimeoutError'))` → `true`
- `isNetworkTransientError(new Error('The operation timed out.'))` → `true` (bare-error wrapper case)
- Case-insensitive matching confirmed
- Non-timeout `DOMException('invalid syntax', 'SyntaxError')` → `false` (regression guard — no over-classification)
- `retryWithBackoff`: throws on first 2 attempts, succeeds on 3rd (`maxAttempts: 3`) — proves retry happens
- `retryWithBackoff`: budget exhausted (`maxAttempts: 2`) → throws the original `DOMException` with `name === 'TimeoutError'` and the original message — clear terminal error

All 85 tests across the 3 retry test files pass (`retry.quota.test.ts`, `retry.test.ts`, `retry.onAuthError.test.ts`).

## Scope

- **2 files**, +82 lines, 0 deletions
- `packages/core/src/utils/retry.ts` — 2 entries added to an existing string array
- `packages/core/src/utils/retry.quota.test.ts` — 7 behavioral tests
- No new subsystem, abstraction, dependency, setting, workflow, agent-memory, or quality-tool change
- The standalone `packages/tools/src/utils/retry.ts` copy is intentionally left untouched (not on the agent-loop path; out of scope)

## Non-goals

The broader cross-platform first-chunk-timeout architecture (including structural `DOMException.name === 'TimeoutError'` recognition for message-variant/localization defense-in-depth) is tracked separately in #2532 for a later milestone.

## Verification

- [x] Tests: 85/85 pass across retry test files
- [x] Lint: clean (eslint exit 0 on both files)
- [x] Format: clean (prettier --check)
- [x] Typecheck: no new errors (pre-existing MCP-related failures in `config.ts`/`agents` confirmed identical on clean `main` via stash)
- [x] deepthinker compliance review: PASS, no Blocker/In-scope findings
- [x] Local OCR: 2 files reviewed, 0 comments

fixes #2557
