### PR TITLE
Fix Windows sandbox proxy connection loss (Fixes #2908)

### DIFF
--- a/packages/auth/src/proxy/__tests__/proxy-socket-client.test.ts
+++ b/packages/auth/src/proxy/__tests__/proxy-socket-client.test.ts
@@ -13,6 +13,8 @@ import * as net from 'node:net';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 
 import {
   ProxySocketClient,
@@ -61,6 +63,120 @@ function createTempSocketPath(): string {
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-test-'));
   return path.join(tmpDir, 'test.sock');
+}
+
+/**
+ * Absolute path to the ProxySocketClient source, so a spawned subprocess can
+ * import the REAL implementation (no mocks) via a dynamic import. Uses a
+ * file:// URL (not URL.pathname) for Windows portability.
+ */
+const PROXY_SOCKET_CLIENT_URL = new URL(
+  '../proxy-socket-client.js',
+  import.meta.url,
+).href;
+
+/**
+ * Budget for deadline races in tests. Comfortably below Bun's 5s per-test cap
+ * and the 30s request timeout, so a regression fails fast instead of hanging.
+ */
+const TEST_DEADLINE_MS = 2_000;
+
+/**
+ * Races a promise against a deadline and returns the textual outcome plus the
+ * losing timer handle so the caller can clear it in every path. A settled
+ * promise yields its error message (or 'resolved' on success). A pending
+ * promise yields a sentinel string that fails strict assertions.
+ */
+async function deadlineRace<T>(
+  promise: Promise<T>,
+  budgetMs: number,
+): Promise<{ result: string; timer: ReturnType<typeof setTimeout> }> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const result = await Promise.race([
+    promise.then(
+      () => 'resolved',
+      (err: unknown) => (err instanceof Error ? err.message : String(err)),
+    ),
+    new Promise<string>((resolve) => {
+      timer = setTimeout(
+        () => resolve('STILL PENDING — transport loss not detected'),
+        budgetMs,
+      );
+    }),
+  ]);
+  return { result, timer: timer! };
+}
+
+/**
+ * Inline script run by a real subprocess to prove an idle proxy client exits
+ * on its own. It imports the real ProxySocketClient via a file:// URL,
+ * connects, completes one request to reach the idle state, then resolves. If
+ * the idle socket is unreferenced the event loop drains and the process exits
+ * 0; if it is referenced the process hangs and the watchdog SIGKILLs it.
+ *
+ * Bun `--eval` strips the `--` separator, so the script reads the socket path
+ * from process.argv[2]. The module URL is passed as process.argv[1].
+ */
+const IDLE_EXIT_SCRIPT = [
+  `const mod = await import(process.argv[1]);`,
+  `const { ProxySocketClient } = mod;`,
+  `const socketPath = process.argv[2];`,
+  `const client = new ProxySocketClient(socketPath);`,
+  `await client.ensureConnected();`,
+  `// Perform one request to transition active -> idle.`,
+  `const res = await client.request('idle-probe', { ok: true });`,
+  `if (res.ok !== true) process.exitCode = 2;`,
+  `// Nothing else is scheduled. An unreferenced idle socket lets the`,
+  `// process exit naturally.`,
+].join('\n');
+
+/**
+ * Spawns a Bun subprocess for the idle-exit liveness test and resolves its
+ * exit status. A watchdog SIGKILLs the child if it does not self-exit within
+ * the budget, so a referenced-socket regression fails fast instead of
+ * hanging the suite.
+ */
+async function runIdleExitSubprocess(
+  clientModuleUrl: string,
+  ipcPath: string,
+  budgetMs = TEST_DEADLINE_MS,
+): Promise<{
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+}> {
+  const child = spawn(
+    process.execPath,
+    ['--eval', IDLE_EXIT_SCRIPT, '--', clientModuleUrl, ipcPath],
+    {
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  let stderr = '';
+  child.stderr.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  const exit = once(child, 'exit');
+  const watchdog = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+    }
+  }, budgetMs);
+  try {
+    const [code, signal] = (await exit) as [
+      number | null,
+      NodeJS.Signals | null,
+    ];
+    return { code, signal, stderr };
+  } finally {
+    clearTimeout(watchdog);
+    // Always terminate and await the child exit in cleanup so no process leaks.
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+      await exit;
+    }
+  }
 }
 
 /**
@@ -250,20 +366,30 @@ describe('ProxySocketClient', () => {
     expect(handshake.op).toBe('handshake');
   });
 
-  it('unrefs the socket after connect so idle proxy clients do not keep Bun alive', async () => {
+  /**
+   * @requirement R24.2
+   * @scenario An idle connected proxy client must NOT keep the process alive.
+   *           Verified through real process liveness: a subprocess that
+   *           connects and goes idle must exit on its own, because the socket
+   *           is unreferenced while no work is outstanding.
+   */
+  it('an idle connected client does not keep the process alive', async () => {
     server = createAutoReplyServer(socketPath);
     trackServerSockets(server);
     await new Promise<void>((resolve) => server.listen(socketPath, resolve));
 
-    const unrefSpy = vi.spyOn(net.Socket.prototype, 'unref');
-    try {
-      client = new ProxySocketClient(socketPath);
-      await client.ensureConnected();
+    const { code, signal, stderr } = await runIdleExitSubprocess(
+      PROXY_SOCKET_CLIENT_URL,
+      socketPath,
+    );
 
-      expect(unrefSpy).toHaveBeenCalled();
-    } finally {
-      unrefSpy.mockRestore();
-    }
+    // A clean self-exit (code 0) proves the idle socket did not hold the
+    // event loop open. A SIGKILL from the watchdog means the process hung.
+    expect({ code, signal, stderr }).toStrictEqual({
+      code: 0,
+      signal: null,
+      stderr: '',
+    });
   });
 
   /**
@@ -399,7 +525,9 @@ describe('ProxySocketClient', () => {
 
   /**
    * @requirement R24.2
-   * @scenario Connection error surfaces descriptive error message
+   * @scenario Server destroys the transport while a post-handshake request is
+   *           pending. The request must reject promptly with the
+   *           connection-loss error — not wait for the 30s request timeout.
    */
   it('surfaces "Credential proxy connection lost" on connection error', async () => {
     server = net.createServer((socket) => {
@@ -412,7 +540,6 @@ describe('ProxySocketClient', () => {
           if (msg.op === 'handshake') {
             socket.write(encodeFrame({ ok: true, v: PROTOCOL_VERSION }));
           } else {
-            // Destroy connection mid-request to simulate error
             socket.destroy();
           }
         }
@@ -424,9 +551,16 @@ describe('ProxySocketClient', () => {
     client = new ProxySocketClient(socketPath);
     await client.ensureConnected();
 
-    await expect(client.request('will-fail', {})).rejects.toThrow(
-      /credential proxy connection lost/i,
+    const { result, timer } = await deadlineRace(
+      client.request('will-fail', {}),
+      TEST_DEADLINE_MS,
     );
+    try {
+      expect(result).toMatch(/credential proxy connection lost/i);
+      expect(result).not.toMatch(/timed out/i);
+    } finally {
+      clearTimeout(timer);
+    }
   });
 
   /**
@@ -650,5 +784,73 @@ describe('ProxySocketClient', () => {
     await expect(client.ensureConnected()).rejects.toThrow(
       /Credential proxy authentication failed/i,
     );
+  });
+
+  /**
+   * @requirement R24.2
+   * @scenario Server destroys the transport while MULTIPLE requests are
+   *           concurrently pending. Every pending request must reject promptly
+   *           with the connection-loss error — not wait for the per-request
+   *           timeout. After cleanup the client must reconnect to a fresh
+   *           server and succeed.
+   */
+  it('rejects all concurrently pending requests promptly on transport loss, then reconnects', async () => {
+    server = net.createServer((socket) => {
+      trackServerSockets(server);
+      const decoder = new FrameDecoder();
+      let requestCount = 0;
+      socket.on('data', (chunk) => {
+        const frames = decoder.feed(chunk);
+        for (const frame of frames) {
+          const msg = frame;
+          if (msg.op === 'handshake') {
+            socket.write(encodeFrame({ ok: true, v: PROTOCOL_VERSION }));
+          } else {
+            requestCount++;
+            if (requestCount >= 3) {
+              socket.destroy();
+            }
+          }
+        }
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+    client = new ProxySocketClient(socketPath);
+    await client.ensureConnected();
+
+    const requests = Array.from({ length: 3 }, (_, i) =>
+      client.request(`concurrent-${i}`, {}),
+    );
+
+    const timers: Array<ReturnType<typeof setTimeout>> = [];
+    try {
+      const outcomes = await Promise.all(
+        requests.map(async (p) => {
+          const { result, timer } = await deadlineRace(p, TEST_DEADLINE_MS);
+          timers.push(timer);
+          return result;
+        }),
+      );
+
+      for (const outcome of outcomes) {
+        expect(outcome).toMatch(/credential proxy connection lost/i);
+        expect(outcome).not.toMatch(/timed out/i);
+      }
+    } finally {
+      for (const timer of timers) clearTimeout(timer);
+    }
+
+    destroyServerSockets(server);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    server = createAutoReplyServer(socketPath);
+    trackServerSockets(server);
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+    const response = await client.request('after-reconnect', { ok: true });
+    expect(response.ok).toBe(true);
+    expect(response.data).toStrictEqual({ ok: true });
   });
 });

--- a/packages/auth/src/proxy/proxy-socket-client.ts
+++ b/packages/auth/src/proxy/proxy-socket-client.ts
@@ -339,7 +339,8 @@ export class ProxySocketClient {
       this.socket!.once('connect', resolve);
       this.socket!.once('error', reject);
     });
-    this.socket.unref();
+    // Socket is referenced while connect/handshake is in flight; resetIdleTimer
+    // releases the reference once the connection is genuinely idle.
   }
 
   /**
@@ -528,7 +529,15 @@ export class ProxySocketClient {
    */
   private resetIdleTimer(): void {
     this.cancelIdleTimer();
-    if (this.pendingRequests.size > 0) return;
+    if (this.pendingRequests.size > 0) {
+      // Active work — keep the transport referenced so transport events are
+      // delivered promptly (fixes the Windows request-loss symptom).
+      this.socket?.ref();
+      return;
+    }
+    // Idle — release the reference so a stale proxy connection does not keep
+    // the process alive.
+    this.socket?.unref();
     this.armIdleTimer();
   }
 
@@ -542,8 +551,11 @@ export class ProxySocketClient {
    * @pseudocode 002-frame-and-cancel.md lines 30-32
    */
   private maybeArmIdleTimer(): void {
-    if (this.pendingRequests.size === 0 && this.idleTimer === null) {
-      this.armIdleTimer();
+    if (this.pendingRequests.size === 0) {
+      this.socket?.unref();
+      if (this.idleTimer === null) {
+        this.armIdleTimer();
+      }
     }
   }
 

--- a/packages/providers/src/auth/proxy/__tests__/integration.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/integration.test.ts
@@ -668,16 +668,41 @@ describe('proxy integration (phase 31)', () => {
 
   it('surfaces hard error to client when proxy connection is lost', async () => {
     // @requirement R24.2
-    // @scenario After server stop, further client requests should raise transport error.
+    // @scenario After a successful request and server stop, an immediate
+    // follow-up request must reject promptly with a transport/connect error —
+    // not hang on a stale connection until the 30s request timeout fires.
+    // The deadline is well below the request timeout and the Bun per-test cap;
+    // the losing timer is cleared and the store is closed in cleanup so no
+    // pending promise or referenced socket survives.
+    const TEST_DEADLINE_MS = 2_000;
     const started = await startServer();
+    const proxyStore = new ProxyTokenStore(started.socketPath);
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const proxyStore = new ProxyTokenStore(started.socketPath);
       await proxyStore.listProviders();
       await started.server.stop();
-      await expect(proxyStore.listProviders()).rejects.toThrow(
+
+      const result = await Promise.race([
+        proxyStore
+          .listProviders()
+          .then(() => 'resolved')
+          .catch((err: Error) => err.message),
+        new Promise<string>((resolve) => {
+          deadlineTimer = setTimeout(
+            () => resolve('STILL PENDING — stale connection not detected'),
+            TEST_DEADLINE_MS,
+          );
+        }),
+      ]);
+
+      expect(result).toMatch(
         /Credential proxy connection lost|connect|ECONNREFUSED|ENOENT/i,
       );
+      expect(result).not.toMatch(/timed out/i);
     } finally {
+      clearTimeout(deadlineTimer);
+      // Close the client so no referenced socket or pending operation survives.
+      proxyStore.getClient().close();
       await started.server.stop();
     }
   });

--- a/project-plans/issue2908/plan.md
+++ b/project-plans/issue2908/plan.md
@@ -1,0 +1,139 @@
+# Issue 2908: Windows Sandbox Credential-Proxy Connection Loss
+
+## Status
+
+Candidate remediation and local verification are complete on POSIX (macOS arm64,
+Bun 1.3.14). Windows candidate CI remains pending and is authoritative for the
+reported named-pipe behavior.
+
+## Root Cause
+
+After a successful connect+handshake the proxy socket was unconditionally
+`unref()`-ed. On Windows named pipes the libuv transport stops polling an
+unreferenced handle, so transport events (error/close/end) were not delivered
+promptly while a request was pending. A request whose server-side transport was
+lost therefore waited the full 30-second request timeout instead of rejecting
+with the connection-loss error.
+
+## Accepted Production Fix (smallest root fix)
+
+Socket reference is now driven by active-versus-idle state:
+
+- The unconditional `socket.unref()` immediately after connect is removed, so
+  the socket stays referenced while connect/handshake is in flight.
+- `resetIdleTimer()` calls `socket.ref()` while requests are pending and
+  `socket.unref()` once idle.
+- `maybeArmIdleTimer()` releases the reference on the active→idle transition.
+
+No ownership guards, listener-stripping, connect-cancellation subsystem, or
+gracefulClose refactor. Those speculative expansions were reviewed and removed
+because they could orphan connect (removeAllListeners strips one-shot
+connect/error listeners) and are outside accepted issue behavior.
+
+## Files Changed
+
+1. `packages/auth/src/proxy/proxy-socket-client.ts` — production ref/unref
+   lifecycle fix only (3 hunks: connect, resetIdleTimer, maybeArmIdleTimer).
+2. `packages/auth/src/proxy/__tests__/proxy-socket-client.test.ts` — behavioral
+   tests using real sockets/subprocess.
+3. `packages/providers/src/auth/proxy/__tests__/integration.test.ts` —
+   strengthened transport-loss provider integration test.
+
+## Test Remediation
+
+- Subprocess module locator uses a portable ESM file URL
+  (`new URL('../proxy-socket-client.js', import.meta.url).href`) instead of
+  `URL.pathname`.
+- A single `TEST_DEADLINE_MS = 2_000` budget (well below Bun's 5s per-test cap
+  and the 30s request timeout) centralizes all deadline races.
+- `deadlineRace()` helper returns the losing timer so callers clear it in every
+  path; subprocess cleanup always terminates and awaits child exit.
+- The pre-existing auth transport-loss test ("surfaces 'Credential proxy
+  connection lost' on connection error") is strengthened with a sub-cap deadline
+  and strict connection-loss/not-timeout assertion.
+- ONE multi-pending transport-loss + reconnection case is kept; it covers
+  concurrent settlement and reconnect behavior directly.
+- The speculative stale-terminal-event test and all standalone reconnect
+  duplicates were removed (no deterministic RED evidence; overclaimed ownership).
+- The real idle-process liveness subprocess test is kept and made portable and
+  fail-fast (2s watchdog, child always terminated in cleanup).
+- The provider integration test closes `proxyStore.getClient()` and clears the
+  deadline timer in cleanup so no pending promise, timer, or referenced socket
+  survives failure.
+
+## Focused Verification (POSIX, macOS arm64, Bun 1.3.14)
+
+- `packages/auth` proxy-socket-client tests: 16 pass, 0 fail (stable across 3
+  repeated runs).
+- `packages/providers` proxy integration tests: 25 pass, 0 fail (stable across
+  3 repeated runs).
+- ESLint on changed files: clean.
+- Typecheck (`tsc --noEmit`) for `packages/auth` and `packages/providers`:
+  clean.
+- Prettier `--check` on changed files: clean.
+- `git diff --check`: clean.
+
+## Full Local Verification
+
+- Repository-wide test suite: passed. An initial run had one core test-file
+  process timeout; the isolated file passed immediately and the complete suite
+  passed on rerun.
+- Repository-wide lint: passed.
+- Repository-wide typecheck: passed.
+- Repository-wide format: passed.
+- Repository build: passed.
+- `stepfun-37` smoke test: passed.
+
+## Remaining Mandatory Gate
+
+Windows named-pipe CI is authoritative for the unref-polling behavior that
+causes the reported request-loss symptom. POSIX tests cannot reproduce the
+deferred event ordering that triggers the Windows failure. The PR cannot be
+declared complete until the candidate head passes Windows CI with these tests.
+
+## Accepted Behavior
+
+### Required behavior
+
+1. When an established sandbox credential-proxy transport is lost while a
+   request is pending, that request rejects with the existing descriptive
+   connection-loss error instead of waiting for its request timeout.
+2. When the server stops after a successful request, a subsequent request does
+   not remain pending on a stale Windows named-pipe connection. It rejects
+   promptly with a transport/connect error.
+3. Transport-loss cleanup settles each pending request once, clears its timeout
+   and abort listener, and leaves the client able to establish a new connection
+   when a server is available again.
+4. A connected client remains unreferenced while idle so an idle proxy does not
+   keep Bun alive. The socket is referenced while connect/handshake or an
+   active request requires transport events; the reference is restored to idle
+   unreferenced behavior after settlement.
+5. Existing successful request, concurrent request, cancellation, explicit
+   `close()`, graceful idle close, protocol negotiation, and POSIX socket
+   behavior remain unchanged.
+
+### Explicit non-goals
+
+- No request-timeout increase or acceptance of timeout as a connection-loss
+  result.
+- No credential-proxy removal or redesign.
+- No change to non-sandbox direct keyring behavior.
+- No behavioral-eval prompt, assertion, model, provider, aggregation, or retry
+  change.
+- No GitHub Actions workflow change.
+- No adjacent proxy cleanup, public abstraction, dependency, lint configuration,
+  or test-runner change.
+
+## Review Classification Rules
+
+- **Blocker-Fix:** Violates an accepted behavior, causes test/CI failure,
+  introduces a regression or unsafe lifecycle, weakens strict eval quality, or
+  violates repository guardrails.
+- **In-scope-Fix:** A valid defect in changed proxy lifecycle code/tests that is
+  directly necessary for accepted behavior or maintainability of that bounded
+  change.
+- **Reject:** Factually incorrect, already covered, asks to weaken the contract,
+  or proposes speculative hardening/cleanup.
+- **Defer:** Valid but outside the accepted sandbox transport-lifecycle
+  behavior, especially workflow/eval redesign or broader credential
+  architecture.


### PR DESCRIPTION
## TLDR

Fix Windows container-sandbox credential-proxy connection-loss handling by keeping its socket referenced during connect, handshake, and active requests, then unreferencing it when idle. This prevents pending named-pipe requests from reaching the 30-second request timeout while preserving natural process exit for idle clients.

## Dive Deeper

The proxy client previously unreferenced its socket immediately after connect. On Windows named pipes, transport loss could remain unobserved while requests were active. Socket reference state now follows active work: referenced during connection and pending requests, unreferenced after the final request settles.

This is limited to the credential proxy used by container sandboxes. Non-sandbox direct keyring access is unchanged. The strict save-memory behavioral eval correctly rejected duplicate or trailing model output; this PR preserves that contract and does not change eval prompts, assertions, models, aggregation, retries, or workflows. Recent dedicated three-attempt eval workflows are green, so the eval side of the nightly report required no product change.

## Reviewer Test Plan

1. Run the auth proxy socket-client test file and confirm prompt connection-loss rejection, concurrent pending-request settlement, reconnection, and idle subprocess exit.
2. Run the provider proxy integration test file and confirm a request immediately after server shutdown rejects before the request timeout.
3. On Windows, run Bun Native Test Compatibility and confirm the named-pipe credential-proxy tests pass.
4. Run the repository verification commands listed below.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅ full local suite | ✅ CI Bun native compatibility | ✅ CI |
| npx      | ➖ not applicable | ➖ not applicable | ➖ not applicable |
| Docker   | ➖ no manual container smoke | ➖ no manual container smoke | ✅ CI E2E |
| Podman   | ➖ not exercised | - | - |
| Seatbelt | ➖ unaffected | - | - |

Local verification passed: npm run test, npm run lint, npm run typecheck, npm run format, npm run build, and the stepfun-37 smoke test. Focused auth tests passed 16/16 and provider integration tests passed 25/25. Two DeepThinker and two detached local Open Code Review cycles completed with valid in-scope findings resolved.

## Linked issues / bugs

Fixes #2908
