### PR TITLE
Publish todos after session rebind and end the turn on cancel (Fixes #2963, Fixes #2964)

### DIFF
--- a/packages/cli/src/cliSessionBootstrap.ts
+++ b/packages/cli/src/cliSessionBootstrap.ts
@@ -206,15 +206,12 @@ async function releaseResumedResources(
  */
 function setupObservation(config: Config): void {
   const projectRoot = config.getProjectRoot();
-  initializeObservationProducer(
-    {
-      repository: basename(projectRoot),
-      path: projectRoot,
-      agentKind: 'llxprt',
-      displayName: basename(projectRoot),
-    },
-    config.getSessionId(),
-  );
+  initializeObservationProducer({
+    repository: basename(projectRoot),
+    path: projectRoot,
+    agentKind: 'llxprt',
+    displayName: basename(projectRoot),
+  });
 }
 
 function registerRecordingCleanup(

--- a/packages/cli/src/observation/jspProducer.test.ts
+++ b/packages/cli/src/observation/jspProducer.test.ts
@@ -110,7 +110,7 @@ describe('JspProducer', () => {
     producer.observeActivityChanged('acting');
     producer.observeWaitOpened('permission');
     producer.observeWaitResolved();
-    producer.observeTodosReplaced('session', undefined, [
+    producer.observeTodosReplaced(undefined, [
       { content: 'Ship it', status: 'in_progress' },
     ]);
     producer.observeToolCreated('read_file', 'proposed');
@@ -140,17 +140,50 @@ describe('JspProducer', () => {
     producer.stop();
   });
 
-  it('filters todos and keeps the latest-created tool as the headline', async () => {
+  it('keeps publishing todos after the CLI session id is rebound', async () => {
+    // Regression for #2963. `Config.adoptSessionId` rebinds the session id at
+    // runtime (resume, session browser, /chat resume). The producer used to
+    // compare each replacement against a session id captured at startup, so
+    // every list published after such a rebind was silently dropped and Jefe
+    // rendered the pane as unknown for the rest of the session. Todos are the
+    // only field gated that way, which is why status and the last message
+    // kept working.
     const { hooks, published } = makeHarness();
     const producer = new JspProducer(bootstrap, nativeSession, hooks);
-    producer.setSession('mine', 'primary');
+    producer.setAgentScope(undefined);
     producer.start();
     await producer.flush();
     published.length = 0;
-    producer.observeTodosReplaced('other', 'agent-2', [
+
+    // The tool dispatcher always supplies a concrete agent id, and the primary
+    // agent's is the default scope; the session id is not part of the decision.
+    producer.observeTodosReplaced('primary', [
+      { content: 'after resume', status: 'in_progress' },
+    ]);
+    await producer.flush();
+
+    expect(eventTypes(published)).toStrictEqual(['todos.replaced']);
+    expect(producer.snapshot().todos).toMatchObject({
+      availability: 'known',
+      value: {
+        revision: 1,
+        items: [{ text: 'after resume', completed: false }],
+      },
+    });
+    producer.stop();
+  });
+
+  it('filters todos and keeps the latest-created tool as the headline', async () => {
+    const { hooks, published } = makeHarness();
+    const producer = new JspProducer(bootstrap, nativeSession, hooks);
+    producer.setAgentScope('primary');
+    producer.start();
+    await producer.flush();
+    published.length = 0;
+    producer.observeTodosReplaced('agent-2', [
       { content: 'not mine', status: 'pending' },
     ]);
-    producer.observeTodosReplaced('mine', 'primary', [
+    producer.observeTodosReplaced('primary', [
       { content: 'mine', status: 'completed' },
     ]);
     producer.observeToolCreated('read_file', 'proposed');
@@ -177,7 +210,7 @@ describe('JspProducer', () => {
     const producer = new JspProducer(bootstrap, nativeSession, hooks);
     producer.start();
     await producer.flush();
-    producer.observeTodosReplaced('session', undefined, [
+    producer.observeTodosReplaced(undefined, [
       { content: 'Completed task', status: 'completed' },
     ]);
     producer.observeAssistantMessageDisplayed('Committed reply', 4999);

--- a/packages/cli/src/observation/jspProducer.ts
+++ b/packages/cli/src/observation/jspProducer.ts
@@ -135,7 +135,6 @@ export class JspProducer {
   private readonly queue: JspBoundedQueue;
   private readonly identity: JspProducerIdentity;
   private state: JspProducerState;
-  private sessionId: string | null = null;
   private agentId = DEFAULT_AGENT_SCOPE;
   private todoRevision = 0;
   private started = false;
@@ -177,8 +176,12 @@ export class JspProducer {
     });
   }
 
-  setSession(sessionId: string, agentId: string | undefined): void {
-    this.sessionId = sessionId;
+  /**
+   * Bind the producer to an agent scope. Deliberately does not take a session
+   * id: `Config.adoptSessionId` rebinds the CLI session at runtime, so a copy
+   * held here would go stale and silently filter this agent's own events.
+   */
+  setAgentScope(agentId: string | undefined): void {
     this.agentId = agentId ?? DEFAULT_AGENT_SCOPE;
   }
 
@@ -456,15 +459,17 @@ export class JspProducer {
   }
 
   observeTodosReplaced(
-    sessionId: string,
     agentId: string | undefined,
     todos: readonly NativeTodoLike[],
   ): void {
+    // Scope by agent only. Subagent todos stay out of the projection (they are
+    // out of scope for the observation contract), but the CLI session id must
+    // NOT gate publication: `Config.adoptSessionId` rebinds it at runtime when
+    // a conversation is resumed or picked from the session browser, and this
+    // producer is constructed once per process. Comparing against a cached copy
+    // silently dropped every later replacement for the rest of the session.
     const scopedAgent = agentId ?? DEFAULT_AGENT_SCOPE;
-    if (
-      this.sessionId !== null &&
-      (sessionId !== this.sessionId || scopedAgent !== this.agentId)
-    ) {
+    if (scopedAgent !== this.agentId) {
       return;
     }
     this.todoRevision += 1;

--- a/packages/cli/src/observation/jspWiring.test.ts
+++ b/packages/cli/src/observation/jspWiring.test.ts
@@ -138,7 +138,7 @@ describe('createTodoObservationSubscription', () => {
     });
     unsubscribe();
 
-    expect(observer).toHaveBeenCalledWith('session-1', 'default', todos);
+    expect(observer).toHaveBeenCalledWith('default', todos);
 
     // A stale listener on the global emitter would keep publishing after the
     // session is gone, so prove the unsubscribe actually detaches it.

--- a/packages/cli/src/observation/jspWiring.ts
+++ b/packages/cli/src/observation/jspWiring.ts
@@ -36,14 +36,10 @@ let tap: ObservationTap = createObservationTap(null);
 let unsubscribeTodos: (() => void) | null = null;
 
 export function createTodoObservationSubscription(
-  observer: (
-    sessionId: string,
-    agentId: string | undefined,
-    todos: readonly Todo[],
-  ) => void,
+  observer: (agentId: string | undefined, todos: readonly Todo[]) => void,
 ): () => void {
   const listener = (event: TodoUpdateEvent) => {
-    observer(event.sessionId, event.agentId, event.todos);
+    observer(event.agentId, event.todos);
   };
   todoEvents.onTodoUpdated(listener);
   return () => todoEvents.offTodoUpdated(listener);
@@ -132,7 +128,6 @@ export function createObservationProducer(
 
 export function initializeObservationProducer(
   context: ObservationSessionContext,
-  sessionId: string,
 ): void {
   unsubscribeTodos?.();
   unsubscribeTodos = null;
@@ -147,7 +142,7 @@ export function initializeObservationProducer(
   if (producer === null) {
     return;
   }
-  producer.setSession(sessionId, undefined);
+  producer.setAgentScope(undefined);
   unsubscribeTodos = createTodoObservationSubscription(observeTodosReplaced);
   tap = createObservationTap({
     onTurnStarted: () => producer?.observeTurnStarted(),
@@ -197,6 +192,16 @@ export function observeTurnFailed(): void {
   isolate(() => tap.onTurnEnded('failed'));
 }
 
+/**
+ * Close the observed turn when the user cancels interactively. The abort does
+ * not surface as a terminal `done` event and does not reach the submit path's
+ * failure handler, so without this the producer would keep reporting an active
+ * turn with a growing elapsed time for the rest of the session.
+ */
+export function observeTurnCancelled(): void {
+  isolate(() => tap.onTurnEnded('cancelled'));
+}
+
 export function observeAgentEvent(event: AgentEvent): void {
   isolate(() => tap.processEvent(event));
 }
@@ -209,9 +214,8 @@ export function observeAssistantMessageCommitted(
 }
 
 export function observeTodosReplaced(
-  sessionId: string,
   agentId: string | undefined,
   todos: readonly Todo[],
 ): void {
-  isolate(() => producer?.observeTodosReplaced(sessionId, agentId, todos));
+  isolate(() => producer?.observeTodosReplaced(agentId, todos));
 }

--- a/packages/cli/src/observation/observationTap.test.ts
+++ b/packages/cli/src/observation/observationTap.test.ts
@@ -183,6 +183,39 @@ describe('createObservationTap', () => {
     }
   });
 
+  it('ends a turn at most once no matter which exit path fires first', () => {
+    // Regression for #2964. A turn can be closed by a terminal `done` event, by
+    // the submit path's failure handler, or by the interactive cancel handler.
+    // Interactive cancel reaches none of the other two, so it must close the
+    // turn itself -- but a late `done` must then not close it a second time.
+    const cancelFirst: string[] = [];
+    const cancelTap = createObservationTap(noopTarget(cancelFirst));
+    cancelTap.onTurnStarted();
+    cancelTap.onTurnEnded('cancelled');
+    cancelTap.processEvent({ type: 'done', reason: 'aborted' } as AgentEvent);
+    expect(
+      cancelFirst.filter((call) => call.startsWith('turn.ended')),
+    ).toStrictEqual(['turn.ended:cancelled']);
+
+    // And the reverse order: a normal completion wins over a later cancel.
+    const doneFirst: string[] = [];
+    const doneTap = createObservationTap(noopTarget(doneFirst));
+    doneTap.onTurnStarted();
+    doneTap.processEvent({ type: 'done', reason: 'stop' } as AgentEvent);
+    doneTap.onTurnEnded('cancelled');
+    expect(
+      doneFirst.filter((call) => call.startsWith('turn.ended')),
+    ).toStrictEqual(['turn.ended:completed']);
+
+    // Ending a turn that was never started is a no-op, not a phantom end.
+    const neverStarted: string[] = [];
+    const idleTap = createObservationTap(noopTarget(neverStarted));
+    idleTap.onTurnEnded('cancelled');
+    expect(
+      neverStarted.filter((call) => call.startsWith('turn.ended')),
+    ).toStrictEqual([]);
+  });
+
   it('maps every ToolUpdateStatus to the correct JSP tool phase', () => {
     for (const [status, phase] of [
       ['validating', 'proposed'],

--- a/packages/cli/src/observation/observationTap.ts
+++ b/packages/cli/src/observation/observationTap.ts
@@ -127,7 +127,7 @@ function routeEvent(
   event: AgentEvent,
   target: ObservationTapTarget,
   scope: TurnScope,
-  resetTurnScopedState: () => void,
+  endTurn: (outcome: JspTurnOutcome) => void,
 ): void {
   switch (event.type) {
     case 'text':
@@ -160,8 +160,7 @@ function routeEvent(
       target.onSourceError(event.error.message, 'AGENT_ERROR');
       break;
     case 'done':
-      resetTurnScopedState();
-      target.onTurnEnded(mapDoneReason(event.reason));
+      endTurn(mapDoneReason(event.reason));
       break;
     default:
       break;
@@ -201,17 +200,33 @@ export function createObservationTap(
     }
   };
 
+  /**
+   * A turn can now be closed from three places: a terminal `done` event, the
+   * submit path's failure handler, and the interactive cancel handler. Only the
+   * first of those may take effect, or the observer would see several ends for
+   * one turn. Ending a turn that was never started is likewise a no-op.
+   */
+  let turnOpen = false;
+  const endTurn = (outcome: JspTurnOutcome): void => {
+    if (!turnOpen) {
+      return;
+    }
+    turnOpen = false;
+    resetTurnScopedState();
+    target.onTurnEnded(outcome);
+  };
+
   return {
     onTurnStarted(): void {
       resetTurnScopedState();
+      turnOpen = true;
       target.onTurnStarted();
     },
     onTurnEnded(outcome: JspTurnOutcome): void {
-      resetTurnScopedState();
-      target.onTurnEnded(outcome);
+      endTurn(outcome);
     },
     processEvent(event: AgentEvent): void {
-      routeEvent(event, target, scope, resetTurnScopedState);
+      routeEvent(event, target, scope, endTurn);
     },
     onFlushCommitted(content: string, committedMs: number): void {
       if (content.length > 0) {

--- a/packages/cli/src/ui/hooks/agentStream/useAgentStreamLifecycle.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentStreamLifecycle.ts
@@ -18,6 +18,7 @@ import {
   StreamingState,
   type HistoryItemWithoutId,
 } from '../../types.js';
+import { observeTurnCancelled } from '../../../observation/jspWiring.js';
 import { useShellCommandProcessor } from '../shellCommandProcessor.js';
 import {
   type TrackedCancelledToolCall,
@@ -254,6 +255,7 @@ export function useCancellation(
     addItem({ type: MessageType.INFO, text: 'Request cancelled.' }, Date.now());
     setPendingHistoryItem(null);
     onCancelSubmit();
+    observeTurnCancelled();
     setIsResponding(false);
     setShellInputFocused(false);
   }, [


### PR DESCRIPTION
Two field-reported defects in the JSP/1 observation producer, both introduced by #2897. Jefe was rendering faithfully in both cases; the producer was at fault.

## Todos always render as unknown (#2963)

`observeTodosReplaced` compared every incoming event against a session id captured once, at producer construction:

    if (this.sessionId !== null && (sessionId !== this.sessionId || ...)) return;

`Config.adoptSessionId` rebinds the session id at runtime — resuming a conversation, `/chat resume`, the session browser — and the producer is built once per process, so after any of those the comparison fails forever. Every replacement was silently discarded, `state.todos` stayed `null`, and the snapshot published todos as `unknown`.

The session id gates exactly one field. Turn, activity, wait, tool and last-message all publish unconditionally. That is precisely why the report was "the last message and status are fine, the todo list is always unknown", and why it looked intermittent: only agents that had adopted a session were affected.

The producer's wire identity is agent id + lifecycle generation + source epoch. The CLI session id is conversation metadata that is *allowed* to change, so it has no business gating publication. The check is now agent-scope only, which still keeps subagent lists out of the projection (subagents are out of scope per #2779).

The dead plumbing is removed rather than left as write-only state: `setSession` becomes `setAgentScope`, and the session id is dropped from `observeTodosReplaced`, the todo subscription, and `initializeObservationProducer`.

## Cancelling a prompt leaves Preview stuck on Working (#2964)

A turn was closed from exactly two places: a terminal `done` event, and `useSubmitQuery`'s `catch` when `executeStream` throws.

Interactive cancel reaches neither. `useAgentStreamLifecycle` aborts the controller and tears down UI state, but never notifies the observation layer — the file had no observation import at all. The abort does not surface as a terminal `done`, and it does not propagate as a throw. `currentTurn` therefore survived, and because `buildSnapshot` derives `elapsed_ms` from the turn anchor, every later snapshot reported a live turn with a growing elapsed time. Jefe's status precedence correctly rendered that as Working.

The cancel handler now reports the turn cancelled.

Since that introduces a third exit path, turn end is now idempotent: the first close wins, and ending a turn that never started is a no-op. Worth noting explicitly — an earlier automated review raised this exact idempotency concern and I dismissed it on the grounds that the `done` and throw paths were mutually exclusive. That was true at the time and is not true any more.

## Tests

- `keeps publishing todos after the CLI session id is rebound` — pins that publication does not depend on a session id.
- `ends a turn at most once no matter which exit path fires first` — cancel-then-done, done-then-cancel, and end-without-start.
- Existing todo-filter test retained, so subagent lists are still excluded.

## Verification

- `bun test src/observation/` — 104 pass, 0 fail
- `npm run build` — exit 0 (confirms the signature changes typecheck across packages)
- `npm run lint` — exit 0
- `npx prettier --check .` — exit 0
