### PR TITLE
Block tool execution when a BeforeTool hook exits 2 with no stderr (Fixes #2942)

### DIFF
--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestRig, poll } from './test-helper.js';
 import { join } from 'node:path';
-import { writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 
 describe('Hooks System Integration', () => {
   let rig: TestRig;
@@ -137,6 +137,63 @@ process.exit(2);
         'File writing blocked by security policy',
       );
       expect(blockHook?.hookCall.success).toBe(false);
+    });
+
+    it('should block tool execution with default reason when hook exits code 2 with empty stderr', async () => {
+      rig.setup(
+        'should block tool execution with default reason when hook exits code 2 with empty stderr',
+        {
+          fakeResponsesPath: join(
+            import.meta.dirname,
+            'hooks-system.block-tool.responses',
+          ),
+          settings: {
+            hooks: {
+              enabled: true,
+              BeforeTool: [
+                {
+                  matcher: 'write_file',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: 'bun exit2_block_hook.ts',
+                      timeout: 5000,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      );
+      const exit2HookPath = join(rig.testDir!, 'exit2_block_hook.ts');
+      writeFileSync(
+        exit2HookPath,
+        `import process from 'node:process';
+process.exit(2);
+`,
+      );
+
+      await rig.run({
+        args: 'Create a file called test.txt with content "Hello World"',
+      });
+
+      // The tool must not run at all, successfully or otherwise
+      const toolLogs = rig.readToolLogs();
+      const writeFileCalls = toolLogs.filter(
+        (t) => t.toolRequest.name === 'write_file' && t.toolRequest.success,
+      );
+      expect(writeFileCalls).toHaveLength(0);
+      expect(existsSync(join(rig.testDir!, 'test.txt'))).toBe(false);
+
+      // Verify hook telemetry shows exit code 2 and the synthesized deny reason
+      const hookLogs = rig.readHookLogs();
+      const blockHook = hookLogs.find((log) => log.hookCall.exit_code === 2);
+      expect(blockHook).toBeDefined();
+      expect(blockHook?.hookCall.success).toBe(false);
+      expect(JSON.stringify(blockHook?.hookCall.hook_output)).toContain(
+        'Hook exited with code 2 without an error message',
+      );
     });
 
     it('should allow tool execution when hook returns allow decision', async () => {

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -129,7 +129,7 @@ process.exit(2);
       // Result should mention the blocking reason from stderr
       expect(result).toContain('File writing blocked by security policy');
 
-      // Verify hook telemetry shows exit code 2 and stderr
+      // Verify hook telemetry shows exit code 2, stderr and the deny decision
       const hookLogs = rig.readHookLogs();
       const blockHook = hookLogs.find((log) => log.hookCall.exit_code === 2);
       expect(blockHook).toBeDefined();
@@ -137,6 +137,17 @@ process.exit(2);
         'File writing blocked by security policy',
       );
       expect(blockHook?.hookCall.success).toBe(false);
+      // Telemetry serializes hook_output as a JSON string.
+      const stderrHookOutput = JSON.parse(
+        String(blockHook?.hookCall.hook_output),
+      ) as {
+        decision?: string;
+        reason?: string;
+      };
+      expect(stderrHookOutput.decision).toBe('deny');
+      expect(stderrHookOutput.reason).toBe(
+        'File writing blocked by security policy',
+      );
     });
 
     it('should block tool execution with default reason when hook exits code 2 with empty stderr', async () => {
@@ -186,12 +197,20 @@ process.exit(2);
       expect(writeFileCalls).toHaveLength(0);
       expect(existsSync(join(rig.testDir!, 'test.txt'))).toBe(false);
 
-      // Verify hook telemetry shows exit code 2 and the synthesized deny reason
+      // Verify hook telemetry shows exit code 2 and the synthesized deny decision
       const hookLogs = rig.readHookLogs();
       const blockHook = hookLogs.find((log) => log.hookCall.exit_code === 2);
       expect(blockHook).toBeDefined();
       expect(blockHook?.hookCall.success).toBe(false);
-      expect(JSON.stringify(blockHook?.hookCall.hook_output)).toContain(
+      // Telemetry serializes hook_output as a JSON string.
+      const hookOutput = JSON.parse(
+        String(blockHook?.hookCall.hook_output),
+      ) as {
+        decision?: string;
+        reason?: string;
+      };
+      expect(hookOutput.decision).toBe('deny');
+      expect(hookOutput.reason).toBe(
         'Hook exited with code 2 without an error message',
       );
     });

--- a/integration-tests/hooks/hooks-e2e.integration.test.ts
+++ b/integration-tests/hooks/hooks-e2e.integration.test.ts
@@ -148,6 +148,36 @@ process.exit(0);
       expect(result!.getEffectiveReason()).toContain('/etc');
     });
 
+    it('should block tool execution when hook script exits with code 2 and empty stderr', async () => {
+      const scriptContent = `import process from 'node:process';
+process.exit(2);
+`;
+
+      const scriptPath = createHookScript(
+        'block-exit-2-no-stderr.ts',
+        scriptContent,
+      );
+      const config = createRealConfig({
+        event: 'BeforeTool',
+        scriptPath,
+      });
+
+      const hookSystem = config.getHookSystem();
+      await hookSystem!.initialize();
+
+      const eventHandler = hookSystem!.getEventHandler();
+      const result = await eventHandler.fireBeforeToolEvent('write_file', {
+        path: '/home/user/file.txt',
+        content: 'some content',
+      });
+
+      expect(result).toBeDefined();
+      expect(result!.isBlockingDecision()).toBe(true);
+      expect(result!.getEffectiveReason()).toBe(
+        'Hook exited with code 2 without an error message',
+      );
+    });
+
     it('should allow tool execution when hook script exits with code 0', async () => {
       const scriptContent = `import process from 'node:process';
 import { readFileSync } from 'node:fs';

--- a/packages/core/src/hooks/hookRunner.exitCode.test.ts
+++ b/packages/core/src/hooks/hookRunner.exitCode.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { HookRunner } from './hookRunner.js';
+import {
+  DefaultHookOutput,
+  HookEventName,
+  HookType,
+  type HookInput,
+} from './types.js';
+import type { Config } from '../config/config.js';
+
+const input: HookInput = {
+  session_id: 'session-id',
+  transcript_path: 'transcript.jsonl',
+  cwd: process.cwd(),
+  hook_event_name: HookEventName.BeforeTool,
+  timestamp: new Date(0).toISOString(),
+};
+
+async function execute(command: string) {
+  const runner = new HookRunner({
+    getSanitizationConfig: () => undefined,
+  } as Config);
+  return runner.executeHook(
+    { type: HookType.Command, command },
+    HookEventName.BeforeTool,
+    input,
+  );
+}
+
+describe('HookRunner exit code semantics', () => {
+  it('denies with a default reason when a hook exits 2 without writing to stderr', async () => {
+    const result = await execute('node -e "process.exit(2)"');
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.output).toStrictEqual({
+      decision: 'deny',
+      reason: 'Hook exited with code 2 without an error message',
+    });
+  });
+
+  it('denies with the stderr text when a hook exits 2 after writing to stderr', async () => {
+    const result = await execute(
+      'node -e "process.stderr.write(\'denied by policy\'); process.exit(2)"',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.output).toStrictEqual({
+      decision: 'deny',
+      reason: 'denied by policy',
+    });
+  });
+
+  it('produces no decision when a hook exits 1 without writing to stderr', async () => {
+    const result = await execute('node -e "process.exit(1)"');
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toBeUndefined();
+  });
+
+  it('warns without blocking when a hook exits 1 after writing to stderr', async () => {
+    const result = await execute(
+      'node -e "process.stderr.write(\'hook broke\'); process.exit(1)"',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toStrictEqual({
+      decision: 'allow',
+      systemMessage: 'Warning: hook broke',
+    });
+    expect(
+      new DefaultHookOutput(result.output ?? {}).isBlockingDecision(),
+    ).toBe(false);
+  });
+
+  it('produces no output when a hook exits 0 without writing anything', async () => {
+    const result = await execute('node -e "process.exit(0)"');
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBeUndefined();
+  });
+
+  it('keeps plain stdout as a system message when a hook exits 0', async () => {
+    const result = await execute(
+      'node -e "process.stdout.write(\'all good\')"',
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toStrictEqual({
+      decision: 'allow',
+      systemMessage: 'all good',
+    });
+  });
+});

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -60,6 +60,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function defaultErrorMessage(exitCode: number): string {
+  return `Hook exited with code ${exitCode} without an error message`;
+}
+
 function buildPowerShellExitCodeWrapper(encodedCommand: string): string {
   return (
     '& { ' +
@@ -586,10 +590,30 @@ export class HookRunner {
         // Not JSON, convert plain text to structured output
         return this.convertPlainTextToHookOutput(stdout.trim(), exitCode);
       }
-    } else if (exitCode !== EXIT_CODE_SUCCESS && stderr.trim()) {
-      // Convert error output to structured format
-      return this.convertPlainTextToHookOutput(
+    } else if (exitCode !== EXIT_CODE_SUCCESS) {
+      return this.convertNonZeroExitToHookOutput(
         stderr.trim(),
+        effectiveErrorExitCode,
+      );
+    }
+    return undefined;
+  }
+
+  /**
+   * A blocking exit code is authoritative on its own, so it must deny even
+   * when the hook wrote no message. Other non-zero exits stay silent unless
+   * the hook explained itself on stderr, so they cannot inject a decision.
+   */
+  private convertNonZeroExitToHookOutput(
+    stderr: string,
+    effectiveErrorExitCode: number,
+  ): HookOutput | undefined {
+    if (stderr) {
+      return this.convertPlainTextToHookOutput(stderr, effectiveErrorExitCode);
+    }
+    if (effectiveErrorExitCode === EXIT_CODE_BLOCKING_ERROR) {
+      return this.convertPlainTextToHookOutput(
+        defaultErrorMessage(effectiveErrorExitCode),
         effectiveErrorExitCode,
       );
     }

--- a/project-plans/issue2942/plan.md
+++ b/project-plans/issue2942/plan.md
@@ -1,0 +1,86 @@
+# Issue #2942 — BeforeTool hook exiting 2 with empty stderr fails open
+
+## Problem
+
+`HookRunner.parseHookOutput` (`packages/core/src/hooks/hookRunner.ts`) only converts a
+non-zero hook exit into a `HookOutput` when `stderr.trim()` is non-empty:
+
+    } else if (exitCode !== EXIT_CODE_SUCCESS && stderr.trim()) {
+
+A hook that exits `2` and writes nothing to stderr therefore produces `output === undefined`.
+`HookAggregator.aggregateResults` only collects `result.output`, so `finalOutput` stays
+undefined, and `checkHookDecision` in `packages/agents/src/scheduler/tool-executor.ts`
+(which reads only `shouldStopExecution()` / `isBlockingDecision()`) never fires. The tool
+executes. Exit code 2 is the documented blocking signal, so this fails open on a security
+control.
+
+## Decision
+
+A **blocking** exit code is authoritative on its own. `parseHookOutput` no longer requires
+stderr to produce a blocking decision:
+
+- exit `2`, stderr present → `{ decision: 'deny', reason: <stderr> }` (unchanged)
+- exit `2`, stderr empty → `{ decision: 'deny', reason: 'Hook exited with code 2 without an error message' }`
+- other non-zero, stderr present → `{ decision: 'allow', systemMessage: 'Warning: <stderr>' }` (unchanged)
+- other non-zero, stderr empty → `undefined` (unchanged)
+
+Explicit sub-decisions:
+
+- The behavior is **not** gated on event name. Non-zero exit with non-empty stderr already
+  produces a deny for every event; empty stderr must behave identically. Gating on
+  `BeforeTool` only would create a second, divergent code path.
+- A default message is synthesized **only** for the blocking exit code. Synthesizing an
+  output for every non-zero exit would make a silent exit-`1` hook emit
+  `{ decision: 'allow', … }`, and `HookAggregator.mergeWithFieldReplacement` (used by
+  `BeforeModel` / `AfterModel`) lets a later `allow` overwrite an earlier `deny`. A hook
+  that says nothing must not be able to manufacture a permissive decision.
+- Exit `1` therefore stays non-blocking and stays silent when it writes nothing, matching
+  `EXIT_CODE_NON_BLOCKING_ERROR`.
+- Exit `0` is untouched: the stdout JSON path, the double-encoded JSON path, the
+  plain-text-to-`systemMessage` path, and the empty-stdout `undefined` result are unchanged.
+  Empty stderr on exit `0` never reaches the non-zero branch.
+- Timeout and spawn-error results are out of scope; they take different code paths
+  (`timeoutResult` / `errorResult`) and the issue does not cover them.
+
+## Acceptance criteria
+
+1. `BeforeTool` hook exiting `2` with empty stderr and empty stdout blocks the tool and
+   surfaces the default reason.
+2. `BeforeTool` hook exiting `2` with a stderr message still blocks, using that stderr text
+   as the reason (unchanged).
+3. Hook exiting `1` with empty stderr remains non-blocking and produces no output.
+4. Hook exiting `1` with stderr text remains non-blocking with `Warning: <stderr>` (unchanged).
+5. Exit code `0` behavior is unchanged in every existing case.
+
+## Test plan (tests first)
+
+### `packages/core/src/hooks/hookRunner.exitCode.test.ts`
+
+Behavioral tests that run real hook processes through `HookRunner.executeHook(...)` (same
+style as `hookRunner.windows.test.ts`), asserting on `result.output`:
+
+- exit `2`, no output → `{ decision: 'deny', reason: 'Hook exited with code 2 without an error message' }`; `success === false`, `exitCode === 2`.
+- exit `2`, stderr `'denied by policy'` → `{ decision: 'deny', reason: 'denied by policy' }`.
+- exit `1`, no output → `output === undefined`, `exitCode === 1`.
+- exit `1`, stderr text → `{ decision: 'allow', systemMessage: 'Warning: <text>' }` and not a blocking decision.
+- exit `0`, no output → `output === undefined`.
+- exit `0`, plain-text stdout → `{ decision: 'allow', systemMessage: <text> }`.
+
+### `integration-tests/hooks/hooks-e2e.integration.test.ts`
+
+Real hook script (`process.exit(2)` with no output) fired through
+`HookSystem.getEventHandler().fireBeforeToolEvent(...)`; assert the aggregated result is a
+blocking decision with the default reason.
+
+### `integration-tests/hooks-system.test.ts`
+
+Rig-level `BeforeTool` test reusing `hooks-system.block-tool.responses`: hook script exits 2
+with no stderr; assert no successful `write_file` tool call in the tool logs, that the target
+file was never created, and that hook telemetry carries the synthesized deny reason.
+
+## Out of scope
+
+- Changing `HookAggregator` or `checkHookDecision`.
+- Making timeouts or spawn failures fail closed.
+- Parsing stdout on non-zero exits.
+- Any documentation rewrite (handled by #2937).


### PR DESCRIPTION
## Summary

A `BeforeTool` hook that exited with code 2 and wrote nothing to stderr did not block the tool. The tool ran. Exit code 2 is the documented blocking signal, and blocking hooks are security controls, so this failed open silently with no warning to the user.

Fixes #2942

## Root cause

`HookRunner.parseHookOutput` in `packages/core/src/hooks/hookRunner.ts` gated the non-zero exit branch on stderr being non-empty:

    } else if (exitCode !== EXIT_CODE_SUCCESS && stderr.trim()) {
      return this.convertPlainTextToHookOutput(stderr.trim(), effectiveErrorExitCode);
    }
    return undefined;

With empty stderr the method returned `undefined`, so no `HookOutput` existed. `HookAggregator.aggregateResults` collects into `allOutputs` only `if (result.output)`, and `checkHookDecision` in `packages/agents/src/scheduler/tool-executor.ts` decides purely from the merged output, so neither `shouldStopExecution()` nor `isBlockingDecision()` fired and execution continued. The failure was recorded on the result object (`success: false`, `exitCode: 2`) but nothing downstream consults it for authorization.

## Change

A blocking exit code is now authoritative on its own. `parseHookOutput` delegates the non-zero case to a small helper:

- non-zero exit with stderr text: unchanged, converts the stderr text as before.
- exit code 2 with empty stderr: synthesizes the reason `Hook exited with code 2 without an error message`, so `convertPlainTextToHookOutput` yields `{ decision: 'deny', reason }` and the tool is blocked.
- other non-zero exits with empty stderr: unchanged, still produce no output.

Exit code 0 is untouched: the stdout JSON path, the double-encoded JSON path, the plain-text-to-`systemMessage` path, and the empty-stdout `undefined` result all behave exactly as before.

### Why the default message is synthesized only for the blocking code

The issue suggested dropping the stderr gate entirely and defaulting the message for every non-zero exit. That was implemented first and then rejected during review, because it makes a silent exit-1 hook emit `{ decision: 'allow', systemMessage: 'Warning: ...' }`. `HookAggregator.mergeWithFieldReplacement`, used by `BeforeModel` and `AfterModel`, lets a later output overwrite an earlier one, so a hook that says nothing could overwrite a preceding `deny` with an `allow`. Fixing a fail-open must not open a different one. A hook that explains nothing now cannot manufacture any decision; only the blocking code, which is unambiguous on its own, synthesizes output.

This behavior is not gated on event name. Non-zero exit with non-empty stderr already produced a deny for every event, so empty stderr behaves identically rather than adding a second divergent code path.

## Behavioral evidence

New `packages/core/src/hooks/hookRunner.exitCode.test.ts` runs real hook processes through `HookRunner.executeHook` (no spawn mocks), following the style of `hookRunner.windows.test.ts`:

- exit 2, no output: `{ decision: 'deny', reason: 'Hook exited with code 2 without an error message' }`, `success: false`, `exitCode: 2`
- exit 2, stderr text: `{ decision: 'deny', reason: <stderr> }` (regression pin, unchanged)
- exit 1, no output: `output` is `undefined`
- exit 1, stderr text: `{ decision: 'allow', systemMessage: 'Warning: <stderr>' }` and not a blocking decision
- exit 0, no output: `output` is `undefined`
- exit 0, plain stdout: `{ decision: 'allow', systemMessage: <text> }`

Both new exit-code-2 and exit-code-1 expectations were confirmed to fail against the unpatched parser before the fix was applied.

`integration-tests/hooks/hooks-e2e.integration.test.ts` adds a real hook script that only calls `process.exit(2)`, fired through `HookSystem.getEventHandler().fireBeforeToolEvent`, asserting a blocking decision with the default reason through real aggregation.

`integration-tests/hooks-system.test.ts` adds a rig-level `BeforeTool` case with the same silent exit-2 hook, asserting no successful `write_file` tool call, that the target file was never created, and that hook telemetry carries exit code 2 with the synthesized deny reason.

The new unit tests live in a separate file rather than in `hookRunner.test.ts` because that file is already near the 800-line `max-lines` limit; the lint threshold was not changed.

## Verification

- `npm run typecheck`: clean
- `npm run lint`: clean
- `npm run format`: applied
- `npm run build`: clean
- `npm run test`: the only failures are the pre-existing image-resize cases in `packages/tools` (`imageResize`, `fileUtils`, `filesystem-tools`, `read-many-files-filtering-behavior`), reproduced identically on a clean checkout of `main` in this environment
- targeted: 6 new core tests, 7 hook E2E integration tests, 4 rig-level blocking tests, all passing
- smoke: `bun scripts/start.ts --profile-load stepfun-37`

## Scope

Only `parseHookOutput` changes in production code. `HookAggregator`, `checkHookDecision`, the timeout path, the spawn-error path, the untrusted-project-hook path, and stdout handling on non-zero exits are untouched. Those remaining fail-open paths are pre-existing policy and outside this issue.
