### PR TITLE
Reject profiles whose named auth key cannot be resolved (Fixes #2916)

### DIFF
--- a/packages/cli/test-bun/profileAuthKeyNameIssue2916.bun.ts
+++ b/packages/cli/test-bun/profileAuthKeyNameIssue2916.bun.ts
@@ -1,0 +1,266 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(dirname(import.meta.dir), '..', '..');
+const CLI_ENTRY = join(REPO_ROOT, 'packages', 'cli', 'index.ts');
+
+const AUTH_KEY_NAME = 'issue2916-ghost-key';
+const PROMPT = 'issue-2916-trap-guard-prompt';
+// Output the local trap would return if a regression ever contacted a
+// provider. Distinct from PROMPT so its absence proves no model output.
+const TRAP_MODEL_OUTPUT = 'ISSUE_2916_TRAP_MODEL_OUTPUT_SUCCESS';
+// Deterministic lower-precedence credential inputs. None must ever be used:
+// the unresolved named key must fail before provider invocation, proven by a
+// trap request count of exactly zero.
+const ENV_PROVIDER_KEY = 'issue2916-env-provider-secret';
+const INLINE_AUTH_KEY = 'issue2916-inline-fallback-secret';
+const KEYFILE_SECRET = 'issue2916-keyfile-fallback-secret';
+
+// Essential executable/platform variables, copied individually (never spread
+// from process.env) so no ambient keyring, proxy, provider credential,
+// dotenv/config path, or unrelated LLXPRT_* variable leaks into the child.
+const PLATFORM_ENV_KEYS = [
+  'PATH',
+  'USER',
+  'SHELL',
+  'LANG',
+  'LC_ALL',
+  'TMPDIR',
+  'TERM',
+] as const;
+
+interface CliRunResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/**
+ * Runs the CLI as an isolated subprocess, draining stdout/stderr immediately
+ * and racing process exit against a timeout. On timeout only the tracked
+ * child PID is terminated (never a broad process-group kill); exit and both
+ * stream drains are always awaited before returning.
+ */
+async function runCli(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+  timeoutMs: number,
+): Promise<CliRunResult> {
+  const proc = Bun.spawn({
+    cmd: [process.execPath, CLI_ENTRY, ...args],
+    cwd,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  // Drain both streams immediately so a full pipe buffer cannot deadlock the
+  // child before it exits.
+  const stdoutDone = new Response(proc.stdout).text();
+  const stderrDone = new Response(proc.stderr).text();
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<boolean>((resolveTimeout) => {
+    timeoutHandle = setTimeout(() => resolveTimeout(true), timeoutMs);
+  });
+
+  let exitCode: number | null = null;
+  let timedOut = false;
+  try {
+    const outcome = await Promise.race([
+      proc.exited.then<number | null>((code) => code),
+      timeoutPromise.then<number | null>(() => null),
+    ]);
+    if (outcome === null) {
+      timedOut = true;
+    } else {
+      exitCode = outcome;
+    }
+  } finally {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
+    if (timedOut) {
+      try {
+        proc.kill();
+      } catch {
+        // The child exited between the timeout firing and termination.
+      }
+      await proc.exited;
+    }
+  }
+
+  const [stdout, stderr] = await Promise.all([stdoutDone, stderrDone]);
+  return { exitCode, stdout, stderr, timedOut };
+}
+
+describe('issue #2916 CLI subprocess: unresolved auth-key-name fails fast', () => {
+  let tempRoot: string | null = null;
+  let trapServer: ReturnType<typeof Bun.serve> | null = null;
+
+  afterEach(() => {
+    if (trapServer !== null) {
+      trapServer.stop();
+      trapServer = null;
+    }
+    if (tempRoot !== null) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+  });
+
+  it('exits non-zero with an actionable named-key error and never contacts a provider', async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'llxprt-cli-2916-'));
+    const configHome = join(tempRoot, 'config');
+    const dataHome = join(tempRoot, 'data');
+    const cacheHome = join(tempRoot, 'cache');
+    const logHome = join(tempRoot, 'log');
+    const fakeHome = join(tempRoot, 'home');
+    const workspaceCwd = join(tempRoot, 'workspace');
+    for (const dir of [
+      configHome,
+      dataHome,
+      cacheHome,
+      logHome,
+      fakeHome,
+      workspaceCwd,
+    ]) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    // A unique, request-counting local HTTP trap configured as the profile
+    // base-url. If profile application ever fell through to provider
+    // invocation (a regression), the provider would POST here and increment
+    // the counter. The assertion that the count is exactly zero proves the
+    // unresolved named key fails before any provider call — and that no
+    // external OpenAI endpoint is ever contacted.
+    const trap = { requestCount: 0 };
+    trapServer = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch() {
+        trap.requestCount += 1;
+        return new Response(
+          JSON.stringify({
+            id: 'chatcmpl-issue2916-trap',
+            object: 'chat.completion',
+            created: 1,
+            model: 'issue2916-trap-model',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: TRAP_MODEL_OUTPUT },
+                finish_reason: 'stop',
+              },
+            ],
+            usage: {
+              prompt_tokens: 1,
+              completion_tokens: 1,
+              total_tokens: 2,
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        );
+      },
+    });
+    const trapBaseUrl = `http://127.0.0.1:${trapServer.port}/v1`;
+
+    const keyfilePath = join(tempRoot, 'lower-precedence.key');
+    writeFileSync(keyfilePath, `${KEYFILE_SECRET}\n`);
+
+    mkdirSync(join(configHome, 'profiles'), { recursive: true });
+    writeFileSync(
+      join(configHome, 'profiles', 'issue2916.json'),
+      JSON.stringify(
+        {
+          version: 1,
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          modelParams: {},
+          ephemeralSettings: {
+            'auth-key-name': AUTH_KEY_NAME,
+            'base-url': trapBaseUrl,
+            'auth-key': INLINE_AUTH_KEY,
+            'auth-keyfile': keyfilePath,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const env: NodeJS.ProcessEnv = {};
+    for (const key of PLATFORM_ENV_KEYS) {
+      const value = process.env[key];
+      if (value !== undefined) {
+        env[key] = value;
+      }
+    }
+    env.HOME = fakeHome;
+    env.LLXPRT_CONFIG_HOME = configHome;
+    env.LLXPRT_DATA_HOME = dataHome;
+    env.LLXPRT_CACHE_HOME = cacheHome;
+    env.LLXPRT_LOG_HOME = logHome;
+    env.LLXPRT_TEST_DISABLE_OS_KEYRING = '1';
+    // Point system settings/defaults at controlled nonexistent paths so the
+    // child never reads developer system configuration.
+    env.LLXPRT_SYSTEM_SETTINGS_PATH = join(
+      tempRoot,
+      'nonexistent-system-settings.json',
+    );
+    env.LLXPRT_SYSTEM_DEFAULTS_PATH = join(
+      tempRoot,
+      'nonexistent-system-defaults.json',
+    );
+    env.CI = 'true';
+    env.NO_BROWSER = 'true';
+    env.LLXPRT_NO_BROWSER_AUTH = 'true';
+    // Deterministic lower-precedence environment credential input. Proven
+    // unused by the trap request count of zero below.
+    env.OPENAI_API_KEY = ENV_PROVIDER_KEY;
+
+    const { exitCode, stdout, stderr, timedOut } = await runCli(
+      [
+        '--profile-load',
+        'issue2916',
+        '--prompt',
+        PROMPT,
+        '--yolo',
+        '--ide-mode',
+        'disable',
+      ],
+      env,
+      workspaceCwd,
+      45_000,
+    );
+
+    expect(timedOut).toBe(false);
+    const combined = `${stdout}\n${stderr}`;
+
+    expect(exitCode).not.toBe(0);
+    expect(exitCode).not.toBeNull();
+    expect(combined).toContain(AUTH_KEY_NAME);
+    expect(combined).toContain('/key save');
+    // The trap was never contacted: the provider was never invoked.
+    expect(trap.requestCount).toBe(0);
+    // No model output reached the caller.
+    expect(combined).not.toContain(TRAP_MODEL_OUTPUT);
+    // No lower-precedence credential leaked into the error output.
+    expect(combined).not.toContain(ENV_PROVIDER_KEY);
+    expect(combined).not.toContain(INLINE_AUTH_KEY);
+    expect(combined).not.toContain(KEYFILE_SECRET);
+  }, 90_000);
+});

--- a/packages/cli/test-bun/profileAuthKeyNameIssue2916.bun.ts
+++ b/packages/cli/test-bun/profileAuthKeyNameIssue2916.bun.ts
@@ -24,6 +24,9 @@ const ENV_PROVIDER_KEY = 'issue2916-env-provider-secret';
 const INLINE_AUTH_KEY = 'issue2916-inline-fallback-secret';
 const KEYFILE_SECRET = 'issue2916-keyfile-fallback-secret';
 
+/** Grace period allowed for a SIGTERM to land before escalating to SIGKILL. */
+const SIGKILL_GRACE_MS = 5_000;
+
 // Essential executable/platform variables, copied individually (never spread
 // from process.env) so no ambient keyring, proxy, provider credential,
 // dotenv/config path, or unrelated LLXPRT_* variable leaks into the child.
@@ -96,7 +99,22 @@ async function runCli(
       } catch {
         // The child exited between the timeout firing and termination.
       }
-      await proc.exited;
+      // A child that ignores SIGTERM would leave `proc.exited` pending
+      // forever, and awaiting it here outlives the enclosing test timeout —
+      // the run would hang rather than fail. Escalate to SIGKILL, which
+      // cannot be caught, after a short grace period.
+      const reaped = await Promise.race([
+        proc.exited.then(() => true),
+        Bun.sleep(SIGKILL_GRACE_MS).then(() => false),
+      ]);
+      if (!reaped) {
+        try {
+          proc.kill('SIGKILL');
+        } catch {
+          // The child exited during the grace period.
+        }
+        await proc.exited;
+      }
     }
   }
 

