### PR TITLE
Provider-aware image token estimation for context window management (Fixes #1648)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -4778,7 +4778,7 @@ jobs:
             if (outOfDiffRouted.length > 0) {
               body.push('', '### Findings outside the PR diff', '');
               for (const f of outOfDiffRouted) {
-                const where = f && f.path ? ``${f.path}`: ` : '';
+                const where = f && f.path ? `\`${f.path}\`: ` : '';
                 const label = categorySeverityLabel(f);
                 const rawText = f.content || f.comment || f.message || f.body;
                 const text = renderFindingText(typeof rawText === 'string' ? rawText : 'OCR finding');

--- a/packages/agents/src/compression/TopDownTruncationStrategy.test.ts
+++ b/packages/agents/src/compression/TopDownTruncationStrategy.test.ts
@@ -26,6 +26,7 @@ import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/Ag
 import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
 import type { Logger } from '@vybestack/llxprt-code-core/core/logger.js';
 import type { PromptResolver } from '@vybestack/llxprt-code-core/prompt-config/prompt-resolver.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { TopDownTruncationStrategy } from './TopDownTruncationStrategy.js';
 
 // ---------------------------------------------------------------------------
@@ -651,5 +652,122 @@ describe('TopDownTruncationStrategy', () => {
       expect(result.metadata.compressedMessageCount).toBe(0);
       expect(result.metadata.llmCallMade).toBe(false);
     });
+  });
+});
+
+describe('TopDownTruncationStrategy image token accounting', () => {
+  const IMAGE_WIDTH = 1092;
+  const IMAGE_HEIGHT = 1092;
+
+  function pngBase64(width: number, height: number): string {
+    const buf = Buffer.alloc(24);
+    buf[0] = 0x89;
+    buf[1] = 0x50;
+    buf[2] = 0x4e;
+    buf[3] = 0x47;
+    buf[4] = 0x0d;
+    buf[5] = 0x0a;
+    buf[6] = 0x1a;
+    buf[7] = 0x0a;
+    buf.write('IHDR', 12, 'ascii');
+    buf.writeUInt32BE(width, 16);
+    buf.writeUInt32BE(height, 20);
+    return buf.toString('base64');
+  }
+
+  /** Wire the real HistoryService estimator exactly as CompressionHandler does. */
+  function realEstimator(
+    provider: string,
+  ): (contents: readonly IContent[]) => Promise<number> {
+    const history = new HistoryService();
+    history.setActiveTokenizationTarget('claude-sonnet-4-20250514', provider);
+    return (contents) =>
+      history.estimateTokensForContents(contents as IContent[]);
+  }
+
+  /** Twelve messages of ~500 estimated tokens each. */
+  function textHistory(): IContent[] {
+    return Array.from({ length: 12 }, (_, i) => ({
+      speaker: i % 2 === 0 ? ('human' as const) : ('ai' as const),
+      blocks: [{ type: 'text' as const, text: 'x'.repeat(2000) }],
+    }));
+  }
+
+  function withTrailingImage(history: IContent[]): IContent[] {
+    const copy = history.map((content) => ({
+      ...content,
+      blocks: [...content.blocks],
+    }));
+    const last = copy[copy.length - 1];
+    last.blocks = [
+      ...last.blocks,
+      {
+        type: 'media' as const,
+        mimeType: 'image/png',
+        encoding: 'base64' as const,
+        data: pngBase64(IMAGE_WIDTH, IMAGE_HEIGHT),
+      },
+    ];
+    return copy;
+  }
+
+  it('truncates more aggressively when the history contains an image', async () => {
+    const strategy = new TopDownTruncationStrategy();
+    const estimateTokens = realEstimator('anthropic');
+
+    const textOnly = await strategy.compress(
+      buildContext({
+        history: textHistory(),
+        contextLimit: 10000,
+        compressionThreshold: 0.8,
+        currentTokenCount: 9000,
+        estimateTokens,
+      }),
+    );
+    const withImage = await strategy.compress(
+      buildContext({
+        history: withTrailingImage(textHistory()),
+        contextLimit: 10000,
+        compressionThreshold: 0.8,
+        currentTokenCount: 9000,
+        estimateTokens,
+      }),
+    );
+
+    expect(textOnly.kind).toBe('applied');
+    expect(withImage.kind).toBe('applied');
+    expect(withImage.metadata.compressedMessageCount).toBeLessThan(
+      textOnly.metadata.compressedMessageCount,
+    );
+  });
+
+  it('charges an image according to the active provider', async () => {
+    const strategy = new TopDownTruncationStrategy();
+    const history = withTrailingImage(textHistory());
+
+    const anthropic = await strategy.compress(
+      buildContext({
+        history,
+        contextLimit: 10000,
+        compressionThreshold: 0.8,
+        currentTokenCount: 9000,
+        estimateTokens: realEstimator('anthropic'),
+      }),
+    );
+    const unknownProvider = await strategy.compress(
+      buildContext({
+        history,
+        contextLimit: 10000,
+        compressionThreshold: 0.8,
+        currentTokenCount: 9000,
+        estimateTokens: realEstimator('stepfun'),
+      }),
+    );
+
+    // Anthropic charges 1590 tokens for a 1092x1092 image; an unrecognised
+    // provider charges the 1000-token default, so it can retain more history.
+    expect(anthropic.metadata.compressedMessageCount).toBeLessThan(
+      unknownProvider.metadata.compressedMessageCount,
+    );
   });
 });

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -587,6 +587,7 @@ export class HistoryService
     return {
       getTokenizerForModel: (modelName: string) =>
         this.getTokenizerForModel(modelName, this.activeTokenizationProvider),
+      activeProvider: this.activeTokenizationProvider,
     };
   }
 

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -815,6 +815,7 @@ export class HistoryService
       const tokenizerProvider: TokenizerProvider = {
         getTokenizerForModel: (targetModel) =>
           this.getTokenizerForModel(targetModel, activeProvider),
+        activeProvider,
       };
 
       for (const entry of this.history) {

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -583,11 +583,13 @@ export class HistoryService
   }
 
   /** Provide the TokenizerProvider interface for the token estimation helpers. */
