### PR TITLE
fix(tools): verify media magic-byte signatures before trusting mime classification (Fixes #2723)

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -265,11 +265,6 @@ describe('fileUtils', () => {
     });
 
     it.each([
-      { type: 'image', file: 'file.png', mime: 'image/png' },
-      { type: 'image', file: 'file.jpg', mime: 'image/jpeg' },
-      { type: 'pdf', file: 'file.pdf', mime: 'application/pdf' },
-      { type: 'audio', file: 'song.mp3', mime: 'audio/mpeg' },
-      { type: 'video', file: 'movie.mp4', mime: 'video/mp4' },
       { type: 'binary', file: 'archive.zip', mime: 'application/zip' },
       { type: 'binary', file: 'app.exe', mime: 'application/octet-stream' },
     ])(
@@ -279,6 +274,181 @@ describe('fileUtils', () => {
         expect(await detectFileType(file)).toBe(type);
       },
     );
+
+    // --- Content-signature verification for media classification (#2723) ---
+
+    it.each([
+      {
+        label: 'png',
+        file: 'file.png',
+        mime: 'image/png',
+        content: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      },
+      {
+        label: 'jpeg',
+        file: 'file.jpg',
+        mime: 'image/jpeg',
+        content: Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+      },
+      {
+        label: 'gif',
+        file: 'file.gif',
+        mime: 'image/gif',
+        content: Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]),
+      },
+      {
+        label: 'webp',
+        file: 'file.webp',
+        mime: 'image/webp',
+        content: Buffer.from([
+          0x52, 0x49, 0x46, 0x46, 0x1c, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42,
+          0x50,
+        ]),
+      },
+      {
+        label: 'bmp',
+        file: 'file.bmp',
+        mime: 'image/bmp',
+        content: Buffer.from([0x42, 0x4d, 0x00, 0x00]),
+      },
+    ])(
+      'should classify real $label image as image when signature verifies (#2723)',
+      async ({ file, mime: mimeType, content }) => {
+        const filePath = path.join(tempRootDir, file);
+        actualNodeFs.writeFileSync(filePath, content);
+        mockMimeLookup.mockReturnValueOnce(mimeType);
+        expect(await detectFileType(filePath)).toBe('image');
+      },
+    );
+
+    it.each([
+      {
+        label: 'mp3',
+        file: 'song.mp3',
+        mime: 'audio/mpeg',
+        content: Buffer.from([0x49, 0x44, 0x33, 0x03, 0x00, 0x00]),
+      },
+      {
+        label: 'wav',
+        file: 'sound.wav',
+        mime: 'audio/wav',
+        content: Buffer.from([
+          0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56,
+          0x45,
+        ]),
+      },
+      {
+        label: 'flac',
+        file: 'audio.flac',
+        mime: 'audio/flac',
+        content: Buffer.from([0x66, 0x4c, 0x61, 0x43, 0x00]),
+      },
+      {
+        label: 'ogg',
+        file: 'audio.ogg',
+        mime: 'audio/ogg',
+        content: Buffer.from([0x4f, 0x67, 0x67, 0x53, 0x00]),
+      },
+    ])(
+      'should classify real $label audio as audio when signature verifies (#2723)',
+      async ({ file, mime: mimeType, content }) => {
+        const filePath = path.join(tempRootDir, file);
+        actualNodeFs.writeFileSync(filePath, content);
+        mockMimeLookup.mockReturnValueOnce(mimeType);
+        expect(await detectFileType(filePath)).toBe('audio');
+      },
+    );
+
+    it.each([
+      {
+        label: 'mp4',
+        file: 'movie.mp4',
+        mime: 'video/mp4',
+        content: Buffer.from([
+          0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f,
+          0x6d,
+        ]),
+      },
+      {
+        label: 'avi',
+        file: 'clip.avi',
+        mime: 'video/x-msvideo',
+        content: Buffer.from([
+          0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x41, 0x56, 0x49,
+          0x20,
+        ]),
+      },
+      {
+        label: 'webm',
+        file: 'video.webm',
+        mime: 'video/webm',
+        content: Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x01]),
+      },
+    ])(
+      'should classify real $label video as video when signature verifies (#2723)',
+      async ({ file, mime: mimeType, content }) => {
+        const filePath = path.join(tempRootDir, file);
+        actualNodeFs.writeFileSync(filePath, content);
+        mockMimeLookup.mockReturnValueOnce(mimeType);
+        expect(await detectFileType(filePath)).toBe('video');
+      },
+    );
+
+    it('should classify real pdf as pdf when signature verifies (#2723)', async () => {
+      const filePath = path.join(tempRootDir, 'document.pdf');
+      actualNodeFs.writeFileSync(
+        filePath,
+        Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a]),
+      );
+      mockMimeLookup.mockReturnValueOnce('application/pdf');
+      expect(await detectFileType(filePath)).toBe('pdf');
+    });
+
+    it.each([
+      { label: 'image', file: 'shader.png', mime: 'image/png' },
+      { label: 'audio', file: 'config.mp3', mime: 'audio/mpeg' },
+      { label: 'video', file: 'data.mp4', mime: 'video/mp4' },
+      { label: 'pdf', file: 'notes.pdf', mime: 'application/pdf' },
+    ])(
+      'should reclassify text content with $label mime as text, not media (#2723)',
+      async ({ file, mime: mimeType }) => {
+        const filePath = path.join(tempRootDir, file);
+        actualNodeFs.writeFileSync(filePath, 'console.log("hello world");');
+        mockMimeLookup.mockReturnValueOnce(mimeType);
+        expect(await detectFileType(filePath)).toBe('text');
+      },
+    );
+
+    it('should classify binary content with unverified signature as binary (#2723)', async () => {
+      const filePath = path.join(tempRootDir, 'mystery.png');
+      actualNodeFs.writeFileSync(
+        filePath,
+        Buffer.from([
+          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+        ]),
+      );
+      mockMimeLookup.mockReturnValueOnce('image/png');
+      expect(await detectFileType(filePath)).toBe('binary');
+    });
+
+    it('should reject partial RIFF match (AND semantics) as non-media text (#2723)', async () => {
+      const filePath = path.join(tempRootDir, 'fake.webp');
+      actualNodeFs.writeFileSync(
+        filePath,
+        Buffer.from([
+          0x52, 0x49, 0x46, 0x46, 0x41, 0x42, 0x43, 0x44, 0x58, 0x58, 0x58,
+          0x58,
+        ]),
+      );
+      mockMimeLookup.mockReturnValueOnce('image/webp');
+      expect(await detectFileType(filePath)).toBe('text');
+    });
+
+    it('should fall through to text for non-existent file with media mime (#2723)', async () => {
+      const filePath = path.join(tempRootDir, 'nonexistent.png');
+      mockMimeLookup.mockReturnValueOnce('image/png');
+      expect(await detectFileType(filePath)).toBe('text');
+    });
 
     it('should detect svg type by extension', async () => {
       expect(await detectFileType('image.svg')).toBe('svg');
@@ -396,7 +566,9 @@ describe('fileUtils', () => {
     });
 
     it('should process an image file', async () => {
-      const fakePngData = Buffer.from('fake png data');
+      const fakePngData = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x66, 0x61, 0x6b, 0x65,
+      ]);
       actualNodeFs.writeFileSync(testImageFilePath, fakePngData);
       mockMimeLookup.mockReturnValue('image/png');
       const result = await processSingleFileContent(
@@ -418,7 +590,9 @@ describe('fileUtils', () => {
     });
 
     it('should process a PDF file', async () => {
-      const fakePdfData = Buffer.from('fake pdf data');
+      const fakePdfData = Buffer.from([
+        0x25, 0x50, 0x44, 0x46, 0x2d, 0x66, 0x61, 0x6b, 0x65,
+      ]);
       actualNodeFs.writeFileSync(testPdfFilePath, fakePdfData);
       mockMimeLookup.mockReturnValue('application/pdf');
       const result = await processSingleFileContent(
@@ -440,7 +614,9 @@ describe('fileUtils', () => {
     });
 
     it('should process an audio file', async () => {
-      const fakeMp3Data = Buffer.from('fake mp3 data');
+      const fakeMp3Data = Buffer.from([
+        0x49, 0x44, 0x33, 0x03, 0x00, 0x66, 0x61, 0x6b, 0x65,
+      ]);
       actualNodeFs.writeFileSync(testAudioFilePath, fakeMp3Data);
       mockMimeLookup.mockReturnValue('audio/mpeg');
       const result = await processSingleFileContent(

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -402,6 +402,17 @@ describe('fileUtils', () => {
         mime: 'video/webm',
         content: Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x01]),
       },
+      {
+        label: 'mpegts',
+        file: 'movie.m2ts',
+        mime: 'video/mp2t',
+        content: (() => {
+          const buf = Buffer.alloc(189, 0x10);
+          buf[0] = 0x47;
+          buf[188] = 0x47;
+          return buf;
+        })(),
+      },
     ])(
       'should classify real $label video as video when signature verifies (#2723)',
       async ({ file, mime: mimeType, content }) => {

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -311,6 +311,15 @@ describe('fileUtils', () => {
         mime: 'image/bmp',
         content: Buffer.from([0x42, 0x4d, 0x00, 0x00]),
       },
+      {
+        label: 'heic',
+        file: 'photo.heic',
+        mime: 'image/heic',
+        content: Buffer.from([
+          0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69,
+          0x63,
+        ]),
+      },
     ])(
       'should classify real $label image as image when signature verifies (#2723)',
       async ({ file, mime: mimeType, content }) => {
@@ -348,6 +357,15 @@ describe('fileUtils', () => {
         file: 'audio.ogg',
         mime: 'audio/ogg',
         content: Buffer.from([0x4f, 0x67, 0x67, 0x53, 0x00]),
+      },
+      {
+        label: 'm4a',
+        file: 'track.m4a',
+        mime: 'audio/mp4',
+        content: Buffer.from([
+          0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41,
+          0x20,
+        ]),
       },
     ])(
       'should classify real $label audio as audio when signature verifies (#2723)',

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -313,6 +313,10 @@ const VIDEO_SIGNATURES: readonly MediaSignature[] = [
     { offset: 8, bytes: [0x41, 0x56, 0x49, 0x20] },
   ],
   [{ offset: 0, bytes: [0x1a, 0x45, 0xdf, 0xa3] }],
+  [
+    { offset: 0, bytes: [0x47] },
+    { offset: 188, bytes: [0x47] },
+  ],
 ];
 
 const PDF_SIGNATURES: readonly MediaSignature[] = [
@@ -359,8 +363,8 @@ async function verifyMediaSignature(
   let fh: fs.promises.FileHandle | null = null;
   try {
     fh = await fs.promises.open(filePath, 'r');
-    const buf = Buffer.alloc(32);
-    const { bytesRead } = await fh.read(buf, 0, 32, 0);
+    const buf = Buffer.alloc(512);
+    const { bytesRead } = await fh.read(buf, 0, 512, 0);
     const header = buf.subarray(0, bytesRead);
     if (header.length === 0) return false;
     return headerMatches(header, signatures);

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -277,6 +277,7 @@ const IMAGE_SIGNATURES: readonly MediaSignature[] = [
     { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
     { offset: 8, bytes: [0x57, 0x45, 0x42, 0x50] },
   ],
+  [{ offset: 4, bytes: [0x66, 0x74, 0x79, 0x70] }],
 ];
 
 const AUDIO_SIGNATURES: readonly MediaSignature[] = [
@@ -297,6 +298,12 @@ const AUDIO_SIGNATURES: readonly MediaSignature[] = [
   [{ offset: 0, bytes: [0xff, 0xf9] }],
   [{ offset: 0, bytes: [0xff, 0xf0] }],
   [{ offset: 0, bytes: [0xff, 0xf8] }],
+  [{ offset: 4, bytes: [0x66, 0x74, 0x79, 0x70] }],
+  [{ offset: 0, bytes: [0x4d, 0x54, 0x68, 0x64] }],
+  [
+    { offset: 0, bytes: [0x46, 0x4f, 0x52, 0x4d] },
+    { offset: 8, bytes: [0x41, 0x49, 0x46, 0x46] },
+  ],
 ];
 
 const VIDEO_SIGNATURES: readonly MediaSignature[] = [
@@ -357,7 +364,11 @@ async function verifyMediaSignature(
     const header = buf.subarray(0, bytesRead);
     if (header.length === 0) return false;
     return headerMatches(header, signatures);
-  } catch {
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to verify media signature for: ${filePath}`,
+      error instanceof Error ? error.message : String(error),
+    );
     return false;
   } finally {
     if (fh) {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -248,6 +248,128 @@ export async function isBinaryFile(filePath: string): Promise<boolean> {
   }
 }
 
+// --- Media magic-byte signatures --------------------------------------------
+// Before trusting an extension-derived media mime we verify the file's actual
+// bytes against known magic-number signatures. This prevents text/source files
+// whose extension collides with a media mime (e.g. .fh -> image/x-freehand,
+// .ts -> video/mp2t) from being misclassified and sent as base64 media, which
+// causes provider 400 errors. Files whose signature does not verify fall
+// through to the content sniff; the check reads only the leading bytes and
+// costs sub-ms / sub-KB, so no caching is needed.
+
+interface BytePattern {
+  readonly offset: number;
+  readonly bytes: readonly number[];
+}
+
+type MediaSignature = readonly BytePattern[];
+
+const IMAGE_SIGNATURES: readonly MediaSignature[] = [
+  [{ offset: 0, bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] }],
+  [{ offset: 0, bytes: [0xff, 0xd8, 0xff] }],
+  [{ offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x37, 0x61] }],
+  [{ offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x39, 0x61] }],
+  [{ offset: 0, bytes: [0x42, 0x4d] }],
+  [{ offset: 0, bytes: [0x49, 0x49, 0x2a, 0x00] }],
+  [{ offset: 0, bytes: [0x4d, 0x4d, 0x00, 0x2a] }],
+  [{ offset: 0, bytes: [0x00, 0x00, 0x01, 0x00] }],
+  [
+    { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+    { offset: 8, bytes: [0x57, 0x45, 0x42, 0x50] },
+  ],
+];
+
+const AUDIO_SIGNATURES: readonly MediaSignature[] = [
+  [{ offset: 0, bytes: [0x49, 0x44, 0x33] }],
+  [{ offset: 0, bytes: [0xff, 0xfb] }],
+  [{ offset: 0, bytes: [0xff, 0xfa] }],
+  [{ offset: 0, bytes: [0xff, 0xf3] }],
+  [{ offset: 0, bytes: [0xff, 0xf2] }],
+  [{ offset: 0, bytes: [0xff, 0xe3] }],
+  [{ offset: 0, bytes: [0xff, 0xe2] }],
+  [
+    { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+    { offset: 8, bytes: [0x57, 0x41, 0x56, 0x45] },
+  ],
+  [{ offset: 0, bytes: [0x66, 0x4c, 0x61, 0x43] }],
+  [{ offset: 0, bytes: [0x4f, 0x67, 0x67, 0x53] }],
+  [{ offset: 0, bytes: [0xff, 0xf1] }],
+  [{ offset: 0, bytes: [0xff, 0xf9] }],
+  [{ offset: 0, bytes: [0xff, 0xf0] }],
+  [{ offset: 0, bytes: [0xff, 0xf8] }],
+];
+
+const VIDEO_SIGNATURES: readonly MediaSignature[] = [
+  [{ offset: 4, bytes: [0x66, 0x74, 0x79, 0x70] }],
+  [
+    { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+    { offset: 8, bytes: [0x41, 0x56, 0x49, 0x20] },
+  ],
+  [{ offset: 0, bytes: [0x1a, 0x45, 0xdf, 0xa3] }],
+];
+
+const PDF_SIGNATURES: readonly MediaSignature[] = [
+  [{ offset: 0, bytes: [0x25, 0x50, 0x44, 0x46] }],
+];
+
+interface MediaCategory {
+  readonly type: 'image' | 'audio' | 'video' | 'pdf';
+  readonly signatures: readonly MediaSignature[];
+}
+
+function resolveMediaCategory(mimeType: string): MediaCategory | null {
+  if (mimeType.startsWith('image/')) {
+    return { type: 'image', signatures: IMAGE_SIGNATURES };
+  }
+  if (mimeType.startsWith('audio/')) {
+    return { type: 'audio', signatures: AUDIO_SIGNATURES };
+  }
+  if (mimeType.startsWith('video/')) {
+    return { type: 'video', signatures: VIDEO_SIGNATURES };
+  }
+  if (mimeType === 'application/pdf') {
+    return { type: 'pdf', signatures: PDF_SIGNATURES };
+  }
+  return null;
+}
+
+function headerMatches(
+  header: Buffer,
+  signatures: readonly MediaSignature[],
+): boolean {
+  return signatures.some((sig) =>
+    sig.every(({ offset, bytes }) => {
+      if (offset + bytes.length > header.length) return false;
+      return bytes.every((b, i) => header[offset + i] === b);
+    }),
+  );
+}
+
+async function verifyMediaSignature(
+  filePath: string,
+  signatures: readonly MediaSignature[],
+): Promise<boolean> {
+  let fh: fs.promises.FileHandle | null = null;
+  try {
+    fh = await fs.promises.open(filePath, 'r');
+    const buf = Buffer.alloc(32);
+    const { bytesRead } = await fh.read(buf, 0, 32, 0);
+    const header = buf.subarray(0, bytesRead);
+    if (header.length === 0) return false;
+    return headerMatches(header, signatures);
+  } catch {
+    return false;
+  } finally {
+    if (fh) {
+      try {
+        await fh.close();
+      } catch {
+        // ignore close errors
+      }
+    }
+  }
+}
+
 /**
  * Detects the type of file based on extension and content.
  * @param filePath Path to the file.
@@ -261,7 +383,7 @@ export async function detectFileType(
   // The mimetype for various TypeScript extensions (ts, mts, cts, tsx) can be
   // MPEG transport stream (a video format), but we want to assume these are
   // TypeScript files instead.
-  if (['.ts', '.mts', '.cts'].includes(ext)) {
+  if (['.ts', '.mts', '.cts', '.tsx'].includes(ext)) {
     return 'text';
   }
 
@@ -281,17 +403,20 @@ export async function detectFileType(
     lookedUpMimeType !== '' &&
     !freehandExtensions.includes(ext)
   ) {
-    if (lookedUpMimeType.startsWith('image/')) {
-      return 'image';
-    }
-    if (lookedUpMimeType.startsWith('audio/')) {
-      return 'audio';
-    }
-    if (lookedUpMimeType.startsWith('video/')) {
-      return 'video';
-    }
-    if (lookedUpMimeType === 'application/pdf') {
-      return 'pdf';
+    const category = resolveMediaCategory(lookedUpMimeType);
+    if (category) {
+      if (await verifyMediaSignature(filePath, category.signatures)) {
+        return category.type;
+      }
+      // Signature did not verify. If the content is clearly text, reclassify
+      // as text to avoid sending source/text as base64 media (provider 400).
+      // Binary-but-unrecognized content is classified as binary rather than
+      // the media type: an unverified binary blob sent as base64 media would
+      // trigger the same provider 400 errors this feature prevents.
+      if (!(await isBinaryFile(filePath))) {
+        return 'text';
+      }
+      return 'binary';
     }
   }
 

--- a/packages/tools/src/__tests__/filesystem-tools.test.ts
+++ b/packages/tools/src/__tests__/filesystem-tools.test.ts
@@ -364,7 +364,13 @@ describe('Filesystem Tool Group Behavioral Tests @plan:PLAN-20260608-ISSUE1585.P
 
     it('returns a clear error for corrupt images under automatic resizing', async () => {
       const filePath = join(tempDir, 'corrupt.png');
-      writeFileSync(filePath, Buffer.from('corrupt image bytes'));
+      writeFileSync(
+        filePath,
+        Buffer.from([
+          0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01, 0x02,
+          0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+        ]),
+      );
       const tool = new ReadFileTool(
         _createFakeFileHost(tempDir, {
           'image-resize.maxLongEdge': 120,

--- a/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
+++ b/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
@@ -288,7 +288,11 @@ describe('ReadManyFilesTool real behavioral filtering', () => {
     {
       name: 'corrupt',
       extension: 'png',
-      create: async () => Buffer.from('corrupt image bytes'),
+      create: async () =>
+        Buffer.from([
+          0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01, 0x02,
+          0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+        ]),
     },
     {
       name: 'unsupported',

--- a/packages/tools/src/utils/fileUtils.test.ts
+++ b/packages/tools/src/utils/fileUtils.test.ts
@@ -122,6 +122,14 @@ describe('fileUtils.detectFileType', () => {
       mime: 'image/bmp',
       content: Buffer.from([0x42, 0x4d, 0x00, 0x00]),
     },
+    {
+      label: 'heic',
+      file: 'photo.heic',
+      mime: 'image/heic',
+      content: Buffer.from([
+        0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63,
+      ]),
+    },
   ])(
     'should classify real $label image as image when signature verifies (#2723)',
     async ({ file, mime: mimeType, content }) => {
@@ -158,6 +166,14 @@ describe('fileUtils.detectFileType', () => {
       file: 'audio.ogg',
       mime: 'audio/ogg',
       content: Buffer.from([0x4f, 0x67, 0x67, 0x53, 0x00]),
+    },
+    {
+      label: 'm4a',
+      file: 'track.m4a',
+      mime: 'audio/mp4',
+      content: Buffer.from([
+        0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
+      ]),
     },
   ])(
     'should classify real $label audio as audio when signature verifies (#2723)',

--- a/packages/tools/src/utils/fileUtils.test.ts
+++ b/packages/tools/src/utils/fileUtils.test.ts
@@ -87,18 +87,173 @@ describe('fileUtils.detectFileType', () => {
     expect(await detectFileType(fhPath)).toBe('binary');
   });
 
+  // --- Content-signature verification for media classification (#2723) ---
+
   it.each([
-    { type: 'image', file: 'file.png', mime: 'image/png' },
-    { type: 'pdf', file: 'file.pdf', mime: 'application/pdf' },
-    { type: 'audio', file: 'song.mp3', mime: 'audio/mpeg' },
-    { type: 'video', file: 'movie.mp4', mime: 'video/mp4' },
+    {
+      label: 'png',
+      file: 'file.png',
+      mime: 'image/png',
+      content: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    },
+    {
+      label: 'jpeg',
+      file: 'file.jpg',
+      mime: 'image/jpeg',
+      content: Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+    },
+    {
+      label: 'gif',
+      file: 'file.gif',
+      mime: 'image/gif',
+      content: Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]),
+    },
+    {
+      label: 'webp',
+      file: 'file.webp',
+      mime: 'image/webp',
+      content: Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x1c, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+      ]),
+    },
+    {
+      label: 'bmp',
+      file: 'file.bmp',
+      mime: 'image/bmp',
+      content: Buffer.from([0x42, 0x4d, 0x00, 0x00]),
+    },
   ])(
-    'should detect $type type for $file by mime',
-    async ({ file, mime: mimeType, type }) => {
+    'should classify real $label image as image when signature verifies (#2723)',
+    async ({ file, mime: mimeType, content }) => {
+      const filePath = path.join(tempRootDir, file);
+      actualNodeFs.writeFileSync(filePath, content);
       mockMimeLookup.mockReturnValueOnce(mimeType);
-      expect(await detectFileType(file)).toBe(type);
+      expect(await detectFileType(filePath)).toBe('image');
     },
   );
+
+  it.each([
+    {
+      label: 'mp3',
+      file: 'song.mp3',
+      mime: 'audio/mpeg',
+      content: Buffer.from([0x49, 0x44, 0x33, 0x03, 0x00, 0x00]),
+    },
+    {
+      label: 'wav',
+      file: 'sound.wav',
+      mime: 'audio/wav',
+      content: Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45,
+      ]),
+    },
+    {
+      label: 'flac',
+      file: 'audio.flac',
+      mime: 'audio/flac',
+      content: Buffer.from([0x66, 0x4c, 0x61, 0x43, 0x00]),
+    },
+    {
+      label: 'ogg',
+      file: 'audio.ogg',
+      mime: 'audio/ogg',
+      content: Buffer.from([0x4f, 0x67, 0x67, 0x53, 0x00]),
+    },
+  ])(
+    'should classify real $label audio as audio when signature verifies (#2723)',
+    async ({ file, mime: mimeType, content }) => {
+      const filePath = path.join(tempRootDir, file);
+      actualNodeFs.writeFileSync(filePath, content);
+      mockMimeLookup.mockReturnValueOnce(mimeType);
+      expect(await detectFileType(filePath)).toBe('audio');
+    },
+  );
+
+  it.each([
+    {
+      label: 'mp4',
+      file: 'movie.mp4',
+      mime: 'video/mp4',
+      content: Buffer.from([
+        0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
+      ]),
+    },
+    {
+      label: 'avi',
+      file: 'clip.avi',
+      mime: 'video/x-msvideo',
+      content: Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x41, 0x56, 0x49, 0x20,
+      ]),
+    },
+    {
+      label: 'webm',
+      file: 'video.webm',
+      mime: 'video/webm',
+      content: Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x01]),
+    },
+  ])(
+    'should classify real $label video as video when signature verifies (#2723)',
+    async ({ file, mime: mimeType, content }) => {
+      const filePath = path.join(tempRootDir, file);
+      actualNodeFs.writeFileSync(filePath, content);
+      mockMimeLookup.mockReturnValueOnce(mimeType);
+      expect(await detectFileType(filePath)).toBe('video');
+    },
+  );
+
+  it('should classify real pdf as pdf when signature verifies (#2723)', async () => {
+    const filePath = path.join(tempRootDir, 'document.pdf');
+    actualNodeFs.writeFileSync(
+      filePath,
+      Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a]),
+    );
+    mockMimeLookup.mockReturnValueOnce('application/pdf');
+    expect(await detectFileType(filePath)).toBe('pdf');
+  });
+
+  it.each([
+    { label: 'image', file: 'shader.png', mime: 'image/png' },
+    { label: 'audio', file: 'config.mp3', mime: 'audio/mpeg' },
+    { label: 'video', file: 'data.mp4', mime: 'video/mp4' },
+    { label: 'pdf', file: 'notes.pdf', mime: 'application/pdf' },
+  ])(
+    'should reclassify text content with $label mime as text, not media (#2723)',
+    async ({ file, mime: mimeType }) => {
+      const filePath = path.join(tempRootDir, file);
+      actualNodeFs.writeFileSync(filePath, 'console.log("hello world");');
+      mockMimeLookup.mockReturnValueOnce(mimeType);
+      expect(await detectFileType(filePath)).toBe('text');
+    },
+  );
+
+  it('should classify binary content with unverified signature as binary (#2723)', async () => {
+    const filePath = path.join(tempRootDir, 'mystery.png');
+    actualNodeFs.writeFileSync(
+      filePath,
+      Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a]),
+    );
+    mockMimeLookup.mockReturnValueOnce('image/png');
+    expect(await detectFileType(filePath)).toBe('binary');
+  });
+
+  it('should reject partial RIFF match (AND semantics) as non-media text (#2723)', async () => {
+    const filePath = path.join(tempRootDir, 'fake.webp');
+    actualNodeFs.writeFileSync(
+      filePath,
+      Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x41, 0x42, 0x43, 0x44, 0x58, 0x58, 0x58, 0x58,
+      ]),
+    );
+    mockMimeLookup.mockReturnValueOnce('image/webp');
+    expect(await detectFileType(filePath)).toBe('text');
+  });
+
+  it('should fall through to text for non-existent file with media mime (#2723)', async () => {
+    const filePath = path.join(tempRootDir, 'nonexistent.png');
+    mockMimeLookup.mockReturnValueOnce('image/png');
+    expect(await detectFileType(filePath)).toBe('text');
+  });
 
   it('should default to text if mime is unknown and content is not binary', async () => {
     mockMimeLookup.mockReturnValueOnce(false);
@@ -244,7 +399,13 @@ describe('processSingleFileContent image resizing', () => {
 
   it('preserves a structured image-resize failure', async () => {
     const imagePath = path.join(tempRootDir, 'corrupt.png');
-    actualNodeFs.writeFileSync(imagePath, Buffer.from('corrupt image bytes'));
+    actualNodeFs.writeFileSync(
+      imagePath,
+      Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01, 0x02, 0x03,
+        0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+      ]),
+    );
 
     const result = await processSingleFileContent(
       imagePath,

--- a/packages/tools/src/utils/fileUtils.test.ts
+++ b/packages/tools/src/utils/fileUtils.test.ts
@@ -208,6 +208,17 @@ describe('fileUtils.detectFileType', () => {
       mime: 'video/webm',
       content: Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x01]),
     },
+    {
+      label: 'mpegts',
+      file: 'movie.m2ts',
+      mime: 'video/mp2t',
+      content: (() => {
+        const buf = Buffer.alloc(189, 0x10);
+        buf[0] = 0x47;
+        buf[188] = 0x47;
+        return buf;
+      })(),
+    },
   ])(
     'should classify real $label video as video when signature verifies (#2723)',
     async ({ file, mime: mimeType, content }) => {

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -281,6 +281,10 @@ const VIDEO_SIGNATURES: readonly MediaSignature[] = [
     { offset: 8, bytes: [0x41, 0x56, 0x49, 0x20] },
   ],
   [{ offset: 0, bytes: [0x1a, 0x45, 0xdf, 0xa3] }],
+  [
+    { offset: 0, bytes: [0x47] },
+    { offset: 188, bytes: [0x47] },
+  ],
 ];
 
 const PDF_SIGNATURES: readonly MediaSignature[] = [
@@ -327,8 +331,8 @@ async function verifyMediaSignature(
   let fh: fs.promises.FileHandle | null = null;
   try {
     fh = await fs.promises.open(filePath, 'r');
-    const buf = Buffer.alloc(32);
-    const { bytesRead } = await fh.read(buf, 0, 32, 0);
+    const buf = Buffer.alloc(512);
+    const { bytesRead } = await fh.read(buf, 0, 512, 0);
     const header = buf.subarray(0, bytesRead);
     if (header.length === 0) return false;
     return headerMatches(header, signatures);

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -216,6 +216,128 @@ export async function isBinaryFile(filePath: string): Promise<boolean> {
   }
 }
 
+// --- Media magic-byte signatures --------------------------------------------
+// Before trusting an extension-derived media mime we verify the file's actual
+// bytes against known magic-number signatures. This prevents text/source files
+// whose extension collides with a media mime (e.g. .fh -> image/x-freehand,
+// .ts -> video/mp2t) from being misclassified and sent as base64 media, which
+// causes provider 400 errors. Files whose signature does not verify fall
+// through to the content sniff; the check reads only the leading bytes and
+// costs sub-ms / sub-KB, so no caching is needed.
+
+interface BytePattern {
+  readonly offset: number;
+  readonly bytes: readonly number[];
+}
+
+type MediaSignature = readonly BytePattern[];
+
+const IMAGE_SIGNATURES: readonly MediaSignature[] = [
+  [{ offset: 0, bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] }],
+  [{ offset: 0, bytes: [0xff, 0xd8, 0xff] }],
+  [{ offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x37, 0x61] }],
+  [{ offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x39, 0x61] }],
+  [{ offset: 0, bytes: [0x42, 0x4d] }],
+  [{ offset: 0, bytes: [0x49, 0x49, 0x2a, 0x00] }],
+  [{ offset: 0, bytes: [0x4d, 0x4d, 0x00, 0x2a] }],
+  [{ offset: 0, bytes: [0x00, 0x00, 0x01, 0x00] }],
+  [
+    { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+    { offset: 8, bytes: [0x57, 0x45, 0x42, 0x50] },
+  ],
+];
+
+const AUDIO_SIGNATURES: readonly MediaSignature[] = [
+  [{ offset: 0, bytes: [0x49, 0x44, 0x33] }],
+  [{ offset: 0, bytes: [0xff, 0xfb] }],
+  [{ offset: 0, bytes: [0xff, 0xfa] }],
+  [{ offset: 0, bytes: [0xff, 0xf3] }],
+  [{ offset: 0, bytes: [0xff, 0xf2] }],
+  [{ offset: 0, bytes: [0xff, 0xe3] }],
+  [{ offset: 0, bytes: [0xff, 0xe2] }],
+  [
+    { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+    { offset: 8, bytes: [0x57, 0x41, 0x56, 0x45] },
+  ],
+  [{ offset: 0, bytes: [0x66, 0x4c, 0x61, 0x43] }],
+  [{ offset: 0, bytes: [0x4f, 0x67, 0x67, 0x53] }],
+  [{ offset: 0, bytes: [0xff, 0xf1] }],
+  [{ offset: 0, bytes: [0xff, 0xf9] }],
+  [{ offset: 0, bytes: [0xff, 0xf0] }],
+  [{ offset: 0, bytes: [0xff, 0xf8] }],
+];
+
+const VIDEO_SIGNATURES: readonly MediaSignature[] = [
+  [{ offset: 4, bytes: [0x66, 0x74, 0x79, 0x70] }],
+  [
+    { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+    { offset: 8, bytes: [0x41, 0x56, 0x49, 0x20] },
+  ],
+  [{ offset: 0, bytes: [0x1a, 0x45, 0xdf, 0xa3] }],
+];
+
+const PDF_SIGNATURES: readonly MediaSignature[] = [
+  [{ offset: 0, bytes: [0x25, 0x50, 0x44, 0x46] }],
+];
+
+interface MediaCategory {
+  readonly type: 'image' | 'audio' | 'video' | 'pdf';
+  readonly signatures: readonly MediaSignature[];
+}
+
+function resolveMediaCategory(mimeType: string): MediaCategory | null {
+  if (mimeType.startsWith('image/')) {
+    return { type: 'image', signatures: IMAGE_SIGNATURES };
+  }
+  if (mimeType.startsWith('audio/')) {
+    return { type: 'audio', signatures: AUDIO_SIGNATURES };
+  }
+  if (mimeType.startsWith('video/')) {
+    return { type: 'video', signatures: VIDEO_SIGNATURES };
+  }
+  if (mimeType === 'application/pdf') {
+    return { type: 'pdf', signatures: PDF_SIGNATURES };
+  }
+  return null;
+}
+
+function headerMatches(
+  header: Buffer,
+  signatures: readonly MediaSignature[],
+): boolean {
+  return signatures.some((sig) =>
+    sig.every(({ offset, bytes }) => {
+      if (offset + bytes.length > header.length) return false;
+      return bytes.every((b, i) => header[offset + i] === b);
+    }),
+  );
+}
+
+async function verifyMediaSignature(
+  filePath: string,
+  signatures: readonly MediaSignature[],
+): Promise<boolean> {
+  let fh: fs.promises.FileHandle | null = null;
+  try {
+    fh = await fs.promises.open(filePath, 'r');
+    const buf = Buffer.alloc(32);
+    const { bytesRead } = await fh.read(buf, 0, 32, 0);
+    const header = buf.subarray(0, bytesRead);
+    if (header.length === 0) return false;
+    return headerMatches(header, signatures);
+  } catch {
+    return false;
+  } finally {
+    if (fh) {
+      try {
+        await fh.close();
+      } catch {
+        // ignore close errors
+      }
+    }
+  }
+}
+
 export async function detectFileType(
   filePath: string,
 ): Promise<'text' | 'image' | 'pdf' | 'audio' | 'video' | 'binary' | 'svg'> {
@@ -240,10 +362,21 @@ export async function detectFileType(
     lookedUpMimeType !== '' &&
     !freehandExtensions.includes(ext)
   ) {
-    if (lookedUpMimeType.startsWith('image/')) return 'image';
-    if (lookedUpMimeType.startsWith('audio/')) return 'audio';
-    if (lookedUpMimeType.startsWith('video/')) return 'video';
-    if (lookedUpMimeType === 'application/pdf') return 'pdf';
+    const category = resolveMediaCategory(lookedUpMimeType);
+    if (category) {
+      if (await verifyMediaSignature(filePath, category.signatures)) {
+        return category.type;
+      }
+      // Signature did not verify. If the content is clearly text, reclassify
+      // as text to avoid sending source/text as base64 media (provider 400).
+      // Binary-but-unrecognized content is classified as binary rather than
+      // the media type: an unverified binary blob sent as base64 media would
+      // trigger the same provider 400 errors this feature prevents.
+      if (!(await isBinaryFile(filePath))) {
+        return 'text';
+      }
+      return 'binary';
+    }
   }
 
   if (BINARY_EXTENSIONS.includes(ext)) {

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -245,6 +245,7 @@ const IMAGE_SIGNATURES: readonly MediaSignature[] = [
     { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
     { offset: 8, bytes: [0x57, 0x45, 0x42, 0x50] },
   ],
+  [{ offset: 4, bytes: [0x66, 0x74, 0x79, 0x70] }],
 ];
 
 const AUDIO_SIGNATURES: readonly MediaSignature[] = [
@@ -265,6 +266,12 @@ const AUDIO_SIGNATURES: readonly MediaSignature[] = [
   [{ offset: 0, bytes: [0xff, 0xf9] }],
   [{ offset: 0, bytes: [0xff, 0xf0] }],
   [{ offset: 0, bytes: [0xff, 0xf8] }],
+  [{ offset: 4, bytes: [0x66, 0x74, 0x79, 0x70] }],
+  [{ offset: 0, bytes: [0x4d, 0x54, 0x68, 0x64] }],
+  [
+    { offset: 0, bytes: [0x46, 0x4f, 0x52, 0x4d] },
+    { offset: 8, bytes: [0x41, 0x49, 0x46, 0x46] },
+  ],
 ];
 
 const VIDEO_SIGNATURES: readonly MediaSignature[] = [
@@ -325,7 +332,11 @@ async function verifyMediaSignature(
     const header = buf.subarray(0, bytesRead);
     if (header.length === 0) return false;
     return headerMatches(header, signatures);
-  } catch {
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to verify media signature for: ${filePath}`,
+      error instanceof Error ? error.message : String(error),
+    );
     return false;
   } finally {
     if (fh) {

--- a/project-plans/issue-2723-content-signature-verification.md
+++ b/project-plans/issue-2723-content-signature-verification.md
@@ -1,0 +1,96 @@
+# Issue #2723 — Content-signature verification before trusting media mime classification
+
+## Policy basis
+
+The bounded issue-delivery policy is supplied inline with the issue request.
+Scope targets: ≤ 25 files, ≤ 1 500 net changed lines; mandatory scope review
+above either; stop without approval above 40 files or 2 500 net lines.
+
+## Goal
+
+Stop blindly trusting the extension-derived media mime in `detectFileType()`.
+Before classifying a file as `image` / `audio` / `video`, validate the file's
+actual bytes against a known magic-number signature. If no signature matches,
+defer to the existing `isBinaryFile()` content sniff: clear text → `text`;
+binary-but-unrecognized → retain the media type (avoids breaking legitimate
+formats whose signature is not in the table).
+
+## Decisions
+
+- **Signature table mirroring** (CodeRabbit Design Choice 1, Option 2): mirror
+  the signature table and verification helper in both `fileUtils.ts` copies
+  (`packages/core` and `packages/tools`). This matches the existing duplication
+  precedent — `detectFileType`, `isBinaryFile`, `detectBOM` are already
+  duplicated. A shared module is a later, separate refactor.
+- **Unverified-binary falls back to binary** (OCR finding, overriding
+  CodeRabbit Design Choice 2 Option 2): when the signature does not verify,
+  reclassify to `text` only when `isBinaryFile()` says text. Binary-but-
+  unrecognized content is classified as `binary`, NOT the media type. An
+  unverified binary blob sent as base64 media would trigger the same provider
+  400 errors this feature prevents. The media type is only trusted when the
+  signature actually verifies.
+- **No caching** (issue comment from acoliver): the signature check reads ≤ 512
+  bytes and compares against ~20 patterns — single-digit ms, sub-KB I/O.
+  Per the cost/complexity guidance in the issue comment, no session-level
+  caching is warranted. The cost is identical in order to the existing
+  `isBinaryFile()` read (4 KB) which already runs un-cached.
+- **`.tsx` alignment**: core's copy omits `.tsx` from the TypeScript
+  short-circuit (tools includes it). Both are aligned to include `.tsx`.
+- **Freehand allowlist stays**: the narrow `.fh*` exclusion from #2719
+  remains. With the binary-fallback fix it is functionally redundant (the
+  signature gate catches it), but it saves a `verifyMediaSignature` I/O call
+  for `.fh` files and preserves the existing tested behavior.
+
+## Acceptance matrix
+
+| AC | Accepted behavior | Behavioral evidence |
+| --- | --- | --- |
+| A1 | A file with a media-colliding extension (e.g. `.png`) whose bytes are clear text and whose mime is mocked to `image/*` is classified `text`, not `image`. | `detectFileType` regression test: write text bytes, mock `image/png`, assert `text`. |
+| A2 | A file with a genuine PNG signature and `image/png` mime is still classified `image`. | `detectFileType` test: write real PNG header, mock `image/png`, assert `image`. |
+| A3 | A file with a genuine JPEG signature and `image/jpeg` mime is still classified `image`. | `detectFileType` test with JPEG header. |
+| A4 | A file with binary content but no known media signature is classified `binary`, not the media type. Sending unverified binary as base64 media would trigger the same 400 errors this feature prevents. | `detectFileType` test: write random binary, mock `image/x-foo`, assert `binary`. |
+| A5 | Audio collisions: text content with `audio/mpeg` mime → `text`; real MP3/ID3 header → `audio`. | `detectFileType` tests for audio category. |
+| A6 | Video collisions: text content with `video/mp4` mime → `text`; real MP4 ftyp header → `video`. | `detectFileType` tests for video category. |
+| A7 | PDF: real `%PDF` header with `application/pdf` → `pdf`; text content with `application/pdf` → `text`. | `detectFileType` tests for pdf category. |
+| A8 | Existing `.ts`/`.mts`/`.cts`/`.tsx` and `.svg` short-circuits are unchanged. | Existing extension tests remain green; `.tsx` added to core. |
+| A9 | Existing `.fh*` freehand exclusion remains effective. | Existing #2719 tests remain green. |
+| A10 | Both `packages/core` and `packages/tools` copies behave identically. | Parity test cases in both test files. |
+| A11 | I/O error during signature read conservatively returns "no match" so the caller falls through to the content sniff. | `detectFileType` test: non-existent path with media mime falls through to text/binary. |
+
+## Explicit non-goals
+
+- No new shared cross-package module (mirroring only).
+- No session-level signature cache (cost is sub-ms, sub-KB).
+- No removal of the existing `.fh*` freehand allowlist (#2719).
+- No changes to `BINARY_EXTENSIONS` lists.
+- No changes to downstream consumers (`processSingleFileContent`,
+  `processMediaFile`, `read-many-files.ts`) — they already dispatch on the
+  `detectFileType()` return value and need no modification.
+- No new public abstraction, dependency, workflow, agent-memory, quality rule,
+  lint/complexity threshold, suppression, or source exclusion.
+- No unrelated refactor, test relocation, optional hardening, or cleanup.
+
+## Bounded vertical slices
+
+1. **Signature table + verification helper** — add `BytePattern` / signature
+   constants and a `verifyMediaSignature()` helper (mirrored in both copies)
+   that reads ≤ 512 bytes and matches against category signatures.
+2. **Gate media branch** — rewire the `image/`/`audio/`/`video/`/`pdf` mime
+   short-circuit in both `detectFileType()` copies to gate on signature
+   verification, deferring to `isBinaryFile()` when unverified.
+3. **`.tsx` alignment** — add `.tsx` to core's TypeScript short-circuit list.
+4. **Regression tests** — add parity test cases in both test files covering
+   text-with-media-mime, genuine-signature, binary-unrecognized, audio, video,
+   pdf, and I/O-error fallthrough.
+
+## Scope ledger
+
+| Item | Status |
+| --- | --- |
+| `packages/core/src/utils/fileUtils.ts` — signature table + helper + gate | planned |
+| `packages/tools/src/utils/fileUtils.ts` — mirror of above | planned |
+| `packages/core/src/utils/fileUtils.test.ts` — regression tests | planned |
+| `packages/tools/src/utils/fileUtils.test.ts` — parity regression tests | planned |
+| `project-plans/issue-2723-content-signature-verification.md` — this plan | planned |
+
+Expected files: 5. Expected net lines: well under 500.


### PR DESCRIPTION
## Summary

`detectFileType()` previously returned `image`/`audio`/`video` on the **first** extension-derived mime match, before any content inspection. Extensions that collide with media mimes but are actually source/text (e.g. `.fh` to `image/x-freehand`, `.ts` to `video/mp2t`) were misclassified and sent as base64 media, causing provider 400 errors.

This PR adds a **content-signature verification step** that validates actual file bytes against known magic-number signatures before trusting a media classification. This is the holistic fix for file-type detection tracked in #2723 (follow-on from the narrow #2719 FreeHand allowlist).

## How it works

1. When `mime.lookup()` returns an `image/*`, `audio/*`, `video/*`, or `application/pdf` mime, the leading 32 bytes are read and matched against a signature table for that media category.
2. **Signature verifies**: the media type is trusted (e.g. a real PNG returns `image`).
3. **Signature does not verify + content is text**: reclassified as `text` (the bug fix: source/text files are read as text, not sent as base64 media).
4. **Signature does not verify + content is binary**: classified as `binary` (never sends an unverified blob as base64 media).

## Performance

The signature check reads only the leading 32 bytes and compares against ~20 patterns -- sub-ms, sub-KB I/O. Per the issue author's cost/complexity guidance, no session-level caching is needed.

## Signature table coverage

- **Image**: PNG, JPEG, GIF87a/GIF89a, BMP, TIFF (LE/BE), ICO, WEBP (RIFF+WEBP)
- **Audio**: MP3 (ID3 + frame sync variants), WAV (RIFF+WAVE), FLAC, OGG, AAC (ADTS variants)
- **Video**: MP4/MOV (ftyp box), AVI (RIFF+AVI), WebM/MKV (EBML)
- **PDF**: %PDF header

## Changes

- `packages/tools/src/utils/fileUtils.ts` -- signature tables, `verifyMediaSignature()`, gated media branch
- `packages/core/src/utils/fileUtils.ts` -- mirrored changes + `.tsx` alignment
- `packages/tools/src/utils/fileUtils.test.ts` -- comprehensive signature-based regression tests
- `packages/core/src/utils/fileUtils.test.ts` -- parallel regression tests
- `project-plans/issue-2723-content-signature-verification.md` -- acceptance matrix

## Verification

- All new tests pass (signature verification, collision detection, AND-semantics, I/O error fallthrough)
- Lint, format, typecheck, eslint-guard all pass
- Pre-existing sharp `metadata.autoOrient` test failure is unrelated (confirmed on main)
- Smoke test passes

Fixes #2723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file type detection by verifying media content signatures instead of relying only on file extensions.
  - Prevented text or invalid files from being incorrectly treated as images, audio, video, or PDFs.
  - Added support for `.tsx` files as text.
  - Improved handling of corrupt media files and image-resizing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->