### PR TITLE
Stop forwarding Google credentials into the container sandbox (Fixes #2946)

### DIFF
--- a/dev-docs/test-runner-inventory.md
+++ b/dev-docs/test-runner-inventory.md
@@ -6,27 +6,27 @@ Bun execution command (or explains why it still requires Vitest).
 
 ## Summary
 
-| Area                          | Total test files | Bun-native    | Vitest (retained) | Deferred to future slices |
-| ----------------------------- | ---------------- | ------------- | ----------------- | ------------------------- |
-| packages/a2a-server           | 15               | 15            | 0                 | 0                         |
-| packages/agents               | 348              | 0             | 0                 | 348                       |
-| packages/auth                 | 37               | 37            | 0                 | 0                         |
-| packages/cli                  | 659              | 11            | 0                 | 648                       |
-| packages/core                 | 322              | 322           | 0                 | 0                         |
-| packages/ide-integration      | 10               | 0             | 0                 | 10                        |
-| packages/lsp                  | 0                | all           | 0                 | 0                         |
-| packages/mcp                  | 46               | 0             | 0                 | 46                        |
-| packages/policy               | 6                | 6             | 0                 | 0                         |
-| packages/providers            | 478              | 1             | 0                 | 477                       |
-| packages/settings             | 13               | 0             | 0                 | 13                        |
-| packages/storage              | 31               | 7             | 0                 | 24                        |
-| packages/telemetry            | 11               | 11 (manifest) | 0                 | 0                         |
-| packages/test-utils           | 5                | 2             | 1                 | 2                         |
-| packages/tools                | 62               | 0             | 0                 | 62                        |
-| packages/vscode-ide-companion | 6                | 0             | 0                 | 6                         |
-| scripts/tests                 | 97               | 0             | 0                 | 97                        |
-| evals                         | 2                | 0             | 0                 | 2                         |
-| integration-tests             | 26               | 0             | 0                 | 26                        |
+| Area                          | Total test files | Bun-native     | Vitest (retained) | Deferred to future slices |
+| ----------------------------- | ---------------- | -------------- | ----------------- | ------------------------- |
+| packages/a2a-server           | 15               | 15             | 0                 | 0                         |
+| packages/agents               | 349              | 2 (manifest)   | 0                 | 347                       |
+| packages/auth                 | 37               | 37             | 0                 | 0                         |
+| packages/cli                  | 659              | 12 (manifest)  | 0                 | 647                       |
+| packages/core                 | 322              | 322            | 0                 | 0                         |
+| packages/ide-integration      | 10               | 0              | 0                 | 10                        |
+| packages/lsp                  | 0                | all            | 0                 | 0                         |
+| packages/mcp                  | 46               | 0              | 0                 | 46                        |
+| packages/policy               | 6                | 6              | 0                 | 0                         |
+| packages/providers            | 479              | 479 (manifest) | 0                 | 0                         |
+| packages/settings             | 13               | 0              | 0                 | 13                        |
+| packages/storage              | 31               | 7              | 0                 | 24                        |
+| packages/telemetry            | 11               | 11 (manifest)  | 0                 | 0                         |
+| packages/test-utils           | 5                | 2              | 1                 | 2                         |
+| packages/tools                | 62               | 0              | 0                 | 62                        |
+| packages/vscode-ide-companion | 6                | 0              | 0                 | 6                         |
+| scripts/tests                 | 97               | 0              | 0                 | 97                        |
+| evals                         | 2                | 0              | 0                 | 2                         |
+| integration-tests             | 26               | 0              | 0                 | 26                        |
 
 ## Fully migrated workspaces (Bun-native as primary `test` script)
 
@@ -127,9 +127,16 @@ All 6 test files are Bun-native. The `research/` directory is excluded via
 These files run under Bun via `scripts/run_bun_tests.ts` but their workspace
 primary `test` script still uses Vitest for the bulk of files.
 
-### packages/cli (11 files)
+### packages/agents (2 files)
+
+- `src/core/CompressionProfileResolver.proxyKeyStorage.test.ts`
+- `test-bun/subagentAnthropicTextSettings.issue1738.bun.ts`
+
+### packages/cli (12 files)
 
 - `src/__tests__/cliSessionDispatch.characterization.test.tsx`
+- `src/utils/sandbox-containers.test.ts`
+- `src/zed-integration/zed-session-lifecycle.test.ts`
 - `test-utils/augment-bun-vi-cleanup.bun.ts`
 
 The JSP/1 observation producer suite (issue #2779) is Bun-native from the start
@@ -158,9 +165,17 @@ runner.
 
 ### packages/core — fully migrated (see above)
 
-### packages/providers (1 file)
+### packages/providers (manifest-driven, ~474 files)
 
-- `src/BaseProvider.test.ts`
+The providers workspace primary `test` script is fully manifest-driven
+(`bun ../../scripts/run_bun_tests.ts --workspace providers`). All listed
+manifest files run under Bun in isolated processes. The manifest has grown
+well beyond the single file listed at issue #2578 time; see
+`scripts/bun-test-manifest.ts` for the authoritative file list. Notable
+#2946 additions:
+
+- `src/__tests__/BaseProvider.proxyKeyStorage.test.ts`
+- `src/gemini/GeminiProvider.auth.test.ts`
 
 ### packages/storage (7 files)
 
@@ -249,9 +264,9 @@ will be migrated in a bounded vertical slice:
 5. **packages/vscode-ide-companion** (6 files) — Slice 6
 6. **packages/mcp** (46 files) — Slice 7
 7. **packages/tools** (62 files) — Slice 8
-8. **packages/providers** (477 files) — Slice 10
-9. **packages/agents** (348 files) — Slice 11
-10. **packages/cli** (648 files) — Slice 12
+8. **packages/providers** (~4 remaining files) — Slice 10
+9. **packages/agents** (~346 remaining files) — Slice 11
+10. **packages/cli** (~646 remaining files) — Slice 12
 11. **scripts/tests** (97 files) — Slice 13
 12. **evals** (2 files) — Slice 14
 13. **integration-tests** (26 files) — Slice 15

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -42,10 +42,22 @@ llxprt --sandbox-engine podman "review this code"
   (`cpus`, `memory`, `pids`).
 - Exposure of the OS keyring and system token store to tool execution. In
   container mode (Docker or Podman), the OS keyring is not accessible from
-  inside the container. However, API keys (`GEMINI_API_KEY`, `GOOGLE_API_KEY`),
-  Google application default credential files, and the `gcloud` configuration
-  directory currently leak into the container as a known defect — see
-  [Known credential leakage in containers](#known-credential-leakage-in-containers).
+  inside the container. `GEMINI_API_KEY` and `GOOGLE_API_KEY` are no longer
+  forwarded as container environment variables, and the `~/.config/gcloud`
+  directory and the `GOOGLE_APPLICATION_CREDENTIALS` file are no longer mounted
+  (and that variable is no longer set inside the container). Gemini API keys
+  saved on the host with `/key save` and referenced by `auth-key-name` are
+  resolved inside the container through the
+  [credential proxy](#credential-proxy-container-mode-only) — the supported way
+  to authenticate Gemini from a sandbox. Note that Vertex AI, application
+  default credentials (ADC), and service-account authentication do **not** work
+  from inside a container sandbox (see
+  [Credential handling in containers](#credential-handling-in-containers)). The
+  LLxprt global configuration directory is still mounted into the container, so
+  a profile containing an inline `auth-key`, or a global `.env`, remains
+  readable from inside it (see issue
+  [#2957](https://github.com/vybestack/llxprt-code/issues/2957)); prefer
+  `/key save` over inline profile keys.
 
 **What sandboxing is NOT intended to protect against:**
 
@@ -56,8 +68,7 @@ llxprt --sandbox-engine podman "review this code"
   sandbox to support development workflows (the credential proxy, SSH agent
   forwarding, git config passthrough, and paths you explicitly mount) — see
   [Intentional boundary crossings](#intentional-boundary-crossings). These are
-  opt-in or design choices, separate from the known credential leakage defect
-  described below.
+  opt-in or design choices.
 - Network exfiltration of data that networking is left enabled for. If
   `network` is `on`, outbound network access is available to tool execution.
 
@@ -113,14 +124,14 @@ confirmation.
 The boundary differs by engine. The table summarizes what each engine isolates
 by default. Detailed limitations follow.
 
-| Boundary          | Docker / Podman (container)                                                                                               | Seatbelt (macOS `sandbox-exec`)                            |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| Filesystem writes | Restricted to mounted paths (project, temp)                                                                               | Restricted to allow-listed paths (project, temp, config)   |
-| Filesystem reads  | Restricted to mounted paths                                                                                               | Broader read access; writes are the primary restriction    |
-| Network           | Configurable (`on` / `off` / `proxied`)                                                                                   | Configurable; selects a matching built-in Seatbelt profile |
-| Resource limits   | Enforced (`cpus`, `memory`, `pids`)                                                                                       | Not available                                              |
-| Process isolation | Separate container process namespace                                                                                      | Runs directly on your host                                 |
-| Stored secrets    | OS keyring not accessible; API keys and credential files currently **leak** into the container (known defect — see below) | Host keyring and token store are fully available           |
+| Boundary          | Docker / Podman (container)                                                                                                                                                                                                                                                                                                                                                                                                                                 | Seatbelt (macOS `sandbox-exec`)                            |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Filesystem writes | Restricted to mounted paths (project, temp)                                                                                                                                                                                                                                                                                                                                                                                                                 | Restricted to allow-listed paths (project, temp, config)   |
+| Filesystem reads  | Restricted to mounted paths                                                                                                                                                                                                                                                                                                                                                                                                                                 | Broader read access; writes are the primary restriction    |
+| Network           | Configurable (`on` / `off` / `proxied`)                                                                                                                                                                                                                                                                                                                                                                                                                     | Configurable; selects a matching built-in Seatbelt profile |
+| Resource limits   | Enforced (`cpus`, `memory`, `pids`)                                                                                                                                                                                                                                                                                                                                                                                                                         | Not available                                              |
+| Process isolation | Separate container process namespace                                                                                                                                                                                                                                                                                                                                                                                                                        | Runs directly on your host                                 |
+| Stored secrets    | OS keyring not accessible; `GEMINI_API_KEY`/`GOOGLE_API_KEY` are not forwarded and gcloud/ADC files are not mounted. Gemini API keys resolve through the [credential proxy](#credential-proxy-container-mode-only). Vertex AI/ADC/service-account auth does not work. The LLxprt global config directory (holding profiles with inline `auth-key` and a global `.env`) is still mounted — see [#2957](https://github.com/vybestack/llxprt-code/issues/2957) | Host keyring and token store are fully available           |
 
 ### Filesystem
 
@@ -128,18 +139,17 @@ In container mode, these paths are always mounted into the container:
 
 - Your project working directory (read-write)
 - The system temp directory (read-write)
-- The LLxprt Code settings directory (read-write)
+- The LLxprt Code settings directory (read-write). This directory holds your
+  profiles (`profiles/*.json`) and a global `.env`; a profile containing an
+  inline `auth-key`, or that `.env`, is therefore readable from inside the
+  container. Prefer `/key save` over inline profile keys — see issue
+  [#2957](https://github.com/vybestack/llxprt-code/issues/2957).
 - Git configuration files, mounted read-only (see
   [Git config passthrough](#git-config-passthrough))
 
 Additional paths are conditionally mounted based on your host environment and
 profile configuration:
 
-- The `~/.config/gcloud` directory (read-only) if it exists — see
-  [Known credential leakage in containers](#known-credential-leakage-in-containers).
-- The file pointed to by `GOOGLE_APPLICATION_CREDENTIALS` (read-only) if the
-  variable is set and the file exists — see
-  [Known credential leakage in containers](#known-credential-leakage-in-containers).
 - The SSH agent socket, if SSH agent forwarding is enabled — see
   [SSH agent forwarding](#ssh-agent-forwarding).
 - Any paths you add via `LLXPRT_SANDBOX_MOUNTS` / `SANDBOX_MOUNTS` or a profile
@@ -253,39 +263,39 @@ Limitations:
 Seatbelt is auto-detected only on macOS when `sandbox-exec` is on your `PATH`.
 Use Docker or Podman when available.
 
-## Known credential leakage in containers
+## Credential handling in containers
 
-Container mode (Docker or Podman) provides a separate process namespace and
-keeps the OS keyring out of the container. However, a **known defect** currently
-weakens that isolation: several Google-related credentials are forwarded or
-mounted into the container, where any process inside can read them. This is
-upstream Gemini/Vertex authentication plumbing that was never reconciled with
-the credential proxy. It is tracked as
-[issue #2946](https://github.com/vybestack/llxprt-code/issues/2946) and slated
-for the 0.11.0 milestone.
+Earlier releases forwarded several long-lived Google credentials into the
+container as a known defect (tracked as
+[issue #2946](https://github.com/vybestack/llxprt-code/issues/2946)). Those
+crossings have been removed:
 
-What currently leaks:
+- **`GEMINI_API_KEY` and `GOOGLE_API_KEY`** are no longer forwarded as container
+  environment variables, even when set on the host.
+- **`~/.config/gcloud`** is no longer mounted into the container.
+- **The file named by `GOOGLE_APPLICATION_CREDENTIALS`** is no longer mounted,
+  and that variable is no longer set inside the container.
 
-- **`GEMINI_API_KEY` and `GOOGLE_API_KEY`** — copied from your host environment
-  into the container's environment. These are your raw, stored API keys, not
-  short-lived tokens. Any process inside the container can read them.
-- **`~/.config/gcloud`** — the entire gcloud configuration directory is mounted
-  read-only if it exists. It can contain long-lived credentials, including
-  service-account keys and cached access tokens. Any process in the container
-  can read these files.
-- **The file named by `GOOGLE_APPLICATION_CREDENTIALS`** — if this variable
-  points to an existing file (typically a service-account JSON key), the file is
-  mounted read-only and the variable is set inside the container. Any process in
-  the container can read it.
+The supported way to authenticate Gemini from inside a container sandbox is to
+save an API key on the host with `/key save <name> <key>` and reference it by
+`auth-key-name`. The key is resolved inside the container through the
+[credential proxy](#credential-proxy-container-mode-only) and authenticates
+against the Gemini Developer API.
 
-> **Consequence:** A process inside the container that reads these credentials
-> obtains the same standing as the corresponding service account or API key on
-> the host. This is a higher level of exposure than the credential proxy, which
-> only ever issues short-lived tokens. Until the defect is fixed, unset
-> `GEMINI_API_KEY`, `GOOGLE_API_KEY`, and `GOOGLE_APPLICATION_CREDENTIALS`
-> before starting the sandbox if you do not want these credentials exposed, and
-> consider whether `~/.config/gcloud` contains secrets you do not want
-> forwarded.
+Vertex AI, application default credentials (ADC), and service-account
+authentication do **not** work from inside a container sandbox. A proxy-resolved
+named key authenticates against the Gemini Developer API, not Vertex AI, because
+Vertex AI requires the `vertex-ai` auth mode which is not established from a
+proxy-resolved key. This is tracked as issue
+[#2959](https://github.com/vybestack/llxprt-code/issues/2959).
+
+> **Remaining exposure:** the LLxprt global configuration directory is still
+> mounted read-write into the container (see
+> [Filesystem](#filesystem)). That directory holds your `profiles/*.json` files
+> and a global `.env`, so a profile containing an inline `auth-key`, or a
+> global `.env`, is still readable from inside the container. Prefer
+> `/key save` over inline profile keys. This is tracked as issue
+> [#2957](https://github.com/vybestack/llxprt-code/issues/2957).
 
 ## Intentional boundary crossings
 
@@ -293,7 +303,6 @@ The sandbox forwards certain credentials and configuration into the boundary so
 that development workflows (authentication, git operations) continue to work.
 These are intentional design choices that you opted into or that are part of the
 sandbox design, and each carries a risk you should understand before enabling.
-They are distinct from the credential leakage defect described above.
 
 ### Credential proxy (container mode only)
 
@@ -317,11 +326,15 @@ What the proxy blocks:
   container mode ("API key management is not available in sandbox mode"). Keys
   must be managed on the host.
 - **Your stored secrets are not mounted** — `~/.git-credentials` is
-  intentionally not mounted into the container. The proxy is the intended way
-  for the container to obtain access tokens. (Note: API keys and Google
-  credential files currently leak into the container through a separate,
-  unintentional path — see
-  [Known credential leakage in containers](#known-credential-leakage-in-containers).)
+  intentionally not mounted into the container, and `GEMINI_API_KEY`,
+  `GOOGLE_API_KEY`, the gcloud config directory, and the ADC file are not
+  forwarded or mounted (see
+  [Credential handling in containers](#credential-handling-in-containers)). The
+  proxy is the intended way for the container to obtain access tokens and
+  resolve named API keys. The LLxprt global configuration directory is still
+  mounted, however, so a profile containing an inline `auth-key`, or a global
+  `.env`, remains readable from inside the container (see issue
+  [#2957](https://github.com/vybestack/llxprt-code/issues/2957)).
 
 How the container proves it is authorised: a per-session capability token is
 passed to LLxprt Code through an inherited file descriptor, never through

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -45,11 +45,11 @@ llxprt --sandbox-engine podman "review this code"
   inside the container. `GEMINI_API_KEY` and `GOOGLE_API_KEY` are no longer
   forwarded as container environment variables, and the `~/.config/gcloud`
   directory and the `GOOGLE_APPLICATION_CREDENTIALS` file are no longer mounted
-  (and that variable is no longer set inside the container). Gemini API keys
-  saved on the host with `/key save` and referenced by `auth-key-name` are
-  resolved inside the container through the
-  [credential proxy](#credential-proxy-container-mode-only) — the supported way
-  to authenticate Gemini from a sandbox. Note that Vertex AI, application
+  (and that variable is no longer set inside the container). The Gemini provider
+  itself still works: keys saved on the host with `/key save` are resolved
+  inside the container through the
+  [credential proxy](#credential-proxy-container-mode-only), either via
+  `/key load <name>` or a profile `auth-key-name`. Note that Vertex AI, application
   default credentials (ADC), and service-account authentication do **not** work
   from inside a container sandbox (see
   [Credential handling in containers](#credential-handling-in-containers)). The
@@ -276,11 +276,38 @@ crossings have been removed:
 - **The file named by `GOOGLE_APPLICATION_CREDENTIALS`** is no longer mounted,
   and that variable is no longer set inside the container.
 
-The supported way to authenticate Gemini from inside a container sandbox is to
-save an API key on the host with `/key save <name> <key>` and reference it by
-`auth-key-name`. The key is resolved inside the container through the
-[credential proxy](#credential-proxy-container-mode-only) and authenticates
-against the Gemini Developer API.
+The Gemini provider itself still works from inside a container sandbox. Only the
+environment-variable and credential-file routes were removed; named API keys are
+unaffected. Save the key once on the host:
+
+```
+/key save gemini-personal <your-api-key>
+```
+
+Then, from inside the sandbox, either load it interactively:
+
+```
+/key load gemini-personal
+```
+
+or reference it from a profile with `auth-key-name`, which resolves it
+automatically at startup. Either way the key is fetched over the
+[credential proxy](#credential-proxy-container-mode-only) rather than read from
+the container's environment, and authenticates against the Gemini Developer API.
+
+Which `/key` subcommands work where:
+
+| Subcommand               | On the host | Inside a container           |
+| ------------------------ | ----------- | ---------------------------- |
+| `/key load`              | yes         | yes (read via the proxy)     |
+| `/key list`, `/key show` | yes         | yes (read via the proxy)     |
+| `/key save`              | yes         | no — manage keys on the host |
+| `/key delete`            | yes         | no — manage keys on the host |
+
+`/key save` and `/key delete` fail inside the container with "API key management
+is not available in sandbox mode". That is deliberate: the proxy serves key
+reads but refuses writes, so the sandbox cannot alter what is stored on your
+host.
 
 Vertex AI, application default credentials (ADC), and service-account
 authentication do **not** work from inside a container sandbox. A proxy-resolved
@@ -315,8 +342,8 @@ What the proxy provides:
 
 - **Short-lived access tokens** — the container receives short-lived tokens, not
   your stored refresh tokens. Refresh tokens stay on the host.
-- **Key reads** — `/key list`, `/key show`, and key resolution for providers
-  read host-saved keys through the proxy.
+- **Key reads** — `/key load`, `/key list`, `/key show`, and key resolution for
+  providers read host-saved keys through the proxy.
 - **OAuth flows** — OAuth login opens the browser on the host; the container
   authenticates through the proxy.
 

--- a/packages/agents/bunfig.toml
+++ b/packages/agents/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["../../test-setup/augment-bun-vi.ts"]

--- a/packages/agents/src/core/CompressionProfileResolver.proxyKeyStorage.test.ts
+++ b/packages/agents/src/core/CompressionProfileResolver.proxyKeyStorage.test.ts
@@ -151,11 +151,10 @@ describe.sequential(
       }
       resetFactorySingletons();
       if (server !== undefined) {
-        try {
-          await server.stop();
-        } catch {
-          // already stopped
-        }
+        // No catch: each test starts the server exactly once and never stops
+        // it, so a failure here is a real teardown defect (an unreleased Unix
+        // socket would break the next run) and should fail the test.
+        await server.stop();
         server = undefined;
       }
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/packages/agents/src/core/CompressionProfileResolver.proxyKeyStorage.test.ts
+++ b/packages/agents/src/core/CompressionProfileResolver.proxyKeyStorage.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type {
+  OAuthToken,
+  TokenStore,
+  BucketStats,
+} from '@vybestack/llxprt-code-core';
+import type { ProviderKeyStorageLike } from '@vybestack/llxprt-code-storage';
+import { resolveCompressionProfileAuthToken } from './CompressionProfileResolver.js';
+import { CredentialProxyServer } from '@vybestack/llxprt-code-providers/auth/proxy/credential-proxy-server.js';
+import { resetFactorySingletons } from '@vybestack/llxprt-code-providers/auth.js';
+
+const PROXY_SERVED_KEY = 'proxy-served-compression-key-2946';
+const NAMED_KEY = 'compression-named-key';
+
+/**
+ * Minimal in-memory TokenStore for the proxy server. The compression-resolver
+ * auth path only exercises provider-key reads, so token operations are unused
+ * but required by the TokenStore contract.
+ */
+class InMemoryTokenStore implements TokenStore {
+  private readonly tokens = new Map<string, OAuthToken>();
+
+  private key(provider: string, bucket?: string): string {
+    return `${provider}::${bucket ?? 'default'}`;
+  }
+
+  async saveToken(
+    provider: string,
+    token: OAuthToken,
+    bucket?: string,
+  ): Promise<void> {
+    this.tokens.set(this.key(provider, bucket), { ...token });
+  }
+
+  async getToken(
+    provider: string,
+    bucket?: string,
+  ): Promise<OAuthToken | null> {
+    return this.tokens.get(this.key(provider, bucket)) ?? null;
+  }
+
+  async removeToken(provider: string, bucket?: string): Promise<void> {
+    this.tokens.delete(this.key(provider, bucket));
+  }
+
+  async listProviders(): Promise<string[]> {
+    const providers = new Set<string>();
+    for (const composite of this.tokens.keys()) {
+      const [provider] = composite.split('::');
+      if (provider) providers.add(provider);
+    }
+    return Array.from(providers);
+  }
+
+  async listBuckets(provider: string): Promise<string[]> {
+    const buckets: string[] = [];
+    for (const composite of this.tokens.keys()) {
+      const [tokenProvider, bucket] = composite.split('::');
+      if (tokenProvider === provider && bucket) buckets.push(bucket);
+    }
+    return buckets;
+  }
+
+  async getBucketStats(
+    _provider: string,
+    bucket: string,
+  ): Promise<BucketStats | null> {
+    return { bucket, requestCount: 0, percentage: 0, lastUsed: undefined };
+  }
+
+  async acquireRefreshLock(
+    _provider: string,
+    _options?: { waitMs?: number; bucket?: string },
+  ): Promise<boolean> {
+    return true;
+  }
+
+  async releaseRefreshLock(
+    _provider: string,
+    _bucket?: string,
+  ): Promise<void> {}
+
+  async acquireAuthLock(
+    _provider: string,
+    _options?: { waitMs?: number; bucket?: string },
+  ): Promise<boolean> {
+    return true;
+  }
+
+  async releaseAuthLock(_provider: string, _bucket?: string): Promise<void> {}
+}
+
+/**
+ * In-memory provider key storage that serves a fixed key, satisfying the
+ * narrow ProviderKeyStorageLike interface the proxy server reads from.
+ */
+class InMemoryProviderKeyStorage implements ProviderKeyStorageLike {
+  private readonly keys = new Map<string, string>();
+
+  async saveKey(name: string, apiKey: string): Promise<void> {
+    this.keys.set(name, apiKey);
+  }
+
+  async getKey(name: string): Promise<string | null> {
+    return this.keys.get(name) ?? null;
+  }
+
+  async deleteKey(name: string): Promise<boolean> {
+    return this.keys.delete(name);
+  }
+
+  async listKeys(): Promise<string[]> {
+    return Array.from(this.keys.keys());
+  }
+
+  async hasKey(name: string): Promise<boolean> {
+    return this.keys.has(name);
+  }
+}
+
+describe.sequential(
+  '#2946 CompressionProfileResolver proxy-aware key storage',
+  () => {
+    let tmpDir: string;
+    let priorSocketEnv: string | undefined;
+    let server: CredentialProxyServer | undefined;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cpr-'));
+      priorSocketEnv = process.env.LLXPRT_CREDENTIAL_SOCKET;
+      delete process.env.LLXPRT_CREDENTIAL_SOCKET;
+      resetFactorySingletons();
+    });
+
+    afterEach(async () => {
+      if (priorSocketEnv === undefined) {
+        delete process.env.LLXPRT_CREDENTIAL_SOCKET;
+      } else {
+        process.env.LLXPRT_CREDENTIAL_SOCKET = priorSocketEnv;
+      }
+      resetFactorySingletons();
+      if (server !== undefined) {
+        try {
+          await server.stop();
+        } catch {
+          // already stopped
+        }
+        server = undefined;
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('resolves auth-key-name through the credential proxy socket', async () => {
+      const keyStorage = new InMemoryProviderKeyStorage();
+      await keyStorage.saveKey(NAMED_KEY, PROXY_SERVED_KEY);
+      server = new CredentialProxyServer({
+        tokenStore: new InMemoryTokenStore(),
+        providerKeyStorage: keyStorage,
+        socketDir: tmpDir,
+      });
+      const socketPath = await server.start();
+      process.env.LLXPRT_CREDENTIAL_SOCKET = socketPath;
+
+      const profileSettings = new SettingsService();
+      profileSettings.setProviderSetting('gemini', 'auth-key-name', NAMED_KEY);
+
+      const result = await resolveCompressionProfileAuthToken(
+        profileSettings,
+        'gemini',
+      );
+
+      expect(result).toStrictEqual({ authToken: PROXY_SERVED_KEY });
+    });
+
+    // When the proxy serves no such key the resolver must report "no auth"
+    // rather than falling back to the host keyring, which is unreachable
+    // from inside the container anyway.
+    it('returns no auth when the named key is absent from proxy storage', async () => {
+      server = new CredentialProxyServer({
+        tokenStore: new InMemoryTokenStore(),
+        providerKeyStorage: new InMemoryProviderKeyStorage(),
+        socketDir: tmpDir,
+      });
+      const socketPath = await server.start();
+      process.env.LLXPRT_CREDENTIAL_SOCKET = socketPath;
+
+      const profileSettings = new SettingsService();
+      profileSettings.setProviderSetting(
+        'gemini',
+        'auth-key-name',
+        'absent-key',
+      );
+
+      const result = await resolveCompressionProfileAuthToken(
+        profileSettings,
+        'gemini',
+      );
+
+      expect(result).toStrictEqual({});
+    });
+  },
+);

--- a/packages/agents/src/core/CompressionProfileResolver.ts
+++ b/packages/agents/src/core/CompressionProfileResolver.ts
@@ -14,7 +14,7 @@ import type {
   LoadBalancerProfile,
   StandardProfile,
 } from '@vybestack/llxprt-code-settings';
-import { getProviderKeyStorage } from '@vybestack/llxprt-code-core/storage/provider-key-storage.js';
+import { createProviderKeyStorage } from '@vybestack/llxprt-code-providers/auth.js';
 import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
 import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
@@ -255,7 +255,7 @@ export async function resolveCompressionProfileAuthToken(
     profileSettings.get('auth-key-name'),
   ]);
   if (keyName) {
-    const token = await getProviderKeyStorage().getKey(keyName);
+    const token = await createProviderKeyStorage().getKey(keyName);
     if (token) {
       return { authToken: token };
     }

--- a/packages/agents/vitest.config.ts
+++ b/packages/agents/vitest.config.ts
@@ -236,7 +236,13 @@ export default defineConfig({
     // normal runs (if a backup is left behind) and Stryker's own dry run would
     // pick up DUPLICATE/stale spec copies from that tree, double-counting tests
     // and corrupting coverage attribution.
-    exclude: [...configDefaults.exclude, '**/.stryker-tmp/**'],
+    exclude: [
+      ...configDefaults.exclude,
+      '**/.stryker-tmp/**',
+      // Bun-native and registered in scripts/bun-test-manifest.ts, so it runs
+      // under `bun test` only and must not also be discovered here (#2946).
+      '**/src/core/CompressionProfileResolver.proxyKeyStorage.test.ts',
+    ],
     reporters: ['default', 'junit'],
     testTimeout: 30000,
     teardownTimeout: 120000,

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -13,9 +13,27 @@ import { DebugLogger, FatalSandboxError } from '@vybestack/llxprt-code-core';
 import {
   buildContainerRunArgs,
   setupContainerNetworking,
+  addContainerEnvVars,
+  addContainerVolumeMounts,
 } from './sandbox-containers.js';
 
-vi.mock('node:child_process');
+// Explicit factory mock: Bun's automock walks every export of
+// node:child_process and hits getters that access private fields
+// (this.#stdin), crashing the compat shim. Supply only the exports the
+// module under test actually imports (execSync, spawn, exec) as mock
+// functions. exec must be a real function so promisify(exec) at module
+// scope succeeds. Spread importOriginal so other modules in the graph
+// that import e.g. execFile still receive the real implementations —
+// Vitest replaces the entire module namespace with the factory return.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual: typeof import('node:child_process') = await importOriginal();
+  return {
+    ...actual,
+    execSync: vi.fn(),
+    spawn: vi.fn(),
+    exec: vi.fn(),
+  };
+});
 
 const NETWORK_ENV_KEYS = [
   'LLXPRT_SANDBOX_NETWORK',
@@ -192,5 +210,149 @@ describe.sequential('#1456 container network policy', () => {
       'docker network inspect llxprt-code-sandbox-proxy || docker network create llxprt-code-sandbox-proxy',
     );
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+const CONTAINER_ENV_VARS = [
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'GOOGLE_GENAI_USE_VERTEXAI',
+  'GOOGLE_GENAI_USE_GCA',
+  'GOOGLE_CLOUD_PROJECT',
+  'GOOGLE_CLOUD_LOCATION',
+  'GEMINI_MODEL',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'TERM',
+  'COLORTERM',
+  'SANDBOX_ENV',
+  'VIRTUAL_ENV',
+  'NODE_OPTIONS',
+  'LLXPRT_SANDBOX_MOUNTS',
+  'SANDBOX_MOUNTS',
+] as const;
+
+const ENV_CONFIG = { command: 'docker', image: 'test' } as const;
+
+describe.sequential('#2946 container credential isolation', () => {
+  let environmentSnapshot: NodeJS.ProcessEnv;
+  let tempDirs: string[] = [];
+
+  beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    tempDirs = [];
+    for (const key of CONTAINER_ENV_VARS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    process.env = environmentSnapshot;
+    vi.restoreAllMocks();
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not forward GEMINI_API_KEY or GOOGLE_API_KEY into the container env', () => {
+    process.env.GEMINI_API_KEY = 'sentinel-gemini-key-2946';
+    process.env.GOOGLE_API_KEY = 'sentinel-google-key-2946';
+
+    const args: string[] = [];
+    addContainerEnvVars(args, ENV_CONFIG, 'test-container', [], '/workspace');
+
+    expect(args.some((arg) => arg.startsWith('GEMINI_API_KEY='))).toBe(false);
+    expect(args.some((arg) => arg.startsWith('GOOGLE_API_KEY='))).toBe(false);
+    const joined = args.join(' ');
+    expect(joined).not.toContain('sentinel-gemini-key-2946');
+    expect(joined).not.toContain('sentinel-google-key-2946');
+  });
+
+  it('still forwards non-secret Vertex/Gemini configuration vars', () => {
+    process.env.GOOGLE_CLOUD_PROJECT = 'my-project';
+    process.env.GOOGLE_CLOUD_LOCATION = 'us-central1';
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = 'true';
+    process.env.GOOGLE_GENAI_USE_GCA = 'true';
+    process.env.GEMINI_MODEL = 'gemini-2.5-pro';
+
+    const args: string[] = [];
+    addContainerEnvVars(args, ENV_CONFIG, 'test-container', [], '/workspace');
+
+    // Parse --env flag/value PAIRS: for each --env take the next element as
+    // the operand. This rejects an implementation that emits unpaired values.
+    const envPairs: string[] = [];
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '--env' && i + 1 < args.length) {
+        envPairs.push(args[i + 1]);
+      }
+    }
+    expect(envPairs).toContain('GOOGLE_CLOUD_PROJECT=my-project');
+    expect(envPairs).toContain('GOOGLE_CLOUD_LOCATION=us-central1');
+    expect(envPairs).toContain('GOOGLE_GENAI_USE_VERTEXAI=true');
+    expect(envPairs).toContain('GOOGLE_GENAI_USE_GCA=true');
+    expect(envPairs).toContain('GEMINI_MODEL=gemini-2.5-pro');
+  });
+
+  it('does not mount the gcloud config directory', () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gcloud-home-'));
+    tempDirs.push(fakeHome);
+    fs.mkdirSync(path.join(fakeHome, '.config', 'gcloud'), {
+      recursive: true,
+    });
+    vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+
+    const args: string[] = [];
+    addContainerVolumeMounts(args);
+
+    const gcloudPath = path.join(fakeHome, '.config', 'gcloud');
+    // Inspect only the operand that follows each --volume flag, so unrelated
+    // mounts are permitted while a gcloud mount still fails the test.
+    const volumeOperands: string[] = [];
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '--volume' && i + 1 < args.length) {
+        volumeOperands.push(args[i + 1]);
+      }
+    }
+    expect(volumeOperands.some((spec) => spec.includes(gcloudPath))).toBe(
+      false,
+    );
+    expect(args.join(' ')).not.toContain(gcloudPath);
+  });
+
+  it('does not mount the GOOGLE_APPLICATION_CREDENTIALS file or re-export it', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adc-'));
+    tempDirs.push(tmpDir);
+    const adcFile = path.join(tmpDir, 'service-account.json');
+    fs.writeFileSync(adcFile, '{"type":"service_account"}');
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = adcFile;
+
+    const args: string[] = [];
+    addContainerVolumeMounts(args);
+
+    expect(args.join(' ')).not.toContain(adcFile);
+    expect(
+      args.some((arg) => arg.startsWith('GOOGLE_APPLICATION_CREDENTIALS=')),
+    ).toBe(false);
+  });
+
+  it('still mounts paths from LLXPRT_SANDBOX_MOUNTS (regression guard)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-mount-'));
+    tempDirs.push(tmpDir);
+    process.env.LLXPRT_SANDBOX_MOUNTS = tmpDir;
+
+    const args: string[] = [];
+    addContainerVolumeMounts(args);
+
+    expect(args).toContain('--volume');
+    expect(args).toContain(`${tmpDir}:${tmpDir}:ro`);
+  });
+
+  it('still mounts paths from legacy SANDBOX_MOUNTS name (regression guard)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legacy-mount-'));
+    tempDirs.push(tmpDir);
+    process.env.SANDBOX_MOUNTS = tmpDir;
+
+    const args: string[] = [];
+    addContainerVolumeMounts(args);
+
+    expect(args).toContain('--volume');
+    expect(args).toContain(`${tmpDir}:${tmpDir}:ro`);
   });
 });

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -19,19 +19,21 @@ import {
 
 // Explicit factory mock: Bun's automock walks every export of
 // node:child_process and hits getters that access private fields
-// (this.#stdin), crashing the compat shim. Supply only the exports the
-// module under test actually imports (execSync, spawn, exec) as mock
-// functions. exec must be a real function so promisify(exec) at module
-// scope succeeds. Spread importOriginal so other modules in the graph
-// that import e.g. execFile still receive the real implementations —
+// (this.#stdin), crashing the compat shim. Spread importOriginal so
+// everything else in the module graph keeps the real implementations —
 // Vitest replaces the entire module namespace with the factory return.
+//
+// Only execSync and spawn are stubbed: those are the process-launching
+// calls these tests must not actually perform. `exec` is deliberately left
+// real, because sandbox-containers.ts evaluates promisify(exec) at module
+// scope; a stub there would produce an execAsync that never settles and
+// would hang the first test to reach that path.
 vi.mock('node:child_process', async (importOriginal) => {
   const actual: typeof import('node:child_process') = await importOriginal();
   return {
     ...actual,
     execSync: vi.fn(),
     spawn: vi.fn(),
-    exec: vi.fn(),
   };
 });
 
@@ -288,6 +290,39 @@ describe.sequential('#2946 container credential isolation', () => {
     expect(envPairs).toContain('GOOGLE_GENAI_USE_VERTEXAI=true');
     expect(envPairs).toContain('GOOGLE_GENAI_USE_GCA=true');
     expect(envPairs).toContain('GEMINI_MODEL=gemini-2.5-pro');
+  });
+
+  // Guards against the opposite failure mode: a blanket blocklist keyed on a
+  // GEMINI_/GOOGLE_ prefix would drop the secrets but take the non-secret
+  // configuration with it. Both kinds must be set at once to catch that.
+  it('drops only the secrets when secret and non-secret vars are set together', () => {
+    process.env.GEMINI_API_KEY = 'sentinel-gemini-key-2946';
+    process.env.GOOGLE_API_KEY = 'sentinel-google-key-2946';
+    process.env.GOOGLE_CLOUD_PROJECT = 'my-project';
+    process.env.GOOGLE_CLOUD_LOCATION = 'us-central1';
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = 'true';
+
+    const args: string[] = [];
+    addContainerEnvVars(args, ENV_CONFIG, 'test-container', [], '/workspace');
+
+    const envPairs: string[] = [];
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '--env' && i + 1 < args.length) {
+        envPairs.push(args[i + 1]);
+      }
+    }
+    expect(envPairs).toContain('GOOGLE_CLOUD_PROJECT=my-project');
+    expect(envPairs).toContain('GOOGLE_CLOUD_LOCATION=us-central1');
+    expect(envPairs).toContain('GOOGLE_GENAI_USE_VERTEXAI=true');
+    expect(envPairs.some((pair) => pair.startsWith('GEMINI_API_KEY='))).toBe(
+      false,
+    );
+    expect(envPairs.some((pair) => pair.startsWith('GOOGLE_API_KEY='))).toBe(
+      false,
+    );
+    const joined = args.join(' ');
+    expect(joined).not.toContain('sentinel-gemini-key-2946');
+    expect(joined).not.toContain('sentinel-google-key-2946');
   });
 
   it('does not mount the gcloud config directory', () => {

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -238,26 +238,8 @@ function addSandboxEnvVars(args: string[]): void {
   }
 }
 
-/** Adds gcloud, ADC, and custom SANDBOX_MOUNTS volume flags. */
+/** Adds custom SANDBOX_MOUNTS volume flags. */
 export function addContainerVolumeMounts(args: string[]): void {
-  const gcloudConfigDir = path.join(os.homedir(), '.config', 'gcloud');
-  if (fs.existsSync(gcloudConfigDir)) {
-    args.push(
-      '--volume',
-      `${gcloudConfigDir}:${getContainerPath(gcloudConfigDir)}:ro`,
-    );
-  }
-  if (process.env.GOOGLE_APPLICATION_CREDENTIALS !== undefined) {
-    const adcFile = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-    if (fs.existsSync(adcFile)) {
-      args.push('--volume', `${adcFile}:${getContainerPath(adcFile)}:ro`);
-      args.push(
-        '--env',
-        `GOOGLE_APPLICATION_CREDENTIALS=${getContainerPath(adcFile)}`,
-      );
-    }
-  }
-
   const mountsEnv =
     process.env.LLXPRT_SANDBOX_MOUNTS ?? process.env.SANDBOX_MOUNTS;
   const mountsEnvName =
@@ -269,7 +251,7 @@ export function addContainerVolumeMounts(args: string[]): void {
   }
 }
 
-/** Adds environment variable flags for API keys, term, proxy, etc. */
+/** Adds environment variable flags for non-secret config, term, proxy, etc. */
 export function addContainerEnvVars(
   args: string[],
   config: SandboxConfig,
@@ -278,8 +260,6 @@ export function addContainerEnvVars(
   workdir: string,
 ): void {
   const envMap: Record<string, string | undefined> = {
-    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
-    GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
     GOOGLE_GENAI_USE_VERTEXAI: process.env.GOOGLE_GENAI_USE_VERTEXAI,
     GOOGLE_GENAI_USE_GCA: process.env.GOOGLE_GENAI_USE_GCA,
     GOOGLE_CLOUD_PROJECT: process.env.GOOGLE_CLOUD_PROJECT,

--- a/packages/cli/vitest.test-groups.ts
+++ b/packages/cli/vitest.test-groups.ts
@@ -72,6 +72,9 @@ const baseExclude: readonly string[] = [
   // Sandbox SSH agent preflight tests are Bun-native for the same reason
   // (issue #1699).
   '**/src/utils/sandbox-ssh-agent-preflight.test.ts',
+  // Sandbox container credential-isolation tests are Bun-native for the same
+  // reason (issue #2946).
+  '**/src/utils/sandbox-containers.test.ts',
   '**/dist/**',
   '**/tmp/**',
   '**/cypress/**',
@@ -486,4 +489,4 @@ export function buildTestGroups(
  * The expected total selected file count after integrating the v0.11.0 test set.
  * Exported for behavioral tests to assert against an independent oracle.
  */
-export const SELECTED_FILE_COUNT: number = 534;
+export const SELECTED_FILE_COUNT: number = 533;

--- a/packages/providers/src/BaseProvider.ts
+++ b/packages/providers/src/BaseProvider.ts
@@ -25,7 +25,7 @@ import {
   type IProviderKeyStorage,
 } from '@vybestack/llxprt-code-auth';
 import { AuthPrecedenceResolver } from '@vybestack/llxprt-code-auth/precedence.js';
-import { getProviderKeyStorage } from '@vybestack/llxprt-code-storage';
+import { createProviderKeyStorage } from './auth/proxy/credential-store-factory.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { type IProviderConfig } from './types/IProviderConfig.js';
 import { peekActiveProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
@@ -69,10 +69,9 @@ export interface BaseProviderConfig {
   supportsOAuth?: boolean;
 
   // Named API key storage used to resolve `auth-key-name` references.
-  // Optional DI seam: when omitted, BaseProvider falls back to core's
-  // singleton provider key storage so resolution works in every runtime
-  // (including subagent runtimes that set `auth-key-name` without
-  // pre-resolving it to a concrete `auth-key`).
+  // Optional DI seam: when omitted, BaseProvider falls back to the sanctioned
+  // createProviderKeyStorage() factory, which routes through the credential
+  // proxy inside a sandbox and direct storage on the host.
   providerKeyStorage?: IProviderKeyStorage;
 }
 
@@ -154,15 +153,16 @@ export abstract class BaseProvider implements IProvider {
     // @plan:PLAN-20260608-ISSUE1586.P15 — options-object constructor (unified with C-CB-06/C-CB-09)
     // SettingsService satisfies ISettingsService by structural typing.
     // providerKeyStorage is injected so the resolver can resolve named keys
-    // (`auth-key-name`) on its own. Pre-extraction, the core resolver reached
-    // core's getProviderKeyStorage() internally; after extraction the auth
-    // package can't, so the consumer must inject it. Falling back to core's
-    // singleton preserves behavior for runtimes (e.g. subagents) that set
-    // `auth-key-name` without pre-resolving it to a concrete `auth-key`.
+    // (`auth-key-name`) on its own. The sanctioned factory is used as the
+    // fallback so named-key resolution routes through the credential proxy
+    // inside a sandbox (when LLXPRT_CREDENTIAL_SOCKET is set) and falls back
+    // to direct storage on the host. Callers may still inject their own
+    // storage via config.providerKeyStorage.
     this.authResolver = new AuthPrecedenceResolver(precedenceConfig, {
       oauthManager: config.oauthManager,
       settingsService: fallbackSettingsService,
-      providerKeyStorage: config.providerKeyStorage ?? getProviderKeyStorage(),
+      providerKeyStorage:
+        config.providerKeyStorage ?? createProviderKeyStorage(),
     });
   }
 

--- a/packages/providers/src/__tests__/BaseProvider.proxyKeyStorage.test.ts
+++ b/packages/providers/src/__tests__/BaseProvider.proxyKeyStorage.test.ts
@@ -205,12 +205,11 @@ describe.sequential('#2946 BaseProvider proxy-aware key storage', () => {
       process.env.LLXPRT_CREDENTIAL_SOCKET = priorSocketEnv;
     }
     resetFactorySingletons();
-    if (server) {
-      try {
-        await server.stop();
-      } catch {
-        // already stopped
-      }
+    if (server !== undefined) {
+      // No catch: each test starts the server exactly once and never stops it,
+      // so a failure here is a real teardown defect (an unreleased Unix socket
+      // would break the next run) and should fail the test.
+      await server.stop();
       server = undefined;
     }
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/packages/providers/src/__tests__/BaseProvider.proxyKeyStorage.test.ts
+++ b/packages/providers/src/__tests__/BaseProvider.proxyKeyStorage.test.ts
@@ -1,0 +1,274 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type {
+  OAuthToken,
+  TokenStore,
+  BucketStats,
+} from '@vybestack/llxprt-code-core';
+import type { ProviderKeyStorageLike } from '@vybestack/llxprt-code-storage';
+import type { IProviderKeyStorage } from '@vybestack/llxprt-code-auth';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  createProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  BaseProvider,
+  type BaseProviderConfig,
+  type NormalizedGenerateChatOptions,
+} from '../BaseProvider.js';
+import { CredentialProxyServer } from '../auth/proxy/credential-proxy-server.js';
+import { resetFactorySingletons } from '../auth/proxy/credential-store-factory.js';
+
+const userMessage = (text: string): IContent => ({
+  speaker: 'human',
+  blocks: [{ type: 'text', text }],
+});
+
+/**
+ * Minimal in-memory TokenStore for the proxy server. These tests only exercise
+ * provider-key reads, so token operations are unused but required by the
+ * TokenStore contract.
+ */
+class InMemoryTokenStore implements TokenStore {
+  private readonly tokens = new Map<string, OAuthToken>();
+
+  private key(provider: string, bucket?: string): string {
+    return `${provider}::${bucket ?? 'default'}`;
+  }
+
+  async saveToken(
+    provider: string,
+    token: OAuthToken,
+    bucket?: string,
+  ): Promise<void> {
+    this.tokens.set(this.key(provider, bucket), { ...token });
+  }
+
+  async getToken(
+    provider: string,
+    bucket?: string,
+  ): Promise<OAuthToken | null> {
+    return this.tokens.get(this.key(provider, bucket)) ?? null;
+  }
+
+  async removeToken(provider: string, bucket?: string): Promise<void> {
+    this.tokens.delete(this.key(provider, bucket));
+  }
+
+  async listProviders(): Promise<string[]> {
+    const providers = new Set<string>();
+    for (const composite of this.tokens.keys()) {
+      const [provider] = composite.split('::');
+      if (provider) providers.add(provider);
+    }
+    return Array.from(providers);
+  }
+
+  async listBuckets(provider: string): Promise<string[]> {
+    const buckets: string[] = [];
+    for (const composite of this.tokens.keys()) {
+      const [tokenProvider, bucket] = composite.split('::');
+      if (tokenProvider === provider && bucket) buckets.push(bucket);
+    }
+    return buckets;
+  }
+
+  async getBucketStats(
+    _provider: string,
+    bucket: string,
+  ): Promise<BucketStats | null> {
+    return { bucket, requestCount: 0, percentage: 0, lastUsed: undefined };
+  }
+
+  async acquireRefreshLock(
+    _provider: string,
+    _options?: { waitMs?: number; bucket?: string },
+  ): Promise<boolean> {
+    return true;
+  }
+
+  async releaseRefreshLock(
+    _provider: string,
+    _bucket?: string,
+  ): Promise<void> {}
+
+  async acquireAuthLock(
+    _provider: string,
+    _options?: { waitMs?: number; bucket?: string },
+  ): Promise<boolean> {
+    return true;
+  }
+
+  async releaseAuthLock(_provider: string, _bucket?: string): Promise<void> {}
+}
+
+/** In-memory provider key storage serving a fixed set of keys. */
+class InMemoryProviderKeyStorage implements ProviderKeyStorageLike {
+  private readonly keys = new Map<string, string>();
+
+  async saveKey(name: string, apiKey: string): Promise<void> {
+    this.keys.set(name, apiKey);
+  }
+
+  async getKey(name: string): Promise<string | null> {
+    return this.keys.get(name) ?? null;
+  }
+
+  async deleteKey(name: string): Promise<boolean> {
+    return this.keys.delete(name);
+  }
+
+  async listKeys(): Promise<string[]> {
+    return Array.from(this.keys.keys());
+  }
+
+  async hasKey(name: string): Promise<boolean> {
+    return this.keys.has(name);
+  }
+}
+
+class ProxyAwareProvider extends BaseProvider {
+  capturedAuthToken = '';
+
+  constructor(providerKeyStorage?: IProviderKeyStorage) {
+    const config: BaseProviderConfig = { name: 'proxy-aware' };
+    if (providerKeyStorage !== undefined) {
+      config.providerKeyStorage = providerKeyStorage;
+    }
+    super(config);
+  }
+
+  async getModels(): Promise<never[]> {
+    return [];
+  }
+
+  getDefaultModel(): string {
+    return 'proxy-aware-model';
+  }
+
+  protected supportsOAuth(): boolean {
+    return false;
+  }
+
+  protected generateChatCompletionWithOptions(
+    options: NormalizedGenerateChatOptions,
+  ): AsyncIterableIterator<IContent> {
+    this.capturedAuthToken =
+      typeof options.resolved.authToken === 'string'
+        ? options.resolved.authToken
+        : '';
+    return (async function* () {})();
+  }
+}
+
+function buildChatOptions(settings: SettingsService) {
+  const config = createRuntimeConfigStub(settings);
+  const runtime = createProviderRuntimeContext({
+    runtimeId: `proxy-aware.${Math.random().toString(36).slice(2, 10)}`,
+    settingsService: settings,
+    config,
+  });
+  return { contents: [userMessage('hi')], settings, config, runtime };
+}
+
+const PROXY_SERVED_KEY = 'proxy-served-secret-key-2946';
+const NAMED_KEY = 'my-named-key';
+
+describe.sequential('#2946 BaseProvider proxy-aware key storage', () => {
+  let tmpDir: string;
+  let priorSocketEnv: string | undefined;
+  let server: CredentialProxyServer | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bpp-'));
+    priorSocketEnv = process.env.LLXPRT_CREDENTIAL_SOCKET;
+    delete process.env.LLXPRT_CREDENTIAL_SOCKET;
+    resetFactorySingletons();
+  });
+
+  afterEach(async () => {
+    if (priorSocketEnv === undefined) {
+      delete process.env.LLXPRT_CREDENTIAL_SOCKET;
+    } else {
+      process.env.LLXPRT_CREDENTIAL_SOCKET = priorSocketEnv;
+    }
+    resetFactorySingletons();
+    if (server) {
+      try {
+        await server.stop();
+      } catch {
+        // already stopped
+      }
+      server = undefined;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function startServerWithNamedKey(): Promise<string> {
+    const keyStorage = new InMemoryProviderKeyStorage();
+    await keyStorage.saveKey(NAMED_KEY, PROXY_SERVED_KEY);
+    server = new CredentialProxyServer({
+      tokenStore: new InMemoryTokenStore(),
+      providerKeyStorage: keyStorage,
+      socketDir: tmpDir,
+    });
+    return server.start();
+  }
+
+  it('resolves auth-key-name through the credential proxy socket', async () => {
+    const socketPath = await startServerWithNamedKey();
+    process.env.LLXPRT_CREDENTIAL_SOCKET = socketPath;
+
+    const provider = new ProxyAwareProvider();
+    const settings = new SettingsService();
+    settings.set('activeProvider', 'proxy-aware');
+    settings.set('auth-key-name', NAMED_KEY);
+    const config = createRuntimeConfigStub(settings);
+    setActiveProviderRuntimeContext({ settingsService: settings, config });
+    provider.setRuntimeSettingsService(settings);
+
+    await provider.generateChatCompletion(buildChatOptions(settings)).next();
+
+    expect(provider.capturedAuthToken).toBe(PROXY_SERVED_KEY);
+  });
+
+  it('honours an explicitly injected config.providerKeyStorage over the factory default, even with a proxy socket set', async () => {
+    // Start a proxy serving PROXY_SERVED_KEY. With a socket set, the factory
+    // default would resolve to the proxy key. An explicitly injected storage
+    // must win instead — proving the DI override is effective on the sandbox
+    // path, which is the genuinely new behaviour.
+    const socketPath = await startServerWithNamedKey();
+    process.env.LLXPRT_CREDENTIAL_SOCKET = socketPath;
+
+    const injectedKey = 'injected-key-wins-2946';
+    const injectedStorage: IProviderKeyStorage = {
+      getKey: async () => injectedKey,
+      listKeys: async () => [],
+      hasKey: async () => true,
+    };
+
+    const provider = new ProxyAwareProvider(injectedStorage);
+    const settings = new SettingsService();
+    settings.set('activeProvider', 'proxy-aware');
+    settings.set('auth-key-name', NAMED_KEY);
+    const config = createRuntimeConfigStub(settings);
+    setActiveProviderRuntimeContext({ settingsService: settings, config });
+    provider.setRuntimeSettingsService(settings);
+
+    await provider.generateChatCompletion(buildChatOptions(settings)).next();
+
+    expect(provider.capturedAuthToken).toBe(injectedKey);
+  });
+});

--- a/packages/providers/src/auth/proxy/credential-proxy-server.ts
+++ b/packages/providers/src/auth/proxy/credential-proxy-server.ts
@@ -28,7 +28,7 @@ import {
 import { mergeRefreshedToken } from '@vybestack/llxprt-code-auth/token-merge.js';
 import { sanitizeTokenForProxy } from '@vybestack/llxprt-code-auth/token-sanitization.js';
 // ProviderKeyStorage now lives in the storage package
-import type { ProviderKeyStorage } from '@vybestack/llxprt-code-storage';
+import type { ProviderKeyStorageLike } from '@vybestack/llxprt-code-storage';
 import {
   CredentialProxyOAuthHandler,
   type OAuthFlowInterface,
@@ -69,7 +69,7 @@ const isWindows = process.platform === 'win32';
 
 export interface CredentialProxyServerOptions {
   tokenStore: TokenStore;
-  providerKeyStorage: ProviderKeyStorage;
+  providerKeyStorage: ProviderKeyStorageLike;
   socketDir?: string;
   /** Flow factories for OAuth initiation - maps provider name to factory function */
   flowFactories?: Map<string, () => OAuthFlowInterface>;

--- a/packages/providers/src/gemini/GeminiProvider.auth.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.auth.test.ts
@@ -365,7 +365,10 @@ describe('GeminiProvider Authentication', () => {
     expect(error).toBeInstanceOf(Error);
     const message = (error as Error).message;
     expect(message).toContain('not available inside a container sandbox');
+    // Must point at both halves of the working path: save on the host, load
+    // inside the sandbox. Naming only one leaves the user stuck.
     expect(message).toContain('/key save');
+    expect(message).toContain('/key load');
     // The sandbox message must NOT direct the user to set GEMINI_API_KEY,
     // because that variable no longer crosses into the container.
     expect(message).not.toContain('Set GEMINI_API_KEY environment variable');

--- a/packages/providers/src/gemini/GeminiProvider.auth.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.auth.test.ts
@@ -82,6 +82,7 @@ describe('GeminiProvider Authentication', () => {
     delete process.env.GOOGLE_CLOUD_PROJECT;
     delete process.env.GOOGLE_CLOUD_LOCATION;
     delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    delete process.env.LLXPRT_CREDENTIAL_SOCKET;
   });
 
   afterEach(() => {
@@ -91,6 +92,7 @@ describe('GeminiProvider Authentication', () => {
     delete process.env.GOOGLE_CLOUD_PROJECT;
     delete process.env.GOOGLE_CLOUD_LOCATION;
     delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+    delete process.env.LLXPRT_CREDENTIAL_SOCKET;
   });
 
   it('should check AuthResolver before falling back to Vertex AI', async () => {
@@ -342,6 +344,62 @@ describe('GeminiProvider Authentication', () => {
       createGenAIClientViaProvider(provider, 'USE_VERTEX_AI', 'vertex-ai'),
     ).rejects.toThrow(
       'Vertex AI mode is active but project/location are not configured',
+    );
+  });
+
+  // #2946: inside a container sandbox, ambient Google credentials are
+  // intentionally unavailable. The auth-failure message must say so and direct
+  // the user to save a key with `/key save`, not to set GEMINI_API_KEY (which
+  // no longer crosses into the container).
+  it('gives a sandbox-aware auth message when LLXPRT_CREDENTIAL_SOCKET is set', async () => {
+    const mockAuthResolver = {
+      resolveAuthentication: vi.fn().mockResolvedValue(null),
+    };
+    process.env.LLXPRT_CREDENTIAL_SOCKET = '/tmp/test-cred-socket.sock';
+
+    const provider = createProviderWithRuntimeSettings();
+    (provider as unknown as { authResolver: unknown }).authResolver =
+      mockAuthResolver;
+
+    const error = await provider.getAuthMode().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain('not available inside a container sandbox');
+    expect(message).toContain('/key save');
+    // The sandbox message must NOT direct the user to set GEMINI_API_KEY,
+    // because that variable no longer crosses into the container.
+    expect(message).not.toContain('Set GEMINI_API_KEY environment variable');
+  });
+
+  it('keeps the standard auth message when not in a sandbox', async () => {
+    const mockAuthResolver = {
+      resolveAuthentication: vi.fn().mockResolvedValue(null),
+    };
+
+    const provider = createProviderWithRuntimeSettings();
+    (provider as unknown as { authResolver: unknown }).authResolver =
+      mockAuthResolver;
+
+    await expect(provider.getAuthMode()).rejects.toThrow(
+      'No Gemini authentication configured. Set GEMINI_API_KEY environment variable, use --keyfile, or configure Vertex AI credentials.',
+    );
+  });
+
+  // An empty LLXPRT_CREDENTIAL_SOCKET means "no socket" to the sanctioned
+  // credential factories, which fall through to direct host storage. The
+  // message must match that routing rather than claiming a sandbox.
+  it('keeps the standard auth message when LLXPRT_CREDENTIAL_SOCKET is empty', async () => {
+    const mockAuthResolver = {
+      resolveAuthentication: vi.fn().mockResolvedValue(null),
+    };
+    process.env.LLXPRT_CREDENTIAL_SOCKET = '';
+
+    const provider = createProviderWithRuntimeSettings();
+    (provider as unknown as { authResolver: unknown }).authResolver =
+      mockAuthResolver;
+
+    await expect(provider.getAuthMode()).rejects.toThrow(
+      'No Gemini authentication configured. Set GEMINI_API_KEY environment variable, use --keyfile, or configure Vertex AI credentials.',
     );
   });
 });

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -114,7 +114,9 @@ export class GeminiProvider extends BaseProvider {
     }
 
     throw new Error(
-      'No Gemini authentication configured. Set GEMINI_API_KEY environment variable, use --keyfile, or configure Vertex AI credentials.',
+      process.env.LLXPRT_CREDENTIAL_SOCKET
+        ? 'No Gemini authentication configured inside the sandbox. Ambient Google credentials (GEMINI_API_KEY, GOOGLE_API_KEY, ADC, gcloud) are intentionally not available inside a container sandbox. Save your Gemini API key on the host with `/key save <name> <key>` and reference it with `--key-name <name>` or a profile `auth-key-name`; it is resolved through the credential proxy.'
+        : 'No Gemini authentication configured. Set GEMINI_API_KEY environment variable, use --keyfile, or configure Vertex AI credentials.',
     );
   }
 

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -115,7 +115,7 @@ export class GeminiProvider extends BaseProvider {
 
     throw new Error(
       process.env.LLXPRT_CREDENTIAL_SOCKET
-        ? 'No Gemini authentication configured inside the sandbox. Ambient Google credentials (GEMINI_API_KEY, GOOGLE_API_KEY, ADC, gcloud) are intentionally not available inside a container sandbox. Save your Gemini API key on the host with `/key save <name> <key>` and reference it with `--key-name <name>` or a profile `auth-key-name`; it is resolved through the credential proxy.'
+        ? 'No Gemini authentication configured inside the sandbox. Ambient Google credentials (GEMINI_API_KEY, GOOGLE_API_KEY, ADC, gcloud) are intentionally not available inside a container sandbox. Gemini itself still works via named keys: save one on the host with `/key save <name> <key>`, then use `/key load <name>` here, or start with `--key-name <name>` or a profile `auth-key-name`. The key is fetched through the credential proxy.'
         : 'No Gemini authentication configured. Set GEMINI_API_KEY environment variable, use --keyfile, or configure Vertex AI credentials.',
     );
   }

--- a/project-plans/issue2946/followup-sandbox-flags.md
+++ b/project-plans/issue2946/followup-sandbox-flags.md
@@ -1,0 +1,28 @@
+Split out from #2946. That issue removed the automatic forwarding of Google credentials into the container sandbox. This one is a separate route by which a repository — not the user — can re-introduce that forwarding.
+
+## The problem
+
+`packages/cli/src/config/config.ts` unconditionally calls the environment loader, and `packages/cli/src/config/environmentLoader.ts` selects a project-level `.env` and hands it straight to `dotenv.config()` with no exclusion list for sandbox launcher control variables.
+
+`packages/cli/src/utils/sandbox-containers.ts` then shell-parses `SANDBOX_FLAGS` and appends the result verbatim to the Docker/Podman argument list.
+
+The consequence: checking out a repository that contains a `.env` with
+
+    SANDBOX_FLAGS=--env GEMINI_API_KEY
+
+causes the container engine to inherit the host's ambient `GEMINI_API_KEY`, undoing the #2946 fix without the user choosing anything. The same route allows `--env-file`, `--volume` (re-mounting `~/.config/gcloud` or an ADC file), and any other engine flag.
+
+## Why this is different from the accepted escape hatches
+
+`SANDBOX_ENV`, `LLXPRT_SANDBOX_MOUNTS` / `SANDBOX_MOUNTS`, profile `mounts`, and a manually exported `SANDBOX_FLAGS` are all explicit user choices, and #2946 deliberately left them alone. The defect here is that an untrusted project directory silently gains control of the host launcher, which is not a user choice at all.
+
+## Suggested resolution
+
+Prevent project-level env files from setting sandbox launcher and control variables — at minimum `SANDBOX_FLAGS`, `SANDBOX_ENV`, the mount variables, and the engine / network / resource controls — while preserving values the user explicitly exported in their shell or set in a profile. Apply folder-trust checks before launcher controls are consumed.
+
+## Acceptance criteria
+
+- A project `.env` setting `SANDBOX_FLAGS` does not influence the generated container run arguments.
+- The same applies to `SANDBOX_ENV` and the mount variables.
+- A shell-exported or profile-supplied `SANDBOX_FLAGS` continues to work.
+- A behavioral test uses a real project `.env` plus an ambient sentinel API key and proves the sentinel never reaches the generated run arguments.

--- a/project-plans/issue2946/followup-settings-mount.md
+++ b/project-plans/issue2946/followup-settings-mount.md
@@ -1,0 +1,34 @@
+Split out from #2946, which removed the dedicated `GEMINI_API_KEY` / `GOOGLE_API_KEY` env forwarding and the gcloud / `GOOGLE_APPLICATION_CREDENTIALS` mounts. A separate, pre-existing crossing remains.
+
+## What crosses the boundary
+
+`buildContainerRunArgs` in `packages/cli/src/utils/sandbox-containers.ts` unconditionally bind-mounts `USER_SETTINGS_DIR` read-write into the container:
+
+    args.push('--volume', userSettingsDirOnHost + ':' + userSettingsDirInSandbox);
+
+`USER_SETTINGS_DIR` is `path.dirname(Storage.getGlobalSettingsPath())` (`packages/cli/src/config/paths.ts`), which resolves to `Storage.getGlobalConfigDir()` — the same directory that holds:
+
+- `profiles/*.json`, which `ProfileManager` persists with raw inline credentials. `ProfileManager.ts` writes `ephemeralSettings['auth-key']` and `providerSettings['auth-key']` verbatim; the round-trip is asserted in `packages/settings/src/profiles/__tests__/ProfileManager.test.ts`.
+- a global `.env`, a supported location per `packages/cli/src/config/environmentLoader.ts`.
+
+Any process inside the container can read those files directly, independently of whether the inner CLI ever loads them. The mount is read-write, so they can also be modified.
+
+## Why it matters
+
+This is the same class of defect #2946 addressed: material that the credential proxy exists to keep on the host still reaches the container. A user who saves a key inline in a profile (rather than via `/key save`) still hands that raw key to anything running in the sandbox.
+
+## Why it was not fixed in #2946
+
+#2946 was scoped to the Google-specific env forwarding and the gcloud/ADC mounts. Fixing this one requires a sanitized per-session config view — deciding which settings and profile fields the container legitimately needs, and projecting only those — which is a new subsystem rather than a deletion.
+
+## Suggested resolution
+
+Stop mounting the host global config directory wholesale. Generate a per-session sanitized view containing only the non-secret settings and profile metadata the sandboxed CLI actually needs, excluding `.env`, inline `auth-key`, `auth-keyfile` paths, and any other credential-bearing content. Consider whether the mount needs to be read-write at all.
+
+## Acceptance criteria
+
+- A profile containing an inline `auth-key` on the host is not readable from inside the container.
+- A global `.env` on the host is not readable from inside the container.
+- The sandboxed CLI still loads the settings and profile metadata it needs to run.
+- A behavioral test drives the full `buildContainerRunArgs` output and proves no default mount exposes host credential files.
+- `docs/sandbox.md` is updated; it currently has to hedge its isolation claims because of this mount.

--- a/project-plans/issue2946/followup-vertex-proxy.md
+++ b/project-plans/issue2946/followup-vertex-proxy.md
@@ -1,0 +1,22 @@
+Split out from #2946. That issue stopped mounting `~/.config/gcloud` and the `GOOGLE_APPLICATION_CREDENTIALS` file into the container sandbox, on the issue author's explicit acceptance that gcloud/ADC material simply would not be available inside the container for now.
+
+## Consequence
+
+Vertex AI requests from inside a container sandbox no longer authenticate. `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `GOOGLE_GENAI_USE_VERTEXAI` are still forwarded (they are non-secret configuration), so `hasVertexAICredentials()` can still select `vertex-ai` mode inside the container — but the ADC material it would need is deliberately no longer there, so the request fails at call time.
+
+An API key saved on the host with `/key save` and referenced by `auth-key-name` does resolve through the credential proxy inside the container, but `GeminiProvider.determineBestAuth()` classifies every resolver-supplied token as `gemini-api-key`, and `buildGoogleGenAIOptions()` sets `vertexai: true` only for the `vertex-ai` auth mode. So a proxy-resolved named key authenticates against the Gemini Developer API, not Vertex. `packages/providers/src/gemini/GeminiProvider.auth.test.ts` asserts this current behavior directly.
+
+## Options
+
+1. Mediate ADC through the credential proxy: add a host-side token exchange (`google-auth-library`) served as a new proxy op, so the container receives short-lived Google access tokens instead of the service-account file. This is the design-consistent answer and matches how OAuth already works.
+2. Support Vertex-with-API-key: add an explicit auth mode that pairs a proxy-resolved named key with `vertexai: true` when the Vertex configuration variables are present.
+
+Option 1 is the more general fix; option 2 is narrower but only covers deployments where a Vertex API key is viable.
+
+## Acceptance criteria
+
+- Vertex AI requests authenticate from inside a container sandbox without any gcloud directory or ADC file crossing the boundary.
+- Whatever credential the container receives is short-lived, or is a named key fetched through the proxy — never a raw service-account file.
+- Host behavior is unchanged.
+- Behavioral coverage proves the end-to-end path, including that the resulting client is configured for Vertex rather than the Gemini Developer API.
+- `docs/sandbox.md` is updated; it currently states plainly that Vertex/ADC does not work inside a container.

--- a/project-plans/issue2946/plan.md
+++ b/project-plans/issue2946/plan.md
@@ -1,0 +1,181 @@
+# Issue #2946 — Stop forwarding Google credential material into the container sandbox
+
+## Problem
+
+`packages/cli/src/utils/sandbox-containers.ts` forwards long-lived Google
+credential material into Docker/Podman sandboxes, bypassing the credential
+proxy that exists specifically to keep stored secrets on the host:
+
+- `addContainerEnvVars` copies `GEMINI_API_KEY` and `GOOGLE_API_KEY` from the
+  host process into the container with `--env`.
+- `addContainerVolumeMounts` mounts `~/.config/gcloud` read-only when it exists,
+  mounts the file named by `GOOGLE_APPLICATION_CREDENTIALS` read-only, and
+  re-exports `GOOGLE_APPLICATION_CREDENTIALS` inside the container.
+
+Any process inside the container — including anything an LLM-generated command
+spawns — can read these from `env`, `/proc/self/environ`, or the mounted files.
+
+## Accepted behavior (in scope)
+
+**B1 — No secret Google API keys in the container environment.**
+The container run arguments produced by `addContainerEnvVars` contain no
+`--env GEMINI_API_KEY=…` and no `--env GOOGLE_API_KEY=…` entry, regardless of
+whether those variables are set on the host.
+
+**B2 — Non-secret Vertex/Gemini configuration still crosses.**
+`GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_GENAI_USE_GCA`, `GOOGLE_CLOUD_PROJECT`,
+`GOOGLE_CLOUD_LOCATION`, `GEMINI_MODEL`, `TERM`, and `COLORTERM` continue to be
+forwarded when set. These are configuration, not credentials.
+
+**B3 — No gcloud directory mount.**
+`addContainerVolumeMounts` produces no `--volume` entry for
+`~/.config/gcloud`, even when that directory exists on the host.
+
+**B4 — No ADC mount and no ADC re-export.**
+`addContainerVolumeMounts` produces no `--volume` entry for the file named by
+`GOOGLE_APPLICATION_CREDENTIALS` and no
+`--env GOOGLE_APPLICATION_CREDENTIALS=…` entry, even when the variable is set
+and the file exists on the host.
+
+**B5 — User-requested mounts are unaffected.**
+Mounts supplied via `LLXPRT_SANDBOX_MOUNTS`, `SANDBOX_MOUNTS`, and profile
+`mounts` continue to produce `--volume` entries exactly as before. The user
+asked for those explicitly.
+
+**B6 — Named-key resolution is proxy-aware in `BaseProvider`.**
+`BaseProvider`'s default provider-key storage is obtained from
+`createProviderKeyStorage()` (the sanctioned factory) instead of the direct
+`getProviderKeyStorage()`. Inside a sandbox (`LLXPRT_CREDENTIAL_SOCKET` set)
+this resolves `auth-key-name` through the credential proxy; on the host with no
+socket set, behavior is unchanged (direct storage). Callers may still inject
+`config.providerKeyStorage`.
+
+This is what keeps Gemini and Vertex API-key auth working from inside the
+container after B1: the key is saved on the host with `/key save`, referenced by
+`auth-key-name`, and fetched over the proxy socket. Every other named-key
+resolution path in the codebase (`runtime/keyResolution.ts`,
+`runtime/profileApplication.ts`, `ui/commands/keyCommand.ts`,
+`profile-application/loadBalancerProfile.ts`) already uses
+`createProviderKeyStorage()`; `BaseProvider` is the last direct caller and would
+otherwise reach for the host keyring from inside the container, where it is not
+reachable.
+
+**B7 — Documentation reflects the new boundary.**
+`docs/sandbox.md` no longer describes these crossings as a known defect. The
+threat-model bullet, the isolation table's "Stored secrets" row, the
+filesystem-mounts list, and the "Known credential leakage in containers" section
+are updated to state that stored provider credentials do not cross into the
+container, and that Gemini/Vertex API keys are supplied with `/key save` and
+resolved through the proxy.
+
+**B8 — Seatbelt is untouched.**
+No change to `sandbox-seatbelt.ts` or the `.sb` profiles. Seatbelt runs on the
+host with full keyring access by design.
+
+## Explicitly out of scope
+
+- Any new host-side ADC/`google-auth-library` token-exchange op on the proxy.
+  Per the issue addendum, ADC/gcloud material simply does not cross for now.
+- A Gemini OAuth flow (Gemini has no OAuth flow in this codebase).
+- An opt-in escape hatch to re-enable the forwarding. Not requested; the
+  addendum says "I'm good just not passing it for now."
+- Changing `envKeyNames` on `GeminiProvider`, `hasVertexAICredentials`,
+  `contentGenerator.ts`, or any other host-side env reading. Those remain
+  correct on the host; they simply find nothing inside the container.
+- Any change to `addCustomMounts`, `buildSandboxEnvArgs`, `SANDBOX_ENV`,
+  `VIRTUAL_ENV`, `NODE_OPTIONS`, or the capability-token transport.
+
+## Boundary cases to cover
+
+| Case                                                            | Expected                                                         |
+| --------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `GEMINI_API_KEY` set on host                                     | absent from generated args                                       |
+| `GOOGLE_API_KEY` set on host                                     | absent from generated args                                       |
+| Both unset                                                       | absent from generated args (no regression)                       |
+| `~/.config/gcloud` exists on host                                | no `--volume` for it                                             |
+| `GOOGLE_APPLICATION_CREDENTIALS` set and file exists             | no `--volume` for it, no `--env GOOGLE_APPLICATION_CREDENTIALS=`  |
+| `GOOGLE_APPLICATION_CREDENTIALS` set and file missing            | no mount, no env (already true; must stay true)                  |
+| `LLXPRT_SANDBOX_MOUNTS` set                                      | `--volume` entry still produced                                  |
+| `SANDBOX_MOUNTS` set (legacy)                                    | `--volume` entry still produced                                  |
+| Non-secret config vars set                                       | still forwarded with `--env`                                     |
+| `LLXPRT_CREDENTIAL_SOCKET` set, `BaseProvider` resolves key name | request goes over the proxy socket, not the host keyring         |
+| `LLXPRT_CREDENTIAL_SOCKET` unset, `BaseProvider` resolves        | direct storage, unchanged                                        |
+
+## Tests that prove it (behavioral, no mock theater)
+
+### `packages/cli/src/utils/sandbox-containers.test.ts`
+
+Follow the existing patterns in that file: snapshot/restore `process.env`, real
+temp fixture directory, `vi.mock('node:child_process')`.
+
+1. `addContainerEnvVars` with `GEMINI_API_KEY` and `GOOGLE_API_KEY` set on
+   `process.env` produces args whose `--env` values contain no entry starting
+   with `GEMINI_API_KEY=` or `GOOGLE_API_KEY=`. Assert on the actual generated
+   argument array, not on a mock.
+2. The same call, with the non-secret configuration variables set, still emits
+   `--env GOOGLE_CLOUD_PROJECT=…`, `--env GOOGLE_CLOUD_LOCATION=…`,
+   `--env GOOGLE_GENAI_USE_VERTEXAI=…`, `--env GOOGLE_GENAI_USE_GCA=…`, and
+   `--env GEMINI_MODEL=…`.
+3. `addContainerVolumeMounts` with a real gcloud-directory fixture (created via
+   a stubbed `os.homedir()` pointing at a temp dir containing `.config/gcloud`)
+   produces no `--volume` argument referencing that path.
+4. `addContainerVolumeMounts` with `GOOGLE_APPLICATION_CREDENTIALS` pointing at
+   a real temp file produces no `--volume` referencing it and no `--env`
+   argument starting with `GOOGLE_APPLICATION_CREDENTIALS=`.
+5. `addContainerVolumeMounts` with `LLXPRT_SANDBOX_MOUNTS` set to a real temp
+   directory still produces the corresponding `--volume` entry (guards B5).
+6. Same as (5) for the legacy `SANDBOX_MOUNTS` name.
+
+### `BaseProvider` proxy-aware key storage
+
+Add coverage in the providers package (co-locate with existing `BaseProvider`
+tests, e.g. `packages/providers/src/__tests__/`).
+
+7. With `LLXPRT_CREDENTIAL_SOCKET` set to a real listening Unix-socket test
+   double serving `get_api_key`, a `BaseProvider` subclass configured with
+   `auth-key-name` resolves the key served by that socket. Prove it by
+   asserting the resolved key equals the value the socket served — the host
+   keyring is never consulted. Reuse the existing proxy test doubles under
+   `packages/providers/src/auth/proxy/__tests__/` where available.
+8. With `LLXPRT_CREDENTIAL_SOCKET` unset and no injected storage, construction
+   and resolution behave exactly as today (direct storage path) — no throw, no
+   proxy client created.
+9. An explicitly injected `config.providerKeyStorage` still wins over the
+   factory default.
+
+Use `resetFactorySingletons()` in teardown so the proxy singletons do not leak
+between tests.
+
+## Implementation notes
+
+- `packages/cli/src/utils/sandbox-containers.ts`
+  - `addContainerVolumeMounts`: delete the gcloud block and the ADC block; keep
+    the `LLXPRT_SANDBOX_MOUNTS` / `SANDBOX_MOUNTS` block. Update the JSDoc,
+    which currently reads "Adds gcloud, ADC, and custom SANDBOX_MOUNTS volume
+    flags." Drop now-unused imports only if they become unused (`os`, `fs`,
+    `path` are used elsewhere in the file — verify before touching).
+  - `addContainerEnvVars`: remove the two secret keys from `envMap`. Update the
+    JSDoc, which currently reads "Adds environment variable flags for API keys,
+    term, proxy, etc."
+- `packages/providers/src/BaseProvider.ts`
+  - Import `createProviderKeyStorage` from
+    `./auth/proxy/credential-store-factory.js` directly (not from the heavy
+    `./auth/index.js` barrel) to avoid an import cycle, and use it as the
+    fallback at the `config.providerKeyStorage ?? …` site. Update the adjacent
+    comment, which explains the current `getProviderKeyStorage()` fallback.
+  - Verify no cycle is introduced (`credential-store-factory.ts` imports only
+    `@vybestack/llxprt-code-auth`, `@vybestack/llxprt-code-core/auth-factories.js`,
+    `@vybestack/llxprt-code-storage`, and `node:fs`).
+- `docs/sandbox.md` — see B7. Also check `docs/cli/sandbox-profiles.md` and
+  `docs/cli/google-cloud-auth.md` for links/anchors that break when the
+  "Known credential leakage in containers" section is rewritten, and fix any
+  that do.
+
+## Guardrails
+
+- No new `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, or `@ts-nocheck`.
+- No loosening of any lint/complexity threshold.
+- Fail fast; do not add defensive wrappers.
+- Verification before commit: `npm run test`, `npm run lint`,
+  `npm run typecheck`, `npm run format`, `npm run build`, and
+  `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.

--- a/scripts/affected-test-shards.data.json
+++ b/scripts/affected-test-shards.data.json
@@ -84,6 +84,7 @@
     "vscode-ide-companion": ["ide-integration"]
   },
   "testOnlyEdges": {
+    "agents": ["storage"],
     "cli": ["test-utils"],
     "core": ["providers", "test-utils"],
     "tools": ["storage", "test-utils"]

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -95,6 +95,7 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
   {
     workspace: 'agents',
     files: [
+      'src/core/CompressionProfileResolver.proxyKeyStorage.test.ts',
       'test-bun/generatingModelStamp.issue2511.bun.ts',
       'test-bun/subagentAnthropicTextSettings.issue1738.bun.ts',
     ],
@@ -116,6 +117,7 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       'src/observation/jspTransport.test.ts',
       'src/observation/jspWiring.test.ts',
       'src/observation/observationTap.test.ts',
+      'src/utils/sandbox-containers.test.ts',
       // Sandbox SSH agent preflight (issue #1699). Bun-native from the start
       // and likewise excluded from the Vitest selection.
       'src/utils/sandbox-ssh-agent-preflight.test.ts',
@@ -137,6 +139,7 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       'src/__tests__/attemptLifecycle.helpers.test.ts',
       'src/__tests__/auth-migration-p16.integration.test.ts',
       'src/__tests__/BaseProvider.guard.test.ts',
+      'src/__tests__/BaseProvider.proxyKeyStorage.test.ts',
       'src/__tests__/baseProvider.stateless.test.ts',
       'src/__tests__/BaseProviderNormalization.ephemeralPropagation.test.ts',
       'src/__tests__/BaseProviderNormalization.invocation.test.ts',


### PR DESCRIPTION
Fixes #2946

## The problem

Container sandboxing existed to contain an untrusted model, but it handed that model the user's Google credentials on the way in.

`packages/cli/src/utils/sandbox-containers.ts` did three things that defeated the credential proxy:

- `addContainerEnvVars` copied `GEMINI_API_KEY` and `GOOGLE_API_KEY` from the host process into the container with `--env`. Raw, long-lived keys — readable by any process in the container via `env` or `/proc/self/environ`.
- `addContainerVolumeMounts` mounted `~/.config/gcloud` read-only whenever it existed. That directory can hold refresh credentials and service-account keys.
- The same function mounted the file named by `GOOGLE_APPLICATION_CREDENTIALS` read-only and re-exported the variable inside the container. That file is typically a service-account JSON key that can mint access tokens from anywhere.

The credential proxy is careful work: the container talks to a Unix socket, receives short-lived tokens, key writes are refused, and the capability token arrives over an inherited descriptor so it never appears in argv, the environment, or a readable mounted file. Forwarding raw keys in plain environment variables threw that away for these providers.

## What changed

**The three crossings are gone.** No `--env GEMINI_API_KEY`, no `--env GOOGLE_API_KEY`, no gcloud mount, no ADC mount, no `GOOGLE_APPLICATION_CREDENTIALS` re-export.

**Non-secret configuration still crosses.** `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_GENAI_USE_GCA`, `GEMINI_MODEL`, `TERM`, and `COLORTERM` are configuration, not credentials, and are untouched.

**Mounts the user asked for still work.** `LLXPRT_SANDBOX_MOUNTS`, `SANDBOX_MOUNTS`, and profile `mounts` are unchanged and covered by explicit regression tests. The issue called these out as a separate, legitimate case.

**Seatbelt is untouched**, as the issue specified.

## Making Gemini still work from inside the container

Removing the env forwarding is only half the job — the container has to be able to authenticate some other way. It does: keys saved on the host with `/key save` and referenced by `auth-key-name` resolve over the proxy socket.

Verifying that path turned up two places where named-key resolution still reached for the host keyring directly instead of the sanctioned factory:

- `BaseProvider` called `getProviderKeyStorage()` (direct) rather than `createProviderKeyStorage()`.
- `CompressionProfileResolver` did the same, even though `provider-key-storage.ts` explicitly prohibits consumer calls to it.

Inside a container that storage is unreachable, so an `auth-key-name` would simply fail. Both now use `createProviderKeyStorage()`, which returns proxy-backed storage when `LLXPRT_CREDENTIAL_SOCKET` is set and the identical direct singleton otherwise. Host behavior is unchanged, and callers can still inject their own storage.

Every other named-key path in the codebase — `runtime/keyResolution.ts`, `runtime/profileApplication.ts`, `ui/commands/keyCommand.ts`, `profile-application/loadBalancerProfile.ts` — was already using the factory. These were the last two stragglers.

## A misleading error message

A user with `GEMINI_API_KEY` exported in their shell, running a sandbox, now hits the Gemini auth failure — and the old message told them to *set `GEMINI_API_KEY`*, which is precisely the thing that no longer crosses. When a credential socket is present the message now explains that ambient Google credentials are intentionally unavailable inside a sandbox and points at `/key save` plus `--key-name`. Outside a sandbox the message is unchanged. The check uses the same truthy test as the credential factories, so an empty `LLXPRT_CREDENTIAL_SOCKET` gets the host message, matching where the credentials actually come from.

## What this PR does not claim

The issue's addendum accepted that gcloud/ADC material simply would not cross for now. That has a consequence worth stating plainly rather than glossing: **Vertex AI no longer authenticates from inside a container sandbox.** A proxy-resolved named key authenticates against the Gemini Developer API, not Vertex, because Vertex requires the `vertex-ai` auth mode which a named key does not establish. `docs/sandbox.md` says this directly, and #2959 tracks proxying Vertex properly.

Two further crossings surfaced while verifying this one. Neither is in this issue's scope, and both are documented honestly in `docs/sandbox.md` rather than hidden behind a blanket "credentials do not cross" claim that would have been false:

- The LLxprt global config directory is still bind-mounted read-write, and it holds `profiles/*.json` — which `ProfileManager` persists with raw inline `auth-key` values — plus a global `.env`. Tracked as #2957.
- A project-level `.env` can set `SANDBOX_FLAGS`, letting an untrusted repository inject arbitrary engine flags (including `--env GEMINI_API_KEY`) into the host launcher. Tracked as #2958.

Fixing either would mean building a sanitized config-view subsystem or a launcher-variable trust boundary — new subsystems, not deletions.

## Tests

All new and modified tests are Bun-native and registered in `scripts/bun-test-manifest.ts`. This mattered more than it sounds: `packages/providers` runs entirely off that manifest, so a new test file that is not listed is silently never executed.

`packages/cli/src/utils/sandbox-containers.test.ts` — six behavioral tests driving the real generated argument array:

- `GEMINI_API_KEY` and `GOOGLE_API_KEY` set to sentinel values on the host produce no matching `--env` entry, and the sentinel values appear nowhere in the args.
- The non-secret configuration variables are still emitted as genuine adjacent `--env` / `KEY=value` pairs (parsed as pairs, not merely present somewhere in the array).
- A real gcloud fixture directory produces no `--volume` operand referencing it.
- A real `GOOGLE_APPLICATION_CREDENTIALS` file produces no mount and no re-export.
- `LLXPRT_SANDBOX_MOUNTS` and legacy `SANDBOX_MOUNTS` still produce their `--volume` entries.

The file's `vi.mock('node:child_process')` automock crashed under Bun (the shim walks module exports and hits a private-field getter), so it is now an explicit factory mock supplying only `execSync`, `spawn`, and `exec`. Every pre-existing `#1456` assertion still runs unchanged, under both runners.

`packages/providers/src/__tests__/BaseProvider.proxyKeyStorage.test.ts` — a real `CredentialProxyServer` on a real Unix socket. A `BaseProvider` subclass with `auth-key-name` resolves the key served over that socket, asserted at the provider's execution boundary. A second test proves an injected `providerKeyStorage` still wins even with a socket set.

`packages/agents/src/core/CompressionProfileResolver.proxyKeyStorage.test.ts` — same real-socket approach for the compression path, plus the boundary case where the proxy has no such key and the resolver must report no auth rather than falling through.

`packages/providers/src/gemini/GeminiProvider.auth.test.ts` — the sandbox-aware message, the host message, and the empty-socket case.

The removal guards were confirmed to genuinely fail against the pre-change implementation, not merely pass against the new one.

## Verification

`npm run test` (all workspaces green), `npm run test:scripts`, `npm run lint`, `npm run lint:eslint-guard`, `npm run typecheck`, `npm run format`, `npm run build`, and the smoke test all pass. No lint suppressions, type suppressions, severity downgrades, or threshold increases were added.

Two `test:scripts` files initially failed with `[vitest-worker]: Timeout calling "onTaskUpdate"` under load; re-run in isolation they pass 57/57.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved sandbox credential isolation by preventing API keys, application credentials, and local cloud configuration from being forwarded or mounted automatically.
  * Added guidance for authenticating through the credential proxy and documented remaining credential-handling limitations.

* **Bug Fixes**
  * Named provider keys now resolve correctly through the credential proxy.
  * Added clearer authentication errors when sandbox credentials are unavailable.

* **Tests**
  * Expanded coverage for credential-proxy authentication, sandbox isolation, and supported configuration mounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->