### PR TITLE
fix(providers): surface provider 403 immediately instead of hanging

### DIFF
--- a/packages/core/src/utils/retry.onAuthError.test.ts
+++ b/packages/core/src/utils/retry.onAuthError.test.ts
@@ -12,7 +12,7 @@
  * 3. Passes errorStatus to the callback
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
 import { retryWithBackoff, type HttpError } from './retry.js';
 import { setSimulate429 } from './testUtils.js';
 

--- a/packages/core/src/utils/retry.onAuthError.test.ts
+++ b/packages/core/src/utils/retry.onAuthError.test.ts
@@ -170,4 +170,96 @@ describe('retryWithBackoff onAuthError callback', () => {
     expect(mockOnAuthError).toHaveBeenCalledTimes(1);
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
+
+  /**
+   * @fix issue2917
+   * A 403 with only onAuthError (no onPersistent429) must still get the single
+   * auth-refresh retry. This pins the intent explicitly: once 403 is no longer
+   * blindly retryable by status, the refresh allowance must be driven by the
+   * presence of an auth-recovery handler. Without the canRecoverFromAuthError
+   * gate this would regress to a single call with no onAuthError invocation.
+   */
+  it('retries a 403 exactly once when only onAuthError is supplied (issue #2917)', async () => {
+    const mockOnAuthError = vi.fn().mockResolvedValue(undefined);
+
+    const mockFn = vi.fn(async () => {
+      const error: HttpError = new Error('Forbidden');
+      error.status = 403;
+      throw error;
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 6,
+      initialDelayMs: 10,
+      onAuthError: mockOnAuthError,
+    });
+
+    promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await expect(promise).rejects.toThrow('Forbidden');
+
+    expect(mockOnAuthError).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * @fix issue2917
+   * A 403 with no auth-recovery handler at all must not burn the backoff budget:
+   * it is a terminal configuration/authorization problem, so retrying only
+   * delays the error. Today this retries up to maxAttempts.
+   */
+  it('does not backoff-retry a 403 when no auth-recovery handler is configured (issue #2917)', async () => {
+    const mockFn = vi.fn(async () => {
+      const error: HttpError = new Error('Forbidden');
+      error.status = 403;
+      throw error;
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 6,
+      initialDelayMs: 10,
+    });
+
+    promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await expect(promise).rejects.toThrow('Forbidden');
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * @fix issue2917
+   * Budget guard for the onAuthError-driven refresh allowance. When the
+   * attempt budget is already exhausted (maxAttempts reached on the very first
+   * attempt), granting a refresh retry cannot help — there is no attempt left
+   * for it to run — yet it would burn a full backoff cycle. The allowance must
+   * be gated the same way `invokeAuthErrorCallback` already gates the callback
+   * (it skips when `attempt >= maxAttempts`): a 403 at maxAttempts with only
+   * onAuthError must call the function exactly once and never invoke the
+   * callback.
+   *
+   * RED before R1(b): the function is called twice (the unconditional
+   * onAuthError allowance forces a decrement-and-continue).
+   */
+  it('does not grant an onAuthError refresh retry when the attempt budget is exhausted (issue #2917)', async () => {
+    const mockOnAuthError = vi.fn().mockResolvedValue(undefined);
+    const mockFn = vi.fn(async () => {
+      const error: HttpError = new Error('Forbidden');
+      error.status = 403;
+      throw error;
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 1,
+      initialDelayMs: 10,
+      onAuthError: mockOnAuthError,
+    });
+
+    promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await expect(promise).rejects.toThrow('Forbidden');
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(mockOnAuthError).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -18,7 +18,7 @@ export interface HttpError extends Error {
   status?: number;
 }
 
-const RETRYABLE_STATUS_CODES = new Set([401, 403, 429]);
+const RETRYABLE_STATUS_CODES = new Set([401, 429]);
 
 function isRetryableStatus(status: number): boolean {
   return RETRYABLE_STATUS_CODES.has(status) || (status >= 500 && status < 600);
@@ -238,7 +238,9 @@ export function isNetworkTransientError(error: unknown): boolean {
  *    (centralized in isNetworkTransientError)
  * 2. RetryableQuotaError → retry
  * 3. Anthropic body-level errors (overloaded_error, rate_limit_error, api_error, no HTTP status) → retry
- * 4. Generic status 401/403/429 or 5xx → retry; 400 → NEVER retry
+ * 4. Generic status 401/429 or 5xx → retry; 403 → NEVER retry by status (a
+ *    403 "forbidden" is a terminal auth/config problem, not a throttle, so
+ *    blind status-based retry only stalls; issue #2917). 400 → NEVER retry
  * 5. All others → do not retry
  *
  * @param error The error object.
@@ -347,7 +349,7 @@ function updateErrorCounters(
   is429: boolean,
   isAuthError: boolean,
   is500: boolean,
-  canAttemptFailover: boolean,
+  canRecoverFromAuthError: boolean,
   failoverThreshold: number,
   state: RetryLoopState,
   logger: DebugLogger,
@@ -370,7 +372,7 @@ function updateErrorCounters(
     is500 && !is429 && !isAuthError ? state.consecutiveServerErrors + 1 : 0;
 
   const shouldAttemptRefreshRetry =
-    isAuthError && canAttemptFailover && state.consecutiveAuthErrors === 1;
+    isAuthError && canRecoverFromAuthError && state.consecutiveAuthErrors === 1;
   return { shouldAttemptRefreshRetry };
 }
 
@@ -696,7 +698,14 @@ async function handleRetryFailure(
     classified.is429,
     classified.isAuthError,
     classified.is500,
-    context.options?.onPersistent429 !== undefined,
+    // The onPersistent429-driven allowance is left unconditional (issue #1123:
+    // a 403 must still get one refresh retry before bucket failover). The
+    // onAuthError-driven allowance is budget-guarded to match
+    // invokeAuthErrorCallback, which skips when attempt >= maxAttempts: granting
+    // a refresh retry with no attempt left only burns a backoff cycle (issue #2917).
+    context.options?.onPersistent429 !== undefined ||
+      (context.options?.onAuthError !== undefined &&
+        state.attempt < context.maxAttempts),
     context.failoverThreshold,
     state,
     context.logger,

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -95,6 +95,7 @@ import { AttemptNotificationContext } from './retryAttemptNotifier.js';
 import {
   getBucketFailoverHandlerFromOptions,
   getOnAuthErrorHandlerFromOptions,
+  hasAuthRecoveryHandler,
 } from './retryConfigHandlers.js';
 import { resolveAuthTokenFromOptions } from './retryAuthTokenResolver.js';
 import { randomUUID } from 'node:crypto';
@@ -170,10 +171,6 @@ export class RetryOrchestrator implements IProvider {
       authRetryTimeoutMs: config?.authRetryTimeoutMs ?? 30000,
       trackThrottleWaitTime: config?.trackThrottleWaitTime ?? (() => {}),
     };
-  }
-
-  private shouldBypassRetry(options: GenerateChatOptions): boolean {
-    return options.metadata?.loadBalancerDelegate === true;
   }
 
   // Delegate all IProvider methods to wrapped provider
@@ -307,7 +304,7 @@ export class RetryOrchestrator implements IProvider {
   private async *generateChatCompletionWithRetry(
     options: GenerateChatOptions,
   ): AsyncIterableIterator<IContent> {
-    if (this.shouldBypassRetry(options)) {
+    if (options.metadata?.loadBalancerDelegate === true) {
       yield* this.wrappedProvider.generateChatCompletion(options);
       return;
     }
@@ -746,7 +743,10 @@ export class RetryOrchestrator implements IProvider {
 
   /**
    * Invoke the auth error handler on the first consecutive auth failure (if
-   * retries remain), returning whether a refresh attempt was made.
+   * retries remain), returning whether a refresh attempt was made. Only grant
+   * the retry when a recovery mechanism that can change the outcome is
+   * configured (an onAuthError or bucket-failover handler) — otherwise it only
+   * burns an attempt + backoff on a terminal 403 (issue #2917).
    */
   private async maybeRefreshAuth(
     isAuthError: boolean,
@@ -760,6 +760,7 @@ export class RetryOrchestrator implements IProvider {
   ): Promise<boolean> {
     if (!(isAuthError && consecutiveAuthErrors === 1 && attempt < maxAttempts))
       return false;
+    if (!hasAuthRecoveryHandler(options)) return false;
     await this.invokeAuthErrorHandler(error, options, errorStatus, signal);
     return true;
   }

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
@@ -458,20 +458,24 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
   });
 
   /**
-   * Coverage for the 401/403 override in isTransientBackendFailure. These
-   * statuses ARE classified retryable by core's isRetryableError, but the
-   * load balancer intentionally treats them as non-transient (auth/config
-   * problems, not transient load). An all-401 or all-403 aggregate must
-   * therefore be NON-retryable — this guards against accidentally removing
-   * the override, which the mixed tests can no longer catch because the 429
-   * siblings alone satisfy some().
+   * Coverage for the 401/403 override in isTransientBackendFailure. The load
+   * balancer intentionally treats 401/403 as non-transient (auth/config
+   * problems, not transient load) regardless of core's classification. An
+   * all-401 or all-403 aggregate must therefore be NON-retryable — this guards
+   * against accidentally removing the override, which the mixed tests can no
+   * longer catch because the 429 siblings alone satisfy some().
+   *
+   * The `coreRetryable` column documents core's individual-status classification:
+   * 401 remains retryable (genuine token-refresh case), but 403 is no longer
+   * retryable in isolation (issue #2917: forbidden ≠ throttled). The LB override
+   * must still classify the aggregate as non-retryable in both cases.
    */
   it.each([
-    ['401', 401, 'unauthorized'],
-    ['403', 403, 'forbidden'],
+    ['401', 401, 'unauthorized', true],
+    ['403', 403, 'forbidden', false],
   ])(
     'classifies an all-%s aggregate as NON-retryable (auth/config override)',
-    async (_label, status, message) => {
+    async (_label, status, message, coreRetryable) => {
       const { error, counter } = await captureFailoverError(
         function* (): AsyncGenerator<IContent> {
           throw statusError(message, status);
@@ -480,9 +484,12 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
         'glm-all-auth',
       );
 
-      // Sanity: core considers 401/403 retryable in isolation, but the load
-      // balancer override must mark them non-transient for aggregation.
-      expect(isRetryableError(statusError(message, status))).toBe(true);
+      // Sanity: core's retryability of the individual status.
+      expect(isRetryableError(statusError(message, status))).toBe(
+        coreRetryable,
+      );
+      // The load balancer override marks them non-transient for aggregation
+      // regardless of core's individual classification.
       expect(error.isRetryable).toBe(false);
       expect(isRetryableError(error)).toBe(false);
       expect(counter.value).toBe(3);

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
@@ -13,7 +13,7 @@
  * delegate providers (the unit under test is never mocked).
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'bun:test';
 import { ProviderManager } from '../ProviderManager.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';

--- a/packages/providers/src/__tests__/RetryOrchestrator.failover.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.failover.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import { RetryOrchestrator } from '../RetryOrchestrator.js';
 import type { IProvider, GenerateChatOptions } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';

--- a/packages/providers/src/__tests__/RetryOrchestrator.failover.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.failover.test.ts
@@ -329,6 +329,47 @@ describe('RetryOrchestrator', () => {
       expect(currentBucket).toBe('bucket2');
     });
 
+    // issue1123 / SB-06: the sibling "401/403" test only constructs a 401;
+    // this real-403 case protects the preserved second-403 bucket-failover
+    // after issue #2917 made 403 non-retryable by status.
+    it('should failover on a genuine 403 after one retry', async () => {
+      let currentBucket = 'bucket1';
+      const buckets = ['bucket1', 'bucket2'];
+      let bucketIndex = 0;
+      const provider = createTestProvider({
+        responses: [
+          { error: createAuthError(403) },
+          { error: createAuthError(403) },
+          'success',
+        ],
+      });
+      const failoverHandler = {
+        getBuckets: () => buckets,
+        getCurrentBucket: () => currentBucket,
+        tryFailover: async () => {
+          bucketIndex++;
+          if (bucketIndex >= buckets.length) return false;
+          currentBucket = buckets[bucketIndex];
+          return true;
+        },
+        isEnabled: () => true,
+      };
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 5,
+        initialDelayMs: 10,
+      });
+      const options = {
+        contents: [{ role: 'user', blocks: [{ type: 'text', text: 'test' }] }],
+        runtime: {
+          config: { getBucketFailoverHandler: () => failoverHandler },
+        },
+      } as unknown as GenerateChatOptions;
+      const result = await consumeStream(
+        orchestrator.generateChatCompletion(options),
+      );
+      expect(result).toHaveLength(1);
+      expect(currentBucket).toBe('bucket2');
+    });
     it('should reset retry count after successful bucket switch', async () => {
       const rateLimitError = createRateLimitError();
       let currentBucket = 'bucket1';

--- a/packages/providers/src/__tests__/RetryOrchestrator.forbidden-composed.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.forbidden-composed.test.ts
@@ -25,7 +25,7 @@
  * changes, update this mirror accordingly.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import {
   retryWithBackoff,
   isRetryableError,

--- a/packages/providers/src/__tests__/RetryOrchestrator.forbidden-composed.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.forbidden-composed.test.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @fix issue2917
+ * Composed end-to-end regression test for the two-layer retry stack.
+ *
+ * In production, `StreamProcessor._executeStreamApiCall`
+ * (packages/agents/src/core/StreamProcessor.ts:253) wraps a provider's
+ * `RetryOrchestrator` call in core `retryWithBackoff`. The isolated
+ * per-layer tests cannot detect the nested duplication that issue #2917
+ * exposed (each layer independently granting an "auth refresh retry" for a
+ * 403, compounding transport attempts). This test composes the real layers
+ * exactly as StreamProcessor does and counts raw transport invocations
+ * across both layers, so a regression that reintroduces the duplication
+ * fails here.
+ *
+ * Rather than scaffold a full StreamProcessor, this mirrors the composition
+ * directly: core `retryWithBackoff` around a real `RetryOrchestrator`, using
+ * the SAME options StreamProcessor passes (notably `onPersistent429`, which
+ * returns null when no failover bucket is configured, and the
+ * `shouldRetryOnError` predicate that combines `EmptyStreamError`,
+ * `isTerminalRetryError`, and core `isRetryableError`). If that call site
+ * changes, update this mirror accordingly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  retryWithBackoff,
+  isRetryableError,
+} from '@vybestack/llxprt-code-core/utils/retry.js';
+import { EmptyStreamError } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import { isTerminalRetryError } from '../retryErrorClassification.js';
+import type { IProvider, GenerateChatOptions } from '../IProvider.js';
+import type { IModel } from '../IModel.js';
+
+/**
+ * Fake provider that throws a fixed status error on every transport call and
+ * counts each call, so the test can measure raw transport invocations across
+ * both retry layers without mocking the units under test.
+ */
+function createAlwaysFailingProvider(config: {
+  error: Error & { status?: number };
+  onTransportCall?: () => void;
+}): IProvider {
+  return {
+    name: 'test-provider',
+    async *generateChatCompletion(_options: GenerateChatOptions) {
+      config.onTransportCall?.();
+      throw config.error;
+      // Unreachable: satisfies require-yield and pins the generator's yield type.
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: '' }],
+      } satisfies IContent;
+    },
+    async getModels(): Promise<IModel[]> {
+      return [];
+    },
+    getDefaultModel(): string {
+      return 'test-model';
+    },
+    getServerTools(): string[] {
+      return [];
+    },
+    async invokeServerTool(): Promise<unknown> {
+      return null;
+    },
+  };
+}
+
+/** A status-bearing error matching Crusoe's forbidden-response body. */
+function createStatusError(
+  status: number,
+  message: string,
+): Error & { status: number } {
+  const error = new Error(message) as Error & { status: number };
+  error.status = status;
+  return error;
+}
+
+/**
+ * Drive a RetryOrchestrator turn exactly like StreamProcessor does: eagerly
+ * pull the first chunk WITHIN the retry boundary (mirroring
+ * `StreamProcessor._consumeFirstChunkAndReturn`) so a throw-before-output
+ * surfaces as a rejection of `fn()` rather than during later streaming. A
+ * fresh orchestrator stream is created per call so each outer retry gets a
+ * clean inner retry state, matching production where the orchestrator is
+ * invoked once per outer attempt.
+ */
+function runProviderTurn(
+  orchestrator: RetryOrchestrator,
+  options: GenerateChatOptions,
+): () => Promise<IContent[]> {
+  return async (): Promise<IContent[]> => {
+    const stream = orchestrator.generateChatCompletion(options);
+    const first = await stream.next();
+    if (first.done === true) return [];
+    const chunks: IContent[] = [first.value];
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+    return chunks;
+  };
+}
+
+describe('issue #2917 — composed two-layer retry (core retryWithBackoff around RetryOrchestrator)', () => {
+  it('a persistent 403 with no recovery handlers costs a bounded number of transport calls and surfaces the provider error', async () => {
+    let transportCalls = 0;
+    const provider = createAlwaysFailingProvider({
+      error: createStatusError(
+        403,
+        "Request blocked: parameter 'reasoning' is not allowed",
+      ),
+      onTransportCall: () => {
+        transportCalls++;
+      },
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 6,
+      initialDelayMs: 1,
+      maxDelayMs: 5,
+    });
+    const options: GenerateChatOptions = { contents: [] };
+
+    const promise = retryWithBackoff(runProviderTurn(orchestrator, options), {
+      maxAttempts: 5,
+      initialDelayMs: 1,
+      maxDelayMs: 5,
+      // Mirrors StreamProcessor: _handleBucketFailover returns null when no
+      // failover handler is configured.
+      onPersistent429: async () => null,
+      shouldRetryOnError: (error) =>
+        error instanceof EmptyStreamError ||
+        (!isTerminalRetryError(error) && isRetryableError(error)),
+    });
+
+    let thrown: unknown;
+    try {
+      await promise;
+    } catch (error) {
+      thrown = error;
+    }
+
+    // With issue #2917 fixed, the inner RetryOrchestrator makes exactly one
+    // transport attempt (no refresh can occur without a recovery handler).
+    // The outer core layer preserves its single onPersistent429-driven refresh
+    // retry before failover-returns-null -> throw (issue #1123). Total = 2.
+    // Before the fix this was 4 (each layer granted its own refresh retry).
+    expect(transportCalls).toBe(2);
+
+    expect(thrown).toBeDefined();
+    expect((thrown as Error & { status: number }).status).toBe(403);
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+    expect(message).toContain(
+      "Request blocked: parameter 'reasoning' is not allowed",
+    );
+  });
+
+  it('a persistent 422 through the same composition costs exactly one transport call (issue acceptance: "the same way a 422 does")', async () => {
+    let transportCalls = 0;
+    const provider = createAlwaysFailingProvider({
+      error: createStatusError(422, 'Unprocessable entity'),
+      onTransportCall: () => {
+        transportCalls++;
+      },
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 6,
+      initialDelayMs: 1,
+      maxDelayMs: 5,
+    });
+    const options: GenerateChatOptions = { contents: [] };
+
+    const promise = retryWithBackoff(runProviderTurn(orchestrator, options), {
+      maxAttempts: 5,
+      initialDelayMs: 1,
+      maxDelayMs: 5,
+      onPersistent429: async () => null,
+      shouldRetryOnError: (error) =>
+        error instanceof EmptyStreamError ||
+        (!isTerminalRetryError(error) && isRetryableError(error)),
+    });
+
+    await expect(promise).rejects.toThrow('Unprocessable entity');
+
+    // 422 is not retryable at either layer and has no recovery path, so it
+    // surfaces after a single transport invocation — the baseline the issue
+    // requires a 403 to match.
+    expect(transportCalls).toBe(1);
+  });
+});

--- a/packages/providers/src/__tests__/RetryOrchestrator.forbidden.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.forbidden.test.ts
@@ -13,7 +13,7 @@
  * the surfaced error shape.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'bun:test';
 import { RetryOrchestrator } from '../RetryOrchestrator.js';
 import type { IProvider, GenerateChatOptions } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';

--- a/packages/providers/src/__tests__/RetryOrchestrator.forbidden.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.forbidden.test.ts
@@ -1,0 +1,295 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @fix issue2917
+ * Behavioral tests for RetryOrchestrator handling of a persistent provider 403.
+ *
+ * A 403 ("forbidden") is a terminal configuration/authorization problem, not a
+ * throttle. Retrying it blindly only delays the surfaced error. These tests
+ * drive a real RetryOrchestrator with a fake provider that throws real
+ * status-bearing errors, and assert the observable transport-attempt count and
+ * the surfaced error shape.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import type { IProvider, GenerateChatOptions } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { IModel } from '../IModel.js';
+import type { OnAuthErrorHandler } from '@vybestack/llxprt-code-core/config/configTypes.js';
+
+/**
+ * Fake provider that replays a fixed list of responses. Mirrors the helper used
+ * by the sibling RetryOrchestrator suites so the IProvider contract is honoured
+ * exactly. `onTransportCall` fires on every transport invocation, letting tests
+ * count real transport attempts without mocking the orchestrator under test.
+ */
+function createTestProvider(config: {
+  name?: string;
+  responses?: Array<'success' | 'error' | { error: Error }>;
+  onTransportCall?: () => void;
+}): IProvider {
+  let callCount = 0;
+
+  const successContent: IContent = {
+    speaker: 'ai',
+    blocks: [{ type: 'text', text: 'test response' }],
+  };
+
+  return {
+    name: config.name ?? 'test-provider',
+    async *generateChatCompletion(_options: GenerateChatOptions) {
+      config.onTransportCall?.();
+      const responseIndex = Math.min(
+        callCount,
+        (config.responses?.length ?? 1) - 1,
+      );
+      callCount++;
+
+      const response = config.responses?.[responseIndex] ?? 'success';
+
+      if (response === 'error') {
+        throw new Error('Generic error');
+      } else if (typeof response === 'object' && 'error' in response) {
+        throw response.error;
+      }
+
+      yield successContent;
+    },
+    async getModels(): Promise<IModel[]> {
+      return [];
+    },
+    getDefaultModel(): string {
+      return 'test-model';
+    },
+    getServerTools(): string[] {
+      return [];
+    },
+    async invokeServerTool(): Promise<unknown> {
+      return null;
+    },
+  };
+}
+
+/** A status-bearing error matching Crusoe's forbidden-response body (issue #2917). */
+function createForbiddenError(): Error {
+  const error = new Error(
+    "Request blocked: parameter 'reasoning' is not allowed",
+  ) as Error & { status?: number };
+  error.status = 403;
+  return error;
+}
+
+/** Generic status-bearing error for table-driven assertions. */
+function createStatusError(status: number, message?: string): Error {
+  const error = new Error(message ?? `HTTP ${status}`) as Error & {
+    status?: number;
+  };
+  error.status = status;
+  return error;
+}
+
+/** Consume an async iterator fully, surfacing any thrown error as a rejection. */
+async function consumeStream(
+  stream: AsyncIterableIterator<IContent>,
+): Promise<IContent[]> {
+  const chunks: IContent[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+describe('RetryOrchestrator forbidden (403) handling — issue #2917', () => {
+  it('surfaces a persistent 403 after exactly one attempt when no recovery handler is configured (AC1)', async () => {
+    let transportCalls = 0;
+    const provider = createTestProvider({
+      responses: [{ error: createForbiddenError() }],
+      onTransportCall: () => {
+        transportCalls++;
+      },
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 6,
+      initialDelayMs: 1,
+    });
+
+    await expect(
+      consumeStream(
+        orchestrator.generateChatCompletion({
+          contents: [],
+        }),
+      ),
+    ).rejects.toThrow("Request blocked: parameter 'reasoning' is not allowed");
+
+    // No auth-error handler and no bucket-failover handler are configured, so
+    // no refresh can possibly occur: the orchestrator must make exactly one
+    // transport attempt and rethrow immediately — identical to 422/400/404.
+    expect(transportCalls).toBe(1);
+  });
+
+  it('still grants a single auth-refresh retry when an onAuthError handler is configured (AC3)', async () => {
+    let transportCalls = 0;
+    const handleAuthError = vi.fn().mockResolvedValue(undefined);
+    const onAuthErrorHandler: OnAuthErrorHandler = { handleAuthError };
+
+    const provider = createTestProvider({
+      responses: [{ error: createForbiddenError() }, 'success'],
+      onTransportCall: () => {
+        transportCalls++;
+      },
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 6,
+      initialDelayMs: 1,
+    });
+
+    const result = await consumeStream(
+      orchestrator.generateChatCompletion({
+        contents: [],
+        resolved: { authToken: 'revoked-403-token' },
+        runtime: {
+          config: {
+            getOnAuthErrorHandler: () => onAuthErrorHandler,
+          },
+        },
+      } as GenerateChatOptions),
+    );
+
+    // With a real recovery mechanism, the orchestrator retries exactly once
+    // (initial attempt + one auth-refresh retry) and invokes the handler once.
+    expect(transportCalls).toBe(2);
+    expect(handleAuthError).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+  });
+
+  it('still refreshes then fails over when a bucketFailoverHandler is configured (AC4)', async () => {
+    let transportCalls = 0;
+    const buckets = ['bucket1', 'bucket2'];
+    let bucketIndex = 0;
+    let currentBucket = buckets[bucketIndex];
+
+    const provider = createTestProvider({
+      responses: [
+        { error: createForbiddenError() },
+        { error: createForbiddenError() },
+        'success',
+      ],
+      onTransportCall: () => {
+        transportCalls++;
+      },
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 6,
+      initialDelayMs: 1,
+    });
+
+    const result = await consumeStream(
+      orchestrator.generateChatCompletion({
+        contents: [],
+        runtime: {
+          config: {
+            getBucketFailoverHandler: () => ({
+              getBuckets: () => buckets,
+              getCurrentBucket: () => currentBucket,
+              tryFailover: async () => {
+                bucketIndex++;
+                if (bucketIndex >= buckets.length) return false;
+                currentBucket = buckets[bucketIndex];
+                return true;
+              },
+              isEnabled: () => true,
+            }),
+          },
+        },
+      } as GenerateChatOptions),
+    );
+
+    // First 403 triggers the refresh-retry allowance, second 403 triggers
+    // bucket failover. Failover behavior is unchanged by issue #2917.
+    expect(transportCalls).toBe(3);
+    expect(currentBucket).toBe('bucket2');
+    expect(result).toHaveLength(1);
+  });
+
+  it('preserves the provider status (403) and body text in the surfaced error (AC2)', async () => {
+    const provider = createTestProvider({
+      responses: [{ error: createForbiddenError() }],
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 6,
+      initialDelayMs: 1,
+    });
+
+    let thrown: unknown;
+    try {
+      await consumeStream(
+        orchestrator.generateChatCompletion({ contents: [] }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect((thrown as { status?: number }).status).toBe(403);
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+    expect(message).toContain(
+      "Request blocked: parameter 'reasoning' is not allowed",
+    );
+  });
+
+  it.each([
+    { status: 400, label: 'bad request' },
+    { status: 404, label: 'not found' },
+    { status: 422, label: 'unprocessable entity' },
+  ])(
+    'does not retry a persistent $label (status $status) (AC5)',
+    async ({ status }) => {
+      let transportCalls = 0;
+      const provider = createTestProvider({
+        responses: [{ error: createStatusError(status) }],
+        onTransportCall: () => {
+          transportCalls++;
+        },
+      });
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 6,
+        initialDelayMs: 1,
+      });
+
+      await expect(
+        consumeStream(orchestrator.generateChatCompletion({ contents: [] })),
+      ).rejects.toThrow(`HTTP ${status}`);
+
+      expect(transportCalls).toBe(1);
+    },
+  );
+
+  it.each([
+    { status: 429, label: 'rate limit' },
+    { status: 503, label: 'service unavailable' },
+  ])(
+    'still retries a persistent $label (status $status) beyond a single refresh attempt (AC5)',
+    async ({ status }) => {
+      let transportCalls = 0;
+      const provider = createTestProvider({
+        responses: [{ error: createStatusError(status) }],
+        onTransportCall: () => {
+          transportCalls++;
+        },
+      });
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 6,
+        initialDelayMs: 1,
+      });
+
+      await expect(
+        consumeStream(orchestrator.generateChatCompletion({ contents: [] })),
+      ).rejects.toThrow(`HTTP ${status}`);
+
+      expect(transportCalls).toBe(6);
+    },
+  );
+});

--- a/packages/providers/src/__tests__/RetryOrchestrator.forbidden.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.forbidden.test.ts
@@ -166,7 +166,8 @@ describe('RetryOrchestrator forbidden (403) handling — issue #2917', () => {
   });
 
   it('still refreshes then fails over when a bucketFailoverHandler is configured (AC4)', async () => {
-    let transportCalls = 0;
+    const attemptBuckets: string[] = [];
+    let failoverCalls = 0;
     const buckets = ['bucket1', 'bucket2'];
     let bucketIndex = 0;
     let currentBucket = buckets[bucketIndex];
@@ -178,7 +179,7 @@ describe('RetryOrchestrator forbidden (403) handling — issue #2917', () => {
         'success',
       ],
       onTransportCall: () => {
-        transportCalls++;
+        attemptBuckets.push(currentBucket);
       },
     });
     const orchestrator = new RetryOrchestrator(provider, {
@@ -195,6 +196,7 @@ describe('RetryOrchestrator forbidden (403) handling — issue #2917', () => {
               getBuckets: () => buckets,
               getCurrentBucket: () => currentBucket,
               tryFailover: async () => {
+                failoverCalls++;
                 bucketIndex++;
                 if (bucketIndex >= buckets.length) return false;
                 currentBucket = buckets[bucketIndex];
@@ -207,10 +209,12 @@ describe('RetryOrchestrator forbidden (403) handling — issue #2917', () => {
       } as GenerateChatOptions),
     );
 
-    // First 403 triggers the refresh-retry allowance, second 403 triggers
-    // bucket failover. Failover behavior is unchanged by issue #2917.
-    expect(transportCalls).toBe(3);
-    expect(currentBucket).toBe('bucket2');
+    // First 403 triggers the refresh-retry allowance on the ORIGINAL bucket,
+    // and only the second 403 triggers bucket failover. Asserting the bucket
+    // per attempt pins that ordering: a failover after the first 403 would
+    // still produce three calls and still end on bucket2.
+    expect(attemptBuckets).toStrictEqual(['bucket1', 'bucket1', 'bucket2']);
+    expect(failoverCalls).toBe(1);
     expect(result).toHaveLength(1);
   });
 

--- a/packages/providers/src/retryConfigHandlers.ts
+++ b/packages/providers/src/retryConfigHandlers.ts
@@ -60,3 +60,16 @@ export function getOnAuthErrorHandlerFromOptions(
     resolveOnAuthErrorHandlerFromConfig(options.config)
   );
 }
+
+/**
+ * Whether any auth-recovery mechanism that can change a retry's outcome is
+ * resolvable from the options: an onAuthError handler OR a bucket-failover
+ * handler. Used to avoid granting a refresh retry when no recovery can occur
+ * (issue #2917).
+ */
+export function hasAuthRecoveryHandler(options: GenerateChatOptions): boolean {
+  return (
+    getOnAuthErrorHandlerFromOptions(options) !== undefined ||
+    getBucketFailoverHandlerFromOptions(options) !== undefined
+  );
+}

--- a/packages/providers/src/retryDelayPolicy.ts
+++ b/packages/providers/src/retryDelayPolicy.ts
@@ -38,7 +38,8 @@ export function shouldRetryError(error: unknown): boolean {
   if (isNetworkTransientError(error)) {
     return true;
   }
-  if (status === 401 || status === 403) {
+  // 403 means the request is forbidden, not throttled; retrying only delays the error (issue #2917).
+  if (status === 401) {
     return true;
   }
   return isStreamTimeoutError(error);

--- a/project-plans/issue2917/plan.md
+++ b/project-plans/issue2917/plan.md
@@ -1,0 +1,261 @@
+# Issue #2917 — A 403 from an OpenAI-compatible provider presents as an indefinite hang
+
+## Problem
+
+Crusoe (`https://api.inference.crusoecloud.com/v1`) rejects a request in 0.18s with:
+
+```
+403  {"errors":["Request blocked: parameter 'reasoning' is not allowed"]}
+```
+
+llxprt produced no output and no exit for 60+ seconds. By contrast, Friendli's `422`
+on the same class of request surfaced immediately as a clean error.
+
+## Root cause (measured, not inferred)
+
+A `403` is classified as retryable **by HTTP status** in two independent retry layers:
+
+| Location                                             | Code                                       |
+| ---------------------------------------------------- | ------------------------------------------ |
+| `packages/core/src/utils/retry.ts:21`                | `RETRYABLE_STATUS_CODES = new Set([401, 403, 429])` |
+| `packages/providers/src/retryDelayPolicy.ts:41`      | `if (status === 401 \|\| status === 403) return true;` |
+
+A `422` matches none of the retryable branches in `shouldRetryError`, so it throws on
+the first attempt — which is exactly why 422 looks correct and 403 does not.
+
+### Measured transport-attempt counts
+
+Instrumented `RetryOrchestrator` with a provider that always throws a status error,
+`maxAttempts: 6`:
+
+| Status | Transport attempts (before fix) |
+| ------ | ------------------------------- |
+| 400    | 1                               |
+| 422    | 1                               |
+| 403    | **6** (entire retry budget)     |
+
+At production defaults (`initialDelayMs: 5000`, `maxDelayMs: 30000`) six attempts means
+delays of 5s + 10s + 20s + 30s + 30s ≈ **95 seconds of complete silence** at the
+`RetryOrchestrator` layer alone.
+
+That is then **compounded** by a second, outer retry layer:
+`packages/agents/src/core/StreamProcessor.ts:253` wraps the orchestrator in
+`retryWithBackoff(...)` whose `shouldRetryOnError` calls core `isRetryableError`, which
+also treats 403 as retryable. `createRetriesExhaustedError` propagates the effective
+`status`, so the outer layer sees 403 again and restarts the whole inner budget.
+Nested, this is many minutes of silence — indistinguishable from a hang.
+
+## Non-goals (explicitly out of scope)
+
+- `401` retry behavior. The issue is about 403. 401 ("credentials not accepted") is the
+  genuine token-refresh case and stays retryable.
+- `packages/tools/src/utils/retry.ts:192` (`RETRYABLE_STATUSES`) — tool-side HTTP retry,
+  not on the provider request path.
+- Any change to the reasoning-dialect fan-out (that was #2896 / PR #2915).
+- Any change to bucket failover policy or `failoverSettings.ts`.
+
+## Acceptance criteria
+
+**AC1 — A persistent provider 403 surfaces as an error without burning the retry budget when no recovery is possible.**
+With `maxAttempts: 6`, a provider that always returns 403:
+- with **no** auth-error handler and **no** bucket-failover handler: RetryOrchestrator makes
+  **exactly 1** transport attempt and rethrows immediately — identical to 422/400/404.
+- with an `onAuthError` handler configured: **exactly 2** attempts (the single auth-refresh
+  allowance) and the handler is invoked once.
+- with a `bucketFailoverHandler` configured: refresh retry then failover (unchanged).
+
+The caller receives a rejected stream, not a stall.
+
+**AC1-composed — The nested two-layer composition is bounded.**
+`StreamProcessor._executeStreamApiCall` (packages/agents/src/core/StreamProcessor.ts:253) wraps
+the provider's `RetryOrchestrator` in core `retryWithBackoff`. Across **both** layers, a
+persistent 403 with no recovery handlers costs a bounded number of transport invocations
+(measured: **2** — the outer `onPersistent429`-driven refresh retry is preserved per issue #1123,
+then failover-returns-null → throw). Before this remediation it was **4** (each layer granted
+its own auth-refresh retry). A 422 through the same composition costs **1**.
+
+**AC2 — The surfaced error preserves the provider's status and body text.**
+The error thrown to the caller must still carry `status === 403` and the provider's
+message (e.g. `Request blocked: parameter 'reasoning' is not allowed`), so a user can
+tell a configuration problem from a quota problem.
+
+**AC3 — The existing one-shot auth-refresh retry on 403 is preserved.**
+`retryWithBackoff` must still invoke `onAuthError` exactly once for a 403 and retry
+exactly once, so OAuth token-revocation recovery (issue1861) keeps working. This must
+hold even when `onPersistent429` is **not** supplied — today that path only works by
+accident, via blind status-based retryability.
+
+**AC4 — Bucket failover on repeated 403 is preserved.**
+Two consecutive 403s with a failover handler configured must still trigger failover
+(issue1123, SB-06).
+
+**AC5 — Non-auth statuses are unaffected.** 400/404/422 still fail on the first attempt;
+429 and 5xx still retry through the full budget.
+
+## Design
+
+Two production edits, both removing *blind status-based* retryability of 403 while
+keeping the *explicitly modeled* auth-recovery paths intact.
+
+### Edit 1 — `packages/providers/src/retryDelayPolicy.ts`
+
+```diff
+-  if (status === 401 || status === 403) {
++  if (status === 401) {
+     return true;
+   }
+```
+
+`RetryOrchestrator.decideRetryOrThrow` throws when
+`!shouldRetryError && !shouldAttemptRefreshRetry`. `maybeRefreshAuth` still grants the
+first auth error one retry, so 403 → 2 attempts then a clean throw of the **raw**
+provider error (not a `RetriesExhaustedError`), which satisfies AC2.
+
+### Edit 2 — `packages/core/src/utils/retry.ts`
+
+```diff
+-const RETRYABLE_STATUS_CODES = new Set([401, 403, 429]);
++const RETRYABLE_STATUS_CODES = new Set([401, 429]);
+```
+
+This alone would regress AC3: in `handleRetryFailure` the refresh-retry allowance is
+gated on `canAttemptFailover = options?.onPersistent429 !== undefined`. Callers that
+supply only `onAuthError` (see `retry.onAuthError.test.ts`) would lose both the retry
+and the `onAuthError` invocation. So the gate must also recognise an auth handler:
+
+```diff
+     classified.is500,
+-    context.options?.onPersistent429 !== undefined,
++    context.options?.onPersistent429 !== undefined ||
++      context.options?.onAuthError !== undefined,
+     context.failoverThreshold,
+```
+
+and the corresponding `updateErrorCounters` parameter is renamed
+`canAttemptFailover` → `canRecoverFromAuthError`, since it now means "some auth-recovery
+mechanism exists", not specifically "failover is possible".
+
+### Remediation edits (remove the no-recovery auth-refresh retry)
+
+A deep review found that Edits 1+2 alone still left a persistent 403 with **no** auth
+handler and **no** failover handler costing **4** transport attempts and ~15s backoff in
+the real `StreamProcessor` composition (each layer grants its own auth-refresh retry even
+though no refresh can occur). Two coordinated edits close that gap:
+
+### Edit 3 (R1a) — `packages/providers/src/RetryOrchestrator.ts`, `maybeRefreshAuth`
+
+Only grant the auth-refresh retry when a recovery mechanism that can change the outcome is
+actually configured, via the shared `hasAuthRecoveryHandler(options)` helper
+(`packages/providers/src/retryConfigHandlers.ts`, which checks both
+`getOnAuthErrorHandlerFromOptions` and `getBucketFailoverHandlerFromOptions`):
+
+```diff
+   if (!(isAuthError && consecutiveAuthErrors === 1 && attempt < maxAttempts))
+     return false;
++  if (!hasAuthRecoveryHandler(options)) return false;
+   await this.invokeAuthErrorHandler(error, options, errorStatus, signal);
+   return true;
+```
+
+Effect: isolated RetryOrchestrator, persistent 403, no handlers → **1** attempt (was 2).
+
+### Edit 4 (R1b) — `packages/core/src/utils/retry.ts`, the `canRecoverFromAuthError` expression
+
+Budget-guard the `onAuthError`-driven allowance to match the guard
+`invokeAuthErrorCallback` already applies (`attempt >= maxAttempts` → skip). The
+`onPersistent429`-driven branch is left identical (issue #1123 depends on it):
+
+```diff
+     context.options?.onPersistent429 !== undefined ||
+-      context.options?.onAuthError !== undefined,
++      (context.options?.onAuthError !== undefined &&
++        state.attempt < context.maxAttempts),
+```
+
+## Test plan (write these first; confirm RED before editing production code)
+
+All tests are behavioral: real `RetryOrchestrator` / real `retryWithBackoff`, driven by a
+fake provider/transport that throws real status-bearing errors. No mocking of the unit
+under test, no assertions on mock call plumbing beyond counting real transport calls.
+
+### T1 (AC1) — `packages/providers/src/__tests__/RetryOrchestrator.forbidden.test.ts` *(new)*
+
+Real `RetryOrchestrator`, `maxAttempts: 6`, fake provider that always throws a 403
+carrying Crusoe's body text. Count transport invocations.
+
+- **no handler**: asserts transport called exactly **1** time (RED before R1(a): 2). The
+  orchestrator rethrows immediately — identical to 422/400/404.
+- **`onAuthError` handler configured**: asserts transport called exactly **2** times and the
+  handler invoked once (refresh allowance preserved).
+- **`bucketFailoverHandler` configured**: asserts refresh-then-failover (3 attempts, bucket
+  switches) — unchanged.
+
+### T2 (AC2) — same file
+
+Asserts the rejection carries `status: 403` and a message containing
+`Request blocked: parameter 'reasoning' is not allowed`.
+
+### T3 (AC5) — same file
+
+Table-driven over `[400, 404, 422]` → exactly 1 transport attempt; over `[429, 503]` →
+retries beyond 2 attempts. Guards against over-correcting.
+
+### T-composed (AC1-composed) — `packages/providers/src/__tests__/RetryOrchestrator.forbidden-composed.test.ts` *(new)*
+
+Composes core `retryWithBackoff` around a **real** `RetryOrchestrator`, mirroring the
+options `StreamProcessor.ts:253` passes (`onPersistent429` returning null, the
+`shouldRetryOnError` predicate combining `EmptyStreamError`/`isTerminalRetryError`/
+`isRetryableError`). The isolated per-layer tests cannot detect the nested duplication, so
+this exercises the real composition.
+
+- persistent 403, no recovery handlers: asserts **2** total transport invocations across both
+  layers (RED before R1(a): 4) and that the surfaced error preserves status 403 + body text.
+- 422 contrast through the same composition: asserts **1** transport invocation — the issue's
+  literal acceptance ("surfaces as an error the same way a 422 does").
+
+### T4 (AC3) — `packages/core/src/utils/retry.onAuthError.test.ts` *(extend)*
+
+The existing 403 test already asserts `onAuthError` called once and the function called
+twice, but it passes today only because of blind status retryability. Add an explicit
+case that pins the intent: a 403 with `onAuthError` supplied and **no** `onPersistent429`
+retries exactly once and then rejects with the original error. RED after Edit 2 alone,
+GREEN with the `canRecoverFromAuthError` change.
+
+Also add: a 403 with **neither** `onAuthError` nor `onPersistent429` must call the
+function exactly **once** (no pointless backoff). RED today (calls it up to `maxAttempts`).
+
+### T5 (AC4) — existing suites must stay green, unmodified
+
+- `packages/core/src/utils/retry.test.ts` — "should retry once on 403 before bucket failover"
+- `packages/providers/src/__tests__/RetryOrchestrator.failover.test.ts` — "should failover on 401/403 after one retry"
+- `packages/providers/src/__tests__/RetryOrchestrator.onAuthError.test.ts` — 403 onAuthError
+- `packages/providers/src/auth/__tests__/behavioral/single-bucket.behavioral.spec.ts` — SB-06
+
+### Measured results (final, this remediation)
+
+Transport-attempt counts, instrumented with a counting fake provider/transport:
+
+| Scenario                                           | Before fix | After fix |
+| -------------------------------------------------- | ---------- | --------- |
+| Isolated RetryOrchestrator, 403, no handlers       | 2          | **1**     |
+| Isolated RetryOrchestrator, 403, `onAuthError` set | 2          | **2**     |
+| Isolated RetryOrchestrator, 403, `bucketFailover`  | 3          | **3**     |
+| Isolated RetryOrchestrator, 422                    | 1          | **1**     |
+| **Composed** (core `retryWithBackoff` ⊃ RetryOrchestrator), 403, no handlers | **4** (~15s) | **2** |
+| **Composed**, 422                                  | 1          | **1**     |
+
+The composed 403 path still spends one outer `onPersistent429`-driven refresh retry (issue
+#1123) before failover-returns-null → throw; that is intentional and protected by
+`packages/core/src/utils/retry.test.ts` "should retry once on 403 before bucket failover".
+
+### Suite results
+
+- `packages/core`: `retry.test.ts` 53/53, `retry.onAuthError.test.ts` 8/8 pass
+- `packages/providers`: `RetryOrchestrator.{basic,failover,failover5xx,onAuthError,forbidden,forbidden-composed}.test.ts` + `LoadBalancingProvider.failover.retryable.test.ts` + `single-bucket.behavioral.spec.ts` — 101/101 pass
+- `packages/providers/src/openai/OpenAIProvider.shouldRetry.test.ts` fails to load under
+  vitest (`vi.importActualSync` requires Bun) — **pre-existing**, unrelated, runs under `bun test`
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`,
+and `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -206,6 +206,8 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       'src/__tests__/RetryOrchestrator.basic.test.ts',
       'src/__tests__/RetryOrchestrator.failover-budget.test.ts',
       'src/__tests__/RetryOrchestrator.failover.test.ts',
+      'src/__tests__/RetryOrchestrator.forbidden.test.ts',
+      'src/__tests__/RetryOrchestrator.forbidden-composed.test.ts',
       'src/__tests__/RetryOrchestrator.getContextLimit.test.ts',
       'src/__tests__/RetryOrchestrator.integration.test.ts',
       'src/__tests__/RetryOrchestrator.invocation.test.ts',


### PR DESCRIPTION
Closes #2917

## Symptom

Crusoe (an OpenAI-compatible endpoint) rejected a request in 0.18 seconds:

    403  {"errors":["Request blocked: parameter 'reasoning' is not allowed"]}

llxprt produced **no output and no exit** — still running after 60 seconds, killed manually. A Friendli **422** on the same class of request surfaced as a clean error message instantly.

## Root cause

The difference between 422 and 403 was never transport — it was classification. A 403 was retryable **by HTTP status** in two independent retry engines:

| Location | Before |
| --- | --- |
| `packages/core/src/utils/retry.ts` | `RETRYABLE_STATUS_CODES = new Set([401, 403, 429])` |
| `packages/providers/src/retryDelayPolicy.ts` (`shouldRetryError`) | `if (status === 401 \|\| status === 403) return true` |

A 422 matches no retryable branch in either engine, so it throws on the first attempt. That is exactly the behavior the issue asks 403 to have.

**The two engines compound.** `packages/agents/src/core/StreamProcessor.ts` wraps a `RetryOrchestrator` call inside core's `retryWithBackoff`, and `createRetriesExhaustedError` propagates the numeric `status` onto the thrown error. So the outer engine re-classified the *exhausted inner failure* as retryable and started a brand-new inner budget.

Additionally, `RetryOrchestrator.maybeRefreshAuth` returned `true` for the first auth error **even when no auth handler was configured**, spending a pointless retry plus a 5-second delay on a request that had no recovery mechanism available.

## Measured impact

Transport attempts at production defaults (core `maxAttempts` 5, orchestrator `maxAttempts` 6, `initialDelayMs` 5000, `maxDelayMs` 30000):

| Scenario | Before | After |
| --- | --- | --- |
| Persistent 403, no recovery handler, composed path | **12 attempts / ~195s silent** (136–253s with jitter) | **2 attempts** |
| Persistent 403, no recovery handler, orchestrator alone | 6 | **1** (identical to 422/400/404) |
| Persistent 403 + `onAuthError` handler | — | **2**, handler invoked exactly once |
| Persistent 403 + `bucketFailoverHandler` | — | **3**, bucket1 → bucket2 |
| 422 composed path (control) | 1 | **1** (unchanged) |
| Persistent 429 / 503 (control) | 6 | **6** (unchanged) |

The ~195 seconds of total silence is what the reporter experienced as an indefinite hang.

## The change

**Production**

1. `packages/core/src/utils/retry.ts` — `RETRYABLE_STATUS_CODES` narrowed to `[401, 429]`. The `isRetryableError` JSDoc now states that 403 is never retried by status. In `handleRetryFailure`, the recovery-allowance argument became `onPersistent429 !== undefined || (onAuthError !== undefined && state.attempt < maxAttempts)`; the `onPersistent429` branch is deliberately left unconditional to preserve #1123 bucket failover, while the `onAuthError` branch is budget-guarded so it matches the conditions under which `invokeAuthErrorCallback` would actually fire. The `updateErrorCounters` parameter was renamed `canAttemptFailover` → `canRecoverFromAuthError` to describe what it now means.
2. `packages/providers/src/retryDelayPolicy.ts` — `shouldRetryError` retains only 401 in its auth-status branch. A 403 means forbidden, not throttled; retrying only delays the error.
3. `packages/providers/src/RetryOrchestrator.ts` — `maybeRefreshAuth` early-returns `false` when no auth recovery handler is configured.
4. `packages/providers/src/retryConfigHandlers.ts` — new exported `hasAuthRecoveryHandler(options)`, true when either an `onAuthError` handler or a bucket-failover handler is resolvable.

**Tests**

5. New `RetryOrchestrator.forbidden.test.ts` (9 tests): 403 with no handler = exactly 1 transport attempt; 403 + `onAuthError` = 2 attempts with the handler called once; 403 + `bucketFailoverHandler` = 3 attempts with a bucket switch; the surfaced error preserves status 403 **and** the provider's body text `Request blocked: parameter 'reasoning' is not allowed`; 400/404/422 each cost exactly 1 attempt; 429/503 still cost exactly 6.
6. New `RetryOrchestrator.forbidden-composed.test.ts` (2 tests): wraps a **real** `RetryOrchestrator` inside **real** core `retryWithBackoff`, mirroring `StreamProcessor.ts`, proving the composed path costs 2 attempts for a persistent 403 and 1 for a 422, with status and body surviving both layers. This is the regression test for the compounding defect specifically.
7. `RetryOrchestrator.failover.test.ts` — a pre-existing case named "401/403" only ever constructed a 401; a genuine-403 bucket-failover case was added.
8. `packages/core/src/utils/retry.onAuthError.test.ts` — 3 tests covering no-handler 403, explicit `onAuthError` without `onPersistent429`, and the `maxAttempts: 1` boundary.
9. `LoadBalancingProvider.failover.retryable.test.ts` — added a `coreRetryable` sanity column (401 true, 403 false); the primary assertion is unchanged.

The fake in these tests is only the transport seam. The retry engines, classification, stream consumption, and error propagation are all real, and the assertions are on externally observable transport counts and surfaced errors.

## What is deliberately preserved

403 is still classified as an **auth** error in both engines. Only the blind *status-based* retry was removed. Every legitimate recovery path still works, and each is covered by a test:

- **OAuth token revocation (#1861)** — `classifyError` / `classifyRetryError` still treat 403 as auth; `OnAuthErrorHandlerImpl` still force-refreshes on 401/403; the single explicit retry is retained.
- **Load-balancer bucket failover (#1123, behavioral spec SB-06)** — `RetryOrchestrator` resolves its own `BucketFailoverHandler` independently of core; `BucketFailoverHandlerImpl` still recognizes 403; core's unconditional `onPersistent429` allowance is untouched.
- **Anthropic OAuth, Gemini/Vertex** — all providers are wrapped by `RetryOrchestrator` in `ProviderManager` and use the same classification. Configurations *with* a recovery handler still recover; configurations *without* one now correctly fail fast instead of hanging.

## Scope notes

One non-obvious edit: the single-use private method `shouldBypassRetry` in `RetryOrchestrator.ts` was inlined at its one call site. Adding the `maybeRefreshAuth` guard pushed the file to 804 lines against the repo's `max-lines: 800` eslint rule. This was forced by lint, is semantics-preserving, and was independently confirmed during review (restoring the helper fails `max-lines` at 802).

Findings raised during review and **rejected**, with reasons:

- *"`packages/tools/src/utils/retry.ts` also lists 403 as retryable."* Separate retry implementation serving `direct-web-fetch`, not the chat completion path implicated here. Out of scope without its own reproducer.
- *"Provider bucket failover is unreachable because core `attemptFailover` gates on `onPersistent429`."* Conflates two independent engines — bucket failover is a provider-layer concept core knows nothing about, and the proposed patch would open the core gate with no callback to invoke. Disproved empirically: the genuine-403 failover test exercises the real path and passes.
- *"`attemptFailover`'s `state.attempt--` could loop forever."* Intentional pre-existing fresh-budget-per-bucket behavior; production handlers have finite buckets and eventually return false.
- *"Delete the unreachable `yield` after `throw` in the composed test's fake provider."* Attempted, then reverted — eslint `require-yield` fails without it. The final form keeps a minimal unreachable `yield` with an explanatory comment and drops the separate unused const.

**Deferred** (tracked as out of scope, no reproducer): network-transient classification is evaluated *before* status classification in `isRetryableError`, so a status-bearing error that independently matches a transient signature could still retry. This ordering predates the fix and changing it would affect unrelated network retry behavior.

## Verification

`npm run format`, `npm run typecheck`, `npm run lint`, `npm run build` all pass. Full `npm run test`: 6698 passed, 7 failed. All 9 failing tests (7 vitest + 2 native bun) were confirmed pre-existing by stashing the production changes and re-running — they fail identically without this patch:

- `sandbox-credential.test.ts` (5, platform/container cases, tracked as #1456)
- `bun-launcher.test.ts` (1, parent fd 3 close)
- `permissionsModifyTrustDialog.multiFolder.test.tsx` (1, message mismatch)
- `auth/proxy/__tests__/integration.test.ts` and `e2e-credential-flow.test.ts` (2, real-socket connection-loss tests that time out on this Windows workspace)

Reviewed by an independent compliance review (verdict: approved, no blocker or in-scope findings) and by Open Code Review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP 403 errors are no longer retried automatically, preventing unnecessary repeated requests.
  * Authentication recovery retries now occur only when a recovery or failover handler is configured and attempts remain.
  * Provider failover continues to work for eligible authentication errors, including consecutive 403 responses.
  * Retry behavior now consistently distinguishes terminal errors from retryable 401, 429, and 5xx responses.

* **Tests**
  * Added comprehensive coverage for authentication recovery, failover, retry limits, and persistent provider errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->