### PR TITLE
Detect an empty host SSH agent during sandbox forwarding and guide remediation (Fixes #1699)

### DIFF
--- a/dev-docs/test-runner-inventory.md
+++ b/dev-docs/test-runner-inventory.md
@@ -11,7 +11,7 @@ Bun execution command (or explains why it still requires Vitest).
 | packages/a2a-server           | 15               | 15            | 0                 | 0                         |
 | packages/agents               | 348              | 0             | 0                 | 348                       |
 | packages/auth                 | 37               | 37            | 0                 | 0                         |
-| packages/cli                  | 658              | 10            | 0                 | 648                       |
+| packages/cli                  | 659              | 11            | 0                 | 648                       |
 | packages/core                 | 322              | 322           | 0                 | 0                         |
 | packages/ide-integration      | 10               | 0             | 0                 | 10                        |
 | packages/lsp                  | 0                | all           | 0                 | 0                         |
@@ -127,7 +127,7 @@ All 6 test files are Bun-native. The `research/` directory is excluded via
 These files run under Bun via `scripts/run_bun_tests.ts` but their workspace
 primary `test` script still uses Vitest for the bulk of files.
 
-### packages/cli (10 files)
+### packages/cli (11 files)
 
 - `src/__tests__/cliSessionDispatch.characterization.test.tsx`
 - `test-utils/augment-bun-vi-cleanup.bun.ts`
@@ -145,6 +145,16 @@ do not change `SELECTED_FILE_COUNT`:
 - `src/observation/jspTransport.test.ts`
 - `src/observation/jspWiring.test.ts`
 - `src/observation/observationTap.test.ts`
+
+The sandbox SSH agent preflight suite (issue #1699) follows the same pattern —
+Bun-native from the start and excluded from the Vitest selection:
+
+- `src/utils/sandbox-ssh-agent-preflight.test.ts`
+
+It partially mocks `node:child_process` through an async `importOriginal`
+factory rather than a bare `vi.mock` automock: automocking walks every export
+and throws on `ChildProcess`'s private `#stdin` getter under Bun's native
+runner.
 
 ### packages/core — fully migrated (see above)
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -365,6 +365,11 @@ For Podman on macOS, an existing non-host `--network` setting stays
 authoritative. LLxprt Code warns and skips SSH agent forwarding rather than
 overriding your network policy to make forwarding work.
 
+When the host agent is reachable but has no identities loaded, LLxprt Code
+prints a warning at startup with remediation guidance. Forwarding still
+proceeds — load a key with `ssh-add` so git SSH operations succeed inside the
+container.
+
 ### Git config passthrough
 
 These files are mounted read-only into the container when they exist on the
@@ -664,6 +669,16 @@ export SSH_AUTH_SOCK=~/.llxprt/ssh-agent.sock
 ssh-add ~/.ssh/id_ed25519
 llxprt --sandbox-engine podman --sandbox-profile-load dev
 ```
+
+**SSH agent forwarded but git auth still fails** — the host agent may be running
+with no identities loaded. Check with `ssh-add -l`; if it reports an empty
+agent, load a key:
+
+```bash
+ssh-add ~/.ssh/id_ed25519
+```
+
+LLxprt Code prints a startup warning when it detects this empty-agent state.
 
 **"socat not found" error** — the sandbox container image needs `socat` for SSH
 agent and credential proxy tunneling. Use the official sandbox image.

--- a/packages/cli/src/utils/sandbox-seatbelt.test-helpers.ts
+++ b/packages/cli/src/utils/sandbox-seatbelt.test-helpers.ts
@@ -9,6 +9,8 @@ import fs from 'node:fs';
 import net from 'node:net';
 
 const PROCESS_LISTENER_EVENTS = ['exit', 'SIGINT', 'SIGTERM'] as const;
+const CHILD_CLOSE_DRAIN_TURNS = 5;
+const CHILD_CLOSE_DRAIN_INTERVAL_MS = 10;
 
 type FixtureSignal = '-TERM' | '-KILL';
 type ProcessListenerEvent = (typeof PROCESS_LISTENER_EVENTS)[number];
@@ -81,6 +83,22 @@ export function restoreSeatbeltHarnessFixture(
   }
 }
 
+/**
+ * `waitForFixtureProcessExit` observes the OS-level exit, but Node delivers the
+ * matching `close` event only once the child's stdio pipes reach EOF, which
+ * happens on a later loop turn. The seatbelt proxy close handler calls
+ * `process.exit(1)`, so the harness stub must stay installed until those
+ * pending events have been delivered — restoring first lets a late `close`
+ * terminate the whole test run.
+ */
+async function drainPendingChildCloseEvents(): Promise<void> {
+  for (let turn = 0; turn < CHILD_CLOSE_DRAIN_TURNS; turn++) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, CHILD_CLOSE_DRAIN_INTERVAL_MS),
+    );
+  }
+}
+
 export async function cleanupSeatbeltHarnessFixture(
   fixtureDir: string,
   restoreState: () => void,
@@ -93,6 +111,7 @@ export async function cleanupSeatbeltHarnessFixture(
     }
     await assertSeatbeltProxyPortAvailable();
   } finally {
+    await drainPendingChildCloseEvents();
     restoreSeatbeltHarnessFixture(fixtureDir, restoreState);
   }
 }

--- a/packages/cli/src/utils/sandbox-ssh-agent-preflight.test.ts
+++ b/packages/cli/src/utils/sandbox-ssh-agent-preflight.test.ts
@@ -12,8 +12,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
 
-vi.mock('node:child_process');
-vi.mock('node:fs/promises');
+// Only `spawn` is replaced, and the real module is spread rather than
+// automocked: automocking walks every export, which throws on ChildProcess's
+// private `#stdin` getter under Bun's native runner.
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawn: vi.fn(),
+}));
 
 import { setupSshAgentForwarding } from './sandbox.js';
 
