### PR TITLE
fix(ci): prune symlinks in issue-planner confinement check

### DIFF
--- a/.github/workflows/issue-planner.yml
+++ b/.github/workflows/issue-planner.yml
@@ -193,13 +193,16 @@ jobs:
           # --allowed-tools syntax does NOT path-restrict writes (CLI
           # normalization strips parentheses), so this read-only checkout
           # except planner/ is the actual enforcement.
+          # Symlinks (workspace links, .bin shims) are lrwxrwxrwx on Linux and
+          # cannot be made read-only; prune them so the writable check does
+          # not false-positive.
           find . \
-            \( -path './.git' -o -path './planner' \) -prune -o \
+            \( -path './.git' -o -path './planner' -o -type l \) -prune -o \
             -exec chmod a-w {} +
           chmod u+w planner
           remaining_writable="$(
             find . \
-              \( -path './.git' -o -path './planner' \) -prune -o \
+              \( -path './.git' -o -path './planner' -o -type l \) -prune -o \
               \( -perm -u=w -o -perm -g=w -o -perm -o=w \) -print
           )"
           if [[ -n "${remaining_writable}" ]]; then

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -659,6 +659,14 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
     cwd: '.',
     files: ['scripts/tests/pr-review-walkthrough-sanitize.bun.test.ts'],
   },
