### PR TITLE
Make blocked todo pauses visible to observers (Fixes #3071)

### DIFF
--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.todoPause.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.todoPause.test.ts
@@ -30,6 +30,8 @@ import { MockTool } from '@vybestack/llxprt-code-core/test-utils/mock-tool.js';
 import { clearAllSchedulers } from '@vybestack/llxprt-code-core/config/schedulerSingleton.js';
 import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import { mapLoopStream } from '../../../api/eventAdapter.js';
+import type { AgentEvent } from '../../../api/event-types.js';
 import {
   createScriptedAgentClient,
   createTestConfig,
@@ -245,5 +247,74 @@ describe('AgenticLoop pause loop-break (issue #2653)', () => {
     );
 
     expect(turnMessages).toHaveLength(2);
+  });
+
+  it('emits the terminal done BEFORE the todo_pause tool-result through mapLoopStream (issue #3071 ordering)', async () => {
+    // CHARACTERIZATION GUARD. The CLI observation tap
+    // (packages/cli/src/observation/observationTap.ts) opens the user_input
+    // wait for issue #3071 from onStreamSettled(), NOT from endTurn, precisely
+    // because the terminal `done` is emitted BEFORE the pause tool-result
+    // (turn.ts emits Finished on the provider chunk's finishReason, the
+    // deferred-events flush runs before the loop schedules the tool, and the
+    // adapter maps Finished to an immediate `done`). endTurn therefore runs on
+    // the early done while the pause has not yet been observed, so opening the
+    // wait there would be dead code. If this ordering ever changes (done after
+    // the result, or the result projected with an empty name / an error), the
+    // tap's onStreamSettled design must be revisited.
+    const pauseTool = new MockTool({
+      name: 'todo_pause',
+      execute: async () => ({
+        llmContent: 'paused',
+        returnDisplay: 'paused',
+      }),
+    });
+
+    const toolRegistry = createToolRegistryForTest([pauseTool]);
+    const messageBus = new MessageBus(createAskPolicyEngine(), false);
+    const config = createTestConfig({
+      messageBus,
+      toolRegistry,
+      policyEngine: createAskPolicyEngine(),
+      interactive: true,
+      approvalMode: ApprovalMode.YOLO,
+    });
+
+    const { client } = createScriptedAgentClient([
+      [
+        toolCallRequestEvent('todo_pause', 'pause-order', {
+          reason: 'blocked',
+        }),
+        finishedEvent(),
+      ],
+    ]);
+
+    const loop = new AgenticLoop({
+      agentClient: client,
+      config,
+      messageBus,
+      interactiveMode: true,
+    });
+
+    const agentEvents: AgentEvent[] = [];
+    for await (const ev of mapLoopStream(
+      loop.run([{ type: 'text', text: 'pause' }], new AbortController().signal),
+    )) {
+      agentEvents.push(ev);
+    }
+
+    const doneIndex = agentEvents.findIndex((e) => e.type === 'done');
+    const pauseResult = agentEvents.find(
+      (e): e is Extract<AgentEvent, { type: 'tool-result' }> =>
+        e.type === 'tool-result' && e.result.name === 'todo_pause',
+    );
+
+    // The pause tool result is projected with its true name and no error.
+    expect(pauseResult).not.toBeUndefined();
+    expect(pauseResult?.result.isError).toBe(false);
+
+    // CRITICAL ordering: the terminal `done` precedes the pause result.
+    expect(doneIndex).toBeGreaterThanOrEqual(0);
+    const pauseResultIndex = agentEvents.indexOf(pauseResult!);
+    expect(doneIndex).toBeLessThan(pauseResultIndex);
   });
 });

--- a/packages/cli/src/observation/jspWiring.ts
+++ b/packages/cli/src/observation/jspWiring.ts
@@ -227,6 +227,17 @@ export function observeTurnCancelled(): void {
   isolate(() => tap.onTurnEnded('cancelled'));
 }
 
+/**
+ * Signal that the agent stream for the current turn has fully settled and
+ * control has returned to the prompt. The terminal `done` event fires before
+ * the turn's tool results arrive, so a pause that ends the turn is only
+ * observable once the stream has settled. This is the hook that lets the tap
+ * open a `user_input` wait at the honest moment (issue #3071).
+ */
+export function observeTurnSettled(): void {
+  isolate(() => tap.onStreamSettled());
+}
+
 export function observeAgentEvent(event: AgentEvent): void {
   isolate(() => tap.processEvent(event));
 }

--- a/packages/cli/src/observation/observationTap.test.ts
+++ b/packages/cli/src/observation/observationTap.test.ts
@@ -66,6 +66,27 @@ const errorResultEvent: AgentEvent = {
   type: 'tool-result',
   result: { id: 'tool-1', name: 'read_file', output: 'boom', isError: true },
 };
