### PR TITLE
Prevent reasoning-field provider drift with shared resolution and entry-point coverage (Fixes #2524)

### DIFF
--- a/packages/providers/src/openai-vercel/__tests__/vercelReasoningCapture.fieldName.test.ts
+++ b/packages/providers/src/openai-vercel/__tests__/vercelReasoningCapture.fieldName.test.ts
@@ -133,4 +133,55 @@ describe('parseReasoningFromSseStream — configurable field name (#2488)', () =
 
     expect(captureBuffer.reasoningChunks).toStrictEqual([]);
   });
+
+  it('falls back to delta.reasoning when reasoning_content is an empty string (unified policy, #2524)', async () => {
+    const captureBuffer = createCaptureBuffer();
+    const sseData = [
+      'data: {"choices":[{"delta":{"reasoning_content":"","reasoning":"fallback reasoning"}}]}',
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.reasoningChunks).toStrictEqual(['fallback reasoning']);
+    expect(captureBuffer.actualFieldName).toBe('reasoning');
+  });
+
+  it('falls back to delta.reasoning when reasoning_content is a non-string object (unified policy, #2524)', async () => {
+    const captureBuffer = createCaptureBuffer();
+    const sseData = [
+      'data: {"choices":[{"delta":{"reasoning_content":{"malformed":true},"reasoning":"fallback reasoning"}}]}',
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.reasoningChunks).toStrictEqual(['fallback reasoning']);
+    expect(captureBuffer.actualFieldName).toBe('reasoning');
+  });
+
+  it('treats empty-string field name as unset (uses default field, #2524)', async () => {
+    const captureBuffer = createCaptureBuffer('');
+    const sseData = [
+      'data: {"choices":[{"delta":{"reasoning_content":"standard reasoning"}}]}',
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.reasoningChunks).toStrictEqual(['standard reasoning']);
+    expect(captureBuffer.actualFieldName).toBe('reasoning_content');
+  });
 });

--- a/packages/providers/src/openai-vercel/__tests__/vercelReasoningCapture.fieldName.test.ts
+++ b/packages/providers/src/openai-vercel/__tests__/vercelReasoningCapture.fieldName.test.ts
@@ -184,4 +184,27 @@ describe('parseReasoningFromSseStream — configurable field name (#2488)', () =
     expect(captureBuffer.reasoningChunks).toStrictEqual(['standard reasoning']);
     expect(captureBuffer.actualFieldName).toBe('reasoning_content');
   });
+
+  it('preserves whitespace-only reasoning_content as usable (no fallback, #721/#2524)', async () => {
+    const whitespace = '  \n\t  ';
+    const captureBuffer = createCaptureBuffer();
+    const sseData = [
+      'data: ' +
+        JSON.stringify({
+          choices: [
+            { delta: { reasoning_content: whitespace, reasoning: 'fallback' } },
+          ],
+        }),
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.reasoningChunks).toStrictEqual([whitespace]);
+    expect(captureBuffer.actualFieldName).toBe('reasoning_content');
+  });
 });

