### PR TITLE
docs: align hooks prerequisite with Node 24 baseline (Fixes #2015)

### DIFF
--- a/docs/hooks/writing-hooks.md
+++ b/docs/hooks/writing-hooks.md
@@ -314,7 +314,7 @@ SessionEnd → Extract and store memories
 
 **Prerequisites:**
 
-- Node.js 18+
+- Node.js 24+
 - LLxprt Code installed
 
 **Setup:**


### PR DESCRIPTION
## Summary

Issue #2015 asked to update the Node.js minimum from Node 20 to Node 24 and ensure consistency across .nvmrc, package metadata, docs, and CI.

The bulk of this upgrade was already delivered by PR #2318 (Fixes #2316), which raised the baseline to Node 24 across .nvmrc, all package.json engines fields, @types/node, and every CI workflow. However, one documentation page was missed: docs/hooks/writing-hooks.md still listed Node.js 18+ as the prerequisite for the hooks installation example.

This PR fixes that last inconsistency so the documented minimum Node.js version is consistent everywhere.

## Changes

- docs/hooks/writing-hooks.md: changed hooks installation prerequisite from Node.js 18+ to Node.js 24+ to match the project baseline.

## Acceptance criteria verification

- The documented minimum Node.js version is consistent across .nvmrc (24), package metadata (engines.node >= 24 in root and all 16 workspace packages), docs (getting-started.md, sandbox-setup.md, README.md, CONTRIBUTING.md, writing-hooks.md all now say 24+), and CI (all workflows use .nvmrc or explicit 24/24.x).
- CI runs on the new Node baseline without Node 20 deprecation warnings (already ensured by #2318; no workflow references Node 20).
- No package or dependency incompatibilities — @types/node is already ^24.2.1 everywhere, third-party package-lock.json >=18 entries are transitive dependency metadata that cannot be changed.

## Non-goals

- Historical project-plans/ specs are immutable records and were intentionally not updated.
- Vendored bundle/ SDK error messages and tmp/ research code are out of scope.

## Verification

- npm run format — passed (no changes needed)
- npm run lint — passed (no errors)
- test/typecheck/build are no-ops for a markdown-only change

Fixes #2015