### PR TITLE
fix(cli): parse envelope format in todo list/load commands (Fixes #1542)

### DIFF
--- a/packages/cli/src/ui/commands/todoCommand.ts
+++ b/packages/cli/src/ui/commands/todoCommand.ts
@@ -34,6 +34,7 @@ import {
   undoAllTodos,
   undoRangeOfTodos,
   undoSingleTodo,
+  parseTodoFileContent,
 } from './todoOperations.js';
 import {
   formatTodoList,
@@ -455,7 +456,7 @@ export const todoCommand: SlashCommand = {
 
           const selectedFile = files[sessionNum - 1];
           const content = fs.readFileSync(selectedFile.path, 'utf8');
-          const todos: Todo[] = JSON.parse(content);
+          const todos: Todo[] = parseTodoFileContent(content);
 
           context.todoContext.updateTodos(todos);
 

--- a/packages/cli/src/ui/commands/todoFileFormat.test.ts
+++ b/packages/cli/src/ui/commands/todoFileFormat.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #1542: saved task lists still borked.
+ *
+ * Root cause: TaskStore.writeTodos() persists an envelope object
+ * { todos: [...], paused: boolean }, but the slash commands parsed the
+ * file content as a bare Task[] array via JSON.parse. The parsed object
+ * has no .filter() method, so countStatuses / buildStatusSummary threw
+ * TypeError, the catch block fired, and every saved session showed
+ * "(error reading file)".
+ *
+ * Fix: parseTodoFileContent() handles both the current envelope format and
+ * the legacy bare-array format, returning Task[]. formatSessionEntry and
+ * the load subcommand now use it instead of raw JSON.parse.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseTodoFileContent } from './todoOperations.js';
+import type { Todo } from '@vybestack/llxprt-code-core';
+
+describe('parseTodoFileContent (issue #1542)', () => {
+  describe('envelope format { todos, paused }', () => {
+    it('extracts the todos array from an envelope with paused=false', () => {
+      const todos: Todo[] = [
+        { id: '1', content: 'Task A', status: 'pending' },
+        { id: '2', content: 'Task B', status: 'in_progress' },
+      ];
+      const content = JSON.stringify({ todos, paused: false });
+
+      const result = parseTodoFileContent(content);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].content).toBe('Task A');
+      expect(result[1].status).toBe('in_progress');
+    });
+
+    it('extracts todos when paused=true', () => {
+      const todos: Todo[] = [
+        { id: '1', content: 'Paused task', status: 'pending' },
+      ];
+      const content = JSON.stringify({ todos, paused: true });
+
+      const result = parseTodoFileContent(content);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].content).toBe('Paused task');
+    });
+
+    it('returns empty array when envelope has an empty todos array', () => {
+      const content = JSON.stringify({ todos: [], paused: false });
+
+      expect(parseTodoFileContent(content)).toStrictEqual([]);
+    });
+  });
+
+  describe('legacy bare-array format', () => {
+    it('parses a bare Task[] array', () => {
+      const todos: Todo[] = [
+        { id: '1', content: 'Legacy task', status: 'completed' },
+      ];
+      const content = JSON.stringify(todos);
+
+      const result = parseTodoFileContent(content);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].content).toBe('Legacy task');
+      expect(result[0].status).toBe('completed');
+    });
+
+    it('returns empty array for an empty bare array', () => {
+      expect(parseTodoFileContent('[]')).toStrictEqual([]);
+    });
+  });
+
+  describe('invalid or unexpected content', () => {
+    it('returns empty array when the envelope has no todos array', () => {
+      const content = JSON.stringify({ paused: false });
+
+      expect(parseTodoFileContent(content)).toStrictEqual([]);
+    });
+
+    it('returns empty array when the envelope todos field is not an array', () => {
+      const content = JSON.stringify({ todos: 'not-an-array', paused: false });
+
+      expect(parseTodoFileContent(content)).toStrictEqual([]);
+    });
+
+    it('returns empty array for a JSON object without a todos field', () => {
+      const content = JSON.stringify({ foo: 'bar' });
+
+      expect(parseTodoFileContent(content)).toStrictEqual([]);
+    });
+
+    it('returns empty array for a JSON primitive', () => {
+      expect(parseTodoFileContent('42')).toStrictEqual([]);
+      expect(parseTodoFileContent('"hello"')).toStrictEqual([]);
+      expect(parseTodoFileContent('null')).toStrictEqual([]);
+      expect(parseTodoFileContent('true')).toStrictEqual([]);
+    });
+
+    it('throws on invalid JSON', () => {
+      expect(() => parseTodoFileContent('{ not json')).toThrow(SyntaxError);
+      expect(() => parseTodoFileContent('')).toThrow(SyntaxError);
+    });
+  });
+
+  describe('round-trip with TaskStore envelope', () => {
+    it('parses output matching TaskStore.writeTodos format', () => {
+      // TaskStore writes { todos, paused } — simulate that exact shape.
+      const todos: Todo[] = [
+        {
+          id: 'user-1700000000000',
+          content: 'Fix the bug',
+          status: 'in_progress',
+        },
+        { id: 'user-1700000000001', content: 'Write tests', status: 'pending' },
+      ];
+      const diskContent = JSON.stringify({ todos, paused: false }, null, 2);
+
+      const result = parseTodoFileContent(diskContent);
+
+      expect(result).toStrictEqual(todos);
+    });
+
+    it('handles subtasks within the envelope', () => {
+      const todos: Todo[] = [
+        {
+          id: '1',
+          content: 'Parent',
+          status: 'pending',
+          subtasks: [
+            { id: '1.1', content: 'Subtask one' },
+            { id: '1.2', content: 'Subtask two' },
+          ],
+        },
+      ];
+      const content = JSON.stringify({ todos, paused: false });
+
+      const result = parseTodoFileContent(content);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].subtasks).toHaveLength(2);
+      expect(result[0].subtasks?.[0].content).toBe('Subtask one');
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/todoFormatters.formatSessionEntry.test.ts
+++ b/packages/cli/src/ui/commands/todoFormatters.formatSessionEntry.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #1542: formatSessionEntry must handle the
+ * { todos, paused } envelope format that TodoStore writes to disk.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { formatSessionEntry } from './todoFormatters.js';
+import type { TodoSessionFile } from './todoOperations.js';
+
+// vi.mock is hoisted above imports — the factory must not reference any
+// top-level variable. vi.hoisted gives us a stable mock function that is
+// available both inside the factory and in the test body.
+const { readFileSyncMock } = vi.hoisted(() => ({
+  readFileSyncMock: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  readFileSync: readFileSyncMock,
+}));
+
+function makeFile(path: string, mtime: Date): TodoSessionFile {
+  return { name: path.split('/').pop()!, path, mtime };
+}
+
+describe('formatSessionEntry (issue #1542 envelope format)', () => {
+  beforeEach(() => {
+    readFileSyncMock.mockReset();
+  });
+
+  it('reads an envelope-format file { todos, paused } without "(error reading file)"', () => {
+    const todos = [
+      { id: '1', content: 'Task A', status: 'pending' },
+      { id: '2', content: 'Task B', status: 'in_progress' },
+    ];
+    readFileSyncMock.mockReturnValue(JSON.stringify({ todos, paused: false }));
+
+    const file = makeFile('/fake/todo-1.json', new Date());
+    const lines = formatSessionEntry(file, 0);
+
+    const joined = lines.join('\n');
+    expect(joined).not.toContain('(error reading file)');
+    expect(joined).toContain('2 items');
+    expect(joined).toContain('Task A');
+  });
+
+  it('reads a legacy bare-array format file', () => {
+    const todos = [{ id: '1', content: 'Legacy task', status: 'completed' }];
+    readFileSyncMock.mockReturnValue(JSON.stringify(todos));
+
+    const file = makeFile('/fake/todo-2.json', new Date());
+    const lines = formatSessionEntry(file, 0);
+
+    const joined = lines.join('\n');
+    expect(joined).not.toContain('(error reading file)');
+    expect(joined).toContain('1 items');
+    expect(joined).toContain('Legacy task');
+  });
+
+  it('shows "(error reading file)" only for genuinely corrupted content', () => {
+    readFileSyncMock.mockReturnValue('{ not valid json');
+
+    const file = makeFile('/fake/todo-broken.json', new Date());
+    const lines = formatSessionEntry(file, 0);
+
+    expect(lines[0]).toContain('(error reading file)');
+  });
+
+  it('handles an empty envelope { todos: [], paused: false }', () => {
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({ todos: [], paused: false }),
+    );
+
+    const file = makeFile('/fake/todo-empty.json', new Date());
+    const lines = formatSessionEntry(file, 0);
+
+    const joined = lines.join('\n');
+    expect(joined).not.toContain('(error reading file)');
+    expect(joined).toContain('0 items');
+    expect(joined).toContain('(empty)');
+  });
+
+  it('includes a status summary for envelope with mixed statuses', () => {
+    const todos = [
+      { id: '1', content: 'Done', status: 'completed' },
+      { id: '2', content: 'Active', status: 'in_progress' },
+      { id: '3', content: 'Waiting', status: 'pending' },
+    ];
+    readFileSyncMock.mockReturnValue(JSON.stringify({ todos, paused: false }));
+
+    const file = makeFile('/fake/todo-mixed.json', new Date());
+    const lines = formatSessionEntry(file, 0);
+
+    const joined = lines.join('\n');
+    expect(joined).not.toContain('(error reading file)');
+    expect(joined).toContain('3 items');
+    expect(joined).toContain('in_progress');
+    expect(joined).toContain('pending');
+    expect(joined).toContain('completed');
+  });
+});

--- a/packages/cli/src/ui/commands/todoFormatters.ts
+++ b/packages/cli/src/ui/commands/todoFormatters.ts
@@ -6,7 +6,11 @@
 
 import * as fs from 'fs';
 import type { Todo } from '@vybestack/llxprt-code-core';
-import { LIST_ITEM_LABEL, type TodoSessionFile } from './todoOperations.js';
+import {
+  LIST_ITEM_LABEL,
+  parseTodoFileContent,
+  type TodoSessionFile,
+} from './todoOperations.js';
 
 /**
  * Get the icon for a task-list status.
@@ -94,7 +98,7 @@ export function formatSessionEntry(
 ): string[] {
   try {
     const content = fs.readFileSync(file.path, 'utf8');
-    const todos: Todo[] = JSON.parse(content);
+    const todos = parseTodoFileContent(content);
 
     const counts = countStatuses(todos);
     const firstTitle = todos[0]?.content || '(empty)';

--- a/packages/cli/src/ui/commands/todoOperations.ts
+++ b/packages/cli/src/ui/commands/todoOperations.ts
@@ -198,6 +198,31 @@ export type TodoContext = CommandContext & {
 };
 
 /**
+ * Parse saved task-list file content, handling both the current envelope
+ * format ({ todos: [...], paused: boolean }) and the legacy bare-array
+ * format. Returns the todos array, or an empty array when the content is
+ * neither a valid array nor an envelope object with a todos array.
+ */
+export function parseTodoFileContent(content: string): Todo[] {
+  const rawData: unknown = JSON.parse(content);
+
+  if (Array.isArray(rawData)) {
+    return rawData as Todo[];
+  }
+
+  if (
+    typeof rawData === 'object' &&
+    rawData !== null &&
+    'todos' in rawData &&
+    Array.isArray((rawData as { todos: unknown }).todos)
+  ) {
+    return (rawData as { todos: Todo[] }).todos;
+  }
+
+  return [];
+}
+
+/**
  * Apply a status change to a single parent task and report the result.
  */
 export function applyStatusChange(

--- a/packages/cli/vitest.test-groups.ts
+++ b/packages/cli/vitest.test-groups.ts
@@ -477,4 +477,4 @@ export function buildTestGroups(
  * The expected total selected file count after integrating the v0.11.0 test set.
  * Exported for behavioral tests to assert against an independent oracle.
  */
-export const SELECTED_FILE_COUNT: number = 505;
+export const SELECTED_FILE_COUNT: number = 507;


### PR DESCRIPTION
## Summary

Fixes the bug where `/todo list` showed `(error reading file)` for every saved session and `/todo load` could not restore sessions.

## Root Cause

`TodoStore.writeTodos()` persists files in an **envelope format**: `{ todos: [...], paused: boolean }`. However, the slash commands parsed the file content as a **bare `Todo[]` array** via `JSON.parse(content)`:

- `formatSessionEntry` in `todoFormatters.ts` — used by `/todo list`
- The `/todo load` subcommand in `todoCommand.ts`

When the parsed result was an object (not an array), `todos.filter()` threw `TypeError: todos.filter is not a function`. The `catch` block fired, and every saved session displayed `(error reading file)`.

## Fix

Added a shared `parseTodoFileContent(content: string): Todo[]` helper in `todoOperations.ts` that:
1. Handles the current **envelope format** `{ todos: [...], paused }` — extracts the `todos` array
2. Handles the **legacy bare-array format** `Todo[]` — returns it directly
3. Returns an empty array for unrecognized shapes (non-array, non-envelope objects, JSON primitives)

Both `formatSessionEntry` and `/todo load` now use `parseTodoFileContent` instead of raw `JSON.parse`.

## Test Coverage

- **`todoFileFormat.test.ts`** (12 tests): `parseTodoFileContent` with envelope format, legacy format, invalid/unexpected content, and round-trip with TodoStore envelope
- **`todoFormatters.formatSessionEntry.test.ts`** (5 tests): `formatSessionEntry` correctly reads envelope files without showing `(error reading file)`, handles legacy format, and only shows error for genuinely corrupted content

All 69 todo-related tests pass (52 existing + 17 new).

## Verification

- **Lint**: clean on all changed files
- **Typecheck**: no new errors (pre-existing errors in `contextLimitResolver.ts` and `fileSystemService.ts` confirmed on main)
- **Format**: clean
- **Build**: no new failures (pre-existing `fileSystemService.ts` build error confirmed on main)
- **OCR**: 0 comments (clean review)

Closes #1542