--- a/packages/providers/src/openai-vercel/vercelReasoningCapture.ts
+++ b/packages/providers/src/openai-vercel/vercelReasoningCapture.ts
@@ -15,6 +15,7 @@
  */
 
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { resolveReasoningField } from '../utils/reasoningField.js';
 
 /**
  * Buffer that accumulates reasoning chunks captured from the
@@ -67,26 +68,16 @@ function captureReasoningFromJson(
   const delta = parsed.choices[0]?.delta;
   if (delta === undefined) return;
 
-  const fieldName = captureBuffer.fieldName ?? 'reasoning_content';
-  let actualFieldName = fieldName;
-  let reasoningContent: unknown = delta[fieldName];
-
-  // Auto-fallback: when fieldName was not explicitly set (undefined), also
-  // check 'reasoning' for Ollama compatibility (issue #2488)
-  if (
-    (reasoningContent === undefined || reasoningContent === null) &&
-    captureBuffer.fieldName === undefined
-  ) {
-    reasoningContent = delta['reasoning'];
-    actualFieldName = 'reasoning';
-  }
-
-  if (typeof reasoningContent === 'string' && reasoningContent !== '') {
-    captureBuffer.reasoningChunks.push(reasoningContent);
-    captureBuffer.actualFieldName = actualFieldName;
+  const resolved = resolveReasoningField({
+    fieldName: captureBuffer.fieldName,
+    delta,
+  });
+  if (resolved !== undefined) {
+    captureBuffer.reasoningChunks.push(resolved.value);
+    captureBuffer.actualFieldName = resolved.actualFieldName;
     logger.debug(
       () =>
-        `[ReasoningCaptureFetch] Captured ${actualFieldName} chunk: ${reasoningContent.length} chars`,
+        `[ReasoningCaptureFetch] Captured ${resolved.actualFieldName} chunk: ${resolved.value.length} chars`,
     );
   }
 }

--- a/packages/providers/src/openai/OpenAIProvider.ts
+++ b/packages/providers/src/openai/OpenAIProvider.ts
@@ -67,6 +67,29 @@ import {
   mergeInvocationHeaders,
 } from './OpenAIClientFactory.js';
 
+/**
+ * Typed options object for {@link OpenAIProvider.dispatchResponse}.
+ *
+ * @issue #2524 — Replaces the 12-positional-parameter list for clarity and
+ *   safety.
+ */
+export interface DispatchResponseOptions {
+  response:
+    | AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>
+    | OpenAI.Chat.Completions.ChatCompletion;
+  model: string;
+  detectedFormat: string;
+  streamingEnabled: boolean;
+  abortSignal: AbortSignal | undefined;
+  requestBody: OpenAI.Chat.ChatCompletionCreateParams;
+  messagesWithSystem: OpenAI.Chat.Completions.ChatCompletionMessageParam[];
+  client: OpenAI;
+  mergedHeaders: Record<string, string> | undefined;
+  baseURL: string | undefined;
+  logger: DebugLogger;
+  reasoningFieldName: string | undefined;
+}
+
 export class OpenAIProvider extends BaseProvider implements IProvider {
   private readonly textToolParser = new GemmaToolCallParser();
   private readonly toolCallPipeline = new ToolCallPipeline();
@@ -574,20 +597,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
   }
 
   private async *dispatchResponse(
-    response:
-      | AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>
-      | OpenAI.Chat.Completions.ChatCompletion,
-    model: string,
-    detectedFormat: string,
-    streamingEnabled: boolean,
-    abortSignal: AbortSignal | undefined,
-    requestBody: OpenAI.Chat.ChatCompletionCreateParams,
-    messagesWithSystem: OpenAI.Chat.Completions.ChatCompletionMessageParam[],
-    client: OpenAI,
-    mergedHeaders: Record<string, string> | undefined,
-    baseURL: string | undefined,
-    logger: DebugLogger,
-    reasoningFieldName: string | undefined,
+    options: DispatchResponseOptions,
   ): AsyncGenerator<IContent, void, unknown> {
     const { processStreamingResponse } = await import(
       './OpenAIStreamProcessor.js'
@@ -595,24 +605,24 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
     const { handleNonStreamingResponse } = await import(
       './OpenAINonStreamHandler.js'
     );
-    if (streamingEnabled) {
+    if (options.streamingEnabled) {
       const deps = {
         toolCallPipeline: this.toolCallPipeline,
         textToolParser: this.textToolParser,
-        logger,
+        logger: options.logger,
         getBaseURL: () => this.getBaseURL(),
-        reasoningFieldName,
+        reasoningFieldName: options.reasoningFieldName,
       };
       yield* processStreamingResponse(
-        response as AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>,
-        model,
-        detectedFormat,
-        abortSignal,
-        requestBody,
-        messagesWithSystem,
-        client,
-        mergedHeaders,
-        baseURL,
+        options.response as AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>,
+        options.model,
+        options.detectedFormat,
+        options.abortSignal,
+        options.requestBody,
+        options.messagesWithSystem,
+        options.client,
+        options.mergedHeaders,
+        options.baseURL,
         deps,
         this.requestContinuationAfterToolCalls.bind(this),
       );
@@ -620,12 +630,12 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       const deps = {
         toolCallPipeline: this.toolCallPipeline,
         textToolParser: this.textToolParser,
-        logger,
+        logger: options.logger,
       };
       yield* handleNonStreamingResponse(
-        response as OpenAI.Chat.Completions.ChatCompletion,
-        model,
-        detectedFormat,
+        options.response as OpenAI.Chat.Completions.ChatCompletion,
+        options.model,
+        options.detectedFormat,
         deps,
       );
     }
@@ -803,7 +813,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       | string
       | undefined;
 
-    yield* this.dispatchResponse(
+    yield* this.dispatchResponse({
       response,
       model,
       detectedFormat,
@@ -816,7 +826,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       baseURL,
       logger,
       reasoningFieldName,
-    );
+    });
   }
 
   /**

--- a/packages/providers/src/openai/OpenAIProvider.ts
+++ b/packages/providers/src/openai/OpenAIProvider.ts
@@ -73,7 +73,7 @@ import {
  * @issue #2524 — Replaces the 12-positional-parameter list for clarity and
  *   safety.
  */
-export interface DispatchResponseOptions {
+interface DispatchResponseOptions {
   response:
     | AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>
     | OpenAI.Chat.Completions.ChatCompletion;

--- a/packages/providers/src/openai/OpenAIResponseParser.ts
+++ b/packages/providers/src/openai/OpenAIResponseParser.ts
@@ -21,6 +21,7 @@ import type {
   ThinkingBlock,
 } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { sanitizeProviderText } from '../utils/textSanitizer.js';
+import { resolveReasoningField } from '../utils/reasoningField.js';
 import { normalizeToolName } from '../utils/toolNameNormalization.js';
 import { normalizeToHistoryToolId } from '@vybestack/llxprt-code-tools/toolIdNormalization.js';
 import { processToolParameters } from '@vybestack/llxprt-code-tools/doubleEscapeUtils.js';
@@ -36,55 +37,14 @@ type DeltaWithReasoning =
     reasoning?: unknown;
   };
 
-/**
- * Selects the reasoning value and provenance field name. Returns undefined
- * when no usable reasoning is available. When fieldName is unset (undefined)
- * and the primary value is not a usable non-empty string, falls back to the
- * Ollama delta.reasoning field (issue #2488 / #2505).
- */
-function resolveReasoningValue(
-  primaryValue: unknown,
-  explicitField: string,
-  ollamaReasoning: unknown,
-  fieldName: string | undefined,
-): { value: string; actualFieldName: string } | undefined {
-  if (hasUsableReasoning(primaryValue)) {
-    return { value: primaryValue, actualFieldName: explicitField };
-  }
-  if (fieldName === undefined && hasUsableReasoning(ollamaReasoning)) {
-    return { value: ollamaReasoning, actualFieldName: 'reasoning' };
-  }
-  return undefined;
-}
-
-function hasUsableReasoning(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0;
-}
-
 function readReasoningFromDelta(
   delta: DeltaWithReasoning,
   fieldName: string | undefined,
 ): { content: string; actualFieldName: string } | undefined {
-  // Treat empty/whitespace-only field names as unset so auto-fallback still
-  // applies (issue #2505: guards against reasoning.fieldName='' misconfig).
-  // Trim a non-empty field name before using it as a delta property key.
-  const trimmed = fieldName?.trim();
-  const normalizedFieldName =
-    trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined;
-  const deltaRecord = delta as Record<string, unknown>;
-  const explicitField = normalizedFieldName ?? 'reasoning_content';
-  const primaryValue =
-    normalizedFieldName === undefined
-      ? delta.reasoning_content
-      : deltaRecord[explicitField];
-
-  const resolved = resolveReasoningValue(
-    primaryValue,
-    explicitField,
-    delta.reasoning,
-    normalizedFieldName,
-  );
-
+  const resolved = resolveReasoningField({
+    fieldName,
+    delta: delta as Record<string, unknown>,
+  });
   if (resolved === undefined) {
     return undefined;
   }

--- a/packages/providers/src/openai/__tests__/OpenAIProvider.reasoningFieldEntry.test.ts
+++ b/packages/providers/src/openai/__tests__/OpenAIProvider.reasoningFieldEntry.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Provider-entry behavioral tests for issue #2524: prove the full real wiring
+ * from settings.get('reasoning.fieldName') through OpenAIProvider →
+ * dispatchResponse → StreamProcessorDeps.reasoningFieldName →
+ * parseStreamingReasoningDelta → terminal ThinkingBlock.sourceField.
+ *
+ * These tests exercise the real provider instance (no internal mocking of the
+ * stream processor), so they prove the actual end-to-end wiring.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OpenAIProvider } from '../OpenAIProvider.js';
+import type {
+  IContent,
+  ThinkingBlock,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { initializeTestProviderRuntime } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { resetSettingsService } from '@vybestack/llxprt-code-settings';
+import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import type OpenAI from 'openai';
+
+const mockChatCompletionsCreate = vi.fn();
+
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = {
+      completions: {
+        create: mockChatCompletionsCreate,
+      },
+    };
+  },
+}));
+
+function makeReasoningStreamChunk(
+  delta: Record<string, unknown>,
+  finishReason: string | null,
+): OpenAI.Chat.Completions.ChatCompletionChunk {
+  return {
+    id: 'chatcmpl-entry',
+    object: 'chat.completion.chunk',
+    created: Date.now(),
+    model: 'gpt-4o',
+    choices: [
+      {
+        index: 0,
+        delta,
+        finish_reason: finishReason,
+      },
+    ],
+  } as OpenAI.Chat.Completions.ChatCompletionChunk;
+}
+
+function makeStream(
+  chunks: OpenAI.Chat.Completions.ChatCompletionChunk[],
+): AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    },
+  };
+}
+
+function findThinkingBlock(results: IContent[]): ThinkingBlock | undefined {
+  for (const content of results) {
+    for (const block of content.blocks) {
+      if (block.type === 'thinking') {
+        return block;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function collectResults(
+  iterable: AsyncIterable<IContent>,
+): Promise<IContent[]> {
+  const results: IContent[] = [];
+  for await (const content of iterable) {
+    results.push(content);
+  }
+  return results;
+}
+
+describe('OpenAIProvider reasoning.fieldName entry wiring (#2524)', () => {
+  let provider: OpenAIProvider;
+  let settingsService: SettingsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChatCompletionsCreate.mockClear();
+    resetSettingsService();
+
+    const runtime = initializeTestProviderRuntime({
+      runtimeId: `openai-reasoning-entry-${Math.random().toString(36).slice(2, 10)}`,
+      metadata: { suite: 'OpenAIProvider.reasoningFieldEntry.test' },
+      configOverrides: {
+        getProvider: () => 'openai',
+        getModel: () => 'gpt-4o',
+        getEphemeralSettings: () => ({ model: 'gpt-4o' }),
+      },
+    });
+
+    settingsService = runtime.settingsService;
+    provider = new OpenAIProvider('test-api-key', 'https://api.openai.com/v1');
+    provider.setRuntimeSettingsService(settingsService);
+    provider.setConfig?.(runtime.config);
+
+    settingsService.set('activeProvider', provider.name);
+    settingsService.set('model', 'gpt-4o');
+    settingsService.setProviderSetting(provider.name, 'model', 'gpt-4o');
+  });
+
+  it('forwards reasoning.fieldName to capture delta.reasoning with sourceField provenance', async () => {
+    settingsService.set('reasoning.fieldName', 'reasoning');
+
+    const chunks = [
+      makeReasoningStreamChunk({ reasoning: 'ollama thinking trace' }, null),
+      makeReasoningStreamChunk({}, 'stop'),
+    ];
+    mockChatCompletionsCreate.mockReturnValue(makeStream(chunks));
+
+    const messages: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'Test question' }] },
+    ];
+
+    const results = await collectResults(
+      provider.generateChatCompletion(messages),
+    );
+
+    const thinking = findThinkingBlock(results);
+    expect(thinking).toBeDefined();
+    expect(thinking?.thought).toBe('ollama thinking trace');
+    expect(thinking?.sourceField).toBe('reasoning');
+  });
+
+  it('does NOT capture reasoning_content when fieldName is explicitly "reasoning"', async () => {
+    settingsService.set('reasoning.fieldName', 'reasoning');
+
+    // Emit ONLY reasoning_content (not reasoning) — should produce NO thinking block
+    // because the explicit field 'reasoning' is absent and no fallback applies.
+    const chunks = [
+      makeReasoningStreamChunk(
+        { reasoning_content: 'should be ignored' },
+        null,
+      ),
+      makeReasoningStreamChunk({}, 'stop'),
+    ];
+    mockChatCompletionsCreate.mockReturnValue(makeStream(chunks));
+
+    const messages: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'Test question' }] },
+    ];
+
+    const results = await collectResults(
+      provider.generateChatCompletion(messages),
+    );
+
+    const thinking = findThinkingBlock(results);
+    expect(thinking).toBeUndefined();
+  });
+
+  it('captures reasoning_content with sourceField provenance when fieldName is unset (default path)', async () => {
+    // Leave reasoning.fieldName unset — standard provider default behavior
+    const chunks = [
+      makeReasoningStreamChunk(
+        { reasoning_content: 'standard reasoning' },
+        null,
+      ),
+      makeReasoningStreamChunk({}, 'stop'),
+    ];
+    mockChatCompletionsCreate.mockReturnValue(makeStream(chunks));
+
+    const messages: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'Test question' }] },
+    ];
+
+    const results = await collectResults(
+      provider.generateChatCompletion(messages),
+    );
+
+    const thinking = findThinkingBlock(results);
+    expect(thinking).toBeDefined();
+    expect(thinking?.thought).toBe('standard reasoning');
+    expect(thinking?.sourceField).toBe('reasoning_content');
+  });
+});

