### PR TITLE
Stop replaying truncated Responses streams (Fixes #3049)

### DIFF
--- a/packages/providers/src/openai-responses/OpenAIResponsesProvider.parity.test.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProvider.parity.test.ts
@@ -34,6 +34,11 @@ function makeSseResponse(): Response {
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
     start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+        ),
+      );
       controller.enqueue(encoder.encode('data: [DONE]\n\n'));
       controller.close();
     },

--- a/packages/providers/src/openai-responses/OpenAIResponsesProvider.websocketFallback.test.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProvider.websocketFallback.test.ts
@@ -102,6 +102,11 @@ function httpSseResponse(): Response {
           'data: {"type":"response.output_text.delta","delta":"http"}\n\n',
         ),
       );
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+        ),
+      );
       controller.enqueue(encoder.encode('data: [DONE]\n\n'));
       controller.close();
     },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProjectionEndpointParity.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProjectionEndpointParity.test.ts
@@ -127,6 +127,11 @@ function streamingFetchStub(requestedUrls: string[]): typeof global.fetch {
     return new Response(
       new ReadableStream({
         start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+            ),
+          );
           controller.enqueue(encoder.encode('data: [DONE]\n\n'));
           controller.close();
         },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesPromptEnvelopeProjection.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesPromptEnvelopeProjection.test.ts
@@ -237,6 +237,11 @@ describe('OpenAIResponsesProvider.projectPromptEnvelope (issue #2817 A5)', () =>
       const encoder = new TextEncoder();
       const body = new ReadableStream({
         start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+            ),
+          );
           controller.enqueue(encoder.encode('data: [DONE]\n\n'));
           controller.close();
         },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.malformedCallId.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.malformedCallId.test.ts
@@ -65,6 +65,8 @@ describe('OpenAIResponsesProvider Codex Mode - malformed call ids', () => {
   it('should not emit function_call_output for malformed call ids that cannot match a function_call', async () => {
     const provider = buildProviderWithOAuth();
 
+    const encoder = new TextEncoder();
+
     const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
       const bodyText =
         init?.body instanceof Blob
@@ -99,7 +101,21 @@ describe('OpenAIResponsesProvider Codex Mode - malformed call ids', () => {
         }
       }
 
-      return new Response('', { status: 200 });
+      const sseStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+            ),
+          );
+          controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+          controller.close();
+        },
+      });
+      return new Response(sseStream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
     });
 
     globalThis.fetch = fetchMock as typeof globalThis.fetch;

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.stateless.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.stateless.test.ts
@@ -57,6 +57,11 @@ function createMockStreamingResponse() {
       controller.enqueue(
         encoder.encode('data: {"type":"content.delta","delta":"ok"}\n\n'),
       );
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+        ),
+      );
       controller.enqueue(encoder.encode('data: [DONE]\n\n'));
       controller.close();
     },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.pdf.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.pdf.test.ts
@@ -87,6 +87,11 @@ async function captureRequestBody(
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+            ),
+          );
           controller.enqueue(encoder.encode('data: [DONE]\n\n'));
           controller.close();
         },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
@@ -65,6 +65,11 @@ function createMockStreamingResponse() {
       controller.enqueue(
         encoder.encode('data: {"type":"content.delta","delta":"test"}\n\n'),
       );
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+        ),
+      );
       controller.enqueue(encoder.encode('data: [DONE]\n\n'));
       controller.close();
     },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.reasoningEffort.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.reasoningEffort.test.ts
