### PR TITLE
Make abrupt-response transport canaries deterministic (Fixes #3097)

### DIFF
--- a/project-plans/issue3097/plan.md
+++ b/project-plans/issue3097/plan.md
@@ -1,0 +1,117 @@
+# Plan: Deterministic Abrupt-Response Transport Canaries
+
+Plan ID: PLAN-20260806-ISSUE3097
+Generated: 2026-08-06
+Requirements: REQ-PEER-001, REQ-TERM-001, REQ-TELEM-001, REQ-AUDIT-001
+
+## Scope and acceptance boundary
+
+This issue fixes transport tests that use local event-loop scheduling as a substitute for acknowledgement by a separate process or network peer. It does not change production OCR monitor behavior, add retries or delays, increase timeouts, weaken assertions, or introduce a public synchronization framework.
+
+### REQ-PEER-001: Peer-observed failure ordering
+
+**Requirement text:** The abrupt-response canary must trigger the upstream reset only after the downstream client has observed HTTP 200 and the complete partial payload.
+
+- GIVEN the real Bun client, separate Node monitor child, and loopback upstream fixture are running
+- WHEN the upstream sends HTTP 200 and the partial payload
+- THEN the downstream data callback must observe both before it triggers the one-shot upstream reset
+
+### REQ-TERM-001: Exact abnormal-termination behavior
+
+**Requirement text:** The canary must distinguish the intended post-header response-stream failure from a pre-header request failure or clean completion.
+
+- GIVEN downstream has observed HTTP 200 and the partial payload
+- WHEN upstream is reset
+- THEN the response must terminate abnormally with exact status and body evidence
+- AND a request-level error before response headers must fail the test
+- AND a clean response end must fail the test
+
+### REQ-TELEM-001: Exact monitor accounting
+
+**Requirement text:** The monitor must remain alive and account for the partially forwarded HTTP 200 exactly once.
+
+- GIVEN the intended post-header reset occurs
+- WHEN the embedded monitor is stopped
+- THEN telemetry must report one total request, no upstream setup error, one HTTP 200 response, and clean shutdown
+- AND the existing pre-header connection-failure scenario must remain HTTP 502 with one upstream error
+
+### REQ-AUDIT-001: Concrete sibling-fixture audit
+
+**Requirement text:** Repository abrupt-response fixtures must be checked for the same unacknowledged write-then-scheduled-destroy pattern.
+
+- GIVEN test files containing `setImmediate`, response/socket `destroy`, reset errors, partial bodies, or premature termination
+- WHEN those fixtures are reviewed
+- THEN every concrete case that writes through one process and schedules destruction without peer acknowledgement is included in this issue
+- AND unrelated direct socket-close, mocked-error, cancellation, and same-process lifecycle tests remain out of scope
+
+## Preflight and audit evidence
+
+- `scripts/tests/ocr-concurrency-canary-2673.test.ts` currently writes HTTP 200 and `{"partial":`, then calls `response.destroy()` from `setImmediate`.
+- The downstream request maps a pre-response request error to synthetic status 0, which is the observed CI failure.
+- `.github/workflows/ocr-review.yml` runs the monitor in a separate Node process and destroys the downstream response when the upstream response errors.
+- Repository searches found the OCR canary as the only test combining `setImmediate` with response destruction. Other response/socket destruction matches are direct connection lifecycle, cancellation, security, or pre-header failure fixtures and do not use a local scheduling yield as cross-process acknowledgement.
+- `packages/vscode-ide-companion/src/ide-server-concurrency.test.ts` contains a relevant established precedent: it replaced `setImmediate` timing yields with an explicit signal that the authoritative peer-side path had been entered.
+- No new dependency, workflow, production subsystem, or public API is required.
+
+## Test-first implementation sequence
+
+### Phase 1: RED — require the correct transport behavior
+
+Modify only the existing real-loopback scenario in `scripts/tests/ocr-concurrency-canary-2673.test.ts` so that it:
+
+1. rejects a request error before the response callback;
+2. fails if the response emits clean `end`;
+3. resolves only from abnormal response termination;
+4. requires status 200 and exact partial payload;
+5. retains exact telemetry assertions, including clean monitor shutdown.
+
+Run the focused test before changing fixture synchronization. The current unsynchronized fixture must fail by taking the pre-response request-error path or otherwise failing the strengthened contract.
+
+### Phase 2: GREEN — synchronize on downstream observation
+
+In the same behavioral fixture:
+
+1. hold the upstream response open after writing HTTP 200 and the complete partial payload;
+2. capture a one-shot action that destroys that specific upstream response;
+3. invoke it from the downstream data handler only after the accumulated body equals the complete partial sentinel;
+4. keep production monitor code unchanged;
+5. preserve resource cleanup for both success and failure paths.
+
+Run the focused test normally and repeatedly under concurrent host load without retrying failed cases.
+
+### Phase 3: Audit confirmation and regression verification
+
+Re-run the repository searches for the concrete anti-pattern and document that no sibling fixtures require modification. Verify the adjacent pre-header 502 scenario and the complete canary file.
+
+## Behavioral evidence
+
+Focused verification:
+
+```bash
+bun scripts/run_bun_tests.ts --root scripts-tests scripts/tests/ocr-concurrency-canary-2673.test.ts --testNamePattern "handles an upstream error after headers and partial body"
+bun scripts/run_bun_tests.ts --root scripts-tests scripts/tests/ocr-concurrency-canary-2673.test.ts
+```
+
+Stress verification must execute fresh focused test processes repeatedly, including bounded concurrent host load, and require every invocation to pass without reruns.
+
+## Full verification
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Before push, run DeepThinker review and detached OCR with `--timeout 20`, including test files. Classify every finding as Blocker-Fix, In-scope-Fix, Reject, or Defer. Do not exceed two review cycles.
+
+## Completion conditions
+
+- Every accepted behavior has direct behavioral evidence.
+- The concrete sibling-fixture audit is complete.
+- No retry, sleep, timeout increase, suppression, weakened assertion, production monitor change, or speculative abstraction is introduced.
+- Focused stress verification and the full local suite pass.
+- Review findings are triaged and all Blocker-Fix/In-scope-Fix findings resolved.
+- Candidate-head CI is green, review threads are resolved, ancestry is current, and the PR is conflict-free.

--- a/scripts/tests/ocr-concurrency-canary-2673.test.ts
+++ b/scripts/tests/ocr-concurrency-canary-2673.test.ts
@@ -514,16 +514,17 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
       let monitorStopAttempted = false;
 
       try {
-        resource = await startEmbeddedMonitor(
+        const startedResource = await startEmbeddedMonitor(
           `http://127.0.0.1:${upstreamPort}/v1`,
         );
+        resource = startedResource;
         const result = await new Promise<{ statusCode: number; body: string }>(
           (resolve, reject) => {
             const chunks: Buffer[] = [];
             let terminatedCleanly = false;
             let settled = false;
             const proxyRequest = http.request(
-              new URL(asString(resource.ready.proxy_url)),
+              new URL(asString(startedResource.ready.proxy_url)),
               {
                 method: 'POST',
                 headers: {
@@ -594,7 +595,7 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
           },
         );
         monitorStopAttempted = true;
-        const telemetry = await stopEmbeddedMonitor(resource);
+        const telemetry = await stopEmbeddedMonitor(startedResource);
 
         expect(result.statusCode).toBe(200);
         expect(result.body).toBe(partialSentinel);

--- a/scripts/tests/ocr-concurrency-canary-2673.test.ts
+++ b/scripts/tests/ocr-concurrency-canary-2673.test.ts
@@ -495,79 +495,123 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
     });
 
     it('handles an upstream error after headers and partial body without crashing or double-counting', async () => {
+      const partialSentinel = '{"partial":';
+      let triggerUpstreamReset: (() => void) | null = null;
       const upstream = http.createServer((request, response) => {
         request.resume();
         request.on('end', () => {
           response.writeHead(200, { 'content-type': 'application/json' });
-          response.write('{"partial":');
-          setImmediate(() =>
-            response.destroy(new Error('upstream mid-stream crash')),
-          );
+          response.write(partialSentinel);
+          triggerUpstreamReset = () => {
+            response.destroy(new Error('upstream mid-stream crash'));
+          };
         });
       });
       const upstreamPort = await listen(upstream);
-      const resource = await startEmbeddedMonitor(
-        `http://127.0.0.1:${upstreamPort}/v1`,
-      );
+      let resource:
+        | Awaited<ReturnType<typeof startEmbeddedMonitor>>
+        | undefined;
+      let monitorStopAttempted = false;
 
-      const result = await new Promise<{
-        statusCode: number | undefined;
-        body: string;
-      }>((resolve) => {
-        // The upstream sends 200 headers and then destroys the socket
-        // mid-body, so the client-visible failure can surface either on the
-        // response stream or as a request-level 'error', depending on which
-        // event loop turn the reset lands in. Record the status line as soon
-        // as headers arrive so the request-level path reports the status the
-        // client genuinely observed instead of racing to 0.
-        let observedStatus: number | undefined;
-        let observedChunks: Buffer[] = [];
-        const proxyRequest = http.request(
-          new URL(asString(resource.ready.proxy_url)),
-          {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json',
-              'x-stainless-retry-count': '0',
-            },
-          },
-          (response) => {
-            observedStatus = response.statusCode;
+      try {
+        resource = await startEmbeddedMonitor(
+          `http://127.0.0.1:${upstreamPort}/v1`,
+        );
+        const result = await new Promise<{ statusCode: number; body: string }>(
+          (resolve, reject) => {
             const chunks: Buffer[] = [];
-            observedChunks = chunks;
-            response.on('data', (chunk) => chunks.push(chunk));
-            response.on('end', () =>
-              resolve({
-                statusCode: response.statusCode,
-                body: Buffer.concat(chunks).toString('utf8'),
-              }),
+            let terminatedCleanly = false;
+            let settled = false;
+            const proxyRequest = http.request(
+              new URL(asString(resource.ready.proxy_url)),
+              {
+                method: 'POST',
+                headers: {
+                  'content-type': 'application/json',
+                  'x-stainless-retry-count': '0',
+                },
+              },
+              (response) => {
+                const statusCode = response.statusCode;
+                if (statusCode === undefined) {
+                  settled = true;
+                  reject(new Error('response arrived without an HTTP status'));
+                  return;
+                }
+                const resolveAbnormal = () => {
+                  if (settled) {
+                    return;
+                  }
+                  settled = true;
+                  resolve({
+                    statusCode,
+                    body: Buffer.concat(chunks).toString('utf8'),
+                  });
+                };
+                response.on('data', (chunk) => {
+                  chunks.push(chunk);
+                  if (
+                    triggerUpstreamReset !== null &&
+                    Buffer.concat(chunks).toString('utf8') === partialSentinel
+                  ) {
+                    const trigger = triggerUpstreamReset;
+                    triggerUpstreamReset = null;
+                    trigger();
+                  }
+                });
+                response.on('end', () => {
+                  terminatedCleanly = true;
+                  if (!settled) {
+                    settled = true;
+                    reject(
+                      new Error(
+                        'response ended cleanly; expected abnormal termination after the partial sentinel',
+                      ),
+                    );
+                  }
+                });
+                response.on('error', resolveAbnormal);
+                response.on('close', () => {
+                  if (!terminatedCleanly) {
+                    resolveAbnormal();
+                  }
+                });
+              },
             );
-            response.on('error', () =>
-              resolve({
-                statusCode: response.statusCode,
-                body: Buffer.concat(chunks).toString('utf8'),
-              }),
-            );
+            proxyRequest.once('error', (error) => {
+              if (!settled) {
+                settled = true;
+                reject(
+                  new Error(
+                    `request-level error reached the client before response headers: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                  ),
+                );
+              }
+            });
+            proxyRequest.end('{"test":true}');
           },
         );
-        proxyRequest.once('error', () =>
-          resolve({
-            statusCode: observedStatus ?? 0,
-            body:
-              observedStatus === undefined
-                ? 'connection error'
-                : Buffer.concat(observedChunks).toString('utf8'),
-          }),
-        );
-        proxyRequest.end('{"test":true}');
-      });
-      const telemetry = await stopEmbeddedMonitor(resource);
-      await closeServer(upstream);
+        monitorStopAttempted = true;
+        const telemetry = await stopEmbeddedMonitor(resource);
 
-      expect(telemetry.total_requests).toBe(1);
-      expect(telemetry.upstream_errors).toBe(0);
-      expect(telemetry.responses_by_status).toEqual({ 200: 1 });
-      expect(result.statusCode).toBe(200);
+        expect(result.statusCode).toBe(200);
+        expect(result.body).toBe(partialSentinel);
+        expect(telemetry.total_requests).toBe(1);
+        expect(telemetry.upstream_errors).toBe(0);
+        expect(telemetry.responses_by_status).toEqual({ 200: 1 });
+        expect(telemetry.shutdown_complete).toBe(true);
+      } finally {
+        try {
+          if (resource !== undefined && !monitorStopAttempted) {
+            monitorStopAttempted = true;
+            await stopEmbeddedMonitor(resource);
+          }
+        } finally {
+          await closeServer(upstream);
+        }
+      }
     });
 
     it('handles a client-aborted request during streaming without crashing or double-counting', async () => {


### PR DESCRIPTION
## Summary

Fixes the recurring scripts-shard transport canary race by replacing local event-loop timing with explicit downstream peer observation.

The upstream fixture now remains open after sending HTTP 200 and the complete partial payload. The downstream client triggers the one-shot upstream reset only after those bytes have crossed the separate Node monitor process and arrived in its data handler.

## Root cause

The previous fixture wrote the partial response and destroyed the upstream response from `setImmediate`. That ordered only the Bun fixture event loop; it did not acknowledge forwarding by the separate Node monitor or parsing by the downstream Bun client. Under some host schedules, the reset reached the client before its response callback, and the test manufactured synthetic status 0.

## Behavioral changes

- Require downstream HTTP 200 and exact partial body before triggering reset.
- Reject request-level errors before response headers.
- Reject clean response completion.
- Resolve only from abnormal response-stream termination.
- Assert exact one-request telemetry and clean monitor shutdown.
- Always close the upstream server and attempt monitor stop at most once.
- Keep production monitor behavior unchanged.

## Scope audit

Repository abrupt-response fixtures were audited for the same write-then-scheduled-destroy cross-process anti-pattern. This canary was the only concrete match. Other socket destruction fixtures are direct same-process lifecycle or cancellation scenarios. The VS Code concurrency suite already uses explicit peer-arrival signaling.

## Verification

- TDD RED: strengthened contract failed under host load on the pre-response request-error path.
- Focused GREEN stress: 20/20 loaded fresh processes passed.
- Complete canary stress: 15/15 fresh processes passed.
- Post-review focused canary: 1/1 passed.
- Complete canary file: 17/17 passed.
- Changed-file ESLint and formatting passed.
- Repository lint passed.
- Repository build passed.
- Stepfun runtime smoke passed.
- DeepThinker review completed; all Blocker-Fix and In-scope-Fix findings resolved.
- OCR review completed and triaged.

## Repository-wide gate observations

Current main has unrelated failures outside this change:

- Full test: two agents tests timed out. `hookAdmin.behavior.test.ts` passed independently; `subagentOrchestrator-loadBalancer.test.ts` independently reproduces a timeout.
- Full typecheck: current-main cache-anchor code references missing `HistoryService` and metadata members across agents/providers/CLI/a2a-server.

This PR does not modify those unrelated systems. Candidate-head CI will provide the authoritative supported-platform result, and every failure will be evaluated before merge readiness.

Fixes #3097
