### PR TITLE
Warn when PATH Bun cannot hold Keychain grants (Fixes #3021)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -129,6 +129,44 @@ llxprt --provider xai --key-name xai-prod
 - **Linux containers:** Same situation. Use `--keyfile` or `--key` if the encrypted fallback doesn't work.
 - **macOS:** Keychain should work out of the box. If not, check `security list-keychains` in Terminal.
 
+#### macOS: Repeated Keychain Password Prompts (Ad-hoc / Unsigned Bun)
+
+On macOS, the launcher prefers a Bun already on `PATH` when it meets the pinned version floor (so npm re-installs do not unlink a running session — see [#2962](https://github.com/vybestack/llxprt-code/issues/2962)). But on macOS the **code signature** of that binary decides whether it can hold a durable Keychain grant, and a Bun that is ad-hoc signed or otherwise lacks a stable team identity (for example the Homebrew `homebrew/core` formula, which compiles from source and discards Oven's Developer ID) cannot.
+
+The launcher inspects the selected Bun's designated code-signing requirement on startup and prints a single advisory warning to stderr when a successful inspection carries no team-identity clause (`certificate leaf[subject.OU]`), for example:
+
+```
+LLxprt Code: the Bun on your PATH is ad-hoc signed or otherwise
+lacks a stable team identity, so it cannot hold a persistent macOS
+Keychain grant. You will be prompted for your login password on every
+credential read, and "Always Allow" will not persist (#3020).
+Install the official Bun release signed by Oven:
+    brew uninstall bun && brew install oven-sh/bun/bun
+    curl -fsSL https://bun.com/install | bash
+```
+
+**Why "Always Allow" does not work:** the Keychain ACL stored on each item is identity-based, so it matches any Oven-signed Bun anywhere on disk. A binary that is ad-hoc signed or has no team ID can never satisfy that requirement. Per [#3020](https://github.com/vybestack/llxprt-code/issues/3020), `change_acl` on these items has an empty application list, so clicking **Always Allow** is silently discarded — the prompt recurs on every credential read. Replacing the binary with Oven's signed build is the only durable fix.
+
+**Why it is a warning, not a hard failure:** a Bun that is ad-hoc signed or has no team identity runs LLxprt Code correctly in every respect except Keychain access, and some users keep no credentials in the Keychain at all. Failing closed would break those working setups. Skipping it and falling through to the bundled Bun would silently re-enable the npm-unlink failure mode that #2962 exists to prevent, so the launcher warns and continues to use the selected Bun.
+
+To install an Oven-signed Bun (either remedy clears the warning):
+
+```bash
+# Homebrew: use the official oven-sh tap instead of homebrew/core
+brew uninstall bun && brew install oven-sh/bun/bun
+
+# Or the official installer
+curl -fsSL https://bun.com/install | bash
+```
+
+Verify the team identity afterward (it should report `7FRXF46ZSN`):
+
+```bash
+codesign -dv --requirements - "$(command -v bun)" 2>&1
+```
+
+This check is macOS-only; Linux and Windows never key credential access on code identity.
+
 ### Common Authentication Errors
 
 **`Failed to login. Message: Request contains an invalid argument`**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -133,9 +133,9 @@ llxprt --provider xai --key-name xai-prod
 
 On macOS, the launcher prefers a Bun already on `PATH` when it meets the pinned version floor (so npm re-installs do not unlink a running session — see [#2962](https://github.com/vybestack/llxprt-code/issues/2962)). But on macOS the **code signature** of that binary decides whether it can hold a durable Keychain grant, and a Bun that is ad-hoc signed or otherwise lacks a stable team identity (for example the Homebrew `homebrew/core` formula, which compiles from source and discards Oven's Developer ID) cannot.
 
-The launcher inspects the selected Bun's designated code-signing requirement on startup and prints a single advisory warning to stderr when a successful inspection carries no team-identity clause (`certificate leaf[subject.OU]`), for example:
+The launcher inspects the selected Bun's designated code-signing requirement on startup and prints a single advisory warning to stderr when codesign inspection fails OR when a successful inspection lacks Oven's required team identity (`certificate leaf[subject.OU] = "7FRXF46ZSN"`), for example:
 
-```
+```text
 LLxprt Code: the Bun on your PATH is ad-hoc signed or otherwise
 lacks a stable team identity, so it cannot hold a persistent macOS
 Keychain grant. You will be prompted for your login password on every

--- a/packages/cli/bin/llxprt
+++ b/packages/cli/bin/llxprt
@@ -329,20 +329,24 @@ if [ "$_llxprt_kernel" = "Darwin" ] && [ -n "$_llxprt_bun_pin" ]; then
     # identity-based macOS Keychain ACL, so every credential read degrades to a
     # login-password prompt that "Always Allow" cannot persist (#3020 sealed
     # change_acl with an empty application list). Inspect the designated
-    # requirement of the exact binary selected and warn once when it carries no
-    # team-identity clause (certificate leaf[subject.OU]). The warning is
-    # advisory: a Bun that is ad-hoc signed or has no team identity runs llxprt
-    # correctly except for Keychain access, and skipping it would silently
-    # restore the npm-unlink failure mode #2962 exists to prevent.
+    # requirement of the exact binary selected and warn once unless it carries
+    # Oven's exact team-identity clause (certificate leaf[subject.OU] =
+    # "7FRXF46ZSN"), which is the OU stored in the existing Keychain ACL. The
+    # warning is advisory: a Bun that is ad-hoc signed or has no team identity
+    # runs llxprt correctly except for Keychain access, and skipping it would
+    # silently restore the npm-unlink failure mode #2962 exists to prevent.
     if _llxprt_path_bun_exe=$(command -v bun 2>/dev/null) && \
        [ -n "$_llxprt_path_bun_exe" ]; then
       # Suppress the warning only when codesign succeeds AND its output carries
-      # the team-identity clause. A failing codesign (unsigned binary, or an
-      # error whose diagnostic merely echoes the clause) must still warn.
+      # Oven's exact team-identity clause. A failing codesign (unsigned binary,
+      # or an error whose diagnostic merely echoes the clause), or a successful
+      # inspection signed by any other team, must still warn — the Keychain ACL
+      # stores Oven's OU (7FRXF46ZSN) and only a binary signed by that exact
+      # team can satisfy it.
       _llxprt_has_team_id=0
       if _llxprt_dr=$(codesign -d --requirements - "$_llxprt_path_bun_exe" 2>&1); then
         case "$_llxprt_dr" in
-          *certificate\ leaf\[subject.OU]*) _llxprt_has_team_id=1 ;;
+          *certificate\ leaf\[subject.OU]\ =\ \"7FRXF46ZSN\"*) _llxprt_has_team_id=1 ;;
           *) ;;
         esac
       fi

--- a/packages/cli/bin/llxprt
+++ b/packages/cli/bin/llxprt
@@ -325,6 +325,36 @@ if [ "$_llxprt_kernel" = "Darwin" ] && [ -n "$_llxprt_bun_pin" ]; then
   if _llxprt_path_bun_version=$(bun --version 2>/dev/null) && \
      [ -n "$_llxprt_path_bun_version" ] && \
      _llxprt_version_ge "$_llxprt_path_bun_version" "$_llxprt_bun_pin"; then
+    # Issue #3021: an ad-hoc or cdhash-only signed PATH Bun cannot satisfy the
+    # identity-based macOS Keychain ACL, so every credential read degrades to a
+    # login-password prompt that "Always Allow" cannot persist (#3020 sealed
+    # change_acl with an empty application list). Inspect the designated
+    # requirement of the exact binary selected and warn once when it carries no
+    # team-identity clause (certificate leaf[subject.OU]). The warning is
+    # advisory: a Bun that is ad-hoc signed or has no team identity runs llxprt
+    # correctly except for Keychain access, and skipping it would silently
+    # restore the npm-unlink failure mode #2962 exists to prevent.
+    if _llxprt_path_bun_exe=$(command -v bun 2>/dev/null) && \
+       [ -n "$_llxprt_path_bun_exe" ]; then
+      # Suppress the warning only when codesign succeeds AND its output carries
+      # the team-identity clause. A failing codesign (unsigned binary, or an
+      # error whose diagnostic merely echoes the clause) must still warn.
+      _llxprt_has_team_id=0
+      if _llxprt_dr=$(codesign -d --requirements - "$_llxprt_path_bun_exe" 2>&1); then
+        case "$_llxprt_dr" in
+          *certificate\ leaf\[subject.OU]*) _llxprt_has_team_id=1 ;;
+        esac
+      fi
+      if [ "$_llxprt_has_team_id" -eq 0 ]; then
+        printf '%s\n' 'LLxprt Code: the Bun on your PATH is ad-hoc signed or otherwise' >&2
+        printf '%s\n' 'lacks a stable team identity, so it cannot hold a persistent macOS' >&2
+        printf '%s\n' 'Keychain grant. You will be prompted for your login password on every' >&2
+        printf '%s\n' 'credential read, and "Always Allow" will not persist (#3020).' >&2
+        printf '%s\n' 'Install the official Bun release signed by Oven:' >&2
+        printf '%s\n' '    brew uninstall bun && brew install oven-sh/bun/bun' >&2
+        printf '%s\n' '    curl -fsSL https://bun.com/install | bash' >&2
+      fi
+    fi
     exec bun "$_llxprt_entry" "$@"
   fi
 fi

--- a/packages/cli/bin/llxprt
+++ b/packages/cli/bin/llxprt
@@ -343,6 +343,7 @@ if [ "$_llxprt_kernel" = "Darwin" ] && [ -n "$_llxprt_bun_pin" ]; then
       if _llxprt_dr=$(codesign -d --requirements - "$_llxprt_path_bun_exe" 2>&1); then
         case "$_llxprt_dr" in
           *certificate\ leaf\[subject.OU]*) _llxprt_has_team_id=1 ;;
+          *) ;;
         esac
       fi
       if [ "$_llxprt_has_team_id" -eq 0 ]; then

--- a/project-plans/issue3021/PLAN.md
+++ b/project-plans/issue3021/PLAN.md
@@ -1,0 +1,71 @@
+# PLAN-20260804-ISSUE3021 — Diagnose ad-hoc PATH Bun on macOS
+
+Issue: #3021 — macOS launcher should warn when the selected PATH Bun is ad-hoc signed
+
+## Accepted behavior
+
+1. When the POSIX launcher is running on Darwin and the existing #2962 version gate selects a Bun from `PATH`, inspect that exact executable's designated code-signing requirement before `exec`.
+2. Treat a requirement containing a certificate team-identity clause (`certificate leaf[subject.OU]`) as identity-based. Continue without a warning; this includes Oven-signed Bun.
+3. If the requirement is ad-hoc, cdhash-only, unsigned, or otherwise contains no team-identity clause, emit one warning block to stderr. The warning explains the repeated macOS Keychain password prompts, states that “Always Allow” will not persist, and names both supported remedies:
+   - `brew uninstall bun && brew install oven-sh/bun/bun`
+   - `curl -fsSL https://bun.com/install | bash`
+4. The warning is advisory. The selected PATH Bun must still receive the entry path and user arguments and be executed normally.
+5. Do not inspect signatures or emit this warning outside Darwin. Existing Linux and Windows runtime selection remains unchanged.
+6. Document the warning and remedies in the macOS Keychain recovery guidance, including why #3020 makes “Always Allow” ineffective.
+
+## Decision: warn, do not skip
+
+The launcher will not skip an ad-hoc PATH Bun and will not fail startup. An ad-hoc Bun is valid for users who do not access Keychain credentials, while falling through to the bundled Bun would silently restore the npm-unlink failure mode that #2962 avoids. This issue therefore adds diagnosis and recovery guidance only.
+
+## Relevant inputs and boundaries
+
+| Input | Accepted result |
+| --- | --- |
+| Darwin; PATH Bun meets pinned version; designated requirement has Oven's `certificate leaf[subject.OU]` clause | Execute PATH Bun with no ad-hoc warning |
+| Darwin; PATH Bun meets pinned version; designated requirement is cdhash-only | Emit one actionable warning, then execute PATH Bun |
+| Darwin; PATH Bun meets pinned version; signature inspection reports unsigned/no team identity | Emit one actionable warning, then execute PATH Bun |
+| Darwin; PATH Bun is below the pinned version or pin is unavailable | Preserve existing bundled-Bun fallback; no PATH-Bun signature inspection requirement |
+| Linux or Windows-equivalent kernel result | No signature inspection and no ad-hoc warning |
+| User arguments contain spaces, Unicode, or shell metacharacters | Preserve existing argument forwarding unchanged |
+
+No new configuration, dependency, public API, abstraction, workflow, or signature policy is accepted. In particular, this issue does not add a hard failure, automatically choose the bundled Bun, alter Keychain storage, or implement the #2928 keyring opt-out.
+
+## Test-first evidence
+
+Extend `scripts/tests/issue-2962-system-bun-preference.bun.test.ts` using executable filesystem fixtures and the real launcher; use Bun and `bun:test` only.
+
+1. **RED — cdhash/ad-hoc warning is actionable and non-fatal**
+   - Put a version-compatible Bun stub and a `codesign` stub on `PATH`.
+   - Return a cdhash-only designated requirement.
+   - Assert one warning block on stderr contains the Keychain consequence and both remedies.
+   - Assert exit status 0 and stdout proves the PATH Bun executed.
+2. **RED — unsigned/no-identity output warns**
+   - Make `codesign` report no signed requirement.
+   - Assert the same single warning and successful PATH-Bun execution.
+3. **RED — Oven identity does not warn**
+   - Return a designated requirement containing `certificate leaf[subject.OU] = "7FRXF46ZSN"`.
+   - Assert successful PATH-Bun execution and absence of the warning.
+4. **RED — non-Darwin kernels do not inspect or warn**
+   - Exercise the launcher with controlled Linux and Windows-like `uname` results while a warning-triggering `codesign` stub is present.
+   - Assert the bundled entry executes and stderr has no ad-hoc warning.
+5. Preserve the existing #2962 version-floor, bundled-fallback, and argument-forwarding tests.
+6. Run the focused test before implementation and record that the new assertions fail because the warning behavior is absent. Implement only enough launcher and documentation change to turn them green.
+
+## Verification gates
+
+- Focused Bun launcher test
+- `npm run test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run format`
+- `npm run build`
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+- DeepThinker review and Open Code Review, with each finding classified as Blocker-Fix, In-scope-Fix, Reject, or Defer
+- PR checks green on the candidate head, all review threads resolved or explicitly deferred for user judgment, branch conflict-free, and ancestry based on current `origin/main`
+
+## Guardrails
+
+- No lint, complexity, coverage, or source-size rule changes or suppressions.
+- No new JavaScript or Vitest/Node test suite changes; changed tests use Bun and `bun:test`.
+- No adjacent launcher cleanup, speculative signature hardening, unrelated refactor, dependency change, workflow change, or `.llxprt/` modification.
+- Local OCR and PR OCR are each capped at two runs.

--- a/scripts/tests/issue-2962-system-bun-preference.bun.test.ts
+++ b/scripts/tests/issue-2962-system-bun-preference.bun.test.ts
@@ -143,6 +143,17 @@ const DR_OVEN_IDENTITY =
   'certificate leaf[subject.OU] = "7FRXF46ZSN"';
 
 /**
+ * A successful designated requirement that carries a team-identity clause but
+ * for a non-Oven OU. The Keychain ACL the launcher relies on stores Oven's
+ * exact OU (7FRXF46ZSN), so a binary signed by a different team cannot satisfy
+ * it and must still warn — only Oven's signed Bun can hold the persistent
+ * grant. See issue #3021.
+ */
+const DR_NON_OVEN_OU =
+  'designated => identifier "other" and anchor apple generic and ' +
+  'certificate leaf[subject.OU] = "ABCDE12345"';
+
+/**
  * Options for the codesign stub. The stub always proves it received exactly
  * the launcher's four-argument invocation (`-d --requirements - <target>`),
  * recording an invocation marker so non-Darwin branches can be shown to never
@@ -595,6 +606,43 @@ describeDarwinOnly(
         expect(result.stdout).toContain(STUB_MARKER);
         expect(result.stdout).not.toContain(BUNDLED_MARKER);
         expect(result.stderr).not.toContain(WARNING_NEEDLE);
+      },
+      LAUNCHER_TEST_TIMEOUT_MS,
+    );
+
+    it(
+      'warns exactly once and still execs the PATH Bun when a successful requirement carries a non-Oven team-identity clause',
+      () => {
+        // Regression: codesign succeeds and its output carries a
+        // `certificate leaf[subject.OU]` clause, but the OU is not Oven's
+        // (7FRXF46ZSN). The Keychain ACL stored on each credential item
+        // matches the exact Oven OU, so a binary signed by any other team
+        // cannot satisfy it and must still warn. Only the literal Oven OU
+        // should suppress the warning.
+        const { pkgRoot, launcherTarget } = makePinnedLayout(
+          tempDir,
+          BUNDLED_ENTRY_CODE,
+        );
+        const bunDir = makeStubBunDir(tempDir, bumpPatch(realBunVersion()));
+        const codesign = makeCodesignStubDir(tempDir, {
+          requirement: DR_NON_OVEN_OU,
+          expectedTarget: join(bunDir, 'bun'),
+        });
+        const result = runLauncher(
+          launcherTarget,
+          pkgRoot,
+          makePath(bunDir, codesign.binDir),
+        );
+        expectNoSpawnError(result);
+        expectExitOk(result);
+        expect(existsSync(codesign.markerPath)).toBe(true);
+        // The selected PATH Bun must still run; the warning is advisory.
+        expect(result.stdout).toContain(STUB_MARKER);
+        expect(result.stdout).not.toContain(BUNDLED_MARKER);
+        expect(result.stderr).toContain(WARNING_NEEDLE);
+        expect(result.stderr).toContain(REMEDY_BREW);
+        expect(result.stderr).toContain(REMEDY_CURL);
+        expect(countOccurrences(result.stderr, WARNING_NEEDLE)).toBe(1);
       },
       LAUNCHER_TEST_TIMEOUT_MS,
     );

--- a/scripts/tests/issue-2962-system-bun-preference.bun.test.ts
+++ b/scripts/tests/issue-2962-system-bun-preference.bun.test.ts
@@ -27,6 +27,7 @@ import {
   rmSync,
   chmodSync,
   readFileSync,
+  existsSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -103,6 +104,188 @@ function runLauncher(
     timeout: STANDARD_LAUNCH_TIMEOUT_MS,
     env: { ...process.env, PATH: pathValue },
   });
+}
+
+// --- Issue #3021 fixtures -------------------------------------------------
+//
+// The launcher inspects the selected PATH Bun's designated code-signing
+// requirement on Darwin and warns when it carries no team-identity clause
+// (`certificate leaf[subject.OU]`). These fixtures stub the external tools the
+// launcher shells out to (codesign, uname, od) so the real launcher script is
+// exercised against controlled inputs, mirroring how a real ad-hoc or
+// Oven-signed Bun would present itself.
+
+/**
+ * Distinctive substring present exactly once in the advisory warning block.
+ * Chosen to be specific to the no-team-identity condition (which covers
+ * ad-hoc, cdhash-only, and unsigned PATH Buns alike), not merely the
+ * "ad-hoc" label, so the wording stays accurate for all warn cases.
+ */
+const WARNING_NEEDLE = 'lacks a stable team identity';
+const REMEDY_BREW = 'brew uninstall bun && brew install oven-sh/bun/bun';
+const REMEDY_CURL = 'curl -fsSL https://bun.com/install | bash';
+
+/**
+ * Per-test timeout for launcher spawn tests. The launcher exec's the real
+ * bundled Bun for the non-Darwin (forced-kernel) cases, whose cold start can
+ * exceed bun:test's 5s default; this stays comfortably above the spawnSync
+ * timeout so a hung process is reported by the spawn, not the test runner.
+ */
+const LAUNCHER_TEST_TIMEOUT_MS = 45_000;
+
+/** cdhash-only designated requirement, like homebrew/core's ad-hoc Bun. */
+const DR_CDHASH_ONLY =
+  'designated => cdhash H"f73edee81b5af18948a4dab2dd158319d3dcacfd"';
+
+/** Oven Developer-ID designated requirement with a team-identity clause. */
+const DR_OVEN_IDENTITY =
+  'designated => identifier "bun" and anchor apple generic and ' +
+  'certificate leaf[subject.OU] = "7FRXF46ZSN"';
+
+/**
+ * Options for the codesign stub. The stub always proves it received exactly
+ * the launcher's four-argument invocation (`-d --requirements - <target>`),
+ * recording an invocation marker so non-Darwin branches can be shown to never
+ * reach codesign.
+ */
+interface CodesignStubOptions {
+  /** Designated requirement printed to stdout on success (exit 0). */
+  requirement?: string;
+  /**
+   * When set, the stub verifies its arguments, writes this string to stderr,
+   * and exits 1 — mimicking codesign rejecting an unsigned or unqualified
+   * binary. Takes precedence over `requirement`.
+   */
+  failDiagnostic?: string;
+  /**
+   * The exact PATH-Bun path the stub must receive as its fourth argument.
+   * When omitted the fourth argument is not range-checked (used for stubs
+   * that are never expected to run, e.g. the non-Darwin branches).
+   */
+  expectedTarget?: string;
+}
+
+/**
+ * Builds a private bin directory containing a stub `codesign` that:
+ *   - writes an invocation marker (proving the launcher reached codesign at
+ *     all, used to assert the non-Darwin branches never inspect signatures);
+ *   - asserts it received exactly four arguments in the exact order the
+ *     launcher emits (`-d`, `--requirements`, `-`, <PATH Bun>), exiting 2 on
+ *     any mismatch so a wrong target or ordering fails the test rather than
+ *     silently producing a misleading requirement;
+ *   - then either prints the supplied designated requirement to stdout
+ *     (success) or writes `failDiagnostic` to stderr and exits 1 (failure).
+ *
+ * Returns the bin directory and the path to the invocation marker so callers
+ * can assert presence/absence across the Darwin and non-Darwin cases.
+ */
+function makeCodesignStubDir(
+  root: string,
+  opts: CodesignStubOptions,
+): { binDir: string; markerPath: string } {
+  const tag =
+    opts.failDiagnostic !== undefined ? 'codesign-fail' : 'codesign-stub';
+  const binDir = join(root, tag);
+  mkdirSync(binDir, { recursive: true });
+  const stub = join(binDir, 'codesign');
+  const markerPath = join(binDir, 'invoked.marker');
+  const lines: string[] = ['#!/bin/sh'];
+  // Record that codesign was reached, before any argument checking, so a
+  // non-Darwin branch that never shells out leaves no marker.
+  lines.push(`printf '1' > "${markerPath}"`);
+  // The launcher always invokes: codesign -d --requirements - <target>.
+  // Fail (exit 2) on a wrong argument count or any mismatched positional,
+  // so the test can't pass on a mis-ordered or wrong-target invocation.
+  lines.push('[ "$#" -eq 4 ] || exit 2');
+  lines.push('[ "$1" = "-d" ] || exit 2');
+  lines.push('[ "$2" = "--requirements" ] || exit 2');
+  lines.push('[ "$3" = "-" ] || exit 2');
+  if (opts.expectedTarget !== undefined) {
+    // Compare against a file so a path containing shell metacharacters cannot
+    // break the generated script; command substitution strips the trailing
+    // newline.
+    const targetFile = join(binDir, 'expected-target');
+    writeFileSync(targetFile, opts.expectedTarget);
+    lines.push(`[ "$4" = "$(cat "${targetFile}")" ] || exit 2`);
+  }
+  if (opts.failDiagnostic !== undefined) {
+    const diagFile = join(binDir, 'diagnostic.txt');
+    writeFileSync(
+      diagFile,
+      `${opts.failDiagnostic}
+`,
+    );
+    lines.push(`cat "${diagFile}" >&2`);
+    lines.push('exit 1');
+  } else {
+    const drFile = join(binDir, 'dr.txt');
+    writeFileSync(
+      drFile,
+      `${opts.requirement ?? ''}
+`,
+    );
+    lines.push(`cat "${drFile}"`);
+    lines.push('exit 0');
+  }
+  lines.push('');
+  writeFileSync(stub, lines.join(String.fromCharCode(10)));
+  chmodSync(stub, 0o755);
+  return { binDir, markerPath };
+}
+
+/**
+ * Builds a private bin directory containing a stub `uname` that always reports
+ * the supplied kernel string, regardless of arguments. Lets a Darwin host
+ * exercise the launcher's non-Darwin branches.
+ */
+function makeUnameStubDir(root: string, kernel: string): string {
+  const binDir = join(root, 'uname-stub');
+  mkdirSync(binDir, { recursive: true });
+  const stub = join(binDir, 'uname');
+  writeFileSync(
+    stub,
+    `#!/bin/sh
+echo '${kernel}'
+`,
+  );
+  chmodSync(stub, 0o755);
+  return binDir;
+}
+
+/**
+ * Builds a private bin directory containing a stub `od` that emits the
+ * supplied magic bytes. The launcher strips spaces/newlines from od's output,
+ * so the magic is given as a compact hex string (e.g. "7f454c46" for ELF).
+ */
+function makeOdStubDir(root: string, magic: string): string {
+  const binDir = join(root, 'od-stub');
+  mkdirSync(binDir, { recursive: true });
+  const stub = join(binDir, 'od');
+  writeFileSync(
+    stub,
+    `#!/bin/sh
+echo '${magic}'
+`,
+  );
+  chmodSync(stub, 0o755);
+  return binDir;
+}
+
+/** Joins stub bin directories ahead of a minimal system PATH. */
+function makePath(...stubDirs: string[]): string {
+  return [...stubDirs, '/usr/bin', '/bin'].join(':');
+}
+
+/** Counts non-overlapping occurrences of needle in haystack. */
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    count += 1;
+    idx = haystack.indexOf(needle, idx + needle.length);
+  }
+  return count;
 }
 
 describe('POSIX launcher system-Bun preference source gating', () => {
@@ -217,7 +400,14 @@ describeDarwinOnly('POSIX launcher system-Bun preference (issue #2962)', () => {
     expect(result.stdout).not.toContain(STUB_MARKER);
   });
 
-  it('forwards arguments through the PATH Bun', () => {
+  it('forwards arguments through the PATH Bun with exact positional boundaries', () => {
+    // This runs through a controlled warning-triggering PATH-Bun path: a
+    // cdhash-only codesign stub is on PATH so the #3021 inspection fires
+    // deterministically, and the PATH Bun is still exec'd unchanged. The stub
+    // Bun emits the argument count and each positional argument on its own
+    // delimited line so boundary errors (a space-split "a b", an expanded
+    // "$HOME", a mangled multi-byte arg) are detected rather than hidden by
+    // the flattened "$*" join the launcher used previously.
     const { pkgRoot, launcherTarget } = makePinnedLayout(
       tempDir,
       BUNDLED_ENTRY_CODE,
@@ -234,18 +424,248 @@ describeDarwinOnly('POSIX launcher system-Bun preference (issue #2962)', () => {
         '  exit 0',
         'fi',
         'shift',
-        `printf 'ARGS:%s\\n' "$*"`,
+        `printf 'ARGCOUNT:%s\\n' "$#"`,
+        '_i=1',
+        'for _a in "$@"; do',
+        `  printf 'ARG[%s]:%s\\n' "$_i" "$_a"`,
+        '  _i=$((_i + 1))',
+        'done',
         '',
       ].join('\n'),
     );
     chmodSync(stub, 0o755);
+    const codesign = makeCodesignStubDir(tempDir, {
+      requirement: DR_CDHASH_ONLY,
+      expectedTarget: stub,
+    });
     const result = runLauncher(
       launcherTarget,
       pkgRoot,
-      `${stubDir}:/usr/bin:/bin`,
+      makePath(stubDir, codesign.binDir),
       ['a b', 'ünicode', '$HOME'],
     );
     expectNoSpawnError(result);
-    expect(result.stdout).toContain('ARGS:a b ünicode $HOME');
+    expectExitOk(result);
+    // The controlled warning path fired.
+    expect(existsSync(codesign.markerPath)).toBe(true);
+    expect(result.stderr).toContain(WARNING_NEEDLE);
+    // Exactly three arguments forwarded, with exact positional boundaries.
+    expect(result.stdout).toContain('ARGCOUNT:3');
+    expect(result.stdout).toContain('ARG[1]:a b');
+    expect(result.stdout).toContain('ARG[2]:ünicode');
+    expect(result.stdout).toContain('ARG[3]:$HOME');
   });
 });
+
+describeDarwinOnly(
+  'POSIX launcher ad-hoc PATH Bun warning (issue #3021)',
+  () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), 'llxprt-adhoc-'));
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it(
+      'warns exactly once and still execs the PATH Bun when the requirement is cdhash-only',
+      () => {
+        const { pkgRoot, launcherTarget } = makePinnedLayout(
+          tempDir,
+          BUNDLED_ENTRY_CODE,
+        );
+        const bunDir = makeStubBunDir(tempDir, bumpPatch(realBunVersion()));
+        const codesign = makeCodesignStubDir(tempDir, {
+          requirement: DR_CDHASH_ONLY,
+          expectedTarget: join(bunDir, 'bun'),
+        });
+        const result = runLauncher(
+          launcherTarget,
+          pkgRoot,
+          makePath(bunDir, codesign.binDir),
+        );
+        expectNoSpawnError(result);
+        expectExitOk(result);
+        // codesign was reached and proved it received the launcher's exact
+        // four-argument invocation against the selected PATH Bun.
+        expect(existsSync(codesign.markerPath)).toBe(true);
+        // The selected PATH Bun must still run; the warning is advisory.
+        expect(result.stdout).toContain(STUB_MARKER);
+        expect(result.stdout).not.toContain(BUNDLED_MARKER);
+        expect(result.stderr).toContain(WARNING_NEEDLE);
+        expect(result.stderr).toContain('Keychain');
+        expect(result.stderr).toContain('Always Allow');
+        expect(result.stderr).toContain(REMEDY_BREW);
+        expect(result.stderr).toContain(REMEDY_CURL);
+        expect(countOccurrences(result.stderr, WARNING_NEEDLE)).toBe(1);
+      },
+      LAUNCHER_TEST_TIMEOUT_MS,
+    );
+
+    it(
+      'warns exactly once and still execs the PATH Bun when codesign reports unsigned',
+      () => {
+        const { pkgRoot, launcherTarget } = makePinnedLayout(
+          tempDir,
+          BUNDLED_ENTRY_CODE,
+        );
+        const bunDir = makeStubBunDir(tempDir, bumpPatch(realBunVersion()));
+        const codesign = makeCodesignStubDir(tempDir, {
+          failDiagnostic: 'code object is not signed at all',
+          expectedTarget: join(bunDir, 'bun'),
+        });
+        const result = runLauncher(
+          launcherTarget,
+          pkgRoot,
+          makePath(bunDir, codesign.binDir),
+        );
+        expectNoSpawnError(result);
+        expectExitOk(result);
+        expect(existsSync(codesign.markerPath)).toBe(true);
+        expect(result.stdout).toContain(STUB_MARKER);
+        expect(result.stdout).not.toContain(BUNDLED_MARKER);
+        expect(result.stderr).toContain(WARNING_NEEDLE);
+        expect(result.stderr).toContain(REMEDY_BREW);
+        expect(result.stderr).toContain(REMEDY_CURL);
+        expect(countOccurrences(result.stderr, WARNING_NEEDLE)).toBe(1);
+      },
+      LAUNCHER_TEST_TIMEOUT_MS,
+    );
+
+    it(
+      'warns and still execs when a failing codesign echoes the team-identity clause in its diagnostic',
+      () => {
+        // Regression: codesign exits non-zero while its diagnostic happens to
+        // contain `certificate leaf[subject.OU]`. The launcher must still warn
+        // (only a *successful* codesign carrying the clause suppresses it) and
+        // must still execute the selected PATH Bun.
+        const { pkgRoot, launcherTarget } = makePinnedLayout(
+          tempDir,
+          BUNDLED_ENTRY_CODE,
+        );
+        const bunDir = makeStubBunDir(tempDir, bumpPatch(realBunVersion()));
+        const codesign = makeCodesignStubDir(tempDir, {
+          failDiagnostic:
+            'code failed to satisfy designated requirement: ' +
+            'certificate leaf[subject.OU] = "7FRXF46ZSN"',
+          expectedTarget: join(bunDir, 'bun'),
+        });
+        const result = runLauncher(
+          launcherTarget,
+          pkgRoot,
+          makePath(bunDir, codesign.binDir),
+        );
+        expectNoSpawnError(result);
+        expectExitOk(result);
+        expect(existsSync(codesign.markerPath)).toBe(true);
+        // The PATH Bun must still run despite the failing codesign.
+        expect(result.stdout).toContain(STUB_MARKER);
+        expect(result.stdout).not.toContain(BUNDLED_MARKER);
+        expect(result.stderr).toContain(WARNING_NEEDLE);
+        expect(result.stderr).toContain(REMEDY_BREW);
+        expect(result.stderr).toContain(REMEDY_CURL);
+        expect(countOccurrences(result.stderr, WARNING_NEEDLE)).toBe(1);
+      },
+      LAUNCHER_TEST_TIMEOUT_MS,
+    );
+
+    it(
+      'does not warn when the PATH Bun carries an Oven team-identity requirement',
+      () => {
+        const { pkgRoot, launcherTarget } = makePinnedLayout(
+          tempDir,
+          BUNDLED_ENTRY_CODE,
+        );
+        const bunDir = makeStubBunDir(tempDir, bumpPatch(realBunVersion()));
+        const codesign = makeCodesignStubDir(tempDir, {
+          requirement: DR_OVEN_IDENTITY,
+          expectedTarget: join(bunDir, 'bun'),
+        });
+        const result = runLauncher(
+          launcherTarget,
+          pkgRoot,
+          makePath(bunDir, codesign.binDir),
+        );
+        expectNoSpawnError(result);
+        expectExitOk(result);
+        expect(existsSync(codesign.markerPath)).toBe(true);
+        expect(result.stdout).toContain(STUB_MARKER);
+        expect(result.stdout).not.toContain(BUNDLED_MARKER);
+        expect(result.stderr).not.toContain(WARNING_NEEDLE);
+      },
+      LAUNCHER_TEST_TIMEOUT_MS,
+    );
+  },
+);
+
+describeDarwinOnly(
+  'POSIX launcher signature warning is Darwin-only (issue #3021)',
+  () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), 'llxprt-adhoc-nodarwin-'));
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it(
+      'does not inspect or warn under a Linux kernel',
+      () => {
+        const { pkgRoot, launcherTarget } = makePinnedLayout(
+          tempDir,
+          BUNDLED_ENTRY_CODE,
+        );
+        const unameDir = makeUnameStubDir(tempDir, 'Linux');
+        const odDir = makeOdStubDir(tempDir, '7f454c46');
+        const codesign = makeCodesignStubDir(tempDir, {
+          requirement: DR_CDHASH_ONLY,
+        });
+        const result = runLauncher(
+          launcherTarget,
+          pkgRoot,
+          makePath(unameDir, odDir, codesign.binDir),
+        );
+        expectNoSpawnError(result);
+        expectExitOk(result);
+        // Non-Darwin kernels must never inspect signatures: codesign is not
+        // reached, so no invocation marker is written.
+        expect(existsSync(codesign.markerPath)).toBe(false);
+        expect(result.stdout).toContain(BUNDLED_MARKER);
+        expect(result.stderr).not.toContain(WARNING_NEEDLE);
+      },
+      LAUNCHER_TEST_TIMEOUT_MS,
+    );
+
+    it(
+      'does not inspect or warn under a Windows-like (MINGW) kernel',
+      () => {
+        const { pkgRoot, launcherTarget } = makePinnedLayout(
+          tempDir,
+          BUNDLED_ENTRY_CODE,
+        );
+        const unameDir = makeUnameStubDir(tempDir, 'MINGW64_NT-10.0');
+        const odDir = makeOdStubDir(tempDir, '4d5a');
+        const codesign = makeCodesignStubDir(tempDir, {
+          requirement: DR_CDHASH_ONLY,
+        });
+        const result = runLauncher(
+          launcherTarget,
+          pkgRoot,
+          makePath(unameDir, odDir, codesign.binDir),
+        );
+        expectNoSpawnError(result);
+        expectExitOk(result);
+        expect(existsSync(codesign.markerPath)).toBe(false);
+        expect(result.stdout).toContain(BUNDLED_MARKER);
+        expect(result.stderr).not.toContain(WARNING_NEEDLE);
+      },
+      LAUNCHER_TEST_TIMEOUT_MS,
+    );
+  },
+);


