### PR TITLE
Keep a failed tool call failed through OpenAI-Vercel and the ContentConverters round trip (Fixes #3076)

### DIFF
--- a/packages/core/src/code_assist/contentGeneratorAdapters.toolFailure.test.ts
+++ b/packages/core/src/code_assist/contentGeneratorAdapters.toolFailure.test.ts
@@ -58,6 +58,7 @@ describe('contentGeneratorAdapters tool-failure (issue #3076)', () => {
 
     expect(response?.status).toBe('error');
     expect(response?.error).toBe('boom');
+    expect(response?.result).toEqual({ output: 'partial data' });
   });
 
   it('toGenerateContentParameters emits a byte-identical raw response for a successful tool_response (regression guard)', () => {

--- a/packages/core/src/code_assist/contentGeneratorAdapters.toolFailure.test.ts
+++ b/packages/core/src/code_assist/contentGeneratorAdapters.toolFailure.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Issue #3076 — the Google code-assist request path
+ * (`contentGeneratorAdapters.toGenerateContentParameters`) is the ONLY live
+ * consumer of the outbound failure encoding produced by ContentConverters.
+ * These proofs drive the real adapter with real IContent fixtures (no mocks)
+ * and assert that a failed tool_response reaches the wire carrying an explicit
+ * failure signal rather than masquerading as a success.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  toGenerateContentParameters,
+  toCountTokensParameters,
+} from './contentGeneratorAdapters.js';
+import type { ModelGenerationRequest } from '../llm-types/modelRequest.js';
+import type { CountTokensRequest } from '../llm-types/tokensAndEmbeddings.js';
+import type { IContent } from '../services/history/IContent.js';
+
+function failedToolContent(): IContent {
+  return {
+    speaker: 'tool',
+    blocks: [
+      {
+        type: 'tool_response',
+        callId: 'hist_tool_fail1',
+        toolName: 'failingTool',
+        result: { output: 'partial data' },
+        error: 'boom',
+      },
+    ],
+  };
+}
+
+describe('contentGeneratorAdapters tool-failure (issue #3076)', () => {
+  it('toGenerateContentParameters emits an explicit failure signal for a failed tool_response', () => {
+    const request: ModelGenerationRequest = {
+      contents: [failedToolContent()],
+      model: 'gemini-2.5-pro',
+    };
+    const params = toGenerateContentParameters(request);
+    const response = params.contents[0]?.parts?.[0]?.functionResponse?.response;
+
+    expect(response?.status).toBe('error');
+    expect(response?.error).toBe('boom');
+  });
+
+  it('toGenerateContentParameters emits a byte-identical raw response for a successful tool_response (regression guard)', () => {
+    const result = { found: true, nested: { a: 1 } };
+    const successContent: IContent = {
+      speaker: 'tool',
+      blocks: [
+        {
+          type: 'tool_response',
+          callId: 'hist_tool_ok1',
+          toolName: 'okTool',
+          result,
+        },
+      ],
+    };
+    const request: ModelGenerationRequest = {
+      contents: [successContent],
+      model: 'gemini-2.5-pro',
+    };
+    const params = toGenerateContentParameters(request);
+    const response = params.contents[0]?.parts?.[0]?.functionResponse?.response;
+
+    expect(response).toStrictEqual(result);
+    expect(response).not.toHaveProperty('status');
+    expect(response).not.toHaveProperty('error');
+  });
+
+  it('toCountTokensParameters counts the same failure-shaped response', () => {
+    const request: CountTokensRequest = { contents: [failedToolContent()] };
+    const params = toCountTokensParameters(request, 'gemini-2.5-pro');
+    const response = params.contents[0]?.parts?.[0]?.functionResponse?.response;
+
+    expect(response?.status).toBe('error');
+  });
+});

--- a/packages/core/src/llm-types/geminiContent.ts
+++ b/packages/core/src/llm-types/geminiContent.ts
@@ -64,6 +64,13 @@ export interface GeminiPartExtension {
   llxprtThoughtBlockId?: string;
   llxprtThoughtBlockStatus?: 'delta' | 'complete';
   llxprtThoughtIsHidden?: boolean;
+  /**
+   * Part-level discriminant stamped alongside a failed-tool `functionResponse`
+   * so the inbound decoder only fires on parts we encoded (issue #3076).
+   * Without it a SUCCESSFUL tool whose result happens to be shaped like
+   * `{ status: 'error', error: ... }` would be misdecoded into a failure.
+   */
+  llxprtToolFailure?: boolean;
 }
 
 /**

--- a/packages/core/src/services/history/ContentConverters.toolFailure.test.ts
+++ b/packages/core/src/services/history/ContentConverters.toolFailure.test.ts
@@ -120,6 +120,9 @@ describe('ContentConverters tool-failure round trip (issue #3076)', () => {
                     result: { output: 'partial data' },
                   },
                 },
+                // The part-level discriminant (F2): the decoder only fires on
+                // a part carrying the flag, so the hand-crafted shape must too.
+                llxprtToolFailure: true,
               },
             ],
           },
@@ -213,35 +216,132 @@ describe('ContentConverters tool-failure round trip (issue #3076)', () => {
       expect(failed.error).toBe('boom');
       expect(failed.result).toEqual({ output: 'partial data' });
       expect(failed.callId).toBe('hist_tool_fail1');
+      expect(failed.toolName).toBe('failingTool');
       expect(succeeded.error).toBeUndefined();
       expect(succeeded.result).toEqual({ found: true });
+      expect(succeeded.toolName).toBe('okTool');
     });
 
-    it('AC2.7 — an error envelope whose original result was undefined decodes to {} and still carries the failure marker', () => {
-      const block = singleToolResponse(
-        ContentConverters.toIContent(
-          {
-            role: 'user',
-            parts: [
-              {
-                functionResponse: {
-                  name: 'failingTool',
-                  id: 'hist_tool_fail2',
-                  response: {
-                    status: 'error',
-                    error: 'no result at all',
-                  },
-                },
-              },
-            ],
-          },
-          undefined,
-          undefined,
-          'turn-1',
-        ),
-      );
+    it('AC2.7 — a failed block with result undefined round-trips: result coerces to {} and the marker survives', () => {
+      // Full round trip through the encoder then decoder (not a hand-crafted
+      // inbound shape) so the `result: undefined` -> key-omission branch is
+      // actually driven: undefined is omitted outbound, then decoded to {}.
+      const contents: IContent[] = [
+        toolResponseContent({
+          type: 'tool_response',
+          callId: 'hist_tool_fail2',
+          toolName: 'failingTool',
+          result: undefined,
+          error: 'no result at all',
+        }),
+      ];
+      const converted = ContentConverters.toGeminiContents(contents);
+      const back = ContentConverters.toIContents(converted);
+      const block = singleToolResponse(back[0]);
       expect(block.error).toBe('no result at all');
       expect(block.result).toEqual({});
+      expect(block.callId).toBe('hist_tool_fail2');
+    });
+
+    it('AC2.8 — a failed block with result null round-trips: null is preserved verbatim and the marker survives', () => {
+      // historyToolPairing/historyToolNormalization produce result:null on a
+      // failed block. The encoder writes null through and the decoder returns
+      // it verbatim (NOT coerced to {}).
+      const contents: IContent[] = [
+        toolResponseContent({
+          type: 'tool_response',
+          callId: 'hist_tool_fail3',
+          toolName: 'failingTool',
+          result: null,
+          error: 'boom',
+        }),
+      ];
+      const converted = ContentConverters.toGeminiContents(contents);
+      const back = ContentConverters.toIContents(converted);
+      const block = singleToolResponse(back[0]);
+      expect(block.error).toBe('boom');
+      expect(block.result).toBeNull();
+      expect(block.callId).toBe('hist_tool_fail3');
+    });
+
+    it('AC2.9 — a SUCCESSFUL tool whose result is shaped like a failure envelope round-trips intact (F2 regression guard)', () => {
+      // Without the part-level llxprtToolFailure discriminant this would be
+      // misdecoded into a spurious failure with its payload destroyed, because
+      // the inbound decoder used to fire on any { status:'error', error } shape.
+      const original = {
+        status: 'error',
+        error: 'fake failure',
+        payload: 'preserved data',
+      };
+      const contents: IContent[] = [
+        toolResponseContent({
+          type: 'tool_response',
+          callId: 'hist_tool_ok3',
+          toolName: 'okTool',
+          result: original,
+        }),
+      ];
+      const converted = ContentConverters.toGeminiContents(contents);
+      const back = ContentConverters.toIContents(converted);
+      const block = singleToolResponse(back[0]);
+      expect(block.error).toBeUndefined();
+      expect(block.result).toEqual(original);
+    });
+
+    it('AC2.10 — a failed block with a non-object result round-trips the result verbatim', () => {
+      const results: unknown[] = ['hello', [1, 2, 3]];
+      for (const result of results) {
+        const contents: IContent[] = [
+          toolResponseContent({
+            type: 'tool_response',
+            callId: 'hist_tool_fail4',
+            toolName: 'failingTool',
+            result,
+            error: 'boom',
+          }),
+        ];
+        const converted = ContentConverters.toGeminiContents(contents);
+        const back = ContentConverters.toIContents(converted);
+        const block = singleToolResponse(back[0]);
+        expect(block.error).toBe('boom');
+        expect(block.result).toEqual(result);
+      }
+    });
+
+    it('AC2.11 — one IContent with multiple tool_response blocks round-trips each marker independently', () => {
+      const contents: IContent[] = [
+        {
+          speaker: 'tool',
+          blocks: [
+            {
+              type: 'tool_response',
+              callId: 'hist_tool_fail5',
+              toolName: 'failingTool',
+              result: { output: 'partial data' },
+              error: 'boom',
+            },
+            {
+              type: 'tool_response',
+              callId: 'hist_tool_ok4',
+              toolName: 'okTool',
+              result: { found: true },
+            },
+          ],
+        },
+      ];
+      const converted = ContentConverters.toGeminiContents(contents);
+      const back = ContentConverters.toIContents(converted);
+      const blocks = back.flatMap((c) => c.blocks) as ToolResponseBlock[];
+
+      const failed = blocks.find((b) => b.callId === 'hist_tool_fail5');
+      const succeeded = blocks.find((b) => b.callId === 'hist_tool_ok4');
+      if (!failed || !succeeded) {
+        throw new Error('expected both a failed and a succeeded block');
+      }
+      expect(failed.error).toBe('boom');
+      expect(failed.result).toEqual({ output: 'partial data' });
+      expect(succeeded.error).toBeUndefined();
+      expect(succeeded.result).toEqual({ found: true });
     });
   });
 });

--- a/packages/core/src/services/history/ContentConverters.toolFailure.test.ts
+++ b/packages/core/src/services/history/ContentConverters.toolFailure.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Issue #3076 — a failed tool call must survive the Gemini-shaped
+ * ContentConverters round trip. These behavioural proofs drive the real
+ * converter static methods with plain data fixtures and assert only on
+ * observable output, never on implementation internals.
+ *
+ * Note: identifiers deliberately avoid any provider-prefixed naming so this
+ * file stays inside the repository's provider-neutral naming boundary.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ContentConverters } from './ContentConverters.js';
+import type { IContent, ToolResponseBlock } from './IContent.js';
+
+type ConvertedContent = ReturnType<typeof ContentConverters.toGeminiContent>;
+
+function toolResponseContent(block: ToolResponseBlock): IContent {
+  return { speaker: 'tool', blocks: [block] };
+}
+
+/** Read the single functionResponse part from a converted content object. */
+function functionResponseOf(content: ConvertedContent): {
+  name?: string;
+  id?: string;
+  response?: Record<string, unknown>;
+} {
+  const fr = content.parts?.[0]?.functionResponse;
+  if (!fr) {
+    throw new Error('expected a functionResponse part');
+  }
+  return fr;
+}
+
+/** Narrow a converted IContent to its single tool_response block. */
+function singleToolResponse(content: IContent): ToolResponseBlock {
+  const block = content.blocks[0];
+  if (block.type !== 'tool_response') {
+    throw new Error('expected a tool_response block');
+  }
+  return block;
+}
+
+describe('ContentConverters tool-failure round trip (issue #3076)', () => {
+  describe('toGeminiContent — outbound', () => {
+    it('AC2.1 — a failed tool_response produces a functionResponse with status:error and the error string', () => {
+      const converted = ContentConverters.toGeminiContent(
+        toolResponseContent({
+          type: 'tool_response',
+          callId: 'hist_tool_fail1',
+          toolName: 'failingTool',
+          result: { output: 'partial data' },
+          error: 'boom',
+        }),
+      );
+      const fr = functionResponseOf(converted);
+      expect(fr.response?.status).toBe('error');
+      expect(fr.response?.error).toBe('boom');
+    });
+
+    it('AC2.2 — the failure envelope carries the original result verbatim under result', () => {
+      const converted = ContentConverters.toGeminiContent(
+        toolResponseContent({
+          type: 'tool_response',
+          callId: 'hist_tool_fail1',
+          toolName: 'failingTool',
+          result: { output: 'partial data', extra: 7 },
+          error: 'boom',
+        }),
+      );
+      const fr = functionResponseOf(converted);
+      expect(fr.response?.result).toEqual({ output: 'partial data', extra: 7 });
+    });
+
+    it('AC2.3 — a successful tool_response is unchanged (raw result, no status, no error)', () => {
+      const converted = ContentConverters.toGeminiContent(
+        toolResponseContent({
+          type: 'tool_response',
+          callId: 'hist_tool_ok1',
+          toolName: 'okTool',
+          result: { found: true },
+        }),
+      );
+      const fr = functionResponseOf(converted);
+      expect(fr.response).toEqual({ found: true });
+      expect(fr.response).not.toHaveProperty('status');
+      expect(fr.response).not.toHaveProperty('error');
+    });
+  });
+
+  describe('toIContent — inbound', () => {
+    it('AC2.4 — an error envelope reconstructs a block with error set and the original result', () => {
+      const block = singleToolResponse(
+        ContentConverters.toIContent(
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  name: 'failingTool',
+                  id: 'hist_tool_fail1',
+                  response: {
+                    status: 'error',
+                    error: 'boom',
+                    result: { output: 'partial data' },
+                  },
+                },
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          'turn-1',
+        ),
+      );
+      expect(block.error).toBe('boom');
+      expect(block.result).toEqual({ output: 'partial data' });
+    });
+
+    it('AC2.5 — an ordinary functionResponse is unchanged (existing string/JSON coercion still applies)', () => {
+      const objectBlock = singleToolResponse(
+        ContentConverters.toIContent(
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  name: 'okTool',
+                  id: 'hist_tool_ok1',
+                  response: { output: 'all good' },
+                },
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          'turn-1',
+        ),
+      );
+      expect(objectBlock.error).toBeUndefined();
+      expect(objectBlock.result).toEqual({ output: 'all good' });
+
+      // A JSON-string response is still coerced via the existing path.
+      const stringBlock = singleToolResponse(
+        ContentConverters.toIContent(
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  name: 'okTool',
+                  id: 'hist_tool_ok2',
+                  response: '{"output":"parsed"}',
+                },
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          'turn-1',
+        ),
+      );
+      expect(stringBlock.error).toBeUndefined();
+      expect(stringBlock.result).toEqual({ output: 'parsed' });
+    });
+  });
+
+  describe('full round trip toGeminiContents -> toIContents', () => {
+    it('AC2.6 — preserves failure marker, result, toolName and callId for a failure; preserves the absence of a marker for a success', () => {
+      // hist_tool_ prefixed ids are canonical and therefore idempotent through
+      // canonicalizeToolResponseId, so callId survives the round trip verbatim.
+      const contents: IContent[] = [
+        toolResponseContent({
+          type: 'tool_response',
+          callId: 'hist_tool_fail1',
+          toolName: 'failingTool',
+          result: { output: 'partial data' },
+          error: 'boom',
+        }),
+        toolResponseContent({
+          type: 'tool_response',
+          callId: 'hist_tool_ok1',
+          toolName: 'okTool',
+          result: { found: true },
+        }),
+      ];
+
+      const converted = ContentConverters.toGeminiContents(contents);
+      const back = ContentConverters.toIContents(converted);
+      const blocks = back.flatMap((c) => c.blocks) as ToolResponseBlock[];
+
+      const failed = blocks.find((b) => b.toolName === 'failingTool');
+      const succeeded = blocks.find((b) => b.toolName === 'okTool');
+      if (!failed || !succeeded) {
+        throw new Error('expected both a failed and a succeeded block');
+      }
+
+      expect(failed.error).toBe('boom');
+      expect(failed.result).toEqual({ output: 'partial data' });
+      expect(failed.callId).toBe('hist_tool_fail1');
+      expect(succeeded.error).toBeUndefined();
+      expect(succeeded.result).toEqual({ found: true });
+    });
+
+    it('AC2.7 — an error envelope whose original result was undefined decodes to {} and still carries the failure marker', () => {
+      const block = singleToolResponse(
+        ContentConverters.toIContent(
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  name: 'failingTool',
+                  id: 'hist_tool_fail2',
+                  response: {
+                    status: 'error',
+                    error: 'no result at all',
+                  },
+                },
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          'turn-1',
+        ),
+      );
+      expect(block.error).toBe('no result at all');
+      expect(block.result).toEqual({});
+    });
+  });
+});

