### PR TITLE
fix(github): make unknown-parameter rejections self-correcting and declare threadId in the tool schema (Fixes #3019)

### DIFF
--- a/packages/providers/src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for issue #3019: unknown-parameter rejections are self-correcting.
+ *
+ * When a caller passes a parameter an operation does not accept (e.g.
+ * `number` on `pr.resolve-thread`), the broker must name the offending
+ * parameter AND the parameters the operation DOES accept, plus the required
+ * ones when the descriptor declares any. The old `Unknown parameter: <key>`
+ * message named only what was wrong, leaving the caller no recovery path —
+ * and when only `number` was supplied it actively hid the missing required
+ * `threadId`.
+ *
+ * These are behavioural tests driven through the real dispatch entry point
+ * and the real per-op validators. No mocks: validation runs before any `gh`
+ * process is spawned, so the dispatch tests never shell out.
+ *
+ * @plan issue-3019-github-unknown-parameter
+ * @requirement AB1
+ * @issue 3019
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { executeGitHubOp } from '../github-broker.js';
+import { validateResolveThreadParams } from '../github-broker-multistep-ops.js';
+import {
+  validateIssueListParams,
+  validateIssueViewParams,
+} from '../github-broker-issue-ops.js';
+
+/** Extracts a message from any thrown value without type assertions. */
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+describe('issue #3019: self-correcting unknown-parameter rejection', () => {
+  // ─── Dispatch path (validation before any gh spawn) ───────────────────
+
+  /**
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB1
+   * @issue 3019
+   */
+  it('executeGitHubOp pr.resolve-thread with number names accepted + required params', async () => {
+    const signal = new AbortController().signal;
+    let thrown: unknown = undefined;
+    try {
+      await executeGitHubOp(
+        'pr.resolve-thread',
+        { threadId: 'PRRT_x', number: 3018 },
+        signal,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    const message = errorMessage(thrown);
+    expect(message).toContain('Unknown parameter: number');
+    expect(message).toContain('Accepted parameters: threadId, repo');
+    expect(message).toContain('Required: threadId');
+  });
+
+  /**
+   * The case the old message actively hid: the caller passed only `number`,
+   * no `threadId`. The unknown-parameter check still runs first, and the new
+   * message reveals the required `threadId`.
+   *
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB1
+   * @issue 3019
+   */
+  it('executeGitHubOp pr.resolve-thread with number only still reveals the accepted params', async () => {
+    const signal = new AbortController().signal;
+    let thrown: unknown = undefined;
+    try {
+      await executeGitHubOp('pr.resolve-thread', { number: 3018 }, signal);
+    } catch (error) {
+      thrown = error;
+    }
+    const message = errorMessage(thrown);
+    expect(message).toContain('Unknown parameter: number');
+    expect(message).toContain('Accepted parameters: threadId, repo');
+    expect(message).toContain('Required: threadId');
+  });
+
+  // ─── Per-op validators ───────────────────────────────────────────────
+
+  /**
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB1
+   * @issue 3019
+   */
+  it('validateResolveThreadParams returns INVALID_PARAM listing accepted + required params', () => {
+    const result = validateResolveThreadParams({
+      threadId: 'PRRT_x',
+      number: 3018,
+    });
+    expect(result?.code).toBe('INVALID_PARAM');
+    expect(result?.message).toContain('Unknown parameter: number');
+    expect(result?.message).toContain('Accepted parameters: threadId, repo');
+    expect(result?.message).toContain('Required: threadId');
+  });
+
+  /**
+   * Ops that declare no required params list accepted params but NO
+   * `Required:` clause.
+   *
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB1
+   * @issue 3019
+   */
+  it('validateIssueListParams lists accepted params with no Required clause', () => {
+    const result = validateIssueListParams({ bogus: true });
+    expect(result?.code).toBe('INVALID_PARAM');
+    expect(result?.message).toContain(
+      'Accepted parameters: search, state, label, limit, repo',
+    );
+    expect(result?.message).not.toContain('Required:');
+  });
+
+  /**
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB1
+   * @issue 3019
+   */
+  it('validateIssueViewParams lists number, comments, repo', () => {
+    const result = validateIssueViewParams({
+      number: 135,
+      bogusParam: 'x',
+    });
+    expect(result?.code).toBe('INVALID_PARAM');
+    expect(result?.message).toContain(
+      'Accepted parameters: number, comments, repo',
+    );
+  });
+
+  // ─── Regression guards ───────────────────────────────────────────────
+
+  /**
+   * Valid params still validate to null; an invalid VALUE keeps its existing
+   * per-kind message and is NOT rewritten to the accepted-parameter message.
+   *
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB1
+   * @issue 3019
+   */
+  it('regression: valid pr.resolve-thread passes, and an invalid repo value keeps its own message', () => {
+    expect(
+      validateResolveThreadParams({
+        threadId: 'PRRT_x',
+        repo: 'owner/name',
+      }),
+    ).toBeNull();
+
+    const invalidValue = validateResolveThreadParams({
+      threadId: 'PRRT_x',
+      repo: 'not a repo',
+    });
+    expect(invalidValue?.code).toBe('INVALID_PARAM');
+    // The per-kind repo message must survive, not be replaced.
+    expect(invalidValue?.message).toContain('must be "owner/name"');
+    expect(invalidValue?.message).not.toContain('Accepted parameters');
+  });
+});

--- a/packages/providers/src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts
@@ -58,9 +58,9 @@ describe('issue #3019: self-correcting unknown-parameter rejection', () => {
       thrown = error;
     }
     const message = errorMessage(thrown);
-    expect(message).toContain('Unknown parameter: number');
-    expect(message).toContain('Accepted parameters: threadId, repo');
-    expect(message).toContain('Required: threadId');
+    expect(message).toBe(
+      'Unknown parameter: number. Accepted parameters: threadId, repo. Required: threadId.',
+    );
   });
 
   /**
@@ -81,9 +81,9 @@ describe('issue #3019: self-correcting unknown-parameter rejection', () => {
       thrown = error;
     }
     const message = errorMessage(thrown);
-    expect(message).toContain('Unknown parameter: number');
-    expect(message).toContain('Accepted parameters: threadId, repo');
-    expect(message).toContain('Required: threadId');
+    expect(message).toBe(
+      'Unknown parameter: number. Accepted parameters: threadId, repo. Required: threadId.',
+    );
   });
 
   // ─── Per-op validators ───────────────────────────────────────────────
@@ -99,9 +99,9 @@ describe('issue #3019: self-correcting unknown-parameter rejection', () => {
       number: 3018,
     });
     expect(result?.code).toBe('INVALID_PARAM');
-    expect(result?.message).toContain('Unknown parameter: number');
-    expect(result?.message).toContain('Accepted parameters: threadId, repo');
-    expect(result?.message).toContain('Required: threadId');
+    expect(result?.message).toBe(
+      'Unknown parameter: number. Accepted parameters: threadId, repo. Required: threadId.',
+    );
   });
 
   /**
@@ -115,10 +115,9 @@ describe('issue #3019: self-correcting unknown-parameter rejection', () => {
   it('validateIssueListParams lists accepted params with no Required clause', () => {
     const result = validateIssueListParams({ bogus: true });
     expect(result?.code).toBe('INVALID_PARAM');
-    expect(result?.message).toContain(
-      'Accepted parameters: search, state, label, limit, repo',
+    expect(result?.message).toBe(
+      'Unknown parameter: bogus. Accepted parameters: search, state, label, limit, repo.',
     );
-    expect(result?.message).not.toContain('Required:');
   });
 
   /**
@@ -163,5 +162,72 @@ describe('issue #3019: self-correcting unknown-parameter rejection', () => {
     // The per-kind repo message must survive, not be replaced.
     expect(invalidValue?.message).toContain('must be "owner/name"');
     expect(invalidValue?.message).not.toContain('Accepted parameters');
+  });
+});
+
+describe('issue #3019 (FIX 4): prototype-chain names are rejected, not accepted', () => {
+  // `constructor`, `toString` and `__proto__` are inherited from
+  // Object.prototype, so an `in`-operator unknown-key check would treat them
+  // as known and silently skip them. A valid `threadId` is included so the
+  // required-param check does not fire first — isolating the unknown-key
+  // rejection to the prototype name itself. Each must be rejected with
+  // INVALID_PARAM and the accepted-parameter message.
+
+  /**
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB1
+   * @issue 3019
+   */
+  it('rejects `constructor` as an unknown parameter', () => {
+    const result = validateResolveThreadParams({
+      threadId: 'PRRT_x',
+      constructor: 'x',
+    });
+    expect(result?.code).toBe('INVALID_PARAM');
+    expect(result?.message).toContain('Unknown parameter: constructor');
+    expect(result?.message).toContain('Accepted parameters: threadId, repo');
+  });
+
+  /**
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB1
+   * @issue 3019
+   */
+  it('rejects `toString` as an unknown parameter', () => {
+    const result = validateResolveThreadParams({
+      threadId: 'PRRT_x',
+      toString: 'x',
+    });
+    expect(result?.code).toBe('INVALID_PARAM');
+    expect(result?.message).toContain('Unknown parameter: toString');
+    expect(result?.message).toContain('Accepted parameters: threadId, repo');
+  });
+
+  /**
+   * `__proto__` must be a real own enumerable key to be observable: an object
+   * literal would mutate the prototype instead of creating an own property.
+   * `Object.defineProperty` creates a genuine own data property without
+   * changing the object's [[Prototype]], so the unknown-key check sees it.
+   *
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB1
+   * @issue 3019
+   */
+  it('rejects an own `__proto__` key as an unknown parameter', () => {
+    const params: Record<string, unknown> = { threadId: 'PRRT_x' };
+    Object.defineProperty(params, '__proto__', {
+      value: 'x',
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    // Guard: verify this really is an own key before asserting on it.
+    expect(Object.prototype.hasOwnProperty.call(params, '__proto__')).toBe(
+      true,
+    );
+    const result = validateResolveThreadParams(params);
+    expect(result?.code).toBe('INVALID_PARAM');
+    expect(result?.message).toContain('Unknown parameter: __proto__');
+    expect(result?.message).toContain('Accepted parameters: threadId, repo');
   });
 });

--- a/packages/providers/src/auth/proxy/github-broker-validation.ts
+++ b/packages/providers/src/auth/proxy/github-broker-validation.ts
@@ -80,7 +80,7 @@ export function validateParams(
     if (!(key in spec)) {
       return {
         code: 'INVALID_PARAM',
-        message: `Unknown parameter: ${key}`,
+        message: unknownParamMessage(key, spec, required),
       };
     }
   }
@@ -99,6 +99,37 @@ export function validateParams(
     if (err) return err;
   }
   return null;
+}
+
+/**
+ * Builds the self-correcting message for an unknown parameter.
+ *
+ * Names the offending parameter, the parameters the operation DOES accept
+ * (in the descriptor's declaration order, i.e. `Object.keys` of the spec),
+ * and — only when a non-empty `required` list was supplied — the required
+ * ones. The old `Unknown parameter: <key>` message named only what was
+ * wrong, leaving a caller no recovery path; for `pr.resolve-thread` called
+ * with only `number` it also hid the missing required `threadId`.
+ *
+ * Unknown parameters are still REJECTED, never accepted or ignored: the
+ * accepted-parameter text describes how to retry correctly, it does not
+ * broaden what the op accepts.
+ *
+ * @plan issue-3019-github-unknown-parameter
+ * @requirement AB1
+ * @issue 3019
+ */
+function unknownParamMessage(
+  key: string,
+  spec: Readonly<Record<string, ParamKind>>,
+  required: readonly string[] | undefined,
+): string {
+  const accepted = Object.keys(spec).join(', ');
+  const base = `Unknown parameter: ${key}. Accepted parameters: ${accepted}.`;
+  if (required !== undefined && required.length > 0) {
+    return `${base} Required: ${required.join(', ')}.`;
+  }
+  return base;
 }
 
 /**

--- a/packages/providers/src/auth/proxy/github-broker-validation.ts
+++ b/packages/providers/src/auth/proxy/github-broker-validation.ts
@@ -77,7 +77,13 @@ export function validateParams(
   required?: readonly string[],
 ): ValidationError | null {
   for (const key of Object.keys(params)) {
-    if (!(key in spec)) {
+    // `in` walks the prototype chain, so `{ constructor: 'x' }`,
+    // `{ toString: 'x' }` and an own `__proto__` key would all pass an
+    // unknown-key check here and then never reach the per-kind loop (which
+    // iterates the spec's own entries). `hasOwnProperty` restricts the check
+    // to the spec's own declared parameters, so prototype names are rejected
+    // like any other unknown parameter instead of being silently ignored.
+    if (!Object.prototype.hasOwnProperty.call(spec, key)) {
       return {
         code: 'INVALID_PARAM',
         message: unknownParamMessage(key, spec, required),

--- a/packages/tools/src/tools/github-unknown-param.bun.test.ts
+++ b/packages/tools/src/tools/github-unknown-param.bun.test.ts
@@ -31,9 +31,27 @@ function stubClient(): GitHubBrokerClient {
 }
 
 /**
- * Reads a single declared property's `type` and `description` via
- * `in`-operator narrowing — no type assertions, no `any`. Returns null when
- * the property is absent or the schema shape is unexpected.
+ * True when `container` declares `name` as its OWN property.
+ *
+ * `in` alone is what this PR removes from the broker's unknown-key check,
+ * because it walks the prototype chain — a schema that inherited
+ * `properties` or a property that inherited `description` would read as
+ * declared here. The `in` check is kept alongside it purely for type
+ * narrowing, which `hasOwnProperty` cannot provide.
+ */
+function declaresOwn<K extends string>(
+  container: object,
+  name: K,
+): container is Record<K, unknown> {
+  return (
+    Object.prototype.hasOwnProperty.call(container, name) && name in container
+  );
+}
+
+/**
+ * Reads a single declared property's `type` and `description` — own
+ * properties only, no type assertions, no `any`. Returns null when the
+ * property is absent or the schema shape is unexpected.
  */
 function propertyTypeAndDescription(
   tool: GithubTool,
@@ -41,15 +59,15 @@ function propertyTypeAndDescription(
 ): { type: unknown; description: string } | null {
   const schema: unknown = tool.parameterSchema;
   if (typeof schema !== 'object' || schema === null) return null;
-  if (!('properties' in schema)) return null;
+  if (!declaresOwn(schema, 'properties')) return null;
   const properties = schema.properties;
   if (typeof properties !== 'object' || properties === null) return null;
-  if (!(name in properties)) return null;
+  if (!declaresOwn(properties, name)) return null;
   const prop = properties[name];
   if (typeof prop !== 'object' || prop === null) return null;
-  const type = 'type' in prop ? prop.type : undefined;
+  const type = declaresOwn(prop, 'type') ? prop.type : undefined;
   const description =
-    'description' in prop && typeof prop.description === 'string'
+    declaresOwn(prop, 'description') && typeof prop.description === 'string'
       ? prop.description
       : '';
   return { type, description };

--- a/packages/tools/src/tools/github-unknown-param.bun.test.ts
+++ b/packages/tools/src/tools/github-unknown-param.bun.test.ts
@@ -33,19 +33,17 @@ function stubClient(): GitHubBrokerClient {
 /**
  * True when `container` declares `name` as its OWN property.
  *
- * `in` alone is what this PR removes from the broker's unknown-key check,
- * because it walks the prototype chain — a schema that inherited
- * `properties` or a property that inherited `description` would read as
- * declared here. The `in` check is kept alongside it purely for type
- * narrowing, which `hasOwnProperty` cannot provide.
+ * `in` is what this PR removes from the broker's unknown-key check, because
+ * it walks the prototype chain — a schema that inherited `properties`, or a
+ * property that inherited `description`, would read as declared here. The
+ * type predicate supplies the narrowing that `in` would otherwise be needed
+ * for, so the schema reads stay free of type assertions.
  */
 function declaresOwn<K extends string>(
   container: object,
   name: K,
 ): container is Record<K, unknown> {
-  return (
-    Object.prototype.hasOwnProperty.call(container, name) && name in container
-  );
+  return Object.prototype.hasOwnProperty.call(container, name);
 }
 
 /**

--- a/packages/tools/src/tools/github-unknown-param.bun.test.ts
+++ b/packages/tools/src/tools/github-unknown-param.bun.test.ts
@@ -8,11 +8,11 @@
  * Tests for issue #3019 (AB2): the `github` tool schema/description stops
  * implying `number` is universal.
  *
- * The description is shipped in every system prompt, so it must state that
- * parameters are per-operation, that an operation rejects parameters it does
- * not accept and names them, and that pr.resolve-thread is addressed by
- * threadId alone. The `number` property schema must likewise make clear it
- * only applies to operations that accept it.
+ * The schema ships in every system prompt, so its `properties` must declare
+ * `threadId` (the parameter `pr.resolve-thread` actually requires) and must
+ * not present `number` as universal. The assertions here are structural —
+ * they read the declared schema via `in`-operator narrowing, not substring
+ * matches on prose that would pass on main before the fix.
  *
  * @plan issue-3019-github-unknown-parameter
  * @requirement AB2
@@ -31,54 +31,85 @@ function stubClient(): GitHubBrokerClient {
 }
 
 /**
- * Reads the `number` property description from the tool's declared schema.
- * Narrows `unknown` without type assertions; returns '' when absent.
+ * Reads a single declared property's `type` and `description` via
+ * `in`-operator narrowing — no type assertions, no `any`. Returns null when
+ * the property is absent or the schema shape is unexpected.
  */
-function numberSchemaDescription(tool: GithubTool): string {
+function propertyTypeAndDescription(
+  tool: GithubTool,
+  name: string,
+): { type: unknown; description: string } | null {
   const schema: unknown = tool.parameterSchema;
-  if (typeof schema !== 'object' || schema === null) return '';
-  if (!('properties' in schema)) return '';
+  if (typeof schema !== 'object' || schema === null) return null;
+  if (!('properties' in schema)) return null;
   const properties = schema.properties;
-  if (typeof properties !== 'object' || properties === null) return '';
-  if (!('number' in properties)) return '';
-  const numberProp = properties.number;
-  if (typeof numberProp !== 'object' || numberProp === null) return '';
-  if (!('description' in numberProp)) return '';
-  const description = numberProp.description;
-  return typeof description === 'string' ? description : '';
+  if (typeof properties !== 'object' || properties === null) return null;
+  if (!(name in properties)) return null;
+  const prop = properties[name];
+  if (typeof prop !== 'object' || prop === null) return null;
+  const type = 'type' in prop ? prop.type : undefined;
+  const description =
+    'description' in prop && typeof prop.description === 'string'
+      ? prop.description
+      : '';
+  return { type, description };
 }
 
 describe('issue #3019 (AB2): github tool documents per-operation params', () => {
   /**
+   * Structural: `threadId` must be a declared property with `type: 'string'`,
+   * and its description must point back to `pr.reviews` as the source of the
+   * thread node id. On main `threadId` is not declared at all, so this fails
+   * there.
+   *
    * @plan issue-3019-github-unknown-parameter
    * @requirement AB2
    * @issue 3019
    */
-  it('description states pr.resolve-thread is addressed by threadId, not number', () => {
+  it('declares threadId as a string property sourced from pr.reviews', () => {
     const tool = new GithubTool(stubClient());
-    expect(tool.description).toContain('pr.resolve-thread');
-    expect(tool.description).toContain('threadId');
+    const threadId = propertyTypeAndDescription(tool, 'threadId');
+    expect(threadId).not.toBeNull();
+    if (threadId === null) return;
+    expect(threadId.type).toBe('string');
+    expect(threadId.description).toContain('pr.reviews');
   });
 
   /**
+   * Structural: the `number` property description must explicitly name
+   * `pr.resolve-thread` as an operation that does not take `number`. On main
+   * the description is "Issue or pull request number, for operations that
+   * take one." with no mention of `pr.resolve-thread`.
+   *
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB2
+   * @issue 3019
+   */
+  it('number schema description names pr.resolve-thread as not taking number', () => {
+    const tool = new GithubTool(stubClient());
+    const numberProp = propertyTypeAndDescription(tool, 'number');
+    expect(numberProp).not.toBeNull();
+    if (numberProp === null) return;
+    expect(numberProp.description.length).toBeGreaterThan(0);
+    expect(numberProp.description).toContain('pr.resolve-thread');
+  });
+
+  /**
+   * Prose assertion pinning the per-operation rejection rule in the Notes
+   * section, specific enough to fail on main (which has no such rule). The
+   * structural assertions above cannot cover a rule stated in free text.
+   *
    * @plan issue-3019-github-unknown-parameter
    * @requirement AB2
    * @issue 3019
    */
   it('description states operations reject parameters they do not accept', () => {
     const tool = new GithubTool(stubClient());
-    expect(tool.description).toContain('reject');
-  });
-
-  /**
-   * @plan issue-3019-github-unknown-parameter
-   * @requirement AB2
-   * @issue 3019
-   */
-  it('number schema description notes it is per-operation and may be rejected', () => {
-    const tool = new GithubTool(stubClient());
-    const description = numberSchemaDescription(tool);
-    expect(description.length).toBeGreaterThan(0);
-    expect(description).toContain('rejects');
+    // Collapse whitespace so the assertion is robust to line wrapping in the
+    // template literal; the clause itself is what is pinned.
+    const normalized = tool.description.replace(/\s+/g, ' ');
+    expect(normalized).toContain(
+      'an operation rejects any parameter it does not accept and names the accepted ones in the error',
+    );
   });
 });

--- a/packages/tools/src/tools/github-unknown-param.bun.test.ts
+++ b/packages/tools/src/tools/github-unknown-param.bun.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for issue #3019 (AB2): the `github` tool schema/description stops
+ * implying `number` is universal.
+ *
+ * The description is shipped in every system prompt, so it must state that
+ * parameters are per-operation, that an operation rejects parameters it does
+ * not accept and names them, and that pr.resolve-thread is addressed by
+ * threadId alone. The `number` property schema must likewise make clear it
+ * only applies to operations that accept it.
+ *
+ * @plan issue-3019-github-unknown-parameter
+ * @requirement AB2
+ * @issue 3019
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { GithubTool, type GitHubBrokerClient } from './github.js';
+
+function stubClient(): GitHubBrokerClient {
+  return {
+    async runOperation() {
+      return { ok: true };
+    },
+  };
+}
+
+/**
+ * Reads the `number` property description from the tool's declared schema.
+ * Narrows `unknown` without type assertions; returns '' when absent.
+ */
+function numberSchemaDescription(tool: GithubTool): string {
+  const schema: unknown = tool.parameterSchema;
+  if (typeof schema !== 'object' || schema === null) return '';
+  if (!('properties' in schema)) return '';
+  const properties = schema.properties;
+  if (typeof properties !== 'object' || properties === null) return '';
+  if (!('number' in properties)) return '';
+  const numberProp = properties.number;
+  if (typeof numberProp !== 'object' || numberProp === null) return '';
+  if (!('description' in numberProp)) return '';
+  const description = numberProp.description;
+  return typeof description === 'string' ? description : '';
+}
+
+describe('issue #3019 (AB2): github tool documents per-operation params', () => {
+  /**
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB2
+   * @issue 3019
+   */
+  it('description states pr.resolve-thread is addressed by threadId, not number', () => {
+    const tool = new GithubTool(stubClient());
+    expect(tool.description).toContain('pr.resolve-thread');
+    expect(tool.description).toContain('threadId');
+  });
+
+  /**
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB2
+   * @issue 3019
+   */
+  it('description states operations reject parameters they do not accept', () => {
+    const tool = new GithubTool(stubClient());
+    expect(tool.description).toContain('reject');
+  });
+
+  /**
+   * @plan issue-3019-github-unknown-parameter
+   * @requirement AB2
+   * @issue 3019
+   */
+  it('number schema description notes it is per-operation and may be rejected', () => {
+    const tool = new GithubTool(stubClient());
+    const description = numberSchemaDescription(tool);
+    expect(description.length).toBeGreaterThan(0);
+    expect(description).toContain('rejects');
+  });
+});

--- a/packages/tools/src/tools/github.ts
+++ b/packages/tools/src/tools/github.ts
@@ -174,6 +174,9 @@ Examples:
   { "op": "pr.checks", "number": 2317, "watch": true }
 
 Notes:
+- Parameters are per-operation: an operation rejects any parameter it does
+  not accept and names the accepted ones in the error. pr.resolve-thread
+  identifies its target by threadId alone (no number).
 - pr.reviews with actionable:true omits resolved and outdated threads, leaving
   only review comments that still need action. The returned thread id is what
   pr.resolve-thread takes, so the two compose.
@@ -200,7 +203,9 @@ const PARAMETER_SCHEMA = {
     number: {
       type: 'number',
       description:
-        'Issue or pull request number, for operations that take one.',
+        'Issue or pull request number, but only for operations whose ' +
+        'parameter list includes it. An operation that does not accept ' +
+        'number rejects it and names the parameters it does accept.',
     },
   },
   required: ['op'],

--- a/packages/tools/src/tools/github.ts
+++ b/packages/tools/src/tools/github.ts
@@ -147,6 +147,7 @@ export interface GithubToolParams {
   op: string;
   repo?: string;
   number?: number;
+  threadId?: string;
   [key: string]: unknown;
 }
 
@@ -204,8 +205,15 @@ const PARAMETER_SCHEMA = {
       type: 'number',
       description:
         'Issue or pull request number, but only for operations whose ' +
-        'parameter list includes it. An operation that does not accept ' +
-        'number rejects it and names the parameters it does accept.',
+        'parameter list includes it. pr.resolve-thread does not take number ' +
+        '(use threadId); any operation that does not accept number rejects ' +
+        'it and names the parameters it does accept.',
+    },
+    threadId: {
+      type: 'string',
+      description:
+        'Review-thread node id returned by pr.reviews; pr.resolve-thread ' +
+        'identifies its target with this rather than a pull request number.',
     },
   },
   required: ['op'],

--- a/project-plans/issue-3019-github-unknown-parameter/plan.md
+++ b/project-plans/issue-3019-github-unknown-parameter/plan.md
@@ -1,0 +1,114 @@
+# Issue #3019 — `pr.resolve-thread` rejects `number` with a dead-end error
+
+## Problem
+
+Calling the `github` tool as:
+
+    { "op": "pr.resolve-thread", "threadId": "PRRT_...", "number": 3018 }
+
+fails with:
+
+    GitHub operation failed: Unknown parameter: number
+
+`resolveReviewThread` takes only a thread node id, so `pr.resolve-thread`'s
+descriptor (`packages/providers/src/auth/proxy/github-broker-multistep-ops.ts`)
+accepts exactly `threadId` and `repo`. The broker's strict validation
+(`github-broker-validation.ts`) rejects any parameter outside that set — which
+is the documented and correct invariant
+(`project-plans/20260731-gh-sandbox-broker/analysis/pseudocode/003-github-broker.md`
+line 30: "Unknown parameters are REJECTED, not ignored (fail fast)").
+
+Two things combine to make this a dead end for a model:
+
+1. **The tool schema advertises `number` globally.** `PARAMETER_SCHEMA` in
+   `packages/tools/src/tools/github.ts` documents exactly three properties —
+   `op`, `repo`, `number` — with `additionalProperties: true`. `number` is
+   described as "Issue or pull request number, for operations that take one",
+   with nothing anywhere saying which operations those are. Supplying the PR
+   number for a PR-scoped operation is the natural reading.
+2. **The rejection carries no recovery information.** `Unknown parameter:
+   number` names only what is wrong, never what is right. A caller that passed
+   only `number` (no `threadId`) gets the same message, which hides the real
+   problem — the missing `threadId` — completely.
+
+In the reported session the model abandoned the tool and issued a raw
+`gh api graphql` mutation instead.
+
+## Accepted behaviour
+
+**AB1 — Unknown-parameter rejections are self-correcting.**
+When an operation is called with a parameter its descriptor does not accept,
+the `INVALID_PARAM` message names the offending parameter *and* the parameters
+that operation does accept, in descriptor declaration order, plus its required
+parameters when the descriptor declares any. For issue #3019 the message
+becomes:
+
+    Unknown parameter: number. Accepted parameters: threadId, repo. Required: threadId.
+
+**AB2 — The tool schema stops implying `number` is universal.**
+The `github` tool's `number` schema description and its prose description state
+that parameters are per-operation, that an operation rejects parameters it does
+not accept and names the ones it does, and that `pr.resolve-thread` identifies
+its target by `threadId` alone.
+
+Behaviour NOT changed (deliberate): `pr.resolve-thread` continues to REJECT
+`number` rather than accepting and ignoring it. Silently ignoring unknown
+parameters is explicitly forbidden by the broker's design (a typo must not
+produce a different query than the caller intended), and `number` is genuinely
+meaningless to `resolveReviewThread`.
+
+## Inputs and boundary cases
+
+| Case | Expected |
+| --- | --- |
+| `pr.resolve-thread` + `{threadId, number}` | `INVALID_PARAM`; message lists `threadId, repo` and `Required: threadId` |
+| `pr.resolve-thread` + `{number}` only | Same message — the unknown-parameter check runs first, and the message reveals the required `threadId` |
+| Op whose descriptor declares no `requiredParams` (e.g. `issue.list`) | Message lists accepted parameters, and has NO `Required:` clause |
+| Multiple unknown parameters | First unknown key in insertion order reported (unchanged) |
+| Known parameter with an invalid value | Existing per-kind messages unchanged |
+| Valid parameters | Still validate to `null`; no gh invocation behaviour changes |
+| Unknown *operation* | Still `UNKNOWN_OP`, unchanged |
+
+Accepted-parameter order is the descriptor's declaration order (`Object.keys`
+of the param spec), which is deterministic and puts the operation's primary
+parameter first.
+
+## Tests that prove it (written first, Bun + `bun:test`)
+
+New file: `packages/providers/src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts`,
+registered in `scripts/bun-test-manifest.ts` under the `providers` workspace.
+
+1. `executeGitHubOp('pr.resolve-thread', { threadId, number })` rejects with a
+   message containing `Unknown parameter: number`, `Accepted parameters:
+   threadId, repo` and `Required: threadId` — driven through the real dispatch
+   path, which validates before any `gh` process is spawned.
+2. `executeGitHubOp('pr.resolve-thread', { number })` (no `threadId`) produces
+   the same self-correcting message.
+3. `validateResolveThreadParams({ threadId, number })` returns
+   `code === 'INVALID_PARAM'` with the accepted-parameter list.
+4. `validateIssueListParams({ bogus: true })` lists `search, state, label,
+   limit, repo` and contains no `Required:` clause.
+5. `validateIssueViewParams({ number, bogusParam })` lists `number, comments,
+   repo`.
+6. Regression guards: a valid `pr.resolve-thread` param set still validates to
+   `null`; an invalid *value* (e.g. `repo: 'not-a-repo'`) still yields its
+   existing message and is not rewritten.
+7. The `github` tool's declared schema/description documents the per-operation
+   parameter rule and that `pr.resolve-thread` is addressed by `threadId`
+   rather than `number` (AB2).
+
+## Files in scope
+
+- `packages/providers/src/auth/proxy/github-broker-validation.ts` (AB1)
+- `packages/tools/src/tools/github.ts` (AB2)
+- `packages/providers/src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts` (new)
+- `scripts/bun-test-manifest.ts` (register the new test)
+
+## Out of scope
+
+- Accepting or ignoring `number` on `pr.resolve-thread`.
+- Reworking the per-op bespoke `Parameter number is required` pre-checks in
+  `pr.view` / `pr.checks` / `pr.reviews` / `issue.view` into `requiredParams`.
+- Generating a full per-operation parameter table into the tool description
+  (would duplicate the broker registry across a deliberate package boundary).
+- Any other operation's parameter set.

--- a/project-plans/issue-3019-github-unknown-parameter/plan.md
+++ b/project-plans/issue-3019-github-unknown-parameter/plan.md
@@ -45,11 +45,24 @@ becomes:
 
     Unknown parameter: number. Accepted parameters: threadId, repo. Required: threadId.
 
-**AB2 — The tool schema stops implying `number` is universal.**
-The `github` tool's `number` schema description and its prose description state
-that parameters are per-operation, that an operation rejects parameters it does
-not accept and names the ones it does, and that `pr.resolve-thread` identifies
-its target by `threadId` alone.
+**AB2 — The tool schema declares `threadId` and stops implying `number` is universal.**
+`PARAMETER_SCHEMA.properties` declares a `threadId` property (`type: 'string'`)
+whose description states it is the review-thread node id returned by
+`pr.reviews` and that `pr.resolve-thread` identifies its target with it rather
+than a pull request number. The `number` property description explicitly names
+`pr.resolve-thread` as an operation that does not take `number`. The prose
+description states that parameters are per-operation, that an operation rejects
+parameters it does not accept and names the ones it does, and that
+`pr.resolve-thread` identifies its target by `threadId` alone.
+
+**AB3 — Unknown-key detection ignores the prototype chain.**
+`validateParams` rejects an unknown parameter with
+`Object.prototype.hasOwnProperty.call(spec, key)` rather than `key in spec`.
+Because `in` walks the prototype chain, `constructor`, `toString` and an own
+`__proto__` key — all inherited from `Object.prototype` — previously passed the
+unknown-key check and were then never reached by the per-kind loop (which
+iterates the spec's own entries). They are now rejected as unknown, closing the
+gap that silently contradicted the "unknown parameters are REJECTED" invariant.
 
 Behaviour NOT changed (deliberate): `pr.resolve-thread` continues to REJECT
 `number` rather than accepting and ignoring it. Silently ignoring unknown
@@ -93,16 +106,28 @@ registered in `scripts/bun-test-manifest.ts` under the `providers` workspace.
 6. Regression guards: a valid `pr.resolve-thread` param set still validates to
    `null`; an invalid *value* (e.g. `repo: 'not-a-repo'`) still yields its
    existing message and is not rewritten.
-7. The `github` tool's declared schema/description documents the per-operation
-   parameter rule and that `pr.resolve-thread` is addressed by `threadId`
-   rather than `number` (AB2).
+7. The `github` tool's declared schema structurally declares a `threadId`
+   string property whose description references `pr.reviews`, the `number`
+   property description names `pr.resolve-thread`, and the prose Notes state
+   the per-operation rejection rule (AB2). Assertions read the schema via
+   `in`-operator narrowing with no type assertions; a substring-only version
+   is rejected as tautological.
+8. `constructor`, `toString` and an own `__proto__` key (built with
+   `Object.defineProperty` so it is a real own enumerable key) are each
+   rejected by `validateResolveThreadParams` with `INVALID_PARAM` and the
+   accepted-parameter message (AB3).
+9. The exact unknown-parameter message — `Unknown parameter: number.
+   Accepted parameters: threadId, repo. Required: threadId.` — is pinned with
+   `toBe` for the two dispatch cases and the `validateResolveThreadParams`
+   case, and the no-required case pins its full message too (AB1).
 
 ## Files in scope
 
-- `packages/providers/src/auth/proxy/github-broker-validation.ts` (AB1)
+- `packages/providers/src/auth/proxy/github-broker-validation.ts` (AB1, AB3)
 - `packages/tools/src/tools/github.ts` (AB2)
-- `packages/providers/src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts` (new)
-- `scripts/bun-test-manifest.ts` (register the new test)
+- `packages/providers/src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts` (new; AB1, AB3)
+- `packages/tools/src/tools/github-unknown-param.bun.test.ts` (new; AB2)
+- `scripts/bun-test-manifest.ts` and `scripts/bun-test-manifest-data-tools.ts` (register the new tests)
 
 ## Out of scope
 

--- a/scripts/bun-test-manifest-data-tools.ts
+++ b/scripts/bun-test-manifest-data-tools.ts
@@ -19,6 +19,7 @@ export const TOOLS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
     'src/tools/exa-web-search.test.ts',
     'src/tools/direct-web-fetch.test.ts',
     'src/tools/github.test.ts',
+    'src/tools/github-unknown-param.bun.test.ts',
     'src/tools/check-async-tasks.test.ts',
     'src/tools/list-subagents.test.ts',
     'src/tools/codesearch.test.ts',

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -401,6 +401,7 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       'src/auth/proxy/__tests__/github-broker-p10.test.ts',
       'src/auth/proxy/__tests__/github-broker-p10b.test.ts',
       'src/auth/proxy/__tests__/github-broker-security.test.ts',
+      'src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts',
       'src/auth/proxy/__tests__/github-broker-watch.test.ts',
       'src/auth/proxy/__tests__/github-broker-write-ops.test.ts',
       'src/auth/proxy/__tests__/github-broker.test.ts',


### PR DESCRIPTION
## TLDR

Calling the `github` tool with `pr.resolve-thread` and a pull request `number` failed with a bare `Unknown parameter: number` and no way forward, so the model in #3019 abandoned the tool and issued a raw `gh api graphql` mutation instead.

Two things caused it, and both are fixed:

1. The rejection named only what was wrong, never what was right. It now names the parameters the operation does accept and its required ones:

       Unknown parameter: number. Accepted parameters: threadId, repo. Required: threadId.

2. The tool's JSON schema declared `op`, `repo` and `number` — and not `threadId`. The one parameter `pr.resolve-thread` actually needs was invisible to a model reading the schema, while the parameter it rejects was advertised. `threadId` is now a declared string property, and the `number` description names `pr.resolve-thread` as an operation that does not take one.

`pr.resolve-thread` still **rejects** `number` rather than accepting and ignoring it: `resolveReviewThread` consumes only a thread node id, and the broker's design requires unknown parameters to fail fast so a typo cannot silently produce a different query than the caller intended.

## Dive Deeper

**Why not just accept `number` and ignore it?**
`003-github-broker.md` line 30 is explicit: "Unknown parameters are REJECTED, not ignored (fail fast). A typo must not silently produce a different query than the caller intended." Accepting `number` would trade a recoverable error for a silent one across every operation. The right fix is to make the rejection carry enough information to retry, and to stop the schema from inviting the mistake in the first place.

**The self-correcting message** (`github-broker-validation.ts`). `validateParams` already receives the operation's param spec and, via `executeGitHubOp`, its `requiredParams`. The unknown-key branch now builds its message from both. Accepted parameters are listed in descriptor declaration order (`Object.keys` of the spec), which is deterministic and puts the operation's primary parameter first. The `Required:` clause appears only when the descriptor declares required parameters.

This also fixes a case the old message actively hid: a caller passing only `number` and no `threadId` got `Unknown parameter: number`, which said nothing about the missing required parameter. The unknown-key check still runs first, but the message now reveals `threadId` either way.

**Prototype-chain hole in the same check.** The unknown-key test was `key in spec`, and `in` walks the prototype chain — so `{ constructor: 'x' }`, `{ toString: 'x' }` and an own `__proto__` key all passed as "known" and were then never validated, because the per-kind loop iterates the spec's own entries. They were silently ignored, which is exactly what this function exists to prevent. The check now uses `Object.prototype.hasOwnProperty.call(spec, key)`. No exploit path existed (builders read named parameters, so the ignored values never reached argv), but the invariant was not actually holding.

**Schema and description** (`packages/tools/src/tools/github.ts`). `threadId?: string` was added to `GithubToolParams` and a `threadId` property to `PARAMETER_SCHEMA`, described as the review-thread node id returned by `pr.reviews`. The `number` description now names `pr.resolve-thread` explicitly, and one Notes bullet states the per-operation rule. Both additions were kept short — this description ships in every system prompt.

**Deliberately out of scope:** the bespoke `Parameter number is required` pre-checks in `issue.view` / `pr.view` / `pr.diff` / `pr.checks` / `pr.reviews` order their messages differently from descriptor dispatch. The model-facing path goes through `executeGitHubOp`, which uses `requiredParams` directly and is unaffected, so that inconsistency is left alone rather than refactored here.

Planning notes: `project-plans/issue-3019-github-unknown-parameter/plan.md`.

## Reviewer Test Plan

Behavioural checks, no repository is mutated:

    cd packages/providers && bun test src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts
    cd packages/tools     && bun test src/tools/github-unknown-param.bun.test.ts

Both new files are registered in the Bun manifest (`scripts/bun-test-manifest.ts` for providers, `scripts/bun-test-manifest-data-tools.ts` for tools), so CI runs them.

To see the change end to end, ask an agent to resolve a review thread and pass a PR number alongside the thread id — for example a prompt like "resolve thread PRRT_xxxx on PR 3018 using the github tool". Before this change the call dead-ended at `Unknown parameter: number`; now the error names `threadId` and `repo`, and the model can retry successfully in the next turn. Reading the tool's schema (`/tools` or any tool-listing view) should also show `threadId` as a declared parameter.

Regression surface worth a look: every operation's unknown-parameter message changed text, so any consumer matching on the old exact string would notice. Existing broker suites assert on the `INVALID_PARAM` code rather than the message and still pass (566 tests across the proxy test directory).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run typecheck`, `npm run lint`, `npm run lint:eslint-guard`, `npm run build`, `npm run test` (all workspaces, 0 failures), `npm run format`, and the CLI smoke test (`bun scripts/start.ts --profile-load stepfun-37`).

## Linked issues / bugs

Fixes #3019


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `threadId` support for GitHub operations.
  * Clarified operation-specific parameter requirements and supported inputs.
  * Improved error messages to show invalid, accepted, and required parameters.

* **Bug Fixes**
  * Prevented prototype-chain names such as `constructor`, `toString`, and `__proto__` from being accepted as valid parameters.
  * Preserved existing validation errors for invalid parameter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->