### PR TITLE
Fix range-editor tools' phantom trailing-newline line model (Fixes #3036)

### DIFF
--- a/packages/core/src/prompt-config/defaults/tools/insert-at-line.md
+++ b/packages/core/src/prompt-config/defaults/tools/insert-at-line.md
@@ -1,4 +1,4 @@
-Inserts new content at a specific line in a file. This is the "paste" operation for refactoring. The 'line_number' is 1-based. The new content will be inserted before this line number. To prepend to the top of a file, use 'line_number: 1'. If 'line_number' is greater than the total lines, the content will be appended to the end of the file.
+Inserts new content at a specific line in a file. This is the "paste" operation for refactoring. The 'line_number' is 1-based. The new content will be inserted before this line number. To prepend to the top of a file, use 'line_number: 1'. The valid range is 1 .. totalLines + 1; setting 'line_number' to totalLines + 1 appends the content after the last line. A 'line_number' greater than totalLines + 1 is an error.
 
 ## Parameters
 

--- a/packages/tools/src/tools/delete_line_range.ts
+++ b/packages/tools/src/tools/delete_line_range.ts
@@ -31,6 +31,11 @@ import { getSpecificMimeType } from '../utils/fileUtils.js';
 import { DEFAULT_CREATE_PATCH_OPTIONS } from '../utils/diffOptions.js';
 import { collectLspDiagnosticsBlock } from '../utils/lsp-diagnostics-helper.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
+import {
+  splitFileLines,
+  joinFileLines,
+  type SplitFileLines,
+} from '../utils/lineEditing.js';
 
 /**
  * Parameters for the DeleteLineRange tool
@@ -106,17 +111,11 @@ class DeleteLineRangeToolInvocation extends BaseToolInvocation<
       return false;
     }
 
-    const lines = originalContent.split('\n');
-    const totalLines = lines.length;
-    if (this.params.start_line > totalLines) {
+    const deletion = this.applyDeletion(splitFileLines(originalContent));
+    if (deletion === null) {
       return false;
     }
-
-    const startIndex = this.params.start_line - 1;
-    const count = this.params.end_line - this.params.start_line + 1;
-    const newLines = [...lines];
-    newLines.splice(startIndex, count);
-    const newContent = newLines.join('\n');
+    const newContent = deletion.newContent;
 
     const relativePath = makeRelative(filePath, this.host.getTargetDir());
     const fileName = path.basename(filePath);
@@ -170,29 +169,23 @@ class DeleteLineRangeToolInvocation extends BaseToolInvocation<
       };
     }
 
-    const lines = content.split('\n');
+    const split = splitFileLines(content);
+    const totalLines = split.lines.length;
 
-    const totalLines = lines.length;
-    if (this.params.start_line > totalLines) {
+    const deletion = this.applyDeletion(split);
+    if (deletion === null) {
+      const message = `start_line ${this.params.start_line} exceeds file length (${totalLines})`;
       return {
         llmContent: `Cannot delete lines: start_line ${this.params.start_line} is beyond the total number of lines (${totalLines})`,
         returnDisplay: `Cannot delete lines: start_line ${this.params.start_line} is beyond the total number of lines (${totalLines})`,
         error: {
-          message: `start_line ${this.params.start_line} exceeds file length (${totalLines})`,
+          message,
           type: ToolErrorType.INVALID_TOOL_PARAMS,
         },
       };
     }
 
-    const startIndex = this.params.start_line - 1;
-    const count = this.params.end_line - this.params.start_line + 1;
-
-    const deletedContent = lines
-      .slice(startIndex, startIndex + count)
-      .join('\n');
-    lines.splice(startIndex, count);
-
-    const newContent = lines.join('\n');
+    const { newContent, deletedContent, effectiveEnd, count } = deletion;
 
     try {
       await fs.writeFile(filePath, newContent, 'utf8');
@@ -200,7 +193,7 @@ class DeleteLineRangeToolInvocation extends BaseToolInvocation<
       this.recordMetrics(filePath, count);
 
       const llmSuccessMessageParts: string[] = [
-        `Successfully deleted lines ${this.params.start_line}-${this.params.end_line} from ${filePath}`,
+        `Successfully deleted lines ${this.params.start_line}-${effectiveEnd} from ${filePath}`,
         deletedContent,
       ];
 
@@ -222,7 +215,7 @@ class DeleteLineRangeToolInvocation extends BaseToolInvocation<
 
       return {
         llmContent: llmSuccessMessageParts.join('\n\n'),
-        returnDisplay: `Deleted ${count} lines (${this.params.start_line}-${this.params.end_line})`,
+        returnDisplay: `Deleted ${count} lines (${this.params.start_line}-${effectiveEnd})`,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -235,6 +228,31 @@ class DeleteLineRangeToolInvocation extends BaseToolInvocation<
         },
       };
     }
+  }
+
+  private applyDeletion(split: SplitFileLines): {
+    readonly newContent: string;
+    readonly deletedContent: string;
+    readonly effectiveEnd: number;
+    readonly count: number;
+  } | null {
+    const { lines, hadTrailingNewline } = split;
+    const totalLines = lines.length;
+    if (this.params.start_line > totalLines) {
+      return null;
+    }
+    const startIndex = this.params.start_line - 1;
+    const effectiveEnd = Math.min(this.params.end_line, totalLines);
+    const count = effectiveEnd - this.params.start_line + 1;
+    const deletedContent = lines
+      .slice(startIndex, startIndex + count)
+      .join('\n');
+    const remaining = [
+      ...lines.slice(0, startIndex),
+      ...lines.slice(startIndex + count),
+    ];
+    const newContent = joinFileLines(remaining, hadTrailingNewline);
+    return { newContent, deletedContent, effectiveEnd, count };
   }
 
   private recordMetrics(filePath: string, linesDeleted: number): void {

--- a/packages/tools/src/tools/insert_at_line.ts
+++ b/packages/tools/src/tools/insert_at_line.ts
@@ -31,6 +31,11 @@ import { DEFAULT_CREATE_PATCH_OPTIONS } from '../utils/diffOptions.js';
 import { collectLspDiagnosticsBlock } from '../utils/lsp-diagnostics-helper.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
 import { stringOrDefault } from '../utils/stringCoalescing.js';
+import {
+  splitFileLines,
+  joinFileLines,
+  type SplitFileLines,
+} from '../utils/lineEditing.js';
 
 /**
  * Parameters for the InsertAtLine tool
@@ -61,6 +66,32 @@ function splitInsertContent(content: string): string[] {
   return content.endsWith('\n')
     ? content.slice(0, -1).split('\n')
     : content.split('\n');
+}
+
+/**
+ * Rebuilds file content after splicing the inserted lines in at `insertIndex`.
+ * Shared by execute() and shouldConfirmExecute() so the confirmation preview is
+ * byte-identical to the written bytes.
+ *
+ * A zero-line file (a non-existent file being created, or a truly empty file)
+ * must always be written newline-terminated. Before issue #3036 the phantom
+ * trailing '' from content.split('\n') guaranteed this; splitFileLines models an
+ * empty file as zero lines with no trailing newline, so the zero-line case is
+ * handled here rather than in lineEditing.ts (which delete_line_range depends
+ * on to empty a file without a stray newline).
+ */
+function buildInsertedContent(
+  split: SplitFileLines,
+  insertIndex: number,
+  insertedLines: readonly string[],
+): string {
+  const resultLines = [
+    ...split.lines.slice(0, insertIndex),
+    ...insertedLines,
+    ...split.lines.slice(insertIndex),
+  ];
+  const zeroLineFile = split.lines.length === 0;
+  return joinFileLines(resultLines, zeroLineFile || split.hadTrailingNewline);
 }
 
 class InsertAtLineToolInvocation extends BaseToolInvocation<
