### PR TITLE
Resize images for model input limits (Fixes #2038)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,6 +90,7 @@
         "picomatch": "4.0.4",
         "react": "^19.2.0",
         "read-package-up": "^11.0.0",
+        "sharp": "^0.35.3",
         "shell-quote": "^1.8.4",
         "simple-git": "^3.36.0",
         "string-width": "^8.1.0",
@@ -603,6 +604,7 @@
         "html-to-text": "^9.0.5",
         "mime-types": "^3.0.1",
         "node-fetch": "^3.3.2",
+        "sharp": "^0.35.3",
         "shell-quote": "^1.8.4",
         "turndown": "^7.2.2",
         "zod": "^3.25.76",
@@ -878,6 +880,8 @@
 
     "@dqbd/tiktoken": ["@dqbd/tiktoken@1.0.22", "", {}, "sha512-RYhO8xeHkMNX5Ixqf4M1Ve3siCYJY/dI0yLnlX4M4oIEDOvjMIQ+E+3OUpAaZcWTaMtQJzGcDAghYfllpx3i/w=="],
 
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
@@ -975,6 +979,60 @@
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@iarna/toml": ["@iarna/toml@2.2.5", "", {}, "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
+
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
+
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@2.0.7", "", {}, "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q=="],
 
@@ -2890,6 +2948,8 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" }, "peerDependencies": { "@types/node": "*" }, "optionalPeers": ["@types/node"] }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -3380,7 +3440,17 @@
 
     "@vybestack/llxprt-code/@vybestack/llxprt-code-auth": ["@vybestack/llxprt-code-auth@file:packages/auth", { "dependencies": { "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.8.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-ide-integration": ["@vybestack/llxprt-code-ide-integration@file:packages/ide-integration", { "dependencies": { "@modelcontextprotocol/sdk": "^1.25.2", "@vybestack/llxprt-code-telemetry": "file:../telemetry", "undici": "^7.28.0", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.219.0", "@opentelemetry/core": "^2.8.0", "@opentelemetry/instrumentation-http": "^0.219.0", "@opentelemetry/resources": "^2.8.0", "@opentelemetry/sdk-logs": "^0.219.0", "@opentelemetry/sdk-metrics": "^2.8.0", "@opentelemetry/sdk-trace-base": "^2.8.0", "@opentelemetry/sdk-trace-node": "^2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0", "@vybestack/llxprt-code-storage": "file:../storage", "debug": "^4.3.4" }, "devDependencies": { "@types/debug": "^4.1.12", "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^3.0.1", "node-fetch": "^3.3.2", "sharp": "^0.35.3", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-a2a-server/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
 
@@ -3388,7 +3458,15 @@
 
     "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-auth": ["@vybestack/llxprt-code-auth@file:packages/auth", { "dependencies": { "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.8.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-ide-integration": ["@vybestack/llxprt-code-ide-integration@file:packages/ide-integration", { "dependencies": { "@modelcontextprotocol/sdk": "^1.25.2", "@vybestack/llxprt-code-telemetry": "file:../telemetry", "undici": "^7.28.0", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-policy": ["@vybestack/llxprt-code-policy@file:packages/policy", { "dependencies": { "@iarna/toml": "^2.2.5", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^3.0.1", "node-fetch": "^3.3.2", "sharp": "^0.35.3", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-agents/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
@@ -3396,17 +3474,33 @@
 
     "@vybestack/llxprt-code-core/@vybestack/llxprt-code-auth": ["@vybestack/llxprt-code-auth@file:packages/auth", { "dependencies": { "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.8.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-ide-integration": ["@vybestack/llxprt-code-ide-integration@file:packages/ide-integration", { "dependencies": { "@modelcontextprotocol/sdk": "^1.25.2", "@vybestack/llxprt-code-telemetry": "file:../telemetry", "undici": "^7.28.0", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-core/@vybestack/llxprt-code-policy": ["@vybestack/llxprt-code-policy@file:packages/policy", { "dependencies": { "@iarna/toml": "^2.2.5", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-core/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.219.0", "@opentelemetry/core": "^2.8.0", "@opentelemetry/instrumentation-http": "^0.219.0", "@opentelemetry/resources": "^2.8.0", "@opentelemetry/sdk-logs": "^0.219.0", "@opentelemetry/sdk-metrics": "^2.8.0", "@opentelemetry/sdk-trace-base": "^2.8.0", "@opentelemetry/sdk-trace-node": "^2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0", "@vybestack/llxprt-code-storage": "file:../storage", "debug": "^4.3.4" }, "devDependencies": { "@types/debug": "^4.1.12", "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^3.0.1", "node-fetch": "^3.3.2", "sharp": "^0.35.3", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-core/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "@vybestack/llxprt-code-core/js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
+    "@vybestack/llxprt-code-ide-integration/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.219.0", "@opentelemetry/core": "^2.8.0", "@opentelemetry/instrumentation-http": "^0.219.0", "@opentelemetry/resources": "^2.8.0", "@opentelemetry/sdk-logs": "^0.219.0", "@opentelemetry/sdk-metrics": "^2.8.0", "@opentelemetry/sdk-trace-base": "^2.8.0", "@opentelemetry/sdk-trace-node": "^2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0", "@vybestack/llxprt-code-storage": "file:../storage", "debug": "^4.3.4" }, "devDependencies": { "@types/debug": "^4.1.12", "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-ide-integration/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
+
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^3.0.1", "node-fetch": "^3.3.2", "sharp": "^0.35.3", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-mcp/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
@@ -3414,7 +3508,13 @@
 
     "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-auth": ["@vybestack/llxprt-code-auth@file:packages/auth", { "dependencies": { "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.8.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^3.0.1", "node-fetch": "^3.3.2", "sharp": "^0.35.3", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-providers/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
@@ -3425,6 +3525,8 @@
     "@vybestack/llxprt-code-telemetry/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
+
+    "@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@x70102/ink/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -3597,6 +3699,8 @@
     "keytar/node-addon-api": ["node-addon-api@4.3.0", "", {}, "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="],
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "llxprt-code-vscode-ide-companion/@vybestack/llxprt-code-ide-integration": ["@vybestack/llxprt-code-ide-integration@file:packages/ide-integration", { "dependencies": { "@modelcontextprotocol/sdk": "^1.25.2", "@vybestack/llxprt-code-telemetry": "file:../telemetry", "undici": "^7.28.0", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "fast-check": "^4.2.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "load-json-file/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
 
@@ -3806,23 +3910,69 @@
 
     "@vscode/vsce/minimatch/brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-ide-integration/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", {}],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
+
     "@vybestack/llxprt-code-agents/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "@vybestack/llxprt-code-auth/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-ide-integration/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", {}],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-telemetry/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
+
     "@vybestack/llxprt-code-core/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
+    "@vybestack/llxprt-code-ide-integration/@vybestack/llxprt-code-telemetry/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
     "@vybestack/llxprt-code-ide-integration/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
 
     "@vybestack/llxprt-code-mcp/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "@vybestack/llxprt-code-policy/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
+
     "@vybestack/llxprt-code-providers/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "@vybestack/llxprt-code-telemetry/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
+    "@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
     "@vybestack/llxprt-code/@vybestack/llxprt-code-auth/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-ide-integration/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", {}],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-ide-integration/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -3911,6 +4061,10 @@
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "llxprt-code-vscode-ide-companion/@vybestack/llxprt-code-ide-integration/@vybestack/llxprt-code-telemetry": ["@vybestack/llxprt-code-telemetry@file:packages/telemetry", {}],
+
+    "llxprt-code-vscode-ide-companion/@vybestack/llxprt-code-ide-integration/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "multimatch/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
 
@@ -4056,6 +4210,10 @@
 
     "@vybestack/llxprt-code/@vybestack/llxprt-code-auth/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-ide-integration/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "archiver-utils/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
@@ -4095,6 +4253,8 @@
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "gradient-string/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "llxprt-code-vscode-ide-companion/@vybestack/llxprt-code-ide-integration/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "npm-run-all/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 

--- a/docs/reference/ephemerals.md
+++ b/docs/reference/ephemerals.md
@@ -53,6 +53,19 @@ Prevent tools from flooding the context. Applied to all tools via the batch sche
 | `tool-output-item-size-limit` | number | `524288` (512KB)                  | yes     | Max bytes per individual file/item. Prevents one huge file from consuming the budget.                                                                                       |
 | `file-read-max-lines`         | number | `2000`                            | yes     | Default max lines when reading a text file with no explicit limit. Prevents accidentally reading massive files.                                                             |
 
+## Image Resizing
+
+`read_file` and explicitly requested images in `read_many_files` automatically downscale images when an effective model or profile limit is present. The fit preserves aspect ratio and never upscales. Images already within every configured limit are returned byte-for-byte without re-encoding. Resized PNG, JPEG, GIF, and WebP inputs retain their MIME type and container; animated GIF/WebP inputs retain their frame count. Resize-required corrupt images and unsupported containers fail clearly rather than returning oversized originals.
+
+| Setting                     | Type    | Default       | Profile | Description                                                                                        |
+| --------------------------- | ------- | ------------- | ------- | -------------------------------------------------------------------------------------------------- |
+| `image-resize.enabled`      | boolean | model default | yes     | Set `false` to disable automatic image resizing, including model defaults, and preserve originals. |
+| `image-resize.maxLongEdge`  | number  | model default | yes     | Positive integer maximum for the orientation-independent longer edge, in pixels.                   |
+| `image-resize.maxShortEdge` | number  | model default | yes     | Positive integer maximum for the orientation-independent shorter edge, in pixels.                  |
+| `image-resize.maxPixels`    | number  | model default | yes     | Positive integer maximum decoded pixel count.                                                      |
+
+Built-in visual-model aliases provide conservative advisory defaults: Claude Opus/Sonnet use `1568`/`1568`/`1229312`; OpenAI `gpt-*` uses `2048`/`2048`/`1572864`; Kimi uses `4096`/`2160`/`8847360` (long edge/short edge/pixels). These are useful-resolution targets, not universal provider hard limits. Explicit profile values take precedence over model defaults. When no limit is configured, image reads retain legacy byte-for-byte behavior. Setting `image-resize.enabled false` disables all automatic limits for the profile. For one `read_file` call, pass `skip_image_resize: true` to return the original image; `read_many_files` has no per-call opt-out.
+
 ## Timeouts
 
 Prevent commands and tasks from hanging indefinitely. In seconds (not milliseconds, despite older docs).

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,7 @@
         "picomatch": "4.0.4",
         "react": "^19.2.0",
         "read-package-up": "^11.0.0",
+        "sharp": "^0.35.3",
         "shell-quote": "^1.8.4",
         "simple-git": "^3.36.0",
         "string-width": "^8.1.0",
@@ -1739,6 +1740,16 @@
       "integrity": "sha512-RYhO8xeHkMNX5Ixqf4M1Ve3siCYJY/dI0yLnlX4M4oIEDOvjMIQ+E+3OUpAaZcWTaMtQJzGcDAghYfllpx3i/w==",
       "license": "MIT"
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -2698,6 +2709,506 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.7",
@@ -10419,9 +10930,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -18774,6 +19283,55 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -20576,7 +21134,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tunnel": {
@@ -23950,6 +24508,7 @@
         "html-to-text": "^9.0.5",
         "mime-types": "^3.0.1",
         "node-fetch": "^3.3.2",
+        "sharp": "^0.35.3",
         "shell-quote": "^1.8.4",
         "turndown": "^7.2.2",
         "zod": "^3.25.76",

--- a/package.json
+++ b/package.json
@@ -338,6 +338,7 @@
     "react": "^19.2.0",
     "read-package-up": "^11.0.0",
     "shell-quote": "^1.8.4",
+    "sharp": "^0.35.3",
     "simple-git": "^3.36.0",
     "string-width": "^8.1.0",
     "strip-ansi": "^7.1.0",

--- a/packages/providers/src/composition/aliases/anthropic.config
+++ b/packages/providers/src/composition/aliases/anthropic.config
@@ -18,7 +18,11 @@
         "reasoning.adaptiveThinking": true,
         "reasoning.includeInContext": true
       },
-      "unallowedParameters": ["temperature", "top_p", "top_k"]
+      "unallowedParameters": [
+        "temperature",
+        "top_p",
+        "top_k"
+      ]
     },
     {
       "pattern": "claude-(opus-5|opus-4-8|fable-5|sonnet-4-6|sonnet-5)",
@@ -26,6 +30,14 @@
         "reasoning.effort": "high",
         "context-limit": 1000000,
         "maxOutputTokens": 128000
+      }
+    },
+    {
+      "pattern": "^claude-(opus|sonnet)(?:-|$)",
+      "ephemeralSettings": {
+        "image-resize.maxLongEdge": 1568,
+        "image-resize.maxShortEdge": 1568,
+        "image-resize.maxPixels": 1229312
       }
     }
   ]

--- a/packages/providers/src/composition/aliases/claudecode.config
+++ b/packages/providers/src/composition/aliases/claudecode.config
@@ -25,6 +25,14 @@
         "context-limit": 1000000,
         "maxOutputTokens": 128000
       }
+    },
+    {
+      "pattern": "^claude-(opus|sonnet)(?:-|$)",
+      "ephemeralSettings": {
+        "image-resize.maxLongEdge": 1568,
+        "image-resize.maxShortEdge": 1568,
+        "image-resize.maxPixels": 1229312
+      }
     }
   ],
   "staticModels": [

--- a/packages/providers/src/composition/aliases/codex.config
+++ b/packages/providers/src/composition/aliases/codex.config
@@ -16,16 +16,55 @@
     {
       "pattern": "gpt-5",
       "ephemeralSettings": {},
-      "unallowedParameters": ["temperature", "top_p", "top_k", "frequency_penalty", "presence_penalty"]
+      "unallowedParameters": [
+        "temperature",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ]
+    },
+    {
+      "pattern": "^gpt-",
+      "ephemeralSettings": {
+        "image-resize.maxLongEdge": 2048,
+        "image-resize.maxShortEdge": 2048,
+        "image-resize.maxPixels": 1572864
+      }
     }
   ],
   "staticModels": [
-    { "id": "gpt-5.6-sol", "name": "GPT-5.6 Sol", "contextWindow": 262144 },
-    { "id": "gpt-5.6-terra", "name": "GPT-5.6 Terra", "contextWindow": 262144 },
-    { "id": "gpt-5.6-luna", "name": "GPT-5.6 Luna", "contextWindow": 262144 },
-    { "id": "gpt-5.5", "name": "gpt-5.5" },
-    { "id": "gpt-5.4", "name": "gpt-5.4" },
-    { "id": "gpt-5.4-mini", "name": "gpt-5.4-mini" },
-    { "id": "gpt-5.3-codex-spark", "name": "gpt-5.3-codex-spark", "contextWindow": 131072 }
+    {
+      "id": "gpt-5.6-sol",
+      "name": "GPT-5.6 Sol",
+      "contextWindow": 262144
+    },
+    {
+      "id": "gpt-5.6-terra",
+      "name": "GPT-5.6 Terra",
+      "contextWindow": 262144
+    },
+    {
+      "id": "gpt-5.6-luna",
+      "name": "GPT-5.6 Luna",
+      "contextWindow": 262144
+    },
+    {
+      "id": "gpt-5.5",
+      "name": "gpt-5.5"
+    },
+    {
+      "id": "gpt-5.4",
+      "name": "gpt-5.4"
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "name": "gpt-5.4-mini"
+    },
+    {
+      "id": "gpt-5.3-codex-spark",
+      "name": "gpt-5.3-codex-spark",
+      "contextWindow": 131072
+    }
   ]
 }

--- a/packages/providers/src/composition/aliases/kimi.config
+++ b/packages/providers/src/composition/aliases/kimi.config
@@ -51,7 +51,10 @@
         "reasoning.includeInContext": true,
         "reasoning.stripFromContext": "none",
         "max_tokens": 32768,
-        "context-limit": 262144
+        "context-limit": 262144,
+        "image-resize.maxLongEdge": 4096,
+        "image-resize.maxShortEdge": 2160,
+        "image-resize.maxPixels": 8847360
       },
       "unallowedParameters": [
         "temperature",

--- a/packages/providers/src/composition/aliases/openai-responses.config
+++ b/packages/providers/src/composition/aliases/openai-responses.config
@@ -5,5 +5,15 @@
   "baseProvider": "openai-responses",
   "base-url": "https://api.openai.com/v1",
   "defaultModel": "gpt-4o",
-  "apiKeyEnv": "OPENAI_API_KEY"
+  "apiKeyEnv": "OPENAI_API_KEY",
+  "modelDefaults": [
+    {
+      "pattern": "^gpt-",
+      "ephemeralSettings": {
+        "image-resize.maxLongEdge": 2048,
+        "image-resize.maxShortEdge": 2048,
+        "image-resize.maxPixels": 1572864
+      }
+    }
+  ]
 }

--- a/packages/providers/src/composition/aliases/openai-vercel.config
+++ b/packages/providers/src/composition/aliases/openai-vercel.config
@@ -5,5 +5,15 @@
   "baseProvider": "openai-vercel",
   "base-url": "https://api.openai.com/v1",
   "defaultModel": "gpt-4o",
-  "apiKeyEnv": "OPENAI_API_KEY"
+  "apiKeyEnv": "OPENAI_API_KEY",
+  "modelDefaults": [
+    {
+      "pattern": "^gpt-",
+      "ephemeralSettings": {
+        "image-resize.maxLongEdge": 2048,
+        "image-resize.maxShortEdge": 2048,
+        "image-resize.maxPixels": 1572864
+      }
+    }
+  ]
 }

--- a/packages/providers/src/composition/aliases/openai.config
+++ b/packages/providers/src/composition/aliases/openai.config
@@ -10,7 +10,13 @@
     {
       "pattern": "gpt-5",
       "ephemeralSettings": {},
-      "unallowedParameters": ["temperature", "top_p", "top_k", "frequency_penalty", "presence_penalty"]
+      "unallowedParameters": [
+        "temperature",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ]
     },
     {
       "pattern": "gpt-5.6",
@@ -20,6 +26,14 @@
         "context-limit": 1050000,
         "maxOutputTokens": 128000,
         "prompt-caching": "24h"
+      }
+    },
+    {
+      "pattern": "^gpt-",
+      "ephemeralSettings": {
+        "image-resize.maxLongEdge": 2048,
+        "image-resize.maxShortEdge": 2048,
+        "image-resize.maxPixels": 1572864
       }
     }
   ]

--- a/packages/providers/src/composition/providerAliases.kimi.test.ts
+++ b/packages/providers/src/composition/providerAliases.kimi.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { computeModelDefaults } from '../runtime/providerMutations.js';
 import { loadProviderAliasEntries } from './providerAliases.js';
 
 describe('builtin kimi provider alias', () => {
@@ -142,5 +143,27 @@ describe('builtin kimi provider alias', () => {
     expect(entry?.config.mediaSupport?.inlineImages).toBe(true);
     expect(entry?.config.mediaSupport?.fileUpload).toBe(true);
     expect(entry?.config.mediaSupport?.videoSupport).toBe(true);
+  });
+
+  it('applies family-wide image limits to Kimi vision models', () => {
+    const entry = loadProviderAliasEntries().find(
+      (candidate) => candidate.alias === 'kimi',
+    );
+    const broadRule = entry?.config.modelDefaults?.find(
+      (rule) => rule.pattern === '^kimi|^k3-256k$',
+    );
+
+    const imageLimits = {
+      'image-resize.maxLongEdge': 4096,
+      'image-resize.maxShortEdge': 2160,
+      'image-resize.maxPixels': 8_847_360,
+    };
+    expect(broadRule?.ephemeralSettings).toMatchObject(imageLimits);
+    const rules = entry?.config.modelDefaults ?? [];
+    expect(computeModelDefaults('kimi-k3', rules)).toMatchObject(imageLimits);
+    expect(computeModelDefaults('k3-256k', rules)).toMatchObject(imageLimits);
+    expect(computeModelDefaults('custom-model', rules)).not.toHaveProperty(
+      'image-resize.maxLongEdge',
+    );
   });
 });

--- a/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
+++ b/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
@@ -21,6 +21,14 @@ import {
   type ModelDefaultRule,
 } from './providerAliases.js';
 
+function expectNoImageResizeDefaults(
+  defaults: Readonly<Record<string, unknown>>,
+): void {
+  expect(defaults).not.toHaveProperty('image-resize.maxLongEdge');
+  expect(defaults).not.toHaveProperty('image-resize.maxShortEdge');
+  expect(defaults).not.toHaveProperty('image-resize.maxPixels');
+}
+
 /**
  * Helper to load entries from a temp user alias dir via Storage mock.
  * Shared across multiple test suites to avoid sonarjs/no-identical-functions.
@@ -625,6 +633,53 @@ describe('anthropic.config modelDefaults (Phase 02)', () => {
     expect(defaults['context-limit']).toBe(1000000);
   });
 
+  it.each(['anthropic', 'claudecode'])(
+    '%s applies image limits to Opus and Sonnet families only',
+    (alias) => {
+      const entry = loadProviderAliasEntries().find(
+        (candidate) =>
+          candidate.alias === alias && candidate.source === 'builtin',
+      );
+      expect(entry).toBeDefined();
+      const rules = entry?.config.modelDefaults ?? [];
+      for (const model of [
+        'claude-opus-4-5-20251101',
+        'claude-opus-5',
+        'claude-sonnet-4-20250514',
+        'claude-sonnet-5',
+      ]) {
+        expect(computeMatchedDefaults(model, rules)).toMatchObject({
+          'image-resize.maxLongEdge': 1568,
+          'image-resize.maxShortEdge': 1568,
+          'image-resize.maxPixels': 1_229_312,
+        });
+      }
+      expectNoImageResizeDefaults(
+        computeMatchedDefaults('claude-haiku-4-5', rules),
+      );
+      expectNoImageResizeDefaults(
+        computeMatchedDefaults('claude-fable-5', rules),
+      );
+    },
+  );
+
+  it.each(['openai', 'openai-responses', 'openai-vercel', 'codex'])(
+    '%s applies image limits to every gpt- family model',
+    (alias) => {
+      const entry = loadProviderAliasEntries().find(
+        (candidate) =>
+          candidate.alias === alias && candidate.source === 'builtin',
+      );
+      expect(entry).toBeDefined();
+      const rules = entry?.config.modelDefaults ?? [];
+      expect(computeMatchedDefaults('gpt-future-vision', rules)).toMatchObject({
+        'image-resize.maxLongEdge': 2048,
+        'image-resize.maxShortEdge': 2048,
+        'image-resize.maxPixels': 1_572_864,
+      });
+      expectNoImageResizeDefaults(computeMatchedDefaults('o4-mini', rules));
+    },
+  );
   it('user anthropic.config with different modelDefaults shadows the builtin', async () => {
     const { Storage } = await import('@vybestack/llxprt-code-settings');
     const fakeLlxprtDir = path.join(tmpDir, '.llxprt');

--- a/packages/settings/src/__tests__/settingsRegistry.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.test.ts
@@ -378,6 +378,27 @@ describe('validateSetting — validation', () => {
     expect(result.success).toBe(false);
   });
 
+  it('validates the image resize enabled profile setting', () => {
+    expect(validateSetting('image-resize.enabled', true).success).toBe(true);
+    expect(validateSetting('image-resize.enabled', false).success).toBe(true);
+    expect(validateSetting('image-resize.enabled', 'yes').success).toBe(false);
+  });
+
+  it.each([
+    'image-resize.maxLongEdge',
+    'image-resize.maxShortEdge',
+    'image-resize.maxPixels',
+  ])('validates numeric image resize profile setting %s', (key) => {
+    expect(validateSetting(key, 2048).success).toBe(true);
+    expect(validateSetting(key, 0).success).toBe(false);
+    expect(validateSetting(key, -1).success).toBe(false);
+    expect(validateSetting(key, 1.5).success).toBe(false);
+    expect(validateSetting(key, '2048').success).toBe(false);
+    expect(validateSetting(key, NaN).success).toBe(false);
+    expect(validateSetting(key, Infinity).success).toBe(false);
+    expect(getProfilePersistableKeys()).toContain(key);
+  });
+
   it('rejects Infinity for compression-threshold', () => {
     const result = validateSetting('compression-threshold', Infinity);
     expect(result.success).toBe(false);

--- a/packages/settings/src/profiles/types.ts
+++ b/packages/settings/src/profiles/types.ts
@@ -73,6 +73,10 @@ export interface EphemeralSettings {
   'tool-output-max-tokens'?: number;
   'tool-output-truncate-mode'?: 'warn' | 'truncate' | 'sample';
   'tool-output-item-size-limit'?: number;
+  'image-resize.enabled'?: boolean;
+  'image-resize.maxLongEdge'?: number;
+  'image-resize.maxShortEdge'?: number;
+  'image-resize.maxPixels'?: number;
   'max-prompt-tokens'?: number;
   'disabled-tools'?: string[];
   'shell-replacement'?: 'allowlist' | 'all' | 'none' | boolean;

--- a/packages/settings/src/settings/registry/registry-entries-1.ts
+++ b/packages/settings/src/settings/registry/registry-entries-1.ts
@@ -407,6 +407,45 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     },
   },
   {
+    key: 'image-resize.enabled',
+    category: 'cli-behavior',
+    description: 'Enable automatic model-aware resizing for image file reads',
+    type: 'boolean',
+    persistToProfile: true,
+  },
+  ...[
+    {
+      key: 'image-resize.maxLongEdge',
+      description: 'Maximum image long edge in pixels',
+    },
+    {
+      key: 'image-resize.maxShortEdge',
+      description: 'Maximum image short edge in pixels',
+    },
+    {
+      key: 'image-resize.maxPixels',
+      description: 'Maximum total decoded image pixels',
+    },
+  ].map(
+    ({ key, description }): SettingSpec => ({
+      key,
+      category: 'cli-behavior',
+      description,
+      type: 'number',
+      hint: 'positive integer pixels',
+      persistToProfile: true,
+      validate: (value: unknown): ValidationResult => {
+        if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+          return { success: true, value };
+        }
+        return {
+          success: false,
+          message: `${key} must be a positive integer`,
+        };
+      },
+    }),
+  ),
+  {
     key: 'tool-output-max-tokens',
     category: 'cli-behavior',
     description: 'Maximum tokens in tool output',

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -258,7 +258,8 @@
     "@ast-grep/lang-ruby": "^0.0.6",
     "@ast-grep/lang-rust": "^0.0.6",
     "@lvce-editor/ripgrep": "^1.6.0",
-    "mime-types": "^3.0.1"
+    "mime-types": "^3.0.1",
+    "sharp": "^0.35.3"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",

--- a/packages/tools/src/__tests__/filesystem-tools.test.ts
+++ b/packages/tools/src/__tests__/filesystem-tools.test.ts
@@ -33,6 +33,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import sharp from 'sharp';
 import type { IToolHost, IStorageService } from '../interfaces/index.js';
 import {
   DeleteLineRangeTool,
@@ -81,7 +82,10 @@ function createTempDir(prefix = 'llxprt-fs-test-'): {
 /**
  * Minimal structural fake for IToolHost providing a temp directory.
  */
-function _createFakeFileHost(targetDir: string): IToolHost {
+function _createFakeFileHost(
+  targetDir: string,
+  ephemeralSettings: Record<string, unknown> = {},
+): IToolHost {
   return {
     getTargetDir: () => targetDir,
     getWorkspaceRoots: () => [targetDir],
@@ -106,7 +110,7 @@ function _createFakeFileHost(targetDir: string): IToolHost {
     recordFileRead: () => {},
     getFileSystemService: () => undefined,
     getLlxprtIgnorePatterns: () => [],
-    getEphemeralSettings: () => ({}),
+    getEphemeralSettings: () => ({ ...ephemeralSettings }),
     getDebugMode: () => false,
   };
 }
@@ -163,6 +167,40 @@ async function executeDeclarativeToolForBehavioralAssertion(
   }
 }
 
+function readInlineImage(result: ToolResult): {
+  data: Buffer;
+  mimeType: string | undefined;
+  displayName: string | undefined;
+} {
+  if (typeof result.llmContent === 'string') {
+    throw new Error(result.llmContent);
+  }
+  const inlineData = result.llmContent.inlineData;
+  if (inlineData?.data === undefined) {
+    throw new Error('Expected inline image data');
+  }
+  return {
+    data: Buffer.from(inlineData.data, 'base64'),
+    mimeType: inlineData.mimeType,
+    displayName: inlineData.displayName,
+  };
+}
+
+async function createPngFixture(
+  targetDir: string,
+  fileName: string,
+  background: { r: number; g: number; b: number },
+): Promise<{ filePath: string; original: Buffer }> {
+  const filePath = join(targetDir, fileName);
+  const original = await sharp({
+    create: { width: 240, height: 120, channels: 3, background },
+  })
+    .png()
+    .toBuffer();
+  writeFileSync(filePath, original);
+  return { filePath, original };
+}
+
 describe('Filesystem Tool Group Behavioral Tests @plan:PLAN-20260608-ISSUE1585.P10', () => {
   let tempDir: string;
   let cleanup: () => void;
@@ -211,6 +249,133 @@ describe('Filesystem Tool Group Behavioral Tests @plan:PLAN-20260608-ISSUE1585.P
 
       expect(result.error).toContain('does-not-exist.txt');
       expect(result.llmContent).toContain('does-not-exist.txt');
+    });
+
+    it('resizes an oversized image according to effective profile limits', async () => {
+      const { filePath } = await createPngFixture(tempDir, 'oversized.png', {
+        r: 90,
+        g: 120,
+        b: 150,
+      });
+      const tool = new ReadFileTool(
+        _createFakeFileHost(tempDir, {
+          'image-resize.maxLongEdge': 120,
+        }),
+      );
+
+      const result = await executeToolForBehavioralAssertion(tool, {
+        file_path: filePath,
+      });
+      const image = readInlineImage(result);
+      const metadata = await sharp(image.data).metadata();
+
+      expect(metadata.autoOrient).toEqual({ width: 120, height: 60 });
+      expect(image.mimeType).toBe('image/png');
+      expect(image.displayName).toBe('oversized.png');
+    });
+
+    it('preserves original bytes when profile resizing is explicitly disabled', async () => {
+      const { filePath, original } = await createPngFixture(
+        tempDir,
+        'disabled.png',
+        { r: 120, g: 90, b: 60 },
+      );
+      const tool = new ReadFileTool(
+        _createFakeFileHost(tempDir, {
+          'image-resize.enabled': false,
+          'image-resize.maxLongEdge': 120,
+        }),
+      );
+
+      const result = await executeToolForBehavioralAssertion(tool, {
+        file_path: filePath,
+      });
+
+      expect(readInlineImage(result).data).toEqual(original);
+    });
+
+    it('exposes and honors skip_image_resize for a single image read', async () => {
+      const { filePath, original } = await createPngFixture(
+        tempDir,
+        'original.png',
+        { r: 30, g: 60, b: 90 },
+      );
+      const tool = new ReadFileTool(
+        _createFakeFileHost(tempDir, {
+          'image-resize.maxLongEdge': 120,
+        }),
+      );
+
+      expect(tool.schema.parametersJsonSchema).toMatchObject({
+        properties: {
+          skip_image_resize: { type: 'boolean' },
+        },
+      });
+      const result = await executeToolForBehavioralAssertion(tool, {
+        file_path: filePath,
+        skip_image_resize: true,
+      });
+
+      expect(readInlineImage(result).data).toEqual(original);
+    });
+
+    it('preserves exact image bytes when no resize policy is configured', async () => {
+      const { filePath, original } = await createPngFixture(
+        tempDir,
+        'absent-policy.png',
+        { r: 15, g: 45, b: 75 },
+      );
+
+      const result = await executeToolForBehavioralAssertion(
+        new ReadFileTool(_createFakeFileHost(tempDir)),
+        { file_path: filePath },
+      );
+
+      expect(readInlineImage(result).data).toEqual(original);
+    });
+
+    it('returns a clear error for malformed image resize settings', async () => {
+      const { filePath } = await createPngFixture(
+        tempDir,
+        'invalid-policy.png',
+        {
+          r: 15,
+          g: 30,
+          b: 45,
+        },
+      );
+      const tool = new ReadFileTool(
+        _createFakeFileHost(tempDir, {
+          'image-resize.maxLongEdge': 0,
+        }),
+      );
+
+      const result = await executeToolForBehavioralAssertion(tool, {
+        file_path: filePath,
+      });
+
+      expect(result.error).toContain(
+        'image-resize.maxLongEdge must be a positive integer',
+      );
+      expect(result.returnDisplay).toContain(
+        'Image Resize Configuration Error',
+      );
+    });
+
+    it('returns a clear error for corrupt images under automatic resizing', async () => {
+      const filePath = join(tempDir, 'corrupt.png');
+      writeFileSync(filePath, Buffer.from('corrupt image bytes'));
+      const tool = new ReadFileTool(
+        _createFakeFileHost(tempDir, {
+          'image-resize.maxLongEdge': 120,
+        }),
+      );
+
+      const result = await executeToolForBehavioralAssertion(tool, {
+        file_path: filePath,
+      });
+
+      expect(result.error).toContain('Unable to resize image corrupt.png');
     });
   });
 

--- a/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
+++ b/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
@@ -8,6 +8,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { writeFileSync, mkdirSync, rmSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import sharp from 'sharp';
 import { createRealToolHost as createRealHost } from './helpers/create-real-tool-host.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
 import type { ToolResult } from '../index.js';
@@ -35,6 +37,33 @@ function stringifyLlmContent(result: ToolResult): string {
         .map((part) => (typeof part === 'string' ? part : JSON.stringify(part)))
         .join('\n')
     : String(result.llmContent);
+}
+function findInlineImage(result: ToolResult): Buffer {
+  if (!Array.isArray(result.llmContent)) {
+    throw new Error('Expected multipart read-many-files content');
+  }
+  for (const part of result.llmContent) {
+    if (typeof part !== 'string' && part.inlineData?.data !== undefined) {
+      return Buffer.from(part.inlineData.data, 'base64');
+    }
+  }
+  throw new Error('Expected inline image data');
+}
+function createHostWithSettings(
+  targetDir: string,
+  settings: Readonly<Record<string, unknown>>,
+) {
+  const baseHost = createRealHost(targetDir, {
+    respectGitIgnore: true,
+    respectLlxprtIgnore: true,
+  });
+  return {
+    ...baseHost,
+    getEphemeralSettings: () => ({
+      ...baseHost.getEphemeralSettings(),
+      ...settings,
+    }),
+  };
 }
 
 describe('ReadManyFilesTool real behavioral filtering', () => {
@@ -163,4 +192,136 @@ describe('ReadManyFilesTool real behavioral filtering', () => {
     // keeps the focus on keep.txt being restored by the .llxprtignore negation.
     expect(content).not.toContain('secret content');
   });
+
+  it('resizes explicitly requested images through the shared media path', async () => {
+    const filePath = join(tempDir, 'large.png');
+    const original = await sharp({
+      create: {
+        width: 240,
+        height: 120,
+        channels: 3,
+        background: { r: 45, g: 90, b: 135 },
+      },
+    })
+      .png()
+      .toBuffer();
+    writeFileSync(filePath, original);
+    const host = createHostWithSettings(tempDir, {
+      'image-resize.maxLongEdge': 120,
+    });
+
+    const result = await new ReadManyFilesTool(host).execute({
+      paths: ['large.png'],
+    });
+    const metadata = await sharp(findInlineImage(result)).metadata();
+
+    expect(metadata.autoOrient).toEqual({ width: 120, height: 60 });
+  });
+
+  it('preserves image bytes when no resize limit is configured', async () => {
+    const filePath = join(tempDir, 'legacy.png');
+    const original = await sharp({
+      create: {
+        width: 240,
+        height: 120,
+        channels: 3,
+        background: { r: 135, g: 90, b: 45 },
+      },
+    })
+      .png()
+      .toBuffer();
+    writeFileSync(filePath, original);
+    const host = createRealHost(tempDir, {
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    });
+
+    const result = await new ReadManyFilesTool(host).execute({
+      paths: ['legacy.png'],
+    });
+
+    expect(findInlineImage(result)).toEqual(original);
+  });
+
+  it('resizes an explicitly requested noisy image before enforcing returned-byte limits', async () => {
+    const filePath = join(tempDir, 'noisy.png');
+    const original = await sharp(randomBytes(900 * 700 * 3), {
+      raw: { width: 900, height: 700, channels: 3 },
+    })
+      .png({ compressionLevel: 0 })
+      .toBuffer();
+    expect(original.byteLength).toBeGreaterThan(512 * 1024);
+    writeFileSync(filePath, original);
+    const host = createHostWithSettings(tempDir, {
+      'image-resize.maxLongEdge': 64,
+      'tool-output-item-size-limit': 512 * 1024,
+    });
+
+    const result = await new ReadManyFilesTool(host).execute({
+      paths: ['noisy.png'],
+    });
+    const resized = findInlineImage(result);
+
+    expect(result.error).toBeUndefined();
+    expect(resized.byteLength).toBeLessThanOrEqual(512 * 1024);
+    expect((await sharp(resized).metadata()).width).toBeLessThanOrEqual(64);
+  });
+
+  it('returns a clear ToolResult error for malformed resize settings', async () => {
+    const host = createHostWithSettings(tempDir, {
+      'image-resize.maxLongEdge': 0,
+    });
+
+    const result = await new ReadManyFilesTool(host).execute({
+      paths: ['keep.txt'],
+    });
+
+    expect(result.error).toMatchObject({
+      message: expect.stringContaining(
+        'image-resize.maxLongEdge must be a positive integer',
+      ),
+    });
+    expect(result.returnDisplay).toContain('Image Resize Error');
+  });
+
+  it.each([
+    {
+      name: 'corrupt',
+      extension: 'png',
+      create: async () => Buffer.from('corrupt image bytes'),
+    },
+    {
+      name: 'unsupported',
+      extension: 'tiff',
+      create: async () =>
+        sharp({
+          create: {
+            width: 200,
+            height: 100,
+            channels: 3,
+            background: { r: 20, g: 40, b: 60 },
+          },
+        })
+          .tiff()
+          .toBuffer(),
+    },
+  ])(
+    'returns a clear ToolResult error for $name image resizing',
+    async (fixture) => {
+      const fileName = `${fixture.name}.${fixture.extension}`;
+      writeFileSync(join(tempDir, fileName), await fixture.create());
+      const host = createHostWithSettings(tempDir, {
+        'image-resize.maxLongEdge': 50,
+      });
+
+      const result = await new ReadManyFilesTool(host).execute({
+        paths: [fileName],
+      });
+
+      expect(result.error).toMatchObject({
+        message: expect.stringContaining(`Unable to resize image ${fileName}`),
+      });
+      expect(result.returnDisplay).toContain('Image Resize Error');
+    },
+  );
 });

--- a/packages/tools/src/tools/read-file.ts
+++ b/packages/tools/src/tools/read-file.ts
@@ -27,6 +27,8 @@ import type { GitLineChangeMarker } from '../utils/gitLineChanges.js';
 import { getGitLineChanges } from '../utils/gitLineChanges.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
 import { stringOrDefault } from '../utils/stringCoalescing.js';
+import { resolveImageResizePolicy } from '../utils/imageResize.js';
+import { ToolErrorType } from '../types/tool-error.js';
 
 /**
  * Parameters for the ReadFile tool
@@ -62,6 +64,11 @@ export interface ReadFileToolParams {
    * When true, prefixes each text line with a git-change marker column.
    */
   showGitChanges?: boolean;
+
+  /**
+   * When true, returns original image bytes for this call.
+   */
+  skip_image_resize?: boolean;
 }
 
 function formatWithLineNumbers(content: string, startLine: number): string {
@@ -283,12 +290,27 @@ ${formattedContent}`;
       this.params.limit ??
       (ephemeralSettings['file-read-max-lines'] as number | undefined) ??
       DEFAULT_MAX_LINES_TEXT_FILE;
+    let imageResizePolicy;
+    try {
+      imageResizePolicy = resolveImageResizePolicy(
+        ephemeralSettings,
+        this.params.skip_image_resize === true,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        llmContent: message,
+        returnDisplay: `## Image Resize Configuration Error\n\n${message}`,
+        error: { message, type: ToolErrorType.READ_CONTENT_FAILURE },
+      };
+    }
 
     const result = await processSingleFileContent(
       this.getFilePath(),
       this.host.getTargetDir(),
       this.params.offset,
       effectiveLimit,
+      imageResizePolicy,
     );
 
     if (result.error) {
@@ -396,6 +418,11 @@ If git status cannot be read, the tool will still return file content and includ
           showGitChanges: {
             description:
               "Optional: When true (text files only), prefixes each returned line with a single-character git-change marker column computed relative to HEAD (includes staged and unstaged changes). This marker column is virtual and not part of the file content. Legend: '░' unchanged, 'N' new, 'M' modified, 'D' deletion after line. Column order: git marker first, then (optional) the virtual line number column, then line content. If git status cannot be read, content is still returned and a brief warning is included.",
+            type: 'boolean',
+          },
+          skip_image_resize: {
+            description:
+              'Optional: When true, returns original image bytes without applying configured automatic resizing. This has no effect on non-image files.',
             type: 'boolean',
           },
         },

--- a/packages/tools/src/tools/read-many-files.ts
+++ b/packages/tools/src/tools/read-many-files.ts
@@ -17,16 +17,27 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { glob, escape as globEscape } from 'glob';
 import {
+  createImageResizeToolResult,
   detectFileType,
+  getImageResizeToolResult,
+  getImageSourceSizeLimit,
+  getProcessedFileSkipReason,
+  isAssetExplicitlyRequested,
+  type ProcessedFileReadResult,
   processSingleFileContent,
+  shouldResizeExplicitImage,
   DEFAULT_ENCODING,
-  getSpecificMimeType,
   DEFAULT_MAX_LINES_TEXT_FILE,
+  getSpecificMimeType,
 } from '../utils/fileUtils.js';
 import { type ContentPartUnion } from '../types/wire-types.js';
 import { stat } from 'fs/promises';
 import { ToolErrorType } from '../types/tool-error.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
+import {
+  resolveImageResizePolicy,
+  type ImageResizePolicy,
+} from '../utils/imageResize.js';
 import {
   buildParameterSchema,
   formatExcludePatterns,
@@ -43,6 +54,9 @@ interface AddFileContentResult {
   totalTokens: number;
   action: AddFileContentAction;
 }
+
+type ProcessFilesResult = Readonly<{ totalTokens: number; error?: ToolResult }>;
+type ProcessSingleFileResult = ProcessFilesResult & { readonly done: boolean };
 
 /**
  * Parameters for the ReadManyFilesTool.
@@ -226,7 +240,7 @@ ${this.host.getTargetDir()}
     contentParts: Array<string | ContentPartUnion>,
     limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
   ): Promise<ToolResult> {
-    const totalTokens = await this.processFiles(
+    const processResult = await this.processFiles(
       sortedFiles,
       inputPatterns,
       skippedFiles,
@@ -234,11 +248,14 @@ ${this.host.getTargetDir()}
       contentParts,
       limits,
     );
+    if (processResult.error !== undefined) {
+      return processResult.error;
+    }
 
     const displayMessage = this.buildDisplayMessage(
       processedFilesRelativePaths,
       skippedFiles,
-      totalTokens,
+      processResult.totalTokens,
     );
 
     if (contentParts.length > 0) {
@@ -499,7 +516,21 @@ ${this.host.getTargetDir()}
     processedFilesRelativePaths: string[],
     contentParts: Array<string | ContentPartUnion>,
     limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
-  ): Promise<number> {
+  ): Promise<ProcessFilesResult> {
+    const ephemeralSettings = this.host.getEphemeralSettings();
+    let imageResizePolicy: ImageResizePolicy | undefined;
+    try {
+      imageResizePolicy = resolveImageResizePolicy(ephemeralSettings);
+    } catch (error) {
+      return createImageResizeToolResult(
+        getErrorMessage(error),
+        ToolErrorType.READ_CONTENT_FAILURE,
+        0,
+      );
+    }
+    const maxLinesPerFile =
+      (ephemeralSettings['file-read-max-lines'] as number | undefined) ??
+      DEFAULT_MAX_LINES_TEXT_FILE;
     let totalTokens = 0;
     for (const filePath of sortedFiles) {
       const result = await this.processSingleFile(
@@ -511,13 +542,15 @@ ${this.host.getTargetDir()}
         contentParts,
         limits,
         totalTokens,
+        imageResizePolicy,
+        maxLinesPerFile,
       );
-      if (result.done) {
-        return result.totalTokens;
+      if (result.error !== undefined || result.done) {
+        return result;
       }
       totalTokens = result.totalTokens;
     }
-    return totalTokens;
+    return { totalTokens };
   }
 
   private async processSingleFile(
@@ -529,37 +562,52 @@ ${this.host.getTargetDir()}
     contentParts: Array<string | ContentPartUnion>,
     limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
     currentTokens: number,
-  ): Promise<{ done: boolean; totalTokens: number }> {
+    imageResizePolicy: ImageResizePolicy | undefined,
+    maxLinesPerFile: number,
+  ): Promise<ProcessSingleFileResult> {
     const relativePathForDisplay = path
       .relative(this.host.getTargetDir(), filePath)
       .replace(/\\/g, '/');
-
-    const sizeCheck = await this.checkFileSize(
+    const resizeBeforeOutputLimit = await shouldResizeExplicitImage(
       filePath,
-      relativePathForDisplay,
-      skippedFiles,
+      inputPatterns,
+      imageResizePolicy !== undefined,
+    );
+    if (
+      (await this.checkFileSize(
+        filePath,
+        relativePathForDisplay,
+        skippedFiles,
+        getImageSourceSizeLimit(resizeBeforeOutputLimit, limits.fileSizeLimit),
+      )) === 'skip' ||
+      (await this.checkAssetFile(
+        filePath,
+        relativePathForDisplay,
+        inputPatterns,
+        skippedFiles,
+      )) === 'skip'
+    ) {
+      return { done: false, totalTokens: currentTokens };
+    }
+
+    const fileReadResult = await processSingleFileContent(
+      filePath,
+      this.host.getTargetDir(),
+      undefined,
+      maxLinesPerFile,
+      imageResizePolicy,
+    );
+    const resizeError = getImageResizeToolResult(fileReadResult, currentTokens);
+    if (resizeError !== undefined) {
+      return resizeError;
+    }
+    const skipReason = getProcessedFileSkipReason(
+      fileReadResult,
+      resizeBeforeOutputLimit,
       limits.fileSizeLimit,
     );
-    if (sizeCheck === 'skip') {
-      return { done: false, totalTokens: currentTokens };
-    }
-
-    const assetCheck = await this.checkAssetFile(
-      filePath,
-      relativePathForDisplay,
-      inputPatterns,
-      skippedFiles,
-    );
-    if (assetCheck === 'skip') {
-      return { done: false, totalTokens: currentTokens };
-    }
-
-    const fileReadResult = await this.readFileContent(filePath);
-    if (fileReadResult.error) {
-      skippedFiles.push({
-        path: relativePathForDisplay,
-        reason: `Read error: ${fileReadResult.error}`,
-      });
+    if (skipReason !== undefined) {
+      skippedFiles.push({ path: relativePathForDisplay, reason: skipReason });
       return { done: false, totalTokens: currentTokens };
     }
 
@@ -586,7 +634,6 @@ ${this.host.getTargetDir()}
     }
     return { done: false, totalTokens: addResult.totalTokens };
   }
-
   private async checkFileSize(
     filePath: string,
     relativePathForDisplay: string,
@@ -619,45 +666,22 @@ ${this.host.getTargetDir()}
     skippedFiles: Array<{ path: string; reason: string }>,
   ): Promise<'skip' | 'continue'> {
     const fileType = await detectFileType(filePath);
-    if (fileType === 'image' || fileType === 'pdf' || fileType === 'audio') {
-      const fileExtension = path.extname(filePath).toLowerCase();
-      const fileNameWithoutExtension = path.basename(filePath, fileExtension);
-      const requestedExplicitly = inputPatterns.some(
-        (pattern: string) =>
-          pattern.toLowerCase().includes(fileExtension) ||
-          pattern.includes(fileNameWithoutExtension),
-      );
-
-      if (!requestedExplicitly) {
-        skippedFiles.push({
-          path: relativePathForDisplay,
-          reason:
-            'asset file (image/pdf/audio) was not explicitly requested by name or extension',
-        });
-        return 'skip';
-      }
+    if (
+      (fileType === 'image' || fileType === 'pdf' || fileType === 'audio') &&
+      !isAssetExplicitlyRequested(filePath, inputPatterns)
+    ) {
+      skippedFiles.push({
+        path: relativePathForDisplay,
+        reason:
+          'asset file (image/pdf/audio) was not explicitly requested by name or extension',
+      });
+      return 'skip';
     }
     return 'continue';
   }
 
-  private async readFileContent(
-    filePath: string,
-  ): Promise<Awaited<ReturnType<typeof processSingleFileContent>>> {
-    const maxLinesPerFile =
-      (this.host.getEphemeralSettings()['file-read-max-lines'] as
-        | number
-        | undefined) ?? DEFAULT_MAX_LINES_TEXT_FILE;
-
-    return processSingleFileContent(
-      filePath,
-      this.host.getTargetDir(),
-      undefined,
-      maxLinesPerFile,
-    );
-  }
-
   private addFileContent(
-    fileReadResult: Awaited<ReturnType<typeof processSingleFileContent>>,
+    fileReadResult: ProcessedFileReadResult,
     filePath: string,
     relativePathForDisplay: string,
     skippedFiles: Array<{ path: string; reason: string }>,
@@ -697,7 +721,7 @@ ${this.host.getTargetDir()}
   }
 
   private addTextFileContent(
-    fileReadResult: Awaited<ReturnType<typeof processSingleFileContent>>,
+    fileReadResult: ProcessedFileReadResult,
     filePath: string,
     relativePathForDisplay: string,
     skippedFiles: Array<{ path: string; reason: string }>,

--- a/packages/tools/src/utils/fileUtils.test.ts
+++ b/packages/tools/src/utils/fileUtils.test.ts
@@ -19,6 +19,7 @@ import path from 'node:path';
 import os from 'node:os';
 import mime from 'mime-types';
 
+import sharp from 'sharp';
 import { detectFileType, processSingleFileContent } from './fileUtils.js';
 
 vi.mock('mime-types', () => ({
@@ -140,6 +141,122 @@ describe('processSingleFileContent media displayName @issue:2608', () => {
         displayName: 'quarterly-report.pdf',
         mimeType: 'application/pdf',
       }),
+    });
+  });
+});
+
+describe('processSingleFileContent image resizing', () => {
+  let tempRootDir: string;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    tempRootDir = actualNodeFs.mkdtempSync(
+      path.join(os.tmpdir(), 'tools-fileUtils-image-test-'),
+    );
+    mockMimeLookup.mockReturnValue('image/png');
+  });
+
+  afterEach(() => {
+    actualNodeFs.rmSync(tempRootDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('resizes real image bytes through the shared media path', async () => {
+    const imagePath = path.join(tempRootDir, 'large.png');
+    const original = await sharp({
+      create: {
+        width: 240,
+        height: 120,
+        channels: 3,
+        background: { r: 40, g: 80, b: 120 },
+      },
+    })
+      .png()
+      .toBuffer();
+    actualNodeFs.writeFileSync(imagePath, original);
+
+    const result = await processSingleFileContent(
+      imagePath,
+      tempRootDir,
+      undefined,
+      undefined,
+      { maxLongEdge: 120 },
+    );
+    if (typeof result.llmContent === 'string') {
+      throw new Error(result.llmContent);
+    }
+    const resized = Buffer.from(
+      result.llmContent.inlineData?.data ?? '',
+      'base64',
+    );
+    const metadata = await sharp(resized).metadata();
+
+    expect(metadata.autoOrient).toEqual({ width: 120, height: 60 });
+    expect(result.llmContent.inlineData?.mimeType).toBe('image/png');
+    expect(result.llmContent.inlineData?.displayName).toBe('large.png');
+  });
+
+  it('keeps compliant image bytes unchanged through the shared media path', async () => {
+    const imagePath = path.join(tempRootDir, 'small.png');
+    const original = await sharp({
+      create: {
+        width: 40,
+        height: 20,
+        channels: 3,
+        background: { r: 20, g: 40, b: 60 },
+      },
+    })
+      .png()
+      .toBuffer();
+    actualNodeFs.writeFileSync(imagePath, original);
+
+    const result = await processSingleFileContent(
+      imagePath,
+      tempRootDir,
+      undefined,
+      undefined,
+      { maxLongEdge: 120 },
+    );
+    if (typeof result.llmContent === 'string') {
+      throw new Error(result.llmContent);
+    }
+
+    expect(
+      Buffer.from(result.llmContent.inlineData?.data ?? '', 'base64'),
+    ).toEqual(original);
+  });
+
+  it('does not apply image policy to SVG or other media', async () => {
+    const svgPath = path.join(tempRootDir, 'diagram.svg');
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>x</text></svg>';
+    actualNodeFs.writeFileSync(svgPath, svg);
+
+    const result = await processSingleFileContent(
+      svgPath,
+      tempRootDir,
+      undefined,
+      undefined,
+      { maxLongEdge: 1 },
+    );
+
+    expect(result.llmContent).toBe(svg);
+  });
+
+  it('preserves a structured image-resize failure', async () => {
+    const imagePath = path.join(tempRootDir, 'corrupt.png');
+    actualNodeFs.writeFileSync(imagePath, Buffer.from('corrupt image bytes'));
+
+    const result = await processSingleFileContent(
+      imagePath,
+      tempRootDir,
+      undefined,
+      undefined,
+      { maxLongEdge: 1 },
+    );
+
+    expect(result).toMatchObject({
+      errorKind: 'image-resize',
+      error: expect.stringContaining('Unable to resize image corrupt.png'),
     });
   });
 });

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -10,10 +10,16 @@ import { type ContentPartUnion } from '../types/wire-types.js';
 import mime from 'mime-types';
 import { ToolErrorType } from '../types/tool-error.js';
 import { debugLogger } from './debugLogger.js';
+import {
+  ImageResizeError,
+  resizeImageIfNeeded,
+  type ImageResizePolicy,
+} from './imageResize.js';
 
 // Constants for text file processing
 export const DEFAULT_MAX_LINES_TEXT_FILE = 2000;
 const MAX_LINE_LENGTH_TEXT_FILE = 2000;
+const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
 
 // Default values for encoding and separator format
 export const DEFAULT_ENCODING: BufferEncoding = 'utf-8';
@@ -247,7 +253,6 @@ export async function detectFileType(
   if (await isBinaryFile(filePath)) {
     return 'binary';
   }
-
   return 'text';
 }
 
@@ -256,15 +261,122 @@ export interface ProcessedFileReadResult {
   returnDisplay: string;
   error?: string;
   errorType?: ToolErrorType;
+  errorKind?: 'image-resize';
   isTruncated?: boolean;
   originalLineCount?: number;
   linesShown?: [number, number];
+}
+
+export function isAssetExplicitlyRequested(
+  filePath: string,
+  inputPatterns: readonly string[],
+): boolean {
+  const fileExtension = path.extname(filePath).toLowerCase();
+  const fileNameWithoutExtension = path.basename(filePath, fileExtension);
+  return inputPatterns.some(
+    (pattern) =>
+      pattern.toLowerCase().includes(fileExtension) ||
+      pattern.includes(fileNameWithoutExtension),
+  );
+}
+
+export async function shouldResizeExplicitImage(
+  filePath: string,
+  inputPatterns: readonly string[],
+  hasResizePolicy: boolean,
+): Promise<boolean> {
+  return (
+    hasResizePolicy &&
+    (await detectFileType(filePath)) === 'image' &&
+    isAssetExplicitlyRequested(filePath, inputPatterns)
+  );
+}
+
+export function getReturnedByteLength(result: ProcessedFileReadResult): number {
+  if (typeof result.llmContent === 'string') {
+    return Buffer.byteLength(result.llmContent);
+  }
+  const data = result.llmContent.inlineData?.data;
+  return data === undefined ? 0 : Buffer.byteLength(data, 'base64');
+}
+export function createImageResizeToolResult(
+  message: string,
+  type: ToolErrorType | undefined,
+  totalTokens: number,
+): {
+  done: true;
+  totalTokens: number;
+  error: {
+    llmContent: string;
+    returnDisplay: string;
+    error: { message: string; type: ToolErrorType | undefined };
+  };
+} {
+  return {
+    done: true,
+    totalTokens,
+    error: {
+      llmContent: message,
+      returnDisplay: `## Image Resize Error\n\n${message}`,
+      error: { message, type },
+    },
+  };
+}
+
+export function getImageResizeToolResult(
+  result: ProcessedFileReadResult,
+  totalTokens: number,
+): ReturnType<typeof createImageResizeToolResult> | undefined {
+  return result.errorKind === 'image-resize' && result.error !== undefined
+    ? createImageResizeToolResult(result.error, result.errorType, totalTokens)
+    : undefined;
+}
+
+export function getProcessedFileErrorReason(
+  result: ProcessedFileReadResult,
+): string | undefined {
+  return result.error === undefined ? undefined : `Read error: ${result.error}`;
+}
+
+function returnedImageExceedsLimit(
+  result: ProcessedFileReadResult,
+  shouldResize: boolean,
+  outputLimit: number,
+): boolean {
+  return shouldResize && getReturnedByteLength(result) > outputLimit;
+}
+
+export function getReturnedImageLimitReason(
+  result: ProcessedFileReadResult,
+  shouldResize: boolean,
+  outputLimit: number,
+): string | undefined {
+  return returnedImageExceedsLimit(result, shouldResize, outputLimit)
+    ? `returned file size exceeds limit (${Math.round(outputLimit / 1024)}KB)`
+    : undefined;
+}
+
+export function getProcessedFileSkipReason(
+  result: ProcessedFileReadResult,
+  shouldResize: boolean,
+  outputLimit: number,
+): string | undefined {
+  return (
+    getProcessedFileErrorReason(result) ??
+    getReturnedImageLimitReason(result, shouldResize, outputLimit)
+  );
 }
 
 export function countLines(lines: string[]): number {
   return lines.length > 0 && lines[lines.length - 1] === ''
     ? lines.length - 1
     : lines.length;
+}
+export function getImageSourceSizeLimit(
+  shouldResize: boolean,
+  outputLimit: number,
+): number {
+  return shouldResize ? MAX_FILE_SIZE_BYTES : outputLimit;
 }
 
 function validateFileAccess(filePath: string): ProcessedFileReadResult | null {
@@ -301,7 +413,7 @@ function validateFileSize(
   stats: fs.Stats,
 ): ProcessedFileReadResult | null {
   const fileSizeInMB = stats.size / (1024 * 1024);
-  if (fileSizeInMB > 20) {
+  if (stats.size > MAX_FILE_SIZE_BYTES) {
     return {
       llmContent: 'File size exceeds the 20MB limit.',
       returnDisplay: 'File size exceeds the 20MB limit.',
@@ -394,21 +506,31 @@ async function processMediaFile(
   filePath: string,
   relativePathForDisplay: string,
   fileType: 'image' | 'pdf' | 'audio' | 'video',
+  imageResizePolicy: ImageResizePolicy | undefined,
 ): Promise<ProcessedFileReadResult> {
   const contentBuffer = await fs.promises.readFile(filePath);
-  const base64Data = contentBuffer.toString('base64');
   const mimeTypeRaw = mime.lookup(filePath);
   const mimeType =
     typeof mimeTypeRaw === 'string' && mimeTypeRaw !== ''
       ? mimeTypeRaw
       : 'application/octet-stream';
+  const displayName = path.basename(relativePathForDisplay);
+  const outputBuffer =
+    fileType === 'image'
+      ? await resizeImageIfNeeded(
+          contentBuffer,
+          mimeType,
+          displayName,
+          imageResizePolicy,
+        )
+      : contentBuffer;
 
   return {
     llmContent: {
       inlineData: {
-        data: base64Data,
+        data: outputBuffer.toString('base64'),
         mimeType,
-        displayName: path.basename(relativePathForDisplay),
+        displayName,
       },
     },
     returnDisplay: `Read ${fileType} file: ${relativePathForDisplay}`,
@@ -422,6 +544,7 @@ async function processFileByType(
   stats: fs.Stats,
   offset: number | undefined,
   limit: number | undefined,
+  imageResizePolicy: ImageResizePolicy | undefined,
 ): Promise<ProcessedFileReadResult> {
   switch (fileType) {
     case 'binary':
@@ -434,7 +557,12 @@ async function processFileByType(
     case 'pdf':
     case 'audio':
     case 'video':
-      return processMediaFile(filePath, relativePathForDisplay, fileType);
+      return processMediaFile(
+        filePath,
+        relativePathForDisplay,
+        fileType,
+        imageResizePolicy,
+      );
     default:
       return processTextFile(filePath, relativePathForDisplay, offset, limit);
   }
@@ -445,6 +573,7 @@ export async function processSingleFileContent(
   rootDirectory: string,
   offset?: number,
   limit?: number,
+  imageResizePolicy?: ImageResizePolicy,
 ): Promise<ProcessedFileReadResult> {
   try {
     const accessError = validateFileAccess(filePath);
@@ -469,6 +598,7 @@ export async function processSingleFileContent(
       stats,
       offset,
       limit,
+      imageResizePolicy,
     );
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -480,6 +610,7 @@ export async function processSingleFileContent(
       returnDisplay: `Error reading file ${displayPath}: ${errorMessage}`,
       error: `Error reading file ${filePath}: ${errorMessage}`,
       errorType: ToolErrorType.READ_CONTENT_FAILURE,
+      errorKind: error instanceof ImageResizeError ? 'image-resize' : undefined,
     };
   }
 }

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -287,8 +287,8 @@ export async function shouldResizeExplicitImage(
 ): Promise<boolean> {
   return (
     hasResizePolicy &&
-    (await detectFileType(filePath)) === 'image' &&
-    isAssetExplicitlyRequested(filePath, inputPatterns)
+    isAssetExplicitlyRequested(filePath, inputPatterns) &&
+    (await detectFileType(filePath)) === 'image'
   );
 }
 

--- a/packages/tools/src/utils/imageResize.test.ts
+++ b/packages/tools/src/utils/imageResize.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import sharp from 'sharp';
+import {
+  resolveImageResizePolicy,
+  resizeImageIfNeeded,
+  type ImageResizePolicy,
+} from './imageResize.js';
+
+async function createImage(
+  width: number,
+  height: number,
+  format: 'jpeg' | 'png' | 'webp',
+): Promise<Buffer> {
+  const image = sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r: 80, g: 120, b: 160, alpha: 0.75 },
+    },
+  });
+  switch (format) {
+    case 'jpeg':
+      return image.jpeg().toBuffer();
+    case 'png':
+      return image.png().toBuffer();
+    case 'webp':
+      return image.webp().toBuffer();
+    default:
+      throw new Error(`Unsupported test image format: ${format}`);
+  }
+}
+
+async function createAnimatedImage(format: 'gif' | 'webp'): Promise<Buffer> {
+  const red = await sharp({
+    create: {
+      width: 120,
+      height: 80,
+      channels: 4,
+      background: { r: 255, g: 0, b: 0, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  const blue = await sharp({
+    create: {
+      width: 120,
+      height: 80,
+      channels: 4,
+      background: { r: 0, g: 0, b: 255, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  const animation = sharp([red, blue], { join: { animated: true } });
+  return format === 'gif'
+    ? animation.gif({ delay: [100, 150], loop: 0 }).toBuffer()
+    : animation.webp({ delay: [100, 150], loop: 0 }).toBuffer();
+}
+
+async function getDisplayedDimensions(
+  content: Buffer,
+): Promise<{ width: number; height: number }> {
+  const metadata = await sharp(content, { animated: true }).metadata();
+  const width = metadata.autoOrient.width;
+  const totalHeight = metadata.autoOrient.height;
+  const pages = metadata.pages ?? 1;
+  const height = metadata.pageHeight ?? totalHeight / pages;
+  return { width, height };
+}
+
+const EDGE_POLICY: ImageResizePolicy = {
+  maxLongEdge: 100,
+  maxShortEdge: 60,
+};
+
+describe('resizeImageIfNeeded', () => {
+  it('returns compliant image bytes without re-encoding or upscaling', async () => {
+    const original = await createImage(80, 40, 'png');
+
+    const resized = await resizeImageIfNeeded(
+      original,
+      'image/png',
+      'small.png',
+      EDGE_POLICY,
+    );
+
+    expect(resized).toBe(original);
+  });
+
+  it('returns original bytes without decoding when no limit is configured', async () => {
+    const original = Buffer.from('not an image');
+
+    const result = await resizeImageIfNeeded(
+      original,
+      'image/png',
+      'legacy.png',
+    );
+
+    expect(result).toBe(original);
+  });
+
+  it('fits proportionally within edge and pixel limits', async () => {
+    const original = await createImage(400, 200, 'jpeg');
+
+    const resized = await resizeImageIfNeeded(
+      original,
+      'image/jpeg',
+      'large.jpg',
+      { maxLongEdge: 180, maxShortEdge: 120, maxPixels: 12_000 },
+    );
+    const dimensions = await getDisplayedDimensions(resized);
+    const metadata = await sharp(resized).metadata();
+
+    expect(dimensions).toEqual({ width: 154, height: 77 });
+    expect(metadata.format).toBe('jpeg');
+  });
+
+  it('applies limits to orientation-aware displayed dimensions', async () => {
+    const original = await sharp({
+      create: {
+        width: 120,
+        height: 60,
+        channels: 3,
+        background: { r: 20, g: 100, b: 180 },
+      },
+    })
+      .jpeg()
+      .withMetadata({ orientation: 6 })
+      .toBuffer();
+
+    const resized = await resizeImageIfNeeded(
+      original,
+      'image/jpeg',
+      'rotated.jpg',
+      { maxLongEdge: 80 },
+    );
+
+    expect(await getDisplayedDimensions(resized)).toEqual({
+      width: 40,
+      height: 80,
+    });
+  });
+
+  it.each(['gif', 'webp'] as const)(
+    'preserves animation and container when resizing %s',
+    async (format) => {
+      const original = await createAnimatedImage(format);
+
+      const resized = await resizeImageIfNeeded(
+        original,
+        `image/${format}`,
+        `animated.${format}`,
+        { maxLongEdge: 60 },
+      );
+      const metadata = await sharp(resized, { animated: true }).metadata();
+
+      expect(metadata.format).toBe(format);
+      expect(metadata.pages).toBe(2);
+      expect(await getDisplayedDimensions(resized)).toEqual({
+        width: 60,
+        height: 40,
+      });
+    },
+  );
+
+  it('counts every animated frame against maxPixels', async () => {
+    const original = await createAnimatedImage('gif');
+
+    const resized = await resizeImageIfNeeded(
+      original,
+      'image/gif',
+      'aggregate.gif',
+      { maxPixels: 10_000 },
+    );
+    const metadata = await sharp(resized, { animated: true }).metadata();
+    const dimensions = await getDisplayedDimensions(resized);
+
+    expect(
+      (metadata.pages ?? 1) * dimensions.width * dimensions.height,
+    ).toBeLessThanOrEqual(10_000);
+    expect(metadata.pages).toBe(2);
+  });
+
+  it('fails clearly when a configured image cannot be decoded', async () => {
+    await expect(
+      resizeImageIfNeeded(
+        Buffer.from('corrupt image bytes'),
+        'image/png',
+        'broken.png',
+        { maxLongEdge: 100 },
+      ),
+    ).rejects.toThrow('Unable to resize image broken.png');
+  });
+
+  it('fails clearly for a real unsupported source container', async () => {
+    const unsupported = await sharp({
+      create: {
+        width: 200,
+        height: 100,
+        channels: 3,
+        background: { r: 10, g: 20, b: 30 },
+      },
+    })
+      .tiff()
+      .toBuffer();
+
+    await expect(
+      resizeImageIfNeeded(unsupported, 'image/tiff', 'large.tiff', {
+        maxLongEdge: 100,
+      }),
+    ).rejects.toThrow('Unable to resize image large.tiff');
+  });
+
+  it('rejects a supported declared MIME that mismatches the decoded container', async () => {
+    const png = await createImage(80, 40, 'png');
+
+    await expect(
+      resizeImageIfNeeded(png, 'image/jpeg', 'mismatch.jpg', {
+        maxLongEdge: 100,
+      }),
+    ).rejects.toThrow('Unable to resize image mismatch.jpg');
+  });
+});
+
+describe('resolveImageResizePolicy', () => {
+  it('returns configured limits when automatic resizing is enabled', () => {
+    expect(
+      resolveImageResizePolicy({
+        'image-resize.enabled': true,
+        'image-resize.maxLongEdge': 2048,
+        'image-resize.maxPixels': 1_572_864,
+      }),
+    ).toEqual({ maxLongEdge: 2048, maxPixels: 1_572_864 });
+  });
+
+  it('preserves legacy behavior when limits are absent or disabled', () => {
+    expect(resolveImageResizePolicy({})).toBeUndefined();
+    expect(
+      resolveImageResizePolicy({
+        'image-resize.enabled': false,
+        'image-resize.maxLongEdge': 100,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('honors the per-call opt-out before resolving profile values', () => {
+    expect(
+      resolveImageResizePolicy({ 'image-resize.maxLongEdge': 'invalid' }, true),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    { 'image-resize.enabled': 'yes' },
+    { 'image-resize.enabled': true },
+    { 'image-resize.maxLongEdge': 0 },
+    { 'image-resize.maxShortEdge': 1.5 },
+    { 'image-resize.maxPixels': 'large' },
+  ])('rejects malformed direct profile values: %j', (settings) => {
+    expect(() => resolveImageResizePolicy(settings)).toThrow(
+      'Invalid image resize settings',
+    );
+  });
+});

--- a/packages/tools/src/utils/imageResize.ts
+++ b/packages/tools/src/utils/imageResize.ts
@@ -25,7 +25,7 @@ interface ImageDimensions {
   readonly frames: number;
 }
 
-const MIME_FORMATS = new Map<string, string>([
+const MIME_FORMATS: ReadonlyMap<string, string> = new Map([
   ['image/jpeg', 'jpeg'],
   ['image/png', 'png'],
   ['image/gif', 'gif'],
@@ -66,19 +66,19 @@ function getScale(
   return Math.min(...scales);
 }
 
+const MIME_ENCODERS: ReadonlyMap<string, (pipeline: Sharp) => Sharp> = new Map([
+  ['image/jpeg', (pipeline) => pipeline.jpeg()],
+  ['image/png', (pipeline) => pipeline.png()],
+  ['image/gif', (pipeline) => pipeline.gif()],
+  ['image/webp', (pipeline) => pipeline.webp()],
+]);
+
 function encodeSourceFormat(pipeline: Sharp, mimeType: string): Sharp {
-  switch (mimeType) {
-    case 'image/jpeg':
-      return pipeline.jpeg();
-    case 'image/png':
-      return pipeline.png();
-    case 'image/gif':
-      return pipeline.gif();
-    case 'image/webp':
-      return pipeline.webp();
-    default:
-      throw new Error(`resizing does not support ${mimeType} output`);
+  const encode = MIME_ENCODERS.get(mimeType);
+  if (encode === undefined) {
+    throw new Error(`resizing does not support ${mimeType} output`);
   }
+  return encode(pipeline);
 }
 
 function isWithinLimit(value: number, limit: number | undefined): boolean {

--- a/packages/tools/src/utils/imageResize.ts
+++ b/packages/tools/src/utils/imageResize.ts
@@ -1,0 +1,219 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import sharp, { type Metadata, type Sharp } from 'sharp';
+
+export interface ImageResizePolicy {
+  readonly maxLongEdge?: number;
+  readonly maxShortEdge?: number;
+  readonly maxPixels?: number;
+}
+
+export class ImageResizeError extends Error {
+  constructor(displayName: string, reason: string) {
+    super(`Unable to resize image ${displayName}: ${reason}`);
+    this.name = 'ImageResizeError';
+  }
+}
+
+interface ImageDimensions {
+  readonly width: number;
+  readonly height: number;
+  readonly frames: number;
+}
+
+const MIME_FORMATS = new Map<string, string>([
+  ['image/jpeg', 'jpeg'],
+  ['image/png', 'png'],
+  ['image/gif', 'gif'],
+  ['image/webp', 'webp'],
+]);
+
+function getDimensions(metadata: Metadata): ImageDimensions {
+  const width = metadata.width;
+  const height = metadata.pageHeight ?? metadata.height;
+  if (!Number.isInteger(width) || !Number.isInteger(height)) {
+    throw new Error('image metadata is missing width or height');
+  }
+  const frames = metadata.pages ?? 1;
+  const swapsAxes =
+    metadata.orientation !== undefined && metadata.orientation >= 5;
+  return swapsAxes
+    ? { width: height, height: width, frames }
+    : { width, height, frames };
+}
+
+function getScale(
+  dimensions: ImageDimensions,
+  policy: ImageResizePolicy,
+): number {
+  const longEdge = Math.max(dimensions.width, dimensions.height);
+  const shortEdge = Math.min(dimensions.width, dimensions.height);
+  const scales = [
+    1,
+    policy.maxLongEdge === undefined ? 1 : policy.maxLongEdge / longEdge,
+    policy.maxShortEdge === undefined ? 1 : policy.maxShortEdge / shortEdge,
+    policy.maxPixels === undefined
+      ? 1
+      : Math.sqrt(
+          policy.maxPixels /
+            (dimensions.width * dimensions.height * dimensions.frames),
+        ),
+  ];
+  return Math.min(...scales);
+}
+
+function encodeSourceFormat(pipeline: Sharp, mimeType: string): Sharp {
+  switch (mimeType) {
+    case 'image/jpeg':
+      return pipeline.jpeg();
+    case 'image/png':
+      return pipeline.png();
+    case 'image/gif':
+      return pipeline.gif();
+    case 'image/webp':
+      return pipeline.webp();
+    default:
+      throw new Error(`resizing does not support ${mimeType} output`);
+  }
+}
+
+function isWithinLimit(value: number, limit: number | undefined): boolean {
+  return limit === undefined || value <= limit;
+}
+
+function satisfiesPolicy(
+  dimensions: ImageDimensions,
+  policy: ImageResizePolicy,
+): boolean {
+  const longEdge = Math.max(dimensions.width, dimensions.height);
+  const shortEdge = Math.min(dimensions.width, dimensions.height);
+  const pixels = dimensions.width * dimensions.height * dimensions.frames;
+  return (
+    isWithinLimit(longEdge, policy.maxLongEdge) &&
+    isWithinLimit(shortEdge, policy.maxShortEdge) &&
+    isWithinLimit(pixels, policy.maxPixels)
+  );
+}
+
+function hasLimits(
+  policy: ImageResizePolicy | undefined,
+): policy is ImageResizePolicy {
+  return (
+    policy !== undefined &&
+    (policy.maxLongEdge !== undefined ||
+      policy.maxShortEdge !== undefined ||
+      policy.maxPixels !== undefined)
+  );
+}
+
+function readPositiveInteger(
+  settings: Readonly<Record<string, unknown>>,
+  key: string,
+): number | undefined {
+  const value = settings[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new Error(
+      `Invalid image resize settings: ${key} must be a positive integer`,
+    );
+  }
+  return value;
+}
+
+export function resolveImageResizePolicy(
+  settings: Readonly<Record<string, unknown>>,
+  skipImageResize = false,
+): ImageResizePolicy | undefined {
+  if (skipImageResize) {
+    return undefined;
+  }
+  const enabled = settings['image-resize.enabled'];
+  if (enabled !== undefined && typeof enabled !== 'boolean') {
+    throw new Error(
+      'Invalid image resize settings: image-resize.enabled must be a boolean',
+    );
+  }
+  if (enabled === false) {
+    return undefined;
+  }
+  const policy: ImageResizePolicy = {
+    maxLongEdge: readPositiveInteger(settings, 'image-resize.maxLongEdge'),
+    maxShortEdge: readPositiveInteger(settings, 'image-resize.maxShortEdge'),
+    maxPixels: readPositiveInteger(settings, 'image-resize.maxPixels'),
+  };
+  if (!hasLimits(policy)) {
+    if (enabled === true) {
+      throw new Error(
+        'Invalid image resize settings: enabled resizing requires at least one limit',
+      );
+    }
+    return undefined;
+  }
+  return policy;
+}
+
+export async function resizeImageIfNeeded(
+  content: Buffer,
+  mimeType: string,
+  displayName: string,
+  policy?: ImageResizePolicy,
+): Promise<Buffer> {
+  if (!hasLimits(policy)) {
+    return content;
+  }
+
+  try {
+    const metadata = await sharp(content, {
+      animated: true,
+      failOn: 'warning',
+    }).metadata();
+    const sourceFormat = MIME_FORMATS.get(mimeType);
+    if (sourceFormat === undefined) {
+      throw new Error(`resizing does not support ${mimeType} source`);
+    }
+    if (metadata.format !== sourceFormat) {
+      throw new Error(
+        `declared ${mimeType} does not match decoded ${metadata.format} container`,
+      );
+    }
+    const dimensions = getDimensions(metadata);
+    const scale = getScale(dimensions, policy);
+    if (scale >= 1) {
+      return content;
+    }
+
+    const targetWidth = Math.max(1, Math.floor(dimensions.width * scale));
+    const targetHeight = Math.max(1, Math.floor(dimensions.height * scale));
+    const pipeline = sharp(content, { animated: true, failOn: 'warning' })
+      .rotate()
+      .resize({
+        width: targetWidth,
+        height: targetHeight,
+        fit: 'inside',
+        withoutEnlargement: true,
+      });
+    const resized = await encodeSourceFormat(pipeline, mimeType).toBuffer();
+    const resizedMetadata = await sharp(resized, { animated: true }).metadata();
+    const resizedDimensions = getDimensions(resizedMetadata);
+
+    if (resizedMetadata.format !== sourceFormat) {
+      throw new Error(`output container changed from ${mimeType}`);
+    }
+    if (!satisfiesPolicy(resizedDimensions, policy)) {
+      throw new Error('output dimensions exceed the configured limits');
+    }
+    if ((metadata.pages ?? 1) !== (resizedMetadata.pages ?? 1)) {
+      throw new Error('output animation frame count changed');
+    }
+    return resized;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new ImageResizeError(displayName, reason);
+  }
+}

--- a/project-plans/issue2038/plan.md
+++ b/project-plans/issue2038/plan.md
@@ -211,12 +211,12 @@ ledger and obtaining approval where the policy requires it.
 
 | Category | Planned files | Planned net lines | Actual files | Actual net lines |
 | --- | ---: | ---: | ---: | ---: |
-| Plan | 1 | 340 | 1 | 339 |
-| Dependency and locks | 4 | 680 | 4 | 719 |
-| Production/config source | 13 | 400 | 13 | 466 |
-| Behavioral/settings tests | 7 | 800 | 7 | 829 |
+| Plan | 1 | 340 | 1 | 358 |
+| Dependency and locks | 4 | 680 | 4 | 721 |
+| Production/config source | 13 | 400 | 13 | 540 |
+| Behavioral/settings tests | 7 | 800 | 7 | 812 |
 | Documentation | 1 | 45 | 1 | 13 |
-| **Total** | **26** | **2,265** | **26** | **2,366** |
+| **Total** | **26** | **2,265** | **26** | **2,444** |
 
 Targets and stops:
 
@@ -231,11 +231,11 @@ Targets and stops:
 - Generated lockfile changes and all incidental tracked/untracked files count.
 - Do not consume the hard budget for optional cleanup or hardening.
 
-Final scope reconciliation: 26 paths and 2,366 net text-equivalent lines
-remain below the 40-path/2,500-line hard stop. This includes every line in the
-three untracked planned files and measures the binary-attributed npm lock after
-normalizing both JSON versions, producing 562 additions and 3 deletions. No path
-outside the reconciled list was changed.
+Final scope reconciliation: 26 paths and 2,444 net text-equivalent lines
+remain below the 40-path/2,500-line hard stop. The exact candidate diff contributes
+1,725 net lines excluding `bun.lock`; formatting both Bun lock versions as JSON
+adds 160 normalized lines. The 559-line npm lock change is included in the
+721-line dependency/lock category. No path outside the reconciled list changed.
 
 ## Approval gate: new dependency
 

--- a/project-plans/issue2038/plan.md
+++ b/project-plans/issue2038/plan.md
@@ -1,0 +1,358 @@
+# Issue 2038 Delivery Plan: Model-aware image downscaling
+
+Plan ID: PLAN-20260730-ISSUE2038
+Base: `origin/main`
+Issue: https://github.com/vybestack/llxprt-code/issues/2038
+
+## Policy provenance
+
+`dev-docs/workflow/ISSUE-DELIVERY.md` is not present on this branch, in the
+repository tree, or in repository history. This plan applies the bounded
+issue-delivery policy supplied with the request directly. `dev-docs/RULES.md`
+governs test-first delivery and behavioral evidence.
+
+## Problem and chosen architecture
+
+`read_file` and `read_many_files` both call
+`processSingleFileContent()` in `packages/tools/src/utils/fileUtils.ts`.
+Images currently follow the same media path as PDF/audio/video: the complete
+file is read, base64-encoded, and returned without inspecting its dimensions.
+Large image tool results can therefore exceed a model's useful native vision
+resolution or a provider's admission limits.
+
+The bounded design is:
+
+- Keep the existing read tools. Add `skip_image_resize` to `read_file`; do not
+  add a duplicative `read_image` tool.
+- Add profile-persisted ephemeral settings under the existing setting registry:
+  - `image-resize.enabled`: boolean; explicit `false` disables automatic image
+    resizing for the profile.
+  - `image-resize.maxLongEdge`: positive integer pixels.
+  - `image-resize.maxShortEdge`: positive integer pixels.
+  - `image-resize.maxPixels`: positive integer total decoded pixels.
+- Resolve those settings through the existing `IToolHost` setting snapshot.
+  Missing limits preserve the current behavior. Enabled resizing requires at
+  least one valid limit; malformed direct profile values fail clearly rather
+  than silently selecting a different image policy.
+- Add class-based limits to the existing provider alias `modelDefaults` rules.
+  `computeModelDefaults()` already merges every matching rule in order and
+  `recomputeAndApplyModelDefaultsDiff()` preserves explicit profile values, so
+  no new model-class subsystem is required.
+- Put decoding/resizing in the leaf `packages/tools` package. Use `sharp`
+  0.35.3 to inspect orientation-aware dimensions and perform one
+  aspect-preserving, no-upscale fit. This is a new Apache-2.0 native dependency
+  compatible with the package's Node >=24 requirement, and is the approval gate
+  recorded below.
+- Preserve the input container and MIME type for supported resize outputs. Keep
+  animated GIF/WebP animated when resizing. If an oversized configured image is
+  corrupt, unsupported by the decoder/encoder, or cannot be resized without
+  flattening animation, return a clear tool error; never catch-and-send the
+  original oversized bytes.
+- Apply automatic resizing to both `read_file` and `read_many_files` through the
+  shared media path. The per-call escape hatch is intentionally limited to
+  `read_file`; a model can use individual reads when it explicitly needs an
+  original image.
+
+### Vendor-derived class defaults
+
+The defaults are conservative useful-resolution targets, not claims that every
+provider rejects larger files:
+
+| Class | Match and built-in aliases | maxLongEdge | maxShortEdge | maxPixels | Basis |
+| --- | --- | ---: | ---: | ---: | --- |
+| Claude Opus | provider alias `anthropic` or `claudecode`; model contains the normalized Opus family | 1568 | 1568 | 1,229,312 | Anthropic standard tier: 1568 px long edge and 1568 28x28 visual patches. The 8000x8000 value is a hard admission ceiling, not a useful automatic target. |
+| Claude Sonnet | provider alias `anthropic` or `claudecode`; model contains the normalized Sonnet family | 1568 | 1568 | 1,229,312 | Same conservative class-safe standard tier. Version-specific Claude 4.7+ expansion is deliberately not inferred from class. |
+| OpenAI GPT | built-in `openai`, `openai-responses`, `openai-vercel`, or `codex`; model begins with `gpt-` | 2048 | 2048 | 1,572,864 | Conservative common high-detail envelope: 2048 px max dimension and 1536 32x32 patches. It is advisory; OpenAI publishes no generic class-wide hard dimension cap, and exact versions/detail modes differ. |
+| Moonshot/Kimi | built-in `kimi`; model begins with `kimi` or is `k3-256k` | 4096 | 2160 | 8,847,360 | Moonshot recommendation not to exceed 4K (4096x2160), interpreted orientation-independently as long/short edges. It is advisory, not a documented rejection limit. |
+
+The resize scale is the minimum of 1 and every configured edge/pixel scale.
+Dimensions are rounded down, then re-read and checked against all limits.
+Images already within every applicable limit are returned byte-for-byte without
+re-encoding.
+
+Primary references retrieved 2026-07-30:
+
+- Anthropic vision: https://platform.claude.com/docs/en/build-with-claude/vision
+- Anthropic request limits: https://platform.claude.com/docs/en/api/errors
+- OpenAI image inputs: https://developers.openai.com/api/docs/guides/images-vision
+- Moonshot/Kimi vision: https://platform.kimi.ai/docs/guide/use-kimi-vision-model
+
+## Decision-complete acceptance matrix
+
+| ID | Given | When | Then | Behavioral evidence |
+| --- | --- | --- | --- | --- |
+| A1 | `read_file` reads an image and effective resize limits are present | the decoded image exceeds any effective edge or pixel limit | it returns a proportionally downscaled inline image satisfying every configured limit, with source display name and matching output MIME preserved | real read-file/tool utility test using a generated image and decoding the returned bytes |
+| A2 | `read_many_files` explicitly reads an image and effective limits are present | the image exceeds a limit | its inline image content satisfies every effective limit through the same shared path | real read-many-files behavioral test |
+| A3 | an image is within every effective limit | either read tool processes it | the exact original bytes are returned and it is not upscaled or re-encoded | image utility and tool-boundary tests |
+| A4 | no resize limit is configured | either read tool processes an image | existing byte-for-byte image behavior is unchanged | read-file and read-many-files behavioral tests |
+| A5 | `image-resize.enabled` is explicitly false in the profile snapshot | either read tool processes an oversized image | original dimensions and bytes are preserved despite class defaults | tool behavioral test plus model-default precedence test |
+| A6 | `read_file` receives `skip_image_resize: true` | it processes an oversized image under enabled defaults | original dimensions and bytes are preserved for that call only | read-file schema/invocation behavioral test |
+| A7 | `read_file` receives `skip_image_resize` for text/PDF/audio/video/SVG | it processes the file | existing non-image behavior is unchanged | existing suites plus focused non-image regression only if needed |
+| A8 | automatic resize is required for a corrupt or unsupported image | decoding/resizing runs | the invocation fails with a clear image-resize error naming the source; it does not silently pass the original bytes | real corrupt-file behavioral test |
+| A9 | automatic resize handles orientation-bearing image metadata | it computes the fit | limits apply to displayed dimensions and the output remains correctly oriented | image utility test with generated orientation metadata |
+| A10 | automatic resize handles animated GIF/WebP | resize is required | the output remains animated with the same frame count; if the selected encoder cannot preserve it, the tool fails clearly instead of flattening | real animated-image utility test, limited to formats supported by the approved dependency |
+| B1 | profile settings are validated through the registry | each image-resize setting is set | booleans and positive integers are accepted; zero, negative, fractional, or wrong-type values are rejected | settings registry tests |
+| B2 | no limits exist, or a profile explicitly sets `image-resize.enabled=false` | model defaults are applied | missing limits preserve legacy behavior; explicit profile values win over model defaults | provider mutation/model-default test |
+| C1 | any versioned Claude Opus or Sonnet model matches the built-in Anthropic or Claude Code alias | model defaults are computed | it receives the Claude class limits, while Haiku/Fable and unrelated model names do not | alias/default computation tests |
+| C2 | any `gpt-` model uses a built-in OpenAI visual alias | model defaults are computed | it receives the GPT class limits without enumerating model versions | alias/default computation tests across OpenAI aliases |
+| C3 | a `kimi*` or `k3-256k` model uses the built-in Kimi alias | model defaults are computed | it receives the Kimi class limits by family rather than version | Kimi alias/default computation test |
+| C4 | a non-matching/custom model has no profile resize policy | model defaults are computed and an image is read | no image resize setting is injected and existing image behavior remains unchanged | provider-default and read behavior tests |
+| D1 | profile settings or the per-call opt-out are documented | a user configures image resizing | the docs state defaults, precedence, advisory vs hard limits, original-preservation behavior, and supported escape hatches | documentation review |
+
+## Explicit non-goals
+
+- A new `read_image` tool, model capability registry, provider-specific image
+  pipeline, or public service/manager/adapter abstraction.
+- Version-specific image limits, including a Claude 4.7+ high-resolution
+  override or GPT detail-mode/version capability table.
+- Provider request-body byte budgeting, aggregate multi-image limits, remote URL
+  fetching, upload APIs, retries, or provider-side error translation.
+- Changing provider format support, accepting new source formats, SVG rasterizing,
+  PDF rendering, OCR, cropping, rotation UI, image-detail parameters, or quality
+  controls.
+- Enforcing vendor hard admission limits after `skip_image_resize` or profile
+  disable; those escape hatches intentionally preserve the original tool result.
+- A per-call opt-out on `read_many_files`; original reads remain available through
+  `read_file`.
+- Converting unsupported BMP/HEIC/HEIF sources to another format. Existing
+  pass-through behavior remains when resizing is disabled/not configured;
+  resize-required unsupported sources fail clearly.
+- Load-balancer per-subprofile model-default recomputation. The effective tool
+  setting snapshot remains the existing runtime contract.
+- Any workflow, agent-memory, quality-tool, lint, complexity, coverage, safety,
+  CI, or package-boundary change.
+- Unrelated refactors, test moves, optional hardening, or cleanup after accepted
+  behavior and required gates pass.
+
+## Bounded test-first vertical slices
+
+### Slice 1: image fit behavior
+
+RED: add real-buffer behavioral tests for A3, A8-A10 and the proportional
+edge/pixel fit in A1. Generate images through the real image library; decode the
+actual output. No mocked decoder or expected-value mock.
+
+GREEN: add the smallest `imageResize.ts` utility using `sharp`. Perform one
+no-upscale resize, preserve format/animation, and re-check output dimensions.
+
+### Slice 2: shared read path and escape hatches
+
+RED: extend the real file/tool behavioral tests for A1-A7, including both read
+entry points and the public `skip_image_resize` schema.
+
+GREEN: thread one immutable resize policy into `processSingleFileContent()` and
+apply it only in the image media branch. Resolve the setting snapshot in the
+read tools; do not add model knowledge to `packages/tools`.
+
+### Slice 3: validated configuration and class defaults
+
+RED: add B1-B2 and C1-C4 settings/default tests before changing registry or
+aliases.
+
+GREEN: register the four ephemeral settings and add family-wide rules to the
+existing alias config files. Explicit profile values must continue to win via
+existing model-default diff semantics.
+
+### Slice 4: user documentation
+
+GREEN after preceding behavioral evidence: document D1 in the existing
+ephemeral settings reference. No additional guide or architecture document.
+
+Every production change follows a failing behavioral test. Existing assertions
+must not be weakened or rewritten to legitimize a regression.
+
+## Expected paths
+
+Plan and dependency/locks:
+
+1. `project-plans/issue2038/plan.md`
+2. `packages/tools/package.json`
+3. `package-lock.json`
+4. `bun.lock`
+
+Tools production/tests:
+
+5. `packages/tools/src/utils/imageResize.ts` (new)
+6. `packages/tools/src/utils/imageResize.test.ts` (new)
+7. `packages/tools/src/utils/fileUtils.ts`
+8. `packages/tools/src/utils/fileUtils.test.ts`
+9. `packages/tools/src/tools/read-file.ts`
+10. `packages/tools/src/tools/read-many-files.ts`
+11. `packages/tools/src/__tests__/filesystem-tools.test.ts`
+12. `packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts`
+
+Settings/provider defaults/tests:
+
+13. `packages/settings/src/profiles/types.ts`
+14. `packages/settings/src/settings/registry/registry-entries-1.ts`
+15. `packages/settings/src/__tests__/settingsRegistry.test.ts`
+16. `packages/providers/src/composition/aliases/anthropic.config`
+17. `packages/providers/src/composition/aliases/claudecode.config`
+18. `packages/providers/src/composition/aliases/openai.config`
+19. `packages/providers/src/composition/aliases/openai-responses.config`
+20. `packages/providers/src/composition/aliases/openai-vercel.config`
+21. `packages/providers/src/composition/aliases/codex.config`
+22. `packages/providers/src/composition/aliases/kimi.config`
+23. `packages/providers/src/composition/providerAliases.modelDefaults.test.ts`
+24. `packages/providers/src/composition/providerAliases.kimi.test.ts`
+
+Documentation:
+
+25. `docs/reference/ephemerals.md`
+
+Published root manifest:
+
+26. `package.json`
+
+No path beyond this list is authorized without first updating the matrix and
+ledger and obtaining approval where the policy requires it.
+
+## Scope ledger
+
+| Category | Planned files | Planned net lines | Actual files | Actual net lines |
+| --- | ---: | ---: | ---: | ---: |
+| Plan | 1 | 340 | 1 | 339 |
+| Dependency and locks | 4 | 680 | 4 | 719 |
+| Production/config source | 13 | 400 | 13 | 466 |
+| Behavioral/settings tests | 7 | 800 | 7 | 829 |
+| Documentation | 1 | 45 | 1 | 13 |
+| **Total** | **26** | **2,265** | **26** | **2,366** |
+
+Targets and stops:
+
+- Target ceiling: 25 files or 1,500 net changed lines.
+- The mandatory scope review accepted the target overrun: the measured
+  1,971-line implementation included 674 generated dependency/lock lines and
+  remained below the 40-path/2,500-line hard stop. Publish-integrity testing
+  proved the approved runtime dependency must also be declared by the published
+  root package, authorizing `package.json` as bounded path 26 before edit.
+- Mandatory scope review if either target is exceeded.
+- Hard stop without approval above 40 files or 2,500 net changed lines.
+- Generated lockfile changes and all incidental tracked/untracked files count.
+- Do not consume the hard budget for optional cleanup or hardening.
+
+Final scope reconciliation: 26 paths and 2,366 net text-equivalent lines
+remain below the 40-path/2,500-line hard stop. This includes every line in the
+three untracked planned files and measures the binary-attributed npm lock after
+normalizing both JSON versions, producing 562 additions and 3 deletions. No path
+outside the reconciled list was changed.
+
+## Approval gate: new dependency
+
+The repository has no image decoder/resizer. Implementing the accepted behavior
+requires one. The planned dependency is `sharp@^0.35.3` in
+`@vybestack/llxprt-code-tools`; it is Apache-2.0, supports Node >=20.9, and ships
+platform-specific native libvips packages. This changes the package graph and
+lockfiles and can affect bundle/install size and cross-platform packaging.
+
+The supplied policy requires stopping for approval before a dependency change.
+No production code, tests that import the proposed package, package manifest, or
+lockfile will be changed until explicit approval is received.
+
+## Review triage contract
+
+Every DeepThinker, Open Code Review, CodeRabbit, CI, and human finding will be
+recorded as exactly one of:
+
+- **Blocker-Fix**: accepted behavior, safety, correctness, architecture, or a
+  required gate cannot complete without it.
+- **In-scope-Fix**: a valid issue within this matrix and ledger.
+- **Reject**: factually incorrect, already covered, harmful, or incompatible
+  with accepted behavior.
+- **Defer**: valid but outside this issue's matrix; no implementation in this PR.
+
+Reviewer suggestions do not authorize scope expansion. At most two local OCR
+and two PR OCR reviews are allowed. Across code/design review work, no more than
+two review/remediation cycles will be performed; at least one includes
+DeepThinker.
+
+### First-cycle accepted findings
+
+| ID | Classification | Resolution contract |
+| --- | --- | --- |
+| F1 | Blocker-Fix — resolved | Declared approved `sharp@^0.35.3` in root runtime dependencies, regenerated both locks, and publish integrity passes. |
+| F2 | Blocker-Fix — resolved | `maxPixels` now counts every decoded frame while per-frame `pageHeight` remains the edge geometry; real two-frame GIF evidence passes. |
+| F3 | Blocker-Fix — resolved | `ImageResizeError` survives as the `image-resize` result discriminant and `read_many_files` returns an explicit error for real corrupt/unsupported buffers without message parsing. |
+| F4 | In-scope-Fix — resolved | Explicit policy-resized images retain the 20 MiB source guard and are checked against returned-byte limits after resize; noisy >512 KiB source evidence passes, while other paths retain pre-read limits. |
+| F5 | In-scope-Fix — resolved | Decoded format is checked against declared PNG/JPEG/GIF/WebP MIME before resize; TIFF/AVIF output branches are removed and real TIFF/mismatched PNG evidence passes. |
+| F6 | In-scope-Fix — resolved | Direct absent-policy `ReadFileTool` exact-byte evidence uses the shared PNG fixture builder. |
+| F7 | Defer — unchanged | No decoder-budget policy was added. |
+
+
+### Local Open Code Review triage
+
+Local OCR session `0e384f2f-695c-4790-9448-14204bcb8778` reviewed 15
+source/test/manifest files and produced eleven comments. All were evaluated:
+
+- **In-scope-Fix — resolved:** numeric setting tests now cover `NaN` and
+  `Infinity` and use named parameterized cases; Kimi effective merged defaults
+  are asserted for `kimi-k3` and `k3-256k`; duplicate read-many host setup was
+  removed; decoded image dimensions now fail clearly when metadata omits width
+  or height; image resize policy is resolved once per `read_many_files`
+  invocation and malformed policy values return explicit tool errors in both
+  read tools; the shared 20 MiB constant now governs both source-size checks.
+- **In-scope-Fix — resolved:** negative provider-default evidence now asserts
+  the complete long-edge, short-edge, and pixel-limit group is absent.
+- **Reject:** OCR suggestions to silently fall back to no resize or skip files
+  when profile settings are malformed conflict with the accepted fail-fast A8/B1
+  behavior. The underlying duplicate-resolution bug was fixed while preserving
+  a clear configuration error.
+
+No additional production/config path was added. All accepted local OCR findings
+are resolved, and the two-cycle review limit is closed; no further local design
+or code review will be launched.
+
+## Stop conditions requiring approval
+
+Stop before:
+
+- changing or adding behavior outside A1-D1;
+- adding a dependency other than the explicitly approved `sharp` change;
+- adding a new tool, subsystem, public abstraction, service, manager, adapter,
+  provider capability registry, or public API beyond `skip_image_resize` and
+  the four planned ephemeral settings;
+- changing a workflow, agent memory, quality tool, lint/complexity/coverage/CI
+  rule, source exclusion, package boundary, or safety requirement;
+- moving an unrelated refactor/test or changing unrelated assertions;
+- exceeding the expected path list without a scope review, exceeding the target
+  after consolidation, or exceeding the hard budget under any circumstance.
+
+## Required gates and exact-head completion
+
+The candidate head is complete only when:
+
+1. Every A1-D1 row has behavioral evidence on that exact head.
+2. Focused package tests pass, followed by `npm run test`, `npm run lint`,
+   `npm run typecheck`, `npm run format`, and `npm run build`.
+3. The available project smoke command,
+   `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`,
+   passes. (`scripts/start.js` is absent on this base.)
+4. Local DeepThinker and OCR reviews are complete; every finding is classified;
+   all Blocker-Fix and In-scope-Fix items are resolved.
+5. The committed exact head is pushed; CI and bounded PR reviews pass on it;
+   every CodeRabbit comment is evaluated, answered, and resolved when addressed
+   or invalid.
+6. `git merge-base --is-ancestor origin/main HEAD` succeeds, the PR reports no
+   conflicts, and the final file/line counts reconcile to a clean scope ledger.
+7. No suppressions, weakened gates, optional cleanup, or out-of-matrix changes
+
+## Exact-tree verification evidence
+
+The final uncommitted candidate tree passed:
+
+- focused image/settings/provider behavioral suites: 251 tests;
+- publish-integrity suite: 17 tests;
+- `npm run test`;
+- `npm run lint`;
+- `npm run typecheck` after refreshing workspace links with `npm install`;
+- `npm run format` and `git diff --check`;
+- `npm run build`;
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+
+The requested `scripts/start.js` entry point is not present on this base. The
+project-local Bun launcher and configured smoke profile completed successfully.
+`origin/main` is an ancestor of the candidate branch, and the working tree
+contains only the 26 reconciled issue paths.
+   remain.
+
+Stop successfully at that point. Do not continue optional hardening or cleanup.


### PR DESCRIPTION
## TLDR

Automatically downscale oversized images returned by read_file and read_many_files according to model-family defaults or profile overrides, while preserving original bytes when resizing is disabled, skipped, unconfigured, or unnecessary.

The implementation uses the current sharp 0.35.3 release and adds defaults for Claude Opus/Sonnet, OpenAI GPT, and Kimi model families.

## Dive Deeper

- Adds validated profile settings: image-resize.enabled, image-resize.maxLongEdge, image-resize.maxShortEdge, and image-resize.maxPixels.
- Adds the read_file per-call skip_image_resize escape hatch.
- Applies resizing in the shared media path used by both file-reading tools.
- Preserves aspect ratio and avoids upscaling or re-encoding compliant images.
- Honors EXIF orientation and preserves animated GIF/WebP frame counts while counting all decoded frames toward pixel limits.
- Resizes explicitly requested read_many_files images before enforcing returned-item byte limits, while retaining the existing 20 MiB source guard.
- Fails clearly for corrupt, unsupported, MIME-mismatched images and malformed resize settings.
- Adds sharp@^0.35.3 to the tools and published root runtime dependency sets and updates npm/Bun locks.
- Documents profile behavior and records the bounded acceptance matrix, scope ledger, and completed review triage under project-plans/issue2038/plan.md.

The final scope is 26 authorized paths and 2,366 text-equivalent net lines, below the 40-path/2,500-line hard limits. DeepThinker and local Open Code Review findings were triaged; all Blocker-Fix and In-scope-Fix findings were resolved.

## Reviewer Test Plan

1. Configure a visual-model profile with small image resize edge/pixel limits.
2. Read a larger PNG or JPEG with read_file and verify the returned inline image respects the limits.
3. Repeat with skip_image_resize true and verify original bytes/dimensions are preserved.
4. Set image-resize.enabled false and verify both read tools preserve original images.
5. Explicitly request a large image through read_many_files and verify it is resized before the returned-item byte limit is applied.
6. Try corrupt image bytes or malformed settings and verify the tool reports a clear read/resize error.
7. Run the focused behavioral suites or the complete local suite listed below.

Local verification completed on the candidate head:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- publish-integrity tests
- focused image/settings/provider suites: 251 tests
- bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2038


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic image resizing for supported images read through file-reading tools.
  * Preserves aspect ratio, animation, and original bytes when resizing is unnecessary.
  * Added configurable image limits for dimensions and total pixels.
  * Added a per-call opt-out for single-file reads.

* **Documentation**
  * Documented resizing behavior, supported formats, settings, defaults, and error handling.

* **Bug Fixes**
  * Improved handling of oversized, corrupt, unsupported, and mismatched image files with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->