### PR TITLE
Fix sandbox config mount path and repeated first-time setup (Fixes #3081)

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -245,13 +245,15 @@ In container mode, these paths are always mounted into the container:
 - The LLxprt Code global **configuration** directory (read-write). This is your
   platform-standard config directory (the same one resolved by
   `Storage.getGlobalConfigDir()`, e.g. `~/.config/llxprt-code` on Linux or
-  `~/Library/Preferences/llxprt-code` on macOS). It is mounted at the identical
-  path inside the container, and `LLXPRT_CONFIG_HOME` is pinned to that path so
-  the in-container CLI reads your `settings.json`, profiles, subagents, prompts,
-  commands, policies, hooks, global `LLXPRT.md`, `welcomeConfig.json`,
-  `trustedFolders.json` and user `skills/`. This directory holds a global `.env`
-  and profiles (`profiles/*.json`); a profile containing an inline `auth-key`, or
-  that `.env`, is therefore readable from inside the container. Prefer `/key save`
+  `~/Library/Preferences/llxprt-code` on macOS). It is mounted at the equivalent
+  path inside the container (on Windows hosts the mount destination is the
+  translated POSIX form, e.g. `C:\Users\me\...` becomes `/c/Users/me/...`), and
+  `LLXPRT_CONFIG_HOME` is pinned to that destination so the in-container CLI
+  reads your `settings.json`, profiles, subagents, prompts, commands, policies,
+  hooks, global `LLXPRT.md`, `welcomeConfig.json`, `trustedFolders.json` and
+  user `skills/`. This directory holds a global `.env` and profiles
+  (`profiles/*.json`); a profile containing an inline `auth-key`, or that
+  `.env`, is therefore readable from inside the container. Prefer `/key save`
   over inline profile keys — see issue
   [#2957](https://github.com/vybestack/llxprt-code/issues/2957).
 - Git configuration files, mounted read-only (see
@@ -264,7 +266,9 @@ In container mode, these paths are always mounted into the container:
 > only for the lifetime of a sandboxed session and are discarded when the
 > container exits. Anything written to them during a sandboxed session — including
 > freshly minted credentials — is lost on exit. Their container paths are pinned
-> with `LLXPRT_DATA_HOME`, `LLXPRT_CACHE_HOME` and `LLXPRT_LOG_HOME` so they stay
+> with `LLXPRT_DATA_HOME`, `LLXPRT_CACHE_HOME` and `LLXPRT_LOG_HOME` from the
+> container's _real_ HOME inside the sandbox entrypoint (so they follow the
+> sandbox image's default user home, including custom images), keeping them
 > separate from the mounted config directory. This is why you may need to
 > re-authenticate inside a sandbox: the credential proxy (`LLXPRT_CREDENTIAL_SOCKET`)
 > is the supported way to reach host secrets without bind-mounting credential files.
@@ -891,11 +895,12 @@ the container, removing a mandatory-access-control boundary. Use it only to
 diagnose a SELinux denial, then remove it so label enforcement is restored.
 
 **SSH not working in Podman on macOS** — use a stable socket path. The default
-launchd socket paths are unreliable. Set up a dedicated socket:
+launchd socket paths are unreliable. Set up a dedicated socket under a
+non-legacy location (such as `~/.ssh/` or `$XDG_RUNTIME_DIR`):
 
 ```bash
-ssh-agent -a ~/.llxprt/ssh-agent.sock
-export SSH_AUTH_SOCK=~/.llxprt/ssh-agent.sock
+ssh-agent -a ~/.ssh/ssh-agent.sock
+export SSH_AUTH_SOCK=~/.ssh/ssh-agent.sock
 ssh-add ~/.ssh/id_ed25519
 llxprt --sandbox-engine podman --sandbox-profile-load dev
 ```

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -242,13 +242,32 @@ In container mode, these paths are always mounted into the container:
 
 - Your project working directory (read-write)
 - The system temp directory (read-write)
-- The LLxprt Code settings directory (read-write). This directory holds your
-  profiles (`profiles/*.json`) and a global `.env`; a profile containing an
-  inline `auth-key`, or that `.env`, is therefore readable from inside the
-  container. Prefer `/key save` over inline profile keys — see issue
+- The LLxprt Code global **configuration** directory (read-write). This is your
+  platform-standard config directory (the same one resolved by
+  `Storage.getGlobalConfigDir()`, e.g. `~/.config/llxprt-code` on Linux or
+  `~/Library/Preferences/llxprt-code` on macOS). It is mounted at the identical
+  path inside the container, and `LLXPRT_CONFIG_HOME` is pinned to that path so
+  the in-container CLI reads your `settings.json`, profiles, subagents, prompts,
+  commands, policies, hooks, global `LLXPRT.md`, `welcomeConfig.json`,
+  `trustedFolders.json` and user `skills/`. This directory holds a global `.env`
+  and profiles (`profiles/*.json`); a profile containing an inline `auth-key`, or
+  that `.env`, is therefore readable from inside the container. Prefer `/key save`
+  over inline profile keys — see issue
   [#2957](https://github.com/vybestack/llxprt-code/issues/2957).
 - Git configuration files, mounted read-only (see
   [Git config passthrough](#git-config-passthrough))
+
+> **What is _not_ mounted:** only the configuration directory crosses the
+> boundary. The **data** directory (OAuth credentials, provider accounts,
+> installation id, conversations, history, todos), the **cache** directory, and
+> the **log/state** directory are _container-local and ephemeral_: they exist
+> only for the lifetime of a sandboxed session and are discarded when the
+> container exits. Anything written to them during a sandboxed session — including
+> freshly minted credentials — is lost on exit. Their container paths are pinned
+> with `LLXPRT_DATA_HOME`, `LLXPRT_CACHE_HOME` and `LLXPRT_LOG_HOME` so they stay
+> separate from the mounted config directory. This is why you may need to
+> re-authenticate inside a sandbox: the credential proxy (`LLXPRT_CREDENTIAL_SOCKET`)
+> is the supported way to reach host secrets without bind-mounting credential files.
 
 Additional paths are conditionally mounted based on your host environment and
 profile configuration:

--- a/docs/tutorials/sandbox-setup.md
+++ b/docs/tutorials/sandbox-setup.md
@@ -138,11 +138,12 @@ If keys appear, SSH passthrough is working.
 
 ### Podman on macOS: reliable socket setup
 
-If forwarding fails with launchd socket paths, switch to a dedicated socket:
+If forwarding fails with launchd socket paths, switch to a dedicated socket
+under a non-legacy location (such as `~/.ssh/` or `$XDG_RUNTIME_DIR`):
 
 ```bash
-ssh-agent -a ~/.llxprt/ssh-agent.sock
-export SSH_AUTH_SOCK=~/.llxprt/ssh-agent.sock
+ssh-agent -a ~/.ssh/ssh-agent.sock
+export SSH_AUTH_SOCK=~/.ssh/ssh-agent.sock
 ssh-add ~/.ssh/id_ed25519
 llxprt --sandbox-engine podman --sandbox-profile-load dev
 ```

--- a/packages/cli/src/config/pathMigration.profileRepair.test.ts
+++ b/packages/cli/src/config/pathMigration.profileRepair.test.ts
@@ -12,6 +12,7 @@ import {
   isMigrationComplete,
   repairProfiles,
   runStartupMigrationWithPath,
+  MIGRATION_MARKER_VERSION,
   type MigrationDestinations,
 } from './pathMigration.js';
 import {
@@ -530,7 +531,7 @@ describe('runStartupMigrationWithPath — marker orchestration', () => {
     fs.mkdirSync(env.destinations.dataDir, { recursive: true });
     fs.writeFileSync(
       path.join(env.destinations.dataDir, '.migration-complete.json'),
-      JSON.stringify({ version: 1 }),
+      JSON.stringify({ version: MIGRATION_MARKER_VERSION }),
     );
     setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
     const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
@@ -701,7 +702,7 @@ describe('runStartupMigrationWithPath — logging', () => {
     fs.mkdirSync(env.destinations.dataDir, { recursive: true });
     fs.writeFileSync(
       path.join(env.destinations.dataDir, '.migration-complete.json'),
-      JSON.stringify({ version: 1 }),
+      JSON.stringify({ version: MIGRATION_MARKER_VERSION }),
     );
     setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
     const writes: string[] = [];
@@ -727,7 +728,7 @@ describe('runStartupMigrationWithPath — logging', () => {
     fs.mkdirSync(env.destinations.dataDir, { recursive: true });
     fs.writeFileSync(
       path.join(env.destinations.dataDir, '.migration-complete.json'),
-      JSON.stringify({ version: 1 }),
+      JSON.stringify({ version: MIGRATION_MARKER_VERSION }),
     );
     setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
     const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);

--- a/packages/cli/src/config/pathMigration.test.ts
+++ b/packages/cli/src/config/pathMigration.test.ts
@@ -19,6 +19,7 @@ import {
   performMigration,
   isMigrationComplete,
   markMigrationComplete,
+  MIGRATION_MARKER_VERSION,
   type MigrationDestinations,
   type MigrationResult,
 } from './pathMigration.js';
@@ -212,7 +213,10 @@ describe('migration-completion marker (#2237)', () => {
   );
 
   it.each([
-    { name: 'current', marker: JSON.stringify({ version: 1 }) },
+    {
+      name: 'current',
+      marker: JSON.stringify({ version: MIGRATION_MARKER_VERSION }),
+    },
     { name: 'newer', marker: JSON.stringify({ version: 999 }) },
   ])(
     'treats a $name marker as complete without a rerun diagnostic',

--- a/packages/cli/src/config/pathMigration.ts
+++ b/packages/cli/src/config/pathMigration.ts
@@ -86,7 +86,7 @@ const TMP_SKILLS_DIR = 'skills';
 
 const MIGRATION_MARKER_FILE = '.migration-complete.json';
 
-export const MIGRATION_MARKER_VERSION = 2;
+export const MIGRATION_MARKER_VERSION = 1;
 
 const REPAIR_MARKER_FILE = '.profile-repair-complete.json';
 
@@ -317,8 +317,20 @@ function copyLegacyEntries(
   visited: Set<string>,
   errors: string[],
 ): number {
+  // Process entries in a deterministic, name-sorted order. Copy semantics are
+  // no-overwrite (COPYFILE_EXCL), so for a same-named collision the FIRST
+  // source to publish wins. Sorting guarantees the top-level `skills/` config
+  // entry is copied before the `tmp/` directory (whose `migrateTmpDir` routes
+  // `tmp/skills/` to the same `<config>/skills` destination), so an explicit
+  // precedence is defined: top-level `skills/` wins over `tmp/skills/`
+  // (#3081). Investigation: historically skills lived ONLY under
+  // `tmp/skills/` (a documented misplacement — skills are user configuration,
+  // not temporary state); no top-level legacy skills directory existed. The
+  // top-level `skills` CONFIG_ENTRIES entry is still correct because the
+  // canonical reader is `Storage.getUserSkillsDir()` = `<config>/skills`.
+  const sorted = [...entries].sort((a, b) => a.name.localeCompare(b.name));
   let filesCopied = 0;
-  for (const entry of entries) {
+  for (const entry of sorted) {
     const category = categorizeEntry(entry.name);
     if (category === 'exclude') {
       continue;

--- a/packages/cli/src/config/pathMigration.ts
+++ b/packages/cli/src/config/pathMigration.ts
@@ -49,6 +49,14 @@ const CONFIG_ENTRIES = new Set([
   '.env',
   'LLXPRT.md',
   '.LLXPRT_SYSTEM',
+  // Issue #3081: these are read from the CONFIG directory but were missing
+  // from this set, so the migration categorizer routed them to DATA instead.
+  // welcomeConfig.json — getWelcomeConfigPath (USER_SETTINGS_DIR)
+  // trustedFolders.json — getTrustedFoldersPath (USER_SETTINGS_DIR)
+  // skills — Storage.getUserSkillsDir() = <configDir>/skills
+  'welcomeConfig.json',
+  'trustedFolders.json',
+  'skills',
 ]);
 
 const DATA_ENTRIES = new Set([
@@ -78,7 +86,7 @@ const TMP_SKILLS_DIR = 'skills';
 
 const MIGRATION_MARKER_FILE = '.migration-complete.json';
 
-const MIGRATION_MARKER_VERSION = 1;
+export const MIGRATION_MARKER_VERSION = 2;
 
 const REPAIR_MARKER_FILE = '.profile-repair-complete.json';
 

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -550,13 +550,35 @@ function volumeDestinations(args: readonly string[]): string[] {
   const dests: string[] = [];
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--volume' && i + 1 < args.length) {
-      const parts = args[i + 1].split(':');
-      // [host, dest] or [host, dest, options]
-      if (parts.length >= 2) dests.push(parts[1]);
+      const volume = args[i + 1];
+      const sourceEnd = volume.indexOf(
+        ':',
+        /^[A-Za-z]:[\\/]/.test(volume) ? 2 : 0,
+      );
+      if (sourceEnd === -1) continue;
+      const destinationAndOptions = volume.slice(sourceEnd + 1);
+      const optionStart = destinationAndOptions.indexOf(':');
+      dests.push(
+        destinationAndOptions.slice(
+          0,
+          optionStart === -1 ? undefined : optionStart,
+        ),
+      );
     }
   }
   return dests;
 }
+
+describe('volumeDestinations', () => {
+  it('extracts the destination from a Windows host path', () => {
+    expect(
+      volumeDestinations([
+        '--volume',
+        'C:\\Users\\me\\config:/c/Users/me/config:z',
+      ]),
+    ).toEqual(['/c/Users/me/config']);
+  });
+});
 
 function envValue(args: readonly string[], name: string): string | undefined {
   for (let i = 0; i < args.length; i++) {

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -18,8 +18,12 @@ import {
   addContainerEnvVars,
   addContainerVolumeMounts,
 } from './sandbox-containers.js';
-import { getContainerPath } from './sandbox-env.js';
-import { USER_SETTINGS_DIR } from '../config/settings.js';
+import {
+  getContainerPath,
+  resolveSandboxContainerHome,
+} from './sandbox-env.js';
+import { entrypoint } from './sandbox-entrypoint.js';
+import { Storage } from '@vybestack/llxprt-code-storage';
 
 // Explicit factory mock: Bun's automock walks every export of
 // node:child_process and hits getters that access private fields
@@ -563,6 +567,42 @@ function envValue(args: readonly string[], name: string): string | undefined {
   return undefined;
 }
 
+function countEnv(args: readonly string[], name: string): number {
+  let count = 0;
+  for (let i = 0; i < args.length; i++) {
+    if (
+      args[i] === '--env' &&
+      i + 1 < args.length &&
+      args[i + 1].startsWith(`${name}=`)
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function entrypointScript(workdir: string): string {
+  // The final element of entrypoint()'s returned argv is the shell script the
+  // container runs. cliArgs is [cli, subcommand, ...userArgs].
+  return String(entrypoint(workdir, ['llxprt', 'chat']).at(-1));
+}
+
+function xdgDefaultFromScript(script: string, name: string): string {
+  // Extracts the value from `export NAME="VALUE"`. Uses string indexOf so the
+  // $/${} metacharacters need no escaping.
+  const prefix = 'export ' + name + '="';
+  const start = script.indexOf(prefix);
+  if (start === -1) {
+    throw new Error(`${name} export not found in entrypoint script`);
+  }
+  const valueStart = start + prefix.length;
+  const end = script.indexOf('"', valueStart);
+  if (end === -1) {
+    throw new Error(`${name} export not found in entrypoint script`);
+  }
+  return script.slice(valueStart, end);
+}
+
 const CANONICAL_CONFIG_MOUNT_ENV_KEYS = [
   'SANDBOX_SET_UID_GID',
   'LLXPRT_CONFIG_HOME',
@@ -581,12 +621,13 @@ describe.sequential('#3081 canonical config mount + env pinning', () => {
     vi.resetAllMocks();
     vi.mocked(childProcess.execSync).mockReturnValue(Buffer.from(''));
     // Force the non-current-user path deterministically: the Debian/Ubuntu
-    // auto-detect makes shouldUseCurrentUserInSandboxSync return true on some
+    // auto-detect makes shouldUseCurrentUserInSandbox return true on some
     // CI hosts. containerHome is then /home/node regardless of host.
     process.env.SANDBOX_SET_UID_GID = 'false';
     for (const key of CANONICAL_CONFIG_MOUNT_ENV_KEYS) {
       if (key !== 'SANDBOX_SET_UID_GID') delete process.env[key];
     }
+    delete process.env.SANDBOX_ENV;
   });
 
   afterEach(() => {
@@ -597,66 +638,178 @@ describe.sequential('#3081 canonical config mount + env pinning', () => {
     }
   });
 
-  it('mounts the host config dir at path parity (the canonical destination)', () => {
+  it('mounts the config dir at path parity and emits no legacy dot-llxprt destination', () => {
     const args = buildArgs(fixturePath);
-    const hostConfigDir = USER_SETTINGS_DIR;
+    const hostConfigDir = Storage.getGlobalConfigDir();
     const containerConfigDir = getContainerPath(hostConfigDir);
 
+    // The canonical mount is present at path parity...
     expect(args).toContain('--volume');
     expect(args).toContain(`${hostConfigDir}:${containerConfigDir}`);
-  });
-
-  it('emits no --volume destination ending in the legacy /.llxprt', () => {
-    const args = buildArgs(fixturePath);
-
+    // ...and the legacy destination is gone from every volume destination.
     const dests = volumeDestinations(args);
     expect(dests.every((d) => !d.endsWith('/.llxprt'))).toBe(true);
   });
 
   it('pins LLXPRT_CONFIG_HOME to the config mount destination', () => {
     const args = buildArgs(fixturePath);
-    const containerConfigDir = getContainerPath(USER_SETTINGS_DIR);
+    const containerConfigDir = getContainerPath(Storage.getGlobalConfigDir());
 
     expect(envValue(args, 'LLXPRT_CONFIG_HOME')).toBe(containerConfigDir);
   });
 
-  it('pins DATA/CACHE/LOG homes pairwise distinct and outside the config mount', () => {
-    const args = buildArgs(fixturePath);
-    const configMount = getContainerPath(USER_SETTINGS_DIR);
+  it('pins DATA/CACHE/LOG homes from the container HOME inside the entrypoint', () => {
+    // After fix #4 the three ephemeral roots are exported from $HOME inside
+    // the entrypoint (not passed as --env from the host), so they follow the
+    // image's real container HOME. Verify the entrypoint script carries all
+    // three exports with the correct distinct $HOME-relative suffixes.
+    const script = entrypointScript(fixturePath);
+    const data = xdgDefaultFromScript(script, 'LLXPRT_DATA_HOME');
+    const cache = xdgDefaultFromScript(script, 'LLXPRT_CACHE_HOME');
+    const log = xdgDefaultFromScript(script, 'LLXPRT_LOG_HOME');
 
-    const data = envValue(args, 'LLXPRT_DATA_HOME');
-    const cache = envValue(args, 'LLXPRT_CACHE_HOME');
-    const log = envValue(args, 'LLXPRT_LOG_HOME');
-    expect(data).toBeDefined();
-    expect(cache).toBeDefined();
-    expect(log).toBeDefined();
-    expect(data).not.toBe(cache);
-    expect(data).not.toBe(log);
-    expect(cache).not.toBe(log);
-    // None of the ephemeral roots may resolve inside the mounted config dir,
-    // otherwise data/cache/logs would be persisted back to the host config.
-    for (const root of [data, cache, log]) {
-      expect(root?.startsWith(`${configMount}/`)).toBe(false);
-      expect(root).not.toBe(configMount);
+    expect(data).toBe('$HOME/.local/share/llxprt-code');
+    expect(cache).toBe('$HOME/.cache/llxprt-code');
+    expect(log).toBe('$HOME/.local/state/llxprt-code');
+    // Pairwise distinct, so data/cache/log never collapse into one directory.
+    expect(new Set([data, cache, log]).size).toBe(3);
+  });
+
+  it('does not emit DATA/CACHE/LOG homes as --env from the host', () => {
+    // They moved to the entrypoint; none may appear in the host-built argv.
+    const args = buildArgs(fixturePath);
+    expect(envValue(args, 'LLXPRT_DATA_HOME')).toBeUndefined();
+    expect(envValue(args, 'LLXPRT_CACHE_HOME')).toBeUndefined();
+    expect(envValue(args, 'LLXPRT_LOG_HOME')).toBeUndefined();
+  });
+
+  it('drives the config mount from LLXPRT_CONFIG_HOME at call time (regression for frozen constant)', () => {
+    // Fix #3 made the config dir read dynamically; setting the env var must
+    // actually change the emitted mount (it was inert against the frozen
+    // module-load-time constant before). Use a DISTINCT temp dir so the value
+    // is absolute, valid and provably different from the workdir/tmpdir mount.
+    const configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-3081-'));
+    process.env.LLXPRT_CONFIG_HOME = configHome;
+    try {
+      const args = buildArgs(fixturePath);
+      const expectedContainer = getContainerPath(configHome);
+
+      expect(args).toContain(`${configHome}:${expectedContainer}`);
+      expect(envValue(args, 'LLXPRT_CONFIG_HOME')).toBe(expectedContainer);
+    } finally {
+      delete process.env.LLXPRT_CONFIG_HOME;
+      fs.rmSync(configHome, { recursive: true, force: true });
     }
   });
 
-  it('produces no duplicate --volume destination', () => {
-    // Simulate the host collapsing all four roots to one config dir.
-    process.env.LLXPRT_CONFIG_HOME = fixturePath;
+  it('covers the resolved config dir with an emitted --volume destination', () => {
+    // The original bug: the destination the CLI resolved inside the container
+    // was NOT covered by any --volume mount. Compute the expectation via the
+    // REAL resolver (independent of the argv the function just produced), then
+    // assert the resolver's answer is present among the volume destinations.
     const args = buildArgs(fixturePath);
-
-    const dests = volumeDestinations(args);
-    expect(new Set(dests).size).toBe(dests.length);
+    const emitted = envValue(args, 'LLXPRT_CONFIG_HOME');
+    expect(emitted).toBeDefined();
+    process.env.LLXPRT_CONFIG_HOME = emitted;
+    const resolved = Storage.getGlobalConfigDir();
+    expect(volumeDestinations(args)).toContain(resolved);
   });
 
-  it('covers the resolved config dir with an emitted --volume destination (regression)', () => {
-    // The bug: the destination the CLI resolved inside the container
-    // (/home/node/.config/llxprt-code) was NOT covered by any --volume mount.
+  it('emitted LLXPRT_CONFIG_HOME satisfies Storage.isNonEmptyAbsoluteOverride', () => {
+    // That override check is what short-circuits the phantom in-container
+    // startup migration. Pin it so a non-absolute / relative value would fail.
     const args = buildArgs(fixturePath);
-    const resolvedConfigDir = envValue(args, 'LLXPRT_CONFIG_HOME');
+    const emitted = envValue(args, 'LLXPRT_CONFIG_HOME');
+    expect(emitted).toBeDefined();
+    expect(Storage.isNonEmptyAbsoluteOverride(emitted)).toBe(true);
+  });
 
-    expect(resolvedConfigDir).toBeDefined();
-    expect(volumeDestinations(args)).toContain(resolvedConfigDir);
+  it('emits exactly one --env LLXPRT_CONFIG_HOME even when SANDBOX_ENV also names it', () => {
+    process.env.SANDBOX_ENV =
+      'FOO=bar,LLXPRT_CONFIG_HOME=/evil/override,BAZ=qux';
+    const args = buildArgs(fixturePath);
+    // addContainerEnvVars runs after buildContainerRunArgs in the real flow.
+    addContainerEnvVars(args, ENV_CONFIG, 'test-container', [], '/workspace');
+
+    expect(countEnv(args, 'LLXPRT_CONFIG_HOME')).toBe(1);
+    // The surviving value is the mount destination, not the SANDBOX_ENV one.
+    expect(envValue(args, 'LLXPRT_CONFIG_HOME')).toBe(
+      getContainerPath(Storage.getGlobalConfigDir()),
+    );
+  });
+
+  it('translates Windows host paths: no backslash in emitted config home or entrypoint roots', () => {
+    // With the host platform stubbed to win32, every emitted LLXPRT_*_HOME
+    // value must be POSIX (no backslashes); the /c/... translation form is
+    // pinned directly against getContainerPath in sandbox-env.bun.ts.
+    vi.spyOn(os, 'platform').mockReturnValue('win32');
+    const args = buildArgs(fixturePath);
+
+    const configHome = envValue(args, 'LLXPRT_CONFIG_HOME');
+    expect(configHome).toBeDefined();
+    expect(configHome).not.toMatch(/\\/);
+    const script = entrypointScript(fixturePath);
+    for (const name of [
+      'LLXPRT_DATA_HOME',
+      'LLXPRT_CACHE_HOME',
+      'LLXPRT_LOG_HOME',
+    ]) {
+      expect(xdgDefaultFromScript(script, name)).not.toMatch(/\\/);
+    }
+  });
+});
+
+describe.sequential('#3081 current-user container-home agreement', () => {
+  let environmentSnapshot: NodeJS.ProcessEnv;
+  let fixturePath = '';
+
+  beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), 'container-3081-cu-'));
+    vi.resetAllMocks();
+    vi.mocked(childProcess.execSync).mockReturnValue(Buffer.from(''));
+    process.env.SANDBOX_SET_UID_GID = '1';
+    for (const key of CANONICAL_CONFIG_MOUNT_ENV_KEYS) {
+      if (key !== 'SANDBOX_SET_UID_GID') delete process.env[key];
+    }
+    delete process.env.SANDBOX_ENV;
+  });
+
+  afterEach(() => {
+    process.env = environmentSnapshot;
+    vi.restoreAllMocks();
+    if (fixturePath !== '') {
+      fs.rmSync(fixturePath, { recursive: true, force: true });
+    }
+  });
+
+  it('pins HOME and the entrypoint ephemeral roots to the host home, keeping CONFIG_HOME on the mount', async () => {
+    const args = buildArgs(fixturePath);
+    // Capture the clean entrypoint script before setupContainerUser wraps it
+    // in `su -p`; its $HOME-relative exports are what the exec'd CLI inherits.
+    const finalEntrypoint = entrypoint(fixturePath, ['llxprt', 'chat']);
+    const cleanScript = String(finalEntrypoint.at(-1));
+    await setupContainerUser(args, finalEntrypoint);
+
+    const home = envValue(args, 'HOME');
+    const expectedHome = resolveSandboxContainerHome();
+    expect(home).toBe(expectedHome);
+    expect(expectedHome).toBe(getContainerPath(os.homedir()));
+
+    // The three ephemeral roots are derived from that HOME, so the HOME pinned
+    // here and the entrypoint's $HOME-relative defaults can never disagree.
+    expect(cleanScript).toContain('$HOME/.local/share/llxprt-code');
+    expect(cleanScript).toContain('$HOME/.cache/llxprt-code');
+    expect(cleanScript).toContain('$HOME/.local/state/llxprt-code');
+
+    // LLXPRT_CONFIG_HOME still points at the config bind mount, not the home.
+    const configHome = envValue(args, 'LLXPRT_CONFIG_HOME');
+    expect(configHome).toBe(getContainerPath(Storage.getGlobalConfigDir()));
+    expect(volumeDestinations(args)).toContain(configHome);
+
+    // The current-user branch was actually taken (the other branch is covered
+    // by the #3081 canonical config mount describe above).
+    expect(args).toContain('--user');
+    expect(args[args.indexOf('--user') + 1]).toBe('root');
   });
 });

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -18,6 +18,7 @@ import {
   addContainerEnvVars,
   addContainerVolumeMounts,
 } from './sandbox-containers.js';
+import { runContainerSandbox } from './sandbox-exec.js';
 import {
   getContainerPath,
   resolveSandboxContainerHome,
@@ -567,20 +568,6 @@ function envValue(args: readonly string[], name: string): string | undefined {
   return undefined;
 }
 
-function countEnv(args: readonly string[], name: string): number {
-  let count = 0;
-  for (let i = 0; i < args.length; i++) {
-    if (
-      args[i] === '--env' &&
-      i + 1 < args.length &&
-      args[i + 1].startsWith(`${name}=`)
-    ) {
-      count++;
-    }
-  }
-  return count;
-}
-
 function entrypointScript(workdir: string): string {
   // The final element of entrypoint()'s returned argv is the shell script the
   // container runs. cliArgs is [cli, subcommand, ...userArgs].
@@ -724,31 +711,33 @@ describe.sequential('#3081 canonical config mount + env pinning', () => {
     expect(Storage.isNonEmptyAbsoluteOverride(emitted)).toBe(true);
   });
 
-  it('rejects a SANDBOX_ENV override of the pinned LLXPRT_CONFIG_HOME', () => {
-    process.env.SANDBOX_ENV =
-      'FOO=bar,LLXPRT_CONFIG_HOME=/evil/override,BAZ=qux';
+  it.each([
+    'LLXPRT_CONFIG_HOME',
+    'LLXPRT_DATA_HOME',
+    'LLXPRT_CACHE_HOME',
+    'LLXPRT_LOG_HOME',
+  ])('rejects a SANDBOX_ENV override of pinned %s', (reservedKey) => {
+    process.env.SANDBOX_ENV = `FOO=bar,${reservedKey}=/evil/override,BAZ=qux`;
     const args = buildArgs(fixturePath);
 
     // addContainerEnvVars runs after buildContainerRunArgs in the real flow.
     expect(() =>
-      addContainerEnvVars(
-        args,
-        ENV_CONFIG,
-        'test-container',
-        [],
-        '/workspace',
-      ),
+      addContainerEnvVars(args, ENV_CONFIG, 'test-container', [], '/workspace'),
     ).toThrowError(FatalSandboxError);
     expect(() =>
-      addContainerEnvVars(
-        args,
-        ENV_CONFIG,
-        'test-container',
-        [],
-        '/workspace',
-      ),
-    ).toThrowError(/may not override reserved key 'LLXPRT_CONFIG_HOME'/);
-    expect(countEnv(args, 'LLXPRT_CONFIG_HOME')).toBe(1);
+      addContainerEnvVars(args, ENV_CONFIG, 'test-container', [], '/workspace'),
+    ).toThrowError(
+      new RegExp(`may not override reserved key '${reservedKey}'`),
+    );
+  });
+
+  it('rejects reserved SANDBOX_ENV before image or network side effects', async () => {
+    process.env.SANDBOX_ENV = 'LLXPRT_CONFIG_HOME=/evil/override';
+
+    await expect(runContainerSandbox(CONFIG, [])).rejects.toThrowError(
+      /may not override reserved key 'LLXPRT_CONFIG_HOME'/,
+    );
+    expect(vi.mocked(childProcess.execSync)).not.toHaveBeenCalled();
   });
 
   it('translates Windows host paths: no backslash in emitted config home or entrypoint roots', () => {

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -724,18 +724,31 @@ describe.sequential('#3081 canonical config mount + env pinning', () => {
     expect(Storage.isNonEmptyAbsoluteOverride(emitted)).toBe(true);
   });
 
-  it('emits exactly one --env LLXPRT_CONFIG_HOME even when SANDBOX_ENV also names it', () => {
+  it('rejects a SANDBOX_ENV override of the pinned LLXPRT_CONFIG_HOME', () => {
     process.env.SANDBOX_ENV =
       'FOO=bar,LLXPRT_CONFIG_HOME=/evil/override,BAZ=qux';
     const args = buildArgs(fixturePath);
-    // addContainerEnvVars runs after buildContainerRunArgs in the real flow.
-    addContainerEnvVars(args, ENV_CONFIG, 'test-container', [], '/workspace');
 
+    // addContainerEnvVars runs after buildContainerRunArgs in the real flow.
+    expect(() =>
+      addContainerEnvVars(
+        args,
+        ENV_CONFIG,
+        'test-container',
+        [],
+        '/workspace',
+      ),
+    ).toThrowError(FatalSandboxError);
+    expect(() =>
+      addContainerEnvVars(
+        args,
+        ENV_CONFIG,
+        'test-container',
+        [],
+        '/workspace',
+      ),
+    ).toThrowError(/may not override reserved key 'LLXPRT_CONFIG_HOME'/);
     expect(countEnv(args, 'LLXPRT_CONFIG_HOME')).toBe(1);
-    // The surviving value is the mount destination, not the SANDBOX_ENV one.
-    expect(envValue(args, 'LLXPRT_CONFIG_HOME')).toBe(
-      getContainerPath(Storage.getGlobalConfigDir()),
-    );
   });
 
   it('translates Windows host paths: no backslash in emitted config home or entrypoint roots', () => {

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -576,7 +576,7 @@ describe('volumeDestinations', () => {
         '--volume',
         'C:\\Users\\me\\config:/c/Users/me/config:z',
       ]),
-    ).toEqual(['/c/Users/me/config']);
+    ).toStrictEqual(['/c/Users/me/config']);
   });
 });
 

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -18,6 +18,8 @@ import {
   addContainerEnvVars,
   addContainerVolumeMounts,
 } from './sandbox-containers.js';
+import { getContainerPath } from './sandbox-env.js';
+import { USER_SETTINGS_DIR } from '../config/settings.js';
 
 // Explicit factory mock: Bun's automock walks every export of
 // node:child_process and hits getters that access private fields
@@ -533,5 +535,128 @@ describe.sequential('#2902 sandbox privilege hardening', () => {
     const userIdx = proxyArgs.indexOf('--user');
     expect(userIdx).toBeGreaterThanOrEqual(0);
     expect(proxyArgs[userIdx + 1]).toBe('501:20');
+  });
+});
+
+// Parsing helpers that operate on the produced docker argv. They look only at
+// the real buildContainerRunArgs output — no mocks — so the assertions pin the
+// observable container behaviour, not a stub's call arguments.
+function volumeDestinations(args: readonly string[]): string[] {
+  const dests: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--volume' && i + 1 < args.length) {
+      const parts = args[i + 1].split(':');
+      // [host, dest] or [host, dest, options]
+      if (parts.length >= 2) dests.push(parts[1]);
+    }
+  }
+  return dests;
+}
+
+function envValue(args: readonly string[], name: string): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--env' && i + 1 < args.length) {
+      const pair = args[i + 1];
+      if (pair.startsWith(`${name}=`)) return pair.slice(name.length + 1);
+    }
+  }
+  return undefined;
+}
+
+const CANONICAL_CONFIG_MOUNT_ENV_KEYS = [
+  'SANDBOX_SET_UID_GID',
+  'LLXPRT_CONFIG_HOME',
+  'LLXPRT_DATA_HOME',
+  'LLXPRT_CACHE_HOME',
+  'LLXPRT_LOG_HOME',
+] as const;
+
+describe.sequential('#3081 canonical config mount + env pinning', () => {
+  let environmentSnapshot: NodeJS.ProcessEnv;
+  let fixturePath = '';
+
+  beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), 'container-3081-'));
+    vi.resetAllMocks();
+    vi.mocked(childProcess.execSync).mockReturnValue(Buffer.from(''));
+    // Force the non-current-user path deterministically: the Debian/Ubuntu
+    // auto-detect makes shouldUseCurrentUserInSandboxSync return true on some
+    // CI hosts. containerHome is then /home/node regardless of host.
+    process.env.SANDBOX_SET_UID_GID = 'false';
+    for (const key of CANONICAL_CONFIG_MOUNT_ENV_KEYS) {
+      if (key !== 'SANDBOX_SET_UID_GID') delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.env = environmentSnapshot;
+    vi.restoreAllMocks();
+    if (fixturePath !== '') {
+      fs.rmSync(fixturePath, { recursive: true, force: true });
+    }
+  });
+
+  it('mounts the host config dir at path parity (the canonical destination)', () => {
+    const args = buildArgs(fixturePath);
+    const hostConfigDir = USER_SETTINGS_DIR;
+    const containerConfigDir = getContainerPath(hostConfigDir);
+
+    expect(args).toContain('--volume');
+    expect(args).toContain(`${hostConfigDir}:${containerConfigDir}`);
+  });
+
+  it('emits no --volume destination ending in the legacy /.llxprt', () => {
+    const args = buildArgs(fixturePath);
+
+    const dests = volumeDestinations(args);
+    expect(dests.every((d) => !d.endsWith('/.llxprt'))).toBe(true);
+  });
+
+  it('pins LLXPRT_CONFIG_HOME to the config mount destination', () => {
+    const args = buildArgs(fixturePath);
+    const containerConfigDir = getContainerPath(USER_SETTINGS_DIR);
+
+    expect(envValue(args, 'LLXPRT_CONFIG_HOME')).toBe(containerConfigDir);
+  });
+
+  it('pins DATA/CACHE/LOG homes pairwise distinct and outside the config mount', () => {
+    const args = buildArgs(fixturePath);
+    const configMount = getContainerPath(USER_SETTINGS_DIR);
+
+    const data = envValue(args, 'LLXPRT_DATA_HOME');
+    const cache = envValue(args, 'LLXPRT_CACHE_HOME');
+    const log = envValue(args, 'LLXPRT_LOG_HOME');
+    expect(data).toBeDefined();
+    expect(cache).toBeDefined();
+    expect(log).toBeDefined();
+    expect(data).not.toBe(cache);
+    expect(data).not.toBe(log);
+    expect(cache).not.toBe(log);
+    // None of the ephemeral roots may resolve inside the mounted config dir,
+    // otherwise data/cache/logs would be persisted back to the host config.
+    for (const root of [data, cache, log]) {
+      expect(root?.startsWith(`${configMount}/`)).toBe(false);
+      expect(root).not.toBe(configMount);
+    }
+  });
+
+  it('produces no duplicate --volume destination', () => {
+    // Simulate the host collapsing all four roots to one config dir.
+    process.env.LLXPRT_CONFIG_HOME = fixturePath;
+    const args = buildArgs(fixturePath);
+
+    const dests = volumeDestinations(args);
+    expect(new Set(dests).size).toBe(dests.length);
+  });
+
+  it('covers the resolved config dir with an emitted --volume destination (regression)', () => {
+    // The bug: the destination the CLI resolved inside the container
+    // (/home/node/.config/llxprt-code) was NOT covered by any --volume mount.
+    const args = buildArgs(fixturePath);
+    const resolvedConfigDir = envValue(args, 'LLXPRT_CONFIG_HOME');
+
+    expect(resolvedConfigDir).toBeDefined();
+    expect(volumeDestinations(args)).toContain(resolvedConfigDir);
   });
 });

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -279,10 +279,9 @@ function pushSandboxEnvEntry(args: string[], env: string): void {
   const eqIdx = env.indexOf('=');
   const envName = env.substring(0, eqIdx);
   if (RESERVED_SANDBOX_ENV_KEYS.has(envName)) {
-    debugLogger.log(
-      `SANDBOX_ENV: ignoring reserved key '${envName}' (pinned by sandbox infrastructure)`,
+    throw new FatalSandboxError(
+      `SANDBOX_ENV may not override reserved key '${envName}' (pinned by sandbox infrastructure)`,
     );
-    return;
   }
   debugLogger.log(`SANDBOX_ENV: ${envName}=<redacted>`);
   args.push('--env', env);

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -270,29 +270,40 @@ const RESERVED_SANDBOX_ENV_KEYS = new Set([
   'LLXPRT_LOG_HOME',
 ]);
 
-function pushSandboxEnvEntry(args: string[], env: string): void {
-  if (!env.includes('=')) {
-    throw new FatalSandboxError(
-      'SANDBOX_ENV must be a comma-separated list of key=value pairs',
-    );
+function parseSandboxEnvVars(): string[] {
+  const entries: string[] = [];
+  for (const raw of process.env.SANDBOX_ENV?.split(',') ?? []) {
+    const env = raw.trim();
+    if (env === '') {
+      continue;
+    }
+    if (!env.includes('=')) {
+      throw new FatalSandboxError(
+        'SANDBOX_ENV must be a comma-separated list of key=value pairs',
+      );
+    }
+    const envName = env.substring(0, env.indexOf('='));
+    if (RESERVED_SANDBOX_ENV_KEYS.has(envName)) {
+      throw new FatalSandboxError(
+        `SANDBOX_ENV may not override reserved key '${envName}' (pinned by sandbox infrastructure)`,
+      );
+    }
+    entries.push(env);
   }
-  const eqIdx = env.indexOf('=');
-  const envName = env.substring(0, eqIdx);
-  if (RESERVED_SANDBOX_ENV_KEYS.has(envName)) {
-    throw new FatalSandboxError(
-      `SANDBOX_ENV may not override reserved key '${envName}' (pinned by sandbox infrastructure)`,
-    );
-  }
-  debugLogger.log(`SANDBOX_ENV: ${envName}=<redacted>`);
-  args.push('--env', env);
+  return entries;
+}
+
+/** Validates SANDBOX_ENV before sandbox image, network, or bridge side effects. */
+export function validateContainerSandboxEnv(): void {
+  parseSandboxEnvVars();
 }
 
 function addSandboxEnvVars(args: string[]): void {
-  for (const raw of process.env.SANDBOX_ENV!.split(',')) {
-    const env = raw.trim();
-    if (env !== '') {
-      pushSandboxEnvEntry(args, env);
-    }
+  const entries = parseSandboxEnvVars();
+  for (const env of entries) {
+    const envName = env.substring(0, env.indexOf('='));
+    debugLogger.log(`SANDBOX_ENV: ${envName}=<redacted>`);
+    args.push('--env', env);
   }
 }
 

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -33,6 +33,7 @@ import {
   isSandboxDebugModeEnabled,
   shouldAllocateSandboxTty,
   shouldUseCurrentUserInSandbox,
+  resolveSandboxContainerHome,
   parseImageName,
   sandboxPorts,
   resolveDebugPort,
@@ -184,20 +185,34 @@ export function buildContainerRunArgs(
   }
   if (shouldAllocateSandboxTty()) args.push('-t');
   args.push('--volume', `${workdir}:${containerWorkdir}`);
-  const userSettingsDirOnHost = USER_SETTINGS_DIR;
-  const userSettingsDirInSandbox = getContainerPath(
-    `/home/node/${SETTINGS_DIRECTORY_NAME}`,
+  // Issue #3081: mount the host config directory at path parity and pin all
+  // four canonical roots via env overrides. The legacy /home/node/.llxprt
+  // destination is dropped: the in-container CLI resolves its config through
+  // Storage to /home/node/.config/llxprt-code, so nothing was mounted where
+  // it looks and every sandboxed launch saw an empty config. Setting
+  // LLXPRT_CONFIG_HOME also short-circuits the in-container startup
+  // migration. Data/cache/log stay container-local (ephemeral); only the
+  // config directory crosses the boundary, unchanged from before — mounting
+  // the data directory would push raw OAuth/provider credentials across the
+  // sandbox boundary (#2946). All four roots must be pinned because
+  // resolveGlobalDataDir/CacheDir/LogDir fall back to LLXPRT_CONFIG_HOME.
+  const hostConfigDir = USER_SETTINGS_DIR;
+  const containerConfigDir = getContainerPath(hostConfigDir);
+  if (!fs.existsSync(hostConfigDir)) {
+    fs.mkdirSync(hostConfigDir, { recursive: true });
+  }
+  args.push('--volume', `${hostConfigDir}:${containerConfigDir}`);
+  const containerHome = resolveSandboxContainerHome();
+  args.push(
+    '--env',
+    `LLXPRT_CONFIG_HOME=${containerConfigDir}`,
+    '--env',
+    `LLXPRT_DATA_HOME=${path.posix.join(containerHome, '.local/share/llxprt-code')}`,
+    '--env',
+    `LLXPRT_CACHE_HOME=${path.posix.join(containerHome, '.cache/llxprt-code')}`,
+    '--env',
+    `LLXPRT_LOG_HOME=${path.posix.join(containerHome, '.local/state/llxprt-code')}`,
   );
-  if (!fs.existsSync(userSettingsDirOnHost)) {
-    fs.mkdirSync(userSettingsDirOnHost);
-  }
-  args.push('--volume', `${userSettingsDirOnHost}:${userSettingsDirInSandbox}`);
-  if (userSettingsDirInSandbox !== userSettingsDirOnHost) {
-    args.push(
-      '--volume',
-      `${userSettingsDirOnHost}:${getContainerPath(userSettingsDirOnHost)}`,
-    );
-  }
   mountGitConfigFiles(args, os.homedir(), '/home/node');
   args.push(
     '--volume',
@@ -426,7 +441,9 @@ export async function setupContainerUser(
     const gid = execSync('id -g').toString().trim();
 
     const username = 'gemini';
-    const homeDir = getContainerPath(os.homedir());
+    // Use the shared container-home resolution so the HOME pinned here and the
+    // LLXPRT_*_HOME roots set by buildContainerRunArgs agree (#3081).
+    const homeDir = resolveSandboxContainerHome();
     const setupUserCommands = [
       `groupadd -f -g ${gid} ${username}`,
       `id -u ${username} &>/dev/null || useradd -o -u ${uid} -g ${gid} -d ${homeDir} -s /bin/bash ${username}`,
@@ -454,7 +471,7 @@ export async function setupContainerUser(
       'fi',
     ].join('\n');
     userFlag = `--user ${uid}:${gid}`;
-    args.push('--env', `HOME=${os.homedir()}`);
+    args.push('--env', `HOME=${homeDir}`);
   }
 
   return userFlag;

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -22,10 +22,7 @@ import {
   createHostOnlyCapabilityEnvFile,
   runCapabilityCleanupStep,
 } from './sandbox-capability.js';
-import {
-  USER_SETTINGS_DIR,
-  SETTINGS_DIRECTORY_NAME,
-} from '../config/settings.js';
+import { SETTINGS_DIRECTORY_NAME } from '../config/settings.js';
 import {
   getContainerPath,
   mountGitConfigFiles,
@@ -49,6 +46,7 @@ import {
   getProxySocketPath,
   getProxyCapabilityToken,
 } from '@vybestack/llxprt-code-providers/auth.js';
+import { Storage } from '@vybestack/llxprt-code-storage';
 
 const execAsync = promisify(exec);
 
@@ -185,35 +183,36 @@ export function buildContainerRunArgs(
   }
   if (shouldAllocateSandboxTty()) args.push('-t');
   args.push('--volume', `${workdir}:${containerWorkdir}`);
-  // Issue #3081: mount the host config directory at path parity and pin all
-  // four canonical roots via env overrides. The legacy /home/node/.llxprt
-  // destination is dropped: the in-container CLI resolves its config through
-  // Storage to /home/node/.config/llxprt-code, so nothing was mounted where
-  // it looks and every sandboxed launch saw an empty config. Setting
+  // Issue #3081: mount the host config directory at path parity and pin
+  // LLXPRT_CONFIG_HOME to the mount destination. The legacy dot-llxprt
+  // destination under the container home was dropped: the in-container CLI
+  // resolves its config through Storage, so nothing was mounted where it
+  // looks and every sandboxed launch saw an empty config. Pinning
   // LLXPRT_CONFIG_HOME also short-circuits the in-container startup
-  // migration. Data/cache/log stay container-local (ephemeral); only the
-  // config directory crosses the boundary, unchanged from before — mounting
-  // the data directory would push raw OAuth/provider credentials across the
-  // sandbox boundary (#2946). All four roots must be pinned because
-  // resolveGlobalDataDir/CacheDir/LogDir fall back to LLXPRT_CONFIG_HOME.
-  const hostConfigDir = USER_SETTINGS_DIR;
+  // migration. The host dir is resolved dynamically through Storage (not the
+  // module-load-time constant) so the legacy-fallback path in cli.tsx that
+  // sets LLXPRT_CONFIG_HOME at runtime is honoured by the mount too. The
+  // startup lifecycle (cli.tsx) creates this directory long before any
+  // sandbox launch, so no defensive mkdir is needed here. Data/cache/log
+  // stay container-local (ephemeral); only the config directory crosses the
+  // boundary — mounting the data directory would push raw OAuth/provider
+  // credentials across the sandbox boundary (#2946). Their roots are pinned
+  // from the real container HOME inside the entrypoint (sandbox-entrypoint.ts)
+  // so they follow the image's default user home; they cannot be left unset
+  // because resolveGlobalDataDir/CacheDir/LogDir fall back to
+  // LLXPRT_CONFIG_HOME. The config mount needs the :z SELinux shared label
+  // under podman (matching the SSH-agent socket mount in setupSshAgentLinux)
+  // so a labelled container process can read/write it on SELinux hosts.
+  const hostConfigDir = Storage.getGlobalConfigDir();
   const containerConfigDir = getContainerPath(hostConfigDir);
-  if (!fs.existsSync(hostConfigDir)) {
-    fs.mkdirSync(hostConfigDir, { recursive: true });
-  }
-  args.push('--volume', `${hostConfigDir}:${containerConfigDir}`);
-  const containerHome = resolveSandboxContainerHome();
+  const configMountLabel = config.command === 'podman' ? ':z' : '';
   args.push(
-    '--env',
-    `LLXPRT_CONFIG_HOME=${containerConfigDir}`,
-    '--env',
-    `LLXPRT_DATA_HOME=${path.posix.join(containerHome, '.local/share/llxprt-code')}`,
-    '--env',
-    `LLXPRT_CACHE_HOME=${path.posix.join(containerHome, '.cache/llxprt-code')}`,
-    '--env',
-    `LLXPRT_LOG_HOME=${path.posix.join(containerHome, '.local/state/llxprt-code')}`,
+    '--volume',
+    `${hostConfigDir}:${containerConfigDir}${configMountLabel}`,
   );
-  mountGitConfigFiles(args, os.homedir(), '/home/node');
+  args.push('--env', `LLXPRT_CONFIG_HOME=${containerConfigDir}`);
+  const containerHome = resolveSandboxContainerHome();
+  mountGitConfigFiles(args, os.homedir(), containerHome);
   args.push(
     '--volume',
     `${resolvedTmpdir}:${getContainerPath(resolvedTmpdir)}`,
@@ -253,20 +252,47 @@ function addCustomMounts(
   }
 }
 
+/**
+ * Env var names that SANDBOX_ENV may not override because the sandbox
+ * infrastructure pins them authoritatively. `LLXPRT_CONFIG_HOME` is pinned by
+ * `buildContainerRunArgs` to point at the config bind mount; a SANDBOX_ENV
+ * value would come later in the argv and win under docker/podman last-wins
+ * semantics, silently detaching the in-container CLI from its mounted config.
+ * The data/cache/log roots are exported unconditionally from the container
+ * `$HOME` inside the entrypoint (#3081) so they follow the image's real home;
+ * reserving them here ensures a SANDBOX_ENV entry cannot also emit a host-side
+ * `--env` that would shadow the entrypoint export under last-wins semantics.
+ */
+const RESERVED_SANDBOX_ENV_KEYS = new Set([
+  'LLXPRT_CONFIG_HOME',
+  'LLXPRT_DATA_HOME',
+  'LLXPRT_CACHE_HOME',
+  'LLXPRT_LOG_HOME',
+]);
+
+function pushSandboxEnvEntry(args: string[], env: string): void {
+  if (!env.includes('=')) {
+    throw new FatalSandboxError(
+      'SANDBOX_ENV must be a comma-separated list of key=value pairs',
+    );
+  }
+  const eqIdx = env.indexOf('=');
+  const envName = env.substring(0, eqIdx);
+  if (RESERVED_SANDBOX_ENV_KEYS.has(envName)) {
+    debugLogger.log(
+      `SANDBOX_ENV: ignoring reserved key '${envName}' (pinned by sandbox infrastructure)`,
+    );
+    return;
+  }
+  debugLogger.log(`SANDBOX_ENV: ${envName}=<redacted>`);
+  args.push('--env', env);
+}
+
 function addSandboxEnvVars(args: string[]): void {
   for (const raw of process.env.SANDBOX_ENV!.split(',')) {
     const env = raw.trim();
     if (env !== '') {
-      if (env.includes('=')) {
-        const eqIdx = env.indexOf('=');
-        const envName = env.substring(0, eqIdx);
-        debugLogger.log(`SANDBOX_ENV: ${envName}=<redacted>`);
-        args.push('--env', env);
-      } else {
-        throw new FatalSandboxError(
-          'SANDBOX_ENV must be a comma-separated list of key=value pairs',
-        );
-      }
+      pushSandboxEnvEntry(args, env);
     }
   }
 }
@@ -427,7 +453,7 @@ export async function setupContainerUser(
 ): Promise<string> {
   let userFlag = '';
 
-  if (await shouldUseCurrentUserInSandbox()) {
+  if (shouldUseCurrentUserInSandbox()) {
     // Root is required here: this branch runs groupadd/useradd to create the
     // host user inside the container, then su to drop to that user's uid/gid.
     // Creating the user and writing /etc/shadow needs the capabilities below;

--- a/packages/cli/src/utils/sandbox-entrypoint.ts
+++ b/packages/cli/src/utils/sandbox-entrypoint.ts
@@ -84,6 +84,26 @@ const CAPABILITY_CAPTURE_STANZA = [
 ].join(NL);
 
 /**
+ * Pins the container-local data/cache/log roots to the REAL container HOME.
+ *
+ * These cannot be omitted: `resolveGlobalDataDir`/`CacheDir`/`LogDir` fall
+ * back to `LLXPRT_CONFIG_HOME` (the mounted host config dir), so leaving them
+ * unset would redirect container-local data, cache and logs into the mounted
+ * host config directory. They are exported INSIDE the entrypoint rather than
+ * passed as `--env` from the host so they follow the image's default user
+ * home — a host-side hard-coded home would break custom sandbox images whose
+ * default user home is elsewhere (#3081). The export is unconditional (not
+ * `${VAR:-...}`) so no image-inherited or host override can redirect these
+ * roots back into the mounted config directory; SANDBOX_ENV is additionally
+ * filtered for these keys in sandbox-containers.ts.
+ */
+const XDG_HOME_PIN_STANZA = [
+  'export LLXPRT_DATA_HOME="$HOME/.local/share/llxprt-code"',
+  'export LLXPRT_CACHE_HOME="$HOME/.cache/llxprt-code"',
+  'export LLXPRT_LOG_HOME="$HOME/.local/state/llxprt-code"',
+].join(NL);
+
+/**
  * Builds the final CLI exec stanza. Opens fd 3 and sets `LLXPRT_CAPABILITY_FD=3`
  * only when a capability token was captured; otherwise execs the CLI without
  * capability transport (tokenless path). The captured shell variable is unset
@@ -133,6 +153,12 @@ export function entrypoint(
 
   // STEP 1 (security): capture and scrub the capability BEFORE anything else.
   shellCmds.push(CAPABILITY_CAPTURE_STANZA);
+
+  // STEP 1.5: pin the container-local data/cache/log roots to the real
+  // container HOME before the CLI is exec'd on every path this entrypoint
+  // takes (default and current-user `su -p` modes, docker and podman). Runs
+  // before prefixes/relays/exec; the exports propagate to the exec'd CLI.
+  shellCmds.push(XDG_HOME_PIN_STANZA);
 
   // STEP 2: trusted prefixes (ssh-agent / cred-proxy bridges) run AFTER capture
   // and env scrub, so they have neither the token nor (it was never on fd 3

--- a/packages/cli/src/utils/sandbox-env.ts
+++ b/packages/cli/src/utils/sandbox-env.ts
@@ -145,7 +145,7 @@ function osReleaseContainsLike(content: string, keyword: string): boolean {
   return false;
 }
 
-export function shouldUseCurrentUserInSandboxSync(): boolean {
+export function shouldUseCurrentUserInSandbox(): boolean {
   const envVar = process.env.SANDBOX_SET_UID_GID?.toLowerCase().trim();
 
   if (envVar === '1' || envVar === 'true') {
@@ -178,10 +178,6 @@ export function shouldUseCurrentUserInSandboxSync(): boolean {
   return false;
 }
 
-export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
-  return shouldUseCurrentUserInSandboxSync();
-}
-
 /**
  * The container HOME used to derive container-local XDG directories.
  *
@@ -190,11 +186,10 @@ export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
  * `/home/node`). Sharing this single resolution between
  * {@link buildContainerRunArgs} — which sets the `LLXPRT_*_HOME` env overrides
  * — and the user setup guarantees the in-container HOME and the pinned roots
- * can never disagree. Synchronous so it is callable from the synchronous
- * arg builder.
+ * can never disagree.
  */
 export function resolveSandboxContainerHome(): string {
-  return shouldUseCurrentUserInSandboxSync()
+  return shouldUseCurrentUserInSandbox()
     ? getContainerPath(os.homedir())
     : '/home/node';
 }

--- a/packages/cli/src/utils/sandbox-env.ts
+++ b/packages/cli/src/utils/sandbox-env.ts
@@ -143,9 +143,11 @@ function osReleaseValue(content: string, key: string): string | undefined {
   }
   const value = line.slice(prefix.length).trim();
   const quote = value.at(0);
-  return quote !== undefined && (quote === '"' || quote === "'")
-    ? value.slice(1, value.endsWith(quote) ? -1 : undefined)
-    : value;
+  if (quote !== '"' && quote !== "'") {
+    return value;
+  }
+  const closingQuote = value.endsWith(quote) ? -1 : undefined;
+  return value.slice(1, closingQuote);
 }
 
 function isDebianLikeOsRelease(content: string): boolean {

--- a/packages/cli/src/utils/sandbox-env.ts
+++ b/packages/cli/src/utils/sandbox-env.ts
@@ -7,7 +7,6 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import { debugLogger } from '@vybestack/llxprt-code-telemetry';
 
 const PASSTHROUGH_VARIABLES = [
@@ -146,7 +145,7 @@ function osReleaseContainsLike(content: string, keyword: string): boolean {
   return false;
 }
 
-export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
+export function shouldUseCurrentUserInSandboxSync(): boolean {
   const envVar = process.env.SANDBOX_SET_UID_GID?.toLowerCase().trim();
 
   if (envVar === '1' || envVar === 'true') {
@@ -158,7 +157,7 @@ export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
 
   if (os.platform() === 'linux') {
     try {
-      const osReleaseContent = await readFile('/etc/os-release', 'utf8');
+      const osReleaseContent = fs.readFileSync('/etc/os-release', 'utf8');
       if (
         osReleaseContent.includes('ID=debian') ||
         osReleaseContent.includes('ID=ubuntu') ||
@@ -177,4 +176,25 @@ export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
     }
   }
   return false;
+}
+
+export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
+  return shouldUseCurrentUserInSandboxSync();
+}
+
+/**
+ * The container HOME used to derive container-local XDG directories.
+ *
+ * Mirrors the HOME that {@link setupContainerUser} pins (the host home under
+ * `SANDBOX_SET_UID_GID`/Debian-Ubuntu auto-detect, otherwise the image default
+ * `/home/node`). Sharing this single resolution between
+ * {@link buildContainerRunArgs} — which sets the `LLXPRT_*_HOME` env overrides
+ * — and the user setup guarantees the in-container HOME and the pinned roots
+ * can never disagree. Synchronous so it is callable from the synchronous
+ * arg builder.
+ */
+export function resolveSandboxContainerHome(): string {
+  return shouldUseCurrentUserInSandboxSync()
+    ? getContainerPath(os.homedir())
+    : '/home/node';
 }

--- a/packages/cli/src/utils/sandbox-env.ts
+++ b/packages/cli/src/utils/sandbox-env.ts
@@ -135,14 +135,30 @@ export function parseImageName(image: string): string {
   return tag ? `${name}-${tag}` : name;
 }
 
-/** Checks if any ID_LIKE= line in /etc/os-release contains the given keyword. */
-function osReleaseContainsLike(content: string, keyword: string): boolean {
-  for (const line of content.split('\n')) {
-    if (line.startsWith('ID_LIKE=') && line.includes(keyword)) {
-      return true;
-    }
+function osReleaseValue(content: string, key: string): string | undefined {
+  const prefix = `${key}=`;
+  const line = content.split('\n').find((entry) => entry.startsWith(prefix));
+  if (line === undefined) {
+    return undefined;
   }
-  return false;
+  const value = line.slice(prefix.length).trim();
+  const quote = value.at(0);
+  return quote !== undefined && (quote === '"' || quote === "'")
+    ? value.slice(1, value.endsWith(quote) ? -1 : undefined)
+    : value;
+}
+
+function isDebianLikeOsRelease(content: string): boolean {
+  const id = osReleaseValue(content, 'ID');
+  if (id === 'debian' || id === 'ubuntu') {
+    return true;
+  }
+  const idLike = osReleaseValue(content, 'ID_LIKE');
+  return (
+    idLike
+      ?.split(/\s+/)
+      .some((value) => value === 'debian' || value === 'ubuntu') ?? false
+  );
 }
 
 export function shouldUseCurrentUserInSandbox(): boolean {
@@ -158,12 +174,7 @@ export function shouldUseCurrentUserInSandbox(): boolean {
   if (os.platform() === 'linux') {
     try {
       const osReleaseContent = fs.readFileSync('/etc/os-release', 'utf8');
-      if (
-        osReleaseContent.includes('ID=debian') ||
-        osReleaseContent.includes('ID=ubuntu') ||
-        osReleaseContainsLike(osReleaseContent, 'debian') ||
-        osReleaseContainsLike(osReleaseContent, 'ubuntu')
-      ) {
+      if (isDebianLikeOsRelease(osReleaseContent)) {
         debugLogger.log(
           'INFO: Defaulting to use current user UID/GID for Debian/Ubuntu-based Linux.',
         );

--- a/packages/cli/src/utils/sandbox-exec.ts
+++ b/packages/cli/src/utils/sandbox-exec.ts
@@ -35,6 +35,7 @@ import {
   wireCleanupHandlers,
   handleStdinForSandbox,
   restoreStdinAfterSandbox,
+  validateContainerSandboxEnv,
   LOCAL_DEV_SANDBOX_IMAGE_NAME,
 } from './sandbox-containers.js';
 import { stopProxy } from '@vybestack/llxprt-code-providers/auth.js';
@@ -151,6 +152,7 @@ async function prepareContainerSandbox(
   cliConfig: Config | undefined,
   cliArgs: string[],
 ): Promise<ContainerSandboxPrepared> {
+  validateContainerSandboxEnv();
   let credentialProxyBridgeCleanup: (() => void) | undefined;
 
   const { image, workdir, resolvedTmpdir, args } =

--- a/packages/cli/src/utils/sandbox-ssh.test.ts
+++ b/packages/cli/src/utils/sandbox-ssh.test.ts
@@ -12,7 +12,6 @@ import { DebugLogger } from '@vybestack/llxprt-code-core';
 import { testRegex } from '../test-utils/regex.js';
 
 vi.mock('node:child_process');
-vi.mock('node:fs/promises');
 
 import {
   setupSshAgentForwarding,
@@ -835,10 +834,15 @@ describe('setupSshAgentDockerLinux', () => {
 
   it('falls back to TCP bridge when host uid differs from container uid', async () => {
     process.getuid = () => 501;
-    // shouldUseCurrentUserInSandboxSync returns false when os-release is
-    // unavailable. The detection reads /etc/os-release synchronously.
-    vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
-      throw new Error('not found');
+    // shouldUseCurrentUserInSandbox returns false when os-release is
+    // unavailable. The stub is path-conditional: only /etc/os-release throws;
+    // every other synchronous read delegates to the real implementation.
+    const realReadFileSync = fs.readFileSync;
+    vi.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      if (p === '/etc/os-release') {
+        throw new Error('not found');
+      }
+      return realReadFileSync(p);
     });
     vi.spyOn(os, 'platform').mockReturnValue('linux');
     const args: string[] = [];
@@ -854,9 +858,15 @@ describe('setupSshAgentDockerLinux', () => {
 
   it('uses direct bind-mount on Debian/Ubuntu (shouldUseCurrentUserInSandbox)', async () => {
     process.getuid = () => 501;
-    vi.spyOn(fs, 'readFileSync').mockReturnValue(
-      'ID=ubuntu' + String.fromCharCode(10) + 'VERSION_ID="22.04"',
-    );
+    // Path-conditional stub: only /etc/os-release returns Ubuntu content;
+    // every other synchronous read delegates to the real implementation.
+    const realReadFileSync = fs.readFileSync;
+    vi.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      if (p === '/etc/os-release') {
+        return 'ID=ubuntu' + String.fromCharCode(10) + 'VERSION_ID="22.04"';
+      }
+      return realReadFileSync(p);
+    });
     vi.spyOn(os, 'platform').mockReturnValue('linux');
     // shouldUseCurrentUserInSandbox logs an INFO message via debugLogger.log on Debian/Ubuntu
     const logSpy = vi

--- a/packages/cli/src/utils/sandbox-ssh.test.ts
+++ b/packages/cli/src/utils/sandbox-ssh.test.ts
@@ -835,9 +835,11 @@ describe('setupSshAgentDockerLinux', () => {
 
   it('falls back to TCP bridge when host uid differs from container uid', async () => {
     process.getuid = () => 501;
-    // shouldUseCurrentUserInSandbox returns false when os-release is unavailable
-    const { readFile } = await import('node:fs/promises');
-    vi.mocked(readFile).mockRejectedValue(new Error('not found'));
+    // shouldUseCurrentUserInSandboxSync returns false when os-release is
+    // unavailable. The detection reads /etc/os-release synchronously.
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw new Error('not found');
+    });
     vi.spyOn(os, 'platform').mockReturnValue('linux');
     const args: string[] = [];
     const result = await setupSshAgentDockerLinux(args, '/tmp/auth.sock');
@@ -852,11 +854,8 @@ describe('setupSshAgentDockerLinux', () => {
 
   it('uses direct bind-mount on Debian/Ubuntu (shouldUseCurrentUserInSandbox)', async () => {
     process.getuid = () => 501;
-    const { readFile } = await import('node:fs/promises');
-    vi.mocked(readFile).mockResolvedValue(
-      Buffer.from(
-        'ID=ubuntu' + String.fromCharCode(10) + 'VERSION_ID="22.04"',
-      ) as never,
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      'ID=ubuntu' + String.fromCharCode(10) + 'VERSION_ID="22.04"',
     );
     vi.spyOn(os, 'platform').mockReturnValue('linux');
     // shouldUseCurrentUserInSandbox logs an INFO message via debugLogger.log on Debian/Ubuntu

--- a/packages/cli/src/utils/sandbox-ssh.ts
+++ b/packages/cli/src/utils/sandbox-ssh.ts
@@ -356,7 +356,7 @@ export async function setupSshAgentDockerLinux(
   args: string[],
   sshAuthSock: string,
 ): Promise<SshAgentResult> {
-  const willMatchHostUser = await shouldUseCurrentUserInSandbox();
+  const willMatchHostUser = shouldUseCurrentUserInSandbox();
   const hostUid = process.getuid?.() ?? -1;
 
   if (willMatchHostUser || hostUid === 1000) {

--- a/packages/cli/test-bun/pathMigration.issue3081.bun.ts
+++ b/packages/cli/test-bun/pathMigration.issue3081.bun.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #3081: the legacy → canonical migration
+ * categorizer previously routed `welcomeConfig.json`, `trustedFolders.json`
+ * and `skills/` to the DATA directory, while the application reads all three
+ * from the CONFIG directory. These tests drive the REAL `performMigration`
+ * (and `shouldMigrate`/`isMigrationComplete`) against real temp directories
+ * — no module mocking, no mock-theater — so they pin observable outcomes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  performMigration,
+  shouldMigrate,
+  type MigrationDestinations,
+} from '../src/config/pathMigration.js';
+
+async function makeTempDir(): Promise<string> {
+  return fs.promises.mkdtemp(path.join(os.tmpdir(), 'llxprt-migration-3081-'));
+}
+
+function makeDestinations(base: string): MigrationDestinations {
+  return {
+    configDir: path.join(base, 'config'),
+    dataDir: path.join(base, 'data'),
+    cacheDir: path.join(base, 'cache'),
+    logDir: path.join(base, 'log'),
+  };
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+  const fullPath = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
+}
+
+describe('#3081 migration categorizer (config entries)', () => {
+  let legacyDir: string;
+  let destBase: string;
+  let destinations: MigrationDestinations;
+
+  beforeEach(async () => {
+    legacyDir = await makeTempDir();
+    destBase = await makeTempDir();
+    destinations = makeDestinations(destBase);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(legacyDir, { recursive: true, force: true });
+    await fs.promises.rm(destBase, { recursive: true, force: true });
+  });
+
+  it('migrates legacy welcomeConfig.json to the CONFIG destination (not data)', () => {
+    writeFile(
+      legacyDir,
+      'welcomeConfig.json',
+      JSON.stringify({ welcomeCompleted: true }),
+    );
+
+    const result = performMigration(legacyDir, destinations);
+
+    expect(result.filesCopied).toBeGreaterThan(0);
+    expect(
+      fs.existsSync(path.join(destinations.configDir, 'welcomeConfig.json')),
+    ).toBe(true);
+    // It must NOT also land in the data directory (the old, buggy route).
+    expect(
+      fs.existsSync(path.join(destinations.dataDir, 'welcomeConfig.json')),
+    ).toBe(false);
+  });
+
+  it('migrates legacy trustedFolders.json to the CONFIG destination (not data)', () => {
+    writeFile(
+      legacyDir,
+      'trustedFolders.json',
+      JSON.stringify({ trustedFolders: [] }),
+    );
+
+    const result = performMigration(legacyDir, destinations);
+
+    expect(result.filesCopied).toBeGreaterThan(0);
+    expect(
+      fs.existsSync(path.join(destinations.configDir, 'trustedFolders.json')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(destinations.dataDir, 'trustedFolders.json')),
+    ).toBe(false);
+  });
+
+  it('migrates a legacy skills/<name>/SKILL.md tree under <configDir>/skills/', () => {
+    writeFile(legacyDir, path.join('skills', 'greet', 'SKILL.md'), '# greet');
+
+    const result = performMigration(legacyDir, destinations);
+
+    expect(result.filesCopied).toBeGreaterThan(0);
+    expect(
+      fs.existsSync(
+        path.join(destinations.configDir, 'skills', 'greet', 'SKILL.md'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not overwrite a pre-existing canonical file on re-run after the marker version bump', () => {
+    // Pre-existing canonical welcome marker (already migrated correctly).
+    writeFile(destinations.configDir, 'welcomeConfig.json', 'CANONICAL');
+    // Legacy still carries a (different) copy.
+    writeFile(legacyDir, 'welcomeConfig.json', 'LEGACY');
+    // Stamp an outdated v1 marker: after the bump to v2, isMigrationComplete
+    // must treat it as stale so the re-run actually happens.
+    fs.mkdirSync(destinations.dataDir, { recursive: true });
+    writeFile(
+      destinations.dataDir,
+      '.migration-complete.json',
+      JSON.stringify({ version: 1, completedAt: '1970-01-01T00:00:00.000Z' }),
+    );
+
+    // The marker version bump causes shouldMigrate to re-run.
+    expect(shouldMigrate(legacyDir, destinations)).toBe(true);
+
+    performMigration(legacyDir, destinations);
+
+    // No-overwrite copy semantics: the canonical file is untouched.
+    expect(
+      fs.readFileSync(
+        path.join(destinations.configDir, 'welcomeConfig.json'),
+        'utf-8',
+      ),
+    ).toBe('CANONICAL');
+  });
+
+  it('keeps the tmp/skills special case benign alongside the top-level skills config entry', () => {
+    // Both <legacy>/skills and <legacy>/tmp/skills now target <config>/skills.
+    // They must merge without clobbering each other (distinct child names).
+    writeFile(legacyDir, path.join('skills', 'a', 'SKILL.md'), '# a');
+    writeFile(legacyDir, path.join('tmp', 'skills', 'b', 'SKILL.md'), '# b');
+
+    const result = performMigration(legacyDir, destinations);
+
+    expect(result.filesCopied).toBeGreaterThan(0);
+    expect(
+      fs.existsSync(
+        path.join(destinations.configDir, 'skills', 'a', 'SKILL.md'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(destinations.configDir, 'skills', 'b', 'SKILL.md'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/cli/test-bun/pathMigration.issue3081.bun.ts
+++ b/packages/cli/test-bun/pathMigration.issue3081.bun.ts
@@ -20,6 +20,7 @@ import * as os from 'node:os';
 import {
   performMigration,
   shouldMigrate,
+  MIGRATION_MARKER_VERSION,
   type MigrationDestinations,
 } from '../src/config/pathMigration.js';
 
@@ -108,52 +109,59 @@ describe('#3081 migration categorizer (config entries)', () => {
     ).toBe(true);
   });
 
-  it('does not overwrite a pre-existing canonical file on re-run after the marker version bump', () => {
-    // Pre-existing canonical welcome marker (already migrated correctly).
-    writeFile(destinations.configDir, 'welcomeConfig.json', 'CANONICAL');
-    // Legacy still carries a (different) copy.
-    writeFile(legacyDir, 'welcomeConfig.json', 'LEGACY');
-    // Stamp an outdated v1 marker: after the bump to v2, isMigrationComplete
-    // must treat it as stale so the re-run actually happens.
+  it('does not recreate a deleted canonical entry when the migration marker is current', () => {
+    // Safety property (#3081): with a CURRENT marker, shouldMigrate returns
+    // false and the legacy copy pass is skipped, so an entry the user
+    // deliberately deleted from the canonical directories is never resurrected
+    // from the legacy directory. oauth_creds.json is the concrete case — it is
+    // deleted by OAuthCredentialStorage.clearCredentials() on logout, and
+    // re-running the copy pass would silently re-authenticate a user who
+    // logged out. The marker version stays at 1: bumping it would re-run the
+    // whole copy pass and recreate every deleted entry.
+    writeFile(legacyDir, 'oauth_creds.json', '{"token":"LEGACY"}');
+    // Canonical data dir exists but oauth_creds.json was deleted by the user.
     fs.mkdirSync(destinations.dataDir, { recursive: true });
     writeFile(
       destinations.dataDir,
       '.migration-complete.json',
-      JSON.stringify({ version: 1, completedAt: '1970-01-01T00:00:00.000Z' }),
+      JSON.stringify({
+        version: MIGRATION_MARKER_VERSION,
+        completedAt: '2026-01-01T00:00:00.000Z',
+      }),
     );
 
-    // The marker version bump causes shouldMigrate to re-run.
-    expect(shouldMigrate(legacyDir, destinations)).toBe(true);
+    // A current marker means the legacy copy pass must NOT run.
+    expect(shouldMigrate(legacyDir, destinations)).toBe(false);
+
+    // The deleted credential is not recreated from the legacy directory.
+    expect(
+      fs.existsSync(path.join(destinations.dataDir, 'oauth_creds.json')),
+    ).toBe(false);
+  });
+
+  it('gives top-level skills/ precedence over tmp/skills/ on a same-name collision', () => {
+    // Both <legacy>/skills and <legacy>/tmp/skills target <config>/skills.
+    // For a same-named skill, the top-level copy must win (explicit
+    // precedence implemented by deterministic name-sorted iteration order
+    // combined with no-overwrite COPYFILE_EXCL copy semantics).
+    writeFile(
+      legacyDir,
+      path.join('skills', 'shared', 'SKILL.md'),
+      'TOP_LEVEL',
+    );
+    writeFile(
+      legacyDir,
+      path.join('tmp', 'skills', 'shared', 'SKILL.md'),
+      'TMP',
+    );
 
     performMigration(legacyDir, destinations);
 
-    // No-overwrite copy semantics: the canonical file is untouched.
     expect(
       fs.readFileSync(
-        path.join(destinations.configDir, 'welcomeConfig.json'),
+        path.join(destinations.configDir, 'skills', 'shared', 'SKILL.md'),
         'utf-8',
       ),
-    ).toBe('CANONICAL');
-  });
-
-  it('keeps the tmp/skills special case benign alongside the top-level skills config entry', () => {
-    // Both <legacy>/skills and <legacy>/tmp/skills now target <config>/skills.
-    // They must merge without clobbering each other (distinct child names).
-    writeFile(legacyDir, path.join('skills', 'a', 'SKILL.md'), '# a');
-    writeFile(legacyDir, path.join('tmp', 'skills', 'b', 'SKILL.md'), '# b');
-
-    const result = performMigration(legacyDir, destinations);
-
-    expect(result.filesCopied).toBeGreaterThan(0);
-    expect(
-      fs.existsSync(
-        path.join(destinations.configDir, 'skills', 'a', 'SKILL.md'),
-      ),
-    ).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(destinations.configDir, 'skills', 'b', 'SKILL.md'),
-      ),
-    ).toBe(true);
+    ).toBe('TOP_LEVEL');
   });
 });

--- a/packages/cli/test-bun/pathMigration.issue3081.bun.ts
+++ b/packages/cli/test-bun/pathMigration.issue3081.bun.ts
@@ -19,6 +19,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import {
   performMigration,
+  runStartupMigrationWithPath,
   shouldMigrate,
   MIGRATION_MARKER_VERSION,
   type MigrationDestinations,
@@ -130,8 +131,12 @@ describe('#3081 migration categorizer (config entries)', () => {
       }),
     );
 
-    // A current marker means the legacy copy pass must NOT run.
+    // A current marker means the production startup orchestrator must skip
+    // the legacy copy pass. Calling performMigration directly would bypass the
+    // marker by design; runStartupMigrationWithPath is the single production
+    // authority that composes shouldMigrate with the copy operation.
     expect(shouldMigrate(legacyDir, destinations)).toBe(false);
+    runStartupMigrationWithPath(legacyDir, destinations);
 
     // The deleted credential is not recreated from the legacy directory.
     expect(

--- a/packages/cli/test-bun/sandbox-env.bun.ts
+++ b/packages/cli/test-bun/sandbox-env.bun.ts
@@ -105,20 +105,26 @@ describe('#3081 shouldUseCurrentUserInSandbox — Linux os-release auto-detect',
     });
   }
 
-  it('detects Debian via ID=debian', () => {
-    stubOsRelease('ID=debian\nVERSION_ID="12"\n');
+  it.each(['ID=debian', 'ID="debian"', "ID='debian'"])(
+    'detects Debian via %s',
+    (idLine) => {
+      stubOsRelease(`${idLine}\nVERSION_ID="12"\n`);
+      expect(shouldUseCurrentUserInSandbox()).toBe(true);
+    },
+  );
+
+  it.each(['ID=ubuntu', 'ID="ubuntu"'])('detects Ubuntu via %s', (idLine) => {
+    stubOsRelease(`${idLine}\nVERSION_ID="22.04"\n`);
     expect(shouldUseCurrentUserInSandbox()).toBe(true);
   });
 
-  it('detects Ubuntu via ID=ubuntu', () => {
-    stubOsRelease('ID=ubuntu\nVERSION_ID="22.04"\n');
-    expect(shouldUseCurrentUserInSandbox()).toBe(true);
-  });
-
-  it('detects a Debian derivative via ID_LIKE=debian', () => {
-    stubOsRelease('ID=linuxmint\nID_LIKE=debian\n');
-    expect(shouldUseCurrentUserInSandbox()).toBe(true);
-  });
+  it.each(['ID_LIKE=debian', 'ID_LIKE="debian ubuntu"'])(
+    'detects a Debian derivative via %s',
+    (idLikeLine) => {
+      stubOsRelease(`ID=linuxmint\n${idLikeLine}\n`);
+      expect(shouldUseCurrentUserInSandbox()).toBe(true);
+    },
+  );
 
   it('does NOT auto-detect a non-Debian distro (Fedora)', () => {
     stubOsRelease('ID=fedora\nVERSION_ID="40"\n');

--- a/packages/cli/test-bun/sandbox-env.bun.ts
+++ b/packages/cli/test-bun/sandbox-env.bun.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the sandbox env helpers (#3081). These exercise the
+ * REAL `shouldUseCurrentUserInSandbox`, `resolveSandboxContainerHome` and
+ * `getContainerPath` against controlled `process.env`, platform and
+ * os-release inputs — no module-level mocking of the production code, only
+ * spies on the host-surface inputs the functions read.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import os from 'node:os';
+import fs from 'node:fs';
+import {
+  shouldUseCurrentUserInSandbox,
+  resolveSandboxContainerHome,
+  getContainerPath,
+} from '../src/utils/sandbox-env.js';
+
+describe('#3081 shouldUseCurrentUserInSandbox — env-value contract', () => {
+  const savedSetUidGid = process.env.SANDBOX_SET_UID_GID;
+  let platformSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    delete process.env.SANDBOX_SET_UID_GID;
+    // Default to a non-Linux platform so os-release is never consulted unless
+    // a test explicitly opts into the Linux auto-detect path.
+    platformSpy = spyOn(os, 'platform').mockReturnValue('darwin');
+  });
+
+  afterEach(() => {
+    platformSpy.mockRestore();
+    if (savedSetUidGid === undefined) {
+      delete process.env.SANDBOX_SET_UID_GID;
+    } else {
+      process.env.SANDBOX_SET_UID_GID = savedSetUidGid;
+    }
+  });
+
+  it('returns false when unset on a non-Linux host', () => {
+    expect(shouldUseCurrentUserInSandbox()).toBe(false);
+  });
+
+  it.each(['0', 'false'])(
+    'returns false for an explicit disable value %s',
+    (v) => {
+      process.env.SANDBOX_SET_UID_GID = v;
+      expect(shouldUseCurrentUserInSandbox()).toBe(false);
+    },
+  );
+
+  it.each(['1', 'true'])(
+    'returns true for an explicit enable value %s',
+    (v) => {
+      process.env.SANDBOX_SET_UID_GID = v;
+      expect(shouldUseCurrentUserInSandbox()).toBe(true);
+    },
+  );
+
+  it('treats mixed-case enable values as enabled', () => {
+    process.env.SANDBOX_SET_UID_GID = 'True';
+    expect(shouldUseCurrentUserInSandbox()).toBe(true);
+  });
+
+  it('trims surrounding whitespace before evaluating', () => {
+    process.env.SANDBOX_SET_UID_GID = '  1  ';
+    expect(shouldUseCurrentUserInSandbox()).toBe(true);
+  });
+});
+
+describe('#3081 shouldUseCurrentUserInSandbox — Linux os-release auto-detect', () => {
+  const savedSetUidGid = process.env.SANDBOX_SET_UID_GID;
+  let platformSpy: ReturnType<typeof spyOn>;
+  let readSpy: ReturnType<typeof spyOn>;
+  const realReadFileSync = fs.readFileSync;
+
+  beforeEach(() => {
+    delete process.env.SANDBOX_SET_UID_GID;
+    platformSpy = spyOn(os, 'platform').mockReturnValue('linux');
+  });
+
+  afterEach(() => {
+    platformSpy.mockRestore();
+    readSpy?.mockRestore();
+    if (savedSetUidGid === undefined) {
+      delete process.env.SANDBOX_SET_UID_GID;
+    } else {
+      process.env.SANDBOX_SET_UID_GID = savedSetUidGid;
+    }
+  });
+
+  function stubOsRelease(content: string | (() => never)): void {
+    readSpy = spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      if (p === '/etc/os-release') {
+        if (typeof content === 'function') {
+          content();
+        }
+        return content as string;
+      }
+      return realReadFileSync(p);
+    });
+  }
+
+  it('detects Debian via ID=debian', () => {
+    stubOsRelease('ID=debian\nVERSION_ID="12"\n');
+    expect(shouldUseCurrentUserInSandbox()).toBe(true);
+  });
+
+  it('detects Ubuntu via ID=ubuntu', () => {
+    stubOsRelease('ID=ubuntu\nVERSION_ID="22.04"\n');
+    expect(shouldUseCurrentUserInSandbox()).toBe(true);
+  });
+
+  it('detects a Debian derivative via ID_LIKE=debian', () => {
+    stubOsRelease('ID=linuxmint\nID_LIKE=debian\n');
+    expect(shouldUseCurrentUserInSandbox()).toBe(true);
+  });
+
+  it('does NOT auto-detect a non-Debian distro (Fedora)', () => {
+    stubOsRelease('ID=fedora\nVERSION_ID="40"\n');
+    expect(shouldUseCurrentUserInSandbox()).toBe(false);
+  });
+
+  it('returns false when /etc/os-release is unreadable', () => {
+    stubOsRelease(() => {
+      throw new Error('not found');
+    });
+    expect(shouldUseCurrentUserInSandbox()).toBe(false);
+  });
+});
+
+describe('#3081 resolveSandboxContainerHome', () => {
+  const savedSetUidGid = process.env.SANDBOX_SET_UID_GID;
+  let platformSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    platformSpy = spyOn(os, 'platform').mockReturnValue('linux');
+  });
+
+  afterEach(() => {
+    platformSpy.mockRestore();
+    if (savedSetUidGid === undefined) {
+      delete process.env.SANDBOX_SET_UID_GID;
+    } else {
+      process.env.SANDBOX_SET_UID_GID = savedSetUidGid;
+    }
+  });
+
+  it('returns the host home (translated) on the current-user path', () => {
+    process.env.SANDBOX_SET_UID_GID = '1';
+    expect(resolveSandboxContainerHome()).toBe(getContainerPath(os.homedir()));
+  });
+
+  it('returns the image default home on the non-current-user path', () => {
+    process.env.SANDBOX_SET_UID_GID = 'false';
+    expect(resolveSandboxContainerHome()).toBe('/home/node');
+  });
+});
+
+describe('#3081 getContainerPath — host path translation', () => {
+  let platformSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    platformSpy?.mockRestore();
+  });
+
+  it('translates a Windows drive path to the /c/... POSIX form under win32', () => {
+    platformSpy = spyOn(os, 'platform').mockReturnValue('win32');
+    expect(getContainerPath('C:\\Users\\me\\llxprt-code')).toBe(
+      '/c/Users/me/llxprt-code',
+    );
+  });
+
+  it('does not translate a POSIX path on a non-win32 host', () => {
+    platformSpy = spyOn(os, 'platform').mockReturnValue('linux');
+    const p = '/home/node/.config/llxprt-code';
+    expect(getContainerPath(p)).toBe(p);
+  });
+});

--- a/project-plans/issue-3081-sandbox-canonical-config-mount.md
+++ b/project-plans/issue-3081-sandbox-canonical-config-mount.md
@@ -1,0 +1,179 @@
+# Issue #3081 — Container sandbox mounts the global config at the legacy `~/.llxprt` path
+
+## Problem
+
+`buildContainerRunArgs` in `packages/cli/src/utils/sandbox-containers.ts` mounts the host
+global config directory into the container at `/home/node/.llxprt`:
+
+    const userSettingsDirOnHost = USER_SETTINGS_DIR;
+    const userSettingsDirInSandbox = getContainerPath(
+      `/home/node/${SETTINGS_DIRECTORY_NAME}`,
+    );
+    if (!fs.existsSync(userSettingsDirOnHost)) {
+      fs.mkdirSync(userSettingsDirOnHost);
+    }
+    args.push('--volume', `${userSettingsDirOnHost}:${userSettingsDirInSandbox}`);
+    if (userSettingsDirInSandbox !== userSettingsDirOnHost) {
+      args.push(
+        '--volume',
+        `${userSettingsDirOnHost}:${getContainerPath(userSettingsDirOnHost)}`,
+      );
+    }
+
+The CLI inside the container resolves its config directory through
+`Storage.getGlobalConfigDir()` → `env-paths('llxprt-code').config` →
+`/home/node/.config/llxprt-code`. Nothing is mounted there, so the sandboxed CLI
+sees an empty configuration on every launch.
+
+Verified against the shipped sandbox image:
+
+    config = /home/node/.config/llxprt-code
+    data   = /home/node/.local/share/llxprt-code
+    mounted content is at /home/node/.llxprt
+    /home/node/.config does not exist
+
+Because `/home/node/.llxprt` exists and has content, the in-container startup migration
+(`runStartupMigration`) treats it as a legacy directory and copies the whole host config
+into ephemeral container paths on every start. `categorizeEntry` routes anything not
+listed in `CONFIG_ENTRIES` to the **data** directory, and three entries the application
+reads from the **config** directory are missing from that set:
+
+- `welcomeConfig.json` — read from `USER_SETTINGS_DIR` (`getWelcomeConfigPath`)
+- `trustedFolders.json` — read from `USER_SETTINGS_DIR` (`getTrustedFoldersPath`)
+- `skills` — read from `Storage.getUserSkillsDir()` = `<configDir>/skills`
+  (only `tmp/skills` is special-cased today)
+
+So even the accidental in-container migration lands `welcomeConfig.json` in the data
+directory, where the CLI never looks. Net user-visible effect: **the first-time setup
+wizard runs on every sandboxed launch**, folder trust is re-prompted, and profiles /
+subagents / prompts / commands / policies / hooks / global memory are all invisible.
+
+The same `categorizeEntry` gap is a genuine host bug independent of the sandbox: a user
+migrating from a legacy `~/.llxprt` loses their welcome marker, their trusted-folder
+decisions and their user skills.
+
+The macOS Seatbelt path was already corrected during the OS-standard path migration
+(`buildSeatbeltArgs` passes `CONFIG_DIR` / `DATA_DIR` / `CACHE_DIR` / `LOG_DIR` resolved
+through `Storage`). Only the container path was left behind.
+
+## Scope
+
+In scope:
+
+1. Container mount + environment pinning for the canonical config directory.
+2. Removal of the legacy `/home/node/.llxprt` destination.
+3. `categorizeEntry` correctness for `welcomeConfig.json`, `trustedFolders.json`, `skills`.
+4. Migration marker version bump so the categorization fix actually applies to users who
+   already migrated but still have a legacy directory.
+5. Docs.
+
+Explicitly out of scope (documented, not changed):
+
+- Mounting the **data** directory. It holds `oauth_creds.json`, `google_accounts.json`
+  and `provider_accounts.json`. Bind-mounting it would push raw stored credentials
+  across the sandbox boundary, which is exactly what #2946 removed and what the
+  credential proxy (`LLXPRT_CREDENTIAL_SOCKET`) exists to prevent. Data, cache and log
+  stay container-local, which is the behaviour that already ships today.
+- Sanitising the config-directory mount. Tracked separately by #2957 (security,
+  milestone 0.12.0). This change must not increase what crosses the boundary — the same
+  single directory crosses, only its destination inside the container changes.
+
+## Design
+
+### 1. `packages/cli/src/utils/sandbox-containers.ts`
+
+Replace the legacy mount block with a canonical, `HOME`-independent one.
+
+- Mount the host config directory at **path parity**: `getContainerPath(hostConfigDir)`.
+  Path parity is what the old code already did for its second mount, and it keeps
+  host-absolute paths that appear inside settings/profiles resolvable.
+- Pin the four canonical roots explicitly with environment overrides so in-container
+  resolution never depends on the container `HOME` (which is `/home/node` by default and
+  the host home directory under `SANDBOX_SET_UID_GID`):
+  - `LLXPRT_CONFIG_HOME` = `getContainerPath(hostConfigDir)` (the mount)
+  - `LLXPRT_DATA_HOME`   = `<containerHome>/.local/share/llxprt-code`
+  - `LLXPRT_CACHE_HOME`  = `<containerHome>/.cache/llxprt-code`
+  - `LLXPRT_LOG_HOME`    = `<containerHome>/.local/state/llxprt-code`
+
+  All four must be set. `resolveGlobalDataDir` / `CacheDir` / `LogDir` fall back to
+  `LLXPRT_CONFIG_HOME` when their own variable is absent, so setting only
+  `LLXPRT_CONFIG_HOME` would redirect container-local data, cache and logs into the
+  mounted host config directory. Pinning all four preserves today's container-local
+  behaviour for the three unmounted categories.
+
+  `<containerHome>` must be derived from the same value that decides the container `HOME`
+  (`/home/node` normally, `os.homedir()` under `shouldUseCurrentUserInSandbox()`), so the
+  two never disagree. Because `setupContainerUser` runs after `buildContainerRunArgs`,
+  the home resolution needs to be a single shared helper used by both.
+
+- Drop the `/home/node/${SETTINGS_DIRECTORY_NAME}` destination entirely. Setting
+  `LLXPRT_CONFIG_HOME` also makes `runStartupMigration` return early, so the phantom
+  in-container legacy migration stops on both counts.
+
+- `fs.mkdirSync(userSettingsDirOnHost)` must become `{ recursive: true }`. The
+  non-recursive form throws `ENOENT` when the platform config parent does not exist yet.
+
+- `SETTINGS_DIRECTORY_NAME` may become unused in this file; remove the import if so.
+  Note it is still used at line ~305 for the `sandbox.venv` path — check before removing.
+
+### 2. `packages/cli/src/config/pathMigration.ts`
+
+- Add `'welcomeConfig.json'`, `'trustedFolders.json'` and `'skills'` to `CONFIG_ENTRIES`.
+- Bump `MIGRATION_MARKER_VERSION` from 1 to 2 so a user who already migrated under the
+  old categorisation re-runs migration once and gets the three entries placed correctly.
+  Re-running is safe: `copyEntry` publishes with hard-link / `COPYFILE_EXCL` semantics and
+  never overwrites a pre-existing canonical file.
+- Confirm the `tmp/skills` special case in `migrateTmpDir` still behaves correctly now
+  that a top-level `skills` entry is also categorised as config; they are different
+  sources (`<legacy>/skills` vs `<legacy>/tmp/skills`) writing to the same destination,
+  and the no-overwrite copy semantics must keep that collision benign.
+
+### 3. Docs
+
+- `docs/sandbox.md`: state which host directory is mounted into the container, at which
+  path, and that data / cache / logs are container-local and do not persist.
+
+## Tests (behavioral, Bun)
+
+`packages/cli/src/utils/sandbox-containers.test.ts` is already registered as a Bun-native
+suite in `scripts/bun-test-manifest.ts` (workspace `cli`), so new cases belong there.
+
+Drive the real `buildContainerRunArgs` output — no assertions against mocks:
+
+1. The `--volume` operand list contains `<hostConfigDir>:<getContainerPath(hostConfigDir)>`.
+2. No `--volume` operand has a destination ending in `/.llxprt`.
+3. `--env LLXPRT_CONFIG_HOME=<getContainerPath(hostConfigDir)>` is present and equals the
+   config mount destination.
+4. `--env LLXPRT_DATA_HOME`, `LLXPRT_CACHE_HOME`, `LLXPRT_LOG_HOME` are all present, are
+   pairwise distinct, and none of them is inside the mounted config directory.
+5. With `LLXPRT_CONFIG_HOME` set on the host (so all four host roots collapse to one
+   directory) the produced arguments contain no duplicate `--volume` destination.
+6. A test that pins the regression directly: the destination the CLI would resolve inside
+   the container (i.e. the value of `--env LLXPRT_CONFIG_HOME`) is covered by one of the
+   emitted `--volume` destinations. This is the invariant that was violated.
+
+For the migration categoriser, add cases to the existing bun-registered migration suite
+(or a new `packages/cli/test-bun/*.bun.ts` file registered in the manifest) driving the
+real `performMigration` against a temp legacy directory:
+
+7. A legacy dir containing `welcomeConfig.json` migrates it to the **config** destination,
+   not data, and `isWelcomeCompleted()` reads it back as completed.
+8. Same for `trustedFolders.json`.
+9. A legacy `skills/<name>/SKILL.md` lands under `<configDir>/skills/<name>/SKILL.md`.
+10. A pre-existing canonical file is not overwritten when migration re-runs after the
+    marker version bump.
+
+No new test may assert on a mock's call arguments in place of real behaviour.
+
+## Verification
+
+    npm run test
+    npm run lint
+    npm run typecheck
+    npm run format
+    npm run build
+    bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+
+Manual sandbox check (docker available locally):
+
+    LLXPRT_SANDBOX=docker llxprt   # twice; the welcome wizard must not reappear

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -191,6 +191,9 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       'src/observation/jspWiring.test.ts',
       'src/observation/observationTap.test.ts',
       'src/utils/sandbox-containers.test.ts',
+      // Issue #3081: legacy→canonical migration categorization for config
+      // entries that were previously routed to the data directory.
+      'test-bun/pathMigration.issue3081.bun.ts',
       // Sandbox SSH agent preflight (issue #1699). Bun-native from the start
       // and likewise excluded from the Vitest selection.
       'src/utils/sandbox-ssh-agent-preflight.test.ts',

--- a/scripts/bun-test-manifest.ts
+++ b/scripts/bun-test-manifest.ts
@@ -194,6 +194,9 @@ export const BUN_NATIVE_TEST_MANIFEST: readonly BunTestWorkspaceEntry[] = [
       // Issue #3081: legacy→canonical migration categorization for config
       // entries that were previously routed to the data directory.
       'test-bun/pathMigration.issue3081.bun.ts',
+      // Issue #3081: sandbox env helpers (current-user detection, container
+      // home resolution, Windows path translation).
+      'test-bun/sandbox-env.bun.ts',
       // Sandbox SSH agent preflight (issue #1699). Bun-native from the start
       // and likewise excluded from the Vitest selection.
       'src/utils/sandbox-ssh-agent-preflight.test.ts',


### PR DESCRIPTION
## TLDR

Fixes the container sandbox path mismatch that made every sandboxed LLxprt launch look like a fresh install. The host global config directory was mounted at the legacy dot-llxprt destination, while the in-container CLI resolves config through the OS-standard path. The sandbox now mounts the canonical config directory at path parity, pins `LLXPRT_CONFIG_HOME` to the mount, and keeps data/cache/log roots container-local via entrypoint exports derived from the real container `HOME`.

Also corrects fresh legacy migrations so `welcomeConfig.json`, `trustedFolders.json`, and user `skills/` are routed to the config directory where the application reads them.

## Dive Deeper

### Container sandbox

- Resolves the host config directory dynamically through `Storage.getGlobalConfigDir()`, so runtime migration fallback and explicit host overrides are honored.
- Mounts that directory at the translated path-parity destination and sets `LLXPRT_CONFIG_HOME` to it.
- Removes the obsolete container-home dot-llxprt destination that triggered a phantom legacy migration on every start.
- Exports `LLXPRT_DATA_HOME`, `LLXPRT_CACHE_HOME`, and `LLXPRT_LOG_HOME` from the real container `$HOME` inside the trusted entrypoint. This is required because those roots otherwise fall back to `LLXPRT_CONFIG_HOME`, which would redirect ephemeral state into the host config mount. Resolving them container-side also supports custom images whose default home is not `/home/node`.
- Rejects `SANDBOX_ENV` attempts to override any of the four canonical roots before image/network/SSH side effects.
- Uses the Podman `:z` shared SELinux label for the writable config bind mount.
- Keeps the security boundary unchanged: only the same global config directory crosses. The data directory is deliberately not mounted because it contains OAuth/provider credentials; credential access remains through the proxy.

### Legacy migration

Fresh/unmarked migrations now route these entries to config rather than data:

- `welcomeConfig.json`
- `trustedFolders.json`
- `skills/`

The migration marker remains version 1. A full marker bump was rejected because re-running the entire copy pass could resurrect deliberately deleted credentials, hooks, commands, profiles, and `.env` files. Recovery of entries already misplaced by a completed v1 migration is tracked separately in #3085 as a bounded data-to-config reconciliation.

Top-level `skills/` deterministically wins over the historical `tmp/skills/` source on same-name collisions.

### Review and verification

- Deep architecture review and Open Code Review completed; all actionable findings were remediated.
- Added Bun-registered behavioral coverage for container argv composition, resolver/mount agreement, custom/current-user `HOME` handling, Windows path translation, reserved-root validation ordering, Podman labeling, migration categorization, marker safety, and skills precedence.
- Updated sandbox documentation, including Windows path translation and non-legacy SSH-agent socket examples.

## Reviewer Test Plan

1. Run the complete validation suite:

       npm run test
       npm run lint
       npm run typecheck
       npm run format
       npm run build
       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

2. Inspect generated container args via the focused suite:

       bun test --preload ./test-setup/augment-bun-vi.ts packages/cli/src/utils/sandbox-containers.test.ts
       bun test packages/cli/test-bun/sandbox-env.bun.ts
       bun test packages/cli/test-bun/pathMigration.issue3081.bun.ts

3. Launch a Docker or Podman sandbox twice from a configured host install. Confirm:
   - the active profile/settings are visible on both launches;
   - the welcome wizard does not reappear;
   - the config root maps to the host canonical directory;
   - data/cache/log roots are under the container `HOME`, not under the mounted config root.

4. Set `SANDBOX_ENV=LLXPRT_CONFIG_HOME=/tmp/override` and confirm startup fails before image/network/SSH setup with the reserved-key error.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ➖  | -   | -   |

macOS Docker and Podman bind-mount checks passed. Windows and Linux behavior is covered by the platform-focused Bun tests; no physical Windows/Linux host was used for this PR. Seatbelt is unaffected by this container-only mount change and already resolves canonical roots directly through `Storage`.

## Linked issues / bugs

Fixes #3081

Follow-up recovery for already-completed v1 migrations: #3085

Related security boundary: #2957


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox containers now preserve global configuration while keeping data, cache, and logs container-local.
  * Sandbox environment settings are validated before startup, with clearer handling of invalid or reserved variables.
  * Configuration migration now includes welcome settings, trusted folders, and skills.

* **Bug Fixes**
  * Migration ordering prevents newer skills from being overwritten by legacy files.
  * SSH-agent setup guidance now uses stable socket locations.

* **Documentation**
  * Updated sandbox and Podman macOS setup instructions to reflect current storage and SSH-agent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->