@@ -258,6 +263,7 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
     const { args } = await runForwarding('podman', ['--network', 'none']);
 
     expect(args).toStrictEqual(['--network', 'none']);
+    expect(child_process.spawn).not.toHaveBeenCalled();
     expect(stderrText()).toBe('');
   });
 });

--- a/packages/cli/src/utils/sandbox-ssh-agent-preflight.test.ts
+++ b/packages/cli/src/utils/sandbox-ssh-agent-preflight.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as child_process from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import fs from 'node:fs';
+import os from 'node:os';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
+
+vi.mock('node:child_process');
+vi.mock('node:fs/promises');
+
+import { setupSshAgentForwarding } from './sandbox.js';
+
+const HOST_SOCKET = '/tmp/test-ssh-agent.sock';
+const CONTAINER_SOCKET_ENV = 'SSH_AUTH_SOCK=/ssh-agent';
+const EMPTY_AGENT_STDOUT = 'The agent has no identities.\n';
+const COMMUNICATION_FAILURE_STDERR =
+  'error fetching identities: communication with agent failed\n';
+const EXPECTED_WARNING =
+  'SSH agent socket is present, but no identities are loaded (ssh-add -l reported empty).\n' +
+  'SSH forwarding is enabled, but git SSH auth will fail until a key is loaded.\n' +
+  'Try: ssh-add ~/.ssh/id_ed25519\n';
+
+interface SshAddOutcome {
+  stdout?: string;
+  stderr?: string;
+  status?: number | null;
+  signal?: NodeJS.Signals;
+  spawnError?: Error;
+}
+
+/**
+ * Stands in for the `ssh-add -l` child process, replaying a realistic outcome
+ * (streamed output, then either a spawn error or an exit status) so the code
+ * under test consumes the same events a real probe would produce.
+ */
+function mockSshAdd(outcome: SshAddOutcome): void {
+  const child = new EventEmitter();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  Object.assign(child, { stdout, stderr });
+
+  vi.mocked(child_process.spawn).mockImplementation(() => {
+    setImmediate(() => {
+      if (outcome.spawnError) {
+        child.emit('error', outcome.spawnError);
+        return;
+      }
+      stdout.end(outcome.stdout ?? '');
+      stderr.end(outcome.stderr ?? '');
+      stdout.on('end', () => {
+        child.emit('close', outcome.status ?? 0, outcome.signal ?? null);
+      });
+    });
+    return child as unknown as child_process.ChildProcess;
+  });
+}
+
+/**
+ * Reaches the direct-mount fallback: SSH agent enabled, socket present on disk,
+ * and a platform without a dedicated helper, so no sockets or tunnels are
+ * created and every assertion stays hermetic.
+ */
+function enableForwardingViaFallback(): void {
+  process.env.LLXPRT_SANDBOX_SSH_AGENT = 'auto';
+  process.env.SSH_AUTH_SOCK = HOST_SOCKET;
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  vi.spyOn(os, 'platform').mockReturnValue('freebsd');
+}
+
+function captureStderr(): () => string {
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  return () => spy.mock.calls.map((call) => String(call[0])).join('');
+}
+
+function silenceDebugWarnings(): void {
+  vi.spyOn(DebugLogger.prototype, 'warn').mockImplementation(() => {});
+}
+
+async function runForwarding(
+  command: 'docker' | 'podman' = 'docker',
+  initialArgs: string[] = [],
+): Promise<{ result: unknown; args: string[] }> {
+  const args = [...initialArgs];
+  const result = await setupSshAgentForwarding({ command }, args);
+  return { result, args };
+}
+
+describe('setupSshAgentForwarding SSH agent identity preflight', () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('warns with remediation when the agent reports no identities', async () => {
+    enableForwardingViaFallback();
+    const stderrText = captureStderr();
+    mockSshAdd({ status: 1, stdout: EMPTY_AGENT_STDOUT });
+
+    await runForwarding();
+
+    expect(stderrText()).toBe(EXPECTED_WARNING);
+  });
+
+  it('still configures forwarding when the agent reports no identities', async () => {
+    enableForwardingViaFallback();
+    captureStderr();
+    mockSshAdd({ status: 1, stdout: EMPTY_AGENT_STDOUT });
+
+    const { result, args } = await runForwarding();
+
+    expect(result).toStrictEqual({});
+    expect(args).toContain(CONTAINER_SOCKET_ENV);
+  });
+
+  it('stays silent when the agent has identities loaded', async () => {
+    enableForwardingViaFallback();
+    const stderrText = captureStderr();
+    mockSshAdd({ status: 0, stdout: '256 SHA256:abc user@host (ED25519)\n' });
+
+    const { args } = await runForwarding();
+
+    expect(stderrText()).toBe('');
+    expect(args).toContain(CONTAINER_SOCKET_ENV);
+  });
+
+  it('stays silent when listing identities fails for a reason other than an empty agent', async () => {
+    enableForwardingViaFallback();
+    silenceDebugWarnings();
+    const stderrText = captureStderr();
+    mockSshAdd({ status: 1, stderr: COMMUNICATION_FAILURE_STDERR });
+
+    const { args } = await runForwarding();
+
+    expect(stderrText()).toBe('');
+    expect(args).toContain(CONTAINER_SOCKET_ENV);
+  });
+
+  it('stays silent when the agent cannot be contacted', async () => {
+    enableForwardingViaFallback();
+    silenceDebugWarnings();
+    const stderrText = captureStderr();
+    mockSshAdd({
+      status: 2,
+      stderr: 'Could not open a connection to your authentication agent.\n',
+    });
+
+    const { args } = await runForwarding();
+
+    expect(stderrText()).toBe('');
+    expect(args).toContain(CONTAINER_SOCKET_ENV);
+  });
+
+  it('stays silent when ssh-add is not installed', async () => {
+    enableForwardingViaFallback();
+    silenceDebugWarnings();
+    const stderrText = captureStderr();
+    mockSshAdd({
+      spawnError: Object.assign(new Error('spawn ssh-add ENOENT'), {
+        code: 'ENOENT',
+      }),
+    });
+
+    const { args } = await runForwarding();
+
+    expect(stderrText()).toBe('');
+    expect(args).toContain(CONTAINER_SOCKET_ENV);
+  });
+
+  it('stays silent when the probe is killed after exceeding its timeout', async () => {
+    enableForwardingViaFallback();
+    silenceDebugWarnings();
+    const stderrText = captureStderr();
+    mockSshAdd({ status: null, signal: 'SIGKILL' });
+
+    const { args } = await runForwarding();
+
+    expect(stderrText()).toBe('');
+    expect(args).toContain(CONTAINER_SOCKET_ENV);
+  });
+
+  it('queries the agent that is being forwarded, under a bounded timeout', async () => {
+    enableForwardingViaFallback();
+    captureStderr();
+    mockSshAdd({ status: 0 });
+
+    await runForwarding();
+
+    expect(child_process.spawn).toHaveBeenCalledWith(
+      'ssh-add',
+      ['-l'],
+      expect.objectContaining({
+        env: expect.objectContaining({ SSH_AUTH_SOCK: HOST_SOCKET }),
+        timeout: 5000,
+        killSignal: 'SIGKILL',
+      }),
+    );
+  });
+
+  it('does not query the agent when forwarding is off', async () => {
+    process.env.LLXPRT_SANDBOX_SSH_AGENT = 'off';
+    process.env.SSH_AUTH_SOCK = HOST_SOCKET;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const stderrText = captureStderr();
+
+    await runForwarding();
+
+    expect(child_process.spawn).not.toHaveBeenCalled();
+    expect(stderrText()).toBe('');
+  });
+
+  it('does not query the agent when SSH_AUTH_SOCK is unset', async () => {
+    process.env.LLXPRT_SANDBOX_SSH_AGENT = 'on';
+    delete process.env.SSH_AUTH_SOCK;
+    silenceDebugWarnings();
+    const stderrText = captureStderr();
+
+    await runForwarding();
+
+    expect(child_process.spawn).not.toHaveBeenCalled();
+    expect(stderrText()).toBe('');
+  });
+
+  it('does not query the agent when the socket path is missing', async () => {
+    process.env.LLXPRT_SANDBOX_SSH_AGENT = 'on';
+    process.env.SSH_AUTH_SOCK = '/nope/not-there.sock';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    silenceDebugWarnings();
+    const stderrText = captureStderr();
+
+    await runForwarding();
+
+    expect(child_process.spawn).not.toHaveBeenCalled();
+    expect(stderrText()).toBe('');
+  });
+
+  it('does not claim forwarding is enabled when Podman declines to override the network mode', async () => {
+    process.env.LLXPRT_SANDBOX_SSH_AGENT = 'on';
+    process.env.SSH_AUTH_SOCK = HOST_SOCKET;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(os, 'platform').mockReturnValue('darwin');
+    silenceDebugWarnings();
+    const stderrText = captureStderr();
+    mockSshAdd({ status: 1, stdout: EMPTY_AGENT_STDOUT });
+
+    const { args } = await runForwarding('podman', ['--network', 'none']);
+
+    expect(args).toStrictEqual(['--network', 'none']);
+    expect(stderrText()).toBe('');
+  });
+});

