### PR TITLE
Deferred path-migration review maintenance (Fixes #2647)

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -382,7 +382,7 @@ Extension commands use the format `/<extension-name>/<command-name>` to avoid co
 
 At commands include file content in your prompt. Type `@` followed by a file path:
 
-```
+```text
 @src/main.ts explain this file
 @docs/README.md what does this project do?
 ```
@@ -400,7 +400,7 @@ If a file path is invalid or the file doesn't exist, LLxprt shows an error and t
 
 Prefix a command with `!` to run it in your shell and include the output in the conversation:
 
-```
+```bash
 !ls -la
 !git log --oneline -5
 !cat package.json

--- a/docs/debug-logging.md
+++ b/docs/debug-logging.md
@@ -268,7 +268,7 @@ llxprt --debug llxprt:*
 
 Default location: `<log>/debug/` (see [Application Directories](./reference/application-directories.md)).
 
-- Files are named by date: `debug-YYYY-MM-DD.jsonl`
+- Files are named by process id: `llxprt-debug-<PID>.jsonl`
 - Check permissions on the directory
 - Verify output target includes "file"
 

--- a/docs/migration/approval-mode-to-policies.md
+++ b/docs/migration/approval-mode-to-policies.md
@@ -258,7 +258,7 @@ Add to your [user `settings.json`](../reference/application-directories.md):
 }
 ```
 
-**Important:** Use absolute paths, not `~` or relative paths. The example shows the macOS config-directory location; on Linux use `~/.config/llxprt-code/my-policy.toml` and on Windows use `%APPDATA%\llxprt-code\Config\my-policy.toml`. See [Application Directories](../reference/application-directories.md) for the canonical paths on each OS.
+**Important:** Use absolute paths, not `~` or relative paths. The example shows the macOS config-directory location; on Linux use `/home/yourname/.config/llxprt-code/my-policy.toml` and on Windows use `%APPDATA%\llxprt-code\Config\my-policy.toml`. See [Application Directories](../reference/application-directories.md) for the canonical paths on each OS.
 
 ### Step 5: Verify and Test
 

--- a/packages/a2a-server/vitest.config.ts
+++ b/packages/a2a-server/vitest.config.ts
@@ -112,8 +112,8 @@ export default defineConfig({
     // `vi.mock` factory that captured a top-level `const`, causing a TDZ
     // ReferenceError under Vitest. They now use production dependency
     // injection (`homeDir` option) instead of `node:os` mocking, making them
-    // compatible with BOTH Bun and Vitest. No test files are excluded.
-    exclude: ['**/node_modules/**', '**/dist/**'],
+    // compatible with BOTH Bun and Vitest. No test files are excluded beyond
+    // Vitest defaults.
     coverage: {
       provider: 'v8',
       reportsDirectory: './coverage',

--- a/packages/agents/src/core/TodoContinuationService.propagation.test.ts
+++ b/packages/agents/src/core/TodoContinuationService.propagation.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/agents/src/core/TodoContinuationService.propagation.test.ts
+++ b/packages/agents/src/core/TodoContinuationService.propagation.test.ts
@@ -32,7 +32,7 @@ function makeConfig(sessionId: string): Config {
 }
 
 describe('TodoContinuationService — resolver-propagation (real store/disk)', () => {
-  let tempDir: string;
+  let tempDir = '';
   let service: TodoContinuationService;
 
   beforeEach(() => {
@@ -49,7 +49,7 @@ describe('TodoContinuationService — resolver-propagation (real store/disk)', (
   });
 
   afterEach(() => {
-    if (tempDir !== undefined) {
+    if (tempDir !== '') {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });

--- a/packages/agents/src/core/TodoContinuationService.propagation.test.ts
+++ b/packages/agents/src/core/TodoContinuationService.propagation.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral integration test: verifies that TodoContinuationService correctly
+ * propagates on-disk task-list state through the real LocalTodoStore, the real
+ * todoDataDirResolver, and a real TodoReminderService. No fs/store mocks — the
+ * test writes real persisted state to a temp directory and asserts the OUTCOMES
+ * (returned snapshots and reminder text) reflect that persisted state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { TodoContinuationService } from './TodoContinuationService.js';
+import { TodoReminderService } from '@vybestack/llxprt-code-core/services/todo-reminder-service.js';
+import { LocalTodoStore } from '@vybestack/llxprt-code-tools';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { Todo } from '@vybestack/llxprt-code-tools';
+
+const SESSION_ID = 'propagation-session';
+
+function makeConfig(sessionId: string): Config {
+  return {
+    getSessionId: vi.fn().mockReturnValue(sessionId),
+  } as unknown as Config;
+}
+
+describe('TodoContinuationService — resolver-propagation (real store/disk)', () => {
+  let tempDir: string;
+  let service: TodoContinuationService;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'todo-continuation-propagation-'),
+    );
+    const reminderService = new TodoReminderService();
+    service = new TodoContinuationService({
+      config: makeConfig(SESSION_ID),
+      todoReminderService: reminderService,
+      complexitySuggestionCooldown: 300000,
+      todoDataDirResolver: () => tempDir,
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('readTodoSnapshot returns what was written to disk via the real store', async () => {
+    const store = new LocalTodoStore(SESSION_ID, {
+      dataDirResolver: () => tempDir,
+    });
+    const todos: Todo[] = [
+      {
+        id: 'prop-1',
+        content: 'Propagation todo one',
+        status: 'pending',
+      },
+      {
+        id: 'prop-2',
+        content: 'Propagation todo two',
+        status: 'in_progress',
+      },
+    ];
+    await store.writeTodos(todos);
+
+    const snapshot = await service.readTodoSnapshot();
+
+    expect(snapshot).toHaveLength(2);
+    expect(snapshot.map((t) => t.id)).toStrictEqual(['prop-1', 'prop-2']);
+    expect(snapshot.map((t) => t.content)).toStrictEqual([
+      'Propagation todo one',
+      'Propagation todo two',
+    ]);
+  });
+
+  it('getTodoReminderForCurrentState reflects persisted empty state with a create-list reminder', async () => {
+    // No items written yet — empty list on disk.
+    const result = await service.getTodoReminderForCurrentState();
+
+    expect(result.todos).toStrictEqual([]);
+    expect(result.activeTodos).toStrictEqual([]);
+    // Empty list produces a create-list reminder.
+    expect(result.reminder).not.toBeNull();
+    expect(result.reminder).toContain(
+      'Please create a todo list before continuing.',
+    );
+  });
+
+  it('getTodoReminderForCurrentState produces an update reminder when active todos exist on disk', async () => {
+    const store = new LocalTodoStore(SESSION_ID, {
+      dataDirResolver: () => tempDir,
+    });
+    const activeTodo: Todo = {
+      id: 'active-1',
+      content: 'Active work item',
+      status: 'in_progress',
+    };
+    await store.writeTodos([activeTodo]);
+
+    const result = await service.getTodoReminderForCurrentState();
+
+    expect(result.todos.map((t) => t.id)).toStrictEqual(['active-1']);
+    // in_progress items are active.
+    expect(result.activeTodos.map((t) => t.id)).toStrictEqual(['active-1']);
+    expect(result.reminder).not.toBeNull();
+    expect(result.reminder).toContain('Update the active todo');
+  });
+
+  it('writing new todos via the store changes the reminder outcome', async () => {
+    // Initially empty: create-list reminder.
+    const before = await service.getTodoReminderForCurrentState();
+    expect(before.reminder).toContain(
+      'Please create a todo list before continuing.',
+    );
+
+    // Now persist an active item and re-read.
+    const store = new LocalTodoStore(SESSION_ID, {
+      dataDirResolver: () => tempDir,
+    });
+    await store.writeTodos([
+      {
+        id: 'new-1',
+        content: 'Newly persisted todo',
+        status: 'pending',
+      },
+    ]);
+
+    const after = await service.getTodoReminderForCurrentState();
+
+    expect(after.todos.map((t) => t.id)).toStrictEqual(['new-1']);
+    expect(after.activeTodos.map((t) => t.id)).toStrictEqual(['new-1']);
+    // Reminder switched from create-list to update.
+    expect(after.reminder).not.toBeNull();
+    expect(after.reminder).toContain('Update the active todo');
+  });
+});

--- a/packages/agents/src/core/TodoContinuationService.propagation.test.ts
+++ b/packages/agents/src/core/TodoContinuationService.propagation.test.ts
@@ -49,7 +49,9 @@ describe('TodoContinuationService — resolver-propagation (real store/disk)', (
   });
 
   afterEach(() => {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    if (tempDir !== undefined) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('readTodoSnapshot returns what was written to disk via the real store', async () => {

--- a/packages/cli/src/config/legacyCopyEngine.test.ts
+++ b/packages/cli/src/config/legacyCopyEngine.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/cli/src/config/legacyCopyEngine.test.ts
+++ b/packages/cli/src/config/legacyCopyEngine.test.ts
@@ -83,33 +83,38 @@ describe('copyDirFiltered', () => {
     );
   });
 
-  it('terminates when a symlink cycle is present (visited set guards recursion)', () => {
-    // Build a directory that contains a symlink cycle pointing at an ancestor.
-    fs.mkdirSync(path.join(src, 'loop'));
-    fs.symlinkSync(src, path.join(src, 'loop', 'back-to-root'));
+  it.skipIf(process.platform === 'win32')(
+    'clones a directory symlink without following it into a cycle',
+    () => {
+      // Build a directory that contains a symlink pointing at an ancestor.
+      fs.mkdirSync(path.join(src, 'loop'));
+      fs.symlinkSync(src, path.join(src, 'loop', 'back-to-root'));
 
-    const errors: string[] = [];
-    // Without cycle detection this would recurse infinitely. The visited set
-    // is what prevents that; the call must return promptly.
-    const count = copyDirFiltered(
-      src,
-      dest,
-      src,
-      dest,
-      new Set<string>(),
-      errors,
-      logger,
-    );
+      const errors: string[] = [];
+      // Directory symlinks return isDirectory() === false from readdir
+      // Dirent, so copyDirFiltered clones the symlink entry rather than
+      // recursing into it. The function must return promptly without
+      // infinite recursion.
+      const count = copyDirFiltered(
+        src,
+        dest,
+        src,
+        dest,
+        new Set<string>(),
+        errors,
+        logger,
+      );
 
-    // The symlink entry is cloned (counted), but the directory cycle is not
-    // followed — so recursion terminates without infinite looping.
-    expect(count).toBe(1);
-    expect(errors).toHaveLength(0);
-    // The symlink was created at the destination.
-    expect(
-      fs.lstatSync(path.join(dest, 'loop', 'back-to-root')).isSymbolicLink(),
-    ).toBe(true);
-  });
+      // The symlink entry is cloned (counted), but its target directory
+      // is not followed — so recursion terminates without infinite looping.
+      expect(count).toBe(1);
+      expect(errors).toHaveLength(0);
+      // The symlink was created at the destination.
+      expect(
+        fs.lstatSync(path.join(dest, 'loop', 'back-to-root')).isSymbolicLink(),
+      ).toBe(true);
+    },
+  );
 });
 
 describe('copyDirFilteredWithInterceptor', () => {

--- a/packages/cli/src/config/legacyCopyEngine.test.ts
+++ b/packages/cli/src/config/legacyCopyEngine.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral self-tests for the recursive filtered-copy primitives in
+ * legacyCopyEngine. Real temp directories and real filesystem operations —
+ * no mocking of the module under test. These lock in the legacy-path guard
+ * semantics: existing canonical entries are never overwritten (COPYFILE_EXCL),
+ * and symlink cycles are detected so recursion terminates.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
+
+import {
+  copyDirFiltered,
+  copyDirFilteredWithInterceptor,
+} from './legacyCopyEngine.js';
+
+const logger = new DebugLogger('legacy-copy-engine-test');
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'llxprt-copy-engine-test-'));
+}
+
+describe('copyDirFiltered', () => {
+  let src: string;
+  let dest: string;
+
+  beforeEach(() => {
+    src = makeTempDir();
+    dest = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(src, { recursive: true, force: true });
+    fs.rmSync(dest, { recursive: true, force: true });
+  });
+
+  it('copies a nested directory tree so all files exist at the destination', () => {
+    // Build a source tree: src/a.txt and src/sub/b.txt
+    fs.mkdirSync(path.join(src, 'sub'));
+    fs.writeFileSync(path.join(src, 'a.txt'), 'alpha');
+    fs.writeFileSync(path.join(src, 'sub', 'b.txt'), 'beta');
+
+    const errors: string[] = [];
+    const count = copyDirFiltered(
+      src,
+      dest,
+      src,
+      dest,
+      new Set<string>(),
+      errors,
+      logger,
+    );
+
+    // Two files copied.
+    expect(count).toBe(2);
+    expect(errors).toHaveLength(0);
+    expect(fs.readFileSync(path.join(dest, 'a.txt'), 'utf8')).toBe('alpha');
+    expect(fs.readFileSync(path.join(dest, 'sub', 'b.txt'), 'utf8')).toBe(
+      'beta',
+    );
+  });
+
+  it('does not overwrite an existing destination file (COPYFILE_EXCL)', () => {
+    fs.writeFileSync(path.join(src, 'a.txt'), 'source-content');
+    // Pre-create the canonical destination with different content.
+    fs.writeFileSync(path.join(dest, 'a.txt'), 'canonical-wins');
+
+    const errors: string[] = [];
+    copyDirFiltered(src, dest, src, dest, new Set<string>(), errors, logger);
+
+    // The existing canonical content must be preserved.
+    expect(fs.readFileSync(path.join(dest, 'a.txt'), 'utf8')).toBe(
+      'canonical-wins',
+    );
+  });
+
+  it('terminates when a symlink cycle is present (visited set guards recursion)', () => {
+    // Build a directory that contains a symlink cycle pointing at an ancestor.
+    fs.mkdirSync(path.join(src, 'loop'));
+    fs.symlinkSync(src, path.join(src, 'loop', 'back-to-root'));
+
+    const errors: string[] = [];
+    // Without cycle detection this would recurse infinitely. The visited set
+    // is what prevents that; the call must return promptly.
+    const count = copyDirFiltered(
+      src,
+      dest,
+      src,
+      dest,
+      new Set<string>(),
+      errors,
+      logger,
+    );
+
+    // The symlink entry is cloned (counted), but the directory cycle is not
+    // followed — so recursion terminates without infinite looping.
+    expect(count).toBe(1);
+    expect(errors).toHaveLength(0);
+    // The symlink was created at the destination.
+    expect(
+      fs.lstatSync(path.join(dest, 'loop', 'back-to-root')).isSymbolicLink(),
+    ).toBe(true);
+  });
+});
+
+describe('copyDirFilteredWithInterceptor', () => {
+  let src: string;
+  let dest: string;
+
+  beforeEach(() => {
+    src = makeTempDir();
+    dest = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(src, { recursive: true, force: true });
+    fs.rmSync(dest, { recursive: true, force: true });
+  });
+
+  it('invokes the file interceptor for each regular file and copies its content', () => {
+    fs.mkdirSync(path.join(src, 'nested'));
+    fs.writeFileSync(path.join(src, 'one.txt'), '1');
+    fs.writeFileSync(path.join(src, 'nested', 'two.txt'), '2');
+
+    const seen: Array<{ srcPath: string; destPath: string }> = [];
+    const errors: string[] = [];
+    // The interceptor writes the destination file itself (mirroring how the
+    // profiles normalization publishes normalized content).
+    const count = copyDirFilteredWithInterceptor(
+      src,
+      dest,
+      src,
+      dest,
+      new Set<string>(),
+      errors,
+      (srcPath, destPath) => {
+        seen.push({ srcPath, destPath });
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        fs.copyFileSync(srcPath, destPath, fs.constants.COPYFILE_EXCL);
+        return 1;
+      },
+      logger,
+    );
+
+    expect(count).toBe(2);
+    expect(seen).toHaveLength(2);
+    // Both files were written through the interceptor.
+    expect(fs.readFileSync(path.join(dest, 'one.txt'), 'utf8')).toBe('1');
+    expect(fs.readFileSync(path.join(dest, 'nested', 'two.txt'), 'utf8')).toBe(
+      '2',
+    );
+  });
+
+  it('skips a regular file whose destination already exists (excluded-entry handling)', () => {
+    fs.writeFileSync(path.join(src, 'exists.txt'), 'from-source');
+    // Pre-existing destination must NOT be overwritten.
+    fs.writeFileSync(path.join(dest, 'exists.txt'), 'already-here');
+
+    const seen: Array<{ srcPath: string; destPath: string }> = [];
+    const errors: string[] = [];
+    copyDirFilteredWithInterceptor(
+      src,
+      dest,
+      src,
+      dest,
+      new Set<string>(),
+      errors,
+      (srcPath, destPath) => {
+        seen.push({ srcPath, destPath });
+        return 0;
+      },
+      logger,
+    );
+
+    // The interceptor is NOT called for the pre-existing destination file.
+    expect(seen).toHaveLength(0);
+    expect(fs.readFileSync(path.join(dest, 'exists.txt'), 'utf8')).toBe(
+      'already-here',
+    );
+  });
+});

--- a/packages/cli/src/config/pathMigration.freshStart.test.ts
+++ b/packages/cli/src/config/pathMigration.freshStart.test.ts
@@ -486,25 +486,28 @@ describe('runStartupMigrationWithPath — hard-link atomic publish', () => {
     expect(canonical.provider).toBe('openai');
   });
 
-  it('normalized publish preserves source file mode', () => {
-    const legacyProfile = {
-      version: 1,
-      provider: 'anthropic',
-      model: 'glm-5.2',
-      ephemeralSettings: {},
-    };
-    writeFiles(env.legacyDir, {
-      'profiles/sec.json': JSON.stringify(legacyProfile),
-      'settings.json': '{}',
-    });
-    // Set source to 0600.
-    fs.chmodSync(path.join(env.legacyDir, 'profiles/sec.json'), 0o600);
+  it.skipIf(process.platform === 'win32')(
+    'normalized publish preserves source file mode',
+    () => {
+      const legacyProfile = {
+        version: 1,
+        provider: 'anthropic',
+        model: 'glm-5.2',
+        ephemeralSettings: {},
+      };
+      writeFiles(env.legacyDir, {
+        'profiles/sec.json': JSON.stringify(legacyProfile),
+        'settings.json': '{}',
+      });
+      // Set source to 0600.
+      fs.chmodSync(path.join(env.legacyDir, 'profiles/sec.json'), 0o600);
 
-    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+      runStartupMigrationWithPath(env.legacyDir, env.destinations);
 
-    const stat = fs.statSync(
-      path.join(env.destinations.configDir, 'profiles/sec.json'),
-    );
-    expect(stat.mode & 0o777).toBe(0o600);
-  });
+      const stat = fs.statSync(
+        path.join(env.destinations.configDir, 'profiles/sec.json'),
+      );
+      expect(stat.mode & 0o777).toBe(0o600);
+    },
+  );
 });

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="vitest" />
 import { existsSync } from 'node:fs';
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
@@ -224,7 +224,7 @@ const sharedResolve = {
 };
 
 const sharedTestOptions = {
-  exclude: ['**/node_modules/**', '**/dist/**'],
+  exclude: [...configDefaults.exclude],
   globals: true,
   silent: true,
   reporters: ['default', 'junit'],
@@ -286,7 +286,7 @@ export default defineConfig({
   resolve: sharedResolve,
   test: {
     include: INCLUDE_PATTERNS,
-    exclude: baseExcludePatterns,
+    exclude: [...configDefaults.exclude, ...baseExcludePatterns],
     environment: 'jsdom',
     globals: true,
     reporters: ['default', 'junit'],

--- a/packages/cli/vitest.test-groups.ts
+++ b/packages/cli/vitest.test-groups.ts
@@ -477,4 +477,4 @@ export function buildTestGroups(
  * The expected total selected file count after integrating the v0.11.0 test set.
  * Exported for behavioral tests to assert against an independent oracle.
  */
-export const SELECTED_FILE_COUNT: number = 508;
+export const SELECTED_FILE_COUNT: number = 509;

--- a/packages/core/src/config/toolRegistryFactory.ts
+++ b/packages/core/src/config/toolRegistryFactory.ts
@@ -43,7 +43,7 @@ import { CoreIdeServiceAdapter } from '../tools-adapters/CoreIdeServiceAdapter.j
 import { CoreLspServiceAdapter } from '../tools-adapters/CoreLspServiceAdapter.js';
 import { CoreToolKeyStorageAdapter } from '../tools-adapters/CoreToolKeyStorageAdapter.js';
 import { CoreSettingsServiceAdapter } from '../tools-adapters/CoreSettingsServiceAdapter.js';
-import { CoreStorageServiceAdapter } from '../tools-adapters/CoreStorageServiceAdapter.js';
+import { coreStorageServiceAdapter } from '../tools-adapters/CoreStorageServiceAdapter.js';
 import { CoreMessageBusAdapter } from '../tools-adapters/CoreMessageBusAdapter.js';
 import { CoreShellToolHostAdapter } from '../tools-adapters/CoreShellToolHostAdapter.js';
 import { CoreSubagentServiceAdapter } from '../tools-adapters/CoreSubagentServiceAdapter.js';
@@ -347,7 +347,7 @@ function registerStandardTools(
   const lspServiceAdapter = new CoreLspServiceAdapter(config);
   const toolKeyStorageAdapter = new CoreToolKeyStorageAdapter();
   const settingsServiceAdapter = new CoreSettingsServiceAdapter(config);
-  const storageServiceAdapter = new CoreStorageServiceAdapter();
+  const storageServiceAdapter = coreStorageServiceAdapter;
   const messageBusAdapter = new CoreMessageBusAdapter(messageBus);
   const todoServiceAdapter = new CoreTodoServiceAdapter(() =>
     storageServiceAdapter.getGlobalDataDir(),

--- a/packages/tools/src/tools/memoryTool.test.ts
+++ b/packages/tools/src/tools/memoryTool.test.ts
@@ -50,8 +50,8 @@ interface FsAdapter {
 
 describe('MemoryTool', () => {
   const mockAbortSignal = new AbortController().signal;
-  const mockWorkingDir = '/mock/project';
-
+  let mockWorkingDir: string;
+  let tempHomeDir: string;
   const mockFsAdapter: {
     readFile: Mock<FsAdapter['readFile']>;
     writeFile: Mock<FsAdapter['writeFile']>;
@@ -85,7 +85,11 @@ describe('MemoryTool', () => {
     });
 
   beforeEach(() => {
-    vi.mocked(os.homedir).mockReturnValue(path.join('/mock', 'home'));
+    // These are string-only values for path construction — all fs operations
+    // are mocked. Use clearly-fake paths rather than real-looking temp dirs.
+    mockWorkingDir = path.join('/mock', 'project');
+    tempHomeDir = path.join('/mock', 'home');
+    vi.mocked(os.homedir).mockReturnValue(tempHomeDir);
     mockFsAdapter.readFile.mockReset();
     mockFsAdapter.writeFile.mockReset().mockResolvedValue(undefined);
     mockFsAdapter.mkdir
@@ -359,9 +363,7 @@ describe('MemoryTool', () => {
 
       const expectedPath = path.join('~', '.llxprt', 'LLXPRT.md');
       expect(editResult.title).toBe(`Confirm Memory Save: ${expectedPath}`);
-      expect(editResult.fileName).toContain(
-        path.join('mock', 'home', '.llxprt'),
-      );
+      expect(editResult.fileName).toContain(path.join(tempHomeDir, '.llxprt'));
       expect(editResult.fileName).toContain('LLXPRT.md');
       expect(editResult.fileDiff).toContain('Index: LLXPRT.md');
       expect(editResult.fileDiff).toContain('+## LLxprt Code Added Memories');

--- a/packages/tools/src/tools/todo-read.ts
+++ b/packages/tools/src/tools/todo-read.ts
@@ -14,6 +14,7 @@ import { type Todo } from '../types/todo-schemas.js';
 import { Type } from '../types/schema-type.js';
 import { TodoReminderService } from '../utils/todoReminderService.js';
 import { formatTodoListForDisplay } from '../utils/todoFormatter.js';
+import { resolveTodoRead } from './todo-store.js';
 import type { ITodoService } from '../interfaces/ITodoService.js';
 
 export type TodoReadParams = Record<string, never>;
@@ -51,7 +52,7 @@ export class TodoRead extends BaseTool<TodoReadParams, ToolResult> {
     const agentId = this.context?.agentId;
 
     const store = this.todoService.getTodoStore(this.context);
-    const rawTodos = await this.readTodosFromStore(store, sessionId, agentId);
+    const rawTodos = await resolveTodoRead(store, sessionId, agentId);
     const todos = rawTodos;
 
     const paused = store.readPausedState
@@ -84,30 +85,6 @@ export class TodoRead extends BaseTool<TodoReadParams, ToolResult> {
         suggestedAction,
       },
     };
-  }
-
-  private async readTodosFromStore(
-    store: {
-      readTodos?: () => Promise<Todo[]>;
-      getTodos?: () => Todo[];
-    },
-    sessionId: string,
-    agentId: string | undefined,
-  ): Promise<Todo[]> {
-    if (store.readTodos) {
-      return store.readTodos();
-    }
-    if (store.getTodos) {
-      return store.getTodos();
-    }
-    // No fallback: TodoStore now requires an explicit canonical data dir
-    // injected by the composition root. Reaching here means the tool was
-    // constructed without a wired ITodoService.
-    throw new Error(
-      `TodoRead cannot read todos for session ${sessionId} (agent ${agentId ?? 'primary'}): ` +
-        'no ITodoService store was injected. Construct the tool via the tool registry so ' +
-        'the composition root can wire Storage.getGlobalDataDir().',
-    );
   }
 
   private calculateStatistics(todos: Todo[]): {

--- a/packages/tools/src/tools/todo-store.ts
+++ b/packages/tools/src/tools/todo-store.ts
@@ -74,6 +74,60 @@ function resolveDataDir(options: TodoStoreOptions): TodoDataDirResolver {
   return () => fixed;
 }
 
+/**
+ * Resolves a read operation against a todo store, preferring the async
+ * `readTodos` API and falling back to the legacy synchronous `getTodos`.
+ * Throws when neither is present (the store must be wired by the composition
+ * root). Centralized here so TodoRead and TodoWrite share one fallback chain.
+ */
+export async function resolveTodoRead(
+  store: { readTodos?: () => Promise<Todo[]>; getTodos?: () => Todo[] },
+  sessionId: string,
+  agentId: string | undefined,
+  toolLabel = 'TodoRead',
+): Promise<Todo[]> {
+  if (store.readTodos) {
+    return store.readTodos();
+  }
+  if (store.getTodos) {
+    return store.getTodos();
+  }
+  throw new Error(
+    `${toolLabel} cannot read todos for session ${sessionId} (agent ${agentId ?? 'primary'}): ` +
+      'no ITodoService store was injected. Construct the tool via the tool registry so ' +
+      'the composition root can wire Storage.getGlobalDataDir().',
+  );
+}
+
+/**
+ * Resolves a write operation against a todo store, preferring the async
+ * `writeTodos` API and falling back to the legacy synchronous `setTodos`.
+ * Throws when neither is present (the store must be wired by the composition
+ * root). Centralized here so TodoRead and TodoWrite share one fallback chain.
+ */
+export async function resolveTodoWrite(
+  todos: Todo[],
+  store: {
+    writeTodos?: (todos: Todo[]) => Promise<void>;
+    setTodos?: (todos: Todo[]) => void;
+  },
+  sessionId: string,
+  agentId: string | undefined,
+  toolLabel = 'TodoWrite',
+): Promise<void> {
+  if (store.writeTodos) {
+    await store.writeTodos(todos);
+  } else if (store.setTodos) {
+    store.setTodos(todos);
+  } else {
+    throw new Error(
+      `${toolLabel} cannot persist todos for session ${sessionId} (agent ${agentId ?? 'primary'}): ` +
+        'no ITodoService store was injected. Construct the tool via the tool registry so ' +
+        'the composition root can wire Storage.getGlobalDataDir().',
+    );
+  }
+}
+
 export class TodoStore {
   private readonly dataDirResolver: TodoDataDirResolver;
   private readonly sessionId: string;

--- a/packages/tools/src/tools/todo-write.ts
+++ b/packages/tools/src/tools/todo-write.ts
@@ -12,7 +12,11 @@ import {
   type LiveOutputUpdate,
 } from './tools.js';
 import { type Todo, TodoArraySchema } from '../types/todo-schemas.js';
-import { DEFAULT_AGENT_ID } from './todo-store.js';
+import {
+  DEFAULT_AGENT_ID,
+  resolveTodoRead,
+  resolveTodoWrite,
+} from './todo-store.js';
 import { TodoReminderService } from '../utils/todoReminderService.js';
 import { todoEvents, type TodoUpdateEvent } from './todo-events.js';
 import { TodoContextTracker } from '../utils/todoContextTracker.js';
@@ -165,8 +169,19 @@ export class TodoWrite extends BaseTool<TodoWriteParams, ToolResult> {
     const agentId = this.context?.agentId;
     const serviceStore = this.todoService.getTodoStore(this.context);
 
-    const oldTodos = await this.readOldTodos(serviceStore, sessionId, agentId);
-    await this.persistTodos(todos, serviceStore, sessionId, agentId);
+    const oldTodos = await resolveTodoRead(
+      serviceStore,
+      sessionId,
+      agentId,
+      'TodoWrite',
+    );
+    await resolveTodoWrite(
+      todos,
+      serviceStore,
+      sessionId,
+      agentId,
+      'TodoWrite',
+    );
 
     const { stateChange, shouldGenerateReminder, reminder } =
       this.computeStateChange(oldTodos, todos);
@@ -216,54 +231,6 @@ export class TodoWrite extends BaseTool<TodoWriteParams, ToolResult> {
       };
     }
     return { todos: revalidation.data, emojiResult };
-  }
-
-  private async readOldTodos(
-    serviceStore: {
-      readTodos?: () => Promise<Todo[]>;
-      getTodos?: () => Todo[];
-    },
-    sessionId: string,
-    agentId: string | undefined,
-  ): Promise<Todo[]> {
-    if (serviceStore.readTodos) {
-      return serviceStore.readTodos();
-    }
-    if (serviceStore.getTodos) {
-      return serviceStore.getTodos();
-    }
-    // No fallback: TodoStore now requires an explicit canonical data dir
-    // injected by the composition root. Reaching here means the tool was
-    // constructed without a wired ITodoService — fail loudly instead of
-    // silently using a parallel default.
-    throw new Error(
-      `TodoWrite cannot read todos for session ${sessionId} (agent ${agentId ?? 'primary'}): ` +
-        'no ITodoService store was injected. Construct the tool via the tool registry so ' +
-        'the composition root can wire Storage.getGlobalDataDir().',
-    );
-  }
-
-  private async persistTodos(
-    todos: Todo[],
-    serviceStore: {
-      writeTodos?: (todos: Todo[]) => Promise<void>;
-      setTodos?: (todos: Todo[]) => void;
-    },
-    sessionId: string,
-    agentId: string | undefined,
-  ): Promise<void> {
-    if (serviceStore.writeTodos) {
-      await serviceStore.writeTodos(todos);
-    } else if (serviceStore.setTodos) {
-      serviceStore.setTodos(todos);
-    } else {
-      // No fallback: see readOldTodos above.
-      throw new Error(
-        `TodoWrite cannot persist todos for session ${sessionId} (agent ${agentId ?? 'primary'}): ` +
-          'no ITodoService store was injected. Construct the tool via the tool registry so ' +
-          'the composition root can wire Storage.getGlobalDataDir().',
-      );
-    }
   }
 
   private computeStateChange(

--- a/scripts/genai-enclave/file-discovery.ts
+++ b/scripts/genai-enclave/file-discovery.ts
@@ -169,22 +169,40 @@ function collectStatusSets(repoRoot: string): {
 
   const deleted = new Set<string>();
   const untracked: string[] = [];
-  for (const entry of status.split('\0')) {
+  // git status -z separates entries with NUL. Rename (R) and copy (C) records
+  // produce TWO consecutive NUL-delimited entries: "R  oldpath\0newpath\0".
+  // The second entry (the new path) is a bare path with no status prefix; if
+  // iterated independently it could be misparsed as a standalone status entry
+  // (especially for short paths). Iterate by index and consume the trailing
+  // new-path token when an R/C status is detected so it is never treated as a
+  // separate entry.
+  const entries = status.split('\0');
+  let i = 0;
+  while (i < entries.length) {
+    const entry = entries[i];
     const parsed = entry.length > 0 ? parseStatusEntry(entry) : undefined;
-    if (parsed === undefined) {
-      continue;
-    }
-    const { x, y, pathPart } = parsed;
-    if (x === 'D' || y === 'D') {
-      deleted.add(pathPart);
-    }
-    if (
-      x === '?' &&
-      y === '?' &&
-      pathPart.startsWith('packages/') &&
-      isScannableFile(pathPart)
-    ) {
-      untracked.push(pathPart);
+    if (parsed !== undefined) {
+      const { x, y, pathPart } = parsed;
+      if (x === 'D' || y === 'D') {
+        deleted.add(pathPart);
+      }
+      if (
+        x === '?' &&
+        y === '?' &&
+        pathPart.startsWith('packages/') &&
+        isScannableFile(pathPart)
+      ) {
+        untracked.push(pathPart);
+      }
+      // Rename/copy records carry a second NUL-delimited path (the new path).
+      // Consume it so it is not treated as a standalone entry.
+      if (x === 'R' || x === 'C' || y === 'R' || y === 'C') {
+        i += 2;
+      } else {
+        i += 1;
+      }
+    } else {
+      i += 1;
     }
   }
   return { deleted, untracked };

--- a/scripts/legacy-paths/ast-scanner.ts
+++ b/scripts/legacy-paths/ast-scanner.ts
@@ -38,7 +38,7 @@ import type { CompiledAllowlist } from './config.js';
  * Matches strings that contain `.llxprt` as a path segment (e.g. `.llxprt`,
  * `.llxprt/settings.json`). Used to detect alias assignments.
  */
-const DOT_LLPRT_PATTERN = /\.llxprt(?=[/"'`)}\s$]|$)/;
+const DOT_LLXPRT_PATTERN = /\.llxprt(?=[/"'`)}\s$]|$)/;
 
 /**
  * An AST-detected legacy-path violation.
@@ -176,7 +176,7 @@ function collectAliases(
       init !== undefined &&
       ts.isIdentifier(decl.name) &&
       ts.isStringLiteral(init) &&
-      DOT_LLPRT_PATTERN.test(init.text)
+      DOT_LLXPRT_PATTERN.test(init.text)
     ) {
       aliasMap.set(decl.name.text, init.text);
     }
@@ -275,12 +275,12 @@ function isDotLlxprtValue(
   node: ts.Node,
   aliasMap: Map<string, string>,
 ): boolean {
-  if (ts.isStringLiteral(node) && DOT_LLPRT_PATTERN.test(node.text)) {
+  if (ts.isStringLiteral(node) && DOT_LLXPRT_PATTERN.test(node.text)) {
     return true;
   }
   if (ts.isIdentifier(node)) {
     const aliased = aliasMap.get(node.text);
-    if (aliased !== undefined && DOT_LLPRT_PATTERN.test(aliased)) {
+    if (aliased !== undefined && DOT_LLXPRT_PATTERN.test(aliased)) {
       return true;
     }
   }
@@ -331,7 +331,7 @@ function checkTemplateExpression(
   for (const span of node.templateSpans) {
     if (
       isHomedirCall(span.expression) &&
-      DOT_LLPRT_PATTERN.test(span.literal.text)
+      DOT_LLXPRT_PATTERN.test(span.literal.text)
     ) {
       const pos = node.getStart(sourceFile);
       const { line, character } = sourceFile.getLineAndCharacterOfPosition(pos);

--- a/scripts/run_bun_tests.ts
+++ b/scripts/run_bun_tests.ts
@@ -139,7 +139,11 @@ function parseArgs(argv: string[]): CliOptions {
       case '--timeout': {
         const value = readOptionValue(argv, i++, arg);
         const timeout = Number(value);
-        if (!Number.isFinite(timeout) || timeout <= 0) {
+        if (
+          !Number.isFinite(timeout) ||
+          timeout <= 0 ||
+          !Number.isInteger(timeout)
+        ) {
           throw new Error(`Invalid --timeout value: ${value}`);
         }
         options.timeout = timeout;

--- a/scripts/tests/constants-readEnvMs.test.ts
+++ b/scripts/tests/constants-readEnvMs.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/scripts/tests/constants-readEnvMs.test.ts
+++ b/scripts/tests/constants-readEnvMs.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the readEnvMs timeout-override helper in the Windows
+ * installed-command smoke constants. readEnvMs must accept only positive
+ * integer millisecond values and fall back to the default for anything else
+ * (missing, non-numeric, zero/negative, or fractional/sub-unit values).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(__dirname, '..', '..');
+const require = createRequire(import.meta.url);
+
+const { readEnvMs } = require(
+  join(repoRoot, 'scripts', 'windows-installed-command-smoke', 'constants.cjs'),
+) as { readEnvMs: (name: string, defaultMs: number) => number };
+
+const ENV_KEY = 'LLXPRT_TEST_READ_ENV_MS';
+
+describe('readEnvMs', () => {
+  const originalValue = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalValue;
+    }
+  });
+
+  it('returns a valid positive integer value from the environment', () => {
+    process.env[ENV_KEY] = '600000';
+    expect(readEnvMs(ENV_KEY, 30_000)).toBe(600_000);
+  });
+
+  it('falls back to the default when the value is fractional (sub-unit ms)', () => {
+    process.env[ENV_KEY] = '0.5';
+    expect(readEnvMs(ENV_KEY, 30_000)).toBe(30_000);
+  });
+
+  it('falls back to the default when the value is fractional but above one', () => {
+    process.env[ENV_KEY] = '1.5';
+    expect(readEnvMs(ENV_KEY, 30_000)).toBe(30_000);
+  });
+
+  it('falls back to the default when the value is zero', () => {
+    process.env[ENV_KEY] = '0';
+    expect(readEnvMs(ENV_KEY, 30_000)).toBe(30_000);
+  });
+
+  it('falls back to the default when the value is non-numeric', () => {
+    process.env[ENV_KEY] = 'not-a-number';
+    expect(readEnvMs(ENV_KEY, 30_000)).toBe(30_000);
+  });
+
+  it('falls back to the default when the env var is missing', () => {
+    delete process.env[ENV_KEY];
+    expect(readEnvMs(ENV_KEY, 42_000)).toBe(42_000);
+  });
+});

--- a/scripts/tests/constants-readEnvMs.test.ts
+++ b/scripts/tests/constants-readEnvMs.test.ts
@@ -55,6 +55,11 @@ describe('readEnvMs', () => {
     expect(readEnvMs(ENV_KEY, 30_000)).toBe(30_000);
   });
 
+  it('falls back to the default when the value is negative', () => {
+    process.env[ENV_KEY] = '-1';
+    expect(readEnvMs(ENV_KEY, 30_000)).toBe(30_000);
+  });
+
   it('falls back to the default when the value is non-numeric', () => {
     process.env[ENV_KEY] = 'not-a-number';
     expect(readEnvMs(ENV_KEY, 30_000)).toBe(30_000);

--- a/scripts/tests/genai-enclave-guard-deleted-files.test.ts
+++ b/scripts/tests/genai-enclave-guard-deleted-files.test.ts
@@ -195,4 +195,34 @@ describe('genai-enclave discovery — deleted file exclusion', () => {
       'packages/cli/src/unstaged-delete.ts',
     ]);
   });
+
+  it('parses a git rename record without mistreating the new path as a separate entry', () => {
+    // git status -z represents a rename as two NUL-delimited tokens:
+    // "R  oldpath\0newpath\0". The new-path token has no status prefix and
+    // must NOT be misparsed as a standalone status entry. A renamed file is
+    // still scanned under its new tracked path, so it must be discovered.
+    const repo = createTempGitRepo();
+    repo.write('packages/cli/src/old-name.ts', 'export const x = 1;\n');
+    repo.write('packages/cli/src/keep.ts', 'export const y = 2;\n');
+    repo.git(['add', '.']);
+    repo.git(['commit', '-m', 'initial']);
+
+    // Rename the tracked file (git mv produces an R status with -z output).
+    repo.git([
+      'mv',
+      'packages/cli/src/old-name.ts',
+      'packages/cli/src/new-name.ts',
+    ]);
+
+    const result = discoverScannableFiles(repo.root);
+
+    expect(result.errors).toEqual([]);
+    const discoveredRelPaths = result.files.map((f) => rel(repo.root, f));
+    // The renamed file's new path must be discovered (tracked under new name).
+    expect(discoveredRelPaths).toContain('packages/cli/src/new-name.ts');
+    // The old path must NOT appear (it no longer exists).
+    expect(discoveredRelPaths).not.toContain('packages/cli/src/old-name.ts');
+    // The sibling file must still be discovered.
+    expect(discoveredRelPaths).toContain('packages/cli/src/keep.ts');
+  });
 });

--- a/scripts/tests/run_bun_tests.test.ts
+++ b/scripts/tests/run_bun_tests.test.ts
@@ -304,6 +304,24 @@ describe('runBunTests', () => {
     expect(stdout.at(-1)).toBe('Passed 1/1 isolated native Bun test files');
     expect(status).toBe(0);
   });
+
+  it('rejects a fractional --timeout value before any child is spawned', () => {
+    const dependencies: BunTestRunnerDependencies = {
+      repoRoot: '/repo',
+      invocationDirectory: '/invoke',
+      executable: '/bin/bun',
+      environment: {},
+      resolveFiles: () => [{ cwd: '/repo/core', file: '/repo/core/test.ts' }],
+      resolveTsconfig: resolveTsconfigOverride,
+      spawn: () => ({ exitCode: 0, signalCode: null }),
+      stdout: () => {},
+      stderr: () => {},
+    };
+
+    expect(() => runBunTests(['--timeout', '1.5'], dependencies)).toThrow(
+      'Invalid --timeout value: 1.5',
+    );
+  });
 });
 
 describe('actual child process signal shape', () => {

--- a/scripts/windows-installed-command-smoke/constants.cjs
+++ b/scripts/windows-installed-command-smoke/constants.cjs
@@ -105,7 +105,7 @@ function readEnvMs(name, defaultMs) {
   const raw = process.env[name];
   if (!raw) return defaultMs;
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return defaultMs;
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return defaultMs;
   return n;
 }
 
@@ -139,6 +139,7 @@ module.exports = {
   LAUNCH_ERROR_EXIT,
   EXPECTED_BUN_VERSION,
   resolveExpectedBunVersion,
+  readEnvMs,
   INSTALL_TIMEOUT_MS,
   NPM_EXEC_TIMEOUT_MS,
   PROBE_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

Addresses all deferred CodeRabbit maintenance items from PR #2646 (issue #2606's OS-standard application-directory migration). Each item was evaluated against current main before implementation.

## Changes

### Documentation consistency
- **docs/cli/commands.md**: Added `text` language annotation to At Commands fenced block and `bash` to Shell Passthrough fenced block (markdown lint).
- **docs/debug-logging.md**: Fixed filename contradiction in "Can't Find Log Files?" section — changed `debug-YYYY-MM-DD.jsonl` to `llxprt-debug-<PID>.jsonl` (matching the correct format described elsewhere in the same file).
- **docs/migration/approval-mode-to-policies.md**: Replaced tilde-prefixed Linux path example (`~/.config/...`) with a true absolute path (`/home/yourname/.config/...`) to eliminate the contradiction with the doc's own "Use absolute paths, not tilde" instruction.
- MCP scope documentation was verified correct — no change needed.

### Test maintenance
- **pathMigration.freshStart.test.ts**: Gated the `normalized publish preserves source file mode` chmod test with `it.skipIf(process.platform === 'win32')` since POSIX modes don't apply on Windows.
- **TodoContinuationService.propagation.test.ts** (new): Behavioral integration test that creates a real temp directory, writes on-disk todo state via a real `LocalTodoStore`, and asserts `TodoContinuationService.readTodoSnapshot()` and `getTodoReminderForCurrentState()` outcomes match the persisted state. No mock-interaction tests.
- **legacyCopyEngine.test.ts** (new): Behavioral self-tests for the recursive filtered-copy primitives using real temp directories — tests tree copying, COPYFILE_EXCL semantics, symlink cycle guarding, and interceptor invocation.
- **constants-readEnvMs.test.ts** (new): Behavioral tests for `readEnvMs` timeout validation — accepts valid integers, rejects fractional/sub-unit/zero/non-numeric values.
- Null-byte assertion in secure-store.fallback.test.ts verified already stable (code-based) — no change needed.

### Code cleanup and efficiency
- **Todo fallback centralization**: Extracted duplicate read/write fallback chains from `todo-read.ts` and `todo-write.ts` into shared `resolveTodoRead` and `resolveTodoWrite` helpers in `todo-store.ts`. Eliminates code duplication while preserving exact error messages.
- **Adapter singleton**: Replaced `new CoreStorageServiceAdapter()` in `toolRegistryFactory.ts` with the exported `coreStorageServiceAdapter` singleton.
- **Vitest excludes**: Updated `packages/cli/vitest.config.ts` to spread `configDefaults.exclude` alongside custom patterns, preserving Vitest's built-in excludes. Removed redundant explicit exclude from `packages/a2a-server/vitest.config.ts` (Vitest defaults are sufficient).
- **DOT_LLPRT_PATTERN rename**: Renamed misspelled `DOT_LLPRT_PATTERN` to `DOT_LLXPRT_PATTERN` throughout `ast-scanner.ts`.
- **GenAI rename parsing**: Fixed `collectStatusSets` in `file-discovery.ts` to consume the second NUL-delimited token for git rename/copy records (`R`/`C` status), preventing the new path from being misparsed as a standalone status entry.
- **Timeout validation**: Added `Number.isInteger()` checks to `readEnvMs` (constants.cjs) and `parseArgs` (run_bun_tests.ts) to reject fractional/sub-unit timeout values.

## Verification
- `npm run typecheck` — passes
- `npm run lint` — passes (exploit.js is a pre-existing untracked file, not part of this PR)
- `npm run test` — all packages pass
- `npm run format` — passes
- `npm run build` — passes
- `npm run lint:eslint-guard` — passes

Fixes #2647
