### PR TITLE
Route clipboard copy through OSC-52 inside the sandbox (Fixes #1562)

### DIFF
--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -86,6 +86,7 @@ const resetEnv = () => {
   delete process.env['WSL_INTEROP'];
   delete process.env['TERM'];
   delete process.env['WT_SESSION'];
+  delete process.env['SANDBOX'];
 };
 
 interface MockChildProcess extends EventEmitter {
@@ -246,6 +247,73 @@ describe('commandUtils', () => {
       expect(tty.write).toHaveBeenCalledTimes(1);
       expect(tty.write.mock.calls[0][0]).toBe(expected);
       expect(tty.end).toHaveBeenCalledTimes(1); // /dev/tty closed after write
+      expect(mockClipboardyWrite).not.toHaveBeenCalled();
+    });
+
+    it('writes OSC-52 to the terminal when inside a macOS seatbelt sandbox', async () => {
+      const testText = 'seatbelt-copy';
+      const tty = makeWritable({ isTTY: true });
+      mockFs.createWriteStream.mockImplementation(() => {
+        setTimeout(() => tty.emit('open'), 0);
+        return tty;
+      });
+
+      process.env['SANDBOX'] = 'sandbox-exec';
+
+      await copyToClipboard(testText);
+
+      const b64 = Buffer.from(testText, 'utf8').toString('base64');
+      const expected = `${ESC}]52;c;${b64}${BEL}`;
+
+      expect(tty.write).toHaveBeenCalledTimes(1);
+      expect(tty.write.mock.calls[0][0]).toBe(expected);
+      expect(tty.end).toHaveBeenCalledTimes(1);
+      expect(mockClipboardyWrite).not.toHaveBeenCalled();
+    });
+
+    it('writes OSC-52 to the terminal when inside a container sandbox', async () => {
+      const testText = 'container-copy';
+      const tty = makeWritable({ isTTY: true });
+      mockFs.createWriteStream.mockImplementation(() => {
+        setTimeout(() => tty.emit('open'), 0);
+        return tty;
+      });
+
+      process.env['SANDBOX'] = 'llxprt-code-sandbox';
+
+      await copyToClipboard(testText);
+
+      const b64 = Buffer.from(testText, 'utf8').toString('base64');
+      const expected = `${ESC}]52;c;${b64}${BEL}`;
+
+      expect(tty.write).toHaveBeenCalledTimes(1);
+      expect(tty.write.mock.calls[0][0]).toBe(expected);
+      expect(tty.end).toHaveBeenCalledTimes(1);
+      expect(mockClipboardyWrite).not.toHaveBeenCalled();
+    });
+
+    it('falls back to stderr when inside a sandbox and /dev/tty is unavailable', async () => {
+      const testText = 'sandbox-stderr';
+      const stderrStream = makeWritable({ isTTY: true });
+      Object.defineProperty(process, 'stderr', {
+        value: stderrStream,
+        configurable: true,
+      });
+
+      process.env['SANDBOX'] = 'sandbox-exec';
+
+      mockFs.createWriteStream.mockImplementation(() => {
+        const tty = makeWritable({ isTTY: true });
+        setTimeout(() => tty.emit('error', new Error('EACCES')), 0);
+        return tty;
+      });
+
+      await copyToClipboard(testText);
+
+      const b64 = Buffer.from(testText, 'utf8').toString('base64');
+      const expected = `${ESC}]52;c;${b64}${BEL}`;
+
+      expect(stderrStream.write).toHaveBeenCalledWith(expected);
       expect(mockClipboardyWrite).not.toHaveBeenCalled();
     });
 

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -152,8 +152,14 @@ const isWindowsTerminal = (): boolean =>
 
 const isDumbTerm = (): boolean => (process.env['TERM'] ?? '') === 'dumb';
 
+// Inside a sandbox the local clipboard utility (pbcopy/xclip/wl-copy) is either
+// absent (container) or blocked by the seatbelt profile, so the OSC-52 terminal
+// escape path is used instead — the bytes flow through the sandbox PTY to the
+// host terminal emulator, which sets the host clipboard.
+const isInSandbox = (): boolean => Boolean(process.env['SANDBOX']);
+
 const hasOsc52Environment = (): boolean =>
-  isSSH() || isWSL() || isWindowsTerminal();
+  isSSH() || isWSL() || isWindowsTerminal() || isInSandbox();
 
 const shouldUseOsc52 = (tty: TtyTarget): tty is Exclude<TtyTarget, null> => {
   if (tty === null) {

--- a/project-plans/issue-1562-sandbox-copy.md
+++ b/project-plans/issue-1562-sandbox-copy.md
@@ -1,0 +1,50 @@
+# Issue #1562 — Copy support for sandbox proxy
+
+## Problem
+
+When the TUI runs inside a sandbox, clipboard copies are lost:
+
+- **Container (docker/podman):** `process.env.SANDBOX` is set to the container
+  name. `clipboardy.write()` shells out to `pbcopy`/`xclip`/`wl-copy` *inside*
+  the container, where they are absent or target an isolated clipboard.
+- **macOS Seatbelt (`SANDBOX=sandbox-exec`):** the seatbelt profile is
+  `(deny default)` with no grant for the pasteboard Mach service, so `pbcopy`
+  is blocked.
+
+The existing `copyToClipboard` (`packages/cli/src/ui/utils/commandUtils.ts`)
+already implements an **OSC 52** terminal escape-sequence path, but it only
+activates for SSH/WSL/WindowsTerminal. OSC 52 bytes flow transparently through
+the sandbox PTY → container client → host terminal, where the host terminal
+emulator writes to the **host** clipboard.
+
+## Approach
+
+Extend the existing OSC 52 mechanism to also cover sandbox environments. This
+reuses tested code; it is **not** a new subsystem (no container mounts, no
+daemon, no seatbelt-profile security change). A full host-side clipboard-proxy
+daemon is a larger, separately-scoped effort and is deferred.
+
+## Acceptance criteria
+
+1. **AC1:** When `process.env.SANDBOX` is set (container name or
+   `sandbox-exec`), `/copy` and mouse-selection copies route through the OSC 52
+   terminal path instead of the local `clipboardy` utility.
+2. **AC2:** OSC 52 is written to an appropriate TTY stream (preferring
+   `/dev/tty`, falling back to stderr/stdout).
+3. **AC3:** Non-sandboxed behavior is unchanged — local `clipboardy` is used
+   when no remote/sandbox environment is detected.
+4. **AC4:** tmux/screen wrapping and the empty-text no-op are preserved.
+5. **AC5 (tests):** `SANDBOX` set → OSC 52 path (no `clipboardy`); `SANDBOX`
+   unset → `clipboardy` path (no OSC 52).
+
+## Scope boundaries
+
+- In scope: `commandUtils.ts` sandbox detection + tests.
+- Out of scope: host-side clipboard-proxy daemon, seatbelt profile clipboard
+  grants, new settings/schema, container mount changes.
+
+## Limitation
+
+OSC 52 requires a terminal emulator that supports it (iTerm2, kitty, WezTerm,
+Alacritty, Windows Terminal, recent GNOME Terminal). macOS Terminal.app does
+not. This is the same limitation the existing SSH/WSL path has.


### PR DESCRIPTION
## Summary

When the TUI runs **inside a sandbox**, clipboard copies are silently lost because they target the sandbox's clipboard instead of the host's. This PR extends the existing **OSC-52 terminal escape-sequence** path so it also covers sandbox environments, allowing copies to flow through the sandbox PTY to the host terminal emulator which writes to the **host** clipboard.

Fixes #1562.

## Root cause

- **Container sandbox (docker/podman):** `process.env.SANDBOX` is set to the container name. The local clipboard utility (`clipboardy` → pbcopy/xclip/wl-copy) shells out *inside* the container, where those tools are absent or target an isolated clipboard.
- **macOS Seatbelt (`SANDBOX=sandbox-exec`):** the seatbelt profile uses `(deny default)` with no grant for the pasteboard Mach service, so pbcopy is blocked.

The existing `copyToClipboard()` in `packages/cli/src/ui/utils/commandUtils.ts` already implemented an OSC-52 terminal escape-sequence path, but it only activated for SSH/WSL/WindowsTerminal environments. OSC-52 bytes flow transparently through the sandbox's PTY → container client → host terminal, where the host terminal emulator sets the host clipboard.

## Change

Extend the existing OSC-52 mechanism (not a new subsystem) to also cover sandbox environments:

- `commandUtils.ts`: add `isInSandbox()` detection (`process.env.SANDBOX` truthy) and OR it into `hasOsc52Environment()`. This makes both the `/copy` command and mouse-selection copy route through OSC-52 when inside a sandbox, instead of the unavailable/blocked local clipboard utility.
- `commandUtils.test.ts`: clear `SANDBOX` in the shared `resetEnv()` for test isolation, and add behavioral tests for the seatbelt marker, the container-name marker, and the `/dev/tty`-unavailable stderr fallback.

No container mounts, no daemon, and no seatbelt-profile security change are required.

## Acceptance criteria

- [x] AC1: When `process.env.SANDBOX` is set (container name or `sandbox-exec`), `/copy` and mouse-selection copies route through OSC-52 instead of the local `clipboardy` utility.
- [x] AC2: OSC-52 is written to an appropriate TTY stream (preferring `/dev/tty`, falling back to stderr/stdout).
- [x] AC3: Non-sandboxed behavior is unchanged (local `clipboardy` is still used when no remote/sandbox environment is detected).
- [x] AC4: tmux/screen wrapping and the empty-text no-op are preserved.
- [x] AC5 (tests): `SANDBOX` set → OSC-52 path (no `clipboardy`); `SANDBOX` unset → `clipboardy` path.

## Verification

- Focused tests: 53/53 (`commandUtils.test.ts`, `clipboard.test.ts`, `copyCommand.test.ts`)
- Typecheck: 0 errors (cli workspace)
- Lint + eslint-guard: clean
- Build (cli workspace): success
- Smoke test (`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku..."`): pass

## Limitation (intentional, out of scope)

OSC-52 requires a terminal emulator that supports it (iTerm2, kitty, WezTerm, Alacritty, Windows Terminal, recent GNOME Terminal). macOS Terminal.app does not. This is the same limitation the existing SSH/WSL path already has. A full host-side clipboard-proxy daemon (reliable for all terminals) is a larger, separately-scoped effort and is deferred.