--- a/packages/cli/src/utils/sandbox-ssh.ts
+++ b/packages/cli/src/utils/sandbox-ssh.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execSync, type ChildProcess } from 'node:child_process';
+import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import os from 'node:os';
 import fs from 'node:fs';
 import net from 'node:net';
@@ -34,6 +34,15 @@ export interface PortForwardingResult {
 const CONTAINER_SSH_AGENT_SOCK = '/ssh-agent';
 const CONTAINER_CREDENTIAL_PROXY_SOCK = '/tmp/llxprt-credential.sock';
 const SSH_TUNNEL_POLL_TIMEOUT_MS = 10000;
+const SSH_AGENT_PROBE_TIMEOUT_MS = 5000;
+const SSH_AGENT_ENV_PREFIX = 'SSH_AUTH_SOCK=';
+const SSH_AGENT_NO_IDENTITIES_PATTERN = /agent has no identities/i;
+const SSH_AGENT_EMPTY_WARNING =
+  [
+    'SSH agent socket is present, but no identities are loaded (ssh-add -l reported empty).',
+    'SSH forwarding is enabled, but git SSH auth will fail until a key is loaded.',
+    'Try: ssh-add ~/.ssh/id_ed25519',
+  ].join('\n') + '\n';
 
 export { SSH_TUNNEL_POLL_TIMEOUT_MS };
 export const createTunnelProcessCleanup = (tunnelProcess: ChildProcess) => {
@@ -69,6 +78,91 @@ export const createServerCleanup = (server: net.Server) => {
     }
   };
 };
