### PR TITLE
Make apply_patch feedback truthful: deletes delete, success is evidence, errors name the cause (Fixes #3033)

### DIFF
--- a/packages/tools/src/__tests__/apply-patch-ax.bun.test.ts
+++ b/packages/tools/src/__tests__/apply-patch-ax.bun.test.ts
@@ -6,11 +6,9 @@
 
 /**
  * Behavioral tests for issue #3033 (apply_patch agent-experience fixes).
- *
  * Drives the real `ApplyPatchTool` through `validateBuildAndExecute` against a
  * real on-disk temp directory, asserting on filesystem state and `ToolResult`
  * content only. No mocking of the tool under test, no private-method access.
- *
  * @issue 3033
  */
 
@@ -24,9 +22,17 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import type { IToolHost, ILspService, ToolResult, FileDiff } from '../index.js';
+import type {
+  ApprovalMode,
+  IToolHost,
+  IToolHostFileSystemService,
+  ILspService,
+  ToolCallConfirmationDetails,
+  ToolResult,
+  FileDiff,
+} from '../index.js';
 import { ApplyPatchTool, ToolErrorType } from '../index.js';
-import { describeHunkCountMismatch } from '../tools/apply-patch-analysis.js';
+import type { ApplyPatchToolParams } from '../index.js';
 
 function createTempDir(prefix = 'llxprt-apply-patch-ax-'): {
   dir: string;
@@ -49,10 +55,7 @@ function createTempDir(prefix = 'llxprt-apply-patch-ax-'): {
   };
 }
 
-/**
- * Shared temp-directory lifecycle: registers the hooks once and returns a
- * lazy accessor so every describe block wires setup in a single line.
- */
+/** Shared temp-directory lifecycle: registers hooks once, lazy accessor. */
 function useTempDir(): () => string {
   let dir = '';
   let cleanup = (): void => {};
@@ -65,42 +68,94 @@ function useTempDir(): () => string {
   return () => dir;
 }
 
-function createFakeToolHost(targetDir: string): IToolHost {
-  return {
+interface FakeHostOptions {
+  approvalMode?: ApprovalMode;
+  fileSystemService?: IToolHostFileSystemService;
+}
+
+function createFakeToolHost(
+  targetDir: string,
+  options?: FakeHostOptions,
+): IToolHost {
+  const base = {
     getTargetDir: () => targetDir,
     getWorkspaceRoots: () => [targetDir],
-    getApprovalMode: () => 'auto',
+    getApprovalMode: (): ApprovalMode => options?.approvalMode ?? 'auto',
     setApprovalMode: () => {},
     isInteractive: () => false,
     hasFeatureFlag: () => false,
     getEphemeralSettings: () => ({}),
   };
+  if (options?.fileSystemService) {
+    const fs = options.fileSystemService;
+    return { ...base, getFileSystemService: () => fs };
+  }
+  return base;
+}
+
+interface RunOptions {
+  approvalMode?: ApprovalMode;
+  lsp?: ILspService;
+  fileSystemService?: IToolHostFileSystemService;
 }
 
 async function runPatch(
   targetDir: string,
-  params: Record<string, unknown>,
-  options?: { lsp?: ILspService },
+  params: ApplyPatchToolParams,
+  options?: RunOptions,
 ): Promise<ToolResult> {
   const tool = new ApplyPatchTool(
-    createFakeToolHost(targetDir),
+    createFakeToolHost(targetDir, {
+      approvalMode: options?.approvalMode,
+      fileSystemService: options?.fileSystemService,
+    }),
     undefined,
     options?.lsp,
   );
-  return tool.validateBuildAndExecute(
-    params as never,
-    new AbortController().signal,
-  );
+  return tool.validateBuildAndExecute(params, new AbortController().signal);
 }
 
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null;
+/** Drives `shouldConfirmExecute` through a real invocation in ASK mode. */
+async function runConfirmation(
+  targetDir: string,
+  params: ApplyPatchToolParams,
+  options?: { approvalMode?: ApprovalMode },
+): Promise<ToolCallConfirmationDetails | false> {
+  const tool = new ApplyPatchTool(
+    createFakeToolHost(targetDir, { approvalMode: options?.approvalMode }),
+  );
+  const invocation = tool.build(params);
+  return invocation.shouldConfirmExecute(new AbortController().signal);
+}
+
+function isStringRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string');
 }
 
 function isFileDisplay(rd: unknown): rd is FileDiff {
   return (
-    isRecord(rd) && 'newContent' in rd && 'fileDiff' in rd && 'fileName' in rd
+    isStringRecord(rd) &&
+    'newContent' in rd &&
+    'fileDiff' in rd &&
+    'fileName' in rd
   );
+}
+
+interface EditConfirmationLike {
+  type: string;
+  title: string;
+  newContent: string;
+  filePath?: string;
+}
+
+function isEditConfirmation(
+  c: ToolCallConfirmationDetails,
+): c is EditConfirmationLike {
+  return 'newContent' in c;
 }
 
 function countOccurrences(haystack: string, needle: string): number {
@@ -114,31 +169,26 @@ function countOccurrences(haystack: string, needle: string): number {
   return count;
 }
 
+/** A whole-file delete patch for the given basename. */
+function deletePatch(basename: string, lines: string[]): string {
+  const body = lines.map((l) => `-${l}`).join('\n');
+  return `--- a/${basename}\n+++ /dev/null\n@@ -1,${lines.length} +0,0 @@\n${body}\n`;
+}
+
 describe('issue #3033 AC1 — delete patches delete', () => {
   const tempDir = useTempDir();
 
   it('removes the file from disk when a whole-file delete patch is applied', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
-
-    const patch = `--- a/target.txt
-+++ /dev/null
-@@ -1,3 +0,0 @@
--a
--b
--c
-`;
-
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
-      patch_content: patch,
+      patch_content: deletePatch('target.txt', ['a', 'b', 'c']),
     });
-
     expect(result.error).toBeUndefined();
     expect(existsSync(filePath)).toBe(false);
     expect(result.llmContent.toLowerCase()).toContain('deleted');
     expect(result.llmContent).toContain('target.txt');
-    // returnDisplay is a FileDiff showing removal (new content empty).
     expect(isFileDisplay(result.returnDisplay)).toBe(true);
     if (isFileDisplay(result.returnDisplay)) {
       expect(result.returnDisplay.newContent).toBe('');
@@ -148,20 +198,10 @@ describe('issue #3033 AC1 — delete patches delete', () => {
   it('rejects a delete patch that does not remove the whole file and leaves it untouched', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'a\nb\nc\nd\n', 'utf-8');
-
-    const patch = `--- a/target.txt
-+++ /dev/null
-@@ -1,3 +0,0 @@
--a
--b
--c
-`;
-
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
-      patch_content: patch,
+      patch_content: deletePatch('target.txt', ['a', 'b', 'c']),
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.PATCH_APPLY_FAILURE);
     expect(existsSync(filePath)).toBe(true);
@@ -171,21 +211,73 @@ describe('issue #3033 AC1 — delete patches delete', () => {
   it('still rejects a delete patch whose --- header basename does not match the target', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'a\n', 'utf-8');
-
-    const patch = `--- a/other.txt
-+++ /dev/null
-@@ -1,1 +0,0 @@
--a
-`;
-
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
-      patch_content: patch,
+      patch_content: deletePatch('other.txt', ['a']),
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
     expect(readFileSync(filePath, 'utf-8')).toBe('a\n');
+  });
+});
+
+describe('F1 — delete routes through the host filesystem service', () => {
+  const tempDir = useTempDir();
+
+  it('asks the host filesystem service to delete instead of unlinking behind its back', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+    const deletedPaths: string[] = [];
+    const fileSystemService: IToolHostFileSystemService = {
+      readTextFile: async (p) => readFileSync(p, 'utf8'),
+      writeTextFile: async (p, c) => writeFileSync(p, c, 'utf8'),
+      deleteFile: (p) => {
+        deletedPaths.push(p);
+        return Promise.resolve();
+      },
+    };
+    const result = await runPatch(
+      tempDir(),
+      {
+        absolute_path: filePath,
+        patch_content: deletePatch('target.txt', ['a', 'b', 'c']),
+      },
+      { fileSystemService },
+    );
+    expect(result.error).toBeUndefined();
+    // The service was asked to delete exactly the target path.
+    expect(deletedPaths).toEqual([filePath]);
+    // The real file was NOT unlinked behind the service's back: the fake
+    // service intercepted delete and removed nothing, so a bypass would have
+    // removed the on-disk file while a routed delete leaves it in place.
+    expect(existsSync(filePath)).toBe(true);
+  });
+});
+
+describe('F2 — deletion failure returns a structured error, not a thrown exception', () => {
+  const tempDir = useTempDir();
+
+  it('returns a FILE_WRITE_FAILURE result when the host delete rejects', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+    const fileSystemService: IToolHostFileSystemService = {
+      readTextFile: async (p) => readFileSync(p, 'utf8'),
+      writeTextFile: async (p, c) => writeFileSync(p, c, 'utf8'),
+      deleteFile: () => Promise.reject(new Error('permission denied')),
+    };
+    const result = await runPatch(
+      tempDir(),
+      {
+        absolute_path: filePath,
+        patch_content: deletePatch('target.txt', ['a', 'b', 'c']),
+      },
+      { fileSystemService },
+    );
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.FILE_WRITE_FAILURE);
+    expect(result.llmContent).toContain('Error deleting file');
+    expect(result.llmContent).toContain('permission denied');
+    expect(existsSync(filePath)).toBe(true);
   });
 });
 
@@ -195,94 +287,103 @@ describe('issue #3033 AC2 — success message is evidence', () => {
   it('reports hunk count and landing lines for a successful modify', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
-
-    const patch = `--- a/target.txt
-+++ b/target.txt
-@@ -1,3 +1,3 @@
- a
--b
-+B
- c
-`;
-
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,3 @@\n a\n-b\n+B\n c\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeUndefined();
-    // Evidence must name the declared hunk count and the landing line.
     expect(result.llmContent).toContain(
       'Patch declared 1 hunk(s). The applied change landed at line 2.',
     );
+    expect(readFileSync(filePath, 'utf-8')).toBe('a\nB\nc\n');
   });
 
   it('announces when a hunk context block occurs more than once in the file', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'repeat\nx\nrepeat\ny\n', 'utf-8');
-
-    const patch = `--- a/target.txt
-+++ b/target.txt
-@@ -1,1 +1,1 @@
--repeat
-+REPLACED
-`;
-
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,1 +1,1 @@\n-repeat\n+REPLACED\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeUndefined();
-    // Ambiguity announcement must name the hunk, the declared line, the
-    // occurrence count, and every line where the context block appears.
     expect(result.llmContent).toContain(
       'Hunk 1 context (declared at line 1) occurs 2 times in the file (lines 1, 3); check the reported landing lines.',
     );
+    expect(readFileSync(filePath, 'utf-8')).toBe('REPLACED\nx\nrepeat\ny\n');
   });
 
   it('notes when a hunk declared line differs from where it actually matched', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'unique\nb\nc\n', 'utf-8');
-
     // Declared at line 5, but "unique" only exists at line 1.
-    const patch = `--- a/target.txt
-+++ b/target.txt
-@@ -5,1 +5,1 @@
--unique
-+CHANGED
-`;
-
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -5,1 +5,1 @@\n-unique\n+CHANGED\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeUndefined();
-    // Drift note must name the hunk, the declared line, and the matched line.
     expect(result.llmContent).toContain(
       'Hunk 1 declared line 5 but its context matches line 1.',
     );
+    expect(readFileSync(filePath, 'utf-8')).toBe('CHANGED\nb\nc\n');
   });
 
   it('gives proportionate evidence (lines written) for a creation', async () => {
     const filePath = join(tempDir(), 'new.txt');
-
-    const patch = `--- /dev/null
-+++ b/new.txt
-@@ -0,0 +1,2 @@
-+hello
-+world
-`;
-
+    const patch = `--- /dev/null\n+++ b/new.txt\n@@ -0,0 +1,2 @@\n+hello\n+world\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeUndefined();
     expect(result.llmContent).toContain('Successfully created file from patch');
     expect(result.llmContent).toContain('Created file with 2 line(s).');
+    expect(readFileSync(filePath, 'utf-8')).toBe('hello\nworld\n');
+  });
+});
+
+describe('F3 — deletion landing evidence does not name a nonexistent line', () => {
+  const tempDir = useTempDir();
+
+  it('reports content removed before the resulting first line for a start deletion', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,2 @@\n-a\n b\n c\n`;
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.llmContent).toContain('content removed before line 1');
+    expect(readFileSync(filePath, 'utf-8')).toBe('b\nc\n');
+  });
+
+  it('reports content removed before the resulting line for a middle deletion', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,2 @@\n a\n-b\n c\n`;
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.llmContent).toContain('content removed before line 2');
+    expect(readFileSync(filePath, 'utf-8')).toBe('a\nc\n');
+  });
+
+  it('reports content removed at end of file for an end deletion', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,2 @@\n a\n b\n-c\n`;
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.llmContent).toContain('content removed at end of file');
+    expect(readFileSync(filePath, 'utf-8')).toBe('a\nb\n');
   });
 });
 
