### PR TITLE
Remove the Bun exclusion list from core: migrate the 6 test files still routed to Vitest (Fixes #2968)

### DIFF
--- a/dev-docs/test-runner-inventory.md
+++ b/dev-docs/test-runner-inventory.md
@@ -219,10 +219,11 @@ test suite and is retained:
    vitest's runtime semantics by spawning `vitest run` subprocesses. This is
    a meta-test of the test runner itself, not an application test.
 
-2. **Per-workspace `test:vitest` scripts** — Each migrated workspace retains a
+2. **Per-workspace `test:vitest` scripts** — Most migrated workspaces retain a
    `test:vitest` script so the Vitest path remains available as a fallback
    during the migration transition. These will be removed once the full
-   migration is complete.
+   migration is complete. `packages/core` is the exception: its script was
+   removed with the Bun exclusion list (issue #2968), so core is Bun-only.
 
 3. **`scripts/tests/vitest.config.ts`** — The scripts-tests harness (97 files)
    still runs under Vitest. Migration is deferred to Slice 13.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -538,7 +538,6 @@
     "format": "prettier --write .",
     "test": "bun run-bun-tests.ts",
     "test:ci": "bun run-bun-tests.ts",
-    "test:vitest": "vitest run",
     "test:mutation": "stryker run stryker.conf.json",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/core/run-bun-tests.ts
+++ b/packages/core/run-bun-tests.ts
@@ -22,24 +22,12 @@
 
 import { spawn } from 'node:child_process';
 import { readdirSync, statSync, writeFileSync } from 'node:fs';
-import { join, sep } from 'node:path';
+import { join } from 'node:path';
 import { availableParallelism } from 'node:os';
 
 const PRELOAD = './bun-preload.ts';
 const CONCURRENCY = Math.min(8, availableParallelism());
 const PER_FILE_TIMEOUT_MS = 60_000;
-
-// Test files excluded from Bun native execution because they depend on
-// vitest-only APIs (@fast-check/vitest's it.prop/itProp, process.platform
-// assertions). They run under vitest via `npm run test:vitest` instead.
-const EXCLUDE: ReadonlySet<string> = new Set([
-  'src/recording/SessionRecordingService.test.ts',
-  'src/recording/resumeSession.test.ts',
-  'src/recording/sessionCleanupUtils.test.ts',
-  'src/recording/sessionManagement.test.ts',
-  'src/hooks/hookRunner.consoleIsolation.test.ts',
-  'src/utils/retry.quota.test.ts',
-]);
 
 function findTestFiles(dir: string): string[] {
   const results: string[] = [];
@@ -58,8 +46,7 @@ function findTestFiles(dir: string): string[] {
       results.push(...findTestFiles(fullPath));
     } else if (
       (entry.endsWith('.test.ts') || entry.endsWith('.test.tsx')) &&
-      !entry.endsWith('.d.ts') &&
-      !EXCLUDE.has(fullPath.split(sep).join('/'))
+      !entry.endsWith('.d.ts')
     ) {
       results.push(fullPath);
     }

--- a/packages/core/src/hooks/hookRunner.consoleIsolation.test.ts
+++ b/packages/core/src/hooks/hookRunner.consoleIsolation.test.ts
@@ -62,6 +62,10 @@ describe('HookRunner Windows console isolation (Issue #2548)', () => {
 
   beforeEach(() => {
     mockSpawnObj = createMockSpawn();
+    // The spawn mock is created once by the module factory, so its recorded
+    // calls survive across tests. Clear them so each test only observes the
+    // spawn invocation it triggered itself.
+    vi.mocked(spawn).mockClear();
     vi.mocked(spawn).mockReturnValue(
       mockSpawnObj as unknown as ReturnType<typeof spawn>,
     );

--- a/packages/core/src/recording/SessionDiscovery.test.ts
+++ b/packages/core/src/recording/SessionDiscovery.test.ts
@@ -22,7 +22,7 @@
  * SessionRecordingService instances to create genuine session JSONL files
  * in real temp directories — no mock theater.
  *
- * Property-based tests use @fast-check/vitest (≥30% of total tests).
+ * Property-based tests use fast-check (≥30% of total tests).
  * All tests expect real behavior. They will fail against the Phase 18 stub
  * — that is correct TDD.
  */

--- a/packages/core/src/recording/SessionLockManager.test.ts
+++ b/packages/core/src/recording/SessionLockManager.test.ts
@@ -22,19 +22,12 @@
  * state (lock files exist/don't exist) using real temp directories — no mock
  * theater.
  *
- * Property-based tests use @fast-check/vitest (≥30% of total tests).
+ * All tests are example-based; this file has no property-based coverage.
  * All tests expect real behavior from the lock manager. They will fail against
  * the Phase 09 stub — that is correct TDD.
  */
 
-import {
-  describe,
-  it as itProp,
-  expect,
-  beforeEach,
-  afterEach,
-  vi,
-} from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as path from 'path';
 import * as os from 'os';
 import {
@@ -131,7 +124,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-001
      * Test 3: getLockPath returns path + '.lock'
      */
-    itProp('getLockPath returns <chatsDir>/<sessionId>.lock', () => {
+    it('getLockPath returns <chatsDir>/<sessionId>.lock', () => {
       const result = SessionLockManager.getLockPath(
         '/tmp/chats',
         'session-abc123',
@@ -144,34 +137,28 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-001
      * Test 29: getLockPathForSession uses session-ID-based path
      */
-    itProp(
-      'getLockPath uses session-ID-based path independent of JSONL',
-      () => {
-        const result = SessionLockManager.getLockPath(chatsDir, 'abc123');
-        expect(result).toBe(path.join(chatsDir, 'abc123.lock'));
-      },
-    );
+    it('getLockPath uses session-ID-based path independent of JSONL', () => {
+      const result = SessionLockManager.getLockPath(chatsDir, 'abc123');
+      expect(result).toBe(path.join(chatsDir, 'abc123.lock'));
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-001
      * getLockPathFromFilePath extracts sessionId correctly
      */
-    itProp(
-      'getLockPathFromFilePath derives lock path from JSONL file path',
-      () => {
-        const jsonlPath = path.join(chatsDir, 'session-myid.jsonl');
-        const result = SessionLockManager.getLockPathFromFilePath(jsonlPath);
-        expect(result).toBe(path.join(chatsDir, 'myid.lock'));
-      },
-    );
+    it('getLockPathFromFilePath derives lock path from JSONL file path', () => {
+      const jsonlPath = path.join(chatsDir, 'session-myid.jsonl');
+      const result = SessionLockManager.getLockPathFromFilePath(jsonlPath);
+      expect(result).toBe(path.join(chatsDir, 'myid.lock'));
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-001
      * getLockPathFromFilePath rejects invalid file names
      */
-    itProp('getLockPathFromFilePath throws for non-session file path', () => {
+    it('getLockPathFromFilePath throws for non-session file path', () => {
       expect(() =>
         SessionLockManager.getLockPathFromFilePath('/tmp/random.txt'),
       ).toThrow('Cannot extract session ID from path');
@@ -188,7 +175,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-001, REQ-CON-002
      * Test 1: acquire creates .lock file
      */
-    itProp('acquire creates a .lock file on disk', async () => {
+    it('acquire creates a .lock file on disk', async () => {
       const sessionId = 'test-session-001';
       const handle = await SessionLockManager.acquire(chatsDir, sessionId);
 
@@ -204,7 +191,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-001
      * Test 2: Lock file contains PID and timestamp
      */
-    itProp('lock file contains JSON with pid and timestamp', async () => {
+    it('lock file contains JSON with pid and timestamp', async () => {
       const sessionId = 'test-session-002';
       const handle = await SessionLockManager.acquire(chatsDir, sessionId);
 
@@ -223,62 +210,53 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-001
      * Test 28: Lock file contains sessionId field
      */
-    itProp(
-      'lock file contains sessionId field matching the requested session',
-      async () => {
-        const sessionId = 'test-session-028';
-        const handle = await SessionLockManager.acquire(chatsDir, sessionId);
+    it('lock file contains sessionId field matching the requested session', async () => {
+      const sessionId = 'test-session-028';
+      const handle = await SessionLockManager.acquire(chatsDir, sessionId);
 
-        const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
-        const raw = await fs.readFile(lockPath, 'utf-8');
-        const data = JSON.parse(raw);
+      const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+      const raw = await fs.readFile(lockPath, 'utf-8');
+      const data = JSON.parse(raw);
 
-        expect(data.sessionId).toBe(sessionId);
+      expect(data.sessionId).toBe(sessionId);
 
-        await handle.release();
-      },
-    );
+      await handle.release();
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-002, REQ-REC-004
      * Test 27: acquireForSession creates lock before JSONL file exists
      */
-    itProp(
-      'acquire creates lock before JSONL file exists (deferred materialization)',
-      async () => {
-        const sessionId = 'test-session-027';
-        const handle = await SessionLockManager.acquire(chatsDir, sessionId);
+    it('acquire creates lock before JSONL file exists (deferred materialization)', async () => {
+      const sessionId = 'test-session-027';
+      const handle = await SessionLockManager.acquire(chatsDir, sessionId);
 
-        const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
-        const jsonlPath = path.join(chatsDir, `session-${sessionId}.jsonl`);
+      const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+      const jsonlPath = path.join(chatsDir, `session-${sessionId}.jsonl`);
 
-        expect(await fileExists(lockPath)).toBe(true);
-        expect(await fileExists(jsonlPath)).toBe(false);
+      expect(await fileExists(lockPath)).toBe(true);
+      expect(await fileExists(jsonlPath)).toBe(false);
 
-        await handle.release();
-      },
-    );
+      await handle.release();
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-002
      * Test 7: Lock with non-existent directory creates parent
      */
-    itProp(
-      'acquire creates parent directory if it does not exist',
-      async () => {
-        const nestedDir = path.join(tempDir, 'deep', 'nested', 'chats');
-        const sessionId = 'test-session-007';
+    it('acquire creates parent directory if it does not exist', async () => {
+      const nestedDir = path.join(tempDir, 'deep', 'nested', 'chats');
+      const sessionId = 'test-session-007';
 
-        const handle = await SessionLockManager.acquire(nestedDir, sessionId);
+      const handle = await SessionLockManager.acquire(nestedDir, sessionId);
 
-        const lockPath = SessionLockManager.getLockPath(nestedDir, sessionId);
-        expect(await fileExists(lockPath)).toBe(true);
+      const lockPath = SessionLockManager.getLockPath(nestedDir, sessionId);
+      expect(await fileExists(lockPath)).toBe(true);
 
-        await handle.release();
-      },
-    );
+      await handle.release();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -291,7 +269,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-003
      * Test 4: release deletes lock file
      */
-    itProp('release deletes the lock file from disk', async () => {
+    it('release deletes the lock file from disk', async () => {
       const sessionId = 'test-session-004';
       const handle = await SessionLockManager.acquire(chatsDir, sessionId);
       const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
@@ -308,7 +286,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-003
      * Test 5: Double release is safe (idempotent)
      */
-    itProp('double release is safe and idempotent', async () => {
+    it('double release is safe and idempotent', async () => {
       const sessionId = 'test-session-005';
       const handle = await SessionLockManager.acquire(chatsDir, sessionId);
 
@@ -325,7 +303,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-003
      * Test 10: LockHandle.release() followed by acquire succeeds
      */
-    itProp('release allows subsequent acquire on same session', async () => {
+    it('release allows subsequent acquire on same session', async () => {
       const sessionId = 'test-session-010';
       const handle1 = await SessionLockManager.acquire(chatsDir, sessionId);
       await handle1.release();
@@ -342,20 +320,17 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-003
      * Test 30: Lock transition: pre-materialization to released (no JSONL)
      */
-    itProp(
-      'acquire and release with no JSONL created leaves clean state',
-      async () => {
-        const sessionId = 'test-session-030';
-        const handle = await SessionLockManager.acquire(chatsDir, sessionId);
-        await handle.release();
+    it('acquire and release with no JSONL created leaves clean state', async () => {
+      const sessionId = 'test-session-030';
+      const handle = await SessionLockManager.acquire(chatsDir, sessionId);
+      await handle.release();
 
-        const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
-        const jsonlPath = path.join(chatsDir, `session-${sessionId}.jsonl`);
+      const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+      const jsonlPath = path.join(chatsDir, `session-${sessionId}.jsonl`);
 
-        expect(await fileExists(lockPath)).toBe(false);
-        expect(await fileExists(jsonlPath)).toBe(false);
-      },
-    );
+      expect(await fileExists(lockPath)).toBe(false);
+      expect(await fileExists(jsonlPath)).toBe(false);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -368,7 +343,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-004
      * Test 6: Concurrent acquire fails
      */
-    itProp('second acquire on same session throws "in use" error', async () => {
+    it('second acquire on same session throws "in use" error', async () => {
       const sessionId = 'test-session-006';
       const handle = await SessionLockManager.acquire(chatsDir, sessionId);
 
@@ -384,7 +359,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-004
      * Test 11: Multiple sessions don't conflict
      */
-    itProp('different sessionIds can be locked independently', async () => {
+    it('different sessionIds can be locked independently', async () => {
       const handle1 = await SessionLockManager.acquire(chatsDir, 'session-a');
       const handle2 = await SessionLockManager.acquire(chatsDir, 'session-b');
 
@@ -409,7 +384,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-005
      * Test 8: Stale lock detection: dead PID
      */
-    itProp('checkStale returns true for a lock with dead PID', async () => {
+    it('checkStale returns true for a lock with dead PID', async () => {
       const sessionId = 'test-session-008';
       const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
       await writeFakeLock(lockPath, DEAD_PID, sessionId);
@@ -423,41 +398,35 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-005
      * Test 9: Stale lock detection: alive PID
      */
-    itProp(
-      'checkStale returns false for a lock with current process PID',
-      async () => {
-        const sessionId = 'test-session-009';
-        const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
-        await writeFakeLock(lockPath, process.pid, sessionId);
+    it('checkStale returns false for a lock with current process PID', async () => {
+      const sessionId = 'test-session-009';
+      const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+      await writeFakeLock(lockPath, process.pid, sessionId);
 
-        const stale = await SessionLockManager.checkStale(lockPath);
-        expect(stale).toBe(false);
-      },
-    );
+      const stale = await SessionLockManager.checkStale(lockPath);
+      expect(stale).toBe(false);
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-005
      * Test 18: Corrupt lock file treated as stale
      */
-    itProp(
-      'checkStale returns true for corrupt (non-JSON) lock file',
-      async () => {
-        const sessionId = 'test-session-018';
-        const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
-        await fs.writeFile(lockPath, 'this is not json garbage!!!', 'utf-8');
+    it('checkStale returns true for corrupt (non-JSON) lock file', async () => {
+      const sessionId = 'test-session-018';
+      const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+      await fs.writeFile(lockPath, 'this is not json garbage!!!', 'utf-8');
 
-        const stale = await SessionLockManager.checkStale(lockPath);
-        expect(stale).toBe(true);
-      },
-    );
+      const stale = await SessionLockManager.checkStale(lockPath);
+      expect(stale).toBe(true);
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-005
      * Test 10 (stale breaking): acquire breaks stale lock transparently
      */
-    itProp('acquire succeeds when stale lock exists (dead PID)', async () => {
+    it('acquire succeeds when stale lock exists (dead PID)', async () => {
       const sessionId = 'test-session-stale';
       const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
       await writeFakeLock(lockPath, DEAD_PID, sessionId);
@@ -477,7 +446,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-005
      * Test 14: isStale returns true for dead PID
      */
-    itProp('isStale returns true when lock file has dead PID', async () => {
+    it('isStale returns true when lock file has dead PID', async () => {
       const sessionId = 'test-session-014';
       const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
       await writeFakeLock(lockPath, DEAD_PID, sessionId);
@@ -486,40 +455,37 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
       expect(stale).toBe(true);
     });
 
-    itProp(
-      'checkStale returns false when process.kill throws EPERM',
-      async () => {
-        const sessionId = 'test-session-eperm-stale';
-        const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
-        await writeFakeLock(lockPath, 12345, sessionId);
+    it('checkStale returns false when process.kill throws EPERM', async () => {
+      const sessionId = 'test-session-eperm-stale';
+      const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+      await writeFakeLock(lockPath, 12345, sessionId);
 
-        const killSpy = vi
-          .spyOn(process, 'kill')
-          .mockImplementation(
-            (_pid: number, _signal?: number | NodeJS.Signals) => {
-              const error = new Error(
-                'operation not permitted',
-              ) as NodeJS.ErrnoException;
-              error.code = 'EPERM';
-              throw error;
-            },
-          );
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation(
+          (_pid: number, _signal?: number | NodeJS.Signals) => {
+            const error = new Error(
+              'operation not permitted',
+            ) as NodeJS.ErrnoException;
+            error.code = 'EPERM';
+            throw error;
+          },
+        );
 
-        try {
-          const stale = await SessionLockManager.checkStale(lockPath);
-          expect(stale).toBe(false);
-        } finally {
-          killSpy.mockRestore();
-        }
-      },
-    );
+      try {
+        const stale = await SessionLockManager.checkStale(lockPath);
+        expect(stale).toBe(false);
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-005
      * Test 15: isStale returns false when no lock
      */
-    itProp('isStale returns false when no lock file exists', async () => {
+    it('isStale returns false when no lock file exists', async () => {
       const stale = await SessionLockManager.isStale(chatsDir, 'nonexistent');
       expect(stale).toBe(false);
     });
@@ -535,25 +501,22 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-001
      * Test 11: isLocked returns true when locked
      */
-    itProp(
-      'isLocked returns true when lock is held by live process',
-      async () => {
-        const sessionId = 'test-session-locked';
-        const handle = await SessionLockManager.acquire(chatsDir, sessionId);
+    it('isLocked returns true when lock is held by live process', async () => {
+      const sessionId = 'test-session-locked';
+      const handle = await SessionLockManager.acquire(chatsDir, sessionId);
 
-        const locked = await SessionLockManager.isLocked(chatsDir, sessionId);
-        expect(locked).toBe(true);
+      const locked = await SessionLockManager.isLocked(chatsDir, sessionId);
+      expect(locked).toBe(true);
 
-        await handle.release();
-      },
-    );
+      await handle.release();
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-001
      * Test 12: isLocked returns false when not locked
      */
-    itProp('isLocked returns false when no lock file exists', async () => {
+    it('isLocked returns false when no lock file exists', async () => {
       const locked = await SessionLockManager.isLocked(
         chatsDir,
         'no-such-session',
@@ -566,7 +529,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-001, REQ-CON-005
      * Test 13: isLocked returns false for stale lock
      */
-    itProp('isLocked returns false for stale lock (dead PID)', async () => {
+    it('isLocked returns false for stale lock (dead PID)', async () => {
       const sessionId = 'test-session-stale-locked';
       const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
       await writeFakeLock(lockPath, DEAD_PID, sessionId);
@@ -576,7 +539,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
     });
   });
 
-  itProp('acquire maps ENOENT then EEXIST race to in-use error', async () => {
+  it('acquire maps ENOENT then EEXIST race to in-use error', async () => {
     const sessionId = 'test-session-enoent-race';
     const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
     const writeFileMock = vi.mocked(fs.writeFile);
@@ -626,7 +589,7 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-005
      * Test 16: removeStaleLock deletes lock file
      */
-    itProp('removeStaleLock removes the lock file from disk', async () => {
+    it('removeStaleLock removes the lock file from disk', async () => {
       const sessionId = 'test-session-016';
       const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
       await writeFakeLock(lockPath, DEAD_PID, sessionId);
@@ -641,16 +604,13 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-005
      * Test 17: removeStaleLock is safe when no lock exists
      */
-    itProp(
-      'removeStaleLock does not throw when no lock file exists',
-      async () => {
-        // Verify removeStaleLock completes without throwing when the lock
-        // file does not exist (idempotent cleanup).
-        await expect(
-          SessionLockManager.removeStaleLock(chatsDir, 'nonexistent-session'),
-        ).resolves.toBeUndefined();
-      },
-    );
+    it('removeStaleLock does not throw when no lock file exists', async () => {
+      // Verify removeStaleLock completes without throwing when the lock
+      // file does not exist (idempotent cleanup).
+      await expect(
+        SessionLockManager.removeStaleLock(chatsDir, 'nonexistent-session'),
+      ).resolves.toBeUndefined();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -663,47 +623,41 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
      * @requirement REQ-CON-005
      * Test 31: Orphan lock cleanup: stale lock with no JSONL
      */
-    itProp(
-      'cleanupOrphanedLocks removes stale lock with no JSONL file',
-      async () => {
-        const sessionId = 'orphan-no-jsonl';
-        const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
-        await writeFakeLock(lockPath, DEAD_PID, sessionId);
+    it('cleanupOrphanedLocks removes stale lock with no JSONL file', async () => {
+      const sessionId = 'orphan-no-jsonl';
+      const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+      await writeFakeLock(lockPath, DEAD_PID, sessionId);
 
-        await SessionLockManager.cleanupOrphanedLocks(chatsDir);
+      await SessionLockManager.cleanupOrphanedLocks(chatsDir);
 
-        expect(await fileExists(lockPath)).toBe(false);
-      },
-    );
+      expect(await fileExists(lockPath)).toBe(false);
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-005
      * Test 32: Orphan lock cleanup: stale lock with existing JSONL
      */
-    itProp(
-      'cleanupOrphanedLocks removes stale lock but preserves JSONL file',
-      async () => {
-        const sessionId = 'orphan-with-jsonl';
-        const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
-        const jsonlPath = path.join(chatsDir, `session-${sessionId}.jsonl`);
+    it('cleanupOrphanedLocks removes stale lock but preserves JSONL file', async () => {
+      const sessionId = 'orphan-with-jsonl';
+      const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+      const jsonlPath = path.join(chatsDir, `session-${sessionId}.jsonl`);
 
-        await writeFakeLock(lockPath, DEAD_PID, sessionId);
-        await fs.writeFile(jsonlPath, '{"type":"session_start"}\n', 'utf-8');
+      await writeFakeLock(lockPath, DEAD_PID, sessionId);
+      await fs.writeFile(jsonlPath, '{"type":"session_start"}\n', 'utf-8');
 
-        await SessionLockManager.cleanupOrphanedLocks(chatsDir);
+      await SessionLockManager.cleanupOrphanedLocks(chatsDir);
 
-        expect(await fileExists(lockPath)).toBe(false);
-        expect(await fileExists(jsonlPath)).toBe(true);
-      },
-    );
+      expect(await fileExists(lockPath)).toBe(false);
+      expect(await fileExists(jsonlPath)).toBe(true);
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P10
      * @requirement REQ-CON-004
      * Test 33: Active lock is not removed by cleanup
      */
-    itProp('cleanupOrphanedLocks does not remove active locks', async () => {
+    it('cleanupOrphanedLocks does not remove active locks', async () => {
       const sessionId = 'active-lock';
       const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
       // Write lock with current PID (alive)

--- a/packages/core/src/recording/SessionRecordingService.test.ts
+++ b/packages/core/src/recording/SessionRecordingService.test.ts
@@ -21,13 +21,12 @@
  * Behavioral tests for SessionRecordingService. Tests verify actual file
  * contents written to real temp directories — no mock theater.
  *
- * Property-based tests use @fast-check/vitest (≥30% of total tests).
+ * Property-based tests use fast-check (≥30% of total tests).
  * All tests expect real behavior from the service. They will fail against
  * the Phase 03 stub — that is correct TDD.
  */
 
-import { describe, expect, beforeEach, afterEach, vi } from 'vitest';
-import { it } from '@fast-check/vitest';
+import { describe, expect, beforeEach, afterEach, it, vi } from 'vitest';
 import * as fc from 'fast-check';
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -83,6 +82,24 @@ async function readJsonlFile(filePath: string): Promise<SessionRecordLine[]> {
 function isValidIso8601(ts: string): boolean {
   const date = new Date(ts);
   return !isNaN(date.getTime()) && ts === date.toISOString();
+}
+
+/**
+ * Runs `body` against a freshly created temp chats directory and removes
+ * the whole temp tree afterwards, even if `body` throws.
+ */
+async function withTempChatsDir<T>(
+  prefix: string,
+  body: (chatsDir: string) => Promise<T>,
+): Promise<T> {
+  const localTempDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const localChatsDir = path.join(localTempDir, 'chats');
+  await fs.mkdir(localChatsDir, { recursive: true });
+  try {
+    return await body(localChatsDir);
+  } finally {
+    await fs.rm(localTempDir, { recursive: true, force: true });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -801,49 +818,41 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
      * @plan PLAN-20260211-SESSIONRECORDING.P04
      * @requirement REQ-REC-003.3
      */
-    it.prop([
-      fc.record({
-        speaker: fc.constantFrom('human' as const, 'ai' as const),
-        text: fc.string({ minLength: 1, maxLength: 200 }),
-      }),
-    ])(
-      'any valid IContent round-trips through JSONL faithfully @requirement:REQ-REC-003.3 @plan:PLAN-20260211-SESSIONRECORDING.P04',
-      async ({ speaker, text }) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-roundtrip-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('any valid IContent round-trips through JSONL faithfully @requirement:REQ-REC-003.3 @plan:PLAN-20260211-SESSIONRECORDING.P04', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.record({
+            speaker: fc.constantFrom('human' as const, 'ai' as const),
+            text: fc.string({ minLength: 1, maxLength: 200 }),
+          }),
+          async ({ speaker, text }) =>
+            withTempChatsDir('prop-roundtrip-', async (localChatsDir) => {
+              const config = makeConfig({ chatsDir: localChatsDir });
+              const svc = new SessionRecordingService(config);
 
-        try {
-          const config = makeConfig({ chatsDir: localChatsDir });
-          const svc = new SessionRecordingService(config);
+              const content: IContent = {
+                speaker,
+                blocks: [{ type: 'text', text }],
+              };
 
-          const content: IContent = {
-            speaker,
-            blocks: [{ type: 'text', text }],
-          };
+              svc.recordContent(content);
+              await svc.flush();
 
-          svc.recordContent(content);
-          await svc.flush();
+              const events = await readJsonlFile(svc.getFilePath()!);
+              const contentEvent = events.find((e) => e.type === 'content');
+              expect(contentEvent).toBeDefined();
 
-          const events = await readJsonlFile(svc.getFilePath()!);
-          const contentEvent = events.find((e) => e.type === 'content');
-          expect(contentEvent).toBeDefined();
+              const payload = contentEvent!.payload as { content: IContent };
+              expect(payload.content.speaker).toBe(speaker);
+              expect(payload.content.blocks[0]).toStrictEqual({
+                type: 'text',
+                text,
+              });
 
-          const payload = contentEvent!.payload as { content: IContent };
-          expect(payload.content.speaker).toBe(speaker);
-          expect(payload.content.blocks[0]).toStrictEqual({
-            type: 'text',
-            text,
-          });
-
-          await svc.dispose();
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+              await svc.dispose();
+            }),
+        ),
+      ));
 
     /**
      * Property test 17: Sequence numbers are always monotonic regardless of enqueue pattern.
@@ -851,69 +860,61 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
      * @plan PLAN-20260211-SESSIONRECORDING.P04
      * @requirement REQ-REC-001.2
      */
-    it.prop([
-      fc.array(
-        fc.constantFrom(
-          'content' as const,
-          'session_event' as const,
-          'provider_switch' as const,
-          'directories_changed' as const,
-          'rewind' as const,
+    it('sequence numbers are always strictly monotonic @requirement:REQ-REC-001.2 @plan:PLAN-20260211-SESSIONRECORDING.P04', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.array(
+            fc.constantFrom(
+              'content' as const,
+              'session_event' as const,
+              'provider_switch' as const,
+              'directories_changed' as const,
+              'rewind' as const,
+            ),
+            { minLength: 1, maxLength: 15 },
+          ),
+          async (eventTypes) =>
+            withTempChatsDir('prop-seq-', async (localChatsDir) => {
+              const config = makeConfig({ chatsDir: localChatsDir });
+              const svc = new SessionRecordingService(config);
+
+              // Ensure first event is content to trigger materialization
+              svc.recordContent(makeContent('trigger'));
+
+              for (const eventType of eventTypes) {
+                switch (eventType) {
+                  case 'content':
+                    svc.recordContent(makeContent('test'));
+                    break;
+                  case 'session_event':
+                    svc.recordSessionEvent('info', 'test event');
+                    break;
+                  case 'provider_switch':
+                    svc.recordProviderSwitch('test-provider', 'test-model');
+                    break;
+                  case 'directories_changed':
+                    svc.recordDirectoriesChanged(['/test']);
+                    break;
+                  case 'rewind':
+                    svc.recordRewind(1);
+                    break;
+                  default:
+                    break;
+                }
+              }
+
+              await svc.flush();
+              const events = await readJsonlFile(svc.getFilePath()!);
+
+              // Verify strict monotonicity
+              for (let i = 1; i < events.length; i++) {
+                expect(events[i].seq).toBeGreaterThan(events[i - 1].seq);
+              }
+
+              await svc.dispose();
+            }),
         ),
-        { minLength: 1, maxLength: 15 },
-      ),
-    ])(
-      'sequence numbers are always strictly monotonic @requirement:REQ-REC-001.2 @plan:PLAN-20260211-SESSIONRECORDING.P04',
-      async (eventTypes) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-seq-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
-
-        try {
-          const config = makeConfig({ chatsDir: localChatsDir });
-          const svc = new SessionRecordingService(config);
-
-          // Ensure first event is content to trigger materialization
-          svc.recordContent(makeContent('trigger'));
-
-          for (const eventType of eventTypes) {
-            switch (eventType) {
-              case 'content':
-                svc.recordContent(makeContent('test'));
-                break;
-              case 'session_event':
-                svc.recordSessionEvent('info', 'test event');
-                break;
-              case 'provider_switch':
-                svc.recordProviderSwitch('test-provider', 'test-model');
-                break;
-              case 'directories_changed':
-                svc.recordDirectoriesChanged(['/test']);
-                break;
-              case 'rewind':
-                svc.recordRewind(1);
-                break;
-              default:
-                break;
-            }
-          }
-
-          await svc.flush();
-          const events = await readJsonlFile(svc.getFilePath()!);
-
-          // Verify strict monotonicity
-          for (let i = 1; i < events.length; i++) {
-            expect(events[i].seq).toBeGreaterThan(events[i - 1].seq);
-          }
-
-          await svc.dispose();
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+      ));
 
     /**
      * Property test 18: Multiple flush calls are idempotent.
@@ -921,38 +922,33 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
      * @plan PLAN-20260211-SESSIONRECORDING.P04
      * @requirement REQ-REC-005
      */
-    it.prop([fc.integer({ min: 1, max: 5 }), fc.integer({ min: 1, max: 10 })])(
-      'multiple flush calls produce same file content @requirement:REQ-REC-005 @plan:PLAN-20260211-SESSIONRECORDING.P04',
-      async (flushCount, eventCount) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-flush-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('multiple flush calls produce same file content @requirement:REQ-REC-005 @plan:PLAN-20260211-SESSIONRECORDING.P04', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 5 }),
+          fc.integer({ min: 1, max: 10 }),
+          async (flushCount, eventCount) =>
+            withTempChatsDir('prop-flush-', async (localChatsDir) => {
+              const config = makeConfig({ chatsDir: localChatsDir });
+              const svc = new SessionRecordingService(config);
 
-        try {
-          const config = makeConfig({ chatsDir: localChatsDir });
-          const svc = new SessionRecordingService(config);
+              for (let i = 0; i < eventCount; i++) {
+                svc.recordContent(makeContent(`msg ${i}`));
+              }
 
-          for (let i = 0; i < eventCount; i++) {
-            svc.recordContent(makeContent(`msg ${i}`));
-          }
+              // Flush multiple times
+              for (let i = 0; i < flushCount; i++) {
+                await svc.flush();
+              }
 
-          // Flush multiple times
-          for (let i = 0; i < flushCount; i++) {
-            await svc.flush();
-          }
+              const events = await readJsonlFile(svc.getFilePath()!);
+              // session_start + eventCount content events
+              expect(events).toHaveLength(eventCount + 1);
 
-          const events = await readJsonlFile(svc.getFilePath()!);
-          // session_start + eventCount content events
-          expect(events).toHaveLength(eventCount + 1);
-
-          await svc.dispose();
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+              await svc.dispose();
+            }),
+        ),
+      ));
 
     /**
      * Property test 19: Session ID is always present in session_start payload.
@@ -960,34 +956,26 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
      * @plan PLAN-20260211-SESSIONRECORDING.P04
      * @requirement REQ-REC-001
      */
-    it.prop([fc.uuid()])(
-      'session_start payload always contains matching sessionId @requirement:REQ-REC-001 @plan:PLAN-20260211-SESSIONRECORDING.P04',
-      async (sessionId) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-sid-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('session_start payload always contains matching sessionId @requirement:REQ-REC-001 @plan:PLAN-20260211-SESSIONRECORDING.P04', async () =>
+      fc.assert(
+        fc.asyncProperty(fc.uuid(), async (sessionId) =>
+          withTempChatsDir('prop-sid-', async (localChatsDir) => {
+            const config = makeConfig({ chatsDir: localChatsDir, sessionId });
+            const svc = new SessionRecordingService(config);
 
-        try {
-          const config = makeConfig({ chatsDir: localChatsDir, sessionId });
-          const svc = new SessionRecordingService(config);
+            svc.recordContent(makeContent('trigger'));
+            await svc.flush();
 
-          svc.recordContent(makeContent('trigger'));
-          await svc.flush();
+            const events = await readJsonlFile(svc.getFilePath()!);
+            expect(events[0].type).toBe('session_start');
 
-          const events = await readJsonlFile(svc.getFilePath()!);
-          expect(events[0].type).toBe('session_start');
+            const startPayload = events[0].payload as { sessionId: string };
+            expect(startPayload.sessionId).toBe(sessionId);
 
-          const startPayload = events[0].payload as { sessionId: string };
-          expect(startPayload.sessionId).toBe(sessionId);
-
-          await svc.dispose();
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+            await svc.dispose();
+          }),
+        ),
+      ));
 
     /**
      * Property test 20: Any number of enqueued events produces correct line count.
@@ -995,33 +983,25 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
      * @plan PLAN-20260211-SESSIONRECORDING.P04
      * @requirement REQ-REC-003.2
      */
-    it.prop([fc.integer({ min: 1, max: 30 })])(
-      'N content events produce exactly N+1 lines (session_start + N) @requirement:REQ-REC-003.2 @plan:PLAN-20260211-SESSIONRECORDING.P04',
-      async (eventCount) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-count-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('N content events produce exactly N+1 lines (session_start + N) @requirement:REQ-REC-003.2 @plan:PLAN-20260211-SESSIONRECORDING.P04', async () =>
+      fc.assert(
+        fc.asyncProperty(fc.integer({ min: 1, max: 30 }), async (eventCount) =>
+          withTempChatsDir('prop-count-', async (localChatsDir) => {
+            const config = makeConfig({ chatsDir: localChatsDir });
+            const svc = new SessionRecordingService(config);
 
-        try {
-          const config = makeConfig({ chatsDir: localChatsDir });
-          const svc = new SessionRecordingService(config);
+            for (let i = 0; i < eventCount; i++) {
+              svc.recordContent(makeContent(`msg ${i}`));
+            }
+            await svc.flush();
 
-          for (let i = 0; i < eventCount; i++) {
-            svc.recordContent(makeContent(`msg ${i}`));
-          }
-          await svc.flush();
+            const events = await readJsonlFile(svc.getFilePath()!);
+            expect(events).toHaveLength(eventCount + 1);
 
-          const events = await readJsonlFile(svc.getFilePath()!);
-          expect(events).toHaveLength(eventCount + 1);
-
-          await svc.dispose();
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+            await svc.dispose();
+          }),
+        ),
+      ));
 
     /**
      * Property test 21: Timestamps are always valid ISO-8601 in any number of events.
@@ -1029,35 +1009,27 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
      * @plan PLAN-20260211-SESSIONRECORDING.P04
      * @requirement REQ-REC-001.3
      */
-    it.prop([fc.integer({ min: 1, max: 15 })])(
-      'all events have valid ISO-8601 timestamps @requirement:REQ-REC-001.3 @plan:PLAN-20260211-SESSIONRECORDING.P04',
-      async (eventCount) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-ts-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('all events have valid ISO-8601 timestamps @requirement:REQ-REC-001.3 @plan:PLAN-20260211-SESSIONRECORDING.P04', async () =>
+      fc.assert(
+        fc.asyncProperty(fc.integer({ min: 1, max: 15 }), async (eventCount) =>
+          withTempChatsDir('prop-ts-', async (localChatsDir) => {
+            const config = makeConfig({ chatsDir: localChatsDir });
+            const svc = new SessionRecordingService(config);
 
-        try {
-          const config = makeConfig({ chatsDir: localChatsDir });
-          const svc = new SessionRecordingService(config);
+            for (let i = 0; i < eventCount; i++) {
+              svc.recordContent(makeContent(`msg ${i}`));
+            }
+            await svc.flush();
 
-          for (let i = 0; i < eventCount; i++) {
-            svc.recordContent(makeContent(`msg ${i}`));
-          }
-          await svc.flush();
+            const events = await readJsonlFile(svc.getFilePath()!);
+            for (const event of events) {
+              expect(isValidIso8601(event.ts)).toBe(true);
+            }
 
-          const events = await readJsonlFile(svc.getFilePath()!);
-          for (const event of events) {
-            expect(isValidIso8601(event.ts)).toBe(true);
-          }
-
-          await svc.dispose();
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+            await svc.dispose();
+          }),
+        ),
+      ));
 
     /**
      * Property test 22: Envelope structure is consistent regardless of event type.
@@ -1065,77 +1037,72 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
      * @plan PLAN-20260211-SESSIONRECORDING.P04
      * @requirement REQ-REC-001
      */
-    it.prop([
-      fc.constantFrom(
-        'content' as const,
-        'compressed' as const,
-        'rewind' as const,
-        'provider_switch' as const,
-        'session_event' as const,
-        'directories_changed' as const,
-      ),
-    ])(
-      'every event has consistent envelope {v, seq, ts, type, payload} @requirement:REQ-REC-001 @plan:PLAN-20260211-SESSIONRECORDING.P04',
-      async (eventType) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-envelope-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('every event has consistent envelope {v, seq, ts, type, payload} @requirement:REQ-REC-001 @plan:PLAN-20260211-SESSIONRECORDING.P04', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.constantFrom(
+            'content' as const,
+            'compressed' as const,
+            'rewind' as const,
+            'provider_switch' as const,
+            'session_event' as const,
+            'directories_changed' as const,
+          ),
+          async (eventType) =>
+            withTempChatsDir('prop-envelope-', async (localChatsDir) => {
+              const config = makeConfig({ chatsDir: localChatsDir });
+              const svc = new SessionRecordingService(config);
 
-        try {
-          const config = makeConfig({ chatsDir: localChatsDir });
-          const svc = new SessionRecordingService(config);
+              // First enqueue content to materialize
+              svc.recordContent(makeContent('trigger'));
 
-          // First enqueue content to materialize
-          svc.recordContent(makeContent('trigger'));
+              // Then enqueue the specific event type
+              switch (eventType) {
+                case 'content':
+                  svc.recordContent(makeContent('test'));
+                  break;
+                case 'compressed':
+                  svc.recordCompressed(
+                    {
+                      speaker: 'ai',
+                      blocks: [{ type: 'text', text: 'summary' }],
+                    },
+                    5,
+                  );
+                  break;
+                case 'rewind':
+                  svc.recordRewind(2);
+                  break;
+                case 'provider_switch':
+                  svc.recordProviderSwitch('test', 'model');
+                  break;
+                case 'session_event':
+                  svc.recordSessionEvent('info', 'test');
+                  break;
+                case 'directories_changed':
+                  svc.recordDirectoriesChanged(['/dir']);
+                  break;
+                default:
+                  break;
+              }
 
-          // Then enqueue the specific event type
-          switch (eventType) {
-            case 'content':
-              svc.recordContent(makeContent('test'));
-              break;
-            case 'compressed':
-              svc.recordCompressed(
-                { speaker: 'ai', blocks: [{ type: 'text', text: 'summary' }] },
-                5,
-              );
-              break;
-            case 'rewind':
-              svc.recordRewind(2);
-              break;
-            case 'provider_switch':
-              svc.recordProviderSwitch('test', 'model');
-              break;
-            case 'session_event':
-              svc.recordSessionEvent('info', 'test');
-              break;
-            case 'directories_changed':
-              svc.recordDirectoriesChanged(['/dir']);
-              break;
-            default:
-              break;
-          }
+              await svc.flush();
+              const events = await readJsonlFile(svc.getFilePath()!);
 
-          await svc.flush();
-          const events = await readJsonlFile(svc.getFilePath()!);
+              for (const event of events) {
+                expect(typeof event.v).toBe('number');
+                expect(event.v).toBe(1);
+                expect(typeof event.seq).toBe('number');
+                expect(typeof event.ts).toBe('string');
+                expect(typeof event.type).toBe('string');
+                expect(event.payload).toBeDefined();
+                expect(event.payload).not.toBeNull();
+              }
 
-          for (const event of events) {
-            expect(typeof event.v).toBe('number');
-            expect(event.v).toBe(1);
-            expect(typeof event.seq).toBe('number');
-            expect(typeof event.ts).toBe('string');
-            expect(typeof event.type).toBe('string');
-            expect(event.payload).toBeDefined();
-            expect(event.payload).not.toBeNull();
-          }
-
-          await svc.dispose();
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+              await svc.dispose();
+            }),
+        ),
+      ));
 
     /**
      * Property test 24: Any number of metadata events before first content preserves
@@ -1144,77 +1111,69 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
      * @plan PLAN-20260211-SESSIONRECORDING.P04
      * @requirement REQ-REC-004, REQ-REC-001.2
      */
-    it.prop([
-      fc.array(
-        fc.constantFrom(
-          'provider_switch' as const,
-          'directories_changed' as const,
-          'session_event' as const,
+    it('any metadata events before first content are written in exact enqueue order @requirement:REQ-REC-004, REQ-REC-001.2 @plan:PLAN-20260211-SESSIONRECORDING.P04', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.array(
+            fc.constantFrom(
+              'provider_switch' as const,
+              'directories_changed' as const,
+              'session_event' as const,
+            ),
+            { minLength: 0, maxLength: 10 },
+          ),
+          async (metadataTypes) =>
+            withTempChatsDir('prop-order-', async (localChatsDir) => {
+              const config = makeConfig({ chatsDir: localChatsDir });
+              const svc = new SessionRecordingService(config);
+
+              // Enqueue metadata events before any content
+              for (const eventType of metadataTypes) {
+                switch (eventType) {
+                  case 'provider_switch':
+                    svc.recordProviderSwitch('test', 'model');
+                    break;
+                  case 'directories_changed':
+                    svc.recordDirectoriesChanged(['/dir']);
+                    break;
+                  case 'session_event':
+                    svc.recordSessionEvent('info', 'event');
+                    break;
+                  default:
+                    break;
+                }
+              }
+
+              // Content triggers materialization
+              svc.recordContent(makeContent('first content'));
+              await svc.flush();
+
+              const events = await readJsonlFile(svc.getFilePath()!);
+
+              // Expected: session_start + metadata events + content
+              const expectedLength = 1 + metadataTypes.length + 1;
+              expect(events).toHaveLength(expectedLength);
+
+              // Line 1 is always session_start
+              expect(events[0].type).toBe('session_start');
+
+              // Middle lines are metadata in exact enqueue order
+              for (let i = 0; i < metadataTypes.length; i++) {
+                expect(events[i + 1].type).toBe(metadataTypes[i]);
+              }
+
+              // Last line is content
+              expect(events[events.length - 1].type).toBe('content');
+
+              // All seq values are strictly monotonically increasing (1, 2, ..., N+2)
+              for (let i = 0; i < events.length; i++) {
+                expect(events[i].seq).toBe(i + 1);
+              }
+
+              await svc.dispose();
+            }),
         ),
-        { minLength: 0, maxLength: 10 },
-      ),
-    ])(
-      'any metadata events before first content are written in exact enqueue order @requirement:REQ-REC-004, REQ-REC-001.2 @plan:PLAN-20260211-SESSIONRECORDING.P04',
-      async (metadataTypes) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-order-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
-
-        try {
-          const config = makeConfig({ chatsDir: localChatsDir });
-          const svc = new SessionRecordingService(config);
-
-          // Enqueue metadata events before any content
-          for (const eventType of metadataTypes) {
-            switch (eventType) {
-              case 'provider_switch':
-                svc.recordProviderSwitch('test', 'model');
-                break;
-              case 'directories_changed':
-                svc.recordDirectoriesChanged(['/dir']);
-                break;
-              case 'session_event':
-                svc.recordSessionEvent('info', 'event');
-                break;
-              default:
-                break;
-            }
-          }
-
-          // Content triggers materialization
-          svc.recordContent(makeContent('first content'));
-          await svc.flush();
-
-          const events = await readJsonlFile(svc.getFilePath()!);
-
-          // Expected: session_start + metadata events + content
-          const expectedLength = 1 + metadataTypes.length + 1;
-          expect(events).toHaveLength(expectedLength);
-
-          // Line 1 is always session_start
-          expect(events[0].type).toBe('session_start');
-
-          // Middle lines are metadata in exact enqueue order
-          for (let i = 0; i < metadataTypes.length; i++) {
-            expect(events[i + 1].type).toBe(metadataTypes[i]);
-          }
-
-          // Last line is content
-          expect(events[events.length - 1].type).toBe('content');
-
-          // All seq values are strictly monotonically increasing (1, 2, ..., N+2)
-          for (let i = 0; i < events.length; i++) {
-            expect(events[i].seq).toBe(i + 1);
-          }
-
-          await svc.dispose();
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+      ));
 
     /**
      * Property test (bonus): Session start payload always contains all required fields.
@@ -1222,52 +1181,46 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
      * @plan PLAN-20260211-SESSIONRECORDING.P04
      * @requirement REQ-REC-001
      */
-    it.prop([
-      fc.record({
-        sessionId: fc.uuid(),
-        provider: fc.constantFrom('anthropic', 'openai', 'google'),
-        model: fc.string({ minLength: 1, maxLength: 30 }),
-      }),
-    ])(
-      'session_start payload has all required fields @requirement:REQ-REC-001 @plan:PLAN-20260211-SESSIONRECORDING.P04',
-      async ({ sessionId, provider, model }) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-start-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('session_start payload has all required fields @requirement:REQ-REC-001 @plan:PLAN-20260211-SESSIONRECORDING.P04', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.record({
+            sessionId: fc.uuid(),
+            provider: fc.constantFrom('anthropic', 'openai', 'google'),
+            model: fc.string({ minLength: 1, maxLength: 30 }),
+          }),
+          async ({ sessionId, provider, model }) =>
+            withTempChatsDir('prop-start-', async (localChatsDir) => {
+              const config = makeConfig({
+                chatsDir: localChatsDir,
+                sessionId,
+                provider,
+                model,
+              });
+              const svc = new SessionRecordingService(config);
 
-        try {
-          const config = makeConfig({
-            chatsDir: localChatsDir,
-            sessionId,
-            provider,
-            model,
-          });
-          const svc = new SessionRecordingService(config);
+              svc.recordContent(makeContent('trigger'));
+              await svc.flush();
 
-          svc.recordContent(makeContent('trigger'));
-          await svc.flush();
+              const events = await readJsonlFile(svc.getFilePath()!);
+              const startPayload = events[0].payload as Record<string, unknown>;
 
-          const events = await readJsonlFile(svc.getFilePath()!);
-          const startPayload = events[0].payload as Record<string, unknown>;
+              expect(startPayload.sessionId).toBe(sessionId);
+              expect(startPayload.projectHash).toBe(config.projectHash);
+              expect(startPayload.provider).toBe(provider);
+              expect(startPayload.model).toBe(model);
+              expect(startPayload.workspaceDirs).toStrictEqual(
+                config.workspaceDirs,
+              );
+              expect(startPayload.cwd).toBe(config.cwd);
+              expect(typeof startPayload.startTime).toBe('string');
+              expect(isValidIso8601(startPayload.startTime as string)).toBe(
+                true,
+              );
 
-          expect(startPayload.sessionId).toBe(sessionId);
-          expect(startPayload.projectHash).toBe(config.projectHash);
-          expect(startPayload.provider).toBe(provider);
-          expect(startPayload.model).toBe(model);
-          expect(startPayload.workspaceDirs).toStrictEqual(
-            config.workspaceDirs,
-          );
-          expect(startPayload.cwd).toBe(config.cwd);
-          expect(typeof startPayload.startTime).toBe('string');
-          expect(isValidIso8601(startPayload.startTime as string)).toBe(true);
-
-          await svc.dispose();
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+              await svc.dispose();
+            }),
+        ),
+      ));
   });
 });

--- a/packages/core/src/recording/integration.advanced.test.ts
+++ b/packages/core/src/recording/integration.advanced.test.ts
@@ -21,7 +21,7 @@
  * End-to-end integration tests exercising the full recording → replay →
  * resume → continue lifecycle. Uses real filesystem, real services, no mocks.
  *
- * Property-based tests use @fast-check/vitest (≥30% of total).
+ * Property-based tests use fast-check (≥30% of total).
  */
 
 import { describe, expect, beforeEach, afterEach, it } from 'vitest';

--- a/packages/core/src/recording/integration.basic.test.ts
+++ b/packages/core/src/recording/integration.basic.test.ts
@@ -21,7 +21,7 @@
  * End-to-end integration tests exercising the full recording → replay →
  * resume → continue lifecycle. Uses real filesystem, real services, no mocks.
  *
- * Property-based tests use @fast-check/vitest (≥30% of total).
+ * Property-based tests use fast-check (≥30% of total).
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';

--- a/packages/core/src/recording/resumeSession.test.ts
+++ b/packages/core/src/recording/resumeSession.test.ts
@@ -23,13 +23,12 @@
  * to create, lock, and resume genuine session JSONL files in real temp
  * directories — no mock theater.
  *
- * Property-based tests use @fast-check/vitest (≥30% of total tests).
+ * Property-based tests use fast-check (≥30% of total tests).
  * All tests expect real behavior. They will fail against the Phase 18 stub
  * — that is correct TDD.
  */
 
-import { describe, expect, beforeEach, afterEach } from 'vitest';
-import { it as itProp } from '@fast-check/vitest';
+import { describe, expect, beforeEach, afterEach, it } from 'vitest';
 import * as fc from 'fast-check';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -142,6 +141,30 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Asserts the result is the success variant and returns it narrowed.
+ * Couples the runtime check to the type narrowing so a caller cannot
+ * reach the success fields without the assertion having passed.
+ */
+function expectOk<T extends { ok: boolean }>(
+  result: T,
+): Extract<T, { ok: true }> {
+  expect(result.ok).toBe(true);
+  return result as Extract<T, { ok: true }>;
+}
+
+/**
+ * Asserts the result is the failure variant and returns it narrowed.
+ * Couples the runtime check to the type narrowing so a caller cannot
+ * reach the failure fields without the assertion having passed.
+ */
+function expectNotOk<T extends { ok: boolean }>(
+  result: T,
+): Extract<T, { ok: false }> {
+  expect(result.ok).toBe(false);
+  return result as Extract<T, { ok: false }>;
+}
+
 // ---------------------------------------------------------------------------
 // Test suite
 // ---------------------------------------------------------------------------
@@ -180,7 +203,7 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-001
      */
-    itProp('resumes the most recent unlocked session', async () => {
+    it('resumes the most recent unlocked session', async () => {
       await createTestSession(chatsDir, {
         projectHash: PROJECT_HASH,
         contents: [makeContent('first session message')],
@@ -193,17 +216,15 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
 
       const result = await resumeSession(makeResumeRequest(chatsDir));
 
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.history).toHaveLength(1);
-        expect(result.history[0].blocks[0]).toStrictEqual({
-          type: 'text',
-          text: 'second session message',
-        });
-        expect(result.lockHandle).toBeDefined();
-        expect(result.lockHandle.lockPath).toBeTruthy();
-        lockHandles.push(result.lockHandle);
-      }
+      const okResult = expectOk(result);
+      expect(okResult.history).toHaveLength(1);
+      expect(okResult.history[0].blocks[0]).toStrictEqual({
+        type: 'text',
+        text: 'second session message',
+      });
+      expect(okResult.lockHandle).toBeDefined();
+      expect(okResult.lockHandle.lockPath).toBeTruthy();
+      lockHandles.push(okResult.lockHandle);
     });
   });
 
@@ -221,7 +242,7 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-002
      */
-    itProp('resumes a specific session by ID', async () => {
+    it('resumes a specific session by ID', async () => {
       const targetId = 'target-resume-session';
       await createTestSession(chatsDir, {
         sessionId: targetId,
@@ -237,18 +258,16 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
         makeResumeRequest(chatsDir, { continueRef: targetId }),
       );
 
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.history).toHaveLength(1);
-        expect(result.history[0].blocks[0]).toStrictEqual({
-          type: 'text',
-          text: 'target content',
-        });
-        expect(result.metadata.sessionId).toBe(targetId);
-        expect(result.lockHandle).toBeDefined();
-        expect(result.lockHandle.lockPath).toBeTruthy();
-        lockHandles.push(result.lockHandle);
-      }
+      const okResult = expectOk(result);
+      expect(okResult.history).toHaveLength(1);
+      expect(okResult.history[0].blocks[0]).toStrictEqual({
+        type: 'text',
+        text: 'target content',
+      });
+      expect(okResult.metadata.sessionId).toBe(targetId);
+      expect(okResult.lockHandle).toBeDefined();
+      expect(okResult.lockHandle.lockPath).toBeTruthy();
+      lockHandles.push(okResult.lockHandle);
     });
   });
 
@@ -266,7 +285,7 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-004
      */
-    itProp('reconstructs history with correct IContent items', async () => {
+    it('reconstructs history with correct IContent items', async () => {
       const contents: IContent[] = [
         makeContent('question 1', 'human'),
         makeContent('answer 1', 'ai'),
@@ -280,26 +299,24 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
 
       const result = await resumeSession(makeResumeRequest(chatsDir));
 
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        lockHandles.push(result.lockHandle);
-        expect(result.history).toHaveLength(3);
-        expect(result.history[0].speaker).toBe('human');
-        expect(result.history[0].blocks[0]).toStrictEqual({
-          type: 'text',
-          text: 'question 1',
-        });
-        expect(result.history[1].speaker).toBe('ai');
-        expect(result.history[1].blocks[0]).toStrictEqual({
-          type: 'text',
-          text: 'answer 1',
-        });
-        expect(result.history[2].speaker).toBe('human');
-        expect(result.history[2].blocks[0]).toStrictEqual({
-          type: 'text',
-          text: 'question 2',
-        });
-      }
+      const okResult = expectOk(result);
+      lockHandles.push(okResult.lockHandle);
+      expect(okResult.history).toHaveLength(3);
+      expect(okResult.history[0].speaker).toBe('human');
+      expect(okResult.history[0].blocks[0]).toStrictEqual({
+        type: 'text',
+        text: 'question 1',
+      });
+      expect(okResult.history[1].speaker).toBe('ai');
+      expect(okResult.history[1].blocks[0]).toStrictEqual({
+        type: 'text',
+        text: 'answer 1',
+      });
+      expect(okResult.history[2].speaker).toBe('human');
+      expect(okResult.history[2].blocks[0]).toStrictEqual({
+        type: 'text',
+        text: 'question 2',
+      });
     });
 
     /**
@@ -311,58 +328,53 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-004
      */
-    itProp(
-      'reconstructs history correctly for compressed sessions',
-      async () => {
-        const sessionId = 'compressed-session';
-        const config = makeConfig(chatsDir, {
-          sessionId,
-          projectHash: PROJECT_HASH,
-        });
-        const svc = new SessionRecordingService(config);
+    it('reconstructs history correctly for compressed sessions', async () => {
+      const sessionId = 'compressed-session';
+      const config = makeConfig(chatsDir, {
+        sessionId,
+        projectHash: PROJECT_HASH,
+      });
+      const svc = new SessionRecordingService(config);
 
-        // Add initial content
-        svc.recordContent(makeContent('old msg 1', 'human'));
-        svc.recordContent(makeContent('old msg 2', 'ai'));
-        svc.recordContent(makeContent('old msg 3', 'human'));
+      // Add initial content
+      svc.recordContent(makeContent('old msg 1', 'human'));
+      svc.recordContent(makeContent('old msg 2', 'ai'));
+      svc.recordContent(makeContent('old msg 3', 'human'));
 
-        // Compress all prior content
-        const summary: IContent = {
-          speaker: 'ai',
-          blocks: [{ type: 'text', text: 'Summary of prior conversation' }],
-          metadata: { isSummary: true },
-        };
-        svc.recordCompressed(summary, 3);
+      // Compress all prior content
+      const summary: IContent = {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Summary of prior conversation' }],
+        metadata: { isSummary: true },
+      };
+      svc.recordCompressed(summary, 3);
 
-        // Add new content after compression
-        svc.recordContent(makeContent('new msg after compression', 'human'));
-        svc.recordContent(makeContent('new response', 'ai'));
+      // Add new content after compression
+      svc.recordContent(makeContent('new msg after compression', 'human'));
+      svc.recordContent(makeContent('new response', 'ai'));
 
-        await svc.flush();
-        await svc.dispose();
+      await svc.flush();
+      await svc.dispose();
 
-        const result = await resumeSession(makeResumeRequest(chatsDir));
+      const result = await resumeSession(makeResumeRequest(chatsDir));
 
-        expect(result.ok).toBe(true);
-        if (result.ok) {
-          lockHandles.push(result.lockHandle);
-          // After compression: summary + 2 new content items = 3
-          expect(result.history).toHaveLength(3);
-          expect(result.history[0].blocks[0]).toStrictEqual({
-            type: 'text',
-            text: 'Summary of prior conversation',
-          });
-          expect(result.history[1].blocks[0]).toStrictEqual({
-            type: 'text',
-            text: 'new msg after compression',
-          });
-          expect(result.history[2].blocks[0]).toStrictEqual({
-            type: 'text',
-            text: 'new response',
-          });
-        }
-      },
-    );
+      const okResult = expectOk(result);
+      lockHandles.push(okResult.lockHandle);
+      // After compression: summary + 2 new content items = 3
+      expect(okResult.history).toHaveLength(3);
+      expect(okResult.history[0].blocks[0]).toStrictEqual({
+        type: 'text',
+        text: 'Summary of prior conversation',
+      });
+      expect(okResult.history[1].blocks[0]).toStrictEqual({
+        type: 'text',
+        text: 'new msg after compression',
+      });
+      expect(okResult.history[2].blocks[0]).toStrictEqual({
+        type: 'text',
+        text: 'new response',
+      });
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -379,7 +391,7 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-004
      */
-    itProp('returns correct session metadata', async () => {
+    it('returns correct session metadata', async () => {
       const sessionId = 'metadata-session-id';
       await createTestSession(chatsDir, {
         sessionId,
@@ -395,15 +407,13 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
         }),
       );
 
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        lockHandles.push(result.lockHandle);
-        expect(result.metadata.sessionId).toBe(sessionId);
-        expect(result.metadata.provider).toBe('google');
-        expect(result.metadata.model).toBe('gemini-3');
-        expect(result.metadata.projectHash).toBe(PROJECT_HASH);
-        expect(typeof result.metadata.startTime).toBe('string');
-      }
+      const okResult = expectOk(result);
+      lockHandles.push(okResult.lockHandle);
+      expect(okResult.metadata.sessionId).toBe(sessionId);
+      expect(okResult.metadata.provider).toBe('google');
+      expect(okResult.metadata.model).toBe('gemini-3');
+      expect(okResult.metadata.projectHash).toBe(PROJECT_HASH);
+      expect(typeof okResult.metadata.startTime).toBe('string');
     });
   });
 
@@ -421,13 +431,11 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-001
      */
-    itProp('returns error when no sessions exist', async () => {
+    it('returns error when no sessions exist', async () => {
       const result = await resumeSession(makeResumeRequest(chatsDir));
 
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error.toLowerCase()).toContain('no session');
-      }
+      const errResult = expectNotOk(result);
+      expect(errResult.error.toLowerCase()).toContain('no session');
     });
 
     /**
@@ -439,7 +447,7 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-002
      */
-    itProp('returns error when specific session ID is not found', async () => {
+    it('returns error when specific session ID is not found', async () => {
       await createTestSession(chatsDir, { projectHash: PROJECT_HASH });
 
       const result = await resumeSession(
@@ -448,10 +456,8 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
         }),
       );
 
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error).toBeTruthy();
-      }
+      const errResult = expectNotOk(result);
+      expect(errResult.error).toBeTruthy();
     });
 
     /**
@@ -463,7 +469,7 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-001
      */
-    itProp('returns error when target session is locked', async () => {
+    it('returns error when target session is locked', async () => {
       const sessionId = 'locked-session';
       await createTestSession(chatsDir, {
         sessionId,
@@ -477,10 +483,8 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
         makeResumeRequest(chatsDir, { continueRef: sessionId }),
       );
 
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error.toLowerCase()).toContain('in use');
-      }
+      const errResult = expectNotOk(result);
+      expect(errResult.error.toLowerCase()).toContain('in use');
     });
 
     /**
@@ -492,40 +496,35 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-001
      */
-    itProp(
-      'CONTINUE_LATEST skips locked sessions and resumes next unlocked',
-      async () => {
-        // Create older session
-        await createTestSession(chatsDir, {
-          projectHash: PROJECT_HASH,
-          contents: [makeContent('older unlocked content')],
-        });
-        await delay(100);
+    it('CONTINUE_LATEST skips locked sessions and resumes next unlocked', async () => {
+      // Create older session
+      await createTestSession(chatsDir, {
+        projectHash: PROJECT_HASH,
+        contents: [makeContent('older unlocked content')],
+      });
+      await delay(100);
 
-        // Create newer session and lock it
-        const newer = await createTestSession(chatsDir, {
-          projectHash: PROJECT_HASH,
-          contents: [makeContent('newer locked content')],
-        });
+      // Create newer session and lock it
+      const newer = await createTestSession(chatsDir, {
+        projectHash: PROJECT_HASH,
+        contents: [makeContent('newer locked content')],
+      });
 
-        const handle = await SessionLockManager.acquire(
-          chatsDir,
-          newer.sessionId,
-        );
-        lockHandles.push(handle);
+      const handle = await SessionLockManager.acquire(
+        chatsDir,
+        newer.sessionId,
+      );
+      lockHandles.push(handle);
 
-        const result = await resumeSession(makeResumeRequest(chatsDir));
+      const result = await resumeSession(makeResumeRequest(chatsDir));
 
-        expect(result.ok).toBe(true);
-        if (result.ok) {
-          lockHandles.push(result.lockHandle);
-          expect(result.history[0].blocks[0]).toStrictEqual({
-            type: 'text',
-            text: 'older unlocked content',
-          });
-        }
-      },
-    );
+      const okResult = expectOk(result);
+      lockHandles.push(okResult.lockHandle);
+      expect(okResult.history[0].blocks[0]).toStrictEqual({
+        type: 'text',
+        text: 'older unlocked content',
+      });
+    });
 
     /**
      * Test 20: Resume all locked returns error
@@ -536,7 +535,7 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-001
      */
-    itProp('returns error when all sessions are locked', async () => {
+    it('returns error when all sessions are locked', async () => {
       const s1 = await createTestSession(chatsDir, {
         projectHash: PROJECT_HASH,
       });
@@ -555,10 +554,8 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
 
       const result = await resumeSession(makeResumeRequest(chatsDir));
 
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error.toLowerCase()).toContain('in use');
-      }
+      const errResult = expectNotOk(result);
+      expect(errResult.error.toLowerCase()).toContain('in use');
     });
   });
 
@@ -576,46 +573,41 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-005
      */
-    itProp(
-      'records provider_switch when current provider differs from session',
-      async () => {
-        await createTestSession(chatsDir, {
-          projectHash: PROJECT_HASH,
-          provider: 'anthropic',
-          model: 'claude-4',
-          contents: [makeContent('original content')],
-        });
+    it('records provider_switch when current provider differs from session', async () => {
+      await createTestSession(chatsDir, {
+        projectHash: PROJECT_HASH,
+        provider: 'anthropic',
+        model: 'claude-4',
+        contents: [makeContent('original content')],
+      });
 
-        const result = await resumeSession(
-          makeResumeRequest(chatsDir, {
-            currentProvider: 'openai',
-            currentModel: 'gpt-5',
-          }),
-        );
+      const result = await resumeSession(
+        makeResumeRequest(chatsDir, {
+          currentProvider: 'openai',
+          currentModel: 'gpt-5',
+        }),
+      );
 
-        expect(result.ok).toBe(true);
-        if (result.ok) {
-          lockHandles.push(result.lockHandle);
-          // Flush the recording to ensure the provider_switch is written
-          await result.recording.flush();
+      const okResult = expectOk(result);
+      lockHandles.push(okResult.lockHandle);
+      // Flush the recording to ensure the provider_switch is written
+      await okResult.recording.flush();
 
-          // Read the file and check for provider_switch event
-          const events = await readJsonlFile(result.recording.getFilePath()!);
-          const providerSwitchEvents = events.filter(
-            (e) => e.type === 'provider_switch',
-          );
-          expect(providerSwitchEvents.length).toBeGreaterThanOrEqual(1);
+      // Read the file and check for provider_switch event
+      const events = await readJsonlFile(okResult.recording.getFilePath()!);
+      const providerSwitchEvents = events.filter(
+        (e) => e.type === 'provider_switch',
+      );
+      expect(providerSwitchEvents.length).toBeGreaterThanOrEqual(1);
 
-          const switchPayload = providerSwitchEvents[
-            providerSwitchEvents.length - 1
-          ].payload as { provider: string; model: string };
-          expect(switchPayload.provider).toBe('openai');
-          expect(switchPayload.model).toBe('gpt-5');
+      const switchPayload = providerSwitchEvents[
+        providerSwitchEvents.length - 1
+      ].payload as { provider: string; model: string };
+      expect(switchPayload.provider).toBe('openai');
+      expect(switchPayload.model).toBe('gpt-5');
 
-          await result.recording.dispose();
-        }
-      },
-    );
+      await okResult.recording.dispose();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -632,80 +624,70 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-006
      */
-    itProp(
-      'new events after resume have seq continuing from lastSeq',
-      async () => {
-        // Create session with 3 content events (session_start seq=1, content seq=2,3,4)
-        await createTestSession(chatsDir, {
-          projectHash: PROJECT_HASH,
-          contents: [
-            makeContent('msg 1', 'human'),
-            makeContent('msg 2', 'ai'),
-            makeContent('msg 3', 'human'),
-          ],
-        });
+    it('new events after resume have seq continuing from lastSeq', async () => {
+      // Create session with 3 content events (session_start seq=1, content seq=2,3,4)
+      await createTestSession(chatsDir, {
+        projectHash: PROJECT_HASH,
+        contents: [
+          makeContent('msg 1', 'human'),
+          makeContent('msg 2', 'ai'),
+          makeContent('msg 3', 'human'),
+        ],
+      });
 
-        const result = await resumeSession(makeResumeRequest(chatsDir));
+      const result = await resumeSession(makeResumeRequest(chatsDir));
 
-        expect(result.ok).toBe(true);
-        if (result.ok) {
-          lockHandles.push(result.lockHandle);
-          // Record new content
-          result.recording.recordContent(makeContent('resumed msg', 'human'));
-          await result.recording.flush();
+      const okResult = expectOk(result);
+      lockHandles.push(okResult.lockHandle);
+      // Record new content
+      okResult.recording.recordContent(makeContent('resumed msg', 'human'));
+      await okResult.recording.flush();
 
-          // Read the file and check seq continuation
-          const events = await readJsonlFile(result.recording.getFilePath()!);
+      // Read the file and check seq continuation
+      const events = await readJsonlFile(okResult.recording.getFilePath()!);
 
-          // Original: session_start(1), content(2), content(3), content(4)
-          // New events should have seq > 4
-          const originalLastSeq = 4;
-          const newEvents = events.filter((e) => e.seq > originalLastSeq);
-          expect(newEvents.length).toBeGreaterThanOrEqual(1);
+      // Original: session_start(1), content(2), content(3), content(4)
+      // New events should have seq > 4
+      const originalLastSeq = 4;
+      const newEvents = events.filter((e) => e.seq > originalLastSeq);
+      expect(newEvents.length).toBeGreaterThanOrEqual(1);
 
-          // All new events have seq > originalLastSeq
-          for (const evt of newEvents) {
-            expect(evt.seq).toBeGreaterThan(originalLastSeq);
-          }
+      // All new events have seq > originalLastSeq
+      for (const evt of newEvents) {
+        expect(evt.seq).toBeGreaterThan(originalLastSeq);
+      }
 
-          // Verify monotonicity across all events
-          for (let i = 1; i < events.length; i++) {
-            expect(events[i].seq).toBeGreaterThan(events[i - 1].seq);
-          }
+      // Verify monotonicity across all events
+      for (let i = 1; i < events.length; i++) {
+        expect(events[i].seq).toBeGreaterThan(events[i - 1].seq);
+      }
 
-          await result.recording.dispose();
-        }
-      },
-    );
+      await okResult.recording.dispose();
+    });
 
     /**
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-006
      */
-    itProp(
-      'returned recording has non-null file path and matching session ID',
-      async () => {
-        const sessionId = 'recording-check-session';
-        await createTestSession(chatsDir, {
-          sessionId,
-          projectHash: PROJECT_HASH,
-        });
+    it('returned recording has non-null file path and matching session ID', async () => {
+      const sessionId = 'recording-check-session';
+      await createTestSession(chatsDir, {
+        sessionId,
+        projectHash: PROJECT_HASH,
+      });
 
-        const result = await resumeSession(
-          makeResumeRequest(chatsDir, { continueRef: sessionId }),
-        );
+      const result = await resumeSession(
+        makeResumeRequest(chatsDir, { continueRef: sessionId }),
+      );
 
-        expect(result.ok).toBe(true);
-        if (result.ok) {
-          lockHandles.push(result.lockHandle);
-          expect(result.recording).toBeDefined();
-          expect(result.recording.getFilePath()).not.toBeNull();
-          expect(result.recording.getSessionId()).toBe(sessionId);
-          expect(result.recording.isActive()).toBe(true);
-          await result.recording.dispose();
-        }
-      },
-    );
+      const okResult = expectOk(result);
+      lockHandles.push(okResult.lockHandle);
+      expect(okResult.recording).toBeDefined();
+      expect(okResult.recording.getFilePath()).not.toBeNull();
+      expect(okResult.recording.getSessionId()).toBe(sessionId);
+      expect(okResult.recording.isActive()).toBe(true);
+      await okResult.recording.dispose();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -722,38 +704,33 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-004
      */
-    itProp(
-      'passes through replay warnings for corrupt mid-file lines',
-      async () => {
-        // Create a valid session first
-        const { filePath } = await createTestSession(chatsDir, {
-          projectHash: PROJECT_HASH,
-          contents: [makeContent('valid content')],
-        });
+    it('passes through replay warnings for corrupt mid-file lines', async () => {
+      // Create a valid session first
+      const { filePath } = await createTestSession(chatsDir, {
+        projectHash: PROJECT_HASH,
+        contents: [makeContent('valid content')],
+      });
 
-        // Inject a corrupt line in the middle of the file
-        const fileContent = await fs.readFile(filePath, 'utf-8');
-        const lines = fileContent.trimEnd().split('\n');
-        // Insert corrupt line between session_start and content
-        const withCorruption =
-          [lines[0], '{this is not valid json}', ...lines.slice(1)].join('\n') +
-          '\n';
-        await fs.writeFile(filePath, withCorruption, 'utf-8');
+      // Inject a corrupt line in the middle of the file
+      const fileContent = await fs.readFile(filePath, 'utf-8');
+      const lines = fileContent.trimEnd().split('\n');
+      // Insert corrupt line between session_start and content
+      const withCorruption =
+        [lines[0], '{this is not valid json}', ...lines.slice(1)].join('\n') +
+        '\n';
+      await fs.writeFile(filePath, withCorruption, 'utf-8');
 
-        const result = await resumeSession(makeResumeRequest(chatsDir));
+      const result = await resumeSession(makeResumeRequest(chatsDir));
 
-        expect(result.ok).toBe(true);
-        if (result.ok) {
-          lockHandles.push(result.lockHandle);
-          expect(result.warnings.length).toBeGreaterThan(0);
-          const hasParseWarning = result.warnings.some(
-            (w) => w.includes('parse') || w.includes('JSON'),
-          );
-          expect(hasParseWarning).toBe(true);
-          await result.recording.dispose();
-        }
-      },
-    );
+      const okResult = expectOk(result);
+      lockHandles.push(okResult.lockHandle);
+      expect(okResult.warnings.length).toBeGreaterThan(0);
+      const hasParseWarning = okResult.warnings.some(
+        (w) => w.includes('parse') || w.includes('JSON'),
+      );
+      expect(hasParseWarning).toBe(true);
+      await okResult.recording.dispose();
+    });
   });
 
   // =========================================================================
@@ -768,53 +745,54 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-004
      */
-    itProp.prop([
-      fc.array(
-        fc.record({
-          speaker: fc.constantFrom('human' as const, 'ai' as const),
-          text: fc.string({ minLength: 1, maxLength: 100 }),
-        }),
-        { minLength: 1, maxLength: 5 },
-      ),
-    ])(
-      'preserves any IContent through write-resume cycle @requirement:REQ-RSM-004',
-      async (items) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-resume-roundtrip-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('preserves any IContent through write-resume cycle @requirement:REQ-RSM-004', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.array(
+            fc.record({
+              speaker: fc.constantFrom('human' as const, 'ai' as const),
+              text: fc.string({ minLength: 1, maxLength: 100 }),
+            }),
+            { minLength: 1, maxLength: 5 },
+          ),
+          async (items) => {
+            const localTempDir = await fs.mkdtemp(
+              path.join(os.tmpdir(), 'prop-resume-roundtrip-'),
+            );
+            const localChatsDir = path.join(localTempDir, 'chats');
+            await fs.mkdir(localChatsDir, { recursive: true });
 
-        try {
-          const contents: IContent[] = items.map((item) => ({
-            speaker: item.speaker,
-            blocks: [{ type: 'text' as const, text: item.text }],
-          }));
+            try {
+              const contents: IContent[] = items.map((item) => ({
+                speaker: item.speaker,
+                blocks: [{ type: 'text' as const, text: item.text }],
+              }));
 
-          await createTestSession(localChatsDir, {
-            projectHash: PROJECT_HASH,
-            contents,
-          });
+              await createTestSession(localChatsDir, {
+                projectHash: PROJECT_HASH,
+                contents,
+              });
 
-          const result = await resumeSession(makeResumeRequest(localChatsDir));
-
-          expect(result.ok).toBe(true);
-          if (result.ok) {
-            expect(result.history).toHaveLength(contents.length);
-            for (let i = 0; i < contents.length; i++) {
-              expect(result.history[i].speaker).toBe(contents[i].speaker);
-              expect(result.history[i].blocks[0]).toStrictEqual(
-                contents[i].blocks[0],
+              const result = await resumeSession(
+                makeResumeRequest(localChatsDir),
               );
+
+              const okResult = expectOk(result);
+              expect(okResult.history).toHaveLength(contents.length);
+              for (let i = 0; i < contents.length; i++) {
+                expect(okResult.history[i].speaker).toBe(contents[i].speaker);
+                expect(okResult.history[i].blocks[0]).toStrictEqual(
+                  contents[i].blocks[0],
+                );
+              }
+              await okResult.recording.dispose();
+              await okResult.lockHandle.release();
+            } finally {
+              await fs.rm(localTempDir, { recursive: true, force: true });
             }
-            await result.recording.dispose();
-            await result.lockHandle.release();
-          }
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+          },
+        ),
+      ));
 
     /**
      * Test 28: Provider mismatch detection works for any provider strings
@@ -823,59 +801,60 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-005
      */
-    itProp.prop([
-      fc.string({ minLength: 1, maxLength: 20 }),
-      fc.string({ minLength: 1, maxLength: 20 }),
-    ])(
-      'detects provider mismatch for any two different provider strings @requirement:REQ-RSM-005',
-      async (sessionProvider, currentProvider) => {
-        fc.pre(sessionProvider !== currentProvider);
+    it('detects provider mismatch for any two different provider strings @requirement:REQ-RSM-005', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 20 }),
+          fc.string({ minLength: 1, maxLength: 20 }),
+          async (sessionProvider, currentProvider) => {
+            fc.pre(sessionProvider !== currentProvider);
 
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-provider-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
-
-        try {
-          await createTestSession(localChatsDir, {
-            projectHash: PROJECT_HASH,
-            provider: sessionProvider,
-            model: 'model-a',
-          });
-
-          const result = await resumeSession(
-            makeResumeRequest(localChatsDir, {
-              currentProvider,
-              currentModel: 'model-b',
-            }),
-          );
-
-          expect(result.ok).toBe(true);
-          if (result.ok) {
-            await result.recording.flush();
-
-            // Verify provider_switch event was recorded
-            const events = await readJsonlFile(result.recording.getFilePath()!);
-            const switchEvents = events.filter(
-              (e) => e.type === 'provider_switch',
+            const localTempDir = await fs.mkdtemp(
+              path.join(os.tmpdir(), 'prop-provider-'),
             );
-            expect(switchEvents.length).toBeGreaterThanOrEqual(1);
+            const localChatsDir = path.join(localTempDir, 'chats');
+            await fs.mkdir(localChatsDir, { recursive: true });
 
-            const payload = switchEvents[switchEvents.length - 1].payload as {
-              provider: string;
-              model: string;
-            };
-            expect(payload.provider).toBe(currentProvider);
+            try {
+              await createTestSession(localChatsDir, {
+                projectHash: PROJECT_HASH,
+                provider: sessionProvider,
+                model: 'model-a',
+              });
 
-            await result.recording.dispose();
-            await result.lockHandle.release();
-          }
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+              const result = await resumeSession(
+                makeResumeRequest(localChatsDir, {
+                  currentProvider,
+                  currentModel: 'model-b',
+                }),
+              );
+
+              const okResult = expectOk(result);
+              await okResult.recording.flush();
+
+              // Verify provider_switch event was recorded
+              const events = await readJsonlFile(
+                okResult.recording.getFilePath()!,
+              );
+              const switchEvents = events.filter(
+                (e) => e.type === 'provider_switch',
+              );
+              expect(switchEvents.length).toBeGreaterThanOrEqual(1);
+
+              const payload = switchEvents[switchEvents.length - 1].payload as {
+                provider: string;
+                model: string;
+              };
+              expect(payload.provider).toBe(currentProvider);
+
+              await okResult.recording.dispose();
+              await okResult.lockHandle.release();
+            } finally {
+              await fs.rm(localTempDir, { recursive: true, force: true });
+            }
+          },
+        ),
+      ));
 
     /**
      * Test 29: Sequence continuation after resume produces monotonic seq
@@ -884,53 +863,56 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-006
      */
-    itProp.prop([
-      fc.integer({ min: 1, max: 8 }),
-      fc.integer({ min: 1, max: 5 }),
-    ])(
-      'sequence is monotonic across resume boundary @requirement:REQ-RSM-006',
-      async (originalCount, newCount) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-seq-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('sequence is monotonic across resume boundary @requirement:REQ-RSM-006', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 8 }),
+          fc.integer({ min: 1, max: 5 }),
+          async (originalCount, newCount) => {
+            const localTempDir = await fs.mkdtemp(
+              path.join(os.tmpdir(), 'prop-seq-'),
+            );
+            const localChatsDir = path.join(localTempDir, 'chats');
+            await fs.mkdir(localChatsDir, { recursive: true });
 
-        try {
-          const originalContents: IContent[] = [];
-          for (let i = 0; i < originalCount; i++) {
-            originalContents.push(makeContent(`original-${i}`));
-          }
+            try {
+              const originalContents: IContent[] = [];
+              for (let i = 0; i < originalCount; i++) {
+                originalContents.push(makeContent(`original-${i}`));
+              }
 
-          await createTestSession(localChatsDir, {
-            projectHash: PROJECT_HASH,
-            contents: originalContents,
-          });
+              await createTestSession(localChatsDir, {
+                projectHash: PROJECT_HASH,
+                contents: originalContents,
+              });
 
-          const result = await resumeSession(makeResumeRequest(localChatsDir));
+              const result = await resumeSession(
+                makeResumeRequest(localChatsDir),
+              );
 
-          expect(result.ok).toBe(true);
-          if (result.ok) {
-            // Add new events
-            for (let i = 0; i < newCount; i++) {
-              result.recording.recordContent(makeContent(`new-${i}`));
+              const okResult = expectOk(result);
+              // Add new events
+              for (let i = 0; i < newCount; i++) {
+                okResult.recording.recordContent(makeContent(`new-${i}`));
+              }
+              await okResult.recording.flush();
+
+              // Verify monotonic seq across entire file
+              const events = await readJsonlFile(
+                okResult.recording.getFilePath()!,
+              );
+              for (let i = 1; i < events.length; i++) {
+                expect(events[i].seq).toBeGreaterThan(events[i - 1].seq);
+              }
+
+              await okResult.recording.dispose();
+              await okResult.lockHandle.release();
+            } finally {
+              await fs.rm(localTempDir, { recursive: true, force: true });
             }
-            await result.recording.flush();
-
-            // Verify monotonic seq across entire file
-            const events = await readJsonlFile(result.recording.getFilePath()!);
-            for (let i = 1; i < events.length; i++) {
-              expect(events[i].seq).toBeGreaterThan(events[i - 1].seq);
-            }
-
-            await result.recording.dispose();
-            await result.lockHandle.release();
-          }
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+          },
+        ),
+      ));
 
     /**
      * Test 32: Resume result always has non-null recording service
@@ -939,41 +921,44 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-006
      */
-    itProp.prop([fc.integer({ min: 1, max: 5 })])(
-      'resume always returns a non-null active recording service @requirement:REQ-RSM-006',
-      async (contentCount) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-recording-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('resume always returns a non-null active recording service @requirement:REQ-RSM-006', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 5 }),
+          async (contentCount) => {
+            const localTempDir = await fs.mkdtemp(
+              path.join(os.tmpdir(), 'prop-recording-'),
+            );
+            const localChatsDir = path.join(localTempDir, 'chats');
+            await fs.mkdir(localChatsDir, { recursive: true });
 
-        try {
-          const contents: IContent[] = [];
-          for (let i = 0; i < contentCount; i++) {
-            contents.push(makeContent(`content-${i}`));
-          }
+            try {
+              const contents: IContent[] = [];
+              for (let i = 0; i < contentCount; i++) {
+                contents.push(makeContent(`content-${i}`));
+              }
 
-          await createTestSession(localChatsDir, {
-            projectHash: PROJECT_HASH,
-            contents,
-          });
+              await createTestSession(localChatsDir, {
+                projectHash: PROJECT_HASH,
+                contents,
+              });
 
-          const result = await resumeSession(makeResumeRequest(localChatsDir));
+              const result = await resumeSession(
+                makeResumeRequest(localChatsDir),
+              );
 
-          expect(result.ok).toBe(true);
-          if (result.ok) {
-            expect(result.recording).toBeDefined();
-            expect(result.recording.getFilePath()).not.toBeNull();
-            expect(result.recording.isActive()).toBe(true);
-            await result.recording.dispose();
-            await result.lockHandle.release();
-          }
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+              const okResult = expectOk(result);
+              expect(okResult.recording).toBeDefined();
+              expect(okResult.recording.getFilePath()).not.toBeNull();
+              expect(okResult.recording.isActive()).toBe(true);
+              await okResult.recording.dispose();
+              await okResult.lockHandle.release();
+            } finally {
+              await fs.rm(localTempDir, { recursive: true, force: true });
+            }
+          },
+        ),
+      ));
 
     /**
      * Test 33: Compression followed by content produces correct resume history length
@@ -983,61 +968,62 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-004
      */
-    itProp.prop([
-      fc.integer({ min: 1, max: 5 }),
-      fc.integer({ min: 0, max: 5 }),
-    ])(
-      'compression + new content produces correct history length @requirement:REQ-RSM-004',
-      async (preCompressCount, postCompressCount) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-compress-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
+    it('compression + new content produces correct history length @requirement:REQ-RSM-004', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 5 }),
+          fc.integer({ min: 0, max: 5 }),
+          async (preCompressCount, postCompressCount) => {
+            const localTempDir = await fs.mkdtemp(
+              path.join(os.tmpdir(), 'prop-compress-'),
+            );
+            const localChatsDir = path.join(localTempDir, 'chats');
+            await fs.mkdir(localChatsDir, { recursive: true });
 
-        try {
-          const sessionId = crypto.randomUUID();
-          const config = makeConfig(localChatsDir, {
-            sessionId,
-            projectHash: PROJECT_HASH,
-          });
-          const svc = new SessionRecordingService(config);
+            try {
+              const sessionId = crypto.randomUUID();
+              const config = makeConfig(localChatsDir, {
+                sessionId,
+                projectHash: PROJECT_HASH,
+              });
+              const svc = new SessionRecordingService(config);
 
-          // Pre-compression content
-          for (let i = 0; i < preCompressCount; i++) {
-            svc.recordContent(makeContent(`pre-${i}`));
-          }
+              // Pre-compression content
+              for (let i = 0; i < preCompressCount; i++) {
+                svc.recordContent(makeContent(`pre-${i}`));
+              }
 
-          // Compression
-          const summary: IContent = {
-            speaker: 'ai',
-            blocks: [{ type: 'text', text: 'Summary' }],
-            metadata: { isSummary: true },
-          };
-          svc.recordCompressed(summary, preCompressCount);
+              // Compression
+              const summary: IContent = {
+                speaker: 'ai',
+                blocks: [{ type: 'text', text: 'Summary' }],
+                metadata: { isSummary: true },
+              };
+              svc.recordCompressed(summary, preCompressCount);
 
-          // Post-compression content
-          for (let i = 0; i < postCompressCount; i++) {
-            svc.recordContent(makeContent(`post-${i}`));
-          }
+              // Post-compression content
+              for (let i = 0; i < postCompressCount; i++) {
+                svc.recordContent(makeContent(`post-${i}`));
+              }
 
-          await svc.flush();
-          await svc.dispose();
+              await svc.flush();
+              await svc.dispose();
 
-          const result = await resumeSession(makeResumeRequest(localChatsDir));
+              const result = await resumeSession(
+                makeResumeRequest(localChatsDir),
+              );
 
-          expect(result.ok).toBe(true);
-          if (result.ok) {
-            // history = 1 (summary) + postCompressCount
-            expect(result.history).toHaveLength(1 + postCompressCount);
-            await result.recording.dispose();
-            await result.lockHandle.release();
-          }
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+              const okResult = expectOk(result);
+              // history = 1 (summary) + postCompressCount
+              expect(okResult.history).toHaveLength(1 + postCompressCount);
+              await okResult.recording.dispose();
+              await okResult.lockHandle.release();
+            } finally {
+              await fs.rm(localTempDir, { recursive: true, force: true });
+            }
+          },
+        ),
+      ));
 
     /**
      * Extra property: Resume succeeds for any number of content items
@@ -1045,40 +1031,43 @@ describe('resumeSession @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P19
      * @requirement REQ-RSM-004
      */
-    itProp.prop([fc.integer({ min: 1, max: 10 })])(
-      'resume succeeds for any N content items @requirement:REQ-RSM-004',
-      async (contentCount) => {
-        const localTempDir = await fs.mkdtemp(
-          path.join(os.tmpdir(), 'prop-any-count-'),
-        );
-        const localChatsDir = path.join(localTempDir, 'chats');
-        await fs.mkdir(localChatsDir, { recursive: true });
-
-        try {
-          const contents: IContent[] = [];
-          for (let i = 0; i < contentCount; i++) {
-            contents.push(
-              makeContent(`msg-${i}`, i % 2 === 0 ? 'human' : 'ai'),
+    it('resume succeeds for any N content items @requirement:REQ-RSM-004', async () =>
+      fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 10 }),
+          async (contentCount) => {
+            const localTempDir = await fs.mkdtemp(
+              path.join(os.tmpdir(), 'prop-any-count-'),
             );
-          }
+            const localChatsDir = path.join(localTempDir, 'chats');
+            await fs.mkdir(localChatsDir, { recursive: true });
 
-          await createTestSession(localChatsDir, {
-            projectHash: PROJECT_HASH,
-            contents,
-          });
+            try {
+              const contents: IContent[] = [];
+              for (let i = 0; i < contentCount; i++) {
+                contents.push(
+                  makeContent(`msg-${i}`, i % 2 === 0 ? 'human' : 'ai'),
+                );
+              }
 
-          const result = await resumeSession(makeResumeRequest(localChatsDir));
+              await createTestSession(localChatsDir, {
+                projectHash: PROJECT_HASH,
+                contents,
+              });
 
-          expect(result.ok).toBe(true);
-          if (result.ok) {
-            expect(result.history).toHaveLength(contentCount);
-            await result.recording.dispose();
-            await result.lockHandle.release();
-          }
-        } finally {
-          await fs.rm(localTempDir, { recursive: true, force: true });
-        }
-      },
-    );
+              const result = await resumeSession(
+                makeResumeRequest(localChatsDir),
+              );
+
+              const okResult = expectOk(result);
+              expect(okResult.history).toHaveLength(contentCount);
+              await okResult.recording.dispose();
+              await okResult.lockHandle.release();
+            } finally {
+              await fs.rm(localTempDir, { recursive: true, force: true });
+            }
+          },
+        ),
+      ));
   });
 });

--- a/packages/core/src/recording/sessionCleanupUtils.test.ts
+++ b/packages/core/src/recording/sessionCleanupUtils.test.ts
@@ -22,13 +22,12 @@
  * .jsonl session files. Tests verify actual file system state using real
  * temp directories — no mock theater.
  *
- * Property-based tests use @fast-check/vitest (≥30% of total tests).
+ * Property-based tests use fast-check (≥30% of total tests).
  * All tests expect real behavior from the cleanup utilities. They will fail
  * against the Phase 15 stubs — that is correct TDD.
  */
 
-import { describe, expect, beforeEach, afterEach } from 'vitest';
-import { it as itProp } from '@fast-check/vitest';
+import { describe, expect, beforeEach, afterEach, it } from 'vitest';
 import * as fc from 'fast-check';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -159,7 +158,7 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-001
      */
-    itProp('finds .jsonl session files in the chats directory', async () => {
+    it('finds .jsonl session files in the chats directory', async () => {
       const file1 = writeSessionFile(
         chatsDir,
         'aaa11111-0000-0000-0000-000000000001',
@@ -187,7 +186,7 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-001
      */
-    itProp('skips non-session files (.txt, random names)', async () => {
+    it('skips non-session files (.txt, random names)', async () => {
       writeSessionFile(chatsDir, 'session-valid001');
       fs.writeFileSync(path.join(chatsDir, 'notes.txt'), 'some notes');
       fs.writeFileSync(path.join(chatsDir, 'data.jsonl'), '{"not":"session"}');
@@ -204,36 +203,33 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-001
      */
-    itProp(
-      'ignores old .json session files (only targets .jsonl)',
-      async () => {
-        writeSessionFile(chatsDir, 'session-newformat');
-        fs.writeFileSync(
-          path.join(
-            chatsDir,
-            'persisted-session-2025-01-01T00-00-00-old12345.json',
-          ),
-          JSON.stringify({ sessionId: 'old', messages: [] }),
-        );
-        fs.writeFileSync(
-          path.join(chatsDir, 'session-2025-01-01T00-00-00-legacy12.json'),
-          JSON.stringify({ sessionId: 'legacy', messages: [] }),
-        );
+    it('ignores old .json session files (only targets .jsonl)', async () => {
+      writeSessionFile(chatsDir, 'session-newformat');
+      fs.writeFileSync(
+        path.join(
+          chatsDir,
+          'persisted-session-2025-01-01T00-00-00-old12345.json',
+        ),
+        JSON.stringify({ sessionId: 'old', messages: [] }),
+      );
+      fs.writeFileSync(
+        path.join(chatsDir, 'session-2025-01-01T00-00-00-legacy12.json'),
+        JSON.stringify({ sessionId: 'legacy', messages: [] }),
+      );
 
-        const entries = await getAllJsonlSessionFiles(chatsDir);
+      const entries = await getAllJsonlSessionFiles(chatsDir);
 
-        expect(entries).toHaveLength(1);
-        const fileNames = entries.map((e) => e.fileName);
-        expect(fileNames.every((f) => f.endsWith('.jsonl'))).toBe(true);
-      },
-    );
+      expect(entries).toHaveLength(1);
+      const fileNames = entries.map((e) => e.fileName);
+      expect(fileNames.every((f) => f.endsWith('.jsonl'))).toBe(true);
+    });
 
     /**
      * Test 11: Empty chats directory returns empty list
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-001
      */
-    itProp('returns empty list for empty chats directory', async () => {
+    it('returns empty list for empty chats directory', async () => {
       const entries = await getAllJsonlSessionFiles(chatsDir);
       expect(entries).toHaveLength(0);
     });
@@ -243,7 +239,7 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-001
      */
-    itProp('returns empty list for non-existent chats directory', async () => {
+    it('returns empty list for non-existent chats directory', async () => {
       const nonExistent = path.join(tempDir, 'does-not-exist');
       const entries = await getAllJsonlSessionFiles(nonExistent);
       expect(entries).toHaveLength(0);
@@ -254,20 +250,17 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-001
      */
-    itProp(
-      'extracts session info from .jsonl header (session_start event)',
-      async () => {
-        const sessionId = 'abc12345-6789-0000-aaaa-bbbbccccdddd';
-        const startTime = '2025-06-15T10:30:00.000Z';
-        writeSessionFile(chatsDir, sessionId, startTime);
+    it('extracts session info from .jsonl header (session_start event)', async () => {
+      const sessionId = 'abc12345-6789-0000-aaaa-bbbbccccdddd';
+      const startTime = '2025-06-15T10:30:00.000Z';
+      writeSessionFile(chatsDir, sessionId, startTime);
 
-        const entries = await getAllJsonlSessionFiles(chatsDir);
+      const entries = await getAllJsonlSessionFiles(chatsDir);
 
-        expect(entries).toHaveLength(1);
-        expect(entries[0].sessionInfo).not.toBeNull();
-        expect(entries[0].sessionInfo!.id).toBe(sessionId);
-      },
-    );
+      expect(entries).toHaveLength(1);
+      expect(entries[0].sessionInfo).not.toBeNull();
+      expect(entries[0].sessionInfo!.id).toBe(sessionId);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -280,25 +273,22 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-002
      */
-    itProp(
-      'returns skip for a .jsonl with an active lock (current PID)',
-      async () => {
-        const sessionPath = writeSessionFile(chatsDir, 'locked-session');
-        writeLockFile(sessionPath, process.pid);
-        const entry = makeEntry(sessionPath, 'locked-session');
+    it('returns skip for a .jsonl with an active lock (current PID)', async () => {
+      const sessionPath = writeSessionFile(chatsDir, 'locked-session');
+      writeLockFile(sessionPath, process.pid);
+      const entry = makeEntry(sessionPath, 'locked-session');
 
-        const result = await shouldDeleteSession(entry);
+      const result = await shouldDeleteSession(entry);
 
-        expect(result).toBe('skip');
-      },
-    );
+      expect(result).toBe('skip');
+    });
 
     /**
      * Test 5: shouldDeleteSession allows unlocked .jsonl (no .lock file)
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-002
      */
-    itProp('returns delete for a .jsonl with no .lock file', async () => {
+    it('returns delete for a .jsonl with no .lock file', async () => {
       const sessionPath = writeSessionFile(chatsDir, 'unlocked-session');
       const entry = makeEntry(sessionPath, 'unlocked-session');
 
@@ -312,18 +302,15 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-002, REQ-CLN-003
      */
-    itProp(
-      'returns stale-lock-only for a .jsonl with a stale lock (dead PID)',
-      async () => {
-        const sessionPath = writeSessionFile(chatsDir, 'stale-session1');
-        writeLockFile(sessionPath, DEAD_PID);
-        const entry = makeEntry(sessionPath, 'stale-session1');
+    it('returns stale-lock-only for a .jsonl with a stale lock (dead PID)', async () => {
+      const sessionPath = writeSessionFile(chatsDir, 'stale-session1');
+      writeLockFile(sessionPath, DEAD_PID);
+      const entry = makeEntry(sessionPath, 'stale-session1');
 
-        const result = await shouldDeleteSession(entry);
+      const result = await shouldDeleteSession(entry);
 
-        expect(result).toBe('stale-lock-only');
-      },
-    );
+      expect(result).toBe('stale-lock-only');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -336,7 +323,7 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-004
      */
-    itProp('removes orphaned .lock file with no matching .jsonl', async () => {
+    it('removes orphaned .lock file with no matching .jsonl', async () => {
       const orphanedLockPath = path.join(chatsDir, 'orphan.lock');
       fs.writeFileSync(
         orphanedLockPath,
@@ -358,62 +345,53 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-004
      */
-    itProp(
-      'keeps .lock file that has matching .jsonl and live PID',
-      async () => {
-        const sessionPath = writeSessionFile(chatsDir, 'active-sess1');
-        const lockPath = writeLockFile(sessionPath, process.pid);
+    it('keeps .lock file that has matching .jsonl and live PID', async () => {
+      const sessionPath = writeSessionFile(chatsDir, 'active-sess1');
+      const lockPath = writeLockFile(sessionPath, process.pid);
 
-        await cleanupStaleLocks(chatsDir);
+      await cleanupStaleLocks(chatsDir);
 
-        expect(fs.existsSync(lockPath)).toBe(true);
-        expect(fs.existsSync(sessionPath)).toBe(true);
-      },
-    );
+      expect(fs.existsSync(lockPath)).toBe(true);
+      expect(fs.existsSync(sessionPath)).toBe(true);
+    });
 
-    itProp(
-      'keeps a live full-ID lock before its recording materializes',
-      async () => {
-        const lockPath = path.join(chatsDir, 'new-active-session.lock');
-        fs.writeFileSync(
-          lockPath,
-          JSON.stringify({
-            pid: process.pid,
-            timestamp: new Date().toISOString(),
-            sessionId: 'new-active-session',
-          }),
-        );
+    it('keeps a live full-ID lock before its recording materializes', async () => {
+      const lockPath = path.join(chatsDir, 'new-active-session.lock');
+      fs.writeFileSync(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          timestamp: new Date().toISOString(),
+          sessionId: 'new-active-session',
+        }),
+      );
 
-        const count = await cleanupStaleLocks(chatsDir);
+      const count = await cleanupStaleLocks(chatsDir);
 
-        expect(count).toBe(0);
-        expect(fs.existsSync(lockPath)).toBe(true);
-      },
-    );
+      expect(count).toBe(0);
+      expect(fs.existsSync(lockPath)).toBe(true);
+    });
     /**
      * Test 9: cleanupStaleLocks removes stale .lock (dead PID) but preserves .jsonl
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-004
      */
-    itProp(
-      'removes stale .lock (dead PID) but preserves the .jsonl file',
-      async () => {
-        const sessionPath = writeSessionFile(chatsDir, 'stale-lock01');
-        const lockPath = writeLockFile(sessionPath, DEAD_PID);
+    it('removes stale .lock (dead PID) but preserves the .jsonl file', async () => {
+      const sessionPath = writeSessionFile(chatsDir, 'stale-lock01');
+      const lockPath = writeLockFile(sessionPath, DEAD_PID);
 
-        await cleanupStaleLocks(chatsDir);
+      await cleanupStaleLocks(chatsDir);
 
-        expect(fs.existsSync(lockPath)).toBe(false);
-        expect(fs.existsSync(sessionPath)).toBe(true);
-      },
-    );
+      expect(fs.existsSync(lockPath)).toBe(false);
+      expect(fs.existsSync(sessionPath)).toBe(true);
+    });
 
     /**
      * Test 10: cleanupStaleLocks returns count
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-004
      */
-    itProp('returns the count of lock files cleaned up', async () => {
+    it('returns the count of lock files cleaned up', async () => {
       // Create 3 orphaned locks
       for (let i = 0; i < 3; i++) {
         const orphanLock = path.join(chatsDir, `orphan${i}.lock`);
@@ -443,31 +421,28 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-003
      */
-    itProp(
-      'stale lock with recent session: shouldDeleteSession returns stale-lock-only (not delete)',
-      async () => {
-        const recentTime = new Date(
-          Date.now() - 1 * 60 * 60 * 1000,
-        ).toISOString(); // 1 hour ago
-        const sessionPath = writeSessionFile(
-          chatsDir,
-          'recent-stale1',
-          recentTime,
-        );
-        writeLockFile(sessionPath, DEAD_PID);
-        const entry = makeEntry(sessionPath, 'recent-stale1');
+    it('stale lock with recent session: shouldDeleteSession returns stale-lock-only (not delete)', async () => {
+      const recentTime = new Date(
+        Date.now() - 1 * 60 * 60 * 1000,
+      ).toISOString(); // 1 hour ago
+      const sessionPath = writeSessionFile(
+        chatsDir,
+        'recent-stale1',
+        recentTime,
+      );
+      writeLockFile(sessionPath, DEAD_PID);
+      const entry = makeEntry(sessionPath, 'recent-stale1');
 
-        const result = await shouldDeleteSession(entry);
+      const result = await shouldDeleteSession(entry);
 
-        // Stale lock should result in 'stale-lock-only' — the data file
-        // is NOT deleted just because the lock is stale. Retention policy
-        // (not exercised here) decides deletion of the data file.
-        expect(result).toBe('stale-lock-only');
+      // Stale lock should result in 'stale-lock-only' — the data file
+      // is NOT deleted just because the lock is stale. Retention policy
+      // (not exercised here) decides deletion of the data file.
+      expect(result).toBe('stale-lock-only');
 
-        // The .jsonl file must still exist on disk
-        expect(fs.existsSync(sessionPath)).toBe(true);
-      },
-    );
+      // The .jsonl file must still exist on disk
+      expect(fs.existsSync(sessionPath)).toBe(true);
+    });
 
     /**
      * Test 24: Stale lock with OLD session → lock removed, session deleted by retention (not stale status)
@@ -479,28 +454,21 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * policy layer, not shouldDeleteSession. shouldDeleteSession only evaluates
      * lock status.
      */
-    itProp(
-      'stale lock with old session: shouldDeleteSession still returns stale-lock-only',
-      async () => {
-        const oldTime = new Date(
-          Date.now() - 30 * 24 * 60 * 60 * 1000,
-        ).toISOString(); // 30 days ago
-        const sessionPath = writeSessionFile(
-          chatsDir,
-          'old-stale-001',
-          oldTime,
-        );
-        writeLockFile(sessionPath, DEAD_PID);
-        const entry = makeEntry(sessionPath, 'old-stale-001');
+    it('stale lock with old session: shouldDeleteSession still returns stale-lock-only', async () => {
+      const oldTime = new Date(
+        Date.now() - 30 * 24 * 60 * 60 * 1000,
+      ).toISOString(); // 30 days ago
+      const sessionPath = writeSessionFile(chatsDir, 'old-stale-001', oldTime);
+      writeLockFile(sessionPath, DEAD_PID);
+      const entry = makeEntry(sessionPath, 'old-stale-001');
 
-        const result = await shouldDeleteSession(entry);
+      const result = await shouldDeleteSession(entry);
 
-        // shouldDeleteSession only evaluates lock status, not age.
-        // 'stale-lock-only' means: remove the lock, let retention policy
-        // independently decide whether to delete the data file.
-        expect(result).toBe('stale-lock-only');
-      },
-    );
+      // shouldDeleteSession only evaluates lock status, not age.
+      // 'stale-lock-only' means: remove the lock, let retention policy
+      // independently decide whether to delete the data file.
+      expect(result).toBe('stale-lock-only');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -513,315 +481,337 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-001
      */
-    itProp.prop([fc.nat({ max: 8 })], { numRuns: 15 })(
-      'all N .jsonl session files are discovered for any N @requirement:REQ-CLN-001',
-      async (count) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-discover-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('all N .jsonl session files are discovered for any N @requirement:REQ-CLN-001', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.nat({ max: 8 }), async (count) => {
+          const localTemp = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'prop-discover-'),
+          );
+          const localChats = path.join(localTemp, 'chats');
+          fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          const created: string[] = [];
-          for (let i = 0; i < count; i++) {
-            const id = `prop-sess-${i.toString().padStart(4, '0')}-${Date.now()}`;
-            const ts = new Date(Date.now() - i * 1000).toISOString();
-            const filePath = writeSessionFile(localChats, id, ts);
-            created.push(path.basename(filePath));
+          try {
+            const created: string[] = [];
+            for (let i = 0; i < count; i++) {
+              const id = `prop-sess-${i.toString().padStart(4, '0')}-${Date.now()}`;
+              const ts = new Date(Date.now() - i * 1000).toISOString();
+              const filePath = writeSessionFile(localChats, id, ts);
+              created.push(path.basename(filePath));
+            }
+
+            const entries = await getAllJsonlSessionFiles(localChats);
+
+            expect(entries).toHaveLength(count);
+            const foundNames = entries.map((e) => e.fileName);
+            for (const name of created) {
+              expect(foundNames).toContain(name);
+            }
+          } finally {
+            fs.rmSync(localTemp, { recursive: true, force: true });
           }
-
-          const entries = await getAllJsonlSessionFiles(localChats);
-
-          expect(entries).toHaveLength(count);
-          const foundNames = entries.map((e) => e.fileName);
-          for (const name of created) {
-            expect(foundNames).toContain(name);
-          }
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+        }),
+        { numRuns: 15 },
+      );
+    });
 
     /**
      * Test 15: Orphaned lock cleanup is safe for any file count
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-004
      */
-    itProp.prop([fc.nat({ max: 5 }), fc.nat({ max: 5 })], { numRuns: 15 })(
-      'orphaned lock cleanup is safe: only orphans removed for any counts @requirement:REQ-CLN-004',
-      async (orphanCount, pairedCount) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-orphan-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
-
-        try {
-          const orphanLockPaths: string[] = [];
-          const pairedLockPaths: string[] = [];
-          const pairedSessionPaths: string[] = [];
-
-          // Create orphaned locks (no matching .jsonl)
-          for (let i = 0; i < orphanCount; i++) {
-            const lockPath = path.join(
-              localChats,
-              `orphan-${i}-${Date.now()}.lock`,
+    it('orphaned lock cleanup is safe: only orphans removed for any counts @requirement:REQ-CLN-004', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.nat({ max: 5 }),
+          fc.nat({ max: 5 }),
+          async (orphanCount, pairedCount) => {
+            const localTemp = fs.mkdtempSync(
+              path.join(os.tmpdir(), 'prop-orphan-'),
             );
-            fs.writeFileSync(
-              lockPath,
-              JSON.stringify({
-                pid: DEAD_PID,
-                timestamp: new Date().toISOString(),
-                sessionId: `orphan-${i}`,
-              }),
-            );
-            orphanLockPaths.push(lockPath);
-          }
+            const localChats = path.join(localTemp, 'chats');
+            fs.mkdirSync(localChats, { recursive: true });
 
-          // Create paired session+lock (live PID — should be preserved)
-          for (let i = 0; i < pairedCount; i++) {
-            const id = `paired-${i}-${Date.now()}`;
-            const ts = new Date(Date.now() - i * 1000).toISOString();
-            const sessionPath = writeSessionFile(localChats, id, ts);
-            const lockPath = writeLockFile(sessionPath, process.pid);
-            pairedLockPaths.push(lockPath);
-            pairedSessionPaths.push(sessionPath);
-          }
+            try {
+              const orphanLockPaths: string[] = [];
+              const pairedLockPaths: string[] = [];
+              const pairedSessionPaths: string[] = [];
 
-          await cleanupStaleLocks(localChats);
+              // Create orphaned locks (no matching .jsonl)
+              for (let i = 0; i < orphanCount; i++) {
+                const lockPath = path.join(
+                  localChats,
+                  `orphan-${i}-${Date.now()}.lock`,
+                );
+                fs.writeFileSync(
+                  lockPath,
+                  JSON.stringify({
+                    pid: DEAD_PID,
+                    timestamp: new Date().toISOString(),
+                    sessionId: `orphan-${i}`,
+                  }),
+                );
+                orphanLockPaths.push(lockPath);
+              }
 
-          // All orphaned locks should be removed
-          for (const lockPath of orphanLockPaths) {
-            expect(fs.existsSync(lockPath)).toBe(false);
-          }
+              // Create paired session+lock (live PID — should be preserved)
+              for (let i = 0; i < pairedCount; i++) {
+                const id = `paired-${i}-${Date.now()}`;
+                const ts = new Date(Date.now() - i * 1000).toISOString();
+                const sessionPath = writeSessionFile(localChats, id, ts);
+                const lockPath = writeLockFile(sessionPath, process.pid);
+                pairedLockPaths.push(lockPath);
+                pairedSessionPaths.push(sessionPath);
+              }
 
-          // All paired locks (live PID) should remain
-          for (const lockPath of pairedLockPaths) {
-            expect(fs.existsSync(lockPath)).toBe(true);
-          }
+              await cleanupStaleLocks(localChats);
 
-          // All paired session files should remain
-          for (const sessionPath of pairedSessionPaths) {
-            expect(fs.existsSync(sessionPath)).toBe(true);
-          }
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+              // All orphaned locks should be removed
+              for (const lockPath of orphanLockPaths) {
+                expect(fs.existsSync(lockPath)).toBe(false);
+              }
+
+              // All paired locks (live PID) should remain
+              for (const lockPath of pairedLockPaths) {
+                expect(fs.existsSync(lockPath)).toBe(true);
+              }
+
+              // All paired session files should remain
+              for (const sessionPath of pairedSessionPaths) {
+                expect(fs.existsSync(sessionPath)).toBe(true);
+              }
+            } finally {
+              fs.rmSync(localTemp, { recursive: true, force: true });
+            }
+          },
+        ),
+        { numRuns: 15 },
+      );
+    });
 
     /**
      * Test 16: Lock-aware protection never deletes active sessions
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-002
      */
-    itProp.prop([fc.nat({ max: 6 })], { numRuns: 15 })(
-      'shouldDeleteSession never returns delete for active-locked sessions @requirement:REQ-CLN-002',
-      async (count) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-active-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('shouldDeleteSession never returns delete for active-locked sessions @requirement:REQ-CLN-002', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.nat({ max: 6 }), async (count) => {
+          const localTemp = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'prop-active-'),
+          );
+          const localChats = path.join(localTemp, 'chats');
+          fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          for (let i = 0; i < count; i++) {
-            const id = `active-${i}-${Date.now()}`;
-            const ts = new Date(Date.now() - i * 1000).toISOString();
-            const sessionPath = writeSessionFile(localChats, id, ts);
-            writeLockFile(sessionPath, process.pid);
-            const entry = makeEntry(sessionPath, id);
+          try {
+            for (let i = 0; i < count; i++) {
+              const id = `active-${i}-${Date.now()}`;
+              const ts = new Date(Date.now() - i * 1000).toISOString();
+              const sessionPath = writeSessionFile(localChats, id, ts);
+              writeLockFile(sessionPath, process.pid);
+              const entry = makeEntry(sessionPath, id);
 
-            const result = await shouldDeleteSession(entry);
+              const result = await shouldDeleteSession(entry);
 
-            // Active sessions (current PID lock) must NEVER return 'delete'
-            expect(result).toBe('skip');
+              // Active sessions (current PID lock) must NEVER return 'delete'
+              expect(result).toBe('skip');
+            }
+          } finally {
+            fs.rmSync(localTemp, { recursive: true, force: true });
           }
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+        }),
+        { numRuns: 15 },
+      );
+    });
 
     /**
      * Test 17: Stale lock detection is consistent with PID liveness
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-002, REQ-CLN-003
      */
-    itProp.prop([fc.boolean()], { numRuns: 20 })(
-      'shouldDeleteSession result is consistent with PID liveness @requirement:REQ-CLN-002',
-      async (useAlivePid) => {
-        const localTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'prop-pid-'));
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('shouldDeleteSession result is consistent with PID liveness @requirement:REQ-CLN-002', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.boolean(), async (useAlivePid) => {
+          const localTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'prop-pid-'));
+          const localChats = path.join(localTemp, 'chats');
+          fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          const id = `pid-test-${Date.now()}`;
-          const sessionPath = writeSessionFile(localChats, id);
-          const pid = useAlivePid ? process.pid : DEAD_PID;
-          writeLockFile(sessionPath, pid);
-          const entry = makeEntry(sessionPath, id);
+          try {
+            const id = `pid-test-${Date.now()}`;
+            const sessionPath = writeSessionFile(localChats, id);
+            const pid = useAlivePid ? process.pid : DEAD_PID;
+            writeLockFile(sessionPath, pid);
+            const entry = makeEntry(sessionPath, id);
 
-          const result = await shouldDeleteSession(entry);
+            const result = await shouldDeleteSession(entry);
 
-          if (useAlivePid) {
-            expect(result).toBe('skip');
-          } else {
-            expect(result).toBe('stale-lock-only');
+            const expected = useAlivePid ? 'skip' : 'stale-lock-only';
+            expect(result).toBe(expected);
+          } finally {
+            fs.rmSync(localTemp, { recursive: true, force: true });
           }
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+        }),
+        { numRuns: 20 },
+      );
+    });
 
     /**
      * Test 18: Non-session files are never included regardless of count
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-001
      */
-    itProp.prop([fc.nat({ max: 8 })], { numRuns: 15 })(
-      'non-session files are never included in scan results @requirement:REQ-CLN-001',
-      async (count) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-nonsess-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('non-session files are never included in scan results @requirement:REQ-CLN-001', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.nat({ max: 8 }), async (count) => {
+          const localTemp = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'prop-nonsess-'),
+          );
+          const localChats = path.join(localTemp, 'chats');
+          fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          // Create random non-session files
-          const nonSessionNames = [
-            'notes.txt',
-            'config.json',
-            'data.csv',
-            'readme.md',
-            'log.jsonl',
-            'backup.jsonl',
-            'temp.lock',
-            'index.html',
-          ];
-          for (let i = 0; i < count && i < nonSessionNames.length; i++) {
-            fs.writeFileSync(
-              path.join(localChats, nonSessionNames[i]),
-              'content',
-            );
+          try {
+            // Create random non-session files
+            const nonSessionNames = [
+              'notes.txt',
+              'config.json',
+              'data.csv',
+              'readme.md',
+              'log.jsonl',
+              'backup.jsonl',
+              'temp.lock',
+              'index.html',
+            ];
+            for (let i = 0; i < count && i < nonSessionNames.length; i++) {
+              fs.writeFileSync(
+                path.join(localChats, nonSessionNames[i]),
+                'content',
+              );
+            }
+
+            const entries = await getAllJsonlSessionFiles(localChats);
+
+            // No non-session files should appear
+            expect(entries).toHaveLength(0);
+          } finally {
+            fs.rmSync(localTemp, { recursive: true, force: true });
           }
-
-          const entries = await getAllJsonlSessionFiles(localChats);
-
-          // No non-session files should appear
-          expect(entries).toHaveLength(0);
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+        }),
+        { numRuns: 15 },
+      );
+    });
 
     /**
      * Test 19: Cleanup returns correct count for any combination
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-004
      */
-    itProp.prop([fc.nat({ max: 4 }), fc.nat({ max: 4 }), fc.nat({ max: 4 })], {
-      numRuns: 10,
-    })(
-      'cleanupStaleLocks returns correct count for any combo of orphan/stale/active @requirement:REQ-CLN-004',
-      async (orphanCount, staleCount, activeCount) => {
-        const localTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'prop-count-'));
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
-
-        try {
-          // Orphaned locks (no .jsonl) — should be cleaned
-          for (let i = 0; i < orphanCount; i++) {
-            const lockPath = path.join(
-              localChats,
-              `orph-${i}-${Date.now()}.lock`,
+    it('cleanupStaleLocks returns correct count for any combo of orphan/stale/active @requirement:REQ-CLN-004', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.nat({ max: 4 }),
+          fc.nat({ max: 4 }),
+          fc.nat({ max: 4 }),
+          async (orphanCount, staleCount, activeCount) => {
+            const localTemp = fs.mkdtempSync(
+              path.join(os.tmpdir(), 'prop-count-'),
             );
-            fs.writeFileSync(
-              lockPath,
-              JSON.stringify({
-                pid: DEAD_PID,
-                timestamp: new Date().toISOString(),
-                sessionId: `orph-${i}`,
-              }),
-            );
-          }
+            const localChats = path.join(localTemp, 'chats');
+            fs.mkdirSync(localChats, { recursive: true });
 
-          // Stale locks (dead PID with .jsonl) — should be cleaned
-          for (let i = 0; i < staleCount; i++) {
-            const id = `stale-${i}-${Date.now()}`;
-            const ts = new Date(Date.now() - i * 1000).toISOString();
-            const sessionPath = writeSessionFile(localChats, id, ts);
-            writeLockFile(sessionPath, DEAD_PID);
-          }
+            try {
+              // Orphaned locks (no .jsonl) — should be cleaned
+              for (let i = 0; i < orphanCount; i++) {
+                const lockPath = path.join(
+                  localChats,
+                  `orph-${i}-${Date.now()}.lock`,
+                );
+                fs.writeFileSync(
+                  lockPath,
+                  JSON.stringify({
+                    pid: DEAD_PID,
+                    timestamp: new Date().toISOString(),
+                    sessionId: `orph-${i}`,
+                  }),
+                );
+              }
 
-          // Active locks (live PID with .jsonl) — should NOT be cleaned
-          for (let i = 0; i < activeCount; i++) {
-            const id = `active-${i}-${Date.now()}`;
-            const ts = new Date(Date.now() - i * 1000).toISOString();
-            const sessionPath = writeSessionFile(localChats, id, ts);
-            writeLockFile(sessionPath, process.pid);
-          }
+              // Stale locks (dead PID with .jsonl) — should be cleaned
+              for (let i = 0; i < staleCount; i++) {
+                const id = `stale-${i}-${Date.now()}`;
+                const ts = new Date(Date.now() - i * 1000).toISOString();
+                const sessionPath = writeSessionFile(localChats, id, ts);
+                writeLockFile(sessionPath, DEAD_PID);
+              }
 
-          const count = await cleanupStaleLocks(localChats);
+              // Active locks (live PID with .jsonl) — should NOT be cleaned
+              for (let i = 0; i < activeCount; i++) {
+                const id = `active-${i}-${Date.now()}`;
+                const ts = new Date(Date.now() - i * 1000).toISOString();
+                const sessionPath = writeSessionFile(localChats, id, ts);
+                writeLockFile(sessionPath, process.pid);
+              }
 
-          // Orphaned + stale should be cleaned; active should remain
-          expect(count).toBe(orphanCount + staleCount);
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+              const count = await cleanupStaleLocks(localChats);
+
+              // Orphaned + stale should be cleaned; active should remain
+              expect(count).toBe(orphanCount + staleCount);
+            } finally {
+              fs.rmSync(localTemp, { recursive: true, force: true });
+            }
+          },
+        ),
+        {
+          numRuns: 10,
+        },
+      );
+    });
 
     /**
      * Test 20: Stale lock with recent session → lock removed, session preserved (property)
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-003
      */
-    itProp.prop([fc.nat({ max: 5 })], { numRuns: 10 })(
-      'stale lock on recent sessions: lock removed, session preserved @requirement:REQ-CLN-003',
-      async (count) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-stalerecent-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('stale lock on recent sessions: lock removed, session preserved @requirement:REQ-CLN-003', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.nat({ max: 5 }), async (count) => {
+          const localTemp = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'prop-stalerecent-'),
+          );
+          const localChats = path.join(localTemp, 'chats');
+          fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          const sessionPaths: string[] = [];
-          const lockPaths: string[] = [];
+          try {
+            const sessionPaths: string[] = [];
+            const lockPaths: string[] = [];
 
-          for (let i = 0; i < count; i++) {
-            const id = `recent-stale-${i}-${Date.now()}`;
-            const recentTime = new Date(
-              Date.now() - (i + 1) * 60 * 60 * 1000,
-            ).toISOString(); // hours ago
-            const sessionPath = writeSessionFile(localChats, id, recentTime);
-            const lockPath = writeLockFile(sessionPath, DEAD_PID);
-            sessionPaths.push(sessionPath);
-            lockPaths.push(lockPath);
+            for (let i = 0; i < count; i++) {
+              const id = `recent-stale-${i}-${Date.now()}`;
+              const recentTime = new Date(
+                Date.now() - (i + 1) * 60 * 60 * 1000,
+              ).toISOString(); // hours ago
+              const sessionPath = writeSessionFile(localChats, id, recentTime);
+              const lockPath = writeLockFile(sessionPath, DEAD_PID);
+              sessionPaths.push(sessionPath);
+              lockPaths.push(lockPath);
+            }
+
+            await cleanupStaleLocks(localChats);
+
+            // All stale locks should be removed
+            for (const lockPath of lockPaths) {
+              expect(fs.existsSync(lockPath)).toBe(false);
+            }
+
+            // All session files should be preserved (recent, within retention)
+            for (const sessionPath of sessionPaths) {
+              expect(fs.existsSync(sessionPath)).toBe(true);
+            }
+          } finally {
+            fs.rmSync(localTemp, { recursive: true, force: true });
           }
-
-          await cleanupStaleLocks(localChats);
-
-          // All stale locks should be removed
-          for (const lockPath of lockPaths) {
-            expect(fs.existsSync(lockPath)).toBe(false);
-          }
-
-          // All session files should be preserved (recent, within retention)
-          for (const sessionPath of sessionPaths) {
-            expect(fs.existsSync(sessionPath)).toBe(true);
-          }
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+        }),
+        { numRuns: 10 },
+      );
+    });
 
     /**
      * Test 21: Stale lock with old session → both removed (property: retention handles data, cleanup handles lock)
@@ -833,209 +823,229 @@ describe('sessionCleanupUtils @plan:PLAN-20260211-SESSIONRECORDING.P16', () => {
      * for the retention policy to handle (cleanupStaleLocks does NOT delete
      * session files).
      */
-    itProp.prop([fc.nat({ max: 5 })], { numRuns: 10 })(
-      'stale lock cleanup removes locks but never deletes session files @requirement:REQ-CLN-003',
-      async (count) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-staleold-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('stale lock cleanup removes locks but never deletes session files @requirement:REQ-CLN-003', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.nat({ max: 5 }), async (count) => {
+          const localTemp = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'prop-staleold-'),
+          );
+          const localChats = path.join(localTemp, 'chats');
+          fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          const sessionPaths: string[] = [];
-          const lockPaths: string[] = [];
+          try {
+            const sessionPaths: string[] = [];
+            const lockPaths: string[] = [];
 
-          for (let i = 0; i < count; i++) {
-            const id = `old-stale-${i}-${Date.now()}`;
-            const oldTime = new Date(
-              Date.now() - (30 + i) * 24 * 60 * 60 * 1000,
-            ).toISOString(); // 30+ days ago
-            const sessionPath = writeSessionFile(localChats, id, oldTime);
-            const lockPath = writeLockFile(sessionPath, DEAD_PID);
-            sessionPaths.push(sessionPath);
-            lockPaths.push(lockPath);
+            for (let i = 0; i < count; i++) {
+              const id = `old-stale-${i}-${Date.now()}`;
+              const oldTime = new Date(
+                Date.now() - (30 + i) * 24 * 60 * 60 * 1000,
+              ).toISOString(); // 30+ days ago
+              const sessionPath = writeSessionFile(localChats, id, oldTime);
+              const lockPath = writeLockFile(sessionPath, DEAD_PID);
+              sessionPaths.push(sessionPath);
+              lockPaths.push(lockPath);
+            }
+
+            await cleanupStaleLocks(localChats);
+
+            // All stale locks removed
+            for (const lockPath of lockPaths) {
+              expect(fs.existsSync(lockPath)).toBe(false);
+            }
+
+            // Session files are NOT deleted by cleanupStaleLocks — that's
+            // the retention policy's job
+            for (const sessionPath of sessionPaths) {
+              expect(fs.existsSync(sessionPath)).toBe(true);
+            }
+          } finally {
+            fs.rmSync(localTemp, { recursive: true, force: true });
           }
-
-          await cleanupStaleLocks(localChats);
-
-          // All stale locks removed
-          for (const lockPath of lockPaths) {
-            expect(fs.existsSync(lockPath)).toBe(false);
-          }
-
-          // Session files are NOT deleted by cleanupStaleLocks — that's
-          // the retention policy's job
-          for (const sessionPath of sessionPaths) {
-            expect(fs.existsSync(sessionPath)).toBe(true);
-          }
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+        }),
+        { numRuns: 10 },
+      );
+    });
 
     /**
      * Test 22: Stale lock status never causes deletion within retention window (property)
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-003
      */
-    itProp.prop([fc.nat({ max: 3 }), fc.nat({ max: 3 })], { numRuns: 10 })(
-      'stale lock status never causes deletion of sessions within retention window @requirement:REQ-CLN-003',
-      async (staleWithinRetention, staleOutsideRetention) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-retention-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('stale lock status never causes deletion of sessions within retention window @requirement:REQ-CLN-003', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.nat({ max: 3 }),
+          fc.nat({ max: 3 }),
+          async (staleWithinRetention, staleOutsideRetention) => {
+            const localTemp = fs.mkdtempSync(
+              path.join(os.tmpdir(), 'prop-retention-'),
+            );
+            const localChats = path.join(localTemp, 'chats');
+            fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          const withinRetentionPaths: string[] = [];
-          const outsideRetentionPaths: string[] = [];
+            try {
+              const withinRetentionPaths: string[] = [];
+              const outsideRetentionPaths: string[] = [];
 
-          // Create N files within retention (e.g. < 7 days) with stale locks
-          for (let i = 0; i < staleWithinRetention; i++) {
-            const id = `within-${i}-${Date.now()}`;
-            const recentTime = new Date(
-              Date.now() - (i + 1) * 60 * 60 * 1000,
-            ).toISOString(); // hours ago
-            const sessionPath = writeSessionFile(localChats, id, recentTime);
-            writeLockFile(sessionPath, DEAD_PID);
-            withinRetentionPaths.push(sessionPath);
-          }
+              // Create N files within retention (e.g. < 7 days) with stale locks
+              for (let i = 0; i < staleWithinRetention; i++) {
+                const id = `within-${i}-${Date.now()}`;
+                const recentTime = new Date(
+                  Date.now() - (i + 1) * 60 * 60 * 1000,
+                ).toISOString(); // hours ago
+                const sessionPath = writeSessionFile(
+                  localChats,
+                  id,
+                  recentTime,
+                );
+                writeLockFile(sessionPath, DEAD_PID);
+                withinRetentionPaths.push(sessionPath);
+              }
 
-          // Create M files outside retention (e.g. > 30 days) with stale locks
-          for (let i = 0; i < staleOutsideRetention; i++) {
-            const id = `outside-${i}-${Date.now()}`;
-            const oldTime = new Date(
-              Date.now() - (31 + i) * 24 * 60 * 60 * 1000,
-            ).toISOString();
-            const sessionPath = writeSessionFile(localChats, id, oldTime);
-            writeLockFile(sessionPath, DEAD_PID);
-            outsideRetentionPaths.push(sessionPath);
-          }
+              // Create M files outside retention (e.g. > 30 days) with stale locks
+              for (let i = 0; i < staleOutsideRetention; i++) {
+                const id = `outside-${i}-${Date.now()}`;
+                const oldTime = new Date(
+                  Date.now() - (31 + i) * 24 * 60 * 60 * 1000,
+                ).toISOString();
+                const sessionPath = writeSessionFile(localChats, id, oldTime);
+                writeLockFile(sessionPath, DEAD_PID);
+                outsideRetentionPaths.push(sessionPath);
+              }
 
-          // shouldDeleteSession should return 'stale-lock-only' for ALL of these
-          // because lock staleness alone does NOT justify data file deletion.
-          for (const sessionPath of [
-            ...withinRetentionPaths,
-            ...outsideRetentionPaths,
-          ]) {
-            const header = JSON.parse(
-              fs.readFileSync(sessionPath, 'utf-8').split('\n')[0],
-            ) as { payload: { sessionId: string } };
-            const entry = makeEntry(sessionPath, header.payload.sessionId);
-            const result = await shouldDeleteSession(entry);
-            // stale-lock-only — not 'delete'. The retention policy decides deletion.
-            expect(result).toBe('stale-lock-only');
-          }
+              // shouldDeleteSession should return 'stale-lock-only' for ALL of these
+              // because lock staleness alone does NOT justify data file deletion.
+              for (const sessionPath of [
+                ...withinRetentionPaths,
+                ...outsideRetentionPaths,
+              ]) {
+                const header = JSON.parse(
+                  fs.readFileSync(sessionPath, 'utf-8').split('\n')[0],
+                ) as { payload: { sessionId: string } };
+                const entry = makeEntry(sessionPath, header.payload.sessionId);
+                const result = await shouldDeleteSession(entry);
+                // stale-lock-only — not 'delete'. The retention policy decides deletion.
+                expect(result).toBe('stale-lock-only');
+              }
 
-          // All session files must still exist — shouldDeleteSession doesn't delete
-          for (const sessionPath of withinRetentionPaths) {
-            expect(fs.existsSync(sessionPath)).toBe(true);
-          }
-          for (const sessionPath of outsideRetentionPaths) {
-            expect(fs.existsSync(sessionPath)).toBe(true);
-          }
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+              // All session files must still exist — shouldDeleteSession doesn't delete
+              for (const sessionPath of withinRetentionPaths) {
+                expect(fs.existsSync(sessionPath)).toBe(true);
+              }
+              for (const sessionPath of outsideRetentionPaths) {
+                expect(fs.existsSync(sessionPath)).toBe(true);
+              }
+            } finally {
+              fs.rmSync(localTemp, { recursive: true, force: true });
+            }
+          },
+        ),
+        { numRuns: 10 },
+      );
+    });
 
     /**
      * Test 23 (property): getAllJsonlSessionFiles returns entries with valid structure
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-001
      */
-    itProp.prop([fc.nat({ max: 5 })], { numRuns: 10 })(
-      'getAllJsonlSessionFiles always returns entries with correct structure @requirement:REQ-CLN-001',
-      async (count) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-struct-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('getAllJsonlSessionFiles always returns entries with correct structure @requirement:REQ-CLN-001', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.nat({ max: 5 }), async (count) => {
+          const localTemp = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'prop-struct-'),
+          );
+          const localChats = path.join(localTemp, 'chats');
+          fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          for (let i = 0; i < count; i++) {
-            const id = `struct-${i}-${Date.now()}`;
-            const ts = new Date(Date.now() - i * 1000).toISOString();
-            writeSessionFile(localChats, id, ts);
+          try {
+            for (let i = 0; i < count; i++) {
+              const id = `struct-${i}-${Date.now()}`;
+              const ts = new Date(Date.now() - i * 1000).toISOString();
+              writeSessionFile(localChats, id, ts);
+            }
+
+            const entries = await getAllJsonlSessionFiles(localChats);
+
+            expect(entries).toHaveLength(count);
+            for (const entry of entries) {
+              expect(entry.fileName).toMatch(/^session-.*\.jsonl$/);
+              expect(entry.filePath).toBe(
+                path.join(localChats, entry.fileName),
+              );
+              expect(entry.stat.size).toBeGreaterThan(0);
+              expect(entry.stat.mtime).toBeInstanceOf(Date);
+            }
+          } finally {
+            fs.rmSync(localTemp, { recursive: true, force: true });
           }
-
-          const entries = await getAllJsonlSessionFiles(localChats);
-
-          expect(entries).toHaveLength(count);
-          for (const entry of entries) {
-            expect(entry.fileName).toMatch(/^session-.*\.jsonl$/);
-            expect(entry.filePath).toBe(path.join(localChats, entry.fileName));
-            expect(entry.stat.size).toBeGreaterThan(0);
-            expect(entry.stat.mtime).toBeInstanceOf(Date);
-          }
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+        }),
+        { numRuns: 10 },
+      );
+    });
 
     /**
      * Test 24 (property): shouldDeleteSession without lock always returns 'delete'
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-002
      */
-    itProp.prop([fc.nat({ max: 6 })], { numRuns: 10 })(
-      'shouldDeleteSession returns delete for all unlocked sessions @requirement:REQ-CLN-002',
-      async (count) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-unlocked-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('shouldDeleteSession returns delete for all unlocked sessions @requirement:REQ-CLN-002', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.nat({ max: 6 }), async (count) => {
+          const localTemp = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'prop-unlocked-'),
+          );
+          const localChats = path.join(localTemp, 'chats');
+          fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          for (let i = 0; i < count; i++) {
-            const id = `unlocked-${i}-${Date.now()}`;
-            const ts = new Date(Date.now() - i * 1000).toISOString();
-            const sessionPath = writeSessionFile(localChats, id, ts);
-            const entry = makeEntry(sessionPath, id);
+          try {
+            for (let i = 0; i < count; i++) {
+              const id = `unlocked-${i}-${Date.now()}`;
+              const ts = new Date(Date.now() - i * 1000).toISOString();
+              const sessionPath = writeSessionFile(localChats, id, ts);
+              const entry = makeEntry(sessionPath, id);
 
-            const result = await shouldDeleteSession(entry);
-            expect(result).toBe('delete');
+              const result = await shouldDeleteSession(entry);
+              expect(result).toBe('delete');
+            }
+          } finally {
+            fs.rmSync(localTemp, { recursive: true, force: true });
           }
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+        }),
+        { numRuns: 10 },
+      );
+    });
 
     /**
      * Test 25 (property): cleanupStaleLocks on empty directory returns 0
      * @plan PLAN-20260211-SESSIONRECORDING.P16
      * @requirement REQ-CLN-004
      */
-    itProp.prop([fc.nat({ max: 3 })], { numRuns: 10 })(
-      'cleanupStaleLocks on directory with only session files (no locks) returns 0 @requirement:REQ-CLN-004',
-      async (count) => {
-        const localTemp = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'prop-nolocks-'),
-        );
-        const localChats = path.join(localTemp, 'chats');
-        fs.mkdirSync(localChats, { recursive: true });
+    it('cleanupStaleLocks on directory with only session files (no locks) returns 0 @requirement:REQ-CLN-004', async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.nat({ max: 3 }), async (count) => {
+          const localTemp = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'prop-nolocks-'),
+          );
+          const localChats = path.join(localTemp, 'chats');
+          fs.mkdirSync(localChats, { recursive: true });
 
-        try {
-          for (let i = 0; i < count; i++) {
-            const id = `nolocks-${i}-${Date.now()}`;
-            const ts = new Date(Date.now() - i * 1000).toISOString();
-            writeSessionFile(localChats, id, ts);
+          try {
+            for (let i = 0; i < count; i++) {
+              const id = `nolocks-${i}-${Date.now()}`;
+              const ts = new Date(Date.now() - i * 1000).toISOString();
+              writeSessionFile(localChats, id, ts);
+            }
+
+            const cleaned = await cleanupStaleLocks(localChats);
+            expect(cleaned).toBe(0);
+          } finally {
+            fs.rmSync(localTemp, { recursive: true, force: true });
           }
-
-          const cleaned = await cleanupStaleLocks(localChats);
-          expect(cleaned).toBe(0);
-        } finally {
-          fs.rmSync(localTemp, { recursive: true, force: true });
-        }
-      },
-    );
+        }),
+        { numRuns: 10 },
+      );
+    });
   });
 });

--- a/packages/core/src/recording/sessionManagement.test.ts
+++ b/packages/core/src/recording/sessionManagement.test.ts
@@ -23,7 +23,7 @@
  * create genuine session JSONL files in real temp directories — no mock
  * theater.
  *
- * Property-based tests use @fast-check/vitest (≥30% of total tests).
+ * Property-based tests use fast-check (≥30% of total tests).
  */
 
 import { describe, expect, beforeEach, afterEach, it } from 'vitest';
@@ -403,35 +403,30 @@ describe('sessionManagement @plan:PLAN-20260211-SESSIONRECORDING.P22', () => {
       }
     });
 
-    itProp(
-      'lists live checkpoint blockers instead of deleting their source',
-      async () => {
-        const sessionId = 'checkpoint-source-session';
-        const recording = new SessionRecordingService(
-          makeConfig(chatsDir, { sessionId }),
-        );
-        recording.recordContent(makeContent('checkpointed history'));
-        await recording.flush();
-        const first = await recording.createCheckpoint('before-refactor');
-        const second = await recording.createCheckpoint('before-release');
-        const filePath = recording.getFilePath();
-        await recording.dispose();
+    it('lists live checkpoint blockers instead of deleting their source', async () => {
+      const sessionId = 'checkpoint-source-session';
+      const recording = new SessionRecordingService(
+        makeConfig(chatsDir, { sessionId }),
+      );
+      recording.recordContent(makeContent('checkpointed history'));
+      await recording.flush();
+      const first = await recording.createCheckpoint('before-refactor');
+      const second = await recording.createCheckpoint('before-release');
+      const filePath = recording.getFilePath();
+      await recording.dispose();
 
-        const result = await deleteSession(sessionId, chatsDir, PROJECT_HASH);
+      const result = await deleteSession(sessionId, chatsDir, PROJECT_HASH);
 
-        expect(result).toStrictEqual({
-          ok: false,
-          error:
-            `Cannot delete session: live checkpoints block deletion: ` +
-            `before-refactor (${first.checkpointId}), ` +
-            `before-release (${second.checkpointId})`,
-        });
-        expect(filePath).not.toBeNull();
-        if (filePath !== null) {
-          expect(await fileExists(filePath)).toBe(true);
-        }
-      },
-    );
+      expect(result).toStrictEqual({
+        ok: false,
+        error:
+          `Cannot delete session: live checkpoints block deletion: ` +
+          `before-refactor (${first.checkpointId}), ` +
+          `before-release (${second.checkpointId})`,
+      });
+      expect(filePath).not.toBeNull();
+      expect(await fileExists(filePath!)).toBe(true);
+    });
   });
 
   describe('deleteSessionById', () => {
@@ -576,7 +571,7 @@ describe('sessionManagement @plan:PLAN-20260211-SESSIONRECORDING.P22', () => {
   // =========================================================================
 
   describe('deletion replay safety', () => {
-    itProp('fails closed when the session file is corrupt', async () => {
+    it('fails closed when the session file is corrupt', async () => {
       const sessionId = 'corrupt-blocker-session';
       const { filePath } = await createTestSession(chatsDir, { sessionId });
       const lines = (await fs.readFile(filePath, 'utf-8')).trim().split('\n');
@@ -596,19 +591,16 @@ describe('sessionManagement @plan:PLAN-20260211-SESSIONRECORDING.P22', () => {
       expect(await fileExists(filePath)).toBe(true);
     });
 
-    itProp(
-      'fails closed when the session file contains invalid JSON',
-      async () => {
-        const sessionId = 'invalid-json-blocker-session';
-        const { filePath } = await createTestSession(chatsDir, { sessionId });
-        await fs.writeFile(filePath, '{"v":1,"seq":1', 'utf-8');
+    it('fails closed when the session file contains invalid JSON', async () => {
+      const sessionId = 'invalid-json-blocker-session';
+      const { filePath } = await createTestSession(chatsDir, { sessionId });
+      await fs.writeFile(filePath, '{"v":1,"seq":1', 'utf-8');
 
-        const result = await deleteSession(sessionId, chatsDir, PROJECT_HASH);
+      const result = await deleteSession(sessionId, chatsDir, PROJECT_HASH);
 
-        expect(result.ok).toBe(false);
-        expect(await fileExists(filePath)).toBe(true);
-      },
-    );
+      expect(result.ok).toBe(false);
+      expect(await fileExists(filePath)).toBe(true);
+    });
   });
 
   describe('Property-Based Tests @plan:PLAN-20260211-SESSIONRECORDING.P22', () => {

--- a/packages/core/src/utils/retry.quota.test.ts
+++ b/packages/core/src/utils/retry.quota.test.ts
@@ -460,16 +460,20 @@ describe('retryWithBackoff Windows timeout retry (issue #2557)', () => {
       return 'success';
     });
 
-    const promise = retryWithBackoff(mockFn, {
+    // Settle the promise into a tagged outcome up front. The fake-timer drain
+    // below is what actually runs the retry loop, so a rejection would
+    // otherwise surface while the promise still has no handler attached.
+    const outcome = retryWithBackoff(mockFn, {
       maxAttempts: 3,
       initialDelayMs: 10,
-    });
+    }).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
 
-    await Promise.all([
-      expect(promise).resolves.toBe('success'),
-      vi.runAllTimersAsync(),
-    ]);
+    await vi.runAllTimersAsync();
 
+    expect(await outcome).toStrictEqual({ ok: true, value: 'success' });
     expect(mockFn).toHaveBeenCalledTimes(3);
   });
 

--- a/project-plans/20260803-issue2968/PLAN.md
+++ b/project-plans/20260803-issue2968/PLAN.md
@@ -1,0 +1,290 @@
+# Issue #2968 — Remove the Bun EXCLUDE list from packages/core
+
+## Goal
+
+Make the six core test files currently routed to Vitest execute under Bun's
+native test runner, then delete the escape hatch (`EXCLUDE` in
+`packages/core/run-bun-tests.ts`) and the `test:vitest` script from
+`packages/core/package.json`.
+
+## Measured baseline (captured on `main`, before any change)
+
+### Vitest run of the six excluded files
+
+    npx vitest run --reporter=verbose <the six files>
+
+| File                                          | Vitest passing cases |
+| --------------------------------------------- | -------------------- |
+| src/recording/SessionRecordingService.test.ts   | 33                   |
+| src/recording/resumeSession.test.ts             | 20                   |
+| src/recording/sessionCleanupUtils.test.ts       | 28                   |
+| src/recording/sessionManagement.test.ts         | 0 — SUITE FAILS      |
+| src/hooks/hookRunner.consoleIsolation.test.ts   | 2                    |
+| src/utils/retry.quota.test.ts                   | 27                   |
+| **Total**                                       | **110 + 1 failed suite** |
+
+The exact test-case name lists are captured under `/tmp/parity/*.vitest.txt`
+and are the parity oracle for the migrated Bun run.
+
+### Vitest run of the four non-excluded sibling recording files
+
+| File                                     | Vitest | Bun (current `main`) |
+| ---------------------------------------- | ------ | -------------------- |
+| src/recording/SessionDiscovery.test.ts    | —      | 22 pass / 0 fail     |
+| src/recording/SessionLockManager.test.ts  | —      | 31 pass / 0 fail     |
+| src/recording/integration.basic.test.ts   | —      | 16 pass / 0 fail     |
+| src/recording/integration.advanced.test.ts| —      | 20 pass / 0 fail     |
+| **Total**                                 | **89** | **89**               |
+
+These four files only mention `@fast-check/vitest` in a doc comment; they
+import bare `fast-check` and `it` from `vitest`. They already achieve exact
+count parity under Bun. **No code change is required for them** — the issue's
+"reconcile" requirement is satisfied by this verification, which is recorded
+here and in the PR description.
+
+## Blockers found, with evidence
+
+### B1 — `@fast-check/vitest` throws at import time under Bun
+
+Affected: `SessionRecordingService.test.ts`, `resumeSession.test.ts`,
+`sessionCleanupUtils.test.ts`.
+
+    TypeError: undefined is not an object (evaluating 'testFn[key]')
+        at buildTest (node_modules/@fast-check/vitest/lib/internals/TestBuilder.js:65:33)
+
+The package walks the Vitest `it` object's sub-properties (`it.concurrent`,
+`it.fails`, …). Bun's injected `vitest` shim does not expose the same shape,
+so the module blows up on load and the whole file yields `0 pass / 1 fail`.
+
+Fix: remove the `@fast-check/vitest` import from all three files.
+
+- Plain `itProp('name', async () => { … })` (no `.prop`) is not a property
+  test at all — it is a passthrough to `it`. Rewrite as `it('name', …)`.
+- `it.prop([arb, …], opts?)('name', async (a, …) => { … })` becomes
+
+      it('name', async () => {
+        await fc.assert(
+          fc.asyncProperty(arb, …, async (a, …) => { … }),
+          opts,
+        );
+      });
+
+  This is exactly the pattern already used by the passing sibling files
+  (e.g. `sessionManagement.test.ts` `Property-Based Tests` block), so it is
+  the established project convention, not a new invention.
+
+  `fc.assert` fails on a falsy predicate return; the bodies here assert with
+  `expect`, which throws — behaviour is preserved.
+
+### B2 — `sessionManagement.test.ts` references an undefined `itProp`
+
+The file imports `it` from `vitest` and never imports `itProp`, yet calls
+`itProp(...)` three times (lines 406, 579, 599).
+
+- Under **Vitest** this is a collection-time `ReferenceError` that fails the
+  entire suite: all 20 of its tests currently run **zero** times, and
+  `npm run test:vitest -w packages/core` is therefore red on `main`.
+- Under **Bun** it produces two "unhandled error between tests" reports and
+  silently drops those three cases (17 of 20 run).
+
+Fix: these three calls pass no arbitraries — they are plain example-based
+tests. Change `itProp` to `it`.
+
+Result: **25 passing cases** under Bun, and **25 under Vitest** as well. Only
+17 ran under Bun before the fix — the two aborted `describe` callbacks took
+the 3 broken cases plus 5 healthy siblings down with them.
+
+### B3 — `hookRunner.consoleIsolation.test.ts` reads a stale mock call index
+
+The second test asserts on `vi.mocked(spawn).mock.calls[0][2]`, i.e. the
+*first ever* recorded call. Under Vitest the module-level `vi.fn()` from the
+`vi.mock` factory is reset between tests by `vi.restoreAllMocks()`; under Bun
+`restoreAllMocks` does not clear a factory-created `vi.fn()`, so `calls[0]`
+is still the `win32` call from the first test and `windowsHide` is `true`.
+
+This is order-dependence in the test, not a `process.platform` limitation —
+`Object.defineProperty(process, 'platform', …)` works correctly under Bun (the
+`win32` test passes).
+
+Fix: clear the spawn mock in `beforeEach` so each test observes only its own
+call. Keeps both assertions intact; no assertion is weakened or skipped.
+
+### B4 — `retry.quota.test.ts` deadlocks the Bun process
+
+All 27 cases report `(pass)` and then the process never exits. Isolating each
+case shows the hang is exactly:
+
+    'retries a DOMException TimeoutError and succeeds when a later attempt succeeds'
+
+which uses
+
+    await Promise.all([
+      expect(promise).resolves.toBe('success'),
+      vi.runAllTimersAsync(),
+    ]);
+
+Racing an unsettled `expect(...).resolves` against the fake-timer drain
+deadlocks under Bun. A scratch reproduction confirmed the sequential form
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBe('success');
+
+passes in 2.7 ms. The sequential form is already what the very next test in
+the same `describe` does, so this aligns the two.
+
+Fix: sequence the drain before the assertion. Same assertions, same count.
+
+## Changes to make
+
+1. `packages/core/src/recording/SessionRecordingService.test.ts` — drop the
+   `@fast-check/vitest` import, add `it` to the `vitest` import, convert the
+   9 `it.prop` blocks to `fc.assert(fc.asyncProperty(...))`.
+2. `packages/core/src/recording/resumeSession.test.ts` — drop the import,
+   add `it` to the `vitest` import, rename 14 plain `itProp` → `it`, convert
+   6 `itProp.prop` blocks.
+3. `packages/core/src/recording/sessionCleanupUtils.test.ts` — same shape:
+   16 plain → `it`, 12 `.prop` blocks converted.
+4. `packages/core/src/recording/sessionManagement.test.ts` — 3 stray
+   `itProp` → `it`.
+5. `packages/core/src/hooks/hookRunner.consoleIsolation.test.ts` — clear the
+   spawn mock between tests.
+6. `packages/core/src/utils/retry.quota.test.ts` — sequence the timer drain.
+7. `packages/core/run-bun-tests.ts` — delete `EXCLUDE`, its comment, the
+   `!EXCLUDE.has(...)` condition and the now-unused `sep` import.
+8. `packages/core/package.json` — delete the `test:vitest` script.
+9. Update the stale doc-comment line in each migrated recording test that
+   claims tests use `@fast-check/vitest`, so the comment matches reality.
+
+## Knock-on lint work (not optional, not scope creep)
+
+Removing the `@fast-check/vitest` indirection made `npm run lint` fail with 72
+errors that had never been reported before:
+
+- 71 × `vitest/no-conditional-expect` / `vitest/no-conditional-in-test`
+- 1 × `max-lines` on `SessionRecordingService.test.ts` (812 > 800)
+
+The lint errors are not new defects. `@vitest/eslint-plugin` only lints call
+expressions it recognises as test declarations. While these files declared
+tests through the aliased identifier `itProp`, the plugin saw nothing and the
+bodies went unlinted. Plain `it(...)` is recognised, so the pre-existing smells
+finally surfaced. Silencing them would defeat the purpose of the migration, so
+they are fixed:
+
+- **Conditional assertions.** Bodies used `if (result.ok) { …expects… }` purely
+  to narrow a discriminated union. That means a regression flipping `ok` to
+  `false` would silently skip every assertion inside. Replaced with two
+  file-local helpers in `resumeSession.test.ts` that couple the runtime
+  assertion to the narrowing, so the narrowed value cannot be obtained unless
+  the assertion passed:
+
+      function expectOk<T extends { ok: boolean }>(
+        result: T,
+      ): Extract<T, { ok: true }>;
+      function expectNotOk<T extends { ok: boolean }>(
+        result: T,
+      ): Extract<T, { ok: false }>;
+
+  The two single-site cases in `sessionManagement.test.ts` and
+  `sessionCleanupUtils.test.ts` were made unconditional directly.
+
+- **`max-lines`.** The threshold was NOT raised. The 9 property tests each
+  repeated the same mkdtemp / mkdir / try-finally-rm scaffold; that was
+  extracted into a generic `withTempChatsDir<T>(prefix, body)` helper, taking
+  the file from 812 to 750 counted lines while removing the duplication.
+
+`SessionLockManager.test.ts` also imported `it as itProp` from `vitest` — the
+same plugin-blinding alias, with no fast-check involved at all. The alias is
+removed; the file lints clean and still passes 31/31.
+
+## Review findings and triage
+
+Two independent reviews were run.
+
+Accepted and fixed:
+
+- `retry.quota.test.ts` attached its `.resolves` expectation only after
+  `runAllTimersAsync()` had already driven the retry loop, leaving a window in
+  which a rejection would surface with no handler attached. The promise is now
+  settled into a tagged outcome up front and the outcome asserted after the
+  drain.
+- Stale header comments claiming `@fast-check/vitest` usage were corrected in
+  all six migrated files and in the four sibling recording tests. The
+  `SessionLockManager.test.ts` header additionally claimed property-based
+  coverage it has never had; that claim is removed rather than restated.
+- `dev-docs/test-runner-inventory.md` asserted that every migrated workspace
+  keeps a `test:vitest` fallback. Core no longer does; the entry now says so.
+- 20 inline `as Extract<typeof result, …>` casts in `resumeSession.test.ts`
+  were centralised behind the two helpers above, so one cast is enforced by an
+  assertion instead of 20 unchecked ones.
+
+Rejected, with reasons:
+
+- "Restore the `if (filePath !== null)` guard around the `expect`." The
+  premise is wrong: `expect(filePath).not.toBeNull()` throws first, so the
+  following `filePath!` is never evaluated when the value is null. The
+  suggested fix would also reintroduce the `vitest/no-conditional-expect`
+  error this work exists to remove.
+- "Use `if (!result.ok) throw …` instead of the narrowing helper." That
+  reintroduces a conditional in a test body and trips
+  `vitest/no-conditional-in-test`.
+- "The property tests leak a lock handle when an assertion fails, and the old
+  `if (result.ok)` form avoided it." The `dispose()`/`release()` calls sit
+  after the assertions in exactly the same order as on `main`; the old `if`
+  form had the identical gap. Pre-existing, unchanged by this work, and only
+  reachable on a failing test.
+
+## Out of scope
+
+- Any workspace other than `core`.
+- Removing Vitest deps/config repo-wide, or the `test:vitest` script in other
+  workspaces.
+- `dev-docs/test-runner-inventory.md`'s general statement about per-workspace
+  `test:vitest` scripts remains true for the other workspaces.
+
+## Observed but deliberately not changed
+
+Two more places in `packages/core` route test declarations through an
+identifier `@vitest/eslint-plugin` does not recognise. Neither is named by the
+issue, neither is excluded from Bun, and both pass:
+
+- `src/recording/SessionLockManager.property.test.ts` — `import { it as itProp }
+  from 'vitest'`, the same blinding alias removed from its sibling.
+- `src/recording/integration.advanced.test.ts` — a local, correctly typed
+  `it.prop` polyfill that already drives `fc.assert(fc.asyncProperty(...))`
+  through `it`. This is a working adapter, not a stale shim.
+
+`src/hooks/__tests__/hookSystem-lifecycle.test.ts` also has a header comment
+claiming `@fast-check/vitest` while importing bare `fast-check`. It has no
+`@fast-check/vitest` import, so it does not violate the acceptance criteria.
+
+All three are adjacent cleanup outside this issue's scope and are left for a
+follow-up.
+
+## Acceptance evidence required
+
+- `bun test --preload ./bun-preload.ts <file>` for each of the six files:
+  exits 0, process terminates (no hang), no "unhandled error between tests".
+- Per-file Bun test-name list diffed against `/tmp/parity/*.vitest.txt`:
+  identical sets for the five files that collected under Vitest.
+  `sessionManagement.test.ts` has no Vitest baseline (broken suite) and must
+  reach 25 passing cases.
+
+## Result
+
+| File                                          | Vitest before | Bun after |
+| --------------------------------------------- | ------------- | --------- |
+| src/recording/SessionRecordingService.test.ts   | 33            | 33        |
+| src/recording/resumeSession.test.ts             | 20            | 20        |
+| src/recording/sessionCleanupUtils.test.ts       | 28            | 28        |
+| src/recording/sessionManagement.test.ts         | 0 (suite red) | 25        |
+| src/hooks/hookRunner.consoleIsolation.test.ts   | 2             | 2         |
+| src/utils/retry.quota.test.ts                   | 27            | 27        |
+
+For the five files that collected under Vitest, the sorted list of passing
+test-case names is byte-identical between the Vitest baseline and the Bun
+run — not merely the counts. `sessionManagement.test.ts` also now passes
+25/25 under Vitest, confirming the `itProp` fix is a genuine repair rather
+than a Bun-specific workaround.
+- `grep -r "@fast-check/vitest" packages/core/` returns nothing.
+- `grep -n EXCLUDE packages/core/run-bun-tests.ts` returns nothing.
+- `npm run test`, `lint`, `typecheck`, `format`, `build` all pass.


### PR DESCRIPTION
## TLDR

`packages/core/run-bun-tests.ts` carried an `EXCLUDE` set that hid six test files from Bun discovery, with a comment saying they run "under vitest via `npm run test:vitest` instead." They did not — `test:vitest` was never invoked by any script, workflow, or Makefile target, so those six files were not being executed by the core test suite at all. One of them, `sessionManagement.test.ts`, failed collection outright under Vitest because it called an undefined `itProp`, so all 25 of its tests ran zero times.

This PR fixes the four underlying incompatibilities, deletes the `EXCLUDE` set and the `test:vitest` script, and proves test-case parity by comparing the sorted list of passing test **names** (not just counts) between the Vitest baseline on `main` and the Bun run.

**What reviewers should look at most closely:** the 27 `it.prop` → `fc.assert(fc.asyncProperty(...))` conversions (did any arbitrary, `numRuns` option, or assertion get lost?) and the 72 knock-on lint errors, which are fixed rather than suppressed.

## Dive Deeper

### Root causes, each fixed rather than routed around

**1. `@fast-check/vitest` throws at import time under Bun.**

    TypeError: undefined is not an object (evaluating 'testFn[key]')
        at buildTest (node_modules/@fast-check/vitest/lib/internals/TestBuilder.js:65:33)

The package walks sub-properties of Vitest's `it` (`it.concurrent`, `it.fails`, …). Bun's injected `vitest` shim does not expose the same shape, so the module blows up on load and the entire file yields `0 pass / 1 fail`.

The 27 property tests across `SessionRecordingService.test.ts` (9), `sessionCleanupUtils.test.ts` (12) and `resumeSession.test.ts` (6) now drive bare `fast-check`:

    it('name', async () => {
      await fc.assert(
        fc.asyncProperty(arbA, arbB, async (a, b) => { ... }),
        { numRuns: 15 },
      );
    });

This is the pattern the already-passing sibling tests use, not a new invention. Arbitrary order, callback parameter binding, `fc.pre` guards and every `numRuns` option are preserved. The 30 plain `itProp('name', cb)` calls carried no arbitraries at all — they were passthroughs to `it` and are now just `it`.

**2. Three tests referencing an undefined `itProp`.** They pass no arbitraries; they are plain example-based tests. Changed to `it`. `sessionManagement.test.ts` now passes 25/25 under **both** Bun and Vitest, which confirms this is a genuine repair rather than a Bun-specific workaround.

**3. `hookRunner.consoleIsolation.test.ts` read a stale mock call index.** The second test asserted on `vi.mocked(spawn).mock.calls[0][2]` — the *first ever* recorded call. Under Vitest the module-level `vi.fn()` from the `vi.mock` factory is reset by `vi.restoreAllMocks()`; under Bun `restoreAllMocks` does not clear a factory-created `vi.fn()`, so `calls[0]` was still the `win32` call from the first test and `windowsHide` came back `true`. This was order-dependence in the test, not a `process.platform` limitation — `Object.defineProperty(process, 'platform', …)` works fine under Bun (the win32 test passes). The spawn mock is now cleared per test; both assertions are intact.

**4. `retry.quota.test.ts` deadlocked the Bun process.** All 27 cases reported `(pass)` and then the process never exited. Bisecting to a single case:

    await Promise.all([
      expect(promise).resolves.toBe('success'),
      vi.runAllTimersAsync(),
    ]);

Racing an unsettled `expect(...).resolves` against the fake-timer drain deadlocks under Bun. The promise is now settled into a tagged outcome *before* the drain:

    const outcome = retryWithBackoff(...).then(
      (value) => ({ ok: true as const, value }),
      (error: unknown) => ({ ok: false as const, error }),
    );
    await vi.runAllTimersAsync();
    expect(await outcome).toStrictEqual({ ok: true, value: 'success' });

This also closes a window flagged in review: previously the promise had no handler attached while `runAllTimersAsync()` was driving the retry loop, so a regression that rejected during the drain would surface as an unhandled rejection instead of a clean assertion failure.

### Knock-on lint work — no rule was relaxed

Removing the `itProp` indirection made `npm run lint` report **72 errors that had never been reported before**. These are not new defects. `@vitest/eslint-plugin` only lints call expressions it recognises as test declarations; while tests were declared through the aliased identifier `itProp`, the plugin saw nothing and the bodies went unlinted. Plain `it(...)` is recognised, so the pre-existing smells finally surfaced. Silencing them would have defeated the point of the migration. No `eslint-disable`, no `@ts-ignore`, no threshold increase, no severity downgrade, no ignore-list entry.

**71 × `vitest/no-conditional-expect` / `no-conditional-in-test`.** Bodies used `if (result.ok) { …expects… }` purely to narrow a discriminated union — meaning a regression flipping `ok` to `false` would silently skip every assertion inside while the test still passed on the `expect(result.ok).toBe(true)` line. `resumeSession.test.ts` gains two file-local helpers that couple the runtime assertion to the narrowing, so the narrowed value cannot be obtained unless the assertion passed:

    function expectOk<T extends { ok: boolean }>(result: T): Extract<T, { ok: true }> {
      expect(result.ok).toBe(true);
      return result as Extract<T, { ok: true }>;
    }

One enforced cast instead of 20 unchecked ones. The two remaining single sites in `sessionManagement.test.ts` and `sessionCleanupUtils.test.ts` were made unconditional directly.

**1 × `max-lines` (812 > 800) on `SessionRecordingService.test.ts`.** The threshold was not raised. The 9 property tests each repeated the same mkdtemp / mkdir / try-finally-rm scaffold; that was extracted into a generic `withTempChatsDir<T>(prefix, body)` helper, taking the file to 750 counted lines while removing the duplication.

### Sibling reconciliation

The issue asked whether the four non-excluded recording tests that reference `@fast-check/vitest` were silently degraded. They were not — they only mention it in a doc comment and already import bare `fast-check`. Verified at exact parity, **89 Vitest = 89 Bun**:

| File | Vitest | Bun |
| --- | ---: | ---: |
| `SessionDiscovery.test.ts` | 22 | 22 |
| `SessionLockManager.test.ts` | 31 | 31 |
| `integration.basic.test.ts` | 16 | 16 |
| `integration.advanced.test.ts` | 20 | 20 |

Their stale header comments are corrected. `SessionLockManager.test.ts` additionally imported `it as itProp` from `vitest` — the same plugin-blinding alias, with no fast-check involved at all — and its header claimed property-based coverage it has never had. The alias is removed, the false claim is removed, and it still passes 31/31.

### Test-case parity — measured, not asserted

Baseline captured on `main` with `npx vitest run --reporter=verbose`, then compared against the Bun run. For the five files that collected under Vitest, the **sorted list of passing test-case names is byte-identical** — not merely the counts.

| File | Vitest on `main` | Bun after |
| --- | ---: | ---: |
| `SessionRecordingService.test.ts` | 33 | 33 |
| `resumeSession.test.ts` | 20 | 20 |
| `sessionCleanupUtils.test.ts` | 28 | 28 |
| `sessionManagement.test.ts` | **0 — suite red** | **25** |
| `hookRunner.consoleIsolation.test.ts` | 2 | 2 |
| `retry.quota.test.ts` | 27 | 27 |

Nothing was dropped, skipped, filtered, marked todo, or moved to another exclusion mechanism. Bun discovery went from 320 files to 326 — exactly the six intended files and nothing else.

### Acceptance criteria from #2968

- [x] All six previously excluded core test files execute under the Bun native test runner
- [x] The `EXCLUDE` constant no longer exists in `packages/core/run-bun-tests.ts` (along with its comment and the now-unused `sep` import)
- [x] No `@fast-check/vitest` import remains anywhere under `packages/core/`
- [x] The four non-excluded recording tests are verified at 89/89 parity under Bun
- [x] The `test:vitest` script is removed from `packages/core/package.json`
- [x] Test-case parity verified per file, by name, not just by count
- [x] No test dropped, filtered, newly skipped, or deferred
- [x] Full verification suite passes

### Deliberately not changed

`SessionLockManager.property.test.ts` still aliases `it as itProp`, and `integration.advanced.test.ts` defines a local (correct, fully typed) `it.prop` polyfill. `hooks/__tests__/hookSystem-lifecycle.test.ts` has a header comment mentioning `@fast-check/vitest` while importing bare `fast-check`. None of these is an `@fast-check/vitest` import, none is excluded from Bun, and all pass — they are adjacent cleanup outside this issue's scope, recorded in `project-plans/20260803-issue2968/PLAN.md` for a follow-up.

## Reviewer Test Plan

This PR is test-infrastructure only; no product code changes. Validate that the six files really run under Bun and that nothing was lost.

**1. Confirm the escape hatch is gone.**

    grep -n EXCLUDE packages/core/run-bun-tests.ts          # no output
    grep -n '"test:vitest"' packages/core/package.json      # no output
    grep -rn "@fast-check/vitest" packages/core/src         # only an unrelated doc comment in hooks/__tests__

**2. Confirm the six files now run under Bun and terminate.** Each should exit 0 with `0 fail`, `0 errors`, and no "Unhandled error between tests":

    cd packages/core
    for f in src/recording/SessionRecordingService.test.ts \
             src/recording/resumeSession.test.ts \
             src/recording/sessionCleanupUtils.test.ts \
             src/recording/sessionManagement.test.ts \
             src/hooks/hookRunner.consoleIsolation.test.ts \
             src/utils/retry.quota.test.ts; do
      bun test --preload ./bun-preload.ts "$f"
    done

Expected: 33, 20, 28, 25, 2, 27 passing. `retry.quota.test.ts` is the one to watch — on `main` it hangs forever after printing all 27 passes; here it should exit in well under a second.

**3. Reproduce the parity check yourself.** On `main`, capture the baseline; on this branch, capture the Bun run; diff the name lists:

    git checkout main
    cd packages/core && npx vitest run --reporter=verbose \
      src/recording/SessionRecordingService.test.ts \
      src/recording/resumeSession.test.ts \
      src/recording/sessionCleanupUtils.test.ts \
      src/hooks/hookRunner.consoleIsolation.test.ts \
      src/utils/retry.quota.test.ts

Note that `sessionManagement.test.ts` cannot be included in the baseline — it fails collection on `main` with `ReferenceError: itProp is not defined`, which is itself worth confirming.

**4. Confirm the lint fixes are real fixes.** `npm run lint` must be clean, and the diff must contain no `eslint-disable`, no `@ts-*` suppression, and no change to `eslint.config.js`:

    git diff main -- . | grep -nE "eslint-disable|@ts-ignore|@ts-expect-error|@ts-nocheck"   # no output
    git diff main --stat -- eslint.config.js                                                 # no output

**5. Full suite.** `npm run test` — core should report `Passed 326/326 test files` (320 on `main`).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS (`npm run format` / `lint` / `build` / `typecheck` / `test`, plus the `bun scripts/start.ts --profile-load stepfun-37` smoke test). Linux is covered by the CI test shards and E2E jobs on this PR, all green. Windows is not directly exercised; the one platform-sensitive assertion (`windowsHide` on `win32` in `hookRunner.consoleIsolation.test.ts`) is driven by `Object.defineProperty(process, 'platform', …)` rather than by the real host platform, and `SessionRecordingService.test.ts` contains one `win32`-gated case that runs only on Windows — accounting for its 33-of-34 declared cases on macOS/Linux.

Two intermittent failures seen locally (`config.mcp-lazy.test.ts`, `config.agentInversion.test.ts`) were reproduced only while three heavy suites were running concurrently on the same machine; both pass in isolation in under a second, both are untouched by this PR, and a clean run of the core suite on this branch is 326/326 against 320/320 on `main`.

## Linked issues / bugs

Fixes #2968

Sub-issue of #2578 (migrate all remaining repository tests to direct Bun execution). Completes the part of #2842 that was left unfinished when the core workspace was marked migrated while still carrying this exclusion list.
