### PR TITLE
Fail fast when the running runtime is unlinked instead of storming macOS Keychain prompts (Fixes #2926)

### DIFF
--- a/packages/auth/src/interfaces/index.ts
+++ b/packages/auth/src/interfaces/index.ts
@@ -21,6 +21,7 @@ export type {
   ISecureStoreError,
   SecureStoreErrorCode,
 } from './secure-store.js';
+export { isRuntimeReplacedStoreError } from './secure-store.js';
 
 export type { ISettingsService } from './settings-service.js';
 

--- a/packages/auth/src/interfaces/secure-store.ts
+++ b/packages/auth/src/interfaces/secure-store.ts
@@ -12,6 +12,9 @@
 /**
  * Error codes for secure store operations.
  * Derived from core SecureStore error handling evidence (P01 dependency-audit).
+ *
+ * `RUNTIME_REPLACED` is a terminal error identity: downstream swallow/fallback
+ * layers must rethrow it rather than absorb it (issue #2926).
  */
 export type SecureStoreErrorCode =
   | 'UNAVAILABLE'
@@ -19,7 +22,8 @@ export type SecureStoreErrorCode =
   | 'DENIED'
   | 'CORRUPT'
   | 'TIMEOUT'
-  | 'NOT_FOUND';
+  | 'NOT_FOUND'
+  | 'RUNTIME_REPLACED';
 
 /**
  * Error shape thrown/rejected by ISecureStore operations.
@@ -54,4 +58,21 @@ export interface ISecureStore {
   delete(key: string): Promise<boolean>;
   list(): Promise<string[]>;
   has(key: string): Promise<boolean>;
+}
+
+/**
+ * Type guard: narrows to an ISecureStoreError whose code is RUNTIME_REPLACED.
+ * Downstream swallow/fallback layers must rethrow this terminal error rather
+ * than absorb it (issue #2926).
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3
+ */
+export function isRuntimeReplacedStoreError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'RUNTIME_REPLACED'
+  );
 }

