### PR TITLE
Document image generation and editing (Fixes #2977)

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -70,6 +70,15 @@ Slash commands control the CLI itself — configuration, navigation, session man
 | `/policies`    | View active policy rules              |
 | `/todo`        | View or manage the current todo list  |
 
+### Images
+
+| Command                                          | Description                                                          |
+| ------------------------------------------------ | -------------------------------------------------------------------- |
+| `/image <output.png> [input.png ...] "<prompt>"` | Generate or edit an image (zero inputs generates; one-to-five edits) |
+
+See [Image Generation](../tools/image-generation.md) for prerequisites,
+quoting rules, path rules, and the non-interactive `-O`/`-P`/`-I` flags.
+
 ### UI and Display
 
 | Command         | Description                                  |

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -11,6 +11,7 @@ For a general overview, see the [main documentation page](../index.md).
 | Save and switch between configurations    | [Profiles](./profiles.md)                             |
 | Tailor how LLxprt Code behaves            | [Configuration](./configuration.md)                   |
 | Run LLxprt Code in scripts and automation | [Non-interactive mode](#non-interactive-mode) (below) |
+| Generate or edit an image                 | [Image Generation](../tools/image-generation.md)      |
 | Customise the CLI's appearance            | [Themes](./themes.md)                                 |
 
 ## Get authenticated
@@ -100,3 +101,17 @@ interacting afterward.
 | `llxprt -i "prompt"`         | Interactive     | Yes                |
 | `llxprt --profile-load name` | Interactive     | Yes                |
 | `echo "prompt" \| llxprt`    | Non-interactive | No                 |
+
+### Image generation (`-O` / `-P`)
+
+Generate or edit an image without starting a conversation. `-O` sets the output
+path and `-P` sets the prompt; both are required. Use `-I` to supply input
+images for editing (repeatable up to five times):
+
+```bash
+llxprt -O out.png -P "a photorealistic cat"
+```
+
+Image generation runs on your Codex account and is independent of the provider
+you would chat with. See [Image Generation](../tools/image-generation.md) for
+prerequisites, the full flag reference, and path rules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ Add capabilities through MCP servers, lifecycle hooks, custom themes, and more.
 
 ## Tools
 
-LLxprt Code ships with built-in tools for file editing, shell commands, web search, code analysis, and memory. It also supports [MCP servers](./tools/mcp-server.md) and [extensions](./extension.md) for adding additional tools and capabilities. See the **[Tools Overview](./tools/index.md)** for the full list.
+LLxprt Code ships with built-in tools for file editing, shell commands, web search, code analysis, and memory. It also supports [MCP servers](./tools/mcp-server.md) and [extensions](./extension.md) for adding additional tools and capabilities. See the **[Tools Overview](./tools/index.md)** for the full list, including [image generation](./tools/image-generation.md).
 
 ## Reference
 

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -1,0 +1,331 @@
+# Image Generation and Editing
+
+Generate or edit PNG images from a text prompt. This page covers the three ways
+to reach the feature — the `/image` slash command, the `generate_image` tool the
+model calls on its own, and the non-interactive CLI flags — and the rules that
+apply to all of them.
+
+## Audience and goal
+
+You want to create a new image or change an existing one from inside LLxprt
+Code. You may be using any conversational provider (Anthropic, z.ai, Gemini, a
+local model, or any other). This page shows you the fastest path and then the
+rules and limits that apply to every entry point.
+
+## Two things to know first
+
+These two facts trip up most first-time users, so read them before anything else.
+
+1. **Image generation runs on your Codex account, not your chat provider.** It
+   uses ChatGPT Plus/Pro subscription OAuth through Codex. It is completely
+   independent of the provider you are chatting with. You can be talking to
+   Anthropic, z.ai, Gemini, or a local model and still generate images.
+   Generating an image does not change your active provider or model in any way.
+
+2. **Setup is `/auth codex enable`.** If image generation reports that it is
+   unavailable, that is almost always the reason.
+
+## Prerequisites
+
+- An **active ChatGPT Plus or Pro subscription**, plus Codex OAuth. Enable it
+  with:
+
+  ```text
+  /auth codex enable
+  ```
+
+  Enabling is lazy: nothing opens until your first Codex request, and the
+  browser login appears when you run your first image operation. Use
+  `/auth codex login` instead if you want to sign in immediately. See
+  [Authentication](../cli/authentication.md) and
+  [OAuth Setup](../oauth-setup.md) for the full setup walkthrough.
+
+- The model behind image generation is `gpt-image-2`, and the output is always
+  **PNG**. You cannot choose a different model or output format.
+
+## Quick start
+
+Once Codex OAuth is enabled, generate your first image from the REPL:
+
+```text
+/image output.png "Create a black-and-white line-art cat"
+```
+
+On success the command reports what it did and the absolute path it wrote:
+
+```text
+Generated image.
+Saved to: /path/to/workspace/output.png
+```
+
+Open that file to see the result.
+
+## The three entry points
+
+All three entry points converge on one underlying image service, so the rules in
+[Output rules](#output-rules) and [Input rules](#input-rules) apply to each of
+them. How you supply the prompt and the paths differs, and so does the wording of
+the errors you get back.
+
+| Entry point                                             | When to use it                                                     |
+| ------------------------------------------------------- | ------------------------------------------------------------------ |
+| [`/image` slash command](#the-image-slash-command)      | You are in the REPL and want direct control over paths and prompt. |
+| [`generate_image` tool](#the-generate_image-tool)       | You want the model to produce an image as part of a task.          |
+| [Non-interactive CLI flags](#non-interactive-cli-flags) | You are scripting or automating an image operation.                |
+
+### The `/image` slash command
+
+The slash command is the most direct way to generate or edit an image from the
+REPL.
+
+#### Grammar
+
+```text
+/image <output.png> [<input.png> ...] "<prompt>"
+```
+
+- The **output path** is the first argument and is required.
+- Zero **input paths** generates a new image; one to five input paths edit or
+  compose from them.
+- The **prompt** is the last argument and is required.
+
+#### Quoting
+
+Quote the prompt whenever it contains spaces, and **always** quote it when you
+supply input paths. Only a single-word prompt with no input paths may be left
+unquoted. Single quotes and double quotes both work. Inside a quoted string, a
+backslash escapes the enclosing quote character, or another backslash. Quoted
+paths may contain spaces.
+
+The **last** argument is always taken as the prompt, so put every input path
+before it. An unquoted argument after a quoted one is rejected as a trailing
+argument. A `--` separator is not accepted.
+
+#### Tab completion
+
+Paths support tab completion, and what is offered depends on which argument you
+are typing:
+
+- **Output path** — workspace directories, plus a suggested `.png` filename.
+  Existing images are not offered here, because the output must be a new file.
+- **Input paths** — existing `.png` files and directories inside the workspace,
+  plus a hint that you can start the prompt. Once five inputs are present, only
+  the prompt hint remains.
+- **Prompt** — no filesystem completion while you are typing inside the quotes.
+
+Nothing outside the workspace is ever suggested.
+
+#### On success
+
+The command reports what it did and the exact absolute path it wrote:
+
+```text
+Generated image.
+Saved to: /path/to/workspace/output.png
+```
+
+Editing reports `Edited image.` instead.
+
+#### Examples
+
+These are the three examples shown in the built-in usage text:
+
+```text
+/image output.png "Create a black-and-white line-art cat"
+```
+
+```text
+/image fixed.png original.png "Correct the lettering"
+```
+
+```text
+/image composite.png subject.png background.png "Place the subject into the background"
+```
+
+### The `generate_image` tool
+
+The `generate_image` tool is what the model calls when you ask it to produce an
+image as part of a task (for example, "generate a diagram of this architecture
+and save it"). You do not call it directly.
+
+#### Parameters
+
+| Parameter     | Required | Description                                                                                                  |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `prompt`      | Yes      | A non-empty text description. Whitespace-only prompts are rejected.                                          |
+| `output_path` | Yes      | Where to save the result. Must end in `.png`. Relative to the workspace root, or an absolute path inside it. |
+| `input_paths` | No       | An array of zero to five input images. Omit (or leave empty) to generate; supply one to five to edit.        |
+
+There is **no** model parameter. The backend owns the model identity, and
+calling the tool never changes your active conversational provider or model.
+
+#### What it returns
+
+The tool returns the saved path as text **plus the image itself as media**, so
+the model can see what it produced and continue working with it.
+
+The prompt, the output extension and workspace containment, and every input path
+are validated before the provider request is made, so a bad path costs you
+nothing. The no-overwrite rule is the exception: it is enforced when the result
+is saved, so an output path that already exists fails _after_ the image has been
+generated.
+
+### Non-interactive CLI flags
+
+For scripting and automation, LLxprt Code accepts dedicated image flags.
+
+| Flag                        | Short | Purpose                                                                                         |
+| --------------------------- | ----- | ----------------------------------------------------------------------------------------------- |
+| `--image-output <path.png>` | `-O`  | The output path (required).                                                                     |
+| `--image-prompt "<text>"`   | `-P`  | The prompt (required).                                                                          |
+| `--image-input <path.png>`  | `-I`  | An input image. Repeatable up to five times; order is preserved and values are not comma-split. |
+
+Both `-O` and `-P` are required whenever any image flag is present. Supplying
+only one is an error.
+
+#### Generate
+
+```bash
+llxprt -O out.png -P "a photorealistic cat"
+```
+
+#### Edit with two inputs
+
+```bash
+llxprt -O composite.png -I subject.png -I background.png -P "Place the subject into the background"
+```
+
+#### Conflicts and restrictions
+
+- Image mode is **mutually exclusive** with a conversational prompt. You cannot
+  combine the image flags with a positional prompt, `--prompt`/`-p`, or
+  `--prompt-interactive`/`-i`.
+- `--output-format stream-json` is **not** supported with image mode.
+
+#### Output
+
+By default the process prints human-readable text:
+
+```text
+Generated image via <backend> (<model>).
+Saved to: <absolute path>
+```
+
+Editing prints `Edited image via …` instead.
+
+With `--output-format json` you get a JSON object containing:
+
+| Field                  | Description                                  |
+| ---------------------- | -------------------------------------------- |
+| `operation`            | `generate` or `edit`                         |
+| `output_path`          | The absolute saved path                      |
+| `relative_output_path` | The path relative to the workspace root      |
+| `mime_type`            | The image MIME type                          |
+| `backend`              | The backend that produced the image          |
+| `provider`             | The provider name                            |
+| `model`                | The model name                               |
+| `input_paths`          | The input images used (empty for generation) |
+
+Base64 image data is **never** printed.
+
+The process exits nonzero when the operation fails or is cancelled.
+
+## Output rules
+
+These rules come from the shared image service, so they apply to all three entry
+points.
+
+- The output path **must end in `.png`**.
+- Relative paths resolve against the **workspace root**. Paths outside the
+  workspace are rejected — including paths that escape through a symlink.
+- **Missing parent directories are created** automatically.
+- Existing files are **never overwritten**. The operation fails with a message
+  of the form:
+
+  ```text
+  Output file already exists (will not overwrite): <absolute path>.
+  ```
+
+  Remove the file first if you want to replace it. This check happens when the
+  image is saved, not before it is generated.
+
+- Writes are **atomic**. A cancelled or failed operation never leaves a partial
+  file at the target path.
+
+## Input rules
+
+Input rules apply when editing (the `/image` command with inputs, the
+`generate_image` tool with `input_paths`, or `-I` flags).
+
+- You can supply **one to five** input images. More than five is rejected.
+- Inputs must be **PNG**: both a `.png` extension **and** a valid PNG file
+  signature are required.
+- Inputs must be **existing regular files inside the workspace**. Symbolic links
+  are rejected.
+- **Remote URLs** are rejected: a path beginning with `http://`, `https://`, or
+  `file://` is refused. Copy the file into the workspace first.
+- Each input is capped at **20 MiB** (20 × 1024 × 1024 bytes).
+
+## Limitations
+
+- While a `/image` request is running in the interactive UI, the input prompt is
+  hidden and **Esc does not cancel the request**. Generation can take a minute
+  or more, so check the paths and the prompt before you press Enter. See
+  [the known-limitation tracking issue](https://github.com/vybestack/llxprt-code/issues/2976)
+  for status. The non-interactive flags are not affected: Ctrl+C cancels an
+  image operation started with `-O`/`-P`, and no partial file is left behind.
+- **No model selection.** The model is always `gpt-image-2`.
+- **PNG output only.**
+- **No overwrite.** Remove an existing file before reusing its path.
+
+## Troubleshooting
+
+### Image generation reported as unavailable
+
+Codex OAuth is almost always the reason. Run:
+
+```text
+/auth codex enable
+```
+
+then retry the image request; the browser opens for login on that first request.
+Use `/auth codex login` if you would rather sign in straight away.
+
+This is **not** related to your current provider. Image generation uses your
+Codex account regardless of which provider you chat with.
+
+### An error about the output file already existing
+
+An image already exists at that path, and existing files are never overwritten.
+Remove the file or choose a new output name.
+
+### An error about the output path
+
+The output path resolved outside the workspace, escaped through a symlink, or
+does not end in `.png`. Use a path inside the workspace that ends in `.png`. The
+exact wording differs slightly between `/image` and the CLI flags, but the fix
+is the same.
+
+### An input image was rejected
+
+An input is refused when it is **not a PNG** (extension or file signature), is a
+**symlink**, is **outside the workspace**, is a **URL**, or is **larger than
+20 MiB**. Copy a valid PNG into the workspace and reference that local path.
+
+### `/image` prompt quoting errors
+
+- **Unquoted prompt** — quote it: `/image out.png "my prompt"`. A prompt with
+  spaces always needs quotes, and so does any prompt used together with input
+  paths.
+- **Unterminated quote** — make sure every opening quote has a matching closing
+  quote.
+- **Trailing arguments after the prompt** — the prompt must be the final
+  argument. Move any path arguments before it.
+
+## Related
+
+- [Tools](./index.md) — all built-in tools
+- [CLI Commands](../cli/commands.md) — slash command reference
+- [Authentication](../cli/authentication.md) — key management, keyring, OAuth
+- [OAuth Setup](../oauth-setup.md) — OAuth configuration
+- [CLI](../cli/index.md) — non-interactive mode and scripting

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -47,6 +47,15 @@ The shell tool is the only tool that can reach **outside your workspace**. All f
 | `direct_web_fetch` | Fetch and convert a URL to text/markdown      |
 | `codesearch`       | Search for code snippets, APIs, documentation |
 
+### Images
+
+| Tool             | What It Does                                           |
+| ---------------- | ------------------------------------------------------ |
+| `generate_image` | Generate or edit an image (Codex-backed, any provider) |
+
+Image generation runs on your Codex account and is independent of the provider
+you are chatting with. See [Image Generation](./image-generation.md).
+
 ### GitHub
 
 | Tool     | What It Does                                       |
@@ -143,6 +152,7 @@ The **shell tool is the exception** — it can run any command your user account
 ## Related
 
 - [GitHub](./github.md) — issues, pull requests and checks without a token in the sandbox
+- [Image Generation](./image-generation.md) — generate or edit images (Codex-backed, any provider)
 - [MCP Servers](./mcp-server.md) — adding third-party tools
 - [Memory](./memory.md) — how long-term memory works
 - [Sandboxing](../sandbox.md) — running in a container

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -200,6 +200,14 @@ PowerShell's IntelliSense treats `@` as a hashtable literal start, causing lag. 
 
 ## Common Error Messages
 
+**Image generation is unavailable**
+
+Image generation runs on your Codex account and is independent of the provider
+you are chatting with. If it reports that it is unavailable, Codex OAuth is
+almost always not set up. Run `/auth codex enable`, then retry — the browser
+login opens on that first request. See
+[Image Generation](./tools/image-generation.md) for the full guide.
+
 **`EADDRINUSE` (MCP server)**
 
 Another process is using that port. Stop it or configure a different port in your MCP server settings.

--- a/project-plans/issue-2977/plan.md
+++ b/project-plans/issue-2977/plan.md
@@ -1,0 +1,102 @@
+# Issue 2977 — Document image generation and editing
+
+## Goal
+
+Ship user documentation for the image generation/editing feature. All three
+user-facing surfaces are currently undocumented under `docs/`:
+
+1. the `/image` slash command,
+2. the `generate_image` tool the model can call,
+3. the non-interactive `-I` / `-O` / `-P` flags.
+
+Documentation only. No product-code behavior changes.
+
+## Source of truth (verified against the implementation)
+
+| Fact                        | Evidence                                                                                                                            |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Slash grammar               | `packages/cli/src/ui/commands/imageCommandTokenizer.ts` — `/image <output.png> [<input.png> ...] "<prompt>"`                          |
+| Quoting rules               | same file — single/double quotes, backslash escape; a multiword prompt must be quoted, and so must any prompt used with input paths; `--` rejected; an unquoted token after a quoted one is a trailing-argument error |
+| Max inputs                  | `IMAGE_MAX_INPUTS = 5`; `MAX_INPUT_IMAGES = 5` in `packages/core/src/services/image/imageOperation.ts`                                 |
+| generate/edit selection     | zero inputs → generate; one to five → edit                                                                                            |
+| Output rules                | `resolveOutputPath` — must end `.png`, resolved against workspace root, must stay inside the workspace, parent dirs created           |
+| No overwrite                | `writeImageAtomically` publishes with `fs.link`; existing target fails with `Output file already exists (will not overwrite): <path>.` — detected at save time, after the provider call |
+| Input rules                 | `resolveInputPaths` — local workspace paths only (no `http://`, `https://`, `file://`), `.png` extension **and** PNG signature, regular non-symlink file, 20 MiB cap |
+| Tool surface                | `packages/tools/src/tools/generate-image/GenerateImageTool.ts` — `{ prompt, output_path, input_paths? }`, no model override           |
+| Model / output format       | `packages/providers/src/openai/codexImageBackend.ts` — `CODEX_IMAGE_MODEL = 'gpt-image-2'`, PNG output                                 |
+| Provider independence       | `packages/providers/src/openai/codexImageBackendResolver.ts` — active conversational provider is deliberately not a gate              |
+| Setup                       | same file — "Codex image generation requires OAuth authentication. Run /auth codex enable."                                            |
+| CLI flags                   | `packages/cli/src/config/yargsOptions.ts` — `--image-input/-I` (repeatable, ≤5), `--image-output/-O`, `--image-prompt/-P`             |
+| CLI flag validation         | `packages/cli/src/config/imageMode.ts` — `-O` and `-P` both required, mutually exclusive with `-p`/`-i`/positional prompt, no stream-json |
+| CLI output                  | `packages/cli/src/config/imageModeDispatch.ts` — text or `--output-format json`; never emits base64; nonzero exit on failure           |
+| Tab completion              | `packages/cli/src/ui/commands/imageCommandCompletion.ts` — output phase offers directories plus a new `.png` name; input phase offers existing `.png` files, directories, and a prompt hint; no filesystem completion inside the quoted prompt; nothing outside the workspace |
+| Success output              | `imageCommand.ts` — `Generated image.` / `Edited image.` then `Saved to: <absolute>`; `imageModeDispatch.ts` — `<Verb> image via <backend> (<model>).` then `Saved to: <absolute>` |
+| Setup is lazy               | `docs/oauth-setup.md` — `/auth codex enable` defers the browser to the first request; `/auth codex login` opens it immediately        |
+
+## Acceptance criteria
+
+- **AC1 — canonical page.** `docs/tools/image-generation.md` exists and covers
+  the feature end to end: prerequisites, quick start, `/image`, `generate_image`,
+  CLI flags, path and format rules, limitations, troubleshooting, related links.
+- **AC2 — Codex independence is prominent.** The page states, before the
+  reference material, that image generation runs on the Codex account and is
+  independent of the provider you are chatting with, and that setup is
+  `/auth codex enable`.
+- **AC3 — `/image` reference is accurate.** Grammar, generate-vs-edit rule,
+  quoting (including the "quote whenever inputs are present" rule), per-phase
+  tab completion, five-input limit, the success output, and the no-overwrite
+  rule are documented and match the tokenizer/completion/service.
+- **AC4 — `generate_image` reference is accurate.** Parameter names, required
+  vs optional, the five-input cap, and the fact that the model cannot pick the
+  model are documented and match the tool schema.
+- **AC5 — CLI flags reference is accurate.** `-I`/`-O`/`-P` long and short
+  forms, the both-required rule, mutual exclusion with conversational prompts,
+  the stream-json restriction, and `--output-format json` output are documented.
+- **AC6 — boundaries documented.** Workspace-relative output, rejection outside
+  the workspace, PNG-only input with the signature check and 20 MiB cap, and
+  `gpt-image-2` / PNG output are stated. Validation ordering is stated
+  accurately: paths are checked before the provider request, no-overwrite at
+  save time.
+- **AC7 — known limitation.** The page notes that a long `/image` currently
+  hides the input prompt and that Esc does not cancel it, linking issue 2976,
+  without claiming more about interactive cancellation than is verified.
+- **AC8 — cross-links.** The page is reachable from `docs/tools/index.md`,
+  `docs/cli/commands.md` (`/image`), `docs/cli/index.md` (non-interactive
+  section), and `docs/troubleshooting.md`; the page links back to the
+  authentication/OAuth pages.
+- **AC9 — style compliance.** The page follows
+  `dev-docs/documentation-style-guide.md` (how-to structure, "you" voice,
+  prerequisites/expected result, limitations before advanced setup, "LLxprt
+  Code" in prose and `llxprt` for the command) and contains no plan/requirement
+  bookkeeping markers.
+
+## Boundary cases to document
+
+- Output path that already exists (no overwrite; remove the file first).
+- Output path outside the workspace, or reached via a symlink that escapes it.
+- Output path without a `.png` extension.
+- Six or more input images.
+- Non-PNG or remote-URL input.
+- `-O` without `-P` (and vice versa).
+- Image flags combined with `-p` / `-i` / a positional prompt.
+- Image flags with `--output-format stream-json`.
+- Unquoted multiword prompt, unterminated quote, trailing arguments.
+- Image generation reported unavailable (Codex OAuth not set up).
+
+## Verification
+
+Documentation change, so proof is mechanical and factual rather than behavioral:
+
+1. `npm run lint:doc-links` — every repository-relative link and anchor resolves.
+2. `npm run lint:doc-placement` — page is correctly placed and marker-free.
+3. `npm run format` / prettier check — markdown formatting matches the repo.
+4. Full local suite (`npm run test`, `lint`, `typecheck`, `build`) plus the CLI
+   smoke test, confirming the docs-only change breaks nothing.
+5. Every documented flag, parameter, limit, and error condition traced back to
+   the source references in the table above.
+
+## Out of scope
+
+- Any change to image generation behavior, messages, or flags.
+- Architecture/design notes (these belong in `dev-docs/`).
+- Fixing the `/image` prompt-visibility and Esc-cancellation limitation (2976).


### PR DESCRIPTION
Fixes #2977.

## Why

Image generation and editing shipped with three separate user-facing entry points and no documentation. Searching `docs/` for `generate_image` or `/image` returned nothing, so the only way to discover the feature was to read the source or already know it existed. During testing the feature read as broken when it was working correctly, because nothing explained that it runs on the Codex account rather than the provider you are chatting with.

## What this adds

A new canonical page, `docs/tools/image-generation.md`, covering the feature end to end, plus cross-links from the places a user would actually look:

| File | Change |
| --- | --- |
| `docs/tools/image-generation.md` | New canonical page |
| `docs/tools/index.md` | New "Images" section with the `generate_image` row, plus a Related entry |
| `docs/cli/commands.md` | New "Images" section documenting the `/image` grammar |
| `docs/cli/index.md` | "Where to start" row and an image-generation subsection under non-interactive mode |
| `docs/troubleshooting.md` | "Common Error Messages" entry for image generation reported as unavailable |
| `docs/index.md` | One-sentence pointer from the Tools paragraph |
| `project-plans/issue-2977/plan.md` | Acceptance criteria and the source-of-truth mapping used to write the page |

The page leads with the two facts the issue called out as the most surprising, before any reference material:

- Image generation runs on your **Codex** account and is independent of the provider you are chatting with. You can be on Anthropic, z.ai, Gemini, or a local model and still generate images, and generating one never changes your active provider or model.
- Setup is `/auth codex enable`. If image generation reports it is unavailable, that is almost always why.

It then documents all three surfaces — the `/image` slash command (grammar, quoting, per-phase tab completion, examples, success output), the model-callable `generate_image` tool (parameters, what it returns, when validation happens), and the non-interactive `-I` / `-O` / `-P` flags (required combinations, conflicts with conversational prompts, `--output-format json` fields, exit status) — followed by the shared output and input rules, limitations, and troubleshooting.

## Accuracy

Every claim was verified against the implementation rather than taken from the issue text, which corrected several details that would otherwise have shipped wrong:

- A prompt must be quoted whenever input paths are present, not only when it contains spaces. An unquoted single-word prompt is accepted only for zero-input generation.
- The last argument is always taken as the prompt. Trailing-argument rejection applies to an unquoted token following a quoted one, so the accurate guidance is "put every input path before the prompt".
- Tab completion differs by phase: the output token offers directories and a suggested new `.png` filename, not existing images; existing `.png` files are offered only for input tokens.
- Path validation happens before the provider request, but the no-overwrite check is enforced atomically at save time, so an output path that already exists fails after the image has been generated. That is worth knowing because it costs a request.
- The input size cap is 20 MiB (20 x 1024 x 1024 bytes), not decimal 20 MB.
- `/auth codex enable` is lazy: the browser login opens on the first request. `/auth codex login` signs in immediately.
- Success output is two lines and uses "Generated"/"Edited", which the page now shows literally.

Error messages are described rather than quoted as verbatim strings where the wording differs between the slash command, the tool, and the CLI flags.

The known limitation from #2976 is recorded: while `/image` is running the input prompt is hidden and Esc does not cancel it. The page does not claim more about interactive cancellation than is verifiable, and notes that the non-interactive path is unaffected.

## Scope

Documentation only. No source, test, script, or configuration file is touched, and no product behavior changes. Fixing the `/image` prompt-visibility and Esc-cancellation limitation stays with #2976.

## Verification

- `npm run lint:doc-links` — passed
- `npm run lint:doc-placement` — passed
- `npm run lint:copyright-year` — passed
- `npm run format` / prettier — clean
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm run test` — passed (all workspaces)
- Smoke test: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` — passed

Open Code Review was previewed and reports every changed file as `unsupported_ext`; it does not review Markdown, so it has no findings to contribute on a docs-only change. Review coverage came from a full accuracy audit against the implementation instead, whose findings are folded into the page above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for generating and editing PNG images through the `/image` command and image-generation tool.
  * Documented non-interactive CLI usage, supported options, input images, output formats, validation, and troubleshooting.
  * Added image generation to CLI, tools, and getting-started documentation.
  * Added guidance for enabling required authentication when image generation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->