### PR TITLE
fix(windows): isolate child process console to prevent terminal corruption

### DIFF
--- a/packages/core/src/hooks/hookRunner.consoleIsolation.test.ts
+++ b/packages/core/src/hooks/hookRunner.consoleIsolation.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { spawn } from 'node:child_process';
+import { HookRunner } from './hookRunner.js';
+import {
+  HookEventName,
+  HookType,
+  type HookConfig,
+  type HookInput,
+} from './types.js';
+import type { Config } from '../config/config.js';
+
+vi.mock('node:child_process', async () => {
+  const actual =
+    await vi.importActual<typeof import('node:child_process')>(
+      'node:child_process',
+    );
+  return { ...actual, spawn: vi.fn() };
+});
+
+const mockInput: HookInput = {
+  session_id: 'session-id',
+  transcript_path: 'transcript.jsonl',
+  cwd: process.cwd(),
+  hook_event_name: HookEventName.BeforeTool,
+  timestamp: new Date(0).toISOString(),
+};
+
+const commandConfig: HookConfig = {
+  type: HookType.Command,
+  command: './hooks/test.sh',
+  timeout: 5000,
+};
+
+interface MockChildProcess {
+  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+  stdout: { on: ReturnType<typeof vi.fn> };
+  stderr: { on: ReturnType<typeof vi.fn> };
+  on: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  killed: boolean;
+}
+
+function createMockSpawn(): MockChildProcess {
+  return {
+    stdin: { write: vi.fn(), end: vi.fn() },
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    killed: false,
+  };
+}
+
+describe('HookRunner Windows console isolation (Issue #2548)', () => {
+  let mockSpawnObj: MockChildProcess;
+
+  beforeEach(() => {
+    mockSpawnObj = createMockSpawn();
+    vi.mocked(spawn).mockReturnValue(
+      mockSpawnObj as unknown as ReturnType<typeof spawn>,
+    );
+
+    mockSpawnObj.on.mockImplementation(
+      (event: string, callback: (code: number) => void) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 10);
+        }
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should spawn with windowsHide=true on Windows to isolate console', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    });
+
+    const runner = new HookRunner({
+      getSanitizationConfig: () => undefined,
+    } as Config);
+
+    try {
+      await runner.executeHook(
+        commandConfig,
+        HookEventName.BeforeTool,
+        mockInput,
+      );
+
+      expect(spawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({
+          windowsHide: true,
+          shell: false,
+        }),
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  it('should not set windowsHide on non-Windows platforms and keep shell disabled', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+      configurable: true,
+    });
+
+    const runner = new HookRunner({
+      getSanitizationConfig: () => undefined,
+    } as Config);
+
+    try {
+      await runner.executeHook(
+        commandConfig,
+        HookEventName.BeforeTool,
+        mockInput,
+      );
+
+      const spawnOptions = vi.mocked(spawn).mock.calls[0][2];
+      expect(spawnOptions).toBeDefined();
+      expect(spawnOptions.shell).toBe(false);
+      expect(spawnOptions.windowsHide).toBeUndefined();
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+});

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -557,6 +557,10 @@ export class HookRunner {
         cwd: input.cwd,
         stdio: ['pipe', 'pipe', 'pipe'],
         shell: false, // CRITICAL: must be false to prevent injection
+        // Prevents child from inheriting parent's console screen buffer on
+        // Windows (sets CREATE_NO_WINDOW). PowerShell Console API writes
+        // would otherwise bypass the pipes and corrupt the terminal UI. Issue #2548
+        windowsHide: process.platform === 'win32' ? true : undefined,
       },
     );
   }

--- a/packages/core/src/services/shellExecutionService.fallback.test.ts
+++ b/packages/core/src/services/shellExecutionService.fallback.test.ts
@@ -461,6 +461,7 @@ describe('ShellExecutionService child_process fallback', () => {
         expect.objectContaining({
           shell: false,
           detached: false,
+          windowsHide: true,
         }),
       );
     });
