### PR TITLE
Preserve provider prompt-cache prefixes through compression (Fixes #3070)

### DIFF
--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -76,6 +76,8 @@ Match your context limit to your local model's configuration:
 
 **Important**: This should match the context size configured in your local server (LM Studio, llama.cpp, etc.). Mismatched settings can cause truncation or errors.
 
+> **Rule**: `context-limit` must always be strictly greater than `max_tokens` / `maxOutputTokens`. The completion budget is reserved inside `context-limit`, so a `context-limit` at or below the budget leaves zero room for prompts. For small-context local models (e.g. 32K), explicitly set a smaller `maxOutputTokens` (e.g. `/set maxOutputTokens 8192`) or the compression trigger will fire on every send. See [Provider Models and Limits](./providers/models-and-limits.md) for details.
+
 ### Socket Configuration for Stability
 
 Local AI servers can sometimes have connection stability issues. Configure socket settings for more reliable connections:
@@ -130,6 +132,7 @@ LM Studio is one of the easiest ways to run local models:
 /key clear
 /model your-model-name
 /set context-limit 32768  # Match LM Studio's context setting
+/set maxOutputTokens 16384  # Reserve a smaller budget for small-context models
 ```
 
 ### Ollama

--- a/docs/providers/models-and-limits.md
+++ b/docs/providers/models-and-limits.md
@@ -65,6 +65,30 @@ You can override any limit at runtime:
 /set modelparam max_tokens 4096
 ```
 
+> **Note:** `context-limit` must always exceed `max_tokens` / `maxOutputTokens`.
+> A configured `max_tokens >= context-limit` is rejected as an impossible
+> configuration. For models whose catalog context window is already 200,000,
+> setting `/set context-limit 200000` adds no headroom over the default — you
+> may want to leave the default or increase it only if the provider's actual
+> window is larger.
+
+## Compression and context budgeting
+
+The automatic compression trigger fires when `currentTokens >=
+compressionThreshold × (context-limit − completionBudget)`. This means:
+
+- **Lowering `context-limit` increases spend superlinearly.** Halving the limit
+  does not halve the trigger point — it cuts it much more steeply, because the
+  completion budget is subtracted from a smaller base. More compressions means
+  more paid LLM summarization calls **and** more prompt-cache prefix rewrites.
+- **`max_tokens >= context-limit` is rejected.** An explicitly configured
+  completion budget that meets or exceeds the context window leaves zero prompt
+  budget and is now rejected with an error rather than silently triggering
+  compression on every send.
+- **`compression.strategy=high-density` mutates history continuously** (every
+  turn, not just at the threshold) and is hostile to prompt caching. Use
+  `middle-out` (the default) when cache reuse matters.
+
 ## Model geometry and budgeting
 
 `context-limit` and `max_tokens` describe a **single shared window**, not two

--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import path from 'node:path';
-import { Storage } from '@vybestack/llxprt-code-settings/storage/Storage.js';
 import type { ModelGenerationSettings } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import type {
@@ -33,6 +31,8 @@ import {
   parseCompressionStrategyName,
 } from './compressionStrategyFactory.js';
 import { PendingContextWindowEnforcer } from './pendingContextWindowEnforcement.js';
+import { applyCompressionWithAnchor } from './cacheAnchor.js';
+import { buildCompressionContext as buildContext } from './compressionContextBuilder.js';
 import type { TokenUsageLogger } from '../core/TokenUsageLogger.js';
 /**
  * @plan:PLAN-20260603-ISSUE1584.P05
@@ -48,7 +48,6 @@ import {
   extractThinkingBlocks,
   estimateThinkingTokens,
 } from './reasoningUtils.js';
-import { PromptResolver } from '@vybestack/llxprt-code-core/prompt-config/prompt-resolver.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { retryWithBackoff } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
@@ -88,6 +87,7 @@ export class CompressionHandler {
   private compressionFailureCount: number = 0;
   private lastCompressionFailureTime: number | null = null;
   private lastSuccessfulCompressionTime: number | null = null;
+  private compressionSummary: IContent | undefined;
   densityDirty: boolean = true;
   private _suppressDensityDirty: boolean = false;
   private _suppressDensityDirtyDepth: number = 0;
@@ -271,16 +271,14 @@ export class CompressionHandler {
     // Calculate fresh each time to respect runtime setting changes
     const threshold = this.runtimeContext.ephemerals.compressionThreshold();
     const contextLimit = this.runtimeContext.ephemerals.contextLimit();
-    const completionBudget = Math.max(
-      0,
-      getCompletionBudget(
-        this.generationConfig,
-        this.runtimeContext.state.model,
-        undefined,
-        this.providerRuntimeNullable?.settingsService,
-      ),
+    const completionBudget = getCompletionBudget(
+      this.generationConfig,
+      this.runtimeContext.state.model,
+      undefined,
+      this.providerRuntimeNullable?.settingsService,
+      contextLimit,
     );
-    const effectiveLimit = Math.max(0, contextLimit - completionBudget);
+    const effectiveLimit = contextLimit - completionBudget;
     const compressionThreshold = threshold * effectiveLimit;
 
     this.logger.debug('Compression threshold:', {
@@ -397,17 +395,15 @@ export class CompressionHandler {
     limit: number;
     marginAdjustedLimit: number;
   } {
-    const completionBudget = Math.max(
-      0,
-      getCompletionBudget(
-        this.generationConfig,
-        this.runtimeContext.state.model,
-        provider,
-        this.providerRuntimeNullable?.settingsService,
-      ),
-    );
     const userContextLimit = this.runtimeContext.ephemerals.contextLimit();
     const limit = tokenLimit(this.runtimeContext.state.model, userContextLimit);
+    const completionBudget = getCompletionBudget(
+      this.generationConfig,
+      this.runtimeContext.state.model,
+      provider,
+      this.providerRuntimeNullable?.settingsService,
+      limit,
+    );
     const marginAdjustedLimit = computeMarginAdjustedLimit(limit);
     return { completionBudget, limit, marginAdjustedLimit };
   }
@@ -418,10 +414,7 @@ export class CompressionHandler {
     enforcer: ProviderContentEnforcer,
     pendingContents: IContent[] | undefined,
   ): void {
-    if (!provider) {
-      return;
-    }
-    if (typeof provider.setCompressionCallback !== 'function') {
+    if (!provider || typeof provider.setCompressionCallback !== 'function') {
       return;
     }
 
@@ -447,12 +440,6 @@ export class CompressionHandler {
     };
 
     provider.setCompressionCallback(callback);
-  }
-
-  private detachCompressionCallback(provider?: IProvider): void {
-    if (provider && typeof provider.setCompressionCallback === 'function') {
-      provider.setCompressionCallback(null);
-    }
   }
 
   private pushSuppressDensityDirty(): void {
@@ -488,7 +475,9 @@ export class CompressionHandler {
    */
   clearProviderCompressionCallback(provider?: IProvider): void {
     try {
-      this.detachCompressionCallback(provider);
+      if (provider && typeof provider.setCompressionCallback === 'function') {
+        provider.setCompressionCallback(null);
+      }
     } catch (error) {
       this.logger.warn(
         () =>
@@ -522,7 +511,11 @@ export class CompressionHandler {
           const outcome = await this.performFallbackCompression(
             context,
             new Error('Provider content fallback truncation triggered'),
-            applyAndResetPromptCount,
+            // The enforcer owns its own history restore (restoreHistory) which
+            // already resets the cache anchor; the topPreserved parameter is
+            // not consumed on this path.
+            (newHistory, _summary, _topPreserved) =>
+              applyAndResetPromptCount(newHistory),
             { swallowErrors: false },
           );
           return outcome === 'applied';
@@ -656,11 +649,11 @@ export class CompressionHandler {
     const preCompressionCount =
       this.historyService.getStatistics().totalMessages;
     this.historyService.startCompression();
-    let compressionSummary: IContent | undefined;
     // Compression outcome determined by runCompressionWithRetryAndFallback.
     // On 'noop', we must avoid history mutation, recording events, and
     // counter/timestamp changes entirely. (Issue #2602)
     let compressionOutcome: 'applied' | 'noop' | 'failed' = 'failed';
+    this.compressionSummary = undefined;
     // @plan PLAN-20260211-HIGHDENSITY.P20
     // @requirement REQ-HD-002.6
     // Suppress densityDirty during compression rebuild (clear+add loop)
@@ -668,22 +661,7 @@ export class CompressionHandler {
     try {
       compressionOutcome = await this.runCompressionWithRetryAndFallback(
         prompt_id,
-        (newHistory, summary) => {
-          // Record which chronology span the summary stands in for BEFORE the
-          // write-back, so the destroyed seq range is still derivable (#1721).
-          // The subsequent add() calls stamp the summary's own marker.
-          const annotated = annotateCompressionSpan(
-            this.historyService.getRawHistory(),
-            newHistory,
-          );
-          // Apply result: clear history, add each entry from newHistory
-          this.historyService.clear();
-          for (const content of annotated) {
-            this.historyService.add(content, this.runtimeContext.state.model);
-          }
-          this.lastPromptTokenCount = null;
-          compressionSummary = summary;
-        },
+        this.createApplyCallback(),
       );
     } finally {
       this.setSuppressDensityDirty(false);
@@ -694,7 +672,7 @@ export class CompressionHandler {
         this.historyService.endCompression();
       } else {
         this.historyService.endCompression(
-          compressionSummary,
+          this.compressionSummary,
           preCompressionCount,
         );
       }
@@ -717,6 +695,33 @@ export class CompressionHandler {
     );
 
     return PerformCompressionResult.FAILED;
+  }
+
+  /**
+   * Create the apply callback for runCompressionWithRetryAndFallback.
+   *
+   * Resolves and validates the new cache anchor BEFORE mutating history so an
+   * invalid strategy result cannot leave a partially applied compression
+   * (#3070 Defect 3). After mutation: if the prefix was destroyed
+   * (topPreserved <= 0), explicitly reset the anchor (#3070 Defect 5);
+   * otherwise set it to the last preserved-head entry's exact identity.
+   */
+  private createApplyCallback(): (
+    newHistory: IContent[],
+    summary: IContent | undefined,
+    topPreserved: number,
+  ) => void {
+    return (newHistory, summary, topPreserved) => {
+      applyCompressionWithAnchor(
+        this.historyService,
+        newHistory,
+        topPreserved,
+        this.runtimeContext.state.model,
+        annotateCompressionSpan,
+      );
+      this.lastPromptTokenCount = null;
+      this.compressionSummary = summary;
+    };
   }
 
   /**
@@ -802,6 +807,7 @@ export class CompressionHandler {
     applyResult: (
       newHistory: IContent[],
       summary: IContent | undefined,
+      topPreserved: number,
     ) => void,
   ): Promise<'applied' | 'noop' | 'failed'> {
     const context = await this.buildCompressionContext(promptId);
@@ -856,7 +862,8 @@ export class CompressionHandler {
     const fallbackOutcome = await this.performFallbackCompression(
       context,
       primaryError,
-      (newHistory, summary) => applyResult(newHistory, summary),
+      (newHistory, summary, topPreserved) =>
+        applyResult(newHistory, summary, topPreserved),
     );
     return fallbackOutcome;
   }
@@ -876,6 +883,7 @@ export class CompressionHandler {
     applyResult: (
       newHistory: IContent[],
       summary: IContent | undefined,
+      topPreserved: number,
     ) => void,
   ): Promise<'applied' | 'noop'> {
     if (configuredStrategyName !== 'middle-out') {
@@ -919,20 +927,28 @@ export class CompressionHandler {
     applyResult: (
       newHistory: IContent[],
       summary: IContent | undefined,
+      topPreserved: number,
     ) => void,
   ): void {
     if (result.kind === 'noop') {
-      // Defensive: callers (pending enforcer) already filter noop, but ensure
-      // a truthful no-op never mutates history if reached directly.
       this.logger.debug(
         `applyFallbackCompressionResult received structural no-op (${result.reason}); not applying`,
       );
       return;
     }
+    // Delegate the history mutation to the caller-supplied applyResult so each
+    // caller's rewrite runs with its own contract: createApplyCallback applies
+    // the cache anchor via applyCompressionWithAnchor on the primary path,
+    // while the enforcer wrappers (executeFallbackTruncation,
+    // PendingContextWindowEnforcer) own their clear/rebuild and rely on this
+    // callback to mark history as applied (historyRestored). Every caller also
+    // clears the stale prompt-token baseline, so applying it here directly
+    // would bypass those contracts (#3070 fallback truncation propagation).
     const summary = CompressionHandler.selectCompressionSummary(
       result.newHistory,
     );
-    applyResult(result.newHistory, summary);
+    applyResult(result.newHistory, summary, result.metadata.topPreserved ?? 0);
+    this.compressionSummary = summary;
     this.compressionFailureCount = 0;
     this.lastCompressionFailureTime = null;
     this.lastSuccessfulCompressionTime = Date.now();
@@ -966,6 +982,7 @@ export class CompressionHandler {
     applyResult: (
       newHistory: IContent[],
       summary: IContent | undefined,
+      topPreserved: number,
     ) => void,
     options?: { swallowErrors?: boolean },
   ): Promise<'applied' | 'noop' | 'failed'> {
@@ -1022,46 +1039,14 @@ export class CompressionHandler {
    * @requirement REQ-CS-001.6
    */
   async buildCompressionContext(promptId: string): Promise<CompressionContext> {
-    const promptResolver = new PromptResolver();
-    const promptBaseDir = path.join(Storage.getGlobalConfigDir(), 'prompts');
-
-    let activeTodos: string | undefined;
-    if (this.activeTodosProvider) {
-      try {
-        activeTodos = await this.activeTodosProvider();
-      } catch (error) {
-        this.logger.debug(
-          'Failed to fetch active todos for compression',
-          error,
-        );
-      }
-    }
-
-    // Get config from runtimeContext for bucket failover handling
-    const config = this.providerRuntimeNullable?.config;
-
-    return {
-      history: this.historyService.getCurated(),
-      runtimeContext: this.runtimeContext,
-      runtimeState: this.runtimeContext.state,
-      estimateTokens: (contents) =>
-        this.historyService.estimateTokensForContents(contents as IContent[]),
-      currentTokenCount: this.historyService.getTotalTokens(),
-      logger: this.logger,
-      resolveProvider: (profileName?) =>
-        Promise.resolve(this.providerResolver(profileName)),
-      promptResolver,
-      promptBaseDir,
-      promptContext: {
-        provider: this.runtimeContext.state.provider,
-        model: this.runtimeContext.state.model,
-      },
+    return buildContext(
       promptId,
-      ...(activeTodos ? { activeTodos } : {}),
-      compressionVerification:
-        this.runtimeContext.ephemerals.compressionVerification(),
-      ...(config ? { config } : {}),
-    };
+      this.runtimeContext,
+      this.historyService,
+      (profileName?) => Promise.resolve(this.providerResolver(profileName)),
+      this.activeTodosProvider,
+      this.logger,
+    );
   }
 
   /**

--- a/packages/agents/src/compression/MiddleOutStrategy.ts
+++ b/packages/agents/src/compression/MiddleOutStrategy.ts
@@ -47,6 +47,7 @@ import {
 import {
   adjustForToolCallBoundary,
   aggregateTextFromBlocks,
+  findForwardValidSplitPoint,
   buildTriggerInstruction,
   COMPRESSION_SECURITY_PREAMBLE,
   runVerificationPass,
@@ -243,7 +244,12 @@ export class MiddleOutStrategy implements CompressionStrategy {
     const topPreserveThreshold =
       context.runtimeContext.ephemerals.topPreserveThreshold();
 
-    let topSplitIndex = Math.ceil(history.length * topPreserveThreshold);
+    let topSplitIndex = this.resolveTopSplitIndex(
+      history,
+      topPreserveThreshold,
+      context.cacheAnchorSeq ?? 0,
+    );
+    const anchorFloor = topSplitIndex;
     let bottomSplitIndex = Math.floor(history.length * (1 - preserveThreshold));
 
     if (bottomSplitIndex - topSplitIndex < MINIMUM_MIDDLE_MESSAGES) {
@@ -251,6 +257,18 @@ export class MiddleOutStrategy implements CompressionStrategy {
     }
 
     topSplitIndex = adjustForToolCallBoundary(history, topSplitIndex);
+    // The tool-boundary adjustment can move the index BACKWARD (forward scan
+    // returns index-1; backward scan can go arbitrarily far back). If it drops
+    // below the anchor floor, search FORWARD for the next valid split point at
+    // or above the floor so the cacheable prefix invariant is never broken
+    // (#3070 Defect 4). If no valid split at or above the floor exists, return
+    // a clean structural no-op rather than silently dropping below the floor.
+    if (topSplitIndex < anchorFloor) {
+      topSplitIndex = this.findValidSplitAtOrAboveFloor(history, anchorFloor);
+      if (topSplitIndex === -1) {
+        return { toKeepTop: [...history], toCompress: [], toKeepBottom: [] };
+      }
+    }
     bottomSplitIndex = adjustForToolCallBoundary(history, bottomSplitIndex);
 
     if (
@@ -265,6 +283,70 @@ export class MiddleOutStrategy implements CompressionStrategy {
       toCompress: history.slice(topSplitIndex, bottomSplitIndex),
       toKeepBottom: history.slice(bottomSplitIndex),
     };
+  }
+
+  /**
+   * Resolve the top (preserved-head) split index, applying the monotonic cache
+   * anchor floor so the preserved head never shrinks across successive
+   * compressions (#3070).
+   *
+   * The base index is `ceil(N * topPreserveThreshold)`. The anchor raises it to
+   * `anchorIndex + 1`, where `anchorIndex` is the index of the history entry
+   * whose chronology `seq` is EXACTLY `cacheAnchorSeq`. The match is by exact
+   * identity, not a `<=` threshold scan, because the compression rebuild
+   * re-adds preserved TAIL entries that keep their ORIGINAL low seqs while the
+   * freshly minted summary/continuation get the HIGHEST seqs and sit in the
+   * MIDDLE of the array — so the array is NOT sorted by seq and a backward
+   * `<=` scan would match a low-seq TAIL entry at a high index (#3070 Defect 2).
+   * When no entry matches exactly there is no floor; fall back to the base
+   * fractional split. An anchor at or beyond the whole history degrades to a
+   * split past the end, which the caller's structural no-op guards turn into a
+   * clean no-op.
+   */
+  private resolveTopSplitIndex(
+    history: readonly IContent[],
+    topPreserveThreshold: number,
+    cacheAnchorSeq: number,
+  ): number {
+    const baseSplitIndex = Math.ceil(history.length * topPreserveThreshold);
+
+    if (cacheAnchorSeq <= 0) {
+      return baseSplitIndex;
+    }
+
+    let anchorIndex = -1;
+    for (let i = 0; i < history.length; i++) {
+      const seq = history[i].metadata?.chronology?.seq;
+      if (seq === cacheAnchorSeq) {
+        anchorIndex = i;
+        break;
+      }
+    }
+
+    if (anchorIndex === -1) {
+      return baseSplitIndex;
+    }
+
+    return Math.max(baseSplitIndex, anchorIndex + 1);
+  }
+
+  /**
+   * Search forward from the anchor floor for the next valid split point that
+   * does not land inside a tool-call/response pair. The canonical utility may
+   * move a candidate backward, so candidates below the floor are skipped.
+   */
+  private findValidSplitAtOrAboveFloor(
+    history: readonly IContent[],
+    floor: number,
+  ): number {
+    const candidateHistory = [...history];
+    for (let candidate = floor; candidate <= history.length; candidate++) {
+      const adjusted = findForwardValidSplitPoint(candidateHistory, candidate);
+      if (adjusted >= floor) {
+        return adjusted;
+      }
+    }
+    return -1;
   }
 
   private resolvePrompt(context: CompressionContext): string {

--- a/packages/agents/src/compression/__tests__/compression.characterization.test.ts
+++ b/packages/agents/src/compression/__tests__/compression.characterization.test.ts
@@ -490,6 +490,12 @@ describe('P26: compressionBudgeting characterization', () => {
     ).toBe(32768);
   });
 
+  it('getCompletionBudget rejects a non-positive context limit', () => {
+    expect(() => getCompletionBudget({}, 'm', undefined, undefined, 0)).toThrow(
+      RangeError,
+    );
+  });
+
   it('getCompletionBudget rejects a live budget that consumes the context', () => {
     const settingsService = {
       get: (key: string) => (key === 'maxOutputTokens' ? 131_072 : undefined),

--- a/packages/agents/src/compression/__tests__/compression.characterization.test.ts
+++ b/packages/agents/src/compression/__tests__/compression.characterization.test.ts
@@ -40,6 +40,7 @@ import {
   extractCompletionBudgetFromParams,
   getCompletionBudget,
   estimatePendingTokens,
+  InvalidContextBudgetError,
 } from '../compressionBudgeting.js';
 import type { ProviderContentEnvelope } from '@vybestack/llxprt-code-core/services/history/historyProviderPipeline.js';
 
@@ -453,18 +454,24 @@ describe('P26: compressionBudgeting characterization', () => {
 
   it('getCompletionBudget prefers generationConfig.maxOutputTokens over provider params and default', () => {
     const cfg = { maxOutputTokens: 8192 } as Record<string, unknown>;
-    expect(getCompletionBudget(cfg as never, 'm')).toBe(8192);
+    expect(
+      getCompletionBudget(cfg as never, 'm', undefined, undefined, 131_072),
+    ).toBe(8192);
   });
 
   it('getCompletionBudget falls back to provider getModelParams when generationConfig has no budget', () => {
     const provider = {
       getModelParams: () => ({ maxTokens: 4096 }),
     } as unknown as IProvider;
-    expect(getCompletionBudget({}, 'm', provider)).toBe(4096);
+    expect(getCompletionBudget({}, 'm', provider, undefined, 131_072)).toBe(
+      4096,
+    );
   });
 
   it('getCompletionBudget falls back to the default (65536) when nothing is set', () => {
-    expect(getCompletionBudget({}, 'm')).toBe(65_536);
+    expect(getCompletionBudget({}, 'm', undefined, undefined, 131_072)).toBe(
+      65_536,
+    );
   });
 
   it('getCompletionBudget prefers the live settingsService maxOutputTokens over all other sources', () => {
@@ -473,8 +480,39 @@ describe('P26: compressionBudgeting characterization', () => {
     };
     const cfg = { maxOutputTokens: 8192 } as Record<string, unknown>;
     expect(
-      getCompletionBudget(cfg as never, 'm', undefined, settingsService),
+      getCompletionBudget(
+        cfg as never,
+        'm',
+        undefined,
+        settingsService,
+        131_072,
+      ),
     ).toBe(32768);
+  });
+
+  it('getCompletionBudget rejects a live budget that consumes the context', () => {
+    const settingsService = {
+      get: (key: string) => (key === 'maxOutputTokens' ? 131_072 : undefined),
+    };
+    expect(() =>
+      getCompletionBudget({}, 'm', undefined, settingsService, 131_072),
+    ).toThrow(InvalidContextBudgetError);
+  });
+
+  it('getCompletionBudget rejects a generation budget that consumes the context', () => {
+    const cfg = { maxOutputTokens: 131_072 } as Record<string, unknown>;
+    expect(() =>
+      getCompletionBudget(cfg as never, 'm', undefined, undefined, 131_072),
+    ).toThrow(InvalidContextBudgetError);
+  });
+
+  it('getCompletionBudget rejects a provider budget that consumes the context', () => {
+    const provider = {
+      getModelParams: () => ({ maxTokens: 131_072 }),
+    } as unknown as IProvider;
+    expect(() =>
+      getCompletionBudget({}, 'm', provider, undefined, 131_072),
+    ).toThrow(InvalidContextBudgetError);
   });
 
   it('estimatePendingTokens returns 0 for empty contents', async () => {

--- a/packages/agents/src/compression/__tests__/compressionAnchorE2E.test.ts
+++ b/packages/agents/src/compression/__tests__/compressionAnchorE2E.test.ts
@@ -69,6 +69,11 @@ function extractHeadByAnchor(hs: HistoryService): string[] {
     const anchorIndex = curated.findIndex(
       (entry) => entry.metadata?.chronology?.seq === anchorSeq,
     );
+    if (anchorIndex < 0) {
+      throw new Error(
+        `Cache anchor ${anchorSeq} is absent from curated history`,
+      );
+    }
     headEnd = anchorIndex + 1;
   }
   return serializeForCache(curated.slice(0, headEnd));

--- a/packages/agents/src/compression/__tests__/compressionAnchorE2E.test.ts
+++ b/packages/agents/src/compression/__tests__/compressionAnchorE2E.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * End-to-end prefix-stability tests for issue #3070 (cache anchor).
+ *
+ * These tests drive CompressionHandler.performCompression (NOT MiddleOutStrategy
+ * directly) against a real HistoryService over multiple compressions with a
+ * growing history. This is the regime where all of Defects 1-4 manifest and
+ * where the anchor actually binds.
+ *
+ * The ONLY test double is a real in-process async generator satisfying the
+ * IProvider port. No assertions on mock call records.
+ */
+
+import { describe, it, expect, vi, beforeEach } from '../../testApi.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { CompressionHandler } from '../CompressionHandler.js';
+import { buildRuntimeContext } from '../../core/__tests__/chatSession-density-helpers.js';
+import {
+  createCaptureProvider,
+  testProviderRuntime,
+} from '../MiddleOutStrategy-test-helpers.js';
+import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
+
+// ---------------------------------------------------------------------------
+// Test-local helpers: operational definition of a "cacheable prefix"
+// ---------------------------------------------------------------------------
+
+function serializeForCache(contents: readonly IContent[]): string[] {
+  return contents.map((c) =>
+    JSON.stringify({ speaker: c.speaker, blocks: c.blocks }),
+  );
+}
+
+function commonPrefixLength(
+  a: readonly string[],
+  b: readonly string[],
+): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return i;
+  }
+  return len;
+}
+
+function humanMsg(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+function aiMsg(text: string): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text }] };
+}
+
+/**
+ * Extract the serialized preserved head using the cache anchor: find the entry
+ * whose chronology.seq === cacheAnchorSeq (exact identity, per Defect 2 fix).
+ * The head is everything up to and including that entry.
+ */
+function extractHeadByAnchor(hs: HistoryService): string[] {
+  const anchorSeq = hs.getCacheAnchorSeq();
+  const curated = hs.getCurated();
+  let headEnd = 0;
+  if (anchorSeq > 0) {
+    const anchorIndex = curated.findIndex(
+      (entry) => entry.metadata?.chronology?.seq === anchorSeq,
+    );
+    headEnd = anchorIndex + 1;
+  }
+  return serializeForCache(curated.slice(0, headEnd));
+}
+
+/**
+ * Build a CompressionHandler with a real HistoryService and a real in-process
+ * provider (capture provider). Uses production geometry for compression settings.
+ */
+function buildHandler(opts: {
+  historyService: HistoryService;
+  capturedRequests: IContent[];
+}): CompressionHandler {
+  const { historyService, capturedRequests } = opts;
+
+  const runtimeContext = buildRuntimeContext(historyService, {
+    contextLimit: 200_000,
+    compressionThreshold: 0.85,
+  });
+
+  const provider = createCaptureProvider(capturedRequests);
+  const providerResult = {
+    provider,
+    runtime: testProviderRuntime as never,
+  };
+
+  const handler = new CompressionHandler(
+    runtimeContext,
+    historyService,
+    {},
+    () => Promise.resolve(providerResult),
+    () => Promise.resolve(undefined),
+  );
+
+  return handler;
+}
+
+// ---------------------------------------------------------------------------
+// E2E: serialized content prefix is monotonically non-decreasing
+// ---------------------------------------------------------------------------
+
+describe('E2E: CompressionHandler.performCompression keeps prefix monotonically non-decreasing across 5 compressions with growing history (#3070 Defects 1-4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('serialized content prefix never shrinks across 5 append-compress cycles', async () => {
+    const historyService = new HistoryService();
+    const capturedRequests: IContent[] = [];
+    const handler = buildHandler({ historyService, capturedRequests });
+
+    // Seed with 40 messages (20 turns) — enough to compress
+    for (let i = 0; i < 20; i++) {
+      historyService.add(humanMsg(`seed user ${i}`));
+      historyService.add(aiMsg(`seed ai ${i}`));
+    }
+
+    // Track the preserved HEAD content (everything up to the cache anchor seq)
+    // across cycles. The head is the cacheable prefix; it must never shrink.
+    let prevHead: string[] = [];
+    let prevAnchorSeq = 0;
+    let anchorAdvanced = false;
+
+    for (let cycle = 0; cycle < 5; cycle++) {
+      // Force compression by calling performCompression directly
+      const result = await handler.performCompression('test-prompt', {
+        trigger: 'manual',
+      });
+
+      // Compression should have applied (or no-op, which is also prefix-stable)
+      expect([
+        PerformCompressionResult.COMPRESSED,
+        PerformCompressionResult.NOOP,
+      ]).toContain(result);
+
+      // Extract the preserved head using the cache anchor: find the entry whose
+      // chronology.seq === cacheAnchorSeq (exact identity, per Defect 2 fix).
+      // The head is everything up to and including that entry.
+      const currentHead = extractHeadByAnchor(historyService);
+
+      // The previous head must be a COMPLETE prefix of the current head. The
+      // anchor may remain fixed for a cycle, but it must never move backward,
+      // and this growing workload must advance it at least once.
+      const prefix = commonPrefixLength(prevHead, currentHead);
+      expect(prefix).toBe(prevHead.length);
+      const currentAnchorSeq = historyService.getCacheAnchorSeq();
+      expect(currentAnchorSeq).toBeGreaterThanOrEqual(prevAnchorSeq);
+      anchorAdvanced ||= currentAnchorSeq > prevAnchorSeq;
+
+      prevHead = currentHead;
+      prevAnchorSeq = currentAnchorSeq;
+
+      // Append enough messages to push the fractional split beyond the prior
+      // head, forcing the anchor itself to advance. Twelve reaches a fixed
+      // point where the floor never binds and would miss anchor regressions.
+      for (let i = 0; i < 8; i++) {
+        historyService.add(humanMsg(`cycle ${cycle} user ${i}`));
+        historyService.add(aiMsg(`cycle ${cycle} ai ${i}`));
+      }
+    }
+
+    expect(anchorAdvanced).toBe(true);
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Defect 5: prefix-destroying strategies leave a stale anchor
+// ---------------------------------------------------------------------------
+
+describe('Defect 5: prefix-destroying compression resets the anchor and next compression is not wedged (#3070)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('after a truncation-style result that preserves no head, the anchor resets and the next compression succeeds', async () => {
+    const historyService = new HistoryService();
+    const capturedRequests: IContent[] = [];
+    const handler = buildHandler({ historyService, capturedRequests });
+
+    // Seed history
+    for (let i = 0; i < 20; i++) {
+      historyService.add(humanMsg(`seed user ${i}`));
+      historyService.add(aiMsg(`seed ai ${i}`));
+    }
+
+    // Advance the anchor to simulate a prior compression having set it
+    const stamped = historyService.getRawHistory();
+    const lastSeq = stamped[stamped.length - 1].metadata?.chronology?.seq ?? 0;
+    historyService.setCacheAnchorSeq(lastSeq);
+
+    // Now manually simulate a prefix-destroying result by clearing history
+    // and resetting the anchor (as TopDownTruncationStrategy path would do)
+    historyService.clear();
+    historyService.resetCacheAnchorSeq();
+
+    expect(historyService.getCacheAnchorSeq()).toBe(0);
+
+    // Re-add a small history and confirm a new compression can proceed
+    for (let i = 0; i < 20; i++) {
+      historyService.add(humanMsg(`post-reset user ${i}`));
+      historyService.add(aiMsg(`post-reset ai ${i}`));
+    }
+
+    const result = await handler.performCompression('test-prompt', {
+      trigger: 'manual',
+    });
+
+    // Must not be wedged — compression applies or no-ops cleanly
+    expect([
+      PerformCompressionResult.COMPRESSED,
+      PerformCompressionResult.NOOP,
+    ]).toContain(result);
+
+    // Anchor must be in a valid state (either 0 or advanced, not stale)
+    const anchorAfter = historyService.getCacheAnchorSeq();
+    expect(anchorAfter).toBeGreaterThanOrEqual(0);
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Defect 6: client.restoreHistory resets the anchor
+// ---------------------------------------------------------------------------
+
+describe('Defect 6: client.restoreHistory resets the cache anchor (#3070)', () => {
+  it('HistoryService.resetCacheAnchorSeq resets to 0 (the primitive restoreHistory calls)', () => {
+    const hs = new HistoryService();
+    hs.setCacheAnchorSeq(42);
+    expect(hs.getCacheAnchorSeq()).toBe(42);
+
+    hs.resetCacheAnchorSeq();
+    expect(hs.getCacheAnchorSeq()).toBe(0);
+  });
+
+  it('a wholesale history replacement via addAll after resetCacheAnchorSeq leaves the anchor at 0', () => {
+    const hs = new HistoryService();
+    hs.setCacheAnchorSeq(99);
+    expect(hs.getCacheAnchorSeq()).toBe(99);
+
+    // Simulate the restoreHistory flow: reset + validateAndFix + addAll
+    hs.resetCacheAnchorSeq();
+    hs.validateAndFix();
+    const newHistory: IContent[] = [];
+    for (let i = 0; i < 5; i++) {
+      newHistory.push(humanMsg(`restored user ${i}`));
+      newHistory.push(aiMsg(`restored ai ${i}`));
+    }
+    hs.addAll(newHistory);
+
+    // The anchor must be 0 — restoreHistory resets it
+    expect(hs.getCacheAnchorSeq()).toBe(0);
+  });
+});

--- a/packages/agents/src/compression/__tests__/compressionPrefixStability.test.ts
+++ b/packages/agents/src/compression/__tests__/compressionPrefixStability.test.ts
@@ -1,0 +1,557 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Prefix-stability tests for issue #3070.
+ *
+ * Defect A: the compression trigger collapsed to zero on small context windows
+ * because the completion budget defaulted to a flat 65,536 regardless of the
+ * window size, and a `Math.max(0, ...)` clamp silently converted the
+ * contradiction into every-send compression.
+ *
+ * Defect B: the preserved-head split boundary was a fraction of the CURRENT
+ * history length, so it shrank after each compression, destroying the
+ * cacheable prefix for every provider. The fix is a monotonic cache anchor
+ * derived from `metadata.chronology.seq`.
+ *
+ * The ONLY test double is a real in-process async generator satisfying the
+ * IProvider port. Every assertion is on observable output (returned
+ * newHistory, pure-function return/throw). Metadata is excluded from the
+ * cache-prefix proxy because chronology is never serialized to a provider.
+ */
+
+import { describe, it, expect } from '../../testApi.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type {
+  CompressionContext,
+  StrategyCompressionResult,
+} from '@vybestack/llxprt-code-core/core/compression/types.js';
+import { MiddleOutStrategy } from '../MiddleOutStrategy.js';
+import {
+  buildContext,
+  humanMsg,
+  aiTextMsg,
+  aiToolCallMsg,
+  toolResponseMsg,
+} from '../MiddleOutStrategy-test-helpers.js';
+import {
+  getCompletionBudget,
+  DEFAULT_COMPLETION_BUDGET,
+  DEFAULT_COMPLETION_FRACTION,
+  InvalidContextBudgetError,
+} from '../compressionBudgeting.js';
+import { resolveHeadAnchorSeq } from '../cacheAnchor.js';
+
+// ---------------------------------------------------------------------------
+// Test-local helpers: operational definition of a "cacheable prefix"
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize content the way an implicit-cache provider matches on it:
+ * speaker + blocks only. Chronology metadata is deliberately excluded because
+ * it is never sent to a provider.
+ */
+function serializeForCache(contents: readonly IContent[]): string[] {
+  return contents.map((c) =>
+    JSON.stringify({ speaker: c.speaker, blocks: c.blocks }),
+  );
+}
+
+/** Count of equal leading serialised entries between two arrays. */
+function commonPrefixLength(
+  a: readonly string[],
+  b: readonly string[],
+): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return i;
+  }
+  return len;
+}
+
+/**
+ * Index of the end of the preserved head, using the strategy-reported
+ * preserved-head length rather than searching for a summary entry. Searching
+ * for the FIRST isSummary entry is wrong from the second compression onward
+ * because the previous compression's summary sits inside the preserved head
+ * and still carries isSummary metadata (#3070 test defect).
+ */
+function findHeadEnd(
+  history: readonly IContent[],
+  topPreserved: number,
+): number {
+  return Math.min(topPreserved, history.length);
+}
+
+// ---------------------------------------------------------------------------
+// Context builder: real chronology + cache anchor
+// ---------------------------------------------------------------------------
+
+/** Production geometry: preserveThreshold=0.4, topPreserveThreshold=0.2. */
+const PRODUCTION_PRESERVE = 0.4;
+const PRODUCTION_TOP_PRESERVE = 0.2;
+
+/** Stamp chronology onto plain messages via a real HistoryService. */
+function stampHistory(messages: IContent[]): IContent[] {
+  const hs = new HistoryService();
+  for (const msg of messages) {
+    hs.add(msg);
+  }
+  return [...hs.getRawHistory()];
+}
+
+/** Build a CompressionContext from already-stamped history + anchor. */
+function buildCtx(
+  stampedHistory: IContent[],
+  anchor: number,
+): CompressionContext {
+  return {
+    ...buildContext({
+      history: stampedHistory,
+      preserveThreshold: PRODUCTION_PRESERVE,
+      topPreserveThreshold: PRODUCTION_TOP_PRESERVE,
+    }),
+    cacheAnchorSeq: anchor,
+  };
+}
+
+/**
+ * Re-stamp a strategy-produced newHistory through a fresh HistoryService,
+ * preserving existing chronology markers on head/bottom entries and minting
+ * new ones for the synthetic summary/continuation entries, then append
+ * additional messages.
+ */
+function restampAndAppend(
+  newHistory: IContent[],
+  extra: IContent[],
+): IContent[] {
+  const hs = new HistoryService();
+  for (const entry of newHistory) {
+    hs.add(entry);
+  }
+  for (const msg of extra) {
+    hs.add(msg);
+  }
+  return [...hs.getRawHistory()];
+}
+
+function assertApplied(result: StrategyCompressionResult): {
+  newHistory: IContent[];
+  topPreserved: number;
+} {
+  if (result.kind !== 'applied') {
+    throw new Error(
+      `Expected compression to apply but got kind=${result.kind}`,
+    );
+  }
+  return {
+    newHistory: result.newHistory,
+    topPreserved: result.metadata.topPreserved,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// A3: trigger arithmetic (budget fraction + fail-fast)
+// ---------------------------------------------------------------------------
+
+describe('A3: completion-budget trigger arithmetic (#3070 Defect A)', () => {
+  const THRESHOLD = 0.85;
+
+  function triggerFor(contextLimit: number, budget: number): number {
+    return THRESHOLD * (contextLimit - budget);
+  }
+
+  it('with an explicit 65536 budget: 200k → 114294.4, 100k → 29294.4 (ratio > 3.5)', () => {
+    const budget = getCompletionBudget(
+      { maxOutputTokens: 65_536 } as never,
+      'm',
+      undefined,
+      undefined,
+      200_000,
+    );
+    const trigger200k = triggerFor(200_000, budget);
+    const trigger100k = triggerFor(100_000, budget);
+
+    expect(budget).toBe(65_536);
+    expect(trigger200k).toBeCloseTo(114_294.4, 1);
+    expect(trigger100k).toBeCloseTo(29_294.4, 1);
+    expect(trigger200k / trigger100k).toBeGreaterThan(3.5);
+  });
+
+  it('throws InvalidContextBudgetError when an explicit budget >= context-limit', () => {
+    expect(() =>
+      getCompletionBudget(
+        { maxOutputTokens: 200_000 } as never,
+        'm',
+        undefined,
+        undefined,
+        200_000,
+      ),
+    ).toThrow(InvalidContextBudgetError);
+  });
+
+  it('throws when a live maxOutputTokens setting >= context-limit', () => {
+    const settingsService = {
+      get: (key: string) => (key === 'maxOutputTokens' ? 50_000 : undefined),
+    };
+    expect(() =>
+      getCompletionBudget({}, 'm', undefined, settingsService, 50_000),
+    ).toThrow(InvalidContextBudgetError);
+  });
+
+  it('default budget on a 32768 window produces a POSITIVE trigger (every-send loop is gone)', () => {
+    const budget = getCompletionBudget({}, 'm', undefined, undefined, 32_768);
+    const trigger = triggerFor(32_768, budget);
+
+    // min(65536, floor(32768 * 0.5)) = 16384
+    expect(budget).toBe(16_384);
+    expect(trigger).toBeCloseTo(13_926.4, 1);
+    expect(trigger).toBeGreaterThan(0);
+  });
+
+  it('default budget is identical to the flat 65536 for every window >= 131072', () => {
+    for (const limit of [131_072, 200_000, 1_000_000]) {
+      const budget = getCompletionBudget({}, 'm', undefined, undefined, limit);
+      expect(budget).toBe(DEFAULT_COMPLETION_BUDGET);
+    }
+  });
+
+  it('DEFAULT_COMPLETION_FRACTION is 0.5', () => {
+    expect(DEFAULT_COMPLETION_FRACTION).toBe(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A4: HistoryService cache-anchor contract
+// ---------------------------------------------------------------------------
+
+describe('A4: HistoryService cache-anchor contract (#3070 Defect B)', () => {
+  it('a fresh service reports 0', () => {
+    const hs = new HistoryService();
+    expect(hs.getCacheAnchorSeq()).toBe(0);
+  });
+
+  it('setCacheAnchorSeq tracks exact identity, including a numerically lower seq', () => {
+    const hs = new HistoryService();
+    hs.setCacheAnchorSeq(10);
+    expect(hs.getCacheAnchorSeq()).toBe(10);
+    hs.setCacheAnchorSeq(5);
+    expect(hs.getCacheAnchorSeq()).toBe(5);
+  });
+
+  it('setCacheAnchorSeq rejects non-positive and non-integer identities', () => {
+    const hs = new HistoryService();
+    expect(() => hs.setCacheAnchorSeq(0)).toThrow();
+    expect(() => hs.setCacheAnchorSeq(1.5)).toThrow();
+  });
+
+  it('clear() preserves the anchor (compression rebuild survives)', () => {
+    const hs = new HistoryService();
+    hs.add(humanMsg('msg'));
+    hs.setCacheAnchorSeq(3);
+    hs.clear();
+    expect(hs.getCacheAnchorSeq()).toBe(3);
+  });
+
+  it('resetCacheAnchorSeq resets to 0 (session-reset path)', () => {
+    const hs = new HistoryService();
+    hs.setCacheAnchorSeq(7);
+    hs.resetCacheAnchorSeq();
+    expect(hs.getCacheAnchorSeq()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A1 + A2: head never shrinks across successive compressions
+// ---------------------------------------------------------------------------
+
+describe('A1: preserved head never shrinks across successive compressions (#3070 Defect B)', () => {
+  it('40 messages → head preserved after second compression with anchor', async () => {
+    const strategy = new MiddleOutStrategy();
+
+    // 40 plain human/ai messages (no tool calls → boundary adjustment is no-op)
+    const baseHistory: IContent[] = [];
+    for (let i = 0; i < 20; i++) {
+      baseHistory.push(humanMsg(`user ${i}`));
+      baseHistory.push(aiTextMsg(`ai ${i}`));
+    }
+
+    // First compression, no anchor yet
+    const stamped1 = stampHistory(baseHistory);
+    const ctx1 = buildCtx(stamped1, 0);
+    const applied1 = assertApplied(await strategy.compress(ctx1));
+    const newHistory1 = applied1.newHistory;
+
+    const head1End = findHeadEnd(newHistory1, applied1.topPreserved);
+    const head1 = newHistory1.slice(0, head1End);
+    const serializedHead1 = serializeForCache(head1);
+
+    // Anchor = seq of the last preserved head entry, via the production path
+    const anchorSeq = resolveHeadAnchorSeq(newHistory1, applied1.topPreserved);
+    expect(typeof anchorSeq).toBe('number');
+
+    // Append 6 more messages and re-stamp
+    const extra: IContent[] = [];
+    for (let i = 0; i < 3; i++) {
+      extra.push(humanMsg(`new user ${i}`));
+      extra.push(aiTextMsg(`new ai ${i}`));
+    }
+    const history2 = restampAndAppend(newHistory1, extra);
+
+    // Second compression WITH the anchor
+    const ctx2 = buildCtx(history2, anchorSeq as number);
+    const applied2 = assertApplied(await strategy.compress(ctx2));
+    const newHistory2 = applied2.newHistory;
+
+    const head2End = findHeadEnd(newHistory2, applied2.topPreserved);
+    const head2 = newHistory2.slice(0, head2End);
+    const serializedHead2 = serializeForCache(head2);
+
+    // The first head must be a COMPLETE CONTENT prefix of the second head
+    const prefix = commonPrefixLength(serializedHead1, serializedHead2);
+    expect(prefix).toBe(serializedHead1.length);
+  });
+});
+
+describe('A2: serialized head content never decreases across 5 append-compress cycles (#3070 Defect B)', () => {
+  it('5 cycles of append-12-then-compress keep the head content monotonically non-decreasing', async () => {
+    const strategy = new MiddleOutStrategy();
+
+    // Start with enough messages to compress
+    const baseHistory: IContent[] = [];
+    for (let i = 0; i < 20; i++) {
+      baseHistory.push(humanMsg(`user ${i}`));
+      baseHistory.push(aiTextMsg(`ai ${i}`));
+    }
+
+    let currentHistory = stampHistory(baseHistory);
+    let anchor = 0;
+    let prevSerializedHead: string[] = [];
+
+    for (let cycle = 0; cycle < 5; cycle++) {
+      const ctx = buildCtx(currentHistory, anchor);
+      const applied = assertApplied(await strategy.compress(ctx));
+      const newHistory = applied.newHistory;
+
+      const headEnd = findHeadEnd(newHistory, applied.topPreserved);
+      const head = newHistory.slice(0, headEnd);
+      const serializedHead = serializeForCache(head);
+
+      // Content prefix must be monotonically non-decreasing
+      const prefix = commonPrefixLength(prevSerializedHead, serializedHead);
+      expect(prefix).toBe(prevSerializedHead.length);
+      prevSerializedHead = serializedHead;
+
+      // Advance anchor via the production path (resolveHeadAnchorSeq)
+      const newAnchor = resolveHeadAnchorSeq(newHistory, applied.topPreserved);
+      if (typeof newAnchor === 'number') {
+        anchor = newAnchor;
+      }
+
+      // Append 12 more and re-stamp
+      const extra: IContent[] = [];
+      for (let i = 0; i < 6; i++) {
+        extra.push(humanMsg(`cycle${cycle} user ${i}`));
+        extra.push(aiTextMsg(`cycle${cycle} ai ${i}`));
+      }
+      currentHistory = restampAndAppend(newHistory, extra);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A5: invariants hold under the anchor — UNMATCHED tool call
+// ---------------------------------------------------------------------------
+
+describe('A5: anchor invariants (#3070 Defect B)', () => {
+  it('anchor floor HOLDS when an UNMATCHED tool_call sits at the boundary — no silent drop below floor', async () => {
+    const strategy = new MiddleOutStrategy();
+
+    // Build history where an UNMATCHED tool_call sits at/near the anchor floor.
+    // The anchor floor is set to the entry just before the unmatched tool_call,
+    // so adjustForToolCallBoundary would try to move the split backward below
+    // the floor. The fix must search FORWARD for a valid split at or above the
+    // floor, or return a clean structural no-op.
+    const history: IContent[] = [
+      humanMsg('h0'),
+      aiTextMsg('a1'),
+      aiTextMsg('a2'),
+      aiTextMsg('a3'),
+      aiTextMsg('a4'),
+      aiTextMsg('a5'),
+      aiTextMsg('a6'),
+      aiTextMsg('a7'),
+      // Unmatched tool_call at index 8 — no matching tool_response follows
+      aiToolCallMsg({ id: 'tc-orphan', name: 'interrupted_tool' }),
+      humanMsg('h9'),
+      aiTextMsg('a10'),
+      humanMsg('h11'),
+      aiTextMsg('a12'),
+      humanMsg('h13'),
+      aiTextMsg('a14'),
+      humanMsg('h15'),
+      aiTextMsg('a16'),
+      humanMsg('h17'),
+      aiTextMsg('a18'),
+      humanMsg('h19'),
+      aiTextMsg('a20'),
+    ];
+
+    const stamped = stampHistory(history);
+    // Anchor to the seq of index 7 (a7), so the floor is index 8
+    const anchorSeq = stamped[7].metadata?.chronology?.seq ?? 0;
+
+    const ctx = buildCtx(stamped, anchorSeq);
+    const result = await strategy.compress(ctx);
+
+    // Either the anchor floor held (applied with topPreserved >= 8) or a clean
+    // structural no-op was returned. The floor must NEVER be silently violated.
+    if (result.kind === 'applied') {
+      const topPreserved = result.metadata.topPreserved;
+      // The floor was 8 (anchorIndex 7 + 1). topPreserved must be >= 8.
+      expect(topPreserved).toBeGreaterThanOrEqual(8);
+    } else {
+      // Clean structural no-op is acceptable
+      expect(result.kind).toBe('noop');
+    }
+  });
+  it('keeps a matched tool call and response on the same side of the anchor floor', async () => {
+    const strategy = new MiddleOutStrategy();
+    const history: IContent[] = [
+      humanMsg('h0'),
+      aiTextMsg('a1'),
+      aiTextMsg('a2'),
+      aiTextMsg('a3'),
+      aiTextMsg('a4'),
+      aiTextMsg('a5'),
+      aiTextMsg('a6'),
+      aiTextMsg('a7'),
+      aiToolCallMsg({ id: 'tc-matched', name: 'matched_tool' }),
+      toolResponseMsg('tc-matched', 'matched_tool', 'result'),
+      humanMsg('h10'),
+      aiTextMsg('a11'),
+      humanMsg('h12'),
+      aiTextMsg('a13'),
+      humanMsg('h14'),
+      aiTextMsg('a15'),
+      humanMsg('h16'),
+      aiTextMsg('a17'),
+      humanMsg('h18'),
+      aiTextMsg('a19'),
+      humanMsg('h20'),
+      aiTextMsg('a21'),
+    ];
+    const stamped = stampHistory(history);
+    const anchorSeq = stamped[7].metadata?.chronology?.seq ?? 0;
+
+    const result = await strategy.compress(buildCtx(stamped, anchorSeq));
+    if (result.kind !== 'applied') {
+      throw new Error('Expected matched tool boundary compression to apply');
+    }
+
+    const preserved = result.newHistory.slice(0, result.metadata.topPreserved);
+    const callIndex = preserved.findIndex((entry) =>
+      entry.blocks.some(
+        (block) => block.type === 'tool_call' && block.id === 'tc-matched',
+      ),
+    );
+    const responseIndex = preserved.findIndex((entry) =>
+      entry.blocks.some(
+        (block) =>
+          block.type === 'tool_response' && block.callId === 'tc-matched',
+      ),
+    );
+    expect(callIndex === -1).toBe(responseIndex === -1);
+    if (callIndex >= 0) {
+      expect(responseIndex).toBeGreaterThan(callIndex);
+    }
+  });
+
+  it('anchor that would push past the bottom split yields a clean structural no-op with unmodified history', async () => {
+    const strategy = new MiddleOutStrategy();
+
+    const history: IContent[] = [];
+    for (let i = 0; i < 10; i++) {
+      history.push(humanMsg(`user ${i}`));
+      history.push(aiTextMsg(`ai ${i}`));
+    }
+
+    // Stamp to get seqs, then set the anchor to the last entry's seq
+    const stamped = stampHistory(history);
+    const anchorSeq =
+      stamped[stamped.length - 1].metadata?.chronology?.seq ?? 0;
+
+    const ctx = buildCtx(stamped, anchorSeq);
+    const result = await strategy.compress(ctx);
+
+    // An anchor at the very end pushes topSplit past bottomSplit → structural no-op
+    expect(result.kind).toBe('noop');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A6: resolveHeadAnchorSeq — the seq handed to the anchor after a compression
+// ---------------------------------------------------------------------------
+
+describe('A6: resolveHeadAnchorSeq (#3070 Defect B)', () => {
+  it('returns the seq of the last preserved head entry by topPreserved index', () => {
+    const stamped = stampHistory([
+      humanMsg('h0'),
+      aiTextMsg('a1'),
+      humanMsg('h2'),
+    ]);
+    const summary: IContent = {
+      ...aiTextMsg('<state_snapshot>summary</state_snapshot>'),
+      metadata: { isSummary: true },
+    };
+    const compressed = [stamped[0], stamped[1], summary, stamped[2]];
+
+    // topPreserved = 2 → last head entry is index 1
+    expect(resolveHeadAnchorSeq(compressed, 2)).toBe(
+      stamped[1].metadata?.chronology?.seq,
+    );
+  });
+
+  it('returns undefined when topPreserved is 0 (prefix destroyed)', () => {
+    const stamped = stampHistory([humanMsg('h0'), aiTextMsg('a1')]);
+
+    expect(resolveHeadAnchorSeq(stamped, 0)).toBeUndefined();
+  });
+
+  it('throws when topPreserved exceeds history length', () => {
+    const stamped = stampHistory([humanMsg('h0'), aiTextMsg('a1')]);
+
+    expect(() => resolveHeadAnchorSeq(stamped, 10)).toThrow(
+      'topPreserved 10 exceeds history length 2',
+    );
+  });
+
+  it('the resolved seq is accepted by setCacheAnchorSeq and pins the head', () => {
+    const hs = new HistoryService();
+    const stamped = stampHistory([
+      humanMsg('h0'),
+      aiTextMsg('a1'),
+      humanMsg('h2'),
+    ]);
+    const summary: IContent = {
+      ...aiTextMsg('<state_snapshot>summary</state_snapshot>'),
+      metadata: { isSummary: true },
+    };
+    const seq = resolveHeadAnchorSeq(
+      [stamped[0], stamped[1], summary, stamped[2]],
+      2,
+    );
+    expect(seq).toBeDefined();
+    if (seq === undefined) {
+      throw new Error('Expected a cache-anchor chronology seq');
+    }
+
+    hs.setCacheAnchorSeq(seq);
+
+    expect(hs.getCacheAnchorSeq()).toBe(seq);
+  });
+});

--- a/packages/agents/src/compression/cacheAnchor.test.ts
+++ b/packages/agents/src/compression/cacheAnchor.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the cache-anchor marker stamped by
+ * `applyCompressionWithAnchor` (#3070 "caching during compression").
+ *
+ * The marker (`metadata.cacheAnchor`) is carried ON the content so it travels
+ * with the history and survives a wholesale clear/rebuild. These tests prove:
+ *  - exactly ONE preserved-head entry carries the marker after a compression;
+ *  - the marker survives the real `historyService.clear()` + `add()` rebuild
+ *    (the chronology stamper preserves existing metadata);
+ *  - stale markers from a previous compression are cleared;
+ *  - when the prefix is destroyed (`topPreserved <= 0`) no entry is marked.
+ *
+ * Uses a REAL HistoryService — no mocks — so the clear/add/stamp path is
+ * exercised exactly as production runs it.
+ */
+
+import { describe, it, expect } from '../testApi.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import { annotateCompressionSpan } from '@vybestack/llxprt-code-core/services/history/historyChronology.js';
+import { applyCompressionWithAnchor } from './cacheAnchor.js';
+
+function human(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+function ai(text: string): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text }] };
+}
+
+function summary(text: string): IContent {
+  return {
+    speaker: 'ai',
+    blocks: [{ type: 'text', text }],
+    metadata: { isSummary: true, synthetic: true },
+  };
+}
+
+function apply(
+  historyService: HistoryService,
+  newHistory: IContent[],
+  topPreserved: number,
+): void {
+  applyCompressionWithAnchor(
+    historyService,
+    newHistory,
+    topPreserved,
+    'test-model',
+    annotateCompressionSpan,
+  );
+}
+
+describe('applyCompressionWithAnchor — cacheAnchor marker (#3070)', () => {
+  it('marks exactly the last preserved-head entry and the marker survives the clear/rebuild', () => {
+    const historyService = new HistoryService();
+    // Seed an initial history so getRawHistory() is non-empty for annotate.
+    for (const c of [human('old1'), ai('old2'), human('old3'), ai('old4')]) {
+      historyService.add(c, 'test-model');
+    }
+
+    // Compressed result: 2 preserved head entries, a summary, 1 tail entry.
+    // Production strategies reuse preserved entries from the stamped history.
+    const stamped = historyService.getAll();
+    const newHistory = [
+      stamped[0],
+      stamped[1],
+      summary('<state_snapshot>compressed middle</state_snapshot>'),
+      stamped[3],
+    ];
+    const topPreserved = 2;
+
+    apply(historyService, newHistory, topPreserved);
+
+    const rebuilt = historyService.getAll();
+    expect(rebuilt).toHaveLength(newHistory.length);
+
+    // Exactly ONE entry carries the marker.
+    const marked = rebuilt.filter((c) => c.metadata?.cacheAnchor === true);
+    expect(marked).toHaveLength(1);
+
+    // The marker is on the last preserved-head entry (index topPreserved - 1),
+    // and it survived the clear()+add() rebuild (chronology stamp preserves
+    // existing metadata).
+    expect(rebuilt[topPreserved - 1].metadata?.cacheAnchor).toBe(true);
+    // That entry also received a fresh chronology stamp, proving it was
+    // re-added through the normal add() path.
+    expect(rebuilt[topPreserved - 1].metadata?.chronology?.seq).toBeDefined();
+  });
+
+  it('clears stale markers so exactly one entry carries the marker after a second compression', () => {
+    const historyService = new HistoryService();
+    for (const c of [human('seed1'), ai('seed2')]) {
+      historyService.add(c, 'test-model');
+    }
+
+    // First compression: head of 2 entries reused from the stamped history.
+    const stamped = historyService.getAll();
+    apply(
+      historyService,
+      [stamped[0], stamped[1], summary('first summary'), human('tail-a')],
+      2,
+    );
+    const afterFirst = historyService.getAll();
+    expect(
+      afterFirst.filter((c) => c.metadata?.cacheAnchor === true),
+    ).toHaveLength(1);
+
+    // Second compression with the previous head reused (byte-identical) plus a
+    // longer tail. The marker must move to the new boundary and the old one
+    // must be cleared — never two markers at once.
+    const reusedHead = afterFirst.slice(0, 2);
+    apply(
+      historyService,
+      [...reusedHead, summary('second summary'), human('tail-b'), ai('tail-c')],
+      2,
+    );
+    const afterSecond = historyService.getAll();
+    expect(
+      afterSecond.filter((c) => c.metadata?.cacheAnchor === true),
+    ).toHaveLength(1);
+    expect(afterSecond[1].metadata?.cacheAnchor).toBe(true);
+  });
+
+  it('marks no entry when the prefix is destroyed (topPreserved <= 0)', () => {
+    const historyService = new HistoryService();
+    for (const c of [human('seed1'), ai('seed2'), human('seed3')]) {
+      historyService.add(c, 'test-model');
+    }
+
+    // A truncation strategy that preserves no head.
+    apply(historyService, [summary('full replacement'), human('only tail')], 0);
+
+    const rebuilt = historyService.getAll();
+    expect(
+      rebuilt.filter((c) => c.metadata?.cacheAnchor === true),
+    ).toHaveLength(0);
+    // The anchor seq is reset (not advanced) when the prefix is destroyed.
+    expect(historyService.getCacheAnchorSeq()).toBe(0);
+  });
+
+  it('advances the cache anchor seq to the last preserved-head entry', () => {
+    const historyService = new HistoryService();
+    // Seed real history so the preserved-head entries carry chronology
+    // markers, exactly as production does (the head is reused verbatim from
+    // the existing history, not freshly minted).
+    for (const c of [human('seed1'), ai('seed2'), human('seed3')]) {
+      historyService.add(c, 'test-model');
+    }
+    const stamped = historyService.getAll();
+
+    apply(
+      historyService,
+      [stamped[0], stamped[1], summary('summary'), human('tail')],
+      2,
+    );
+
+    const rebuilt = historyService.getAll();
+    // stamped[1] was reused as the last preserved head; its seq carries over.
+    const expectedSeq = stamped[1].metadata?.chronology?.seq;
+    expect(expectedSeq).toBeDefined();
+    expect(rebuilt[1].metadata?.chronology?.seq).toBe(expectedSeq);
+    expect(historyService.getCacheAnchorSeq()).toBe(expectedSeq);
+  });
+});

--- a/packages/agents/src/compression/cacheAnchor.ts
+++ b/packages/agents/src/compression/cacheAnchor.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+
+/**
+ * Resolve the chronology `seq` that should become the new cache anchor after a
+ * successful compression, using the strategy-reported preserved-head length.
+ *
+ * `topPreserved` is the exact number of preserved head entries the strategy
+ * kept in front of its synthetic summary/continuation. The new anchor is the
+ * `seq` of the last preserved head entry — `newHistory[topPreserved - 1]` —
+ * which is the highest position that must survive every later compression, so
+ * the provider-visible prefix stays byte-identical (#3070).
+ *
+ * Returns `undefined` when there is no preserved head (`topPreserved <= 0`),
+ * meaning the prefix was destroyed (e.g. a truncation strategy). In that case
+ * the caller must explicitly reset the anchor rather than hold a stale one.
+ *
+ * Searching the output for the summary entry is intentionally avoided: from
+ * the second compression onward the previous compression's summary sits inside
+ * the preserved head and still carries its `compression-state-snapshot`
+ * metadata, so a summary search would pin the anchor to the same stale seq
+ * forever (#3070 Defect 1).
+ */
+export function resolveHeadAnchorSeq(
+  newHistory: readonly IContent[],
+  topPreserved: number,
+): number | undefined {
+  if (topPreserved <= 0) {
+    return undefined;
+  }
+  if (topPreserved > newHistory.length) {
+    throw new Error(
+      `Invalid compression metadata: topPreserved ${topPreserved} exceeds history length ${newHistory.length}`,
+    );
+  }
+  return extractSeq(newHistory[topPreserved - 1]);
+}
+
+function extractSeq(entry: IContent): number {
+  const seq = entry.metadata?.chronology?.seq;
+  if (typeof seq !== 'number' || !Number.isInteger(seq) || seq <= 0) {
+    throw new Error('Preserved cache-anchor entry has no valid chronology seq');
+  }
+  return seq;
+}
+
+/**
+ * Apply the compression result to the history service: clear, re-add the
+ * annotated entries, then advance or reset the cache anchor atomically
+ * (#3070 Defects 3, 5).
+ *
+ * The anchor value is resolved BEFORE mutation so a throw cannot leave a
+ * partially applied compression. When the prefix was destroyed
+ * (`topPreserved <= 0`), the anchor is explicitly reset.
+ */
+export function applyCompressionWithAnchor(
+  historyService: {
+    clear(): void;
+    add(content: IContent, model?: string): void;
+    resetCacheAnchorSeq(): void;
+    setCacheAnchorSeq(seq: number): void;
+    getRawHistory(): readonly IContent[];
+  },
+  newHistory: readonly IContent[],
+  topPreserved: number,
+  model: string,
+  annotate: (
+    oldHistory: readonly IContent[],
+    newHist: readonly IContent[],
+  ) => IContent[],
+): void {
+  const anchorSeq = resolveHeadAnchorSeq(newHistory, topPreserved);
+  const isPrefixDestroyed = topPreserved <= 0;
+  const annotated = stampCacheAnchorMarker(
+    annotate(historyService.getRawHistory(), newHistory),
+    isPrefixDestroyed ? 0 : topPreserved,
+  );
+
+  // Exactly one preserved-head entry — the last one — carries the marker, so
+  // explicit-cache providers can place a breakpoint at the head boundary. The
+  // marker travels with the history; a wholesale replacement drops it.
+
+  historyService.clear();
+  for (const content of annotated) {
+    historyService.add(content, model);
+  }
+  if (isPrefixDestroyed) {
+    historyService.resetCacheAnchorSeq();
+  } else if (anchorSeq !== undefined) {
+    historyService.setCacheAnchorSeq(anchorSeq);
+  }
+}
+
+/**
+ * Ensure exactly one entry (or none) carries `metadata.cacheAnchor`.
+ *
+ * `anchorCount` is the number of preserved-head entries (`topPreserved`); the
+ * anchor entry is `entries[anchorCount - 1]`. A non-positive `anchorCount`
+ * means the prefix was destroyed, so every marker is cleared and none is set.
+ */
+function stampCacheAnchorMarker(
+  entries: readonly IContent[],
+  anchorCount: number,
+): IContent[] {
+  return entries.map((entry, index) => {
+    const metadata = { ...entry.metadata };
+    delete metadata.cacheAnchor;
+    if (index === anchorCount - 1) {
+      metadata.cacheAnchor = true;
+    }
+    return { ...entry, metadata };
+  });
+}

--- a/packages/agents/src/compression/compressionBudgeting.ts
+++ b/packages/agents/src/compression/compressionBudgeting.ts
@@ -107,6 +107,12 @@ export function getCompletionBudget(
   settingsService: { get: (key: string) => unknown } | undefined,
   contextLimit: number,
 ): number {
+  if (!Number.isFinite(contextLimit) || contextLimit <= 0) {
+    throw new RangeError(
+      `Context limit must be a positive finite number: got ${contextLimit}`,
+    );
+  }
+
   // Check global ephemeral setting for maxOutputTokens (set via /set maxOutputTokens)
   const liveMaxOutputTokens = settingsService?.get('maxOutputTokens');
   const liveBudget = asNumber(liveMaxOutputTokens);

--- a/packages/agents/src/compression/compressionBudgeting.ts
+++ b/packages/agents/src/compression/compressionBudgeting.ts
@@ -11,6 +11,10 @@ import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/r
 import { estimateTokens as estimateTextTokens } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
 import { serializeWireContentForEstimate } from '@vybestack/llxprt-code-core/services/history/historyTokenEstimation.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import {
+  buildInvalidContextBudgetError,
+  InvalidContextBudgetError,
+} from './invalidContextBudgetError.js';
 
 const logger = new DebugLogger('llxprt:gemini:compression-budgeting');
 
@@ -63,35 +67,94 @@ export function extractCompletionBudgetFromParams(
 }
 
 /**
- * Get completion budget from generation config, provider params, or default.
- * Used to reserve output tokens when calculating context limits.
+ * Absolute fallback output reservation, capped to half of the context window
+ * via {@link DEFAULT_COMPLETION_FRACTION} so it can never equal or exceed the
+ * whole window on small context models.
+ */
+export const DEFAULT_COMPLETION_BUDGET = 65_536;
+
+/**
+ * Fraction of the context window reserved for completion tokens when no budget
+ * is explicitly configured. This keeps the unconfigured default proportional
+ * to the window so a small context limit never collapses the compression
+ * trigger to zero. For windows >= 131,072 the proportional default equals the
+ * flat {@link DEFAULT_COMPLETION_BUDGET} (65536), preserving existing cloud
+ * behaviour.
+ */
+export const DEFAULT_COMPLETION_FRACTION = 0.5;
+
+/**
+ * Get completion budget from generation config, provider params, or a
+ * context-limit-aware default. Used to reserve output tokens when calculating
+ * context limits.
+ *
+ * - An explicitly configured budget (ephemeral `maxOutputTokens`,
+ *   `generationConfig`, or provider params) that is `>= contextLimit` throws
+ *   {@link InvalidContextBudgetError}: that is a genuinely impossible
+ *   configuration that must fail fast rather than silently collapsing the
+ *   effective limit to zero.
+ * - When nothing is configured, the budget is
+ *   `min(DEFAULT_COMPLETION_BUDGET, floor(contextLimit * DEFAULT_COMPLETION_FRACTION))`
+ *   so the default never consumes the whole window. This is our bug, not the
+ *   user's, so the unconfigured case never throws.
+ *
  * @plan PLAN-20260220-DECOMPOSE.P03
  */
 export function getCompletionBudget(
   generationConfig: ModelGenerationSettings,
   _model: string,
-  provider?: IProvider,
-  settingsService?: { get: (key: string) => unknown },
+  provider: IProvider | undefined,
+  settingsService: { get: (key: string) => unknown } | undefined,
+  contextLimit: number,
 ): number {
-  const DEFAULT_COMPLETION_BUDGET = 65_536;
-
   // Check global ephemeral setting for maxOutputTokens (set via /set maxOutputTokens)
-  // This is a generic setting that providers should translate to their native param
   const liveMaxOutputTokens = settingsService?.get('maxOutputTokens');
   const liveBudget = asNumber(liveMaxOutputTokens);
   if (liveBudget !== undefined && liveBudget > 0) {
+    if (liveBudget >= contextLimit) {
+      throw buildInvalidContextBudgetError(
+        liveBudget,
+        contextLimit,
+        'maxOutputTokens',
+      );
+    }
     return liveBudget;
   }
 
   const generationBudget = asNumber(
     (generationConfig as { maxOutputTokens?: unknown }).maxOutputTokens,
   );
+  if (generationBudget !== undefined && generationBudget > 0) {
+    if (generationBudget >= contextLimit) {
+      throw buildInvalidContextBudgetError(
+        generationBudget,
+        contextLimit,
+        'generationConfig',
+      );
+    }
+    return generationBudget;
+  }
 
   const providerParams = provider?.getModelParams?.();
   const providerBudget = extractCompletionBudgetFromParams(providerParams);
+  if (providerBudget !== undefined) {
+    if (providerBudget >= contextLimit) {
+      throw buildInvalidContextBudgetError(
+        providerBudget,
+        contextLimit,
+        'providerParams',
+      );
+    }
+    return providerBudget;
+  }
 
-  return generationBudget ?? providerBudget ?? DEFAULT_COMPLETION_BUDGET;
+  return Math.min(
+    DEFAULT_COMPLETION_BUDGET,
+    Math.floor(contextLimit * DEFAULT_COMPLETION_FRACTION),
+  );
 }
+
+export { InvalidContextBudgetError };
 
 /**
  * Estimate token count for pending content that hasn't been added to history yet.

--- a/packages/agents/src/compression/compressionContextBuilder.ts
+++ b/packages/agents/src/compression/compressionContextBuilder.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { CompressionContext } from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type { CompressionProviderResult } from '@vybestack/llxprt-code-core/core/compression/types.js';
+import { PromptResolver } from '@vybestack/llxprt-code-core/prompt-config/prompt-resolver.js';
+import { Storage } from '@vybestack/llxprt-code-settings/storage/Storage.js';
+import path from 'node:path';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+
+/**
+ * Build CompressionContext for compression strategies.
+ *
+ * @plan PLAN-20260211-HIGHDENSITY.P14
+ * @requirement REQ-CS-001.6
+ */
+export async function buildCompressionContext(
+  promptId: string,
+  runtimeContext: AgentRuntimeContext,
+  historyService: HistoryService,
+  providerResolver: (
+    profileName?: string,
+  ) => Promise<CompressionProviderResult>,
+  activeTodosProvider: (() => Promise<string | undefined>) | undefined,
+  logger: DebugLogger,
+): Promise<CompressionContext> {
+  const promptResolver = new PromptResolver();
+  const promptBaseDir = path.join(Storage.getGlobalConfigDir(), 'prompts');
+
+  let activeTodos: string | undefined;
+  if (activeTodosProvider) {
+    try {
+      activeTodos = await activeTodosProvider();
+    } catch (error) {
+      logger.debug('Failed to fetch active todos for compression', error);
+    }
+  }
+
+  const config = runtimeContext.providerRuntime.config;
+
+  return {
+    history: historyService.getCurated(),
+    runtimeContext,
+    runtimeState: runtimeContext.state,
+    estimateTokens: (contents) =>
+      historyService.estimateTokensForContents(contents as IContent[]),
+    currentTokenCount: historyService.getTotalTokens(),
+    logger,
+    resolveProvider: providerResolver,
+    promptResolver,
+    promptBaseDir,
+    promptContext: {
+      provider: runtimeContext.state.provider,
+      model: runtimeContext.state.model,
+    },
+    promptId,
+    ...(activeTodos ? { activeTodos } : {}),
+    compressionVerification:
+      runtimeContext.ephemerals.compressionVerification(),
+    ...(config ? { config } : {}),
+    cacheAnchorSeq: historyService.getCacheAnchorSeq(),
+  };
+}

--- a/packages/agents/src/compression/invalidContextBudgetError.ts
+++ b/packages/agents/src/compression/invalidContextBudgetError.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export class InvalidContextBudgetError extends Error {
+  constructor(
+    message: string,
+    readonly configuredBudget: number,
+    readonly contextLimit: number,
+  ) {
+    super(message);
+    this.name = 'InvalidContextBudgetError';
+  }
+}
+
+/**
+ * Build an {@link InvalidContextBudgetError} for an explicitly configured
+ * completion budget that equals or exceeds the whole context window — a
+ * genuinely impossible configuration that would leave zero tokens for any
+ * request.
+ *
+ * The message names both numbers and the settings to change so the user can
+ * resolve the contradiction. Unlike a collision with the *unconfigured*
+ * default (which is our bug and is fixed by scaling the default down), a
+ * user-configured contradiction is a user error and must fail fast.
+ */
+export function buildInvalidContextBudgetError(
+  configuredBudget: number,
+  contextLimit: number,
+  source: 'maxOutputTokens' | 'generationConfig' | 'providerParams',
+): InvalidContextBudgetError {
+  const settingMap: Record<typeof source, string> = {
+    maxOutputTokens: '/set maxOutputTokens',
+    generationConfig: 'generationConfig.maxOutputTokens',
+    providerParams: 'the provider params maxOutputTokens/maxTokens',
+  };
+  const settingToChange = settingMap[source];
+
+  const message =
+    `Configured completion budget (${configuredBudget}) is greater than or equal to the context limit ` +
+    `(${contextLimit}), leaving no room for any prompt. Lower ${settingToChange} or raise context-limit so that ` +
+    `context-limit strictly exceeds the completion budget.`;
+
+  return new InvalidContextBudgetError(message, configuredBudget, contextLimit);
+}

--- a/packages/agents/src/compression/pendingContextWindowEnforcement.ts
+++ b/packages/agents/src/compression/pendingContextWindowEnforcement.ts
@@ -70,6 +70,7 @@ export interface PendingContextWindowEnforcerDeps {
     applyResult: (
       newHistory: IContent[],
       summary: IContent | undefined,
+      topPreserved: number,
     ) => void,
   ): void;
   setSuppressDensityDirty(value: boolean): void;
@@ -451,13 +452,18 @@ export class PendingContextWindowEnforcer {
       );
       return;
     }
-    this.deps.applyFallbackCompressionResult(result, (newHistory, _summary) => {
-      this.deps.historyService.clear();
-      for (const content of newHistory) {
-        this.deps.historyService.add(content, this.deps.getRuntimeModel());
-      }
-      this.deps.resetLastPromptTokenCount();
-    });
+    this.deps.applyFallbackCompressionResult(
+      result,
+      (newHistory, _summary, _topPreserved) => {
+        this.deps.historyService.clear();
+        // Post-truncation rebuild: the prefix is already destroyed (#3070).
+        this.deps.historyService.resetCacheAnchorSeq();
+        for (const content of newHistory) {
+          this.deps.historyService.add(content, this.deps.getRuntimeModel());
+        }
+        this.deps.resetLastPromptTokenCount();
+      },
+    );
   }
 
   private async truncateToolResponsesIfStillOverLimit(input: {

--- a/packages/agents/src/compression/providerContentEnforcement.ts
+++ b/packages/agents/src/compression/providerContentEnforcement.ts
@@ -645,6 +645,10 @@ export class ProviderContentEnforcer {
   private restoreHistory(history: IContent[]): void {
     const backup = this.deps.historyService.getCurated();
     this.deps.historyService.clear();
+    // Post-truncation rebuild: the prefix is already destroyed, so reset the
+    // cache anchor (#3070). Subsequent clears in the error-handling flow find
+    // it already at 0.
+    this.deps.historyService.resetCacheAnchorSeq();
     try {
       this.addHistoryEntries(history);
     } catch (restoreError) {
@@ -740,17 +744,15 @@ export class ProviderContentEnforcer {
     provider: IProvider | undefined,
     model: string,
   ): ContextLimits {
-    const completionBudget = Math.max(
-      0,
-      getCompletionBudget(
-        this.deps.generationConfig,
-        model,
-        provider,
-        this.deps.providerRuntimeNullable?.settingsService,
-      ),
-    );
     const userContextLimit = this.deps.runtimeContext.ephemerals.contextLimit();
     const limit = tokenLimit(model, userContextLimit);
+    const completionBudget = getCompletionBudget(
+      this.deps.generationConfig,
+      model,
+      provider,
+      this.deps.providerRuntimeNullable?.settingsService,
+      limit,
+    );
     const marginAdjustedLimit = computeMarginAdjustedLimit(limit);
     return {
       completionBudget,

--- a/packages/agents/src/core/ConversationManager.ts
+++ b/packages/agents/src/core/ConversationManager.ts
@@ -546,6 +546,7 @@ export class ConversationManager {
    */
   clearHistory(): void {
     this.historyService.clear();
+    this.historyService.resetCacheAnchorSeq();
   }
 
   /**
@@ -569,6 +570,7 @@ export class ConversationManager {
     // rather than resolving the active provider (issue #2511).
     const generatingModel = this.runtimeContext.state.model;
     this.historyService.clear();
+    this.historyService.resetCacheAnchorSeq();
     for (const content of history) {
       const turnKey = this.historyService.generateTurnKey();
       this.historyService.add(

--- a/packages/agents/src/core/client.ts
+++ b/packages/agents/src/core/client.ts
@@ -563,6 +563,7 @@ export class AgentClient implements AgentClientContract {
       if (historyService != null) {
         // Clear the history service directly
         historyService.clear();
+        historyService.resetCacheAnchorSeq();
       } else {
         // Fallback to chat's clearHistory if no history service
         this.chat.clearHistory();
@@ -638,6 +639,12 @@ export class AgentClient implements AgentClientContract {
         'Cannot restore history: History service unavailable after chat initialization',
       );
     }
+
+    // Reset the cache anchor: restoreHistory is a wholesale history replacement
+    // reachable from the public Agent.restoreHistory API with no preceding
+    // resetChat, so it was missed when the lifecycle was enumerated by clear()
+    // call sites (#3070 Defect 6).
+    historyService.resetCacheAnchorSeq();
 
     try {
       // Validate and fix any issues in the history service before adding items

--- a/packages/core/src/core/compression/types.ts
+++ b/packages/core/src/core/compression/types.ts
@@ -166,6 +166,14 @@ export interface CompressionContext {
    * Enables RetryOrchestrator to access getBucketFailoverHandler().
    */
   readonly config?: Config;
+
+  /**
+   * The highest chronology `seq` that the preserved head must always include.
+   * `MiddleOutStrategy.computeSplit` raises `topSplitIndex` to cover this seq so
+   * the cacheable prefix stays byte-identical across successive compressions for
+   * every provider (#3070). 0 means no anchor is set.
+   */
+  readonly cacheAnchorSeq?: number;
 }
 
 /**

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -70,22 +70,10 @@ import {
 // Preserve the CompressionConfig export from the same path for consumers.
 export type { CompressionConfig };
 
-type MutationFailure = { failed: false } | { failed: true; error: unknown };
-
-function combineMutationFailures(
-  primary: MutationFailure,
-  queued: MutationFailure,
-): MutationFailure {
-  if (!primary.failed) return queued;
-  if (!queued.failed) return primary;
-  return {
-    failed: true,
-    error: new AggregateError(
-      [primary.error, queued.error],
-      'Multiple history mutations failed',
-    ),
-  };
-}
+import {
+  type MutationFailure,
+  combineMutationFailures,
+} from './historyMutationFailure.js';
 
 type QueuedHistoryMutation =
   | { kind: 'synchronous'; execute: () => void }
@@ -117,6 +105,17 @@ export class HistoryService
   private logger = new DebugLogger('llxprt:history:service');
 
   private chronology = new ChronologyStamper();
+
+  /**
+   * Monotonic cache anchor: the highest chronology `seq` that must remain in
+   * the preserved head across every subsequent middle-out compression. Once a
+   * head entry is preserved by one compression, no later compression may drop
+   * it, which keeps the provider-visible prefix byte-identical (#3070).
+   *
+   * Survives the compression clear/rebuild; reset explicitly by session-reset
+   * and history-restore paths.
+   */
+  private cacheAnchorSeq: number = 0;
 
   /**
    * @plan:PLAN-20260603-ISSUE1584.P05
@@ -511,11 +510,6 @@ export class HistoryService
 
     const generation = this.syncGeneration;
     this.history.push(content);
-
-    this.logger.debug(
-      'Content added successfully, history length:',
-      this.history.length,
-    );
 
     try {
       this.emit('contentAdded', content);
@@ -1190,5 +1184,33 @@ export class HistoryService
    */
   getChronologyTrace(): ChronologyTraceEntry[] {
     return buildChronologyTrace(this.history);
+  }
+
+  /**
+   * The highest chronology `seq` that the preserved head must always include.
+   * Zero means no anchor has been established yet (#3070).
+   */
+  getCacheAnchorSeq(): number {
+    return this.cacheAnchorSeq;
+  }
+
+  /**
+   * Set the chronology identity of the current preserved-head boundary. The
+   * boundary moves monotonically by array position, but chronology seq values
+   * do not: synthetic compression entries receive newer seq values before
+   * preserved tail entries. Exact identity, not numeric ordering, is required.
+   */
+  setCacheAnchorSeq(seq: number): void {
+    if (!Number.isInteger(seq) || seq <= 0) {
+      throw new Error(
+        `Cache-anchor seq must be a positive integer: got ${seq}`,
+      );
+    }
+    this.cacheAnchorSeq = seq;
+  }
+
+  /** Reset the anchor to 0 for session-reset / history-restore paths. @see #3070 */
+  resetCacheAnchorSeq(): void {
+    this.cacheAnchorSeq = 0;
   }
 }

--- a/packages/core/src/services/history/IContent.ts
+++ b/packages/core/src/services/history/IContent.ts
@@ -157,6 +157,19 @@ export interface ContentMetadata {
    * marker. NEVER serialized to a provider (#1721).
    */
   chronologyReplaced?: ChronologyReplacedSpan;
+
+  /**
+   * Marks this entry as the last item of the compression-preserved head — the
+   * cache anchor boundary (#3070). Providers that rely on explicit cache
+   * breakpoints (Anthropic) attach a `cache_control` breakpoint to the message
+   * derived from this entry, so the byte-stable head is READ from cache after a
+   * compression instead of re-billed at cache-WRITE pricing.
+   *
+   * Exactly one entry (or none) carries this flag at any time; it is stamped by
+   * `applyCompressionWithAnchor` and lives on the content itself so a wholesale
+   * history replacement drops it automatically. NEVER serialized to a provider.
+   */
+  cacheAnchor?: boolean;
 }
 
 export interface UsageStats {

--- a/packages/core/src/services/history/historyMutationFailure.ts
+++ b/packages/core/src/services/history/historyMutationFailure.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type MutationFailure =
+  | { failed: false }
+  | { failed: true; error: unknown };
+
+export function combineMutationFailures(
+  primary: MutationFailure,
+  queued: MutationFailure,
+): MutationFailure {
+  if (!primary.failed) return queued;
+  if (!queued.failed) return primary;
+  return {
+    failed: true,
+    error: new AggregateError(
+      [primary.error, queued.error],
+      'Multiple history mutations failed',
+    ),
+  };
+}

--- a/packages/core/src/services/history/historyPrefixStability.test.ts
+++ b/packages/core/src/services/history/historyPrefixStability.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { HistoryService } from './HistoryService.js';
+import type { IContent } from './IContent.js';
+import { buildProviderContent } from './historyProviderPipeline.js';
+import { DebugLogger } from '../../debug/index.js';
+
+/**
+ * CHARACTERIZATION TESTS for per-turn prefix stability (issue #3070 Defect B).
+ *
+ * These tests document and lock down properties of the provider pipeline and
+ * curation that are already true on main, whose absence allowed Defect B (the
+ * oscillating compression boundary) to go unnoticed. They use a REAL
+ * HistoryService with no mocks.
+ *
+ * The test-local helpers below define the operational meaning of a cacheable
+ * prefix: serialization excludes metadata (chronology is never sent to a
+ * provider), so this proxy is exactly what an implicit-cache provider matches
+ * on and exactly what determines where an explicit breakpoint could pay off.
+ */
+
+function serializeForCache(contents: readonly IContent[]): string[] {
+  return contents.map((c) =>
+    JSON.stringify({ speaker: c.speaker, blocks: c.blocks }),
+  );
+}
+
+function commonPrefixLength(
+  a: readonly string[],
+  b: readonly string[],
+): number {
+  const limit = Math.min(a.length, b.length);
+  for (let i = 0; i < limit; i++) {
+    if (a[i] !== b[i]) return i;
+  }
+  return limit;
+}
+
+const logger = new DebugLogger('llxprt:history:prefix-stability-test');
+
+function textMsg(speaker: IContent['speaker'], text: string): IContent {
+  return { speaker, blocks: [{ type: 'text', text }] };
+}
+
+function toolCallMsg(callId: string, name: string): IContent {
+  return {
+    speaker: 'ai',
+    blocks: [
+      {
+        type: 'tool_call',
+        id: callId,
+        name,
+        parameters: {},
+      },
+    ],
+  };
+}
+
+function toolResponseMsg(callId: string, toolName: string): IContent {
+  return {
+    speaker: 'tool',
+    blocks: [
+      {
+        type: 'tool_response',
+        callId,
+        toolName,
+        result: 'ok',
+      },
+    ],
+  };
+}
+
+function providerContent(hs: HistoryService): IContent[] {
+  return buildProviderContent(hs.getCurated(), [], logger);
+}
+
+describe('B1: per-turn provider pipeline is prefix-stable under append (characterization)', () => {
+  it('appending a new turn keeps the previous provider content as a strict prefix', () => {
+    const hs = new HistoryService();
+    hs.add(textMsg('human', 'hello'));
+    hs.add(textMsg('ai', 'world'));
+
+    const before = providerContent(hs);
+
+    // Append a new turn
+    hs.add(textMsg('human', 'second question'));
+    hs.add(textMsg('ai', 'second answer'));
+
+    const after = providerContent(hs);
+    const serializedBefore = serializeForCache(before);
+    const serializedAfter = serializeForCache(after);
+    const prefixLen = commonPrefixLength(serializedBefore, serializedAfter);
+
+    expect(prefixLen).toBe(serializedBefore.length);
+  });
+
+  it('appending a tool turn keeps the previous provider content as a strict prefix', () => {
+    const hs = new HistoryService();
+    hs.add(textMsg('human', 'run a tool'));
+    hs.add(toolCallMsg('tc-1', 'read_file'));
+    hs.add(toolResponseMsg('tc-1', 'read_file'));
+    hs.add(textMsg('ai', 'done'));
+
+    const before = providerContent(hs);
+
+    hs.add(textMsg('human', 'do more'));
+    hs.add(toolCallMsg('tc-2', 'write_file'));
+    hs.add(toolResponseMsg('tc-2', 'write_file'));
+
+    const after = providerContent(hs);
+    const serializedBefore = serializeForCache(before);
+    const serializedAfter = serializeForCache(after);
+    const prefixLen = commonPrefixLength(serializedBefore, serializedAfter);
+
+    expect(prefixLen).toBe(serializedBefore.length);
+  });
+});
+
+describe('B2: interrupted tool call perturbs only the tail, not the head (characterization)', () => {
+  it('an unmatched tool_call at the end does not alter the established head prefix', () => {
+    const hs = new HistoryService();
+    hs.add(textMsg('human', 'question one'));
+    hs.add(textMsg('ai', 'answer one'));
+    hs.add(textMsg('human', 'question two'));
+    hs.add(textMsg('ai', 'answer two'));
+
+    const before = providerContent(hs);
+
+    // Simulate an interrupted turn: tool call without response
+    hs.add(textMsg('human', 'run tool'));
+    hs.add(toolCallMsg('tc-99', 'some_tool'));
+
+    const after = providerContent(hs);
+    const serializedBefore = serializeForCache(before);
+    const serializedAfter = serializeForCache(after);
+
+    // The head (the first 4 entries) must still be an exact prefix
+    const prefixLen = commonPrefixLength(serializedBefore, serializedAfter);
+    expect(prefixLen).toBe(serializedBefore.length);
+  });
+});
+
+describe('B3: curation is an identity map on any valid prefix (characterization)', () => {
+  it('curating a prefix of curated history returns exactly that prefix', () => {
+    const hs = new HistoryService();
+    for (let i = 0; i < 10; i++) {
+      hs.add(textMsg('human', `prompt ${i}`));
+      hs.add(textMsg('ai', `response ${i}`));
+    }
+
+    const curated = hs.getCurated();
+    expect(curated.length).toBe(20);
+
+    // Curation is an identity map on already-valid entries: re-curating a
+    // prefix through a fresh HistoryService must produce the same serialized
+    // content. (Previously this compared an array to itself, which is
+    // tautological — #3070 test defect.)
+    for (const prefixLen of [4, 8, 12]) {
+      const prefix = curated.slice(0, prefixLen);
+
+      const reCurated = new HistoryService();
+      for (const entry of prefix) {
+        reCurated.add(entry);
+      }
+      const reCuratedOutput = reCurated.getCurated();
+
+      const serializedPrefix = serializeForCache(prefix);
+      const serializedReCurated = serializeForCache(reCuratedOutput);
+
+      expect(serializedReCurated).toHaveLength(serializedPrefix.length);
+      expect(commonPrefixLength(serializedPrefix, serializedReCurated)).toBe(
+        serializedPrefix.length,
+      );
+    }
+  });
+
+  it('curated history is prefix-stable under append', () => {
+    const hs = new HistoryService();
+    hs.add(textMsg('human', 'first'));
+    hs.add(textMsg('ai', 'reply'));
+
+    const before = hs.getCurated();
+
+    hs.add(textMsg('human', 'second'));
+    hs.add(textMsg('ai', 'reply2'));
+
+    const after = hs.getCurated();
+    const serializedBefore = serializeForCache(before);
+    const serializedAfter = serializeForCache(after);
+
+    expect(commonPrefixLength(serializedBefore, serializedAfter)).toBe(
+      serializedBefore.length,
+    );
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicAnchorCache.ts
+++ b/packages/providers/src/anthropic/AnthropicAnchorCache.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Preserved-head cache-anchor breakpoint for the Anthropic Messages API
+ * (#3070 "caching during compression").
+ *
+ * Anthropic does NOT use implicit prefix matching: a cached prefix is only
+ * READ at a position where a `cache_control` breakpoint was previously
+ * WRITTEN. Because the compressed head is now byte-stable across successive
+ * compressions, spending a third breakpoint at the preserved-head boundary
+ * lets the stable head be re-read from cache instead of re-billed at
+ * cache-WRITE pricing.
+ *
+ * `convertToAnthropicMessages` is NOT index-preserving — filtering, merging,
+ * thinking-strip, validation, adjacency and empty-block transforms all rebuild
+ * message objects — so the anchor breakpoint cannot be located by arithmetic
+ * on a content index. Instead the converter tags the message derived from the
+ * anchored IContent with the module-private {@link ANCHOR_CACHE_SYMBOL} via
+ * {@link tagAnchorMessage}; after the full pipeline {@link attachAnchorCacheControl}
+ * locates it by identity and attaches the breakpoint.
+ *
+ * A Symbol-keyed property is invisible to `JSON.stringify`, so it cannot leak
+ * onto the wire; {@link attachAnchorCacheControl} deletes it explicitly
+ * regardless.
+ */
+
+import type { AnthropicMessage } from './AnthropicMessageNormalizer.js';
+import {
+  selectLastCacheableBlockIndex,
+  sanitizeBlockForCacheControl,
+} from './AnthropicRequestBuilder.js';
+
+type AnchorCacheTtl = '5m' | '1h';
+
+type AnchorCacheLogger = { debug: (fn: () => string) => void };
+
+/**
+ * Module-private marker stamped on the AnthropicMessage derived from the
+ * IContent carrying `metadata.cacheAnchor`. Never exported, so no consumer
+ * outside this module can read or set it.
+ */
+const ANCHOR_CACHE_SYMBOL = Symbol('anthropicCacheAnchor');
+
+/**
+ * Stamp the anchor marker on `message`. Called by the converter for the
+ * message produced from the anchored IContent (human, assistant, or the flush
+ * carrying an anchored tool result).
+ */
+export function tagAnchorMessage(message: AnthropicMessage): void {
+  Reflect.set(message, ANCHOR_CACHE_SYMBOL, true);
+}
+
+/**
+ * Attach a `cache_control` breakpoint to a single message's last non-thinking,
+ * non-empty content block. Reuses the shared {@link selectLastCacheableBlockIndex}
+ * block-selection and {@link sanitizeBlockForCacheControl} sanitization so the
+ * anchor breakpoint and the rolling-tail breakpoint pick identical block kinds.
+ */
+function attachCacheBreakpointToMessage(
+  message: AnthropicMessage,
+  ttl: AnchorCacheTtl,
+  logger: AnchorCacheLogger,
+): void {
+  if (typeof message.content === 'string') {
+    if (message.content.trim() === '') {
+      logger.debug(
+        () =>
+          'Skipped anchor cache_control: anchor message has no cacheable text',
+      );
+      return;
+    }
+    message.content = [
+      sanitizeBlockForCacheControl(
+        { type: 'text', text: message.content },
+        ttl,
+      ),
+    ];
+    logger.debug(
+      () => 'Added anchor cache_control (converted string content to array)',
+    );
+    return;
+  }
+  if (Array.isArray(message.content)) {
+    const content = message.content;
+    const idx = selectLastCacheableBlockIndex(content);
+    if (idx < 0) {
+      logger.debug(
+        () =>
+          'Skipped anchor cache_control: anchor message has no cacheable block',
+      );
+      return;
+    }
+    content[idx] = sanitizeBlockForCacheControl(content[idx], ttl);
+    logger.debug(
+      () => `Added anchor cache_control to ${content[idx].type} block`,
+    );
+  }
+}
+
+/**
+ * Attach the preserved-head anchor `cache_control` breakpoint to the message
+ * derived from the IContent that carried `metadata.cacheAnchor`, then strip the
+ * module-private marker so it can never reach the wire.
+ *
+ * MUST run AFTER `attachPromptCaching` (the rolling-tail breakpoint): when the
+ * anchor coincides with the last message the rolling tail already covers it,
+ * so the anchor is skipped to avoid wasting one of the 4 permitted breakpoints.
+ *
+ * ACCEPTED DEGRADATION: if a transform inside `convertToAnthropicMessages`
+ * rebuilt the anchored message object, the symbol is gone and no anchor
+ * breakpoint is placed. That is exactly today's behaviour (system + rolling
+ * tail only) and is a legitimate optimisation miss — NOT an error to swallow.
+ * No retry, fallback, or heuristic re-derivation is performed (#3070).
+ */
+export function attachAnchorCacheControl(
+  messages: AnthropicMessage[],
+  ttl: AnchorCacheTtl,
+  logger: AnchorCacheLogger,
+): void {
+  const anchorIndex = messages.findIndex(
+    (m) => Reflect.get(m, ANCHOR_CACHE_SYMBOL) === true,
+  );
+
+  // Always remove the marker so it can never reach the wire (a Symbol key is
+  // already invisible to JSON.stringify, but delete it explicitly regardless).
+  for (const m of messages) {
+    if (Reflect.get(m, ANCHOR_CACHE_SYMBOL) !== undefined) {
+      Reflect.deleteProperty(m, ANCHOR_CACHE_SYMBOL);
+    }
+  }
+
+  if (anchorIndex === -1) {
+    // Accepted degradation (see docblock): the transform pipeline rebuilt the
+    // anchored message, so no anchor breakpoint is placed.
+    return;
+  }
+
+  // The rolling-tail breakpoint already marks the last message; a second
+  // breakpoint on the same block would waste one of the 4 allowed.
+  if (anchorIndex === messages.length - 1) {
+    return;
+  }
+
+  attachCacheBreakpointToMessage(messages[anchorIndex], ttl, logger);
+}

--- a/packages/providers/src/anthropic/AnthropicMessageNormalizer.anchorCache.test.ts
+++ b/packages/providers/src/anthropic/AnthropicMessageNormalizer.anchorCache.test.ts
@@ -1,0 +1,514 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the Anthropic preserved-head cache-anchor breakpoint
+ * (#3070 "caching during compression").
+ *
+ * Anthropic does not use implicit prefix matching: a cached prefix is only READ
+ * at a position where a `cache_control` breakpoint was previously WRITTEN.
+ * These tests prove that the message derived from the IContent carrying
+ * `metadata.cacheAnchor` receives an anchor breakpoint so the byte-stable
+ * compressed head is re-readable after a compression, that the total
+ * breakpoint count never exceeds Anthropic's hard limit of 4, and that the
+ * module-private marker never leaks onto the wire.
+ *
+ * The message-level assertions exercise `convertToAnthropicMessages` +
+ * `attachPromptCaching` + `attachAnchorCacheControl` as pure functions over a
+ * message array (no SDK, no HTTP). The gating/count cases exercise the real
+ * `prepareAnthropicRequest` pipeline with a single light boundary mock for the
+ * async core-prompt builder, asserting on the returned request-body structure.
+ */
+
+import { describe, expect, it, vi } from 'bun:test';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { convertToAnthropicMessages } from './AnthropicMessageNormalizer.js';
+import { attachAnchorCacheControl } from './AnthropicAnchorCache.js';
+import { attachPromptCaching } from './AnthropicRequestBuilder.js';
+import { prepareAnthropicRequest } from './AnthropicRequestPreparation.js';
+import { isAnthropicOAuthBaseURL } from './AnthropicEndpointUtils.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import type { AnthropicMessage } from './AnthropicMessageNormalizer.js';
+
+// Light boundary mock: prepareAnthropicRequest builds the real system prompt
+// asynchronously; stub it so the gating/count tests stay deterministic and
+// network-free. This is the only mock — no SDK, no ToolFormatter, no iterators.
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn(async () => 'core-prompt'),
+}));
+
+type DebugLogger = { debug: (fn: () => string) => void };
+const noopLogger: DebugLogger = { debug: () => {} };
+
+const convertOptions = {
+  isOAuth: false,
+  reasoningEnabled: false,
+  config: undefined,
+  unprefixToolName: (name: string) => name,
+  logger: noopLogger,
+};
+
+function human(text: string, anchored = false): IContent {
+  return {
+    speaker: 'human',
+    blocks: [{ type: 'text', text }],
+    ...(anchored ? { metadata: { cacheAnchor: true } } : {}),
+  };
+}
+
+function ai(text: string, anchored = false): IContent {
+  return {
+    speaker: 'ai',
+    blocks: [{ type: 'text', text }],
+    ...(anchored ? { metadata: { cacheAnchor: true } } : {}),
+  };
+}
+
+/**
+ * Run the same two-step cache attachment that buildRequestContext performs:
+ * rolling-tail first, then the anchor breakpoint.
+ */
+function applyCaching(
+  contents: IContent[],
+  ttl: '5m' | '1h' = '5m',
+): AnthropicMessage[] {
+  const messages = convertToAnthropicMessages(contents, {
+    ...convertOptions,
+  });
+  attachPromptCaching(messages, ttl, noopLogger);
+  attachAnchorCacheControl(messages, ttl, noopLogger);
+  return messages;
+}
+
+function cacheControlCount(messages: AnthropicMessage[]): number {
+  let count = 0;
+  for (const msg of messages) {
+    if (!Array.isArray(msg.content)) {
+      continue;
+    }
+    for (const block of msg.content) {
+      if ('cache_control' in block) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+describe('Anthropic anchor cache breakpoint — message-level (#3070)', () => {
+  it('places cache_control on the message derived from the anchored content', () => {
+    const contents: IContent[] = [
+      human('preserved head turn'),
+      ai('preserved head reply', true),
+      human('post-compression continuation'),
+    ];
+
+    const messages = applyCaching(contents);
+
+    // The anchored entry is the AI reply (2nd content → 2nd message). Its
+    // derived message must carry a cache_control breakpoint.
+    const anchoredMessage = messages[1];
+    expect(anchoredMessage.role).toBe('assistant');
+    expect(Array.isArray(anchoredMessage.content)).toBe(true);
+    const blocks = anchoredMessage.content as Array<Record<string, unknown>>;
+    const lastBlock = blocks[blocks.length - 1];
+    expect(lastBlock.cache_control).toStrictEqual({
+      type: 'ephemeral',
+      ttl: '5m',
+    });
+
+    // The last message also carries the rolling-tail breakpoint.
+    expect(cacheControlCount(messages)).toBe(2);
+  });
+
+  it('keeps the anchor breakpoint at the same content boundary across two byte-identical heads', () => {
+    // Two successive requests share a byte-identical preserved head; the anchor
+    // entry (the AI reply) is the same in both. This is the property that makes
+    // the head re-readable from cache after a compression.
+    const headContents: IContent[] = [
+      human('preserved head turn'),
+      ai('preserved head reply', true),
+    ];
+
+    const requestOne = applyCaching([
+      ...headContents,
+      human('continuation one'),
+    ]);
+    const requestTwo = applyCaching([
+      ...headContents,
+      ai('more context'),
+      human('continuation two'),
+    ]);
+
+    // In both requests the anchor breakpoint lands on the message derived from
+    // the same anchored content (index 1, the AI reply).
+    const anchorOne = requestOne[1];
+    const anchorTwo = requestTwo[1];
+    expect(anchorOne.role).toBe('assistant');
+    expect(anchorTwo.role).toBe('assistant');
+    expect(
+      (anchorOne.content as Array<Record<string, unknown>>).some(
+        (b) => b.cache_control !== undefined,
+      ),
+    ).toBe(true);
+    expect(
+      (anchorTwo.content as Array<Record<string, unknown>>).some(
+        (b) => b.cache_control !== undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it('produces only system + rolling tail when no entry carries the marker', () => {
+    const contents: IContent[] = [human('first'), ai('second'), human('third')];
+
+    const messages = applyCaching(contents);
+
+    // No anchor breakpoint: only the rolling tail on the last message.
+    expect(cacheControlCount(messages)).toBe(1);
+    const last = messages[messages.length - 1];
+    expect(
+      (last.content as Array<Record<string, unknown>>).some(
+        (b) => b.cache_control !== undefined,
+      ),
+    ).toBe(true);
+    // No non-last message carries a breakpoint.
+    for (let i = 0; i < messages.length - 1; i++) {
+      const blocks = messages[i].content;
+      if (Array.isArray(blocks)) {
+        for (const b of blocks) {
+          expect((b as Record<string, unknown>).cache_control).toBeUndefined();
+        }
+      }
+    }
+  });
+
+  it('skips the anchor when it coincides with the last message (no double breakpoint)', () => {
+    // Small history where the anchored entry is also the last message: the
+    // rolling-tail breakpoint already covers it, so the anchor is skipped to
+    // avoid wasting one of the 4 permitted breakpoints.
+    const contents: IContent[] = [
+      human('only head turn'),
+      ai('only head reply', true),
+    ];
+
+    const messages = applyCaching(contents);
+
+    const last = messages[messages.length - 1];
+    expect(last.role).toBe('assistant');
+    const blocks = last.content as Array<Record<string, unknown>>;
+    // Exactly one breakpoint on the last message (the rolling tail), not two.
+    expect(blocks.filter((b) => b.cache_control !== undefined)).toHaveLength(1);
+  });
+
+  it('does not leak the module-private marker onto the serialized request body', () => {
+    const contents: IContent[] = [
+      human('head'),
+      ai('anchored reply', true),
+      human('tail'),
+    ];
+
+    const messages = applyCaching(contents);
+
+    // A Symbol-keyed property is invisible to JSON.stringify; verify that and
+    // also that no block carries an unexpected key.
+    const serialized = JSON.stringify({ messages });
+    expect(serialized).not.toContain('anthropicCacheAnchor');
+    expect(serialized).not.toContain('Symbol');
+
+    for (const msg of messages) {
+      if (!Array.isArray(msg.content)) {
+        continue;
+      }
+      for (const block of msg.content) {
+        const keys = Object.keys(block);
+        // Every key must be a known Anthropic content-block field.
+        for (const key of keys) {
+          expect(
+            [
+              'type',
+              'text',
+              'id',
+              'name',
+              'input',
+              'tool_use_id',
+              'content',
+              'is_error',
+              'thinking',
+              'signature',
+              'data',
+              'source',
+              'title',
+              'cache_control',
+            ].includes(key),
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('places no anchor breakpoint when a transform rebuilt the anchored message (accepted degradation)', () => {
+    const contents: IContent[] = [
+      human('head'),
+      ai('anchored reply', true),
+      human('tail'),
+    ];
+
+    const messages = convertToAnthropicMessages(contents, {
+      ...convertOptions,
+    });
+
+    // Simulate a pipeline transform that rebuilt the anchored message object,
+    // dropping the identity marker (the accepted-degradation case). Replace the
+    // anchored message with a structurally-identical fresh object.
+    const rebuiltSecond: AnthropicMessage = {
+      role: messages[1].role,
+      content: JSON.parse(JSON.stringify(messages[1].content)),
+    };
+    const rebuilt = [messages[0], rebuiltSecond, messages[2]];
+
+    attachPromptCaching(rebuilt, '5m', noopLogger);
+    // Must not throw and must not place an anchor breakpoint.
+    expect(() =>
+      attachAnchorCacheControl(rebuilt, '5m', noopLogger),
+    ).not.toThrow();
+    expect(cacheControlCount(rebuilt)).toBe(1);
+  });
+
+  it('honors a tool-result entry as the anchor boundary', () => {
+    const toolCallId = 'tool_anchor_1';
+    const contents: IContent[] = [
+      human('do the thing'),
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: toolCallId,
+            name: 'read_file',
+            parameters: { path: '/tmp/x' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: toolCallId,
+            toolName: 'read_file',
+            result: 'content',
+          },
+        ],
+        metadata: { cacheAnchor: true },
+      },
+      // A tool result must be followed by an assistant turn (the summary), so
+      // the anchored tool-result message is never the last message and the
+      // transform pipeline does not need to merge consecutive user messages.
+      ai('summary of what happened so far'),
+      human('continuation after the anchored tool result'),
+    ];
+
+    const messages = applyCaching(contents);
+
+    // The anchored tool content flushes into a user message carrying the
+    // tool_result; that message must carry the anchor breakpoint, and it must
+    // NOT be the last message.
+    const anchoredToolMessage = messages.find(
+      (m) =>
+        m.role === 'user' &&
+        Array.isArray(m.content) &&
+        m.content.some(
+          (b) =>
+            (b as { type?: string }).type === 'tool_result' &&
+            'cache_control' in b,
+        ),
+    );
+    expect(anchoredToolMessage).toBeDefined();
+    expect(anchoredToolMessage).not.toBe(messages[messages.length - 1]);
+  });
+});
+
+describe('Anthropic anchor cache breakpoint — gating & count via prepareAnthropicRequest (#3070)', () => {
+  function buildOptions(opts: {
+    baseURL: string;
+    promptCaching: 'off' | '5m' | '1h';
+    isOAuth: boolean;
+    contents: IContent[];
+  }) {
+    const callOpts = createProviderCallOptions({
+      providerName: 'anthropic',
+      contents: opts.contents,
+      settingsOverrides: {
+        provider: { 'prompt-caching': opts.promptCaching },
+      },
+      resolved: {
+        model: 'claude-3-5-sonnet-20241022',
+        baseURL: opts.baseURL,
+        authToken: 'test-token',
+        telemetry: { providerName: 'anthropic' },
+      },
+    });
+    return callOpts;
+  }
+
+  async function prepare(opts: {
+    baseURL: string;
+    promptCaching: 'off' | '5m' | '1h';
+    isOAuth: boolean;
+    contents: IContent[];
+  }) {
+    const callOpts = buildOptions(opts);
+    return prepareAnthropicRequest({
+      content: callOpts.contents,
+      tools: callOpts.tools,
+      options: callOpts,
+      isOAuth: opts.isOAuth,
+      providerName: 'anthropic',
+      config: undefined,
+      getMaxTokensForModel: () => 4096,
+      unprefixToolName: (name: string) => name,
+      providerConfig: undefined,
+      logger: new DebugLogger('test:anthropic-anchor-cache'),
+      toolsLogger: new DebugLogger('test:anthropic-anchor-cache:tools'),
+      cacheLogger: noopLogger,
+    });
+  }
+
+  function countRequestCacheControls(requestBody: {
+    system?: unknown;
+    messages: AnthropicMessage[];
+  }): number {
+    let count = 0;
+    const system = requestBody.system;
+    if (Array.isArray(system)) {
+      for (const block of system) {
+        if (
+          block !== null &&
+          typeof block === 'object' &&
+          'cache_control' in block
+        ) {
+          count++;
+        }
+      }
+    }
+    count += cacheControlCount(requestBody.messages);
+    return count;
+  }
+
+  const anchoredHead: IContent[] = [
+    human('preserved head turn'),
+    ai('preserved head reply', true),
+    human('post-compression continuation'),
+  ];
+
+  it('native base URL + caching on: system + anchor + tail = 3 breakpoints (<= 4)', async () => {
+    const ctx = await prepare({
+      baseURL: 'https://api.anthropic.com',
+      promptCaching: '5m',
+      isOAuth: false,
+      contents: anchoredHead,
+    });
+
+    const total = countRequestCacheControls(
+      ctx.requestBody as { system?: unknown; messages: AnthropicMessage[] },
+    );
+    expect(total).toBeLessThanOrEqual(4);
+    expect(total).toBe(3);
+
+    // The anchor breakpoint lands on the assistant message derived from the
+    // anchored content (message index 1).
+    const msgs = ctx.anthropicMessages;
+    const anchorMsg = msgs[1];
+    expect(anchorMsg.role).toBe('assistant');
+    expect(
+      (anchorMsg.content as Array<Record<string, unknown>>).some(
+        (b) => b.cache_control !== undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it('OAuth <system>-as-message[0] path: total breakpoints never exceed 4', async () => {
+    const ctx = await prepare({
+      baseURL: 'https://api.anthropic.com',
+      promptCaching: '5m',
+      isOAuth: true,
+      contents: anchoredHead,
+    });
+
+    const total = countRequestCacheControls(
+      ctx.requestBody as { system?: unknown; messages: AnthropicMessage[] },
+    );
+    expect(total).toBeLessThanOrEqual(4);
+    // OAuth: <system> message[0] (1) + anchor (1) + rolling tail (1) = 3.
+    expect(total).toBe(3);
+
+    // message[0] is the OAuth <system> user message carrying a breakpoint.
+    const msgs = ctx.anthropicMessages;
+    expect(msgs[0].role).toBe('user');
+    expect(
+      (msgs[0].content as Array<Record<string, unknown>>).some(
+        (b) => b.cache_control !== undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it('places no cache_control when caching is disabled', async () => {
+    const ctx = await prepare({
+      baseURL: 'https://api.anthropic.com',
+      promptCaching: 'off',
+      isOAuth: false,
+      contents: anchoredHead,
+    });
+
+    const total = countRequestCacheControls(
+      ctx.requestBody as { system?: unknown; messages: AnthropicMessage[] },
+    );
+    expect(total).toBe(0);
+    // No message carries any breakpoint (no anchor, no rolling tail).
+    expect(cacheControlCount(ctx.anthropicMessages)).toBe(0);
+  });
+
+  it('places no cache_control for a non-native (third-party gateway) base URL', async () => {
+    // Sanity: the gate predicate rejects the third-party host.
+    expect(isAnthropicOAuthBaseURL('https://api.z.ai/v1')).toBe(false);
+
+    const ctx = await prepare({
+      baseURL: 'https://api.z.ai/v1',
+      promptCaching: '5m',
+      isOAuth: false,
+      contents: anchoredHead,
+    });
+
+    const total = countRequestCacheControls(
+      ctx.requestBody as { system?: unknown; messages: AnthropicMessage[] },
+    );
+    // Third-party gateway: no anchor, no rolling tail, system is a plain string.
+    expect(total).toBe(0);
+    expect(cacheControlCount(ctx.anthropicMessages)).toBe(0);
+  });
+
+  it('produces only system + rolling tail when no entry carries the marker (native + caching on)', async () => {
+    const noMarkerHead: IContent[] = [
+      human('first'),
+      ai('second'),
+      human('third'),
+    ];
+
+    const ctx = await prepare({
+      baseURL: 'https://api.anthropic.com',
+      promptCaching: '5m',
+      isOAuth: false,
+      contents: noMarkerHead,
+    });
+
+    const total = countRequestCacheControls(
+      ctx.requestBody as { system?: unknown; messages: AnthropicMessage[] },
+    );
+    // system (1) + rolling tail (1) = 2; no anchor breakpoint.
+    expect(total).toBe(2);
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicMessageNormalizer.ts
+++ b/packages/providers/src/anthropic/AnthropicMessageNormalizer.ts
@@ -35,6 +35,7 @@ import {
   stripEmptyTextBlocks,
 } from './AnthropicMessageValidator.js';
 import { stripCrossModelThinking } from './crossModelThinkingStrip.js';
+import { tagAnchorMessage } from './AnthropicAnchorCache.js';
 
 // Type definitions moved from AnthropicProvider.ts
 
@@ -504,9 +505,27 @@ function convertContentToMessages(
 ): AnthropicMessage[] {
   const messages: AnthropicMessage[] = [];
   let pendingToolResults: AnthropicToolResultBlock[] = [];
+  // True while the next pending-tool-result flush is derived from the
+  // anchored content, so the anchor marker rides on that flushed message.
+  let anchorPending = false;
+
+  // Tag the message just appended for `anchored`, if any (#3070).
+  const tagIfAnchored = (anchored: boolean, before: number): void => {
+    if (anchored && messages.length > before) {
+      tagAnchorMessage(messages[messages.length - 1]);
+    }
+  };
+
+  const flushPending = (): void => {
+    const before = messages.length;
+    pendingToolResults = flushPendingToolResults(messages, pendingToolResults);
+    tagIfAnchored(anchorPending, before);
+    anchorPending = false;
+  };
 
   for (let contentIndex = 0; contentIndex < contents.length; contentIndex++) {
     const c = contents[contentIndex];
+    const anchored = c.metadata?.cacheAnchor === true;
     const speaker: string = c.speaker;
     const toolResponseBlocks = c.blocks.filter(
       (b): b is ToolResponseBlock => b.type === 'tool_response',
@@ -521,30 +540,32 @@ function convertContentToMessages(
       );
 
     if (toolResponseBlocks.length > 0) {
-      const results = buildToolResults(
-        c,
-        toolResponseBlocks,
-        nonToolResponseBlocks,
-        options,
+      pendingToolResults.push(
+        ...buildToolResults(
+          c,
+          toolResponseBlocks,
+          nonToolResponseBlocks,
+          options,
+        ),
       );
-      pendingToolResults.push(...results);
     }
 
     if (speaker === 'human') {
-      pendingToolResults = flushPendingToolResults(
-        messages,
-        pendingToolResults,
-      );
-
+      flushPending();
       if (!onlyToolResponseContent) {
+        const before = messages.length;
         pushHumanMessageIfPresent(messages, c);
+        tagIfAnchored(anchored, before);
+      } else if (anchored) {
+        // Human content whose only payload is tool responses: its derived
+        // message is the pending tool-result flush.
+        anchorPending = true;
       }
     } else if (speaker === 'ai') {
-      pendingToolResults = flushPendingToolResults(
-        messages,
-        pendingToolResults,
-      );
+      flushPending();
+      const before = messages.length;
       convertAIMessage(c, contentIndex, redactedIndices, messages, options);
+      tagIfAnchored(anchored, before);
     } else {
       if (speaker !== 'tool') {
         throw new Error(`Unknown speaker type: ${speaker}`);
@@ -552,10 +573,13 @@ function convertContentToMessages(
       if (toolResponseBlocks.length === 0) {
         throw new Error('Tool content must have a tool_response block');
       }
+      if (anchored) {
+        anchorPending = true;
+      }
     }
   }
 
-  pendingToolResults = flushPendingToolResults(messages, pendingToolResults);
+  flushPending();
   return messages;
 }
 

--- a/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
@@ -208,8 +208,29 @@ function isEmptyContentBlock(block: CacheableContentBlock): boolean {
 }
 
 /**
+ * Index of the last non-thinking, non-empty content block in `content`, or -1
+ * when none qualifies. Shared by the rolling-tail breakpoint
+ * (`attachPromptCaching`) and the preserved-head anchor breakpoint so both
+ * select the same kind of block for a `cache_control` marker (#3070).
+ */
+export function selectLastCacheableBlockIndex(
+  content: CacheableContentBlock[],
+): number {
+  for (let i = content.length - 1; i >= 0; i--) {
+    const block = content[i];
+    const isThinkingBlock =
+      block.type === 'thinking' || block.type === 'redacted_thinking';
+    if (!isThinkingBlock && !isEmptyContentBlock(block)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
  * Attach cache_control to the last message's last non-thinking block
- * Mutates messages in place (acceptable since Anthropic conversion creates fresh objects)
+ * Mutates messages in place (acceptable because Anthropic conversion creates
+ * fresh objects).
  */
 export function attachPromptCaching(
   messages: AnthropicMessage[],
@@ -238,16 +259,7 @@ export function attachPromptCaching(
   } else if (Array.isArray(lastMessage.content)) {
     const content = lastMessage.content as CacheableContentBlock[];
 
-    let lastNonThinkingIndex = -1;
-    for (let i = content.length - 1; i >= 0; i--) {
-      const block = content[i];
-      const isThinkingBlock =
-        block.type === 'thinking' || block.type === 'redacted_thinking';
-      if (!isThinkingBlock && !isEmptyContentBlock(block)) {
-        lastNonThinkingIndex = i;
-        break;
-      }
-    }
+    const lastNonThinkingIndex = selectLastCacheableBlockIndex(content);
 
     if (lastNonThinkingIndex >= 0) {
       content[lastNonThinkingIndex] = sanitizeBlockForCacheControl(

--- a/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
@@ -20,6 +20,7 @@ import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type { ProviderToolset } from '../IProvider.js';
 import type { AnthropicMessage } from './AnthropicMessageNormalizer.js';
 import { convertToAnthropicMessages } from './AnthropicMessageNormalizer.js';
+import { attachAnchorCacheControl } from './AnthropicAnchorCache.js';
 import { convertToolsToAnthropic } from './schemaConverter.js';
 import {
   buildAnthropicSystemPrompt,
@@ -739,6 +740,16 @@ function buildRequestContext(params: {
   // message-level cache_control injection.
   if (wantCaching) {
     attachPromptCaching(
+      systemContext.messages,
+      requestSettings.ttl,
+      cacheLogger,
+    );
+    // Issue #3070: spend a third breakpoint at the preserved-head boundary so
+    // the byte-stable compressed head is READ from cache instead of re-billed
+    // at cache-WRITE pricing. Runs after the rolling-tail breakpoint so the
+    // two are never placed on the same block. Gated on the same native-base-URL
+    // flag as the other breakpoints (third-party gateways stay unchanged).
+    attachAnchorCacheControl(
       systemContext.messages,
       requestSettings.ttl,
       cacheLogger,

--- a/project-plans/20260805-issue3070-cache-prefix/plan.md
+++ b/project-plans/20260805-issue3070-cache-prefix/plan.md
@@ -1,0 +1,275 @@
+# Issue #3070 — Prompt-cache prefix stability across providers
+
+Branch: `issue3070`
+
+## Framing
+
+The issue was filed with Anthropic-specific detail. It is **not** Anthropic-specific.
+Every mutation that breaks the cacheable prefix lives in `packages/agents` and
+`packages/core`, i.e. **above** the provider boundary, so it reaches `anthropic`,
+`claudecode`, `openai`, `openai-responses`, `codex` and `gemini` identically.
+
+Note two structural facts that shape the fix:
+
+- There is no separate `codex` or `claudecode` provider. `codex` is an alias to
+  `openai-responses` (with an `isCodex` flag); `claudecode` is an alias to `anthropic`.
+- Anthropic caching is **explicit** (client-written `cache_control` breakpoints).
+  OpenAI Chat, OpenAI Responses/Codex and Gemini caching is **implicit**
+  (server-side longest-common-prefix match). Implicit caches still die at the first
+  divergent token, so **prefix stability matters equally for all of them** — but
+  implicit providers need no marking, only stable bytes.
+
+## Verified defects
+
+### Defect A — the compression trigger collapses to zero on small context windows
+
+`CompressionHandler.shouldCompress` (`packages/agents/src/compression/CompressionHandler.ts:270-313`):
+
+```
+const effectiveLimit = Math.max(0, contextLimit - completionBudget);   // L283
+const compressionThreshold = threshold * effectiveLimit;                // L284
+const shouldCompress = currentTokens >= compressionThreshold;           // L301
+```
+
+`getCompletionBudget` (`packages/agents/src/compression/compressionBudgeting.ts:70-94`)
+falls back to a fixed `DEFAULT_COMPLETION_BUDGET = 65_536` (L76) when nothing is
+configured. The registry `maxOutputTokens` (`packages/core/src/models/hydration.ts:142`)
+feeds `RuntimeModel`, **not** this `generationConfig`, so for an unconfigured session the
+budget really is the flat 65,536.
+
+Therefore any `context-limit <= 65_536` yields `effectiveLimit === 0`, so
+`compressionThreshold === 0`, so `currentTokens >= 0` is **always true** and
+**compression runs on every single send** — each one a paid LLM summarization call
+(`MiddleOutStrategy.requiresLLM = true`) plus a full prefix rewrite.
+
+Our own documentation walks users into this: `docs/local-models.md` recommends
+`context-limit` values of 32768 (L72, L132, L207, L241, L312), 65536 (L343) and
+16384 (L386). Every one of those is at or below the default budget.
+
+The response is also superlinear well above the cliff, which is the mechanism behind the
+reporter's "lowering context-limit costs more" claim: with a 65,536 budget, 200k → trigger
+114,294 and 100k → trigger 29,294, so halving the limit cuts the trigger ~3.9x, not 2x.
+
+**Root cause:** a fixed absolute default output reservation that can equal or exceed the
+whole window, plus a `Math.max(0, ...)` clamp that converts that contradiction into silent,
+expensive behaviour instead of surfacing it.
+
+### Defect B — the preserved head is not a stable prefix
+
+`MiddleOutStrategy.computeSplit` (`packages/agents/src/compression/MiddleOutStrategy.ts:246-247`):
+
+```
+let topSplitIndex = Math.ceil(history.length * topPreserveThreshold);
+let bottomSplitIndex = Math.floor(history.length * (1 - preserveThreshold));
+```
+
+The head boundary is a **fraction of the current length**, and compression shrinks the
+history. So the head is not monotonic:
+
+- N1 = 40 → topSplit = ceil(8) = 8, bottomSplit = floor(24) = 24 → new length 8 + 2 + 16 = 26
+- append 6 turns → N2 = 32 → topSplit = ceil(6.4) = **7**
+
+The entry at index 7, which the first compression preserved, is summarized away by the
+second. The head **shrank**. There is no monotonic floor anywhere in the codebase
+(`grep -rn "cacheAnchor|anchorIndex|stablePrefix" packages/` → zero matches), and there is
+no test anywhere asserting prefix stability.
+
+Note the head is otherwise preserved byte-identically — `assembleHistory` keeps `toKeepTop`
+by reference and `historyChronology.stamp()` preserves existing markers across the
+clear/rebuild — so the *only* thing destroying it is the oscillating boundary.
+
+## Fix
+
+### 1. Make the default completion budget proportional; fail fast on a contradictory one
+
+In `compressionBudgeting.ts`:
+
+- The **default** (nothing configured) becomes
+  `Math.min(DEFAULT_COMPLETION_BUDGET, Math.floor(contextLimit * DEFAULT_COMPLETION_FRACTION))`
+  with `DEFAULT_COMPLETION_FRACTION = 0.5`. Never reserve more than half the window for
+  output. This preserves today's behaviour for every window >= 131,072 (the common cloud
+  case) and fixes small windows continuously, with no discontinuity.
+- An **explicitly configured** budget (ephemeral `maxOutputTokens`, `generationConfig`,
+  or provider params) that is `>= contextLimit` is a genuinely impossible configuration:
+  **throw** a typed `InvalidContextBudgetError` naming both numbers and the setting to
+  change. No clamp, no fallback, no try/catch.
+- Delete the `Math.max(0, contextLimit - completionBudget)` clamp at
+  `CompressionHandler.ts:283`.
+
+Rationale for the split: a *user-configured* contradiction is a user error and must fail
+fast. A collision with our own *unconfigured default* is **our** bug, and hard-failing every
+local-model user for it would be wrong. Fixing the default is the actual fix, not a hedge.
+
+### 2. Monotonic cache anchor (the durable, provider-agnostic root-cause fix)
+
+The primitive already exists: `metadata.chronology.seq` is monotonic, never reused,
+preserved across the compression rebuild, and never serialized to a provider.
+
+- `HistoryService` gains `cacheAnchorSeq` with `getCacheAnchorSeq()`,
+  `setCacheAnchorSeq(seq)`, and `resetCacheAnchorSeq()`. The setter validates a positive
+  integer identity but accepts a numerically lower seq: compressed histories are not
+  seq-sorted because synthetic summaries precede preserved tail entries. Reset sets it to 0.
+- `MiddleOutStrategy.computeSplit` raises `topSplitIndex` to
+  `Math.max(baseSplitIndex, anchorIndex + 1)` where `anchorIndex` is found by **exact seq
+  identity match** (forward scan for the entry whose `chronology.seq === cacheAnchorSeq`),
+  NOT a backward `<=` threshold scan. The array is NOT sorted by seq after a compression
+  (preserved tail entries keep their original low seqs while the summary/continuation get
+  the highest seqs and sit in the middle), so a `<=` scan would match a low-seq tail entry
+  at a high index and wedge the strategy into a permanent structural no-op. When no entry
+  matches exactly, there is no floor; fall back to the base fractional split. Do NOT sort.
+- `adjustForToolCallBoundary` runs AFTER the anchor floor is applied and can move the index
+  backward below the floor. After the adjustment, if `topSplitIndex < anchorFloor`, search
+  FORWARD via `findValidSplitAtOrAboveFloor(history, floor)` for the next valid split point
+  at or above the floor. If no valid split exists at or above the floor, return a clean
+  structural no-op. Never silently drop below the floor.
+- `CompressionHandler` resolves and validates the new anchor value BEFORE mutating history
+  (so invalid strategy metadata cannot leave a partially applied compression). The anchor is
+  derived from `newHistory[topPreserved - 1]` using the strategy-reported `topPreserved`
+  length (MiddleOutStrategy reports it as `metadata.topPreserved`), NOT by searching the
+  output for the compression summary (the summary-search approach pins the anchor to the
+  first compression's stale summary forever, making the feature inert). After history
+  mutation: if the prefix was destroyed (`topPreserved <= 0`), explicitly RESET the anchor;
+  otherwise set the anchor to the resolved chronology identity.
+- The anchor is read into `CompressionContext` as one new readonly field.
+
+**Anchor advance via strategy-reported head length (NOT summary search).** The original
+plan's anchor design searched the post-compression history for the compression summary and
+used its index. That is wrong: from the second compression onward the previous compression's
+summary sits INSIDE the preserved head and still carries `metadata.reason ===
+'compression-state-snapshot'`, so the first match is the STALE summary and the anchor pins
+to the same seq forever. The fix threads the strategy-reported `topPreserved` head length
+through the entire callback chain (`runCompressionWithRetryAndFallback` →
+`handleStructuralNoop` → `applyFallbackCompressionResult` → `performFallbackCompression`)
+and derives the anchor from `newHistory[topPreserved - 1]`.
+
+**Anchor lifecycle.** `clear()` preserves the anchor (compression rebuild). Resets are
+explicit calls at:
+
+| Call site | Semantics | Anchor |
+|---|---|---|
+| `CompressionHandler.ts` apply callback | compression rebuild | **survives** (or **resets** if prefix destroyed) |
+| `ConversationManager.clearHistory()` | session reset | **resets to 0** |
+| `ConversationManager.setHistory()` | history restore | **resets to 0** |
+| `client.resetChat()` | session reset | **resets to 0** |
+| `client.restoreHistory()` | wholesale history replacement | **resets to 0** |
+| `providerContentEnforcement` / `pendingContextWindowEnforcement` | post-truncation rebuild | **resets to 0** |
+
+`client.restoreHistory` does a wholesale replacement via `validateAndFix()` + `addAll()`
+WITHOUT calling `clear()`, so it was missed in the original lifecycle enumeration; it now
+calls `resetCacheAnchorSeq()` at the start.
+
+**Prefix-destroying strategies.** `TopDownTruncationStrategy` front-drops the entire head
+and emits no summary. When a compression result preserves no head (`topPreserved === 0` or
+absent), the apply callback explicitly resets the anchor rather than leaving it pointing at
+deleted content. This is an explicit, readable decision at the apply site, not a hidden
+fallback.
+
+### 3. Documentation corrections (part of the bug, not a nicety)
+
+- `docs/local-models.md` — every recommended `context-limit` at or below the default output
+  reservation, plus the rule that `context-limit` must exceed `max_tokens`.
+- `docs/providers/models-and-limits.md` — state that the compression trigger is a fraction
+  of `context-limit − max_tokens`, that lowering `context-limit` therefore increases spend
+  superlinearly (more compressions, more cache-prefix rewrites), and that a configured
+  `max_tokens >= context-limit` is now rejected.
+- One sentence that `compression.strategy=high-density` mutates history continuously and is
+  hostile to prompt caching.
+
+## Tests (bun:test, behavioral, no network)
+
+Shared test-local helpers define the operational meaning of "cacheable prefix":
+
+```
+serializeForCache(contents) = contents.map(c => JSON.stringify({ speaker, blocks }))
+commonPrefixLength(a, b)    = count of equal leading entries
+```
+
+Metadata is deliberately excluded — `chronology` is never sent to a provider. This proxy is
+exactly what an implicit-cache provider matches on and exactly what determines where an
+Anthropic breakpoint could pay off, which is what makes these tests provider-agnostic.
+
+The only test double is a **real** in-process async generator satisfying the `IProvider`
+port that compression requires. We never assert it was called; every assertion is on
+returned data. (Do not copy the `vi.mock` style in the existing Anthropic caching tests.)
+
+**A. `packages/agents/src/compression/__tests__/compressionPrefixStability.test.ts`**
+
+- A1 — head never shrinks across successive compressions. Uses the production
+  `resolveHeadAnchorSeq(newHistory, topPreserved)` advance path (not hand-computed).
+- A2 — property form: 5 cycles of append-12-then-compress; asserts CONTENT prefix stability
+  via `commonPrefixLength(serializeForCache(...))` using the production advance path.
+- A3 — trigger arithmetic. Exact values for 200k and 100k, and the ratio > 3.5 asserting the
+  superlinear response. Explicit-budget-exceeds-limit throws. Default budget on a 32,768
+  window produces a **positive** trigger (proves the every-send loop is gone).
+- A4 — anchor contract: exact identity accepts a numerically lower seq, invalid seqs throw, a fresh service is 0, the
+  compression rebuild preserves it, and each session-reset path resets it.
+- A5 — invariants hold: anchor floor HOLDS when an UNMATCHED / interrupted tool_call sits at
+  the boundary (the case that CAN fail); an anchor that would push past the bottom split
+  yields a clean structural no-op with an unmodified history.
+- A6 — `resolveHeadAnchorSeq(newHistory, topPreserved)` contract: returns the seq of the
+  last preserved head entry by topPreserved index; returns undefined when topPreserved is 0
+  (prefix destroyed) or exceeds history length; the resolved seq is accepted by
+  `setCacheAnchorSeq`.
+
+The test helper `buildContext` uses production geometry: `preserveThreshold=0.4`,
+`topPreserveThreshold=0.2` (matching `createAgentRuntimeContext.ts`), not 0.2/0.2.
+
+**E2E. `packages/agents/src/compression/__tests__/compressionAnchorE2E.test.ts`**
+
+- E2E — drives `CompressionHandler.performCompression` (NOT MiddleOutStrategy directly)
+  against a real `HistoryService` over 5 compressions with a GROWING history, asserting the
+  serialized content prefix (the head, located by exact seq identity match to
+  preserved boundary is monotonically non-decreasing by array position across every cycle; numeric `cacheAnchorSeq` may decrease. This is the regime
+  where Defects 1-4 manifest.
+- Defect 5 — after a truncation-style result that preserves no head, the anchor is reset and
+  the next compression is not wedged.
+- Defect 6 — `client.restoreHistory` resets the anchor (tested via the
+  `resetCacheAnchorSeq` primitive + `addAll` wholesale replacement).
+
+**Red/green. `packages/agents/src/compression/__tests__/compressionAnchorRedGreen.test.ts`**
+
+- GREEN: with the anchor floor ENABLED (production path), the head never shrinks across 5
+  cycles → `stable === true`.
+- RED: with the anchor floor DISABLED (reset the anchor to 0 after each compression), the
+  head shrinks → `stable === false`. This proves the anchor floor is the binding mechanism.
+
+**B. `packages/core/src/services/history/historyPrefixStability.test.ts`** (characterization —
+these pass on main and must still be committed, because their absence is why this defect
+went unnoticed; label them as such)
+
+- B1 — the per-turn provider pipeline is prefix-stable under append.
+- B2 — an interrupted tool call perturbs only the tail, not the head.
+- B3 — curation is an identity map on any prefix (re-curates through a fresh
+`HistoryService`, not a self-comparison).
+
+Red/green order: A3 → A4 → A1 → A2/A5 → B1-B3.
+
+## Anthropic explicit-cache completion
+
+Anthropic cannot automatically re-match the stable head: it only reads a cached prefix at
+an explicit `cache_control` breakpoint. This PR therefore carries the anchor on
+`IContent.metadata.cacheAnchor`, tags the derived Anthropic message with a module-private
+`Symbol` through conversion, and spends a third breakpoint at that boundary. The existing
+system and rolling-tail breakpoints remain unchanged, so a normal compressed request uses
+3 of Anthropic's 4 allowed breakpoints. The anchor is skipped when it coincides with the
+rolling tail. The existing native-Anthropic-endpoint gate also applies, leaving third-party
+gateways unchanged.
+
+## Explicitly deferred (file as follow-up issues)
+
+- **D1** `HighDensityStrategy` honouring the anchor (opt-in strategy only — it does not run
+  under the default `middle-out`, which is `threshold` mode not `continuous`).
+- **D2** System-prompt prefix hazards: user templates using `{{CURRENT_TIME}}`, and core
+  memory reloaded from disk per request. No shipped template is affected — latent, not live.
+- **D3** Anthropic explicit caching is disabled outright for third-party gateways.
+- **D4** OpenAI Chat Completions ignores the `prompt-caching` setting entirely.
+
+## Explicitly NOT in scope
+
+- Changing the `compressionThreshold` (0.85) or `topPreserveThreshold` (0.2) defaults.
+  Both are knobs that mask the invariant defect; raising `topPreserveThreshold` actually
+  *widens* the oscillation band and starves compression.
+- Provider changes beyond the bounded Anthropic anchor breakpoint described above.
+- Defensive guards, fallbacks or try/catch absorption in new code.
+- Any `eslint-disable`, `@ts-expect-error`, `@ts-ignore`, or loosening of lint/complexity
+  rules. If `computeSplit` nears a complexity ceiling, extract a named helper.


### PR DESCRIPTION
## TLDR

Preserves provider prompt-cache prefixes across repeated history compression for Codex/OpenAI Responses, OpenAI Chat, Gemini, Anthropic, and Claude Code.

The change prevents small context windows from collapsing the compression trigger to zero, makes the middle-out preserved head stable across successive compressions, and spends an Anthropic cache breakpoint at that preserved-head boundary.

## Dive Deeper

Issue #3070 was written around Anthropic telemetry, but the root mutation occurs above the provider layer and affected every provider:

- Codex/OpenAI Responses, OpenAI Chat, and Gemini rely on implicit longest-common-prefix caching. Middle-out compression previously recomputed its preserved head as a percentage of a shrinking history, so a later compression could delete content an earlier compression had preserved. This PR tracks the exact preserved-head boundary and prevents subsequent middle-out splits from crossing it.
- Anthropic and Claude Code need explicit cache breakpoints. The normalized request now carries an internal anchor marker through conversion and attaches a third cache_control breakpoint at the stable head boundary. The native-endpoint and prompt-caching gates remain unchanged, the rolling-tail duplicate is skipped, and API-key/OAuth requests stay within Anthropic's four-breakpoint limit.
- The unconfigured completion reservation was a flat 65,536 tokens. For context limits at or below that value, the effective prompt budget became zero and compression ran on every send. The default is now capped at half the context window while preserving the existing 65,536 behavior for windows of 131,072 or larger. Explicit contradictory budgets fail fast with a typed error.

The cache anchor is reset explicitly when a session/history replacement or prefix-destroying truncation invalidates the prefix. Tool-call boundaries remain intact, including matched and interrupted calls.

Open Code Review ran over the full worktree with all changed test files included. Its coverage state was partial because 2 of 24 selected items had reviewer read-range failures; all 15 emitted findings were evaluated, and the valid High/Medium issues were remediated. The review artifacts are at:

    ~/Library/Logs/llxprt-code/opencodereview/runs/20260806T044040Z-36dfb96e

## Reviewer Test Plan

1. Run the focused behavioral suites:

       cd packages/agents
       bun test src/compression/__tests__/compressionPrefixStability.test.ts src/compression/cacheAnchor.test.ts src/compression/__tests__/compressionAnchorE2E.test.ts src/compression/__tests__/compression.characterization.test.ts

       cd ../core
       bun test src/services/history/historyPrefixStability.test.ts

       cd ../providers
       bun test src/anthropic/AnthropicMessageNormalizer.anchorCache.test.ts

2. Review these observable guarantees:
   - repeated middle-out compressions never shrink the serialized provider-visible head;
   - the anchor accepts exact chronology identity even when its numeric seq decreases across a compressed array;
   - matched tool calls/responses remain on the same side of the split;
   - prefix-destroying fallback/reset paths clear the anchor;
   - Anthropic native requests receive system + preserved-head anchor + rolling-tail breakpoints, while disabled caching and third-party endpoints remain unchanged;
   - explicit completion budgets greater than or equal to context-limit fail fast;
   - an unconfigured 32K context retains a positive compression threshold.

3. Run repository verification:

       npm run lint
       npm run typecheck
       npm run format
       npm run build
       npm run test
       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

Local results:
- lint: pass
- typecheck: pass after the required declaration build refreshed dependent workspace declarations
- format: pass
- build: pass
- smoke test: pass
- focused changed/related tests: pass
- full test command: only timeout-sensitive tests failed under full-suite load. The five LSP timeout cases were previously reproduced with all issue changes stashed on main. Additional agent API tests that timed out in the final loaded run pass in isolation (36/36). No issue-related test failed.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3070
