### PR TITLE
fix(ci): make issue-planner enrichment steps non-fatal (closes #2984)

### DIFF
--- a/.github/workflows/issue-planner.yml
+++ b/.github/workflows/issue-planner.yml
@@ -125,11 +125,14 @@ jobs:
           GH_TOKEN: '${{ github.token }}'
         run: |
           set -euo pipefail
-          # Use the production extractLinkedReferences() helper (handles
-          # fenced-code exclusion and de-dup) so the workflow and tests share
-          # one implementation. Excludes the current issue number.
-          bun .github/scripts/issue-planner.ts \
-            --extract-linked-references planner "${ISSUE_NUMBER}"
+          # Advisory enrichment — best effort, never fatal (#2984). The helper
+          # reads issue.json (already gathered); if it fails, degrade to an
+          # empty reference list rather than aborting the run.
+          if ! bun .github/scripts/issue-planner.ts \
+              --extract-linked-references planner "${ISSUE_NUMBER}"; then
+            echo "::warning::Linked-references extraction failed; using empty list."
+            printf '' > planner/linked-references.txt
+          fi
 
           mapfile -t linked_numbers < planner/linked-references.txt
           for num in "${linked_numbers[@]}"; do
@@ -193,7 +196,13 @@ jobs:
           COMMENT_BODY: '${{ github.event.comment.body }}'
         run: |
           set -euo pipefail
-          bun .github/scripts/issue-planner.ts --extract-feedback planner
+          # Advisory enrichment — best effort, never fatal (#2984). Feedback
+          # only applies to /plan comment re-runs; if extraction fails,
+          # degrade to empty feedback.
+          if ! bun .github/scripts/issue-planner.ts --extract-feedback planner; then
+            echo "::warning::Plan-feedback extraction failed; using empty feedback."
+            printf '' > planner/feedback.txt
+          fi
 
       - name: 'Render planner context and instructions'
         run: |

--- a/project-plans/issue2984/plan.md
+++ b/project-plans/issue2984/plan.md
@@ -1,0 +1,93 @@
+# Plan — #2984: Make advisory enrichment steps non-fatal (umbrella close-out)
+
+## Goal
+
+Close the umbrella issue #2984 ("make the Issue Planner workflow reliable")
+by satisfying its last open acceptance criterion:
+
+> Optional enrichment failures cannot fail the run.
+
+Both enumerated child defects are already closed (#2960 confinement symlinks,
+#2972 search-query interpolation / concurrency). The remaining gap is that two
+advisory-enrichment helper invocations run **unguarded** under
+`set -euo pipefail`, so a failure in either aborts the whole run — contradicting
+the umbrella's theme #2 ("Optional context gathering should degrade to empty,
+not abort").
+
+## Root cause
+
+`.github/workflows/issue-planner.yml`:
+
+1. Step **"Extract linked references and fetch linked issues"** runs
+   `bun .github/scripts/issue-planner.ts --extract-linked-references …`
+   unguarded. If the helper throws (e.g. malformed `issue.json`), `set -e`
+   aborts the job. (The *linked-issue fetch loop* below it is already
+   `if !`-guarded, but the helper call itself is not.)
+
+2. Step **"Extract /plan feedback"** runs
+   `bun .github/scripts/issue-planner.ts --extract-feedback` unguarded.
+   Same abort risk.
+
+Both are advisory: linked references and `/plan` feedback are optional context.
+The downstream consumers already tolerate empty output (`mapfile` reads nothing
+from an empty `linked-references.txt`; `--render-context` treats empty/missing
+`feedback.txt` as `null`).
+
+## Fix (mirrors the #2972 related-candidate pattern)
+
+Wrap each helper call in an `if ! … then ::warning:: ; printf '' > <file>` guard
+so a failure degrades to empty output with a visible `::warning::`, exactly like
+the existing `--build-search-query` / `gh search` guards.
+
+### Essential steps stay fatal (do NOT guard)
+
+`Gather issue metadata`, `Validate required repository variables`,
+`Render planner context/instructions`, `Confine filesystem`, and
+`Run planner agent` are essential — they are not advisory enrichment and must
+remain able to fail the run (the visible-failure contract depends on it).
+
+## Files
+
+| File | Change |
+|------|--------|
+| `.github/workflows/issue-planner.yml` | Guard the two enrichment helper calls |
+| `scripts/tests/issue-planner-enrichment.bun.test.ts` | **NEW** bun-native workflow-structure assertions |
+| `scripts/bun-test-manifest.ts` | Register the new bun test file |
+
+No script (`issue-planner.ts`) changes — the script throws appropriately; the
+workflow catches and degrades.
+
+## Tests (test-first, bun-native, TS — no vitest/node/js)
+
+`issue-planner-enrichment.bun.test.ts` (uses `parseWorkflowYaml` /
+`workflowJob` / `findStep` / `asString` from `typed-test-helpers.ts`):
+
+1. **`--extract-linked-references` is guarded** — the step script matches
+   `/if\s+!\s+bun[\s\S]*?--extract-linked-references/`, contains `::warning::`,
+   and contains the empty fallback `printf '' > planner/linked-references.txt`.
+2. **`--extract-feedback` is guarded** — matches
+   `/if\s+!\s+bun[\s\S]*?--extract-feedback/`, contains `::warning::`, and
+   contains `printf '' > planner/feedback.txt`.
+3. **#2972 regression** — the related-candidate step still guards
+   `--build-search-query` and `gh search prs` (not weakened).
+4. **Essential steps stay fatal** — `Gather issue metadata` and
+   `Render planner context and instructions` contain neither `|| true` nor
+   `2>/dev/null` (enrichment hardening did not over-weaken essential steps).
+
+The regex form (`if ! bun … <mode>`) fails on the old unguarded code and passes
+on the guarded code, so it is a true regression guard.
+
+## Verification
+
+- `bun test scripts/tests/issue-planner-enrichment.bun.test.ts` (new test)
+- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/issue-planner.test.ts` (existing planner tests still pass)
+- `npx tsc --project tsconfig.scripts.json`
+- `npx eslint .github/workflows/issue-planner.yml scripts/tests/issue-planner-enrichment.bun.test.ts scripts/bun-test-manifest.ts --max-warnings 0`
+- `npx prettier --check` on all touched files
+- Workflow YAML lint passes (actionlint / yamllint via CI)
+
+## Out of scope
+
+- Any change to `issue-planner.ts` logic.
+- Model/provider/prompt quality.
+- Making the plan blocking.

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -712,6 +712,14 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
     cwd: '.',
     files: ['scripts/tests/issue-planner-confinement.bun.test.ts'],
   },
+  {
+    // Bun-native tests for the issue-planner advisory-enrichment non-fatality
+    // guards (umbrella #2984): vitest skips `*.bun.test.ts`; this runs under
+    // Bun's native runner only.
+    workspace: 'issue-planner-enrichment',
+    cwd: '.',
+    files: ['scripts/tests/issue-planner-enrichment.bun.test.ts'],
+  },
 ];
 
 /**

--- a/scripts/tests/issue-planner-enrichment.bun.test.ts
+++ b/scripts/tests/issue-planner-enrichment.bun.test.ts
@@ -41,36 +41,67 @@ function loadStepScript(stepName: string): string {
   return asString(step.run);
 }
 
+/**
+ * Assert that a command is wrapped in an `if !` guard whose condition
+ * terminates at "; then". Uses plain string indices (not a regex spanning
+ * newlines), so the assertion ties the flag to its specific guard and fails
+ * if the flag is relocated to a different command. When `flag` is empty, only
+ * the guard prefix and its "; then" terminator are checked.
+ */
+function expectFlagWithinGuard(
+  script: string,
+  guardPrefix: string,
+  flag = '',
+): void {
+  const guardStart = script.indexOf(guardPrefix);
+  expect(guardStart).toBeGreaterThanOrEqual(0);
+  const thenIdx = script.indexOf('; then', guardStart);
+  expect(thenIdx).toBeGreaterThanOrEqual(0);
+  if (flag !== '') {
+    const flagIdx = script.indexOf(flag, guardStart);
+    expect(flagIdx).toBeGreaterThan(guardStart);
+    expect(flagIdx).toBeLessThan(thenIdx);
+  }
+}
+
 describe('issue-planner advisory-enrichment non-fatality (#2984)', () => {
   it('guards --extract-linked-references with an if-fallback (#2984)', () => {
     const script = loadStepScript(
       'Extract linked references and fetch linked issues',
     );
     // The helper invocation must be wrapped so a non-zero exit degrades to an
-    // empty reference list instead of aborting under set -e.
-    expect(script).toMatch(/if\s+!\s+bun[\s\S]*?--extract-linked-references/);
+    // empty reference list instead of aborting under set -e. Anchoring the
+    // flag between "if ! bun" and "; then" proves it belongs to the guarded
+    // command and cannot pass if the flag is relocated elsewhere.
+    expectFlagWithinGuard(script, 'if ! bun', '--extract-linked-references');
     expect(script).toContain('::warning::');
     expect(script).toContain("printf '' > planner/linked-references.txt");
   });
 
   it('guards --extract-feedback with an if-fallback (#2984)', () => {
     const script = loadStepScript('Extract /plan feedback');
-    expect(script).toMatch(/if\s+!\s+bun[\s\S]*?--extract-feedback/);
+    expectFlagWithinGuard(script, 'if ! bun', '--extract-feedback');
     expect(script).toContain('::warning::');
     expect(script).toContain("printf '' > planner/feedback.txt");
   });
 
   it('does not weaken the related-candidate step guards (#2972 regression)', () => {
     const script = loadStepScript('Precompute related PRs/issues candidates');
-    expect(script).toMatch(/if\s+!\s+bun[\s\S]*?--build-search-query/);
-    expect(script).toMatch(/if\s+!\s+gh\s+search\s+prs/);
+    expectFlagWithinGuard(script, 'if ! bun', '--build-search-query');
+    expectFlagWithinGuard(script, 'if ! gh search prs');
+    expectFlagWithinGuard(script, 'if ! gh search issues');
   });
 
   it('keeps essential steps fatal (no blanket suppression)', () => {
     const gather = loadStepScript('Gather issue metadata');
     expect(gather).not.toContain('|| true');
     expect(gather).not.toContain('2>/dev/null');
+    // Essential steps must not be wrapped in the same `if !` guard that makes
+    // advisory enrichment non-fatal — that would silently swallow their errors.
+    expect(gather).not.toMatch(/if\s+!/);
     const render = loadStepScript('Render planner context and instructions');
     expect(render).not.toContain('|| true');
+    expect(render).not.toContain('2>/dev/null');
+    expect(render).not.toMatch(/if\s+!/);
   });
 });

--- a/scripts/tests/issue-planner-enrichment.bun.test.ts
+++ b/scripts/tests/issue-planner-enrichment.bun.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Bun-native regression tests for the issue-planner advisory-enrichment
+// steps (umbrella #2984, criterion: "Optional enrichment failures cannot
+// fail the run"). The `--extract-linked-references` and `--extract-feedback`
+// helper invocations previously ran unguarded under `set -euo pipefail`, so a
+// failure in either advisory step aborted the whole run. They are now wrapped
+// in `if !` guards that degrade to empty output with a `::warning::`, matching
+// the pattern established for the related-candidate step (#2972).
+//
+// These run under Bun's native runner (see scripts/bun-test-manifest.ts);
+// vitest skips `*.bun.test.ts` files (see scripts/tests/vitest.config.ts).
+
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  asString,
+  findStep,
+  parseWorkflowYaml,
+  workflowJob,
+} from './typed-test-helpers.ts';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const WORKFLOW_PATH = '.github/workflows/issue-planner.yml';
+
+function loadStepScript(stepName: string): string {
+  const source = fs.readFileSync(path.join(ROOT, WORKFLOW_PATH), 'utf8');
+  const workflow = parseWorkflowYaml(source);
+  const planJob = workflowJob(workflow, 'plan');
+  const step = findStep(planJob, stepName);
+  if (!step?.run) {
+    throw new Error(
+      `Step "${stepName}" (or its run script) not found in ${WORKFLOW_PATH}; the step may have been renamed.`,
+    );
+  }
+  return asString(step.run);
+}
+
+describe('issue-planner advisory-enrichment non-fatality (#2984)', () => {
+  it('guards --extract-linked-references with an if-fallback (#2984)', () => {
+    const script = loadStepScript(
+      'Extract linked references and fetch linked issues',
+    );
+    // The helper invocation must be wrapped so a non-zero exit degrades to an
+    // empty reference list instead of aborting under set -e.
+    expect(script).toMatch(/if\s+!\s+bun[\s\S]*?--extract-linked-references/);
+    expect(script).toContain('::warning::');
+    expect(script).toContain("printf '' > planner/linked-references.txt");
+  });
+
+  it('guards --extract-feedback with an if-fallback (#2984)', () => {
+    const script = loadStepScript('Extract /plan feedback');
+    expect(script).toMatch(/if\s+!\s+bun[\s\S]*?--extract-feedback/);
+    expect(script).toContain('::warning::');
+    expect(script).toContain("printf '' > planner/feedback.txt");
+  });
+
+  it('does not weaken the related-candidate step guards (#2972 regression)', () => {
+    const script = loadStepScript('Precompute related PRs/issues candidates');
+    expect(script).toMatch(/if\s+!\s+bun[\s\S]*?--build-search-query/);
+    expect(script).toMatch(/if\s+!\s+gh\s+search\s+prs/);
+  });
+
+  it('keeps essential steps fatal (no blanket suppression)', () => {
+    const gather = loadStepScript('Gather issue metadata');
+    expect(gather).not.toContain('|| true');
+    expect(gather).not.toContain('2>/dev/null');
+    const render = loadStepScript('Render planner context and instructions');
+    expect(render).not.toContain('|| true');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2984 (umbrella: "make the Issue Planner workflow reliable") by closing its last open acceptance criterion: **optional enrichment failures cannot fail the run.**

Both enumerated child defects were already fixed (#2960 confinement symlinks, #2972 search-query interpolation + concurrency), but two advisory-enrichment helper invocations still ran **unguarded** under `set -euo pipefail`, so a failure in either aborted the whole job.

## What changed

`.github/workflows/issue-planner.yml` — wrapped the two advisory helper calls in `if !` guards that degrade to empty output with a visible `::warning::`, exactly mirroring the #2972 related-candidate pattern:

- **`--extract-linked-references`** (step "Extract linked references and fetch linked issues") → on failure, writes empty `planner/linked-references.txt` so the downstream `mapfile` reads no linked issues.
- **`--extract-feedback`** (step "Extract /plan feedback") → on failure, writes empty `planner/feedback.txt` so `--render-context` treats feedback as absent.

Essential steps (**gather metadata, render context, confine filesystem, run planner agent**) are deliberately left fatal — they are not advisory enrichment, and the visible-failure contract depends on their ability to abort the run.

## Why this pattern

These steps are advisory context enrichment, not essential to producing a plan. Their downstream consumers already tolerate empty output. The `if !`/`::warning::`/empty-fallback pattern is the same one already used (and reviewed) for the related-candidate precompute step in #2972.

## Tests

New **bun-native** test file `scripts/tests/issue-planner-enrichment.bun.test.ts` (TS, `bun:test` — no vitest/node/js), registered in `scripts/bun-test-manifest.ts`:

1. `--extract-linked-references` is guarded (`if !` + `::warning::` + empty fallback).
2. `--extract-feedback` is guarded (`if !` + `::warning::` + empty fallback).
3. The #2972 related-candidate guards (`--build-search-query`, `gh search prs`) are **unchanged** (no regression).
4. Essential steps (`Gather issue metadata`, `Render planner context and instructions`) contain no `|| true` / `2>/dev/null` — not blanket-suppressed.

The regex guards fail on the old unguarded code and pass on the new code, so they are true regression tests.

## Verification

- `bun test scripts/tests/issue-planner-enrichment.bun.test.ts` → 4 pass, 0 fail
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/issue-planner.test.ts` → 60 pass / 1 known win32-only env-fail (confinement chmod test, passes on ubuntu CI; pre-existing, out of scope)
- `npx tsc --project tsconfig.scripts.json` → clean
- `npx eslint ... --max-warnings 0` → exit 0
- `npx prettier --check` → clean
- OpenCodeReview (local) → **0 findings across 3 files**

## Umbrella #2984 acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Child defects (#2960, #2972) closed | ✅ |
| 2 | Adversarial issue titles succeed | ✅ (#2972 sanitizer) |
| 3 | No title/body shell interpolation | ✅ (env-var + quoted query) |
| 4 | Optional enrichment degrades to empty, never aborts | ✅ **(this PR)** |
| 5 | Concurrency collapses opened+labeled runs | ✅ (#2972) |
| 6 | Failure visible via infra-failure comment | ✅ |
| 7 | Regression tests exist | ✅ (#2960, #2972, this PR) |

This PR satisfies criterion #4, the last open item, and closes the umbrella.

Closes #2984.
