### PR TITLE
Escape the backticks that broke the OCR results script (Fixes #3005)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -4778,7 +4778,7 @@ jobs:
             if (outOfDiffRouted.length > 0) {
               body.push('', '### Findings outside the PR diff', '');
               for (const f of outOfDiffRouted) {
-                const where = f && f.path ? ``${f.path}`: ` : '';
+                const where = f && f.path ? `\`${f.path}\`: ` : '';
                 const label = categorySeverityLabel(f);
                 const rawText = f.content || f.comment || f.message || f.body;
                 const text = renderFindingText(typeof rawText === 'string' ? rawText : 'OCR finding');


### PR DESCRIPTION
Fixes #3005.

## The break

OpenCodeReview has been failing on every pull request. "Post OCR results" died in 23 seconds having done no work:

    ##[error]Unhandled error: SyntaxError: Unexpected identifier '$'
        at new AsyncFunction (<anonymous>)
        at callAsyncFunction (.../github-script/.../dist/index.js:64949:16)

## Cause

The out-of-diff findings loop added in #2998 wrote its path prefix with unescaped backticks:

    const where = f && f.path ? ``${f.path}`: ` : '';

The template literal terminates at the second backtick, so the rest of the line parses as garbage. `actions/github-script` compiles the whole `script:` block as a single `AsyncFunction`, so one bad line took down all 104 KB of it before a single statement ran.

The two sibling loops immediately above and below it — inline overflow, and findings without a resolvable position — already escape the backticks correctly. Only the new loop was missing them. This restores the same form:

    const where = f && f.path ? `\`${f.path}\`: ` : '';

## Blast radius

"Post OCR results" is where the reviewed-range manifest is written. With that step dead, the manifest stayed at the empty placeholder created during artifact initialization, so "Compute reviewed-range manifest hashes" then failed too:

    ##[error]SyntaxError: Unexpected end of JSON input
        at JSON.parse (<anonymous>)

and "Upload OCR artifacts" was skipped. Two unrelated branches show the identical pair of failures:

- https://github.com/vybestack/llxprt-code/actions/runs/30868882536/job/91866551721 — branch issue2977, documentation only
- https://github.com/vybestack/llxprt-code/actions/runs/30864777328 — branch issue1648, source change

## Verification

I extracted every `script:` block from `.github/workflows` and compiled each one exactly the way `actions/github-script` does, with `AsyncFunction`:

- Before this change: 10 blocks checked, 1 fails — `ocr-review.yml` with `Unexpected identifier '$'`.
- After this change: 10 blocks checked, 0 failures.

`actionlint` (with the CI ignore set) and `prettier --check` are both clean on the workflow.

## Note for reviewers

`ocr-review.yml` runs on `pull_request_target`, so GitHub uses the workflow definition from the base branch. **This PR's own OpenCodeReview check will still fail**, because it runs main's copy. The fix only takes effect for PRs opened or updated after it merges.

## Follow-up worth considering

This 104 KB of JavaScript embedded in YAML is not syntax-checked anywhere, which is how a two-character omission reached main and broke CI for every open PR. The AsyncFunction compile check used to verify this fix is about 40 lines and catches the entire class of bug. I have not added it here to keep this PR to the one-line fix — happy to send it separately if wanted.