--- a/packages/core/src/services/history/ContentConverters.ts
+++ b/packages/core/src/services/history/ContentConverters.ts
@@ -116,14 +116,17 @@ export class ContentConverters {
   /**
    * Canonical Gemini-shaped encoding of a failed tool response (issue #3076).
    *
-   * Why: the failure marker on a tool_response block would otherwise be lost on
-   * the Gemini wire path (it is read by contentGeneratorAdapters and the
-   * streamRequestHelpers round trip). Encoding it inside `functionResponse`
-   * mirrors the precedent already set by GeminiMessageConverter and lets the
-   * inbound decoder reconstruct the failure. It deliberately preserves only
-   * `callId`, `toolName`, `result` and the `error` marker — `isComplete` and
-   * `providerMetadata` are local bookkeeping with no Gemini representation and
-   * are intentionally dropped, never encoded.
+   * The only live consumer of this outbound encoding is the Google code-assist
+   * request path (contentGeneratorAdapters). The matching inbound decoder
+   * exists so the Gemini-shaped representation stays symmetric and lossless as
+   * #3076 requires; it has no other live consumer today. The part carries the
+   * `llxprtToolFailure` flag so a successful tool whose result merely happens
+   * to be shaped like `{ status: 'error', ... }` is never misdecoded.
+   *
+   * The legacy representation carries `callId`, `toolName`, `result` and the
+   * `error` marker and nothing else: `isComplete` and `providerMetadata` are
+   * local bookkeeping with no Gemini representation, so they are deliberately
+   * dropped rather than encoded into a payload the model would then see.
    */
   private static buildFailureFunctionResponse(
     toolResponse: Extract<ContentBlock, { type: 'tool_response' }>,
@@ -138,9 +141,10 @@ export class ContentConverters {
     return {
       functionResponse: {
         name: toolResponse.toolName,
-        id: toolResponse.callId,
         response,
+        id: toolResponse.callId,
       },
+      llxprtToolFailure: true,
     };
   }
 
@@ -452,22 +456,27 @@ export class ContentConverters {
         callId,
         resolvedToolName,
         part.functionResponse!.response,
+        part.llxprtToolFailure === true,
       ),
     ];
     return { blocks, responseIndex: responseIndex + 1 };
   }
 
   /**
-   * Build a tool_response block from a functionResponse payload, restoring a
-   * failure marker verbatim when the payload carries the issue #3076 envelope,
-   * otherwise falling back to the existing string/JSON coercion.
+   * Build a tool_response block from a functionResponse payload. The issue
+   * #3076 failure envelope is decoded verbatim ONLY when `isToolFailure` is
+   * true (the part carried the `llxprtToolFailure` flag); any other response
+   * shape keeps the existing string/JSON coercion unchanged.
    */
   private static buildToolResponseBlock(
     callId: string,
     toolName: string,
     response: unknown,
-  ): ContentBlock {
-    const failure = ContentConverters.decodeFailureEnvelope(response);
+    isToolFailure: boolean,
+  ): Extract<ContentBlock, { type: 'tool_response' }> {
+    const failure = isToolFailure
+      ? ContentConverters.decodeFailureEnvelope(response)
+      : null;
     if (failure) {
       return {
         type: 'tool_response',

--- a/packages/core/src/services/history/ContentConverters.ts
+++ b/packages/core/src/services/history/ContentConverters.ts
@@ -288,7 +288,10 @@ export class ContentConverters {
    * Returns null for any non-envelope response so the caller keeps the
    * existing string/JSON coercion path untouched. The envelope's `result`
    * is restored verbatim — it must NOT go through parseFunctionResponseResult,
-   * the whole point being fidelity to the original block.
+   * the whole point being fidelity to the original block. The one normalization
+   * is the omitted-key case: an original `result` of `undefined` is not encoded
+   * at all and comes back as `{}`, matching the pre-existing empty-response
+   * convention.
    */
   private static decodeFailureEnvelope(
     response: unknown,

--- a/packages/core/src/services/history/ContentConverters.ts
+++ b/packages/core/src/services/history/ContentConverters.ts
@@ -101,11 +101,45 @@ export class ContentConverters {
       hasResult: ContentConverters.hasLegacyTruthyValue(toolResponse.result),
       hasError: ContentConverters.hasLegacyTruthyValue(toolResponse.error),
     });
+    if (ContentConverters.hasLegacyTruthyValue(toolResponse.error)) {
+      return ContentConverters.buildFailureFunctionResponse(toolResponse);
+    }
     return {
       functionResponse: {
         name: toolResponse.toolName,
         response: toolResponse.result as Record<string, unknown>,
         id: toolResponse.callId,
+      },
+    };
+  }
+
+  /**
+   * Canonical Gemini-shaped encoding of a failed tool response (issue #3076).
+   *
+   * Why: the failure marker on a tool_response block would otherwise be lost on
+   * the Gemini wire path (it is read by contentGeneratorAdapters and the
+   * streamRequestHelpers round trip). Encoding it inside `functionResponse`
+   * mirrors the precedent already set by GeminiMessageConverter and lets the
+   * inbound decoder reconstruct the failure. It deliberately preserves only
+   * `callId`, `toolName`, `result` and the `error` marker — `isComplete` and
+   * `providerMetadata` are local bookkeeping with no Gemini representation and
+   * are intentionally dropped, never encoded.
+   */
+  private static buildFailureFunctionResponse(
+    toolResponse: Extract<ContentBlock, { type: 'tool_response' }>,
+  ): GeminiContentPart {
+    const response: Record<string, unknown> = {
+      status: 'error',
+      error: toolResponse.error,
+    };
+    if (toolResponse.result !== undefined) {
+      response.result = toolResponse.result;
+    }
+    return {
+      functionResponse: {
+        name: toolResponse.toolName,
+        id: toolResponse.callId,
+        response,
       },
     };
   }
@@ -242,6 +276,27 @@ export class ContentConverters {
       return {};
     }
     return ContentConverters.parseResponseValue(response, callId);
+  }
+
+  /**
+   * Detect the canonical failure envelope produced by
+   * `buildFailureFunctionResponse` (issue #3076) and decode it verbatim.
+   * Returns null for any non-envelope response so the caller keeps the
+   * existing string/JSON coercion path untouched. The envelope's `result`
+   * is restored verbatim — it must NOT go through parseFunctionResponseResult,
+   * the whole point being fidelity to the original block.
+   */
+  private static decodeFailureEnvelope(
+    response: unknown,
+  ): { error: string; result: unknown } | null {
+    if (!ContentConverters.isPlainObject(response)) {
+      return null;
+    }
+    if (response.status !== 'error' || typeof response.error !== 'string') {
+      return null;
+    }
+    const result = 'result' in response ? response.result : {};
+    return { error: response.error, result };
   }
 
   /** Parse a non-null/non-undefined response value into a Record. */
@@ -388,23 +443,46 @@ export class ContentConverters {
       toolName: part.functionResponse!.name,
       matchedByPosition: !!matched,
     });
-    const result = ContentConverters.parseFunctionResponseResult(
-      part.functionResponse!.response,
-      callId,
+    const resolvedToolName = ContentConverters.firstNonEmpty(
+      matched?.toolName,
+      part.functionResponse!.name,
     );
-
     const blocks: ContentBlock[] = [
-      {
-        type: 'tool_response',
+      ContentConverters.buildToolResponseBlock(
         callId,
-        toolName: ContentConverters.firstNonEmpty(
-          matched?.toolName,
-          part.functionResponse!.name,
-        ),
-        result,
-      },
+        resolvedToolName,
+        part.functionResponse!.response,
+      ),
     ];
     return { blocks, responseIndex: responseIndex + 1 };
+  }
+
+  /**
+   * Build a tool_response block from a functionResponse payload, restoring a
+   * failure marker verbatim when the payload carries the issue #3076 envelope,
+   * otherwise falling back to the existing string/JSON coercion.
+   */
+  private static buildToolResponseBlock(
+    callId: string,
+    toolName: string,
+    response: unknown,
+  ): ContentBlock {
+    const failure = ContentConverters.decodeFailureEnvelope(response);
+    if (failure) {
+      return {
+        type: 'tool_response',
+        callId,
+        toolName,
+        result: failure.result,
+        error: failure.error,
+      };
+    }
+    return {
+      type: 'tool_response',
+      callId,
+      toolName,
+      result: ContentConverters.parseFunctionResponseResult(response, callId),
+    };
   }
 
   /** Convert a text-or-thought Part into a ContentBlock. */

--- a/packages/providers/src/openai-vercel/messageConversion.toolFailure.test.ts
+++ b/packages/providers/src/openai-vercel/messageConversion.toolFailure.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Issue #3076 — a failed tool call must stay failed through the OpenAI-Vercel
+ * conversion. These behavioural proofs drive the real exported converters with
+ * plain IContent fixtures and assert only on observable output, never on
+ * implementation internals.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type { ToolResultPart } from 'ai';
+import type {
+  IContent,
+  ToolResponseBlock,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  convertToVercelMessages,
+  convertFromVercelMessages,
+} from './messageConversion.js';
+
+function toolContent(...blocks: ToolResponseBlock[]): IContent {
+  return { speaker: 'tool', blocks };
+}
+
+/** Drive convertToVercelMessages and return the first tool-result part's output. */
+function firstToolResultOutput(contents: IContent[]): ToolResultPart['output'] {
+  const messages = convertToVercelMessages(contents);
+  const toolMessage = messages.find((m) => m.role === 'tool');
+  if (!toolMessage) {
+    throw new Error('expected a tool message');
+  }
+  const parts = toolMessage.content as unknown as ToolResultPart[];
+  if (!Array.isArray(parts) || parts.length === 0) {
+    throw new Error('expected at least one tool-result part');
+  }
+  return parts[0].output;
+}
+
+describe('messageConversion tool-failure round trip (issue #3076)', () => {
+  it('AC1.1 — a tool_response with error set converts to an error-text output', () => {
+    const output = firstToolResultOutput([
+      toolContent({
+        type: 'tool_response',
+        callId: 'hist_tool_1',
+        toolName: 'failingTool',
+        result: { output: 'partial data' },
+        error: 'boom',
+      }),
+    ]);
+    expect(output.type).toBe('error-text');
+  });
+
+  it('AC1.2 — the error-text value is the model-facing result text', () => {
+    const output = firstToolResultOutput([
+      toolContent({
+        type: 'tool_response',
+        callId: 'hist_tool_1',
+        toolName: 'failingTool',
+        result: { output: 'partial data' },
+        error: 'boom',
+      }),
+    ]);
+    if (output.type !== 'error-text') {
+      throw new Error(`expected error-text output, got ${output.type}`);
+    }
+    expect(output.value).toBe('partial data');
+  });
+
+  it('AC1.3 — a failed block with no result yields the error text, not [no tool result]', () => {
+    const output = firstToolResultOutput([
+      toolContent({
+        type: 'tool_response',
+        callId: 'hist_tool_1',
+        toolName: 'failingTool',
+        result: undefined,
+        error: 'the tool exploded',
+      }),
+    ]);
+    if (output.type !== 'error-text') {
+      throw new Error(`expected error-text output, got ${output.type}`);
+    }
+    expect(output.value).toBe('the tool exploded');
+  });
+
+  it('AC1.4 — a tool_response without error still yields a text output (regression guard, incl. empty placeholder)', () => {
+    const successOutput = firstToolResultOutput([
+      toolContent({
+        type: 'tool_response',
+        callId: 'hist_tool_1',
+        toolName: 'okTool',
+        result: { output: 'all good' },
+      }),
+    ]);
+    expect(successOutput.type).toBe('text');
+    if (successOutput.type !== 'text') {
+      throw new Error(`expected text output, got ${successOutput.type}`);
+    }
+    expect(successOutput.value).toBe('all good');
+
+    const emptyOutput = firstToolResultOutput([
+      toolContent({
+        type: 'tool_response',
+        callId: 'hist_tool_1',
+        toolName: 'voidTool',
+        result: undefined,
+      }),
+    ]);
+    expect(emptyOutput.type).toBe('text');
+    if (emptyOutput.type !== 'text') {
+      throw new Error(`expected text output, got ${emptyOutput.type}`);
+    }
+    expect(emptyOutput.value).toBe('[no tool result]');
+  });
+
+  it('AC1.5 — round trip convertTo -> convertFrom keeps failures failed and successes clean', () => {
+    const contents: IContent[] = [
+      toolContent({
+        type: 'tool_response',
+        callId: 'hist_tool_1',
+        toolName: 'failingTool',
+        result: { output: 'partial data' },
+        error: 'boom',
+      }),
+      toolContent({
+        type: 'tool_response',
+        callId: 'hist_tool_2',
+        toolName: 'okTool',
+        result: { output: 'all good' },
+      }),
+    ];
+
+    const vercel = convertToVercelMessages(contents);
+    const roundTripped = convertFromVercelMessages(vercel);
+    const blocks = roundTripped.flatMap((c) => c.blocks) as ToolResponseBlock[];
+
+    const failed = blocks.find((b) => b.toolName === 'failingTool');
+    const succeeded = blocks.find((b) => b.toolName === 'okTool');
+    if (!failed || !succeeded) {
+      throw new Error('expected both a failed and a succeeded block');
+    }
+
+    expect((failed as { isError?: boolean }).isError).toBe(true);
+    expect(typeof failed.error).toBe('string');
+    expect(failed.error?.length ?? 0).toBeGreaterThan(0);
+
+    expect((succeeded as { isError?: boolean }).isError).toBeUndefined();
+    expect(succeeded.error).toBeUndefined();
+  });
+});

--- a/packages/providers/src/openai-vercel/messageConversion.toolFailure.test.ts
+++ b/packages/providers/src/openai-vercel/messageConversion.toolFailure.test.ts
@@ -36,15 +36,22 @@ function toolContent(...blocks: ToolResponseBlock[]): IContent {
   return { speaker: 'tool', blocks };
 }
 
-/** Drive convertToVercelMessages and return the first tool-result part's output. */
-function firstToolResultOutput(contents: IContent[]): ToolResultPart['output'] {
+/** Run convertToVercelMessages and return the parts of the (single) tool message. */
+function toolResultParts(contents: IContent[]): ToolResultPart[] {
   const messages = convertToVercelMessages(contents);
+  // The find predicate narrows the message to CoreToolMessage (TS find
+  // inference), so toolMessage.content is already ToolResultPart[].
   const toolMessage = messages.find((m) => m.role === 'tool');
   if (!toolMessage) {
     throw new Error('expected a tool message');
   }
-  const parts = toolMessage.content as unknown as ToolResultPart[];
-  if (!Array.isArray(parts) || parts.length === 0) {
+  return toolMessage.content;
+}
+
+/** Drive convertToVercelMessages and return the first tool-result part's output. */
+function firstToolResultOutput(contents: IContent[]): ToolResultPart['output'] {
+  const parts = toolResultParts(contents);
+  if (parts.length === 0) {
     throw new Error('expected at least one tool-result part');
   }
   return parts[0].output;
@@ -105,7 +112,6 @@ describe('messageConversion tool-failure round trip (issue #3076)', () => {
         result: { output: 'all good' },
       }),
     ]);
-    expect(successOutput.type).toBe('text');
     if (successOutput.type !== 'text') {
       throw new Error(`expected text output, got ${successOutput.type}`);
     }
@@ -119,14 +125,13 @@ describe('messageConversion tool-failure round trip (issue #3076)', () => {
         result: undefined,
       }),
     ]);