--- a/packages/providers/src/openai/__tests__/OpenAIProvider.reasoningFieldEntry.test.ts
+++ b/packages/providers/src/openai/__tests__/OpenAIProvider.reasoningFieldEntry.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/providers/src/utils/reasoningField.test.ts
+++ b/packages/providers/src/utils/reasoningField.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @issue #2524 — Shared reasoning-field resolution for OpenAI-compatible providers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveReasoningField,
+  normalizeReasoningFieldName,
+  isUsableReasoningValue,
+} from './reasoningField.js';
+
+describe('resolveReasoningField — shared fallback policy (#2524)', () => {
+  it('captures configured explicit field when present', () => {
+    const result = resolveReasoningField({
+      fieldName: 'reasoning',
+      delta: { reasoning: 'x' },
+    });
+    expect(result).toStrictEqual({
+      value: 'x',
+      actualFieldName: 'reasoning',
+    });
+  });
+
+  it('returns undefined when configured field is absent (no fallback)', () => {
+    const result = resolveReasoningField({
+      fieldName: 'custom',
+      delta: { reasoning_content: 'y' },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('treats empty-string field name as unset', () => {
+    const result = resolveReasoningField({
+      fieldName: '',
+      delta: { reasoning_content: 'z' },
+    });
+    expect(result).toStrictEqual({
+      value: 'z',
+      actualFieldName: 'reasoning_content',
+    });
+  });
+
+  it('treats whitespace-only field name as unset', () => {
+    const result = resolveReasoningField({
+      fieldName: '  ',
+      delta: { reasoning_content: 'z' },
+    });
+    expect(result).toStrictEqual({
+      value: 'z',
+      actualFieldName: 'reasoning_content',
+    });
+  });
+
+  it('trims a whitespace-padded field name', () => {
+    const result = resolveReasoningField({
+      fieldName: '  reasoning  ',
+      delta: { reasoning: 'w' },
+    });
+    expect(result).toStrictEqual({
+      value: 'w',
+      actualFieldName: 'reasoning',
+    });
+  });
+
+  it('falls back to delta.reasoning when primary is empty string (unset field)', () => {
+    const result = resolveReasoningField({
+      fieldName: undefined,
+      delta: { reasoning_content: '', reasoning: 'fb' },
+    });
+    expect(result).toStrictEqual({
+      value: 'fb',
+      actualFieldName: 'reasoning',
+    });
+  });
+
+  it('falls back to delta.reasoning when primary is null (unset field)', () => {
+    const result = resolveReasoningField({
+      fieldName: undefined,
+      delta: { reasoning_content: null, reasoning: 'fb' },
+    });
+    expect(result).toStrictEqual({
+      value: 'fb',
+      actualFieldName: 'reasoning',
+    });
+  });
+
+  it('falls back to delta.reasoning when primary is undefined (unset field)', () => {
+    const result = resolveReasoningField({
+      fieldName: undefined,
+      delta: { reasoning: 'fb' },
+    });
+    expect(result).toStrictEqual({
+      value: 'fb',
+      actualFieldName: 'reasoning',
+    });
+  });
+
+  it('falls back to delta.reasoning when primary is a non-string object (unset field)', () => {
+    const result = resolveReasoningField({
+      fieldName: undefined,
+      delta: { reasoning_content: { x: 1 }, reasoning: 'fb' },
+    });
+    expect(result).toStrictEqual({
+      value: 'fb',
+      actualFieldName: 'reasoning',
+    });
+  });
+
+  it('preserves whitespace-only primary as usable (no fallback, issue #721)', () => {
+    const result = resolveReasoningField({
+      fieldName: undefined,
+      delta: { reasoning_content: '  ', reasoning: 'fb' },
+    });
+    expect(result).toStrictEqual({
+      value: '  ',
+      actualFieldName: 'reasoning_content',
+    });
+  });
+
+  it('captures standard-provider default field when present', () => {
+    const result = resolveReasoningField({
+      fieldName: undefined,
+      delta: { reasoning_content: 'std' },
+    });
+    expect(result).toStrictEqual({
+      value: 'std',
+      actualFieldName: 'reasoning_content',
+    });
+  });
+
+  it('prefers primary over fallback when both present and field unset', () => {
+    const result = resolveReasoningField({
+      fieldName: undefined,
+      delta: { reasoning_content: 'std', reasoning: 'fb' },
+    });
+    expect(result).toStrictEqual({
+      value: 'std',
+      actualFieldName: 'reasoning_content',
+    });
+  });
+
+  it('does not fall back when explicit field has non-usable value', () => {
+    const result = resolveReasoningField({
+      fieldName: 'custom',
+      delta: { custom: '', reasoning: 'fb' },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when no reasoning is present anywhere', () => {
+    const result = resolveReasoningField({
+      fieldName: undefined,
+      delta: { content: 'hi' },
+    });
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('normalizeReasoningFieldName', () => {
+  it('returns undefined for undefined input', () => {
+    expect(normalizeReasoningFieldName(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(normalizeReasoningFieldName('')).toBeUndefined();
+  });
+
+  it('returns undefined for whitespace-only string', () => {
+    expect(normalizeReasoningFieldName('   ')).toBeUndefined();
+  });
+
+  it('trims and returns non-empty field name', () => {
+    expect(normalizeReasoningFieldName('  reasoning  ')).toBe('reasoning');
+  });
+
+  it('returns already-trimmed field name as-is', () => {
+    expect(normalizeReasoningFieldName('reasoning')).toBe('reasoning');
+  });
+});
+
+describe('isUsableReasoningValue', () => {
+  it('returns true for non-empty string', () => {
+    expect(isUsableReasoningValue('hello')).toBe(true);
+  });
+
+  it('returns true for whitespace-only string (issue #721)', () => {
+    expect(isUsableReasoningValue('  ')).toBe(true);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isUsableReasoningValue('')).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isUsableReasoningValue(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isUsableReasoningValue(undefined)).toBe(false);
+  });
+
+  it('returns false for non-string object', () => {
+    expect(isUsableReasoningValue({ x: 1 })).toBe(false);
+  });
+});

--- a/packages/providers/src/utils/reasoningField.test.ts
+++ b/packages/providers/src/utils/reasoningField.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/providers/src/utils/reasoningField.ts
+++ b/packages/providers/src/utils/reasoningField.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared reasoning-field resolution for all OpenAI-compatible providers.
+ *
+ * Both the classic openai provider (OpenAIResponseParser) and the openai-vercel
+ * provider (vercelReasoningCapture) previously duplicated this logic with subtly
+ * different fallback semantics, causing provider drift. This module unifies the
+ * policy so that all providers resolve reasoning deltas identically.
+ *
+ * @issue #2524
+ */
+
+/** Default reasoning delta field for standard OpenAI-compatible providers. */
+export const DEFAULT_REASONING_FIELD = 'reasoning_content';
+
+/** Ollama's reasoning delta field, used for auto-fallback when no field is configured. */
+export const OLLAMA_REASONING_FIELD = 'reasoning';
+
+export interface ResolvedReasoningField {
+  value: string;
+  actualFieldName: string;
+}
+
+/**
+ * Normalize a raw reasoning field name. Empty/whitespace-only names are treated
+ * as "unset" (undefined) so auto-fallback still applies. Non-empty names are trimmed.
+ */
+export function normalizeReasoningFieldName(
+  fieldName: string | undefined,
+): string | undefined {
+  const trimmed = fieldName?.trim();
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * True when a delta value is a usable reasoning string (issue #721: whitespace-only
+ * strings are preserved for streaming formatting, so length > 0 is the only bar).
+ */
+export function isUsableReasoningValue(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * Resolve which reasoning value to capture from a streaming delta, applying the
+ * single shared fallback policy used by all OpenAI-compatible providers.
+ *
+ * - When fieldName is unset (undefined after normalization): the primary value
+ *   (default field `reasoning_content`) is preferred; if it is not a usable
+ *   non-empty string, auto-fallback to `delta.reasoning` (Ollama) applies.
+ * - When fieldName is explicitly set: only that field is read; no auto-fallback.
+ *
+ * Returns undefined when no usable reasoning is available.
+ */
+export function resolveReasoningField(params: {
+  fieldName: string | undefined;
+  delta: Record<string, unknown>;
+}): ResolvedReasoningField | undefined {
+  const normalizedFieldName = normalizeReasoningFieldName(params.fieldName);
+  const explicitField = normalizedFieldName ?? DEFAULT_REASONING_FIELD;
+  const primaryValue = params.delta[explicitField];
+  if (isUsableReasoningValue(primaryValue)) {
+    return { value: primaryValue, actualFieldName: explicitField };
+  }
+  if (normalizedFieldName === undefined) {
+    const ollamaValue = params.delta[OLLAMA_REASONING_FIELD];
+    if (isUsableReasoningValue(ollamaValue)) {
+      return {
+        value: ollamaValue,
+        actualFieldName: OLLAMA_REASONING_FIELD,
+      };
+    }
+  }
+  return undefined;
+}

--- a/packages/providers/src/utils/reasoningField.ts
+++ b/packages/providers/src/utils/reasoningField.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Fixes #2524. Follow-up to #2505 / PR #2513 that closes the entry-point test gap and eliminates the risk of provider behavior drifting again by unifying the duplicated reasoning-field resolution logic.

### The drift problem

Two OpenAI-compatible provider paths duplicated reasoning-field selection/fallback logic with **divergent semantics**:

- **Classic OpenAI** (`OpenAIResponseParser.ts`): fell back to `delta.reasoning` (Ollama) whenever the primary value was not a usable non-empty string — i.e. empty string, null, undefined, and non-string objects all triggered fallback. Also normalized empty/whitespace-only field names to "unset".
- **OpenAI-Vercel** (`vercelReasoningCapture.ts`): only fell back for `null`/`undefined` primary values. An empty-string or non-string primary was **silently dropped** (neither captured nor fallen back from). It also did not normalize empty-string field names (it would read `delta['']`).

This is the same class of provider-drift defect that allowed one reasoning path to be fixed (#2505) while another retained different behavior.

## Changes (7 files)

### 1. Shared helper — `packages/providers/src/utils/reasoningField.ts` (new)
Exports `resolveReasoningField({ fieldName, delta })`, `normalizeReasoningFieldName`, `isUsableReasoningValue`, plus `DEFAULT_REASONING_FIELD` / `OLLAMA_REASONING_FIELD` constants. Implements the single unified fallback policy (the robust classic semantics):
- Field name unset → prefer primary (`reasoning_content`); fall back to `delta.reasoning` only when the primary is not a usable non-empty string.
- Field name explicit → read only that field; no auto-fallback.
- Empty/whitespace-only field names normalized to "unset".

### 2. Helper unit tests — `packages/providers/src/utils/reasoningField.test.ts` (new, 25 tests)
Covers every acceptance-criterion case: explicit field present/absent, empty/whitespace field names, primary empty/null/undefined/non-string, whitespace-only-is-usable (#721), standard-provider default, precedence, and direct tests for the normalize/usable helpers.

### 3. Classic OpenAI wired — `packages/providers/src/openai/OpenAIResponseParser.ts`
`readReasoningFromDelta` now delegates to the shared helper; removed the redundant local `resolveReasoningValue` and `hasUsableReasoning`. Behavior is identical for all inputs (verified by existing parser tests passing unchanged).

### 4. OpenAI-Vercel wired — `packages/providers/src/openai-vercel/vercelReasoningCapture.ts`
`captureReasoningFromJson` now delegates to the shared helper. This **fixes** the vercel path so empty-string and non-string primaries now correctly fall back to `delta.reasoning`, matching the classic path.

### 5. dispatchResponse typed options — `packages/providers/src/openai/OpenAIProvider.ts`
Replaced the 12-positional-parameter `dispatchResponse` signature with a typed `DispatchResponseOptions` object. The reasoning field name (and all other params) are now named fields, so future provider-specific wiring cannot be silently omitted by a positional mismatch. Pure mechanical refactor — no behavior change.

### 6. Provider-entry behavioral test — `packages/providers/src/openai/__tests__/OpenAIProvider.reasoningFieldEntry.test.ts` (new, 3 tests)
Proves the full real wiring: `settings.get('reasoning.fieldName')` → `OpenAIProvider` → `dispatchResponse` → `StreamProcessorDeps.reasoningFieldName` → terminal `ThinkingBlock.sourceField`. Uses the real provider instance with a mocked HTTP stream (same pattern as the existing e2e test). The "explicit field blocks fallback" case genuinely **fails** if the provider stops reading/forwarding the setting — it is a real regression guard, not a tautology.

### 7. Vercel unified-policy tests — `packages/providers/src/openai-vercel/__tests__/vercelReasoningCapture.fieldName.test.ts`
3 new cases proving the vercel path now falls back for empty-string and non-string primaries (the bug fix), and treats empty-string field names as unset.

## Acceptance criteria checklist

- [x] A provider-entry behavioral test fails if OpenAIProvider stops reading reasoning.fieldName from settings or stops forwarding it to dispatchResponse.
- [x] Classic OpenAI and Vercel use a shared reasoning-field resolution abstraction rather than duplicated fallback logic.
- [x] Shared helper has behavioral coverage for: explicit field present; explicit field absent; empty and whitespace-only field names; primary empty/null/undefined/non-string; standard-provider default.
- [x] dispatchResponse no longer relies on the long positional parameter sequence for reasoning-field propagation.
- [x] Existing provider behavior remains covered and all verification suites pass.
- [x] Source-field provenance (last-write-wins) preserved unchanged.

## Non-goals

- `processStreamingResponse` signature unchanged (out of scope — larger blast radius).
- Continuation callback signatures unchanged.
- `vercelRequestParams.ts` defaults unchanged.
- No new dependencies.

## Verification

- typecheck: PASS (providers package, 0 errors)
- lint: PASS (all 7 files, 0 violations — no rules loosened, no suppressions)
- format: PASS (Prettier clean)
- test: 64/64 reasoning-related tests pass; existing OpenAIResponseParser.fieldName / OpenAIProviders.fieldName / e2e tests green. 27 pre-existing failures in the full providers suite are unrelated (environment/test-runner issue, confirmed identical on base via git stash).
- build: PASS
- Open Code Review (ocr, --timeout 20): 0 comments.