### PR TITLE
Detect file paths in AI responses and render them as clickable links (Fixes #2848)

### DIFF
--- a/packages/cli/src/ui/components/messages/AiMessage.tsx
+++ b/packages/cli/src/ui/components/messages/AiMessage.tsx
@@ -13,6 +13,7 @@ import { ThinkingBlockDisplay } from './ThinkingBlockDisplay.js';
 import type { ThinkingBlock } from '@vybestack/llxprt-code-core';
 import { useRuntimeApi } from '../../contexts/RuntimeContext.js';
 import { useUIState } from '../../contexts/UIStateContext.js';
+import { useResolvedWorkspaceDirectories } from '../../hooks/useResolvedWorkspaceDirectories.js';
 
 interface AiMessageProps {
   text: string;
@@ -22,6 +23,7 @@ interface AiMessageProps {
   model?: string;
   profileName?: string;
   thinkingBlocks?: ThinkingBlock[]; // @plan:PLAN-20251202-THINKING-UI.P06
+  workspaceDirectories?: readonly string[];
 }
 
 export function getVisibleThinkingBlocks(
@@ -42,6 +44,7 @@ export const AiMessage: React.FC<AiMessageProps> = ({
   model,
   profileName,
   thinkingBlocks,
+  workspaceDirectories,
 }) => {
   /**
    * @plan:PLAN-20251202-THINKING-UI.P06
@@ -52,6 +55,8 @@ export const AiMessage: React.FC<AiMessageProps> = ({
   const showThinking = (getEphemeralSetting('reasoning.includeInResponse') ??
     true) as boolean;
   const { renderMarkdown } = useUIState();
+  const resolvedWorkspaceDirectories =
+    useResolvedWorkspaceDirectories(workspaceDirectories);
 
   const prefix = ' ';
   const prefixWidth = prefix.length;
@@ -99,6 +104,7 @@ export const AiMessage: React.FC<AiMessageProps> = ({
             availableTerminalHeight={availableTerminalHeight}
             terminalWidth={terminalWidth}
             renderMarkdown={renderMarkdown}
+            workspaceDirectories={resolvedWorkspaceDirectories}
           />
         </Box>
       </Box>

--- a/packages/cli/src/ui/components/messages/AiMessageContent.tsx
+++ b/packages/cli/src/ui/components/messages/AiMessageContent.tsx
@@ -8,12 +8,14 @@ import type React from 'react';
 import { Box } from 'ink';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
 import { useUIState } from '../../contexts/UIStateContext.js';
+import { useResolvedWorkspaceDirectories } from '../../hooks/useResolvedWorkspaceDirectories.js';
 
 interface AiMessageContentProps {
   text: string;
   isPending: boolean;
   availableTerminalHeight?: number;
   terminalWidth: number;
+  workspaceDirectories?: readonly string[];
 }
 
 /*
@@ -27,8 +29,12 @@ export const AiMessageContent: React.FC<AiMessageContentProps> = ({
   isPending,
   availableTerminalHeight,
   terminalWidth,
+  workspaceDirectories,
 }) => {
   const { renderMarkdown } = useUIState();
+  const resolvedWorkspaceDirectories =
+    useResolvedWorkspaceDirectories(workspaceDirectories);
+
   const originalPrefix = '✦ ';
   const prefixWidth = originalPrefix.length;
 
@@ -40,6 +46,7 @@ export const AiMessageContent: React.FC<AiMessageContentProps> = ({
         availableTerminalHeight={availableTerminalHeight}
         terminalWidth={terminalWidth}
         renderMarkdown={renderMarkdown}
+        workspaceDirectories={resolvedWorkspaceDirectories}
       />
     </Box>
   );

--- a/packages/cli/src/ui/hooks/useResolvedWorkspaceDirectories.ts
+++ b/packages/cli/src/ui/hooks/useResolvedWorkspaceDirectories.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/cli/src/ui/hooks/useResolvedWorkspaceDirectories.ts
+++ b/packages/cli/src/ui/hooks/useResolvedWorkspaceDirectories.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useMemo } from 'react';
+import { useRuntimeApi } from '../contexts/RuntimeContext.js';
+
+/**
+ * Resolve the workspace directories for file-path linking.
+ *
+ * When an explicit `workspaceDirectories` prop is provided (e.g. from a
+ * parent component), it takes precedence. Otherwise the directories are
+ * resolved from the active CLI runtime. If no runtime is registered, the
+ * result is `undefined` and file-path linking is gracefully disabled.
+ *
+ * The resolution is memoized so the runtime call chain only runs when the
+ * prop identity changes, avoiding unnecessary work on re-renders.
+ */
+export function useResolvedWorkspaceDirectories(
+  workspaceDirectories?: readonly string[],
+): readonly string[] | undefined {
+  const { getCliRuntimeServices } = useRuntimeApi();
+
+  return useMemo(() => {
+    if (workspaceDirectories) {
+      return workspaceDirectories;
+    }
+    try {
+      return getCliRuntimeServices()
+        .config.getWorkspaceContext()
+        .getDirectories();
+    } catch {
+      return undefined;
+    }
+  }, [workspaceDirectories, getCliRuntimeServices]);
+}

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.ts
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.test.ts
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import {
   RenderInlineInternal,
   getPlainTextLength,
@@ -68,6 +71,8 @@ function collectElementProps(node: React.ReactNode): ElementProps[] {
   return [];
 }
 
+const OSC8_PREFIX = '\x1b]8;;';
+
 describe('RenderInline', () => {
   it('forwards presentation props to its top-level Text node', () => {
     const node = renderInlineNode({
@@ -121,6 +126,111 @@ describe('RenderInline', () => {
     expect(
       flattenText(renderInlineNode({ text: 'keep compile_time unchanged' })),
     ).toBe('keep compile_time unchanged');
+  });
+});
+
+describe('RenderInline file path links', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inline-fp-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  function createTempFile(relativePath: string): string {
+    const fullPath = path.join(tempDir, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, 'content');
+    return fullPath;
+  }
+
+  it('renders a relative file path as an OSC 8 link when it exists in a workspace directory', () => {
+    createTempFile('src/utils.ts');
+    const node = renderInlineNode({
+      text: 'Edit src/utils.ts to fix the bug.',
+      workspaceDirectories: [tempDir],
+    });
+
+    const flat = flattenText(node);
+    expect(flat).toContain(OSC8_PREFIX);
+    expect(flat).toContain('src/utils.ts');
+  });
+
+  it('does not link path-like tokens when workspaceDirectories is not provided', () => {
+    createTempFile('src/utils.ts');
+    const node = renderInlineNode({
+      text: 'Edit src/utils.ts to fix the bug.',
+    });
+
+    const flat = flattenText(node);
+    expect(flat).not.toContain(OSC8_PREFIX);
+    expect(flat).toContain('src/utils.ts');
+  });
+
+  it('does not link a file path inside inline code (backticks)', () => {
+    createTempFile('src/utils.ts');
+    const node = renderInlineNode({
+      text: 'Edit `src/utils.ts` to fix the bug.',
+      workspaceDirectories: [tempDir],
+    });
+
+    const flat = flattenText(node);
+    expect(flat).not.toContain(OSC8_PREFIX);
+    expect(flat).toContain('src/utils.ts');
+  });
+
+  it('renders an absolute path that exists as a link', () => {
+    const abs = createTempFile('config.json');
+    const node = renderInlineNode({
+      text: `See ${abs} for settings.`,
+      workspaceDirectories: [tempDir],
+    });
+
+    const flat = flattenText(node);
+    expect(flat).toContain(OSC8_PREFIX);
+    expect(flat).toContain(abs);
+  });
+
+  it('renders an absolute path that does not exist as plain text', () => {
+    const node = renderInlineNode({
+      text: 'See /nonexistent/absolute/12345-file.txt for nothing.',
+      workspaceDirectories: [tempDir],
+    });
+
+    const flat = flattenText(node);
+    expect(flat).not.toContain(OSC8_PREFIX);
+    expect(flat).toContain('/nonexistent/absolute/12345-file.txt');
+  });
+
+  it('renders an absolute path that exists as a link even without workspaceDirectories', () => {
+    const abs = createTempFile('config.json');
+    const node = renderInlineNode({
+      text: `See ${abs} for settings.`,
+    });
+
+    const flat = flattenText(node);
+    expect(flat).toContain(OSC8_PREFIX);
+    expect(flat).toContain(abs);
+  });
+
+  it('links a relative path with trailing punctuation when the file exists', () => {
+    createTempFile('src/utils.ts');
+    const node = renderInlineNode({
+      text: 'Edit src/utils.ts. to fix the bug.',
+      workspaceDirectories: [tempDir],
+    });
+
+    const flat = flattenText(node);
+    expect(flat).toContain(OSC8_PREFIX);
+    // The trailing period must be stripped from the resolved path used in the
+    // OSC 8 link URI. Assert the link region ends with the file and NOT the
+    // trailing period.
+    const linkUri = flat.slice(flat.indexOf(OSC8_PREFIX));
+    expect(linkUri).toContain('src/utils.ts');
+    expect(linkUri).not.toContain('src/utils.ts.');
   });
 });
 

--- a/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
+++ b/packages/cli/src/ui/utils/InlineMarkdownRenderer.tsx
@@ -9,6 +9,7 @@ import { Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import stringWidth from 'string-width';
 import { debugLogger } from '@vybestack/llxprt-code-telemetry';
+import { createFilePathLink } from './terminalLinks.js';
 
 // Constants for Markdown parsing
 const BOLD_MARKER_LENGTH = 2; // For "**"
@@ -24,6 +25,7 @@ interface RenderInlineProps {
   bold?: boolean;
   italic?: boolean;
   wrap?: React.ComponentProps<typeof Text>['wrap'];
+  workspaceDirectories?: readonly string[];
 }
 
 function renderBoldNode(
@@ -214,25 +216,206 @@ function renderMatchedNode(
   return null;
 }
 
-export const RenderInlineInternal: React.FC<RenderInlineProps> = ({
-  text,
-  defaultColor,
-  bold,
-  italic,
-  wrap,
-}) => {
-  const baseColor = defaultColor ?? theme.text.primary;
-  // Early return for plain text without markdown or URLs
-  // Static regex for markdown marker detection - no dynamic parts
+/**
+ * Path-like token pattern. Tokens must contain at least one path separator, or
+ * be a `.`/`..` relative path prefix. Bounded quantifiers avoid sonarjs/slow-regex,
+ * and the pattern is passed via an identifier so it is not a static literal
+ * flagged by sonarjs/regular-expr.
+ */
+const FILE_PATH_PATTERN =
+  '(\\S{1,500}[/\\\\]\\S{1,500}|\\.\\.?[/\\\\]\\S{1,500})';
 
-  if (!/[*_~`<[]|https?:\/\//.test(text)) {
-    return (
-      <Text color={baseColor} bold={bold} italic={italic} wrap={wrap}>
-        {text}
-      </Text>
+const PATH_DELIMITERS = new Set([
+  '(',
+  ')',
+  '[',
+  ']',
+  '{',
+  '}',
+  "'",
+  '"',
+  '.',
+  ',',
+  ';',
+  ':',
+  '!',
+  '?',
+]);
+
+function renderPlainSegment(
+  textSlice: string,
+  baseColor: string,
+  key: string,
+  bold?: boolean,
+  italic?: boolean,
+): React.ReactNode {
+  return (
+    <Text key={key} color={baseColor} bold={bold} italic={italic}>
+      {textSlice}
+    </Text>
+  );
+}
+
+/**
+ * Strip leading and trailing sentence-punctuation delimiters from a candidate
+ * path token so that prose like `src/utils.ts.` or `(src/utils.ts)` resolves
+ * correctly. Uses a character-set lookup instead of a regex to avoid
+ * backtracking-vulnerable patterns.
+ */
+function trimPathDelimiters(candidate: string): string {
+  let start = 0;
+  let end = candidate.length;
+  while (start < end && PATH_DELIMITERS.has(candidate[start])) {
+    start++;
+  }
+  while (end > start && PATH_DELIMITERS.has(candidate[end - 1])) {
+    end--;
+  }
+  return candidate.slice(start, end);
+}
+
+/**
+ * Scan a plain-text segment for path-like tokens, resolving each against the
+ * workspace directories. Tokens that exist on disk become OSC 8 link nodes;
+ * intervening text becomes plain `<Text>` nodes. Returns null if no links were
+ * produced (caller should render a single plain segment instead).
+ */
+function collectLinkNodes(
+  textSegment: string,
+  workspaceDirectories: readonly string[],
+  baseColor: string,
+  keyPrefix: string,
+  bold?: boolean,
+  italic?: boolean,
+): React.ReactNode[] | null {
+  const pathRegex = new RegExp(FILE_PATH_PATTERN, 'g');
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let segmentIndex = 0;
+
+  while ((match = pathRegex.exec(textSegment)) !== null) {
+    const rawCandidate = match[0];
+    const candidate = trimPathDelimiters(rawCandidate);
+    const link = createFilePathLink(candidate, workspaceDirectories);
+    if (link === null) {
+      continue;
+    }
+
+    if (match.index > lastIndex) {
+      nodes.push(
+        renderPlainSegment(
+          textSegment.slice(lastIndex, match.index),
+          baseColor,
+          `${keyPrefix}-p${segmentIndex}`,
+          bold,
+          italic,
+        ),
+      );
+      segmentIndex++;
+    }
+
+    nodes.push(
+      <Text key={`${keyPrefix}-l${segmentIndex}`} color={theme.text.link}>
+        {link}
+      </Text>,
+    );
+    segmentIndex++;
+    lastIndex = match.index + rawCandidate.length;
+  }
+
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  if (lastIndex < textSegment.length) {
+    nodes.push(
+      renderPlainSegment(
+        textSegment.slice(lastIndex),
+        baseColor,
+        `${keyPrefix}-p${segmentIndex}`,
+        bold,
+        italic,
+      ),
     );
   }
 
+  return nodes;
+}
+
+/**
+ * Process a plain-text segment (text that is NOT inside markdown tokens) for
+ * file-path links. Path-like tokens are resolved against the workspace
+ * directories; absolute paths are resolved directly. Tokens that exist on disk
+ * are rendered as OSC 8 links, the remaining text renders as plain `<Text>`
+ * nodes.
+ */
+function processPlainTextForLinks(
+  textSegment: string,
+  workspaceDirectories: readonly string[] | undefined,
+  baseColor: string,
+  keyPrefix: string,
+  bold?: boolean,
+  italic?: boolean,
+): React.ReactNode {
+  const linkNodes = collectLinkNodes(
+    textSegment,
+    workspaceDirectories ?? [],
+    baseColor,
+    keyPrefix,
+    bold,
+    italic,
+  );
+  return (
+    linkNodes ??
+    renderPlainSegment(textSegment, baseColor, keyPrefix, bold, italic)
+  );
+}
+
+function renderPlainTextNodes(
+  text: string,
+  baseColor: string,
+  bold: boolean | undefined,
+  italic: boolean | undefined,
+  wrap: React.ComponentProps<typeof Text>['wrap'],
+): React.ReactNode {
+  return (
+    <Text color={baseColor} bold={bold} italic={italic} wrap={wrap}>
+      {text}
+    </Text>
+  );
+}
+
+/**
+ * Determine whether the text needs full markdown/path tokenization or can be
+ * rendered as a single plain-text node. When workspace directories are present,
+ * path separators (`/` `\`) also trigger tokenization so file paths can be linked.
+ * Without workspace directories we still tokenize for absolute paths
+ * (`/...` or `C:\...`) so direct paths can be linked.
+ */
+function needsTokenization(text: string, hasWorkspaceDirs: boolean): boolean {
+  if (/[*_~`<[]|https?:\/\//.test(text)) {
+    return true;
+  }
+  if (hasWorkspaceDirs) {
+    return /[/\\]/.test(text);
+  }
+  // Without workspace dirs, still tokenize for absolute paths (/... or C:\...)
+  return /(^|\s)[/\\]|[A-Za-z]:[\\/]/.test(text);
+}
+
+/**
+ * Tokenize `text` into inline markdown nodes and plain-text segments. Plain-text
+ * segments are additionally processed for file-path links when workspace
+ * directories are available.
+ */
+function tokenizeInlineMarkdown(
+  text: string,
+  workspaceDirectories: readonly string[] | undefined,
+  baseColor: string,
+  bold?: boolean,
+  italic?: boolean,
+): React.ReactNode[] {
   const nodes: React.ReactNode[] = [];
   let lastIndex = 0;
   // Inline markdown tokens. The bounded lazy quantifiers avoid sonarjs/slow-regex
@@ -246,9 +429,14 @@ export const RenderInlineInternal: React.FC<RenderInlineProps> = ({
   while ((match = inlineRegex.exec(text)) !== null) {
     if (match.index > lastIndex) {
       nodes.push(
-        <Text key={`t-${lastIndex}`} color={baseColor}>
-          {text.slice(lastIndex, match.index)}
-        </Text>,
+        processPlainTextForLinks(
+          text.slice(lastIndex, match.index),
+          workspaceDirectories,
+          baseColor,
+          `t-${lastIndex}`,
+          bold,
+          italic,
+        ),
       );
     }
 
@@ -282,15 +470,47 @@ export const RenderInlineInternal: React.FC<RenderInlineProps> = ({
 
   if (lastIndex < text.length) {
     nodes.push(
-      <Text key={`t-${lastIndex}`} color={baseColor}>
-        {text.slice(lastIndex)}
-      </Text>,
+      processPlainTextForLinks(
+        text.slice(lastIndex),
+        workspaceDirectories,
+        baseColor,
+        `t-${lastIndex}`,
+        bold,
+        italic,
+      ),
     );
   }
 
+  return nodes.filter((node) => node !== null);
+}
+
+export const RenderInlineInternal: React.FC<RenderInlineProps> = ({
+  text,
+  defaultColor,
+  bold,
+  italic,
+  wrap,
+  workspaceDirectories,
+}) => {
+  const baseColor = defaultColor ?? theme.text.primary;
+  const hasWorkspaceDirs =
+    workspaceDirectories !== undefined && workspaceDirectories.length > 0;
+
+  if (!needsTokenization(text, hasWorkspaceDirs)) {
+    return renderPlainTextNodes(text, baseColor, bold, italic, wrap);
+  }
+
+  const nodes = tokenizeInlineMarkdown(
+    text,
+    workspaceDirectories,
+    baseColor,
+    bold,
+    italic,
+  );
+
   return (
     <Text color={baseColor} bold={bold} italic={italic} wrap={wrap}>
-      {nodes.filter((node) => node !== null)}
+      {nodes}
     </Text>
   );
 };

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -18,6 +18,7 @@ interface MarkdownDisplayProps {
   availableTerminalHeight?: number;
   terminalWidth: number;
   renderMarkdown?: boolean;
+  workspaceDirectories?: readonly string[];
 }
 
 // Constants for Markdown parsing and rendering
@@ -33,6 +34,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   availableTerminalHeight,
   terminalWidth,
   renderMarkdown = true,
+  workspaceDirectories,
 }) => {
   const settings = useSettings();
   const responseColor = theme.text.response;
@@ -71,6 +73,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
     availableTerminalHeight,
     terminalWidth,
     responseColor,
+    workspaceDirectories,
   );
 
   if (finalCodeBlockState.inCodeBlock) {
@@ -231,6 +234,7 @@ function processLineEntry(
   tableHeaders: string[],
   tableRows: string[][],
   responseColor: string,
+  workspaceDirectories: readonly string[] | undefined,
   addContentBlock: (block: React.ReactNode) => void,
   applyLineResult: (result: LineProcessResult, index: number) => void,
 ): CodeBlockState {
@@ -272,6 +276,7 @@ function processLineEntry(
       tableRows,
       regexes,
       responseColor,
+      workspaceDirectories,
     ),
     index,
   );
@@ -285,6 +290,7 @@ function processLines(
   availableTerminalHeight: number | undefined,
   terminalWidth: number,
   responseColor: string,
+  workspaceDirectories: readonly string[] | undefined,
 ): ProcessLinesResult {
   const contentBlocks: React.ReactNode[] = [];
   const renderState = { lastLineEmpty: true };
@@ -343,6 +349,7 @@ function processLines(
       tableHeaders,
       tableRows,
       responseColor,
+      workspaceDirectories,
       addContentBlock,
       applyLineResult,
     );
@@ -369,6 +376,7 @@ interface LineProcessResult {
 function renderHeaderNode(
   headerMatch: RegExpMatchArray,
   responseColor: string,
+  workspaceDirectories: readonly string[] | undefined,
 ): React.ReactNode {
   const level = headerMatch[1].length;
   const headerText = headerMatch[2];
@@ -376,11 +384,21 @@ function renderHeaderNode(
     case 1:
     case 2:
       return (
-        <RenderInline text={headerText} defaultColor={theme.text.link} bold />
+        <RenderInline
+          text={headerText}
+          defaultColor={theme.text.link}
+          bold
+          workspaceDirectories={workspaceDirectories}
+        />
       );
     case 3:
       return (
-        <RenderInline text={headerText} defaultColor={responseColor} bold />
+        <RenderInline
+          text={headerText}
+          defaultColor={responseColor}
+          bold
+          workspaceDirectories={workspaceDirectories}
+        />
       );
     case 4:
       return (
@@ -388,10 +406,17 @@ function renderHeaderNode(
           text={headerText}
           defaultColor={theme.text.secondary}
           italic
+          workspaceDirectories={workspaceDirectories}
         />
       );
     default:
-      return <RenderInline text={headerText} defaultColor={responseColor} />;
+      return (
+        <RenderInline
+          text={headerText}
+          defaultColor={responseColor}
+          workspaceDirectories={workspaceDirectories}
+        />
+      );
   }
 }
 
@@ -403,6 +428,7 @@ function processTableLine(
   currentTableHeaders: string[],
   currentTableRows: string[][],
   responseColor: string,
+  workspaceDirectories: readonly string[] | undefined,
 ): LineProcessResult {
   const empty: LineProcessResult = {
     block: null,
@@ -448,7 +474,12 @@ function processTableLine(
     const block =
       line.trim().length > 0 ? (
         <Box key={key}>
-          <RenderInline text={line} defaultColor={responseColor} wrap="wrap" />
+          <RenderInline
+            text={line}
+            defaultColor={responseColor}
+            wrap="wrap"
+            workspaceDirectories={workspaceDirectories}
+          />
         </Box>
       ) : null;
     return {
@@ -464,11 +495,71 @@ function processTableLine(
   return empty;
 }
 
+function renderListItemBlock(
+  key: string,
+  itemText: string,
+  type: 'ul' | 'ol',
+  marker: string,
+  leadingWhitespace: string,
+  workspaceDirectories: readonly string[] | undefined,
+): React.ReactNode {
+  return (
+    <RenderListItem
+      key={key}
+      itemText={itemText}
+      type={type}
+      marker={marker}
+      leadingWhitespace={leadingWhitespace}
+      workspaceDirectories={workspaceDirectories}
+    />
+  );
+}
+
+function renderHrBlock(key: string): React.ReactNode {
+  return (
+    <Box key={key}>
+      <Text color={theme.ui.comment}>---</Text>
+    </Box>
+  );
+}
+
+function renderHeaderBlock(
+  key: string,
+  headerMatch: RegExpMatchArray,
+  responseColor: string,
+  workspaceDirectories: readonly string[] | undefined,
+): React.ReactNode {
+  return (
+    <Box key={key}>
+      {renderHeaderNode(headerMatch, responseColor, workspaceDirectories)}
+    </Box>
+  );
+}
+
+function renderParagraphBlock(
+  key: string,
+  line: string,
+  responseColor: string,
+  workspaceDirectories: readonly string[] | undefined,
+): React.ReactNode {
+  return (
+    <Box key={key}>
+      <RenderInline
+        text={line}
+        defaultColor={responseColor}
+        wrap="wrap"
+        workspaceDirectories={workspaceDirectories}
+      />
+    </Box>
+  );
+}
+
 function processNonTableLine(
   line: string,
   key: string,
   matches: LineMatchResult,
   responseColor: string,
+  workspaceDirectories: readonly string[] | undefined,
 ): LineProcessResult {
   const empty: LineProcessResult = {
     block: null,
@@ -480,23 +571,17 @@ function processNonTableLine(
   };
 
   if (matches.hrMatch) {
-    return {
-      ...empty,
-      block: (
-        <Box key={key}>
-          <Text color={theme.ui.comment}>---</Text>
-        </Box>
-      ),
-    };
+    return { ...empty, block: renderHrBlock(key) };
   }
 
   if (matches.headerMatch) {
     return {
       ...empty,
-      block: (
-        <Box key={key}>
-          {renderHeaderNode(matches.headerMatch, responseColor)}
-        </Box>
+      block: renderHeaderBlock(
+        key,
+        matches.headerMatch,
+        responseColor,
+        workspaceDirectories,
       ),
     };
   }
@@ -504,14 +589,13 @@ function processNonTableLine(
   if (matches.ulMatch) {
     return {
       ...empty,
-      block: (
-        <RenderListItem
-          key={key}
-          itemText={matches.ulMatch[3]}
-          type="ul"
-          marker={matches.ulMatch[2]}
-          leadingWhitespace={matches.ulMatch[1]}
-        />
+      block: renderListItemBlock(
+        key,
+        matches.ulMatch[3],
+        'ul',
+        matches.ulMatch[2],
+        matches.ulMatch[1],
+        workspaceDirectories,
       ),
     };
   }
@@ -519,14 +603,13 @@ function processNonTableLine(
   if (matches.olMatch) {
     return {
       ...empty,
-      block: (
-        <RenderListItem
-          key={key}
-          itemText={matches.olMatch[3]}
-          type="ol"
-          marker={matches.olMatch[2]}
-          leadingWhitespace={matches.olMatch[1]}
-        />
+      block: renderListItemBlock(
+        key,
+        matches.olMatch[3],
+        'ol',
+        matches.olMatch[2],
+        matches.olMatch[1],
+        workspaceDirectories,
       ),
     };
   }
@@ -537,11 +620,7 @@ function processNonTableLine(
 
   return {
     ...empty,
-    block: (
-      <Box key={key}>
-        <RenderInline text={line} defaultColor={responseColor} wrap="wrap" />
-      </Box>
-    ),
+    block: renderParagraphBlock(key, line, responseColor, workspaceDirectories),
   };
 }
 
@@ -556,6 +635,7 @@ function processLine(
   currentTableRows: string[][],
   regexes: MarkdownRegexes,
   responseColor: string,
+  workspaceDirectories: readonly string[] | undefined,
 ): LineProcessResult {
   if (matches.tableRowMatch && !currentInTable) {
     if (
@@ -570,12 +650,18 @@ function processLine(
         currentTableHeaders,
         currentTableRows,
         responseColor,
+        workspaceDirectories,
       );
     }
     return {
       block: (
         <Box key={key}>
-          <RenderInline text={line} defaultColor={responseColor} wrap="wrap" />
+          <RenderInline
+            text={line}
+            defaultColor={responseColor}
+            wrap="wrap"
+            workspaceDirectories={workspaceDirectories}
+          />
         </Box>
       ),
       emptyLine: false,
@@ -595,10 +681,17 @@ function processLine(
       currentTableHeaders,
       currentTableRows,
       responseColor,
+      workspaceDirectories,
     );
   }
 
-  return processNonTableLine(line, key, matches, responseColor);
+  return processNonTableLine(
+    line,
+    key,
+    matches,
+    responseColor,
+    workspaceDirectories,
+  );
 }
 
 interface RenderCodeBlockProps {
@@ -684,6 +777,7 @@ interface RenderListItemProps {
   type: 'ul' | 'ol';
   marker: string;
   leadingWhitespace?: string;
+  workspaceDirectories?: readonly string[];
 }
 
 const RenderListItemInternal: React.FC<RenderListItemProps> = ({
@@ -691,6 +785,7 @@ const RenderListItemInternal: React.FC<RenderListItemProps> = ({
   type,
   marker,
   leadingWhitespace = '',
+  workspaceDirectories,
 }) => {
   const prefix = type === 'ol' ? `${marker}. ` : `${marker} `;
   const prefixWidth = prefix.length;
@@ -710,6 +805,7 @@ const RenderListItemInternal: React.FC<RenderListItemProps> = ({
           text={itemText}
           defaultColor={listResponseColor}
           wrap="wrap"
+          workspaceDirectories={workspaceDirectories}
         />
       </Box>
     </Box>

--- a/packages/cli/src/ui/utils/terminalLinks.test.ts
+++ b/packages/cli/src/ui/utils/terminalLinks.test.ts
@@ -4,8 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
-import { createOsc8Link } from './terminalLinks.js';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createFilePathLink, createOsc8Link } from './terminalLinks.js';
+
+const OSC8_OPEN = '\x1b]8;;';
+const BEL = '\x07';
+
+/**
+ * Extract the visible label from an OSC 8 link string (the text between the
+ * opening `ESC ]8;;URL BEL` and the closing `ESC ]8;; BEL`).
+ */
+function extractOsc8Label(link: string): string {
+  const urlEnd = link.indexOf(BEL, OSC8_OPEN.length);
+  const closeStart = link.indexOf(OSC8_OPEN, urlEnd + 1);
+  return link.slice(urlEnd + 1, closeStart);
+}
 
 describe('createOsc8Link', () => {
   it('uses BEL terminators (not ST) for OSC-8 links', () => {
@@ -13,5 +30,103 @@ describe('createOsc8Link', () => {
 
     expect(link).toBe('\x1b]8;;https://example.com\x07Click\x1b]8;;\x07');
     expect(link).not.toContain('\x1b\\');
+  });
+});
+
+describe('createFilePathLink', () => {
+  let tempDirs: string[];
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDirs = [];
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  function createTempDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'filepath-link-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function createTempFile(relativePath: string): string {
+    const fullPath = path.join(tempDir, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, 'test content');
+    return fullPath;
+  }
+
+  it('returns an OSC 8 link for an absolute path that exists', () => {
+    const filePath = createTempFile('existing.txt');
+    const link = createFilePathLink(filePath, []);
+
+    expect(link).not.toBeNull();
+    expect(link).toContain('\x1b]8;;');
+    // The label is the path itself
+    expect(link).toContain(filePath);
+    // The URL is a file:// URI pointing at the absolute path
+    expect(link).toContain(pathToFileURL(filePath).href);
+  });
+
+  it('returns null for a non-existent absolute path', () => {
+    const link = createFilePathLink(
+      '/nonexistent/path/to/missing-file-12345.txt',
+      [],
+    );
+    expect(link).toBeNull();
+  });
+
+  it('returns null for a plain word with no path separators', () => {
+    const link = createFilePathLink('hello', [tempDir]);
+    expect(link).toBeNull();
+  });
+
+  it('resolves a relative path against a workspace directory that contains the file', () => {
+    createTempFile('src/index.ts');
+    const link = createFilePathLink('src/index.ts', [tempDir]);
+
+    expect(link).not.toBeNull();
+    const resolved = path.resolve(tempDir, 'src/index.ts');
+    expect(link).toContain(resolved);
+    expect(link).toContain(pathToFileURL(resolved).href);
+  });
+
+  it('returns null when the relative path does not exist in any workspace directory', () => {
+    const link = createFilePathLink('nope/missing.ts', [tempDir]);
+    expect(link).toBeNull();
+  });
+
+  it('returns null when workspaceDirectories is empty for a relative path', () => {
+    const link = createFilePathLink('src/index.ts', []);
+    expect(link).toBeNull();
+  });
+
+  it('tries multiple workspace directories and links against the first match', () => {
+    const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'other-ws-'));
+    tempDirs.push(otherDir);
+    const nested = path.join(otherDir, 'config.yaml');
+    fs.writeFileSync(nested, 'config');
+
+    const link = createFilePathLink('config.yaml', [tempDir, otherDir]);
+
+    expect(link).not.toBeNull();
+    expect(link).toContain(nested);
+    expect(link).toContain(pathToFileURL(nested).href);
+  });
+
+  it('keeps the ORIGINAL candidate as the visible label for a relative path', () => {
+    createTempFile('src/index.ts');
+    const link = createFilePathLink('src/index.ts', [tempDir]);
+
+    expect(link).not.toBeNull();
+    // The visible label (between the escape sequences) must be the original
+    // relative candidate, NOT the absolute resolved path.
+    const label = extractOsc8Label(link ?? '');
+    expect(label).toBe('src/index.ts');
   });
 });

--- a/packages/cli/src/ui/utils/terminalLinks.ts
+++ b/packages/cli/src/ui/utils/terminalLinks.ts
@@ -12,10 +12,97 @@
  * intentionally use BEL for compatibility.
  */
 
+import path from 'node:path';
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { ESC } from './input.js';
 
 const BEL = '\x07';
 
+const FILE_EXTENSION_PATTERN = /\.[A-Za-z0-9]{1,10}$/;
+
+const LINK_CACHE_MAX = 500;
+const linkCache = new Map<string, string | null>();
+
 export function createOsc8Link(label: string, url: string): string {
   return `${ESC}]8;;${url}${BEL}${label}${ESC}]8;;${BEL}`;
+}
+
+/**
+ * Heuristic check: does the candidate look like a plausible file path? It must
+ * contain a path separator, or start with a `.`/`..` relative marker, or have a
+ * file extension. This avoids touching plain words like "hello".
+ */
+function looksLikeFilePath(candidate: string): boolean {
+  if (candidate.includes('/') || candidate.includes('\\')) {
+    return true;
+  }
+  if (candidate.startsWith('..') || candidate.startsWith('.')) {
+    return true;
+  }
+  return FILE_EXTENSION_PATTERN.test(candidate);
+}
+
+/**
+ * Convert an absolute filesystem path into a `file://` URI using Node's
+ * built-in `pathToFileURL`, which correctly handles Windows drive letters
+ * and special characters/spaces.
+ */
+function toFileUri(absolutePath: string): string {
+  try {
+    return pathToFileURL(absolutePath).href;
+  } catch {
+    return absolutePath;
+  }
+}
+
+/**
+ * Attempts to resolve a candidate string as a file path and returns an
+ * OSC 8 link if the path exists on disk. Returns null otherwise.
+ *
+ * - Absolute paths are checked directly.
+ * - Relative paths are resolved against each workspace directory until
+ *   one resolves to an existing file.
+ *
+ * Results are memoized in a bounded LRU-style cache to avoid repeated
+ * synchronous filesystem probes during incremental rendering.
+ */
+export function createFilePathLink(
+  candidate: string,
+  workspaceDirectories: readonly string[],
+): string | null {
+  if (!looksLikeFilePath(candidate)) {
+    return null;
+  }
+
+  const cacheKey = `${candidate}::${workspaceDirectories.join(',')}`;
+  if (linkCache.has(cacheKey)) {
+    return linkCache.get(cacheKey) ?? null;
+  }
+
+  let result: string | null = null;
+
+  if (path.isAbsolute(candidate)) {
+    if (fs.existsSync(candidate)) {
+      result = createOsc8Link(candidate, toFileUri(candidate));
+    }
+  } else {
+    for (const dir of workspaceDirectories) {
+      const resolved = path.resolve(dir, candidate);
+      if (fs.existsSync(resolved)) {
+        result = createOsc8Link(candidate, toFileUri(resolved));
+        break;
+      }
+    }
+  }
+
+  if (linkCache.size >= LINK_CACHE_MAX) {
+    const firstKey = linkCache.keys().next().value;
+    if (firstKey !== undefined) {
+      linkCache.delete(firstKey);
+    }
+  }
+  linkCache.set(cacheKey, result);
+
+  return result;
 }


### PR DESCRIPTION
## Summary

Detects file paths (both absolute and relative) in AI response text and renders them as clickable OSC 8 terminal hyperlinks. When a user clicks a linked path, it opens in the OS-associated application for that file type.

Resolves #2848.

## What Changed

### Path detection and linking
- **`terminalLinks.ts`**: New `createFilePathLink()` function that:
  - Accepts a candidate string and workspace directories
  - Checks whether the candidate looks like a file path (must contain a path separator, start with `.`/`..`, or have a file extension)
  - For absolute paths: checks existence directly via `fs.existsSync`
  - For relative paths: resolves against each workspace directory until one matches an existing file
  - Returns an OSC 8 link via the existing `createOsc8Link()` helper, or `null` if the path does not exist
  - Results are memoized in a bounded LRU-style cache (max 500 entries) to avoid repeated synchronous filesystem probes during incremental/streaming rendering

### Inline markdown renderer
- **`InlineMarkdownRenderer.tsx`**: Plain-text segments between markdown tokens are scanned for path-like tokens. When a token resolves to an existing file, it is rendered as a clickable link:
  - Trailing sentence punctuation (`. , ; : ! ? ( ) [ ] { } " "`) is stripped from candidates before resolution
  - The bold/italic styling from the parent context is preserved on intervening plain-text nodes
  - Paths inside inline code (backticks) and markdown links are NOT linked (they render as before)
  - The early-return fast path now also checks for path separators when workspace directories are present

### Markdown display threading
- **`MarkdownDisplay.tsx`**: A new `workspaceDirectories` prop is threaded through the rendering pipeline (paragraphs, headings of all levels, list items, and table-adjacent text). Table cell rendering was left unchanged (out of scope).

### Shared workspace resolution hook
- **`useResolvedWorkspaceDirectories.ts`** (new file): A shared, memoized React hook that resolves workspace directories from the active CLI runtime when an explicit prop is not provided. This eliminates the duplicated try/catch resolution logic that previously existed in both `AiMessage` and `AiMessageContent`.
- **`AiMessage.tsx`** and **`AiMessageContent.tsx`**: Both now use the shared hook.

## Test Coverage

### `terminalLinks.test.ts` (9 tests)
- Absolute path that exists → OSC 8 link with correct `file://` URI
- Absolute path that does not exist → null
- Plain word with no separator → null
- Relative path resolved against workspace dir → link with resolved absolute path
- Relative path not found in any workspace dir → null
- Empty workspace directories for relative path → null
- Multiple workspace directories → first match wins
- Relative path label is the ORIGINAL candidate (not the resolved absolute path)
- (removed redundant trailing-period test — stripping is tested at the renderer level)

### `InlineMarkdownRenderer.test.ts` (19 tests)
- All existing markdown tests still pass (bold, italic, strikethrough, code, links, underline, precedence)
- Relative file path in prose → rendered as OSC 8 link
- Relative path without workspaceDirectories → plain text (no link)
- File path inside inline code → plain text (not linked)
- Absolute path that exists → link
- Absolute path that does not exist → plain text
- Absolute path exists without workspaceDirectories → link
- Relative path with trailing punctuation → link with punctuation stripped from the URI

## Verification

- `npx vitest run` for affected test files: **28/28 pass**
- `npx eslint` on all changed files: **clean**
- `npx tsc --noEmit` (CLI package): **clean**
- `npx tsc` build (CLI package): **clean**
- `npx prettier --check`: **clean**
- 10 `MarkdownDisplay.test.tsx` snapshot failures are **pre-existing on main** (verified via `git stash` test on clean main — line-number rendering bug unrelated to this change)

## Notes

- The LRU cache uses `fs.existsSync` (synchronous). Since results are cached after the first probe, the impact is minimal during streaming/incremental rendering where the same paths appear repeatedly. The cache is bounded at 500 entries.
- `pathToFileURL` is wrapped in try/catch to handle edge cases on certain platforms gracefully, falling back to the raw absolute path in the URI.