### PR TITLE
fix(cli): reject repeated prompt flags at parse time to prevent React crash (Fixes #2851)

### DIFF
--- a/packages/cli/src/config/__tests__/parseArgumentsParity.test.ts
+++ b/packages/cli/src/config/__tests__/parseArgumentsParity.test.ts
@@ -28,6 +28,17 @@ vi.mock('read-package-up', () => ({
   ),
 }));
 
+function expectParseExit(): {
+  mockExit: ReturnType<typeof vi.spyOn>;
+  mockErr: ReturnType<typeof vi.spyOn>;
+} {
+  const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('process.exit called');
+  });
+  const mockErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+  return { mockExit, mockErr };
+}
+
 // ─── Suite ────────────────────────────────────────────────────────────────────
 
 describe('parseArgumentsParity: positional mapping', () => {
@@ -35,6 +46,7 @@ describe('parseArgumentsParity: positional mapping', () => {
 
   afterEach(() => {
     process.argv = originalArgv;
+    vi.restoreAllMocks();
   });
 
   it('no positional → query is undefined', async () => {
@@ -87,6 +99,35 @@ describe('parseArgumentsParity: positional mapping', () => {
     );
     mockExit.mockRestore();
     mockErr.mockRestore();
+  });
+
+  it('repeated --prompt → clean parse error (no array, no later crash)', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--prompt',
+      'first',
+      '--prompt',
+      'second',
+    ];
+    const { mockErr } = expectParseExit();
+    await expect(parseArguments({} as Settings)).rejects.toThrow(
+      'process.exit called',
+    );
+    expect(mockErr).toHaveBeenCalledWith(
+      expect.stringContaining('--prompt (-p) can only be specified once'),
+    );
+  });
+
+  it('repeated -p alias → clean parse error', async () => {
+    process.argv = ['node', 'script.js', '-p', 'first', '-p', 'second'];
+    const { mockErr } = expectParseExit();
+    await expect(parseArguments({} as Settings)).rejects.toThrow(
+      'process.exit called',
+    );
+    expect(mockErr).toHaveBeenCalledWith(
+      expect.stringContaining('--prompt (-p) can only be specified once'),
+    );
   });
 
   it('@path prefix → mapped to prompt (one-shot)', async () => {
@@ -383,6 +424,7 @@ describe('parseArgumentsParity: --prompt-interactive / -i alias', () => {
 
   afterEach(() => {
     process.argv = originalArgv;
+    vi.restoreAllMocks();
   });
 
   it('--prompt-interactive sets promptInteractive', async () => {
@@ -396,5 +438,38 @@ describe('parseArgumentsParity: --prompt-interactive / -i alias', () => {
     process.argv = ['node', 'script.js', '-i', 'hi'];
     const argv = await parseArguments({} as Settings);
     expect(argv.promptInteractive).toBe('hi');
+  });
+
+  it('repeated --prompt-interactive → clean parse error (no array, no later crash)', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--prompt-interactive',
+      'first',
+      '--prompt-interactive',
+      'second',
+    ];
+    const { mockErr } = expectParseExit();
+    await expect(parseArguments({} as Settings)).rejects.toThrow(
+      'process.exit called',
+    );
+    expect(mockErr).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '--prompt-interactive (-i) can only be specified once',
+      ),
+    );
+  });
+
+  it('repeated -i alias → clean parse error', async () => {
+    process.argv = ['node', 'script.js', '-i', 'first', '-i', 'second'];
+    const { mockErr } = expectParseExit();
+    await expect(parseArguments({} as Settings)).rejects.toThrow(
+      'process.exit called',
+    );
+    expect(mockErr).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '--prompt-interactive (-i) can only be specified once',
+      ),
+    );
   });
 });

--- a/packages/cli/src/config/__tests__/parseArgumentsParity.test.ts
+++ b/packages/cli/src/config/__tests__/parseArgumentsParity.test.ts
@@ -28,10 +28,7 @@ vi.mock('read-package-up', () => ({
   ),
 }));
 
-function expectParseExit(): {
-  mockExit: ReturnType<typeof vi.spyOn>;
-  mockErr: ReturnType<typeof vi.spyOn>;
-} {
+function expectParseExit() {
   const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
     throw new Error('process.exit called');
   });

--- a/packages/cli/src/config/cliArgParser.ts
+++ b/packages/cli/src/config/cliArgParser.ts
@@ -246,6 +246,23 @@ function hasNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }
 
