### PR TITLE
Restore safe PR walkthrough generation (Fixes #3062)

### DIFF
--- a/project-plans/issue3062/plan.md
+++ b/project-plans/issue3062/plan.md
@@ -1,0 +1,134 @@
+# Issue 3062: Restore PR walkthrough generation without public prompt leakage
+
+Plan ID: ISSUE-3062-WALKTHROUGH-BURP
+Generated: 2026-08-05
+
+## Observed failure and root cause
+
+The linked PR review run installed the published nightly CLI and invoked it with
+`--provider openai`. Every model call failed before reaching the API because the
+prebuilt bundle registered no built-in providers:
+
+    Could not activate explicitly-configured provider 'openai': Provider 'openai' not found
+
+The same defect reproduces on the current source tree: the unbundled CLI
+activates `openai` and reaches the configured endpoint, while the freshly built
+`packages/cli/bundle/llxprt.js` reports that the provider is absent.
+
+Built-in provider definitions are data files under
+`packages/providers/src/composition/aliases`. The bundled provider loader
+already searches for the documented publish layout at
+`bundle/providers/aliases`, but `buildCliBundle()` emits only `bundle/llxprt.js`.
+Consequently `loadProviderAliasEntries()` finds no built-in entries and
+`createProviderManager()` cannot register `openai`.
+
+A second issue turned that internal failure into the reported public “burp”:
+`runMapPhase()` copied each rejected process error into the per-file placeholder
+summary. Node's failed-command message includes the complete argument vector,
+including the prompt and its `UNTRUSTED DATA (JSON)` payload. The public
+walkthrough therefore reproduced internal command and prompt diagnostics.
+
+## Accepted behavior
+
+### AC1: Published CLI bundles include built-in provider aliases
+
+- **Given** the normal CLI prepack/bundle build
+- **When** `buildCliBundle()` completes successfully
+- **Then** the bundle layout contains the built-in provider alias data expected
+  by the existing bundled provider loader.
+- **And** running the built bundle with an explicitly configured `openai`
+  provider activates that provider and reaches an OpenAI-compatible endpoint,
+  rather than failing with `Provider 'openai' not found`.
+
+### AC2: Successful provider calls can produce the walkthrough
+
+- **Given** valid review artifacts and successful structured responses from the
+  configured LLxprt provider
+- **When** the walkthrough pipeline runs through the same command boundary used
+  by CI
+- **Then** it writes a rendered walkthrough comment from those responses rather
+  than a list of failed per-file summaries.
+
+### AC3: Per-file failures never publish process or prompt diagnostics
+
+- **Given** a per-file LLxprt invocation that fails and whose internal error
+  contains its command, prompt, `UNTRUSTED DATA (JSON)` payload, or provider
+  stack details
+- **When** the pipeline renders a fallback walkthrough
+- **Then** the public comment contains only a fixed generic per-file failure
+  summary and the affected file path.
+- **And** the public comment does not contain the failed command, prompt content,
+  untrusted-data payload, API details, or stack trace.
+- **And** internal diagnostics remain available through workflow stderr/logs.
+
+## Relevant inputs and boundary cases
+
+- Built-in alias files are runtime package assets, not user alias files. User
+  provider configuration behavior is unchanged.
+- The `UNTRUSTED DATA (JSON)` prompt boundary is intentional injection
+  hardening and remains unchanged; only accidental publication of a failed
+  prompt is prevented.
+- The established generic placeholder for an oversized file remains unchanged.
+- A mixture of successful and failed per-file calls keeps successful summaries
+  and substitutes the same generic placeholder only for failures.
+- Missing required configuration and whole-pipeline failures retain their
+  existing behavior; this issue does not redesign error handling.
+- The trusted-base checkout, nightly installation step, workflow triggers,
+  credentials, models, quota selection, and comment-posting workflow remain
+  unchanged. No workflow file change is required or accepted.
+- No dependency, public package API, agent-memory, quality-tool, or lint-rule
+  change is accepted.
+
+## Test-first evidence
+
+1. **RED — bundle behavior.** Add a Bun behavioral regression that performs the
+   real CLI bundle build, verifies the expected alias assets are emitted, and
+   runs the generated bundle against a local OpenAI-compatible HTTP fixture.
+   It must fail on the issue baseline because the assets are absent and the
+   bundle reports `Provider 'openai' not found`.
+2. **GREEN — bundle behavior.** Make the minimal build change that emits the
+   existing provider alias assets at the path already consumed by the bundle.
+   The same test must prove the built-in provider activates and receives the
+   fixture response.
+3. **RED — public fallback.** Add a Bun process-level walkthrough regression
+   using real review artifacts and a deliberately failing `llxprt` executable
+   whose error contains a unique command/prompt diagnostic sentinel and the
+   `UNTRUSTED DATA (JSON)` marker. It must fail on the baseline because the
+   rendered comment contains those diagnostics.
+4. **GREEN — public fallback.** Replace the dynamic per-file public failure
+   reason with a fixed generic summary. The process-level test must prove the
+   comment still identifies the file, contains the generic summary, and contains
+   none of the sentinels, command, prompt marker, or stack detail. It must also
+   prove the internal process output retains the diagnostic sentinel.
+5. Run focused Bun tests, then the complete project verification suite and the
+   required profile smoke test.
+
+## Implementation boundary
+
+The production change is limited to:
+
+- the existing CLI bundle build function, to place existing built-in alias data
+  in its already-documented runtime location; and
+- the existing per-file failure projection in the walkthrough script, to use a
+  fixed public placeholder rather than the internal process error.
+
+No adjacent cleanup, provider-loader redesign, workflow edit, new subsystem,
+new dependency, or public abstraction is in scope.
+
+## Review triage policy
+
+Every review finding will be classified as one of:
+
+- **Blocker-Fix**: violates accepted behavior, TDD/architecture/safety gates,
+  candidate ancestry, conflict-free delivery, or required verification.
+- **In-scope-Fix**: corrects implementation or behavioral evidence for AC1-AC3
+  without adding behavior beyond this plan.
+- **Reject**: factually incorrect, already satisfied, or contrary to accepted
+  behavior.
+- **Defer**: potentially valid but outside AC1-AC3 or requiring an unaccepted
+  workflow, subsystem, dependency, abstraction, or unrelated refactor.
+
+Open Code Review is capped at two local reviews and two PR reviews for this
+issue. Completion requires behavioral evidence for every acceptance criterion,
+full local verification, completed and triaged reviews, green CI on the
+candidate head, correct ancestry, and a conflict-free PR.

--- a/scripts/bun-build.config.ts
+++ b/scripts/bun-build.config.ts
@@ -25,7 +25,14 @@
  * a2a-server build. Top-level execution is guarded by `import.meta.main`.
  */
 
-import { copyFileSync, existsSync, readFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -177,6 +184,26 @@ export const cliBundleConfig: Parameters<typeof Bun.build>[0] = {
 };
 
 /**
+ * Built-in provider alias data (issue #3062).
+ *
+ * The bundled `providerAliases` loader computes its built-in directory as
+ * `<bundleDir>/providers/aliases` (resolved from the bundle's own `__dirname`
+ * at runtime). When the bundle was the only emitted artifact that directory did
+ * not exist, so no built-in aliases registered and `--provider openai` failed
+ * with "Provider 'openai' not found". The alias assets live as raw
+ * `.config`/`.json` files in the providers package source; emit them verbatim
+ * next to the bundle so the loader finds them exactly as in development.
+ */
+const providerAliasSourceDir = join(
+  root,
+  'packages/providers/src/composition/aliases',
+);
+const providerAliasBundleDir = join(
+  root,
+  'packages/cli/bundle/providers/aliases',
+);
+
+/**
  * Runs a Bun.build target and exits non-zero on any failure (rejected promise
  * or `success === false`), surfacing diagnostics. Stale artifacts must never be
  * shipped downstream, so both failure modes are fatal.
@@ -222,6 +249,30 @@ async function buildA2aServer(): Promise<readonly string[]> {
 }
 
 /**
+ * Collects built-in provider alias asset names (`.config`/`.json`) from `dir`,
+ * failing fast when none are found.
+ *
+ * An empty result is a build-input error, not a silent no-op: the bundled
+ * `providerAliases` loader would then register zero built-in providers and
+ * `--provider openai` would fail at launch (issue #3062 regression). Surfacing
+ * this at build time prevents shipping a bundle that silently dropped every
+ * built-in alias.
+ */
+export function collectAliasAssets(dir: string): string[] {
+  const assets = readdirSync(dir).filter(
+    (name) => name.endsWith('.config') || name.endsWith('.json'),
+  );
+  if (assets.length === 0) {
+    throw new Error(
+      `cli-bundle build produced no built-in provider alias assets: ${dir} ` +
+        `contains no .config/.json files; the bundled providerAliases loader ` +
+        `would register no built-in providers.`,
+    );
+  }
+  return assets;
+}
+
+/**
  * Builds the prebuilt CLI bundle only (issue #2999).
  *
  * Kept separately invocable so `prepack` can produce the shipped bundle
@@ -248,7 +299,24 @@ export async function buildCliBundle(): Promise<readonly string[]> {
       `cli-bundle build completed with errors: ${detail || '(no details)'}`,
     );
   }
-  return cliResult.outputs.map((o) => `${o.path}=${o.size}`);
+
+  // Emit the built-in provider alias data next to the bundle (issue #3062).
+  // Replace any stale copy wholesale so removed/renamed alias files never leak
+  // into a publish artifact.
+  rmSync(providerAliasBundleDir, { recursive: true, force: true });
+  mkdirSync(providerAliasBundleDir, { recursive: true });
+  const aliasAssets = collectAliasAssets(providerAliasSourceDir);
+  for (const name of aliasAssets) {
+    copyFileSync(
+      join(providerAliasSourceDir, name),
+      join(providerAliasBundleDir, name),
+    );
+  }
+
+  return [
+    ...cliResult.outputs.map((o) => `${o.path}=${o.size}`),
+    ...aliasAssets.map((name) => join(providerAliasBundleDir, name)),
+  ];
 }
 
 /**

--- a/scripts/pr-review-walkthrough.ts
+++ b/scripts/pr-review-walkthrough.ts
@@ -424,14 +424,20 @@ async function runMapPhase(
       JSON.stringify(result, null, 2),
     );
   }
-  return results.map((result) =>
-    'error' in result && typeof result.error === 'string'
-      ? placeholderSummary(
-          String(result.filePath),
-          `(per-file summary failed: ${result.error})`,
-        )
-      : result,
-  );
+  return results.map((result) => {
+    if (!('error' in result) || typeof result.error !== 'string') {
+      return result;
+    }
+    // The rejection message carries the prompt and untrusted payload; keep it
+    // on stderr/logs only and render a fixed label into the public comment.
+    console.error(
+      `[walkthrough] per-file summary failed for ${result.filePath}: ${result.error}`,
+    );
+    return placeholderSummary(
+      String(result.filePath),
+      PER_FILE_SUMMARY_UNAVAILABLE,
+    );
+  });
 }
 
 interface MapItem {
@@ -468,6 +474,16 @@ const magnitudeInputSchema = z.object({
 const MAP_MODEL = process.env.LLXPRT_DEFAULT_MODEL;
 const STRONG_MODEL =
   process.env.LLXPRT_STRONG_MODEL || process.env.LLXPRT_DEFAULT_MODEL;
+
+/**
+ * Public placeholder shown when a single file's summary could not be produced.
+ *
+ * The underlying failure message (from the model subprocess) embeds the full
+ * prompt, including untrusted diff/PR data and the exact command line, so it
+ * must never be rendered into the published comment. The real diagnostic is
+ * written to stderr/logs instead; the comment gets only this fixed label.
+ */
+const PER_FILE_SUMMARY_UNAVAILABLE = '(per-file summary unavailable)';
 
 function placeholderSummary(
   filePath: string,

--- a/scripts/pr-review-walkthrough.ts
+++ b/scripts/pr-review-walkthrough.ts
@@ -229,10 +229,12 @@ function spawnCapturingStdout(
         maxBuffer: 10 * 1024 * 1024,
         env: childEnv,
       },
-      (error, stdout) => {
+      (error, stdout, stderr) => {
         cleanup();
         if (error) {
-          reject(sanitizeErrorMessage(error));
+          reject(
+            buildSafeSubprocessError(error, stderr, extraEnv.OPENAI_API_KEY),
+          );
         } else {
           resolve(stdout);
         }
@@ -255,9 +257,104 @@ function spawnCapturingStdout(
     process.on('SIGTERM', terminate);
     child.on('error', (error) => {
       cleanup();
-      reject(sanitizeErrorMessage(error));
+      reject(buildSafeSubprocessError(error, '', extraEnv.OPENAI_API_KEY));
     });
   });
+}
+
+/**
+ * Build a safe diagnostic Error from a rejected `execFile` result WITHOUT
+ * serializing the command/argv. Node's `ExecError.message` is
+ * `Command failed: <command>
+<stderr>`, which embeds the full `--prompt`
+ * value (untrusted diff/PR data) and the process command line — neither may
+ * reach stderr or the public walkthrough comment.
+ *
+ * Preserved safe diagnostics: exit code / signal, the `killed` flag, and the
+ * provider's own stderr (redacted of any secret value). The provider stderr is
+ * what retry classification (`isRetryableLlxprtError`) inspects for HTTP status
+ * patterns, so surfacing it keeps transient-failure retries working without
+ * leaking the command. The `code`, `signal`, and `killed` metadata is copied as
+ * own properties so retry/timeout classification behaves as before.
+ */
+function buildSafeSubprocessError(
+  error: unknown,
+  providerStderr: string,
+  secret: string | undefined,
+): Error {
+  const code = errorProperty(error, 'code');
+  const signal = errorProperty(error, 'signal');
+  const killed = errorProperty(error, 'killed');
+  const safe = new Error(
+    describeSafeSubprocessFailure(code, signal, killed, providerStderr, secret),
+  );
+  defineOwnPropertyIfDefined(safe, 'code', code);
+  defineOwnPropertyIfDefined(safe, 'signal', signal);
+  defineOwnPropertyIfDefined(safe, 'killed', killed);
+  return safe;
+}
+
+function errorProperty(error: unknown, key: PropertyKey): unknown {
+  if (error === null || typeof error !== 'object') {
+    return undefined;
+  }
+  return Reflect.get(error, key);
+}
+
+function defineOwnPropertyIfDefined(
+  target: Error,
+  key: PropertyKey,
+  value: unknown,
+): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function describeSafeSubprocessFailure(
+  code: unknown,
+  signal: unknown,
+  killed: unknown,
+  providerStderr: string,
+  secret: string | undefined,
+): string {
+  const detail: string[] = [];
+  if (typeof code === 'number') {
+    detail.push(`exit code ${code}`);
+  } else if (typeof code === 'string' && code.length > 0) {
+    detail.push(`code ${code}`);
+  }
+  if (typeof signal === 'string' && signal.length > 0) {
+    detail.push(`signal ${signal}`);
+  }
+  if (killed === true) {
+    detail.push('killed');
+  }
+  const descriptor = detail.length > 0 ? ` (${detail.join(', ')})` : '';
+  const sanitizedStderr =
+    typeof providerStderr === 'string' && providerStderr.length > 0
+      ? redactSecret(providerStderr, secret).trim()
+      : '';
+  return sanitizedStderr.length > 0
+    ? `LLM subprocess failed${descriptor}: ${sanitizedStderr}`
+    : `LLM subprocess failed${descriptor}`;
+}
+
+function redactSecret(text: string, secret: string | undefined): string {
+  if (
+    typeof secret !== 'string' ||
+    secret.length === 0 ||
+    !text.includes(secret)
+  ) {
+    return text;
+  }
+  return text.split(secret).join('[REDACTED]');
 }
 
 /**

--- a/scripts/tests/issue-3062-cli-bundle-aliases.bun.test.ts
+++ b/scripts/tests/issue-3062-cli-bundle-aliases.bun.test.ts
@@ -21,9 +21,12 @@
  * missing provider; after the fix `openai` activates and the fixture receives
  * the chat-completion request.
  *
- * Gated behind `LLXPRT_RUN_BUNDLE_BUILD_TEST=1` (the build takes ~20s), the
- * same gate as the issue #2999 launchability test, so the default shard stays
- * fast while nightly CI exercises it.
+ * This runs unconditionally in the `scripts` shard (the build takes ~20s), like
+ * the issue #3055 bundle-purity guard. Each file executes in its own isolated
+ * process and cleans up its generated bundle in `afterAll`, so it neither
+ * conflicts with the issue #2999 launchability smoke nor leaves artifacts
+ * behind. Unlike #2999 (which stays behind a nightly opt-in gate), this is a
+ * production behavioral regression that must run on every PR.
  */
 
 import { afterAll, describe, expect, it } from 'bun:test';
@@ -58,7 +61,32 @@ const sourceAliasDir = join(
   'aliases',
 );
 
-const RUN_BUILD_TEST = process.env.LLXPRT_RUN_BUNDLE_BUILD_TEST === '1';
+/**
+ * Observation/telemetry env vars inherited from the parent process that must
+ * NOT leak into the spawned bundle. This test proves provider activation, not
+ * observation: an inherited `LLXPRT_JSP_BOOTSTRAP_FILE` (set whenever the test
+ * runs inside an llxprt-code agent) would make the bundle initialize telemetry
+ * against a parent-process bootstrap file, which is unrelated to provider
+ * activation and crashes the spawned CLI before it reaches the provider.
+ * Stripping these keeps the bundle in the same non-observing state CI runs it
+ * in, so the test is hermetic regardless of the host that executes it.
+ */
+const OBSERVATION_ENV_BLOCKLIST = [
+  'LLXPRT_JSP_BOOTSTRAP_FILE',
+  'LLXPRT_JSP_NO_CONTENT',
+] as const;
+
+function bundleSpawnEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENAI_API_KEY: 'test-key',
+    CI: 'true',
+  };
+  for (const key of OBSERVATION_ENV_BLOCKLIST) {
+    delete env[key];
+  }
+  return env;
+}
 
 /**
  * A minimal OpenAI-compatible SSE server: it streams a chat-completion whose
@@ -131,177 +159,170 @@ function startFixture(): Promise<{
   });
 }
 
-describe.skipIf(!RUN_BUILD_TEST)(
-  'issue #3062: CLI bundle ships built-in provider aliases and activates openai',
-  () => {
-    // The bundle is a gitignored publish artifact; clean it so a stale copy
-    // cannot mask a regression in either the build or the alias emission.
-    afterAll(() => {
-      rmSync(bundleDir, { recursive: true, force: true });
+describe('issue #3062: CLI bundle ships built-in provider aliases and activates openai', () => {
+  // The bundle is a gitignored publish artifact; clean it so a stale copy
+  // cannot mask a regression in either the build or the alias emission.
+  afterAll(() => {
+    rmSync(bundleDir, { recursive: true, force: true });
+  });
+
+  it('the CLI bundle build emits the built-in alias assets the bundled loader reads', () => {
+    rmSync(bundleDir, { recursive: true, force: true });
+
+    // Build via the same publish-time script `prepack`/`bundle:cli` invoke.
+    // A subprocess is used (rather than calling buildCliBundle() in-process)
+    // because Bun's in-test bundler cannot resolve the CLI's dynamic imports
+    // on every host, whereas the script-mode bundler always can; this is the
+    // real publish boundary either way.
+    const buildScript = join(repoRoot, 'scripts', 'bun-build.config.ts');
+    const build = spawnSync(bunExecutable, [buildScript, '--cli-only'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 120_000,
+      env: { ...process.env, CI: 'true' },
     });
-
-    it('the CLI bundle build emits the built-in alias assets the bundled loader reads', () => {
-      rmSync(bundleDir, { recursive: true, force: true });
-
-      // Build via the same publish-time script `prepack`/`bundle:cli` invoke.
-      // A subprocess is used (rather than calling buildCliBundle() in-process)
-      // because Bun's in-test bundler cannot resolve the CLI's dynamic imports
-      // on every host, whereas the script-mode bundler always can; this is the
-      // real publish boundary either way.
-      const buildScript = join(repoRoot, 'scripts', 'bun-build.config.ts');
-      const build = spawnSync(bunExecutable, [buildScript, '--cli-only'], {
-        cwd: repoRoot,
-        encoding: 'utf8',
-        timeout: 120_000,
-        env: { ...process.env, CI: 'true' },
-      });
-      if (build.status !== 0) {
-        throw new Error(
-          `CLI bundle build failed (exit=${build.status}):\n${build.stderr ?? ''}`,
-        );
-      }
-
-      expect(existsSync(bundlePath)).toBe(true);
-      // The bundled loader reads bundle/providers/aliases (providerAliases.ts);
-      // openai.config must be present or `--provider openai` cannot activate.
-      expect(existsSync(join(bundleAliasDir, 'openai.config'))).toBe(true);
-
-      // Every shipped built-in alias asset must be emitted, not just openai.
-      const sourceAssets = readdirSync(sourceAliasDir).filter(
-        (name) => name.endsWith('.config') || name.endsWith('.json'),
+    if (build.status !== 0) {
+      throw new Error(
+        `CLI bundle build failed (exit=${build.status}):\n${build.stderr ?? ''}`,
       );
-      expect(sourceAssets.length).toBeGreaterThan(0);
-      for (const name of sourceAssets) {
-        expect(existsSync(join(bundleAliasDir, name))).toBe(true);
-      }
-    }, 180_000);
+    }
 
-    it('activates the openai provider and reaches the OpenAI-compatible fixture', async () => {
-      // The previous test built the bundle + aliases; assert the artifact exists
-      // so a missing build surfaces here rather than as an opaque spawn error.
-      expect(existsSync(bundlePath)).toBe(true);
+    expect(existsSync(bundlePath)).toBe(true);
+    // The bundled loader reads bundle/providers/aliases (providerAliases.ts);
+    // openai.config must be present or `--provider openai` cannot activate.
+    expect(existsSync(join(bundleAliasDir, 'openai.config'))).toBe(true);
 
-      const fixture = await startFixture();
-      // The fixture is an in-process HTTP server, so the bundle must run as an
-      // async child (not spawnSync, which would block this process's event loop
-      // and starve the server).
-      let child: ChildProcess | undefined;
-      let stdout = '';
-      let stderr = '';
-      let exited = false;
-      try {
-        child = spawn(
-          bunExecutable,
-          [
-            bundlePath,
-            '--provider',
-            'openai',
-            '--model',
-            'gpt-5.5',
-            '--baseurl',
-            `http://127.0.0.1:${fixture.port}/v1`,
-            '--prompt',
-            'Reply with exactly: haiku',
-          ],
-          {
-            stdio: ['ignore', 'pipe', 'pipe'],
-            env: {
-              ...process.env,
-              OPENAI_API_KEY: 'test-key',
-              CI: 'true',
-            },
-          },
-        );
-        child.stdout?.on('data', (data: Buffer) => {
-          stdout += data.toString();
+    // Every shipped built-in alias asset must be emitted, not just openai.
+    const sourceAssets = readdirSync(sourceAliasDir).filter(
+      (name) => name.endsWith('.config') || name.endsWith('.json'),
+    );
+    expect(sourceAssets.length).toBeGreaterThan(0);
+    for (const name of sourceAssets) {
+      expect(existsSync(join(bundleAliasDir, name))).toBe(true);
+    }
+  }, 180_000);
+
+  it('activates the openai provider and reaches the OpenAI-compatible fixture', async () => {
+    // The previous test built the bundle + aliases; assert the artifact exists
+    // so a missing build surfaces here rather than as an opaque spawn error.
+    expect(existsSync(bundlePath)).toBe(true);
+
+    const fixture = await startFixture();
+    // The fixture is an in-process HTTP server, so the bundle must run as an
+    // async child (not spawnSync, which would block this process's event loop
+    // and starve the server).
+    let child: ChildProcess | undefined;
+    let stdout = '';
+    let stderr = '';
+    let exited = false;
+    try {
+      child = spawn(
+        bunExecutable,
+        [
+          bundlePath,
+          '--provider',
+          'openai',
+          '--model',
+          'gpt-5.5',
+          '--baseurl',
+          `http://127.0.0.1:${fixture.port}/v1`,
+          '--prompt',
+          'Reply with exactly: haiku',
+        ],
+        {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env: bundleSpawnEnv(),
+        },
+      );
+      child.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+      child.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      // Track the real exit so cleanup only terminates a still-running child
+      // and the success path can await a bounded clean completion. Spawn
+      // failures (e.g. ENOENT) emit 'error' with no following 'exit'; route
+      // them through this same lifecycle so the test fails with the real
+      // error instead of crashing on an unhandled EventEmitter emission. The
+      // handler is attached inside the executor, where rejectExit is already
+      // bound (attaching it earlier would reference it before assignment).
+      const exitInfo = new Promise<{
+        code: number | null;
+        signal: NodeJS.Signals | null;
+      }>((resolveExit, rejectExit) => {
+        child!.once('exit', (code, signal) => {
+          exited = true;
+          resolveExit({ code, signal });
         });
-        child.stderr?.on('data', (data: Buffer) => {
-          stderr += data.toString();
+        child!.once('error', (error: Error) => {
+          exited = true;
+          rejectExit(error);
         });
+      });
 
-        // Track the real exit so cleanup only terminates a still-running child
-        // and the success path can await a bounded clean completion. Spawn
-        // failures (e.g. ENOENT) emit 'error' with no following 'exit'; route
-        // them through this same lifecycle so the test fails with the real
-        // error instead of crashing on an unhandled EventEmitter emission. The
-        // handler is attached inside the executor, where rejectExit is already
-        // bound (attaching it earlier would reference it before assignment).
-        const exitInfo = new Promise<{
+      // Phase 1: prove the provider activated and reached the endpoint. If the
+      // child exits before the first chat-completion request, that is a
+      // failure; bound it so a hang cannot stall CI.
+      const reachedEndpoint = await Promise.race([
+        fixture.awaitChatHit().then(() => true),
+        exitInfo.then(() => false),
+        new Promise<boolean>((resolveTimeout) =>
+          setTimeout(() => resolveTimeout(false), 60_000),
+        ),
+      ]);
+      expect(reachedEndpoint).toBe(true);
+
+      // Give stdout a tick to flush after the hit.
+      await new Promise((done) => setTimeout(done, 500));
+
+      const combined = `${stdout}${stderr}`;
+      // Activation proof #1: no missing-provider failure.
+      expect(combined).not.toContain("Provider 'openai' not found");
+      // Activation proof #2: the provider made a real chat-completion request.
+      expect(fixture.chatHits()).toBeGreaterThan(0);
+      // The streamed fixture response reaches the prompt output.
+      expect(combined).toContain('haiku');
+
+      // Phase 2: the bundled CLI must complete cleanly at the CI command
+      // boundary. Independent execution produces the response and exits 0; a
+      // hang, signal, or non-zero exit is a regression.
+      const cleanExit = await Promise.race([
+        exitInfo,
+        new Promise<{
           code: number | null;
           signal: NodeJS.Signals | null;
-        }>((resolveExit, rejectExit) => {
-          child!.once('exit', (code, signal) => {
-            exited = true;
-            resolveExit({ code, signal });
-          });
-          child!.once('error', (error: Error) => {
-            exited = true;
-            rejectExit(error);
+        }>((resolveTimeout) =>
+          setTimeout(
+            () => resolveTimeout({ code: null, signal: null }),
+            60_000,
+          ),
+        ),
+      ]);
+      expect(cleanExit.code).toBe(0);
+      expect(cleanExit.signal).toBeNull();
+    } finally {
+      // Exact-child cleanup: terminate only the spawned child (never a
+      // pattern-based kill) and await its bounded exit so no zombie lingers.
+      // A child that already settled (clean exit or spawn error, both set
+      // `exited`) is left alone; no speculative SIGKILL escalation. The exit
+      // listener is attached before signalling so the reap is never missed.
+      if (!exited && child) {
+        const reaped = new Promise<void>((resolveReap) => {
+          const timer = setTimeout(resolveReap, 10_000);
+          child!.once('exit', () => {
+            clearTimeout(timer);
+            resolveReap();
           });
         });
-
-        // Phase 1: prove the provider activated and reached the endpoint. If the
-        // child exits before the first chat-completion request, that is a
-        // failure; bound it so a hang cannot stall CI.
-        const reachedEndpoint = await Promise.race([
-          fixture.awaitChatHit().then(() => true),
-          exitInfo.then(() => false),
-          new Promise<boolean>((resolveTimeout) =>
-            setTimeout(() => resolveTimeout(false), 60_000),
-          ),
-        ]);
-        expect(reachedEndpoint).toBe(true);
-
-        // Give stdout a tick to flush after the hit.
-        await new Promise((done) => setTimeout(done, 500));
-
-        const combined = `${stdout}${stderr}`;
-        // Activation proof #1: no missing-provider failure.
-        expect(combined).not.toContain("Provider 'openai' not found");
-        // Activation proof #2: the provider made a real chat-completion request.
-        expect(fixture.chatHits()).toBeGreaterThan(0);
-        // The streamed fixture response reaches the prompt output.
-        expect(combined).toContain('haiku');
-
-        // Phase 2: the bundled CLI must complete cleanly at the CI command
-        // boundary. Independent execution produces the response and exits 0; a
-        // hang, signal, or non-zero exit is a regression.
-        const cleanExit = await Promise.race([
-          exitInfo,
-          new Promise<{
-            code: number | null;
-            signal: NodeJS.Signals | null;
-          }>((resolveTimeout) =>
-            setTimeout(
-              () => resolveTimeout({ code: null, signal: null }),
-              60_000,
-            ),
-          ),
-        ]);
-        expect(cleanExit.code).toBe(0);
-        expect(cleanExit.signal).toBeNull();
-      } finally {
-        // Exact-child cleanup: terminate only the spawned child (never a
-        // pattern-based kill) and await its bounded exit so no zombie lingers.
-        // A child that already settled (clean exit or spawn error, both set
-        // `exited`) is left alone; no speculative SIGKILL escalation. The exit
-        // listener is attached before signalling so the reap is never missed.
-        if (!exited && child) {
-          const reaped = new Promise<void>((resolveReap) => {
-            const timer = setTimeout(resolveReap, 10_000);
-            child!.once('exit', () => {
-              clearTimeout(timer);
-              resolveReap();
-            });
-          });
-          child.kill('SIGTERM');
-          await reaped;
-        }
-        await new Promise<void>((done) => fixture.server.close(() => done()));
+        child.kill('SIGTERM');
+        await reaped;
       }
-    }, 180_000);
-  },
-);
+      await new Promise<void>((done) => fixture.server.close(() => done()));
+    }
+  }, 180_000);
+});
 
 /**
  * Issue #3062 (build-input guard) — `buildCliBundle()` must fail fast rather

--- a/scripts/tests/issue-3062-cli-bundle-aliases.bun.test.ts
+++ b/scripts/tests/issue-3062-cli-bundle-aliases.bun.test.ts
@@ -1,0 +1,339 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3062 (AC1/AC2) — the prebuilt CLI bundle must ship the built-in
+ * provider alias data so an explicitly configured `openai` provider activates.
+ *
+ * Root cause: `buildCliBundle()` emitted only `bundle/llxprt.js`. The bundled
+ * `providerAliases` loader looks for built-in alias data at
+ * `bundle/providers/aliases` (relative to the bundle), found nothing, so
+ * `createProviderManager()` registered no built-in providers and
+ * `--provider openai` failed with `Provider 'openai' not found`.
+ *
+ * This builds the real CLI bundle via the publish-time `buildCliBundle()`,
+ * asserts the alias assets are emitted at the path the bundled loader reads,
+ * then executes the artifact against a local OpenAI-compatible SSE fixture.
+ * On the issue baseline the assets are absent and the bundle reports the
+ * missing provider; after the fix `openai` activates and the fixture receives
+ * the chat-completion request.
+ *
+ * Gated behind `LLXPRT_RUN_BUNDLE_BUILD_TEST=1` (the build takes ~20s), the
+ * same gate as the issue #2999 launchability test, so the default shard stays
+ * fast while nightly CI exercises it.
+ */
+
+import { afterAll, describe, expect, it } from 'bun:test';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { collectAliasAssets } from '../bun-build.config.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(__filename, '..', '..', '..');
+// process.execPath is the Bun running this test; the node_modules/bun layout is
+// platform-specific and absent on some dev machines.
+const bunExecutable = process.execPath;
+const bundleDir = join(repoRoot, 'packages', 'cli', 'bundle');
+const bundlePath = join(bundleDir, 'llxprt.js');
+const bundleAliasDir = join(bundleDir, 'providers', 'aliases');
+const sourceAliasDir = join(
+  repoRoot,
+  'packages',
+  'providers',
+  'src',
+  'composition',
+  'aliases',
+);
+
+const RUN_BUILD_TEST = process.env.LLXPRT_RUN_BUNDLE_BUILD_TEST === '1';
+
+/**
+ * A minimal OpenAI-compatible SSE server: it streams a chat-completion whose
+ * assistant text is `haiku`, answers `/models`, and records every
+ * chat-completion hit so the test can prove the provider actually reached the
+ * endpoint rather than failing at activation.
+ */
+function startFixture(): Promise<{
+  server: Server;
+  port: number;
+  chatHits: () => number;
+  awaitChatHit: () => Promise<void>;
+}> {
+  let chatHits = 0;
+  let firstHit: () => void;
+  const firstHitPromise = new Promise<void>((resolvePromise) => {
+    firstHit = resolvePromise;
+  });
+  const server = createServer((req, res) => {
+    const url = req.url ?? '';
+    if (req.method === 'GET' && url.endsWith('/models')) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          object: 'list',
+          data: [{ id: 'gpt-5.5', object: 'model', owned_by: 'test' }],
+        }),
+      );
+      return;
+    }
+    if (req.method === 'POST' && url.includes('chat/completions')) {
+      chatHits += 1;
+      firstHit();
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      });
+      const chunk = (delta: Record<string, unknown>, finish: string | null) =>
+        'data: ' +
+        JSON.stringify({
+          id: 'chatcmpl-3062',
+          object: 'chat.completion.chunk',
+          created: Math.floor(Date.now() / 1000),
+          model: 'gpt-5.5',
+          choices: [{ index: 0, delta, finish_reason: finish }],
+        }) +
+        '\n\n';
+      res.write(chunk({ role: 'assistant', content: 'hai' }, null));
+      res.write(chunk({ content: 'ku' }, null));
+      res.write(chunk({}, 'stop'));
+      res.write('data: [DONE]\n\n');
+      res.end();
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  return new Promise((resolvePromise) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = addr !== null && typeof addr === 'object' ? addr.port : 0;
+      resolvePromise({
+        server,
+        port,
+        chatHits: () => chatHits,
+        awaitChatHit: () => firstHitPromise,
+      });
+    });
+  });
+}
+
+describe.skipIf(!RUN_BUILD_TEST)(
+  'issue #3062: CLI bundle ships built-in provider aliases and activates openai',
+  () => {
+    // The bundle is a gitignored publish artifact; clean it so a stale copy
+    // cannot mask a regression in either the build or the alias emission.
+    afterAll(() => {
+      rmSync(bundleDir, { recursive: true, force: true });
+    });
+
+    it('the CLI bundle build emits the built-in alias assets the bundled loader reads', () => {
+      rmSync(bundleDir, { recursive: true, force: true });
+
+      // Build via the same publish-time script `prepack`/`bundle:cli` invoke.
+      // A subprocess is used (rather than calling buildCliBundle() in-process)
+      // because Bun's in-test bundler cannot resolve the CLI's dynamic imports
+      // on every host, whereas the script-mode bundler always can; this is the
+      // real publish boundary either way.
+      const buildScript = join(repoRoot, 'scripts', 'bun-build.config.ts');
+      const build = spawnSync(bunExecutable, [buildScript, '--cli-only'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        timeout: 120_000,
+        env: { ...process.env, CI: 'true' },
+      });
+      if (build.status !== 0) {
+        throw new Error(
+          `CLI bundle build failed (exit=${build.status}):\n${build.stderr ?? ''}`,
+        );
+      }
+
+      expect(existsSync(bundlePath)).toBe(true);
+      // The bundled loader reads bundle/providers/aliases (providerAliases.ts);
+      // openai.config must be present or `--provider openai` cannot activate.
+      expect(existsSync(join(bundleAliasDir, 'openai.config'))).toBe(true);
+
+      // Every shipped built-in alias asset must be emitted, not just openai.
+      const sourceAssets = readdirSync(sourceAliasDir).filter(
+        (name) => name.endsWith('.config') || name.endsWith('.json'),
+      );
+      expect(sourceAssets.length).toBeGreaterThan(0);
+      for (const name of sourceAssets) {
+        expect(existsSync(join(bundleAliasDir, name))).toBe(true);
+      }
+    }, 180_000);
+
+    it('activates the openai provider and reaches the OpenAI-compatible fixture', async () => {
+      // The previous test built the bundle + aliases; assert the artifact exists
+      // so a missing build surfaces here rather than as an opaque spawn error.
+      expect(existsSync(bundlePath)).toBe(true);
+
+      const fixture = await startFixture();
+      // The fixture is an in-process HTTP server, so the bundle must run as an
+      // async child (not spawnSync, which would block this process's event loop
+      // and starve the server).
+      let child: ChildProcess | undefined;
+      let stdout = '';
+      let stderr = '';
+      let exited = false;
+      try {
+        child = spawn(
+          bunExecutable,
+          [
+            bundlePath,
+            '--provider',
+            'openai',
+            '--model',
+            'gpt-5.5',
+            '--baseurl',
+            `http://127.0.0.1:${fixture.port}/v1`,
+            '--prompt',
+            'Reply with exactly: haiku',
+          ],
+          {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: {
+              ...process.env,
+              OPENAI_API_KEY: 'test-key',
+              CI: 'true',
+            },
+          },
+        );
+        child.stdout?.on('data', (data: Buffer) => {
+          stdout += data.toString();
+        });
+        child.stderr?.on('data', (data: Buffer) => {
+          stderr += data.toString();
+        });
+
+        // Track the real exit so cleanup only terminates a still-running child
+        // and the success path can await a bounded clean completion. Spawn
+        // failures (e.g. ENOENT) emit 'error' with no following 'exit'; route
+        // them through this same lifecycle so the test fails with the real
+        // error instead of crashing on an unhandled EventEmitter emission. The
+        // handler is attached inside the executor, where rejectExit is already
+        // bound (attaching it earlier would reference it before assignment).
+        const exitInfo = new Promise<{
+          code: number | null;
+          signal: NodeJS.Signals | null;
+        }>((resolveExit, rejectExit) => {
+          child!.once('exit', (code, signal) => {
+            exited = true;
+            resolveExit({ code, signal });
+          });
+          child!.once('error', (error: Error) => {
+            exited = true;
+            rejectExit(error);
+          });
+        });
+
+        // Phase 1: prove the provider activated and reached the endpoint. If the
+        // child exits before the first chat-completion request, that is a
+        // failure; bound it so a hang cannot stall CI.
+        const reachedEndpoint = await Promise.race([
+          fixture.awaitChatHit().then(() => true),
+          exitInfo.then(() => false),
+          new Promise<boolean>((resolveTimeout) =>
+            setTimeout(() => resolveTimeout(false), 60_000),
+          ),
+        ]);
+        expect(reachedEndpoint).toBe(true);
+
+        // Give stdout a tick to flush after the hit.
+        await new Promise((done) => setTimeout(done, 500));
+
+        const combined = `${stdout}${stderr}`;
+        // Activation proof #1: no missing-provider failure.
+        expect(combined).not.toContain("Provider 'openai' not found");
+        // Activation proof #2: the provider made a real chat-completion request.
+        expect(fixture.chatHits()).toBeGreaterThan(0);
+        // The streamed fixture response reaches the prompt output.
+        expect(combined).toContain('haiku');
+
+        // Phase 2: the bundled CLI must complete cleanly at the CI command
+        // boundary. Independent execution produces the response and exits 0; a
+        // hang, signal, or non-zero exit is a regression.
+        const cleanExit = await Promise.race([
+          exitInfo,
+          new Promise<{
+            code: number | null;
+            signal: NodeJS.Signals | null;
+          }>((resolveTimeout) =>
+            setTimeout(
+              () => resolveTimeout({ code: null, signal: null }),
+              60_000,
+            ),
+          ),
+        ]);
+        expect(cleanExit.code).toBe(0);
+        expect(cleanExit.signal).toBeNull();
+      } finally {
+        // Exact-child cleanup: terminate only the spawned child (never a
+        // pattern-based kill) and await its bounded exit so no zombie lingers.
+        // A child that already settled (clean exit or spawn error, both set
+        // `exited`) is left alone; no speculative SIGKILL escalation. The exit
+        // listener is attached before signalling so the reap is never missed.
+        if (!exited && child) {
+          const reaped = new Promise<void>((resolveReap) => {
+            const timer = setTimeout(resolveReap, 10_000);
+            child!.once('exit', () => {
+              clearTimeout(timer);
+              resolveReap();
+            });
+          });
+          child.kill('SIGTERM');
+          await reaped;
+        }
+        await new Promise<void>((done) => fixture.server.close(() => done()));
+      }
+    }, 180_000);
+  },
+);
+
+/**
+ * Issue #3062 (build-input guard) — `buildCliBundle()` must fail fast rather
+ * than ship a bundle with zero built-in alias assets. This exercises the
+ * extracted `collectAliasAssets` directly so the guard is covered by a cheap,
+ * always-on unit test (no ~20s build required).
+ */
+describe('issue #3062: collectAliasAssets fail-fast on empty alias assets', () => {
+  it('throws when the directory has no .config/.json assets', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'llxprt-alias-empty-'));
+    try {
+      expect(() => collectAliasAssets(dir)).toThrow(
+        /no built-in provider alias assets/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('collects only .config and .json assets from a populated directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'llxprt-alias-populated-'));
+    try {
+      writeFileSync(join(dir, 'openai.config'), 'test');
+      writeFileSync(join(dir, 'vertex.json'), '{}');
+      writeFileSync(join(dir, 'README.md'), 'ignored');
+      const assets = collectAliasAssets(dir);
+      expect(assets).toEqual(
+        expect.arrayContaining(['openai.config', 'vertex.json']),
+      );
+      expect(assets).not.toContain('README.md');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/issue-3062-walkthrough-no-leak.bun.test.ts
+++ b/scripts/tests/issue-3062-walkthrough-no-leak.bun.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3062 (AC3) — per-file walkthrough failures must never publish the
+ * internal process/prompt diagnostics.
+ *
+ * `runMapPhase()` previously embedded `result.error` (the rejected
+ * `execFile` error, whose message is the full `llxprt … --prompt <entire
+ * prompt including the UNTRUSTED DATA payload>`) straight into the public
+ * per-file summary. When every provider call failed, the rendered walkthrough
+ * comment reproduced the command, the prompt, and the untrusted-data payload.
+ *
+ * This is a process-level regression: it runs the real walkthrough script as a
+ * subprocess against real review artifacts and a deliberately failing `llxprt`
+ * executable (on PATH), then asserts the rendered comment contains only a fixed
+ * generic per-file failure summary plus the file path — never the diagnostics —
+ * while the script's stderr still carries them for workflow logs.
+ *
+ * POSIX-only: the failing executable is a shebang script resolved by
+ * `execFile` via PATH, which is the same boundary CI exercises.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(__filename, '..', '..', '..');
+const walkthroughScript = join(repoRoot, 'scripts', 'pr-review-walkthrough.ts');
+// process.execPath is the Bun running this test, so it exists on every host
+// (dev installs resolve Bun via the system PATH; the node_modules/bun layout
+// is platform-specific and absent on some dev machines).
+const bunExecutable = process.execPath;
+
+// A unique marker planted inside review artifacts. It flows into the map
+// prompt (buildMapPrompt embeds the diff and PR body), so a leaked command
+// error would carry it into the public comment. The generic summary must not.
+const DIFF_SENTINEL = 'LEAKSENTINEL_DIFF_3062';
+const PR_SENTINEL = 'LEAKSENTINEL_PR_3062';
+const UNTRUSTED_MARKER = 'UNTRUSTED DATA (JSON)';
+// Unique marker planted in the diff so it flows through the map prompt into the
+// rejected command diagnostic that the walkthrough logs on stderr. It must never
+// reach the public comment. (The failing executable's own stdio is captured and
+// discarded by execFile, so the prompt is the only propagation path into the
+// logged diagnostic.)
+const FAILED_SENTINEL = 'LLXPRT-FAKE-3062-FAILED';
+
+const isPosix = process.platform !== 'win32';
+
+describe.skipIf(!isPosix)(
+  'issue #3062 (AC3): per-file failures publish a generic summary, not diagnostics',
+  () => {
+    it('renders a generic per-file summary and keeps diagnostics on stderr', () => {
+      const sandbox = mkdtempSync(join(tmpdir(), 'llxprt-3062-walkthrough-'));
+      try {
+        const reviewDir = join(sandbox, 'review');
+        mkdirSync(reviewDir, { recursive: true });
+        mkdirSync(join(reviewDir, 'issues'), { recursive: true });
+        mkdirSync(join(reviewDir, 'diffs'), { recursive: true });
+
+        // Real review artifacts the pipeline reads (pr-review-artifacts.ts).
+        writeFileSync(
+          join(reviewDir, 'pr.json'),
+          JSON.stringify({
+            number: 3062,
+            title: 'Restore walkthrough without prompt leakage',
+            body: PR_SENTINEL,
+            changedFiles: 1,
+            additions: 5,
+            deletions: 1,
+          }),
+        );
+        writeFileSync(
+          join(reviewDir, 'issues', '3062.json'),
+          JSON.stringify({
+            number: 3062,
+            title: 'Issue 3062',
+            body: 'Acceptance criteria for the walkthrough hardening.',
+          }),
+        );
+        // Small diff (well under MAX_DIFF_BYTES) so it is not skipped as
+        // oversized; it must reach the failing LLM call path.
+        writeFileSync(
+          join(reviewDir, 'diffs', 'app.diff'),
+          [
+            'diff --git a/src/app.ts b/src/app.ts',
+            '--- a/src/app.ts',
+            '+++ b/src/app.ts',
+            '@@ -1,3 +1,4 @@',
+            ' function app() {',
+            '-  return null;',
+            `+  return ${DIFF_SENTINEL};`,
+            `+  // ${FAILED_SENTINEL}`,
+            ' }',
+            '',
+          ].join('\n'),
+        );
+        writeFileSync(
+          join(reviewDir, 'diff-manifest.txt'),
+          'app.diff\tsrc/app.ts\n',
+        );
+        writeFileSync(join(reviewDir, 'numstat.txt'), '5\t1\tsrc/app.ts\n');
+        const binDir = join(sandbox, 'bin');
+        mkdirSync(binDir, { recursive: true });
+
+        // Failing `llxprt` executable on PATH. It exits non-zero so execFile
+        // rejects with a message equal to the full command + args, including the
+        // `--prompt` value (which carries the diff, its sentinels, and the
+        // UNTRUSTED DATA payload). That rejected message is the diagnostic the
+        // walkthrough logs on stderr and which must never be published.
+        // execFile captures and discards the child's own stdio, so the sentinels
+        // reach the logged diagnostic solely via the prompt.
+        const fakeLlxprt = join(binDir, 'llxprt');
+        writeFileSync(fakeLlxprt, '#!/bin/sh\nexit 1\n');
+        chmodSync(fakeLlxprt, 0o755);
+
+        const childEnv = {
+          ...process.env,
+          PATH: binDir + delimiter + (process.env.PATH ?? ''),
+          LLXPRT_DEFAULT_PROVIDER: 'openai',
+          OPENAI_API_KEY: 'test',
+          // Required by runLlxprtPrompt; never reached because llxprt fails.
+          OPENAI_BASE_URL: 'http://127.0.0.1:9/v1',
+          LLXPRT_DEFAULT_MODEL: 'gpt-test',
+          LLXPRT_STRONG_MODEL: 'gpt-test',
+          CI: 'true',
+        };
+
+        // Run the real walkthrough script at the same command boundary CI uses.
+        // cwd is the sandbox so the script's hardcoded "review" dir resolves to
+        // the artifacts above.
+        const proc = spawnSync(bunExecutable, [walkthroughScript], {
+          cwd: sandbox,
+          encoding: 'utf8',
+          timeout: 120_000,
+          env: childEnv,
+          maxBuffer: 10 * 1024 * 1024,
+        });
+
+        const stderr = proc.stderr ?? '';
+
+        // The walkthrough must complete cleanly at the CI command boundary: a
+        // timeout (proc.error set / signal SIGTERM) or a hang must not pass.
+        expect(proc.error).toBeUndefined();
+        expect(proc.status).toBe(0);
+        expect(proc.signal).toBeNull();
+
+        const commentPath = join(reviewDir, 'comment.md');
+        if (!existsSync(commentPath)) {
+          throw new Error(
+            `walkthrough did not write comment.md. exit=${proc.status} signal=${proc.signal}\nstderr:\n${stderr}`,
+          );
+        }
+        const comment = readFileSync(commentPath, 'utf8');
+
+        // The public comment must identify the file and the generic failure.
+        expect(comment).toContain('src/app.ts');
+        expect(comment).toMatch(/per-file summary unavailable/i);
+
+        // The public comment must NOT leak any internal diagnostic, including
+        // the unique failing-executable marker and the prompt's sentinels.
+        expect(comment).not.toContain(FAILED_SENTINEL);
+        expect(comment).not.toContain(DIFF_SENTINEL);
+        expect(comment).not.toContain(PR_SENTINEL);
+        expect(comment).not.toContain(UNTRUSTED_MARKER);
+        expect(comment).not.toContain('--prompt');
+        expect(comment).not.toContain('Command failed: llxprt');
+
+        // Internal diagnostics remain available on stderr itself (not stdout)
+        // for workflow logs: the rejected command error carries the failing-
+        // executable marker, the prompt, and its UNTRUSTED DATA payload —
+        // proving diagnostics are logged rather than swallowed or published.
+        expect(stderr).toContain(FAILED_SENTINEL);
+        expect(stderr).toContain(UNTRUSTED_MARKER);
+        expect(stderr).toContain(DIFF_SENTINEL);
+        expect(stderr).toContain('--prompt');
+        expect(stderr).toContain('Command failed: llxprt');
+      } finally {
+        rmSync(sandbox, { recursive: true, force: true });
+      }
+    }, 180_000);
+  },
+);

--- a/scripts/tests/issue-3062-walkthrough-no-leak.bun.test.ts
+++ b/scripts/tests/issue-3062-walkthrough-no-leak.bun.test.ts
@@ -47,18 +47,24 @@ const walkthroughScript = join(repoRoot, 'scripts', 'pr-review-walkthrough.ts');
 // is platform-specific and absent on some dev machines).
 const bunExecutable = process.execPath;
 
-// A unique marker planted inside review artifacts. It flows into the map
+// Unique markers planted inside review artifacts. They flow into the map
 // prompt (buildMapPrompt embeds the diff and PR body), so a leaked command
-// error would carry it into the public comment. The generic summary must not.
+// error would carry them into the public comment or onto stderr. They must
+// appear in neither: the subprocess boundary must redact the command/argv and
+// --prompt value rather than logging them.
 const DIFF_SENTINEL = 'LEAKSENTINEL_DIFF_3062';
 const PR_SENTINEL = 'LEAKSENTINEL_PR_3062';
 const UNTRUSTED_MARKER = 'UNTRUSTED DATA (JSON)';
-// Unique marker planted in the diff so it flows through the map prompt into the
-// rejected command diagnostic that the walkthrough logs on stderr. It must never
-// reach the public comment. (The failing executable's own stdio is captured and
-// discarded by execFile, so the prompt is the only propagation path into the
-// logged diagnostic.)
+// A second prompt-borne marker planted in the diff. It reaches the rejected
+// command diagnostic only via the prompt (the failing executable's own stdio
+// is captured and discarded by execFile), so its absence from stderr proves
+// the prompt value itself was not serialized.
 const FAILED_SENTINEL = 'LLXPRT-FAKE-3062-FAILED';
+// A SAFE diagnostic the failing executable writes to its OWN stderr. It must
+// survive onto the script's stderr (after secret redaction) so workflow logs
+// keep a useful provider-side failure reason — proving diagnostics are redacted
+// of the command/prompt, not silenced entirely.
+const PROVIDER_DIAG_SENTINEL = 'PROVIDERDIAG_3062';
 
 const isPosix = process.platform !== 'win32';
 
@@ -118,15 +124,19 @@ describe.skipIf(!isPosix)(
         const binDir = join(sandbox, 'bin');
         mkdirSync(binDir, { recursive: true });
 
-        // Failing `llxprt` executable on PATH. It exits non-zero so execFile
-        // rejects with a message equal to the full command + args, including the
-        // `--prompt` value (which carries the diff, its sentinels, and the
-        // UNTRUSTED DATA payload). That rejected message is the diagnostic the
-        // walkthrough logs on stderr and which must never be published.
-        // execFile captures and discards the child's own stdio, so the sentinels
-        // reach the logged diagnostic solely via the prompt.
+        // Failing `llxprt` executable on PATH. It writes a SAFE provider-side
+        // diagnostic to its own stderr, then exits non-zero. execFile captures
+        // the child's stdio, so that diagnostic reaches the parent only through
+        // the rejected error object. The boundary must surface the provider
+        // stderr (secret-redacted) and the exit code on the script's stderr,
+        // while never serializing the command/argv or the `--prompt` value
+        // (which carries the diff, its sentinels, and the UNTRUSTED DATA
+        // payload).
         const fakeLlxprt = join(binDir, 'llxprt');
-        writeFileSync(fakeLlxprt, '#!/bin/sh\nexit 1\n');
+        writeFileSync(
+          fakeLlxprt,
+          `#!/bin/sh\necho "${PROVIDER_DIAG_SENTINEL}: upstream connection refused" 1>&2\nexit 7\n`,
+        );
         chmodSync(fakeLlxprt, 0o755);
 
         const childEnv = {
@@ -173,23 +183,33 @@ describe.skipIf(!isPosix)(
         expect(comment).toMatch(/per-file summary unavailable/i);
 
         // The public comment must NOT leak any internal diagnostic, including
-        // the unique failing-executable marker and the prompt's sentinels.
+        // the unique failing-executable marker, the prompt's sentinels, or the
+        // safe provider diagnostic (which belongs on stderr only).
         expect(comment).not.toContain(FAILED_SENTINEL);
         expect(comment).not.toContain(DIFF_SENTINEL);
         expect(comment).not.toContain(PR_SENTINEL);
         expect(comment).not.toContain(UNTRUSTED_MARKER);
+        expect(comment).not.toContain(PROVIDER_DIAG_SENTINEL);
         expect(comment).not.toContain('--prompt');
-        expect(comment).not.toContain('Command failed: llxprt');
+        expect(comment).not.toContain('Command failed:');
 
-        // Internal diagnostics remain available on stderr itself (not stdout)
-        // for workflow logs: the rejected command error carries the failing-
-        // executable marker, the prompt, and its UNTRUSTED DATA payload —
-        // proving diagnostics are logged rather than swallowed or published.
-        expect(stderr).toContain(FAILED_SENTINEL);
-        expect(stderr).toContain(UNTRUSTED_MARKER);
-        expect(stderr).toContain(DIFF_SENTINEL);
-        expect(stderr).toContain('--prompt');
-        expect(stderr).toContain('Command failed: llxprt');
+        // SAFE diagnostics must remain on stderr (not stdout) for workflow
+        // logs: the provider-side failure reason the executable wrote to its
+        // own stderr, plus process-exit metadata. This proves diagnostics are
+        // REDACTED of the command/prompt, not silenced entirely.
+        expect(stderr).toContain(PROVIDER_DIAG_SENTINEL);
+        expect(stderr).toMatch(/exit code/i);
+
+        // The command/argv and the --prompt value must NEVER reach stderr: the
+        // subprocess boundary redacts them at the source rather than logging the
+        // rejected ExecError verbatim. Their prompt-borne sentinels must
+        // therefore be absent as well.
+        expect(stderr).not.toContain(FAILED_SENTINEL);
+        expect(stderr).not.toContain(UNTRUSTED_MARKER);
+        expect(stderr).not.toContain(DIFF_SENTINEL);
+        expect(stderr).not.toContain(PR_SENTINEL);
+        expect(stderr).not.toContain('--prompt');
+        expect(stderr).not.toContain('Command failed:');
       } finally {
         rmSync(sandbox, { recursive: true, force: true });
       }


### PR DESCRIPTION
## TLDR

Restore PR walkthrough generation by shipping the existing built-in provider aliases with the prebuilt CLI bundle, and prevent failed per-file model commands from publishing prompts or untrusted diff payloads in walkthrough comments.

## Dive Deeper

The published bundle's provider alias loader resolves built-in aliases from bundle/providers/aliases, but the CLI bundle build emitted only llxprt.js. Explicit OpenAI activation therefore failed before any walkthrough request reached the configured endpoint.

The bundle build now copies every existing provider alias config into the loader's runtime path and fails fast if the alias source unexpectedly yields no assets. The production loader and provider abstractions are unchanged.

Per-file walkthrough failures previously interpolated the complete child-process error into the public placeholder. Node's error included the command arguments, full prompt, and the UNTRUSTED DATA JSON payload. The failure detail now remains on stderr for workflow diagnostics while the public walkthrough receives a fixed per-file unavailable summary.

Behavioral Bun tests prove that:

- the publish-time bundle emits every built-in alias asset;
- explicit OpenAI activation reaches a local OpenAI-compatible endpoint, returns model output, and exits cleanly;
- empty alias inputs fail at build time;
- a real walkthrough process keeps command, prompt, stack, and untrusted-data sentinels out of the generated public comment while retaining diagnostics on stderr.

No workflow, dependency, public API, quality configuration, or provider-loader redesign is included.

## Reviewer Test Plan

1. Run the focused behavioral tests:

       LLXPRT_RUN_BUNDLE_BUILD_TEST=1 bun test --preload ./test-setup/augment-bun-vi.ts --preload ./scripts/tests/test-setup.ts scripts/tests/issue-3062-cli-bundle-aliases.bun.test.ts scripts/tests/issue-3062-walkthrough-no-leak.bun.test.ts

2. Confirm all five tests pass, including the real bundled OpenAI request and clean process exit.
3. Optionally run the CLI bundle build and verify packages/cli/bundle/providers/aliases/openai.config exists:

       bun scripts/bun-build.config.ts --cli-only

4. Inspect the no-leak regression and confirm the generated comment contains the changed file and generic unavailable summary, but none of the command, prompt, provider, or diff sentinels.

Local verification completed on macOS:

- focused issue tests: 5 passed
- canonical scoped lint plus changed-file ESLint: passed
- full typecheck after build: passed
- full formatter: passed
- full build: passed
- required stepfun-37 smoke test: passed
- DeepThinker review: completed and remediated
- local Open Code Review: all in-scope findings triaged and remediated

The repository-wide test and full-tree lint invocations were attempted repeatedly but the local command harness terminated those long-running processes with SIGTERM. The affected scripts tests and changed-file lint/type/format checks pass; CI remains the authoritative complete runner.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3062