@@ -118,8 +149,8 @@ class InsertAtLineToolInvocation extends BaseToolInvocation<
       }
     }
 
-    const lines = originalContent.split('\n');
-    const totalLines = lines.length;
+    const split = splitFileLines(originalContent);
+    const totalLines = split.lines.length;
 
     if (fileExists && this.params.line_number > totalLines + 1) {
       return false;
@@ -130,10 +161,8 @@ class InsertAtLineToolInvocation extends BaseToolInvocation<
     }
 
     const insertIndex = this.params.line_number - 1;
-    const newLines = splitInsertContent(this.params.content);
-    const resultLines = [...lines];
-    resultLines.splice(insertIndex, 0, ...newLines);
-    const newContent = resultLines.join('\n');
+    const insertedLines = splitInsertContent(this.params.content);
+    const newContent = buildInsertedContent(split, insertIndex, insertedLines);
 
     const relativePath = makeRelative(filePath, this.host.getTargetDir());
     const fileName = path.basename(filePath);
@@ -174,25 +203,24 @@ class InsertAtLineToolInvocation extends BaseToolInvocation<
     const state = await this.readFileState();
     if (!state.ok) return state.result;
 
-    const lines = state.content.split('\n');
-    const totalLines = lines.length;
+    const split = splitFileLines(state.content);
+    const totalLines = split.lines.length;
     if (state.fileExists && this.params.line_number > totalLines + 1) {
       return {
         llmContent: `Cannot insert at line ${this.params.line_number}: exceeds file length (${totalLines}). Use line_number <= ${totalLines + 1} to append.`,
         returnDisplay: `Cannot insert at line ${this.params.line_number}: exceeds file length (${totalLines})`,
         error: {
-          message: `line_number ${this.params.line_number} exceeds file length (${totalLines})`,
+          message: `line_number ${this.params.line_number} exceeds file length (${totalLines}); use line_number <= ${totalLines + 1} to append`,
           type: ToolErrorType.INVALID_TOOL_PARAMS,
         },
       };
     }
 
     const insertIndex = this.params.line_number - 1;
-    const newLines = splitInsertContent(this.params.content);
-    lines.splice(insertIndex, 0, ...newLines);
-    const newContent = lines.join('\n');
+    const insertedLines = splitInsertContent(this.params.content);
+    const newContent = buildInsertedContent(split, insertIndex, insertedLines);
 
-    return this.buildWriteResult(state.fileExists, newContent, newLines);
+    return this.buildWriteResult(state.fileExists, newContent, insertedLines);
   }
 
   private async readFileState(): Promise<
