### PR TITLE
fix(providers): sanitize prompt_cache_key on Chat Completions transport (Fixes #2853)

### DIFF
--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue2853.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue2853.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @issue #2853 - prompt cache key bug again
+ *
+ * Behavioral regression tests proving that the OpenAI **Chat Completions**
+ * transport (prepareRequest) never forwards an overlong `prompt_cache_key`
+ * to the API. Subagents compose long runtime IDs (e.g.
+ * `<uuid>#<subagent-name>#<8-char id>` = 69 chars) that exceed the
+ * OpenAI-enforced 64-char limit, producing 400 errors.
+ *
+ * The Responses transport already sanitizes (issue #2135); this suite
+ * closes the gap on the Chat Completions transport by exercising the
+ * shared request-preparation path (`prepareRequest` →
+ * `applyRequestBodyOverrides`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { prepareRequest } from './OpenAIRequestPreparation.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { sanitizePromptCacheKey } from '../openai-responses/sanitizePromptCacheKey.js';
+
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('test system prompt'),
+}));
+
+vi.mock('../../prompt-config/subagent-delegation.js', () => ({
+  shouldIncludeSubagentDelegation: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('../utils/userMemory.js', () => ({
+  resolveUserMemory: vi.fn().mockResolvedValue(''),
+}));
+
+function createMockOptions(
+  overrides: Partial<NormalizedGenerateChatOptions> = {},
+  modelParams: Record<string, unknown> = {},
+): NormalizedGenerateChatOptions {
+  const settings = new SettingsService();
+  return {
+    contents: [],
+    tools: undefined,
+    metadata: {},
+    settings,
+    config: undefined,
+    invocation: {
+      requestId: 'test-request',
+      timestamp: Date.now(),
+      modelBehavior: {},
+      modelParams,
+    },
+    resolved: {
+      model: 'gpt-4o',
+      authToken: { token: 'test-token', type: 'api-key' },
+    },
+    ...overrides,
+  } as unknown as NormalizedGenerateChatOptions;
+}
+
+describe('OpenAIRequestPreparation.prepareRequest prompt_cache_key sanitization (issue #2853)', () => {
+  let logger: DebugLogger;
+
+  beforeEach(() => {
+    logger = new DebugLogger('llxprt:provider:openai:test');
+  });
+
+  it('clamps an overlong subagent-style prompt_cache_key to <=64 chars via modelParams', async () => {
+    // Mirrors a real subagent runtimeId: <uuid>#<subagent-name>#<8-char id> (69 chars)
+    const overlongKey =
+      '0d4429a9-79b0-4b64-a63e-d5d7a45f1878#fallbacktypescriptcoder#a1b2c3d4';
+    expect(overlongKey.length).toBe(69);
+
+    const options = createMockOptions(
+      {
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
+      },
+      { prompt_cache_key: overlongKey },
+    );
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const cacheKey = result.requestBody.prompt_cache_key;
+    expect(cacheKey).toBeDefined();
+    expect(cacheKey!.length).toBeLessThanOrEqual(64);
+    // The overlong original must NOT be forwarded verbatim
+    expect(cacheKey).not.toBe(overlongKey);
+    // Deterministic clamp matches the shared sanitizer
+    expect(cacheKey).toBe(sanitizePromptCacheKey(overlongKey));
+  });
+
+  it('passes short, valid prompt_cache_key values through unchanged', async () => {
+    const shortKey = 'session-abc123';
+    const options = createMockOptions(
+      {
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
+      },
+      { prompt_cache_key: shortKey },
+    );
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    expect(result.requestBody.prompt_cache_key).toBe(shortKey);
+  });
+
+  it('drops empty/whitespace prompt_cache_key instead of forwarding it', async () => {
+    const options = createMockOptions(
+      {
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
+      },
+      { prompt_cache_key: '   ' },
+    );
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    expect(result.requestBody.prompt_cache_key).toBeUndefined();
+  });
+
+  it('drops non-string prompt_cache_key instead of forwarding it', async () => {
+    const options = createMockOptions(
+      {
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
+      },
+      { prompt_cache_key: 12345, temperature: 0.5 },
+    );
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    expect(result.requestBody.prompt_cache_key).toBeUndefined();
+    // Other valid params must still flow through
+    expect(result.requestBody.temperature).toBe(0.5);
+  });
+
+  it('preserves other model params including provider-specific extensions (issue #2853 scope)', async () => {
+    // The fix must ONLY sanitize prompt_cache_key; all other model params,
+    //including canonical Chat Completions fields and provider-specific
+    // extensions used by OpenAI-compatible aliases, must pass through.
+    const overlongKey =
+      '0d4429a9-79b0-4b64-a63e-d5d7a45f1878#fallbacktypescriptcoder#a1b2c3d4';
+    const options = createMockOptions(
+      {
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
+      },
+      {
+        prompt_cache_key: overlongKey,
+        reasoning_effort: 'high',
+        service_tier: 'priority',
+        store: true,
+        repetition_penalty: 1.1,
+      },
+    );
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    // prompt_cache_key is sanitized
+    const cacheKey = result.requestBody.prompt_cache_key;
+    expect(cacheKey).toBeDefined();
+    expect(cacheKey!.length).toBeLessThanOrEqual(64);
+
+    // All other params pass through unchanged
+    expect(result.requestBody).toHaveProperty('reasoning_effort', 'high');
+    expect(result.requestBody).toHaveProperty('service_tier', 'priority');
+    expect(result.requestBody).toHaveProperty('store', true);
+    expect(result.requestBody).toHaveProperty('repetition_penalty', 1.1);
+  });
+});

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue2853.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue2853.test.ts
@@ -166,6 +166,84 @@ describe('OpenAIRequestPreparation.prepareRequest prompt_cache_key sanitization 
     expect(result.requestBody.temperature).toBe(0.5);
   });
 
+  it('passes a 64-character prompt_cache_key through unchanged (exact boundary)', async () => {
+    // The shared sanitizer has a hard cutoff at 64 chars and returns keys
+    // of exactly that length unchanged. An off-by-one regression would not
+    // be caught without this boundary test.
+    const exactKey = 'a'.repeat(64);
+    expect(exactKey.length).toBe(64);
+
+    const options = createMockOptions(
+      {
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
+      },
+      { prompt_cache_key: exactKey },
+    );
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    expect(result.requestBody.prompt_cache_key).toBe(exactKey);
+  });
+
+  it('omits prompt_cache_key from the request body when modelParams has no cache key', async () => {
+    // Exercises the early-return branch when prompt_cache_key is undefined.
+    // This is the most common real-world case (no modelParams supplied).
+    const options = createMockOptions(
+      {
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
+      },
+      { temperature: 0.5 },
+    );
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    expect(result.requestBody.prompt_cache_key).toBeUndefined();
+    // Other params still flow through
+    expect(result.requestBody.temperature).toBe(0.5);
+  });
+
+  it('drops null prompt_cache_key instead of forwarding it', async () => {
+    // null is treated as invalid (typeof null === 'object') and dropped.
+    const options = createMockOptions(
+      {
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
+      },
+      { prompt_cache_key: null, temperature: 0.7 },
+    );
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    expect(result.requestBody.prompt_cache_key).toBeUndefined();
+    expect(result.requestBody.temperature).toBe(0.7);
+  });
+
   it('preserves other model params including provider-specific extensions (issue #2853 scope)', async () => {
     // The fix must ONLY sanitize prompt_cache_key; all other model params,
     //including canonical Chat Completions fields and provider-specific

--- a/packages/providers/src/openai/OpenAIRequestPreparation.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.ts
@@ -25,6 +25,7 @@ import { mergeSystemInstruction } from '../utils/systemInstructionMerge.js';
 import { resolveToolFormat } from '../utils/toolFormatDetection.js';
 import { buildMessagesWithReasoning } from './OpenAIRequestBuilder.js';
 import { extractModelParamsFromOptions } from './OpenAIClientFactory.js';
+import { sanitizePromptCacheKey } from '../openai-responses/sanitizePromptCacheKey.js';
 import { type Config } from '@vybestack/llxprt-code-core/config/config.js';
 
 export interface RequestContext {
@@ -174,15 +175,24 @@ function applyRequestBodyOverrides(
   streamingEnabled: boolean,
   logger: DebugLogger,
 ): void {
-  // Apply request overrides
+  // Apply request overrides, sanitizing prompt_cache_key at the transport
+  // boundary so an overlong value (e.g. a subagent runtimeId) never reaches
+  // the API (issue #2853). Non-string or empty cache keys are dropped.
+  // All other model params are forwarded unchanged.
   const requestOverrides = extractModelParamsFromOptions(options);
   if (requestOverrides) {
-    if (logger.enabled) {
+    const sanitizedOverrides = sanitizeOverridesCacheKey(
+      requestOverrides,
+      logger,
+    );
+    if (logger.enabled && sanitizedOverrides) {
       logger.debug(() => `[OpenAIProvider] Applying request overrides`, {
-        overrideKeys: Object.keys(requestOverrides),
+        overrideKeys: Object.keys(sanitizedOverrides),
       });
     }
-    Object.assign(requestBody, requestOverrides);
+    if (sanitizedOverrides) {
+      Object.assign(requestBody, sanitizedOverrides);
+    }
   }
 
   resolveReasoningConfig(requestBody, options);
@@ -199,6 +209,35 @@ function applyRequestBodyOverrides(
   if (streamingEnabled) {
     Object.assign(requestBody, { stream_options: streamOptions });
   }
+}
+
+/**
+ * Sanitize a single extracted model-params record, clamping/dropping only
+ * the `prompt_cache_key` field (issue #2853). All other keys are preserved
+ * verbatim so that provider-specific extensions and canonical Chat
+ * Completions fields (service_tier, store, verbosity, etc.) continue to
+ * pass through. Returns undefined when the cache key was the only entry
+ * and it was dropped.
+ */
+function sanitizeOverridesCacheKey(
+  overrides: Record<string, unknown>,
+  logger: DebugLogger,
+): Record<string, unknown> | undefined {
+  const value = overrides['prompt_cache_key'];
+  if (value === undefined) {
+    return overrides;
+  }
+  const result: Record<string, unknown> = { ...overrides };
+  if (typeof value === 'string' && value.trim() !== '') {
+    result['prompt_cache_key'] = sanitizePromptCacheKey(value);
+  } else {
+    delete result['prompt_cache_key'];
+    logger.debug(
+      () =>
+        `Dropping invalid prompt_cache_key from modelParams (type=${typeof value})`,
+    );
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 /**

--- a/project-plans/issue2853-prompt-cache-key.md
+++ b/project-plans/issue2853-prompt-cache-key.md
@@ -1,0 +1,70 @@
+# Issue #2853 — prompt cache key bug again
+
+## Summary
+Subagent requests via the OpenAI **Chat Completions** transport send
+`prompt_cache_key` values longer than 64 chars, producing API 400 errors:
+`Invalid 'prompt_cache_key': string too long. Expected ... maximum length 64,
+but got ... length 69`.
+
+The Responses transport already sanitizes; Chat Completions does not.
+
+## Root cause
+`packages/providers/src/openai/OpenAIRequestPreparation.ts`
+`applyRequestBodyOverrides()` (L169–198) does:
+```ts
+const requestOverrides = extractModelParamsFromOptions(options);
+Object.assign(requestBody, requestOverrides);
+```
+`extractModelParamsFromOptions` pulls `options.invocation.modelParams` raw.
+When a subagent runtime ID (e.g. `<uuid>#fallbacktypescriptcoder#a1b2c3d4`
+= 69 chars) is the source of `prompt_cache_key`, it is forwarded to the
+wire unchanged → 400.
+
+A helper, `filterOpenAIRequestParams()` in `openaiRequestParams.ts`, already
+sanitizes (clamps to 64, drops empty/non-string) with full unit coverage —
+but it is never invoked by the Chat Completions production path.
+
+## Acceptance matrix
+| # | Behavior | Evidence |
+|---|----------|----------|
+| A1 | Chat Completions request body never contains a `prompt_cache_key` longer than 64 chars | Regression test in `OpenAIRequestPreparation.issue2853.test.ts`: supply a 69-char subagent-style runtimeId in `modelParams.prompt_cache_key`; assert emitted `requestBody.prompt_cache_key.length <= 64` and starts with `rk:` |
+| A2 | Short, valid `prompt_cache_key` passes through unchanged | Regression test: 20-char key emitted verbatim |
+| A3 | Empty / whitespace-only `prompt_cache_key` is dropped, not forwarded | Regression test |
+| A4 | Non-string `prompt_cache_key` is dropped, not forwarded | Regression test |
+| A5 | Other model params (temperature, max_tokens, reasoning_effort, top_p) still flow through `applyRequestBodyOverrides` unchanged | Existing `OpenAIRequestPreparation.issue1943.test.ts` still passes |
+| A6 | Responses transport behavior is unchanged | Existing `OpenAIResponsesProvider.promptCacheKey.test.ts` + `sanitizePromptCacheKey.test.ts` still pass |
+
+## Non-goals
+- Do NOT modify runtime ID composition in `packages/agents` or `packages/core`.
+- Do NOT introduce a new sanitizer; reuse `filterOpenAIRequestParams()` +
+  `sanitizePromptCacheKey()`.
+- Do NOT add a default cache key when none is supplied.
+- Do NOT touch the Responses executor/transport (already correct).
+- Do NOT add tests inside subagent orchestration code.
+
+## Bounded vertical slices
+1. **Test-first** — add `OpenAIRequestPreparation.issue2853.test.ts` with
+   A1–A4 (RED before fix).
+2. **Fix** — sanitize only `prompt_cache_key` in
+   `applyRequestBodyOverrides()` (targeted, not a broad allowlist filter,
+   so provider-specific extensions and canonical Chat Completions fields
+   continue to pass through). Reuse `sanitizePromptCacheKey()`.
+3. **Verify** — full suite + smoke test.
+
+## Scope ledger
+| File | Change type | Status |
+|------|-------------|--------|
+| `packages/providers/src/openai/OpenAIRequestPreparation.ts` | Production fix (targeted cache-key sanitization) | done |
+| `packages/providers/src/openai/OpenAIRequestPreparation.issue2853.test.ts` | New regression test | done |
+
+Target: 1 production file (43 insertions, 4 deletions) + 1 new test file. Well within budget.
+
+## Design decision (post DeepThinker review)
+The initial approach applied the closed allowlist `filterOpenAIRequestParams()`
+to all model params. DeepThinker correctly flagged this as a Blocker: it
+silently drops valid canonical Chat Completions fields (`service_tier`,
+`store`, `verbosity`, `web_search_options`) and provider-specific
+extensions used by OpenAI-compatible aliases. The revised approach does
+**targeted sanitization of only `prompt_cache_key`** via a new
+`sanitizeOverridesCacheKey()` helper, preserving all other model params
+unchanged.


### PR DESCRIPTION
## Summary

Fixes the recurring prompt cache key bug (#2853) where subagent requests via the OpenAI **Chat Completions** transport sent overlong prompt_cache_key values to the API, producing 400 errors:

    Client error: Invalid 'prompt_cache_key': string too long. Expected a string with maximum length 64, but got a string with length 69 instead.

## Root cause

The Responses transport already sanitized prompt_cache_key via sanitizePromptCacheKey() (issue #2135), but the Chat Completions transport (prepareRequest -> applyRequestBodyOverrides) forwarded model params directly into the request body via Object.assign without any sanitization. Subagent runtime IDs (e.g. <uuid>#fallbacktypescriptcoder#a1b2c3d4 = 69 chars) exceeded the 64-char API limit.

There was a helper (filterOpenAIRequestParams) with full sanitization and tests, but it was never called by production Chat Completions code.

## Fix

Targeted sanitization of prompt_cache_key at the transport boundary in applyRequestBodyOverrides(), reusing the existing sanitizePromptCacheKey() helper. Only prompt_cache_key is touched; all other model params (reasoning_effort, service_tier, store, verbosity, provider-specific extensions) continue to pass through unchanged.

This approach was chosen over applying the closed allowlist filterOpenAIRequestParams() to all model params, which would silently drop valid canonical Chat Completions fields and OpenAI-compatible provider extensions.

## Test plan

New regression test suite (OpenAIRequestPreparation.issue2853.test.ts) covering:
- Overlong subagent-style key (69 chars) clamped to <=64 chars deterministically
- Short, valid key passes through unchanged
- Empty/whitespace key dropped, not forwarded
- Non-string key dropped, not forwarded
- Other model params (reasoning_effort, service_tier, store, repetition_penalty) preserved unchanged

All existing OpenAI provider tests pass (1409 passed, 6 skipped integration). DeepThinker review and OCR both clean.

Closes #2853