### PR TITLE
Harden sandbox container privileges (Fixes #2902)

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -71,10 +71,75 @@ llxprt --sandbox-engine podman "review this code"
   opt-in or design choices.
 - Network exfiltration of data that networking is left enabled for. If
   `network` is `on`, outbound network access is available to tool execution.
+- Reading the sandboxed CLI process's own memory. The credential never enters
+  the sandbox's filesystem, environment, or argv, but it does enter the sandbox
+  CLI process's address space whenever a provider call is made. Whether a
+  same-UID in-container process can read that memory is **conditional on the
+  host kernel's Yama `ptrace_scope` setting**: on a permissive host (scope 0,
+  or no Yama — notably Docker Desktop for macOS) a descendant process can read
+  the CLI's `/proc/<pid>/mem`; on a host with `ptrace_scope >= 1` (the Ubuntu
+  default) that read is denied. The container flags below cannot change this.
+  See
+  [Credential residency and process memory](#credential-residency-and-process-memory).
 
 The sandbox raises the bar for accidental damage and limits the blast radius of
 LLM-generated commands. It is a containment control, not a full security
 isolation boundary.
+
+## Credential residency and process memory
+
+The credential proxy keeps your stored secrets on the host. To be precise about
+what that does and does not guarantee:
+
+**Where the credential does not go:**
+
+- It is never written to the container's filesystem.
+- It is never placed in the container's environment or argv.
+- It is only returned over the proxy socket to a caller that presents the
+  per-session capability token; it is not broadcast or forwarded to arbitrary
+  network peers.
+
+**Where the credential does go:** the sandbox CLI process's own address space,
+whenever it must make a provider call. Resolving a named key through the proxy
+returns the raw key into that same address space so the CLI can authenticate.
+This is unavoidable: the CLI needs the credential to call the provider.
+
+**The consequence.** Anything that can read the CLI process's memory can read
+both the capability token and the credential. The agent's shell commands are
+**descendants** of the token-holding CLI process, so they are trying to read an
+**ancestor**. Whether that succeeds is **conditional on the host kernel's Yama
+`ptrace_scope`**, because the container shares the host (or VM) kernel:
+
+- On a host with `kernel.yama.ptrace_scope >= 1` (the default on Ubuntu and many
+  distributions), the kernel **denies** the read (`EACCES`).
+- On a host with `ptrace_scope == 0`, or where the Yama LSM is absent — notably
+  **Docker Desktop for macOS**, whose VM kernel reports no `ptrace_scope` at all
+  — a descendant process can read the ancestor CLI's `/proc/<pid>/mem` and
+  recover the secret.
+
+This was confirmed empirically (see issue
+[#2902](https://github.com/vybestack/llxprt-code/issues/2902)): under
+`ptrace_scope == 0` (Podman machine VM) and on Docker Desktop (no Yama), a
+descendant of the token-holding CLI process recovered the secret from the CLI's
+heap under every combination of `--cap-drop=ALL`, `--security-opt
+no-new-privileges`, and `--user root` versus non-root; with the Podman machine VM
+set to `ptrace_scope == 1`, the same probe was denied. None of the container
+invocation flags can change this: reading `/proc/<pid>/mem` is an `open()` plus
+`pread()`, not the `ptrace` syscall, so `--cap-drop=ALL` is irrelevant and a
+seccomp filter on `ptrace` is ineffective (filtering `open`/`pread` by path is
+not possible with classic seccomp). The deciding factor is the host's Yama
+setting.
+
+The capability token remains a meaningful secret in its own right: it persists
+for the session and can fetch a credential from the proxy at a time when no
+credential is yet resident in memory. Once a credential is resident, however,
+both live in the same address space.
+
+The sandbox therefore defends against a prompt-injected agent that reads files,
+inspects the environment, scans argv, or speaks the proxy protocol. On a
+permissive Yama host it does not defend against one that reads the CLI process's
+memory; on a host with Yama `ptrace_scope >= 1` that descendant-reads-ancestor
+vector is blocked by the kernel.
 
 ## Using GitHub from a Sandbox
 
@@ -209,6 +274,53 @@ consume your machine's resources.
 
 Container mode runs in a separate process namespace. Seatbelt runs directly on
 your host with macOS kernel restrictions applied via `sandbox-exec`.
+
+### Privilege hardening (container mode)
+
+Every Docker and Podman sandbox run is started with two privilege-hardening
+flags by default:
+
+- **`--cap-drop=ALL`** — drops every Linux capability, so the sandboxed process
+  starts with an empty capability set. It cannot perform privileged operations
+  such as `mount`, changing network configuration, or overriding file
+  permissions. (Whether binding to privileged ports requires a capability is
+  kernel/sysctl dependent: modern Docker sets
+  `net.ipv4.ip_unprivileged_port_start=0` in containers, so a non-root process
+  can bind low ports even with no capabilities. `--publish` port forwarding is
+  handled by the runtime and is unaffected.)
+- **`--security-opt no-new-privileges`** — forbids the process from gaining new
+  privileges. Setuid-root binaries the image ships (such as `su`, `mount`, and
+  `passwd`) execute **without** their setuid effect, so an agent command cannot
+  escalate to root through them. This was verified against a real setuid-root
+  binary inside the sandbox image: under these flags the effective uid stays the
+  caller's, whereas without `no-new-privileges` it becomes 0.
+
+These defaults are applied **before** any `SANDBOX_FLAGS`, so `SANDBOX_FLAGS`
+can still extend or override them (see
+[Extra container flags](#extra-container-flags)). Note that adding a capability
+back with `--cap-add` only widens the bounding set; whether the final process
+actually holds it depends on the runtime and path.
+
+#### Current-user path capability add-backs
+
+On Linux distributions where the container is mapped to your host UID/GID
+(Debian/Ubuntu by default, or any host with `SANDBOX_SET_UID_GID=true`), the
+sandbox starts as root, creates a matching user with `groupadd`/`useradd`, and
+then drops to your UID/GID via `su`. That setup needs a small, fixed set of
+capabilities, so exactly these three are added back on this path — and no others
+(proven by leave-one-out testing; `DAC_OVERRIDE` and `FOWNER` are not required):
+
+- `CHOWN` — `groupadd`/`useradd` write to `/etc/gshadow` and `/etc/shadow`.
+- `SETUID`, `SETGID` — create the matching UID/GID and let `su` drop to them.
+
+`--security-opt no-new-privileges` does not interfere with this path: `su` is
+invoked by root (already uid 0), so no setuid escalation is required. The three
+capabilities are the verified minimum; removing any one of them makes
+`groupadd`/`useradd` fail to write the shadow files or `su` unable to
+authenticate.
+
+These capability flags do **not** change the memory-read boundary above: reading
+`/proc/<pid>/mem` of a same-UID process requires no capability.
 
 ## Per-engine limitations
 
@@ -665,6 +777,27 @@ Pass additional flags to the container runtime:
 ```bash
 export SANDBOX_FLAGS="--security-opt label=disable"
 ```
+
+`SANDBOX_FLAGS` are applied **after** the default hardening flags
+(`--cap-drop=ALL` and `--security-opt no-new-privileges`) and survive into the
+container argv, so they can extend or override the defaults:
+
+```bash
+# Applied after --cap-drop=ALL, so it appears later in the argv
+export SANDBOX_FLAGS="--cap-add=NET_ADMIN"
+```
+
+> **Warning — `--cap-add` only widens the bounding set.** On Docker the image's
+> non-root user receives an added capability only in the **bounding** set (the
+> permitted/effective/ambient sets stay empty), and on the current-user path
+> `su` clears effective/permitted/ambient capabilities on both runtimes. So
+> `--cap-add` alone does **not** guarantee the final process actually holds the
+> capability — that depends on the runtime and on whether the current-user `su`
+> path is in use. The defaults drop all capabilities on purpose; only widen them
+> when you understand the exposure, and remove `SANDBOX_FLAGS` afterward so the
+> hardened default is restored. If a workflow genuinely needs elevated
+> privileges, `--security-opt no-new-privileges=false` and `--privileged` exist
+> as explicit, security-reducing escape hatches.
 
 > **Warning — `label=disable` turns off SELinux labelling.** The flag
 > `--security-opt label=disable` removes the SELinux process label (MCS/MLS

--- a/integration-tests/sandboxPrivilege.real.test.ts
+++ b/integration-tests/sandboxPrivilege.real.test.ts
@@ -1,0 +1,350 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Real-container behavioral test for sandbox privilege hardening (#2902).
+ *
+ * This test obtains the container arguments FROM THE PRODUCTION FUNCTIONS
+ * (`buildContainerRunArgs` and `setupContainerUser` in
+ * packages/cli/src/utils/sandbox-containers.ts), filters them down to the
+ * security-relevant flags, and launches a REAL Docker/Podman container using
+ * those production-derived flags. It then asserts on OBSERVED KERNEL STATE
+ * read from inside the container (/proc/self/status) — never on argv strings.
+ *
+ * The expected kernel-state values are INDEPENDENT LITERALS, not computed from
+ * the production constants, so deleting the production hardening makes this
+ * test FAIL (verified — see the falsifiability note in the plan). Both this
+ * test and the unit test are independently falsifiable.
+ *
+ * Gating:
+ *   - RUNS whenever a container runtime is usable and the sandbox image is
+ *     present locally; SKIPS only when they genuinely are not. No CI opt-in.
+ *   - Runtime selection honors `LLXPRT_SANDBOX=docker|podman` (set by the npm
+ *     scripts) and `LLXPRT_SANDBOX_TEST_RUNTIME=<runtime>` (explicit override),
+ *     so the nominal podman suite tests podman rather than silently testing
+ *     docker.
+ *   - Override the image with `LLXPRT_SANDBOX_TEST_IMAGE=<ref>`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  buildContainerRunArgs,
+  setupContainerUser,
+} from '../packages/cli/src/utils/sandbox-containers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Bounded per-run timeout so a hung runtime fails the test, not the suite.
+const RUN_TIMEOUT_MS = 90_000;
+
+// --- runtime + image resolution --------------------------------------------
+
+function resolveSandboxImage(): string {
+  if (process.env.LLXPRT_SANDBOX_TEST_IMAGE !== undefined) {
+    return process.env.LLXPRT_SANDBOX_TEST_IMAGE;
+  }
+  // Resolve the tag the same way the product does: the config.sandboxImageUri
+  // field of packages/cli/package.json.
+  try {
+    const pkgPath = join(__dirname, '..', 'packages', 'cli', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+      config?: { sandboxImageUri?: string };
+    };
+    if (pkg.config?.sandboxImageUri !== undefined) {
+      return pkg.config.sandboxImageUri;
+    }
+  } catch {
+    // fall through to the pinned default
+  }
+  return 'ghcr.io/vybestack/llxprt-code/sandbox:0.11.0';
+}
+
+function commandWorks(cmd: string): boolean {
+  try {
+    execFileSync(cmd, ['--version'], {
+      stdio: 'ignore',
+      timeout: 10_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runtimeUsable(cmd: string): boolean {
+  try {
+    execFileSync(cmd, ['info'], { stdio: 'ignore', timeout: 20_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function imagePresent(cmd: string, image: string): boolean {
+  try {
+    const out = execFileSync(cmd, ['images', '-q', image], {
+      timeout: 20_000,
+    })
+      .toString()
+      .trim();
+    return out !== '';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Selects the runtime: an explicit test override
+ * (LLXPRT_SANDBOX_TEST_RUNTIME) wins, then LLXPRT_SANDBOX when it is docker or
+ * podman (set by the npm scripts), then auto-detection. Honoring
+ * LLXPRT_SANDBOX prevents the nominal podman suite from silently testing
+ * docker.
+ */
+function detectRuntime(): string | undefined {
+  const sandboxPref =
+    process.env.LLXPRT_SANDBOX === 'docker' ||
+    process.env.LLXPRT_SANDBOX === 'podman'
+      ? process.env.LLXPRT_SANDBOX
+      : undefined;
+  const requested = process.env.LLXPRT_SANDBOX_TEST_RUNTIME ?? sandboxPref;
+  if (requested !== undefined) {
+    return commandWorks(requested) && runtimeUsable(requested)
+      ? requested
+      : undefined;
+  }
+  for (const cmd of ['docker', 'podman']) {
+    if (commandWorks(cmd) && runtimeUsable(cmd)) {
+      return cmd;
+    }
+  }
+  return undefined;
+}
+
+// --- production-derived flag extraction -------------------------------------
+
+/**
+ * Keeps only the security-relevant flags from a production argv: capability
+ * drops/adds, --security-opt, and --user. The SOURCE is always the production
+ * function output; the kernel-state assertions below are independent literals.
+ */
+function extractSecurityFlags(args: readonly string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith('--cap-drop=') || a.startsWith('--cap-add=')) {
+      out.push(a);
+    } else if (a === '--security-opt' || a === '--user') {
+      out.push(a, args[i + 1] ?? '');
+      i += 1;
+    }
+  }
+  return out;
+}
+
+// --- container execution + parsing helpers ---------------------------------
+
+function runInContainer(
+  runtime: string,
+  image: string,
+  flagArgs: readonly string[],
+  innerCommand: string,
+): string {
+  return execFileSync(
+    runtime,
+    ['run', '--rm', ...flagArgs, image, 'bash', '-lc', innerCommand],
+    { timeout: RUN_TIMEOUT_MS, maxBuffer: 10 * 1024 * 1024 },
+  ).toString();
+}
+
+/** Extracts a single-valued /proc/self/status field (e.g. NoNewPrivs). */
+function statusField(output: string, name: string): string {
+  const match = output.match(new RegExp(`^${name}:\\s+(\\S+)`, 'm'));
+  if (match === null) {
+    throw new Error(`${name} not found in container output:\n${output}`);
+  }
+  return match[1];
+}
+
+/** Parses the four Uid values (real effective saved fsuid) from a status dump. */
+function parseUidLine(uidLine: string): {
+  real: number;
+  effective: number;
+} {
+  const tokens = uidLine.split(/\s+/);
+  const real = Number.parseInt(tokens[1] ?? '', 10);
+  const effective = Number.parseInt(tokens[2] ?? '', 10);
+  if (Number.isNaN(real) || Number.isNaN(effective)) {
+    throw new Error(`Failed to parse Uid line: ${uidLine}`);
+  }
+  return { real, effective };
+}
+
+const SETUP_USER_CMD = [
+  'groupadd -f -g 12345 gemini',
+  'id -u gemini >/dev/null 2>&1 || useradd -o -u 12345 -g 12345 -d /home/node -s /bin/bash gemini',
+  'echo SU_CHECK=$(su -p gemini -c "id -u")',
+].join('; ');
+
+// --- gating -----------------------------------------------------------------
+
+const runtime = detectRuntime();
+const image = resolveSandboxImage();
+const skipTests = runtime === undefined || !imagePresent(runtime, image);
+
+describe.skipIf(skipTests)(
+  'Sandbox privilege hardening (real container) #2902',
+  () => {
+    const savedSandboxFlags = process.env.SANDBOX_FLAGS;
+    const savedSetUidGid = process.env.SANDBOX_SET_UID_GID;
+    let fixtureWorkdir = '';
+
+    beforeAll(() => {
+      // Ensure the production argv is the clean default (no stray SANDBOX_FLAGS
+      // or SANDBOX_SET_UID_GID from the test runner leaking into flag extraction).
+      delete process.env.SANDBOX_FLAGS;
+      delete process.env.SANDBOX_SET_UID_GID;
+      fixtureWorkdir = mkdtempSync(join(tmpdir(), 'sandbox2902-real-'));
+    });
+
+    afterAll(() => {
+      if (savedSandboxFlags !== undefined) {
+        process.env.SANDBOX_FLAGS = savedSandboxFlags;
+      } else {
+        delete process.env.SANDBOX_FLAGS;
+      }
+      if (savedSetUidGid !== undefined) {
+        process.env.SANDBOX_SET_UID_GID = savedSetUidGid;
+      } else {
+        delete process.env.SANDBOX_SET_UID_GID;
+      }
+      if (fixtureWorkdir !== '') {
+        rmSync(fixtureWorkdir, { recursive: true, force: true });
+      }
+    });
+
+    /** Security flags from the production default-path argv builder. */
+    function defaultPathFlags(): string[] {
+      const args = buildContainerRunArgs(
+        { command: 'docker', image },
+        image,
+        fixtureWorkdir,
+        '/workspace',
+        fixtureWorkdir,
+      );
+      return extractSecurityFlags(args);
+    }
+
+    /** Security flags from the production current-user path (build + setup). */
+    async function currentUserFlags(): Promise<string[]> {
+      const args = buildContainerRunArgs(
+        { command: 'docker', image },
+        image,
+        fixtureWorkdir,
+        '/workspace',
+        fixtureWorkdir,
+      );
+      process.env.SANDBOX_SET_UID_GID = 'true';
+      try {
+        // setupContainerUser pushes --user root and the capability add-backs;
+        // its entrypoint rewrite is irrelevant here (we only read argv flags).
+        await setupContainerUser(args, ['true']);
+      } finally {
+        delete process.env.SANDBOX_SET_UID_GID;
+      }
+      return extractSecurityFlags(args);
+    }
+
+    it('default path forbids new privileges and holds no capabilities (AC1, AC2, AC6)', () => {
+      // The default (non-current-user) path adds no --user, so the container
+      // runs as the image's default user (node, uid 1000) under cap-drop=ALL
+      // and no-new-privileges.
+      const out = runInContainer(
+        runtime!,
+        image,
+        defaultPathFlags(),
+        [
+          'grep -E "^(NoNewPrivs|CapBnd|CapEff):" /proc/self/status',
+          'echo ME_UID=$(id -u)',
+        ].join('; '),
+      );
+
+      // Independent literals: a missing hardening flag makes these fail.
+      expect(statusField(out, 'NoNewPrivs')).toBe('1');
+      expect(statusField(out, 'CapBnd')).toBe('0000000000000000');
+      expect(statusField(out, 'CapEff')).toBe('0000000000000000');
+      // The default process is non-root.
+      expect(out).toMatch(/ME_UID=1000\b/);
+    });
+
+    it('current-user path yields exactly the three minimal capabilities and groupadd/useradd/su succeed (AC3)', async () => {
+      const out = runInContainer(
+        runtime!,
+        image,
+        await currentUserFlags(),
+        [
+          'echo ROOT_CAPBND=$(grep "^CapBnd:" /proc/self/status | cut -f2)',
+          'echo ROOT_NNPRIVS=$(grep "^NoNewPrivs:" /proc/self/status | cut -f2)',
+          SETUP_USER_CMD,
+        ].join('; '),
+      );
+
+      // CapBnd 0xc1 == CHOWN(bit0) | SETGID(bit6) | SETUID(bit7) — exactly the
+      // three minimal capabilities. Independent literal, not derived.
+      expect(out).toMatch(/ROOT_CAPBND=00000000000000c1\b/);
+      // no-new-privileges is still in force on the current-user path.
+      expect(out).toMatch(/ROOT_NNPRIVS=1\b/);
+      // groupadd/useradd/su all succeeded: su dropped to uid 12345.
+      expect(out).toMatch(/SU_CHECK=12345\b/);
+    });
+
+    it.each(['CHOWN', 'SETUID', 'SETGID'])(
+      'current-user setup FAILS when %s is removed (AC3 leave-one-out minimum)',
+      async (cap) => {
+        // Start from the production current-user flags (source = production),
+        // then remove exactly one capability and prove the setup breaks.
+        const flags = (await currentUserFlags()).filter(
+          (f) => f !== `--cap-add=${cap}`,
+        );
+        const out = runInContainer(runtime!, image, flags, SETUP_USER_CMD);
+
+        // If the capability were not necessary, su would still reach uid 12345.
+        expect(out).not.toMatch(/SU_CHECK=12345\b/);
+      },
+    );
+
+    it('a non-root process cannot escalate through a setuid-root binary (AC6)', async () => {
+      // Starts as root (current-user caps) so it can create a setuid-root
+      // binary, then drops to the non-root `node` user and execs it. With
+      // no-new-privileges the kernel ignores the setuid bit, so the exec'd
+      // process keeps effective uid 1000. Falsifiable: without
+      // --security-opt no-new-privileges the same binary yields effective uid 0.
+      const out = runInContainer(
+        runtime!,
+        image,
+        await currentUserFlags(),
+        [
+          'cp /bin/cat /tmp/rootcat',
+          'chmod 4755 /tmp/rootcat',
+          'echo NODE_UID=$(su -s /bin/bash node -c "id -u")',
+          'echo ESCAL_UID_LINE=$(su -s /bin/bash node -c "/tmp/rootcat /proc/self/status" | grep "^Uid:")',
+        ].join('; '),
+      );
+
+      expect(out).toMatch(/NODE_UID=1000\b/);
+      const uidLineMatch = out.match(/ESCAL_UID_LINE=Uid:\s+(.*)/);
+      expect(uidLineMatch).not.toBeNull();
+      const { real, effective } = parseUidLine(`Uid: ${uidLineMatch![1]}`);
+      expect(real).toBe(1000);
+      // The setuid bit must NOT have elevated the effective uid.
+      expect(effective).toBe(1000);
+    });
+  },
+);

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -507,4 +507,31 @@ describe.sequential('#2902 sandbox privilege hardening', () => {
     expect(secIdx).toBeGreaterThanOrEqual(0);
     expect(proxyArgs[secIdx + 1]).toBe('no-new-privileges');
   });
+
+  it('keeps the base hardening flags alongside a non-empty userFlag on the proxy sidecar', async () => {
+    // The proxy sidecar has always forwarded setupContainerUser's userFlag
+    // (unchanged by this PR). Assert that the hardening flags coexist with it
+    // and that the user selection is still passed through intact.
+    vi.mocked(childProcess.spawn).mockImplementation(() => {
+      throw new Error('proxy-argv-captured');
+    });
+
+    await expect(
+      startProxyContainer(
+        CONFIG,
+        'echo proxy',
+        '--user 501:20',
+        'test-image',
+        '/workspace',
+      ),
+    ).rejects.toThrow('proxy-argv-captured');
+
+    const proxyArgs = vi.mocked(childProcess.spawn).mock.calls[0][1];
+    expect(proxyArgs).toContain('--cap-drop=ALL');
+    const secIdx = proxyArgs.indexOf('--security-opt');
+    expect(proxyArgs[secIdx + 1]).toBe('no-new-privileges');
+    const userIdx = proxyArgs.indexOf('--user');
+    expect(userIdx).toBeGreaterThanOrEqual(0);
+    expect(proxyArgs[userIdx + 1]).toBe('501:20');
+  });
 });

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -13,6 +13,8 @@ import { DebugLogger, FatalSandboxError } from '@vybestack/llxprt-code-core';
 import {
   buildContainerRunArgs,
   setupContainerNetworking,
+  setupContainerUser,
+  startProxyContainer,
   addContainerEnvVars,
   addContainerVolumeMounts,
 } from './sandbox-containers.js';
@@ -389,5 +391,120 @@ describe.sequential('#2946 container credential isolation', () => {
 
     expect(args).toContain('--volume');
     expect(args).toContain(`${tmpDir}:${tmpDir}:ro`);
+  });
+});
+
+const HARDENING_ENV_KEYS = [
+  'SANDBOX_FLAGS',
+  'SANDBOX_SET_UID_GID',
+  'LLXPRT_CODE_INTEGRATION_TEST',
+] as const;
+
+describe.sequential('#2902 sandbox privilege hardening', () => {
+  let environmentSnapshot: NodeJS.ProcessEnv;
+  let fixturePath = '';
+
+  beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), 'container-2902-'));
+    vi.resetAllMocks();
+    // current-user path calls `id -u` / `id -g` via execSync; stub to empty
+    // so the path completes without a real shell. The cap-add values under
+    // test do not depend on uid/gid.
+    vi.mocked(childProcess.execSync).mockReturnValue(Buffer.from(''));
+    for (const key of HARDENING_ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    process.env = environmentSnapshot;
+    vi.restoreAllMocks();
+    if (fixturePath !== '') {
+      fs.rmSync(fixturePath, { recursive: true, force: true });
+    }
+  });
+
+  it('emits --security-opt no-new-privileges on every container run (AC1)', () => {
+    const args = buildArgs(fixturePath);
+
+    const secIdx = args.indexOf('--security-opt');
+    expect(secIdx).toBeGreaterThanOrEqual(0);
+    expect(args[secIdx + 1]).toBe('no-new-privileges');
+  });
+
+  it('emits --cap-drop=ALL on every container run (AC2)', () => {
+    const args = buildArgs(fixturePath);
+
+    expect(args).toContain('--cap-drop=ALL');
+  });
+
+  it('places --cap-drop=ALL before SANDBOX_FLAGS so a user can add caps back (AC7)', () => {
+    process.env.SANDBOX_FLAGS = '--cap-add=NET_ADMIN';
+
+    const args = buildArgs(fixturePath);
+
+    const capDropIdx = args.indexOf('--cap-drop=ALL');
+    const netAdminIdx = args.indexOf('--cap-add=NET_ADMIN');
+    expect(capDropIdx).toBeGreaterThanOrEqual(0);
+    expect(netAdminIdx).toBeGreaterThan(capDropIdx);
+  });
+
+  it('adds back exactly the three minimal current-user capabilities and nothing more (AC3)', async () => {
+    process.env.SANDBOX_SET_UID_GID = 'true';
+
+    const args = buildArgs(fixturePath);
+    await setupContainerUser(args, ['sh', '-c', 'true']);
+
+    const capAdds = args
+      .filter((a) => a.startsWith('--cap-add='))
+      .map((a) => a.slice('--cap-add='.length));
+    expect(capAdds).toStrictEqual(['CHOWN', 'SETUID', 'SETGID']);
+  });
+
+  it('keeps --user root on the current-user path (AC5)', async () => {
+    process.env.SANDBOX_SET_UID_GID = 'true';
+
+    const args = buildArgs(fixturePath);
+    await setupContainerUser(args, ['sh', '-c', 'true']);
+
+    const userIdx = args.indexOf('--user');
+    expect(userIdx).toBeGreaterThanOrEqual(0);
+    expect(args[userIdx + 1]).toBe('root');
+  });
+
+  it('does not set --user when LLXPRT_CODE_INTEGRATION_TEST is set and the current-user path is not taken (AC4)', async () => {
+    // Force the non-current-user path deterministically: on Debian/Ubuntu
+    // Linux CI, shouldUseCurrentUserInSandbox() returns true by default, which
+    // would take the current-user branch and push --user root. SANDBOX_SET_UID_GID
+    // is authoritative (checked before the distro auto-detect) and host-independent.
+    process.env.SANDBOX_SET_UID_GID = 'false';
+    // The obsolete LLXPRT_CODE_INTEGRATION_TEST must have no effect.
+    process.env.LLXPRT_CODE_INTEGRATION_TEST = 'true';
+
+    const args = buildArgs(fixturePath);
+    const userFlag = await setupContainerUser(args, ['sh', '-c', 'true']);
+
+    expect(userFlag).toBe('');
+    expect(args).not.toContain('--user');
+  });
+
+  it('applies the base hardening flags to the proxy sidecar argv (AC2)', async () => {
+    // startProxyContainer builds a second `run` argv that previously bypassed
+    // the hardening. spawn is stubbed to throw immediately so the function
+    // rejects before performing I/O, while the call args are recorded.
+    vi.mocked(childProcess.spawn).mockImplementation(() => {
+      throw new Error('proxy-argv-captured');
+    });
+
+    await expect(
+      startProxyContainer(CONFIG, 'echo proxy', '', 'test-image', '/workspace'),
+    ).rejects.toThrow('proxy-argv-captured');
+
+    const spawnCalls = vi.mocked(childProcess.spawn).mock.calls;
+    expect(spawnCalls.length).toBeGreaterThan(0);
+    const proxyArgs = spawnCalls[0][1];
+    expect(proxyArgs).toContain('--cap-drop=ALL');
+    const secIdx = proxyArgs.indexOf('--security-opt');
+    expect(secIdx).toBeGreaterThanOrEqual(0);
+    expect(proxyArgs[secIdx + 1]).toBe('no-new-privileges');
   });
 });

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -76,6 +76,20 @@ const SANDBOX_PROXY_NAME = 'llxprt-code-sandbox-proxy';
 
 export { LOCAL_DEV_SANDBOX_IMAGE_NAME };
 
+/**
+ * Privilege-hardening flags applied to EVERY Docker/Podman sandbox container
+ * run, including the proxy sidecar: drop every Linux capability and forbid
+ * privilege escalation. Centralized here so no `run` argv can omit it. User
+ * SANDBOX_FLAGS are still applied afterward (in buildContainerRunArgs), so a
+ * user can add a specific capability back. See
+ * project-plans/issue-2902-sandbox-privilege-hardening.md.
+ */
+const BASE_CONTAINER_HARDENING_FLAGS = [
+  '--cap-drop=ALL',
+  '--security-opt',
+  'no-new-privileges',
+] as const;
+
 /** Composes cleanup callbacks and surfaces failures after attempting both. */
 function composeCleanups(
   a: (() => void) | undefined,
@@ -137,6 +151,10 @@ export function buildContainerRunArgs(
   resolvedTmpdir: string,
 ): string[] {
   const args = ['run', '-i', '--rm', '--init', '--workdir', containerWorkdir];
+  // Privilege hardening defaults: applied before SANDBOX_FLAGS so a user can
+  // still add specific capabilities back via SANDBOX_FLAGS. See
+  // project-plans/issue-2902-sandbox-privilege-hardening.md.
+  args.push(...BASE_CONTAINER_HARDENING_FLAGS);
   if (process.env.SANDBOX_FLAGS) {
     const flags = parse(process.env.SANDBOX_FLAGS, process.env).filter(
       (f): f is string => typeof f === 'string',
@@ -377,6 +395,16 @@ export function assignContainerName(
   return containerName;
 }
 
+/**
+ * Minimum capabilities required on the current-user path, proven by
+ * leave-one-out testing against the sandbox image: groupadd/useradd need CHOWN
+ * to write /etc/gshadow and /etc/shadow, and SETUID/SETGID create the matching
+ * UID/GID and let su drop to them. DAC_OVERRIDE and FOWNER are NOT required.
+ * Removing any one of these three breaks groupadd/useradd or su. See
+ * project-plans/issue-2902-sandbox-privilege-hardening.md. Do not add more.
+ */
+const CURRENT_USER_CAPABILITIES = ['CHOWN', 'SETUID', 'SETGID'] as const;
+
 /** Configures user/UID for the container and modifies entrypoint if needed. */
 export async function setupContainerUser(
   args: string[],
@@ -384,11 +412,16 @@ export async function setupContainerUser(
 ): Promise<string> {
   let userFlag = '';
 
-  if (process.env.LLXPRT_CODE_INTEGRATION_TEST === 'true') {
+  if (await shouldUseCurrentUserInSandbox()) {
+    // Root is required here: this branch runs groupadd/useradd to create the
+    // host user inside the container, then su to drop to that user's uid/gid.
+    // Creating the user and writing /etc/shadow needs the capabilities below;
+    // su is then invoked as root (already uid 0), so no-new-privileges does
+    // not block it.
     args.push('--user', 'root');
-    userFlag = '--user root';
-  } else if (await shouldUseCurrentUserInSandbox()) {
-    args.push('--user', 'root');
+    for (const cap of CURRENT_USER_CAPABILITIES) {
+      args.push(`--cap-add=${cap}`);
+    }
     const uid = execSync('id -u').toString().trim();
     const gid = execSync('id -g').toString().trim();
 
@@ -578,6 +611,7 @@ export async function startProxyContainer(
     'run',
     '--rm',
     '--init',
+    ...BASE_CONTAINER_HARDENING_FLAGS,
     ...userFlag.split(' ').filter((f) => f.length > 0),
     '--name',
     SANDBOX_PROXY_NAME,

--- a/project-plans/issue-2902-sandbox-privilege-hardening.md
+++ b/project-plans/issue-2902-sandbox-privilege-hardening.md
@@ -1,0 +1,248 @@
+# Issue #2902 — Sandbox container privilege hardening
+
+## Step 1 (required by the issue): empirical result
+
+The issue asks for the ptrace/`/proc/PID/mem` claim to be confirmed or refuted
+in a running container rather than reasoned about. It was tested.
+
+### Method
+
+A victim process holds a 64-hex, capability-token-shaped secret in an
+unexported shell variable (the same shape and residency as the token the CLI
+holds after consuming fd 3). A **descendant** process then reads
+`/proc/<victim>/maps` and `/proc/<victim>/mem` and scans readable mappings for
+the secret. This models exactly the issue's attacker: a shell command run by
+the agent, which is a descendant of the token-holding CLI process.
+
+Probe scripts and raw transcripts: see "Evidence" below.
+
+### Environment
+
+| | |
+|---|---|
+| Host | macOS (darwin, arm64) |
+| Docker | Server 29.1.3, builtin seccomp, cgroupns. Docker Desktop Linux VM kernel has **no Yama LSM** (`kernel.yama.ptrace_scope` is unavailable). |
+| Podman | 5.7.1, machine kernel 6.17.7-300.fc43.aarch64, rootless. Machine VM `kernel.yama.ptrace_scope` defaults to **0** (permissive). |
+| Image | `ghcr.io/vybestack/llxprt-code/sandbox` (0.11.0 / 0.10.0-nightly) |
+
+> The container shares the host (or VM) kernel, so the host's
+> `kernel.yama.ptrace_scope` governs `/proc/<pid>/mem` access **inside** the
+> container. Both originally-tested environments are the permissive case
+> (scope 0, or no Yama at all), which is why every row A–D recovered the token.
+> Row E adds a host with scope 1 (the Ubuntu default) and is DENIED.
+
+### Result matrix
+
+`TOKEN_RECOVERED` means the descendant read the secret out of the ancestor's
+heap; `MEM_OPEN_DENIED` means the `open()` of `/proc/<pid>/mem` returned
+`EACCES`. `ptrace_scope` is the host/VM `kernel.yama.ptrace_scope` (Podman
+machine VM or Docker Desktop VM), not anything the container sets.
+
+| # | Flags | Runtime | uid | CapEff | NoNewPrivs | ptrace_scope | Result |
+|---|---|---|---|---|---|---|---|
+| A | current llxprt flags | Podman | 1000 | 0 | 0 | 0 | **TOKEN_RECOVERED** |
+| A | current llxprt flags | Docker | 1000 | 0 | 0 | (no Yama) | **TOKEN_RECOVERED** |
+| B | + `--user root` | Podman | 0 | default subset¹ | 0 | 0 | **TOKEN_RECOVERED** |
+| B | + `--user root` | Docker | 0 | default subset¹ | 0 | (no Yama) | **TOKEN_RECOVERED** |
+| C | `--cap-drop=ALL --security-opt no-new-privileges` | Podman | 1000 | 0 | 1 | 0 | **TOKEN_RECOVERED** |
+| C | `--cap-drop=ALL --security-opt no-new-privileges` | Docker | 1000 | 0 | 1 | (no Yama) | **TOKEN_RECOVERED** |
+| D | C + `--user root` | Podman | 0 | 0 | 1 | 0 | **TOKEN_RECOVERED** |
+| D | C + `--user root` | Docker | 0 | 0 | 1 | (no Yama) | **TOKEN_RECOVERED** |
+| E | C (flags are irrelevant to this vector) | Podman | 1000 | 0 | 1 | **1** | **MEM_OPEN_DENIED EACCES** |
+
+¹ An ordinary root container does **not** hold "full" capabilities: the runtime
+grants a default bounding subset that normally excludes `CAP_SYS_PTRACE`. None
+of the rows grant `CAP_SYS_PTRACE`, and it would not matter anyway — reading a
+same-UID process's `/proc/<pid>/mem` requires no capability.
+
+### Conclusions
+
+1. **The exposure is REAL but CONDITIONAL on the host kernel's Yama setting.**
+   A process the agent controls inside the sandbox is a **descendant** of the
+   token-holding CLI process, so it is trying to read an **ancestor**. Yama
+   evaluates the tracer/tracee ancestry relationship regardless of PID
+   namespace, and the container shares the host (or VM) kernel, so the host
+   `kernel.yama.ptrace_scope` governs behavior inside the container:
+   - `ptrace_scope >= 1` (the Ubuntu default and many distros): reading an
+     ancestor's `/proc/<pid>/mem` is **DENIED** (`EACCES`) — row E.
+   - `ptrace_scope == 0`, or no Yama LSM at all (Docker Desktop's macOS VM
+     kernel reports no `ptrace_scope`): reading succeeds — rows A–D.
+
+2. **The issue text's dependency on Yama is CORRECT.** An earlier draft of this
+   conclusion claimed Yama was irrelevant because attacker and victim share the
+   container's PID namespace. That was wrong: Yama applies across the shared
+   kernel regardless of PID namespace, and the host sysctl is the deciding
+   factor. The originally-tested environments happened to be the permissive
+   ones (Podman VM scope 0; Docker Desktop VM with no Yama), which is why every
+   row recovered the token.
+
+3. **Every *container-invocation* remedy the issue proposes is ineffective
+   against this vector.** (These remain empirically supported.)
+   - `--cap-drop=ALL`: no effect. Reading `/proc/<pid>/mem` of a same-UID
+     process requires no capability.
+   - `--security-opt no-new-privileges`: no effect on this vector.
+   - `--user root` vs. non-root: no difference (within a given ptrace_scope).
+   - A seccomp profile that filters the `ptrace` syscall: ineffective, because
+     `/proc/<pid>/mem` is accessed via `open()` plus `pread()`, not the
+     `ptrace` syscall. Filtering `open`/`pread` is not viable in practice
+     because classic seccomp cannot filter by path. (Row D runs under the
+     default seccomp profile with all capabilities dropped and still succeeds
+     — but only because the host ptrace_scope is 0; row E shows scope 1 denies
+     it regardless of the seccomp profile.)
+   - `kernel.yama.ptrace_scope` is not namespaced, so the container cannot set
+     it; it is a **host** control, not an llxprt container flag.
+
+4. **UID separation is NOT the only possible control.** Three controls exist:
+   - A host with `kernel.yama.ptrace_scope >= 1` (rows A–D succeed only on the
+     permissive environments; row E shows scope 1 denies the read). This is
+     already the default on Ubuntu and many distributions.
+   - Making the CLI process non-dumpable via `prctl(PR_SET_DUMPABLE, 0)`, which
+     makes `/proc/<pid>/mem` root-owned so a same-UID reader is denied. Node
+     cannot call `prctl` without native code, so this remains future work.
+   - Per-command process-credential separation (the agent's commands run under
+     a different UID than the CLI). Tested: with `--cap-drop=ALL`, a process
+     cannot `setresuid` at all (`Operation not permitted`), so this requires
+     the CLI to run as root holding `CAP_SETUID`/`CAP_SETGID` and to drop every
+     agent-executed command to a separate unprivileged UID. That is an
+     architectural change to tool execution, not a container invocation flag.
+     It also inverts the current posture (CLI would have to be root) and
+     creates workspace file-ownership problems. Deferred, requires separate
+     approval.
+
+5. **The capability token remains a meaningful secret in its own right.** It
+   persists for the session and can be used to fetch a credential from the
+   proxy endpoint at a time when no credential is yet resident in memory.
+   Stealing it is therefore not *strictly* redundant with stealing the
+   credential — although, once a credential is resident in the CLI's address
+   space, anything that can read the CLI's heap can read the credential
+   directly (`ProxyProviderKeyStorage.getKey()` returns the raw key into that
+   same address space so the CLI can make provider calls).
+
+### Honest restatement of the security property
+
+> The credential never enters the sandbox's **filesystem, environment, or
+> argv** — it is not written to any of them. It does enter the sandbox CLI
+> process's address space when a provider call is made (the proxy endpoint
+> that returns it requires the capability token).
+>
+> Whether a same-UID in-container process can read that memory is **conditional
+> on the host kernel's Yama setting**, because the container shares the host
+> (or VM) kernel:
+> - On a host with `kernel.yama.ptrace_scope >= 1` (the Ubuntu default), the
+>   descendant agent process is **denied** (`EACCES`) when it tries to read the
+>   ancestor CLI process's `/proc/<pid>/mem` — row E.
+> - On a host with `ptrace_scope == 0`, or where the Yama LSM is absent
+>   (notably Docker Desktop for macOS, whose VM kernel reports no
+>   `ptrace_scope`), the read **succeeds** and the capability token and
+>   credential are recoverable — rows A–D.
+>
+> The sandbox defends against a prompt-injected agent that reads files,
+> inspects environments, scans argv, or speaks the proxy protocol. On
+> permissive Yama configurations it does **not** defend against one that reads
+> the CLI process's memory; on a host with Yama `ptrace_scope >= 1` that
+> descendant-reads-ancestor vector is blocked by the kernel.
+
+## Evidence
+
+Reproduce with the probe below (host must have Docker or Podman running):
+
+    # victim holds the secret; a DESCENDANT tries to read it back
+    TOKEN=deadbeef...4242 ; export VICTIM_PID=$$
+    node -e 'read /proc/$VICTIM_PID/maps + /proc/$VICTIM_PID/mem, scan for TOKEN'
+
+Full probe scripts are reproduced in the PR description. Transcripts show
+`mem open: SUCCESS` and `RESULT: TOKEN_RECOVERED from <heap range>` for rows
+A–D (the permissive environments: Podman VM `ptrace_scope == 0`, Docker
+Desktop with no Yama). With the Podman machine VM set to
+`kernel.yama.ptrace_scope == 1`, the same probe prints
+`### yama.ptrace_scope: 1` and `RESULT: MEM_OPEN_DENIED EACCES` (row E).
+
+## Step 2 — accepted scope
+
+Issue item 3 ("add a behavioral test asserting that an in-container process
+cannot obtain the capability token") asserts a property that **cannot be made
+true** by the container-invocation changes in issue item 2. Shipping those
+flags plus a test that only asserts the flags are present would be precisely
+the reasoned-about, non-falsifiable hardening the issue set out to avoid.
+
+Accepted: issue item 2 in full, plus the item-1 disproof recorded on the
+issue, plus an honest restatement of the boundary in `docs/sandbox.md`.
+
+**Item 3 is not delivered and is explicitly out of scope**, because it is not
+achievable by container invocation flags. The tests written here assert the
+properties the flags *do* deliver, and are falsifiable: they run real
+containers and check observed kernel state and real escalation attempts, not
+the presence of argv strings.
+
+Deferred, requires separate approval: per-command UID separation (conclusion 4
+above) is one design that would make item 3 true; the other two — a host with
+Yama `ptrace_scope >= 1`, and making the CLI process non-dumpable via
+`prctl(PR_SET_DUMPABLE, 0)` (which Node cannot call without native code) — are
+host-level or future work, not container invocation flags.
+
+## Acceptance matrix
+
+| AC | Behavior | Evidence |
+|---|---|---|
+| AC1 | Every docker/podman sandbox run passes `--security-opt no-new-privileges`. | Args test over `buildContainerRunArgs`; real-container test observes `NoNewPrivs: 1`. |
+| AC2 | Every docker/podman sandbox run passes `--cap-drop=ALL`. | Args test; real-container test observes `CapBnd: 0000000000000000` on the default path. |
+| AC3 | The current-user path adds back exactly `CHOWN,SETUID,SETGID` — the proven minimum for `groupadd`/`useradd`/`su` — and nothing more. | Args test asserts the exact set; real-container test proves the path succeeds with the three and FAILS when any one is removed (leave-one-out negative coverage). |
+| AC4 | The `LLXPRT_CODE_INTEGRATION_TEST` → `--user root` branch is removed and has no effect. | Test forces the non-current-user path (`SANDBOX_SET_UID_GID=false`) with the obsolete variable set and asserts no `--user`; `LLXPRT_CODE_INTEGRATION_TEST` is set nowhere in the repo. |
+| AC5 | The current-user path still uses `--user root`, and the reason is documented in code. | Existing current-user behavior tests continue to pass; comment present. |
+| AC6 | A non-root in-container process holds no capabilities and cannot escalate through the image's setuid-root binaries. | Real-container test attempts escalation via a shipped setuid binary and asserts failure. |
+| AC7 | User `SANDBOX_FLAGS` are applied after the default hardening flags and survive into the argv. (The docs no longer promise `--cap-add` alone yields a usable capability in the final process — that depends on runtime and path.) | Args ordering test asserts `--cap-add=NET_ADMIN` follows `--cap-drop=ALL`. |
+| AC8 | `docs/sandbox.md` states the boundary honestly, conditioned on the host Yama setting (including that Docker Desktop for macOS has no Yama so the exposure applies there). | Doc diff. |
+| AC9 | The proxy sidecar `run` argv receives the same base hardening flags as the main container. | Unit test asserts the sidecar argv contains `--cap-drop=ALL` and `--security-opt no-new-privileges`. |
+
+Real-container tests (AC1/AC2/AC3/AC6) RUN whenever a container runtime and the
+sandbox image are available, and SKIP only when they genuinely are not — no CI
+opt-in. Runtime selection honors `LLXPRT_SANDBOX=docker|podman` so the nominal
+podman suite tests podman. The restructured test obtains its flags from the
+production functions (`buildContainerRunArgs`/`setupContainerUser`) and asserts
+on observed kernel state; it is falsifiable (removing the production hardening
+makes it fail — verified during development).
+
+## Non-goals
+
+- No change to the credential proxy protocol, token format, or authorization.
+- No new daemon, sidecar, or public abstraction.
+- No workflow, dependency, or quality-tool change.
+- No Seatbelt redesign.
+- No seccomp profile: proven ineffective for this vector (conclusion 3).
+- No change to the proxy container's command, image, or networking — only that
+  it now receives the same base hardening flags as the main container (AC9),
+  via the shared `BASE_CONTAINER_HARDENING_FLAGS` constant.
+
+## Review triage
+
+### Cycle 1 (design/security review)
+
+| # | Finding | Class | Decision |
+|---|---|---|---|
+| F1 | Plan claimed host Yama is irrelevant; exposure asserted unconditionally | Blocker | ACCEPTED. Re-verified: at `ptrace_scope=1` the read is `MEM_OPEN_DENIED EACCES`; at `0` it is `TOKEN_RECOVERED`. Plan + docs rewritten to state the condition. The issue text was right and the earlier draft was wrong. |
+| F2 | Proxy sidecar argv bypassed the hardening while docs claimed "every run" | Blocker | ACCEPTED. Extracted `BASE_CONTAINER_HARDENING_FLAGS` and applied it to both argv builders (AC9). |
+| F3 | Real test silently no-opped in CI; runtime selection ignored `LLXPRT_SANDBOX` | Blocker | ACCEPTED. Gating now runs whenever runtime+image exist; runtime honors `LLXPRT_SANDBOX`. No workflow file was touched. |
+| F4 | Real test duplicated flag constants and never called production code | Blocker | ACCEPTED. Test now sources flags from `buildContainerRunArgs`/`setupContainerUser`; expected kernel state remains independent literals. Falsifiability re-verified independently: removing the production hardening turns all 6 tests red. |
+| F5 | AC4 unit test was host-dependent and would fail on Debian/Ubuntu CI | Blocker | ACCEPTED. Test forces `SANDBOX_SET_UID_GID=false`; current-user tests force `true`. |
+| F6 | Capability set was not minimal | In-scope-Fix | ACCEPTED. Leave-one-out re-verified: `CHOWN,SETUID,SETGID` are each necessary and jointly sufficient; `DAC_OVERRIDE`/`FOWNER` removed. Negative leave-one-out coverage added. |
+| F7 | Docs overpromised the `--cap-add` escape hatch | In-scope-Fix | ACCEPTED. Docs now state `--cap-add` widens the bounding set only, and that the final process depends on runtime and the current-user `su` path. |
+| F8 | Docs contradicted the implementation on credential flow | In-scope-Fix | ACCEPTED. "Network reach" claim removed; "strictly redundant" softened — the token persists and can fetch a credential when none is resident. |
+| F9 | Privileged-port claim wrong on modern Docker | In-scope-Fix | ACCEPTED. Corrected to kernel/sysctl dependent. |
+| F10 | Removing the `LLXPRT_CODE_INTEGRATION_TEST` branch is unsafe | Reject | Reviewer's own rejection; the variable is set nowhere in the repo. |
+| F11 | Seatbelt path is a bypass | Reject | Seatbelt is not a Docker/Podman invocation; macOS container mode uses the common builder. |
+| F12 | `beforeEach` snapshot ordering defect | Reject | False positive; the snapshot is already taken first. |
+
+### Cycle 2 (Open Code Review)
+
+| # | Finding | Class | Decision |
+|---|---|---|---|
+| O1 | Redundant `runtime !== undefined` in the `skipTests` short-circuit | In-scope-Fix | ACCEPTED. Simplified to `runtime === undefined \|\| !imagePresent(...)`. |
+| O2 | `parseUidLine` returned `NaN` silently on malformed input | In-scope-Fix | ACCEPTED. Now throws with the offending line (fail fast, consistent with `statusField`). |
+
+## Known limitation
+
+Empirical coverage is Docker and Podman on a macOS host, plus a Linux VM kernel
+at both `ptrace_scope` settings. A native Linux host was not available; the
+Yama-conditioned behavior is kernel-level and was measured directly in the
+Podman VM's Linux kernel at both settings, which is the property that governs
+the container.


### PR DESCRIPTION
Fixes #2902.

## Step 1: the falsifiable test the issue asked for

The issue asked for the ptrace / `/proc/<pid>/mem` claim to be **tested, not reasoned about**. It was. Full matrix in `project-plans/issue-2902-sandbox-privilege-hardening.md`.

A victim process holds a 64-hex, capability-token-shaped secret in its heap; a **descendant** (the agent's shell command, which is what the CLI's tool execution spawns) reads `/proc/<victim>/maps` and `/proc/<victim>/mem` and scans for it.

| # | Flags | Runtime | uid | CapEff | NoNewPrivs | ptrace_scope | Result |
|---|---|---|---|---|---|---|---|
| A | current llxprt flags | Podman | 1000 | 0 | 0 | 0 | TOKEN_RECOVERED |
| A | current llxprt flags | Docker | 1000 | 0 | 0 | (no Yama) | TOKEN_RECOVERED |
| B | + `--user root` | Podman/Docker | 0 | default subset | 0 | 0 / none | TOKEN_RECOVERED |
| C | `--cap-drop=ALL --security-opt no-new-privileges` | Podman/Docker | 1000 | 0 | 1 | 0 / none | TOKEN_RECOVERED |
| D | C + `--user root` | Podman/Docker | 0 | 0 | 1 | 0 / none | TOKEN_RECOVERED |
| E | C | Podman | 1000 | 0 | 1 | **1** | **MEM_OPEN_DENIED EACCES** |

### Conclusions

1. **The exposure is real, and CONDITIONAL on the host kernel's `kernel.yama.ptrace_scope` — exactly as the issue said.** The attacker is a *descendant* of the token-holding CLI, so it is reading an *ancestor*. At `ptrace_scope >= 1` (the Ubuntu default) that is denied; at `0`, or where the Yama LSM is absent entirely (Docker Desktop's macOS VM reports no `ptrace_scope`), it succeeds.

   During review I had drafted the opposite claim — that Yama was irrelevant because attacker and victim share the container's PID namespace. **That was wrong**, and row E disproves it. Yama evaluates the ancestry relation across the shared kernel regardless of namespace. Both of my originally-tested environments happened to be the permissive case, which is why rows A-D all recovered the token.

2. **No container-invocation flag closes this vector.** `--cap-drop=ALL` does nothing, because reading a same-UID process's memory requires no capability. `no-new-privileges` does nothing here. Root vs non-root makes no difference. A seccomp profile filtering `ptrace` is ineffective because `/proc/<pid>/mem` is `open()` + `pread()`, not the `ptrace` syscall; filtering those generally is not viable since classic seccomp cannot filter by path. Remounting `/proc` with `hidepid=2` is denied even to a root container.

3. Controls that *would* work, none of which is a container flag: a host at `ptrace_scope >= 1`; `prctl(PR_SET_DUMPABLE, 0)` on the CLI (Node cannot call `prctl` without native code); or per-command UID separation (a new subsystem that inverts the privilege posture).

## Step 2: what this PR does and does not deliver

**Issue item 3 — "a behavioral test asserting that an in-container process cannot obtain the capability token" — is NOT delivered, because item 2's flags cannot make it true.** Shipping those flags with a test that only asserts flag strings are present would be precisely the non-falsifiable hardening this issue was written to avoid. The docs now state the boundary honestly rather than overclaiming it.

Issue item 2 is delivered in full:

- **`--cap-drop=ALL` and `--security-opt no-new-privileges` on every Docker/Podman run**, including the proxy sidecar, via a single shared `BASE_CONTAINER_HARDENING_FLAGS` constant so no argv builder can omit them. Applied before `SANDBOX_FLAGS` so user flags still apply afterward.
- **The current-user path adds back only `CHOWN`, `SETUID`, `SETGID`.** Leave-one-out testing proved each is necessary and the three jointly sufficient; `DAC_OVERRIDE` and `FOWNER` were not required and are not granted.
- **The dead `LLXPRT_CODE_INTEGRATION_TEST` -> `--user root` branch is removed** (the variable is set nowhere in the repo; `integration-tests/globalSetup.ts` says it is no longer used). The current-user path keeps `--user root`, with the reason documented in code.

These flags do deliver a real, separate property: a non-root agent can no longer escalate through the setuid-root binaries the image ships (`su`, `mount`, `passwd`, `chsh`, `chfn`, `gpasswd`, `newgrp`, `umount`, `ssh-keysign`).

## Tests

`integration-tests/sandboxPrivilege.real.test.ts` obtains its container arguments **from the production functions** (`buildContainerRunArgs`, `setupContainerUser`), launches a real container with them, and asserts on kernel state observed inside it (`/proc/self/status`). Expected values are independent literals, not derived from the production constants.

Falsifiability verified: with the production hardening removed, **all 6 tests fail**; restored, all 6 pass on both runtimes.

    Docker 29.1.3   Test Files 1 passed (1) / Tests 6 passed (6)
    Podman 5.7.1    Test Files 1 passed (1) / Tests 6 passed (6)

Coverage: default-path `CapBnd`/`CapEff` = 0 and `NoNewPrivs` = 1; current-user `CapBnd` = `00000000000000c1`; leave-one-out negative coverage for each of the three capabilities; and a real setuid-root escalation attempt asserting the effective uid stays 1000 (without the hardening it becomes 0).

The test runs whenever a runtime and image are available and skips only when they genuinely are not — no CI opt-in, so the existing Docker e2e job exercises it. Runtime selection honors `LLXPRT_SANDBOX` so the podman suite tests podman.

Plus 7 args-level tests in `packages/cli/src/utils/sandbox-containers.test.ts` covering AC1-AC5, AC7 and the proxy sidecar.

## Verification

`npm run lint`, `lint:eslint-guard`, `typecheck`, `format`, `build` all exit 0. Unit tests 25/25. Real-container tests 6/6 on Docker and Podman. Stepfun smoke test returns a haiku.

Two `packages/core` tests (`config.mcp-lazy`, `config.scheduler`) flaked on separate full-suite runs and pass in isolation both with and without this change; `packages/tools` has 4 pre-existing `sharp` failures reproduced with this change stashed. Neither package depends on `packages/cli`.

## Review

Two review cycles. Cycle 1 raised 5 blockers (all accepted and fixed: the Yama correction, the unhardened proxy sidecar, CI-silent test gating, a test that never called production code, and a host-dependent unit test) plus 4 in-scope doc/minimality fixes. Cycle 2 (Open Code Review) raised 2 maintainability findings, both accepted. Full triage table is in the plan document.
