### PR TITLE
Retry transient 429 on same LB backend before failover (Fixes #2849)

### DIFF
--- a/docs/cli/profiles.md
+++ b/docs/cli/profiles.md
@@ -205,7 +205,7 @@ Configure before saving a load balancer profile with `/set`:
 
 | Setting                         | Default               | Description                               |
 | ------------------------------- | --------------------- | ----------------------------------------- |
-| `failover_retry_count`          | 1                     | Retries per backend before moving to next |
+| `failover_retry_count`          | 2                     | Retries per backend before moving to next |
 | `failover_retry_delay_ms`       | 0                     | Delay between retries (ms)                |
 | `failover_on_network_errors`    | true                  | Failover on TCP/network errors            |
 | `failover_status_codes`         | [429,500,502,503,504] | HTTP codes that trigger failover          |

--- a/packages/cli/vitest.test-groups.ts
+++ b/packages/cli/vitest.test-groups.ts
@@ -479,4 +479,4 @@ export function buildTestGroups(
  * The expected total selected file count after integrating the v0.11.0 test set.
  * Exported for behavioral tests to assert against an independent oracle.
  */
-export const SELECTED_FILE_COUNT: number = 521;
+export const SELECTED_FILE_COUNT: number = 520;

--- a/packages/cli/vitest.test-groups.ts
+++ b/packages/cli/vitest.test-groups.ts
@@ -479,4 +479,4 @@ export function buildTestGroups(
  * The expected total selected file count after integrating the v0.11.0 test set.
  * Exported for behavioral tests to assert against an independent oracle.
  */
-export const SELECTED_FILE_COUNT: number = 520;
+export const SELECTED_FILE_COUNT: number = 521;

--- a/packages/providers/src/__tests__/LoadBalancingProvider.compressionAccounting.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.compressionAccounting.test.ts
@@ -349,8 +349,8 @@ describe('LoadBalancingProvider - compression accounting (issue #2207)', () => {
         strategy: 'failover',
         contextLimit: 10,
         lbProfileEphemeralSettings: {
-          'failover-retry-count': 1,
-          'failover-retry-delay-ms': 0,
+          failover_retry_count: 1,
+          failover_retry_delay_ms: 0,
         },
         subProfiles: [
           createResolvedSubProfile({
@@ -406,8 +406,8 @@ describe('LoadBalancingProvider - compression accounting (issue #2207)', () => {
         strategy: 'failover',
         contextLimit: 10,
         lbProfileEphemeralSettings: {
-          'failover-retry-count': 1,
-          'failover-retry-delay-ms': 0,
+          failover_retry_count: 1,
+          failover_retry_delay_ms: 0,
         },
         subProfiles: [
           createResolvedSubProfile({

--- a/packages/providers/src/__tests__/LoadBalancingProvider.compressionAccounting.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.compressionAccounting.test.ts
@@ -166,9 +166,8 @@ describe('LoadBalancingProvider - compression accounting (issue #2207)', () => {
       strategy: 'failover',
       contextLimit: 4,
       lbProfileEphemeralSettings: {
-        'failover-retry-count': 1,
-        'failover-retry-delay-ms': 0,
         failover_retry_count: 1,
+        failover_retry_delay_ms: 0,
       },
       subProfiles: [
         createResolvedSubProfile({
@@ -489,9 +488,8 @@ describe('LoadBalancingProvider - compression accounting (issue #2207)', () => {
       strategy: 'failover',
       contextLimit: 100000,
       lbProfileEphemeralSettings: {
-        'failover-retry-count': 1,
-        'failover-retry-delay-ms': 0,
         failover_retry_count: 1,
+        failover_retry_delay_ms: 0,
       },
       subProfiles: [
         createResolvedSubProfile({

--- a/packages/providers/src/__tests__/LoadBalancingProvider.compressionAccounting.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.compressionAccounting.test.ts
@@ -168,6 +168,7 @@ describe('LoadBalancingProvider - compression accounting (issue #2207)', () => {
       lbProfileEphemeralSettings: {
         'failover-retry-count': 1,
         'failover-retry-delay-ms': 0,
+        failover_retry_count: 1,
       },
       subProfiles: [
         createResolvedSubProfile({
@@ -490,6 +491,7 @@ describe('LoadBalancingProvider - compression accounting (issue #2207)', () => {
       lbProfileEphemeralSettings: {
         'failover-retry-count': 1,
         'failover-retry-delay-ms': 0,
+        failover_retry_count: 1,
       },
       subProfiles: [
         createResolvedSubProfile({

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
@@ -483,6 +483,7 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       const lbConfig: LoadBalancingProviderConfig = {
         profileName: 'test-per-backend-msg',
         strategy: 'failover',
+        lbProfileEphemeralSettings: { failover_retry_count: 1 },
         subProfiles: [
           {
             name: 'zai',
@@ -552,6 +553,7 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       const lbConfig: LoadBalancingProviderConfig = {
         profileName: 'test-per-backend-status',
         strategy: 'failover',
+        lbProfileEphemeralSettings: { failover_retry_count: 1 },
         subProfiles: [
           {
             name: 'zai',
@@ -652,6 +654,7 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
               modelParams: {},
             },
           ],
+          lbProfileEphemeralSettings: { failover_retry_count: 1 },
           lbProfileModelParams: { topK: 40 },
         },
         providerManager,

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
@@ -107,6 +107,10 @@ function makeFailoverConfig(profileName: string): LoadBalancingProviderConfig {
         authToken: 'token-3',
       },
     ],
+    // Issue #2849 raised the LB default retry count to 2. These tests focus on
+    // aggregate-retryability classification, not per-backend retry count, so
+    // pin retryCount=1 to preserve each test's attempt-count assertions.
+    lbProfileEphemeralSettings: { failover_retry_count: 1 },
   };
 }
 

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
@@ -489,7 +489,7 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
     },
   );
 
-  it('preserves immediate failover-to-next-backend behavior on a single 429 (issue #902 regression guard)', async () => {
+  it('advances to next backend when retryCount=1 and a 429 exhausts per-backend retries', async () => {
     const { provider, counter } = makeFakeProvider(function* (
       attempt: number,
     ): AsyncGenerator<IContent> {
@@ -515,13 +515,13 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
   });
 
   /**
-   * Streaming edge case (issue #2450 regression guard): when an immediate
-   * failover error (e.g. 429) occurs AFTER the backend has already yielded
-   * chunks to the consumer, the load balancer abandons the failover path and
-   * re-throws the RAW backend error rather than wrapping it in a
-   * LoadBalancerFailoverError. A partial stream cannot be silently retried
-   * against another backend, so the consumer must see the underlying status
-   * error, not the aggregate. This documents and guards that distinct path.
+   * Streaming edge case (issue #2450 regression guard): when an error occurs
+   * AFTER the backend has already yielded chunks to the consumer, the load
+   * balancer abandons the failover path and re-throws the RAW backend error
+   * rather than wrapping it in a LoadBalancerFailoverError. A partial stream
+   * cannot be silently retried against another backend, so the consumer must
+   * see the underlying status error, not the aggregate. This documents and
+   * guards that distinct path.
    *
    * The second backend's error is deliberately a distinct 500 (not a 429) so
    * that `getErrorStatus(thrown) === 429` can only pass if the FIRST backend's

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.stickyIndex.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.stickyIndex.test.ts
@@ -58,6 +58,7 @@ describe('LoadBalancingProvider - Failover Sticky Index (Issue #2492)', () => {
     const lbConfig: LoadBalancingProviderConfig = {
       profileName: 'test-sticky-wraparound',
       strategy: 'failover',
+      lbProfileEphemeralSettings: { failover_retry_count: 1 },
       subProfiles: [
         {
           name: 'backend-a',
@@ -164,6 +165,7 @@ describe('LoadBalancingProvider - Failover Sticky Index (Issue #2492)', () => {
     const lbConfig: LoadBalancingProviderConfig = {
       profileName: 'test-reset-on-all-fail',
       strategy: 'failover',
+      lbProfileEphemeralSettings: { failover_retry_count: 1 },
       subProfiles: [
         {
           name: 'backend-a',
@@ -242,6 +244,7 @@ describe('LoadBalancingProvider - Failover Sticky Index (Issue #2492)', () => {
     const lbConfig: LoadBalancingProviderConfig = {
       profileName: 'test-full-rotation-from-zero',
       strategy: 'failover',
+      lbProfileEphemeralSettings: { failover_retry_count: 1 },
       subProfiles: [
         {
           name: 'backend-a',
@@ -332,6 +335,7 @@ describe('LoadBalancingProvider - Failover Sticky Index (Issue #2492)', () => {
     const lbConfig: LoadBalancingProviderConfig = {
       profileName: 'test-not-pegged',
       strategy: 'failover',
+      lbProfileEphemeralSettings: { failover_retry_count: 1 },
       subProfiles: [
         {
           name: 'zai',

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.streaming.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.streaming.test.ts
@@ -375,6 +375,7 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       const lbConfig: LoadBalancingProviderConfig = {
         profileName: 'test-non-status-error',
         strategy: 'failover',
+        lbProfileEphemeralSettings: { failover_retry_count: 1 },
         subProfiles: [
           {
             name: 'backend1',

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.streaming.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.streaming.test.ts
@@ -191,6 +191,7 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
             authToken: 'test-token-2',
           },
         ],
+        lbProfileEphemeralSettings: { failover_retry_count: 1 },
       };
 
       const provider = new LoadBalancingProvider(lbConfig, providerManager);
@@ -253,6 +254,7 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
             authToken: 'test-token-2',
           },
         ],
+        lbProfileEphemeralSettings: { failover_retry_count: 1 },
       };
 
       const provider = new LoadBalancingProvider(lbConfig, providerManager);
@@ -500,6 +502,7 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
             authToken: 'test-token-3',
           },
         ],
+        lbProfileEphemeralSettings: { failover_retry_count: 1 },
       };
 
       const provider = new LoadBalancingProvider(lbConfig, providerManager);

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.streaming.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.streaming.test.ts
@@ -271,15 +271,15 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       expect(provider.getCurrentFailoverIndex()).toBe(1);
     });
 
-    it('should immediately failover on 429 without retrying current member', async () => {
+    it('retries 429 on the same backend before failing over (issue #2849)', async () => {
       let callCount = 0;
 
       const mockProvider: IProvider = {
         name: 'test-provider',
         async *generateChatCompletion(): AsyncGenerator<IContent> {
           callCount++;
-          // First call: throw 429
-          // Second call: succeed
+          // First call: throw 429 (retryable on same backend)
+          // Second call: succeed (same backend retry succeeds)
           if (callCount === 1) {
             const error = new Error('Rate limited') as Error & {
               status: number;
@@ -317,7 +317,7 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
           },
         ],
         lbProfileEphemeralSettings: {
-          failover_retry_count: 3, // Even with retry count, 429 should not retry
+          failover_retry_count: 3, // 429 is retried up to this many times
         },
       };
 
@@ -332,24 +332,23 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
         results.push(chunk);
       }
 
-      // Backend1 throws 429, immediate failover to backend2
-      // So only 2 calls total (no retries on 429)
+      // Backend1 throws 429, retry on same backend succeeds.
+      // 2 calls total (no failover needed).
       expect(callCount).toBe(2);
     });
 
     it('should distinguish non-status errors from immediate failover errors (429)', async () => {
-      // This test verifies that errors without HTTP status are handled differently
-      // from 429/401/402/403. Non-status errors follow normal retry flow, while
-      // immediate failover errors (429, etc.) skip retry entirely.
+      // This test verifies that errors without HTTP status are handled
+      // similarly to 429 with failover_retry_count: 1. Both exhaust
+      // per-backend retries and fail over, but the difference is:
+      // - Non-status errors: never retry even if retryCount > 1 (no status
+      //   to classify as failover-eligible)
+      // - 429: retries on same backend when retryCount > 1 (issue #2849)
       //
-      // With failover_retry_count: 1 (default), a non-status error will:
+      // With failover_retry_count: 1 (pinned), a non-status error will:
       // 1. Try backend1, fail, exhaust retries (1 attempt)
       // 2. Move to backend2, succeed
       // Total: 2 calls
-      //
-      // This is the same as 429, but the key difference is:
-      // - 429: No retry attempt on same backend (immediate failover)
-      // - Non-status error: Would retry if failover_retry_count > 1
       let callCount = 0;
 
       const mockProvider: IProvider = {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.streaming.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.streaming.test.ts
@@ -341,11 +341,13 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       // This test verifies that errors without HTTP status are handled
       // similarly to 429 with failover_retry_count: 1. Both exhaust
       // per-backend retries and fail over, but the difference is:
-      // - Non-status errors: never retry even if retryCount > 1 (no status
-      //   to classify as failover-eligible)
-      // - 429: retries on same backend when retryCount > 1 (issue #2849)
+      // - Non-status errors: shouldFailover() returns false, so shouldRetry
+      //   is always false — the LB advances to the next backend without
+      //   retrying the same backend, even when retryCount > 1.
+      // - 429: shouldFailover() returns true, so the LB retries on the same
+      //   backend when retryCount > 1 (issue #2849).
       //
-      // With failover_retry_count: 1 (pinned), a non-status error will:
+      // With failover_retry_count: 1 (pinned), both behave identically:
       // 1. Try backend1, fail, exhaust retries (1 attempt)
       // 2. Move to backend2, succeed
       // Total: 2 calls

--- a/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
@@ -39,10 +39,11 @@ import type { GenerateChatOptions } from '../GenerateChatOptions.js';
 /** Build a fake delegate whose per-invocation behavior is supplied inline. */
 function makeFakeProvider(
   respond: (invocation: number) => AsyncGenerator<IContent>,
+  providerName = 'test-provider',
 ): { provider: IProvider; counter: { value: number } } {
   const counter = { value: 0 };
   const provider: IProvider = {
-    name: 'test-provider',
+    name: providerName,
     async *generateChatCompletion(): AsyncGenerator<IContent> {
       counter.value++;
       yield* respond(counter.value);
@@ -90,29 +91,39 @@ function makeOptions(): GenerateChatOptions {
  * makoraglm51 + ollamaglm51). Uses the DEFAULT failover_retry_count (now 2)
  * — no lbProfileEphemeralSettings override — so the test exercises the
  * production default behavior.
+ *
+ * Each sub-profile references a distinct providerName so individual backends
+ * can be configured with different failure modes (e.g., healthy vs exhausted).
  */
-function makeGlmConfig(profileName: string): LoadBalancingProviderConfig {
+function makeGlmConfig(
+  profileName: string,
+  providers: [string, string, string] = [
+    'zai-provider',
+    'makora-provider',
+    'ollama-provider',
+  ],
+): LoadBalancingProviderConfig {
   return {
     profileName,
     strategy: 'failover',
     subProfiles: [
       {
         name: 'zai',
-        providerName: 'test-provider',
+        providerName: providers[0],
         modelId: 'model1',
         baseURL: 'https://api.z.ai',
         authToken: 'token-1',
       },
       {
         name: 'makoraglm51',
-        providerName: 'test-provider',
+        providerName: providers[1],
         modelId: 'model2',
         baseURL: 'https://api.makora.ai',
         authToken: 'token-2',
       },
       {
         name: 'ollamaglm51',
-        providerName: 'test-provider',
+        providerName: providers[2],
         modelId: 'model3',
         baseURL: 'https://api.ollama.ai',
         authToken: 'token-3',
@@ -155,8 +166,19 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
         return throwStatus('rate limited', 429)();
       }
       return successChunk();
-    });
+    }, 'zai-provider');
     providerManager.registerProvider(provider);
+    // Other backends would fail if reached, but zai succeeds on retry.
+    const exhausted1 = makeFakeProvider(
+      () => throwStatus('rate limited', 429)(),
+      'makora-provider',
+    );
+    providerManager.registerProvider(exhausted1.provider);
+    const exhausted2 = makeFakeProvider(
+      () => throwStatus('rate limited', 429)(),
+      'ollama-provider',
+    );
+    providerManager.registerProvider(exhausted2.provider);
 
     const lb = new LoadBalancingProvider(
       makeGlmConfig('glm-transient-429'),
@@ -168,6 +190,9 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
     expect(chunks).toHaveLength(1);
     // Both invocations hit zai (backend 0): first 429, second success.
     expect(counter.value).toBe(2);
+    // Other backends never reached.
+    expect(exhausted1.counter.value).toBe(0);
+    expect(exhausted2.counter.value).toBe(0);
     // Stayed on zai — no failover.
     expect(lb.getCurrentFailoverIndex()).toBe(0);
   });
@@ -179,15 +204,18 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
    * a chance to recover.
    */
   it('fails over to the next backend after exhausting per-backend retries on persistent 429', async () => {
-    const { provider, counter } = makeFakeProvider((invocation) => {
-      // zai attempts 1+2: both 429 (exhaust retryCount=2)
-      // makoraglm51 attempt 3: succeeds
-      if (invocation <= 2) {
-        return throwStatus('rate limited', 429)();
-      }
-      return successChunk();
-    });
-    providerManager.registerProvider(provider);
+    const zai = makeFakeProvider(
+      () => throwStatus('rate limited', 429)(),
+      'zai-provider',
+    );
+    providerManager.registerProvider(zai.provider);
+    const makora = makeFakeProvider(() => successChunk(), 'makora-provider');
+    providerManager.registerProvider(makora.provider);
+    const ollama = makeFakeProvider(
+      () => throwStatus('rate limited', 429)(),
+      'ollama-provider',
+    );
+    providerManager.registerProvider(ollama.provider);
 
     const lb = new LoadBalancingProvider(
       makeGlmConfig('glm-persistent-429-then-success'),
@@ -198,7 +226,10 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
 
     expect(chunks).toHaveLength(1);
     // zai tried twice (both 429), then makoraglm51 succeeded.
-    expect(counter.value).toBe(3);
+    expect(zai.counter.value).toBe(2);
+    expect(makora.counter.value).toBe(1);
+    // ollamaglm51 never reached.
+    expect(ollama.counter.value).toBe(0);
     // Failover index advanced to makoraglm51 (index 1).
     expect(lb.getCurrentFailoverIndex()).toBe(1);
   });
@@ -209,15 +240,13 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
    * backend is futile.
    */
   it('still immediately fails over on 401 auth errors without same-backend retry', async () => {
-    const { provider, counter } = makeFakeProvider((invocation) => {
-      // zai attempt 1: 401 (immediate failover)
-      // makoraglm51 attempt 2: succeeds
-      if (invocation === 1) {
-        return throwStatus('unauthorized', 401)();
-      }
-      return successChunk();
-    });
-    providerManager.registerProvider(provider);
+    const zai = makeFakeProvider(
+      () => throwStatus('unauthorized', 401)(),
+      'zai-provider',
+    );
+    providerManager.registerProvider(zai.provider);
+    const makora = makeFakeProvider(() => successChunk(), 'makora-provider');
+    providerManager.registerProvider(makora.provider);
 
     const lb = new LoadBalancingProvider(
       makeGlmConfig('glm-auth-failover'),
@@ -227,30 +256,39 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
     const chunks = await consumeStream(lb, makeOptions());
 
     expect(chunks).toHaveLength(1);
-    // Only 2 invocations: zai 401 → immediate failover → makoraglm51 success.
-    expect(counter.value).toBe(2);
+    // Only 1 invocation on zai: 401 → immediate failover.
+    expect(zai.counter.value).toBe(1);
+    // makoraglm51 succeeded on first attempt.
+    expect(makora.counter.value).toBe(1);
     expect(lb.getCurrentFailoverIndex()).toBe(1);
   });
 
   /**
-   * Full reliability scenario: one backend is healthy (zai), two are
-   * persistently exhausted. The LB must succeed by retrying/failing-over
-   * through the rotation without burning the budget excessively. This is the
-   * scenario described in the issue: "zai is not exhausted, it sometimes
-   * throws minor errors" — a transient 429 on zai should recover on retry,
-   * not cause a loopbreak.
+   * Full reliability scenario from the issue: zai is healthy but sometimes
+   * throws a transient 429; makoraglm51 and ollamaglm51 are persistently
+   * exhausted. The LB must succeed by retrying zai's transient 429 on the
+   * same backend — NOT by failing over to the exhausted backends. This
+   * proves the LB is "as reliable as zai alone" even when the other backends
+   * are down.
    */
-  it('succeeds when the primary backend has a transient 429 and others are persistently exhausted', async () => {
-    const { provider, counter } = makeFakeProvider((invocation) => {
-      // zai attempt 1: transient 429
-      // zai attempt 2 (retry): success
-      // (makoraglm51 and ollamaglm51 never reached)
+  it('succeeds when zai has a transient 429 and other backends are persistently exhausted', async () => {
+    const zai = makeFakeProvider((invocation) => {
       if (invocation === 1) {
         return throwStatus('rate limited', 429)();
       }
       return successChunk();
-    });
-    providerManager.registerProvider(provider);
+    }, 'zai-provider');
+    providerManager.registerProvider(zai.provider);
+    const makora = makeFakeProvider(
+      () => throwStatus('rate limit exhausted', 429)(),
+      'makora-provider',
+    );
+    providerManager.registerProvider(makora.provider);
+    const ollama = makeFakeProvider(
+      () => throwStatus('rate limit exhausted', 429)(),
+      'ollama-provider',
+    );
+    providerManager.registerProvider(ollama.provider);
 
     const lb = new LoadBalancingProvider(
       makeGlmConfig('glm-zai-transient-others-exhausted'),
@@ -261,9 +299,11 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0]).toStrictEqual({ type: 'text', content: 'ok' });
-    // Only 2 invocations: zai 429 → retry → zai success.
-    // The LB did NOT fail over to the exhausted backends.
-    expect(counter.value).toBe(2);
+    // zai: 429 then success on retry — never failed over.
+    expect(zai.counter.value).toBe(2);
+    // Exhausted backends never reached because zai succeeded on retry.
+    expect(makora.counter.value).toBe(0);
+    expect(ollama.counter.value).toBe(0);
     expect(lb.getCurrentFailoverIndex()).toBe(0);
   });
 
@@ -273,10 +313,15 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
    * default retryCount=2 and 3 backends, this is 6 delegate invocations.
    */
   it('throws a bounded aggregate error when all backends are persistently 429', async () => {
-    const { provider, counter } = makeFakeProvider(() =>
-      throwStatus('rate limited', 429)(),
-    );
-    providerManager.registerProvider(provider);
+    const counters: Array<{ value: number }> = [];
+    for (const name of ['zai-provider', 'makora-provider', 'ollama-provider']) {
+      const fake = makeFakeProvider(
+        () => throwStatus('rate limited', 429)(),
+        name,
+      );
+      counters.push(fake.counter);
+      providerManager.registerProvider(fake.provider);
+    }
 
     const lb = new LoadBalancingProvider(
       makeGlmConfig('glm-all-persistent-429'),
@@ -287,7 +332,8 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
       /Load balancer "glm-all-persistent-429"/,
     );
 
-    // 3 backends × 2 retries each = 6 bounded invocations.
-    expect(counter.value).toBe(6);
+    // Each backend tried 2 times (retryCount=2). 3 backends × 2 = 6 total.
+    const total = counters.reduce((sum, c) => sum + c.value, 0);
+    expect(total).toBe(6);
   });
 });

--- a/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
@@ -68,14 +68,14 @@ function throwStatus(
   message: string,
   status: number,
 ): () => AsyncGenerator<IContent> {
-  return function* (): AsyncGenerator<IContent> {
+  return async function* (): AsyncGenerator<IContent> {
     throw statusError(message, status);
     yield undefined as unknown as IContent; // eslint require-yield
   };
 }
 
 /** A generator that yields a single success chunk. */
-function* successChunk(): AsyncGenerator<IContent> {
+async function* successChunk(): AsyncGenerator<IContent> {
   yield { type: 'text' as const, content: 'ok' } as unknown as IContent;
 }
 

--- a/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Vybestack LLC
+ * Copyright 2026 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0
  *
  * Behavioral acceptance tests for issue #2849: a load-balancer `failover`

--- a/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
@@ -102,10 +102,12 @@ function makeGlmConfig(
     'makora-provider',
     'ollama-provider',
   ],
+  ephemeralSettings: Record<string, unknown> = {},
 ): LoadBalancingProviderConfig {
   return {
     profileName,
     strategy: 'failover',
+    lbProfileEphemeralSettings: ephemeralSettings,
     subProfiles: [
       {
         name: 'zai',
@@ -324,7 +326,9 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
     }
 
     const lb = new LoadBalancingProvider(
-      makeGlmConfig('glm-all-persistent-429'),
+      makeGlmConfig('glm-all-persistent-429', undefined, {
+        failover_retry_count: 2,
+      }),
       providerManager,
     );
 
@@ -335,5 +339,50 @@ describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', 
     // Each backend tried 2 times (retryCount=2). 3 backends × 2 = 6 total.
     const total = counters.reduce((sum, c) => sum + c.value, 0);
     expect(total).toBe(6);
+  });
+
+  /**
+   * Boundary: if a backend yields one or more chunks and THEN throws 429,
+   * the LB must re-throw immediately (immediate-throw) — it cannot retry or
+   * fail over because doing so would duplicate the already-yielded chunks.
+   * This is enforced by `handleFailoverError` when `chunksYielded === true`.
+   */
+  it('re-throws immediately when 429 occurs mid-stream after chunks are yielded', async () => {
+    const zai = makeFakeProvider(
+      () =>
+        (async function* (): AsyncGenerator<IContent> {
+          yield {
+            type: 'text' as const,
+            content: 'partial',
+          } as unknown as IContent;
+          throw statusError('rate limited', 429);
+        })(),
+      'zai-provider',
+    );
+    const makora = makeFakeProvider(() => successChunk(), 'makora-provider');
+    providerManager.registerProvider(zai.provider);
+    providerManager.registerProvider(makora.provider);
+
+    const lb = new LoadBalancingProvider(
+      makeGlmConfig('glm-midstream-429'),
+      providerManager,
+    );
+
+    // The stream yields the partial chunk then throws the raw 429 error.
+    const chunks: IContent[] = [];
+    await expect(
+      (async () => {
+        for await (const chunk of lb.generateChatCompletion(makeOptions())) {
+          chunks.push(chunk);
+        }
+      })(),
+    ).rejects.toThrow('rate limited');
+
+    // The partial chunk WAS yielded before the error.
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toStrictEqual({ type: 'text', content: 'partial' });
+    // Only zai was called — no failover to makora after mid-stream 429.
+    expect(zai.counter.value).toBe(1);
+    expect(makora.counter.value).toBe(0);
   });
 });

--- a/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.issue2849.test.ts
@@ -1,0 +1,293 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral acceptance tests for issue #2849: a load-balancer `failover`
+ * profile must be at least as reliable as a standalone provider profile for
+ * transient 429 (rate-limit) errors.
+ *
+ * Root cause: `isImmediateFailoverError()` previously treated 429 as an
+ * immediate-failover signal alongside 401/402/403. This caused the LB to skip
+ * same-backend retry entirely and burn the shared transport-attempt budget
+ * cycling through backends. With 3 backends and a budget of 6, the LB got
+ * only 2 full rotations — far fewer retries than a standalone provider, which
+ * retries 429s with exponential backoff up to the same budget.
+ *
+ * Fix: 429 is no longer an immediate-failover error. The LB now retries 429
+ * on the same backend (up to `failover_retry_count`, default 2) before
+ * advancing to the next backend. Only after exhausting per-backend retries
+ * does the LB fail over. Auth errors (401/402/403) remain immediate-failover.
+ *
+ * These tests use the real `LoadBalancingProvider`, a real `ProviderManager`,
+ * and fake delegate providers. No mock theater.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ProviderManager } from '../ProviderManager.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  LoadBalancingProvider,
+  type LoadBalancingProviderConfig,
+} from '../LoadBalancingProvider.js';
+import type { IProvider } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { GenerateChatOptions } from '../GenerateChatOptions.js';
+
+/** Build a fake delegate whose per-invocation behavior is supplied inline. */
+function makeFakeProvider(
+  respond: (invocation: number) => AsyncGenerator<IContent>,
+): { provider: IProvider; counter: { value: number } } {
+  const counter = { value: 0 };
+  const provider: IProvider = {
+    name: 'test-provider',
+    async *generateChatCompletion(): AsyncGenerator<IContent> {
+      counter.value++;
+      yield* respond(counter.value);
+    },
+    getModels: async () => [],
+    getDefaultModel: () => 'test-model',
+    getServerTools: () => [],
+    invokeServerTool: async () => ({ content: [] }),
+  };
+  return { provider, counter };
+}
+
+/** Create a status-bearing error like the ones real providers throw. */
+function statusError(message: string, status: number): Error {
+  const error = new Error(message) as Error & { status: number };
+  error.status = status;
+  return error;
+}
+
+/** A generator that always throws the given status. */
+function throwStatus(
+  message: string,
+  status: number,
+): () => AsyncGenerator<IContent> {
+  return function* (): AsyncGenerator<IContent> {
+    throw statusError(message, status);
+    yield undefined as unknown as IContent; // eslint require-yield
+  };
+}
+
+/** A generator that yields a single success chunk. */
+function* successChunk(): AsyncGenerator<IContent> {
+  yield { type: 'text' as const, content: 'ok' } as unknown as IContent;
+}
+
+function makeOptions(): GenerateChatOptions {
+  return {
+    prompt: 'test prompt',
+    messages: [{ role: 'user' as const, content: 'test' }],
+  };
+}
+
+/**
+ * Three-backend failover config matching the issue's "glm" profile (zai +
+ * makoraglm51 + ollamaglm51). Uses the DEFAULT failover_retry_count (now 2)
+ * — no lbProfileEphemeralSettings override — so the test exercises the
+ * production default behavior.
+ */
+function makeGlmConfig(profileName: string): LoadBalancingProviderConfig {
+  return {
+    profileName,
+    strategy: 'failover',
+    subProfiles: [
+      {
+        name: 'zai',
+        providerName: 'test-provider',
+        modelId: 'model1',
+        baseURL: 'https://api.z.ai',
+        authToken: 'token-1',
+      },
+      {
+        name: 'makoraglm51',
+        providerName: 'test-provider',
+        modelId: 'model2',
+        baseURL: 'https://api.makora.ai',
+        authToken: 'token-2',
+      },
+      {
+        name: 'ollamaglm51',
+        providerName: 'test-provider',
+        modelId: 'model3',
+        baseURL: 'https://api.ollama.ai',
+        authToken: 'token-3',
+      },
+    ],
+  };
+}
+
+/** Consume the entire stream and return all chunks. */
+async function consumeStream(
+  provider: LoadBalancingProvider,
+  options: GenerateChatOptions,
+): Promise<IContent[]> {
+  const chunks: IContent[] = [];
+  for await (const chunk of provider.generateChatCompletion(options)) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+describe('LoadBalancingProvider issue #2849: LB reliability for transient 429', () => {
+  let settingsService: SettingsService;
+  let config: Config;
+  let providerManager: ProviderManager;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    config = createRuntimeConfigStub(settingsService);
+    providerManager = new ProviderManager({ settingsService, config });
+  });
+
+  /**
+   * Core acceptance: a single transient 429 on the primary backend must be
+   * retried on the SAME backend (not immediately failed over). This gives
+   * the LB at least the same retry behavior as a standalone provider.
+   */
+  it('retries a transient 429 on the same backend before failing over', async () => {
+    const { provider, counter } = makeFakeProvider((invocation) => {
+      if (invocation === 1) {
+        return throwStatus('rate limited', 429)();
+      }
+      return successChunk();
+    });
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeGlmConfig('glm-transient-429'),
+      providerManager,
+    );
+
+    const chunks = await consumeStream(lb, makeOptions());
+
+    expect(chunks).toHaveLength(1);
+    // Both invocations hit zai (backend 0): first 429, second success.
+    expect(counter.value).toBe(2);
+    // Stayed on zai — no failover.
+    expect(lb.getCurrentFailoverIndex()).toBe(0);
+  });
+
+  /**
+   * After exhausting per-backend retries (default 2) on persistent 429, the
+   * LB must still advance to the next backend. This prevents infinite
+   * retrying of a truly exhausted backend while still giving transient 429s
+   * a chance to recover.
+   */
+  it('fails over to the next backend after exhausting per-backend retries on persistent 429', async () => {
+    const { provider, counter } = makeFakeProvider((invocation) => {
+      // zai attempts 1+2: both 429 (exhaust retryCount=2)
+      // makoraglm51 attempt 3: succeeds
+      if (invocation <= 2) {
+        return throwStatus('rate limited', 429)();
+      }
+      return successChunk();
+    });
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeGlmConfig('glm-persistent-429-then-success'),
+      providerManager,
+    );
+
+    const chunks = await consumeStream(lb, makeOptions());
+
+    expect(chunks).toHaveLength(1);
+    // zai tried twice (both 429), then makoraglm51 succeeded.
+    expect(counter.value).toBe(3);
+    // Failover index advanced to makoraglm51 (index 1).
+    expect(lb.getCurrentFailoverIndex()).toBe(1);
+  });
+
+  /**
+   * Regression guard: 401 (auth) must still cause IMMEDIATE failover — no
+   * same-backend retry. Auth errors are non-transient; retrying the same
+   * backend is futile.
+   */
+  it('still immediately fails over on 401 auth errors without same-backend retry', async () => {
+    const { provider, counter } = makeFakeProvider((invocation) => {
+      // zai attempt 1: 401 (immediate failover)
+      // makoraglm51 attempt 2: succeeds
+      if (invocation === 1) {
+        return throwStatus('unauthorized', 401)();
+      }
+      return successChunk();
+    });
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeGlmConfig('glm-auth-failover'),
+      providerManager,
+    );
+
+    const chunks = await consumeStream(lb, makeOptions());
+
+    expect(chunks).toHaveLength(1);
+    // Only 2 invocations: zai 401 → immediate failover → makoraglm51 success.
+    expect(counter.value).toBe(2);
+    expect(lb.getCurrentFailoverIndex()).toBe(1);
+  });
+
+  /**
+   * Full reliability scenario: one backend is healthy (zai), two are
+   * persistently exhausted. The LB must succeed by retrying/failing-over
+   * through the rotation without burning the budget excessively. This is the
+   * scenario described in the issue: "zai is not exhausted, it sometimes
+   * throws minor errors" — a transient 429 on zai should recover on retry,
+   * not cause a loopbreak.
+   */
+  it('succeeds when the primary backend has a transient 429 and others are persistently exhausted', async () => {
+    const { provider, counter } = makeFakeProvider((invocation) => {
+      // zai attempt 1: transient 429
+      // zai attempt 2 (retry): success
+      // (makoraglm51 and ollamaglm51 never reached)
+      if (invocation === 1) {
+        return throwStatus('rate limited', 429)();
+      }
+      return successChunk();
+    });
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeGlmConfig('glm-zai-transient-others-exhausted'),
+      providerManager,
+    );
+
+    const chunks = await consumeStream(lb, makeOptions());
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toStrictEqual({ type: 'text', content: 'ok' });
+    // Only 2 invocations: zai 429 → retry → zai success.
+    // The LB did NOT fail over to the exhausted backends.
+    expect(counter.value).toBe(2);
+    expect(lb.getCurrentFailoverIndex()).toBe(0);
+  });
+
+  /**
+   * When all backends are persistently exhausted (all 429 on every attempt),
+   * the LB must throw an aggregate error after bounded attempts. With the
+   * default retryCount=2 and 3 backends, this is 6 delegate invocations.
+   */
+  it('throws a bounded aggregate error when all backends are persistently 429', async () => {
+    const { provider, counter } = makeFakeProvider(() =>
+      throwStatus('rate limited', 429)(),
+    );
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeGlmConfig('glm-all-persistent-429'),
+      providerManager,
+    );
+
+    await expect(consumeStream(lb, makeOptions())).rejects.toThrow(
+      /Load balancer "glm-all-persistent-429"/,
+    );
+
+    // 3 backends × 2 retries each = 6 bounded invocations.
+    expect(counter.value).toBe(6);
+  });
+});

--- a/packages/providers/src/__tests__/LoadBalancingProvider.lifecycle.noPhantom.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.lifecycle.noPhantom.test.ts
@@ -151,10 +151,13 @@ describe('LoadBalancingProvider lifecycle (finding #2): no phantom starts', () =
     providerManager.registerProvider(successProvider);
 
     const provider = new LoadBalancingProvider(
-      makeFailoverConfig([
-        { name: 'primary', providerName: 'throw-provider' },
-        { name: 'secondary', providerName: 'success-provider' },
-      ]),
+      {
+        ...makeFailoverConfig([
+          { name: 'primary', providerName: 'throw-provider' },
+          { name: 'secondary', providerName: 'success-provider' },
+        ]),
+        lbProfileEphemeralSettings: { failover_retry_count: 1 },
+      },
       providerManager,
     );
 

--- a/packages/providers/src/__tests__/LoadBalancingProvider.tokenAccounting.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.tokenAccounting.test.ts
@@ -681,6 +681,7 @@ describe('LoadBalancingProvider - Token Accounting (issue #2207)', () => {
         lbProfileEphemeralSettings: {
           'failover-retry-count': 1,
           'failover-retry-delay-ms': 0,
+          failover_retry_count: 1,
         },
         subProfiles: [
           createResolvedSubProfile({

--- a/packages/providers/src/__tests__/LoadBalancingProvider.tokenAccounting.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.tokenAccounting.test.ts
@@ -679,9 +679,8 @@ describe('LoadBalancingProvider - Token Accounting (issue #2207)', () => {
         strategy: 'failover',
         contextLimit: 1_000_000,
         lbProfileEphemeralSettings: {
-          'failover-retry-count': 1,
-          'failover-retry-delay-ms': 0,
           failover_retry_count: 1,
+          failover_retry_delay_ms: 0,
         },
         subProfiles: [
           createResolvedSubProfile({

--- a/packages/providers/src/__tests__/LoadBalancingProvider.tokenAccounting.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.tokenAccounting.test.ts
@@ -142,8 +142,8 @@ function setupTwoTargetFailoverGuard(providerManager: ProviderManager): {
         strategy: 'failover',
         contextLimit: 10,
         lbProfileEphemeralSettings: {
-          'failover-retry-count': 1,
-          'failover-retry-delay-ms': 0,
+          failover_retry_count: 1,
+          failover_retry_delay_ms: 0,
         },
         subProfiles: [
           createResolvedSubProfile({
@@ -568,8 +568,8 @@ describe('LoadBalancingProvider - Token Accounting (issue #2207)', () => {
         strategy: 'failover',
         contextLimit: 100,
         lbProfileEphemeralSettings: {
-          'failover-retry-count': 1,
-          'failover-retry-delay-ms': 0,
+          failover_retry_count: 1,
+          failover_retry_delay_ms: 0,
         },
         subProfiles: [
           createResolvedSubProfile({
@@ -615,8 +615,8 @@ describe('LoadBalancingProvider - Token Accounting (issue #2207)', () => {
         strategy: 'failover',
         contextLimit: 10,
         lbProfileEphemeralSettings: {
-          'failover-retry-count': 1,
-          'failover-retry-delay-ms': 0,
+          failover_retry_count: 1,
+          failover_retry_delay_ms: 0,
         },
         subProfiles: [
           createResolvedSubProfile({

--- a/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
+++ b/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
@@ -105,6 +105,11 @@ describe('extracted provider helper behavior', () => {
     expect(shouldFailover(statusError(502), defaults)).toBe(true);
     expect(shouldFailover(statusError(404), defaults)).toBe(false);
     expect(isImmediateFailoverError(statusError(401))).toBe(true);
+    // Issue #2849: 429 is transient and must be retried on the same backend,
+    // not immediately failed over. Only auth/quota errors are immediate.
+    expect(isImmediateFailoverError(statusError(429))).toBe(false);
+    expect(isImmediateFailoverError(statusError(402))).toBe(true);
+    expect(isImmediateFailoverError(statusError(403))).toBe(true);
 
     const custom = extractFailoverSettings({
       failover_retry_count: 120,

--- a/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
+++ b/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
@@ -99,7 +99,7 @@ describe('extracted provider helper behavior', () => {
   it('preserves load-balancer failover defaults and status classification', () => {
     const defaults = extractFailoverSettings(undefined);
 
-    expect(defaults.retryCount).toBe(1);
+    expect(defaults.retryCount).toBe(2);
     expect(defaults.retryDelayMs).toBe(0);
     expect(defaults.failoverOnNetworkErrors).toBe(true);
     expect(shouldFailover(statusError(502), defaults)).toBe(true);

--- a/packages/providers/src/loadBalancing/failoverSettings.ts
+++ b/packages/providers/src/loadBalancing/failoverSettings.ts
@@ -28,7 +28,7 @@ export function extractFailoverSettings(
     retryCount: Math.min(
       typeof settings.failover_retry_count === 'number'
         ? settings.failover_retry_count
-        : 1,
+        : 2,
       100,
     ),
     retryDelayMs:
@@ -114,11 +114,18 @@ export function shouldFailover(
  *
  * These status codes indicate the backend cannot serve requests
  * and retrying the SAME backend would be futile:
- * - 429: Rate limited
  * - 401: Unauthorized (per Issue #902 spec; OAuth bucket failover has
  *        separate auto-renew logic that doesn't apply to load balancer)
  * - 402: Payment required
  * - 403: Forbidden
+ *
+ * Note: 429 (rate limited) is intentionally NOT an immediate-failover error
+ * (issue #2849). A rate-limit is often transient — the same backend may
+ * recover on a retry. Retrying 429 on the same backend (controlled by
+ * failover_retry_count) before failing over gives the LB at least the same
+ * retry behavior as a standalone provider profile, which retries 429s with
+ * backoff. Only after exhausting per-backend retries does the LB advance to
+ * the next backend.
  */
 export function isImmediateFailoverError(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -128,5 +135,5 @@ export function isImmediateFailoverError(error: unknown): boolean {
   if (status === undefined) {
     return false;
   }
-  return status === 429 || status === 401 || status === 402 || status === 403;
+  return status === 401 || status === 402 || status === 403;
 }

--- a/project-plans/issue-2849-lb-retry-reliability.md
+++ b/project-plans/issue-2849-lb-retry-reliability.md
@@ -1,0 +1,66 @@
+# Issue #2849: LB Profile Reliability for Transient 429
+
+## Problem
+
+A load-balancer `failover` profile (e.g., "glm" = zai + ollamaglm51 + chutes)
+loopbreaks more frequently than the standalone zai profile. The root cause is
+twofold:
+
+1. **429 treated as immediate-failover**: `isImmediateFailoverError()` classified
+   HTTP 429 (rate limited) alongside 401/402/403 as an "immediate failover"
+   signal. This caused the LB to skip same-backend retry entirely and immediately
+   advance to the next backend on every 429.
+
+2. **Default retryCount=1**: The per-backend retry count defaulted to 1, so even
+   non-immediate errors got only a single attempt per backend per rotation.
+
+Combined, these meant: with 3 backends and a transport-attempt budget of 6, the
+LB completed only 2 full rotations — far fewer effective retries than a standalone
+provider (which retries 429s with exponential backoff up to the same budget).
+
+## Acceptance Matrix
+
+| # | Behavior | Evidence |
+|---|----------|----------|
+| A1 | A transient 429 on the primary backend is retried on the SAME backend before failing over | `LoadBalancingProvider.issue2849.test.ts` — "retries a transient 429 on the same backend" |
+| A2 | After exhausting per-backend retries on persistent 429, the LB advances to the next backend | `LoadBalancingProvider.issue2849.test.ts` — "fails over after exhausting per-backend retries" |
+| A3 | Auth errors (401/402/403) still cause immediate failover without same-backend retry | `LoadBalancingProvider.issue2849.test.ts` — "still immediately fails over on 401" |
+| A4 | When the primary has a transient 429 and others are exhausted, the LB succeeds on the primary's retry | `LoadBalancingProvider.issue2849.test.ts` — "succeeds when primary transient + others exhausted" |
+| A5 | All backends persistently 429 → bounded aggregate error (3 × retryCount invocations) | `LoadBalancingProvider.issue2849.test.ts` — "throws bounded aggregate when all persistent 429" |
+| A6 | Default `failover_retry_count` is 2 | `extracted-helpers.behavior.test.ts` — default assertion updated to 2 |
+| A7 | Issue #2450 orchestrator-level retry still works (all-429 rotation retried) | `LoadBalancingProvider.retryBoundary.integration.test.ts` — Scenario A & B pass unchanged |
+
+## Non-Goals
+
+- Changing the transport-attempt budget model (shared budget consumption per backend)
+- Adding within-LB exponential backoff (the orchestrator already provides backoff at the rotation level)
+- Changing the circuit-breaker or TPM-threshold logic
+- Modifying the round-robin strategy path
+- Changing the bucket-failover system (separate from LB failover)
+
+## Changes
+
+### Production (1 file, 2 lines changed)
+
+**`packages/providers/src/loadBalancing/failoverSettings.ts`**:
+1. `extractFailoverSettings()`: default `failover_retry_count` changed from 1 → 2
+2. `isImmediateFailoverError()`: removed 429 from immediate-failover status codes
+
+### Tests (8 files)
+
+- **`LoadBalancingProvider.issue2849.test.ts`** (new): 5 behavioral acceptance tests
+- **7 existing test files**: pinned `failover_retry_count: 1` in configs for tests
+  that verify error messages, sticky index, compression, lifecycle, and token
+  accounting (not retry behavior). This preserves each test's original intent
+  while letting the production default change take effect.
+
+## Scope Ledger
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Files changed | 11 (9 modified + 2 new) | Under 25-file budget |
+| Net changed lines | ~35 insertions, ~8 deletions (production) + ~260 lines (new test) | Under 1,500-line budget |
+| New subsystem? | No | |
+| New public abstraction? | No | |
+| Workflow/CI change? | No | |
+| Dependency change? | No | |


### PR DESCRIPTION
## Summary

A load-balancer (LB) failover profile loopbroke more often than a standalone provider profile when one provider was quota-exhausted. The root cause was two-fold:

1. **429 treated as immediate-failover**: `isImmediateFailoverError()` classified HTTP 429 alongside 401/402/403, causing the LB to skip same-backend retry entirely and immediately fail over to the next backend.
2. **Default `failover_retry_count` was 1**: Even without the immediate-failover classification, each backend got only 1 attempt per rotation.

Combined, this meant the LB burned its transport-attempt budget cycling through backends (3 backends = 3 budget units per rotation) instead of giving a transient 429 time to recover on the same backend — getting only ~2 full rotations vs a standalone provider's 6 retries with exponential backoff.

## Fix

Two changes in `packages/providers/src/loadBalancing/failoverSettings.ts`:

1. **Remove 429 from `isImmediateFailoverError()`** — 429 is transient and should be retried on the same backend (up to `failover_retry_count`) before advancing to the next backend. Auth errors (401/402/403) remain immediate-failover.

2. **Raise default `failover_retry_count` from 1 to 2** — so each backend gets at least one retry before failover, matching the reliability of a standalone provider profile.

## Behavior after fix

| Scenario | Before | After |
|---|---|---|
| Transient 429 on zai (healthy) | Immediate failover to next backend | Retry on zai (up to 2x), succeeds without failover |
| All backends persistent 429 | 3 invocations (1 per backend) | 6 invocations (2 per backend), then bounded aggregate error |
| 401/402/403 auth error | Immediate failover | Immediate failover (unchanged) |
| Chunks yielded before error | Immediate throw (unchanged) | Immediate throw (unchanged) |

## Test coverage

- 5 new behavioral acceptance tests in `LoadBalancingProvider.issue2849.test.ts` using distinct fake providers per sub-profile
- 7 existing test files pinned to `failover_retry_count: 1` to preserve their original test intent (error messages, sticky index, compression, lifecycle, token accounting)
- All 277 LoadBalancingProvider tests pass (29 test files)
- Issue #2450 integration tests (orchestrator-level LB retry) still pass

## Verification

- ✅ TypeScript typecheck (providers package)
- ✅ ESLint (all changed files)
- ✅ Prettier format (all changed files)
- ✅ Build (`npm run build`)
- ✅ 277/277 LoadBalancingProvider tests pass
- ⚠️ Smoke test: kimi-k2.5 model was retired (410) — pre-existing external API issue, unrelated to this change

Closes #2849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load balancing now retries each backend twice by default.
  * HTTP 429 responses are retried on the same backend before failover.
  * Authentication and authorization errors continue to trigger immediate failover.

* **Bug Fixes**
  * Improved failover handling for transient errors, recovery scenarios, streaming responses, and bounded retry behavior.

* **Documentation**
  * Updated load-balancer profile documentation to reflect the new default retry count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->