### PR TITLE
fix(observation): stop a tool-result from resurrecting a cancelled tool phase

### DIFF
--- a/packages/cli/src/observation/observationTap.test.ts
+++ b/packages/cli/src/observation/observationTap.test.ts
@@ -5,8 +5,10 @@
  */
 
 import type { AgentEvent } from '@vybestack/llxprt-code-agents';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'bun:test';
+import type { JspToolPhase } from './jspDocuments.js';
 import { createObservationTap } from './observationTap.js';
+import type { ObservationTapTarget } from './observationTap.js';
 
 const textEvent: AgentEvent = { type: 'text', text: 'draft' };
 const toolCallEvent: AgentEvent = {
@@ -44,6 +46,26 @@ const secondExecutingEvent: AgentEvent = {
   type: 'tool-status',
   update: { id: 'tool-2', name: 'run_shell', status: 'executing' },
 };
+const cancelledStatusEvent: AgentEvent = {
+  type: 'tool-status',
+  update: { id: 'tool-1', name: 'read_file', status: 'cancelled' },
+};
+const errorStatusEvent: AgentEvent = {
+  type: 'tool-status',
+  update: { id: 'tool-1', name: 'read_file', status: 'error' },
+};
+const successStatusEvent: AgentEvent = {
+  type: 'tool-status',
+  update: { id: 'tool-1', name: 'read_file', status: 'success' },
+};
+const okResultEvent: AgentEvent = {
+  type: 'tool-result',
+  result: { id: 'tool-1', name: 'read_file', output: 'done', isError: false },
+};
+const errorResultEvent: AgentEvent = {
+  type: 'tool-result',
+  result: { id: 'tool-1', name: 'read_file', output: 'boom', isError: true },
+};
 
 /**
  * A target whose callbacks are inert except where a test overrides them, so
@@ -62,6 +84,20 @@ function noopTarget(calls: string[]) {
     onAssistantMessageCommitted: () => undefined,
     onSourceError: () => undefined,
   };
+}
+
+/** Records only the headline tool phases, in order, for terminal-stickiness. */
+function phaseRecordingTarget(): {
+  target: ObservationTapTarget;
+  phases: string[];
+} {
+  const phases: string[] = [];
+  const target: ObservationTapTarget = {
+    ...noopTarget([]),
+    onToolPhaseChanged: (_label: string, phase: JspToolPhase) =>
+      phases.push(phase),
+  };
+  return { target, phases };
 }
 
 describe('createObservationTap', () => {
@@ -243,5 +279,103 @@ describe('createObservationTap', () => {
       } as AgentEvent);
       expect(calls).toContain(`phase:read_file:${phase}`);
     }
+  });
+
+  it('preserves a cancelled phase when a later non-error tool-result arrives (#2914)', () => {
+    // A tool cancelled by abort projects to a non-error tool-result, so the
+    // later result must not rewrite the faithful cancelled status.
+    const { target, phases } = phaseRecordingTarget();
+    const tap = createObservationTap(target);
+    tap.onTurnStarted();
+    tap.processEvent(toolCallEvent);
+    tap.processEvent(cancelledStatusEvent);
+    tap.processEvent(okResultEvent);
+
+    expect(phases).toStrictEqual(['cancelled']);
+  });
+
+  it('preserves a cancelled phase when a later error tool-result arrives (#2914)', () => {
+    const { target, phases } = phaseRecordingTarget();
+    const tap = createObservationTap(target);
+    tap.onTurnStarted();
+    tap.processEvent(cancelledStatusEvent);
+    tap.processEvent(errorResultEvent);
+
+    expect(phases).toStrictEqual(['cancelled']);
+  });
+
+  it('does not resurrect a terminal phase with a later non-terminal status', () => {
+    const { target, phases } = phaseRecordingTarget();
+    const tap = createObservationTap(target);
+    tap.onTurnStarted();
+    tap.processEvent(toolCallEvent);
+    tap.processEvent(errorStatusEvent);
+    tap.processEvent(executingEvent);
+
+    expect(phases).toStrictEqual(['failed']);
+  });
+
+  it('keeps the first terminal phase when two terminal statuses disagree', () => {
+    const { target, phases } = phaseRecordingTarget();
+    const tap = createObservationTap(target);
+    tap.onTurnStarted();
+    tap.processEvent(toolCallEvent);
+    tap.processEvent(cancelledStatusEvent);
+    tap.processEvent(successStatusEvent);
+
+    expect(phases).toStrictEqual(['cancelled']);
+  });
+
+  it('still reports succeeded and failed for normal terminal results when nothing was cancelled', () => {
+    const success = phaseRecordingTarget();
+    const successTap = createObservationTap(success.target);
+    successTap.onTurnStarted();
+    successTap.processEvent(toolCallEvent);
+    successTap.processEvent(executingEvent);
+    successTap.processEvent(okResultEvent);
+    expect(success.phases).toContain('succeeded');
+
+    const failure = phaseRecordingTarget();
+    const failureTap = createObservationTap(failure.target);
+    failureTap.onTurnStarted();
+    failureTap.processEvent(errorResultEvent);
+    expect(failure.phases).toStrictEqual(['failed']);
+  });
+
+  it('resets terminal suppression at the turn boundary so a reused id can succeed again', () => {
+    const { target, phases } = phaseRecordingTarget();
+    const tap = createObservationTap(target);
+
+    // Turn 1: tool-1 is cancelled, so its terminal phase sticks.
+    tap.onTurnStarted();
+    tap.processEvent(toolCallEvent);
+    tap.processEvent(cancelledStatusEvent);
+
+    // Turn 2: the same call id is replayed with a normal success. The
+    // suppression must not leak across the turn boundary.
+    tap.onTurnStarted();
+    tap.processEvent(toolCallEvent);
+    tap.processEvent(okResultEvent);
+
+    expect(phases).toStrictEqual(['cancelled', 'succeeded']);
+  });
+
+  it('does not strand a wait when a terminal tool-result is suppressed (#2914)', () => {
+    const resolved: string[] = [];
+    const { target, phases } = phaseRecordingTarget();
+    const tap = createObservationTap({
+      ...target,
+      onWaitResolved: () => resolved.push('resolved'),
+    });
+    tap.onTurnStarted();
+    tap.processEvent(toolCallEvent);
+    tap.processEvent(confirmationEvent);
+    tap.processEvent(cancelledStatusEvent);
+    tap.processEvent(okResultEvent);
+
+    // The wait resolves exactly once (from the cancelled status), and the
+    // suppressed tool-result emits no further phase at all.
+    expect(resolved).toStrictEqual(['resolved']);
+    expect(phases).toStrictEqual(['awaiting_approval', 'cancelled']);
   });
 });