@@ -323,7 +351,7 @@ export class InsertAtLineTool extends BaseDeclarativeTool<
     super(
       InsertAtLineTool.Name,
       'InsertAtLine',
-      `Inserts new content at a specific line in a file. This is the "paste" operation for refactoring. The 'line_number' is 1-based. The new content will be inserted *before* this line number. To prepend to the top of a file, use 'line_number: 1'. If 'line_number' is greater than the total lines, the content will be appended to the end of the file.`,
+      `Inserts new content at a specific line in a file. This is the "paste" operation for refactoring. The 'line_number' is 1-based. The new content will be inserted *before* this line number. To prepend to the top of a file, use 'line_number: 1'. The valid range is 1 .. totalLines + 1; setting 'line_number' to totalLines + 1 appends the content after the last line. A 'line_number' greater than totalLines + 1 is an error.`,
       Kind.Edit,
       {
         properties: {

--- a/packages/tools/src/tools/line-range-tools-issue3036.bun.test.ts
+++ b/packages/tools/src/tools/line-range-tools-issue3036.bun.test.ts
@@ -1,0 +1,771 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3036: range-editor tools treat `content.split('\n')` as "the lines of
+ * the file", but a newline-terminated file yields a phantom trailing '' element
+ * which is the final newline, not a line. These behavioural tests pin the
+ * accepted behaviour (AB1-AB5) with real temp files and byte-exact assertions.
+ *
+ * @plan issue3036
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ApprovalMode, IToolHost } from '../interfaces/index.js';
+import { ToolErrorType } from '../types/tool-error.js';
+import type {
+  ToolCallConfirmationDetails,
+  ToolEditConfirmationDetails,
+  ToolResult,
+} from './tools.js';
+import { DeleteLineRangeTool } from './delete_line_range.js';
+import { InsertAtLineTool } from './insert_at_line.js';
+import { ReadLineRangeTool } from './read_line_range.js';
+
+/**
+ * Registers a per-describe temp dir lifecycle and returns a lazy accessor.
+ * One line of shared setup per describe block (RULES.md test structure).
+ */
+function useTempDir(): () => string {
+  let dir = '';
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'issue3036-'));
+  });
+  afterEach(() => {
+    if (dir !== '') {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  return () => dir;
+}
+
+function createHost(
+  targetDir: string,
+  approvalMode: ApprovalMode = 'auto',
+): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => approvalMode,
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({}),
+    getDebugMode: () => false,
+  };
+}
+
+interface DeleteParams {
+  readonly file_path: string;
+  readonly start_line: number;
+  readonly end_line: number;
+}
+
+interface InsertParams {
+  readonly file_path: string;
+  readonly line_number: number;
+  readonly content: string;
+}
+
+interface ReadParams {
+  readonly file_path: string;
+  readonly start_line: number;
+  readonly end_line: number;
+  readonly showLineNumbers?: boolean;
+  readonly showGitChanges?: boolean;
+}
+
+async function runDelete(
+  targetDir: string,
+  params: DeleteParams,
+): Promise<ToolResult> {
+  return new DeleteLineRangeTool(createHost(targetDir))
+    .build(params)
+    .execute(new AbortController().signal);
+}
+
+async function runInsert(
+  targetDir: string,
+  params: InsertParams,
+): Promise<ToolResult> {
+  return new InsertAtLineTool(createHost(targetDir))
+    .build(params)
+    .execute(new AbortController().signal);
+}
+
+async function runRead(
+  targetDir: string,
+  params: ReadParams,
+): Promise<ToolResult> {
+  return new ReadLineRangeTool(createHost(targetDir))
+    .build(params)
+    .execute(new AbortController().signal);
+}
+
+async function runDeleteConfirmation(
+  targetDir: string,
+  params: DeleteParams,
+): Promise<ToolCallConfirmationDetails | false> {
+  return new DeleteLineRangeTool(createHost(targetDir, 'default'))
+    .build(params)
+    .shouldConfirmExecute(new AbortController().signal);
+}
+
+async function runInsertConfirmation(
+  targetDir: string,
+  params: InsertParams,
+): Promise<ToolCallConfirmationDetails | false> {
+  return new InsertAtLineTool(createHost(targetDir, 'default'))
+    .build(params)
+    .shouldConfirmExecute(new AbortController().signal);
+}
+
+function editConfirmation(
+  details: ToolCallConfirmationDetails,
+): ToolEditConfirmationDetails {
+  expect(details.type).toBe('edit');
+  if (details.type !== 'edit') {
+    throw new Error('expected edit confirmation');
+  }
+  return details;
+}
+
+/**
+ * Narrows a ToolResult's llmContent to a string without a type assertion.
+ * Throws when the content is non-text so the failure is explicit.
+ */
+function contentOf(result: ToolResult): string {
+  if (typeof result.llmContent !== 'string') {
+    throw new Error('expected string llmContent');
+  }
+  return result.llmContent;
+}
+
+const NEWLINE = String.fromCharCode(10);
+const HEADER_SEPARATOR = NEWLINE + NEWLINE;
+
+function bodyAfterHeader(content: string): string {
+  return content.slice(
+    content.indexOf(HEADER_SEPARATOR) + HEADER_SEPARATOR.length,
+  );
+}
+
+function joinLines(...parts: readonly string[]): string {
+  return parts.join(NEWLINE);
+}
+
+describe('AB1: delete_line_range preserves trailing-newline state', () => {
+  const tempDir = useTempDir();
+
+  const cases: ReadonlyArray<{
+    readonly name: string;
+    readonly file: string;
+    readonly start: number;
+    readonly end: number;
+    readonly expected: string;
+  }> = [
+    {
+      name: 'newline-terminated delete(3,3) keeps final newline',
+      file: 'aaa\nbbb\nccc\n',
+      start: 3,
+      end: 3,
+      expected: 'aaa\nbbb\n',
+    },
+    {
+      name: 'newline-terminated delete(3,999) keeps final newline',
+      file: 'aaa\nbbb\nccc\n',
+      start: 3,
+      end: 999,
+      expected: 'aaa\nbbb\n',
+    },
+    {
+      name: 'no-trailing-newline delete(3,3) stays newline-free',
+      file: 'aaa\nbbb\nccc',
+      start: 3,
+      end: 3,
+      expected: 'aaa\nbbb',
+    },
+    {
+      name: 'no-trailing-newline delete(3,999) stays newline-free',
+      file: 'aaa\nbbb\nccc',
+      start: 3,
+      end: 999,
+      expected: 'aaa\nbbb',
+    },
+    {
+      name: 'delete(1,999) empties the file with no stray newline',
+      file: 'aaa\nbbb\nccc\n',
+      start: 1,
+      end: 999,
+      expected: '',
+    },
+    {
+      name: 'delete(2,2) keeps surrounding lines and final newline',
+      file: 'aaa\nbbb\nccc\n',
+      start: 2,
+      end: 2,
+      expected: 'aaa\nccc\n',
+    },
+  ];
+
+  cases.forEach((c, index) => {
+    it(c.name, async () => {
+      const filePath = join(tempDir(), `ab1-${index}.txt`);
+      writeFileSync(filePath, c.file, 'utf-8');
+
+      await runDelete(tempDir(), {
+        file_path: filePath,
+        start_line: c.start,
+        end_line: c.end,
+      });
+
+      expect(readFileSync(filePath, 'utf-8')).toBe(c.expected);
+    });
+  });
+
+  it('echoes exactly the real deleted lines with no phantom blank', async () => {
+    const filePath = join(tempDir(), 'ab1-echo.txt');
+    writeFileSync(filePath, 'aaa\nbbb\nccc\n', 'utf-8');
+
+    // delete(3, 999) exercises the overshoot path where the phantom trailing ''
+    // element was previously consumed into the deleted-content echo.
+    const result = await runDelete(tempDir(), {
+      file_path: filePath,
+      start_line: 3,
+      end_line: 999,
+    });
+
+    expect(result.error).toBeUndefined();
+    const content = contentOf(result);
+    // The echo is the body after the status header; it must be exactly 'ccc'.
+    expect(bodyAfterHeader(content)).toBe('ccc');
+  });
+
+  it('reports the effective clamped range, not the raw over-shoot', async () => {
+    const filePath = join(tempDir(), 'ab1-clamp.txt');
+    writeFileSync(filePath, 'aaa\nbbb\nccc\n', 'utf-8');
+
+    const result = await runDelete(tempDir(), {
+      file_path: filePath,
+      start_line: 3,
+      end_line: 999,
+    });
+
+    expect(result.llmContent).toContain('lines 3-3');
+    expect(result.llmContent).not.toContain('3-999');
+    expect(result.returnDisplay).toContain('Deleted 1 lines (3-3)');
+    expect(result.returnDisplay).not.toContain('997');
+  });
+
+  it('confirm preview is byte-identical to the bytes execute writes', async () => {
+    const filePath = join(tempDir(), 'ab1-confirm.txt');
+    const original = 'aaa\nbbb\nccc\n';
+    writeFileSync(filePath, original, 'utf-8');
+
+    const confirmation = await runDeleteConfirmation(tempDir(), {
+      file_path: filePath,
+      start_line: 3,
+      end_line: 999,
+    });
+    expect(confirmation).not.toBe(false);
+    if (confirmation === false) return;
+    const preview = editConfirmation(confirmation).newContent;
+
+    // Run execute against a fresh copy so the on-disk result is comparable.
+    const execPath = join(tempDir(), 'ab1-confirm-exec.txt');
+    writeFileSync(execPath, original, 'utf-8');
+    await runDelete(tempDir(), {
+      file_path: execPath,
+      start_line: 3,
+      end_line: 999,
+    });
+
+    // The preview must equal the correct bytes (with the final newline
+    // preserved), and those must be byte-identical to what execute writes.
+    expect(preview).toBe('aaa\nbbb\n');
+    expect(preview).toBe(readFileSync(execPath, 'utf-8'));
+  });
+});
+
+describe('AB2: user-facing line counts exclude the phantom line', () => {
+  const tempDir = useTempDir();
+
+  it('insert_at_line error reports real length (7) on a 7-line file', async () => {
+    const filePath = join(tempDir(), 'ab2-insert.txt');
+    writeFileSync(filePath, 'l1\nl2\nl3\nl4\nl5\nl6\nl7\n', 'utf-8');
+
+    const result = await runInsert(tempDir(), {
+      file_path: filePath,
+      line_number: 999,
+      content: 'x\n',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toContain('(7)');
+    expect(result.error?.message).toContain('<= 8 to append');
+  });
+
+  it('delete_line_range error reports real length (8) on an 8-line file', async () => {
+    const filePath = join(tempDir(), 'ab2-delete.txt');
+    writeFileSync(filePath, 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\n', 'utf-8');
+
+    const result = await runDelete(tempDir(), {
+      file_path: filePath,
+      start_line: 100,
+      end_line: 100,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toContain('(8)');
+  });
+
+  it('an empty file has 0 lines: delete(1,1) is out-of-bounds', async () => {
+    const filePath = join(tempDir(), 'ab2-empty.txt');
+    writeFileSync(filePath, '', 'utf-8');
+
+    const result = await runDelete(tempDir(), {
+      file_path: filePath,
+      start_line: 1,
+      end_line: 1,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+  });
+
+  it("a single '\\n' file has 1 (empty) line: delete(1,1) empties it", async () => {
+    const filePath = join(tempDir(), 'ab2-newline.txt');
+    writeFileSync(filePath, '\n', 'utf-8');
+
+    const result = await runDelete(tempDir(), {
+      file_path: filePath,
+      start_line: 1,
+      end_line: 1,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe('');
+  });
+
+  it("a single '\\n' file reports length 1: delete(2,2) is out-of-bounds", async () => {
+    const filePath = join(tempDir(), 'ab2-newline-count.txt');
+    writeFileSync(filePath, '\n', 'utf-8');
+
+    const result = await runDelete(tempDir(), {
+      file_path: filePath,
+      start_line: 2,
+      end_line: 2,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.error?.message).toBe('start_line 2 exceeds file length (1)');
+  });
+
+  it('insert error.message carries actionable append guidance', async () => {
+    const filePath = join(tempDir(), 'ab2-guidance.txt');
+    writeFileSync(filePath, 'l1\nl2\nl3\nl4\nl5\nl6\nl7\n', 'utf-8');
+
+    const result = await runInsert(tempDir(), {
+      file_path: filePath,
+      line_number: 999,
+      content: 'x\n',
+    });
+
+    expect(result.error?.message).toBe(
+      'line_number 999 exceeds file length (7); use line_number <= 8 to append',
+    );
+  });
+});
+
+describe('AB3: insert_at_line append boundary matches the description', () => {
+  const tempDir = useTempDir();
+
+  it('appends at line totalLines + 1 byte-exact, preserving the newline', async () => {
+    const filePath = join(tempDir(), 'ab3-append.txt');
+    writeFileSync(filePath, 'aaa\nbbb\nccc\n', 'utf-8');
+
+    const result = await runInsert(tempDir(), {
+      file_path: filePath,
+      line_number: 4,
+      content: 'ddd\n',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe('aaa\nbbb\nccc\nddd\n');
+  });
+
+  it('rejects line totalLines + 2 instead of inserting a spurious blank', async () => {
+    const filePath = join(tempDir(), 'ab3-reject.txt');
+    writeFileSync(filePath, 'aaa\nbbb\nccc\n', 'utf-8');
+
+    const before = readFileSync(filePath, 'utf-8');
+    const result = await runInsert(tempDir(), {
+      file_path: filePath,
+      line_number: 5,
+      content: 'ddd\n',
+    });
+
+    expect(result.error).toBeDefined();
+    // File must be untouched.
+    expect(readFileSync(filePath, 'utf-8')).toBe(before);
+  });
+
+  it('tool description states the valid range and drops the append promise', () => {
+    const tool = new InsertAtLineTool(createHost(tempDir()));
+    expect(tool.description).not.toContain('appended to the end of the file');
+    expect(tool.description).toContain('totalLines + 1');
+  });
+
+  it('the prompt-config mirror matches the tool description', () => {
+    const mirrorPath = fileURLToPath(
+      new URL(
+        '../../../core/src/prompt-config/defaults/tools/insert-at-line.md',
+        import.meta.url,
+      ),
+    );
+    const mirror = readFileSync(mirrorPath, 'utf-8');
+    expect(mirror).not.toContain('appended to the end of the file');
+    expect(mirror).toContain('totalLines + 1');
+  });
+});
+
+describe('AB4: read_line_range plain status vs genuine line shortening', () => {
+  const tempDir = useTempDir();
+
+  it('ordinary partial read shows a plain status, not a truncation banner', async () => {
+    const filePath = join(tempDir(), 'ab4-plain.txt');
+    writeFileSync(
+      filePath,
+      'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\nl11\nl12\nl13\nl14\n',
+      'utf-8',
+    );
+
+    const result = await runRead(tempDir(), {
+      file_path: filePath,
+      start_line: 1,
+      end_line: 5,
+    });
+    expect(typeof result.llmContent).toBe('string');
+    const content = contentOf(result);
+
+    expect(content).toContain('Status: Showing lines 1-5 of 14 total lines.');
+    expect(content).not.toContain('has been truncated');
+    expect(content).not.toContain('(truncated)');
+    expect(content).not.toContain('Action: To read more');
+    // The body after the status header must be exactly the requested bytes.
+    expect(bodyAfterHeader(content)).toBe(
+      joinLines('l1', 'l2', 'l3', 'l4', 'l5'),
+    );
+  });
+
+  it('a range whose end exceeds EOF reports the clamped range plainly', async () => {
+    const filePath = join(tempDir(), 'ab4-past-eof-range.txt');
+    writeFileSync(
+      filePath,
+      'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\nl11\nl12\nl13\nl14\n',
+      'utf-8',
+    );
+
+    const result = await runRead(tempDir(), {
+      file_path: filePath,
+      start_line: 10,
+      end_line: 30,
+    });
+    expect(typeof result.llmContent).toBe('string');
+    const content = contentOf(result);
+
+    expect(content).toContain('Status: Showing lines 10-14 of 14 total lines.');
+    expect(content).not.toContain('has been truncated');
+    expect(content).not.toContain('Action: To read more');
+    // The body must be exactly the clamped bytes.
+    expect(bodyAfterHeader(content)).toBe(
+      joinLines('l10', 'l11', 'l12', 'l13', 'l14'),
+    );
+  });
+
+  it('genuine per-line shortening is still flagged explicitly', async () => {
+    const filePath = join(tempDir(), 'ab4-shortened.txt');
+    const longLine = 'x'.repeat(2100);
+    writeFileSync(filePath, `${longLine}\nshort\nl3\nl4\n`, 'utf-8');
+
+    const result = await runRead(tempDir(), {
+      file_path: filePath,
+      start_line: 1,
+      end_line: 1,
+    });
+    expect(typeof result.llmContent).toBe('string');
+    const content = contentOf(result);
+
+    expect(content).toContain('Status: Showing lines 1-1 of 4 total lines.');
+    expect(content.toLowerCase()).toContain('shortened');
+    // The long line must actually be clipped to the max length and still carry
+    // the existing truncation marker.
+    expect(bodyAfterHeader(content)).toBe('x'.repeat(2000) + '... [truncated]');
+  });
+
+  it('showLineNumbers formatting is preserved in the plain format', async () => {
+    const filePath = join(tempDir(), 'ab4-linenumbers.txt');
+    writeFileSync(filePath, 'line1\nline2\nline3\nline4\nline5\n', 'utf-8');
+
+    const result = await runRead(tempDir(), {
+      file_path: filePath,
+      start_line: 1,
+      end_line: 2,
+      showLineNumbers: true,
+    });
+    expect(typeof result.llmContent).toBe('string');
+    const content = contentOf(result);
+
+    expect(content).toContain('| line1');
+    expect(content).toContain('Status: Showing lines 1-2 of 5 total lines.');
+    expect(content).not.toContain('has been truncated');
+  });
+
+  it('showGitChanges legend and marker column are preserved', async () => {
+    const filePath = join(tempDir(), 'ab4-gitchanges.txt');
+    writeFileSync(filePath, 'line1\nline2\nline3\nline4\nline5\n', 'utf-8');
+
+    const result = await runRead(tempDir(), {
+      file_path: filePath,
+      start_line: 1,
+      end_line: 2,
+      showGitChanges: true,
+    });
+    expect(typeof result.llmContent).toBe('string');
+    const content = contentOf(result);
+
+    expect(content).toContain('Git changes legend:');
+    expect(content).toContain('Status: Showing lines 1-2 of 5 total lines.');
+    expect(content).not.toContain('has been truncated');
+    // Unchanged lines carry the unchanged marker column.
+    expect(content).toContain('░');
+  });
+});
+
+describe('AB5: reads starting past EOF error instead of an inverted range', () => {
+  const tempDir = useTempDir();
+
+  function fourteenLineFile(): string {
+    return 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\nl11\nl12\nl13\nl14\n';
+  }
+
+  it('start_line past EOF returns an INVALID_TOOL_PARAMS error', async () => {
+    const filePath = join(tempDir(), 'ab5-past-eof.txt');
+    writeFileSync(filePath, fourteenLineFile(), 'utf-8');
+
+    const result = await runRead(tempDir(), {
+      file_path: filePath,
+      start_line: 20,
+      end_line: 30,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.error?.message).toBe(
+      'start_line 20 is beyond end of file (14 lines)',
+    );
+    // Never emit the inverted range.
+    expect(result.llmContent).not.toContain('Showing lines 15-14');
+  });
+
+  it('start_line == totalLines with end_line past EOF still succeeds', async () => {
+    const filePath = join(tempDir(), 'ab5-last-line.txt');
+    writeFileSync(filePath, fourteenLineFile(), 'utf-8');
+
+    const result = await runRead(tempDir(), {
+      file_path: filePath,
+      start_line: 14,
+      end_line: 30,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(typeof result.llmContent).toBe('string');
+    expect(result.llmContent).toContain('l14');
+  });
+
+  it('a single-line file uses the singular form in the EOF message', async () => {
+    const filePath = join(tempDir(), 'ab5-singular.txt');
+    writeFileSync(filePath, NEWLINE, 'utf-8');
+
+    const result = await runRead(tempDir(), {
+      file_path: filePath,
+      start_line: 2,
+      end_line: 2,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.error?.message).toBe(
+      'start_line 2 is beyond end of file (1 line)',
+    );
+  });
+});
+
+describe('regression: insert_at_line preserves newline state across content/file combinations', () => {
+  const tempDir = useTempDir();
+
+  // The file's own trailing-newline state must be preserved regardless of
+  // whether the inserted content ends in a newline.
+  const cases: ReadonlyArray<{
+    readonly name: string;
+    readonly fileTrailingNewline: boolean;
+    readonly contentTrailingNewline: boolean;
+    readonly expectedTrailingNewline: boolean;
+  }> = [
+    {
+      name: 'newline-terminated file keeps its trailing newline (content with newline)',
+      fileTrailingNewline: true,
+      contentTrailingNewline: true,
+      expectedTrailingNewline: true,
+    },
+    {
+      name: 'newline-terminated file keeps its trailing newline (content without newline)',
+      fileTrailingNewline: true,
+      contentTrailingNewline: false,
+      expectedTrailingNewline: true,
+    },
+    {
+      name: 'newline-free file stays newline-free (content with newline)',
+      fileTrailingNewline: false,
+      contentTrailingNewline: true,
+      expectedTrailingNewline: false,
+    },
+    {
+      name: 'newline-free file stays newline-free (content without newline)',
+      fileTrailingNewline: false,
+      contentTrailingNewline: false,
+      expectedTrailingNewline: false,
+    },
+  ];
+
+  cases.forEach((c, index) => {
+    it(c.name, async () => {
+      const filePath = join(tempDir(), `regress-newline-${index}.txt`);
+      const fileContent =
+        joinLines('aaa', 'bbb', 'ccc') + (c.fileTrailingNewline ? NEWLINE : '');
+      writeFileSync(filePath, fileContent, 'utf-8');
+
+      const insertContent = 'xxx' + (c.contentTrailingNewline ? NEWLINE : '');
+      const result = await runInsert(tempDir(), {
+        file_path: filePath,
+        line_number: 2,
+        content: insertContent,
+      });
+
+      expect(result.error).toBeUndefined();
+      const expected =
+        joinLines('aaa', 'xxx', 'bbb', 'ccc') +
+        (c.expectedTrailingNewline ? NEWLINE : '');
+      expect(readFileSync(filePath, 'utf-8')).toBe(expected);
+    });
+  });
+
+  it('appends at totalLines + 1 to a file with no final newline', async () => {
+    const filePath = join(tempDir(), 'regress-append-no-newline.txt');
+    writeFileSync(filePath, joinLines('aaa', 'bbb', 'ccc'), 'utf-8');
+
+    const result = await runInsert(tempDir(), {
+      file_path: filePath,
+      line_number: 4,
+      content: 'ddd' + NEWLINE,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe(
+      joinLines('aaa', 'bbb', 'ccc', 'ddd'),
+    );
+  });
+});
+
+describe('regression: insert_at_line newline-terminates a zero-line file', () => {
+  const tempDir = useTempDir();
+
+  it('creating a non-existent file with content "foo\\n" writes exactly "foo\\n"', async () => {
+    const filePath = join(tempDir(), 'ab6-new-trailing.txt');
+
+    const result = await runInsert(tempDir(), {
+      file_path: filePath,
+      line_number: 1,
+      content: 'foo\n',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe('foo\n');
+  });
+
+  it('creating a non-existent file with content "foo" writes exactly "foo\\n"', async () => {
+    const filePath = join(tempDir(), 'ab6-new-notrailing.txt');
+
+    const result = await runInsert(tempDir(), {
+      file_path: filePath,
+      line_number: 1,
+      content: 'foo',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe('foo\n');
+  });
+
+  it('inserting at line 1 of an existing 0-byte file writes exactly "foo\\n"', async () => {
+    const filePath = join(tempDir(), 'ab6-empty.txt');
+    writeFileSync(filePath, '', 'utf-8');
+
+    const result = await runInsert(tempDir(), {
+      file_path: filePath,
+      line_number: 1,
+      content: 'foo\n',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe('foo\n');
+  });
+
+  it('confirm preview equals the bytes execute writes for the create-a-new-file case', async () => {
+    const previewPath = join(tempDir(), 'ab6-confirm-preview.txt');
+    const execPath = join(tempDir(), 'ab6-confirm-exec.txt');
+
+    const confirmation = await runInsertConfirmation(tempDir(), {
+      file_path: previewPath,
+      line_number: 1,
+      content: 'foo\n',
+    });
+    expect(confirmation).not.toBe(false);
+    if (confirmation === false) return;
+    const preview = editConfirmation(confirmation).newContent;
+
+    // Run execute against a fresh path so the on-disk result is comparable.
+    await runInsert(tempDir(), {
+      file_path: execPath,
+      line_number: 1,
+      content: 'foo\n',
+    });
+
+    // The preview must be newline-terminated and byte-identical to execute.
+    expect(preview).toBe('foo\n');
+    expect(preview).toBe(readFileSync(execPath, 'utf-8'));
+  });
+});

--- a/packages/tools/src/tools/read_line_range.ts
+++ b/packages/tools/src/tools/read_line_range.ts
@@ -6,6 +6,7 @@
 
 import path from 'path';
 import { type ContentPartUnion } from '../types/wire-types.js';
+import { ToolErrorType } from '../types/tool-error.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -119,6 +120,25 @@ function formatWithGitChanges(
   return formattedLines.join('\n');
 }
 
+/**
+ * A processed read result narrowed to carry the numeric line-range fields that
+ * text reads always populate. Used to avoid non-null assertions when reading
+ * `linesShown`/`originalLineCount` (issue #3036).
+ */
+type LineRangeResult = ProcessedFileReadResult & {
+  linesShown: [number, number];
+  originalLineCount: number;
+};
+
+function hasLineRange(
+  result: ProcessedFileReadResult,
+): result is LineRangeResult {
+  return (
+    Array.isArray(result.linesShown) &&
+    typeof result.originalLineCount === 'number'
+  );
+}
+
 class ReadLineRangeToolInvocation extends BaseToolInvocation<
   ReadLineRangeToolParams,
   ToolResult
@@ -198,42 +218,55 @@ class ReadLineRangeToolInvocation extends BaseToolInvocation<
     return `${headerParts.join('\n')}\n\n${llmContent}`;
   }
 
-  private buildTruncatedLlmContent(
-    result: ProcessedFileReadResult,
+  private buildRangeLlmContent(
+    content: string,
+    range: LineRangeResult,
+    shortened: boolean,
     gitWarning: string | undefined,
     markersByLine: Map<number, Exclude<GitLineChangeMarker, '░'>> | undefined,
     deletionAfterLines: Set<number> | undefined,
   ): ContentPartUnion {
-    const [start, end] = result.linesShown!;
-    const total = result.originalLineCount!;
+    const [start, end] = range.linesShown;
+    const total = range.originalLineCount;
 
     const formattedContent = this.applyTextFormatting(
-      result.llmContent as string,
+      content,
       this.params.start_line,
       markersByLine,
       deletionAfterLines,
     );
 
-    const gitLegend =
-      this.params.showGitChanges === true
-        ? `\nGit changes legend: ░ unchanged, N new, M modified, D deletion after line.\n`
-        : '';
-    const gitWarningText =
-      this.params.showGitChanges === true && gitWarning !== undefined
-        ? `\nNOTE: Failed to read git change status: ${gitWarning}\n`
-        : '';
+    const headerParts: string[] = [];
+    if (this.params.showGitChanges === true) {
+      if (gitWarning !== undefined) {
+        headerParts.push(
+          `NOTE: Failed to read git change status: ${gitWarning}`,
+        );
+      }
+      headerParts.push(
+        'Git changes legend: ░ unchanged, N new, M modified, D deletion after line.',
+      );
+    }
+    if (shortened) {
+      headerParts.push(
+        'NOTE: Some lines were shortened because they exceed the maximum line length.',
+      );
+    }
+    headerParts.push(
+      `Status: Showing lines ${start}-${end} of ${total} total lines.`,
+    );
 
-    return `\nIMPORTANT: The file content has been truncated.${gitWarningText}${gitLegend}\nStatus: Showing lines ${start}-${end} of ${total} total lines.\nAction: To read more of the file, you can use the 'read_line_range' tool with adjusted 'start_line' and 'end_line' parameters.\n\n--- FILE CONTENT (truncated) ---\n${formattedContent}`;
+    return `${headerParts.join('\n')}\n\n${formattedContent}`;
   }
 
   private buildFullLlmContent(
-    result: ProcessedFileReadResult,
+    content: string,
     gitWarning: string | undefined,
     markersByLine: Map<number, Exclude<GitLineChangeMarker, '░'>> | undefined,
     deletionAfterLines: Set<number> | undefined,
   ): ContentPartUnion {
     const formatted = this.applyTextFormatting(
-      result.llmContent as string,
+      content,
       this.params.start_line,
       markersByLine,
       deletionAfterLines,
@@ -255,6 +288,47 @@ class ReadLineRangeToolInvocation extends BaseToolInvocation<
     void filePath;
   }
 
+  private startBeyondEofResult(totalLines: number): ToolResult {
+    const lineWord = totalLines === 1 ? 'line' : 'lines';
+    const message = `start_line ${this.params.start_line} is beyond end of file (${totalLines} ${lineWord})`;
+    return {
+      llmContent: message,
+      returnDisplay: message,
+      error: {
+        message,
+        type: ToolErrorType.INVALID_TOOL_PARAMS,
+      },
+    };
+  }
+
+  private assembleContent(
+    result: ProcessedFileReadResult,
+    gitWarning: string | undefined,
+    markersByLine: Map<number, Exclude<GitLineChangeMarker, '░'>> | undefined,
+    deletionAfterLines: Set<number> | undefined,
+  ): ContentPartUnion {
+    if (typeof result.llmContent !== 'string') {
+      return result.llmContent;
+    }
+    const content = result.llmContent;
+    if (result.isTruncated === true && hasLineRange(result)) {
+      return this.buildRangeLlmContent(
+        content,
+        result,
+        result.linesShortened === true,
+        gitWarning,
+        markersByLine,
+        deletionAfterLines,
+      );
+    }
+    return this.buildFullLlmContent(
+      content,
+      gitWarning,
+      markersByLine,
+      deletionAfterLines,
+    );
+  }
+
   async execute(): Promise<ToolResult> {
     const offset = this.params.start_line - 1;
     const limit = this.params.end_line - this.params.start_line + 1;
@@ -274,40 +348,21 @@ class ReadLineRangeToolInvocation extends BaseToolInvocation<
       };
     }
 
-    let gitWarning: string | undefined;
-    let markersByLine:
-      | Map<number, Exclude<GitLineChangeMarker, '░'>>
-      | undefined;
-    let deletionAfterLines: Set<number> | undefined;
-
-    const shouldAnnotateGit =
-      this.params.showGitChanges === true &&
-      typeof result.llmContent === 'string';
-
-    if (shouldAnnotateGit) {
-      ({ gitWarning, markersByLine, deletionAfterLines } =
-        await this.fetchGitAnnotations(this.params.absolute_path));
+    if (
+      typeof result.llmContent === 'string' &&
+      hasLineRange(result) &&
+      this.params.start_line > result.originalLineCount
+    ) {
+      return this.startBeyondEofResult(result.originalLineCount);
     }
 
-    let llmContent: ContentPartUnion;
-
-    if (typeof result.llmContent !== 'string') {
-      llmContent = result.llmContent;
-    } else if (result.isTruncated === true) {
-      llmContent = this.buildTruncatedLlmContent(
-        result,
-        gitWarning,
-        markersByLine,
-        deletionAfterLines,
-      );
-    } else {
-      llmContent = this.buildFullLlmContent(
-        result,
-        gitWarning,
-        markersByLine,
-        deletionAfterLines,
-      );
-    }
+    const gitAnnotations = await this.loadGitAnnotations(result);
+    const llmContent = this.assembleContent(
+      result,
+      gitAnnotations.gitWarning,
+      gitAnnotations.markersByLine,
+      gitAnnotations.deletionAfterLines,
+    );
 
     this.recordReadMetric(result.llmContent, this.params.absolute_path);
 
@@ -315,6 +370,24 @@ class ReadLineRangeToolInvocation extends BaseToolInvocation<
       llmContent,
       returnDisplay: result.returnDisplay || '',
     };
+  }
+
+  private async loadGitAnnotations(result: ProcessedFileReadResult): Promise<{
+    gitWarning: string | undefined;
+    markersByLine: Map<number, Exclude<GitLineChangeMarker, '░'>> | undefined;
+    deletionAfterLines: Set<number> | undefined;
+  }> {
+    if (
+      this.params.showGitChanges !== true ||
+      typeof result.llmContent !== 'string'
+    ) {
+      return {
+        gitWarning: undefined,
+        markersByLine: undefined,
+        deletionAfterLines: undefined,
+      };
+    }
+    return this.fetchGitAnnotations(this.params.absolute_path);
   }
 }
 

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -413,6 +413,13 @@ export interface ProcessedFileReadResult {
   isTruncated?: boolean;
   originalLineCount?: number;
   linesShown?: [number, number];
+  /**
+   * True when at least one returned line was shortened because it exceeded the
+   * maximum line length. Distinct from `isTruncated` (which also covers range
+   * narrowing), so consumers like read_line_range can flag genuine per-line
+   * truncation without implying the requested range was incomplete.
+   */
+  linesShortened?: boolean;
 }
 
 export function isAssetExplicitlyRequested(
@@ -647,6 +654,7 @@ async function processTextFile(
     isTruncated,
     originalLineCount,
     linesShown: [actualStartLine + 1, endLine],
+    linesShortened: linesWereTruncatedInLength,
   };
 }
 

--- a/packages/tools/src/utils/lineEditing.ts
+++ b/packages/tools/src/utils/lineEditing.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Newline-aware line splitting/joining for the line-range editor tools
+ * (issue #3036).
+ *
+ * `content.split('\n')` treats a trailing newline as a phantom empty final
+ * element; that element IS the newline, not a line. These helpers model a
+ * file as the lines between newlines plus a separate trailing-newline flag so
+ * edit tools preserve the file's final-newline state.
+ */
+
+export interface SplitFileLines {
+  readonly lines: readonly string[];
+  readonly hadTrailingNewline: boolean;
+}
+
+/**
+ * Splits file content into real lines and records whether it ended in a
+ * newline. An empty file has zero lines.
+ */
+export function splitFileLines(content: string): SplitFileLines {
+  if (content === '') {
+    return { lines: [], hadTrailingNewline: false };
+  }
+  const hadTrailingNewline = content.endsWith('\n');
+  const body = hadTrailingNewline ? content.slice(0, -1) : content;
+  return { lines: body.split('\n'), hadTrailingNewline };
+}
+
+/**
+ * Joins lines back into file content, restoring the trailing newline only when
+ * the source file had one. An empty line set is always the empty file (no
+ * stray newline), even if the source was newline-terminated.
+ */
+export function joinFileLines(
+  lines: readonly string[],
+  hadTrailingNewline: boolean,
+): string {
+  if (lines.length === 0) {
+    return '';
+  }
+  const joined = lines.join('\n');
+  return hadTrailingNewline ? `${joined}\n` : joined;
+}

--- a/project-plans/issue3036/plan.md
+++ b/project-plans/issue3036/plan.md
@@ -1,0 +1,122 @@
+# Issue #3036 — Range-editor tools: trailing-newline loss, phantom line counts, false truncation banner
+
+## Problem
+
+`packages/tools/src/tools/{delete_line_range,insert_at_line,read_line_range}.ts` all treat the
+result of `content.split('\n')` as "the lines of the file". For a POSIX file that ends in a
+newline this yields a phantom trailing `''` element which *is* the final newline, not a line.
+Five defects follow from that (plus one documentation mismatch):
+
+1. `delete_line_range` consumes the phantom element — and therefore the file's final newline —
+   whenever `end_line` exceeds EOF, so `delete(3,3)` and `delete(3,999)` on `aaa\nbbb\nccc\n`
+   produce different files.
+2. Bounds-error messages report `lines.length` (phantom included), so a 7-line file is described
+   as having 8 lines.
+3. `insert_at_line`'s tool description promises append-past-EOF; the implementation rejects it.
+4. `read_line_range` prefixes every ordinary partial read with
+   `IMPORTANT: The file content has been truncated.` plus an `Action:` line that suggests the
+   exact call the caller just made.
+5. `read_line_range` with `start_line` past EOF returns an inverted range
+   (`Showing lines 15-14 of 14`) with empty content and no error.
+
+## Accepted behaviour (acceptance criteria)
+
+### AB1 — `delete_line_range` never changes the file's trailing-newline state
+
+Line splitting must be newline-aware: a file's line count excludes the phantom element, and the
+file's final-newline state is preserved across the edit.
+
+| Given file content     | Call                | Expected file afterwards |
+| ---------------------- | ------------------- | ------------------------ |
+| `aaa\nbbb\nccc\n`      | delete(3, 3)        | `aaa\nbbb\n`             |
+| `aaa\nbbb\nccc\n`      | delete(3, 999)      | `aaa\nbbb\n`             |
+| `aaa\nbbb\nccc`        | delete(3, 3)        | `aaa\nbbb`               |
+| `aaa\nbbb\nccc`        | delete(3, 999)      | `aaa\nbbb`               |
+| `aaa\nbbb\nccc\n`      | delete(1, 999)      | `` (empty, no newline)   |
+| `aaa\nbbb\nccc\n`      | delete(2, 2)        | `aaa\nccc\n`             |
+
+- The deleted-content echo in `llmContent` contains exactly the real deleted lines (`ccc`), never
+  a trailing phantom blank line.
+- `returnDisplay` and the success `llmContent` report the *effective* (clamped) range and count —
+  `delete(3, 999)` on a 3-line file reports 1 line deleted over lines 3-3, not 997 lines.
+- `shouldConfirmExecute` computes its diff preview from the same newline-aware logic, so the
+  preview matches the bytes `execute` writes.
+
+### AB2 — Line counts in user-facing messages are real line counts
+
+- `insert_at_line(line_number: 999)` on a 7-line newline-terminated file reports file length `7`.
+- `delete_line_range(start_line: 100)` on an 8-line newline-terminated file reports file length `8`.
+- A file whose content is `''` has 0 lines; a file whose content is `'\n'` has 1 (empty) line.
+  Consequently `delete_line_range(1, 1)` on an empty file is an out-of-bounds error rather than a
+  silent no-op.
+- The `error.message` (the half that actually reaches the caller) carries the actionable guidance,
+  not only `llmContent`: the insert error states the append position, e.g.
+  `line_number 999 exceeds file length (7); use line_number <= 8 to append`.
+
+### AB3 — `insert_at_line`'s description matches its behaviour
+
+Resolution chosen: **correct the description, keep the bounds check.** Silently relocating content
+to EOF when the caller passes a stale/incorrect line number risks writing content in the wrong
+place with no signal; failing fast with an actionable message is the safer contract and matches the
+project's fail-fast preference.
+
+- The tool description (and `packages/core/src/prompt-config/defaults/tools/insert-at-line.md`,
+  which mirrors it) no longer claims content is appended when `line_number` exceeds the total
+  lines; it states the valid range is `1 .. totalLines + 1`, where `totalLines + 1` appends.
+- `insert_at_line(line_number: totalLines + 1)` appends and preserves the trailing-newline state:
+  on `aaa\nbbb\nccc\n` with content `ddd\n`, line 4 yields `aaa\nbbb\nccc\nddd\n`.
+- `insert_at_line(line_number: totalLines + 2)` returns an error (it must not silently insert a
+  spurious blank line, which is what the phantom element caused today).
+
+### AB4 — `read_line_range` only reports truncation when content was actually truncated
+
+- A partial range read that returns exactly the requested lines must not contain
+  `has been truncated`, `--- FILE CONTENT (truncated) ---`, or the `Action: To read more…` line.
+  It reports the range plainly, e.g. `Status: Showing lines 1-5 of 14 total lines.`
+- A range whose end exceeds EOF is likewise not "truncated": lines 10-30 of a 14-line file report
+  `Status: Showing lines 10-14 of 14 total lines.`
+- Genuine truncation is still flagged: when an individual line was clipped to the maximum line
+  length, the response says so. `ProcessedFileReadResult` gains an optional `linesShortened`
+  boolean so `read_line_range` can distinguish this from range narrowing; `read-file`'s own banner
+  is unchanged (out of scope).
+- `showLineNumbers` and `showGitChanges` (legend, warning, marker column) keep working in the new
+  plain format.
+
+### AB5 — Reads that start past EOF return an error
+
+- `read_line_range(start_line: 20, end_line: 30)` on a 14-line file returns an error result whose
+  message reads `start_line 20 is beyond end of file (14 lines)`. No inverted `15-14` range and no
+  empty success body.
+- `read_line_range(start_line: 14, end_line: 30)` on a 14-line file still succeeds.
+
+## Out of scope
+
+- `read-file.ts`'s own truncation banner and any other tool that shares `processSingleFileContent`.
+- CRLF normalisation, encoding handling, or any other newline concern not raised in the issue.
+- `apply_patch` / `ast_edit` AX issues (#3033 and the sibling issue).
+
+## Test plan (tests first)
+
+New Bun test file `packages/tools/src/tools/line-range-tools-issue3036.bun.test.ts`, registered in
+`scripts/bun-test-manifest-data-tools.ts`. Behavioural only: tests write a real temp file and run
+the real tool against a fake `IToolHost`, asserting on the bytes on disk and on the `ToolResult`
+the caller receives. No mock assertions. (The tool-description and prompt-config mirror assertions
+inspect the tool's static text and read no temp file.)
+
+Coverage: every row of the AB1 table (byte-exact file content assertions, including the
+trailing-newline byte), the AB1 echo/report assertions and the confirm-preview equality, both AB2
+count assertions plus the empty-file and `'\n'` cases and the actionable `error.message`, the AB3
+append/reject pair plus a description assertion, the AB4 banner-absence/plain-status/line-shortened
+trio with a `showLineNumbers` and a `showGitChanges` variant, and both AB5 cases.
+
+Every test that asserts a reported defect must fail on `main` for the stated reason before the fix
+lands; positive-boundary and regression tests exist to pin behaviour that must not change.
+
+### Regression guard: zero-line file creation
+
+`splitFileLines` models an empty file as zero lines with no trailing newline. Before issue #3036
+the phantom trailing `''` from `content.split('\n')` guaranteed a newly created file was always
+newline-terminated; removing the phantom line would otherwise have changed how a new/empty file is
+created. A regression block pins that `insert_at_line` into a zero-line file (a non-existent file
+being created, or a truly empty file) always writes a newline-terminated result, and that the
+confirmation preview equals the bytes `execute` writes.

--- a/scripts/bun-test-manifest-data-tools.ts
+++ b/scripts/bun-test-manifest-data-tools.ts
@@ -20,6 +20,7 @@ export const TOOLS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
     'src/tools/direct-web-fetch.test.ts',
     'src/tools/github.test.ts',
     'src/tools/github-unknown-param.bun.test.ts',
+    'src/tools/line-range-tools-issue3036.bun.test.ts',
     'src/tools/check-async-tasks.test.ts',
     'src/tools/list-subagents.test.ts',
     'src/tools/codesearch.test.ts',


### PR DESCRIPTION
## TLDR

The three line-range editor tools modelled a file as `content.split('\n')`. For a POSIX file ending in a newline that array carries a phantom trailing `''` element which **is** the final newline, not a line. Five user-visible defects followed, the worst of which silently deleted a file's trailing newline.

This replaces that model with real lines plus a separate trailing-newline flag, and fixes all five reported defects:

1. `delete_line_range` no longer strips the final newline when `end_line` overshoots EOF — `delete(3,3)` and `delete(3,999)` on `aaa\nbbb\nccc\n` now produce identical bytes.
2. Bounds errors report real line counts (a 7-line file is described as 7 lines, not 8).
3. `insert_at_line`'s description no longer promises an append-past-EOF that the code rejects; the error message now carries the actionable append position.
4. `read_line_range` stops labelling its own normal path `IMPORTANT: The file content has been truncated.`
5. `read_line_range` returns a real error instead of an inverted `Showing lines 15-14 of 14` range when the read starts past EOF.

Reviewers should look hardest at `packages/tools/src/utils/lineEditing.ts` (the newline model everything else rests on) and at the `read_line_range` output-format change.

## Dive Deeper

### The root cause

`'aaa\nbbb\nccc\n'.split('\n')` is `['aaa','bbb','ccc','']`. The trailing `''` is not a line — it is the final newline. Every defect in #3036 is a consequence of counting or splicing it as if it were a line:

- `delete_line_range` computed `count = end_line - start_line + 1` with no clamp. With `end_line: 3` the splice removed only `'ccc'` and the `''` survived; with `end_line: 999` the count was 997, the splice consumed the `''` too, and the file lost its POSIX final newline — tripping `eol-last`, Prettier, and producing a spurious diff hunk. Same intent, same file, different bytes depending on whether the caller clamped the range, and clamping is the natural thing to write when you mean "delete to the end".
- `totalLines = lines.length` counted the phantom, so bounds errors were off by one in the direction that makes the number ambiguous ("is 8 the count, or the last valid index?").
- `insert_at_line` allowed `line_number` up to `totalLines + 1` where `totalLines` already included the phantom, so the real append position and one position past it were both accepted — the latter silently inserting a blank line. The documented "greater than the total lines appends" behaviour never existed; it errored.

### The model

`packages/tools/src/utils/lineEditing.ts` introduces `splitFileLines(content)` → `{ lines, hadTrailingNewline }` and `joinFileLines(lines, hadTrailingNewline)`:

- `''` is zero lines (an empty file has no lines)
- `'\n'` is one empty line
- `'aaa\nbbb\n'` is two lines with `hadTrailingNewline: true`
- `joinFileLines([], true)` is `''` — deleting every line yields a truly empty file, not a stray newline

`delete_line_range` and `insert_at_line` both build on it, and in both tools `execute()` and `shouldConfirmExecute()` now share one transformation function, so the confirmation diff preview is byte-identical to what gets written. Previously the preview duplicated the buggy arithmetic independently.

### The `insert_at_line` documentation mismatch

The issue offered a choice: implement the documented append-past-EOF, or correct the description. This corrects the description and keeps the bounds check. Silently relocating content to EOF when the caller passes a stale line number would write content in the wrong place with no signal; failing fast with an actionable message (`line_number 999 exceeds file length (7); use line_number <= 8 to append`) is the safer contract and matches the project's fail-fast preference. The guidance previously lived only in `llmContent`, which does not reach the caller — it is now in `error.message`. The prompt-config mirror `packages/core/src/prompt-config/defaults/tools/insert-at-line.md` is updated in lockstep, and a test asserts the two cannot drift apart.

### The `read_line_range` output change

`isTruncated` is true for *any* partial range, which for a range-reading tool is every ordinary call. Asking a range tool for a range and being told in capitals that the result is truncated — with an "Action" suggesting the call you just made — is noise on the intended path. Ordinary reads now say `Status: Showing lines 1-5 of 14 total lines.` and nothing more.

Genuine truncation is still reported. `ProcessedFileReadResult` gains an optional `linesShortened` flag (populated from the existing `linesWereTruncatedInLength` local in `processTextFile`) so the tool can distinguish a line clipped at the maximum line length from a range that is simply narrower than the file. `read-file.ts`, which shares `processSingleFileContent` and has its own banner, is deliberately untouched — out of scope.

### Behaviour changes worth flagging

- An empty file now has 0 lines rather than 1, so `delete_line_range(1, 1)` on a 0-byte file is an out-of-bounds error rather than a silent no-op.
- `insert_at_line(line_number: totalLines + 2)` is now a clean error rather than an insert that appended a spurious blank line.
- `delete_line_range` reports the effective clamped range: `delete(3, 999)` on a 3-line file says `Deleted 1 lines (3-3)`, not `Deleted 997 lines (3-999)`.
- Creating a file via `insert_at_line` still writes newline-terminated content, exactly as before. This is pinned by an explicit regression block, because the zero-line case is where the phantom was previously doing the work.

### Scope

Accepted behaviours AB1–AB5 are recorded in `project-plans/issue3036/plan.md` together with the out-of-scope list. Not touched: `read-file.ts`'s banner, CRLF/encoding normalisation, and the sibling `apply_patch` (#3033) and `ast_edit` AX issues.

## Reviewer Test Plan

Build and run the CLI, then in a scratch directory:

```
printf 'aaa\nbbb\nccc\n' > a.txt
printf 'aaa\nbbb\nccc\n' > b.txt
```

1. **Trailing newline (the headline bug).** Ask the agent to `delete_line_range(a.txt, start_line: 3, end_line: 3)` and `delete_line_range(b.txt, start_line: 3, end_line: 999)`. Then `hexdump -C a.txt b.txt` — both must be `6161 610a 6262 620a` (`aaa\nbbb\n`). On `main`, `b.txt` loses the final `0a`.
2. **Line counts.** On a 7-line newline-terminated file, `insert_at_line(line_number: 999)` must report `exceeds file length (7); use line_number <= 8 to append` — not `(8)`.
3. **Append boundary.** `insert_at_line(line_number: 4, content: 'ddd\n')` on the 3-line file must yield `aaa\nbbb\nccc\nddd\n`; `line_number: 5` must error and leave the file untouched.
4. **Delete to end.** `delete_line_range(start_line: 1, end_line: 999)` must leave a 0-byte file, not a file containing a lone newline.
5. **Read noise.** `read_line_range(start_line: 1, end_line: 5)` on any longer file must not mention truncation and must read `Status: Showing lines 1-5 of N total lines.`
6. **Read past EOF.** `read_line_range(start_line: 20, end_line: 30)` on a 14-line file must error with `start_line 20 is beyond end of file (14 lines)`, not return an empty body with `Showing lines 15-14`.
7. **Confirmation preview.** With approval mode set so edits require confirmation, run the `delete(3, 999)` case and confirm the diff shown matches the bytes written.

Automated coverage: `packages/tools/src/tools/line-range-tools-issue3036.bun.test.ts` (36 behavioural tests, byte-exact filesystem assertions, registered in `scripts/bun-test-manifest-data-tools.ts`). Run with `cd packages/tools && bun test src/tools/line-range-tools-issue3036.bun.test.ts`. Nineteen of them fail on `main` for the reported-defect reasons; the remainder are positive-boundary and regression tests that pin behaviour which must not change.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test`, `npm run lint`, `npm run lint:eslint-guard`, `npm run typecheck`, `npm run format`, `npm run build`, and the CLI smoke run. The `packages/tools` Bun suite passes 75/75 files.

## Linked issues / bugs

Fixes #3036