+const pauseToolCallEvent: AgentEvent = {
+  type: 'tool-call',
+  call: { id: 'pause-1', name: 'todo_pause', args: { reason: 'blocked' } },
+};
+const pauseOkResultEvent: AgentEvent = {
+  type: 'tool-result',
+  result: {
+    id: 'pause-1',
+    name: 'todo_pause',
+    output: 'paused',
+    isError: false,
+  },
+};
+const pauseSuccessStatusEvent: AgentEvent = {
+  type: 'tool-status',
+  update: { id: 'pause-1', name: 'todo_pause', status: 'success' },
+};
+const pauseCancelledStatusEvent: AgentEvent = {
+  type: 'tool-status',
+  update: { id: 'pause-1', name: 'todo_pause', status: 'cancelled' },
+};
 
 /**
  * A target whose callbacks are inert except where a test overrides them, so
@@ -377,5 +398,380 @@ describe('createObservationTap', () => {
     // suppressed tool-result emits no further phase at all.
     expect(resolved).toStrictEqual(['resolved']);
     expect(phases).toStrictEqual(['awaiting_approval', 'cancelled']);
+  });
+
+  // ─── pause tool opens a user_input wait (#3071) ────────────────────────
+  //
+  // Production event ordering for a pause turn (recorded against the real
+  // AgenticLoop + CoreToolScheduler + the pause MockTool through mapLoopStream):
+  //
+  //   tool-call (pause tool)
+  //   done reason=stop            <- turn.ended fires here (early)
+  //   tool-status (pause):success
+  //   tool-result name="pause tool" isError=false
+  //
+  // `done` arrives BEFORE the tool-result, so the user_input wait cannot open
+  // from endTurn (the pause has not been observed yet). It opens from
+  // onStreamSettled(), which runs once the stream — including the late result —
+  // has arrived. Every pause test below drives this ordering and the hook.
+
+  it('opens a user_input wait after a successful todo_pause settles on a completed turn', () => {
+    const calls: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget(calls),
+      onWaitOpened: (reason) => calls.push(`wait.opened:${reason}`),
+    });
+
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent(pauseOkResultEvent);
+    tap.onStreamSettled();
+
+    // turn.ended is published first; the wait opens only once control has
+    // returned (after settle).
+    expect(calls[calls.length - 2]).toBe('turn.ended:completed');
+    expect(calls[calls.length - 1]).toBe('wait.opened:user_input');
+  });
+
+  it('does not open a wait when onStreamSettled runs before any pause', () => {
+    const opened: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget([]),
+      onWaitOpened: (reason) => opened.push(reason),
+    });
+
+    tap.onTurnStarted();
+    tap.processEvent(doneEvent);
+    tap.onStreamSettled();
+
+    expect(opened).toStrictEqual([]);
+  });
+
+  it('does not open a wait when the todo_pause result is an error', () => {
+    const opened: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget([]),
+      onWaitOpened: (reason) => opened.push(reason),
+    });
+
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent({
+      type: 'tool-result',
+      result: {
+        id: 'pause-1',
+        name: 'todo_pause',
+        output: 'boom',
+        isError: true,
+      },
+    } as AgentEvent);
+    tap.onStreamSettled();
+
+    expect(opened).toStrictEqual([]);
+  });
+
+  it('does not open a wait when the todo_pause result carries an errorType', () => {
+    const opened: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget([]),
+      onWaitOpened: (reason) => opened.push(reason),
+    });
+
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent({
+      type: 'tool-result',
+      result: {
+        id: 'pause-1',
+        name: 'todo_pause',
+        output: 'schema error',
+        errorType: 'validation',
+      },
+    } as AgentEvent);
+    tap.onStreamSettled();
+
+    expect(opened).toStrictEqual([]);
+  });
+
+  it('does not open a wait for a todo_pause cancelled by abort (#3071)', () => {
+    // A pause cancelled by abort projects to isError:false and
+    // errorType:undefined (buildCancelledTransition leaves them unset on the
+    // abort path), so the result fields alone cannot reject it. The terminal
+    // phase recorded from tool-status:cancelled is what prevents this from
+    // counting as a successful pause.
+    const opened: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget([]),
+      onWaitOpened: (reason) => opened.push(reason),
+    });
+
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseCancelledStatusEvent);
+    tap.processEvent({
+      type: 'tool-result',
+      result: {
+        id: 'pause-1',
+        name: 'todo_pause',
+        output: '',
+        isError: false,
+      },
+    } as AgentEvent);
+    tap.onStreamSettled();
+
+    expect(opened).toStrictEqual([]);
+  });
+
+  it('matches the todo_pause tool name case-insensitively', () => {
+    const opened: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget([]),
+      onWaitOpened: (reason) => opened.push(reason),
+    });
+
+    tap.onTurnStarted();
+    tap.processEvent({
+      type: 'tool-call',
+      call: { id: 'pause-1', name: 'TODO_PAUSE', args: {} },
+    } as AgentEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent({
+      type: 'tool-status',
+      update: { id: 'pause-1', name: 'TODO_PAUSE', status: 'success' },
+    } as AgentEvent);
+    tap.processEvent({
+      type: 'tool-result',
+      result: {
+        id: 'pause-1',
+        name: 'TODO_PAUSE',
+        output: 'paused',
+        isError: false,
+      },
+    } as AgentEvent);
+    tap.onStreamSettled();
+
+    expect(opened).toStrictEqual(['user_input']);
+  });
+
+  it('opens the wait via toolLabels correlation when the result name is empty', () => {
+    // A result whose projection carries name: '' is correlated through the
+    // call id. After the terminal done resets turn-scoped state, the
+    // intervening tool-status re-establishes the label correlation, so the
+    // empty result name still resolves to the pause tool.
+    const opened: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget([]),
+      onWaitOpened: (reason) => opened.push(reason),
+    });
+
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent({
+      type: 'tool-result',
+      result: { id: 'pause-1', name: '', output: 'paused', isError: false },
+    } as AgentEvent);
+    tap.onStreamSettled();
+
+    expect(opened).toStrictEqual(['user_input']);
+  });
+
+  it('does not open a pause wait on a cancelled or failed turn even with a successful pause', () => {
+    for (const reason of ['aborted', 'error'] as const) {
+      const opened: string[] = [];
+      const tap = createObservationTap({
+        ...noopTarget([]),
+        onWaitOpened: (r) => opened.push(r),
+      });
+
+      tap.onTurnStarted();
+      tap.processEvent(pauseToolCallEvent);
+      tap.processEvent({ type: 'done', reason } as AgentEvent);
+      tap.processEvent(pauseSuccessStatusEvent);
+      tap.processEvent(pauseOkResultEvent);
+      tap.onStreamSettled();
+
+      expect(opened).toStrictEqual([]);
+    }
+  });
+
+  it('does not reuse a completed outcome when the next turn settles without done', () => {
+    const opened: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget([]),
+      onWaitOpened: (reason) => opened.push(reason),
+    });
+
+    // Turn 1 completes normally and records a completed outcome.
+    tap.onTurnStarted();
+    tap.processEvent(doneEvent);
+    tap.onStreamSettled();
+
+    // Turn 2 observes a pause result but never receives its own terminal done.
+    // Its settle must not reuse Turn 1's completed outcome.
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent(pauseOkResultEvent);
+    tap.onStreamSettled();
+
+    expect(opened).toStrictEqual([]);
+  });
+
+  it('resolves the pause wait exactly once on the next turn start, before turn.started', () => {
+    const calls: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget(calls),
+      onWaitOpened: (reason) => calls.push(`wait.opened:${reason}`),
+      onWaitResolved: () => calls.push('wait.resolved'),
+    });
+
+    // Turn 1: a pause opens a wait.
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent(pauseOkResultEvent);
+    tap.onStreamSettled();
+    expect(calls).toContain('wait.opened:user_input');
+
+    // Turn 2: the lingering pause wait resolves once, before turn.started.
+    calls.length = 0;
+    tap.onTurnStarted();
+    expect(calls).toStrictEqual(['wait.resolved', 'turn.started']);
+
+    // Turn 3: a normal turn with no pause emits no further wait.resolved.
+    calls.length = 0;
+    tap.onTurnStarted();
+    tap.processEvent(toolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(okResultEvent);
+    tap.onStreamSettled();
+    expect(calls.filter((c) => c === 'wait.resolved')).toStrictEqual([]);
+  });
+
+  it('opens at most one pause wait per turn and survives a duplicate settle', () => {
+    const opened: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget([]),
+      onWaitOpened: (reason) => opened.push(reason),
+    });
+
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent(pauseOkResultEvent);
+    tap.processEvent({
+      type: 'tool-call',
+      call: { id: 'pause-2', name: 'todo_pause', args: {} },
+    } as AgentEvent);
+    tap.processEvent({
+      type: 'tool-status',
+      update: { id: 'pause-2', name: 'todo_pause', status: 'success' },
+    } as AgentEvent);
+    tap.processEvent({
+      type: 'tool-result',
+      result: {
+        id: 'pause-2',
+        name: 'todo_pause',
+        output: 'paused',
+        isError: false,
+      },
+    } as AgentEvent);
+    tap.onStreamSettled();
+    // A duplicate settle must not open a second wait.
+    tap.onStreamSettled();
+
+    expect(opened).toStrictEqual(['user_input']);
+  });
+
+  it('resolves a stranded permission wait before opening the pause wait', () => {
+    const calls: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget(calls),
+      onWaitOpened: (reason) => calls.push(`wait.opened:${reason}`),
+      onWaitResolved: () => calls.push('wait.resolved'),
+    });
+
+    tap.onTurnStarted();
+    tap.processEvent(toolCallEvent);
+    tap.processEvent(confirmationEvent);
+    // The permission is never cleared (no executing/success status), so it is
+    // stranded when the turn ends. Meanwhile, a pause also lands.
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent(pauseOkResultEvent);
+    tap.onStreamSettled();
+
+    // The stranded permission resolves (from resetTurnScopedState on done),
+    // then the turn ends, then the pause wait opens once settled -- in order.
+    expect(calls.slice(-3)).toStrictEqual([
+      'wait.resolved',
+      'turn.ended:completed',
+      'wait.opened:user_input',
+    ]);
+  });
+
+  it('resolves and re-opens the pause wait once each across two consecutive pause turns', () => {
+    const calls: string[] = [];
+    const tap = createObservationTap({
+      ...noopTarget(calls),
+      onWaitOpened: () => calls.push('wait.opened'),
+      onWaitResolved: () => calls.push('wait.resolved'),
+    });
+
+    // Turn 1: pause opens a wait.
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent(pauseOkResultEvent);
+    tap.onStreamSettled();
+
+    // Turn 2: another pause resolves the prior wait, then re-opens it.
+    calls.length = 0;
+    tap.onTurnStarted();
+    tap.processEvent(pauseToolCallEvent);
+    tap.processEvent(doneEvent);
+    tap.processEvent(pauseSuccessStatusEvent);
+    tap.processEvent(pauseOkResultEvent);
+    tap.onStreamSettled();
+
+    expect(calls.filter((c) => c === 'wait.resolved')).toStrictEqual([
+      'wait.resolved',
+    ]);
+    expect(calls.filter((c) => c === 'wait.opened')).toStrictEqual([
+      'wait.opened',
+    ]);
+    // The wait resolves (on turn start) before turn.started, then re-opens
+    // after the second settle.
+    expect(calls).toContain('wait.resolved');
+    expect(calls[calls.length - 1]).toBe('wait.opened');
+  });
+
+  it('stays inert with observation disabled through the pause sequence including settle', () => {
+    const tap = createObservationTap(null);
+
+    expect(() => {
+      tap.onTurnStarted();
+      tap.processEvent(pauseToolCallEvent);
+      tap.processEvent(doneEvent);
+      tap.processEvent(pauseSuccessStatusEvent);
+      tap.processEvent(pauseOkResultEvent);
+      tap.onStreamSettled();
+      tap.onTurnStarted();
+      tap.onTurnEnded('completed');
+      tap.onStreamSettled();
+    }).not.toThrow();
   });
 });

--- a/packages/cli/src/observation/observationTap.ts
+++ b/packages/cli/src/observation/observationTap.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AgentEvent, DoneReason } from '@vybestack/llxprt-code-agents';
+import type {
+  AgentEvent,
+  AgentToolResult,
+  DoneReason,
+} from '@vybestack/llxprt-code-agents';
 import type {
   JspActivityState,
   JspToolPhase,
@@ -30,6 +34,50 @@ export interface ObservationTap {
   onTurnEnded(outcome: JspTurnOutcome): void;
   processEvent(event: AgentEvent): void;
   onFlushCommitted(content: string, committedMs: number): void;
+  /**
+   * The agent stream for the current turn has fully settled and control has
+   * returned to the prompt. This is distinct from `done`/`endTurn`: the
+   * terminal `done` event fires before the turn's tool results arrive, so a
+   * turn that ended with the pause tool still has its tool result pending at
+   * `endTurn`. Settled is the honest moment to decide whether a user_input
+   * wait should open, because every event the turn will produce has arrived.
+   */
+  onStreamSettled(): void;
+}
+
+/**
+ * The pause tool name, matched case-insensitively. Kept as a local literal
+ * for consistency with `AgenticLoop.ts` and `TodoContinuationService.ts`,
+ * which hardcode the same value. The matching constant is also exported from
+ * a self-contained module in the tools package, but the other two call sites
+ * use the literal, so this matches them rather than introducing a new import
+ * for a single string comparison.
+ */
+const TODO_PAUSE_TOOL_NAME = 'todo_pause';
+
+/**
+ * A pause is "successful" only when it ended in a succeeded terminal phase
+ * with a non-error result. This mirrors `hasSuccessfulTodoPause` in
+ * AgenticLoop.ts, which additionally requires `status === 'success'` beyond
+ * the error/response checks. The projected-event analogue of that status is
+ * the effective terminal phase: a pause cancelled by abort projects
+ * `isError: false` and `errorType: undefined` but a `cancelled` phase, so the
+ * phase gate is what prevents a cancelled-by-abort pause from masquerading as
+ * a successful one. A failed pause (invalid reason, schema error, filtered
+ * text) does not stop the loop, so it must not be reported as the agent being
+ * blocked on a human.
+ */
+function isSuccessfulPauseResult(
+  label: string,
+  result: AgentToolResult,
+  effectivePhase: JspToolPhase,
+): boolean {
+  return (
+    label.toLowerCase() === TODO_PAUSE_TOOL_NAME &&
+    effectivePhase === 'succeeded' &&
+    result.isError !== true &&
+    result.errorType === undefined
+  );
 }
 
 /**
@@ -95,17 +143,25 @@ interface TurnScope {
   readonly toolLabels: Map<string, string>;
   readonly awaitingConfirmation: Set<string>;
   /**
-   * Call ids that already reported a terminal phase this turn.
+   * The FIRST terminal phase observed for each call id, keyed by call id.
    *
-   * The first terminal phase observed for a call id is sticky: a cancelled
-   * tool still emits a terminal `tool-result`, and
-   * `projectToolResult` derives `isError` as
+   * The first terminal phase is sticky: a cancelled tool still emits a
+   * terminal `tool-result`, and `projectToolResult` derives `isError` as
    * `status === 'error' || (status === 'cancelled' && outcome === Cancel)`,
    * so a tool cancelled by abort (not by an explicit Cancel confirmation
    * outcome) yields `isError: false` and would otherwise be rewritten from
-   * `cancelled` to `succeeded` by the later `tool-result`.
+   * `cancelled` to `succeeded` by the later `tool-result`. Recording the
+   * phase rather than a bare membership also lets the pause-success check
+   * reject a cancelled-by-abort pause, whose result carries neither error
+   * flag nor errorType.
    */
