### PR TITLE
Retry then failover on 5xx Internal Server Errors (Fixes #1726)

### DIFF
--- a/packages/agents/src/core/__tests__/bucketFailoverIntegration.spec.ts
+++ b/packages/agents/src/core/__tests__/bucketFailoverIntegration.spec.ts
@@ -536,5 +536,101 @@ describe('bucketFailoverIntegration', () => {
       expect(result.bucket).toBe('bucket2');
       expect(mockProvider.generateChatCompletion).toHaveBeenCalledTimes(2);
     });
+
+    it('fails over on HTTP 5xx server error (issue #1726)', async () => {
+      const responseContent: IContent = {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Success!' }],
+      };
+
+      const serverError = new Error('Internal server error');
+      (serverError as { status?: number }).status = 500;
+      const failGenerator = () => createThrowingGenerator(serverError);
+
+      async function* successGenerator() {
+        yield responseContent;
+      }
+
+      vi.mocked(mockProvider.generateChatCompletion)
+        .mockReturnValueOnce(failGenerator())
+        .mockReturnValueOnce(successGenerator());
+
+      const config: BucketFailoverConfig = {
+        buckets: ['bucket1', 'bucket2'],
+        provider: mockProvider,
+      };
+
+      const result = await executeProviderWithBucketFailover(options, config);
+
+      expect(result.bucket).toBe('bucket2');
+      expect(mockProvider.generateChatCompletion).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails over on Anthropic api_error body type (issue #1726)', async () => {
+      const responseContent: IContent = {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Success!' }],
+      };
+
+      const apiError = new Error('Internal server error');
+      (
+        apiError as { error?: { type?: string; error?: { type?: string } } }
+      ).error = {
+        type: 'error',
+        error: {
+          type: 'api_error',
+          message: 'Internal server error',
+        },
+      };
+      const failGenerator = () => createThrowingGenerator(apiError);
+
+      async function* successGenerator() {
+        yield responseContent;
+      }
+
+      vi.mocked(mockProvider.generateChatCompletion)
+        .mockReturnValueOnce(failGenerator())
+        .mockReturnValueOnce(successGenerator());
+
+      const config: BucketFailoverConfig = {
+        buckets: ['bucket1', 'bucket2'],
+        provider: mockProvider,
+      };
+
+      const result = await executeProviderWithBucketFailover(options, config);
+
+      expect(result.bucket).toBe('bucket2');
+      expect(mockProvider.generateChatCompletion).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails over on "internal server error" in message text', async () => {
+      const responseContent: IContent = {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Success!' }],
+      };
+
+      const serverError = new Error(
+        'API Error: {"type":"error","error":{"type":"api_error","message":"Internal server error"}}',
+      );
+      const failGenerator = () => createThrowingGenerator(serverError);
+
+      async function* successGenerator() {
+        yield responseContent;
+      }
+
+      vi.mocked(mockProvider.generateChatCompletion)
+        .mockReturnValueOnce(failGenerator())
+        .mockReturnValueOnce(successGenerator());
+
+      const config: BucketFailoverConfig = {
+        buckets: ['bucket1', 'bucket2'],
+        provider: mockProvider,
+      };
+
+      const result = await executeProviderWithBucketFailover(options, config);
+
+      expect(result.bucket).toBe('bucket2');
+      expect(mockProvider.generateChatCompletion).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/agents/src/core/bucketFailoverIntegration.ts
+++ b/packages/agents/src/core/bucketFailoverIntegration.ts
@@ -22,13 +22,14 @@ import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
  *
  * Failover triggers:
  * - 429 rate limit
+ * - 5xx server errors (including Anthropic api_error / Internal server error)
  * - Quota exceeded
  * - 402 payment required
  * - Token renewal failure
  *
  * Does NOT failover:
  * - 400 bad request
- * - Other API errors
+ * - Other client errors
  */
 function shouldFailover(error: Error): boolean {
   const message = error.message.toLowerCase();
@@ -38,21 +39,34 @@ function shouldFailover(error: Error): boolean {
   if (errorStatus === 401 || errorStatus === 403) {
     return true;
   }
+  if (errorStatus !== undefined && errorStatus >= 500 && errorStatus < 600) {
+    return true;
+  }
 
-  // Check for Anthropic body-level error types (rate_limit_error, overloaded_error)
-  const bodyError = error as { error?: { type?: string } };
+  // Check for Anthropic body-level error types (rate_limit_error,
+  // overloaded_error, api_error — the latter covers "Internal server error")
+  const bodyError = error as {
+    error?: { type?: string; error?: { type?: string } };
+  };
+  const bodyType = bodyError.error?.error?.type ?? bodyError.error?.type ?? '';
   if (
-    bodyError.error?.type === 'rate_limit_error' ||
-    bodyError.error?.type === 'overloaded_error'
+    bodyType === 'rate_limit_error' ||
+    bodyType === 'overloaded_error' ||
+    bodyType === 'api_error'
   ) {
     return true;
   }
 
-  const hasStatusCode =
-    message.includes('429') ||
-    message.includes('401') ||
-    message.includes('403') ||
-    message.includes('402');
+  const FAIL_OVER_STATUS_STRINGS = [
+    '429',
+    '401',
+    '403',
+    '402',
+    'internal server error',
+  ];
+  const hasStatusCode = FAIL_OVER_STATUS_STRINGS.some((s) =>
+    message.includes(s),
+  );
   const hasRateLimitText =
     message.includes('rate limit') || message.includes('quota');
   const hasPaymentText =

--- a/packages/core/src/utils/retry.serverErrorFailover.test.ts
+++ b/packages/core/src/utils/retry.serverErrorFailover.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0 */
+
+import { describe, it, expect, vi } from 'vitest';
+import { retryWithBackoff } from './retry.js';
+
+interface HttpError extends Error {
+  status?: number;
+}
+
+describe('retryWithBackoff - server error failover (issue #1726)', () => {
+  it('should call onPersistent429 callback on persistent HTTP 5xx errors', async () => {
+    vi.useFakeTimers();
+    let attempt = 0;
+
+    const mockFn = vi.fn(async () => {
+      attempt++;
+      if (attempt <= 1) {
+        const error: HttpError = new Error('Internal server error');
+        error.status = 500;
+        throw error;
+      }
+      return 'success after bucket switch';
+    });
+
+    const failoverCallback = vi.fn(async () => true);
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 5,
+      initialDelayMs: 100,
+      onPersistent429: failoverCallback,
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBe('success after bucket switch');
+    expect(failoverCallback).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call onPersistent429 callback on persistent Anthropic api_error', async () => {
+    vi.useFakeTimers();
+    let attempt = 0;
+
+    const mockFn = vi.fn(async () => {
+      attempt++;
+      if (attempt <= 1) {
+        const error: HttpError & {
+          error?: { type?: string; error?: { type?: string } };
+        } = new Error('Internal server error');
+        error.status = undefined;
+        error.error = {
+          type: 'error',
+          error: {
+            type: 'api_error',
+            message: 'Internal server error',
+          },
+        };
+        throw error;
+      }
+      return 'success after bucket switch';
+    });
+
+    const failoverCallback = vi.fn(async () => true);
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 5,
+      initialDelayMs: 100,
+      onPersistent429: failoverCallback,
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBe('success after bucket switch');
+    // api_error is caught by isOverloadError, treated as overload, and
+    // triggers failover through the 429/overload threshold path.
+    expect(failoverCallback).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/utils/retry.serverErrorFailover.test.ts
+++ b/packages/core/src/utils/retry.serverErrorFailover.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0 */
 
 import { describe, it, expect, vi } from 'vitest';

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -301,6 +301,7 @@ interface RetryLoopState {
   currentDelay: number;
   consecutive429s: number;
   consecutiveAuthErrors: number;
+  consecutiveServerErrors: number;
 }
 
 /** Classifies an error into categories used by retry logic. */
@@ -343,6 +344,7 @@ async function handleContentRetry<T>(
 function updateErrorCounters(
   is429: boolean,
   isAuthError: boolean,
+  is500: boolean,
   canAttemptFailover: boolean,
   failoverThreshold: number,
   state: RetryLoopState,
@@ -358,15 +360,15 @@ function updateErrorCounters(
     state.consecutive429s = 0;
   }
 
-  if (isAuthError) {
-    state.consecutiveAuthErrors++;
-  } else {
-    state.consecutiveAuthErrors = 0;
-  }
+  state.consecutiveAuthErrors = isAuthError
+    ? state.consecutiveAuthErrors + 1
+    : 0;
+
+  state.consecutiveServerErrors =
+    is500 && !is429 && !isAuthError ? state.consecutiveServerErrors + 1 : 0;
 
   const shouldAttemptRefreshRetry =
     isAuthError && canAttemptFailover && state.consecutiveAuthErrors === 1;
-
   return { shouldAttemptRefreshRetry };
 }
 
@@ -414,6 +416,7 @@ async function attemptFailover(
   is429: boolean,
   is402: boolean,
   isAuthError: boolean,
+  is500: boolean,
   errorStatus: number | undefined,
   options: Partial<RetryOptions> | undefined,
   state: RetryLoopState,
@@ -424,13 +427,21 @@ async function attemptFailover(
   const canAttemptFailover = Boolean(options?.onPersistent429);
   const thresholdReached = is429 && state.consecutive429s >= failoverThreshold;
   const authFailoverReached = isAuthError && state.consecutiveAuthErrors > 1;
+  const serverFailoverReached =
+    is500 && state.consecutiveServerErrors >= failoverThreshold;
+  const failoverConditions = [
+    thresholdReached,
+    is402,
+    authFailoverReached,
+    serverFailoverReached,
+  ];
   const shouldAttemptFailover =
-    canAttemptFailover && (thresholdReached || is402 || authFailoverReached);
+    canAttemptFailover && failoverConditions.some((c) => c);
 
   logger.debug(
     () =>
-      `[issue1029] Failover decision: errorStatus=${errorStatus}, is429=${is429}, is402=${is402}, isAuthError=${isAuthError}, ` +
-      `consecutive429s=${state.consecutive429s}, consecutiveAuthErrors=${state.consecutiveAuthErrors}, ` +
+      `[issue1029] Failover decision: errorStatus=${errorStatus}, is429=${is429}, is402=${is402}, isAuthError=${isAuthError}, is500=${is500}, ` +
+      `consecutive429s=${state.consecutive429s}, consecutiveAuthErrors=${state.consecutiveAuthErrors}, consecutiveServerErrors=${state.consecutiveServerErrors}, ` +
       `canAttemptFailover=${canAttemptFailover}, shouldAttemptFailover=${shouldAttemptFailover}`,
   );
 
@@ -445,9 +456,10 @@ async function attemptFailover(
     return 'proceed';
   }
 
-  const failoverReason = is429
-    ? `${state.consecutive429s} consecutive 429 errors`
-    : `status ${errorStatus}`;
+  let failoverReason = `status ${errorStatus}`;
+  if (is429) failoverReason = `${state.consecutive429s} consecutive 429 errors`;
+  else if (is500)
+    failoverReason = `${state.consecutiveServerErrors} consecutive server errors`;
   logger.debug(() => `Attempting bucket failover after ${failoverReason}`);
   const failoverResult = await options.onPersistent429(error);
 
@@ -460,6 +472,7 @@ async function attemptFailover(
     logger.debug(() => `Bucket failover successful, resetting retry state`);
     state.consecutive429s = 0;
     state.consecutiveAuthErrors = 0;
+    state.consecutiveServerErrors = 0;
     state.currentDelay = initialDelayMs;
     state.attempt--;
     return 'continue';
@@ -629,6 +642,7 @@ async function runRetryGuards(
     classified.is429,
     classified.is402,
     classified.isAuthError,
+    classified.is500,
     classified.errorStatus,
     context.options,
     state,
@@ -679,6 +693,7 @@ async function handleRetryFailure(
   const { shouldAttemptRefreshRetry } = updateErrorCounters(
     classified.is429,
     classified.isAuthError,
+    classified.is500,
     context.options?.onPersistent429 !== undefined,
     context.failoverThreshold,
     state,
@@ -772,6 +787,7 @@ export async function retryWithBackoff<T>(
     currentDelay: initialDelayMs,
     consecutive429s: 0,
     consecutiveAuthErrors: 0,
+    consecutiveServerErrors: 0,
   };
 
   while (state.attempt < maxAttempts) {
@@ -783,6 +799,7 @@ export async function retryWithBackoff<T>(
       const result = await fn();
       state.consecutive429s = 0;
       state.consecutiveAuthErrors = 0;
+      state.consecutiveServerErrors = 0;
 
       if (
         await handleContentRetry(

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -412,6 +412,7 @@ export class RetryOrchestrator implements IProvider {
       consecutive429s: number;
       consecutiveAuthErrors: number;
       consecutiveNetworkErrors: number;
+      consecutiveServerErrors: number;
     },
     bucketFailoverHandler: BucketFailoverHandler | undefined,
     budget: { used: number; limit: number },
@@ -521,6 +522,7 @@ export class RetryOrchestrator implements IProvider {
       consecutive429s: number;
       consecutiveAuthErrors: number;
       consecutiveNetworkErrors: number;
+      consecutiveServerErrors: number;
     },
     maxAttempts: number,
     initialDelayMs: number,
@@ -534,41 +536,35 @@ export class RetryOrchestrator implements IProvider {
     if (isTerminalRetryError(error)) return { type: 'throw', error };
 
     const classification = classifyRetryError(error);
-    const {
-      status: errorStatus,
-      category,
-      is429,
-      is402,
-      isAuthError,
-      isNetworkError,
-    } = classification;
+    const { status: errorStatus, category, ...f } = classification;
     this.observeProviderError(options, error, errorStatus, category);
-
     this.logger.debug(
       () =>
-        `[attempt ${state.attempt}/${maxAttempts}] Error: status=${errorStatus}, is429=${is429}, is402=${is402}, isAuth=${isAuthError}, isNetwork=${isNetworkError}`,
+        `[attempt ${state.attempt}/${maxAttempts}] Error: status=${errorStatus}, is429=${f.is429}, is402=${f.is402}, isAuth=${f.isAuthError}, isNetwork=${f.isNetworkError}, is5xx=${f.is5xxServerError}`,
     );
-
     updateRetryErrorCounters(state, classification);
 
-    const shouldAttemptRefreshRetry =
-      isAuthError &&
-      state.consecutiveAuthErrors === 1 &&
-      state.attempt < maxAttempts;
-
-    if (shouldAttemptRefreshRetry) {
-      await this.invokeAuthErrorHandler(error, options, errorStatus, signal);
-    }
+    const shouldAttemptRefreshRetry = await this.maybeRefreshAuth(
+      f.isAuthError,
+      state.consecutiveAuthErrors,
+      state.attempt,
+      maxAttempts,
+      error,
+      options,
+      errorStatus,
+      signal,
+    );
 
     const shouldAttemptFailover =
       state.attempt < maxAttempts &&
       permitsBucketFailover(error) &&
       this.shouldAttemptFailover(
         bucketFailoverHandler,
-        is429,
-        is402,
-        isAuthError,
-        isNetworkError,
+        f.is429,
+        f.is402,
+        f.isAuthError,
+        f.isNetworkError,
+        f.is5xxServerError,
         state,
         failoverThreshold,
       );
@@ -576,8 +572,9 @@ export class RetryOrchestrator implements IProvider {
     if (shouldAttemptFailover && bucketFailoverHandler) {
       return this.handleFailoverDecision(
         errorStatus,
-        is429,
-        isNetworkError,
+        f.is429,
+        f.isNetworkError,
+        f.is5xxServerError,
         state,
         initialDelayMs,
         bucketFailoverHandler,
@@ -605,10 +602,12 @@ export class RetryOrchestrator implements IProvider {
     is402: boolean,
     isAuthError: boolean,
     isNetworkError: boolean,
+    is5xxServerError: boolean,
     state: {
       consecutive429s: number;
       consecutiveAuthErrors: number;
       consecutiveNetworkErrors: number;
+      consecutiveServerErrors: number;
     },
     failoverThreshold: number,
   ): boolean {
@@ -624,17 +623,24 @@ export class RetryOrchestrator implements IProvider {
     if (isAuthError && state.consecutiveAuthErrors > 1) {
       return true;
     }
-    return isNetworkError && state.consecutiveNetworkErrors > failoverThreshold;
+    if (isNetworkError && state.consecutiveNetworkErrors > failoverThreshold) {
+      return true;
+    }
+    return (
+      is5xxServerError && state.consecutiveServerErrors > failoverThreshold
+    );
   }
 
   private async handleFailoverDecision(
     errorStatus: number | undefined,
     is429: boolean,
     isNetworkError: boolean,
+    is5xxServerError: boolean,
     state: {
       consecutive429s: number;
       consecutiveNetworkErrors: number;
       consecutiveAuthErrors: number;
+      consecutiveServerErrors: number;
       attempt: number;
       currentDelay: number;
     },
@@ -648,6 +654,7 @@ export class RetryOrchestrator implements IProvider {
       errorStatus,
       is429,
       isNetworkError,
+      is5xxServerError,
       state,
       bucketFailoverHandler,
       authRetryTimeoutMs,
@@ -717,6 +724,26 @@ export class RetryOrchestrator implements IProvider {
   }
 
   /**
+   * Invoke the auth error handler on the first consecutive auth failure (if
+   * retries remain), returning whether a refresh attempt was made.
+   */
+  private async maybeRefreshAuth(
+    isAuthError: boolean,
+    consecutiveAuthErrors: number,
+    attempt: number,
+    maxAttempts: number,
+    error: unknown,
+    options: GenerateChatOptions,
+    errorStatus: number | undefined,
+    signal: AbortSignal | undefined,
+  ): Promise<boolean> {
+    if (!(isAuthError && consecutiveAuthErrors === 1 && attempt < maxAttempts))
+      return false;
+    await this.invokeAuthErrorHandler(error, options, errorStatus, signal);
+    return true;
+  }
+
+  /**
    * Invoke the auth error handler to allow cache invalidation and force-refresh.
    */
   private async invokeAuthErrorHandler(
@@ -762,11 +789,13 @@ export class RetryOrchestrator implements IProvider {
     errorStatus: number | undefined,
     is429: boolean,
     isNetworkError: boolean,
+    is5xxServerError: boolean,
     state: {
       attempt: number;
       consecutive429s: number;
       consecutiveNetworkErrors: number;
       consecutiveAuthErrors: number;
+      consecutiveServerErrors: number;
     },
     bucketFailoverHandler: BucketFailoverHandler,
     authRetryTimeoutMs: number,
@@ -775,8 +804,10 @@ export class RetryOrchestrator implements IProvider {
     const failoverReason = resolveFailoverReason(
       is429,
       isNetworkError,
+      is5xxServerError,
       state.consecutive429s,
       state.consecutiveNetworkErrors,
+      state.consecutiveServerErrors,
       errorStatus,
     );
     this.logger.debug(

--- a/packages/providers/src/__tests__/RetryOrchestrator.failover.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.failover.test.ts
@@ -85,10 +85,6 @@ function createRateLimitError(retryAfter?: number): Error {
 }
 
 /**
- * Helper to create a 5xx server error
- */
-
-/**
  * Helper to create a 400 bad request error
  */
 

--- a/packages/providers/src/__tests__/RetryOrchestrator.failover5xx.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.failover5xx.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/providers/src/__tests__/RetryOrchestrator.failover5xx.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.failover5xx.test.ts
@@ -1,0 +1,266 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import type { IProvider, GenerateChatOptions } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { IModel } from '../IModel.js';
+
+function createTestProvider(config: {
+  name?: string;
+  responses?: Array<'success' | 'error' | { error: Error }>;
+}): IProvider {
+  let callCount = 0;
+
+  const successContent: IContent = {
+    speaker: 'ai',
+    blocks: [{ type: 'text', text: 'test response' }],
+  };
+
+  return {
+    name: config.name ?? 'test-provider',
+    async *generateChatCompletion() {
+      const responseIndex = Math.min(
+        callCount,
+        (config.responses?.length ?? 1) - 1,
+      );
+      callCount++;
+
+      const response = config.responses?.[responseIndex] ?? 'success';
+
+      if (response === 'error') {
+        throw new Error('Generic error');
+      } else if (typeof response === 'object' && 'error' in response) {
+        throw response.error;
+      }
+
+      yield successContent;
+    },
+    async getModels(): Promise<IModel[]> {
+      return [];
+    },
+    getDefaultModel(): string {
+      return 'test-model';
+    },
+    getServerTools(): string[] {
+      return [];
+    },
+    async invokeServerTool(): Promise<unknown> {
+      return null;
+    },
+  };
+}
+
+function createRateLimitError(): Error {
+  const error = new Error('Rate limit exceeded') as Error & {
+    status?: number;
+  };
+  error.status = 429;
+  return error;
+}
+
+function createServerError(status = 500): Error {
+  const error = new Error('Internal server error') as Error & {
+    status?: number;
+  };
+  error.status = status;
+  return error;
+}
+
+function createAnthropicApiError(): Error {
+  const error = new Error('Internal server error') as Error & {
+    status?: number;
+    error?: unknown;
+  };
+  error.status = undefined;
+  error.error = {
+    type: 'error',
+    error: {
+      details: null,
+      type: 'api_error',
+      message: 'Internal server error',
+    },
+    request_id: 'req_011CYxB3kPD86oumRyhWrd9P',
+  };
+  return error;
+}
+
+async function consumeStream(
+  stream: AsyncIterableIterator<IContent>,
+): Promise<IContent[]> {
+  const chunks: IContent[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+function createFailoverHandler(buckets: string[]) {
+  let bucketIndex = 0;
+  let currentBucket = buckets[0];
+  let failoverAttempted = false;
+  return {
+    handler: {
+      getBuckets: () => buckets,
+      getCurrentBucket: () => currentBucket,
+      tryFailover: async () => {
+        failoverAttempted = true;
+        bucketIndex++;
+        if (bucketIndex >= buckets.length) return false;
+        currentBucket = buckets[bucketIndex];
+        return true;
+      },
+      isEnabled: () => true,
+    },
+    get currentBucket() {
+      return currentBucket;
+    },
+    get failoverAttempted() {
+      return failoverAttempted;
+    },
+  };
+}
+
+function createOptions(handler: unknown): GenerateChatOptions {
+  return {
+    contents: [{ role: 'user', blocks: [{ type: 'text', text: 'test' }] }],
+    runtime: {
+      config: {
+        getBucketFailoverHandler: () => handler,
+      } as unknown as GenerateChatOptions['runtime'],
+    } as unknown as GenerateChatOptions['runtime'],
+  };
+}
+
+describe('RetryOrchestrator - 5xx server error failover (issue #1726)', () => {
+  it('should failover to next bucket on persistent HTTP 5xx errors', async () => {
+    const serverError = createServerError(500);
+    const fo = createFailoverHandler(['bucket1', 'bucket2', 'bucket3']);
+
+    const provider = createTestProvider({
+      responses: [{ error: serverError }, { error: serverError }, 'success'],
+    });
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 5,
+      initialDelayMs: 10,
+    });
+
+    const result = await consumeStream(
+      orchestrator.generateChatCompletion(createOptions(fo.handler)),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(fo.currentBucket).toBe('bucket2');
+  });
+
+  it('should failover on Anthropic api_error body type via overload path', async () => {
+    const apiError = createAnthropicApiError();
+    const fo = createFailoverHandler(['bucket1', 'bucket2']);
+
+    const provider = createTestProvider({
+      responses: [{ error: apiError }, { error: apiError }, 'success'],
+    });
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 5,
+      initialDelayMs: 10,
+    });
+
+    const result = await consumeStream(
+      orchestrator.generateChatCompletion(createOptions(fo.handler)),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(fo.currentBucket).toBe('bucket2');
+  });
+
+  it('should NOT failover on single 5xx error (retries first)', async () => {
+    const serverError = createServerError(500);
+    const fo = createFailoverHandler(['bucket1', 'bucket2']);
+
+    const provider = createTestProvider({
+      responses: [{ error: serverError }, 'success'],
+    });
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 5,
+      initialDelayMs: 10,
+    });
+
+    const result = await consumeStream(
+      orchestrator.generateChatCompletion(createOptions(fo.handler)),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(fo.failoverAttempted).toBe(false);
+  });
+
+  it('should throw AllBucketsExhaustedError when all buckets exhausted due to 5xx', async () => {
+    const serverError = createServerError(500);
+    const buckets = ['bucket1', 'bucket2'];
+    let bucketIndex = 0;
+
+    const provider = createTestProvider({
+      responses: [
+        { error: serverError },
+        { error: serverError },
+        { error: serverError },
+        { error: serverError },
+      ],
+    });
+
+    const handler = {
+      getBuckets: () => buckets,
+      getCurrentBucket: () =>
+        buckets[Math.min(bucketIndex, buckets.length - 1)],
+      tryFailover: async () => {
+        bucketIndex++;
+        return bucketIndex < buckets.length;
+      },
+      isEnabled: () => true,
+    };
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 10,
+      initialDelayMs: 10,
+    });
+
+    await expect(
+      consumeStream(
+        orchestrator.generateChatCompletion(createOptions(handler)),
+      ),
+    ).rejects.toThrow(/bucket/i);
+  });
+
+  it('should reset server error counter when a different error type occurs', async () => {
+    const serverError = createServerError(500);
+    const rateLimitError = createRateLimitError();
+    const fo = createFailoverHandler(['bucket1', 'bucket2']);
+
+    const provider = createTestProvider({
+      responses: [
+        { error: serverError },
+        { error: rateLimitError },
+        { error: serverError },
+        'success',
+      ],
+    });
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 6,
+      initialDelayMs: 10,
+    });
+
+    const result = await consumeStream(
+      orchestrator.generateChatCompletion(createOptions(fo.handler)),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(fo.failoverAttempted).toBe(false);
+  });
+});

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -423,12 +423,13 @@ export class AuthenticationError extends ProviderError {
 
 /**
  * Error for server errors (5xx)
- * Retryable with exponential backoff, does not trigger bucket failover
+ * Retryable with exponential backoff, triggers bucket failover after
+ * threshold (issue #1726).
  */
 export class ServerError extends ProviderError {
   readonly category = 'server_error' as const;
   readonly isRetryable = true;
-  readonly shouldFailover = false;
+  readonly shouldFailover = true;
 }
 
 /**

--- a/packages/providers/src/provider-manager-behavior.test.ts
+++ b/packages/providers/src/provider-manager-behavior.test.ts
@@ -439,11 +439,11 @@ describe('Provider error hierarchy behavioral tests', () => {
    * @plan:PLAN-20260603-ISSUE1584.P10
    * @requirement:REQ-TEST-001
    */
-  it('ServerError is retryable but does not trigger failover', () => {
+  it('ServerError is retryable and triggers failover (issue #1726)', () => {
     const error = new ServerError('server error', { status: 500 });
     expect(error.category).toBe('server_error');
     expect(error.isRetryable).toBe(true);
-    expect(error.shouldFailover).toBe(false);
+    expect(error.shouldFailover).toBe(true);
   });
 
   /**

--- a/packages/providers/src/retryDelayPolicy.ts
+++ b/packages/providers/src/retryDelayPolicy.ts
@@ -98,8 +98,10 @@ export function hasRetryAfterHeader(error: unknown): boolean {
 export function resolveFailoverReason(
   is429: boolean,
   isNetworkError: boolean,
+  is5xxServerError: boolean,
   consecutive429s: number,
   consecutiveNetworkErrors: number,
+  consecutiveServerErrors: number,
   errorStatus: number | undefined,
 ): string {
   if (is429) {
@@ -107,6 +109,9 @@ export function resolveFailoverReason(
   }
   if (isNetworkError) {
     return `${consecutiveNetworkErrors} consecutive network errors`;
+  }
+  if (is5xxServerError) {
+    return `${consecutiveServerErrors} consecutive server errors`;
   }
   return `status ${errorStatus}`;
 }

--- a/packages/providers/src/retryErrorClassification.ts
+++ b/packages/providers/src/retryErrorClassification.ts
@@ -15,6 +15,7 @@ export interface RetryErrorCounters {
   consecutive429s: number;
   consecutiveAuthErrors: number;
   consecutiveNetworkErrors: number;
+  consecutiveServerErrors: number;
 }
 
 export interface RetryErrorClassification {
@@ -24,6 +25,7 @@ export interface RetryErrorClassification {
   readonly is402: boolean;
   readonly isAuthError: boolean;
   readonly isNetworkError: boolean;
+  readonly is5xxServerError: boolean;
 }
 
 const errorsAfterStreamOutput = new WeakSet<object>();
@@ -62,13 +64,24 @@ export function isTerminalRetryError(error: unknown): boolean {
 export function classifyRetryError(error: unknown): RetryErrorClassification {
   const status = getErrorStatus(error);
   const category = classifyProviderError(error, status);
+  const is429 = status === 429 || isOverloadError(error);
+  const is402 = status === 402;
+  const isAuthError = status === 401 || status === 403;
+  const isNetworkError = category === 'network';
+  // Server errors include plain HTTP 5xx statuses and Anthropic api_error.
+  // category === 'server_error' is already mutually exclusive with the
+  // rate_limit/quota/authentication categories, so the only overlap is with
+  // is429 (which catches api_error via isOverloadError). Exclude is429 so
+  // api_error/overloaded_error use the existing 429 failover path.
+  const is5xxServerError = category === 'server_error' && !is429;
   return {
     status,
     category,
-    is429: status === 429 || isOverloadError(error),
-    is402: status === 402,
-    isAuthError: status === 401 || status === 403,
-    isNetworkError: category === 'network',
+    is429,
+    is402,
+    isAuthError,
+    isNetworkError,
+    is5xxServerError,
   };
 }
 
@@ -76,7 +89,8 @@ export function updateRetryErrorCounters(
   state: RetryErrorCounters,
   classification: RetryErrorClassification,
 ): void {
-  const { is429, isAuthError, isNetworkError } = classification;
+  const { is429, isAuthError, isNetworkError, is5xxServerError } =
+    classification;
   state.consecutive429s = is429 ? state.consecutive429s + 1 : 0;
   state.consecutiveAuthErrors = isAuthError
     ? state.consecutiveAuthErrors + 1
@@ -85,10 +99,14 @@ export function updateRetryErrorCounters(
     isNetworkError && !is429 && !isAuthError
       ? state.consecutiveNetworkErrors + 1
       : 0;
+  state.consecutiveServerErrors = is5xxServerError
+    ? state.consecutiveServerErrors + 1
+    : 0;
 }
 
 export function resetRetryErrorCounters(state: RetryErrorCounters): void {
   state.consecutive429s = 0;
   state.consecutiveAuthErrors = 0;
   state.consecutiveNetworkErrors = 0;
+  state.consecutiveServerErrors = 0;
 }

--- a/packages/providers/src/retryFailoverLogic.ts
+++ b/packages/providers/src/retryFailoverLogic.ts
@@ -21,6 +21,7 @@ export interface FailoverState {
   consecutive429s: number;
   consecutiveNetworkErrors: number;
   consecutiveAuthErrors: number;
+  consecutiveServerErrors: number;
   attempt: number;
   currentDelay: number;
 }
@@ -35,6 +36,7 @@ export function shouldAttemptFailover(
   is402: boolean,
   isAuthError: boolean,
   isNetworkError: boolean,
+  is5xxServerError: boolean,
   state: FailoverState,
   failoverThreshold: number,
 ): boolean {
@@ -50,7 +52,10 @@ export function shouldAttemptFailover(
   if (isAuthError && state.consecutiveAuthErrors > 1) {
     return true;
   }
-  return isNetworkError && state.consecutiveNetworkErrors > failoverThreshold;
+  if (isNetworkError && state.consecutiveNetworkErrors > failoverThreshold) {
+    return true;
+  }
+  return is5xxServerError && state.consecutiveServerErrors > failoverThreshold;
 }
 
 /**
@@ -61,6 +66,7 @@ export async function attemptBucketFailover(
   errorStatus: number | undefined,
   is429: boolean,
   isNetworkError: boolean,
+  is5xxServerError: boolean,
   state: FailoverState,
   bucketFailoverHandler: BucketFailoverHandler,
   authRetryTimeoutMs: number,
@@ -70,8 +76,10 @@ export async function attemptBucketFailover(
   const failoverReason = resolveFailoverReason(
     is429,
     isNetworkError,
+    is5xxServerError,
     state.consecutive429s,
     state.consecutiveNetworkErrors,
+    state.consecutiveServerErrors,
     errorStatus,
   );
   logger.debug(() => `Attempting bucket failover after ${failoverReason}`);

--- a/packages/providers/src/retryTransportOwnership.ts
+++ b/packages/providers/src/retryTransportOwnership.ts
@@ -38,6 +38,7 @@ export function createInitialRetryState(initialDelayMs: number): {
   consecutive429s: number;
   consecutiveAuthErrors: number;
   consecutiveNetworkErrors: number;
+  consecutiveServerErrors: number;
 } {
   return {
     attempt: 0,
@@ -45,5 +46,6 @@ export function createInitialRetryState(initialDelayMs: number): {
     consecutive429s: 0,
     consecutiveAuthErrors: 0,
     consecutiveNetworkErrors: 0,
+    consecutiveServerErrors: 0,
   };
 }


### PR DESCRIPTION
## Summary

5xx server errors (including Anthropic `api_error` / "Internal server error") were retried with backoff but never triggered bucket failover — unlike 429/402/401/403 errors. This left bucketed profiles stuck on a failing bucket even when another OAuth bucket could serve the request.

## Root Cause

The `shouldAttemptFailover()` method in `RetryOrchestrator` only checked `is429`, `is402`, `isAuthError`, and `isNetworkError` conditions. Server errors (5xx/`api_error`) were completely absent from the failover decision, despite being classified as retryable. Similarly, the core `retryWithBackoff` `attemptFailover()` and the legacy `bucketFailoverIntegration.shouldFailover()` both lacked 5xx conditions.

This was inconsistent with `LoadBalancingProvider.shouldFailover()` which already correctly handles 5xx:
```typescript
return status === 429 || (status >= 500 && status < 600);
```

## Changes

### Error Classification (`retryErrorClassification.ts`)
- Added `is5xxServerError` to `RetryErrorClassification` (derived from `category === 'server_error'` and not 429)
- Added `consecutiveServerErrors` to `RetryErrorCounters`, tracked in `updateRetryErrorCounters()` and reset in `resetRetryErrorCounters()`

### RetryOrchestrator (`RetryOrchestrator.ts`)
- `shouldAttemptFailover()` now includes `is5xxServerError && state.consecutiveServerErrors > failoverThreshold` condition
- Passes `is5xxServerError` through `handleFailoverDecision` → `attemptBucketFailover` → `resolveFailoverReason`
- `consecutiveServerErrors` added to retry state via `createInitialRetryState()`

### Core retryWithBackoff (`retry.ts`)
- `updateErrorCounters()` now tracks `consecutiveServerErrors` (using `is500` flag)
- `attemptFailover()` now includes `serverFailoverReached` condition using `>= failoverThreshold` (same as 429)

### Legacy bucketFailoverIntegration (`bucketFailoverIntegration.ts`)
- `shouldFailover()` now checks HTTP 5xx status codes (`>= 500 && < 600`)
- `shouldFailover()` now checks Anthropic body-level `api_error` type
- `shouldFailover()` now checks "internal server error" in message text

### Error Class (`errors.ts`)
- `ServerError.shouldFailover` changed from `false` to `true` (consistent with LoadBalancingProvider behavior)

### Failover Reason (`retryDelayPolicy.ts`, `retryFailoverLogic.ts`)
- `resolveFailoverReason()` now returns "N consecutive server errors" for 5xx-triggered failover

## Tests
- `RetryOrchestrator.failover5xx.test.ts`: 5 tests covering persistent HTTP 5xx failover, api_error body type failover, single-5xx no-failover, all-buckets-exhausted, and counter reset on error type change
- `retry.serverErrorFailover.test.ts`: 2 tests covering core retryWithBackoff 5xx and api_error failover
- `bucketFailoverIntegration.spec.ts`: 3 new tests covering legacy path 5xx, api_error body type, and message-text matching
- `provider-manager-behavior.test.ts`: Updated ServerError test to expect `shouldFailover: true`

Fixes #1726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider failover now responds to repeated HTTP 5xx server errors.
  * Added support for recognizing additional server-error response formats, including Anthropic API errors.
  * Retry behavior now tracks consecutive server errors and switches providers after the configured threshold.
  * Server-error counters reset appropriately when requests succeed or error types change.
  * Improved failover reasons and handling when all provider options are exhausted.

* **Tests**
  * Added coverage for server-error retries, failover, recovery, and exhausted-provider scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->