-  private tokenizerProvider(): TokenizerProvider {
+  private tokenizerProvider(
+    activeProvider = this.activeTokenizationProvider,
+  ): TokenizerProvider {
     return {
       getTokenizerForModel: (modelName: string) =>
-        this.getTokenizerForModel(modelName, this.activeTokenizationProvider),
-      activeProvider: this.activeTokenizationProvider,
+        this.getTokenizerForModel(modelName, activeProvider),
+      activeProvider,
     };
   }
 
@@ -812,11 +814,7 @@ export class HistoryService
   ): Promise<void> {
     return this.runSerializedTokenOperation(async () => {
       let newTotal = 0;
-      const tokenizerProvider: TokenizerProvider = {
-        getTokenizerForModel: (targetModel) =>
-          this.getTokenizerForModel(targetModel, activeProvider),
-        activeProvider,
-      };
+      const tokenizerProvider = this.tokenizerProvider(activeProvider);
 
       for (const entry of this.history) {
         const entryTokens = await estimateContentTokensImpl(

--- a/packages/core/src/services/history/historyTokenEstimation.compressionEvidence.test.ts
+++ b/packages/core/src/services/history/historyTokenEstimation.compressionEvidence.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { HistoryService } from './HistoryService.js';
+import type { IContent, MediaBlock } from './IContent.js';
+import { estimateImageTokens } from '@vybestack/llxprt-code-tools/utils/imageTokenEstimation.js';
+import { parseImageDimensionsFromBase64 } from '@vybestack/llxprt-code-tools/utils/imageDimensions.js';
+
+function buildPngBase64(width: number, height: number): string {
+  const buf = Buffer.alloc(24);
+  buf[0] = 0x89;
+  buf[1] = 0x50;
+  buf[2] = 0x4e;
+  buf[3] = 0x47;
+  buf[4] = 0x0d;
+  buf[5] = 0x0a;
+  buf[6] = 0x1a;
+  buf[7] = 0x0a;
+  buf.write('IHDR', 12, 'ascii');
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf.toString('base64');
+}
+
+function imageContent(): IContent {
+  const b64 = buildPngBase64(1092, 1092);
+  const block: MediaBlock = {
+    type: 'media',
+    mimeType: 'image/png',
+    encoding: 'base64',
+    data: b64,
+  };
+  return { speaker: 'human', blocks: [block] };
+}
+
+describe('HistoryService.estimateTokensForContents — image token evidence', () => {
+  it('returns materially more tokens for history containing an image', async () => {
+    const svc = new HistoryService();
+    svc.setActiveTokenizationTarget('claude-sonnet-4-20250514', 'anthropic');
+
+    const withImage = [imageContent()];
+    const withoutImage: IContent[] = [];
+
+    const tokensWith = await svc.estimateTokensForContents(withImage);
+    const tokensWithout = await svc.estimateTokensForContents(withoutImage);
+
+    expect(tokensWith).toBeGreaterThan(tokensWithout);
+  });
+
+  it('the delta matches the estimator for the configured provider', async () => {
+    const svc = new HistoryService();
+    svc.setActiveTokenizationTarget('claude-sonnet-4-20250514', 'anthropic');
+
+    const content = [imageContent()];
+    // The 1092x1092 PNG costs 1590 tokens on Anthropic (published reference).
+    const expectedImageTokens = 1590;
+
+    const tokensWith = await svc.estimateTokensForContents(content);
+    const tokensWithout = await svc.estimateTokensForContents([]);
+
+    expect(tokensWith - tokensWithout).toBe(expectedImageTokens);
+  });
+
+  it('varies the image token delta by provider', async () => {
+    const content = [imageContent()];
+    const b64 = (content[0].blocks[0] as MediaBlock).data;
+    const dims = parseImageDimensionsFromBase64(b64);
+
+    const svcAnthropic = new HistoryService();
+    svcAnthropic.setActiveTokenizationTarget(
+      'claude-sonnet-4-20250514',
+      'anthropic',
+    );
+    const anthropicDelta =
+      (await svcAnthropic.estimateTokensForContents(content)) -
+      (await svcAnthropic.estimateTokensForContents([]));
+
+    const svcOpenai = new HistoryService();
+    svcOpenai.setActiveTokenizationTarget('gpt-4o', 'openai');
+    const openaiDelta =
+      (await svcOpenai.estimateTokensForContents(content)) -
+      (await svcOpenai.estimateTokensForContents([]));
+
+    expect(anthropicDelta).toBe(
+      estimateImageTokens({ provider: 'anthropic', dimensions: dims }),
+    );
+    expect(openaiDelta).toBe(
+      estimateImageTokens({ provider: 'openai', dimensions: dims }),
+    );
+    expect(anthropicDelta).not.toBe(openaiDelta);
+  });
+});

--- a/packages/core/src/services/history/historyTokenEstimation.compressionEvidence.test.ts
+++ b/packages/core/src/services/history/historyTokenEstimation.compressionEvidence.test.ts
@@ -17,7 +17,6 @@
 import { describe, expect, it } from 'bun:test';
 import { HistoryService } from './HistoryService.js';
 import type { IContent, MediaBlock } from './IContent.js';
-import { estimateImageTokens } from '@vybestack/llxprt-code-tools/utils/imageTokenEstimation.js';
 import { parseImageDimensionsFromBase64 } from '@vybestack/llxprt-code-tools/utils/imageDimensions.js';
 
 function buildPngBase64(width: number, height: number): string {
@@ -36,13 +35,14 @@ function buildPngBase64(width: number, height: number): string {
   return buf.toString('base64');
 }
 
-function imageContent(): IContent {
+function imageContent(caption?: string): IContent {
   const b64 = buildPngBase64(1092, 1092);
   const block: MediaBlock = {
     type: 'media',
     mimeType: 'image/png',
     encoding: 'base64',
     data: b64,
+    caption,
   };
   return { speaker: 'human', blocks: [block] };
 }
@@ -52,13 +52,19 @@ describe('HistoryService.estimateTokensForContents — image token evidence', ()
     const svc = new HistoryService();
     svc.setActiveTokenizationTarget('claude-sonnet-4-20250514', 'anthropic');
 
-    const withImage = [imageContent()];
-    const withoutImage: IContent[] = [];
+    const caption = 'a screenshot of the failing build';
+    const withImage = [imageContent(caption)];
+    const withoutImage: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: caption }] },
+    ];
 
     const tokensWith = await svc.estimateTokensForContents(withImage);
     const tokensWithout = await svc.estimateTokensForContents(withoutImage);
 
-    expect(tokensWith).toBeGreaterThan(tokensWithout);
+    // The identical caption text is present in both, so the whole difference is
+    // the 1590-token cost of the 1092x1092 image on Anthropic.
+    expect(tokensWithout).toBeGreaterThan(0);
+    expect(tokensWith - tokensWithout).toBe(1590);
   });
 
   it('the delta matches the estimator for the configured provider', async () => {
@@ -78,7 +84,12 @@ describe('HistoryService.estimateTokensForContents — image token evidence', ()
   it('varies the image token delta by provider', async () => {
     const content = [imageContent()];
     const b64 = (content[0].blocks[0] as MediaBlock).data;
-    const dims = parseImageDimensionsFromBase64(b64);
+    // Guard the fixture: a dimensionless payload would silently collapse both
+    // providers onto their unknown-dimension constants.
+    expect(parseImageDimensionsFromBase64(b64)).toEqual({
+      width: 1092,
+      height: 1092,
+    });
 
     const svcAnthropic = new HistoryService();
     svcAnthropic.setActiveTokenizationTarget(
@@ -95,12 +106,9 @@ describe('HistoryService.estimateTokensForContents — image token evidence', ()
       (await svcOpenai.estimateTokensForContents(content)) -
       (await svcOpenai.estimateTokensForContents([]));
 
-    expect(anthropicDelta).toBe(
-      estimateImageTokens({ provider: 'anthropic', dimensions: dims }),
-    );
-    expect(openaiDelta).toBe(
-      estimateImageTokens({ provider: 'openai', dimensions: dims }),
-    );
-    expect(anthropicDelta).not.toBe(openaiDelta);
+    // 1092x1092: Anthropic charges ceil(1092*1092/750) = 1590; OpenAI high
+    // detail normalises to 768x768 = 4 tiles -> 170*4 + 85 = 765.
+    expect(anthropicDelta).toBe(1590);
+    expect(openaiDelta).toBe(765);
   });
 });

--- a/packages/core/src/services/history/historyTokenEstimation.imageTokens.test.ts
+++ b/packages/core/src/services/history/historyTokenEstimation.imageTokens.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  estimateContentTokens,
+  type TokenizerProvider,
+} from './historyTokenEstimation.js';
+import type { IContent, MediaBlock } from './IContent.js';
+import type { RuntimeTokenizer } from '../../runtime/contracts/RuntimeTokenizer.js';
+import type { DebugLogger } from '../../debug/index.js';
+import { estimateImageTokens } from '@vybestack/llxprt-code-tools/utils/imageTokenEstimation.js';
+import { parseImageDimensionsFromBase64 } from '@vybestack/llxprt-code-tools/utils/imageDimensions.js';
+
+const noopLogger: DebugLogger = {
+  debug: () => {},
+  error: () => {},
+  warn: () => {},
+  info: () => {},
+} as unknown as DebugLogger;
+
+/**
+ * A REAL tokenizer that counts deterministically (length / 4), so assertions
+ * exercise genuine arithmetic on the caption text rather than a canned total.
+ */
+function makeLengthTokenizer(): RuntimeTokenizer {
+  return {
+    fallbackPolicy: 'allow',
+    countTokens: (content: unknown) => Math.ceil(String(content).length / 4),
+  };
+}
+
+function providerWith(activeProvider?: string): TokenizerProvider {
+  return {
+    getTokenizerForModel: () => makeLengthTokenizer(),
+    activeProvider,
+  };
+}
+
+function buildPngBase64(width: number, height: number): string {
+  const buf = Buffer.alloc(24);
+  buf[0] = 0x89;
+  buf[1] = 0x50;
+  buf[2] = 0x4e;
+  buf[3] = 0x47;
+  buf[4] = 0x0d;
+  buf[5] = 0x0a;
+  buf[6] = 0x1a;
+  buf[7] = 0x0a;
+  buf.write('IHDR', 12, 'ascii');
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf.toString('base64');
+}
+
+function mediaBlock(
+  overrides: Partial<MediaBlock> & { data: string },
+): MediaBlock {
+  return {
+    type: 'media',
+    mimeType: 'image/png',
+    encoding: 'base64',
+    ...overrides,
+  };
+}
+
+describe('estimateContentTokens — image media blocks', () => {
+  it('adds the anthropic image estimate to the caption tokens for base64 images', async () => {
+    const caption = 'a diagram of the system';
+    const b64 = buildPngBase64(1092, 1092);
+    const content: IContent = {
+      speaker: 'human',
+      blocks: [mediaBlock({ data: b64, caption })],
+    };
+    // 1092x1092 costs 1590 tokens on Anthropic (published reference value).
+    const expected = Math.ceil(caption.length / 4) + 1590;
+
+    const total = await estimateContentTokens(
+      content,
+      'claude-sonnet',
+      providerWith('anthropic'),
+      noopLogger,
+    );
+
+    expect(total).toBe(expected);
+    expect(total).toBeGreaterThan(Math.ceil(caption.length / 4));
+  });
+
+  it('produces different totals for openai vs gemini for the same image', async () => {
+    const b64 = buildPngBase64(1024, 1024);
+    const content: IContent = {
+      speaker: 'human',
+      blocks: [mediaBlock({ data: b64 })],
+    };
+
+    const openaiTotal = await estimateContentTokens(
+      content,
+      'gpt-4o',
+      providerWith('openai'),
+      noopLogger,
+    );
+    const flatFamilyTotal = await estimateContentTokens(
+      content,
+      'gemini-2.5-pro',
+      providerWith('gemini'),
+      noopLogger,
+    );
+
+    expect(openaiTotal).not.toBe(flatFamilyTotal);
+  });
+
+  it('uses the unknown-dimension constant for url-encoded image media', async () => {
+    const content: IContent = {
+      speaker: 'human',
+      blocks: [
+        mediaBlock({
+          data: 'https://example.com/image.png',
+          encoding: 'url',
+          mimeType: 'image/png',
+        }),
+      ],
+    };
+
+    const total = await estimateContentTokens(
+      content,
+      'claude-sonnet',
+      providerWith('anthropic'),
+      noopLogger,
+    );
+
+    expect(total).toBe(1590);
+  });
+
+  it('keeps caption-only behaviour for non-image media (audio)', async () => {
+    const caption = 'voice memo transcript';
+    const content: IContent = {
+      speaker: 'human',
+      blocks: [
+        mediaBlock({
+          data: 'aGVsbG8=',
+          mimeType: 'audio/mpeg',
+          caption,
+        }),
+      ],
+    };
+    const expected = Math.ceil(caption.length / 4);
+
+    const total = await estimateContentTokens(
+      content,
+      'claude-sonnet',
+      providerWith('anthropic'),
+      noopLogger,
+    );
+
+    expect(total).toBe(expected);
+  });
+
+  it('adds text tokens and image tokens together for mixed content', async () => {
+    const text = 'look at this photo of a cat';
+    const caption = 'a fluffy cat';
+    const b64 = buildPngBase64(200, 200);
+    const content: IContent = {
+      speaker: 'human',
+      blocks: [{ type: 'text', text }, mediaBlock({ data: b64, caption })],
+    };
+    const textTokens =
+      Math.ceil(text.length / 4) + Math.ceil(caption.length / 4);
+    const imageTokens = estimateImageTokens({
+      provider: 'anthropic',
+      dimensions: parseImageDimensionsFromBase64(b64),
+    });
+
+    const total = await estimateContentTokens(
+      content,
+      'claude-sonnet',
+      providerWith('anthropic'),
+      noopLogger,
+    );
+
+    expect(total).toBe(textTokens + imageTokens);
+  });
+
+  it('defaults to the 1000 default family when provider is unknown/absent', async () => {
+    const b64 = buildPngBase64(1024, 1024);
+    const content: IContent = {
+      speaker: 'human',
+      blocks: [mediaBlock({ data: b64 })],
+    };
+
+    const total = await estimateContentTokens(
+      content,
+      'stepfun-37',
+      providerWith('stepfun'),
+      noopLogger,
+    );
+
+    expect(total).toBe(1000);
+
+    const totalNoProvider = await estimateContentTokens(
+      content,
+      'stepfun-37',
+      providerWith(undefined),
+      noopLogger,
+    );
+    expect(totalNoProvider).toBe(1000);
+  });
+
+  it('counts an image with no caption as the image estimate only', async () => {
+    const b64 = buildPngBase64(1024, 1024);
+    const content: IContent = {
+      speaker: 'human',
+      blocks: [mediaBlock({ data: b64 })],
+    };
+    // 1024x1024 costs 765 tokens on OpenAI high detail (published reference).
+    const expected = 765;
+
+    const total = await estimateContentTokens(
+      content,
+      'gpt-4o',
+      providerWith('openai'),
+      noopLogger,
+    );
+
+    expect(total).toBe(expected);
+  });
+});

--- a/packages/core/src/services/history/historyTokenEstimation.imageTokens.test.ts
+++ b/packages/core/src/services/history/historyTokenEstimation.imageTokens.test.ts
@@ -22,8 +22,6 @@ import {
 import type { IContent, MediaBlock } from './IContent.js';
 import type { RuntimeTokenizer } from '../../runtime/contracts/RuntimeTokenizer.js';
 import type { DebugLogger } from '../../debug/index.js';
-import { estimateImageTokens } from '@vybestack/llxprt-code-tools/utils/imageTokenEstimation.js';
-import { parseImageDimensionsFromBase64 } from '@vybestack/llxprt-code-tools/utils/imageDimensions.js';
 
 const noopLogger: DebugLogger = {
   debug: () => {},
@@ -119,7 +117,10 @@ describe('estimateContentTokens — image media blocks', () => {
       noopLogger,
     );
 
-    expect(openaiTotal).not.toBe(flatFamilyTotal);
+    // 1024x1024 high detail: 2x2 tiles * 170 + 85 base.
+    expect(openaiTotal).toBe(765);
+    // The flat family charges a fixed estimate regardless of dimensions.
+    expect(flatFamilyTotal).toBe(3000);
   });
 
   it('uses the unknown-dimension constant for url-encoded image media', async () => {
@@ -178,10 +179,8 @@ describe('estimateContentTokens — image media blocks', () => {
     };
     const textTokens =
       Math.ceil(text.length / 4) + Math.ceil(caption.length / 4);
-    const imageTokens = estimateImageTokens({
-      provider: 'anthropic',
-      dimensions: parseImageDimensionsFromBase64(b64),
-    });
+    // 200x200 on Anthropic: ceil(200 * 200 / 750) = 54 (published reference).
+    const imageTokens = 54;
 
     const total = await estimateContentTokens(
       content,

--- a/packages/core/src/services/history/historyTokenEstimation.ts
+++ b/packages/core/src/services/history/historyTokenEstimation.ts
@@ -126,10 +126,7 @@ function estimateMediaBlockImageTokens(
   block: MediaBlock,
   provider: string | undefined,
 ): number {
-  // Media blocks can be rehydrated from persisted sessions, where the MIME
-  // type may be absent despite the declared type.
-  const isImage = block.mimeType?.toLowerCase().startsWith('image/') ?? false;
-  if (!isImage) return 0;
+  if (!block.mimeType.toLowerCase().startsWith('image/')) return 0;
   const dimensions =
     block.encoding === 'base64'
       ? parseImageDimensionsFromBase64(block.data)

--- a/packages/core/src/services/history/historyTokenEstimation.ts
+++ b/packages/core/src/services/history/historyTokenEstimation.ts
@@ -126,7 +126,10 @@ function estimateMediaBlockImageTokens(
   block: MediaBlock,
   provider: string | undefined,
 ): number {
-  if (!block.mimeType.toLowerCase().startsWith('image/')) return 0;
+  // Media blocks can be rehydrated from persisted sessions, where the MIME
+  // type may be absent despite the declared type.
+  const isImage = block.mimeType?.toLowerCase().startsWith('image/') ?? false;
+  if (!isImage) return 0;
   const dimensions =
     block.encoding === 'base64'
       ? parseImageDimensionsFromBase64(block.data)

--- a/packages/core/src/services/history/historyTokenEstimation.ts
+++ b/packages/core/src/services/history/historyTokenEstimation.ts
@@ -17,11 +17,14 @@
 import type {
   ContentBlock,
   IContent,
+  MediaBlock,
   ToolCallBlock,
   ToolResponseBlock,
 } from './IContent.js';
 import type { DebugLogger } from '../../debug/index.js';
 import type { RuntimeTokenizer as ITokenizer } from '../../runtime/contracts/RuntimeTokenizer.js';
+import { parseImageDimensionsFromBase64 } from '@vybestack/llxprt-code-tools/utils/imageDimensions.js';
+import { estimateImageTokens } from '@vybestack/llxprt-code-tools/utils/imageTokenEstimation.js';
 
 /**
  * Resolve the effective model name. An active target model always wins over
@@ -106,6 +109,29 @@ export function serializeWireContentForEstimate(content: IContent): string {
 /** Abstraction over HistoryService's tokenizer lookup. */
 export interface TokenizerProvider {
   getTokenizerForModel(modelName: string): ITokenizer;
+  /**
+   * The active provider name (e.g. 'anthropic', 'openai', 'gemini'), used to
+   * pick the correct image token estimation family. Optional for callers that
+   * have no provider context (defaults to the 'default' family).
+   */
+  readonly activeProvider?: string;
+}
+
+/**
+ * Estimate the image token cost of a base64/URL media block for the given
+ * provider family. This is independent of the text tokenizer and cannot throw,
+ * so it is added outside the tokenizer try/catch in {@link estimateContentTokens}.
+ */
+function estimateMediaBlockImageTokens(
+  block: MediaBlock,
+  provider: string | undefined,
+): number {
+  if (!block.mimeType.toLowerCase().startsWith('image/')) return 0;
+  const dimensions =
+    block.encoding === 'base64'
+      ? parseImageDimensionsFromBase64(block.data)
+      : undefined;
+  return estimateImageTokens({ provider, dimensions });
 }
 
 /**
@@ -121,6 +147,12 @@ export async function estimateContentTokens(
   let totalTokens = 0;
 
   for (const block of content.blocks) {
+    if (block.type === 'media') {
+      totalTokens += estimateMediaBlockImageTokens(
+        block,
+        tokenizerProvider.activeProvider,
+      );
+    }
     const blockText = blockToEstimationText(block, logger);
     if (!blockText) {
       continue;

--- a/packages/providers/src/loadBalancing/loadBalancerTokenEstimator.imageTokens.test.ts
+++ b/packages/providers/src/loadBalancing/loadBalancerTokenEstimator.imageTokens.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'bun:test';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { estimateRequestTokens } from './loadBalancerTokenEstimator.js';
 

--- a/packages/providers/src/loadBalancing/loadBalancerTokenEstimator.imageTokens.test.ts
+++ b/packages/providers/src/loadBalancing/loadBalancerTokenEstimator.imageTokens.test.ts
@@ -67,10 +67,10 @@ describe('estimateRequestTokens image accounting', () => {
   });
 
   it('varies the image charge with the selected provider', async () => {
-    const anthropic = await estimateRequestTokens(
-      withImage(),
-      'anthropic',
-      'claude-sonnet-4-20250514',
+    const baseline = await estimateRequestTokens(
+      textOnly(),
+      'openai',
+      'gpt-4o',
       {},
     );
     const openai = await estimateRequestTokens(
@@ -86,7 +86,9 @@ describe('estimateRequestTokens image accounting', () => {
       {},
     );
 
-    expect(anthropic.tokens).not.toBe(openai.tokens);
-    expect(anthropic.tokens).not.toBe(unknown.tokens);
+    // 1092x1092 normalises to 768x768 = 4 tiles -> 170*4 + 85.
+    expect(openai.tokens - baseline.tokens).toBe(765);
+    // An unrecognised provider falls back to the flat default estimate.
+    expect(unknown.tokens - baseline.tokens).toBe(1000);
   });
 });

--- a/packages/providers/src/loadBalancing/loadBalancerTokenEstimator.imageTokens.test.ts
+++ b/packages/providers/src/loadBalancing/loadBalancerTokenEstimator.imageTokens.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { estimateRequestTokens } from './loadBalancerTokenEstimator.js';
+
+function pngBase64(width: number, height: number): string {
+  const buf = Buffer.alloc(24);
+  buf[0] = 0x89;
+  buf[1] = 0x50;
+  buf[2] = 0x4e;
+  buf[3] = 0x47;
+  buf[4] = 0x0d;
+  buf[5] = 0x0a;
+  buf[6] = 0x1a;
+  buf[7] = 0x0a;
+  buf.write('IHDR', 12, 'ascii');
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf.toString('base64');
+}
+
+function textOnly(): IContent[] {
+  return [
+    { speaker: 'human', blocks: [{ type: 'text', text: 'describe this' }] },
+  ];
+}
+
+function withImage(): IContent[] {
+  return [
+    {
+      speaker: 'human',
+      blocks: [
+        { type: 'text', text: 'describe this' },
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          encoding: 'base64',
+          data: pngBase64(1092, 1092),
+        },
+      ],
+    },
+  ];
+}
+
+describe('estimateRequestTokens image accounting', () => {
+  it('charges the selected provider formula for an image', async () => {
+    const baseline = await estimateRequestTokens(
+      textOnly(),
+      'anthropic',
+      'claude-sonnet-4-20250514',
+      {},
+    );
+    const withMedia = await estimateRequestTokens(
+      withImage(),
+      'anthropic',
+      'claude-sonnet-4-20250514',
+      {},
+    );
+
+    // A 1092x1092 image costs 1590 tokens on Anthropic.
+    expect(withMedia.tokens - baseline.tokens).toBe(1590);
+  });
+
+  it('varies the image charge with the selected provider', async () => {
+    const anthropic = await estimateRequestTokens(
+      withImage(),
+      'anthropic',
+      'claude-sonnet-4-20250514',
+      {},
+    );
+    const openai = await estimateRequestTokens(
+      withImage(),
+      'openai',
+      'gpt-4o',
+      {},
+    );
+    const unknown = await estimateRequestTokens(
+      withImage(),
+      'stepfun',
+      'step-3.7-flash',
+      {},
+    );
+
+    expect(anthropic.tokens).not.toBe(openai.tokens);
+    expect(anthropic.tokens).not.toBe(unknown.tokens);
+  });
+});

--- a/packages/providers/src/loadBalancing/loadBalancerTokenEstimator.ts
+++ b/packages/providers/src/loadBalancing/loadBalancerTokenEstimator.ts
@@ -45,6 +45,8 @@ export interface LoadBalancerEstimatorDeps {
 }
 
 class GenericTokenizerProvider implements TokenizerProvider {
+  constructor(readonly activeProvider: string | undefined) {}
+
   getTokenizerForModel(_modelName: string): ITokenizer {
     return {
       countTokens: (text: unknown) =>
@@ -53,13 +55,13 @@ class GenericTokenizerProvider implements TokenizerProvider {
   }
 }
 
-const genericTokenizerProvider = new GenericTokenizerProvider();
-
 function createTokenizerAdapter(
   runtimeTokenizer: ITokenizer,
+  activeProvider: string,
 ): TokenizerProvider {
   return {
     getTokenizerForModel: () => runtimeTokenizer,
+    activeProvider,
   };
 }
 
@@ -87,7 +89,12 @@ export async function estimateRequestTokens(
 
   if (tokenizer) {
     try {
-      return await estimateWithTokenizer(contents, modelName, tokenizer);
+      return await estimateWithTokenizer(
+        contents,
+        modelName,
+        tokenizer,
+        providerName,
+      );
     } catch (error) {
       if (tokenizer.fallbackPolicy === 'deny') {
         throw error;
@@ -106,7 +113,7 @@ export async function estimateRequestTokens(
     );
   }
 
-  const result = await estimateWithGeneric(contents);
+  const result = await estimateWithGeneric(contents, providerName);
   return {
     ...result,
     source: `${result.source} (tokenizer unavailable: ${tokenizerFailureModel})`,
@@ -117,8 +124,9 @@ async function estimateWithTokenizer(
   contents: IContent[],
   modelName: string,
   tokenizer: ITokenizer,
+  providerName: string,
 ): Promise<EstimationResult> {
-  const tokenizerProvider = createTokenizerAdapter(tokenizer);
+  const tokenizerProvider = createTokenizerAdapter(tokenizer, providerName);
   const tokens = await estimateTokensForContents(
     contents,
     modelName,
@@ -323,12 +331,13 @@ function estimateRawContentTokens(contents: IContent[]): number {
 
 async function estimateWithGeneric(
   contents: IContent[],
+  providerName?: string,
 ): Promise<EstimationResult> {
   try {
     const tokens = await estimateTokensForContents(
       contents,
       undefined,
-      genericTokenizerProvider,
+      new GenericTokenizerProvider(providerName),
       logger,
     );
     return {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -51,6 +51,16 @@
       "bun": "./src/utils/fetch.ts",
       "import": "./dist/src/utils/fetch.js"
     },
+    "./utils/imageDimensions.js": {
+      "types": "./dist/src/utils/imageDimensions.d.ts",
+      "bun": "./src/utils/imageDimensions.ts",
+      "import": "./dist/src/utils/imageDimensions.js"
+    },
+    "./utils/imageTokenEstimation.js": {
+      "types": "./dist/src/utils/imageTokenEstimation.d.ts",
+      "bun": "./src/utils/imageTokenEstimation.ts",
+      "import": "./dist/src/utils/imageTokenEstimation.js"
+    },
     "./textDelta.js": {
       "types": "./dist/src/utils/textDelta.d.ts",
       "bun": "./src/utils/textDelta.ts",

--- a/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
+++ b/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
@@ -13,6 +13,7 @@ import sharp from 'sharp';
 import { createRealToolHost as createRealHost } from './helpers/create-real-tool-host.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
 import type { ToolResult } from '../index.js';
+import { DEFAULT_IMAGE_TOKEN_ESTIMATE } from '../utils/imageTokenEstimation.js';
 
 function createTempDir(prefix = 'llxprt-read-many-files-behavior-'): {
   dir: string;
@@ -336,8 +337,8 @@ describe('ReadManyFilesTool real behavioral filtering', () => {
     const filePath = join(tempDir, 'big.png');
     const original = await sharp({
       create: {
-        width: 1092,
-        height: 1092,
+        width: 10,
+        height: 10,
         channels: 3,
         background: { r: 10, g: 20, b: 30 },
       },
@@ -384,12 +385,10 @@ describe('ReadManyFilesTool real behavioral filtering', () => {
     });
 
     expect(result.error).toBeUndefined();
-    // The default-family estimate for any image is 1000 tokens. The display
-    // formats totals with toLocaleString(), so tolerate any group separator.
-    const reported = /([\d\s.,\u00a0\u202f]+) tokens/.exec(
-      result.returnDisplay as string,
+    // The display formats totals with toLocaleString(), so build the expected
+    // string the same way rather than assuming a group separator.
+    expect(result.returnDisplay).toContain(
+      `${DEFAULT_IMAGE_TOKEN_ESTIMATE.toLocaleString()} tokens`,
     );
-    expect(reported).not.toBeNull();
-    expect(Number(reported?.[1].replace(/\D/g, ''))).toBe(1000);
   });
 });

--- a/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
+++ b/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
@@ -328,4 +328,63 @@ describe('ReadManyFilesTool real behavioral filtering', () => {
       expect(result.returnDisplay).toContain('Image Resize Error');
     },
   );
+
+  it('skips an image whose estimate exceeds tool-output-max-tokens under the new estimator', async () => {
+    // A 1092x1092 PNG under the default family costs 1000 tokens — well above
+    // the old hardcoded 85. Set a token budget that the old 85 would have passed
+    // but the new 1000 does not.
+    const filePath = join(tempDir, 'big.png');
+    const original = await sharp({
+      create: {
+        width: 1092,
+        height: 1092,
+        channels: 3,
+        background: { r: 10, g: 20, b: 30 },
+      },
+    })
+      .png()
+      .toBuffer();
+    writeFileSync(filePath, original);
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-tokens': 100,
+    });
+
+    const result = await new ReadManyFilesTool(host).execute({
+      paths: ['big.png'],
+    });
+
+    // The image must be skipped — the new estimate (1000) exceeds the 100
+    // budget, whereas the old 85 would have been admitted.
+    expect(result.returnDisplay).toContain('would exceed token limit');
+    expect(result.returnDisplay).toContain('big.png');
+  });
+
+  it('reflects the new image token estimate in the reported total', async () => {
+    // A small image (10x10) under the default family still costs 1000 tokens
+    // (the default flat estimate). With a generous budget the image is
+    // admitted and the reported total reflects the new estimator, not 85.
+    const filePath = join(tempDir, 'small.png');
+    const original = await sharp({
+      create: {
+        width: 10,
+        height: 10,
+        channels: 3,
+        background: { r: 200, g: 200, b: 200 },
+      },
+    })
+      .png()
+      .toBuffer();
+    writeFileSync(filePath, original);
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-tokens': 50000,
+    });
+
+    const result = await new ReadManyFilesTool(host).execute({
+      paths: ['small.png'],
+    });
+
+    expect(result.error).toBeUndefined();
+    // The default-family estimate for any image is 1000 tokens.
+    expect(result.returnDisplay).toContain('1,000 tokens');
+  });
 });

--- a/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
+++ b/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
@@ -330,9 +330,9 @@ describe('ReadManyFilesTool real behavioral filtering', () => {
   );
 
   it('skips an image whose estimate exceeds tool-output-max-tokens under the new estimator', async () => {
-    // A 1092x1092 PNG under the default family costs 1000 tokens — well above
-    // the old hardcoded 85. Set a token budget that the old 85 would have passed
-    // but the new 1000 does not.
+    // Any image under the default family costs DEFAULT_IMAGE_TOKEN_ESTIMATE
+    // (1000) regardless of its dimensions — well above the old hardcoded 85.
+    // Set a token budget that the old 85 would have passed but 1000 does not.
     const filePath = join(tempDir, 'big.png');
     const original = await sharp({
       create: {
@@ -384,7 +384,12 @@ describe('ReadManyFilesTool real behavioral filtering', () => {
     });
 
     expect(result.error).toBeUndefined();
-    // The default-family estimate for any image is 1000 tokens.
-    expect(result.returnDisplay).toContain('1,000 tokens');
+    // The default-family estimate for any image is 1000 tokens. The display
+    // formats totals with toLocaleString(), so tolerate any group separator.
+    const reported = /([\d\s.,\u00a0\u202f]+) tokens/.exec(
+      result.returnDisplay as string,
+    );
+    expect(reported).not.toBeNull();
+    expect(Number(reported?.[1].replace(/\D/g, ''))).toBe(1000);
   });
 });

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -168,6 +168,19 @@ export {
 export type { MediaBlock, MediaCategory } from './utils/mediaUtils.js';
 export { classifyMediaBlock } from './utils/mediaUtils.js';
 export {
+  type ImageDimensions,
+  parseImageDimensions,
+  parseImageDimensionsFromBase64,
+} from './utils/imageDimensions.js';
+export {
+  type ImageTokenProviderFamily,
+  DEFAULT_IMAGE_TOKEN_ESTIMATE,
+  resolveImageTokenProviderFamily,
+  type ImageTokenEstimateInput,
+  estimateImageTokens,
+  estimateNonTextPartTokens,
+} from './utils/imageTokenEstimation.js';
+export {
   DEFAULT_DIFF_OPTIONS,
   DEFAULT_CREATE_PATCH_OPTIONS,
   getDiffStat,

--- a/packages/tools/src/tools/read-many-files.ts
+++ b/packages/tools/src/tools/read-many-files.ts
@@ -38,6 +38,7 @@ import {
   resolveImageResizePolicy,
   type ImageResizePolicy,
 } from '../utils/imageResize.js';
+import { estimateNonTextPartTokens } from '../utils/imageTokenEstimation.js';
 import {
   buildParameterSchema,
   formatExcludePatterns,
@@ -705,8 +706,13 @@ ${this.host.getTargetDir()}
       );
     }
 
-    // Non-text content (images/PDFs)
-    const estimatedTokens = 85;
+    // Non-text content (images/PDFs). No provider is available at the tool
+    // layer, so image estimates use the provider-agnostic default family.
+    const inlineData = fileReadResult.llmContent.inlineData;
+    const estimatedTokens = estimateNonTextPartTokens(
+      inlineData?.mimeType,
+      inlineData?.data,
+    );
 
     if (totalTokens + estimatedTokens > limits.maxTokens) {
       skippedFiles.push({

--- a/packages/tools/src/utils/imageDimensions.ts
+++ b/packages/tools/src/utils/imageDimensions.ts
@@ -39,11 +39,13 @@ function readUint24LE(bytes: Uint8Array, offset: number): number {
 }
 
 function readUint32BE(bytes: Uint8Array, offset: number): number {
+  // `>>> 0` keeps the result unsigned; `<< 24` alone sign-extends past 2^31.
   return (
-    (bytes[offset] << 24) |
-    (bytes[offset + 1] << 16) |
-    (bytes[offset + 2] << 8) |
-    bytes[offset + 3]
+    ((bytes[offset] << 24) |
+      (bytes[offset + 1] << 16) |
+      (bytes[offset + 2] << 8) |
+      bytes[offset + 3]) >>>
+    0
   );
 }
 

--- a/packages/tools/src/utils/imageDimensions.ts
+++ b/packages/tools/src/utils/imageDimensions.ts
@@ -260,9 +260,14 @@ export function parseImageDimensionsFromBase64(
 ): ImageDimensions | undefined {
   if (base64.length === 0) return undefined;
   try {
-    // Read a bounded window first so a multi-megabyte payload is never scanned
-    // or copied in full; the window is doubled to absorb interleaved newlines.
-    const window = stripDataUriPrefix(base64).slice(
+    // Bound the input before stripping so a multi-megabyte payload is never
+    // scanned or copied in full. The window is doubled to absorb interleaved
+    // newlines, and widened again to cover a leading data: URI prefix.
+    const bounded = base64.slice(
+      0,
+      MAX_DATA_URI_PREFIX_CHARS + MAX_BASE64_HEADER_CHARS * 2,
+    );
+    const window = stripDataUriPrefix(bounded).slice(
       0,
       MAX_BASE64_HEADER_CHARS * 2,
     );

--- a/packages/tools/src/utils/imageDimensions.ts
+++ b/packages/tools/src/utils/imageDimensions.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure, dependency-free image header parsing. Reads only the leading bytes
+ * needed to recover width/height for PNG, GIF, JPEG, and WEBP. It never throws
+ * and returns `undefined` for any unrecognised, truncated, or corrupt input.
+ */
+
+export interface ImageDimensions {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Bound on the number of base64 characters decoded before header parsing. */
+const MAX_BASE64_HEADER_CHARS = 174_764; // ~128 KiB, covers EXIF-heavy JPEG headers
+
+function makeDimensions(width: number, height: number): ImageDimensions {
+  return { width, height };
+}
+
+function isValidDimension(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function readUint16BE(bytes: Uint8Array, offset: number): number {
+  return (bytes[offset] << 8) | bytes[offset + 1];
+}
+
+function readUint16LE(bytes: Uint8Array, offset: number): number {
+  return bytes[offset] | (bytes[offset + 1] << 8);
+}
+
+function readUint24LE(bytes: Uint8Array, offset: number): number {
+  return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
+}
+
+function readUint32BE(bytes: Uint8Array, offset: number): number {
+  return (
+    (bytes[offset] << 24) |
+    (bytes[offset + 1] << 16) |
+    (bytes[offset + 2] << 8) |
+    bytes[offset + 3]
+  );
+}
+
+function readUint32LE(bytes: Uint8Array, offset: number): number {
+  return (
+    bytes[offset] |
+    (bytes[offset + 1] << 8) |
+    (bytes[offset + 2] << 16) |
+    (bytes[offset + 3] << 24)
+  );
+}
+
+function hasBytes(bytes: Uint8Array, offset: number, count: number): boolean {
+  return offset >= 0 && count >= 0 && offset + count <= bytes.length;
+}
+
+function matchesAscii(
+  bytes: Uint8Array,
+  offset: number,
+  expected: string,
+): boolean {
+  if (!hasBytes(bytes, offset, expected.length)) return false;
+  for (let i = 0; i < expected.length; i++) {
+    if (bytes[offset + i] !== expected.charCodeAt(i)) return false;
+  }
+  return true;
+}
+
+function parsePngDimensions(bytes: Uint8Array): ImageDimensions | undefined {
+  // PNG signature (8) + IHDR length (4) + "IHDR" (4) precede width/height.
+  if (!hasBytes(bytes, 0, 24)) return undefined;
+  const ihdrOffset = 12;
+  if (!matchesAscii(bytes, ihdrOffset, 'IHDR')) {
+    return undefined;
+  }
+  const width = readUint32BE(bytes, 16);
+  const height = readUint32BE(bytes, 20);
+  if (!isValidDimension(width) || !isValidDimension(height)) return undefined;
+  return makeDimensions(width, height);
+}
+
+function parseGifDimensions(bytes: Uint8Array): ImageDimensions | undefined {
+  if (!hasBytes(bytes, 0, 10)) return undefined;
+  const width = readUint16LE(bytes, 6);
+  const height = readUint16LE(bytes, 8);
+  if (!isValidDimension(width) || !isValidDimension(height)) return undefined;
+  return makeDimensions(width, height);
+}
+
+/** SOF markers that carry frame dimensions. */
+function isStartOfFrameMarker(marker: number): boolean {
+  // SOF markers occupy several non-contiguous ranges: C0–C3, C5–C7, C9–CB, CD–CF.
+  if (marker >= 0xc0 && marker <= 0xc3) return true;
+  if (marker >= 0xc5 && marker <= 0xc7) return true;
+  if (marker >= 0xc9 && marker <= 0xcb) return true;
+  return marker >= 0xcd && marker <= 0xcf;
+}
+
+/** Standalone markers carry no length field. */
+function isStandaloneMarker(marker: number): boolean {
+  if (marker === 0x01) return true;
+  return marker >= 0xd0 && marker <= 0xd9;
+}
+
+function parseJpegDimensions(bytes: Uint8Array): ImageDimensions | undefined {
+  // Walk JPEG segments starting after the SOI marker.
+  let offset = 2;
+  while (offset + 1 < bytes.length) {
+    // Skip fill bytes before each marker.
+    while (offset < bytes.length && bytes[offset] !== 0xff) {
+      offset++;
+    }
+    // Collapse runs of FF fill bytes.
+    while (offset < bytes.length && bytes[offset] === 0xff) {
+      offset++;
+    }
+    if (offset >= bytes.length) return undefined;
+    const marker = bytes[offset];
+    offset++;
+    if (marker === 0xda) return undefined; // SOS: scan data begins, no SOF seen
+    if (isStandaloneMarker(marker)) continue;
+
+    // Segment length field is big-endian uint16 and includes its own 2 bytes.
+    if (offset + 2 > bytes.length) return undefined;
+    const segmentLength = readUint16BE(bytes, offset);
+    if (segmentLength < 2) return undefined;
+
+    if (isStartOfFrameMarker(marker)) {
+      // SOF body layout (offsets relative to the length field):
+      // [len:2][precision:1][height:2][width:2][components...].
+      const heightOffset = offset + 3;
+      const widthOffset = offset + 5;
+      if (!hasBytes(bytes, widthOffset, 2)) return undefined;
+      const height = readUint16BE(bytes, heightOffset);
+      const width = readUint16BE(bytes, widthOffset);
+      if (!isValidDimension(width) || !isValidDimension(height)) {
+        return undefined;
+      }
+      return makeDimensions(width, height);
+    }
+    offset += segmentLength;
+  }
+  return undefined;
+}
+
+function parseWebpDimensions(bytes: Uint8Array): ImageDimensions | undefined {
+  // RIFF (4) + size (4) + WEBP (4) + chunk FourCC (4) = 16 bytes minimum.
+  if (!hasBytes(bytes, 0, 16)) return undefined;
+  const fourCc = String.fromCharCode(
+    bytes[12],
+    bytes[13],
+    bytes[14],
+    bytes[15],
+  );
+
+  if (fourCc === 'VP8 ') {
+    if (!hasBytes(bytes, 0, 30)) return undefined;
+    // The 3-byte frame tag at 20-22 is followed by the keyframe start code.
+    if (bytes[23] !== 0x9d || bytes[24] !== 0x01 || bytes[25] !== 0x2a) {
+      return undefined;
+    }
+    const width = readUint16LE(bytes, 26) & 0x3fff;
+    const height = readUint16LE(bytes, 28) & 0x3fff;
+    if (!isValidDimension(width) || !isValidDimension(height)) return undefined;
+    return makeDimensions(width, height);
+  }
+  if (fourCc === 'VP8L') {
+    if (!hasBytes(bytes, 0, 25)) return undefined;
+    if (bytes[20] !== 0x2f) return undefined; // VP8L signature byte
+    const bits = readUint32LE(bytes, 21);
+    const width = (bits & 0x3fff) + 1;
+    const height = ((bits >> 14) & 0x3fff) + 1;
+    if (!isValidDimension(width) || !isValidDimension(height)) return undefined;
+    return makeDimensions(width, height);
+  }
+  if (fourCc === 'VP8X') {
+    if (!hasBytes(bytes, 0, 30)) return undefined;
+    const width = readUint24LE(bytes, 24) + 1;
+    const height = readUint24LE(bytes, 27) + 1;
+    if (!isValidDimension(width) || !isValidDimension(height)) return undefined;
+    return makeDimensions(width, height);
+  }
+  return undefined;
+}
+
+/** PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A. */
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function isPng(bytes: Uint8Array): boolean {
+  if (!hasBytes(bytes, 0, PNG_SIGNATURE.length)) return false;
+  for (let i = 0; i < PNG_SIGNATURE.length; i++) {
+    if (bytes[i] !== PNG_SIGNATURE[i]) return false;
+  }
+  return true;
+}
+
+function isGif(bytes: Uint8Array): boolean {
+  return matchesAscii(bytes, 0, 'GIF87a') || matchesAscii(bytes, 0, 'GIF89a');
+}
+
+function isJpeg(bytes: Uint8Array): boolean {
+  return hasBytes(bytes, 0, 2) && bytes[0] === 0xff && bytes[1] === 0xd8;
+}
+
+function isWebp(bytes: Uint8Array): boolean {
+  return matchesAscii(bytes, 0, 'RIFF') && matchesAscii(bytes, 8, 'WEBP');
+}
+
+/**
+ * Parse width/height from raw image header bytes.
+ *
+ * Returns `undefined` for unrecognised, truncated, or corrupt input. It never
+ * throws: all bounds are checked before reads.
+ */
+export function parseImageDimensions(
+  bytes: Uint8Array,
+): ImageDimensions | undefined {
+  if (bytes.length === 0) return undefined;
+  try {
+    if (isPng(bytes)) return parsePngDimensions(bytes);
+    if (isGif(bytes)) return parseGifDimensions(bytes);
+    if (isJpeg(bytes)) return parseJpegDimensions(bytes);
+    if (isWebp(bytes)) return parseWebpDimensions(bytes);
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Longest `data:<mime>;base64,` prefix considered when locating the payload. */
+const MAX_DATA_URI_PREFIX_CHARS = 256;
+
+/** Strip an optional `data:<mime>;base64,` prefix from a base64 string. */
+function stripDataUriPrefix(value: string): string {
+  const commaIndex = value.slice(0, MAX_DATA_URI_PREFIX_CHARS).indexOf(',');
+  if (commaIndex >= 0 && value.slice(0, commaIndex).endsWith(';base64')) {
+    return value.slice(commaIndex + 1);
+  }
+  return value;
+}
+
+/**
+ * Parse image dimensions from a base64 payload.
+ *
+ * Tolerates `data:` URI prefixes and embedded whitespace. Decodes only a bounded
+ * prefix (enough to cover EXIF-heavy JPEG headers) and delegates to
+ * {@link parseImageDimensions}. Returns `undefined` on invalid base64 or when no
+ * usable header bytes decode. It never throws.
+ */
+export function parseImageDimensionsFromBase64(
+  base64: string,
+): ImageDimensions | undefined {
+  if (base64.length === 0) return undefined;
+  try {
+    // Read a bounded window first so a multi-megabyte payload is never scanned
+    // or copied in full; the window is doubled to absorb interleaved newlines.
+    const window = stripDataUriPrefix(base64).slice(
+      0,
+      MAX_BASE64_HEADER_CHARS * 2,
+    );
+    const stripped = window.replace(/\s+/g, '');
+    if (stripped.length === 0) return undefined;
+    const truncated =
+      stripped.length > MAX_BASE64_HEADER_CHARS
+        ? stripped.slice(0, MAX_BASE64_HEADER_CHARS)
+        : stripped;
+    const decoded = Buffer.from(truncated, 'base64');
+    if (decoded.length === 0) return undefined;
+    return parseImageDimensions(decoded);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/tools/src/utils/imageTokenEstimation.ts
+++ b/packages/tools/src/utils/imageTokenEstimation.ts
@@ -1,0 +1,221 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  parseImageDimensionsFromBase64,
+  type ImageDimensions,
+} from './imageDimensions.js';
+
+/**
+ * Provider-aware image token estimation. Each family applies the documented
+ * client-side approximation for its platform; there is no server round-trip.
+ */
+
+export type ImageTokenProviderFamily =
+  | 'anthropic'
+  | 'openai'
+  | 'gemini'
+  | 'default';
+
+/** Flat fallback when no provider is known (better than 85, safer than 3000). */
+export const DEFAULT_IMAGE_TOKEN_ESTIMATE = 1000;
+
+/**
+ * Google publishes no client-side image token formula, so that family charges a
+ * conservative flat estimate for every image regardless of dimensions.
+ */
+const FLAT_IMAGE_TOKEN_ESTIMATE = 3000;
+
+/** Anthropic caps the long edge of an accepted image at this many pixels. */
+const ANTHROPIC_MAX_LONG_EDGE = 1568;
+
+/**
+ * Anthropic's documented largest accepted 1:1 image is 1092x1092; anything
+ * larger is downscaled to at most that many pixels before being tokenised.
+ */
+const ANTHROPIC_MAX_PIXELS = 1092 * 1092;
+
+/** Anthropic charges one token per this many pixels. */
+const ANTHROPIC_PIXELS_PER_TOKEN = 750;
+
+/**
+ * The cost of Anthropic's largest accepted image, which is also its worst case
+ * when dimensions cannot be parsed.
+ */
+const ANTHROPIC_UNKNOWN_DIMENSIONS_TOKENS = Math.ceil(
+  ANTHROPIC_MAX_PIXELS / ANTHROPIC_PIXELS_PER_TOKEN,
+);
+
+/**
+ * OpenAI's larger published high-detail example (2048x4096) is the safest
+ * documented value when dimensions are unknown. The tile formula has no finite
+ * maximum because the aspect ratio is unbounded, so a documented example is
+ * preferred over an arbitrarily large constant that would make context
+ * compression fire spuriously for every URL-referenced image.
+ */
+const OPENAI_UNKNOWN_DIMENSIONS_TOKENS = 1105;
+
+/** OpenAI first fits the image inside a square of this many pixels per edge. */
+const OPENAI_MAX_EDGE = 2048;
+
+/** OpenAI then normalises the shortest side to this many pixels. */
+const OPENAI_SHORT_SIDE = 768;
+
+/** OpenAI divides the normalised image into square tiles of this size. */
+const OPENAI_TILE_SIZE = 512;
+
+/** OpenAI charges this many tokens per high-detail tile. */
+const OPENAI_TOKENS_PER_TILE = 170;
+
+/** OpenAI charges this base cost for every high-detail image. */
+const OPENAI_BASE_TOKENS = 85;
+
+export interface ImageTokenEstimateInput {
+  readonly provider?: string;
+  readonly dimensions?: ImageDimensions;
+}
+
+/**
+ * Provider-name fragments per family. Substring matching mirrors the tokenizer
+ * selection in the providers runtime so alias providers that wrap a backing
+ * platform (for example `claudecode` or `codex`) resolve to the same family as
+ * the platform they proxy.
+ */
+const FAMILY_MATCHERS: ReadonlyArray<
+  readonly [ImageTokenProviderFamily, readonly string[]]
+> = [
+  ['anthropic', ['anthropic', 'claude']],
+  ['gemini', ['gemini', 'google']],
+  ['openai', ['openai', 'codex']],
+];
+
+export function resolveImageTokenProviderFamily(
+  provider: string | undefined,
+): ImageTokenProviderFamily {
+  if (provider === undefined) return 'default';
+  const normalized = provider.trim().toLowerCase();
+  if (normalized.length === 0) return 'default';
+  for (const [family, fragments] of FAMILY_MATCHERS) {
+    if (fragments.some((fragment) => normalized.includes(fragment))) {
+      return family;
+    }
+  }
+  return 'default';
+}
+
+function hasValidDimensions(
+  dimensions: ImageDimensions | undefined,
+): dimensions is ImageDimensions {
+  if (dimensions === undefined) return false;
+  return (
+    Number.isFinite(dimensions.width) &&
+    Number.isFinite(dimensions.height) &&
+    dimensions.width > 0 &&
+    dimensions.height > 0
+  );
+}
+
+/**
+ * Anthropic: downscale until both the long-edge and total-pixel limits hold
+ * (never upscaling), then charge one token per 750 pixels.
+ */
+function estimateAnthropicTokens(dimensions: ImageDimensions): number {
+  const { width, height } = dimensions;
+  const edgeScale = Math.min(
+    1,
+    ANTHROPIC_MAX_LONG_EDGE / Math.max(width, height),
+  );
+  const edgePixels = width * edgeScale * (height * edgeScale);
+  const areaScale =
+    edgePixels > ANTHROPIC_MAX_PIXELS
+      ? Math.sqrt(ANTHROPIC_MAX_PIXELS / edgePixels)
+      : 1;
+  const pixels = edgePixels * areaScale * areaScale;
+  // Any visible image costs at least one token.
+  return Math.max(1, Math.ceil(pixels / ANTHROPIC_PIXELS_PER_TOKEN));
+}
+
+/** Tolerance absorbing float error for dimensions that land exactly on a tile edge. */
+const TILE_EDGE_EPSILON = 1e-6;
+
+function countTiles(edge: number): number {
+  return Math.max(1, Math.ceil(edge / OPENAI_TILE_SIZE - TILE_EDGE_EPSILON));
+}
+
+/**
+ * OpenAI high detail: fit inside 2048x2048, normalise the shortest side to 768,
+ * then count 512-px tiles at 170 tokens each plus an 85-token base.
+ */
+function estimateOpenaiTokens(dimensions: ImageDimensions): number {
+  const { width, height } = dimensions;
+  const boundScale = Math.min(1, OPENAI_MAX_EDGE / Math.max(width, height));
+  const boundedWidth = width * boundScale;
+  const boundedHeight = height * boundScale;
+  const shortSideScale =
+    OPENAI_SHORT_SIDE / Math.min(boundedWidth, boundedHeight);
+  const tiles =
+    countTiles(boundedWidth * shortSideScale) *
+    countTiles(boundedHeight * shortSideScale);
+  return OPENAI_TOKENS_PER_TILE * tiles + OPENAI_BASE_TOKENS;
+}
+
+function estimateForFamily(
+  family: ImageTokenProviderFamily,
+  dimensions: ImageDimensions | undefined,
+): number {
+  if (!hasValidDimensions(dimensions)) {
+    switch (family) {
+      case 'anthropic':
+        return ANTHROPIC_UNKNOWN_DIMENSIONS_TOKENS;
+      case 'openai':
+        return OPENAI_UNKNOWN_DIMENSIONS_TOKENS;
+      case 'gemini':
+        return FLAT_IMAGE_TOKEN_ESTIMATE;
+      default:
+        return DEFAULT_IMAGE_TOKEN_ESTIMATE;
+    }
+  }
+  switch (family) {
+    case 'anthropic':
+      return estimateAnthropicTokens(dimensions);
+    case 'openai':
+      return estimateOpenaiTokens(dimensions);
+    case 'gemini':
+      return FLAT_IMAGE_TOKEN_ESTIMATE;
+    default:
+      return DEFAULT_IMAGE_TOKEN_ESTIMATE;
+  }
+}
+
+/**
+ * Estimate image token cost for a given provider family and optional parsed
+ * dimensions. Always returns a positive integer.
+ */
+export function estimateImageTokens(input: ImageTokenEstimateInput): number {
+  const family = resolveImageTokenProviderFamily(input.provider);
+  return estimateForFamily(family, input.dimensions);
+}
+
+/**
+ * Estimate tokens for a non-text (binary) part described by its MIME type and
+ * optional base64 payload. Images are measured from their parsed header
+ * dimensions; every other binary payload uses the flat default estimate.
+ */
+export function estimateNonTextPartTokens(
+  mimeType: string | undefined,
+  base64Data: string | undefined,
+  provider?: string,
+): number {
+  const isImage = mimeType?.toLowerCase().startsWith('image/') ?? false;
+  if (!isImage) {
+    return DEFAULT_IMAGE_TOKEN_ESTIMATE;
+  }
+  const dimensions =
+    base64Data === undefined
+      ? undefined
+      : parseImageDimensionsFromBase64(base64Data);
+  return estimateImageTokens({ provider, dimensions });
+}

--- a/packages/tools/test-bun/imageDimensions.bun.ts
+++ b/packages/tools/test-bun/imageDimensions.bun.ts
@@ -1,0 +1,302 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  parseImageDimensions,
+  parseImageDimensionsFromBase64,
+} from '../src/utils/imageDimensions.js';
+
+// --- Fixture builders (pure bytes; no binary files committed) ---
+
+function buildPng(width: number, height: number): Uint8Array {
+  const buf = Buffer.alloc(8 + 4 + 4 + 13);
+  // PNG signature
+  buf[0] = 0x89;
+  buf[1] = 0x50;
+  buf[2] = 0x4e;
+  buf[3] = 0x47;
+  buf[4] = 0x0d;
+  buf[5] = 0x0a;
+  buf[6] = 0x1a;
+  buf[7] = 0x0a;
+  // IHDR length (13) big-endian
+  buf.writeUInt32BE(13, 8);
+  // IHDR chunk type
+  buf.write('IHDR', 12, 'ascii');
+  // width / height big-endian
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+function buildGif(
+  width: number,
+  height: number,
+  version: '87a' | '89a' = '89a',
+): Uint8Array {
+  const buf = Buffer.alloc(13);
+  buf.write(`GIF${version}`, 0, 'ascii');
+  buf.writeUInt16LE(width, 6);
+  buf.writeUInt16LE(height, 8);
+  return buf;
+}
+
+/**
+ * Build a minimal JPEG with a single optional APP segment before the SOF0.
+ * `appPayloadSize` is the number of throwaway bytes inside the APP segment so
+ * the marker-walking logic must skip a large EXIF-like block.
+ */
+function buildJpeg(
+  width: number,
+  height: number,
+  appPayloadSize = 0,
+): Uint8Array {
+  const segments: Buffer[] = [];
+  // SOI
+  segments.push(Buffer.from([0xff, 0xd8]));
+  // Optional APP1 segment with arbitrary payload (proves marker walking)
+  if (appPayloadSize > 0) {
+    const payload = Buffer.alloc(appPayloadSize, 0x42);
+    const len = payload.length + 2; // length includes its own 2 bytes
+    const header = Buffer.alloc(4);
+    header[0] = 0xff;
+    header[1] = 0xe1; // APP1
+    header.writeUInt16BE(len, 2);
+    segments.push(Buffer.concat([header, payload]));
+  }
+  // SOF0 (baseline): marker, length, precision, height, width, Nf, component
+  const sofLen = 2 + 1 + 2 + 2 + 1 + 3; // len + precision + h + w + Nf + 1 comp(3)
+  const sof = Buffer.alloc(2 + sofLen);
+  sof[0] = 0xff;
+  sof[1] = 0xc0; // SOF0
+  sof.writeUInt16BE(sofLen, 2);
+  sof[4] = 8; // precision
+  sof.writeUInt16BE(height, 5); // height
+  sof.writeUInt16BE(width, 7); // width
+  sof[9] = 1; // number of components
+  segments.push(sof);
+  // SOS marker (signals start of scan; walking must stop here)
+  segments.push(Buffer.from([0xff, 0xda]));
+  return Buffer.concat(segments);
+}
+
+/** Build a minimal WEBP with the given chunk FourCC. */
+function buildWebp(
+  fourCc: 'VP8 ' | 'VP8L' | 'VP8X',
+  width: number,
+  height: number,
+): Uint8Array {
+  // RIFF header (12 bytes) + chunk FourCC + chunk body.
+  const buf = Buffer.alloc(30);
+  buf.write('RIFF', 0, 'ascii');
+  buf.writeUInt32LE(0, 4); // file size placeholder
+  buf.write('WEBP', 8, 'ascii');
+  buf.write(fourCc, 12, 'ascii');
+
+  if (fourCc === 'VP8 ') {
+    buf.writeUInt32LE(10, 16); // chunk size
+    // 3-byte frame tag occupies 20-22; the keyframe start code follows at 23-25.
+    buf[20] = 0x9d;
+    buf[21] = 0x01;
+    buf[22] = 0x2a;
+    buf[23] = 0x9d;
+    buf[24] = 0x01;
+    buf[25] = 0x2a;
+    buf.writeUInt16LE(width & 0x3fff, 26);
+    buf.writeUInt16LE(height & 0x3fff, 28);
+  } else if (fourCc === 'VP8L') {
+    buf.writeUInt32LE(5, 16); // chunk size
+    buf[20] = 0x2f; // signature
+    const w14 = (width - 1) & 0x3fff;
+    const h14 = ((height - 1) & 0x3fff) << 14;
+    buf.writeUInt32LE(w14 | h14, 21);
+  } else {
+    // VP8X
+    buf.writeUInt32LE(10, 16); // chunk size
+    // canvas width/height are stored as 24-bit LE (value = dimension - 1)
+    const wMinus1 = width - 1;
+    const hMinus1 = height - 1;
+    buf[24] = wMinus1 & 0xff;
+    buf[25] = (wMinus1 >> 8) & 0xff;
+    buf[26] = (wMinus1 >> 16) & 0xff;
+    buf[27] = hMinus1 & 0xff;
+    buf[28] = (hMinus1 >> 8) & 0xff;
+    buf[29] = (hMinus1 >> 16) & 0xff;
+  }
+  return buf;
+}
+
+describe('parseImageDimensions', () => {
+  it('reads PNG dimensions from the IHDR header', () => {
+    expect(parseImageDimensions(buildPng(640, 480))).toEqual({
+      width: 640,
+      height: 480,
+    });
+  });
+
+  it('reads PNG dimensions for a large square', () => {
+    expect(parseImageDimensions(buildPng(1092, 1092))).toEqual({
+      width: 1092,
+      height: 1092,
+    });
+  });
+
+  it('reads JPEG baseline SOF0 dimensions', () => {
+    expect(parseImageDimensions(buildJpeg(1024, 1024))).toEqual({
+      width: 1024,
+      height: 1024,
+    });
+
+    expect(parseImageDimensions(buildJpeg(2048, 4096))).toEqual({
+      width: 2048,
+      height: 4096,
+    });
+  });
+
+  it('walks past a large APP1/EXIF segment to reach the SOF', () => {
+    expect(parseImageDimensions(buildJpeg(800, 600, 2048))).toEqual({
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it('skips standalone markers (RSTn) without a length field', () => {
+    // Insert a standalone RST0 (FF D0) before the SOF to prove the walker
+    // advances past markers that carry no length.
+    const soi = Buffer.from([0xff, 0xd8]);
+    const rst = Buffer.from([0xff, 0xd0]);
+    const rest = buildJpeg(512, 512).subarray(2); // drop our SOI
+    expect(parseImageDimensions(Buffer.concat([soi, rst, rest]))).toEqual({
+      width: 512,
+      height: 512,
+    });
+  });
+
+  it('reads GIF87a dimensions (little-endian)', () => {
+    expect(parseImageDimensions(buildGif(320, 200, '87a'))).toEqual({
+      width: 320,
+      height: 200,
+    });
+  });
+
+  it('reads GIF89a dimensions (little-endian)', () => {
+    expect(parseImageDimensions(buildGif(256, 256, '89a'))).toEqual({
+      width: 256,
+      height: 256,
+    });
+  });
+
+  it('reads WEBP lossy (VP8 ) dimensions', () => {
+    expect(parseImageDimensions(buildWebp('VP8 ', 1280, 720))).toEqual({
+      width: 1280,
+      height: 720,
+    });
+  });
+
+  it('reads WEBP lossless (VP8L) dimensions', () => {
+    expect(parseImageDimensions(buildWebp('VP8L', 400, 300))).toEqual({
+      width: 400,
+      height: 300,
+    });
+  });
+
+  it('reads WEBP extended (VP8X) dimensions', () => {
+    expect(parseImageDimensions(buildWebp('VP8X', 1920, 1080))).toEqual({
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  it('rejects a WEBP whose VP8 keyframe start code is corrupt', () => {
+    const corrupt = Buffer.from(buildWebp('VP8 ', 1280, 720));
+    corrupt[23] = 0x00;
+    expect(parseImageDimensions(corrupt)).toBeUndefined();
+  });
+
+  it('returns undefined for a truncated PNG (missing IHDR)', () => {
+    const truncated = buildPng(100, 100).subarray(0, 14);
+    expect(parseImageDimensions(truncated)).toBeUndefined();
+  });
+
+  it('returns undefined for random bytes', () => {
+    expect(parseImageDimensions(Buffer.alloc(64, 0xab))).toBeUndefined();
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(parseImageDimensions(new Uint8Array(0))).toBeUndefined();
+  });
+
+  it('never throws for corrupt input that resembles a header', () => {
+    const corrupt = Buffer.alloc(8, 0);
+    expect(() => parseImageDimensions(corrupt)).not.toThrow();
+  });
+});
+
+describe('parseImageDimensionsFromBase64', () => {
+  it('decodes a plain base64 PNG payload', () => {
+    const png = buildPng(100, 50);
+    const b64 = Buffer.from(png).toString('base64');
+    expect(parseImageDimensionsFromBase64(b64)).toEqual({
+      width: 100,
+      height: 50,
+    });
+  });
+
+  it('strips a data: URI prefix', () => {
+    const png = buildPng(64, 64);
+    const b64 = `data:image/png;base64,${Buffer.from(png).toString('base64')}`;
+    expect(parseImageDimensionsFromBase64(b64)).toEqual({
+      width: 64,
+      height: 64,
+    });
+  });
+
+  it('tolerates whitespace-wrapped base64', () => {
+    const png = buildPng(48, 36);
+    const raw = Buffer.from(png).toString('base64');
+    const spaced = raw.replace(/(.{8})/g, '$1\n');
+    expect(parseImageDimensionsFromBase64(spaced)).toEqual({
+      width: 48,
+      height: 36,
+    });
+  });
+
+  it('returns undefined for invalid base64', () => {
+    expect(parseImageDimensionsFromBase64('!!!not base64!!!')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(parseImageDimensionsFromBase64('')).toBeUndefined();
+  });
+
+  it('reads an unpadded base64 header without dropping its final bytes', () => {
+    const gif = buildGif(320, 200);
+    const unpadded = Buffer.from(gif).toString('base64').replace(/=+$/, '');
+    expect(parseImageDimensionsFromBase64(unpadded)).toEqual({
+      width: 320,
+      height: 200,
+    });
+  });
+
+  it('reads the header of a payload far larger than the decode bound', () => {
+    const header = Buffer.from(buildPng(1024, 768));
+    const huge = Buffer.concat([header, Buffer.alloc(2_000_000, 0x11)]);
+    expect(parseImageDimensionsFromBase64(huge.toString('base64'))).toEqual({
+      width: 1024,
+      height: 768,
+    });
+  });
+
+  it('reads JPEG dimensions from a base64 payload with a large APP1', () => {
+    const jpeg = buildJpeg(600, 450, 1024);
+    const b64 = Buffer.from(jpeg).toString('base64');
+    expect(parseImageDimensionsFromBase64(b64)).toEqual({
+      width: 600,
+      height: 450,
+    });
+  });
+});

--- a/packages/tools/test-bun/imageTokenEstimation.bun.ts
+++ b/packages/tools/test-bun/imageTokenEstimation.bun.ts
@@ -1,0 +1,338 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  DEFAULT_IMAGE_TOKEN_ESTIMATE,
+  resolveImageTokenProviderFamily,
+  estimateImageTokens,
+  estimateNonTextPartTokens,
+} from '../src/utils/imageTokenEstimation.js';
+
+function buildPngBase64(width: number, height: number): string {
+  const buf = Buffer.alloc(24);
+  buf[0] = 0x89;
+  buf[1] = 0x50;
+  buf[2] = 0x4e;
+  buf[3] = 0x47;
+  buf[4] = 0x0d;
+  buf[5] = 0x0a;
+  buf[6] = 0x1a;
+  buf[7] = 0x0a;
+  buf.write('IHDR', 12, 'ascii');
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf.toString('base64');
+}
+
+describe('resolveImageTokenProviderFamily', () => {
+  it('maps anthropic names to the anthropic family', () => {
+    expect(resolveImageTokenProviderFamily('anthropic')).toBe('anthropic');
+    expect(resolveImageTokenProviderFamily('claude')).toBe('anthropic');
+  });
+
+  it('maps openai names to the openai family', () => {
+    expect(resolveImageTokenProviderFamily('openai')).toBe('openai');
+  });
+
+  it('maps gemini/google names to the gemini family', () => {
+    expect(resolveImageTokenProviderFamily('gemini')).toBe('gemini');
+    expect(resolveImageTokenProviderFamily('google')).toBe('gemini');
+  });
+
+  it('falls back to default for unknown, empty, or undefined providers', () => {
+    expect(resolveImageTokenProviderFamily(undefined)).toBe('default');
+    expect(resolveImageTokenProviderFamily('')).toBe('default');
+    expect(resolveImageTokenProviderFamily('stepfun')).toBe('default');
+  });
+
+  it('maps alias providers to the platform they proxy', () => {
+    expect(resolveImageTokenProviderFamily('claudecode')).toBe('anthropic');
+    expect(resolveImageTokenProviderFamily('claude-code')).toBe('anthropic');
+    expect(resolveImageTokenProviderFamily('codex')).toBe('openai');
+    expect(resolveImageTokenProviderFamily('azure-openai')).toBe('openai');
+    expect(resolveImageTokenProviderFamily('google-vertex-gemini')).toBe(
+      'gemini',
+    );
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(resolveImageTokenProviderFamily('  Claude  ')).toBe('anthropic');
+    expect(resolveImageTokenProviderFamily('GOOGLE')).toBe('gemini');
+    expect(resolveImageTokenProviderFamily('OpenAI')).toBe('openai');
+  });
+});
+
+describe('estimateImageTokens — anthropic reference values', () => {
+  it('produces 1590 for 1092x1092 (Anthropic docs)', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'anthropic',
+        dimensions: { width: 1092, height: 1092 },
+      }),
+    ).toBe(1590);
+  });
+
+  it('produces 54 for 200x200 (Anthropic docs)', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'anthropic',
+        dimensions: { width: 200, height: 200 },
+      }),
+    ).toBe(54);
+  });
+
+  it('never charges more than the largest accepted image', () => {
+    // Every oversized image is downscaled to at most 1092x1092 worth of pixels.
+    for (const dims of [
+      { width: 1568, height: 1568 },
+      { width: 3136, height: 1568 },
+      { width: 8000, height: 6000 },
+      { width: 20000, height: 100 },
+    ]) {
+      expect(
+        estimateImageTokens({ provider: 'anthropic', dimensions: dims }),
+      ).toBeLessThanOrEqual(1590);
+    }
+    expect(
+      estimateImageTokens({
+        provider: 'anthropic',
+        dimensions: { width: 1568, height: 1568 },
+      }),
+    ).toBe(1590);
+  });
+
+  it('never upscales an image below the limits', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'anthropic',
+        dimensions: { width: 10, height: 10 },
+      }),
+    ).toBe(1);
+    expect(
+      estimateImageTokens({
+        provider: 'anthropic',
+        dimensions: { width: 800, height: 600 },
+      }),
+    ).toBe(640);
+  });
+});
+
+describe('estimateImageTokens — openai reference values', () => {
+  it('produces 765 for 1024x1024 (OpenAI docs high detail)', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'openai',
+        dimensions: { width: 1024, height: 1024 },
+      }),
+    ).toBe(765);
+  });
+
+  it('produces 1105 for 2048x4096 (OpenAI docs high detail)', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'openai',
+        dimensions: { width: 2048, height: 4096 },
+      }),
+    ).toBe(1105);
+  });
+
+  it('normalises the shortest side to 768 and rounds into 512 tiles', () => {
+    // A square 768x768 yields exactly 4 tiles -> 170*4 + 85 = 765.
+    expect(
+      estimateImageTokens({
+        provider: 'openai',
+        dimensions: { width: 768, height: 768 },
+      }),
+    ).toBe(765);
+  });
+
+  it('counts a partial tile just past a 512-pixel boundary', () => {
+    // 4001x3000 normalises to ~1024.26x768, which needs a third tile column.
+    expect(
+      estimateImageTokens({
+        provider: 'openai',
+        dimensions: { width: 4001, height: 3000 },
+      }),
+    ).toBe(1105);
+    // 4000x3000 normalises to exactly 1024x768 and stays at two columns.
+    expect(
+      estimateImageTokens({
+        provider: 'openai',
+        dimensions: { width: 4000, height: 3000 },
+      }),
+    ).toBe(765);
+  });
+
+  it('charges wide panoramas for every tile column', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'openai',
+        dimensions: { width: 4096, height: 1024 },
+      }),
+    ).toBe(2125);
+  });
+});
+
+describe('estimateImageTokens — gemini and default families', () => {
+  it('returns the flat 3000 for gemini regardless of dimensions', () => {
+    for (const dims of [
+      { width: 100, height: 100 },
+      { width: 4096, height: 4096 },
+      { width: 1, height: 1 },
+    ]) {
+      expect(
+        estimateImageTokens({ provider: 'gemini', dimensions: dims }),
+      ).toBe(3000);
+    }
+  });
+
+  it('returns 3000 for gemini when dimensions are unknown', () => {
+    expect(estimateImageTokens({ provider: 'gemini' })).toBe(3000);
+  });
+
+  it('returns the flat 1000 default for unknown provider', () => {
+    expect(
+      estimateImageTokens({ dimensions: { width: 500, height: 500 } }),
+    ).toBe(1000);
+    expect(estimateImageTokens({})).toBe(DEFAULT_IMAGE_TOKEN_ESTIMATE);
+  });
+});
+
+describe('estimateImageTokens — unknown-dimension constants', () => {
+  it('anthropic unknown dimensions -> 1590', () => {
+    expect(estimateImageTokens({ provider: 'anthropic' })).toBe(1590);
+  });
+
+  it('the anthropic unknown fallback is never below a known estimate', () => {
+    const fallback = estimateImageTokens({ provider: 'anthropic' });
+    for (const dims of [
+      { width: 1, height: 1 },
+      { width: 1092, height: 1092 },
+      { width: 4096, height: 4096 },
+      { width: 30000, height: 30000 },
+    ]) {
+      expect(
+        estimateImageTokens({ provider: 'anthropic', dimensions: dims }),
+      ).toBeLessThanOrEqual(fallback);
+    }
+  });
+
+  it('openai unknown dimensions -> 1105', () => {
+    expect(estimateImageTokens({ provider: 'openai' })).toBe(1105);
+  });
+
+  it('gemini unknown dimensions -> 3000', () => {
+    expect(estimateImageTokens({ provider: 'gemini' })).toBe(3000);
+  });
+
+  it('default unknown dimensions -> 1000', () => {
+    expect(estimateImageTokens({})).toBe(1000);
+  });
+});
+
+describe('estimateImageTokens — degenerate dimensions treated as unknown', () => {
+  it('treats zero dimensions as unknown', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'anthropic',
+        dimensions: { width: 0, height: 0 },
+      }),
+    ).toBe(1590);
+  });
+
+  it('treats negative dimensions as unknown', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'openai',
+        dimensions: { width: -10, height: 100 },
+      }),
+    ).toBe(1105);
+  });
+
+  it('treats NaN dimensions as unknown', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'gemini',
+        dimensions: { width: Number.NaN, height: 100 },
+      }),
+    ).toBe(3000);
+  });
+
+  it('treats Infinity dimensions as unknown', () => {
+    expect(
+      estimateImageTokens({
+        provider: 'anthropic',
+        dimensions: { width: Number.POSITIVE_INFINITY, height: 100 },
+      }),
+    ).toBe(1590);
+  });
+
+  it('always returns a positive integer', () => {
+    const result = estimateImageTokens({
+      provider: 'openai',
+      dimensions: { width: 1024, height: 1024 },
+    });
+    expect(Number.isInteger(result)).toBe(true);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('estimateNonTextPartTokens', () => {
+  it('measures images from their parsed header dimensions', () => {
+    expect(
+      estimateNonTextPartTokens(
+        'image/png',
+        buildPngBase64(1092, 1092),
+        'anthropic',
+      ),
+    ).toBe(1590);
+    expect(
+      estimateNonTextPartTokens(
+        'image/png',
+        buildPngBase64(1024, 1024),
+        'openai',
+      ),
+    ).toBe(765);
+  });
+
+  it('uses the unknown-dimension estimate when the payload is unparseable', () => {
+    expect(
+      estimateNonTextPartTokens('image/png', 'not-a-real-png', 'anthropic'),
+    ).toBe(1590);
+    expect(estimateNonTextPartTokens('image/png', undefined, 'openai')).toBe(
+      1105,
+    );
+  });
+
+  it('returns the flat default for non-image binary payloads', () => {
+    expect(
+      estimateNonTextPartTokens('application/pdf', 'JVBERi0=', 'anthropic'),
+    ).toBe(DEFAULT_IMAGE_TOKEN_ESTIMATE);
+    expect(estimateNonTextPartTokens('audio/mpeg', 'AAAA', 'openai')).toBe(
+      DEFAULT_IMAGE_TOKEN_ESTIMATE,
+    );
+    expect(estimateNonTextPartTokens(undefined, undefined)).toBe(
+      DEFAULT_IMAGE_TOKEN_ESTIMATE,
+    );
+  });
+
+  it('is case-insensitive on the image MIME type', () => {
+    expect(
+      estimateNonTextPartTokens(
+        'IMAGE/PNG',
+        buildPngBase64(200, 200),
+        'anthropic',
+      ),
+    ).toBe(54);
+  });
+
+  it('falls back to the default family when no provider is supplied', () => {
+    expect(
+      estimateNonTextPartTokens('image/png', buildPngBase64(1024, 1024)),
+    ).toBe(DEFAULT_IMAGE_TOKEN_ESTIMATE);
+  });
+});

--- a/project-plans/issue1648/plan.md
+++ b/project-plans/issue1648/plan.md
@@ -1,0 +1,161 @@
+# Issue #1648 — Provider-aware image token estimation
+
+Plan ID: `PLAN-20260803-ISSUE1648`
+
+## 1. Problem (verified against the codebase)
+
+| # | Claim in issue | Verified state on `main` |
+|---|---|---|
+| 1 | Compression strategies ignore image tokens | **TRUE.** `packages/core/src/services/history/historyTokenEstimation.ts` `blockToEstimationText()` maps `case 'media': return block.caption ?? ''`. With no caption the block contributes **0 tokens**. `CompressionHandler.ts` injects `estimateTokens: (contents) => historyService.estimateTokensForContents(contents)`, which routes through that exact function. So `HighDensityStrategy` / `TopDownTruncationStrategy` see images as free. |
+| 2 | `toolOutputLimiter.ts` has no image awareness | **TRUE but not reachable.** Every call site of `estimateTokens(text: string)` (core and tools copies) receives a plain `string`; `Part[]` / `MediaBlock` / binary never reaches it. |
+| 3 | `read-many-files.ts` hardcodes `85` | **TRUE.** `packages/tools/src/tools/read-many-files.ts` `addFileContent()` uses `const estimatedTokens = 85` for every non-text part (images, PDFs, audio). |
+
+## 2. Accepted behaviour (acceptance criteria)
+
+### AC-1 — Provider-aware image token estimator
+A pure, dependency-free estimator exists and is the single source of truth for image token cost.
+
+`estimateImageTokens({ provider?, dimensions? }): number`
+
+Provider family resolution (case-insensitive **substring** match on the provider name,
+mirroring the tokenizer matchers in `providerManagerInstance.ts` so alias providers that
+wrap a backing platform — `claudecode`, `codex`, `azure-openai` — resolve to the platform
+they proxy rather than falling through to the default):
+
+| Provider name contains | Family |
+|---|---|
+| `anthropic`, `claude` | `anthropic` |
+| `gemini`, `google` | `gemini` |
+| `openai`, `codex` | `openai` |
+| anything else / `undefined` | `default` |
+
+Formulas:
+
+- **anthropic** — downscale until both documented limits hold (never upscaling): long edge
+  at most `1568` px, and total pixels at most `1092 * 1092` (Anthropic's largest accepted
+  1:1 image). Then `Math.ceil(pixels / 750)`.
+  Reference values from Anthropic docs: `1092x1092 -> 1590`, `200x200 -> 54`.
+  The pixel ceiling means no image can be charged more than `1590` tokens, which keeps the
+  known-dimension path consistent with the unknown-dimension fallback.
+- **openai** (high detail) — (a) scale to fit inside `2048x2048` preserving aspect ratio; (b) scale so the shortest side is exactly `768`; (c) `tiles = ceil(w/512) * ceil(h/512)` computed on the **unrounded** scaled dimensions, with a `1e-6` tolerance so a side that lands mathematically on a tile edge does not gain a phantom tile; (d) `tokens = 170 * tiles + 85`.
+  Reference values from OpenAI docs: `1024x1024 -> 765`, `2048x4096 -> 1105`.
+  Boundary evidence: `4000x3000 -> 765` (exactly `1024x768`) but `4001x3000 -> 1105`
+  (`~1024.26x768`, which needs a third tile column).
+- **gemini** — flat `3000` regardless of dimensions (upstream `IMAGE_TOKEN_ESTIMATE`; Google publishes no client-side formula). Explicitly the behaviour named in the issue.
+- **default** — flat `1000` (issue-specified: better than `85`, safer than `3000`).
+
+Unknown dimensions (`dimensions` omitted or unparseable) resolve to a per-family documented constant:
+
+| Family | Unknown-dimension tokens | Rationale |
+|---|---|---|
+| anthropic | `1590` | the cost of Anthropic's largest accepted image, i.e. the true maximum the known-dimension path can return |
+| openai | `1105` | the larger of OpenAI's two published high-detail examples (`2048x4096`) |
+| gemini | `3000` | same flat constant |
+| default | `1000` | issue-specified fallback |
+
+The OpenAI tile formula has **no** finite maximum because the aspect ratio is unbounded
+(`4096x1024 -> 2125`), so no constant can dominate every known-dimension result. A
+documented example is preferred over an arbitrarily large constant that would make
+context compression fire spuriously for every URL-referenced image.
+
+Boundary rules: non-finite, zero, or negative dimensions are treated as unknown. Results are always positive integers.
+
+### AC-2 — Dependency-free image dimension parsing
+`parseImageDimensions(bytes): { width, height } | undefined` reads dimensions from raw header bytes for **PNG**, **JPEG**, **GIF**, and **WEBP** (VP8 / VP8L / VP8X). It returns `undefined` for unrecognised, truncated, or corrupt input — it never throws.
+
+`parseImageDimensionsFromBase64(base64): { width, height } | undefined` decodes a bounded prefix of the base64 payload (enough to cover JPEG EXIF-heavy headers) and delegates to `parseImageDimensions`. It tolerates `data:` URI prefixes and embedded whitespace, and returns `undefined` on invalid base64.
+
+Rationale for a hand-rolled parser: `sharp` exists only in `packages/tools` and requires a full decode; header parsing is a few dozen bytes and works in every package.
+
+### AC-3 — History / compression estimation counts images
+`estimateContentTokens()` in `packages/core/src/services/history/historyTokenEstimation.ts`:
+
+- For a `media` block whose `mimeType` starts with `image/`: token cost = tokens for `caption` (via the injected tokenizer, unchanged behaviour) **plus** `estimateImageTokens({ provider, dimensions })`.
+  - `encoding === 'base64'` -> dimensions parsed from the payload.
+  - `encoding === 'url'` -> dimensions unknown -> per-family unknown constant.
+- For a `media` block with a non-image MIME type: behaviour is **unchanged** (caption only). Audio/PDF estimation is out of scope for this issue.
+- The active provider reaches the estimator through the existing `TokenizerProvider` abstraction (`HistoryService` already tracks `activeTokenizationProvider`). No new public subsystem.
+
+Consequence proven by test: `HistoryService.estimateTokensForContents()` — the exact function `CompressionHandler` injects as `CompressionContext.estimateTokens` — returns a materially larger number for history containing images, and the number varies by active provider. A strategy-level test drives `TopDownTruncationStrategy` with that real estimator and shows an image changes the truncation outcome.
+
+The load-balancer estimator (`loadBalancerTokenEstimator.ts`) shares this estimation path and previously discarded the selected subprofile's provider name; it now propagates it on both the tokenizer and generic paths so load-balanced requests get the same provider-aware image accounting.
+
+### AC-4 — `read-many-files` no longer hardcodes 85
+`addFileContent()` estimates non-text parts as:
+
+- `image/*` -> `estimateImageTokens({ dimensions: parseImageDimensionsFromBase64(data) })`. The tool layer has no provider handle (`IToolHost` exposes none), so the `default` family applies. This is exactly the issue's stated minimum ("at minimum raise it to 1000+ as a safer default") while routing through the shared estimator instead of a second magic number.
+- non-image non-text (PDF, audio, video) -> the same exported `default` constant.
+
+The literal `85` is removed.
+
+### AC-5 — `toolOutputLimiter` — no change, with evidence
+Every call site passes a `string`; no `Part[]`/media path exists. Changing it would be speculative. Recorded here as a deliberate no-op finding.
+
+## 3. Out of scope (explicitly not doing)
+
+- Server-side `countTokens` calls for Gemini.
+- Dimension-aware Gemini estimation (issue specifies the flat constant).
+- Audio / PDF / video token estimation.
+- Adding a provider accessor to `IToolHost` (public abstraction change; would need approval).
+- Unifying the separate `loadBalancerTokenEstimator` media heuristic.
+- Any change to lint/complexity configuration.
+
+## 4. Placement and dependency boundary
+
+`packages/core` **must not** import `packages/providers`. Dependency edges that already exist: `core -> tools`, and `tools -> (nothing)`.
+
+Therefore the estimator lives in the leaf package next to the existing `imageResize.ts`:
+
+- `packages/tools/src/utils/imageDimensions.ts`
+- `packages/tools/src/utils/imageTokenEstimation.ts`
+
+Both get subpath entries in `packages/tools/package.json` `exports` (mirroring the existing `./utils/*.js` entries) plus barrel re-exports in `packages/tools/index.ts`. `packages/core` imports them by subpath so the history hot path does not pull the whole tools barrel.
+
+## 5. Test-first plan (behavioural, no mock theatre)
+
+Order: every test below is written and observed failing before the corresponding production code.
+
+### T1 — `packages/tools/test-bun/imageDimensions.bun.ts` (bun, registered in `scripts/bun-test-manifest.ts` under the `tools` workspace)
+- PNG built from a real IHDR header -> exact `{width, height}`.
+- JPEG with a baseline SOF0 -> exact dimensions.
+- JPEG with a large APP1/EXIF segment before SOF -> exact dimensions (proves marker walking).
+- GIF87a / GIF89a -> exact dimensions (little-endian).
+- WEBP lossy (`VP8 `), lossless (`VP8L`), extended (`VP8X`) -> exact dimensions.
+- Truncated PNG / random bytes / empty input -> `undefined`, no throw.
+- Base64 variant: `data:image/png;base64,...` prefix, whitespace-wrapped base64, invalid base64 -> correct value / `undefined`.
+
+### T2 — `packages/tools/test-bun/imageTokenEstimation.bun.ts` (bun, registered in the manifest)
+- Anthropic reference values `1092x1092 -> 1590`, `200x200 -> 54`.
+- Anthropic long-edge clamp: `3136x1568` collapses to the `1568`-capped result; a small image is never upscaled.
+- OpenAI reference values `1024x1024 -> 765`, `2048x4096 -> 1105`.
+- OpenAI tile boundary: shortest-side normalisation to `768` and `512`-tile rounding.
+- Gemini flat `3000` for several sizes and for unknown dimensions.
+- Unknown provider -> `1000`.
+- Unknown dimensions per family -> the documented constants.
+- Provider name case-insensitivity and alias handling (`Claude`, `GOOGLE`).
+- Degenerate dimensions (`0`, negative, `NaN`, `Infinity`) -> treated as unknown.
+
+### T3 — `packages/core/src/services/history/historyTokenEstimation.imageTokens.test.ts` (bun; core auto-discovers)
+- `IContent` with a base64 PNG `media` block and provider `anthropic` -> total equals caption tokens + the Anthropic formula for the embedded dimensions.
+- Same content with provider `openai` and with `gemini` -> different, provider-specific totals (proves provider awareness, not a constant).
+- `media` block with `encoding: 'url'` -> the unknown-dimension constant for that family.
+- `media` block with `mimeType: 'audio/mpeg'` -> unchanged caption-only behaviour.
+- Mixed text + image content -> text tokens and image tokens both present and additive.
+- Unknown/absent provider -> `1000` default.
+
+### T4 — compression-facing evidence (bun, core)
+Through a real `HistoryService` (`setActiveTokenizationTarget`, then `estimateTokensForContents`) — the exact call `CompressionHandler` injects into `CompressionContext.estimateTokens`:
+- history containing an image returns materially more tokens than the same history with the image removed;
+- the delta matches the estimator for the configured provider.
+
+### T5 — `read-many-files` non-text accounting
+Extend the existing `packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts` (no new vitest file):
+- reading an image whose estimate exceeds `tool-output-max-tokens` is skipped with the existing "would exceed token limit (non-text content)" reason, at a budget that would have passed under the old `85`;
+- the reported total token count reflects the new estimate.
+
+## 6. Verification gates
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+
+No `eslint-disable`, no TS suppression directives, no complexity-threshold changes.

--- a/scripts/bun-test-manifest-data-tools.ts
+++ b/scripts/bun-test-manifest-data-tools.ts
@@ -10,6 +10,8 @@ export const TOOLS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
   workspace: 'tools',
   preload: 'test-setup-storage-isolation.ts',
   files: [
+    'test-bun/imageDimensions.bun.ts',
+    'test-bun/imageTokenEstimation.bun.ts',
     'test-bun/language-analysis.followup.bun.ts',
     'src/tools/activate-skill.test.ts',
     'src/tools/ast-edit.ide.test.ts',

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -459,6 +459,7 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       'src/kimi/kimiMediaProcessing.test.ts',
       'src/kimi/usageInfo.test.ts',
       'src/loadBalancing/failoverState.test.ts',
+      'src/loadBalancing/loadBalancerTokenEstimator.imageTokens.test.ts',
       'src/logging/conversationResponseLogger.test.ts',
       'src/logging/ProviderPerformanceTracker.test.ts',
       'src/logging/serverToolLogger.test.ts',

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -712,6 +712,7 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       'scripts/tests/ocr-review-422-grouping.bun.test.ts',
       'scripts/tests/ocr-review-422-wiring.bun.test.ts',
       'scripts/tests/ocr-review-coverage-preview.bun.test.ts',
+      'scripts/tests/ocr-review-github-script-syntax.bun.test.ts',
       'scripts/tests/ocr-review-incremental-checkpoint-b.bun.test.ts',
       'scripts/tests/ocr-review-workflow.bun.test.ts',
     ],

--- a/scripts/tests/ocr-review-github-script-syntax.bun.test.ts
+++ b/scripts/tests/ocr-review-github-script-syntax.bun.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `actions/github-script` compiles a step's whole `script:` input into an
+ * AsyncFunction before executing any of it, so a single stray character
+ * anywhere in the block kills the step at parse time — no matter which branch
+ * of the script would actually have run. That is silent in review: the YAML is
+ * still valid, every other job stays green, and the breakage only surfaces on
+ * the first pull request whose OCR run reaches the step.
+ *
+ * These tests compile every `github-script` block in the OCR review workflow
+ * the same way the action does, so a malformed template literal fails here
+ * instead of in CI.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { readRootFile, WORKFLOW_PATH } from './ocr-review-workflow-helpers.ts';
+import {
+  jobSteps,
+  parseWorkflowYaml,
+  type WorkflowStep,
+} from './typed-test-helpers.ts';
+
+const GITHUB_SCRIPT_ACTION = 'actions/github-script@';
+
+const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor as new (
+  body: string,
+) => unknown;
+
+interface GithubScriptBlock {
+  readonly job: string;
+  readonly step: string;
+  readonly source: string;
+}
+
+function stepScript(step: WorkflowStep): string | undefined {
+  const uses = typeof step.uses === 'string' ? step.uses : '';
+  if (!uses.startsWith(GITHUB_SCRIPT_ACTION)) return undefined;
+  const script = step.with?.['script'];
+  return typeof script === 'string' ? script : undefined;
+}
+
+function collectGithubScriptBlocks(): GithubScriptBlock[] {
+  const workflow = parseWorkflowYaml(readRootFile(WORKFLOW_PATH));
+  const blocks: GithubScriptBlock[] = [];
+  for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+    for (const [index, step] of jobSteps(job).entries()) {
+      const source = stepScript(step);
+      if (source === undefined) continue;
+      blocks.push({
+        job: jobName,
+        step: step.name ?? step.id ?? `step #${index}`,
+        source,
+      });
+    }
+  }
+  return blocks;
+}
+
+describe(`${WORKFLOW_PATH} — github-script blocks compile`, () => {
+  const blocks = collectGithubScriptBlocks();
+
+  it('finds the github-script steps it is meant to guard', () => {
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks.some((block) => block.step === 'Post OCR results')).toBe(
+      true,
+    );
+  });
+
+  for (const block of blocks) {
+    it(`compiles ${block.job} / ${block.step}`, () => {
+      // Compiling — not running — mirrors what actions/github-script does
+      // before it invokes the script, and executes none of the workflow logic.
+      expect(() => new AsyncFunction(block.source)).not.toThrow();
+    });
+  }
+});