@@ -538,6 +539,47 @@ describe('ShellExecutionService child_process fallback', () => {
         (call) => call[0] === 'error',
       );
       expect(errorCalls.length).toBe(1);
+    });
+  });
+
+  describe('Windows console isolation (Issue #2548)', () => {
+    it('should include windowsHide=true in spawn options on Windows', async () => {
+      mockPlatform.mockReturnValue('win32');
+      stubProcessPlatform('win32');
+      await simulateExecution('echo hello', (cp) => cp.emit('exit', 0, null));
+
+      expect(mockCpSpawn).toHaveBeenCalledWith(
+        'powershell.exe',
+        ['-NoProfile', '-Command', 'echo hello'],
+        expect.objectContaining({
+          windowsHide: true,
+        }),
+      );
+    });
+
+    it('should still capture stdout output when windowsHide=true on Windows', async () => {
+      mockPlatform.mockReturnValue('win32');
+      stubProcessPlatform('win32');
+
+      const { result } = await simulateExecution('echo hello', (cp) => {
+        cp.stdout?.emit('data', Buffer.from('hello world output'));
+        cp.emit('exit', 0, null);
+      });
+
+      expect(result.output).toBe('hello world output');
+      expect(onOutputEventMock).toHaveBeenCalledWith({
+        type: 'data',
+        chunk: 'hello world output',
+      });
+    });
+
+    it('should not set windowsHide on non-Windows platforms', async () => {
+      mockPlatform.mockReturnValue('linux');
+      await simulateExecution('echo hello', (cp) => cp.emit('exit', 0, null));
+
+      const spawnCall = mockCpSpawn.mock.calls[0];
+      const spawnOptions = spawnCall[2];
+      expect(spawnOptions.windowsHide).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -109,6 +109,11 @@ export class ShellExecutionService {
         windowsVerbatimArguments: isWindows ? false : undefined,
         shell: false,
         detached: !isWindows,
+        // Prevents child from inheriting parent's console screen buffer on
+        // Windows (sets CREATE_NO_WINDOW). PowerShell Console API writes
+        // (error coloring, progress bars) would otherwise bypass the pipes
+        // and corrupt the terminal UI. Issue #2548
+        windowsHide: isWindows ? true : undefined,
         env: envVars,
       });
 


### PR DESCRIPTION
## Summary

On Windows, shell tool output sometimes escapes LLxprt's managed rendering area and overwrites the terminal UI. This is caused by `child_process.spawn()` using `detached: false` on Windows, which causes the child PowerShell process to inherit the parent's console screen buffer. PowerShell Console API writes (error coloring, progress bars, VT sequences) bypass stdout/stderr pipes and corrupt the Ink-rendered terminal.

## Root Cause

When `ShellExecutionService` executes shell commands via the `child_process` path (the default when `shouldUseNodePtyShell` is `false`), the spawn options use `detached: !isWindows`, which evaluates to `false` on Windows. This means no `DETACHED_PROCESS` flag is set, so the child process inherits the parent's console screen buffer.

On Windows, the console is a shared resource independent of stdin/stdout/stderr file descriptors. Even though `stdio: ['ignore', 'pipe', 'pipe']` redirects stdout/stderr to pipes (so text output IS captured), the child process retains a handle to the parent's console screen buffer via the Windows Console API (`WriteConsole`, `SetConsoleTextAttribute`, `SetConsoleCursorPosition`). PowerShell uses these APIs for:
- **Error record coloring** — `SetConsoleTextAttribute()` changes console colors
- **Progress bars** (`Write-Progress`) — cursor positioning + buffer writes  
- **VT processing** — escape sequences interpreted as cursor moves/screen clears

These Console API calls write to the same buffer Ink is rendering to, corrupting the display. This is intermittent because only error-heavy commands, progress-bar-producing commands, or commands that change console state trigger the Console API path.

## Fix

Add `windowsHide: true` to spawn options for Windows in two locations:

1. **`ShellExecutionService.childProcessFallback()`** — the main shell tool execution path
2. **`HookRunner.spawnHookProcess()`** — user-configured hooks that spawn PowerShell (same vulnerability)

`windowsHide: true` sets the `CREATE_NO_WINDOW` (0x08000000) flag in `CreateProcessW()`, which prevents the child from inheriting the parent's console screen buffer. stdout/stderr pipes still capture all text output normally — output capture is completely unaffected.

The PTY/ConPTY path does not need this fix because ConPTY already creates a completely isolated pseudoconsole for the child process.

## Test Plan

- [x] New test: `shellExecutionService.fallback.test.ts` — verifies `windowsHide=true` is set on Windows spawn options
- [x] New test: `shellExecutionService.fallback.test.ts` — verifies stdout output is still captured with `windowsHide=true`
- [x] New test: `shellExecutionService.fallback.test.ts` — verifies `windowsHide` is not set on non-Windows platforms
- [x] New test: `hookRunner.consoleIsolation.test.ts` — verifies hook runner sets `windowsHide=true` on Windows
- [x] New test: `hookRunner.consoleIsolation.test.ts` — verifies hook runner does not set `windowsHide` on non-Windows
- [x] Modified existing test: `shellExecutionService.fallback.test.ts` — added `windowsHide: true` assertion to existing Windows spawn test
- [x] All 115 existing shell execution and hook runner tests pass

Closes #2548