### PR DESCRIPTION
## TLDR

Warn macOS users when the version-compatible Bun selected from PATH cannot hold a durable Keychain grant because it is ad-hoc signed, unsigned, cdhash-only, or otherwise lacks a stable team identity. The warning remains advisory and names both Oven-signed installation remedies.

## Dive Deeper

The Darwin launcher path introduced by #2962 intentionally prefers a compatible external Bun so npm cannot unlink the runtime of an active session. Version compatibility alone does not establish a durable macOS code identity, however: an ad-hoc or unsigned Bun cannot satisfy the team-identity requirement stored in Keychain ACLs, and #3020 means clicking Always Allow cannot add a lasting grant.

This change:

- inspects the designated requirement of the exact PATH Bun selected by the existing version gate;
- suppresses the warning only when codesign succeeds and reports a certificate team-identity clause;
- emits one actionable stderr warning for cdhash-only, ad-hoc, unsigned, failed-inspection, or other no-team-identity cases;
- continues to execute the selected PATH Bun with exact argument boundaries;
- never invokes the signature check on Linux or Windows-like launcher paths;
- records the warn-versus-skip decision: skipping would silently restore the npm-unlink failure mode #2962 avoids;
- documents the #3020 Keychain consequence and both Oven-signed recovery commands.

Review findings were triaged as follows:

- In-scope-Fix: codesign exit-status handling, exact target verification, non-Darwin non-invocation evidence, exact argument-boundary evidence, and unsigned-safe warning wording. All were remediated.
- Reject: changing https://bun.com/install to bun.sh. The issue explicitly requires bun.com, the endpoint serves the installer, and Bun's current official installation documentation prescribes bun.com.
- Reject: escaping fixed kernel/magic test constants as though they were untrusted inputs. They are closed test fixtures, so general-purpose hardening would be outside scope.

## Reviewer Test Plan

On macOS:

1. Run the focused behavioral suite:

       bun test scripts/tests/issue-2962-system-bun-preference.bun.test.ts

2. Confirm all cases pass for:
   - cdhash-only requirement warns once and still launches;
   - unsigned or failed codesign warns once and still launches;
   - Oven team identity does not warn;
   - codesign receives the exact selected PATH Bun;
   - Linux and MINGW simulations never invoke codesign;
   - spaces, Unicode, and shell metacharacters retain exact argument boundaries.
3. Run sh -n packages/cli/bin/llxprt.
4. Optionally inspect a local Bun directly:

       codesign -dv --requirements - "$(command -v bun)" 2>&1

Local verification completed on the candidate head:

- focused launcher suite: 13 passed;
- full lint, typecheck, format, and build: passed;
- required StepFun profile smoke test: passed;
- full tests completed except for two unrelated core-suite concurrency timeouts across separate runs; each timed-out file passed immediately in isolation, and all issue-focused tests remained green.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Linux and Windows-like launcher behavior is covered through controlled kernel fixtures that prove codesign is not invoked.

## Linked issues / bugs

Fixes #3021

Related: #2962, #3020, #2928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - macOS now detects when a PATH-selected Bun runtime lacks the expected signing identity and displays an advisory warning.
  - The launcher continues running the selected Bun runtime despite the warning.

- **Documentation**
  - Added troubleshooting guidance for repeated macOS Keychain password prompts.
  - Documented why “Always Allow” may not persist, how to install Bun through official channels, and how to verify its signing identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->