### PR TITLE
ci: skip heavy build and packaging jobs on docs-only PRs (Fixes #342)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
   doc_change_filter:
     name: 'Detect doc-only changes'
     runs-on: 'ubuntu-latest'
+    # Every heavy job declares `needs: doc_change_filter`, so a stalled `gh api`
+    # call here would block the whole tier for the 6-hour Actions default. Cap
+    # it like shard_selector does; two API calls need nowhere near this.
+    timeout-minutes: 5
     needs:
       - 'skip_check'
     if: ${{ needs.skip_check.outputs.should_skip != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
     if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     env:
       GH_TOKEN: '${{ github.token }}'
+    # Reads PR file metadata (issue #342); be explicit rather than relying on
+    # the repo being public. Matches how shard_selector declares permissions.
+    permissions:
+      contents: 'read'
+      pull-requests: 'read'
     outputs:
       docs_only: '${{ steps.detect.outputs.docs_only }}'
     steps:
@@ -63,6 +68,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: 'Set up Node.js'
+        uses: 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020' # ratchet:actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+
       - name: 'Determine documentation-only PR'
         id: 'detect'
         env:
@@ -70,76 +80,41 @@ jobs:
             ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
         run: |
           set -euo pipefail
+          # Non-PR events (push, merge_group, workflow_dispatch) always run full CI.
           if [[ -z "${PR_NUMBER:-}" ]]; then
             echo "docs_only=false" >>"$GITHUB_OUTPUT"
             exit 0
           fi
 
-          files="$(gh api \
+          # Fetch the full structured PR file list as NDJSON (one entry per line
+          # across all pages, including status/previous_filename/patch so renames
+          # and the .gitignore carve-out are handled) and the authoritative
+          # changed_files count. `|| true` keeps an API blip from failing this
+          # job: the detector script then resolves to docs_only=false (run full
+          # CI) rather than skipping the six heavy jobs and wedging the PR.
+          files_json="${RUNNER_TEMP}/pr-files.ndjson"
+          : >"$files_json"
+          gh api \
             --paginate \
             -H "Accept: application/vnd.github+json" \
             "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-            --jq '.[].filename')"
+            --jq '.[]' >"$files_json" || true
 
-          if [[ -z "$files" ]]; then
-            echo "docs_only=false" >>"$GITHUB_OUTPUT"
-            {
-              echo "### Unable to determine doc-only status"
-              echo "GitHub API returned no files; running full CI to be safe."
-            } >>"$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
+          changed_files="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --jq '.changed_files' || true)"
 
-          gitignore_patch=''
-          if grep -Fxq '.gitignore' <<<"$files"; then
-            gitignore_patch="$(gh api \
-              --paginate \
-              -H "Accept: application/vnd.github+json" \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-              --jq '.[] | select(.filename == ".gitignore") | .patch' || true)"
-          fi
-
-          docs_only=true
-          while IFS= read -r file; do
-            [[ -z "$file" ]] && continue
-            case "$file" in
-              # integration-tests/ fixtures (any extension) are never docs.
-              integration-tests/*)
-                docs_only=false
-                break
-                ;;
-              docs/*|README.md|README.*|CHANGELOG.md|CHANGELOG.*)
-                ;;
-              CONTRIBUTING.md|CONTRIBUTING.*|CODE_OF_CONDUCT.md|SECURITY.md)
-                ;;
-              *.md|*.mdx|*.rst|*.txt|*.adoc)
-                ;;
-              .gitignore)
-                if [[ -z "$gitignore_patch" ]]; then
-                  docs_only=false
-                  break
-                fi
-                if printf '%s\n' "$gitignore_patch" \
-                  | grep -E '^[+-][^+-]' \
-                  | grep -Ev '^[+-](!docs/reference/|#.*docs/reference)' >/dev/null; then
-                  docs_only=false
-                  break
-                fi
-                ;;
-              *)
-                docs_only=false
-                break
-                ;;
-            esac
-          done <<<"$files"
-
-          echo "docs_only=${docs_only}" >>"$GITHUB_OUTPUT"
-          if [[ "$docs_only" == "true" ]]; then
-            {
-              echo "### Documentation-only PR detected"
-              echo "Skipping automated test suites (unit + coverage) for this PR."
-            } >>"$GITHUB_STEP_SUMMARY"
-          fi
+          # The classifier (scripts/docs-only-filter.ts) is a conservative
+          # allowlist (issue #342): runtime .md/.txt inputs under packages/ are
+          # CODE, renames require both sides to be docs, and the changed_files
+          # count guards against the 3000-file API ceiling. It writes docs_only
+          # to GITHUB_OUTPUT and a summary to GITHUB_STEP_SUMMARY, always
+          # exiting 0 so a detector blip never wedges a PR.
+          node scripts/docs-only-filter.ts \
+            --files-json "$files_json" \
+            --changed-files "$changed_files" \
+            --output github-actions || true
   #
   # Lint: GitHub Actions
   #
@@ -622,9 +597,62 @@ jobs:
       # test_shard depends directly on it (issue #2877); lint retains the
       # dependency here to preserve smoke coverage when the matrix is skipped.
       - 'node_consumer_smoke'
+      # doc_change_filter (issue #342) makes node_consumer_smoke skippable on
+      # docs-only PRs. skip_check makes every job skippable on duplicate runs.
+      # Both are read below so this required aggregator stays honest instead of
+      # being skipped by GitHub when a needed job is skipped.
+      - 'doc_change_filter'
+      - 'skip_check'
+    if: ${{ always() }}
     runs-on: 'ubuntu-latest'
     steps:
-      - run: |-
+      - name: 'Check lint results'
+        run: |-
+          should_skip='${{ needs.skip_check.outputs.should_skip }}'
+          docs_only='${{ needs.doc_change_filter.outputs.docs_only }}'
+          lint_github_actions_result='${{ needs.lint_github_actions.result }}'
+          lint_javascript_result='${{ needs.lint_javascript.result }}'
+          lint_shell_result='${{ needs.lint_shell.result }}'
+          lint_yaml_result='${{ needs.lint_yaml.result }}'
+          node_consumer_smoke_result='${{ needs.node_consumer_smoke.result }}'
+
+          # Explicit duplicate-skip: skip_check said this run duplicates a
+          # passing one, so every downstream job was intentionally skipped.
+          # The required Lint check is green by design.
+          if [ "$should_skip" == "true" ]; then
+            echo "skip_check reported a duplicate passing run (should_skip=true). Lint check is green by design."
+            exit 0
+          fi
+
+          # Every linter must succeed regardless of PR type.
+          if [ "$lint_github_actions_result" != "success" ]; then
+            echo "::error::GitHub Actions lint did not succeed (result: $lint_github_actions_result)"
+            exit 1
+          fi
+          if [ "$lint_javascript_result" != "success" ]; then
+            echo "::error::JavaScript lint did not succeed (result: $lint_javascript_result)"
+            exit 1
+          fi
+          if [ "$lint_shell_result" != "success" ]; then
+            echo "::error::Shell lint did not succeed (result: $lint_shell_result)"
+            exit 1
+          fi
+          if [ "$lint_yaml_result" != "success" ]; then
+            echo "::error::YAML lint did not succeed (result: $lint_yaml_result)"
+            exit 1
+          fi
+
+          # node_consumer_smoke must succeed on code PRs. On docs-only PRs
+          # (issue #342) it is intentionally skipped, which is accepted here.
+          if [ "$node_consumer_smoke_result" != "success" ]; then
+            if [ "$docs_only" == "true" ] && [ "$node_consumer_smoke_result" == "skipped" ]; then
+              echo "docs-only PR: node_consumer_smoke intentionally skipped (issue #342)."
+            else
+              echo "::error::Node Consumer Smoke did not succeed (result: $node_consumer_smoke_result)"
+              exit 1
+            fi
+          fi
+
           echo 'All linters finished!'
 
   #
@@ -644,8 +672,11 @@ jobs:
     # fast instead of occupying a runner up to the 6-hour GitHub Actions default.
     timeout-minutes: 15
     needs:
+      - 'doc_change_filter'
       - 'skip_check'
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
+    # Skip on docs-only PRs (issue #342): a doc edit cannot change whether
+    # `bun install` resolves and links the workspaces.
+    if: ${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # ratchet:actions/checkout@v7
@@ -686,8 +717,11 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 15
     needs:
+      - 'doc_change_filter'
       - 'skip_check'
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
+    # Skip on docs-only PRs (issue #342): a doc edit cannot change native
+    # module load/operate behaviour under the Bun runtime.
+    if: ${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' }}
     permissions:
       contents: 'read'
     steps:
@@ -729,8 +763,11 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 15
     needs:
+      - 'doc_change_filter'
       - 'skip_check'
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
+    # Skip on docs-only PRs (issue #342): a doc edit cannot change npm
+    # package install/invocation compatibility.
+    if: ${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' }}
     # This job installs the packed package with npm (executing third-party
     # install scripts) and only needs to read the repo, so scope permissions to
     # contents:read and drop credential persistence. It validates the published
@@ -788,8 +825,11 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10
     needs:
+      - 'doc_change_filter'
       - 'skip_check'
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
+    # Skip on docs-only PRs (issue #342): a doc edit cannot change test
+    # orchestrator discovery/parsing/routing behaviour.
+    if: ${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' }}
     permissions:
       contents: 'read'
     steps:
@@ -840,8 +880,11 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10
     needs:
+      - 'doc_change_filter'
       - 'skip_check'
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
+    # Skip on docs-only PRs (issue #342): a doc edit cannot change test
+    # manifest root resolution or file existence.
+    if: ${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' }}
     permissions:
       contents: 'read'
     steps:
@@ -1134,8 +1177,11 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 20
     needs:
+      - 'doc_change_filter'
       - 'skip_check'
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
+    # Skip on docs-only PRs (issue #342): a doc edit cannot change the
+    # built CLI's agent conformance behaviour.
+    if: ${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' }}
     permissions:
       contents: 'read'
     steps:
@@ -1235,12 +1281,14 @@ jobs:
       - 'skip_check'
       - 'node_consumer_smoke'
       - 'acp_conformance'
+      - 'doc_change_filter'
     if: ${{ always() }}
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Check shard results'
         run: |-
           should_skip='${{ needs.skip_check.outputs.should_skip }}'
+          docs_only='${{ needs.doc_change_filter.outputs.docs_only }}'
           selector_result='${{ needs.shard_selector.result }}'
           has_tests='${{ needs.shard_selector.outputs.has_tests }}'
           shard_result='${{ needs.test_shard.result }}'
@@ -1255,15 +1303,31 @@ jobs:
             exit 0
           fi
 
+          # There is intentionally NO unconditional docs-only early return here
+          # (issue #342). shard_selector is an independent, stricter classifier
+          # than doc_change_filter; requiring it to succeed (and, when it reports
+          # tests, requiring the selected shards to succeed) means a
+          # misclassification by doc_change_filter fails closed instead of
+          # greening the required Test check. Only the docs-only-skippable jobs
+          # (node_consumer_smoke, acp_conformance) accept a `skipped` result when
+          # docs_only == 'true'; the selector/has_tests/test_shard logic below is
+          # unchanged.
+
           # Fail closed if the selector itself did not succeed.
           if [ "$selector_result" != "success" ]; then
             echo "::error::Shard selector did not succeed (result: $selector_result); cannot trust test selection."
             exit 1
           fi
 
+          # node_consumer_smoke must succeed on code PRs. On docs-only PRs
+          # (issue #342) it is intentionally skipped, which is accepted here.
           if [ "$node_consumer_smoke_result" != "success" ]; then
-            echo "::error::Node Consumer Smoke did not succeed (result: $node_consumer_smoke_result)"
-            exit 1
+            if [ "$docs_only" == "true" ] && [ "$node_consumer_smoke_result" == "skipped" ]; then
+              echo "docs-only PR: node_consumer_smoke intentionally skipped (issue #342)."
+            else
+              echo "::error::Node Consumer Smoke did not succeed (result: $node_consumer_smoke_result)"
+              exit 1
+            fi
           fi
 
           # Intentional no-test PR: selector succeeded and said has_tests=false.
@@ -1277,10 +1341,15 @@ jobs:
             fi
           fi
 
-          # ACP conformance must succeed (issue #2564).
+          # ACP conformance must succeed on code PRs. On docs-only PRs it is
+          # intentionally skipped (issue #342), which is accepted here.
           if [ "$acp_result" != "success" ]; then
-            echo "::error::ACP conformance job did not succeed (result: $acp_result)"
-            exit 1
+            if [ "$docs_only" == "true" ] && [ "$acp_result" == "skipped" ]; then
+              echo "docs-only PR: acp_conformance intentionally skipped (issue #342)."
+            else
+              echo "::error::ACP conformance job did not succeed (result: $acp_result)"
+              exit 1
+            fi
           fi
 
           echo 'All test shards finished!'

--- a/project-plans/issue342/plan.md
+++ b/project-plans/issue342/plan.md
@@ -1,0 +1,264 @@
+# Issue #342 — Skip heavy CI jobs on docs-only changes
+
+## Current state (verified against `main`)
+
+`.github/workflows/ci.yml` already contains a change-detection job:
+
+- `doc_change_filter` (line ~50): runs after `skip_check`, queries
+  `repos/{owner}/{repo}/pulls/{n}/files` via `gh api`, and emits
+  `outputs.docs_only`. It emits `false` for non-PR events (push,
+  `merge_group`, `workflow_dispatch`), `false` when the API returns no files,
+  and `false` as soon as any changed path is not documentation.
+
+Consumers that already honour it:
+
+| Workflow | Job | Gated? |
+| --- | --- | --- |
+| `ci.yml` | `test_shard` | yes |
+| `ci.yml` | `secure_store_backend` | yes |
+| `ci.yml` | `post_coverage_comment` | yes (via `needs`) |
+| `e2e.yml` | `e2e_linux`, `e2e_macos` | yes (own `e2e_doc_change_filter`) |
+
+## Gap this issue closes
+
+The issue asks for `test`, `e2e` **and packaging** to be gated. `test` and
+`e2e` are done; the build/packaging/smoke tier is not. On a docs-only PR the
+following jobs still install dependencies, build, pack and run:
+
+1. `bun_install_smoke` — full `bun install` + workspace link verification
+2. `bun_native_modules_smoke` — `npm ci` + native module smoke harness
+3. `node_consumer_smoke` — `npm pack` + install of the packed tarball
+   (this is literally the packaging job)
+4. `bun_test_orchestrator_smoke` — `bun install` + orchestrator run
+5. `bun_native_test_parity` — `bun install` + manifest resolution
+6. `acp_conformance` — `bun install` + `npm run build` + acplint run
+   (20-minute cap)
+
+None of these can observe a `.md` edit.
+
+## How the classifier works (sound allowlist)
+
+The docs-only decision is extracted from inline workflow bash into a committed,
+testable TypeScript script: **`scripts/docs-only-filter.ts`**. It follows the
+exact conventions of `scripts/affected-test-shards.ts` /
+`scripts/affected-lint-targets.ts` (CLI flags, `--output github-actions`
+writing to `GITHUB_OUTPUT`, a `GITHUB_STEP_SUMMARY` note, exported pure
+functions for testing).
+
+A change set is docs-only ONLY IF every touched path is documentation. The
+classifier is a conservative **allowlist** — anything not explicitly
+documentation is CODE (fail closed toward *more* CI):
+
+- **CODE** (checked BEFORE any extension rule, because these are paths that the
+  shard selector routes to shards or a full run — see the invariant below):
+  `packages/`, `scripts/`, `integration-tests/`, `evals/`, `test-setup/`,
+  `test-scripts/`, `shell-scripts/`, `eslint-rules/`, `schemas/`, `profiles/`,
+  `.github/`, `.husky/`, `bundle/`.
+- **DOCS**: `docs/`, `dev-docs/`, `project-plans/`, `research/`, plus root-level
+  (no `/`) `README*`, `CHANGELOG*`, `CONTRIBUTING*`, `CODE_OF_CONDUCT*`,
+  `SECURITY*`, `ROADMAP*`, `AGENTS.md`, and root-level
+  `*.md|*.mdx|*.rst|*.txt|*.adoc`.
+- **Everything else → CODE** (fail closed).
+
+This fixes the review-found fail-open: the prior inline rule treated ANY
+`*.md|*.mdx|*.rst|*.txt|*.adoc` outside `integration-tests/` as docs, so a PR
+editing only `packages/core/src/prompt-config/defaults/core.md` (a RUNTIME
+PROMPT INPUT embedded into the built prompt manifest) was reported
+`docs_only=true`, skipped every heavy job, and greened the required `Test`
+check with zero testing.
+
+**Cross-classifier invariant (MUST hold):** every path `docs-only-filter`
+calls DOCS must be a no-shard path for `scripts/affected-test-shards.ts`. The
+CODE prefixes above are exactly the package/source/infra roots that the shard
+selector routes to shards or a full run; being stricter than the selector is
+safe, being looser is a bug. A test imports the real selector and asserts this.
+
+### Rename handling
+
+GitHub returns `status` and `previous_filename` for renamed entries. The
+workflow fetches structured JSON entries (`gh api --paginate --jq '.[]'`) and
+passes them to the script. For a renamed entry, BOTH `filename` AND
+`previous_filename` must classify as docs; otherwise the change set is CODE.
+This also closes the "rename `.gitignore` to `something.md`" bypass (a rename
+away from `.gitignore` has no patch for the old path, so it fails closed to
+CODE).
+
+### `.gitignore` carve-out
+
+`.gitignore` counts as docs ONLY when its patch touches nothing but
+`docs/reference` ignore lines (an `!docs/reference/` un-ignore line or a
+`# ...docs/reference` comment line); otherwise CODE. No patch available → CODE.
+This preserves the exact patch-inspection rule the workflow used before.
+
+### GitHub API guards
+
+- **File-count ceiling:** the workflow fetches the PR's authoritative
+  `changed_files` count (`gh api repos/{repo}/pulls/{n} --jq '.changed_files'`)
+  and passes it to the script. If the returned entry count does not equal
+  `changed_files` (the files endpoint caps at 3000 even with `--paginate`), or
+  either value is unavailable, the script emits `docs_only=false` (fail closed)
+  with a reason in the step summary.
+- **Detector failure must not wedge PRs:** every `gh api` call uses `|| true`,
+  and the script always exits 0 (any internal/API failure resolves to
+  `docs_only=false`, i.e. run full CI). This matches the existing empty-file-list
+  branch and the `|| true` already used in `e2e.yml`, so an API blip can no
+  longer skip all six heavy jobs and wedge the `Lint`/`Test` aggregators.
+
+## Acceptance criteria
+
+### AC1 — the six heavy jobs are skipped on docs-only PRs
+
+Each of `bun_install_smoke`, `bun_native_modules_smoke`,
+`node_consumer_smoke`, `bun_test_orchestrator_smoke`,
+`bun_native_test_parity` and `acp_conformance`:
+
+- lists `doc_change_filter` in `needs`
+- declares the exact `if` condition
+  `${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' }}`
+  (asserted as the full normalized string, not a substring, in tests)
+- does NOT add `always()`/`!cancelled()` — it keeps the plain `needs` + `if`
+  shape it shares with the pre-existing `test_shard`/`secure_store_backend`
+  gates
+
+### AC2 — cheap jobs keep running on docs-only PRs
+
+`skip_check`, `doc_change_filter`, `shard_selector`, `lint_github_actions`,
+`lint_javascript`, `lint_shell`, `lint_yaml` and `codeql` must **not** gain a
+`docs_only` gate. Documentation is still linted (prettier, `lint:doc-links`,
+`lint:doc-placement`) and workflow YAML is still actionlint'ed.
+
+### AC3 — the `Test` required check stays honest (no unconditional early return)
+
+`test` is the required aggregator. There is intentionally **NO unconditional
+docs-only early return**. Instead:
+
+- `test` gains `doc_change_filter` in `needs` and reads `docs_only`.
+- `shard_selector` is an independent, stricter classifier than
+  `doc_change_filter`; requiring it to succeed (and, when it reports tests,
+  requiring the selected shards to succeed) means a misclassification by
+  `doc_change_filter` fails closed instead of greening the required check.
+- The `shard_selector` result check, the `has_tests` logic, and the `test_shard`
+  result check are UNCHANGED.
+- The `node_consumer_smoke` check accepts `skipped` when `docs_only == 'true'`
+  (otherwise must be `success`).
+- The `acp_conformance` check accepts `skipped` when `docs_only == 'true'`
+  (otherwise must be `success`).
+
+Result: green on a genuine docs-only PR (selector success + `has_tests=false` +
+both docs-only-skippable jobs `skipped`); red whenever the selector, any
+selected shard, or any non-skipped required job fails — even if
+`doc_change_filter` wrongly said docs-only.
+
+### AC4 — the `Lint` required check stays honest
+
+`lint` is a required aggregator. It:
+
+- runs with `if: ${{ always() }}`
+- explicitly fails when any of `lint_github_actions`, `lint_javascript`,
+  `lint_shell`, `lint_yaml` is not `success`
+- requires `node_consumer_smoke == 'success'` **unless** `docs_only == 'true'`,
+  in which case a `skipped` node consumer smoke is accepted (same exemption
+  shape the `test` aggregator uses)
+- stays green by design when `skip_check` reported a duplicate run
+
+### AC5 — non-PR events are unaffected
+
+`push` to `main`/`release/**`, `merge_group` and `workflow_dispatch` produce
+`docs_only=false` (emitted directly by the detect step before the script runs),
+so every job above runs exactly as it does today.
+
+### AC6 — the classifier is sound and tested
+
+`scripts/docs-only-filter.ts` exports pure functions (`classifyPath`,
+`gitignoreIsDocs`, `classifyEntry`, `classifyDocsOnly`) covered by behavioral
+tests in `scripts/tests/docs-only-filter.bun.test.ts`, including the exact
+regression guard (`packages/core/src/prompt-config/defaults/core.md` → CODE),
+rename handling, `.gitignore` carve-out, API truncation, and the
+cross-classifier invariant against the real shard selector.
+
+## Boundary cases
+
+| Input | Expected |
+| --- | --- |
+| genuine docs-only PR (selector success, `has_tests=false`) | six heavy jobs skipped; `Lint` + `Test` green |
+| `docs_only == 'false'` | unchanged full CI |
+| `docs_only == ''` (filter skipped/failed) | `!= 'true'` → heavy jobs run (fail-open toward *more* CI) |
+| `docs_only == 'true'` but selector reports tests + `test_shard` skipped | **red** — selector still gates |
+| `docs_only == 'true'` but `node_consumer_smoke=failure` | **red** — exemption only accepts `skipped` |
+| `packages/core/src/prompt-config/defaults/core.md` only | `docs_only=false` → full CI (the fail-open fix) |
+| rename `packages/.../foo.ts` → `docs/foo.md` | `docs_only=false` → full CI |
+| rename `.gitignore` → `docs/notes.md` | `docs_only=false` → full CI |
+| API truncation (entry count ≠ `changed_files`) | `docs_only=false` → full CI |
+| `gh api` blip / empty file list | `docs_only=false`, job succeeds → full CI (never wedges) |
+| `should_skip == 'true'` | everything skipped; `Lint` + `Test` green by design |
+| shell metacharacters in a `needs.*.result` value | aggregators must not evaluate them (positional-parameter substitution) |
+
+## Tests (behavioral, `bun:test`)
+
+New file `scripts/tests/docs-only-filter.bun.test.ts` — tests the EXPORTED
+classifier functions against realistic structured file entries:
+
+- pure docs change (`docs/`, `README.md`, `dev-docs/`, `project-plans/`) → true
+- `packages/core/src/prompt-config/defaults/core.md` alone → **false**
+  (regression guard, named to be obvious)
+- `packages/core/src/core/legacy-model-limits.expected.txt` → false
+- `packages/cli/src/providers/README.md` → false
+- `.github/pull_request_template.md` → false
+- `integration-tests/TESTING_STRATEGY.md` → false
+- mixed docs + one `.ts` → false; unknown path → false
+- rename `packages/core/src/foo.ts` → `docs/foo.md` → false
+- rename `docs/a.md` → `docs/b.md` → true
+- rename `.gitignore` → `docs/notes.md` → false
+- `.gitignore` docs/reference-only patch → true; other patch → false; no patch → false
+- entry count < `changed_files` (truncation) → false; zero entries → false
+- path-classification unit cases (docs prefixes, root docs, all CODE prefixes)
+- cross-classifier invariant: every DOCS path selects no shards via the REAL
+  `selectAffectedShards`
+
+New file `scripts/tests/ci-docs-only-skip.bun.test.ts`:
+
+**Static workflow wiring (parse `ci.yml`)**
+
+1. each heavy job `needs` `doc_change_filter`
+2. each heavy job's normalized `if` EQUALS the shared exact condition (full
+   string, not a substring)
+3. cheap jobs have **no** `docs_only` gate
+4. `doc_change_filter` invokes `scripts/docs-only-filter.ts`
+5. `doc_change_filter` emits `docs_only=false` on non-PR events
+6. `lint` declares `if: always()`
+
+**Executable aggregator behaviour (run the real `run:` bash with substituted
+`needs` values, following the existing `runTestAggregate` harness)**
+
+7. `Test` aggregator: docs-only + selector success + `has_tests=false` +
+   `node_consumer_smoke=skipped` + `acp=skipped` → exit 0
+8. `Test` aggregator: docs-only + `has_tests=true` + `test_shard=skipped` →
+   exit 1 (selector still gates)
+9. `Test` aggregator: docs-only + `node_consumer_smoke=failure` → exit 1
+   (exemption only accepts `skipped`)
+10. `Test` aggregator: code PR with `node_consumer_smoke=failure` → exit 1
+11. `Test` aggregator: code PR with `acp_conformance=failure` → exit 1
+12. `Test` aggregator: code PR with `test_shard=skipped`, `has_tests=true` →
+    exit 1
+13. `Test` aggregator: shell-injection sentinel in a result value is not
+    evaluated
+14. `Lint` aggregator: all linters `success`, `node_consumer_smoke=skipped`,
+    `docs_only=true` → exit 0
+15. `Lint` aggregator: code PR rejects a skipped `node_consumer_smoke` → exit 1
+16. `Lint` aggregator: `lint_javascript=failure` → exit 1 (even when
+    `docs_only=true`)
+17. `Lint` aggregator: `should_skip=true` with everything `skipped` → exit 0
+18. `Lint` aggregator: shell-injection sentinel is not evaluated
+
+Existing assertions in `scripts/tests/ci-acplint-workflow.test.ts` that pin the
+`lint` and `test` `needs` lists include `doc_change_filter`; they are the
+pinning tests for those lists.
+
+## Explicitly out of scope
+
+- Refactoring the duplicated detection shell between `ci.yml`,
+  `e2e.yml` and `pr-review.yml` into a shared composite action. The
+  `e2e.yml` duplicate classifier is deliberately deferred (it is not modified).
+- Gating `codeql` (security scan; the issue names test/e2e/packaging).
+- Adopting `dorny/paths-filter` in place of the existing `gh api` script.
+- Changing the documentation path patterns themselves.

--- a/scripts/docs-only-filter.ts
+++ b/scripts/docs-only-filter.ts
@@ -218,11 +218,10 @@ export function classifyDocsOnly({
     };
   }
 
-  if (
-    changedFiles !== undefined &&
-    Number.isInteger(changedFiles) &&
-    changedFiles !== entries.length
-  ) {
+  // No Number.isInteger() guard: a non-integer (NaN, 3.5) can never equal an
+  // integer entry count, so comparing directly fails closed. Skipping the
+  // comparison for such values would instead bypass the ceiling check.
+  if (changedFiles !== undefined && changedFiles !== entries.length) {
     return {
       docsOnly: false,
       reason: `API truncation: returned ${entries.length} entries but PR reports ${changedFiles} changed files — fail closed to full CI`,

--- a/scripts/docs-only-filter.ts
+++ b/scripts/docs-only-filter.ts
@@ -69,8 +69,12 @@ export interface DocsOnlyResult {
 /** Parameters for {@link classifyDocsOnly}. */
 export interface ClassifyDocsOnlyParams {
   readonly entries: readonly ChangedFileEntry[];
-  /** Authoritative PR `changed_files` count; undefined skips the ceiling check. */
-  readonly changedFiles?: number;
+  /**
+   * Authoritative PR `changed_files` count. Deliberately a required key (not
+   * `?:`) so a caller cannot silently omit the ceiling check; an unusable
+   * count must be passed explicitly as `undefined` and fails closed.
+   */
+  readonly changedFiles: number | undefined;
 }
 
 /** Parsed CLI options. */
@@ -203,7 +207,8 @@ export function classifyEntry(entry: ChangedFileEntry): PathClassification {
  *
  * Fail-closed rules (docsOnly=false):
  * - zero entries
- * - `changedFiles` provided and not equal to the entry count (API truncation)
+ * - `changedFiles` is not a usable count (undefined, NaN, negative, fractional)
+ * - `changedFiles` not equal to the entry count (API truncation)
  * - any entry that is CODE, unclassifiable, or part of a non-docs rename
  */
 export function classifyDocsOnly({
@@ -218,10 +223,19 @@ export function classifyDocsOnly({
     };
   }
 
-  // No Number.isInteger() guard: a non-integer (NaN, 3.5) can never equal an
-  // integer entry count, so comparing directly fails closed. Skipping the
-  // comparison for such values would instead bypass the ceiling check.
-  if (changedFiles !== undefined && changedFiles !== entries.length) {
+  // An unusable count must fail closed rather than skip the ceiling check:
+  // without a trustworthy total there is no way to know the API returned every
+  // changed file (issue #342 R3). Note this rejects the value, it does not
+  // bypass the comparison — bypassing is exactly the fail-open being avoided.
+  if (!Number.isInteger(changedFiles) || (changedFiles as number) < 0) {
+    return {
+      docsOnly: false,
+      reason: `unusable changed_files count (${String(changedFiles)}); cannot verify the API returned every file — fail closed to full CI`,
+      pathReasons: [],
+    };
+  }
+
+  if (changedFiles !== entries.length) {
     return {
       docsOnly: false,
       reason: `API truncation: returned ${entries.length} entries but PR reports ${changedFiles} changed files — fail closed to full CI`,

--- a/scripts/docs-only-filter.ts
+++ b/scripts/docs-only-filter.ts
@@ -1,0 +1,506 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Documentation-only change detector (issue #342).
+ *
+ * A change set is documentation-only ONLY IF every touched path (including
+ * both sides of a rename) is documentation. Classification is a conservative
+ * ALLOWLIST: anything not explicitly documentation is CODE, which makes the
+ * required `Test`/`Lint` checks run (fail closed toward *more* CI).
+ *
+ * Why this exists separately from the inline workflow bash it replaces:
+ * the prompt-config defaults markdown tree under packages/core/src, the
+ * `.expected.txt` test fixtures, packages/cli/src markdown packaged source,
+ * etc. are `.md`/`.txt` files that are NOT documentation — they are runtime
+ * prompt inputs, test fixtures, or packaged source. A naive "any .md is docs"
+ * rule turns a runtime behaviour change into a green required check with zero
+ * testing (a real fail-open found in review).
+ *
+ * Cross-classifier invariant (MUST hold): every path this module classifies as
+ * DOCS must be a no-shard path for `scripts/affected-test-shards.ts`
+ * (selectAffectedShards selects no shards). That is why the CODE prefixes below
+ * are excluded from DOCS — they correspond to paths that select shards or force
+ * a full test run. Being stricter than the shard selector is safe; being looser
+ * is a bug because the `test` aggregator still consults the shard selector, so a
+ * misclassification here fails closed instead of greening the required check.
+ *
+ * Path-only, dependency-free (Node built-ins only). The GitHub PR file-list API
+ * response is external/untrusted input, so its shape is validated here.
+ */
+
+import { appendFileSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { argv, exit, stdout, stderr } from 'node:process';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A structured entry from GET /repos/{owner}/{repo}/pulls/{n}/files. */
+export interface ChangedFileEntry {
+  readonly filename: string;
+  readonly status: string;
+  readonly previous_filename?: string;
+  readonly patch?: string;
+}
+
+/** Per-path classification. DOCS may skip heavy CI; CODE must run it. */
+export type PathClassification = 'docs' | 'code';
+
+/** Per-path explanation of the docs/code decision. */
+export interface DocsPathReason {
+  readonly path: string;
+  readonly classification: PathClassification;
+  readonly reason: string;
+}
+
+/** Result of classifying a whole change set. */
+export interface DocsOnlyResult {
+  readonly docsOnly: boolean;
+  readonly reason: string;
+  readonly pathReasons: readonly DocsPathReason[];
+}
+
+/** Parameters for {@link classifyDocsOnly}. */
+export interface ClassifyDocsOnlyParams {
+  readonly entries: readonly ChangedFileEntry[];
+  /** Authoritative PR `changed_files` count; undefined skips the ceiling check. */
+  readonly changedFiles?: number;
+}
+
+/** Parsed CLI options. */
+interface ParsedArgs {
+  readonly filesJson?: string;
+  readonly changedFiles?: number;
+  readonly output?: string;
+  readonly help?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Classification tables
+// ---------------------------------------------------------------------------
+
+/**
+ * Directory prefixes that are always CODE — checked BEFORE any extension rule.
+ * Each corresponds to a path that selects test shards or forces a full test run
+ * in `scripts/affected-test-shards.ts` (see the cross-classifier invariant
+ * above), or is otherwise source/infra rather than documentation.
+ */
+const CODE_PREFIXES: readonly string[] = [
+  'packages/',
+  'scripts/',
+  'integration-tests/',
+  'evals/',
+  'test-setup/',
+  'test-scripts/',
+  'shell-scripts/',
+  'eslint-rules/',
+  'schemas/',
+  'profiles/',
+  '.github/',
+  '.husky/',
+  'bundle/',
+];
+
+/**
+ * Directory prefixes that are always DOCS. Each is a no-shard path for the test
+ * shard selector, satisfying the cross-classifier invariant.
+ */
+const DOCS_PREFIXES: readonly string[] = [
+  'docs/',
+  'dev-docs/',
+  'project-plans/',
+  'research/',
+];
+
+/** Root-level (no `/`) documentation basenames/prefixes. */
+const ROOT_DOC_PREFIX_RE =
+  /^(README|CHANGELOG|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|ROADMAP)/i;
+
+/** Root-level documentation file extensions. */
+const DOC_EXTENSION_RE = /\.(md|mdx|rst|txt|adoc)$/i;
+
+/**
+ * `.gitignore` patch is docs ONLY when every content add/remove line relates to
+ * the `docs/reference` ignore carve-out (an `!docs/reference/` un-ignore line or
+ * a `# ...docs/reference` comment line). Matches the rule the workflow used.
+ */
+const GITIGNORE_CONTENT_LINE_RE = /^[+-][^+-]/;
+const GITIGNORE_DOCS_LINE_RE = /^[+-](!docs\/reference\/|#.*docs\/reference)/;
+
+// ---------------------------------------------------------------------------
+// Path classification (pure, exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * `.gitignore` counts as documentation ONLY when its patch touches nothing but
+ * `docs/reference` ignore lines. No patch (unavailable) → CODE (fail closed).
+ * Mirrors the patch-inspection rule the workflow has used since issue #342.
+ */
+export function gitignoreIsDocs(patch: string | undefined): boolean {
+  if (patch === undefined || patch === '') return false;
+  for (const line of patch.split('\n')) {
+    if (!GITIGNORE_CONTENT_LINE_RE.test(line)) continue;
+    if (!GITIGNORE_DOCS_LINE_RE.test(line)) return false;
+  }
+  return true;
+}
+
+function isRootLevel(path: string): boolean {
+  return !path.includes('/');
+}
+
+/**
+ * Classifies a single path. `.gitignore` needs its patch (the only path whose
+ * docs-vs-code decision depends on content); pass `undefined` to fail closed.
+ */
+export function classifyPath(
+  path: string,
+  gitignorePatch?: string,
+): PathClassification {
+  if (path === '') return 'code';
+  if (path === '.gitignore') {
+    return gitignoreIsDocs(gitignorePatch) ? 'docs' : 'code';
+  }
+  if (CODE_PREFIXES.some((prefix) => path.startsWith(prefix))) return 'code';
+  if (DOCS_PREFIXES.some((prefix) => path.startsWith(prefix))) return 'docs';
+  if (isRootLevel(path)) {
+    if (path === 'AGENTS.md') return 'docs';
+    if (ROOT_DOC_PREFIX_RE.test(path)) return 'docs';
+    if (DOC_EXTENSION_RE.test(path)) return 'docs';
+  }
+  return 'code';
+}
+
+/**
+ * Classifies a single structured file entry. For a renamed entry, BOTH the new
+ * filename AND the previous filename must classify as docs; otherwise CODE.
+ * This closes the "rename .gitignore to something.md" bypass: the previous
+ * `.gitignore` path is classified without a patch, which fails closed to CODE.
+ */
+export function classifyEntry(entry: ChangedFileEntry): PathClassification {
+  const filenameSide = classifyPath(entry.filename, entry.patch);
+  const previous = entry.previous_filename;
+  if (previous === undefined || previous === '') return filenameSide;
+  // The previous path has no dedicated patch; classifying `.gitignore` without
+  // one fails closed to CODE (a rename away from .gitignore is a code change).
+  const previousSide = classifyPath(previous);
+  return filenameSide === 'docs' && previousSide === 'docs' ? 'docs' : 'code';
+}
+
+// ---------------------------------------------------------------------------
+// Change-set classification (pure, exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Classifies a whole change set as docs-only iff every entry is docs AND the
+ * returned entry count matches the authoritative PR `changed_files` count.
+ *
+ * Fail-closed rules (docsOnly=false):
+ * - zero entries
+ * - `changedFiles` provided and not equal to the entry count (API truncation)
+ * - any entry that is CODE, unclassifiable, or part of a non-docs rename
+ */
+export function classifyDocsOnly({
+  entries,
+  changedFiles,
+}: ClassifyDocsOnlyParams): DocsOnlyResult {
+  if (entries.length === 0) {
+    return {
+      docsOnly: false,
+      reason: 'no changed files provided — fail closed to full CI',
+      pathReasons: [],
+    };
+  }
+
+  if (
+    changedFiles !== undefined &&
+    Number.isInteger(changedFiles) &&
+    changedFiles !== entries.length
+  ) {
+    return {
+      docsOnly: false,
+      reason: `API truncation: returned ${entries.length} entries but PR reports ${changedFiles} changed files — fail closed to full CI`,
+      pathReasons: [],
+    };
+  }
+
+  const pathReasons: DocsPathReason[] = [];
+  for (const entry of entries) {
+    const classification = classifyEntry(entry);
+    const previous = entry.previous_filename;
+    const detail =
+      previous !== undefined && previous !== ''
+        ? `rename '${previous}' -> '${entry.filename}'`
+        : `'${entry.filename}'`;
+    pathReasons.push({
+      path: entry.filename,
+      classification,
+      reason:
+        classification === 'docs'
+          ? `${detail} is documentation`
+          : `${detail} is not documentation (CODE)`,
+    });
+    if (classification === 'code') {
+      return {
+        docsOnly: false,
+        reason: `${detail} is not documentation-only — fail closed to full CI`,
+        pathReasons,
+      };
+    }
+  }
+
+  return {
+    docsOnly: true,
+    reason: 'all changed paths are documentation',
+    pathReasons,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// External input validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates one raw object from the GitHub PR files API. Returns the typed
+ * entry, or `null` when the shape cannot be trusted (fail closed upstream).
+ */
+export function parseEntry(raw: unknown): ChangedFileEntry | null {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+  const rec = raw as Record<string, unknown>;
+  const filename = rec['filename'];
+  if (typeof filename !== 'string' || filename === '') return null;
+  const status = rec['status'];
+  const previous = rec['previous_filename'];
+  const patch = rec['patch'];
+  return {
+    filename,
+    status: typeof status === 'string' ? status : 'modified',
+    previous_filename:
+      typeof previous === 'string' && previous !== '' ? previous : undefined,
+    patch: typeof patch === 'string' ? patch : undefined,
+  };
+}
+
+/**
+ * Parses JSON safely. Returns `undefined` when `text` is not valid JSON so
+ * callers can fall back to line-by-line NDJSON parsing.
+ */
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Type guard keeping only parsed, non-null entries (no `as` assertion). */
+function isEntry(entry: ChangedFileEntry | null): entry is ChangedFileEntry {
+  return entry !== null;
+}
+
+/**
+ * Parses a single JSON array of entries. Returns `null` when `raw` is not a
+ * JSON array, so the caller can fall back to NDJSON parsing.
+ */
+function parseJsonArrayDocument(raw: string): ChangedFileEntry[] | null {
+  const parsed = tryParseJson(raw);
+  if (!Array.isArray(parsed)) return null;
+  return parsed.map(parseEntry).filter(isEntry);
+}
+
+/**
+ * Parses NDJSON (one JSON object per non-empty line, as emitted across pages by
+ * `gh api --paginate --jq '.[]'`). Malformed lines are skipped.
+ */
+function parseNdjsonLines(raw: string): ChangedFileEntry[] {
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .map(tryParseJson)
+    .map(parseEntry)
+    .filter(isEntry);
+}
+
+/**
+ * Parses a file that is either a JSON array of entries or NDJSON (one entry per
+ * line, as `gh api --paginate --jq '.[]'` emits across pages). Malformed lines
+ * are skipped; a totally unparseable file yields an empty list (fail closed).
+ */
+export function parseEntriesFile(filePath: string): ChangedFileEntry[] {
+  const raw = readFileSync(filePath, 'utf8').trim();
+  if (raw === '') return [];
+  return parseJsonArrayDocument(raw) ?? parseNdjsonLines(raw);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(args: readonly string[]): ParsedArgs {
+  const opts: {
+    filesJson?: string;
+    changedFiles?: number;
+    output?: string;
+    help?: boolean;
+  } = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--files-json') {
+      opts.filesJson = args[++i];
+    } else if (a === '--changed-files') {
+      opts.changedFiles = parseChangedFilesArg(args[++i]);
+    } else if (a === '--output') {
+      opts.output = args[++i];
+    } else if (a === '--help' || a === '-h') {
+      opts.help = true;
+    }
+  }
+  return opts;
+}
+
+/**
+ * Parses the `--changed-files` value. An empty/non-numeric value yields
+ * `undefined` (count unavailable), which the CLI treats as fail-closed.
+ */
+function parseChangedFilesArg(value: string | undefined): number | undefined {
+  if (value === undefined || value === '') return undefined;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) return undefined;
+  return n;
+}
+
+function printHelp(): void {
+  stdout.write(`Usage: docs-only-filter.ts [options]
+
+Options:
+  --files-json <path>    Path to PR files: a JSON array or NDJSON (gh api --paginate --jq '.[]')
+  --changed-files <N>    Authoritative PR changed_files count; mismatch => docs_only=false
+  --output <mode>        Output mode: json (default) or github-actions
+  --help                 Show this help
+
+Output (json): a single JSON object with docsOnly, reason, and pathReasons.
+Output (github-actions): writes docs_only to GITHUB_OUTPUT and a summary to
+GITHUB_STEP_SUMMARY for CI. Always exits 0; API/parse failures resolve to
+docs_only=false (run full CI) so a detector blip never wedges a PR.
+`);
+}
+
+/**
+ * Flattens newlines out of a PR-controlled string so a filename containing one
+ * cannot break the step-summary markdown. Uses split/join rather than a regex
+ * because a literal CR/LF character class trips `no-control-regex`.
+ */
+function sanitizeGhValue(value: string): string {
+  return value.split('\r').join(' ').split('\n').join(' ');
+}
+
+/**
+ * Writes the docs_only decision to GITHUB_OUTPUT and a summary to
+ * GITHUB_STEP_SUMMARY. PR-controlled values are sanitized of CR/LF to prevent
+ * GITHUB_OUTPUT injection. Mirrors the output shape the workflow consumes.
+ */
+function outputGithubActions(result: DocsOnlyResult): void {
+  const ghOutputPath = process.env.GITHUB_OUTPUT;
+  const ghSummaryPath = process.env.GITHUB_STEP_SUMMARY;
+  const docsOnlyStr = String(result.docsOnly);
+  const safeReason = sanitizeGhValue(result.reason);
+
+  if (ghOutputPath) {
+    appendFileSync(ghOutputPath, `docs_only=${docsOnlyStr}\n`);
+  }
+
+  if (ghSummaryPath) {
+    const summary = [
+      '### Documentation-only detection (issue #342)',
+      '',
+      `**Docs only:** \`${docsOnlyStr}\``,
+      `**Reason:** \`${safeReason}\``,
+    ];
+    appendFileSync(ghSummaryPath, summary.join('\n') + '\n');
+  }
+
+  stdout.write(`docs_only=${docsOnlyStr}\nreason=${result.reason}\n`);
+}
+
+/** Builds a fail-closed result for CLI-level problems (always docs_only=false). */
+function failClosed(reason: string): DocsOnlyResult {
+  return { docsOnly: false, reason, pathReasons: [] };
+}
+
+function emit(result: DocsOnlyResult, outputMode: string): void {
+  if (outputMode === 'github-actions') {
+    outputGithubActions(result);
+  } else {
+    stdout.write(JSON.stringify(result, null, 2) + '\n');
+  }
+}
+
+function main(): void {
+  const opts = parseArgs(argv.slice(2));
+
+  if (opts.help) {
+    printHelp();
+    return;
+  }
+
+  const outputMode: string =
+    typeof opts.output === 'string' ? opts.output : 'json';
+
+  try {
+    // --files-json is required to classify a PR.
+    if (typeof opts.filesJson !== 'string') {
+      stderr.write('Error: --files-json <path> is required\n');
+      emit(
+        failClosed('no PR file list provided — fail closed to full CI'),
+        outputMode,
+      );
+      return;
+    }
+
+    const entries = parseEntriesFile(opts.filesJson);
+
+    // changed_files unavailable (empty/invalid flag) => cannot guard against the
+    // 3000-file API ceiling, so fail closed to full CI (issue #342 R3: if either
+    // value is unavailable, docs_only=false). classifyDocsOnly additionally
+    // fails closed when the returned entry count disagrees with changed_files.
+    if (opts.changedFiles === undefined) {
+      emit(
+        failClosed(
+          'GitHub API changed_files count unavailable — fail closed to full CI',
+        ),
+        outputMode,
+      );
+      return;
+    }
+
+    const result = classifyDocsOnly({
+      entries,
+      changedFiles: opts.changedFiles,
+    });
+    emit(result, outputMode);
+  } catch (error) {
+    // Any unexpected failure resolves to docs_only=false so the job never
+    // wedges a PR (issue #342 R4). Exit 0; GitHub then runs full CI.
+    const msg = error instanceof Error ? error.message : String(error);
+    emit(
+      failClosed(`docs-only detector failed (${msg}) — fail closed to full CI`),
+      outputMode,
+    );
+  }
+}
+
+const isMain =
+  argv[1] !== undefined && resolve(argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main();
+  exit(0);
+}

--- a/scripts/docs-only-filter.ts
+++ b/scripts/docs-only-filter.ts
@@ -500,6 +500,20 @@ function main(): void {
 const isMain =
   argv[1] !== undefined && resolve(argv[1]) === fileURLToPath(import.meta.url);
 if (isMain) {
-  main();
+  // Single process-level boundary that makes the documented "always exits 0"
+  // contract structurally true, rather than nesting guards around each write.
+  // main() already reports its own failures; this only covers a failure of the
+  // reporting path itself (e.g. GITHUB_OUTPUT is unwritable). When no
+  // docs_only is emitted the workflow reads an empty output, which is
+  // `!= 'true'` and therefore runs full CI — the fail-closed default.
+  try {
+    main();
+  } catch (error) {
+    stderr.write(
+      `docs-only detector could not report a result: ${
+        error instanceof Error ? error.message : String(error)
+      }\n`,
+    );
+  }
   exit(0);
 }

--- a/scripts/tests/ci-acplint-workflow.test.ts
+++ b/scripts/tests/ci-acplint-workflow.test.ts
@@ -65,6 +65,7 @@ function transitiveNeeds(
 
 interface TestAggregateResults {
   shouldSkip: string;
+  docsOnly: string;
   selector: string;
   hasTests: string;
   shards: string;
@@ -78,11 +79,12 @@ function runTestAggregate(
 ): SpawnSyncReturns<string> {
   const substitutions = [
     ["'${{ needs.skip_check.outputs.should_skip }}'", '"$1"'],
-    ["'${{ needs.shard_selector.result }}'", '"$2"'],
-    ["'${{ needs.shard_selector.outputs.has_tests }}'", '"$3"'],
-    ["'${{ needs.test_shard.result }}'", '"$4"'],
-    ["'${{ needs.node_consumer_smoke.result }}'", '"$5"'],
-    ["'${{ needs.acp_conformance.result }}'", '"$6"'],
+    ["'${{ needs.doc_change_filter.outputs.docs_only }}'", '"$2"'],
+    ["'${{ needs.shard_selector.result }}'", '"$3"'],
+    ["'${{ needs.shard_selector.outputs.has_tests }}'", '"$4"'],
+    ["'${{ needs.test_shard.result }}'", '"$5"'],
+    ["'${{ needs.node_consumer_smoke.result }}'", '"$6"'],
+    ["'${{ needs.acp_conformance.result }}'", '"$7"'],
   ] as const;
   let script = runText;
   for (const [expression, parameter] of substitutions) {
@@ -95,6 +97,7 @@ function runTestAggregate(
       script,
       '--',
       results.shouldSkip,
+      results.docsOnly,
       results.selector,
       results.hasTests,
       results.shards,
@@ -409,7 +412,7 @@ describe('Issue #2877: test matrix scheduling', () => {
     ).toEqual([]);
   });
 
-  it('lint aggregator needs exactly the four linters plus node_consumer_smoke', () => {
+  it('lint aggregator needs the four linters plus node_consumer_smoke, doc_change_filter, and skip_check', () => {
     const needs = jobNeeds(lintJob);
     expect(needs).toEqual([
       'lint_github_actions',
@@ -417,12 +420,14 @@ describe('Issue #2877: test matrix scheduling', () => {
       'lint_shell',
       'lint_yaml',
       'node_consumer_smoke',
+      'doc_change_filter',
+      'skip_check',
     ]);
   });
 
-  it('node_consumer_smoke needs only skip_check', () => {
+  it('node_consumer_smoke needs doc_change_filter and skip_check', () => {
     const needs = jobNeeds(nodeConsumerSmokeJob);
-    expect(needs).toEqual(['skip_check']);
+    expect(needs).toEqual(['doc_change_filter', 'skip_check']);
   });
 
   it('node_consumer_smoke preserves its skip condition', () => {
@@ -447,6 +452,7 @@ describe('Issue #2877: test matrix scheduling', () => {
       'skip_check',
       'node_consumer_smoke',
       'acp_conformance',
+      'doc_change_filter',
     ]);
     expect(runText).toContain("shard_result='${{ needs.test_shard.result }}'");
     expect(runText).toContain(`if [ "$shard_result" != "success" ]; then
@@ -459,6 +465,7 @@ describe('Issue #2877: test matrix scheduling', () => {
     const checkStep = stepNamed(testJob, 'Check shard results');
     const result = runTestAggregate(checkStep.run ?? '', {
       shouldSkip: 'false',
+      docsOnly: 'false',
       selector: 'success',
       hasTests: 'false',
       shards: 'skipped',
@@ -477,6 +484,7 @@ describe('Issue #2877: test matrix scheduling', () => {
     const nodeConsumerSmoke = `failure'; printf '${sentinel}' >&2; #`;
     const result = runTestAggregate(checkStep.run ?? '', {
       shouldSkip: 'false',
+      docsOnly: 'false',
       selector: 'success',
       hasTests: 'false',
       shards: 'skipped',

--- a/scripts/tests/ci-docs-only-skip.bun.test.ts
+++ b/scripts/tests/ci-docs-only-skip.bun.test.ts
@@ -79,6 +79,14 @@ function runAggregateScript(
   expressions: readonly string[],
   values: readonly string[],
 ): SpawnSyncReturns<string> {
+  // Positional mapping: a drift between the two arrays would leave a `${{ }}`
+  // expression unsubstituted (silently comparing a literal) while an extra
+  // value went unused. Fail loudly here instead.
+  if (expressions.length !== values.length) {
+    throw new Error(
+      `aggregate harness mismatch: ${expressions.length} expressions but ${values.length} values`,
+    );
+  }
   let script = runText;
   expressions.forEach((expression, index) => {
     script = script.replaceAll(expression, `"$${index + 1}"`);
@@ -332,6 +340,22 @@ describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {
       expect(result.stdout).toContain(
         'Test shards did not all succeed (result: skipped)',
       );
+    });
+
+    it('should_skip=true is green by design', () => {
+      // Parity with the lint aggregator: a duplicate run intentionally skips
+      // every downstream job, so the required Test check must stay green.
+      const result = runTestAggregate(testCheckRun, {
+        shouldSkip: 'true',
+        docsOnly: 'false',
+        selector: 'skipped',
+        hasTests: '',
+        shards: 'skipped',
+        nodeConsumerSmoke: 'skipped',
+        acp: 'skipped',
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('green by design');
     });
 
     it('does not evaluate shell syntax injected via a result value', () => {

--- a/scripts/tests/ci-docs-only-skip.bun.test.ts
+++ b/scripts/tests/ci-docs-only-skip.bun.test.ts
@@ -63,6 +63,28 @@ function jobNeeds(job: WorkflowJob | undefined): string[] {
   return Array.isArray(needs) ? [...needs] : [needs];
 }
 
+/**
+ * Runs a real aggregator `run:` script with each `'${{ needs.* }}'` literal
+ * replaced by a positional parameter, then passes the values as bash args so
+ * shell metacharacters in a job result can never be evaluated.
+ *
+ * `expressions` and `values` are positional: `expressions[i]` is replaced by
+ * `"$(i+1)"` and receives `values[i]`.
+ */
+function runAggregateScript(
+  runText: string,
+  expressions: readonly string[],
+  values: readonly string[],
+): SpawnSyncReturns<string> {
+  let script = runText;
+  expressions.forEach((expression, index) => {
+    script = script.replaceAll(expression, `"$${index + 1}"`);
+  });
+  return spawnSync('bash', ['-c', script, '--', ...values], {
+    encoding: 'utf8',
+  });
+}
+
 interface TestAggregateResults {
   shouldSkip: string;
   docsOnly: string;
@@ -73,43 +95,30 @@ interface TestAggregateResults {
   acp: string;
 }
 
-// Runs the real `test` aggregator `run:` script with each `'${{ needs.* }}'`
-// literal replaced by a positional parameter, mirroring the existing
-// runTestAggregate harness. The substituted values are passed as bash args so
-// shell metacharacters cannot be evaluated.
+const TEST_AGGREGATE_EXPRESSIONS = [
+  "'${{ needs.skip_check.outputs.should_skip }}'",
+  "'${{ needs.doc_change_filter.outputs.docs_only }}'",
+  "'${{ needs.shard_selector.result }}'",
+  "'${{ needs.shard_selector.outputs.has_tests }}'",
+  "'${{ needs.test_shard.result }}'",
+  "'${{ needs.node_consumer_smoke.result }}'",
+  "'${{ needs.acp_conformance.result }}'",
+] as const;
+
+/** Runs the real `test` aggregator "Check shard results" script. */
 function runTestAggregate(
   runText: string,
   results: TestAggregateResults,
 ): SpawnSyncReturns<string> {
-  const substitutions = [
-    ["'${{ needs.skip_check.outputs.should_skip }}'", '"$1"'],
-    ["'${{ needs.doc_change_filter.outputs.docs_only }}'", '"$2"'],
-    ["'${{ needs.shard_selector.result }}'", '"$3"'],
-    ["'${{ needs.shard_selector.outputs.has_tests }}'", '"$4"'],
-    ["'${{ needs.test_shard.result }}'", '"$5"'],
-    ["'${{ needs.node_consumer_smoke.result }}'", '"$6"'],
-    ["'${{ needs.acp_conformance.result }}'", '"$7"'],
-  ] as const;
-  let script = runText;
-  for (const [expression, parameter] of substitutions) {
-    script = script.replaceAll(expression, parameter);
-  }
-  return spawnSync(
-    'bash',
-    [
-      '-c',
-      script,
-      '--',
-      results.shouldSkip,
-      results.docsOnly,
-      results.selector,
-      results.hasTests,
-      results.shards,
-      results.nodeConsumerSmoke,
-      results.acp,
-    ],
-    { encoding: 'utf8' },
-  );
+  return runAggregateScript(runText, TEST_AGGREGATE_EXPRESSIONS, [
+    results.shouldSkip,
+    results.docsOnly,
+    results.selector,
+    results.hasTests,
+    results.shards,
+    results.nodeConsumerSmoke,
+    results.acp,
+  ]);
 }
 
 interface LintAggregateResults {
@@ -122,41 +131,30 @@ interface LintAggregateResults {
   nodeConsumerSmoke: string;
 }
 
-// Runs the real `lint` aggregator `run:` script with each `'${{ needs.* }}'`
-// literal replaced by a positional parameter, mirroring runTestAggregate.
+const LINT_AGGREGATE_EXPRESSIONS = [
+  "'${{ needs.skip_check.outputs.should_skip }}'",
+  "'${{ needs.doc_change_filter.outputs.docs_only }}'",
+  "'${{ needs.lint_github_actions.result }}'",
+  "'${{ needs.lint_javascript.result }}'",
+  "'${{ needs.lint_shell.result }}'",
+  "'${{ needs.lint_yaml.result }}'",
+  "'${{ needs.node_consumer_smoke.result }}'",
+] as const;
+
+/** Runs the real `lint` aggregator "Check lint results" script. */
 function runLintAggregate(
   runText: string,
   results: LintAggregateResults,
 ): SpawnSyncReturns<string> {
-  const substitutions = [
-    ["'${{ needs.skip_check.outputs.should_skip }}'", '"$1"'],
-    ["'${{ needs.doc_change_filter.outputs.docs_only }}'", '"$2"'],
-    ["'${{ needs.lint_github_actions.result }}'", '"$3"'],
-    ["'${{ needs.lint_javascript.result }}'", '"$4"'],
-    ["'${{ needs.lint_shell.result }}'", '"$5"'],
-    ["'${{ needs.lint_yaml.result }}'", '"$6"'],
-    ["'${{ needs.node_consumer_smoke.result }}'", '"$7"'],
-  ] as const;
-  let script = runText;
-  for (const [expression, parameter] of substitutions) {
-    script = script.replaceAll(expression, parameter);
-  }
-  return spawnSync(
-    'bash',
-    [
-      '-c',
-      script,
-      '--',
-      results.shouldSkip,
-      results.docsOnly,
-      results.lintGithubActions,
-      results.lintJavascript,
-      results.lintShell,
-      results.lintYaml,
-      results.nodeConsumerSmoke,
-    ],
-    { encoding: 'utf8' },
-  );
+  return runAggregateScript(runText, LINT_AGGREGATE_EXPRESSIONS, [
+    results.shouldSkip,
+    results.docsOnly,
+    results.lintGithubActions,
+    results.lintJavascript,
+    results.lintShell,
+    results.lintYaml,
+    results.nodeConsumerSmoke,
+  ]);
 }
 
 describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {

--- a/scripts/tests/ci-docs-only-skip.bun.test.ts
+++ b/scripts/tests/ci-docs-only-skip.bun.test.ts
@@ -44,6 +44,9 @@ const EXPECTED_HEAVY_IF =
 // Cheap jobs that must keep running even on docs-only PRs (docs are still
 // linted and workflow YAML is still actionlint'ed).
 const UNGATED_JOBS = [
+  // skip_check is the root dependency of both required aggregators; gating it
+  // on docs_only would stop Test and Lint from running at all.
+  'skip_check',
   'lint_github_actions',
   'lint_javascript',
   'lint_shell',

--- a/scripts/tests/ci-docs-only-skip.bun.test.ts
+++ b/scripts/tests/ci-docs-only-skip.bun.test.ts
@@ -1,0 +1,442 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #342: skip heavy CI jobs on docs-only changes.
+ *
+ * The heavy build/packaging/smoke tier gains a `docs_only` gate, and the
+ * required `Test` and `Lint` aggregators stay honest (green on docs-only,
+ * red on code PRs). These tests pin both the static workflow wiring and the
+ * real aggregator bash by extracting the committed `run:` script and feeding
+ * it substituted `needs` values via positional parameters (the same harness
+ * as ci-acplint-workflow.test.ts), so the logic under test is the actual
+ * workflow code, not a re-implementation.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { describe, it, expect, beforeAll } from 'bun:test';
+import type { WorkflowDocument, WorkflowJob } from './typed-test-helpers.ts';
+import { parseWorkflowYaml } from './typed-test-helpers.ts';
+import {
+  readRootFile,
+  stepNamed,
+  normalize,
+} from './ocr-review-workflow-helpers.ts';
+
+const HEAVY_JOBS = [
+  'bun_install_smoke',
+  'bun_native_modules_smoke',
+  'node_consumer_smoke',
+  'bun_test_orchestrator_smoke',
+  'bun_native_test_parity',
+  'acp_conformance',
+] as const;
+
+// The exact `if:` condition every heavy job must declare (normalized). The
+// full string is asserted, not just a substring, so a stray extra/missing
+// clause fails loudly (issue #342).
+const EXPECTED_HEAVY_IF =
+  "${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' }}";
+
+// Cheap jobs that must keep running even on docs-only PRs (docs are still
+// linted and workflow YAML is still actionlint'ed).
+const UNGATED_JOBS = [
+  'lint_github_actions',
+  'lint_javascript',
+  'lint_shell',
+  'lint_yaml',
+  'shard_selector',
+  'codeql',
+] as const;
+
+function loadCiWorkflow(): WorkflowDocument {
+  const source = readRootFile('.github/workflows/ci.yml');
+  return parseWorkflowYaml(source);
+}
+
+function jobNeeds(job: WorkflowJob | undefined): string[] {
+  const needs = job?.needs;
+  if (needs === undefined) return [];
+  return Array.isArray(needs) ? [...needs] : [needs];
+}
+
+interface TestAggregateResults {
+  shouldSkip: string;
+  docsOnly: string;
+  selector: string;
+  hasTests: string;
+  shards: string;
+  nodeConsumerSmoke: string;
+  acp: string;
+}
+
+// Runs the real `test` aggregator `run:` script with each `'${{ needs.* }}'`
+// literal replaced by a positional parameter, mirroring the existing
+// runTestAggregate harness. The substituted values are passed as bash args so
+// shell metacharacters cannot be evaluated.
+function runTestAggregate(
+  runText: string,
+  results: TestAggregateResults,
+): SpawnSyncReturns<string> {
+  const substitutions = [
+    ["'${{ needs.skip_check.outputs.should_skip }}'", '"$1"'],
+    ["'${{ needs.doc_change_filter.outputs.docs_only }}'", '"$2"'],
+    ["'${{ needs.shard_selector.result }}'", '"$3"'],
+    ["'${{ needs.shard_selector.outputs.has_tests }}'", '"$4"'],
+    ["'${{ needs.test_shard.result }}'", '"$5"'],
+    ["'${{ needs.node_consumer_smoke.result }}'", '"$6"'],
+    ["'${{ needs.acp_conformance.result }}'", '"$7"'],
+  ] as const;
+  let script = runText;
+  for (const [expression, parameter] of substitutions) {
+    script = script.replaceAll(expression, parameter);
+  }
+  return spawnSync(
+    'bash',
+    [
+      '-c',
+      script,
+      '--',
+      results.shouldSkip,
+      results.docsOnly,
+      results.selector,
+      results.hasTests,
+      results.shards,
+      results.nodeConsumerSmoke,
+      results.acp,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+interface LintAggregateResults {
+  shouldSkip: string;
+  docsOnly: string;
+  lintGithubActions: string;
+  lintJavascript: string;
+  lintShell: string;
+  lintYaml: string;
+  nodeConsumerSmoke: string;
+}
+
+// Runs the real `lint` aggregator `run:` script with each `'${{ needs.* }}'`
+// literal replaced by a positional parameter, mirroring runTestAggregate.
+function runLintAggregate(
+  runText: string,
+  results: LintAggregateResults,
+): SpawnSyncReturns<string> {
+  const substitutions = [
+    ["'${{ needs.skip_check.outputs.should_skip }}'", '"$1"'],
+    ["'${{ needs.doc_change_filter.outputs.docs_only }}'", '"$2"'],
+    ["'${{ needs.lint_github_actions.result }}'", '"$3"'],
+    ["'${{ needs.lint_javascript.result }}'", '"$4"'],
+    ["'${{ needs.lint_shell.result }}'", '"$5"'],
+    ["'${{ needs.lint_yaml.result }}'", '"$6"'],
+    ["'${{ needs.node_consumer_smoke.result }}'", '"$7"'],
+  ] as const;
+  let script = runText;
+  for (const [expression, parameter] of substitutions) {
+    script = script.replaceAll(expression, parameter);
+  }
+  return spawnSync(
+    'bash',
+    [
+      '-c',
+      script,
+      '--',
+      results.shouldSkip,
+      results.docsOnly,
+      results.lintGithubActions,
+      results.lintJavascript,
+      results.lintShell,
+      results.lintYaml,
+      results.nodeConsumerSmoke,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {
+  let jobs: Record<string, WorkflowJob>;
+
+  beforeAll(() => {
+    const workflow = loadCiWorkflow();
+    jobs = workflow['jobs']!;
+  });
+
+  describe('static workflow wiring', () => {
+    it('each heavy job needs doc_change_filter', () => {
+      for (const jobName of HEAVY_JOBS) {
+        const needs = jobNeeds(jobs[jobName]);
+        expect(needs, `${jobName} should need doc_change_filter`).toContain(
+          'doc_change_filter',
+        );
+      }
+    });
+
+    it('each heavy job declares the exact docs_only + should_skip if condition', () => {
+      for (const jobName of HEAVY_JOBS) {
+        const condition = normalize(jobs[jobName]?.if);
+        expect(
+          condition,
+          `${jobName} if should equal the shared docs_only + should_skip condition`,
+        ).toBe(EXPECTED_HEAVY_IF);
+      }
+    });
+
+    it('cheap jobs (linters, shard_selector, codeql) gain no docs_only gate', () => {
+      for (const jobName of UNGATED_JOBS) {
+        const condition = jobs[jobName]?.if ?? '';
+        expect(
+          condition,
+          `${jobName} must not gain a docs_only gate`,
+        ).not.toContain('doc_change_filter.outputs.docs_only');
+      }
+    });
+
+    it('doc_change_filter invokes the committed scripts/docs-only-filter.ts', () => {
+      const detect = stepNamed(
+        jobs['doc_change_filter'],
+        'Determine documentation-only PR',
+      );
+      expect(detect.run ?? '').toContain('scripts/docs-only-filter.ts');
+    });
+
+    it('doc_change_filter emits docs_only=false on non-PR events', () => {
+      const detect = stepNamed(
+        jobs['doc_change_filter'],
+        'Determine documentation-only PR',
+      );
+      const script = detect.run ?? '';
+      // The PR_NUMBER-empty branch is the non-PR fallback (push, merge_group,
+      // workflow_dispatch) and must emit docs_only=false so heavy jobs run.
+      expect(script).toContain('-z "${PR_NUMBER:-}"');
+      expect(script).toContain('docs_only=false');
+    });
+
+    it('lint aggregator declares if: always()', () => {
+      expect(jobs['lint']?.if).toContain('always()');
+    });
+  });
+
+  describe('Test aggregator behaviour (real bash)', () => {
+    let testCheckRun: string;
+
+    beforeAll(() => {
+      testCheckRun = stepNamed(jobs['test'], 'Check shard results').run ?? '';
+    });
+
+    it('docs-only PR is green when selector succeeds, has_tests=false, and the docs-only-skippable jobs are skipped', () => {
+      // There is no unconditional docs-only early return (issue #342): the
+      // selector still must succeed, and the two docs-only-skippable jobs
+      // (node_consumer_smoke, acp_conformance) accept a `skipped` result only
+      // because docs_only == 'true'.
+      const result = runTestAggregate(testCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'true',
+        selector: 'success',
+        hasTests: 'false',
+        shards: 'skipped',
+        nodeConsumerSmoke: 'skipped',
+        acp: 'skipped',
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        'node_consumer_smoke intentionally skipped',
+      );
+      expect(result.stdout).toContain('acp_conformance intentionally skipped');
+    });
+
+    it('docs-only PR is red when the selector reports tests but test_shard is skipped (selector still gates)', () => {
+      // Proves docs_only == 'true' does NOT bypass the shard selector: when
+      // the selector says has_tests=true, a skipped test_shard is still red.
+      const result = runTestAggregate(testCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'true',
+        selector: 'success',
+        hasTests: 'true',
+        shards: 'skipped',
+        nodeConsumerSmoke: 'skipped',
+        acp: 'skipped',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        'Test shards did not all succeed (result: skipped)',
+      );
+    });
+
+    it('docs-only PR is red when node_consumer_smoke fails (not just skipped)', () => {
+      // The exemption only accepts `skipped`; an actual failure is still red.
+      const result = runTestAggregate(testCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'true',
+        selector: 'success',
+        hasTests: 'false',
+        shards: 'skipped',
+        nodeConsumerSmoke: 'failure',
+        acp: 'skipped',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        'Node Consumer Smoke did not succeed (result: failure)',
+      );
+    });
+
+    it('code PR with node_consumer_smoke=failure is red', () => {
+      const result = runTestAggregate(testCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'false',
+        selector: 'success',
+        hasTests: 'true',
+        shards: 'success',
+        nodeConsumerSmoke: 'failure',
+        acp: 'success',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        'Node Consumer Smoke did not succeed (result: failure)',
+      );
+    });
+
+    it('code PR with acp_conformance=failure is red', () => {
+      const result = runTestAggregate(testCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'false',
+        selector: 'success',
+        hasTests: 'true',
+        shards: 'success',
+        nodeConsumerSmoke: 'success',
+        acp: 'failure',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        'ACP conformance job did not succeed (result: failure)',
+      );
+    });
+
+    it('code PR with test_shard=skipped and has_tests=true is red', () => {
+      const result = runTestAggregate(testCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'false',
+        selector: 'success',
+        hasTests: 'true',
+        shards: 'skipped',
+        nodeConsumerSmoke: 'success',
+        acp: 'success',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        'Test shards did not all succeed (result: skipped)',
+      );
+    });
+
+    it('does not evaluate shell syntax injected via a result value', () => {
+      const sentinel = 'TEST_AGGREGATE_SHELL_INJECTION';
+      const nodeConsumerSmoke = `failure'; printf '${sentinel}' >&2; #`;
+      const result = runTestAggregate(testCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'false',
+        selector: 'success',
+        hasTests: 'false',
+        shards: 'skipped',
+        nodeConsumerSmoke,
+        acp: 'success',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        `Node Consumer Smoke did not succeed (result: ${nodeConsumerSmoke})`,
+      );
+      expect(result.stderr).not.toContain(sentinel);
+    });
+  });
+
+  describe('Lint aggregator behaviour (real bash)', () => {
+    let lintCheckRun: string;
+
+    beforeAll(() => {
+      lintCheckRun = stepNamed(jobs['lint'], 'Check lint results').run ?? '';
+    });
+
+    it('docs-only run accepts a skipped node_consumer_smoke', () => {
+      const result = runLintAggregate(lintCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'true',
+        lintGithubActions: 'success',
+        lintJavascript: 'success',
+        lintShell: 'success',
+        lintYaml: 'success',
+        nodeConsumerSmoke: 'skipped',
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('All linters finished!');
+    });
+
+    it('code PR rejects a skipped node_consumer_smoke', () => {
+      const result = runLintAggregate(lintCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'false',
+        lintGithubActions: 'success',
+        lintJavascript: 'success',
+        lintShell: 'success',
+        lintYaml: 'success',
+        nodeConsumerSmoke: 'skipped',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        'Node Consumer Smoke did not succeed (result: skipped)',
+      );
+    });
+
+    it('a failing linter is red even on a docs-only PR', () => {
+      const result = runLintAggregate(lintCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'true',
+        lintGithubActions: 'success',
+        lintJavascript: 'failure',
+        lintShell: 'success',
+        lintYaml: 'success',
+        nodeConsumerSmoke: 'skipped',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        'JavaScript lint did not succeed (result: failure)',
+      );
+    });
+
+    it('should_skip=true is green by design', () => {
+      const result = runLintAggregate(lintCheckRun, {
+        shouldSkip: 'true',
+        docsOnly: 'false',
+        lintGithubActions: 'skipped',
+        lintJavascript: 'skipped',
+        lintShell: 'skipped',
+        lintYaml: 'skipped',
+        nodeConsumerSmoke: 'skipped',
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('green by design');
+    });
+
+    it('does not evaluate shell syntax injected via a result value', () => {
+      const sentinel = 'LINT_AGGREGATE_SHELL_INJECTION';
+      const lintJavascript = `failure'; printf '${sentinel}' >&2; #`;
+      const result = runLintAggregate(lintCheckRun, {
+        shouldSkip: 'false',
+        docsOnly: 'false',
+        lintGithubActions: 'success',
+        lintJavascript,
+        lintShell: 'success',
+        lintYaml: 'success',
+        nodeConsumerSmoke: 'success',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        `JavaScript lint did not succeed (result: ${lintJavascript})`,
+      );
+      expect(result.stderr).not.toContain(sentinel);
+    });
+  });
+});

--- a/scripts/tests/docs-only-filter.bun.test.ts
+++ b/scripts/tests/docs-only-filter.bun.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the documentation-only change detector (issue #342).
+ *
+ * These exercise the EXPORTED pure classifier functions from
+ * `scripts/docs-only-filter.ts` against realistic structured GitHub PR file
+ * entries, plus a cross-classifier invariant check against the REAL
+ * `scripts/affected-test-shards.ts` selector.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  classifyDocsOnly,
+  classifyEntry,
+  classifyPath,
+  gitignoreIsDocs,
+  type ChangedFileEntry,
+} from '../docs-only-filter.ts';
+import { selectAffectedShards } from '../affected-test-shards.ts';
+
+/** Builds a single structured file entry. */
+function entry(
+  filename: string,
+  extra: Partial<Omit<ChangedFileEntry, 'filename'>> = {},
+): ChangedFileEntry {
+  return { filename, status: 'modified', ...extra };
+}
+
+describe('docs-only-filter: pure docs changes are docs-only', () => {
+  it('a change set of only documentation paths is docs-only', () => {
+    const entries = [
+      entry('docs/index.md'),
+      entry('README.md'),
+      entry('dev-docs/bun.md'),
+      entry('project-plans/issue342/plan.md'),
+    ];
+    const result = classifyDocsOnly({ entries, changedFiles: entries.length });
+    expect(result.docsOnly).toBe(true);
+  });
+});
+
+describe('docs-only-filter: runtime prompt inputs are NOT docs (fail-open fix)', () => {
+  it('packages/core/src/prompt-config/defaults/core.md is CODE — the exact review fail-open', () => {
+    // Regression guard: this .md file is a RUNTIME PROMPT INPUT embedded into
+    // the built prompt manifest and loaded at runtime. It MUST NOT be docs.
+    const entries = [entry('packages/core/src/prompt-config/defaults/core.md')];
+    const result = classifyDocsOnly({
+      entries,
+      changedFiles: entries.length,
+    });
+    expect(result.docsOnly).toBe(false);
+  });
+
+  it('packages/core/src/core/legacy-model-limits.expected.txt (test fixture) is CODE', () => {
+    const entries = [
+      entry('packages/core/src/core/legacy-model-limits.expected.txt'),
+    ];
+    const result = classifyDocsOnly({
+      entries,
+      changedFiles: entries.length,
+    });
+    expect(result.docsOnly).toBe(false);
+  });
+
+  it('packages/cli/src/providers/README.md (packaged source) is CODE', () => {
+    const entries = [entry('packages/cli/src/providers/README.md')];
+    const result = classifyDocsOnly({
+      entries,
+      changedFiles: entries.length,
+    });
+    expect(result.docsOnly).toBe(false);
+  });
+
+  it('.github/pull_request_template.md is CODE', () => {
+    const entries = [entry('.github/pull_request_template.md')];
+    const result = classifyDocsOnly({
+      entries,
+      changedFiles: entries.length,
+    });
+    expect(result.docsOnly).toBe(false);
+  });
+
+  it('integration-tests/TESTING_STRATEGY.md is CODE', () => {
+    const entries = [entry('integration-tests/TESTING_STRATEGY.md')];
+    const result = classifyDocsOnly({
+      entries,
+      changedFiles: entries.length,
+    });
+    expect(result.docsOnly).toBe(false);
+  });
+});
+
+describe('docs-only-filter: mixed changes are not docs-only', () => {
+  it('one docs file plus one .ts file is not docs-only', () => {
+    const entries = [
+      entry('docs/index.md'),
+      entry('packages/core/src/index.ts'),
+    ];
+    const result = classifyDocsOnly({
+      entries,
+      changedFiles: entries.length,
+    });
+    expect(result.docsOnly).toBe(false);
+  });
+
+  it('an unknown/unclassified path is not docs-only', () => {
+    const entries = [entry('some-new-top-level-thing/x.json')];
+    const result = classifyDocsOnly({
+      entries,
+      changedFiles: entries.length,
+    });
+    expect(result.docsOnly).toBe(false);
+  });
+});
+
+describe('docs-only-filter: rename handling', () => {
+  it('rename packages/core/src/foo.ts -> docs/foo.md is not docs-only', () => {
+    const e = entry('docs/foo.md', {
+      status: 'renamed',
+      previous_filename: 'packages/core/src/foo.ts',
+    });
+    const result = classifyDocsOnly({
+      entries: [e],
+      changedFiles: 1,
+    });
+    expect(result.docsOnly).toBe(false);
+  });
+
+  it('rename docs/a.md -> docs/b.md is docs-only', () => {
+    const e = entry('docs/b.md', {
+      status: 'renamed',
+      previous_filename: 'docs/a.md',
+    });
+    const result = classifyDocsOnly({
+      entries: [e],
+      changedFiles: 1,
+    });
+    expect(result.docsOnly).toBe(true);
+  });
+
+  it('rename .gitignore -> docs/notes.md is not docs-only (bypass closed)', () => {
+    const e = entry('docs/notes.md', {
+      status: 'renamed',
+      previous_filename: '.gitignore',
+    });
+    const result = classifyDocsOnly({
+      entries: [e],
+      changedFiles: 1,
+    });
+    expect(result.docsOnly).toBe(false);
+  });
+});
+
+describe('docs-only-filter: .gitignore carve-out', () => {
+  it('.gitignore patch toggling only a docs/reference line is docs', () => {
+    const patch =
+      '@@ -1,1 +1,2 @@\n+# keep built docs/reference output\n+!docs/reference/\n';
+    expect(gitignoreIsDocs(patch)).toBe(true);
+    expect(classifyPath('.gitignore', patch)).toBe('docs');
+  });
+
+  it('.gitignore patch with any other content line is CODE', () => {
+    const patch = '@@ -1,1 +1,2 @@\n+node_modules/\n';
+    expect(gitignoreIsDocs(patch)).toBe(false);
+    expect(classifyPath('.gitignore', patch)).toBe('code');
+  });
+
+  it('.gitignore with no patch available is CODE (fail closed)', () => {
+    expect(gitignoreIsDocs(undefined)).toBe(false);
+    expect(classifyPath('.gitignore', undefined)).toBe('code');
+    expect(classifyEntry(entry('.gitignore'))).toBe('code');
+  });
+});
+
+describe('docs-only-filter: GitHub API guards', () => {
+  it('entry count < changed_files (API truncation) is not docs-only', () => {
+    const entries = [entry('docs/index.md'), entry('README.md')];
+    const result = classifyDocsOnly({ entries, changedFiles: 4000 });
+    expect(result.docsOnly).toBe(false);
+    expect(result.reason).toContain('truncation');
+  });
+
+  it('zero entries is not docs-only', () => {
+    const result = classifyDocsOnly({ entries: [], changedFiles: 0 });
+    expect(result.docsOnly).toBe(false);
+  });
+});
+
+describe('docs-only-filter: path classification unit cases', () => {
+  it('classifies documentation prefixes as docs', () => {
+    expect(classifyPath('docs/index.md')).toBe('docs');
+    expect(classifyPath('dev-docs/bun.md')).toBe('docs');
+    expect(classifyPath('project-plans/x/plan.md')).toBe('docs');
+    expect(classifyPath('research/note.md')).toBe('docs');
+  });
+
+  it('classifies root-level documentation as docs', () => {
+    expect(classifyPath('README.md')).toBe('docs');
+    expect(classifyPath('README_CN.md')).toBe('docs');
+    expect(classifyPath('CHANGELOG.md')).toBe('docs');
+    expect(classifyPath('CONTRIBUTING.md')).toBe('docs');
+    expect(classifyPath('CODE_OF_CONDUCT.md')).toBe('docs');
+    expect(classifyPath('SECURITY.md')).toBe('docs');
+    expect(classifyPath('ROADMAP.md')).toBe('docs');
+    expect(classifyPath('AGENTS.md')).toBe('docs');
+    expect(classifyPath('LICENSE_NOTE.md')).toBe('docs');
+  });
+
+  it('classifies all CODE prefixes as code regardless of extension', () => {
+    expect(classifyPath('packages/cli/src/SKILL.md')).toBe('code');
+    expect(classifyPath('scripts/foo.md')).toBe('code');
+    expect(classifyPath('integration-tests/README.md')).toBe('code');
+    expect(classifyPath('evals/readme.md')).toBe('code');
+    expect(classifyPath('test-setup/x.md')).toBe('code');
+    expect(classifyPath('test-scripts/x.md')).toBe('code');
+    expect(classifyPath('shell-scripts/x.md')).toBe('code');
+    expect(classifyPath('eslint-rules/x.md')).toBe('code');
+    expect(classifyPath('schemas/x.md')).toBe('code');
+    expect(classifyPath('profiles/x.md')).toBe('code');
+    expect(classifyPath('.github/workflows/ci.yml')).toBe('code');
+    expect(classifyPath('.husky/pre-commit')).toBe('code');
+    expect(classifyPath('bundle/x.md')).toBe('code');
+  });
+});
+
+describe('docs-only-filter: cross-classifier invariant', () => {
+  // The invariant: anything docs-only-filter calls DOCS must select NO shards
+  // for affected-test-shards. Being stricter is fine; being looser is a bug.
+  it('every DOCS path selects no test shards (imports the real selector)', () => {
+    const docsPaths = [
+      'docs/index.md',
+      'docs/reference/x.md',
+      'dev-docs/bun.md',
+      'project-plans/issue342/plan.md',
+      'research/note.md',
+      'README.md',
+      'README_CN.md',
+      'CHANGELOG.md',
+      'CONTRIBUTING.md',
+      'CODE_OF_CONDUCT.md',
+      'SECURITY.md',
+      'ROADMAP.md',
+      'AGENTS.md',
+      'SOMETHING.md',
+      'NOTES.mdx',
+      'NOTES.rst',
+      'NOTES.txt',
+      'NOTES.adoc',
+    ];
+    for (const p of docsPaths) {
+      // Sanity: docs-only-filter agrees this is docs.
+      expect(classifyPath(p), `${p} should be docs`).toBe('docs');
+      const selection = selectAffectedShards({
+        event: 'pull_request',
+        changedPaths: [p],
+      });
+      expect(
+        selection.selectedShards.length,
+        `DOCS path '${p}' must select no shards, got [${selection.selectedShards.join(', ')}]`,
+      ).toBe(0);
+      expect(selection.hasTests).toBe(false);
+    }
+  });
+
+  it('a .gitignore with a docs/reference-only patch is docs AND selects no shards', () => {
+    const patch = '@@ -1,1 +1,2 @@\n+!docs/reference/\n';
+    expect(classifyPath('.gitignore', patch)).toBe('docs');
+    const selection = selectAffectedShards({
+      event: 'pull_request',
+      changedPaths: ['.gitignore'],
+    });
+    expect(selection.selectedShards.length).toBe(0);
+  });
+});

--- a/scripts/tests/docs-only-filter.bun.test.ts
+++ b/scripts/tests/docs-only-filter.bun.test.ts
@@ -190,13 +190,20 @@ describe('docs-only-filter: GitHub API guards', () => {
     expect(result.docsOnly).toBe(false);
   });
 
-  it('a non-integer changed_files count fails closed rather than skipping the ceiling check', () => {
-    // A caller passing NaN (e.g. from an unguarded Number(...)) must not bypass
-    // the truncation guard and green an all-docs entry list.
+  // An unusable changed_files count must never let an all-docs entry list
+  // through: without a trustworthy total we cannot know the API returned every
+  // changed file. Each of these would otherwise be a fail-open.
+  it.each([
+    ['NaN', Number.NaN],
+    ['undefined', undefined],
+    ['negative', -1],
+    ['fractional', 3.5],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('an unusable changed_files count (%s) fails closed', (_label, count) => {
     const entries = [entry('docs/index.md')];
-    const result = classifyDocsOnly({ entries, changedFiles: Number.NaN });
+    const result = classifyDocsOnly({ entries, changedFiles: count });
     expect(result.docsOnly).toBe(false);
-    expect(result.reason).toContain('truncation');
+    expect(result.reason).toContain('unusable changed_files count');
   });
 });
 

--- a/scripts/tests/docs-only-filter.bun.test.ts
+++ b/scripts/tests/docs-only-filter.bun.test.ts
@@ -189,6 +189,15 @@ describe('docs-only-filter: GitHub API guards', () => {
     const result = classifyDocsOnly({ entries: [], changedFiles: 0 });
     expect(result.docsOnly).toBe(false);
   });
+
+  it('a non-integer changed_files count fails closed rather than skipping the ceiling check', () => {
+    // A caller passing NaN (e.g. from an unguarded Number(...)) must not bypass
+    // the truncation guard and green an all-docs entry list.
+    const entries = [entry('docs/index.md')];
+    const result = classifyDocsOnly({ entries, changedFiles: Number.NaN });
+    expect(result.docsOnly).toBe(false);
+    expect(result.reason).toContain('truncation');
+  });
 });
 
 describe('docs-only-filter: path classification unit cases', () => {


### PR DESCRIPTION
## TLDR

Docs-only PRs still ran the entire build/packaging/smoke tier. This gates six heavy jobs on the existing `doc_change_filter` output, so a `.md` edit no longer pays for `bun install`, `npm pack`, a full build and an ACP conformance run. Linting and actionlint still run on every PR, so documentation keeps its coverage.

**The part reviewers should look at hardest:** making a required check green based on a path classifier is only safe if the classifier is sound, and the one on `main` was not. It treated *any* `*.md`/`*.txt` outside `integration-tests/` as documentation — but `packages/core/src/prompt-config/defaults/**/*.md` (52 files) are **runtime prompt inputs** compiled into the prompt manifest, and `*.expected.txt` files are **test fixtures**. This PR replaces that rule with a conservative allowlist in a committed, unit-tested script and keeps the `Test` aggregator cross-checking the independent shard selector, so a misclassification fails closed rather than greening a required check.

## Dive Deeper

### What gets skipped

Six jobs gain `doc_change_filter` in `needs` and `needs.doc_change_filter.outputs.docs_only != 'true'` in their `if` (keeping the existing `should_skip` clause): `bun_install_smoke`, `bun_native_modules_smoke`, `node_consumer_smoke`, `bun_test_orchestrator_smoke`, `bun_native_test_parity`, `acp_conformance`.

`test_shard`, `secure_store_backend`, `post_coverage_comment` and the E2E jobs were already gated. Untouched and still running on every PR: `skip_check`, `doc_change_filter`, `shard_selector`, all four linters, and `codeql`.

### Why the classifier was replaced

The inline bash detector is now `scripts/docs-only-filter.ts`, following the conventions of the existing `scripts/affected-test-shards.ts` (CLI flags, `--output github-actions`, exported pure functions). It is a conservative allowlist:

- **Code (checked before any extension rule):** `packages/`, `scripts/`, `integration-tests/`, `evals/`, `test-setup/`, `test-scripts/`, `shell-scripts/`, `eslint-rules/`, `schemas/`, `profiles/`, `.github/`, `.husky/`, `bundle/`
- **Docs:** `docs/`, `dev-docs/`, `project-plans/`, `research/`, plus root-level `README*`/`CHANGELOG*`/`CONTRIBUTING*`/`CODE_OF_CONDUCT*`/`SECURITY*`/`ROADMAP*`/`AGENTS.md` and root-level doc extensions
- **Everything else:** code (fail closed)

There is a **cross-classifier invariant**, enforced by a test that imports the real `selectAffectedShards`: anything this module calls DOCS must also select no shards in `affected-test-shards.ts`. Being stricter than the shard selector is safe; being looser is a bug.

Three additional fail-closed paths were added:

1. **Renames** — the old detector projected only `.filename`, so renaming a code file to a `.md` path read as docs-only. Both `filename` and `previous_filename` must now be documentation.
2. **API ceiling** — `GET /pulls/{n}/files` caps at 3000 entries even with `--paginate`. The authoritative `changed_files` count is now compared against the returned entries; any mismatch means full CI.
3. **Detector failure** — the step used to fail the job, which (via plain `needs`) skipped all six jobs and turned the aggregators red, wedging the PR. API and script failures now resolve to `docs_only=false` so a blip runs full CI instead.

### Keeping the required checks honest

`Lint` was a bare `echo` with **no `if:`**. Once `node_consumer_smoke` became skippable, GitHub would have skipped `Lint` entirely — and a skipped required check is a silent bypass. It now runs with `always()` and explicitly verifies each linter, accepting a *skipped* node consumer smoke only when `docs_only == 'true'`.

`Test` gains the same narrow exemption for `node_consumer_smoke` and `acp_conformance`. Deliberately **no** unconditional docs-only early return: it still requires `shard_selector` to succeed and still honours `has_tests`/`test_shard`. That cross-check is what makes a detector misclassification fail closed.

## Reviewer Test Plan

The classifier is a plain CLI, so you can exercise the real decision logic directly:

    # A genuine code PR -> false
    gh api --paginate -H "Accept: application/vnd.github+json" \
      "repos/vybestack/llxprt-code/pulls/3014/files" --jq '.[]' > /tmp/files.ndjson
    CF=$(gh api "repos/vybestack/llxprt-code/pulls/3014" --jq '.changed_files')
    node scripts/docs-only-filter.ts --files-json /tmp/files.ndjson --changed-files "$CF"

    # Pure docs -> true
    printf '%s\n' '{"filename":"docs/index.md","status":"modified"}' > /tmp/d.ndjson
    node scripts/docs-only-filter.ts --files-json /tmp/d.ndjson --changed-files 1

    # The regression that motivated the rewrite: a runtime prompt file -> false
    printf '%s\n' '{"filename":"packages/core/src/prompt-config/defaults/core.md","status":"modified"}' > /tmp/p.ndjson
    node scripts/docs-only-filter.ts --files-json /tmp/p.ndjson --changed-files 1

    # Rename bypass -> false ; API truncation -> false
    printf '%s\n' '{"filename":"docs/foo.md","status":"renamed","previous_filename":"packages/core/src/foo.ts"}' > /tmp/r.ndjson
    node scripts/docs-only-filter.ts --files-json /tmp/r.ndjson --changed-files 1
    node scripts/docs-only-filter.ts --files-json /tmp/d.ndjson --changed-files 4000

Full suite (103 tests across the four CI-workflow test files):

    bun test --preload ./test-setup/augment-bun-vi.ts --preload ./scripts/tests/test-setup.ts \
      scripts/tests/docs-only-filter.bun.test.ts scripts/tests/ci-docs-only-skip.bun.test.ts \
      scripts/tests/ci-acplint-workflow.test.ts scripts/tests/ci-secure-store-workflow.test.ts

The aggregator tests do not re-implement the logic — they extract the real `run:` bash out of `ci.yml`, substitute each `needs` expression with a positional parameter, and execute it under `bash`, including shell-injection sentinels proving a job result is never evaluated.

**End-to-end behaviour to confirm on this PR itself:** this PR touches `.github/` and `scripts/`, so `docs_only` must be `false` and the full matrix must run. A follow-up docs-only PR is the positive case.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run lint` (0), `npm run typecheck` (0), `npm run build` (0), `npm run format` (clean/idempotent), 103 targeted tests passing, `yamllint` and `actionlint` (with CI's ignore flags) clean on `ci.yml`, and the CLI smoke run. The change is CI-configuration and a Node/Bun path classifier, so it carries no platform-specific runtime surface; the Linux behaviour is exercised by this PR's own CI run.

## Linked issues / bugs

Fixes #342


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation-only pull requests are now identified automatically.
  * Documentation-only changes can skip heavyweight installation, build, and test jobs while retaining essential validation.
  * Documentation-only changes are handled safely for renames, ignored files, incomplete metadata, and mixed code changes.

* **Bug Fixes**
  * CI now fails safely when changed-file information is missing, malformed, or incomplete.

* **Tests**
  * Added comprehensive coverage for documentation classification, workflow behavior, test aggregation, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->