+
+interface SshAgentProbe {
+  status: number | null;
+  output: string;
+  spawnError?: Error;
+}
+
+/**
+ * Lists the identities held by the agent behind `sshAuthSock`. Resolves for
+ * every outcome — a failed probe is a diagnostic dead end, not an error worth
+ * propagating into sandbox startup.
+ */
+function listSshAgentIdentities(sshAuthSock: string): Promise<SshAgentProbe> {
+  return new Promise((resolve) => {
+    const probe = spawn('ssh-add', ['-l'], {
+      env: { ...process.env, SSH_AUTH_SOCK: sshAuthSock },
+      timeout: SSH_AGENT_PROBE_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+
+    let output = '';
+    const collect = (chunk: string) => {
+      output += chunk;
+    };
+    probe.stdout.setEncoding('utf8');
+    probe.stderr.setEncoding('utf8');
+    probe.stdout.on('data', collect);
+    probe.stderr.on('data', collect);
+
+    probe.on('error', (spawnError) => {
+      resolve({ status: null, output, spawnError });
+    });
+    probe.on('close', (status) => {
+      resolve({ status, output });
+    });
+  });
+}
+
+/**
+ * Warns when the agent being forwarded is reachable but holds no identities —
+ * the cause of "Permission denied (publickey)" inside a sandbox whose
+ * forwarding is otherwise wired up correctly.
+ *
+ * `ssh-add -l` exits 1 for any identity-listing failure, including a
+ * communication error with the agent, so the empty case is confirmed from the
+ * reported output rather than from the exit status alone. Every other outcome
+ * is debug-only: an inconclusive probe must not push guesswork at the user.
+ */
+async function warnIfSshAgentHasNoIdentities(
+  sshAuthSock: string,
+): Promise<void> {
+  const probe = await listSshAgentIdentities(sshAuthSock);
+
+  if (probe.spawnError) {
+    debugLogger.warn(
+      `Could not run ssh-add to check for loaded SSH agent identities: ${probe.spawnError.message}`,
+    );
+    return;
+  }
+
+  if (probe.status === 0) {
+    return;
+  }
+
+  if (
+    probe.status === 1 &&
+    SSH_AGENT_NO_IDENTITIES_PATTERN.test(probe.output)
+  ) {
+    process.stderr.write(SSH_AGENT_EMPTY_WARNING);
+    return;
+  }
+
+  debugLogger.warn(
+    `Could not determine whether the SSH agent has identities loaded; ssh-add -l exited with status ${probe.status}.`,
+  );
+}
+
+/**
+ * True once a helper has configured the container to use the forwarded agent.
+ * A helper can decline (Podman refuses to override a non-host `--network`), and
+ * the empty-agent warning must not claim forwarding is enabled in that case.
+ */
+function containerWillReceiveSshAgent(args: readonly string[]): boolean {
+  return args.some((arg) => arg.startsWith(SSH_AGENT_ENV_PREFIX));
+}
 
 /**
  * Routes SSH agent forwarding to the appropriate platform-specific helper.
@@ -114,6 +208,30 @@ export async function setupSshAgentForwarding(
     return {};
   }
 
+  const result = await dispatchSshAgentForwarding(
+    config,
+    args,
+    sshAuthSock,
+    options,
+  );
+
+  if (containerWillReceiveSshAgent(args)) {
+    await warnIfSshAgentHasNoIdentities(sshAuthSock);
+  }
+
+  return result;
+}
+
+/** Hands forwarding to the helper that matches the host platform and engine. */
+async function dispatchSshAgentForwarding(
+  config: { command: 'docker' | 'podman' | 'sandbox-exec' },
+  args: string[],
+  sshAuthSock: string,
+  options: {
+    reserveTunnelPort?: (port: number) => void;
+    excludedTunnelPorts?: ReadonlySet<number>;
+  },
+): Promise<SshAgentResult> {
   const platform = os.platform();
 
   if (platform === 'linux') {

--- a/packages/cli/vitest.test-groups.ts
+++ b/packages/cli/vitest.test-groups.ts
@@ -69,6 +69,9 @@ const baseExclude: readonly string[] = [
   // scripts/bun-test-manifest.ts, so they run under `bun test` only and
   // must not also be discovered by Vitest (issue #2779).
   '**/src/observation/**/*.test.ts',
+  // Sandbox SSH agent preflight tests are Bun-native for the same reason
+  // (issue #1699).
+  '**/src/utils/sandbox-ssh-agent-preflight.test.ts',
   '**/dist/**',
   '**/tmp/**',
   '**/cypress/**',

--- a/project-plans/issue1699-sandbox-ssh-agent-preflight/PLAN.md
+++ b/project-plans/issue1699-sandbox-ssh-agent-preflight/PLAN.md
@@ -1,0 +1,149 @@
+# Issue #1699 — Sandbox SSH agent forwarding: detect empty host agent and guide remediation
+
+## Problem
+
+When sandboxing is enabled and `sshAgent` is `auto`/`on`, LLxprt Code forwards
+`SSH_AUTH_SOCK` into the container. If the host agent is running but has **zero
+identities loaded**, the forwarding path is wired up correctly yet every git
+operation over SSH inside the sandbox fails with the generic
+`git@github.com: Permission denied (publickey).` The root cause (empty host
+agent) is invisible to the user.
+
+## Scope
+
+In scope:
+
+- A host-side preflight that queries the host SSH agent for loaded identities
+  during sandbox SSH agent forwarding setup.
+- A targeted, user-visible warning with remediation when the agent is reachable
+  but reports no identities.
+- Documentation of the new warning in the sandbox troubleshooting docs.
+
+Explicitly out of scope (listed as "optional" in the issue, not implemented):
+
+- An interactive helper/wizard command for loading a key.
+- A new CLI flag that runs a preflight and attempts a guided fix.
+- Any change to how forwarding itself is configured.
+
+## Design
+
+`setupSshAgentForwarding()` in `packages/cli/src/utils/sandbox-ssh.ts` is the
+single entry point for all container sandbox SSH forwarding (docker + podman,
+linux + macOS). It already validates, in order: the `off` setting, the
+`on`/auto enablement rule, `SSH_AUTH_SOCK` presence, and socket existence on
+disk.
+
+The check runs **after** the platform dispatch, gated on the container actually
+being configured to use the forwarded agent (an `SSH_AUTH_SOCK=` env argument
+was added). A platform helper can still decline — Podman on macOS refuses to
+override a non-host `--network` — and a warning claiming "SSH forwarding is
+enabled" would be wrong in that case.
+
+Detection: run `ssh-add -l` with `SSH_AUTH_SOCK` pointed at the socket being
+forwarded. The child is spawned asynchronously — a diagnostic must not block
+the event loop during sandbox startup — and its exit status, output, and spawn
+error are collected into one value so no outcome is signalled by an exception.
+
+`ssh-add` exits 1 for **any** identity-listing failure, not only for an empty
+agent: OpenSSH prints `The agent has no identities.` on stdout for the empty
+case but `error fetching identities: ...` on stderr for a communication
+failure, and exits 1 in both. Exit status alone is therefore not a valid
+discriminator.
+
+| outcome                                     | action                        |
+| ------------------------------------------- | ----------------------------- |
+| exit 0 — agent has identities                | silent, proceed               |
+| exit 1 + `agent has no identities` in output | user-visible warning, proceed |
+| exit 1 + any other output                    | debug-level log only, proceed |
+| exit 2 — agent could not be contacted        | debug-level log only, proceed |
+| spawn error (`ssh-add` missing, timeout)     | debug-level log only, proceed |
+
+Surfacing: host-side `process.stderr.write`, the established convention in
+this package for user-facing messages emitted outside the Ink UI
+(`unconfiguredProviderGuard.ts`, `pathMigration.ts`). `debugLogger.warn` is
+**not** sufficient — it is suppressed unless debug output is enabled, which is
+exactly why the existing SSH warnings are invisible to users. The startup
+warnings file (`gemini-cli-warnings.txt`) is **not** usable here: it is written
+on the host but read inside the container, whose `os.tmpdir()` is `/tmp` and is
+not the mounted host temp directory.
+
+The preflight is strictly non-blocking: an empty agent is a legitimate state
+(the user may intend to add a key later, or may not need SSH at all), so
+forwarding proceeds unchanged in every case.
+
+Robustness: the agent query is bounded by a short timeout, and the timeout kill
+signal is `SIGKILL` so a child that ignores `SIGTERM` cannot hold sandbox
+startup open past the deadline.
+
+## Acceptance criteria
+
+- **AC1** When SSH agent forwarding is enabled (`sshAgent` not `off`, or `on`),
+  `SSH_AUTH_SOCK` is set, the socket exists on disk, and the container has been
+  configured to use the forwarded agent, LLxprt Code queries the host agent for
+  loaded identities.
+- **AC2** When the agent reports no identities, a warning is written to stderr
+  containing all three pieces of information from the issue: that the socket is
+  present but no identities are loaded, that git SSH auth will fail until a key
+  is loaded, and the remediation `ssh-add ~/.ssh/id_ed25519`.
+- **AC3** The check is non-blocking: the forwarding arguments and the returned
+  `SshAgentResult` are identical to today regardless of the outcome.
+- **AC4** When the agent reports identities, no user-visible warning is emitted.
+- **AC5** When the check is inconclusive (agent unreachable, identity listing
+  fails for a reason other than an empty agent, `ssh-add` not installed,
+  timeout, or any other failure), no empty-agent warning is emitted; a
+  debug-level log records the reason.
+- **AC6** No `ssh-add` process is spawned when forwarding is `off`, when
+  `SSH_AUTH_SOCK` is unset, when the socket path does not exist, or when the
+  selected platform helper declined to configure forwarding.
+- **AC7** The query runs against the socket that is being forwarded (explicit
+  `SSH_AUTH_SOCK` in the child environment) and is bounded by a timeout that is
+  enforced with `SIGKILL`.
+
+## Boundary cases
+
+- Exit 1 with `error fetching identities: communication with agent failed` on
+  stderr (socket accepts the connection then closes) → AC5, **not** the
+  empty-agent message.
+- No numeric status (killed by signal after the timeout, or a spawn error such
+  as `ENOENT` because `ssh-add` is not installed) → AC5.
+- Exit status 2 (agent unreachable) even though the socket file exists (stale
+  socket) → AC5.
+- Podman on macOS with a pre-existing non-host `--network`: the helper skips
+  forwarding, so no warning is emitted even with an empty agent → AC6.
+- Warning must not be emitted more than once per setup call.
+
+## Test plan (behavioral, no mock theater)
+
+All tests in `packages/cli/src/utils/sandbox-ssh-agent-preflight.test.ts`,
+driving the public `setupSshAgentForwarding` entry point. Tests assert
+observable behavior — the exact bytes written to stderr and the arguments and
+result produced — and model realistic `ssh-add` outcomes (status, signal,
+stdout, stderr, spawn error) rather than a synthetic exit code.
+
+1. **Empty agent warns (AC2)**: exit 1 with `The agent has no identities.` on
+   stdout → stderr receives exactly the three-line remediation message.
+2. **Empty agent still forwards (AC3)**: same outcome → the container
+   `SSH_AUTH_SOCK` argument is still added and the result is unchanged.
+3. **Loaded agent is silent (AC4)**: exit 0 with a key listing → no stderr
+   output; forwarding configured.
+4. **Non-empty listing failure is silent (AC5)**: exit 1 with
+   `error fetching identities: communication with agent failed` on stderr → no
+   stderr output; forwarding configured.
+5. **Agent unreachable is silent (AC5)**: exit 2 → no stderr output.
+6. **`ssh-add` not installed is silent (AC5)**: spawn error `ENOENT` → no
+   stderr output.
+7. **Timeout kill is silent (AC5)**: the child closes with no status after
+   `SIGKILL` → no stderr output.
+8. **Queries the forwarded socket under a bounded timeout (AC7)**: `ssh-add -l`
+   with `SSH_AUTH_SOCK` equal to the socket being forwarded, a finite timeout,
+   and `killSignal: 'SIGKILL'`.
+9. **Disabled paths do not query (AC6)**: `sshAgent: off`, missing
+   `SSH_AUTH_SOCK`, and a non-existent socket path each spawn nothing.
+10. **Declined forwarding does not warn (AC6)**: Podman on macOS with
+    `--network none` and an empty agent → forwarding is skipped and stderr
+    stays empty.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, and the CLI smoke test.

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -110,6 +110,9 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       'src/observation/jspTransport.test.ts',
       'src/observation/jspWiring.test.ts',
       'src/observation/observationTap.test.ts',
+      // Sandbox SSH agent preflight (issue #1699). Bun-native from the start
+      // and likewise excluded from the Vitest selection.
+      'src/utils/sandbox-ssh-agent-preflight.test.ts',
       'src/zed-integration/zed-session-lifecycle.test.ts',
       'test-utils/augment-bun-vi-cleanup.bun.ts',
     ],


### PR DESCRIPTION
## TLDR

When sandboxing is enabled and `sshAgent` is `auto`/`on`, LLxprt Code forwards the host `SSH_AUTH_SOCK` into the container. If the host agent is running but holds **zero identities**, forwarding is wired up perfectly and every git operation over SSH inside the sandbox still fails with `git@github.com: Permission denied (publickey).` Nothing points at the real cause, so the failure looks like broken forwarding rather than an empty agent.

This PR asks the agent what it is holding (`ssh-add -l`) once forwarding has actually been configured, and prints targeted remediation to stderr when the agent answers that it has none:

    SSH agent socket is present, but no identities are loaded (ssh-add -l reported empty).
    SSH forwarding is enabled, but git SSH auth will fail until a key is loaded.
    Try: ssh-add ~/.ssh/id_ed25519

Forwarding proceeds unchanged in every case — an empty agent is a legitimate state, so this is a diagnostic, never a gate.

**What reviewers should look at:** the empty-agent discrimination logic in `warnIfSshAgentHasNoIdentities` (see "Dive Deeper" — exit status alone is not a valid signal), and the placement of the probe after the platform dispatch.

## Dive Deeper

**Why exit status alone is not enough.** `ssh-add -l` exits 1 for *any* identity-listing failure. OpenSSH prints `The agent has no identities.` on stdout for the empty case, but `error fetching identities: communication with agent failed` on stderr when a stale socket accepts the connection and then drops it — and exits 1 in both cases. Keying off status 1 alone would confidently tell users to load a key when the real problem is a dead agent. The empty case is therefore confirmed from the reported output; every other outcome (status 2, non-empty status 1, missing `ssh-add`, timeout) is debug-level only. There is a dedicated regression test for the communication-failure case.

**Where the check runs.** After the platform dispatch, gated on the container actually being configured to use the forwarded agent (`containerWillReceiveSshAgent`). A platform helper can still decline — Podman on macOS refuses to override a non-host `--network` — and a warning claiming "SSH forwarding is enabled" would be wrong there. This is also covered by a test.

**Why stderr.** `debugLogger.warn` is suppressed unless debug output is enabled, which is exactly why the existing SSH warnings in this module are invisible to users. The startup-warnings file is not usable either: it is written on the host but read inside the container, whose `os.tmpdir()` is `/tmp` and not the mounted host temp directory. `process.stderr.write` is the established convention in this package for user-facing messages emitted outside the Ink UI (`unconfiguredProviderGuard.ts`, `pathMigration.ts`).

**Non-blocking.** The child is spawned asynchronously so a slow agent cannot freeze the event loop during sandbox startup, and the probe is bounded by a 5s timeout enforced with `SIGKILL` so a child that ignores `SIGTERM` cannot hold startup open past the deadline.

**Scope.** The issue also listed two optional enhancements — an interactive key-loading wizard and a CLI preflight flag. Both are deliberately **not** implemented; this PR delivers only the detection and guidance the issue asks for. Acceptance criteria and the test plan are recorded in `project-plans/issue1699-sandbox-ssh-agent-preflight/PLAN.md`.

## Reviewer Test Plan

Reproduce the original bug and then the new guidance on a machine with Docker or Podman:

1. Start a dedicated agent with no keys in it and point the shell at it:

   ```bash
   ssh-agent -a /tmp/empty-agent.sock
   export SSH_AUTH_SOCK=/tmp/empty-agent.sock
   ssh-add -l    # expect: "The agent has no identities."
   ```

2. Launch LLxprt in a sandbox with SSH forwarding enabled, e.g.:

   ```bash
   llxprt --sandbox-engine docker
   ```

3. Expect the three-line warning on stderr before the container UI starts, and expect the sandbox to launch normally (forwarding is still configured — check with `env | grep SSH_AUTH_SOCK` inside the container).

4. Now load a key and relaunch:

   ```bash
   ssh-add ~/.ssh/id_ed25519
   llxprt --sandbox-engine docker
   ```

   Expect no warning at all, and `git fetch` against a `git@github.com:` remote to succeed inside the sandbox.

5. Negative cases worth poking at: point `SSH_AUTH_SOCK` at a stale/dead socket file (expect **no** "load a key" advice — that would be a misdiagnosis), and set `sshAgent: off` (expect no `ssh-add` process to be spawned at all).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Full local suite plus lint/typecheck/format/build/copyright and the CLI smoke test were run on macOS; CI covers Linux (unit, `E2E sandbox:docker`, `E2E sandbox:none`) and macOS E2E. The empty-agent, communication-failure, unreachable-agent, missing-`ssh-add`, timeout, disabled-forwarding, and Podman-declines paths are all covered by behavioral tests that drive the public `setupSshAgentForwarding` entry point and assert the exact bytes written to stderr.

Local verification:

    npm run format                          pass
    npm run lint                            pass
    npm run typecheck                       pass
    bun scripts/check-copyright-year.ts     pass
    npm run build                           pass
    npm run test                            pass for every package this PR touches
    bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"   pass

The only failing tests locally are 8 pre-existing failures in `packages/tools` (`imageResize`, `fileUtils`, `read-many-files-filtering-behavior`, `filesystem-tools`) which reproduce identically on `main` at the same commit and are unrelated to this change (image decoding / sharp).

## Linked issues / bugs

Fixes #1699


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a startup warning when SSH agent forwarding is enabled but the host agent has no loaded identities.
  * SSH agent forwarding continues while clearly indicating the missing identity.

* **Documentation**
  * Added troubleshooting guidance for detecting an empty SSH agent and loading a key with `ssh-add`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->