-  readonly terminalTools: Set<string>;
+  readonly terminalPhases: Map<string, JspToolPhase>;
+  /**
+   * Becomes true once a successful pause-tool result has been seen this turn.
+   * Turn-scoped: reset at each turn boundary so it never leaks across turns.
+   * Mutable by design — it records observed turn state.
+   */
+  successfulPauseObserved: boolean;
 }
 
 function routeToolEvent(
@@ -115,11 +171,18 @@ function routeToolEvent(
 ): void {
   if (event.type === 'tool-status') {
     const label = scope.toolLabels.get(event.update.id) ?? event.update.name;
+    // Refresh the call-id → label correlation from the status update's name.
+    // The terminal `done` resets turn-scoped state (clearing toolLabels) before
+    // a turn's tool results arrive, so a result whose projection carries an
+    // empty name must be re-correlated from the intervening status updates.
+    if (event.update.name.length > 0) {
+      scope.toolLabels.set(event.update.id, event.update.name);
+    }
     const phase = mapToolStatus(event.update.status);
-    if (!scope.terminalTools.has(event.update.id)) {
+    if (!scope.terminalPhases.has(event.update.id)) {
       target.onToolPhaseChanged(label, phase);
       if (isTerminalPhase(phase)) {
-        scope.terminalTools.add(event.update.id);
+        scope.terminalPhases.set(event.update.id, phase);
       }
     }
     // Suppression above covers only the phase emission. A suppressed event
@@ -135,11 +198,26 @@ function routeToolEvent(
     return;
   }
   const label = scope.toolLabels.get(event.result.id) ?? event.result.name;
-  const phase: JspToolPhase =
-    event.result.isError === true ? 'failed' : 'succeeded';
-  if (!scope.terminalTools.has(event.result.id)) {
-    target.onToolPhaseChanged(label, phase);
-    scope.terminalTools.add(event.result.id);
+  // The effective terminal phase honors the sticky first terminal status when
+  // one was observed (a cancelled-by-abort tool reaches here with
+  // isError:false). Only when no status ever arrived does the result's error
+  // flag derive the phase.
+  const effectivePhase: JspToolPhase =
+    scope.terminalPhases.get(event.result.id) ??
+    (event.result.isError === true ? 'failed' : 'succeeded');
+  if (!scope.terminalPhases.has(event.result.id)) {
+    target.onToolPhaseChanged(label, effectivePhase);
+    scope.terminalPhases.set(event.result.id, effectivePhase);
+  }
+  // Record a successful pause using the correlated label (captured above,
+  // before the toolLabels entry is deleted below) so a result whose raw-stream
+  // projection carries an empty name is still matched against the tool-call.
+  // This check MUST stay outside the terminal-phase guard above: production
+  // delivers tool-status:success BEFORE the tool-result, so guarding it would
+  // suppress every genuine pause (the phase is already recorded as terminal
+  // when the result arrives).
+  if (isSuccessfulPauseResult(label, event.result, effectivePhase)) {
+    scope.successfulPauseObserved = true;
   }
   scope.toolLabels.delete(event.result.id);
   if (
@@ -203,13 +281,26 @@ export function createObservationTap(
       onTurnEnded: () => undefined,
       processEvent: () => undefined,
       onFlushCommitted: () => undefined,
+      onStreamSettled: () => undefined,
     };
   }
   const scope: TurnScope = {
     toolLabels: new Map<string, string>(),
     awaitingConfirmation: new Set<string>(),
-    terminalTools: new Set<string>(),
+    terminalPhases: new Map<string, JspToolPhase>(),
+    successfulPauseObserved: false,
   };
+
+  /**
+   * Session-scoped: a pause wait deliberately survives the turn-scoped reset so
+   * the observer keeps showing "needs you" while the agent sits at the prompt.
+   * It is resolved only when the next turn actually begins — that is the moment
+   * the human re-engages, so the wait resolves there and only there. Keeping it
+   * out of the turn-scoped reset is the entire point: an unconditional wait on
+   * every turn end would mark every idle agent as needing attention, destroying
+   * the distinction between "finished" and "gave up and blocked on a human".
+   */
+  let pauseWaitOpen = false;
 
   /**
    * Tool correlation is turn-scoped. A cancelled or aborted turn never delivers
@@ -223,7 +314,8 @@ export function createObservationTap(
     const hadPendingApproval = scope.awaitingConfirmation.size > 0;
     scope.toolLabels.clear();
     scope.awaitingConfirmation.clear();
-    scope.terminalTools.clear();
+    scope.terminalPhases.clear();
+    scope.successfulPauseObserved = false;
     if (hadPendingApproval) {
       target.onWaitResolved();
     }
@@ -234,20 +326,41 @@ export function createObservationTap(
    * submit path's failure handler, and the interactive cancel handler. Only the
    * first of those may take effect, or the observer would see several ends for
    * one turn. Ending a turn that was never started is likewise a no-op.
+   *
+   * The wait is NOT opened here. The terminal `done` event fires before the
+   * turn's tool results arrive (the scheduler flushes deferred Finished events
+   * before scheduling tools), so at this point a pause result has not
+   * been observed yet. Opening the wait here would be dead code. The wait opens
+   * in `onStreamSettled`, which runs once the stream — including those late
+   * results — has fully arrived.
    */
   let turnOpen = false;
+  let lastOutcome: JspTurnOutcome | null = null;
   const endTurn = (outcome: JspTurnOutcome): void => {
     if (!turnOpen) {
       return;
     }
     turnOpen = false;
     resetTurnScopedState();
+    // Record the outcome before publishing turn.ended so onStreamSettled (which
+    // runs after the turn's tool results arrive) can gate the user_input wait
+    // on the turn's actual outcome rather than re-deriving it.
+    lastOutcome = outcome;
     target.onTurnEnded(outcome);
   };
 
   return {
     onTurnStarted(): void {
+      // Resolve a lingering pause wait before the new turn begins. The wait is
+      // session-scoped precisely so it survives here: the next prompt is the
+      // moment the human re-engages, so the wait resolves exactly once, before
+      // turn.started, and a later turn with no pause emits no further signal.
+      if (pauseWaitOpen) {
+        target.onWaitResolved();
+        pauseWaitOpen = false;
+      }
       resetTurnScopedState();
+      lastOutcome = null;
       turnOpen = true;
       target.onTurnStarted();
     },
@@ -260,6 +373,26 @@ export function createObservationTap(
     onFlushCommitted(content: string, committedMs: number): void {
       if (content.length > 0) {
         target.onAssistantMessageCommitted(content, committedMs);
+      }
+    },
+    onStreamSettled(): void {
+      // The stream has settled: every event the turn will produce — including
+      // the tool results that arrive after the terminal `done` — has arrived.
+      // Only now can a successful pause be observed truthfully, so this is
+      // the honest moment to open the user_input wait.
+      //
+      // turn.ended (published by endTurn on the early `done`) and wait.opened
+      // are published as two separate revisions, so a consumer sampling between
+      // them momentarily sees the idle state. Ordering (turn.ended first) is
+      // still correct: the wait must not claim the agent is blocked before
+      // control has actually returned.
+      if (
+        scope.successfulPauseObserved &&
+        lastOutcome === 'completed' &&
+        !pauseWaitOpen
+      ) {
+        target.onWaitOpened('user_input');
+        pauseWaitOpen = true;
       }
     },
   };

--- a/packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts
@@ -44,6 +44,7 @@ import type { StreamRuntime, UiSubagentManager } from '../../cliUiRuntime.js';
 import {
   observeAgentEvent,
   observeTurnFailed,
+  observeTurnSettled,
   observeTurnStarted,
 } from '../../../observation/jspWiring.js';
 
@@ -716,6 +717,14 @@ async function runSubmitQueryCore(
       } catch {
         /* non-fatal */
       }
+    }
+    // The stream has settled: every event for this turn, including tool
+    // results that arrive after the terminal `done`, has been processed. This
+    // is the honest moment a pause-ended turn can open a user_input
+    // wait (issue #3071). Guarded so a superseded turn cannot open a wait for
+    // a turn that no longer owns the controller.
+    if (isCurrentTurn(cbd, turn.abortSignal)) {
+      observeTurnSettled();
     }
   }
 }

--- a/project-plans/issue3071/plan.md
+++ b/project-plans/issue3071/plan.md
@@ -1,0 +1,234 @@
+# Issue #3071 — `todo_pause` must open a `user_input` wait on the observation channel
+
+## Problem
+
+When the model calls `todo_pause` successfully, `AgenticLoop.buildNextMessage`
+returns `{ continueLoop: false }` and the stream finishes with `done: 'stop'`.
+`observationTap.mapDoneReason` maps that to the turn outcome `completed`, so the
+only thing an observer (jefe) receives is a normal successful `turn.ended`.
+An agent that gave up and is blocked on a human is indistinguishable from an
+agent that finished its work.
+
+`wait.opened` had exactly one production emitter: `onWaitOpened('permission')`
+on a tool-confirmation prompt. The `user_input` reason in the JSP contract had
+never been emitted.
+
+## Design decision (already decided, kept)
+
+**Only an explicit blocked pause opens a `user_input` wait. A normal return to
+the prompt does not.**
+
+Emitting `user_input` unconditionally on every `turn.ended` would collapse the
+distinction between "the agent finished and is idle" and "the agent gave up and
+needs you". The second is the one that must pull attention, and it is exactly
+what `todo_pause` means. So the wait is opened only when a successful
+`todo_pause` tool result was observed in the turn that just settled.
+
+## The dead-code defect this design fixes
+
+The first uncommitted attempt opened the wait from `endTurn` (right after
+`onTurnEnded`). That never fired. The real public `AgentEvent` order for a pause
+turn, recorded against the real AgenticLoop + real CoreToolScheduler + real
+todo_pause MockTool through `mapLoopStream`, is:
+
+```
+tool-call todo_pause
+done reason=stop            <- turn.ended fires here (EARLY)
+tool-status todo_pause:validating
+tool-status todo_pause:scheduled
+tool-status todo_pause:executing
+tool-status todo_pause:success
+tool-result name="todo_pause" isError=false
+```
+
+`done` arrives BEFORE the tool-result. `turn.ts` emits `AgentEventType.Finished`
+whenever the provider chunk carries a finishReason;
+`TodoContinuationService.shouldDeferStreamEvent` defers Finished;
+`MessageStreamOrchestrator._finishWithToolCalls` flushes the deferred events at
+the end of the model iteration — i.e. BEFORE AgenticLoop schedules the tools —
+and `eventAdapter.ts` maps Finished to an immediate `done`. So in
+`observationTap` `endTurn` runs on the early `done` while the pause tool result
+has not yet been observed, and the later tool result sets its flag after
+`endTurn` has already become a no-op. The net observable output was
+`turn.started, turn.ended:completed, turn.started` — no `wait.opened`.
+
+## Where the change goes
+
+The change spans three CLI files (not `observationTap.ts` alone) plus the
+terminal-phase-based success predicate:
+
+1. `packages/cli/src/observation/observationTap.ts` — the hook and predicate.
+2. `packages/cli/src/observation/jspWiring.ts` — a wiring export.
+3. `packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts` — the call site.
+
+No change is needed in `packages/tools/src/tools/todo-pause.ts`, in
+`AgenticLoop.ts`'s pause handling, in `TodoContinuationService.ts`, in the JSP
+contract, or in the producer. The `done`-before-result ordering in
+`packages/agents` is a separate pre-existing defect and is explicitly left
+untouched; the tap works with the stream as it actually is.
+
+### The `onStreamSettled` hook (why `endTurn` is the wrong place)
+
+`done` is not the moment control returns to the prompt. The tap exposes a new
+`onStreamSettled(): void` on its `ObservationTap` interface, implemented by both
+the disabled no-op tap and the real tap. Semantics: the agent stream for the
+current turn has fully settled and control has returned to the prompt. If a
+successful `todo_pause` was observed during the settled turn AND the recorded
+turn outcome was `'completed'` AND no pause wait is already open, it emits
+`onWaitOpened('user_input')` and sets the session-scoped `pauseWaitOpen`.
+
+`endTurn` no longer opens the wait. It records the outcome into a closure
+variable (`lastOutcome`) before calling `target.onTurnEnded(outcome)`; the wait
+opening moves entirely to `onStreamSettled`, which runs after the late tool
+result has set `successfulPauseObserved`. `onTurnStarted` resets `lastOutcome`
+to `null` alongside the turn-scoped state, so a malformed later stream that
+settles without its own terminal `done` cannot reuse a previous turn's
+`completed` outcome and open a false wait.
+
+The ordering that makes this work: `resetTurnScopedState()` runs inside
+`endTurn` (on the early `done`), i.e. BEFORE the pause tool-result arrives, so
+`scope.successfulPauseObserved` is cleared and then re-set by the late
+tool-result, and survives until the next `onTurnStarted`. `successfulPauseObserved`
+continues to be cleared in `resetTurnScopedState`.
+
+`turn.ended` (published by `endTurn` on the early `done`) and `wait.opened`
+(published by `onStreamSettled`) are two separate revisions, so a consumer
+sampling between them momentarily sees the idle state. Ordering (`turn.ended`
+first) is still correct: the wait must not claim the agent is blocked before
+control has actually returned.
+
+### The call site
+
+`packages/cli/src/observation/jspWiring.ts` exports `observeTurnSettled()`,
+routed through the existing `isolate()` boundary (the one sanctioned telemetry
+swallow), matching the style of `observeTurnStarted` / `observeTurnFailed` /
+`observeTurnCancelled`.
+
+`packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts` calls
+`observeTurnSettled()` in the `finally` block of `runSubmitQueryCore`, guarded
+by `isCurrentTurn(cbd, turn.abortSignal)` so a superseded turn cannot open a
+wait for a turn that no longer owns the controller.
+
+### The terminal-phase-based success predicate (cancelled-pause false positive)
+
+The previous predicate only checked `isError !== true && errorType === undefined`.
+The predicate it claimed to mirror — `hasSuccessfulTodoPause` in `AgenticLoop.ts`
+— additionally requires `status === 'success'`. A `todo_pause` cancelled by abort
+projects (via `projectToolResult` and `buildCancelledTransition`) to
+`isError: false` and `errorType: undefined`, because the abort path leaves error
+and errorType unset. So the old predicate counted a cancelled-by-abort pause as
+successful. Under the `onStreamSettled` fix this becomes a live false positive
+(the early `done` already recorded outcome `'completed'`, so the outcome gate
+does not catch it).
+
+The fix makes the tap's notion of success match the scheduler's terminal phase.
+`TurnScope.terminalTools: Set<string>` became
+`terminalPhases: Map<string, JspToolPhase>`, recording the FIRST terminal phase
+seen for each call id (preserving the existing sticky-suppression behavior for
+the #2914 tests unchanged). In the tool-result branch the effective terminal
+phase is computed as `terminalPhases.get(id) ?? (isError === true ? 'failed' : 'succeeded')`,
+and the pause counts as successful only when the correlated label matches
+`todo_pause` case-insensitively AND the effective phase is `'succeeded'` AND
+`result.isError !== true` AND `result.errorType === undefined`.
+
+The pause check stays OUTSIDE the existing `terminalPhases.has(id)` guard:
+production delivers `tool-status:success` BEFORE the tool-result, so guarding it
+would suppress every genuine pause.
+
+`isSuccessfulPauseResult` now takes the typed values (resolved label, the typed
+tool result, and the effective phase) instead of three loose positionals that
+invited an argument swap.
+
+### Tool name resolution
+
+The CLI operative path delivers the pause result via `tools_complete` /
+`CompletedToolCall`, which `projectToolResult` projects with the true name
+(`todo_pause`) — not the empty name the raw a2a-stream projection carries. So in
+the CLI the result name is non-empty and the `toolLabels` correlation is not the
+operative path. The `toolLabels` correlation (for a result whose projection
+carries `name: ''`) is retained as a fallback for that real-but-non-CLI path;
+because the terminal `done` resets turn-scoped state before the result arrives,
+intervening `tool-status` updates refresh the call-id→label correlation so the
+fallback still functions under the real event ordering.
+
+## Accepted behavior
+
+1. **Open on successful pause, after settle.** When a turn ended with outcome
+   `completed` and a successful `todo_pause` tool result was observed during the
+   settled turn, `onStreamSettled` emits `onWaitOpened('user_input')`.
+2. **Ordering.** `turn.ended` is emitted first (on the early `done`); the wait
+   opens after the stream settles. The agent is blocked on the human only once
+   control has actually returned to the prompt.
+3. **Failed pause opens nothing.** A `todo_pause` tool result with `isError: true`
+   or with an `errorType` set does not open a wait.
+4. **Cancelled-by-abort pause opens nothing.** A pause whose terminal phase is
+   `cancelled` does not open a wait, even though its projected result carries
+   `isError: false` and no `errorType`.
+5. **Case-insensitive name match**, matching `AgenticLoop.hasSuccessfulTodoPause`.
+6. **No pause, no wait.** A turn that ends `completed` without a successful
+   `todo_pause` emits no `wait.opened`. Idle is not needs-you.
+7. **Only the current turn's `completed` opens the wait.** A turn that ended
+   `cancelled` or `failed` (recorded in `lastOutcome`) does not open a pause wait
+   even if a successful pause was observed. `lastOutcome` resets at turn start,
+   so a stream that settles without its own terminal `done` also opens nothing.
+8. **The wait survives the turn boundary.** `pauseWaitOpen` is session-scoped and
+   survives `resetTurnScopedState`; that is the entire point — the agent stays in
+   needs-you while it sits at the prompt.
+9. **Resolved by the next prompt.** On the next `onTurnStarted()`, the tap emits
+   `onWaitResolved()` exactly once, before `target.onTurnStarted()`, and clears
+   `pauseWaitOpen`. A later turn with no pause emits no further `wait.resolved`.
+10. **At most one open per turn.** Duplicate or repeated `todo_pause` tool results
+    in a turn, and a duplicate `onStreamSettled` call, produce exactly one
+    `wait.opened`.
+11. **Permission waits are unaffected.** A pending tool-confirmation stranded at
+    turn end still resolves through `resetTurnScopedState` (on the early `done`),
+    and the pause wait opens after settle.
+12. **Disabled observation stays inert.** `createObservationTap(null)` remains a
+    no-op on every path, including `onStreamSettled`.
+
+## Tests (behavioral)
+
+In `packages/cli/src/observation/observationTap.test.ts`, every pause test drives
+the PRODUCTION event ordering (tool-call, done, tool-status:success, tool-result)
+and the new `onStreamSettled()` hook. The tool-result-before-done ordering does
+not appear in any pause test. Coverage:
+
+1. successful `todo_pause` + `done: 'stop'` + status/result + settle → ordered
+   calls end with `turn.ended:completed` then `wait.opened:user_input`.
+2. `onStreamSettled()` before any pause → no `wait.opened`.
+3. result with `isError: true` → no `wait.opened`.
+4. result with `errorType` set → no `wait.opened`.
+5. cancelled-by-abort: `tool-status:cancelled` + result `isError:false`,
+   `errorType:undefined` → no `wait.opened` (the step-2 regression guard; fails
+   against a predicate that ignores the terminal phase).
+6. `TODO_PAUSE` / mixed case → wait still opens.
+7. result whose `name` is `''` but correlates to a `todo_pause` tool-call → wait
+   still opens.
+8. `done: 'aborted'` / `done: 'error'` with a successful pause → no `wait.opened`;
+   a later turn that settles without its own `done` cannot reuse a prior
+   `completed` outcome.
+9. after the wait is open, the next `onTurnStarted()` emits exactly one
+   `wait.resolved` before `turn.started`; a following turn with no pause emits no
+   further `wait.resolved`.
+10. two successful `todo_pause` results in one turn → exactly one `wait.opened`;
+    a duplicate `onStreamSettled()` → still exactly one.
+11. a stranded pending confirmation plus a successful pause → `wait.resolved`
+    (stranded permission) then `turn.ended:completed` then `wait.opened:user_input`.
+12. two consecutive pause turns → the wait resolves and re-opens exactly once each.
+13. `createObservationTap(null)` through the whole pause sequence including settle
+    throws nothing and emits nothing.
+
+Additionally, `packages/agents/src/core/agenticLoop/__tests__/agenticLoop.todoPause.test.ts`
+has a characterization test that runs the real AgenticLoop through `mapLoopStream`
+for a `todo_pause` turn and pins the ordering assumption at its source: the
+terminal `done` is emitted BEFORE the `todo_pause` tool-result, and the result
+carries name `todo_pause` with `isError` false. If that ordering ever changes,
+the tap's `onStreamSettled` design must be revisited.
+
+## Out of scope
+
+- Emitting `question`, `elicitation`, `choice` or `other` wait reasons.
+- Any `user_input` wait on a normal idle return to the prompt.
+- Changing `done` semantics in `packages/agents`.
+- Changes to `todo-pause.ts`, `AgenticLoop.ts`'s pause handling,
+  `TodoContinuationService.ts`, the JSP contract, or the producer.


### PR DESCRIPTION
## TLDR

A successful `todo_pause` now publishes a JSP `user_input` wait after the agent stream has fully settled, so jefe and other observers can distinguish “finished and idle” from “blocked and needs a human.” The wait resolves exactly once when the next prompt starts.

The implementation deliberately does **not** mark every ordinary return to the prompt as needing attention.

## Dive Deeper

The first implementation idea—opening the wait from the `done` handler—does not work with the actual public event stream. A real pause turn emits:

    tool-call todo_pause
    done reason=stop
    tool-status todo_pause:validating/scheduled/executing/success
    tool-result todo_pause

Because `done` arrives before the tool result, this PR adds an explicit `onStreamSettled` observation hook. The submit path invokes it from its current-turn-owned `finally` block, after all tool results have been processed. The tap records the terminal turn outcome, recognizes a successful pause, and opens `user_input` only at that honest return-to-prompt boundary.

The pause wait is session-scoped so turn-state cleanup cannot discard it. The next `onTurnStarted` resolves it before publishing the new `turn.started`. Normal completions, failed pauses, cancelled/failed turns, duplicate settles, superseded turns, and disabled observation open no false wait.

The success check also preserves each tool call's first terminal phase. This matters because an abort-cancelled tool can project as `isError: false`; requiring the effective phase to be `succeeded` prevents that cancellation from masquerading as a successful pause.

A real `AgenticLoop` characterization test pins the current `done`-before-result ordering. While investigating it, I found the broader public-stream defect where tool turns can emit `done` before tool activity and more than once; that is tracked separately in #3087 rather than changing public stream semantics in this bounded fix.

Open Code Review reported one valid stale-outcome concern. The tap now clears `lastOutcome` at each turn start, with a regression test proving a later stream that settles without its own `done` cannot reuse a prior completed outcome. OCR's low-priority shared-constant suggestion was not applied because the two owning agent-layer predicates already use a local literal; consolidating all three call sites is outside this issue and would introduce package coupling for a single string.

## Reviewer Test Plan

1. Run the observation behavior tests:

       cd packages/cli
       bun test src/observation/observationTap.test.ts

   Confirm successful pause opens `user_input` only after settle, cancellation/error paths open nothing, and the next turn resolves the wait exactly once.

2. Run the real AgenticLoop ordering characterization:

       cd packages/agents
       bun test src/core/agenticLoop/__tests__/agenticLoop.todoPause.test.ts

   Confirm the public stream test observes `done` before the successful pause result.

3. Under JSP observation, have an agent call `todo_pause`. Confirm the observer moves to needs-you after control returns to the prompt. Submit another prompt and confirm the wait resolves before the new turn starts.

4. Let an agent finish normally without `todo_pause`. Confirm no `user_input` wait opens.

5. Completed local verification:

       npm run format
       npm run lint
       npm run typecheck
       npm run build
       npm run test
       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

   The full suite surfaced independent concurrency timeouts in the launcher and agent disposal tests. The exact launcher case passed in isolation; all four reported agent files passed individually; and the complete agents workspace passed on isolated rerun. All affected observation and AgenticLoop tests pass.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3071

Related: #3087
