### PR TITLE
Guard ast_edit ambiguous-match rejection and align contract (Fixes #1756)

### DIFF
--- a/packages/tools/src/tools/ast-edit.ts
+++ b/packages/tools/src/tools/ast-edit.ts
@@ -131,7 +131,7 @@ export class ASTEditTool
           },
           old_string: {
             description:
-              'The exact literal text to replace. Must match existing content exactly including whitespace and indentation.',
+              'The exact literal text to replace. Must match existing content exactly including whitespace, indentation, newlines, and surrounding code. Must be unique in the file: if old_string appears more than once the edit is rejected — include enough surrounding context to target exactly one occurrence.',
             type: 'string',
           },
           new_string: {

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-1756.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-1756.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0
  *
  * Regression tests for issue #1756: ast_edit must not silently replace only

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-1756.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-1756.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression tests for issue #1756: ast_edit must not silently replace only
+ * the first occurrence when old_string matches multiple locations.
+ *
+ * The exact reproduction from the issue is a TypeScript file where a fragment
+ * like `active: true,` appears in two distinct syntactic contexts (a function
+ * body and a const declaration). Both the apply and preview phases must reject
+ * the edit with EDIT_EXPECTED_OCCURRENCE_MISMATCH and leave the file untouched.
+ * Providing enough surrounding context to match exactly once must still succeed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  useTempDir,
+  createFakeToolHost,
+  executeApply,
+  executePreview,
+} from './test-helpers.js';
+import { ASTEditTool } from '../../ast-edit.js';
+import { ToolErrorType } from '../../../types/tool-error.js';
+
+const TWO_CONTEXT_CONTENT = [
+  'function getConfig() {',
+  '  return {',
+  '    active: true,',
+  '    name: "function-config",',
+  '  };',
+  '}',
+  'const defaultConfig = {',
+  '  active: true,',
+  '  name: "const-config",',
+  '};',
+].join('\n');
+
+describe('ast_edit issue #1756: no silent first-occurrence replacement', () => {
+  const ctx = useTempDir();
+
+  it('apply rejects when the ambiguous fragment appears in two contexts', async () => {
+    const filePath = join(ctx.tempDir, 'two-contexts.ts');
+    writeFileSync(filePath, TWO_CONTEXT_CONTENT, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'active: true,',
+      new_string: 'active: false,',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(
+      ToolErrorType.EDIT_EXPECTED_OCCURRENCE_MISMATCH,
+    );
+    expect(String(result.llmContent)).toContain('2 times');
+    expect(readFileSync(filePath, 'utf-8')).toBe(TWO_CONTEXT_CONTENT);
+  });
+
+  it('preview rejects the same ambiguous fragment so no diff is shown', async () => {
+    const filePath = join(ctx.tempDir, 'two-contexts-preview.ts');
+    writeFileSync(filePath, TWO_CONTEXT_CONTENT, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'active: true,',
+      new_string: 'active: false,',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(
+      ToolErrorType.EDIT_EXPECTED_OCCURRENCE_MISMATCH,
+    );
+    expect(String(result.llmContent)).not.toContain('LLXPRT EDIT PREVIEW');
+    expect(readFileSync(filePath, 'utf-8')).toBe(TWO_CONTEXT_CONTENT);
+  });
+
+  it('succeeds when the caller disambiguates by including surrounding context', async () => {
+    const filePath = join(ctx.tempDir, 'disambiguated.ts');
+    writeFileSync(filePath, TWO_CONTEXT_CONTENT, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: '    active: true,\n    name: "function-config",',
+      new_string: '    active: false,\n    name: "function-config",',
+    });
+
+    expect(result.error).toBeUndefined();
+    // Assert the full expected content so a regression that replaces the WRONG
+    // occurrence (or both) is caught: only the function-body fragment changed,
+    // the const-declaration fragment is untouched.
+    const expected = [
+      'function getConfig() {',
+      '  return {',
+      '    active: false,',
+      '    name: "function-config",',
+      '  };',
+      '}',
+      'const defaultConfig = {',
+      '  active: true,',
+      '  name: "const-config",',
+      '};',
+    ].join('\n');
+    expect(readFileSync(filePath, 'utf-8')).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1756

Issue #1756 reported that ast_edit silently replaced only the first occurrence when old_string matched multiple locations in a file, unlike the replace tool which errors on ambiguous matches.

## Investigation outcome

Thorough investigation showed the behavioral fix already shipped with the 0.11.0 integration (commit 207749848). edit-calculator.ts validateEditParams() counts occurrences via an indexOf loop and rejects when occurrences > 1 with EDIT_EXPECTED_OCCURRENCE_MISMATCH. Both the apply path (force: true) and preview path (force: false) route through calculateEdit, and the confirmation / IDE-modify paths are gated by shouldConfirmExecute (which short-circuits on the same error), so no reachable code path silently replaces the first occurrence.

The residual gap relative to the issue's "consistent with replace tool behavior" framing was in the tool contract: ast_edit's old_string parameter description said only "Must match existing content exactly" with no warning that the string must be unique or that ambiguous matches are rejected. The replace tool's old_string description explicitly documents the uniqueness/context requirement. This left callers with no guidance until they hit the error.

## Changes

- packages/tools/src/tools/ast-edit.ts: Align the old_string parameter description with the replace tool contract: document that the string must be unique in the file, that ambiguous matches are rejected, and to include surrounding context to target a single occurrence.
- packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-1756.test.ts: New regression test tied to issue #1756 using the exact reproduction from the issue (the fragment appearing in two distinct syntactic contexts, a function body and a const declaration). Covers:
  - apply rejects with EDIT_EXPECTED_OCCURRENCE_MISMATCH and leaves the file untouched
  - preview rejects the same way (no diff shown)
  - disambiguation succeeds when the caller includes surrounding context, asserted via full-content toBe so a wrong-occurrence regression is caught

## Verification

- ast-edit test suite: 164/164 pass (161 existing + 3 new)
- tools package typecheck: clean
- eslint on changed files: clean (max-warnings 0)
- prettier: clean
- eslint-guard (CI suppression/threshold gate): passed
- Open Code Review (ocr, --timeout 20): 1 In-scope-Fix finding (test assertions too weak to detect wrong-occurrence replacement) resolved by switching to full-content assertion

## Test plan

- [x] New regression test passes
- [x] Full ast-edit suite green
- [ ] CI green on this PR