--- a/packages/cli/test-bun/profileAuthKeyNameIssue2916.bun.ts
+++ b/packages/cli/test-bun/profileAuthKeyNameIssue2916.bun.ts
@@ -79,6 +79,7 @@ async function runCli(
 
   let exitCode: number | null = null;
   let timedOut = false;
+  let unreapable = false;
   try {
     const outcome = await Promise.race([
       proc.exited.then<number | null>((code) => code),
@@ -113,9 +114,24 @@ async function runCli(
         } catch {
           // The child exited during the grace period.
         }
-        await proc.exited;
+        // Bound this wait too. SIGKILL cannot be caught, but a process stuck
+        // in an uninterruptible wait still will not be reaped, and an
+        // unbounded await here would hang the runner rather than fail it.
+        const killed = await Promise.race([
+          proc.exited.then(() => true),
+          Bun.sleep(SIGKILL_GRACE_MS).then(() => false),
+        ]);
+        // Recorded rather than thrown here: a throw inside finally would
+        // discard whatever exception was already propagating.
+        unreapable = !killed;
       }
     }
+  }
+
+  if (unreapable) {
+    throw new Error(
+      `CLI subprocess (pid ${proc.pid}) survived SIGKILL and could not be reaped.`,
+    );
   }
 
   const [stdout, stderr] = await Promise.all([stdoutDone, stderrDone]);

--- a/packages/providers/src/runtime/__tests__/profileApplication.issue2916.bun.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.issue2916.bun.test.ts
@@ -242,7 +242,10 @@ describe('issue #2916: unresolved auth-key-name rejects profile application', ()
     expect(thrownError?.cause).toBeInstanceOf(Error);
     expect(message).toContain("'prod-key'");
     expect(message).toContain('keyring backend unavailable');
-    expect(message).toContain('/key save prod-key');
+    // A retrieval fault must not advertise the '/key save' remedy: the key may
+    // already be stored and re-saving would overwrite it while leaving the
+    // real fault (locked or unreadable keychain) in place.
+    expect(message).not.toContain('/key save');
   });
 
   it('does not apply an inline auth-key when the named key is unresolved', async () => {

--- a/packages/providers/src/runtime/__tests__/profileApplication.issue2916.bun.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.issue2916.bun.test.ts
@@ -1,0 +1,428 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Profile } from '@vybestack/llxprt-code-settings';
+
+type StorageMode = 'not-found' | 'error' | 'resolved';
+
+interface KeyStorageController {
+  mode: StorageMode;
+  resolvedValue: string | null | undefined;
+  error: Error | null;
+  entries: Map<string, string>;
+}
+
+let keyStorage: KeyStorageController = {
+  mode: 'not-found',
+  resolvedValue: null,
+  error: null,
+  entries: new Map(),
+};
+
+let tempDir: string | null = null;
+
+function createProviderKeyStorageDouble() {
+  return {
+    getKey(name: string): Promise<string | null | undefined> {
+      if (keyStorage.mode === 'error') {
+        return Promise.reject(
+          keyStorage.error ?? new Error('key storage error'),
+        );
+      }
+      if (keyStorage.mode === 'resolved') {
+        return Promise.resolve(keyStorage.resolvedValue);
+      }
+      return Promise.resolve(keyStorage.entries.get(name) ?? null);
+    },
+  };
+}
+
+const configStub = {
+  ephemerals: new Map<string, unknown>(),
+  model: 'gpt-4o' as string | undefined,
+  getModel() {
+    return this.model;
+  },
+  getEphemeralSetting(key: string) {
+    return this.ephemerals.get(key);
+  },
+  setEphemeralSetting(key: string, value: unknown) {
+    if (value === undefined) {
+      this.ephemerals.delete(key);
+      return;
+    }
+    this.ephemerals.set(key, value);
+  },
+  getEphemeralSettings() {
+    return Object.fromEntries(this.ephemerals.entries());
+  },
+  getContentGeneratorConfig() {
+    return undefined;
+  },
+};
+
+const settingsServiceStub = {
+  providerSettings: new Map<string, Record<string, unknown>>(),
+  getProviderSettings(providerName: string) {
+    return (
+      this.providerSettings.get(providerName) ??
+      this.providerSettings.set(providerName, {}).get(providerName)!
+    );
+  },
+  setProviderSetting(providerName: string, key: string, value: unknown) {
+    this.getProviderSettings(providerName)[key] = value;
+  },
+  setCurrentProfileName(_name: string | null) {
+    void _name;
+  },
+  getCurrentProfileName() {
+    return null;
+  },
+};
+
+const providerManagerStub = {
+  available: ['openai'],
+  activeProviderName: 'openai',
+  providerLookup: new Map<
+    string,
+    { name: string; getDefaultModel?: () => string }
+  >([['openai', { name: 'openai', getDefaultModel: () => 'gpt-4o' }]]),
+  listProviders() {
+    return this.available.slice();
+  },
+  getProviderByName(name: string) {
+    return this.providerLookup.get(name) ?? null;
+  },
+  getActiveProviderName() {
+    return this.activeProviderName;
+  },
+  getActiveProvider() {
+    return (
+      this.providerLookup.get(this.activeProviderName) ?? {
+        name: this.activeProviderName,
+        getDefaultModel: () => 'gpt-4o',
+      }
+    );
+  },
+};
+
+await mock.module('../runtimeSettings.js', () => ({
+  getCliRuntimeServices: () => ({
+    config: configStub,
+    settingsService: settingsServiceStub,
+    providerManager: providerManagerStub,
+    profileManager: {
+      loadProfile: async (_name: string) => {
+        void _name;
+        throw new Error('not used for standard profiles');
+      },
+    },
+  }),
+  createProviderKeyStorage: () => createProviderKeyStorageDouble(),
+  setEphemeralSetting: (key: string, value: unknown) =>
+    configStub.setEphemeralSetting(key, value),
+  getEphemeralSetting: (key: string) => configStub.getEphemeralSetting(key),
+  getEphemeralSettings: () => configStub.getEphemeralSettings(),
+  clearActiveModelParam: (_key: string) => {
+    void _key;
+  },
+  getActiveModelParams: () => ({}),
+  setActiveModelParam: (_key: string, _value: unknown) => {
+    void _key;
+    void _value;
+  },
+  isCliRuntimeStatelessReady: () => true,
+  isCliStatelessProviderModeEnabled: () => true,
+  switchActiveProvider: async (providerName: string) => {
+    providerManagerStub.activeProviderName = providerName;
+    return { infoMessages: [] as string[], changed: true };
+  },
+  setActiveModel: async (model: string) => {
+    void model;
+    return { nextModel: 'gpt-4o' };
+  },
+  updateActiveProviderApiKey: async (_apiKey: string | null) => {
+    void _apiKey;
+    return {};
+  },
+  updateActiveProviderBaseUrl: async (_baseUrl: string | null) => {
+    void _baseUrl;
+    return {};
+  },
+}));
+
+const { applyProfileWithGuards } = await import('../profileApplication.js');
+
+function standardProfile(authKeyName: unknown): Profile {
+  return {
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: {},
+    ephemeralSettings: { 'auth-key-name': authKeyName },
+  };
+}
+
+function providerAuthKey(): unknown {
+  return settingsServiceStub.getProviderSettings('openai')['auth-key'];
+}
+
+async function captureRejection(
+  promise: Promise<unknown>,
+): Promise<{ thrown: unknown; message: string }> {
+  return promise.then(
+    () => ({ thrown: undefined, message: '' }),
+    (error: unknown) => ({
+      thrown: error,
+      message: error instanceof Error ? error.message : String(error),
+    }),
+  );
+}
+
+function asError(value: unknown): Error | undefined {
+  return value instanceof Error ? value : undefined;
+}
+
+describe('issue #2916: unresolved auth-key-name rejects profile application', () => {
+  beforeEach(() => {
+    configStub.ephemerals.clear();
+    configStub.model = 'gpt-4o';
+    settingsServiceStub.providerSettings.clear();
+    providerManagerStub.available = ['openai'];
+    providerManagerStub.activeProviderName = 'openai';
+    providerManagerStub.providerLookup = new Map([
+      ['openai', { name: 'openai', getDefaultModel: () => 'gpt-4o' }],
+    ]);
+    keyStorage = {
+      mode: 'not-found',
+      resolvedValue: null,
+      error: null,
+      entries: new Map(),
+    };
+    tempDir = null;
+  });
+
+  afterEach(() => {
+    if (tempDir !== null) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects when provider key storage returns no secret for a named key', async () => {
+    keyStorage.mode = 'not-found';
+
+    const { thrown, message } = await captureRejection(
+      applyProfileWithGuards(standardProfile('work-key')),
+    );
+
+    expect(thrown).toBeDefined();
+    expect(message).toContain("Named key 'work-key' not found");
+    expect(message).toContain('/key save work-key');
+  });
+
+  it('rejects with the original storage error as cause', async () => {
+    const storageError = new Error('keyring backend unavailable');
+    keyStorage.mode = 'error';
+    keyStorage.error = storageError;
+
+    const { thrown, message } = await captureRejection(
+      applyProfileWithGuards(standardProfile('prod-key')),
+    );
+
+    const thrownError = asError(thrown);
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError?.cause).toBe(storageError);
+    expect(thrownError?.cause).toBeInstanceOf(Error);
+    expect(message).toContain("'prod-key'");
+    expect(message).toContain('keyring backend unavailable');
+    expect(message).toContain('/key save prod-key');
+  });
+
+  it('does not apply an inline auth-key when the named key is unresolved', async () => {
+    keyStorage.mode = 'not-found';
+    const profileWithFallback: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {
+        'auth-key-name': 'ghost-key',
+        'auth-key': 'inline-fallback-secret',
+      },
+    };
+
+    const { thrown, message } = await captureRejection(
+      applyProfileWithGuards(profileWithFallback),
+    );
+
+    expect(thrown).toBeDefined();
+    expect(message).toContain("Named key 'ghost-key' not found");
+    expect(providerAuthKey()).not.toBe('inline-fallback-secret');
+  });
+
+  it('does not apply a keyfile credential when the named key is unresolved', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-2916-keyfile-'));
+    const keyfilePath = join(tempDir, 'key');
+    writeFileSync(keyfilePath, 'keyfile-fallback-secret');
+
+    keyStorage.mode = 'not-found';
+    const profileWithKeyfile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {
+        'auth-key-name': 'ghost-key',
+        'auth-keyfile': keyfilePath,
+      },
+    };
+
+    const { thrown, message } = await captureRejection(
+      applyProfileWithGuards(profileWithKeyfile),
+    );
+
+    expect(thrown).toBeDefined();
+    expect(message).toContain("Named key 'ghost-key' not found");
+    expect(providerAuthKey()).not.toBe('keyfile-fallback-secret');
+    expect(
+      settingsServiceStub.getProviderSettings('openai')['auth-keyfile'],
+    ).toBeUndefined();
+  });
+
+  it('does not replace a previously configured provider credential when the named key is unresolved', async () => {
+    settingsServiceStub.setProviderSetting(
+      'openai',
+      'auth-key',
+      'prior-configured-secret',
+    );
+    keyStorage.mode = 'not-found';
+
+    const { thrown, message } = await captureRejection(
+      applyProfileWithGuards(standardProfile('ghost-key')),
+    );
+
+    expect(thrown).toBeDefined();
+    expect(message).toContain("Named key 'ghost-key' not found");
+    expect(providerAuthKey()).toBe('prior-configured-secret');
+  });
+
+  it('does not leave the unresolved name in ephemerals after a failed resolution', async () => {
+    keyStorage.mode = 'not-found';
+
+    const { thrown } = await captureRejection(
+      applyProfileWithGuards(standardProfile('ghost-key')),
+    );
+
+    expect(thrown).toBeDefined();
+    expect(configStub.getEphemeralSetting('auth-key-name')).toBeUndefined();
+  });
+
+  it('preserves prior application state when named-key resolution fails', async () => {
+    configStub.setEphemeralSetting('context-limit', 50000);
+    configStub.setEphemeralSetting('auth-key', 'prior-applied-secret');
+    settingsServiceStub.setProviderSetting(
+      'openai',
+      'auth-key',
+      'prior-provider-secret',
+    );
+    keyStorage.mode = 'not-found';
+
+    const { thrown, message } = await captureRejection(
+      applyProfileWithGuards(standardProfile('ghost-key')),
+    );
+
+    expect(thrown).toBeDefined();
+    expect(message).toContain("Named key 'ghost-key' not found");
+    // Prior non-auth ephemeral must survive a failed apply.
+    expect(configStub.getEphemeralSetting('context-limit')).toBe(50000);
+    // Prior auth ephemeral must survive a failed apply.
+    expect(configStub.getEphemeralSetting('auth-key')).toBe(
+      'prior-applied-secret',
+    );
+    // Prior provider auth must survive a failed apply.
+    expect(providerAuthKey()).toBe('prior-provider-secret');
+    // The unresolved new name must never be installed.
+    expect(configStub.getEphemeralSetting('auth-key-name')).toBeUndefined();
+  });
+
+  const unresolvedStoredResults: ReadonlyArray<{
+    label: string;
+    storedValue: string | null | undefined;
+  }> = [
+    { label: 'null', storedValue: null },
+    { label: 'undefined', storedValue: undefined },
+    { label: 'empty string', storedValue: '' },
+    { label: 'whitespace', storedValue: '   ' },
+  ];
+
+  for (const { label, storedValue } of unresolvedStoredResults) {
+    it(`fails as unresolved when storage returns ${label} for a named key`, async () => {
+      keyStorage.mode = 'resolved';
+      keyStorage.resolvedValue = storedValue;
+
+      const { thrown, message } = await captureRejection(
+        applyProfileWithGuards(standardProfile('work-key')),
+      );
+
+      expect(thrown).toBeDefined();
+      expect(message).toContain("Named key 'work-key' not found");
+      expect(providerAuthKey()).toBeUndefined();
+      expect(configStub.getEphemeralSetting('auth-key-name')).toBeUndefined();
+    });
+  }
+
+  it('applies a resolved named key and preserves the name reference', async () => {
+    keyStorage.mode = 'resolved';
+    keyStorage.resolvedValue = 'resolved-secret-value';
+
+    const result = await applyProfileWithGuards(standardProfile('work-key'));
+
+    expect(result.providerName).toBe('openai');
+    expect(configStub.getEphemeralSetting('auth-key-name')).toBe('work-key');
+    expect(providerAuthKey()).toBe('resolved-secret-value');
+  });
+
+  const nonNamedNameInputs: ReadonlyArray<{
+    label: string;
+    nameValue: unknown;
+    omit: boolean;
+  }> = [
+    { label: 'absent', nameValue: undefined, omit: true },
+    { label: 'null', nameValue: null, omit: false },
+    { label: 'a non-string number', nameValue: 123, omit: false },
+    { label: 'empty string', nameValue: '', omit: false },
+    { label: 'whitespace', nameValue: '   ', omit: false },
+  ];
+
+  for (const { label, nameValue, omit } of nonNamedNameInputs) {
+    it(`does not treat ${label} auth-key-name as a named credential and keeps lower-precedence auth`, async () => {
+      // Storage errors prove the named-key lookup never ran: had the name been
+      // treated as a credential, storage would be queried and throw, failing
+      // the apply. Instead the lower-precedence inline key must be applied.
+      keyStorage.mode = 'error';
+      keyStorage.error = new Error('storage must not be reached');
+      const profileWithInline: Profile = {
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {
+          ...(omit ? {} : { 'auth-key-name': nameValue }),
+          'auth-key': 'inline-direct-key',
+        },
+      };
+
+      await applyProfileWithGuards(profileWithInline);
+
+      expect(configStub.getEphemeralSetting('auth-key-name')).toBeUndefined();
+      expect(providerAuthKey()).toBe('inline-direct-key');
+    });
+  }
+});