### PR DESCRIPTION
Closes #1648

## Problem

Image content was effectively **free** in LLxprt's context accounting.

`historyTokenEstimation.ts` mapped every `media` block to `block.caption ?? ''`, so an image with no caption contributed **zero tokens**. That function is exactly what `CompressionHandler` injects as `CompressionContext.estimateTokens`, so `HighDensityStrategy` and `TopDownTruncationStrategy` were blind to images and conversations silently overran the model's context window.

Separately, `read-many-files.ts` charged a flat `85` tokens for every non-text part. That constant is OpenAI's *low detail* price and is wrong on every provider and every resolution.

## What this adds

### A provider-aware estimator (`packages/tools/src/utils/imageTokenEstimation.ts`)

Pure, dependency-free, no new packages. Provider families are resolved by substring so alias providers that wrap a backing platform (`claudecode`, `codex`, `azure-openai`) map to the platform they proxy rather than falling through to the default — this mirrors the tokenizer matchers already used in `providerManagerInstance.ts`.

| Family | Formula | Published reference values |
| --- | --- | --- |
| anthropic | downscale until long edge <= 1568 px **and** total pixels <= 1092x1092, then `ceil(pixels / 750)` | `1092x1092 -> 1590`, `200x200 -> 54` |
| openai | fit inside 2048x2048, normalise shortest side to 768, `ceil(w/512) * ceil(h/512)` tiles at 170 each + 85 base | `1024x1024 -> 765`, `2048x4096 -> 1105` |
| google | flat 3000 (no client-side formula is published; matches upstream's constant) | n/a |
| default | flat 1000 (better than 85, safer than 3000) | n/a |

Tiles are counted from the **unrounded** scaled dimensions with a 1e-6 tolerance, so a partial tile column is never dropped: `4000x3000 -> 765` (exactly 1024x768) but `4001x3000 -> 1105` (~1024.26x768).

The Anthropic pixel ceiling means no image can be charged more than 1590 tokens, which keeps the known-dimension path consistent with the unknown-dimension fallback.

Unknown dimensions (URL-referenced images, unparseable payloads) fall back to `1590` / `1105` / `3000` / `1000` respectively.

### A dependency-free dimension parser (`packages/tools/src/utils/imageDimensions.ts`)

`sharp` lives only in `packages/tools` and requires a full decode, so dimensions are read straight from the header bytes for **PNG** (IHDR), **GIF** (little-endian screen descriptor), **JPEG** (segment walk to the SOF, tolerating large APP1/EXIF blocks and standalone markers), and **WEBP** (VP8 with keyframe start-code validation, VP8L bit unpacking, VP8X 24-bit canvas). It never throws and returns `undefined` for unrecognised, truncated, or corrupt input.

`parseImageDimensionsFromBase64` bounds the input window before stripping a `data:` URI prefix so a multi-megabyte payload is never scanned or copied in full.

### Wiring

- `historyTokenEstimation.ts` now adds the provider-specific image cost for `media` blocks with an `image/*` MIME type, **in addition to** the existing caption tokens. Non-image media (audio, PDF) behaviour is unchanged.
- The active provider reaches the estimator through the existing `TokenizerProvider` abstraction, which gains an optional `activeProvider`. `HistoryService` supplies it from `activeTokenizationProvider` at both estimation entry points.
- `loadBalancerTokenEstimator.ts` shares this estimation path and previously discarded the selected subprofile's provider name; it now propagates it on both the tokenizer and the generic fallback paths.
- `read-many-files.ts` drops the literal `85` and routes through the shared estimator. The tool layer has no provider handle (`IToolHost` exposes none, and adding one is out of scope), so images there use the default family.

### Deliberately not changed

`toolOutputLimiter.ts` — every call site of `estimateTokens(text: string)` in both the core and tools copies receives a plain `string`. No `Part[]`, `MediaBlock`, or binary path exists, so image awareness there would be speculative.

Also out of scope: server-side `countTokens` for Google, dimension-aware Google estimation (the issue specifies the flat constant), audio/PDF/video estimation, and a provider accessor on `IToolHost`.

## Behavioural evidence

All new tests are bun tests, registered in `scripts/bun-test-manifest*.ts`.

- `packages/tools/test-bun/imageTokenEstimation.bun.ts` — every published reference value asserted as a literal, plus alias resolution, the Anthropic ceiling, the OpenAI 512-tile boundary in both directions, panorama tile counts, unknown-dimension constants, and degenerate dimensions.
- `packages/tools/test-bun/imageDimensions.bun.ts` — all four formats built from real header bytes (no binary fixtures), a JPEG with a large APP1 before the SOF, standalone RST markers, corrupt VP8 start codes, truncated and random input, `data:` prefixes, whitespace-wrapped and unpadded base64, and a payload far larger than the decode bound.
- `packages/core/src/services/history/historyTokenEstimation.imageTokens.test.ts` — per-provider totals through the real estimation function using a deterministic counting tokenizer, URL-encoded media, non-image media, and mixed text+image.
- `packages/core/src/services/history/historyTokenEstimation.compressionEvidence.test.ts` — the exact `HistoryService.estimateTokensForContents` call `CompressionHandler` injects, with the image delta asserted against published values.
- `packages/agents/src/compression/TopDownTruncationStrategy.test.ts` — the strategy driven end to end with the real `HistoryService` estimator: an image-bearing history is truncated more aggressively than the identical text-only history, and the retained message count varies with the active provider.
- `packages/providers/src/loadBalancing/loadBalancerTokenEstimator.imageTokens.test.ts` — exact per-provider image charges through `estimateRequestTokens`.
- `packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts` — an image is now skipped at a budget the old `85` would have passed, and the reported total reflects the new estimate.

## Verification

`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and `bun scripts/start.ts --profile-load stepfun-37` all pass locally on the rebased head.

No lint or complexity rule was loosened, and no eslint/TypeScript suppression directive was added.