--- a/packages/cli/src/observation/observationTap.ts
+++ b/packages/cli/src/observation/observationTap.ts
@@ -86,10 +86,26 @@ function mapToolStatus(
   }
 }
 
+function isTerminalPhase(phase: JspToolPhase): boolean {
+  return phase === 'succeeded' || phase === 'failed' || phase === 'cancelled';
+}
+
 /** Mutable correlation state scoped to a single turn. */
 interface TurnScope {
   readonly toolLabels: Map<string, string>;
   readonly awaitingConfirmation: Set<string>;
+  /**
+   * Call ids that already reported a terminal phase this turn.
+   *
+   * The first terminal phase observed for a call id is sticky: a cancelled
+   * tool still emits a terminal `tool-result`, and
+   * `projectToolResult` derives `isError` as
+   * `status === 'error' || (status === 'cancelled' && outcome === Cancel)`,
+   * so a tool cancelled by abort (not by an explicit Cancel confirmation
+   * outcome) yields `isError: false` and would otherwise be rewritten from
+   * `cancelled` to `succeeded` by the later `tool-result`.
+   */
+  readonly terminalTools: Set<string>;
 }
 
 function routeToolEvent(
@@ -99,9 +115,18 @@ function routeToolEvent(
 ): void {
   if (event.type === 'tool-status') {
     const label = scope.toolLabels.get(event.update.id) ?? event.update.name;
-    target.onToolPhaseChanged(label, mapToolStatus(event.update.status));
+    const phase = mapToolStatus(event.update.status);
+    if (!scope.terminalTools.has(event.update.id)) {
+      target.onToolPhaseChanged(label, phase);
+      if (isTerminalPhase(phase)) {
+        scope.terminalTools.add(event.update.id);
+      }
+    }
+    // Suppression above covers only the phase emission. A suppressed event
+    // still has to clear a pending approval, or an observer would be left
+    // showing a wait that can never resolve.
     if (
-      mapToolStatus(event.update.status) !== 'awaiting_approval' &&
+      phase !== 'awaiting_approval' &&
       scope.awaitingConfirmation.delete(event.update.id) &&
       scope.awaitingConfirmation.size === 0
     ) {
@@ -110,10 +135,12 @@ function routeToolEvent(
     return;
   }
   const label = scope.toolLabels.get(event.result.id) ?? event.result.name;
-  target.onToolPhaseChanged(
-    label,
-    event.result.isError === true ? 'failed' : 'succeeded',
-  );
+  const phase: JspToolPhase =
+    event.result.isError === true ? 'failed' : 'succeeded';
+  if (!scope.terminalTools.has(event.result.id)) {
+    target.onToolPhaseChanged(label, phase);
+    scope.terminalTools.add(event.result.id);
+  }
   scope.toolLabels.delete(event.result.id);
   if (
     scope.awaitingConfirmation.delete(event.result.id) &&
@@ -181,6 +208,7 @@ export function createObservationTap(
   const scope: TurnScope = {
     toolLabels: new Map<string, string>(),
     awaitingConfirmation: new Set<string>(),
+    terminalTools: new Set<string>(),
   };
 
   /**
@@ -195,6 +223,7 @@ export function createObservationTap(
     const hadPendingApproval = scope.awaitingConfirmation.size > 0;
     scope.toolLabels.clear();
     scope.awaitingConfirmation.clear();
+    scope.terminalTools.clear();
     if (hadPendingApproval) {
       target.onWaitResolved();
     }

--- a/project-plans/20260804-issue2914/plan.md
+++ b/project-plans/20260804-issue2914/plan.md
@@ -1,0 +1,164 @@
+# Issue #2914 — Observation tap: a tool-result event overwrites a prior cancelled tool phase
+
+## Problem
+
+`routeToolEvent` in `packages/cli/src/observation/observationTap.ts` maps a
+`tool-result` event to a headline tool phase based solely on `isError`:
+
+```ts
+target.onToolPhaseChanged(
+  label,
+  event.result.isError === true ? 'failed' : 'succeeded',
+);
+```
+
+If a preceding `tool-status` event already reported the tool as `cancelled`, the
+subsequent non-error `tool-result` overwrites that phase with `succeeded`, so a
+cancelled tool is published to JSP/1 observers as having completed successfully.
+
+## Required design decisions (from the issue)
+
+### 1. Can a cancelled tool still emit a terminal `tool-result`?
+
+**Yes.** `packages/agents/src/api/eventAdapter.ts` `mapLoopEvent` emits:
+
+- `tool-status` for every `ToolCall` in a loop `tool_update` event
+  (`projectToolUpdate`), including `status: 'cancelled'`; and
+- `tool-result` for **every** `CompletedToolCall` in a `tools_complete` event
+  (`projectToolResult`), with no filtering of cancelled calls.
+
+So the canonical event stream does deliver `tool-status(cancelled)` followed by
+a terminal `tool-result` for the same call id.
+
+### 2. Is `isError` a reliable cancellation signal?
+
+**No.** `projectToolResult` computes:
+
+```ts
+isError:
+  x.status === 'error' ||
+  (x.status === 'cancelled' && x.outcome === ToolConfirmationOutcome.Cancel),
+```
+
+A tool cancelled by abort (signal/turn cancellation) rather than by an explicit
+user `Cancel` confirmation outcome yields `isError: false`. That is precisely
+the reported failure mode: `cancelled` -> `succeeded`.
+
+### 3. What is the correct terminal phase?
+
+**The first terminal phase observed for a tool call wins.** `succeeded`,
+`failed` and `cancelled` are all terminal in `JspToolPhase`. Once a tool call
+has been reported in a terminal phase, no later event for that same call id may
+change it — neither a redundant terminal event (the `cancelled` -> `succeeded`
+bug) nor a stale non-terminal event (which would resurrect a completed tool as
+`executing`).
+
+This is safe against genuine disagreement: `tool_update` and `tools_complete`
+project the **same** `ToolCall` object, so a status/result disagreement can only
+arise from the `isError` derivation above, where `tool-status` carries the more
+faithful value.
+
+## Implementation
+
+File: `packages/cli/src/observation/observationTap.ts`
+
+1. Add a module-level predicate:
+
+   ```ts
+   function isTerminalPhase(phase: JspToolPhase): boolean {
+     return phase === 'succeeded' || phase === 'failed' || phase === 'cancelled';
+   }
+   ```
+
+2. Extend `TurnScope` with per-tool terminal tracking:
+
+   ```ts
+   interface TurnScope {
+     readonly toolLabels: Map<string, string>;
+     readonly awaitingConfirmation: Set<string>;
+     /** Call ids that already reported a terminal phase this turn. */
+     readonly terminalTools: Set<string>;
+   }
+   ```
+
+3. In `routeToolEvent`:
+   - **`tool-status` branch**: call `mapToolStatus` exactly **once** (it is
+     currently called twice) and store it in a local. If
+     `scope.terminalTools.has(event.update.id)`, do **not** call
+     `onToolPhaseChanged`. Otherwise emit the phase and, when
+     `isTerminalPhase(phase)`, add the id to `scope.terminalTools`.
+     The pending-approval bookkeeping (`awaitingConfirmation.delete` +
+     `onWaitResolved`) must run **unconditionally**, i.e. it must not be
+     skipped by terminal suppression, or a suppressed event could strand a wait.
+   - **`tool-result` branch**: if `scope.terminalTools.has(event.result.id)`, do
+     **not** call `onToolPhaseChanged`. Otherwise emit
+     `isError === true ? 'failed' : 'succeeded'` and record the id as terminal.
+     The existing `toolLabels.delete` and pending-approval bookkeeping stay
+     unconditional.
+
+4. In `createObservationTap`, initialise `terminalTools: new Set<string>()` and
+   clear it in `resetTurnScopedState()` alongside `toolLabels` /
+   `awaitingConfirmation`, so the suppression is turn-scoped and cannot leak
+   into a later turn (and cannot grow for the life of the session).
+
+Add a short comment explaining *why* terminal phases are sticky (the `isError`
+derivation above), not *what* the code does.
+
+No changes to `jspProducerState.ts` / `jspProducer.ts`: the defect is entirely
+in the tap's event->phase mapping.
+
+## Tests
+
+File: `packages/cli/src/observation/observationTap.test.ts`
+
+This file already runs **Bun-native only** — it is registered in
+`scripts/bun-test-manifest.ts` and excluded from Vitest discovery by
+`packages/cli/vitest.test-groups.ts` (`'**/src/observation/**/*.test.ts'`).
+It currently still imports from `'vitest'` via Bun's shim.
+
+**Conversion requirement:** change the import to `import { describe, expect, it }
+from 'bun:test';`. No new Vitest/Node tests. Do not add the file to any Vitest
+config. Do not change `bun-test-manifest.ts` (already listed) or
+`vitest.test-groups.ts` (already excluded).
+
+Behavioral tests to add (real `createObservationTap`, real `AgentEvent`
+payloads, recording target — no mocks of the unit under test):
+
+1. **cancelled survives a non-error tool-result** — `tool-call`,
+   `tool-status(cancelled)`, `tool-result{isError: false}`. Assert the recorded
+   phase changes for the tool are exactly `['cancelled']` and that
+   `succeeded` never appears.
+2. **cancelled survives an error tool-result** — `tool-status(cancelled)` then
+   `tool-result{isError: true}`. Assert `failed` is not emitted after
+   `cancelled`.
+3. **a terminal phase is not resurrected by a later non-terminal status** —
+   `tool-status(error)` then `tool-status(executing)`. Assert only `failed` is
+   recorded.
+4. **first terminal wins across two disagreeing terminal statuses** —
+   `tool-status(cancelled)` then `tool-status(success)`; only `cancelled`.
+5. **normal success is unaffected** — `tool-call`, `tool-status(executing)`,
+   `tool-result{isError: false}` still reports `succeeded`; and
+   `tool-result{isError: true}` alone still reports `failed`. This guards
+   against the suppression over-firing.
+6. **suppression is turn-scoped** — cancel tool id `tool-1` in turn 1, start a
+   new turn, replay `tool-call` + `tool-result{isError:false}` for the same id,
+   and assert `succeeded` **is** emitted in turn 2.
+7. **terminal suppression does not strand a wait** — `tool-call`,
+   `tool-confirmation` (wait opened), `tool-status(cancelled)` (wait resolved
+   once), then `tool-result{isError:false}`; assert exactly one
+   `wait.resolved` and no `succeeded` phase.
+
+Keep the existing tests passing unchanged (notably the full canonical-event
+ordering assertion and the `ToolUpdateStatus` -> `JspToolPhase` mapping table).
+
+## Verification (all must pass)
+
+```
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/run_bun_tests.ts --workspace cli
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```


### PR DESCRIPTION
## Summary

Fixes the observation tap defect reported in #2914: a `tool-result` event
overwrote a tool phase that a prior `tool-status` event had already reported as
`cancelled`, so observers were told a cancelled tool completed successfully.

Closes #2914

## Root cause

`routeToolEvent` in `packages/cli/src/observation/observationTap.ts` derived the
headline tool phase for a `tool-result` event from a single boolean:

```ts
target.onToolPhaseChanged(label, event.result.isError === true ? 'failed' : 'succeeded');
```

The issue asked for a decision about the `AgentEvent` ordering guarantees before
fixing this. That analysis is in `packages/agents/src/api/eventAdapter.ts`:

1. **A cancelled tool can still emit a terminal result.** `mapLoopEvent` yields a
   `tool-status` for every `ToolCall` in a `tool_update` batch (including one
   whose status is `cancelled`) and a `tool-result` for every `CompletedToolCall`
   in `tools_complete`. Nothing filters cancelled calls out of `tools_complete`,
   so the `cancelled` status and the terminal result are both delivered, in that
   order.

2. **A cancelled tool's result is not necessarily an error.**
   `projectToolResult` computes

   ```ts
   isError: x.status === 'error' ||
            (x.status === 'cancelled' && x.outcome === ToolConfirmationOutcome.Cancel)
   ```

   A tool cancelled by the **abort signal** rather than by an explicit `Cancel`
   confirmation outcome therefore arrives with `isError: false`. That is the
   exact sequence in the issue: `cancelled` -> `succeeded`.

3. **The correct terminal phase is the first one.** `cancelled`, `failed` and
   `succeeded` are all terminal in the JSP tool-phase vocabulary. The earliest
   terminal phase is the one the scheduler actually decided; the later
   `tool-result` is a projection of the same completion, not a new outcome.

## The fix

Rather than special-casing the cancelled-then-result pair, the tap now treats
the **first terminal phase observed for a call id as authoritative for the rest
of the turn**.

- `TurnScope` gains `readonly terminalTools: Set<string>` (documented with the
  `projectToolResult` derivation above as the reason it has to exist).
- A small `isTerminalPhase(phase)` predicate recognises `succeeded` / `failed` /
  `cancelled`.
- Both the `tool-status` and `tool-result` branches skip `onToolPhaseChanged`
  when the call id is already in `terminalTools`, and record the id when they do
  emit a terminal phase.
- `resetTurnScopedState()` clears the set, so it is turn-scoped exactly like
  `toolLabels` and `awaitingConfirmation`.

This also closes the symmetric resurrection hole: a late **non-terminal**
`tool-status` can no longer move a finished tool backwards. That is reachable
today, because `projectToolOutput` maps a trailing `tool_output` chunk to a
`tool-status` with status `executing`.

### Wait bookkeeping is deliberately not suppressed

Suppression covers **only** the phase emission. Label cleanup
(`toolLabels.delete`) and the `awaitingConfirmation` / `onWaitResolved`
bookkeeping still run for every event. Gating those behind the same check would
let a suppressed terminal result strand a pending approval, leaving an observer
showing a wait that can never resolve. There is a comment at the call site
saying so, and a dedicated regression test.

The `tool-status` branch also now calls `mapToolStatus` once into a local
instead of twice.

## Tests

`packages/cli/src/observation/observationTap.test.ts` gains seven behavioral
tests (13 total in the file, all passing). Each `#2914` test was confirmed to
**fail against the pre-fix code**:

| Test | Guards |
| --- | --- |
| cancelled phase preserved when a later non-error `tool-result` arrives | the exact defect in the issue |
| cancelled phase preserved when a later error `tool-result` arrives | the `outcome === Cancel` variant |
| a terminal phase is not resurrected by a later non-terminal status | trailing `tool_output` -> `executing` |
| the first terminal phase wins when two terminal statuses disagree | ordering decision #3 |
| `succeeded` / `failed` still reported for normal results | no regression to the happy path |
| suppression resets at a turn boundary so a reused id can succeed again | turn-scoping of `terminalTools` |
| a suppressed terminal result does not strand a wait | the unconditional wait bookkeeping |

### Test-framework conversion

The file is converted from `vitest` to `bun:test` in the same change. It was
already excluded from Vitest by `packages/cli/vitest.test-groups.ts:71`
(`'**/src/observation/**/*.test.ts'`) and registered as Bun-native in
`scripts/bun-test-manifest.ts:122`, so the `vitest` import was only resolving
through Bun's compatibility shim. No new Vitest or `node:test` tests are added.

## Verification

- `bun test src/observation/observationTap.test.ts` -> **13 pass, 0 fail**, 34 assertions
- `bun scripts/run_bun_tests.ts --workspace cli` -> 23/24 files pass; the one
  failure is the pre-existing Windows `sandbox-containers.test.ts` drive-letter
  case, untouched by this change
- `npm run typecheck` -> clean
- `npm run build` -> clean
- `npx eslint` on both changed files -> clean
- `npx prettier --check` on both changed files -> unchanged
- Open code review (`ocr review --audience agent`) -> the logic change is
  explicitly endorsed; its only two findings both question the `bun:test`
  import, which is a false positive (100+ files in the repo already import from
  `bun:test`, and this file is Vitest-excluded and Bun-manifest-registered)

## Scope

No behavior outside the observation tap changes. `jspProducerState.ts`,
`jspProducer.ts` and `jspWiring.ts` were audited and have no other path that can
publish a cancelled tool as succeeded. The Vitest exclusion list and the Bun
test manifest already covered this file and were not modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool status reporting to preserve terminal states consistently.
  - Prevented conflicting follow-up updates after a tool reaches a terminal state.
  - Ensured turn-level state resets correctly between interactions.
  - Improved handling of suppressed terminal results so pending waits resolve reliably.
  - Preserved approval updates while preventing duplicate terminal notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->