### PR TITLE
Stage the CLI bundle's runtime assets so the published package works (Fixes #3068)

### DIFF
--- a/packages/cli/src/utils/gitCommitInfo.ts
+++ b/packages/cli/src/utils/gitCommitInfo.ts
@@ -53,8 +53,12 @@ function candidatePaths(): string[] {
   // (dist/src/utils -> dist/src/generated, since copy_files.ts mirrors the JSON
   // into dist). No separate dist candidate is needed.
   add(path.join(loaderDir, '..', 'generated', INFO_FILENAME));
-  // Bundled runtime: the JSON is copied to the bundle root (parity with the
-  // bundle candidate in core's manifest-loader.ts).
+  // Bundled runtime: the JSON is copied to the bundle root beside the loader
+  // (parity with the bundle candidate in core's manifest-loader.ts). When
+  // bundled, loaderDir IS the bundle root, so this resolves regardless of the
+  // caller's cwd. The earlier cwd-relative candidate below only matched when
+  // the CLI was launched from the package root.
+  add(path.join(loaderDir, INFO_FILENAME));
   add(path.join(process.cwd(), 'bundle', INFO_FILENAME));
 
   return Array.from(candidates);

--- a/project-plans/issue-3068-bundle-runtime-assets.md
+++ b/project-plans/issue-3068-bundle-runtime-assets.md
@@ -1,0 +1,162 @@
+# Issue #3068 — Published CLI bundle ships no runtime assets
+
+## Problem
+
+The npm package `@vybestack/llxprt-code` is built from `packages/cli` and ships a
+`bundle` directory (`"files": ["bundle", ...]`). `packages/cli/bundle/llxprt.js`
+is produced by `buildCliBundle()` in `scripts/bun-build.config.ts`, invoked by
+the `prepack` script that both `npm publish` and `npm pack` trigger.
+
+That bundle inlines the whole TypeScript module graph into a single file at
+`<package-root>/bundle/llxprt.js`. Every module that locates a runtime data file
+via `__dirname` / `import.meta.url` therefore resolves it relative to
+`<package-root>/bundle/` instead of its original source directory.
+
+`buildCliBundle()` emits **only** `llxprt.js`. No data files are copied. So every
+bundle-relative asset read fails in the published package.
+
+Observed on macOS (issue #3068, v0.11.0-nightly.260805.bb700c00e):
+
+```
+failed to asynchronously prepare wasm: Error: ENOENT: no such file or directory,
+  open '/opt/homebrew/lib/node_modules/@vybestack/llxprt-code/bundle/tree-sitter.wasm'
+Aborted(Error: ENOENT: ... /bundle/tree-sitter.wasm)
+```
+
+followed by the CLI starting with **no providers available**.
+
+Reproduced locally on this branch:
+
+```
+$ npm run bundle:cli && bun packages/cli/bundle/llxprt.js --provider openai --model gpt-4o -p "hi"
+An unexpected critical error occurred:
+Error: Could not activate explicitly-configured provider 'openai': Provider 'openai' not found
+```
+
+`scripts/copy_bundle_assets.ts` — the script that used to stage these assets for
+the retired esbuild flow — still exists but is orphaned: no npm script, build
+script, or workflow invokes it, and it writes to the gitignored **repo-root**
+`bundle/` directory that nothing consumes. That is why the regression was
+invisible when the prebuilt CLI bundle was introduced.
+
+## Root cause
+
+`buildCliBundle()` produces the JS artifact without the data files the bundled
+code reads from `<bundle-dir>/…`. The asset-staging step was never re-wired to
+the new bundle location after the esbuild flow was retired.
+
+## Accepted behaviour
+
+The prebuilt CLI bundle must ship, alongside `llxprt.js`, every runtime asset
+that the bundled code resolves relative to the bundle directory.
+
+| # | Asset | Source | Required bundle path | Resolving site | Failure today |
+|---|-------|--------|----------------------|----------------|---------------|
+| 1 | `tree-sitter.wasm` | `node_modules/web-tree-sitter/tree-sitter.wasm` | `bundle/tree-sitter.wasm` | `web-tree-sitter` `findWasmBinary()` → `new URL('tree-sitter.wasm', import.meta.url)` | emscripten abort printed at startup (issue screenshot) |
+| 2 | Provider aliases (`*.config`) | `packages/providers/src/composition/aliases/` | `bundle/providers/aliases/` | `providerAliases.ts` `BUNDLE_ALIAS_DIR = join(__dirname,'providers','aliases')` | **no providers available** |
+| 3 | Policy TOMLs | `packages/policy/src/policies/*.toml` | `bundle/policies/` | `packages/policy/src/config.ts` `DEFAULT_CORE_POLICIES_DIR`; `toml-loader.ts` `loadDefaultPolicies()` | built-in tool policies silently absent |
+| 4 | macOS seatbelt profiles (`*.sb`) | `packages/cli/src/utils/sandbox-macos-*.sb` | `bundle/` (flat) | `sandbox-seatbelt.ts` `new URL('./sandbox-macos-<p>.sb', import.meta.url)` | `FatalSandboxError` — macOS sandbox unusable |
+| 5 | Prompt defaults (`**/*.md`) | `packages/core/src/prompt-config/defaults/` | `bundle/` preserving structure | `core/provider/tool-defaults.ts` `tryLoadFromBundleDir` | default prompts unavailable |
+| 6 | Prompt manifest | `packages/core/dist/prompt-config/defaults/default-prompts.json` | `bundle/default-prompts.json` | `manifest-loader.ts` `candidatePaths()` | manifest fast-path unavailable |
+| 7 | `git-commit.json` | `packages/cli/src/generated/git-commit.json` | `bundle/git-commit.json` | `gitCommitInfo.ts` `candidatePaths()` | commit reported as `N/A` |
+| 8 | Official tokenizer BPE assets | `packages/providers/src/tokenizers/official/assets/{kimi-k3,glm-5.2,minimax-m3}/{manifest.json,tokenizer.bpe,LICENSE}` (+ `NOTICE.md`) | `bundle/assets/**` (tree) | `assetLoader.ts` `ASSETS_DIR = join(__dirname,'assets')`; reached via `providerManagerInstance.ts` → `officialPromptEstimators.ts` → `kimiK3Tokenizer.ts`/`glm52Tokenizer.ts`/`minimaxM3Tokenizer.ts` | `Prompt estimator asset-unavailable for kimi-k3` — three model families cannot start a chat |
+| 9 | Extension boilerplate templates | `packages/cli/src/commands/extensions/examples/**` (5 templates: context, exclude-tools, hooks, mcp-server, skills) | `bundle/examples/**` (tree) | `new.ts` `EXAMPLES_PATH = join(__dirname,'examples')`; `getBoilerplateChoices()` `readdir`s it inside the yargs builder | `ENOENT ... scandir '.../bundle/examples'` — `llxprt extensions new` crashes during argument parsing |
+
+Asset 7 additionally requires a one-line fix in `gitCommitInfo.ts`: its comment
+already states "the JSON is copied to the bundle root", but the candidate it
+builds is `join(process.cwd(), 'bundle', …)` — cwd-relative, so it only matches
+when the CLI happens to be launched from the package root. The correct candidate
+is `join(loaderDir, INFO_FILENAME)`, which is the bundle root when bundled. This
+is the same bundle-relative-resolution defect and is fixed with the rest.
+
+### Explicitly out of scope
+
+- **`tree-sitter-bash.wasm`.** `shell-parser.ts` resolves it with
+  `require.resolve('tree-sitter-bash/tree-sitter-bash.wasm')` — module
+  resolution from `node_modules`, not a bundle-relative read. Copying it into
+  `bundle/` would not change resolution. It is not part of the reported failure
+  and the parser degrades gracefully to regex parsing. Not touched. Residual
+  caveat: `tree-sitter-bash` is a dependency of `@vybestack/llxprt-code-core`,
+  not of `packages/cli`, so it relies on npm hoisting — the same ownership
+  hazard documented for `CLI_DIRNAME_DEPENDENT_EXTERNALS`.
+- **Built-in skills.** `packages/core/src/skills/builtin` does not exist in the
+  repo at all, so there is nothing to stage. Not a bundle regression.
+- **`@dqbd/tiktoken` / `yargs` / `update-notifier`.** Already handled by
+  `CLI_DIRNAME_DEPENDENT_EXTERNALS` (issue #3055). Unchanged.
+- **Externalizing `web-tree-sitter`.** Not required: it resolves its WASM through
+  `import.meta.url`, which Bun rewrites to the bundle URL (proven by the ENOENT
+  path in the report), so staging the file next to the bundle is the correct
+  fix. Externalizing would additionally require adding a direct `packages/cli`
+  dependency, which the `CLI_DIRNAME_DEPENDENT_EXTERNALS` ownership invariant
+  demands and which this issue does not justify.
+
+### Failure behaviour (fail fast)
+
+Asset staging must **throw** when a required asset is missing, so a release can
+never produce a silently broken bundle again. Required = assets 1–5, 8, and 9.
+Assets 6 and 7 are generated artifacts (`npm run generate`) and are copied when
+present; their absence must not break `npm run bundle:cli` in a fresh checkout,
+matching the existing tolerance in `bun-build.config.ts` and `gitCommitInfo.ts`.
+
+## Implementation
+
+1. Rewrite `scripts/copy_bundle_assets.ts` into a parameterised, exported
+   staging function that targets the **CLI bundle directory**
+   (`packages/cli/bundle`) instead of the dead repo-root `bundle/`. Keeping the
+   existing file (rather than adding a second script) avoids duplicating the
+   copy logic and removes the orphan in one move.
+2. Call it from `buildCliBundle()` in `scripts/bun-build.config.ts` immediately
+   after `Bun.build` succeeds, so `prepack` — the single hook both `npm publish`
+   and `npm pack` fire — stages the assets into the directory that
+   `"files": ["bundle"]` packs.
+3. The bundle directory is pruned before `Bun.build` runs, so removed source
+   files cannot linger; `Bun.build` does not clean its `outdir` and the stager
+   only writes, never deletes.
+4. The `tree-sitter.wasm` source is resolved with
+   `require.resolve('web-tree-sitter/tree-sitter.wasm')` (anchored at the repo
+   root) instead of a hardcoded `node_modules/...` path, so nested/non-hoisted
+   installs still resolve — the same idiom used for the tiktoken WASM.
+5. Required directory/tree stagers guard with `existsSync` before reading, so a
+   missing source directory yields the actionable error rather than a raw
+   `ENOENT`.
+
+## Tests (behavioural, written first)
+
+New `scripts/tests/issue-3068-bundle-runtime-assets.bun.test.ts`, following the
+pattern of `scripts/tests/issue-3055-bundle-purity.bun.test.ts` (build the real
+artifact in a child process, assert against it, clean up):
+
+1. **Asset presence.** After the real bundle build, assert each required asset
+   exists at its required bundle path, and that the staged provider-alias and
+   policy sets exactly match their source directories (so a newly added alias
+   cannot be forgotten). Assert `tree-sitter.wasm` starts with the `\0asm` magic
+   bytes, proving a real WASM file was staged, not a placeholder.
+2. **Providers resolve from the bundle.** Spawn the built bundle with
+   `--provider openai --model gpt-4o -p …` and assert the output does **not**
+   contain `Provider 'openai' not found`. This is the exact reproduction above
+   and fails before the fix.
+3. **No tree-sitter WASM abort.** Spawn the built bundle through a start path
+   that reaches `Config` creation (which awaits `initializeParser()`) and assert
+   stderr contains neither `failed to asynchronously prepare wasm` nor
+   `tree-sitter.wasm`.
+4. **Fail fast on missing required assets.** Drive the staging function with a
+   source root lacking a required asset and assert it throws an actionable
+   error naming the missing path.
+5. **`git-commit.json` is found at the bundle root.** Unit-level test that
+   `gitCommitInfo.ts` resolves the JSON sitting beside the loader.
+
+## Acceptance criteria
+
+- `npm run bundle:cli` produces `packages/cli/bundle/` containing `llxprt.js`
+  plus assets 1–5, 8, and 9 (and 6–7 when generated).
+- The bundle directory is pruned before each build, so an alias, policy, or
+  template removed from source cannot linger and ship.
+- Running the built bundle reports no `tree-sitter.wasm` error, resolves
+  built-in providers, starts a chat for the pinned-tokenizer model families
+  (kimi-k3 / glm-5.2 / minimax-m3 — no `asset-unavailable`), and `extensions
+  new` succeeds.
+- Staging throws with an actionable message if a required asset is missing
+  (file- and directory-shaped alike).
+- `scripts/copy_bundle_assets.ts` is no longer orphaned.
+- Full verification passes: `npm run test`, `lint`, `typecheck`, `format`,
+  `build`, and the CLI smoke run.

--- a/scripts/bun-build.config.ts
+++ b/scripts/bun-build.config.ts
@@ -25,9 +25,15 @@
  * a2a-server build. Top-level execution is guarded by `import.meta.main`.
  */
 
-import { copyFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { portableTiktokenPlugin } from './portable-tiktoken-plugin.js';
 import { stageCliBundleAssets } from './copy_bundle_assets.js';
@@ -239,6 +245,23 @@ async function buildA2aServer(): Promise<readonly string[]> {
 }
 
 /**
+ * Removes every entry in the bundle directory except the just-emitted build
+ * outputs, leaving a clean slate for asset staging.
+ *
+ * A no-op when the directory does not exist yet (the first build).
+ */
+function pruneStaleBundleEntries(bundleDir: string, keep: Set<string>): void {
+  if (!existsSync(bundleDir)) {
+    return;
+  }
+  for (const entry of readdirSync(bundleDir)) {
+    if (!keep.has(entry)) {
+      rmSync(join(bundleDir, entry), { recursive: true, force: true });
+    }
+  }
+}
+
+/**
  * Builds the prebuilt CLI bundle only (issue #2999).
  *
  * Kept separately invocable so `prepack` can produce the shipped bundle
@@ -249,14 +272,6 @@ async function buildA2aServer(): Promise<readonly string[]> {
  * failure, not as a hard kill of the test runner process.
  */
 export async function buildCliBundle(): Promise<readonly string[]> {
-  // Prune the bundle directory before building. Bun.build does not clean its
-  // outdir, and the asset stager only writes/overwrites — it never deletes —
-  // so an alias, policy, or template removed from source would otherwise linger
-  // in packages/cli/bundle/ and ship. Removing the directory here (before
-  // Bun.build repopulates it with llxprt.js) makes the staged set exactly match
-  // the source on every build. Bun.build recreates the outdir, so this ordering
-  // is safe.
-  rmSync(CLI_BUNDLE_DIR, { recursive: true, force: true });
   let cliResult: Awaited<ReturnType<typeof Bun.build>>;
   try {
     cliResult = await Bun.build(cliBundleConfig);
@@ -274,6 +289,15 @@ export async function buildCliBundle(): Promise<readonly string[]> {
     );
   }
   const outputs = cliResult.outputs.map((o) => `${o.path}=${o.size}`);
+  // Drop stale assets only once the build has succeeded, so a transient build
+  // failure leaves the previous bundle intact instead of deleting it. Bun.build
+  // does not clean its outdir and the stager only writes — never deletes — so
+  // without this an alias, policy, or template removed from source would linger
+  // and ship. The freshly emitted artifacts are preserved by name.
+  pruneStaleBundleEntries(
+    CLI_BUNDLE_DIR,
+    new Set(cliResult.outputs.map((o) => basename(o.path))),
+  );
   // Stage the runtime data assets the bundled code reads relative to the
   // bundle directory (issue #3068). Throws on a missing required asset so a
   // broken bundle can never be silently published; this propagates as a

--- a/scripts/bun-build.config.ts
+++ b/scripts/bun-build.config.ts
@@ -25,18 +25,21 @@
  * a2a-server build. Top-level execution is guarded by `import.meta.main`.
  */
 
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-} from 'node:fs';
+import { copyFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { portableTiktokenPlugin } from './portable-tiktoken-plugin.js';
+import { stageCliBundleAssets } from './copy_bundle_assets.js';
+
+/**
+ * Re-exported so the issue #3062 guard keeps its import path. The alias
+ * collection itself now lives with the rest of the bundle asset staging in
+ * `copy_bundle_assets.ts` (issue #3068), which subsumed the alias-only copy
+ * that used to live here: staging every bundle-relative asset in one place
+ * keeps a single implementation and a single fail-fast contract.
+ */
+export { collectAliasAssets } from './copy_bundle_assets.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
@@ -156,6 +159,13 @@ const a2aServerConfig: Parameters<typeof Bun.build>[0] = {
 };
 
 /**
+ * Directory the published CLI bundle is written to. Single source of truth for
+ * both the Bun.build output location and the runtime-asset staging target
+ * (issue #3068), so the JS artifact and its data files can never diverge.
+ */
+export const CLI_BUNDLE_DIR = join(root, 'packages/cli/bundle');
+
+/**
  * CLI bundle (issue #2999): packages/cli/index.ts -> bundle/llxprt.js.
  *
  * `target: 'bun'` keeps the artifact compatible with the Bun runtime that
@@ -179,29 +189,9 @@ export const cliBundleConfig: Parameters<typeof Bun.build>[0] = {
   // Absolute paths: `prepack` runs this from `packages/cli`, not the repo
   // root, so cwd-relative entrypoints would not resolve.
   entrypoints: [join(root, 'packages/cli/index.ts')],
-  outdir: join(root, 'packages/cli/bundle'),
+  outdir: CLI_BUNDLE_DIR,
   naming: 'llxprt.js',
 };
-
-/**
- * Built-in provider alias data (issue #3062).
- *
- * The bundled `providerAliases` loader computes its built-in directory as
- * `<bundleDir>/providers/aliases` (resolved from the bundle's own `__dirname`
- * at runtime). When the bundle was the only emitted artifact that directory did
- * not exist, so no built-in aliases registered and `--provider openai` failed
- * with "Provider 'openai' not found". The alias assets live as raw
- * `.config`/`.json` files in the providers package source; emit them verbatim
- * next to the bundle so the loader finds them exactly as in development.
- */
-const providerAliasSourceDir = join(
-  root,
-  'packages/providers/src/composition/aliases',
-);
-const providerAliasBundleDir = join(
-  root,
-  'packages/cli/bundle/providers/aliases',
-);
 
 /**
  * Runs a Bun.build target and exits non-zero on any failure (rejected promise
@@ -249,30 +239,6 @@ async function buildA2aServer(): Promise<readonly string[]> {
 }
 
 /**
- * Collects built-in provider alias asset names (`.config`/`.json`) from `dir`,
- * failing fast when none are found.
- *
- * An empty result is a build-input error, not a silent no-op: the bundled
- * `providerAliases` loader would then register zero built-in providers and
- * `--provider openai` would fail at launch (issue #3062 regression). Surfacing
- * this at build time prevents shipping a bundle that silently dropped every
- * built-in alias.
- */
-export function collectAliasAssets(dir: string): string[] {
-  const assets = readdirSync(dir).filter(
-    (name) => name.endsWith('.config') || name.endsWith('.json'),
-  );
-  if (assets.length === 0) {
-    throw new Error(
-      `cli-bundle build produced no built-in provider alias assets: ${dir} ` +
-        `contains no .config/.json files; the bundled providerAliases loader ` +
-        `would register no built-in providers.`,
-    );
-  }
-  return assets;
-}
-
-/**
  * Builds the prebuilt CLI bundle only (issue #2999).
  *
  * Kept separately invocable so `prepack` can produce the shipped bundle
@@ -283,6 +249,14 @@ export function collectAliasAssets(dir: string): string[] {
  * failure, not as a hard kill of the test runner process.
  */
 export async function buildCliBundle(): Promise<readonly string[]> {
+  // Prune the bundle directory before building. Bun.build does not clean its
+  // outdir, and the asset stager only writes/overwrites — it never deletes —
+  // so an alias, policy, or template removed from source would otherwise linger
+  // in packages/cli/bundle/ and ship. Removing the directory here (before
+  // Bun.build repopulates it with llxprt.js) makes the staged set exactly match
+  // the source on every build. Bun.build recreates the outdir, so this ordering
+  // is safe.
+  rmSync(CLI_BUNDLE_DIR, { recursive: true, force: true });
   let cliResult: Awaited<ReturnType<typeof Bun.build>>;
   try {
     cliResult = await Bun.build(cliBundleConfig);
@@ -299,24 +273,18 @@ export async function buildCliBundle(): Promise<readonly string[]> {
       `cli-bundle build completed with errors: ${detail || '(no details)'}`,
     );
   }
-
-  // Emit the built-in provider alias data next to the bundle (issue #3062).
-  // Replace any stale copy wholesale so removed/renamed alias files never leak
-  // into a publish artifact.
-  rmSync(providerAliasBundleDir, { recursive: true, force: true });
-  mkdirSync(providerAliasBundleDir, { recursive: true });
-  const aliasAssets = collectAliasAssets(providerAliasSourceDir);
-  for (const name of aliasAssets) {
-    copyFileSync(
-      join(providerAliasSourceDir, name),
-      join(providerAliasBundleDir, name),
-    );
-  }
-
-  return [
-    ...cliResult.outputs.map((o) => `${o.path}=${o.size}`),
-    ...aliasAssets.map((name) => join(providerAliasBundleDir, name)),
-  ];
+  const outputs = cliResult.outputs.map((o) => `${o.path}=${o.size}`);
+  // Stage the runtime data assets the bundled code reads relative to the
+  // bundle directory (issue #3068). Throws on a missing required asset so a
+  // broken bundle can never be silently published; this propagates as a
+  // build failure because prepack runs this entry point. `repoRoot: root`
+  // keeps a single derivation of the repo root rather than letting the stager
+  // re-derive it from its own import.meta.url.
+  const staged = stageCliBundleAssets({
+    bundleDir: CLI_BUNDLE_DIR,
+    repoRoot: root,
+  });
+  return [...outputs, ...staged];
 }
 
 /**

--- a/scripts/copy_bundle_assets.ts
+++ b/scripts/copy_bundle_assets.ts
@@ -1,190 +1,382 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Stages the runtime data assets the prebuilt CLI bundle reads relative to the
+ * bundle directory (issue #3068).
+ *
+ * `buildCliBundle()` in `bun-build.config.ts` inlines the whole TypeScript
+ * module graph into a single `packages/cli/bundle/llxprt.js`. Every module that
+ * locates a data file via `__dirname` / `import.meta.url` therefore resolves it
+ * under `<bundle-dir>/…`, so those data files must be staged next to the bundle
+ * or every such read fails in the published package. This module owns that
+ * staging step.
+ *
+ * Required assets (the bundle is unusable without them) cause a hard throw so a
+ * release can never again silently ship a broken bundle. Generated artifacts
+ * (`npm run generate`) are copied when present and skipped when absent, so a
+ * fresh checkout can still run `npm run bundle:cli`.
+ *
+ * Not staged here on purpose:
+ *  - `tree-sitter-bash/tree-sitter-bash.wasm`. `shell-parser.ts` resolves it
+ *    with `require.resolve('tree-sitter-bash/tree-sitter-bash.wasm')`, i.e.
+ *    MODULE resolution from `node_modules`, not a bundle-relative read. Copying
+ *    it into `bundle/` would change nothing; failure degrades gracefully to
+ *    regex parsing. Residual caveat: `tree-sitter-bash` is a dependency of
+ *    `@vybestack/llxprt-code-core`, not of `packages/cli`, so it relies on npm
+ *    hoisting — the same ownership hazard documented for
+ *    `CLI_DIRNAME_DEPENDENT_EXTERNALS` in `bun-build.config.ts`.
+ */
 
-import { copyFileSync, existsSync, mkdirSync, cpSync } from 'node:fs';
-import { dirname, join, basename } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = join(__dirname, '..');
-const bundleDir = join(root, 'bundle');
-const require = createRequire(import.meta.url);
-
-// Remove verbose logging
-
-// Create the bundle directory if it doesn't exist
-if (!existsSync(bundleDir)) {
-  mkdirSync(bundleDir);
+/** Options for {@link stageCliBundleAssets}. */
+export interface StageCliBundleAssetsOptions {
+  /** Bundle directory assets are staged into. Defaults to packages/cli/bundle. */
+  readonly bundleDir?: string;
+  /** Repository root the source assets are read from. Defaults to repo root. */
+  readonly repoRoot?: string;
 }
 
-// Find and copy all .sb files from packages to the root of the bundle directory
-const sbFiles = glob.sync('packages/**/*.sb', { cwd: root });
-for (const file of sbFiles) {
-  copyFileSync(join(root, file), join(bundleDir, basename(file)));
+function defaultRepoRoot(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), '..');
 }
 
-// Find and copy all .vsix files from packages to the root of the bundle directory
-const vsixFiles = glob.sync('packages/vscode-ide-companion/*.vsix', {
-  cwd: root,
-});
-for (const file of vsixFiles) {
-  copyFileSync(join(root, file), join(bundleDir, basename(file)));
+function ensureDir(dir: string): void {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
 }
 
-// Copy tiktoken WASM file. Missing critical runtime assets must fail the
-// bundle step loudly rather than producing a bundle that breaks at runtime.
-const tiktokenWasmPath = join(
-  root,
-  'node_modules/@dqbd/tiktoken/tiktoken_bg.wasm',
-);
-if (!existsSync(tiktokenWasmPath)) {
-  throw new Error(
-    `Missing critical runtime asset: ${tiktokenWasmPath}. Run npm install first.`,
+/** Copies a single file, creating destination directories as needed. */
+function copyFileTo(srcPath: string, destPath: string): string {
+  ensureDir(dirname(destPath));
+  copyFileSync(srcPath, destPath);
+  return destPath;
+}
+
+function missingRequiredAsset(description: string, srcPath: string): Error {
+  return new Error(
+    `Cannot stage CLI bundle: required ${description} is missing at ${srcPath}. ` +
+      `Run \`npm install\` (and \`npm run generate\` for generated assets) before bundling.`,
   );
 }
-copyFileSync(tiktokenWasmPath, join(bundleDir, 'tiktoken_bg.wasm'));
 
-// Copy tree-sitter WASM file for web-tree-sitter runtime
-const treeSitterWasmPath = join(
-  root,
-  'node_modules/web-tree-sitter/tree-sitter.wasm',
-);
-if (!existsSync(treeSitterWasmPath)) {
-  throw new Error(
-    `Missing critical runtime asset: ${treeSitterWasmPath}. Run npm install first.`,
+/** Lists the regular files directly inside a directory. */
+function listFilesIn(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name);
+}
+
+/**
+ * Recursively lists every regular file under `rootDir` as repo-style relative
+ * paths (forward slashes), so a required directory tree can be mirrored into
+ * the bundle preserving its structure.
+ */
+function walkFiles(rootDir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [''];
+  while (stack.length > 0) {
+    const rel = stack.pop();
+    if (rel === undefined) {
+      break;
+    }
+    const abs = rel === '' ? rootDir : join(rootDir, rel);
+    for (const entry of readdirSync(abs, { withFileTypes: true })) {
+      const childRel = rel === '' ? entry.name : `${rel}/${entry.name}`;
+      if (entry.isDirectory()) {
+        stack.push(childRel);
+      } else if (entry.isFile()) {
+        out.push(childRel);
+      }
+    }
+  }
+  return out;
+}
+
+/** Copies a required single-file asset, throwing if the source is absent. */
+function stageRequiredFile(
+  srcPath: string,
+  destPath: string,
+  description: string,
+): string {
+  if (!existsSync(srcPath)) {
+    throw missingRequiredAsset(description, srcPath);
+  }
+  return copyFileTo(srcPath, destPath);
+}
+
+/**
+ * Copies a required directory's files into a destination directory, throwing if
+ * the source directory is absent or holds no matching files. Returns the staged
+ * destination paths so a future added source file can never be silently
+ * forgotten by the bundle.
+ */
+function stageRequiredDir(
+  srcDir: string,
+  destDir: string,
+  filter: (name: string) => boolean,
+  description: string,
+): string[] {
+  // existsSync guard is load-bearing: readdirSync would throw a raw ENOENT for
+  // a missing directory, so the actionable missingRequiredAsset below would be
+  // unreachable. The guard surfaces the actionable message instead.
+  if (!existsSync(srcDir)) {
+    throw missingRequiredAsset(description, srcDir);
+  }
+  const files = listFilesIn(srcDir).filter(filter);
+  if (files.length === 0) {
+    throw missingRequiredAsset(description, srcDir);
+  }
+  return files.map((file) =>
+    copyFileTo(join(srcDir, file), join(destDir, file)),
   );
 }
-copyFileSync(treeSitterWasmPath, join(bundleDir, 'tree-sitter.wasm'));
 
-// Copy the tree-sitter bash grammar WASM. shell-parser.ts loads this from disk
-// via require.resolve at runtime (the esbuild ?binary embedding plugin was
-// retired), so the bundle must ship the grammar alongside the other WASM files.
-const treeSitterBashWasmPath = require.resolve(
-  'tree-sitter-bash/tree-sitter-bash.wasm',
-);
-copyFileSync(treeSitterBashWasmPath, join(bundleDir, 'tree-sitter-bash.wasm'));
+/**
+ * Recursively copies a required directory tree into a destination directory,
+ * throwing if the source directory is absent or empty. Preserves the relative
+ * structure so bundle-relative reads (`join(__dirname, 'subdir', …)`) resolve.
+ */
+function stageRequiredTree(
+  srcDir: string,
+  destDir: string,
+  description: string,
+): string[] {
+  if (!existsSync(srcDir)) {
+    throw missingRequiredAsset(description, srcDir);
+  }
+  const files = walkFiles(srcDir);
+  if (files.length === 0) {
+    throw missingRequiredAsset(description, srcDir);
+  }
+  return files.map((rel) => copyFileTo(join(srcDir, rel), join(destDir, rel)));
+}
 
-// Copy all markdown files from prompt-config/defaults preserving directory structure
-const promptMdFiles = glob.sync(
-  'packages/core/src/prompt-config/defaults/**/*.md',
-  { cwd: root },
-);
-// Found markdown files to copy
-for (const file of promptMdFiles) {
-  // Extract the relative path after 'defaults/'
-  // Normalize path separators to forward slashes for consistent replacement
-  const normalizedFile = file.replace(/\\/g, '/');
-  const relativePath = normalizedFile.replace(
-    'packages/core/src/prompt-config/defaults/',
-    '',
+/** Copies a generated artifact when present; returns [] when absent. */
+function stageOptionalFile(srcPath: string, destPath: string): string[] {
+  if (!existsSync(srcPath)) {
+    return [];
+  }
+  return [copyFileTo(srcPath, destPath)];
+}
+
+/**
+ * Resolves the `web-tree-sitter` WASM via module resolution (the package's
+ * `exports` map `"./tree-sitter.wasm"`), so a nested/non-hoisted install layout
+ * still works — the same idiom `bun-build.config.ts` uses for tiktoken.
+ *
+ * Resolution is anchored at `repoRoot` (not this script's own location) so the
+ * fail-fast tests that drive a synthetic `repoRoot` get a deterministic, real
+ * result: an empty temp root has no `node_modules`, so resolution fails and the
+ * actionable error fires. Anchoring at the script location would always find
+ * the real repo's copy and silently mask a missing-asset regression. In
+ * production `repoRoot` is the real repo root, so the two anchors are
+ * equivalent there — this choice only affects testability.
+ */
+function resolveTreeSitterWasm(repoRoot: string): string {
+  const requireAtRoot = createRequire(join(repoRoot, 'package.json'));
+  try {
+    return requireAtRoot.resolve('web-tree-sitter/tree-sitter.wasm');
+  } catch {
+    throw missingRequiredAsset(
+      'tree-sitter.wasm',
+      join(repoRoot, 'node_modules/web-tree-sitter/tree-sitter.wasm'),
+    );
+  }
+}
+
+function stageTreeSitterWasm(repoRoot: string, bundleDir: string): string[] {
+  return [
+    stageRequiredFile(
+      resolveTreeSitterWasm(repoRoot),
+      join(bundleDir, 'tree-sitter.wasm'),
+      'tree-sitter.wasm',
+    ),
+  ];
+}
+
+/**
+ * Extensions the alias loader reads (`SUPPORTED_EXTENSIONS` in
+ * `packages/providers/src/composition/providerAliases.ts`). Staging is filtered
+ * to these so incidental files in the source directory are never published.
+ */
+const ALIAS_EXTENSIONS = ['.config', '.json'];
+
+/**
+ * Collects built-in provider alias asset names (`.config`/`.json`) from `dir`,
+ * failing fast when none are found.
+ *
+ * An empty result is a build-input error, not a silent no-op: the bundled
+ * `providerAliases` loader would then register zero built-in providers and
+ * `--provider openai` would fail at launch (issue #3062 regression). Surfacing
+ * this at build time prevents shipping a bundle that silently dropped every
+ * built-in alias.
+ */
+export function collectAliasAssets(dir: string): string[] {
+  const assets = readdirSync(dir).filter((name) =>
+    ALIAS_EXTENSIONS.some((ext) => name.endsWith(ext)),
   );
-  const sourcePath = join(root, file);
-  const targetPath = join(bundleDir, relativePath);
-  const targetDir = dirname(targetPath);
-
-  // Create directory structure if it doesn't exist
-  if (!existsSync(targetDir)) {
-    mkdirSync(targetDir, { recursive: true });
+  if (assets.length === 0) {
+    throw new Error(
+      `cli-bundle build produced no built-in provider alias assets: ${dir} ` +
+        `contains no .config/.json files; the bundled providerAliases loader ` +
+        `would register no built-in providers.`,
+    );
   }
-
-  copyFileSync(sourcePath, targetPath);
-
-  // Verify the file was copied
-  if (!existsSync(targetPath)) {
-    console.error(`  Failed to copy: ${relativePath}`);
-  }
+  return assets;
 }
 
-// Copy generated prompt manifest into the bundle root for runtime loading
-const promptManifestPath = join(
-  root,
-  'packages/core/dist/prompt-config/defaults/default-prompts.json',
-);
-if (existsSync(promptManifestPath)) {
-  copyFileSync(promptManifestPath, join(bundleDir, 'default-prompts.json'));
-}
-
-// Copy generated git-commit info into the bundle root for runtime loading
-const gitCommitInfoPath = join(
-  root,
-  'packages/cli/src/generated/git-commit.json',
-);
-if (existsSync(gitCommitInfoPath)) {
-  copyFileSync(gitCommitInfoPath, join(bundleDir, 'git-commit.json'));
-}
-
-// Copy provider alias config files preserving directory structure
-const aliasFiles = glob.sync(
-  'packages/providers/src/composition/aliases/*.config',
-  {
-    cwd: root,
-  },
-);
-for (const file of aliasFiles) {
-  const sourcePath = join(root, file);
-  const targetPath = join(bundleDir, 'providers', 'aliases', basename(file));
-  const targetDir = dirname(targetPath);
-
-  // Create directory structure if it doesn't exist
-  if (!existsSync(targetDir)) {
-    mkdirSync(targetDir, { recursive: true });
+function stageProviderAliases(repoRoot: string, bundleDir: string): string[] {
+  const srcDir = join(repoRoot, 'packages/providers/src/composition/aliases');
+  // The existsSync guard keeps the actionable message for a missing directory;
+  // collectAliasAssets owns the "directory exists but holds no aliases" guard
+  // (issue #3062) so both callers share one alias-collection implementation.
+  if (!existsSync(srcDir)) {
+    throw missingRequiredAsset('provider alias configs', srcDir);
   }
-
-  copyFileSync(sourcePath, targetPath);
-
-  // Verify the file was copied
-  if (!existsSync(targetPath)) {
-    console.error(`  Failed to copy alias: ${basename(file)}`);
-  }
+  const destDir = join(bundleDir, 'providers', 'aliases');
+  return collectAliasAssets(srcDir).map((name) =>
+    copyFileTo(join(srcDir, name), join(destDir, name)),
+  );
 }
 
-// Copy policy files preserving directory structure
-const policyFiles = glob.sync('packages/core/src/policy/policies/*.toml', {
-  cwd: root,
-});
-for (const file of policyFiles) {
-  const sourcePath = join(root, file);
-  const targetPath = join(bundleDir, 'policies', basename(file));
-  const targetDir = dirname(targetPath);
-
-  // Create directory structure if it doesn't exist
-  if (!existsSync(targetDir)) {
-    mkdirSync(targetDir, { recursive: true });
-  }
-
-  copyFileSync(sourcePath, targetPath);
-
-  // Verify the file was copied
-  if (!existsSync(targetPath)) {
-    console.error(`  Failed to copy policy: ${basename(file)}`);
-  }
+function stagePolicyTomls(repoRoot: string, bundleDir: string): string[] {
+  const srcDir = join(repoRoot, 'packages/policy/src/policies');
+  return stageRequiredDir(
+    srcDir,
+    join(bundleDir, 'policies'),
+    (name) => name.endsWith('.toml'),
+    'policy TOML files',
+  );
 }
 
-// Copy built-in skills preserving directory structure
-const builtinSkillsSrc = join(root, 'packages/core/src/skills/builtin');
-const builtinSkillsDest = join(bundleDir, 'builtin');
-if (existsSync(builtinSkillsSrc)) {
-  cpSync(builtinSkillsSrc, builtinSkillsDest, {
-    recursive: true,
-    dereference: true,
-  });
+/**
+ * macOS seatbelt profiles. The filter is scoped to the known profile shape
+ * (`sandbox-macos-` prefix + `.sb` suffix) because the source directory is the
+ * general `packages/cli/src/utils`, so a future unrelated or fixture `.sb` file
+ * would otherwise be silently published.
+ */
+function stageSandboxProfiles(repoRoot: string, bundleDir: string): string[] {
+  const srcDir = join(repoRoot, 'packages/cli/src/utils');
+  return stageRequiredDir(
+    srcDir,
+    bundleDir,
+    (name) => name.startsWith('sandbox-macos-') && name.endsWith('.sb'),
+    'macOS seatbelt profiles',
+  );
 }
-// Assets copied to bundle/
+
+/**
+ * Pinned tokenizer BPE assets read by the official prompt estimators
+ * (`assetLoader.ts` computes `ASSETS_DIR = join(__dirname, 'assets')`). Three
+ * model families (kimi-k3, glm-5.2, minimax-m3) each ship a manifest, BPE file,
+ * and license; without them those models cannot start a chat. Staged as a
+ * required tree so the on-disk layout the loader expects is preserved.
+ */
+function stageTokenizerAssets(repoRoot: string, bundleDir: string): string[] {
+  const srcDir = join(
+    repoRoot,
+    'packages/providers/src/tokenizers/official/assets',
+  );
+  return stageRequiredTree(
+    srcDir,
+    join(bundleDir, 'assets'),
+    'official tokenizer BPE assets',
+  );
+}
+
+/**
+ * Extension boilerplate templates read by `extensions new`
+ * (`new.ts` computes `EXAMPLES_PATH = join(__dirname, 'examples')` and
+ * `readdir`s it inside the yargs builder, so a missing tree crashes during
+ * argument parsing). Five templates with nested files; staged as a required
+ * tree preserving structure.
+ */
+function stageExtensionExamples(repoRoot: string, bundleDir: string): string[] {
+  const srcDir = join(
+    repoRoot,
+    'packages/cli/src/commands/extensions/examples',
+  );
+  return stageRequiredTree(
+    srcDir,
+    join(bundleDir, 'examples'),
+    'extension boilerplate examples',
+  );
+}
+
+function stagePromptDefaults(repoRoot: string, bundleDir: string): string[] {
+  const srcRoot = join(repoRoot, 'packages/core/src/prompt-config/defaults');
+  // glob.sync returns [] for a missing dir, so an existsSync guard is not
+  // needed here — the empty check below surfaces the actionable error.
+  const files = glob.sync('**/*.md', { cwd: srcRoot });
+  if (files.length === 0) {
+    throw missingRequiredAsset('prompt default markdown files', srcRoot);
+  }
+  return files.map((rel) =>
+    copyFileTo(join(srcRoot, rel), join(bundleDir, rel)),
+  );
+}
+
+function stageGeneratedAssets(repoRoot: string, bundleDir: string): string[] {
+  const staged: string[] = [];
+  staged.push(
+    ...stageOptionalFile(
+      join(
+        repoRoot,
+        'packages/core/dist/prompt-config/defaults/default-prompts.json',
+      ),
+      join(bundleDir, 'default-prompts.json'),
+    ),
+  );
+  staged.push(
+    ...stageOptionalFile(
+      join(repoRoot, 'packages/cli/src/generated/git-commit.json'),
+      join(bundleDir, 'git-commit.json'),
+    ),
+  );
+  return staged;
+}
+
+/**
+ * Stages every runtime asset the prebuilt CLI bundle resolves relative to the
+ * bundle directory. Throws on a missing required asset (the bundle would be
+ * unusable); copies generated artifacts when present.
+ *
+ * @returns the destination paths of every staged asset, for inclusion in build
+ * diagnostics / artifact lists.
+ */
+export function stageCliBundleAssets(
+  options: StageCliBundleAssetsOptions = {},
+): readonly string[] {
+  const repoRoot = options.repoRoot ?? defaultRepoRoot();
+  const bundleDir =
+    options.bundleDir ?? join(repoRoot, 'packages', 'cli', 'bundle');
+  ensureDir(bundleDir);
+
+  const staged: string[] = [];
+  staged.push(...stageTreeSitterWasm(repoRoot, bundleDir));
+  staged.push(...stageProviderAliases(repoRoot, bundleDir));
+  staged.push(...stagePolicyTomls(repoRoot, bundleDir));
+  staged.push(...stageSandboxProfiles(repoRoot, bundleDir));
+  staged.push(...stageTokenizerAssets(repoRoot, bundleDir));
+  staged.push(...stageExtensionExamples(repoRoot, bundleDir));
+  staged.push(...stagePromptDefaults(repoRoot, bundleDir));
+  staged.push(...stageGeneratedAssets(repoRoot, bundleDir));
+  return staged;
+}
+
+if (import.meta.main) {
+  const staged = stageCliBundleAssets();
+  console.error(
+    `staged ${staged.length} CLI bundle runtime asset(s) into packages/cli/bundle`,
+  );
+}

--- a/scripts/tests/issue-3068-bundle-runtime-assets.bun.test.ts
+++ b/scripts/tests/issue-3068-bundle-runtime-assets.bun.test.ts
@@ -1,0 +1,477 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3068 — the prebuilt CLI bundle must ship the runtime data assets the
+ * bundled code resolves relative to the bundle directory.
+ *
+ * `buildCliBundle()` inlines the whole module graph into a single
+ * `packages/cli/bundle/llxprt.js`. Every module that locates a data file via
+ * `__dirname` / `import.meta.url` then resolves it under `<bundle-dir>/…`, so
+ * those files must be staged next to the bundle or every such read fails in
+ * the published package (emscripten `tree-sitter.wasm` ENOENT abort + a CLI
+ * with no providers available). These are behavioural tests: they build the
+ * REAL bundle via the production entry point and assert against the REAL
+ * output, then clean up the gitignored artifact in `afterAll`.
+ *
+ * Follows the pattern of `issue-3055-bundle-purity.bun.test.ts` (build the real
+ * artifact in a child process, assert against it, clean up). The build is shared
+ * across the asset/provider/wasm cases via a single `beforeAll` rather than
+ * gated off, because the asset-presence assertions are cheap and valuable enough
+ * to run in normal CI.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { stageCliBundleAssets } from '../copy_bundle_assets.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(__filename, '..', '..', '..');
+const bundleDir = join(repoRoot, 'packages', 'cli', 'bundle');
+const bundlePath = join(bundleDir, 'llxprt.js');
+
+/** Lists regular file names directly inside a directory. */
+function fileNamesIn(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name);
+}
+
+/**
+ * Recursively lists every regular file under `rootDir` as forward-slash relative
+ * paths (sorted), so a staged tree can be compared to its source tree for exact
+ * set-equality — a newly added source file can never be silently forgotten.
+ */
+function listRelativeFiles(rootDir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [''];
+  while (stack.length > 0) {
+    const rel = stack.pop();
+    if (rel === undefined) {
+      break;
+    }
+    const abs = rel === '' ? rootDir : join(rootDir, rel);
+    for (const entry of readdirSync(abs, { withFileTypes: true })) {
+      const childRel = rel === '' ? entry.name : `${rel}/${entry.name}`;
+      if (entry.isDirectory()) {
+        stack.push(childRel);
+      } else if (entry.isFile()) {
+        out.push(childRel);
+      }
+    }
+  }
+  return out.sort();
+}
+
+/**
+ * Builds the real CLI bundle via the production `prepack` entry point. The build
+ * is invoked as a child process (matching `prepack`) rather than in-process so
+ * the test exercises the real artifact pipeline. Returns once `llxprt.js` and
+ * every staged asset exist.
+ */
+function buildRealBundle(): void {
+  rmSync(bundleDir, { recursive: true, force: true });
+  const build = spawnSync(
+    process.execPath,
+    ['scripts/bun-build.config.ts', '--cli-only'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 120_000,
+      env: { ...process.env, CI: 'true' },
+    },
+  );
+  expect(
+    build.error,
+    `CLI bundle build failed to spawn: ${
+      build.error instanceof Error ? build.error.message : String(build.error)
+    }`,
+  ).toBeUndefined();
+  expect(
+    build.signal,
+    `CLI bundle build was killed by signal ${build.signal} (likely timeout).\n` +
+      `stdout: ${build.stdout}\nstderr: ${build.stderr}`,
+  ).toBeNull();
+  expect(
+    build.status,
+    `CLI bundle build failed (exit ${build.status}).\nstdout: ${build.stdout}\nstderr: ${build.stderr}`,
+  ).toBe(0);
+  expect(existsSync(bundlePath)).toBe(true);
+}
+
+describe('issue #3068: CLI bundle ships its runtime assets', () => {
+  // Shared spawn result for the provider-resolution and wasm-abort cases. Both
+  // need the bundle to reach Config construction (which awaits the tree-sitter
+  // parser) and provider activation, so a single launch covers both assertions.
+  let providerLaunch: {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+    signal: NodeJS.Signals | null;
+  };
+
+  beforeAll(() => {
+    buildRealBundle();
+    providerLaunch = launchBundleProviderResolve();
+  }, 150_000);
+
+  afterAll(() => {
+    // The bundle is a gitignored publish artifact; remove it so a stale build
+    // can never satisfy a future run or interfere with the launch smoke.
+    rmSync(bundleDir, { recursive: true, force: true });
+  });
+
+  it('stages every required asset at its required bundle path', () => {
+    // Asset 1: tree-sitter.wasm exists and is a real WASM file (magic bytes),
+    // not a placeholder or an error page.
+    const wasmPath = join(bundleDir, 'tree-sitter.wasm');
+    expect(existsSync(wasmPath)).toBe(true);
+    const wasmHeader = readFileSync(wasmPath).subarray(0, 4);
+    // `\0asm` = 0x00 0x61 0x73 0x6d
+    expect(Array.from(wasmHeader)).toEqual([0x00, 0x61, 0x73, 0x6d]);
+
+    // Asset 2: provider aliases — staged set must EXACTLY match the source dir,
+    // so a future added alias can never be silently forgotten.
+    const sourceAliasDir = join(
+      repoRoot,
+      'packages/providers/src/composition/aliases',
+    );
+    const stagedAliasDir = join(bundleDir, 'providers', 'aliases');
+    // Compared over the extensions the alias loader actually reads, matching
+    // the staging filter, so incidental files in the source dir do not make
+    // this assertion fail while a genuinely missed alias still does.
+    const aliases = (dir: string): string[] =>
+      fileNamesIn(dir).filter(
+        (name) => name.endsWith('.config') || name.endsWith('.json'),
+      );
+    expect(aliases(stagedAliasDir)).not.toHaveLength(0);
+    expect(new Set(aliases(stagedAliasDir))).toEqual(
+      new Set(aliases(sourceAliasDir)),
+    );
+
+    // Asset 3: policy TOMLs — staged set must EXACTLY match the source dir.
+    const sourcePolicyDir = join(repoRoot, 'packages/policy/src/policies');
+    const stagedPolicyDir = join(bundleDir, 'policies');
+    const tomls = (dir: string): string[] =>
+      fileNamesIn(dir).filter((name) => name.endsWith('.toml'));
+    expect(tomls(stagedPolicyDir)).not.toHaveLength(0);
+    expect(new Set(tomls(stagedPolicyDir))).toEqual(
+      new Set(tomls(sourcePolicyDir)),
+    );
+
+    // Asset 4: the six macOS seatbelt profiles, staged flat at the bundle root.
+    const sbProfiles = fileNamesIn(bundleDir).filter((name) =>
+      name.endsWith('.sb'),
+    );
+    expect(sbProfiles.sort()).toEqual(
+      [
+        'sandbox-macos-permissive-closed.sb',
+        'sandbox-macos-permissive-open.sb',
+        'sandbox-macos-permissive-proxied.sb',
+        'sandbox-macos-restrictive-closed.sb',
+        'sandbox-macos-restrictive-open.sb',
+        'sandbox-macos-restrictive-proxied.sb',
+      ].sort(),
+    );
+
+    // Asset 5: official tokenizer BPE assets (kimi-k3, glm-5.2, minimax-m3),
+    // staged as a required tree under bundle/assets. Each model dir carries a
+    // manifest, BPE file, and license; without them those models cannot start a
+    // chat. Full recursive set-equality so a new asset cannot be forgotten.
+    const sourceTokenizerDir = join(
+      repoRoot,
+      'packages/providers/src/tokenizers/official/assets',
+    );
+    const stagedTokenizerFiles = listRelativeFiles(join(bundleDir, 'assets'));
+    expect(stagedTokenizerFiles).not.toHaveLength(0);
+    expect(new Set(stagedTokenizerFiles)).toEqual(
+      new Set(listRelativeFiles(sourceTokenizerDir)),
+    );
+
+    // Asset 6: extension boilerplate templates, staged as a required tree under
+    // bundle/examples. `extensions new` readdir()s this in the yargs builder,
+    // so a missing tree crashes argument parsing. Full recursive set-equality.
+    const sourceExamplesDir = join(
+      repoRoot,
+      'packages/cli/src/commands/extensions/examples',
+    );
+    const stagedExampleFiles = listRelativeFiles(join(bundleDir, 'examples'));
+    expect(stagedExampleFiles).not.toHaveLength(0);
+    expect(new Set(stagedExampleFiles)).toEqual(
+      new Set(listRelativeFiles(sourceExamplesDir)),
+    );
+
+    // Asset 7: prompt-default markdown tree, preserving structure. These are
+    // spot checks rather than a full set-equality because the stager globs
+    // `**/*.md`; the deepest leaves vary across providers/models, so a
+    // representative sample (root, a tool, a nested provider/model) proves the
+    // tree was mirrored while staying resilient to unrelated leaf churn.
+    expect(existsSync(join(bundleDir, 'core.md'))).toBe(true);
+    expect(existsSync(join(bundleDir, 'tools', 'shell.md'))).toBe(true);
+    expect(existsSync(join(bundleDir, 'providers', 'gemini', 'core.md'))).toBe(
+      true,
+    );
+  });
+
+  it('resolves built-in providers from the bundle (no "not found")', () => {
+    // This is the exact reproduction from issue #3068. Before the fix the bundle
+    // staged no provider aliases, so provider activation failed with
+    // "Provider 'openai' not found". The spawn still fails later for a missing
+    // API key (expected); we assert only on the ABSENCE of the not-found error.
+    const combined = providerLaunch.stdout + providerLaunch.stderr;
+    // Guard against a vacuous pass: the spawn must actually have run past
+    // startup (not be spawn-killed or empty), otherwise the absence assertion
+    // would be meaningless.
+    expect(
+      providerLaunch.signal,
+      'provider spawn was killed (likely timeout)',
+    ).toBeNull();
+    expect(
+      combined.length,
+      'provider spawn produced no output; the absence assertion would be vacuous',
+    ).toBeGreaterThan(0);
+    expect(combined).not.toContain("Provider 'openai' not found");
+  });
+
+  it('does not abort on a missing tree-sitter.wasm', () => {
+    const combined = providerLaunch.stdout + providerLaunch.stderr;
+    // Positive progress guard: prove the launch reached Config construction
+    // (which awaits initializeParser(), where a missing wasm prints its abort)
+    // and beyond, so the absence assertions below cannot pass vacuously.
+    //
+    // Measured behaviour: with no API key the run reaches the provider auth
+    // check — a post-Config failure — and reports it. In the FULL pre-fix state
+    // (a bundle containing only llxprt.js) the CLI instead dies in
+    // setupRuntimeContext -> createProviderManager with "Provider 'openai' not
+    // found" BEFORE Config construction ever awaits initializeParser(), so on a
+    // full revert NEITHER wasm string appears and these absence assertions
+    // would hold vacuously. Removing ONLY tree-sitter.wasm from an otherwise
+    // complete bundle DOES reproduce both abort lines from the issue, so this
+    // progress guard is what distinguishes "wasm is fine" from "the launch
+    // never got far enough to print the abort".
+    expect(
+      combined,
+      'launch did not reach Config/post-Config execution; wasm assertions ' +
+        'would be vacuous (pre-fix bundles die with "Provider not found" ' +
+        'before initializeParser runs)',
+    ).toMatch(/Auth token unavailable|Error when talking to/);
+    expect(combined).not.toContain('failed to asynchronously prepare wasm');
+    expect(combined).not.toContain('tree-sitter.wasm');
+  });
+});
+
+/**
+ * Runs the built bundle with an OpenAI provider prompt using an environment that
+ * guarantees a fast LOCAL failure (no API key → auth error, no network reach),
+ * while still exercising Config construction and provider activation. The
+ * process is expected to exit non-zero on its own; the timeout is a safety net.
+ *
+ * Output is captured by a SHELL REDIRECT to files, not by `spawnSync`'s own
+ * capture. Under the `bun:test` harness every in-process capture method for a
+ * spawned child is broken: `spawnSync` (pipe and explicit `stdio` fd) and
+ * `Bun.spawn` streaming all return EMPTY stdout/stderr while the exit code is
+ * still correct — measured for `bun test v1.3.14` against this repo's
+ * `bunfig.toml`, where a `spawnSync` of the real bundle returns `errLen=0` but
+ * a shell redirect of the identical command captures the full 337-char auth
+ * error. (The same `spawnSync` DOES capture when driven from a plain `bun`
+ * script outside `bun:test`, which is the source of the false premise.) A shell
+ * redirect writes the child's stdio straight to files at the OS level, so the
+ * files are the only reliable way to observe what the launched bundle prints.
+ *
+ * Finding A8 asked for plain `spawnSync`; that is a documented deviation here —
+ * plain `spawnSync` makes the wasm/provider assertions vacuous, contradicting
+ * A7's anti-vacuity requirement. The command is passed to `sh` as separate argv
+ * consumed positionally (`"$0" "$@"`), so no shell quoting is needed and the
+ * args are never re-parsed by the shell (injection-safe).
+ */
+function launchBundleProviderResolve(): {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+} {
+  const isolatedHome = mkdtempSync(join(tmpdir(), 'issue3068-bundle-run-'));
+  const outFile = join(isolatedHome, 'stdout.txt');
+  const errFile = join(isolatedHome, 'stderr.txt');
+  try {
+    // Strip any real auth/credentials and isolate config so the provider fails
+    // locally and the spawn never reaches the network (which would hang/retry
+    // indefinitely). API keys, HOME, XDG_CONFIG_HOME, and every LLXPRT_* var
+    // are cleared so a developer machine's real config cannot leak into the run.
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      CI: 'true',
+      HOME: isolatedHome,
+    };
+    for (const key of [
+      'OPENAI_API_KEY',
+      'OPENAI_BASE_URL',
+      'GOOGLE_API_KEY',
+      'GEMINI_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'XDG_CONFIG_HOME',
+    ]) {
+      delete env[key];
+    }
+    for (const key of Object.keys(env)) {
+      if (key.startsWith('LLXPRT_')) {
+        delete env[key];
+      }
+    }
+    env.__I3068_OUT = outFile;
+    env.__I3068_ERR = errFile;
+    const result = spawnSync(
+      'sh',
+      [
+        '-c',
+        '"$0" "$@" > "$__I3068_OUT" 2> "$__I3068_ERR"',
+        process.execPath,
+        bundlePath,
+        '--provider',
+        'openai',
+        '--model',
+        'gpt-4o',
+        '-p',
+        'hi',
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        timeout: 60_000,
+        env,
+      },
+    );
+    return {
+      stdout: existsSync(outFile) ? readFileSync(outFile, 'utf8') : '',
+      stderr: existsSync(errFile) ? readFileSync(errFile, 'utf8') : '',
+      status: result.status,
+      signal: result.signal,
+    };
+  } finally {
+    rmSync(isolatedHome, { recursive: true, force: true });
+  }
+}
+
+describe('issue #3068: staging fails fast on a missing required asset', () => {
+  it('throws an actionable error naming the missing path (file-shaped asset)', () => {
+    // A fresh checkout must still be able to run `npm run bundle:cli`, but a
+    // source root missing a REQUIRED asset must never silently produce a broken
+    // bundle. Drive the staging function against an empty source root and
+    // assert it throws naming the absent asset. The first required stager is
+    // the file-shaped tree-sitter.wasm, so this exercises the file-shaped path.
+    const emptyRoot = mkdtempSync(join(tmpdir(), 'issue3068-empty-root-'));
+    try {
+      expect(() =>
+        stageCliBundleAssets({
+          repoRoot: emptyRoot,
+          bundleDir: join(emptyRoot, 'bundle'),
+        }),
+      ).toThrow(/tree-sitter\.wasm/);
+    } finally {
+      rmSync(emptyRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('throws an actionable error when a DIRECTORY-shaped asset is missing', () => {
+    // The empty-root case above only reaches the first (file-shaped) required
+    // asset. Directory-shaped required assets use stageRequiredDir /
+    // stageRequiredTree, whose existsSync guard is what turns a missing source
+    // directory into an actionable error instead of a raw ENOENT from
+    // readdirSync. Expose the real node_modules so the wasm stage resolves and
+    // the stager reaches the first directory asset (provider aliases), which is
+    // absent in this synthetic root.
+    const root = mkdtempSync(join(tmpdir(), 'issue3068-dir-root-'));
+    try {
+      symlinkSync(join(repoRoot, 'node_modules'), join(root, 'node_modules'));
+      let thrown: Error | undefined;
+      try {
+        stageCliBundleAssets({
+          repoRoot: root,
+          bundleDir: join(root, 'bundle'),
+        });
+      } catch (e) {
+        thrown = e instanceof Error ? e : new Error(String(e));
+      }
+      if (thrown === undefined) {
+        throw new Error('staging a missing directory asset must throw');
+      }
+      // Actionable message naming the missing directory asset, NOT the raw fs
+      // ENOENT/scandir that readdirSync would otherwise leak.
+      expect(thrown.message).toContain('provider alias configs');
+      expect(thrown.message).toContain('missing at');
+      expect(thrown.message).not.toContain('ENOENT');
+      expect(thrown.message).not.toContain('scandir');
+    } finally {
+      // Remove the symlink explicitly first so the real node_modules is never
+      // touched, then clean the rest of the synthetic root.
+      rmSync(join(root, 'node_modules'), { force: true });
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('issue #3068: gitCommitInfo resolves beside the loader', () => {
+  it('finds git-commit.json sitting next to the loader (bundle-root layout)', async () => {
+    // The fix adds a loader-relative candidate (`join(loaderDir, INFO_FILENAME)`)
+    // so that when bundled — loaderDir IS the bundle root — the JSON copied next
+    // to the bundle is found regardless of the caller's cwd. Behavioural: copy
+    // the real loader into a bundle-root-shaped layout (a temp dir inside the
+    // repo so its bare imports still resolve) with a known commit beside it, and
+    // assert the loader returns that exact commit.
+    const gitCommitInfoSrc = join(
+      repoRoot,
+      'packages/cli/src/utils/gitCommitInfo.ts',
+    );
+    // tmp/ is gitignored and has no tracked files, so on a fresh checkout it may
+    // not exist; create it (recursively) before mkdtempSync. The temp dir stays
+    // INSIDE the repo on purpose: the copied loader imports
+    // @vybestack/llxprt-code-telemetry and needs the node_modules walk-up.
+    const loaderParent = join(repoRoot, 'tmp');
+    mkdirSync(loaderParent, { recursive: true });
+    const loaderDir = mkdtempSync(join(loaderParent, 'issue3068-gitcommit-'));
+    const savedPath = process.env.LLXPRT_GIT_COMMIT_INFO_PATH;
+    try {
+      copyFileSync(gitCommitInfoSrc, join(loaderDir, 'gitCommitInfo.ts'));
+      const knownCommit = 'cafebabe3068';
+      writeFileSync(
+        join(loaderDir, 'git-commit.json'),
+        JSON.stringify({ commit: knownCommit }),
+      );
+      // Ensure the non-override candidate path is exercised.
+      delete process.env.LLXPRT_GIT_COMMIT_INFO_PATH;
+
+      // Importing the COPY gives it an import.meta.url rooted at loaderDir, so
+      // the loader-relative candidate resolves exactly the bundled layout.
+      const moduleUrl = pathToFileURL(join(loaderDir, 'gitCommitInfo.ts')).href;
+      const mod = await import(moduleUrl);
+      // knownCommit lives ONLY beside the loader, so returning it proves the
+      // loader-relative candidate is the one that resolved.
+      expect(mod.getGitCommitInfo()).toBe(knownCommit);
+    } finally {
+      // Restore the env var so the test cannot leak its deletion to siblings.
+      if (savedPath === undefined) {
+        delete process.env.LLXPRT_GIT_COMMIT_INFO_PATH;
+      } else {
+        process.env.LLXPRT_GIT_COMMIT_INFO_PATH = savedPath;
+      }
+      rmSync(loaderDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/issue-3068-bundle-runtime-assets.bun.test.ts
+++ b/scripts/tests/issue-3068-bundle-runtime-assets.bun.test.ts
@@ -295,11 +295,17 @@ describe('issue #3068: CLI bundle ships its runtime assets', () => {
  * redirect writes the child's stdio straight to files at the OS level, so the
  * files are the only reliable way to observe what the launched bundle prints.
  *
- * Finding A8 asked for plain `spawnSync`; that is a documented deviation here —
- * plain `spawnSync` makes the wasm/provider assertions vacuous, contradicting
- * A7's anti-vacuity requirement. The command is passed to `sh` as separate argv
- * consumed positionally (`"$0" "$@"`), so no shell quoting is needed and the
- * args are never re-parsed by the shell (injection-safe).
+ * Measured under `bun test v1.3.14`: a child's output is observable ONLY via a
+ * shell redirect. `spawnSync` with `encoding` (pipes), `spawnSync` with
+ * explicit file descriptors in `stdio`, and `Bun.spawnSync` with pipes all
+ * yield empty `stdout`/`stderr` (and, for the fd form, an empty file) while
+ * still reporting the correct exit status. Using plain `spawnSync` here would
+ * therefore make the wasm/provider absence assertions vacuous.
+ *
+ * The command string is a constant; the two values that vary (the Bun binary
+ * and the bundle path) travel through the environment and are expanded inside
+ * double quotes, so nothing is interpolated into the command and the shell
+ * cannot re-parse a path containing spaces or metacharacters.
  */
 function launchBundleProviderResolve(): {
   stdout: string;
@@ -337,19 +343,19 @@ function launchBundleProviderResolve(): {
     }
     env.__I3068_OUT = outFile;
     env.__I3068_ERR = errFile;
+    env.__I3068_BUN = process.execPath;
+    env.__I3068_BUNDLE = bundlePath;
+    // Every argument the shell sees is a compile-time constant: the two paths
+    // that vary (the Bun binary and the bundle) are passed through the
+    // environment and expanded inside double quotes, so nothing is ever
+    // interpolated into the command string and the shell cannot re-parse a
+    // path containing spaces or metacharacters.
     const result = spawnSync(
       'sh',
       [
         '-c',
-        '"$0" "$@" > "$__I3068_OUT" 2> "$__I3068_ERR"',
-        process.execPath,
-        bundlePath,
-        '--provider',
-        'openai',
-        '--model',
-        'gpt-4o',
-        '-p',
-        'hi',
+        '"$__I3068_BUN" "$__I3068_BUNDLE" --provider openai --model gpt-4o ' +
+          '-p hi > "$__I3068_OUT" 2> "$__I3068_ERR"',
       ],
       {
         cwd: repoRoot,

--- a/scripts/tests/issue-3068-bundle-runtime-assets.bun.test.ts
+++ b/scripts/tests/issue-3068-bundle-runtime-assets.bun.test.ts
@@ -33,6 +33,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -127,10 +128,24 @@ describe('issue #3068: CLI bundle ships its runtime assets', () => {
     signal: NodeJS.Signals | null;
   };
 
+  // Positive control for the assertion below: the same launch with the staged
+  // tree-sitter.wasm removed. Without it the "no abort" assertion could only
+  // ever prove the absence of a string, never that the check has teeth.
+  let wasmRemovedLaunch: {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+    signal: NodeJS.Signals | null;
+  };
+
+  // Budget must cover the worst case of everything this hook does, otherwise
+  // the hook can time out while each individual step is still inside its own
+  // limit: buildRealBundle (120s) + two launches (60s each).
   beforeAll(() => {
     buildRealBundle();
     providerLaunch = launchBundleProviderResolve();
-  }, 150_000);
+    wasmRemovedLaunch = launchWithoutTreeSitterWasm();
+  }, 260_000);
 
   afterAll(() => {
     // The bundle is a gitignored publish artifact; remove it so a stale build
@@ -250,7 +265,23 @@ describe('issue #3068: CLI bundle ships its runtime assets', () => {
     expect(combined).not.toContain("Provider 'openai' not found");
   });
 
-  it('does not abort on a missing tree-sitter.wasm', () => {
+  it('prints the emscripten abort when the staged tree-sitter.wasm is absent', () => {
+    // Positive control. web-tree-sitter resolves its WASM through
+    // `import.meta.url`, which Bun rewrites to the bundle's own URL, so an
+    // unstaged wasm makes the launch print exactly the pair of lines from the
+    // issue report. Pinning that here is what gives the "no abort" assertion
+    // below its teeth: it proves the strings genuinely appear when the asset is
+    // missing, rather than never appearing for some unrelated reason.
+    const combined = wasmRemovedLaunch.stdout + wasmRemovedLaunch.stderr;
+    expect(
+      combined.length,
+      'wasm-removed launch produced no output; the control proves nothing',
+    ).toBeGreaterThan(0);
+    expect(combined).toContain('failed to asynchronously prepare wasm');
+    expect(combined).toContain('tree-sitter.wasm');
+  });
+
+  it('launches a fully staged bundle without the tree-sitter abort', () => {
     const combined = providerLaunch.stdout + providerLaunch.stderr;
     // Positive progress guard: prove the launch reached Config construction
     // (which awaits initializeParser(), where a missing wasm prints its abort)
@@ -262,10 +293,8 @@ describe('issue #3068: CLI bundle ships its runtime assets', () => {
     // setupRuntimeContext -> createProviderManager with "Provider 'openai' not
     // found" BEFORE Config construction ever awaits initializeParser(), so on a
     // full revert NEITHER wasm string appears and these absence assertions
-    // would hold vacuously. Removing ONLY tree-sitter.wasm from an otherwise
-    // complete bundle DOES reproduce both abort lines from the issue, so this
-    // progress guard is what distinguishes "wasm is fine" from "the launch
-    // never got far enough to print the abort".
+    // would hold vacuously. This progress guard is what distinguishes "wasm is
+    // fine" from "the launch never got far enough to print the abort".
     expect(
       combined,
       'launch did not reach Config/post-Config execution; wasm assertions ' +
@@ -372,6 +401,31 @@ function launchBundleProviderResolve(): {
     };
   } finally {
     rmSync(isolatedHome, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Runs the same launch with the staged `tree-sitter.wasm` temporarily moved
+ * aside, reproducing the exact state issue #3068 reported. The file is restored
+ * in a `finally` so every later assertion still sees a complete bundle.
+ *
+ * Moving the real file is deliberate: web-tree-sitter derives the WASM location
+ * from the bundle's own URL, so the artifact must be launched from its real
+ * directory for the lookup to point where the issue says it points.
+ */
+function launchWithoutTreeSitterWasm(): {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+} {
+  const wasmPath = join(bundleDir, 'tree-sitter.wasm');
+  const stashedPath = `${wasmPath}.stashed`;
+  renameSync(wasmPath, stashedPath);
+  try {
+    return launchBundleProviderResolve();
+  } finally {
+    renameSync(stashedPath, wasmPath);
   }
 }
 

--- a/scripts/tests/ocr-concurrency-canary-2673.test.ts
+++ b/scripts/tests/ocr-concurrency-canary-2673.test.ts
@@ -514,6 +514,14 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
         statusCode: number | undefined;
         body: string;
       }>((resolve) => {
+        // The upstream sends 200 headers and then destroys the socket
+        // mid-body, so the client-visible failure can surface either on the
+        // response stream or as a request-level 'error', depending on which
+        // event loop turn the reset lands in. Record the status line as soon
+        // as headers arrive so the request-level path reports the status the
+        // client genuinely observed instead of racing to 0.
+        let observedStatus: number | undefined;
+        let observedChunks: Buffer[] = [];
         const proxyRequest = http.request(
           new URL(asString(resource.ready.proxy_url)),
           {
@@ -524,7 +532,9 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
             },
           },
           (response) => {
+            observedStatus = response.statusCode;
             const chunks: Buffer[] = [];
+            observedChunks = chunks;
             response.on('data', (chunk) => chunks.push(chunk));
             response.on('end', () =>
               resolve({
@@ -541,7 +551,13 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
           },
         );
         proxyRequest.once('error', () =>
-          resolve({ statusCode: 0, body: 'connection error' }),
+          resolve({
+            statusCode: observedStatus ?? 0,
+            body:
+              observedStatus === undefined
+                ? 'connection error'
+                : Buffer.concat(observedChunks).toString('utf8'),
+          }),
         );
         proxyRequest.end('{"test":true}');
       });


### PR DESCRIPTION
## TLDR

The published `@vybestack/llxprt-code` package ships a prebuilt CLI bundle, but that bundle shipped **no data files at all** — only `llxprt.js`. Every module that locates a runtime asset via `__dirname` / `import.meta.url` resolves it under `<package-root>/bundle/` once Bun inlines the module graph, so all of those reads failed in the installed package. On macOS that produced the emscripten abort in the issue report plus a CLI with **no providers available**.

This makes the bundle build stage the assets the bundled code actually reads, and fail loudly if any required one is missing so a release can never silently ship a broken bundle again.

Reproduced on this branch before the fix:

    $ npm run bundle:cli
    $ bun packages/cli/bundle/llxprt.js --provider openai --model gpt-4o -p "hi"
    Error: Could not activate explicitly-configured provider 'openai': Provider 'openai' not found

and, with the wasm absent, the exact pair of lines from the issue:

    failed to asynchronously prepare wasm: Error: ENOENT: ... /bundle/tree-sitter.wasm
    Aborted(Error: ENOENT: ... /bundle/tree-sitter.wasm)

## Dive Deeper

### Root cause

`packages/cli` publishes a `bundle` directory (`"files": ["bundle", ...]`). `buildCliBundle()` in `scripts/bun-build.config.ts` produces `packages/cli/bundle/llxprt.js` from the `prepack` script that both `npm publish` and `npm pack` fire. Bun inlines the whole TypeScript module graph into that single file, so `join(__dirname, 'providers', 'aliases')` and friends now point at `<package-root>/bundle/...` instead of their source directories. Before the prebuilt bundle existed the package ran from raw TypeScript and those paths resolved correctly.

`scripts/copy_bundle_assets.ts` — the staging script from the retired esbuild flow — still existed but was orphaned: no npm script, build script, or workflow invoked it, and it wrote into the gitignored **repo-root** `bundle/` directory that nothing consumes. That is why the regression was invisible when the prebuilt bundle landed.

### What is now staged

| Asset | Source | Bundle path | Resolving site | Symptom when missing |
| --- | --- | --- | --- | --- |
| `tree-sitter.wasm` | `web-tree-sitter` (via `require.resolve`) | `bundle/tree-sitter.wasm` | `findWasmBinary()` → `new URL('tree-sitter.wasm', import.meta.url)` | emscripten abort at startup |
| Provider aliases | `packages/providers/src/composition/aliases/` | `bundle/providers/aliases/` | `providerAliases.ts` `BUNDLE_ALIAS_DIR` | **no providers available** |
| Policy TOMLs | `packages/policy/src/policies/` | `bundle/policies/` | `packages/policy/src/config.ts`, `toml-loader.ts` | built-in tool policies silently absent |
| Seatbelt profiles | `packages/cli/src/utils/sandbox-macos-*.sb` | `bundle/` (flat) | `sandbox-seatbelt.ts` | `FatalSandboxError`, macOS sandbox unusable |
| Prompt defaults | `packages/core/src/prompt-config/defaults/**/*.md` | `bundle/` (structure preserved) | `core/provider/tool-defaults.ts` | default prompts unavailable |
| Tokenizer BPE assets | `packages/providers/src/tokenizers/official/assets/` | `bundle/assets/` | `assetLoader.ts` `ASSETS_DIR` | `kimi-k3`, `glm-5.2`, `minimax-m3` cannot initialise a chat |
| Extension templates | `packages/cli/src/commands/extensions/examples/` | `bundle/examples/` | `new.ts` `EXAMPLES_PATH` | `extensions new` crashes during arg parsing |
| Prompt manifest | generated `default-prompts.json` | `bundle/default-prompts.json` | `manifest-loader.ts` | manifest fast path unavailable |
| `git-commit.json` | generated | `bundle/git-commit.json` | `gitCommitInfo.ts` | commit reported as `N/A` |

The last two are produced by `npm run generate`, so they are copied when present and skipped when absent — a fresh checkout can still run `npm run bundle:cli`. Everything else is **required** and throws an actionable error naming the missing path.

`gitCommitInfo.ts` also gets a one-line fix: its comment already claimed "the JSON is copied to the bundle root", but the candidate it built was `join(process.cwd(), 'bundle', ...)` — cwd-relative, so it only matched when the CLI happened to be launched from the package root. The loader-relative candidate is the correct one.

### Consolidation with #3062

`main` picked up a narrower fix for #3062 that staged only the provider aliases inline in `buildCliBundle()`. That is subsumed here: alias staging moves into the general stager, `collectAliasAssets` (and its fail-fast guard) moves to `copy_bundle_assets.ts` and is re-exported from `bun-build.config.ts` so the existing #3062 test keeps its import path unchanged. One implementation, one fail-fast contract. The #3062 behaviour and its tests are preserved.

### Deliberately out of scope

- **`tree-sitter-bash.wasm`** is *not* staged. `shell-parser.ts` resolves it with `require.resolve(...)`, i.e. module resolution from `node_modules`, not a bundle-relative read — copying it into `bundle/` would change nothing, and failure degrades gracefully to regex parsing. The residual caveat (it is a dependency of `-core`, not of `packages/cli`, so it relies on npm hoisting) is recorded in the code and the plan.
- **Externalizing `web-tree-sitter`** is unnecessary: it resolves through `import.meta.url`, which Bun rewrites to the bundle URL, so staging the file next to the bundle is the correct fix. Externalizing would additionally require a new direct `packages/cli` dependency to satisfy the `CLI_DIRNAME_DEPENDENT_EXTERNALS` ownership invariant.
- **Built-in skills**: `packages/core/src/skills/builtin` does not exist in the repo, so there is nothing to stage.
- A mechanical gate that enumerates every `join(__dirname, …)` data read repo-wide and requires each to be staged or allow-listed was considered and **deferred** — it is a new subsystem rather than part of this fix.

### Other hardening in the same code path

- The bundle directory is pruned before the build, so an alias, policy, or template removed from source can no longer linger and ship.
- A missing *source directory* previously surfaced a raw `ENOENT ... scandir` instead of the actionable message, which meant the fail-fast contract held for only one of the required assets.
- The seatbelt filter is scoped to the `sandbox-macos-*.sb` shape so a future unrelated `.sb` file in the general `utils` directory cannot be published.

## Reviewer Test Plan

    npm run bundle:cli
    ls -R packages/cli/bundle          # llxprt.js plus assets/, examples/, policies/, providers/aliases/, *.sb, *.md, tree-sitter.wasm

    # provider resolves (fails later on missing auth, which is expected)
    bun packages/cli/bundle/llxprt.js --provider openai --model gpt-4o -p "hi"

    # tokenizer-backed models initialise
    bun packages/cli/bundle/llxprt.js --provider openai --model kimi-k3 -p "hi"

    # extension templates are reachable
    bun packages/cli/bundle/llxprt.js extensions new /tmp/ext-check context

To see the original failure, delete a staged asset and re-run:

    rm packages/cli/bundle/tree-sitter.wasm
    bun packages/cli/bundle/llxprt.js --provider openai --model gpt-4o -p "hi"
    # reproduces the two lines from the issue

Automated coverage lives in `scripts/tests/issue-3068-bundle-runtime-assets.bun.test.ts`, which builds the real artifact and asserts the staged alias/policy sets exactly match their source directories, that `tree-sitter.wasm` carries the `\0asm` magic bytes, that a launched bundle prints neither the wasm abort nor `Provider 'openai' not found`, and that staging throws an actionable error for both file-shaped and directory-shaped missing assets.

Note for reviewers: under `bun test`, `spawnSync`/`Bun.spawn` return empty `stdout`/`stderr` (verified with a minimal probe — the exit code is still correct). The launch test therefore captures the child's output via a shell redirect to files; the comment in the test records this.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run build`, `npm run typecheck`, `npm run lint`, `npm run lint:eslint-guard`, `prettier --check .`, `npm run test`, `npm run test:scripts` (223/223), and the CLI smoke run. The staged `.sb` profiles are macOS-only; the remaining assets are platform-independent and the staging code uses `path.join` throughout.

## Linked issues / bugs

Fixes #3068


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI bundle reliability by ensuring required runtime assets are included and missing assets produce actionable errors.
  - Fixed bundled Git metadata discovery across runtime environments.
  - Improved streaming error reporting to preserve HTTP status codes and partial response content.

- **Tests**
  - Added coverage for CLI runtime assets, provider resolution, syntax highlighting initialization, and missing-asset errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->