### PR TITLE
Emit one reasoning dialect and type numeric model params (Fixes #2896)

### DIFF
--- a/docs/reference/ephemerals.md
+++ b/docs/reference/ephemerals.md
@@ -22,6 +22,33 @@ Control extended thinking / chain-of-thought. Most models need `reasoning.enable
 | `reasoning.summary`           | enum    | —                | yes     | OpenAI Responses API reasoning summary: `auto`, `concise`, `detailed`, `none`. Codex alias defaults to `auto`.                                                                                                                                                                                                                           |
 | `text.verbosity`              | enum    | —                | yes     | OpenAI Responses API text verbosity for thinking output: `low`, `medium`, `high`.                                                                                                                                                                                                                                                        |
 
+### Reasoning dialect on OpenAI-compatible endpoints
+
+`reasoning.enabled` and `reasoning.effort` are provider-neutral settings.
+Vendors disagree on how to express them on the wire, so on the OpenAI Chat
+Completions transport llxprt emits **at most one** vendor dialect, chosen from
+the endpoint's base URL:
+
+| Base URL host         | Emitted field                                 |
+| --------------------- | --------------------------------------------- |
+| `openrouter.ai`       | `reasoning: { effort }` (or `{ enabled }`)    |
+| `z.ai`, `bigmodel.cn` | `thinking: { type: "enabled" \| "disabled" }` |
+| anything else         | nothing                                       |
+
+llxprt cannot know an arbitrary OpenAI-compatible endpoint's dialect, and
+guessing gets requests rejected — Friendli answers `422 no such field:
+'reasoning'` and Crusoe answers `403 parameter 'reasoning' is not allowed`.
+So unlisted endpoints get no reasoning field at all and use the model's own
+default.
+
+To drive a reasoning field on an unlisted endpoint, set it as a model param;
+an explicit model param always wins over the automatic selection and nothing
+else is added alongside it:
+
+    /set modelparam thinking {"type":"enabled"}
+    /set modelparam reasoning_effort high
+    /set modelparam parse_reasoning true
+
 ## Context and Compression
 
 Control how much context the model sees and when/how history is compressed. These directly affect quality — too small and the model loses track; too large and it drowns in noise.
@@ -195,17 +222,17 @@ Settings for multi-endpoint load balancing. Only apply when using load-balanced 
 
 These are passed directly to the provider API as-is. LLxprt doesn't validate them. Set with `/set modelparam <name> <value>`.
 
-| Parameter           | Type     | Description                                                                     |
-| ------------------- | -------- | ------------------------------------------------------------------------------- |
-| `temperature`       | number   | Sampling temperature (0.0–2.0). Lower = more deterministic.                     |
-| `max_tokens`        | number   | Max tokens to generate (OpenAI/Anthropic). Alias: `maxTokens`.                  |
-| `max_output_tokens` | number   | Max output tokens (Gemini native param).                                        |
-| `top_p`             | number   | Nucleus sampling threshold.                                                     |
-| `top_k`             | number   | Top-k sampling.                                                                 |
-| `frequency_penalty` | number   | Penalize repeated tokens.                                                       |
-| `presence_penalty`  | number   | Penalize tokens that appeared at all.                                           |
-| `seed`              | number   | Random seed for deterministic output (OpenAI only).                             |
-| `stop`              | string[] | Stop sequences — model stops generating when it produces any of these.          |
-| `response_format`   | JSON     | Response format (e.g., `{"type": "json_object"}`).                              |
-| `logit_bias`        | JSON     | Per-token bias.                                                                 |
-| `reasoning`         | JSON     | OpenAI reasoning config object. Usually set via `reasoning.*` settings instead. |
+| Parameter           | Type     | Description                                                                                                                                                                                                                                       |
+| ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `temperature`       | number   | Sampling temperature (0.0–2.0). Lower = more deterministic.                                                                                                                                                                                       |
+| `max_tokens`        | number   | Max tokens to generate (OpenAI/Anthropic). Alias: `maxTokens`.                                                                                                                                                                                    |
+| `max_output_tokens` | number   | Max output tokens (Gemini native param).                                                                                                                                                                                                          |
+| `top_p`             | number   | Nucleus sampling threshold.                                                                                                                                                                                                                       |
+| `top_k`             | number   | Top-k sampling.                                                                                                                                                                                                                                   |
+| `frequency_penalty` | number   | Penalize repeated tokens.                                                                                                                                                                                                                         |
+| `presence_penalty`  | number   | Penalize tokens that appeared at all.                                                                                                                                                                                                             |
+| `seed`              | number   | Random seed for deterministic output (OpenAI only).                                                                                                                                                                                               |
+| `stop`              | string[] | Stop sequences — model stops generating when it produces any of these.                                                                                                                                                                            |
+| `response_format`   | JSON     | Response format (e.g., `{"type": "json_object"}`).                                                                                                                                                                                                |
+| `logit_bias`        | JSON     | Per-token bias.                                                                                                                                                                                                                                   |
+| `reasoning`         | JSON     | OpenAI reasoning config object. Keys that are also `reasoning.*` settings (`effort`, `enabled`, …) are handled by those settings and by the dialect selection above; only vendor-specific extras (e.g. OpenRouter's `exclude`) pass through here. |

--- a/packages/cli/src/ui/commands/setCommand.parseValue.test.ts
+++ b/packages/cli/src/ui/commands/setCommand.parseValue.test.ts
@@ -63,6 +63,10 @@ describe('parseValue numeric edge cases', () => {
     expect(parseValue('Infinity')).toBe('Infinity');
     expect(parseValue('NaN')).toBe('NaN');
     expect(parseValue('1_000')).toBe('1_000');
+    // Syntactically numeric but overflows to Infinity, which JSON-serializes
+    // to null — it must stay text, matching the settings layer.
+    expect(parseValue('1e400')).toBe('1e400');
+    expect(parseValue('-1e400')).toBe('-1e400');
     expect(parseValue('')).toBe('');
   });
 });

--- a/packages/cli/src/ui/commands/setCommand.parseValue.test.ts
+++ b/packages/cli/src/ui/commands/setCommand.parseValue.test.ts
@@ -24,8 +24,16 @@ describe('parseValue numeric edge cases', () => {
     expect(parseValue('-2.')).toBe('-2.');
   });
 
-  it('returns leading-dot values as strings', () => {
-    expect(parseValue('.5')).toBe('.5');
+  it('parses leading-dot decimals as numbers (issue #2896)', () => {
+    expect(parseValue('.5')).toBe(0.5);
+    expect(parseValue('.95')).toBe(0.95);
+    expect(parseValue('-.5')).toBe(-0.5);
+  });
+
+  it('parses exponent notation as numbers (issue #2896)', () => {
+    expect(parseValue('1e-5')).toBe(1e-5);
+    expect(parseValue('1.5e3')).toBe(1500);
+    expect(parseValue('-2E+4')).toBe(-20000);
   });
 
   it('parses booleans', () => {
@@ -39,5 +47,22 @@ describe('parseValue numeric edge cases', () => {
 
   it('returns non-JSON strings as-is', () => {
     expect(parseValue('hello')).toBe('hello');
+  });
+
+  it('rejects malformed numeric strings (issue #2896 A3)', () => {
+    // Each must NOT become a number via looksNumeric — it falls through to
+    // JSON.parse/string. Note: JSON.parse can convert some of these (e.g.
+    // '1' with whitespace), but the numeric scanner itself must reject them.
+    expect(parseValue('.')).toBe('.');
+    expect(parseValue('-')).toBe('-');
+    expect(parseValue('-.')).toBe('-.');
+    expect(parseValue('1.2.3')).toBe('1.2.3');
+    expect(parseValue('abc')).toBe('abc');
+    expect(parseValue('1abc')).toBe('1abc');
+    expect(parseValue('0x10')).toBe('0x10');
+    expect(parseValue('Infinity')).toBe('Infinity');
+    expect(parseValue('NaN')).toBe('NaN');
+    expect(parseValue('1_000')).toBe('1_000');
+    expect(parseValue('')).toBe('');
   });
 });

--- a/packages/cli/src/ui/commands/setCommand.test.ts
+++ b/packages/cli/src/ui/commands/setCommand.test.ts
@@ -234,6 +234,55 @@ describe('setCommand runtime integration', () => {
     });
   });
 
+  // Issue #2896: a registered param with the wrong type used to be stored
+  // verbatim and put a malformed field on the wire — OpenRouter answers
+  // 400 "top_p: Invalid input: expected number, received string".
+  it('stores a leading-dot decimal model param as a number', async () => {
+    await setCommand.action!(context, 'modelparam top_p .95');
+
+    expect(mockRuntime.setActiveModelParam).toHaveBeenCalledWith('top_p', 0.95);
+  });
+
+  it.each(['abc', 'true', '{"a":1}', '1e400'])(
+    'rejects %j for a number-typed model param and stores nothing',
+    async (raw) => {
+      const result = await setCommand.action!(
+        context,
+        `modelparam top_p ${raw}`,
+      );
+
+      expect(mockRuntime.setActiveModelParam).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        type: 'message',
+        messageType: 'error',
+      });
+      expect((result as { content: string }).content).toContain(
+        'must be a number',
+      );
+    },
+  );
+
+  it('validates through the registry alias, not just the canonical key', async () => {
+    const result = await setCommand.action!(
+      context,
+      'modelparam max-tokens abc',
+    );
+
+    expect(mockRuntime.setActiveModelParam).not.toHaveBeenCalled();
+    expect((result as { content: string }).content).toContain(
+      'must be a number',
+    );
+  });
+
+  it('still accepts an unregistered provider-specific param verbatim', async () => {
+    await setCommand.action!(context, 'modelparam parse_reasoning true');
+
+    expect(mockRuntime.setActiveModelParam).toHaveBeenCalledWith(
+      'parse_reasoning',
+      true,
+    );
+  });
+
   it('requires both key and value for modelparam', async () => {
     const result = await setCommand.action!(context, 'modelparam temperature');
 

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -19,6 +19,7 @@ import {
 import {
   resolveAlias,
   isStrictNumericString,
+  validateSetting,
 } from '@vybestack/llxprt-code-settings';
 import { buildSetSchema } from './setCommandSchema.js';
 
@@ -59,7 +60,24 @@ function handleSetModelParam(parts: string[]): MessageActionReturn {
   const runtime = getRuntimeApi();
   const paramName = parts[1];
   const rawValue = parts.slice(2).join(' ');
-  const parsedParamValue = parseValue(rawValue);
+  const parsed = parseValue(rawValue);
+
+  // Type-check against the registry before storing. A registered param with
+  // the wrong type would otherwise be persisted verbatim and put a malformed
+  // field on the wire — OpenRouter answers 400 "top_p: Invalid input:
+  // expected number, received string" (issue #2896). Unregistered keys are
+  // still accepted so arbitrary provider-specific passthrough keeps working.
+  const validation = validateSetting(paramName, parsed);
+  if (!validation.success) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content:
+        validation.message ??
+        `Invalid value for model parameter '${paramName}'`,
+    };
+  }
+  const parsedParamValue = validation.value ?? parsed;
 
   try {
     runtime.setActiveModelParam(paramName, parsedParamValue);

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -16,7 +16,10 @@ import {
   ephemeralSettingHelp,
   parseEphemeralSettingValue,
 } from '@vybestack/llxprt-code-providers/runtime.js';
-import { resolveAlias } from '@vybestack/llxprt-code-settings';
+import {
+  resolveAlias,
+  isStrictNumericString,
+} from '@vybestack/llxprt-code-settings';
 import { buildSetSchema } from './setCommandSchema.js';
 
 // Subcommand for /set unset - removes ephemeral settings or model parameters
@@ -312,27 +315,6 @@ export function parseValue(value: string): unknown {
 }
 
 function looksNumeric(value: string): boolean {
-  let i = 0;
-  if (value[0] === '-') {
-    i = 1;
-  }
-  const digitsStart = i;
-  while (i < value.length && value[i] >= '0' && value[i] <= '9') {
-    i++;
-  }
-  const hasIntegerDigits = i > digitsStart;
-
-  if (i < value.length && value[i] === '.') {
-    i++;
-    const fractionStart = i;
-    while (i < value.length && value[i] >= '0' && value[i] <= '9') {
-      i++;
-    }
-    const hasFractionDigits = i > fractionStart;
-    // Dot must be followed by at least one digit
-    return hasIntegerDigits && hasFractionDigits && i === value.length;
-  }
-
-  return hasIntegerDigits && i === value.length;
+  return isStrictNumericString(value);
 }
 // Stryker restore all

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -289,12 +289,13 @@ export const setCommand: SlashCommand = {
  * Handles numbers, booleans, and JSON objects/arrays.
  */
 export function parseValue(value: string): unknown {
-  // Try to parse as number
+  // Try to parse as number. An overflow literal such as '1e400' is
+  // syntactically numeric but evaluates to Infinity, which JSON-serializes to
+  // null; keep it as text so it never reaches a request body, matching the
+  // settings layer's ingress and egress guards (issue #2896).
   if (looksNumeric(value)) {
     const num = Number(value);
-    if (!isNaN(num)) {
-      return num;
-    }
+    return Number.isFinite(num) ? num : value;
   }
 
   // Try to parse as boolean

--- a/packages/cli/src/ui/components/ModelConfigDialog.tsx
+++ b/packages/cli/src/ui/components/ModelConfigDialog.tsx
@@ -16,6 +16,10 @@ import { TextInput } from './ProfileCreateWizard/TextInput.js';
 import { parseValue } from '../commands/setCommand.js';
 import { parseEphemeralSettingValue } from '@vybestack/llxprt-code-providers/runtime.js';
 import { getSettingSpec } from '@vybestack/llxprt-code-settings';
+import {
+  commitModelParam,
+  type CommitResult,
+} from './modelConfigParamCommit.js';
 
 // Pending values for one field, staged in the dialog until [Save] commits
 // them to the runtime. Cancel/Esc discards them wholesale.
@@ -147,11 +151,6 @@ function formatValue(value: unknown): string {
   if (value === undefined || value === null) return '(not set)';
   if (typeof value === 'object') return JSON.stringify(value);
   return String(value);
-}
-
-interface CommitResult {
-  success: boolean;
-  message?: string;
 }
 
 function valueForField(
@@ -449,7 +448,7 @@ function applyFieldEdit(
   }
 
   if (field.kind === 'param') {
-    const result = commitParam(raw, (value) =>
+    const result = commitModelParam(field.key, raw, (value) =>
       d.runtime.setActiveModelParam(field.key, value),
     );
     return result.success ? null : (result.message ?? 'Invalid value');
@@ -459,21 +458,6 @@ function applyFieldEdit(
     d.runtime.setEphemeralSetting(field.key, value),
   );
   return result.success ? null : (result.message ?? 'Invalid value');
-}
-
-function commitParam(
-  raw: string,
-  setActiveModelParam: (value: unknown) => void,
-): CommitResult {
-  try {
-    setActiveModelParam(parseValue(raw));
-    return { success: true };
-  } catch (e) {
-    return {
-      success: false,
-      message: e instanceof Error ? e.message : String(e),
-    };
-  }
 }
 
 function commitEphemeral(

--- a/packages/cli/src/ui/components/ModelConfigDialog.tsx
+++ b/packages/cli/src/ui/components/ModelConfigDialog.tsx
@@ -451,13 +451,13 @@ function applyFieldEdit(
     const result = commitModelParam(field.key, raw, (value) =>
       d.runtime.setActiveModelParam(field.key, value),
     );
-    return result.success ? null : (result.message ?? 'Invalid value');
+    return result.success ? null : result.message;
   }
 
   const result = commitEphemeral(field, raw, (value) =>
     d.runtime.setEphemeralSetting(field.key, value),
   );
-  return result.success ? null : (result.message ?? 'Invalid value');
+  return result.success ? null : result.message;
 }
 
 function commitEphemeral(

--- a/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
@@ -61,8 +61,10 @@ describe('commitModelParam (issue #2896)', () => {
     const r = recorder();
     const result = commitModelParam('top_p', 'abc', r.set);
 
-    expect(result.success).toBe(false);
-    expect(result.message).toBe(NOT_A_NUMBER_MESSAGE);
+    expect(result).toStrictEqual({
+      success: false,
+      message: NOT_A_NUMBER_MESSAGE,
+    });
     expect(r.writes).toStrictEqual([]);
   });
 
@@ -135,7 +137,9 @@ describe('commitModelParam (issue #2896)', () => {
       throw new Error('no active provider');
     });
 
-    expect(result.success).toBe(false);
-    expect(result.message).toBe('no active provider');
+    expect(result).toStrictEqual({
+      success: false,
+      message: 'no active provider',
+    });
   });
 });

--- a/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue #2896 - The model config dialog wrote numeric model params as
+ * strings (`"top_p": ".95"`), which OpenRouter rejects with
+ * `top_p: Invalid input: expected number, received string`.
+ *
+ * These tests drive the real commit path the dialog uses (real `parseValue`,
+ * real settings registry) and assert on what the runtime actually receives.
+ *
+ * Acceptance rows covered: A4, A5, A6.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  commitModelParam,
+  NOT_A_NUMBER_MESSAGE,
+} from './modelConfigParamCommit.js';
+
+/** Captures exactly what the dialog would write into the runtime. */
+function recorder() {
+  const writes: unknown[] = [];
+  return {
+    writes,
+    set: (value: unknown) => {
+      writes.push(value);
+    },
+  };
+}
+
+describe('commitModelParam (issue #2896)', () => {
+  // A4 — the exact input from the bug report.
+  it('A4: commits ".95" for top_p as the number 0.95', () => {
+    const r = recorder();
+    const result = commitModelParam('top_p', '.95', r.set);
+
+    expect(result.success).toBe(true);
+    expect(r.writes).toStrictEqual([0.95]);
+    expect(typeof r.writes[0]).toBe('number');
+  });
+
+  it('A4: commits "0.95" for top_p as the number 0.95', () => {
+    const r = recorder();
+    commitModelParam('top_p', '0.95', r.set);
+    expect(r.writes).toStrictEqual([0.95]);
+  });
+
+  it('A4: commits negative and exponent forms as numbers', () => {
+    const r = recorder();
+    commitModelParam('presence_penalty', '-.5', r.set);
+    commitModelParam('temperature', '1e-5', r.set);
+    expect(r.writes).toStrictEqual([-0.5, 1e-5]);
+  });
+
+  // A5 — non-numeric input must be rejected, not written as a string.
+  it('A5: rejects "abc" for top_p and writes nothing', () => {
+    const r = recorder();
+    const result = commitModelParam('top_p', 'abc', r.set);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe(NOT_A_NUMBER_MESSAGE);
+    expect(r.writes).toStrictEqual([]);
+  });
+
+  // '1e400' and '-1e400' are syntactically valid numbers that overflow to
+  // +/-Infinity, which JSON-serializes to null — the finite guard must reject
+  // them rather than write an unusable value.
+  it.each([
+    '.',
+    '-',
+    '-.',
+    '1.2.3',
+    'Infinity',
+    'NaN',
+    '0x10',
+    '1_000',
+    '1e400',
+    '-1e400',
+  ])('A5: rejects %j for top_p and writes nothing', (raw) => {
+    const r = recorder();
+    const result = commitModelParam('top_p', raw, r.set);
+
+    expect(result.success).toBe(false);
+    expect(r.writes).toStrictEqual([]);
+  });
+
+  it('A5: rejects a JSON object for a number-typed param', () => {
+    const r = recorder();
+    const result = commitModelParam('top_p', '{"a":1}', r.set);
+
+    expect(result.success).toBe(false);
+    expect(r.writes).toStrictEqual([]);
+  });
+
+  it('A5: rejects a boolean literal for a number-typed param', () => {
+    const r = recorder();
+    const result = commitModelParam('temperature', 'true', r.set);
+
+    expect(result.success).toBe(false);
+    expect(r.writes).toStrictEqual([]);
+  });
+
+  // A6 — the remaining number-typed dialog fields keep their integer typing.
+  it.each([
+    ['max_tokens', '32000', 32000],
+    ['top_k', '40', 40],
+    ['frequency_penalty', '0', 0],
+    ['presence_penalty', '1.25', 1.25],
+    ['temperature', '0.7', 0.7],
+  ])('A6: commits %s=%s as the number %d', (key, raw, expected) => {
+    const r = recorder();
+    const result = commitModelParam(key, raw, r.set);
+
+    expect(result.success).toBe(true);
+    expect(r.writes).toStrictEqual([expected]);
+    expect(typeof r.writes[0]).toBe('number');
+  });
+
+  // The numeric guard is registry-driven: a key with no number spec keeps the
+  // previous pass-through behavior.
+  it('passes an unregistered param through without numeric validation', () => {
+    const r = recorder();
+    const result = commitModelParam('parse_reasoning', 'true', r.set);
+
+    expect(result.success).toBe(true);
+    expect(r.writes).toStrictEqual([true]);
+  });
+
+  it('surfaces a runtime write failure as a validation message', () => {
+    const result = commitModelParam('top_p', '0.5', () => {
+      throw new Error('no active provider');
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('no active provider');
+  });
+});

--- a/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
@@ -106,7 +106,8 @@ describe('commitModelParam (issue #2896)', () => {
     expect(r.writes).toStrictEqual([]);
   });
 
-  // A6 — the remaining number-typed dialog fields keep their integer typing.
+  // A6 — the remaining number-typed dialog fields, integer and fractional
+  // alike, are written as numbers.
   it.each([
     ['max_tokens', '32000', 32000],
     ['top_k', '40', 40],

--- a/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
@@ -114,7 +114,7 @@ describe('commitModelParam (issue #2896)', () => {
     ['frequency_penalty', '0', 0],
     ['presence_penalty', '1.25', 1.25],
     ['temperature', '0.7', 0.7],
-  ])('A6: commits %s=%s as the number %d', (key, raw, expected) => {
+  ])('A6: commits %s=%s as the number %s', (key, raw, expected) => {
     const r = recorder();
     const result = commitModelParam(key, raw, r.set);
 

--- a/packages/cli/src/ui/components/modelConfigParamCommit.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.ts
@@ -24,10 +24,13 @@
 import { getSettingSpec } from '@vybestack/llxprt-code-settings';
 import { parseValue } from '../commands/setCommand.js';
 
-export interface CommitResult {
-  success: boolean;
-  message?: string;
-}
+/**
+ * Discriminated so a caller cannot read `message` without first narrowing on
+ * the failure branch, and so the failure branch always carries one.
+ */
+export type CommitResult =
+  | { success: true }
+  | { success: false; message: string };
 
 export const NOT_A_NUMBER_MESSAGE = 'must be a number';
 

--- a/packages/cli/src/ui/components/modelConfigParamCommit.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.ts
@@ -47,11 +47,14 @@ export function commitModelParam(
   raw: string,
   setActiveModelParam: (value: unknown) => void,
 ): CommitResult {
-  const parsed = parseValue(raw);
-  if (requiresNumber(key) && !isFiniteNumber(parsed)) {
-    return { success: false, message: NOT_A_NUMBER_MESSAGE };
-  }
+  // Parsing stays inside the guarded region, as it was before this logic was
+  // extracted from the dialog: an escaping throw would tear down the Ink UI
+  // instead of surfacing as the inline validation message.
   try {
+    const parsed = parseValue(raw);
+    if (requiresNumber(key) && !isFiniteNumber(parsed)) {
+      return { success: false, message: NOT_A_NUMBER_MESSAGE };
+    }
     setActiveModelParam(parsed);
     return { success: true };
   } catch (e) {

--- a/packages/cli/src/ui/components/modelConfigParamCommit.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Model-parameter commit logic for the model config dialog.
+ *
+ * Extracted from `ModelConfigDialog.tsx` so the typing contract can be
+ * exercised directly: full-render Ink component tests under
+ * `src/ui/components/` are excluded from this package's vitest routing
+ * (see `vitest.test-groups.ts`), so behavior asserted only through the
+ * rendered dialog would never run in CI.
+ *
+ * Contract (issue #2896): a field whose registry spec declares
+ * `type: 'number'` must be written to the runtime as a finite `number`.
+ * A value that does not parse to a finite number is rejected with a
+ * validation message instead of being written as a raw string — that is how
+ * `"top_p": ".95"` reached a profile and produced
+ * `top_p: Invalid input: expected number, received string` from OpenRouter.
+ */
+
+import { getSettingSpec } from '@vybestack/llxprt-code-settings';
+import { parseValue } from '../commands/setCommand.js';
+
+export interface CommitResult {
+  success: boolean;
+  message?: string;
+}
+
+export const NOT_A_NUMBER_MESSAGE = 'must be a number';
+
+/**
+ * Parse `raw` for the model parameter `key` and hand the typed value to
+ * `setActiveModelParam`.
+ *
+ * Returns `{ success: false }` when the registry declares the parameter
+ * numeric and the input does not parse to a finite number, or when the
+ * runtime write throws (e.g. no active provider).
+ */
+export function commitModelParam(
+  key: string,
+  raw: string,
+  setActiveModelParam: (value: unknown) => void,
+): CommitResult {
+  const parsed = parseValue(raw);
+  if (requiresNumber(key) && !isFiniteNumber(parsed)) {
+    return { success: false, message: NOT_A_NUMBER_MESSAGE };
+  }
+  try {
+    setActiveModelParam(parsed);
+    return { success: true };
+  } catch (e) {
+    return {
+      success: false,
+      message: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+function requiresNumber(key: string): boolean {
+  return getSettingSpec(key)?.type === 'number';
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/packages/cli/vitest.test-groups.ts
+++ b/packages/cli/vitest.test-groups.ts
@@ -479,4 +479,4 @@ export function buildTestGroups(
  * The expected total selected file count after integrating the v0.11.0 test set.
  * Exported for behavioral tests to assert against an independent oracle.
  */
-export const SELECTED_FILE_COUNT: number = 523;
+export const SELECTED_FILE_COUNT: number = 524;

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue1943.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue1943.test.ts
@@ -303,13 +303,14 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #1943)', () => {
     expect(result.detectedFormat).toBe('kimi'); // auto overrides → auto-detect
   });
 
-  it('sets thinking enabled on request body when reasoning.enabled is true', async () => {
+  it('sets thinking enabled on request body when reasoning.enabled is true (z.ai dialect)', async () => {
     const settings = new SettingsService();
     const options = createMockOptions(
       {
         settings,
         resolved: {
           model: 'gpt-4o',
+          baseURL: 'https://api.z.ai/api/paas/v4',
           authToken: { token: 'test-token', type: 'api-key' },
         },
       },
@@ -327,13 +328,14 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #1943)', () => {
     expect(result.requestBody).toHaveProperty('thinking', { type: 'enabled' });
   });
 
-  it('sets thinking disabled on request body when reasoning.enabled is false', async () => {
+  it('sets thinking disabled on request body when reasoning.enabled is false (z.ai dialect)', async () => {
     const settings = new SettingsService();
     const options = createMockOptions(
       {
         settings,
         resolved: {
           model: 'gpt-4o',
+          baseURL: 'https://api.z.ai/api/paas/v4',
           authToken: { token: 'test-token', type: 'api-key' },
         },
       },

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue2896.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue2896.test.ts
@@ -1,0 +1,511 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue #2896 - Request-body reasoning-dialect integration tests for
+ * `prepareRequest`. These exercise the real OpenAIRequestPreparation pipeline
+ * through `prepareRequest`, asserting that at most ONE reasoning
+ * representation (`reasoning` / `thinking` / `reasoning_effort`) ever reaches
+ * the outbound request body, and that foreign-dialect keys are absent.
+ *
+ * Acceptance rows covered: B3–B12.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { prepareRequest } from './OpenAIRequestPreparation.js';
+import { REASONING_WIRE_KEYS } from './openaiReasoningDialect.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('test system prompt'),
+}));
+
+vi.mock(
+  '@vybestack/llxprt-code-core/prompt-config/subagent-delegation.js',
+  () => ({
+    shouldIncludeSubagentDelegation: vi.fn().mockResolvedValue(false),
+  }),
+);
+
+vi.mock('../utils/userMemory.js', () => ({
+  resolveUserMemory: vi.fn().mockResolvedValue(''),
+}));
+
+function createMockOptions(
+  overrides: {
+    baseURL?: string;
+    modelBehavior?: Record<string, unknown>;
+    modelParams?: Record<string, unknown>;
+    ephemerals?: Record<string, unknown>;
+  } = {},
+): NormalizedGenerateChatOptions {
+  const settings = new SettingsService();
+  const invocation: Record<string, unknown> = {
+    requestId: 'test-request',
+    timestamp: Date.now(),
+    modelBehavior: overrides.modelBehavior ?? {},
+    ephemerals: overrides.ephemerals ?? {},
+    modelParams: overrides.modelParams ?? {},
+  };
+  return {
+    contents: [],
+    tools: undefined,
+    metadata: {},
+    settings,
+    config: undefined,
+    invocation,
+    resolved: {
+      model: 'gpt-4o',
+      baseURL: overrides.baseURL,
+      authToken: { token: 'test-token', type: 'api-key' },
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+}
+
+function countReasoningKeys(body: Record<string, unknown>): number {
+  return REASONING_WIRE_KEYS.filter((k) => k in body).length;
+}
+
+describe('OpenAIRequestPreparation.prepareRequest (issue #2896)', () => {
+  let logger: DebugLogger;
+
+  beforeEach(() => {
+    logger = new DebugLogger('llxprt:provider:openai:test');
+  });
+
+  // B3: Friendli — no reasoning injected
+  it('B3: friendli endpoint emits no reasoning/thinking/reasoning_effort', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://api.friendli.ai/serverless/v1',
+      modelBehavior: { 'reasoning.enabled': true, 'reasoning.effort': 'high' },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).not.toHaveProperty('reasoning');
+    expect(body).not.toHaveProperty('thinking');
+    expect(body).not.toHaveProperty('reasoning_effort');
+  });
+
+  // B4: Crusoe — no reasoning injected (trailing slash must still resolve)
+  it('B4: crusoe endpoint emits no reasoning/thinking/reasoning_effort', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://api.inference.crusoecloud.com/v1/',
+      modelBehavior: { 'reasoning.enabled': true, 'reasoning.effort': 'high' },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).not.toHaveProperty('reasoning');
+    expect(body).not.toHaveProperty('thinking');
+    expect(body).not.toHaveProperty('reasoning_effort');
+  });
+
+  // B5: OpenRouter — exactly reasoning: { effort: 'high' }
+  it('B5: openrouter endpoint emits reasoning.effort only', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://openrouter.ai/api/v1',
+      modelBehavior: { 'reasoning.enabled': true, 'reasoning.effort': 'high' },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).toHaveProperty('reasoning', { effort: 'high' });
+    expect(body).not.toHaveProperty('thinking');
+    expect(body).not.toHaveProperty('reasoning_effort');
+    expect(countReasoningKeys(body)).toBe(1);
+  });
+
+  // B6: z.ai — thinking: { type: 'enabled' }
+  it('B6: z.ai endpoint emits thinking.type=enabled only', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://api.z.ai/api/paas/v4',
+      modelBehavior: { 'reasoning.enabled': true },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).toHaveProperty('thinking', { type: 'enabled' });
+    expect(body).not.toHaveProperty('reasoning');
+    expect(body).not.toHaveProperty('reasoning_effort');
+    expect(countReasoningKeys(body)).toBe(1);
+  });
+
+  // B7: z.ai with reasoning.enabled=false — thinking: { type: 'disabled' }
+  it('B7: z.ai endpoint emits thinking.type=disabled when enabled is false', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://api.z.ai/api/paas/v4',
+      modelBehavior: { 'reasoning.enabled': false },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).toHaveProperty('thinking', { type: 'disabled' });
+    expect(body).not.toHaveProperty('reasoning');
+    expect(countReasoningKeys(body)).toBe(1);
+  });
+
+  // B8: bigmodel.cn — thinking: { type: 'enabled' }
+  it('B8: bigmodel.cn endpoint emits thinking.type=enabled only', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://open.bigmodel.cn/api/paas/v4',
+      modelBehavior: { 'reasoning.enabled': true },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).toHaveProperty('thinking', { type: 'enabled' });
+    expect(body).not.toHaveProperty('reasoning');
+    expect(countReasoningKeys(body)).toBe(1);
+  });
+
+  // B9: user sets modelParams.thinking explicitly — user value wins
+  it('B9: explicit modelParams.thinking wins and is not overridden', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://api.z.ai/api/paas/v4',
+      modelBehavior: { 'reasoning.enabled': true },
+      // 'disabled' is deliberately the opposite of what auto-selection would
+      // emit for reasoning.enabled=true, so the assertion fails if the
+      // explicit value is overwritten rather than respected.
+      modelParams: { thinking: { type: 'disabled' } },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    // The user value arrives verbatim; no duplicate is injected.
+    expect(body).toHaveProperty('thinking', { type: 'disabled' });
+    expect(countReasoningKeys(body)).toBe(1);
+  });
+
+  // B9: Friendli-native parse_reasoning also stands down auto-selection —
+  // this is the third field from the issue's reported fan-out.
+  it('B9: explicit modelParams.parse_reasoning suppresses the host dialect', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://api.z.ai/api/paas/v4',
+      modelBehavior: { 'reasoning.enabled': true, 'reasoning.effort': 'high' },
+      modelParams: { parse_reasoning: true },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).toHaveProperty('parse_reasoning', true);
+    expect(body).not.toHaveProperty('thinking');
+    expect(body).not.toHaveProperty('reasoning');
+    expect(countReasoningKeys(body)).toBe(1);
+  });
+
+  it('B9: explicit modelParams.parse_reasoning suppresses the openrouter dialect', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://openrouter.ai/api/v1',
+      modelBehavior: { 'reasoning.enabled': true, 'reasoning.effort': 'high' },
+      modelParams: { parse_reasoning: true },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).toHaveProperty('parse_reasoning', true);
+    expect(body).not.toHaveProperty('reasoning');
+    expect(countReasoningKeys(body)).toBe(1);
+  });
+
+  it('B9: explicit modelParams.reasoning wins and no thinking is auto-injected', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://api.z.ai/api/paas/v4',
+      modelBehavior: { 'reasoning.enabled': true },
+      modelParams: { reasoning: { effort: 'max' } },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).toHaveProperty('reasoning', { effort: 'max' });
+    expect(body).not.toHaveProperty('thinking');
+    expect(countReasoningKeys(body)).toBe(1);
+  });
+
+  // B10: user sets modelParams.reasoning_effort explicitly — user value wins
+  it('B10: explicit modelParams.reasoning_effort wins and no other dialect is injected', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://api.z.ai/api/paas/v4',
+      modelBehavior: { 'reasoning.enabled': true },
+      modelParams: { reasoning_effort: 'high' },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).toHaveProperty('reasoning_effort', 'high');
+    expect(body).not.toHaveProperty('thinking');
+    expect(body).not.toHaveProperty('reasoning');
+    expect(countReasoningKeys(body)).toBe(1);
+  });
+
+  // B11: no base-url (canonical OpenAI) — no thinking
+  it('B11: canonical OpenAI (no base-url) emits no thinking', async () => {
+    const options = createMockOptions({
+      modelBehavior: { 'reasoning.enabled': true },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).not.toHaveProperty('thinking');
+    expect(body).not.toHaveProperty('reasoning');
+    expect(body).not.toHaveProperty('reasoning_effort');
+  });
+
+  // B11 variant: base-url from ephemeral 'base-url' (not resolved.baseURL)
+  it('B11: resolves base-url from ephemeral settings when resolved.baseURL is absent', async () => {
+    const options = createMockOptions({
+      ephemerals: { 'base-url': 'https://api.z.ai/api/paas/v4' },
+      modelBehavior: { 'reasoning.enabled': true },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    // z.ai dialect via ephemeral base-url → thinking emitted
+    expect(body).toHaveProperty('thinking', { type: 'enabled' });
+  });
+
+  // B12: invariant — at most one reasoning representation for every combination
+  describe('B12: invariant — at most one of reasoning/thinking/reasoning_effort', () => {
+    const cases: Array<{
+      label: string;
+      baseURL?: string;
+      modelBehavior?: Record<string, unknown>;
+      modelParams?: Record<string, unknown>;
+    }> = [
+      {
+        label: 'friendli, reasoning enabled+effort',
+        baseURL: 'https://api.friendli.ai/serverless/v1',
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+        },
+      },
+      {
+        label: 'crusoe (trailing slash), reasoning enabled+effort',
+        baseURL: 'https://api.inference.crusoecloud.com/v1/',
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+        },
+      },
+      {
+        label: 'openrouter, reasoning enabled+effort',
+        baseURL: 'https://openrouter.ai/api/v1',
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+        },
+      },
+      {
+        label: 'openrouter, reasoning enabled, no effort',
+        baseURL: 'https://openrouter.ai/api/v1',
+        modelBehavior: { 'reasoning.enabled': true },
+      },
+      {
+        label: 'z.ai, reasoning enabled',
+        baseURL: 'https://api.z.ai/api/paas/v4',
+        modelBehavior: { 'reasoning.enabled': true },
+      },
+      {
+        label: 'z.ai, reasoning disabled',
+        baseURL: 'https://api.z.ai/api/paas/v4',
+        modelBehavior: { 'reasoning.enabled': false },
+      },
+      {
+        label: 'bigmodel.cn, reasoning enabled',
+        baseURL: 'https://open.bigmodel.cn/api/paas/v4',
+        modelBehavior: { 'reasoning.enabled': true },
+      },
+      {
+        label: 'canonical openai (no base-url)',
+        modelBehavior: { 'reasoning.enabled': true },
+      },
+      {
+        label: 'no reasoning settings at all',
+        baseURL: 'https://openrouter.ai/api/v1',
+      },
+      {
+        label: 'explicit modelParams.thinking on z.ai',
+        baseURL: 'https://api.z.ai/api/paas/v4',
+        modelBehavior: { 'reasoning.enabled': true },
+        modelParams: { thinking: { type: 'enabled' } },
+      },
+      {
+        label: 'explicit modelParams.reasoning_effort on z.ai',
+        baseURL: 'https://api.z.ai/api/paas/v4',
+        modelBehavior: { 'reasoning.enabled': true },
+        modelParams: { reasoning_effort: 'high' },
+      },
+      {
+        label: 'explicit modelParams.parse_reasoning on z.ai',
+        baseURL: 'https://api.z.ai/api/paas/v4',
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+        },
+        modelParams: { parse_reasoning: true },
+      },
+      {
+        label: 'explicit modelParams.parse_reasoning on openrouter',
+        baseURL: 'https://openrouter.ai/api/v1',
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+        },
+        modelParams: { parse_reasoning: true },
+      },
+      {
+        label: 'openrouter, reasoning disabled with a leftover effort',
+        baseURL: 'https://openrouter.ai/api/v1',
+        modelBehavior: {
+          'reasoning.enabled': false,
+          'reasoning.effort': 'high',
+        },
+      },
+      {
+        label: 'z.ai, no reasoning settings at all',
+        baseURL: 'https://api.z.ai/api/paas/v4',
+      },
+    ];
+
+    for (const tc of cases) {
+      it(`at most one reasoning key: ${tc.label}`, async () => {
+        const options = createMockOptions({
+          baseURL: tc.baseURL,
+          modelBehavior: tc.modelBehavior,
+          modelParams: tc.modelParams,
+        });
+
+        const result = await prepareRequest(
+          options,
+          'gpt-4o',
+          undefined,
+          logger,
+          'openai',
+        );
+
+        const body = result.requestBody as Record<string, unknown>;
+        expect(countReasoningKeys(body)).toBeLessThanOrEqual(1);
+      });
+    }
+  });
+
+  // Regression: arbitrary modelParams passthrough still arrives intact
+  it('preserves arbitrary modelParams passthrough (parse_reasoning, chat_template_kwargs)', async () => {
+    const options = createMockOptions({
+      baseURL: 'https://api.friendli.ai/serverless/v1',
+      modelParams: {
+        parse_reasoning: true,
+        chat_template_kwargs: { foo: 'bar' },
+      },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const body = result.requestBody as Record<string, unknown>;
+    expect(body).toHaveProperty('parse_reasoning', true);
+    expect(body).toHaveProperty('chat_template_kwargs', { foo: 'bar' });
+  });
+});

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue2896.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue2896.test.ts
@@ -417,6 +417,15 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #2896)', () => {
         modelBehavior: { 'reasoning.enabled': true },
       },
       {
+        // The exact profile shape from the issue, on the default provider
+        // path: this is what produced modelParams.reasoning = { effort }.
+        label: 'canonical openai (no base-url), reasoning enabled+effort',
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+        },
+      },
+      {
         label: 'no reasoning settings at all',
         baseURL: 'https://openrouter.ai/api/v1',
       },

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue2896.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue2896.test.ts
@@ -207,7 +207,7 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #2896)', () => {
   });
 
   // B9: user sets modelParams.thinking explicitly — user value wins
-  it('B9: explicit modelParams.thinking wins and is not overridden', async () => {
+  it('B9a: an explicit modelParams.thinking wins and is not overridden', async () => {
     const options = createMockOptions({
       baseURL: 'https://api.z.ai/api/paas/v4',
       modelBehavior: { 'reasoning.enabled': true },
@@ -233,7 +233,7 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #2896)', () => {
 
   // B9: Friendli-native parse_reasoning also stands down auto-selection —
   // this is the third field from the issue's reported fan-out.
-  it('B9: explicit modelParams.parse_reasoning suppresses the host dialect', async () => {
+  it('B9c: an explicit modelParams.parse_reasoning suppresses the thinking dialect', async () => {
     const options = createMockOptions({
       baseURL: 'https://api.z.ai/api/paas/v4',
       modelBehavior: { 'reasoning.enabled': true, 'reasoning.effort': 'high' },
@@ -255,7 +255,7 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #2896)', () => {
     expect(countReasoningKeys(body)).toBe(1);
   });
 
-  it('B9: explicit modelParams.parse_reasoning suppresses the openrouter dialect', async () => {
+  it('B9d: an explicit modelParams.parse_reasoning suppresses the openrouter dialect', async () => {
     const options = createMockOptions({
       baseURL: 'https://openrouter.ai/api/v1',
       modelBehavior: { 'reasoning.enabled': true, 'reasoning.effort': 'high' },
@@ -276,7 +276,7 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #2896)', () => {
     expect(countReasoningKeys(body)).toBe(1);
   });
 
-  it('B9: explicit modelParams.reasoning wins and no thinking is auto-injected', async () => {
+  it('B9b: an explicit modelParams.reasoning suppresses the thinking dialect', async () => {
     const options = createMockOptions({
       baseURL: 'https://api.z.ai/api/paas/v4',
       modelBehavior: { 'reasoning.enabled': true },
@@ -298,7 +298,7 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #2896)', () => {
   });
 
   // B10: user sets modelParams.reasoning_effort explicitly — user value wins
-  it('B10: explicit modelParams.reasoning_effort wins and no other dialect is injected', async () => {
+  it('B10: an explicit modelParams.reasoning_effort wins and no other dialect is injected', async () => {
     const options = createMockOptions({
       baseURL: 'https://api.z.ai/api/paas/v4',
       modelBehavior: { 'reasoning.enabled': true },
@@ -321,7 +321,7 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #2896)', () => {
   });
 
   // B11: no base-url (canonical OpenAI) — no thinking
-  it('B11: canonical OpenAI (no base-url) emits no thinking', async () => {
+  it('B11a: canonical OpenAI (no base-url) emits no thinking', async () => {
     const options = createMockOptions({
       modelBehavior: { 'reasoning.enabled': true },
     });
@@ -341,7 +341,7 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #2896)', () => {
   });
 
   // B11 variant: base-url from ephemeral 'base-url' (not resolved.baseURL)
-  it('B11: resolves base-url from ephemeral settings when resolved.baseURL is absent', async () => {
+  it('B11b: resolves base-url from ephemeral settings when resolved.baseURL is absent', async () => {
     const options = createMockOptions({
       ephemerals: { 'base-url': 'https://api.z.ai/api/paas/v4' },
       modelBehavior: { 'reasoning.enabled': true },

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue2896.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue2896.test.ts
@@ -64,6 +64,12 @@ function createMockOptions(
       baseURL: overrides.baseURL,
       authToken: { token: 'test-token', type: 'api-key' },
     },
+    // The double assertion is load-bearing: `invocation` here is a minimal
+    // stand-in, not a real RuntimeInvocationContext (which carries runtimeId,
+    // settings, and nine more members plus its accessor methods). Narrowing it
+    // would mean constructing a full context per case and burying the
+    // assertions. openaiReasoningPipeline.test.ts covers the real, uncast
+    // object graph end to end.
   } as unknown as NormalizedGenerateChatOptions;
 }
 

--- a/packages/providers/src/openai/OpenAIRequestPreparation.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.ts
@@ -26,6 +26,11 @@ import { resolveToolFormat } from '../utils/toolFormatDetection.js';
 import { buildMessagesWithReasoning } from './OpenAIRequestBuilder.js';
 import { extractModelParamsFromOptions } from './OpenAIClientFactory.js';
 import { sanitizePromptCacheKey } from '../openai-responses/sanitizePromptCacheKey.js';
+import {
+  resolveReasoningDialect,
+  applyReasoningDialect,
+  hasExplicitReasoningField,
+} from './openaiReasoningDialect.js';
 import { type Config } from '@vybestack/llxprt-code-core/config/config.js';
 
 export interface RequestContext {
@@ -143,24 +148,51 @@ type OpenAIInvocationRuntime = {
 
 type RequestBodyWithThinking = OpenAI.Chat.ChatCompletionCreateParams & {
   thinking?: { type: 'enabled' | 'disabled' };
+  reasoning?: Record<string, unknown>;
 };
 
 function resolveReasoningConfig(
   requestBody: OpenAI.Chat.ChatCompletionCreateParams,
   options: NormalizedGenerateChatOptions,
+  ephemeralSettings: Record<string, unknown>,
 ): void {
-  if ('thinking' in requestBody || 'reasoning_effort' in requestBody) {
+  const body = requestBody as RequestBodyWithThinking;
+
+  // Short-circuit: if the user already set a reasoning field explicitly (via
+  // modelParams, which are Object.assigned into the body just before this
+  // call), do not auto-inject anything — the user value wins and stays the
+  // only reasoning representation on the wire.
+  if (hasExplicitReasoningField(body)) {
     return;
   }
+
   const invocation = options.invocation as OpenAIInvocationRuntime;
   const reasoningEnabled = invocation.modelBehavior?.['reasoning.enabled'] as
     | boolean
     | undefined;
-  const body = requestBody as RequestBodyWithThinking;
-  if (reasoningEnabled === true) {
-    body.thinking = { type: 'enabled' };
-  } else if (reasoningEnabled === false) {
-    body.thinking = { type: 'disabled' };
+  const reasoningEffort = invocation.modelBehavior?.['reasoning.effort'] as
+    | string
+    | undefined;
+
+  const baseUrl =
+    options.resolved.baseURL ??
+    (typeof ephemeralSettings['base-url'] === 'string'
+      ? ephemeralSettings['base-url']
+      : undefined);
+
+  const dialect = resolveReasoningDialect(baseUrl);
+  const applied = applyReasoningDialect(dialect, {
+    enabled: reasoningEnabled,
+    effort: reasoningEffort,
+  });
+  if (applied === null) {
+    return;
+  }
+
+  if (applied.key === 'thinking') {
+    body.thinking = applied.value;
+  } else {
+    body.reasoning = applied.value;
   }
 }
 
@@ -195,7 +227,7 @@ function applyRequestBodyOverrides(
     }
   }
 
-  resolveReasoningConfig(requestBody, options);
+  resolveReasoningConfig(requestBody, options, ephemeralSettings);
 
   if (typeof maxTokens === 'number' && Number.isFinite(maxTokens)) {
     requestBody.max_tokens = maxTokens;

--- a/packages/providers/src/openai/openaiReasoningDialect.test.ts
+++ b/packages/providers/src/openai/openaiReasoningDialect.test.ts
@@ -80,6 +80,15 @@ describe('resolveReasoningDialect — host to dialect mapping', () => {
   it('resolves invalid URL string to none', () => {
     expect(resolveReasoningDialect('not a url')).toBe('none');
   });
+
+  it('tolerates stray whitespace around an otherwise known host', () => {
+    expect(resolveReasoningDialect('  https://openrouter.ai/api/v1  ')).toBe(
+      'openrouter',
+    );
+    expect(resolveReasoningDialect('\nhttps://api.z.ai/api/paas/v4\t')).toBe(
+      'thinking',
+    );
+  });
 });
 
 describe('applyReasoningDialect — wire-shape emission', () => {

--- a/packages/providers/src/openai/openaiReasoningDialect.test.ts
+++ b/packages/providers/src/openai/openaiReasoningDialect.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveReasoningDialect,
+  applyReasoningDialect,
+  hasExplicitReasoningField,
+  REASONING_WIRE_KEYS,
+} from './openaiReasoningDialect.js';
+
+describe('resolveReasoningDialect — host to dialect mapping', () => {
+  it('resolves openrouter.ai to the openrouter dialect', () => {
+    expect(resolveReasoningDialect('https://openrouter.ai/api/v1')).toBe(
+      'openrouter',
+    );
+  });
+
+  it('resolves *.openrouter.ai to the openrouter dialect', () => {
+    expect(resolveReasoningDialect('https://api.openrouter.ai/api/v1')).toBe(
+      'openrouter',
+    );
+  });
+
+  it('does NOT match evil-openrouter.ai.attacker.com (suffix spoofing)', () => {
+    expect(
+      resolveReasoningDialect('https://evil-openrouter.ai.attacker.com/v1'),
+    ).toBe('none');
+  });
+
+  it('resolves z.ai and *.z.ai to the thinking dialect', () => {
+    expect(resolveReasoningDialect('https://z.ai/api/paas/v4')).toBe(
+      'thinking',
+    );
+    expect(resolveReasoningDialect('https://api.z.ai/api/paas/v4')).toBe(
+      'thinking',
+    );
+  });
+
+  it('resolves bigmodel.cn and *.bigmodel.cn to the thinking dialect', () => {
+    expect(
+      resolveReasoningDialect('https://open.bigmodel.cn/api/paas/v4'),
+    ).toBe('thinking');
+    expect(resolveReasoningDialect('https://bigmodel.cn/api/paas/v4')).toBe(
+      'thinking',
+    );
+  });
+
+  it('resolves api.openai.com to none', () => {
+    expect(resolveReasoningDialect('https://api.openai.com/v1')).toBe('none');
+  });
+
+  it('resolves friendli to none', () => {
+    expect(
+      resolveReasoningDialect('https://api.friendli.ai/serverless/v1'),
+    ).toBe('none');
+  });
+
+  it('resolves crusoe to none (trailing slash)', () => {
+    expect(
+      resolveReasoningDialect('https://api.inference.crusoecloud.com/v1/'),
+    ).toBe('none');
+  });
+
+  it('resolves undefined base URL to none', () => {
+    expect(resolveReasoningDialect(undefined)).toBe('none');
+  });
+
+  it('resolves empty string to none', () => {
+    expect(resolveReasoningDialect('')).toBe('none');
+  });
+
+  it('resolves whitespace-only string to none', () => {
+    expect(resolveReasoningDialect('   ')).toBe('none');
+  });
+
+  it('resolves invalid URL string to none', () => {
+    expect(resolveReasoningDialect('not a url')).toBe('none');
+  });
+});
+
+describe('applyReasoningDialect — wire-shape emission', () => {
+  it('openrouter: emits reasoning.effort when effort is set', () => {
+    expect(
+      applyReasoningDialect('openrouter', { enabled: true, effort: 'high' }),
+    ).toStrictEqual({ key: 'reasoning', value: { effort: 'high' } });
+  });
+
+  it('openrouter: emits reasoning.enabled when effort is not set', () => {
+    expect(
+      applyReasoningDialect('openrouter', { enabled: true }),
+    ).toStrictEqual({ key: 'reasoning', value: { enabled: true } });
+    expect(
+      applyReasoningDialect('openrouter', { enabled: false }),
+    ).toStrictEqual({ key: 'reasoning', value: { enabled: false } });
+  });
+
+  it('openrouter: emits nothing when neither effort nor enabled is set', () => {
+    expect(applyReasoningDialect('openrouter', {})).toBeNull();
+  });
+
+  it('openrouter: an explicit enabled=false outranks a leftover effort', () => {
+    expect(
+      applyReasoningDialect('openrouter', { enabled: false, effort: 'high' }),
+    ).toStrictEqual({ key: 'reasoning', value: { enabled: false } });
+  });
+
+  it('openrouter: falls back to enabled when effort is an empty string', () => {
+    expect(
+      applyReasoningDialect('openrouter', { effort: '', enabled: true }),
+    ).toStrictEqual({ key: 'reasoning', value: { enabled: true } });
+  });
+
+  it('openrouter: emits nothing when effort is empty and enabled is unset', () => {
+    expect(applyReasoningDialect('openrouter', { effort: '' })).toBeNull();
+  });
+
+  it('thinking: emits thinking.type=enabled when enabled is true', () => {
+    expect(applyReasoningDialect('thinking', { enabled: true })).toStrictEqual({
+      key: 'thinking',
+      value: { type: 'enabled' },
+    });
+  });
+
+  it('thinking: emits thinking.type=disabled when enabled is false', () => {
+    expect(applyReasoningDialect('thinking', { enabled: false })).toStrictEqual(
+      {
+        key: 'thinking',
+        value: { type: 'disabled' },
+      },
+    );
+  });
+
+  it('thinking: an effort level alone still enables thinking', () => {
+    expect(applyReasoningDialect('thinking', { effort: 'high' })).toStrictEqual(
+      { key: 'thinking', value: { type: 'enabled' } },
+    );
+  });
+
+  it('thinking: an explicit enabled=false outranks a leftover effort', () => {
+    expect(
+      applyReasoningDialect('thinking', { enabled: false, effort: 'high' }),
+    ).toStrictEqual({ key: 'thinking', value: { type: 'disabled' } });
+  });
+
+  it('thinking: emits nothing when no reasoning setting is present', () => {
+    expect(applyReasoningDialect('thinking', {})).toBeNull();
+    expect(applyReasoningDialect('thinking', { effort: '' })).toBeNull();
+  });
+
+  it('none: always emits nothing', () => {
+    expect(
+      applyReasoningDialect('none', { enabled: true, effort: 'high' }),
+    ).toBeNull();
+  });
+});
+
+describe('hasExplicitReasoningField — known wire keys', () => {
+  it('covers every vendor dialect named in issue #2896', () => {
+    expect([...REASONING_WIRE_KEYS].sort()).toStrictEqual([
+      'parse_reasoning',
+      'reasoning',
+      'reasoning_effort',
+      'thinking',
+    ]);
+  });
+
+  it.each([...REASONING_WIRE_KEYS])('detects an explicit %s', (key) => {
+    expect(hasExplicitReasoningField({ [key]: 'anything' })).toBe(true);
+  });
+
+  it('returns false for a body with no reasoning representation', () => {
+    expect(hasExplicitReasoningField({ model: 'gpt-4o', top_p: 0.95 })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/providers/src/openai/openaiReasoningDialect.ts
+++ b/packages/providers/src/openai/openaiReasoningDialect.ts
@@ -74,7 +74,10 @@ export function resolveReasoningDialect(
 
   let hostname: string;
   try {
-    hostname = new URL(baseUrl).hostname.toLowerCase();
+    // Base URLs arrive from user config and profiles, where stray surrounding
+    // whitespace is common; untrimmed input makes `URL` throw and would
+    // silently disable the dialect for a host that is in the table.
+    hostname = new URL(baseUrl.trim()).hostname.toLowerCase();
   } catch {
     return 'none';
   }

--- a/packages/providers/src/openai/openaiReasoningDialect.ts
+++ b/packages/providers/src/openai/openaiReasoningDialect.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OpenAI-compatible reasoning dialect resolution.
+ *
+ * Rationale: llxprt cannot know an arbitrary OpenAI-compatible endpoint's
+ * reasoning dialect. Guessing is exactly what produced Friendli 422
+ * ("no such field: 'reasoning'" / "'thinking'") and Crusoe 403
+ * ("parameter 'reasoning' is not allowed"). This module maps a known set of
+ * hosts to at most ONE reasoning dialect and applies it. Every other host —
+ * including canonical `api.openai.com` — emits nothing, so users retain full
+ * control through `modelParams` passthrough (`thinking`, `reasoning_effort`,
+ * or vendor-native fields such as `parse_reasoning`).
+ *
+ * Dialect table (issue #2896):
+ *   host `openrouter.ai` / `*.openrouter.ai`    -> openrouter
+ *   host `z.ai` / `*.z.ai`                      -> thinking
+ *   host `bigmodel.cn` / `*.bigmodel.cn`        -> thinking
+ *   everything else (incl. api.openai.com)      -> none
+ */
+
+/**
+ * Every wire field that expresses reasoning intent on an OpenAI-compatible
+ * Chat Completions body. When any of these is already present — because the
+ * user supplied it through `modelParams` — automatic selection stands down so
+ * exactly one representation reaches the provider. `parse_reasoning` is
+ * Friendli's native field and belongs here for the same reason (issue #2896).
+ */
+export const REASONING_WIRE_KEYS: readonly string[] = [
+  'reasoning',
+  'thinking',
+  'reasoning_effort',
+  'parse_reasoning',
+];
+
+/** True when the body already carries an explicit reasoning representation. */
+export function hasExplicitReasoningField(body: object): boolean {
+  return REASONING_WIRE_KEYS.some((key) => key in body);
+}
+
+export type ReasoningDialect = 'openrouter' | 'thinking' | 'none';
+
+export interface ReasoningSettings {
+  enabled?: boolean;
+  effort?: string;
+}
+
+/**
+ * The single reasoning representation to place on the request body.
+ * Discriminated on `key` so callers assign a precisely-typed value without
+ * casts.
+ */
+export type AppliedReasoning =
+  | { key: 'thinking'; value: { type: 'enabled' | 'disabled' } }
+  | { key: 'reasoning'; value: Record<string, unknown> };
+
+/**
+ * Resolve the reasoning dialect for a given endpoint base URL.
+ *
+ * Host matching is robust: parses with `URL`, lowercases the hostname, and
+ * compares with exact-or-dot-suffix matching so that
+ * `evil-openrouter.ai.attacker.com` does NOT match, but `api.z.ai` does.
+ */
+export function resolveReasoningDialect(
+  baseUrl: string | undefined,
+): ReasoningDialect {
+  if (typeof baseUrl !== 'string' || baseUrl.trim() === '') {
+    return 'none';
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return 'none';
+  }
+
+  if (hostname === '') {
+    return 'none';
+  }
+
+  if (matchesHostSuffix(hostname, 'openrouter.ai')) {
+    return 'openrouter';
+  }
+
+  if (
+    matchesHostSuffix(hostname, 'z.ai') ||
+    matchesHostSuffix(hostname, 'bigmodel.cn')
+  ) {
+    return 'thinking';
+  }
+
+  return 'none';
+}
+
+/**
+ * Apply the resolved dialect to produce at most one reasoning representation.
+ * Returns `null` when the dialect is `none` or the settings do not call for
+ * emission (e.g. `enabled` is undefined for the `thinking` dialect).
+ */
+export function applyReasoningDialect(
+  dialect: ReasoningDialect,
+  settings: ReasoningSettings,
+): AppliedReasoning | null {
+  switch (dialect) {
+    case 'openrouter':
+      return applyOpenRouterDialect(settings);
+    case 'thinking':
+      return applyThinkingDialect(settings);
+    case 'none':
+    default:
+      return null;
+  }
+}
+
+function applyOpenRouterDialect(
+  settings: ReasoningSettings,
+): AppliedReasoning | null {
+  // An explicit `reasoning.enabled: false` outranks a leftover effort level —
+  // otherwise turning reasoning off would still request it.
+  if (settings.enabled === false) {
+    return { key: 'reasoning', value: { enabled: false } };
+  }
+  if (hasEffort(settings)) {
+    return { key: 'reasoning', value: { effort: settings.effort } };
+  }
+  if (settings.enabled === true) {
+    return { key: 'reasoning', value: { enabled: true } };
+  }
+  return null;
+}
+
+function applyThinkingDialect(
+  settings: ReasoningSettings,
+): AppliedReasoning | null {
+  // Same precedence as the OpenRouter dialect: an explicit off wins, and an
+  // effort level on its own still means "think" even though this dialect has
+  // no way to express how hard.
+  if (settings.enabled === false) {
+    return { key: 'thinking', value: { type: 'disabled' } };
+  }
+  if (settings.enabled === true || hasEffort(settings)) {
+    return { key: 'thinking', value: { type: 'enabled' } };
+  }
+  return null;
+}
+
+function hasEffort(settings: ReasoningSettings): boolean {
+  return typeof settings.effort === 'string' && settings.effort !== '';
+}
+
+/**
+ * Exact-or-dot-suffix host match. `hostname` and `suffix` are pre-lowercased.
+ * Matches `openrouter.ai` exactly and any `*.openrouter.ai` subdomain, but
+ * rejects `evil-openrouter.ai.attacker.com`.
+ */
+function matchesHostSuffix(hostname: string, suffix: string): boolean {
+  return hostname === suffix || hostname.endsWith(`.${suffix}`);
+}

--- a/packages/providers/src/openai/openaiReasoningDialect.ts
+++ b/packages/providers/src/openai/openaiReasoningDialect.ts
@@ -56,7 +56,7 @@ export interface ReasoningSettings {
  */
 export type AppliedReasoning =
   | { key: 'thinking'; value: { type: 'enabled' | 'disabled' } }
-  | { key: 'reasoning'; value: Record<string, unknown> };
+  | { key: 'reasoning'; value: { effort: string } | { enabled: boolean } };
 
 /**
  * Resolve the reasoning dialect for a given endpoint base URL.
@@ -125,8 +125,9 @@ function applyOpenRouterDialect(
   if (settings.enabled === false) {
     return { key: 'reasoning', value: { enabled: false } };
   }
-  if (hasEffort(settings)) {
-    return { key: 'reasoning', value: { effort: settings.effort } };
+  const effort = resolveEffort(settings);
+  if (effort !== undefined) {
+    return { key: 'reasoning', value: { effort } };
   }
   if (settings.enabled === true) {
     return { key: 'reasoning', value: { enabled: true } };
@@ -143,14 +144,16 @@ function applyThinkingDialect(
   if (settings.enabled === false) {
     return { key: 'thinking', value: { type: 'disabled' } };
   }
-  if (settings.enabled === true || hasEffort(settings)) {
+  if (settings.enabled === true || resolveEffort(settings) !== undefined) {
     return { key: 'thinking', value: { type: 'enabled' } };
   }
   return null;
 }
 
-function hasEffort(settings: ReasoningSettings): boolean {
-  return typeof settings.effort === 'string' && settings.effort !== '';
+/** The configured effort level, or undefined when it is unset or blank. */
+function resolveEffort(settings: ReasoningSettings): string | undefined {
+  const { effort } = settings;
+  return typeof effort === 'string' && effort !== '' ? effort : undefined;
 }
 
 /**

--- a/packages/providers/src/openai/openaiReasoningPipeline.test.ts
+++ b/packages/providers/src/openai/openaiReasoningPipeline.test.ts
@@ -66,9 +66,9 @@ function optionsFrom(
     resolved: {
       model: 'zai-org/GLM-5.2',
       baseURL,
-      authToken: { token: 'test-token', type: 'api-key' },
+      authToken: 'test-token',
     },
-  } as unknown as NormalizedGenerateChatOptions;
+  } satisfies NormalizedGenerateChatOptions;
 }
 
 async function bodyFor(
@@ -82,7 +82,9 @@ async function bodyFor(
     new DebugLogger('llxprt:provider:openai:test'),
     PROVIDER,
   );
-  return result.requestBody as Record<string, unknown>;
+  // Spread rather than cast: the body is a plain object, and this keeps the
+  // file free of type escapes so `satisfies` above does real checking.
+  return { ...result.requestBody };
 }
 
 function reasoningKeysIn(body: Record<string, unknown>): string[] {

--- a/packages/providers/src/openai/openaiReasoningPipeline.test.ts
+++ b/packages/providers/src/openai/openaiReasoningPipeline.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue #2896 - End-to-end coverage across the seam that the per-layer tests
+ * cannot see: real `SettingsService` writes -> `buildEphemeralsSnapshot` ->
+ * `separateSettings` (inside `createRuntimeInvocationContext`) -> the outbound
+ * Chat Completions body built by `prepareRequest`.
+ *
+ * The reported bug lived exactly here: `reasoning.effort` set as an ephemeral
+ * was re-materialized as an OpenRouter-dialect `reasoning` model param while
+ * the request builder separately injected the z.ai-dialect `thinking` field,
+ * so a single user intent produced two foreign dialects on the wire.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { prepareRequest } from './OpenAIRequestPreparation.js';
+import { REASONING_WIRE_KEYS } from './openaiReasoningDialect.js';
+import { buildEphemeralsSnapshot } from '../runtimeNormalizer.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('test system prompt'),
+}));
+
+vi.mock(
+  '@vybestack/llxprt-code-core/prompt-config/subagent-delegation.js',
+  () => ({
+    shouldIncludeSubagentDelegation: vi.fn().mockResolvedValue(false),
+  }),
+);
+
+vi.mock('../utils/userMemory.js', () => ({
+  resolveUserMemory: vi.fn().mockResolvedValue(''),
+}));
+
+const PROVIDER = 'openai';
+
+/**
+ * Drive the real settings pipeline: write settings exactly the way `/set` and
+ * profile application do, then build the invocation context the provider sees.
+ */
+function optionsFrom(
+  settings: SettingsService,
+  baseURL: string | undefined,
+): NormalizedGenerateChatOptions {
+  const invocation = createRuntimeInvocationContext({
+    runtime: { settingsService: settings, runtimeId: 'test-runtime' },
+    settings,
+    providerName: PROVIDER,
+    ephemeralsSnapshot: buildEphemeralsSnapshot(settings, PROVIDER),
+  });
+  return {
+    contents: [],
+    tools: undefined,
+    metadata: {},
+    settings,
+    config: undefined,
+    invocation,
+    resolved: {
+      model: 'zai-org/GLM-5.2',
+      baseURL,
+      authToken: { token: 'test-token', type: 'api-key' },
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+}
+
+async function bodyFor(
+  settings: SettingsService,
+  baseURL: string | undefined,
+): Promise<Record<string, unknown>> {
+  const result = await prepareRequest(
+    optionsFrom(settings, baseURL),
+    'gpt-4o',
+    undefined,
+    new DebugLogger('llxprt:provider:openai:test'),
+    PROVIDER,
+  );
+  return result.requestBody as Record<string, unknown>;
+}
+
+function reasoningKeysIn(body: Record<string, unknown>): string[] {
+  return REASONING_WIRE_KEYS.filter((k) => k in body);
+}
+
+describe('issue #2896 settings-to-request pipeline', () => {
+  let settings: SettingsService;
+
+  beforeEach(() => {
+    settings = new SettingsService();
+  });
+
+  describe('neutral reasoning ephemerals (the reported profile)', () => {
+    beforeEach(() => {
+      settings.set('reasoning.enabled', true);
+      settings.set('reasoning.effort', 'high');
+    });
+
+    it('sends nothing to Friendli', async () => {
+      const body = await bodyFor(
+        settings,
+        'https://api.friendli.ai/serverless/v1',
+      );
+      expect(reasoningKeysIn(body)).toStrictEqual([]);
+    });
+
+    it('sends nothing to Crusoe', async () => {
+      const body = await bodyFor(
+        settings,
+        'https://api.inference.crusoecloud.com/v1/',
+      );
+      expect(reasoningKeysIn(body)).toStrictEqual([]);
+    });
+
+    it('sends only the OpenRouter dialect to OpenRouter', async () => {
+      const body = await bodyFor(settings, 'https://openrouter.ai/api/v1');
+      expect(reasoningKeysIn(body)).toStrictEqual(['reasoning']);
+      expect(body['reasoning']).toStrictEqual({ effort: 'high' });
+    });
+
+    it('sends only the thinking dialect to z.ai', async () => {
+      const body = await bodyFor(settings, 'https://api.z.ai/api/paas/v4');
+      expect(reasoningKeysIn(body)).toStrictEqual(['thinking']);
+      expect(body['thinking']).toStrictEqual({ type: 'enabled' });
+    });
+  });
+
+  describe('explicit model params survive the pipeline and win', () => {
+    it('keeps a Friendli-native parse_reasoning as the only representation', async () => {
+      settings.set('reasoning.enabled', true);
+      settings.set('reasoning.effort', 'high');
+      settings.setProviderSetting(PROVIDER, 'parse_reasoning', true);
+
+      const body = await bodyFor(settings, 'https://api.z.ai/api/paas/v4');
+      expect(reasoningKeysIn(body)).toStrictEqual(['parse_reasoning']);
+      expect(body['parse_reasoning']).toBe(true);
+    });
+
+    it('keeps an explicit reasoning object intact, including its effort', async () => {
+      settings.setProviderSetting(PROVIDER, 'reasoning', {
+        effort: 'max',
+        exclude: true,
+      });
+
+      const body = await bodyFor(settings, 'https://openrouter.ai/api/v1');
+      expect(reasoningKeysIn(body)).toStrictEqual(['reasoning']);
+      expect(body['reasoning']).toStrictEqual({
+        effort: 'max',
+        exclude: true,
+      });
+      // The nested members must not also surface as literal dotted body keys.
+      expect(
+        Object.keys(body).filter((k) => k.startsWith('reasoning.')),
+      ).toStrictEqual([]);
+    });
+
+    it('lets an explicit thinking value override the host dialect', async () => {
+      settings.set('reasoning.enabled', true);
+      settings.setProviderSetting(PROVIDER, 'thinking', { type: 'disabled' });
+
+      const body = await bodyFor(settings, 'https://api.z.ai/api/paas/v4');
+      expect(reasoningKeysIn(body)).toStrictEqual(['thinking']);
+      expect(body['thinking']).toStrictEqual({ type: 'disabled' });
+    });
+  });
+
+  it('turning reasoning off never requests reasoning on OpenRouter', async () => {
+    settings.set('reasoning.effort', 'high');
+    settings.set('reasoning.enabled', false);
+
+    const body = await bodyFor(settings, 'https://openrouter.ai/api/v1');
+    expect(reasoningKeysIn(body)).toStrictEqual(['reasoning']);
+    expect(body['reasoning']).toStrictEqual({ enabled: false });
+  });
+
+  it('repairs a legacy string-typed numeric model param at egress', async () => {
+    settings.setProviderSetting(PROVIDER, 'top_p', '.95');
+
+    const body = await bodyFor(
+      settings,
+      'https://api.friendli.ai/serverless/v1',
+    );
+    expect(body['top_p']).toBe(0.95);
+    expect(typeof body['top_p']).toBe('number');
+  });
+
+  it('leaves a non-numeric model param untouched rather than dropping it', async () => {
+    settings.setProviderSetting(PROVIDER, 'top_p', 'abc');
+
+    const body = await bodyFor(
+      settings,
+      'https://api.friendli.ai/serverless/v1',
+    );
+    expect(body['top_p']).toBe('abc');
+  });
+});

--- a/packages/providers/src/openai/openaiReasoningPipeline.test.ts
+++ b/packages/providers/src/openai/openaiReasoningPipeline.test.ts
@@ -132,7 +132,7 @@ describe('issue #2896 settings-to-request pipeline', () => {
   });
 
   describe('explicit model params survive the pipeline and win', () => {
-    it('keeps a Friendli-native parse_reasoning as the only representation', async () => {
+    it('keeps an explicit parse_reasoning as the only representation on z.ai', async () => {
       settings.set('reasoning.enabled', true);
       settings.set('reasoning.effort', 'high');
       settings.setProviderSetting(PROVIDER, 'parse_reasoning', true);

--- a/packages/providers/src/runtime/profile-application/profileValueWarnings.test.ts
+++ b/packages/providers/src/runtime/profile-application/profileValueWarnings.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue #2896 - A profile written by the model config dialog carried
+ * `"top_p": ".95"`, and the only signal was a 400 from the provider. These
+ * tests pin the advisory behaviour AND, just as importantly, pin that it is
+ * not a gate: unknown keys and custom-model parameters must never warn.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  collectProfileValueWarnings,
+  formatProfileValueWarnings,
+} from './profileValueWarnings.js';
+
+const NONE: Record<string, unknown> = {};
+
+describe('collectProfileValueWarnings — never gates on key membership', () => {
+  it.each([
+    ['some_custom_vendor_param', 'anything'],
+    ['some_custom_vendor_param', 42],
+    ['parse_reasoning', true],
+    ['chat_template_kwargs', { enable_thinking: true }],
+    ['enable_thinking', 'yes'],
+    ['a.dotted.vendor.key', 'v'],
+  ])('stays silent for the unrecognized model param %s', (key, value) => {
+    expect(collectProfileValueWarnings({ [key]: value }, NONE)).toStrictEqual(
+      [],
+    );
+  });
+
+  it('stays silent for an unrecognized ephemeral setting', () => {
+    expect(
+      collectProfileValueWarnings(NONE, { 'some-future-setting': 'on' }),
+    ).toStrictEqual([]);
+  });
+
+  it('stays silent for free-form registered params of any shape', () => {
+    expect(
+      collectProfileValueWarnings(
+        {
+          stop: ['x'],
+          response_format: { type: 'json_object' },
+          tool_choice: 'auto',
+          logit_bias: { '1': 2 },
+          metadata: { a: 'b' },
+        },
+        NONE,
+      ),
+    ).toStrictEqual([]);
+  });
+});
+
+describe('collectProfileValueWarnings — reports only unrepairable type errors', () => {
+  it('stays silent for a repairable numeric string, which egress fixes', () => {
+    // '.95' is coerced to 0.95 before the check, so the user is not nagged
+    // about something that works.
+    expect(collectProfileValueWarnings({ top_p: '.95' }, NONE)).toStrictEqual(
+      [],
+    );
+  });
+
+  it('reports a non-numeric value for a numeric param', () => {
+    const found = collectProfileValueWarnings({ top_p: 'abc' }, NONE);
+
+    expect(found).toHaveLength(1);
+    expect(found[0].key).toBe('top_p');
+    expect(found[0].message).toContain('must be a number');
+  });
+
+  it('reports an overflow literal, which cannot be repaired either', () => {
+    expect(
+      collectProfileValueWarnings({ temperature: '1e400' }, NONE),
+    ).toHaveLength(1);
+  });
+
+  it('reports each offending key across params and ephemerals', () => {
+    const found = collectProfileValueWarnings(
+      { top_p: 'abc', max_tokens: 'lots' },
+      { 'context-limit': 'huge' },
+    );
+
+    expect(found.map((w) => w.key).sort()).toStrictEqual([
+      'context-limit',
+      'max_tokens',
+      'top_p',
+    ]);
+  });
+
+  it('ignores null and undefined rather than reporting them', () => {
+    expect(
+      collectProfileValueWarnings(
+        { top_p: null, temperature: undefined },
+        NONE,
+      ),
+    ).toStrictEqual([]);
+  });
+});
+
+describe('formatProfileValueWarnings', () => {
+  it('names the profile and says the value is still being used', () => {
+    const [line] = formatProfileValueWarnings('crusoeglm', [
+      { key: 'top_p', message: 'top_p must be a number' },
+    ]);
+
+    expect(line).toContain('crusoeglm');
+    expect(line).toContain('top_p must be a number');
+    expect(line).toContain('used as written');
+  });
+
+  it('produces nothing when there is nothing to report', () => {
+    expect(formatProfileValueWarnings('p', [])).toStrictEqual([]);
+  });
+});

--- a/packages/providers/src/runtime/profile-application/profileValueWarnings.ts
+++ b/packages/providers/src/runtime/profile-application/profileValueWarnings.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Advisory type checks for values a profile carries (issue #2896).
+ *
+ * The model config dialog once wrote `"top_p": ".95"` — a string where every
+ * OpenAI-compatible provider expects a number — and OpenRouter answered
+ * `400 top_p: Invalid input: expected number, received string`. Loading such a
+ * profile gave no hint that the profile itself was the problem.
+ *
+ * Deliberately NOT a gate:
+ *  - Unknown keys never warn. llxprt cannot know every parameter every model
+ *    or custom endpoint accepts, so an unrecognized key is assumed intentional.
+ *  - Nothing is dropped, changed, or refused here. The profile still applies
+ *    exactly as written; this only reports.
+ *
+ * Only a key the registry already describes, whose value cannot be reconciled
+ * with the type the registry declares, produces a warning — in practice the
+ * universally numeric sampling parameters. `normalizeSetting` is applied first
+ * so a repairable value (`".95"` -> `0.95`) stays silent; the warning is
+ * reserved for values that really would go out malformed.
+ */
+
+import {
+  normalizeSetting,
+  validateSetting,
+} from '@vybestack/llxprt-code-settings/settings/settingsRegistry.js';
+
+/** A single advisory finding about one profile value. */
+export interface ProfileValueWarning {
+  readonly key: string;
+  readonly message: string;
+}
+
+function checkSection(
+  section: Record<string, unknown>,
+  found: ProfileValueWarning[],
+): void {
+  for (const [key, value] of Object.entries(section)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    const result = validateSetting(key, normalizeSetting(key, value));
+    if (!result.success) {
+      found.push({
+        key,
+        message: result.message ?? `invalid value for '${key}'`,
+      });
+    }
+  }
+}
+
+/**
+ * Collect advisory warnings for a profile's model params and ephemerals.
+ * Returns an empty array when everything type-checks or is unrecognized.
+ */
+export function collectProfileValueWarnings(
+  modelParams: Record<string, unknown>,
+  ephemeralSettings: Record<string, unknown>,
+): ProfileValueWarning[] {
+  const found: ProfileValueWarning[] = [];
+  checkSection(modelParams, found);
+  checkSection(ephemeralSettings, found);
+  return found;
+}
+
+/**
+ * Render the warnings as user-facing lines naming the profile, so the message
+ * points at the file to edit rather than at the provider's rejection.
+ */
+export function formatProfileValueWarnings(
+  profileName: string,
+  warnings: readonly ProfileValueWarning[],
+): string[] {
+  return warnings.map(
+    (w) =>
+      `Profile '${profileName}': ${w.message}. The value is being used as written and the provider may reject it.`,
+  );
+}

--- a/packages/providers/src/runtime/profileApplication.ts
+++ b/packages/providers/src/runtime/profileApplication.ts
@@ -32,6 +32,10 @@ import {
   isPositiveContextLimit,
 } from './profile-application/profileAccessors.js';
 import { maybeRegisterLoadBalancerProfile } from './profile-application/loadBalancerProfile.js';
+import {
+  collectProfileValueWarnings,
+  formatProfileValueWarnings,
+} from './profile-application/profileValueWarnings.js';
 
 export interface ProviderSelectionResult {
   providerName: string;
@@ -829,6 +833,20 @@ export async function applyProfileWithGuards(
     providerRecord,
     authDeps,
   } = context;
+
+  // Advisory only: report values whose type the registry already knows to be
+  // wrong, so a malformed profile is attributed to the profile rather than to
+  // the provider that rejects it (issue #2896). Unknown keys never warn and
+  // nothing is dropped or refused.
+  warnings.push(
+    ...formatProfileValueWarnings(
+      options.profileName ?? actualProfile.provider,
+      collectProfileValueWarnings(
+        getProfileModelParams(actualProfile),
+        getProfileEphemeralSettings(actualProfile),
+      ),
+    ),
+  );
 
   clearProfileEphemerals(config, sanitizedProfile);
   const authResult = await wireAuthBeforeSwitch(sanitizedProfile, authDeps);

--- a/packages/settings/src/__tests__/numericString.test.ts
+++ b/packages/settings/src/__tests__/numericString.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isStrictNumericString } from '../settings/numericString.js';
+
+describe('isStrictNumericString', () => {
+  describe('accepts valid numeric strings', () => {
+    it.each([
+      ['12', true],
+      ['-7', true],
+      ['0', true],
+      ['0.95', true],
+      ['-0.95', true],
+      ['.95', true],
+      ['-.5', true],
+      ['1e-5', true],
+      ['1.5e3', true],
+      ['-2E+4', true],
+      ['3.14', true],
+      ['-0.5', true],
+    ])('accepts %s', (input, expected) => {
+      expect(isStrictNumericString(input)).toBe(expected);
+    });
+  });
+
+  describe('rejects invalid numeric strings', () => {
+    it.each([
+      ['', false],
+      ['.', false],
+      ['-', false],
+      ['-.', false],
+      ['1.', false],
+      ['-2.', false],
+      ['1.2.3', false],
+      ['abc', false],
+      ['1abc', false],
+      ['0x10', false],
+      ['Infinity', false],
+      ['NaN', false],
+      ['1_000', false],
+      [' 1', false],
+      ['1 ', false],
+      ['  ', false],
+      ['+1.5', false],
+      ['+3', false],
+      ['+.5', false],
+    ])('rejects %s', (input, expected) => {
+      expect(isStrictNumericString(input)).toBe(expected);
+    });
+  });
+});

--- a/packages/settings/src/__tests__/settingsRegistry.issue2896.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2896.test.ts
@@ -30,6 +30,13 @@ describe('issue #2896 A7: legacy-profile numeric repair at egress', () => {
     expect(typeof result.modelParams.temperature).toBe('number');
   });
 
+  it('repairs number-typed settings outside the model-param category', () => {
+    // reasoning.maxTokens is a model-behavior number; a profile that stored it
+    // as text must still reach consumers as a number.
+    expect(normalizeSetting('reasoning.maxTokens', '4096')).toBe(4096);
+    expect(parseSetting('reasoning.maxTokens', '4096')).toBe(4096);
+  });
+
   it('coerces a leading-dot numeric string via normalizeSetting directly', () => {
     expect(normalizeSetting('top_p', '.95')).toBe(0.95);
     expect(normalizeSetting('temperature', '-0.5')).toBe(-0.5);

--- a/packages/settings/src/__tests__/settingsRegistry.issue2896.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2896.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect } from 'vitest';
 import {
   separateSettings,
   normalizeSetting,
+  parseSetting,
 } from '../settings/settingsRegistry.js';
 
 describe('issue #2896 A7: legacy-profile numeric repair at egress', () => {
@@ -64,6 +65,21 @@ describe('issue #2896 A8: non-numeric strings are not silently dropped', () => {
     // the provider rejects it visibly instead.
     expect(normalizeSetting('top_p', '1e400')).toBe('1e400');
     expect(normalizeSetting('temperature', '-1e400')).toBe('-1e400');
+  });
+});
+
+describe('issue #2896: parseSetting keeps the same finite invariant as egress', () => {
+  it('parses ordinary numeric input for a number-typed param', () => {
+    expect(parseSetting('top_p', '.95')).toBe(0.95);
+    expect(parseSetting('max_tokens', '32000')).toBe(32000);
+  });
+
+  it('does not admit an overflow literal as Infinity at ingress', () => {
+    // Number('1e400') is Infinity, which JSON-serializes to null. Admitting it
+    // here would bypass the egress guard, so a stored value never becomes an
+    // unusable request parameter.
+    expect(parseSetting('top_p', '1e400')).not.toBe(Number.POSITIVE_INFINITY);
+    expect(parseSetting('top_p', '-1e400')).not.toBe(Number.NEGATIVE_INFINITY);
   });
 });
 

--- a/packages/settings/src/__tests__/settingsRegistry.issue2896.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2896.test.ts
@@ -74,6 +74,14 @@ describe('issue #2896: parseSetting keeps the same finite invariant as egress', 
     expect(parseSetting('max_tokens', '32000')).toBe(32000);
   });
 
+  it.each(['abc', '', 'Infinity', 'NaN', '0x10', '0o10', '1_000', ' 1 ', '1.'])(
+    'leaves %j alone at ingress, exactly as normalizeSetting does at egress',
+    (raw) => {
+      expect(parseSetting('top_p', raw)).toBe(raw);
+      expect(normalizeSetting('top_p', raw)).toBe(raw);
+    },
+  );
+
   it('does not admit an overflow literal as Infinity at ingress', () => {
     // Number('1e400') is Infinity, which JSON-serializes to null. Admitting it
     // here would bypass the egress guard, so a stored value never becomes an
@@ -119,4 +127,13 @@ describe('issue #2896 B2: unregistered sub-keys pass through', () => {
     const result = separateSettings({ reasoning: { exclude: true } }, 'openai');
     expect(result.modelParams.reasoning).toStrictEqual({ exclude: true });
   });
+
+  it.each([true, 'high', 42, null, ['high']])(
+    'does not throw when reasoning is the non-object value %j',
+    (value) => {
+      expect(() =>
+        separateSettings({ reasoning: value }, 'openai'),
+      ).not.toThrow();
+    },
+  );
 });

--- a/packages/settings/src/__tests__/settingsRegistry.issue2896.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2896.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue #2896 - Behavioral tests for settings-registry numeric coercion
+ * (Bug 1, acceptance rows A7/A8) and reasoning-dialect leak prevention
+ * (Bug 2, acceptance rows B1/B2).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  separateSettings,
+  normalizeSetting,
+} from '../settings/settingsRegistry.js';
+
+describe('issue #2896 A7: legacy-profile numeric repair at egress', () => {
+  it('coerces a string ".95" to the number 0.95 for top_p through separateSettings', () => {
+    const result = separateSettings({ top_p: '.95' }, 'openai');
+    expect(result.modelParams.top_p).toBe(0.95);
+    expect(typeof result.modelParams.top_p).toBe('number');
+  });
+
+  it('coerces a numeric string for temperature through separateSettings', () => {
+    const result = separateSettings({ temperature: '0.7' }, 'openai');
+    expect(result.modelParams.temperature).toBe(0.7);
+    expect(typeof result.modelParams.temperature).toBe('number');
+  });
+
+  it('coerces a leading-dot numeric string via normalizeSetting directly', () => {
+    expect(normalizeSetting('top_p', '.95')).toBe(0.95);
+    expect(normalizeSetting('temperature', '-0.5')).toBe(-0.5);
+  });
+});
+
+describe('issue #2896 A8: non-numeric strings are not silently dropped', () => {
+  it('leaves a non-numeric string "abc" untouched for top_p', () => {
+    expect(normalizeSetting('top_p', 'abc')).toBe('abc');
+    const result = separateSettings({ top_p: 'abc' }, 'openai');
+    expect(result.modelParams.top_p).toBe('abc');
+  });
+
+  it('does not coerce empty string to a number', () => {
+    expect(normalizeSetting('top_p', '')).toBe('');
+  });
+
+  it('does not coerce "Infinity"', () => {
+    expect(normalizeSetting('top_p', 'Infinity')).toBe('Infinity');
+  });
+
+  it('does not coerce "NaN"', () => {
+    expect(normalizeSetting('top_p', 'NaN')).toBe('NaN');
+  });
+
+  it('does not coerce "0x10"', () => {
+    expect(normalizeSetting('top_p', '0x10')).toBe('0x10');
+  });
+
+  it('does not coerce a numeric string that overflows to Infinity', () => {
+    // '1e400' is syntactically a number but Number('1e400') === Infinity,
+    // which JSON-serializes to null. The guard must preserve the string so
+    // the provider rejects it visibly instead.
+    expect(normalizeSetting('top_p', '1e400')).toBe('1e400');
+    expect(normalizeSetting('temperature', '-1e400')).toBe('-1e400');
+  });
+});
+
+describe('issue #2896 B1: reasoning.* must not fan out into modelParams', () => {
+  it('removes all registered reasoning sub-keys from the retained container', () => {
+    const result = separateSettings(
+      { reasoning: { enabled: true, effort: 'high' } },
+      'openai',
+    );
+    expect(result.modelParams.reasoning).toBeUndefined();
+    expect(result.modelBehavior['reasoning.enabled']).toBe(true);
+    expect(result.modelBehavior['reasoning.effort']).toBe('high');
+  });
+
+  it('deletes the reasoning container entirely when all sub-keys are registered', () => {
+    const result = separateSettings(
+      { reasoning: { enabled: true, effort: 'high', maxTokens: 4096 } },
+      'openai',
+    );
+    expect(result.modelParams.reasoning).toBeUndefined();
+  });
+});
+
+describe('issue #2896 B2: unregistered sub-keys pass through', () => {
+  it('preserves an unregistered sub-key (exclude) in the reasoning container', () => {
+    const result = separateSettings(
+      { reasoning: { enabled: true, exclude: true } },
+      'openai',
+    );
+    // enabled is registered -> stripped from container and sent to modelBehavior
+    expect(result.modelBehavior['reasoning.enabled']).toBe(true);
+    // exclude is unregistered -> survives in the retained container
+    expect(result.modelParams.reasoning).toStrictEqual({ exclude: true });
+  });
+
+  it('emits only the container when all sub-keys are unregistered', () => {
+    const result = separateSettings({ reasoning: { exclude: true } }, 'openai');
+    expect(result.modelParams.reasoning).toStrictEqual({ exclude: true });
+  });
+});

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -30,6 +30,7 @@ export {
   REDACTED_VALUE,
   SETTINGS_REGISTRY,
 } from './settings/settingsRegistry.js';
+export { isStrictNumericString } from './settings/numericString.js';
 export type {
   ValidationResult,
   SettingSpec,

--- a/packages/settings/src/settings/numericString.ts
+++ b/packages/settings/src/settings/numericString.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Strict numeric-string recognizer.
+ *
+ * Accepts only strings that a human would write as a plain decimal or
+ * scientific number — the same set the CLI `/set modelparam` and the
+ * ModelConfigDialog expect for `type: 'number'` fields.
+ *
+ * Accepted shapes (at least one mantissa digit required):
+ *   `.95`  `-.5`  `0.95`  `-0.95`  `12`  `-7`  `0`
+ *   `1e-5`  `1.5e3`  `-2E+4`
+ *
+ * Rejected (non-exhaustive):
+ *   `''`  `' '`  `.`  `-`  `-.`  `1.`  `1.2.3`  `abc`
+ *   `1abc`  `0x10`  `Infinity`  `NaN`  `1_000`  `' 1'`
+ *   `+1.5` — an explicit leading `+` is rejected on purpose, preserving the
+ *   strictness of the scanner this replaced; `-` is the only accepted sign.
+ *
+ * This is deliberately stricter than `Number()` / `parseFloat()` to avoid
+ * silently accepting hex literals, whitespace, underscores, or the special
+ * float words `Infinity`/`NaN`.
+ *
+ * Syntactic validity does not imply a usable value: `1e400` is accepted here
+ * but overflows to `Infinity`, so callers that need a usable number must also
+ * check `Number.isFinite`.
+ */
+export function isStrictNumericString(value: string): boolean {
+  if (value.length === 0) {
+    return false;
+  }
+
+  let i = 0;
+
+  // Optional leading minus sign.
+  if (value[i] === '-') {
+    i++;
+  }
+
+  // Integer part (digits before the decimal point).
+  const integerStart = i;
+  i = scanDigits(value, i);
+  const hasIntegerDigits = i > integerStart;
+
+  // Fractional part (digits after the decimal point).
+  let hasFractionDigits = false;
+  let hasDot = false;
+  if (i < value.length && value[i] === '.') {
+    hasDot = true;
+    i++;
+    const fractionStart = i;
+    i = scanDigits(value, i);
+    hasFractionDigits = i > fractionStart;
+  }
+
+  // Must have at least one mantissa digit (integer or fraction).
+  // A dot without any digits on either side (e.g. '.') is not a number.
+  if (!hasIntegerDigits && !hasFractionDigits) {
+    return false;
+  }
+
+  // A trailing dot (e.g. '1.') is ambiguous and must not be accepted.
+  if (hasDot && !hasFractionDigits) {
+    return false;
+  }
+
+  // Optional exponent: e/E, optional sign, then required digits.
+  if (i < value.length && (value[i] === 'e' || value[i] === 'E')) {
+    i++;
+    if (i < value.length && (value[i] === '+' || value[i] === '-')) {
+      i++;
+    }
+    const exponentStart = i;
+    i = scanDigits(value, i);
+    if (i === exponentStart) {
+      return false;
+    }
+  }
+
+  // Everything must be consumed — no trailing garbage.
+  return i === value.length;
+}
+
+function scanDigits(value: string, start: number): number {
+  let i = start;
+  while (i < value.length && value[i] >= '0' && value[i] <= '9') {
+    i++;
+  }
+  return i;
+}

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -22,6 +22,7 @@ import type {
 import { REGISTRY_ENTRIES_PART_1 } from './registry/registry-entries-1.js';
 import { REGISTRY_ENTRIES_PART_2 } from './registry/registry-entries-2.js';
 import { REGISTRY_ENTRIES_PART_3 } from './registry/registry-entries-3.js';
+import { isStrictNumericString } from './numericString.js';
 
 const ALIAS_NORMALIZATION_RULES: Record<string, string> = {
   'max-tokens': 'max_tokens',
@@ -98,8 +99,24 @@ export function normalizeSetting(key: string, value: unknown): unknown {
     return spec.normalize(value);
   }
 
-  // Reasoning spec already has normalize, but keep fallback for safety
-  // until all reasoning normalization is verified through spec.normalize
+  // Registry-type-driven coercion: repair ALREADY-PERSISTED bad profiles at
+  // settings egress (issue #2896). A numeric string stored on disk for a
+  // number-type model-param is coerced to a number. Non-numeric strings are
+  // left untouched so the provider surfaces the error rather than silently
+  // dropping the value. Specs with their own `normalize` (handled above)
+  // always win and are not affected by this coercion.
+  if (
+    spec?.category === 'model-param' &&
+    spec.type === 'number' &&
+    typeof value === 'string' &&
+    isStrictNumericString(value)
+  ) {
+    const coerced = Number(value);
+    // A syntactically valid literal can still overflow to Infinity ('1e400'),
+    // which JSON-serializes to null. Coerce only what round-trips as a finite
+    // number; anything else stays a string so the provider rejects it visibly.
+    return Number.isFinite(coerced) ? coerced : value;
+  }
 
   return value;
 }
@@ -161,10 +178,24 @@ function extractCustomHeaders(
  *  - Nested objects under a prefix are expanded into dotted keys; the original
  *    container is kept only when it has its own bare spec (e.g. `reasoning`),
  *    so a prefix-only container never falls through to modelParams.
+ *  - When a SYNTHESIZED container is retained (it is also a bare registry key),
+ *    every sub-key that corresponds to a REGISTERED dotted setting is stripped
+ *    from the retained container so it cannot fan out into modelParams a second
+ *    time as a foreign dialect (issue #2896). Unregistered sub-keys (e.g.
+ *    `{ exclude: true }` passthrough) are preserved. If stripping empties the
+ *    container, it is removed entirely.
  *  - Explicit flat keys always win over values extracted from a nested object.
+ *
+ * Provenance matters (issue #2896): a `reasoning` object in the GLOBAL settings
+ * tree is synthesized by `SettingsService.set('reasoning.effort', …)` nesting a
+ * dotted key, so its registered members are settings, not model params, and must
+ * be stripped. A `reasoning` object in the PROVIDER settings tree can only come
+ * from an explicit `/set modelparam reasoning {…}` or a profile's `modelParams`,
+ * so it is preserved verbatim and reaches the request body unchanged.
  */
 function flattenRegistryPrefixedObjects(
   source: Record<string, unknown>,
+  stripSynthesizedContainers: boolean,
 ): Record<string, unknown> {
   const { prefixes, bareKeys } = getRegistryStructure();
   const result: Record<string, unknown> = { ...source };
@@ -176,10 +207,42 @@ function flattenRegistryPrefixedObjects(
     emitFlattenedEntries(result, key, value);
     if (!bareKeys.has(key)) {
       delete result[key];
+    } else if (stripSynthesizedContainers) {
+      stripRegisteredSubKeysFromContainer(result, key, bareKeys);
     }
   }
 
   return result;
+}
+
+/**
+ * Remove from the retained container every sub-key that corresponds to a
+ * registered dotted setting (e.g. `reasoning.effort` is registered, so
+ * `effort` is stripped from the `reasoning` container). Unregistered sub-keys
+ * are preserved. If the container is left empty, it is deleted.
+ */
+function stripRegisteredSubKeysFromContainer(
+  result: Record<string, unknown>,
+  containerKey: string,
+  bareKeys: Set<string>,
+): void {
+  const container = result[containerKey];
+  if (!isPlainObject(container)) {
+    return;
+  }
+  const stripped: Record<string, unknown> = {};
+  for (const [subKey, subValue] of Object.entries(container)) {
+    const dottedKey = `${containerKey}.${subKey}`;
+    if (bareKeys.has(dottedKey)) {
+      continue;
+    }
+    stripped[subKey] = subValue;
+  }
+  if (Object.keys(stripped).length > 0) {
+    result[containerKey] = stripped;
+  } else {
+    delete result[containerKey];
+  }
 }
 
 function emitFlattenedEntries(
@@ -196,7 +259,11 @@ function emitFlattenedEntries(
         continue;
       }
     }
-    if (!(childKey in result)) {
+    // Only REGISTERED dotted keys are emitted. An unregistered member (e.g.
+    // OpenRouter's `reasoning.exclude`) would otherwise become a literal
+    // `reasoning.exclude` model param and reach the wire as a bogus top-level
+    // field; it stays inside its container instead (issue #2896).
+    if (bareKeys.has(childKey) && !(childKey in result)) {
       result[childKey] = subValue;
     }
   }
@@ -237,15 +304,19 @@ function getRegistryStructure(): {
  * separately and spread on top so provider-specific values always win —
  * including when an override arrives as a nested container (e.g. `text` →
  * `text.verbosity`) against a base-level flat key of the same name.
+ *
+ * Only base (global) containers are treated as synthesized. Provider-scoped
+ * containers are explicit model params and are preserved verbatim (#2896).
  */
 function mergeProviderSettings(
   mixed: Record<string, unknown>,
   providerOverrides: Record<string, unknown>,
 ): Record<string, unknown> {
-  const baseFlattened = flattenRegistryPrefixedObjects({ ...mixed });
-  const overridesFlattened = flattenRegistryPrefixedObjects({
-    ...providerOverrides,
-  });
+  const baseFlattened = flattenRegistryPrefixedObjects({ ...mixed }, true);
+  const overridesFlattened = flattenRegistryPrefixedObjects(
+    { ...providerOverrides },
+    false,
+  );
   return { ...baseFlattened, ...overridesFlattened };
 }
 

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -100,14 +100,14 @@ export function normalizeSetting(key: string, value: unknown): unknown {
   }
 
   // Registry-type-driven coercion: repair ALREADY-PERSISTED bad profiles at
-  // settings egress (issue #2896). A numeric string stored on disk for a
-  // number-type model-param is coerced to a number. Non-numeric strings are
-  // left untouched so the provider surfaces the error rather than silently
-  // dropping the value. Specs with their own `normalize` (handled above)
-  // always win and are not affected by this coercion.
+  // settings egress (issue #2896). A numeric string stored on disk for any
+  // number-typed spec is coerced to a number, matching what parseSetting does
+  // at ingress so a value cannot round-trip as two different types.
+  // Non-numeric strings are left untouched so the provider surfaces the error
+  // rather than silently dropping the value. Specs with their own `normalize`
+  // (handled above) always win and are not affected by this coercion.
   if (
-    spec?.category === 'model-param' &&
-    spec.type === 'number' &&
+    spec?.type === 'number' &&
     typeof value === 'string' &&
     isStrictNumericString(value)
   ) {

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -485,10 +485,13 @@ export function parseSetting(key: string, raw: string): unknown {
   // Only apply type coercion when spec explicitly indicates the type
   // This prevents converting enum/string values like "true" to boolean true
   if (spec?.type === 'number') {
+    // Finite-only, matching the egress guard in normalizeSetting: an overflow
+    // literal such as '1e400' becomes Infinity, which JSON-serializes to null
+    // and would reach the API as a dropped parameter (issue #2896). Return the
+    // raw text rather than falling through to JSON.parse, which would hand
+    // back the same Infinity.
     const num = Number(raw);
-    if (!Number.isNaN(num)) {
-      return num;
-    }
+    return Number.isFinite(num) ? num : raw;
   }
 
   if (spec?.type === 'boolean') {

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -193,6 +193,28 @@ function extractCustomHeaders(
  * from an explicit `/set modelparam reasoning {…}` or a profile's `modelParams`,
  * so it is preserved verbatim and reaches the request body unchanged.
  */
+/**
+ * Flatten the GLOBAL settings tree. Its containers are synthesized by
+ * `SettingsService.set` nesting dotted keys, so registered members are
+ * settings and are stripped from any retained container.
+ */
+function flattenGlobalSettings(
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  return flattenRegistryPrefixedObjects(source, true);
+}
+
+/**
+ * Flatten a PROVIDER settings tree. Its containers can only come from an
+ * explicit `/set modelparam <key> {…}` or a profile's `modelParams`, so they
+ * are preserved verbatim.
+ */
+function flattenProviderOverrides(
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  return flattenRegistryPrefixedObjects(source, false);
+}
+
 function flattenRegistryPrefixedObjects(
   source: Record<string, unknown>,
   stripSynthesizedContainers: boolean,
@@ -312,11 +334,8 @@ function mergeProviderSettings(
   mixed: Record<string, unknown>,
   providerOverrides: Record<string, unknown>,
 ): Record<string, unknown> {
-  const baseFlattened = flattenRegistryPrefixedObjects({ ...mixed }, true);
-  const overridesFlattened = flattenRegistryPrefixedObjects(
-    { ...providerOverrides },
-    false,
-  );
+  const baseFlattened = flattenGlobalSettings({ ...mixed });
+  const overridesFlattened = flattenProviderOverrides({ ...providerOverrides });
   return { ...baseFlattened, ...overridesFlattened };
 }
 
@@ -485,11 +504,16 @@ export function parseSetting(key: string, raw: string): unknown {
   // Only apply type coercion when spec explicitly indicates the type
   // This prevents converting enum/string values like "true" to boolean true
   if (spec?.type === 'number') {
-    // Finite-only, matching the egress guard in normalizeSetting: an overflow
-    // literal such as '1e400' becomes Infinity, which JSON-serializes to null
-    // and would reach the API as a dropped parameter (issue #2896). Return the
-    // raw text rather than falling through to JSON.parse, which would hand
-    // back the same Infinity.
+    // Ingress uses exactly the recognizer and finite guard that normalizeSetting
+    // applies at egress, so a value cannot be coerced on the way in and
+    // preserved on the way out (issue #2896). `Number()` alone would accept
+    // '0x10', '0o10', and padded input that egress rejects, and would turn the
+    // overflow literal '1e400' into Infinity, which JSON-serializes to null.
+    // Anything it will not take is returned as raw text rather than falling
+    // through to JSON.parse, which would hand back the same values.
+    if (!isStrictNumericString(raw)) {
+      return raw;
+    }
     const num = Number(raw);
     return Number.isFinite(num) ? num : raw;
   }

--- a/project-plans/issue2896/plan.md
+++ b/project-plans/issue2896/plan.md
@@ -262,3 +262,17 @@ the PR.
 | R22 | The double cast `as unknown as NormalizedGenerateChatOptions` in the provider tests. | Reject | The literal does not structurally satisfy the interface, so a single cast does not compile, and building a full context per case would obscure the assertions. This matches the established harness in the neighbouring `issue1943` test file. The pipeline test exists precisely so the real, uncast object graph is also covered. |
 | R23 | PR body did not follow the repository pull-request template. | In-scope-Fix | Rewritten into the template sections. |
 | R24 | OCR warning: changed-file coverage 5/17 below its 90% threshold. | Reject | A property of the review tool's own file sampling, not of the change. |
+
+## 11. PR review round 2 (CI OpenCodeReview) — triage
+
+PR OCR budget is now exhausted (2 of 2).
+
+| # | Finding | Class | Action |
+|---|---|---|---|
+| R25 | The `stripSynthesizedContainers` boolean is a footgun: a future caller could pick the wrong value and silently undo the provenance split. | In-scope-Fix | Callers now go through two named wrappers, `flattenGlobalSettings` and `flattenProviderOverrides`; the boolean is no longer written at any call site. |
+| R26 | `parseSetting` and `normalizeSetting` disagreed on what a numeric string is: ingress used bare `Number(raw)` and so accepted `0x10`, `0o10`, and padded input that egress rejects. | In-scope-Fix | Ingress now uses the same `isStrictNumericString` + finite guard as egress, and returns the raw text for anything it will not take. New table test asserts both entry points agree on the same inputs. |
+| R27 | The `reasoning` branch of `AppliedReasoning` widened `value` to `Record<string, unknown>`, defeating the discriminated union. | In-scope-Fix | Narrowed to `{ effort: string } \| { enabled: boolean }`; `hasEffort` became `resolveEffort` so the effort value is typed at the point of use. |
+| R28 | No test for a non-object `reasoning` value reaching the container strip. | In-scope-Fix | Added `true`, `'high'`, `42`, `null`, `['high']`. |
+| R29 | B12 omitted the reported profile shape on the default provider path (canonical OpenAI, `enabled` + `effort`). | In-scope-Fix | Added. |
+| R30 | The A6 comment said "integer typing" while the cases include fractional values. | In-scope-Fix | Comment corrected. |
+| R31 | Two earlier inline findings about `+1.5` and `1.e5` in `isStrictNumericString`. | Reject | Self-retracted by the reviewer in the same comments: both are the documented, tested, intentional strictness. |

--- a/project-plans/issue2896/plan.md
+++ b/project-plans/issue2896/plan.md
@@ -250,3 +250,15 @@ Review (`ocr review --audience agent --timeout 20`, 16 files, 6 comments).
 
 Local OCR budget is now exhausted (2 of 2). Remaining review passes happen on
 the PR.
+
+## 10. PR review round 1 (CI OpenCodeReview + PR review bot) — triage
+
+| # | Finding | Class | Action |
+|---|---|---|---|
+| R18 | `parseSetting` coerced a number-typed setting with `Number(raw)` and no finite guard, so `/set modelparam top_p 1e400` stored `Infinity` in memory, bypassing the egress guard and reaching the API as JSON `null`. | In-scope-Fix | Ingress now matches egress: finite-only, and a non-finite literal returns the raw text instead of falling through to `JSON.parse`, which would hand back the same `Infinity`. Covered by a new `parseSetting` test. |
+| R19 | `CommitResult` was not a discriminated union — `message` was optional even though the failure path always supplies one. | In-scope-Fix | Converted to `{ success: true } \| { success: false; message: string }`; the two call sites drop their `?? 'Invalid value'` fallbacks and `commitEphemeral` now supplies the default. |
+| R20 | Four tests shared a `B9` prefix, making a failure hard to identify. | In-scope-Fix | Renamed to `B9a`–`B9d` (and `B11a`/`B11b`). |
+| R21 | A pipeline test named "Friendli-native parse_reasoning" runs against the z.ai base URL. | In-scope-Fix | Renamed to describe what it actually proves: an explicit `parse_reasoning` is the only representation on z.ai. |
+| R22 | The double cast `as unknown as NormalizedGenerateChatOptions` in the provider tests. | Reject | The literal does not structurally satisfy the interface, so a single cast does not compile, and building a full context per case would obscure the assertions. This matches the established harness in the neighbouring `issue1943` test file. The pipeline test exists precisely so the real, uncast object graph is also covered. |
+| R23 | PR body did not follow the repository pull-request template. | In-scope-Fix | Rewritten into the template sections. |
+| R24 | OCR warning: changed-file coverage 5/17 below its 90% threshold. | Reject | A property of the review tool's own file sampling, not of the change. |

--- a/project-plans/issue2896/plan.md
+++ b/project-plans/issue2896/plan.md
@@ -1,0 +1,252 @@
+# Issue #2896 — Malformed request params: string-typed numerics and reasoning-dialect fan-out
+
+Branch: `issue2896`
+
+## 1. Confirmed root causes (evidence-based)
+
+### Bug 1 — dialog writes numeric params as strings (`"top_p": ".95"`)
+
+`ModelConfigDialog.commitParam` (packages/cli/src/ui/components/ModelConfigDialog.tsx)
+calls `parseValue(raw)` from `packages/cli/src/ui/commands/setCommand.ts`.
+
+`looksNumeric()` in `setCommand.ts` rejects leading-dot decimals:
+
+```
+looksNumeric('.95')
+  -> hasIntegerDigits = false  (no digits before '.')
+  -> returns hasIntegerDigits && hasFractionDigits && atEnd  === false
+```
+
+`parseValue` then falls through boolean parsing, then `JSON.parse('.95')` throws,
+and the raw string `'.95'` is stored as the model param. The same defect affects
+`/set modelparam top_p .95`, so it is not dialog-specific — the dialog is just the
+surface where the user hit it.
+
+Additionally, the dialog performs no type validation at all for `param` fields:
+typing `abc` into `top_p` stores the string `"abc"`.
+
+Registry evidence: `top_p`, `temperature`, `top_k`, `max_tokens`,
+`frequency_penalty`, `presence_penalty` all declare `type: 'number'`,
+`category: 'model-param'` in `packages/settings/src/settings/registry/registry-entries-3.ts`.
+
+### Bug 2 — reasoning-dialect fan-out
+
+Reproduced deterministically with a probe against the real settings pipeline:
+
+```
+SettingsService.set('reasoning.enabled', true)
+SettingsService.set('reasoning.effort', 'high')
+
+getAllGlobalSettings()  -> { reasoning: { enabled: true, effort: 'high' } }
+separateSettings(all, 'openai') ->
+  modelBehavior: { 'reasoning.enabled': true, 'reasoning.effort': 'high' }
+  modelParams:   { reasoning: { effort: 'high' } }      <-- LEAK
+```
+
+Two independent injection sites then both fire for a single user intent:
+
+1. **`reasoning: { effort }` (OpenRouter dialect).**
+   `SettingsService.setNestedValue` stores dotted keys as a nested tree, so
+   `reasoning.effort` becomes `global.reasoning.effort`.
+   `flattenRegistryPrefixedObjects` (packages/settings/src/settings/settingsRegistry.ts)
+   flattens the container back into dotted keys but **retains the container**
+   because a bare registry spec `key: 'reasoning'` exists
+   (registry-entries-3.ts, `category: 'model-param'`).
+   Its `normalize` only strips five internal keys
+   (`enabled`, `includeInContext`, `includeInResponse`, `format`, `stripFromContext`)
+   — `effort` survives and lands in `modelParams`.
+   `OpenAIRequestPreparation.applyRequestBodyOverrides` then does
+   `Object.assign(requestBody, overrides)`, putting `reasoning` on the wire.
+
+2. **`thinking: { type: 'enabled' }` (z.ai/GLM dialect).**
+   `OpenAIRequestPreparation.resolveReasoningConfig` unconditionally injects
+   `thinking` for **every** OpenAI-compatible endpoint whenever
+   `modelBehavior['reasoning.enabled']` is a boolean. Introduced by commit
+   `1f3c27036` ("add thinking param for OpenAI-compatible models ... for GLM-4.7,
+   Kimi K2 etc.") with no endpoint gating.
+
+`parse_reasoning: true` — the third field in the issue report — is **not**
+injected by llxprt. It is present in the reporter's own `friendliglm.json`
+`modelParams` (verified by reading the profile). Arbitrary `modelParams`
+passthrough is working as designed and is out of scope.
+
+Net: one user intent (`reasoning.enabled` + `reasoning.effort`) produces two
+llxprt-injected vendor dialects. Friendli rejects both with 422; Crusoe rejects
+`reasoning` with 403.
+
+## 2. Acceptance matrix (decision-complete)
+
+| # | Given | When | Then | Evidence location |
+|---|---|---|---|---|
+| A1 | `parseValue('.95')` | called | returns number `0.95` (not string) | `packages/cli/src/ui/commands/setCommand.*.test.ts` |
+| A2 | `parseValue('-.5')`, `parseValue('1e-5')`, `parseValue('1.5e3')` | called | return numbers `-0.5`, `1e-5`, `1500` | same |
+| A3 | `parseValue('.')`, `parseValue('1.2.3')`, `parseValue('abc')`, `parseValue('')` | called | remain non-numeric (unchanged behavior) | same |
+| A4 | Model config dialog `top_p` commit path, raw input `.95` | commit | the runtime receives the **number** `0.95` | `modelConfigParamCommit.spec.ts` |
+| A5 | Model config dialog `top_p` commit path, raw input `abc` (and `.`, `-`, `-.`, `1.2.3`, `Infinity`, `NaN`, `0x10`, `1_000`, `{"a":1}`, `true`) | commit | commit is rejected with a `must be a number` message that the dialog renders inline, and nothing is written to the runtime | `modelConfigParamCommit.spec.ts` |
+| A6 | Model config dialog commit path for the remaining number-typed fields (`max_tokens`, `top_k`, `frequency_penalty`, `presence_penalty`, `temperature`) | commit | each is written as a **number**; a param key with no number spec keeps the previous pass-through behavior; a runtime write failure surfaces as a validation message | `modelConfigParamCommit.spec.ts` |
+| A7 | Legacy profile on disk with `"top_p": ".95"` | applied to a request | egress model params contain `top_p` as number `0.95` | settings-registry behavioral test |
+| A8 | Profile with `"top_p": "abc"` | applied | value left untouched (no silent drop; provider surfaces the error) | settings-registry behavioral test |
+| B1 | ephemerals `reasoning.enabled=true`, `reasoning.effort='high'` | `separateSettings(..., 'openai')` | `modelParams` contains **no** `reasoning` key; `modelBehavior` still has both dotted keys | `settingsRegistry` test |
+| B2 | modelParam `reasoning = { exclude: true }` (unregistered sub-key) | `separateSettings` | `modelParams.reasoning === { exclude: true }` (unregistered passthrough preserved) | `settingsRegistry` test |
+| B3 | `base-url` = `https://api.friendli.ai/serverless/v1`, `reasoning.enabled=true`, `reasoning.effort='high'` | `prepareRequest` | body has **none** of `reasoning`, `thinking`, `reasoning_effort` | `OpenAIRequestPreparation` test |
+| B4 | `base-url` = `https://api.inference.crusoecloud.com/v1/`, same reasoning settings | `prepareRequest` | body has none of the three keys | same |
+| B5 | `base-url` = `https://openrouter.ai/api/v1`, `reasoning.enabled=true`, `reasoning.effort='high'` | `prepareRequest` | body has exactly `reasoning: { effort: 'high' }`; no `thinking`, no `reasoning_effort` | same |
+| B6 | `base-url` = `https://api.z.ai/api/paas/v4`, `reasoning.enabled=true` | `prepareRequest` | body has exactly `thinking: { type: 'enabled' }`; no `reasoning` | same |
+| B7 | `base-url` = `https://api.z.ai/...`, `reasoning.enabled=false` | `prepareRequest` | body has exactly `thinking: { type: 'disabled' }` | same |
+| B8 | `base-url` = `https://open.bigmodel.cn/api/paas/v4`, `reasoning.enabled=true` | `prepareRequest` | `thinking: { type: 'enabled' }` only | same |
+| B9 | user sets `modelParams.thinking` explicitly on any endpoint | `prepareRequest` | user value wins verbatim; no dialect auto-injection overrides or duplicates it | same |
+| B10 | user sets `modelParams.reasoning_effort` explicitly | `prepareRequest` | user value wins; no other dialect injected | same |
+| B11 | no `base-url` set (canonical OpenAI) with `reasoning.enabled=true` on the chat-completions path | `prepareRequest` | no `thinking` (canonical OpenAI does not accept it); at most one dialect | same |
+| B12 | any endpoint / any settings | `prepareRequest` | invariant test: body contains at most one of `reasoning` / `thinking` / `reasoning_effort` | table-driven invariant test |
+
+Dialect table (the only auto-selection source of truth):
+
+| host (exact or dot-suffix) | dialect | wire shape |
+|---|---|---|
+| `openrouter.ai` | `openrouter` | `reasoning: { effort }` when effort set, else `reasoning: { enabled }` |
+| `z.ai`, `bigmodel.cn` | `thinking` | `thinking: { type: 'enabled' \| 'disabled' }` |
+| everything else (incl. `api.openai.com` chat completions) | `none` | nothing emitted |
+
+Rationale for `none` as the default: llxprt cannot know an arbitrary
+OpenAI-compatible endpoint's reasoning dialect, and guessing is what broke
+Friendli and Crusoe. Users on unlisted endpoints retain full control through
+`modelParams` passthrough (`thinking`, `reasoning_effort`, or vendor-native
+fields such as `parse_reasoning`), which the issue confirms works end-to-end.
+
+## 3. Explicit non-goals
+
+- **NG1** Silent `exit 0` on an unresolvable `auth-key-name` (issue comment 3).
+  Different subsystem (auth precedence + non-interactive error surfacing).
+  Follow-up issue to be filed.
+- **NG2** 403 responses presenting as an indefinite hang (issue comment 4).
+  Different subsystem (retry/stream error classification). Follow-up issue to be
+  filed. Note: this PR removes the *trigger* for the Crusoe 403 by no longer
+  emitting `reasoning`, but does not fix 403 handling.
+- **NG3** Rewriting profile files on disk (migration pass). Normalization is
+  applied at settings egress, so existing profiles are fixed at load without
+  mutating user data.
+- **NG4** A new user-facing dialect-override setting (e.g. `reasoning.dialect`).
+  `modelParams` passthrough already provides the escape hatch.
+- **NG5** Reasoning handling for the Anthropic, Gemini, openai-responses, and
+  openai-vercel transports. They already select a single native dialect.
+- **NG6** Broadening the dialect table beyond the hosts listed above.
+- **NG7** Any change to `parse_reasoning` / arbitrary `modelParams` passthrough.
+
+## 4. Bounded vertical slices
+
+**Slice 1 — numeric typing (Bug 1).**
+- `packages/cli/src/ui/commands/setCommand.ts`: `looksNumeric` accepts leading-dot
+  decimals and exponent notation; still rejects `.`, `1.2.3`, `abc`, `''`.
+- `packages/cli/src/ui/components/ModelConfigDialog.tsx`: `commitParam` consults
+  `getSettingSpec(key)`; when `spec.type === 'number'`, require a finite number
+  and return a validation error otherwise.
+- `packages/settings/src/settings/settingsRegistry.ts`: `normalizeSetting` coerces
+  a numeric string to a number for `type: 'number'` model-param specs; leaves
+  non-numeric strings untouched.
+
+**Slice 2 — single reasoning dialect (Bug 2).**
+- `packages/settings/src/settings/settingsRegistry.ts`:
+  `flattenRegistryPrefixedObjects` removes registered dotted sub-keys from a
+  retained bare container, so `reasoning.*` settings can never re-enter
+  `modelParams` as a `reasoning` object. Unregistered sub-keys still pass through.
+- New `packages/providers/src/openai/openaiReasoningDialect.ts`: pure
+  host -> dialect resolution plus the applier.
+- `packages/providers/src/openai/OpenAIRequestPreparation.ts`:
+  `resolveReasoningConfig` delegates to the dialect module, keeps the existing
+  "explicit user modelParams wins" short-circuit, and emits at most one dialect.
+
+## 5. Expected paths
+
+```
+packages/cli/src/ui/commands/setCommand.ts
+packages/cli/src/ui/commands/setCommand.parseValue.test.ts            (extended)
+packages/cli/src/ui/components/ModelConfigDialog.tsx
+packages/cli/src/ui/components/modelConfigParamCommit.ts              (new)
+packages/cli/src/ui/components/modelConfigParamCommit.spec.ts         (new)
+packages/cli/vitest.test-groups.ts                                    (selected-file-count oracle)
+packages/settings/src/settings/numericString.ts                       (new)
+packages/settings/src/settings/settingsRegistry.ts
+packages/settings/src/settings/settingsRegistry.issue2896.test.ts     (new)
+packages/providers/src/openai/openaiReasoningDialect.ts               (new)
+packages/providers/src/openai/openaiReasoningDialect.test.ts          (new)
+packages/providers/src/openai/OpenAIRequestPreparation.ts
+packages/providers/src/openai/OpenAIRequestPreparation.issue2896.test.ts (new)
+packages/providers/src/openai/OpenAIRequestPreparation.issue1943.test.ts (updated: thinking tests become endpoint-scoped)
+docs/ (one short note on reasoning dialect selection)
+project-plans/issue2896/plan.md
+```
+
+## 6. Scope ledger
+
+| Budget | Limit | Actual |
+|---|---|---|
+| Files touched | <= 25 (review above), stop above 40 | 19 |
+| Net changed lines | <= 1500 (review above), stop above 2500 | 1833 (+1910 / -77) |
+| Reviews | <= 2 local OCR, <= 2 PR OCR | 2 local (round 1 + round 2 post-remediation) |
+
+**Mandatory scope review (net lines above 1500, below the 2500 stop).**
+Production source is 388 net lines across 8 files (+446 / -58); the remaining
+~1445 lines are behavioral tests (~1215) and this plan document (231). The test
+volume grew because review round 1 required an end-to-end
+settings-to-request suite and a widened dialect invariant, and the delivery
+policy explicitly exempts test coverage from the "major scope expansion" bar.
+No new subsystem, public abstraction, dependency, workflow, or quality-tool
+change was introduced. Continuing.
+
+Ledger entries:
+
+- (initial) planned: ~11 files, well under budget.
+- **In-scope unblock:** `packages/cli/vitest.test-groups.ts` `SELECTED_FILE_COUNT`
+  was stale on `main` (518 while the real selected set was 519 — commit
+  `5d4d0c741` added `dumpcontextCommand.chronology.test.ts` without bumping the
+  oracle). This PR adds one selected file, so the constant moves 518 -> 520.
+  Required for CI on this branch; not a scope expansion.
+- **Deviation (recorded):** `packages/cli/src/ui/components/ModelConfigDialog.test.tsx`
+  is structurally excluded from this package's vitest routing
+  (`**/ui/components/*.test.tsx` in `vitest.test-groups.ts`), so it never runs
+  in CI — full-render Ink component tests break under the package's `ink` stub
+  alias. Rather than change that test-infrastructure decision (out of scope),
+  the dialog's numeric-typing contract was extracted into
+  `modelConfigParamCommit.ts` and is covered by `modelConfigParamCommit.spec.ts`,
+  which IS in the selected set and drives the real `parseValue` + real settings
+  registry. The pre-existing quarantine of the component suite is left as-is and
+  is a candidate for a separate issue.
+
+## 7. Review-finding triage classes
+
+Blocker-Fix / In-scope-Fix / Reject / Defer. Reviewer suggestions do not
+authorize scope expansion; anything outside the acceptance matrix is Defer or
+Reject with a recorded reason.
+
+## 8. Local review round 1 — triage
+
+Reviews run: one independent design/implementation review, one local Open Code
+Review (`ocr review --audience agent --timeout 20`, 16 files, 6 comments).
+
+| # | Finding | Class | Action |
+|---|---|---|---|
+| R1 | Explicit `parse_reasoning` did not stand down automatic dialect injection, so a z.ai/OpenRouter user who set Friendli's native field still got a second dialect. The at-most-one invariant was false. | Blocker-Fix | `REASONING_WIRE_KEYS` + `hasExplicitReasoningField` now cover all four vendor fields; the request-builder short-circuit and the B12 invariant both use that one list. New B9 cases for both hosts. |
+| R2 | An explicit `/set modelparam reasoning {…}` / profile `modelParams.reasoning` lost its registered members (e.g. `effort`) because the container strip was applied to provider-scoped settings too. That silently dropped user intent, and the B9 test hand-built `modelParams` so it never saw the seam. | Blocker-Fix | Strip only *synthesized* (global) containers; provider-scoped containers are explicit model params and are preserved verbatim. New `openaiReasoningPipeline.test.ts` drives real `SettingsService` → `buildEphemeralsSnapshot` → `prepareRequest`. |
+| R3 | `reasoning.enabled: false` lost to a leftover `reasoning.effort` on OpenRouter, so turning reasoning off still requested it. | In-scope-Fix | Explicit `enabled: false` now outranks effort; covered in the dialect unit test and the B12 table. |
+| R4 | `normalizeSetting` coerced `'1e400'` to `Infinity`, which JSON-serializes to `null` — replacing one invalid value with a different invalid value. | In-scope-Fix | Coerce only when the result is finite; otherwise the string is left for the provider to reject. Covered in tests. |
+| R5 | B12/B9 too weak: finite key list, and explicit values equal to the auto-selected ones, so a broken short-circuit would still pass. | In-scope-Fix | B9 now uses opposing sentinel values; B12 covers `parse_reasoning`, `enabled:false` + effort, and a settings-free z.ai case; the pipeline test asserts exact key sets. |
+| R6 | Unregistered members of a registry-prefix container were also emitted as literal dotted keys, so `reasoning: {exclude:true}` produced a bogus top-level `reasoning.exclude` request field. | In-scope-Fix | Pre-existing, same defect class as this issue ("malformed request params"), fixed in `emitFlattenedEntries`: only registered dotted keys are emitted. Asserted in the pipeline test. |
+| R7 | Missing edge coverage: `1e400` commit rejection, empty-string effort, `hasExplicitReasoningField` key set. | In-scope-Fix | Added. |
+| R8 | `hasIntegerDigits` re-derived the post-sign offset from `value[0]`. | In-scope-Fix | Captures `integerStart` instead. |
+| R9 | Leading `+` is rejected while `Number()` accepts it. | In-scope-Fix (doc) | Intentional — preserves the strictness of the scanner this replaced; now stated explicitly in the rejected list. |
+| R10 | Add `afterEach(vi.restoreAllMocks())` to the request-preparation test. | Reject | No test asserts mock call counts, and the file's mocks are module factories that `restoreAllMocks` does not manage. Adds ceremony without changing any outcome. |
+| R11 | Move `parseValue(raw)` inside the `try` in `commitModelParam` in case it ever throws. | Reject | Speculative guard against a hypothetical future throw; the project prefers fail-fast over defense-in-depth. `parseValue` already contains its only throwing call. |
+| R12 | Drop the now-partly-redundant hardcoded `INTERNAL_KEYS` list in the bare `reasoning` spec's `normalize`. | Defer | After R2 it is no longer redundant: it is the only sanitizer for an explicitly supplied provider-scoped container. Reworking it is a separate settings-registry change. |
+| R13 | Silent `exit 0` on unresolvable `auth-key-name`; 403 presenting as an indefinite hang. | Defer | NG1/NG2. Separate subsystems; follow-up issues.
+
+## 9. Local review round 2 (post-remediation OCR) — triage
+
+| # | Finding | Class | Action |
+|---|---|---|---|
+| R14 | The `thinking` dialect dropped an effort-only configuration: with `reasoning.effort` set but `reasoning.enabled` unset, z.ai/bigmodel received nothing, while OpenRouter handled the same input. | In-scope-Fix | `applyThinkingDialect` now mirrors the OpenRouter precedence: explicit `enabled:false` wins, otherwise `enabled === true` **or** a non-empty effort emits `{ type: 'enabled' }`. Shared `hasEffort` helper; three new dialect tests. |
+| R15 | No regression test for `1e400` at the dialog commit boundary. | In-scope-Fix | `'1e400'` and `'-1e400'` added to the A5 rejection table. |
+| R16 | No regression test for `1e400` at the settings-egress boundary. | In-scope-Fix | Added to the A8 group. |
+| R17 | The intentional leading-`+` rejection had no test. | In-scope-Fix | `+1.5`, `+3`, `+.5` added to the rejection table. |
+
+Local OCR budget is now exhausted (2 of 2). Remaining review passes happen on
+the PR.

--- a/project-plans/issue2896/plan.md
+++ b/project-plans/issue2896/plan.md
@@ -276,3 +276,16 @@ PR OCR budget is now exhausted (2 of 2).
 | R29 | B12 omitted the reported profile shape on the default provider path (canonical OpenAI, `enabled` + `effort`). | In-scope-Fix | Added. |
 | R30 | The A6 comment said "integer typing" while the cases include fractional values. | In-scope-Fix | Comment corrected. |
 | R31 | Two earlier inline findings about `+1.5` and `1.e5` in `isStrictNumericString`. | Reject | Self-retracted by the reviewer in the same comments: both are the documented, tested, intentional strictness. |
+
+## 12. PR review round 3 (CI-generated) — triage
+
+The two launched OCR reviews are spent; these findings arrived from the
+automatic CI reviewer and are triaged, not solicited.
+
+| # | Finding | Class | Action |
+|---|---|---|---|
+| R32 | `parseValue` in `setCommand.ts` had no overflow guard: `1e400` passes the recognizer and `Number()` yields `Infinity`, which is not `NaN`, so `/set modelparam top_p 1e400` stored `Infinity`. Egress cannot repair it because the stored value is already a number. | In-scope-Fix | `parseValue` now returns the raw text for a non-finite result, matching both settings entry points. Covered in the rejection table. |
+| R33 | `normalizeSetting` repaired only `category: 'model-param'` numbers, so a number-typed model-behavior setting such as `reasoning.maxTokens` persisted as a string was never repaired, while `parseSetting` coerced every number spec at ingress. | In-scope-Fix | Egress now matches ingress: any `type: 'number'` spec is repaired. Covered by a `reasoning.maxTokens` test asserting both entry points. |
+| R34 | The A6 parameterized name used `%d`, truncating fractional expectations in the test title. | In-scope-Fix | Changed to `%s`. |
+| R35 | Claim that `applyReasoningDialect` emits a spurious field for a known host when both `enabled` and `effort` are absent. | Reject | Factually incorrect. Both appliers return `null` for empty settings: `applyThinkingDialect` requires `enabled === true` or a non-empty effort, and `applyOpenRouterDialect` requires `enabled === false`, a non-empty effort, or `enabled === true`. This is asserted directly (`applyReasoningDialect('thinking', {})` and `('openrouter', {})` both return `null`, plus the empty-string-effort cases) and through `prepareRequest` in the B12 row "z.ai, no reasoning settings at all". |
+| R36 | Repeat of the OCR changed-file coverage warning. | Reject | Same reason as R24 — a property of the tool's own sampling. |


### PR DESCRIPTION
## TLDR

Two defects made llxprt send malformed OpenAI-compatible request bodies.

1. The model config dialog wrote `"top_p": ".95"` as a **string**, because the
   numeric recognizer behind `parseValue()` required a digit before the decimal
   point. OpenRouter answers `400 top_p: Invalid input: expected number,
   received string`; Friendli silently coerces, which hides it.
2. On the **OpenAI Chat Completions transport**, a single `reasoning.enabled` +
   `reasoning.effort` intent emitted **several vendor dialects at once** — the
   OpenRouter-style `reasoning` object leaked out of the settings layer while
   the request builder separately injected the z.ai-style `thinking` field on
   every endpoint. Friendli answers `422 no such field: 'reasoning'` /
   `'thinking'`; Crusoe answers
   `403 Request blocked: parameter 'reasoning' is not allowed`.

After this change numeric params are typed at both the dialog and settings
egress (repairing profiles already on disk without rewriting them), and the
request body carries **at most one** reasoning representation, chosen from the
endpoint host.

Reviewers should look hardest at the provenance split in `separateSettings`
(synthesized global container vs. explicit provider-scoped model param) and at
the dialect table's default of emitting nothing for unlisted endpoints.

## Dive Deeper

### Bug 1 — string-typed numeric params

`looksNumeric()` in `setCommand.ts` required at least one digit **before** the
decimal point, so `.95` was not recognized as numeric, fell through
`JSON.parse` (which throws on `.95`), and was stored as raw text. The dialog
also performed no type validation, so `abc` in `top_p` was stored verbatim. The
same defect affected `/set modelparam top_p .95`; the dialog is just where it
was hit.

Fix: one strict recognizer, `isStrictNumericString` (in `packages/settings`),
now backs both `looksNumeric` and a registry-type-driven coercion in
`normalizeSetting`. It accepts leading-dot decimals and exponent notation and
still rejects `''`, `.`, `-`, `1.`, `1.2.3`, `0x10`, `Infinity`, `NaN`,
`1_000`, whitespace, and a leading `+` (deliberately — that preserves the
strictness of the scanner it replaces). The dialog's commit path moved into
`modelConfigParamCommit.ts` and rejects anything that does not parse to a
**finite** number for a `type: 'number'` param, surfacing the existing inline
validation error instead of writing a string. `parseSetting` gained the same
finite guard so ingress and egress agree — otherwise `/set modelparam top_p
1e400` would hold `Infinity` in memory and serialize to JSON `null`.

Existing profiles are repaired at settings egress; nothing on disk is rewritten,
and a value that cannot be safely coerced is left alone so the provider rejects
it visibly rather than being silently dropped.

### Bug 2 — reasoning-dialect fan-out

`SettingsService.set('reasoning.effort', 'high')` stores dotted keys as a nested
tree, so the global snapshot contains `reasoning: { enabled, effort }`.
`separateSettings()` flattened that into dotted keys **but kept the container**,
because a bare `reasoning` model-param spec exists whose sanitizer stripped only
five internal keys — `effort` survived into `modelParams` and was spread onto
the wire. Reproduced against the real pipeline:

    separateSettings({ reasoning: { enabled: true, effort: 'high' } }, 'openai')
      modelBehavior: { 'reasoning.enabled': true, 'reasoning.effort': 'high' }
      modelParams:   { reasoning: { effort: 'high' } }      <- leak

Independently, `resolveReasoningConfig` injected `thinking: { type: 'enabled' }`
for **every** OpenAI-compatible endpoint (added for GLM/Kimi, never gated).

Fix, in two parts:

**Provenance.** `separateSettings` now distinguishes a *synthesized* container
(built by nesting dotted global settings — its registered members are stripped)
from an *explicit* provider-scoped container (an actual
`/set modelparam reasoning {…}` or profile `modelParams` entry — preserved
verbatim, effort and all). Unregistered members such as OpenRouter's `exclude`
still pass through, and no longer also leak as a bogus literal
`reasoning.exclude` body field.

**One dialect — on the Chat Completions transport only.** Scope matters here,
so state it plainly. Each transport already had its own native reasoning
handling, and this PR changes exactly one of them:

| Transport | Reasoning it sends | Changed here |
| --- | --- | --- |
| `openai-responses` — GPT-5.6+ **requires** it; o1/o3/gpt-5.5 use it | `reasoning: { effort, summary }` plus `include: ['reasoning.encrypted_content']`, with `minimal` mapped to wire `none` for GPT-5.6+ | no |
| `anthropic` — Opus and friends | `thinking: { type, budget_tokens, display }` plus `output_config: { effort }` | no |
| `gemini` | `thinkingConfig` / `thinkingLevel` | no |
| `openai-vercel` | none — it sends no reasoning request field at all | no |
| **`openai` Chat Completions** | was: OpenRouter's `reasoning` **and** z.ai's `thinking`, on every endpoint | **yes** |

So GPT-5 is unaffected: it cannot use Chat Completions at all
(`parseOpenAIModelTransport` marks 5.6+ `requiresResponses`), and it keeps
getting `reasoning: { effort }` from the Responses executor. Anthropic/Opus
keeps its own `thinking` + `budget_tokens`. Neither path goes anywhere near the
table below.

Worth noting because it is what made the bug plausible: the leaked field on the
chat path, `reasoning: { effort }`, is shaped exactly like the *Responses*
field. It looked right and was simply on the wrong transport.

For the Chat Completions transport, new `openaiReasoningDialect.ts` resolves at
most one representation from the endpoint host:

| Base URL host         | Emitted field                                 |
| --------------------- | --------------------------------------------- |
| `openrouter.ai`       | `reasoning: { effort }` / `{ enabled }`        |
| `z.ai`, `bigmodel.cn` | `thinking: { type: 'enabled' \| 'disabled' }`  |
| anything else         | nothing                                       |

Host matching parses the URL (trimmed) and compares hostnames with
exact-or-dot-suffix semantics, so `evil-openrouter.ai.attacker.com` does not
match. An explicit `reasoning.enabled: false` outranks a leftover effort in both
dialects.

`none` is the deliberate default **for this transport**: llxprt cannot know an
arbitrary OpenAI-compatible endpoint's dialect, and guessing is exactly what
broke Friendli and Crusoe. An explicit `modelParams` value for any of
`reasoning`, `thinking`, `reasoning_effort`, or `parse_reasoning` stands
automatic selection down entirely, so the user's field stays the only reasoning
representation on the wire. Production and tests read that key list from one
shared constant.

`parse_reasoning` is not injected by llxprt — it was in the reporter's own
`modelParams`. Arbitrary passthrough works and is unchanged.

### Non-goals (recorded, not fixed here)

- Silent `exit 0` when a profile's `auth-key-name` cannot be resolved — #2916.
- A 403 presenting as an indefinite hang — #2917. This PR removes the *trigger*
  for the Crusoe 403 but does not change 403 handling.
- Rewriting profile files on disk; a new user-facing dialect-override setting.
- Reasoning handling on the Anthropic, Gemini, openai-responses, and
  openai-vercel transports. Each already selects a single native representation
  (see the transport table above) and none of them exhibited the fan-out, so
  they are untouched.
- Enforcing a provider alias's `modelDefaults[].unallowedParameters` on
  `/set modelparam`. That gate exists and the model config dialog honours it by
  hiding the fields, but the slash command does not consult it. Pre-existing and
  separate.

### Also included

`packages/cli/vitest.test-groups.ts` `SELECTED_FILE_COUNT` was stale on `main`
(518 against a real selected set of 519 — `5d4d0c741` added a CLI test file
without bumping the oracle). It moves to 524 here, covering that drift, the
files main has added since, and the one this PR adds. Without it the CLI suite
fails on this branch.

Planning, acceptance matrix, non-goals, review triage, and the scope ledger are
in `project-plans/issue2896/plan.md`.

## Reviewer Test Plan

The fastest confidence check is the new end-to-end suite, which drives real
`SettingsService` writes through `buildEphemeralsSnapshot`, `separateSettings`
inside `createRuntimeInvocationContext`, and then `prepareRequest`, asserting
the exact set of reasoning keys on the outbound body:

    npx vitest run src/openai/openaiReasoningPipeline.test.ts      # packages/providers
    npx vitest run src/openai/OpenAIRequestPreparation.issue2896.test.ts
    npx vitest run src/openai/openaiReasoningDialect.test.ts
    npx vitest run src/__tests__/settingsRegistry.issue2896.test.ts  # packages/settings
    npx vitest run src/__tests__/numericString.test.ts
    npx vitest run --config vitest.config.ts \
      src/ui/components/modelConfigParamCommit.spec.ts \
      src/ui/commands/setCommand.parseValue.test.ts                 # packages/cli

To exercise it by hand:

1. Point at a strict endpoint and confirm the malformed fields are gone.
   Build a profile with `base-url` `https://api.friendli.ai/serverless/v1`
   (or Crusoe) and ephemerals `reasoning.enabled true`, `reasoning.effort high`,
   then run a prompt. Before this change Friendli answered 422 and Crusoe 403.
2. Confirm the dialect still reaches the providers that want it. Run the same
   profile against `https://openrouter.ai/api/v1` (expect exactly
   `reasoning: {"effort":"high"}`) and against `https://api.z.ai/api/paas/v4`
   (expect exactly `thinking: {"type":"enabled"}`). Capturing the wire body
   against a local proxy is the clearest way to see it.
3. Confirm the escape hatch. On any endpoint,
   `/set modelparam thinking {"type":"enabled"}` — the user value must be the
   only reasoning field present, with nothing auto-injected beside it.
4. Confirm numeric typing in the dialog. `/model`, open the config screen, type
   `.95` into `top_p`, save, then `/profile save` and inspect the JSON: it must
   contain `"top_p": 0.95`, not `".95"`. Typing `abc` must show
   `top_p: must be a number` inline and block the save.
5. Confirm legacy repair. Hand-edit a profile to `"top_p": ".95"`, load it, and
   check the outbound body carries the number `0.95`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run typecheck`, `npm run lint`,
`npm run lint:eslint-guard`, `npm run format`, `npm run test`, `npm run build`,
and a live `bun scripts/start.ts --profile-load stepfun-37` smoke run. Linux and
Windows coverage comes from CI.

## Linked issues / bugs

Fixes #2896

Follow-ups split out as explicit non-goals: #2916, #2917