-    expect(emptyOutput.type).toBe('text');
     if (emptyOutput.type !== 'text') {
       throw new Error(`expected text output, got ${emptyOutput.type}`);
     }
     expect(emptyOutput.value).toBe('[no tool result]');
   });
 
-  it('AC1.5 — round trip convertTo -> convertFrom keeps failures failed and successes clean', () => {
+  it('AC1.5 — round trip convertTo -> convertFrom keeps failures marked failed and successes clean', () => {
     const contents: IContent[] = [
       toolContent({
         type: 'tool_response',
@@ -153,11 +158,56 @@ describe('messageConversion tool-failure round trip (issue #3076)', () => {
       throw new Error('expected both a failed and a succeeded block');
     }
 
+    // The failure MARKER survives the round trip (isError stays true). The
+    // pre-existing inbound decoder (parseToolResultPart) sets the reconstructed
+    // `error` to the OUTPUT TEXT rather than the original error string, so the
+    // exact error text is NOT preserved here — but the marker is what #3076 is
+    // about, and that is preserved. Assert the exact observed values.
     expect((failed as { isError?: boolean }).isError).toBe(true);
-    expect(typeof failed.error).toBe('string');
-    expect(failed.error?.length ?? 0).toBeGreaterThan(0);
+    expect(failed.error).toBe('partial data');
+    expect(failed.result).toBe('partial data');
 
     expect((succeeded as { isError?: boolean }).isError).toBeUndefined();
     expect(succeeded.error).toBeUndefined();
+    expect(succeeded.result).toBe('all good');
+  });
+
+  it('AC1.6 — one tool message with multiple tool_response blocks keeps error-text/text parts in order', () => {
+    const outputs = toolResultParts([
+      toolContent(
+        {
+          type: 'tool_response',
+          callId: 'hist_tool_1',
+          toolName: 'failingTool',
+          result: { output: 'partial data' },
+          error: 'boom',
+        },
+        {
+          type: 'tool_response',
+          callId: 'hist_tool_2',
+          toolName: 'okTool',
+          result: { output: 'all good' },
+        },
+      ),
+    ]).map((part) => part.output);
+
+    expect(outputs[0]?.type).toBe('error-text');
+    expect(outputs[1]?.type).toBe('text');
+  });
+
+  it('AC1.7 — a failed block with result null yields the error text as the value', () => {
+    const output = firstToolResultOutput([
+      toolContent({
+        type: 'tool_response',
+        callId: 'hist_tool_1',
+        toolName: 'failingTool',
+        result: null,
+        error: 'the tool exploded',
+      }),
+    ]);
+    if (output.type !== 'error-text') {
+      throw new Error(`expected error-text output, got ${output.type}`);
+    }
+    expect(output.value).toBe('the tool exploded');
   });
 });

--- a/packages/providers/src/openai-vercel/messageConversion.toolFailure.test.ts
+++ b/packages/providers/src/openai-vercel/messageConversion.toolFailure.test.ts
@@ -57,6 +57,18 @@ function firstToolResultOutput(contents: IContent[]): ToolResultPart['output'] {
   return parts[0].output;
 }
 
+function roundTripToolResponses(
+  ...blocks: ToolResponseBlock[]
+): ToolResponseBlock[] {
+  return convertFromVercelMessages(
+    convertToVercelMessages([toolContent(...blocks)]),
+  ).flatMap((content) =>
+    content.blocks.flatMap((block) =>
+      block.type === 'tool_response' ? [block] : [],
+    ),
+  );
+}
+
 describe('messageConversion tool-failure round trip (issue #3076)', () => {
   it('AC1.1 — a tool_response with error set converts to an error-text output', () => {
     const output = firstToolResultOutput([
@@ -148,9 +160,13 @@ describe('messageConversion tool-failure round trip (issue #3076)', () => {
       }),
     ];
 
-    const vercel = convertToVercelMessages(contents);
-    const roundTripped = convertFromVercelMessages(vercel);
-    const blocks = roundTripped.flatMap((c) => c.blocks) as ToolResponseBlock[];
+    const blocks = roundTripToolResponses(
+      ...contents.flatMap((content) =>
+        content.blocks.flatMap((block) =>
+          block.type === 'tool_response' ? [block] : [],
+        ),
+      ),
+    );
 
     const failed = blocks.find((b) => b.toolName === 'failingTool');
     const succeeded = blocks.find((b) => b.toolName === 'okTool');
@@ -158,18 +174,43 @@ describe('messageConversion tool-failure round trip (issue #3076)', () => {
       throw new Error('expected both a failed and a succeeded block');
     }
 
-    // The failure MARKER survives the round trip (isError stays true). The
-    // pre-existing inbound decoder (parseToolResultPart) sets the reconstructed
+    // The pre-existing inbound decoder (parseToolResultPart) sets the reconstructed
     // `error` to the OUTPUT TEXT rather than the original error string, so the
-    // exact error text is NOT preserved here — but the marker is what #3076 is
-    // about, and that is preserved. Assert the exact observed values.
-    expect((failed as { isError?: boolean }).isError).toBe(true);
+    // exact error text is NOT preserved here. The canonical `error` property is
+    // the observable failure marker that #3076 requires the round trip to keep.
     expect(failed.error).toBe('partial data');
     expect(failed.result).toBe('partial data');
 
-    expect((succeeded as { isError?: boolean }).isError).toBeUndefined();
     expect(succeeded.error).toBeUndefined();
     expect(succeeded.result).toBe('all good');
+  });
+
+  it('AC1.8 — failed empty-result variants remain failures after a round trip', () => {
+    const blocks = roundTripToolResponses(
+      {
+        type: 'tool_response',
+        callId: 'hist_tool_undefined',
+        toolName: 'undefinedResultTool',
+        result: undefined,
+        error: 'undefined result failed',
+      },
+      {
+        type: 'tool_response',
+        callId: 'hist_tool_null',
+        toolName: 'nullResultTool',
+        result: null,
+        error: 'null result failed',
+      },
+    );
+
+    expect(blocks.map((block) => block.error)).toEqual([
+      'undefined result failed',
+      'null result failed',
+    ]);
+    expect(blocks.map((block) => block.result)).toEqual([
+      'undefined result failed',
+      'null result failed',
+    ]);
   });
 
   it('AC1.6 — one tool message with multiple tool_response blocks keeps error-text/text parts in order', () => {

--- a/packages/providers/src/openai-vercel/messageConversion.ts
+++ b/packages/providers/src/openai-vercel/messageConversion.ts
@@ -45,6 +45,7 @@ import {
 import {
   buildToolResponsePayload,
   EMPTY_TOOL_RESULT_PLACEHOLDER,
+  type ToolResponsePayload,
 } from '../utils/toolResponsePayload.js';
 import type { ToolIdMapper } from '@vybestack/llxprt-code-tools/ToolIdStrategy.js';
 import {
@@ -231,6 +232,23 @@ function convertAiContent(
   }
 }
 
+function buildToolResultOutput(
+  payload: ToolResponsePayload,
+): { type: 'text'; value: string } | { type: 'error-text'; value: string } {
+  if (payload.status === 'error') {
+    // A failure must never reach the model as the bare empty-result placeholder
+    // with no explanation: fall back to the error text in that case (issue #3076).
+    const value =
+      payload.result === EMPTY_TOOL_RESULT_PLACEHOLDER &&
+      typeof payload.error === 'string' &&
+      payload.error.length > 0
+        ? payload.error
+        : payload.result;
+    return { type: 'error-text', value };
+  }
+  return { type: 'text', value: payload.result };
+}
+
 function convertToolContent(
   messages: CoreMessage[],
   content: IContent,
@@ -254,10 +272,7 @@ function convertToolContent(
       type: 'tool-result' as const,
       toolCallId: resolveToolResponseId(block),
       toolName: firstTruthyString(extBlock.name, extBlock.toolName),
-      output: {
-        type: 'text',
-        value: payload.result,
-      },
+      output: buildToolResultOutput(payload),
     };
   });
 

--- a/packages/providers/src/openai-vercel/messageConversion.ts
+++ b/packages/providers/src/openai-vercel/messageConversion.ts
@@ -234,17 +234,17 @@ function convertAiContent(
 
 function buildToolResultOutput(
   payload: ToolResponsePayload,
-): { type: 'text'; value: string } | { type: 'error-text'; value: string } {
+): Extract<ToolResultPart['output'], { type: 'text' | 'error-text' }> {
   if (payload.status === 'error') {
     // A failure must never reach the model as the bare empty-result placeholder
     // with no explanation: fall back to the error text in that case (issue #3076).
-    const value =
-      payload.result === EMPTY_TOOL_RESULT_PLACEHOLDER &&
-      typeof payload.error === 'string' &&
-      payload.error.length > 0
-        ? payload.error
-        : payload.result;
-    return { type: 'error-text', value };
+    return {
+      type: 'error-text',
+      value:
+        payload.result === EMPTY_TOOL_RESULT_PLACEHOLDER
+          ? (payload.error ?? payload.result)
+          : payload.result,
+    };
   }
   return { type: 'text', value: payload.result };
 }

--- a/project-plans/issue3076-tool-failure-roundtrip/plan.md
+++ b/project-plans/issue3076-tool-failure-roundtrip/plan.md
@@ -16,7 +16,8 @@ Chat/Responses builders all read that status. Two paths still discard it:
    inbound without `error`. Consumers: `contentGeneratorAdapters.ts` (Google code-assist
    request path — currently emits no failure signal at all) and
    `streamRequestHelpers.ts` (a `BeforeModel` hook that supplies `llm_request.messages`
-   round-trips history `toGeminiContents` -> `toIContents`, which strips the marker).
+   round-trips history `toGeminiContents` -> `toIContents`, which strips the marker). The
+   second of those two consumer claims does not hold — see "Verified facts" below.
 
 ## Verified facts
 
@@ -33,8 +34,17 @@ Chat/Responses builders all read that status. Two paths still discard it:
 - `GeminiMessageConverter.convertToolContentToGeminiContents` already establishes the
   project's canonical Gemini-shaped failure encoding: `functionResponse.response` is an
   envelope carrying `status`, `result` and `error`. Part 2 follows that precedent.
-- `#3063` (PR #3077) is not merged; this work does not depend on it. Both changes key off the
-  already-declared `ToolResponseBlock.error` field, and they touch disjoint files.
+- `#3063` (PR #3077) is now merged into `main`. `createErrorResponse` sets the top-level
+  `ToolResponseBlock.error` via `toolFailureMarker(...)`, so `buildToolResponsePayload` now
+  derives `status: 'error'` for a genuine tool failure and the blast radius of this change is
+  real: every genuine tool failure takes the new code paths.
+- `streamRequestHelpers.ts` is NOT a live consumer of the outbound encoding, contrary to the
+  issue text. It only round-trips when `hookProvidedMessages()` is true, and in exactly that
+  case `HookTranslator.fromHookLLMRequest` rebuilds contents as text-only `parts: [{ text }]`,
+  discarding the converted contents — so a `functionResponse` part never reaches `toIContents`
+  there. The only live outbound consumer is `contentGeneratorAdapters.ts` (the Google
+  code-assist request path). The inbound decoder exists for symmetry/losslessness and has no
+  other live consumer today.
 
 ## Decisions
 
@@ -51,26 +61,43 @@ reaches the model as the bare placeholder with no explanation.
 ### D2 — Canonical legacy (Gemini-shaped) encoding of a failed tool response
 
 `ContentConverters.toolResponseBlockToPart` emits, **and only when the block carries a
-failure marker**:
+failure marker**, a part that carries BOTH the model-facing envelope inside `functionResponse`
+AND a part-level discriminant `llxprtToolFailure: true`:
 
 ```
-functionResponse: {
-  name, id,
-  response: {
-    status: 'error',
-    error: <error string>,
-    result: <original block.result>,   // key omitted when result is undefined
+{
+  functionResponse: {
+    name: <toolName>,
+    response: {
+      status: 'error',
+      error: <error string>,
+      result: <original block.result>,   // key omitted when result is undefined
+    },
+    id: <callId>,
   },
+  llxprtToolFailure: true,
 }
 ```
 
-A successful tool response is encoded exactly as today (`response` is the raw result), so no
-existing success payload — on the wire to Google or anywhere else — changes.
+A successful tool response is encoded exactly as today (`response` is the raw result, no flag),
+so no existing success payload — on the wire to Google or anywhere else — changes.
 
-`ContentConverters.processFunctionResponsePart` decodes that envelope: when
-`functionResponse.response` is a plain object with `status === 'error'` and a string `error`,
-the reconstructed block gets `error` set and `result` restored verbatim from the envelope
-(`{}` when the `result` key is absent, matching the existing empty-response behaviour).
+`ContentConverters.processFunctionResponsePart` decodes that envelope **only when the part
+carries `llxprtToolFailure === true`**; a part without the flag keeps today's behaviour
+exactly, whatever its `response` shape. This is required because a SUCCESSFUL tool whose
+result merely happens to be `{ status: 'error', error: '...', ...payload }` (third-party MCP
+servers do produce such shapes, and `convertToFunctionResponse` copies them verbatim) would
+otherwise be misdecoded into a spurious failure with its payload destroyed, and it would also
+misdecode the different envelope produced by `GeminiMessageConverter` (whose `result` is a
+serialized string). The flag follows the existing `llxprt*` part-extension convention
+(`llxprtSourceField`, `llxprtThoughtBlockId`, …).
+
+**`result` null/undefined semantics (verified by full round trip):** the `result` key is
+omitted outbound only when `result === undefined`, and the decoder then yields `{}`. A
+`result` of `null` — exactly what `historyToolPairing.ts` / `historyToolNormalization.ts`
+produce on a failed block — is written through and comes back as `null` verbatim (NOT coerced
+to `{}`). The decoder does NOT therefore always yield `{}`; it yields `{}` only for the
+omitted/undefined case and `null` for the explicit-`null` case.
 
 **What the legacy representation preserves:** `callId`, `toolName`, `result`, and the failure
 marker `error`. **What it deliberately does not preserve:** `isComplete` and
@@ -95,8 +122,14 @@ relied on by the success path and is not what this issue is about.
   the same value as before (regression guard, including the empty-result placeholder case).
 - AC1.5 Round trip: `convertToVercelMessages` -> `convertFromVercelMessages` on a failed
   tool response yields a `tool_response` block that is still marked as a failure
-  (`isError === true` and a non-empty `error`), and a successful one yields a block with no
-  failure marker.
+  (`isError === true`). Note the pre-existing inbound decoder (`parseToolResultPart`) sets the
+  reconstructed `error` to the OUTPUT TEXT rather than the original error string, so the exact
+  error text is NOT preserved by this path; only the failure MARKER is. The test asserts the
+  exact observed values (`error === result === <output text>`).
+- AC1.6 One tool `IContent` with multiple `tool_response` blocks (mixed success/failure)
+  produces one tool message whose parts carry `error-text` and `text` respectively, in order.
+- AC1.7 A failed block with `result: null` (falls through to the empty-result placeholder)
+  yields the error text as the `error-text` value.
 
 ### Part 2 — `packages/core/src/services/history/ContentConverters.ts`
 
@@ -112,22 +145,45 @@ relied on by the success path and is not what this issue is about.
 - AC2.6 Full round trip `toGeminiContents` -> `toIContents` preserves the failure marker,
   the result, the tool name and the call id for a failed tool response, and preserves the
   absence of a marker for a successful one.
-- AC2.7 Boundary: an error envelope whose original result was `undefined` decodes to `{}`
-  (the pre-existing empty-response convention) and still carries the failure marker.
+- AC2.7 Full round trip of a failed block with `result: undefined`: `undefined` is omitted
+  outbound and decodes to `{}` (the pre-existing empty-response convention) and still carries
+  the failure marker.
+- AC2.8 Full round trip of a failed block with `result: null`: `null` is written through and
+  comes back as `null` verbatim (NOT `{}`), and the marker survives.
+- AC2.9 A SUCCESSFUL tool whose `result` is shaped like a failure envelope
+  (`{ status:'error', error:'...', ...payload }`) round-trips completely intact: no failure
+  marker, payload preserved. This is the F2 discriminant regression guard.
+- AC2.10 A failed block with a non-object `result` (a string and an array) round-trips with
+  the result preserved verbatim.
+- AC2.11 One `IContent` containing multiple `tool_response` blocks (mixed success/failure)
+  round-trips with each block's marker/absence correct (the discriminant is per-part).
+
+### Part 3 — `packages/core/src/code_assist/contentGeneratorAdapters.ts` (the only live outbound consumer)
+
+- AC3.1 `toGenerateContentParameters` on a request whose contents contain a failed
+  `tool_response` emits a `functionResponse` whose `response` carries the explicit failure
+  signal (`status: 'error'` and the error text).
+- AC3.2 The same for a SUCCESSFUL `tool_response`: the emitted `functionResponse.response` is
+  byte-identical to the raw result (regression guard).
+- AC3.3 `toCountTokensParameters` counts the same failure-shaped response.
 
 ## Test plan (behavioural, written first, no mock theatre)
 
 New Bun (`bun:test`) files — no existing Vitest suite is modified:
 
 1. `packages/providers/src/openai-vercel/messageConversion.toolFailure.test.ts`
-   covers AC1.1 – AC1.5 by driving the real exported converters with real `IContent`
+   covers AC1.1 – AC1.7 by driving the real exported converters with real `IContent`
    fixtures and asserting on the produced `ToolResultPart` / reconstructed blocks.
    Must be registered in `scripts/bun-test-manifest-data-providers.ts` (curated file list).
 2. `packages/core/src/services/history/ContentConverters.toolFailure.test.ts`
-   covers AC2.1 – AC2.7 by driving `toGeminiContent(s)` / `toIContent(s)` directly.
+   covers AC2.1 – AC2.11 by driving `toGeminiContent(s)` / `toIContent(s)` directly.
    The core workspace runner auto-discovers `*.test.ts`, so no manifest edit is needed.
+3. `packages/core/src/code_assist/contentGeneratorAdapters.toolFailure.test.ts`
+   covers AC3.1 – AC3.3 by driving the real adapter with real `ModelGenerationRequest` /
+   `CountTokensRequest` fixtures (no mocks of ContentConverters). The core workspace runner
+   auto-discovers `*.test.ts`, so no manifest edit is needed.
 
-No mocks are required in either file: both units are pure functions over plain data.
+No mocks are required in any file: all three units are pure functions over plain data.
 
 ## Out of scope
 

--- a/project-plans/issue3076-tool-failure-roundtrip/plan.md
+++ b/project-plans/issue3076-tool-failure-roundtrip/plan.md
@@ -130,6 +130,8 @@ relied on by the success path and is not what this issue is about.
   produces one tool message whose parts carry `error-text` and `text` respectively, in order.
 - AC1.7 A failed block with `result: null` (falls through to the empty-result placeholder)
   yields the error text as the `error-text` value.
+- AC1.8 Failed blocks with `result: undefined` or `result: null` remain marked failed via
+  the canonical `error` property after a full Vercel round trip.
 
 ### Part 2 — `packages/core/src/services/history/ContentConverters.ts`
 
@@ -172,7 +174,7 @@ relied on by the success path and is not what this issue is about.
 New Bun (`bun:test`) files — no existing Vitest suite is modified:
 
 1. `packages/providers/src/openai-vercel/messageConversion.toolFailure.test.ts`
-   covers AC1.1 – AC1.7 by driving the real exported converters with real `IContent`
+   covers AC1.1 – AC1.8 by driving the real exported converters with real `IContent`
    fixtures and asserting on the produced `ToolResultPart` / reconstructed blocks.
    Must be registered in `scripts/bun-test-manifest-data-providers.ts` (curated file list).
 2. `packages/core/src/services/history/ContentConverters.toolFailure.test.ts`

--- a/project-plans/issue3076-tool-failure-roundtrip/plan.md
+++ b/project-plans/issue3076-tool-failure-roundtrip/plan.md
@@ -1,0 +1,137 @@
+# Issue #3076 — A failed tool call must stay failed through OpenAI-Vercel and the ContentConverters round trip
+
+## Problem
+
+`buildToolResponsePayload` (`packages/providers/src/utils/toolResponsePayload.ts`) derives
+`status: 'error'` from `ToolResponseBlock.error`. Anthropic, Gemini and the OpenAI
+Chat/Responses builders all read that status. Two paths still discard it:
+
+1. `packages/providers/src/openai-vercel/messageConversion.ts` builds the payload and then
+   emits `output: { type: 'text', value: payload.result }`, throwing away `status` and
+   `error`. Every failed tool call reaches a Vercel-AI-SDK provider as an ordinary success.
+   The reverse path in the same file already decodes any output type starting with `error`,
+   so the shape exists inbound but is never produced outbound.
+2. `packages/core/src/services/history/ContentConverters.ts` logs the failure marker
+   outbound and omits it from `functionResponse`, and reconstructs `tool_response` blocks
+   inbound without `error`. Consumers: `contentGeneratorAdapters.ts` (Google code-assist
+   request path — currently emits no failure signal at all) and
+   `streamRequestHelpers.ts` (a `BeforeModel` hook that supplies `llm_request.messages`
+   round-trips history `toGeminiContents` -> `toIContents`, which strips the marker).
+
+## Verified facts
+
+- Installed AI SDK: `ai@5.0.206` -> `@ai-sdk/provider-utils@3.0.27`. `ToolResultPart.output`
+  is `LanguageModelV2ToolResultOutput` (`@ai-sdk/provider`), whose union includes
+  `{ type: 'error-text'; value: string }` and `{ type: 'error-json'; value: JSONValue }`.
+  So `error-text` is type-safe with the installed version.
+- `@ai-sdk/openai@dist` maps `error-text` to the same wire content string as `text` for both
+  the Chat and Responses transports, so no OpenAI wire regression; providers that do
+  distinguish failure (e.g. Anthropic through the SDK) gain the correct signal.
+- `payload.result` is always a `string` (`buildToolResponsePayload` guarantees it, falling
+  back to `EMPTY_TOOL_RESULT_PLACEHOLDER`), so `error-text` is the correct counterpart of the
+  existing `text` output — `error-json` is not needed.
+- `GeminiMessageConverter.convertToolContentToGeminiContents` already establishes the
+  project's canonical Gemini-shaped failure encoding: `functionResponse.response` is an
+  envelope carrying `status`, `result` and `error`. Part 2 follows that precedent.
+- `#3063` (PR #3077) is not merged; this work does not depend on it. Both changes key off the
+  already-declared `ToolResponseBlock.error` field, and they touch disjoint files.
+
+## Decisions
+
+### D1 — OpenAI-Vercel failure output
+
+A `tool_response` whose payload `status` is `'error'` is emitted as
+`output: { type: 'error-text', value }`. Success is unchanged (`{ type: 'text', value }`).
+
+`value` stays the model-facing remedy (`payload.result`), because that is the text the model
+must act on. Only when `payload.result` is the `[no tool result]` placeholder — i.e. the block
+carried no result at all — does the value fall back to `payload.error`, so a failure never
+reaches the model as the bare placeholder with no explanation.
+
+### D2 — Canonical legacy (Gemini-shaped) encoding of a failed tool response
+
+`ContentConverters.toolResponseBlockToPart` emits, **and only when the block carries a
+failure marker**:
+
+```
+functionResponse: {
+  name, id,
+  response: {
+    status: 'error',
+    error: <error string>,
+    result: <original block.result>,   // key omitted when result is undefined
+  },
+}
+```
+
+A successful tool response is encoded exactly as today (`response` is the raw result), so no
+existing success payload — on the wire to Google or anywhere else — changes.
+
+`ContentConverters.processFunctionResponsePart` decodes that envelope: when
+`functionResponse.response` is a plain object with `status === 'error'` and a string `error`,
+the reconstructed block gets `error` set and `result` restored verbatim from the envelope
+(`{}` when the `result` key is absent, matching the existing empty-response behaviour).
+
+**What the legacy representation preserves:** `callId`, `toolName`, `result`, and the failure
+marker `error`. **What it deliberately does not preserve:** `isComplete` and
+`providerMetadata`. Those are local bookkeeping with no Gemini wire representation; encoding
+them would pollute the payload sent to Google for zero model benefit. This is a recorded
+decision, not an oversight, and is documented at the conversion site.
+
+Non-goal (explicitly out of scope): making the *success* round trip lossless for non-object
+results (`'hello'` still returns as `{ output: 'hello' }`). That is pre-existing behaviour
+relied on by the success path and is not what this issue is about.
+
+## Acceptance criteria
+
+### Part 1 — `packages/providers/src/openai-vercel/messageConversion.ts`
+
+- AC1.1 `convertToVercelMessages` on an `IContent` whose `tool_response` block has `error`
+  set produces a `tool-result` part with `output.type === 'error-text'`.
+- AC1.2 The `error-text` value is the model-facing result text (`payload.result`).
+- AC1.3 When the block has `error` set and no result, the `error-text` value is the error
+  text, not `[no tool result]`.
+- AC1.4 A `tool_response` block with no `error` is unchanged: `output.type === 'text'` with
+  the same value as before (regression guard, including the empty-result placeholder case).
+- AC1.5 Round trip: `convertToVercelMessages` -> `convertFromVercelMessages` on a failed
+  tool response yields a `tool_response` block that is still marked as a failure
+  (`isError === true` and a non-empty `error`), and a successful one yields a block with no
+  failure marker.
+
+### Part 2 — `packages/core/src/services/history/ContentConverters.ts`
+
+- AC2.1 `toGeminiContent` on a `tool_response` block with `error` set produces
+  `functionResponse.response` containing `status: 'error'` and the `error` string.
+- AC2.2 That envelope also carries the original `result` verbatim under `result`.
+- AC2.3 `toGeminiContent` on a `tool_response` block without `error` is byte-identical to
+  today (`response` is the raw result object; no `status`, no `error` key added).
+- AC2.4 `toIContent` on a functionResponse carrying the envelope reconstructs a
+  `tool_response` block with `error` set and `result` equal to the original value.
+- AC2.5 `toIContent` on an ordinary (non-envelope) functionResponse is unchanged, including
+  the existing string/JSON coercion behaviour.
+- AC2.6 Full round trip `toGeminiContents` -> `toIContents` preserves the failure marker,
+  the result, the tool name and the call id for a failed tool response, and preserves the
+  absence of a marker for a successful one.
+- AC2.7 Boundary: an error envelope whose original result was `undefined` decodes to `{}`
+  (the pre-existing empty-response convention) and still carries the failure marker.
+
+## Test plan (behavioural, written first, no mock theatre)
+
+New Bun (`bun:test`) files — no existing Vitest suite is modified:
+
+1. `packages/providers/src/openai-vercel/messageConversion.toolFailure.test.ts`
+   covers AC1.1 – AC1.5 by driving the real exported converters with real `IContent`
+   fixtures and asserting on the produced `ToolResultPart` / reconstructed blocks.
+   Must be registered in `scripts/bun-test-manifest-data-providers.ts` (curated file list).
+2. `packages/core/src/services/history/ContentConverters.toolFailure.test.ts`
+   covers AC2.1 – AC2.7 by driving `toGeminiContent(s)` / `toIContent(s)` directly.
+   The core workspace runner auto-discovers `*.test.ts`, so no manifest edit is needed.
+
+No mocks are required in either file: both units are pure functions over plain data.
+
+## Out of scope
+
+- Changing the success-path encoding anywhere.
+- `providerMetadata` / `isComplete` transport (decision D2 records why).
+- Anything in `#3063` / PR #3077.
+- Emitting `error-json`, or restructuring `buildToolResponsePayload`.

--- a/scripts/bun-test-manifest-data-providers.ts
+++ b/scripts/bun-test-manifest-data-providers.ts
@@ -363,6 +363,7 @@ export const PROVIDERS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
     'src/openai-vercel/__tests__/vercelReasoningCapture.fieldName.test.ts',
     'src/openai-vercel/errorHandling.test.ts',
     'src/openai-vercel/messageConversion.test.ts',
+    'src/openai-vercel/messageConversion.toolFailure.test.ts',
     'src/openai-vercel/modelListing.test.ts',
     'src/openai-vercel/nonStreaming.config.test.ts',
     'src/openai-vercel/nonStreaming.test.ts',


### PR DESCRIPTION
## TLDR

Two conversion paths still handed a failed tool call to the model as if it had succeeded. Both are fixed.

1. **OpenAI-Vercel.** `convertToolContent` built the tool response payload and then dropped its `status`, always emitting `output: { type: 'text', … }`. A failure now emits the AI SDK's native `output: { type: 'error-text', … }`, which is the exact shape the reverse path in the same file already knew how to decode.
2. **ContentConverters.** The Gemini-shaped conversion logged the failure marker outbound and then omitted it, and rebuilt `tool_response` blocks inbound without it. A failed tool response now encodes a canonical envelope that the inbound decoder restores, so the Google code-assist request path finally carries an explicit failure signal instead of an unmarked success.

Success responses are untouched on both paths — that is deliberate and is covered by regression tests, because the outbound Gemini encoding is a live wire payload sent to Google.

Reviewer note: the collision-avoidance design is the part worth a close look. See "Why the failure decode is gated on a part-level flag" below.

## Dive Deeper

### Part 1 — `packages/providers/src/openai-vercel/messageConversion.ts`

`buildToolResultOutput(payload)` maps `status === 'error'` to `{ type: 'error-text', value }` and everything else to the unchanged `{ type: 'text', value }`.

- `error-text` is a real variant of `LanguageModelV2ToolResultOutput` in the installed SDK (`ai@5.0.206` → `@ai-sdk/provider-utils@3.0.27` → `@ai-sdk/provider`). The return type is bound to the SDK via `Extract<ToolResultPart['output'], { type: 'text' | 'error-text' }>`, so it cannot drift. No casts and no suppression comments were needed.
- `@ai-sdk/openai` maps `error-text` to the same wire content string as `text` on both the Chat and Responses transports, so there is no OpenAI wire regression; the tool result is never dropped. Vercel-SDK providers that do model failure gain the correct signal.
- `value` stays the model-facing remedy (`payload.result`), which is what issue #3076 asks for — that is the text the model has to act on. The single exception: when the block carried no result at all, `payload.result` is the `[no tool result]` placeholder, and a failure must never reach the model as a bare placeholder with no explanation, so the error text is used instead.

### Part 2 — `packages/core/src/services/history/ContentConverters.ts`

Only a block that carries a failure marker changes shape. It becomes:

    {
      functionResponse: {
        name: <toolName>,
        response: { status: 'error', error: <error text>, result: <original result> },
        id: <callId>,
      },
      llxprtToolFailure: true,
    }

The `result` key is omitted when the original result was `undefined`. A successful tool response is encoded exactly as before — raw result, no `status`, no `error`, no flag.

The inbound decoder restores `error` and `result` verbatim rather than routing the payload through `parseFunctionResponseResult`, because verbatim fidelity is the whole point of the round trip.

#### Why the failure decode is gated on a part-level flag

Detecting the envelope purely from its shape (`{ status: 'error', error: <string> }`) is not safe. A **successful** tool whose result object merely happens to look like that — third-party MCP servers do model results that way, and `convertToFunctionResponse` copies such objects verbatim — would be misdecoded into a spurious failure with its payload replaced by `{}`. It would also misdecode the different envelope produced by `GeminiMessageConverter`, whose `result` is a serialized string rather than the raw value.

So the failed part carries `llxprtToolFailure: true`, following the `llxprt*` part-extension convention this file already uses for thinking blocks (`llxprtSourceField`, `llxprtThoughtBlockId`, …), and the decoder fires only on parts we encoded. Any other part keeps today's behaviour exactly, whatever its response shape. `AC2.9` is the regression proof and fails without the flag.

#### What the legacy representation preserves

`callId`, `toolName`, `result` and the `error` marker — and nothing else. `isComplete` and `providerMetadata` are local bookkeeping with no Gemini representation, so they are deliberately dropped rather than encoded into a payload the model would then see. This is a recorded decision (documented at the conversion site and in the plan), not an oversight.

`result` null/undefined semantics are pinned by full round-trip tests: `undefined` is omitted outbound and comes back as `{}` (the pre-existing empty-response convention), while an explicit `null` — which is what `historyToolPairing` / `historyToolNormalization` produce on a failed block — is written through and comes back as `null`.

### Correction to the issue text

Issue #3076 names two consumers for Part 2. Only one of them is real:

- `packages/core/src/code_assist/contentGeneratorAdapters.ts` — the Google code-assist request path — **is** a live consumer and genuinely benefits. It is now covered by its own behavioural test file.
- `packages/agents/src/core/streamRequestHelpers.ts` — **is not**. It only round-trips when a `BeforeModel` hook supplies `llm_request.messages`, and in exactly that case `HookTranslator.fromHookLLMRequest` rebuilds contents as text-only `parts: [{ text }]`, discarding the converted contents entirely. A `functionResponse` part therefore never reaches `toIContents` there — the whole `tool_response` block is lost, not merely its marker. That is a separate, larger problem and is out of scope here; the code comment and the plan state the reality rather than repeating the issue's claim.

The inbound decoder is therefore kept for the symmetry and losslessness the issue asks for, and the plan says plainly that it has no other live consumer today.

### Notes

- The `#3063` fix (PR #3077) is merged, so `createErrorResponse` sets the top-level `ToolResponseBlock.error`. That means these paths now fire for every genuine tool failure — this branch is rebased on that commit and verified against it.
- The plan, acceptance criteria and design decisions live in `project-plans/issue3076-tool-failure-roundtrip/plan.md`.

## Reviewer Test Plan

Pull the branch and run the three behavioural suites directly:

    cd packages/core && bun test --preload ./bun-preload.ts \
      src/services/history/ContentConverters.toolFailure.test.ts \
      src/code_assist/contentGeneratorAdapters.toolFailure.test.ts

    cd packages/providers && bun test --preload ../../test-setup/augment-bun-vi.ts \
      src/openai-vercel/messageConversion.toolFailure.test.ts \
      src/openai-vercel/messageConversion.test.ts

To see the fix matters, revert either half and watch the suites go red:

- Remove the `llxprtToolFailure` flag from the encoder or the decoder gate and `AC2.9` fails — a successful tool whose result is shaped like `{ status: 'error', … }` is destroyed.
- Restore `output: { type: 'text', … }` unconditionally and `AC1.1`/`AC1.5` fail.

Exercising it end to end: run any provider through a tool call that fails (for example ask the model to read a file that does not exist, or to run a shell command that exits non-zero), and confirm the model is told the call failed and retries differently rather than treating the error text as a successful result. On an OpenAI-Vercel provider the tool result now leaves as `error-text`; on the Google code-assist path the `functionResponse.response` now carries `status: 'error'` alongside the remedy.

Regression areas worth poking: any successful tool call on the Gemini/code-assist path (payload must be byte-identical to before), and a tool whose successful result object happens to contain a `status`/`error` key.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the profile smoke test all pass. The one full-suite failure observed was an unrelated 30s timeout in `packages/agents/src/api/__tests__/workspaceControl.behavior.test.ts` under load; it passes in isolation and shares no code with this change.

## Linked issues / bugs

Fixes #3076
