### PR TITLE
fix(tools): make ast_edit validation authoritative (Fixes #3035)

### DIFF
--- a/packages/tools/src/tools/ast-edit.ts
+++ b/packages/tools/src/tools/ast-edit.ts
@@ -141,7 +141,8 @@ export class ASTEditTool
           },
           force: {
             type: 'boolean',
-            description: 'Internal execution control. Managed automatically.',
+            description:
+              'Two-step operation control. Omit or set false to PREVIEW the edit without writing. Set true to APPLY the edit and write to disk. AST syntax validation is always enforced and is not skipped by force.',
             default: false,
           },
           last_modified: {

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-ast-validation.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-ast-validation.test.ts
@@ -11,13 +11,14 @@
  * writing to disk.
  */
 
-import { describe, it, expect } from 'vitest';
-import { writeFileSync } from 'node:fs';
+import { describe, it, expect } from 'bun:test';
+import { writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   useTempDir,
   createFakeToolHost,
   executePreview,
+  executeApply,
 } from './test-helpers.js';
 import { ASTEditTool } from '../../ast-edit.js';
 
@@ -147,10 +148,10 @@ describe('ast_edit AST validation: Python', () => {
   });
 });
 
-describe('ast_edit AST validation: unknown file extension', () => {
+describe('ast_edit AST validation: unknown file extension (REQ-3035-5)', () => {
   const ctx = useTempDir();
 
-  it('reports AST PASSED for a .txt file (unknown extension)', async () => {
+  it('reports AST SKIPPED (unsupported file type) for a .txt file', async () => {
     const filePath = join(ctx.tempDir, 'readme.txt');
     writeFileSync(filePath, 'Hello World\n', 'utf-8');
     const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
@@ -162,22 +163,35 @@ describe('ast_edit AST validation: unknown file extension', () => {
     });
 
     expect(result.error).toBeUndefined();
-    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+    const output = String(result.llmContent);
+    expect(output).toContain('AST validation: SKIPPED (unsupported file type)');
+    expect(output).not.toContain('AST validation: PASSED');
   });
 
-  it('reports AST PASSED for a .md file with broken syntax', async () => {
+  it('reports AST SKIPPED for a .md file and remains writable', async () => {
     const filePath = join(ctx.tempDir, 'doc.md');
     writeFileSync(filePath, '# Title\n\nSome text.\n', 'utf-8');
     const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
 
-    const result = await executePreview(tool, {
+    const previewResult = await executePreview(tool, {
       file_path: filePath,
       old_string: 'Some text.',
-      new_string: '} broken { syntax :',
+      new_string: 'More text.',
     });
 
-    expect(result.error).toBeUndefined();
-    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+    expect(previewResult.error).toBeUndefined();
+    expect(String(previewResult.llmContent)).toContain(
+      'AST validation: SKIPPED (unsupported file type)',
+    );
+
+    // Unsupported types must remain editable.
+    const applyResult = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'Some text.',
+      new_string: 'More text.',
+    });
+    expect(applyResult.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe('# Title\n\nMore text.\n');
   });
 });
 

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-concurrency.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-concurrency.test.ts
@@ -10,7 +10,7 @@
  * These tests verify the four timestamp scenarios: stale, future, exact, omitted.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -138,5 +138,37 @@ describe('ast_edit last_modified: omitted timestamp skips check', () => {
 
     expect(result.error).toBeUndefined();
     expect(readFileSync(filePath, 'utf-8')).toBe('const x = 2;\n');
+  });
+});
+
+describe('ast_edit last_modified: stale error is actionable plain text (REQ-3035-9)', () => {
+  const ctx = useTempDir();
+
+  it('emits a plain human-readable message (not JSON) with both timestamps and a retry instruction', async () => {
+    const filePath = join(ctx.tempDir, 'stale-plain.ts');
+    const actualMtime = 1700000005000;
+    const providedMtime = actualMtime - 2000;
+    writeFileWithMtime(filePath, 'const x = 1;\n', actualMtime);
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const x = 1;',
+      new_string: 'const x = 2;',
+      last_modified: providedMtime,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('file_modified_conflict');
+    const raw = String(result.llmContent);
+    // Both timestamps must be present so the caller can diagnose the mismatch.
+    expect(raw).toContain(String(actualMtime));
+    expect(raw).toContain(String(providedMtime));
+    // Must instruct the caller how to recover.
+    expect(raw.toLowerCase()).toMatch(/re-read/);
+    expect(raw.toLowerCase()).toMatch(/retry/);
+    // Must not be encoded JSON.
+    expect(raw).not.toMatch(/^\s*{/);
+    expect(raw).not.toContain('"current_mtime"');
   });
 });

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-force-flag.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-force-flag.test.ts
@@ -7,11 +7,11 @@
  *
  * force: true triggers the apply/execution phase. These tests verify
  * that force does NOT override hard errors (missing old_string,
- * file not found, stale last_modified) but DOES apply edits even
- * when AST validation fails.
+ * file not found, stale last_modified) or newly introduced AST
+ * syntax errors.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -22,12 +22,13 @@ import {
 } from './test-helpers.js';
 import { ASTEditTool } from '../../ast-edit.js';
 
-describe('ast_edit force flag: applies edit with AST validation failure', () => {
+describe('ast_edit force flag: refuses a newly-introduced AST syntax error (REQ-3035-2)', () => {
   const ctx = useTempDir();
 
-  it('writes the file and reports AST FAILED when the replacement produces invalid syntax', async () => {
+  it('refuses the apply and leaves the file byte-for-byte unchanged when the edit breaks syntax', async () => {
     const filePath = join(ctx.tempDir, 'force-broken-ast.ts');
-    writeFileSync(filePath, 'const obj = { a: 1 };\n', 'utf-8');
+    const original = 'const obj = { a: 1 };\n';
+    writeFileSync(filePath, original, 'utf-8');
     const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
 
     const result = await executeApply(tool, {
@@ -36,11 +37,28 @@ describe('ast_edit force flag: applies edit with AST validation failure', () => 
       new_string: 'const obj = { a: 1 ',
     });
 
-    expect(result.error).toBeUndefined();
-    expect(String(result.llmContent)).toContain('Successfully applied edit');
-    expect(String(result.llmContent)).toContain('AST validation: FAILED');
-    const fileContent = readFileSync(filePath, 'utf-8');
-    expect(fileContent).toBe('const obj = { a: 1 \n');
+    // Typed failure, no success-leading output, file untouched.
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    const output = String(result.llmContent);
+    expect(output).not.toContain('Successfully applied edit');
+    expect(output).not.toContain('Successfully created file');
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+
+  it('does not create a new file whose content has a syntax error', async () => {
+    const filePath = join(ctx.tempDir, 'invalid-new-file.ts');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: '',
+      new_string: 'const broken = {{{ 2;\n',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    expect(() => readFileSync(filePath, 'utf-8')).toThrow();
   });
 });
 
@@ -130,10 +148,10 @@ describe('ast_edit force flag: does NOT override stale last_modified', () => {
   });
 });
 
-describe('ast_edit force flag: applies new file creation', () => {
+describe('ast_edit force flag: applies new file creation (REQ-3035-8)', () => {
   const ctx = useTempDir();
 
-  it('creates a new file with force: true when old_string is empty and file does not exist', async () => {
+  it('creates a new file and reports creation (not zero replacements) with force: true', async () => {
     const filePath = join(ctx.tempDir, 'force-new-file.ts');
     const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
 
@@ -144,8 +162,26 @@ describe('ast_edit force flag: applies new file creation', () => {
     });
 
     expect(result.error).toBeUndefined();
-    expect(String(result.llmContent)).toContain('Successfully applied edit');
-    expect(String(result.llmContent)).toContain('AST validation: PASSED');
+    const output = String(result.llmContent);
+    expect(output).toContain('Successfully created file:');
+    expect(output).toContain('AST validation: PASSED');
+    // Creation must not be reported as a replacement count.
+    expect(output).not.toContain('0 replacement');
     expect(readFileSync(filePath, 'utf-8')).toBe('export const NEW = 42;\n');
+  });
+
+  it('reports replacement counts for edits to an existing file', async () => {
+    const filePath = join(ctx.tempDir, 'force-existing-edit.ts');
+    writeFileSync(filePath, 'const greeting = "hello";\n', 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const greeting = "hello";',
+      new_string: 'const greeting = "world";',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('replacement(s) applied');
   });
 });

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-3035-review.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-3035-review.test.ts
@@ -332,6 +332,79 @@ describe('Finding 3 (In-scope): IDE-accepted content classified from the actual 
 });
 
 // ---------------------------------------------------------------------------
+// Line-1 edit region: IDE-accepted candidate diverging at line 1 with a zero
+// net line delta must be validated at the actual edit line (line 1), not
+// skipped because prefixLines === 0. The candidate-diff invariant (candidate
+// differs from the original) keeps this authoritative while excluding the
+// no-change revert and new-file cases.
+// ---------------------------------------------------------------------------
+
+describe('IDE-accepted candidate diverging at line 1 with zero net line delta is validated at the actual edit line', () => {
+  let tmpDir: string;
+  let host: IToolHost;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `ast-edit-line1-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    host = {
+      ...createDefaultToolHost(),
+      getTargetDir: () => tmpDir,
+      getWorkspaceRoots: () => [tmpDir],
+      getApprovalMode: () => 'default',
+    };
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('refuses an IDE candidate that introduces syntax damage on line 1 (zero line delta) and leaves the original unchanged', async () => {
+    // The IDE-accepted content changes line 1 (prefixLines === 0) with no net
+    // line change (lineDelta === 0). The edit region must begin at line 1 so
+    // the candidate is validated authoritatively; introducing damage is refused.
+    const filePath = join(tmpDir, 'line1-damage.ts');
+    const original = 'const a = 1;\nconst b = 2;\n';
+    writeFileSync(filePath, original, 'utf-8');
+    const ide = fakeIdeService('connected', 'const a = {{{ 1;\nconst b = 2;\n');
+    const tool = new ASTEditTool(host, ide);
+
+    const result = await executeApplyWithIdeContent(
+      tool,
+      filePath,
+      'const a = 1;',
+      'const a = 2;',
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+
+  it('writes a valid IDE candidate diverging only at line 1 (zero line delta) with the exact accepted content', async () => {
+    const filePath = join(tmpDir, 'line1-valid.ts');
+    const original = 'const a = 1;\nconst b = 2;\n';
+    writeFileSync(filePath, original, 'utf-8');
+    const ideContent = 'const a = 99;\nconst b = 2;\n';
+    const ide = fakeIdeService('connected', ideContent);
+    const tool = new ASTEditTool(host, ide);
+
+    const result = await executeApplyWithIdeContent(
+      tool,
+      filePath,
+      'const a = 1;',
+      'const a = 2;',
+    );
+
+    expect(result.error).toBeUndefined();
+    // The exact IDE-accepted candidate is authoritative on write.
+    expect(readFileSync(filePath, 'utf-8')).toBe(ideContent);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Finding 4 (In-scope): ast_read_file keeps working-set context.
 // ---------------------------------------------------------------------------
 

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-3035-review.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-3035-review.test.ts
@@ -1,0 +1,811 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for the issue #3035 review remediations.
+ *
+ * Each describe block maps to a classified review finding:
+ * - Finding 1 (Blocker): validate/compare EVERY relevant parser diagnostic, not
+ *   only the first ERROR node, so a pre-existing early error cannot mask a
+ *   newly introduced later error.
+ * - Finding 2 (Blocker): whole-file recovery is only equivalent to a baseline
+ *   whole-file recovery; fail closed otherwise, but stay writable when an
+ *   unchanged baseline whole-file recovery remains after a harmless edit.
+ * - Finding 3 (In-scope): IDE-accepted content is classified from the actual
+ *   original-to-candidate diff, not the model's old/new line metadata.
+ * - Finding 4 (In-scope): ast_read_file keeps working-set context while
+ *   ast_edit preview omits it.
+ * - Finding 5 (In-scope): coherent messages — definitive "resolved" wording and
+ *   current post-edit coordinates for retained pre-existing errors.
+ *
+ * Plus accepted evidence gaps: force-schema behavioral assertion, nested
+ * invalid-new-file, and preview-path mtime text assertion.
+ *
+ * Tests use real files, real git state, real parser behavior. No mocking of the
+ * tool under test.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  useTempDir,
+  createFakeToolHost,
+  executePreview,
+  executeApply,
+} from './test-helpers.js';
+import { ASTEditTool, ASTReadFileTool } from '../../ast-edit.js';
+import { createDefaultToolHost } from '../../edit-utils.js';
+import { ToolConfirmationOutcome } from '../../tools.js';
+import type {
+  IToolHost,
+  IIdeService,
+  DiffUpdateResult,
+  IDEConnectionStatus,
+} from '../../../interfaces/index.js';
+import type { ToolEditConfirmationDetails } from '../../tools.js';
+
+// ---------------------------------------------------------------------------
+// Finding 1 (Blocker): collect and compare every relevant parser diagnostic.
+// ---------------------------------------------------------------------------
+
+describe('Finding 1 (Blocker): a pre-existing early error must not mask a later new error', () => {
+  const ctx = useTempDir();
+
+  it('refuses a TypeScript edit whose new later error is masked by an earlier pre-existing error', async () => {
+    // Line 2 has a pre-existing @@@ error. The edit introduces a SEPARATE
+    // {{{ error at line 10. The first-only ERROR lookup must not mask line 10.
+    const filePath = join(ctx.tempDir, 'mask-ts.ts');
+    const original = [
+      'const a = 1;',
+      'const broken = @@@;',
+      'const b = 2;',
+      'const c = 3;',
+      'const d = 4;',
+      'const e = 5;',
+      'const f = 6;',
+      'const g = 7;',
+      'const h = 8;',
+      'const z = 10;',
+      '',
+    ].join('\n');
+    writeFileSync(filePath, original, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const z = 10;',
+      new_string: 'const z = {{{ 10;',
+    });
+
+    // The later new error must be detected and the write refused.
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    // File must remain byte-for-byte unchanged.
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+
+  it('refuses a Python edit with the same masking pattern (non-JS language)', async () => {
+    const filePath = join(ctx.tempDir, 'mask-py.py');
+    const original = [
+      'x = 1',
+      'broken = @@@',
+      'b = 2',
+      'c = 3',
+      'd = 4',
+      'e = 5',
+      'f = 6',
+      'g = 7',
+      'h = 8',
+      'z = 10',
+      '',
+    ].join('\n');
+    writeFileSync(filePath, original, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'z = 10',
+      new_string: 'z = {{{ 10',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 2 (Blocker): whole-file recovery equivalence + fail-closed.
+// ---------------------------------------------------------------------------
+
+describe('Finding 2 (Blocker): whole-file recovery equivalence', () => {
+  const ctx = useTempDir();
+
+  it('stays writable when an unchanged baseline whole-file recovery remains after a harmless edit', async () => {
+    // Baseline content triggers a whole-file tree-sitter recovery (the
+    // unclosed `return {{{`). A harmless edit to the trailing marker line must
+    // not be classified as newly-introduced damage.
+    const filePath = join(ctx.tempDir, 'whole-keep.ts');
+    const baseline = [
+      'class Foo {',
+      '  bar() {',
+      '    return {{{',
+      '  }',
+      '}',
+      'const marker = 1;',
+      '',
+    ].join('\n');
+    writeFileSync(filePath, baseline, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const marker = 1;',
+      new_string: 'const marker = 2;',
+    });
+
+    // Pre-existing whole-file recovery remains → writable.
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toContain('const marker = 2;');
+  });
+
+  it('fails closed (refuses) when a post whole-file recovery is not equivalent to a precise baseline', async () => {
+    // Baseline has a PRECISE @@@ error at line 1. The edit introduces a
+    // whole-file recovery in the class body. A whole-file recovery cannot be
+    // proven equivalent to a precise baseline error → fail closed.
+    const filePath = join(ctx.tempDir, 'whole-failclosed.ts');
+    const original = [
+      'const broken = @@@;',
+      'class Foo {',
+      '  bar() {',
+      '    return 1;',
+      '  }',
+      '}',
+      '',
+    ].join('\n');
+    writeFileSync(filePath, original, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: '    return 1;',
+      new_string: '    return {{{',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 3 (In-scope): exact IDE candidate classification.
+// ---------------------------------------------------------------------------
+
+/**
+ * A recording fake IIdeService whose applyDiff resolves with a configurable
+ * accepted content. Behavioral: the real confirmation/execute flow consumes it.
+ */
+function fakeIdeService(
+  status: IDEConnectionStatus,
+  acceptedContent: string | undefined,
+): IIdeService {
+  return {
+    getConnectionStatus: () => status,
+    applyDiff: async (): Promise<DiffUpdateResult> => ({
+      status: 'accepted',
+      content: acceptedContent,
+    }),
+    openDiff: async () => {},
+  };
+}
+
+/**
+ * Drives the full IDE confirmation → execute flow: the IDE returns the given
+ * accepted content, which becomes the final write candidate.
+ */
+async function executeApplyWithIdeContent(
+  tool: ASTEditTool,
+  filePath: string,
+  oldString: string,
+  newString: string,
+) {
+  const invocation = tool.build({
+    file_path: filePath,
+    old_string: oldString,
+    new_string: newString,
+    force: true,
+  });
+  const confirmation = (await invocation.shouldConfirmExecute(
+    new AbortController().signal,
+  )) as ToolEditConfirmationDetails;
+  await confirmation.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+  return invocation.execute(new AbortController().signal);
+}
+
+describe('Finding 3 (In-scope): IDE-accepted content classified from the actual diff', () => {
+  let tmpDir: string;
+  let host: IToolHost;
+
+  // Local (non-shared) temp dir so the manual git/init-free host setup is
+  // isolated from the shared useTempDir lifecycle.
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `ast-edit-ide-review-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    host = {
+      ...createDefaultToolHost(),
+      getTargetDir: () => tmpDir,
+      getWorkspaceRoots: () => [tmpDir],
+      // Manual approval so shouldConfirmExecute produces confirmation details.
+      getApprovalMode: () => 'default',
+    };
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes an IDE-accepted valid layout change that shifts an unchanged pre-existing error', async () => {
+    // Baseline has a pre-existing @@@ error on line 2. The IDE-accepted
+    // candidate inserts a line ABOVE the error, shifting it to line 3 — a
+    // valid, harmless layout change that must remain writable.
+    const filePath = join(tmpDir, 'ide-shift.ts');
+    writeFileSync(filePath, 'const keep = 1;\nconst broken = @@@;\n', 'utf-8');
+    const ide = fakeIdeService(
+      'connected',
+      'const keep = 2;\nconst newLine = 3;\nconst broken = @@@;\n',
+    );
+    const tool = new ASTEditTool(host, ide);
+
+    const result = await executeApplyWithIdeContent(
+      tool,
+      filePath,
+      'const keep = 1;',
+      'const keep = 2;',
+    );
+
+    // The shifted pre-existing error is not newly introduced → writable.
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe(
+      'const keep = 2;\nconst newLine = 3;\nconst broken = @@@;\n',
+    );
+  });
+
+  it('refuses IDE-accepted new syntax damage on previously clean content and leaves the original unchanged', async () => {
+    const filePath = join(tmpDir, 'ide-damage.ts');
+    const original = 'const a = 1;\nconst b = 2;\n';
+    writeFileSync(filePath, original, 'utf-8');
+    const ide = fakeIdeService('connected', 'const a = 1;\nconst b = {{{ 3;\n');
+    const tool = new ASTEditTool(host, ide);
+
+    const result = await executeApplyWithIdeContent(
+      tool,
+      filePath,
+      'const b = 2;',
+      'const b = 3;',
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+
+  it('refuses an already-broken baseline plus a distinct new IDE error and leaves the original unchanged', async () => {
+    // Baseline error at line 1 (@@@). The IDE candidate keeps that error AND
+    // adds a new {{{ error on a later line. Both must be compared; the new one
+    // is unmatched → refused.
+    const filePath = join(tmpDir, 'ide-distinct.ts');
+    const original = 'const broken = @@@;\nconst a = 1;\n';
+    writeFileSync(filePath, original, 'utf-8');
+    const ide = fakeIdeService(
+      'connected',
+      'const broken = @@@;\nconst a = 2;\nconst newErr = {{{;\n',
+    );
+    const tool = new ASTEditTool(host, ide);
+
+    const result = await executeApplyWithIdeContent(
+      tool,
+      filePath,
+      'const a = 1;',
+      'const a = 2;',
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 4 (In-scope): ast_read_file keeps working-set context.
+// ---------------------------------------------------------------------------
+
+describe('Finding 4 (In-scope): ast_read_file retains working-set context while ast_edit preview omits it', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `ast-edit-read-ctx-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Initializes a throwaway git repo so a modified tracked file appears in the
+   * git working set (the eager context ast_read_file renders).
+   */
+  function initGitWorkingSet(): void {
+    const git = (args: string[]): void => {
+      spawnSync('git', ['-C', tmpDir, ...args], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+    };
+    git(['init']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'Test']);
+    const other = join(tmpDir, 'other.ts');
+    writeFileSync(other, 'export function helper(): void {}\n', 'utf-8');
+    git(['add', 'other.ts']);
+    spawnSync('git', ['-C', tmpDir, 'commit', '-m', 'init', 'other.ts'], {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    // Mutate the tracked file so it shows up as an unstaged working-set change.
+    writeFileSync(
+      other,
+      'export function helper(): void {\n  return;\n}\n',
+      'utf-8',
+    );
+  }
+
+  it('ast_read_file renders WORKING SET CONTEXT for a git-modified tracked file', async () => {
+    initGitWorkingSet();
+    const target = join(tmpDir, 'target.ts');
+    writeFileSync(target, 'export function alpha(): void {}\n', 'utf-8');
+    const tool = new ASTReadFileTool(createFakeToolHost(tmpDir));
+
+    const result = await tool
+      .build({ file_path: target })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    // Regression guard: working-set context must still be collected/rendered
+    // for ast_read_file after the ast_edit preview optimization.
+    expect(output).toContain('WORKING SET CONTEXT');
+    expect(output).toContain('other.ts');
+  });
+
+  it('ast_edit preview still omits WORKING SET CONTEXT', async () => {
+    initGitWorkingSet();
+    const target = join(tmpDir, 'target.ts');
+    writeFileSync(target, 'export function alpha(): void {}\n', 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(tmpDir));
+
+    const result = await executePreview(tool, {
+      file_path: target,
+      old_string: 'export function alpha()',
+      new_string: 'export function beta()',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).not.toContain('WORKING SET CONTEXT');
+    expect(output).not.toContain('other.ts');
+    expect(output).toContain('ENHANCED CONTEXT ANALYSIS:');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 5 (In-scope): coherent messages.
+// ---------------------------------------------------------------------------
+
+describe('Finding 5 (In-scope): coherent validation messaging', () => {
+  const ctx = useTempDir();
+
+  it('states definitively that the edit resolved the pre-existing error (no "may have") in preview', async () => {
+    const filePath = join(ctx.tempDir, 'resolve-preview.ts');
+    writeFileSync(
+      filePath,
+      'const greeting = "hello";\nconst broken = @@@;\n',
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'const broken = @@@;',
+      new_string: 'const broken = 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('AST validation: PASSED');
+    expect(output).toContain('resolved');
+    expect(output).not.toContain('may have');
+  });
+
+  it('states definitively that the edit resolved the pre-existing error (no "may have") in apply', async () => {
+    const filePath = join(ctx.tempDir, 'resolve-apply.ts');
+    writeFileSync(
+      filePath,
+      'const greeting = "hello";\nconst broken = @@@;\n',
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const broken = @@@;',
+      new_string: 'const broken = 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('resolved');
+    expect(output).not.toContain('may have');
+    expect(output).not.toContain('Pre-existing syntax errors: Yes');
+  });
+
+  it('reports a retained pre-existing error at its CURRENT post-edit line after a line-shifting edit', async () => {
+    // Pre-existing @@@ error on line 2. The edit inserts a line above it,
+    // shifting the unchanged error to line 3. The message must report the
+    // current (post-edit) line 3, not the stale baseline line 2.
+    const filePath = join(ctx.tempDir, 'shift-coords.ts');
+    writeFileSync(filePath, 'const a = 1;\nconst broken = @@@;\n', 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const a = 1;',
+      new_string: 'const a = 1;\nconst extra = 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('pre-existing');
+    // Current post-edit coordinate (line 3), not the stale baseline (line 2).
+    expect(output).toContain('at line 3');
+    expect(output).not.toContain('at line 2');
+    expect(readFileSync(filePath, 'utf-8')).toBe(
+      'const a = 1;\nconst extra = 2;\nconst broken = @@@;\n',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part A (Blocker): retained whole-file recovery + distinct new error → refused.
+// ---------------------------------------------------------------------------
+
+describe('Part A (Blocker): retained whole-file recovery then gains a distinct new error', () => {
+  const ctx = useTempDir();
+
+  it('refuses when a retained whole-program recovery file gains a distinct new syntax error elsewhere (same line count)', async () => {
+    // Baseline triggers a whole-file tree-sitter recovery via `return {{{`.
+    // This is the harmless retained baseline case — both pre and post have
+    // whole-file recovery. The edit then introduces a SEPARATE {{{ error on
+    // a different line (same line count). The new error must be detected.
+    const filePath = join(ctx.tempDir, 'whole-plus-new.ts');
+    const baseline = [
+      'class Foo {',
+      '  bar() {',
+      '    return {{{',
+      '  }',
+      '}',
+      'const marker = 1;',
+      '',
+    ].join('\n');
+    writeFileSync(filePath, baseline, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const marker = 1;',
+      // Same line count; distinct new error on a different line.
+      new_string: 'const marker = {{{ 2;',
+    });
+
+    // The distinct new error must be detected → refused.
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    // File must remain byte-for-byte unchanged.
+    expect(readFileSync(filePath, 'utf-8')).toBe(baseline);
+  });
+
+  it('stays writable when the baseline whole-file recovery is unchanged by a harmless edit', async () => {
+    // Same baseline but a harmless edit that does NOT introduce new damage.
+    const filePath = join(ctx.tempDir, 'whole-keep2.ts');
+    const baseline = [
+      'class Foo {',
+      '  bar() {',
+      '    return {{{',
+      '  }',
+      '}',
+      'const marker = 1;',
+      '',
+    ].join('\n');
+    writeFileSync(filePath, baseline, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const marker = 1;',
+      new_string: 'const marker = 2;',
+    });
+
+    // Pre-existing whole-file recovery remains unchanged → writable.
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toContain('const marker = 2;');
+  });
+});
+// ---------------------------------------------------------------------------
+// Part B (Blocker): exact candidate coordinate mapping.
+// ---------------------------------------------------------------------------
+
+describe('Part B (Blocker): exact candidate coordinate mapping — changed-middle fail-closed', () => {
+  const ctx = useTempDir();
+
+  it('refuses replacing a multi-line region containing a pre-existing error with a different invalid construct at the same line/column', async () => {
+    // Pre-existing error on line 2 (@@@). The edit replaces lines 2-3, putting
+    // a DIFFERENT invalid construct (!!!) at the same line/column. The changed
+    // middle region cannot prove equivalence → fail closed.
+    const filePath = join(ctx.tempDir, 'changed-middle.ts');
+    const original = [
+      'const a = 1;',
+      'const broken = @@@;',
+      'const b = 2;',
+      'const c = 3;',
+      '',
+    ].join('\n');
+    writeFileSync(filePath, original, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const broken = @@@;\nconst b = 2;',
+      new_string: 'const broken = !!!;\nconst b = 2;',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+
+  it('remains writable when a harmless insertion shifts an unchanged trailing pre-existing error', async () => {
+    // Pre-existing @@@ error on line 2. The edit inserts a line BEFORE it,
+    // shifting the unchanged error to line 3. The error is in the unchanged
+    // suffix → proven equivalent → writable.
+    const filePath = join(ctx.tempDir, 'suffix-keep.ts');
+    writeFileSync(filePath, 'const a = 1;\nconst broken = @@@;\n', 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const a = 1;',
+      new_string: 'const a = 1;\nconst extra = 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe(
+      'const a = 1;\nconst extra = 2;\nconst broken = @@@;\n',
+    );
+  });
+
+  it('refuses an IDE multi-hunk candidate with a pre-existing error in the changed middle', async () => {
+    // Pre-existing @@@ error on line 2. The IDE candidate changes lines 1 and
+    // 3 (multi-hunk), leaving the error in the changed middle between the two
+    // hunks. Cannot prove equivalence → fail closed.
+    const dir = join(
+      tmpdir(),
+      `ast-edit-multi-hunk-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(dir, { recursive: true });
+    const filePath = join(dir, 'multi-hunk.ts');
+    const original = 'const a = 1;\nconst broken = @@@;\nconst b = 2;\n';
+    writeFileSync(filePath, original, 'utf-8');
+    const host: IToolHost = {
+      ...createDefaultToolHost(),
+      getTargetDir: () => dir,
+      getWorkspaceRoots: () => [dir],
+      getApprovalMode: () => 'default',
+    };
+    try {
+      const ide = fakeIdeService(
+        'connected',
+        'const a = 999;\nconst broken = @@@;\nconst b = 888;\n',
+      );
+      const tool = new ASTEditTool(host, ide);
+
+      const result = await executeApplyWithIdeContent(
+        tool,
+        filePath,
+        'const a = 1;',
+        'const a = 999;',
+      );
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.type).toBe('ast_syntax_error');
+      expect(readFileSync(filePath, 'utf-8')).toBe(original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Evidence gaps: force schema behavioral, nested invalid-new-file, preview mtime.
+// ---------------------------------------------------------------------------
+
+describe('Evidence gap: force schema behavioral contract', () => {
+  const ctx = useTempDir();
+
+  it('force omitted/false PREVIEWS without writing', async () => {
+    const filePath = join(ctx.tempDir, 'force-preview.ts');
+    const original = 'const x = 1;\n';
+    writeFileSync(filePath, original, 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'const x = 1;',
+      new_string: 'const x = 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('PREVIEW');
+    // Preview must not mutate the file.
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+
+  it('force: true APPLIES and writes to disk', async () => {
+    const filePath = join(ctx.tempDir, 'force-apply.ts');
+    writeFileSync(filePath, 'const x = 1;\n', 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const x = 1;',
+      new_string: 'const x = 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe('const x = 2;\n');
+  });
+});
+
+describe('Evidence gap: nested invalid new file creates neither file nor absent parent directories', () => {
+  const ctx = useTempDir();
+
+  it('refuses an invalid new file under a non-existent nested directory and creates nothing', async () => {
+    const nestedDir = join(ctx.tempDir, 'absent', 'deep');
+    const filePath = join(nestedDir, 'invalid.ts');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: '',
+      new_string: 'const broken = {{{ 2;\n',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
+    // Neither the file...
+    expect(existsSync(filePath)).toBe(false);
+    // ...nor the absent parent directories may be created.
+    expect(existsSync(nestedDir)).toBe(false);
+    expect(existsSync(join(ctx.tempDir, 'absent'))).toBe(false);
+  });
+});
+
+describe('Evidence gap: preview reports the file timestamp', () => {
+  const ctx = useTempDir();
+
+  it('includes a Timestamp line derived from the file mtime', async () => {
+    const filePath = join(ctx.tempDir, 'mtime.ts');
+    writeFileSync(filePath, 'const x = 1;\n', 'utf-8');
+    // Pin the mtime cross-platform via Node utimesSync (GNU touch -d is
+    // unavailable on macOS and would leave this test vacuous).
+    const fixedMtimeSec = 1717000000;
+    utimesSync(filePath, fixedMtimeSec, fixedMtimeSec);
+    const expectedMtime = statSync(filePath).mtime.getTime();
+
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'const x = 1;',
+      new_string: 'const x = 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('Timestamp:');
+    expect(output).toContain(String(expectedMtime));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REQ-3035-9: stale last_modified in preview returns file_modified_conflict.
+// ---------------------------------------------------------------------------
+
+describe('REQ-3035-9: stale last_modified in preview refuses with conflict', () => {
+  const ctx = useTempDir();
+
+  it('preview with stale last_modified returns file_modified_conflict, plain text, timestamps, and does not write', async () => {
+    const filePath = join(ctx.tempDir, 'stale.ts');
+    const original = 'const x = 1;\n';
+    writeFileSync(filePath, original, 'utf-8');
+    // Pin mtime to a known value, then set last_modified BEFORE that so the
+    // file appears modified since last read.
+    const staleSec = 1717000000;
+    const freshSec = 1717000010;
+    utimesSync(filePath, freshSec, freshSec);
+    const currentMtime = statSync(filePath).mtime.getTime();
+
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'const x = 1;',
+      new_string: 'const x = 2;',
+      last_modified: staleSec * 1000,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('file_modified_conflict');
+    // Must be plain non-JSON text (human-readable error, not structured JSON).
+    const content = String(result.llmContent);
+    expect(content).toContain('FILE_MODIFIED_CONFLICT');
+    expect(content).not.toMatch(/^\s*\{/);
+    // Both supplied and current timestamps must appear in the message.
+    expect(content).toContain(String(staleSec * 1000));
+    expect(content).toContain(String(currentMtime));
+    // The remedy must be communicated.
+    expect(content).toContain('Re-read');
+    expect(content).toContain('retry');
+    // No write must have occurred.
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REQ-3035-1 (strengthened): force schema behavioral wording.
+// ---------------------------------------------------------------------------
+
+describe('REQ-3035-1 (strengthened): force schema wording asserts preview/apply mapping', () => {
+  it('states that omitted/false => preview and true => apply', () => {
+    const tool = new ASTEditTool(createFakeToolHost('/tmp'));
+    const schema = tool.parameterSchema as {
+      properties?: { force?: { description?: string } };
+    };
+    const desc = (schema.properties?.force?.description ?? '').toLowerCase();
+    // The description must explicitly map false/omit to preview.
+    expect(desc).toContain('preview');
+    expect(desc).toMatch(/(omit|false).*preview|preview.*(omit|false)/);
+    // The description must explicitly map true to apply.
+    expect(desc).toContain('apply');
+    expect(desc).toMatch(/true.*apply|apply.*true/);
+    // force must NOT be documented as a validation bypass.
+    expect(desc).not.toContain('bypass');
+  });
+});

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-3035.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-issue-3035.test.ts
@@ -1,0 +1,339 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for issue #3035: make ast_edit validation authoritative
+ * and its contract accurate.
+ *
+ * Covers:
+ * - REQ-3035-1: force schema documents the two-step preview/apply contract.
+ * - REQ-3035-3: useful parser locations (whole-file recovery vs. precise).
+ * - REQ-3035-4: coherent validation messaging (resolved vs. pre-existing).
+ * - REQ-3035-6: previews omit WORKING SET CONTEXT but keep ENHANCED CONTEXT.
+ * - REQ-3035-7: unsupported/prose files return no guessed declarations.
+ *
+ * Tests behavior, not implementation: real files on disk, real ASTEditTool
+ * instances, and real git state. No mocking of the tool under test.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { writeFileSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+  useTempDir,
+  createFakeToolHost,
+  executePreview,
+  executeApply,
+} from './test-helpers.js';
+import { ASTEditTool } from '../../ast-edit.js';
+
+/**
+ * Extracts the integer declaration count from the preview "Context:" header.
+ */
+function declarationCountFromPreview(output: string): number {
+  const match = output.match(/with (\d+) declarations/);
+  return match ? Number(match[1]) : -1;
+}
+
+describe('REQ-3035-1: force schema documents the two-step contract', () => {
+  it('states that omitted/false previews and true applies', () => {
+    const tool = new ASTEditTool(createFakeToolHost('/tmp'));
+    const schema = tool.parameterSchema as {
+      properties?: { force?: { description?: string } };
+    };
+    const description = schema.properties?.force?.description ?? '';
+    // Preview vs. apply semantics must be explicit to the agent.
+    expect(description.toLowerCase()).toContain('preview');
+    expect(description.toLowerCase()).toContain('apply');
+    // force must NOT be documented as a validation bypass.
+    expect(description.toLowerCase()).not.toContain('bypass');
+  });
+});
+
+describe('REQ-3035-3: useful parser error locations', () => {
+  const ctx = useTempDir();
+
+  it('reports the edit region (not line 1) for whole-file tree-sitter recovery without a nested diagnostic', async () => {
+    // A class whose method body becomes `return {{{` triggers tree-sitter's
+    // whole-program recovery, which otherwise reports line 1:1. When no
+    // nested precise ERROR is available, the approximate edit-region location
+    // is the only diagnostic.
+    const filePath = join(ctx.tempDir, 'whole-recovery.ts');
+    writeFileSync(
+      filePath,
+      ['class Foo {', '  bar() {', '    return 1;', '  }', '}', ''].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: '    return 1;',
+      new_string: '    return {{{',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('AST validation: FAILED');
+    // Approximate edit-region reporting: the edit starts at line 3.
+    expect(output).not.toMatch(/at line 1, column 1/);
+    expect(output).toMatch(/near line 3/);
+  });
+
+  it('reports a precise nested parser location when available alongside whole-file recovery', async () => {
+    // When the whole-file recovery has a nested precise ERROR, the exact
+    // location is preferred over the approximate edit-region reporting.
+    const filePath = join(ctx.tempDir, 'whole-recovery-nested.ts');
+    writeFileSync(
+      filePath,
+      [
+        'class Foo {',
+        '  bar() {',
+        '    return 1;',
+        '  }',
+        '}',
+        'const marker = 1;',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: '    return 1;',
+      new_string: '    return {{{',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('AST validation: FAILED');
+    // The nested precise ERROR provides an exact location at line 3, column 5
+    // (1-based), preferred over the approximate whole-file recovery message.
+    expect(output).toMatch(/Syntax error at line 3, column 5/);
+    expect(output).not.toMatch(/at line 1, column 1/);
+  });
+
+  it('keeps already-precise parser locations precise (no regression)', async () => {
+    // A localized `{{{` mid-file yields an accurate ERROR node location.
+    const filePath = join(ctx.tempDir, 'precise.ts');
+    writeFileSync(
+      filePath,
+      ['const a = 1;', 'const b = 2;', 'const c = 3;', ''].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'const b = 2;',
+      new_string: 'const b = {{{ 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('AST validation: FAILED');
+    // Accurate location: line 2, column 9 (1-based), reported exactly.
+    expect(output).toMatch(/Syntax error at line 2, column 9/);
+    expect(output).not.toContain('near line');
+    expect(output).not.toContain('whole-file recovery');
+  });
+});
+
+describe('REQ-3035-4: coherent validation messaging', () => {
+  const ctx = useTempDir();
+
+  it('reports resolution and does NOT also claim pre-existing errors remain', async () => {
+    // File starts with a pre-existing syntax error; the edit fixes it.
+    const filePath = join(ctx.tempDir, 'resolvable.ts');
+    writeFileSync(
+      filePath,
+      'const greeting = "hello";\nconst broken = @@@;\n',
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const broken = @@@;',
+      new_string: 'const broken = 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('AST validation: PASSED');
+    expect(output).toContain('resolved');
+    // Must not contradict itself by also reporting lingering pre-existing errors.
+    expect(output).not.toContain('Pre-existing syntax errors: Yes');
+    expect(readFileSync(filePath, 'utf-8')).toBe(
+      'const greeting = "hello";\nconst broken = 2;\n',
+    );
+  });
+
+  it('reports remaining pre-existing-only errors without classifying them as new', async () => {
+    // File has a pre-existing error that the edit does not touch; the edit
+    // elsewhere is valid. The remaining error must be labeled pre-existing.
+    const filePath = join(ctx.tempDir, 'preexisting-remains.ts');
+    writeFileSync(filePath, 'const keep = 1;\nconst broken = @@@;\n', 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executeApply(tool, {
+      file_path: filePath,
+      old_string: 'const keep = 1;',
+      new_string: 'const keep = 2;',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('pre-existing');
+    expect(output).not.toContain('new error introduced');
+  });
+});
+
+describe('REQ-3035-6: previews keep target context and drop working set', () => {
+  const ctx = useTempDir();
+
+  /**
+   * Initializes a throwaway git repo so a modified tracked file appears in the
+   * git working set (the eager context the old code collected).
+   */
+  function initGitWorkingSet(tempDir: string): void {
+    const git = (args: string[]): void => {
+      const result = spawnSync('git', ['-C', tempDir, ...args], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+      if (result.status !== 0 || result.error) {
+        throw new Error(
+          `git ${args.join(' ')} failed: ${result.error?.message ?? result.stderr}`,
+        );
+      }
+    };
+    git(['init']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'Test']);
+    const other = join(tempDir, 'other.ts');
+    writeFileSync(other, 'export function helper(): void {}\n', 'utf-8');
+    git(['add', 'other.ts']);
+    git(['commit', '-m', 'init', 'other.ts']);
+    // Mutate the tracked file so it shows up as an unstaged working-set change.
+    writeFileSync(
+      other,
+      'export function helper(): void {\n  return;\n}\n',
+      'utf-8',
+    );
+  }
+
+  it('omits WORKING SET CONTEXT while retaining ENHANCED CONTEXT ANALYSIS', async () => {
+    initGitWorkingSet(ctx.tempDir);
+    const filePath = join(ctx.tempDir, 'target.ts');
+    writeFileSync(filePath, 'export function alpha(): void {}\n', 'utf-8');
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'export function alpha()',
+      new_string: 'export function beta()',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).not.toContain('WORKING SET CONTEXT');
+    expect(output).not.toContain('other.ts');
+    expect(output).toContain('ENHANCED CONTEXT ANALYSIS:');
+    expect(output).toContain('function: alpha (line 1)');
+  });
+});
+
+describe('REQ-3035-7: prose/unsupported files yield no guessed declarations', () => {
+  const ctx = useTempDir();
+
+  it('returns zero declarations for Markdown containing code-like words', async () => {
+    const filePath = join(ctx.tempDir, 'doc.md');
+    writeFileSync(
+      filePath,
+      [
+        '# Documentation',
+        '',
+        'This specifies the default classification of items.',
+        'The function of this module is described below.',
+        'class diagrams are in the appendix.',
+        'def examples are omitted.',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'class diagrams are in the appendix.',
+      new_string: 'class diagrams are omitted.',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(declarationCountFromPreview(output)).toBe(0);
+    // No garbage guessed declarations under the enhanced context section.
+    const header = 'ENHANCED CONTEXT ANALYSIS:';
+    const headerIdx = output.indexOf(header);
+    expect(headerIdx).toBeGreaterThan(-1);
+    const section = output.slice(headerIdx);
+    // No garbage guessed declarations under the enhanced context section.
+    for (const kind of ['- function:', '- class:', '- variable:', '- def:']) {
+      expect(section).not.toContain(kind);
+    }
+    expect(section).not.toContain(': of');
+    expect(section).not.toContain(': diagrams');
+  });
+
+  it('returns zero declarations for a YAML file', async () => {
+    const filePath = join(ctx.tempDir, 'config.yaml');
+    writeFileSync(
+      filePath,
+      [
+        'classification:',
+        '  default: native',
+        'specifies:',
+        '  mode: strict',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: '  mode: strict',
+      new_string: '  mode: relaxed',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(declarationCountFromPreview(output)).toBe(0);
+  });
+
+  it('still extracts declarations for a supported language that parses cleanly', async () => {
+    // Regression guard: supported-code extraction must keep working.
+    const filePath = join(ctx.tempDir, 'real.ts');
+    writeFileSync(
+      filePath,
+      'export function add(a: number, b: number): number {\n  return a + b;\n}\n',
+      'utf-8',
+    );
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'return a + b;',
+      new_string: 'return a + b + 0;',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(declarationCountFromPreview(output)).toBeGreaterThanOrEqual(1);
+    expect(output).toContain('function: add (line 1)');
+  });
+});

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-preview.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-preview.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -286,9 +286,10 @@ describe('ASTEditTool pre-existing vs newly-introduced error categorization (iss
     );
   });
 
-  it('categorizes a newly-introduced error in apply (force) output', async () => {
+  it('refuses a newly-introduced error in apply (force) output and leaves the file unchanged (REQ-3035-2)', async () => {
     const filePath = join(tempDir, 'apply-new-error.ts');
-    writeFileSync(filePath, 'const greeting = "hello";' + NL, 'utf-8');
+    const original = 'const greeting = "hello";' + NL;
+    writeFileSync(filePath, original, 'utf-8');
 
     const tool = new ASTEditTool(createFakeToolHost(tempDir));
     const result = await tool
@@ -300,12 +301,13 @@ describe('ASTEditTool pre-existing vs newly-introduced error categorization (iss
       })
       .execute(new AbortController().signal);
 
-    expect(result.error).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('ast_syntax_error');
     const content = String(result.llmContent);
-    expect(content).toContain('new error introduced by this edit');
-    expect(content).not.toContain('Pre-existing syntax errors: Yes');
-    // Verify the file was actually written with the (broken) new content.
-    expect(readFileSync(filePath, 'utf-8')).toContain('@@@');
+    expect(content).not.toContain('Successfully applied edit');
+    expect(content).not.toContain('Successfully created file');
+    // The file must remain byte-for-byte unchanged.
+    expect(readFileSync(filePath, 'utf-8')).toBe(original);
   });
 
   it('reports mixed pre-existing and newly-introduced errors in preview', async () => {
@@ -333,7 +335,7 @@ describe('ASTEditTool pre-existing vs newly-introduced error categorization (iss
 
     expect(result.error).toBeUndefined();
     const content = String(result.llmContent);
-    expect(content).toContain('Pre-existing syntax errors: Yes');
+    expect(content).not.toContain('Pre-existing syntax errors: Yes');
     expect(content).toMatch(
       /AST validation: FAILED \(file had pre-existing errors? at line \d+; post-edit error at line \d+ may be newly introduced\)/,
     );

--- a/packages/tools/src/tools/ast-edit/__tests__/validation-categorizer.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/validation-categorizer.test.ts
@@ -4,14 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import {
   summarizeAstValidation,
   computeLineDelta,
+  deriveCandidateMapping,
   findEditStartLine,
   extractErrorLineNumber,
   formatValidationLineLabel,
+  type CandidateMapping,
 } from '../validation-categorizer.js';
+
+/**
+ * Constructs a CandidateMapping simulating a single-line edit at
+ * `editStartLine` (replacing exactly one line) where everything below is
+ * unchanged suffix. This mirrors the old editStartLine + lineDelta semantics
+ * for unit-test scenarios.
+ */
+function singleLineEditMapping(
+  editStartLine: number,
+  lineDelta: number,
+  origLineCount = 200,
+): CandidateMapping {
+  const prefixLines = editStartLine - 1;
+  const suffixLines = origLineCount - editStartLine;
+  return { prefixLines, suffixLines, origLineCount, lineDelta };
+}
 
 describe('summarizeAstValidation', () => {
   it('reports PASSED when both pre- and post-edit are valid', () => {
@@ -59,7 +77,6 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 173, column 5'] },
       { valid: false, errors: ['Syntax error at line 173, column 5'] },
-      0,
     );
     expect(summary.status).toBe('FAILED');
     expect(summary.preExisting).toBe(true);
@@ -73,8 +90,7 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 173, column 5'] },
       { valid: false, errors: ['Syntax error at line 183, column 5'] },
-      10,
-      1,
+      singleLineEditMapping(1, 10),
     );
     expect(summary.status).toBe('FAILED');
     expect(summary.preExisting).toBe(true);
@@ -86,7 +102,6 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 173, column 5'] },
       { valid: false, errors: ['Syntax error at line 4977, column 1'] },
-      0,
     );
     expect(summary.status).toBe('FAILED');
     expect(summary.preExisting).toBe(false);
@@ -110,8 +125,7 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 173, column 5'] },
       { valid: false, errors: ['Syntax error at line 184, column 5'] },
-      10,
-      1,
+      singleLineEditMapping(1, 10),
     );
     expect(summary.preExisting).toBe(false);
     expect(summary.newlyIntroduced).toBe(true);
@@ -121,7 +135,6 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 173, column 5'] },
       { valid: false, errors: ['Syntax error at line 173, column 9'] },
-      0,
     );
     expect(summary.preExisting).toBe(false);
     expect(summary.newlyIntroduced).toBe(true);
@@ -134,8 +147,7 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 50, column 5'] },
       { valid: false, errors: ['Syntax error at line 53, column 5'] },
-      10,
-      1,
+      singleLineEditMapping(1, 10, 50),
     );
     expect(summary.preExisting).toBe(false);
     expect(summary.newlyIntroduced).toBe(true);
@@ -147,8 +159,7 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 100, column 5'] },
       { valid: false, errors: ['Syntax error at line 110, column 5'] },
-      10,
-      50,
+      singleLineEditMapping(50, 10, 100),
     );
     expect(summary.preExisting).toBe(true);
     expect(summary.newlyIntroduced).toBe(false);
@@ -160,8 +171,7 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 10, column 5'] },
       { valid: false, errors: ['Syntax error at line 10, column 5'] },
-      10,
-      50,
+      singleLineEditMapping(50, 10),
     );
     expect(summary.preExisting).toBe(true);
     expect(summary.newlyIntroduced).toBe(false);
@@ -171,8 +181,7 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 50, column 5'] },
       { valid: false, errors: ['Syntax error at line 60, column 5'] },
-      10,
-      50,
+      singleLineEditMapping(50, 10, 100),
     );
     expect(summary.preExisting).toBe(false);
     expect(summary.newlyIntroduced).toBe(true);
@@ -182,7 +191,7 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 50, column 5'] },
       { valid: false, errors: ['Syntax error at line 60, column 5'] },
-      10,
+      // No mapping → everything is unchanged prefix → same-line-only matching.
     );
     expect(summary.preExisting).toBe(false);
     expect(summary.newlyIntroduced).toBe(true);
@@ -204,8 +213,7 @@ describe('summarizeAstValidation', () => {
           'Syntax error at line 110, column 1',
         ],
       },
-      10,
-      5,
+      singleLineEditMapping(5, 10),
     );
     expect(summary.preExisting).toBe(true);
     expect(summary.newlyIntroduced).toBe(false);
@@ -225,8 +233,7 @@ describe('summarizeAstValidation', () => {
           'Syntax error at line 500, column 1',
         ],
       },
-      10,
-      50,
+      singleLineEditMapping(50, 10, 100),
     );
     expect(summary.preExisting).toBe(true);
     expect(summary.newlyIntroduced).toBe(true);
@@ -239,8 +246,7 @@ describe('summarizeAstValidation', () => {
     const summary = summarizeAstValidation(
       { valid: false, errors: ['Syntax error at line 5, column 1'] },
       { valid: false, errors: ['Syntax error at line 15, column 1'] },
-      10,
-      10,
+      singleLineEditMapping(10, 10),
     );
     expect(summary.preExisting).toBe(false);
     expect(summary.newlyIntroduced).toBe(true);
@@ -255,7 +261,6 @@ describe('summarizeAstValidation', () => {
         valid: false,
         errors: ['Syntax error at line 173, column 5', 'unknown parse failure'],
       },
-      0,
     );
     expect(summary.preExisting).toBe(true);
     expect(summary.newlyIntroduced).toBe(true);
@@ -372,5 +377,182 @@ describe('formatValidationLineLabel', () => {
 
   it('returns empty string for an empty error list', () => {
     expect(formatValidationLineLabel([])).toBe('');
+  });
+});
+
+describe('summarizeAstValidation: unsupported file types (REQ-3035-5)', () => {
+  it('reports SKIPPED (unsupported file type) when the post-edit file is unsupported', () => {
+    const summary = summarizeAstValidation(
+      { valid: true, errors: [], supported: false },
+      { valid: true, errors: [], supported: false },
+    );
+    expect(summary.status).toBe('SKIPPED');
+    expect(summary.label).toContain('unsupported file type');
+    expect(summary.newlyIntroduced).toBe(false);
+  });
+
+  it('keeps unsupported files writable by not flagging a newly-introduced error', () => {
+    // Even when the post-edit content is non-empty, an unsupported type never
+    // becomes a syntax failure the apply gate would refuse.
+    const summary = summarizeAstValidation(undefined, {
+      valid: true,
+      errors: [],
+      supported: false,
+    });
+    expect(summary.status).toBe('SKIPPED');
+    expect(summary.newlyIntroduced).toBe(false);
+  });
+
+  it('still validates supported files normally', () => {
+    const summary = summarizeAstValidation(
+      { valid: true, errors: [], supported: true },
+      {
+        valid: false,
+        errors: ['Syntax error at line 5, column 1'],
+        supported: true,
+      },
+    );
+    expect(summary.status).toBe('FAILED');
+    expect(summary.newlyIntroduced).toBe(true);
+  });
+});
+
+describe('summarizeAstValidation: whole-file recovery locations (REQ-3035-3)', () => {
+  const wholeRecovery = (line: number): string =>
+    `Syntax error near line ${line} (whole-file recovery; location approximate)`;
+  const wholeRecoveryBaseline = (line: number): string =>
+    `Syntax error at line ${line}, column 1 (whole-file recovery)`;
+
+  it('flags a whole-file recovery error as newly-introduced when the file was clean', () => {
+    const summary = summarizeAstValidation(
+      { valid: true, errors: [] },
+      { valid: false, errors: [wholeRecovery(3)] },
+    );
+    expect(summary.status).toBe('FAILED');
+    expect(summary.newlyIntroduced).toBe(true);
+  });
+
+  it('fails closed when a post whole-file recovery is not equivalent to a precise baseline', () => {
+    // A precise baseline error (not a whole-file recovery) cannot be proven
+    // equivalent to a post-edit whole-file recovery → classified as newly
+    // introduced (fail closed), not blindly accepted.
+    const summary = summarizeAstValidation(
+      { valid: false, errors: ['Syntax error at line 1, column 16'] },
+      { valid: false, errors: [wholeRecovery(10)] },
+    );
+    expect(summary.newlyIntroduced).toBe(true);
+  });
+
+  it('treats a whole-file recovery as pre-existing when the baseline was also a whole-file recovery', () => {
+    // An unchanged baseline whole-file recovery that remains after a harmless
+    // edit must stay writable (equivalent identity).
+    const summary = summarizeAstValidation(
+      { valid: false, errors: [wholeRecoveryBaseline(1)] },
+      { valid: false, errors: [wholeRecovery(10)] },
+    );
+    expect(summary.preExisting).toBe(true);
+    expect(summary.newlyIntroduced).toBe(false);
+  });
+
+  it('fails closed when a baseline whole-file recovery ends in the changed middle', () => {
+    const summary = summarizeAstValidation(
+      {
+        valid: false,
+        errors: [wholeRecoveryBaseline(1)],
+        diagnostics: [
+          {
+            line: 0,
+            column: 0,
+            endLine: 5,
+            wholeFileRecovery: true,
+            message: wholeRecoveryBaseline(1),
+          },
+        ],
+      },
+      {
+        valid: false,
+        errors: [wholeRecovery(4)],
+        diagnostics: [
+          {
+            line: 0,
+            column: 0,
+            endLine: 6,
+            wholeFileRecovery: true,
+            message: wholeRecovery(4),
+          },
+        ],
+      },
+      {
+        prefixLines: 2,
+        suffixLines: 2,
+        origLineCount: 10,
+        lineDelta: 1,
+      },
+    );
+
+    expect(summary.newlyIntroduced).toBe(true);
+  });
+});
+
+describe('summarizeAstValidation: compares every diagnostic (Finding 1)', () => {
+  it('detects a newly introduced later error even when an earlier pre-existing error matches', () => {
+    // Two post-edit errors: line 2 matches the pre-existing baseline, but line
+    // 10 is new. The first-match-only flaw must not mask line 10.
+    const summary = summarizeAstValidation(
+      { valid: false, errors: ['Syntax error at line 2, column 14'] },
+      {
+        valid: false,
+        errors: [
+          'Syntax error at line 2, column 14',
+          'Syntax error at line 10, column 9',
+        ],
+      },
+    );
+    expect(summary.newlyIntroduced).toBe(true);
+  });
+
+  it('classifies all-matching post errors as pre-existing', () => {
+    const summary = summarizeAstValidation(
+      {
+        valid: false,
+        errors: [
+          'Syntax error at line 2, column 14',
+          'Syntax error at line 10, column 9',
+        ],
+      },
+      {
+        valid: false,
+        errors: [
+          'Syntax error at line 2, column 14',
+          'Syntax error at line 10, column 9',
+        ],
+      },
+    );
+    expect(summary.preExisting).toBe(true);
+    expect(summary.newlyIntroduced).toBe(false);
+  });
+});
+
+describe('deriveCandidateMapping: original-to-candidate line diff (Finding 3)', () => {
+  it('derives a shifted prefix and positive delta for an inserted line', () => {
+    const mapping = deriveCandidateMapping(
+      'const keep = 1;\nconst broken = @@@;\n',
+      'const keep = 2;\nconst newLine = 3;\nconst broken = @@@;\n',
+    );
+    expect(mapping.lineDelta).toBe(1);
+    expect(mapping.prefixLines).toBe(0);
+  });
+
+  it('returns full-prefix mapping and zero delta when candidate equals original', () => {
+    const mapping = deriveCandidateMapping('a\nb\n', 'a\nb\n');
+    expect(mapping.lineDelta).toBe(0);
+    expect(mapping.prefixLines).toBe(3); // all lines are prefix
+    expect(mapping.suffixLines).toBe(0);
+  });
+
+  it('handles a new file (null original) with no reliable mapping', () => {
+    const mapping = deriveCandidateMapping(null, 'const x = 1;\n');
+    expect(mapping.lineDelta).toBe(0);
+    expect(mapping.prefixLines).toBe(Number.MAX_SAFE_INTEGER);
   });
 });

--- a/packages/tools/src/tools/ast-edit/__tests__/validation-categorizer.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/validation-categorizer.test.ts
@@ -16,10 +16,12 @@ import {
 } from '../validation-categorizer.js';
 
 /**
- * Constructs a CandidateMapping simulating a single-line edit at
- * `editStartLine` (replacing exactly one line) where everything below is
- * unchanged suffix. This mirrors the old editStartLine + lineDelta semantics
- * for unit-test scenarios.
+ * Unit-test shortcut that builds a CandidateMapping from an edit start line
+ * and a net line delta, treating the lines above the edit as an unchanged
+ * prefix and the lines below it as an unchanged suffix. It does NOT require a
+ * single-line replacement — only the start line and net delta are inputs,
+ * mirroring the old editStartLine + lineDelta matching semantics for unit-test
+ * scenarios with an unchanged prefix/suffix.
  */
 function singleLineEditMapping(
   editStartLine: number,
@@ -443,15 +445,89 @@ describe('summarizeAstValidation: whole-file recovery locations (REQ-3035-3)', (
     expect(summary.newlyIntroduced).toBe(true);
   });
 
-  it('treats a whole-file recovery as pre-existing when the baseline was also a whole-file recovery', () => {
+  it('treats a whole-file recovery as pre-existing when structured end spans match', () => {
     // An unchanged baseline whole-file recovery that remains after a harmless
-    // edit must stay writable (equivalent identity).
+    // edit stays writable only when its raw END-span identity (end line AND end
+    // column) is preserved through the candidate mapping.
+    const summary = summarizeAstValidation(
+      {
+        valid: false,
+        errors: [wholeRecoveryBaseline(1)],
+        diagnostics: [
+          {
+            line: 0,
+            column: 0,
+            endLine: 6,
+            endColumn: 0,
+            wholeFileRecovery: true,
+            message: wholeRecoveryBaseline(1),
+          },
+        ],
+      },
+      {
+        valid: false,
+        errors: [wholeRecovery(10)],
+        diagnostics: [
+          {
+            line: 0,
+            column: 0,
+            endLine: 6,
+            endColumn: 0,
+            wholeFileRecovery: true,
+            message: wholeRecovery(10),
+          },
+        ],
+      },
+    );
+    expect(summary.preExisting).toBe(true);
+    expect(summary.newlyIntroduced).toBe(false);
+  });
+
+  it('fails closed for string-only whole-file recovery without structured span identity', () => {
+    // Compatibility callers that supply only display strings cannot prove that
+    // two whole-file recoveries are the same span (both normalize endLine to a
+    // sentinel 0), so equivalence must fail closed rather than be trusted.
     const summary = summarizeAstValidation(
       { valid: false, errors: [wholeRecoveryBaseline(1)] },
       { valid: false, errors: [wholeRecovery(10)] },
     );
-    expect(summary.preExisting).toBe(true);
-    expect(summary.newlyIntroduced).toBe(false);
+    expect(summary.newlyIntroduced).toBe(true);
+  });
+
+  it('treats whole-file recoveries that differ only by end column as distinct', () => {
+    // Same end line, different end column → different span identity → not
+    // equivalent → classified as newly introduced (fail closed).
+    const summary = summarizeAstValidation(
+      {
+        valid: false,
+        errors: [wholeRecoveryBaseline(1)],
+        diagnostics: [
+          {
+            line: 0,
+            column: 0,
+            endLine: 6,
+            endColumn: 0,
+            wholeFileRecovery: true,
+            message: wholeRecoveryBaseline(1),
+          },
+        ],
+      },
+      {
+        valid: false,
+        errors: [wholeRecovery(10)],
+        diagnostics: [
+          {
+            line: 0,
+            column: 0,
+            endLine: 6,
+            endColumn: 5,
+            wholeFileRecovery: true,
+            message: wholeRecovery(10),
+          },
+        ],
+      },
+    );
+    expect(summary.newlyIntroduced).toBe(true);
   });
 
   it('fails closed when a baseline whole-file recovery ends in the changed middle', () => {
@@ -464,6 +540,7 @@ describe('summarizeAstValidation: whole-file recovery locations (REQ-3035-3)', (
             line: 0,
             column: 0,
             endLine: 5,
+            endColumn: 0,
             wholeFileRecovery: true,
             message: wholeRecoveryBaseline(1),
           },
@@ -477,6 +554,7 @@ describe('summarizeAstValidation: whole-file recovery locations (REQ-3035-3)', (
             line: 0,
             column: 0,
             endLine: 6,
+            endColumn: 1,
             wholeFileRecovery: true,
             message: wholeRecovery(4),
           },

--- a/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
+++ b/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
@@ -516,7 +516,16 @@ export class ASTEditToolInvocation
         editData.currentContent,
         this.params.old_string,
       );
-    } else if (mapping.prefixLines > 0 || mapping.lineDelta !== 0) {
+    } else if (
+      editData.currentContent !== null &&
+      contentToWrite !== editData.currentContent
+    ) {
+      // IDE-accepted candidate diverges from the original: the edit begins at
+      // the first changed line (line 1 when the first line changed), so
+      // whole-file recovery locations are refined to the actual edited region.
+      // The candidate-diff invariant excludes a no-op revert (candidate equals
+      // original) and new files (no original), avoiding the overly broad
+      // prefixLines/lineDelta condition that skipped a line-1, zero-delta edit.
       editStartLine = mapping.prefixLines + 1;
     } else {
       editStartLine = null;

--- a/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
+++ b/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
@@ -46,10 +46,12 @@ import {
 } from './edit-calculator.js';
 import {
   summarizeAstValidation,
-  computeLineDelta,
+  deriveCandidateMapping,
   findEditStartLine,
   formatValidationLineLabel,
   type AstValidationResult,
+  type AstValidationSummary,
+  type CandidateMapping,
 } from './validation-categorizer.js';
 
 function normalizeSeverity(severity: unknown): string {
@@ -223,9 +225,13 @@ export class ASTEditToolInvocation
           this.params.file_path,
           currentContent,
           workspaceRoot,
+          // REQ-3035-6: previews keep the target file's enhanced context but
+          // omit working-set collection/rendering. ast_read_file still collects
+          // the working set because it passes no option.
+          { collectWorkingSet: false },
         );
 
-      const { astValidation, preEditValidation, lineDelta, editStartLine } =
+      const { astValidation, preEditValidation, mapping } =
         this.computeValidationContext(editData);
 
       const fileName = path.basename(this.params.file_path);
@@ -242,10 +248,8 @@ export class ASTEditToolInvocation
         enhancedContext,
         astValidation,
         preEditValidation,
-        lineDelta,
-        editStartLine,
+        mapping,
         currentMtime,
-        workspaceRoot,
       );
 
       const returnDisplay: FileDiff = {
@@ -274,56 +278,68 @@ export class ASTEditToolInvocation
   }
 
   private computeValidationContext(editData: CalculatedEdit): {
-    astValidation: { valid: boolean; errors: string[] };
+    astValidation: AstValidationResult;
     preEditValidation: AstValidationResult | undefined;
-    lineDelta: number;
-    editStartLine: number | null;
+    mapping: CandidateMapping;
   } {
+    const editStartLine = findEditStartLine(
+      editData.currentContent,
+      this.params.old_string,
+    );
+    const editRegion =
+      editStartLine !== null ? { startLine: editStartLine } : undefined;
     const astValidation =
       editData.astValidation ??
-      this.validateASTSyntax(this.params.file_path, editData.newContent);
+      this.validateASTSyntax(
+        this.params.file_path,
+        editData.newContent,
+        editRegion,
+      );
     const preEditValidation: AstValidationResult | undefined =
       editData.preEditValidation ??
       (editData.currentContent !== null
         ? this.validateASTSyntax(this.params.file_path, editData.currentContent)
         : undefined);
-    const lineDelta = computeLineDelta(
-      this.params.old_string,
-      this.params.new_string,
-    );
-    const editStartLine = findEditStartLine(
+    // Derive the mapping from the actual original-to-candidate content diff so
+    // shifted pre-existing errors are classified correctly regardless of
+    // whether the candidate came from the model or was IDE-edited.
+    const mapping = deriveCandidateMapping(
       editData.currentContent,
-      this.params.old_string,
+      editData.newContent,
     );
-    return { astValidation, preEditValidation, lineDelta, editStartLine };
+    return { astValidation, preEditValidation, mapping };
   }
 
   private buildPreviewLlmContent(
     enhancedContext: Awaited<
       ReturnType<ASTContextCollector['collectEnhancedContext']>
     >,
-    astValidation: { valid: boolean; errors: string[] },
-    preEditValidation: { valid: boolean; errors: string[] } | undefined,
-    lineDelta: number,
-    editStartLine: number | null,
+    astValidation: AstValidationResult,
+    preEditValidation: AstValidationResult | undefined,
+    mapping: CandidateMapping,
     currentMtime: number | null,
-    workspaceRoot: string,
   ): string {
     const summary = summarizeAstValidation(
       preEditValidation,
       astValidation,
-      lineDelta,
-      editStartLine,
+      mapping,
     );
+    const hasOnlyPreExistingSyntaxErrors = Boolean(
+      preEditValidation &&
+        !preEditValidation.valid &&
+        !astValidation.valid &&
+        !summary.newlyIntroduced,
+    );
+    const preExistingSyntaxErrors = hasOnlyPreExistingSyntaxErrors
+      ? `- Pre-existing syntax errors: Yes${formatValidationLineLabel(astValidation.errors)}`
+      : '';
     return [
       `LLXPRT EDIT PREVIEW: ${this.params.file_path}`,
       `- Context: ${enhancedContext.language} file with ${enhancedContext.declarations.length} declarations`,
       `- Functions: ${enhancedContext.languageContext.functions.length}`,
       `- Classes: ${enhancedContext.languageContext.classes.length}`,
       `- AST validation: ${summary.label}`,
-      preEditValidation && !preEditValidation.valid
-        ? `- Pre-existing syntax errors: Yes${formatValidationLineLabel(preEditValidation.errors)}`
-        : '',
+      preExistingSyntaxErrors,
       !astValidation.valid
         ? `- AST errors: ${astValidation.errors.join(', ')}`
         : '',
@@ -334,7 +350,6 @@ export class ASTEditToolInvocation
       enhancedContext.relatedFiles
         ? `- Related files: ${enhancedContext.relatedFiles.length}`
         : '',
-      this.formatConnectedFilesContext(enhancedContext, workspaceRoot),
       currentMtime !== null ? `- Timestamp: ${currentMtime}` : '',
       '',
       'ENHANCED CONTEXT ANALYSIS:',
@@ -348,37 +363,6 @@ export class ASTEditToolInvocation
       .flat()
       .filter(Boolean)
       .join('\n');
-  }
-
-  private formatConnectedFilesContext(
-    enhancedContext: Awaited<
-      ReturnType<ASTContextCollector['collectEnhancedContext']>
-    >,
-    workspaceRoot: string,
-  ): string[] {
-    if (
-      !enhancedContext.connectedFiles ||
-      enhancedContext.connectedFiles.length === 0
-    ) {
-      return [];
-    }
-    return [
-      '',
-      'WORKING SET CONTEXT:',
-      ...enhancedContext.connectedFiles
-        .map((file) => {
-          const relPath = makeRelative(file.filePath, workspaceRoot);
-          if (file.declarations.length === 0)
-            return `- ${relPath} (No declarations)`;
-          return [
-            `- ${relPath}:`,
-            ...file.declarations.map(
-              (d) => `  - ${d.type}: ${d.name}${d.signature ?? ''}`,
-            ),
-          ];
-        })
-        .flat(),
-    ];
   }
 
   private formatRelatedSymbols(
@@ -438,6 +422,17 @@ export class ASTEditToolInvocation
       // replacement — mirrors write_file/edit behavior.
       const contentToWrite = this.ideAcceptedContent ?? editData.newContent;
 
+      // REQ-3035-2: validate the exact final candidate content before any disk
+      // mutation. A newly-introduced syntax error is refused and the file is
+      // left byte-for-byte unchanged.
+      const { summary, finalValidation, preEditValidation } =
+        this.resolveApplyValidation(editData, contentToWrite);
+      if (summary.newlyIntroduced) {
+        return this.refuseNewlyIntroducedEdit(
+          finalValidation.errors.join(', '),
+        );
+      }
+
       await ensureParentDirectoriesExist(this.params.file_path);
       await fsPromises.writeFile(
         this.params.file_path,
@@ -455,43 +450,21 @@ export class ASTEditToolInvocation
         DEFAULT_CREATE_PATCH_OPTIONS,
       );
 
-      const { astValidation, preEditValidation, lineDelta, editStartLine } =
-        this.computeValidationContext(editData);
       const displayResult = {
         fileDiff,
         fileName,
         originalContent: editData.currentContent,
         newContent: contentToWrite,
         applied: true,
-        metadata: {
-          astValidation,
-          preEditValidation,
-        },
+        metadata: { astValidation: finalValidation, preEditValidation },
       };
-      const summary = summarizeAstValidation(
+
+      const llmSuccessMessageParts = this.buildApplySuccessMessage(
+        editData,
+        summary,
+        finalValidation,
         preEditValidation,
-        astValidation,
-        lineDelta,
-        editStartLine,
       );
-
-      const llmSuccessMessageParts: string[] = [
-        `Successfully applied edit to: ${this.params.file_path}`,
-        `- Changes: ${editData.occurrences} replacement(s) applied`,
-        `- AST validation: ${summary.label}`,
-      ];
-
-      if (preEditValidation && !preEditValidation.valid) {
-        llmSuccessMessageParts.push(
-          `- Pre-existing syntax errors: Yes${formatValidationLineLabel(preEditValidation.errors)}${summary.newlyIntroduced ? '' : ' (not introduced by this edit)'}`,
-        );
-      }
-
-      if (summary.newlyIntroduced) {
-        llmSuccessMessageParts.push(
-          `- AST errors: ${astValidation.errors.join(', ')}`,
-        );
-      }
 
       await this.appendLspDiagnostics(llmSuccessMessageParts);
 
@@ -510,6 +483,106 @@ export class ASTEditToolInvocation
         },
       };
     }
+  }
+
+  /**
+   * Validates the exact final candidate content and categorizes the result
+   * relative to the pre-edit baseline. Reuses the pre-computed validation when
+   * the candidate equals the model's replacement; re-validates (with the edit
+   * region) when IDE-accepted content diverges.
+   *
+   * The candidate mapping (unchanged prefix/suffix boundaries) is always
+   * derived from the ACTUAL original-to-candidate content diff so shifted
+   * pre-existing errors are classified correctly regardless of whether the
+   * candidate came from the model or was IDE-edited.
+   */
+  private resolveApplyValidation(
+    editData: CalculatedEdit,
+    contentToWrite: string,
+  ): {
+    summary: AstValidationSummary;
+    finalValidation: AstValidationResult;
+    preEditValidation: AstValidationResult | undefined;
+  } {
+    const isModelContent = contentToWrite === editData.newContent;
+    // Always derive the mapping from the actual original-to-candidate diff.
+    const mapping = deriveCandidateMapping(
+      editData.currentContent,
+      contentToWrite,
+    );
+    let editStartLine: number | null;
+    if (isModelContent) {
+      editStartLine = findEditStartLine(
+        editData.currentContent,
+        this.params.old_string,
+      );
+    } else if (mapping.prefixLines > 0 || mapping.lineDelta !== 0) {
+      editStartLine = mapping.prefixLines + 1;
+    } else {
+      editStartLine = null;
+    }
+    const editRegion =
+      editStartLine !== null && editStartLine > 0
+        ? { startLine: editStartLine }
+        : undefined;
+    const finalValidation =
+      isModelContent && editData.astValidation
+        ? editData.astValidation
+        : this.validateASTSyntax(
+            this.params.file_path,
+            contentToWrite,
+            editRegion,
+          );
+    const preEditValidation = editData.preEditValidation;
+    const summary = summarizeAstValidation(
+      preEditValidation,
+      finalValidation,
+      mapping,
+    );
+    return { summary, finalValidation, preEditValidation };
+  }
+
+  private refuseNewlyIntroducedEdit(detail: string): ToolResult {
+    const prefix = `Refused edit to ${this.params.file_path}: applying it would introduce an AST syntax error (${detail})`;
+    return {
+      llmContent: `${prefix}. No changes were written.`,
+      returnDisplay: `Edit refused: newly-introduced AST syntax error.`,
+      error: {
+        message: `${prefix}. Re-read the file, fix the syntax in new_string, then retry.`,
+        type: ToolErrorType.AST_SYNTAX_ERROR,
+      },
+    };
+  }
+
+  private buildApplySuccessMessage(
+    editData: CalculatedEdit,
+    summary: AstValidationSummary,
+    finalValidation: AstValidationResult,
+    preEditValidation: AstValidationResult | undefined,
+  ): string[] {
+    const parts: string[] = [
+      editData.isNewFile
+        ? `Successfully created file: ${this.params.file_path}`
+        : `Successfully applied edit to: ${this.params.file_path}`,
+    ];
+    if (!editData.isNewFile) {
+      parts.push(`- Changes: ${editData.occurrences} replacement(s) applied`);
+    }
+    parts.push(`- AST validation: ${summary.label}`);
+    // REQ-3035-4/5: only surface lingering pre-existing errors when the
+    // post-edit file is still invalid; a resolved error must not be reported as
+    // remaining, and retained pre-existing errors are reported at their CURRENT
+    // post-edit coordinates (which may have shifted due to a line-changing edit).
+    if (
+      preEditValidation &&
+      !preEditValidation.valid &&
+      !finalValidation.valid
+    ) {
+      parts.push(
+        `- Pre-existing syntax errors: Yes${formatValidationLineLabel(finalValidation.errors)} (not introduced by this edit)`,
+      );
+    }
+    return parts;
   }
 
   // @plan PLAN-20250212-LSP.P31
@@ -644,8 +717,9 @@ export class ASTEditToolInvocation
   private validateASTSyntax(
     filePath: string,
     content: string,
-  ): { valid: boolean; errors: string[] } {
-    return validateASTSyntax(filePath, content);
+    editRegion?: { startLine: number },
+  ): AstValidationResult {
+    return validateASTSyntax(filePath, content, editRegion);
   }
 
   protected async getFileLastModified(

--- a/packages/tools/src/tools/ast-edit/ast-query-extractor.ts
+++ b/packages/tools/src/tools/ast-edit/ast-query-extractor.ts
@@ -29,7 +29,9 @@ export class ASTQueryExtractor {
     ).toLowerCase();
     const lang = LANGUAGE_MAP[extension];
     if (!lang) {
-      return this.fallbackExtraction(content, 'unknown');
+      // Unsupported/prose files (Markdown, YAML, text, ...) must not produce
+      // guessed declarations from the regex fallback.
+      return [];
     }
 
     try {

--- a/packages/tools/src/tools/ast-edit/context-collector.ts
+++ b/packages/tools/src/tools/ast-edit/context-collector.ts
@@ -105,7 +105,9 @@ export class ASTContextCollector {
     targetFilePath: string,
     content: string,
     workspaceRoot: string,
+    options?: { collectWorkingSet?: boolean },
   ): Promise<EnhancedASTContext> {
+    const collectWorkingSet = options?.collectWorkingSet ?? true;
     const startTime = Date.now();
     const startMemory = process.memoryUsage().heapUsed;
 
@@ -115,7 +117,6 @@ export class ASTContextCollector {
     const enhancedContext: EnhancedASTContext = {
       ...baseContext,
       declarations: baseContext.declarations as EnhancedDeclaration[],
-      connectedFiles: [],
     };
 
     // Context optimization
@@ -125,14 +126,17 @@ export class ASTContextCollector {
       workspaceRoot,
     );
 
-    // Phase 2: Working Set Context (Git-based)
-    const connectedFiles = await enrichWithWorkingSetContext(
-      targetFilePath,
-      workspaceRoot,
-      this.repoProvider,
-      this.astExtractor,
-    );
-    enhancedContext.connectedFiles = connectedFiles;
+    // Phase 2: Working Set Context (Git-based). Suppressed only for callers
+    // (ast_edit preview) that opt out; ast_read_file keeps the working set.
+    if (collectWorkingSet) {
+      const connectedFiles = await enrichWithWorkingSetContext(
+        targetFilePath,
+        workspaceRoot,
+        this.repoProvider,
+        this.astExtractor,
+      );
+      enhancedContext.connectedFiles = connectedFiles;
+    }
 
     // Phase 3: Repository context and Cross-file Relationships
     const repoContext =

--- a/packages/tools/src/tools/ast-edit/edit-calculator.ts
+++ b/packages/tools/src/tools/ast-edit/edit-calculator.ts
@@ -354,12 +354,16 @@ export function validateASTSyntax(
  * location to the edited region.
  */
 function toDiagnostic(
-  range: { start: { line: number; column: number }; end: { line: number } },
+  range: {
+    start: { line: number; column: number };
+    end: { line: number; column: number };
+  },
   editRegion: EditRegion | undefined,
 ): AstDiagnostic {
   const line = range.start.line;
   const column = range.start.column;
   const endLine = range.end.line;
+  const endColumn = range.end.column;
   const wholeFileRecovery = line === 0 && column === 0 && endLine > line;
   let message: string;
   if (wholeFileRecovery && editRegion && editRegion.startLine > 1) {
@@ -369,7 +373,7 @@ function toDiagnostic(
   } else {
     message = `Syntax error at line ${line + 1}, column ${column + 1}`;
   }
-  return { line, column, endLine, wholeFileRecovery, message };
+  return { line, column, endLine, endColumn, wholeFileRecovery, message };
 }
 
 /**
@@ -405,11 +409,12 @@ function collectDiagnostics(
   };
   visit(root);
 
-  // Deduplicate true equivalents (identical span) preserving source order.
+  // Deduplicate true equivalents (identical span, including end column)
+  // preserving source order.
   const seen = new Set<string>();
   const result: AstDiagnostic[] = [];
   for (const d of collected) {
-    const key = `${d.line}:${d.column}:${d.endLine}:${d.wholeFileRecovery}`;
+    const key = `${d.line}:${d.column}:${d.endLine}:${d.endColumn ?? ''}:${d.wholeFileRecovery}`;
     if (!seen.has(key)) {
       seen.add(key);
       result.push(d);

--- a/packages/tools/src/tools/ast-edit/edit-calculator.ts
+++ b/packages/tools/src/tools/ast-edit/edit-calculator.ts
@@ -15,6 +15,19 @@ import { ToolErrorType } from '../../types/tool-error.js';
 import { isNodeError } from '../../utils/errors.js';
 import { parse, LANGUAGE_MAP } from '../../utils/ast-grep-utils.js';
 import { applyReplacement } from './edit-helpers.js';
+import {
+  findEditStartLine,
+  type AstValidationResult,
+  type AstDiagnostic,
+} from './validation-categorizer.js';
+
+/**
+ * Optional edit region used to refine whole-file tree-sitter recovery
+ * locations so they point at the edited area instead of line 1.
+ */
+export interface EditRegion {
+  startLine: number;
+}
 
 /**
  * Result of edit calculation, including validation and freshness checks.
@@ -25,8 +38,8 @@ export interface CalculatedEdit {
   occurrences: number;
   error?: { display: string; raw: string; type: ToolErrorType };
   isNewFile: boolean;
-  astValidation?: { valid: boolean; errors: string[] };
-  preEditValidation?: { valid: boolean; errors: string[] };
+  astValidation?: AstValidationResult;
+  preEditValidation?: AstValidationResult;
   fileFreshness?: number | null;
 }
 
@@ -95,9 +108,11 @@ export async function calculateEdit(
       ? validateASTSyntax(params.file_path, currentContent)
       : undefined;
 
-  let astValidation: { valid: boolean; errors: string[] } | undefined;
+  let astValidation: AstValidationResult | undefined;
   if (!noChangeError) {
-    astValidation = validateASTSyntax(params.file_path, newContent);
+    // Refine whole-file recovery locations using the edited region.
+    const editRegion = buildEditRegion(currentContent, normalizedOldString);
+    astValidation = validateASTSyntax(params.file_path, newContent, editRegion);
   }
 
   return {
@@ -164,12 +179,8 @@ function checkFreshness(
       newContent: currentContent ?? '',
       occurrences: 0,
       error: {
-        display: `File has been modified since it was last read. Please read the file again to get the latest content.`,
-        raw: JSON.stringify({
-          message: `File ${params.file_path} mismatch. Expected mtime <= ${params.last_modified}, but found ${currentMtime}.`,
-          current_mtime: currentMtime,
-          your_mtime: params.last_modified,
-        }),
+        display: `File has been modified since it was last read (expected last_modified ${params.last_modified}, current mtime ${currentMtime}). Re-read the file then retry.`,
+        raw: `FILE_MODIFIED_CONFLICT: ${params.file_path} was modified since it was last read. Expected last_modified ${params.last_modified}, but the current mtime is ${currentMtime}. Re-read the file then retry.`,
         type: ToolErrorType.FILE_MODIFIED_CONFLICT,
       },
       isNewFile: false,
@@ -251,6 +262,20 @@ function checkNoChange(
 }
 
 /**
+ * Derives the edited region's start line so whole-file tree-sitter recovery
+ * can report a useful location. Returns undefined for new files or when the
+ * edit position cannot be determined.
+ */
+function buildEditRegion(
+  currentContent: string | null,
+  oldString: string,
+): EditRegion | undefined {
+  if (!currentContent || !oldString) return undefined;
+  const startLine = findEditStartLine(currentContent, oldString);
+  return startLine === null ? undefined : { startLine };
+}
+
+/**
  * Returns the true number of occurrences of searchString in content.
  *
  * @param content - File content
@@ -279,78 +304,118 @@ export function countOccurrences(
  * relying on thrown exceptions (tree-sitter is error-recovering and
  * never throws on syntax errors).
  *
+ * Collects EVERY relevant diagnostic in stable source order (not only the
+ * first ERROR node) so a pre-existing early error cannot mask a newly
+ * introduced later error. Descends through ERROR nodes to retain both enclosing
+ * recovery identity and more precise nested diagnostics, then deduplicates true
+ * equivalents.
+ *
  * @param filePath - File path (used to detect language)
  * @param content - File content to validate
- * @returns Validation result
+ * @param editRegion - When provided, whole-file recovery ERROR nodes are
+ *   re-attributed to the edited region instead of the misleading line 1.
+ * @returns Validation result; `supported` is false for unsupported extensions.
  */
 export function validateASTSyntax(
   filePath: string,
   content: string,
-): { valid: boolean; errors: string[] } {
+  editRegion?: EditRegion,
+): AstValidationResult {
   const extension = path.extname(filePath).substring(1).toLowerCase();
   const lang = LANGUAGE_MAP[extension];
   if (!lang) {
-    return { valid: true, errors: [] };
+    return { valid: true, errors: [], supported: false };
   }
 
   try {
-    const tree = parse(lang, content);
-    const root = tree.root();
-
-    // Check for explicit ERROR nodes (garbled/unparseable tokens)
-    const errorNode = root.find({ rule: { kind: 'ERROR' } });
-    if (errorNode) {
-      const pos = errorNode.range().start;
-      return {
-        valid: false,
-        errors: [
-          `Syntax error at line ${pos.line + 1}, column ${pos.column + 1}`,
-        ],
-      };
+    const root = parse(lang, content).root();
+    const diagnostics = collectDiagnostics(root, content, editRegion);
+    if (diagnostics.length === 0) {
+      return { valid: true, errors: [], supported: true, diagnostics };
     }
-
-    // Check for zero-width phantom nodes (MISSING tokens from error recovery).
-    // Tree-sitter inserts these when expected delimiters are absent (e.g., missing }).
-    // ast-grep doesn't expose isMissing() or kind:'MISSING', but zero-width leaf
-    // nodes in non-empty content reliably indicate recovered syntax errors.
-    if (content.length > 0) {
-      const missingNode = findZeroWidthNode(root);
-      if (missingNode) {
-        return {
-          valid: false,
-          errors: [
-            `Syntax error at line ${missingNode.line + 1}, column ${missingNode.column + 1}`,
-          ],
-        };
-      }
-    }
-
-    return { valid: true, errors: [] };
+    return {
+      valid: false,
+      errors: diagnostics.map((d) => d.message),
+      supported: true,
+      diagnostics,
+    };
   } catch (error) {
     return {
       valid: false,
       errors: [error instanceof Error ? error.message : String(error)],
+      supported: true,
     };
   }
 }
 
 /**
- * Walks the parse tree to find zero-width leaf nodes, which indicate
- * MISSING tokens inserted by tree-sitter's error recovery (e.g., a phantom
- * closing brace). Skips the root node to avoid false positives on empty content.
+ * Builds a single diagnostic from a raw parser range, preserving the raw
+ * coordinates and whole-file-recovery identity while refining only the display
+ * location to the edited region.
  */
-function findZeroWidthNode(
-  node: ReturnType<ReturnType<typeof parse>['root']>,
-): { line: number; column: number } | null {
-  for (const child of node.children()) {
-    const range = child.range();
-    if (range.start.index === range.end.index && child.isLeaf()) {
-      return { line: range.start.line, column: range.start.column };
-    }
-    const found = findZeroWidthNode(child);
-    if (found) return found;
+function toDiagnostic(
+  range: { start: { line: number; column: number }; end: { line: number } },
+  editRegion: EditRegion | undefined,
+): AstDiagnostic {
+  const line = range.start.line;
+  const column = range.start.column;
+  const endLine = range.end.line;
+  const wholeFileRecovery = line === 0 && column === 0 && endLine > line;
+  let message: string;
+  if (wholeFileRecovery && editRegion && editRegion.startLine > 1) {
+    message = `Syntax error near line ${editRegion.startLine} (whole-file recovery; location approximate)`;
+  } else if (wholeFileRecovery) {
+    message = `Syntax error at line ${line + 1}, column ${column + 1} (whole-file recovery)`;
+  } else {
+    message = `Syntax error at line ${line + 1}, column ${column + 1}`;
   }
-  return null;
+  return { line, column, endLine, wholeFileRecovery, message };
+}
+
+/**
+ * Collects every ERROR/MISSING diagnostic by walking the parse tree in source
+ * order, descending through ERROR nodes to find more specific nested
+ * diagnostics. Every relevant diagnostic is retained so the classification
+ * can compare the whole-file recovery identity AND any nested precise
+ * locations — suppressing an enclosing recovery when a child exists would
+ * lose damage that the child does not capture. True equivalents (identical
+ * span) are deduplicated, preserving stable source order.
+ */
+function collectDiagnostics(
+  root: ReturnType<ReturnType<typeof parse>['root']>,
+  content: string,
+  editRegion: EditRegion | undefined,
+): AstDiagnostic[] {
+  const collected: AstDiagnostic[] = [];
+  const visit = (node: typeof root): void => {
+    const kind = node.kind();
+    const range = node.range();
+    const isZeroWidthMissing =
+      content.length > 0 &&
+      range.start.index === range.end.index &&
+      node.isLeaf();
+    if (kind === 'ERROR' || isZeroWidthMissing) {
+      collected.push(toDiagnostic(range, editRegion));
+      // Continue descending into ERROR nodes to find more specific nested
+      // diagnostics — the enclosing recovery must not mask distinct damage.
+    }
+    for (const child of node.children()) {
+      visit(child);
+    }
+  };
+  visit(root);
+
+  // Deduplicate true equivalents (identical span) preserving source order.
+  const seen = new Set<string>();
+  const result: AstDiagnostic[] = [];
+  for (const d of collected) {
+    const key = `${d.line}:${d.column}:${d.endLine}:${d.wholeFileRecovery}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(d);
+    }
+  }
+  return result;
 }
 
 /**

--- a/packages/tools/src/tools/ast-edit/validation-categorizer.ts
+++ b/packages/tools/src/tools/ast-edit/validation-categorizer.ts
@@ -14,7 +14,61 @@
  * whether the failure was already there.
  */
 
-export type AstValidationResult = { valid: boolean; errors: string[] };
+export type AstValidationResult = {
+  valid: boolean;
+  errors: string[];
+  /**
+   * False when the file extension has no supported AST language, so the
+   * content was never parsed. Undefined preserves backward compatibility for
+   * callers that only know {valid, errors}.
+   */
+  supported?: boolean;
+  /**
+   * Structured parser diagnostics in stable source order. Carries the raw
+   * parser identity/range and whole-file-recovery flag so classification can
+   * compare every diagnostic (not only the first) and prove equivalence.
+   * Undefined for callers that only supply display strings.
+   */
+  diagnostics?: AstDiagnostic[];
+};
+
+/**
+ * One parser diagnostic with its raw parser coordinates preserved for
+ * classification, separate from the (possibly edit-region-refined) display
+ * message.
+ */
+export interface AstDiagnostic {
+  /** 0-based start line from the parser (raw, unrefined). */
+  readonly line: number;
+  /** 0-based start column from the parser (raw, unrefined). */
+  readonly column: number;
+  /** 0-based end line; used to detect whole-file recovery spans. */
+  readonly endLine: number;
+  /** True when this is a whole-file tree-sitter recovery node (1:1, spans lines). */
+  readonly wholeFileRecovery: boolean;
+  /** Human-readable message (display location refined to the edit region when applicable). */
+  readonly message: string;
+}
+
+/**
+ * Mapping from original to candidate content with explicit unchanged prefix
+ * and suffix line boundaries and a single conservative changed middle region.
+ *
+ * A pre/post precise diagnostic may match only if it maps through the unchanged
+ * prefix (same line) or the unchanged suffix (line shifted by `lineDelta`).
+ * Diagnostics in the changed middle cannot be proven equivalent and must fail
+ * closed. This is used for model content and IDE-diverged content alike.
+ */
+export interface CandidateMapping {
+  /** Number of unchanged leading lines (1-based lines 1..prefixLines). */
+  readonly prefixLines: number;
+  /** Number of unchanged trailing lines. */
+  readonly suffixLines: number;
+  /** Total lines in the original content. */
+  readonly origLineCount: number;
+  /** Net line delta (candidate line count minus original line count). */
+  readonly lineDelta: number;
+}
 
 export interface AstValidationSummary {
   /** Post-edit validation status. */
@@ -26,6 +80,14 @@ export interface AstValidationSummary {
   /** One-line label suitable for LLM-facing output. */
   label: string;
 }
+
+/** Sentinel mapping representing a no-change edit (entire file is prefix). */
+const NO_CHANGE_MAPPING: CandidateMapping = {
+  prefixLines: Number.MAX_SAFE_INTEGER,
+  suffixLines: 0,
+  origLineCount: Number.MAX_SAFE_INTEGER,
+  lineDelta: 0,
+};
 
 /**
  * Extracts the leading line number from a validation error message such as
@@ -89,37 +151,191 @@ export function computeLineDelta(
 }
 
 /**
+ * Derives the candidate mapping from the ACTUAL original-to-candidate content
+ * diff, with explicit unchanged prefix and suffix boundaries. Used to classify
+ * both model content and IDE-accepted content that diverges from the model
+ * replacement. A diagnostic may match only through the unchanged prefix or
+ * unchanged suffix; diagnostics in the changed middle fail closed.
+ *
+ * Multi-hunk edits conservatively treat the span between the first and last
+ * changed line as the changed middle (even if some lines inside are
+ * unchanged). Returns a no-change mapping when candidate equals original or
+ * when original is null (new file).
+ */
+export function deriveCandidateMapping(
+  original: string | null,
+  candidate: string,
+): CandidateMapping {
+  if (original === null) {
+    return { ...NO_CHANGE_MAPPING };
+  }
+  if (original === candidate) {
+    const origLineCount = original.split('\n').length;
+    return {
+      prefixLines: origLineCount,
+      suffixLines: 0,
+      origLineCount,
+      lineDelta: 0,
+    };
+  }
+  const origLines = original.split('\n');
+  const candLines = candidate.split('\n');
+  const origLineCount = origLines.length;
+  const lineDelta = candLines.length - origLineCount;
+  // Longest common line prefix → first changed line (1-based).
+  const minLen = Math.min(origLines.length, candLines.length);
+  let prefix = 0;
+  while (prefix < minLen && origLines[prefix] === candLines[prefix]) {
+    prefix++;
+  }
+  // Longest common line suffix that does not overlap the prefix.
+  let suffix = 0;
+  while (
+    suffix < minLen - prefix &&
+    origLines[origLines.length - 1 - suffix] ===
+      candLines[candLines.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  return { prefixLines: prefix, suffixLines: suffix, origLineCount, lineDelta };
+}
+
+/**
  * Determines whether a pre-edit error line and a post-edit error line refer to
- * the same location, accounting for line shifts caused by the edit.
+ * the same location, using the candidate mapping's unchanged prefix/suffix
+ * boundaries.
  *
- * When the edit's start line is known, errors at or below the edit must have
- * shifted by `lineDelta`, while errors above it did not shift — this avoids the
- * false positive of matching a newly-introduced error to a nearby pre-existing
- * one. The validator emits deterministic line and column coordinates, so both
- * must match exactly after applying the known line shift.
- *
- * When the edit position is unknown, the two cases are made mutually exclusive
- * based on whether `lineDelta` is zero, which is the safest fallback.
+ * A diagnostic in the unchanged prefix (1-based lines 1..prefixLines) maps to
+ * the same line. A diagnostic in the unchanged suffix maps with a lineDelta
+ * shift. A diagnostic in the changed middle CANNOT be proven equivalent and
+ * must fail closed — this prevents accepting a different new error at the
+ * same/shifted coordinate inside replaced content. The validator emits
+ * deterministic line and column coordinates, so both must match exactly after
+ * applying the known line shift.
  */
 function locationsMatch(
   pre: ErrorLocation,
   post: ErrorLocation,
-  lineDelta: number,
-  editStartLine: number | null,
+  mapping: CandidateMapping,
 ): boolean {
   if (pre.column !== post.column) return false;
 
-  if (editStartLine !== null) {
-    if (pre.line > editStartLine) {
-      return pre.line + lineDelta === post.line;
-    }
-    if (pre.line === editStartLine) {
-      return false;
-    }
+  const { prefixLines, suffixLines, origLineCount, lineDelta } = mapping;
+
+  // Unchanged prefix: diagnostic did not shift.
+  if (pre.line <= prefixLines) {
     return pre.line === post.line;
   }
 
-  return lineDelta === 0 && pre.line === post.line;
+  // Unchanged suffix: diagnostic shifted by lineDelta.
+  const suffixStartOrig = origLineCount - suffixLines; // 0-based line where suffix begins
+  if (suffixLines > 0 && pre.line > suffixStartOrig) {
+    return pre.line + lineDelta === post.line;
+  }
+
+  // Changed middle: cannot prove equivalence → fail closed.
+  return false;
+}
+
+/**
+ * A diagnostic normalized for classification: whole-file recoveries carry no
+ * reliable coordinates (line/column null) but DO carry their raw endLine for
+ * span identity, precise diagnostics carry their 1-based parser coordinates.
+ * Derived from structured diagnostics when present, otherwise from display
+ * strings (backward compatibility — endLine is 0 when unknown).
+ */
+interface NormalizedDiagnostic {
+  wholeFileRecovery: boolean;
+  line: number | null;
+  column: number | null;
+  /** Raw 0-based end line from the parser; 0 when unavailable (string-only). */
+  endLine: number;
+  message: string;
+}
+
+/**
+ * Normalizes an AstValidationResult into classification-ready diagnostics.
+ * Prefers structured diagnostics (which preserve raw parser identity) and
+ * falls back to display-string parsing for callers that supply only strings.
+ */
+function toNormalized(result: AstValidationResult): NormalizedDiagnostic[] {
+  if (result.diagnostics && result.diagnostics.length > 0) {
+    return result.diagnostics.map((d) => ({
+      wholeFileRecovery: d.wholeFileRecovery,
+      line: d.wholeFileRecovery ? null : d.line + 1,
+      column: d.wholeFileRecovery ? null : d.column,
+      endLine: d.endLine,
+      message: d.message,
+    }));
+  }
+  return result.errors.map((err) => {
+    const wholeFileRecovery = err.includes('whole-file recovery');
+    if (wholeFileRecovery) {
+      return {
+        wholeFileRecovery,
+        line: null,
+        column: null,
+        endLine: 0,
+        message: err,
+      };
+    }
+    const loc = extractErrorLocation(err);
+    return {
+      wholeFileRecovery,
+      line: loc?.line ?? null,
+      column: loc?.column ?? null,
+      endLine: 0,
+      message: err,
+    };
+  });
+}
+
+/**
+ * Determines whether a post-edit diagnostic is equivalent to (i.e. explained
+ * by) a pre-edit diagnostic, using the candidate mapping for coordinate
+ * provenance.
+ *
+ * A whole-file recovery has no reliable start coordinates, so it is equivalent
+ * ONLY to a baseline whole-file recovery, and ONLY when the raw end-line span
+ * identity matches after adjustment through the unchanged suffix (or prefix for
+ * a no-change edit). A whole-file recovery cannot be proven equivalent to a
+ * precise baseline error → fail closed (returns false). This avoids blindly
+ * accepting a whole-file recovery whenever the baseline was merely "invalid"
+ * while still staying writable when an unchanged baseline whole-file recovery
+ * remains.
+ */
+function diagnosticsEquivalent(
+  pre: NormalizedDiagnostic,
+  post: NormalizedDiagnostic,
+  mapping: CandidateMapping,
+): boolean {
+  if (post.wholeFileRecovery) {
+    if (!pre.wholeFileRecovery) return false;
+    // Prove equivalence by raw end-line identity through the candidate mapping.
+    const { suffixLines, prefixLines, origLineCount, lineDelta } = mapping;
+    const suffixStartOrig = origLineCount - suffixLines;
+    if (suffixLines > 0 && pre.endLine >= suffixStartOrig) {
+      // End maps through the unchanged suffix (lineDelta shift).
+      return pre.endLine + lineDelta === post.endLine;
+    }
+    if (prefixLines >= origLineCount) {
+      // No-change edit: entire file is unchanged prefix.
+      return pre.endLine === post.endLine;
+    }
+    // End is in the changed middle → cannot prove equivalence → fail closed.
+    return false;
+  }
+  if (pre.wholeFileRecovery) {
+    return false;
+  }
+  if (post.line === null || pre.line === null) {
+    return false;
+  }
+  return locationsMatch(
+    { line: pre.line, column: pre.column ?? 0 },
+    { line: post.line, column: post.column ?? 0 },
+    mapping,
+  );
 }
 
 /**
@@ -128,14 +344,13 @@ function locationsMatch(
  *
  * @param preEdit - Validation result of the original file content.
  * @param postEdit - Validation result of the edited file content.
- * @param lineDelta - Net lines added/removed by the edit (for shift matching).
- * @param editStartLine - 1-based line where the edit begins (for precise matching).
+ * @param mapping - Candidate mapping with unchanged prefix/suffix boundaries.
+ *   Omitted when there is no content diff (everything is unchanged prefix).
  */
 export function summarizeAstValidation(
   preEdit: AstValidationResult | undefined,
   postEdit: AstValidationResult | undefined,
-  lineDelta = 0,
-  editStartLine: number | null = null,
+  mapping: CandidateMapping = NO_CHANGE_MAPPING,
 ): AstValidationSummary {
   if (!postEdit) {
     return {
@@ -146,6 +361,17 @@ export function summarizeAstValidation(
     };
   }
 
+  // Unsupported file types are never syntax-validated; report SKIPPED so the
+  // caller knows the edit is still allowed and not falsely "passing".
+  if (postEdit.supported === false) {
+    return {
+      status: 'SKIPPED',
+      preExisting: false,
+      newlyIntroduced: false,
+      label: 'SKIPPED (unsupported file type)',
+    };
+  }
+
   // Post-edit is valid.
   if (postEdit.valid) {
     if (preEdit && !preEdit.valid) {
@@ -153,7 +379,7 @@ export function summarizeAstValidation(
         status: 'PASSED',
         preExisting: false,
         newlyIntroduced: false,
-        label: `PASSED (edit may have resolved pre-existing error${formatLineLabel(preEdit.errors)})`,
+        label: `PASSED (edit resolved pre-existing error${formatLineLabel(preEdit.errors)})`,
       };
     }
     return {
@@ -166,10 +392,9 @@ export function summarizeAstValidation(
 
   // Post-edit is invalid.
   const postErrors = postEdit.errors;
-  const preHadErrors = preEdit !== undefined && !preEdit.valid;
 
   // Pre-edit was clean (or no baseline / new file) → the edit introduced the error.
-  if (!preHadErrors) {
+  if (preEdit === undefined || preEdit.valid) {
     return {
       status: 'FAILED',
       preExisting: false,
@@ -178,47 +403,54 @@ export function summarizeAstValidation(
     };
   }
 
-  // Both pre- and post-edit are invalid. Determine whether every post-edit
-  // error corresponds to the same location as a pre-edit one. Iterate over the
-  // raw error strings (not just those with parseable line numbers) so that
-  // unparseable post-edit errors are conservatively treated as unmatched
-  // rather than silently dropped.
-  const unmatchedPreLocations = preEdit.errors
-    .map(extractErrorLocation)
-    .filter((location): location is ErrorLocation => location !== null);
+  // Both pre- and post-edit are invalid. Compare EVERY diagnostic (not only the
+  // first) so an earlier pre-existing error cannot mask a later new one.
+  return categorizeBothInvalid(preEdit, postEdit, mapping);
+}
+
+/**
+ * Categorizes the case where both pre- and post-edit content are invalid.
+ * Compares EVERY post-edit diagnostic against the pre-edit diagnostics
+ * (accounting for candidate mapping and whole-file-recovery identity) so an
+ * earlier pre-existing error cannot mask a newly introduced later error.
+ */
+function categorizeBothInvalid(
+  preEdit: AstValidationResult,
+  postEdit: AstValidationResult,
+  mapping: CandidateMapping,
+): AstValidationSummary {
+  const preNorm = toNormalized(preEdit);
+  const postNorm = toNormalized(postEdit);
+  const pool = [...preNorm];
   let matchedCount = 0;
-  let allMatched = postErrors.length > 0;
-  for (const postErr of postErrors) {
-    const postLocation = extractErrorLocation(postErr);
-    const matchingIndex =
-      postLocation === null
-        ? -1
-        : unmatchedPreLocations.findIndex((preLocation) =>
-            locationsMatch(preLocation, postLocation, lineDelta, editStartLine),
-          );
+  const unmatchedPostMessages: string[] = [];
+  for (const post of postNorm) {
+    const matchingIndex = pool.findIndex((pre) =>
+      diagnosticsEquivalent(pre, post, mapping),
+    );
     if (matchingIndex === -1) {
-      allMatched = false;
-      break;
+      unmatchedPostMessages.push(post.message);
+    } else {
+      matchedCount++;
+      pool.splice(matchingIndex, 1);
     }
-    matchedCount++;
-    unmatchedPreLocations.splice(matchingIndex, 1);
   }
 
-  if (allMatched) {
+  if (postNorm.length > 0 && unmatchedPostMessages.length === 0) {
     return {
       status: 'FAILED',
       preExisting: true,
       newlyIntroduced: false,
-      label: `FAILED (pre-existing error${formatLineLabel(postErrors)} — present before this edit)`,
+      label: `FAILED (pre-existing error${formatLineLabel(postEdit.errors)} — present before this edit)`,
     };
   }
 
-  // File was already broken, but the post-edit errors don't line up with the
-  // pre-existing ones. They may be cascading from the same root cause or newly
-  // introduced; surface both for the LLM to judge.
+  // File was already broken, but some post-edit errors do not line up with the
+  // pre-existing ones. List only the unmatched (genuinely new) post errors as
+  // "may be newly introduced" so the message stays coherent (Finding 5).
   return formatMixedValidationSummary(
     preEdit.errors,
-    postErrors,
+    unmatchedPostMessages,
     matchedCount > 0,
   );
 }

--- a/packages/tools/src/tools/ast-edit/validation-categorizer.ts
+++ b/packages/tools/src/tools/ast-edit/validation-categorizer.ts
@@ -44,6 +44,12 @@ export interface AstDiagnostic {
   readonly column: number;
   /** 0-based end line; used to detect whole-file recovery spans. */
   readonly endLine: number;
+  /**
+   * 0-based end column from the parser. Optional for backward compatibility
+   * with structured fixtures that predate it; the parser always supplies it,
+   * and whole-file-recovery span identity requires it.
+   */
+  readonly endColumn?: number;
   /** True when this is a whole-file tree-sitter recovery node (1:1, spans lines). */
   readonly wholeFileRecovery: boolean;
   /** Human-readable message (display location refined to the edit region when applicable). */
@@ -239,10 +245,11 @@ function locationsMatch(
 
 /**
  * A diagnostic normalized for classification: whole-file recoveries carry no
- * reliable coordinates (line/column null) but DO carry their raw endLine for
- * span identity, precise diagnostics carry their 1-based parser coordinates.
- * Derived from structured diagnostics when present, otherwise from display
- * strings (backward compatibility — endLine is 0 when unknown).
+ * reliable start coordinates (line/column null) but DO carry their raw end span
+ * (end line AND end column) for identity, precise diagnostics carry their
+ * 1-based parser coordinates. Derived from structured diagnostics when present,
+ * otherwise from display strings (backward compatibility — endLine is 0 and
+ * endColumn is undefined when unknown).
  */
 interface NormalizedDiagnostic {
   wholeFileRecovery: boolean;
@@ -250,6 +257,8 @@ interface NormalizedDiagnostic {
   column: number | null;
   /** Raw 0-based end line from the parser; 0 when unavailable (string-only). */
   endLine: number;
+  /** Raw 0-based end column; undefined when unavailable (string-only caller). */
+  endColumn: number | undefined;
   message: string;
 }
 
@@ -265,6 +274,7 @@ function toNormalized(result: AstValidationResult): NormalizedDiagnostic[] {
       line: d.wholeFileRecovery ? null : d.line + 1,
       column: d.wholeFileRecovery ? null : d.column,
       endLine: d.endLine,
+      endColumn: d.endColumn,
       message: d.message,
     }));
   }
@@ -276,6 +286,7 @@ function toNormalized(result: AstValidationResult): NormalizedDiagnostic[] {
         line: null,
         column: null,
         endLine: 0,
+        endColumn: undefined,
         message: err,
       };
     }
@@ -285,6 +296,7 @@ function toNormalized(result: AstValidationResult): NormalizedDiagnostic[] {
       line: loc?.line ?? null,
       column: loc?.column ?? null,
       endLine: 0,
+      endColumn: undefined,
       message: err,
     };
   });
@@ -296,13 +308,15 @@ function toNormalized(result: AstValidationResult): NormalizedDiagnostic[] {
  * provenance.
  *
  * A whole-file recovery has no reliable start coordinates, so it is equivalent
- * ONLY to a baseline whole-file recovery, and ONLY when the raw end-line span
- * identity matches after adjustment through the unchanged suffix (or prefix for
- * a no-change edit). A whole-file recovery cannot be proven equivalent to a
- * precise baseline error → fail closed (returns false). This avoids blindly
- * accepting a whole-file recovery whenever the baseline was merely "invalid"
- * while still staying writable when an unchanged baseline whole-file recovery
- * remains.
+ * ONLY to a baseline whole-file recovery, and ONLY when the raw END-span
+ * identity (end line AND end column) matches after adjustment through the
+ * unchanged suffix (or prefix for a no-change edit). An unknown end column
+ * (string-only caller) cannot prove identity → fail closed (returns false), so
+ * a different/new recovery is never silently trusted as pre-existing. A
+ * whole-file recovery cannot be proven equivalent to a precise baseline error
+ * → fail closed. This avoids blindly accepting a whole-file recovery whenever
+ * the baseline was merely "invalid" while still staying writable when an
+ * unchanged baseline whole-file recovery remains.
  */
 function diagnosticsEquivalent(
   pre: NormalizedDiagnostic,
@@ -311,16 +325,25 @@ function diagnosticsEquivalent(
 ): boolean {
   if (post.wholeFileRecovery) {
     if (!pre.wholeFileRecovery) return false;
-    // Prove equivalence by raw end-line identity through the candidate mapping.
+    // Prove equivalence by raw END-span identity (line AND column) through the
+    // candidate mapping. A missing end column means no structured span identity
+    // (string-only caller) → fail closed.
+    if (pre.endColumn === undefined || post.endColumn === undefined) {
+      return false;
+    }
     const { suffixLines, prefixLines, origLineCount, lineDelta } = mapping;
     const suffixStartOrig = origLineCount - suffixLines;
     if (suffixLines > 0 && pre.endLine >= suffixStartOrig) {
-      // End maps through the unchanged suffix (lineDelta shift).
-      return pre.endLine + lineDelta === post.endLine;
+      // End maps through the unchanged suffix (lineDelta shift); the end column
+      // lies within an unchanged line, so it must match exactly.
+      return (
+        pre.endLine + lineDelta === post.endLine &&
+        pre.endColumn === post.endColumn
+      );
     }
     if (prefixLines >= origLineCount) {
       // No-change edit: entire file is unchanged prefix.
-      return pre.endLine === post.endLine;
+      return pre.endLine === post.endLine && pre.endColumn === post.endColumn;
     }
     // End is in the changed middle → cannot prove equivalence → fail closed.
     return false;

--- a/packages/tools/src/types/tool-error.ts
+++ b/packages/tools/src/types/tool-error.ts
@@ -50,6 +50,7 @@ export enum ToolErrorType {
   EDIT_NO_CHANGE_LLM_JUDGEMENT = 'edit_no_change_llm_judgement',
   FILE_MODIFIED_CONFLICT = 'file_modified_conflict',
   PATCH_APPLY_FAILURE = 'patch_apply_failure',
+  AST_SYNTAX_ERROR = 'ast_syntax_error',
 
   // Glob-specific Errors
   GLOB_EXECUTION_ERROR = 'glob_execution_error',

--- a/project-plans/issue3035/plan.md
+++ b/project-plans/issue3035/plan.md
@@ -1,0 +1,153 @@
+# Issue 3035 Plan: Make `ast_edit` validation authoritative and its contract accurate
+
+Plan ID: PLAN-20260804-AST-EDIT-AX
+Generated: 2026-08-04
+Issue: https://github.com/vybestack/llxprt-code/issues/3035
+
+## Accepted behavior
+
+### REQ-3035-1: Document the two-step contract
+
+**Given** an agent inspects the `ast_edit` parameter schema,
+**when** it reads the `force` parameter,
+**then** the description states that an omitted/false value previews and `true` applies.
+
+The existing preview/apply design remains; `force` is not repurposed as a validation bypass.
+
+### REQ-3035-2: Refuse newly broken AST writes
+
+**Given** apply mode receives an edit whose final candidate content introduces an AST syntax error,
+**when** validation compares the candidate with the pre-edit file,
+**then** the tool returns a typed failure before writing and the file remains byte-for-byte unchanged.
+
+Pre-existing-only syntax errors do not block an otherwise valid edit. Unsupported file types are not treated as syntax failures. No public override parameter is added.
+
+### REQ-3035-3: Report useful syntax locations
+
+**Given** tree-sitter provides a specific error location,
+**when** the tool reports the diagnostic,
+**then** that location is preserved.
+
+**Given** tree-sitter reports a whole-file recovery error beginning at line 1 for damage introduced later in the file,
+**when** the tool reports the new error,
+**then** it identifies the edited region rather than falsely pointing to line 1.
+
+### REQ-3035-4: Keep validation messaging coherent
+
+**Given** an edit resolves a pre-existing syntax error,
+**when** apply succeeds,
+**then** the result reports that validation passed/resolved the prior error and does not also claim pre-existing errors remain.
+
+**Given** the post-edit file still has only pre-existing errors,
+**when** apply succeeds,
+**then** the result may identify those remaining errors without classifying them as newly introduced.
+
+### REQ-3035-5: Distinguish unsupported files from validated files
+
+**Given** the edited extension has no supported AST language,
+**when** preview or apply reports validation,
+**then** it says validation was skipped for an unsupported file type, not passed, and the edit remains writable.
+
+### REQ-3035-6: Keep previews targeted
+
+**Given** an ordinary preview,
+**when** context is rendered,
+**then** it omits `WORKING SET CONTEXT` and retains the target file's `ENHANCED CONTEXT ANALYSIS`.
+
+No new opt-in schema, setting, or context subsystem is introduced.
+
+### REQ-3035-7: Do not extract code symbols from prose
+
+**Given** Markdown, YAML, text, or another unsupported file contains words such as `classification`, `default`, or `specifies`,
+**when** declarations are extracted,
+**then** no guessed code declarations are returned.
+
+Fallback extraction for a supported code language that fails normal parsing may remain.
+
+### REQ-3035-8: Report file creation as creation
+
+**Given** apply mode creates a new file with an empty `old_string`,
+**when** the write succeeds,
+**then** the response identifies file creation and does not report zero replacements.
+
+Existing-file edits continue to report replacement counts.
+
+### REQ-3035-9: Make concurrency errors actionable
+
+**Given** `last_modified` is stale,
+**when** preview or apply rejects the edit,
+**then** the error remains `FILE_MODIFIED_CONFLICT`, is a plain human-readable string rather than encoded JSON, includes supplied and current timestamps, and tells the caller to re-read and retry.
+
+## Inputs and boundary cases
+
+- Preview: `force` omitted or false; no disk mutation.
+- Apply: `force: true`; validation applies to the exact final candidate content.
+- Existing clean AST file becomes invalid: reject without mutation.
+- Existing invalid AST file remains invalid without a new error: allow and identify pre-existing state.
+- Existing invalid AST file becomes valid: allow and report resolution coherently.
+- New AST file is invalid: reject and do not create it.
+- Unsupported file type: validation is skipped, not failed, and writing remains allowed.
+- Parser gives a precise error node: retain it.
+- Parser gives a whole-program recovery node at 1:1: identify the edited region.
+- IDE-accepted content, if present, is the candidate that must be validated before write.
+- Stale mtime always wins over `force`; no write occurs.
+
+## Test-first implementation sequence
+
+1. Add or migrate Bun behavioral tests that fail against current behavior:
+   - schema wording;
+   - newly introduced broken-brace edit is rejected and the original file remains unchanged;
+   - invalid new file is not created;
+   - pre-existing-only errors remain writable;
+   - error line for the reported brace fixture is near the edit, while already precise parser locations remain precise;
+   - resolved/pre-existing messages do not contradict each other;
+   - Markdown/text validation is skipped and remains writable;
+   - preview omits working-set context but keeps enhanced target context;
+   - prose extraction returns no declarations;
+   - creation wording;
+   - plain actionable mtime mismatch.
+2. Run the focused tests and record the expected failures before production changes.
+3. Implement the smallest production changes that satisfy the tests:
+   - represent unsupported validation explicitly;
+   - calculate validation against final candidate content before write;
+   - reject newly introduced errors with the existing tool-result error path and a dedicated internal error type if needed;
+   - refine whole-file parser recovery locations using the known edit region;
+   - correct summary/message branches;
+   - remove working-set rendering/collection from preview;
+   - skip declaration extraction for unsupported languages;
+   - branch apply success wording for creation;
+   - replace encoded mtime JSON with actionable text;
+   - update the schema description.
+4. Run focused tests, the tools workspace suite, and the repository-wide verification gates.
+
+## Integration contract
+
+The existing `ASTEditTool` schema remains the user access point. `ASTEditToolInvocation` remains the preview/apply orchestrator. `calculateEdit`, AST validation, and validation categorization remain internal collaborators. No new registration, command, dependency, workflow, setting, or public abstraction is needed.
+
+The authoritative operation order in apply mode is:
+
+1. Verify path, parameters, occurrences, and `last_modified`.
+2. Produce the final candidate content, including IDE-accepted content when applicable.
+3. Compare candidate AST status with pre-edit AST status.
+4. If a newly introduced syntax error exists, return an error without writing.
+5. Otherwise write once and report an accurate outcome.
+
+## Scope exclusions
+
+- No syntax-validation bypass or new override parameter.
+- No opt-in working-set-context configuration.
+- No adjacent editor-tool cleanup.
+- No new dependency, workflow, quality-tool, agent-memory, or lint/config changes.
+- No unrelated refactor or test migration.
+
+## Verification gates
+
+- Focused Bun tests for every accepted behavior.
+- `npm run test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run format`
+- `npm run build`
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+- DeepThinker review and Open Code Review, with every finding classified as Blocker-Fix, In-scope-Fix, Reject, or Defer.
+- PR CI green, CodeRabbit threads triaged/resolved, branch conflict-free, and candidate head descended from current `origin/main`.

--- a/scripts/bun-test-manifest-data-tools.ts
+++ b/scripts/bun-test-manifest-data-tools.ts
@@ -36,6 +36,8 @@ export const TOOLS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
     'src/tools/generate-image/GenerateImageTool.test.ts',
     'src/tools/generate-image/GenerateImageTool.surface.test.ts',
     'src/tools/ast-edit/__tests__/ast-edit-issue-1756.test.ts',
+    'src/tools/ast-edit/__tests__/ast-edit-issue-3035.test.ts',
+    'src/tools/ast-edit/__tests__/ast-edit-issue-3035-review.test.ts',
     'src/tools/ast-edit/__tests__/ast-edit-summary-counts.test.ts',
     'src/tools/ast-edit/__tests__/ast-edit-rust-validation.test.ts',
     'src/tools/ast-edit/__tests__/validation-categorizer.test.ts',


### PR DESCRIPTION
## TLDR

Makes `ast_edit` syntax validation authoritative: apply now validates the exact final candidate before any filesystem mutation and refuses newly introduced syntax damage with a typed error. It also documents the real preview/apply contract, reports unsupported files and parser recovery honestly, and removes noisy working-set context from edit previews without changing `ast_read_file` behavior.

## Dive Deeper

- documents that omitted/false `force` previews and `force: true` applies, while syntax validation is always enforced
- collects and compares every parser diagnostic so existing damage cannot mask a newly introduced error
- conservatively maps diagnostics through unchanged prefix/suffix regions, including IDE-edited final candidates and whole-file parser recovery
- blocks invalid existing-file edits and invalid new-file creation before directory creation or disk writes
- keeps pre-existing-only syntax errors and unsupported file types writable
- reports unsupported AST validation as skipped, resolved errors coherently, retained errors at current locations, and new-file creation accurately
- emits actionable plain-text stale-mtime conflicts with both timestamps and retry guidance
- omits working-set context from `ast_edit` preview while preserving target-file enhanced context and `ast_read_file` working-set output
- avoids declaration extraction from unsupported prose files
- records accepted behavior and boundaries in `project-plans/issue3035/plan.md`

## Reviewer Test Plan

1. Run the tools workspace Bun suite:

       cd packages/tools && npm run test

2. Exercise `ast_edit` against a valid TypeScript file:
   - omit `force` and confirm it previews without writing
   - repeat with `force: true` and invalid syntax, then confirm it returns `ast_syntax_error` and leaves the file unchanged
   - repeat with valid syntax and confirm it writes
3. Exercise a file with a pre-existing parser error:
   - make a harmless edit and confirm it remains writable
   - introduce a second error and confirm the write is refused
4. Exercise a Markdown file and confirm validation says skipped while the edit remains writable.
5. Confirm edit previews omit `WORKING SET CONTEXT` but retain `ENHANCED CONTEXT ANALYSIS`; confirm `ast_read_file` still includes working-set context.

Local evidence on macOS:
- focused issue/OCR suites: 102 passed
- full tools workspace: 78/78 isolated Bun files passed
- changed-file ESLint and Prettier checks passed
- full typecheck, format, build, and stepfun-37 smoke test passed
- full root test reruns reached unrelated unchanged timeout failures in agents tests; CI is the authoritative clean-run gate
- full root lint reports inherited await-thenable failures in unchanged packages; changed issue files pass ESLint

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3035