@@ -294,28 +395,16 @@ describe('issue #3033 AC3 — path mismatch names both accepted forms', () => {
     mkdirSync(subDir, { recursive: true });
     const target = join(subDir, 'target.txt');
     writeFileSync(target, 'keep\n', 'utf-8');
-
-    const patch = `--- a/other.txt
-+++ b/other.txt
-@@ -1,1 +1,1 @@
--keep
-+changed
-`;
-
+    const patch = `--- a/other.txt\n+++ b/other.txt\n@@ -1,1 +1,1 @@\n-keep\n+changed\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: target,
       patch_content: patch,
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
-    // Header value supplied.
     expect(result.llmContent).toContain('other.txt');
-    // Workspace-relative accepted form.
     expect(result.llmContent).toContain('sub/target.txt');
-    // Bare basename accepted form.
     expect(result.llmContent).toContain('target.txt');
-    // Partial path explicitly not accepted.
     expect(result.llmContent.toLowerCase()).toContain('partial path');
     expect(readFileSync(target, 'utf-8')).toBe('keep\n');
   });
@@ -327,17 +416,11 @@ describe('issue #3033 AC4 — missing or unrecognized header is named', () => {
   it('rejects a Codex *** Begin Patch envelope as unsupported', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'keep\n', 'utf-8');
-
-    const patch = `*** Begin Patch
-*** Update File: target.txt
-+new
-`;
-
+    const patch = `*** Begin Patch\n*** Update File: target.txt\n+new\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
     expect(result.llmContent).toContain('*** Begin Patch');
@@ -348,16 +431,11 @@ describe('issue #3033 AC4 — missing or unrecognized header is named', () => {
   it('rejects a patch with --- /+++ headers but no @@ hunks', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'keep\n', 'utf-8');
-
-    const patch = `--- a/target.txt
-+++ b/target.txt
-`;
-
+    const patch = `--- a/target.txt\n+++ b/target.txt\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
     expect(result.llmContent).toContain('@@');
@@ -367,17 +445,11 @@ describe('issue #3033 AC4 — missing or unrecognized header is named', () => {
   it('rejects a headerless patch and names both accepted header forms', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'a\n', 'utf-8');
-
-    const patch = `@@ -1,1 +1,1 @@
--a
-+A
-`;
-
+    const patch = `@@ -1,1 +1,1 @@\n-a\n+A\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
     expect(result.llmContent).toContain('---');
@@ -390,70 +462,104 @@ describe('issue #3033 AC4 — missing or unrecognized header is named', () => {
 describe('issue #3033 AC5 — hunk count mismatch is translated', () => {
   const tempDir = useTempDir();
 
-  it('translates a too-small declared old count into header/declared/actual', async () => {
+  it('translates a too-small declared old count into header/declared/actual numbers', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'a\nb\n', 'utf-8');
-
     // Declared old count 1 but body removes 2 lines.
-    const patch = `--- a/target.txt
-+++ b/target.txt
-@@ -1,1 +1,1 @@
--a
--b
-+c
-`;
-
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,1 +1,1 @@\n-a\n-b\n+c\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
     expect(result.llmContent).toContain('@@ -1,1 +1,1 @@');
-    expect(result.llmContent.toLowerCase()).toContain('declared');
-    expect(result.llmContent.toLowerCase()).toContain('actual');
+    expect(result.llmContent).toContain(
+      'declared 1 old line(s) and 1 new line(s)',
+    );
+    expect(result.llmContent).toContain(
+      'actually has 2 old line(s) and 1 new line(s)',
+    );
   });
 
-  it('translates a too-small declared new count into header/declared/actual', async () => {
+  it('translates a too-small declared new count into header/declared/actual numbers', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'a\n', 'utf-8');
-
     // Declared new count 1 but body adds 2 lines.
-    const patch = `--- a/target.txt
-+++ b/target.txt
-@@ -1,1 +1,1 @@
--a
-+b
-+c
-`;
-
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,1 +1,1 @@\n-a\n+b\n+c\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
     expect(result.llmContent).toContain('@@ -1,1 +1,1 @@');
-    expect(result.llmContent.toLowerCase()).toContain('actual');
+    expect(result.llmContent).toContain(
+      'declared 1 old line(s) and 1 new line(s)',
+    );
+    expect(result.llmContent).toContain(
+      'actually has 1 old line(s) and 2 new line(s)',
+    );
   });
 
-  it('does not misread a removed line that renders as "--- " as a file header', () => {
-    // A real, applicable diff: the removed line "-- some dashed line"
-    // serializes to "--- some dashed line" in the body, and the declared
-    // counts (2 old / 2 new) are correct. The body scanner must NOT terminate
-    // the walk on that line and fabricate a count mismatch. Only the
-    // `--- X` / `+++ Y` header PAIR (or `@@` / `diff --git`) ends a hunk body.
-    const patch = `--- a/target.txt
-+++ b/target.txt
-@@ -1,2 +1,2 @@
---- some dashed line
-+-- replaced line
- keep
-`;
+  it('translates an over-declared count into the correct declared/actual numbers', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\n', 'utf-8');
+    // Declared 3 old / 3 new but body has 1 old / 1 new.
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,3 @@\n-a\n+b\n`;
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent).toContain('@@ -1,3 +1,3 @@');
+    expect(result.llmContent).toContain(
+      'declared 3 old line(s) and 3 new line(s)',
+    );
+    expect(result.llmContent).toContain(
+      'actually has 1 old line(s) and 1 new line(s)',
+    );
+  });
 
-    expect(describeHunkCountMismatch(patch)).toBeNull();
+  it('surfaces the original jsdiff message for a non-count parser error', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\n', 'utf-8');
+    // Declared counts (1/1) are correct for the body; the trailing "QQQ" is
+    // what jsdiff cannot parse. The scanner finds no count mismatch, so the
+    // original parser message ("Unknown line") surfaces unaltered.
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,1 +1,1 @@\n-a\n+b\nQQQ\n`;
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent.toLowerCase()).toContain('unknown line');
+    expect(result.llmContent.toLowerCase()).not.toContain('declared');
+    expect(result.llmContent.toLowerCase()).not.toContain('actual');
+  });
+
+  it('does not misread a "--- "/"+++ " body pair as a file header; surfaces the parser error', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\n', 'utf-8');
+    // The removed line "-- old" renders as "--- old" and the added line
+    // "++ new" renders as "+++ new": exactly a file-header pair in text. The
+    // declared counts (2/2) are correct for that body. The trailing "QQQ"
+    // forces a parse throw; the scanner must NOT terminate the body walk on
+    // the dashed pair and fabricate a 0/0 count mismatch.
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,2 +1,2 @@\n--- old\n+++ new\n keep\nQQQ\n`;
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent.toLowerCase()).toContain('unknown line');
+    expect(result.llmContent.toLowerCase()).not.toContain('declared');
+    expect(result.llmContent.toLowerCase()).not.toContain(
+      'actually has 0 old line',
+    );
   });
 });
 
@@ -462,19 +568,11 @@ describe('issue #3033 AC6 — missing file is not a context mismatch', () => {
 
   it('reports FILE_NOT_FOUND for a non-creation patch on a missing file', async () => {
     const filePath = join(tempDir(), 'missing.txt');
-
-    const patch = `--- a/missing.txt
-+++ b/missing.txt
-@@ -1,1 +1,1 @@
--old
-+new
-`;
-
+    const patch = `--- a/missing.txt\n+++ b/missing.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.FILE_NOT_FOUND);
     expect(result.llmContent).toContain('does not exist');
@@ -484,18 +582,11 @@ describe('issue #3033 AC6 — missing file is not a context mismatch', () => {
 
   it('still creates the file for a creation patch on a missing target', async () => {
     const filePath = join(tempDir(), 'created.txt');
-
-    const patch = `--- /dev/null
-+++ b/created.txt
-@@ -0,0 +1,1 @@
-+hello
-`;
-
+    const patch = `--- /dev/null\n+++ b/created.txt\n@@ -0,0 +1,1 @@\n+hello\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeUndefined();
     expect(readFileSync(filePath, 'utf-8')).toContain('hello');
   });
@@ -507,27 +598,16 @@ describe('issue #3033 AC7 — single error prefix', () => {
   it('reports a context mismatch with exactly one Failed to apply patch prefix', async () => {
     const filePath = join(tempDir(), 'mismatch.txt');
     writeFileSync(filePath, 'actual content\n', 'utf-8');
-
-    const patch = `--- a/mismatch.txt
-+++ b/mismatch.txt
-@@ -1,1 +1,1 @@
--expected content
-+patched content
-`;
-
+    const patch = `--- a/mismatch.txt\n+++ b/mismatch.txt\n@@ -1,1 +1,1 @@\n-expected content\n+patched content\n`;
     const result = await runPatch(tempDir(), {
       absolute_path: filePath,
       patch_content: patch,
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.PATCH_APPLY_FAILURE);
-    const occurrences = countOccurrences(
-      result.llmContent,
-      'Failed to apply patch:',
+    expect(countOccurrences(result.llmContent, 'Failed to apply patch:')).toBe(
+      1,
     );
-    expect(occurrences).toBe(1);
-    // The message must state the cause and a remedy.
     expect(result.llmContent.toLowerCase()).toContain('context');
     expect(result.llmContent.toLowerCase()).toContain('re-read');
     expect(readFileSync(filePath, 'utf-8')).toBe('actual content\n');
@@ -537,52 +617,172 @@ describe('issue #3033 AC7 — single error prefix', () => {
 describe('issue #3033 AC8 — schema states the path requirement', () => {
   const tempDir = useTempDir();
 
-  function declaresOwn(
-    container: object,
-    name: string,
-  ): container is Record<string, unknown> {
-    return Object.prototype.hasOwnProperty.call(container, name);
-  }
-
-  it('parameter schema declares anyOf requiring one of the two path params', () => {
+  it('parameter schema declares anyOf branches requiring absolute_path and file_path', () => {
     const tool = new ApplyPatchTool(createFakeToolHost(tempDir()));
     const schema: unknown = tool.parameterSchema;
-    expect(typeof schema).toBe('object');
-    expect(schema).not.toBeNull();
-    if (typeof schema !== 'object' || schema === null) return;
-    expect(declaresOwn(schema, 'anyOf')).toBe(true);
-    const anyOf = (schema as Record<string, unknown>).anyOf;
+    expect(isStringRecord(schema)).toBe(true);
+    if (!isStringRecord(schema)) return;
+    expect('anyOf' in schema).toBe(true);
+    const anyOf: unknown = schema.anyOf;
     expect(Array.isArray(anyOf)).toBe(true);
+    if (!Array.isArray(anyOf)) return;
+    const requiredSets: string[][] = [];
+    for (const branch of anyOf) {
+      if (!isStringRecord(branch)) continue;
+      const req: unknown = branch.required;
+      if (isStringArray(req)) requiredSets.push(req);
+    }
+    // The two branches require absolute_path and file_path respectively, so an
+    // empty anyOf cannot satisfy this.
+    expect(requiredSets).toContainEqual(['absolute_path']);
+    expect(requiredSets).toContainEqual(['file_path']);
   });
 
   it('rejects a call omitting both paths with a message naming both parameters', async () => {
     const result = await runPatch(tempDir(), {
       patch_content: '--- a/x\n+++ b/x\n',
     });
-
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
     expect(result.llmContent).toContain('absolute_path');
     expect(result.llmContent).toContain('file_path');
+  });
+
+  it('accepts a call supplying only file_path (no absolute_path)', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'keep\n', 'utf-8');
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,1 +1,1 @@\n-keep\n+kept\n`;
+    const result = await runPatch(tempDir(), {
+      file_path: filePath,
+      patch_content: patch,
+    });
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toBe('kept\n');
   });
 });
 
 describe('issue #3033 AC9 — tool description states the rules', () => {
   const tempDir = useTempDir();
 
-  it('description documents the patch header and count rules', () => {
+  it('description documents the patch header, basename, and count rules truthfully', () => {
     const tool = new ApplyPatchTool(createFakeToolHost(tempDir()));
     const d = tool.description.replace(/\s+/g, ' ');
-    // One target file per call.
-    expect(d).toContain('one');
-    // --- /+++ header required.
+    expect(d).toContain('exactly one target file per call');
     expect(d).toContain('---');
     expect(d).toContain('+++');
-    // /dev/null create/delete.
     expect(d).toContain('/dev/null');
-    // Codex envelope not accepted.
     expect(d).toContain('*** Begin Patch');
-    // Counts are strict.
-    expect(d.toLowerCase()).toContain('count');
+    expect(d).toContain('partial path is not accepted');
+    expect(d).toContain('only the basename is matched');
+    expect(d).toContain('line counts are strict');
+  });
+});
+
+describe('F5 — confirmation matches execution', () => {
+  const tempDir = useTempDir();
+
+  it('does not throw and produces no confirmation for a malformed-count patch', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\n', 'utf-8');
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,1 +1,1 @@\n-a\n-b\n+c\n`;
+    const confirmation = await runConfirmation(
+      tempDir(),
+      { absolute_path: filePath, patch_content: patch },
+      { approvalMode: 'default' },
+    );
+    expect(confirmation).toBe(false);
+  });
+
+  it('produces no confirmation for a zero-hunk patch', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'keep\n', 'utf-8');
+    const patch = `--- a/target.txt\n+++ b/target.txt\n`;
+    const confirmation = await runConfirmation(
+      tempDir(),
+      { absolute_path: filePath, patch_content: patch },
+      { approvalMode: 'default' },
+    );
+    expect(confirmation).toBe(false);
+  });
+
+  it('produces no confirmation for a missing-file non-creation patch', async () => {
+    const filePath = join(tempDir(), 'missing.txt');
+    const patch = `--- a/missing.txt\n+++ b/missing.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n`;
+    const confirmation = await runConfirmation(
+      tempDir(),
+      { absolute_path: filePath, patch_content: patch },
+      { approvalMode: 'default' },
+    );
+    expect(confirmation).toBe(false);
+  });
+
+  it('previews the removal (empty new content) for a valid delete patch', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+    const confirmation = await runConfirmation(
+      tempDir(),
+      {
+        absolute_path: filePath,
+        patch_content: deletePatch('target.txt', ['a', 'b', 'c']),
+      },
+      { approvalMode: 'default' },
+    );
+    expect(confirmation).not.toBe(false);
+    if (confirmation === false) return;
+    expect(isEditConfirmation(confirmation)).toBe(true);
+    if (isEditConfirmation(confirmation)) {
+      expect(confirmation.title.toLowerCase()).toContain('delete');
+      expect(confirmation.newContent).toBe('');
+    }
+    // The file is untouched — confirmation is a preview only.
+    expect(existsSync(filePath)).toBe(true);
+  });
+});
+
+describe('F10 — LSP diagnostics are not collected for a deleted file', () => {
+  const tempDir = useTempDir();
+
+  function fakeLsp(record: { called: boolean; path: string }): ILspService {
+    return {
+      waitForDiagnostics: (p: string) => {
+        record.called = true;
+        record.path = p;
+        return Promise.resolve([]);
+      },
+      getDiagnostics: () => [],
+      getLspConfig: () => undefined,
+    };
+  }
+
+  it('does not wait for diagnostics after a successful delete', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+    const record = { called: false, path: '' };
+    const result = await runPatch(
+      tempDir(),
+      {
+        absolute_path: filePath,
+        patch_content: deletePatch('target.txt', ['a', 'b', 'c']),
+      },
+      { lsp: fakeLsp(record) },
+    );
+    expect(result.error).toBeUndefined();
+    expect(record.called).toBe(false);
+    expect(record.path).toBe('');
+  });
+
+  it('waits for diagnostics on the target after a normal modify', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\n', 'utf-8');
+    const record = { called: false, path: '' };
+    const patch = `--- a/target.txt\n+++ b/target.txt\n@@ -1,2 +1,2 @@\n a\n-b\n+B\n`;
+    const result = await runPatch(
+      tempDir(),
+      { absolute_path: filePath, patch_content: patch },
+      { lsp: fakeLsp(record) },
+    );
+    expect(result.error).toBeUndefined();
+    expect(record.called).toBe(true);
+    expect(record.path).toBe(filePath);
   });
 });

--- a/packages/tools/src/__tests__/apply-patch-ax.bun.test.ts
+++ b/packages/tools/src/__tests__/apply-patch-ax.bun.test.ts
@@ -1,0 +1,588 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #3033 (apply_patch agent-experience fixes).
+ *
+ * Drives the real `ApplyPatchTool` through `validateBuildAndExecute` against a
+ * real on-disk temp directory, asserting on filesystem state and `ToolResult`
+ * content only. No mocking of the tool under test, no private-method access.
+ *
+ * @issue 3033
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IToolHost, ILspService, ToolResult, FileDiff } from '../index.js';
+import { ApplyPatchTool, ToolErrorType } from '../index.js';
+import { describeHunkCountMismatch } from '../tools/apply-patch-analysis.js';
+
+function createTempDir(prefix = 'llxprt-apply-patch-ax-'): {
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = join(
+    tmpdir(),
+    `${prefix}${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return {
+    dir,
+    cleanup: () => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+/**
+ * Shared temp-directory lifecycle: registers the hooks once and returns a
+ * lazy accessor so every describe block wires setup in a single line.
+ */
+function useTempDir(): () => string {
+  let dir = '';
+  let cleanup = (): void => {};
+  beforeEach(() => {
+    const tmp = createTempDir();
+    dir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+  afterEach(() => cleanup());
+  return () => dir;
+}
+
+function createFakeToolHost(targetDir: string): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getEphemeralSettings: () => ({}),
+  };
+}
+
+async function runPatch(
+  targetDir: string,
+  params: Record<string, unknown>,
+  options?: { lsp?: ILspService },
+): Promise<ToolResult> {
+  const tool = new ApplyPatchTool(
+    createFakeToolHost(targetDir),
+    undefined,
+    options?.lsp,
+  );
+  return tool.validateBuildAndExecute(
+    params as never,
+    new AbortController().signal,
+  );
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+function isFileDisplay(rd: unknown): rd is FileDiff {
+  return (
+    isRecord(rd) && 'newContent' in rd && 'fileDiff' in rd && 'fileName' in rd
+  );
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle === '') return 0;
+  let count = 0;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    count++;
+    idx = haystack.indexOf(needle, idx + needle.length);
+  }
+  return count;
+}
+
+describe('issue #3033 AC1 — delete patches delete', () => {
+  const tempDir = useTempDir();
+
+  it('removes the file from disk when a whole-file delete patch is applied', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+
+    const patch = `--- a/target.txt
++++ /dev/null
+@@ -1,3 +0,0 @@
+-a
+-b
+-c
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(existsSync(filePath)).toBe(false);
+    expect(result.llmContent.toLowerCase()).toContain('deleted');
+    expect(result.llmContent).toContain('target.txt');
+    // returnDisplay is a FileDiff showing removal (new content empty).
+    expect(isFileDisplay(result.returnDisplay)).toBe(true);
+    if (isFileDisplay(result.returnDisplay)) {
+      expect(result.returnDisplay.newContent).toBe('');
+    }
+  });
+
+  it('rejects a delete patch that does not remove the whole file and leaves it untouched', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\nd\n', 'utf-8');
+
+    const patch = `--- a/target.txt
++++ /dev/null
+@@ -1,3 +0,0 @@
+-a
+-b
+-c
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.PATCH_APPLY_FAILURE);
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, 'utf-8')).toBe('a\nb\nc\nd\n');
+  });
+
+  it('still rejects a delete patch whose --- header basename does not match the target', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\n', 'utf-8');
+
+    const patch = `--- a/other.txt
++++ /dev/null
+@@ -1,1 +0,0 @@
+-a
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(readFileSync(filePath, 'utf-8')).toBe('a\n');
+  });
+});
+
+describe('issue #3033 AC2 — success message is evidence', () => {
+  const tempDir = useTempDir();
+
+  it('reports hunk count and landing lines for a successful modify', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+
+    const patch = `--- a/target.txt
++++ b/target.txt
+@@ -1,3 +1,3 @@
+ a
+-b
++B
+ c
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeUndefined();
+    // Evidence must name the declared hunk count and the landing line.
+    expect(result.llmContent).toContain(
+      'Patch declared 1 hunk(s). The applied change landed at line 2.',
+    );
+  });
+
+  it('announces when a hunk context block occurs more than once in the file', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'repeat\nx\nrepeat\ny\n', 'utf-8');
+
+    const patch = `--- a/target.txt
++++ b/target.txt
+@@ -1,1 +1,1 @@
+-repeat
++REPLACED
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeUndefined();
+    // Ambiguity announcement must name the hunk, the declared line, the
+    // occurrence count, and every line where the context block appears.
+    expect(result.llmContent).toContain(
+      'Hunk 1 context (declared at line 1) occurs 2 times in the file (lines 1, 3); check the reported landing lines.',
+    );
+  });
+
+  it('notes when a hunk declared line differs from where it actually matched', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'unique\nb\nc\n', 'utf-8');
+
+    // Declared at line 5, but "unique" only exists at line 1.
+    const patch = `--- a/target.txt
++++ b/target.txt
+@@ -5,1 +5,1 @@
+-unique
++CHANGED
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeUndefined();
+    // Drift note must name the hunk, the declared line, and the matched line.
+    expect(result.llmContent).toContain(
+      'Hunk 1 declared line 5 but its context matches line 1.',
+    );
+  });
+
+  it('gives proportionate evidence (lines written) for a creation', async () => {
+    const filePath = join(tempDir(), 'new.txt');
+
+    const patch = `--- /dev/null
++++ b/new.txt
+@@ -0,0 +1,2 @@
++hello
++world
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.llmContent).toContain('Successfully created file from patch');
+    expect(result.llmContent).toContain('Created file with 2 line(s).');
+  });
+});
+
+describe('issue #3033 AC3 — path mismatch names both accepted forms', () => {
+  const tempDir = useTempDir();
+
+  it('names the workspace-relative path and basename as accepted header forms', async () => {
+    const subDir = join(tempDir(), 'sub');
+    mkdirSync(subDir, { recursive: true });
+    const target = join(subDir, 'target.txt');
+    writeFileSync(target, 'keep\n', 'utf-8');
+
+    const patch = `--- a/other.txt
++++ b/other.txt
+@@ -1,1 +1,1 @@
+-keep
++changed
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: target,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    // Header value supplied.
+    expect(result.llmContent).toContain('other.txt');
+    // Workspace-relative accepted form.
+    expect(result.llmContent).toContain('sub/target.txt');
+    // Bare basename accepted form.
+    expect(result.llmContent).toContain('target.txt');
+    // Partial path explicitly not accepted.
+    expect(result.llmContent.toLowerCase()).toContain('partial path');
+    expect(readFileSync(target, 'utf-8')).toBe('keep\n');
+  });
+});
+
+describe('issue #3033 AC4 — missing or unrecognized header is named', () => {
+  const tempDir = useTempDir();
+
+  it('rejects a Codex *** Begin Patch envelope as unsupported', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'keep\n', 'utf-8');
+
+    const patch = `*** Begin Patch
+*** Update File: target.txt
++new
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent).toContain('*** Begin Patch');
+    expect(result.llmContent).toContain('unified diff');
+    expect(readFileSync(filePath, 'utf-8')).toBe('keep\n');
+  });
+
+  it('rejects a patch with --- /+++ headers but no @@ hunks', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'keep\n', 'utf-8');
+
+    const patch = `--- a/target.txt
++++ b/target.txt
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent).toContain('@@');
+    expect(readFileSync(filePath, 'utf-8')).toBe('keep\n');
+  });
+
+  it('rejects a headerless patch and names both accepted header forms', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\n', 'utf-8');
+
+    const patch = `@@ -1,1 +1,1 @@
+-a
++A
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent).toContain('---');
+    expect(result.llmContent).toContain('+++');
+    expect(result.llmContent).toContain('target.txt');
+    expect(readFileSync(filePath, 'utf-8')).toBe('a\n');
+  });
+});
+
+describe('issue #3033 AC5 — hunk count mismatch is translated', () => {
+  const tempDir = useTempDir();
+
+  it('translates a too-small declared old count into header/declared/actual', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\n', 'utf-8');
+
+    // Declared old count 1 but body removes 2 lines.
+    const patch = `--- a/target.txt
++++ b/target.txt
+@@ -1,1 +1,1 @@
+-a
+-b
++c
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent).toContain('@@ -1,1 +1,1 @@');
+    expect(result.llmContent.toLowerCase()).toContain('declared');
+    expect(result.llmContent.toLowerCase()).toContain('actual');
+  });
+
+  it('translates a too-small declared new count into header/declared/actual', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\n', 'utf-8');
+
+    // Declared new count 1 but body adds 2 lines.
+    const patch = `--- a/target.txt
++++ b/target.txt
+@@ -1,1 +1,1 @@
+-a
++b
++c
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent).toContain('@@ -1,1 +1,1 @@');
+    expect(result.llmContent.toLowerCase()).toContain('actual');
+  });
+
+  it('does not misread a removed line that renders as "--- " as a file header', () => {
+    // A real, applicable diff: the removed line "-- some dashed line"
+    // serializes to "--- some dashed line" in the body, and the declared
+    // counts (2 old / 2 new) are correct. The body scanner must NOT terminate
+    // the walk on that line and fabricate a count mismatch. Only the
+    // `--- X` / `+++ Y` header PAIR (or `@@` / `diff --git`) ends a hunk body.
+    const patch = `--- a/target.txt
++++ b/target.txt
+@@ -1,2 +1,2 @@
+--- some dashed line
++-- replaced line
+ keep
+`;
+
+    expect(describeHunkCountMismatch(patch)).toBeNull();
+  });
+});
+
+describe('issue #3033 AC6 — missing file is not a context mismatch', () => {
+  const tempDir = useTempDir();
+
+  it('reports FILE_NOT_FOUND for a non-creation patch on a missing file', async () => {
+    const filePath = join(tempDir(), 'missing.txt');
+
+    const patch = `--- a/missing.txt
++++ b/missing.txt
+@@ -1,1 +1,1 @@
+-old
++new
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.FILE_NOT_FOUND);
+    expect(result.llmContent).toContain('does not exist');
+    expect(result.llmContent).toContain('/dev/null');
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it('still creates the file for a creation patch on a missing target', async () => {
+    const filePath = join(tempDir(), 'created.txt');
+
+    const patch = `--- /dev/null
++++ b/created.txt
+@@ -0,0 +1,1 @@
++hello
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(readFileSync(filePath, 'utf-8')).toContain('hello');
+  });
+});
+
+describe('issue #3033 AC7 — single error prefix', () => {
+  const tempDir = useTempDir();
+
+  it('reports a context mismatch with exactly one Failed to apply patch prefix', async () => {
+    const filePath = join(tempDir(), 'mismatch.txt');
+    writeFileSync(filePath, 'actual content\n', 'utf-8');
+
+    const patch = `--- a/mismatch.txt
++++ b/mismatch.txt
+@@ -1,1 +1,1 @@
+-expected content
++patched content
+`;
+
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.PATCH_APPLY_FAILURE);
+    const occurrences = countOccurrences(
+      result.llmContent,
+      'Failed to apply patch:',
+    );
+    expect(occurrences).toBe(1);
+    // The message must state the cause and a remedy.
+    expect(result.llmContent.toLowerCase()).toContain('context');
+    expect(result.llmContent.toLowerCase()).toContain('re-read');
+    expect(readFileSync(filePath, 'utf-8')).toBe('actual content\n');
+  });
+});
+
+describe('issue #3033 AC8 — schema states the path requirement', () => {
+  const tempDir = useTempDir();
+
+  function declaresOwn(
+    container: object,
+    name: string,
+  ): container is Record<string, unknown> {
+    return Object.prototype.hasOwnProperty.call(container, name);
+  }
+
+  it('parameter schema declares anyOf requiring one of the two path params', () => {
+    const tool = new ApplyPatchTool(createFakeToolHost(tempDir()));
+    const schema: unknown = tool.parameterSchema;
+    expect(typeof schema).toBe('object');
+    expect(schema).not.toBeNull();
+    if (typeof schema !== 'object' || schema === null) return;
+    expect(declaresOwn(schema, 'anyOf')).toBe(true);
+    const anyOf = (schema as Record<string, unknown>).anyOf;
+    expect(Array.isArray(anyOf)).toBe(true);
+  });
+
+  it('rejects a call omitting both paths with a message naming both parameters', async () => {
+    const result = await runPatch(tempDir(), {
+      patch_content: '--- a/x\n+++ b/x\n',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent).toContain('absolute_path');
+    expect(result.llmContent).toContain('file_path');
+  });
+});
+
+describe('issue #3033 AC9 — tool description states the rules', () => {
+  const tempDir = useTempDir();
+
+  it('description documents the patch header and count rules', () => {
+    const tool = new ApplyPatchTool(createFakeToolHost(tempDir()));
+    const d = tool.description.replace(/\s+/g, ' ');
+    // One target file per call.
+    expect(d).toContain('one');
+    // --- /+++ header required.
+    expect(d).toContain('---');
+    expect(d).toContain('+++');
+    // /dev/null create/delete.
+    expect(d).toContain('/dev/null');
+    // Codex envelope not accepted.
+    expect(d).toContain('*** Begin Patch');
+    // Counts are strict.
+    expect(d.toLowerCase()).toContain('count');
+  });
+});

--- a/packages/tools/src/__tests__/apply-patch-ax.bun.test.ts
+++ b/packages/tools/src/__tests__/apply-patch-ax.bun.test.ts
@@ -31,7 +31,11 @@ import type {
   ToolResult,
   FileDiff,
 } from '../index.js';
-import { ApplyPatchTool, ToolErrorType } from '../index.js';
+import {
+  ApplyPatchTool,
+  ToolConfirmationOutcome,
+  ToolErrorType,
+} from '../index.js';
 import type { ApplyPatchToolParams } from '../index.js';
 
 function createTempDir(prefix = 'llxprt-apply-patch-ax-'): {
@@ -73,24 +77,36 @@ interface FakeHostOptions {
   fileSystemService?: IToolHostFileSystemService;
 }
 
+/** Exposes the most recent mode passed to the fake host's setApprovalMode. */
+interface FakeToolHostRecorder {
+  /** undefined until setApprovalMode is called. */
+  recordedApprovalMode: ApprovalMode | undefined;
+}
+
 function createFakeToolHost(
   targetDir: string,
   options?: FakeHostOptions,
-): IToolHost {
-  const base = {
+): IToolHost & FakeToolHostRecorder {
+  const fileSystemService = options?.fileSystemService;
+  // Typed so recordedApprovalMode widens to ApprovalMode | undefined and a
+  // real mode written by setApprovalMode stays assignable (no type assertion).
+  const initialMode: ApprovalMode | undefined = undefined;
+  const host = {
+    recordedApprovalMode: initialMode,
     getTargetDir: () => targetDir,
     getWorkspaceRoots: () => [targetDir],
     getApprovalMode: (): ApprovalMode => options?.approvalMode ?? 'auto',
-    setApprovalMode: () => {},
+    setApprovalMode: (mode: ApprovalMode): void => {
+      host.recordedApprovalMode = mode;
+    },
     isInteractive: () => false,
     hasFeatureFlag: () => false,
     getEphemeralSettings: () => ({}),
+    getFileSystemService: fileSystemService
+      ? (): IToolHostFileSystemService => fileSystemService
+      : undefined,
   };
-  if (options?.fileSystemService) {
-    const fs = options.fileSystemService;
-    return { ...base, getFileSystemService: () => fs };
-  }
-  return base;
+  return host;
 }
 
 interface RunOptions {
@@ -169,6 +185,22 @@ function countOccurrences(haystack: string, needle: string): number {
   return count;
 }
 
+/**
+ * Narrows a ToolResult's llmContent to a string for assertions that need
+ * string semantics (.toLowerCase, indexOf, etc.). llmContent is a
+ * ContentPartListUnion (string | ContentPart | arrays thereof); the tool
+ * returns a string at runtime, but routing through here turns a future shape
+ * change into a clear test failure instead of a confusing TypeError.
+ */
+function llmContentAsString(content: ToolResult['llmContent']): string {
+  if (typeof content !== 'string') {
+    throw new Error(
+      `Expected ToolResult.llmContent to be a string, but got ${typeof content}.`,
+    );
+  }
+  return content;
+}
+
 /** A whole-file delete patch for the given basename. */
 function deletePatch(basename: string, lines: string[]): string {
   const body = lines.map((l) => `-${l}`).join('\n');
@@ -187,7 +219,9 @@ describe('issue #3033 AC1 — delete patches delete', () => {
     });
     expect(result.error).toBeUndefined();
     expect(existsSync(filePath)).toBe(false);
-    expect(result.llmContent.toLowerCase()).toContain('deleted');
+    expect(llmContentAsString(result.llmContent).toLowerCase()).toContain(
+      'deleted',
+    );
     expect(result.llmContent).toContain('target.txt');
     expect(isFileDisplay(result.returnDisplay)).toBe(true);
     if (isFileDisplay(result.returnDisplay)) {
@@ -424,7 +458,9 @@ describe('issue #3033 AC3 — path mismatch names both accepted forms', () => {
     expect(result.llmContent).toContain('other.txt');
     expect(result.llmContent).toContain('sub/target.txt');
     expect(result.llmContent).toContain('target.txt');
-    expect(result.llmContent.toLowerCase()).toContain('partial path');
+    expect(llmContentAsString(result.llmContent).toLowerCase()).toContain(
+      'partial path',
+    );
     expect(readFileSync(target, 'utf-8')).toBe('keep\n');
   });
 });
@@ -554,9 +590,15 @@ describe('issue #3033 AC5 — hunk count mismatch is translated', () => {
     });
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
-    expect(result.llmContent.toLowerCase()).toContain('unknown line');
-    expect(result.llmContent.toLowerCase()).not.toContain('declared');
-    expect(result.llmContent.toLowerCase()).not.toContain('actual');
+    expect(llmContentAsString(result.llmContent).toLowerCase()).toContain(
+      'unknown line',
+    );
+    expect(llmContentAsString(result.llmContent).toLowerCase()).not.toContain(
+      'declared',
+    );
+    expect(llmContentAsString(result.llmContent).toLowerCase()).not.toContain(
+      'actual',
+    );
   });
 
   it('does not misread a "--- "/"+++ " body pair as a file header; surfaces the parser error', async () => {
@@ -574,9 +616,13 @@ describe('issue #3033 AC5 — hunk count mismatch is translated', () => {
     });
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
-    expect(result.llmContent.toLowerCase()).toContain('unknown line');
-    expect(result.llmContent.toLowerCase()).not.toContain('declared');
-    expect(result.llmContent.toLowerCase()).not.toContain(
+    expect(llmContentAsString(result.llmContent).toLowerCase()).toContain(
+      'unknown line',
+    );
+    expect(llmContentAsString(result.llmContent).toLowerCase()).not.toContain(
+      'declared',
+    );
+    expect(llmContentAsString(result.llmContent).toLowerCase()).not.toContain(
       'actually has 0 old line',
     );
   });
@@ -624,11 +670,18 @@ describe('issue #3033 AC7 — single error prefix', () => {
     });
     expect(result.error).toBeDefined();
     expect(result.error?.type).toBe(ToolErrorType.PATCH_APPLY_FAILURE);
-    expect(countOccurrences(result.llmContent, 'Failed to apply patch:')).toBe(
-      1,
+    expect(
+      countOccurrences(
+        llmContentAsString(result.llmContent),
+        'Failed to apply patch:',
+      ),
+    ).toBe(1);
+    expect(llmContentAsString(result.llmContent).toLowerCase()).toContain(
+      'context',
     );
-    expect(result.llmContent.toLowerCase()).toContain('context');
-    expect(result.llmContent.toLowerCase()).toContain('re-read');
+    expect(llmContentAsString(result.llmContent).toLowerCase()).toContain(
+      're-read',
+    );
     expect(readFileSync(filePath, 'utf-8')).toBe('actual content\n');
   });
 });
@@ -755,6 +808,26 @@ describe('F5 — confirmation matches execution', () => {
     }
     // The file is untouched — confirmation is a preview only.
     expect(existsSync(filePath)).toBe(true);
+  });
+
+  it('switches the host to auto-approval when the user picks ProceedAlways on a delete preview', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'a\nb\nc\n', 'utf-8');
+    // 'default' requires confirmation, so shouldConfirmExecute builds a preview.
+    const host = createFakeToolHost(tempDir(), { approvalMode: 'default' });
+    const tool = new ApplyPatchTool(host);
+    const invocation = tool.build({
+      absolute_path: filePath,
+      patch_content: deletePatch('target.txt', ['a', 'b', 'c']),
+    });
+    const confirmation = await invocation.shouldConfirmExecute(
+      new AbortController().signal,
+    );
+    expect(confirmation).not.toBe(false);
+    if (confirmation === false) return;
+    expect(host.recordedApprovalMode).toBeUndefined();
+    await confirmation.onConfirm(ToolConfirmationOutcome.ProceedAlways);
+    expect(host.recordedApprovalMode).toBe('auto');
   });
 });
 

--- a/packages/tools/src/__tests__/apply-patch-ax.bun.test.ts
+++ b/packages/tools/src/__tests__/apply-patch-ax.bun.test.ts
@@ -314,6 +314,25 @@ describe('issue #3033 AC2 — success message is evidence', () => {
     expect(readFileSync(filePath, 'utf-8')).toBe('REPLACED\nx\nrepeat\ny\n');
   });
 
+  it('still announces ambiguity for a patch whose own line endings are CRLF', async () => {
+    const filePath = join(tempDir(), 'target.txt');
+    writeFileSync(filePath, 'repeat\nx\nrepeat\ny\n', 'utf-8');
+    // The patch text itself carries CRLF line endings (model-supplied input).
+    // jsdiff's parsePatch retains the carriage returns on hunk.lines, so
+    // buildAdvisoryNotes must normalise them or the duplicated-context block
+    // never matches and the ambiguity note is silently dropped.
+    const patch =
+      '--- a/target.txt\r\n+++ b/target.txt\r\n@@ -1,1 +1,1 @@\r\n-repeat\r\n+REPLACED\r\n';
+    const result = await runPatch(tempDir(), {
+      absolute_path: filePath,
+      patch_content: patch,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.llmContent).toContain(
+      'Hunk 1 context (declared at line 1) occurs 2 times in the file (lines 1, 3); check the reported landing lines.',
+    );
+  });
+
   it('notes when a hunk declared line differs from where it actually matched', async () => {
     const filePath = join(tempDir(), 'target.txt');
     writeFileSync(filePath, 'unique\nb\nc\n', 'utf-8');

--- a/packages/tools/src/interfaces/IToolHost.ts
+++ b/packages/tools/src/interfaces/IToolHost.ts
@@ -46,6 +46,8 @@ export interface IToolHostFileService {
 export interface IToolHostFileSystemService {
   readTextFile(filePath: string): Promise<string>;
   writeTextFile(filePath: string, content: string): Promise<void>;
+  /** Deletes a file when the host owns the filesystem; optional for back-compat. */
+  deleteFile?(filePath: string): Promise<void>;
 }
 
 export interface IToolHostGitStatsService {

--- a/packages/tools/src/tools/apply-patch-analysis.ts
+++ b/packages/tools/src/tools/apply-patch-analysis.ts
@@ -257,7 +257,11 @@ function buildAdvisoryNotes(
     for (const line of hunk.lines) {
       if (line.startsWith('\\')) continue;
       if (line.startsWith(' ') || line.startsWith('-')) {
-        oldBlock.push(line.slice(1));
+        // Patch text is external, model-supplied input. parsePatch retains a
+        // trailing carriage return on every hunk line when the patch itself
+        // uses CRLF endings, which would never match the LF-normalised
+        // originalLines and silently drop every advisory note. Strip it.
+        oldBlock.push(line.slice(1).replace(/\r$/, ''));
       }
     }
     if (oldBlock.length === 0) return;

--- a/packages/tools/src/tools/apply-patch-analysis.ts
+++ b/packages/tools/src/tools/apply-patch-analysis.ts
@@ -1,0 +1,539 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure analysis and message helpers for apply_patch (issue #3033).
+ *
+ * No I/O, no class state — every export is a pure function over its inputs.
+ * Message wording and patch-header math live here so `apply-patch.ts` stays
+ * small and focused on orchestration.
+ *
+ * @issue 3033
+ */
+
+import * as Diff from 'diff';
+import * as path from 'node:path';
+import type { FileDiff, ToolResult } from './tools.js';
+import { ToolErrorType } from '../types/tool-error.js';
+import { DEFAULT_CREATE_PATCH_OPTIONS } from '../utils/diffOptions.js';
+
+/**
+ * Removes the `a/` or `b/` prefix used in unified-diff headers.
+ * Single source of truth for prefix stripping.
+ */
+export function stripHeaderPrefix(headerPath: string): string {
+  if (headerPath.startsWith('a/') || headerPath.startsWith('b/')) {
+    return headerPath.slice(2);
+  }
+  return headerPath;
+}
+
+/**
+ * Reads the stripped old-file header from a parsed patch. jsdiff types the
+ * field as a required string, but `parsePatch` yields `undefined` for a
+ * headerless patch at runtime, so coerce via `||` rather than `??`.
+ */
+function oldHeaderOf(patch: Diff.StructuredPatch): string {
+  return stripHeaderPrefix(patch.oldFileName || '');
+}
+
+function newHeaderOf(patch: Diff.StructuredPatch): string {
+  return stripHeaderPrefix(patch.newFileName || '');
+}
+
+/**
+ * AC4: a headerless patch (only `@@` and body, no `---`/`+++`) parses with
+ * both file names absent. jsdiff types the names as required strings, so a
+ * truthiness check is the runtime-accurate detector.
+ */
+export function hasNoFileHeader(patch: Diff.StructuredPatch): boolean {
+  return !patch.oldFileName && !patch.newFileName;
+}
+
+/**
+ * AC1: a delete patch sends the file to `/dev/null` from a real old header.
+ */
+export function isDeletePatch(patch: Diff.StructuredPatch): boolean {
+  const oldHeader = oldHeaderOf(patch);
+  const newHeader = newHeaderOf(patch);
+  return (
+    newHeader === '/dev/null' && oldHeader !== '' && oldHeader !== '/dev/null'
+  );
+}
+
+/**
+ * AC6: a creation patch originates from `/dev/null`.
+ */
+export function isCreationPatch(patch: Diff.StructuredPatch): boolean {
+  const oldHeader = oldHeaderOf(patch);
+  const newHeader = newHeaderOf(patch);
+  return (
+    oldHeader === '/dev/null' && newHeader !== '' && newHeader !== '/dev/null'
+  );
+}
+
+/**
+ * Detects a Codex `*** Begin Patch` / `*** Update File:` envelope.
+ */
+export function isCodexEnvelope(patchContent: string): boolean {
+  return /^\*\*\* (Begin Patch|Update File|Add File|Delete File)/m.test(
+    patchContent,
+  );
+}
+
+/**
+ * Splits content into lines, dropping the single trailing empty element that a
+ * final newline produces. Empty content yields an empty array.
+ */
+function splitLines(content: string): string[] {
+  if (content === '') return [];
+  const parts = content.split('\n');
+  if (parts.length > 0 && parts[parts.length - 1] === '') {
+    parts.pop();
+  }
+  return parts;
+}
+
+function formatLanding(newStart: number, newLines: number): string {
+  if (newLines <= 1) {
+    return `line ${newStart}`;
+  }
+  return `lines ${newStart}-${newStart + newLines - 1}`;
+}
+
+/**
+ * AC5: when `Diff.parsePatch` throws, explains a hunk whose declared old/new
+ * counts disagree with its body. Returns null when every hunk agrees so the
+ * caller falls back to the original jsdiff message.
+ */
+export function describeHunkCountMismatch(patchContent: string): string | null {
+  const lines = splitPatchLines(patchContent);
+  const hunkHeaderRe = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+  for (let i = 0; i < lines.length; i++) {
+    const match = hunkHeaderRe.exec(lines[i]);
+    if (match === null) continue;
+    const mismatch = checkHunkCounts(match, lines, i);
+    if (mismatch !== null) return mismatch;
+  }
+  return null;
+}
+
+/** Strips exactly one trailing empty element (the terminating newline). */
+function splitPatchLines(patchContent: string): string[] {
+  const lines = patchContent.split(/\r?\n/);
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines;
+}
+
+/**
+ * True when the line at `index` ends the current hunk's body. A `--- ` line is
+ * a real file-section boundary only as the first half of the `--- X` / `+++ Y`
+ * header pair; on its own it may be a removed line whose content begins with
+ * `-- ` (rendered as `--- X`). A lone `+++ ` line is never a terminator: as a
+ * header it is consumed by the pair on the preceding line, as content it is an
+ * added line.
+ */
+function isHunkTerminator(lines: string[], index: number): boolean {
+  const line = lines[index];
+  if (line.startsWith('@@') || line.startsWith('diff --git')) {
+    return true;
+  }
+  if (line.startsWith('--- ')) {
+    return index + 1 < lines.length && lines[index + 1].startsWith('+++ ');
+  }
+  return false;
+}
+
+/** Stops the body walk at a terminator or any non-body line. */
+function stopsHunkBody(lines: string[], index: number): boolean {
+  if (isHunkTerminator(lines, index)) return true;
+  const line = lines[index];
+  if (line.length === 0) return false;
+  const c = line[0];
+  return c !== ' ' && c !== '-' && c !== '+' && c !== '\\';
+}
+
+/** Walks a hunk body counting actual old/new lines until a terminator. */
+function countHunkBody(
+  lines: string[],
+  start: number,
+): {
+  actualOld: number;
+  actualNew: number;
+} {
+  let actualOld = 0;
+  let actualNew = 0;
+  for (let j = start; j < lines.length; j++) {
+    if (stopsHunkBody(lines, j)) break;
+    const body = lines[j];
+    const first = body.length === 0 ? '' : body[0];
+    if (first === '-') actualOld++;
+    else if (first === '+') actualNew++;
+    else if (first === ' ' || first === '') {
+      actualOld++;
+      actualNew++;
+    }
+  }
+  return { actualOld, actualNew };
+}
+
+/** Compares declared vs actual counts for one hunk; returns a message or null. */
+function checkHunkCounts(
+  match: RegExpExecArray,
+  lines: string[],
+  headerIndex: number,
+): string | null {
+  const counts = countHunkBody(lines, headerIndex + 1);
+  const declaredOld = match[2] ? Number(match[2]) : 1;
+  const declaredNew = match[4] ? Number(match[4]) : 1;
+  if (counts.actualOld === declaredOld && counts.actualNew === declaredNew) {
+    return null;
+  }
+  return `Hunk header "${lines[headerIndex]}" (line ${headerIndex + 1}) declared ${declaredOld} old line(s) and ${declaredNew} new line(s), but the body actually has ${counts.actualOld} old line(s) and ${counts.actualNew} new line(s). @@ line numbers are tolerant but the old/new counts are strict; fix the @@ counts to match the body.`;
+}
+
+/**
+ * Finds every 1-based start index in `lines` where `block` matches exactly.
+ */
+function findBlockMatches(block: readonly string[], lines: string[]): number[] {
+  const matches: number[] = [];
+  if (block.length === 0) return matches;
+  for (let i = 0; i + block.length <= lines.length; i++) {
+    let ok = true;
+    for (let j = 0; j < block.length; j++) {
+      if (lines[i + j] !== block[j]) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) matches.push(i + 1);
+  }
+  return matches;
+}
+
+interface PatchEvidence {
+  summary: string;
+  notes: string[];
+}
+
+/**
+ * AC2: advisory notes computed per declared hunk against the original content.
+ * Announces ambiguity (multiple matches) and declared-vs-actual line drift.
+ */
+function buildAdvisoryNotes(
+  patch: Diff.StructuredPatch,
+  originalLines: string[],
+): string[] {
+  const notes: string[] = [];
+  patch.hunks.forEach((hunk, idx) => {
+    const hunkNumber = idx + 1;
+    const oldBlock: string[] = [];
+    for (const line of hunk.lines) {
+      if (line.startsWith('\\')) continue;
+      if (line.startsWith(' ') || line.startsWith('-')) {
+        oldBlock.push(line.slice(1));
+      }
+    }
+    if (oldBlock.length === 0) return;
+    const matches = findBlockMatches(oldBlock, originalLines);
+    if (matches.length === 0) return;
+    if (matches.length > 1) {
+      notes.push(
+        `Hunk ${hunkNumber} context (declared at line ${hunk.oldStart}) occurs ${matches.length} times in the file (lines ${matches.join(', ')}); check the reported landing lines.`,
+      );
+    } else if (matches[0] !== hunk.oldStart) {
+      notes.push(
+        `Hunk ${hunkNumber} declared line ${hunk.oldStart} but its context matches line ${matches[0]}.`,
+      );
+    }
+  });
+  return notes;
+}
+
+/**
+ * AC2: evidence for a successful modify — declared hunk count, true landing
+ * positions derived from the before/after content, plus advisory notes.
+ */
+export function buildModifyEvidence(
+  currentContent: string,
+  newContent: string,
+  patch: Diff.StructuredPatch,
+  fileName: string,
+): PatchEvidence {
+  const declaredHunks = patch.hunks.length;
+  const landing = Diff.structuredPatch(
+    fileName,
+    fileName,
+    currentContent,
+    newContent,
+    '',
+    '',
+    { context: 0 },
+  );
+  const ranges = landing.hunks.map((h) =>
+    formatLanding(h.newStart, h.newLines),
+  );
+  const where = ranges.length > 0 ? ranges.join('; ') : 'no change';
+  const summary = `Patch declared ${declaredHunks} hunk(s). The applied change landed at ${where}.`;
+  const notes = buildAdvisoryNotes(patch, splitLines(currentContent));
+  return { summary, notes };
+}
+
+/** AC2: proportionate evidence for a creation (lines written). */
+export function buildCreateEvidence(newContent: string): string {
+  return `Created file with ${splitLines(newContent).length} line(s).`;
+}
+
+/** AC2: proportionate evidence for a deletion (lines removed). */
+export function buildDeleteEvidence(currentContent: string): string {
+  return `Removed ${splitLines(currentContent).length} line(s).`;
+}
+
+/** AC2: assembles the success message parts for a modify or create. */
+export function buildSuccessParts(opts: {
+  fileExists: boolean;
+  filePath: string;
+  currentContent: string;
+  newContent: string;
+  patch: Diff.StructuredPatch;
+  fileName: string;
+  modifiedByUser: boolean;
+}): string[] {
+  const parts: string[] = [
+    opts.fileExists
+      ? `Successfully applied patch to file: ${opts.filePath}.`
+      : `Successfully created file from patch: ${opts.filePath}.`,
+  ];
+  if (opts.modifiedByUser) {
+    parts.push('User modified the patch content.');
+  }
+  if (opts.fileExists) {
+    const evidence = buildModifyEvidence(
+      opts.currentContent,
+      opts.newContent,
+      opts.patch,
+      opts.fileName,
+    );
+    parts.push(evidence.summary);
+    parts.push(...evidence.notes);
+  } else {
+    parts.push(buildCreateEvidence(opts.newContent));
+  }
+  return parts;
+}
+
+// ---------------------------------------------------------------------------
+// AC3: patch-header target validation (matching rules preserved verbatim).
+// ---------------------------------------------------------------------------
+
+/**
+ * AC3: validates the parsed patch header targets the same file as the
+ * absolute_path. Matching rules are unchanged from the original implementation;
+ * only the rejection message now names both accepted forms.
+ */
+export function validatePatchHeader(
+  patch: Diff.StructuredPatch,
+  filePath: string,
+  targetDir: string,
+): ToolResult | null {
+  const targetName = path.basename(filePath);
+
+  const newHeader = newHeaderOf(patch);
+  const oldHeader = oldHeaderOf(patch);
+
+  const isNewFileFromNull =
+    oldHeader === '/dev/null' && newHeader !== '' && newHeader !== '/dev/null';
+  const isDeleteToNull =
+    newHeader === '/dev/null' && oldHeader !== '' && oldHeader !== '/dev/null';
+
+  if (isNewFileFromNull || isDeleteToNull) {
+    if (isNewFileFromNull && path.basename(newHeader) === targetName) {
+      return null;
+    }
+    if (isDeleteToNull && path.basename(oldHeader) === targetName) {
+      return null;
+    }
+  }
+
+  const toPosix = (p: string): string => p.split(path.sep).join('/');
+  const relativePath = toPosix(path.relative(targetDir, filePath));
+  const headerMatches = (header: string): boolean => {
+    if (header === '') return false;
+    if (header.includes('/') || header.includes(path.sep)) {
+      return toPosix(header) === relativePath;
+    }
+    return path.basename(header) === targetName;
+  };
+
+  if (headerMatches(newHeader) || headerMatches(oldHeader)) {
+    return null;
+  }
+
+  const describedTarget = newHeader || oldHeader || '(unknown)';
+  const msg = `Patch header targets "${describedTarget}" but absolute_path is "${filePath}". The header path must be either the workspace-relative path "${relativePath}" or the bare file name "${targetName}"; a partial path is not accepted. Ensure the patch header matches the target file.`;
+  return {
+    llmContent: msg,
+    returnDisplay: `Rejected patch: header target "${describedTarget}" does not match absolute_path "${targetName}".`,
+    error: {
+      message: msg,
+      type: ToolErrorType.INVALID_TOOL_PARAMS,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ToolResult builders for each rejection / success path.
+// ---------------------------------------------------------------------------
+
+export function buildWorkspacePathResult(pathError: string): ToolResult {
+  return {
+    llmContent: pathError,
+    returnDisplay: 'File path is not within workspace',
+    error: { message: pathError, type: ToolErrorType.INVALID_TOOL_PARAMS },
+  };
+}
+
+export function buildNoSectionsResult(): ToolResult {
+  return {
+    llmContent:
+      'Patch content did not contain any parseable file sections. Provide a valid unified diff with at least one file section.',
+    returnDisplay: 'No parseable patch sections found.',
+    error: {
+      message: 'Patch content did not contain any parseable file sections.',
+      type: ToolErrorType.INVALID_TOOL_PARAMS,
+    },
+  };
+}
+
+export function buildMultiSectionResult(
+  patches: Diff.StructuredPatch[],
+): ToolResult {
+  const fileNames = patches
+    .map((p) => p.newFileName || p.oldFileName)
+    .join(', ');
+  return {
+    llmContent: `apply_patch accepts a single target file patch, but the provided patch_content contained ${patches.length} file sections (${fileNames}). Make a separate apply_patch call for each file.`,
+    returnDisplay: `Rejected multi-file patch: ${patches.length} file sections.`,
+    error: {
+      message: `apply_patch accepts a single target file patch, but the patch_content contained ${patches.length} file sections. Use a separate apply_patch call per file.`,
+      type: ToolErrorType.INVALID_TOOL_PARAMS,
+    },
+  };
+}
+
+export function buildParseErrorResult(message: string): ToolResult {
+  return {
+    llmContent: `Failed to parse patch: ${message}`,
+    returnDisplay: `Error parsing patch: ${message}`,
+    error: {
+      message: `Failed to parse patch: ${message}`,
+      type: ToolErrorType.INVALID_TOOL_PARAMS,
+    },
+  };
+}
+
+export function buildCodexResult(): ToolResult {
+  const msg =
+    'The "*** Begin Patch" / "*** Update File:" / "*** Add File:" / "*** Delete File:" envelope (Codex patch format) is not supported. Provide a unified diff with "---"/"+++" file headers and "@@" hunks.';
+  return {
+    llmContent: msg,
+    returnDisplay: msg,
+    error: { message: msg, type: ToolErrorType.INVALID_TOOL_PARAMS },
+  };
+}
+
+export function buildNoHunksResult(): ToolResult {
+  const msg =
+    'The patch declares no "@@" hunks, so it would change nothing. Provide at least one "@@" hunk with "---"/"+++" headers.';
+  return {
+    llmContent: msg,
+    returnDisplay: msg,
+    error: { message: msg, type: ToolErrorType.INVALID_TOOL_PARAMS },
+  };
+}
+
+export function buildHeaderlessResult(
+  relativePath: string,
+  basename: string,
+): ToolResult {
+  const msg = `The patch has "@@" hunks but is missing the "---"/"+++" file header. A header is required; for this target use either "--- a/${relativePath}" / "+++ b/${relativePath}" or "--- ${basename}" / "+++ ${basename}".`;
+  return {
+    llmContent: msg,
+    returnDisplay: msg,
+    error: { message: msg, type: ToolErrorType.INVALID_TOOL_PARAMS },
+  };
+}
+
+export function buildMissingFileResult(absolutePath: string): ToolResult {
+  const msg = `The file does not exist at "${absolutePath}". To create a new file, use a creation patch with "--- /dev/null" as the old header.`;
+  return {
+    llmContent: msg,
+    returnDisplay: msg,
+    error: { message: msg, type: ToolErrorType.FILE_NOT_FOUND },
+  };
+}
+
+/** AC7: context mismatch — single prefix, states cause and remedy. */
+export function buildContextMismatchResult(): ToolResult {
+  const msg =
+    "Failed to apply patch: the hunk context lines do not match the file's current content. Re-read the file and rebuild the patch against current content.";
+  return {
+    llmContent: msg,
+    returnDisplay: msg,
+    error: { message: msg, type: ToolErrorType.PATCH_APPLY_FAILURE },
+  };
+}
+
+/** AC7: genuine throw from applyPatch — single prefix. */
+export function buildApplyThrowResult(errorMsg: string): ToolResult {
+  return {
+    llmContent: `Failed to apply patch: ${errorMsg}`,
+    returnDisplay: `Error applying patch: ${errorMsg}`,
+    error: {
+      message: `Failed to apply patch: ${errorMsg}`,
+      type: ToolErrorType.PATCH_APPLY_FAILURE,
+    },
+  };
+}
+
+/** AC1: a delete patch that does not remove the whole file. */
+export function buildDeletePartialResult(appliedResult: string): ToolResult {
+  const remaining = splitLines(appliedResult).length;
+  const msg = `Delete patch would leave ${remaining} line(s) in the file; a delete patch must remove the entire file. Re-read the file and rebuild the delete patch to cover every line.`;
+  return {
+    llmContent: msg,
+    returnDisplay: msg,
+    error: { message: msg, type: ToolErrorType.PATCH_APPLY_FAILURE },
+  };
+}
+
+/** AC1: a successful whole-file deletion — FileDiff showing the removal. */
+export function buildDeleteDisplay(
+  fileName: string,
+  filePath: string,
+  currentContent: string,
+): ToolResult {
+  const fileDiff = Diff.createPatch(
+    fileName,
+    currentContent,
+    '',
+    'Current',
+    'Deleted',
+    DEFAULT_CREATE_PATCH_OPTIONS,
+  );
+  const display: FileDiff = {
+    fileDiff,
+    fileName,
+    originalContent: currentContent,
+    newContent: '',
+  };
+  return {
+    llmContent: `Successfully deleted file from patch: ${filePath}.\n\n${buildDeleteEvidence(currentContent)}`,
+    returnDisplay: display,
+  };
+}

--- a/packages/tools/src/tools/apply-patch-analysis.ts
+++ b/packages/tools/src/tools/apply-patch-analysis.ts
@@ -97,8 +97,23 @@ function splitLines(content: string): string[] {
   return parts;
 }
 
-function formatLanding(newStart: number, newLines: number): string {
-  if (newLines <= 1) {
+/**
+ * Renders where a landed hunk sits in the RESULTING file. A pure deletion
+ * yields `newLines === 0`, in which case `newStart` names a line that no longer
+ * exists; describe the boundary where content was removed instead so the
+ * evidence never names a nonexistent line.
+ */
+function formatLanding(
+  newStart: number,
+  newLines: number,
+  resultLineCount: number,
+): string {
+  if (newLines === 0) {
+    return newStart > resultLineCount
+      ? 'content removed at end of file'
+      : `content removed before line ${newStart}`;
+  }
+  if (newLines === 1) {
     return `line ${newStart}`;
   }
   return `lines ${newStart}-${newStart + newLines - 1}`;
@@ -133,10 +148,12 @@ function splitPatchLines(patchContent: string): string[] {
 /**
  * True when the line at `index` ends the current hunk's body. A `--- ` line is
  * a real file-section boundary only as the first half of the `--- X` / `+++ Y`
- * header pair; on its own it may be a removed line whose content begins with
- * `-- ` (rendered as `--- X`). A lone `+++ ` line is never a terminator: as a
- * header it is consumed by the pair on the preceding line, as content it is an
- * added line.
+ * header pair, and that pair is ALWAYS followed by a `@@` hunk header. A removed
+ * line whose content begins with `-- ` (rendered `--- X`) next to an added line
+ * whose content begins with `++ ` (rendered `+++ Y`) serialises to the same two
+ * leading lines, so the `@@` on the third line is the disambiguator. A lone
+ * `+++ ` line is never a terminator: as a header it is consumed by the pair on
+ * the preceding line, as content it is an added line.
  */
 function isHunkTerminator(lines: string[], index: number): boolean {
   const line = lines[index];
@@ -144,7 +161,11 @@ function isHunkTerminator(lines: string[], index: number): boolean {
     return true;
   }
   if (line.startsWith('--- ')) {
-    return index + 1 < lines.length && lines[index + 1].startsWith('+++ ');
+    return (
+      index + 2 < lines.length &&
+      lines[index + 1].startsWith('+++ ') &&
+      lines[index + 2].startsWith('@@')
+    );
   }
   return false;
 }
@@ -275,8 +296,9 @@ export function buildModifyEvidence(
     '',
     { context: 0 },
   );
+  const resultLineCount = splitLines(newContent).length;
   const ranges = landing.hunks.map((h) =>
-    formatLanding(h.newStart, h.newLines),
+    formatLanding(h.newStart, h.newLines, resultLineCount),
   );
   const where = ranges.length > 0 ? ranges.join('; ') : 'no change';
   const summary = `Patch declared ${declaredHunks} hunk(s). The applied change landed at ${where}.`;
@@ -346,10 +368,8 @@ export function validatePatchHeader(
   const newHeader = newHeaderOf(patch);
   const oldHeader = oldHeaderOf(patch);
 
-  const isNewFileFromNull =
-    oldHeader === '/dev/null' && newHeader !== '' && newHeader !== '/dev/null';
-  const isDeleteToNull =
-    newHeader === '/dev/null' && oldHeader !== '' && oldHeader !== '/dev/null';
+  const isNewFileFromNull = isCreationPatch(patch);
+  const isDeleteToNull = isDeletePatch(patch);
 
   if (isNewFileFromNull || isDeleteToNull) {
     if (isNewFileFromNull && path.basename(newHeader) === targetName) {

--- a/packages/tools/src/tools/apply-patch.ts
+++ b/packages/tools/src/tools/apply-patch.ts
@@ -272,6 +272,13 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
     return this.buildEditConfirmation(filePath, currentContent, applied);
   }
 
+  /** ProceedAlways flips the host to auto-approval so later patches skip the prompt. */
+  private handleConfirmationOutcome(outcome: ToolConfirmationOutcome): void {
+    if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+      this.host.setApprovalMode('auto');
+    }
+  }
+
   private buildEditConfirmation(
     filePath: string,
     currentContent: string,
@@ -307,9 +314,7 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       originalContent: currentContent,
       newContent,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
-        if (outcome === ToolConfirmationOutcome.ProceedAlways) {
-          this.host.setApprovalMode('auto');
-        }
+        this.handleConfirmationOutcome(outcome);
         if (ideConfirmation) {
           const result = await ideConfirmation;
           if (result.status === 'accepted' && result.content) {
@@ -345,7 +350,9 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       fileDiff,
       originalContent: currentContent,
       newContent: '',
-      onConfirm: async () => {},
+      onConfirm: async (outcome: ToolConfirmationOutcome) => {
+        this.handleConfirmationOutcome(outcome);
+      },
     };
     return confirmationDetails;
   }

--- a/packages/tools/src/tools/apply-patch.ts
+++ b/packages/tools/src/tools/apply-patch.ts
@@ -229,6 +229,11 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
 
   /**
    * Handles the confirmation prompt for the ApplyPatch tool.
+   *
+   * Returns `false` for every input `execute` rejects so the caller reaches
+   * `execute`, which emits the actionable error. The same predicates and
+   * validation helpers `execute` uses are reused here directly (no parallel
+   * re-implementation), keeping preview and execution in lockstep.
    */
   override async shouldConfirmExecute(
     _abortSignal: AbortSignal,
@@ -239,38 +244,42 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
     }
 
     const filePath = this.getFilePath();
-    let currentContent = '';
 
-    try {
-      currentContent = await this.readTextFile(filePath);
-    } catch (err: unknown) {
-      // File doesn't exist yet - will be created
-      if (!isNodeError(err) || err.code !== 'ENOENT') {
-        throw err;
-      }
-    }
+    const parsed = this.parsePatchContent();
+    if (!Array.isArray(parsed)) return false;
+    const [patch] = parsed;
 
-    // Parse and apply patch to get preview. Use the same validation path as
-    // execute so previews match execution behavior.
-    const patches = Diff.parsePatch(this.params.patch_content);
-    if (patches.length === 0) {
-      return false;
-    }
-    if (patches.length > 1) {
-      return false;
-    }
-    const newContentResult = Diff.applyPatch(currentContent, patches[0]);
-
-    if (typeof newContentResult !== 'string') {
+    if (this.checkPatchHeader(patch) !== null) return false;
+    if (
+      validatePatchHeader(patch, filePath, getTargetDirCompat(this.host)) !==
+      null
+    ) {
       return false;
     }
 
-    const newContent = newContentResult;
+    const { currentContent, fileExists } =
+      await this.readCurrentContent(filePath);
+    if (!fileExists && !isCreationPatch(patch)) return false;
 
+    const applied = this.applyPatchToContent(currentContent, patch);
+    if (typeof applied !== 'string') return false;
+
+    if (isDeletePatch(patch)) {
+      return applied === ''
+        ? this.buildDeleteConfirmation(filePath, currentContent)
+        : false;
+    }
+    return this.buildEditConfirmation(filePath, currentContent, applied);
+  }
+
+  private buildEditConfirmation(
+    filePath: string,
+    currentContent: string,
+    newContent: string,
+  ): ToolCallConfirmationDetails | false {
     const relativePath = makeRelative(filePath, getTargetDirCompat(this.host));
     const fileName = path.basename(filePath);
-
-    const fileDiffResult = Diff.createPatch(
+    const fileDiff = Diff.createPatch(
       fileName,
       currentContent,
       newContent,
@@ -278,12 +287,7 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       'Proposed',
       DEFAULT_CREATE_PATCH_OPTIONS,
     );
-
-    if (!fileDiffResult) {
-      return false;
-    }
-
-    const fileDiff = fileDiffResult;
+    if (!fileDiff) return false;
 
     const ideConfirmation =
       this.ideService !== undefined &&
@@ -304,16 +308,42 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
           this.host.setApprovalMode('auto');
         }
-
         if (ideConfirmation) {
           const result = await ideConfirmation;
           if (result.status === 'accepted' && result.content) {
-            // User modified content in IDE - we'd need to regenerate patch
-            // For now, we don't support this flow for apply_patch
+            // IDE edit flow unsupported for apply_patch
           }
         }
       },
       ideConfirmation,
+    };
+    return confirmationDetails;
+  }
+
+  /** A delete preview presents the removal (new content empty), not an edit. */
+  private buildDeleteConfirmation(
+    filePath: string,
+    currentContent: string,
+  ): ToolCallConfirmationDetails {
+    const relativePath = makeRelative(filePath, getTargetDirCompat(this.host));
+    const fileName = path.basename(filePath);
+    const fileDiff = Diff.createPatch(
+      fileName,
+      currentContent,
+      '',
+      'Current',
+      'Deleted',
+      DEFAULT_CREATE_PATCH_OPTIONS,
+    );
+    const confirmationDetails: ToolEditConfirmationDetails = {
+      type: 'edit',
+      title: `Confirm Delete via Patch: ${shortenPath(relativePath)}`,
+      fileName,
+      filePath,
+      fileDiff,
+      originalContent: currentContent,
+      newContent: '',
+      onConfirm: async () => {},
     };
     return confirmationDetails;
   }
@@ -393,6 +423,19 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       return;
     }
     await fs.writeFile(filePath, content, 'utf8');
+  }
+
+  private async deleteTextFile(filePath: string): Promise<void> {
+    const fileSystemService = this.host.getFileSystemService?.();
+    if (fileSystemService?.deleteFile !== undefined) {
+      await fileSystemService.deleteFile(filePath);
+      return;
+    }
+    // The abstraction's paths are real filesystem paths (AcpFileSystemService
+    // itself falls back to a local service for unsupported ops), so unlink
+    // targets the right file for every in-tree host when no host delete is
+    // supplied.
+    await fs.unlink(filePath);
   }
 
   private async readCurrentContent(
@@ -481,7 +524,19 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
     appliedResult: string,
   ): Promise<ToolResult> {
     if (appliedResult !== '') return buildDeletePartialResult(appliedResult);
-    await fs.unlink(filePath);
+    try {
+      await this.deleteTextFile(filePath);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      return {
+        llmContent: `Error deleting file: ${errorMsg}`,
+        returnDisplay: `Error deleting file: ${errorMsg}`,
+        error: {
+          message: errorMsg,
+          type: ToolErrorType.FILE_WRITE_FAILURE,
+        },
+      };
+    }
     const gitStats = await this.trackGitStats(filePath, currentContent, '');
     const result = buildDeleteDisplay(
       path.basename(filePath),
@@ -548,8 +603,7 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
         modifiedByUser: this.params.modified_by_user === true,
       });
 
-      const classification = classifyPatchOperations([patch]);
-      await this.appendLspDiagnostics(filePath, classification, parts);
+      await this.appendLspDiagnostics(filePath, parts);
 
       const result: ToolResult = {
         llmContent: parts.join('\n\n'),
@@ -598,7 +652,6 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
   // @requirement REQ-DIAG-010
   private async appendLspDiagnostics(
     filePath: string,
-    classification: { contentWriteFiles: string[] },
     llmParts: string[],
   ): Promise<void> {
     try {
@@ -666,7 +719,7 @@ export class ApplyPatchTool extends BaseDeclarativeTool<
       'ApplyPatch',
       `Applies a unified diff patch to exactly one target file per call.
 
-      A "---"/"+++" file header is required; the header path must be the workspace-relative path or the bare file name (a partial path is not accepted). Use "--- /dev/null" as the old header to create a file and "+++ /dev/null" as the new header to delete one. In each "@@" hunk the line numbers are tolerant but the old/new line counts are strict. The Codex "*** Begin Patch" envelope is not accepted; provide a standard unified diff.`,
+      A "---"/"+++" file header is required. For ordinary edits the header path must be the workspace-relative path or the bare file name (a partial path is not accepted); for create and delete patches (using /dev/null) only the basename is matched. Use "--- /dev/null" as the old header to create a file and "+++ /dev/null" as the new header to delete one. In each "@@" hunk the line numbers are tolerant but the old/new line counts are strict. The Codex "*** Begin Patch" envelope is not accepted; provide a standard unified diff.`,
       Kind.Edit,
       {
         properties: {
@@ -675,12 +728,12 @@ export class ApplyPatchTool extends BaseDeclarativeTool<
               (process.platform === 'win32'
                 ? "The absolute path to the file to modify (e.g., 'C:\\Users\\project\\file.txt'). Must be an absolute path. "
                 : "The absolute path to the file to modify (e.g., '/home/user/project/file.txt'). Must start with '/'. ") +
-              'Exactly one of absolute_path or file_path is required.',
+              'At least one of absolute_path or file_path is required; absolute_path takes precedence when both are supplied.',
             type: 'string',
           },
           file_path: {
             description:
-              'Alternative parameter name for absolute_path (for backward compatibility). The absolute path to the file to modify. Exactly one of absolute_path or file_path is required.',
+              'Alternative parameter name for absolute_path (for backward compatibility). The absolute path to the file to modify. At least one of absolute_path or file_path is required; absolute_path takes precedence when both are supplied.',
             type: 'string',
           },
           patch_content: {

--- a/packages/tools/src/tools/apply-patch.ts
+++ b/packages/tools/src/tools/apply-patch.ts
@@ -276,9 +276,12 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
     filePath: string,
     currentContent: string,
     newContent: string,
-  ): ToolCallConfirmationDetails | false {
+  ): ToolCallConfirmationDetails {
     const relativePath = makeRelative(filePath, getTargetDirCompat(this.host));
     const fileName = path.basename(filePath);
+    // Diff.createPatch always returns a non-empty string (verified for every
+    // input including full deletion and empty-to-empty), so there is no falsy
+    // state to guard against. The delete helper relies on the same invariant.
     const fileDiff = Diff.createPatch(
       fileName,
       currentContent,
@@ -287,7 +290,6 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       'Proposed',
       DEFAULT_CREATE_PATCH_OPTIONS,
     );
-    if (!fileDiff) return false;
 
     const ideConfirmation =
       this.ideService !== undefined &&

--- a/packages/tools/src/tools/apply-patch.ts
+++ b/packages/tools/src/tools/apply-patch.ts
@@ -47,6 +47,27 @@ import {
   getLegacyIdeService,
   getLegacyLspService,
 } from './edit-utils.js';
+import {
+  buildApplyThrowResult,
+  buildCodexResult,
+  buildContextMismatchResult,
+  buildDeleteDisplay,
+  buildDeletePartialResult,
+  buildHeaderlessResult,
+  buildMissingFileResult,
+  buildMultiSectionResult,
+  buildNoHunksResult,
+  buildNoSectionsResult,
+  buildParseErrorResult,
+  buildSuccessParts,
+  buildWorkspacePathResult,
+  describeHunkCountMismatch,
+  hasNoFileHeader,
+  isCodexEnvelope,
+  isCreationPatch,
+  isDeletePatch,
+  validatePatchHeader,
+} from './apply-patch-analysis.js';
 
 /**
  * Type representing a parsed patch operation
@@ -303,37 +324,54 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
   override async execute(_signal: AbortSignal): Promise<ToolResult> {
     const filePath = this.getFilePath();
 
-    // Validate file path is within workspace
+    // 1. Validate file path is within workspace.
     const pathError = validatePathWithinWorkspace(
       getWorkspaceRootsCompat(this.host),
       filePath,
     );
-    if (pathError) {
-      return {
-        llmContent: pathError,
-        returnDisplay: 'File path is not within workspace',
-        error: {
-          message: pathError,
-          type: ToolErrorType.INVALID_TOOL_PARAMS,
-        },
-      };
-    }
+    if (pathError) return buildWorkspacePathResult(pathError);
 
+    // 2. Parse patch content (AC5 enriches count-mismatch throws).
+    const parsed = this.parsePatchContent();
+    if (!Array.isArray(parsed)) return parsed;
+
+    const [patch] = parsed;
+
+    // 4. Header-presence check (AC4) before target validation.
+    const headerError = this.checkPatchHeader(patch);
+    if (headerError) return headerError;
+
+    // 5. Validate patch header targets this file (AC3).
+    const targetError = validatePatchHeader(
+      patch,
+      filePath,
+      getTargetDirCompat(this.host),
+    );
+    if (targetError) return targetError;
+
+    // 6. Read current content.
     const { currentContent, fileExists } =
       await this.readCurrentContent(filePath);
-    const patches = this.parsePatchContent();
-    if (!Array.isArray(patches)) return patches;
 
-    const classification = classifyPatchOperations(patches);
-    const newContent = this.applyPatch(currentContent, patches);
-    if (typeof newContent !== 'string') return newContent;
+    // 7. Missing file is not a context mismatch (AC6).
+    if (!fileExists && !isCreationPatch(patch)) {
+      return buildMissingFileResult(filePath);
+    }
 
+    // 8. Apply patch (AC7: single error prefix).
+    const applied = this.applyPatchToContent(currentContent, patch);
+    if (typeof applied !== 'string') return applied;
+
+    // 9. Delete branch (AC1), else write branch (AC2).
+    if (isDeletePatch(patch)) {
+      return this.handleDelete(filePath, currentContent, applied);
+    }
     return this.writeAndFormatResult(
       filePath,
       currentContent,
-      newContent,
+      applied,
       fileExists,
-      classification,
+      patch,
     );
   }
 
@@ -379,154 +417,81 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
     try {
       patches = Diff.parsePatch(this.params.patch_content);
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      return {
-        llmContent: `Failed to parse patch: ${errorMsg}`,
-        returnDisplay: `Error parsing patch: ${errorMsg}`,
-        error: {
-          message: `Failed to parse patch: ${errorMsg}`,
-          type: ToolErrorType.INVALID_TOOL_PARAMS,
-        },
-      };
+      const originalMsg =
+        error instanceof Error ? error.message : String(error);
+      const enriched =
+        describeHunkCountMismatch(this.params.patch_content) ?? originalMsg;
+      return buildParseErrorResult(enriched);
     }
 
-    if (patches.length === 0) {
-      return {
-        llmContent:
-          'Patch content did not contain any parseable file sections. Provide a valid unified diff with at least one file section.',
-        returnDisplay: 'No parseable patch sections found.',
-        error: {
-          message: 'Patch content did not contain any parseable file sections.',
-          type: ToolErrorType.INVALID_TOOL_PARAMS,
-        },
-      };
-    }
-
-    if (patches.length > 1) {
-      const fileNames = patches
-        .map((p) => p.newFileName || p.oldFileName)
-        .join(', ');
-      return {
-        llmContent: `apply_patch accepts a single target file patch, but the provided patch_content contained ${patches.length} file sections (${fileNames}). Make a separate apply_patch call for each file.`,
-        returnDisplay: `Rejected multi-file patch: ${patches.length} file sections.`,
-        error: {
-          message: `apply_patch accepts a single target file patch, but the patch_content contained ${patches.length} file sections. Use a separate apply_patch call per file.`,
-          type: ToolErrorType.INVALID_TOOL_PARAMS,
-        },
-      };
-    }
+    if (patches.length === 0) return buildNoSectionsResult();
+    if (patches.length > 1) return buildMultiSectionResult(patches);
 
     return patches;
   }
 
-  private applyPatch(
-    currentContent: string,
-    patches: Diff.StructuredPatch[],
-  ): string | ToolResult {
-    const [patch] = patches;
-    const targetError = this.validatePatchTarget(patch);
-    if (targetError) {
-      return targetError;
+  /**
+   * AC4: rejects patches with missing or unrecognized headers before target
+   * validation. Removes the silent no-op and the "(unknown)" message.
+   */
+  private checkPatchHeader(patch: Diff.StructuredPatch): ToolResult | null {
+    if (patch.hunks.length === 0) {
+      return isCodexEnvelope(this.params.patch_content)
+        ? buildCodexResult()
+        : buildNoHunksResult();
     }
+    if (hasNoFileHeader(patch)) {
+      const filePath = this.getFilePath();
+      return buildHeaderlessResult(
+        this.computeRelativePath(filePath),
+        path.basename(filePath),
+      );
+    }
+    return null;
+  }
 
+  private computeRelativePath(filePath: string): string {
+    const toPosix = (p: string): string => p.split(path.sep).join('/');
+    return toPosix(path.relative(getTargetDirCompat(this.host), filePath));
+  }
+
+  /**
+   * AC7: applies the patch. A non-string result returns its ToolResult
+   * directly so "Failed to apply patch:" appears exactly once.
+   */
+  private applyPatchToContent(
+    currentContent: string,
+    patch: Diff.StructuredPatch,
+  ): string | ToolResult {
     try {
-      const newContentResult = Diff.applyPatch(currentContent, patch);
-      if (typeof newContentResult !== 'string') {
-        throw new Error('Failed to apply patch: context mismatch');
-      }
-      return newContentResult;
+      const result = Diff.applyPatch(currentContent, patch);
+      return typeof result === 'string' ? result : buildContextMismatchResult();
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
-      return {
-        llmContent: `Failed to apply patch: ${errorMsg}`,
-        returnDisplay: `Error applying patch: ${errorMsg}`,
-        error: {
-          message: `Failed to apply patch: ${errorMsg}`,
-          type: ToolErrorType.PATCH_APPLY_FAILURE,
-        },
-      };
+      return buildApplyThrowResult(errorMsg);
     }
   }
 
   /**
-   * Validates that the parsed patch header targets the same file as the
-   * absolute_path/file_path parameter. Prevents a patch for one file from
-   * being silently applied to a different target.
+   * AC1: a delete patch must remove the whole file; fail fast otherwise.
    */
-  private validatePatchTarget(patch: Diff.StructuredPatch): ToolResult | null {
-    const filePath = this.getFilePath();
-    const targetName = path.basename(filePath);
-
-    const stripPrefix = (headerPath: string): string => {
-      // Remove a/ or b/ prefixes used in unified diffs.
-      if (headerPath.startsWith('a/') || headerPath.startsWith('b/')) {
-        return headerPath.slice(2);
-      }
-      return headerPath;
-    };
-
-    const newHeader = stripPrefix(patch.newFileName || '');
-    const oldHeader = stripPrefix(patch.oldFileName || '');
-
-    // /dev/null is valid for new-file or delete-style patches.
-    const isNewFileFromNull =
-      oldHeader === '/dev/null' &&
-      newHeader !== '' &&
-      newHeader !== '/dev/null';
-    const isDeleteToNull =
-      newHeader === '/dev/null' &&
-      oldHeader !== '' &&
-      oldHeader !== '/dev/null';
-
-    if (isNewFileFromNull || isDeleteToNull) {
-      // For new-file patches, the new header basename should match target.
-      if (isNewFileFromNull && path.basename(newHeader) === targetName) {
-        return null;
-      }
-      // For delete-style patches, the old header basename should match target.
-      if (isDeleteToNull && path.basename(oldHeader) === targetName) {
-        return null;
-      }
-    }
-
-    // Unified-diff headers always use forward slashes, but path.relative returns
-    // OS-native separators (backslashes on Windows). Normalize both sides to
-    // forward slashes so directory-qualified header matching works cross-platform.
-    const toPosix = (p: string): string => p.split(path.sep).join('/');
-    const relativePath = toPosix(
-      path.relative(getTargetDirCompat(this.host), filePath),
+  private async handleDelete(
+    filePath: string,
+    currentContent: string,
+    appliedResult: string,
+  ): Promise<ToolResult> {
+    if (appliedResult !== '') return buildDeletePartialResult(appliedResult);
+    await fs.unlink(filePath);
+    const gitStats = await this.trackGitStats(filePath, currentContent, '');
+    const result = buildDeleteDisplay(
+      path.basename(filePath),
+      filePath,
+      currentContent,
     );
-    const headerMatches = (header: string): boolean => {
-      if (header === '') {
-        return false;
-      }
-      // When the header contains a directory separator, the full relative path
-      // must match so that a directory-qualified header (e.g. 'a/src/foo.txt')
-      // cannot validate against an absolute_path ending in a different
-      // directory's same-named file. Only headers without a directory component
-      // fall back to basename comparison.
-      if (header.includes('/') || header.includes(path.sep)) {
-        return toPosix(header) === relativePath;
-      }
-      return path.basename(header) === targetName;
-    };
-
-    const newMatches = headerMatches(newHeader);
-    const oldMatches = headerMatches(oldHeader);
-
-    if (newMatches || oldMatches) {
-      return null;
+    if (gitStats !== null) {
+      result.metadata = { ...result.metadata, gitStats };
     }
-
-    const describedTarget = newHeader || oldHeader || '(unknown)';
-    return {
-      llmContent: `Patch header targets "${describedTarget}" but the absolute_path targets "${targetName}". Ensure the patch header matches the target file, or use a separate apply_patch call for "${describedTarget}".`,
-      returnDisplay: `Rejected patch: header target "${describedTarget}" does not match absolute_path "${targetName}".`,
-      error: {
-        message: `Patch header target "${describedTarget}" does not match absolute_path "${targetName}".`,
-        type: ToolErrorType.INVALID_TOOL_PARAMS,
-      },
-    };
+    return result;
   }
 
   private async writeAndFormatResult(
@@ -534,7 +499,7 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
     currentContent: string,
     newContent: string,
     fileExists: boolean,
-    classification: { contentWriteFiles: string[] },
+    patch: Diff.StructuredPatch,
   ): Promise<ToolResult> {
     try {
       await this.writeTextFile(filePath, newContent);
@@ -573,24 +538,21 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
         diffStat,
       };
 
-      const llmSuccessMessageParts = [
-        fileExists
-          ? `Successfully applied patch to file: ${filePath}.`
-          : `Successfully created file from patch: ${filePath}.`,
-      ];
-
-      if (this.params.modified_by_user === true) {
-        llmSuccessMessageParts.push(`User modified the patch content.`);
-      }
-
-      await this.appendLspDiagnostics(
+      const parts = buildSuccessParts({
+        fileExists,
         filePath,
-        classification,
-        llmSuccessMessageParts,
-      );
+        currentContent,
+        newContent,
+        patch,
+        fileName,
+        modifiedByUser: this.params.modified_by_user === true,
+      });
+
+      const classification = classifyPatchOperations([patch]);
+      await this.appendLspDiagnostics(filePath, classification, parts);
 
       const result: ToolResult = {
-        llmContent: llmSuccessMessageParts.join('\n\n'),
+        llmContent: parts.join('\n\n'),
         returnDisplay: displayResult,
       };
 
@@ -702,22 +664,23 @@ export class ApplyPatchTool extends BaseDeclarativeTool<
     super(
       ApplyPatchTool.Name,
       'ApplyPatch',
-      `Applies a unified diff format patch to a file. This tool parses the patch content and applies it to the target file.
+      `Applies a unified diff patch to exactly one target file per call.
 
-      The patch_content parameter should contain a valid unified diff patch. The tool will parse, validate, and apply the patch, returning the result.`,
+      A "---"/"+++" file header is required; the header path must be the workspace-relative path or the bare file name (a partial path is not accepted). Use "--- /dev/null" as the old header to create a file and "+++ /dev/null" as the new header to delete one. In each "@@" hunk the line numbers are tolerant but the old/new line counts are strict. The Codex "*** Begin Patch" envelope is not accepted; provide a standard unified diff.`,
       Kind.Edit,
       {
         properties: {
           absolute_path: {
             description:
-              process.platform === 'win32'
-                ? "The absolute path to the file to modify (e.g., 'C:\\Users\\project\\file.txt'). Must be an absolute path."
-                : "The absolute path to the file to modify (e.g., '/home/user/project/file.txt'). Must start with '/'.",
+              (process.platform === 'win32'
+                ? "The absolute path to the file to modify (e.g., 'C:\\Users\\project\\file.txt'). Must be an absolute path. "
+                : "The absolute path to the file to modify (e.g., '/home/user/project/file.txt'). Must start with '/'. ") +
+              'Exactly one of absolute_path or file_path is required.',
             type: 'string',
           },
           file_path: {
             description:
-              'Alternative parameter name for absolute_path (for backward compatibility). The absolute path to the file to modify.',
+              'Alternative parameter name for absolute_path (for backward compatibility). The absolute path to the file to modify. Exactly one of absolute_path or file_path is required.',
             type: 'string',
           },
           patch_content: {
@@ -727,6 +690,7 @@ export class ApplyPatchTool extends BaseDeclarativeTool<
           },
         },
         required: ['patch_content'],
+        anyOf: [{ required: ['absolute_path'] }, { required: ['file_path'] }],
         type: 'object',
       },
       true,

--- a/project-plans/20260805-issue3033-apply-patch-ax/plan.md
+++ b/project-plans/20260805-issue3033-apply-patch-ax/plan.md
@@ -105,7 +105,15 @@ line counts are strict; the Codex `*** Begin Patch` envelope is not accepted.
 - Changing ambiguity resolution to reject like `replace` does. The issue asks
   for the ambiguity to be *announced*, not for the strategy to change.
 - Adding a delete method to the cross-package `FileSystemService` abstraction.
-- Any change outside `packages/tools`.
+- Any change outside `packages/tools`, except the two required cross-package
+  seams already in scope:
+  - Registering the new test file in
+    `scripts/bun-test-manifest-data-tools.ts` (the tools workspace uses an
+    explicit file list, so an unregistered test never runs).
+  - The optional `deleteFile?(filePath: string): Promise<void>` seam added to
+    `IToolHostFileSystemService` in `packages/tools/src/interfaces/IToolHost.ts`
+    so deletion can route through the host filesystem service (no existing host
+    breaks, since the member is optional).
 
 ## Verification
 

--- a/project-plans/20260805-issue3033-apply-patch-ax/plan.md
+++ b/project-plans/20260805-issue3033-apply-patch-ax/plan.md
@@ -1,0 +1,113 @@
+# Issue #3033 — apply_patch agent-experience fixes
+
+## Problem
+
+`apply_patch` mechanics are sound but its feedback is not. A delete patch reports
+success while truncating the file to zero bytes, the success message carries no
+evidence that the change landed where it was asked for, and several errors name a
+symptom instead of the cause (one actively steers the caller to the wrong remedy).
+
+Source of truth: `packages/tools/src/tools/apply-patch.ts`.
+Behavioral surface: `packages/tools/src/__tests__/apply-patch.test.ts`.
+
+## Grounded findings (verified against `diff@8` before planning)
+
+| Probe | Observed |
+| --- | --- |
+| `--- a/x.ts` / `+++ /dev/null` | parses to `newFileName: '/dev/null'` with one all-`-` hunk; `applyPatch` returns `''` |
+| headerless patch (`@@` only) | parses with `oldFileName`/`newFileName` `undefined` |
+| Codex `*** Begin Patch` envelope | parses to a single section with `hunks: []` |
+| declared old-count too small | `parsePatch` throws `Removed line count did not match for hunk at line N` |
+| declared new-count too small | `parsePatch` throws `Unknown line 6 "+c"` |
+| wrong `@@` line hint, duplicate context | applies silently to the *second* occurrence |
+| `structuredPatch(before, after, {context: 0})` | yields the true landing hunks of an applied patch |
+
+The last row is the mechanism used for evidence reporting: landing positions are
+derived from the actual before/after content, not from the patch's claims.
+
+## Acceptance criteria
+
+### AC1 — Delete patches delete (issue B1)
+
+- A patch whose `+++` header is `/dev/null` and whose `---` header names the
+  target removes the file from disk.
+- The result reports deletion explicitly and carries no error.
+- If the patch body does not match the file, the apply fails and the file is
+  left untouched — deletion happens only after a successful apply.
+- A delete patch whose `---` basename does not match the target is still
+  rejected (existing `validatePatchTarget` guarantee is preserved).
+- `returnDisplay` shows the removal, and LSP diagnostics are not collected for a
+  file that no longer exists.
+
+### AC2 — Success is evidence (issue A4, A5)
+
+- A successful modify reports how many hunks were applied and the line range(s)
+  in the resulting file where the change landed.
+- When a hunk's declared start line differs from where it actually matched, the
+  message states both the declared and the actual line.
+- When a hunk's context block occurs more than once in the file, the message
+  says so and names the line it chose.
+- Creation and deletion successes carry their own proportionate evidence
+  (lines written / file removed); no landing report is fabricated for them.
+
+### AC3 — Path mismatch names both accepted forms (issue A1)
+
+- The rejection message states the header value that was supplied *and* both
+  forms that would be accepted: the workspace-relative path of `absolute_path`
+  and its bare basename.
+
+### AC4 — Missing or unrecognized header is named (issue A2)
+
+- A patch with hunks but no `---`/`+++` header is rejected with a message that
+  says the header is required and shows the accepted header forms.
+- A `*** Begin Patch` / `*** Update File:` envelope is rejected with a message
+  that names it as unsupported and points at unified diff.
+- These are distinguishable from the pre-existing "no parseable file sections"
+  case, which stays for genuinely unparseable input.
+
+### AC5 — Hunk count mismatch is translated (issue A3)
+
+- When a `@@` header declares counts that disagree with its body, the error
+  names the offending header, the declared old/new counts, and the counts
+  actually present in the body.
+- Both under- and over-declared counts are covered.
+- A parse failure that is not a count mismatch still surfaces its original
+  message.
+
+### AC6 — Missing file is not reported as context mismatch (issue B3)
+
+- Patching a non-existent file with a non-creation patch fails with a message
+  that says the file does not exist, typed `FILE_NOT_FOUND`.
+- Creation patches (`--- /dev/null`) are unaffected.
+
+### AC7 — Single error prefix (issue B2)
+
+- `Failed to apply patch:` appears exactly once in a context-mismatch failure.
+
+### AC8 — Schema states the path requirement (issue B4)
+
+- The model-visible parameter schema expresses that one of `absolute_path` or
+  `file_path` must be supplied.
+- A call omitting both is rejected with a message naming both parameters.
+
+### AC9 — Tool description states the rules (issue documentation gap)
+
+The description documents: one target file per call; `---`/`+++` header
+required; header path must be the basename or the workspace-relative path;
+`/dev/null` on either side for create/delete; `@@` line numbers are tolerant but
+line counts are strict; the Codex `*** Begin Patch` envelope is not accepted.
+
+## Explicitly out of scope
+
+- Accepting headerless patches (issue floats it as "consider"; the header check
+  is a wrong-file safety guard and removing it is a behavior change, not a
+  messaging fix).
+- Changing ambiguity resolution to reject like `replace` does. The issue asks
+  for the ambiguity to be *announced*, not for the strategy to change.
+- Adding a delete method to the cross-package `FileSystemService` abstraction.
+- Any change outside `packages/tools`.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, plus the CLI smoke run.

--- a/scripts/bun-test-manifest-data-tools.ts
+++ b/scripts/bun-test-manifest-data-tools.ts
@@ -76,6 +76,7 @@ export const TOOLS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
     'src/__tests__/todo-tools.test.ts',
     'src/__tests__/export-surface-helpers.test.ts',
     'src/__tests__/apply-patch.test.ts',
+    'src/__tests__/apply-patch-ax.bun.test.ts',
     'src/__tests__/glob-filtering.test.ts',
     'src/__tests__/ls-filtering-behavior.test.ts',
     'src/__tests__/neutral-types.test.ts',


### PR DESCRIPTION
## TLDR

`apply_patch` had sound mechanics but untrustworthy feedback. The headline bug: a `+++ /dev/null` delete patch reported **success** while leaving a **0-byte file** on disk — `validatePatchTarget` deliberately accepted delete patches, but `writeAndFormatResult` unconditionally called `writeTextFile` and there was no `unlink` anywhere in the file. That is very likely the mechanism behind #2133 ("output says it succeeded, but the changes aren't in the file"), which was closed without a root cause.

Beyond that, the success message was `Successfully applied patch to file: <path>.` and nothing else — no hunk count, no landing line, no warning when matching relocated silently. Callers had to follow **every** patch with a read call to find out what actually happened. Several errors named a symptom instead of a cause, and one actively steered the caller to the wrong remedy.

This makes the feedback truthful: deletes delete, success is evidence, and every error names the cause and the remedy.

**For reviewers:** the interesting files are `apply-patch-analysis.ts` (new, all the pure logic) and the `execute()` / `shouldConfirmExecute()` rewiring in `apply-patch.ts`. Landing evidence is derived from the *actual* before/after content via `structuredPatch`, never from what the patch claims about itself.

## Dive Deeper

Nine accepted criteria, one per defect in the report. Acceptance criteria and the out-of-scope list are recorded in `project-plans/20260805-issue3033-apply-patch-ax/plan.md`.

**Deletes actually delete (B1).** A `+++ /dev/null` patch now removes the file. Two guards come with it: the deletion only happens *after* the patch applies cleanly, and a delete patch that would not remove every line is rejected outright rather than partially applied — it reports how many lines would have been left. LSP diagnostics are not collected for a file that no longer exists.

Deletion routes through an optional `deleteFile` seam on `IToolHostFileSystemService`, falling back to `unlink`. Reads and writes already honoured the host's filesystem service; had deletion gone straight to `unlink`, a host could have had content read through its own service and the file removed behind its back — reintroducing the exact "success without the change" failure this PR exists to kill.

**Success is evidence (A4, A5).** A modify now reports the declared hunk count and where the change actually landed, computed by diffing the real before and after content. Two advisories are emitted when warranted: when a hunk's context block occurs in more than one place (the report's A5: a wrong line hint silently edited the *second* of two identical blocks), and when a hunk's declared line differs from where its context actually matched. A pure deletion describes the boundary in the resulting file rather than naming a line number that no longer exists.

Ambiguity is *announced*, not rejected. The report notes that the sibling `replace` tool rejects ambiguous matches, and that the disagreement is itself a hazard — but changing the resolution strategy is a behavior change, not a messaging fix, so it stayed out of scope.

**Errors name the cause (A1, A2, A3, B2, B3).**

| Before | After |
| --- | --- |
| `Patch header target "src/calculator.ts" does not match absolute_path "calculator.ts".` — implies the basename is required; hides that the full workspace-relative form also works | names the supplied header and *both* accepted forms, and says a partial path is not accepted |
| `Patch header target "(unknown)" ...` for a headerless patch **and** for a Codex `*** Begin Patch` envelope | distinct messages: the header is required (showing both accepted forms), or the Codex envelope is unsupported and a unified diff is expected |
| `Failed to parse patch: Unknown line 15 "     return this.history;"` — names a fine line; the header count is what is wrong | names the offending `@@` header, the declared old/new counts, the counts actually in the body, and that line numbers are tolerant while counts are strict |
| `Failed to apply patch: Failed to apply patch: context mismatch` | one prefix, plus the remedy (re-read the file and rebuild the patch) |
| patching a missing file reported `context mismatch` (ENOENT was swallowed into an empty string) | `FILE_NOT_FOUND`, saying the file does not exist and that creation needs `--- /dev/null` |

**Schema and description (B4, documentation gap).** The schema said `required: ['patch_content']` while a call without a path was rejected at runtime, so a model reading it concluded the path was optional. It now carries `anyOf` over the two path parameters. The description previously documented none of the rules a caller must satisfy; it now states all of them.

Two claims that would have been *false* were caught in review and corrected: the parameters are "at least one" (not "exactly one" — both are accepted, `absolute_path` wins), and the partial-path rule has a genuine exception for create/delete patches, which compare basenames only. Given that this PR is specifically about guidance that does not lie, shipping new inaccurate guidance was not an option.

**Confirmation path.** `shouldConfirmExecute` carried a comment claiming it shared `execute`'s validation path, but it called `parsePatch`/`applyPatch` directly. So in ask mode a malformed hunk count threw a raw jsdiff error before the new message could ever be produced, and patches that `execute` now rejects were still offered for approval. It now runs the same validation and defers to `execute` for the actionable result, and previews a delete as a removal rather than as an edit to empty.

**Deliberately preserved.** The report called out what works well, and none of it changed: line-number tolerance, multi-hunk patches, `\ No newline at end of file` round-tripping, empty-line-as-blank-context, full `git diff` input, `/dev/null` creation, and the multi-file rejection message — which was the model the other messages were rewritten toward.

**Note on a behavior change:** a patch that parses to zero hunks previously rewrote the file with identical content and reported success. It is now rejected, since it can only ever be a no-op.

**Deferred, needs a separate decision:** giving the cross-package `FileSystemService` abstraction in `packages/storage` a real delete operation, and implementing it in `AcpFileSystemService`. The optional seam here is the in-package half; the abstraction has never had a delete and extending it is a cross-package public API change.

## Reviewer Test Plan

The fastest way to see the headline bug is to reproduce it on `main` first.

1. Create a scratch file in the workspace, e.g. `tmp/scratch/doomed.ts` with three lines.
2. On `main`, ask the agent to delete it with a patch whose new header is `/dev/null`:

       --- a/doomed.ts
       +++ /dev/null
       @@ -1,3 +0,0 @@
       -export function oldHelper(): string {
       -  return 'this file exists only to be deleted by a patch';
       -}

   You get `Successfully applied patch to file: ...` and a file that still exists at **0 bytes**. Confirm with `wc -c`.
3. On this branch, the same call reports the deletion and the file is gone.

Then exercise the feedback:

- **Evidence.** Apply an ordinary two-hunk patch and read the result message — it should tell you the hunk count and the lines the change landed on, with no read-back needed.
- **Ambiguity.** Put two identical blocks in a file, patch one with a deliberately wrong `@@` line number, and confirm the message says the context occurs more than once and lists where.
- **Path rule.** Patch a file in a subdirectory using the natural `--- a/src/foo.ts` header. The rejection should name both the workspace-relative path and the bare file name. Confirm both of those actually work.
- **Codex envelope.** Send a `*** Begin Patch` / `*** Update File:` patch and confirm the message tells you it is unsupported and what to send instead.
- **Counts.** Declare `@@ -1,6 +1,7 @@` and supply eight old lines; the error should give declared vs actual counts, not a raw jsdiff line reference.
- **Partial delete.** Send a `/dev/null` patch that omits the file's last line and confirm it is rejected with the file untouched.
- **Ask mode.** With approval mode set to ask, send a malformed-count patch and confirm nothing throws and no confirmation is offered; then send a valid delete patch and confirm the preview shows a removal.

Automated coverage: `cd packages/tools && bun test src/__tests__/apply-patch.test.ts src/__tests__/apply-patch-ax.bun.test.ts --preload ../../test-setup/augment-bun-vi.ts` (45 tests). Every new test was confirmed to fail against the pre-change implementation.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run typecheck`, `npm run build`, `npm run lint`, `npm run lint:eslint-guard`, `npm run format` all exit 0; the `tools` workspace is 79/79 test files green; CLI smoke run passes. Path handling is normalised to POSIX separators for header comparison, which is the only platform-sensitive logic touched.

## Linked issues / bugs

Fixes #3033

Very likely also the root cause of #2133, which was closed without one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved patch application for creating, editing, and fully deleting files.
  * Added clearer validation, success messages, deletion previews, and actionable error details.
  * Supports host-managed file deletion while preserving compatibility with existing integrations.
  * Patch previews and confirmations now follow the same validation behavior as execution.

* **Bug Fixes**
  * Improved handling of missing files, invalid paths, malformed headers, context mismatches, and partial deletion failures.
  * Refined diagnostic behavior for deleted versus modified files.

* **Tests**
  * Added comprehensive coverage for patch execution, validation, confirmation flows, filesystem failures, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->