+/**
+ * yargs coerces a `type: 'string'` option into an array when it is supplied
+ * more than once (e.g. `-i a -i b` yields `['a', 'b']`). For single-valued
+ * options that must stay a string, detect that repetition at parse time and
+ * surface a clear error instead of letting a non-string flow downstream where
+ * it would crash far from the cause (issue #2851 — `initialPrompt.trim`).
+ */
+function rejectRepeatedStringOption(
+  argv: Record<string, unknown>,
+  key: string,
+  label: string,
+): void {
+  if (Array.isArray(argv[key])) {
+    throw new Error(`${label} can only be specified once`);
+  }
+}
+
 function validateLaunchArgs(argv: Record<string, unknown>): true {
   const pw = argv['promptWords'];
   if (hasNonEmptyString(argv['prompt']) && Array.isArray(pw) && pw.length > 0) {
@@ -263,6 +280,12 @@ function validateLaunchArgs(argv: Record<string, unknown>): true {
 }
 
 function validatePromptModeArgs(argv: Record<string, unknown>): void {
+  rejectRepeatedStringOption(argv, 'prompt', '--prompt (-p)');
+  rejectRepeatedStringOption(
+    argv,
+    'promptInteractive',
+    '--prompt-interactive (-i)',
+  );
   if (
     hasNonEmptyString(argv['prompt']) &&
     hasNonEmptyString(argv['promptInteractive'])


### PR DESCRIPTION
## Summary

When the `-i`/`--prompt-interactive` (or `-p`/`--prompt`) flag is supplied more than once — as happened when the `jefe` tool passed an issue — yargs coerces the `type: 'string'` option into an **array** (e.g. `['a', 'b']`). The bare `as string | undefined` type assertions in `mapParsedArgsToCliArgs` let that array flow unchecked through the config pipeline all the way to `useInitialPromptSubmit`, where `initialPrompt.trim()` crashed with a React/Ink error screen:

> `initialPrompt.trim is not a function. (In: 'initialPrompt.trim()', 'initialPrompt.trim' is undefined)`

This matched the issue exactly: `--profile-load glm -i "say hi"` (single flag = string) worked fine, but repeated flags crashed.

## Root Cause

The bug is a **lying type assertion** at the parse boundary. `mapParsedArgsToCliArgs` does `result['promptInteractive'] as string | undefined` — a TypeScript-only assertion with zero runtime validation. yargs's array-coercion behavior for repeated string options is well-known but unguarded here.

## Fix

Detect array coercion at the **parse boundary** (fail-fast at the actual bug source, not a defensive guard downstream):

- Added `rejectRepeatedStringOption()` to `cliArgParser.ts` — detects when yargs has coerced a string option to an array (meaning it was supplied more than once) and throws a clear parse-time error.
- Wired into `validatePromptModeArgs()`, which runs in **both** `.check()` validators (command-scope `validateLaunchArgs` and root-scope `validateRootArgs`), following the existing conflict-detection pattern already in the file.
- The user now sees `--prompt-interactive (-i) can only be specified once` instead of a React crash.

This follows the "fail fast" architecture preference: fix the real bug at its source rather than piling defensive guards at the `.trim()` call site (which the issue author explicitly rejected as too shallow).

## Test plan

Added 4 regression tests to `parseArgumentsParity.test.ts`:
- `repeated --prompt` -> clean parse error
- `repeated -p alias` -> clean parse error  
- `repeated --prompt-interactive` -> clean parse error
- `repeated -i alias` -> clean parse error

Also extracted `expectParseExit()` helper to reduce mock-setup boilerplate and added `vi.restoreAllMocks()` to `afterEach` for failure-safe cleanup.

## Verification

- `npm run typecheck` — PASS
- `npm run lint` (changed files) — clean
- `npm run lint:eslint-guard` — PASS
- `npm run format` — PASS
- `npm run build` — PASS
- 39/39 parity tests pass
- Smoke test: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku..."` — PASS
- Bug reproduction: `bun scripts/start.ts -i "say hi" -i "say bye"` now gives clean error `--prompt-interactive (-i) can only be specified once` (previously: React crash)

Fixes #2851


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line validation for repeated `--prompt` and `--prompt-interactive` options, including their short aliases.
  * Added clear error messages when these options are specified more than once.
  * Preserved validation preventing both prompt modes from being used together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->