@@ -72,6 +72,11 @@ describe('OpenAIResponsesProvider reasoning.effort', () => {
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -133,6 +138,11 @@ describe('OpenAIResponsesProvider reasoning.effort', () => {
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -192,6 +202,11 @@ describe('OpenAIResponsesProvider reasoning.effort', () => {
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -246,6 +261,11 @@ describe('OpenAIResponsesProvider reasoning.effort', () => {
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.reasoningInclude.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.reasoningInclude.test.ts
@@ -84,6 +84,11 @@ describe('OpenAIResponsesProvider reasoning include parameter @plan:PLAN-2026011
           const encoder = new TextEncoder();
           const stream = new ReadableStream({
             start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+                ),
+              );
               controller.enqueue(encoder.encode('data: [DONE]\n\n'));
               controller.close();
             },
@@ -147,6 +152,11 @@ describe('OpenAIResponsesProvider reasoning include parameter @plan:PLAN-2026011
           const encoder = new TextEncoder();
           const stream = new ReadableStream({
             start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+                ),
+              );
               controller.enqueue(encoder.encode('data: [DONE]\n\n'));
               controller.close();
             },
@@ -211,6 +221,11 @@ describe('OpenAIResponsesProvider reasoning include parameter @plan:PLAN-2026011
           const encoder = new TextEncoder();
           const stream = new ReadableStream({
             start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+                ),
+              );
               controller.enqueue(encoder.encode('data: [DONE]\n\n'));
               controller.close();
             },
@@ -277,6 +292,11 @@ describe('OpenAIResponsesProvider reasoning include parameter @plan:PLAN-2026011
           const encoder = new TextEncoder();
           const stream = new ReadableStream({
             start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+                ),
+              );
               controller.enqueue(encoder.encode('data: [DONE]\n\n'));
               controller.close();
             },
@@ -504,6 +524,11 @@ describe('OpenAIResponsesProvider reasoning include parameter @plan:PLAN-2026011
           const encoder = new TextEncoder();
           const stream = new ReadableStream({
             start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+                ),
+              );
               controller.enqueue(encoder.encode('data: [DONE]\n\n'));
               controller.close();
             },
@@ -599,6 +624,11 @@ describe('OpenAIResponsesProvider reasoning include parameter @plan:PLAN-2026011
           const encoder = new TextEncoder();
           const stream = new ReadableStream({
             start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+                ),
+              );
               controller.enqueue(encoder.encode('data: [DONE]\n\n'));
               controller.close();
             },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.reasoningSummary.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.reasoningSummary.test.ts
@@ -70,6 +70,11 @@ describe('OpenAIResponsesProvider reasoning.summary @issue:922', () => {
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -136,6 +141,11 @@ describe('OpenAIResponsesProvider reasoning.summary @issue:922', () => {
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -200,6 +210,11 @@ describe('OpenAIResponsesProvider reasoning.summary @issue:922', () => {
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -264,6 +279,11 @@ describe('OpenAIResponsesProvider reasoning.summary @issue:922', () => {
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -330,6 +350,11 @@ describe('OpenAIResponsesProvider reasoning.summary @issue:922', () => {
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.stateful.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.stateful.test.ts
@@ -47,6 +47,11 @@ function createMockStreamingResponse() {
       controller.enqueue(
         encoder.encode('data: {"type":"content.delta","delta":"ok"}\n\n'),
       );
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+        ),
+      );
       controller.enqueue(encoder.encode('data: [DONE]\n\n'));
       controller.close();
     },

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.textVerbosity.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.textVerbosity.test.ts
@@ -67,6 +67,11 @@ describe('OpenAIResponsesProvider text.verbosity (text.verbosity setting)', () =
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -129,6 +134,11 @@ describe('OpenAIResponsesProvider text.verbosity (text.verbosity setting)', () =
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -191,6 +201,11 @@ describe('OpenAIResponsesProvider text.verbosity (text.verbosity setting)', () =
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -252,6 +267,11 @@ describe('OpenAIResponsesProvider text.verbosity (text.verbosity setting)', () =
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },
@@ -314,6 +334,11 @@ describe('OpenAIResponsesProvider text.verbosity (text.verbosity setting)', () =
         const encoder = new TextEncoder();
         const stream = new ReadableStream({
           start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+              ),
+            );
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           },

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
@@ -155,6 +155,7 @@ describe('executeOpenAIResponsesRequest abort-signal propagation @issue:2607', (
       ok: true,
       body: encodeSse([
         'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
         'data: [DONE]\n\n',
       ]),
     });
@@ -176,6 +177,7 @@ describe('executeOpenAIResponsesRequest abort-signal propagation @issue:2607', (
       ok: true,
       body: encodeSse([
         'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
         'data: [DONE]\n\n',
       ]),
     });
@@ -198,6 +200,7 @@ describe('executeOpenAIResponsesRequest abort-signal propagation @issue:2607', (
       ok: true,
       body: encodeSse([
         'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
         'data: [DONE]\n\n',
       ]),
     });

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
@@ -130,6 +130,7 @@ describe('executeOpenAIResponsesRequest onStreamLiveness threading @issue:2607',
     const sseBody = encodeSse([
       'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
       'data: {"type":"response.output_text.delta","delta":"Hello"}\n\n',
+      'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
       'data: [DONE]\n\n',
     ]);
     vi.stubGlobal(
@@ -157,6 +158,7 @@ describe('executeOpenAIResponsesRequest onStreamLiveness threading @issue:2607',
     const sseBody = encodeSse([
       'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
       'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+      'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
       'data: [DONE]\n\n',
     ]);
     vi.stubGlobal(
@@ -174,6 +176,15 @@ describe('executeOpenAIResponsesRequest onStreamLiveness threading @issue:2607',
       {
         speaker: 'ai',
         blocks: [{ type: 'text', text: 'Hi' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [],
+        metadata: {
+          id: 'r1',
+          stopReason: 'end_turn',
+          finishReason: 'completed',
+        },
       },
     ]);
   });
@@ -234,6 +245,7 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
   it('A3: emits finalized request dump at common pre-transport seam (HTTP)', async () => {
     const sseBody = encodeSse([
       'data: {"type":"response.output_text.delta","delta":"OK"}\n\n',
+      'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
       'data: [DONE]\n\n',
     ]);
     vi.stubGlobal(

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts
@@ -421,6 +421,8 @@ describe('OpenAI Responses HTTP/SSE stream integrity @issue:3049', () => {
     const single = await drainWithPossibleRejection(
       executeOpenAIResponsesRequest(buildNormalizedOptions(), buildDeps()),
     );
+    fetchMock.restore();
+    fetchMock = undefined;
 
     // The identical two events split across separate reader chunks.
     fetchMock = installFetch(

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts
@@ -1,0 +1,471 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for OpenAI Responses HTTP/SSE stream integrity (issue #3049).
+ *
+ * AC1: no internal replay after output — a mid-body error after content was
+ *      yielded rethrows and issues no second fetch.
+ * AC2: internal and orchestrator attempts share one transport budget, so the
+ *      total fetch count for `retries: N` is N, not N*N.
+ * AC3: abrupt reader EOF without an accepted terminal response event raises a
+ *      StreamInterruptionError instead of completing normally.
+ *
+ * Only the fetch boundary is faked. The real executor, the real SSE parser,
+ * and (for AC2) the real RetryOrchestrator wrapping a real executor-backed
+ * provider all run.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  executeOpenAIResponsesRequest,
+  type ResponsesExecutorDeps,
+} from './openAIResponsesExecutor.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
+import type { IModel } from '../IModel.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+
+const TERMINAL_EVENT =
+  'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}\n\n';
+
+const encoder = new TextEncoder();
+
+function encodeSse(chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+/** A body that emits one text delta then errors the ReadableStream. */
+function erroringAfterDeltaBody(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.output_text.delta","delta":"partial"}\n\n',
+        ),
+      );
+    },
+    pull(controller) {
+      // Reached only on the second read (after the enqueued delta is
+      // consumed), simulating a body failure mid-stream.
+      controller.error(new TypeError('body errored mid-stream'));
+    },
+  });
+}
+
+interface FetchMock {
+  readonly calls: { count: number };
+  restore(): void;
+}
+
+function installFetch(
+  handler: (callIndex: number) => Promise<Response>,
+): FetchMock {
+  const original = globalThis.fetch;
+  const calls = { count: 0 };
+  const impl: typeof fetch = (
+    _input: RequestInfo | URL,
+    _init?: RequestInit,
+  ): Promise<Response> => {
+    const index = calls.count;
+    calls.count += 1;
+    return handler(index);
+  };
+  globalThis.fetch = impl;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function buildNormalizedOptions(
+  overrides: {
+    ephemerals?: Record<string, unknown>;
+  } & Partial<NormalizedGenerateChatOptions> = {},
+): NormalizedGenerateChatOptions {
+  const { ephemerals = {}, ...optionOverrides } = overrides;
+  const settings = new SettingsService();
+  const runtime = createProviderRuntimeContext({
+    settingsService: settings,
+    runtimeId: 'test-runtime',
+  });
+  const config = createRuntimeConfigStub(settings, {});
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings,
+    providerName: 'openai-responses',
+    ephemeralsSnapshot: ephemerals,
+    fallbackRuntimeId: 'test-runtime',
+  });
+  const base = {
+    contents: [
+      {
+        speaker: 'human' as const,
+        blocks: [{ type: 'text' as const, text: 'Hello' }],
+      },
+    ],
+    settings,
+    config,
+    runtime,
+    invocation,
+    userMemory: undefined,
+    tools: undefined,
+    metadata: {},
+    resolved: {
+      model: 'gpt-5',
+      baseURL: 'https://api.openai.com/v1',
+      authToken: 'test-token',
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+  return { ...base, ...optionOverrides };
+}
+
+function buildDeps(
+  overrides: Partial<ResponsesExecutorDeps> = {},
+): ResponsesExecutorDeps {
+  return {
+    providerName: 'openai-responses',
+    logger: {
+      debug: () => undefined,
+    } as unknown as ResponsesExecutorDeps['logger'],
+    getProviderBaseURL: () => 'https://api.openai.com/v1',
+    getCustomHeaders: () => undefined,
+    isCodexBaseURL: () => false,
+    getCodexAccountId: async () => 'codex-account',
+    resolveAuthTokenForPrompt: async () => '',
+    generateSyntheticCallId: () => 'call_synthetic_test',
+    shouldRetryOnError: () => true,
+    getDefaultModel: () => 'gpt-5',
+    getGlobalConfig: () => undefined,
+    ...overrides,
+  };
+}
+
+/**
+ * User-defined type guard bridging the IProvider contract (GenerateChatOptions)
+ * to the executor's NormalizedGenerateChatOptions, mirroring how BaseProvider
+ * normalizes before dispatching. Avoids an unsafe assertion.
+ */
+function isNormalizedOptions(
+  options: GenerateChatOptions,
+): options is NormalizedGenerateChatOptions {
+  return (
+    typeof options === 'object' &&
+    'settings' in options &&
+    'invocation' in options &&
+    'resolved' in options
+  );
+}
+
+function createExecutorProvider(deps: ResponsesExecutorDeps): IProvider {
+  return {
+    name: 'openai-responses',
+    async *generateChatCompletion(
+      options: GenerateChatOptions,
+    ): AsyncIterableIterator<IContent> {
+      if (!isNormalizedOptions(options)) {
+        throw new Error('test provider requires normalized options');
+      }
+      yield* executeOpenAIResponsesRequest(options, deps);
+    },
+    async getModels(): Promise<IModel[]> {
+      return [];
+    },
+    getDefaultModel(): string {
+      return 'gpt-5';
+    },
+    getServerTools(): string[] {
+      return [];
+    },
+    async invokeServerTool(): Promise<unknown> {
+      return null;
+    },
+  };
+}
+
+async function drainWithPossibleRejection(
+  iterator: AsyncIterableIterator<IContent>,
+): Promise<{ messages: IContent[]; error: unknown | undefined }> {
+  const messages: IContent[] = [];
+  let error: unknown | undefined;
+  try {
+    for await (const chunk of iterator) messages.push(chunk);
+  } catch (caught) {
+    error = caught;
+  }
+  return { messages, error };
+}
+
+describe('OpenAI Responses HTTP/SSE stream integrity @issue:3049', () => {
+  let fetchMock: FetchMock | undefined;
+
+  beforeEach(() => {
+    fetchMock = undefined;
+  });
+
+  afterEach(() => {
+    fetchMock?.restore();
+  });
+
+  it('AC1: rethrows without replay when the body errors after output', async () => {
+    fetchMock = installFetch(
+      async () => new Response(erroringAfterDeltaBody(), { status: 200 }),
+    );
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 3, retrywait: 0 },
+    });
+    const { messages, error } = await drainWithPossibleRejection(
+      executeOpenAIResponsesRequest(options, buildDeps()),
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toStrictEqual({
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'partial' }],
+    });
+    expect(error).toBeInstanceOf(Error);
+    expect(fetchMock.calls.count).toBe(1);
+  });
+
+  it('AC1 control: a pre-output failure still retries and then succeeds', async () => {
+    fetchMock = installFetch(async (call) => {
+      if (call === 0) throw new TypeError('fetch failed');
+      return new Response(
+        encodeSse([
+          'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
+          TERMINAL_EVENT,
+        ]),
+        { status: 200 },
+      );
+    });
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 3, retrywait: 0 },
+    });
+    const messages: IContent[] = [];
+    for await (const chunk of executeOpenAIResponsesRequest(
+      options,
+      buildDeps(),
+    )) {
+      messages.push(chunk);
+    }
+
+    const text = messages
+      .flatMap((m) => m.blocks)
+      .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+      .map((b) => b.text)
+      .join('');
+    expect(text).toBe('ok');
+    expect(fetchMock.calls.count).toBe(2);
+  });
+
+  it('AC2: shared budget bounds total fetch calls to N, not N*N', async () => {
+    const N = 3;
+    fetchMock = installFetch(async () => {
+      throw new TypeError('fetch failed');
+    });
+    const provider = createExecutorProvider(buildDeps());
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: N,
+      initialDelayMs: 0,
+    });
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: N, retrywait: 1 },
+    });
+
+    const { error } = await drainWithPossibleRejection(
+      orchestrator.generateChatCompletion(options),
+    );
+
+    expect(error).toBeDefined();
+    expect(fetchMock.calls.count).toBe(N);
+  });
+
+  it('AC3: EOF without a terminal event rejects with StreamInterruptionError', async () => {
+    fetchMock = installFetch(
+      async () =>
+        new Response(
+          encodeSse([
+            'data: {"type":"response.output_text.delta","delta":"hello"}\n\n',
+          ]),
+          { status: 200 },
+        ),
+    );
+    const options = buildNormalizedOptions();
+    const { error } = await drainWithPossibleRejection(
+      executeOpenAIResponsesRequest(options, buildDeps()),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe('StreamInterruptionError');
+    expect((error as Error).message).toContain('terminal');
+  });
+
+  it('AC3 control: the same body with a terminal event completes normally', async () => {
+    fetchMock = installFetch(
+      async () =>
+        new Response(
+          encodeSse([
+            'data: {"type":"response.output_text.delta","delta":"hello"}\n\n',
+            TERMINAL_EVENT,
+          ]),
+          { status: 200 },
+        ),
+    );
+    const options = buildNormalizedOptions();
+    const messages: IContent[] = [];
+    for await (const chunk of executeOpenAIResponsesRequest(
+      options,
+      buildDeps(),
+    )) {
+      messages.push(chunk);
+    }
+
+    expect(messages.some((m) => m.blocks.some((b) => b.type === 'text'))).toBe(
+      true,
+    );
+    expect(messages.some((m) => m.metadata?.finishReason === 'completed')).toBe(
+      true,
+    );
+  });
+
+  // Regression for issue #3049: a nonterminal lifecycle event following an
+  // accepted terminal event in the SAME reader chunk must not mask the
+  // terminal. Previously the parser only inspected the last dispatched type
+  // after the chunk, so a trailing nonterminal event caused EOF to throw a
+  // spurious StreamInterruptionError — behavior that depended on network
+  // chunking.
+
+  // SSE frames are terminated by a blank line. Build the terminator from a
+  // char code so the fixtures carry no inline escape sequences.
+  const FRAME_END = String.fromCharCode(10) + String.fromCharCode(10);
+  const sse = (json: string): string => 'data: ' + json + FRAME_END;
+
+  // A valid nonterminal lifecycle event the real parser accepts (default
+  // case, no handler). Used as the masking event that follows the terminal.
+  const CREATED_EVENT = sse(
+    '{"type":"response.created","response":{"id":"resp_1","status":"in_progress"}}',
+  );
+
+  const ACCEPTED_TERMINAL_FIXTURES: ReadonlyArray<{
+    readonly label: string;
+    readonly event: string;
+    readonly finishReason: string;
+  }> = [
+    {
+      label: 'response.completed',
+      event: TERMINAL_EVENT,
+      finishReason: 'completed',
+    },
+    {
+      label: 'response.done',
+      event: sse(
+        '{"type":"response.done","response":{"id":"resp_1","status":"completed"}}',
+      ),
+      finishReason: 'completed',
+    },
+    {
+      label: 'response.incomplete',
+      event: sse(
+        '{"type":"response.incomplete","response":{"id":"resp_1","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}}',
+      ),
+      finishReason: 'incomplete',
+    },
+  ];
+
+  for (const fixture of ACCEPTED_TERMINAL_FIXTURES) {
+    it(`AC4: completes normally when ${fixture.label} is followed by a nonterminal event in one chunk`, async () => {
+      fetchMock = installFetch(
+        async () =>
+          // Both events in a single encoded ReadableStream chunk.
+          new Response(encodeSse([fixture.event + CREATED_EVENT]), {
+            status: 200,
+          }),
+      );
+      const options = buildNormalizedOptions();
+      const { messages, error } = await drainWithPossibleRejection(
+        executeOpenAIResponsesRequest(options, buildDeps()),
+      );
+
+      expect(error).toBeUndefined();
+      expect(
+        messages.some((m) => m.metadata?.finishReason === fixture.finishReason),
+      ).toBe(true);
+    });
+  }
+
+  it('AC4: terminal-then-nonterminal is chunk-boundary independent (response.completed)', async () => {
+    const fixture = ACCEPTED_TERMINAL_FIXTURES[0];
+
+    // Both events in one reader chunk.
+    fetchMock = installFetch(
+      async () =>
+        new Response(encodeSse([fixture.event + CREATED_EVENT]), {
+          status: 200,
+        }),
+    );
+    const single = await drainWithPossibleRejection(
+      executeOpenAIResponsesRequest(buildNormalizedOptions(), buildDeps()),
+    );
+
+    // The identical two events split across separate reader chunks.
+    fetchMock = installFetch(
+      async () => new Response(encodeSse([fixture.event, CREATED_EVENT])),
+    );
+    const split = await drainWithPossibleRejection(
+      executeOpenAIResponsesRequest(buildNormalizedOptions(), buildDeps()),
+    );
+
+    // Both packings must succeed and carry the same terminal metadata,
+    // proving the result does not depend on how the network frames chunks.
+    expect(single.error).toBeUndefined();
+    expect(split.error).toBeUndefined();
+    expect(
+      single.messages.some(
+        (m) => m.metadata?.finishReason === fixture.finishReason,
+      ),
+    ).toBe(true);
+    expect(
+      split.messages.some(
+        (m) => m.metadata?.finishReason === fixture.finishReason,
+      ),
+    ).toBe(true);
+  });
+
+  it('AC4 precedence: a response.failed after an accepted terminal still throws its provider error', async () => {
+    const FAILED_AFTER_COMPLETED =
+      TERMINAL_EVENT +
+      sse(
+        '{"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"message":"server failed after completion"}}}',
+      );
+    fetchMock = installFetch(
+      async () =>
+        // Terminal accepted event, then a protocol failure in the same chunk.
+        new Response(encodeSse([FAILED_AFTER_COMPLETED]), { status: 200 }),
+    );
+    const options = buildNormalizedOptions();
+    const { error } = await drainWithPossibleRejection(
+      executeOpenAIResponsesRequest(options, buildDeps()),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('server failed');
+    // The terminal-masking fix must never swallow a protocol-failure throw:
+    // it surfaces as a retryable interruption error, not a clean completion.
+    expect((error as Error).name).toBe('StreamInterruptionError');
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
@@ -180,6 +180,7 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
       ok: true,
       body: encodeSse([
         'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
         'data: [DONE]\n\n',
       ]),
     });
@@ -208,6 +209,15 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
 
     expect(messages).toStrictEqual([
       { speaker: 'ai', blocks: [{ type: 'text', text: 'Hi' }] },
+      {
+        speaker: 'ai',
+        blocks: [],
+        metadata: {
+          id: 'r1',
+          stopReason: 'end_turn',
+          finishReason: 'completed',
+        },
+      },
     ]);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(transportChecks).toBe(1);
@@ -217,6 +227,7 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
     const fallbackBody = (): ReadableStream<Uint8Array> =>
       encodeSse([
         'data: {"type":"response.output_text.delta","delta":"fallback"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
         'data: [DONE]\n\n',
       ]);
     const fetchSpy = vi
@@ -243,6 +254,15 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
     );
     expect(first).toStrictEqual([
       { speaker: 'ai', blocks: [{ type: 'text', text: 'fallback' }] },
+      {
+        speaker: 'ai',
+        blocks: [],
+        metadata: {
+          id: 'r1',
+          stopReason: 'end_turn',
+          finishReason: 'completed',
+        },
+      },
     ]);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
 
@@ -251,6 +271,15 @@ describe('executeOpenAIResponsesRequest WebSocket selection & fallback @issue:20
     );
     expect(second).toStrictEqual([
       { speaker: 'ai', blocks: [{ type: 'text', text: 'fallback' }] },
+      {
+        speaker: 'ai',
+        blocks: [],
+        metadata: {
+          id: 'r1',
+          stopReason: 'end_turn',
+          finishReason: 'completed',
+        },
+      },
     ]);
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(transport.streamResponseCalls).toBe(1);

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -32,6 +32,7 @@ import {
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
 import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
+import { tryConsumeTransportAttempt } from '../transportAttemptBudget.js';
 import type { ResponsesExecutorDeps } from './openAIResponsesExecutor.js';
 import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
 
@@ -58,6 +59,7 @@ interface FetchStreamParams {
   responsesStored: boolean;
   maxStreamingAttempts: number;
   streamRetryInitialDelayMs: number;
+  normalizedOptions: NormalizedGenerateChatOptions;
   onStreamLiveness?: NormalizedGenerateChatOptions['onStreamLiveness'];
 }
 
@@ -142,14 +144,34 @@ async function* fetchStreamWithRetries(
 ): AsyncIterableIterator<IContent> {
   let streamingAttempt = 0;
   let currentDelay = params.streamRetryInitialDelayMs;
+  let lastError: unknown;
 
   while (streamingAttempt < params.maxStreamingAttempts) {
     streamingAttempt += 1;
+    // AC2 (#3049): after the first attempt, consume a slot from the shared
+    // transport budget so internal retries are bounded by the same `retries`
+    // count as the orchestrator, not retries × retries. When no budget is
+    // attached (direct unit tests without an orchestrator),
+    // tryConsumeTransportAttempt returns true and today's
+    // maxStreamingAttempts-only behavior is unchanged.
+    if (
+      streamingAttempt > 1 &&
+      !tryConsumeTransportAttempt(params.normalizedOptions)
+    ) {
+      throw lastError;
+    }
+
+    const yieldedForAttempt: { value: boolean } = { value: false };
     try {
       const response = await fetchResponse(params);
-      yield* parseSuccessfulResponse(response, params, deps);
+      yield* parseSuccessfulResponse(response, params, deps, yieldedForAttempt);
       return;
     } catch (error) {
+      lastError = error;
+      // AC1 (#3049): content was already yielded for this attempt, so
+      // replaying into the same iterator would concatenate two attempts'
+      // text. Rethrow immediately and let the orchestrator decide.
+      if (yieldedForAttempt.value) throw error;
       currentDelay = await handleStreamRetry(
         error,
         {
@@ -185,6 +207,7 @@ async function* parseSuccessfulResponse(
     'includeThinkingInResponse' | 'responsesStored' | 'onStreamLiveness'
   >,
   deps: ResponsesExecutorDeps,
+  yieldedMarker: { value: boolean },
 ): AsyncIterableIterator<IContent> {
   if (!response.ok) await throwApiError(response, deps);
   if (!response.body) {
@@ -196,11 +219,15 @@ async function* parseSuccessfulResponse(
     includeThinkingInResponse: params.includeThinkingInResponse,
     responsesStored: params.responsesStored,
     onStreamLiveness: params.onStreamLiveness,
+    // AC3 (#3049): an HTTP/SSE body that reaches EOF without an accepted
+    // terminal event is a truncated stream, not a complete response.
+    requireTerminalEvent: true,
   };
   for await (const message of parseResponsesStream(
     response.body,
     streamOptions,
   )) {
+    yieldedMarker.value = true;
     yield message;
   }
 }

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
@@ -10,6 +10,10 @@ import {
   parseResponsesStream,
   type ParseResponsesStreamOptions,
 } from '../openai/parseResponsesStream.js';
+import {
+  ACCEPTED_TERMINAL_EVENT_TYPES,
+  isTerminalEventType,
+} from '../openai/responsesTerminalEvents.js';
 import { createStreamInterruptionError } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
 import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
@@ -73,26 +77,6 @@ interface WebSocketTransportConfig {
 // Matches the Codex client's default WebSocket connect timeout
 // (websocket_connect_timeout_ms in codex-rs/model-provider-info/src/lib.rs).
 const HANDSHAKE_TIMEOUT_MS = 15_000;
-// The parser yields terminal-metadata IContent for these, so a later close
-// must not replace them with a generic interruption error.
-const ACCEPTED_TERMINAL_EVENT_TYPES = new Set([
-  'response.completed',
-  'response.done',
-  'response.incomplete',
-]);
-// Still queued so the parser raises its own specific provider error.
-const PROTOCOL_FAILURE_TERMINAL_EVENT_TYPES = new Set([
-  'response.failed',
-  'error',
-]);
-
-function isTerminalEventType(type: string | undefined): boolean {
-  return (
-    type !== undefined &&
-    (ACCEPTED_TERMINAL_EVENT_TYPES.has(type) ||
-      PROTOCOL_FAILURE_TERMINAL_EVENT_TYPES.has(type))
-  );
-}
 
 function eventType(value: unknown): string | undefined {
   if (typeof value !== 'object' || value === null) return undefined;

--- a/packages/providers/src/openai/OpenAIProvider.concurrentRouting.test.ts
+++ b/packages/providers/src/openai/OpenAIProvider.concurrentRouting.test.ts
@@ -35,6 +35,11 @@ function makeSseResponse(): Response {
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
     start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+        ),
+      );
       controller.enqueue(encoder.encode('data: [DONE]\n\n'));
       controller.close();
     },

--- a/packages/providers/src/openai/OpenAIProvider.transportRouting.test.ts
+++ b/packages/providers/src/openai/OpenAIProvider.transportRouting.test.ts
@@ -37,6 +37,11 @@ function makeSseResponse(): Response {
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
     start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+        ),
+      );
       controller.enqueue(encoder.encode('data: [DONE]\n\n'));
       controller.close();
     },

--- a/packages/providers/src/openai/__tests__/OpenAIChatTransportSelectionParity.test.ts
+++ b/packages/providers/src/openai/__tests__/OpenAIChatTransportSelectionParity.test.ts
@@ -77,6 +77,11 @@ function streamingFetchStub(requestedUrls: string[]): typeof global.fetch {
     return new Response(
       new ReadableStream({
         start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+            ),
+          );
           controller.enqueue(encoder.encode('data: [DONE]\n\n'));
           controller.close();
         },

--- a/packages/providers/src/openai/parseResponsesStream.ts
+++ b/packages/providers/src/openai/parseResponsesStream.ts
@@ -13,6 +13,7 @@ import {
 import { createStreamInterruptionError } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type { StreamLivenessListener } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+import { isAcceptedTerminalEventType } from './responsesTerminalEvents.js';
 import { mapFinishReasonToStopReason } from './finishReasonMapping.js';
 import type {
   DispatchResult,
@@ -50,6 +51,14 @@ export interface ParseResponsesStreamOptions {
    * Malformed data and the [DONE] sentinel do not count.
    */
   onStreamLiveness?: StreamLivenessListener;
+  /**
+   * When true, reader EOF reached without an accepted terminal response event
+   * (response.completed, response.done, response.incomplete) raises a
+   * StreamInterruptionError instead of completing normally. Used by the
+   * HTTP/SSE path to detect a connection cut mid-body (issue #3049).
+   * Default false so the WebSocket caller and existing tests are untouched.
+   */
+  requireTerminalEvent?: boolean;
 }
 
 /**
@@ -796,6 +805,7 @@ function* dispatchEvent(
   return {
     ...result,
     lastLoggedType: newLastLoggedType,
+    dispatchedEventType: event.type,
   };
 }
 
@@ -818,10 +828,13 @@ async function* tryDispatchEvent(
   try {
     event = JSON.parse(data);
   } catch {
-    // Skip malformed JSON events: return unchanged state
+    // Skip malformed JSON events: return unchanged state and no dispatched
+    // event type so it contributes neither to logging dedup nor to terminal
+    // tracking.
     return {
       ...state,
       lastLoggedType,
+      dispatchedEventType: undefined,
     };
   }
 
@@ -845,6 +858,7 @@ export async function* parseResponsesStream(
     includeThinkingInResponse = true,
     responsesStored = false,
     onStreamLiveness,
+    requireTerminalEvent = false,
   } = options;
   const reader = stream.getReader();
   const decoder = new TextDecoder();
@@ -861,6 +875,7 @@ export async function* parseResponsesStream(
   const emittedThoughts = new Map<string, { hasEncrypted: boolean }>();
 
   let lastLoggedType: string | undefined;
+  let acceptedTerminalSeen = false;
 
   try {
     const streamActive = { done: false };
@@ -897,7 +912,28 @@ export async function* parseResponsesStream(
         );
         state = dispatchState;
         lastLoggedType = dispatchState.lastLoggedType;
+        // Record accepted-terminal state monotonically for every
+        // successfully dispatched event (OR semantics). `lastLoggedType` is
+        // deduplicated and can be overwritten by a later nonterminal event in
+        // the same chunk, so terminal tracking must use the per-event
+        // dispatched type. A protocol-failure terminal (response.failed/error)
+        // still throws during dispatch above and is never masked (#3049).
+        acceptedTerminalSeen ||= isAcceptedTerminalEventType(
+          dispatchState.dispatchedEventType,
+        );
       }
+    }
+    // Reader reached EOF. When the caller opted in (HTTP/SSE path), a body
+    // that never carried an accepted terminal event is a truncated stream,
+    // not a complete response. Throw on the normal completion path only —
+    // never from `finally`, so consumer-driven break/return() is not turned
+    // into an error and in-flight exceptions are not masked (issue #3049).
+    if (requireTerminalEvent && !acceptedTerminalSeen) {
+      throw createStreamInterruptionError(
+        'Responses stream ended without an accepted terminal response event ' +
+          '(expected one of: response.completed, response.done, ' +
+          'response.incomplete)',
+      );
     }
   } finally {
     reader.releaseLock();

--- a/packages/providers/src/openai/parseResponsesStreamTypes.ts
+++ b/packages/providers/src/openai/parseResponsesStreamTypes.ts
@@ -80,4 +80,14 @@ export type DispatchState = {
 
 export type DispatchResult = DispatchState & {
   lastLoggedType: string | undefined;
+  /**
+   * The `type` of the event that was successfully parsed and dispatched in
+   * this step, independent of the deduplicated `lastLoggedType`. `undefined`
+   * when the event was malformed JSON and therefore not dispatched.
+   *
+   * Used to record accepted-terminal state monotonically per data line so
+   * that a nonterminal event following a terminal one in the same reader
+   * chunk cannot mask the terminal (issue #3049).
+   */
+  dispatchedEventType: string | undefined;
 };

--- a/packages/providers/src/openai/responsesTerminalEvents.ts
+++ b/packages/providers/src/openai/responsesTerminalEvents.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Accepted terminal response event types for the OpenAI Responses API.
+ *
+ * A stream that reaches one of these events has produced a well-formed,
+ * complete (or explicitly incomplete) response. The parser yields terminal
+ * metadata for these, so a subsequent connection close must not be treated as
+ * a truncation.
+ *
+ * Shared by the WebSocket transport (terminal assertion) and the SSE parser
+ * (HTTP abrupt-EOF detection, issue #3049).
+ */
+export const ACCEPTED_TERMINAL_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'response.completed',
+  'response.done',
+  'response.incomplete',
+]);
+
+/**
+ * Terminal event types that signal a protocol failure. The parser raises its
+ * own specific provider error for these, so they are never confused with an
+ * accepted terminal.
+ */
+export const PROTOCOL_FAILURE_TERMINAL_EVENT_TYPES: ReadonlySet<string> =
+  new Set(['response.failed', 'error']);
+
+/** True when the event type is one of the accepted terminal events. */
+export function isAcceptedTerminalEventType(type: string | undefined): boolean {
+  return type !== undefined && ACCEPTED_TERMINAL_EVENT_TYPES.has(type);
+}
+
+/** True when the event type is any terminal event (accepted or failure). */
+export function isTerminalEventType(type: string | undefined): boolean {
+  return (
+    type !== undefined &&
+    (ACCEPTED_TERMINAL_EVENT_TYPES.has(type) ||
+      PROTOCOL_FAILURE_TERMINAL_EVENT_TYPES.has(type))
+  );
+}

--- a/project-plans/issue3049/plan.md
+++ b/project-plans/issue3049/plan.md
@@ -1,0 +1,135 @@
+# Issue #3049 — OpenAI Responses HTTP/SSE: no mid-stream replay, no attempt multiplication, no silent truncation
+
+Follow-up to #3034 / PR #3047 (WebSocket transport).
+
+## Problem (grounded in code)
+
+`packages/providers/src/openai-responses/openAIResponsesHttpStream.ts`
+
+- `fetchStreamWithRetries` wraps `yield* parseSuccessfulResponse(...)` in the
+  attempt-level `try`. A body failure that happens **after** messages were
+  yielded re-runs `fetchResponse` and yields the second attempt's messages into
+  the SAME provider iterator. `StreamProcessor` accumulates one assistant
+  message per iterator, so attempt 1's partial text and attempt 2's regenerated
+  text are concatenated. `RetryOrchestrator.yieldStreamUnprotected` forbids
+  exactly this one layer up (`markErrorAfterStreamOutput`, "cannot retry (would
+  produce mixed response)"), and the WebSocket transport does not do it.
+- The `retries` ephemeral feeds BOTH the internal loop (`maxStreamingAttempts`,
+  executor line ~214) and the orchestrator budget
+  (`resolveRetryRequestContext` -> `attachTransportAttemptBudget`). The internal
+  loop does not touch the shared budget, so a pre-output failure costs
+  N internal fetches per orchestrator attempt: up to `retries x retries`
+  requests.
+
+`packages/providers/src/openai/parseResponsesStream.ts`
+
+- The read loop `break`s on `done` and the generator returns normally. No
+  terminal response event is required, and `parseSuccessfulResponse` adds no
+  completion check, so a connection cut mid-body is indistinguishable from a
+  completed response. `packages/agents/src/core/streamValidationHelpers.ts`
+  only rejects a missing finish reason when there is also no text, so truncated
+  text is silently committed to history. The WebSocket transport already throws
+  `Codex Responses WebSocket ended before a terminal response event` via
+  `source.didReceiveAcceptedTerminal()`.
+
+## Accepted behavior (acceptance criteria)
+
+**AC1 — no internal replay after output.**
+When the HTTP/SSE body fails after at least one `IContent` has been yielded for
+the current attempt, `fetchStreamWithRetries` rethrows. It does not issue a
+second `fetch` and does not yield any content from a second attempt. The
+already-yielded content stays yielded (the consumer/orchestrator decides).
+
+**AC2 — attempts do not multiply.**
+When a shared transport attempt budget is attached (the normal path: every
+provider is wrapped by `RetryOrchestrator`), the total number of `fetch` calls
+for one logical request is bounded by the `retries` budget, not by
+`retries x retries`. Internal retries consume from the same
+`TransportAttemptBudget` used by the orchestrator, via
+`tryConsumeTransportAttempt(normalizedOptions)`. When no budget is attached
+(provider used directly, e.g. unit tests), behavior is unchanged: the internal
+loop is bounded by `maxStreamingAttempts`.
+
+**AC3 — abrupt EOF is an error, not a success.**
+An HTTP/SSE body that reaches EOF without an accepted terminal response event
+(`response.completed`, `response.done`, `response.incomplete`) raises a
+stream-interruption error (`name === 'StreamInterruptionError'`, retryable
+classification) instead of returning normally. `response.failed` and `error`
+keep throwing their existing specific errors. A body that DOES carry a terminal
+event completes normally, unchanged.
+
+**AC4 — behavioral tests** for AC1, AC2 and AC3 in the existing Responses
+executor test style (real executor, real parser, only the `fetch` boundary
+faked).
+
+### Boundary cases and explicit non-goals
+
+- Consumer-driven early termination (`break`, `return()`) must not be turned
+  into an interruption error — only reader EOF inside the parse loop.
+- Abort (`AbortError`) keeps its current precedence: never retried, never
+  reclassified.
+- `!response.body` (no body at all) keeps returning early. That path never
+  enters the parser, and an empty stream is already handled one layer up by
+  `throwIfEmptyStreamExhaustsBudget`. Out of scope.
+- The WebSocket path's own terminal assertion stays exactly as it is. If the
+  accepted-terminal event set is shared, it is shared by extraction, with no
+  behavior change on the WS side.
+- `streamValidationHelpers.ts` (agents package) is NOT changed.
+- `transportAttemptOwnership = 'provider'` is deliberately NOT declared on the
+  Responses providers: that flag also flips `isWrapperLifecycleOwner`
+  (`packages/providers/src/logging/lifecycleOwnership.ts`), which would change
+  attempt-lifecycle logging for every chain without an orchestrator, and it
+  would have to be declared on `OpenAIProvider` too (which also routes to this
+  executor), changing its Chat Completions path as well. Participating in the
+  shared budget achieves AC2 with a strictly narrower blast radius.
+
+## Implementation shape
+
+1. `fetchStreamWithRetries`: track `yieldedForAttempt`; set it immediately
+   before the first `yield` of an attempt; in the `catch`, rethrow when it is
+   true. Only when nothing was emitted may `handleStreamRetry` run.
+2. Same loop: before starting an attempt after the first, require a shared
+   budget slot (`tryConsumeTransportAttempt(params.normalizedOptions)`); when
+   the budget is exhausted, rethrow the last error instead of refetching.
+   `getTransportAttemptBudget` returning `undefined` (no orchestrator) must
+   keep today's behavior. The budget object arrives through
+   `options.metadata._retryRequestContext` and survives normalization
+   (`mergeInvocationMetadata` in `BaseProviderNormalization.ts`).
+3. `parseResponsesStream`: add an opt-in option (default off, so the WS caller
+   and the parser's own tests are untouched) that makes reader EOF without an
+   accepted terminal event throw `createStreamInterruptionError`. The HTTP path
+   opts in. Accepted terminal event types are defined once and reused by the
+   WebSocket transport instead of being duplicated.
+4. Keep `parseResponsesStream.ts` and `openAIResponsesHttpStream.ts` inside the
+   `max-lines` (800) and `max-lines-per-function` (80) budgets; extract a small
+   helper module if needed. No lint/complexity threshold changes, no
+   suppression directives.
+
+## Tests (behavioral, bun:test, added to `scripts/bun-test-manifest-data-providers.ts`)
+
+New file(s) under `packages/providers/src/openai-responses/`:
+
+- **AC1**: fetch returns a body that emits `response.output_text.delta` then
+  errors the `ReadableStream`. Assert: the yielded content contains the partial
+  text exactly once, the iterator rejects, and `fetch` was called exactly once.
+- **AC1 control**: a pre-output failure (fetch rejects with
+  `TypeError('fetch failed')`) still retries and succeeds — proving the fix did
+  not disable legitimate connection-phase retry.
+- **AC2**: provider wrapped so a shared budget with `retries: N` is attached,
+  fetch always fails pre-output. Assert the total `fetch` count equals N (not
+  N x N).
+- **AC3**: body with a text delta and EOF, no terminal event. Assert the
+  iterator rejects with `name === 'StreamInterruptionError'` and a message
+  naming the missing terminal event.
+- **AC3 control**: identical body plus `response.completed` completes normally
+  and yields the terminal metadata.
+
+Existing fixtures in the HTTP path that end without a terminal event must be
+given a real terminal event (they are simulating a complete response), not
+have the check weakened.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, and
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.

--- a/scripts/bun-test-manifest-data-providers.ts
+++ b/scripts/bun-test-manifest-data-providers.ts
@@ -350,6 +350,7 @@ export const PROVIDERS_MANIFEST_ENTRY: BunTestWorkspaceEntry = {
     'src/openai-responses/buildResponsesInputFromContent.mediaBlock.test.ts',
     'src/openai-responses/openAIResponsesExecutor.abort.test.ts',
     'src/openai-responses/openAIResponsesExecutor.liveness.test.ts',
+    'src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts',
     'src/openai-responses/openAIResponsesExecutor.websocket.test.ts',
     'src/openai-responses/OpenAIResponsesProvider.emptyModelFallback.test.ts',
     'src/openai-responses/OpenAIResponsesProvider.headers.test.ts',


### PR DESCRIPTION
## TLDR

Fixes the OpenAI Responses HTTP/SSE path so it cannot concatenate output from multiple transport attempts and cannot silently accept a truncated stream.

The transport now stops retrying once an attempt has yielded content, consumes internal retries from the same transport-attempt budget as RetryOrchestrator, and requires an accepted terminal Responses event before treating SSE EOF as successful.

## Dive Deeper

Three related failure modes are addressed:

1. A body error after a text delta previously caused the HTTP transport to replay the entire request inside the same async iterator. Downstream code then accumulated the partial first response and regenerated second response into one assistant message. The HTTP retry loop now records whether an attempt yielded any IContent and rethrows immediately after output instead of replaying.

2. The internal HTTP retry loop and RetryOrchestrator previously treated the retries setting as independent budgets, allowing physical fetch attempts to multiply. Internal retries after the first attempt now consume from the attached shared TransportAttemptBudget. Direct executor use without an orchestrator retains the existing maxStreamingAttempts behavior.

3. Reader EOF previously completed successfully even when the SSE body never contained response.completed, response.done, or response.incomplete. The HTTP path now opts into terminal-event enforcement and raises StreamInterruptionError for abrupt EOF. WebSocket behavior remains unchanged; both transports share the accepted terminal-event definitions.

Terminal recognition is monotonic per dispatched event rather than inferred from logging state, so an accepted terminal followed by another valid event behaves identically regardless of reader chunk boundaries. Later response.failed and error events still retain their specific error precedence.

Existing HTTP fixtures that model successful Responses streams now include a real terminal event rather than relying on the data-done sentinel alone.

## Reviewer Test Plan

1. Run the behavioral regression file:

       bun test packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts

   It covers:
   - no replay after partial output;
   - legitimate retry before output;
   - shared attempt-budget enforcement;
   - abrupt EOF rejection;
   - successful terminal completion;
   - all accepted terminal event types followed by a nonterminal event;
   - reader chunk-boundary independence;
   - protocol-failure precedence.

2. Run the providers test workspace and verify all provider tests pass.

3. Run typecheck, lint, format, and build.

4. Optionally use a local OpenAI-compatible SSE endpoint that closes after a delta without sending a terminal response event. Verify the request fails as a stream interruption and is not silently committed as a completed assistant response.

Local verification:

- New behavioral tests: 10/10 passed.
- Providers package: 501/501 test files passed.
- Typecheck: passed.
- Build: passed.
- Format: passed.
- ESLint policy guard and focused ESLint: passed.
- Full lint passed during implementation verification; a second foreground invocation was externally terminated before producing output.
- Smoke test with the stepfun-37 profile: passed.
- Full npm test run reached one unrelated core test hook timeout under parallel load in config.mcp-lazy.test.ts; that test passed 9/9 immediately in isolation. No provider tests failed.
- DeepThinker review found one terminal-tracking edge case; it was remediated with chunk-boundary regression coverage.
- Open Code Review reviewed 25 changed files with zero findings. Its review of the large new behavioral test exhausted the tool-round budget; that file was covered by DeepThinker and the focused 10-test run.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3049

Follow-up to #3034 and PR #3047.
