### PR TITLE
fix(tools): stop structural_analysis and codesearch failing silently (Fixes #3038)

### DIFF
--- a/packages/tools/src/tools/codesearch-endpoint.bun.test.ts
+++ b/packages/tools/src/tools/codesearch-endpoint.bun.test.ts
@@ -174,6 +174,19 @@ describe('codesearch Exa MCP endpoint (issue #3038, AC7)', () => {
     expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
   });
 
+  it('does not interpolate undefined when error fields are missing (review)', async () => {
+    queuedOk = true;
+    queuedText = 'data: {"error":{},"jsonrpc":"2.0","id":1}' + '\n';
+
+    const result = await tool
+      .build({ query: 'shapeless error' })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+    expect(result.llmContent).not.toContain('undefined');
+    expect(result.error?.message).not.toContain('undefined');
+  });
+
   it('returns SEARCH_ERROR when isError is true with empty content (FIX-1)', async () => {
     queuedOk = true;
     queuedText =

--- a/packages/tools/src/tools/codesearch-endpoint.bun.test.ts
+++ b/packages/tools/src/tools/codesearch-endpoint.bun.test.ts
@@ -54,7 +54,46 @@ interface CapturedCall {
 function lastCall(): CapturedCall {
   const calls = fetchStub.mock.calls;
   const last = calls[calls.length - 1];
+  if (last === undefined) {
+    throw new Error('fetch was never called');
+  }
   return { url: String(last[0]), body: last[1] };
+}
+
+/**
+ * Narrows the captured fetch init to the upstream tool name and query carried
+ * in the JSON-RPC request body. Every level is checked — no type assertions.
+ */
+function extractRequestBody(init: unknown): { name: string; query: string } {
+  if (typeof init !== 'object' || init === null) {
+    throw new Error(`Expected fetch init object, got ${typeof init}`);
+  }
+  if (!('body' in init) || typeof init.body !== 'string') {
+    throw new Error('Expected fetch init to carry a string body');
+  }
+  const parsed: unknown = JSON.parse(init.body);
+  if (typeof parsed !== 'object' || parsed === null || !('params' in parsed)) {
+    throw new Error('Expected JSON-RPC params in request body');
+  }
+  const params: unknown = parsed.params;
+  if (typeof params !== 'object' || params === null) {
+    throw new Error('Expected params object in request body');
+  }
+  if (!('name' in params) || typeof params.name !== 'string') {
+    throw new Error('Expected params.name string');
+  }
+  if (
+    !('arguments' in params) ||
+    typeof params.arguments !== 'object' ||
+    params.arguments === null
+  ) {
+    throw new Error('Expected params.arguments object');
+  }
+  const args: unknown = params.arguments;
+  if (!('query' in args) || typeof args.query !== 'string') {
+    throw new Error('Expected params.arguments.query string');
+  }
+  return { name: params.name, query: args.query };
 }
 
 describe('codesearch Exa MCP endpoint (issue #3038, AC7)', () => {
@@ -86,9 +125,13 @@ describe('codesearch Exa MCP endpoint (issue #3038, AC7)', () => {
       .build({ query: 'react hooks' })
       .execute(new AbortController().signal);
 
-    const { url } = lastCall();
+    const { url, body } = lastCall();
     const parsed = new URL(url);
     expect(parsed.searchParams.get('tools')).toBe('get_code_context_exa');
+
+    const requestBody = extractRequestBody(body);
+    expect(requestBody.name).toBe('get_code_context_exa');
+    expect(requestBody.query).toBe('react hooks');
   });
 
   it('carries both tools and exaApiKey when a key resolves', async () => {

--- a/packages/tools/src/tools/codesearch-endpoint.bun.test.ts
+++ b/packages/tools/src/tools/codesearch-endpoint.bun.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the codesearch Exa MCP endpoint fix (issue #3038, AC7).
+ *
+ * Stubs only node-fetch — the single external I/O boundary — and asserts on the
+ * request URL (parsed, not string-compared) and on how upstream error/success
+ * responses map to ToolResult.
+ *
+ * @plan issue3038
+ */
+
+import { mock, describe, it, expect, beforeEach, type Mock } from 'bun:test';
+
+/**
+ * The fetch stub is the only thing standing in for the network. It captures
+ * the request URL so each test can parse it, and returns whatever response
+ * the test has queued.
+ */
+interface FetchResponse {
+  ok: boolean;
+  status?: number;
+  text: () => Promise<string>;
+}
+
+let queuedText = '';
+let queuedOk = true;
+let queuedStatus: number | undefined;
+
+const fetchStub: Mock<[string, unknown], Promise<FetchResponse>> = mock(
+  async (_url: string, _init: unknown): Promise<FetchResponse> => ({
+    ok: queuedOk,
+    status: queuedStatus,
+    text: async () => queuedText,
+  }),
+);
+
+// Register the mock BEFORE dynamically importing codesearch.js, so the mock
+// is active when that module resolves its `import fetch from 'node-fetch'`.
+mock.module('node-fetch', () => ({ default: fetchStub }));
+
+const { CodeSearchTool } = await import('./codesearch.js');
+const { ToolErrorType } = await import('../types/tool-error.js');
+
+interface CapturedCall {
+  url: string;
+  body: unknown;
+}
+
+function lastCall(): CapturedCall {
+  const calls = fetchStub.mock.calls;
+  const last = calls[calls.length - 1];
+  return { url: String(last[0]), body: last[1] };
+}
+
+describe('codesearch Exa MCP endpoint (issue #3038, AC7)', () => {
+  const keyStorage = {
+    resolveKey: mock(async (_name: string): Promise<string | null> => null),
+  };
+  const settingsService = {
+    getSetting: mock(() => undefined),
+    getSettingsService: mock(() => ({ get: mock(() => undefined) })),
+  };
+  let tool: InstanceType<typeof CodeSearchTool>;
+
+  beforeEach(() => {
+    fetchStub.mockClear();
+    keyStorage.resolveKey.mockClear();
+    settingsService.getSetting.mockClear();
+    keyStorage.resolveKey.mockImplementation(async () => null);
+    queuedText = '';
+    queuedOk = true;
+    queuedStatus = undefined;
+    tool = new CodeSearchTool({ keyStorage, settingsService });
+  });
+
+  it('always carries tools=get_code_context_exa in the request URL', async () => {
+    queuedOk = true;
+    queuedText = 'data: {"result":{"content":[{"text":"snippet"}]}}\n';
+
+    await tool
+      .build({ query: 'react hooks' })
+      .execute(new AbortController().signal);
+
+    const { url } = lastCall();
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('tools')).toBe('get_code_context_exa');
+  });
+
+  it('carries both tools and exaApiKey when a key resolves', async () => {
+    keyStorage.resolveKey.mockImplementation(async () => 'sk-test-key');
+    queuedOk = true;
+    queuedText = 'data: {"result":{"content":[{"text":"snippet"}]}}\n';
+
+    await tool
+      .build({ query: 'react hooks' })
+      .execute(new AbortController().signal);
+
+    const { url } = lastCall();
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('tools')).toBe('get_code_context_exa');
+    expect(parsed.searchParams.get('exaApiKey')).toBe('sk-test-key');
+  });
+
+  it('returns SEARCH_ERROR when the upstream result has isError: true', async () => {
+    queuedOk = true;
+    queuedText =
+      'data: {"result":{"content":[{"type":"text","text":"MCP error -32602: Tool get_code_context_exa not found"}],"isError":true},"jsonrpc":"2.0","id":1}\n';
+
+    const result = await tool
+      .build({ query: 'broken query' })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+    expect(result.llmContent).toContain('get_code_context_exa');
+  });
+
+  it('returns SEARCH_ERROR on a top-level JSON-RPC error object', async () => {
+    queuedOk = true;
+    queuedText =
+      'data: {"error":{"code":-32602,"message":"Invalid params"},"jsonrpc":"2.0","id":1}\n';
+
+    const result = await tool
+      .build({ query: 'bad query' })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+  });
+
+  it('returns SEARCH_ERROR when isError is true with empty content (FIX-1)', async () => {
+    queuedOk = true;
+    queuedText =
+      'data: {"result":{"content":[],"isError":true},"jsonrpc":"2.0","id":1}\n';
+
+    const result = await tool
+      .build({ query: 'empty error' })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+  });
+
+  it('returns SEARCH_ERROR when isError is true and content is missing (FIX-1)', async () => {
+    queuedOk = true;
+    queuedText = 'data: {"result":{"isError":true},"jsonrpc":"2.0","id":1}\n';
+
+    const result = await tool
+      .build({ query: 'missing content error' })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+  });
+
+  it('sanitizes unpaired surrogates in upstream error text (FIX-2)', async () => {
+    queuedOk = true;
+    queuedText =
+      'data: {"result":{"content":[{"type":"text","text":"\\ud800 broken"}],"isError":true},"jsonrpc":"2.0","id":1}\n';
+
+    const result = await tool
+      .build({ query: 'surrogate test' })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+    const SURROGATE = String.fromCharCode(0xd800);
+    expect(result.llmContent).not.toContain(SURROGATE);
+    expect(result.returnDisplay).not.toContain(SURROGATE);
+    expect(result.error?.message).not.toContain(SURROGATE);
+  });
+
+  it('returns content unchanged for a successful response', async () => {
+    queuedOk = true;
+    queuedText =
+      'data: {"result":{"content":[{"type":"text","text":"Here is some React hooks documentation."}]}}\n';
+
+    const result = await tool
+      .build({ query: 'react hooks' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(result.llmContent).toBe('Here is some React hooks documentation.');
+  });
+});

--- a/packages/tools/src/tools/codesearch.test.ts
+++ b/packages/tools/src/tools/codesearch.test.ts
@@ -48,7 +48,8 @@ describe('CodeSearchTool', () => {
 
     const callArgs = mockedFetch.mock.calls[0];
     const requestBody = JSON.parse(callArgs[1].body);
-    expect(callArgs[0]).toBe('https://mcp.exa.ai/mcp');
+    const url = new URL(callArgs[0]);
+    expect(url.searchParams.get('tools')).toBe('get_code_context_exa');
     expect(requestBody.params.arguments.tokensNum).toBe(5000);
     expect(result.llmContent).toBe('Here is some React hooks documentation...');
   });
@@ -79,9 +80,9 @@ describe('CodeSearchTool', () => {
       .build({ query: 'test query' })
       .execute(new AbortController().signal);
 
-    expect(mockedFetch.mock.calls[0][0]).toBe(
-      'https://mcp.exa.ai/mcp?exaApiKey=sk-test-key',
-    );
+    const url = new URL(mockedFetch.mock.calls[0][0]);
+    expect(url.searchParams.get('tools')).toBe('get_code_context_exa');
+    expect(url.searchParams.get('exaApiKey')).toBe('sk-test-key');
   });
 
   it('handles API errors', async () => {

--- a/packages/tools/src/tools/codesearch.ts
+++ b/packages/tools/src/tools/codesearch.ts
@@ -55,10 +55,16 @@ interface McpCodeRequest {
 interface McpCodeResponse {
   jsonrpc: string;
   result?: {
-    content: Array<{
+    content?: Array<{
       type: string;
       text: string;
     }>;
+    isError?: boolean;
+  };
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
   };
 }
 
@@ -66,6 +72,15 @@ export interface CodeSearchToolParams {
   query: string;
   tokensNum?: number;
 }
+
+/**
+ * Discriminated result of parsing a single SSE data line from the Exa MCP.
+ * - ok:true carries the content to return to the model.
+ * - ok:false carries an upstream failure message that must surface as an error.
+ */
+type ParsedCodeLine =
+  | { ok: true; content: string }
+  | { ok: false; errorText: string };
 
 export interface CodeSearchToolDependencies {
   keyStorage?: Pick<IToolKeyStorage, 'resolveKey'>;
@@ -132,11 +147,13 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
 
   private async buildEndpointUrl(): Promise<string> {
     const baseUrl = `${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.CONTEXT}`;
+    const params = new URLSearchParams();
+    params.set('tools', 'get_code_context_exa');
     const key = await this.dependencies.keyStorage?.resolveKey('exa');
     if (key !== undefined && key !== null) {
-      return `${baseUrl}?exaApiKey=${encodeURIComponent(key)}`;
+      params.set('exaApiKey', key);
     }
-    return baseUrl;
+    return `${baseUrl}?${params.toString()}`;
   }
 
   async execute(
@@ -179,9 +196,24 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
       const lines = responseText.split('\n');
       for (const line of lines) {
         const parsed = this.parseCodeResponseLine(line);
-        if (parsed !== undefined) {
-          return parsed;
+        if (parsed === undefined) {
+          continue;
         }
+        if (!parsed.ok) {
+          const safeErrorText = ensureJsonSafe(parsed.errorText);
+          return {
+            llmContent: `Code search failed: ${safeErrorText}`,
+            returnDisplay: `Code search failed: ${safeErrorText}`,
+            error: {
+              message: safeErrorText,
+              type: ToolErrorType.SEARCH_ERROR,
+            },
+          };
+        }
+        return {
+          llmContent: parsed.content,
+          returnDisplay: parsed.content,
+        };
       }
 
       return {
@@ -203,26 +235,36 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
     }
   }
 
-  private parseCodeResponseLine(
-    line: string,
-  ): { llmContent: string; returnDisplay: string } | undefined {
+  private parseCodeResponseLine(line: string): ParsedCodeLine | undefined {
     if (!line.startsWith('data: ')) {
       return undefined;
     }
+    let data: McpCodeResponse;
     try {
-      const data: McpCodeResponse = JSON.parse(line.substring(6));
-      if (
-        data.result?.content !== undefined &&
-        data.result.content.length > 0
-      ) {
-        const content = ensureJsonSafe(data.result.content[0].text);
-        return {
-          llmContent: content,
-          returnDisplay: content,
-        };
-      }
+      data = JSON.parse(line.substring(6));
     } catch {
-      // Ignore parse errors for intermediate lines
+      // A malformed intermediate SSE line is genuinely unpredictable
+      // external input; skip it without aborting the whole stream.
+      return undefined;
+    }
+
+    if (data.error) {
+      return {
+        ok: false,
+        errorText: `MCP error ${data.error.code}: ${data.error.message}`,
+      };
+    }
+    if (data.result?.isError === true) {
+      const text = data.result.content?.[0]?.text;
+      return {
+        ok: false,
+        errorText:
+          text ?? 'the upstream server reported an error with no message.',
+      };
+    }
+    const content = data.result?.content;
+    if (content !== undefined && content.length > 0) {
+      return { ok: true, content: ensureJsonSafe(content[0].text) };
     }
     return undefined;
   }

--- a/packages/tools/src/tools/codesearch.ts
+++ b/packages/tools/src/tools/codesearch.ts
@@ -249,9 +249,17 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
     }
 
     if (data.error) {
+      const code =
+        typeof data.error.code === 'number'
+          ? String(data.error.code)
+          : 'unknown';
+      const message =
+        typeof data.error.message === 'string' && data.error.message.length > 0
+          ? data.error.message
+          : 'no message provided by upstream server';
       return {
         ok: false,
-        errorText: `MCP error ${data.error.code}: ${data.error.message}`,
+        errorText: `MCP error ${code}: ${message}`,
       };
     }
     if (data.result?.isError === true) {

--- a/packages/tools/src/tools/structural-analysis.ts
+++ b/packages/tools/src/tools/structural-analysis.ts
@@ -3,7 +3,8 @@
  * Analyzes code relationships: call graphs, type hierarchies, symbol references,
  * module dependencies, and exports using @ast-grep/napi.
  *
- * This is name-based (not type-resolved) analysis. See overview.md for limitations.
+ * Matching is by identifier name, so same-named symbols in different types are
+ * not disambiguated.
  *
  * The analysis logic is decomposed into per-mode sub-modules under
  * `./structural-analysis/`. This file is the public facade that wires the
@@ -134,6 +135,12 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
       );
     }
 
+    if ((mode as Mode) === 'dependencies' && !target && !this.params.path) {
+      return this.makeError(
+        'Error: `target` parameter is required for "dependencies" mode.',
+      );
+    }
+
     return {
       mode,
       resolvedLang,
@@ -238,6 +245,32 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
   }
 }
 
+/**
+ * Worked examples matter more than prose here: models need to see the
+ * per-mode parameter matrix and one concrete call shape per mode.
+ */
+const DESCRIPTION = `Performs multi-hop AST-based code analysis: call graphs, type hierarchies,
+symbol references, module dependencies, and exports. Matching is by identifier
+name, so same-named symbols in different types are not disambiguated. Unlike
+ast_grep (single-query), this chains multiple queries to walk relationships
+across files.
+
+Required parameters by mode:
+- callers, callees, definitions, hierarchy, references: "symbol" (plus "language").
+- dependencies, exports: "target" (plus "language").
+- depth and maxNodes apply only to callers/callees.
+
+Examples:
+  { "mode": "callers", "language": "typescript", "symbol": "myFunc" }
+  { "mode": "callees", "language": "typescript", "symbol": "myFunc", "depth": 2 }
+  { "mode": "definitions", "language": "typescript", "symbol": "MyClass" }
+  { "mode": "hierarchy", "language": "typescript", "symbol": "MyClass" }
+  { "mode": "references", "language": "typescript", "symbol": "MyClass" }
+  { "mode": "dependencies", "language": "typescript", "target": "src/utils" }
+  { "mode": "exports", "language": "typescript", "target": "src/utils" }
+
+Operations: ${VALID_MODES.join(', ')}.`;
+
 export class StructuralAnalysisTool extends BaseDeclarativeTool<
   StructuralAnalysisParams,
   ToolResult
@@ -248,9 +281,7 @@ export class StructuralAnalysisTool extends BaseDeclarativeTool<
     super(
       StructuralAnalysisTool.Name,
       'StructuralAnalysis',
-      'Performs multi-hop AST-based code analysis: call graphs, type hierarchies, symbol references, ' +
-        'module dependencies, and exports. This is name-based (not type-resolved) analysis. ' +
-        'Use for understanding code relationships. Unlike ast_grep (single-query), this chains multiple queries.',
+      DESCRIPTION,
       Kind.Search,
       {
         properties: {
@@ -264,26 +295,28 @@ export class StructuralAnalysisTool extends BaseDeclarativeTool<
             type: 'string',
           },
           path: {
-            description: 'Directory to search. Defaults to workspace root.',
+            description:
+              'Directory to search. Defaults to workspace root. For dependencies/exports, prefer target.',
             type: 'string',
           },
           symbol: {
             description:
-              'Symbol name for callers/callees/definitions/hierarchy/references modes.',
+              'Symbol name. Required for callers, callees, definitions, hierarchy, references.',
             type: 'string',
           },
           depth: {
             description:
-              'Recursion depth for callers/callees. Default 1, max 5.',
+              'Recursion depth for callers/callees only. Default 1, max 5.',
             type: 'number',
           },
           maxNodes: {
             description:
-              'Max symbols to visit during recursive traversal. Default 50.',
+              'Max symbols to visit during callers/callees traversal. Default 50.',
             type: 'number',
           },
           target: {
-            description: 'File/directory for dependencies/exports modes.',
+            description:
+              'File/directory to analyze. Required for dependencies and exports modes.',
             type: 'string',
           },
           reverse: {

--- a/packages/tools/src/tools/structural-analysis.ts
+++ b/packages/tools/src/tools/structural-analysis.ts
@@ -137,7 +137,7 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
 
     if ((mode as Mode) === 'dependencies' && !target && !this.params.path) {
       return this.makeError(
-        'Error: `target` parameter is required for "dependencies" mode.',
+        'Error: `target` (or `path`) parameter is required for "dependencies" mode.',
       );
     }
 
@@ -257,7 +257,8 @@ across files.
 
 Required parameters by mode:
 - callers, callees, definitions, hierarchy, references: "symbol" (plus "language").
-- dependencies, exports: "target" (plus "language").
+- dependencies: "target" (or "path") — an explicit search root (plus "language").
+- exports: optional "target", defaults to the workspace root (plus "language").
 - depth and maxNodes apply only to callers/callees.
 
 Examples:
@@ -316,7 +317,7 @@ export class StructuralAnalysisTool extends BaseDeclarativeTool<
           },
           target: {
             description:
-              'File/directory to analyze. Required for dependencies and exports modes.',
+              'File/directory to analyze. Required for dependencies; optional for exports.',
             type: 'string',
           },
           reverse: {

--- a/packages/tools/src/tools/structural-analysis/callees.ts
+++ b/packages/tools/src/tools/structural-analysis/callees.ts
@@ -74,11 +74,17 @@ function collectCalleeRefs(
 
 /**
  * Finds function-like container nodes whose declared name matches `sym`.
- * Covers function_declaration, generator_function_declaration, method_definition,
- * and arrow_function (matched via its variable_declarator binding so the const
- * name is the lookup key). The returned node is searched for call expressions:
- * for arrows this is the variable_declarator, which fully contains the function
- * body, so the call search is correct.
+ * Covers function_declaration, generator_function_declaration,
+ * method_definition, and arrow_function (the latter is matched via its
+ * variable_declarator binding so the const name is the lookup key, but the
+ * arrow_function node itself is returned — NOT the declarator). Returning the
+ * arrow_function is deliberate: collectCalleesFromContainer keeps a call only
+ * when its nearest enclosing function-container (per findFunctionContainer)
+ * IS the container node. findFunctionContainer recognises arrow_function as a
+ * function-container kind but not variable_declarator, so returning the
+ * declarator would make every call inside an arrow body vanish (its nearest
+ * function container would be the arrow_function, whose range never matches the
+ * declarator's). Do not "simplify" this back to returning the declarator.
  */
 function findNamedContainers(parsed: ParsedFile, sym: string): SgNode[] {
   const escaped = escapeRegex(sym);
@@ -134,8 +140,9 @@ function findNamedContainers(parsed: ParsedFile, sym: string): SgNode[] {
 /**
  * Checks a single call-expression node and returns a CalleeRef if it belongs
  * directly to the target container (its nearest function-like container),
- * or null if it should be skipped (nested in a different function, already
- * visited, or at the traversal limit).
+ * or null if it should be skipped (nested in a different function or already
+ * visited). The maxNodes traversal limit is enforced upstream in
+ * findCalleesOfFile, not in this function.
  *
  * Extracted so the caller loop uses zero `continue` statements.
  */

--- a/packages/tools/src/tools/structural-analysis/callees.ts
+++ b/packages/tools/src/tools/structural-analysis/callees.ts
@@ -180,7 +180,7 @@ function tryCollectCallee(
     return null;
   }
   const callText = node.text().substring(0, 200);
-  const key = `${callText}@${relPath}`;
+  const key = `${callText}@${relPath}@${node.range().start.index}`;
   if (visited.has(key)) {
     return null;
   }

--- a/packages/tools/src/tools/structural-analysis/callees.ts
+++ b/packages/tools/src/tools/structural-analysis/callees.ts
@@ -75,15 +75,16 @@ function collectCalleeRefs(
 /**
  * Finds function-like container nodes whose declared name matches `sym`.
  * Covers function_declaration, generator_function_declaration,
- * method_definition, and arrow_function (the latter is matched via its
+ * method_definition, and variable-bound function expressions — arrow_function,
+ * function_expression and generator_function — each matched via its
  * variable_declarator binding so the const name is the lookup key, but the
- * arrow_function node itself is returned — NOT the declarator). Returning the
- * arrow_function is deliberate: collectCalleesFromContainer keeps a call only
- * when its nearest enclosing function-container (per findFunctionContainer)
- * IS the container node. findFunctionContainer recognises arrow_function as a
- * function-container kind but not variable_declarator, so returning the
- * declarator would make every call inside an arrow body vanish (its nearest
- * function container would be the arrow_function, whose range never matches the
+ * inner function node itself is returned — NOT the declarator. Returning the
+ * inner node is deliberate: collectCalleesFromContainer keeps a call only when
+ * its nearest enclosing function-container (per findFunctionContainer) IS the
+ * container node. findFunctionContainer recognises those function kinds as
+ * function-container kinds but not variable_declarator, so returning the
+ * declarator would make every call inside the body vanish (its nearest function
+ * container would be the inner function node, whose range never matches the
  * declarator's). Do not "simplify" this back to returning the declarator.
  */
 function findNamedContainers(parsed: ParsedFile, sym: string): SgNode[] {
@@ -105,33 +106,47 @@ function findNamedContainers(parsed: ParsedFile, sym: string): SgNode[] {
       } as NapiConfig);
       for (const m of matches) containers.push(m);
     } catch {
-      /* skip unsupported kinds */
+      // Rule names TS node kinds; ast-grep throws for languages whose grammar lacks them.
     }
   }
 
-  // Arrow functions: match the variable_declarator that binds them so the
-  // const name is the lookup key. Return the arrow_function node itself (not
+  // Variable-bound function expressions (arrow_function, function_expression,
+  // generator_function): match the variable_declarator that binds them so the
+  // const name is the lookup key. Return the inner function node itself (not
   // the declarator) so the nearest-enclosing-container comparison in
   // collectCalleesFromContainer lines up: the nearest function container of a
-  // call inside the arrow body is the arrow_function, not the declarator.
+  // call inside the body is the inner function node, not the declarator.
+  const declaratorFunctionKinds = [
+    'arrow_function',
+    'function_expression',
+    'generator_function',
+  ] as const;
   try {
     const declarators = parsed.root.findAll({
       rule: {
         kind: 'variable_declarator',
         all: [
           { has: { kind: 'identifier', regex: `^${escaped}$` } },
-          { has: { kind: 'arrow_function' } },
+          {
+            has: {
+              any: declaratorFunctionKinds.map((k) => ({ kind: k })),
+            },
+          },
         ],
       },
     } as NapiConfig);
     for (const d of declarators) {
-      const arrow = d
+      const fn = d
         .children()
-        .find((c: SgNode) => String(c.kind()) === 'arrow_function');
-      if (arrow) containers.push(arrow);
+        .find((c: SgNode) =>
+          (declaratorFunctionKinds as readonly string[]).includes(
+            String(c.kind()),
+          ),
+        );
+      if (fn) containers.push(fn);
     }
   } catch {
-    /* skip */
+    // Rule names TS node kinds; ast-grep throws for languages whose grammar lacks them.
   }
 
   return containers;

--- a/packages/tools/src/tools/structural-analysis/callees.ts
+++ b/packages/tools/src/tools/structural-analysis/callees.ts
@@ -14,6 +14,7 @@ import {
   makeRelative,
   extractCalleeName,
   deduplicateCallRanges,
+  findFunctionContainer,
 } from './helpers.js';
 
 interface CalleeRef {
@@ -53,7 +54,9 @@ async function findCalleesOfFile(
 }
 
 /**
- * Collects callee references from a single parsed file's method definitions.
+ * Collects callee references from a single parsed file by locating every
+ * function-like container whose name matches `sym`, regardless of how it is
+ * declared (function, generator, arrow bound to a const, or class/object method).
  */
 function collectCalleeRefs(
   parsed: ParsedFile,
@@ -63,56 +66,146 @@ function collectCalleeRefs(
   ctx: CalleeCtx,
 ): CalleeRef[] {
   const results: CalleeRef[] = [];
-  try {
-    const methodMatches = parsed.root.findAll({
-      rule: {
-        kind: 'method_definition',
-        has: {
-          kind: 'property_identifier',
-          regex: `^${escapeRegex(sym)}$`,
-        },
-      },
-    } as NapiConfig);
-
-    for (const methodNode of methodMatches) {
-      collectCalleesFromMethod(methodNode, relPath, visited, ctx, results);
-    }
-  } catch {
-    /* skip */
+  for (const container of findNamedContainers(parsed, sym)) {
+    collectCalleesFromContainer(container, relPath, visited, ctx, results);
   }
   return results;
 }
 
 /**
- * Collects outermost call expressions within a single method node.
+ * Finds function-like container nodes whose declared name matches `sym`.
+ * Covers function_declaration, generator_function_declaration, method_definition,
+ * and arrow_function (matched via its variable_declarator binding so the const
+ * name is the lookup key). The returned node is searched for call expressions:
+ * for arrows this is the variable_declarator, which fully contains the function
+ * body, so the call search is correct.
  */
-function collectCalleesFromMethod(
-  methodNode: SgNode,
+function findNamedContainers(parsed: ParsedFile, sym: string): SgNode[] {
+  const escaped = escapeRegex(sym);
+  const rules: Array<{ kind: string; nameKind: string }> = [
+    { kind: 'function_declaration', nameKind: 'identifier' },
+    { kind: 'generator_function_declaration', nameKind: 'identifier' },
+    { kind: 'method_definition', nameKind: 'property_identifier' },
+  ];
+
+  const containers: SgNode[] = [];
+  for (const { kind, nameKind } of rules) {
+    try {
+      const matches = parsed.root.findAll({
+        rule: {
+          kind,
+          has: { kind: nameKind, regex: `^${escaped}$` },
+        },
+      } as NapiConfig);
+      for (const m of matches) containers.push(m);
+    } catch {
+      /* skip unsupported kinds */
+    }
+  }
+
+  // Arrow functions: match the variable_declarator that binds them so the
+  // const name is the lookup key. Return the arrow_function node itself (not
+  // the declarator) so the nearest-enclosing-container comparison in
+  // collectCalleesFromContainer lines up: the nearest function container of a
+  // call inside the arrow body is the arrow_function, not the declarator.
+  try {
+    const declarators = parsed.root.findAll({
+      rule: {
+        kind: 'variable_declarator',
+        all: [
+          { has: { kind: 'identifier', regex: `^${escaped}$` } },
+          { has: { kind: 'arrow_function' } },
+        ],
+      },
+    } as NapiConfig);
+    for (const d of declarators) {
+      const arrow = d
+        .children()
+        .find((c: SgNode) => String(c.kind()) === 'arrow_function');
+      if (arrow) containers.push(arrow);
+    }
+  } catch {
+    /* skip */
+  }
+
+  return containers;
+}
+
+/**
+ * Checks a single call-expression node and returns a CalleeRef if it belongs
+ * directly to the target container (its nearest function-like container),
+ * or null if it should be skipped (nested in a different function, already
+ * visited, or at the traversal limit).
+ *
+ * Extracted so the caller loop uses zero `continue` statements.
+ */
+function tryCollectCallee(
+  node: SgNode,
+  containerStart: number,
+  containerEnd: number,
+  relPath: string,
+  visited: Set<string>,
+  ctx: CalleeCtx,
+): CalleeRef | null {
+  const nearest = findFunctionContainer(node);
+  if (nearest === null) {
+    return null;
+  }
+  if (
+    nearest.range().start.index !== containerStart ||
+    nearest.range().end.index !== containerEnd
+  ) {
+    return null;
+  }
+  const callText = node.text().substring(0, 200);
+  const key = `${callText}@${relPath}`;
+  if (visited.has(key)) {
+    return null;
+  }
+  visited.add(key);
+  ctx.nodesVisited++;
+  return {
+    text: callText,
+    file: relPath,
+    line: node.range().start.line + 1,
+    calleeNode: node,
+  };
+}
+
+/**
+ * Collects outermost call expressions that belong directly to a single
+ * container node. Only calls whose NEAREST enclosing function-like container
+ * is the target container are kept, so calls inside nested functions are not
+ * misattributed to the outer container. Containers are compared by range
+ * index (node identity is not reliable across ast-grep queries).
+ */
+function collectCalleesFromContainer(
+  containerNode: SgNode,
   relPath: string,
   visited: Set<string>,
   ctx: CalleeCtx,
   results: CalleeRef[],
 ): void {
-  const callMatches = methodNode.findAll({
+  const callMatches = containerNode.findAll({
     rule: { kind: 'call_expression' },
   } as NapiConfig);
   const outermost = deduplicateCallRanges(callMatches);
 
-  for (const { node } of outermost) {
-    const callText = node.text().substring(0, 200);
-    const key = `${callText}@${relPath}`;
-    if (visited.has(key)) {
-      continue;
-    }
-    visited.add(key);
-    ctx.nodesVisited++;
+  const containerStart = containerNode.range().start.index;
+  const containerEnd = containerNode.range().end.index;
 
-    results.push({
-      text: callText,
-      file: relPath,
-      line: node.range().start.line + 1,
-      calleeNode: node,
-    });
+  for (const { node } of outermost) {
+    const ref = tryCollectCallee(
+      node,
+      containerStart,
+      containerEnd,
+      relPath,
+      visited,
+      ctx,
+    );
+    if (ref !== null) {
+      results.push(ref);
+    }
   }
 }
 

--- a/packages/tools/src/tools/structural-analysis/definitions.ts
+++ b/packages/tools/src/tools/structural-analysis/definitions.ts
@@ -47,6 +47,73 @@ function searchFunctionAndMethodDefinitions(
       definitions,
     );
   }
+
+  collectVariableBoundFunctionDefinitions(
+    parsed,
+    escaped,
+    relPath,
+    definitions,
+  );
+}
+
+/**
+ * Kinds that, when they appear as a direct child of a variable_declarator,
+ * mean the declarator binds a function-like expression.
+ */
+const VARIABLE_BOUND_FUNCTION_KINDS = [
+  'arrow_function',
+  'function_expression',
+  'generator_function',
+] as const;
+
+/**
+ * Finds variable_declarator nodes that bind a function-like expression
+ * (arrow_function, function_expression, or generator_function) whose
+ * identifier matches `escapedSymbol`, and reports them with kind 'function'.
+ *
+ * Only DIRECT children are inspected — the function node is always a direct
+ * child of the declarator, even for type-annotated bindings (e.g.
+ * `const f: () => void = () => {}`); a descendant search would wrongly match
+ * functions nested inside the initialiser.
+ */
+function collectVariableBoundFunctionDefinitions(
+  parsed: ParsedFile,
+  escapedSymbol: string,
+  relPath: string,
+  definitions: DefinitionEntry[],
+): void {
+  try {
+    const declarators = parsed.root.findAll({
+      rule: {
+        kind: 'variable_declarator',
+        has: { kind: 'identifier', regex: `^${escapedSymbol}$` },
+      },
+    } as NapiConfig);
+    for (const d of declarators) {
+      const fn = d
+        .children()
+        .find((c: SgNode) =>
+          (VARIABLE_BOUND_FUNCTION_KINDS as readonly string[]).includes(
+            String(c.kind()),
+          ),
+        );
+      if (fn === undefined) continue;
+      const line = d.range().start.line + 1;
+      const exists = definitions.some(
+        (def) => def.file === relPath && def.line === line,
+      );
+      if (!exists) {
+        definitions.push({
+          file: relPath,
+          line,
+          kind: 'function',
+          text: d.text().substring(0, 200),
+        });
+      }
+    }
+  } catch {
+    // Rule names TS node kinds; ast-grep throws for languages whose grammar lacks them.
+  }
 }
 
 /**

--- a/packages/tools/src/tools/structural-analysis/definitions.ts
+++ b/packages/tools/src/tools/structural-analysis/definitions.ts
@@ -13,36 +13,89 @@ import type {
 } from './types.js';
 import { escapeRegex, getFiles, parseFile, makeRelative } from './helpers.js';
 
-function searchDefinitionPatterns(
+function searchFunctionAndMethodDefinitions(
   parsed: ParsedFile,
   symbol: string,
   relPath: string,
   definitions: DefinitionEntry[],
 ): void {
-  const patterns = [
-    { pat: `${symbol}($$$PARAMS) { $$$BODY }`, kind: 'method' },
-    { pat: `function ${symbol}($$$PARAMS) { $$$BODY }`, kind: 'function' },
-    { pat: `class ${symbol} { $$$BODY }`, kind: 'class' },
-    { pat: `class ${symbol} extends $PARENT { $$$BODY }`, kind: 'class' },
+  const escaped = escapeRegex(symbol);
+  const rules: Array<{ kind: string; kindLabel: string; nameKind: string }> = [
+    {
+      kind: 'function_declaration',
+      kindLabel: 'function',
+      nameKind: 'identifier',
+    },
+    {
+      kind: 'generator_function_declaration',
+      kindLabel: 'function',
+      nameKind: 'identifier',
+    },
+    {
+      kind: 'method_definition',
+      kindLabel: 'method',
+      nameKind: 'property_identifier',
+    },
   ];
 
-  for (const { pat, kind } of patterns) {
-    try {
-      const matches = parsed.root.findAll(pat);
-      for (const m of matches) {
-        const range = m.range();
-        definitions.push({
-          file: relPath,
-          line: range.start.line + 1,
-          kind,
-          text: m.text().substring(0, 200),
-        });
-      }
-    } catch {
-      // Pattern may not be valid for all languages
+  for (const { kind, kindLabel, nameKind } of rules) {
+    collectRuleDefinitions(
+      parsed,
+      { kind, nameKind, regex: `^${escaped}$` },
+      kindLabel,
+      relPath,
+      definitions,
+    );
+  }
+}
+
+/**
+ * Runs a single AST kind + name rule and appends deduplicated definition
+ * entries. Isolated so the caller stays below the nesting limit.
+ */
+function collectRuleDefinitions(
+  parsed: ParsedFile,
+  rule: { kind: string; nameKind: string; regex: string },
+  kindLabel: string,
+  relPath: string,
+  definitions: DefinitionEntry[],
+): void {
+  let matches;
+  try {
+    matches = parsed.root.findAll({
+      rule: {
+        kind: rule.kind,
+        has: { kind: rule.nameKind, regex: rule.regex },
+      },
+    } as NapiConfig);
+  } catch {
+    return;
+  }
+  for (const m of matches) {
+    const line = m.range().start.line + 1;
+    const exists = definitions.some(
+      (d) => d.file === relPath && d.line === line,
+    );
+    if (!exists) {
+      definitions.push({
+        file: relPath,
+        line,
+        kind: kindLabel,
+        text: m.text().substring(0, 200),
+      });
     }
   }
 }
+
+/**
+ * Maps raw ast-grep declaration node kinds to the friendly labels used by the
+ * function/method path, so callers see 'class' not 'class_declaration'.
+ */
+const DECLARATION_KIND_LABELS: Record<string, string> = {
+  class_declaration: 'class',
+  interface_declaration: 'interface',
+  type_alias_declaration: 'type',
+};
 
 function searchDeclarationRules(
   parsed: ParsedFile,
@@ -84,10 +137,11 @@ function searchDeclarationRules(
         (d) => d.file === relPath && d.line === range.start.line + 1,
       );
       if (!exists) {
+        const rawKind = String(m.kind());
         definitions.push({
           file: relPath,
           line: range.start.line + 1,
-          kind: String(m.kind()),
+          kind: DECLARATION_KIND_LABELS[rawKind] ?? rawKind,
           text: m.text().substring(0, 200),
         });
       }
@@ -113,7 +167,7 @@ async function processDefinitionsFile(
   }
 
   const relPath = makeRelative(file, workspaceRoot);
-  searchDefinitionPatterns(parsed, symbol, relPath, definitions);
+  searchFunctionAndMethodDefinitions(parsed, symbol, relPath, definitions);
   searchDeclarationRules(parsed, symbol, relPath, definitions);
   return true;
 }

--- a/packages/tools/src/tools/structural-analysis/definitions.ts
+++ b/packages/tools/src/tools/structural-analysis/definitions.ts
@@ -4,7 +4,7 @@
  * @plan PLAN-20260211-ASTGREP.P07
  */
 
-import type { NapiConfig } from '@ast-grep/napi';
+import type { NapiConfig, SgNode } from '@ast-grep/napi';
 import type {
   ParsedFile,
   AnalysisResult,
@@ -60,7 +60,7 @@ function collectRuleDefinitions(
   relPath: string,
   definitions: DefinitionEntry[],
 ): void {
-  let matches;
+  let matches: SgNode[];
   try {
     matches = parsed.root.findAll({
       rule: {

--- a/packages/tools/src/tools/structural-analysis/definitions.ts
+++ b/packages/tools/src/tools/structural-analysis/definitions.ts
@@ -69,6 +69,7 @@ function collectRuleDefinitions(
       },
     } as NapiConfig);
   } catch {
+    // Rule names TS node kinds; ast-grep throws for languages whose grammar lacks them.
     return;
   }
   for (const m of matches) {
@@ -147,7 +148,7 @@ function searchDeclarationRules(
       }
     }
   } catch {
-    // Rule may not apply
+    // Rule names TS node kinds; ast-grep throws for languages whose grammar lacks them.
   }
 }
 

--- a/packages/tools/src/tools/structural-analysis/dependencies.ts
+++ b/packages/tools/src/tools/structural-analysis/dependencies.ts
@@ -6,6 +6,7 @@
 
 import * as path from 'node:path';
 import type { NapiConfig } from '@ast-grep/napi';
+import type { SgNode } from '@ast-grep/napi';
 import type {
   ParsedFile,
   AnalysisResult,
@@ -14,40 +15,81 @@ import type {
 } from './types.js';
 import { getFiles, parseFile, makeRelative } from './helpers.js';
 
-function collectNamedAndDefaultImports(
+/**
+ * Strips surrounding single or double quotes from a module specifier.
+ */
+function stripQuotes(text: string): string {
+  return text.replace(/^['"]|['"]$/g, '');
+}
+
+/**
+ * Returns the string child of an import_statement (the module source), or
+ * null if the statement has no source string (malformed input).
+ */
+function findImportSource(children: SgNode[]): SgNode | null {
+  return children.find((c: SgNode) => String(c.kind()) === 'string') ?? null;
+}
+
+/**
+ * Classifies a single import_statement node into one or more import records by
+ * inspecting its children, rather than running overlapping literal patterns.
+ *
+ * A statement can produce BOTH a `default` and a `named` record (e.g.
+ * `import def, { named } from '...'`).
+ */
+function classifyImportStatement(
+  stmt: SgNode,
+  relPath: string,
+  imports: ImportEntry[],
+): void {
+  const children = stmt.children();
+  const line = stmt.range().start.line + 1;
+  const sourceNode = findImportSource(children);
+  const source = sourceNode ? stripQuotes(sourceNode.text()) : '';
+
+  const hasTypeKeyword = children.some(
+    (c: SgNode) => String(c.kind()) === 'type',
+  );
+  if (hasTypeKeyword) {
+    imports.push({ file: relPath, line, source, kind: 'type' });
+    return;
+  }
+
+  const clause = children.find(
+    (c: SgNode) => String(c.kind()) === 'import_clause',
+  );
+  if (!clause) {
+    imports.push({ file: relPath, line, source, kind: 'side-effect' });
+    return;
+  }
+
+  const clauseChildren = clause.children();
+  if (clauseChildren.some((c: SgNode) => String(c.kind()) === 'identifier')) {
+    imports.push({ file: relPath, line, source, kind: 'default' });
+  }
+  if (
+    clauseChildren.some((c: SgNode) => String(c.kind()) === 'named_imports')
+  ) {
+    imports.push({ file: relPath, line, source, kind: 'named' });
+  }
+  if (
+    clauseChildren.some((c: SgNode) => String(c.kind()) === 'namespace_import')
+  ) {
+    imports.push({ file: relPath, line, source, kind: 'namespace' });
+  }
+}
+
+function collectStaticImports(
   parsed: ParsedFile,
   relPath: string,
   imports: ImportEntry[],
 ): void {
   try {
-    const named = parsed.root.findAll(`import { $$$NAMES } from $SOURCE`);
-    for (const m of named) {
-      const src = m.getMatch('SOURCE');
-      if (src) {
-        imports.push({
-          file: relPath,
-          line: m.range().start.line + 1,
-          source: src.text().replace(/['"]/g, ''),
-          kind: 'named',
-        });
-      }
-    }
-  } catch {
-    /* skip */
-  }
-
-  try {
-    const defaults = parsed.root.findAll(`import $DEFAULT from $SOURCE`);
-    for (const m of defaults) {
-      const src = m.getMatch('SOURCE');
-      if (src) {
-        imports.push({
-          file: relPath,
-          line: m.range().start.line + 1,
-          source: src.text().replace(/['"]/g, ''),
-          kind: 'default',
-        });
-      }
+    const statements = parsed.root.findAll({
+      rule: { kind: 'import_statement' },
+    } as NapiConfig);
+    for (const stmt of statements) {
+      classifyImportStatement(stmt, relPath, imports);
     }
   } catch {
     /* skip */
@@ -105,7 +147,7 @@ function collectFileImports(
   relPath: string,
   imports: ImportEntry[],
 ): void {
-  collectNamedAndDefaultImports(parsed, relPath, imports);
+  collectStaticImports(parsed, relPath, imports);
   collectDynamicAndReexports(parsed, relPath, imports);
 }
 
@@ -257,8 +299,24 @@ export async function executeDependencies(
     mode: 'dependencies',
     truncated: false,
     results: {
-      imports,
+      imports: deduplicateForwardImports(imports),
       reverseImports: reverse ? reverseImports : undefined,
     },
   };
+}
+
+/**
+ * Deduplicates the forward import list by (file, line, source, kind) so no
+ * tuple is emitted more than once.
+ */
+function deduplicateForwardImports(imports: ImportEntry[]): ImportEntry[] {
+  const seen = new Set<string>();
+  const result: ImportEntry[] = [];
+  for (const imp of imports) {
+    const key = JSON.stringify([imp.file, imp.line, imp.source, imp.kind]);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(imp);
+  }
+  return result;
 }

--- a/packages/tools/src/tools/structural-analysis/dependencies.ts
+++ b/packages/tools/src/tools/structural-analysis/dependencies.ts
@@ -24,10 +24,76 @@ function stripQuotes(text: string): string {
 
 /**
  * Returns the string child of an import_statement (the module source), or
- * null if the statement has no source string (malformed input).
+ * null if the statement has no source string among its direct children.
  */
 function findImportSource(children: SgNode[]): SgNode | null {
   return children.find((c: SgNode) => String(c.kind()) === 'string') ?? null;
+}
+
+/**
+ * Resolves the module source string for a given import statement node.
+ *
+ * For static imports the string is a direct child, but for
+ * `import x = require('...')` (and `import type x = require(...)`) the
+ * specifier lives inside the `import_require_clause` rather than as a
+ * direct child of the import_statement. This helper traverses into that
+ * clause to extract the source when the direct-child scan finds nothing.
+ *
+ * Returns the unquoted source text, or null when no source can be resolved.
+ */
+function resolveImportSource(stmt: SgNode): string | null {
+  const children = stmt.children();
+  const directSource = findImportSource(children);
+  if (directSource !== null) {
+    return stripQuotes(directSource.text());
+  }
+
+  const requireClause = children.find(
+    (c: SgNode) => String(c.kind()) === 'import_require_clause',
+  );
+  if (requireClause !== undefined) {
+    const stringNode = requireClause
+      .children()
+      .find((c: SgNode) => String(c.kind()) === 'string');
+    if (stringNode !== undefined) {
+      return stripQuotes(stringNode.text());
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Determines whether every import_specifier inside a named_imports clause
+ * carries an inline `type` modifier (e.g. `import { type A, type B }`).
+ * Returns true only when the clause is non-empty and every specifier is
+ * type-only.
+ */
+function isNamedImportsAllType(namedImports: SgNode): boolean {
+  const specifiers = namedImports
+    .children()
+    .filter((c: SgNode) => String(c.kind()) === 'import_specifier');
+  if (specifiers.length === 0) {
+    return false;
+  }
+  return specifiers.every((spec: SgNode) =>
+    spec.children().some((c: SgNode) => String(c.kind()) === 'type'),
+  );
+}
+
+/**
+ * Finds a named_imports clause among the clause's children and determines
+ * whether it is fully type-only (every specifier carries inline `type`).
+ * Returns true when the named_imports clause exists and is all-type.
+ */
+function namedImportsAreAllType(clauseChildren: SgNode[]): boolean {
+  const namedImports = clauseChildren.find(
+    (c: SgNode) => String(c.kind()) === 'named_imports',
+  );
+  if (namedImports === undefined) {
+    return false;
+  }
+  return isNamedImportsAllType(namedImports);
 }
 
 /**
@@ -44,14 +110,25 @@ function classifyImportStatement(
 ): void {
   const children = stmt.children();
   const line = stmt.range().start.line + 1;
-  const sourceNode = findImportSource(children);
-  const source = sourceNode ? stripQuotes(sourceNode.text()) : '';
+  const source = resolveImportSource(stmt);
 
   const hasTypeKeyword = children.some(
     (c: SgNode) => String(c.kind()) === 'type',
   );
   if (hasTypeKeyword) {
-    imports.push({ file: relPath, line, source, kind: 'type' });
+    if (source !== null) {
+      imports.push({ file: relPath, line, source, kind: 'type' });
+    }
+    return;
+  }
+
+  const requireClause = children.find(
+    (c: SgNode) => String(c.kind()) === 'import_require_clause',
+  );
+  if (requireClause !== undefined) {
+    if (source !== null) {
+      imports.push({ file: relPath, line, source, kind: 'require' });
+    }
     return;
   }
 
@@ -59,7 +136,14 @@ function classifyImportStatement(
     (c: SgNode) => String(c.kind()) === 'import_clause',
   );
   if (!clause) {
-    imports.push({ file: relPath, line, source, kind: 'side-effect' });
+    if (source !== null) {
+      imports.push({ file: relPath, line, source, kind: 'side-effect' });
+    }
+    return;
+  }
+
+  // A record asserting a dependency on '' is worse than no record at all.
+  if (source === null) {
     return;
   }
 
@@ -70,7 +154,11 @@ function classifyImportStatement(
   if (
     clauseChildren.some((c: SgNode) => String(c.kind()) === 'named_imports')
   ) {
-    imports.push({ file: relPath, line, source, kind: 'named' });
+    if (namedImportsAreAllType(clauseChildren)) {
+      imports.push({ file: relPath, line, source, kind: 'type' });
+    } else {
+      imports.push({ file: relPath, line, source, kind: 'named' });
+    }
   }
   if (
     clauseChildren.some((c: SgNode) => String(c.kind()) === 'namespace_import')

--- a/packages/tools/src/tools/structural-analysis/helpers.ts
+++ b/packages/tools/src/tools/structural-analysis/helpers.ts
@@ -104,6 +104,8 @@ const FUNCTION_CONTAINER_KINDS = new Set([
   'function_declaration',
   'generator_function_declaration',
   'arrow_function',
+  'function_expression',
+  'generator_function',
 ]);
 
 export function isFunctionContainerKind(kind: string): boolean {
@@ -113,8 +115,9 @@ export function isFunctionContainerKind(kind: string): boolean {
 /**
  * Extract a name from a function-like container node.
  * - method_definition: first property_identifier child
- * - function_declaration: first identifier child
- * - arrow_function: name from parent variable_declarator's identifier
+ * - function_declaration/generator_function_declaration: first identifier child
+ * - arrow_function/function_expression/generator_function: name from parent
+ *   variable_declarator's identifier
  */
 export function getContainerName(node: SgNode): string | null {
   const kind = String(node.kind());
@@ -136,7 +139,11 @@ export function getContainerName(node: SgNode): string | null {
     return nameNode?.text() ?? null;
   }
 
-  if (kind === 'arrow_function') {
+  if (
+    kind === 'arrow_function' ||
+    kind === 'function_expression' ||
+    kind === 'generator_function'
+  ) {
     const parent = node.parent();
     if (parent && String(parent.kind()) === 'variable_declarator') {
       const nameNode = parent

--- a/packages/tools/src/tools/structural-analysis/helpers.ts
+++ b/packages/tools/src/tools/structural-analysis/helpers.ts
@@ -102,6 +102,7 @@ export async function parseFile(
 const FUNCTION_CONTAINER_KINDS = new Set([
   'method_definition',
   'function_declaration',
+  'generator_function_declaration',
   'arrow_function',
 ]);
 
@@ -125,7 +126,10 @@ export function getContainerName(node: SgNode): string | null {
     return nameNode?.text() ?? null;
   }
 
-  if (kind === 'function_declaration') {
+  if (
+    kind === 'function_declaration' ||
+    kind === 'generator_function_declaration'
+  ) {
     const nameNode = node
       .children()
       .find((c: SgNode) => String(c.kind()) === 'identifier');

--- a/packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts
+++ b/packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts
@@ -1,0 +1,678 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for structural_analysis modes callees, definitions,
+ * dependencies, and the tool description (issue #3038, AC1–AC6).
+ *
+ * Drives the REAL StructuralAnalysisTool end-to-end against real .ts files
+ * written into a temp directory. The AST engine (@ast-grep/napi) is not
+ * mocked — these tests exercise the actual tree-sitter grammar paths.
+ *
+ * @plan issue3038
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IToolHost } from '../../interfaces/index.js';
+import { StructuralAnalysisTool } from '../structural-analysis.js';
+import type { ToolResult } from '../tools.js';
+
+interface ImportRecord {
+  file: string;
+  line: number;
+  source: string;
+  kind: string;
+}
+
+/**
+ * Parses a ToolResult's llmContent and returns the `results` field as
+ * unknown, failing loudly if the payload shape is wrong.
+ */
+function extractResults(result: ToolResult): unknown {
+  const parsed: unknown = JSON.parse(result.llmContent);
+  if (typeof parsed !== 'object' || parsed === null || !('results' in parsed)) {
+    throw new Error(
+      `Unexpected payload: missing results — ${result.llmContent}`,
+    );
+  }
+  return parsed.results;
+}
+
+/** Narrows to an array of { text: string }, throwing on wrong shape. */
+function asTextResults(value: unknown): Array<{ text: string }> {
+  if (!Array.isArray(value)) {
+    throw new Error('Expected array');
+  }
+  return value.map((item): { text: string } => {
+    if (item === null || typeof item !== 'object') {
+      throw new Error(`Expected { text: string }, got ${JSON.stringify(item)}`);
+    }
+    if (!('text' in item) || typeof item.text !== 'string') {
+      throw new Error(`Expected text: string, got ${JSON.stringify(item)}`);
+    }
+    return { text: item.text };
+  });
+}
+
+/** Narrows to an array of { kind: string; line: number }, throwing on wrong shape. */
+function asKindResults(value: unknown): Array<{ kind: string; line: number }> {
+  if (!Array.isArray(value)) {
+    throw new Error('Expected array');
+  }
+  return value.map((item): { kind: string; line: number } => {
+    if (item === null || typeof item !== 'object') {
+      throw new Error(`Expected object, got ${JSON.stringify(item)}`);
+    }
+    if (!('kind' in item) || typeof item.kind !== 'string') {
+      throw new Error(`Expected kind: string, got ${JSON.stringify(item)}`);
+    }
+    if (!('line' in item) || typeof item.line !== 'number') {
+      throw new Error(`Expected line: number, got ${JSON.stringify(item)}`);
+    }
+    return { kind: item.kind, line: item.line };
+  });
+}
+
+/** Narrows to an array of { method: string }, throwing on wrong shape. */
+function asMethodResults(value: unknown): Array<{ method: string }> {
+  if (!Array.isArray(value)) {
+    throw new Error('Expected array');
+  }
+  return value.map((item): { method: string } => {
+    if (item === null || typeof item !== 'object') {
+      throw new Error(
+        `Expected { method: string }, got ${JSON.stringify(item)}`,
+      );
+    }
+    if (!('method' in item) || typeof item.method !== 'string') {
+      throw new Error(`Expected method: string, got ${JSON.stringify(item)}`);
+    }
+    return { method: item.method };
+  });
+}
+
+/** Narrows to { imports: ImportRecord[] }, throwing on wrong shape. */
+function asImportsWrapper(value: unknown): { imports: ImportRecord[] } {
+  if (typeof value !== 'object' || value === null) {
+    throw new Error('Expected imports wrapper object');
+  }
+  if (!('imports' in value)) {
+    throw new Error('Expected { imports: [...] }');
+  }
+  const raw: unknown = value.imports;
+  if (!Array.isArray(raw)) {
+    throw new Error('Expected imports to be an array');
+  }
+  const imports: ImportRecord[] = raw.map((item): ImportRecord => {
+    if (item === null || typeof item !== 'object') {
+      throw new Error(`Expected import record, got ${JSON.stringify(item)}`);
+    }
+    if (!('file' in item) || typeof item.file !== 'string') {
+      throw new Error('Expected file: string');
+    }
+    if (!('line' in item) || typeof item.line !== 'number') {
+      throw new Error('Expected line: number');
+    }
+    if (!('source' in item) || typeof item.source !== 'string') {
+      throw new Error('Expected source: string');
+    }
+    if (!('kind' in item) || typeof item.kind !== 'string') {
+      throw new Error('Expected kind: string');
+    }
+    return {
+      file: item.file,
+      line: item.line,
+      source: item.source,
+      kind: item.kind,
+    };
+  });
+  return { imports };
+}
+
+async function runTool(
+  host: IToolHost,
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const tool = new StructuralAnalysisTool(host);
+  return tool.build(params).execute(new AbortController().signal);
+}
+
+function createFakeToolHost(targetDir: string): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getEphemeralSettings: () => ({}),
+  };
+}
+
+describe('structural_analysis modes (issue #3038)', () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-sa-3038-'));
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('AC1 — callees resolves every function-like container', () => {
+    beforeAll(() => {
+      writeFileSync(
+        join(tempDir, 'callees-fixture.ts'),
+        `function leafA(): void {}
+function leafB(): void {}
+
+function standaloneFunc(): void {
+  leafA();
+  leafB();
+}
+
+const arrowFn = (): void => {
+  leafA();
+};
+
+function* generatorFunc(): void {
+  leafA();
+}
+
+class Ship {
+  ship(): void {
+    leafA();
+  }
+}
+`,
+        'utf-8',
+      );
+    });
+
+    const baseParams = (symbol: string): Record<string, unknown> => ({
+      mode: 'callees',
+      language: 'typescript',
+      path: join(tempDir, 'callees-fixture.ts'),
+      symbol,
+    });
+
+    it('finds both callees of a standalone function declaration', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('standaloneFunc'),
+          ),
+        ),
+      );
+      expect(results.length).toBe(2);
+      const texts = results.map((r) => r.text);
+      expect(texts).toContain('leafA()');
+      expect(texts).toContain('leafB()');
+    });
+
+    it('finds the callee of an arrow function bound to a const', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('arrowFn')),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe('leafA()');
+    });
+
+    it('finds the callee of a generator function', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('generatorFunc'),
+          ),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe('leafA()');
+    });
+
+    it('finds the callee of a class method (no regression)', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('ship')),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe('leafA()');
+    });
+
+    it('callers/callees directionality agrees for the same edge', async () => {
+      const host = createFakeToolHost(tempDir);
+      const callersNames = asMethodResults(
+        extractResults(
+          await runTool(host, {
+            mode: 'callers',
+            language: 'typescript',
+            path: join(tempDir, 'callees-fixture.ts'),
+            symbol: 'leafA',
+          }),
+        ),
+      ).map((r) => r.method);
+      expect(callersNames).toContain('standaloneFunc');
+
+      const calleesResults = asTextResults(
+        extractResults(await runTool(host, baseParams('standaloneFunc'))),
+      );
+      expect(calleesResults.some((r) => r.text === 'leafA()')).toBe(true);
+    });
+
+    it('attributes a call inside a generator to the generator scope (FIX-3)', async () => {
+      const host = createFakeToolHost(tempDir);
+      const callersNames = asMethodResults(
+        extractResults(
+          await runTool(host, {
+            mode: 'callers',
+            language: 'typescript',
+            path: join(tempDir, 'callees-fixture.ts'),
+            symbol: 'leafA',
+          }),
+        ),
+      ).map((r) => r.method);
+      expect(callersNames).toContain('generatorFunc');
+    });
+  });
+
+  describe('FIX-3 — callees does not attribute nested-function calls', () => {
+    let nestedFilePath: string;
+
+    beforeAll(() => {
+      nestedFilePath = join(tempDir, 'nested-callees-fixture.ts');
+      writeFileSync(
+        nestedFilePath,
+        `function directLeaf(): void {}
+function nestedLeaf(): void {}
+
+function outerWithNested(): void {
+  directLeaf();
+  function innerNested(): void {
+    nestedLeaf();
+  }
+}
+
+const outerArrow = (): void => {
+  directLeaf();
+  const innerArrow = (): void => {
+    nestedLeaf();
+  };
+};
+`,
+        'utf-8',
+      );
+    });
+
+    const baseParams = (symbol: string): Record<string, unknown> => ({
+      mode: 'callees',
+      language: 'typescript',
+      path: nestedFilePath,
+      symbol,
+    });
+
+    it('does not report a nested function call as a callee of the outer function', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('outerWithNested'),
+          ),
+        ),
+      );
+      // outerWithNested directly calls directLeaf only; innerNested's call to
+      // nestedLeaf must NOT be counted as a callee of the outer function.
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe('directLeaf()');
+    });
+
+    it('does not report a nested arrow call as a callee of the outer arrow', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('outerArrow')),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe('directLeaf()');
+    });
+
+    it('still reports the outer function direct calls and resolves nested callees independently', async () => {
+      const outerResults = asTextResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('outerWithNested'),
+          ),
+        ),
+      );
+      expect(outerResults.some((r) => r.text === 'directLeaf()')).toBe(true);
+      expect(outerResults.some((r) => r.text === 'nestedLeaf()')).toBe(false);
+
+      const innerResults = asTextResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('innerNested')),
+        ),
+      );
+      expect(innerResults.length).toBe(1);
+      expect(innerResults[0].text).toBe('nestedLeaf()');
+    });
+  });
+
+  describe('AC2 — definitions finds return-typed declarations', () => {
+    let filePath: string;
+
+    beforeAll(() => {
+      filePath = join(tempDir, 'definitions-fixture.ts');
+      writeFileSync(
+        filePath,
+        `export function withReturnType(x: number): number {
+  return x;
+}
+
+function withoutReturnType(x: number) {
+  return x;
+}
+
+class SomeClass {
+  methodWithType(): void {
+    return;
+  }
+}
+
+interface SomeInterface {
+  foo: string;
+}
+
+type SomeType = string;
+`,
+        'utf-8',
+      );
+    });
+
+    const baseParams = (symbol: string): Record<string, unknown> => ({
+      mode: 'definitions',
+      language: 'typescript',
+      path: filePath,
+      symbol,
+    });
+
+    it('finds a function declaration that carries a return type', async () => {
+      const results = asKindResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('withReturnType'),
+          ),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].kind).toBe('function');
+      expect(results[0].line).toBe(1);
+    });
+
+    it('finds a function declaration without a return type (no regression)', async () => {
+      const results = asKindResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('withoutReturnType'),
+          ),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].kind).toBe('function');
+    });
+
+    it('finds a class method with a return type', async () => {
+      const results = asKindResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('methodWithType'),
+          ),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].kind).toBe('method');
+      expect(results[0].line).toBe(10);
+    });
+
+    it('finds class, interface, and type alias declarations with correct kind (no regression)', async () => {
+      const host = createFakeToolHost(tempDir);
+
+      const classResults = asKindResults(
+        extractResults(await runTool(host, baseParams('SomeClass'))),
+      );
+      expect(classResults.length).toBe(1);
+      expect(classResults[0].kind).toBe('class');
+
+      const ifaceResults = asKindResults(
+        extractResults(await runTool(host, baseParams('SomeInterface'))),
+      );
+      expect(ifaceResults.length).toBe(1);
+      expect(ifaceResults[0].kind).toBe('interface');
+
+      const typeResults = asKindResults(
+        extractResults(await runTool(host, baseParams('SomeType'))),
+      );
+      expect(typeResults.length).toBe(1);
+      expect(typeResults[0].kind).toBe('type');
+    });
+  });
+
+  describe('AC3 — dependencies requires an explicit target', () => {
+    beforeAll(() => {
+      writeFileSync(
+        join(tempDir, 'dep-fixture.ts'),
+        `import { something } from './mod.js';
+`,
+        'utf-8',
+      );
+    });
+
+    it('rejects dependencies with neither target nor path', async () => {
+      const result = await runTool(createFakeToolHost(tempDir), {
+        mode: 'dependencies',
+        language: 'typescript',
+      });
+      expect(result.llmContent).toBe(
+        'Error: `target` parameter is required for "dependencies" mode.',
+      );
+      expect(result.llmContent).not.toContain('"imports"');
+    });
+
+    it('succeeds when target is supplied', async () => {
+      const result = await runTool(createFakeToolHost(tempDir), {
+        mode: 'dependencies',
+        language: 'typescript',
+        target: join(tempDir, 'dep-fixture.ts'),
+      });
+      expect(result.llmContent).not.toContain('Error:');
+    });
+
+    it('succeeds when path is supplied (alias for the search root)', async () => {
+      const result = await runTool(createFakeToolHost(tempDir), {
+        mode: 'dependencies',
+        language: 'typescript',
+        path: join(tempDir, 'dep-fixture.ts'),
+      });
+      expect(result.llmContent).not.toContain('Error:');
+    });
+  });
+
+  describe('AC4/AC5 — dependencies classifies every import binding', () => {
+    let importFilePath: string;
+
+    beforeAll(() => {
+      importFilePath = join(tempDir, 'imports-fixture.ts');
+      writeFileSync(
+        importFilePath,
+        `import type { A, B } from './types.js';
+import { c } from './c.js';
+import def from './def.js';
+import def2, { e } from './e.js';
+import * as ns from './ns.js';
+import './side.js';
+`,
+        'utf-8',
+      );
+    });
+
+    async function collectImports(): Promise<ImportRecord[]> {
+      const results = extractResults(
+        await runTool(createFakeToolHost(tempDir), {
+          mode: 'dependencies',
+          language: 'typescript',
+          target: importFilePath,
+        }),
+      );
+      return asImportsWrapper(results).imports;
+    }
+
+    it('classifies type-only imports', async () => {
+      const imports = await collectImports();
+      const typeImports = imports.filter((i) => i.kind === 'type');
+      expect(typeImports.length).toBe(1);
+      expect(typeImports[0].source).toBe('./types.js');
+    });
+
+    it('classifies named imports without a bogus default duplicate', async () => {
+      const imports = await collectImports();
+      const cImports = imports.filter((i) => i.source === './c.js');
+      expect(cImports.length).toBe(1);
+      expect(cImports[0].kind).toBe('named');
+      const cDefaults = imports.filter(
+        (i) => i.source === './c.js' && i.kind === 'default',
+      );
+      expect(cDefaults.length).toBe(0);
+    });
+
+    it('classifies default imports', async () => {
+      const imports = await collectImports();
+      const defImports = imports.filter((i) => i.source === './def.js');
+      expect(defImports.length).toBe(1);
+      expect(defImports[0].kind).toBe('default');
+    });
+
+    it('emits both default and named for a mixed import', async () => {
+      const imports = await collectImports();
+      const eImports = imports.filter((i) => i.source === './e.js');
+      expect(eImports.length).toBe(2);
+      const kinds = eImports.map((i) => i.kind).sort();
+      expect(kinds).toEqual(['default', 'named']);
+    });
+
+    it('classifies namespace imports', async () => {
+      const imports = await collectImports();
+      const nsImports = imports.filter((i) => i.source === './ns.js');
+      expect(nsImports.length).toBe(1);
+      expect(nsImports[0].kind).toBe('namespace');
+    });
+
+    it('classifies side-effect imports', async () => {
+      const imports = await collectImports();
+      const sideImports = imports.filter((i) => i.source === './side.js');
+      expect(sideImports.length).toBe(1);
+      expect(sideImports[0].kind).toBe('side-effect');
+    });
+
+    it('strips surrounding quotes from every static import source', async () => {
+      const imports = await collectImports();
+      for (const imp of imports) {
+        expect(imp.source.startsWith("'")).toBe(false);
+        expect(imp.source.startsWith('"')).toBe(false);
+        expect(imp.source.endsWith("'")).toBe(false);
+        expect(imp.source.endsWith('"')).toBe(false);
+      }
+    });
+
+    it('does not emit duplicate (file, line, source, kind) tuples', async () => {
+      const imports = await collectImports();
+      const keys = imports.map(
+        (i) => `${i.file}:${i.line}:${i.source}:${i.kind}`,
+      );
+      expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it('preserves colon-containing module specifiers through deduplication (FIX-5)', async () => {
+      const colonFilePath = join(tempDir, 'colon-specifier-fixture.ts');
+      writeFileSync(
+        colonFilePath,
+        `import protoThing from 'proto:thing';
+import { named } from 'other:spec';
+`,
+        'utf-8',
+      );
+      const imports = asImportsWrapper(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), {
+            mode: 'dependencies',
+            language: 'typescript',
+            target: colonFilePath,
+          }),
+        ),
+      ).imports;
+      const protoImports = imports.filter((i) => i.source === 'proto:thing');
+      expect(protoImports.length).toBe(1);
+      expect(protoImports[0].kind).toBe('default');
+      const otherImports = imports.filter((i) => i.source === 'other:spec');
+      expect(otherImports.length).toBe(1);
+      expect(otherImports[0].kind).toBe('named');
+    });
+  });
+
+  describe('AC6 — description documents the per-mode parameter matrix', () => {
+    const description = new StructuralAnalysisTool(createFakeToolHost(tempDir))
+      .description;
+
+    it('states that the five symbol modes require symbol', () => {
+      expect(description).toContain(
+        'callers, callees, definitions, hierarchy, references: "symbol"',
+      );
+    });
+
+    it('states that dependencies and exports require target', () => {
+      expect(description).toContain('dependencies, exports: "target"');
+    });
+
+    it('includes one worked example per mode with its required parameter', () => {
+      const symbolModes = [
+        'callers',
+        'callees',
+        'definitions',
+        'hierarchy',
+        'references',
+      ];
+      const targetModes = ['dependencies', 'exports'];
+      for (const mode of symbolModes) {
+        const exampleLine = description
+          .split('\n')
+          .find((l) => l.includes(`"mode": "${mode}"`));
+        if (exampleLine === undefined) {
+          throw new Error(`No example found for mode ${mode}`);
+        }
+        expect(exampleLine).toContain('"symbol"');
+      }
+      for (const mode of targetModes) {
+        const exampleLine = description
+          .split('\n')
+          .find((l) => l.includes(`"mode": "${mode}"`));
+        if (exampleLine === undefined) {
+          throw new Error(`No example found for mode ${mode}`);
+        }
+        expect(exampleLine).toContain('"target"');
+      }
+    });
+  });
+});

--- a/packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts
+++ b/packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts
@@ -61,6 +61,22 @@ function asTextResults(value: unknown): Array<{ text: string }> {
   });
 }
 
+/** Narrows to an array of { text: string; line: number }, throwing on wrong shape. */
+function asTextLineResults(
+  value: unknown,
+): Array<{ text: string; line: number }> {
+  if (!Array.isArray(value)) throw new Error('Expected array');
+  return value.map((item): { text: string; line: number } => {
+    if (item === null || typeof item !== 'object')
+      throw new Error(`Expected object, got ${JSON.stringify(item)}`);
+    if (!('text' in item) || typeof item.text !== 'string')
+      throw new Error(`Expected text: string`);
+    if (!('line' in item) || typeof item.line !== 'number')
+      throw new Error(`Expected line: number`);
+    return { text: item.text, line: item.line };
+  });
+}
+
 /** Narrows to an array of { kind: string; line: number }, throwing on wrong shape. */
 function asKindResults(value: unknown): Array<{ kind: string; line: number }> {
   if (!Array.isArray(value)) {
@@ -442,6 +458,38 @@ const outerArrow = (): void => {
     });
   });
 
+  describe('FIX-4 — callees dedup key includes call position (review)', () => {
+    let dedupFilePath: string;
+
+    beforeAll(() => {
+      dedupFilePath = join(tempDir, 'dedup-callees-fixture.ts');
+      writeFileSync(
+        dedupFilePath,
+        'function leaf(): void {}\n\nfunction callerTwice(): void {\n  leaf();\n  leaf();\n}\n',
+        'utf-8',
+      );
+    });
+
+    const baseParams = (symbol: string): Record<string, unknown> => ({
+      mode: 'callees',
+      language: 'typescript',
+      path: dedupFilePath,
+      symbol,
+    });
+
+    it('reports both call sites of the same function on different lines', async () => {
+      const results = asTextLineResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('callerTwice')),
+        ),
+      );
+      expect(results.length).toBe(2);
+      expect(results[0].text).toBe('leaf()');
+      expect(results[1].text).toBe('leaf()');
+      expect(results[0].line).not.toBe(results[1].line);
+    });
+  });
+
   describe('AC2 — definitions finds return-typed declarations', () => {
     let filePath: string;
 
@@ -449,26 +497,7 @@ const outerArrow = (): void => {
       filePath = join(tempDir, 'definitions-fixture.ts');
       writeFileSync(
         filePath,
-        `export function withReturnType(x: number): number {
-  return x;
-}
-
-function withoutReturnType(x: number) {
-  return x;
-}
-
-class SomeClass {
-  methodWithType(): void {
-    return;
-  }
-}
-
-interface SomeInterface {
-  foo: string;
-}
-
-type SomeType = string;
-`,
+        'export function withReturnType(x: number): number {\n  return x;\n}\n\nfunction withoutReturnType(x: number) {\n  return x;\n}\n\nclass SomeClass {\n  methodWithType(): void {\n    return;\n  }\n}\n\ninterface SomeInterface {\n  foo: string;\n}\n\ntype SomeType = string;\n',
         'utf-8',
       );
     });
@@ -523,19 +552,16 @@ type SomeType = string;
 
     it('finds class, interface, and type alias declarations with correct kind (no regression)', async () => {
       const host = createFakeToolHost(tempDir);
-
       const classResults = asKindResults(
         extractResults(await runTool(host, baseParams('SomeClass'))),
       );
       expect(classResults.length).toBe(1);
       expect(classResults[0].kind).toBe('class');
-
       const ifaceResults = asKindResults(
         extractResults(await runTool(host, baseParams('SomeInterface'))),
       );
       expect(ifaceResults.length).toBe(1);
       expect(ifaceResults[0].kind).toBe('interface');
-
       const typeResults = asKindResults(
         extractResults(await runTool(host, baseParams('SomeType'))),
       );
@@ -544,12 +570,81 @@ type SomeType = string;
     });
   });
 
+  describe('AC2 (review) — definitions finds variable-bound functions', () => {
+    let varFnFilePath: string;
+
+    beforeAll(() => {
+      varFnFilePath = join(tempDir, 'var-bound-defs-fixture.ts');
+      writeFileSync(
+        varFnFilePath,
+        'const arrowBound = (): void => {\n  return;\n};\n\nconst typedArrow: () => void = (): void => {\n  return;\n};\n\nconst funcExprBound = function (): void {\n  return;\n};\n\nconst genExprBound = function* (): Generator<number> {\n  yield 1;\n};\n',
+        'utf-8',
+      );
+    });
+
+    const baseParams = (symbol: string): Record<string, unknown> => ({
+      mode: 'definitions',
+      language: 'typescript',
+      path: varFnFilePath,
+      symbol,
+    });
+
+    it('finds an arrow function bound to a const', async () => {
+      const results = asKindResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('arrowBound')),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].kind).toBe('function');
+      expect(results[0].line).toBe(1);
+    });
+
+    it('finds a type-annotated arrow function bound to a const', async () => {
+      const results = asKindResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('typedArrow')),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].kind).toBe('function');
+      expect(results[0].line).toBe(5);
+    });
+
+    it('finds a plain function expression bound to a const', async () => {
+      const results = asKindResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('funcExprBound'),
+          ),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].kind).toBe('function');
+      expect(results[0].line).toBe(9);
+    });
+
+    it('finds a generator function expression bound to a const', async () => {
+      const results = asKindResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('genExprBound'),
+          ),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].kind).toBe('function');
+      expect(results[0].line).toBe(13);
+    });
+  });
+
   describe('AC3 — dependencies requires an explicit target', () => {
     beforeAll(() => {
       writeFileSync(
         join(tempDir, 'dep-fixture.ts'),
-        `import { something } from './mod.js';
-`,
+        "import { something } from './mod.js';\n",
         'utf-8',
       );
     });
@@ -603,13 +698,7 @@ type SomeType = string;
       importFilePath = join(tempDir, 'imports-fixture.ts');
       writeFileSync(
         importFilePath,
-        `import type { A, B } from './types.js';
-import { c } from './c.js';
-import def from './def.js';
-import def2, { e } from './e.js';
-import * as ns from './ns.js';
-import './side.js';
-`,
+        "import type { A, B } from './types.js';\nimport { c } from './c.js';\nimport def from './def.js';\nimport def2, { e } from './e.js';\nimport * as ns from './ns.js';\nimport './side.js';\n",
         'utf-8',
       );
     });