+  {
+    // Bun-native regression test for the issue-planner filesystem-confinement
+    // step (issue #2960): vitest skips `*.bun.test.ts`; this runs under Bun's
+    // native runner only.
+    workspace: 'issue-planner-confinement',
+    cwd: '.',
+    files: ['scripts/tests/issue-planner-confinement.bun.test.ts'],
+  },
 ];
 
 /**

--- a/scripts/tests/issue-planner-confinement.bun.test.ts
+++ b/scripts/tests/issue-planner-confinement.bun.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Bun-native regression tests for the issue-planner filesystem-confinement
+// step (issue #2960). The confinement `find` previously did not prune
+// symlinks; because a symlink's own mode is always lrwxrwxrwx on Linux (and
+// chmod without -h cannot change it), `bun install`-materialized symlinks
+// false-positived the writable check and failed every issues-triggered run.
+// These run under Bun's native runner (see scripts/bun-test-manifest.ts);
+// vitest skips `*.bun.test.ts` files (see scripts/tests/vitest.config.ts).
+//
+// The textual suite guards the regression marker on hosts without bash; the
+// behavioral suite runs the actual confinement script under a POSIX shell.
+
+import { describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  asString,
+  findStep,
+  parseWorkflowYaml,
+  workflowJob,
+} from './typed-test-helpers.ts';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const WORKFLOW_PATH = '.github/workflows/issue-planner.yml';
+const CONFINEMENT_STEP = 'Confine filesystem for planner agent';
+
+function loadConfinementScript(): string {
+  const source = fs.readFileSync(path.join(ROOT, WORKFLOW_PATH), 'utf8');
+  const workflow = parseWorkflowYaml(source);
+  const planJob = workflowJob(workflow, 'plan');
+  const step = findStep(planJob, CONFINEMENT_STEP);
+  if (!step) {
+    throw new Error(
+      `Confinement step "${CONFINEMENT_STEP}" not found in ${WORKFLOW_PATH}; the step may have been renamed. Update CONFINEMENT_STEP to match.`,
+    );
+  }
+  return asString(step.run);
+}
+
+/**
+ * Lazily detect a POSIX `bash` with GNU find/chmod. Cached so detection runs
+ * at most once per process (not as a bare import-time side effect).
+ */
+let detectedBash: string | null | undefined;
+function detectBash(): string | null {
+  if (detectedBash !== undefined) return detectedBash;
+  try {
+    const result = spawnSync('bash', ['-c', 'echo ok'], { encoding: 'utf8' });
+    detectedBash =
+      result.status === 0 && result.stdout.trim() === 'ok' ? 'bash' : null;
+  } catch {
+    detectedBash = null;
+  }
+  return detectedBash;
+}
+
+/**
+ * Register a behavioral test that runs only under bash, otherwise skip.
+ * Centralizes platform gating so the suite never fails on a missing shell
+ * (e.g. Windows). Temp-dir setup/teardown is owned here so every test cleans
+ * up via a single finally.
+ */
+function bashOnly(name: string, fn: (dir: string) => void): void {
+  if (!detectBash()) {
+    it.skip(`${name} (requires bash)`, () => {});
+    return;
+  }
+  it(name, () => {
+    const dir = makeTempDir('planner-confinement-');
+    try {
+      fn(dir);
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+}
+
+function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/**
+ * Recursively restore write bits so rmSync can delete a read-only tree. Best
+ * effort: a chmod failure is swallowed so one stuck entry never prevents the
+ * directory (and its siblings) from being removed.
+ */
+function restoreWriteBits(root: string): void {
+  if (!fs.existsSync(root)) return;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const target = path.join(root, entry.name);
+    if (entry.isDirectory()) restoreWriteBits(target);
+    if (!entry.isSymbolicLink()) {
+      try {
+        fs.chmodSync(target, entry.isDirectory() ? 0o700 : 0o600);
+      } catch {
+        /* best-effort cleanup; rmSync still runs */
+      }
+    }
+  }
+  try {
+    fs.chmodSync(root, 0o700);
+  } catch {
+    /* best-effort cleanup; rmSync still runs */
+  }
+}
+
+function removeTempDir(dir: string): void {
+  restoreWriteBits(dir);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('issue-planner confinement script (textual)', () => {
+  const script = loadConfinementScript();
+
+  it('prunes symlinks in the confinement logic', () => {
+    // Whitespace-tolerant: counts `type l` occurrences regardless of line
+    // breaks, added comments, or spacing. At least two means both the chmod
+    // pass and the writable-verification pass exclude symlinks.
+    const matches = script.match(/type\s+l/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('still enforces confinement: keeps -prune, remaining_writable, and no suppression', () => {
+    expect(script).toContain('-prune');
+    expect(script).toContain('remaining_writable');
+    expect(script).toContain('chmod u+w planner');
+    expect(script).not.toContain('|| true');
+    expect(script).not.toContain('2>/dev/null');
+  });
+
+  it('still checks for writable real files (symlink prune did not drop detection)', () => {
+    // The symlink prune must not remove the writable-bit detection itself.
+    expect(script).toContain('-perm -u=w');
+    expect(script).toContain('-perm -g=w');
+    expect(script).toContain('-perm -o=w');
+  });
+});
+
+describe('issue-planner confinement script (behavioral)', () => {
+  bashOnly(
+    'passes when node_modules contains a symlink (regression for #2960)',
+    (dir) => {
+      fs.mkdirSync(path.join(dir, '.git'));
+      fs.mkdirSync(path.join(dir, 'planner'));
+      fs.mkdirSync(path.join(dir, 'src', 'nested'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'src', 'nested', 'code.js'), 'code');
+      fs.mkdirSync(path.join(dir, 'node_modules', '.bin'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'node_modules', 'real-cli'), 'cli');
+      fs.symlinkSync(
+        path.join(dir, 'node_modules', 'real-cli'),
+        path.join(dir, 'node_modules', '.bin', 'llxprt'),
+      );
+
+      const script = loadConfinementScript();
+      const result = spawnSync('bash', ['-c', script], {
+        cwd: dir,
+        encoding: 'utf8',
+      });
+      expect(result.status, String(result.stderr ?? '')).toBe(0);
+      // The real source file was made read-only.
+      expect(
+        fs.statSync(path.join(dir, 'src', 'nested', 'code.js')).mode & 0o222,
+      ).toBe(0);
+      // planner/ and .git/ remain owner-writable (pruned from the chmod pass).
+      expect(fs.statSync(path.join(dir, 'planner')).mode & 0o200).toBe(0o200);
+      expect(fs.statSync(path.join(dir, '.git')).mode & 0o200).toBe(0o200);
+    },
+  );
+});

--- a/scripts/tests/issue-planner-confinement.bun.test.ts
+++ b/scripts/tests/issue-planner-confinement.bun.test.ts
@@ -112,8 +112,15 @@ function restoreWriteBits(root: string): void {
 }
 
 function removeTempDir(dir: string): void {
-  restoreWriteBits(dir);
-  fs.rmSync(dir, { recursive: true, force: true });
+  try {
+    restoreWriteBits(dir);
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (error) {
+    // Best-effort cleanup: surface the failure so it is visible, but never
+    // re-throw — a cleanup error thrown from `finally` would mask the real
+    // assertion failure. rmSync(force) already tolerates a missing path.
+    console.warn(`temp cleanup failed for ${dir}:`, error);
+  }
 }
 
 describe('issue-planner confinement script (textual)', () => {


### PR DESCRIPTION
fixes #2960

## Summary

The autonomous **Issue Planner** workflow (`issue-planner.yml`) has been failing on every `issues`-triggered run since PR #2757 added a `bun install` step. Instead of producing a plan, it posted a generic **"LLxprt Issue Planner — infrastructure failure / The planner did not produce output"** comment (see [issue #2960](https://github.com/vybestack/llxprt-code/issues/2960)).

## Root cause

PR #2757 added an `Install planner script dependencies` → `bun install` step, which materializes `node_modules/` containing symlinks (workspace package links and `.bin/*` shims).

The subsequent **"Confine filesystem for planner agent"** step enforces a read-only checkout (except `planner/`) by chmod-ing everything read-only and then verifying no writable paths remain. That verification `find` did **not** exclude symlinks:

```bash
find . \( -path './.git' -o -path './planner' \) -prune -o \
  \( -perm -u=w -o -perm -g=w -o -perm -o=w \) -print
```

On Linux a symlink's own mode is **always `lrwxrwxrwx`** (0777), and `chmod` (without `-h`) **cannot** change it. So every symlink in `node_modules/` was reported as "remaining writable" → `remaining_writable` non-empty → the confinement step `exit 1` → the **"Run planner agent"** step was skipped → `planner/comment.md` stayed empty → `ensureCommentBody('')` substituted the generic infrastructure-failure body.

In short: the confinement check that *protects* the planner agent was incorrectly concluding the checkout was unsafe purely because of symlink modes.

## Fix

Add `-type l` to the prune group of **both** `find` passes in the confinement step (the `chmod a-w` pass and the writable-verification pass), so symlinks are pruned from both:

```diff
-          \( -path './.git' -o -path './planner' \) -prune -o \
+          \( -path './.git' -o -path './planner' -o -type l \) -prune -o \
```

This is correct and safe: a symlink's **target** resolves inside the checkout and is already made read-only by the `chmod a-w` pass; only the symlink *itself* (whose mode is immutable on Linux) is excluded from the check. No suppression directives (`|| true`, `2>/dev/null`) were added.

## Tests

Per the repo's **bun-native mandate** (new tests must be bun, not vitest/node), added `scripts/tests/issue-planner-confinement.bun.test.ts` (named `*.bun.test.ts` so vitest's exclude glob skips it; registered in the bun-native manifest so it gates CI via `bun_native_test_parity`):

- **Textual** (run everywhere): the confinement script prunes symlinks (`-type l`) in both find passes; still keeps `-prune`, `remaining_writable`, `chmod u+w planner`; still contains the writable-bit detection checks (`-perm -u=w/-g=w/-o=w`); and does **not** contain `|| true` or `2>/dev/null`.
- **Behavioral** (bash-gated; skips cleanly on hosts without bash, e.g. Windows — runs in CI on Linux): builds a temp tree with a real `node_modules/.bin/llxprt` symlink and runs the **actual** confinement script, asserting it exits `0`, the real source file is read-only, and `planner/` + `.git/` stay owner-writable. This is the direct regression for #2960.

The existing vitest `scripts/tests/issue-planner.test.ts` is unchanged — its confinement tests create no symlinks, so `-type l` pruning is a no-op for them, and all of their textual assertions (`-prune`, `remaining_writable`, no `|| true`, no `2>/dev/null`) are preserved.

## Verification

- `bun test scripts/tests/issue-planner-confinement.bun.test.ts` → 3 pass, 1 skip (bash-gated), 0 fail.
- Existing `scripts/tests/issue-planner.test.ts` confinement tests unchanged/passing.
- `tsc --project tsconfig.scripts.json --noEmit` → clean.
- `eslint` on changed TS → clean (max-warnings 0).
- `prettier --check` → clean.
- Pre-push OCR review looped to convergence; correctness-relevant findings addressed.

## Checklist

- [x] Root cause diagnosed and documented in #2960
- [x] Fix is minimal and scoped to the confinement step
- [x] New test is bun-native (per mandate), registered in the manifest
- [x] No new lint suppressions / severity changes
- [x] Host behavior unchanged (only the CI confinement step's `find` is affected)
