### PR TITLE
Deliver the model-facing llmContent remedy on tool errors (Fixes #3037)

### DIFF
--- a/packages/agents/src/core/nonInteractiveToolExecutor.test.ts
+++ b/packages/agents/src/core/nonInteractiveToolExecutor.test.ts
@@ -259,7 +259,10 @@ describe('executeToolCall', () => {
       | { error?: unknown; output?: unknown }
       | undefined;
     expect(payload?.output).toBeUndefined();
-    expect(payload?.error).toBe('Execution failed');
+    // Issue #3037: the model-facing tool_response carries the remedial
+    // llmContent ('Error: Execution failed'), not the terse error.message
+    // ('Execution failed'), while error.message/resultDisplay stay terse.
+    expect(payload?.error).toBe('Error: Execution failed');
   });
 
   it('should return an error if execution throws', async () => {

--- a/packages/agents/src/scheduler/result-aggregator.test.ts
+++ b/packages/agents/src/scheduler/result-aggregator.test.ts
@@ -445,6 +445,10 @@ describe('ResultAggregator', () => {
       );
     });
 
+    // The fallback hands back error.message verbatim, without token limiting.
+    // That is the pre-existing behaviour of every createErrorResponse call
+    // site and is deliberately left alone here; AC4's limiting applies to the
+    // llmContent this change newly lifts through the boundary.
     it('falls back to error.message when llmContent is empty (AC3)', async () => {
       agg.beginBatch(1);
       const call = makeScheduledCall('c-empty', 'insert_at_line');

--- a/packages/agents/src/scheduler/result-aggregator.test.ts
+++ b/packages/agents/src/scheduler/result-aggregator.test.ts
@@ -12,6 +12,7 @@ import type { ToolResult } from '@vybestack/llxprt-code-tools';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
 import { DEFAULT_MAX_TOKENS } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
 import type { ToolOutputSettingsProvider } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
+import type { ToolCallResponseInfo } from '../core/turn.js';
 
 // ---- helpers ----------------------------------------------------------------
 
@@ -351,6 +352,227 @@ describe('ResultAggregator', () => {
       // All succeed; batchOutputConfig was used instead of fallback for
       // individual publishing (fallback still called once during beginBatch)
       expect(callbacks.setSuccess).toHaveBeenCalledTimes(10);
+    });
+  });
+
+  // ---------- publishResult — error llmContent remedy (issue #3037) --------
+
+  describe('publishResult — model-facing error llmContent (issue #3037)', () => {
+    function publishedErrorResponse(): ToolCallResponseInfo {
+      const calls = (callbacks.setError as ReturnType<typeof vi.fn>).mock
+        .calls as Array<[string, ToolCallResponseInfo]>;
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+      return calls[calls.length - 1][1];
+    }
+
+    function errorResultBlockText(response: ToolCallResponseInfo): string {
+      const block = response.responseParts[0];
+      if (block.type !== 'tool_response') {
+        throw new Error(
+          `expected a tool_response block but got ${String(block.type)}`,
+        );
+      }
+      const result = block.result;
+      if (
+        typeof result !== 'object' ||
+        result === null ||
+        !('error' in result)
+      ) {
+        throw new Error(
+          'tool_response block result is not an object with an error property',
+        );
+      }
+      if (typeof result.error !== 'string') {
+        throw new Error('tool_response block result.error is not a string');
+      }
+      return result.error;
+    }
+
+    // The issue's reproduction: insert_at_line out of range.
+    it('delivers the remedial llmContent to the model while keeping the terse message for logs/UI (AC1 + AC2)', async () => {
+      agg.beginBatch(1);
+      const call = makeScheduledCall('c-ial', 'insert_at_line');
+      const result: ToolResult = {
+        error: {
+          message: 'line_number 999 exceeds file length (8)',
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+        llmContent:
+          'Cannot insert at line 999: exceeds file length (8). Use line_number <= 9 to append.',
+        returnDisplay: 'Cannot insert at line 999: exceeds file length (8)',
+      };
+      agg.bufferResult('c-ial', 'insert_at_line', call, result, 0);
+
+      await agg.publishBufferedResults(makeAbortSignal());
+
+      const response = publishedErrorResponse();
+      expect(errorResultBlockText(response)).toBe(
+        'Cannot insert at line 999: exceeds file length (8). Use line_number <= 9 to append.',
+      );
+      expect(response.error?.message).toBe(
+        'line_number 999 exceeds file length (8)',
+      );
+      expect(response.resultDisplay).toBe(
+        'line_number 999 exceeds file length (8)',
+      );
+      expect(response.errorType).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    });
+
+    it('delivers the apply_patch header-mismatch remedy to the model (AC6)', async () => {
+      agg.beginBatch(1);
+      const call = makeScheduledCall('c-ap', 'apply_patch');
+      const result: ToolResult = {
+        error: {
+          message:
+            'Patch header target "other.txt" does not match absolute_path "target.txt".',
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+        llmContent:
+          'Patch header targets "other.txt" but the absolute_path targets "target.txt". Ensure the patch header matches the target file, or use a separate apply_patch call for "other.txt".',
+        returnDisplay:
+          'Rejected patch: header target "other.txt" does not match absolute_path "target.txt".',
+      };
+      agg.bufferResult('c-ap', 'apply_patch', call, result, 0);
+
+      await agg.publishBufferedResults(makeAbortSignal());
+
+      const response = publishedErrorResponse();
+      expect(errorResultBlockText(response)).toContain(
+        'Ensure the patch header matches the target file',
+      );
+      expect(response.error?.message).toBe(
+        'Patch header target "other.txt" does not match absolute_path "target.txt".',
+      );
+    });
+
+    it('falls back to error.message when llmContent is empty (AC3)', async () => {
+      agg.beginBatch(1);
+      const call = makeScheduledCall('c-empty', 'insert_at_line');
+      const result: ToolResult = {
+        error: {
+          message: 'line_number 999 exceeds file length (8)',
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+        llmContent: '',
+        returnDisplay: 'Cannot insert at line 999: exceeds file length (8)',
+      };
+      agg.bufferResult('c-empty', 'insert_at_line', call, result, 0);
+
+      await agg.publishBufferedResults(makeAbortSignal());
+
+      expect(errorResultBlockText(publishedErrorResponse())).toBe(
+        'line_number 999 exceeds file length (8)',
+      );
+    });
+
+    it('falls back to error.message when llmContent is media-only (AC3)', async () => {
+      agg.beginBatch(1);
+      const call = makeScheduledCall('c-media', 'insert_at_line');
+      const result: ToolResult = {
+        error: {
+          message: 'line_number 999 exceeds file length (8)',
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+        llmContent: [{ inlineData: { data: 'YWJj', mimeType: 'text/plain' } }],
+        returnDisplay: 'Cannot insert at line 999: exceeds file length (8)',
+      };
+      agg.bufferResult('c-media', 'insert_at_line', call, result, 0);
+
+      await agg.publishBufferedResults(makeAbortSignal());
+
+      expect(errorResultBlockText(publishedErrorResponse())).toBe(
+        'line_number 999 exceeds file length (8)',
+      );
+    });
+
+    it('joins and delivers an array llmContent of text parts (AC3)', async () => {
+      agg.beginBatch(1);
+      const call = makeScheduledCall('c-arr', 'insert_at_line');
+      const result: ToolResult = {
+        error: {
+          message: 'line_number 999 exceeds file length (8)',
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+        llmContent: [
+          { text: 'Cannot insert at line 999.' },
+          { text: 'Use line_number <= 9 to append.' },
+        ],
+        returnDisplay: 'Cannot insert at line 999: exceeds file length (8)',
+      };
+      agg.bufferResult('c-arr', 'insert_at_line', call, result, 0);
+
+      await agg.publishBufferedResults(makeAbortSignal());
+
+      expect(errorResultBlockText(publishedErrorResponse())).toBe(
+        'Cannot insert at line 999.' + '\n' + 'Use line_number <= 9 to append.',
+      );
+    });
+
+    // bufferError synthesises llmContent === error.message, so the model-facing
+    // text is the same string whichever branch produces it. This pins the
+    // observable output rather than the internal path (AC5).
+    it('keeps bufferError observable output unchanged — still error.message (AC5)', async () => {
+      agg.beginBatch(1);
+      const call = makeScheduledCall('c-rawerr', 'insert_at_line');
+      agg.bufferError('c-rawerr', 'insert_at_line', call, new Error('boom'), 0);
+
+      await agg.publishBufferedResults(makeAbortSignal());
+
+      expect(errorResultBlockText(publishedErrorResponse())).toBe('boom');
+    });
+
+    it('still publishes successful results untouched on the success path', async () => {
+      agg.beginBatch(1);
+      const call = makeScheduledCall('c-ok', 'read_file');
+      agg.bufferResult('c-ok', 'read_file', call, makeSuccessResult('done'), 0);
+
+      await agg.publishBufferedResults(makeAbortSignal());
+
+      expect(callbacks.setSuccess).toHaveBeenCalledTimes(1);
+      expect(callbacks.setError).not.toHaveBeenCalled();
+    });
+
+    it('applies the batch output config to the error path (AC4)', async () => {
+      (
+        callbacks.getFallbackOutputConfig as ReturnType<typeof vi.fn>
+      ).mockReturnValue({
+        getEphemeralSettings: () => ({ 'tool-output-max-tokens': 2000 }),
+      } as ToolOutputSettingsProvider);
+
+      agg.beginBatch(2); // per-tool budget floored at 1000 tokens
+      const oversized = Array.from(
+        { length: 3000 },
+        (_, index) => `word${index}`,
+      ).join(' ');
+      const errorCall = makeScheduledCall('c-big', 'insert_at_line');
+      const successCall = makeScheduledCall('c-small', 'read_file');
+      agg.bufferResult(
+        'c-big',
+        'insert_at_line',
+        errorCall,
+        {
+          error: {
+            message: 'line_number 999 exceeds file length (8)',
+            type: ToolErrorType.INVALID_TOOL_PARAMS,
+          },
+          llmContent: oversized,
+          returnDisplay: 'Cannot insert at line 999',
+        },
+        0,
+      );
+      agg.bufferResult(
+        'c-small',
+        'read_file',
+        successCall,
+        makeSuccessResult('ok'),
+        1,
+      );
+
+      await agg.publishBufferedResults(makeAbortSignal());
+
+      const text = errorResultBlockText(publishedErrorResponse());
+      expect(text.length).toBeLessThan(oversized.length);
+      expect(text).toContain('[Output truncated due to token limit]');
     });
   });
 });

--- a/packages/agents/src/scheduler/result-aggregator.tool-error-remedy.test.ts
+++ b/packages/agents/src/scheduler/result-aggregator.tool-error-remedy.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Issue #3037 — end-to-end evidence (T3) that a real tool's remedial
+ * llmContent survives the ResultAggregator boundary and reaches the model.
+ *
+ * The test drives a real InsertAtLineTool over a real temp directory to
+ * produce a genuine ToolResult (no hand-rolled strings), then feeds that
+ * result through a real ResultAggregator and asserts the ToolCallResponseInfo
+ * handed to setError carries the remedy.
+ */
+
+import { describe, it, expect } from '../testApi.js';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ResultAggregator } from './result-aggregator.js';
+import type { ResultPublishCallbacks } from './result-aggregator.js';
+import type { ScheduledToolCall } from '@vybestack/llxprt-code-core/scheduler/types.js';
+import type { ToolCallResponseInfo } from '../core/turn.js';
+import {
+  InsertAtLineTool,
+  type IToolHost,
+  type ToolResult,
+} from '@vybestack/llxprt-code-tools';
+import { DEFAULT_MAX_TOKENS } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
+import type { ToolOutputSettingsProvider } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
+import type { ContentBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+
+/**
+ * Narrows a tool_response ContentBlock and reads its `result.error` string
+ * via real type guards (not a cast), failing the test with a clear message if
+ * the block shape does not match expectations.
+ */
+function toolResponseErrorText(block: ContentBlock): string {
+  if (block.type !== 'tool_response') {
+    throw new Error(
+      `expected a tool_response block but got ${String(block.type)}`,
+    );
+  }
+  const result = block.result;
+  if (typeof result !== 'object' || result === null || !('error' in result)) {
+    throw new Error(
+      'tool_response block result is not an object with an error property',
+    );
+  }
+  if (typeof result.error !== 'string') {
+    throw new Error('tool_response block result.error is not a string');
+  }
+  return result.error;
+}
+
+/**
+ * Minimal structural IToolHost over a temp directory, mirroring
+ * `_createFakeFileHost` in packages/tools/src/__tests__/filesystem-tools.test.ts
+ * but trimmed to the surface the InsertAtLineTool path touches.
+ */
+function createFakeFileHost(targetDir: string): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({
+      'tool-output-max-tokens': DEFAULT_MAX_TOKENS,
+    }),
+    getDebugMode: () => false,
+  };
+}
+
+function makeScheduledCall(callId: string, name: string): ScheduledToolCall {
+  return {
+    status: 'scheduled',
+    request: { callId, name, args: {} },
+    // tool/invocation are required by ScheduledToolCall but never touched by
+    // this test, so placeholder casts match the convention in
+    // result-aggregator.test.ts makeScheduledCall.
+    tool: {} as ScheduledToolCall['tool'],
+    invocation: {} as ScheduledToolCall['invocation'],
+  };
+}
+
+function makeCallbacks(): {
+  callbacks: ResultPublishCallbacks;
+  lastError: () => ToolCallResponseInfo | undefined;
+} {
+  let captured: ToolCallResponseInfo | undefined;
+  const callbacks: ResultPublishCallbacks = {
+    setSuccess: () => {},
+    setError: (_callId: string, response: ToolCallResponseInfo) => {
+      captured = response;
+    },
+    getFallbackOutputConfig: () =>
+      ({
+        getEphemeralSettings: () => ({
+          'tool-output-max-tokens': DEFAULT_MAX_TOKENS,
+        }),
+      }) satisfies ToolOutputSettingsProvider,
+  };
+  return { callbacks, lastError: () => captured };
+}
+
+describe('ResultAggregator — real tool error remedy (issue #3037, AC6)', () => {
+  it('delivers the real InsertAtLineTool out-of-range remedy to the model', async () => {
+    const tempDir = join(
+      tmpdir(),
+      `llxprt-3037-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+    try {
+      // 8-line file (no trailing newline → exactly 8 lines on split).
+      const targetPath = join(tempDir, 'target.txt');
+      writeFileSync(targetPath, '1\n2\n3\n4\n5\n6\n7\n8');
+
+      const tool = new InsertAtLineTool(createFakeFileHost(tempDir));
+      const realResult: ToolResult = await tool.execute(
+        {
+          absolute_path: targetPath,
+          line_number: 999,
+          content: 'new line',
+        },
+        new AbortController().signal,
+      );
+
+      // Sanity: the real tool produced the expected remedial llmContent.
+      expect(realResult.error).toBeDefined();
+      expect(realResult.llmContent).toContain(
+        'Use line_number <= 9 to append.',
+      );
+      expect(realResult.error?.message).toBe(
+        'line_number 999 exceeds file length (8)',
+      );
+
+      const { callbacks, lastError } = makeCallbacks();
+      const agg = new ResultAggregator(callbacks);
+      const call = makeScheduledCall('call-real', 'insert_at_line');
+      agg.beginBatch(1);
+      agg.bufferResult('call-real', 'insert_at_line', call, realResult, 0);
+
+      await agg.publishBufferedResults(new AbortController().signal);
+
+      const response = lastError();
+      expect(response).toBeDefined();
+      expect(toolResponseErrorText(response!.responseParts[0])).toContain(
+        'Use line_number <= 9 to append.',
+      );
+      expect(response!.error?.message).toBe(
+        'line_number 999 exceeds file length (8)',
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agents/src/scheduler/result-aggregator.tool-error-remedy.test.ts
+++ b/packages/agents/src/scheduler/result-aggregator.tool-error-remedy.test.ts
@@ -143,12 +143,10 @@ describe('ResultAggregator — real tool error remedy (issue #3037, AC6)', () =>
       );
 
       // Sanity: the real tool produced the expected remedial llmContent.
+      // Only the remedy clause is pinned — the tool owns its exact wording.
       expect(realResult.error).toBeDefined();
       expect(realResult.llmContent).toContain(
         'Use line_number <= 9 to append.',
-      );
-      expect(realResult.error?.message).toBe(
-        'line_number 999 exceeds file length (8)',
       );
 
       const { callbacks, lastError } = makeCallbacks();
@@ -164,9 +162,9 @@ describe('ResultAggregator — real tool error remedy (issue #3037, AC6)', () =>
       expect(toolResponseErrorText(response!.responseParts[0])).toContain(
         'Use line_number <= 9 to append.',
       );
-      expect(response!.error?.message).toBe(
-        'line_number 999 exceeds file length (8)',
-      );
+      // The terse half is passed through from the tool untouched.
+      expect(response!.error?.message).toBe(realResult.error!.message);
+      expect(response!.resultDisplay).toBe(realResult.error!.message);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/packages/agents/src/scheduler/result-aggregator.ts
+++ b/packages/agents/src/scheduler/result-aggregator.ts
@@ -24,6 +24,7 @@ import {
   convertToFunctionResponse,
   extractAgentIdFromMetadata,
   createErrorResponse,
+  extractModelFacingErrorText,
 } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
 import {
   DEFAULT_MAX_TOKENS,
@@ -343,9 +344,10 @@ export class ResultAggregator {
   ): Promise<void> {
     const { result, callId, toolName, scheduledCall } = buffered;
 
+    const outputConfig =
+      this.batchOutputConfig ?? this.callbacks.getFallbackOutputConfig();
+
     if (result.error === undefined) {
-      const outputConfig =
-        this.batchOutputConfig ?? this.callbacks.getFallbackOutputConfig();
       const responseParts = convertToFunctionResponse(
         toolName,
         callId,
@@ -379,6 +381,7 @@ export class ResultAggregator {
         scheduledCall.request,
         error,
         result.error.type,
+        extractModelFacingErrorText(result.llmContent, toolName, outputConfig),
       );
       this.callbacks.setError(callId, errorResponse);
     }

--- a/packages/core/src/utils/generateContentResponseUtilities.toolErrorRemedy.test.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.toolErrorRemedy.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Issue #3037 — tool errors must deliver the model-facing llmContent remedy.
+ * These are the unit-level proofs for the extraction helper and the
+ * createErrorResponse boundary (T1 in the accepted plan). They assert the
+ * observable ToolCallResponseInfo / extracted text, never method bookkeeping.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  createErrorResponse,
+  extractModelFacingErrorText,
+} from './generateContentResponseUtilities.js';
+import type { ToolCallRequestInfo } from '../core/turn.js';
+import type { ToolErrorType } from '../index.js';
+import type { ToolOutputSettingsProvider } from './toolOutputLimiter.js';
+import type { ContentBlock } from '../services/history/IContent.js';
+
+function makeRequest(
+  callId = 'call-err',
+  name = 'failingTool',
+): ToolCallRequestInfo {
+  return {
+    callId,
+    name,
+    args: {},
+    isClientInitiated: false,
+    prompt_id: 'prompt-1',
+  };
+}
+
+/**
+ * Narrows a tool_response ContentBlock and reads its `result.error` string
+ * via real type guards (not a cast), failing the test with a clear message if
+ * the block shape does not match expectations.
+ */
+function toolResponseErrorText(block: ContentBlock): string {
+  if (block.type !== 'tool_response') {
+    throw new Error(
+      `expected a tool_response block but got ${String(block.type)}`,
+    );
+  }
+  const result = block.result;
+  if (typeof result !== 'object' || result === null || !('error' in result)) {
+    throw new Error(
+      'tool_response block result is not an object with an error property',
+    );
+  }
+  if (typeof result.error !== 'string') {
+    throw new Error('tool_response block result.error is not a string');
+  }
+  return result.error;
+}
+
+const REMEDY =
+  'Cannot insert at line 999: exceeds file length (8). Use line_number <= 9 to append.';
+const TERSE = 'line_number 999 exceeds file length (8)';
+
+describe('createErrorResponse — model-facing content (issue #3037)', () => {
+  it('falls back to error.message when no fourth argument is given (AC5)', () => {
+    const error = new Error(TERSE);
+    const response = createErrorResponse(
+      makeRequest(),
+      error,
+      'EXECUTION_FAILED' as ToolErrorType,
+    );
+
+    const block = response.responseParts[0];
+    expect(toolResponseErrorText(block)).toBe(TERSE);
+  });
+
+  it('delivers model-facing content in result.error while keeping resultDisplay and error.message terse (AC1 + AC2)', () => {
+    const error = new Error(TERSE);
+    const response = createErrorResponse(
+      makeRequest(),
+      error,
+      'INVALID_TOOL_PARAMS' as ToolErrorType,
+      REMEDY,
+    );
+
+    expect(response.error).toBe(error);
+    expect(response.error?.message).toBe(TERSE);
+    expect(response.resultDisplay).toBe(TERSE);
+    expect(response.errorType).toBe('INVALID_TOOL_PARAMS');
+
+    const block = response.responseParts[0];
+    expect(toolResponseErrorText(block)).toBe(REMEDY);
+  });
+
+  it('falls back to error.message when modelFacingContent is undefined', () => {
+    const error = new Error(TERSE);
+    const response = createErrorResponse(
+      makeRequest(),
+      error,
+      undefined,
+      undefined,
+    );
+    expect(toolResponseErrorText(response.responseParts[0])).toBe(TERSE);
+  });
+});
+
+describe('extractModelFacingErrorText (issue #3037)', () => {
+  it('returns a non-empty remedial string verbatim', () => {
+    expect(extractModelFacingErrorText(REMEDY, 'insert_at_line')).toBe(REMEDY);
+  });
+
+  it.each(['', '   ', '   \n\t  '])(
+    'returns undefined for whitespace-only string %j (falls back to error.message)',
+    (value) => {
+      expect(
+        extractModelFacingErrorText(value, 'insert_at_line'),
+      ).toBeUndefined();
+    },
+  );
+
+  it('returns undefined for undefined and null', () => {
+    expect(
+      extractModelFacingErrorText(undefined, 'insert_at_line'),
+    ).toBeUndefined();
+    expect(extractModelFacingErrorText(null, 'insert_at_line')).toBeUndefined();
+  });
+
+  it('joins legacy {text} parts with newlines', () => {
+    expect(
+      extractModelFacingErrorText([{ text: 'a' }, { text: 'b' }], 'tool'),
+    ).toBe('a\nb');
+  });
+
+  it('joins a plain string[] with newlines', () => {
+    expect(extractModelFacingErrorText(['a', 'b'], 'tool')).toBe('a\nb');
+  });
+
+  it('returns undefined when only inlineData (media) parts are present', () => {
+    expect(
+      extractModelFacingErrorText(
+        [{ inlineData: { data: 'YWJj', mimeType: 'text/plain' } }],
+        'tool',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when text parts are all whitespace', () => {
+    expect(
+      extractModelFacingErrorText([{ text: '   ' }, { text: '\n' }], 'tool'),
+    ).toBeUndefined();
+  });
+
+  it('applies the token limit just like the success path (AC4)', () => {
+    const oversized = Array.from(
+      { length: 200 },
+      (_, index) => `word${index}`,
+    ).join(' ');
+    const lowConfig: ToolOutputSettingsProvider = {
+      getEphemeralSettings: () => ({
+        'tool-output-max-tokens': 50,
+        'tool-output-truncate-mode': 'truncate',
+      }),
+    };
+
+    const result = extractModelFacingErrorText(
+      oversized,
+      'read_file',
+      lowConfig,
+    );
+
+    expect(result).toBeDefined();
+    expect(result!.length).toBeLessThan(oversized.length);
+    expect(result).toContain('[Output truncated due to token limit]');
+  });
+
+  // Ordering guard: the blank check must run BEFORE limitStringOutput. When
+  // the limiter truncates, it appends a non-blank marker, so limiting first
+  // would turn whitespace-only content into a spurious "truncated" string and
+  // suppress the error.message fallback required by AC3.
+  it('keeps the blank check ahead of truncation for an oversized whitespace-only string (AC3)', () => {
+    const lowConfig: ToolOutputSettingsProvider = {
+      getEphemeralSettings: () => ({
+        'tool-output-max-tokens': 5,
+        'tool-output-truncate-mode': 'truncate',
+      }),
+    };
+    expect(
+      extractModelFacingErrorText(' '.repeat(1000), 'read_file', lowConfig),
+    ).toBeUndefined();
+  });
+
+  it('keeps the blank check ahead of truncation for an oversized whitespace-only text-part array (AC3)', () => {
+    const lowConfig: ToolOutputSettingsProvider = {
+      getEphemeralSettings: () => ({
+        'tool-output-max-tokens': 5,
+        'tool-output-truncate-mode': 'truncate',
+      }),
+    };
+    expect(
+      extractModelFacingErrorText(
+        [{ text: ' '.repeat(1000) }],
+        'read_file',
+        lowConfig,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/generateContentResponseUtilities.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.ts
@@ -429,10 +429,50 @@ export function extractAgentIdFromMetadata(
   return undefined;
 }
 
+/**
+ * Extracts the model-facing text from a ToolResult's `llmContent` for the
+ * error path, applying the same output limiting as the success path so a huge
+ * error body cannot bypass `tool-output-max-tokens`. Returns `undefined` when
+ * no usable text is present, letting the caller fall back to `error.message`.
+ *
+ * Issue #3037: tools author a remedial `llmContent` for the model and a terse
+ * `error.message` for logs/UI; this keeps both intact by lifting `llmContent`
+ * through the error boundary instead of discarding it.
+ */
+export function extractModelFacingErrorText(
+  llmContent: unknown,
+  toolName: string,
+  config?: ToolOutputSettingsProvider,
+): string | undefined {
+  if (typeof llmContent === 'string') {
+    if (llmContent.trim().length === 0) {
+      return undefined;
+    }
+    return limitStringOutput(llmContent, toolName, config);
+  }
+
+  const blocks = toBlocksFromLegacyParts(llmContent);
+  const textParts: string[] = [];
+  for (const block of blocks) {
+    if (block.type === 'text') {
+      textParts.push(block.text);
+    }
+  }
+  if (textParts.length === 0) {
+    return undefined;
+  }
+  const joined = textParts.join('\n');
+  if (joined.trim().length === 0) {
+    return undefined;
+  }
+  return limitStringOutput(joined, toolName, config);
+}
+
 export const createErrorResponse = (
   request: ToolCallRequestInfo,
   error: Error,
   errorType: ToolErrorType | undefined,
+  modelFacingContent?: string,
 ): ToolCallResponseInfo => ({
   callId: request.callId,
   error,
@@ -441,7 +481,7 @@ export const createErrorResponse = (
       type: 'tool_response',
       callId: request.callId,
       toolName: request.name,
-      result: { error: error.message },
+      result: { error: modelFacingContent ?? error.message },
     },
   ],
   resultDisplay: error.message,

--- a/project-plans/issue3037-tool-error-llmcontent/plan.md
+++ b/project-plans/issue3037-tool-error-llmcontent/plan.md
@@ -1,0 +1,245 @@
+# Issue #3037 — Tool errors must deliver the model-facing `llmContent` remedy
+
+## Problem (verified in source)
+
+`ToolResult` carries two error-facing strings:
+
+- `llmContent` — written for the model: states the constraint **and names the remedy**.
+- `error.message` — written for logs / UI status lines: terse, symptom-only.
+
+There is exactly **one** boundary in the codebase that converts a `ToolResult`
+that has both fields into a model-facing response:
+
+`packages/agents/src/scheduler/result-aggregator.ts` → `ResultAggregator.publishResult()`
+
+```ts
+if (result.error === undefined) {
+  // success: llmContent → convertToFunctionResponse → responseParts
+} else {
+  const error = new Error(result.error.message);
+  const errorResponse = createErrorResponse(
+    scheduledCall.request,
+    error,
+    result.error.type,
+  );
+  this.callbacks.setError(callId, errorResponse);   // result.llmContent DISCARDED
+}
+```
+
+`createErrorResponse` (`packages/core/src/utils/generateContentResponseUtilities.ts:432`)
+builds the sole response part as `result: { error: error.message }`. The
+provider layer (`packages/providers/src/utils/toolResponsePayload.ts`)
+serialises `block.result` into the tool output the model sees, so the model
+receives `{"error":"line_number 999 exceeds file length (8)"}` — exactly the
+payload quoted in the issue — and the remedy sentence never leaves the process.
+
+Every other `createErrorResponse` call site has **no** `ToolResult` and
+therefore no `llmContent` to preserve (tool not found, invalid tool params,
+policy denial, publish failure, unhandled scheduler exception). Those are
+out of scope and must keep their current behaviour.
+
+## Accepted behaviour (acceptance criteria)
+
+**AC1 — the remedy reaches the model.**
+When a tool returns a `ToolResult` with `error` set and an `llmContent` that
+carries text, the published `ToolCallResponseInfo.responseParts` tool_response
+block carries that `llmContent` text instead of the terse `error.message`.
+
+**AC2 — the terse message is retained everywhere it is used today.**
+`ToolCallResponseInfo.error.message`, `errorType` and `resultDisplay` keep
+their current values (`result.error.message`). Logs, telemetry and UI status
+lines are unchanged.
+
+**AC3 — boundary cases fall back to `error.message`.**
+
+| `llmContent`                                  | model-facing text        |
+| --------------------------------------------- | ------------------------ |
+| non-empty string                               | the string               |
+| `''` / whitespace only                         | `error.message`          |
+| `undefined` / `null`                           | `error.message`          |
+| `['a', 'b']` / `[{text:'a'},{text:'b'}]`       | `'a\nb'`                 |
+| media / inlineData parts only (no text)        | `error.message`          |
+| identical to `error.message`                   | that message, once       |
+
+**AC4 — output limiting applies as it does on the success path.**
+The model-facing error text is limited with the same batch / fallback
+`ToolOutputSettingsProvider` used by `publishResult`'s success branch, so a
+huge error body cannot bypass `tool-output-max-tokens`.
+
+**AC5 — error paths with no `ToolResult` are unchanged.**
+`tool-dispatcher.ts`, `policy-helpers.ts`, `coreToolScheduler.ts` and
+`nonInteractiveToolExecutor.ts` error responses keep using `error.message`.
+`ResultAggregator.bufferError` / `bufferCancelled` synthesise
+`llmContent === error.message`, so their observable output is unchanged.
+
+**AC6 — the issue's cited tools are demonstrably fixed.**
+`insert_at_line` out-of-range, `apply_patch` header mismatch, and `apply_patch`
+multi-file now deliver their remedial sentence to the model.
+
+## Explicitly out of scope
+
+- Rewriting any tool's `llmContent` / `error.message` wording (the issue's
+  "audit the editing tools" follow-up). The boundary fix alone repairs every
+  example cited in the issue without touching a single tool.
+- Changing `resultDisplay` to `result.returnDisplay` (the issue explicitly
+  keeps `error.message` for `returnDisplay`).
+- Setting the top-level `ToolResponseBlock.error` field / changing the
+  provider payload `status`.
+- Any change to media-block handling on the error path.
+
+## Implementation shape
+
+### 1. `packages/core/src/utils/generateContentResponseUtilities.ts`
+
+Add an exported helper:
+
+```ts
+export function extractModelFacingErrorText(
+  llmContent: unknown,
+  toolName: string,
+  config?: ToolOutputSettingsProvider,
+): string | undefined;
+```
+
+- `string` input → return it when it has non-whitespace content, after
+  `limitStringOutput(llmContent, toolName, config)`.
+- otherwise → `toBlocksFromLegacyParts(llmContent)`, join `text` blocks with
+  `'\n'`, return it when non-whitespace, after `limitStringOutput`.
+- no usable text → `undefined`.
+
+Extend `createErrorResponse` with a fourth optional parameter:
+
+```ts
+export const createErrorResponse = (
+  request: ToolCallRequestInfo,
+  error: Error,
+  errorType: ToolErrorType | undefined,
+  modelFacingContent?: string,
+): ToolCallResponseInfo => ({
+  ...
+  responseParts: [{ ..., result: { error: modelFacingContent ?? error.message } }],
+  resultDisplay: error.message,
+  ...
+});
+```
+
+The `{ error: … }` result shape is preserved so downstream consumers
+(`humanizeJsonForDisplay`, zed replay, existing tests) keep working.
+
+### 2. `packages/agents/src/scheduler/result-aggregator.ts`
+
+In `publishResult`'s error branch, resolve the output config the same way the
+success branch does and pass the extracted text through:
+
+```ts
+const outputConfig =
+  this.batchOutputConfig ?? this.callbacks.getFallbackOutputConfig();
+const errorResponse = createErrorResponse(
+  scheduledCall.request,
+  new Error(result.error.message),
+  result.error.type,
+  extractModelFacingErrorText(result.llmContent, toolName, outputConfig),
+);
+```
+
+Hoist the shared `outputConfig` lookup above the `if` so it is computed once.
+
+## Test plan (write tests first — RED before GREEN)
+
+All new/changed tests use **Bun** (`bun:test`, via each package's existing
+test facade). No Vitest suites added or modified.
+
+### T1 — `packages/core/src/utils/generateContentResponseUtilities.test.ts`
+
+Extend the existing `createErrorResponse` describe block and add an
+`extractModelFacingErrorText` block:
+
+1. `createErrorResponse` with no fourth argument still produces
+   `result: { error: <error.message> }` (regression guard for AC5).
+2. `createErrorResponse` with model-facing content produces
+   `result: { error: <model-facing content> }` while `resultDisplay` and
+   `error.message` stay terse (AC1 + AC2).
+3. `extractModelFacingErrorText('Cannot insert at line 999: exceeds file
+   length (8). Use line_number <= 9 to append.', 'insert_at_line')` returns
+   that string verbatim.
+4. Returns `undefined` for `''`, `'   '`, `undefined`, `null`.
+5. Joins `[{text:'a'},{text:'b'}]` to `'a\nb'`; handles a plain `string[]`.
+6. Returns `undefined` when only `inlineData` parts are present.
+7. Applies the token limit: with a `ToolOutputSettingsProvider` capping
+   `tool-output-max-tokens` low, an oversized `llmContent` comes back
+   truncated (assert length shrank / limit marker present, matching how the
+   existing limiter tests in this file assert truncation).
+
+### T2 — `packages/agents/src/scheduler/result-aggregator.test.ts`
+
+Behavioural tests against the **real** `ResultAggregator` (no stubbing of the
+unit under test); assert on the `ToolCallResponseInfo` handed to `setError`.
+
+1. **The issue's reproduction.** Buffer a `ToolResult` whose `llmContent` is
+   `'Cannot insert at line 999: exceeds file length (8). Use line_number <= 9
+   to append.'` and whose `error.message` is `'line_number 999 exceeds file
+   length (8)'`. Publish. The `setError` response part's `result.error`
+   contains `'Use line_number <= 9 to append.'`; `response.error.message` and
+   `response.resultDisplay` are still the terse message; `errorType` is
+   preserved.
+2. **`apply_patch` header mismatch** — same shape, asserts the
+   `'Ensure the patch header matches the target file'` clause survives.
+3. **Fallback** — `llmContent: ''` publishes `result.error ===
+   error.message`.
+4. **Fallback** — `llmContent` with only a media/inlineData part publishes
+   `result.error === error.message`.
+5. **Array `llmContent`** — text parts are joined and delivered.
+6. **`bufferError` unchanged** — a raw `Error` still publishes
+   `result.error === error.message` (AC5).
+7. **Success path untouched** — an existing success assertion must keep
+   passing (no new test needed if already covered; add one if not).
+8. **Batch limiting** — inside a 2-tool batch with a low
+   `tool-output-max-tokens`, an oversized error `llmContent` is truncated,
+   proving AC4 uses the batch config.
+
+### T3 — end-to-end evidence for AC6
+
+New Bun test file
+`packages/agents/src/scheduler/result-aggregator.tool-error-remedy.test.ts`:
+
+- Build a real `InsertAtLineTool` from `@vybestack/llxprt-code-tools` with a
+  minimal structural `IToolHost` fake over a real temp directory (mirror
+  `_createFakeFileHost` in
+  `packages/tools/src/__tests__/filesystem-tools.test.ts`, but only the
+  members `IToolHost` requires).
+- Write an 8-line file, build the invocation with `line_number: 999`, and
+  `execute()` it to obtain a **real** `ToolResult`.
+- Feed that real result through a real `ResultAggregator` and assert the
+  published `setError` response part contains `'Use line_number <= 9 to
+  append.'`.
+- Repeat for the real `ApplyPatchTool` header-mismatch case if it can be
+  driven with the same host fake; if the host surface required by
+  `apply_patch` is materially larger, cover it at T2 level with the literal
+  strings taken from the tool source and note that in the test docstring.
+
+If placing tool construction inside `packages/agents` tests turns out to
+require production dependency changes, put T3 in `packages/tools` instead as a
+test that the real tool's `ToolResult.llmContent` carries the remedy, and keep
+the boundary proof at T2. **Do not add a production dependency to satisfy a
+test.**
+
+## Verification
+
+Run and pass, from the repo root:
+
+```
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+## Guardrails
+
+- No new `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `@ts-nocheck`.
+- No lint severity downgrades, no complexity/size threshold increases, no
+  additions to ignore lists. Fix the underlying issue instead.
+- No `any`, no type assertions to dodge strict mode.
+- Fail fast: no defensive layering. One extraction helper, one fallback.


### PR DESCRIPTION
## TLDR

Tools write **two** error strings. `error.message` is terse and symptom-only — written for a log line or a UI status. `llmContent` is written for the model: it states the constraint and **names the remedy**. Only the first one ever reached the model; the useful half was thrown away at the boundary.

`insert_at_line` is the cleanest reproduction. It builds both halves:

    llmContent:    Cannot insert at line 999: exceeds file length (8). Use line_number <= 9 to append.
    error.message: line_number 999 exceeds file length (8)

and the model received `{"error":"line_number 999 exceeds file length (8)"}`. The remedy — the only actionable content — never arrived.

This is a one-place fix. The good messages already existed; they were written, tested, and then discarded. **No tool's wording was changed** and every example cited in the issue is repaired.

Reviewers should look at: the choice to keep the `{ error: … }` result shape (rather than `{ output: … }`), and the ordering inside `extractModelFacingErrorText` — the blank check must run *before* the token limiter, since the limiter appends a non-blank truncation marker.

## Dive Deeper

### The boundary

`ResultAggregator.publishResult` (`packages/agents/src/scheduler/result-aggregator.ts`) is the single place that converts a `ToolResult` carrying **both** `error` and `llmContent` into a model-facing response. Its error branch built a fresh `Error` from `result.error.message` and handed it to `createErrorResponse`, which set the sole response part to `result: { error: error.message }`. `result.llmContent` was never read.

Every other `createErrorResponse` call site — `tool-dispatcher.ts`, `coreToolScheduler.ts`, `policy-helpers.ts` — has no `ToolResult` at all (tool not found, invalid tool params, policy denial, publish failure, unhandled exception), so there is nothing to preserve. Those are untouched and pass three arguments as before.

Because interactive execution, the non-interactive CLI, subagents, A2A, hook-decorated results and MCP tool failures all converge on this same aggregator, fixing it once repairs all of them.

### The change

Two production files:

1. **`packages/core/src/utils/generateContentResponseUtilities.ts`**
   - New exported `extractModelFacingErrorText(llmContent, toolName, config?)`. Handles a plain string, a legacy `Part[]` of text parts, a `string[]`, and mixed text+media (text wins, media is dropped). Reuses the existing private `toBlocksFromLegacyParts` and the exported `limitStringOutput` rather than duplicating either. Returns `undefined` when there is no usable text.
   - `createErrorResponse` gains an optional fourth parameter `modelFacingContent`, used as `result: { error: modelFacingContent ?? error.message }`. Nothing else about it moves.

2. **`packages/agents/src/scheduler/result-aggregator.ts`**
   - The `outputConfig` lookup is hoisted above the success/error branch so both share it, and the extracted text is passed through.

### Design notes

- **Why `{ error: … }` and not `{ output: … }`.** `buildToolResponsePayload` in the providers layer treats a `{ output: string }` result specially and otherwise serialises the object. Keeping `{ error: … }` preserves the historical failure shape that downstream consumers already key on — `humanizeJsonForDisplay` prefers the `error` key, and the Zed session replay explicitly recognises `result.error`. Switching to `output` would have been a wider, riskier change for cosmetic gain.
- **Blank check before limiting.** `limitStringOutput` replaces oversized input with a non-blank truncation marker. Limiting first would turn a whitespace-only `llmContent` into a spurious "truncated" string and suppress the `error.message` fallback. Two ordering-guard tests pin this.
- **`??` and not `||`.** The only producer of the fourth argument guarantees a non-blank string or `undefined`, so `??` is exactly right. Adding a second `||` fallback would be defence-in-depth against a caller bug rather than a fix for one.
- **Output limiting on the error path.** The error text now obeys the same batch-divided `tool-output-max-tokens` budget as successful output, so a huge error body cannot bypass the limit.

### What stayed terse

`ToolCallResponseInfo.error.message`, `errorType` and `resultDisplay` are unchanged. Logs, telemetry and UI status lines see exactly what they saw before.

### Deliberately out of scope

- Rewriting any tool's `llmContent` / `error.message` wording (the issue's "audit the editing tools" follow-up). The boundary fix alone repairs every cited example without touching a tool.
- Setting the top-level `ToolResponseBlock.error` field. That field — not `result.error` — is what drives `payload.status`, so today an errored tool response is still reported to providers as `status: success`. That mismatch predates this change, and correcting it would alter Anthropic's `is_error`, Gemini's response status, retry behaviour and Zed replay. It deserves its own issue with cross-provider tests.
- Changing `resultDisplay` to `result.returnDisplay`.

## Reviewer Test Plan

The fastest way to see the change is to make an editing tool fail and read what comes back.

1. Create a short file (say 8 lines) and ask the agent to insert at a line well past the end — e.g. *"insert a comment at line 999 of that file"*. Before this change the tool response was `{"error":"line_number 999 exceeds file length (8)"}`; now it carries `Cannot insert at line 999: exceeds file length (8). Use line_number <= 9 to append.` and the model can correct itself in one turn instead of probing for the boundary.
2. Same idea with `apply_patch`: give a patch whose header names a different path than `absolute_path`. The response should now include *"Ensure the patch header matches the target file…"* rather than only the mismatch statement.
3. Confirm the UI is unchanged — the status line and any error surfaced in the CLI still show the short message, not the long one.
4. Confirm unaffected failures are untouched: call a tool that does not exist, or one blocked by policy. Those still return the plain terse message.

Automated:

    cd packages/core  && bun test src/utils/generateContentResponseUtilities.toolErrorRemedy.test.ts
    cd packages/agents && bun test src/scheduler/result-aggregator.test.ts \
                                   src/scheduler/result-aggregator.tool-error-remedy.test.ts \
                                   src/core/nonInteractiveToolExecutor.test.ts

23 tests across three suites, all Bun. Coverage: the issue's exact reproduction; the `apply_patch` header-mismatch clause; fallback for empty, whitespace-only and media-only `llmContent`; text-part joining; blank-check-before-truncation ordering; batch output limiting on the error path; `bufferError` output unchanged; and an end-to-end test that drives a **real** `InsertAtLineTool` over a real temp file and feeds the genuine `ToolResult` through a real `ResultAggregator`.

One existing characterization test changed: `nonInteractiveToolExecutor.test.ts` now expects the remedial `llmContent` in the model-facing payload while still asserting that `error.message` and `resultDisplay` stay terse. That is the behaviour change this PR is for, verified end-to-end through `executeToolCall`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run format`, `npm run lint`, `npm run build`, `npm run typecheck` all exit 0, and the `stepfun-37` smoke run succeeds. `npm run test` is green apart from two load-induced flakes that pass in isolation and reference none of the changed modules (`packages/lsp` LspClient server-crash integration; `packages/agents` memoryControl `setMemory("")`, which hit a 30 s timeout under full-parallel load).

## Linked issues / bugs

Fixes #3037