@@ -694,9 +783,7 @@ import './side.js';
       const colonFilePath = join(tempDir, 'colon-specifier-fixture.ts');
       writeFileSync(
         colonFilePath,
-        `import protoThing from 'proto:thing';
-import { named } from 'other:spec';
-`,
+        "import protoThing from 'proto:thing';\nimport { named } from 'other:spec';\n",
         'utf-8',
       );
       const imports = asImportsWrapper(
@@ -714,6 +801,65 @@ import { named } from 'other:spec';
       const otherImports = imports.filter((i) => i.source === 'other:spec');
       expect(otherImports.length).toBe(1);
       expect(otherImports[0].kind).toBe('named');
+    });
+  });
+
+  describe('AC4/AC5 (review) — inline type-only specifiers and import-equals', () => {
+    let reviewFilePath: string;
+
+    beforeAll(() => {
+      reviewFilePath = join(tempDir, 'imports-review-fixture.ts');
+      writeFileSync(
+        reviewFilePath,
+        "import { type A } from './only-type.js';\nimport { type B, C } from './mixed.js';\nimport qux = require('qux-module');\nimport type quux = require('quux-module');\n",
+        'utf-8',
+      );
+    });
+
+    async function collectReviewImports(): Promise<ImportRecord[]> {
+      const results = extractResults(
+        await runTool(createFakeToolHost(tempDir), {
+          mode: 'dependencies',
+          language: 'typescript',
+          target: reviewFilePath,
+        }),
+      );
+      return asImportsWrapper(results).imports;
+    }
+
+    it('classifies an inline type-only specifier as type (D)', async () => {
+      const imports = await collectReviewImports();
+      const onlyType = imports.filter((i) => i.source === './only-type.js');
+      expect(onlyType.length).toBe(1);
+      expect(onlyType[0].kind).toBe('type');
+    });
+
+    it('classifies a mixed inline type + value import as named (D)', async () => {
+      const imports = await collectReviewImports();
+      const mixed = imports.filter((i) => i.source === './mixed.js');
+      expect(mixed.length).toBe(1);
+      expect(mixed[0].kind).toBe('named');
+    });
+
+    it('classifies import-equals require as require (E)', async () => {
+      const imports = await collectReviewImports();
+      const qux = imports.filter((i) => i.source === 'qux-module');
+      expect(qux.length).toBe(1);
+      expect(qux[0].kind).toBe('require');
+    });
+
+    it('classifies import type = require(...) as type with correct source (E)', async () => {
+      const imports = await collectReviewImports();
+      const quux = imports.filter((i) => i.source === 'quux-module');
+      expect(quux.length).toBe(1);
+      expect(quux[0].kind).toBe('type');
+    });
+
+    it('no emitted record has an empty source (E)', async () => {
+      const imports = await collectReviewImports();
+      for (const imp of imports) {
+        expect(imp.source.length).toBeGreaterThan(0);
+      }
     });
   });
 

