### PR TITLE
Start test fanout after Node Consumer Smoke (Fixes #2877)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1226,6 +1226,7 @@ jobs:
       - 'test_shard'
       - 'shard_selector'
       - 'skip_check'
+      - 'node_consumer_smoke'
       - 'acp_conformance'
     if: ${{ always() }}
     runs-on: 'ubuntu-latest'
@@ -1236,6 +1237,7 @@ jobs:
           selector_result='${{ needs.shard_selector.result }}'
           has_tests='${{ needs.shard_selector.outputs.has_tests }}'
           shard_result='${{ needs.test_shard.result }}'
+          node_consumer_smoke_result='${{ needs.node_consumer_smoke.result }}'
           acp_result='${{ needs.acp_conformance.result }}'
 
           # Explicit duplicate-skip: skip_check said this run duplicates a
@@ -1249,6 +1251,11 @@ jobs:
           # Fail closed if the selector itself did not succeed.
           if [ "$selector_result" != "success" ]; then
             echo "::error::Shard selector did not succeed (result: $selector_result); cannot trust test selection."
+            exit 1
+          fi
+
+          if [ "$node_consumer_smoke_result" != "success" ]; then
+            echo "::error::Node Consumer Smoke did not succeed (result: $node_consumer_smoke_result)"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,8 +618,9 @@ jobs:
       - 'lint_javascript'
       - 'lint_shell'
       - 'lint_yaml'
-      # Gates the expensive test matrix behind a cheap npm build+smoke so a
-      # broken build fails fast on ubuntu instead of on every matrix leg.
+      # node_consumer_smoke provides a cheap package install/invocation gate.
+      # test_shard depends directly on it (issue #2877); lint retains the
+      # dependency here to preserve smoke coverage when the matrix is skipped.
       - 'node_consumer_smoke'
     runs-on: 'ubuntu-latest'
     steps:
@@ -720,8 +721,9 @@ jobs:
   # Guards npm install/invocation compatibility: install with npm, then run the
   # installed bin directly. The bin is a POSIX sh launcher (issue #2603) that
   # execs the package-local Bun against packages/cli/index.ts — no Node process
-  # is started on the installed command path. Wired into the `lint` aggregator
-  # so the expensive test matrix waits for this fast install+smoke check first.
+  # is started on the installed command path. A direct dependency of test_shard
+  # (issue #2877) and of the lint aggregator, so broken package installs or CLI
+  # invocation fail before matrix fanout.
   node_consumer_smoke:
     name: 'Node Consumer Smoke'
     runs-on: 'ubuntu-latest'
@@ -729,11 +731,11 @@ jobs:
     needs:
       - 'skip_check'
     if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
-    # This job runs npm ci (executing third-party install scripts) and only
-    # needs to read the repo, so scope permissions to contents:read and drop
-    # credential persistence (matches bun_native_modules_smoke hardening). It
-    # validates the published npm entry path by running the installed launcher
-    # directly after install; the launcher execs Bun on TypeScript source.
+    # This job installs the packed package with npm (executing third-party
+    # install scripts) and only needs to read the repo, so scope permissions to
+    # contents:read and drop credential persistence. It validates the published
+    # npm entry path by running the installed launcher directly after install;
+    # the launcher execs Bun on TypeScript source.
     permissions:
       contents: 'read'
     steps:
@@ -750,8 +752,8 @@ jobs:
           cache: 'npm'
 
       - name: 'Setup Bun'
-        # Must run before npm ci because lifecycle hooks and npm run build are
-        # Bun-backed after issue 2242, even though dependencies stay npm-based.
+        # The installed launcher executes Bun against the package's TypeScript
+        # sources even though the package itself is installed with npm.
         uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # ratchet:oven-sh/setup-bun@v2
         with:
           bun-version-file: '.bun-version'
@@ -899,7 +901,7 @@ jobs:
     # hung shard fails instead of occupying a runner for the 6h default.
     timeout-minutes: 45
     needs:
-      - 'lint'
+      - 'node_consumer_smoke'
       - 'doc_change_filter'
       - 'shard_selector'
       - 'skip_check'
@@ -1098,10 +1100,10 @@ jobs:
   # name while the real work fans out across the matrix.
   #
   # `if: always()` is essential: when a `test_shard` leg fails or is skipped
-  # (e.g. because an upstream `lint` dependency failed), GitHub would
-  # otherwise **skip** this job, and branch protection treats skipped checks
-  # as passing — a silent bypass. The explicit result check converts any
-  # non-success outcome (failure, skipped, cancelled) into a `failure`
+  # (e.g. because an upstream `node_consumer_smoke` dependency failed), GitHub
+  # would otherwise **skip** this job, and branch protection treats skipped
+  # checks as passing — a silent bypass. The explicit result check converts
+  # any non-success outcome (failure, skipped, cancelled) into a `failure`
   # conclusion on this required check.
   #
   # Issue #2709: the `test` job now also depends on `shard_selector`. When the

--- a/scripts/tests/ci-acplint-workflow.test.ts
+++ b/scripts/tests/ci-acplint-workflow.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { WorkflowDocument, WorkflowJob } from './typed-test-helpers.ts';
 import { parseWorkflowYaml, asOptionalRecord } from './typed-test-helpers.ts';
@@ -60,6 +61,34 @@ function transitiveNeeds(
     if (expanded.size === closure.size) return expanded;
     closure = expanded;
   }
+}
+
+interface TestAggregateResults {
+  shouldSkip: string;
+  selector: string;
+  hasTests: string;
+  shards: string;
+  nodeConsumerSmoke: string;
+  acp: string;
+}
+
+function runTestAggregate(
+  runText: string,
+  results: TestAggregateResults,
+): SpawnSyncReturns<string> {
+  const expressions = new Map([
+    ['${{ needs.skip_check.outputs.should_skip }}', results.shouldSkip],
+    ['${{ needs.shard_selector.result }}', results.selector],
+    ['${{ needs.shard_selector.outputs.has_tests }}', results.hasTests],
+    ['${{ needs.test_shard.result }}', results.shards],
+    ['${{ needs.node_consumer_smoke.result }}', results.nodeConsumerSmoke],
+    ['${{ needs.acp_conformance.result }}', results.acp],
+  ]);
+  let script = runText;
+  for (const [expression, value] of expressions) {
+    script = script.replaceAll(expression, value);
+  }
+  return spawnSync('bash', ['-c', script], { encoding: 'utf8' });
 }
 
 describe('Issue #2564: acp_conformance CI job', () => {
@@ -402,6 +431,7 @@ describe('Issue #2877: test matrix scheduling', () => {
       'test_shard',
       'shard_selector',
       'skip_check',
+      'node_consumer_smoke',
       'acp_conformance',
     ]);
     expect(runText).toContain("shard_result='${{ needs.test_shard.result }}'");
@@ -409,6 +439,22 @@ describe('Issue #2877: test matrix scheduling', () => {
     echo "::error::Test shards did not all succeed (result: $shard_result)"
     exit 1
   fi`);
+  });
+
+  it('fails the no-tests path when node_consumer_smoke fails', () => {
+    const checkStep = stepNamed(testJob, 'Check shard results');
+    const result = runTestAggregate(checkStep.run ?? '', {
+      shouldSkip: 'false',
+      selector: 'success',
+      hasTests: 'false',
+      shards: 'skipped',
+      nodeConsumerSmoke: 'failure',
+      acp: 'success',
+    });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      'Node Consumer Smoke did not succeed (result: failure)',
+    );
   });
 
   it('preserves the exact test_shard condition', () => {

--- a/scripts/tests/ci-acplint-workflow.test.ts
+++ b/scripts/tests/ci-acplint-workflow.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { WorkflowDocument, WorkflowJob } from './typed-test-helpers.ts';
-import { parseWorkflowYaml } from './typed-test-helpers.ts';
+import { parseWorkflowYaml, asOptionalRecord } from './typed-test-helpers.ts';
 import { readRootFile, stepNamed } from './ocr-review-workflow-helpers.ts';
 
 const ACPLINT_PIN =
@@ -26,6 +26,40 @@ const UPLOAD_ARTIFACT_SHA =
 function loadCiWorkflow(): WorkflowDocument {
   const source = readRootFile('.github/workflows/ci.yml');
   return parseWorkflowYaml(source);
+}
+
+function jobNeeds(job: WorkflowJob | undefined): string[] {
+  const needs = job?.needs;
+  if (needs === undefined) return [];
+  return Array.isArray(needs) ? [...needs] : [needs];
+}
+
+function workflowJob(
+  jobs: Record<string, WorkflowJob>,
+  jobName: string,
+): WorkflowJob {
+  const job = jobs[jobName];
+  if (job === undefined) {
+    throw new Error(`Unknown workflow job referenced by needs: ${jobName}`);
+  }
+  return job;
+}
+
+function transitiveNeeds(
+  jobs: Record<string, WorkflowJob>,
+  jobName: string,
+): Set<string> {
+  let closure = new Set(jobNeeds(workflowJob(jobs, jobName)));
+  while (true) {
+    const expanded = new Set([
+      ...closure,
+      ...[...closure].flatMap((dependency) =>
+        jobNeeds(workflowJob(jobs, dependency)),
+      ),
+    ]);
+    if (expanded.size === closure.size) return expanded;
+    closure = expanded;
+  }
 }
 
 describe('Issue #2564: acp_conformance CI job', () => {
@@ -281,5 +315,118 @@ describe('Issue #2564: acp_conformance CI job', () => {
       const uses = step.uses ?? '';
       expect(uses).not.toContain('8207627863c7cc4c66a329aec7e433d2d1c52a9');
     }
+  });
+});
+
+describe('Issue #2877: test matrix scheduling', () => {
+  let workflow: WorkflowDocument;
+  let jobs: Record<string, WorkflowJob>;
+  let testShardJob: WorkflowJob | undefined;
+  let lintJob: WorkflowJob | undefined;
+  let testJob: WorkflowJob | undefined;
+  let nodeConsumerSmokeJob: WorkflowJob | undefined;
+  let secureStoreJob: WorkflowJob | undefined;
+
+  beforeAll(() => {
+    workflow = loadCiWorkflow();
+    jobs = workflow['jobs']!;
+    testShardJob = jobs['test_shard'];
+    lintJob = jobs['lint'];
+    testJob = jobs['test'];
+    nodeConsumerSmokeJob = jobs['node_consumer_smoke'];
+    secureStoreJob = jobs['secure_store_backend'];
+  });
+
+  it('test_shard depends directly on exactly node_consumer_smoke, doc_change_filter, shard_selector, and skip_check', () => {
+    const needs = jobNeeds(testShardJob);
+    expect(needs).toEqual([
+      'node_consumer_smoke',
+      'doc_change_filter',
+      'shard_selector',
+      'skip_check',
+    ]);
+  });
+
+  it('test_shard does not directly need lint or any lint_* job', () => {
+    const needs = jobNeeds(testShardJob);
+    expect(needs).not.toContain('lint');
+    const lintDeps = needs.filter((n) => n.startsWith('lint_'));
+    expect(lintDeps, `unexpected lint_* deps: ${lintDeps.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('test_shard has no transitive dependency on lint or any lint_* job', () => {
+    const closure = transitiveNeeds(jobs, 'test_shard');
+    expect(closure.has('lint')).toBe(false);
+    const lintInClosure = [...closure].filter((n) => n.startsWith('lint'));
+    expect(
+      lintInClosure,
+      `transitive lint dependency found: ${lintInClosure.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('lint aggregator needs exactly the four linters plus node_consumer_smoke', () => {
+    const needs = jobNeeds(lintJob);
+    expect(needs).toEqual([
+      'lint_github_actions',
+      'lint_javascript',
+      'lint_shell',
+      'lint_yaml',
+      'node_consumer_smoke',
+    ]);
+  });
+
+  it('node_consumer_smoke needs only skip_check', () => {
+    const needs = jobNeeds(nodeConsumerSmokeJob);
+    expect(needs).toEqual(['skip_check']);
+  });
+
+  it('node_consumer_smoke preserves its skip condition', () => {
+    expect(nodeConsumerSmokeJob?.if).toContain("should_skip != 'true'");
+  });
+
+  it('preserves the Lint aggregator name', () => {
+    expect(lintJob?.name).toBe('Lint');
+  });
+
+  it('preserves the Test aggregator name', () => {
+    expect(testJob?.name).toBe('Test');
+  });
+
+  it('preserves the Test aggregator failure check for skipped test shards', () => {
+    const checkStep = stepNamed(testJob, 'Check shard results');
+    const runText = checkStep.run ?? '';
+    expect(testJob?.if).toContain('always()');
+    expect(jobNeeds(testJob)).toEqual([
+      'test_shard',
+      'shard_selector',
+      'skip_check',
+      'acp_conformance',
+    ]);
+    expect(runText).toContain("shard_result='${{ needs.test_shard.result }}'");
+    expect(runText).toContain(`if [ "$shard_result" != "success" ]; then
+    echo "::error::Test shards did not all succeed (result: $shard_result)"
+    exit 1
+  fi`);
+  });
+
+  it('preserves the exact test_shard condition', () => {
+    expect(testShardJob?.if).toBe(
+      "${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' && needs.shard_selector.result == 'success' && needs.shard_selector.outputs.has_tests == 'true' }}",
+    );
+  });
+
+  it('preserves test_shard matrix scheduling from shard_selector', () => {
+    const strategy = asOptionalRecord(testShardJob?.strategy);
+    expect(strategy?.['fail-fast']).toBe(false);
+    expect(asOptionalRecord(strategy?.['matrix'])).toEqual({
+      include: '${{ fromJSON(needs.shard_selector.outputs.matrix) }}',
+    });
+  });
+
+  it('secure_store_backend still needs lint', () => {
+    const needs = jobNeeds(secureStoreJob);
+    expect(needs).toContain('lint');
   });
 });

--- a/scripts/tests/ci-acplint-workflow.test.ts
+++ b/scripts/tests/ci-acplint-workflow.test.ts
@@ -76,19 +76,33 @@ function runTestAggregate(
   runText: string,
   results: TestAggregateResults,
 ): SpawnSyncReturns<string> {
-  const expressions = new Map([
-    ['${{ needs.skip_check.outputs.should_skip }}', results.shouldSkip],
-    ['${{ needs.shard_selector.result }}', results.selector],
-    ['${{ needs.shard_selector.outputs.has_tests }}', results.hasTests],
-    ['${{ needs.test_shard.result }}', results.shards],
-    ['${{ needs.node_consumer_smoke.result }}', results.nodeConsumerSmoke],
-    ['${{ needs.acp_conformance.result }}', results.acp],
-  ]);
+  const substitutions = [
+    ["'${{ needs.skip_check.outputs.should_skip }}'", '"$1"'],
+    ["'${{ needs.shard_selector.result }}'", '"$2"'],
+    ["'${{ needs.shard_selector.outputs.has_tests }}'", '"$3"'],
+    ["'${{ needs.test_shard.result }}'", '"$4"'],
+    ["'${{ needs.node_consumer_smoke.result }}'", '"$5"'],
+    ["'${{ needs.acp_conformance.result }}'", '"$6"'],
+  ] as const;
   let script = runText;
-  for (const [expression, value] of expressions) {
-    script = script.replaceAll(expression, value);
+  for (const [expression, parameter] of substitutions) {
+    script = script.replaceAll(expression, parameter);
   }
-  return spawnSync('bash', ['-c', script], { encoding: 'utf8' });
+  return spawnSync(
+    'bash',
+    [
+      '-c',
+      script,
+      '--',
+      results.shouldSkip,
+      results.selector,
+      results.hasTests,
+      results.shards,
+      results.nodeConsumerSmoke,
+      results.acp,
+    ],
+    { encoding: 'utf8' },
+  );
 }
 
 describe('Issue #2564: acp_conformance CI job', () => {
@@ -455,6 +469,25 @@ describe('Issue #2877: test matrix scheduling', () => {
     expect(result.stdout).toContain(
       'Node Consumer Smoke did not succeed (result: failure)',
     );
+  });
+
+  it('passes aggregate results to Bash without evaluating shell syntax', () => {
+    const checkStep = stepNamed(testJob, 'Check shard results');
+    const sentinel = 'TEST_AGGREGATE_SHELL_INJECTION';
+    const nodeConsumerSmoke = `failure'; printf '${sentinel}' >&2; #`;
+    const result = runTestAggregate(checkStep.run ?? '', {
+      shouldSkip: 'false',
+      selector: 'success',
+      hasTests: 'false',
+      shards: 'skipped',
+      nodeConsumerSmoke,
+      acp: 'success',
+    });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      `Node Consumer Smoke did not succeed (result: ${nodeConsumerSmoke})`,
+    );
+    expect(result.stderr).not.toContain(sentinel);
   });
 
   it('preserves the exact test_shard condition', () => {


### PR DESCRIPTION
## TLDR

Starts the selected Test matrix as soon as Node Consumer Smoke, documentation filtering, shard selection, and duplicate-run checks succeed. This removes the full Lint aggregate from the test fanout critical path while preserving the existing package install/invocation smoke gate and required Lint/Test aggregates.

## Dive Deeper

The old graph made every Test matrix leg wait for the Lint aggregate, even though the matrix jobs install dependencies and build independently. The JavaScript lint leg is substantially longer than Node Consumer Smoke, so this delayed the first Test result without adding a required dependency for test execution.

This changes test_shard.needs from lint to node_consumer_smoke. Lint still depends on the four lint jobs plus node_consumer_smoke, so its required-check behavior and smoke coverage remain intact. The Test aggregator, shard condition, dynamic matrix, duplicate-run behavior, selector failure handling, docs-only behavior, and secure-store serialization remain unchanged.

The workflow comments now accurately describe Node Consumer Smoke as a package install/invocation gate rather than a full checkout build. Behavioral tests parse the real workflow and assert the exact direct dependencies, absence of transitive lint dependencies, exact condition and matrix strategy, preserved aggregate names/results, smoke skip behavior, and secure-store dependency. Unknown jobs in the transitive graph fail fast instead of being silently ignored.

## Reviewer Test Plan

1. Run:

       bun test scripts/tests/ci-acplint-workflow.test.ts scripts/tests/ci-secure-store-workflow.test.ts scripts/tests/validate-acplint-report.test.ts

2. Inspect the Actions dependency graph and confirm Test matrix jobs depend on Node Consumer Smoke rather than Lint.
3. In the PR run, compare job timestamps and confirm the first Test matrix leg starts after Node Consumer Smoke completes and before Lint completes.
4. Confirm the final Lint and Test aggregate checks retain their existing names and conclusions.

Local verification:

- Focused/adjacent workflow tests: 99 passing
- Build: passing
- Typecheck after build: passing
- Format: passing
- StepFun CLI smoke: passing
- Full npm test: one persistent unrelated core trust-transition timeout and one transient CLI test failure; the transient CLI test passes in isolation. Current main CI Test shards are green.
- Full lint: one unchanged provider-test strict-boolean error locally; current main CI Lint (Javascript) is green.
- Open Code Review workspace run completed over both changed files; its one valid test-helper finding was fixed. Wrapper coverage was reported as unknown, so no clean-coverage claim is made.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | CI  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2877


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI workflow dependency handling to ensure smoke checks run before downstream validation.
  * Updated test scheduling and failure handling for more reliable linting, test aggregation, and matrix execution.
  * Added safeguards for skipped or failed checks and secure-store lint validation.

* **Tests**
  * Expanded automated coverage for workflow dependencies, shard conditions, matrix configuration, and job isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->