### PR TITLE
Split the overloaded JSP-E004 bootstrap diagnostic code (Fixes #2912)

### DIFF
--- a/packages/cli/src/observation/jspSchema.test.ts
+++ b/packages/cli/src/observation/jspSchema.test.ts
@@ -62,6 +62,26 @@ describe('parseBootstrap', () => {
     expect(errorCode(result)).toBe('JSP-E001');
   });
 
+  // A bare delimiter reports an empty search/hash but still travels in the
+  // endpoint string, so appending the route segment would yield a target such
+  // as "http://127.0.0.1:9123?/jsp/1" with the route folded into the query.
+  it('rejects an endpoint carrying a bare query or fragment delimiter', () => {
+    for (const endpoint of [
+      'http://127.0.0.1:9123?',
+      'http://127.0.0.1:9123#',
+      'http://127.0.0.1:9123?#',
+      'http://127.0.0.1:9123/jsp/1?',
+      'http://127.0.0.1:9123/jsp/1#',
+    ]) {
+      const result = parseBootstrap({ ...validBootstrap, endpoint });
+      expect(result.ok).toBe(false);
+      expect(errorCode(result)).toBe('JSP-E001');
+      expect(errorMessage(result)).toBe(
+        'endpoint must not include a query or fragment',
+      );
+    }
+  });
+
   it('rejects an endpoint carrying a fragment', () => {
     const result = parseBootstrap({
       ...validBootstrap,

--- a/packages/cli/src/observation/jspSchema.test.ts
+++ b/packages/cli/src/observation/jspSchema.test.ts
@@ -23,6 +23,12 @@ function errorCode(
   return result.ok ? undefined : result.error.code;
 }
 
+function errorMessage(
+  result: ReturnType<typeof parseBootstrap>,
+): string | undefined {
+  return result.ok ? undefined : result.error.message;
+}
+
 describe('parseBootstrap', () => {
   it('accepts a closed valid bootstrap', () => {
     const result = parseBootstrap(validBootstrap);
@@ -37,12 +43,14 @@ describe('parseBootstrap', () => {
   });
 
   it('rejects a non-loopback endpoint', () => {
-    const result = parseBootstrap({
-      ...validBootstrap,
-      endpoint: 'http://192.168.1.5:9123/jsp/1',
-    });
-    expect(result.ok).toBe(false);
-    expect(errorCode(result)).toBe('JSP-E004');
+    for (const endpoint of [
+      'http://192.168.1.5:9123/jsp/1',
+      'http://example.com/jsp/1',
+    ]) {
+      const result = parseBootstrap({ ...validBootstrap, endpoint });
+      expect(result.ok).toBe(false);
+      expect(errorCode(result)).toBe('JSP-E004');
+    }
   });
 
   it('rejects an endpoint carrying a query string', () => {
@@ -63,6 +71,49 @@ describe('parseBootstrap', () => {
     expect(errorCode(result)).toBe('JSP-E001');
   });
 
+  it('reports a distinct, accurate message for each endpoint rejection branch', () => {
+    const unparseable = parseBootstrap({
+      ...validBootstrap,
+      endpoint: 'not a url',
+    });
+    expect(errorMessage(unparseable)).toBe('endpoint is not a valid URL');
+
+    const badScheme = parseBootstrap({
+      ...validBootstrap,
+      endpoint: 'ws://127.0.0.1:9123/jsp/1',
+    });
+    expect(errorMessage(badScheme)).toBe(
+      'endpoint scheme must be http or https',
+    );
+
+    const nonLoopback = parseBootstrap({
+      ...validBootstrap,
+      endpoint: 'http://192.168.1.5:9123/jsp/1',
+    });
+    expect(errorMessage(nonLoopback)).toBe(
+      'endpoint host must be a loopback address',
+    );
+
+    const query = parseBootstrap({
+      ...validBootstrap,
+      endpoint: 'http://127.0.0.1:9123?token=abc',
+    });
+    expect(errorMessage(query)).toBe(
+      'endpoint must not include a query or fragment',
+    );
+  });
+
+  it('never echoes rejected endpoint input in its diagnostic', () => {
+    const endpoint = 'ws://user:s3cr3t-do-not-leak@127.0.0.1:9123/jsp/1';
+    const result = parseBootstrap({ ...validBootstrap, endpoint });
+    expect(result.ok).toBe(false);
+    const message = errorMessage(result);
+    expect(message).not.toContain('s3cr3t-do-not-leak');
+    expect(message).not.toContain('127.0.0.1');
+    expect(message).not.toContain('ws');
+    expect(message).not.toContain(endpoint);
+  });
+
   it('rejects a wrong protocol version', () => {
     const result = parseBootstrap({
       ...validBootstrap,
@@ -72,7 +123,7 @@ describe('parseBootstrap', () => {
     expect(errorCode(result)).toBe('JSP-E003');
   });
 
-  it('rejects a non-positive lifecycle generation', () => {
+  it('rejects a zero lifecycle generation with JSP-E004', () => {
     const result = parseBootstrap({
       ...validBootstrap,
       lifecycle_generation: 0,
@@ -81,13 +132,40 @@ describe('parseBootstrap', () => {
     expect(errorCode(result)).toBe('JSP-E004');
   });
 
-  it('rejects a negative lifecycle generation', () => {
+  it('rejects a negative lifecycle generation with JSP-E001', () => {
+    for (const lifecycle_generation of [-1, -2, -999]) {
+      const result = parseBootstrap({
+        ...validBootstrap,
+        lifecycle_generation,
+      });
+      expect(result.ok).toBe(false);
+      expect(errorCode(result)).toBe('JSP-E001');
+    }
+  });
+
+  it('rejects a non-integer lifecycle generation with JSP-E001', () => {
     const result = parseBootstrap({
       ...validBootstrap,
-      lifecycle_generation: -1,
+      lifecycle_generation: 1.5,
     });
     expect(result.ok).toBe(false);
-    expect(errorCode(result)).toBe('JSP-E004');
+    expect(errorCode(result)).toBe('JSP-E001');
+  });
+
+  it('accepts a positive lifecycle generation', () => {
+    const result = parseBootstrap({
+      ...validBootstrap,
+      lifecycle_generation: 1,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts a large positive lifecycle generation', () => {
+    const result = parseBootstrap({
+      ...validBootstrap,
+      lifecycle_generation: Number.MAX_SAFE_INTEGER,
+    });
+    expect(result.ok).toBe(true);
   });
 
   it('accepts https on loopback', () => {
@@ -106,13 +184,39 @@ describe('parseBootstrap', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('rejects a non-http(s) scheme', () => {
-    const result = parseBootstrap({
-      ...validBootstrap,
-      endpoint: 'ws://127.0.0.1:9123/jsp/1',
-    });
-    expect(result.ok).toBe(false);
-    expect(errorCode(result)).toBe('JSP-E004');
+  it('rejects a non-http(s) scheme as a shape violation', () => {
+    for (const endpoint of [
+      'ws://127.0.0.1:9123/jsp/1',
+      'ftp://127.0.0.1:9123/jsp/1',
+      'file:///jsp/1',
+      'urn:example:test',
+      'javascript://127.0.0.1:9123/jsp/1',
+    ]) {
+      const result = parseBootstrap({ ...validBootstrap, endpoint });
+      expect(result.ok).toBe(false);
+      expect(errorCode(result)).toBe('JSP-E001');
+      expect(errorMessage(result)).toBe(
+        'endpoint scheme must be http or https',
+      );
+    }
+  });
+
+  // A scheme-prefixed endpoint that is itself unparsable must reach the
+  // malformed-URL branch, not the scheme branch, even though both report
+  // JSP-E001. Pinned by message so the two branches cannot be confused.
+  // Two independent causes of a parse failure are covered so this does not
+  // rest on a single WHATWG rule: a file URL may not carry a port, and the
+  // IPv6 literal is unterminated. Both throw in Node and in Bun.
+  it('rejects a scheme-prefixed but unparsable endpoint as a malformed URL', () => {
+    for (const endpoint of [
+      'file://127.0.0.1:9123/jsp/1',
+      'http://[::1:9123/jsp/1',
+    ]) {
+      const result = parseBootstrap({ ...validBootstrap, endpoint });
+      expect(result.ok).toBe(false);
+      expect(errorCode(result)).toBe('JSP-E001');
+      expect(errorMessage(result)).toBe('endpoint is not a valid URL');
+    }
   });
 
   // URL parsing rejects an out-of-range IPv4 literal before the loopback test
@@ -163,6 +267,7 @@ describe('parseBootstrap', () => {
         endpoint: `http://${host}:9123/jsp/1`,
       });
       expect(result.ok).toBe(false);
+      expect(errorCode(result)).toBe('JSP-E004');
     }
   });
 

--- a/packages/cli/src/observation/jspSchema.ts
+++ b/packages/cli/src/observation/jspSchema.ts
@@ -154,7 +154,14 @@ function classifyEndpoint(
   // The publisher appends the "/jsp/1" route segment to this endpoint. A query
   // or fragment would end up before that segment and produce a malformed URL,
   // so reject it here rather than silently building a broken request target.
-  if (parsed.search !== '' || parsed.hash !== '') {
+  // A bare trailing "?" or "#" reports an empty search/hash while still
+  // carrying the delimiter, so the serialisations are compared instead: an
+  // endpoint of "http://127.0.0.1:9123?" would otherwise be accepted and
+  // then build the request target "http://127.0.0.1:9123?/jsp/1".
+  const withoutQueryOrFragment = new URL(parsed.href);
+  withoutQueryOrFragment.search = '';
+  withoutQueryOrFragment.hash = '';
+  if (withoutQueryOrFragment.href !== parsed.href) {
     return {
       ok: false,
       error: {

--- a/packages/cli/src/observation/jspSchema.ts
+++ b/packages/cli/src/observation/jspSchema.ts
@@ -54,7 +54,34 @@ const BootstrapSchema = z
     }),
     publisher_credential: z.string().min(1),
     agent_id: z.string().min(1).max(128).regex(opaqueIdRegex),
-    lifecycle_generation: z.number().int().positive(),
+    // The domain violation (negative) and the identity violation (zero) carry
+    // distinct diagnostic codes, so each is raised as its own issue. Exactly
+    // one issue is emitted per value, which keeps the mapping independent of
+    // the order in which Zod would otherwise report overlapping checks.
+    lifecycle_generation: z
+      .number()
+      .int()
+      .superRefine((value, ctx) => {
+        // minimum 0 inclusive is the unsigned domain bound, which is a
+        // different rule from the positivity requirement checked below: the
+        // domain admits zero, and the identity rule is what rejects it.
+        if (value < 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.too_small,
+            minimum: 0,
+            type: 'number',
+            inclusive: true,
+            message: 'lifecycle_generation must not be negative',
+          });
+          return;
+        }
+        if (value === 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'lifecycle_generation must be greater than 0',
+          });
+        }
+      }),
   })
   .strict();
 
@@ -96,34 +123,72 @@ function isLoopbackHost(hostname: string): boolean {
 
 function classifyEndpoint(
   endpoint: string,
-): { ok: true; url: URL } | { ok: false; code: JspErrorCode } {
+): { ok: true; url: URL } | { ok: false; error: JspError } {
   let parsed: URL;
   try {
     parsed = new URL(endpoint);
   } catch {
-    return { ok: false, code: 'JSP-E001' };
+    return {
+      ok: false,
+      error: { code: 'JSP-E001', message: 'endpoint is not a valid URL' },
+    };
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return { ok: false, code: 'JSP-E004' };
+    return {
+      ok: false,
+      error: {
+        code: 'JSP-E001',
+        message: 'endpoint scheme must be http or https',
+      },
+    };
   }
   if (!isLoopbackHost(parsed.hostname)) {
-    return { ok: false, code: 'JSP-E004' };
+    return {
+      ok: false,
+      error: {
+        code: 'JSP-E004',
+        message: 'endpoint host must be a loopback address',
+      },
+    };
   }
   // The publisher appends the "/jsp/1" route segment to this endpoint. A query
   // or fragment would end up before that segment and produce a malformed URL,
   // so reject it here rather than silently building a broken request target.
   if (parsed.search !== '' || parsed.hash !== '') {
-    return { ok: false, code: 'JSP-E001' };
+    return {
+      ok: false,
+      error: {
+        code: 'JSP-E001',
+        message: 'endpoint must not include a query or fragment',
+      },
+    };
   }
   return { ok: true, url: parsed };
 }
 
+// The Jefe JSP/1 specification (§2) mandates JSP-E004 for a
+// lifecycle_generation of exactly zero: it is a well-formed number that
+// violates the positive-identity rule. A negative value is outside the
+// reference unsigned domain, so it is a JSP-E001 shape violation instead. A
+// non-integer fails the .int() check (invalid_type) and falls through to the
+// general invalid_type handler in zodToJspError, which is also JSP-E001.
+function lifecycleGenerationErrorCode(
+  issue: z.ZodIssue,
+): JspErrorCode | undefined {
+  if (issue.path[issue.path.length - 1] !== 'lifecycle_generation') {
+    return undefined;
+  }
+  if (issue.code === z.ZodIssueCode.too_small) return 'JSP-E001';
+  if (issue.code === z.ZodIssueCode.custom) return 'JSP-E004';
+  return undefined;
+}
+
 function zodToJspError(issue: z.ZodIssue): JspErrorCode {
+  const generationCode = lifecycleGenerationErrorCode(issue);
+  if (generationCode !== undefined) return generationCode;
   const code = issue.code;
   const lastPath = issue.path[issue.path.length - 1];
-  if (code === z.ZodIssueCode.too_big) return 'JSP-E002';
-  if (code === z.ZodIssueCode.too_small) {
-    if (lastPath === 'lifecycle_generation') return 'JSP-E004';
+  if (code === z.ZodIssueCode.too_big || code === z.ZodIssueCode.too_small) {
     return 'JSP-E002';
   }
   if (
@@ -147,7 +212,7 @@ export function parseBootstrap(input: unknown): JspResult<JspBootstrap> {
   }
   const endpointCheck = classifyEndpoint(parsed.data.endpoint);
   if (!endpointCheck.ok) {
-    return err(endpointCheck.code, 'endpoint not loopback');
+    return err(endpointCheck.error.code, endpointCheck.error.message);
   }
   return ok({
     schema: parsed.data.schema,

--- a/project-plans/issue-2912-jsp-e004-split.md
+++ b/project-plans/issue-2912-jsp-e004-split.md
@@ -3,8 +3,12 @@
 ## Scope decision
 
 One issue-linked pull request against `packages/cli/src/observation/jspSchema.ts`
-and its test file. Diagnostics only: no bootstrap input that is accepted today
-becomes rejected, and no input that is rejected today becomes accepted.
+and its test file. Primarily a diagnostics change. One deliberate exception to
+that, accepted during review and recorded under A7: an endpoint carrying a bare
+trailing `?` or `#` is now rejected, because the existing guard's own stated
+purpose was already to reject it and it only escaped on a technicality. Apart
+from A7, no input accepted today becomes rejected and no input rejected today
+becomes accepted.
 
 ## Cross-repository determination (done before implementation)
 
@@ -60,7 +64,8 @@ binding boundary and the generation identity rule — and nothing else.
 | A3 | Generation domain vs identity split | `0` → `JSP-E004`; `-1`, `-2`, `-999` → `JSP-E001`; `1.5` → `JSP-E001` | Zero rejected with `JSP-E004`; every negative and non-integer rejected with `JSP-E001` | Collapsing a negative (outside the reference `u64` domain) onto the identity code, or weakening the accept set | Schema tests |
 | A4 | Every endpoint rejection carries a message describing its own branch | All four `classifyEndpoint` branches | Each branch yields a distinct, accurate message; the invalid-scheme branch no longer claims "endpoint not loopback" | One hardcoded message for semantically different failures | Schema tests asserting messages |
 | A5 | Diagnostics never echo the rejected input | Endpoint containing a credential-like value, e.g. `ws://user:secret@127.0.0.1/` | Message is a fixed string; the rejected endpoint, its host, its scheme, and any userinfo never appear in it | Leaking bootstrap material into a diagnostic, contrary to Jefe specification decision 12 | Schema tests |
-| A6 | Accepted inputs are unchanged | Existing valid corpus: `http`/`https`, `localhost`, `app.localhost`, `[::1]`, `[0:0:0:0:0:0:0:1]`, `127.x` including zero-padded octets | All still accepted | A diagnostics-only change altering the accept set | Existing schema tests, unmodified |
+| A6 | Accepted inputs are otherwise unchanged | Existing valid corpus: `http`/`https`, `localhost`, `app.localhost`, `[::1]`, `[0:0:0:0:0:0:0:1]`, `127.x` including zero-padded octets | All still accepted | Altering the accept set anywhere other than A7 | Existing schema tests, unmodified |
+| A7 | A bare query or fragment delimiter is rejected | `http://127.0.0.1:9123?`, `...#`, `...?#`, and the same with a `/jsp/1` path | Rejected with `JSP-E001` and the query/fragment message | Accepting an endpoint that then builds the request target `http://127.0.0.1:9123?/jsp/1`, folding the route into the query | Schema tests |
 
 ## Test-first sequence
 
@@ -89,7 +94,8 @@ of a bare code, give each branch its own fixed message, and have
 ## Explicit non-goals
 
 - Adding `JSP-E007` or any change to the closed `JSP-E001..JSP-E006` set.
-- Changing which bootstraps are accepted or rejected.
+- Changing which bootstraps are accepted or rejected, other than the bare
+  trailing `?`/`#` case in A7.
 - Changing which generation values are accepted: only integers strictly
   greater than zero remain accepted. The codes change (`JSP-E004` for zero,
   `JSP-E001` for a negative, `JSP-E001` for a non-integer), but the
@@ -163,20 +169,24 @@ values.
 
 CodeRabbit, 1 review (1 finding):
 
-- **Deferred to #3027.** The endpoint guard tests `URL.search`/`URL.hash`
-  against the empty string, but both return `''` for a *bare* trailing `?` or
-  `#`, so `http://127.0.0.1:9123?` and `http://127.0.0.1:9123#` are accepted
-  today. Because `parseBootstrap` returns the raw endpoint string, appending
-  the route segment yields `http://127.0.0.1:9123?/jsp/1`, which is exactly
-  the malformed request target the guard exists to prevent. The finding is
-  correct and was confirmed empirically. It is deferred because fixing it
-  changes the accept/reject set, which this diagnostics-only PR lists as an
-  explicit non-goal, and because the predicate is unchanged from main (it
-  arrived in #2897 and this PR touched only that branch's message).
+- **Adopted (A7).** The endpoint guard tested `URL.search`/`URL.hash` against
+  the empty string, but both return `''` for a *bare* trailing `?` or `#`, so
+  `http://127.0.0.1:9123?` and `http://127.0.0.1:9123#` were accepted. Because
+  `parseBootstrap` returns the raw endpoint string, appending the route segment
+  yields `http://127.0.0.1:9123?/jsp/1`, which is exactly the malformed request
+  target the guard exists to prevent. The guard now compares the serialisation
+  against a copy with `search` and `hash` cleared.
+
+  This was initially deferred as #3027 on the grounds that it moves the
+  accept/reject set. That call was overruled by the maintainer: the guard's own
+  stated purpose already covered this input, so closing the hole completes the
+  existing intent rather than expanding scope, and splitting it into a separate
+  pull request would not have been worth the overhead. #3027 is closed as
+  delivered here.
 
 ## Review counters
 
 - Independent review/remediation cycles: 1 of 2.
 - Local OCR: 1 of 2.
 - PR OCR: 1 of 2 (CI OpenCodeReview job, pass).
-- CodeRabbit: 1 review, 1 finding, deferred to #3027 with a recorded reply.
+- CodeRabbit: 1 review, 1 finding, adopted as A7 with a recorded reply.

--- a/project-plans/issue-2912-jsp-e004-split.md
+++ b/project-plans/issue-2912-jsp-e004-split.md
@@ -161,8 +161,22 @@ issue per value and removes that dependency on library-internal ordering.
 Accept/reject behavior is identical; verified empirically across all boundary
 values.
 
+CodeRabbit, 1 review (1 finding):
+
+- **Deferred to #3027.** The endpoint guard tests `URL.search`/`URL.hash`
+  against the empty string, but both return `''` for a *bare* trailing `?` or
+  `#`, so `http://127.0.0.1:9123?` and `http://127.0.0.1:9123#` are accepted
+  today. Because `parseBootstrap` returns the raw endpoint string, appending
+  the route segment yields `http://127.0.0.1:9123?/jsp/1`, which is exactly
+  the malformed request target the guard exists to prevent. The finding is
+  correct and was confirmed empirically. It is deferred because fixing it
+  changes the accept/reject set, which this diagnostics-only PR lists as an
+  explicit non-goal, and because the predicate is unchanged from main (it
+  arrived in #2897 and this PR touched only that branch's message).
+
 ## Review counters
 
 - Independent review/remediation cycles: 1 of 2.
 - Local OCR: 1 of 2.
-- PR OCR: 0 of 2.
+- PR OCR: 1 of 2 (CI OpenCodeReview job, pass).
+- CodeRabbit: 1 review, 1 finding, deferred to #3027 with a recorded reply.

--- a/project-plans/issue-2912-jsp-e004-split.md
+++ b/project-plans/issue-2912-jsp-e004-split.md
@@ -1,0 +1,168 @@
+# Issue 2912 delivery plan — split the overloaded JSP-E004 bootstrap diagnostic
+
+## Scope decision
+
+One issue-linked pull request against `packages/cli/src/observation/jspSchema.ts`
+and its test file. Diagnostics only: no bootstrap input that is accepted today
+becomes rejected, and no input that is rejected today becomes accepted.
+
+## Cross-repository determination (done before implementation)
+
+The issue states that splitting the codes touches the frozen JSP/1 diagnostic
+surface and must be coordinated with the Jefe broker. That coordination was
+performed by reading the authority rather than assumed. The finding is that the
+split can be made **inside** the frozen set, so no protocol change and no Jefe
+change is required.
+
+Evidence, from `llxprt-jefe` at `6b6d92896`:
+
+- `dev-docs/jsp/v1/specification.md` §14 fixes a closed six-member code set.
+  `src/jsp/v1/error.rs` and `tests/jsp_v1_snapshot_compliance.rs` both pin
+  `JSP-E001..JSP-E006` exactly. Introducing a `JSP-E007` would be a protocol
+  change; it is not needed and is therefore not proposed.
+- §14 defines `JSP-E001` as "Closed JSON / syntax / shape violation" and
+  `JSP-E004` as "Identity / **binding** violation".
+- §2, line 108: "`lifecycle_generation` must be positive (`>= 1`). Zero fails
+  with `JSP-E004`." This mandates `JSP-E004` for **zero** specifically. It does
+  not mandate `JSP-E004` for every non-positive value. `src/jsp/v1/wire.rs:255`
+  declares `lifecycle_generation: u64`, so a negative value fails serde
+  deserialization, and `src/jsp/v1/parse.rs` maps deserialization/data failures
+  to `JSP-E001`. The reference oracle therefore distinguishes zero
+  (`JSP-E004`, the identity rule) from any negative (`JSP-E001`, outside the
+  unsigned domain). The previous llxprt mapping collapsed both onto `JSP-E004`;
+  splitting them so zero is `JSP-E004` and a negative is `JSP-E001` is exactly
+  the split this issue asks for, and is what the code now does. The accept set
+  is unchanged: only integers strictly greater than zero are accepted.
+- Jefe never consumes llxprt's bootstrap rejection code. `JspCode` is used only
+  on the broker's document-parsing path (`src/jsp/v1/`). `src/jsp_host/launch.rs`
+  writes the bootstrap file and asserts loopback itself before writing
+  (`endpoint.ip().is_loopback()`, then `"endpoint": format!("http://{endpoint}/jsp/1")`);
+  it never reads a code back. Neither
+  `dev-docs/jsp/v1/compliance/producer-contract.md` nor
+  `src/bin/jefe-jsp-compliance.rs` asserts any bootstrap endpoint code.
+  llxprt's only consumer is `jspWiring.loadBootstrapFromEnv`, which formats the
+  code into a local `Error` message.
+
+Conclusion: the genuine defect is that an unsupported **scheme** is reported as
+a binding violation. A scheme that is not `http:`/`https:` is a shape violation
+of the `endpoint` field, which is exactly what `JSP-E001` already means, and is
+exactly how the same function already reports the other two malformed-endpoint
+branches (unparsable URL, query/fragment present). Moving it to `JSP-E001`
+leaves `JSP-E004` meaning precisely what §14 says it means — the loopback
+binding boundary and the generation identity rule — and nothing else.
+
+## Acceptance matrix
+
+| ID | Behavior | Inputs / boundary cases | Success | Failure guarded against | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| A1 | Unsupported endpoint scheme is a shape violation | `ws://`, `ftp://`, `file://`, and `javascript:` endpoints on a loopback host | Rejected with `JSP-E001` | Silently reclassifying it as the security-boundary code, or accepting a non-HTTP scheme | Schema tests |
+| A2 | Non-loopback host stays the security boundary | `http://192.168.1.5:9123/jsp/1`, `http://example.com/jsp/1`, and the padded-octet near-misses already pinned | Rejected with `JSP-E004` | Weakening the loopback check while relabelling codes | Schema tests |
+| A3 | Generation domain vs identity split | `0` → `JSP-E004`; `-1`, `-2`, `-999` → `JSP-E001`; `1.5` → `JSP-E001` | Zero rejected with `JSP-E004`; every negative and non-integer rejected with `JSP-E001` | Collapsing a negative (outside the reference `u64` domain) onto the identity code, or weakening the accept set | Schema tests |
+| A4 | Every endpoint rejection carries a message describing its own branch | All four `classifyEndpoint` branches | Each branch yields a distinct, accurate message; the invalid-scheme branch no longer claims "endpoint not loopback" | One hardcoded message for semantically different failures | Schema tests asserting messages |
+| A5 | Diagnostics never echo the rejected input | Endpoint containing a credential-like value, e.g. `ws://user:secret@127.0.0.1/` | Message is a fixed string; the rejected endpoint, its host, its scheme, and any userinfo never appear in it | Leaking bootstrap material into a diagnostic, contrary to Jefe specification decision 12 | Schema tests |
+| A6 | Accepted inputs are unchanged | Existing valid corpus: `http`/`https`, `localhost`, `app.localhost`, `[::1]`, `[0:0:0:0:0:0:0:1]`, `127.x` including zero-padded octets | All still accepted | A diagnostics-only change altering the accept set | Existing schema tests, unmodified |
+
+## Test-first sequence
+
+RED first, in `packages/cli/src/observation/jspSchema.test.ts`:
+
+1. Change the existing `rejects a non-http(s) scheme` expectation from
+   `JSP-E004` to `JSP-E001` and extend it across `ws:`, `ftp:`, `javascript:`,
+   and scheme-bearing endpoints that genuinely parse (`file:///jsp/1`,
+   `urn:example:test`). Note that `file://127.0.0.1:9123/jsp/1` is **not**
+   usable here: the `file` scheme forbids a port, so `new URL(...)` throws and
+   the row hits the unparsable-URL branch, not the scheme branch. Pin that
+   malformed case as its own assertion (`JSP-E001` + the unparsable-URL
+   message), and assert the scheme message on every scheme row.
+2. Add message assertions for all four endpoint branches (A4). These fail
+   against current `main`, which returns `endpoint not loopback` for every one.
+3. Add the no-echo assertion (A5).
+4. Split the generation tests so `0` pins `JSP-E004`, a negative pins
+   `JSP-E001`, a non-integer (`1.5`) pins `JSP-E001`, and positive and large
+   positive integers are still accepted (A3, A6).
+
+GREEN: have `classifyEndpoint` return a `JspError` (code plus message) instead
+of a bare code, give each branch its own fixed message, and have
+`parseBootstrap` propagate that error rather than substituting the hardcoded
+`'endpoint not loopback'`.
+
+## Explicit non-goals
+
+- Adding `JSP-E007` or any change to the closed `JSP-E001..JSP-E006` set.
+- Changing which bootstraps are accepted or rejected.
+- Changing which generation values are accepted: only integers strictly
+  greater than zero remain accepted. The codes change (`JSP-E004` for zero,
+  `JSP-E001` for a negative, `JSP-E001` for a non-integer), but the
+  accept/reject set is unchanged.
+- Restructuring `zodToJspError` beyond what A1–A5 require.
+- Any change to Jefe, to the compliance corpus, or to the wire protocol.
+- Any lint ignore, ESLint disable, TypeScript suppression, or threshold change.
+- Any `.llxprt` change.
+
+## Scope ledger
+
+| Item | Disposition | Notes |
+| --- | --- | --- |
+| Invalid scheme `JSP-E004` → `JSP-E001` | Accepted | The defect named in the issue |
+| Per-branch endpoint rejection messages | Accepted | The issue names the wrong hardcoded message explicitly |
+| Non-loopback stays `JSP-E004` | Accepted, no change | §14 "identity / binding violation" |
+| Negative generation `JSP-E004` → `JSP-E001` (zero stays `JSP-E004`) | Accepted | `wire.rs:255` `u64` plus the parse mapping make negatives `JSP-E001`; §2 line 108 covers zero only. The accept set is unchanged |
+| New `JSP-E007` | Rejected | Frozen set; unnecessary once scheme maps to `JSP-E001` |
+| Jefe-side change | Not required | Jefe never consumes the bootstrap code; evidence above |
+
+## Review dispositions
+
+Independent review, cycle 1 of 2:
+
+- **In-scope-Fix, adopted.** A negative `lifecycle_generation` was still mapped
+  to `JSP-E004`. The Jefe specification mandates `JSP-E004` for **zero**
+  specifically (§2 line 108); the reference parser types the field `u64`
+  (`src/jsp/v1/wire.rs:255`) and maps deserialization failures to `JSP-E001`,
+  so a negative value is a shape violation there. Zero now maps to `JSP-E004`
+  and a negative to `JSP-E001`, matching the oracle.
+- **In-scope-Fix, adopted.** The unsupported-scheme test used
+  `file://127.0.0.1:9123/jsp/1`, which does not parse and so never reached the
+  scheme branch; the row would have passed with the bug still present. It was
+  replaced with `file:///jsp/1` and `urn:example:test`, which do parse, and the
+  test now asserts the scheme **message** as well as the code.
+- **Deferred.** LLxprt's accepted endpoint profile is broader than the Jefe
+  embedded profile (it allows HTTPS, DNS `localhost` forms, and IPv6, where
+  §15.1 describes IPv4 loopback HTTP), and userinfo-bearing loopback endpoints
+  are accepted. Both predate this change and altering either would change the
+  accept set, which this diagnostics-only issue must not do.
+- **Deferred.** A non-loopback IPv6 near-miss such as `http://[::2]/` is not
+  covered. The host predicate is unchanged here, so this is future hardening.
+
+Local Open Code Review, run 1 of 2 (2 findings):
+
+- **Rejected — factual error.** A high-severity finding claimed
+  `new URL('file://127.0.0.1:9123/jsp/1')` succeeds and that the malformed-URL
+  test therefore fails at runtime. It throws: the WHATWG URL parser makes a
+  file URL carrying a port a parse failure. Verified empirically in Node
+  (`Invalid URL`) and in Bun (`cannot be parsed as a URL`), and the suite
+  passes 25/25 under both runners. The suggested replacement was not applied.
+  The malformed-URL case was nonetheless broadened to cover a second,
+  independent parse failure (an unterminated IPv6 literal) so the branch no
+  longer rests on a single WHATWG rule.
+- **Rejected as proposed; underlying readability point adopted.** A finding
+  argued that `minimum: 0, inclusive: true` on the negative branch implies zero
+  is valid, and proposed emitting `custom` for both branches. That change would
+  remove the discriminator the split depends on and collapse negative and zero
+  back onto one code — the exact defect this issue exists to fix. The bound is
+  correct as written, because it expresses the unsigned **domain** rule, which
+  is genuinely inclusive of zero and distinct from the positivity rule applied
+  after it. A comment recording that distinction was added instead.
+
+Additional change made during review, not from a reviewer: the negative/zero
+split originally used `.min(0).refine(...)`, which emits **two** issues for a
+negative value and therefore depended on Zod reporting `too_small` before
+`custom` in `issues[0]`. It now uses `superRefine`, which emits exactly one
+issue per value and removes that dependency on library-internal ordering.
+Accept/reject behavior is identical; verified empirically across all boundary
+values.
+
+## Review counters
+
+- Independent review/remediation cycles: 1 of 2.
+- Local OCR: 1 of 2.
+- PR OCR: 0 of 2.


### PR DESCRIPTION
## TLDR

JSP/1 bootstrap validation mapped semantically distinct failures onto one diagnostic code, and reported **every** endpoint failure with the hardcoded message `endpoint not loopback` — which is simply wrong for the invalid-scheme branch.

This splits those cases apart. No new error code is introduced. It is a diagnostics change with **one deliberate behavior fix**: an endpoint carrying a bare trailing `?` or `#` is now rejected (see below). Every other accepted bootstrap is unchanged.

| Input | Before | After |
| --- | --- | --- |
| Unsupported endpoint scheme (`ws:`, `ftp:`, `file:`, `urn:`, …) | `JSP-E004` "endpoint not loopback" | `JSP-E001` "endpoint scheme must be http or https" |
| Non-loopback host | `JSP-E004` "endpoint not loopback" | `JSP-E004` "endpoint host must be a loopback address" |
| Unparsable endpoint URL | `JSP-E001` "endpoint not loopback" | `JSP-E001` "endpoint is not a valid URL" |
| Endpoint with query/fragment | `JSP-E001` "endpoint not loopback" | `JSP-E001` "endpoint must not include a query or fragment" |
| `lifecycle_generation: 0` | `JSP-E004` | `JSP-E004` (unchanged) |
| `lifecycle_generation: -1` | `JSP-E004` | `JSP-E001` |
| `http://127.0.0.1:9123?` / `...#` | **accepted** | `JSP-E001` "endpoint must not include a query or fragment" |

**The main thing for a reviewer to check** is the cross-repository reasoning below, since the issue flagged this as a change to a frozen protocol surface.

## Dive Deeper

### Why no `JSP-E007`, and why no Jefe change

The issue notes that the JSP/1 diagnostic surface is frozen and shared with the Jefe broker, so it should not be changed unilaterally. That coordination was done by reading the authority rather than assumed. Evidence from `llxprt-jefe` at `6b6d92896`:

- **The code set is closed at six members.** `dev-docs/jsp/v1/specification.md` §14 lists only `JSP-E001..JSP-E006`; `src/jsp/v1/error.rs` declares exactly six variants and notes that changing the wire strings requires a version bump; `tests/jsp_v1_snapshot_compliance.rs` pins all six. Adding a seventh code *would* be a protocol change — so this PR does not add one. The `JspErrorCode` union still has exactly six members.
- **§14 gives us enough to split within the set.** `JSP-E001` is "Closed JSON / syntax / shape violation"; `JSP-E004` is "Identity / **binding** violation". An unsupported scheme is a shape violation of the `endpoint` field — which is already how the *other* two malformed-endpoint branches in the same function are reported. Escaping loopback is the binding/security boundary and stays `JSP-E004`. `JSP-E003` is only "unsupported version or kind", so it is not a candidate.
- **Jefe never consumes this code.** `src/jsp_host/launch.rs` validates loopback itself and *writes* the bootstrap file; it never reads a rejection code back. Neither `dev-docs/jsp/v1/compliance/producer-contract.md` nor `src/bin/jefe-jsp-compliance.rs` asserts any bootstrap endpoint code. Every `JspCode` use in Jefe is on the broker's document-parsing path. llxprt's only consumer is `jspWiring.loadBootstrapFromEnv`, which formats the code into its own thrown `Error`.

So the split is faithful to the frozen contract, and **no Jefe-side change is required.**

### The `lifecycle_generation` case

The issue also named the non-positive `lifecycle_generation` mapping. This turned out to need splitting rather than either keeping or wholesale changing:

- Specification §2 says "`lifecycle_generation` must be positive (`>= 1`). **Zero** fails with `JSP-E004`." That mandates `JSP-E004` for zero specifically.
- The reference parser types the field `u64` (`src/jsp/v1/wire.rs:255`) and maps deserialization failures to `JSP-E001`, so a *negative* value is a shape violation in the oracle.

llxprt collapsed both onto `JSP-E004`. Now zero maps to `JSP-E004` (identity) and a negative maps to `JSP-E001` (outside the unsigned domain), matching the oracle. A non-integer such as `1.5` remains `JSP-E001` and is now pinned by a test.

Implementation note: the two rules are raised as separate issues via `superRefine`, which emits exactly one issue per value. An earlier `.min(0).refine(...)` formulation emitted *two* issues for a negative value and so depended on Zod reporting `too_small` before `custom` in `issues[0]`; that dependency on library-internal ordering is gone.

### The bare `?` / `#` hole (the one behavior change)

The guard that rejects a query or fragment tested `URL.search` and `URL.hash` against the empty string. Both report `''` for a *bare* trailing delimiter, while the delimiter still travels in the endpoint string:

    "http://127.0.0.1:9123?"   search="" hash=""  href=http://127.0.0.1:9123/?
    "http://127.0.0.1:9123#"   search="" hash=""  href=http://127.0.0.1:9123/#

Since `parseBootstrap` returns the **raw** endpoint rather than the normalized URL, `http://127.0.0.1:9123?` was accepted and then produced the request target `http://127.0.0.1:9123?/jsp/1` — the route segment folded into the query, so `register`, `publish`, and `heartbeat` all went to the wrong target. That is precisely what the guard's own comment says it exists to prevent.

The guard now compares the serialization against a copy with `search` and `hash` cleared, catching the bare and populated forms alike. Behavior verified identical in Node and Bun.

This is the only change to the accept/reject set. It closes a hole in the guard's existing intent rather than adding a new rule, which is why it is folded in here. Found by CodeRabbit on this PR; briefly tracked as #3027, now closed as delivered here.

### Privacy

All four endpoint messages are fixed string literals that never interpolate any part of the input, per the specification's rule that diagnostics never echo input values. A test asserts that a credential-bearing endpoint leaks neither the secret, the host, the scheme, nor the full endpoint into the message.

## Reviewer Test Plan

The change is a pure function, so it is easy to exercise directly:

    npx vitest run packages/cli/src/observation/jspSchema.test.ts
    bun test packages/cli/src/observation/jspSchema.test.ts

Both runners pass 25/25. To confirm the behavior by hand, point `LLXPRT_JSP_BOOTSTRAP_FILE` at a bootstrap JSON file and start the CLI; startup fails with the code in the message. Useful cases to try:

- `"endpoint": "ws://127.0.0.1:9123/jsp/1"` — now reports `JSP-E001` instead of claiming the endpoint is not loopback.
- `"endpoint": "http://192.168.1.5:9123/jsp/1"` — still `JSP-E004`, now with an accurate loopback message.
- `"lifecycle_generation": -1` — now `JSP-E001`; `0` is still `JSP-E004`.
- Any previously valid bootstrap — still accepted, unchanged.

Worth verifying specifically: that the accept/reject set moved **only** for the bare `?`/`#` case. The full pre-existing acceptance corpus (https on loopback, `localhost`, `app.localhost`, `[::1]`, `[0:0:0:0:0:0:0:1]`, `127.x` including zero-padded octets, and the `registration_id` UTF-8 byte-bound cases) is retained unmodified and still passes.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test`, `lint`, `lint:eslint-guard`, `typecheck`, `format`, `build`, and the profile smoke test. The change is platform-independent (pure schema validation), and the one WHATWG URL-parsing behavior it relies on was confirmed in both Node and Bun.

## Linked issues / bugs

Fixes #2912
Closes #3027

Found while reviewing #2897 (issue #2779), where it was deliberately deferred as a protocol-level change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootstrap validation messages for invalid endpoints and lifecycle generation values.
  * Added clearer handling for unsupported URL schemes and malformed endpoints.
  * Preserved specific diagnostics for loopback and rejected endpoints.
  * Updated validation to correctly accept valid positive and maximum-safe lifecycle generation values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
