### PR TITLE
Advise the model to retry differently after a tool-content 400 (Fixes #2722)

### DIFF
--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -66,7 +66,7 @@ export interface MessageStreamDeps {
     prompt_id: string,
     turns?: number,
     isInvalidStreamRetry?: boolean,
-    is413Retry?: boolean,
+    isPayloadRecoveryRetry?: boolean,
   ) => AsyncGenerator<ServerAgentStreamEvent, Turn>;
   createTurn?: (
     chat: ChatSession,
@@ -83,7 +83,7 @@ export interface StreamContext {
   signal: AbortSignal;
   turns: number;
   isInvalidStreamRetry: boolean;
-  is413Retry: boolean;
+  isPayloadRecoveryRetry: boolean;
 }
 
 export interface IterationResult {
@@ -146,7 +146,7 @@ export class MessageStreamOrchestrator {
     prompt_id: string,
     turns: number,
     isInvalidStreamRetry: boolean,
-    is413Retry: boolean = false,
+    isPayloadRecoveryRetry: boolean = false,
   ): AsyncGenerator<ServerAgentStreamEvent, Turn> {
     this.deps.logger.debug(() => 'DEBUG: AgentClient.sendMessageStream called');
 
@@ -162,7 +162,7 @@ export class MessageStreamOrchestrator {
       signal,
       turns,
       isInvalidStreamRetry,
-      is413Retry,
+      isPayloadRecoveryRetry,
     };
 
     const request = yield* this._preflight(narrowedRequest, ctx);

--- a/packages/agents/src/core/MessageStreamTerminalHandler.ts
+++ b/packages/agents/src/core/MessageStreamTerminalHandler.ts
@@ -12,6 +12,13 @@ import {
   type StreamContext,
 } from './MessageStreamOrchestrator.js';
 import { AgentEventType, type ServerAgentStreamEvent } from './turn.js';
+import {
+  buildToolContentRejectionAdvice,
+  describeRejectedPayload,
+  extractToolNamesFromRequest,
+  isToolContentRejection,
+  type RejectedPayloadDescription,
+} from './toolContentRejection.js';
 
 interface TerminalState {
   hadToolCallsThisTurn: boolean;
@@ -64,53 +71,6 @@ async function* fireAfterHookAndEmitClearContext(
   }
 }
 
-/**
- * Extracts a tool name from a single request part in neutral or legacy form.
- *
- * Recognizes:
- * - Neutral `tool_response`: `{ type: 'tool_response', toolName }`
- * - Neutral `tool_call`: `{ type: 'tool_call', name }`
- * - Legacy Google `functionResponse`: `{ functionResponse: { name } }`
- *
- * Returns the extracted name, or `undefined` if the part is not a
- * tool-response/tool-call shape.
- */
-function extractToolName(part: unknown): string | undefined {
-  if (part == null || typeof part !== 'object') return undefined;
-  const obj = part as Record<string, unknown>;
-
-  if (obj['type'] === 'tool_response') {
-    const toolName = obj['toolName'];
-    if (typeof toolName === 'string' && toolName.length > 0) return toolName;
-    return undefined;
-  }
-
-  if (obj['type'] === 'tool_call') {
-    const name = obj['name'];
-    if (typeof name === 'string' && name.length > 0) return name;
-    return undefined;
-  }
-
-  if ('functionResponse' in obj) {
-    const funcResp = obj['functionResponse'] as { name?: string } | undefined;
-    if (funcResp?.name) return funcResp.name;
-  }
-
-  return undefined;
-}
-
-function extractToolNamesFromRequest(request: AgentMessageInput): string[] {
-  if (!Array.isArray(request)) return [];
-  const names = new Set<string>();
-  for (const rawPart of request) {
-    const name = extractToolName(rawPart);
-    if (name !== undefined) {
-      names.add(name);
-    }
-  }
-  return [...names];
-}
-
 async function* handle413Error(
   deps: MessageStreamDeps,
   ctx: StreamContext,
@@ -120,7 +80,7 @@ async function* handle413Error(
   signal: AbortSignal,
   boundedTurns: number,
 ): AsyncGenerator<ServerAgentStreamEvent, IterationResult | undefined> {
-  if (ctx.is413Retry) {
+  if (ctx.isPayloadRecoveryRetry) {
     deps.logger.warn(
       () =>
         `[stream:orchestrator] received repeated 413 after retry; ending iteration`,
@@ -166,7 +126,67 @@ async function* handle413Error(
   });
 }
 
-function getErrorStatus(event: ServerAgentStreamEvent): number | undefined {
+async function* handleToolContentRejection400(
+  deps: MessageStreamDeps,
+  ctx: StreamContext,
+  deferredEvents: ServerAgentStreamEvent[],
+  state: TerminalState,
+  description: RejectedPayloadDescription,
+  providerMessage: string,
+  signal: AbortSignal,
+  boundedTurns: number,
+): AsyncGenerator<ServerAgentStreamEvent, IterationResult | undefined> {
+  if (ctx.isPayloadRecoveryRetry) {
+    deps.logger.warn(
+      () =>
+        `[stream:orchestrator] received repeated tool-content 400 after retry; ending iteration`,
+      {
+        deferredEventCount: deferredEvents.length,
+        hadToolCallsThisTurn: state.hadToolCallsThisTurn,
+      },
+    );
+    for (const d of deferredEvents) yield d;
+    await fireAfterHook(deps, ctx);
+    return earlyIterResult(state.hadToolCallsThisTurn, {
+      ...state,
+      deferredEvents,
+    });
+  }
+
+  const advice = buildToolContentRejectionAdvice(description, providerMessage);
+  deps.logger.warn(
+    () =>
+      `[stream:orchestrator] retrying after tool-content rejection (HTTP 400)`,
+    {
+      toolNames: description.toolNames,
+      mediaDescriptors: description.mediaDescriptors,
+      deferredEventCount: deferredEvents.length,
+      hadToolCallsThisTurn: state.hadToolCallsThisTurn,
+    },
+  );
+  yield* deps.sendMessageStream(
+    [{ type: 'text', text: advice }],
+    signal,
+    ctx.prompt_id,
+    boundedTurns - 1,
+    false,
+    true,
+  );
+  await fireAfterHook(deps, ctx);
+  return earlyIterResult(state.hadToolCallsThisTurn, {
+    ...state,
+    deferredEvents,
+  });
+}
+
+/**
+ * Narrows the error payload carried by a terminal Error event. The payload
+ * originates from provider SDKs, so its shape is genuinely external and is
+ * validated structurally rather than trusted. Returns the narrowed value as a
+ * plain `object`; each field is read by the accessors below with an `in` plus
+ * `typeof` check, so no cast to an index-signature type is needed.
+ */
+function getErrorPayload(event: ServerAgentStreamEvent): object | undefined {
   if (!('value' in event)) {
     return undefined;
   }
@@ -180,7 +200,21 @@ function getErrorStatus(event: ServerAgentStreamEvent): number | undefined {
   if (errorValue == null || typeof errorValue !== 'object') {
     return undefined;
   }
-  return (errorValue as { status?: number }).status;
+  return errorValue;
+}
+
+function getErrorStatus(event: ServerAgentStreamEvent): number | undefined {
+  const payload = getErrorPayload(event);
+  if (payload === undefined || !('status' in payload)) return undefined;
+  const status = payload.status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+function getErrorMessage(event: ServerAgentStreamEvent): string | undefined {
+  const payload = getErrorPayload(event);
+  if (payload === undefined || !('message' in payload)) return undefined;
+  const message = payload.message;
+  return typeof message === 'string' ? message : undefined;
 }
 
 async function* handleErrorEvent(
@@ -193,6 +227,7 @@ async function* handleErrorEvent(
   initialRequest: AgentMessageInput,
 ): AsyncGenerator<ServerAgentStreamEvent, IterationResult | undefined> {
   const errorStatus = getErrorStatus(event);
+  const errorMessage = getErrorMessage(event);
   const { config } = deps;
   const boundedTurns = Math.min(ctx.turns, MAX_TURNS);
 
@@ -220,6 +255,34 @@ async function* handleErrorEvent(
       boundedTurns,
     );
     if (result) return result;
+  }
+
+  if (
+    isToolContentRejection(errorStatus, errorMessage) &&
+    config.getContinueOnFailedApiCall() &&
+    canRetryFailedStream(state)
+  ) {
+    // Issue #2722 is about tool-related 400s: recovery also requires that the
+    // failing request actually carried tool evidence (a tool_response or a
+    // media block), so a 400 caused by user-pasted content is not mistaken for
+    // rejected tool content.
+    const description = describeRejectedPayload(initialRequest);
+    if (
+      description.toolNames.length > 0 ||
+      description.mediaDescriptors.length > 0
+    ) {
+      const result = yield* handleToolContentRejection400(
+        deps,
+        ctx,
+        deferredEvents,
+        state,
+        description,
+        errorMessage ?? '',
+        signal,
+        boundedTurns,
+      );
+      if (result) return result;
+    }
   }
 
   deps.logger.warn(

--- a/packages/agents/src/core/client.sendMessageStream-toolContent400.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-toolContent400.test.ts
@@ -1,0 +1,617 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * sendMessageStream tests: HTTP 400 tool-content rejection recovery (issue #2722).
+ * Sibling to client.sendMessageStream-errors.test.ts (the 413 suite), modelled
+ * closely on its structure: same vi.mock preamble, same setupAgentClient helper.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from '../testApi.js';
+import { AgentClient } from './client.js';
+import type { ChatSession } from './chatSession.js';
+import { AgentEventType } from './turn.js';
+import {
+  fromAsync,
+  setupAgentClient,
+  type MockResponseShape,
+} from './client-test-helpers.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+
+const REJECTION_400_MESSAGE =
+  "The image data you provided does not represent a valid image. Please check your input and try again with one of the supported image formats: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].";
+
+// Mock prompts module before imports
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn(() =>
+    Promise.resolve('Test system instruction'),
+  ),
+  getCoreSystemPrompt: vi.fn(() => 'Test system instruction'),
+  getCompressionPrompt: vi.fn(() => 'Test compression prompt'),
+  initializePromptSystem: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+// Mock clientToolGovernance module so tests can control tool name/governance returns
+vi.mock('./clientToolGovernance.js', () => ({
+  getToolGovernanceEphemerals: vi.fn(() => undefined),
+  readToolList: vi.fn((v: unknown) =>
+    Array.isArray(v)
+      ? (v as unknown[]).filter(
+          (e): e is string => typeof e === 'string' && e.trim().length > 0,
+        )
+      : [],
+  ),
+  buildToolDeclarationsFromView: vi.fn(() => []),
+  getEnabledToolNamesForPrompt: vi.fn(() => []),
+  shouldIncludeSubagentDelegationForConfig: vi.fn(() => Promise.resolve(false)),
+}));
+
+// --- Mocks (hoisted so vi.mock factories can reference them) ---
+const {
+  mockChatCreateFn,
+  mockGenerateContentFn,
+  mockEmbedContentFn,
+  mockTurnRunFn,
+} = vi.hoisted(() => ({
+  mockChatCreateFn: vi.fn(),
+  mockGenerateContentFn: vi.fn(),
+  mockEmbedContentFn: vi.fn(),
+  mockTurnRunFn: vi.fn(),
+}));
+
+const {
+  todoStoreReadMock,
+  todoStoreReadPausedMock,
+  todoStoreWritePausedMock,
+  mockTodoStoreConstructor,
+} = vi.hoisted(() => {
+  const readMock = vi.fn();
+  const readPausedMock = vi.fn();
+  const writePausedMock = vi.fn();
+  const constructorMock = vi.fn().mockImplementation(() => ({
+    readTodos: readMock,
+    readPausedState: readPausedMock,
+    writePausedState: writePausedMock,
+  }));
+  return {
+    todoStoreReadMock: readMock,
+    todoStoreReadPausedMock: readPausedMock,
+    todoStoreWritePausedMock: writePausedMock,
+    mockTodoStoreConstructor: constructorMock,
+  };
+});
+
+vi.mock('@vybestack/llxprt-code-core/services/complexity-analyzer.js', () => ({
+  ComplexityAnalyzer: vi.fn().mockImplementation(() => ({
+    analyzeComplexity: vi.fn().mockReturnValue({
+      complexityScore: 0.2,
+      isComplex: false,
+      detectedTasks: [],
+      sequentialIndicators: [],
+      questionCount: 0,
+      shouldSuggestTodos: false,
+    }),
+  })),
+}));
+
+vi.mock(
+  '@vybestack/llxprt-code-core/services/todo-reminder-service.js',
+  () => ({
+    TodoReminderService: vi.fn().mockImplementation(() => ({
+      getComplexTaskSuggestion: vi.fn(),
+      getEscalatedComplexTaskSuggestion: vi.fn(),
+      getCreateListReminder: vi.fn(),
+      getUpdateActiveTodoReminder: vi.fn(),
+    })),
+  }),
+);
+vi.mock('@vybestack/llxprt-code-tools', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@vybestack/llxprt-code-tools')>();
+  return {
+    ...actual,
+    LocalTodoStore: mockTodoStoreConstructor,
+  };
+});
+vi.mock('./turn', (importOriginal) => {
+  const result = importOriginal() as
+    | typeof import('./turn.js')
+    | Promise<typeof import('./turn.js')>;
+  class MockTurn {
+    pendingToolCalls: unknown[] = [];
+    run = mockTurnRunFn;
+    constructor() {}
+  }
+  if (result instanceof Promise) {
+    return result.then((actual) => ({
+      ...actual,
+      Turn: MockTurn,
+    }));
+  }
+  return {
+    ...result,
+    Turn: MockTurn,
+  };
+});
+
+vi.mock('@vybestack/llxprt-code-core/config/config.js');
+vi.mock('@vybestack/llxprt-code-core/utils/getFolderStructure.js', () => ({
+  getFolderStructure: vi.fn().mockResolvedValue('Mock Folder Structure'),
+}));
+vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
+  reportError: vi.fn(),
+}));
+vi.mock(
+  '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js',
+  () => ({
+    getResponseText: (result: MockResponseShape) =>
+      result.candidates?.[0]?.content?.parts
+        ?.map((part) => part.text)
+        .join('') ?? undefined,
+  }),
+);
+vi.mock('@vybestack/llxprt-code-core/telemetry/index.js', () => ({
+  logApiRequest: vi.fn(),
+  logApiResponse: vi.fn(),
+  logApiError: vi.fn(),
+}));
+vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
+  retryWithBackoff: vi.fn((apiCall) => apiCall()),
+}));
+vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@vybestack/llxprt-code-ide-integration')
+    >();
+  return {
+    ...actual,
+    ideContext: {
+      ...actual.ideContext,
+      getIdeContext: vi.fn(),
+      subscribeToIdeContext: vi.fn(),
+      setIdeContext: vi.fn(),
+      clearIdeContext: vi.fn(),
+    },
+  };
+});
+vi.mock(
+  '@vybestack/llxprt-code-core/core/tokenLimits.js',
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    const tokenLimit = vi.fn();
+    return {
+      ...actual,
+      tokenLimit,
+      resolveEffectiveContextLimit: vi.fn(
+        (model: string, userCtx?: number, provCtx?: number) => {
+          const ok = (v: unknown): v is number =>
+            typeof v === 'number' && Number.isFinite(v) && v > 0;
+          if (ok(userCtx)) return userCtx;
+          if (ok(provCtx)) return provCtx;
+          return tokenLimit(model);
+        },
+      ),
+    };
+  },
+);
+vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
+  uiTelemetryService: {
+    setLastPromptTokenCount: vi.fn(),
+    getLastPromptTokenCount: vi.fn(),
+  },
+}));
+
+function makeChatMock(): Partial<ChatSession> {
+  return {
+    addHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+    getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+    getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
+    getContextLimit: vi.fn().mockReturnValue(1000000),
+  };
+}
+
+describe('Agent Client (client.ts)', () => {
+  let client: AgentClient;
+
+  beforeEach(async () => {
+    const ctx = await setupAgentClient({
+      mockChatCreateFn,
+      mockGenerateContentFn,
+      mockEmbedContentFn,
+    });
+    client = ctx.client;
+
+    mockTodoStoreConstructor.mockImplementation(() => ({
+      readTodos: todoStoreReadMock,
+      readPausedState: todoStoreReadPausedMock,
+      writePausedState: todoStoreWritePausedMock,
+    }));
+    todoStoreReadMock.mockResolvedValue([]);
+    todoStoreReadPausedMock.mockResolvedValue(false);
+    todoStoreWritePausedMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    client.dispose();
+    vi.restoreAllMocks();
+  });
+
+  describe('sendMessageStream — tool-content 400 recovery', () => {
+    beforeEach(() => {
+      (
+        client as unknown as {
+          todoContinuationService: { todoToolsAvailable: boolean };
+        }
+      ).todoContinuationService.todoToolsAvailable = true;
+    });
+
+    it('AC1/AC4: injects an advice message and re-issues after a tool-content 400', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      const mockStream1 = (async function* () {
+        yield {
+          type: AgentEventType.Error,
+          value: {
+            error: { message: REJECTION_400_MESSAGE, status: 400 },
+          },
+        };
+      })();
+      const mockStream2 = (async function* () {
+        yield { type: AgentEventType.Content, value: 'Retried content' };
+      })();
+
+      mockTurnRunFn
+        .mockReturnValueOnce(mockStream1)
+        .mockReturnValueOnce(mockStream2);
+
+      client['chat'] = makeChatMock() as ChatSession;
+
+      const initialRequest = [
+        { type: 'text', text: 'Show me the shader file' },
+        {
+          type: 'tool_response',
+          callId: 'read_file',
+          toolName: 'read_file',
+          result: { content: 'binary blob' },
+        },
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          data: 'AAA',
+          encoding: 'base64',
+          filename: 'shader.fh',
+        },
+      ];
+      const signal = new AbortController().signal;
+
+      const events = await fromAsync(
+        client.sendMessageStream(initialRequest, signal, 'prompt-id-400-retry'),
+      );
+
+      // The error event is still emitted before recovery.
+      expect(events).toStrictEqual([
+        {
+          type: AgentEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'gemini',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
+        {
+          type: AgentEventType.Error,
+          value: {
+            error: { message: REJECTION_400_MESSAGE, status: 400 },
+          },
+        },
+        { type: AgentEventType.Content, value: 'Retried content' },
+      ]);
+
+      // turn.run is called twice: the failing attempt then the recovery.
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+
+      const secondCallArgs = mockTurnRunFn.mock.calls[1];
+      const secondRequest = secondCallArgs?.[0];
+      expect(secondRequest).toStrictEqual([
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: expect.any(String) }],
+        },
+      ]);
+      const adviceText =
+        (
+          secondRequest as unknown as Array<{
+            blocks: Array<{ text: string }>;
+          }>
+        )[0]?.blocks[0]?.text ?? '';
+      // The advice names the tool, the rejected media, and the alternative.
+      expect(adviceText).toContain('HTTP 400');
+      expect(adviceText).toContain('The tools involved were: read_file.');
+      expect(adviceText).toContain(
+        'The rejected content was: shader.fh (image/png).',
+      );
+      expect(adviceText).toContain('read it as text');
+    });
+
+    it('AC2: a non-content 400 is not recovered (turn.run called once)', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      const mockStream1 = (async function* () {
+        yield {
+          type: AgentEventType.Error,
+          value: {
+            error: {
+              message: "Invalid value for 'temperature': must be <= 2",
+              status: 400,
+            },
+          },
+        };
+      })();
+      mockTurnRunFn.mockReturnValueOnce(mockStream1);
+      client['chat'] = makeChatMock() as ChatSession;
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-400-noncontent',
+        ),
+      );
+
+      expect(events).toStrictEqual([
+        {
+          type: AgentEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'gemini',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
+        {
+          type: AgentEventType.Error,
+          value: {
+            error: {
+              message: "Invalid value for 'temperature': must be <= 2",
+              status: 400,
+            },
+          },
+        },
+      ]);
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('AC5: stops after one recovery when the tool-content 400 repeats', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      mockTurnRunFn.mockImplementation(() =>
+        (async function* () {
+          yield {
+            type: AgentEventType.Error,
+            value: {
+              error: { message: REJECTION_400_MESSAGE, status: 400 },
+            },
+          };
+        })(),
+      );
+      client['chat'] = makeChatMock() as ChatSession;
+
+      // The request must carry tool evidence so the recovery gate fires.
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [
+            { type: 'text', text: 'Hi' },
+            {
+              type: 'tool_response',
+              callId: 'read_file',
+              toolName: 'read_file',
+              result: { content: 'x' },
+            },
+          ],
+          new AbortController().signal,
+          'prompt-id-400-infinite',
+        ),
+      );
+
+      // 1 ModelInfo + exactly 2 Error events (original + 1 recovery), no loop.
+      expect(events.length).toBe(3);
+      expect(events[0]?.type).toBe(AgentEventType.ModelInfo);
+      expect(
+        events
+          .slice(1)
+          .every(
+            (e) =>
+              e.type === AgentEventType.Error &&
+              (e.value as { error: { status?: number } }).error.status === 400,
+          ),
+      ).toBe(true);
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('AC1 gate: a content-rejection 400 whose request carried no tool evidence is not recovered', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      const mockStream1 = (async function* () {
+        yield {
+          type: AgentEventType.Error,
+          value: {
+            error: { message: REJECTION_400_MESSAGE, status: 400 },
+          },
+        };
+      })();
+      mockTurnRunFn.mockReturnValueOnce(mockStream1);
+      client['chat'] = makeChatMock() as ChatSession;
+
+      // Plain text request: no tool_response and no media block. Even though
+      // the message is a content-rejection 400, recovery must NOT fire because
+      // the failing request carried no tool evidence.
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-400-no-tool-evidence',
+        ),
+      );
+
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+      // Only the original 400 Error event was emitted (plus ModelInfo).
+      expect(
+        events.filter((e) => e.type === AgentEventType.Error),
+      ).toHaveLength(1);
+    });
+
+    it('AC6a: does not recover when getContinueOnFailedApiCall is false', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        false,
+      );
+      const mockStream1 = (async function* () {
+        yield {
+          type: AgentEventType.Error,
+          value: {
+            error: { message: REJECTION_400_MESSAGE, status: 400 },
+          },
+        };
+      })();
+      mockTurnRunFn.mockReturnValueOnce(mockStream1);
+      client['chat'] = makeChatMock() as ChatSession;
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-400-no-continue',
+        ),
+      );
+
+      expect(events).toStrictEqual([
+        {
+          type: AgentEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'gemini',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
+        {
+          type: AgentEventType.Error,
+          value: {
+            error: { message: REJECTION_400_MESSAGE, status: 400 },
+          },
+        },
+      ]);
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('AC6b: does not recover when content was already emitted before the 400', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      const mockStream = (async function* () {
+        yield { type: AgentEventType.Content, value: 'Partial content' };
+        yield {
+          type: AgentEventType.Error,
+          value: {
+            error: { message: REJECTION_400_MESSAGE, status: 400 },
+          },
+        };
+      })();
+      mockTurnRunFn.mockReturnValueOnce(mockStream);
+      client['chat'] = makeChatMock() as ChatSession;
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-400-after-content',
+        ),
+      );
+
+      expect(events.slice(-2)).toStrictEqual([
+        { type: AgentEventType.Content, value: 'Partial content' },
+        {
+          type: AgentEventType.Error,
+          value: {
+            error: { message: REJECTION_400_MESSAGE, status: 400 },
+          },
+        },
+      ]);
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+/**
+ * Issue #2722 recovery re-issues a bare text message after a failed
+ * tool-response request, which leaves the preceding AI turn's tool_call
+ * without a matching tool_response in history. That is safe ONLY because
+ * HistoryService.getCuratedForProvider closes orphaned tool calls before any
+ * provider converter runs. This test pins that structural assumption using a
+ * real HistoryService (no mocks).
+ */
+describe('tool-content 400 recovery — history assumption (issue #2722)', () => {
+  it('orphaned tool calls are closed before the provider sees the recovery request (issue #2722)', () => {
+    const history = new HistoryService();
+    // Seed: an AI turn issued a tool_call whose response was rejected by the
+    // provider (HTTP 400), so no tool_response was ever recorded for it.
+    const aiTurn: IContent = {
+      speaker: 'ai',
+      blocks: [
+        {
+          type: 'tool_call',
+          id: 'call-1',
+          name: 'read_file',
+          parameters: { path: 'shader.fh' },
+        },
+      ],
+    };
+    history.add(aiTurn);
+
+    // The recovery re-issues a bare text (advice) message as tail content.
+    const tailContents: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'text',
+            text: 'System: The provider rejected the previous request with HTTP 400.',
+          },
+        ],
+      },
+    ];
+
+    const curated = history.getCuratedForProvider(tailContents);
+
+    const aiIndex = curated.findIndex(
+      (c) =>
+        c.speaker === 'ai' &&
+        c.blocks.some((b) => b.type === 'tool_call' && b.id === 'call-1'),
+    );
+    expect(aiIndex).toBeGreaterThanOrEqual(0);
+
+    // A synthetic tool response is inserted immediately after the AI turn...
+    expect(curated[aiIndex + 1]?.speaker).toBe('tool');
+    expect(
+      curated[aiIndex + 1]?.blocks.some(
+        (b) => b.type === 'tool_response' && b.callId === 'call-1',
+      ),
+    ).toBe(true);
+
+    // ...and BEFORE the human advice content reaches the provider.
+    const humanIndex = curated.findIndex((c) => c.speaker === 'human');
+    expect(humanIndex).toBeGreaterThan(aiIndex + 1);
+
+    // Stored history is left untouched (the offending media was never added).
+    expect(history.getAll()).toHaveLength(1);
+  });
+});