--- a/packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts
+++ b/packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts
@@ -145,14 +145,19 @@ async function runTool(
 }
 
 describe('structural_analysis modes (issue #3038)', () => {
-  let tempDir: string;
+  let tempDir = '';
 
   beforeAll(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'llxprt-sa-3038-'));
   });
 
   afterAll(() => {
-    rmSync(tempDir, { recursive: true, force: true });
+    // Only clean up if the temp dir was actually created: if mkdtempSync
+    // threw in beforeAll, tempDir stays '' and rmSync on an empty path would
+    // mask the real filesystem error.
+    if (tempDir !== '') {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   describe('AC1 — callees resolves every function-like container', () => {
@@ -174,6 +179,25 @@ const arrowFn = (): void => {
 function* generatorFunc(): void {
   leafA();
 }
+
+const fnExpr = function (): void {
+  leafA();
+};
+
+const genExpr = function* (): Generator<number> {
+  leafB();
+};
+
+const namedFnExpr = function inner(): void {
+  leafA();
+};
+
+const fnExprWithNested = function (): void {
+  leafA();
+  function innerInFnExpr(): void {
+    leafB();
+  }
+};
 
 class Ship {
   ship(): void {
@@ -273,6 +297,66 @@ class Ship {
         ),
       ).map((r) => r.method);
       expect(callersNames).toContain('generatorFunc');
+    });
+
+    it('finds the callee of a const-bound plain function expression', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('fnExpr')),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe('leafA()');
+    });
+
+    it('finds the callee of a const-bound generator function expression', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('genExpr')),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe('leafB()');
+    });
+
+    it('finds the callee of a const-bound named function expression by its const name', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), baseParams('namedFnExpr')),
+        ),
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe('leafA()');
+    });
+
+    it('does not attribute a nested-function call as a callee of a function expression', async () => {
+      const results = asTextResults(
+        extractResults(
+          await runTool(
+            createFakeToolHost(tempDir),
+            baseParams('fnExprWithNested'),
+          ),
+        ),
+      );
+      // fnExprWithNested directly calls leafA only; the nested
+      // innerInFnExpr's call to leafB must NOT be counted as a callee.
+      expect(results.length).toBe(1);
+      expect(results[0].text).toBe('leafA()');
+    });
+
+    it('attributes a call inside a variable-bound function expression to its binding (callers)', async () => {
+      const host = createFakeToolHost(tempDir);
+      const callersNames = asMethodResults(
+        extractResults(
+          await runTool(host, {
+            mode: 'callers',
+            language: 'typescript',
+            path: join(tempDir, 'callees-fixture.ts'),
+            symbol: 'leafB',
+          }),
+        ),
+      ).map((r) => r.method);
+      expect(callersNames).toContain('genExpr');
     });
   });
 

