### PR TITLE
Add stable chronology markers to chat history (Fixes #1721)

### DIFF
--- a/docs/debug-logging.md
+++ b/docs/debug-logging.md
@@ -209,6 +209,60 @@ cat "${LLXPRT_LOG_HOME:-$HOME/.local/state/llxprt-code}/debug/llxprt-debug-"*.js
 tail -f "${LLXPRT_LOG_HOME:-$HOME/.local/state/llxprt-code}/debug/llxprt-debug-<PID>.jsonl" | jq '.'
 ```
 
+## Tracing Message Order (Chronology Markers)
+
+Every item that enters the conversation history is stamped with a client-side
+chronology marker, so you can reconstruct the exact order of events even when
+requests are retried or tool calls interleave with ordinary messages.
+
+Each marker carries:
+
+| Field        | Meaning                                                              |
+| ------------ | -------------------------------------------------------------------- |
+| `seq`        | Monotonic insertion ordinal. Never reused, including after `/clear`. |
+| `userTurn`   | Which user turn the item belongs to (`0` before the first prompt).   |
+| `step`       | Position within that user turn, so tool round-trips stay ordered.    |
+| `recordedAt` | Epoch milliseconds when the item entered history.                    |
+
+Markers are **client-side only**. They are never included in a provider request
+payload, and they are excluded from token estimation so they cannot affect when
+compression triggers.
+
+### In debug logs
+
+Chronology appears on every "Adding content to history" record:
+
+```bash
+LLXPRT_DEBUG=llxprt:history:service llxprt
+
+cat "${LLXPRT_LOG_HOME:-$HOME/.local/state/llxprt-code}/debug/llxprt-debug-"*.jsonl \
+  | jq 'select(.namespace == "llxprt:history:service") | .args[1].chronology'
+```
+
+### In context dumps
+
+`/dumpcontext now` writes the full ordered trace into the request dump file
+under a top-level `chronology` key, as a sibling of `request`:
+
+```bash
+jq '.chronology' ~/.cache/llxprt-code/dumps/<baseId>-request.json
+```
+
+The trace lists structural descriptors only — speaker, block types, tool call
+and tool response IDs — and never message text, tool parameters, or tool
+results, so it is safe to attach to a bug report. `request.body` stays exactly
+what the provider receives.
+
+### After compression
+
+Compression destroys history items, which shows up as a gap in the `seq`
+series. When a summary replaces those items, the summary records the span it
+stands in for:
+
+```json
+{ "chronologyReplaced": { "fromSeq": 1, "toSeq": 42, "itemCount": 42 } }
+```
+
 ## Examples
 
 ### Debugging Provider Issues

--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -13,6 +13,7 @@ import type {
   ContentBlock,
 } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { ProviderContentEnvelope } from '@vybestack/llxprt-code-core/services/history/historyProviderPipeline.js';
+import { annotateCompressionSpan } from '@vybestack/llxprt-code-core/services/history/historyChronology.js';
 import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
 import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
@@ -668,9 +669,16 @@ export class CompressionHandler {
       compressionOutcome = await this.runCompressionWithRetryAndFallback(
         prompt_id,
         (newHistory, summary) => {
+          // Record which chronology span the summary stands in for BEFORE the
+          // write-back, so the destroyed seq range is still derivable (#1721).
+          // The subsequent add() calls stamp the summary's own marker.
+          const annotated = annotateCompressionSpan(
+            this.historyService.getRawHistory(),
+            newHistory,
+          );
           // Apply result: clear history, add each entry from newHistory
           this.historyService.clear();
-          for (const content of newHistory) {
+          for (const content of annotated) {
             this.historyService.add(content, this.runtimeContext.state.model);
           }
           this.lastPromptTokenCount = null;

--- a/packages/agents/src/compression/__tests__/CompressionHandler.chronology.test.ts
+++ b/packages/agents/src/compression/__tests__/CompressionHandler.chronology.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioural tests for issue #1721 constraint C2: chronology must survive
+ * summarization. Compression destroys history items, so the summary that
+ * replaces them must record the span it stands in for, and every item that
+ * survives must keep the chronology marker it already had.
+ *
+ * These drive the real CompressionHandler write-back path against a real
+ * HistoryService. Only the compression strategy (which would otherwise need a
+ * live model) is substituted.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type {
+  CompressionProviderResult,
+  CompressionStrategy,
+  CompressionResultMetadata,
+} from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type { RuntimeProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
+import {
+  makeUserMessage,
+  buildRuntimeContext,
+} from '../../core/__tests__/chatSession-density-helpers.js';
+import { CompressionHandler } from '../CompressionHandler.js';
+import * as compressionFactory from '../compressionStrategyFactory.js';
+
+vi.mock('@vybestack/llxprt-code-settings', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@vybestack/llxprt-code-settings')>();
+  return {
+    ...original,
+    Storage: {
+      ...original.Storage,
+      getGlobalConfigDir: vi.fn(() => '/tmp/llxprt-test-config'),
+    },
+  };
+});
+
+const STRATEGY_METADATA: CompressionResultMetadata = {
+  originalMessageCount: 0,
+  compressedMessageCount: 0,
+  strategyUsed: 'one-shot',
+};
+
+function summaryContent(text: string): IContent {
+  return {
+    speaker: 'human',
+    blocks: [{ type: 'text', text }],
+    metadata: {
+      isSummary: true,
+      synthetic: true,
+      reason: 'compression-state-snapshot',
+    },
+  };
+}
+
+/**
+ * Install a compression strategy that returns the supplied history verbatim.
+ * The strategy is the only substituted collaborator; the write-back path,
+ * HistoryService, and chronology stamping are all real.
+ */
+function installStrategyReturning(newHistory: IContent[]): void {
+  const strategy: CompressionStrategy = {
+    name: 'one-shot',
+    requiresLLM: true,
+    trigger: 'threshold',
+    compress: async () => ({
+      kind: 'applied',
+      newHistory,
+      metadata: STRATEGY_METADATA,
+    }),
+  };
+  vi.spyOn(compressionFactory, 'getCompressionStrategy').mockReturnValue(
+    strategy,
+  );
+}
+
+describe('CompressionHandler chronology survival (#1721 C2)', () => {
+  let historyService: HistoryService;
+  let runtimeContext: AgentRuntimeContext;
+  let handler: CompressionHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    historyService = new HistoryService();
+    runtimeContext = buildRuntimeContext(historyService, {
+      contextLimit: 200_000,
+      compressionThreshold: 0.8,
+    });
+
+    const provider = {
+      name: 'test',
+      generateChatCompletion: vi.fn(),
+    } as unknown as RuntimeProvider;
+    const providerResult: CompressionProviderResult = { provider };
+    handler = new CompressionHandler(
+      runtimeContext,
+      historyService,
+      {},
+      vi.fn().mockResolvedValue(providerResult),
+      vi.fn().mockResolvedValue(undefined),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function seedFourTurns(): IContent[] {
+    historyService.add(makeUserMessage('first'));
+    historyService.add(makeUserMessage('second'));
+    historyService.add(makeUserMessage('third'));
+    historyService.add(makeUserMessage('fourth'));
+    return [...historyService.getAll()];
+  }
+
+  /** AC15 */
+  it('annotates the summary with the span of destroyed sequence numbers', async () => {
+    const seeded = seedFourTurns();
+    installStrategyReturning([summaryContent('summary'), seeded[3]]);
+
+    const outcome = await handler.performCompression('prompt-1');
+
+    expect(outcome).toBe(PerformCompressionResult.COMPRESSED);
+    expect(
+      historyService.getAll()[0].metadata?.chronologyReplaced,
+    ).toStrictEqual({
+      fromSeq: 1,
+      toSeq: 3,
+      itemCount: 3,
+    });
+  });
+
+  it('stamps the summary with its own chronology marker', async () => {
+    const seeded = seedFourTurns();
+    installStrategyReturning([summaryContent('summary'), seeded[3]]);
+
+    await handler.performCompression('prompt-1');
+
+    expect(historyService.getAll()[0].metadata?.chronology?.seq).toBe(5);
+  });
+
+  it('preserves the chronology marker of every retained item', async () => {
+    const seeded = seedFourTurns();
+    const retainedSeq = seeded[3].metadata?.chronology?.seq;
+    installStrategyReturning([summaryContent('summary'), seeded[3]]);
+
+    await handler.performCompression('prompt-1');
+
+    expect(historyService.getAll()[1].metadata?.chronology?.seq).toBe(
+      retainedSeq,
+    );
+  });
+
+  it('leaves every item in history carrying a chronology marker', async () => {
+    const seeded = seedFourTurns();
+    installStrategyReturning([summaryContent('summary'), seeded[3]]);
+
+    await handler.performCompression('prompt-1');
+
+    for (const item of historyService.getAll()) {
+      expect(item.metadata?.chronology).toBeDefined();
+    }
+  });
+
+  it('does not annotate a summary when compression destroyed nothing', async () => {
+    const seeded = seedFourTurns();
+    installStrategyReturning([summaryContent('summary'), ...seeded]);
+
+    await handler.performCompression('prompt-1');
+
+    expect(
+      historyService.getAll()[0].metadata?.chronologyReplaced,
+    ).toBeUndefined();
+  });
+
+  it('records a truncation-only result as a gap without a summary annotation', async () => {
+    const seeded = seedFourTurns();
+    installStrategyReturning([seeded[2], seeded[3]]);
+
+    await handler.performCompression('prompt-1');
+
+    const seqs = historyService
+      .getAll()
+      .map((item) => item.metadata?.chronology?.seq);
+    expect(seqs).toStrictEqual([3, 4]);
+  });
+
+  it('does not annotate retained items when compression only truncated', async () => {
+    const seeded = seedFourTurns();
+    installStrategyReturning([seeded[2], seeded[3]]);
+
+    await handler.performCompression('prompt-1');
+
+    for (const item of historyService.getAll()) {
+      expect(item.metadata?.chronologyReplaced).toBeUndefined();
+    }
+  });
+});

--- a/packages/agents/src/compression/__tests__/chronologyTokenNeutrality.test.ts
+++ b/packages/agents/src/compression/__tests__/chronologyTokenNeutrality.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import { HistoryService as RealHistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import { estimatePendingTokens } from '../compressionBudgeting.js';
+import { findCompressSplitPoint } from '../../core/clientHelpers.js';
+
+/**
+ * Chronology markers (#1721) are client-side only and are never sent to a
+ * provider. Token accounting must therefore be blind to them, otherwise every
+ * history item silently costs phantom tokens and compression fires early.
+ */
+
+function human(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+function ai(text: string): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text }] };
+}
+
+function aiToolCall(id: string): IContent {
+  return {
+    speaker: 'ai',
+    blocks: [{ type: 'tool_call', id, name: 'read_file', parameters: {} }],
+  };
+}
+
+function toolResponse(callId: string): IContent {
+  return {
+    speaker: 'tool',
+    blocks: [
+      { type: 'tool_response', callId, toolName: 'read_file', result: 'ok' },
+    ],
+  };
+}
+
+function withChronology(content: IContent, seq: number): IContent {
+  return {
+    ...content,
+    metadata: {
+      ...content.metadata,
+      chronology: {
+        seq,
+        userTurn: Math.ceil(seq / 2),
+        step: seq % 2 === 0 ? 2 : 1,
+        recordedAt: 1_759_000_000_000 + seq,
+      },
+    },
+  };
+}
+
+function stampAll(history: IContent[]): IContent[] {
+  return history.map((content, index) => withChronology(content, index + 1));
+}
+
+const conversation: IContent[] = [
+  human('first question about the repository layout'),
+  ai('here is a fairly long answer describing the layout in detail'),
+  aiToolCall('call-1'),
+  toolResponse('call-1'),
+  human('a follow up question'),
+  ai('another answer'),
+  aiToolCall('call-2'),
+  toolResponse('call-2'),
+  human('a third question'),
+  ai('a third answer'),
+];
+
+/**
+ * A HistoryService whose tokenizer path is unavailable, which is the documented
+ * trigger for estimatePendingTokens' local fallback estimator. Only the
+ * collaborator is substituted; the fallback estimator under test is real.
+ */
+function historyServiceWithUnavailableTokenizer(): HistoryService {
+  const service = new RealHistoryService();
+  service.estimateTokensForContents = () =>
+    Promise.reject(new Error('tokenizer unavailable'));
+  return service;
+}
+
+describe('estimatePendingTokens chronology neutrality', () => {
+  /** AC23 — tokenizer path */
+  it('returns the same estimate with and without chronology markers', async () => {
+    const service = new RealHistoryService();
+
+    const withMarkers = await estimatePendingTokens(
+      stampAll(conversation),
+      service,
+      'gpt-4.1',
+    );
+    const withoutMarkers = await estimatePendingTokens(
+      conversation,
+      service,
+      'gpt-4.1',
+    );
+
+    expect(withMarkers).toBe(withoutMarkers);
+  });
+
+  /** AC23 — local fallback estimator */
+  it('returns the same fallback estimate with and without chronology markers', async () => {
+    const withMarkers = await estimatePendingTokens(
+      stampAll(conversation),
+      historyServiceWithUnavailableTokenizer(),
+      'gpt-4.1',
+    );
+    const withoutMarkers = await estimatePendingTokens(
+      conversation,
+      historyServiceWithUnavailableTokenizer(),
+      'gpt-4.1',
+    );
+
+    expect(withMarkers).toBe(withoutMarkers);
+  });
+
+  it('still reflects real content growth in the fallback estimate', async () => {
+    const short = await estimatePendingTokens(
+      [ai('short')],
+      historyServiceWithUnavailableTokenizer(),
+      'gpt-4.1',
+    );
+    const long = await estimatePendingTokens(
+      [ai('a substantially longer assistant response than the other one')],
+      historyServiceWithUnavailableTokenizer(),
+      'gpt-4.1',
+    );
+
+    expect(long).toBeGreaterThan(short);
+  });
+});
+
+describe('findCompressSplitPoint chronology neutrality', () => {
+  /** AC24 */
+  it('returns the same split index with and without chronology markers', () => {
+    expect(findCompressSplitPoint(stampAll(conversation), 0.5)).toBe(
+      findCompressSplitPoint(conversation, 0.5),
+    );
+  });
+
+  it('returns the same split index at a low fraction', () => {
+    expect(findCompressSplitPoint(stampAll(conversation), 0.2)).toBe(
+      findCompressSplitPoint(conversation, 0.2),
+    );
+  });
+
+  it('returns the same split index at a high fraction', () => {
+    expect(findCompressSplitPoint(stampAll(conversation), 0.8)).toBe(
+      findCompressSplitPoint(conversation, 0.8),
+    );
+  });
+});

--- a/packages/agents/src/compression/compressionBudgeting.ts
+++ b/packages/agents/src/compression/compressionBudgeting.ts
@@ -9,6 +9,7 @@ import type { HistoryService } from '@vybestack/llxprt-code-core/services/histor
 import type { ModelGenerationSettings } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import { estimateTokens as estimateTextTokens } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
+import { serializeWireContentForEstimate } from '@vybestack/llxprt-code-core/services/history/historyTokenEstimation.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 
 const logger = new DebugLogger('llxprt:gemini:compression-budgeting');
@@ -124,7 +125,7 @@ function estimateFallbackContentTokens(
   fallbackLogger: DebugLogger,
 ): number {
   try {
-    const serialized = JSON.stringify(content);
+    const serialized = serializeWireContentForEstimate(content);
     return estimateTextTokens(serialized);
   } catch (stringifyError) {
     fallbackLogger.debug(

--- a/packages/agents/src/core/clientHelpers.ts
+++ b/packages/agents/src/core/clientHelpers.ts
@@ -7,6 +7,7 @@
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { AgentMessageInput } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import type { AgentRequestInput } from '@vybestack/llxprt-code-core/core/clientContract.js';
+import { serializeWireContentForEstimate } from '@vybestack/llxprt-code-core/services/history/historyTokenEstimation.js';
 
 export function isThinkingSupported(model: string) {
   return !model.startsWith('gemini-2.0');
@@ -29,7 +30,9 @@ export function findCompressSplitPoint(
     throw new Error('Fraction must be between 0 and 1');
   }
 
-  const charCounts = contents.map((content) => JSON.stringify(content).length);
+  const charCounts = contents.map(
+    (content) => serializeWireContentForEstimate(content).length,
+  );
   const totalCharCount = charCounts.reduce((sum, length) => sum + length, 0);
   const targetCharCount = totalCharCount * fraction;
 

--- a/packages/cli/src/services/__tests__/performResume.swap.spec.ts
+++ b/packages/cli/src/services/__tests__/performResume.swap.spec.ts
@@ -374,9 +374,14 @@ describe('performResume swap and latest @plan:PLAN-20260214-SESSIONBROWSER.P10',
           ok: false,
           error: 'Failed to commit session transition: commit failed',
         });
-        expect(historyService.getAll()).toStrictEqual([
-          makeContent('previous history'),
-        ]);
+        // Compare the conversation payload only: every history item also
+        // carries a client-side chronology marker (#1721) that this rollback
+        // assertion is not about.
+        expect(
+          historyService
+            .getAll()
+            .map(({ speaker, blocks }) => ({ speaker, blocks })),
+        ).toStrictEqual([makeContent('previous history')]);
         expect(disposeSpy).toHaveBeenCalled();
         expect(adoptSessionId).toHaveBeenCalledTimes(2);
         expect(await SessionLockManager.isLocked(chatsDir, targetId)).toBe(
@@ -415,9 +420,14 @@ describe('performResume swap and latest @plan:PLAN-20260214-SESSIONBROWSER.P10',
         error:
           'Failed to commit session transition: commit failed; failed to restore prior history: rollback restore failed',
       });
-      expect(historyService.getAll()).toStrictEqual([
-        makeContent('replacement history'),
-      ]);
+      // Compare the conversation payload only: every history item also
+      // carries a client-side chronology marker (#1721) that this assertion
+      // is not about.
+      expect(
+        historyService
+          .getAll()
+          .map(({ speaker, blocks }) => ({ speaker, blocks })),
+      ).toStrictEqual([makeContent('replacement history')]);
       expect(await SessionLockManager.isLocked(chatsDir, targetId)).toBe(false);
     });
   });

--- a/packages/cli/src/ui/commands/dumpcontextCommand.chronology.test.ts
+++ b/packages/cli/src/ui/commands/dumpcontextCommand.chronology.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Issue #1721: /dumpcontext must surface the client-side chronology trace for
+ * debugging WITHOUT putting it inside the provider request body. The body has
+ * to stay byte-for-byte what the provider receives, because providers reject
+ * unknown fields with HTTP 400.
+ */
+
+import { vi, describe, it, expect } from 'vitest';
+import { dumpcontextCommand } from './dumpcontextCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+
+vi.mock('@vybestack/llxprt-code-providers', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@vybestack/llxprt-code-providers')>();
+  return {
+    ...actual,
+    dumpRequestContext: vi.fn().mockResolvedValue({
+      baseId: '20260101-120000-anthropic-abc123',
+      requestFilename: '20260101-120000-anthropic-abc123-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    }),
+  };
+});
+
+import { dumpRequestContext } from '@vybestack/llxprt-code-providers';
+
+vi.mock('../contexts/RuntimeContext.js', () => ({
+  getRuntimeApi: vi.fn(() => ({
+    getEphemeralSetting: vi.fn(() => 'off'),
+    setEphemeralSetting: vi.fn(),
+  })),
+}));
+
+import { assertDefined } from '../../test-utils/assertions.js';
+
+const dumpcontextAction = dumpcontextCommand.action;
+assertDefined(dumpcontextAction);
+
+const TRACE = [
+  {
+    seq: 1,
+    userTurn: 1,
+    step: 1,
+    recordedAt: 1_759_000_000_000,
+    speaker: 'human',
+    blockTypes: ['text'],
+    toolCallIds: [],
+    toolResponseIds: [],
+    isSummary: false,
+  },
+];
+
+function contextWithTrace(): CommandContext {
+  const historyService = {
+    getAll: vi
+      .fn()
+      .mockReturnValue([
+        { speaker: 'human', blocks: [{ type: 'text', text: 'Hello' }] },
+      ]),
+    getChronologyTrace: vi.fn().mockReturnValue(TRACE),
+  };
+
+  return createMockCommandContext({
+    services: {
+      config: {
+        getAgentClient: vi.fn().mockReturnValue({
+          getHistoryService: vi.fn().mockReturnValue(historyService),
+        }),
+        getProviderManager: vi.fn().mockReturnValue({
+          getActiveProviderName: vi.fn().mockReturnValue('anthropic'),
+        }),
+      } as unknown as CommandContext['services']['config'],
+    },
+  });
+}
+
+// Declared as a const arrow (not a hoisted function declaration) so the
+// assertDefined narrowing of dumpcontextAction above applies inside the body.
+const dumpAndCaptureCall = async (): Promise<unknown[]> => {
+  vi.mocked(dumpRequestContext).mockClear();
+  await dumpcontextAction(contextWithTrace(), 'now');
+  return vi.mocked(dumpRequestContext).mock.calls[0];
+};
+
+describe('dumpcontext now chronology sidecar (#1721)', () => {
+  it('forwards the history chronology trace to the dump writer', async () => {
+    const call = await dumpAndCaptureCall();
+
+    expect(call[3]).toStrictEqual(TRACE);
+  });
+
+  it('does not place the trace inside the dumped request', async () => {
+    const call = await dumpAndCaptureCall();
+
+    // Structural check rather than a substring scan: this fails if the trace
+    // is smuggled into the request under ANY key, not only one literally
+    // named "chronology".
+    expect(Object.keys(call[0] as object).sort()).toStrictEqual([
+      'body',
+      'method',
+      'url',
+    ]);
+  });
+
+  it('keeps the dumped body to the provider payload shape', async () => {
+    const call = await dumpAndCaptureCall();
+
+    const body = (call[0] as { body: Record<string, unknown> }).body;
+    expect(Object.keys(body).sort()).toStrictEqual(['messages']);
+  });
+
+  it('still dumps the immediate context request', async () => {
+    const call = await dumpAndCaptureCall();
+
+    expect(call[0]).toMatchObject({ url: 'immediate-context-dump' });
+  });
+});

--- a/packages/cli/src/ui/commands/dumpcontextCommand.test.ts
+++ b/packages/cli/src/ui/commands/dumpcontextCommand.test.ts
@@ -190,6 +190,7 @@ describe('dumpcontextCommand', () => {
           { speaker: 'human', blocks: [{ type: 'text', text: 'Hello' }] },
           { speaker: 'ai', blocks: [{ type: 'text', text: 'Hi there' }] },
         ]),
+        getChronologyTrace: vi.fn().mockReturnValue([]),
       });
       const mockGetProviderManager = vi.fn().mockReturnValue({
         getActiveProviderName: vi.fn().mockReturnValue('anthropic'),
@@ -212,6 +213,8 @@ describe('dumpcontextCommand', () => {
       expect(dumpRequestContext).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({ url: 'immediate-context-dump' }),
         'anthropic',
+        undefined,
+        [],
       );
       expect(result).toStrictEqual({
         type: 'message',
@@ -239,6 +242,7 @@ describe('dumpcontextCommand', () => {
           .mockReturnValue([
             { speaker: 'human', blocks: [{ type: 'text', text: 'Hello' }] },
           ]),
+        getChronologyTrace: vi.fn().mockReturnValue([]),
       };
 
       const configWithReceiverDependentMethod = {
@@ -264,6 +268,8 @@ describe('dumpcontextCommand', () => {
       expect(dumpRequestContext).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({ url: 'immediate-context-dump' }),
         'anthropic',
+        undefined,
+        [],
       );
       expect(result).toStrictEqual({
         type: 'message',
@@ -320,6 +326,7 @@ describe('dumpcontextCommand', () => {
                     ],
                   },
                 ]),
+                getChronologyTrace: vi.fn().mockReturnValue([]),
               }),
             }),
             getEphemeralSettings: vi.fn().mockReturnValue({}),
@@ -380,6 +387,7 @@ describe('dumpcontextCommand', () => {
             getAgentClient: vi.fn().mockReturnValue({
               getHistoryService: vi.fn().mockReturnValue({
                 getAll: vi.fn().mockReturnValue(history),
+                getChronologyTrace: vi.fn().mockReturnValue([]),
               }),
             }),
             getEphemeralSettings: vi.fn().mockReturnValue({}),
@@ -450,6 +458,7 @@ describe('dumpcontextCommand', () => {
                     ],
                   },
                 ]),
+                getChronologyTrace: vi.fn().mockReturnValue([]),
               }),
             }),
             getEphemeralSettings: vi.fn().mockReturnValue({}),
@@ -545,6 +554,7 @@ describe('dumpcontextCommand', () => {
                     ],
                   },
                 ]),
+                getChronologyTrace: vi.fn().mockReturnValue([]),
               }),
             }),
             getEphemeralSettings: vi.fn().mockReturnValue({}),
@@ -626,6 +636,7 @@ describe('dumpcontextCommand', () => {
                 ],
               },
             ]),
+            getChronologyTrace: vi.fn().mockReturnValue([]),
           }),
         }),
         getProviderManager: vi.fn().mockReturnValue({
@@ -676,6 +687,7 @@ describe('dumpcontextCommand', () => {
             getAgentClient: vi.fn().mockReturnValue({
               getHistoryService: vi.fn().mockReturnValue({
                 getAll: vi.fn().mockReturnValue(history),
+                getChronologyTrace: vi.fn().mockReturnValue([]),
               }),
             }),
             getEphemeralSettings: vi.fn().mockReturnValue({}),
@@ -754,6 +766,7 @@ describe('dumpcontextCommand', () => {
           .mockReturnValue([
             { speaker: 'human', blocks: [{ type: 'text', text: 'Hello' }] },
           ]),
+        getChronologyTrace: vi.fn().mockReturnValue([]),
       });
 
       const ctxNoProviderManager = createMockCommandContext({

--- a/packages/cli/src/ui/commands/dumpcontextCommand.ts
+++ b/packages/cli/src/ui/commands/dumpcontextCommand.ts
@@ -23,11 +23,17 @@ import {
   buildProviderDumpBody,
   dumpRequestContext,
 } from '@vybestack/llxprt-code-providers';
-import type { IContent } from '@vybestack/llxprt-code-core';
+import type {
+  IContent,
+  ChronologyTraceEntry,
+} from '@vybestack/llxprt-code-core';
 import { Storage } from '@vybestack/llxprt-code-settings';
 import * as path from 'node:path';
 
-type HistoryService = { getAll: () => unknown };
+type HistoryService = {
+  getAll: () => unknown;
+  getChronologyTrace: () => readonly ChronologyTraceEntry[];
+};
 
 type AgentClientWithHistory = {
   getHistoryService?: () => HistoryService | null;
@@ -123,7 +129,14 @@ async function dumpImmediateContext(
       model: activeModel,
     }),
   };
-  const result = await dumpRequestContext(request, providerName);
+  // Chronology is written alongside the request, never inside request.body:
+  // the body must stay byte-for-byte what the provider would receive (#1721).
+  const result = await dumpRequestContext(
+    request,
+    providerName,
+    undefined,
+    historyService.getChronologyTrace(),
+  );
   return {
     type: 'message',
     messageType: 'info',

--- a/packages/cli/vitest.test-groups.ts
+++ b/packages/cli/vitest.test-groups.ts
@@ -477,4 +477,4 @@ export function buildTestGroups(
  * The expected total selected file count after integrating the v0.11.0 test set.
  * Exported for behavioral tests to assert against an independent oracle.
  */
-export const SELECTED_FILE_COUNT: number = 512;
+export const SELECTED_FILE_COUNT: number = 513;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -163,6 +163,10 @@
       "bun": "./src/services/history/historyProviderPipeline.ts",
       "import": "./dist/src/services/history/historyProviderPipeline.js"
     },
+    "./services/history/historyChronology.js": {
+      "bun": "./src/services/history/historyChronology.ts",
+      "import": "./dist/src/services/history/historyChronology.js"
+    },
     "./services/history/historyTokenEstimation.js": {
       "bun": "./src/services/history/historyTokenEstimation.ts",
       "import": "./dist/src/services/history/historyTokenEstimation.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -510,6 +510,9 @@ export { sessionId } from './utils/session.js';
 // Export content interfaces
 export * from './services/history/IContent.js';
 export { ContentConverters } from './services/history/ContentConverters.js';
+// Chronology trace shape (#1721) is part of the public surface so consumers
+// (e.g. the CLI /dumpcontext command) can type the trace without deep-importing.
+export type { ChronologyTraceEntry } from './services/history/historyChronology.js';
 
 // @plan PLAN-20260702-LLMTYPES.P04
 // @requirement REQ-013.1

--- a/packages/core/src/services/history/HistoryService.chronology.test.ts
+++ b/packages/core/src/services/history/HistoryService.chronology.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { HistoryService } from './HistoryService.js';
+import type {
+  IContent,
+  ToolResponseBlock,
+  ContentMetadata,
+} from './IContent.js';
+import type { DensityResult } from '../../core/compression/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers (data builders — NOT mocks)
+// ---------------------------------------------------------------------------
+
+function makeHumanContent(text: string, metadata?: ContentMetadata): IContent {
+  return {
+    speaker: 'human',
+    blocks: [{ type: 'text', text }],
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function makeAIContent(text: string, metadata?: ContentMetadata): IContent {
+  return {
+    speaker: 'ai',
+    blocks: [{ type: 'text', text }],
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function makeToolResponseContent(
+  callId: string,
+  metadata?: ContentMetadata,
+): IContent {
+  return {
+    speaker: 'tool',
+    blocks: [
+      {
+        type: 'tool_response',
+        callId,
+        toolName: 'read_file',
+        result: { ok: true },
+      },
+    ],
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function makeAIWithToolCall(
+  callId: string,
+  metadata?: ContentMetadata,
+): IContent {
+  return {
+    speaker: 'ai',
+    blocks: [
+      { type: 'text', text: 'I will use a tool.' },
+      { type: 'tool_call', id: callId, name: 'read_file', parameters: {} },
+    ],
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC1: seq starts at 1, increments by 1
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC1: seq starts at 1 and increments', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('stamps the first added item with seq 1', () => {
+    service.add(makeHumanContent('hello'));
+
+    expect(service.getAll()[0].metadata?.chronology?.seq).toBe(1);
+  });
+
+  it('increments seq by 1 for each subsequent item', () => {
+    service.add(makeHumanContent('a'));
+    service.add(makeAIContent('b'));
+    service.add(makeHumanContent('c'));
+
+    const seqs = service.getAll().map((c) => c.metadata?.chronology?.seq);
+    expect(seqs).toStrictEqual([1, 2, 3]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2: seq never reused after clear()
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC2: seq never reused after clear()', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('continues seq from the previous maximum after clear()', () => {
+    service.add(makeHumanContent('a'));
+    service.add(makeAIContent('b'));
+    // seq max is now 2
+
+    service.clear();
+    service.add(makeHumanContent('c'));
+
+    const seqAfterClear = service.getAll()[0].metadata?.chronology?.seq;
+    expect(seqAfterClear).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3: userTurn increments only on human; ai/tool share it
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC3: userTurn increments on human only', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('increments userTurn on human and shares it with ai/tool of the same turn', () => {
+    service.add(makeHumanContent('q1'));
+    service.add(makeAIContent('a1'));
+    service.add(makeToolResponseContent('call_1'));
+    service.add(makeHumanContent('q2'));
+    service.add(makeAIContent('a2'));
+
+    const turns = service.getAll().map((c) => c.metadata?.chronology?.userTurn);
+
+    expect(turns).toStrictEqual([1, 1, 1, 2, 2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC4: step is 1 for the human, increments across the turn, resets next turn
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC4: step increments within turn, resets on human', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('assigns step 1 to the human, increments across the turn, resets on next human', () => {
+    service.add(makeHumanContent('q1'));
+    service.add(makeAIContent('a1'));
+    service.add(makeToolResponseContent('call_1'));
+    service.add(makeHumanContent('q2'));
+    service.add(makeAIContent('a2'));
+
+    const steps = service.getAll().map((c) => c.metadata?.chronology?.step);
+
+    expect(steps).toStrictEqual([1, 2, 3, 1, 2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC5: recordedAt populated with insertion time on every item
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC5: recordedAt populated', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('populates recordedAt with a finite number within the insertion time bracket', () => {
+    const before = Date.now();
+    service.add(makeHumanContent('hello'));
+    const after = Date.now();
+
+    const recordedAt = service.getAll()[0].metadata?.chronology?.recordedAt;
+
+    expect(typeof recordedAt).toBe('number');
+    expect(Number.isFinite(recordedAt)).toBe(true);
+    expect(recordedAt).toBeGreaterThanOrEqual(before);
+    expect(recordedAt).toBeLessThanOrEqual(after);
+  });
+
+  it('populates recordedAt on every item', () => {
+    const before = Date.now();
+    service.add(makeHumanContent('a'));
+    service.add(makeAIContent('b'));
+    const after = Date.now();
+
+    for (const item of service.getAll()) {
+      const recordedAt = item.metadata?.chronology?.recordedAt;
+      expect(Number.isFinite(recordedAt)).toBe(true);
+      expect(recordedAt).toBeGreaterThanOrEqual(before);
+      expect(recordedAt).toBeLessThanOrEqual(after);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC8: INV-1 holds after validateAndFix inserts synthetic tool messages
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC8: validateAndFix preserves INV-1', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('stamps every synthetic tool message inserted by validateAndFix', () => {
+    service.add(makeAIWithToolCall('hist_tool_orphan1'));
+    service.add(makeHumanContent('next question'));
+
+    service.validateAndFix();
+
+    // Guard against a vacuous pass: the two seeded items already carry markers,
+    // so the loop below only proves anything if a synthetic message was
+    // actually inserted.
+    expect(service.getAll()).toHaveLength(3);
+
+    for (const item of service.getAll()) {
+      expect(item.metadata?.chronology).toBeDefined();
+      expect(item.metadata?.chronology?.seq).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC9: INV-1 holds after applyDensityResult; replacement inherits marker
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC9: applyDensityResult inherits marker', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('inherits the replaced item marker on density replacement and keeps INV-1', async () => {
+    service.add(makeHumanContent('h1'));
+    service.add(makeAIContent('a1'));
+    service.add(makeHumanContent('h2'));
+
+    const replacedSeq = service.getAll()[1].metadata?.chronology?.seq;
+    const replacedUserTurn = service.getAll()[1].metadata?.chronology?.userTurn;
+    const replacedStep = service.getAll()[1].metadata?.chronology?.step;
+
+    const replacement: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'stubbed response' }],
+    };
+
+    const densityResult: DensityResult = {
+      removals: [],
+      replacements: new Map([[1, replacement]]),
+      metadata: {
+        readWritePairsPruned: 0,
+        fileDeduplicationsPruned: 0,
+        recencyPruned: 0,
+      },
+    };
+
+    await service.applyDensityResult(densityResult);
+
+    const replaced = service.getAll()[1];
+    // Guard against a vacuous pass: if the replacement never landed, the
+    // original item would still satisfy the marker assertions below.
+    expect(replaced.blocks).toStrictEqual(replacement.blocks);
+    expect(replaced.metadata?.chronology?.seq).toBe(replacedSeq);
+    expect(replaced.metadata?.chronology?.userTurn).toBe(replacedUserTurn);
+    expect(replaced.metadata?.chronology?.step).toBe(replacedStep);
+
+    for (const item of service.getAll()) {
+      expect(item.metadata?.chronology).toBeDefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC10: INV-1 holds after summarizeOldHistory; retained items keep their seq
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC10: summarizeOldHistory preserves markers', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('stamps the summary and retains original seqs on kept items', async () => {
+    service.add(makeHumanContent('h1'));
+    service.add(makeAIContent('a1'));
+    service.add(makeHumanContent('h2'));
+    service.add(makeAIContent('a2'));
+
+    const keptSeqBefore = service.getAll()[3].metadata?.chronology?.seq;
+
+    await service.summarizeOldHistory(1, async () =>
+      makeAIContent('summary of old history'),
+    );
+
+    const history = service.getAll();
+    // The summary is first, then the kept tail
+    const summary = history[0];
+    const keptTail = history[1];
+
+    expect(summary.metadata?.chronology).toBeDefined();
+    expect(keptTail.metadata?.chronology).toBeDefined();
+    expect(keptTail.metadata?.chronology?.seq).toBe(keptSeqBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC11: replaceToolResponseBlock preserves the chronology marker
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC11: replaceToolResponseBlock preserves marker', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('stamps every entry installed through replaceAll', async () => {
+    service.add(makeHumanContent('h1'));
+
+    await service.replaceAll([
+      makeHumanContent('replacement h'),
+      makeAIContent('replacement a'),
+    ]);
+
+    for (const item of service.getAll()) {
+      expect(item.metadata?.chronology).toBeDefined();
+    }
+  });
+
+  it('continues the sequence past pre-existing entries after replaceAll', async () => {
+    service.add(makeHumanContent('h1'));
+    service.add(makeAIContent('a1'));
+
+    await service.replaceAll([makeHumanContent('replacement h')]);
+
+    expect(service.getAll()[0].metadata?.chronology?.seq).toBe(3);
+  });
+
+  it('preserves markers on entries that already carry one through replaceAll', async () => {
+    service.add(makeHumanContent('h1'));
+    const existing = service.getAll()[0];
+
+    await service.replaceAll([existing]);
+
+    expect(service.getAll()[0].metadata?.chronology?.seq).toBe(1);
+  });
+
+  it('preserves the entry chronology marker after replacing a tool_response block', async () => {
+    service.add(makeHumanContent('h1'));
+    service.add(makeAIWithToolCall('call_1'));
+    service.add(makeToolResponseContent('call_1'));
+
+    const originalMarker = service.getAll()[2].metadata?.chronology;
+    const originalSeq = originalMarker?.seq;
+
+    const replacementBlock: ToolResponseBlock = {
+      type: 'tool_response',
+      callId: 'call_1',
+      toolName: 'read_file',
+      result: { replaced: true },
+    };
+
+    await service.replaceToolResponseBlock(2, 0, replacementBlock);
+
+    const replaced = service.getAll()[2];
+    expect(replaced.metadata?.chronology?.seq).toBe(originalSeq);
+    expect(replaced.metadata?.chronology).toStrictEqual(originalMarker);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC25: getChronologyTrace returns ordered entries with no message text
+// ---------------------------------------------------------------------------
+
+describe('HistoryService chronology - AC25: getChronologyTrace', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('returns one ordered entry per history item with marker fields', () => {
+    service.add(makeHumanContent('q1'));
+    service.add(makeAIContent('a1'));
+    service.add(makeHumanContent('q2'));
+
+    const trace = service.getChronologyTrace();
+
+    expect(trace).toHaveLength(3);
+    expect(trace.map((e) => e.seq)).toStrictEqual([1, 2, 3]);
+    expect(trace.map((e) => e.speaker)).toStrictEqual(['human', 'ai', 'human']);
+  });
+
+  it('includes structural descriptors (blockTypes, toolCallIds, toolResponseIds)', () => {
+    service.add(makeAIWithToolCall('tc_trace_1'));
+    service.add(makeToolResponseContent('tc_trace_1'));
+
+    const trace = service.getChronologyTrace();
+
+    expect(trace[0].blockTypes).toContain('tool_call');
+    expect(trace[0].toolCallIds).toStrictEqual(['tc_trace_1']);
+    expect(trace[1].toolResponseIds).toStrictEqual(['tc_trace_1']);
+  });
+
+  it('does not leak message text into the trace', () => {
+    service.add(makeHumanContent('VERY_SECRET_USER_TEXT'));
+
+    const trace = service.getChronologyTrace();
+    const serialised = JSON.stringify(trace);
+
+    expect(serialised).not.toContain('VERY_SECRET_USER_TEXT');
+  });
+});

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -62,6 +62,11 @@ import {
   getWithinTokenLimit as getWithinTokenLimitHelper,
   summarizeOldHistory as summarizeOldHistoryHelper,
 } from './historyContextWindow.js';
+import {
+  ChronologyStamper,
+  buildChronologyTrace,
+  type ChronologyTraceEntry,
+} from './historyChronology.js';
 
 // Preserve the CompressionConfig export from the same path for consumers.
 export type { CompressionConfig };
@@ -110,6 +115,8 @@ export class HistoryService
   private historyMutationInProgress = false;
   private historyMutationQueue: QueuedHistoryMutation[] = [];
   private logger = new DebugLogger('llxprt:history:service');
+
+  private chronology = new ChronologyStamper();
 
   /**
    * @plan:PLAN-20260603-ISSUE1584.P05
@@ -411,8 +418,6 @@ export class HistoryService
   }
 
   private addInternal(content: IContent, modelName?: string): void {
-    logContentAdded(this.logger, content, modelName);
-
     // Reject zero-block turns: a Content with no blocks corrupts provider-
     // facing history (notably z.ai rejects empty human turns with HTTP 400
     // error 1213, issue #2410). This is a systemic safety net — earlier
@@ -421,32 +426,46 @@ export class HistoryService
     const hasValidSpeaker = ['human', 'ai', 'tool'].includes(content.speaker);
     const hasBlocks =
       Array.isArray(content.blocks) && content.blocks.length > 0;
-    if (hasValidSpeaker && hasBlocks) {
-      const generation = this.syncGeneration;
-      this.history.push(content);
+    const accepted = hasValidSpeaker && hasBlocks;
 
+    if (accepted) {
+      // Stamp chronology only once the content is known to be accepted, so a
+      // rejected turn never consumes a sequence number (#1721).
+      this.chronology.stamp(content);
+    }
+
+    logContentAdded(this.logger, content, modelName);
+
+    if (!accepted) {
       this.logger.debug(
-        'Content added successfully, history length:',
-        this.history.length,
-      );
-
-      try {
-        this.emit('contentAdded', content);
-      } catch (error: unknown) {
-        this.history.pop();
-        throw error;
-      }
-
-      // Update token count asynchronously but atomically
-      void this.updateTokenCount(content, modelName, generation);
-    } else if (!hasValidSpeaker) {
-      this.logger.debug('Content rejected - invalid speaker:', content.speaker);
-    } else {
-      this.logger.debug(
-        'Content rejected - zero blocks (issue #2410):',
+        hasValidSpeaker
+          ? 'Content rejected - zero blocks (issue #2410):'
+          : 'Content rejected - invalid speaker:',
         content.speaker,
       );
+      return;
     }
+
+    const generation = this.syncGeneration;
+    this.history.push(content);
+
+    this.logger.debug(
+      'Content added successfully, history length:',
+      this.history.length,
+    );
+
+    try {
+      this.emit('contentAdded', content);
+    } catch (error: unknown) {
+      // Roll back the insertion. The consumed chronology sequence number is
+      // intentionally NOT reclaimed: sequence numbers are never reused, and
+      // the resulting gap truthfully records that an item was removed.
+      this.history.pop();
+      throw error;
+    }
+
+    // Update token count asynchronously but atomically
+    void this.updateTokenCount(content, modelName, generation);
   }
 
   /**
@@ -542,6 +561,11 @@ export class HistoryService
     const previousHistory = this.history;
     const previousTokens = this.totalTokens;
     this.invalidatePendingSyncs();
+    // Uphold the chronology invariant on this insertion path too: items that
+    // already carry a marker keep it, and anything new is stamped (#1721).
+    for (const content of accepted) {
+      this.chronology.stamp(content);
+    }
     this.history = [...accepted];
     this.totalTokens = replacementTokens;
     try {
@@ -589,6 +613,15 @@ export class HistoryService
    */
   async applyDensityResult(result: DensityResult): Promise<void> {
     validateDensityResult(result, this.history.length);
+    // Each density replacement takes over the chronology position of the item
+    // it replaces, so the surviving history keeps an unbroken sequence.
+    // densityValidation stays free of chronology knowledge.
+    for (const [index, replacement] of result.replacements) {
+      const replacedMarker = this.history[index].metadata?.chronology;
+      if (replacedMarker !== undefined) {
+        this.chronology.inherit(replacement, replacedMarker);
+      }
+    }
     applyDensityMutations(this.history, result);
 
     this.logger.debug('Density: applied result', {
@@ -760,6 +793,8 @@ export class HistoryService
     this.pendingOperations = [];
     this.tokenizerCache.clear();
     this.tokenizerLock = Promise.resolve();
+    // Chronology counters are intentionally NOT reset: seq must never be reused
+    // (NG8) so that items added after dispose() never collide with earlier ones.
   }
 
   /**
@@ -792,6 +827,8 @@ export class HistoryService
     const previousTokens = this.totalTokens;
     this.history = [];
     this.totalTokens = 0;
+    // Chronology counters are intentionally NOT reset on clear (NG8): seq must
+    // never be reused so items added after a clear never collide with earlier ones.
 
     // Emit event with reset count
     this.emit('tokensUpdated', {
@@ -936,16 +973,18 @@ export class HistoryService
     for (let i = 0; i < this.history.length; i++) {
       const missing = getMissingToolCalls(this.history[i], respondedCallIds);
       if (missing.length > 0) {
-        const syntheticToolMessage = createSyntheticToolMessage(missing);
+        const stampedSynthetic = this.chronology.stamp(
+          createSyntheticToolMessage(missing),
+        );
 
-        this.history.splice(i + 1, 0, syntheticToolMessage);
+        this.history.splice(i + 1, 0, stampedSynthetic);
         insertedCount += 1;
 
         for (const tc of missing) {
           respondedCallIds.add(tc.id);
         }
 
-        void this.updateTokenCount(syntheticToolMessage);
+        void this.updateTokenCount(stampedSynthetic);
         i += 1;
       }
     }
@@ -994,6 +1033,11 @@ export class HistoryService
       summarizeFn,
     );
     if (result) {
+      // Stamp every item: retained items already carry a marker and keep it,
+      // while the freshly generated summary gets a new one.
+      for (const item of result) {
+        this.chronology.stamp(item);
+      }
       this.history = result;
       await this.recalculateTotalTokens();
     }
@@ -1066,5 +1110,14 @@ export class HistoryService
    */
   getStatistics(): ConversationStatistics {
     return computeStatistics(this.history);
+  }
+
+  /**
+   * Get an ordered chronology trace: one compact, JSON-safe entry per history
+   * item carrying its marker fields and structural descriptors. No message
+   * text, tool parameters, or tool results appear in the trace.
+   */
+  getChronologyTrace(): ChronologyTraceEntry[] {
+    return buildChronologyTrace(this.history);
   }
 }

--- a/packages/core/src/services/history/IContent.ts
+++ b/packages/core/src/services/history/IContent.ts
@@ -40,6 +40,52 @@ export interface IContent {
 }
 
 /**
+ * The span of chronology sequence numbers that a summary entry replaced.
+ *
+ * Produced when compression destroys history items, so the surviving summary
+ * records which part of the conversation it stands in for.
+ *
+ * @issue #1721
+ */
+export interface ChronologyReplacedSpan {
+  /** Lowest chronology sequence number destroyed by the compression. */
+  readonly fromSeq: number;
+
+  /** Highest chronology sequence number destroyed by the compression. */
+  readonly toSeq: number;
+
+  /** How many history items the compression destroyed. */
+  readonly itemCount: number;
+}
+
+/**
+ * Client-side ordering marker stamped on every history item.
+ *
+ * This exists to make request/response ordering reconstructable across retries
+ * and tool round-trips. It is a debugging/tracing aid only and is NEVER
+ * serialized into a provider request payload — providers reject unknown fields
+ * on message objects with HTTP 400.
+ *
+ * @issue #1721
+ */
+export interface ChronologyMarker {
+  /**
+   * Monotonic 1-based insertion ordinal within a HistoryService instance.
+   * Sequence numbers are never reused, including across `clear()`.
+   */
+  readonly seq: number;
+
+  /** 0 before the first human turn, then 1-based per human turn. */
+  readonly userTurn: number;
+
+  /** 1-based ordinal of this item within its `userTurn`. */
+  readonly step: number;
+
+  /** Epoch milliseconds at the moment the item entered history. */
+  readonly recordedAt: number;
+}
+
+/**
  * Metadata associated with content
  */
 export interface ContentMetadata {
@@ -88,6 +134,20 @@ export interface ContentMetadata {
 
   /** Reason the response was incomplete (e.g., max_output_tokens) */
   incompleteReason?: string;
+
+  /**
+   * Client-side chronology marker. Stamped by HistoryService on insertion.
+   * NEVER serialized to a provider (#1721).
+   */
+  chronology?: ChronologyMarker;
+
+  /**
+   * On a summary entry, the span of chronology sequence numbers this summary
+   * replaced. Kept as a sibling of `chronology` because compression builds the
+   * summary before it has ever entered history and therefore before it has a
+   * marker. NEVER serialized to a provider (#1721).
+   */
+  chronologyReplaced?: ChronologyReplacedSpan;
 }
 
 export interface UsageStats {

--- a/packages/core/src/services/history/curationDebugLogger.ts
+++ b/packages/core/src/services/history/curationDebugLogger.ts
@@ -144,6 +144,7 @@ export function logContentAdded(
       })),
     contentId: content.metadata?.id,
     modelName,
+    chronology: content.metadata?.chronology,
   });
 }
 

--- a/packages/core/src/services/history/historyChronology.test.ts
+++ b/packages/core/src/services/history/historyChronology.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  ChronologyStamper,
+  annotateCompressionSpan,
+  buildChronologyTrace,
+} from './historyChronology.js';
+import type { ChronologyMarker, IContent } from './IContent.js';
+
+function fixedClock(value: number): () => number {
+  return () => value;
+}
+
+function humanText(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+function aiText(text: string): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text }] };
+}
+
+function marked(content: IContent, marker: ChronologyMarker): IContent {
+  return { ...content, metadata: { ...content.metadata, chronology: marker } };
+}
+
+function markerAt(
+  seq: number,
+  userTurn: number,
+  step: number,
+): ChronologyMarker {
+  return { seq, userTurn, step, recordedAt: 1_000 + seq };
+}
+
+function summaryEntry(text: string): IContent {
+  return {
+    speaker: 'human',
+    blocks: [{ type: 'text', text }],
+    metadata: { isSummary: true, synthetic: true },
+  };
+}
+
+describe('ChronologyStamper.stamp', () => {
+  it('assigns the recorded time from the injected clock', () => {
+    const stamper = new ChronologyStamper(fixedClock(42));
+
+    const stamped = stamper.stamp(humanText('hi'));
+
+    expect(stamped.metadata?.chronology?.recordedAt).toBe(42);
+  });
+
+  it('returns the same object reference so history stores what the caller added', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    const original = humanText('hi');
+
+    expect(stamper.stamp(original)).toBe(original);
+  });
+
+  it('leaves blocks untouched when stamping', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    const original = humanText('hi');
+    const blocks = original.blocks;
+
+    stamper.stamp(original);
+
+    expect(original.blocks).toBe(blocks);
+  });
+
+  /** AC6 */
+  it('returns content carrying an existing marker unchanged by reference', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    const existing = marked(aiText('kept'), markerAt(7, 3, 2));
+
+    const result = stamper.stamp(existing);
+
+    expect(result).toBe(existing);
+  });
+
+  /** AC7 */
+  it('gives fresh content a sequence greater than every preserved sequence', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    stamper.stamp(marked(aiText('kept'), markerAt(9, 4, 3)));
+
+    const fresh = stamper.stamp(humanText('next'));
+
+    expect(fresh.metadata?.chronology?.seq).toBe(10);
+  });
+
+  it('continues the user turn counter after preserving a marker', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    stamper.stamp(marked(aiText('kept'), markerAt(9, 4, 3)));
+
+    const fresh = stamper.stamp(humanText('next'));
+
+    expect(fresh.metadata?.chronology?.userTurn).toBe(5);
+  });
+
+  it('continues the step counter within the preserved user turn', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    stamper.stamp(marked(aiText('kept'), markerAt(9, 4, 3)));
+
+    const fresh = stamper.stamp(aiText('same turn'));
+
+    expect(fresh.metadata?.chronology?.step).toBe(4);
+  });
+
+  it('restarts the step counter when a fresh human turn begins', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    stamper.stamp(humanText('turn one'));
+    stamper.stamp(aiText('reply one'));
+
+    const fresh = stamper.stamp(humanText('turn two'));
+
+    expect(fresh.metadata?.chronology).toStrictEqual({
+      seq: 3,
+      userTurn: 2,
+      step: 1,
+      recordedAt: 1,
+    });
+  });
+
+  it('restarts the step counter when a preserved marker advances the turn', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    stamper.stamp(humanText('turn one'));
+    stamper.stamp(aiText('reply one'));
+    stamper.stamp(marked(humanText('turn two'), markerAt(20, 2, 1)));
+
+    const fresh = stamper.stamp(aiText('reply two'));
+
+    expect(fresh.metadata?.chronology?.step).toBe(2);
+  });
+
+  it('ignores a stale lower-turn marker when continuing the current turn', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    stamper.stamp(humanText('turn one'));
+    stamper.stamp(humanText('turn two'));
+    stamper.stamp(marked(aiText('stale'), markerAt(1, 1, 9)));
+
+    const fresh = stamper.stamp(aiText('reply two'));
+
+    expect(fresh.metadata?.chronology?.step).toBe(2);
+  });
+
+  it('keeps the current turn when a stale lower-turn marker is preserved', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    stamper.stamp(humanText('turn one'));
+    stamper.stamp(humanText('turn two'));
+    stamper.stamp(marked(aiText('stale'), markerAt(1, 1, 9)));
+
+    const fresh = stamper.stamp(aiText('reply two'));
+
+    expect(fresh.metadata?.chronology?.userTurn).toBe(2);
+  });
+
+  it('preserves unrelated metadata when stamping', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    const content: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'x' }],
+      metadata: { model: 'gpt-4.1' },
+    };
+
+    const stamped = stamper.stamp(content);
+
+    expect(stamped.metadata?.model).toBe('gpt-4.1');
+  });
+});
+
+describe('ChronologyStamper.inherit', () => {
+  it('applies the supplied marker to the returned content', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    const marker = markerAt(5, 2, 2);
+
+    const result = stamper.inherit(aiText('replacement'), marker);
+
+    expect(result.metadata?.chronology).toStrictEqual(marker);
+  });
+
+  it('advances the sequence counter past the inherited marker', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    stamper.inherit(aiText('replacement'), markerAt(5, 2, 2));
+
+    const fresh = stamper.stamp(humanText('next'));
+
+    expect(fresh.metadata?.chronology?.seq).toBe(6);
+  });
+
+  it('returns the same object reference so the replacement itself is stored', () => {
+    const stamper = new ChronologyStamper(fixedClock(1));
+    const original = aiText('replacement');
+
+    expect(stamper.inherit(original, markerAt(5, 2, 2))).toBe(original);
+  });
+});
+
+describe('annotateCompressionSpan', () => {
+  /** AC12 */
+  it('records the destroyed sequence span on the summary entry', () => {
+    const previous = [
+      marked(humanText('a'), markerAt(1, 1, 1)),
+      marked(aiText('b'), markerAt(2, 1, 2)),
+      marked(humanText('c'), markerAt(3, 2, 1)),
+      marked(aiText('d'), markerAt(4, 2, 2)),
+    ];
+    const kept = previous[3];
+
+    const result = annotateCompressionSpan(previous, [summaryEntry('s'), kept]);
+
+    expect(result[0].metadata?.chronologyReplaced).toStrictEqual({
+      fromSeq: 1,
+      toSeq: 3,
+      itemCount: 3,
+    });
+  });
+
+  it('counts only the sequences that disappeared', () => {
+    const previous = [
+      marked(humanText('a'), markerAt(1, 1, 1)),
+      marked(aiText('b'), markerAt(2, 1, 2)),
+      marked(aiText('c'), markerAt(5, 1, 3)),
+    ];
+
+    const result = annotateCompressionSpan(previous, [
+      summaryEntry('s'),
+      previous[1],
+    ]);
+
+    expect(result[0].metadata?.chronologyReplaced).toStrictEqual({
+      fromSeq: 1,
+      toSeq: 5,
+      itemCount: 2,
+    });
+  });
+
+  /** AC13 */
+  it('leaves the summary unannotated when nothing was destroyed', () => {
+    const previous = [marked(humanText('a'), markerAt(1, 1, 1))];
+    const summary = summaryEntry('s');
+
+    const result = annotateCompressionSpan(previous, [previous[0], summary]);
+
+    expect(result[1].metadata?.chronologyReplaced).toBeUndefined();
+  });
+
+  /** AC14 */
+  it('returns items unchanged when the result contains no summary entry', () => {
+    const previous = [
+      marked(humanText('a'), markerAt(1, 1, 1)),
+      marked(aiText('b'), markerAt(2, 1, 2)),
+    ];
+    const kept = previous[1];
+
+    const result = annotateCompressionSpan(previous, [kept]);
+
+    expect(result[0]).toBe(kept);
+  });
+
+  it('does not overwrite an existing replaced span', () => {
+    const previous = [
+      marked(humanText('a'), markerAt(1, 1, 1)),
+      marked(aiText('b'), markerAt(2, 1, 2)),
+    ];
+    const existing: IContent = {
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 's' }],
+      metadata: {
+        isSummary: true,
+        chronologyReplaced: { fromSeq: 90, toSeq: 99, itemCount: 4 },
+      },
+    };
+
+    const result = annotateCompressionSpan(previous, [existing]);
+
+    expect(result[0].metadata?.chronologyReplaced).toStrictEqual({
+      fromSeq: 90,
+      toSeq: 99,
+      itemCount: 4,
+    });
+  });
+
+  it('ignores entries that carry no chronology marker', () => {
+    const previous = [
+      humanText('unmarked'),
+      marked(aiText('b'), markerAt(2, 1, 2)),
+    ];
+
+    const result = annotateCompressionSpan(previous, [summaryEntry('s')]);
+
+    expect(result[0].metadata?.chronologyReplaced).toStrictEqual({
+      fromSeq: 2,
+      toSeq: 2,
+      itemCount: 1,
+    });
+  });
+
+  it('annotates every summary entry when the result contains more than one', () => {
+    const previous = [
+      marked(humanText('a'), markerAt(1, 1, 1)),
+      marked(aiText('b'), markerAt(2, 1, 2)),
+    ];
+
+    const result = annotateCompressionSpan(previous, [
+      summaryEntry('s1'),
+      summaryEntry('s2'),
+    ]);
+
+    expect(
+      result.map((entry) => entry.metadata?.chronologyReplaced),
+    ).toStrictEqual([
+      { fromSeq: 1, toSeq: 2, itemCount: 2 },
+      { fromSeq: 1, toSeq: 2, itemCount: 2 },
+    ]);
+  });
+
+  it('does not mutate the supplied new history entries', () => {
+    const previous = [marked(humanText('a'), markerAt(1, 1, 1))];
+    const summary = summaryEntry('s');
+
+    annotateCompressionSpan(previous, [summary]);
+
+    expect(summary.metadata?.chronologyReplaced).toBeUndefined();
+  });
+});
+
+describe('buildChronologyTrace', () => {
+  it('returns one entry per marked history item in order', () => {
+    const history = [
+      marked(humanText('a'), markerAt(1, 1, 1)),
+      marked(aiText('b'), markerAt(2, 1, 2)),
+    ];
+
+    const trace = buildChronologyTrace(history);
+
+    expect(trace.map((entry) => entry.seq)).toStrictEqual([1, 2]);
+  });
+
+  it('skips items that carry no marker', () => {
+    const history = [
+      humanText('unmarked'),
+      marked(aiText('b'), markerAt(2, 1, 2)),
+    ];
+
+    const trace = buildChronologyTrace(history);
+
+    expect(trace).toHaveLength(1);
+  });
+
+  it('describes block types without their content', () => {
+    const history = [
+      marked(
+        {
+          speaker: 'ai',
+          blocks: [
+            { type: 'text', text: 'visible' },
+            { type: 'tool_call', id: 'call-1', name: 'run', parameters: {} },
+          ],
+        },
+        markerAt(1, 1, 1),
+      ),
+    ];
+
+    const trace = buildChronologyTrace(history);
+
+    expect(trace[0].blockTypes).toStrictEqual(['text', 'tool_call']);
+  });
+
+  it('surfaces tool call ids', () => {
+    const history = [
+      marked(
+        {
+          speaker: 'ai',
+          blocks: [
+            { type: 'tool_call', id: 'call-1', name: 'run', parameters: {} },
+          ],
+        },
+        markerAt(1, 1, 1),
+      ),
+    ];
+
+    const trace = buildChronologyTrace(history);
+
+    expect(trace[0].toolCallIds).toStrictEqual(['call-1']);
+  });
+
+  it('surfaces tool response call ids', () => {
+    const history = [
+      marked(
+        {
+          speaker: 'tool',
+          blocks: [
+            {
+              type: 'tool_response',
+              callId: 'call-1',
+              toolName: 'run',
+              result: 'secret result',
+            },
+          ],
+        },
+        markerAt(1, 1, 1),
+      ),
+    ];
+
+    const trace = buildChronologyTrace(history);
+
+    expect(trace[0].toolResponseIds).toStrictEqual(['call-1']);
+  });
+
+  it('marks summary entries', () => {
+    const history = [marked(summaryEntry('s'), markerAt(1, 1, 1))];
+
+    const trace = buildChronologyTrace(history);
+
+    expect(trace[0].isSummary).toBe(true);
+  });
+
+  it('surfaces the replaced span when present', () => {
+    const summary: IContent = {
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 's' }],
+      metadata: {
+        isSummary: true,
+        chronology: markerAt(4, 2, 1),
+        chronologyReplaced: { fromSeq: 1, toSeq: 3, itemCount: 3 },
+      },
+    };
+
+    const trace = buildChronologyTrace([summary]);
+
+    expect(trace[0].replaced).toStrictEqual({
+      fromSeq: 1,
+      toSeq: 3,
+      itemCount: 3,
+    });
+  });
+
+  it('omits the replaced key when the item replaced nothing', () => {
+    const trace = buildChronologyTrace([
+      marked(humanText('a'), markerAt(1, 1, 1)),
+    ]);
+
+    expect(trace[0].replaced).toBeUndefined();
+  });
+
+  it('never leaks message text, tool parameters or tool results', () => {
+    const history = [
+      marked(humanText('SECRET_USER_TEXT'), markerAt(1, 1, 1)),
+      marked(
+        {
+          speaker: 'ai',
+          blocks: [
+            { type: 'thinking', thought: 'SECRET_THOUGHT' },
+            {
+              type: 'tool_call',
+              id: 'call-1',
+              name: 'run',
+              parameters: { token: 'SECRET_PARAM' },
+            },
+          ],
+        },
+        markerAt(2, 1, 2),
+      ),
+      marked(
+        {
+          speaker: 'tool',
+          blocks: [
+            {
+              type: 'tool_response',
+              callId: 'call-1',
+              toolName: 'run',
+              result: 'SECRET_RESULT',
+            },
+          ],
+        },
+        markerAt(3, 1, 3),
+      ),
+    ];
+
+    const serialized = JSON.stringify(buildChronologyTrace(history));
+
+    expect(serialized).not.toMatch(/SECRET_/);
+  });
+});

--- a/packages/core/src/services/history/historyChronology.ts
+++ b/packages/core/src/services/history/historyChronology.ts
@@ -1,0 +1,291 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  IContent,
+  ChronologyMarker,
+  ChronologyReplacedSpan,
+} from './IContent.js';
+
+/**
+ * Stamps and reconciles {@link ChronologyMarker}s onto {@link IContent}.
+ *
+ * OWNERSHIP TRANSFER: {@link stamp} and {@link inherit} attach the marker
+ * IN PLACE and return the same object reference. This is deliberate. Callers
+ * hand ownership of the content to history at the insertion boundary, and
+ * `HistoryService` has a long-standing contract that the object you add is the
+ * object it stores — `removeLastIfMatches` compares by reference, and density
+ * replacement callers assert that the exact replacement object lands in the
+ * history array. Returning a copy would silently break that contract.
+ *
+ * Only the additive `metadata.chronology` field is written; no existing field
+ * is read-modified-written and no block is touched. This mirrors the
+ * established in-place metadata pattern used by the provider stream parsers
+ * (for example `content.metadata ??= {}` in `OpenAIStreamProcessorState`).
+ *
+ * When a marker already exists it is preserved verbatim and only the stamper's
+ * internal counters are reconciled, so a subsequent fresh stamp never collides.
+ */
+export class ChronologyStamper {
+  private nextSeq = 1;
+  private currentUserTurn = 0;
+  private nextStep = 1;
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  /**
+   * Attach a chronology marker to `content` and return it.
+   *
+   * - Fresh stamp (no existing marker): a new marker is minted and written to
+   *   `content.metadata.chronology`.
+   * - Existing marker: left untouched; only the stamper's counters are
+   *   reconciled (preserve + reconcile).
+   *
+   * The returned reference is always the reference that was passed in.
+   */
+  stamp(content: IContent): IContent {
+    const existing = content.metadata?.chronology;
+    if (existing) {
+      this.reconcile(existing);
+      return content;
+    }
+
+    if (content.speaker === 'human') {
+      this.currentUserTurn += 1;
+      this.nextStep = 1;
+    }
+
+    const marker: ChronologyMarker = {
+      seq: this.nextSeq,
+      userTurn: this.currentUserTurn,
+      step: this.nextStep,
+      recordedAt: this.now(),
+    };
+    this.nextSeq += 1;
+    this.nextStep += 1;
+
+    return this.assign(content, marker);
+  }
+
+  /**
+   * Attach the given marker verbatim to `content` and return it. Used for
+   * replacements that occupy the same logical position as another item, so the
+   * replacement keeps the replaced item's place in the chronology. The
+   * stamper's counters are reconciled exactly as for an existing marker in
+   * {@link stamp}.
+   *
+   * The returned reference is always the reference that was passed in.
+   */
+  inherit(content: IContent, marker: ChronologyMarker): IContent {
+    this.reconcile(marker);
+    return this.assign(content, marker);
+  }
+
+  /** Write the marker into the content's metadata in place. */
+  private assign(content: IContent, marker: ChronologyMarker): IContent {
+    const target = content;
+    target.metadata ??= {};
+    target.metadata.chronology = marker;
+    return target;
+  }
+
+  /**
+   * Reconcile internal counters so a future fresh stamp never collides with a
+   * preserved/inherited marker.
+   *
+   * The step counter is scoped to a single user turn, so each of the three
+   * turn relationships needs distinct handling:
+   *  - the marker advances the turn: the step counter belongs to the new turn
+   *    and must restart from that marker rather than carrying the previous
+   *    turn's high-water mark forward;
+   *  - the marker is in the current turn: take the high-water mark;
+   *  - the marker is from an older turn (restored or merged history): it says
+   *    nothing about the current turn, so the step counter is left alone.
+   */
+  private reconcile(marker: ChronologyMarker): void {
+    this.nextSeq = Math.max(this.nextSeq, marker.seq + 1);
+
+    if (marker.userTurn > this.currentUserTurn) {
+      this.currentUserTurn = marker.userTurn;
+      this.nextStep = marker.step + 1;
+      return;
+    }
+
+    if (marker.userTurn === this.currentUserTurn) {
+      this.nextStep = Math.max(this.nextStep, marker.step + 1);
+    }
+  }
+}
+
+/**
+ * Collect the set of chronology `seq` values present in a history array.
+ * Entries without a marker are ignored.
+ */
+function collectSeqs(history: readonly IContent[]): Set<number> {
+  const seqs = new Set<number>();
+  for (const item of history) {
+    const seq = item.metadata?.chronology?.seq;
+    if (typeof seq === 'number') {
+      seqs.add(seq);
+    }
+  }
+  return seqs;
+}
+
+/**
+ * Annotate summary entries in `newHistory` with the span of chronology seqs
+ * destroyed by the compression that produced it.
+ *
+ * Computes the set of `seq` values present in `previousHistory` but absent
+ * from `newHistory` (the items destroyed by the strategy). When any were
+ * destroyed, attaches `metadata.chronologyReplaced` to every
+ * `metadata.isSummary === true` entry in `newHistory` that does NOT already
+ * carry a `chronologyReplaced` field.
+ *
+ * Designed to run BEFORE the new history is written back through
+ * HistoryService, so the stamper attaches `chronology` afterwards — keeping
+ * the span separate from the marker (compression builds its summary entry
+ * before that entry has ever entered HistoryService, so it has no marker yet).
+ *
+ * Neither input array nor its items are mutated. A shallow copy of the array
+ * is returned with copies made only for the summary entries that receive a
+ * `chronologyReplaced` annotation; all other entries are returned by
+ * reference unchanged.
+ */
+export function annotateCompressionSpan(
+  previousHistory: readonly IContent[],
+  newHistory: readonly IContent[],
+): IContent[] {
+  const previousSeqs = collectSeqs(previousHistory);
+  const newSeqs = collectSeqs(newHistory);
+
+  const destroyed = new Set<number>();
+  for (const seq of previousSeqs) {
+    if (!newSeqs.has(seq)) {
+      destroyed.add(seq);
+    }
+  }
+
+  if (destroyed.size === 0) {
+    return [...newHistory];
+  }
+
+  // Iterative min/max: spreading a Set into Math.min/Math.max puts every
+  // element on the call stack, which a large compressed history could overflow.
+  let minSeq = Number.POSITIVE_INFINITY;
+  let maxSeq = Number.NEGATIVE_INFINITY;
+  for (const seq of destroyed) {
+    if (seq < minSeq) {
+      minSeq = seq;
+    }
+    if (seq > maxSeq) {
+      maxSeq = seq;
+    }
+  }
+  const span: ChronologyReplacedSpan = {
+    fromSeq: minSeq,
+    toSeq: maxSeq,
+    itemCount: destroyed.size,
+  };
+
+  const hasSummary = newHistory.some(
+    (item) => item.metadata?.isSummary === true,
+  );
+  if (!hasSummary) {
+    return [...newHistory];
+  }
+
+  return newHistory.map((item) => {
+    if (
+      item.metadata?.isSummary === true &&
+      item.metadata.chronologyReplaced === undefined
+    ) {
+      return {
+        ...item,
+        metadata: {
+          ...item.metadata,
+          chronologyReplaced: span,
+        },
+      };
+    }
+    return item;
+  });
+}
+
+/**
+ * A single compact, JSON-safe projection of a history item's chronology and
+ * structural descriptors. No message text, tool parameters, or tool results
+ * appear in a trace entry, so the trace itself is safe to share.
+ */
+export interface ChronologyTraceEntry {
+  readonly seq: number;
+  readonly userTurn: number;
+  readonly step: number;
+  readonly recordedAt: number;
+  readonly speaker: IContent['speaker'];
+  readonly blockTypes: readonly string[];
+  readonly toolCallIds: readonly string[];
+  readonly toolResponseIds: readonly string[];
+  readonly isSummary: boolean;
+  readonly replaced?: ChronologyReplacedSpan;
+}
+
+/**
+ * Build an ordered chronology trace, one entry per history item that carries
+ * a chronology marker. Items without a marker are skipped without throwing.
+ *
+ * The trace contains marker fields, the speaker, structural block descriptors,
+ * and the `replaced` span (from `metadata.chronologyReplaced`) when present.
+ * It NEVER contains message text, tool parameters, or tool results.
+ */
+export function buildChronologyTrace(
+  history: readonly IContent[],
+): ChronologyTraceEntry[] {
+  const entries: ChronologyTraceEntry[] = [];
+  for (const item of history) {
+    const marker = item.metadata?.chronology;
+    if (marker === undefined) {
+      continue;
+    }
+    const blockTypes: string[] = [];
+    const toolCallIds: string[] = [];
+    const toolResponseIds: string[] = [];
+    for (const block of item.blocks) {
+      blockTypes.push(block.type);
+      if (block.type === 'tool_call') {
+        toolCallIds.push(block.id);
+      } else if (block.type === 'tool_response') {
+        toolResponseIds.push(block.callId);
+      }
+    }
+    const entry: ChronologyTraceEntry = {
+      seq: marker.seq,
+      userTurn: marker.userTurn,
+      step: marker.step,
+      recordedAt: marker.recordedAt,
+      speaker: item.speaker,
+      blockTypes,
+      toolCallIds,
+      toolResponseIds,
+      isSummary: item.metadata?.isSummary === true,
+      ...(item.metadata?.chronologyReplaced !== undefined
+        ? { replaced: item.metadata.chronologyReplaced }
+        : {}),
+    };
+    entries.push(entry);
+  }
+  return entries;
+}

--- a/packages/core/src/services/history/historyTokenEstimation.test.ts
+++ b/packages/core/src/services/history/historyTokenEstimation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { serializeWireContentForEstimate } from './historyTokenEstimation.js';
+import type { IContent } from './IContent.js';
+
+const baseContent: IContent = {
+  speaker: 'ai',
+  blocks: [
+    { type: 'text', text: 'the quick brown fox' },
+    { type: 'tool_call', id: 'call-1', name: 'run', parameters: { a: 1 } },
+  ],
+};
+
+function withChronology(content: IContent): IContent {
+  return {
+    ...content,
+    metadata: {
+      ...content.metadata,
+      chronology: { seq: 12, userTurn: 4, step: 3, recordedAt: 1_759_000_000 },
+      chronologyReplaced: { fromSeq: 1, toSeq: 11, itemCount: 11 },
+    },
+  };
+}
+
+describe('serializeWireContentForEstimate', () => {
+  /** AC23 */
+  it('produces an identical string with and without a chronology marker', () => {
+    expect(serializeWireContentForEstimate(withChronology(baseContent))).toBe(
+      serializeWireContentForEstimate(baseContent),
+    );
+  });
+
+  it('excludes every metadata field, not just chronology', () => {
+    const withMetadata: IContent = {
+      ...baseContent,
+      metadata: { model: 'gpt-4.1', turnId: 'turn_abc', isSummary: true },
+    };
+
+    const serialized = serializeWireContentForEstimate(withMetadata);
+
+    expect(serialized).not.toContain('turn_abc');
+  });
+
+  it('retains the speaker so role changes still affect the estimate', () => {
+    const asHuman: IContent = { ...baseContent, speaker: 'human' };
+
+    expect(serializeWireContentForEstimate(asHuman)).not.toBe(
+      serializeWireContentForEstimate(baseContent),
+    );
+  });
+
+  it('retains block content so text changes still affect the estimate', () => {
+    const longer: IContent = {
+      ...baseContent,
+      blocks: [{ type: 'text', text: 'a much longer piece of text entirely' }],
+    };
+
+    expect(serializeWireContentForEstimate(longer)).not.toBe(
+      serializeWireContentForEstimate(baseContent),
+    );
+  });
+});

--- a/packages/core/src/services/history/historyTokenEstimation.ts
+++ b/packages/core/src/services/history/historyTokenEstimation.ts
@@ -92,6 +92,18 @@ export function blockToTokenFallbackString(block: ContentBlock): string {
   }
 }
 
+/**
+ * Serialize only the parts of an IContent that can reach a provider.
+ *
+ * `metadata` is deliberately excluded: no provider converter serializes it into
+ * a wire payload, so counting it inflates context estimates and makes
+ * compression fire early. This matters most for the client-side chronology
+ * marker (#1721), which is stamped on every history item.
+ */
+export function serializeWireContentForEstimate(content: IContent): string {
+  return JSON.stringify({ speaker: content.speaker, blocks: content.blocks });
+}
+
 /** Abstraction over HistoryService's tokenizer lookup. */
 export interface TokenizerProvider {
   getTokenizerForModel(modelName: string): ITokenizer;
@@ -235,7 +247,7 @@ export async function estimateTokensForContents(
 function fallbackEstimateForContent(content: IContent): number {
   let serialized = '';
   try {
-    serialized = JSON.stringify(content);
+    serialized = serializeWireContentForEstimate(content);
   } catch {
     // fall through to block-level fallback
   }

--- a/packages/providers/src/utils/chronologyProviderIsolation.test.ts
+++ b/packages/providers/src/utils/chronologyProviderIsolation.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { buildMessagesWithReasoning } from '../openai/OpenAIRequestBuilder.js';
+import { buildResponsesInputFromContent } from '../openai-responses/buildResponsesInputFromContent.js';
+import { buildResponsesRequest } from '../openai/buildResponsesRequest.js';
+import { convertToAnthropicMessages } from '../anthropic/AnthropicMessageNormalizer.js';
+import { convertToVercelMessages } from '../openai-vercel/messageConversion.js';
+import { buildProviderDumpBody } from './providerRequestConversion.js';
+
+/**
+ * Issue #1721 constraint C1.
+ *
+ * `metadata.chronology` / `metadata.chronologyReplaced` are client-side
+ * debugging markers stamped on EVERY history item. Providers reject unknown
+ * fields on message objects with HTTP 400 (z.ai already does this for empty
+ * human turns, issue #2410), so a leak here would break every request for the
+ * affected provider.
+ *
+ * `deepCloneWithoutCircularRefs` copies metadata, so chronology genuinely
+ * travels with IContent right up to each converter. These tests are the
+ * regression guard that it stops there.
+ *
+ * When a new provider wire converter is added, add it to CONVERTERS below.
+ */
+
+const SENTINEL_SEQ = 987_654;
+const SENTINEL_USER_TURN = 4_242;
+const SENTINEL_STEP = 3_131;
+const SENTINEL_RECORDED_AT = 1_759_123_456_789;
+const SENTINEL_FROM_SEQ = 111_222;
+const SENTINEL_TO_SEQ = 333_444;
+const SENTINEL_ITEM_COUNT = 555_666;
+
+const CHRONOLOGY_SENTINELS = [
+  String(SENTINEL_SEQ),
+  String(SENTINEL_USER_TURN),
+  String(SENTINEL_STEP),
+  String(SENTINEL_RECORDED_AT),
+  String(SENTINEL_FROM_SEQ),
+  String(SENTINEL_TO_SEQ),
+  String(SENTINEL_ITEM_COUNT),
+];
+
+function chronologyMetadata(): IContent['metadata'] {
+  return {
+    chronology: {
+      seq: SENTINEL_SEQ,
+      userTurn: SENTINEL_USER_TURN,
+      step: SENTINEL_STEP,
+      recordedAt: SENTINEL_RECORDED_AT,
+    },
+    chronologyReplaced: {
+      fromSeq: SENTINEL_FROM_SEQ,
+      toSeq: SENTINEL_TO_SEQ,
+      itemCount: SENTINEL_ITEM_COUNT,
+    },
+  };
+}
+
+/**
+ * A representative conversation covering every speaker and block type that can
+ * reach a provider, with chronology markers on every entry.
+ */
+function chronologyBearingHistory(): IContent[] {
+  return [
+    {
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'list the files' }],
+      metadata: chronologyMetadata(),
+    },
+    {
+      speaker: 'ai',
+      blocks: [
+        { type: 'text', text: 'I will list them.' },
+        {
+          type: 'tool_call',
+          id: 'call-1',
+          name: 'list_directory',
+          parameters: { path: '.' },
+        },
+      ],
+      metadata: chronologyMetadata(),
+    },
+    {
+      speaker: 'tool',
+      blocks: [
+        {
+          type: 'tool_response',
+          callId: 'call-1',
+          toolName: 'list_directory',
+          result: 'README.md',
+        },
+      ],
+      metadata: chronologyMetadata(),
+    },
+    {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'There is one file.' }],
+      metadata: { ...chronologyMetadata(), isSummary: true },
+    },
+  ];
+}
+
+function settingsStub(): SettingsService {
+  return { get: () => undefined } as unknown as SettingsService;
+}
+
+const CONVERTERS: ReadonlyArray<{
+  readonly name: string;
+  readonly convert: (history: IContent[]) => unknown;
+}> = [
+  {
+    name: 'OpenAI chat (buildMessagesWithReasoning)',
+    convert: (history) =>
+      buildMessagesWithReasoning(
+        history,
+        { settings: settingsStub() },
+        'openai',
+        undefined,
+      ),
+  },
+  {
+    name: 'OpenAI Responses (buildResponsesInputFromContent)',
+    convert: (history) => buildResponsesInputFromContent(history),
+  },
+  {
+    name: 'OpenAI Responses legacy (buildResponsesRequest)',
+    convert: (history) =>
+      buildResponsesRequest({ model: 'gpt-5', messages: history }),
+  },
+  {
+    name: 'Anthropic (convertToAnthropicMessages)',
+    convert: (history) =>
+      convertToAnthropicMessages(history, {
+        isOAuth: false,
+        reasoningEnabled: false,
+        config: undefined,
+        unprefixToolName: (name: string) => name,
+        logger: new DebugLogger('llxprt:test:chronology-isolation'),
+      }),
+  },
+  {
+    name: 'Vercel (convertToVercelMessages)',
+    convert: (history) => convertToVercelMessages(history),
+  },
+  {
+    name: 'dump body: openai',
+    convert: (history) =>
+      buildProviderDumpBody({ providerName: 'openai', history }),
+  },
+  {
+    name: 'dump body: anthropic',
+    convert: (history) =>
+      buildProviderDumpBody({ providerName: 'anthropic', history }),
+  },
+  {
+    // Also the Gemini wire-converter guard: buildProviderDumpBody delegates to
+    // the real convertHistoryToGeminiFormat. It is reached through the
+    // provider-neutral entry point so this file does not import a
+    // Gemini-prefixed symbol outside its architectural boundary.
+    name: 'dump body: gemini',
+    convert: (history) =>
+      buildProviderDumpBody({ providerName: 'gemini', history }),
+  },
+];
+
+describe('chronology markers never reach a provider wire payload (#1721 C1)', () => {
+  it.each(CONVERTERS)('$name emits no chronology key', ({ convert }) => {
+    const serialized = JSON.stringify(convert(chronologyBearingHistory()));
+
+    expect(serialized).not.toContain('chronology');
+  });
+
+  it.each(CONVERTERS)('$name emits no chronology values', ({ convert }) => {
+    const serialized = JSON.stringify(convert(chronologyBearingHistory()));
+
+    for (const sentinel of CHRONOLOGY_SENTINELS) {
+      expect(serialized).not.toContain(sentinel);
+    }
+  });
+
+  it.each(CONVERTERS)(
+    '$name still emits the conversation content',
+    ({ convert }) => {
+      const serialized = JSON.stringify(convert(chronologyBearingHistory()));
+
+      expect(serialized).toContain('list the files');
+    },
+  );
+});

--- a/packages/providers/src/utils/dumpContext.test.ts
+++ b/packages/providers/src/utils/dumpContext.test.ts
@@ -9,7 +9,12 @@ import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { Storage } from '@vybestack/llxprt-code-settings';
-import { dumpContext, redactSensitiveData, shouldDump } from './dumpContext.js';
+import {
+  dumpContext,
+  dumpRequestContext,
+  redactSensitiveData,
+  shouldDump,
+} from './dumpContext.js';
 
 // Sandbox the config home before Storage.getGlobalCacheDir() is evaluated,
 // so tests do not write to the real user data directory.
@@ -441,6 +446,90 @@ describe('dumpContext', () => {
       expect(dump.request.headers).toBeDefined();
       expect(dump.request.body).toBeDefined();
       expect(typeof dump.request.body).toBe('object');
+    });
+  });
+
+  describe('chronology sidecar (#1721)', () => {
+    const request = {
+      url: 'https://api.openai.com/v1/chat/completions',
+      method: 'POST',
+      body: { model: 'gpt-4', messages: [{ role: 'user', content: 'Test' }] },
+    };
+
+    const chronology = [
+      {
+        seq: 1,
+        userTurn: 1,
+        step: 1,
+        recordedAt: 1_759_000_000_000,
+        speaker: 'human' as const,
+        blockTypes: ['text'],
+        toolCallIds: [],
+        toolResponseIds: [],
+        isSummary: false,
+      },
+    ];
+
+    async function writeDumpWithChronology(): Promise<Record<string, unknown>> {
+      const result = await dumpRequestContext(
+        request,
+        'openai',
+        undefined,
+        chronology,
+      );
+      createdFiles.push(result.requestFilename);
+      const content = await fs.readFile(
+        path.join(testDumpDir, result.requestFilename),
+        'utf-8',
+      );
+      return JSON.parse(content) as Record<string, unknown>;
+    }
+
+    it('writes the trace at the top level of the dump file', async () => {
+      const dump = await writeDumpWithChronology();
+
+      expect(dump['chronology']).toStrictEqual(chronology);
+    });
+
+    it('leaves the dumped request structurally identical to the input', async () => {
+      // Structural equality rather than a substring scan: this fails if the
+      // trace is smuggled into the request under ANY key, not just one
+      // literally named "chronology". The expected value is rebuilt from a
+      // literal so an in-place mutation of the shared input cannot hide.
+      const dump = await writeDumpWithChronology();
+
+      expect(dump['request']).toStrictEqual({
+        url: 'https://api.openai.com/v1/chat/completions',
+        method: 'POST',
+        body: {
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'Test' }],
+        },
+      });
+    });
+
+    it('does not mutate the caller request when writing the sidecar', async () => {
+      await writeDumpWithChronology();
+
+      expect(request).toStrictEqual({
+        url: 'https://api.openai.com/v1/chat/completions',
+        method: 'POST',
+        body: {
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'Test' }],
+        },
+      });
+    });
+
+    it('omits the key entirely when no trace is supplied', async () => {
+      const result = await dumpRequestContext(request, 'openai');
+      createdFiles.push(result.requestFilename);
+      const content = await fs.readFile(
+        path.join(testDumpDir, result.requestFilename),
+        'utf-8',
+      );
+
+      expect(JSON.parse(content)).not.toHaveProperty('chronology');
     });
   });
 });

--- a/packages/providers/src/utils/dumpContext.ts
+++ b/packages/providers/src/utils/dumpContext.ts
@@ -8,6 +8,7 @@ import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { Storage } from '@vybestack/llxprt-code-settings';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { ChronologyTraceEntry } from '@vybestack/llxprt-code-core/services/history/historyChronology.js';
 
 const logger = new DebugLogger('llxprt:core:dumpContext');
 
@@ -32,6 +33,13 @@ export interface DumpData {
   request?: DumpRequest;
   response?: DumpResponse;
   relatedRequestFile?: string;
+  /**
+   * Client-side chronology trace for the history the request was built from
+   * (#1721). This is a SIBLING of `request` and is deliberately never placed
+   * inside `request.body`: the body must remain exactly what the provider
+   * receives, and providers reject unknown fields with HTTP 400.
+   */
+  chronology?: readonly ChronologyTraceEntry[];
 }
 
 /**
@@ -121,6 +129,7 @@ export async function dumpRequestContext(
   request: DumpRequest,
   provider: string,
   baseId?: string,
+  chronology?: readonly ChronologyTraceEntry[],
 ): Promise<DumpRequestResult> {
   const dumpDir = path.join(Storage.getGlobalCacheDir(), 'dumps');
   await fs.mkdir(dumpDir, { recursive: true });
@@ -131,10 +140,12 @@ export async function dumpRequestContext(
 
   const redactedRequest = redactSensitiveData(request);
 
-  const data = {
+  const data: DumpData = {
     provider,
     timestamp: new Date().toISOString(),
     request: redactedRequest,
+    // Sibling of `request`, never inside `request.body` (#1721).
+    ...(chronology ? { chronology } : {}),
   };
 
   await fs.writeFile(filepath, JSON.stringify(data, null, 2), 'utf-8');

--- a/project-plans/20260731-issue1721/PLAN.md
+++ b/project-plans/20260731-issue1721/PLAN.md
@@ -1,0 +1,357 @@
+# PLAN-20260731-CHRONOLOGY — Stable chronology markers in chat history (Issue #1721)
+
+## 1. Problem statement
+
+When provider requests are retried, and when tool calls interleave with normal
+messages, there is no reliable way to reconstruct the exact order of history
+events or to correlate "what the model saw" with what happened in the client.
+
+Grounded findings (evidence in `RESEARCH.md`):
+
+- `ContentMetadata` has **no ordinal / sequence concept at all**.
+- `metadata.turnId` is `turn_<randomUUID()>` — unique but **not ordered**, and a
+  new UUID is minted per construction site (user input, AI turn, restored
+  history), so it does not correlate a user turn with its downstream tool
+  round-trips.
+- `metadata.timestamp` is **not set on production AI/tool history items** — only
+  tests and explicit `createUserMessage` callers set it.
+- `metadata.id` conflates tool-call ID canonicalisation with OpenAI Responses
+  `previous_response_id` identity; it is absent on most AI turns.
+- Array position is the only ordering signal, and **compression destroys it**:
+  `CompressionHandler` does `historyService.clear()` then re-`add()`s the new
+  history, and summary entries carry no trace of what they replaced.
+
+## 2. Owner constraints (issue thread, @acoliver)
+
+> "(BTW I'm not against stamps per se you just cant send them to the provider
+> and we will munge them in summarization)"
+
+Three hard constraints, all are acceptance criteria:
+
+1. **C1 — Chronology must never reach a provider wire payload.** Providers reject
+   unknown fields in message objects with HTTP 400 (z.ai already does this for
+   empty human turns per issue #2410). A leaked `chronology` key on any message
+   would break every request for that provider. This is the single highest risk
+   of the change and is guarded by an explicit regression test over **every**
+   wire converter, not by inspection.
+2. **C2 — Chronology must survive summarization/compression**, and where items
+   are destroyed by summarization, the summary must record what span it
+   replaced.
+3. **C3 — Chronology must not inflate token accounting.** Three fallback
+   estimators serialize the *whole* `IContent` (metadata included) to estimate
+   tokens. Adding a ~90-character marker per history item would silently inflate
+   context estimates and trigger compression early. Since metadata is never sent,
+   these estimators must serialize only the wire-relevant `{ speaker, blocks }`.
+
+## 3. Non-goals (explicit, will not be implemented)
+
+| # | Non-goal | Rationale |
+|---|---|---|
+| NG1 | Sending chronology to providers / rendering it into prompts | Explicitly vetoed by the owner. The issue text mentions "surfaced to prompt rendering and provider payloads" — the owner overrode that. |
+| NG2 | New telemetry event fields or OTel schema changes | Separate subsystem; would be a workflow/dependency-class change requiring approval. |
+| NG3 | Threading `HistoryService` into provider SDK execution so `/dumpcontext on|error` dumps get a chronology sidecar | Large cross-package plumbing change through 4 provider execution paths. Out of budget. `/dumpcontext now` (which already has history access) is covered. |
+| NG4 | Redesigning or replacing `turnId`, `metadata.id`, or `metadata.timestamp` semantics | Pre-existing behaviour, widely depended on. Chronology is purely additive. |
+| NG5 | Persisting chronology into a session/resume file format | No file-format change in scope. Markers are per-`HistoryService`-instance and reconciled from whatever markers are present on restored items. |
+| NG6 | A user-facing settings/config toggle for chronology | Stamping is unconditional and free (three integer fields); a toggle would add config surface for no benefit. |
+| NG7 | Fixing the inconsistent `metadata.timestamp` population | Out of scope; `chronology.recordedAt` supplies a reliable time instead. |
+| NG8 | Changing `HistoryService.clear()` to reset chronology counters | Non-reuse of `seq` is the point of the feature. Documented in AC2. |
+
+## 4. Design
+
+### 4.1 Data shape
+
+Added to `packages/core/src/services/history/IContent.ts`:
+
+```ts
+/** Span of chronology sequence numbers that a summary entry replaced. */
+export interface ChronologyReplacedSpan {
+  readonly fromSeq: number;   // lowest seq destroyed by compression
+  readonly toSeq: number;     // highest seq destroyed by compression
+  readonly itemCount: number; // how many history items were destroyed
+}
+
+/** Client-side ordering marker. NEVER sent to a provider. */
+export interface ChronologyMarker {
+  readonly seq: number;       // 1-based, monotonic per HistoryService, never reused
+  readonly userTurn: number;  // 0 before the first human turn, then 1-based
+  readonly step: number;      // 1-based ordinal within the current userTurn
+  readonly recordedAt: number;// epoch ms at the moment of insertion
+}
+
+export interface ContentMetadata {
+  // ...existing fields...
+  /** Client-side chronology marker. Never serialised to a provider. */
+  chronology?: ChronologyMarker;
+  /**
+   * On a summary entry, the span of chronology sequence numbers that this
+   * summary replaced. Never serialised to a provider.
+   */
+  chronologyReplaced?: ChronologyReplacedSpan;
+}
+```
+
+`chronologyReplaced` is deliberately a **sibling** of `chronology`, not a field
+inside `ChronologyMarker`. Compression constructs its summary entry before that
+entry has ever entered `HistoryService`, so it has no marker yet; keeping the
+span separate lets the span be attached by a pure function and the marker be
+attached later by the stamper, with neither knowing about the other.
+
+### 4.2 Stamping engine
+
+New pure module `packages/core/src/services/history/historyChronology.ts`:
+
+```ts
+export class ChronologyStamper {
+  constructor(now?: () => number);
+  /** Returns content carrying a chronology marker, preserving any existing one. */
+  stamp(content: IContent): IContent;
+  /** Returns content carrying the given marker verbatim (used for replacements). */
+  inherit(content: IContent, marker: ChronologyMarker): IContent;
+}
+```
+
+Rules:
+
+- **Fresh stamp** (`content.metadata.chronology` absent):
+  - if `speaker === 'human'` → `currentUserTurn += 1`, `nextStep = 1`
+  - `marker = { seq: nextSeq++, userTurn: currentUserTurn, step: nextStep++, recordedAt: now() }`
+- **Preserve + reconcile** (marker already present — this is the compression
+  write-back and restored-history case):
+  - `currentUserTurn = max(currentUserTurn, marker.userTurn)`
+  - `nextSeq = max(nextSeq, marker.seq + 1)`
+  - if `marker.userTurn === currentUserTurn` → `nextStep = max(nextStep, marker.step + 1)`
+  - content is returned unchanged (identity preserved where possible).
+- Pure w.r.t. the caller's object: never mutates input; returns a shallow copy
+  with merged metadata only when a marker is actually added.
+
+Rationale for preserve-not-restamp: `CompressionHandler` applies results by
+`clear()` + `add()` for every retained item. Restamping there would renumber the
+entire surviving history on every compression, which is exactly the "munging"
+the owner warned about.
+
+### 4.3 Invariant
+
+**INV-1: every item in `HistoryService`'s backing history array carries
+`metadata.chronology`.**
+
+Research identified 4 mutation paths that bypass `addInternal`. Each is handled:
+
+| Path | Handling |
+|---|---|
+| `addInternal` (covers `add`/`addAll`/`recordTurn`/`merge`/`fromJSON`/compression write-back/queued ops) | `stamp()` before push |
+| `validateAndFix` (splices synthetic tool messages) | `stamp()` the synthetic message before splice |
+| `applyDensityResult` → `applyDensityMutations` (index replacement) | replacement **inherits** the replaced item's marker (same logical position) |
+| `summarizeOldHistory` (whole-array replacement from a caller-supplied fn) | `stamp()` each item of the returned array (preserves markers on retained items, stamps the new summary) |
+| `replaceToolResponseBlock` | already preserves `metadata` via `{ ...entry, blocks }` — no change, covered by test |
+
+### 4.4 Compression span annotation (constraint C2)
+
+New pure helper in core:
+`packages/core/src/services/history/historyChronology.ts`
+
+```ts
+export function annotateCompressionSpan(
+  previousHistory: readonly IContent[],
+  newHistory: readonly IContent[],
+): IContent[];
+```
+
+- Computes `destroyed` = the set of `metadata.chronology.seq` values present in
+  `previousHistory` but absent from `newHistory` (the items the strategy
+  destroyed). Entries without a marker are ignored on both sides.
+- If `destroyed` is empty, returns `newHistory` items unchanged.
+- Otherwise, for every entry with `metadata.isSummary === true` that does not
+  already carry `metadata.chronologyReplaced`, returns a copy with
+  `chronologyReplaced: { fromSeq: min(destroyed), toSeq: max(destroyed), itemCount: destroyed.size }`.
+- If there is no summary entry (e.g. `TopDownTruncationStrategy`, which drops
+  without summarising), returns items unchanged — the loss is still visible as a
+  gap in the `seq` series.
+
+Applied once, in `CompressionHandler`'s `applyResult` callback, immediately
+before `clear()` + `add()`. The subsequent `add()` calls stamp `chronology` onto
+the summary entry, so the finished entry carries both fields. One call site
+covers OneShot, MiddleOut, TopDown and any future strategy.
+
+### 4.5 Constraint C1 — provider isolation guard (400-safety)
+
+The wire boundary is already safe by construction: every converter builds
+provider messages by explicit field picks from `content.blocks`, never by
+spreading `content` or `content.metadata`. Audit result:
+
+| Converter | File | Metadata handling |
+|---|---|---|
+| OpenAI chat `buildMessagesWithReasoning` | `providers/src/openai/OpenAIRequestBuilder.ts` | no `metadata` reference at all |
+| OpenAI Responses `buildResponsesInputFromContent` | `providers/src/openai-responses/buildResponsesInputFromContent.ts` | no `metadata` reference at all |
+| OpenAI Responses legacy `buildResponsesRequest` | `providers/src/openai/buildResponsesRequest.ts:321` | explicit pick of `metadata.usage` only |
+| Anthropic `convertToAnthropicMessages` | `providers/src/anthropic/AnthropicMessageNormalizer.ts:209` | reads `metadata.model` for a decision; never serialises |
+| Gemini `convertHistoryToGeminiFormat` | `providers/src/gemini/GeminiMessageConverter.ts:129` | switches on `speaker`, reads `blocks` only |
+| Vercel `convertToVercelMessages` | `providers/src/openai-vercel/messageConversion.ts:271` | reads `metadata.role` for a decision; builds messages from blocks |
+| Gemini neutral `ContentConverters.toGeminiContent` | `core/src/services/history/ContentConverters.ts:266` | builds `{ role, parts }` from blocks |
+
+`deepCloneWithoutCircularRefs` (`historyCloneUtils.ts:29-35`) shallow-copies
+metadata, so chronology *does* travel with IContent right up to each converter —
+which is exactly why the guard must be a test and not an assumption.
+
+There is **no existing test guarding this**. We add a behavioural regression
+guard that feeds chronology-bearing history through each of the seven real
+converters above (the same functions the live request paths use) and asserts the
+serialised output contains no `chronology` key and none of its scalar values.
+The guard is written so that adding a new converter without updating the guard
+is visible: it asserts against a named list of converters.
+
+### 4.6 Constraint C3 — token-accounting isolation
+
+Three sites serialize the whole `IContent` (metadata included) for estimation:
+
+- `core/src/services/history/historyTokenEstimation.ts:238`
+  (`fallbackEstimateForContent`)
+- `agents/src/core/clientHelpers.ts:32` (`findCompressSplitPoint` char counts)
+- `agents/src/compression/compressionBudgeting.ts:127`
+  (`estimateFallbackContentTokens`)
+
+Because metadata is never sent, counting it was always an over-estimate; adding
+chronology makes the error material (~90 chars ≈ 20 tokens per history item).
+
+Fix: export a single helper from `historyTokenEstimation.ts`
+
+```ts
+/** Serialize only the parts of an IContent that can reach a provider. */
+export function serializeWireContentForEstimate(content: IContent): string;
+```
+
+returning `JSON.stringify({ speaker: content.speaker, blocks: content.blocks })`,
+and use it at all three sites. This is the minimal correct fix and is required by
+our change — it is not an opportunistic refactor.
+
+`packages/providers/src/utils/contentPreview.ts:62` also stringifies content, but
+only to build a debug log preview, so it is left alone.
+
+### 4.7 Surfacing (debugging/tracing)
+
+1. `HistoryService.getChronologyTrace(): ChronologyTraceEntry[]` — an ordered,
+   compact, JSON-safe projection: `{ seq, userTurn, step, recordedAt, speaker,
+   blockTypes, toolCallIds, toolResponseIds, isSummary, replaced }`. No message
+   text, so the trace itself is safe to share.
+2. `curationDebugLogger.logContentAdded` gains the chronology triple, so
+   `LLXPRT_DEBUG=llxprt:history:*` shows insertion order including retries and
+   tool round-trips.
+3. `/dumpcontext now` writes the trace as a **sibling** key in the dump file
+   (`DumpData.chronology`), never inside `request.body`. `dumpRequestContext`
+   gains an optional `chronology` parameter; the CLI command supplies it.
+
+## 5. Acceptance matrix
+
+Every row is a required behaviour with a behavioural test. "Evidence" names the
+test file that must fail without the production change.
+
+| ID | Behaviour | Evidence file |
+|---|---|---|
+| AC1 | Adding content to `HistoryService` stamps `metadata.chronology` with `seq` starting at 1 and incrementing by 1 per item | `HistoryService.chronology.test.ts` |
+| AC2 | `seq` is never reused: after `clear()`, the next added item's `seq` continues from the previous maximum | `HistoryService.chronology.test.ts` |
+| AC3 | `userTurn` increments only on `human` items; the following `ai`/`tool` items share that `userTurn` | `HistoryService.chronology.test.ts` |
+| AC4 | `step` is 1 for the human item of a turn and increments across the ai/tool round-trips of that turn, then resets on the next human item | `HistoryService.chronology.test.ts` |
+| AC5 | `recordedAt` is populated with the insertion time on every item | `HistoryService.chronology.test.ts` |
+| AC6 | Content already carrying a marker is re-added unchanged (marker preserved, not renumbered) | `historyChronology.test.ts` |
+| AC7 | After preserving a marker, subsequently added fresh content gets a `seq` greater than every preserved `seq` (no collision) | `historyChronology.test.ts` |
+| AC8 | INV-1: every item has a marker after `validateAndFix()` inserts synthetic tool messages | `HistoryService.chronology.test.ts` |
+| AC9 | INV-1: every item has a marker after `applyDensityResult()`, and a density replacement inherits the replaced item's `seq`/`userTurn`/`step` | `HistoryService.chronology.test.ts` |
+| AC10 | INV-1: every item has a marker after `summarizeOldHistory()`, with retained items keeping their original `seq` | `HistoryService.chronology.test.ts` |
+| AC11 | `replaceToolResponseBlock()` preserves the entry's chronology marker | `HistoryService.chronology.test.ts` |
+| AC12 | A compression result that destroys items annotates the summary entry with `chronologyReplaced: { fromSeq, toSeq, itemCount }` covering exactly the destroyed `seq` values | `historyChronology.test.ts` |
+| AC13 | A compression result that destroys nothing leaves the summary entry without `chronologyReplaced` | `historyChronology.test.ts` |
+| AC14 | A compression result with no summary entry (truncation-only) is returned unchanged | `historyChronology.test.ts` |
+| AC15 | `CompressionHandler` write-back annotates the summary entry and preserves retained items' markers end-to-end | `CompressionHandler.chronology.test.ts` (agents) |
+| AC16 | C1: OpenAI chat wire messages built from chronology-bearing history contain no chronology data | `chronologyProviderIsolation.test.ts` (providers) |
+| AC17 | C1: OpenAI Responses wire input (both `buildResponsesInputFromContent` and legacy `buildResponsesRequest`) contains no chronology data | `chronologyProviderIsolation.test.ts` (providers) |
+| AC18 | C1: Anthropic wire messages contain no chronology data | `chronologyProviderIsolation.test.ts` (providers) |
+| AC19 | C1: Gemini wire contents contain no chronology data | `chronologyProviderIsolation.test.ts` (providers) |
+| AC20 | C1: Vercel wire messages contain no chronology data | `chronologyProviderIsolation.test.ts` (providers) |
+| AC21 | C1: `ContentConverters.toGeminiContent` output contains no chronology data | `ContentConverters.test.ts` (core, extend) |
+| AC22 | C1: `buildProviderDumpBody` output for openai/anthropic/gemini contains no chronology data (it delegates to the real wire converters) | `chronologyProviderIsolation.test.ts` (providers) |
+| AC23 | C3: token estimate for a chronology-bearing item equals the estimate for the same item without a marker, on all three fallback estimators | `historyTokenEstimation.test.ts` (core), `compressionBudgeting` + `clientHelpers` tests (agents) |
+| AC24 | C3: `findCompressSplitPoint` returns the same split index for history with and without chronology markers | `clientHelpers` test (agents) |
+| AC25 | `getChronologyTrace()` returns one ordered entry per history item with the marker fields and structural descriptors, and no message text, tool parameters or tool results | `HistoryService.chronology.test.ts` |
+| AC26 | `/dumpcontext now` writes the chronology trace at the top level of the dump file and **not** inside `request.body` | `dumpcontextCommand` test (cli) + `dumpContext` test (providers) |
+
+## 6. Bounded vertical slices
+
+| Slice | Content | ACs |
+|---|---|---|
+| S1 | `ChronologyMarker`/`ChronologyReplacedSpan` types + `ChronologyStamper` + `annotateCompressionSpan` + `buildChronologyTrace` (pure module, core) | AC6, AC7, AC12, AC13, AC14 |
+| S2 | `HistoryService` integration across all five mutation paths + `getChronologyTrace()` + debug logging | AC1–AC5, AC8–AC11, AC25 |
+| S3 | C3 token-accounting isolation: `serializeWireContentForEstimate` + its three call sites | AC23, AC24 |
+| S4 | `CompressionHandler` span annotation at write-back | AC15 |
+| S5 | C1 provider isolation regression guard across all seven converters | AC16–AC22 |
+| S6 | `/dumpcontext now` sidecar | AC26 |
+| S7 | Docs (`docs/debug-logging.md` + `docs/troubleshooting.md` pointer) | — |
+
+Ordering note: **S3 and S5 must land in the same commit as S1/S2 or earlier in
+the branch than any release**, because S1/S2 alone introduce the C1 and C3
+exposure that S5 and S3 respectively guard against.
+
+## 7. Expected paths
+
+Production:
+
+- `packages/core/src/services/history/IContent.ts` (types)
+- `packages/core/src/services/history/historyChronology.ts` (new)
+- `packages/core/src/services/history/HistoryService.ts` (integration)
+- `packages/core/src/services/history/densityValidation.ts` (inherit marker on replacement)
+- `packages/core/src/services/history/curationDebugLogger.ts` (log chronology)
+- `packages/core/src/services/history/historyTokenEstimation.ts` (C3 helper + use)
+- `packages/core/package.json` (subpath export for the new module — no dependency change)
+- `packages/agents/src/core/clientHelpers.ts` (C3)
+- `packages/agents/src/compression/compressionBudgeting.ts` (C3)
+- `packages/agents/src/compression/CompressionHandler.ts` (span annotation)
+- `packages/providers/src/utils/dumpContext.ts` (optional sidecar field)
+- `packages/cli/src/ui/commands/dumpcontextCommand.ts` (supply the sidecar)
+- `docs/debug-logging.md`
+
+Tests:
+
+- `packages/core/src/services/history/historyChronology.test.ts` (new)
+- `packages/core/src/services/history/HistoryService.chronology.test.ts` (new)
+- `packages/core/src/services/history/historyTokenEstimation.test.ts` (new or extend)
+- `packages/core/src/services/history/ContentConverters.test.ts` (extend)
+- `packages/agents/src/compression/__tests__/CompressionHandler.chronology.test.ts` (new)
+- `packages/agents/src/compression/__tests__/chronologyTokenNeutrality.test.ts` (new)
+- `packages/providers/src/utils/chronologyProviderIsolation.test.ts` (new)
+- `packages/providers/src/utils/dumpContext.test.ts` (extend)
+- `packages/cli/src/ui/commands/dumpcontextCommand.test.ts` (extend)
+
+Plan artefacts:
+
+- `project-plans/20260731-issue1721/PLAN.md`
+- `project-plans/20260731-issue1721/RESEARCH.md`
+
+## 8. Scope ledger
+
+| Metric | Budget | Planned |
+|---|---|---|
+| Files touched | ≤ 25 (review > 25, stop > 40) | ~24 |
+| Net changed lines | ≤ 1500 (review > 1500, stop > 2500) | ~1200 |
+| New public abstractions | approval required | `ChronologyMarker`, `ChronologyReplacedSpan`, `ChronologyStamper`, `annotateCompressionSpan`, `buildChronologyTrace`, `ChronologyTraceEntry`, `getChronologyTrace`, `serializeWireContentForEstimate` — all required by the accepted behaviour and declared here up front |
+| New dependencies | none | none |
+| Workflow / agent-memory / quality-tool changes | none | none |
+
+Stop-for-approval triggers (restated for implementers):
+
+- adding a subsystem or public abstraction not listed above
+- any workflow, agent-memory, quality-tool or dependency change
+- pulling an unrelated refactor or test move into scope
+- implementing behaviour outside the acceptance matrix
+- exceeding 40 files or 2500 net changed lines
+
+## 9. Hard engineering constraints for implementers
+
+- TDD: each AC gets a failing behavioural test first. No mock theatre; no
+  mocking the component under test; no asserting that mocks were called.
+- No `any`, no non-null assertions in new code; `unknown` + type guards.
+- No new `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `@ts-nocheck`.
+- No loosening of any lint/complexity/size threshold and no ESLint severity
+  downgrades. Fix the underlying issue instead.
+- Immutability: never mutate an input `IContent`; return copies.
+- Fail fast over defence in depth: do not wrap chronology logic in try/catch
+  swallows or add speculative guards for internally-controlled data.
+- Full verification before hand-back: `npm run test`, `npm run lint`,
+  `npm run typecheck`, `npm run format`, `npm run build`, and the CLI smoke.

--- a/project-plans/20260731-issue1721/RESEARCH.md
+++ b/project-plans/20260731-issue1721/RESEARCH.md
@@ -1,0 +1,154 @@
+# RESEARCH — Issue #1721 chronology markers
+
+Evidence gathered against `main` @ `52ae41f78`. Line numbers are from that tree.
+
+## A. History mutation paths (`HistoryService`)
+
+Backing array: `private history: IContent[]`
+(`packages/core/src/services/history/HistoryService.ts:78`).
+
+| Path | Operation | Routes through `addInternal`? |
+|---|---|---|
+| `add()` → `addInternal()` (`HistoryService.ts:285`, `:300`) | push | yes |
+| `addAll()` (`:394`) | push per item | yes (via `add`) |
+| `recordTurn()` (`:730`) | push | yes |
+| `merge()` (`:805`) | push | yes |
+| `static fromJSON()` (`:845`) | push | yes |
+| queued ops flushed by `endCompression()` (`:855`) | push | yes |
+| `validateAndFix()` (`:763`) | `splice` insert of synthetic tool messages | **no** |
+| `applyDensityResult()` (`:429`) → `applyDensityMutations()` (`densityValidation.ts`) | index assignment + `splice` removal | **no** |
+| `replaceToolResponseBlock()` (`:455`) | index assignment, spreads `{ ...entry, blocks }` so metadata survives | **no** (but metadata-safe) |
+| `summarizeOldHistory()` (`:820`) | whole-array replacement | **no** |
+| `clear()` / `clearInternal()` (`:607`, `:621`) | array replacement with `[]` | n/a |
+| `pop()` (`:672`), `removeLastIfMatches()` (`:662`), `dispose()` (`:586`) | removal | n/a |
+
+`getRawHistory()` (`:538`) returns the live array typed `readonly`;
+`getAll()` (`:579`) returns a shallow copy. No production caller was found that
+pushes/splices the returned array — all mutation goes through the methods above.
+
+## B. Provider wire boundary
+
+Real wire converters:
+
+- OpenAI chat: `buildMessagesWithReasoning`
+  (`packages/providers/src/openai/OpenAIRequestBuilder.ts`)
+- OpenAI Responses: `buildResponsesInputFromContent`
+  (`packages/providers/src/openai-responses/buildResponsesInputFromContent.ts`)
+  and `buildResponsesRequest` (`packages/providers/src/openai/buildResponsesRequest.ts`)
+- Anthropic: `convertToAnthropicMessages`
+  (`packages/providers/src/anthropic/AnthropicMessageNormalizer.ts`)
+- Gemini: `convertHistoryToGeminiFormat`
+  (`packages/providers/src/gemini/GeminiMessageConverter.ts:129`)
+- Gemini neutral: `ContentConverters.toGeminiContent`
+  (`packages/core/src/services/history/ContentConverters.ts:266`)
+
+**Finding: no converter spreads `content` or `content.metadata` into a wire
+payload.** Every provider message is built from explicit field picks off
+`content.blocks`. The only metadata field that crosses the wire is:
+
+```
+packages/providers/src/openai/buildResponsesRequest.ts:321
+      if (msg.metadata?.usage) {
+:322    result.usage = msg.metadata.usage;
+```
+
+which is an explicit pick, not a spread. Metadata is read for *decisions* in two
+more places without being serialised:
+`AnthropicMessageNormalizer.ts:209` (`metadata.model`, cross-model thinking
+strip) and `openAIResponsesStateful.ts:61-63,88` (`responsesStored`/`id` for
+`previous_response_id`).
+
+`deepCloneWithoutCircularRefs` (`historyCloneUtils.ts:29-35`) shallow-copies
+metadata, so metadata does travel with IContent up to the converter boundary —
+but is dropped there.
+
+**Gap: no existing test asserts metadata is excluded from wire payloads.**
+
+`buildProviderDumpBody` (`packages/providers/src/utils/providerRequestConversion.ts:127`)
+delegates to the same three real converters for openai/anthropic/gemini, and
+falls back to `{ history: params.history }` (raw IContent, metadata included) for
+unrecognised providers — this is a local dump file, not a wire payload.
+
+## C. Compression / summarization
+
+`CompressionHandler.performCompression()` applies results with:
+
+```
+this.historyService.clear();
+for (const content of newHistory) {
+  this.historyService.add(content, this.runtimeContext.state.model);
+}
+```
+
+so every retained item re-enters through `addInternal`.
+
+Summary entries are constructed at `OneShotStrategy.ts:210` and
+`MiddleOutStrategy.ts:546` with `metadata: { isSummary: true, synthetic: true,
+reason: 'compression-state-snapshot' }` — **no `turnId`, no `timestamp`, no
+reference to what was destroyed**. `TopDownTruncationStrategy` produces no
+summary at all (deterministic drop). `HighDensityStrategy` replaces tool
+responses with metadata-only stubs via `applyDensityResult`.
+
+Retained items keep their object identity and metadata; only their array indices
+shift. So a marker stored on the item survives; an index-based scheme would not.
+
+## D. Retries
+
+`retryWithBackoff` (`packages/core/src/utils/retry.ts`),
+`RetryOrchestrator` (`packages/providers/src/RetryOrchestrator.ts`), and
+`DirectMessageProcessor._executeWithRetry` are the retry surfaces. History is
+re-read fresh per attempt via `getCuratedForProvider()`; pending user content is
+added once, not per attempt. So retries produce repeated *sends* of the same
+history items — which is precisely why a per-item insertion marker (rather than a
+per-request counter) is what disambiguates the trace.
+
+## E. Existing tracing surfaces
+
+- `/dumpcontext now` → `dumpImmediateContext()`
+  (`packages/cli/src/ui/commands/dumpcontextCommand.ts:100-130`) reads
+  `historyService.getAll()` and writes
+  `{ url: 'immediate-context-dump', method: 'DUMP', body }` via
+  `dumpRequestContext`. The dump file shape is
+  `{ provider, timestamp, request }` (`packages/providers/src/utils/dumpContext.ts:117-140`).
+  A sibling key can be added without touching `request.body`.
+- `/dumpcontext on|error` dumps happen inside provider SDK execution
+  (`dumpSDKContext.ts`), which has no `HistoryService` access — sidecar there
+  would require cross-package plumbing (declared NG3).
+- Debug namespaces: `llxprt:history:service` (`HistoryService.ts:84`),
+  `llxprt:content:converters`, `llxprt:core:dumpContext`.
+  `curationDebugLogger.logContentAdded` already logs speaker, block types, tool
+  ids and `metadata.id` — the natural place to add chronology.
+- Telemetry `ConversationRequestEvent` has `turn_number`/`prompt_id`
+  (`packages/telemetry/src/telemetry/events/conversation-events.ts`), but these
+  are per-request session counters, not per-history-item. Declared NG2.
+
+## F. Existing partial implementations
+
+- `generateTurnKey()` (`HistoryService.ts:163`) → `turn_${randomUUID()}`.
+  Unique, **not ordered**. Minted independently at
+  `ConversationManager.ts:134,474,498,533,546`, `ChatSessionFactory.ts:189`,
+  `DirectMessageProcessor.ts:248`, `streamRequestHelpers.ts:64`,
+  `ContentConverters.ts:503`. Summary entries get none.
+- `metadata.timestamp` (`IContent.ts:44`): only set when a caller explicitly
+  passes it to `createUserMessage`; production AI/tool construction sites do not
+  set it.
+- `metadata.id` (`IContent.ts:53`): produced by `getIdGeneratorCallback`
+  (`HistoryService.ts:157`) → `canonicalizeToolCallId`, i.e. a tool-call ID
+  scheme, and separately overloaded as the OpenAI Responses response id. Not
+  present on most AI turns, not ordered.
+- **No sequence/ordinal/step/position field exists anywhere on `ContentMetadata`.**
+
+## G. Test conventions
+
+| Package | Runner |
+|---|---|
+| core | vitest (`vitest run`) |
+| agents | vitest |
+| providers | bun test (`bun ../../scripts/run_bun_tests.ts --workspace providers`), `test:vitest` also available |
+| cli | vitest |
+
+`dev-docs/RULES.md` mandates: TDD (failing test first), behaviour over
+implementation, no mock theatre (never mock the component under test, never mock
+the expected output, never assert that mocks were called), infrastructure-only
+mocking, TypeScript strict (no `any`, no assertions), immutability, never
+enshrine a bug as a passing test, Arrange-Act-Assert, DRY setup.


### PR DESCRIPTION
Fixes #1721

## Problem

There is no reliable way to reconstruct the order of history events, which is exactly what you need when a request was retried or when tool calls interleave with ordinary messages. Nothing in `ContentMetadata` carries an ordinal:

- `metadata.turnId` is `turn_<randomUUID()>` — unique but **unordered**, and a fresh UUID is minted independently at each construction site, so it does not tie a user turn to its downstream tool round-trips.
- `metadata.timestamp` is **not set** on production AI/tool history items; only callers that explicitly pass it to `createUserMessage` get one.
- `metadata.id` conflates tool-call ID canonicalisation with the OpenAI Responses `previous_response_id`, and is absent on most AI turns.
- Array position is the only remaining signal, and compression destroys it: `CompressionHandler` does `clear()` then re-`add()`s, and summary entries carried no trace of what they replaced.

## What this adds

`HistoryService` stamps every item it accepts with a chronology marker:

| Field | Meaning |
| --- | --- |
| `seq` | Monotonic insertion ordinal, never reused (including across `/clear`) |
| `userTurn` | Which user turn the item belongs to (`0` before the first prompt) |
| `step` | Position within that user turn, so tool round-trips stay ordered |
| `recordedAt` | Epoch ms when the item entered history |

Markers are **preserved, not renumbered**, when an item re-enters history. That matters because compression write-back re-adds every retained item — restamping there would renumber the whole surviving conversation on each compression, which is precisely the "munging" raised in the issue thread.

The invariant is that **every** item in the backing array carries a marker. Four mutation paths bypass `addInternal`, and each is handled: `validateAndFix` stamps its synthetic tool message; density replacements inherit the marker of the item they replace; `summarizeOldHistory` stamps the array it installs; `replaceToolResponseBlock` already preserved metadata (now covered by a test).

## Owner constraints from the issue thread

> "(BTW I'm not against stamps per se you just cant send them to the provider and we will munge them in summarization)"

### Markers never reach a provider

This was treated as the primary risk, since providers reject unknown fields on message objects with HTTP 400 — a leak would break **every** request for that provider.

Audit result: every wire converter builds messages from explicit field picks off `content.blocks`; none spreads `content` or `metadata`. The only metadata field that crosses the wire is `metadata.usage` in `buildResponsesRequest.ts`, an explicit pick. But `deepCloneWithoutCircularRefs` copies metadata, so chronology genuinely travels with `IContent` right up to each converter — and **nothing guarded that boundary**.

Added `chronologyProviderIsolation.test.ts`, which pushes chronology-bearing history through the real request builders (OpenAI chat, OpenAI Responses, OpenAI Responses legacy, Anthropic, Vercel, plus the dump-body path that delegates to the real Gemini converter) and asserts no chronology key and no chronology values appear. The guard was mutation-tested: injecting a deliberately leaking converter fails it.

### Markers never affect token accounting

Not in the issue text, but it would have been a silent regression. Three fallback estimators serialize the **whole** `IContent`, so a marker would have added roughly 20 phantom tokens per history item and triggered compression early. Estimation now goes through `serializeWireContentForEstimate`, which serializes only the wire-relevant `{ speaker, blocks }`. Covered by neutrality tests for the estimator and for `findCompressSplitPoint`.

### Summarization records what it destroyed

`annotateCompressionSpan` runs in `CompressionHandler` before write-back and stamps the summary entry with `chronologyReplaced: { fromSeq, toSeq, itemCount }` covering exactly the sequence numbers the strategy removed. Truncation-only strategies produce no summary, and their loss stays visible as a gap in the sequence. Mutation-tested by removing the call.

## Surfacing for debugging

- `HistoryService.getChronologyTrace()` — ordered, JSON-safe projection.
- Chronology on every "Adding content to history" debug record (`llxprt:history:service`).
- `/dumpcontext now` writes the trace to a top-level `chronology` key in the dump file, as a **sibling** of `request` — never inside `request.body`, which stays byte-for-byte what the provider receives.

The trace carries structural descriptors only (speaker, block types, tool call/response IDs) and never message text, tool parameters, or tool results, so it is safe to attach to a bug report. This is asserted by a test.

Documented in `docs/debug-logging.md`.

## Non-goals

Recorded up front in the plan: no prompt-rendering or provider-payload exposure (explicitly vetoed by the owner); no telemetry schema change; no chronology sidecar for `/dumpcontext on|error` (that would need `HistoryService` plumbed through four provider execution paths); no change to `turnId` / `id` / `timestamp` semantics; no session-file format change; no new settings toggle.

## Review notes

Local Open Code Review found one high-severity bug: `reconcile()` did not reset the step counter when a marker advanced the user turn, producing skipped step numbers — reachable via `fromJSON`, `merge`, and compression write-back. Fixed.

Its suggested patch was itself incorrect (it made the step update unconditional, so a stale lower-turn marker would corrupt the current turn's counter). The implementation here handles all three turn relationships explicitly, and there are tests that reject both the original bug and the suggested patch.

Two pre-existing guards needed maintenance rather than loosening:

- The provider-agnostic naming guard flagged a direct Gemini-converter import in the new test. Rather than allowlist it, Gemini coverage is routed through the provider-neutral `buildProviderDumpBody` entry point, which delegates to the same real converter.
- `SELECTED_FILE_COUNT` bumped for the added CLI test file.

An earlier iteration made `add()` return a stamped copy, which broke reference identity that `removeLastIfMatches` and roughly ten existing assertions depend on. That approach was reverted in favour of identity-preserving in-place stamping (matching the existing `content.metadata ??= {}` pattern in the provider stream parsers), so those tests pass unmodified.

## Verification

`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and `npm run lint:eslint-guard` all pass on this head. CLI smoke (`bun scripts/start.ts --profile-load stepfun-37`) returns a haiku with exit 0 — a real provider round-trip with markers present in history.

No lint suppressions, no severity downgrades, and no complexity/size threshold changes.
