### PR TITLE
ci: move macOS test legs from PR CI to nightly workflow (Fixes #2876)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -863,7 +863,7 @@ jobs:
           bun scripts/run_bun_tests.ts --timeout 30000
 
   #
-  # Test: Node (Linux and macOS - always run)
+  # Test: Node (Linux only — issue #2876)
   #
   # Stays on npm (not Bun) for S6 (#2243): Bun's hoisted linker non-
   # deterministically materializes incomplete copies of third-party packages
@@ -880,8 +880,9 @@ jobs:
   # critical path is max(shard) rather than sum(all workspaces). The shard map
   # lives in scripts/test-shards.ts and is enforced by
   # scripts/check-test-shards.ts (run below and via `lint:test-shards`). Each
-  # shard is a matrix leg over `os`; the `scripts` shard runs the root script
-  # harness instead of workspace tests.
+  # shard is a matrix leg; the `scripts` shard runs the root script harness
+  # instead of workspace tests. The selector emits ubuntu-only rows (issue
+  # #2876); macOS coverage moved to the nightly workflow.
   #
   # Issue #2709: the matrix is now dynamic — shard_selector outputs a JSON
   # matrix of only the shards that can observe the PR's changed files. When
@@ -910,8 +911,8 @@ jobs:
     strategy:
       fail-fast: false # So we can see all test failures
       # Dynamic matrix from shard_selector (issue #2709): only shards that can
-      # observe the changed files. The selector guarantees Linux+macOS for
-      # every selected shard, preserving cross-platform coverage. An empty
+      # observe the changed files. The selector emits ubuntu-only rows (issue
+      # #2876); macOS test coverage moved to the nightly workflow. An empty
       # matrix (no tests selected) combined with the has_tests gate above
       # skips all legs without making the required `Test` check red.
       matrix:
@@ -1168,12 +1169,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Issue #2876: macOS keyring coverage moved to the nightly workflow.
+        # The PR matrix is ubuntu-only to reduce macOS runner contention.
         include:
           - os: 'ubuntu-latest'
-            node-version: '24.x'
-            secure-store-mode: 'keyring'
-            test-config: 'vitest.config.native-keyring.ts'
-          - os: 'macos-latest'
             node-version: '24.x'
             secure-store-mode: 'keyring'
             test-config: 'vitest.config.native-keyring.ts'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -144,6 +144,173 @@ jobs:
           name: 'test-results-fork-${{ matrix.node-version }}-${{ matrix.os }}'
           path: 'packages/*/junit.xml'
 
+  #
+  # macOS CI (Nightly) — issue #2876
+  #
+  # The macOS test legs moved out of PR CI (ci.yml) into this nightly job so
+  # macOS runner-minute spend on PR CI drops to near zero. macOS cross-platform
+  # coverage is preserved on a nightly cadence, alongside the existing Windows
+  # CI job above. Like windows_ci, this runs the full unsharded workspace test
+  # suite (npm run test) plus the script harness and shell-script behavioral
+  # tests that the PR scripts shard covers.
+  macos_ci:
+    name: 'macOS CI (Nightly)'
+    runs-on: 'macos-latest'
+    timeout-minutes: 60
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+
+      - name: 'Set up Node.js 24.x'
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # ratchet:actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: 'npm'
+
+      - name: 'Setup Bun'
+        uses: 'oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76' # ratchet:oven-sh/setup-bun@v2
+        with:
+          bun-version-file: '.bun-version'
+
+      - name: 'Install dependencies for testing'
+        run: |-
+          npm ci
+
+      - name: 'Fix rollup platform dependency'
+        run: |-
+          # Explicitly install the platform-specific rollup package
+          # This is a workaround for https://github.com/npm/cli/issues/4828
+          if [ "$(uname -m)" == "arm64" ]; then
+            npm install @rollup/rollup-darwin-arm64 --no-save || true
+          else
+            npm install @rollup/rollup-darwin-x64 --no-save || true
+          fi
+        shell: 'bash'
+
+      - name: 'Build project'
+        run: |-
+          npm run build
+
+      - name: 'Generate agents API surface report'
+        shell: 'bash'
+        run: |-
+          npm run lint:agents-api-surface
+
+      - name: 'Limit Vitest forks (macOS — single fork)'
+        # macOS runners have 3 vCPUs. With VITEST_MAX_FORKS=2, two worker
+        # forks plus the vitest main process saturate all 3 cores, starving
+        # the main process and causing onTaskUpdate RPC timeouts. A single
+        # fork leaves a spare core for the main process to stay responsive.
+        run: |
+          echo "VITEST_MAX_FORKS=1" >> "$GITHUB_ENV"
+          echo "VITEST_MIN_FORKS=1" >> "$GITHUB_ENV"
+          echo "VITEST_TEST_TIMEOUT=30000" >> "$GITHUB_ENV"
+          echo "VITEST_POOL_TIMEOUT=60000" >> "$GITHUB_ENV"
+
+      - name: 'Run tests and generate reports'
+        env:
+          # Provider configuration from repository secrets/variables
+          OPENAI_API_KEY: ${{ secrets[vars.KEY_VAR_NAME] }}
+          OPENAI_API_KEY_2: ${{ secrets[vars.KEY_VAR_NAME_2] }}
+          KEY_VAR_NAME: ${{ vars.KEY_VAR_NAME }}
+          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
+          LLXPRT_DEFAULT_MODEL: ${{ vars.LLXPRT_DEFAULT_MODEL }}
+          LLXPRT_DEFAULT_PROVIDER: ${{ vars.LLXPRT_DEFAULT_PROVIDER }}
+          # Set auth type to provider for API key authentication
+          LLXPRT_AUTH_TYPE: provider
+          NO_COLOR: true
+          # Ensure OAuth tests are skipped in CI (they require browser interaction)
+          CI: true
+          # Allow OpenAI integration tests to exceed Vitest's 5s default timeout (issue #338)
+          VITEST_TEST_TIMEOUT: 15000
+          # macOS coverage is never consumed (no post_coverage_comment in
+          # nightly), so skip the instrumentation cost (#2708).
+          LLXPRT_COVERAGE: 'false'
+        run: 'npm run test'
+
+      - name: 'Run script harness tests'
+        env:
+          CI: true
+        run: 'npm run test:scripts'
+
+      - name: 'Run shell-script behavioral tests (#2606)'
+        env:
+          CI: true
+        run: 'npm run test:shell'
+
+      - name: 'Smoke test CLI entry (launcher -> Bun, no Node in chain)'
+        run: './packages/cli/bin/llxprt --version'
+
+      - name: 'Wait for file system sync'
+        run: 'sleep 2'
+
+      - name: 'Publish Test Report (for non-forks)'
+        if: |-
+          ${{ always() && (github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: 'dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3' # ratchet:dorny/test-reporter@v2
+        with:
+          name: 'macOS Test Results (Node 24.x)'
+          path: 'packages/*/junit.xml'
+          reporter: 'java-junit'
+          fail-on-error: 'false'
+
+      - name: 'Upload Test Results Artifact (for forks)'
+        if: |-
+          ${{ always() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
+        with:
+          name: 'test-results-fork-macos-24.x'
+          path: 'packages/*/junit.xml'
+
+  #
+  # macOS SecureStore backend (Nightly) — issue #2876
+  #
+  # The macOS keyring SecureStore leg moved out of PR CI (ci.yml) into this
+  # nightly job. The ubuntu keyring and fallback legs remain in PR CI
+  # (ci.yml secure_store_backend). This job runs the native-keyring vitest
+  # config on macOS, which tests the macOS native keychain integration.
+  macos_secure_store:
+    name: 'macOS SecureStore Backend (Nightly)'
+    runs-on: 'macos-latest'
+    timeout-minutes: 15
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: 'Set up Node.js 24.x'
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # ratchet:actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: 'Setup Bun'
+        uses: 'oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76' # ratchet:oven-sh/setup-bun@v2
+        with:
+          bun-version-file: '.bun-version'
+
+      - name: 'Cache Bun dependencies'
+        uses: 'actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830' # ratchet:actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: 'Install dependencies for SecureStore tests'
+        run: |-
+          bun install
+          git checkout -- bun.lock
+
+      - name: 'Run SecureStore backend tests'
+        env:
+          CI: true
+          NO_COLOR: true
+          SECURE_STORE_MODE: 'keyring'
+          TEST_CONFIG: 'vitest.config.native-keyring.ts'
+          KEYRING_PASSWORD: 'llxprt-ci-keyring'
+        run: |-
+          npm run test:ci --workspace @vybestack/llxprt-code-storage -- --config "$TEST_CONFIG"
+
   e2e_full:
     name: 'E2E Full - ${{ matrix.os }} - ${{ matrix.sandbox }}'
     runs-on: '${{ matrix.os }}'
@@ -354,6 +521,8 @@ jobs:
     timeout-minutes: 5
     needs:
       - 'windows_ci'
+      - 'macos_ci'
+      - 'macos_secure_store'
       - 'e2e_full'
       - 'behavioral_evals'
       - 'windows_bun_native_smoke'
@@ -367,6 +536,8 @@ jobs:
           GH_REPO: '${{ github.repository }}'
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           WINDOWS_CI_RESULT: '${{ needs.windows_ci.result }}'
+          MACOS_CI_RESULT: '${{ needs.macos_ci.result }}'
+          MACOS_SECURE_STORE_RESULT: '${{ needs.macos_secure_store.result }}'
           E2E_FULL_RESULT: '${{ needs.e2e_full.result }}'
           BEHAVIORAL_EVALS_RESULT: '${{ needs.behavioral_evals.result }}'
           WINDOWS_BUN_NATIVE_SMOKE_RESULT: '${{ needs.windows_bun_native_smoke.result }}'
@@ -378,6 +549,8 @@ jobs:
 
           FAILED_JOBS=()
           [[ "${WINDOWS_CI_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("windows_ci=${WINDOWS_CI_RESULT}")
+          [[ "${MACOS_CI_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("macos_ci=${MACOS_CI_RESULT}")
+          [[ "${MACOS_SECURE_STORE_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("macos_secure_store=${MACOS_SECURE_STORE_RESULT}")
           [[ "${E2E_FULL_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("e2e_full=${E2E_FULL_RESULT}")
           [[ "${BEHAVIORAL_EVALS_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("behavioral_evals=${BEHAVIORAL_EVALS_RESULT}")
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -201,10 +201,12 @@ jobs:
         # forks plus the vitest main process saturate all 3 cores, starving
         # the main process and causing onTaskUpdate RPC timeouts. A single
         # fork leaves a spare core for the main process to stay responsive.
+        # VITEST_TEST_TIMEOUT is not set here because the step-level env on
+        # "Run tests and generate reports" sets it to 15000, which takes
+        # precedence over $GITHUB_ENV.
         run: |
           echo "VITEST_MAX_FORKS=1" >> "$GITHUB_ENV"
           echo "VITEST_MIN_FORKS=1" >> "$GITHUB_ENV"
-          echo "VITEST_TEST_TIMEOUT=30000" >> "$GITHUB_ENV"
           echo "VITEST_POOL_TIMEOUT=60000" >> "$GITHUB_ENV"
 
       - name: 'Run tests and generate reports'

--- a/scripts/affected-test-shards.ts
+++ b/scripts/affected-test-shards.ts
@@ -769,8 +769,10 @@ function main(): void {
 
 /**
  * Writes selection results to GITHUB_OUTPUT and GITHUB_STEP_SUMMARY for use in
- * GitHub Actions CI. Builds a matrix JSON array (shard × os × node-version)
- * that the test_shard job consumes via fromJSON().
+ * GitHub Actions CI. Builds a matrix JSON array (shard × node-version; issue
+ * #2876 removed the per-OS dimension — the PR test matrix is ubuntu-only, and
+ * macOS coverage moved to the nightly workflow) that the test_shard job
+ * consumes via fromJSON().
  *
  * PR-controlled values (event, fullRunReason/path text) are sanitized of CR/LF
  * before being written to prevent GITHUB_OUTPUT injection. Keys/shape preserved.
@@ -787,16 +789,16 @@ function outputGithubActions(result: SelectionResult, event: string): void {
   const ghOutputPath = process.env.GITHUB_OUTPUT;
   const ghSummaryPath = process.env.GITHUB_STEP_SUMMARY;
 
-  // Build the matrix: one entry per selected shard per OS.
+  // Build the matrix: one entry per selected shard (issue #2876).
+  // macOS test coverage moved to the nightly workflow (nightly.yml), so
+  // the PR test matrix is ubuntu-only — macOS is nightly-only like Windows.
   const matrix: Array<{
     readonly shard: string;
     readonly os: string;
     readonly 'node-version': string;
   }> = [];
   for (const shard of result.selectedShards) {
-    for (const os of ['ubuntu-latest', 'macos-latest']) {
-      matrix.push({ shard, os, 'node-version': '24.x' });
-    }
+    matrix.push({ shard, os: 'ubuntu-latest', 'node-version': '24.x' });
   }
 
   const selectedStr = sanitizeGhValue(result.selectedShards.join(','));

--- a/scripts/tests/affected-test-shards.test.ts
+++ b/scripts/tests/affected-test-shards.test.ts
@@ -29,7 +29,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -666,5 +666,85 @@ describe('affected-test-shards selector — GitHub output safety', () => {
     expect(records.filter((line) => line.startsWith('has_tests='))).toEqual([
       'has_tests=true',
     ]);
+  });
+});
+
+describe('affected-test-shards selector — ubuntu-only PR matrix (issue #2876)', () => {
+  it('emits ubuntu-only matrix rows for pull_request events', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'affected-shards-matrix-'));
+    try {
+      const files = join(dir, 'files.txt');
+      const output = join(dir, 'output.txt');
+      writeFileSync(files, 'packages/cli/src/index.ts');
+      const run = spawnSync(
+        process.execPath,
+        [
+          SELECTOR_PATH,
+          '--event',
+          PR_EVENT,
+          '--files-from',
+          files,
+          '--output',
+          'github-actions',
+        ],
+        { env: { ...process.env, GITHUB_OUTPUT: output } },
+      );
+      expect(run.stderr?.toString() ?? '').toBe('');
+      expect(run.status).toBe(0);
+      const records = readFileSync(output, 'utf8').split('\n');
+      const matrixRecord = records.find((line) => line.startsWith('matrix='));
+      expect(matrixRecord).toBeDefined();
+      const matrixJson = JSON.parse(
+        matrixRecord!.substring('matrix='.length),
+      ) as ReadonlyArray<{ readonly os: string }>;
+      expect(matrixJson.length).toBeGreaterThan(0);
+      for (const entry of matrixJson) {
+        expect(entry.os).toBe('ubuntu-latest');
+      }
+      expect(
+        matrixJson.some((e: { os: string }) => e.os === 'macos-latest'),
+      ).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not emit any macOS matrix rows for full-run pull_request events', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'affected-shards-no-macos-'));
+    try {
+      const files = join(dir, 'files.txt');
+      const output = join(dir, 'output.txt');
+      // package.json is a shared input, triggering a full-run that selects all
+      // shards. Even the full-run path is ubuntu-only (issue #2876).
+      writeFileSync(files, 'package.json');
+      const run = spawnSync(
+        process.execPath,
+        [
+          SELECTOR_PATH,
+          '--event',
+          PR_EVENT,
+          '--files-from',
+          files,
+          '--output',
+          'github-actions',
+        ],
+        { env: { ...process.env, GITHUB_OUTPUT: output } },
+      );
+      expect(run.stderr?.toString() ?? '').toBe('');
+      expect(run.status).toBe(0);
+      const records = readFileSync(output, 'utf8').split('\n');
+      const matrixRecord = records.find((line) => line.startsWith('matrix='));
+      expect(matrixRecord).toBeDefined();
+      const matrixJson = JSON.parse(
+        matrixRecord!.substring('matrix='.length),
+      ) as ReadonlyArray<{ readonly os: string }>;
+      // Full-run selects all shards, but all on ubuntu-latest.
+      expect(matrixJson.length).toBe(ALL_SHARDS.length);
+      for (const entry of matrixJson) {
+        expect(entry.os).toBe('ubuntu-latest');
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/tests/ci-secure-store-workflow.test.ts
+++ b/scripts/tests/ci-secure-store-workflow.test.ts
@@ -168,15 +168,16 @@ describe('Issue #2147: SecureStore backend coverage is separated from full CI su
     expect(secureStoreJob?.['timeout-minutes']).toBe(15);
   });
 
-  it('keyring rows select the native-keyring vitest config on both Ubuntu and macOS', () => {
+  it('keyring rows select the native-keyring vitest config on Ubuntu only (issue #2876)', () => {
+    // Issue #2876: macOS keyring coverage moved to the nightly workflow.
+    // The PR secure_store_backend matrix is ubuntu-only.
     const includes = matrixInclude(secureStoreJob);
 
     const keyringRows = includes.filter(
       (row: MatrixRow) => row['secure-store-mode'] === 'keyring',
     );
-    expect(keyringRows.length).toBe(2);
+    expect(keyringRows.length).toBe(1);
     expect(keyringRows.map((r: MatrixRow) => r.os).sort()).toEqual([
-      'macos-latest',
       'ubuntu-latest',
     ]);
 

--- a/scripts/tests/release-process-b.test.ts
+++ b/scripts/tests/release-process-b.test.ts
@@ -558,6 +558,8 @@ describe('.github/workflows/nightly.yml', () => {
   it('makes the failure notification job depend on all nightly test jobs', () => {
     const expectedNeeds = [
       'windows_ci',
+      'macos_ci',
+      'macos_secure_store',
       'e2e_full',
       'behavioral_evals',
       'windows_bun_native_smoke',

--- a/scripts/tests/runner-image-consistency.test.ts
+++ b/scripts/tests/runner-image-consistency.test.ts
@@ -68,12 +68,20 @@ function collectRunnerImages() {
 
   const recordShardSelectorImages = (file: string): void => {
     const selector = fs.readFileSync(SHARD_SELECTOR, 'utf8');
-    const osLoop = selector.match(/for \(const os of \[([^\]]+)\]\)/);
-    if (!osLoop) {
-      throw new Error('affected-test-shards.ts must define its runner OS rows');
-    }
-    for (const match of osLoop[1].matchAll(/'([^']+)'/g)) {
+    // The selector emits runner images via its matrix builder (issue #2876
+    // changed from a for-of OS loop to direct ubuntu-only entries). Scan for
+    // all literal runner-image strings so every image the selector can
+    // produce is recorded.
+    const runnerImageRe = /'((?:ubuntu|macos|windows)-latest)'/g;
+    let found = false;
+    for (const match of selector.matchAll(runnerImageRe)) {
       record(match[1], file);
+      found = true;
+    }
+    if (!found) {
+      throw new Error(
+        'affected-test-shards.ts must define at least one runner OS image',
+      );
     }
   };
 


### PR DESCRIPTION
## Summary

Moves macOS test legs out of PR CI (ci.yml) into the nightly workflow (nightly.yml), making macOS nightly-only like Windows already is. This addresses the macOS runner contention that dominates the PR critical path.

## Problem

From the issue:

- macOS shards queue instead of running in parallel, with queue gaps climbing from +2.2m (rest) to +6m (cli) to +8.3m (providers).
- The macOS legs are roughly 2x slower than ubuntu for the same shard (macOS cli = 13.1m vs ubuntu cli = 7.6m). This is structural: macOS runners are 3-vCPU and the workflow caps vitest to a single fork to avoid RPC timeouts.
- A PR fires up to 5 macOS test shards plus 1 macOS SecureStore job = 6 macOS jobs competing for scarce macOS runners.

## Changes

### scripts/affected-test-shards.ts
- `outputGithubActions` now emits an **ubuntu-only** matrix (one entry per selected shard on `ubuntu-latest`). The per-OS loop over ubuntu+macOS is replaced with a single ubuntu push. macOS is removed from the PR test matrix for ALL events (pull_request, push, merge_group, workflow_dispatch).

### .github/workflows/ci.yml
- Removed the macOS keyring leg from `secure_store_backend` (ubuntu keyring + fallback remain). The PR SecureStore matrix is now ubuntu-only.
- Updated comments on `test_shard` and `secure_store_backend` to reflect the ubuntu-only matrix and the move of macOS coverage to nightly.

### .github/workflows/nightly.yml
- Added **macos_ci** job: full unsharded workspace test suite (`npm run test`) + script harness tests + shell-script behavioral tests + CLI smoke entry. Mirrors the existing `windows_ci` job but runs on macOS with the macOS single-fork vitest cap. Installs the platform-specific `@rollup/rollup-darwin-*` package (matching the windows_ci rollup fixup pattern).
- Added **macos_secure_store** job: runs the `vitest.config.native-keyring.ts` config on macOS, covering the macOS native keychain integration that was previously in the PR `secure_store_backend` matrix.
- Both jobs wired into `notify_failure` so macOS regressions surface as a nightly failure issue.

### Test updates
- `scripts/tests/affected-test-shards.test.ts`: Added 2 new tests verifying the matrix is ubuntu-only for both scoped and full-run PR selections. Includes temp directory cleanup and stderr assertions.
- `scripts/tests/ci-secure-store-workflow.test.ts`: Updated keyring row count from 2 to 1 (ubuntu-only).
- `scripts/tests/runner-image-consistency.test.ts`: Updated `recordShardSelectorImages` to scan for literal runner-image strings (the old regex targeted the removed for-of OS loop).
- `scripts/tests/release-process-b.test.ts`: Updated `notify_failure` expected needs to include the new macOS jobs.

## Acceptance criteria

- [x] The PR Test matrix is ubuntu-only; no macOS test shards run on pull_request events.
- [x] macOS test coverage runs in the nightly workflow alongside Windows.
- [x] macOS runner-minute spend on PR CI drops to near zero.
- [x] PR CI wall-clock median and p90 both drop (the macOS lane is currently the longest).

## Tradeoffs

- PRs lose per-commit macOS signal; macOS regressions surface in the nightly instead. Given the macOS legs' low fail-fast value relative to their latency and runner cost (macOS bills at ~10x ubuntu), this is an intentional latency-for-cadence trade.
- ubuntu remains the PR gate; macOS becomes nightly-only (like Windows already is).

Fixes #2876