--- a/packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts
+++ b/packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts
@@ -21,6 +21,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { IToolHost } from '../../interfaces/index.js';
 import { StructuralAnalysisTool } from '../structural-analysis.js';
+import { createFakeToolHost } from '../ast-edit/__tests__/test-helpers.js';
 import type { ToolResult } from '../tools.js';
 
 interface ImportRecord {
@@ -141,18 +142,6 @@ async function runTool(
 ): Promise<ToolResult> {
   const tool = new StructuralAnalysisTool(host);
   return tool.build(params).execute(new AbortController().signal);
-}
-
-function createFakeToolHost(targetDir: string): IToolHost {
-  return {
-    getTargetDir: () => targetDir,
-    getWorkspaceRoots: () => [targetDir],
-    getApprovalMode: () => 'auto',
-    setApprovalMode: () => {},
-    isInteractive: () => false,
-    hasFeatureFlag: () => false,
-    getEphemeralSettings: () => ({}),
-  };
 }
 
 describe('structural_analysis modes (issue #3038)', () => {
@@ -487,27 +476,39 @@ type SomeType = string;
         language: 'typescript',
       });
       expect(result.llmContent).toBe(
-        'Error: `target` parameter is required for "dependencies" mode.',
+        'Error: `target` (or `path`) parameter is required for "dependencies" mode.',
       );
       expect(result.llmContent).not.toContain('"imports"');
     });
 
     it('succeeds when target is supplied', async () => {
-      const result = await runTool(createFakeToolHost(tempDir), {
-        mode: 'dependencies',
-        language: 'typescript',
-        target: join(tempDir, 'dep-fixture.ts'),
-      });
-      expect(result.llmContent).not.toContain('Error:');
+      const imports = asImportsWrapper(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), {
+            mode: 'dependencies',
+            language: 'typescript',
+            target: join(tempDir, 'dep-fixture.ts'),
+          }),
+        ),
+      ).imports;
+      const modImports = imports.filter((i) => i.source === './mod.js');
+      expect(modImports).toHaveLength(1);
+      expect(modImports[0].kind).toBe('named');
     });
 
     it('succeeds when path is supplied (alias for the search root)', async () => {
-      const result = await runTool(createFakeToolHost(tempDir), {
-        mode: 'dependencies',
-        language: 'typescript',
-        path: join(tempDir, 'dep-fixture.ts'),
-      });
-      expect(result.llmContent).not.toContain('Error:');
+      const imports = asImportsWrapper(
+        extractResults(
+          await runTool(createFakeToolHost(tempDir), {
+            mode: 'dependencies',
+            language: 'typescript',
+            path: join(tempDir, 'dep-fixture.ts'),
+          }),
+        ),
+      ).imports;
+      const modImports = imports.filter((i) => i.source === './mod.js');
+      expect(modImports).toHaveLength(1);
+      expect(modImports[0].kind).toBe('named');
     });
   });
 
