### PR TITLE
Prove the JSP producer's failure paths and fail bootstrap legibly (Fixes #2921)

### DIFF
--- a/packages/cli/src/cliSessionBootstrap.ts
+++ b/packages/cli/src/cliSessionBootstrap.ts
@@ -206,6 +206,11 @@ async function releaseResumedResources(
  */
 function setupObservation(config: Config): void {
   const projectRoot = config.getProjectRoot();
+  // loadBootstrapFromEnv fails fast (FatalConfigError, exit 52) on an
+  // explicitly misconfigured observation bootstrap. This is intentional: the
+  // non-blocking guarantee covers the post-startup path, while startup
+  // configuration validation is deliberately fail-fast. Recording cleanup is
+  // already registered above, so the process exits cleanly on the way out.
   initializeObservationProducer({
     repository: basename(projectRoot),
     path: projectRoot,

--- a/packages/cli/src/observation/jspProducer.test.ts
+++ b/packages/cli/src/observation/jspProducer.test.ts
@@ -104,28 +104,40 @@ function todoItemsOfSnapshot(
 }
 
 describe('heartbeat cadence', () => {
-  it('heartbeats at least three times within the observer lease', async () => {
-    const bootstrapped = makeHarness();
-    const sent: number[] = [];
-    const clock = 0;
-    const hooks: JspProducerHooks = {
-      ...bootstrapped.hooks,
-      now: () => clock,
-      register: () => Promise.resolve(OK),
-      publish: () => Promise.resolve(OK),
-      heartbeat: () => {
-        sent.push(clock);
-        return Promise.resolve(OK);
-      },
-    };
-    const producer = new JspProducer(bootstrap, nativeSession, hooks);
-    producer.start();
-    await producer.flush();
-    // A heartbeat interval equal to the lease makes expiry a race with
-    // scheduling jitter, so require headroom for two lost heartbeats.
-    const interval = producer.heartbeatIntervalMs();
-    expect(interval * 3).toBeLessThanOrEqual(OBSERVER_LEASE_MS);
-    producer.stop();
+  it('delivers at least three heartbeats within the observer lease on the shipped default interval', async () => {
+    vi.useFakeTimers();
+    let producer: JspProducer | undefined;
+    try {
+      const bootstrapped = makeHarness();
+      let heartbeats = 0;
+      const hooks: JspProducerHooks = {
+        ...bootstrapped.hooks,
+        register: () => Promise.resolve(OK),
+        publish: () => Promise.resolve(OK),
+        heartbeat: () => {
+          heartbeats += 1;
+          return Promise.resolve(OK);
+        },
+      };
+      // No heartbeatMs override: the shipped DEFAULT interval is the value
+      // under test. The cadence property only holds if that shipped value
+      // leaves room for two lost heartbeats inside one lease.
+      producer = new JspProducer(bootstrap, nativeSession, hooks);
+      const interval = producer.heartbeatIntervalMs();
+      producer.start();
+      await producer.flush();
+      // Advance a full lease window so the interval has fired repeatedly.
+      await vi.advanceTimersByTimeAsync(OBSERVER_LEASE_MS);
+      // An observer must be able to lose two consecutive heartbeats inside
+      // one lease, so at least three must actually be delivered.
+      expect(heartbeats).toBeGreaterThanOrEqual(3);
+      expect(interval * 3).toBeLessThanOrEqual(OBSERVER_LEASE_MS);
+    } finally {
+      // Stop in the finally: a failed assertion must not leave the interval
+      // armed for the rest of the file.
+      producer?.stop();
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -340,13 +352,17 @@ describe('JspProducer', () => {
     ]);
   });
 
-  it('never blocks or throws when registration and publication fail', () => {
+  it('never throws into the foreground when registration is terminally rejected', async () => {
+    let publishCalls = 0;
     const identity = makeHarness().hooks.createIdentity(bootstrap);
     const hooks: JspProducerHooks = {
       now: () => 100,
       createIdentity: () => identity,
       register: () => Promise.resolve(REJECTED_409),
-      publish: () => Promise.reject(new Error('offline')),
+      publish: () => {
+        publishCalls += 1;
+        return Promise.resolve(OK);
+      },
       heartbeat: () => Promise.resolve(TRANSPORT),
     };
     const producer = new JspProducer(bootstrap, nativeSession, hooks, {
@@ -358,6 +374,43 @@ describe('JspProducer', () => {
       producer.observeActivityChanged('acting');
       producer.observeTurnEnded('completed');
     }).not.toThrow();
+    await producer.flush();
+    // A terminal registration stops the producer before any publish attempt,
+    // which is the property the narrowed name claims.
+    expect(publishCalls).toBe(0);
+    producer.stop();
+  });
+
+  it('never throws into the foreground when publication rejects and stays usable', async () => {
+    let publishCalls = 0;
+    const identity = makeHarness().hooks.createIdentity(bootstrap);
+    const hooks: JspProducerHooks = {
+      now: () => 5000,
+      createIdentity: () => identity,
+      register: () => Promise.resolve(OK),
+      publish: () => {
+        publishCalls += 1;
+        return Promise.reject(new Error('offline'));
+      },
+      heartbeat: () => Promise.resolve(OK),
+    };
+    const producer = new JspProducer(bootstrap, nativeSession, hooks, {
+      capacity: 1,
+    });
+    expect(() => {
+      producer.start();
+      producer.observeTurnStarted();
+      producer.observeActivityChanged('acting');
+      producer.observeTurnEnded('completed');
+    }).not.toThrow();
+    await producer.flush();
+    // The rejecting publish path was genuinely exercised.
+    expect(publishCalls).toBeGreaterThan(0);
+    // The producer must remain usable: a later observation still advances the
+    // sequence, proving the rejection did not strand the foreground stream.
+    const before = producer.snapshot().source_sequence;
+    producer.observeTurnStarted();
+    expect(producer.snapshot().source_sequence).toBeGreaterThan(before);
     producer.stop();
   });
 
@@ -631,18 +684,38 @@ describe('construction and shutdown robustness', () => {
     }
   });
 
-  it('still stops cleanly when the final drain rejects', async () => {
+  it('still stops cleanly and publishes the terminal snapshot when every publish fails', async () => {
     const identity = makeHarness().hooks.createIdentity(bootstrap);
+    const published: JspBoundDocument[] = [];
     const hooks: JspProducerHooks = {
       now: () => 100,
       createIdentity: () => identity,
       register: () => Promise.resolve(OK),
-      publish: () => Promise.reject(new Error('broker vanished mid-drain')),
+      publish: (document) => {
+        published.push(document);
+        return Promise.reject(new Error('broker vanished mid-drain'));
+      },
       heartbeat: () => Promise.resolve(OK),
     };
     const producer = new JspProducer(bootstrap, nativeSession, hooks);
     producer.start();
+    // Let registration complete so the following observation enqueues a real
+    // event the drain will publish (and reject). Without this, the observation
+    // is made while unregistered and never reaches publish, so the drain has
+    // nothing to fail on.
+    await producer.flush();
+
+    // Burn the queue's one-shot recovery request before shutdown. The failed
+    // send below asks the producer for a recovery snapshot, and that request
+    // is not renewed until a send actually succeeds. Doing it here means the
+    // failures during shutdown cannot inject a queue-authored snapshot, so a
+    // snapshot arriving last during shutdown can only be the direct terminal
+    // publish. Two flushes: the first settles the failing send, the second the
+    // drain carrying the recovery snapshot it asked for.
     producer.observeTurnStarted();
+    await producer.flush();
+    await producer.flush();
+    published.length = 0;
 
     // shutdown must not propagate the drain failure, and must leave the
     // producer stopped rather than half-torn-down: a stopped producer is
@@ -651,6 +724,13 @@ describe('construction and shutdown robustness', () => {
     const after = producer.snapshot().source_sequence;
     producer.observeTurnStarted();
     expect(producer.snapshot().source_sequence).toBe(after);
+
+    // Shutdown drains the session.ended event, and every publish rejects. Any
+    // snapshot the queue still had to offer was enqueued ahead of that event,
+    // so the trailing snapshot is the direct terminal publish: it happened
+    // after the failed drain rather than being skipped by it.
+    expect(published.some((document) => document.kind === 'event')).toBe(true);
+    expect(published.at(-1)?.kind).toBe('snapshot');
   });
 });
 
@@ -770,6 +850,51 @@ describe('overflow recovery', () => {
 
     // The gap must be reported and repaired by a fresh snapshot, otherwise the
     // observer rejects everything that follows.
+    expect(published.some((document) => document.kind === 'snapshot')).toBe(
+      true,
+    );
+    producer.stop();
+  });
+
+  it('repairs an overflow through the queue recovery callback with no further observation', async () => {
+    // The burst test above can be satisfied by the polling path inside
+    // applyAndPublish: a later transition sees needsSnapshotRecovery() and
+    // enqueues the snapshot itself. This test isolates the callback path by
+    // overflowing and then making NO further observation, so the only route to
+    // a published snapshot is JspBoundedQueue's onRecoveryNeeded firing through
+    // queueMicrotask.
+    const identity = makeHarness().hooks.createIdentity(bootstrap);
+    const published: JspBoundDocument[] = [];
+    const hooks: JspProducerHooks = {
+      now: () => 100,
+      createIdentity: () => identity,
+      register: () => Promise.resolve(OK),
+      publish: (document) => {
+        published.push(document);
+        return Promise.resolve(OK);
+      },
+      heartbeat: () => Promise.resolve(OK),
+    };
+    const producer = new JspProducer(bootstrap, nativeSession, hooks, {
+      capacity: 1,
+    });
+    producer.start();
+    await producer.flush();
+    published.length = 0;
+
+    // The first event fills the capacity-one buffer. The second overflows: the
+    // event is dropped and the queue requests recovery via microtask.
+    producer.observeTurnStarted();
+    producer.observeActivityChanged('acting');
+    // Deliberately make no further observation. The polling path in
+    // applyAndPublish is never reached again, so a published snapshot can only
+    // arrive through the queue's onRecoveryNeeded callback.
+    await producer.flush();
+    // The recovery callback runs as a microtask and enqueues its snapshot,
+    // which is picked up by whichever drain is live at that moment; a second
+    // flush settles that drain.
+    await producer.flush();
+
     expect(published.some((document) => document.kind === 'snapshot')).toBe(
       true,
     );

--- a/packages/cli/src/observation/jspProducer.test.ts
+++ b/packages/cli/src/observation/jspProducer.test.ts
@@ -133,10 +133,12 @@ describe('heartbeat cadence', () => {
       expect(heartbeats).toBeGreaterThanOrEqual(3);
       expect(interval * 3).toBeLessThanOrEqual(OBSERVER_LEASE_MS);
     } finally {
-      // Stop in the finally: a failed assertion must not leave the interval
-      // armed for the rest of the file.
-      producer?.stop();
+      // Restore real timers before stopping: restoration discards the fake
+      // interval outright, so it cannot be skipped by anything stop() does,
+      // and a failed assertion still cannot leave fake timers installed for
+      // the rest of the file. stop() then releases the producer itself.
       vi.useRealTimers();
+      producer?.stop();
     }
   });
 });

--- a/packages/cli/src/observation/jspWiring.test.ts
+++ b/packages/cli/src/observation/jspWiring.test.ts
@@ -104,7 +104,7 @@ describe('loadBootstrapFromEnv', () => {
     expect(result?.agentId).toBe('agent-alex');
   });
 
-  it('throws on unreadable bootstrap file (fail fast, exit 52)', async () => {
+  it('throws on unreadable bootstrap file (fail fast, exit 52)', () => {
     process.env.LLXPRT_JSP_BOOTSTRAP_FILE =
       join(
         tmpdir(),

--- a/packages/cli/src/observation/jspWiring.test.ts
+++ b/packages/cli/src/observation/jspWiring.test.ts
@@ -14,7 +14,7 @@ import {
 } from './jspWiring.js';
 import type { JspPostResult } from './jspPublisher.js';
 import type { JspSnapshotDocument, JspBoundDocument } from './jspDocuments.js';
-import { todoEvents } from '@vybestack/llxprt-code-core';
+import { todoEvents, FatalConfigError } from '@vybestack/llxprt-code-core';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -50,6 +50,22 @@ async function writeTempFile(name: string, content: string): Promise<string> {
   const filePath = join(dir, name);
   await fs.writeFile(filePath, content, 'utf8');
   return filePath;
+}
+
+/**
+ * Run a load attempt and capture the thrown error, asserting it is a
+ * FatalConfigError with exit code 52. Returns the error so the caller can
+ * make message assertions without re-deriving the throw.
+ */
+function expectFatalBootstrap(fn: () => unknown): FatalConfigError {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(FatalConfigError);
+    expect((error as FatalConfigError).exitCode).toBe(52);
+    return error as FatalConfigError;
+  }
+  throw new Error('expected loadBootstrapFromEnv to throw');
 }
 
 describe('loadBootstrapFromEnv', () => {
@@ -88,15 +104,26 @@ describe('loadBootstrapFromEnv', () => {
     expect(result?.agentId).toBe('agent-alex');
   });
 
-  it('throws on malformed bootstrap (fail fast)', async () => {
-    const file = await writeTempFile('bad.json', '{ not json');
-    process.env.LLXPRT_JSP_BOOTSTRAP_FILE = file;
-    expect(() => loadBootstrapFromEnv()).toThrow(
-      'JSP bootstrap file is malformed JSON',
-    );
+  it('throws on unreadable bootstrap file (fail fast, exit 52)', async () => {
+    process.env.LLXPRT_JSP_BOOTSTRAP_FILE =
+      join(
+        tmpdir(),
+        'jsp-no-such-file-' + Math.random().toString(36).slice(2),
+      ) + '.json';
+    const error = expectFatalBootstrap(() => loadBootstrapFromEnv());
+    expect(error.message).toContain('LLXPRT_JSP_BOOTSTRAP_FILE');
+    expect(error.message).toContain('could not be read');
   });
 
-  it('throws on non-loopback endpoint (insecure)', async () => {
+  it('throws on malformed bootstrap (fail fast, exit 52)', async () => {
+    const file = await writeTempFile('bad.json', '{ not json');
+    process.env.LLXPRT_JSP_BOOTSTRAP_FILE = file;
+    const error = expectFatalBootstrap(() => loadBootstrapFromEnv());
+    expect(error.message).toContain('LLXPRT_JSP_BOOTSTRAP_FILE');
+    expect(error.message).toContain('malformed JSON');
+  });
+
+  it('throws on non-loopback endpoint (insecure, exit 52)', async () => {
     const file = await writeTempFile(
       'insecure.json',
       JSON.stringify({
@@ -105,16 +132,23 @@ describe('loadBootstrapFromEnv', () => {
       }),
     );
     process.env.LLXPRT_JSP_BOOTSTRAP_FILE = file;
-    expect(() => loadBootstrapFromEnv()).toThrow('JSP bootstrap rejected');
+    const error = expectFatalBootstrap(() => loadBootstrapFromEnv());
+    expect(error.message).toContain('LLXPRT_JSP_BOOTSTRAP_FILE');
+    expect(error.message).toContain('rejected (JSP-E004)');
+    // A credential-bearing file's secrets must not leak into the diagnostic.
+    expect(error.message).not.toContain('pub-secret-xyz');
+    expect(error.message).not.toContain('reg-abc');
   });
 
-  it('throws on wrong protocol version', async () => {
+  it('throws on wrong protocol version (exit 52)', async () => {
     const file = await writeTempFile(
       'wrong.json',
       JSON.stringify({ ...validBootstrapJson, protocol: 'jsp/2' }),
     );
     process.env.LLXPRT_JSP_BOOTSTRAP_FILE = file;
-    expect(() => loadBootstrapFromEnv()).toThrow('JSP bootstrap rejected');
+    const error = expectFatalBootstrap(() => loadBootstrapFromEnv());
+    expect(error.message).toContain('LLXPRT_JSP_BOOTSTRAP_FILE');
+    expect(error.message).toContain('rejected (JSP-E003)');
   });
 });
 

--- a/packages/cli/src/observation/jspWiring.ts
+++ b/packages/cli/src/observation/jspWiring.ts
@@ -8,6 +8,7 @@ import { readFileSync } from 'node:fs';
 import type { AgentEvent } from '@vybestack/llxprt-code-agents';
 import {
   todoEvents,
+  FatalConfigError,
   type Todo,
   type TodoUpdateEvent,
 } from '@vybestack/llxprt-code-core';
@@ -45,6 +46,24 @@ export function createTodoObservationSubscription(
   return () => todoEvents.offTodoUpdated(listener);
 }
 
+/**
+ * Load and validate the JSP bootstrap file declared on the environment.
+ *
+ * A bootstrap file is present only when a supervisor has deliberately opted
+ * this process into observation, so a misconfiguration must fail fast and
+ * legibly: silently degrading turns a broken observation setup into an
+ * invisible "agent never appears in the observer" failure with no local
+ * signal. Issue 2779's non-blocking guarantee is scoped to the post-startup
+ * path (transport outage or queue pressure degrading telemetry without failing
+ * the foreground); startup configuration validation is the distinct P1 row and
+ * is deliberately fail-fast. Each failure throws `FatalConfigError` so the CLI
+ * entry point renders a single actionable line rather than an
+ * unexpected-critical stack trace.
+ *
+ * The messages intentionally name only the environment variable and the
+ * failure category: this file is credential-bearing, and the message is
+ * written to stderr where a supervisor may log it.
+ */
 export function loadBootstrapFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): JspBootstrap | null {
@@ -56,17 +75,23 @@ export function loadBootstrapFromEnv(
   try {
     raw = readFileSync(filePath, 'utf8');
   } catch {
-    throw new Error('JSP bootstrap file could not be read');
+    throw new FatalConfigError(
+      `JSP bootstrap file named by ${BOOTSTRAP_ENV} could not be read`,
+    );
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    throw new Error('JSP bootstrap file is malformed JSON');
+    throw new FatalConfigError(
+      `JSP bootstrap file named by ${BOOTSTRAP_ENV} is malformed JSON`,
+    );
   }
   const result = parseBootstrap(parsed);
   if (!result.ok) {
-    throw new Error(`JSP bootstrap rejected (${result.error.code})`);
+    throw new FatalConfigError(
+      `JSP bootstrap file named by ${BOOTSTRAP_ENV} was rejected (${result.error.code})`,
+    );
   }
   return result.value;
 }

--- a/project-plans/issue-2921-jsp-producer-hardening.md
+++ b/project-plans/issue-2921-jsp-producer-hardening.md
@@ -1,0 +1,127 @@
+# Issue 2921 delivery plan — JSP producer hardening and honest evidence
+
+## Scope decision
+
+Deliver one issue-linked pull request closing issue 2921. The issue collects
+review findings raised against the observation producer after PR 2897 had been
+adjudicated. Scope is exactly those findings: nothing in
+`packages/cli/src/observation` beyond them, and no adjacent cleanup.
+
+## Baseline audit
+
+Every finding was re-verified against `main` at `bb700c00e` before planning.
+The producer source fixes for findings 1-6 landed inside PR 2897 itself
+(`git log -S` on `heartbeatLifecycle`, `requestRecovery`, and
+`applyOpenTransition` all resolve to `8b8abeb3a`). What remains is the evidence
+that those behaviors actually hold, plus the three findings that were never
+addressed.
+
+| Finding | Subject | State on `main` | Work |
+| --- | --- | --- | --- |
+| 1 | Heartbeat rejection must degrade telemetry only | Implemented; covered by `degrades telemetry only when a heartbeat rejects` | None |
+| 2 | Heartbeat bound to its lifecycle | Implemented; covered by `a stale in-flight heartbeat cannot stop a restarted producer` | None |
+| 3 | Shutdown cleanup survives a failing drain | Implemented; test proves `stop()` ran but not that the final publish still happened | Strengthen evidence (see below) |
+| 4 | Constructor validates capacity and heartbeat interval | Implemented; covered by both construction tests | None |
+| 5 | Queue overflow invokes the recovery callback | Implemented; existing test cannot fail if the callback is deleted | Replace with real evidence |
+| 6 | Post-terminal immutability | Implemented; covered by `ignores transitions that arrive after the session ended` | None |
+| 7 | Heartbeat cadence test proves nothing | Not addressed | Rewrite |
+| 8 | Registration/publication test name overstates | Not addressed | Split into honest tests |
+| 9 | Bootstrap failure policy | Not addressed | Decide, record, make legible |
+
+### Finding 3 in detail
+
+The finding is written as "if `flush()` rejects the error propagates and
+`stop()` never runs". With the shipped queue that premise is unreachable:
+`JspBoundedQueue.send` catches every sink rejection and converts it to a
+non-delivery, and the producer's registration task carries its own `catch`, so
+neither `JspProducer.flush` nor `JspBoundedQueue.flush` can reject. The
+`try/finally` in `shutdown` is therefore a guarantee about a path the current
+queue cannot take, and no test can honestly exercise it without a fabricated
+seam.
+
+What is reachable, and what the finding is really protecting, is the other
+half: a drain in which every publish fails must not skip the final terminal
+snapshot or leave the producer started. That is what A4 proves.
+
+Proving it needs care. A failed send asks the producer for a recovery
+snapshot, so a naive "the last published document is a snapshot" assertion is
+satisfied by the queue's own recovery snapshot even when the direct terminal
+publish is deleted (verified by mutation). The recovery request is one-shot
+until a send succeeds, so A4 burns it before shutdown; after that, every
+snapshot the queue can still offer is enqueued ahead of the `session.ended`
+event, and a trailing snapshot can only be the direct terminal publish.
+
+### Finding 5 in detail
+
+`overflow recovery > publishes a fresh snapshot after the queue overflows`
+bursts three events through a capacity-one queue. The third event reaches
+`applyAndPublish`, sees `needsSnapshotRecovery()`, and enqueues the snapshot
+itself. The assertion therefore passes through the polling path and is
+satisfied even if `JspBoundedQueue` never calls `onRecoveryNeeded`, which is
+the code path the finding is about. Real evidence requires an overflow with no
+subsequent event, so the only route to a published snapshot is the callback.
+
+## Bootstrap failure policy (finding 9)
+
+**Decision: explicit misconfiguration keeps failing fast, and now fails
+legibly.**
+
+Rationale:
+
+- `LLXPRT_JSP_BOOTSTRAP_FILE` is never set by a human interactive session; it
+  is set by the launching supervisor. Its presence is an explicit statement
+  that this process is meant to be observed.
+- Silently degrading turns "my agent never appears in the observer" into an
+  invisible failure with no local signal, which is the harder failure to
+  diagnose of the two.
+- A rejected bootstrap includes the non-loopback endpoint case. Refusing loudly
+  is the correct answer to a credential aimed off-host; continuing quietly
+  teaches the operator nothing.
+- Issue 2779's non-blocking guarantee is scoped to the post-startup path:
+  "After valid startup, transport outage or queue pressure degrades telemetry
+  without failing/blocking the foreground TUI." Startup-time configuration
+  validation is the P1 row, which already reads "Explicit invalid config fails
+  fast without leaking values". The recorded design note is therefore upheld,
+  not contradicted, and no existing test or note needs to be reversed.
+
+What changes: today the three `loadBootstrapFromEnv` failures throw a bare
+`Error`, so the CLI entry point classifies them as an unexpected critical error
+and prints a stack trace under "An unexpected critical error occurred". A
+deliberate fail-fast policy has to produce a deliberate diagnostic, so these
+become `FatalConfigError` (exit code 52), which the entry point renders as a
+single actionable line. Messages name the environment variable and the failure
+category, and carry neither the file contents nor the publisher credential.
+
+## Acceptance criteria
+
+| ID | Boundary | Inputs / edge cases | Success | Failure / side effects | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| A1 | Heartbeat cadence | Shipped default interval, observer lease window, fake timers | At least three heartbeats are actually delivered within `OBSERVER_LEASE_MS`, and the delivered count is asserted | A producer that never arms its interval fails the test | `jspProducer.test.ts` |
+| A2 | Terminal registration | Registration returns 409 | No throw from the foreground calls, and publish is proven uncalled | A test name that implies publish failure coverage without exercising it | `jspProducer.test.ts` |
+| A3 | Publication failure | Registration accepted, publish rejects | No throw, publish is proven called, producer stays usable | Rejection escaping into the foreground | `jspProducer.test.ts` |
+| A4 | Shutdown cleanup | Every publish fails during the final drain | Final terminal snapshot publish is still attempted and producer ends stopped and inert | Skipped final publish or a producer left started | `jspProducer.test.ts` |
+| A5 | Overflow recovery | Overflow with no further observations | A fresh snapshot is published through the queue's recovery callback | Deleting `onRecoveryNeeded` must fail this test | `jspProducer.test.ts` |
+| A6 | Bootstrap failure | Unreadable file, malformed JSON, rejected schema | Startup fails with `FatalConfigError` and a message naming the env var | Message leaks the credential or the raw file body; unexpected-critical stack trace | `jspWiring.test.ts` |
+
+## Constraints
+
+- Heartbeat tests use fake timers and restore real timers in a `finally`. Real
+  timers plus sleep-based waits leave a live `setInterval` and pending promises
+  behind and hang the file.
+- The cadence assertion uses the shipped default interval, not a small test
+  override, because the shipped value is the thing under test.
+- Changed tests stay on Bun. `src/observation/jspProducer.test.ts` and
+  `jspWiring.test.ts` are already Bun-native entries in
+  `scripts/bun-test-manifest.ts` and are excluded from the Vitest selection;
+  the `vitest` import resolves through the preloaded Bun compatibility shim.
+- No new lint suppressions, no complexity or size threshold changes, no
+  test-suite exclusions.
+
+## Out of scope
+
+- Suppressing the duplicate `source_sequence` a no-op transition publishes.
+  That behavior predates this issue, is shared with the superseded-tool case,
+  and has an existing accepted test.
+- Any change to the queue's drain strategy, the publisher, or the tap.
+- Converting the remaining real-timer producer tests to fake timers. They pass
+  and stop their producers; only the heartbeat cadence test is in scope.


### PR DESCRIPTION
## TLDR

Issue #2921 collected nine review findings against the JSP/1 observation producer. Re-verifying each one against `main` first turned up something worth stating up front: the producer fixes for findings 1-6 already landed inside PR #2897 itself (`git log -S` on `heartbeatLifecycle`, `requestRecovery`, and `applyOpenTransition` all resolve to 8b8abeb3a). So this PR is mostly about the part that was actually missing — proof — plus the three findings nobody had touched.

Two of the tests this PR replaces could not fail. The heartbeat cadence test filled an array it never asserted and advanced no clock. The overflow-recovery test was satisfied by a completely different code path from the one the finding is about. Both are now mutation-verified. The third piece is the deliberate decision issue #2921 asked for on bootstrap failure policy: explicit misconfiguration keeps failing fast, and now fails legibly.

The reasoning, the baseline audit, and the acceptance criteria are in `project-plans/issue-2921-jsp-producer-hardening.md`.

## Dive Deeper

### Baseline audit (please sanity-check this, it shapes the whole PR)

| Finding | State on `main` | This PR |
| --- | --- | --- |
| 1 heartbeat rejection degrades telemetry only | Implemented, real test | untouched |
| 2 heartbeat bound to its lifecycle | Implemented, real test | untouched |
| 3 shutdown cleanup survives a failing drain | Implemented, test had a gap | evidence fixed |
| 4 capacity / heartbeat interval validated | Implemented, real test | untouched |
| 5 overflow invokes the recovery callback | Implemented, test was vacuous | evidence fixed |
| 6 post-terminal immutability | Implemented, real test | untouched |
| 7 cadence test proves nothing | not addressed | rewritten |
| 8 test name overstates coverage | not addressed | split |
| 9 bootstrap failure policy | not addressed | decided + implemented |

Each "real test" claim was checked by mutation, not by reading.

### Finding 7 — the cadence test now proves delivery

It ran on real timers, never advanced a clock, and asserted only `interval * 3 <= OBSERVER_LEASE_MS`. It now uses fake timers, constructs the producer with **no** `heartbeatMs` override so the shipped default is the value under test, advances a full `OBSERVER_LEASE_MS`, and asserts at least three heartbeats were actually delivered. Mutation: stop `beginHeartbeat()` from arming the interval and the test fails with `Expected: >= 3, Received: 0`.

### Finding 8 — one dishonest test became two honest ones

`never blocks or throws when registration and publication fail` set `publish` to reject, but registration returned a terminal 409, so publish was never reached. It is now a terminal-registration test that **proves** publish is never called, plus a new publication-failure test where registration succeeds, publish rejects, the call count proves the rejecting path ran, and a later observation proves the producer is still usable.

### Finding 5 — the overflow test was measuring the wrong path

The old test burst three events through a capacity-one queue. The third event reached `applyAndPublish`, saw `needsSnapshotRecovery()`, and enqueued the snapshot itself — so the assertion passed through the polling path and would have passed with `JspBoundedQueue`'s `onRecoveryNeeded` deleted, which is the code the finding is about. The new test overflows and then makes **no** further observation, leaving the callback as the only route to a published snapshot. Mutation: delete `requestRecovery()` from the overflow branch and it fails.

### Finding 3 — the finding's literal premise is unreachable, so this proves the reachable half

The finding says "if `flush()` rejects". It cannot: `JspBoundedQueue.send` catches every sink rejection and converts it to a non-delivery, and the registration task carries its own `catch`, so neither `JspProducer.flush` nor `JspBoundedQueue.flush` can reject. The `try/finally` in `shutdown` guards a path the shipped queue cannot take. What *is* reachable is the other half — a drain where every publish fails must not skip the final terminal snapshot — and that is what the test now proves.

Getting teeth into it took a second pass. A failed send asks the producer for a recovery snapshot, so the obvious "last published document is a snapshot" assertion is satisfied by the queue's own recovery snapshot even with the direct terminal publish deleted (verified: the publish sequence became `["event","snapshot"]` and still passed). The recovery request is one-shot until a send succeeds, so the test now burns it before shutdown. After that, every snapshot the queue can still offer is enqueued ahead of the `session.ended` event, so a trailing snapshot can only be the direct terminal publish. Mutation: delete that publish and the test fails with `Expected: "snapshot", Received: "event"`.

### Finding 9 — bootstrap failure policy: fail fast, but legibly

The issue asked for a deliberate decision. The decision is to keep failing fast:

- `LLXPRT_JSP_BOOTSTRAP_FILE` is never set by a human interactive session; a supervisor sets it. Its presence is an explicit statement that this process is meant to be observed.
- Degrading silently turns a broken observation setup into "my agent never appears in the observer", an invisible failure with no local signal.
- A rejected bootstrap includes the non-loopback endpoint case. Refusing loudly is the right answer to a credential aimed off-host.
- Issue #2779's non-blocking guarantee is scoped to the post-startup path ("After valid startup, transport outage or queue pressure degrades telemetry without failing/blocking the foreground TUI"). Startup configuration validation is the separate P1 row, which already reads "Explicit invalid config fails fast without leaking values". The recorded design note is upheld, not contradicted, so no existing note or test had to be reversed.

What changes is legibility. The three `loadBootstrapFromEnv` failures threw a bare `Error`, so `packages/cli/index.ts` classified them as an unexpected critical error and printed a stack trace. They now throw `FatalConfigError` (exit code 52), which the entry point renders as a single actionable red line. Messages name the environment variable and the failure category and carry no path, file body, publisher credential, or registration id — a test asserts the credential and registration id are absent, since this diagnostic can end up in a supervisor's logs.

### Deliberately not done

- Suppressing the duplicate `source_sequence` that a no-op transition publishes. Predates this issue, shared with the superseded-tool case, and has an existing accepted test.
- Removing the now-known-unreachable `flush()` rejection guard in `shutdown`. It is on `main`, it is harmless, and deleting it is not what this issue asked for.
- Converting the remaining real-timer producer tests to fake timers. They pass and stop their producers.

## Reviewer Test Plan

The interesting review question is whether the new tests can actually fail. Please check by mutation rather than by reading:

    cd packages/cli

1. Heartbeat cadence — comment out `this.beginHeartbeat();` in `ensureRegistered()` in `src/observation/jspProducer.ts`, then:

       bun test src/observation/jspProducer.test.ts -t "heartbeat cadence"

   Expect `Expected: >= 3, Received: 0`. Restore.

2. Overflow recovery callback — comment out `this.requestRecovery();` in the overflow branch of `enqueue()` in `src/observation/jspQueue.ts`, then:

       bun test src/observation/jspProducer.test.ts -t "repairs an overflow"

   Expect a failure. Restore.

3. Terminal snapshot on shutdown — change `if (this.registered)` to `if (this.registered && false)` around the direct publish in `shutdown()` in `src/observation/jspProducer.ts`, then:

       bun test src/observation/jspProducer.test.ts -t "still stops cleanly"

   Expect `Expected: "snapshot", Received: "event"`. Restore. Worth also confirming the pre-change version of this test passes under that same mutation, which is why it was rewritten.

4. Whole area, and confirm it terminates rather than hanging:

       bun test src/observation/

Bootstrap failure behavior end to end:

    echo 'not json' > /tmp/bad-bootstrap.json
    LLXPRT_JSP_BOOTSTRAP_FILE=/tmp/bad-bootstrap.json bun scripts/start.ts "hi"

Expect a single red line naming `LLXPRT_JSP_BOOTSTRAP_FILE` and exit code 52, not "An unexpected critical error occurred" plus a stack trace. With the variable unset, observation stays disabled and the CLI behaves normally.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `bun test src/observation/` (129 pass), the full CLI shard (`bun scripts/test.ts --shard cli` — 530 vitest files / 6780 tests passed, 26/26 native Bun files passed), `npm run lint`, `npm run format`, `npm run build`, CLI typecheck clean on the changed files, and the profile smoke test. Nothing here is platform-specific: the change is test logic plus an error type swap.

## Linked issues / bugs

Fixes #2921

Follows up on #2897 and the design note in `project-plans/issue-2779-jsp-producer.md` (#2779).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid observation configuration now fails fast during startup with clear, credential-safe diagnostics.
  * Improved reliability for observation heartbeats, shutdown snapshots, rejected publications, and queue overflow recovery.

* **Tests**
  * Expanded coverage for configuration validation, heartbeat timing, terminal handling, publication failures, shutdown behavior, and overflow recovery.

* **Documentation**
  * Clarified startup failure behavior and non-blocking observation behavior after startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->