### PR TITLE
Publish the todo's real task state on JSP/1 instead of a derived completed boolean (Fixes #3003)

### DIFF
--- a/packages/cli/src/observation/jspBounds.ts
+++ b/packages/cli/src/observation/jspBounds.ts
@@ -17,6 +17,7 @@ export const JSP_BOUNDS = {
   idBytes: 128,
   todoEntries: 256,
   todoTextBytes: 2 * 1024,
+  todoStateBytes: 64,
   displayedContentBytes: 16 * 1024,
   diagnosticSummaryBytes: 2 * 1024,
   toolLabelBytes: 256,

--- a/packages/cli/src/observation/jspDocuments.ts
+++ b/packages/cli/src/observation/jspDocuments.ts
@@ -51,7 +51,16 @@ export type JspTurnOutcome = 'completed' | 'failed' | 'cancelled';
 
 export interface JspTodoItem {
   readonly text: string;
-  readonly completed: boolean;
+  /**
+   * The native task state, published as the source reports it.
+   *
+   * Deliberately a bare string rather than a closed union: the recognized
+   * values are `pending`, `in_progress` and `completed`, but the vocabulary is
+   * open so a consumer reads anything else as neither completed nor active.
+   * Narrowing the type here would force the producer to guess, which is the
+   * defect this field exists to remove.
+   */
+  readonly state: string;
 }
 
 export interface JspTodoList {

--- a/packages/cli/src/observation/jspProducer.test.ts
+++ b/packages/cli/src/observation/jspProducer.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import type { JspBoundDocument } from './jspDocuments.js';
+import type {
+  JspBoundDocument,
+  JspSnapshotDocument,
+  JspTodoItem,
+} from './jspDocuments.js';
 import {
   JspProducer,
   OBSERVER_LEASE_MS,
@@ -72,6 +76,31 @@ function eventTypes(documents: readonly JspBoundDocument[]): string[] {
   return documents.flatMap((document) =>
     document.kind === 'event' ? [document.event.type] : [],
   );
+}
+
+/**
+ * Pull the task-list items out of a published `todos.replaced` event so a test
+ * can assert them exactly. The consumer schema is closed, so an extra member is
+ * rejected at ingress; a partial matcher would let one through.
+ */
+function todoItemsOfEvent(
+  document: JspBoundDocument,
+): readonly JspTodoItem[] | undefined {
+  if (document.kind !== 'event' || document.event.type !== 'todos.replaced') {
+    return undefined;
+  }
+  return document.event.items;
+}
+
+/** The same, for the task list carried on a snapshot. */
+function todoItemsOfSnapshot(
+  snapshot: JspSnapshotDocument,
+): readonly JspTodoItem[] | undefined {
+  const { todos } = snapshot;
+  if (todos === 'unsupported' || todos.availability !== 'known') {
+    return undefined;
+  }
+  return todos.value.items;
 }
 
 describe('heartbeat cadence', () => {
@@ -167,8 +196,80 @@ describe('JspProducer', () => {
       availability: 'known',
       value: {
         revision: 1,
-        items: [{ text: 'after resume', completed: false }],
+        items: [{ text: 'after resume', state: 'in_progress' }],
       },
+    });
+    producer.stop();
+  });
+
+  it('publishes the item the agent is working on as in_progress', async () => {
+    // The active item is the whole point of the field: a derived boolean
+    // collapsed pending and in_progress, so an observer had to guess which
+    // entry was live. Prove the distinction survives the wire on the event
+    // path as well as the snapshot.
+    const { hooks, published } = makeHarness();
+    const producer = new JspProducer(bootstrap, nativeSession, hooks);
+    producer.start();
+    await producer.flush();
+    published.length = 0;
+
+    producer.observeTodosReplaced(undefined, [
+      { content: 'Done already', status: 'completed' },
+      { content: 'Working on it', status: 'in_progress' },
+      { content: 'Not started', status: 'pending' },
+    ]);
+    await producer.flush();
+
+    // The consumer schema is closed, so assert the published items exactly
+    // rather than with a partial match: a surviving `completed` member would
+    // be rejected at ingress and take the whole document with it.
+    expect(published).toHaveLength(1);
+    expect(todoItemsOfEvent(published[0])).toStrictEqual([
+      { text: 'Done already', state: 'completed' },
+      { text: 'Working on it', state: 'in_progress' },
+      { text: 'Not started', state: 'pending' },
+    ]);
+    expect(todoItemsOfSnapshot(producer.snapshot())).toStrictEqual([
+      { text: 'Done already', state: 'completed' },
+      { text: 'Working on it', state: 'in_progress' },
+      { text: 'Not started', state: 'pending' },
+    ]);
+    producer.stop();
+  });
+
+  it('drops a todo replacement it cannot publish faithfully', async () => {
+    // The native status set is a closed enum well inside the bound, so an
+    // over-bound status is an impossible state. Publishing a truncated label
+    // would put a value the source never reported onto the wire, and
+    // publishing the full one would be rejected for the bound and take the
+    // whole document with it, so the replacement is refused outright.
+    const { hooks, published } = makeHarness();
+    const producer = new JspProducer(bootstrap, nativeSession, hooks);
+    producer.start();
+    await producer.flush();
+    published.length = 0;
+
+    expect(() =>
+      producer.observeTodosReplaced(undefined, [
+        { content: 'Runaway', status: 'x'.repeat(65) },
+      ]),
+    ).toThrow(RangeError);
+    await producer.flush();
+
+    expect(published).toStrictEqual([]);
+    expect(producer.snapshot().todos).toMatchObject({
+      availability: 'unknown',
+    });
+
+    // The refused replacement must not consume a revision: a hole in the
+    // sequence is how an observer detects loss.
+    producer.observeTodosReplaced(undefined, [
+      { content: 'Recovered', status: 'pending' },
+    ]);
+    await producer.flush();
+    expect(producer.snapshot().todos).toMatchObject({
+      availability: 'known',
+      value: { revision: 1 },
     });
     producer.stop();
   });
@@ -218,14 +319,10 @@ describe('JspProducer', () => {
 
     await producer.shutdown();
 
-    expect(published.at(-1)).toMatchObject({
+    const terminal = published.at(-1);
+    expect(terminal).toMatchObject({
       kind: 'snapshot',
-      todos: {
-        availability: 'known',
-        value: {
-          items: [{ text: 'Completed task', completed: true }],
-        },
-      },
+      todos: { availability: 'known' },
       last_displayed_assistant_message: {
         availability: 'known',
         value: { content: 'Committed reply' },
@@ -235,6 +332,12 @@ describe('JspProducer', () => {
         value: null,
       },
     });
+    // Assert the task-list items exactly: the consumer schema is closed, so a
+    // surviving `completed` member would fail the whole snapshot at ingress
+    // and a partial match would not notice it.
+    expect(todoItemsOfSnapshot(terminal as JspSnapshotDocument)).toStrictEqual([
+      { text: 'Completed task', state: 'completed' },
+    ]);
   });
 
   it('never blocks or throws when registration and publication fail', () => {

--- a/packages/cli/src/observation/jspProducer.ts
+++ b/packages/cli/src/observation/jspProducer.ts
@@ -472,14 +472,20 @@ export class JspProducer {
     if (scopedAgent !== this.agentId) {
       return;
     }
+    // Project the list before claiming a revision. buildTodoItems rejects a
+    // list it cannot publish faithfully, and consuming a revision number for a
+    // replacement that never reaches the wire would leave a hole in the
+    // sequence an observer uses to detect loss.
+    const items = buildTodoItems(todos, {
+      todoTextBytes: JSP_BOUNDS.todoTextBytes,
+      todoEntries: JSP_BOUNDS.todoEntries,
+      todoStateBytes: JSP_BOUNDS.todoStateBytes,
+    });
     this.todoRevision += 1;
     this.applyAndPublish({
       type: 'todos.replaced',
       revision: this.todoRevision,
-      items: buildTodoItems(todos, {
-        todoTextBytes: JSP_BOUNDS.todoTextBytes,
-        todoEntries: JSP_BOUNDS.todoEntries,
-      }),
+      items,
     });
   }
 

--- a/packages/cli/src/observation/jspProducerState.test.ts
+++ b/packages/cli/src/observation/jspProducerState.test.ts
@@ -164,13 +164,19 @@ describe('todos', () => {
       {
         type: 'todos.replaced',
         revision: 1,
-        items: [{ text: 'Do thing', completed: false }],
+        items: [
+          { text: 'Do thing', state: 'in_progress' },
+          { text: 'Do other thing', state: 'pending' },
+        ],
       },
       () => 200,
     );
     expect(state.todos).toStrictEqual({
       revision: 1,
-      items: [{ text: 'Do thing', completed: false }],
+      items: [
+        { text: 'Do thing', state: 'in_progress' },
+        { text: 'Do other thing', state: 'pending' },
+      ],
     });
   });
 
@@ -187,7 +193,7 @@ describe('todos', () => {
       {
         type: 'todos.replaced',
         revision: 1,
-        items: [{ text: 'old', completed: true }],
+        items: [{ text: 'old', state: 'completed' }],
       },
       () => 300,
     );
@@ -358,7 +364,7 @@ describe('buildSnapshot', () => {
       {
         type: 'todos.replaced',
         revision: 1,
-        items: [{ text: 'x', completed: false }],
+        items: [{ text: 'x', state: 'in_progress' }],
       },
       () => 300,
     );
@@ -376,7 +382,7 @@ describe('buildSnapshot', () => {
     });
     expect(snap.todos).toMatchObject({
       availability: 'known',
-      value: { revision: 1 },
+      value: { revision: 1, items: [{ text: 'x', state: 'in_progress' }] },
     });
     expect(snap.current_turn).toMatchObject({
       availability: 'known',

--- a/packages/cli/src/observation/jspRedaction.test.ts
+++ b/packages/cli/src/observation/jspRedaction.test.ts
@@ -10,6 +10,7 @@ import {
   buildTodoItems,
   NO_CONTENT,
 } from './jspRedaction.js';
+import { JSP_BOUNDS } from './jspBounds.js';
 
 describe('redactAssistantContent', () => {
   it('returns bounded content for normal text', () => {
@@ -56,26 +57,45 @@ describe('redactAssistantContent', () => {
 });
 
 describe('buildTodoItems', () => {
-  it('maps native todos to bounded {text,completed}', () => {
+  const BOUNDS = {
+    todoTextBytes: JSP_BOUNDS.todoTextBytes,
+    todoEntries: JSP_BOUNDS.todoEntries,
+    todoStateBytes: JSP_BOUNDS.todoStateBytes,
+  };
+
+  it('maps native todos to bounded {text,state}', () => {
     const items = buildTodoItems(
       [
         { content: 'Write parser', status: 'completed' },
         { content: 'Add tests', status: 'in_progress' },
+        { content: 'Ship it', status: 'pending' },
       ],
-      { todoTextBytes: 2 * 1024, todoEntries: 256 },
+      BOUNDS,
     );
     expect(items).toStrictEqual([
-      { text: 'Write parser', completed: true },
-      { text: 'Add tests', completed: false },
+      { text: 'Write parser', state: 'completed' },
+      { text: 'Add tests', state: 'in_progress' },
+      { text: 'Ship it', state: 'pending' },
     ]);
+  });
+
+  it('publishes only text and state, never the retired completed flag', () => {
+    // The consumer schema is closed, so a residual member is rejected outright
+    // rather than ignored. Assert on the item's own keys so a leftover cannot
+    // slip past a partial match.
+    const items = buildTodoItems(
+      [{ content: 'Write parser', status: 'completed' }],
+      BOUNDS,
+    );
+    expect(Object.keys(items[0]).sort()).toStrictEqual(['state', 'text']);
   });
 
   it('rejects an over-limit todo text by truncating to byte boundary', () => {
     const long = 'x'.repeat(2 * 1024 + 10);
-    const items = buildTodoItems([{ content: long, status: 'pending' }], {
-      todoTextBytes: 2 * 1024,
-      todoEntries: 256,
-    });
+    const items = buildTodoItems(
+      [{ content: long, status: 'pending' }],
+      BOUNDS,
+    );
     expect(Buffer.byteLength(items[0].text, 'utf8')).toBeLessThanOrEqual(
       2 * 1024,
     );
@@ -86,10 +106,7 @@ describe('buildTodoItems', () => {
       content: `task ${i}`,
       status: 'pending',
     }));
-    const items = buildTodoItems(many, {
-      todoTextBytes: 2 * 1024,
-      todoEntries: 256,
-    });
+    const items = buildTodoItems(many, BOUNDS);
     expect(items.length).toBe(256);
   });
 
@@ -103,15 +120,67 @@ describe('buildTodoItems', () => {
       { content: 'b', status: 'completed' },
     ];
     expect(() =>
-      buildTodoItems(todos, { todoTextBytes: 64, todoEntries: -1 }),
+      buildTodoItems(todos, {
+        todoTextBytes: 64,
+        todoEntries: -1,
+        todoStateBytes: 64,
+      }),
     ).toThrow(RangeError);
   });
 
-  it('publishes an unrecognised native status as not completed', () => {
+  it('publishes an unrecognised native status verbatim', () => {
+    // The vocabulary is open on purpose: the consumer reads an unrecognised
+    // label as neither completed nor active. Coercing it onto a recognised
+    // value here would reintroduce the guess this field exists to remove.
     const items = buildTodoItems([{ content: 'x', status: 'cancelled' }], {
-      todoTextBytes: 64,
+      ...BOUNDS,
       todoEntries: 8,
     });
-    expect(items).toStrictEqual([{ text: 'x', completed: false }]);
+    expect(items).toStrictEqual([{ text: 'x', state: 'cancelled' }]);
+  });
+
+  it('publishes an empty state verbatim rather than substituting one', () => {
+    const items = buildTodoItems([{ content: 'x', status: '' }], BOUNDS);
+    expect(items).toStrictEqual([{ text: 'x', state: '' }]);
+  });
+
+  it('publishes a state of exactly the byte bound unchanged', () => {
+    const at = 's'.repeat(JSP_BOUNDS.todoStateBytes);
+    expect(Buffer.byteLength(at, 'utf8')).toBe(JSP_BOUNDS.todoStateBytes);
+    const items = buildTodoItems([{ content: 'x', status: at }], BOUNDS);
+    expect(items[0].state).toBe(at);
+  });
+
+  it('rejects an over-bound state rather than publishing a truncated label', () => {
+    // A status is an opaque label the consumer compares for equality, so a
+    // truncated one is a value the source never reported. Publishing it would
+    // put a producer invention into the field that exists to stop the producer
+    // guessing, so the projection fails instead.
+    const over = 's'.repeat(JSP_BOUNDS.todoStateBytes + 1);
+    expect(() =>
+      buildTodoItems([{ content: 'x', status: over }], BOUNDS),
+    ).toThrow(/todo state exceeds/);
+  });
+
+  it('measures the state bound in UTF-8 bytes, not UTF-16 code units', () => {
+    // Sixteen astral characters are 32 code units but 64 bytes, so a code-unit
+    // check would accept a status that doubles the published bound.
+    const atBytes = '𝕏'.repeat(JSP_BOUNDS.todoStateBytes / 4);
+    expect(Buffer.byteLength(atBytes, 'utf8')).toBe(JSP_BOUNDS.todoStateBytes);
+    expect(
+      buildTodoItems([{ content: 'x', status: atBytes }], BOUNDS),
+    ).toStrictEqual([{ text: 'x', state: atBytes }]);
+    expect(() =>
+      buildTodoItems([{ content: 'x', status: atBytes + 'a' }], BOUNDS),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects a negative state bound instead of rejecting every status', () => {
+    expect(() =>
+      buildTodoItems([{ content: 'x', status: 'pending' }], {
+        ...BOUNDS,
+        todoStateBytes: -1,
+      }),
+    ).toThrow(RangeError);
   });
 });

--- a/packages/cli/src/observation/jspRedaction.ts
+++ b/packages/cli/src/observation/jspRedaction.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { utf8ByteLength } from './jspBounds.js';
+import { utf8ByteLength, withinByteBound } from './jspBounds.js';
 
 export const NO_CONTENT = '';
 
@@ -58,38 +58,53 @@ function isHighSurrogate(unit: number): boolean {
 interface TodoBounds {
   readonly todoTextBytes: number;
   readonly todoEntries: number;
+  readonly todoStateBytes: number;
 }
 
+/**
+ * Project native todos onto the published `{text, state}` shape.
+ *
+ * The status is published exactly as the native model reports it. A derived
+ * boolean used to collapse `pending` and `in_progress` into the same value, so
+ * the item the agent was actually working on did not survive the wire; the
+ * consumer degrades an unrecognised label to neither completed nor active, and
+ * coercing an unfamiliar status onto a recognised one here would reintroduce
+ * that loss as a guess presented as fact.
+ */
 export function buildTodoItems(
   todos: readonly TodoLike[],
   bounds: TodoBounds,
-): Array<{ text: string; completed: boolean }> {
+): Array<{ text: string; state: string }> {
   if (!Number.isInteger(bounds.todoEntries) || bounds.todoEntries < 0) {
     throw new RangeError('todoEntries must be a non-negative integer');
+  }
+  if (!Number.isInteger(bounds.todoStateBytes) || bounds.todoStateBytes < 0) {
+    throw new RangeError('todoStateBytes must be a non-negative integer');
   }
   const capped = todos.slice(0, bounds.todoEntries);
   return capped.map((todo) => ({
     text: truncateToByteBound(todo.content, bounds.todoTextBytes),
-    completed: mapTodoCompleted(todo.status),
+    state: boundedTodoState(todo.status, bounds.todoStateBytes),
   }));
 }
 
 /**
- * Map a native task status to the published completion flag.
+ * Return the status unchanged, or fail if it does not fit the published bound.
  *
- * The native status set is open, so an unrecognised value is published as not
- * completed rather than guessed at. The known values are listed explicitly so
- * that decision stays visible instead of being implied by a bare equality
- * check against `'completed'`.
+ * Text is truncated because it is free-form content whose tail carries no
+ * contract. A status is the opposite: it is an opaque label the consumer
+ * compares for equality, so a truncated one is a label the source never
+ * reported. Publishing it would put a value the producer invented into the one
+ * field that exists to stop the producer guessing. The native status set is a
+ * closed three-value enum well inside the bound, so an over-bound status is an
+ * impossible state rather than input to accommodate; failing here surfaces that
+ * bug instead of smuggling it onto the wire. The observation boundary isolates
+ * producer failures, so the cost is a dropped telemetry update, never a
+ * disrupted foreground session.
  */
-function mapTodoCompleted(status: string): boolean {
-  switch (status) {
-    case 'completed':
-      return true;
-    case 'pending':
-    case 'in_progress':
-      return false;
-    default:
-      return false;
+function boundedTodoState(status: string, maxBytes: number): string {
+  if (!withinByteBound(status, maxBytes)) {
+    throw new RangeError('todo state exceeds the published byte bound');
   }
+  return status;
 }

--- a/project-plans/issue-3003-jsp-todo-state.md
+++ b/project-plans/issue-3003-jsp-todo-state.md
@@ -1,0 +1,122 @@
+# Issue 3003 — JSP producer publishes the todo's real task state
+
+## Problem
+
+The JSP/1 producer publishes each todo as `{ text, completed: boolean }`.
+`mapTodoCompleted` in `packages/cli/src/observation/jspRedaction.ts` collapses
+the native three-state task model (`pending`, `in_progress`, `completed`) into a
+boolean, so "the item the agent is working on right now" does not survive the
+wire and the consumer can only guess at the active item.
+
+## Accepted behaviour
+
+The amended JSP/1 todo item is `{ "text": "<string>", "state": "<string>" }`.
+`schema` stays `1`; this is a clean break, not a dual carry.
+
+- **AC1 — the wire carries `state`, never `completed`.** Every published todo
+  item on both the snapshot `todos` field and the `todos.replaced` event carries
+  exactly `text` and `state`. The consumer schema is closed
+  (`additionalProperties: false`), so a residual `completed` member would be
+  rejected with JSP-E001.
+- **AC2 — recognized statuses are published verbatim.** `pending`,
+  `in_progress` and `completed` appear on the wire as themselves.
+- **AC3 — the vocabulary is open and unrecognized statuses are not coerced.** A
+  native status outside the recognized set is published verbatim. It is never
+  mapped onto one of the three, because the consumer already degrades an
+  unrecognized label to "not completed and not active", and coercing here would
+  reintroduce exactly the loss this issue removes.
+- **AC4 — `state` is bounded at 64 UTF-8 bytes, inclusive.** A status of exactly
+  64 bytes is published unchanged. An over-bound status is refused: the
+  projection throws and no todo replacement reaches the wire. Truncation is
+  explicitly rejected as the producer behaviour. Text is truncated because it is
+  free-form content whose tail carries no contract, but a status is an opaque
+  label the consumer compares for equality, so a truncated one is a label the
+  source never reported — a producer invention in the one field that exists to
+  stop the producer guessing, which is AC3's violation by another route.
+  Publishing the over-bound value instead is worse still: the consumer rejects
+  the whole document with JSP-E002, which the producer classifies as terminal
+  and stops. The native status set is a closed three-value enum well inside the
+  bound, so this branch is an impossible state rather than input to accommodate,
+  and failing surfaces the bug. The observation boundary (`isolate` in
+  `jspWiring.ts`) already contains producer failures, so the cost is a dropped
+  telemetry update and never a disrupted foreground session. The refused
+  replacement must not consume a todo revision, because a hole in the revision
+  sequence is how an observer detects loss.
+- **AC5 — `mapTodoCompleted` is retired,** not adapted.
+- **AC6 — no other bound behaviour changes.** Todo text truncation, the entry
+  cap, and the `RangeError` on a negative byte bound or negative entry cap keep
+  their current behaviour.
+
+## Inputs and boundary cases
+
+| Input status                          | Published `state`                       |
+| ------------------------------------- | --------------------------------------- |
+| `pending`                             | `pending`                               |
+| `in_progress`                         | `in_progress`                           |
+| `completed`                           | `completed`                             |
+| `cancelled` (unrecognized)            | `cancelled`                             |
+| empty string                          | empty string, verbatim                  |
+| 64-byte label                         | unchanged                               |
+| 16 astral characters (64 bytes)       | unchanged — the bound is bytes, not     |
+|                                       | UTF-16 code units                       |
+| 65-byte label                         | `RangeError`; nothing published         |
+| 65-byte multibyte label               | `RangeError`; nothing published         |
+| negative `todoStateBytes` (misuse)    | `RangeError`                            |
+
+## Tests that prove it
+
+All behavioural, against real producer code, no mock theater.
+
+`packages/cli/src/observation/jspRedaction.test.ts`
+
+1. `buildTodoItems` maps native todos to bounded `{text, state}` and preserves
+   `in_progress` distinctly from `pending` and `completed` (AC1, AC2).
+2. No published item carries a `completed` key (AC1) — asserted on the item's
+   own keys, so a leftover member cannot slip through a `toMatchObject`.
+3. An unrecognized status is published verbatim rather than coerced (AC3).
+4. An empty status is published verbatim rather than substituted (AC3).
+5. A 64-byte status is published unchanged (AC4 boundary, inclusive).
+6. A 65-byte status throws, so no invented label can reach the wire (AC4). The
+   assertion is on the thrown error, not on a truncated value, so an
+   implementation that silently returned a shortened label would fail.
+7. The bound is measured in UTF-8 bytes, not UTF-16 code units: 16 astral
+   characters are 64 bytes and publish unchanged, and one more byte throws
+   (AC4).
+8. A negative `todoStateBytes` throws as a misuse of the bound rather than
+   rejecting every status as over-bound (AC6 symmetry with `todoEntries`).
+9. Existing text-bound, entry-cap and `RangeError` tests keep passing (AC6).
+
+`packages/cli/src/observation/jspProducer.test.ts`
+
+10. A `todos.replaced` event published for a mixed list carries
+    `state: 'in_progress'` on the active item, proving the active item survives
+    the wire. The event items and the snapshot items are both asserted with
+    `toStrictEqual`, which is what proves AC1's negative half: a partial matcher
+    would let a surviving `completed` member through, and the consumer schema is
+    closed so such a member fails the whole document at ingress.
+11. The terminal snapshot published at shutdown carries exactly
+    `[{ text: 'Completed task', state: 'completed' }]` (AC1 end to end).
+12. A replacement carrying an over-bound status publishes nothing at all, leaves
+    the snapshot's todos unknown, and does not consume a revision — the next
+    good replacement is still revision 1 (AC4).
+
+`packages/cli/src/observation/jspProducerState.test.ts`
+
+13. `todos.replaced` state transitions and `buildSnapshot` carry `state` through
+    unchanged, including `in_progress` alongside `pending` (AC1 on the snapshot
+    path).
+
+## Scope
+
+In scope: `jspRedaction.ts`, `jspDocuments.ts`, the `todoStateBytes` bound in
+`jspBounds.ts`, the `buildTodoItems` call site in `jspProducer.ts`, and the
+producer tests that assert the boolean.
+
+Out of scope: any change to the todo payload beyond task state, the consumer
+half (tracked as vybestack/llxprt-jefe#625), and unrelated observation cleanup.
+
+## Coordination
+
+The two halves must land together. A producer still sending `completed` is
+rejected at ingress by the amended consumer, and a producer sending `state` is
+rejected by the unamended one.


### PR DESCRIPTION
## TLDR

JSP/1 published each todo as `{ text, completed: boolean }`. The native LLxprt task model has three states, and `mapTodoCompleted` collapsed `pending` and `in_progress` into the same `false`, so "the item the agent is working on right now" did not survive the wire. Jefe could render a flat checklist or derive an active item, and deriving it violates the field-state contract the rest of the protocol honours: state is authoritative or explicitly unknown, never quietly assumed.

The wire item is now `{ text, state }`, with the status published exactly as the native model reports it. `mapTodoCompleted` is deleted rather than adapted.

**The one thing to look at closely** is the 64-byte bound, which refuses an over-bound status rather than truncating it. The obvious move is to truncate the way todo text already is, and that is deliberately not what happens here. Reasoning in Dive Deeper.

This half is useless alone — it must land with vybestack/llxprt-jefe#625.

## Dive Deeper

### Coordination

The envelope `schema` stays `1`. This is a clean break rather than a dual carry or a version bump, which is what shipping both halves together makes affordable. A producer still sending `completed` is rejected closed at ingress with JSP-E001, and a producer sending `state` is rejected by the unamended consumer, so neither half is useful on its own.

### `state` is a bare `string`, not a union

The vocabulary is deliberately open: the consumer reads an unrecognized label as neither completed nor active. Narrowing the type here would force the producer to guess, which is the defect the field exists to remove. An unrecognized native status is published verbatim.

### Why the bound fails instead of truncating

Text is truncated because it is free-form content whose tail carries no contract. A status is the opposite — an opaque label the consumer compares for equality — so a truncated one is a label the source never reported. That is a producer invention in the one field meant to stop the producer guessing, which is the same defect by another route.

Publishing the full over-bound value instead is worse: the consumer fails it with JSP-E002, which `classifyPostResult` treats as terminal, so a single long label would stop telemetry for the rest of the session.

`Todo.status` is a closed three-value zod enum (`packages/tools/src/types/todo-schemas.ts`) well inside the bound, so this branch is an impossible state rather than input to accommodate. Failing surfaces the bug instead of smuggling it onto the wire, and `isolate()` in `jspWiring.ts` already contains producer failures, so the cost is a dropped telemetry update and never a disrupted foreground session.

### Revision ordering

`observeTodosReplaced` now projects the list before claiming a revision. A revision consumed by a replacement that never reaches the wire would leave a hole in the sequence an observer uses to detect loss.

### Files

- `jspRedaction.ts` — `buildTodoItems` emits `state`; `mapTodoCompleted` retired; new `boundedTodoState` enforces the bound by failing.
- `jspDocuments.ts` — `JspTodoItem` is `{ text, state }`. This single type feeds both the snapshot `todos` field and the `todos.replaced` event payload, so both paths change together.
- `jspBounds.ts` — adds `todoStateBytes: 64`.
- `jspProducer.ts` — passes the new bound and reorders the revision increment.
- The three producer test files that asserted the boolean.

### On the tests

They are behavioral, against the real producer, state machine and queue; only the clock and transport are substituted.

The published items are asserted with `toStrictEqual` on **both** the `todos.replaced` event and the terminal snapshot, not with a partial matcher. That is what proves the negative half of the contract: the consumer schema is closed, so a surviving `completed` member fails the whole document, and `toMatchObject` would let one through.

The boundary tests are written so a weaker implementation fails rather than passes:

- the over-bound case asserts the throw, so an implementation that silently returned a shortened label fails;
- the bound is proven to be measured in UTF-8 bytes rather than UTF-16 code units by publishing 16 astral characters (64 bytes, 32 code units) unchanged and rejecting one byte more;
- an empty status and an unrecognized status are each proven verbatim rather than substituted;
- a refused replacement is proven to publish nothing, leave the snapshot's todos unknown, and not consume a revision — the next good replacement is still revision 1.

No lint rule was loosened and no suppression directive was added. A `sonarjs/todo-tag` error on new comments was fixed by rewording to the codebase's existing "task list" phrasing rather than by disabling the rule.

## Reviewer Test Plan

The change is on a telemetry path with no user-visible surface in this repository, so the meaningful validation is the test suite plus the paired consumer.

Run the producer suite directly:

    cd packages/cli && bun test src/observation/

Then confirm the tests are not vacuous, which is the part worth a reviewer's attention:

1. In `jspRedaction.ts`, change `boundedTodoState` to `return truncateToByteBound(status, maxBytes)`. The over-bound test must fail — it asserts the throw, not a shortened value.
2. Add `completed: false` to the object literal in `buildTodoItems`. The `toStrictEqual` assertions on the event and on the terminal snapshot must both fail; this is the negative half of the contract, and it is why those assertions are not `toMatchObject`.
3. Change `withinByteBound` to compare `status.length` instead of UTF-8 bytes. The astral test must fail — 16 astral characters are 64 bytes but only 32 code units.

End-to-end validation requires the consumer half (vybestack/llxprt-jefe#625). With both applied, a Jefe pane should show the in-progress item as active rather than as one more unchecked box. Without the consumer half applied, this producer is expected to be rejected at ingress; that is the coordination constraint, not a regression.

## Testing Matrix

Verified locally on macOS (`npm run test`, `lint`, `typecheck`, `format`, `build`, and the `stepfun-37` smoke test). Linux and Windows coverage is via CI, which is green on this head including E2E on Linux (sandbox:none and sandbox:docker) and macOS.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3003

Consumer half: vybestack/llxprt-jefe#625. The two must land together.