--- a/packages/auth/src/interfaces/secure-store.ts
+++ b/packages/auth/src/interfaces/secure-store.ts
@@ -68,7 +68,9 @@ export interface ISecureStore {
  * @plan PLAN-20260801-ISSUE2926
  * @requirement R3
  */
-export function isRuntimeReplacedStoreError(error: unknown): boolean {
+export function isRuntimeReplacedStoreError(
+  error: unknown,
+): error is ISecureStoreError {
   return (
     typeof error === 'object' &&
     error !== null &&

--- a/packages/auth/src/keyring-token-store.ts
+++ b/packages/auth/src/keyring-token-store.ts
@@ -27,7 +27,11 @@ import {
   type AuthLockRecoveryResult,
   type ForceRecoverOptions,
 } from './token-store.js';
-import { type IDebugLogger, type ISecureStore } from './interfaces/index.js';
+import {
+  type IDebugLogger,
+  type ISecureStore,
+  isRuntimeReplacedStoreError,
+} from './interfaces/index.js';
 import {
   buildCurrentProcessOwnerMetadata,
   parseOwnerMetadata,
@@ -553,6 +557,9 @@ export class KeyringTokenStore implements TokenStore {
     try {
       raw = await this.secureStore.get(key);
     } catch (error) {
+      if (isRuntimeReplacedStoreError(error)) {
+        throw error;
+      }
       if (isSecureStoreCorruptError(error)) {
         const msg = errorMessageOf(error);
         this.logger.warn(
@@ -597,6 +604,9 @@ export class KeyringTokenStore implements TokenStore {
     try {
       await this.secureStore.delete(key);
     } catch (error) {
+      if (isRuntimeReplacedStoreError(error)) {
+        throw error;
+      }
       const msg = error instanceof Error ? error.message : String(error);
       this.logger.warn(
         `Failed to remove token for [${this.hashIdentifier(key)}]: ${msg}`,
@@ -617,6 +627,9 @@ export class KeyringTokenStore implements TokenStore {
       }
       return Array.from(providerSet).sort();
     } catch (error) {
+      if (isRuntimeReplacedStoreError(error)) {
+        throw error;
+      }
       const msg = error instanceof Error ? error.message : String(error);
       this.logger.warn(`Failed to list providers: ${msg}`);
       return [];
@@ -637,6 +650,9 @@ export class KeyringTokenStore implements TokenStore {
       }
       return buckets.sort();
     } catch (error) {
+      if (isRuntimeReplacedStoreError(error)) {
+        throw error;
+      }
       const msg = error instanceof Error ? error.message : String(error);
       this.logger.warn(
         `Failed to list buckets for [${this.hashIdentifier(provider + ':')}]: ${msg}`,

--- a/packages/cli/src/config/extensions/settingsStorage.ts
+++ b/packages/cli/src/config/extensions/settingsStorage.ts
@@ -19,7 +19,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'node:crypto';
 import type { ExtensionSetting } from './extensionSettings.js';
-import { SecureStore } from '@vybestack/llxprt-code-storage';
+import {
+  SecureStore,
+  isRuntimeReplacedError,
+} from '@vybestack/llxprt-code-storage';
 import { debugLogger } from '@vybestack/llxprt-code-telemetry';
 import { getWorkspaceIdentity } from '../../utils/gitUtils.js';
 
@@ -206,6 +209,9 @@ export class ExtensionSettingsStorage {
         await this.store.delete(envVar);
       }
     } catch (error) {
+      if (isRuntimeReplacedError(error)) {
+        throw error;
+      }
       debugLogger.error(
         `Failed to persist sensitive setting ${envVar} in keychain:`,
         error,
@@ -266,6 +272,9 @@ export class ExtensionSettingsStorage {
         const value = await this.store.get(setting.envVar);
         result[setting.envVar] = value ?? undefined;
       } catch (error) {
+        if (isRuntimeReplacedError(error)) {
+          throw error;
+        }
         debugLogger.error(
           `Failed to load sensitive setting ${setting.envVar} from keychain:`,
           error,
@@ -294,15 +303,29 @@ export class ExtensionSettingsStorage {
     // Delete all SecureStore entries for this service
     try {
       const keys = await this.store.list();
-      for (const key of keys) {
-        try {
-          await this.store.delete(key);
-        } catch (error) {
-          debugLogger.error(`Failed to delete keychain entry ${key}:`, error);
-        }
-      }
+      await this.deleteKeychainEntries(keys);
     } catch (error) {
+      if (isRuntimeReplacedError(error)) {
+        throw error;
+      }
       debugLogger.error('Failed to delete keychain entries:', error);
+    }
+  }
+
+  /**
+   * Deletes each keychain entry, rethrowing RUNTIME_REPLACED errors.
+   * Extracted to keep deleteSettings within the nesting limit.
+   */
+  private async deleteKeychainEntries(keys: readonly string[]): Promise<void> {
+    for (const key of keys) {
+      try {
+        await this.store.delete(key);
+      } catch (error) {
+        if (isRuntimeReplacedError(error)) {
+          throw error;
+        }
+        debugLogger.error(`Failed to delete keychain entry ${key}:`, error);
+      }
     }
   }
 
@@ -321,6 +344,9 @@ export class ExtensionSettingsStorage {
       const keys = await this.store.list();
       return keys.length > 0;
     } catch (error) {
+      if (isRuntimeReplacedError(error)) {
+        throw error;
+      }
       debugLogger.error('Failed to check keychain entries:', error);
     }
 

--- a/packages/core/src/storage/secure-store.ts
+++ b/packages/core/src/storage/secure-store.ts
@@ -8,3 +8,9 @@ export type {
   SecureStoreOptions,
   SecureStoreErrorCode,
 } from '@vybestack/llxprt-code-storage/storage/secure-store.js';
+export { isRuntimeReplacedError } from '@vybestack/llxprt-code-storage/storage/secure-store.js';
+export {
+  forceRuntimeReplacedForTesting,
+  resetRuntimeIdentityForTesting,
+  resetRuntimeReplacedWarningForTesting,
+} from '@vybestack/llxprt-code-storage/storage/secure-store.js';

--- a/packages/core/src/tools/tool-key-storage.test.ts
+++ b/packages/core/src/tools/tool-key-storage.test.ts
@@ -23,6 +23,33 @@ import {
   maskKeyForDisplay,
 } from '@vybestack/llxprt-code-tools';
 import { isValidEnvelope } from '@vybestack/llxprt-code-storage';
+import {
+  forceRuntimeReplacedForTesting,
+  isRuntimeReplacedError,
+  resetRuntimeIdentityForTesting,
+  resetRuntimeReplacedWarningForTesting,
+} from '../storage/secure-store.js';
+
+/**
+ * Runs `operation` expecting rejection and returns the rejection reason, so
+ * callers assert on the error CODE (via isRuntimeReplacedError) rather than
+ * matching human-readable message text.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3
+ */
+const NOT_REJECTED = Symbol('not-rejected');
+
+async function captureRejection(operation: Promise<unknown>): Promise<unknown> {
+  const outcome: unknown = await operation.then(
+    () => NOT_REJECTED,
+    (error: unknown) => error,
+  );
+  if (outcome === NOT_REJECTED) {
+    expect.fail('expected the operation to reject');
+  }
+  return outcome;
+}
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
 
@@ -448,6 +475,71 @@ describe('ToolKeyStorage', () => {
 
       // File should be gone
       await expect(fs.stat(filePath)).rejects.toThrow(/ENOENT/);
+    });
+  });
+
+  // ─── Replaced-runtime anti-divergence (issue #2926) ──────────────────────
+
+  describe('replaced-runtime anti-divergence (issue #2926)', () => {
+    beforeEach(() => {
+      resetRuntimeIdentityForTesting();
+      resetRuntimeReplacedWarningForTesting();
+    });
+    afterEach(() => {
+      resetRuntimeIdentityForTesting();
+      resetRuntimeReplacedWarningForTesting();
+    });
+
+    /**
+     * @plan PLAN-20260801-ISSUE2926
+     * @requirement R3
+     */
+    it('saveKey rethrows RUNTIME_REPLACED and does NOT create a fallback file', async () => {
+      forceRuntimeReplacedForTesting();
+      const storage = new ToolKeyStorage({
+        toolsDir: tempDir,
+        keyringLoader: async () => null,
+      });
+
+      const error = await captureRejection(storage.saveKey('exa', 'sk-leaked'));
+      expect(isRuntimeReplacedError(error)).toBe(true);
+
+      // The fallback .key file must NOT exist — this is the anti-divergence
+      // guarantee. Without it, the value would be silently written to the
+      // file while the keychain has a different (stale) value, causing
+      // silent data loss on the next healthy start.
+      const filePath = path.join(tempDir, 'exa.key');
+      await expect(fs.access(filePath)).rejects.toThrow(/ENOENT/);
+    });
+
+    /**
+     * @plan PLAN-20260801-ISSUE2926
+     * @requirement R3
+     */
+    it('getKey rethrows RUNTIME_REPLACED instead of falling through to file', async () => {
+      forceRuntimeReplacedForTesting();
+      const storage = new ToolKeyStorage({
+        toolsDir: tempDir,
+        keyringLoader: async () => null,
+      });
+
+      const error = await captureRejection(storage.getKey('exa'));
+      expect(isRuntimeReplacedError(error)).toBe(true);
+    });
+
+    /**
+     * @plan PLAN-20260801-ISSUE2926
+     * @requirement R3
+     */
+    it('deleteKey rethrows RUNTIME_REPLACED instead of silently continuing', async () => {
+      forceRuntimeReplacedForTesting();
+      const storage = new ToolKeyStorage({
+        toolsDir: tempDir,
+        keyringLoader: async () => null,
+      });
+
+      const error = await captureRejection(storage.deleteKey('exa'));
+      expect(isRuntimeReplacedError(error)).toBe(true);
     });
   });
 

--- a/packages/core/src/tools/tool-key-storage.ts
+++ b/packages/core/src/tools/tool-key-storage.ts
@@ -27,6 +27,7 @@ import {
 import {
   SecureStore,
   SecureStoreError,
+  isRuntimeReplacedError,
   type KeyringAdapter,
 } from '../storage/secure-store.js';
 import { Storage } from '@vybestack/llxprt-code-settings';
@@ -414,6 +415,9 @@ export class ToolKeyStorage {
       }
       return;
     } catch (error) {
+      if (isRuntimeReplacedError(error)) {
+        throw error;
+      }
       if (error instanceof SecureStoreError && error.code === 'UNAVAILABLE') {
         await this.saveToFile(toolName, key);
         return;
@@ -428,6 +432,9 @@ export class ToolKeyStorage {
       const key = await this.secureStore.get(toolName);
       if (key !== null) return key;
     } catch (error) {
+      if (isRuntimeReplacedError(error)) {
+        throw error;
+      }
       if (error instanceof SecureStoreError && error.code === 'UNAVAILABLE') {
         // Keyring unavailable — fall through to file
       } else {
@@ -442,6 +449,9 @@ export class ToolKeyStorage {
     try {
       await this.secureStore.delete(toolName);
     } catch (error) {
+      if (isRuntimeReplacedError(error)) {
+        throw error;
+      }
       if (error instanceof SecureStoreError && error.code === 'UNAVAILABLE') {
         // Keyring unavailable — continue to delete file
       } else {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -40,12 +40,11 @@ export type {
   SecureStoreErrorCode,
   SecureStoreOptions,
 } from './secure-store/secure-store.js';
-export { isSecureStoreError } from './secure-store/secure-store-errors.js';
-export { isRuntimeReplacedError } from './secure-store/secure-store-errors.js';
 export {
-  forceRuntimeReplacedForTesting,
-  resetRuntimeIdentityForTesting,
-} from './secure-store/runtime-identity.js';
+  isSecureStoreError,
+  isRuntimeReplacedError,
+} from './secure-store/secure-store-errors.js';
+export { resetRuntimeIdentityForTesting } from './secure-store/runtime-identity.js';
 export {
   ProviderKeyStorage,
   KEY_NAME_REGEX,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -44,7 +44,6 @@ export {
   isSecureStoreError,
   isRuntimeReplacedError,
 } from './secure-store/secure-store-errors.js';
-export { resetRuntimeIdentityForTesting } from './secure-store/runtime-identity.js';
 export {
   ProviderKeyStorage,
   KEY_NAME_REGEX,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -40,6 +40,12 @@ export type {
   SecureStoreErrorCode,
   SecureStoreOptions,
 } from './secure-store/secure-store.js';
+export { isSecureStoreError } from './secure-store/secure-store-errors.js';
+export { isRuntimeReplacedError } from './secure-store/secure-store-errors.js';
+export {
+  forceRuntimeReplacedForTesting,
+  resetRuntimeIdentityForTesting,
+} from './secure-store/runtime-identity.js';
 export {
   ProviderKeyStorage,
   KEY_NAME_REGEX,

--- a/packages/storage/src/secure-store/default-keyring-adapter.ts
+++ b/packages/storage/src/secure-store/default-keyring-adapter.ts
@@ -65,19 +65,6 @@ function isKeyringModuleMissingError(error: unknown): boolean {
   );
 }
 
-/**
- * Type predicate for the shape of the @napi-rs/keyring dynamic import.
- * Avoids `as` casts by narrowing with runtime checks.
- *
- * @plan PLAN-20260801-ISSUE2926
- */
-function isKeyringModuleShape(value: unknown): value is KeyringModuleShape {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-  return 'AsyncEntry' in value && typeof value.AsyncEntry === 'function';
-}
-
 interface KeyringEntry {
   getPassword(): Promise<string | null>;
   setPassword(password: string): Promise<void>;
@@ -88,6 +75,61 @@ interface KeyringModuleShape {
   AsyncEntry: new (service: string, account: string) => KeyringEntry;
   findCredentials?: FindCredentialsFunction;
   findCredentialsAsync?: FindCredentialsFunction;
+}
+
+/**
+ * Type predicate for the shape of the @napi-rs/keyring dynamic import.
+ * Avoids `as` casts by narrowing with runtime checks. Validates that every
+ * present callable member is actually a function, not just present.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+function isKeyringModuleShape(value: unknown): value is KeyringModuleShape {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  if (!('AsyncEntry' in value) || typeof value.AsyncEntry !== 'function') {
+    return false;
+  }
+  if (
+    'findCredentials' in value &&
+    typeof value.findCredentials !== 'function'
+  ) {
+    return false;
+  }
+  if (
+    'findCredentialsAsync' in value &&
+    typeof value.findCredentialsAsync !== 'function'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Selects the keyring module from a dynamic import, robust to CJS/ESM
+ * interop differences. Under some module systems the useful export is the
+ * namespace object; under others it is on `.default`. Preferring the
+ * namespace first and falling back to `.default` is strictly more robust
+ * than either version alone.
+ *
+ * Uses type-predicate narrowing — no type assertions.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+function resolveKeyringModule(namespace: unknown): KeyringModuleShape | null {
+  if (isKeyringModuleShape(namespace)) {
+    return namespace;
+  }
+  if (
+    typeof namespace === 'object' &&
+    namespace !== null &&
+    'default' in namespace &&
+    isKeyringModuleShape(namespace.default)
+  ) {
+    return namespace.default;
+  }
+  return null;
 }
 
 /**
@@ -179,8 +221,8 @@ export async function createDefaultKeyringAdapter(): Promise<KeyringAdapter | nu
   }
   try {
     const module = await import('@napi-rs/keyring');
-    const keyring: unknown = module;
-    if (!isKeyringModuleShape(keyring)) {
+    const keyring = resolveKeyringModule(module);
+    if (keyring === null) {
       return null;
     }
     const kr = keyring;

--- a/packages/storage/src/secure-store/default-keyring-adapter.ts
+++ b/packages/storage/src/secure-store/default-keyring-adapter.ts
@@ -1,0 +1,217 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Default keyring adapter factory — loads @napi-rs/keyring and wraps it in a
+ * KeyringAdapter. Extracted from secure-store.ts for clarity and to respect
+ * the max-lines lint threshold.
+ *
+ * The adapter returned by this factory is **guarded**: every method
+ * re-checks the terminal replaced-runtime state immediately before entering
+ * native code and throws RUNTIME_REPLACED if detected. This covers
+ * SecureStore (which caches its adapter), MCP KeychainTokenStorage (which
+ * caches the module and a positive availability flag), and machine-secret —
+ * all obtain their adapter from this factory.
+ *
+ * The factory also returns null before importing @napi-rs/keyring when the
+ * runtime is already replaced at creation time, so no dynamic import occurs.
+ *
+ * @plan PLAN-20260211-SECURESTORE.P08
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R2
+ */
+
+import type { StorageLogger } from '../types/logger.js';
+import { NullStorageLoggerImpl } from '../types/logger.js';
+import { isRuntimeReplaced } from './runtime-identity.js';
+import { assertRuntimeNotReplaced } from './runtime-replaced-errors.js';
+import type { KeyringAdapter } from './secure-store.js';
+
+export type FindCredentialsFunction = (
+  service: string,
+) => Promise<Array<{ account: string; password: string }>>;
+
+const KEYRING_MODULE_ERROR_CODES = new Set([
+  'ERR_MODULE_NOT_FOUND',
+  'MODULE_NOT_FOUND',
+  'ERR_DLOPEN_FAILED',
+]);
+
+function isErrorWithCode(value: unknown): value is { code: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'code' in value &&
+    typeof value.code === 'string'
+  );
+}
+
+function isErrorWithMessage(value: unknown): value is { message: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'message' in value &&
+    typeof value.message === 'string'
+  );
+}
+
+function isKeyringModuleMissingError(error: unknown): boolean {
+  return (
+    (isErrorWithCode(error) && KEYRING_MODULE_ERROR_CODES.has(error.code)) ||
+    (isErrorWithMessage(error) && error.message.includes('@napi-rs/keyring'))
+  );
+}
+
+/**
+ * Type predicate for the shape of the @napi-rs/keyring dynamic import.
+ * Avoids `as` casts by narrowing with runtime checks.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+function isKeyringModuleShape(value: unknown): value is KeyringModuleShape {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  return 'AsyncEntry' in value && typeof value.AsyncEntry === 'function';
+}
+
+interface KeyringEntry {
+  getPassword(): Promise<string | null>;
+  setPassword(password: string): Promise<void>;
+  deleteCredential(): Promise<boolean>;
+}
+
+interface KeyringModuleShape {
+  AsyncEntry: new (service: string, account: string) => KeyringEntry;
+  findCredentials?: FindCredentialsFunction;
+  findCredentialsAsync?: FindCredentialsFunction;
+}
+
+/**
+ * Wraps an adapter so that every method re-checks the replaced-runtime state
+ * immediately before entering native code. This guarantees R2 even for
+ * adapters cached before the transition — the guard fires on every call.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R2
+ */
+function createGuardedAdapter(inner: KeyringAdapter): KeyringAdapter {
+  const guardedGet = async (
+    service: string,
+    account: string,
+  ): Promise<string | null> => {
+    assertRuntimeNotReplaced();
+    return inner.getPassword(service, account);
+  };
+  const guardedSet = async (
+    service: string,
+    account: string,
+    password: string,
+  ): Promise<void> => {
+    assertRuntimeNotReplaced();
+    await inner.setPassword(service, account, password);
+  };
+  const guardedDelete = async (
+    service: string,
+    account: string,
+  ): Promise<boolean> => {
+    assertRuntimeNotReplaced();
+    return inner.deletePassword(service, account);
+  };
+  const adapter: KeyringAdapter = {
+    getPassword: guardedGet,
+    setPassword: guardedSet,
+    deletePassword: guardedDelete,
+  };
+  if (inner.findCredentials !== undefined) {
+    const innerFind = inner.findCredentials;
+    adapter.findCredentials = async (service: string) => {
+      assertRuntimeNotReplaced();
+      return innerFind(service);
+    };
+  }
+  return adapter;
+}
+
+function withFindCredentials(
+  adapter: KeyringAdapter,
+  findCredentialsFn: FindCredentialsFunction | undefined,
+): KeyringAdapter {
+  if (findCredentialsFn !== undefined) {
+    adapter.findCredentials = async (service: string) => {
+      try {
+        return await findCredentialsFn(service);
+      } catch {
+        return [];
+      }
+    };
+  }
+  return adapter;
+}
+
+let _keyringLogger: StorageLogger = new NullStorageLoggerImpl();
+
+/** Sets the logger used by createDefaultKeyringAdapter for diagnostic output. */
+export function setKeyringLogger(logger: StorageLogger): void {
+  _keyringLogger = logger;
+}
+
+/**
+ * Creates a default KeyringAdapter by loading @napi-rs/keyring.
+ *
+ * Returns null before importing @napi-rs/keyring when the runtime has been
+ * replaced on disk (issue #2926), so zero native keyring calls are issued.
+ *
+ * The returned adapter is guarded: every method re-checks the terminal state
+ * before entering native code. This covers SecureStore, MCP, and
+ * machine-secret, which all obtain their adapter from this factory.
+ *
+ * @plan PLAN-20260211-SECURESTORE.P08
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R2
+ */
+export async function createDefaultKeyringAdapter(): Promise<KeyringAdapter | null> {
+  if (isRuntimeReplaced()) {
+    return null;
+  }
+  try {
+    const module = await import('@napi-rs/keyring');
+    const keyring: unknown = module;
+    if (!isKeyringModuleShape(keyring)) {
+      return null;
+    }
+    const kr = keyring;
+    const findCredentialsFn = kr.findCredentials ?? kr.findCredentialsAsync;
+    const adapter: KeyringAdapter = {
+      getPassword: async (service: string, account: string) => {
+        const entry = new kr.AsyncEntry(service, account);
+        return entry.getPassword();
+      },
+      setPassword: async (
+        service: string,
+        account: string,
+        password: string,
+      ) => {
+        const entry = new kr.AsyncEntry(service, account);
+        await entry.setPassword(password);
+      },
+      deletePassword: async (service: string, account: string) => {
+        const entry = new kr.AsyncEntry(service, account);
+        return entry.deleteCredential();
+      },
+    };
+    const withFindCreds = withFindCredentials(adapter, findCredentialsFn);
+    return createGuardedAdapter(withFindCreds);
+  } catch (error) {
+    if (!isKeyringModuleMissingError(error) && process.env.DEBUG) {
+      const message = isErrorWithMessage(error) ? error.message : String(error);
+      _keyringLogger.warn(
+        `[SecureStore] Unexpected error loading @napi-rs/keyring: ${message}`,
+      );
+    }
+    return null;
+  }
+}

--- a/packages/storage/src/secure-store/runtime-identity.test.ts
+++ b/packages/storage/src/secure-store/runtime-identity.test.ts
@@ -35,6 +35,11 @@ import {
 } from './runtime-identity.js';
 
 // ─── Shared temp-dir helper (RULES.md: no copy-pasted setup) ────────────────
+//
+// The afterEach MUST reset global runtime-identity state in a `finally` so
+// that even if filesystem cleanup throws, the process-wide detector is always
+// reset. Without this, a cleanup failure leaks replaced/forced state into
+// later tests and obscures the real failure (issue #2926 review).
 
 function useTempDir(): {
   beforeEach: () => Promise<void>;
@@ -47,8 +52,12 @@ function useTempDir(): {
       dir = await fs.mkdtemp(path.join(os.tmpdir(), 'runtime-identity-test-'));
     },
     afterEach: async () => {
-      if (dir !== '') {
-        await fs.rm(dir, { recursive: true, force: true });
+      try {
+        if (dir !== '') {
+          await fs.rm(dir, { recursive: true, force: true });
+        }
+      } finally {
+        resetRuntimeIdentityForTesting();
       }
     },
     getDir: () => dir,
@@ -76,10 +85,7 @@ function installDetectorFor(filePath: string): void {
 describe('runtime-identity detector (pinned fd + nlink)', () => {
   const temp = useTempDir();
   beforeEach(temp.beforeEach);
-  afterEach(async () => {
-    await temp.afterEach();
-    resetRuntimeIdentityForTesting();
-  });
+  afterEach(temp.afterEach);
 
   it('is healthy at baseline', async () => {
     const filePath = path.join(temp.getDir(), 'binary');
@@ -191,10 +197,7 @@ describe('runtime-identity edge cases', () => {
 describe('runtime-identity terminal memoisation', () => {
   const temp = useTempDir();
   beforeEach(temp.beforeEach);
-  afterEach(async () => {
-    await temp.afterEach();
-    resetRuntimeIdentityForTesting();
-  });
+  afterEach(temp.afterEach);
 
   it('once replaced, always replaced even if the detector would report healthy again', async () => {
     const filePath = path.join(temp.getDir(), 'binary');
@@ -210,6 +213,89 @@ describe('runtime-identity terminal memoisation', () => {
     // follow the new inode. So nlink of the old fd stays 0.
     await fs.writeFile(filePath, Buffer.from('v2'));
     expect(isRuntimeReplaced()).toBe(true);
+  });
+});
+
+// ─── Detector disposal on swap (fd lifecycle) ────────────────────────────────
+
+/**
+ * @plan PLAN-20260801-ISSUE2926
+ *
+ * When a detector holding a pinned fd is swapped out (via reset / inject /
+ * force), the outgoing fd MUST be closed so per-test detector creation
+ * cannot accumulate descriptors and hit EMFILE. `close()` must be idempotent
+ * and must never throw.
+ *
+ * NOTE on portability: we cannot assert fd closure via platform-specific fd
+ * introspection portably across CI platforms. Instead we assert the observable
+ * behavioural contract: (1) `close()` is invoked on swap, (2) it is idempotent,
+ * (3) calling the disposed detector does not throw and does not report a stale
+ * result. The actual OS-level fd release is guaranteed by the closeSync call
+ * inside close(), which is exercised by these assertions.
+ */
+describe('runtime-identity detector disposal on swap', () => {
+  const temp = useTempDir();
+  beforeEach(temp.beforeEach);
+  afterEach(temp.afterEach);
+
+  it('closes the outgoing detector fd when setRuntimeReplacedDetectorForTesting swaps it out', async () => {
+    const filePath = path.join(temp.getDir(), 'binary');
+    await fs.writeFile(filePath, Buffer.from('v1'));
+
+    // Install a real pinned-fd detector — it opens an fd on the temp file.
+    const detector = createPinnedFdDetector(filePath);
+    setRuntimeReplacedDetectorForTesting(detector);
+
+    // Capture close() before swapping so we can assert it was invoked and is
+    // idempotent.
+    const closeFn = detector.close;
+    expect(typeof closeFn).toBe('function');
+
+    // Swap in a new detector — the outgoing fd must be closed.
+    setRuntimeReplacedDetectorForTesting(() => false);
+
+    // The outgoing close() was idempotent (safe to call again) and did not throw.
+    expect(() => closeFn?.()).not.toThrow();
+  });
+
+  it('closes the outgoing detector fd when resetRuntimeIdentityForTesting swaps it out', async () => {
+    const filePath = path.join(temp.getDir(), 'binary');
+    await fs.writeFile(filePath, Buffer.from('v1'));
+
+    const detector = createPinnedFdDetector(filePath);
+    setRuntimeReplacedDetectorForTesting(detector);
+
+    // Reset swaps in the default detector — the outgoing fd must be closed.
+    // Assert the disposed detector does not throw and does not report stale.
+    resetRuntimeIdentityForTesting();
+
+    expect(() => detector()).not.toThrow();
+    // A disposed pinned-fd detector: fd is closed/invalid, so fstat fails and
+    // the detector reports healthy (false) — it must NOT report a stale true.
+    expect(detector()).toBe(false);
+  });
+
+  it('close() is idempotent: calling it multiple times never throws', async () => {
+    const filePath = path.join(temp.getDir(), 'binary');
+    await fs.writeFile(filePath, Buffer.from('v1'));
+
+    const detector = createPinnedFdDetector(filePath);
+    expect(typeof detector.close).toBe('function');
+
+    // Multiple close() calls must all succeed (idempotent, never throws).
+    expect(() => {
+      detector.close?.();
+      detector.close?.();
+      detector.close?.();
+    }).not.toThrow();
+  });
+
+  it('close() on a plain function detector (no close) is a noop during swap', () => {
+    // A stub without close() — swap must not throw.
+    expect(() => {
+      setRuntimeReplacedDetectorForTesting(() => false);
+      resetRuntimeIdentityForTesting();
+    }).not.toThrow();
   });
 });
 

--- a/packages/storage/src/secure-store/runtime-identity.test.ts
+++ b/packages/storage/src/secure-store/runtime-identity.test.ts
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for runtime-identity detection (Revision 2 — pinned fd,
+ * watch nlink).
+ *
+ * Operates on real temp files, real fds, and real unlinks. No fs mocking.
+ * The detection primitive is: pin an fd on the executable at startup, then
+ * watch fstat(fd).nlink. nlink===0 means the vnode has been unlinked.
+ *
+ * The single most important test here is "still healthy after rename-only"
+ * — that is the regression test for the entire redesign. Revision 1 wrongly
+ * flagged rename-only; Revision 2 must not.
+ *
+ * The detector is injectable so these tests run on ALL platforms (not just
+ * darwin).
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  createPinnedFdDetector,
+  isRuntimeReplaced,
+  setRuntimeReplacedDetectorForTesting,
+  resetRuntimeIdentityForTesting,
+  forceRuntimeReplacedForTesting,
+} from './runtime-identity.js';
+
+// ─── Shared temp-dir helper (RULES.md: no copy-pasted setup) ────────────────
+
+function useTempDir(): {
+  beforeEach: () => Promise<void>;
+  afterEach: () => Promise<void>;
+  getDir: () => string;
+} {
+  let dir = '';
+  return {
+    beforeEach: async () => {
+      dir = await fs.mkdtemp(path.join(os.tmpdir(), 'runtime-identity-test-'));
+    },
+    afterEach: async () => {
+      if (dir !== '') {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    },
+    getDir: () => dir,
+  };
+}
+
+/**
+ * Pins the PRODUCTION detector to a test-controlled file and installs it.
+ *
+ * These tests deliberately exercise `createPinnedFdDetector` — the exact
+ * implementation used on darwin for `process.execPath` — rather than a
+ * reimplementation, so the behaviour under test is the shipped behaviour.
+ * Driving it with a temp file also makes the suite run on every platform.
+ */
+function installDetectorFor(filePath: string): void {
+  setRuntimeReplacedDetectorForTesting(createPinnedFdDetector(filePath));
+}
+
+// ─── Detector tests (real files, real fd, real unlink) ──────────────────────
+
+/**
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R1
+ */
+describe('runtime-identity detector (pinned fd + nlink)', () => {
+  const temp = useTempDir();
+  beforeEach(temp.beforeEach);
+  afterEach(temp.afterEach);
+
+  it('is healthy at baseline', async () => {
+    const filePath = path.join(temp.getDir(), 'binary');
+    await fs.writeFile(filePath, Buffer.from('hello world'));
+    installDetectorFor(filePath);
+    expect(isRuntimeReplaced()).toBe(false);
+  });
+
+  /**
+   * THE regression test for the entire redesign. Revision 1 flagged
+   * rename-only because it compared (dev, ino) at the pathname. But the
+   * pinned fd follows the inode, not the name, so nlink stays 1 after a
+   * rename. This MUST be false.
+   *
+   * @plan PLAN-20260801-ISSUE2926
+   * @requirement R1, R5
+   */
+  it('is still healthy after rename-only (the case Revision 1 got wrong)', async () => {
+    const filePath = path.join(temp.getDir(), 'binary');
+    await fs.writeFile(filePath, Buffer.from('original bytes'));
+    installDetectorFor(filePath);
+
+    // Rename the file aside — the fd still follows the inode, nlink stays 1.
+    const retiredPath = filePath + '.retired';
+    await fs.rename(filePath, retiredPath);
+
+    expect(isRuntimeReplaced()).toBe(false);
+  });
+
+  it('is orphaned after the retired copy is deleted', async () => {
+    const filePath = path.join(temp.getDir(), 'binary');
+    await fs.writeFile(filePath, Buffer.from('original bytes'));
+    installDetectorFor(filePath);
+
+    // npm's exact sequence: rename aside, then delete.
+    const retiredPath = filePath + '.retired';
+    await fs.rename(filePath, retiredPath);
+    expect(isRuntimeReplaced()).toBe(false);
+
+    await fs.unlink(retiredPath);
+    expect(isRuntimeReplaced()).toBe(true);
+  });
+
+  it('is orphaned when the file is deleted outright with no replacement', async () => {
+    const filePath = path.join(temp.getDir(), 'binary');
+    await fs.writeFile(filePath, Buffer.from('temp'));
+    installDetectorFor(filePath);
+
+    await fs.unlink(filePath);
+    expect(isRuntimeReplaced()).toBe(true);
+  });
+
+  /**
+   * @requirement R5 — terminal: stays orphaned after a fresh file appears
+   * at the original path. Once unlinked, the process's code identity is
+   * permanently lost; only a restart recovers it.
+   */
+  it('is terminal: stays orphaned after a fresh file appears at the original path', async () => {
+    const filePath = path.join(temp.getDir(), 'binary');
+    await fs.writeFile(filePath, Buffer.from('v1'));
+    installDetectorFor(filePath);
+
+    await fs.unlink(filePath);
+    expect(isRuntimeReplaced()).toBe(true);
+
+    // Recreate at the original path — the pinned fd's inode is still unlinked.
+    await fs.writeFile(filePath, Buffer.from('v2'));
+    expect(isRuntimeReplaced()).toBe(true);
+  });
+});
+
+// ─── No-baseline and platform tests ──────────────────────────────────────────
+
+/**
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R5
+ */
+describe('runtime-identity edge cases', () => {
+  beforeEach(() => {
+    resetRuntimeIdentityForTesting();
+  });
+  afterEach(() => {
+    resetRuntimeIdentityForTesting();
+  });
+
+  it('reports healthy when there is no baseline (fd could not be opened)', () => {
+    // A detector that simulates "fd could not be opened at startup".
+    // The production detector returns false when pinnedExecutableFd === -1.
+    setRuntimeReplacedDetectorForTesting(() => false);
+    expect(isRuntimeReplaced()).toBe(false);
+  });
+
+  it('non-darwin reports healthy (default detector always returns false)', () => {
+    // On non-darwin, the default detector is () => false.
+    // We simulate this by resetting to default and checking.
+    setRuntimeReplacedDetectorForTesting(null);
+    // The default detector respects platform; on darwin it would check the fd.
+    // On non-darwin it always returns false.
+    // We can't assert platform-specific behaviour here, but we can assert
+    // that calling it does not throw.
+    expect(typeof isRuntimeReplaced()).toBe('boolean');
+  });
+});
+
+// ─── Terminal memoisation is genuinely exercised ─────────────────────────────
+
+/**
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R5
+ */
+describe('runtime-identity terminal memoisation', () => {
+  const temp = useTempDir();
+  beforeEach(temp.beforeEach);
+  afterEach(temp.afterEach);
+
+  it('once replaced, always replaced even if the detector would report healthy again', async () => {
+    const filePath = path.join(temp.getDir(), 'binary');
+    await fs.writeFile(filePath, Buffer.from('v1'));
+    installDetectorFor(filePath);
+
+    await fs.unlink(filePath);
+    expect(isRuntimeReplaced()).toBe(true);
+
+    // Recreate — the detector's memoised state must still be true.
+    // The pinned fd follows the OLD inode which is unlinked.
+    // A NEW file at the same path has a different inode; the fd does NOT
+    // follow the new inode. So nlink of the old fd stays 0.
+    await fs.writeFile(filePath, Buffer.from('v2'));
+    expect(isRuntimeReplaced()).toBe(true);
+  });
+});
+
+// ─── Process-wide forced state (for integration tests) ───────────────────────
+
+describe('forceRuntimeReplacedForTesting', () => {
+  afterEach(() => {
+    resetRuntimeIdentityForTesting();
+  });
+
+  it('forces the replaced condition', () => {
+    forceRuntimeReplacedForTesting();
+    expect(isRuntimeReplaced()).toBe(true);
+  });
+
+  it('reset clears the forced condition', () => {
+    forceRuntimeReplacedForTesting();
+    expect(isRuntimeReplaced()).toBe(true);
+    resetRuntimeIdentityForTesting();
+    setRuntimeReplacedDetectorForTesting(() => false);
+    expect(isRuntimeReplaced()).toBe(false);
+  });
+});

--- a/packages/storage/src/secure-store/runtime-identity.test.ts
+++ b/packages/storage/src/secure-store/runtime-identity.test.ts
@@ -76,7 +76,10 @@ function installDetectorFor(filePath: string): void {
 describe('runtime-identity detector (pinned fd + nlink)', () => {
   const temp = useTempDir();
   beforeEach(temp.beforeEach);
-  afterEach(temp.afterEach);
+  afterEach(async () => {
+    await temp.afterEach();
+    resetRuntimeIdentityForTesting();
+  });
 
   it('is healthy at baseline', async () => {
     const filePath = path.join(temp.getDir(), 'binary');
@@ -169,16 +172,14 @@ describe('runtime-identity edge cases', () => {
     expect(isRuntimeReplaced()).toBe(false);
   });
 
-  it('non-darwin reports healthy (default detector always returns false)', () => {
-    // On non-darwin, the default detector is () => false.
-    // We simulate this by resetting to default and checking.
-    setRuntimeReplacedDetectorForTesting(null);
-    // The default detector respects platform; on darwin it would check the fd.
-    // On non-darwin it always returns false.
-    // We can't assert platform-specific behaviour here, but we can assert
-    // that calling it does not throw.
-    expect(typeof isRuntimeReplaced()).toBe('boolean');
-  });
+  it.skipIf(process.platform === 'darwin')(
+    'non-darwin reports healthy (default detector always returns false)',
+    () => {
+      setRuntimeReplacedDetectorForTesting(null);
+      // On non-darwin the default detector is `() => false`.
+      expect(isRuntimeReplaced()).toBe(false);
+    },
+  );
 });
 
 // ─── Terminal memoisation is genuinely exercised ─────────────────────────────
@@ -190,7 +191,10 @@ describe('runtime-identity edge cases', () => {
 describe('runtime-identity terminal memoisation', () => {
   const temp = useTempDir();
   beforeEach(temp.beforeEach);
-  afterEach(temp.afterEach);
+  afterEach(async () => {
+    await temp.afterEach();
+    resetRuntimeIdentityForTesting();
+  });
 
   it('once replaced, always replaced even if the detector would report healthy again', async () => {
     const filePath = path.join(temp.getDir(), 'binary');

--- a/packages/storage/src/secure-store/runtime-identity.ts
+++ b/packages/storage/src/secure-store/runtime-identity.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Runtime identity detection for the macOS orphaned-executable condition
+ * (issue #2926).
+ *
+ * On macOS, LLxprt execs the Bun binary bundled inside its own npm package
+ * tree. When an in-place reinstall renames that tree aside and deletes it,
+ * the running process survives but its executable vnode becomes nameless.
+ * macOS securityd can then no longer reconstruct the process's code identity
+ * (proc_pidpath() returns ENOENT), so it cannot evaluate any Keychain item's
+ * requirement and falls back to a login-password prompt on every protected
+ * operation — an unbounded storm.
+ *
+ * ## Correct signal: pinned fd, watch nlink
+ *
+ * Revision 1 used a (dev, ino) pathname comparator. That was wrong: renaming
+ * the tree aside changes the inode at the path but is harmless (the C harness
+ * showed SecCode create=0 valid=0 while renamed aside). The correct signal
+ * is whether the **live executable vnode has been unlinked** — not whether a
+ * file at the same path has a different inode.
+ *
+ * We open a file descriptor on `process.execPath` at startup and pin it. The
+ * fd follows the inode, not the name. `fstat(fd).nlink` is then exact:
+ *
+ *   nlink >= 1  → inode still has ≥1 directory entry. Healthy.
+ *   nlink === 0 → every link gone; file unlinked. Orphaned, terminal.
+ *
+ * Validated empirically against the real npm sequence:
+ *
+ *   baseline               nlink=1  → orphaned: false
+ *   after rename-only      nlink=1  → orphaned: false   (healthy)
+ *   after retired deleted  nlink=0  → orphaned: true    (orphaned)
+ *
+ * Pure Node — no native module, no proc_pidpath binding.
+ *
+ * ## Injectability
+ *
+ * The detector is injectable: `isRuntimeReplaced` delegates to a swappable
+ * predicate so SecureStore behaviour is testable on all CI platforms, not
+ * just macOS. The darwin implementation opens a real fd; tests can inject a
+ * controllable stub via `setRuntimeReplacedDetectorForTesting`.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R1, R2, R5
+ */
+
+import { openSync, fstatSync } from 'node:fs';
+
+/**
+ * Function type for the injectable "is the runtime replaced?" predicate.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R1
+ */
+export type RuntimeReplacedDetector = () => boolean;
+
+// ─── Process-wide state ──────────────────────────────────────────────────────
+
+const NO_PINNED_FD = -1;
+
+/**
+ * Opens a pinned fd on `execPath`, or NO_PINNED_FD if it cannot be opened.
+ * No baseline means we never had a reference point, so the detector reports
+ * healthy (never flags) — tested explicitly.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R5
+ */
+function openPinnedFd(execPath: string): number {
+  try {
+    return openSync(execPath, 'r');
+  } catch {
+    return NO_PINNED_FD;
+  }
+}
+
+/**
+ * Checks whether the pinned executable fd has been unlinked (nlink === 0).
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R1
+ */
+function isPinnedFdUnlinked(fd: number): boolean {
+  try {
+    return fstatSync(fd).nlink === 0;
+  } catch {
+    // fstat failed — state is indeterminate. Report healthy rather than
+    // disabling credentials on a transient I/O error.
+    return false;
+  }
+}
+
+/**
+ * Builds a detector that pins an fd on `execPath` and reports replaced once
+ * that inode has been unlinked. The fd follows the inode, not the name, so a
+ * rename leaves nlink at 1 and is correctly reported healthy.
+ *
+ * Terminal: once replaced, always replaced.
+ *
+ * Exported so tests exercise this exact production implementation against a
+ * temp file, rather than reimplementing it.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R1, R5
+ */
+export function createPinnedFdDetector(
+  execPath: string,
+): RuntimeReplacedDetector {
+  const fd = openPinnedFd(execPath);
+  let memoised = false;
+  return () => {
+    if (memoised) {
+      return true;
+    }
+    if (fd === NO_PINNED_FD) {
+      return false;
+    }
+    memoised = isPinnedFdUnlinked(fd);
+    return memoised;
+  };
+}
+
+/**
+ * Creates the default detector. On darwin it pins an fd on the running
+ * executable; elsewhere it always reports healthy (the bug is macOS-specific).
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R1, R5
+ */
+function createDefaultDetector(): RuntimeReplacedDetector {
+  if (process.platform !== 'darwin') {
+    return () => false;
+  }
+  return createPinnedFdDetector(process.execPath);
+}
+
+/**
+ * The current detector. Created eagerly at module initialisation so the fd is
+ * pinned before any await can interleave a mid-session reinstall. Injectable
+ * for testing (R5: testable on all CI platforms).
+ */
+let currentDetector: RuntimeReplacedDetector = createDefaultDetector();
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Reports whether the running runtime has been replaced on disk since process
+ * start. Process-wide and memoised: once true, always true for the lifetime
+ * of this process.
+ *
+ * Non-darwin platforms always return false (the bug is macOS-specific; R5).
+ * A null baseline (fd could not be opened) always returns false.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R1, R2, R5
+ */
+export function isRuntimeReplaced(): boolean {
+  return currentDetector();
+}
+
+/**
+ * Sets the detector function for testing. This makes the replaced-runtime
+ * behaviour testable on all CI platforms — tests inject a stub that returns
+ * true/false without needing a real darwin fd.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R5
+ */
+export function setRuntimeReplacedDetectorForTesting(
+  detector: RuntimeReplacedDetector | null,
+): void {
+  currentDetector = detector ?? createDefaultDetector();
+}
+
+/**
+ * Resets the process-wide state for testing: clears memoisation and
+ * re-creates the default detector (which re-opens the fd on darwin).
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+export function resetRuntimeIdentityForTesting(): void {
+  currentDetector = createDefaultDetector();
+}
+
+/**
+ * Test-only: forces the replaced condition so SecureStore gating can be
+ * exercised without actually unlinking the real process executable.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+export function forceRuntimeReplacedForTesting(): void {
+  currentDetector = () => true;
+}

--- a/packages/storage/src/secure-store/runtime-identity.ts
+++ b/packages/storage/src/secure-store/runtime-identity.ts
@@ -52,12 +52,23 @@
 import { openSync, fstatSync, closeSync } from 'node:fs';
 
 /**
- * Function type for the injectable "is the runtime replaced?" predicate.
+ * Injectable "is the runtime replaced?" predicate.
+ *
+ * Carries an optional `close()` so a detector that holds resources (the pinned
+ * fd opened by {@link createPinnedFdDetector}) can release them deterministically
+ * when the detector is swapped out of {@link currentDetector}. `close()` must be
+ * idempotent and must never throw.
+ *
+ * Plain function detectors (e.g. the non-darwin `() => false` default and the
+ * test stubs) omit `close()` — they hold no resources.
  *
  * @plan PLAN-20260801-ISSUE2926
  * @requirement R1
  */
-export type RuntimeReplacedDetector = () => boolean;
+export interface RuntimeReplacedDetector {
+  (): boolean;
+  close?(): void;
+}
 
 // ─── Process-wide state ──────────────────────────────────────────────────────
 
@@ -113,7 +124,7 @@ export function createPinnedFdDetector(
 ): RuntimeReplacedDetector {
   let fd = openPinnedFd(execPath);
   let memoised = false;
-  return () => {
+  const detect = (): boolean => {
     if (memoised) {
       return true;
     }
@@ -130,6 +141,25 @@ export function createPinnedFdDetector(
     }
     return memoised;
   };
+  // Deterministic resource release for the swap path (issue #2926 review):
+  // when this detector is replaced via resetRuntimeIdentityForTesting() or
+  // setRuntimeReplacedDetectorForTesting(), the pinned fd must be closed so
+  // per-test detector creation cannot accumulate descriptors and hit EMFILE.
+  // Idempotent: once closed, fd is NO_PINNED_FD so subsequent calls are noops.
+  // Never throws: closeSync failures are swallowed because detection has
+  // already completed its contract by the time close() is invoked.
+  detect.close = (): void => {
+    if (fd !== NO_PINNED_FD) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Swallow: close() must never throw. The fd will be reclaimed by the
+        // OS on process exit regardless.
+      }
+      fd = NO_PINNED_FD;
+    }
+  };
+  return detect;
 }
 
 /**
@@ -153,6 +183,27 @@ function createDefaultDetector(): RuntimeReplacedDetector {
  */
 let currentDetector: RuntimeReplacedDetector = createDefaultDetector();
 
+/**
+ * Disposes a detector's resources (its pinned fd, if any) and then installs
+ * the replacement as the current detector. Centralised so every swap path —
+ * {@link resetRuntimeIdentityForTesting}, {@link setRuntimeReplacedDetectorForTesting},
+ * and {@link forceRuntimeReplacedForTesting} — closes the outgoing detector's
+ * fd before discarding it, preventing per-test fd accumulation that can hit
+ * EMFILE in a long suite.
+ *
+ * `close()` is optional and idempotent; calling it on a detector without one
+ * (e.g. the non-darwin `() => false` default) is a noop.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+function replaceDetector(next: RuntimeReplacedDetector): void {
+  const outgoing = currentDetector;
+  if (typeof outgoing.close === 'function') {
+    outgoing.close();
+  }
+  currentDetector = next;
+}
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 /**
@@ -173,7 +224,8 @@ export function isRuntimeReplaced(): boolean {
 /**
  * Sets the detector function for testing. This makes the replaced-runtime
  * behaviour testable on all CI platforms — tests inject a stub that returns
- * true/false without needing a real darwin fd.
+ * true/false without needing a real darwin fd. Disposes the outgoing
+ * detector's fd (if any) so per-test swaps cannot accumulate descriptors.
  *
  * @plan PLAN-20260801-ISSUE2926
  * @requirement R5
@@ -181,25 +233,27 @@ export function isRuntimeReplaced(): boolean {
 export function setRuntimeReplacedDetectorForTesting(
   detector: RuntimeReplacedDetector | null,
 ): void {
-  currentDetector = detector ?? createDefaultDetector();
+  replaceDetector(detector ?? createDefaultDetector());
 }
 
 /**
  * Resets the process-wide state for testing: clears memoisation and
- * re-creates the default detector (which re-opens the fd on darwin).
+ * re-creates the default detector (which re-opens the fd on darwin). Disposes
+ * the outgoing detector's fd (if any) before swapping.
  *
  * @plan PLAN-20260801-ISSUE2926
  */
 export function resetRuntimeIdentityForTesting(): void {
-  currentDetector = createDefaultDetector();
+  replaceDetector(createDefaultDetector());
 }
 
 /**
  * Test-only: forces the replaced condition so SecureStore gating can be
- * exercised without actually unlinking the real process executable.
+ * exercised without actually unlinking the real process executable. Disposes
+ * the outgoing detector's fd (if any) before swapping.
  *
  * @plan PLAN-20260801-ISSUE2926
  */
 export function forceRuntimeReplacedForTesting(): void {
-  currentDetector = () => true;
+  replaceDetector(() => true);
 }

--- a/packages/storage/src/secure-store/runtime-identity.ts
+++ b/packages/storage/src/secure-store/runtime-identity.ts
@@ -49,7 +49,7 @@
  * @requirement R1, R2, R5
  */
 
-import { openSync, fstatSync } from 'node:fs';
+import { openSync, fstatSync, closeSync } from 'node:fs';
 
 /**
  * Function type for the injectable "is the runtime replaced?" predicate.
@@ -111,7 +111,7 @@ function isPinnedFdUnlinked(fd: number): boolean {
 export function createPinnedFdDetector(
   execPath: string,
 ): RuntimeReplacedDetector {
-  const fd = openPinnedFd(execPath);
+  let fd = openPinnedFd(execPath);
   let memoised = false;
   return () => {
     if (memoised) {
@@ -121,6 +121,13 @@ export function createPinnedFdDetector(
       return false;
     }
     memoised = isPinnedFdUnlinked(fd);
+    if (memoised) {
+      // The inode is orphaned (terminal). The fd is no longer needed and
+      // must be released so repeated detector creation (tests, multiple
+      // SecureStore instances) cannot accumulate descriptors and hit EMFILE.
+      closeSync(fd);
+      fd = NO_PINNED_FD;
+    }
     return memoised;
   };
 }

--- a/packages/storage/src/secure-store/runtime-replaced-errors.ts
+++ b/packages/storage/src/secure-store/runtime-replaced-errors.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Replaced-runtime error constants and warning helper for issue #2926.
+ *
+ * Extracted from secure-store.ts to keep that file under the max-lines lint
+ * threshold. These are the single source of truth for the fail-fast message,
+ * remediation, and once-per-process warning.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3, R4
+ */
+
+import { SecureStoreError } from './secure-store-errors.js';
+import { isRuntimeReplaced } from './runtime-identity.js';
+
+/**
+ * The cause message explaining why credential access is disabled.
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3
+ */
+export const RUNTIME_REPLACED_MESSAGE =
+  "LLxprt's runtime was replaced on disk while this session was running (usually an npm upgrade). macOS can no longer verify this process's identity, so credential access is disabled to avoid a password-prompt storm.";
+
+/**
+ * The remediation: restart to recover, and do not click "Always Allow"
+ * because it cannot take effect for this process.
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3
+ */
+export const RUNTIME_REPLACED_REMEDIATION =
+  'Restart LLxprt to recover. Do not click "Always Allow" — it cannot take effect for this process.';
+
+/**
+ * Tracks whether the replaced-runtime warning has been emitted this process.
+ * Ensures the warning fires at most once (R4).
+ */
+let runtimeReplacedWarned = false;
+
+/**
+ * Resets the process-wide replaced-runtime warning flag for testing.
+ * @plan PLAN-20260801-ISSUE2926
+ */
+export function resetRuntimeReplacedWarningForTesting(): void {
+  runtimeReplacedWarned = false;
+}
+
+/**
+ * Returns whether the one-time warning has been emitted this process.
+ * Used by tests to verify the once-per-process guarantee (R4).
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R4
+ */
+export function hasRuntimeReplacedWarningBeenEmitted(): boolean {
+  return runtimeReplacedWarned;
+}
+
+/**
+ * Creates a SecureStoreError with the RUNTIME_REPLACED code — the distinct
+ * terminal error identity that downstream fallback/swallow layers must
+ * rethrow rather than absorb.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3
+ */
+export function runtimeReplacedError(): SecureStoreError {
+  return new SecureStoreError(
+    RUNTIME_REPLACED_MESSAGE,
+    'RUNTIME_REPLACED',
+    RUNTIME_REPLACED_REMEDIATION,
+  );
+}
+
+/**
+ * Throws a SecureStoreError (RUNTIME_REPLACED) when the running runtime has
+ * been replaced on disk. Called at the keyring-loading boundary of each
+ * credential operation so that zero OS keyring operations are attempted and
+ * no encrypted fallback file diverges from the Keychain.
+ *
+ * The warning is routed through stderr (process.stderr.write) so it is
+ * guaranteed to reach the user regardless of whether an injected logger
+ * was provided — most production SecureStore instances use
+ * NullStorageLoggerImpl which discards messages (R4).
+ *
+ * Overrides fallbackPolicy: 'allow' deliberately — silently writing the
+ * fallback would diverge from the Keychain, and on the next healthy start
+ * get() reads the keyring first and would return the stale pre-divergence
+ * value (silent data loss).
+ *
+ * The warning is emitted at most once per process (R4).
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3, R4
+ */
+export function assertRuntimeNotReplaced(): void {
+  if (!isRuntimeReplaced()) {
+    return;
+  }
+  if (!runtimeReplacedWarned) {
+    runtimeReplacedWarned = true;
+    emitRuntimeReplacedWarning();
+  }
+  throw runtimeReplacedError();
+}
+
+/**
+ * Emits the one-time replaced-runtime warning to stderr, guaranteeing it
+ * reaches the user independent of any injected logger.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R4
+ */
+function emitRuntimeReplacedWarning(): void {
+  process.stderr.write(
+    `\n${RUNTIME_REPLACED_MESSAGE} ${RUNTIME_REPLACED_REMEDIATION}\n\n`,
+  );
+}

--- a/packages/storage/src/secure-store/runtime-replaced-errors.ts
+++ b/packages/storage/src/secure-store/runtime-replaced-errors.ts
@@ -115,7 +115,14 @@ export function assertRuntimeNotReplaced(): void {
  * @requirement R4
  */
 function emitRuntimeReplacedWarning(): void {
-  process.stderr.write(
-    `\n${RUNTIME_REPLACED_MESSAGE} ${RUNTIME_REPLACED_REMEDIATION}\n\n`,
-  );
+  try {
+    process.stderr.write(
+      `\n${RUNTIME_REPLACED_MESSAGE} ${RUNTIME_REPLACED_REMEDIATION}\n\n`,
+    );
+  } catch {
+    // stderr can be closed or broken (EPIPE when piped into a command that
+    // exits early). Losing the notice is acceptable; losing the terminal
+    // RUNTIME_REPLACED error is not, because callers key their rethrow
+    // decision on it. Swallow here so the caller always sees the real error.
+  }
 }

--- a/packages/storage/src/secure-store/secure-store-errors.test.ts
+++ b/packages/storage/src/secure-store/secure-store-errors.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the SecureStore error type guards (issue #2926).
+ *
+ * The central concern: `isRuntimeReplacedError` must identify the terminal
+ * condition **structurally** (duck-typed on the `code` value), not via
+ * `instanceof SecureStoreError`. Downstream consumers in other packages rely
+ * on it to decide whether to rethrow instead of degrading to a fallback file.
+ * If two copies of the class ever exist (bundling, duplicated dependency
+ * resolution), `instanceof` silently returns false and the layer degrades —
+ * the silent divergence / data-loss path this PR exists to prevent.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SecureStoreError,
+  isSecureStoreError,
+  isRuntimeReplacedError,
+  type SecureStoreErrorCode,
+} from './secure-store-errors.js';
+
+describe('isSecureStoreError', () => {
+  it('returns true for a SecureStoreError instance', () => {
+    const error = new SecureStoreError('msg', 'UNAVAILABLE', 'retry');
+    expect(isSecureStoreError(error)).toBe(true);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(isSecureStoreError(new Error('boom'))).toBe(false);
+  });
+
+  it('returns false for a non-error value', () => {
+    expect(isSecureStoreError(null)).toBe(false);
+    expect(isSecureStoreError('string')).toBe(false);
+    expect(isSecureStoreError(undefined)).toBe(false);
+  });
+});
+
+describe('isRuntimeReplacedError', () => {
+  it('returns true for a SecureStoreError with code RUNTIME_REPLACED', () => {
+    const error = new SecureStoreError(
+      'runtime replaced',
+      'RUNTIME_REPLACED',
+      'restart',
+    );
+    expect(isRuntimeReplacedError(error)).toBe(true);
+  });
+
+  it('returns false for a SecureStoreError with a different code', () => {
+    const error = new SecureStoreError('unavailable', 'UNAVAILABLE', 'retry');
+    expect(isRuntimeReplacedError(error)).toBe(false);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(isRuntimeReplacedError(new Error('boom'))).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(isRuntimeReplacedError(null)).toBe(false);
+    expect(isRuntimeReplacedError('RUNTIME_REPLACED')).toBe(false);
+    expect(isRuntimeReplacedError(undefined)).toBe(false);
+    expect(isRuntimeReplacedError(42)).toBe(false);
+  });
+
+  it('returns false for an object without a code property', () => {
+    expect(isRuntimeReplacedError({ message: 'no code' })).toBe(false);
+  });
+
+  /**
+   * THE critical cross-package test. Simulates the duplicate-class-identity
+   * case: a different class (as would arise from bundling or duplicated
+   * dependency resolution) that is structurally identical to SecureStoreError.
+   * `instanceof SecureStoreError` would return false for this object, causing
+   * the downstream fallback layer to degrade — the silent data-loss path.
+   * The structural guard must still return true so the terminal error is
+   * rethrown, not absorbed.
+   *
+   * @plan PLAN-20260801-ISSUE2926
+   * @requirement R3
+   */
+  it('returns true for a structurally-equivalent error from a DIFFERENT class identity (duplicate-class simulation)', () => {
+    // A completely independent class that mimics SecureStoreError's shape.
+    // This is NOT a subclass of SecureStoreError, so instanceof fails.
+    class AlienSecureStoreError extends Error {
+      readonly code: SecureStoreErrorCode;
+      readonly remediation: string;
+      constructor(
+        message: string,
+        code: SecureStoreErrorCode,
+        remediation: string,
+      ) {
+        super(message);
+        this.name = 'SecureStoreError';
+        this.code = code;
+        this.remediation = remediation;
+      }
+    }
+
+    const alien = new AlienSecureStoreError(
+      'runtime replaced',
+      'RUNTIME_REPLACED',
+      'restart',
+    );
+
+    // Proof that instanceof fails across the class-identity boundary —
+    // this is exactly the failure mode the structural guard protects against.
+    expect(alien instanceof SecureStoreError).toBe(false);
+
+    // The structural guard MUST still identify it as terminal, so downstream
+    // fallback layers rethrow rather than degrade to a stale fallback file.
+    expect(isRuntimeReplacedError(alien)).toBe(true);
+  });
+});

--- a/packages/storage/src/secure-store/secure-store-errors.ts
+++ b/packages/storage/src/secure-store/secure-store-errors.ts
@@ -51,11 +51,28 @@ export function isSecureStoreError(error: unknown): error is SecureStoreError {
  * Used by fallback/swallow layers that must rethrow terminal replaced-runtime
  * errors while still degrading on ordinary UNAVAILABLE.
  *
+ * Identification is **structural** (duck-typed on the `code` value), NOT based
+ * on `instanceof SecureStoreError`. Downstream consumers in other packages
+ * (core, cli, auth) rely on this guard to decide whether to rethrow instead of
+ * degrading to a fallback file. If two copies of `SecureStoreError` ever exist
+ * (bundling, duplicated dependency resolution), `instanceof` silently returns
+ * false and the layer degrades — which is precisely the silent divergence /
+ * data-loss path this PR exists to prevent. Failing open here is the worst
+ * possible failure mode.
+ *
+ * Consistent with `isRuntimeReplacedStoreError` in
+ * packages/auth/src/interfaces/secure-store.ts, which is already structural.
+ *
  * @plan PLAN-20260801-ISSUE2926
  * @requirement R3
  */
 export function isRuntimeReplacedError(error: unknown): boolean {
-  return isSecureStoreError(error) && error.code === 'RUNTIME_REPLACED';
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'RUNTIME_REPLACED'
+  );
 }
 
 /**

--- a/packages/storage/src/secure-store/secure-store-errors.ts
+++ b/packages/storage/src/secure-store/secure-store-errors.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Dependency-leaf module for SecureStore error types.
+ *
+ * Extracted from secure-store.ts so that runtime-replaced detection and
+ * error helpers can value-import `SecureStoreError` / `SecureStoreErrorCode`
+ * without creating a cycle back into secure-store.ts (which imports them).
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3
+ */
+
+/**
+ * Error codes for SecureStore operations.
+ *
+ * `RUNTIME_REPLACED` is a terminal error identity introduced in issue #2926.
+ * Downstream fallback and swallow layers that degrade on ordinary
+ * `UNAVAILABLE` MUST rethrow `RUNTIME_REPLACED` rather than absorb it —
+ * absorbing it would diverge the fallback file from the Keychain, causing
+ * silent stale-value data loss on the next healthy start.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3
+ */
+export type SecureStoreErrorCode =
+  | 'UNAVAILABLE'
+  | 'LOCKED'
+  | 'DENIED'
+  | 'CORRUPT'
+  | 'TIMEOUT'
+  | 'NOT_FOUND'
+  | 'RUNTIME_REPLACED';
+
+/**
+ * Type guard: narrows an unknown thrown value to a SecureStoreError.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+export function isSecureStoreError(error: unknown): error is SecureStoreError {
+  return error instanceof SecureStoreError;
+}
+
+/**
+ * Type guard: narrows to a SecureStoreError whose code is RUNTIME_REPLACED.
+ *
+ * Used by fallback/swallow layers that must rethrow terminal replaced-runtime
+ * errors while still degrading on ordinary UNAVAILABLE.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R3
+ */
+export function isRuntimeReplacedError(error: unknown): boolean {
+  return isSecureStoreError(error) && error.code === 'RUNTIME_REPLACED';
+}
+
+/**
+ * Error thrown by SecureStore operations.
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+export class SecureStoreError extends Error {
+  readonly code: SecureStoreErrorCode;
+  readonly remediation: string;
+
+  constructor(
+    message: string,
+    code: SecureStoreErrorCode,
+    remediation: string,
+  ) {
+    super(message);
+    this.name = 'SecureStoreError';
+    this.code = code;
+    this.remediation = remediation;
+  }
+}

--- a/packages/storage/src/secure-store/secure-store.runtime-replaced.test.ts
+++ b/packages/storage/src/secure-store/secure-store.runtime-replaced.test.ts
@@ -1,0 +1,432 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the replaced-runtime fail-fast behaviour in
+ * SecureStore and createDefaultKeyringAdapter (issue #2926, Revision 2).
+ *
+ * When the runtime has been replaced on disk, ALL OS keyring operations are
+ * forbidden (R2). Credential get/set/delete/list/has/isKeychainAvailable all
+ * fail fast with a SecureStoreError whose code is RUNTIME_REPLACED and whose
+ * remediation tells the user to restart and that "Always Allow" cannot take
+ * effect (R3) — regardless of fallbackPolicy (deliberate override of 'allow'
+ * to prevent silent Keychain/fallback divergence).
+ *
+ * Uses the injectable detector so tests run on ALL CI platforms (not just
+ * darwin).
+ *
+ * @plan PLAN-20260801-ISSUE2926
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  SecureStore,
+  SecureStoreError,
+  createDefaultKeyringAdapter,
+  type KeyringAdapter,
+} from './secure-store.js';
+import {
+  isSecureStoreError,
+  isRuntimeReplacedError,
+} from './secure-store-errors.js';
+import {
+  resetRuntimeIdentityForTesting,
+  forceRuntimeReplacedForTesting,
+} from './runtime-identity.js';
+import {
+  resetRuntimeReplacedWarningForTesting,
+  hasRuntimeReplacedWarningBeenEmitted,
+} from './runtime-replaced-errors.js';
+
+// ─── Shared helpers (RULES.md: no copy-pasted setup) ────────────────────────
+
+function useTempDir(): {
+  beforeEach: () => Promise<void>;
+  afterEach: () => Promise<void>;
+  getDir: () => string;
+} {
+  let dir = '';
+  return {
+    beforeEach: async () => {
+      dir = await fs.mkdtemp(path.join(os.tmpdir(), 'secure-store-replaced-'));
+    },
+    afterEach: async () => {
+      if (dir !== '') {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    },
+    getDir: () => dir,
+  };
+}
+
+function useResettableRuntimeState(): {
+  beforeEach: () => void;
+  afterEach: () => void;
+} {
+  return {
+    beforeEach: () => {
+      resetRuntimeIdentityForTesting();
+      resetRuntimeReplacedWarningForTesting();
+    },
+    afterEach: () => {
+      resetRuntimeIdentityForTesting();
+      resetRuntimeReplacedWarningForTesting();
+    },
+  };
+}
+
+/**
+ * A recording keyring adapter that counts every native call. Used to prove
+ * ZERO native calls after the terminal state is set (R2).
+ */
+function createRecordingAdapter(): {
+  adapter: KeyringAdapter;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const adapter: KeyringAdapter = {
+    getPassword: async () => {
+      calls.push('getPassword');
+      return null;
+    },
+    setPassword: async () => {
+      calls.push('setPassword');
+    },
+    deletePassword: async () => {
+      calls.push('deletePassword');
+      return false;
+    },
+    findCredentials: async () => {
+      calls.push('findCredentials');
+      return [];
+    },
+  };
+  return { adapter, calls };
+}
+
+async function fallbackFileExists(dir: string, key: string): Promise<boolean> {
+  const filePath = path.join(dir, `${key}.enc`);
+  return fs.access(filePath).then(
+    () => true,
+    () => false,
+  );
+}
+
+/**
+ * Asserts that the given error is a SecureStoreError with code
+ * RUNTIME_REPLACED and the correct remediation text. Uses instanceof, not
+ * type assertions.
+ */
+function assertRuntimeReplacedError(error: unknown): void {
+  expect(error).toBeInstanceOf(SecureStoreError);
+  expect(isSecureStoreError(error)).toBe(true);
+  expect(isRuntimeReplacedError(error)).toBe(true);
+  if (error instanceof SecureStoreError) {
+    expect(error.code).toBe('RUNTIME_REPLACED');
+    expect(error.remediation).toContain('Restart');
+    expect(error.remediation).toContain('Always Allow');
+  }
+}
+
+// ─── createDefaultKeyringAdapter gating (R2) ────────────────────────────────
+
+/**
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R2
+ */
+describe('createDefaultKeyringAdapter — replaced runtime gating', () => {
+  const runtime = useResettableRuntimeState();
+  beforeEach(runtime.beforeEach);
+  afterEach(runtime.afterEach);
+
+  it('returns null without touching the keyring when the runtime is reported replaced', async () => {
+    forceRuntimeReplacedForTesting();
+    const adapter = await createDefaultKeyringAdapter();
+    expect(adapter).toBeNull();
+  });
+
+  it('does not short-circuit to null when the runtime is intact', async () => {
+    resetRuntimeIdentityForTesting();
+    const result = await createDefaultKeyringAdapter();
+    // We cannot assert non-null (the native module may be absent in CI), but
+    // we MUST assert the result is explicitly null OR a real adapter — never
+    // undefined. (Revision 1 had a vacuous `typeof result === 'object'` check
+    // that also accepted null.)
+    expect(result).not.toBeUndefined();
+  });
+});
+
+// ─── SecureStore fail-fast (R3, R2) ──────────────────────────────────────────
+
+/**
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R2, R3
+ */
+describe('SecureStore — replaced runtime fail-fast', () => {
+  const temp = useTempDir();
+  beforeEach(temp.beforeEach);
+  afterEach(temp.afterEach);
+  const runtime = useResettableRuntimeState();
+  beforeEach(runtime.beforeEach);
+  afterEach(runtime.afterEach);
+
+  it('get() throws SecureStoreError RUNTIME_REPLACED and does not invoke the keyring loader', async () => {
+    forceRuntimeReplacedForTesting();
+    const { adapter, calls } = createRecordingAdapter();
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => adapter,
+      fallbackDir: temp.getDir(),
+    });
+
+    let error: unknown = null;
+    try {
+      await store.get('any-key');
+    } catch (caught) {
+      error = caught;
+    }
+
+    assertRuntimeReplacedError(error);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('set() throws SecureStoreError RUNTIME_REPLACED and does NOT create a fallback file', async () => {
+    forceRuntimeReplacedForTesting();
+    const { adapter, calls } = createRecordingAdapter();
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => adapter,
+      fallbackDir: temp.getDir(),
+      fallbackPolicy: 'allow',
+    });
+
+    let error: unknown = null;
+    try {
+      await store.set('any-key', 'any-value');
+    } catch (caught) {
+      error = caught;
+    }
+
+    assertRuntimeReplacedError(error);
+    expect(calls).toHaveLength(0);
+    expect(await fallbackFileExists(temp.getDir(), 'any-key')).toBe(false);
+  });
+
+  it('with fallbackPolicy allow, still throws instead of writing the fallback', async () => {
+    forceRuntimeReplacedForTesting();
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: temp.getDir(),
+      fallbackPolicy: 'allow',
+    });
+
+    let error: unknown = null;
+    try {
+      await store.get('any-key');
+    } catch (caught) {
+      error = caught;
+    }
+
+    assertRuntimeReplacedError(error);
+    expect(await fallbackFileExists(temp.getDir(), 'any-key')).toBe(false);
+  });
+});
+
+// ─── Coherent surface: every method throws consistently (R5) ─────────────────
+
+/**
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R5
+ */
+describe('SecureStore — coherent surface under terminal state', () => {
+  const temp = useTempDir();
+  beforeEach(temp.beforeEach);
+  afterEach(temp.afterEach);
+  const runtime = useResettableRuntimeState();
+  beforeEach(runtime.beforeEach);
+  afterEach(runtime.afterEach);
+
+  it('delete() throws RUNTIME_REPLACED and makes zero native calls', async () => {
+    forceRuntimeReplacedForTesting();
+    const { adapter, calls } = createRecordingAdapter();
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => adapter,
+      fallbackDir: temp.getDir(),
+    });
+
+    let error: unknown = null;
+    try {
+      await store.delete('any-key');
+    } catch (caught) {
+      error = caught;
+    }
+
+    assertRuntimeReplacedError(error);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('list() throws RUNTIME_REPLACED and makes zero native calls', async () => {
+    forceRuntimeReplacedForTesting();
+    const { adapter, calls } = createRecordingAdapter();
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => adapter,
+      fallbackDir: temp.getDir(),
+    });
+
+    let error: unknown = null;
+    try {
+      await store.list();
+    } catch (caught) {
+      error = caught;
+    }
+
+    assertRuntimeReplacedError(error);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('has() throws RUNTIME_REPLACED and makes zero native calls', async () => {
+    forceRuntimeReplacedForTesting();
+    const { adapter, calls } = createRecordingAdapter();
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => adapter,
+      fallbackDir: temp.getDir(),
+    });
+
+    let error: unknown = null;
+    try {
+      await store.has('any-key');
+    } catch (caught) {
+      error = caught;
+    }
+
+    assertRuntimeReplacedError(error);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('isKeychainAvailable() throws RUNTIME_REPLACED and makes zero native calls', async () => {
+    forceRuntimeReplacedForTesting();
+    const { adapter, calls } = createRecordingAdapter();
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => adapter,
+      fallbackDir: temp.getDir(),
+    });
+
+    let error: unknown = null;
+    try {
+      await store.isKeychainAvailable();
+    } catch (caught) {
+      error = caught;
+    }
+
+    assertRuntimeReplacedError(error);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ─── Zero-native-call proof: cached adapter transition (R2) ──────────────────
+
+/**
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R2
+ */
+describe('SecureStore — cached adapter makes zero native calls after transition', () => {
+  const temp = useTempDir();
+  beforeEach(temp.beforeEach);
+  afterEach(temp.afterEach);
+  const runtime = useResettableRuntimeState();
+  beforeEach(runtime.beforeEach);
+  afterEach(runtime.afterEach);
+
+  it('an adapter cached BEFORE the transition still makes zero calls after it', async () => {
+    // Phase 1: healthy — load the adapter and use it (caches it).
+    resetRuntimeIdentityForTesting();
+    const { adapter, calls } = createRecordingAdapter();
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => adapter,
+      fallbackDir: temp.getDir(),
+    });
+
+    // Prime the cache by doing a get() while healthy.
+    await store.get('warmup-key');
+    expect(calls.length).toBeGreaterThan(0);
+    const callsBeforeTransition = calls.length;
+
+    // Phase 2: force replaced AFTER the adapter is cached.
+    forceRuntimeReplacedForTesting();
+
+    // Now every method must throw and make ZERO additional native calls.
+    const methodCalls: ReadonlyArray<
+      readonly [string, () => Promise<unknown>]
+    > = [
+      ['get', () => store.get('post-key')],
+      ['set', () => store.set('post-key', 'val')],
+      ['delete', () => store.delete('post-key')],
+      ['list', () => store.list()],
+      ['has', () => store.has('post-key')],
+    ];
+    for (const [methodName, call] of methodCalls) {
+      try {
+        await call();
+        expect.fail(`${methodName}() should have thrown RUNTIME_REPLACED`);
+      } catch (error) {
+        assertRuntimeReplacedError(error);
+      }
+    }
+
+    // The guarded adapter must have blocked all native calls.
+    expect(calls.length).toBe(callsBeforeTransition);
+  });
+});
+
+// ─── Notification: null-logger-first ordering (R4) ───────────────────────────
+
+/**
+ * @plan PLAN-20260801-ISSUE2926
+ * @requirement R4
+ */
+describe('SecureStore — replaced-runtime notification via stderr', () => {
+  const temp = useTempDir();
+  beforeEach(temp.beforeEach);
+  afterEach(temp.afterEach);
+  const runtime = useResettableRuntimeState();
+  beforeEach(runtime.beforeEach);
+  afterEach(runtime.afterEach);
+
+  it('emits exactly one user-visible notice via stderr even when the store has a null logger', async () => {
+    forceRuntimeReplacedForTesting();
+    expect(hasRuntimeReplacedWarningBeenEmitted()).toBe(false);
+
+    // Construct a store with NO injected logger (defaults to
+    // NullStorageLoggerImpl which discards). The warning MUST still reach
+    // stderr because it is routed through process.stderr.write.
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: temp.getDir(),
+      fallbackPolicy: 'allow',
+    });
+
+    try {
+      await store.get('any-key');
+    } catch {
+      // expected
+    }
+
+    // The once-per-process flag must be set (R4).
+    expect(hasRuntimeReplacedWarningBeenEmitted()).toBe(true);
+
+    // Perform more operations — the warning must NOT be emitted again.
+    for (let i = 0; i < 5; i++) {
+      try {
+        await store.get(`key-${i}`);
+      } catch {
+        // expected
+      }
+    }
+    // Still true — emitted exactly once.
+    expect(hasRuntimeReplacedWarningBeenEmitted()).toBe(true);
+  });
+});

--- a/packages/storage/src/secure-store/secure-store.runtime-replaced.test.ts
+++ b/packages/storage/src/secure-store/secure-store.runtime-replaced.test.ts
@@ -400,6 +400,41 @@ describe('SecureStore — replaced-runtime notification via stderr', () => {
   beforeEach(runtime.beforeEach);
   afterEach(runtime.afterEach);
 
+  /**
+   * A broken stderr (EPIPE when piped into a command that exits early) must
+   * not replace the terminal error with a stream error: callers key their
+   * rethrow decision on RUNTIME_REPLACED, so losing it would let the very
+   * degradation this guard exists to prevent happen anyway.
+   *
+   * @plan PLAN-20260801-ISSUE2926
+   * @requirement R3, R4
+   */
+  it('still throws RUNTIME_REPLACED when writing the notice to stderr fails', async () => {
+    forceRuntimeReplacedForTesting();
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {
+        throw new Error('EPIPE: broken pipe');
+      });
+
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: temp.getDir(),
+      fallbackPolicy: 'allow',
+    });
+
+    let caught: unknown;
+    try {
+      await store.get('any-key');
+    } catch (error) {
+      caught = error;
+    } finally {
+      stderrSpy.mockRestore();
+    }
+
+    expect(isRuntimeReplacedError(caught)).toBe(true);
+  });
+
   it('emits exactly one user-visible notice via stderr even when the store has a null logger', async () => {
     forceRuntimeReplacedForTesting();
     expect(hasRuntimeReplacedWarningBeenEmitted()).toBe(false);

--- a/packages/storage/src/secure-store/secure-store.runtime-replaced.test.ts
+++ b/packages/storage/src/secure-store/secure-store.runtime-replaced.test.ts
@@ -21,7 +21,7 @@
  * @plan PLAN-20260801-ISSUE2926
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -42,6 +42,7 @@ import {
 import {
   resetRuntimeReplacedWarningForTesting,
   hasRuntimeReplacedWarningBeenEmitted,
+  RUNTIME_REPLACED_REMEDIATION,
 } from './runtime-replaced-errors.js';
 
 // ─── Shared helpers (RULES.md: no copy-pasted setup) ────────────────────────
@@ -377,7 +378,10 @@ describe('SecureStore — cached adapter makes zero native calls after transitio
       }
     }
 
-    // The guarded adapter must have blocked all native calls.
+    // The recording adapter is injected via keyringLoader and is NOT wrapped
+    // by createGuardedAdapter. The zero-call guarantee comes from the
+    // SecureStore-level assertRuntimeNotReplaced() that fires before the
+    // keyring loader is even consulted.
     expect(calls.length).toBe(callsBeforeTransition);
   });
 });
@@ -400,6 +404,8 @@ describe('SecureStore — replaced-runtime notification via stderr', () => {
     forceRuntimeReplacedForTesting();
     expect(hasRuntimeReplacedWarningBeenEmitted()).toBe(false);
 
+    const stderrSpy = vi.spyOn(process.stderr, 'write');
+
     // Construct a store with NO injected logger (defaults to
     // NullStorageLoggerImpl which discards). The warning MUST still reach
     // stderr because it is routed through process.stderr.write.
@@ -418,6 +424,17 @@ describe('SecureStore — replaced-runtime notification via stderr', () => {
     // The once-per-process flag must be set (R4).
     expect(hasRuntimeReplacedWarningBeenEmitted()).toBe(true);
 
+    // The notice must have actually been written to stderr (not stdout, not
+    // swallowed). Assert it contains the remediation guidance.
+    const writes = stderrSpy.mock.calls.map((c) => String(c[0]));
+    const notice = writes.join('');
+    expect(notice).toContain('Restart LLxprt');
+    expect(notice).toContain(RUNTIME_REPLACED_REMEDIATION);
+    expect(notice).toContain('Always Allow');
+
+    // Record how many writes happened for the first operation.
+    const writesAfterFirst = stderrSpy.mock.calls.length;
+
     // Perform more operations — the warning must NOT be emitted again.
     for (let i = 0; i < 5; i++) {
       try {
@@ -426,7 +443,12 @@ describe('SecureStore — replaced-runtime notification via stderr', () => {
         // expected
       }
     }
+
+    // Exactly the same number of stderr writes — no additional notice.
+    expect(stderrSpy.mock.calls.length).toBe(writesAfterFirst);
     // Still true — emitted exactly once.
     expect(hasRuntimeReplacedWarningBeenEmitted()).toBe(true);
+
+    stderrSpy.mockRestore();
   });
 });

--- a/packages/storage/src/secure-store/secure-store.ts
+++ b/packages/storage/src/secure-store/secure-store.ts
@@ -35,38 +35,37 @@ import {
   clearMismatchedKeyringValue,
   verifyKeyringWrite,
 } from './keyring-write-verification.js';
+import { assertRuntimeNotReplaced } from './runtime-replaced-errors.js';
+import { RUNTIME_REPLACED_REMEDIATION } from './runtime-replaced-errors.js';
+import {
+  createDefaultKeyringAdapter,
+  setKeyringLogger,
+} from './default-keyring-adapter.js';
 
-let _moduleLogger: StorageLogger = new NullStorageLoggerImpl();
+export { createDefaultKeyringAdapter } from './default-keyring-adapter.js';
+export { resetRuntimeReplacedWarningForTesting } from './runtime-replaced-errors.js';
+export { hasRuntimeReplacedWarningBeenEmitted } from './runtime-replaced-errors.js';
+export {
+  forceRuntimeReplacedForTesting,
+  resetRuntimeIdentityForTesting,
+} from './runtime-identity.js';
 
-function setSecureStoreModuleLogger(logger: StorageLogger): void {
-  _moduleLogger = logger;
-}
+// ─── Error Type (re-exported from dependency-leaf module) ────────────────────
+//
+// SecureStoreError and SecureStoreErrorCode are defined in
+// secure-store-errors.ts (a dependency leaf) so that runtime-replaced
+// detection and error helpers can import them without creating a cycle back
+// into this module.
 
-// ─── Error Type ──────────────────────────────────────────────────────────────
+export {
+  SecureStoreError,
+  isSecureStoreError,
+  isRuntimeReplacedError,
+} from './secure-store-errors.js';
+export type { SecureStoreErrorCode } from './secure-store-errors.js';
 
-export type SecureStoreErrorCode =
-  | 'UNAVAILABLE'
-  | 'LOCKED'
-  | 'DENIED'
-  | 'CORRUPT'
-  | 'TIMEOUT'
-  | 'NOT_FOUND';
-
-export class SecureStoreError extends Error {
-  readonly code: SecureStoreErrorCode;
-  readonly remediation: string;
-
-  constructor(
-    message: string,
-    code: SecureStoreErrorCode,
-    remediation: string,
-  ) {
-    super(message);
-    this.name = 'SecureStoreError';
-    this.code = code;
-    this.remediation = remediation;
-  }
-}
+import { SecureStoreError } from './secure-store-errors.js';
+import type { SecureStoreErrorCode } from './secure-store-errors.js';
 
 // ─── Adapter Interface ───────────────────────────────────────────────────────
 
@@ -101,29 +100,7 @@ function isErrorWithCode(value: unknown): value is { code: string } {
     typeof value === 'object' &&
     value !== null &&
     'code' in value &&
-    typeof (value as Record<string, unknown>).code === 'string'
-  );
-}
-
-function isErrorWithMessage(value: unknown): value is { message: string } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'message' in value &&
-    typeof (value as Record<string, unknown>).message === 'string'
-  );
-}
-
-const KEYRING_MODULE_ERROR_CODES = new Set([
-  'ERR_MODULE_NOT_FOUND',
-  'MODULE_NOT_FOUND',
-  'ERR_DLOPEN_FAILED',
-]);
-
-function isKeyringModuleMissingError(error: unknown): boolean {
-  return (
-    (isErrorWithCode(error) && KEYRING_MODULE_ERROR_CODES.has(error.code)) ||
-    (isErrorWithMessage(error) && error.message.includes('@napi-rs/keyring'))
+    typeof value.code === 'string'
   );
 }
 
@@ -154,6 +131,8 @@ function getRemediation(code: SecureStoreErrorCode): string {
       return 'Retry, check system load';
     case 'NOT_FOUND':
       return 'Save the key first';
+    case 'RUNTIME_REPLACED':
+      return RUNTIME_REPLACED_REMEDIATION;
     default:
       return 'An unexpected error occurred';
   }
@@ -161,82 +140,6 @@ function getRemediation(code: SecureStoreErrorCode): string {
 
 function isTransientError(error: unknown): boolean {
   return classifyError(error) === 'TIMEOUT';
-}
-
-type FindCredentialsFunction = (
-  service: string,
-) => Promise<Array<{ account: string; password: string }>>;
-
-function withFindCredentials(
-  adapter: KeyringAdapter,
-  findCredentialsFn: FindCredentialsFunction | undefined,
-): KeyringAdapter {
-  if (findCredentialsFn !== undefined) {
-    adapter.findCredentials = async (service: string) => {
-      try {
-        return await findCredentialsFn(service);
-      } catch {
-        return [];
-      }
-    };
-  }
-
-  return adapter;
-}
-
-/**
- * Creates a default KeyringAdapter by loading @napi-rs/keyring.
- * Exported so that other modules can reuse this without duplicating
- * the @napi-rs/keyring import.
- *
- * @plan PLAN-20260211-SECURESTORE.P08
- */
-export async function createDefaultKeyringAdapter(): Promise<KeyringAdapter | null> {
-  try {
-    const module = await import('@napi-rs/keyring');
-    const keyring = (module as Record<string, unknown>).default ?? module;
-    const kr = keyring as {
-      AsyncEntry: new (
-        service: string,
-        account: string,
-      ) => {
-        getPassword(): Promise<string | null>;
-        setPassword(password: string): Promise<void>;
-        deleteCredential(): Promise<boolean>;
-      };
-      findCredentials?: FindCredentialsFunction;
-      findCredentialsAsync?: FindCredentialsFunction;
-    };
-    const findCredentialsFn = kr.findCredentials ?? kr.findCredentialsAsync;
-    const adapter: KeyringAdapter = {
-      getPassword: async (service: string, account: string) => {
-        const entry = new kr.AsyncEntry(service, account);
-        return entry.getPassword();
-      },
-      setPassword: async (
-        service: string,
-        account: string,
-        password: string,
-      ) => {
-        const entry = new kr.AsyncEntry(service, account);
-        await entry.setPassword(password);
-      },
-      deletePassword: async (service: string, account: string) => {
-        const entry = new kr.AsyncEntry(service, account);
-        return entry.deleteCredential();
-      },
-    };
-
-    return withFindCredentials(adapter, findCredentialsFn);
-  } catch (error) {
-    if (!isKeyringModuleMissingError(error) && process.env.DEBUG) {
-      const message = isErrorWithMessage(error) ? error.message : String(error);
-      _moduleLogger.warn(
-        `[SecureStore] Unexpected error loading @napi-rs/keyring: ${message}`,
-      );
-    }
-    return null;
-  }
 }
 
 // ─── SecureStore Class ───────────────────────────────────────────────────────
@@ -283,7 +186,7 @@ export class SecureStore {
     this.machineSecretLoaderFn =
       options?.machineSecretLoader ?? this.defaultMachineSecretLoader;
     this.machineSecretFilePath = options?.machineSecretPath;
-    setSecureStoreModuleLogger(this.logger);
+    setKeyringLogger(this.logger);
   }
 
   private defaultMachineSecretLoader = async (): Promise<Buffer | null> =>
@@ -377,6 +280,7 @@ export class SecureStore {
   // ─── Availability Probe ──────────────────────────────────────────────────
 
   async isKeychainAvailable(): Promise<boolean> {
+    assertRuntimeNotReplaced();
     if (this.probeCache !== null) {
       const elapsed = Date.now() - this.probeCache.timestamp;
       if (elapsed < this.PROBE_TTL_MS) {
@@ -504,6 +408,7 @@ export class SecureStore {
 
   async set(key: string, value: string): Promise<void> {
     this.validateKey(key);
+    assertRuntimeNotReplaced();
 
     const adapter = await this.getKeyring();
     let keyringWriteSucceeded = false;
@@ -572,6 +477,7 @@ export class SecureStore {
 
   async get(key: string): Promise<string | null> {
     this.validateKey(key);
+    assertRuntimeNotReplaced();
     const adapter = await this.getKeyring();
     if (adapter !== null) {
       try {
@@ -632,6 +538,7 @@ export class SecureStore {
 
   async delete(key: string): Promise<boolean> {
     this.validateKey(key);
+    assertRuntimeNotReplaced();
 
     let deletedFromKeyring = false;
     let deletedFromFile = false;
@@ -660,6 +567,7 @@ export class SecureStore {
   // ─── CRUD: list() ────────────────────────────────────────────────────────
 
   async list(): Promise<string[]> {
+    assertRuntimeNotReplaced();
     const keys = new Set<string>();
 
     const adapter = await this.getKeyring();
@@ -723,6 +631,7 @@ export class SecureStore {
 
   async has(key: string): Promise<boolean> {
     this.validateKey(key);
+    assertRuntimeNotReplaced();
 
     const adapter = await this.getKeyring();
     if (adapter !== null) {

--- a/packages/storage/src/secure-store/secure-store.ts
+++ b/packages/storage/src/secure-store/secure-store.ts
@@ -35,8 +35,10 @@ import {
   clearMismatchedKeyringValue,
   verifyKeyringWrite,
 } from './keyring-write-verification.js';
-import { assertRuntimeNotReplaced } from './runtime-replaced-errors.js';
-import { RUNTIME_REPLACED_REMEDIATION } from './runtime-replaced-errors.js';
+import {
+  assertRuntimeNotReplaced,
+  RUNTIME_REPLACED_REMEDIATION,
+} from './runtime-replaced-errors.js';
 import {
   createDefaultKeyringAdapter,
   setKeyringLogger,

--- a/project-plans/issue2926/PLAN.md
+++ b/project-plans/issue2926/PLAN.md
@@ -1,0 +1,316 @@
+# PLAN-20260801-ISSUE2926 — Fail fast when the running runtime has been replaced on disk
+
+Issue: https://github.com/vybestack/llxprt-code/issues/2926
+Milestone: 0.11.0
+
+## Problem
+
+On macOS, LLxprt execs the Bun binary bundled inside its own package tree
+(`packages/cli/bin/llxprt`, final line: `exec "$_llxprt_bun" "$_llxprt_pkg_root/index.ts" "$@"`).
+That Mach-O is the Keychain client process.
+
+An in-place reinstall (`npm i -g`, or a package-cache refresh) renames the old tree aside
+and then **deletes** it. The running process survives, but its executable vnode becomes
+nameless. macOS `securityd` identifies a Keychain client via audit token ->
+`proc_pidpath()` -> reconstruct a `SecCode` -> evaluate the item's requirement and
+partition list. With no path, that reconstruction fails, so securityd cannot evaluate the
+caller at all and falls back to a login-password prompt on **every** protected operation.
+
+Because LLxprt performs at least two uncached credential reads per turn, the result is an
+unbounded password-dialog storm. "Always Allow" cannot fix it (the caller has no identity
+to grant); it only appends duplicate ACL entries.
+
+### Verified evidence
+
+C harness against the real signed Bun binary, simulating npm's rename-then-delete:
+
+    before           proc_pidpath=31  CS_VALID=1  SecCode create=0       valid=0
+    retired-present  proc_pidpath=35  CS_VALID=1  SecCode create=0       valid=0
+    retired-removed  proc_pidpath=0   CS_VALID=1  SecCode create=100002  valid=100002
+
+- Rename alone is harmless. Only the final delete breaks identity.
+- The process stays alive and stays `CS_VALID`. This is a user-space identity
+  reconstruction failure, not a kernel invalidation.
+- Restoring byte-identical bytes at the original path does NOT recover it. Only a restart does.
+
+Detection primitive validated separately: after an npm-style rename/delete/replace with a
+byte-identical binary, `fs.stat(execPath)` reports a different inode
+(`16777234:491441711` -> `16777234:491441716`). So `(dev, ino)` captured at process start,
+compared later, is an exact signal for "my executable file was unlinked".
+
+## Scope
+
+IN scope:
+- Detect the replaced-runtime condition.
+- Guarantee zero OS keyring operations once detected.
+- Fail fast with one actionable message.
+
+OUT of scope (explicitly deferred, noted in the issue as an optional larger alternative):
+- Immutable/content-addressed runtime staging.
+- Keyring error-fidelity work (issue #2928).
+- Non-destructive write verification (issue #2927).
+
+## Requirements
+
+- **R1** Given a process whose executable file has been unlinked or replaced since process
+  start, on darwin, the runtime is reported as replaced.
+- **R2** Given the runtime is reported as replaced, zero OS keyring operations are attempted
+  for the remainder of the process lifetime.
+- **R3** Given the runtime is reported as replaced, credential operations fail with a
+  `SecureStoreError` whose message names the cause and whose remediation says to restart
+  LLxprt and states that "Always Allow" cannot take effect.
+- **R4** The warning is emitted at most once per process.
+- **R5** Given an intact runtime, or a non-darwin platform, behavior is byte-for-byte
+  unchanged from today.
+
+## Design
+
+### New module: `packages/storage/src/secure-store/runtime-identity.ts`
+
+Pure and injectable. No mocks needed to test it — it operates on real files.
+
+    export interface ExecutableIdentity { readonly path: string; readonly dev: number; readonly ino: number; }
+    export function captureExecutableIdentity(execPath?: string): ExecutableIdentity | null;
+    export function isExecutableReplaced(baseline: ExecutableIdentity | null): boolean;
+    export function isRuntimeReplaced(): boolean;   // process-wide, memoised terminal state
+    export function resetRuntimeIdentityForTesting(): void;
+
+Rules:
+- `captureExecutableIdentity` takes the path as a parameter (defaulting to
+  `process.execPath`) so tests use real temp files rather than mocking `fs`.
+- The baseline is captured eagerly at module initialisation, so it is recorded before any
+  reinstall can occur mid-session.
+- `isExecutableReplaced` returns true when the path no longer stats (ENOENT) or when
+  `(dev, ino)` differs from the baseline.
+- Once true, the state is **terminal** — a replaced runtime never becomes healthy again
+  (proven: restoring identical bytes does not recover identity). Memoise it.
+- `process.platform !== 'darwin'` returns false, always. A null baseline returns false.
+
+### Integration point: `createDefaultKeyringAdapter()` in `packages/storage/src/secure-store/secure-store.ts`
+
+This is the single choke point for **all** keyring access in the repo. Verified consumers:
+- `SecureStore` (default `keyringLoaderFn`), secure-store.ts:281
+- `getMachineSecret` / `resolveAndPersist`, machine-secret.ts:201
+- MCP `defaultKeytarLoader`, packages/mcp/src/auth/token-storage/keychain-token-storage.ts:67
+
+Gating here covers every consumer with one change and guarantees R2.
+
+    export async function createDefaultKeyringAdapter(): Promise<KeyringAdapter | null> {
+      if (isRuntimeReplaced()) return null;   // BEFORE importing @napi-rs/keyring
+      ...
+    }
+
+The check must precede the dynamic `import('@napi-rs/keyring')` so no native call is ever
+issued.
+
+### Fail-fast behaviour in `SecureStore`
+
+When the keyring is unavailable **because the runtime was replaced**, SecureStore throws a
+`SecureStoreError` with code `UNAVAILABLE`, **regardless of `fallbackPolicy`**.
+
+Rationale for overriding `fallbackPolicy: 'allow'`: silently writing to the encrypted
+fallback file would diverge from the Keychain, and on the next healthy start `get()` reads
+the keyring first and would return the stale pre-divergence value. That is silent data
+loss. Failing is correct and is what the issue asks for.
+
+Message (single source of truth, one constant):
+
+    LLxprt's runtime was replaced on disk while this session was running (usually an npm
+    upgrade). macOS can no longer verify this process's identity, so credential access is
+    disabled to avoid a password-prompt storm.
+
+Remediation:
+
+    Restart LLxprt to recover. Do not click "Always Allow" — it cannot take effect for this process.
+
+Emit `logger.warn` with the same text exactly once per process (R4).
+
+Implement as ONE explicit state transition at the keyring-loading boundary. Do not scatter
+try/catch across call sites — the project prefers fail-fast over layered defensive guards.
+
+## Test plan (TDD — RED first, behavioural, no mock theatre)
+
+### `runtime-identity` tests — real filesystem, real inode churn
+
+1. captures a stable identity for an existing file
+2. returns null for a path that does not exist
+3. reports NOT replaced when the file is untouched
+4. reports replaced after npm-style rename-aside + delete + recreate with identical bytes
+   (this is the exact real-world sequence; assert it detects despite identical content)
+5. reports replaced when the file is deleted and not recreated
+6. is terminal: once replaced, still reports replaced after the original file is restored
+7. returns false on a non-darwin platform
+8. returns false for a null baseline
+
+Use a real temp dir and real `fs` operations. Use a shared `useTempDir()`-style helper that
+registers its own lifecycle hooks (RULES.md: no copy-pasted beforeEach across describes).
+
+### `createDefaultKeyringAdapter` tests
+
+9. returns null without touching the keyring when the runtime is reported replaced
+10. behaves exactly as today when the runtime is intact
+
+Assert R2 by construction: inject a keyring loader that records invocation, and assert zero
+invocations in the replaced case.
+
+### `SecureStore` tests
+
+11. `get()` throws SecureStoreError UNAVAILABLE with the replaced-runtime remediation
+12. `set()` throws likewise, and does NOT create a fallback file (assert the file is absent
+    on disk — this is the anti-divergence guarantee)
+13. with `fallbackPolicy: 'allow'`, still throws (documents the deliberate override)
+14. the warning is logged exactly once across multiple operations
+15. intact runtime: all existing behaviour unchanged (existing suites must stay green)
+
+## Non-negotiables
+
+- No `eslint-disable`, no `ts-ignore` / `ts-expect-error` / `ts-nocheck`, no lint-severity
+  downgrades, no complexity-threshold increases, no new ignore entries. Fix the underlying
+  issue instead. Enforced by `npm run lint:eslint-guard`.
+- TypeScript strict; no `any`; no type assertions; explicit return types.
+- Immutable data only.
+- Tag new code with `@plan PLAN-20260801-ISSUE2926` and the `@requirement` IDs above.
+- Do not weaken or delete existing tests to make new ones pass.
+
+## Verification (all must pass before hand-back)
+
+    npm run test
+    npm run lint
+    npm run typecheck
+    npm run format
+    npm run build
+    node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"
+
+---
+
+# REVISION 2 — SUPERSEDES the Design and Test plan sections above
+
+Review found the Revision 1 detector design to be **wrong**. The sections below replace
+the "Design" and "Test plan" sections. The Problem, Scope, Requirements, Non-negotiables
+and Verification sections above still stand.
+
+## What Revision 1 got wrong
+
+Revision 1 detected "the pathname `process.execPath` now stats to a different (dev, ino)".
+That is not the failure signal. The verified evidence in this very plan says
+**rename-only is harmless** — the C harness `retired-present` stage showed
+`SecCode create=0 valid=0` while the tree was renamed aside. But a pathname comparator
+reports "replaced" the instant the rename happens, and Revision 1 memoised that as
+terminal. So an npm rollback (rename aside, then restore) would permanently disable
+credentials for a process that is perfectly healthy.
+
+The real signal is: **has my live executable vnode been unlinked?**
+
+## Corrected detector: pin an fd, watch `nlink`
+
+Open a file descriptor on `process.execPath` at startup and pin it. The fd follows the
+inode, not the name. `fstat(fd).nlink` is then exact:
+
+- `nlink >= 1` — the inode still has at least one directory entry. Healthy.
+- `nlink === 0` — every link is gone; the file has been unlinked. Orphaned, terminal.
+
+Validated empirically against the real npm sequence:
+
+    baseline               nlink=1  => orphaned: false
+    after rename-only      nlink=1  => orphaned: false     <- healthy, correctly NOT flagged
+    after retired deleted  nlink=0  => orphaned: true      <- orphaned, correctly flagged
+
+This maps one-for-one onto the C harness stages (`before` / `retired-present` /
+`retired-removed`), which is exactly the correspondence Revision 1 lacked. Pure Node —
+no native module, no `proc_pidpath` binding.
+
+Rules:
+- Open the fd once, eagerly, at module initialisation. Keep it open for process lifetime.
+- If the fd cannot be opened at startup, there is no baseline: the detector reports
+  healthy (never flags), and this must be explicit and tested.
+- `nlink === 0` is terminal — memoise it. Never un-flag.
+- Non-darwin always reports healthy.
+- The detector must be **injectable** so SecureStore behaviour is testable on every CI
+  platform, not just macOS. Separate "is the runtime replaced" (injectable predicate)
+  from "how we detect it on darwin" (the fd/nlink implementation).
+
+## Corrected gate: guard the adapter, not the factory
+
+Revision 1 gated `createDefaultKeyringAdapter()`. That only prevents *creating* an
+adapter — every already-cached adapter keeps working, which review demonstrated with a
+probe that made six native calls after the replaced state was set. `SecureStore` caches
+its adapter (`keyringInstance`), MCP `KeychainTokenStorage` caches its own module and its
+positive availability flag, and `machine-secret` calls the adapter after loading it.
+
+Instead: `createDefaultKeyringAdapter()` must return a **guarded adapter** whose every
+method re-checks the terminal state immediately before entering native code and throws
+if replaced. One wrapper covers SecureStore (all methods), machine-secret, and MCP,
+because they all obtain their adapter from this factory. That is what actually delivers R2.
+
+Keep the factory-level early return too, so no adapter is created after detection.
+
+## Corrected error: make it distinguishable
+
+Revision 1 threw a generic `UNAVAILABLE`. Review verified that `ToolKeyStorage` treats
+`UNAVAILABLE` as ordinary "keyring absent" permission to write its own fallback file
+(`packages/core/src/tools/tool-key-storage.ts`), so a probe successfully wrote and read
+back a fallback after the replaced state was forced — defeating the anti-divergence
+guarantee this plan exists to provide.
+
+Add a **distinct, terminal error identity** (a new `SecureStoreErrorCode` member and/or a
+`SecureStoreError` subclass) that downstream fallback and swallow layers must rethrow
+rather than absorb. Audit and fix every layer that currently degrades on `UNAVAILABLE`:
+`ToolKeyStorage`, extension settings persistence, and the token-store remove/list paths.
+
+Check every consumer that switches on `SecureStoreErrorCode` when adding the member.
+
+## Corrected notification: must actually reach the user
+
+The once-per-process flag is consumed by whichever logger runs first, and most production
+`SecureStore` instances are constructed with no logger (defaulting to
+`NullStorageLoggerImpl`, which discards). So the single warning can be swallowed entirely.
+
+Route the one-time notice through a channel that is guaranteed to be seen (e.g. stderr),
+independent of whether a logger was injected. Test the null-logger-first ordering.
+
+## Corrected coherence
+
+Make the `SecureStore` surface coherent. `get`/`set`/`delete`/`list`/`has`/
+`isKeychainAvailable` must all behave consistently under the terminal state rather than
+some throwing and others silently returning after making native calls.
+
+## Corrected test plan
+
+Replace the Revision 1 test list. Required behavioural coverage:
+
+**Detector (real files, real fd, real unlink):**
+1. healthy at baseline
+2. **still healthy after rename-only** (the case Revision 1 got wrong — this is the
+   regression test for the whole redesign)
+3. orphaned after the retired copy is deleted
+4. orphaned when the file is deleted outright with no replacement
+5. terminal: stays orphaned after a fresh file appears at the original path
+6. no baseline (fd could not be opened) reports healthy
+7. non-darwin reports healthy
+8. terminal memoisation is genuinely exercised (not merely repeated comparison)
+
+**Gate (must prove ZERO native calls):**
+9. a recording adapter proves zero invocations after the terminal state is set, for
+   every SecureStore method — get, set, delete, list, has, isKeychainAvailable
+10. an adapter cached BEFORE the transition still makes zero calls after it
+11. the factory returns null after detection without touching the dynamic import
+
+**Error propagation / anti-divergence:**
+12. `set()` writes no fallback file
+13. `ToolKeyStorage.saveKey` does NOT create a fallback file and rethrows
+14. `fallbackPolicy: 'allow'` still fails
+
+**Notification:**
+15. exactly one user-visible notice, including when the first store has a null logger
+
+**Portability:**
+16. all gate/fail-fast tests run and pass on non-darwin CI (inject the detector; do not
+    skip the suite)
+
+No type assertions in any new code, tests included. Use type predicates and `instanceof`.
+
+## Structural cleanup
+
+Extract `SecureStoreError` and `SecureStoreErrorCode` into a dependency-leaf module so the
+new error/gate modules do not import back into `secure-store.ts`. Revision 1 introduced a
+cycle that currently works only by accident of ESM live bindings.


### PR DESCRIPTION
Fixes #2926.

## The bug

On macOS, LLxprt execs the Bun binary bundled inside its own npm package tree (`packages/cli/bin/llxprt` ends with `exec "$_llxprt_bun" "$_llxprt_pkg_root/index.ts" "$@"`). That Mach-O is the Keychain client process.

An in-place reinstall — `npm i -g`, or a package-cache refresh — renames that tree aside and then **deletes** it. The process survives, but its executable vnode becomes nameless. macOS `securityd` identifies a Keychain client by audit token -> `proc_pidpath()` -> reconstruct a `SecCode` -> evaluate the item's designated requirement and partition list. With no path, that reconstruction fails, so securityd cannot evaluate the caller at all and falls back to a login-password prompt on **every** protected operation.

LLxprt performs at least two uncached credential reads per turn, so this becomes an unbounded password-dialog storm on every message and every tool call. Clicking "Always Allow" cannot help — the caller has no identity to grant — and only appends duplicate ACL entries. One affected machine had 39 byte-identical trusted-application entries on a single item, and 77 on another.

## What this PR does

Detects the condition and fails fast with one actionable message, instead of storming. Preventing the condition (immutable runtime staging) is deliberately out of scope and noted in the issue as a larger follow-up.

## Detection: pin an fd, watch `nlink`

The signal is **has my live executable vnode been unlinked** — not "does the pathname now resolve to different bytes". Those are different, and the difference matters: renaming the tree aside is harmless, and a pathname comparator would flag it and permanently disable credentials on an npm rollback.

So we open an fd on `process.execPath` at startup and pin it. The fd follows the inode, not the name:

- `nlink >= 1` — still linked. Healthy.
- `nlink === 0` — every link gone. Orphaned, terminal.

Validated against the real npm sequence:

    baseline               nlink=1  -> healthy
    after rename-only      nlink=1  -> healthy      (correctly NOT flagged)
    after retired deleted  nlink=0  -> orphaned     (correctly flagged)

That maps one-for-one onto the observed securityd behaviour, measured with a C harness against LLxprt's own signed Bun binary:

    before           proc_pidpath=31  CS_VALID=1  SecCode create=0       valid=0
    retired-present  proc_pidpath=35  CS_VALID=1  SecCode create=0       valid=0
    retired-removed  proc_pidpath=0   CS_VALID=1  SecCode create=100002  valid=100002

Two things fall out of that measurement and are encoded as behaviour here. Rename alone is harmless — only the final delete breaks identity. And restoring byte-identical bytes at the original path does **not** recover; only a restart does, so the state is terminal and memoised.

The detector is pure Node — no native module, no `proc_pidpath` binding — and is injectable, so the gate's behaviour is exercised on every CI platform rather than macOS only.

## The gate wraps the adapter, not the factory

Gating only `createDefaultKeyringAdapter()` would prevent *creating* an adapter while leaving every already-cached one working. `SecureStore` caches `keyringInstance`, MCP `KeychainTokenStorage` caches both its module and its positive availability flag, and `machine-secret` calls the adapter after loading it.

So the factory now returns a **guarded adapter** whose every method re-checks the terminal state immediately before entering native code. One wrapper covers SecureStore, MCP, and machine-secret, because they all obtain their adapter from this factory. The factory-level early return is kept as well. All six `SecureStore` operations (`get`, `set`, `delete`, `list`, `has`, `isKeychainAvailable`) now behave consistently rather than some throwing and others silently returning after native calls.

## Failures carry a distinct code

A generic `UNAVAILABLE` is read by `ToolKeyStorage` as permission to use its own encrypted fallback. That would write a value diverging from the Keychain, which still holds the old one and wins on the next healthy start — silent data loss, and precisely what this change exists to prevent.

Replaced-runtime failures therefore carry a distinct terminal `RUNTIME_REPLACED` code, and the layers that degrade on `UNAVAILABLE` rethrow it instead: `ToolKeyStorage`, extension settings persistence, and the token-store remove/list paths.

## The notice goes to stderr

Most `SecureStore` instances are constructed without a logger and default to `NullStorageLoggerImpl`, which discards. A logger-routed warning could therefore be consumed by the first null logger and never reach anyone. The one-time notice goes to stderr, independent of injected loggers:

    LLxprt's runtime was replaced on disk while this session was running (usually an npm
    upgrade). macOS can no longer verify this process's identity, so credential access is
    disabled to avoid a password-prompt storm.
    Restart LLxprt to recover. Do not click "Always Allow" — it cannot take effect for this process.

## Tests

Behavioural throughout — real temp files, real fds, real renames and unlinks. No fs mocking.

- **Detector:** healthy at baseline; **still healthy after rename-only** (the regression test for the whole design); orphaned after the retired copy is deleted; orphaned when deleted outright; terminal after a fresh file appears at the original path; healthy when no baseline could be established; healthy on non-darwin. The tests drive the exact production `createPinnedFdDetector` against a temp file rather than a reimplementation.
- **Gate:** zero-native-call proofs via a recording adapter for all six `SecureStore` methods, including an adapter cached *before* the transition.
- **Anti-divergence:** `set()` writes no fallback file; `ToolKeyStorage.saveKey` rethrows and creates no fallback file.
- **Notification:** `process.stderr.write` is observed directly, asserting the notice reaches stderr and is written exactly once across repeated operations.

The gate tests run on every platform (the detector is injected) rather than being skipped off-darwin.

## Verification

`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, `npm run lint:eslint-guard`, and the profile smoke test all pass. No lint suppressions, no TypeScript suppressions, no threshold changes, no type assertions in new code.

There are 8 pre-existing failures in `packages/tools` (imageResize / fileUtils / read-many-files / filesystem-tools, sharp image processing). I confirmed these fail identically on a clean checkout of `main`; they are untouched by this change.

## Related

- #2928 — SecureStore cannot distinguish Keychain denial from absence (the native binding collapses every failure into "not found"). That is why the condition also surfaces as "not authenticated".
- #2927 — concurrent credential writes can delete another process's Keychain item.
- vybestack/llxprt-jefe#588 — removes the most common trigger by resolving floating dist-tags to exact versions so a refresh never reinstalls over a live agent.

This PR is the safety net; llxprt-jefe#588 removes the trigger. Both are wanted.
