### PR TITLE
fix(test): prevent orphaned bun test processes and silent mock recursion (Fixes #2909)

### DIFF
--- a/scripts/run_bun_tests.ts
+++ b/scripts/run_bun_tests.ts
@@ -40,6 +40,68 @@ import {
 } from './bun-test-manifest.js';
 
 /**
+ * Detects and kills stale orphaned `bun test` processes (PPID=1) before
+ * starting a new run. When a parent test runner is killed (e.g. by OOM),
+ * child `bun test` processes reparent to PID 1 and keep spinning
+ * indefinitely — consuming CPU and memory. This guard prevents that
+ * accumulation by reaping orphans at the start of every run.
+ *
+ * Exposed as a standalone function for testability.
+ */
+function isOrphanedTestProcess(
+  ppid: number,
+  pid: number,
+  comm: string,
+  ownPid: number,
+): boolean {
+  if (ppid !== 1 || pid === ownPid) return false;
+  const runtime = comm.includes('bun') || comm.includes('node');
+  const isTest = comm.includes('test') || comm.includes('spec');
+  return runtime && isTest;
+}
+
+export function reapStaleBunTestProcesses(
+  spawnSync: (cmd: readonly string[]) => { stdout: string | null },
+  kill: (pid: number, signal: string) => void,
+  ownPid: number,
+  stderr?: (line: string) => void,
+): number {
+  let output: string;
+  try {
+    output = spawnSync(['ps', '-eo', 'pid=,ppid=,comm=']).stdout ?? '';
+  } catch {
+    return 0;
+  }
+
+  let killed = 0;
+  for (const line of output.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    const pid = parseInt(parts[0] ?? '', 10);
+    const ppid = parseInt(parts[1] ?? '', 10);
+    const comm = parts.slice(2).join(' ');
+    if (
+      Number.isFinite(pid) &&
+      Number.isFinite(ppid) &&
+      isOrphanedTestProcess(ppid, pid, comm, ownPid)
+    ) {
+      try {
+        kill(pid, 'SIGTERM');
+        killed++;
+      } catch {
+        // Process may have already exited
+      }
+    }
+  }
+
+  if (killed > 0 && stderr) {
+    stderr(
+      `[run_bun_tests] Reaped ${killed} stale orphaned test process(es) (PPID=1) before run.`,
+    );
+  }
+  return killed;
+}
+
+/**
  * Bun SyncSubprocess shape for the fields used in diagnostics.  The full
  * interface includes stdout/stderr buffers and resourceUsage, but only the
  * exit-related fields matter here.
@@ -440,6 +502,40 @@ export function runBunTests(
 function main(): void {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = resolve(scriptDir, '..');
+
+  // Reap any stale orphaned test processes from previous runs before starting.
+  // This prevents orphaned bun test processes from accumulating when parent
+  // runners are killed (e.g. by OOM). See issue #2909.
+  reapStaleBunTestProcesses(
+    (cmd) => {
+      const result = Bun.spawnSync({
+        cmd: [...cmd],
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      return { stdout: decodeOutput(result.stdout) };
+    },
+    (pid, signal) => process.kill(pid, signal),
+    process.pid,
+    console.error,
+  );
+
+  // Register signal handlers so that Ctrl-C or CI cancellation exits promptly.
+  // Since Bun.spawnSync blocks the event loop, these handlers only fire
+  // between files (not during a running child), so they cannot kill an
+  // in-flight child. For SIGKILL (OOM), the pre-run reaping guard above
+  // is the protection mechanism.
+  let terminating = false;
+  const handleSignal = (signal: string): void => {
+    if (terminating) return;
+    terminating = true;
+    console.error(`[run_bun_tests] Received ${signal}, exiting.`);
+    process.exit(130);
+  };
+  process.on('SIGTERM', () => handleSignal('SIGTERM'));
+  process.on('SIGINT', () => handleSignal('SIGINT'));
+  process.on('SIGHUP', () => handleSignal('SIGHUP'));
+
   process.exitCode = runBunTests(process.argv.slice(2), {
     repoRoot,
     invocationDirectory: process.cwd(),

--- a/scripts/run_bun_tests.ts
+++ b/scripts/run_bun_tests.ts
@@ -68,7 +68,7 @@ export function reapStaleBunTestProcesses(
 ): number {
   let output: string;
   try {
-    output = spawnSync(['ps', '-eo', 'pid=,ppid=,comm=']).stdout ?? '';
+    output = spawnSync(['ps', '-eo', 'pid=,ppid=,args=']).stdout ?? '';
   } catch {
     return 0;
   }
@@ -526,11 +526,16 @@ function main(): void {
   // in-flight child. For SIGKILL (OOM), the pre-run reaping guard above
   // is the protection mechanism.
   let terminating = false;
+  const signalExitCodes: Record<string, number> = {
+    SIGTERM: 143,
+    SIGINT: 130,
+    SIGHUP: 129,
+  };
   const handleSignal = (signal: string): void => {
     if (terminating) return;
     terminating = true;
     console.error(`[run_bun_tests] Received ${signal}, exiting.`);
-    process.exit(130);
+    process.exit(signalExitCodes[signal] ?? 130);
   };
   process.on('SIGTERM', () => handleSignal('SIGTERM'));
   process.on('SIGINT', () => handleSignal('SIGINT'));

--- a/scripts/run_bun_tests.ts
+++ b/scripts/run_bun_tests.ts
@@ -512,6 +512,7 @@ function main(): void {
         cmd: [...cmd],
         stdout: 'pipe',
         stderr: 'pipe',
+        timeout: 5_000,
       });
       return { stdout: decodeOutput(result.stdout) };
     },

--- a/scripts/tests/run_bun_tests.test.ts
+++ b/scripts/tests/run_bun_tests.test.ts
@@ -22,6 +22,7 @@ import {
   isMainModule,
   resolveTsconfigOverride,
   runBunTests,
+  reapStaleBunTestProcesses,
   type BunTestRunnerDependencies,
   type BunTestSpawnOptions,
   type ChildExitInfo,
@@ -135,6 +136,93 @@ describe('isMainModule', () => {
   it('returns false when argv1 is undefined', () => {
     const moduleUrl = pathToFileURL('/some/path/script.ts').href;
     expect(isMainModule(undefined, moduleUrl)).toBe(false);
+  });
+});
+
+describe('reapStaleBunTestProcesses', () => {
+  it('kills orphaned bun test processes with PPID=1 using SIGTERM', () => {
+    const killedPids: number[] = [];
+    const receivedSignals: string[] = [];
+    const psOutput = [
+      '  100  1  bun test src/foo.test.ts',
+      '  200  1  node src/bar.spec.ts',
+      '  300  500  bun test src/baz.test.ts',
+      `  ${process.pid}  ${process.ppid}  bun scripts/run_bun_tests.ts`,
+    ].join('\n');
+
+    const result = reapStaleBunTestProcesses(
+      () => ({ stdout: psOutput }),
+      (pid, signal) => {
+        killedPids.push(pid);
+        receivedSignals.push(signal);
+      },
+      process.pid,
+    );
+
+    expect(result).toBe(2);
+    expect(killedPids).toContain(100);
+    expect(killedPids).toContain(200);
+    expect(killedPids).not.toContain(300);
+    expect(receivedSignals).toEqual(['SIGTERM', 'SIGTERM']);
+  });
+
+  it('does not kill the current process', () => {
+    const killedPids: number[] = [];
+    const ownPid = 12345;
+    const psOutput = `  ${ownPid}  1  bun test src/foo.test.ts`;
+
+    reapStaleBunTestProcesses(
+      () => ({ stdout: psOutput }),
+      (pid) => killedPids.push(pid),
+      ownPid,
+    );
+
+    expect(killedPids).not.toContain(ownPid);
+  });
+
+  it('does not kill non-test bun/node processes', () => {
+    const killedPids: number[] = [];
+    const psOutput = [
+      '  100  1  bun run build',
+      '  200  1  node server.js',
+      '  300  1  bun test src/real.test.ts',
+    ].join('\n');
+
+    const result = reapStaleBunTestProcesses(
+      () => ({ stdout: psOutput }),
+      (pid) => killedPids.push(pid),
+      99999,
+    );
+
+    expect(result).toBe(1);
+    expect(killedPids).toEqual([300]);
+  });
+
+  it('returns 0 when ps fails', () => {
+    const result = reapStaleBunTestProcesses(
+      () => {
+        throw new Error('ps not found');
+      },
+      () => {},
+      99999,
+    );
+
+    expect(result).toBe(0);
+  });
+
+  it('logs a warning when processes are reaped', () => {
+    const stderrMessages: string[] = [];
+    const psOutput = '  100  1  bun test src/foo.test.ts';
+
+    reapStaleBunTestProcesses(
+      () => ({ stdout: psOutput }),
+      () => {},
+      99999,
+      (msg) => stderrMessages.push(msg),
+    );
+
+    expect(stderrMessages).toHaveLength(1);
+    expect(stderrMessages[0]).toContain('Reaped 1 stale orphaned');
   });
 });
 

--- a/test-setup/augment-bun-vi.test.ts
+++ b/test-setup/augment-bun-vi.test.ts
@@ -345,3 +345,13 @@ describe('runCleanupSteps', () => {
     expect(() => runCleanupSteps([])).not.toThrow();
   });
 });
+
+describe('sync factory pre-load fail-fast', () => {
+  it('throws when a sync factory targets a nonexistent module', () => {
+    expect(() =>
+      vi.mock('./nonexistent-preload-fixture.js', () => ({
+        mocked: true,
+      })),
+    ).toThrow();
+  });
+});

--- a/test-setup/augment-bun-vi.ts
+++ b/test-setup/augment-bun-vi.ts
@@ -198,15 +198,33 @@ const resolveActualId = (id: string): string => {
 const actualModules = new Map<string, unknown>();
 const actualAsyncModules = new Map<string, Promise<unknown>>();
 const bareSpecResolvedPaths = new Set<string>();
+const mockedResolvedIds = new Set<string>();
 let actualImportSequence = 0;
 
 /**
  * Synchronously loads the actual (un-mocked) module for a resolved ID.
  * Used by importActualSync (sync factories that were pre-loaded).
+ *
+ * If a mock has been registered for this module (via mock.module) and the
+ * module was NOT pre-loaded into the cache, this function throws. This
+ * prevents the dangerous scenario where localRequire returns the mock
+ * instead of the actual module — which would cause the mock factory's
+ * spread-actual pattern ({ ...actual, override }) to spread the mock into
+ * itself, potentially creating infinite recursion.
  */
 const loadActualSync = (resolvedId: string): unknown => {
   const cached = actualModules.get(resolvedId);
   if (cached !== undefined) return cached;
+
+  if (mockedResolvedIds.has(resolvedId)) {
+    throw new Error(
+      `loadActualSync: module "${resolvedId}" was not pre-loaded and is now ` +
+        `intercepted by mock.module. localRequire would return the mock, ` +
+        `not the actual module. Fix: ensure the module loads synchronously ` +
+        `during pre-load, or use an async vi.mock factory with the ` +
+        `importOriginal parameter instead.`,
+    );
+  }
 
   const actual = localRequire(resolvedId);
   actualModules.set(resolvedId, actual);
@@ -381,6 +399,7 @@ const registerModuleMock = (
   if (!factory) {
     const resolvedId = resolveActualId(id);
     const automocked = automockModule(resolvedId);
+    mockedResolvedIds.add(resolvedId);
     return mock.module(mockId, () => automocked);
   }
 
@@ -389,23 +408,32 @@ const registerModuleMock = (
   // not the mock's incomplete evaluation state. Only safe for SYNCHRONOUS
   // factories — pre-loading an async factory causes mock.module to evaluate
   // it eagerly, which deadlocks the event loop.
+  const resolvedId = resolveActualId(id);
   if (preloadActual) {
-    const isAsyncFactory =
-      factory.constructor.name === 'AsyncFunction' ||
-      async function () {}?.constructor?.name === factory.constructor.name;
+    const asyncFunctionName = async function () {}.constructor.name;
+    const isAsyncFactory = factory.constructor.name === asyncFunctionName;
     if (!isAsyncFactory) {
-      const resolvedId = resolveActualId(id);
       try {
         loadActualSync(resolvedId);
       } catch {
-        // Module may fail to load (e.g. native bindings). The factory's
-        // importActual call will handle the error at evaluation time.
+        // The module genuinely cannot be loaded via localRequire (native
+        // bindings, ESM-only, etc.). Allow mock registration to proceed —
+        // the factory's async importOriginal callback uses Bun.build (not
+        // localRequire) and may still succeed. The mockedResolvedIds guard
+        // below ensures importActualSync calls inside the factory will
+        // fail-fast rather than return the mock.
       }
     }
   }
 
+  // Track that a mock is registered for this resolved path. This lets
+  // loadActualSync detect the dangerous case where localRequire would
+  // return the mock instead of the actual module (if pre-load failed or
+  // was skipped for async factories).
+  mockedResolvedIds.add(resolvedId);
+
   return mock.module(mockId, () =>
-    factory(() => importResolvedActual(resolveActualId(id))),
+    factory(() => importResolvedActual(resolvedId)),
   );
 };
 


### PR DESCRIPTION
## Summary

Fixes two critical defects in the Bun test harness that together took a 128 GB machine to 3.2 GB free and killed every running agent.

## Bug 1: Orphaned bun test processes are never reaped

When a parent test runner is killed (e.g. by OOM), child bun test processes reparent to PID 1 and keep spinning indefinitely — consuming CPU and RAM. 27 orphaned processes accumulated over ~9 hours in the reported incident, with one reaching 85.8 GB RSS.

**Fix:**
- Added `reapStaleBunTestProcesses()` pre-run guard that detects and kills orphaned test processes (PPID=1, matching bun/node + test/spec) before each test run starts.
- Added SIGTERM/SIGINT/SIGHUP signal handlers for prompt exit on Ctrl-C or CI cancellation.
- Added comprehensive unit tests for the reaping logic (5 test cases covering orphan detection, self-exclusion, non-test filtering, ps failure, and warning logging).

## Bug 2: Silent pre-load failure causes unbounded recursion

When `loadActualSync` fails during pre-load for a sync mock factory, the error was silently swallowed. The mock was registered anyway, and later `importActualSync` calls would return the **mock** instead of the actual module. In `StatsDisplay.theme.test.tsx` this created infinite recursion via `actual.Text` becoming a self-reference, growing `recordedTextProps` without bound.

**Fix:**
- Added `mockedResolvedIds` tracking: `loadActualSync` now throws when called for a module that has a mock registered but was not pre-loaded into the cache. This prevents the dangerous scenario where `localRequire` returns the mock instead of the actual module.
- Kept the try/catch on pre-load to allow the async `importOriginal` path for modules that genuinely cannot be `localRequire`'d (native bindings, ESM-only). The `mockedResolvedIds` guard ensures that `importActualSync` calls inside such factories will fail-fast rather than silently returning the mock.
- Simplified async factory detection (removed redundant `||` branch).

## Testing

- All 55 tests pass (34 run_bun_tests + 21 augment-bun-vi).
- Full `npm run test` passes (except 1 pre-existing failure in `userPolicyStore.test.ts` from the latest main merge).
- Lint, format, typecheck, build, and smoke test all pass.

Closes #2909