### PR TITLE
Harness diagnosability polish: surface corrupt-state errors and document diagnostic contract (Fixes #2698)

### DIFF
--- a/project-plans/issue-2698-harness-diagnosability-polish.md
+++ b/project-plans/issue-2698-harness-diagnosability-polish.md
@@ -1,0 +1,83 @@
+# Issue #2698: Follow-ups from #2688 — harness diagnosability polish
+
+Follow-up to #2688 / PR #2690. Three diagnosability items carried over from
+OCR review that were valid but out of scope for the CI-platform fix.
+
+## Acceptance Matrix
+
+| # | Behavior | Evidence |
+|---|----------|----------|
+| A1 | A corrupt/partially-written state file surfaces its parse error (appended to returned stderr) instead of being silently swallowed | Test: `readFakeState` on a corrupt file returns non-empty `parseError` + empty default state |
+| A2 | A missing state file still yields a usable empty default WITHOUT a parse-error diagnostic | Test: `readFakeState` on a nonexistent path returns empty default + empty `parseError` |
+| A3 | `runRecordHistory` threads the surfaced parse error into the returned `stderr` | Code: `runRecordHistory` delegates state read to `readFakeState` and appends `parseError` to `result.stderr` |
+| A4 | Env stubbing in diagnostics tests is consistent (no manual `process.env` manipulation mixed with `vi.stubEnv`) | Test: both CI-presence and CI-absence tests use `vi.stubEnv` + `vi.unstubAllEnvs()` |
+| A5 | The script→harness message coupling is documented as an intentional contract | New `assign-script-contract.ts` with header comment + named marker constants used by the diagnostics assertions |
+| A6 | All existing harness/diagnostics tests still pass | `npm run test:scripts` green; existing `runRecordHistory` callers unaffected (parseError empty in normal flows) |
+| A7 | Full verification suite green | test / lint / typecheck / format / build + smoke all pass |
+
+## Non-Goals
+
+- Changing `createFakeRepo().readState()` behavior (it already surfaces errors by throwing — out of scope).
+- Restoring the old `execFileSync` catch shape in `runAutomationScript` (the issue's "Explicitly not included" section confirms throwing is strictly better).
+- Modifying the bash scripts themselves (their messages are the source of truth; only the TS harness side changes).
+- Modifying `fake-gh.py` (no new corruption trigger added; item 1 is tested via the extracted `readFakeState` helper).
+- Changing CI workflow structure.
+
+## Decisions
+
+- **D1 — `vi.unstubEnv` (singular) does not exist in vitest 3.2.x.** The issue
+  suggested standardizing on `vi.stubEnv` / `vi.unstubEnv`, but only
+  `vi.stubEnv(name, value)` and `vi.unstubAllEnvs()` exist. Verified in
+  `node_modules/vitest/dist/chunks/vi.bdSIJ99Y.js`: `stubEnv` with `undefined`
+  deletes the var, and `unstubAllEnvs` restores all stubbed vars. Since CI is
+  the only env var stubbed in these tests, `unstubAllEnvs()` is effectively
+  targeted here. Item 2 is implemented by replacing manual
+  `delete process.env['CI']` + manual restore with `vi.stubEnv('CI', undefined)`
+  + `vi.unstubAllEnvs()`, making both tests consistent.
+
+- **D2 — Extract `readFakeState` for testability (item 1).** The
+  corrupt-state path cannot be driven end-to-end through `runRecordHistory`
+  because fake-gh always writes valid JSON via `json.dump`, and
+  `runRecordHistory` pre-writes valid initial state. The parse-error-surfacing
+  logic is extracted into a small exported helper `readFakeState(stateFile)`
+  so it can be exercised directly with a real corrupt file. This is a bounded
+  test-infra addition to a module (`assign-helpers.ts`) that already exports
+  ~15 helpers — not a new subsystem or production public abstraction.
+
+- **D3 — Dedicated contract file for item 3.** The bash scripts cannot import
+  TS, so the "(where practical)" qualifier in the issue applies. A dedicated
+  `scripts/tests/assign-script-contract.ts` documents the intentional coupling
+  in a header comment and exports named marker constants used by the
+  diagnostics assertions. This is the more robust of the two options the issue
+  offered (comment vs shared constant).
+
+## Bounded Vertical Slices
+
+### Slice 1: Item 1 — corrupt vs absent state
+- Extract `readFakeState(stateFile)` + `EMPTY_FAKE_STATE` constant in `assign-helpers.ts`.
+- `runRecordHistory` delegates to it and appends `parseError` to returned stderr.
+- Tests: corrupt file → non-empty parseError; missing file → empty parseError.
+
+### Slice 2: Item 2 — consistent env stubbing
+- Replace manual `process.env['CI']` manipulation in the "stays quiet outside CI" test with `vi.stubEnv('CI', undefined)` + `vi.unstubAllEnvs()`.
+
+### Slice 3: Item 3 — document message coupling
+- New `assign-script-contract.ts` with documented marker constants.
+- Diagnostics test imports and uses the constants in its assertions.
+
+## Expected Paths (files to change)
+
+1. `scripts/tests/assign-helpers.ts` — extract `readFakeState`, use in `runRecordHistory`.
+2. `scripts/tests/assign-script-contract.ts` — NEW: documented marker constants.
+3. `scripts/tests/assign-harness-diagnostics.test.ts` — item 2 standardization, item 3 constants, item 1 tests.
+
+## Scope Ledger
+
+| File | Change | Lines (est.) |
+|------|--------|-------------|
+| scripts/tests/assign-helpers.ts | extract readFakeState + EMPTY_FAKE_STATE, use in runRecordHistory | +35 / -18 |
+| scripts/tests/assign-script-contract.ts | NEW documented markers | +55 |
+| scripts/tests/assign-harness-diagnostics.test.ts | item 2 + item 3 + item 1 tests | +45 / -15 |
+| **Total** | **3 files** | **~100 net** |
+
+Well within the 25-file / 1,500-line budget; no mandatory scope review triggered.

--- a/scripts/tests/assign-harness-diagnostics.test.ts
+++ b/scripts/tests/assign-harness-diagnostics.test.ts
@@ -25,13 +25,23 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
 import {
   createFakeRepo,
   defaultState,
   makeIssue,
   makeAssignedEvent,
   daysAgo,
+  EMPTY_FAKE_STATE,
+  readFakeState,
 } from './assign-helpers.ts';
+import {
+  CANDIDATE_DISCOVERY_FAILED,
+  READ_ISSUE_STATE_PREFIX,
+  RETRY_FAILED_SUFFIX,
+} from './assign-script-contract.ts';
 
 /**
  * A repo with one issue that is unambiguously stale, so cleanup has real work
@@ -71,7 +81,8 @@ describe('assign harness diagnosability (#2688)', () => {
     expect(result.status).not.toBe(0);
     // ...and it must say WHY, not merely that it happened. Without this the
     // only signal is a downstream "expected 1 to be +0" state assertion.
-    expect(result.stderr).toMatch(/Candidate discovery failed/i);
+    // The pinned marker is the script→harness contract (assign-script-contract.ts).
+    expect(result.stderr).toMatch(new RegExp(CANDIDATE_DISCOVERY_FAILED, 'i'));
   });
 
   it('reports the retry trail leading up to a cleanup failure', () => {
@@ -86,7 +97,9 @@ describe('assign harness diagnosability (#2688)', () => {
     const result = repo.runCleanup();
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toMatch(/Attempt \d+ failed, retrying/i);
+    expect(result.stderr).toMatch(
+      new RegExp(`Attempt \\d+ ${RETRY_FAILED_SUFFIX}`, 'i'),
+    );
     // The failing endpoint must be identifiable from the output alone.
     expect(result.stderr).toContain('issues/42/timeline');
   });
@@ -113,7 +126,9 @@ describe('assign harness diagnosability (#2688)', () => {
     const result = repo.runCleanup();
 
     expect(result.status).toBe(0);
-    expect(result.stderr).toMatch(/Attempt \d+ failed, retrying/i);
+    expect(result.stderr).toMatch(
+      new RegExp(`Attempt \\d+ ${RETRY_FAILED_SUFFIX}`, 'i'),
+    );
   });
 
   it('echoes script stderr to the console under CI so job logs are self-diagnosing', () => {
@@ -140,7 +155,7 @@ describe('assign harness diagnosability (#2688)', () => {
       errorSpy.mockRestore();
     }
 
-    expect(printed).toMatch(/Candidate discovery failed/i);
+    expect(printed).toMatch(new RegExp(CANDIDATE_DISCOVERY_FAILED, 'i'));
     // The failing script must be identifiable, not just the message.
     expect(printed).toContain('unassign-stale-issues.sh');
   });
@@ -153,17 +168,19 @@ describe('assign harness diagnosability (#2688)', () => {
     });
 
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const originalCi = process.env['CI'];
-    delete process.env['CI'];
+    // Stubbing to undefined removes the var (vitest deletes it), matching the
+    // "no CI" environment. Cleanup uses vi.unstubAllEnvs() for parity with the
+    // CI-presence test above — the only stubbed var here is CI, so the restore
+    // is effectively targeted. (vi.unstubEnv, a per-key reset, does not exist
+    // in vitest 3.2.x; unstubAllEnvs is the available restore.)
+    vi.stubEnv('CI', undefined);
     let callCount;
     try {
       repo.runCleanup();
       // Captured before mockRestore() resets the recorded calls.
       callCount = errorSpy.mock.calls.length;
     } finally {
-      if (originalCi !== undefined) {
-        process.env['CI'] = originalCi;
-      }
+      vi.unstubAllEnvs();
       errorSpy.mockRestore();
     }
 
@@ -189,6 +206,54 @@ describe('assign harness diagnosability (#2688)', () => {
     // emit some non-empty text. A length check would pass on unrelated noise
     // or a bare stack trace, which is the very ambiguity this issue is about.
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toMatch(/Failed to read issue state for #7/i);
+    expect(result.stderr).toMatch(
+      new RegExp(`${READ_ISSUE_STATE_PREFIX}7`, 'i'),
+    );
+  });
+});
+
+describe('state-file diagnosability (#2698)', () => {
+  // The fake-gh state file is read back after every script run so tests can
+  // assert on resulting state. Previously a corrupt/partially-written file
+  // was silently swapped for an empty default, turning a parse failure into a
+  // confusing "expected 1 but got 0" — the same hidden-diagnostic class that
+  // made #2688 expensive to trace. runRecordHistory delegates state reading
+  // to readFakeState and threads any parseError into its returned stderr, so
+  // these tests on the helper prove the surfaced-diagnostic contract.
+
+  it('surfaces the parse error when the state file is corrupt', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'corrupt-state-'));
+    try {
+      const corruptFile = path.join(dir, 'state.json');
+      // Partially-written / truncated JSON, as a real crash mid-write could
+      // leave behind.
+      writeFileSync(corruptFile, '{ "issues": { "42": { partially');
+
+      const { state, parseError } = readFakeState(corruptFile);
+
+      // The corrupt file must NOT silently look like a clean empty run.
+      expect(parseError).toMatch(/unparseable/i);
+      // ...and it must still hand back a usable empty default so callers do
+      // not throw on the state itself.
+      expect(state).toEqual(EMPTY_FAKE_STATE);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns an empty default with no error when no state file exists', () => {
+    // A script that aborts before writing any state is a legitimate empty
+    // result, not corruption. It must not produce a noisy diagnostic.
+    const dir = mkdtempSync(path.join(tmpdir(), 'no-state-'));
+    try {
+      const missing = path.join(dir, 'absent.json');
+
+      const { state, parseError } = readFakeState(missing);
+
+      expect(parseError).toBe('');
+      expect(state).toEqual(EMPTY_FAKE_STATE);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/tests/assign-helpers.ts
+++ b/scripts/tests/assign-helpers.ts
@@ -296,6 +296,60 @@ export function createFakeRepo(
   };
 }
 
+/**
+ * Empty-but-typed fake state. Returned when a script run leaves no usable
+ * state (it aborted before writing, or the written file was unparseable).
+ */
+export const EMPTY_FAKE_STATE: FakeState = {
+  issues: {},
+  prs: {},
+  comments: [],
+  labels: {},
+  events: {},
+  timeline: {},
+  fail_config: {},
+};
+
+/**
+ * Read and parse the fake-gh state file, distinguishing a legitimately absent
+ * file from a corrupt one (#2698 item 1).
+ *
+ * A missing file (ENOENT) means the script aborted before writing any state —
+ * return a usable empty default with no error. A file that EXISTS but cannot
+ * be parsed indicates corruption; surfacing the parse error (via `parseError`)
+ * prevents a confusing downstream "expected 1 but got 0" state assertion,
+ * which is the same hidden-diagnostic class that made #2688 costly to trace.
+ */
+export function readFakeState(stateFile: string): {
+  state: FakeState;
+  parseError: string;
+} {
+  try {
+    return {
+      state: JSON.parse(readFileSync(stateFile, 'utf8')),
+      parseError: '',
+    };
+  } catch (err) {
+    const isMissing =
+      err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT';
+    if (isMissing) {
+      return { state: EMPTY_FAKE_STATE, parseError: '' };
+    }
+    // A filesystem error (EACCES, EISDIR, …) is distinct from a JSON parse
+    // error (SyntaxError has no `code`); label each accurately so the
+    // diagnostic points at the right root cause.
+    const isFsError =
+      err instanceof Error &&
+      typeof (err as NodeJS.ErrnoException).code === 'string';
+    const label = isFsError ? 'unreadable' : 'unparseable';
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      state: EMPTY_FAKE_STATE,
+      parseError: `[assign-helpers] State file was ${label}: ${message}`,
+    };
+  }
+}
+
 export function runRecordHistory({
   state,
   assigneeLogin,
@@ -343,21 +397,15 @@ exec python3 "${FAKE_GH}" "$@"
       '.github/scripts/record-assignment-history.sh',
       env,
     );
-    let finalState: FakeState;
-    try {
-      finalState = JSON.parse(readFileSync(stateFile, 'utf8'));
-    } catch {
-      finalState = {
-        issues: {},
-        labels: {},
-        comments: [],
-        prs: {},
-        events: {},
-        timeline: {},
-        fail_config: {},
-      };
-    }
-    return { ...result, state: finalState };
+    const { state: finalState, parseError } = readFakeState(stateFile);
+    return {
+      ...result,
+      stderr: parseError
+        ? `${result.stderr}
+${parseError}`
+        : result.stderr,
+      state: finalState,
+    };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/tests/assign-script-contract.ts
+++ b/scripts/tests/assign-script-contract.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Diagnostic-message contract between the assign automation bash scripts and
+ * the harness diagnosability tests.
+ *
+ * WHY THIS FILE EXISTS (#2688 / #2698 item 3):
+ * The bash scripts (.github/scripts/assign-issue.sh and
+ * unassign-stale-issues.sh) print human-readable root-cause diagnostics to
+ * stderr. The whole point of #2688 was that those messages were being
+ * discarded by the harness, turning every environment-specific breakage into
+ * a log-archaeology exercise. The diagnosability tests in
+ * assign-harness-diagnostics.test.ts now PIN these exact messages: that
+ * pinning IS the contract — it guarantees a failure explains itself rather
+ * than producing only a bare "expected 1 to be +0" assertion.
+ *
+ * This coupling is INTENTIONAL, not incidental. The strings below mirror the
+ * `echo … >&2` / `printf … >&2` statements in the scripts. If a script
+ * message changes, the corresponding assertion breaks — by design — so the
+ * regression is caught instead of silently losing diagnostics again.
+ *
+ * The bash scripts cannot import this TypeScript module (and that is fine);
+ * these constants are the single named source of truth for what the harness
+ * expects. Each constant records the script and approximate line that emits
+ * it, so both sides can be kept in sync.
+ *
+ * REGEX INVARIANT: these constants are used as `new RegExp(CONST, 'i')`
+ * patterns by the diagnostics tests. Their values MUST NOT contain regex
+ * metacharacters (`.`, `(`, `+`, `*`, `[`, …) — they are literal substrings
+ * of the scripts' stderr output. Dynamic parts (attempt ordinal, issue
+ * number) are intentionally kept OUT of the constants and supplied by the
+ * tests; if a constant ever needs a literal metacharacter, escape it at the
+ * consumer site instead.
+ */
+
+/**
+ * Emitted by unassign-stale-issues.sh `discover_candidates` (~line 239) and
+ * the top-level discovery fallback (~line 771) when the candidate issue
+ * search fails. Exact literal — no dynamic part.
+ */
+export const CANDIDATE_DISCOVERY_FAILED = 'Candidate discovery failed';
+
+/**
+ * Static anchor emitted by unassign-stale-issues.sh retry helpers `retry_gh`
+ * (~line 56) and `retry_gh_capture` (~line 106) on each failed attempt. The
+ * full message is `Attempt ${attempt} failed, retrying: …` where
+ * `${attempt}` is the 1-based ordinal. The harness pins the static text that
+ * surrounds the dynamic ordinal.
+ */
+export const RETRY_FAILED_SUFFIX = 'failed, retrying';
+
+/**
+ * Static prefix emitted by assign-issue.sh (~line 771) when the initial
+ * issue-state read fails. The full message is
+ * `Failed to read issue state for #${ISSUE}` where `${ISSUE}` is the issue
+ * number. The harness pins the static text that precedes the dynamic number.
+ */
+export const READ_ISSUE_STATE_PREFIX = 'Failed to read issue state for #';


### PR DESCRIPTION
Closes #2698.

## Summary

Follow-up to #2688 / PR #2690. Three diagnosability items carried over from OCR review that were valid but deliberately out of scope for the CI-platform fix. Each was evaluated against the source (not accepted at face value), and the "Explicitly not included" non-goal is respected.

## Item 1 — Corrupt state is indistinguishable from absent state

`runRecordHistory` caught a `JSON.parse` failure and substituted an empty state object for **both** a legitimately missing file (script aborted before writing) **and** a corrupt/unparseable file. The latter swallowed the parse error, so a test asserting on state contents failed with "expected 1 but got 0" instead of surfacing the parse error — the same hidden-diagnostic class that made #2688 expensive to trace.

**Fix:** Extracted `readFakeState(stateFile)` which returns `{ state, parseError }`. It distinguishes:
- **ENOENT** (no file) → empty default, no diagnostic (legitimate empty run).
- **Filesystem error** (EACCES/EISDIR/…) → `[assign-helpers] State file was unreadable: …`.
- **Parse error** (SyntaxError) → `[assign-helpers] State file was unparseable: …`.

`runRecordHistory` now delegates to it and appends `parseError` to the returned `stderr`, so a corrupt state file reports itself through the same channel as script diagnostics.

## Item 2 — Inconsistent environment stubbing

The diagnostics tests mixed `vi.stubEnv`/`vi.unstubAllEnvs()` with manual `process.env[CI]` deletion + restore. Standardized the "stays quiet outside CI" test onto `vi.stubEnv(CI, undefined)` (vitest deletes the var) + `vi.unstubAllEnvs()`.

**Note:** The issue suggested `vi.unstubEnv` (per-key reset), but that function does **not exist** in vitest 3.2.x (verified against `node_modules/vitest` — only `stubEnv` + `unstubAllEnvs` exist). `vi.stubEnv(name, undefined)` deletes the property, and since CI is the only stubbed var in these tests, `unstubAllEnvs()` is effectively targeted.

## Item 3 — Document the script-message coupling

The diagnosability tests assert on exact bash-script stderr strings ("Candidate discovery failed", "Attempt N failed, retrying", "Failed to read issue state for #N"). This coupling is **intentional** — it is the contract that makes failures self-diagnosing, which was the whole point of #2688. Added `assign-script-contract.ts` with:
- A header comment documenting that the coupling is intentional and why.
- Named marker constants (`CANDIDATE_DISCOVERY_FAILED`, `RETRY_FAILED_SUFFIX`, `READ_ISSUE_STATE_PREFIX`) with script + line provenance, now used by the assertions.

The bash scripts cannot import TS (and that is fine); the constants are the single named source of truth for what the harness expects.

## Explicitly not included

`runAutomationScript` throwing on `spawnSync` startup failure — unchanged. Throwing is strictly better diagnostics than the old `execFileSync` catch (which returned `{"stdout":"","stderr":"","status":1}` for an ENOENT spawn, making an environment fault indistinguishable from a script that ran and failed).

## Verification

- `assign-harness-diagnostics.test.ts`: 8/8 pass (6 original + 2 new corrupt/missing-state tests).
- `runRecordHistory` callers (`assign-remediation4/5/8`): 58/58 pass — `parseError` is provably empty in every normal flow (fake-gh always writes valid JSON via atomic `json.dump` + `os.replace`).
- `tsc --project tsconfig.scripts.json`, ESLint, ESLint policy guard, and Prettier all pass.

## Review

- TypeScript review (glm) + Open Code Review (ocr, --timeout 20) both completed. Two OCR findings remediated: (1) `readFakeState` now labels filesystem errors ("unreadable") distinctly from parse errors ("unparseable") instead of conflating them; (2) the contract file documents a regex invariant that constant values must not contain regex metacharacters.
- DeepThinker/architect subagents were unavailable (gpt56solhigh usage limit reached; opusthinking has no Anthropic key on this host).