### PR TITLE
Surface the discarded macOS Keychain grant and add a keyring escape hatch (Fixes #3020)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -145,7 +145,7 @@ Install the official Bun release signed by Oven:
     curl -fsSL https://bun.com/install | bash
 ```
 
-**Why "Always Allow" does not work:** the Keychain ACL stored on each item is identity-based, so it matches any Oven-signed Bun anywhere on disk. A binary that is ad-hoc signed or has no team ID can never satisfy that requirement. Per [#3020](https://github.com/vybestack/llxprt-code/issues/3020), `change_acl` on these items has an empty application list, so clicking **Always Allow** is silently discarded — the prompt recurs on every credential read. Replacing the binary with Oven's signed build is the only durable fix.
+**Why "Always Allow" does not work:** the Keychain ACL stored on each item is identity-based, so it matches any Oven-signed Bun anywhere on disk. A binary that is ad-hoc signed or has no team ID can never satisfy that requirement. The structural fact, confirmed in source: every LLxprt credential item is created through macOS `SecKeychainAddGenericPassword`, which takes no access-control parameter, so the item's ACL is the macOS default `SecAccess`. That default carries the required **owner** entry authorizing `change_acl` with an **empty** trusted-application list. Per Apple's documentation an empty list means no application is trusted to amend the ACL **without user confirmation** (unlike a null list, which means any application may). No layer of the dependency chain (`@napi-rs/keyring` 1.3.0 → `keyring-core` → `apple-native-keyring-store` 1.0.1 → `security-framework` 3.7.0) exposes any way to supply a different `SecAccess`, so LLxprt cannot construct or repair the ACL of these items from TypeScript. The exact `securityd` mechanism by which the observed "Always Allow" grant fails to persist is not established by this work — confirming it would require a native ACL inspection of the item immediately before and after a grant — but the symptom (the prompt recurs on every credential read) is consistent with it. Installing an Oven-signed Bun with a stable team identity clears the symptom in practice.
 
 **Why it is a warning, not a hard failure:** a Bun that is ad-hoc signed or has no team identity runs LLxprt Code correctly in every respect except Keychain access, and some users keep no credentials in the Keychain at all. Failing closed would break those working setups. Skipping it and falling through to the bundled Bun would silently re-enable the npm-unlink failure mode that #2962 exists to prevent, so the launcher warns and continues to use the selected Bun.
 
@@ -166,6 +166,32 @@ codesign -dv --requirements - "$(command -v bun)" 2>&1
 ```
 
 This check is macOS-only; Linux and Windows never key credential access on code identity.
+
+##### Runtime diagnostic: "the grant is not being persisted"
+
+If the launcher warning was not present at startup (for example, you started LLxprt Code from an Oven-signed Bun but the grant is still not sticking), LLxprt Code watches for the symptom itself: when the **same** credential has to be authorized interactively a second time in a session — after an earlier authorization for it had already completed — it prints a one-time notice to stderr explaining that the grant is not being persisted and that the prompt will keep recurring. This is a heuristic based on how long a successful credential read blocked, so a pathologically slow keychain can also trigger it. Credential access is **not** interrupted by this notice — the value is still read and returned, so your session keeps working. The notice fires at most once per process.
+
+##### Recovery: disable the OS keyring
+
+If you cannot install an Oven-signed Bun right now, you can route LLxprt's own SecureStore credentials through the encrypted file fallback and leave the Keychain alone:
+
+```bash
+export LLXPRT_DISABLE_OS_KEYRING=1
+```
+
+Add this to your shell profile so it persists; do not toggle it per-invocation (see the caveats below). Only the exact value `1` opts out. With it set:
+
+- **SecureStore credentials** (named API keys and similar) are stored in the encrypted file store under your OS data directory (`~/Library/Application Support/llxprt-code/secure-store/` on macOS), using the same AES-256-GCM envelope as the automatic fallback.
+- Existing Keychain items are **left in place** — nothing is deleted and nothing is migrated. You will re-authenticate once so the credential is written to the file store.
+
+**Limitations of this escape hatch (read before relying on it):**
+
+- **MCP server OAuth tokens are not covered.** MCP server OAuth uses `KeychainTokenStorage`, which requires the OS keyring and throws when it is unavailable. While this variable is set, MCP server OAuth is unavailable. This is the same pre-existing limitation that already applies on hosts with no keyring at all (headless Linux, containers); it is not specific to this variable.
+- **Stores with `fallbackPolicy: 'deny'` still fail.** A store constructed with a deny policy raises `UNAVAILABLE` rather than writing a file. The opt-out deliberately does not defeat a deny policy.
+- **The machine secret can change, and v:2 fallback files are tied to it.** When the machine secret lives only in the OS keyring, disabling the keyring makes machine-secret resolution fall through to the file path and generate a _different_ secret. Existing v:2 fallback files then fail to decrypt with a `CORRUPT` error, and files written while opted out likewise fail to decrypt after the variable is removed. This is a loud, visible failure (not silent), which is why the variable should be set persistently rather than toggled per-invocation.
+- **Re-enabling reads the Keychain first.** After the variable is removed, `SecureStore.get()` consults the keyring before the fallback file, so a credential you re-authenticated while opted out is silently shadowed by the older Keychain value, and a delete performed while opted out leaves the Keychain item in place. This silent behavior is the other reason to treat the variable as persistent.
+
+This is the interim escape hatch for [#3020](https://github.com/vybestack/llxprt-code/issues/3020). The full, settings-driven keyring opt-out is tracked in [#2928](https://github.com/vybestack/llxprt-code/issues/2928).
 
 ### Common Authentication Errors
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -45,6 +45,11 @@ export {
   isRuntimeReplacedError,
 } from './secure-store/secure-store-errors.js';
 export {
+  isKeychainGrantPersistenceBroken,
+  GRANT_NOT_PERSISTING_MESSAGE,
+  GRANT_NOT_PERSISTING_REMEDIATION,
+} from './secure-store/keychain-grant-persistence.js';
+export {
   ProviderKeyStorage,
   KEY_NAME_REGEX,
   getProviderKeyStorage,

--- a/packages/storage/src/secure-store/default-keyring-adapter.ts
+++ b/packages/storage/src/secure-store/default-keyring-adapter.ts
@@ -29,6 +29,7 @@ import { NullStorageLoggerImpl } from '../types/logger.js';
 import { isRuntimeReplaced } from './runtime-identity.js';
 import { assertRuntimeNotReplaced } from './runtime-replaced-errors.js';
 import { verifyKeyringDelete } from './keyring-delete-verification.js';
+import { recordAuthorizedKeyringRead } from './keychain-grant-persistence.js';
 import { SecureStoreError } from './secure-store-errors.js';
 import type { KeyringAdapter } from './secure-store.js';
 
@@ -60,6 +61,20 @@ const DISABLE_OS_KEYRING_ENV = 'LLXPRT_TEST_DISABLE_OS_KEYRING';
 
 function isOsKeyringDisabledForTests(): boolean {
   return process.env[DISABLE_OS_KEYRING_ENV] === '1';
+}
+
+/**
+ * Production opt-out: when `LLXPRT_DISABLE_OS_KEYRING=1` the factory returns
+ * null and all credential traffic routes to the encrypted file fallback. This
+ * is the user-facing recovery lever for the discarded Keychain grant (issue
+ * #3020). Distinct from the test marker above, which exists for suite
+ * isolation: this one is shipped, documented, and leaves existing Keychain
+ * items untouched.
+ */
+const PROD_DISABLE_OS_KEYRING_ENV = 'LLXPRT_DISABLE_OS_KEYRING';
+
+function isOsKeyringDisabled(): boolean {
+  return process.env[PROD_DISABLE_OS_KEYRING_ENV] === '1';
 }
 
 function isErrorWithCode(value: unknown): value is { code: string } {
@@ -244,6 +259,9 @@ export async function createDefaultKeyringAdapter(): Promise<KeyringAdapter | nu
   if (isOsKeyringDisabledForTests()) {
     return null;
   }
+  if (isOsKeyringDisabled()) {
+    return null;
+  }
   try {
     const module = await import('@napi-rs/keyring');
     const keyring = resolveKeyringModule(module);
@@ -255,7 +273,23 @@ export async function createDefaultKeyringAdapter(): Promise<KeyringAdapter | nu
     const adapter: KeyringAdapter = {
       getPassword: async (service: string, account: string) => {
         const entry = new kr.AsyncEntry(service, account);
-        return entry.getPassword();
+        // Issue #3020: time the native read with a monotonic clock
+        // (performance.now) so a repeatedly slow successful read of the
+        // SAME credential surfaces the discarded "Always Allow" grant.
+        // Only non-null reads are recorded; a rejection propagates
+        // untouched because the await throws before this record call is
+        // reached. The correlation key is an opaque Map key only — never
+        // logged or interpolated into any message.
+        const startedAt = performance.now();
+        const value = await entry.getPassword();
+        if (value !== null) {
+          recordAuthorizedKeyringRead({
+            credentialKey: `${service}\u0000${account}`,
+            startedAt,
+            endedAt: performance.now(),
+          });
+        }
+        return value;
       },
       setPassword: async (
         service: string,

--- a/packages/storage/src/secure-store/keychain-grant-persistence.ts
+++ b/packages/storage/src/secure-store/keychain-grant-persistence.ts
@@ -1,0 +1,265 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Heuristic detector for the discarded macOS Keychain "Always Allow" grant
+ * (issue #3020).
+ *
+ * ## What the source chain establishes (and what it does not)
+ *
+ * Every LLxprt credential item on macOS is created through
+ * `SecKeychainAddGenericPassword`, which takes no `SecAccess` parameter, so
+ * the item's ACL is whatever macOS synthesizes by default. That default ACL
+ * carries the required owner entry authorizing `change_acl` with an **empty**
+ * trusted-application list. Per Apple's documentation an empty list means no
+ * application is trusted to amend the ACL **without user confirmation**
+ * (as distinct from a null list, which means any application may). The
+ * fully-proven, load-bearing finding is that **no layer of the dependency
+ * chain** (`@napi-rs/keyring` 1.3.0 → `keyring-core` →
+ * `apple-native-keyring-store` 1.0.1 → `security-framework` 3.7.0) **exposes
+ * any way to supply a different `SecAccess`**, so LLxprt cannot construct or
+ * repair the ACL of these items from TypeScript.
+ *
+ * The exact securityd mechanism by which the observed "Always Allow" grant is
+ * discarded is **NOT** established by this work. Confirming it would require a
+ * native ACL inspection of the item immediately before and after a grant.
+ * This module does not assert that mechanism; it observes a symptom.
+ *
+ * ## The signal, and why it is the only in-process observable
+ *
+ * The only in-process observable that distinguishes "authorized without
+ * interaction" from "a human was made to authorize this read" is the duration
+ * of a read that nonetheless **succeeded**: an interactive authorization
+ * prompt blocks for well over a second, while a pre-authorized read returns in
+ * milliseconds. The binding erases `OSStatus` (see issue #3011), `securityd`
+ * handles any ACL amendment internally and returns the secret regardless of
+ * whether the grant was stored, and the ACL is not readable through the
+ * binding. A read that returns `null` or throws is never an authorization
+ * event — absence and failure are not a granted authorization.
+ *
+ * ## This is a heuristic with a known false-positive envelope, not proof
+ *
+ * A single slow successful read is the normal first-time authorization and
+ * proves nothing. A **second** slow successful read of the **same** credential
+ * that **began after** the first completed is a symptom consistent with a
+ * discarded grant — a pathologically slow but non-interactive keychain could
+ * also produce it. What narrows the envelope: the detector is darwin-only,
+ * requires the duration to be strictly greater than the threshold, correlates
+ * by the same credential, only counts non-overlapping reads (the second must
+ * have begun at or after the first completed), and requires two such events
+ * rather than one.
+ *
+ * ## The consequence is bounded
+ *
+ * The predicate flips to a terminal broken state at most once per process and
+ * emits a single stderr notice. Credential access is **never** blocked and no
+ * data is changed: the read that triggered the notice still returns its value
+ * to the caller.
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+
+/**
+ * Monotonic-clock duration above which a successful keyring read is treated as
+ * an interactive authorization event. Module constant, not configuration: it
+ * is the contract, not a tunable. The detector requires the duration to be
+ * strictly greater than this value (a read exactly at the threshold does not
+ * count).
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+export const INTERACTIVE_AUTH_THRESHOLD_MS = 1500;
+
+/**
+ * The diagnosis emitted when the grant is not persisting. Describes the
+ * observation and its consequence; it does not assert a proven cause.
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+export const GRANT_NOT_PERSISTING_MESSAGE =
+  'LLxprt has been asked to authorize the same macOS Keychain credential again after it was already authorized this session, so the grant is not persisting and the password prompt will keep recurring (see #3020).';
+
+/**
+ * Both remedies. Installing an Oven-signed Bun clears the symptom in practice;
+ * setting the opt-out routes LLxprt's own SecureStore credentials to the
+ * encrypted file fallback. MCP server OAuth tokens still require the OS
+ * keyring (see the troubleshooting guide).
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+export const GRANT_NOT_PERSISTING_REMEDIATION =
+  "Installing an Oven-signed Bun (a build with a stable team identity) clears this in practice: `brew uninstall bun && brew install oven-sh/bun/bun` (or `curl -fsSL https://bun.com/install | bash`). To recover now without changing your Bun, set LLXPRT_DISABLE_OS_KEYRING=1: LLxprt's own SecureStore credentials route to the encrypted file fallback and existing Keychain items are left untouched (MCP server OAuth tokens still require the OS keyring; see the troubleshooting guide).";
+
+/**
+ * Observation of a single successful keyring read, used to detect a discarded
+ * "Always Allow" grant.
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+export interface KeyringReadObservation {
+  /**
+   * Opaque correlation key for the credential. Never logged, never put in a
+   * message, never interpolated into any text. It is a `Map` key only.
+   */
+  readonly credentialKey: string;
+  /** Monotonic milliseconds (from `performance.now()`) when the native read started. */
+  readonly startedAt: number;
+  /** Monotonic milliseconds (from `performance.now()`) when the native read completed. */
+  readonly endedAt: number;
+}
+
+// ─── Process-wide state ──────────────────────────────────────────────────────
+//
+// Mirrors runtime-replaced-errors.ts: a small amount of process-wide state and
+// a once-per-process stderr warning. The state is terminal once set.
+
+let broken = false;
+
+/**
+ * Injectable effective platform so the darwin-only behavior is testable on
+ * every CI platform. `null` means "use process.platform".
+ */
+let effectivePlatform: NodeJS.Platform | null = null;
+
+function currentPlatform(): NodeJS.Platform {
+  return effectivePlatform ?? process.platform;
+}
+
+/**
+ * Upper bound on the number of distinct credentials the tracker remembers.
+ * The tracker only holds credentials that had exactly one interactive read,
+ * and entries are only useful for short-range correlation, so this bound is
+ * generous. Clearing at worst loses a first observation, which biases toward
+ * NOT warning — the safe direction.
+ */
+const MAX_TRACKED_CREDENTIALS = 256;
+
+/**
+ * Holds the `endedAt` of each credential's last interactive read, keyed by an
+ * opaque correlation key. Used only to detect a SECOND non-overlapping
+ * interactive read of the SAME credential. Cleared once the broken state is
+ * reached (no longer needed) and on reset.
+ */
+const lastInteractiveReadEndedAt = new Map<string, number>();
+
+/**
+ * Records a successful keyring read, with its monotonic-clock start and end
+ * times, so a repeatedly slow read of the SAME credential surfaces the
+ * discarded "Always Allow" grant. Called ONLY for reads that returned a
+ * non-null value.
+ *
+ * Does nothing unless the effective platform is `darwin`, and counts only
+ * durations strictly greater than {@link INTERACTIVE_AUTH_THRESHOLD_MS}. The
+ * discarded-grant event is counted only on a SECOND non-overlapping
+ * interactive read of the same credential; on that transition the process
+ * enters the terminal broken state and the warning is emitted exactly once.
+ * Nothing in this module throws.
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+export function recordAuthorizedKeyringRead(
+  observation: KeyringReadObservation,
+): void {
+  // 1. darwin-only.
+  if (currentPlatform() !== 'darwin') {
+    return;
+  }
+  // 2. Terminal state: stop doing work.
+  if (broken) {
+    return;
+  }
+  // 3. Strictly greater than the threshold (a read exactly at it is not an
+  //    event).
+  const duration = observation.endedAt - observation.startedAt;
+  if (!(duration > INTERACTIVE_AUTH_THRESHOLD_MS)) {
+    return;
+  }
+  // 4. Correlate by credential.
+  const previousEndedAt = lastInteractiveReadEndedAt.get(
+    observation.credentialKey,
+  );
+  if (previousEndedAt === undefined) {
+    // First interactive authorization for this credential — the normal
+    // one-time prompt. Remember it for short-range correlation, bounding the
+    // map before inserting a brand-new key.
+    if (lastInteractiveReadEndedAt.size >= MAX_TRACKED_CREDENTIALS) {
+      lastInteractiveReadEndedAt.clear();
+    }
+    lastInteractiveReadEndedAt.set(
+      observation.credentialKey,
+      observation.endedAt,
+    );
+    return;
+  }
+  // Count the discarded-grant event ONLY if this read began at or after the
+  // earlier authorization completed — i.e. a persisted grant would have
+  // covered it. If it began earlier (overlapping/concurrent reads) it proves
+  // nothing: leave the stored value unchanged.
+  if (observation.startedAt < previousEndedAt) {
+    return;
+  }
+  // 5. Counted event: terminal broken state. The map is no longer needed.
+  broken = true;
+  lastInteractiveReadEndedAt.clear();
+  emitGrantNotPersistingWarning();
+}
+
+/**
+ * Reports whether the discarded-grant condition has been detected this process.
+ * Terminal: once true, always true for the lifetime of the process.
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+export function isKeychainGrantPersistenceBroken(): boolean {
+  return broken;
+}
+
+/**
+ * Emits the one-time discarded-grant warning to stderr, guaranteeing it
+ * reaches the user independent of any injected logger.
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+function emitGrantNotPersistingWarning(): void {
+  try {
+    process.stderr.write(
+      `\n${GRANT_NOT_PERSISTING_MESSAGE} ${GRANT_NOT_PERSISTING_REMEDIATION}\n\n`,
+    );
+  } catch {
+    // stderr can be closed or broken (EPIPE when piped into a command that
+    // exits early). Losing the diagnostic notice is acceptable; breaking the
+    // credential read that triggered it is not — the caller must still receive
+    // the value it just read. Swallow here so a stream error can never escape
+    // into the credential read path. Intentionally mirrors the defensive catch
+    // in runtime-replaced-errors.ts.
+  }
+}
+
+// ─── Test seams ──────────────────────────────────────────────────────────────
+
+/**
+ * Resets the observation state for testing, including the credential
+ * correlation map. Does not change the effective platform; pair with
+ * {@link setKeychainGrantPersistencePlatformForTesting}.
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+export function resetKeychainGrantPersistenceForTesting(): void {
+  broken = false;
+  lastInteractiveReadEndedAt.clear();
+}
+
+/**
+ * Overrides the effective platform so the darwin-only behavior is exercisable
+ * on every CI platform. Pass `null` to restore the default (`process.platform`).
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+export function setKeychainGrantPersistencePlatformForTesting(
+  platform: NodeJS.Platform | null,
+): void {
+  effectivePlatform = platform;
+}

--- a/packages/storage/src/secure-store/secure-store.ts
+++ b/packages/storage/src/secure-store/secure-store.ts
@@ -32,6 +32,7 @@ import {
   type Envelope,
 } from './envelope.js';
 import { verifyKeyringWrite } from './keyring-write-verification.js';
+import { isKeychainGrantPersistenceBroken as isKeychainGrantPersistenceBrokenState } from './keychain-grant-persistence.js';
 import {
   assertRuntimeNotReplaced,
   RUNTIME_REPLACED_REMEDIATION,
@@ -360,6 +361,22 @@ export class SecureStore {
       }
       return false;
     }
+  }
+
+  /**
+   * Reports whether the discarded macOS Keychain "Always Allow" grant has been
+   * detected this process (issue #3020). Terminal: once true, always true.
+   *
+   * This proxies **process-wide** state shared across every SecureStore
+   * instance and every service/account — it is NOT scoped to this store
+   * instance or to this service. The detector correlates by credential, but
+   * the resulting predicate is global: once any credential triggers it, every
+   * store's accessor reports true for the rest of the process.
+   *
+   * @plan PLAN-20260805-ISSUE3020
+   */
+  isKeychainGrantPersistenceBroken(): boolean {
+    return isKeychainGrantPersistenceBrokenState();
   }
 
   private async deleteFallbackFiles(key: string): Promise<boolean> {

--- a/packages/storage/test-bun/keychain-grant-persistence.bun.ts
+++ b/packages/storage/test-bun/keychain-grant-persistence.bun.ts
@@ -1,0 +1,419 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the discarded "Always Allow" grant heuristic
+ * (issue #3020).
+ *
+ * The leaf module correlates by credential: a discarded-grant event is counted
+ * only on a SECOND interactive-length successful read of the SAME credential
+ * that began at or after the first completed. Overlapping reads and reads of
+ * different credentials prove nothing. This suite verifies the leaf module's
+ * contract, its wiring into the default keyring adapter, and its surface on
+ * SecureStore.
+ *
+ * Leaf-module cases pass the observation objects directly (the startedAt /
+ * endedAt are explicit monotonic-clock values), so no clock is mocked there.
+ * Adapter-level cases exercise the production timing path: the adapter times
+ * the native read with `performance.now()`, so a controllable `performance.now`
+ * (layered over the real one) makes a read appear to exceed the threshold
+ * without real sleeping. The real clock is restored in afterEach.
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+
+import { beforeEach, afterEach, describe, expect, it, mock } from 'bun:test';
+import type { KeyringAdapter } from '../src/secure-store/secure-store.js';
+import {
+  INTERACTIVE_AUTH_THRESHOLD_MS,
+  recordAuthorizedKeyringRead,
+  isKeychainGrantPersistenceBroken,
+  resetKeychainGrantPersistenceForTesting,
+  setKeychainGrantPersistencePlatformForTesting,
+} from '../src/secure-store/keychain-grant-persistence.js';
+import type { KeyringReadObservation } from '../src/secure-store/keychain-grant-persistence.js';
+import { createDefaultKeyringAdapter } from '../src/secure-store/default-keyring-adapter.js';
+import { SecureStore } from '../src/secure-store/secure-store.js';
+import { resetRuntimeIdentityForTesting } from '../src/secure-store/runtime-identity.js';
+import { resetRuntimeReplacedWarningForTesting } from '../src/secure-store/runtime-replaced-errors.js';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// ─── Controllable clock (adapter-level timing) ──────────────────────────────
+//
+// The adapter times a read as `performance.now()` snapshots around the native
+// call. To make a read appear to exceed the interactive-auth threshold without
+// real sleeping, the fake read advances `clockNow` (layered over the real
+// performance.now) before it resolves. The real performance.now is restored in
+// afterEach so process-wide timing outside these tests stays accurate.
+
+const realPerformanceNow: typeof performance.now =
+  performance.now.bind(performance);
+let clockNow = 0;
+
+function installControllableClock(): void {
+  clockNow = 0;
+  performance.now = (): number => clockNow;
+}
+
+function restoreRealClock(): void {
+  performance.now = realPerformanceNow;
+  clockNow = 0;
+}
+
+function advanceClock(ms: number): void {
+  clockNow += ms;
+}
+
+/** Builds an observation with explicit monotonic-clock start/end values. */
+function obs(
+  credentialKey: string,
+  startedAt: number,
+  endedAt: number,
+): KeyringReadObservation {
+  return { credentialKey, startedAt, endedAt };
+}
+
+// ─── Fake @napi-rs/keyring (boundary double) ────────────────────────────────
+//
+// Same technique as test-bun/keyring-delete-verification.bun.ts: bun's
+// mock.module intercepts the dynamic import for this isolated process (one
+// process per file). The fake read's apparent wall-clock cost and return value
+// are independently controllable, so a slow successful read, a slow null, and a
+// slow rejection can all be staged.
+
+interface FakeKeyringController {
+  readonly entries: Map<string, string>;
+  /** Monotonic ms the fake read appears to take (drives the controllable clock). */
+  readDurationMs: number;
+  /** When set, getPassword() rejects with this error. */
+  getPasswordError: Error | null;
+}
+
+function createFreshController(): FakeKeyringController {
+  return {
+    entries: new Map(),
+    readDurationMs: 0,
+    getPasswordError: null,
+  };
+}
+
+function compositeKey(service: string, account: string): string {
+  return `${service}\u0000${account}`;
+}
+
+let controller: FakeKeyringController = createFreshController();
+
+mock.module('@napi-rs/keyring', () => ({
+  AsyncEntry: class {
+    constructor(
+      private readonly service: string,
+      private readonly account: string,
+    ) {}
+
+    async getPassword(): Promise<string | null> {
+      if (controller.getPasswordError !== null) {
+        throw controller.getPasswordError;
+      }
+      // Advance the controllable clock BEFORE resolving, so the adapter's
+      // performance.now() snapshots reflect an interactive-authorization window.
+      if (controller.readDurationMs > 0) {
+        advanceClock(controller.readDurationMs);
+      }
+      return (
+        controller.entries.get(compositeKey(this.service, this.account)) ?? null
+      );
+    }
+
+    async deleteCredential(): Promise<boolean> {
+      return false;
+    }
+  },
+}));
+
+// ─── stderr capture ─────────────────────────────────────────────────────────
+//
+// The once-per-process warning is written via process.stderr.write. To assert
+// on its text (and the once-per-process guarantee) without spy-invocation
+// counting, the real write is swapped for a capturing function and restored in
+// afterEach.
+
+let realStderrWrite: typeof process.stderr.write | null = null;
+let capturedStderr = '';
+
+function startStderrCapture(): void {
+  realStderrWrite = process.stderr.write;
+  capturedStderr = '';
+  process.stderr.write = (chunk: unknown): boolean => {
+    capturedStderr += typeof chunk === 'string' ? chunk : String(chunk);
+    return true;
+  };
+}
+
+function stopStderrCapture(): void {
+  if (realStderrWrite !== null) {
+    process.stderr.write = realStderrWrite;
+    realStderrWrite = null;
+  }
+}
+
+function resetLeafState(): void {
+  resetKeychainGrantPersistenceForTesting();
+  setKeychainGrantPersistencePlatformForTesting(null);
+}
+
+async function loadAdapter(): Promise<KeyringAdapter> {
+  const adapter = await createDefaultKeyringAdapter();
+  if (adapter === null) {
+    throw new Error(
+      'createDefaultKeyringAdapter returned null — fake @napi-rs/keyring mock did not load',
+    );
+  }
+  return adapter;
+}
+
+/** Strictly above the threshold, so a read of this duration counts as an event. */
+const SLOW = INTERACTIVE_AUTH_THRESHOLD_MS + 500;
+
+// ─── Leaf module (direct observations) ──────────────────────────────────────
+
+/**
+ * @plan PLAN-20260805-ISSUE3020
+ */
+describe('keychain-grant-persistence leaf module (issue #3020)', () => {
+  beforeEach(() => {
+    resetKeychainGrantPersistenceForTesting();
+    setKeychainGrantPersistencePlatformForTesting('darwin');
+  });
+  afterEach(() => {
+    stopStderrCapture();
+    resetLeafState();
+  });
+
+  it('one slow successful read does not flip the predicate (case 1)', () => {
+    recordAuthorizedKeyringRead(obs('cred-a', 0, SLOW));
+    expect(isKeychainGrantPersistenceBroken()).toBe(false);
+  });
+
+  it('two slow sequential reads of the same credential flip the predicate and emit one warning block (case 2)', () => {
+    startStderrCapture();
+    // First interactive authorization for cred-a.
+    recordAuthorizedKeyringRead(obs('cred-a', 0, SLOW));
+    // Second began at or after the first completed (SLOW >= SLOW).
+    recordAuthorizedKeyringRead(obs('cred-a', SLOW, 2 * SLOW));
+
+    expect(isKeychainGrantPersistenceBroken()).toBe(true);
+    // The warning describes the observation, references #3020, and names both
+    // remedies (Oven-signed Bun and LLXPRT_DISABLE_OS_KEYRING).
+    expect(capturedStderr).toContain('not persisting');
+    expect(capturedStderr).toContain('#3020');
+    expect(capturedStderr).toContain('oven-sh/bun/bun');
+    expect(capturedStderr).toContain('LLXPRT_DISABLE_OS_KEYRING');
+  });
+
+  it('third and fourth slow reads keep the predicate true and never repeat the warning (case 3)', () => {
+    startStderrCapture();
+    recordAuthorizedKeyringRead(obs('cred-a', 0, SLOW));
+    recordAuthorizedKeyringRead(obs('cred-a', SLOW, 2 * SLOW));
+    const afterSecond = capturedStderr;
+    expect(isKeychainGrantPersistenceBroken()).toBe(true);
+
+    recordAuthorizedKeyringRead(obs('cred-a', 2 * SLOW, 3 * SLOW));
+    recordAuthorizedKeyringRead(obs('cred-a', 3 * SLOW, 4 * SLOW));
+
+    // Once-per-process: the captured stderr text is byte-for-byte unchanged
+    // after further slow reads — asserted on the text, not a call counter.
+    expect(capturedStderr).toBe(afterSecond);
+    expect(isKeychainGrantPersistenceBroken()).toBe(true);
+  });
+
+  it('a duration exactly at the threshold never counts, even twice (case 4)', () => {
+    recordAuthorizedKeyringRead(
+      obs('cred-a', 0, INTERACTIVE_AUTH_THRESHOLD_MS),
+    );
+    recordAuthorizedKeyringRead(
+      obs(
+        'cred-a',
+        INTERACTIVE_AUTH_THRESHOLD_MS,
+        2 * INTERACTIVE_AUTH_THRESHOLD_MS,
+      ),
+    );
+    expect(isKeychainGrantPersistenceBroken()).toBe(false);
+  });
+
+  it('many fast reads never flip the predicate (case 5)', () => {
+    let t = 0;
+    for (let i = 0; i < 20; i++) {
+      recordAuthorizedKeyringRead(obs('cred-a', t, t + 10));
+      t += 10;
+    }
+    expect(isKeychainGrantPersistenceBroken()).toBe(false);
+  });
+
+  it('a non-darwin platform never observes, regardless of durations (case 6)', () => {
+    setKeychainGrantPersistencePlatformForTesting('linux');
+    startStderrCapture();
+    let t = 0;
+    for (let i = 0; i < 10; i++) {
+      recordAuthorizedKeyringRead(obs('cred-a', t, t + SLOW));
+      t += SLOW;
+    }
+    expect(isKeychainGrantPersistenceBroken()).toBe(false);
+    expect(capturedStderr).toBe('');
+  });
+
+  it('two slow reads of DIFFERENT credentials never flip the predicate (case 7)', () => {
+    startStderrCapture();
+    recordAuthorizedKeyringRead(obs('cred-a', 0, SLOW));
+    recordAuthorizedKeyringRead(obs('cred-b', SLOW, 2 * SLOW));
+    expect(isKeychainGrantPersistenceBroken()).toBe(false);
+    expect(capturedStderr).toBe('');
+  });
+
+  it('two slow reads of the same credential that OVERLAP never flip the predicate (case 8)', () => {
+    startStderrCapture();
+    // First read: [0, SLOW). Second read begins at SLOW/2, before the first
+    // completed — a concurrent first read that proves nothing.
+    recordAuthorizedKeyringRead(obs('cred-a', 0, SLOW));
+    recordAuthorizedKeyringRead(obs('cred-a', SLOW / 2, SLOW + SLOW / 2));
+    expect(isKeychainGrantPersistenceBroken()).toBe(false);
+    expect(capturedStderr).toBe('');
+  });
+
+  it('a third credential first interactive read after the state is broken leaves stderr unchanged (case 9)', () => {
+    startStderrCapture();
+    recordAuthorizedKeyringRead(obs('cred-a', 0, SLOW));
+    recordAuthorizedKeyringRead(obs('cred-a', SLOW, 2 * SLOW));
+    const afterBreak = capturedStderr;
+    expect(isKeychainGrantPersistenceBroken()).toBe(true);
+
+    // State is terminal; a brand-new credential's first read does no work.
+    recordAuthorizedKeyringRead(obs('cred-c', 2 * SLOW, 3 * SLOW));
+
+    expect(isKeychainGrantPersistenceBroken()).toBe(true);
+    expect(capturedStderr).toBe(afterBreak);
+  });
+});
+
+// ─── Adapter-level wiring ───────────────────────────────────────────────────
+
+/**
+ * @plan PLAN-20260805-ISSUE3020
+ */
+describe('createDefaultKeyringAdapter getPassword — grant persistence timing (issue #3020)', () => {
+  beforeEach(() => {
+    resetKeychainGrantPersistenceForTesting();
+    setKeychainGrantPersistencePlatformForTesting('darwin');
+    resetRuntimeIdentityForTesting();
+    resetRuntimeReplacedWarningForTesting();
+    installControllableClock();
+    startStderrCapture();
+    controller = createFreshController();
+  });
+  afterEach(() => {
+    restoreRealClock();
+    stopStderrCapture();
+    resetLeafState();
+    resetRuntimeIdentityForTesting();
+    resetRuntimeReplacedWarningForTesting();
+  });
+
+  it('two slow sequential successful reads of the same service+account flip the predicate and still return the value (case 10)', async () => {
+    controller.readDurationMs = SLOW;
+    controller.entries.set(compositeKey('svc', 'acct'), 'the-secret');
+    const adapter = await loadAdapter();
+
+    // The diagnostic must not break credential access: the value is returned
+    // on both reads.
+    expect(await adapter.getPassword('svc', 'acct')).toBe('the-secret');
+    expect(await adapter.getPassword('svc', 'acct')).toBe('the-secret');
+    expect(isKeychainGrantPersistenceBroken()).toBe(true);
+  });
+
+  it('two slow reads of DIFFERENT accounts on the same service never flip the predicate (case 11)', async () => {
+    controller.readDurationMs = SLOW;
+    controller.entries.set(compositeKey('svc', 'acct-a'), 'secret-a');
+    controller.entries.set(compositeKey('svc', 'acct-b'), 'secret-b');
+    const adapter = await loadAdapter();
+
+    expect(await adapter.getPassword('svc', 'acct-a')).toBe('secret-a');
+    expect(await adapter.getPassword('svc', 'acct-b')).toBe('secret-b');
+    expect(isKeychainGrantPersistenceBroken()).toBe(false);
+  });
+
+  it('slow reads resolving null never flip the predicate (case 12)', async () => {
+    controller.readDurationMs = SLOW;
+    const adapter = await loadAdapter();
+
+    expect(await adapter.getPassword('svc', 'missing')).toBeNull();
+    expect(await adapter.getPassword('svc', 'missing')).toBeNull();
+    expect(isKeychainGrantPersistenceBroken()).toBe(false);
+  });
+
+  it('slow reads that reject propagate the rejection and never flip the predicate (case 13)', async () => {
+    controller.readDurationMs = SLOW;
+    controller.getPasswordError = new Error('keychain read failed');
+    const adapter = await loadAdapter();
+
+    await expect(adapter.getPassword('svc', 'acct')).rejects.toThrow(
+      'keychain read failed',
+    );
+    await expect(adapter.getPassword('svc', 'acct')).rejects.toThrow(
+      'keychain read failed',
+    );
+    expect(isKeychainGrantPersistenceBroken()).toBe(false);
+  });
+});
+
+// ─── SecureStore surface (case 14) ──────────────────────────────────────────
+
+/**
+ * @plan PLAN-20260805-ISSUE3020
+ */
+describe('SecureStore — grant persistence surface (issue #3020)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'grant-persistence-'));
+    resetKeychainGrantPersistenceForTesting();
+    setKeychainGrantPersistencePlatformForTesting('darwin');
+    resetRuntimeIdentityForTesting();
+    resetRuntimeReplacedWarningForTesting();
+    installControllableClock();
+    startStderrCapture();
+    controller = createFreshController();
+  });
+  afterEach(async () => {
+    restoreRealClock();
+    stopStderrCapture();
+    resetLeafState();
+    resetRuntimeIdentityForTesting();
+    resetRuntimeReplacedWarningForTesting();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('after the second slow get() the store reports broken and returned the value both times (case 14)', async () => {
+    controller.readDurationMs = SLOW;
+    controller.entries.set(
+      compositeKey('test-svc', 'token'),
+      'the-token-value',
+    );
+    // The adapter produced by createDefaultKeyringAdapter (which loads the
+    // faked @napi-rs/keyring) carries the read-timing instrumentation. Inject
+    // it via keyringLoader so the full SecureStore read path is exercised.
+    const adapter = await loadAdapter();
+    const store = new SecureStore('test-svc', {
+      keyringLoader: async () => adapter,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+    });
+
+    expect(await store.get('token')).toBe('the-token-value');
+    expect(await store.get('token')).toBe('the-token-value');
+    expect(store.isKeychainGrantPersistenceBroken()).toBe(true);
+  });
+});

--- a/packages/storage/test-bun/keychain-grant-persistence.bun.ts
+++ b/packages/storage/test-bun/keychain-grant-persistence.bun.ts
@@ -375,7 +375,9 @@ describe('createDefaultKeyringAdapter getPassword — grant persistence timing (
  * @plan PLAN-20260805-ISSUE3020
  */
 describe('SecureStore — grant persistence surface (issue #3020)', () => {
-  let tempDir: string;
+  // Empty until beforeEach creates it, so afterEach can tell "never created"
+  // from "created and needs removal".
+  let tempDir = '';
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'grant-persistence-'));
@@ -393,7 +395,12 @@ describe('SecureStore — grant persistence surface (issue #3020)', () => {
     resetLeafState();
     resetRuntimeIdentityForTesting();
     resetRuntimeReplacedWarningForTesting();
-    await fs.rm(tempDir, { recursive: true, force: true });
+    // Only remove a directory that was actually created. If mkdtemp threw in
+    // beforeEach, tempDir is still '' and fs.rm would raise a TypeError that
+    // masks the original failure.
+    if (tempDir !== '') {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('after the second slow get() the store reports broken and returned the value both times (case 14)', async () => {

--- a/packages/storage/test-bun/keyring-opt-out.bun.ts
+++ b/packages/storage/test-bun/keyring-opt-out.bun.ts
@@ -59,7 +59,9 @@ mock.module('@napi-rs/keyring', () => ({
 describe('LLXPRT_DISABLE_OS_KEYRING production opt-out (issue #3020)', () => {
   const originalProd = process.env[PROD_ENV_KEY];
   const originalTest = process.env[TEST_ENV_KEY];
-  let tempDir: string;
+  // Empty until beforeEach creates it, so afterEach can tell "never created"
+  // from "created and needs removal".
+  let tempDir = '';
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prod-disable-'));
@@ -80,7 +82,12 @@ describe('LLXPRT_DISABLE_OS_KEYRING production opt-out (issue #3020)', () => {
     } else {
       process.env[TEST_ENV_KEY] = originalTest;
     }
-    await fs.rm(tempDir, { recursive: true, force: true });
+    // Only remove a directory that was actually created. If mkdtemp threw in
+    // beforeEach, tempDir is still '' and fs.rm would raise a TypeError that
+    // masks the original failure.
+    if (tempDir !== '') {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('produces no keyring adapter when LLXPRT_DISABLE_OS_KEYRING=1 (case 15)', async () => {

--- a/packages/storage/test-bun/keyring-opt-out.bun.ts
+++ b/packages/storage/test-bun/keyring-opt-out.bun.ts
@@ -110,11 +110,18 @@ describe('LLXPRT_DISABLE_OS_KEYRING production opt-out (issue #3020)', () => {
     expect(encrypted).not.toContain('super-secret');
   });
 
-  it('produces an adapter for 0, empty, and true — only exactly 1 opts out (case 17)', async () => {
-    // '0', the empty string, and 'true' must NOT opt out: only the exact
-    // string '1' does, matching the existing test-marker convention. The test
-    // marker is cleared in beforeEach, so these reach the real factory check.
+  it('produces an adapter for 0, empty, unset, and true — only exactly 1 opts out (case 17)', async () => {
+    // '0', the empty string, an unset variable, and 'true' must NOT opt out:
+    // only the exact string '1' does, matching the existing test-marker
+    // convention. The test marker is cleared in beforeEach, so these reach the
+    // real factory check.
     process.env[PROD_ENV_KEY] = '0';
+    expect(await createDefaultKeyringAdapter()).not.toBeNull();
+
+    // Set explicitly rather than deleted: an assigned empty string and an
+    // absent variable are distinct states, and only assignment exercises the
+    // empty-string value itself.
+    process.env[PROD_ENV_KEY] = '';
     expect(await createDefaultKeyringAdapter()).not.toBeNull();
 
     delete process.env[PROD_ENV_KEY];

--- a/packages/storage/test-bun/keyring-opt-out.bun.ts
+++ b/packages/storage/test-bun/keyring-opt-out.bun.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the `LLXPRT_DISABLE_OS_KEYRING` production opt-out
+ * (issue #3020).
+ *
+ * These cases were moved out of the Vitest suite
+ * (`src/secure-store/default-keyring-adapter.test.ts`) into a Bun + `bun:test`
+ * file, because that Vitest suite is not registered in the Bun manifest and
+ * must not import `bun:test`. The opt-out behavior is exercised through the
+ * real `createDefaultKeyringAdapter()` / `SecureStore` factory paths.
+ *
+ * `@napi-rs/keyring` is faked via `mock.module` so the "not opted out" cases
+ * (an adapter IS produced for `0`, `''`, `true`) are deterministic and never
+ * touch the developer's real OS keychain. The fake only takes effect when the
+ * dynamic import actually runs — every opt-out path returns null before
+ * importing.
+ *
+ * Both `LLXPRT_DISABLE_OS_KEYRING` (the shipped lever) and
+ * `LLXPRT_TEST_DISABLE_OS_KEYRING` (the test-isolation marker, which the
+ * factory also honors and which is checked first) are cleared in beforeEach and
+ * restored in afterEach so nothing leaks between cases.
+ *
+ * @plan PLAN-20260805-ISSUE3020
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createDefaultKeyringAdapter } from '../src/secure-store/default-keyring-adapter.js';
+import { SecureStore } from '../src/secure-store/secure-store.js';
+import { SecureStoreError } from '../src/secure-store/secure-store-errors.js';
+
+const PROD_ENV_KEY = 'LLXPRT_DISABLE_OS_KEYRING';
+const TEST_ENV_KEY = 'LLXPRT_TEST_DISABLE_OS_KEYRING';
+
+// Boundary double for @napi-rs/keyring so the "not opted out" cases are
+// deterministic: when the opt-out does NOT fire, the factory proceeds to
+// import @napi-rs/keyring and must produce an adapter. The real module may be
+// absent or may touch the developer's real keychain, so a fake guarantees that
+// "not opted out" is observable as a non-null adapter without side effects.
+mock.module('@napi-rs/keyring', () => ({
+  AsyncEntry: class {
+    async getPassword(): Promise<string | null> {
+      return 'mocked-value';
+    }
+    async setPassword(): Promise<void> {}
+    async deleteCredential(): Promise<boolean> {
+      return false;
+    }
+  },
+}));
+
+describe('LLXPRT_DISABLE_OS_KEYRING production opt-out (issue #3020)', () => {
+  const originalProd = process.env[PROD_ENV_KEY];
+  const originalTest = process.env[TEST_ENV_KEY];
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prod-disable-'));
+    // Both OS-keyring env vars are cleared so no case can be trivially
+    // satisfied by a pre-set test marker, and so nothing leaks between cases.
+    delete process.env[PROD_ENV_KEY];
+    delete process.env[TEST_ENV_KEY];
+  });
+
+  afterEach(async () => {
+    if (originalProd === undefined) {
+      delete process.env[PROD_ENV_KEY];
+    } else {
+      process.env[PROD_ENV_KEY] = originalProd;
+    }
+    if (originalTest === undefined) {
+      delete process.env[TEST_ENV_KEY];
+    } else {
+      process.env[TEST_ENV_KEY] = originalTest;
+    }
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('produces no keyring adapter when LLXPRT_DISABLE_OS_KEYRING=1 (case 15)', async () => {
+    process.env[PROD_ENV_KEY] = '1';
+
+    expect(await createDefaultKeyringAdapter()).toBeNull();
+  });
+
+  it('round-trips SecureStore through the encrypted fallback when LLXPRT_DISABLE_OS_KEYRING=1 (case 16)', async () => {
+    process.env[PROD_ENV_KEY] = '1';
+
+    const store = new SecureStore('prod-disable-test', {
+      fallbackDir: tempDir,
+      lockDir: path.join(tempDir, 'locks'),
+      fallbackPolicy: 'allow',
+      machineSecretLoader: async () => Buffer.from('test-machine-secret'),
+    });
+
+    await store.set('token', 'super-secret');
+
+    expect(await store.get('token')).toBe('super-secret');
+    // Proves the value went to the encrypted file rather than the OS keychain.
+    const encrypted = await fs.readFile(
+      path.join(tempDir, 'token.enc'),
+      'utf8',
+    );
+    expect(encrypted).not.toContain('super-secret');
+  });
+
+  it('produces an adapter for 0, empty, and true — only exactly 1 opts out (case 17)', async () => {
+    // '0', the empty string, and 'true' must NOT opt out: only the exact
+    // string '1' does, matching the existing test-marker convention. The test
+    // marker is cleared in beforeEach, so these reach the real factory check.
+    process.env[PROD_ENV_KEY] = '0';
+    expect(await createDefaultKeyringAdapter()).not.toBeNull();
+
+    delete process.env[PROD_ENV_KEY];
+    expect(await createDefaultKeyringAdapter()).not.toBeNull();
+
+    process.env[PROD_ENV_KEY] = 'true';
+    expect(await createDefaultKeyringAdapter()).not.toBeNull();
+
+    // Contrast: exactly '1' opts out.
+    process.env[PROD_ENV_KEY] = '1';
+    expect(await createDefaultKeyringAdapter()).toBeNull();
+  });
+
+  it('a deny policy still rejects with UNAVAILABLE when opted out (case 18)', async () => {
+    process.env[PROD_ENV_KEY] = '1';
+
+    const store = new SecureStore('prod-disable-deny-test', {
+      fallbackDir: tempDir,
+      lockDir: path.join(tempDir, 'locks'),
+      fallbackPolicy: 'deny',
+      machineSecretLoader: async () => Buffer.from('test-machine-secret'),
+    });
+
+    let caught: unknown;
+    try {
+      await store.set('token', 'super-secret');
+    } catch (error) {
+      caught = error;
+    }
+    // The opt-out does not silently defeat a deny policy: set() raises
+    // UNAVAILABLE rather than writing a fallback file.
+    expect(caught).toBeInstanceOf(SecureStoreError);
+    if (caught instanceof SecureStoreError) {
+      expect(caught.code).toBe('UNAVAILABLE');
+    }
+  });
+});

--- a/project-plans/issue3020/PLAN.md
+++ b/project-plans/issue3020/PLAN.md
@@ -1,0 +1,424 @@
+# PLAN-20260805-ISSUE3020 — Sealed Keychain `change_acl` and the discarded "Always Allow" grant
+
+Issue: #3020 — Keychain items are created with the macOS-default ACL (empty
+`change_acl` trusted-application list), and no layer of the binding chain can
+supply a different one; the "Always Allow" grant fails to persist and the prompt
+recurs. This plan documents what the source establishes, stops short of
+asserting the unproven securityd discard mechanism, and breaks the silence.
+
+## 1. Root cause, confirmed in source
+
+The issue asked for the empty `change_acl` application list to be confirmed
+against source rather than inferred from behaviour. It has been. The write path
+is fully traced below; every link was read, not assumed.
+
+### 1.1 The call chain
+
+| Layer | Version | Code |
+| --- | --- | --- |
+| `packages/storage/src/secure-store/default-keyring-adapter.ts` | — | `new kr.AsyncEntry(service, account).setPassword(value)` |
+| `@napi-rs/keyring` | 1.3.0 | binding over `keyring-core` |
+| `apple-native-keyring-store` (`keychain` module) | 1.0.1 | `Cred::set_secret` |
+| `security-framework` (`os::macos::passwords`) | 3.7.0 | `SecKeychain::set_generic_password` → `add_generic_password` |
+| macOS Security.framework | OS | `SecKeychainAddGenericPassword` |
+
+`apple_native_keyring_store::keychain::Cred::set_secret`:
+
+    fn set_secret(&self, secret: &[u8]) -> Result<()> {
+        self.get_keychain()?
+            .set_generic_password(&self.service, &self.account, secret)
+            .map_err(decode_error)?;
+        Ok(())
+    }
+
+`security_framework::os::macos::passwords`, `SecKeychain::set_generic_password`
+and `add_generic_password`:
+
+    pub fn set_generic_password(&self, service: &str, account: &str, password: &[u8]) -> Result<()> {
+        match self.find_generic_password(service, account) {
+            Ok((_, mut item)) => item.set_password(password),
+            _ => self.add_generic_password(service, account, password),
+        }
+    }
+
+    pub fn add_generic_password(&self, service: &str, account: &str, password: &[u8]) -> Result<()> {
+        unsafe {
+            cvt(SecKeychainAddGenericPassword(
+                self.as_CFTypeRef() as *mut _,
+                service.len() as u32, service.as_ptr().cast(),
+                account.len() as u32, account.as_ptr().cast(),
+                password.len() as u32, password.as_ptr().cast(),
+                ptr::null_mut(),
+            ))?;
+        }
+        Ok(())
+    }
+
+### 1.2 The finding
+
+`SecKeychainAddGenericPassword` has **no `SecAccess` parameter**. Apple's own
+documentation for it states: *"This function sets the initial access rights for
+the new keychain item so that the application creating the item is given trusted
+access."* The `SecAccess` is synthesised by macOS, and the synthesised access is
+the standard default: one ACL entry authorising the data operations
+(`decrypt`, `derive`, `export_clear`, `export_wrapped`, `mac`, `sign`) with the
+creating application in its trusted-application list, plus the single required
+**owner** entry authorising `change_acl` with an **empty** trusted-application
+list.
+
+An empty list is not the same as a null list. Apple's
+`SecACLCreateWithSimpleContents` documentation is explicit: *"Set this parameter
+to `nil` to indicate that any app can use this item. Pass an empty array to
+indicate that there are no trusted apps."* The `applications (0)` form observed
+in the issue's `security dump-keychain -a` output is therefore the "no trusted
+apps" form: no application is trusted to amend the ACL **without user
+confirmation** (as distinct from a null list, which means any application may).
+
+**Conclusion for acceptance criterion 1.** The empty `change_acl`
+trusted-application list is **not** a hardening decision made by LLxprt,
+`@napi-rs/keyring`, `keyring-core`, `apple-native-keyring-store`, or
+`security-framework`. It is the macOS default `SecAccess` for every item created
+through `SecKeychainAddGenericPassword`, and every LLxprt credential item is
+created through exactly that call. The load-bearing, fully-proven finding is
+that no layer of the dependency chain exposes any way to supply a different
+`SecAccess`, so LLxprt cannot construct or repair the ACL of these items from
+TypeScript (see 1.3).
+
+### 1.3 Why we cannot fix it at the ACL layer
+
+The issue's investigation item 2 asked whether items should be created with an
+explicit `SecAccess` that keeps `change_acl` amendable. The answer, from the
+same source reading, is that **there is no API path from TypeScript to do so**:
+
+- `security-framework`'s macOS module hardcodes `SecKeychainAddGenericPassword`
+  in `add_generic_password`. It exposes no variant taking a `SecAccess`, and no
+  `kSecAttrAccess` pass-through.
+- `apple-native-keyring-store` calls `set_generic_password` with no access
+  argument and offers no configuration key for one; its only configuration key
+  is `keychain` (which of the four keychain domains to use).
+- `@napi-rs/keyring`'s `AsyncEntry` surface is `getPassword` / `setPassword` /
+  `deleteCredential`. It has no access-control surface at all.
+
+Constructing a custom `SecAccess` would require a native change in
+`security-framework` (or replacing the binding outright). That is a dependency
+decision of the same class already deferred in #3011, and it is **out of scope
+here**. Investigation item 3 (identity requirement versus cdhash pinning) is
+likewise unreachable: the trusted-application entries are appended by
+`securityd`, not by us, and we cannot choose the requirement form it stores.
+
+### 1.4 What is established and what is not
+
+The source chain establishes the structural fact above (1.1–1.3): every item is
+created with the macOS-default ACL, and that ACL cannot be repaired from
+TypeScript. It does **not** establish the exact `securityd` mechanism by which
+an observed "Always Allow" grant fails to persist. Apple's `SecAccessCreate`
+documentation says the owner ACL's empty application list means the **user is
+prompted for permission** when the access instance is changed — not that the
+change is impossible — and Apple's Access Control Lists documentation says
+"Always Allow" adds the app to the restricted entry's trusted list. Asserting
+that the empty list is *the proven cause* of the discarded grant would
+over-read those documents. Confirming the mechanism would require a native ACL
+inspection of the item immediately before and after a grant; this work does not
+perform that inspection and does not assert the mechanism.
+
+### 1.5 What is therefore left, and it is the real defect
+
+The issue's own failure sequence names step 5 as the defect: *"The grant is
+silently discarded. Nothing is written, and no error surfaces to the user or to
+SecureStore."* This plan does not claim to stop the discard. It **can** stop the
+silence, and it can give the user a way out. That is what this plan delivers.
+
+## 2. Accepted behavior
+
+**AB1 — The source-confirmed root cause is documented.**
+Section 1 of this plan is the authoritative record. `docs/troubleshooting.md`
+carries the user-facing summary.
+
+**AB2 — Repeated interactive Keychain authorization is no longer silent.**
+A new dependency-leaf module observes every OS-keyring credential read that the
+default adapter performs. A read that *succeeds* but takes longer than the
+interactive-authorization threshold is recorded as an authorization event for
+that credential. A **second** such event for the **same** credential that
+**began after** the first completed is a symptom consistent with a grant that
+did not persist. This is a heuristic with a known false-positive envelope (a
+pathologically slow but non-interactive keychain), not proof of the discard
+mechanism, which this work does not establish (see 1.4).
+
+Rationale for this signal, and why there is no better one: the binding erases
+`OSStatus` (#3011), `securityd` handles the ACL append internally and returns
+the secret regardless, and the ACL is not readable from the binding. The
+monotonic-clock duration of a *successful* read is the only in-process
+observable that distinguishes "authorised without interaction" from "a human was
+made to authorise this". What narrows the envelope: darwin-only, strictly
+greater than the threshold, correlation by the **same** credential,
+non-overlapping reads only (the second must begin at or after the first
+completed), and two events rather than one. The consequence is bounded — one
+stderr notice and a predicate; credential access is never blocked and no data is
+changed.
+
+**AB3 — Exactly one actionable diagnostic is emitted, and it never breaks
+credential access.**
+On the transition to the broken state, one warning block is written to stderr
+and never repeated for the lifetime of the process. It describes the
+observation and its consequence (the same credential is being re-authorized
+after it was already authorized this session, so the grant is not persisting),
+names the remedies, and references issue 3020. It does not assert a proven
+cause. Nothing throws; `get()` still returns the credential it just read.
+
+**AB4 — A supported recovery path that does not require deleting keychain
+items.**
+Setting `LLXPRT_DISABLE_OS_KEYRING=1` makes `createDefaultKeyringAdapter()`
+return `null` in production. Every credential consumer — `SecureStore`,
+`machine-secret`, and MCP `KeychainTokenStorage` — obtains its adapter from that
+one factory, so the single check covers all of them, and all credential traffic
+routes to the existing encrypted-file fallback. Existing Keychain items are left
+untouched: nothing is deleted and nothing is migrated.
+
+**AB5 — The recovery procedure is documented.**
+`docs/troubleshooting.md` gains the procedure in the existing macOS Keychain
+section, adjacent to the #3021 ad-hoc-Bun guidance, and states plainly that this
+is the interim escape hatch pending the full keyring opt-out tracked in #2928.
+
+**AB6 — Behavioral test evidence exists for every accepted behavior above.**
+
+### Explicitly out of scope
+
+- Constructing a custom `SecAccess`, or vendoring/patching/replacing
+  `@napi-rs/keyring`, `apple-native-keyring-store`, or `security-framework`.
+- The full #2928 work: native `OSStatus` fidelity, the setter-fallthrough fix,
+  the session-level "keyring is unusable this session" state transition, and a
+  settings-file (non-environment) opt-out. `LLXPRT_DISABLE_OS_KEYRING` here is
+  the narrow recovery lever #3020 requires, not #2928's design.
+- Migrating existing Keychain credentials into the fallback store.
+- Any change to the #3021 launcher warning.
+- Any change to `deletePassword` / `verifyKeyringDelete` (#3011) or to
+  `verifyKeyringWrite` (#2927).
+
+## 3. Inputs and boundary cases
+
+| Input | Accepted result |
+| --- | --- |
+| Platform is darwin; one successful keyring read exceeds the threshold | No warning. A single authorization is normal. |
+| Platform is darwin; a second slow successful read of the **same** credential that **began after** the first completed | Broken state becomes true; exactly one warning block on stderr. |
+| Platform is darwin; two slow successful reads of **different** credentials | No warning. Different credentials never correlate. |
+| Platform is darwin; two slow successful reads of the same credential that **overlap** (the second began before the first completed) | No warning. Concurrent first reads prove nothing. |
+| Platform is darwin; a third and further slow successful reads | State stays true; **no** further warning. |
+| Read duration exactly equals the threshold | Not an authorization event (strictly greater than). |
+| Slow read that returns `null` | Not an authorization event. Absence is not a granted authorization. |
+| Slow read that throws | Not an authorization event, and the rejection propagates unchanged. |
+| Only fast reads, any number | Never warns. |
+| Platform is not darwin | Never observes and never warns, whatever the durations. |
+| `LLXPRT_DISABLE_OS_KEYRING=1` | `createDefaultKeyringAdapter()` resolves `null`; `SecureStore` round-trips through the encrypted file; no keychain item is deleted. |
+| `LLXPRT_DISABLE_OS_KEYRING` unset, empty, `0`, or `true` | Adapter is created normally. Only the exact string `1` opts out, matching the existing `LLXPRT_TEST_DISABLE_OS_KEYRING` convention. |
+| `LLXPRT_DISABLE_OS_KEYRING=1` with `fallbackPolicy: 'deny'` | Existing deny semantics are unchanged: `set()` raises `UNAVAILABLE`. The opt-out does not silently defeat a deny policy. |
+| Runtime already replaced (#2926) | Unchanged. `RUNTIME_REPLACED` still fires first, before any observation. |
+
+## 4. Design
+
+### 4.1 New leaf module: `packages/storage/src/secure-store/keychain-grant-persistence.ts`
+
+A dependency leaf, mirroring the established `runtime-replaced-errors.ts` and
+`runtime-identity.ts` conventions (process-wide state, one-time stderr warning,
+injectable seam so the behavior is testable on every CI platform).
+
+    export const INTERACTIVE_AUTH_THRESHOLD_MS = 1500;
+    export const GRANT_NOT_PERSISTING_MESSAGE: string;
+    export const GRANT_NOT_PERSISTING_REMEDIATION: string;
+
+    export interface KeyringReadObservation {
+      /** Opaque correlation key for the credential. Map key only; never logged. */
+      readonly credentialKey: string;
+      /** Monotonic ms (performance.now) when the native read started. */
+      readonly startedAt: number;
+      /** Monotonic ms (performance.now) when the native read completed. */
+      readonly endedAt: number;
+    }
+
+    /** Records a successful keyring read, correlated by credential. */
+    export function recordAuthorizedKeyringRead(observation: KeyringReadObservation): void;
+
+    export function isKeychainGrantPersistenceBroken(): boolean;
+
+    // Test seams
+    export function resetKeychainGrantPersistenceForTesting(): void;
+    export function setKeychainGrantPersistencePlatformForTesting(
+      platform: NodeJS.Platform | null,
+    ): void;
+
+Behavior:
+
+- Observations are ignored entirely unless the effective platform is `darwin`.
+- Once broken, the state is terminal and no further work is done.
+- An observation counts only when `endedAt - startedAt > INTERACTIVE_AUTH_THRESHOLD_MS`.
+- Observations are correlated by `credentialKey` in a module-private
+  `Map<string, number>` holding the `endedAt` of each credential's last
+  interactive read. A credential's *first* interactive read is normal and is
+  merely recorded. A *second* interactive read of the **same** credential counts
+  as the discarded-grant event **only if** it began at or after the first
+  completed (`startedAt >= previousEndedAt`); overlapping/concurrent reads prove
+  nothing and leave the stored value unchanged.
+- On the counted event the state flips to broken **once**, the map is cleared,
+  and the warning is emitted **once**, to `process.stderr.write`, wrapped in the
+  same defensive `try`/`catch` `runtime-replaced-errors.ts` uses for EPIPE.
+  Losing the notice must never break the credential read.
+- The map is bounded by `MAX_TRACKED_CREDENTIALS = 256`. Before inserting a
+  brand-new key, if the map is full it is cleared first: the tracker only holds
+  credentials that had exactly one interactive read, entries are only useful for
+  short-range correlation, and clearing at worst loses a first observation
+  (biasing toward NOT warning — the safe direction).
+
+Threshold and the cap are module constants, not configuration. No new setting.
+
+### 4.2 `default-keyring-adapter.ts`
+
+`getPassword` times the native call with a monotonic clock and reports it:
+
+    getPassword: async (service, account) => {
+      const entry = new kr.AsyncEntry(service, account);
+      const startedAt = performance.now();
+      const value = await entry.getPassword();
+      if (value !== null) {
+        recordAuthorizedKeyringRead({
+          credentialKey: `${service}\u0000${account}`,
+          startedAt,
+          endedAt: performance.now(),
+        });
+      }
+      return value;
+    },
+
+`performance.now()` is monotonic (unlike `Date.now()`, which NTP steps and
+sleep/wake can move). A rejection propagates without being recorded, because
+the `await` throws before the record call is reached. This is the only
+production timing site, so the observation covers `SecureStore`,
+`machine-secret`, and MCP alike. The correlation key is an opaque `Map` key
+only — never logged or interpolated into any message.
+
+The production opt-out sits beside the existing test marker:
+
+    const DISABLE_OS_KEYRING_ENV = 'LLXPRT_DISABLE_OS_KEYRING';
+    // returns null before the dynamic import, exactly like the test marker
+
+### 4.3 `secure-store.ts`
+
+Minimal: one public accessor so the condition genuinely surfaces at the
+`SecureStore` boundary named in the acceptance criteria.
+
+    isKeychainGrantPersistenceBroken(): boolean {
+      return isKeychainGrantPersistenceBroken();
+    }
+
+No control-flow change. No new error code. No throw. `secure-store.ts` is close
+to the 800-line `max-lines` ceiling, so nothing else is added there and the
+threshold is **not** to be raised.
+
+### 4.4 Package exports
+
+`packages/storage/src/index.ts` re-exports
+`isKeychainGrantPersistenceBroken` and the two message constants. Nothing else
+new becomes public.
+
+## 5. Test-first evidence
+
+All new and changed tests use Bun and `bun:test` only. No Vitest, no new `.js`
+files. New Bun test files must be registered in
+`scripts/bun-test-manifest-data-storage.ts` or CI will not run them.
+
+New file: `packages/storage/test-bun/keychain-grant-persistence.bun.ts`
+
+RED-first, behavioral, no mock-interaction assertions (no call counters, no spy
+argument inspection). Assert observable outcomes: the predicate's value and the
+stderr text. The deterministic clock uses `performance.now` to match production.
+
+1. One slow successful read → predicate false, stderr silent.
+2. Two slow successful reads of the **same** credential that are **sequential**
+   → predicate true; stderr carries exactly one warning block describing the
+   observation, naming both remedies, and referencing #3020.
+3. A third and fourth slow read → predicate still true, stderr unchanged from
+   case 2 (once per process).
+4. Duration exactly at the threshold, twice → predicate false.
+5. Fast reads only, many → predicate false.
+6. Non-darwin effective platform, many slow reads → predicate false, stderr
+   silent.
+7. Two slow successful reads of **different** credential keys → predicate false
+   (different credentials never correlate).
+8. Two slow successful reads of the same credential key that **overlap** (the
+   second's `startedAt` is before the first's `endedAt`) → predicate false.
+9. A third credential reaching its first interactive read after the state is
+   already broken → predicate stays true, stderr unchanged.
+10. Adapter-level, against the fake `@napi-rs/keyring` module: two slow
+    sequential successful reads of the SAME service+account through
+    `createDefaultKeyringAdapter()` → predicate true and the value is still
+    returned to the caller on both reads.
+11. Adapter-level: two slow reads of DIFFERENT accounts on the same service →
+    predicate false.
+12. Adapter-level: a slow `getPassword` resolving `null`, twice → predicate false.
+13. Adapter-level: a slow `getPassword` that rejects, twice → the rejection
+    propagates unchanged and the predicate stays false.
+14. `SecureStore` surface: with the same fake adapter, after the second slow
+    `get()` the store's accessor reports broken and `get()` still returned the
+    stored value both times.
+
+New file: `packages/storage/test-bun/keyring-opt-out.bun.ts` (the
+`LLXPRT_DISABLE_OS_KEYRING` opt-out cases — see FIX 4; moved out of the Vitest
+suite):
+
+15. `LLXPRT_DISABLE_OS_KEYRING=1` → `createDefaultKeyringAdapter()` resolves
+    `null`.
+16. `LLXPRT_DISABLE_OS_KEYRING=1` → `SecureStore` set/get round-trips through
+    the encrypted fallback file, and the ciphertext on disk does not contain the
+    plaintext.
+17. `LLXPRT_DISABLE_OS_KEYRING` set to `0`, empty, and `true` → an adapter is
+    still produced (only exactly `1` opts out).
+18. `LLXPRT_DISABLE_OS_KEYRING=1` with `fallbackPolicy: 'deny'` → `set()`
+    rejects with a `SecureStoreError` whose code is `UNAVAILABLE`.
+
+Regression guard: the existing `LLXPRT_TEST_DISABLE_OS_KEYRING`,
+runtime-replaced, write-verification, and delete-verification suites must stay
+green and unmodified.
+
+Every new test must be run and observed to FAIL before the implementation lands,
+and the RED observation recorded.
+
+## 6. Documentation
+
+`docs/troubleshooting.md`, inside the existing
+"macOS: Repeated Keychain Password Prompts" section:
+
+- The source-confirmed root cause from section 1, condensed: the item's ACL is
+  the macOS default from `SecKeychainAddGenericPassword`, its `change_acl` entry
+  trusts no application, and no layer of the binding chain can supply a
+  different one.
+- The new runtime diagnostic: what the warning means when it appears.
+- The recovery procedure: `export LLXPRT_DISABLE_OS_KEYRING=1`, what it does
+  (encrypted-file fallback in the OS data directory), what it costs
+  (re-authenticate once; keys already in the Keychain are not migrated), and
+  that existing Keychain items are left in place rather than deleted.
+- A note that this is the interim escape hatch and that #2928 tracks the full
+  opt-out.
+
+## 7. Verification gates
+
+- The focused new Bun suites, RED before and GREEN after.
+- `npm run test`
+- `npm run lint`
+- `npm run lint:eslint-guard`
+- `npm run typecheck`
+- `npm run format`
+- `npm run build`
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+- DeepThinker review and Open Code Review, every finding classified
+  Blocker-Fix / In-scope-Fix / Reject / Defer.
+- PR checks green on the candidate head, threads resolved or explicitly deferred
+  for user judgment, branch conflict-free on current `origin/main`.
+
+## 8. Guardrails
+
+- No `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `@ts-nocheck`, severity
+  downgrade, or complexity/size threshold increase. Fix the cause instead.
+  Enforced by `scripts/check-eslint-guard.js`.
+- No new `.js` files; no Vitest/Node test suites added or modified.
+- No dependency change, workflow change, or `.llxprt/` modification.
+- No adjacent refactor of `secure-store.ts`, the fallback envelope, the write or
+  delete verification paths, or the launcher.
+- Plan documents live under `project-plans/`, never `dev-docs/`.

--- a/scripts/bun-test-manifest-data-storage.ts
+++ b/scripts/bun-test-manifest-data-storage.ts
@@ -12,6 +12,8 @@ export const STORAGE_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
   files: [
     'test-bun/credential-write-lock.bun.ts',
     'test-bun/keyring-delete-verification.bun.ts',
+    'test-bun/keychain-grant-persistence.bun.ts',
+    'test-bun/keyring-opt-out.bun.ts',
     'test-bun/keyring-write-verification.bun.ts',
     'test-bun/machine-secret.bun.ts',
     'test-bun/machine-secret.concurrent-write.bun.ts',


### PR DESCRIPTION
## TLDR

macOS Keychain items written by LLxprt carry an ACL whose `change_acl` owner entry has an **empty** trusted-application list. When the runtime's code identity changes, the user is prompted for their login password on every credential read, clicking **Always Allow** appears to work, and nothing is persisted — with no error surfaced to the user or to `SecureStore`. That silence is the defect this PR closes.

Two things land:

1. **The recurring prompt is no longer silent.** A new dependency-leaf module in `packages/storage` observes successful OS-keyring reads. When the **same** credential is authorized interactively a second time — in a read that *began after* the earlier authorization had already completed — the process enters a terminal state and writes exactly one actionable notice to stderr. Credential access is never blocked; the read that triggers the notice still returns its value.
2. **There is a supported way out.** `LLXPRT_DISABLE_OS_KEYRING=1` makes `createDefaultKeyringAdapter()` return `null` before the native module is even imported, routing `SecureStore` credentials to the existing encrypted-file fallback. Existing Keychain items are left in place — nothing is deleted and nothing is migrated.

**What reviewers should look at most closely:**

- **The detector is a heuristic, and the code says so.** Wall-clock duration of a *successful* read is the only in-process signal that distinguishes "authorized without interaction" from "a human was asked to authorize this". It is not proof, and neither the module docblock nor the user-facing message claims otherwise.
- **The root cause is deliberately under-claimed.** See "Dive Deeper" — the source chain is fully established, the securityd mechanism is not, and the plan and docs say which is which.
- **The escape hatch has real limitations**, all four documented in `docs/troubleshooting.md` rather than papered over.

## Dive Deeper

### Root cause: what the source establishes

The write path was traced end to end, reading each layer rather than inferring:

| Layer | Version | Call |
| --- | --- | --- |
| `default-keyring-adapter.ts` | — | `new AsyncEntry(service, account).setPassword(value)` |
| `@napi-rs/keyring` | 1.3.0 | binding over `keyring-core` |
| `apple-native-keyring-store` (`keychain`) | 1.0.1 | `Cred::set_secret` |
| `security-framework` (`os::macos::passwords`) | 3.7.0 | `SecKeychain::set_generic_password` -> `add_generic_password` |
| macOS Security.framework | OS | `SecKeychainAddGenericPassword` |

`SecKeychainAddGenericPassword` takes **no** `SecAccess` parameter, so the item's ACL is whatever macOS synthesizes by default. That default carries the required owner entry authorizing `change_acl` with an empty trusted-application list, which per Apple's `SecACLCreateWithSimpleContents` documentation means no application is trusted to amend the ACL **without user confirmation** — as distinct from a null list, which means any application may.

The load-bearing, fully-proven finding is the last one: **no layer of that chain exposes any way to supply a different `SecAccess`.** `security-framework` hardcodes `SecKeychainAddGenericPassword` in `add_generic_password` and offers no `kSecAttrAccess` pass-through; `apple-native-keyring-store`'s only configuration key is which keychain domain to use; `@napi-rs/keyring`'s surface is `getPassword` / `setPassword` / `deleteCredential` with no access-control API at all. The ACL therefore cannot be constructed or repaired from TypeScript, which closes out investigation items 2 and 3 in the issue: we cannot choose the `SecAccess`, and we cannot choose whether securityd stores an identity requirement or a cdhash.

**What is deliberately NOT claimed:** that the empty `change_acl` list is the proven mechanism by which the grant is discarded. Apple documents that empty owner list as requiring user confirmation, not as making the change impossible. Establishing the actual securityd behaviour would require native ACL inspection of an item immediately before and after a grant, which this change does not do. `project-plans/issue3020/PLAN.md` section 1, the module docblock, and `docs/troubleshooting.md` all state this explicitly rather than papering over it.

### The detector

`packages/storage/src/secure-store/keychain-grant-persistence.ts` is a dependency leaf modelled on the existing `runtime-replaced-errors.ts` / `runtime-identity.ts` conventions: process-wide terminal state, a once-per-process stderr notice with the same EPIPE-safe write, and an injectable platform seam so the darwin-only behaviour is exercisable on every CI platform.

`default-keyring-adapter.ts` times the native read with `performance.now()` (monotonic — `Date.now()` can manufacture or erase a gap across an NTP step or sleep/wake) and records an observation only when the read returned a value. Absence and failure are not granted authorizations, and a rejection propagates untouched because the `await` throws before the record call.

An event is counted only when **all** of these hold:

- the platform is darwin;
- the duration is **strictly** greater than `INTERACTIVE_AUTH_THRESHOLD_MS` (1500);
- it is the **second** interactive read of the **same** credential, correlated by an opaque `service\0account` map key;
- that second read **began at or after** the first one completed — overlapping/concurrent first reads prove nothing, because neither could have benefited from the other's grant.

The correlation map is bounded at 256 entries and cleared when full; clearing at worst loses a first observation, which biases toward *not* warning — the safe direction. It is also cleared once the terminal state is reached, since it is no longer needed.

Requiring the same credential twice, non-overlapping, is what rules out the obvious false positives: two different credentials each prompting once, the `isKeychainAvailable()` probe (which uses a random account and so can never accumulate), and concurrent in-flight reads at startup. What it does **not** rule out is a pathologically slow but non-interactive keychain. The blast radius of a false positive is bounded to one stderr line and a boolean: nothing throws, nothing is stored differently, and the credential is still returned.

### The escape hatch, and its limits

`LLXPRT_DISABLE_OS_KEYRING=1` is checked in `createDefaultKeyringAdapter()` before the dynamic import. Every keyring consumer — `SecureStore`, `machine-secret`, and MCP `KeychainTokenStorage` — obtains its adapter from that one factory, so a single check covers all of them. Only the exact string `1` opts out, matching the existing `LLXPRT_TEST_DISABLE_OS_KEYRING` convention (which is kept separate and untouched: it exists for suite isolation).

Four limitations were verified in source and are documented rather than hidden:

- **MCP server OAuth is not covered.** `MCPOAuthTokenStorage` defaults to `KeychainTokenStorage`, which throws `Keychain is not available` when the factory returns null. This is the same pre-existing limitation that already applies on hosts with no keyring at all (headless Linux, containers). Fixing MCP's storage selection is out of scope here.
- **`fallbackPolicy: 'deny'` still fails**, by design — the opt-out must not silently defeat a deny policy. There is a test for this.
- **The machine secret can change.** When it lives only in the Keychain, disabling the keyring makes machine-secret resolution fall through to the file path and generate a different secret, so existing `v:2` fallback files fail to decrypt with a loud `CORRUPT` error. Hence the guidance to set the variable persistently rather than toggling it per-invocation.
- **Re-enabling reads the Keychain first**, so a credential re-authenticated while opted out is silently shadowed by the older Keychain value. This one is silent, which is the other reason to treat the variable as persistent.

This is explicitly the *interim* escape hatch. The full settings-driven opt-out with reconciliation remains #2928's design problem; this PR does not attempt it.

### Deliberately out of scope

Constructing a custom `SecAccess`; vendoring, patching or replacing `@napi-rs/keyring` / `apple-native-keyring-store` / `security-framework`; the rest of #2928 (native `OSStatus` fidelity, setter fallthrough, session-level degrade, settings-file opt-out); migrating existing Keychain credentials into the fallback store; and any change to the #3021 launcher warning, `verifyKeyringWrite` (#2927), or `verifyKeyringDelete` (#3011).

### Review history

Reviewed by DeepThinker and by Open Code Review. Every finding was triaged. Fixed: the over-claimed root cause (rewritten in all three places), the uncorrelated process-global counter (now keyed by credential and non-overlapping), the non-monotonic clock, opt-out cases that had been added to a Vitest suite that is not in the Bun manifest (moved to a registered `bun:test` file, the Vitest file restored byte-identical to HEAD), the four false promises in the docs, and a test that claimed to cover the empty-string env value but actually deleted the variable. Rejected with reasons: removing the detector outright (no other in-process observable exists), a macOS-native ACL integration fixture (not runnable in CI), and narrowing the stderr `catch` (it intentionally mirrors `emitRuntimeReplacedWarning` — losing a notice is acceptable, breaking the credential read that triggered it is not). Deferred to #2928: a reconciling opt-out design.

## Reviewer Test Plan

**Automated** — 18 behavioral cases, Bun + `bun:test`, both files registered in `scripts/bun-test-manifest-data-storage.ts`:

```bash
cd packages/storage
bun test --preload test-setup-storage-isolation.ts \
  ./test-bun/keychain-grant-persistence.bun.ts \
  ./test-bun/keyring-opt-out.bun.ts
```

Cases 1-9 drive the leaf module directly (single slow read is a non-event; two sequential slow reads warn once; further reads never re-warn; exactly-at-threshold never counts; fast reads never count; non-darwin never observes; **different credentials never combine**; **overlapping reads never count**). Cases 10-14 drive the real `createDefaultKeyringAdapter()` against a fake `@napi-rs/keyring` whose read duration and return value are independently controllable, plus the `SecureStore` surface. Cases 15-18 cover the opt-out, including the deny-policy boundary.

The adapter cases advance a controllable `performance.now` offset rather than sleeping, so the suite is deterministic and fast; the real function is restored in `afterEach`.

**Manual, on macOS** — recovery path:

```bash
export LLXPRT_DISABLE_OS_KEYRING=1
llxprt   # re-authenticate once
ls ~/Library/Application\ Support/llxprt-code/secure-store/   # .enc files appear
security find-generic-password -s llxprt-code-oauth           # Keychain item still present
```

Confirm the credential round-trips, the `.enc` ciphertext does not contain the plaintext, and no Keychain item was deleted. Then confirm only `1` opts out: `LLXPRT_DISABLE_OS_KEYRING=0` (and `''`, and unset) must still use the Keychain.

**Manual** — the diagnostic itself requires a machine that actually reproduces the prompt storm (an ad-hoc-signed Bun on `PATH`, per #3021). On such a machine, two prompted reads of the same credential should produce exactly one stderr notice naming both remedies, and credential access should keep working.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test` (storage 36/36 isolated Bun files, 0 failures), `npm run lint`, `npm run lint:eslint-guard`, `npm run typecheck`, `npm run format`, `npm run build`, and the `stepfun-37` smoke test — all exit 0.

The detector is darwin-gated in production but its behaviour is fully exercised on Linux and Windows CI through the injectable platform seam, so the new suites are not macOS-only.

Two unrelated local failures were investigated rather than waved away. `packages/test-utils/src/interactive-run.test.ts` fails identically (10 pass / 1 fail) on a clean `origin/main` checkout — pre-existing. The remaining failures were timeouts whose failing set differed completely between two runs of the same commit and which pass in isolation; none of them import anything this PR touches, and the storage workspace was green in every run.

## Linked issues / bugs

Fixes #3020

Related: #3021 (the launcher warning for an ad-hoc `PATH` Bun, whose remedy this diagnostic repeats), #2962 (the change that exposed this), #2928 (the full keyring opt-out this escape hatch is an interim stand-in for), #3011 (the `OSStatus` erasure that makes a behavioural signal the only option).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection and diagnostics for macOS Keychain permissions that fail to persist.
  - Added `LLXPRT_DISABLE_OS_KEYRING=1` to use encrypted-file credential storage instead of the OS keyring.
  - Exposed Keychain grant status through the storage API.

- **Documentation**
  - Expanded troubleshooting guidance for Keychain authorization prompts, fallback storage, persistence, and limitations.

- **Tests**
  - Added coverage for Keychain diagnostics, fallback behavior, authorization policies, and encrypted storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->