### PR TITLE
Harden multiline shell heredoc validation (Fixes #2003)

### DIFF
--- a/packages/core/src/utils/shell-parser.ts
+++ b/packages/core/src/utils/shell-parser.ts
@@ -324,12 +324,101 @@ export interface CommandParseResult {
   hasError: boolean;
 }
 
-function hasShellSubstitutionSyntax(command: string): boolean {
+type SourceRange = {
+  startIndex: number;
+  endIndex: number;
+};
+
+function findNamedChild(node: Node, type: string): Node | null {
+  for (let index = 0; index < node.namedChildCount; index += 1) {
+    const child = node.namedChild(index);
+    if (child?.type === type) {
+      return child;
+    }
+  }
+  return null;
+}
+
+function collectHeredocRedirects(root: Node): Node[] {
+  const redirects: Node[] = [];
+  const stack: Node[] = [root];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+
+    if (current.type === 'heredoc_redirect') {
+      redirects.push(current);
+    }
+
+    for (let index = current.namedChildCount - 1; index >= 0; index -= 1) {
+      const child = current.namedChild(index);
+      if (child) {
+        stack.push(child);
+      }
+    }
+  }
+
+  return redirects;
+}
+
+function isQuotedHeredocStart(node: Node, source: string): boolean {
+  const delimiter = source.slice(node.startIndex, node.endIndex);
+  return (
+    delimiter.includes("'") ||
+    delimiter.includes('"') ||
+    delimiter.includes('\\')
+  );
+}
+
+function collectLiteralHeredocBodyRanges(
+  root: Node,
+  source: string,
+): SourceRange[] {
+  const ranges: SourceRange[] = [];
+
+  for (const redirect of collectHeredocRedirects(root)) {
+    const start = findNamedChild(redirect, 'heredoc_start');
+    const body = findNamedChild(redirect, 'heredoc_body');
+    if (start && body && isQuotedHeredocStart(start, source)) {
+      ranges.push({
+        startIndex: body.startIndex,
+        endIndex: body.endIndex,
+      });
+    }
+  }
+
+  return ranges;
+}
+
+function getLiteralRange(
+  ranges: SourceRange[],
+  index: number,
+): SourceRange | null {
+  if (index < 0 || index >= ranges.length) {
+    return null;
+  }
+  return ranges[index];
+}
+
+function hasShellSubstitutionSyntax(command: string, root: Node): boolean {
+  const literalRanges = collectLiteralHeredocBodyRanges(root, command);
+  let literalRangeIndex = 0;
   let inSingleQuotes = false;
   let inDoubleQuotes = false;
   let skipCurrent = false;
 
   for (let i = 0; i < command.length; i += 1) {
+    const literalRange = getLiteralRange(literalRanges, literalRangeIndex);
+    if (literalRange !== null && i >= literalRange.endIndex) {
+      literalRangeIndex += 1;
+    } else if (literalRange !== null && i >= literalRange.startIndex) {
+      i = literalRange.endIndex - 1;
+      continue;
+    }
+
     const char = command[i];
     if (skipCurrent) {
       skipCurrent = false;
@@ -550,7 +639,9 @@ export function parseCommandDetails(
     // Check for syntax errors, empty command list, dangerous prompt transformations,
     // or substitution syntax that the grammar failed to expose as executable commands.
     const hasMissingSubstitutionDetails =
-      hasShellSubstitutionSyntax(command) && !hasCommandSubstitution(tree);
+      hasUnrepresentedHeredocBacktickSubstitution(tree.rootNode, command) ||
+      (hasShellSubstitutionSyntax(command, tree.rootNode) &&
+        !hasParsedCommandSubstitution(tree));
     const hasError =
       tree.rootNode.hasError ||
       details.length === 0 ||
@@ -587,19 +678,11 @@ export function parseCommandDetails(
   }
 }
 
-/**
- * Check if a command contains command substitution patterns.
- * Uses tree-sitter AST to accurately detect:
- * - $() command substitution
- * - `` backtick substitution
- * - <() process substitution
- */
-export function hasCommandSubstitution(tree: Tree): boolean {
+function hasParsedCommandSubstitution(tree: Tree): boolean {
   if (!bashLanguage) {
     return false;
   }
 
-  // Query for command_substitution and process_substitution nodes
   const query = bashLanguage.query(`
     [
       (command_substitution) @sub
@@ -613,6 +696,52 @@ export function hasCommandSubstitution(tree: Tree): boolean {
   } finally {
     query.delete();
   }
+}
+
+function containsUnescapedBacktick(text: string): boolean {
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] === '\\') {
+      index += 1;
+    } else if (text[index] === '`') {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasUnrepresentedHeredocBacktickSubstitution(
+  root: Node,
+  source: string,
+): boolean {
+  for (const redirect of collectHeredocRedirects(root)) {
+    const start = findNamedChild(redirect, 'heredoc_start');
+    const body = findNamedChild(redirect, 'heredoc_body');
+    if (
+      start &&
+      body &&
+      !isQuotedHeredocStart(start, source) &&
+      containsUnescapedBacktick(body.text)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a command contains executable command substitution patterns.
+ * The bash grammar omits backtick nodes in heredoc bodies, so unquoted
+ * heredoc bodies require a narrow source-text check for unescaped backticks.
+ */
+export function hasCommandSubstitution(tree: Tree): boolean {
+  return (
+    hasParsedCommandSubstitution(tree) ||
+    hasUnrepresentedHeredocBacktickSubstitution(
+      tree.rootNode,
+      tree.rootNode.text,
+    )
+  );
 }
 
 /**

--- a/packages/core/src/utils/shell-utils.multiline.test.ts
+++ b/packages/core/src/utils/shell-utils.multiline.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  checkCommandPermissions,
+  detectCommandSubstitution,
+  type ShellPermissionConfig,
+} from './shell-utils.js';
+import {
+  initializeParser,
+  isParserAvailable,
+  parseCommandDetails,
+} from './shell-parser.js';
+
+await initializeParser();
+
+const UNQUOTED_BACKTICK_HEREDOC =
+  'cat <<EOF\nInside heredoc `unterminated\nEOF';
+const QUOTED_BACKTICK_HEREDOC = "cat <<'EOF'\n`not_executed`\nEOF";
+const UNQUOTED_DOLLAR_HEREDOC = 'cat <<EOF\n$(date)\nEOF';
+const QUOTED_DOLLAR_HEREDOC = "cat <<'EOF'\n$(date)\nEOF";
+const UNQUOTED_PAIRED_BACKTICK_HEREDOC = 'cat <<EOF\n`date`\nEOF';
+const UNQUOTED_ESCAPED_BACKTICK_HEREDOC = 'cat <<EOF\n\\`date\\`\nEOF';
+
+const QUOTED_DELIMITER_HEREDOCS = [
+  QUOTED_DOLLAR_HEREDOC,
+  'cat <<"EOF"\n$(date)\nEOF',
+  'cat <<\\EOF\n$(date)\nEOF',
+] as const;
+
+const MALFORMED_SUBSTITUTIONS = [
+  'echo safe\necho `date',
+  'ls -la\n`evil_cmd',
+  '(echo `subshell_cmd',
+  'if true; then `bad_cmd; fi',
+  'echo `; rm -rf /',
+  'cat <(echo `unterminated',
+  'echo $(echo `inner',
+] as const;
+
+function createConfig(
+  mode: 'none' | 'allowlist',
+  coreTools: string[],
+): ShellPermissionConfig {
+  return {
+    getEphemeralSetting: () => mode,
+    getShellReplacement: () => mode,
+    getExcludeTools: () => [],
+    getCoreTools: () => coreTools,
+  };
+}
+
+function permissionDecision(
+  command: string,
+  mode: 'none' | 'allowlist',
+  coreTools: string[],
+): { allAllowed: boolean; isHardDenial: boolean } {
+  const result = checkCommandPermissions(
+    command,
+    createConfig(mode, coreTools),
+  );
+  return {
+    allAllowed: result.allAllowed,
+    isHardDenial: result.isHardDenial === true,
+  };
+}
+
+const HARD_DENIAL = { allAllowed: false, isHardDenial: true };
+
+describe.skipIf(!isParserAvailable())(
+  'multiline command substitution detection',
+  () => {
+    it.each([
+      UNQUOTED_BACKTICK_HEREDOC,
+      UNQUOTED_DOLLAR_HEREDOC,
+      ...MALFORMED_SUBSTITUTIONS,
+    ])('detects executable substitution syntax in %j', (command) => {
+      expect(detectCommandSubstitution(command)).toBe(true);
+    });
+
+    it.each([QUOTED_BACKTICK_HEREDOC, ...QUOTED_DELIMITER_HEREDOCS])(
+      'treats quoted heredoc contents as literal in %j',
+      (command) => {
+        expect(detectCommandSubstitution(command)).toBe(false);
+      },
+    );
+
+    it('detects paired backticks in an unquoted heredoc body', () => {
+      expect(detectCommandSubstitution(UNQUOTED_PAIRED_BACKTICK_HEREDOC)).toBe(
+        true,
+      );
+    });
+
+    it('treats escaped backticks in an unquoted heredoc body as literal', () => {
+      expect(detectCommandSubstitution(UNQUOTED_ESCAPED_BACKTICK_HEREDOC)).toBe(
+        false,
+      );
+    });
+  },
+);
+
+describe.skipIf(!isParserAvailable())('heredoc command parsing', () => {
+  it.each(MALFORMED_SUBSTITUTIONS)(
+    'reports a parse error for malformed substitution %j',
+    (command) => {
+      const result = parseCommandDetails(command);
+      expect(result).not.toBeNull();
+      expect(result?.hasError).toBe(true);
+    },
+  );
+
+  it.each([QUOTED_BACKTICK_HEREDOC, ...QUOTED_DELIMITER_HEREDOCS])(
+    'extracts only cat from quoted heredoc %j',
+    (command) => {
+      expect(parseCommandDetails(command)).toStrictEqual({
+        details: [{ name: 'cat', text: 'cat' }],
+        hasError: false,
+      });
+    },
+  );
+
+  it('rejects an unrepresented backtick substitution in an unquoted heredoc', () => {
+    expect(parseCommandDetails(UNQUOTED_BACKTICK_HEREDOC)).toStrictEqual({
+      details: [{ name: 'cat', text: 'cat' }],
+      hasError: true,
+    });
+  });
+
+  it('extracts a represented nested command from an unquoted heredoc', () => {
+    expect(parseCommandDetails(UNQUOTED_DOLLAR_HEREDOC)).toStrictEqual({
+      details: [
+        { name: 'cat', text: 'cat' },
+        { name: 'date', text: 'date' },
+      ],
+      hasError: false,
+    });
+  });
+});
+
+describe.skipIf(!isParserAvailable())(
+  'multiline shell replacement permissions',
+  () => {
+    it.each([UNQUOTED_BACKTICK_HEREDOC, ...MALFORMED_SUBSTITUTIONS])(
+      'hard-denies executable substitution syntax in none mode for %j',
+      (command) => {
+        expect(
+          permissionDecision(command, 'none', [
+            'run_shell_command(cat)',
+            'run_shell_command(echo)',
+            'run_shell_command(ls)',
+          ]),
+        ).toStrictEqual(HARD_DENIAL);
+      },
+    );
+
+    it.each([QUOTED_BACKTICK_HEREDOC, QUOTED_DOLLAR_HEREDOC])(
+      'allows literal quoted heredoc contents in none mode for %j',
+      (command) => {
+        expect(
+          permissionDecision(command, 'none', ['run_shell_command(cat)']),
+        ).toStrictEqual({ allAllowed: true, isHardDenial: false });
+      },
+    );
+
+    it.each([UNQUOTED_BACKTICK_HEREDOC, ...MALFORMED_SUBSTITUTIONS])(
+      'hard-denies unsafe parsing in allowlist mode for %j',
+      (command) => {
+        expect(
+          permissionDecision(command, 'allowlist', [
+            'run_shell_command(cat)',
+            'run_shell_command(echo)',
+            'run_shell_command(ls)',
+          ]),
+        ).toStrictEqual(HARD_DENIAL);
+      },
+    );
+
+    it.each([QUOTED_BACKTICK_HEREDOC, QUOTED_DOLLAR_HEREDOC])(
+      'allows literal quoted heredoc contents when cat is allowlisted for %j',
+      (command) => {
+        expect(
+          permissionDecision(command, 'allowlist', ['run_shell_command(cat)']),
+        ).toStrictEqual({ allAllowed: true, isHardDenial: false });
+      },
+    );
+
+    it('requires represented nested heredoc commands to be allowlisted', () => {
+      expect(
+        permissionDecision(UNQUOTED_DOLLAR_HEREDOC, 'allowlist', [
+          'run_shell_command(cat)',
+        ]),
+      ).toStrictEqual({ allAllowed: false, isHardDenial: false });
+    });
+
+    it('allows represented nested heredoc commands when each is allowlisted', () => {
+      expect(
+        permissionDecision(UNQUOTED_DOLLAR_HEREDOC, 'allowlist', [
+          'run_shell_command(cat)',
+          'run_shell_command(date)',
+        ]),
+      ).toStrictEqual({ allAllowed: true, isHardDenial: false });
+    });
+  },
+);

--- a/packages/core/src/utils/shell-utils.parserUnavailable.test.ts
+++ b/packages/core/src/utils/shell-utils.parserUnavailable.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { ShellPermissionConfig } from './shell-utils.js';
+
+vi.mock('./shell-parser.js', () => ({
+  isParserAvailable: () => false,
+  parseShellCommand: () => null,
+  extractCommandNames: () => [],
+  hasCommandSubstitution: () => false,
+  splitCommandsWithTree: () => [],
+  parseCommandDetails: () => null,
+  hasPromptCommandTransform: () => false,
+}));
+
+const { checkCommandPermissions } = await import('./shell-utils.js');
+
+function createConfig(
+  mode: 'none' | 'allowlist' | 'all',
+  coreTools: string[],
+): ShellPermissionConfig {
+  return {
+    getEphemeralSetting: () => mode,
+    getShellReplacement: () => mode,
+    getExcludeTools: () => [],
+    getCoreTools: () => coreTools,
+  };
+}
+
+function permissionDecision(
+  command: string,
+  mode: 'none' | 'allowlist' | 'all',
+  coreTools: string[],
+): { allAllowed: boolean; isHardDenial: boolean } {
+  const result = checkCommandPermissions(
+    command,
+    createConfig(mode, coreTools),
+  );
+  return {
+    allAllowed: result.allAllowed,
+    isHardDenial: result.isHardDenial === true,
+  };
+}
+
+const HARD_DENIAL = { allAllowed: false, isHardDenial: true };
+
+describe('permissions without the shell parser', () => {
+  it.each(['none', 'allowlist'] as const)(
+    'hard-denies LF multiline input in %s mode',
+    (mode) => {
+      expect(
+        permissionDecision('echo safe\necho more', mode, [
+          'run_shell_command(echo)',
+        ]),
+      ).toStrictEqual(HARD_DENIAL);
+    },
+  );
+
+  it.each(['none', 'allowlist'] as const)(
+    'hard-denies CRLF multiline input in %s mode',
+    (mode) => {
+      expect(
+        permissionDecision('echo safe\r\necho more', mode, [
+          'run_shell_command(echo)',
+        ]),
+      ).toStrictEqual(HARD_DENIAL);
+    },
+  );
+
+  it.each(['none', 'allowlist'] as const)(
+    'hard-denies one-line heredoc syntax in %s mode',
+    (mode) => {
+      expect(
+        permissionDecision('cat <<EOF', mode, ['run_shell_command(cat)']),
+      ).toStrictEqual(HARD_DENIAL);
+    },
+  );
+
+  it.each(['none', 'allowlist'] as const)(
+    'hard-denies a fully quoted multiline heredoc in %s mode',
+    (mode) => {
+      expect(
+        permissionDecision("cat <<'EOF'\ntext\nEOF", mode, [
+          'run_shell_command(cat)',
+        ]),
+      ).toStrictEqual(HARD_DENIAL);
+    },
+  );
+
+  it.each(['none', 'allowlist', 'all'] as const)(
+    'treats a here-string <<< as ordinary fallback in %s mode',
+    (mode) => {
+      expect(
+        permissionDecision('cat <<<value', mode, ['run_shell_command(cat)']),
+      ).toStrictEqual({ allAllowed: true, isHardDenial: false });
+    },
+  );
+
+  it.each(['none', 'allowlist'] as const)(
+    'does not mistake quoted heredoc-like text for syntax in %s mode',
+    (mode) => {
+      expect(
+        permissionDecision("echo '<<EOF'", mode, ['run_shell_command(echo)']),
+      ).toStrictEqual({ allAllowed: true, isHardDenial: false });
+    },
+  );
+
+  it.each(['none', 'allowlist'] as const)(
+    'retains ordinary one-line fallback in %s mode',
+    (mode) => {
+      expect(
+        permissionDecision('ls -la /tmp', mode, ['run_shell_command(ls)']),
+      ).toStrictEqual({ allAllowed: true, isHardDenial: false });
+    },
+  );
+
+  it('retains one-line substitution denial in none mode', () => {
+    expect(
+      permissionDecision('echo $(date)', 'none', ['run_shell_command(echo)']),
+    ).toStrictEqual(HARD_DENIAL);
+  });
+
+  it.each(['echo safe\necho more', 'cat <<EOF'])(
+    'does not change all mode for %j',
+    (command) => {
+      expect(
+        permissionDecision(command, 'all', ['run_shell_command']),
+      ).toStrictEqual({ allAllowed: true, isHardDenial: false });
+    },
+  );
+});

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -25,9 +25,10 @@
  *
  * Tree-sitter (`shell-parser.ts`) is the primary parser. The regex-based
  * functions in this file are best-effort fallbacks used only when the
- * tree-sitter WASM bundle failed to load at startup. The bypass risk from
- * regex imprecision is mitigated because `allowlist` mode hard-denies on
- * parse errors and tree-sitter is bundled (fallback activation is rare).
+ * tree-sitter WASM bundle failed to load at startup. Because those fallbacks
+ * cannot model multiline or heredoc semantics, `none` and `allowlist` modes
+ * fail closed for line breaks and heredoc operators while the parser is
+ * unavailable.
  */
 
 import type { AnyToolInvocation } from '../index.js';
@@ -471,11 +472,14 @@ export function detectCommandSubstitution(command: string): boolean {
   if (isParserAvailable()) {
     const tree = parseShellCommand(command);
     if (tree) {
-      return treeSitterHasCommandSubstitution(tree);
+      const detected = treeSitterHasCommandSubstitution(tree);
+      if (detected || !tree.rootNode.hasError) {
+        return detected;
+      }
     }
   }
 
-  // Fall back to regex-based detection
+  // Parser errors require conservative detection of malformed substitution starts.
   return detectCommandSubstitutionRegex(command);
 }
 
@@ -605,6 +609,57 @@ function resolveShellReplacementMode(
     | undefined;
   const configValue = config.getShellReplacement();
   return normalizeShellReplacement(ephemeralValue ?? configValue);
+}
+
+function hasHeredocOperator(command: string): boolean {
+  let inSingleQuotes = false;
+  let inDoubleQuotes = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === '\\' && !inSingleQuotes) {
+      index += 1;
+    } else if (char === "'" && !inDoubleQuotes) {
+      inSingleQuotes = !inSingleQuotes;
+    } else if (char === '"' && !inSingleQuotes) {
+      inDoubleQuotes = !inDoubleQuotes;
+    } else if (char === '<' && !inSingleQuotes && !inDoubleQuotes) {
+      // Measure the full contiguous run of '<' so that the Bash here-string
+      // '<<<' (3+) is not misclassified as a heredoc '<<'. Only an exact
+      // two-character run is a heredoc operator (<< or <<-).
+      let runLength = 1;
+      while (command[index + runLength] === '<') {
+        runLength += 1;
+      }
+      if (runLength === 2) {
+        return true;
+      }
+      // Skip the entire run so no later pair within it is reclassified.
+      index += runLength - 1;
+    }
+  }
+
+  return false;
+}
+
+function checkParserUnavailableBlock(
+  command: string,
+  shellReplacementMode: 'allowlist' | 'all' | 'none',
+): PermissionCheckResult | null {
+  if (
+    shellReplacementMode !== 'all' &&
+    !isParserAvailable() &&
+    (/\r|\n/u.test(command) || hasHeredocOperator(command))
+  ) {
+    return {
+      allAllowed: false,
+      disallowedCommands: [command],
+      blockReason:
+        'Command rejected because multiline and heredoc syntax requires the shell parser',
+      isHardDenial: true,
+    };
+  }
+  return null;
 }
 
 function checkShellReplacementBlock(
@@ -820,6 +875,12 @@ export function checkCommandPermissions(
       command: command.substring(0, 50) + (command.length > 50 ? '...' : ''),
     });
   }
+
+  const parserUnavailableBlock = checkParserUnavailableBlock(
+    command,
+    shellReplacementMode,
+  );
+  if (parserUnavailableBlock) return parserUnavailableBlock;
 
   const replacementBlock = checkShellReplacementBlock(
     command,

--- a/project-plans/issue2003-shell-heredoc-audit/plan.md
+++ b/project-plans/issue2003-shell-heredoc-audit/plan.md
@@ -1,0 +1,107 @@
+# Issue 2003: Multiline shell and heredoc parsing audit
+
+Plan ID: PLAN-20260801-ISSUE2003
+
+## Accepted behavior
+
+### AC-1: Exact multiline inputs reach the real APIs
+
+Behavioral tests pass multiline strings directly to `detectCommandSubstitution()`, `parseCommandDetails()`, and `checkCommandPermissions()` without shell evaluation. The tests cover:
+
+- an unquoted heredoc containing an opening backtick
+- a quoted heredoc containing paired backticks
+- a safe command followed by a malformed backtick substitution
+- a safe command followed by a malformed standalone backtick substitution
+- malformed substitution inside a subshell, conditional, process substitution, and nested `$()`
+
+### AC-2: `none` mode denies executable substitution syntax
+
+With tree-sitter available, `shell-replacement=none`:
+
+- hard-denies the unquoted heredoc containing an opening backtick
+- hard-denies every listed malformed multiline/nested substitution input
+- permits a quoted heredoc body containing paired backticks when its executable command is otherwise allowed, because the body is literal
+
+The direct detector returns the same substitution decision for these inputs. A parser error may trigger conservative lexical detection, but a syntactically valid quoted heredoc must retain literal-body semantics.
+
+### AC-3: `allowlist` mode validates complete parse behavior
+
+With tree-sitter available, `shell-replacement=allowlist`:
+
+- hard-denies the unquoted heredoc containing an opening backtick because the executable substitution cannot be parsed safely
+- permits a quoted heredoc containing paired backticks when `cat` is allowlisted
+- hard-denies every listed malformed multiline/nested input as an unsafe parse
+- continues extracting and validating nested commands from supported unquoted heredoc substitutions such as `$(date)`
+- does not treat supported quoted heredoc substitutions such as `$(date)` as executable
+
+### AC-4: Parser-unavailable behavior is fail-closed for this scope
+
+When tree-sitter is unavailable, both `none` and `allowlist` modes hard-deny:
+
+- commands containing line breaks
+- commands containing heredoc redirection syntax outside shell quotes
+
+This intentionally avoids asking the regex fallback to model heredoc delimiter quoting or multiline shell grammar. One-line commands without heredoc syntax retain their existing fallback behavior. `shell-replacement=all` is unchanged.
+
+### AC-5: Limitations are explicit
+
+Implementation documentation states:
+
+- regex fallback does not model multiline/heredoc semantics and permission checks fail closed for those inputs in `none` and `allowlist` modes
+- the bundled tree-sitter grammar does not expose backtick substitutions in heredoc bodies as command-substitution nodes; unquoted heredoc backtick syntax that cannot be fully extracted is therefore rejected in allowlist mode
+
+## Boundary cases and evidence
+
+| Input | Direct detection with parser | `none` | `allowlist` with relevant outer commands allowlisted |
+| --- | --- | --- | --- |
+| `cat <<EOF\nInside heredoc \`unterminated\nEOF` | substitution | hard denial: substitution | hard denial: unsafe parse |
+| `cat <<'EOF'\n\`not_executed\`\nEOF` | literal | allowed | allowed (`cat` only) |
+| `echo safe\necho \`date` | substitution | hard denial: substitution | hard denial: unsafe parse |
+| `ls -la\n\`evil_cmd` | substitution | hard denial: substitution | hard denial: unsafe parse |
+| `(echo \`subshell_cmd` | substitution | hard denial: substitution | hard denial: unsafe parse |
+| `if true; then \`bad_cmd; fi` | substitution | hard denial: substitution | hard denial: unsafe parse |
+| `echo \`; rm -rf /` | substitution | hard denial: substitution | hard denial: unsafe parse |
+| `cat <(echo \`unterminated` | substitution | hard denial: substitution | hard denial: unsafe parse |
+| `echo $(echo \`inner` | substitution | hard denial: substitution | hard denial: unsafe parse |
+| `cat <<EOF\n$(date)\nEOF` | substitution | hard denial: substitution | `date` must be independently allowlisted |
+| `cat <<'EOF'\n$(date)\nEOF` | literal | allowed | allowed (`cat` only) |
+
+Parser-unavailable tests prove fail-closed behavior for LF, CRLF, and heredoc syntax, including a quoted heredoc. They also prove an ordinary one-line command retains its existing result.
+
+## TDD sequence
+
+1. Add tree-sitter behavioral tests for direct detection and permission outcomes using the exact strings above.
+2. Run the focused test file and record failures before production changes.
+3. Add parser-unavailable permission tests by mocking only parser infrastructure, while exercising the real `checkCommandPermissions()` implementation.
+4. Run those tests and record failures before production changes.
+5. Make the minimum parser/orchestration changes required by AC-2 through AC-5.
+6. Run focused tests, then the full verification suite.
+
+## Integration points
+
+- `packages/core/src/utils/shell-parser.ts`: existing AST substitution detection and unsafe-parse classification.
+- `packages/core/src/utils/shell-utils.ts`: existing direct detector and permission-mode orchestration.
+- Existing shell utility test suites: behavioral evidence through public parser and permission functions.
+
+No new dependency, public API, subsystem, workflow, setting, or parser implementation is accepted.
+
+## Out of scope
+
+- changing `shell-replacement=all`
+- replacing tree-sitter or adding a shell parser
+- teaching regex fallback complete shell or heredoc grammar
+- changing unrelated one-line fallback semantics
+- refactoring split-command architecture or unrelated shell utilities
+- adjacent shell hardening not exercised by the accepted inputs
+
+## Verification gates
+
+- Focused shell parser/permission tests pass.
+- `npm run test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run format`
+- `npm run build`
+- configured LLxprt smoke test passes.
+- DeepThinker and Open Code Review findings are classified as Blocker-Fix, In-scope-Fix, Reject, or Defer; all required fixes are complete.
+- Candidate PR head has green CI, resolved required review threads, correct ancestry, and no merge conflict.


### PR DESCRIPTION
## TLDR

Hardens multiline shell permission validation so malformed substitutions and executable substitutions inside unquoted heredocs cannot bypass `shell-replacement=none` or allowlist validation. Fully quoted heredoc bodies remain literal, and parser-unavailable security-sensitive modes now fail closed for multiline and heredoc input without changing here-string or ordinary one-line fallback behavior.

## Dive Deeper

- Uses the Bash tree-sitter AST for quoted-versus-unquoted heredoc semantics.
- Detects unescaped backticks in unquoted heredoc bodies because the bundled grammar does not expose those substitutions as executable command nodes.
- Conservatively checks malformed parser trees with the existing fallback substitution detector so unterminated backticks in multiline, subshell, conditional, process-substitution, and nested-substitution contexts are denied.
- Hard-denies multiline and heredoc commands in `none` and `allowlist` modes when tree-sitter is unavailable; `all` mode and one-line fallback semantics remain unchanged.
- Preserves Bash here-strings (`<<<`) as ordinary one-line fallback input.
- Adds direct behavioral coverage for detector, parser-detail, and full permission APIs with exact LF/CRLF command strings.

Review focus:

- `packages/core/src/utils/shell-parser.ts`: heredoc AST/source orchestration and missing-backtick representation handling.
- `packages/core/src/utils/shell-utils.ts`: parser-error fallback and parser-unavailable fail-closed policy.
- The two new behavioral suites cover parser-available and parser-unavailable paths independently.

Local review findings were classified before submission. All Blocker-Fix and In-scope-Fix findings were addressed. Partial/internal heredoc delimiter quoting remains deferred because the bundled grammar reports those forms as parse errors; security-sensitive permission validation therefore continues to deny them rather than weakening parse-error handling.

## Reviewer Test Plan

From the repository root:

1. Run the focused behavioral tests:

       npm test --workspace @vybestack/llxprt-code-core -- --run src/utils/shell-utils.multiline.test.ts src/utils/shell-utils.parserUnavailable.test.ts

2. Run the shell parsing regression suites:

       cd packages/core
       npm test -- --run src/utils/shell-parser.test.ts src/utils/shell-parser-prompt-transform.test.ts src/utils/shell-utils.detectSubstitution.test.ts src/utils/shell-utils.shellReplacement.test.ts src/utils/shell-utils.splitCommands.test.ts src/utils/shell-utils.multiline.test.ts src/utils/shell-utils.parserUnavailable.test.ts src/utils/shell-utils.test.ts

3. Verify full project gates:

       npm run typecheck
       npm run build
       npm run format
       npm run lint
       npm run test

4. Smoke-test the CLI with an available profile:

       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

Expected focused behavior:

- Quoted heredoc body substitutions are literal and do not trigger `none` mode.
- Unquoted heredoc substitutions trigger `none` and are independently allowlist-validated.
- Malformed listed substitutions are hard-denied.
- With parser infrastructure unavailable, multiline/heredoc input is hard-denied in `none` and `allowlist`, while `all`, here-strings, and ordinary one-line input keep existing behavior.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS local evidence:

- Focused issue suites: 68 passed.
- Shell utility regression suites: 189 passed, 4 skipped.
- Core complete suite: 5,864 passed, 40 skipped.
- Remaining workspaces were run independently after the root sequential test command exceeded the local command watchdog; full typecheck and build passed.
- Focused ESLint, repository lint policy/architecture guards, Prettier, and diff checks passed. The monolithic full lint command exceeded the local command watchdog; CI remains authoritative for that full-tree gate.
- The configured ollamakimi profile returned HTTP 410 because its model was retired externally. The current project-local stepfun-37 smoke profile completed successfully.

## Linked issues / bugs

Fixes #2003