--- a/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
@@ -92,7 +92,6 @@ describe('STEP 2 workflow: pre-switch auth wiring', () => {
 
   afterEach(() => {
     restoreGcpEnvVars(savedGcpProject, savedGcpLocation);
-    mock.clearAllMocks();
   });
   it('sets auth-keyfile ephemeral and provider setting from keyfile before switch', async () => {
     mockReadFile.mockResolvedValue('keyfile-api-key');
@@ -282,7 +281,6 @@ describe('STEP 5 workflow: non-auth ephemerals', () => {
 
   afterEach(() => {
     restoreGcpEnvVars(savedGcpProject, savedGcpLocation);
-    mock.clearAllMocks();
   });
   it('applies non-auth ephemeral settings after provider switch', async () => {
     providerManagerStub.available = ['openai'];
@@ -432,7 +430,6 @@ describe('STEP 6 workflow: model and modelParams application', () => {
 
   afterEach(() => {
     restoreGcpEnvVars(savedGcpProject, savedGcpLocation);
-    mock.clearAllMocks();
   });
   it('sets the requested model and returns it in result', async () => {
     providerManagerStub.available = ['openai'];

--- a/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
@@ -45,10 +45,19 @@ async function expectRejection(
   pattern: RegExp,
 ): Promise<void> {
   let thrown: unknown;
+  let rejected = false;
   try {
     await promise;
   } catch (error) {
     thrown = error;
+    rejected = true;
+  }
+  // Without this guard a promise that stops rejecting reports "expected
+  // undefined to be an instance of Error", which hides the actual regression.
+  if (!rejected) {
+    throw new Error(
+      `Expected the promise to reject with a message matching ${pattern}, but it resolved.`,
+    );
   }
   expect(thrown).toBeInstanceOf(Error);
   expect((thrown as Error).message).toMatch(pattern);

--- a/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
@@ -3,8 +3,9 @@
  * Split from profileApplication.test.ts during #2092 lint hardening.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { importActualSync } from '@vybestack/llxprt-code-test-utils';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createRequire } from 'node:module';
+import type * as FsPromises from 'node:fs/promises';
 import type { Profile } from '@vybestack/llxprt-code-settings';
 import {
   switchActiveProviderMock,
@@ -28,18 +29,32 @@ import {
   restoreGcpEnvVars,
 } from './profileApplicationTestSetup.js';
 
-vi.mock('node:fs/promises', () => {
-  const actual =
-    importActualSync<typeof import('node:fs/promises')>('node:fs/promises');
-  return {
-    ...actual,
-    readFile: vi.fn(),
-  };
+const localRequire = createRequire(import.meta.url);
+
+const mockReadFile = mock(
+  localRequire('node:fs/promises').readFile as typeof FsPromises.readFile,
+);
+
+await mock.module('node:fs/promises', () => {
+  const actual = localRequire('node:fs/promises') as typeof FsPromises;
+  return { ...actual, readFile: mockReadFile };
 });
 
-const mockFs = await import('node:fs/promises');
+async function expectRejection(
+  promise: Promise<unknown>,
+  pattern: RegExp,
+): Promise<void> {
+  let thrown: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  expect((thrown as Error).message).toMatch(pattern);
+}
 
-vi.mock('../runtimeSettings.js', () => ({
+await mock.module('../runtimeSettings.js', () => ({
   switchActiveProvider: switchActiveProviderMock,
   setActiveModel: setActiveModelMock,
   updateActiveProviderBaseUrl: updateActiveProviderBaseUrlMock,
@@ -68,10 +83,10 @@ describe('STEP 2 workflow: pre-switch auth wiring', () => {
 
   afterEach(() => {
     restoreGcpEnvVars(savedGcpProject, savedGcpLocation);
-    vi.clearAllMocks();
+    mock.clearAllMocks();
   });
   it('sets auth-keyfile ephemeral and provider setting from keyfile before switch', async () => {
-    vi.mocked(mockFs.readFile).mockResolvedValue('keyfile-api-key');
+    mockReadFile.mockResolvedValue('keyfile-api-key');
 
     providerManagerStub.available = ['anthropic'];
     providerManagerStub.providerLookup = new Map([
@@ -189,36 +204,6 @@ describe('STEP 2 workflow: pre-switch auth wiring', () => {
     expect(setActiveModelMock).not.toHaveBeenCalledWith('gemini-2.5-pro');
   });
 
-  it('adds warning when auth-key-name is missing from secure storage', async () => {
-    keyStorageStub.getKey.mockResolvedValueOnce(null);
-
-    providerManagerStub.available = ['Chutes.ai'];
-    providerManagerStub.providerLookup = new Map([
-      ['Chutes.ai', { name: 'Chutes.ai' }],
-    ]);
-
-    const profile: Profile = {
-      version: 1,
-      provider: 'Chutes.ai',
-      model: 'MiniMaxAI/MiniMax-M2.1-TEE',
-      modelParams: {},
-      ephemeralSettings: {
-        'auth-key-name': 'missing-key',
-      },
-    };
-
-    const result = await applyProfileWithGuards(profile);
-
-    expect(result.warnings).toStrictEqual(
-      expect.arrayContaining([
-        expect.stringContaining(
-          "Key 'missing-key' not found in secure storage",
-        ),
-      ]),
-    );
-    expect(updateActiveProviderApiKeyMock).not.toHaveBeenCalled();
-  });
-
   it('sets GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION as ephemerals and env vars', async () => {
     providerManagerStub.available = ['gemini'];
     providerManagerStub.providerLookup = new Map([
@@ -250,7 +235,7 @@ describe('STEP 2 workflow: pre-switch auth wiring', () => {
   });
 
   it('falls back to direct auth-key when keyfile read returns empty content', async () => {
-    vi.mocked(mockFs.readFile).mockResolvedValue('   ');
+    mockReadFile.mockResolvedValue('   ');
 
     providerManagerStub.available = ['openai'];
     providerManagerStub.providerLookup = new Map([
@@ -288,7 +273,7 @@ describe('STEP 5 workflow: non-auth ephemerals', () => {
 
   afterEach(() => {
     restoreGcpEnvVars(savedGcpProject, savedGcpLocation);
-    vi.clearAllMocks();
+    mock.clearAllMocks();
   });
   it('applies non-auth ephemeral settings after provider switch', async () => {
     providerManagerStub.available = ['openai'];
@@ -438,7 +423,7 @@ describe('STEP 6 workflow: model and modelParams application', () => {
 
   afterEach(() => {
     restoreGcpEnvVars(savedGcpProject, savedGcpLocation);
-    vi.clearAllMocks();
+    mock.clearAllMocks();
   });
   it('sets the requested model and returns it in result', async () => {
     providerManagerStub.available = ['openai'];
@@ -503,7 +488,8 @@ describe('STEP 6 workflow: model and modelParams application', () => {
       ephemeralSettings: {},
     };
 
-    await expect(applyProfileWithGuards(profile)).rejects.toThrow(
+    await expectRejection(
+      applyProfileWithGuards(profile),
       /does not specify a model/,
     );
   });
@@ -583,7 +569,8 @@ describe('STEP 6 workflow: model and modelParams application', () => {
       ephemeralSettings: {},
     };
 
-    await expect(applyProfileWithGuards(profile)).rejects.toThrow(
+    await expectRejection(
+      applyProfileWithGuards(profile),
       /Active provider.*is not registered/,
     );
     providerManagerStub.getActiveProvider = origGetActiveProvider;

--- a/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
@@ -31,13 +31,23 @@ import {
 
 const localRequire = createRequire(import.meta.url);
 
-const mockReadFile = mock(
-  localRequire('node:fs/promises').readFile as typeof FsPromises.readFile,
-);
+const actualReadFile = localRequire('node:fs/promises')
+  .readFile as typeof FsPromises.readFile;
+
+const mockReadFile = mock(actualReadFile);
 
 await mock.module('node:fs/promises', () => {
   const actual = localRequire('node:fs/promises') as typeof FsPromises;
   return { ...actual, readFile: mockReadFile };
+});
+
+// mockReadFile is module-scoped and individual tests override its resolved
+// value, which otherwise persists into every later test in the file. Restoring
+// the real implementation and dropping recorded calls before each test keeps
+// those overrides from leaking and making the suite order-dependent.
+beforeEach(() => {
+  mockReadFile.mockReset();
+  mockReadFile.mockImplementation(actualReadFile);
 });
 
 async function expectRejection(

--- a/packages/providers/src/runtime/__tests__/profileApplicationTestSetup.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplicationTestSetup.ts
@@ -190,6 +190,30 @@ export const keyStorageStub = {
   getKey: vi.fn<(name: string) => Promise<string | null>>(),
 };
 
+/** Every shared stub whose recorded calls must not survive a test. */
+const SHARED_STUBS = [
+  switchActiveProviderMock,
+  setActiveModelMock,
+  updateActiveProviderBaseUrlMock,
+  updateActiveProviderApiKeyMock,
+  setActiveModelParamMock,
+  clearActiveModelParamMock,
+  getActiveModelParamsMock,
+  setEphemeralSettingMock,
+  createProviderKeyStorageMock,
+  getCliRuntimeServicesMock,
+  getActiveProviderOrThrowMock,
+  isCliStatelessProviderModeEnabledMock,
+  isCliRuntimeStatelessReadyMock,
+  keyStorageStub.getKey,
+];
+
+function clearSharedStubHistory(): void {
+  for (const stub of SHARED_STUBS) {
+    stub.mockClear();
+  }
+}
+
 /**
  * Resets all shared stubs to the standard baseline. Call from beforeEach.
  * Saves and restores GCP env vars.
@@ -200,6 +224,11 @@ export function resetProfileApplicationStubs(): {
 } {
   const savedGcpProject = process.env.GOOGLE_CLOUD_PROJECT;
   const savedGcpLocation = process.env.GOOGLE_CLOUD_LOCATION;
+  // Clearing call history belongs here rather than in each caller: the
+  // stubs are Vitest mocks, so a bun:test caller's mock.clearAllMocks()
+  // would not touch them and recorded calls would leak between tests.
+  // Setting an implementation below does not reset call history either.
+  clearSharedStubHistory();
   configStub.model = undefined;
   configStub.ephemerals.clear();
   settingsServiceStub.currentProfile = null;

--- a/packages/providers/src/runtime/__tests__/profileApplicationTestSetup.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplicationTestSetup.ts
@@ -206,6 +206,7 @@ const SHARED_STUBS = [
   isCliStatelessProviderModeEnabledMock,
   isCliRuntimeStatelessReadyMock,
   keyStorageStub.getKey,
+  mockProfileManager.loadProfile,
 ];
 
 function clearSharedStubHistory(): void {

--- a/packages/providers/src/runtime/profileApplication.ts
+++ b/packages/providers/src/runtime/profileApplication.ts
@@ -180,36 +180,55 @@ interface AuthWiringResult {
   authKeyNameApplied: boolean;
 }
 
+interface NamedAuthResolution {
+  authKey: string | undefined;
+  authKeyNameApplied: boolean;
+  trimmedKeyName: string;
+}
+
+/**
+ * Resolves a named key from secure storage without mutating any application
+ * state. Used as a fail-fast preflight: callers run this BEFORE clearing prior
+ * profile state so an unresolved name rejects before any mutation (issue
+ * #2916). The resolved name is returned so the caller can install the
+ * `auth-key-name` reference only after the prior state is cleared.
+ */
 async function resolveNamedAuthKey(
   authKeyName: unknown,
-  warnings: string[],
-): Promise<{ authKey: string | undefined; authKeyNameApplied: boolean }> {
+): Promise<NamedAuthResolution> {
   if (typeof authKeyName !== 'string' || authKeyName.trim() === '') {
-    return { authKey: undefined, authKeyNameApplied: false };
+    return {
+      authKey: undefined,
+      authKeyNameApplied: false,
+      trimmedKeyName: '',
+    };
   }
   const trimmedKeyName = authKeyName.trim();
-  setEphemeralSetting('auth-key-name', trimmedKeyName);
+  let resolvedAuthKey: string | null;
   try {
-    const resolvedAuthKey =
-      await createProviderKeyStorage().getKey(trimmedKeyName);
-    if (resolvedAuthKey && resolvedAuthKey.trim() !== '') {
-      logger.debug(
-        () =>
-          `[profile] resolved auth-key-name '${trimmedKeyName}' before switch`,
-      );
-      return { authKey: resolvedAuthKey.trim(), authKeyNameApplied: true };
-    }
-    warnings.push(
-      `Key '${trimmedKeyName}' not found in secure storage; falling back to existing credentials.`,
-    );
+    resolvedAuthKey = await createProviderKeyStorage().getKey(trimmedKeyName);
   } catch (error) {
-    warnings.push(
+    throw new Error(
       `Failed to resolve auth-key-name '${trimmedKeyName}': ${
         error instanceof Error ? error.message : String(error)
-      }`,
+      }. Use '/key save ${trimmedKeyName} <key>' to store it.`,
+      { cause: error },
     );
   }
-  return { authKey: undefined, authKeyNameApplied: false };
+  if (resolvedAuthKey && resolvedAuthKey.trim() !== '') {
+    logger.debug(
+      () =>
+        `[profile] resolved auth-key-name '${trimmedKeyName}' before switch`,
+    );
+    return {
+      authKey: resolvedAuthKey.trim(),
+      authKeyNameApplied: true,
+      trimmedKeyName,
+    };
+  }
+  throw new Error(
+    `Named key '${trimmedKeyName}' not found. Use '/key save ${trimmedKeyName} <key>' to store it.`,
+  );
 }
 
 async function loadAuthKeyfile(
@@ -256,20 +275,20 @@ function applyAuthKeyfilePath(filePath: string, deps: AuthWiringDeps): void {
 async function wireAuthBeforeSwitch(
   sanitizedProfile: Profile,
   deps: AuthWiringDeps,
+  namedAuth: NamedAuthResolution,
 ): Promise<AuthWiringResult> {
   const { targetProviderName, warnings, settingsService, setProviderBaseUrl } =
     deps;
   const ephemeralSettings = getProfileEphemeralSettings(sanitizedProfile);
-  const namedAuth = await resolveNamedAuthKey(
-    ephemeralSettings['auth-key-name'],
-    warnings,
-  );
   let authKeyApplied = namedAuth.authKey !== undefined;
   const authKeyNameApplied = namedAuth.authKeyNameApplied;
   let resolvedAuthKeyfilePath: string | null = null;
 
   if (namedAuth.authKey !== undefined) {
     applyResolvedAuthKey(namedAuth.authKey, deps);
+  }
+  if (namedAuth.authKeyNameApplied) {
+    setEphemeralSetting('auth-key-name', namedAuth.trimmedKeyName);
   }
 
   const keyfileAuth = await loadAuthKeyfile(
@@ -568,6 +587,7 @@ function clearProfileEphemerals(
 function buildProfileApplicationContext(
   profileInput: Profile,
   runtimeServices: ReturnType<typeof getCliRuntimeServices>,
+  profileName: string | undefined,
 ): ProfileApplicationContext {
   const { providerManager, settingsService } = runtimeServices;
   const actualProfile = profileInput;
@@ -601,6 +621,19 @@ function buildProfileApplicationContext(
   }
   const sanitizedProfile = createSanitizedProfile(actualProfile);
   sanitizeSensitiveModelParams(sanitizedProfile);
+  // Advisory only: report values whose type the registry already knows to be
+  // wrong, so a malformed profile is attributed to the profile rather than to
+  // the provider that rejects it (issue #2896). Unknown keys never warn and
+  // nothing is dropped or refused.
+  warnings.push(
+    ...formatProfileValueWarnings(
+      profileName ?? actualProfile.provider,
+      collectProfileValueWarnings(
+        getProfileModelParams(actualProfile),
+        getProfileEphemeralSettings(actualProfile),
+      ),
+    ),
+  );
   return {
     actualProfile,
     sanitizedProfile,
@@ -822,6 +855,7 @@ export async function applyProfileWithGuards(
   const context = buildProfileApplicationContext(
     profileInput,
     servicesForProfileApplication,
+    options.profileName,
   );
   const {
     actualProfile,
@@ -834,22 +868,19 @@ export async function applyProfileWithGuards(
     authDeps,
   } = context;
 
-  // Advisory only: report values whose type the registry already knows to be
-  // wrong, so a malformed profile is attributed to the profile rather than to
-  // the provider that rejects it (issue #2896). Unknown keys never warn and
-  // nothing is dropped or refused.
-  warnings.push(
-    ...formatProfileValueWarnings(
-      options.profileName ?? actualProfile.provider,
-      collectProfileValueWarnings(
-        getProfileModelParams(actualProfile),
-        getProfileEphemeralSettings(actualProfile),
-      ),
-    ),
+  // Preflight the named-key resolution BEFORE clearing prior state so an
+  // unresolved name fails fast without destroying the previous application
+  // (issue #2916). The resolved result is reused during auth wiring below so
+  // there is no duplicate storage lookup.
+  const namedAuth = await resolveNamedAuthKey(
+    getProfileEphemeralSettings(sanitizedProfile)['auth-key-name'],
   );
-
   clearProfileEphemerals(config, sanitizedProfile);
-  const authResult = await wireAuthBeforeSwitch(sanitizedProfile, authDeps);
+  const authResult = await wireAuthBeforeSwitch(
+    sanitizedProfile,
+    authDeps,
+    namedAuth,
+  );
   const providerSwitch = await switchProviderForProfile(targetProviderName);
   const infoMessages = providerSwitch.infoMessages;
   const { appliedBaseUrl } = await applyProviderAuthUpdates(

--- a/packages/providers/src/runtime/profileApplication.ts
+++ b/packages/providers/src/runtime/profileApplication.ts
@@ -208,10 +208,14 @@ async function resolveNamedAuthKey(
   try {
     resolvedAuthKey = await createProviderKeyStorage().getKey(trimmedKeyName);
   } catch (error) {
+    // A retrieval fault is not a missing key: the key may well be stored and
+    // the keychain merely locked or unreadable. Suggesting '/key save' here
+    // would invite the user to overwrite a good key and leave the real fault
+    // unaddressed, so the remedy hint belongs only on the not-found path.
     throw new Error(
       `Failed to resolve auth-key-name '${trimmedKeyName}': ${
         error instanceof Error ? error.message : String(error)
-      }. Use '/key save ${trimmedKeyName} <key>' to store it.`,
+      }`,
       { cause: error },
     );
   }

--- a/project-plans/issue2916/plan.md
+++ b/project-plans/issue2916/plan.md
@@ -1,0 +1,113 @@
+# Issue 2916 — Fail loudly for unresolved profile auth-key-name
+
+## Purpose
+
+A standard profile that explicitly names a credential must not silently continue when that name cannot be resolved. Profile application must fail before provider invocation, and non-interactive CLI callers must surface the failure with a non-zero exit status.
+
+## Accepted behavior
+
+### AC1 — Missing named key fails profile application
+
+Given a standard profile with a non-empty `auth-key-name`, when provider key storage returns no secret for that name, profile application rejects. The error identifies the key name and tells the user how to save it.
+
+### AC2 — Storage errors fail profile application
+
+Given a standard profile with a non-empty `auth-key-name`, when provider key storage throws, profile application rejects with the key name and underlying cause. The error is not converted to a warning.
+
+### AC3 — Explicit named-key precedence remains fail-fast
+
+An unresolved `auth-key-name` does not fall through to `auth-keyfile`, inline `auth-key`, environment credentials, or previously active credentials.
+
+### AC4 — Resolved named keys remain supported
+
+When provider key storage returns a non-empty secret, profile application applies that secret and preserves the name reference without persisting the raw secret as the profile's named-key value.
+
+### AC5 — Non-interactive CLI failure is observable
+
+Running the CLI with `--profile-load` and a prompt against a profile whose `auth-key-name` is unresolved prints an actionable error, does not produce model output, and exits non-zero.
+
+## Inputs and boundary cases
+
+| Input | Expected behavior |
+| --- | --- |
+| Absent, non-string, blank, or whitespace-only `auth-key-name` | Existing behavior remains unchanged; it is not treated as an explicit named credential. |
+| Non-empty name resolving to a non-empty secret | Existing successful named-key behavior remains unchanged. |
+| Non-empty name resolving to `null`, `undefined`, empty, or whitespace-only secret | Fail as unresolved. |
+| Provider key storage throws | Fail with named-key context and the underlying cause. |
+| Missing named key alongside lower-precedence auth sources | Fail without fallback. |
+| Load-balancer sub-profile named-key resolution | Existing load-balancer fallback behavior remains unchanged. |
+| `auth-keyfile` loading | Existing behavior remains unchanged. |
+
+## Behavioral evidence
+
+All new or changed tests use Bun and `bun:test`.
+
+1. Provider/profile behavioral test: missing key rejects with the actionable named-key error.
+2. Provider/profile behavioral test: key-storage failure rejects with key-name and cause.
+3. Provider/profile behavioral test: lower-precedence credential is not applied after named-key failure.
+4. Provider/profile behavioral test: resolved named key still applies and preserves the name reference.
+5. CLI subprocess/integration test: unresolved named key produces visible error output and a non-zero exit status before any provider response.
+
+Tests must exercise real profile-application and CLI behavior. Filesystem/process isolation is permitted; tests must not verify mock call choreography as the acceptance proof.
+
+## TDD sequence
+
+1. Add the smallest Bun behavioral test for AC1 and run it to record RED.
+2. Add AC2 and AC3 behavioral cases, keeping production unchanged, and record RED.
+3. Make the minimal profile-application change that turns unresolved named-key results and key-storage errors into actionable failures.
+4. Run the provider/profile Bun tests to GREEN.
+5. Add the CLI subprocess behavioral test for AC5 and record whether existing top-level error handling already satisfies it.
+6. Change CLI error handling only if the AC5 test proves it is necessary; otherwise make no CLI production change.
+7. Add/retain positive evidence for AC4 and run all targeted tests.
+8. Run full project verification and smoke testing.
+
+## Scope boundaries
+
+- Do not alter macOS profile discovery or `Profile 'name' not found` wording. That adjacent suggestion is deferred.
+- Do not alter load-balancer sub-profile fallback semantics.
+- Do not alter keyfile behavior.
+- Do not add dependencies, public abstractions, workflows, quality-tool changes, lint exceptions, TypeScript suppressions, or unrelated refactors.
+- Do not loosen lint, complexity, source-size, safety, coverage, cross-platform, or CI requirements.
+
+## Review triage
+
+Every review finding is classified as one of:
+
+- **Blocker-Fix** — prevents an accepted behavior or required gate.
+- **In-scope-Fix** — improves correctness, evidence, or maintainability within the accepted behavior.
+- **Reject** — factually incorrect or conflicts with the accepted behavior.
+- **Defer** — valid but outside the scope boundaries above.
+
+## Final review triage (remediation)
+
+1. **Blocker-Fix — Fixed.** `packages/cli/test-bun/profileAuthKeyNameIssue2916.bun.ts` now builds a deliberately allowlisted child environment (copies only `PATH/USER/SHELL/LANG/LC_ALL/TMPDIR/TERM` individually, never spreading `process.env`). It sets `LLXPRT_TEST_DISABLE_OS_KEYRING=1`, isolated `LLXPRT_CONFIG/DATA/CACHE/LOG_HOME`, a temp `HOME`, a temp workspace cwd, and points `LLXPRT_SYSTEM_SETTINGS_PATH`/`LLXPRT_SYSTEM_DEFAULTS_PATH` at controlled nonexistent temp paths. It does not pass `LLXPRT_CREDENTIAL_SOCKET`, `LLXPRT_CAPABILITY_FD`, provider credentials, proxy variables, dotenv/config paths, or unrelated `LLXPRT_*` vars.
+2. **Blocker-Fix — Fixed.** The prompt-as-output sentinel is replaced by a unique local request-counting HTTP trap (`Bun.serve` on `127.0.0.1`, port 0) configured as the profile `base-url`. The trap returns a valid-enough completion whose content is distinct from the prompt; the test asserts the request count is exactly zero. A deterministic `OPENAI_API_KEY` lower-precedence credential is present in the isolated child env and proven unused through the zero request count. Nonzero exit, key-name, `/key save` remediation, and no-secret-leak assertions are retained.
+3. **In-scope-Fix — Fixed.** The subprocess helper drains stdout/stderr immediately, races `proc.exited` against a resolve-only timeout, and in `finally` clears the timer and terminates only the tracked child PID (guarded), then awaits `proc.exited` and both stream drains before returning. No broad process-group kill; no orphan/race/unhandled-rejection path.
+4. **In-scope-Fix — Fixed (RED → GREEN).** A behavioral test was written first that seeds prior auth and non-auth ephemerals plus a configured provider credential and proves a failed named-key apply preserves all prior application state while never installing the unresolved name. This initially failed (RED) because `clearProfileEphemerals` destroyed prior ephemerals before `resolveNamedAuthKey` could throw. GREEN: `resolveNamedAuthKey` is now a pure preflight (no mutation; returns the resolved name), called before `clearProfileEphemerals` in `applyProfileWithGuards`; the resolved result is reused by `wireAuthBeforeSwitch`, so there is no duplicate storage lookup and mutation only begins after successful resolution. The advisory value-warnings computation moved into `buildProfileApplicationContext` (where warnings are assembled) to keep `applyProfileWithGuards` within the function size limit without a new public abstraction.
+5. **In-scope-Fix — Fixed.** Stored named-key results (null, undefined, empty, whitespace) and name inputs (absent, null, non-string, empty, whitespace) are now table-driven. The storage double's `getKey`/`resolvedValue` types were widened to `string | null | undefined` so all edge cases are expressed without assertions; each row directly proves expected behavior. Deterministic environment no-fallback is proven through the isolated CLI trap (zero requests).
+6. **In-scope-Fix — Fixed.** The unrelated-secret map entry that could not influence the error path and its `.not.toContain` assertions were removed. Type/non-null assertions in the new provider test were replaced with an `instanceof`-based `asError` narrowing helper and safe `Map` access.
+7. **Defer — Deferred.** No quality tooling was changed for legacy Vitest compatibility. The workflow test remains `bun:test` and passes through the authoritative Bun manifest via the shared vitest-compatible setup.
+8. **Reject — Rejected.** No mock-call assertions were added; all evidence is observable state, output, and request count.
+9. **Plan update — This section.**
+
+## Verification evidence
+
+All new/changed tests use `bun:test`. Commands run from repo root unless noted.
+
+RED → GREEN for the production behavior change (finding 4):
+- RED (before the preflight): the "preserves prior application state" test failed with `context-limit` observed `undefined` (expected `50000`) because `clearProfileEphemerals` ran before `resolveNamedAuthKey` could throw.
+- GREEN (after preflight): same test passes; prior auth and non-auth ephemerals survive a failed apply.
+
+Targeted test results:
+- `cd packages/providers && bun test src/runtime/__tests__/profileApplication.issue2916.bun.test.ts` → 17 pass, 0 fail, 56 expect() calls.
+- `cd packages/providers && bun test src/runtime/__tests__/profileApplication.workflow.test.ts` → 16 pass, 0 fail.
+- `cd packages/providers && bun test src/runtime/__tests__/profileApplication` → 134 pass, 0 fail across 10 files (includes boundaries, load-balancer auth/detection, failover, unavailable-provider).
+- `cd packages/cli && bun test ./test-bun/profileAuthKeyNameIssue2916.bun.ts` → 1 pass, 0 fail, 10 expect() calls (trap request count asserted zero).
+
+Static checks (all exit 0):
+- `cd packages/providers && bunx tsc --noEmit -p tsconfig.json`
+- `cd packages/cli && bunx tsc --noEmit`
+- `bunx tsc --project tsconfig.scripts.json`
+- `bunx eslint` and `bunx prettier --check` on all changed files.
+- `git diff --check` clean.
+- Bun manifest discovery resolves all three issue-2916 test files (`packages/cli/test-bun/profileAuthKeyNameIssue2916.bun.ts`, `packages/providers/src/runtime/__tests__/profileApplication.issue2916.bun.test.ts`, `packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts`).

--- a/scripts/bun-test-manifest-data-providers.ts
+++ b/scripts/bun-test-manifest-data-providers.ts
@@ -453,6 +453,7 @@ export const PROVIDERS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
     'src/runtime/__tests__/profileApplication.basics.test.ts',
     'src/runtime/__tests__/profileApplication.bucket-failover.spec.ts',
     'src/runtime/__tests__/profileApplication.failover.test.ts',
+    'src/runtime/__tests__/profileApplication.issue2916.bun.test.ts',
     'src/runtime/__tests__/profileApplication.lb.authkey.test.ts',
     'src/runtime/__tests__/profileApplication.lb.detection.test.ts',
     'src/runtime/__tests__/profileApplication.unavailableProvider.test.ts',

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -207,6 +207,7 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       'test-bun/steerKey.darwin.bun.ts',
       'test-bun/resolveKeyBindings.bun.ts',
       'test-bun/keypressLineFeed.bun.ts',
+      'test-bun/profileAuthKeyNameIssue2916.bun.ts',
     ],
   },
   {


### PR DESCRIPTION
## TLDR

A profile whose `auth-key-name` cannot be resolved now fails loudly instead of loading "successfully" and leaving the provider with a stale or absent credential. This is the silent `exit 0` from #2916.

Two things were wrong, and the second is the reason the failure was invisible rather than merely unhelpful:

1. An unresolved named key was only a **warning**. `resolveNamedAuthKey` pushed a string onto `warnings` and returned no key, so profile application continued to completion and reported success.
2. The lookup happened **after** `clearProfileEphemerals`, so by the time anything could go wrong the previous profile's state had already been destroyed.

The fix makes an unresolved name an error and moves the lookup into a preflight that runs *before* any mutation, so a rejected profile leaves the previously working state intact.

Reviewers may want to look closely at the ordering in `applyProfileWithGuards` (preflight → clear → wire) and at the deliberate split between the two error messages.

## Dive Deeper

**Fail fast, and only for a real named key.** Both a missing key and a storage fault now reject. The not-found message names the remedy (`/key save <name> <key>`); the storage-fault message deliberately does **not**, because a retrieval fault (locked or unreadable keychain) is not a missing key — the key may well be stored, and suggesting `/key save` would invite the user to overwrite a good key while leaving the real fault unaddressed. The storage fault keeps the original error as `cause` so triage is not lost.

Only a genuinely named key is treated as one. Absent, `null`, non-string, empty and whitespace values remain no-ops that fall through to lower-precedence auth exactly as before, so this does not turn previously working profiles into hard failures. There is a test for each of those five shapes.

**Non-destructive ordering.** `resolveNamedAuthKey` no longer mutates anything: it returns the trimmed name, and the caller installs the `auth-key-name` ephemeral *after* the clear. That means a rejected load does not leave the unresolved name behind either. The resolved value is threaded into `wireAuthBeforeSwitch`, so there is still exactly one storage lookup — the preflight did not add a second round-trip.

`buildProfileApplicationContext` now takes `profileName` and emits the #2896 advisory warnings, keeping context construction the single place that assembles warnings now that the auth preflight runs ahead of it.

**Out of scope:** the issue's closing note about profiles under `~/.llxprt/profiles/` on macOS producing an unclear "Profile not found" message is a separate concern and is not addressed here.

### Test-infrastructure fix included

While migrating `profileApplication.workflow.test.ts` to `bun:test`, `vi.clearAllMocks()` became `mock.clearAllMocks()` — but the shared stubs in `profileApplicationTestSetup.ts` are Vitest `vi.fn()` mocks, which Bun's clear does not touch, and the reset helper only reassigned implementations (`mockImplementation` / `mockResolvedValue` leave call history intact). Call records were leaking between tests. Clearing now lives in `resetProfileApplicationStubs`, which every suite already calls from `beforeEach`, so it is runner-agnostic and fixes the Vitest siblings that share those stubs too.

## Reviewer Test Plan

Reproduce the original silent failure and confirm it is gone.

1. Point a profile at a named key that does not exist in secure storage, then load it non-interactively:

       llxprt --profile-load <profile> -p "What is 17*23? Answer with just the number."

   Before: prints nothing, exits 0. After: exits non-zero with a message naming the key and the `/key save <name> <key>` remedy, and no provider request is made.

2. Confirm the happy path is unchanged — save the key (`/key save <name> <key>`), reload the profile, and verify it resolves and answers normally.

3. Confirm no regression for profiles that never used a named key (plain `auth-key`, `auth-keyfile`, or env credentials); those must load exactly as before.

Automated coverage:

    bun scripts/run_bun_tests.ts issue2916
    bun scripts/run_bun_tests.ts profileApplication.workflow
    bun scripts/run_bun_tests.ts profileAuthKeyNameIssue2916

The last one is a real CLI subprocess test: it runs the actual binary against a trap HTTP server and asserts the process exits non-zero with the actionable message and never contacts the provider.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: full typecheck, build, format, targeted and workspace test suites, and the live CLI smoke test.

## Linked issues / bugs

Fixes #2916

Split out of #2896; PR #2915 fixed the request-body defects only and explicitly left this case open.