--- a/packages/agents/src/core/client.ts
+++ b/packages/agents/src/core/client.ts
@@ -231,8 +231,22 @@ export class AgentClient implements AgentClientContract {
         this.currentSequenceModel = null;
       },
       updateTelemetryTokenCount: () => this.updateTelemetryTokenCount(),
-      sendMessageStream: (req, sig, pid, trns, isRetry, is413) =>
-        this.sendMessageStream(req, sig, pid, trns, isRetry, is413),
+      sendMessageStream: (
+        req,
+        sig,
+        pid,
+        trns,
+        isInvalidStreamRetry,
+        isPayloadRecoveryRetry,
+      ) =>
+        this.sendMessageStream(
+          req,
+          sig,
+          pid,
+          trns,
+          isInvalidStreamRetry,
+          isPayloadRecoveryRetry,
+        ),
       createTurn,
     };
   }
@@ -739,7 +753,7 @@ export class AgentClient implements AgentClientContract {
     prompt_id: string,
     turns: number = this.MAX_TURNS,
     isInvalidStreamRetry: boolean = false,
-    is413Retry: boolean = false,
+    isPayloadRecoveryRetry: boolean = false,
   ): AsyncGenerator<ServerAgentStreamEvent, Turn> {
     this.activeStreamCount++;
     try {
@@ -749,7 +763,7 @@ export class AgentClient implements AgentClientContract {
         prompt_id,
         turns,
         isInvalidStreamRetry,
-        is413Retry,
+        isPayloadRecoveryRetry,
       );
     } finally {
       this.activeStreamCount--;

--- a/packages/agents/src/core/toolContentRejection.test.ts
+++ b/packages/agents/src/core/toolContentRejection.test.ts
@@ -1,0 +1,359 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from '../testApi.js';
+import {
+  isToolContentRejection,
+  describeRejectedPayload,
+  buildToolContentRejectionAdvice,
+  extractToolName,
+} from './toolContentRejection.js';
+import type { MediaBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+
+const VERBATIM_2719_MESSAGE =
+  "The image data you provided does not represent a valid image. Please check your input and try again with one of the supported image formats: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].";
+
+describe('toolContentRejection', () => {
+  describe('isToolContentRejection', () => {
+    it('returns true for the verbatim #2719 message at status 400', () => {
+      expect(isToolContentRejection(400, VERBATIM_2719_MESSAGE)).toBe(true);
+    });
+
+    it.each([
+      ['OpenAI unsupported image', 'You uploaded an unsupported image format.'],
+      [
+        'Anthropic media type mismatch',
+        'image does not match the provided media type',
+      ],
+      ['Could not process image', 'Could not process image'],
+      ['Invalid base64 data', 'Invalid base64 data'],
+      ['Unsupported document type', 'Unsupported document type'],
+      ['unable to decode audio', 'unable to decode audio'],
+      [
+        'Invalid MIME type',
+        'Invalid MIME type. Only image types are supported.',
+      ],
+      ['Unsupported video format', 'Unsupported video format'],
+    ])('returns true for provider phrasing variant: %s', (_name, message) => {
+      expect(isToolContentRejection(400, message)).toBe(true);
+    });
+
+    it.each([
+      [
+        'Anthropic pydantic base64 string',
+        'messages.0.content.1.image.source.base64.data: Input should be a valid string',
+      ],
+      [
+        'Gemini multimodal function responses',
+        'Multimodal function responses are not supported for this model',
+      ],
+      [
+        'Gateway failed to download media',
+        'Failed to download file from https://example.com/image.png',
+      ],
+    ])('returns true for real provider/gateway 400: %s', (_name, message) => {
+      expect(isToolContentRejection(400, message)).toBe(true);
+    });
+
+    it.each([
+      [
+        'image inside read_image function name',
+        "Invalid schema for function 'read_image': exceeds maximum nesting depth",
+      ],
+      [
+        'image inside image_path arg',
+        'Invalid tool call: image_path is required',
+      ],
+    ])(
+      'returns false when a content term appears inside a larger identifier: %s',
+      (_name, message) => {
+        expect(isToolContentRejection(400, message)).toBe(false);
+      },
+    );
+
+    it.each([
+      // Word boundary must NOT prevent legitimate matches.
+      ['image.source.base64', 'image.source.base64 is malformed'],
+      ['image/jpeg in a list', "['image/jpeg', 'image/png'] is unsupported"],
+    ])(
+      'still matches a content term bounded by non-word characters: %s',
+      (_name, message) => {
+        expect(isToolContentRejection(400, message)).toBe(true);
+      },
+    );
+
+    it.each([
+      [
+        'request-shape error',
+        "Invalid JSON payload received. Unknown name 'foo'",
+      ],
+      ['parameter error', "Invalid value for 'temperature': must be <= 2"],
+      [
+        'context overflow',
+        "This model's maximum context length is 128000 tokens",
+      ],
+      [
+        'tool-schema depth',
+        "Invalid schema for function 'x': exceeds maximum nesting depth",
+      ],
+      ['missing model param', "missing required parameter: 'model'"],
+      ['tool-arg error', 'Invalid tool call: file_path is required'],
+    ])('returns false for non-content 400: %s', (_name, message) => {
+      expect(isToolContentRejection(400, message)).toBe(false);
+    });
+
+    it.each([
+      ['413', 413],
+      ['429', 429],
+      ['500', 500],
+      ['undefined', undefined],
+    ])(
+      'returns false for status %s with an otherwise matching message',
+      (_name, status) => {
+        expect(isToolContentRejection(status, VERBATIM_2719_MESSAGE)).toBe(
+          false,
+        );
+      },
+    );
+
+    it.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['empty string', ''],
+      ['whitespace only', '   '],
+      ['non-string object', { message: 'invalid image' }],
+    ])('returns false for a %s message at status 400', (_name, message) => {
+      expect(isToolContentRejection(400, message)).toBe(false);
+    });
+
+    it('is case-insensitive (all-upper variant matches)', () => {
+      expect(
+        isToolContentRejection(400, VERBATIM_2719_MESSAGE.toUpperCase()),
+      ).toBe(true);
+    });
+  });
+
+  describe('extractToolName', () => {
+    it('extracts the name from a neutral tool_response', () => {
+      expect(
+        extractToolName({ type: 'tool_response', toolName: 'read_file' }),
+      ).toBe('read_file');
+    });
+
+    it('extracts the name from a neutral tool_call', () => {
+      expect(extractToolName({ type: 'tool_call', name: 'search_file' })).toBe(
+        'search_file',
+      );
+    });
+
+    it('extracts the name from a valid legacy functionResponse', () => {
+      expect(extractToolName({ functionResponse: { name: 'read_file' } })).toBe(
+        'read_file',
+      );
+    });
+
+    it('returns undefined for a legacy functionResponse with a non-string name', () => {
+      expect(
+        extractToolName({ functionResponse: { name: 123 } }),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for a legacy functionResponse with an empty name', () => {
+      expect(
+        extractToolName({ functionResponse: { name: '' } }),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for a legacy functionResponse that is not an object', () => {
+      expect(extractToolName({ functionResponse: 'nope' })).toBeUndefined();
+    });
+
+    it('returns undefined for a non-tool part', () => {
+      expect(extractToolName({ type: 'text', text: 'hi' })).toBeUndefined();
+    });
+  });
+
+  describe('describeRejectedPayload', () => {
+    it('extracts tool names from ContentBlock[] tool_response blocks, de-duplicated in first-seen order', () => {
+      const request = [
+        { type: 'text', text: 'Hi' },
+        {
+          type: 'tool_response',
+          callId: 'read_file',
+          toolName: 'read_file',
+          result: { content: 'x' },
+        },
+        {
+          type: 'tool_response',
+          callId: 'search_file',
+          toolName: 'search_file',
+          result: { content: 'y' },
+        },
+        {
+          type: 'tool_response',
+          callId: 'read_file-2',
+          toolName: 'read_file',
+          result: { content: 'z' },
+        },
+      ];
+      expect(describeRejectedPayload(request).toolNames).toStrictEqual([
+        'read_file',
+        'search_file',
+      ]);
+    });
+
+    it('extracts the same names from the equivalent IContent[] shape', () => {
+      const request = [
+        {
+          speaker: 'human',
+          blocks: [
+            {
+              type: 'tool_response',
+              callId: 'read_file',
+              toolName: 'read_file',
+              result: { content: 'x' },
+            },
+            {
+              type: 'tool_response',
+              callId: 'search_file',
+              toolName: 'search_file',
+              result: { content: 'y' },
+            },
+          ],
+        },
+      ];
+      expect(describeRejectedPayload(request).toolNames).toStrictEqual([
+        'read_file',
+        'search_file',
+      ]);
+    });
+
+    it('extracts media descriptors with and without filename, de-duplicated', () => {
+      const withFilename: MediaBlock = {
+        type: 'media',
+        mimeType: 'image/png',
+        data: 'AAA',
+        encoding: 'base64',
+        filename: 'shader.fh',
+      };
+      const withoutFilename: MediaBlock = {
+        type: 'media',
+        mimeType: 'image/png',
+        data: 'BBB',
+        encoding: 'base64',
+      };
+      const duplicate: MediaBlock = {
+        type: 'media',
+        mimeType: 'image/png',
+        data: 'CCC',
+        encoding: 'base64',
+        filename: 'shader.fh',
+      };
+      const request = [
+        { type: 'text', text: 'Hi' },
+        withFilename,
+        withoutFilename,
+        duplicate,
+      ];
+      expect(describeRejectedPayload(request).mediaDescriptors).toStrictEqual([
+        'shader.fh (image/png)',
+        'image/png',
+      ]);
+    });
+
+    it.each([
+      ['plain string request', 'just a string'],
+      ['empty array', []],
+    ])('returns empty arrays for %s', (_name, request) => {
+      const result = describeRejectedPayload(request);
+      expect(result.toolNames).toStrictEqual([]);
+      expect(result.mediaDescriptors).toStrictEqual([]);
+    });
+  });
+
+  describe('buildToolContentRejectionAdvice', () => {
+    it('includes the tool clause, media clause, provider message, and the read-as-text guidance', () => {
+      const advice = buildToolContentRejectionAdvice(
+        {
+          toolNames: ['read_file'],
+          mediaDescriptors: ['shader.fh (image/png)'],
+        },
+        'The image data is not valid.',
+      );
+      expect(advice).toContain('HTTP 400');
+      expect(advice).toContain('not added to the conversation');
+      expect(advice).toContain('The tools involved were: read_file.');
+      expect(advice).toContain(
+        'The rejected content was: shader.fh (image/png).',
+      );
+      expect(advice).toContain(
+        'Provider message: "The image data is not valid."',
+      );
+      expect(advice).toContain('read it as text');
+    });
+
+    it('omits the tool clause when there are no tool names and the media clause when there are no media descriptors', () => {
+      const advice = buildToolContentRejectionAdvice(
+        { toolNames: [], mediaDescriptors: [] },
+        'invalid image',
+      );
+      expect(advice).not.toContain('The tools involved were');
+      expect(advice).not.toContain('The rejected content was');
+      expect(advice).toContain('Provider message: "invalid image"');
+    });
+
+    it('truncates a 1000-character provider message to 300 characters plus an ellipsis', () => {
+      const long = 'a'.repeat(1000);
+      const advice = buildToolContentRejectionAdvice(
+        { toolNames: [], mediaDescriptors: [] },
+        long,
+      );
+      // The quoted body should be exactly 300 chars + the ellipsis.
+      expect(advice).toContain(`${'a'.repeat(300)}\u2026`);
+      expect(advice).not.toContain(`${'a'.repeat(301)}`);
+    });
+
+    it('truncates on code points so an astral character is never split into a lone surrogate', () => {
+      // The emoji straddles the 300-character limit: a naive UTF-16 slice
+      // would cut it in half and emit an unpaired surrogate.
+      const long = `${'a'.repeat(299)}\u{1F44D}${'b'.repeat(50)}`;
+      const advice = buildToolContentRejectionAdvice(
+        { toolNames: [], mediaDescriptors: [] },
+        long,
+      );
+
+      expect(advice).toContain(`${'a'.repeat(299)}\u{1F44D}\u2026`);
+      for (const char of advice) {
+        const code = char.codePointAt(0) ?? 0;
+        expect(code >= 0xd800 && code <= 0xdfff).toBe(false);
+      }
+    });
+
+    it('drops the Provider message sentence for a blank provider message', () => {
+      const advice = buildToolContentRejectionAdvice(
+        { toolNames: ['read_file'], mediaDescriptors: [] },
+        '   ',
+      );
+      expect(advice).not.toContain('Provider message');
+      expect(advice).toContain('The tools involved were: read_file.');
+      // Spacing around the dropped sentence is correct (single space).
+      expect(advice).toContain('declared type. That content was not added');
+    });
+
+    it('contains no hardcoded file extension or tool name (AC4 guard)', () => {
+      const advice = buildToolContentRejectionAdvice(
+        {
+          toolNames: ['some_tool'],
+          mediaDescriptors: ['somefile.xyz (image/png)'],
+        },
+        'invalid image',
+      );
+      expect(advice).not.toContain('.fh');
+      expect(advice).not.toContain('read_file');
+      expect(advice).not.toContain('search_file');
+    });
+  });
+});

--- a/packages/agents/src/core/toolContentRejection.test.ts
+++ b/packages/agents/src/core/toolContentRejection.test.ts
@@ -149,26 +149,19 @@ describe('toolContentRejection', () => {
       );
     });
 
-    it('extracts the name from a valid legacy functionResponse', () => {
-      expect(extractToolName({ functionResponse: { name: 'read_file' } })).toBe(
-        'read_file',
-      );
-    });
-
-    it('returns undefined for a legacy functionResponse with a non-string name', () => {
+    it('returns undefined for a tool_response whose toolName is not a non-empty string', () => {
       expect(
-        extractToolName({ functionResponse: { name: 123 } }),
+        extractToolName({ type: 'tool_response', toolName: '' }),
       ).toBeUndefined();
-    });
-
-    it('returns undefined for a legacy functionResponse with an empty name', () => {
       expect(
-        extractToolName({ functionResponse: { name: '' } }),
+        extractToolName({ type: 'tool_response', toolName: 123 }),
       ).toBeUndefined();
+      expect(extractToolName({ type: 'tool_response' })).toBeUndefined();
     });
 
-    it('returns undefined for a legacy functionResponse that is not an object', () => {
-      expect(extractToolName({ functionResponse: 'nope' })).toBeUndefined();
+    it('returns undefined for a tool_call whose name is not a non-empty string', () => {
+      expect(extractToolName({ type: 'tool_call', name: '' })).toBeUndefined();
+      expect(extractToolName({ type: 'tool_call', name: 123 })).toBeUndefined();
     });
 
     it('returns undefined for a non-tool part', () => {

--- a/packages/agents/src/core/toolContentRejection.test.ts
+++ b/packages/agents/src/core/toolContentRejection.test.ts
@@ -105,6 +105,26 @@ describe('toolContentRejection', () => {
       expect(isToolContentRejection(400, message)).toBe(false);
     });
 
+    // Accepted precision/recall trade-off (AC8). A parameter-validation error
+    // whose parameter name IS a standalone content word is indistinguishable
+    // from a real content rejection by message text alone, so it over-matches.
+    // Recall is preferred: the issue requires that "any similar error should
+    // recover", and narrowing the vocabulary to exclude these would drop real
+    // provider rejections. The cost is bounded elsewhere — recovery also
+    // requires the failing request to carry tool evidence, and the shared
+    // one-shot guard allows at most one advice injection per round-trip, so
+    // the worst case is a single wasted round-trip.
+    it.each([
+      ['document', 'Invalid parameter: document is required'],
+      ['audio', 'Invalid parameter: audio is required'],
+      ['video', 'Invalid parameter: video is required'],
+    ])(
+      'deliberately over-matches a parameter error whose parameter name is the standalone content word %s',
+      (_name, message) => {
+        expect(isToolContentRejection(400, message)).toBe(true);
+      },
+    );
+
     it.each([
       ['413', 413],
       ['429', 429],

--- a/packages/agents/src/core/toolContentRejection.ts
+++ b/packages/agents/src/core/toolContentRejection.ts
@@ -1,0 +1,312 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AgentMessageInput } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import { iContentFromAgentMessageInput } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import type { MediaBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+
+/**
+ * Content-type terms a tool-content 400 tends to mention. Lower-cased for
+ * scanning. Matched with a word-boundary requirement (see
+ * `containsAnyWordBoundary`) so a bare `image` does not match inside
+ * `read_image` or `image_path`. Bare `file` is deliberately excluded so that
+ * request-shape errors like "file_path is required" cannot match (AC8).
+ */
+const CONTENT_TERMS: readonly string[] = [
+  'image',
+  'image data',
+  'image_url',
+  'input_image',
+  'picture',
+  'photo',
+  'screenshot',
+  'audio',
+  'video',
+  'document',
+  'pdf',
+  'media',
+  'media type',
+  'mime type',
+  'content type',
+  'attachment',
+  'inline data',
+  'inline_data',
+  'base64',
+  'data uri',
+  'file format',
+  'file type',
+  'file data',
+  'file_data',
+  'uploaded file',
+  'multimodal',
+];
+
+/**
+ * Rejection terms a tool-content 400 tends to mention. Lower-cased for
+ * substring scanning. Plain substring scans (no regex) keep this compatible
+ * with the sonarjs/slow-regex error-level rule. These are multi-word phrases,
+ * so plain substring matching (no word boundary) is sufficient.
+ */
+const REJECTION_TERMS: readonly string[] = [
+  'not a valid',
+  'does not represent a valid',
+  'is not valid',
+  'should be a valid',
+  'invalid',
+  'unsupported',
+  'not supported',
+  'unable to process',
+  'could not process',
+  'cannot process',
+  'unable to decode',
+  'could not decode',
+  'failed to decode',
+  'failed to process',
+  'failed to parse',
+  'failed to download',
+  'could not download',
+  'unable to download',
+  'does not match',
+  'malformed',
+  'corrupt',
+  'unrecognized',
+  'unrecognised',
+  'supported formats',
+];
+
+function containsAnySubstring(
+  haystack: string,
+  terms: readonly string[],
+): boolean {
+  for (const term of terms) {
+    if (haystack.includes(term)) return true;
+  }
+  return false;
+}
+
+/**
+ * Word characters for content-term boundary checks: a-z, 0-9, and _. The
+ * haystack is already lower-cased before matching, so only a-z needs covering.
+ */
+function isWordChar(ch: string | undefined): boolean {
+  if (ch === undefined) return false;
+  const code = ch.charCodeAt(0);
+  if (code >= 0x61 && code <= 0x7a) return true; // a-z
+  if (code >= 0x30 && code <= 0x39) return true; // 0-9
+  return code === 0x5f; // _
+}
+
+/**
+ * A content term matches only when the characters immediately before and
+ * after the match are each absent or NOT a word character, preventing
+ * `image` from matching inside `read_image` or `image_path`. Implemented as
+ * an index scan — no regular expressions (AC8, sonarjs/slow-regex).
+ */
+function matchesWordBoundary(haystack: string, term: string): boolean {
+  const n = term.length;
+  let i = haystack.indexOf(term);
+  while (i !== -1) {
+    const before = i > 0 ? haystack[i - 1] : undefined;
+    const after = i + n < haystack.length ? haystack[i + n] : undefined;
+    if (!isWordChar(before) && !isWordChar(after)) return true;
+    i = haystack.indexOf(term, i + 1);
+  }
+  return false;
+}
+
+function containsAnyWordBoundary(
+  haystack: string,
+  terms: readonly string[],
+): boolean {
+  for (const term of terms) {
+    if (matchesWordBoundary(haystack, term)) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true iff `status === 400` and the (lower-cased) `message` contains
+ * both at least one content term (word-bounded) and at least one rejection
+ * term (plain substring). A missing/non-400 status or a non-string/empty
+ * message returns false (AC8).
+ */
+export function isToolContentRejection(
+  status: number | undefined,
+  message: unknown,
+): boolean {
+  if (status !== 400) return false;
+  if (typeof message !== 'string') return false;
+  const text = message.toLowerCase();
+  return (
+    containsAnyWordBoundary(text, CONTENT_TERMS) &&
+    containsAnySubstring(text, REJECTION_TERMS)
+  );
+}
+
+/**
+ * Extracts a tool name from a single request part in neutral or legacy form.
+ *
+ * Recognizes:
+ * - Neutral `tool_response`: `{ type: 'tool_response', toolName }`
+ * - Neutral `tool_call`: `{ type: 'tool_call', name }`
+ * - Legacy Google `functionResponse`: `{ functionResponse: { name } }`
+ *
+ * Returns the extracted name, or `undefined` if the part is not a
+ * tool-response/tool-call shape.
+ */
+export function extractToolName(part: unknown): string | undefined {
+  if (part == null || typeof part !== 'object') return undefined;
+  const obj = part as Record<string, unknown>;
+
+  if (obj['type'] === 'tool_response') {
+    const toolName = obj['toolName'];
+    if (typeof toolName === 'string' && toolName.length > 0) return toolName;
+    return undefined;
+  }
+
+  if (obj['type'] === 'tool_call') {
+    const name = obj['name'];
+    if (typeof name === 'string' && name.length > 0) return name;
+    return undefined;
+  }
+
+  if ('functionResponse' in obj) {
+    const funcResp = obj['functionResponse'];
+    if (isFunctionResponseWithName(funcResp)) {
+      return funcResp.name;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extracts de-duplicated tool names (first-seen order) directly from a raw
+ * request array. Used by the 413 path on the un-normalised request.
+ */
+export function extractToolNamesFromRequest(
+  request: AgentMessageInput,
+): string[] {
+  if (!Array.isArray(request)) return [];
+  const names = new Set<string>();
+  for (const rawPart of request) {
+    const name = extractToolName(rawPart);
+    if (name !== undefined) {
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
+function isMediaBlock(block: unknown): block is MediaBlock {
+  if (block == null || typeof block !== 'object') return false;
+  const obj = block as Record<string, unknown>;
+  return obj['type'] === 'media' && typeof obj['mimeType'] === 'string';
+}
+
+/**
+ * Type guard for a legacy Google `functionResponse` value whose `name` is a
+ * non-empty string. Extracted so the legacy branch validates the value the
+ * same way the neutral branches do, without a cast to `{ name?: string }`.
+ */
+function isFunctionResponseWithName(value: unknown): value is { name: string } {
+  if (value == null || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  if (!('name' in obj)) return false;
+  const name = obj['name'];
+  return typeof name === 'string' && name.length > 0;
+}
+
+function formatMediaDescriptor(block: MediaBlock): string {
+  return block.filename
+    ? `${block.filename} (${block.mimeType})`
+    : block.mimeType;
+}
+
+export interface RejectedPayloadDescription {
+  readonly toolNames: readonly string[];
+  readonly mediaDescriptors: readonly string[];
+}
+
+/**
+ * Normalises `request` via `iContentFromAgentMessageInput` (so string,
+ * ContentBlock[], IContent, and IContent[] all work — AC9), then scans the
+ * resulting blocks for tool names and `media` blocks. Duplicate names and
+ * descriptors are de-duplicated while preserving first-seen order.
+ */
+export function describeRejectedPayload(
+  request: AgentMessageInput,
+): RejectedPayloadDescription {
+  const contents = iContentFromAgentMessageInput(request);
+  const toolNames: string[] = [];
+  const mediaDescriptors: string[] = [];
+  const seenTools = new Set<string>();
+  const seenMedia = new Set<string>();
+
+  for (const content of contents) {
+    for (const block of content.blocks) {
+      const toolName = extractToolName(block);
+      if (toolName !== undefined && !seenTools.has(toolName)) {
+        seenTools.add(toolName);
+        toolNames.push(toolName);
+      }
+      if (!isMediaBlock(block)) continue;
+      const descriptor = formatMediaDescriptor(block);
+      if (!seenMedia.has(descriptor)) {
+        seenMedia.add(descriptor);
+        mediaDescriptors.push(descriptor);
+      }
+    }
+  }
+
+  return { toolNames, mediaDescriptors };
+}
+
+const MAX_PROVIDER_MESSAGE_LENGTH = 300;
+
+/**
+ * Truncates by Unicode code point rather than UTF-16 code unit so an
+ * astral-plane character (e.g. an emoji) straddling the limit cannot be split
+ * into a lone surrogate in the message shown to the model.
+ */
+function truncateMessage(message: string): string {
+  const codePoints = Array.from(message);
+  if (codePoints.length <= MAX_PROVIDER_MESSAGE_LENGTH) return message;
+  return `${codePoints.slice(0, MAX_PROVIDER_MESSAGE_LENGTH).join('')}\u2026`;
+}
+
+const ADVICE_BASE =
+  'System: The provider rejected the previous request with HTTP 400 because content supplied by a tool result was invalid or unsupported for its declared type.';
+const ADVICE_NOT_ADDED = 'That content was not added to the conversation.';
+const ADVICE_TAIL =
+  'Do not resend the same content or repeat the same tool call with the same arguments. Try a different approach instead \u2014 for example, if a file was sent as an image or other binary attachment but is actually text or source code, read it as text.';
+
+/**
+ * Builds the synthetic advice message injected before re-issuing the request
+ * after a tool-content 400. See the plan's "Advice message template (exact)".
+ * An empty/blank provider message drops the whole Provider-message sentence.
+ */
+export function buildToolContentRejectionAdvice(
+  description: RejectedPayloadDescription,
+  providerMessage: string,
+): string {
+  const toolClause =
+    description.toolNames.length > 0
+      ? ` The tools involved were: ${description.toolNames.join(', ')}.`
+      : '';
+  const mediaClause =
+    description.mediaDescriptors.length > 0
+      ? ` The rejected content was: ${description.mediaDescriptors.join(', ')}.`
+      : '';
+
+  const trimmed = providerMessage.trim();
+  const providerSentence =
+    trimmed.length > 0
+      ? ` Provider message: "${truncateMessage(trimmed)}".`
+      : '';
+
+  return `${ADVICE_BASE}${providerSentence} ${ADVICE_NOT_ADDED}${toolClause}${mediaClause} ${ADVICE_TAIL}`;
+}

--- a/packages/agents/src/core/toolContentRejection.ts
+++ b/packages/agents/src/core/toolContentRejection.ts
@@ -149,10 +149,11 @@ export function isToolContentRejection(
 /**
  * Extracts a tool name from a single request part in neutral or legacy form.
  *
- * Recognizes:
- * - Neutral `tool_response`: `{ type: 'tool_response', toolName }`
- * - Neutral `tool_call`: `{ type: 'tool_call', name }`
- * - Legacy Google `functionResponse`: `{ functionResponse: { name } }`
+ * Recognizes the neutral block shapes only — `{ type: 'tool_response',
+ * toolName }` and `{ type: 'tool_call', name }`. `AgentMessageInput` is the
+ * neutral union (`string | ContentBlock[] | IContent | IContent[]`), so a
+ * Google-shaped `{ functionResponse: { name } }` part cannot reach here; the
+ * agents package is Google-shape free by policy (issue #2424 gate).
  *
  * Returns the extracted name, or `undefined` if the part is not a
  * tool-response/tool-call shape.
@@ -171,13 +172,6 @@ export function extractToolName(part: unknown): string | undefined {
     const name = obj['name'];
     if (typeof name === 'string' && name.length > 0) return name;
     return undefined;
-  }
-
-  if ('functionResponse' in obj) {
-    const funcResp = obj['functionResponse'];
-    if (isFunctionResponseWithName(funcResp)) {
-      return funcResp.name;
-    }
   }
 
   return undefined;
@@ -205,19 +199,6 @@ function isMediaBlock(block: unknown): block is MediaBlock {
   if (block == null || typeof block !== 'object') return false;
   const obj = block as Record<string, unknown>;
   return obj['type'] === 'media' && typeof obj['mimeType'] === 'string';
-}
-
-/**
- * Type guard for a legacy Google `functionResponse` value whose `name` is a
- * non-empty string. Extracted so the legacy branch validates the value the
- * same way the neutral branches do, without a cast to `{ name?: string }`.
- */
-function isFunctionResponseWithName(value: unknown): value is { name: string } {
-  if (value == null || typeof value !== 'object') return false;
-  const obj = value as Record<string, unknown>;
-  if (!('name' in obj)) return false;
-  const name = obj['name'];
-  return typeof name === 'string' && name.length > 0;
 }
 
 function formatMediaDescriptor(block: MediaBlock): string {

--- a/packages/cli/src/integration-tests/todo-continuation.integration.test.ts
+++ b/packages/cli/src/integration-tests/todo-continuation.integration.test.ts
@@ -271,7 +271,7 @@ describe('Task-list Continuation Integration Tests', () => {
         prompt_id: string,
         turns?: number,
         isInvalidStreamRetry?: boolean,
-        is413Retry?: boolean,
+        isPayloadRecoveryRetry?: boolean,
       ): AsyncGenerator<ServerAgentStreamEvent, Turn> {
         capturedMessage =
           typeof request === 'string' ? request : JSON.stringify(request);
@@ -280,7 +280,7 @@ describe('Task-list Continuation Integration Tests', () => {
           prompt_id,
           turns,
           isInvalidStreamRetry,
-          is413Retry,
+          isPayloadRecoveryRetry,
         };
         // Yield a mock stream event
         yield {
@@ -307,7 +307,7 @@ describe('Task-list Continuation Integration Tests', () => {
         prompt_id: 'test-prompt-id',
         turns: undefined,
         isInvalidStreamRetry: undefined,
-        is413Retry: undefined,
+        isPayloadRecoveryRetry: undefined,
       });
 
       // Restore original method

--- a/packages/core/src/core/clientContract.ts
+++ b/packages/core/src/core/clientContract.ts
@@ -156,7 +156,7 @@ export interface AgentClientContract {
     prompt_id: string,
     turns?: number,
     isInvalidStreamRetry?: boolean,
-    is413Retry?: boolean,
+    isPayloadRecoveryRetry?: boolean,
   ): AsyncGenerator<ServerAgentStreamEvent, unknown>;
   getUserTier(): UserTierId | undefined;
   getCurrentSequenceModel(): string | null;

--- a/project-plans/issue2722/plan.md
+++ b/project-plans/issue2722/plan.md
@@ -215,6 +215,15 @@ unchanged. `describeRejectedPayload` normalises via
 `iContentFromAgentMessageInput` before scanning blocks (AC9); it reuses the
 same per-block tool-name extraction.
 
+The moved `extractToolName` carried a vestigial legacy Google branch for
+`{ functionResponse: { name } }`. It is dropped: `AgentMessageInput` is the
+neutral union (`string | ContentBlock[] | IContent | IContent[]`), so that
+shape cannot reach the function, and `scripts/agents-neutral-gate.ts` (the
+issue #2424 enforcement) bans Google-shaped fixtures in this package — which
+means the branch could not be covered by a test either. Removing it is
+preferred over exempting it: it eliminates an unreachable defensive path
+rather than pinning one.
+
 Media descriptor formatting, from a `MediaBlock`
 (`packages/core/src/services/history/IContent.ts:273`):
 

--- a/project-plans/issue2722/plan.md
+++ b/project-plans/issue2722/plan.md
@@ -1,0 +1,351 @@
+# Issue #2722 — Detect tool-related 400 errors and advise the model to try a different approach
+
+## Problem (verified in source)
+
+When a tool result carries content the provider cannot accept (the canonical
+case from #2719: a `.fh` shader source misclassified as `image/png`, so
+`read_file` emitted a base64 `media` block), the failure surfaces on the *next*
+provider call, not at tool-execution time. The provider rejects the whole
+request:
+
+    Client error: The image data you provided does not represent a valid image.
+    Please check your input and try again with one of the supported image
+    formats: ['image/jpeg', 'image/png', 'image/gif', 'image/webp']. (Status: 400)
+
+Traced path (file:line):
+
+1. Provider throws inside `provider.generateChatCompletion` —
+   `packages/agents/src/core/StreamProcessor.ts:518`.
+2. `retryWithBackoff` (`StreamProcessor.ts:253`) does not retry 400
+   (`RETRYABLE_STATUS_CODES` in `packages/core/src/utils/retry.ts`).
+3. `TurnProcessor._runStreamAttempt` (`packages/agents/src/core/TurnProcessor.ts:279`)
+   returns `action: 'stop'`; `_createStreamGenerator` (line 240) rethrows.
+4. `Turn.handleRunError` (`packages/agents/src/core/turn.ts:526`) converts it to
+   an `AgentEventType.Error` event carrying a `StructuredError` with `status`
+   and `message` intact.
+5. `handleErrorEvent` (`packages/agents/src/core/MessageStreamTerminalHandler.ts`)
+   reads the status via `getErrorStatus`. **Only `413` has a recovery
+   branch** (the `handle413Error` call). Every other status falls through to
+   "error event ending iteration without retry".
+6. The CLI renders `[API Error: … (Status: 400)]`
+   (`packages/core/src/utils/errorParsing.ts`), and the turn dies.
+
+The model therefore never learns that the *content* was the problem, and cannot
+self-correct. In #2719 the model eventually worked around it by `cat`-ing the
+files with the shell tool.
+
+Two facts make a clean recovery possible:
+
+- **The failing pending content is never persisted.** User/tool contents are
+  written to history only after a successful send
+  (`TurnProcessor._commitSendResult` → `_recordUserContents`,
+  `packages/agents/src/core/TurnProcessor.ts:793-856`; streaming commits via
+  `ConversationManager.recordHistory` from `streamResponseHelpers.ts:579`).
+  A 400 aborts before any of that, so the offending media is simply dropped.
+  The resulting orphaned `tool_call` (the one whose response was rejected) is,
+  however, still in history without a matching `tool_response`. This is safe
+  because `HistoryService.getCuratedForProvider` runs
+  `buildProviderContent`
+  (`packages/core/src/services/history/historyProviderPipeline.ts:31-71`),
+  which calls
+  `HistoryToolNormalization.ensureToolResponseCompleteness`
+  (`packages/core/src/services/history/historyToolNormalization.ts:219-286`)
+  to synthesize a `tool_response` carrying
+  `error: 'Tool call interrupted or cancelled'` for every orphaned tool call,
+  for ALL providers, before any provider-specific converter runs. (This is the
+  same mechanism that makes the pre-existing 413 recovery safe.)
+- **A proven, guarded synthetic-advice-and-reissue mechanism already exists** —
+  `handle413Error` (`MessageStreamTerminalHandler.ts:114-167`), guarded against
+  looping by the `ctx.is413Retry` one-shot flag.
+
+## Accepted behaviour (acceptance criteria)
+
+**AC1 — Detection and recovery.**
+When the terminal `Error` event carries `status === 400`, a message that
+identifies rejected/unsupported *content* (see AC8 for the classifier
+contract), **and** the failing `initialRequest` actually carried tool
+evidence (`describeRejectedPayload(initialRequest)` yields non-empty
+`toolNames` **or** non-empty `mediaDescriptors`), the orchestrator injects a
+synthetic advice message and re-issues the request via
+`deps.sendMessageStream`, exactly as the 413 path does. A 400 that matches the
+message classifier but whose request carried no tool evidence (e.g.
+user-pasted content) does NOT recover — the iteration ends as today, so the
+advice never falsely claims "content supplied by a tool result".
+
+**AC2 — Precision: non-content 400s are unaffected.**
+A 400 whose message does not identify rejected content ends the iteration
+exactly as today (no extra `turn.run`, no injected message). Representative
+messages that must NOT trigger recovery:
+
+| message                                                                     | why                     |
+| --------------------------------------------------------------------------- | ----------------------- |
+| `Invalid JSON payload received. Unknown name "foo"`                          | request-shape error     |
+| `Invalid value for 'temperature': must be <= 2`                              | parameter error         |
+| `This model's maximum context length is 128000 tokens`                       | context overflow        |
+| `Invalid schema for function 'x': exceeds maximum nesting depth`             | tool-schema depth       |
+| `missing required parameter: 'model'`                                        | request-shape error     |
+| `Invalid tool call: file_path is required`                                   | tool-arg error          |
+
+**AC3 — Other statuses unchanged.**
+`undefined`, `401`, `413`, `429`, `500` are untouched. The 413 branch keeps its
+current message text verbatim and keeps winning for 413.
+
+**AC4 — Advice content.**
+The injected message is a single `{ type: 'text' }` block that:
+
+- states the provider rejected the previous request with HTTP 400 because
+  tool-supplied content was invalid/unsupported for its declared type;
+- quotes the provider message (truncated to at most 300 characters, with a
+  trailing `…` when truncated);
+- states the rejected content was **not** added to the conversation;
+- names the tools involved, when the failing request carried tool responses;
+- names the rejected media (filename and/or MIME type), when the failing
+  request carried `media` blocks;
+- instructs the model not to resend the same content or repeat the identical
+  tool call, and to try a different approach — explicitly offering "if a file
+  was sent as an image or other binary attachment but is actually text or
+  source code, read it as text instead".
+
+It contains **no** hardcoded file extension and **no** hardcoded tool name.
+
+**AC5 — Loop guard (one recovery per model round-trip).**
+The re-issued call is flagged so a second content-rejection 400 inside it does
+**not** inject again; the iteration ends with a warning log, mirroring the
+repeated-413 behaviour. The guard is shared with the 413 path so a
+413-then-400 (or 400-then-413) sequence inside one round-trip also injects at
+most once.
+
+**AC6 — Gating identical to 413.**
+Recovery runs only when `config.getContinueOnFailedApiCall()` is `true` and
+`canRetryFailedStream(state)` holds (no tool call, content, or thinking was
+already emitted in this turn) **and** (per AC1) the failing request carried
+tool evidence. Otherwise the iteration ends as today.
+
+**AC7 — The user still sees the error.**
+The `Error` event is yielded to the consumer before recovery is attempted
+(it is yielded in `MessageStreamOrchestrator._processStreamIteration` at
+line 448, before `handleTerminalEvent` at line 452). This is unchanged.
+
+**AC8 — Classifier contract (generic, provider-neutral).**
+`isToolContentRejection(status, message)` returns `true` iff `status === 400`
+**and** the lower-cased message contains **both**
+
+- at least one *content term* — `image`, `image data`, `image_url`,
+  `input_image`, `picture`, `photo`, `screenshot`, `audio`, `video`,
+  `document`, `pdf`, `media`, `media type`, `mime type`, `content type`,
+  `attachment`, `inline data`, `inline_data`, `base64`, `data uri`,
+  `file format`, `file type`, `file data`, `file_data`, `uploaded file`,
+  `multimodal`; and
+- at least one *rejection term* — `not a valid`, `does not represent a valid`,
+  `is not valid`, `should be a valid`, `invalid`, `unsupported`,
+  `not supported`, `unable to process`, `could not process`, `cannot process`,
+  `unable to decode`, `could not decode`, `failed to decode`,
+  `failed to process`, `failed to parse`, `failed to download`,
+  `could not download`, `unable to download`, `does not match`, `malformed`,
+  `corrupt`, `unrecognized`, `unrecognised`, `supported formats`.
+
+Matching is case-insensitive. A missing/empty/non-string message returns
+`false`. A missing/non-400 status returns `false`. Bare `file` is deliberately
+excluded from the content terms because `Invalid tool call: file_path is
+required` must not match (AC2).
+
+**Word boundaries for content terms.** Content terms are matched with an
+index scan that requires the characters immediately before and after the
+match (when present) to be non-word characters, where a word character is
+`a`-`z`, `0`-`9`, or `_` (the text is already lower-cased). This prevents
+`image` from matching inside `read_image` or `image_path`, while still
+matching `image.source.base64` and `['image/jpeg', 'image/png', ...]` since
+`.`, `/`, `'`, and `[` are not word characters. Rejection terms are multi-word
+phrases and remain plain substring matches.
+
+Detection is implemented with plain lower-cased scans — **no regular
+expressions** — so it cannot backtrack and satisfies `sonarjs/slow-regex`.
+
+**AC9 — Request-shape tolerance.**
+Tool names and media descriptors are extracted after normalising the failing
+request through `iContentFromAgentMessageInput`, so `string`,
+`ContentBlock[]`, `IContent`, and `IContent[]` request shapes all work.
+Duplicate tool names and duplicate media descriptors are de-duplicated and
+kept in first-seen order.
+
+## Explicitly out of scope
+
+- The `.fh` MIME misclassification itself (fixed by #2719).
+- Any change to which statuses `retryWithBackoff` / `turnRetryPolicy` retry.
+- Proactive sanitisation of media before sending, history repair/rewriting, or
+  the `enforceImageBudget` (413/size) path.
+- The `DirectMessageProcessor` non-streaming path and the compression pipeline.
+- Any new user-facing setting.
+
+## Design
+
+### New module — `packages/agents/src/core/toolContentRejection.ts`
+
+Pure, dependency-light, fully unit-testable:
+
+```ts
+export function isToolContentRejection(
+  status: number | undefined,
+  message: unknown,
+): boolean;
+
+export interface RejectedPayloadDescription {
+  readonly toolNames: readonly string[];
+  readonly mediaDescriptors: readonly string[];
+}
+
+export function describeRejectedPayload(
+  request: AgentMessageInput,
+): RejectedPayloadDescription;
+
+export function buildToolContentRejectionAdvice(
+  description: RejectedPayloadDescription,
+  providerMessage: string,
+): string;
+```
+
+`extractToolName` / `extractToolNamesFromRequest` currently live in
+`MessageStreamTerminalHandler.ts:78-112`. **Move them into the new module**
+(exported) and import them back into the handler so the 413 path and the new
+400 path share one implementation — no duplicated tool-name parsing. The move
+must be behaviour-preserving: the existing 413 assertion in
+`packages/agents/src/core/client.sendMessageStream-errors.test.ts:322`
+(`… The tools involved were: read_file, search_file. …`) must keep passing
+unchanged. `describeRejectedPayload` normalises via
+`iContentFromAgentMessageInput` before scanning blocks (AC9); it reuses the
+same per-block tool-name extraction.
+
+Media descriptor formatting, from a `MediaBlock`
+(`packages/core/src/services/history/IContent.ts:273`):
+
+- `filename` present → `` `${filename} (${mimeType})` ``
+- otherwise → `` `${mimeType}` ``
+
+### Loop-guard flag rename
+
+`is413Retry` becomes `isPayloadRecoveryRetry` (same positional slot, same
+default `false`, same semantics plus the new 400 case). Renaming avoids adding
+a seventh positional boolean parameter to a public contract while making the
+now-shared meaning explicit. Sites to update:
+
+- `packages/core/src/core/clientContract.ts:159`
+- `packages/agents/src/core/client.ts:742,752`
+- `packages/agents/src/core/MessageStreamOrchestrator.ts:69,86,149,165`
+- `packages/agents/src/core/MessageStreamTerminalHandler.ts:123`
+- `packages/cli/src/integration-tests/todo-continuation.integration.test.ts:274,283,310`
+
+### Handler change — `MessageStreamTerminalHandler.ts`
+
+Add `handleToolContentRejection400`, structurally parallel to
+`handle413Error`, and dispatch to it from `handleErrorEvent` after the 413
+branch:
+
+```ts
+if (
+  isToolContentRejection(errorStatus, getErrorMessage(event)) &&
+  config.getContinueOnFailedApiCall() &&
+  canRetryFailedStream(state)
+) { … }
+```
+
+A `getErrorMessage(event)` reader is added next to the existing
+`getErrorStatus(event)` (same defensive narrowing over
+`event.value.error.message`).
+
+Keep the file under `max-lines: 800` and each function under
+`max-lines-per-function: 80` (current file is 322 lines; moving the two
+extractors out offsets the additions).
+
+### Advice message template (exact)
+
+```
+System: The provider rejected the previous request with HTTP 400 because
+content supplied by a tool result was invalid or unsupported for its declared
+type. Provider message: "<TRUNCATED_PROVIDER_MESSAGE>". That content was not
+added to the conversation.<TOOL_CLAUSE><MEDIA_CLAUSE> Do not resend the same
+content or repeat the same tool call with the same arguments. Try a different
+approach instead — for example, if a file was sent as an image or other binary
+attachment but is actually text or source code, read it as text.
+```
+
+(Emitted as one line; the wrapping above is presentational only.)
+
+- `<TOOL_CLAUSE>` = `` ` The tools involved were: ${names.join(', ')}.` `` when
+  non-empty, else `''`.
+- `<MEDIA_CLAUSE>` = `` ` The rejected content was: ${descriptors.join(', ')}.` ``
+  when non-empty, else `''`.
+- `<TRUNCATED_PROVIDER_MESSAGE>` = trimmed message, truncated to 300 characters
+  with a trailing `…` when it was longer. An empty/blank provider message
+  drops the whole `Provider message: "…".` sentence.
+
+## Test plan (test-first, `bun:test` via the package test facade)
+
+### Unit — `packages/agents/src/core/toolContentRejection.test.ts`
+
+`isToolContentRejection`:
+
+1. `true` for the verbatim #2719 message at status 400.
+2. `true` (table-driven) for provider phrasing variants across content types:
+   OpenAI `You uploaded an unsupported image…`; Anthropic
+   `image does not match the provided media type`; `Could not process image`;
+   `Invalid base64 data`; `Unsupported document type`; `unable to decode audio`;
+   `Invalid MIME type. Only image types are supported.`;
+   `Unsupported video format`.
+3. `false` (table-driven) for every AC2 row.
+4. `false` for status `413`, `429`, `500`, `undefined` with an otherwise
+   matching message.
+5. `false` for `undefined`, `null`, `''`, `'   '`, and non-string messages.
+6. Case-insensitive: an all-upper-case variant of case 1 returns `true`.
+
+`describeRejectedPayload`:
+
+7. Extracts tool names from a `ContentBlock[]` containing `tool_response`
+   blocks, in first-seen order, de-duplicated.
+8. Extracts the same names from the equivalent `IContent[]` shape (AC9).
+9. Extracts media descriptors `shader.fh (image/png)` (filename present) and
+   `image/png` (filename absent), de-duplicated.
+10. Returns empty arrays for a plain string request and for `[]`.
+
+`buildToolContentRejectionAdvice`:
+
+11. Includes tool clause and media clause when both are present, and the
+    provider message, and the "read it as text" guidance.
+12. Omits the tool clause when there are no tool names; omits the media clause
+    when there are no media descriptors.
+13. Truncates a 1000-character provider message to 300 characters plus `…`.
+14. Drops the `Provider message:` sentence for a blank provider message.
+15. Contains no `.fh` and no hardcoded tool name (AC4 guard).
+
+### Behavioural — `packages/agents/src/core/client.sendMessageStream-toolContent400.test.ts`
+
+Modelled on the existing 413 suite
+(`client.sendMessageStream-errors.test.ts`), driving the real
+`AgentClient.sendMessageStream` with a mocked `Turn.run`:
+
+16. **AC1/AC4** — first stream yields an `Error` event with the #2719 message
+    at status 400 and the request carries a `read_file` `tool_response` plus a
+    `media` block; second stream yields content. Asserts: the error event is
+    still emitted, `turn.run` is called twice, and the second call's request is
+    the single advice text block naming `read_file`, the media descriptor, and
+    the alternative-approach guidance.
+17. **AC2** — a 400 with `Invalid value for 'temperature': must be <= 2` calls
+    `turn.run` exactly once and emits only the error event.
+18. **AC5** — a stream that always yields the content-rejection 400 calls
+    `turn.run` exactly twice (one recovery, then stop).
+19. **AC6a** — with `getContinueOnFailedApiCall()` returning `false`,
+    `turn.run` is called once.
+20. **AC6b** — when a `Content` event precedes the content-rejection 400,
+    `turn.run` is called once (`canRetryFailedStream` false).
+21. **AC3** — the existing 413 assertions in
+    `client.sendMessageStream-errors.test.ts` still pass verbatim after the
+    extractor move and the flag rename (regression guard, no new test needed).
+
+All new/changed tests import the test API from the package facade
+(`../testApi.js`) and run under `bun test`. No Vitest suites are added or
+modified.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, and
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.


### PR DESCRIPTION
## TLDR

When a tool result carries content the provider will not accept, the request that follows is rejected with a 400 and the turn dies with a raw `[API Error: ...]`. The model is never told the *content* was the problem, so it cannot self-correct — in #2719 `gpt-5.6-sol` eventually resorted to `cat`-ing the files with the shell tool.

A tool-content 400 now takes the same guarded synthetic-advice path the existing HTTP 413 overflow recovery already uses: the error is still shown to the user, then a system message is injected naming the tools involved, the rejected media (filename + MIME type) and the provider's own wording, and the request is re-issued **once** so the model can try a different approach.

Reviewers should look hardest at two things: the classifier's precision/recall (`isToolContentRejection`) and the claim that re-issuing a bare text message after a failed tool-response request is structurally safe — there is a dedicated test pinning the latter.

## Dive Deeper

### Where the failure actually happens

The rejection is not a tool-execution error. `read_file` succeeds and emits a base64 `media` block; the provider rejects the **next** request, which now carries that block:

```
The image data you provided does not represent a valid image. Please check your
input and try again with one of the supported image formats: ['image/jpeg',
'image/png', 'image/gif', 'image/webp']. (Status: 400)
```

That 400 is not retryable, so it travels intact up to `handleErrorEvent`
(`packages/agents/src/core/MessageStreamTerminalHandler.ts`) — which had a recovery branch for `413` and nothing else. Everything else fell through to "error event ending iteration without retry".

### Detection is provider-neutral, not `.fh`-, `read_file`- or image-specific

`isToolContentRejection(status, message)` requires `status === 400` **and** both:

- a **content term** — `image`, `image data`, `image_url`, `input_image`, `picture`, `photo`, `screenshot`, `audio`, `video`, `document`, `pdf`, `media`, `media type`, `mime type`, `content type`, `attachment`, `inline data`, `inline_data`, `base64`, `data uri`, `file format`, `file type`, `file data`, `file_data`, `uploaded file`, `multimodal`
- a **rejection term** — `not a valid`, `does not represent a valid`, `is not valid`, `should be a valid`, `invalid`, `unsupported`, `not supported`, `unable to/could not/cannot process`, `unable to/could not/failed to decode`, `failed to process`, `failed to parse`, `failed to/could not/unable to download`, `does not match`, `malformed`, `corrupt`, `unrecognized`, `unrecognised`, `supported formats`

Precision measures, because a false positive burns a round-trip and shows the model a misleading message:

- **Word-boundary matching for content terms.** `Invalid schema for function 'read_image'` and `Invalid tool call: image_path is required` do **not** match, because `image` there is glued to `_`. Bare `file` is excluded from the term list for the same reason (`file_path is required`).
- **Tool-relatedness gate.** Recovery additionally requires the failing request to have carried real tool evidence (a `tool_response` or a `media` block). A 400 caused by user-pasted content is therefore never described to the model as rejected *tool* output.
- **No regular expressions.** Matching is an index scan, so it cannot backtrack (`sonarjs/slow-regex` stays satisfied).

Recall is covered for OpenAI, Anthropic, Gemini and gateway phrasings, including `You uploaded an unsupported image...`, `image does not match the provided media type`, `...image.source.base64: Input should be a valid string`, `Multimodal function responses are not supported for this model` and `Failed to download file from ...`.

### Why re-issuing a bare text message is safe

The rejected content is never persisted — user and tool contents reach history only after a *successful* send, and the 400 aborts before that. What remains is the previous AI turn's `tool_call` with no matching `tool_response`.

That orphan is closed for **every** provider by `HistoryService.getCuratedForProvider` → `buildProviderContent` (`packages/core/src/services/history/historyProviderPipeline.ts`) → `HistoryToolNormalization.ensureToolResponseCompleteness` (`packages/core/src/services/history/historyToolNormalization.ts`), which synthesises a `tool_response` carrying `error: 'Tool call interrupted or cancelled'` *before* any provider-specific converter runs. This is the same property the pre-existing 413 recovery has always relied on; it was previously untested, and this PR adds a test that pins it.

### Loop guard

`is413Retry` is renamed `isPayloadRecoveryRetry`. Both recoveries consult the one flag, so at most one advice message is injected per model round-trip and a 413-then-400 (or 400-then-413) sequence cannot ping-pong. The rename avoids adding a seventh positional boolean to `AgentClientContract.sendMessageStream`. `extractToolName` / `extractToolNamesFromRequest` move into the new module so the 413 and 400 paths share one implementation — the 413 message text is byte-identical and its existing assertions are untouched.

### Gating (identical to 413)

Recovery runs only when `config.getContinueOnFailedApiCall()` is true and nothing was already emitted this turn (`canRetryFailedStream`). The `Error` event is always yielded to the consumer first, so the user still sees the API error.

### Files

| file | change |
| --- | --- |
| `packages/agents/src/core/toolContentRejection.ts` | new: classifier, payload description, advice builder, shared tool-name extractors |
| `packages/agents/src/core/MessageStreamTerminalHandler.ts` | `handleToolContentRejection400` + dispatch; shared `getErrorPayload` narrowing |
| `packages/agents/src/core/MessageStreamOrchestrator.ts`, `client.ts`, `packages/core/src/core/clientContract.ts` | `is413Retry` → `isPayloadRecoveryRetry` |
| `packages/agents/src/core/toolContentRejection.test.ts` | 50 unit tests (classifier tables, extraction, advice) |
| `packages/agents/src/core/client.sendMessageStream-toolContent400.test.ts` | behavioural tests through `AgentClient.sendMessageStream` + the orphan-closure test |
| `project-plans/issue2722/plan.md` | accepted plan / acceptance criteria |

### Explicitly out of scope

The `.fh` MIME misclassification itself (fixed by #2719); changes to which statuses are retried; proactive media sanitisation, history rewriting, or the `enforceImageBudget` (413/size) path; the non-streaming `DirectMessageProcessor` path; any new user-facing setting.

## Reviewer Test Plan

**Automated**

```bash
cd packages/agents
bun test src/core/toolContentRejection.test.ts \
         src/core/client.sendMessageStream-toolContent400.test.ts \
         src/core/client.sendMessageStream-errors.test.ts
```

63 tests. The third file is the pre-existing 413 suite, included unmodified as a regression guard for the extractor move and the flag rename.

**Manual**

The cheapest reproduction is a text file with a binary-ish extension that the MIME detector classifies as an image. Create one, then ask the model to read it:

1. `printf 'uniform float t;\n' > /tmp/demo.<ext>` for an `<ext>` your platform maps to an image type.
2. Start the CLI against a provider that validates image payloads (Gemini, OpenAI, or an OpenAI-compatible gateway).
3. Prompt: `read /tmp/demo.<ext> and tell me what it does`.

Before: the turn ends with `[API Error: ... (Status: 400)]`.
After: the same error is shown, then the model receives the advice message and retries with a different approach (typically reading the file as text) without user intervention.

Worth also confirming the negative path — a genuine parameter 400 (e.g. an out-of-range `temperature`) must **not** trigger a retry.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run build`, the full `packages/agents` Bun suite, and the CLI/core suites, plus the profile smoke run. The change is platform-independent (pure string classification and orchestration).

## Linked issues / bugs

Fixes #2722

Follow-on from #2719, which fixed the specific `.fh` misclassification. This PR makes the *class* of failure recoverable rather than the one extension.