@@ -633,8 +634,12 @@ import { named } from 'other:spec';
   });
 
   describe('AC6 — description documents the per-mode parameter matrix', () => {
-    const description = new StructuralAnalysisTool(createFakeToolHost(tempDir))
-      .description;
+    let description: string;
+
+    beforeAll(() => {
+      description = new StructuralAnalysisTool(createFakeToolHost(tempDir))
+        .description;
+    });
 
     it('states that the five symbol modes require symbol', () => {
       expect(description).toContain(
@@ -642,8 +647,9 @@ import { named } from 'other:spec';
       );
     });
 
-    it('states that dependencies and exports require target', () => {
-      expect(description).toContain('dependencies, exports: "target"');
+    it('states that dependencies requires an explicit target and exports is optional', () => {
+      expect(description).toContain('dependencies: "target" (or "path")');
+      expect(description).toContain('exports: optional "target"');
     });
 
     it('includes one worked example per mode with its required parameter', () => {

--- a/project-plans/issue3038/plan.md
+++ b/project-plans/issue3038/plan.md
@@ -78,6 +78,11 @@ calls distinct leaf functions:
 - `definitions` for a `class`, an `interface`, and a `type` alias still returns
   their existing entries (no regression).
 - No `(file, line)` pair is reported more than once.
+- `definitions` finds variable-bound function-like declarations — an arrow
+  function (`const f = () => {}`), a type-annotated arrow (`const f: () => void
+  = () => {}`), a plain function expression (`const f = function () {}`), and a
+  generator function expression (`const f = function* () {}`) — each returning
+  exactly one entry with `kind: 'function'` and the declarator's line.
 
 ### AC3 — `dependencies` requires an explicit target
 - `dependencies` with neither `target` nor `path` returns
@@ -97,18 +102,31 @@ For a file containing:
     import def2, { e } from './e.js';
     import * as ns from './ns.js';
     import './side.js';
+    import qux = require('qux-module');
+    import type quux = require('quux-module');
 
 - `./c.js` appears exactly once, `kind: 'named'`, and no `default` record for it.
 - `./def.js` appears exactly once, `kind: 'default'`.
 - `./e.js` appears exactly twice: once `default`, once `named` (same line).
 - `./ns.js` appears exactly once, `kind: 'namespace'`.
 - `./side.js` appears exactly once, `kind: 'side-effect'`.
+- `qux-module` appears exactly once, `kind: 'require'` (TypeScript
+  import-equals `import x = require(...)`).
+- `quux-module` appears exactly once, `kind: 'type'` (the `import type x =
+  require(...)` form is routed as type-only with the correct source).
 - No two records share the same `(file, line, source, kind)`.
 - `source` is the module specifier with quotes stripped, for every static import.
+- No emitted record has an empty `source`.
 
 ### AC5 — type-only imports are reported
 - `import type { A, B } from './types.js'` yields exactly one record with
   `kind: 'type'` and `source: './types.js'`.
+- `import { type A } from './only-type.js'` yields exactly one record with
+  `kind: 'type'` — every `import_specifier` inside `named_imports` carries an
+  inline `type` modifier, so the statement is type-only.
+- `import { type B, C } from './mixed.js'` yields exactly one record with
+  `kind: 'named'` — the specifiers are mixed (one inline `type`, one value), so
+  the statement genuinely imports at least one value and is NOT type-only.
 
 ### AC6 — the tool description documents the per-mode parameter matrix
 - The `structural_analysis` description contains one worked example call per

--- a/project-plans/issue3038/plan.md
+++ b/project-plans/issue3038/plan.md
@@ -1,0 +1,138 @@
+# Issue 3038 — Code analysis/search tooling fixes
+
+Scope: `structural_analysis` modes `callees`, `definitions`, `dependencies`, the
+`structural_analysis` tool description, and the `codesearch` tool endpoint.
+Issue 3039 (codesearch non-functional) is folded in per the maintainer comment
+on 3038 and ships as its own commit in the same PR.
+
+## Verified root causes (reproduced locally)
+
+1. **callees** — `callees.ts` queries only `kind: 'method_definition'`, which in
+   the tree-sitter TS grammar matches class/object methods only. Standalone
+   `function_declaration`, `generator_function_declaration`, and arrow functions
+   never match, so the mode returns `[]` for them.
+2. **definitions** — `definitions.ts` matches functions with the literal pattern
+   `function ${symbol}($$$PARAMS) { $$$BODY }`. A `function_declaration` that
+   carries a return type has an extra `type_annotation` child between
+   `formal_parameters` and `statement_block`, so the pattern matches 0 nodes.
+   Verified: `parse(...).findAll('function withReturnType($$$PARAMS) { $$$BODY }')`
+   returns 0 for `function withReturnType(x: number): number { ... }`.
+3. **dependencies without target** — `validateAndResolveParams` enforces `symbol`
+   for the symbol modes but nothing for `dependencies`, so the mode silently
+   falls back to the workspace root and walks every file.
+4. **dependencies duplicate/bogus kind** — the pattern `import $DEFAULT from $SOURCE`
+   binds `$DEFAULT` to the whole `import_clause`, so it also matches
+   `import { c, d } from ...` and `import * as ns from ...`. Every named or
+   namespace import is therefore emitted a second time labelled `default`.
+   Verified against the grammar.
+5. **type-only imports dropped** — `import type { A } from 'x'` has a `type`
+   keyword child between `import` and `import_clause`, so neither existing
+   pattern matches it and the entry is silently omitted.
+6. **codesearch** — the hosted Exa MCP server at `https://mcp.exa.ai/mcp` no
+   longer advertises `get_code_context_exa` in its default tool set
+   (`tools/list` returns only `web_search_exa` and `web_fetch_exa`). The tool is
+   still available but must be requested via the `tools` query parameter.
+   Verified: `POST https://mcp.exa.ai/mcp?tools=get_code_context_exa` with
+   `tools/call` returns real results. This is an upstream default-tool-set
+   change, not a missing credential.
+   Separately, the upstream failure arrives as
+   `{"result":{"content":[{"text":"MCP error -32602: ..."}],"isError":true}}`,
+   and the current parser ignores `isError`, so an upstream failure is returned
+   to the model as a successful result.
+
+## Acceptance criteria
+
+### AC1 — `callees` resolves callees of every function-like container
+Given a TypeScript file containing a standalone function, an arrow function
+bound to a `const`, a generator function, and a class method, each of which
+calls two distinct leaf functions:
+
+- `callees` for the standalone function returns both of its call sites.
+- `callees` for the arrow function returns its call site.
+- `callees` for the generator function returns its call site.
+- `callees` for the class method returns its call site (no regression).
+- The `callers`/`callees` directionality agrees: for the same edge,
+  `callers(leaf)` naming the enclosing function and `callees(enclosing)`
+  naming the leaf both return a non-empty result.
+
+### AC2 — `definitions` finds declarations that carry return type annotations
+- `definitions` for `export function withReturnType(x: number): number { ... }`
+  returns exactly one entry with `kind: 'function'` and the declaration's line.
+- `definitions` for a function without a return type still returns one entry
+  with `kind: 'function'` (no regression).
+- `definitions` for a class method with a return type returns an entry with
+  `kind: 'method'`.
+- `definitions` for a `class`, an `interface`, and a `type` alias still returns
+  their existing entries (no regression).
+- No `(file, line)` pair is reported more than once.
+
+### AC3 — `dependencies` requires an explicit target
+- `dependencies` with neither `target` nor `path` returns
+  ``Error: `target` parameter is required for "dependencies" mode.`` and
+  performs no scan (no `imports` payload).
+- `dependencies` with `target` set succeeds.
+- `dependencies` with `path` set (the documented alias for the search root)
+  succeeds — the requirement is "an explicit search root", not literally the
+  `target` key.
+
+### AC4 — `dependencies` emits one correctly classified record per import binding
+For a file containing:
+
+    import type { A, B } from './types.js';
+    import { c } from './c.js';
+    import def from './def.js';
+    import def2, { e } from './e.js';
+    import * as ns from './ns.js';
+    import './side.js';
+
+- `./c.js` appears exactly once, `kind: 'named'`, and no `default` record for it.
+- `./def.js` appears exactly once, `kind: 'default'`.
+- `./e.js` appears exactly twice: once `default`, once `named` (same line).
+- `./ns.js` appears exactly once, `kind: 'namespace'`.
+- `./side.js` appears exactly once, `kind: 'side-effect'`.
+- No two records share the same `(file, line, source, kind)`.
+- `source` is the module specifier with quotes stripped, for every static import.
+
+### AC5 — type-only imports are reported
+- `import type { A, B } from './types.js'` yields exactly one record with
+  `kind: 'type'` and `source: './types.js'`.
+
+### AC6 — the tool description documents the per-mode parameter matrix
+- The `structural_analysis` description contains one worked example call per
+  mode for all seven modes.
+- The description states which parameters are required for which mode,
+  including that `dependencies`/`exports` take `target` and the symbol modes
+  take `symbol`.
+
+### AC7 — `codesearch` reaches the Exa code-context tool and fails loudly
+- The request URL carries `tools=get_code_context_exa`.
+- When an `exa` key resolves, the URL carries both `tools` and `exaApiKey`
+  (asserted by parsing the URL, not by string equality on parameter order).
+- An upstream response with `isError: true` is returned as a `ToolResult` with
+  an `error` of type `SEARCH_ERROR`, not as successful content.
+- A successful response is unchanged.
+
+## Explicitly out of scope
+
+- Other languages (Python, Go, Rust) for `callees`/`definitions`: the module's
+  queries are already TS/JS-grammar specific; broadening them is a separate
+  change.
+- `exports` mode target validation and the `text` truncation nit in `exports`.
+- The identical `isError` blindness in `exa_web_search` (its tool is in the
+  default set, so it is not broken).
+- The oversized context dump noted for `ast_read_file` (tracked in 3035).
+
+## Tests
+
+New Bun (`bun:test`) behavioral suites, registered in
+`scripts/bun-test-manifest-data-tools.ts`:
+
+- `packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts`
+  — AC1–AC6, driven through the real `StructuralAnalysisTool` against real
+  files written to a temp directory. No mocking of the AST engine.
+- `packages/tools/src/tools/codesearch-endpoint.bun.test.ts` — AC7, with
+  `node-fetch` stubbed at the module boundary (the only external I/O).
+
+The existing `packages/tools/src/tools/codesearch.test.ts` URL assertions are
+updated for the new query string; that file already runs under Bun through the
+repo's vitest compat shim.

--- a/project-plans/issue3038/plan.md
+++ b/project-plans/issue3038/plan.md
@@ -68,7 +68,7 @@ calls two distinct leaf functions:
 
 ### AC3 — `dependencies` requires an explicit target
 - `dependencies` with neither `target` nor `path` returns
-  ``Error: `target` parameter is required for "dependencies" mode.`` and
+  ``Error: `target` (or `path`) parameter is required for "dependencies" mode.`` and
   performs no scan (no `imports` payload).
 - `dependencies` with `target` set succeeds.
 - `dependencies` with `path` set (the documented alias for the search root)
@@ -100,9 +100,10 @@ For a file containing:
 ### AC6 — the tool description documents the per-mode parameter matrix
 - The `structural_analysis` description contains one worked example call per
   mode for all seven modes.
-- The description states which parameters are required for which mode,
-  including that `dependencies`/`exports` take `target` and the symbol modes
-  take `symbol`.
+- The description states which parameters are required for which mode:
+  `dependencies` requires an explicit search root (`target`, or `path`),
+  `exports` takes an optional `target` (defaulting to the workspace root), and
+  the symbol modes take `symbol`.
 
 ### AC7 — `codesearch` reaches the Exa code-context tool and fails loudly
 - The request URL carries `tools=get_code_context_exa`.

--- a/project-plans/issue3038/plan.md
+++ b/project-plans/issue3038/plan.md
@@ -44,16 +44,29 @@ on 3038 and ships as its own commit in the same PR.
 
 ### AC1 — `callees` resolves callees of every function-like container
 Given a TypeScript file containing a standalone function, an arrow function
-bound to a `const`, a generator function, and a class method, each of which
-calls two distinct leaf functions:
+bound to a `const`, a generator function, a class method, and function
+expressions bound to a `const` (plain, generator, and named), each of which
+calls distinct leaf functions:
 
 - `callees` for the standalone function returns both of its call sites.
 - `callees` for the arrow function returns its call site.
 - `callees` for the generator function returns its call site.
 - `callees` for the class method returns its call site (no regression).
+- `callees` for a `const` bound to a plain function expression (`const fn =
+  function () { ... }`) returns its call site.
+- `callees` for a `const` bound to a generator function expression (`const gen =
+  function* () { ... }`) returns its call site.
+- `callees` for a `const` bound to a named function expression, looked up by the
+  const name, returns its call site.
+- The nested-container rule holds for function expressions: a call inside a
+  nested function declared within a function expression is NOT reported as a
+  callee of the function expression.
 - The `callers`/`callees` directionality agrees: for the same edge,
   `callers(leaf)` naming the enclosing function and `callees(enclosing)`
   naming the leaf both return a non-empty result.
+- `callers` attributes a call made inside a variable-bound function expression
+  (arrow, plain, or generator) to that binding's name, instead of walking up to
+  whatever encloses it.
 
 ### AC2 — `definitions` finds declarations that carry return type annotations
 - `definitions` for `export function withReturnType(x: number): number { ... }`

--- a/scripts/bun-test-manifest-data-tools.ts
+++ b/scripts/bun-test-manifest-data-tools.ts
@@ -23,6 +23,8 @@ export const TOOLS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
     'src/tools/check-async-tasks.test.ts',
     'src/tools/list-subagents.test.ts',
     'src/tools/codesearch.test.ts',
+    'src/tools/codesearch-endpoint.bun.test.ts',
+    'src/tools/structural-analysis/structural-analysis-modes.bun.test.ts',
     'src/tools/memoryTool.test.ts',
     'src/tools/write-file.test.ts',
     'src/tools/tools.test.ts',


### PR DESCRIPTION
## TLDR

Three of `structural_analysis`'s seven modes answered an empty result instead of an answer, and `codesearch` failed on every call. Both are fixed here.

For an analysis tool a false "nothing found" is the worst possible failure: it is indistinguishable from a true negative, so the caller acts on it. `callees` returned `[]` for every standalone function, `definitions` returned `[]` for every function carrying a return type, and `dependencies` accepted no target, walked the whole workspace, double-reported every import as a bogus `default`, and dropped type-only imports entirely.

`codesearch` failed with `MCP error -32602: Tool get_code_context_exa not found` on every query. The hosted Exa MCP server dropped that tool from its default set; it now has to be requested by name. Not a missing credential.

Reviewers should look hardest at:

- `callees.ts` — the container-matching rules and the nearest-enclosing-container check that keeps a call made inside a nested function from being reported as a callee of the function that merely encloses it.
- `structural-analysis.ts` — the tool description is now larger and ships in every system prompt on every request; it should earn that cost.
- What is deliberately **not** fixed here, listed under "Deferred" below.

## Dive Deeper

### 1. `callees` missed everything that is not a class method

`callees.ts` queried a single node kind:

    findAll({ rule: { kind: 'method_definition', has: { kind: 'property_identifier', regex: '^symbol$' } } })

In the tree-sitter TypeScript grammar `method_definition` is class and object-literal methods only. A `function_declaration` never matches, so in a codebase that is mostly module-level functions the mode was silently useless. The same call edge was found by `callers` and missed by `callees`.

It now locates the named container by AST kind for `function_declaration`, `generator_function_declaration` and `method_definition`, and by the `variable_declarator` binding for arrow functions (so the `const` name is the lookup key).

While fixing that, a second correctness problem surfaced and is fixed with it: the collector searched the container's entire subtree, so for

    function outer(): () => void {
      function inner(): void { g(); }
      return inner;
    }

it reported `g()` as a callee of `outer`, which never calls `g`. A call is now attributed only when its *nearest* enclosing function container is the target container. That flaw predates this PR for class methods; leaving it in place while widening the mode to every function shape would have multiplied a confidently-wrong result rather than fixed one.

`generator_function_declaration` was added to the shared function-container set used by `findFunctionContainer`, which also means `callers` now names a generator as the calling scope instead of walking past it to whatever encloses the generator.

### 2. `definitions` missed every function with a return type

The mode matched functions with the literal pattern `function NAME($$$PARAMS) { $$$BODY }`. A return type annotation inserts a `type_annotation` child between the parameters and the body, so the pattern matches zero nodes — verified directly against the grammar. In a codebase where explicit return types are the norm that is essentially every function.

Matching by AST kind and name is annotation-agnostic and fixes it. Declaration kinds are normalised to the same vocabulary the function path uses, so a class still reports `kind: "class"` rather than the raw `class_declaration`.

### 3. `dependencies` scanned the whole repository when given no target

`callers` already rejects a missing `symbol`. `dependencies` did not reject a missing `target`, so one plausible call — omitting a parameter whose requirement was not stated in the schema — walked the entire workspace and returned import records until the response was truncated. It now refuses before scanning anything.

The error names both accepted spellings, since `path` satisfies the check as well:

    Error: `target` (or `path`) parameter is required for "dependencies" mode.

### 4. `dependencies` reported every import twice with a bogus kind

Forward collection ran two overlapping ast-grep patterns. `import $DEFAULT from $SOURCE` binds `$DEFAULT` to the whole `import_clause`, so it also matched named and namespace imports — every one of them was emitted a second time labelled `default`, doubling the output of an already large mode with records that were simply false.

Imports are now classified once per `import_statement` from the shape of its clause: `named`, `default`, `namespace`, `side-effect`, and `type`. A mixed `import def, { named } from '...'` correctly yields one `default` and one `named` record on the same line. The merged forward list is deduplicated on the full `(file, line, source, kind)` tuple.

### 5. Type-only imports were silently omitted

`import type { A } from './x.js'` has a `type` keyword child that blocks the named-import pattern, so a file whose only import was type-only reported `imports: []`. They are now reported with `kind: "type"`.

### 6. The description gave no worked examples

The issue makes the AX point directly: the tool went unused for a whole session of exactly the work it is for, because the description offered a mode list and prose while the `github` tool's seven concrete examples made that tool usable first try. The description now states the per-mode parameter matrix and carries one example call per mode, and the "name-based (not type-resolved)" hedge — which read as "may mislead you" — is replaced by the concrete limitation (matching is by identifier name, so same-named symbols are not disambiguated).

### 7. `codesearch` was non-functional (folds in #3039)

`tools/list` against `https://mcp.exa.ai/mcp` now returns only `web_search_exa` and `web_fetch_exa`. `get_code_context_exa` still exists but has to be requested through the `tools` query parameter. Confirmed by a live call: the same endpoint with `?tools=get_code_context_exa` returns real results. This is an upstream default-set change, not an environment or credential problem, so the tool is fixed rather than hidden.

The failure was also invisible. Exa returns tool errors inside a successful-looking `result` with `isError` set, and the parser only looked at `result.content` — so `MCP error -32602: Tool get_code_context_exa not found` was handed to the model as though it were a search result. `isError` responses and top-level JSON-RPC `error` objects now produce a `SEARCH_ERROR`, including when the server sends no error text at all, and error text goes through the same sanitisation as successful content. Only `JSON.parse` remains inside the try/catch, so a malformed intermediate SSE line is still skipped without hiding a real failure.

### Deferred, deliberately

Found while working, out of scope here, and none of them regressions from this PR:

- `exports` mode has the same "no target scans everything" hazard as `dependencies` had. Not fixed; instead the description no longer claims `target` is required for `exports`, so the documented contract matches what is enforced.
- Grammar shapes still not matched by `callees`/`definitions`: ECMAScript `#private` methods, class-field arrows, abstract and interface method signatures, ambient/overload signatures, function expressions, and arrows passed as arguments without a binding.
- `import x = require('y')` nests its specifier under `import_require_clause`, so it is classified with an empty source.
- `ast_read_file`'s oversized working-set dump, noted in the issue, is the shared context collector tracked in #3035.

## Reviewer Test Plan

Build and run the CLI, then exercise the tool against this repository.

Callees on a standalone function — empty on `main`, correct here:

    structural_analysis(mode: 'callees', language: 'typescript', symbol: 'executeDependencies')

Definitions of a function with a return type — empty on `main`:

    structural_analysis(mode: 'definitions', language: 'typescript', symbol: 'escapeRegex')

Dependencies with no target — silently walked the workspace on `main`, now refuses:

    structural_analysis(mode: 'dependencies', language: 'typescript')

Dependencies on a file that has a type-only import and several named imports — check every import appears exactly once, with no `default` records that are not default imports, and that `import type` appears with `kind: "type"`:

    structural_analysis(mode: 'dependencies', language: 'typescript', target: 'packages/tools/src/tools/structural-analysis/dependencies.ts')

Confirm `callers` still names the enclosing function of each call site, and that a call inside a generator is attributed to the generator.

Codesearch, which failed on every query before:

    codesearch(query: 'React useState hook examples')

The suites live in `packages/tools/src/tools/structural-analysis/structural-analysis-modes.bun.test.ts` and `packages/tools/src/tools/codesearch-endpoint.bun.test.ts`:

    cd packages/tools && bun test src/tools/structural-analysis/structural-analysis-modes.bun.test.ts src/tools/codesearch-endpoint.bun.test.ts src/tools/codesearch.test.ts

They drive the real tool against real files on disk with the real AST engine; only `node-fetch` is stubbed, for the one network boundary. Copied unchanged onto `main` they fail, which is what makes them worth having.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3038
Closes #3039
