### PR TITLE
Make the foreground shell wrapper newline-safe (Fixes #2980)

### DIFF
--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -338,16 +338,111 @@ function resolveCallCwd(call: AgentToolCall, targetDir: string): string {
   return resolved;
 }
 
+const TRAP_LINE_PREFIX = 'trap ';
+const TRAP_LINE_SUFFIX = ' EXIT';
+const TRAP_ACTION_PREFIX = '__code=$?; pgrep -g 0 >';
+const TRAP_ACTION_SUFFIX = ' 2>&1; exit $__code';
+
 function commandsMatch(preparedCommand: string, rawCommand: string): boolean {
-  // ShellExecutionService wraps commands to capture their exit code. Match only
-  // that exact prefix so terminal updates attach to the originating raw command.
+  // ShellExecutionService wraps commands in an EXIT trap whose body is the
+  // trimmed raw command verbatim. Correlate by exact equality: either the
+  // prepared command is already the unwrapped raw command, or it is a
+  // canonically generated wrapper whose extracted body equals rawCommand.trim().
   const trimmed = rawCommand.trim();
   if (preparedCommand === trimmed) {
     return true;
   }
-  const terminated =
-    trimmed.endsWith('&') || trimmed.endsWith(';') ? trimmed : `${trimmed};`;
-  return preparedCommand.startsWith(`{ ${terminated} }; __code=$?;`);
+  return extractGeneratedWrapperBody(preparedCommand) === trimmed;
+}
+
+/**
+ * Recognizes a canonical singleQuoteForShell token at the start of `input` and
+ * returns its decoded value plus the unconsumed remainder. Decoding mirrors the
+ * escaped-quote sequence the wrapper emits, then requires re-encoding equality
+ * (via the shared singleQuoteForShell) so only a canonically generated token is
+ * accepted.
+ */
+function matchCanonicalSingleQuoted(
+  input: string,
+): { decoded: string; rest: string } | null {
+  if (!input.startsWith("'")) {
+    return null;
+  }
+  let i = 1;
+  let decoded = '';
+  let closed = false;
+  while (i < input.length) {
+    const ch = input[i];
+    if (ch === "'") {
+      if (input.slice(i, i + 4) === "'\\''") {
+        decoded += "'";
+        i += 4;
+      } else {
+        closed = true;
+        break;
+      }
+    } else {
+      decoded += ch;
+      i += 1;
+    }
+  }
+  if (!closed) {
+    return null;
+  }
+  const token = input.slice(0, i + 1);
+  const reencoded = `'${decoded.split("'").join("'\\''")}'`;
+  return reencoded === token ? { decoded, rest: input.slice(i + 1) } : null;
+}
+
+/**
+ * Confirms a decoded trap action is exactly the generated form:
+ * TRAP_ACTION_PREFIX + one canonical singleQuoteForShell path token +
+ * TRAP_ACTION_SUFFIX.
+ */
+function isCanonicalTrapAction(action: string): boolean {
+  if (
+    !action.startsWith(TRAP_ACTION_PREFIX) ||
+    !action.endsWith(TRAP_ACTION_SUFFIX)
+  ) {
+    return false;
+  }
+  const pathToken = action.slice(
+    TRAP_ACTION_PREFIX.length,
+    action.length - TRAP_ACTION_SUFFIX.length,
+  );
+  const matched = matchCanonicalSingleQuoted(pathToken);
+  // The path slot must be EXACTLY one canonical token: no trailing content may
+  // remain after it, so a same-prefix/suffix trap with extra action content is
+  // treated as non-canonical and left unmatched.
+  return matched !== null && matched.rest === '';
+}
+
+/**
+ * Extracts the body of a canonically generated wrapper, or null if the prepared
+ * command is not the generated wrapper form. The wrapper is
+ * `trap '<quotedAction>' EXIT` followed by a newline and the trimmed body. The
+ * action token may contain a literal newline (e.g. a temp path with a line
+ * break), so it is decoded from the entire suffix after `trap ` rather than
+ * truncated at the first newline; the remainder must then begin exactly with
+ * TRAP_LINE_SUFFIX plus a newline.
+ */
+function extractGeneratedWrapperBody(preparedCommand: string): string | null {
+  if (!preparedCommand.startsWith(TRAP_LINE_PREFIX)) {
+    return null;
+  }
+  const afterPrefix = preparedCommand.slice(TRAP_LINE_PREFIX.length);
+  const actionToken = matchCanonicalSingleQuoted(afterPrefix);
+  if (actionToken === null) {
+    return null;
+  }
+  const bodyDelimiter = TRAP_LINE_SUFFIX + String.fromCharCode(10);
+  if (!actionToken.rest.startsWith(bodyDelimiter)) {
+    return null;
+  }
+  if (!isCanonicalTrapAction(actionToken.decoded)) {
+    return null;
+  }
+  return actionToken.rest.slice(bodyDelimiter.length);
 }
 
 function abortedResult(): ShellExecutionResult {

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'bun:test';
 import type * as acp from '@agentclientprotocol/sdk';
 import {
   DebugLogger,
@@ -28,6 +28,19 @@ const preparedEcho = buildCommandToExecute(
   'echo hello',
   false,
   '/tmp/shell.tmp',
+);
+const preparedEchoSemicolon = buildCommandToExecute(
+  'echo hello;',
+  false,
+  '/tmp/shell.tmp',
+);
+// Builder-generated wrapper whose temp path contains a literal newline. The
+// path is quoted by singleQuoteForShell so it is valid real Bash, but a parser
+// that splits the wrapper at the first newline would fail to correlate it.
+const preparedEchoNewlinePath = buildCommandToExecute(
+  'echo hello',
+  false,
+  '/tmp/before' + String.fromCharCode(10) + 'after.tmp',
 );
 
 function terminalManager(
@@ -67,6 +80,26 @@ function shellToolResultEvent(toolCallId: string, output: string): AgentEvent {
 }
 
 const doneEvent: AgentEvent = { type: 'done', reason: 'stop' };
+
+// bun:test's `expect(p).rejects.toThrow()` is typed to return `void`, so
+// `await expect(...).rejects...` trips @typescript-eslint/await-thenable.
+// Drive the promise directly and assert on the captured rejection instead.
+async function expectRejection(
+  promise: Promise<unknown>,
+  messageFragment: string,
+): Promise<void> {
+  let caught: unknown;
+  let rejected = false;
+  try {
+    await promise;
+  } catch (error) {
+    caught = error;
+    rejected = true;
+  }
+  expect(rejected).toBe(true);
+  const text = caught instanceof Error ? caught.message : String(caught);
+  expect(text).toContain(messageFragment);
+}
 
 describe('Zed terminal execution', () => {
   afterEach(async () => {
@@ -128,7 +161,7 @@ describe('Zed terminal execution', () => {
     });
 
     await terminals.executeShellCommand(
-      preparedEcho,
+      preparedEchoSemicolon,
       '/project',
       () => undefined,
       new AbortController().signal,
@@ -143,17 +176,43 @@ describe('Zed terminal execution', () => {
     );
   });
 
+  it('correlates a wrapper whose temp path contains a literal newline', async () => {
+    const connection = new RecordingConnection();
+    const terminals = terminalManager(connection);
+    await terminals.observeToolCall({
+      id: 'shell-newline-path',
+      name: 'run_shell_command',
+      args: { command: 'echo hello' },
+    });
+
+    await terminals.executeShellCommand(
+      preparedEchoNewlinePath,
+      '/project',
+      () => undefined,
+      new AbortController().signal,
+    );
+
+    expect(connection.onlySessionUpdates()).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'shell-newline-path',
+        content: [{ type: 'terminal', terminalId: 'terminal-1' }],
+      }),
+    );
+  });
+
   it('rejects an agent-reported cwd outside the session project root', async () => {
     const connection = new RecordingConnection();
     const terminals = terminalManager(connection);
 
-    await expect(
+    await expectRejection(
       terminals.observeToolCall({
         id: 'shell-traversal',
         name: 'run_shell_command',
         args: { command: 'echo hello', dir_path: '../../etc' },
       }),
-    ).rejects.toThrow('Shell tool cwd resolves outside the session root');
+      'Shell tool cwd resolves outside the session root',
+    );
 
     expect(connection.createTerminalCalls).toHaveLength(0);
     expect(connection.onlySessionUpdates()).toHaveLength(0);
@@ -181,13 +240,14 @@ describe('Zed terminal execution', () => {
     );
     await connection.waitForTerminalProcessCreated();
 
-    await expect(
+    await expectRejection(
       terminals.observeToolCall({
         id: 'shell-retry',
         name: 'run_shell_command',
         args: { command: 'echo hello' },
       }),
-    ).rejects.toThrow('transport unavailable');
+      'transport unavailable',
+    );
     await terminals.observeToolCall({
       id: 'shell-retry',
       name: 'run_shell_command',
@@ -209,14 +269,15 @@ describe('Zed terminal execution', () => {
     const controller = new AbortController();
     controller.abort();
 
-    await expect(
-      terminalManager(connection).executeShellCommand(
-        preparedEcho,
-        '/project',
-        () => undefined,
-        controller.signal,
-      ),
-    ).resolves.toMatchObject({ aborted: true });
+    const cancelledResult = await terminalManager(
+      connection,
+    ).executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      controller.signal,
+    );
+    expect(cancelledResult).toMatchObject({ aborted: true });
     expect(connection.createTerminalCalls).toHaveLength(0);
   });
 
@@ -285,14 +346,15 @@ describe('Zed terminal execution', () => {
       args: { command: 'echo hello' },
     });
 
-    await expect(
+    await expectRejection(
       terminals.executeShellCommand(
         preparedEcho,
         '/project',
         () => undefined,
         new AbortController().signal,
       ),
-    ).rejects.toThrow('transport closed');
+      'transport closed',
+    );
     expect(connection.killCalls).toBe(1);
     expect(connection.releaseCalls).toBe(1);
   });
@@ -328,6 +390,72 @@ describe('Zed terminal execution', () => {
           { type: 'content', content: { type: 'text', text: 'text-output' } },
         ],
       }),
+    );
+  });
+});
+
+describe('Zed terminal command correlation does not over-match', () => {
+  async function correlationAttempt(
+    rawObserved: string,
+    prepared: string,
+  ): Promise<acp.SessionUpdate[]> {
+    const connection = new RecordingConnection();
+    const terminals = terminalManager(connection);
+    await terminals.observeToolCall({
+      id: 'shell-no-match',
+      name: 'run_shell_command',
+      args: { command: rawObserved },
+    });
+    await terminals.executeShellCommand(
+      prepared,
+      '/project',
+      () => undefined,
+      new AbortController().signal,
+    );
+    return connection.onlySessionUpdates();
+  }
+
+  it('does not correlate an arbitrary (non-canonical) trap command', async () => {
+    const updates = await correlationAttempt(
+      'echo hi',
+      "trap 'echo malicious' EXIT\necho hi",
+    );
+    expect(updates).not.toContainEqual(
+      expect.objectContaining({ toolCallId: 'shell-no-match' }),
+    );
+  });
+
+  it('does not treat a plain command as equal to a semicolon-terminated one', async () => {
+    const updates = await correlationAttempt(
+      'echo hello',
+      preparedEchoSemicolon,
+    );
+    expect(updates).not.toContainEqual(
+      expect.objectContaining({ toolCallId: 'shell-no-match' }),
+    );
+  });
+
+  it('does not treat a plain command as equal to a real trailing-& command', async () => {
+    const preparedEchoAmp = buildCommandToExecute(
+      'echo hello &',
+      false,
+      '/tmp/shell.tmp',
+    );
+    const updates = await correlationAttempt('echo hello', preparedEchoAmp);
+    expect(updates).not.toContainEqual(
+      expect.objectContaining({ toolCallId: 'shell-no-match' }),
+    );
+  });
+
+  it('does not strip an escaped/literal terminal character to force a match', async () => {
+    const preparedEscapedAmp = buildCommandToExecute(
+      'printf foo\\&',
+      false,
+      '/tmp/shell.tmp',
+    );
+    const updates = await correlationAttempt('printf foo', preparedEscapedAmp);
+    expect(updates).not.toContainEqual(
+      expect.objectContaining({ toolCallId: 'shell-no-match' }),
     );
   });
 });

--- a/packages/cli/vitest.test-groups.ts
+++ b/packages/cli/vitest.test-groups.ts
@@ -78,6 +78,10 @@ const baseExclude: readonly string[] = [
   // Claude Code login-bucket characterization is Bun-native for the same
   // reason (issue #2891).
   '**/src/ui/commands/authCommand.loginWithBucket.issue2891.test.ts',
+  // Zed terminal correlation tests migrated to bun:test (issue #2980) and
+  // registered in scripts/bun-test-manifest.ts; they must not also be
+  // discovered by Vitest (bun:test does not resolve under the Vitest runner).
+  '**/src/zed-integration/zedIntegration.terminal.test.ts',
   '**/dist/**',
   '**/tmp/**',
   '**/cypress/**',
@@ -492,4 +496,4 @@ export function buildTestGroups(
  * The expected total selected file count after integrating the v0.11.0 test set.
  * Exported for behavioral tests to assert against an independent oracle.
  */
-export const SELECTED_FILE_COUNT: number = 531;
+export const SELECTED_FILE_COUNT: number = 530;

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -344,15 +344,19 @@ function registerPtyExitHandler(
 
   state.activePtyEntry.onExitDisposable = state.ptyProcess.onExit(
     ({ exitCode, signal }: { exitCode: number; signal?: number }) => {
+      // node-pty reports a signal value of 0 for clean exits; normalize it to
+      // null exactly once at this boundary so downstream formatting treats it
+      // as "no signal" (preserving undefined/null and all nonzero signals).
+      const normalizedSignal = signal === 0 ? null : (signal ?? null);
       state.exitedGuard.markExited();
       state.abortSignal.removeEventListener('abort', abortHandler);
 
       if (state.abortSignal.aborted) {
-        finalizeResult(exitCode, signal ?? null);
+        finalizeResult(exitCode, normalizedSignal);
         return;
       }
 
-      ptyExitRace(state, exitCode, signal, finalizeResult);
+      ptyExitRace(state, exitCode, normalizedSignal, finalizeResult);
     },
   );
 }
@@ -360,7 +364,7 @@ function registerPtyExitHandler(
 function ptyExitRace(
   state: PtyExecState,
   exitCode: number,
-  signal: number | undefined,
+  signal: number | null,
   finalizeResult: (exitCode: number, signal?: number | null) => void,
 ): void {
   const processingComplete = state.processingChain.then(() => 'processed');

--- a/packages/core/src/services/shellPtySignal.bun.test.ts
+++ b/packages/core/src/services/shellPtySignal.bun.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import EventEmitter from 'node:events';
+import { beforeEach, describe, expect, it, mock, vi } from 'bun:test';
+import type { ShellOutputEvent } from './shellExecutionService.js';
+
+/**
+ * Focused Bun boundary evidence for issue 2980 REQ-2980-4: the node-pty
+ * exit-result boundary must normalize a clean-exit signal of 0 to null and an
+ * omitted/undefined signal to null, while preserving every nonzero signal.
+ *
+ * The ShellExecutionService PTY path is driven with a fake pty whose onExit
+ * callback is invoked directly, so the exact node-pty callback shape
+ * ({ exitCode, signal }) is exercised without spawning a real process. The
+ * service is imported dynamically AFTER the getPty module mock is registered
+ * so the mock applies to the service's module graph. No public production
+ * abstraction is added for testing.
+ */
+
+interface FakePtyExit {
+  exitCode: number;
+  signal?: number;
+}
+
+type ExitHandler = (exit: FakePtyExit) => void;
+
+interface FakePty extends EventEmitter {
+  pid: number;
+  kill: ReturnType<typeof vi.fn>;
+  onData: ReturnType<typeof vi.fn>;
+  onExit: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  emitExit: (exit: FakePtyExit) => void;
+}
+
+let fakePty: FakePty;
+
+// getPty is mocked so ShellExecutionService takes the PTY path with a
+// controllable fake pty instead of resolving the real (Bun/native) pty.
+await mock.module('../utils/getPty.js', () => ({
+  getPty: async () => ({
+    module: { spawn: () => fakePty },
+    name: 'mock-pty',
+  }),
+}));
+
+const { ShellExecutionService } = await import('./shellExecutionService.js');
+
+const defaultShellConfig = {
+  showColor: false,
+  scrollback: 600000,
+  terminalWidth: 80,
+  terminalHeight: 24,
+};
+
+function buildFakePty(): FakePty {
+  const pty = new EventEmitter() as FakePty;
+  let exitHandler: ExitHandler = () => undefined;
+  pty.pid = 4242;
+  pty.kill = vi.fn();
+  pty.onData = vi.fn().mockReturnValue({ dispose: vi.fn() });
+  pty.onExit = vi.fn((handler: ExitHandler) => {
+    exitHandler = handler;
+    return { dispose: vi.fn() };
+  });
+  pty.write = vi.fn();
+  pty.resize = vi.fn();
+  pty.emitExit = (exit: FakePtyExit) => exitHandler(exit);
+  return pty;
+}
+
+/** Drives the PTY path to completion with the given onExit payload. */
+async function executeAndExit(
+  payload: FakePtyExit,
+): Promise<{ exitCode: number; signal: number | string | null }> {
+  const onOutputEvent = (_event: ShellOutputEvent): void => undefined;
+  const handle = await ShellExecutionService.execute(
+    'clean-process',
+    '/test/dir',
+    onOutputEvent,
+    new AbortController().signal,
+    true,
+    defaultShellConfig,
+  );
+  // Let the spawn + handler registration settle before firing exit.
+  await new Promise((resolve) => setImmediate(resolve));
+  fakePty.emitExit(payload);
+  const result = await handle.result;
+  return { exitCode: result.exitCode, signal: result.signal };
+}
+
+describe('ShellExecutionService PTY exit signal normalization (issue 2980)', () => {
+  beforeEach(() => {
+    fakePty = buildFakePty();
+  });
+
+  it('normalizes a clean-exit signal of 0 to null', async () => {
+    const { exitCode, signal } = await executeAndExit({
+      exitCode: 0,
+      signal: 0,
+    });
+    expect(exitCode).toBe(0);
+    expect(signal).toBeNull();
+  });
+
+  it('normalizes an omitted signal to null', async () => {
+    const { exitCode, signal } = await executeAndExit({ exitCode: 0 });
+    expect(exitCode).toBe(0);
+    expect(signal).toBeNull();
+  });
+
+  it('preserves a nonzero termination signal', async () => {
+    const { exitCode, signal } = await executeAndExit({
+      exitCode: 0,
+      signal: 15,
+    });
+    expect(exitCode).toBe(0);
+    expect(signal).toBe(15);
+  });
+});

--- a/packages/tools/src/__tests__/shell-helpers-schema.test.ts
+++ b/packages/tools/src/__tests__/shell-helpers-schema.test.ts
@@ -4,19 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'bun:test';
 import { ShellTool } from '../index.js';
 import type {
   IShellExecutionService,
   ShellResult,
 } from '../interfaces/index.js';
-import { buildCommandToExecute } from '../tools/shell-helpers.js';
+import {
+  buildCommandToExecute,
+  singleQuoteForShell,
+} from '../tools/shell-helpers.js';
 
 const { mockPlatform } = vi.hoisted(() => ({
   mockPlatform: vi.fn(() => 'darwin'),
 }));
 
-vi.mock('node:os', async (importOriginal) => {
+void vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     default: { platform: mockPlatform, EOL: actual.EOL },
@@ -145,16 +148,18 @@ describe('buildCommandToExecute foreground wrapping (non-Windows)', () => {
     mockPlatform.mockReturnValue('darwin');
   });
 
-  it('wraps a foreground command in the expected group wrapper', () => {
-    expect(buildCommandToExecute('npm run dev', false, '/tmp/t')).toBe(
-      '{ npm run dev; }; __code=$?; pgrep -g 0 >/tmp/t 2>&1; exit $__code;',
-    );
+  it('wraps a foreground command in an EXIT trap followed by the trimmed body', () => {
+    const built = buildCommandToExecute('npm run dev', false, '/tmp/t');
+    const action = `__code=$?; pgrep -g 0 >${singleQuoteForShell('/tmp/t')} 2>&1; exit $__code`;
+    expect(built).toBe(`trap ${singleQuoteForShell(action)} EXIT
+npm run dev`);
   });
 
-  it('normalises a single trailing ; in the command body', () => {
+  it('keeps a caller-supplied trailing ; in the body verbatim', () => {
     const built = buildCommandToExecute('echo hi;', false, '/tmp/t');
-    expect(built).toContain('{ echo hi; }');
-    expect(built).not.toContain(';;');
+    const newline = String.fromCharCode(10);
+    expect(built.endsWith(`${newline}echo hi;`)).toBe(true);
+    expect(built).not.toContain('{ echo hi');
   });
 });
 

--- a/packages/tools/src/tools/shell-helpers.ts
+++ b/packages/tools/src/tools/shell-helpers.ts
@@ -362,6 +362,12 @@ export function buildCommandToExecute(
   // captures $? before running pgrep and re-exits with it, preserving the
   // body's exit status. Both the path and the whole action are single-quoted
   // via singleQuoteForShell so hostile paths stay literal shell data.
+  // Known boundary: a body that removes (`trap - EXIT`) or replaces the EXIT
+  // trap intentionally opts out — our pgrep temp file is not written and the
+  // epilogue does not re-emit the exit status. The trap is still the right
+  // choice because, unlike an appended epilogue, it survives trailing
+  // comments, heredocs, and terminal operators, and still fires when the body
+  // calls `exit`.
   const trapAction = `${TRAP_ACTION_PREFIX}${singleQuoteForShell(tempFilePath)}${TRAP_ACTION_SUFFIX}`;
   const newline = String.fromCharCode(10);
   return `trap ${singleQuoteForShell(trapAction)} EXIT${newline}${strippedCommand.trim()}`;

--- a/packages/tools/src/tools/shell-helpers.ts
+++ b/packages/tools/src/tools/shell-helpers.ts
@@ -39,8 +39,13 @@ export function isShellToolHost(
   return 'executeShellCommand' in host;
 }
 
-const WRAPPED_PREFIX = '{ ';
-const WRAPPED_SUFFIX = ' }; __code=$?; pgrep -g 0 >';
+const TRAP_LINE_PREFIX = 'trap ';
+// Suffix following the canonical action token on the trap line: ` EXIT`. The
+// action token's own closing quote is consumed by matchCanonicalSingleQuoted,
+// so this is the text that must remain after it.
+const TRAP_LINE_SUFFIX = ' EXIT';
+const TRAP_ACTION_PREFIX = '__code=$?; pgrep -g 0 >';
+const TRAP_ACTION_SUFFIX = ' 2>&1; exit $__code';
 
 /**
  * Wraps a value in single quotes using POSIX-safe escaping so it can be
@@ -50,6 +55,70 @@ const WRAPPED_SUFFIX = ' }; __code=$?; pgrep -g 0 >';
  */
 export function singleQuoteForShell(value: string): string {
   return `'${value.split("'").join("'\\''")}'`;
+}
+
+/**
+ * Recognizes a canonical singleQuoteForShell token at the start of `input` and
+ * returns its decoded value plus the unconsumed remainder. Decoding walks the
+ * escaped-quote sequence (`'\''`) exactly as singleQuoteForShell emits it, then
+ * requires that re-encoding the decoded value reproduces the exact token. This
+ * rejects any input that merely resembles a quoted string without being a
+ * canonically generated wrapper argument.
+ */
+function matchCanonicalSingleQuoted(
+  input: string,
+): { decoded: string; rest: string } | null {
+  if (!input.startsWith("'")) {
+    return null;
+  }
+  let i = 1;
+  let decoded = '';
+  let closed = false;
+  while (i < input.length) {
+    const ch = input[i];
+    if (ch === "'") {
+      if (input.slice(i, i + 4) === "'\\''") {
+        decoded += "'";
+        i += 4;
+      } else {
+        closed = true;
+        break;
+      }
+    } else {
+      decoded += ch;
+      i += 1;
+    }
+  }
+  if (!closed) {
+    return null;
+  }
+  const token = input.slice(0, i + 1);
+  return singleQuoteForShell(decoded) === token
+    ? { decoded, rest: input.slice(i + 1) }
+    : null;
+}
+
+/**
+ * Confirms a decoded trap action is exactly the generated form:
+ * TRAP_ACTION_PREFIX + one canonical singleQuoteForShell path token +
+ * TRAP_ACTION_SUFFIX. Only such an action is treated as a generated wrapper.
+ */
+function isCanonicalTrapAction(action: string): boolean {
+  if (
+    !action.startsWith(TRAP_ACTION_PREFIX) ||
+    !action.endsWith(TRAP_ACTION_SUFFIX)
+  ) {
+    return false;
+  }
+  const pathToken = action.slice(
+    TRAP_ACTION_PREFIX.length,
+    action.length - TRAP_ACTION_SUFFIX.length,
+  );
+  const matched = matchCanonicalSingleQuoted(pathToken);
+  // The path slot must be EXACTLY one canonical token: no trailing content may
+  // remain after it, so a same-prefix/suffix trap with extra action content is
+  // treated as non-canonical and passed through unchanged.
+  return matched !== null && matched.rest === '';
 }
 
 function buildShellResultError(result: ShellResult): Error | null {
@@ -64,21 +133,30 @@ function buildShellResultError(result: ShellResult): Error | null {
 }
 
 function unwrapCommandForExecutionService(command: string): string {
-  if (!command.startsWith(WRAPPED_PREFIX)) {
+  if (!command.startsWith(TRAP_LINE_PREFIX)) {
     return command;
   }
-  // The wrapped form is `{ <cmd> }; __code=$?; pgrep -g 0 ><tmpfile> ...`.
-  // WRAPPED_SUFFIX marks where the command body ends; it is NOT at the very
-  // end of the string (the temp-file path and trailing shell follow it), so
-  // locate it by position rather than with endsWith.
-  const suffixIndex = command.indexOf(WRAPPED_SUFFIX, WRAPPED_PREFIX.length);
-  if (suffixIndex === -1) {
+  // The wrapped form is `trap '<quotedAction>' EXIT` followed by a newline and
+  // the trimmed body. The action token may itself contain a literal newline
+  // (e.g. a temp path with a line break), so it is decoded from the entire
+  // suffix after `trap ` rather than truncated at the first newline. After the
+  // canonical action is validated, the remainder must begin exactly with
+  // TRAP_LINE_SUFFIX plus a newline; the body is everything after that
+  // delimiter. The action token is validated strictly so only a canonically
+  // generated wrapper is unwrapped; anything else passes through unchanged.
+  const afterPrefix = command.slice(TRAP_LINE_PREFIX.length);
+  const actionToken = matchCanonicalSingleQuoted(afterPrefix);
+  if (actionToken === null) {
     return command;
   }
-  const innerCommand = command.slice(WRAPPED_PREFIX.length, suffixIndex).trim();
-  return innerCommand.endsWith(';')
-    ? innerCommand.slice(0, -1).trimEnd()
-    : innerCommand;
+  const bodyDelimiter = TRAP_LINE_SUFFIX + String.fromCharCode(10);
+  if (!actionToken.rest.startsWith(bodyDelimiter)) {
+    return command;
+  }
+  if (!isCanonicalTrapAction(actionToken.decoded)) {
+    return command;
+  }
+  return actionToken.rest.slice(bodyDelimiter.length);
 }
 
 const STANDALONE_BACKGROUND_ERROR =
@@ -279,20 +357,14 @@ export function buildCommandToExecute(
   if (isWindows) {
     return strippedCommand;
   }
-  const body = buildWrappedBody(strippedCommand.trim());
-  return `{ ${body} }; __code=$?; pgrep -g 0 >${tempFilePath} 2>&1; exit $__code;`;
-}
-
-/**
- * Builds the body that sits between the wrapper's `{ ` prefix and its
- * ` }; __code=$?; ...` suffix. A trailing-`;` is normalised away so the
- * generated `{ cmd; }` is syntactically clean.
- */
-function buildWrappedBody(trimmed: string): string {
-  const normalised = trimmed.endsWith(';')
-    ? trimmed.slice(0, -1).trimEnd()
-    : trimmed;
-  return `${normalised};`;
+  // Emit an EXIT trap on its own line so a body comment, heredoc, or terminal
+  // operator cannot consume the appended pgrep/exit epilogue. The trap action
+  // captures $? before running pgrep and re-exits with it, preserving the
+  // body's exit status. Both the path and the whole action are single-quoted
+  // via singleQuoteForShell so hostile paths stay literal shell data.
+  const trapAction = `${TRAP_ACTION_PREFIX}${singleQuoteForShell(tempFilePath)}${TRAP_ACTION_SUFFIX}`;
+  const newline = String.fromCharCode(10);
+  return `trap ${singleQuoteForShell(trapAction)} EXIT${newline}${strippedCommand.trim()}`;
 }
 
 export function parsePgrepFile(

--- a/packages/tools/test-bun/shell-tool-signal-format.bun.ts
+++ b/packages/tools/test-bun/shell-tool-signal-format.bun.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { ShellTool } from '../src/index.js';
+import type {
+  IShellToolHost,
+  IToolMessageBus,
+  ShellExecutionResult,
+  BackgroundPromotionResult,
+  HostShellJobInfo,
+  HostShellJobTailResult,
+} from '../src/interfaces/index.js';
+import { ToolConfirmationOutcome } from '../src/types/tool-confirmation-types.js';
+import type { ToolResult } from '../src/index.js';
+
+/**
+ * Focused Bun evidence for issue 2980 REQ-2980-4: when the PTY boundary has
+ * normalized a clean exit so that ShellExecutionResult.signal is null, shell
+ * tool formatting must report `Signal: (none)` and must NOT emit a
+ * "Command terminated by signal" message. A nonzero signal must still be
+ * reported verbatim with its termination message.
+ *
+ * The tool is exercised end-to-end through a minimal IShellToolHost whose
+ * executeShellCommand returns the normalized result directly, so the real
+ * formatting path (formatNormalOutput) is what is observed.
+ */
+
+function createResultHost(
+  result: Partial<ShellExecutionResult>,
+): IShellToolHost {
+  const full: ShellExecutionResult = {
+    output: '',
+    exitCode: 0,
+    signal: null,
+    error: null,
+    aborted: false,
+    pid: undefined,
+    ...result,
+  };
+  return {
+    getTargetDir: () => process.cwd(),
+    getWorkspaceContext: () => ({
+      getDirectories: () => [process.cwd()],
+      isPathWithinWorkspace: (resolvedPath: string) =>
+        resolvedPath === process.cwd() ||
+        resolvedPath.startsWith(`${process.cwd()}/`),
+    }),
+    isCommandAllowed: () => ({ allowed: true }),
+    isShellInvocationAllowlisted: () => false,
+    isInteractive: () => true,
+    isYoloMode: () => false,
+    getDebugMode: () => false,
+    getShellExecutionConfig: () => ({
+      shouldUseNodePty: false,
+      executionOptions: {},
+    }),
+    getTimeoutConfig: () => ({
+      timeoutSeconds: undefined,
+      defaultTimeoutSeconds: 60,
+    }),
+    getOutputLimits: () => ({}),
+    executeShellCommand: async (): Promise<ShellExecutionResult> => full,
+    getCommandRoots: (command: string) => {
+      const root = command.trim().split(/\s+/)[0];
+      return root ? [root] : [];
+    },
+    stripShellWrapper: (command: string) => command,
+    validatePathWithinWorkspace: () => null,
+    isPtyActive: () => false,
+    formatMemoryUsage: (bytes: number) =>
+      bytes < 1024 ? `${bytes} bytes` : `${(bytes / 1024).toFixed(1)} KB`,
+    trySummarizeOutput: async (content: string) => content,
+    getSummarizeConfig: () => undefined,
+    limitOutputTokens: (content: string) => ({
+      content,
+      wasTruncated: false,
+    }),
+    launchBackgroundJob: (): HostShellJobInfo => {
+      throw new Error('foreground formatting fixture does not launch jobs');
+    },
+    tailBackgroundJob: (id: string): HostShellJobTailResult => ({
+      id,
+      output: '',
+      truncated: false,
+    }),
+    detectTrailingBackground: (command: string): BackgroundPromotionResult => ({
+      promoted: false,
+      command,
+    }),
+  };
+}
+
+function proceedBus(): IToolMessageBus {
+  return {
+    requestConfirmation: async () => ToolConfirmationOutcome.ProceedOnce,
+    publishPolicyUpdate: async () => undefined,
+  };
+}
+
+async function runShell(
+  host: IShellToolHost,
+  command: string,
+): Promise<ToolResult> {
+  const tool = new ShellTool(host, proceedBus());
+  return (await tool.execute({ command })) as ToolResult;
+}
+
+describe('ShellTool signal formatting (issue 2980)', () => {
+  it('reports Signal: (none) and no termination message for a clean exit', async () => {
+    const result = await runShell(
+      createResultHost({ exitCode: 0, signal: null }),
+      'echo clean',
+    );
+
+    const llm = String(result.llmContent);
+    expect(llm).toContain('Signal: (none)');
+    expect(llm).not.toContain('Signal: 0');
+    expect(String(result.returnDisplay)).not.toContain(
+      'Command terminated by signal',
+    );
+  });
+
+  it('keeps a nonzero signal and the termination message unchanged', async () => {
+    const result = await runShell(
+      createResultHost({ exitCode: null, signal: '9' }),
+      'echo sig',
+    );
+
+    const llm = String(result.llmContent);
+    expect(llm).toContain('Signal: 9');
+    expect(String(result.returnDisplay)).toContain(
+      'Command terminated by signal: 9',
+    );
+  });
+});

--- a/packages/tools/test-bun/shell-wrapper.bun.ts
+++ b/packages/tools/test-bun/shell-wrapper.bun.ts
@@ -1,0 +1,410 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'bun:test';
+import type {
+  IShellExecutionService,
+  ShellResult,
+} from '../src/interfaces/IShellExecutionService.js';
+import {
+  buildCommandToExecute,
+  createShellToolHostFromExecutionService,
+  singleQuoteForShell,
+} from '../src/tools/shell-helpers.js';
+
+const isWindows = process.platform === 'win32';
+
+interface BashResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Executes a single bash script as one `bash -c` argument. */
+function runInBash(script: string, cwd: string): BashResult {
+  const result = spawnSync('bash', ['-c', script], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+/** Returns true when `pid` is a live, signalable process. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Sends SIGKILL to exactly one pid, ignoring errors if it already exited. */
+function terminatePid(pid: number): void {
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Already reaped; nothing to clean up.
+  }
+}
+
+/** Parses the numeric pids recorded by a `pgrep` result file. */
+function readPgrepPids(file: string): number[] {
+  if (!existsSync(file)) {
+    return [];
+  }
+  return readFileSync(file, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => Number(line.trim()))
+    .filter((pid) => Number.isInteger(pid) && pid > 0);
+}
+
+/**
+ * Reads and validates a single numeric PID recorded in `file`. Returns
+ * `undefined` when the file is absent or does not contain a valid PID, so a
+ * caller's `finally` can recover the exact survivor even if the in-try
+ * assignment never completed.
+ */
+function readExactPid(file: string): number | undefined {
+  if (!existsSync(file)) {
+    return undefined;
+  }
+  const parsed = Number(readFileSync(file, 'utf8').trim());
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/** Creates an isolated temp directory for the test body and removes it after. */
+async function withTempDir<T>(
+  body: (dir: string) => Promise<T> | T,
+): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'issue2980-'));
+  try {
+    return await body(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('singleQuoteForShell produces literal bash data', () => {
+  it('wraps ordinary text and whitespace in single quotes', () => {
+    expect(singleQuoteForShell('hello')).toBe("'hello'");
+    expect(singleQuoteForShell('a b c')).toBe("'a b c'");
+  });
+
+  it('makes shell metacharacters literal', () => {
+    expect(singleQuoteForShell('$(echo X)')).toBe("'$(echo X)'");
+    expect(singleQuoteForShell('`echo X`')).toBe("'`echo X`'");
+    expect(singleQuoteForShell('$HOME')).toBe("'$HOME'");
+  });
+});
+
+// Real-bash evidence: quoting must round-trip the exact original value, which
+// proves the escaping is correct for apostrophes, consecutive apostrophes, and
+// command-substitution syntax alike. Skipped on Windows (no bash).
+describe.skipIf(isWindows)('singleQuoteForShell survives real bash', () => {
+  it.each([
+    'hello',
+    'a b c',
+    "it's",
+    "a''b",
+    '$(echo INJECTED)',
+    '`echo INJECTED`',
+    'path with $var and $(cmd)',
+  ])('round-trips %j through bash without interpretation', (value) => {
+    const quoted = singleQuoteForShell(value);
+    const { status, stdout } = runInBash(`printf %s ${quoted}`, process.cwd());
+    expect(status).toBe(0);
+    expect(stdout).toBe(value);
+  });
+});
+
+// REQ-2980-1: the foreground wrapper must keep the user's shell grammar intact.
+// The generated command is executed through real bash, not string inspection.
+describe.skipIf(isWindows)(
+  'buildCommandToExecute preserves shell grammar',
+  () => {
+    it('runs an escaped terminal ampersand unchanged (regression contract)', async () => {
+      await withTempDir(async (dir) => {
+        const tempFilePath = join(dir, 'pgrep.tmp');
+        const generated = buildCommandToExecute(
+          'printf foo\\&',
+          false,
+          tempFilePath,
+        );
+        const { status, stdout } = runInBash(generated, dir);
+        expect(status).toBe(0);
+        expect(stdout).toBe('foo&');
+      });
+    });
+
+    it('does not let a trailing comment consume wrapper syntax', async () => {
+      await withTempDir(async (dir) => {
+        const tempFilePath = join(dir, 'pgrep.tmp');
+        const generated = buildCommandToExecute(
+          'echo hi # a trailing comment',
+          false,
+          tempFilePath,
+        );
+        const { status, stdout } = runInBash(generated, dir);
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe('hi');
+        expect(existsSync(tempFilePath)).toBe(true);
+      });
+    });
+
+    it('accepts a heredoc and writes the pgrep result file', async () => {
+      await withTempDir(async (dir) => {
+        const tempFilePath = join(dir, 'pgrep.tmp');
+        const generated = buildCommandToExecute(
+          'cat <<EOF\nhello\nEOF',
+          false,
+          tempFilePath,
+        );
+        const { status, stdout } = runInBash(generated, dir);
+        expect(status).toBe(0);
+        expect(stdout).toBe('hello\n');
+        expect(existsSync(tempFilePath)).toBe(true);
+      });
+    });
+
+    it('captures the exact surviving background PID via pgrep and cleans it up deterministically', async () => {
+      await withTempDir(async (dir) => {
+        const pgrepFile = join(dir, 'pgrep.tmp');
+        const childPidFile = join(dir, 'child.pid');
+        const quotedChildPidFile = singleQuoteForShell(childPidFile);
+        // Body truly ends in `&`. The long-lived child is backgrounded first,
+        // then the shell writes `$!` (the child's exact PID) to the pid file
+        // synchronously in the foreground, before a harmless final background
+        // operator (`true &`). Because the pid file is written before the
+        // script exits, it is guaranteed to exist before the EXIT trap fires,
+        // so the exact surviving PID is independently known for cleanup. All of
+        // the child's stdio is detached so it cannot hold the test's pipes open.
+        const body = `sleep 30 >/dev/null 2>&1 </dev/null & echo $! > ${quotedChildPidFile}; true &`;
+        const generated = buildCommandToExecute(body, false, pgrepFile);
+        try {
+          // Check the wrapper exit immediately and surface stderr as failure
+          // evidence before reading the PID file. stderr is not required to be
+          // empty (pgrep/the environment may legitimately write there).
+          const launch = runInBash(generated, dir);
+          expect(
+            launch.status,
+            `survivor wrapper should exit 0; got status=${launch.status} stderr=${launch.stderr}`,
+          ).toBe(0);
+          // The exact PID is guaranteed written before the trap, so read it
+          // directly rather than polling for it.
+          const childPid = readExactPid(childPidFile);
+          if (childPid === undefined) {
+            throw new Error(
+              `pid file did not record the exact child PID: ${JSON.stringify(
+                existsSync(childPidFile)
+                  ? readFileSync(childPidFile, 'utf8')
+                  : '<missing>',
+              )}`,
+            );
+          }
+          expect(childPid).toBeGreaterThan(0);
+          // The wrapper's EXIT-trap pgrep must record the exact surviving PID.
+          const captured = readPgrepPids(pgrepFile);
+          expect(captured).toContain(childPid);
+          expect(isAlive(childPid)).toBe(true);
+        } finally {
+          // Deterministic exact-PID cleanup: recover the exact PID from the
+          // file even if an assertion above failed, so no survivor can leak.
+          // Never a broad kill pattern.
+          const pid = readExactPid(childPidFile);
+          if (pid !== undefined) {
+            terminatePid(pid);
+          }
+        }
+      });
+    });
+
+    it('captures the body exit status before running pgrep', async () => {
+      await withTempDir(async (dir) => {
+        const cases: Array<{ command: string; exit: number }> = [
+          { command: 'echo ok', exit: 0 },
+          { command: 'false', exit: 1 },
+          { command: 'exit 42', exit: 42 },
+          { command: 'set -e; false', exit: 1 },
+          { command: 'echo hi;', exit: 0 },
+        ];
+        for (const { command, exit } of cases) {
+          const tempFilePath = join(dir, 'pgrep.tmp');
+          const generated = buildCommandToExecute(command, false, tempFilePath);
+          const { status } = runInBash(generated, dir);
+          expect(status).toBe(exit);
+          rmSync(tempFilePath, { force: true });
+        }
+      });
+    });
+  },
+);
+
+// REQ-2980-2: the pgrep temp-file path must be literal shell data, quoted with
+// singleQuoteForShell so command substitution never runs.
+describe.skipIf(isWindows)(
+  'buildCommandToExecute quotes hostile temp-file paths',
+  () => {
+    it('creates the exact literal path with spaces, an apostrophe, and $()', async () => {
+      await withTempDir(async (dir) => {
+        const tempFilePath = join(dir, "hostile's $(echo INJECTED).txt");
+        const generated = buildCommandToExecute(
+          'echo body',
+          false,
+          tempFilePath,
+        );
+        const { status } = runInBash(generated, dir);
+        expect(status).toBe(0);
+        expect(existsSync(tempFilePath)).toBe(true);
+        // Command substitution must not have run, so the expanded name does
+        // not exist.
+        expect(existsSync(join(dir, "hostile's INJECTED.txt"))).toBe(false);
+      });
+    });
+
+    it('records the literal quoted path content via the trap redirect', async () => {
+      await withTempDir(async (dir) => {
+        const tempFilePath = join(dir, 'plain.tmp');
+        const generated = buildCommandToExecute(
+          'printf data',
+          false,
+          tempFilePath,
+        );
+        runInBash(generated, dir);
+        // The redirect target is literal; the file exists even though pgrep
+        // may write nothing depending on the host process-group layout.
+        expect(existsSync(tempFilePath)).toBe(true);
+        expect(typeof readFileSync(tempFilePath, 'utf8')).toBe('string');
+      });
+    });
+
+    it('creates the exact literal path when the temp path contains a literal newline', async () => {
+      await withTempDir(async (dir) => {
+        const newline = String.fromCharCode(10);
+        const tempFilePath = join(dir, `before${newline}after.tmp`);
+        const generated = buildCommandToExecute(
+          'echo body',
+          false,
+          tempFilePath,
+        );
+        const { status } = runInBash(generated, dir);
+        expect(status).toBe(0);
+        expect(existsSync(tempFilePath)).toBe(true);
+      });
+    });
+  },
+);
+
+// REQ-2980-3: the standalone adapter must unwrap the generated form back to the
+// trimmed body (including a caller-supplied trailing semicolon and heredoc),
+// and must not rewrite anything that is not the generated form.
+describe('standalone adapter unwraps the generated wrapper', () => {
+  function recordingService(sink: {
+    command?: string;
+  }): IShellExecutionService {
+    return {
+      execute: async (command: string): Promise<ShellResult> => {
+        sink.command = command;
+        return { stdout: '', stderr: '', exitCode: 0, aborted: false };
+      },
+      isCommandAllowed: () => true,
+    };
+  }
+
+  async function delegatedCommand(
+    command: string,
+  ): Promise<string | undefined> {
+    const sink: { command?: string } = {};
+    const host = createShellToolHostFromExecutionService(
+      recordingService(sink),
+    );
+    await host.executeShellCommand(
+      command,
+      process.cwd(),
+      () => undefined,
+      new AbortController().signal,
+    );
+    return sink.command;
+  }
+
+  it('round-trips a plain trimmed body', async () => {
+    const wrapped = buildCommandToExecute(
+      'echo hi',
+      false,
+      '/tmp/whatever.tmp',
+    );
+    expect(await delegatedCommand(wrapped)).toBe('echo hi');
+  });
+
+  it('preserves a caller-supplied trailing semicolon', async () => {
+    const wrapped = buildCommandToExecute(
+      'echo hi;',
+      false,
+      '/tmp/whatever.tmp',
+    );
+    expect(await delegatedCommand(wrapped)).toBe('echo hi;');
+  });
+
+  it('round-trips a multiline heredoc body verbatim', async () => {
+    const body = 'cat <<EOF\nhello\nEOF';
+    const wrapped = buildCommandToExecute(body, false, '/tmp/whatever.tmp');
+    expect(await delegatedCommand(wrapped)).toBe(body);
+  });
+
+  it('unwraps a wrapper whose temp path contains apostrophes, $(), and spaces', async () => {
+    const hostilePath = "/tmp/hostile's $(echo INJECTED) dir/x.tmp";
+    const wrapped = buildCommandToExecute('echo body', false, hostilePath);
+    expect(await delegatedCommand(wrapped)).toBe('echo body');
+  });
+
+  it('unwraps a wrapper whose temp path contains a literal newline', async () => {
+    const newline = String.fromCharCode(10);
+    const newlinePath = `/tmp/before${newline}after.tmp`;
+    const wrapped = buildCommandToExecute('echo body', false, newlinePath);
+    expect(await delegatedCommand(wrapped)).toBe('echo body');
+  });
+
+  it('does not unwrap an arbitrary trap that merely shares the action prefix/suffix', async () => {
+    const arbitrary =
+      "trap '__code=$?; pgrep -g 0 >FAKE 2>&1; exit $__code' EXIT\nmalicious";
+    expect(await delegatedCommand(arbitrary)).toBe(arbitrary);
+  });
+
+  it('does not unwrap a trap whose action has extra content after the path token', async () => {
+    // Same prefix/suffix and a valid canonical path token as the generated
+    // action, but with trailing content the generated form never contains. The
+    // path slot must be EXACTLY one canonical token, so this must pass through.
+    const actionWithExtra =
+      '__code=$?; pgrep -g 0 >' +
+      singleQuoteForShell('/tmp/x') +
+      ' EVIL 2>&1; exit $__code';
+    const malicious = `trap ${singleQuoteForShell(actionWithExtra)} EXIT\nmalicious`;
+    expect(await delegatedCommand(malicious)).toBe(malicious);
+  });
+
+  it('does not rewrite an input that is not the generated wrapper form', async () => {
+    expect(await delegatedCommand('echo plain')).toBe('echo plain');
+    expect(await delegatedCommand('trap custom EXIT\necho x')).toBe(
+      'trap custom EXIT\necho x',
+    );
+  });
+});
+
+// REQ-2980-3: Windows execution remains a byte-identical pass-through.
+describe('buildCommandToExecute Windows pass-through', () => {
+  it('returns the command unchanged when isWindows is true', () => {
+    const command = "Write-Output 'hello world'";
+    expect(buildCommandToExecute(command, true, '/unused')).toBe(command);
+  });
+});

--- a/packages/tools/test-bun/shell-wrapper.bun.ts
+++ b/packages/tools/test-bun/shell-wrapper.bun.ts
@@ -251,6 +251,67 @@ describe.skipIf(isWindows)(
   },
 );
 
+// REQ-2980-4: characterize the known boundary where a body removes or
+// replaces the EXIT trap. Such a body intentionally opts out of the wrapper's
+// background-process discovery and epilogue exit-status re-emission. These
+// tests run REAL bash to pin the actual behavior; they are not a contract on
+// internal structure.
+describe.skipIf(isWindows)(
+  'buildCommandToExecute EXIT-trap opt-out boundary',
+  () => {
+    it('known opt-out: a body that clears the EXIT trap (trap - EXIT) suppresses the epilogue and writes no temp file', async () => {
+      await withTempDir(async (dir) => {
+        const tempFilePath = join(dir, 'pgrep.tmp');
+        const generated = buildCommandToExecute(
+          'trap - EXIT; echo cleared',
+          false,
+          tempFilePath,
+        );
+        const { status, stdout } = runInBash(generated, dir);
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe('cleared');
+        expect(existsSync(tempFilePath)).toBe(false);
+      });
+    });
+
+    it('known opt-out: a body that replaces the EXIT trap with its own action suppresses our epilogue (our temp file is absent) while its own action still fires', async () => {
+      await withTempDir(async (dir) => {
+        const tempFilePath = join(dir, 'pgrep.tmp');
+        const markerFile = join(dir, 'marker.txt');
+        const replacementTrap = `trap 'printf replaced > ${singleQuoteForShell(markerFile)}' EXIT`;
+        const generated = buildCommandToExecute(
+          `echo body; ${replacementTrap}`,
+          false,
+          tempFilePath,
+        );
+        const { status, stdout } = runInBash(generated, dir);
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe('body');
+        // The body's replacement trap fired on exit (its own marker exists)...
+        expect(existsSync(markerFile)).toBe(true);
+        expect(readFileSync(markerFile, 'utf8')).toBe('replaced');
+        // ...but our wrapper epilogue did not, so its temp file is absent.
+        expect(existsSync(tempFilePath)).toBe(false);
+      });
+    });
+
+    it('positive contrast: a body that calls exit <n> explicitly still triggers the epilogue, preserves the exact exit status, and writes the temp file', async () => {
+      await withTempDir(async (dir) => {
+        const tempFilePath = join(dir, 'pgrep.tmp');
+        const generated = buildCommandToExecute(
+          'echo bye; exit 42',
+          false,
+          tempFilePath,
+        );
+        const { status, stdout } = runInBash(generated, dir);
+        expect(status).toBe(42);
+        expect(stdout.trim()).toBe('bye');
+        expect(existsSync(tempFilePath)).toBe(true);
+      });
+    });
+  },
+);
+
 // REQ-2980-2: the pgrep temp-file path must be literal shell data, quoted with
 // singleQuoteForShell so command substitution never runs.
 describe.skipIf(isWindows)(

--- a/project-plans/issue2980/plan.md
+++ b/project-plans/issue2980/plan.md
@@ -1,0 +1,186 @@
+# Issue 2980: POSIX shell wrapper and PTY signal normalization
+
+Plan ID: PLAN-20260804-ISSUE2980
+Generated: 2026-08-04
+
+## Accepted scope
+
+This issue changes only the existing POSIX foreground command wrapper and the
+node-pty exit-result boundary. It does not change managed background jobs,
+security parsing, Windows execution, shell policy, dependencies, workflows,
+quality configuration, or public APIs.
+
+Current `main` already contains issue 1995. Its AST-based background promotion
+removed the stale `endsWith('&')` branch named in the issue. Therefore the
+escaped-ampersand case is accepted as a regression contract rather than a
+currently failing reproduction. The single-line wrapper still causes the
+comment and heredoc failures, leaves the temp-file redirect unsafe, and still
+receives node-pty's clean-exit signal value `0` unchanged.
+
+## Acceptance criteria
+
+### REQ-2980-1: Shell grammar remains the user's grammar
+
+- **GIVEN** a non-Windows shell command ending in an escaped literal ampersand,
+  such as `printf foo\&`
+- **WHEN** `buildCommandToExecute` generates a command and real Bash executes it
+- **THEN** it exits 0 and prints `foo&`.
+
+- **GIVEN** a command ending in a `#` comment
+- **WHEN** the generated command is executed through real Bash
+- **THEN** the comment does not consume wrapper syntax, the intended output and
+  exit status are preserved, and the pgrep result file is written.
+
+- **GIVEN** a command containing a heredoc
+- **WHEN** the generated command is executed through real Bash
+- **THEN** Bash accepts the heredoc, emits its content, preserves the command's
+  exit status, and writes the pgrep result file.
+
+- **GIVEN** a syntactically valid command body ending in a real `&` that reaches
+  the foreground builder rather than managed-job promotion
+- **WHEN** the generated command is executed through real Bash
+- **THEN** the wrapper itself does not introduce a syntax error and pgrep can
+  record a surviving process in the invocation's process group.
+
+Relevant preservation boundaries are an ordinary successful command, `false`,
+`exit 42`, `set -e; false`, and a command already ending in `;`. These prove
+that the wrapper captures the body status before running pgrep and does not
+silently rewrite the submitted body.
+
+### REQ-2980-2: Temp-file paths are literal shell data
+
+- **GIVEN** a pgrep temp-file path containing spaces, an apostrophe, and shell
+  command-substitution syntax
+- **WHEN** the generated command is executed through real Bash
+- **THEN** redirection creates that exact path, no command substitution runs,
+  and the body exit status is preserved.
+
+The existing `singleQuoteForShell` helper must be reused and covered directly
+for ordinary text, whitespace, apostrophes, consecutive apostrophes, and shell
+metacharacters.
+
+### REQ-2980-3: Wrapper consumers remain integrated
+
+- **GIVEN** the standalone execution-service adapter receives a command produced
+  by `buildCommandToExecute`
+- **WHEN** it unwraps the generated form
+- **THEN** the delegated command equals `strippedCommand.trim()`, including a
+  caller-supplied trailing semicolon and multiline/heredoc content.
+
+- **GIVEN** an input that is not in the generated wrapper form
+- **WHEN** the standalone adapter handles it
+- **THEN** the input is not rewritten.
+
+- **GIVEN** Zed terminal integration compares the generated command with its raw
+  command
+- **WHEN** the wrapper format changes
+- **THEN** terminal updates still correlate with the originating command.
+
+- **GIVEN** `isWindows === true`
+- **WHEN** `buildCommandToExecute` is called
+- **THEN** the command remains a byte-identical pass-through.
+
+### REQ-2980-4: Clean PTY exits do not report a signal
+
+- **GIVEN** node-pty invokes its exit callback with `{ exitCode: 0, signal: 0 }`
+- **WHEN** the PTY result is finalized
+- **THEN** `ShellExecutionResult.signal` is `null`.
+
+- **GIVEN** the normalized clean result reaches shell-tool formatting
+- **WHEN** output is empty or normal
+- **THEN** `llmContent` reports `Signal: (none)` and `returnDisplay` does not say
+  `Command terminated by signal: 0`.
+
+- **GIVEN** node-pty reports a nonzero signal such as 9 or 15
+- **WHEN** the result is finalized and formatted
+- **THEN** that signal remains unchanged and the termination display continues
+  to identify it.
+
+- **GIVEN** node-pty omits the signal
+- **WHEN** the result is finalized
+- **THEN** the signal remains normalized to `null`.
+
+## Design
+
+On POSIX, emit a trap before the body so no body comment, heredoc, or terminal
+operator can consume an appended epilogue:
+
+    trap '__code=$?; pgrep -g 0 >'<safely quoted path>' 2>&1; exit $__code' EXIT
+    <trimmed command body, otherwise verbatim>
+
+Construct both quoting layers with `singleQuoteForShell`: first quote the path
+inside the trap action, then quote the complete action for `trap`. Capture `$?`
+before `pgrep` and explicitly exit with the captured status. Keep `pgrep -g 0`
+and `2>&1`; changing process discovery is outside this issue.
+
+Update the private standalone-adapter unwrapping logic and Zed's private command
+matcher to recognize the new generated grammar. These are required integration
+changes, not new abstractions.
+
+Normalize signal with the exact boundary mapping `signal === 0 ? null : signal
+?? null` in PTY finalization. Do not add a second defensive normalization in
+`CoreShellToolHostAdapter`.
+
+## Test-first implementation sequence
+
+1. Add real-Bash behavioral tests for REQ-2980-1 and REQ-2980-2. The tests must
+   create isolated real temp directories, execute the generated string as one
+   `bash -c` argument, and skip on Windows. Register any new tools test file in
+   the existing Bun tools manifest.
+2. Add wrapper round-trip/pass-through and `singleQuoteForShell` tests for
+   REQ-2980-2/3. Keep the existing Zed integration test derived from the real
+   builder as the integration drift guard.
+3. Add a PTY harness case that drives the existing node-pty callback shape with
+   signal 0, plus shell-tool formatting evidence. Preserve existing nonzero and
+   null/undefined cases.
+4. Run the targeted tests and capture their expected RED failures before
+   changing production code.
+5. Implement only the wrapper, required private consumers, and PTY boundary
+   mapping described above; rerun targeted tests to GREEN.
+6. Run complete project verification and required reviews.
+
+## Explicit non-goals
+
+- Do not change `is_background`, AST promotion, `ShellJobManager`, background
+  spawn, process retention, or cancellation.
+- Do not replace `pgrep -g 0` with `jobs -p`, and do not modify
+  `parsePgrepFile`, `collectProcessInfo`, or PGID resolution.
+- Do not fix the separate CLI `!`-mode wrapper in
+  `shellCommandProcessor.ts`; it uses a different `pwd` protocol.
+- Do not address the deferred standalone-adapter limitation that drops pgrep
+  process information.
+- Do not engineer around a command that replaces the wrapper's EXIT trap or
+  uses `exec`; those are not requested behaviors and receive no new contract in
+  this issue.
+- Do not change Windows/PowerShell behavior, shell policy/security parsing,
+  schemas/descriptions, dependencies, workflows, agent memory, lint rules, or
+  complexity thresholds.
+
+## Review-finding triage baseline
+
+| Finding | Classification | Decision |
+| --- | --- | --- |
+| Current issue text references removed `endsWith('&')` logic | In-scope-Fix | Keep escaped `&` as behavioral regression evidence; fix the shared wrapper grammar rather than restoring heuristics. |
+| Wrapper format is hardcoded by Zed command matching | Blocker-Fix | Update the existing private matcher and retain integration coverage. |
+| Unwrapper currently strips a generated semicolon | Blocker-Fix | Preserve exact trimmed-body round trips under the new wrapper. |
+| Separate CLI `!`-mode wrapper has similar grammar risks | Defer | Different protocol and outside issue 2980. |
+| Standalone adapter does not collect pgrep process data | Defer | Previously recorded defect not listed in this issue. |
+| Tests for user EXIT traps or `exec` degradation | Reject | They would add behavior/contracts outside the accepted issue. |
+| Replace pgrep with upstream `jobs -p` | Reject | Changes process-discovery semantics outside the accepted behavior. |
+| Add adjacent defensive signal normalization | Reject | Normalize once at the PTY source boundary. |
+
+## Verification gates
+
+Targeted behavioral evidence must pass first. Before commit and PR creation, run:
+
+- `npm run test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run format`
+- `npm run build`
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+
+Then complete DeepThinker review, local Open Code Review with test files included,
+PR CI, CodeRabbit/PR review triage, conflict and ancestry checks. Completion
+requires every accepted behavior to have evidence on the candidate head and all
+Blocker-Fix/In-scope-Fix findings to be resolved.

--- a/scripts/bun-test-manifest-data-tools.ts
+++ b/scripts/bun-test-manifest-data-tools.ts
@@ -13,6 +13,8 @@ export const TOOLS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
     'test-bun/imageDimensions.bun.ts',
     'test-bun/imageTokenEstimation.bun.ts',
     'test-bun/language-analysis.followup.bun.ts',
+    'test-bun/shell-wrapper.bun.ts',
+    'test-bun/shell-tool-signal-format.bun.ts',
     'src/tools/activate-skill.test.ts',
     'src/tools/ast-edit.ide.test.ts',
     'src/tools/edit-utils.test.ts',

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -185,6 +185,10 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       // and likewise excluded from the Vitest selection.
       'src/utils/sandbox-ssh-agent-preflight.test.ts',
       'src/zed-integration/zed-session-lifecycle.test.ts',
+      // Issue #2980: Zed terminal command correlation. Migrated to bun:test
+      // and excluded from the Vitest selection below; the strict wrapper
+      // matcher is exercised here while keeping the lifecycle guard intact.
+      'src/zed-integration/zedIntegration.terminal.test.ts',
       'test-bun/iContentToHistoryItems.issue2511.bun.ts',
       'src/ui/commands/authCommand.loginWithBucket.issue2891.test.ts',
       'test-utils/augment-bun-vi-cleanup.bun.ts',


### PR DESCRIPTION
## Summary

Fixes #2980.

The POSIX foreground shell wrapper appended its background-discovery and
exit-status epilogue on the *same line* as the user's command:

    { <command> }; __code=$?; pgrep -g 0 ><tmp> 2>&1; exit $__code;

Any body whose final line legitimately swallows following text destroyed the
epilogue, so the temp file was never written and background-process discovery
and exit-status reporting silently broke. The temp path was also interpolated
unquoted, so a path containing spaces, apostrophes, or command substitution was
parsed as shell syntax.

## What changed

**Wrapper generation (packages/tools/src/tools/shell-helpers.ts)**

The epilogue is now emitted as an EXIT trap on its own line, ahead of the body:

    trap '<action>' EXIT
    <command>

- A trailing comment, a heredoc, or a terminal operator in the body can no
  longer consume the epilogue, because nothing follows the body.
- The trap action captures the body's status first and re-exits with it, so the
  reported exit status is unchanged.
- The temp path and the whole trap action are single-quoted with the existing
  POSIX escaping helper, so hostile paths stay literal shell data.
- The body is no longer rewritten (the old form stripped a trailing semicolon
  to keep the brace group syntactically valid); it is passed through verbatim.
- Windows keeps its existing unwrapped pass-through.

**Wrapper recognition (private, in both consumers)**

The standalone adapter and the Zed terminal manager both need to recognise a
generated wrapper. Recognition is strict: the trap action must decode as
exactly one canonically quoted path token with the exact generated prefix and
suffix and nothing left over. A user command that merely looks like a trap, or
that shares the prefix and suffix with extra content, is passed through
untouched. These helpers stay private to each consumer; no new public API or
shared abstraction is introduced.

**Clean PTY exit signal (packages/core/src/services/shellPtyLifecycle.ts)**

node-pty reports a signal value of 0 on a clean exit, which surfaced as a bogus
termination signal in tool output. It is normalized to null exactly once at the
PTY boundary; undefined stays null and every nonzero signal is preserved.

## Tests

All new and changed tests are Bun / bun:test.

- packages/tools/test-bun/shell-wrapper.bun.ts drives **real bash** and covers:
  quoting round-trips through bash for metacharacters and command
  substitution; an escaped terminal ampersand; a trailing comment; a heredoc;
  exit-status capture across a matrix of statuses; hostile temp paths including
  spaces, an apostrophe, command substitution, and a literal newline; exact
  surviving-background-PID capture via the trap's pgrep, with deterministic
  exact-PID cleanup (never a broad kill pattern); wrapper-recognition
  boundaries; and the Windows pass-through.
- packages/tools/test-bun/shell-tool-signal-format.bun.ts asserts a clean exit
  reports no signal and no termination message, while a real signal is
  unchanged.
- packages/core/src/services/shellPtySignal.bun.test.ts covers signal 0,
  omitted signal, and a preserved nonzero signal.
- packages/cli/src/zed-integration/zedIntegration.terminal.test.ts (migrated to
  bun:test) adds correlation cases for a newline-bearing temp path and
  over-matching negatives.

## Verification

Full suite green on this head: tests, typecheck, format, build, and the
stepfun-37 smoke run.

Note on lint: `npm run lint` reports 15 pre-existing
@typescript-eslint/await-thenable errors in
packages/core/src/utils/retry.onAuthError.test.ts and three
packages/providers RetryOrchestrator tests. Those files are untouched by this
branch and byte-identical to main; the same 15 errors reproduce on a pristine
checkout of main (fd4c82fe2) in the same environment. No lint rule, threshold,
or suppression was changed by this PR.
