### PR TITLE
Stop the CLI bundle baking build-machine paths (Fixes #3055)

### DIFF
--- a/project-plans/issue-3055-bundle-build-path-leak.md
+++ b/project-plans/issue-3055-bundle-build-path-leak.md
@@ -1,0 +1,186 @@
+# Issue #3055 — prebuilt CLI bundle bakes build-machine absolute paths
+
+## Symptom
+
+Launching the installed nightly dies at startup before any CLI code runs:
+
+    error: Missing tiktoken_bg.wasm
+      at <anonymous> (...\@vybestack\llxprt-code\bundle\llxprt.js:194745:11)
+
+Reported on Windows. It is **not** Windows-specific — see "Reproduction" below.
+
+## Root cause
+
+PR #3013 (issue #2999) introduced a prebuilt CLI bundle:
+
+- `scripts/bun-build.config.ts` exports `cliBundleConfig`, which runs
+  `Bun.build({ target: 'bun' })` over `packages/cli/index.ts` and emits
+  `packages/cli/bundle/llxprt.js`.
+- `packages/cli/package.json` lists `bundle` in `files`, so the artifact ships.
+- `packages/cli/bin/llxprt` prefers `<pkg>/bundle/llxprt.js` over `index.ts`
+  whenever the bundle exists.
+
+`@dqbd/tiktoken` ships a CommonJS entry (`tiktoken.cjs`) that locates its WASM
+payload from `__dirname`. When Bun inlines a CommonJS module it materialises
+`__dirname` as a **string literal fixed at build time**. The emitted bundle
+contains:
+
+    var __dirname = "/Volumes/XS1000/.../node_modules/@dqbd/tiktoken";
+    ...
+    candidates.unshift(path.join(__dirname, "./tiktoken_bg.wasm"));
+    ...
+    if (bytes == null) throw new Error("Missing tiktoken_bg.wasm");
+
+The remaining candidates are `<ancestor>/node_modules/tiktoken/tiktoken_bg.wasm`
+built by walking that same baked path — and they use the *unscoped* name
+`tiktoken`, so they never match `@dqbd/tiktoken` on any machine, including the
+builder. The only candidate that ever resolves is the literal build-machine
+path.
+
+Consequences:
+
+1. On the build machine the path exists, so every test and smoke passes.
+2. On any other machine no candidate resolves and the module throws **at import
+   time**, so the CLI cannot start at all.
+3. The published artifact embeds the release engineer's absolute filesystem
+   path, which is leaked verbatim in user-facing stack traces.
+
+`a2aServerConfig` in the same file already guards this hazard with
+`portableTiktokenPlugin`. `cliBundleConfig` has no `plugins` entry, so the
+guard was never applied to the CLI bundle.
+
+Two further modules leak build-machine paths into the same artifact:
+
+- `config-chain` — `find(__dirname, rel)` — but `config-chain` is NOT a direct
+  dependency of `packages/cli`; it is a transitive dependency owned by
+  `@pnpm/npm-conf` (under `update-notifier`'s graph). Externalizing it at the
+  CLI level moves the resolution owner to the wrong package — see "Fix" below.
+- `yargs/build/index.cjs` — `y18n({ directory: resolve(__dirname, '../locales') })`,
+  which silently degrades localisation rather than throwing.
+
+## Why CI did not catch it
+
+`scripts/tests/issue-2999-cli-bundle.bun.test.ts` builds the bundle and runs
+`--version` **from the repo checkout**, where the baked path is still valid.
+The Windows installed-command smoke installs a tarball packed on the same
+runner, so the baked path is likewise still valid there. No existing check can
+observe a build-tree dependency, because every check runs on the build tree.
+
+## Reproduction (macOS, main @ 5c2dc30b4)
+
+    bun scripts/bun-build.config.ts --cli-only
+    bun packages/cli/bundle/llxprt.js --version          # -> 0.11.0
+
+    mv node_modules/@dqbd/tiktoken node_modules/@dqbd/tiktoken__hidden
+    bun packages/cli/bundle/llxprt.js --version          # -> Missing tiktoken_bg.wasm
+    mv node_modules/@dqbd/tiktoken__hidden node_modules/@dqbd/tiktoken
+
+Hiding the build-time location is exactly what installing on a different
+machine does.
+
+## Fix
+
+### Ownership rule (invariant)
+
+Every module the CLI bundle marks external must be a **declared direct
+dependency of `packages/cli/package.json`** (the published package that ships
+the bundle). Only a direct dependency guarantees its runtime resolution from
+`<pkg>/bundle/llxprt.js`: the package manager installs it in the published
+package's own `node_modules` scope, so `require("<name>")` from the bundle
+finds the *right* copy. A transitive dependency that merely appears somewhere
+in `node_modules` does NOT give this guarantee — it may be hoisted, shadowed by
+a consumer's conflicting version, or absent entirely depending on the
+consumer's install tree. Presence somewhere in `node_modules` and
+resolvability from a specific importer are different guarantees.
+
+### What was changed
+
+1. `@dqbd/tiktoken` stays external — it is a declared direct dependency of
+   `packages/cli` and locates tiktoken_bg.wasm via `__dirname`. Keeping it
+   external lets Bun resolve it from `node_modules` at launch, so `__dirname`
+   points at the *installed* package. This restores the pre-#3013 resolution
+   path exactly, and matches the established pattern already used for
+   `require.resolve('tree-sitter-bash/tree-sitter-bash.wasm')`.
+
+2. `config-chain` was removed from the CLI external list and replaced with
+   `update-notifier`, its direct-dependency owner. `config-chain` is owned by
+   `@pnpm/npm-conf` (under `update-notifier -> latest-version -> package-json
+   -> registry-auth-token -> @pnpm/npm-conf -> config-chain`). Externalizing
+   `config-chain` at the CLI level moved the resolution owner to the CLI
+   package, where no package manager guarantees it resolves — it only worked
+   by accidental hoisting. Externalizing `update-notifier` instead keeps the
+   entire transitive graph (including `config-chain`) resolving from
+   `update-notifier`'s own package scope, where `config-chain` is a guaranteed
+   dependency of `@pnpm/npm-conf`.
+
+3. `yargs` stays external — it is a declared direct dependency of
+   `packages/cli` and resolves its locale directory relative to `__dirname`.
+
+4. The a2a-server bundle keeps its current inlining and
+   `portableTiktokenPlugin` treatment; it is a separately packaged,
+   self-contained artifact and must not regress.
+
+### Ownership-contract test
+
+`scripts/tests/issue-3055-cli-externals-ownership.bun.test.ts` reads the real
+`packages/cli/package.json` manifest and asserts every entry in
+`CLI_DIRNAME_DEPENDENT_EXTERNALS` is a declared direct dependency. It fails
+if someone adds an undeclared transitive package (proven against the
+`config-chain` entry that caused the original defect). It is cheap and
+deterministic: no npm install, no network, no mocks — just `JSON.parse` of the
+committed manifests.
+
+### Purity guard
+
+`scripts/tests/issue-3055-bundle-purity.bun.test.ts` builds the real CLI
+bundle and asserts the emitted `llxprt.js` contains no absolute path rooted at
+the repository/build root. It scans for both the raw OS path and its
+JavaScript-escaped form (`JSON.stringify`, which doubles backslashes on
+Windows), and also covers `realpathSync(repoRoot)` because Bun may canonicalize
+a symlinked checkout. This generalises beyond tiktoken: it catches the next
+dependency that bakes `__dirname`, and it also closes the path-disclosure leak.
+
+### Relocated-runtime test
+
+`scripts/tests/issue-3055-tiktoken-relocated.bun.test.ts` builds a fixture
+entry that imports `@dqbd/tiktoken` and encodes a string, using the CLI bundle's
+`external` policy, against a temporary `node_modules` we own. Delete that
+temporary `node_modules`, place an equivalent one beside the relocated bundle,
+and execute. Passes with the module external; reproduces `Missing
+tiktoken_bg.wasm` when inlined. Asserts a positive integer token count, not
+just any digit string.
+
+## Tests (must fail on main, pass after the fix)
+
+- **Artifact purity.** Build `cliBundleConfig` and assert the emitted
+  `llxprt.js` contains no absolute path rooted at the repository root. Fails on
+  main (three such paths). Deterministic, no network, no mocks.
+- **Relocated-runtime behaviour.** Build a fixture entry that imports
+  `@dqbd/tiktoken` and encodes a string, using the CLI bundle's `external`
+  policy, against a temporary `node_modules` we own. Delete that temporary
+  `node_modules`, place an equivalent one beside the relocated bundle, and
+  execute. Passes with the module external; reproduces `Missing
+  tiktoken_bg.wasm` when inlined. This is the automated form of the manual
+  reproduction above.
+- **Ownership contract.** Reads the real manifests and asserts every
+  `CLI_DIRNAME_DEPENDENT_EXTERNALS` entry is a declared direct dependency of
+  `packages/cli`. Fails against the `config-chain` entry that caused the defect.
+
+## Packed/installed conflict test evaluation
+
+The reviewer suggested a full packed/installed regression with a synthetic
+dependency conflict (a conflicting `config-chain` at the consumer level). The
+manifest invariant test is the **stronger and cheaper guard**: it catches the
+defect class at the source — before the bundle is even built — by checking that
+every externalized module is a direct dependency whose resolution is
+guaranteed. A packed/installed conflict test would only catch the specific
+`config-chain` scenario, requires building a synthetic `node_modules` tree
+and a packed tarball, and adds significant runtime. The manifest invariant
+subsumes it: if `config-chain` is never externalized (because it is not a direct
+dependency), the conflict scenario cannot arise. The manifest test is
+preferred.
+
+## Out of scope
+
+Changing the a2a-server bundle strategy, revisiting the #2999 launch-cost
+optimisation, or reworking `portable-tiktoken-plugin.ts` for the a2a target.

--- a/scripts/bun-build.config.ts
+++ b/scripts/bun-build.config.ts
@@ -74,6 +74,54 @@ export const EXTERNALS = [
   'chokidar',
 ];
 
+/**
+ * Modules whose runtime behaviour depends on their own `__dirname` and so MUST
+ * stay external to the CLI bundle.
+ *
+ * When Bun inlines a CommonJS module it freezes `__dirname` as a build-time
+ * string literal. Any dependency that locates a runtime asset (WASM, locales,
+ * config files) relative to its own `__dirname` then ships the *build
+ * machine's* absolute path baked into the artifact: that path resolves only on
+ * the builder and leaks the release engineer's filesystem layout into user
+ * stack traces. Keeping such modules external lets Bun resolve them from
+ * `node_modules` at launch, so `__dirname` points at the *installed* package —
+ * exactly the resolution the pre-bundle TypeScript launch always used.
+ *
+ * **Ownership rule (invariant):** every entry MUST be a declared direct
+ * dependency of `packages/cli/package.json` (the published package that ships
+ * the bundle). Only a direct dependency guarantees its runtime resolution from
+ * `<pkg>/bundle/llxprt.js`: the package manager installs it in the published
+ * package's own `node_modules` scope, so `require("<name>")` from the bundle
+ * finds the *right* copy. A transitive dependency that merely appears somewhere
+ * in `node_modules` does NOT give this guarantee — it may be hoisted, shadowed
+ * by a consumer's conflicting version, or absent entirely depending on the
+ * consumer's install tree. That was the defect behind issue #3055:
+ * `config-chain` is owned by `@pnpm/npm-conf` (under `update-notifier`'s
+ * transitive graph), so externalizing it moved the resolution owner to the CLI
+ * package, where no package manager guarantees it resolves.
+ *
+ * Enforced by `scripts/tests/issue-3055-cli-externals-ownership.bun.test.ts`.
+ *
+ * This list is deliberately separate from `EXTERNALS`: the a2a-server bundle is
+ * a self-contained artifact that inlines its dependencies and already
+ * neutralises tiktoken via `portableTiktokenPlugin`, so forcing these external
+ * there would break that strategy.
+ */
+export const CLI_DIRNAME_DEPENDENT_EXTERNALS = [
+  // Locates tiktoken_bg.wasm via __dirname; throws "Missing tiktoken_bg.wasm"
+  // at import time when the baked build-machine path is absent (issue #3055).
+  '@dqbd/tiktoken',
+  // Direct dependency of packages/cli. Its transitive graph includes
+  // @pnpm/npm-conf -> config-chain, which walks __dirname to find npm-style
+  // config files. Externalizing update-notifier (not config-chain) keeps the
+  // entire transitive graph resolving from update-notifier's own package
+  // scope, where config-chain is a guaranteed dependency of @pnpm/npm-conf.
+  'update-notifier',
+  // Resolves its locale directory relative to __dirname; a baked path silently
+  // degrades CLI localisation.
+  'yargs',
+] as const;
+
 const tiktokenWasmSource = require.resolve('@dqbd/tiktoken/tiktoken_bg.wasm');
 
 // a2a-server bundle: packages/a2a-server/src/http/server.ts -> dist/a2a-server.mjs
@@ -112,7 +160,7 @@ const a2aServerConfig: Parameters<typeof Bun.build>[0] = {
  */
 export const cliBundleConfig: Parameters<typeof Bun.build>[0] = {
   target: 'bun',
-  external: EXTERNALS,
+  external: [...EXTERNALS, ...CLI_DIRNAME_DEPENDENT_EXTERNALS],
   loader: { '.node': 'file' },
   minify: false,
   splitting: false,

--- a/scripts/tests/issue-3055-bundle-purity.bun.test.ts
+++ b/scripts/tests/issue-3055-bundle-purity.bun.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3055 — the shipped CLI bundle must not bake the build machine's
+ * absolute filesystem path into the artifact.
+ *
+ * When Bun inlines a CommonJS module it freezes `__dirname` as a build-time
+ * string literal. Dependencies that locate runtime assets (WASM, locales,
+ * config) relative to their own `__dirname` then ship the *builder's* path,
+ * which resolves only on the build machine and leaks the release engineer's
+ * filesystem layout into user stack traces. `@dqbd/tiktoken` throws
+ * "Missing tiktoken_bg.wasm" at import time on every other machine, killing
+ * the CLI before any of our code runs.
+ *
+ * This guard builds the real CLI bundle and asserts the emitted `llxprt.js`
+ * contains no absolute path rooted at the repository/build root. It generalises
+ * beyond tiktoken: the next dependency that bakes `__dirname` fails here, named
+ * explicitly in the failure message.
+ *
+ * The build is invoked as a child process (`scripts/bun-build.config.ts
+ * --cli-only`) rather than `Bun.build(cliBundleConfig)` in-process. The
+ * production `prepack` step invokes the exact same entry point, so this
+ * exercises the real artefact pipeline; and the in-repo `bunfig.toml` test
+ * preload interferes with Bun.build's resolution of the CLI entry's dynamic
+ * `import('./src/cli.js')` when run under `bun test`, so a fresh process is
+ * both more faithful and more reliable.
+ *
+ * Unlike the launch smoke (`issue-2999-cli-bundle.bun.test.ts`), this guard is
+ * NOT gated behind `LLXPRT_RUN_BUNDLE_BUILD_TEST`, so it runs in the `scripts`
+ * shard on every PR that touches the bundle config or any dependency
+ * (`package.json` / lockfiles are shared inputs that force a full run).
+ */
+
+import { afterAll, describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(__filename, '..', '..', '..');
+const bundleDir = join(repoRoot, 'packages', 'cli', 'bundle');
+const bundlePath = join(bundleDir, 'llxprt.js');
+
+afterAll(() => {
+  // The bundle is a gitignored publish artifact; remove it so a stale build
+  // can never satisfy a future run or interfere with the launch smoke.
+  rmSync(bundleDir, { recursive: true, force: true });
+});
+
+describe('issue #3055: prebuilt CLI bundle is free of build-tree paths', () => {
+  it('the shipped llxprt.js contains no absolute path rooted at the repo root', () => {
+    // Start from a clean slate so a stale artifact can never satisfy the check.
+    rmSync(bundleDir, { recursive: true, force: true });
+
+    // Build the real CLI bundle via the production entry point. process.execPath
+    // is the Bun binary running this test; a fresh process avoids the in-test
+    // bunfig preload that interferes with Bun.build's dynamic-import resolution.
+    const build = spawnSync(
+      process.execPath,
+      ['scripts/bun-build.config.ts', '--cli-only'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        timeout: 120_000,
+        env: { ...process.env, CI: 'true' },
+      },
+    );
+    // Assert spawn health BEFORE status: when spawnSync fails to spawn
+    // (ENOENT) or kills the child on timeout, build.status is null and the
+    // real cause lives in build.error / build.signal. Asserting these first
+    // names the actual failure mode instead of masking it as
+    // "expected null to be 0" with empty streams.
+    expect(
+      build.error,
+      `CLI bundle build failed to spawn (ENOENT or unavailable binary): ${
+        build.error instanceof Error ? build.error.message : String(build.error)
+      }`,
+    ).toBeUndefined();
+    expect(
+      build.signal,
+      `CLI bundle build was killed by signal ${build.signal} (likely timeout).\n` +
+        `stdout: ${build.stdout}\nstderr: ${build.stderr}`,
+    ).toBeNull();
+    expect(
+      build.status,
+      `CLI bundle build failed (exit ${build.status}).\nstdout: ${build.stdout}\nstderr: ${build.stderr}`,
+    ).toBe(0);
+    expect(existsSync(bundlePath)).toBe(true);
+
+    const contents = readFileSync(bundlePath, 'utf8');
+
+    // Any dependency that bakes __dirname emits the build root as a string
+    // literal. Scanning for the repo root catches every such leak without
+    // naming individual packages, so this stays correct as deps drift — and
+    // it closes the path-disclosure leak in one general rule.
+    //
+    // We scan for BOTH the raw OS path and its JavaScript-escaped form
+    // (JSON.stringify, which doubles backslashes on Windows). Bun emits
+    // string literals in the bundle using double quotes, but the exact
+    // escaping depends on the Bun version and the path separator. On Windows
+    // the raw repoRoot is `C:\work\repo`, but Bun emits `"C:\\work\\repo\\..."`
+    // (the JavaScript-escaped form). A regex built from the raw path uses
+    // unescaped backslashes and would never match on Windows, silently
+    // passing the guard. We also cover realpathSync(repoRoot) because Bun
+    // may canonicalize a symlinked checkout, emitting the real path rather
+    // than the logical one.
+    const pathForms = new Set<string>();
+    for (const basePath of [repoRoot, realpathSync(repoRoot)]) {
+      pathForms.add(basePath);
+      pathForms.add(JSON.stringify(basePath).slice(1, -1));
+    }
+
+    const offending: string[] = [];
+    for (const pathForm of pathForms) {
+      if (pathForm.length === 0) continue;
+      const pattern = new RegExp(`${escapeRegExp(`"${pathForm}`)}[^"]*"`, 'g');
+      for (const match of contents.matchAll(pattern)) {
+        if (!offending.includes(match[0])) {
+          offending.push(match[0]);
+        }
+      }
+    }
+
+    expect(
+      offending,
+      `CLI bundle leaked build-tree absolute path(s) into the shipped artifact. ` +
+        `This usually means a CommonJS dependency that derives a runtime asset ` +
+        `path from __dirname was inlined; mark it external in cliBundleConfig ` +
+        `(see CLI_DIRNAME_DEPENDENT_EXTERNALS). Offending path(s):\n` +
+        offending.map((path) => `  ${path}`).join('\n'),
+    ).toEqual([]);
+  }, 180_000);
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/tests/issue-3055-bundle-purity.bun.test.ts
+++ b/scripts/tests/issue-3055-bundle-purity.bun.test.ts
@@ -52,6 +52,47 @@ afterAll(() => {
   rmSync(bundleDir, { recursive: true, force: true });
 });
 
+/**
+ * Scans emitted bundle source for quoted string literals that begin with a
+ * build-root path form, returning every distinct offending literal.
+ *
+ * The repo root must be followed by a path separator (a forward slash, or
+ * the JavaScript-escaped Windows separator - a backslash Bun emits doubled)
+ * OR the closing quote, so a path that merely SHARES the repo root as a
+ * prefix is not mistaken for a leak: with root `/foo/bar` the unrelated
+ * literal `"/foo/barbecue/thing"` is NOT reported while
+ * `"/foo/bar/node_modules/..."` IS. A zero-width lookahead enforces that
+ * boundary while still letting `[^"]*"` capture the complete quoted literal,
+ * so the failure message names the full offending path.
+ *
+ * Extracted from the inline scan so the prefix-rejection contract is unit
+ * tested directly (synthetic strings) without building a real bundle, using
+ * the SAME predicate the real guard uses.
+ */
+function findBuildRootPathLeaks(
+  contents: string,
+  pathForms: Iterable<string>,
+): string[] {
+  const offending: string[] = [];
+  for (const pathForm of pathForms) {
+    if (pathForm.length === 0) continue;
+    // Lookahead asserts the repo root is followed by a path separator or the
+    // closing quote. A single backslash in the class covers the doubled `\`
+    // Bun emits (its first backslash satisfies the class) as well as any raw
+    // single-backslash path form.
+    const pattern = new RegExp(
+      `${escapeRegExp(`"${pathForm}`)}(?=[/\\\\]|")[^"]*"`,
+      'g',
+    );
+    for (const match of contents.matchAll(pattern)) {
+      if (!offending.includes(match[0])) {
+        offending.push(match[0]);
+      }
+    }
+  }
+  return offending;
+}
+
 describe('issue #3055: prebuilt CLI bundle is free of build-tree paths', () => {
   it('the shipped llxprt.js contains no absolute path rooted at the repo root', () => {
     // Start from a clean slate so a stale artifact can never satisfy the check.
@@ -115,16 +156,7 @@ describe('issue #3055: prebuilt CLI bundle is free of build-tree paths', () => {
       pathForms.add(JSON.stringify(basePath).slice(1, -1));
     }
 
-    const offending: string[] = [];
-    for (const pathForm of pathForms) {
-      if (pathForm.length === 0) continue;
-      const pattern = new RegExp(`${escapeRegExp(`"${pathForm}`)}[^"]*"`, 'g');
-      for (const match of contents.matchAll(pattern)) {
-        if (!offending.includes(match[0])) {
-          offending.push(match[0]);
-        }
-      }
-    }
+    const offending = findBuildRootPathLeaks(contents, pathForms);
 
     expect(
       offending,
@@ -135,6 +167,35 @@ describe('issue #3055: prebuilt CLI bundle is free of build-tree paths', () => {
         offending.map((path) => `  ${path}`).join('\n'),
     ).toEqual([]);
   }, 180_000);
+});
+
+describe('issue #3055: build-root leak scan rejects prefix false positives', () => {
+  // The scan must require the repo root to be followed by a path separator (or
+  // the closing quote), so a path that merely shares the repo root as a prefix
+  // is not mistaken for a leak. These exercise the SAME findBuildRootPathLeaks
+  // the real guard uses, so a regression here means the guard is broken too.
+  // No real bundle is built: pure-string inputs keep this fast and hermetic.
+
+  it('does not report a sibling path that only shares the repo-root prefix', () => {
+    const fakeRoot = '/foo/bar';
+    // "/foo/bar" + "ecue/..." shares the prefix but is a different path; it
+    // must NOT be flagged. The real leak ("/foo/bar/node_modules/...") MUST.
+    const source = `"${fakeRoot}ecue/thing", "${fakeRoot}/node_modules/leaked"`;
+    const offending = findBuildRootPathLeaks(source, [fakeRoot]);
+    expect(offending).toEqual([`"${fakeRoot}/node_modules/leaked"`]);
+  });
+
+  it('reports a real leak rooted at the repo root', () => {
+    const fakeRoot = '/foo/bar';
+    const leaked = `"${fakeRoot}/node_modules/@dqbd/tiktoken/asset.wasm"`;
+    expect(findBuildRootPathLeaks(leaked, [fakeRoot])).toEqual([leaked]);
+  });
+
+  it('reports an exact repo-root match followed immediately by the closing quote', () => {
+    const fakeRoot = '/foo/bar';
+    const exact = `"${fakeRoot}"`;
+    expect(findBuildRootPathLeaks(exact, [fakeRoot])).toEqual([exact]);
+  });
 });
 
 function escapeRegExp(value: string): string {

--- a/scripts/tests/issue-3055-cli-externals-ownership.bun.test.ts
+++ b/scripts/tests/issue-3055-cli-externals-ownership.bun.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3055 — ownership contract for CLI bundle externals.
+ *
+ * The invariant: every module the CLI bundle marks external must be a declared
+ * direct dependency of the published package (`packages/cli/package.json`),
+ * otherwise its runtime resolution from `<pkg>/bundle/llxprt.js` is not
+ * guaranteed. A transitive dependency that merely appears somewhere in
+ * `node_modules` can be hoisted, shadowed by a consumer's conflicting version,
+ * or absent entirely depending on the consumer's install tree — exactly the
+ * defect behind issue #3055, where `config-chain` was externalized at the wrong
+ * dependency boundary.
+ *
+ * This test reads the real manifests and asserts the invariant for the
+ * CLI-specific external list (`CLI_DIRNAME_DEPENDENT_EXTERNALS`). It is cheap
+ * and deterministic: no npm install, no network, no mocks — just JSON.parse of
+ * the package manifests that are committed alongside the bundle config.
+ *
+ * The actual ownership check lives in a single shared helper,
+ * `findOwnershipViolations` (see `issue-3055-ownership-helpers.ts`). Both the
+ * primary test below and the config-chain regression test feed inputs through
+ * that SAME helper, so they exercise one implementation — no duplicated
+ * predicate that could drift from the real guard.
+ *
+ * The pre-existing shared `EXTERNALS` array is NOT checked here: those entries
+ * include native addons that are optional/platform-conditional, `node:` builtins
+ * that are always available, and packages like `chokidar` that the runtime
+ * falls back from at launch time. The ownership invariant does not apply to
+ * them in the same strict way, so checking them would require a blanket
+ * exclusion list that adds maintenance cost without catching the real hazard.
+ * The CLI-specific list is the one where the ownership rule is both necessary
+ * and enforceable, because every entry is a package that the bundle emits a
+ * bare `require()` for and expects to resolve from the published package's
+ * scope.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import {
+  CLI_DIRNAME_DEPENDENT_EXTERNALS,
+  cliBundleConfig,
+} from '../bun-build.config.ts';
+import { findOwnershipViolations } from './issue-3055-ownership-helpers.ts';
+
+const repoRoot = resolve(import.meta.dir, '..', '..');
+
+interface PackageJson {
+  readonly dependencies?: Readonly<Record<string, string>>;
+  readonly devDependencies?: Readonly<Record<string, string>>;
+}
+
+function readPackageJson(relativePath: string): PackageJson {
+  return JSON.parse(
+    readFileSync(join(repoRoot, relativePath), 'utf8'),
+  ) as PackageJson;
+}
+
+describe('issue #3055: CLI bundle externals are declared direct dependencies', () => {
+  const cliPackage = readPackageJson('packages/cli/package.json');
+  const cliDeps = new Set(Object.keys(cliPackage.dependencies ?? {}));
+
+  it('every CLI_DIRNAME_DEPENDENT_EXTERNALS entry is a direct dependency of packages/cli', () => {
+    const violations = findOwnershipViolations(
+      CLI_DIRNAME_DEPENDENT_EXTERNALS,
+      cliDeps,
+    );
+
+    expect(
+      violations,
+      `CLI bundle external(s) not declared as direct dependencies of ` +
+        `packages/cli/package.json — their runtime resolution from ` +
+        `<pkg>/bundle/llxprt.js is not guaranteed by any package manager.\n` +
+        `Offending: ${violations.join(', ')}\n` +
+        `Every entry in CLI_DIRNAME_DEPENDENT_EXTERNALS must be a direct ` +
+        `dependency of the published package. See the JSDoc on ` +
+        `CLI_DIRNAME_DEPENDENT_EXTERNALS in scripts/bun-build.config.ts.`,
+    ).toEqual([]);
+  });
+
+  it('the full CLI bundle external list is non-empty and includes the dirname-dependent set', () => {
+    // Sanity: the config we are guarding is wired up correctly. If the
+    // external list were empty, the ownership test would vacuously pass.
+    expect(cliBundleConfig.external.length).toBeGreaterThan(0);
+    for (const entry of CLI_DIRNAME_DEPENDENT_EXTERNALS) {
+      expect(cliBundleConfig.external).toContain(entry);
+    }
+  });
+});
+
+describe('issue #3055: ownership contract would reject the config-chain defect', () => {
+  // This proves the test catches the exact defect that was shipped: if someone
+  // re-adds `config-chain` (a transitive dependency of @pnpm/npm-conf, NOT a
+  // direct dependency of packages/cli), the ownership invariant must fail.
+  //
+  // The regression feeds `config-chain` through the SAME `findOwnershipViolations`
+  // helper the primary test uses — NOT a hand-rolled copy — so a change to the
+  // guard's parsing or exclusions would surface here too.
+  it('config-chain is NOT a direct dependency of packages/cli (proving the guard would catch it)', () => {
+    const cliPackage = readPackageJson('packages/cli/package.json');
+    const cliDeps = new Set(Object.keys(cliPackage.dependencies ?? {}));
+
+    expect(cliDeps.has('config-chain')).toBe(false);
+
+    // Feeding config-chain through the REAL guard must flag it as a violation.
+    const violations = findOwnershipViolations(['config-chain'], cliDeps);
+    expect(violations).toEqual(['config-chain']);
+  });
+});

--- a/scripts/tests/issue-3055-cli-externals-ownership.bun.test.ts
+++ b/scripts/tests/issue-3055-cli-externals-ownership.bun.test.ts
@@ -87,6 +87,12 @@ describe('issue #3055: CLI bundle externals are declared direct dependencies', (
     // Sanity: the config we are guarding is wired up correctly. If the
     // external list were empty, the ownership test would vacuously pass.
     expect(cliBundleConfig.external.length).toBeGreaterThan(0);
+    // If CLI_DIRNAME_DEPENDENT_EXTERNALS were emptied during a refactor of
+    // bun-build.config.ts, the ownership test would find zero violations
+    // (vacuous pass) and the loop below would run zero times (vacuous pass
+    // too). Assert the list is populated so the guard cannot be silently
+    // turned off without failing this test.
+    expect(CLI_DIRNAME_DEPENDENT_EXTERNALS.length).toBeGreaterThan(0);
     for (const entry of CLI_DIRNAME_DEPENDENT_EXTERNALS) {
       expect(cliBundleConfig.external).toContain(entry);
     }

--- a/scripts/tests/issue-3055-ownership-helpers.ts
+++ b/scripts/tests/issue-3055-ownership-helpers.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3055 — shared ownership-invariant helper.
+ *
+ * The invariant: every module the CLI bundle marks external must be a declared
+ * direct dependency of the published package (`packages/cli/package.json`),
+ * otherwise its runtime resolution from `<pkg>/bundle/llxprt.js` is not
+ * guaranteed by any package manager.
+ *
+ * This module holds the SINGLE implementation of that check. Both the primary
+ * ownership test (fed the real `CLI_DIRNAME_DEPENDENT_EXTERNALS`) and the
+ * config-chain regression test (fed `['config-chain']`) call the same
+ * `findOwnershipViolations`, so they exercise one piece of logic — never a
+ * duplicated predicate that could drift from the real guard.
+ *
+ * This lives in a test helper module — NOT in `scripts/bun-build.config.ts` —
+ * because the ownership rule is a *verification* concern *about* the build
+ * config, not build configuration itself. `bun-build.config.ts` defines the
+ * externals lists; this module verifies an invariant about them, keeping the
+ * production config focused on bundling.
+ */
+
+/**
+ * Extracts the bare package name from an external specifier.
+ *
+ * - Scoped: `@scope/name/sub` -> `@scope/name`
+ * - Scoped (no subpath): `@scope/name` -> `@scope/name`
+ * - Unscoped: `name/sub` -> `name`
+ * - Unscoped (no subpath): `name` -> `name`
+ * - `node:` builtins: returned as-is (they are never in package.json deps).
+ */
+export function packageName(specifier: string): string {
+  if (specifier.startsWith('node:')) {
+    return specifier;
+  }
+  if (specifier.startsWith('@')) {
+    const parts = specifier.split('/');
+    return parts.slice(0, 2).join('/');
+  }
+  return specifier.split('/')[0];
+}
+
+/**
+ * Return every external whose bare package name is NOT present in
+ * `declaredDependencies`.
+ *
+ * Each returned entry is the original external specifier (not the normalised
+ * package name), so a violation names the exact `require()` target that lacks
+ * a declared owner.
+ *
+ * @param externals - The external specifiers to check (e.g. a bundle config's
+ *   `external` array, or a synthetic list like `['config-chain']`).
+ * @param declaredDependencies - The set of bare package names the owning
+ *   manifest declares as direct dependencies (e.g. the keys of
+ *   `packages/cli/package.json#dependencies`).
+ * @returns The externals that violate the ownership invariant (empty array if
+ *   all externals are declared direct dependencies).
+ */
+export function findOwnershipViolations(
+  externals: readonly string[],
+  declaredDependencies: ReadonlySet<string>,
+): string[] {
+  const violations: string[] = [];
+  for (const external of externals) {
+    const pkg = packageName(external);
+    if (!declaredDependencies.has(pkg)) {
+      violations.push(external);
+    }
+  }
+  return violations;
+}

--- a/scripts/tests/issue-3055-tiktoken-relocated.bun.test.ts
+++ b/scripts/tests/issue-3055-tiktoken-relocated.bun.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3055 — automated form of the manual "hide the package" reproduction.
+ *
+ * Builds a fixture that imports `@dqbd/tiktoken` and encodes a string, using
+ * the CLI bundle's external policy (`cliBundleConfig.external`). The built
+ * fixture is resolved against a *temporary* `node_modules` tree that this test
+ * creates and owns (a copy of the real `@dqbd/tiktoken` package), then the
+ * bundle is relocated next to a *fresh* `node_modules`, the original build
+ * tree is deleted, and the relocated bundle is executed.
+ *
+ * - On main, `cliBundleConfig.external` does NOT include `@dqbd/tiktoken`, so
+ *   the fixture inlines it with a build-machine `__dirname`; relocated away
+ *   from the (now deleted) build tree, it throws "Missing tiktoken_bg.wasm"
+ *   and the test FAILS.
+ * - After the fix, `@dqbd/tiktoken` is external, so the relocated fixture
+ *   resolves it from the temporary `node_modules` and the WASM is found
+ *   relative to the package's real `__dirname` — the test PASSES.
+ *
+ * The fixture writes its token count to a file (path passed via env var) rather
+ * than stdout: Bun's stdout pipe is not reliably flushed under `spawnSync` from
+ * a `bun test` parent, so a file makes the assertion unambiguous. The
+ * repository's own `node_modules` is never modified.
+ */
+
+import { afterAll, describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { cliBundleConfig } from '../bun-build.config.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(__filename, '..', '..', '..');
+const sourceTiktokenDir = join(repoRoot, 'node_modules', '@dqbd', 'tiktoken');
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+  // Clean up every temp directory even when an assertion throws, so a failure
+  // never leaves build/run trees behind on the runner.
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(directory);
+  return directory;
+}
+
+describe('issue #3055: tiktoken resolves from a relocated node_modules', () => {
+  it('a fixture built with the CLI external policy runs after relocation', async () => {
+    // Precondition: this test copies the real @dqbd/tiktoken package out of
+    // the repo's node_modules into temp trees. If dependencies are not
+    // installed, cpSync throws an opaque ENOENT that does not explain the
+    // precondition — fail fast here with an actionable message instead.
+    if (!existsSync(sourceTiktokenDir)) {
+      throw new Error(
+        `Precondition unmet: @dqbd/tiktoken is not installed at ` +
+          `${sourceTiktokenDir}. This test copies the real package into a ` +
+          `temp tree; run 'npm install' (or 'bun install') at the repo ` +
+          `root to restore it.`,
+      );
+    }
+
+    // 1. Build directory with its OWN node_modules containing @dqbd/tiktoken,
+    //    so the fixture resolves tiktoken at build time. On main (tiktoken not
+    //    external) this inlines it and bakes __dirname into the build tree;
+    //    after the fix it stays a runtime import.
+    const buildDir = makeTempDir('llxprt-3055-build-');
+    mkdirSync(join(buildDir, 'node_modules', '@dqbd'), { recursive: true });
+    cpSync(
+      sourceTiktokenDir,
+      join(buildDir, 'node_modules', '@dqbd', 'tiktoken'),
+      { recursive: true },
+    );
+
+    const entry = join(buildDir, 'entry.ts');
+    writeFileSync(
+      entry,
+      [
+        `import { get_encoding } from '@dqbd/tiktoken';`,
+        `import { writeFileSync } from 'node:fs';`,
+        `const encoder = get_encoding('o200k_base');`,
+        `const tokens = encoder.encode('hello world', [], []);`,
+        `writeFileSync(process.env.RESULT_FILE, String(tokens.length));`,
+        `encoder.free();`,
+        '',
+      ].join('\n'),
+    );
+
+    // 2. Build with the CLI bundle's external policy — the same policy the
+    //    shipped artifact uses.
+    let result: Awaited<ReturnType<typeof Bun.build>>;
+    try {
+      result = await Bun.build({
+        entrypoints: [entry],
+        outdir: buildDir,
+        target: 'bun',
+        external: cliBundleConfig.external,
+        naming: 'entry.js',
+      });
+    } catch (error) {
+      throw new Error(
+        `fixture build failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    expect(result.success).toBe(true);
+    const fixtureBundle = join(buildDir, 'entry.js');
+    expect(existsSync(fixtureBundle)).toBe(true);
+
+    // 3. Relocation directory with a fresh node_modules we own, mirroring an
+    //    install on a different machine. @dqbd/tiktoken has no dependencies of
+    //    its own, so the package directory is self-contained.
+    const runDir = makeTempDir('llxprt-3055-run-');
+    mkdirSync(join(runDir, 'node_modules', '@dqbd'), { recursive: true });
+    cpSync(
+      sourceTiktokenDir,
+      join(runDir, 'node_modules', '@dqbd', 'tiktoken'),
+      { recursive: true },
+    );
+    const relocatedBundle = join(runDir, 'entry.js');
+    copyFileSync(fixtureBundle, relocatedBundle);
+    const resultFile = join(runDir, 'result.txt');
+
+    // 4. Delete the build tree. This is the crux: an inlined (main) bundle has
+    //    __dirname baked to a path that no longer exists, so the WASM lookup
+    //    fails. An external (fixed) bundle resolves tiktoken from runDir's
+    //    node_modules and finds the WASM relative to the package's real
+    //    __dirname.
+    rmSync(buildDir, { recursive: true, force: true });
+
+    // 5. Execute the relocated bundle. process.execPath is the Bun binary
+    //    running this test. The fixture writes its token count to resultFile.
+    const proc = spawnSync(process.execPath, [relocatedBundle], {
+      cwd: runDir,
+      encoding: 'utf8',
+      timeout: 60_000,
+      env: { ...process.env, RESULT_FILE: resultFile },
+    });
+
+    expect(proc.error).toBeUndefined();
+    // Assert the signal is null BEFORE status: when spawnSync kills the child
+    // on timeout, proc.status is null and proc.signal is 'SIGTERM', so the
+    // status assertion alone would read "expected null to be 0" and hide the
+    // timeout. Naming the signal surfaces the real failure mode.
+    expect(
+      proc.signal,
+      `relocated fixture was killed by signal ${proc.signal} (likely timeout).\n` +
+        `stdout: ${proc.stdout}\nstderr: ${proc.stderr}`,
+    ).toBeNull();
+    expect(
+      proc.status,
+      `relocated fixture exited ${proc.status}.\n` +
+        `stdout: ${proc.stdout}\nstderr: ${proc.stderr}`,
+    ).toBe(0);
+    // The result file's presence + numeric content proves the encoder actually
+    // tokenised input using the relocated WASM payload.
+    expect(existsSync(resultFile), resultFile).toBe(true);
+    const tokenCount = readFileSync(resultFile, 'utf8').trim();
+    // Assert the EXACT token count, not just > 0: a degenerate stub returning
+    // `1` for every input would pass a positivity check without proving the
+    // WASM actually executed. 'hello world' under o200k_base is deterministic
+    // and produces exactly 2 tokens (measured empirically and confirmed stable
+    // across node/bun; consistent with the bounded-range precedent in
+    // token-divergence.test.ts:248-249 which asserts > 0 and < 10).
+    const parsed = Number.parseInt(tokenCount, 10);
+    expect(Number.isSafeInteger(parsed)).toBe(true);
+    expect(parsed).toBe(2);
+  }, 120_000);
+});

--- a/scripts/tests/issue-3055-tiktoken-relocated.bun.test.ts
+++ b/scripts/tests/issue-3055-tiktoken-relocated.bun.test.ts
@@ -53,9 +53,26 @@ const tempDirs: string[] = [];
 
 afterAll(() => {
   // Clean up every temp directory even when an assertion throws, so a failure
-  // never leaves build/run trees behind on the runner.
+  // never leaves build/run trees behind on the runner. Each removal is
+  // attempted independently: a single rmSync failure (permission error,
+  // Windows file lock) must not abort the loop and leak every remaining tree.
+  // Failures are collected and surfaced as an AggregateError after every
+  // directory has been attempted, matching the pattern in
+  // gpt56-bundle-runtime.test.ts. This swallow-and-aggregate is scoped to
+  // external filesystem removal only — it is NOT a general pattern.
+  const cleanupErrors: unknown[] = [];
   for (const directory of tempDirs.splice(0)) {
-    rmSync(directory, { recursive: true, force: true });
+    try {
+      rmSync(directory, { recursive: true, force: true });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(
+      cleanupErrors,
+      'Failed to remove test directories',
+    );
   }
 });
 


### PR DESCRIPTION
## TLDR

The prebuilt CLI bundle we started shipping in #3013 cannot start on any machine except the one that built it. `llxprt` dies at launch with `Missing tiktoken_bg.wasm` before a single line of our code runs. It was reported on Windows, but it reproduces identically on macOS and Linux — every install of the affected nightly is broken on every platform.

Bun freezes a CommonJS module's `__dirname` as a **build-time string literal** when it inlines it. `@dqbd/tiktoken` locates its WASM payload from `__dirname`, so the shipped artifact contains the release engineer's absolute path:

    var __dirname = "/Volumes/XS1000/acoliver/projects/.../node_modules/@dqbd/tiktoken";
    ...
    candidates.unshift(path.join(__dirname, "./tiktoken_bg.wasm"));
    ...
    if (bytes == null) throw new Error("Missing tiktoken_bg.wasm");

Every other candidate it derives comes from that same baked path and looks for the *unscoped* name `tiktoken`, so none of them ever match `@dqbd/tiktoken` anywhere. The build machine's literal path is the only candidate that can resolve. As a bonus, the artifact leaked that path into user-facing stack traces.

The fix keeps modules whose runtime behaviour depends on their own `__dirname` external to the CLI bundle, so Bun resolves them from `node_modules` at launch and `__dirname` points at the *installed* package — exactly the resolution the pre-bundle TypeScript launch always used.

**Reviewers should look at:** the ownership rule on `CLI_DIRNAME_DEPENDENT_EXTERNALS`, and why `update-notifier` is externalised rather than `config-chain`.

## Dive Deeper

### Why CI could not catch it

`scripts/tests/issue-2999-cli-bundle.bun.test.ts` builds the bundle and runs `--version` **from the repo checkout**, where the baked path is still valid. The Windows installed-command smoke installs a tarball packed on the same runner, so the baked path is valid there too. Nothing in CI could observe a build-tree dependency, because everything ran on the build tree.

### The ownership rule

`a2aServerConfig` already guarded this hazard with `portableTiktokenPlugin`; `cliBundleConfig` had no `plugins` entry, so the guard was never applied to the CLI bundle. Rather than rewrite third-party source for the CLI target, the affected modules stay external — but externalising is only safe under a contract, now stated on the constant and enforced by a test:

> Every module the CLI bundle marks external must be a **declared direct dependency of `packages/cli/package.json`**.

Only a direct dependency guarantees resolution from `<pkg>/bundle/llxprt.js`. A transitive package that merely happens to be hoisted can be shadowed by a consumer's conflicting copy, nested out of reach, or absent entirely. Presence somewhere in `node_modules` and resolvability from a specific importer are different guarantees.

Exactly three modules baked build-tree paths into the artifact:

| Module | Treatment | Reason |
| --- | --- | --- |
| `@dqbd/tiktoken` | external | Direct dependency. Locates `tiktoken_bg.wasm` via `__dirname`; **fatal** — throws at import time. |
| `yargs` | external | Direct dependency. Resolves its locale directory via `__dirname`; silently degrades localisation. |
| `config-chain` | **not** external — `update-notifier` is | Transitive, owned by `@pnpm/npm-conf`. See below. |

An earlier revision of this PR externalised `config-chain` directly. That is wrong and was caught in review: `config-chain` is five levels down (`update-notifier` → `latest-version` → `package-json` → `registry-auth-token` → `@pnpm/npm-conf` → `config-chain`), so a bare `require("config-chain")` emitted from the bundle moves the resolution owner to the CLI package, where nothing guarantees it resolves. It was demonstrated empirically under both npm and Bun that a consumer-level conflicting `config-chain` gets selected from the bundle — an incompatible copy crashed even `--version`, and an older real copy was selected silently. Externalising its direct-dependency owner `update-notifier` keeps the whole transitive graph resolving through its rightful owners.

`a2aServerConfig` is deliberately untouched. It is a separately packaged, self-contained artifact that already neutralises tiktoken via `portableTiktokenPlugin`, and forcing these modules external there would break that strategy.

### Guards

Three `bun:test` files, all in the `scripts` shard so they run on pull requests:

1. **Artifact purity** (`issue-3055-bundle-purity.bun.test.ts`) — builds the real bundle via the production `prepack` entry point and fails if any absolute path rooted at the build tree survives into `llxprt.js`, naming every offender. Scans the raw OS path, the JavaScript-escaped form (`JSON.stringify`, which doubles backslashes so the guard is not a no-op on Windows), and `realpathSync` for symlinked checkouts. This generalises beyond tiktoken and closes the path-disclosure leak in one rule.
2. **Ownership contract** (`issue-3055-cli-externals-ownership.bun.test.ts`) — reads the real manifests and fails if an external is not a declared direct dependency. The `config-chain` regression feeds that package through the *same* `findOwnershipViolations` helper the primary test uses, so the two cannot drift.
3. **Relocated runtime** (`issue-3055-tiktoken-relocated.bun.test.ts`) — the automated form of the manual reproduction: builds a tiktoken fixture against a temporary `node_modules` it owns, deletes the build tree, relocates the artifact next to a fresh `node_modules`, and executes it. Asserts the exact token count so a degenerate loader cannot pass.

The repository's own `node_modules` is never touched by any of them.

Analysis is recorded in `project-plans/issue-3055-bundle-build-path-leak.md`.

## Reviewer Test Plan

Reproduce the bug on `main` (this works on macOS and Linux — you do not need Windows):

    git checkout main
    bun scripts/bun-build.config.ts --cli-only
    grep -o 'var __dirname = "[^"]*"' packages/cli/bundle/llxprt.js | sort -u
    # three literals pointing at YOUR checkout

    bun packages/cli/bundle/llxprt.js --version
    # 0.11.0 - works only because the baked path exists here

    mv node_modules/@dqbd/tiktoken node_modules/@dqbd/tiktoken__hidden
    bun packages/cli/bundle/llxprt.js --version
    # error: Missing tiktoken_bg.wasm
    mv node_modules/@dqbd/tiktoken__hidden node_modules/@dqbd/tiktoken

Hiding the build-time location is exactly what installing on another machine does.

Now on this branch:

    git checkout issue3055
    rm -rf packages/cli/bundle && bun scripts/bun-build.config.ts --cli-only
    grep -c 'var __dirname = "' packages/cli/bundle/llxprt.js   # -> 0
    bun packages/cli/bundle/llxprt.js --version                 # -> 0.11.0

Confirm the guards fail for the right reasons — revert `cliBundleConfig.external` to plain `EXTERNALS` and watch the purity and relocated-runtime tests fail; add `config-chain` to `CLI_DIRNAME_DEPENDENT_EXTERNALS` and watch the ownership test fail:

    bun scripts/run_bun_tests.ts --root scripts-tests issue-3055

The highest-value check is a real install: publish or pack the branch, install it somewhere that is not this checkout, and launch it.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run build`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run lint:eslint-guard`, `npm run test`, the three issue-3055 tests via `bun scripts/run_bun_tests.ts --root scripts-tests issue-3055`, and the `stepfun-37` launch smoke. The full `npm run test` run showed five 30-second timeouts in `packages/agents` caused by machine contention; all five pass in isolation (70 pass / 0 fail) and are untouched by this change, which is confined to `scripts/`. Linux and Windows are covered by CI.

## Linked issues / bugs

Fixes #3055

Regression from #3013 (which implemented #2999).
