### PR TITLE
Confine the build to type resolution and emit declarations, not JavaScript (Closes #2983)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,9 @@ jobs:
       # declaration-only `dist` makes cross-package imports resolve to a
       # `.d.ts` with no JavaScript behind it. The release path
       # (release.yml -> `npm run build:packages`) still does a full emit,
-      # because every published workspace declares `main: dist/index.js`.
+      # because every published library workspace declares `main:
+      # dist/index.js` and ships `dist`, so npm consumers resolving without the
+      # `bun` export condition load that JavaScript.
       - name: 'Build declarations for type-aware lint'
         run: |-
           npm run build:types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,15 +412,25 @@ jobs:
         run: |-
           npm run lint:affected-shards
 
-      # Build must run BEFORE the type-aware lint: several workspace tsconfigs
-      # map cross-workspace imports to `dist/*.d.ts` (e.g. storage, settings),
-      # so tsserver (projectService) needs the compiled declarations on disk to
-      # resolve types. Under npm `npm ci`'s postinstall builds implicitly; under
-      # `bun install` (whose postinstall only symlinks, see scripts/postinstall.cjs)
-      # it does not, so the build is explicit here.
-      - name: 'Build project'
+      # Build must run BEFORE the type-aware lint: three workspace tsconfigs
+      # map cross-workspace imports to `dist/*.d.ts` — cli -> tools, core -> mcp,
+      # and a2a-server -> settings/storage/tools — so tsserver (projectService)
+      # needs the compiled declarations on disk to resolve types. Under npm
+      # `npm ci`'s postinstall builds implicitly; under `bun install` (whose
+      # postinstall only symlinks, see scripts/postinstall.cjs) it does not, so
+      # the build is explicit here.
+      #
+      # `build:types` emits declarations only (issue #2983). Every step in this
+      # job reads types and none executes application code, so the transpiled
+      # `.js` was pure cost here. Do not reuse `build:types` in a job that runs
+      # the CLI or a Bun test suite: Bun honors tsconfig `paths`, so a
+      # declaration-only `dist` makes cross-package imports resolve to a
+      # `.d.ts` with no JavaScript behind it. The release path
+      # (release.yml -> `npm run build:packages`) still does a full emit,
+      # because every published workspace declares `main: dist/index.js`.
+      - name: 'Build declarations for type-aware lint'
         run: |-
-          npm run build
+          npm run build:types
 
       - name: 'Run agents API-surface guard'
         run: |-
@@ -1008,17 +1018,39 @@ jobs:
         run: |-
           bun install
           git checkout -- bun.lock
-      - name: 'Build project'
+      # Issue #2983: tests never read compiled output. Every workspace declares
+      # a `bun` export condition resolving to TypeScript source, and
+      # packages/cli/vitest.config.ts aliases cross-workspace imports straight
+      # at source, so a full build here produced JavaScript nothing loaded.
+      #
+      # Two shards are the exception. Both run the agents API-surface guard
+      # (`scripts/check-agents-api-surface.ts`) — the `agents` shard through its
+      # package `pretest` hook, the `scripts` shard through
+      # scripts/tests/check-agents-api-surface.test.ts. That guard's temp
+      # tsconfig resolves `@vybestack/llxprt-code-{telemetry,mcp}` and several
+      # `storage/*` subpaths through node_modules to `dist/*.d.ts`, because
+      # packages/agents/tsconfig.json has no source mapping for them. Issue
+      # #2618 (tsconfig bypasses) owns repointing those mappings at source;
+      # until it lands, these two legs need a built workspace.
+      #
+      # These legs must run the FULL build, not `build:types`. Bun applies
+      # tsconfig `paths` at runtime, so `packages/core/tsconfig.json`'s
+      # `@vybestack/llxprt-code-mcp -> ../mcp/dist/mcp/index.d.ts` mapping wins
+      # over the package's `bun` export condition whenever that file exists. A
+      # declaration-only `dist` therefore resolves to a `.d.ts` whose relative
+      # re-export has no emitted JavaScript behind it, and every test importing
+      # core through mcp dies at import time. Either a complete `dist` or no
+      # `dist` at all works; a partial one does not. `build:types` is confined
+      # to `lint_javascript`, which runs no application code.
+      #
+      # The standalone `Run agents API-surface guard` step is gone: the
+      # `lint_javascript` job already runs it after its own declaration build,
+      # and the `agents` shard runs it through the agents package `pretest`
+      # hook.
+      - name: 'Build project (agents API-surface guard prerequisite)'
+        if: matrix.shard == 'agents' || matrix.shard == 'scripts'
         run: |-
           npm run build
-
-      - name: 'Run agents API-surface guard'
-        # Only the agents shard needs this guard (it inspects the agents
-        # package's public API surface). Running it on every shard wastes CI
-        # time on shards that don't exercise the agents package.
-        if: matrix.shard == 'agents'
-        run: |-
-          npm run lint:agents-api-surface
 
       - name: 'Verify test shard completeness (issue #2707)'
         # Fails if any workspace declared in package.json is missing from the

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "docs:settings": "bun ./scripts/generate-settings-doc.ts",
     "docs:keybindings": "bun ./scripts/generate-keybindings-doc.ts",
     "build": "bun scripts/build.ts",
+    "build:types": "cross-env LLXPRT_EMIT_DECLARATIONS_ONLY=1 npm run build",
     "preinstall": "node scripts/preinstall.cjs",
     "postinstall": "node scripts/postinstall.cjs",
     "build-and-start": "npm run build && npm run start",

--- a/packages/auth/src/__tests__/package-boundary.test.ts
+++ b/packages/auth/src/__tests__/package-boundary.test.ts
@@ -427,21 +427,11 @@ describe('Auth workspace DAG constraints', () => {
 // ─────────────────────────────────────────────────────────────────
 // Build artifact checks
 // ─────────────────────────────────────────────────────────────────
-
-describe('Auth package build artifacts', () => {
-  /**
-   * @plan:PLAN-20260608-ISSUE1586.P04
-   * @requirement:REQ-AUTH-001.3
-   */
-  it('dist/index.js exists', () => {
-    expect(fs.existsSync(path.join(AUTH_DIR, 'dist', 'index.js'))).toBe(true);
-  });
-
-  /**
-   * @plan:PLAN-20260608-ISSUE1586.P04
-   * @requirement:REQ-AUTH-001.3
-   */
-  it('dist/index.d.ts exists', () => {
-    expect(fs.existsSync(path.join(AUTH_DIR, 'dist', 'index.d.ts'))).toBe(true);
-  });
-});
+//
+// Removed by issue #2983. These asserted that `dist/index.js` and
+// `dist/index.d.ts` were present on disk, which only held because the test
+// job compiled the workspace first. Tests resolve TypeScript source through
+// the `bun` export condition and never read `dist`, so the assertions
+// measured the CI harness rather than this package. REQ-AUTH-001.3's
+// published contract stays pinned by the `main`, `types`, and `exports`
+// assertions above.

--- a/packages/cli/src/integration-tests/cli-args-test-helpers.ts
+++ b/packages/cli/src/integration-tests/cli-args-test-helpers.ts
@@ -133,8 +133,9 @@ export async function runCli(
     }, 60_000);
 
     // A spawn failure (e.g. a moved or deleted CLI entry) emits 'error' and
-    // never 'close'. Without this the promise would never settle and the case
-    // would hang until the runner's own timeout, hiding the cause.
+    // then 'close' with a null exit code. Settling here keeps the spawn
+    // message; the later 'close' cannot change an already-settled promise.
+    // Without this the case would report a bare exit code with no cause.
     child.on('error', (error: Error) => {
       clearTimeout(timeout);
       resolve({

--- a/packages/cli/src/integration-tests/cli-args-test-helpers.ts
+++ b/packages/cli/src/integration-tests/cli-args-test-helpers.ts
@@ -132,6 +132,18 @@ export async function runCli(
       });
     }, 60_000);
 
+    // A spawn failure (e.g. a moved or deleted CLI entry) emits 'error' and
+    // never 'close'. Without this the promise would never settle and the case
+    // would hang until the runner's own timeout, hiding the cause.
+    child.on('error', (error: Error) => {
+      clearTimeout(timeout);
+      resolve({
+        stdout,
+        stderr: `${stderr}Failed to spawn ${CLI_ENTRY}: ${error.message}`,
+        exitCode: -1,
+      });
+    });
+
     child.on('close', (code) => {
       clearTimeout(timeout);
       resolve({

--- a/packages/cli/src/integration-tests/cli-args-test-helpers.ts
+++ b/packages/cli/src/integration-tests/cli-args-test-helpers.ts
@@ -6,6 +6,20 @@
 
 import { spawn } from 'child_process';
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The CLI's real entry point. Nothing compiles this workspace before tests run
+ * (issue #2983), so spawning `node dist/index.js` had no target; `index.ts` is
+ * what the installed launcher and `npm run start` execute anyway.
+ */
+const CLI_ENTRY = path.resolve(
+  fileURLToPath(import.meta.url),
+  '..',
+  '..',
+  '..',
+  'index.ts',
+);
 
 export type CliRunResult = {
   stdout: string;
@@ -47,10 +61,10 @@ export async function runCli(
     env.LLXPRT_CONFIG_HOME ?? process.env.LLXPRT_CONFIG_HOME ?? '';
 
   return new Promise((resolve) => {
-    // Use the compiled CLI entry point
-    const cliPath = path.join(process.cwd(), 'dist', 'index.js');
-
-    const child = spawn('node', [cliPath, ...args], {
+    // `process.execPath` is the Bun binary running this suite — the CLI
+    // workspace executes Bun-native (issue #2843) — which is exactly the
+    // runtime the shipped launcher execs `index.ts` with.
+    const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
       env: {
         ...process.env,
         // The CI test step injects real provider credentials. These cases

--- a/packages/cli/src/integration-tests/loadbalancer.integration.test.ts
+++ b/packages/cli/src/integration-tests/loadbalancer.integration.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { spawn } from 'child_process';
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import { Storage } from '@vybestack/llxprt-code-storage';
 import * as fs from 'fs/promises';
 import type {
@@ -26,15 +27,29 @@ interface CliResult {
   exitCode: number;
 }
 
+/**
+ * The CLI's real entry point. Nothing compiles this workspace before tests run
+ * (issue #2983), so spawning `node dist/index.js` had no target; `index.ts` is
+ * what the installed launcher and `npm run start` execute anyway.
+ */
+const CLI_ENTRY = path.resolve(
+  fileURLToPath(import.meta.url),
+  '..',
+  '..',
+  '..',
+  'index.ts',
+);
+
 async function runCli(
   args: string[],
   env: Record<string, string> = {},
   input?: string,
 ): Promise<CliResult> {
   return new Promise((resolve) => {
-    const cliPath = path.join(process.cwd(), 'dist', 'index.js');
-
-    const child = spawn('node', [cliPath, ...args], {
+    // `process.execPath` is the Bun binary running this suite — the CLI
+    // workspace executes Bun-native (issue #2843) — which is exactly the
+    // runtime the shipped launcher execs `index.ts` with.
+    const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
       env: {
         ...process.env,
         ...env,

--- a/packages/cli/src/integration-tests/loadbalancer.integration.test.ts
+++ b/packages/cli/src/integration-tests/loadbalancer.integration.test.ts
@@ -93,6 +93,18 @@ async function runCli(
       });
     }, 60_000);
 
+    // A spawn failure (e.g. a moved or deleted CLI entry) emits 'error' and
+    // never 'close'. Without this the promise would never settle and the case
+    // would hang until the runner's own timeout, hiding the cause.
+    child.on('error', (error: Error) => {
+      clearTimeout(timeout);
+      resolve({
+        stdout,
+        stderr: `${stderr}Failed to spawn ${CLI_ENTRY}: ${error.message}`,
+        exitCode: -1,
+      });
+    });
+
     child.on('close', (code) => {
       clearTimeout(timeout);
       resolve({

--- a/packages/cli/src/integration-tests/loadbalancer.integration.test.ts
+++ b/packages/cli/src/integration-tests/loadbalancer.integration.test.ts
@@ -94,8 +94,9 @@ async function runCli(
     }, 60_000);
 
     // A spawn failure (e.g. a moved or deleted CLI entry) emits 'error' and
-    // never 'close'. Without this the promise would never settle and the case
-    // would hang until the runner's own timeout, hiding the cause.
+    // then 'close' with a null exit code. Settling here keeps the spawn
+    // message; the later 'close' cannot change an already-settled promise.
+    // Without this the case would report a bare exit code with no cause.
     child.on('error', (error: Error) => {
       clearTimeout(timeout);
       resolve({

--- a/project-plans/issue2983/plan.md
+++ b/project-plans/issue2983/plan.md
@@ -166,6 +166,18 @@ Updated existing tests:
 - `packages/cli/src/integration-tests/{cli-args-test-helpers,loadbalancer.integration.test}.ts`
   — spawn `packages/cli/index.ts` under Bun instead of `node dist/index.js`.
 
+## Review triage
+
+| Finding                                                            | Class        | Action                                                                                                                              |
+| ------------------------------------------------------------------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Full build still runs on the `agents`/`scripts` legs                 | Defer        | The remedy is repointing cross-workspace mappings at source, which the issue lists under **Out of scope**. Owned by #2618.            |
+| `build:types` still emitted LSP JavaScript                           | In-scope-Fix | `packages/lsp` skipped in declaration mode; nothing imports it or maps it in any tsconfig, so no declarations are lost.               |
+| `copy_files.ts` stages two example-extension `.js` assets            | Reject       | Copied verbatim, not compiler output. Staging must stay so `dist`-mapped JSON imports resolve. Wording tightened to say "transpiled". |
+| New tests only exercised a compiler fixture, not the real pipeline   | In-scope-Fix | Added an end-to-end `build_package.ts` run against a throwaway workspace, asserting emitted files in both modes.                      |
+| Deleting auth's on-disk artifact assertions loses release coverage    | In-scope-Fix | Replaced by the end-to-end pipeline test, which proves the full build writes `index.js`, `index.d.ts`, assets and `.last_build`.      |
+| Comments overstate that nothing consumes `dist/*.js`                 | In-scope-Fix | Corrected: published library packages do consume it through `main`/`import`; only the PR path does not.                              |
+| `scripts/build.ts` builds a shell command string                     | Reject       | Names come from repo-owned manifests and are validated against npm's package-name grammar; matches the file's existing `execSync` use. |
+
 ## Verification
 
 `npm run test`, `npm run lint:ci`, `npm run lint:eslint-guard`,

--- a/project-plans/issue2983/plan.md
+++ b/project-plans/issue2983/plan.md
@@ -1,0 +1,175 @@
+# Issue #2983 — Remove the build from the test path; keep it for lint/typecheck only and emit declarations, not JS
+
+## Objective
+
+Confine the TypeScript build to the one thing that consumes it — type-aware
+lint and `tsc --noEmit` — and stop emitting JavaScript that nothing runs.
+
+Two changes:
+
+1. Remove the full `npm run build` from the `test_shard` CI legs.
+2. Give the retained type-resolution build a declaration-only mode
+   (`--emitDeclarationOnly`) so it writes `.d.ts` and no `.js`.
+
+## Preflight evidence (measured, not assumed)
+
+Ran every shard with `packages/*/dist` and the tsbuildinfo cache deleted.
+
+| Shard       | Result without `dist/`                                        |
+| ----------- | ------------------------------------------------------------- |
+| `core`      | pass                                                          |
+| `providers` | pass                                                          |
+| `rest`      | 2 failures in `packages/auth` (build-artifact assertions)     |
+| `cli`       | 34 failures across 3 integration files spawning `dist/index.js` |
+| `scripts`   | 3 failures from `scripts/start.ts`; 1 from the agents guard   |
+| `agents`    | fails at `pretest` (agents API-surface guard)                 |
+
+Root causes found:
+
+1. **`scripts/start.ts` imports compiled output.**
+   `import { parseBootstrapArgs } from '../packages/cli/dist/src/config/profileBootstrap.js'`
+   — a runtime consumer of emitted JavaScript. This is the defect the issue
+   predicted; fix at the import site by resolving the TypeScript source.
+
+2. **`packages/auth/src/__tests__/package-boundary.test.ts` asserts build
+   artifacts exist on disk** (`dist/index.js`, `dist/index.d.ts`). These are
+   build smoke assertions misplaced in a unit shard: the shard no longer
+   builds, so the assertion tests the harness, not the package. The adjacent
+   metadata assertions (`main === 'dist/index.js'`, `types`, `exports`) already
+   pin the published contract and stay.
+
+3. **`packages/cli`'s build chains `chmod_executable.ts dist/index.js`.**
+   In declaration-only mode that file is deliberately not emitted.
+
+4. **Three CLI integration files spawn `node packages/cli/dist/index.js`.**
+   `cli-args-test-helpers.ts` and `loadbalancer.integration.test.ts` build the
+   path from `process.cwd()`. Their own comments already describe the child as
+   booting "the whole CLI from TypeScript source", so the compiled launcher was
+   vestigial; spawning `index.ts` with the Bun binary that runs the suite is
+   both correct and faster.
+
+5. **`scripts/check-agents-api-surface.ts` needs dependency declarations.**
+   Its docblock claims otherwise, but its temp tsconfig resolves
+   `@vybestack/llxprt-code-{telemetry,mcp}` and several `storage/*` subpaths
+   through `node_modules` → `dist/*.d.ts`, because `packages/agents/tsconfig.json`
+   has no source mapping for them. Those subpaths are not expressible as
+   wildcard `paths` entries — `@vybestack/llxprt-code-storage/storage/secure-store.js`
+   resolves to `src/secure-store/secure-store.ts`, and
+   `@vybestack/llxprt-code-tools/doubleEscapeUtils.js` to
+   `src/formatters/doubleEscapeUtils.ts` — so repointing them is a per-subpath
+   refactor across several packages. That is issue #2618 (tsconfig bypasses)
+   and is explicitly **out of scope here**. Both the `agents` shard (via the
+   agents package `pretest` hook) and the `scripts` shard (via
+   `scripts/tests/check-agents-api-surface.test.ts`) run this guard.
+
+6. **The VS Code companion's build bundles with esbuild**, which resolves
+   `@vybestack/llxprt-code-ide-integration` at `dist/*.js`. It contributes no
+   declarations that any tsconfig maps and is built separately by
+   `npm run build:vscode`, so the declaration build skips it.
+
+7. **A partially built workspace is worse than an unbuilt one.** Bun applies
+   tsconfig `paths` at runtime, so `packages/core/tsconfig.json`'s
+   `@vybestack/llxprt-code-mcp -> ../mcp/dist/mcp/index.d.ts` mapping wins over
+   the package's `bun` export condition whenever that file exists. Measured:
+   with a declaration-only `dist`, 178 of 340 agents test files die at import
+   with `Cannot find module './src/index.js' from packages/mcp/dist/mcp/index.d.ts`,
+   and `bun scripts/start.ts` fails the same way. With no `dist`, resolution
+   falls through to the `bun` condition and everything passes. Therefore
+   `build:types` is confined to `lint_javascript`, which runs no application
+   code, and the two guard legs run the full build.
+
+## Accepted behavior
+
+- **AC1** — No `test_shard` leg runs the full `npm run build`.
+- **AC2** — Every `test_shard` leg that no longer builds passes with no
+  `dist/` on disk. The `agents` and `scripts` legs retain the full build,
+  because both run the agents API-surface guard and that guard needs a built
+  workspace (root causes 5 and 7). This is documented in `ci.yml` and blocked
+  on #2618.
+- **AC3** — A declaration-only build mode exists and is what the type-aware
+  lint job runs. It emits `.d.ts` and writes no `.js`. It is confined to jobs
+  that execute no application code (root cause 7).
+- **AC4** — The release/publish path keeps full JavaScript emit. Every
+  published workspace still declares `main: dist/index.js`, `files` still
+  include `dist`, and `release.yml` still runs `npm run build:packages`.
+- **AC5** — The redundant `Run agents API-surface guard` step is removed from
+  the `agents` test leg; the `lint_javascript` job already runs it after the
+  build, and the agents package `pretest` hook covers the shard.
+- **AC6** — The stale `ci.yml` comment naming "storage, settings" is corrected
+  to the real declaration dependents: `cli → tools`, `core → mcp`,
+  `a2a-server → settings/storage/tools`.
+- **AC7** — The publish-time CLI bundle (`packages/cli/bundle/llxprt.js`,
+  issues #2999/#3013) stays decoupled: it is not built by
+  `scripts/build_package.ts`, and no build path deletes `packages/cli/bundle/`.
+- **AC8** — No new lint suppressions, no relaxed rules, no raised thresholds.
+
+## Out of scope
+
+- Repointing the cross-workspace `dist/*.d.ts` tsconfig mappings at source
+  (issue #2618). The build is retained deliberately for lint/typecheck.
+- Changing what is published or how the CLI launches.
+- Removing the last declaration-only build from the `scripts` shard leg;
+  that is unblocked by #2618.
+
+## Design
+
+### Declaration-only mode
+
+`tsc --build` accepts `--emitDeclarationOnly` (verified against the pinned
+TypeScript 5.8.3 build-mode help), so no parallel tsconfig tree is needed.
+
+- `scripts/build_package.ts` appends `--emitDeclarationOnly` to the
+  `tsc --build` invocation when `LLXPRT_EMIT_DECLARATIONS_ONLY=1`.
+- Root script `build:types` sets that variable and delegates to the existing
+  `build`, so there is exactly one build pipeline with two emit modes.
+- `scripts/build.ts` drops the bundle-only VS Code companion workspace in
+  declaration-only mode.
+- `scripts/chmod_executable.ts` treats an absent target as a no-op **only** in
+  declaration-only mode, and still fails fast otherwise.
+
+### CI wiring
+
+- `lint_javascript` job: `npm run build` → `npm run build:types`.
+- `test_shard`: `Build project` gated to the `agents` and `scripts` legs and
+  left on the full build.
+- `test_shard`: `Run agents API-surface guard` deleted (redundant).
+- `acp_conformance` job and `release.yml` keep the full build unchanged.
+
+Net effect: four of six shard legs stop building entirely, and the retained
+lint/typecheck build stops transpiling.
+
+## Test plan (behavioral, bun:test)
+
+New `scripts/tests/issue-2983-declaration-build.test.ts`:
+
+1. Real `tsc --build --emitDeclarationOnly` run against a temp fixture project
+   emits `.d.ts` and no `.js`; the same fixture without the flag emits `.js`.
+2. `resolveBuildPlan` (exported from `build_package.ts`) selects the flag from
+   the environment and never selects it by default.
+3. `chmod_executable.ts` exits 0 on a missing target in declaration-only mode
+   and exits non-zero on a missing target otherwise.
+4. `ci.yml`: `test_shard` has exactly one build step, gated to the `agents`
+   and `scripts` legs, and it is not the declaration-only variant; no
+   per-shard API-surface guard step remains; `lint_javascript` builds
+   declarations before running the guard and never runs the full build.
+5. `ci.yml`: the lint build comment names `cli -> tools`, `core -> mcp`,
+   `a2a-server -> settings/storage/tools`.
+6. `release.yml` still runs `npm run build:packages` (full emit), and neither
+   `build` nor `build:packages` sets the declaration-only flag.
+7. The CLI bundle stays out of `build_package.ts`/`copy_files.ts` and remains
+   on the CLI package `prepack`.
+
+Updated existing tests:
+
+- `packages/auth/src/__tests__/package-boundary.test.ts` — drop the two
+  build-artifact existence assertions.
+- `packages/cli/src/integration-tests/{cli-args-test-helpers,loadbalancer.integration.test}.ts`
+  — spawn `packages/cli/index.ts` under Bun instead of `node dist/index.js`.
+
+## Verification
+
+`npm run test`, `npm run lint:ci`, `npm run lint:eslint-guard`,
+`npm run typecheck`, `npm run format:check`, `npm run build`, and
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+
+Plus a cold-shard rerun with `packages/*/dist` deleted.

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -100,9 +100,16 @@ function workspaceBuildSelector(): string {
   if (!isDeclarationsOnly()) {
     return '--workspaces';
   }
-  return declarationBuildWorkspaces(readWorkspacePackageNames())
-    .map((name) => `--workspace=${name}`)
-    .join(' ');
+  const selected = declarationBuildWorkspaces(readWorkspacePackageNames());
+  if (selected.length === 0) {
+    // An empty selector would leave a bare `npm run build`, which re-enters
+    // this script instead of fanning out to the workspaces — a silent wrong
+    // build rather than a failure.
+    throw new Error(
+      'Declaration build selected no workspaces; check NON_DECLARATION_WORKSPACES.',
+    );
+  }
+  return selected.map((name) => `--workspace=${name}`).join(' ');
 }
 
 function sandboxAvailable(): boolean {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -18,13 +18,68 @@
 // limitations under the License.
 
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { messageOf } from './utils/error-guards.ts';
+import { isDeclarationsOnly } from './build_package.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
+
+/**
+ * Workspaces whose `build` bundles instead of emitting declarations.
+ *
+ * The VS Code companion's build ends in esbuild, which resolves its workspace
+ * dependencies at `dist/*.js` — exactly what the declaration-only build
+ * (issue #2983) deliberately does not emit. It publishes no declarations that
+ * any tsconfig maps, and both CI and the release workflow build it on their
+ * own track through `npm run build:vscode`, so the declaration build skips it.
+ */
+const BUNDLE_ONLY_WORKSPACES = new Set(['llxprt-code-vscode-ide-companion']);
+
+/**
+ * npm's package-name grammar. Names reach a shell command line below, so a
+ * name outside this grammar is rejected rather than interpolated.
+ */
+const PACKAGE_NAME_PATTERN =
+  /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
+
+/**
+ * Package names of the root `workspaces` entries, in declaration order. The
+ * array holds concrete directory paths (enforced by
+ * scripts/verify-bun-workspace-links.ts), so no glob expansion is needed.
+ */
+function readWorkspacePackageNames(): string[] {
+  const rootPkg = JSON.parse(
+    readFileSync(join(root, 'package.json'), 'utf-8'),
+  ) as { workspaces?: string[] };
+  const workspaces = rootPkg.workspaces;
+  if (!Array.isArray(workspaces) || workspaces.length === 0) {
+    throw new Error('Root package.json must declare a non-empty `workspaces`.');
+  }
+  return workspaces.map((relativeDir) => {
+    const pkg = JSON.parse(
+      readFileSync(join(root, relativeDir, 'package.json'), 'utf-8'),
+    ) as { name?: string };
+    if (!pkg.name || !PACKAGE_NAME_PATTERN.test(pkg.name)) {
+      throw new Error(
+        `Workspace ${relativeDir} has no usable package name: ${String(pkg.name)}`,
+      );
+    }
+    return pkg.name;
+  });
+}
+
+function workspaceBuildSelector(): string {
+  if (!isDeclarationsOnly()) {
+    return '--workspaces';
+  }
+  return readWorkspacePackageNames()
+    .filter((name) => !BUNDLE_ONLY_WORKSPACES.has(name))
+    .map((name) => `--workspace=${name}`)
+    .join(' ');
+}
 
 // npm install if node_modules was removed (e.g. via npm run clean or scripts/clean.ts)
 if (!existsSync(join(root, 'node_modules'))) {
@@ -33,7 +88,10 @@ if (!existsSync(join(root, 'node_modules'))) {
 
 // build all workspaces/packages
 execSync('npm run generate', { stdio: 'inherit', cwd: root });
-execSync('npm run build --workspaces', { stdio: 'inherit', cwd: root });
+execSync(`npm run build ${workspaceBuildSelector()}`, {
+  stdio: 'inherit',
+  cwd: root,
+});
 
 // also build container image if sandboxing is enabled
 // skip (-s) npm install + build since we did that above

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -69,9 +69,18 @@ function readWorkspacePackageNames(): string[] {
     throw new Error('Root package.json must declare a non-empty `workspaces`.');
   }
   return workspaces.map((relativeDir) => {
-    const pkg = JSON.parse(
-      readFileSync(join(root, relativeDir, 'package.json'), 'utf-8'),
-    ) as { name?: string };
+    let pkg: { name?: string };
+    try {
+      pkg = JSON.parse(
+        readFileSync(join(root, relativeDir, 'package.json'), 'utf-8'),
+      ) as { name?: string };
+    } catch (error) {
+      // Name the workspace: a bare SyntaxError from JSON.parse leaves the
+      // reader to guess which of sixteen manifests is malformed.
+      throw new Error(
+        `Could not read ${relativeDir}/package.json: ${messageOf(error)}`,
+      );
+    }
     if (!pkg.name || !PACKAGE_NAME_PATTERN.test(pkg.name)) {
       throw new Error(
         `Workspace ${relativeDir} has no usable package name: ${String(pkg.name)}`,

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -49,11 +49,13 @@ const NON_DECLARATION_WORKSPACES = new Set([
 ]);
 
 /**
- * npm's package-name grammar. Names reach a shell command line below, so a
- * name outside this grammar is rejected rather than interpolated.
+ * Characters an npm package name may contain. Names reach a shell command line
+ * below, so a name outside this grammar is rejected rather than interpolated.
+ * Uppercase is accepted: npm rejects it for *new* packages but still resolves
+ * legacy names that use it, and it is shell-safe either way.
  */
 const PACKAGE_NAME_PATTERN =
-  /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
+  /^(?:@[A-Za-z0-9][A-Za-z0-9._-]*\/)?[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 /**
  * Package names of the root `workspaces` entries, in declaration order. The

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -28,15 +28,25 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 
 /**
- * Workspaces whose `build` bundles instead of emitting declarations.
+ * Workspaces the declaration-only build (issue #2983) skips, because no
+ * tsconfig `paths` entry and no source import resolves their declarations, so
+ * building them produces nothing that type-aware lint or `tsc --noEmit` reads.
+ * Both still build normally on the release path.
  *
- * The VS Code companion's build ends in esbuild, which resolves its workspace
- * dependencies at `dist/*.js` — exactly what the declaration-only build
- * (issue #2983) deliberately does not emit. It publishes no declarations that
- * any tsconfig maps, and both CI and the release workflow build it on their
- * own track through `npm run build:vscode`, so the declaration build skips it.
+ *  - `llxprt-code-vscode-ide-companion` ends its build in esbuild, which
+ *    resolves its workspace dependencies at `dist/*.js` — exactly what
+ *    declaration-only emit does not produce. CI and the release workflow build
+ *    it on their own track through `npm run build:vscode`.
+ *  - `@vybestack/llxprt-code-lsp` builds with a bare `tsc -p tsconfig.json`
+ *    that never sees `--emitDeclarationOnly`, so including it would emit
+ *    JavaScript into a build whose whole point is not to. It is reached at
+ *    runtime by module resolution from a spawned process, never imported, so
+ *    nothing type-checks against its declarations.
  */
-const BUNDLE_ONLY_WORKSPACES = new Set(['llxprt-code-vscode-ide-companion']);
+const NON_DECLARATION_WORKSPACES = new Set([
+  'llxprt-code-vscode-ide-companion',
+  '@vybestack/llxprt-code-lsp',
+]);
 
 /**
  * npm's package-name grammar. Names reach a shell command line below, so a
@@ -71,32 +81,18 @@ function readWorkspacePackageNames(): string[] {
   });
 }
 
+export function declarationBuildWorkspaces(names: string[]): string[] {
+  return names.filter((name) => !NON_DECLARATION_WORKSPACES.has(name));
+}
+
 function workspaceBuildSelector(): string {
   if (!isDeclarationsOnly()) {
     return '--workspaces';
   }
-  return readWorkspacePackageNames()
-    .filter((name) => !BUNDLE_ONLY_WORKSPACES.has(name))
+  return declarationBuildWorkspaces(readWorkspacePackageNames())
     .map((name) => `--workspace=${name}`)
     .join(' ');
 }
-
-// npm install if node_modules was removed (e.g. via npm run clean or scripts/clean.ts)
-if (!existsSync(join(root, 'node_modules'))) {
-  execSync('npm install', { stdio: 'inherit', cwd: root });
-}
-
-// build all workspaces/packages
-execSync('npm run generate', { stdio: 'inherit', cwd: root });
-execSync(`npm run build ${workspaceBuildSelector()}`, {
-  stdio: 'inherit',
-  cwd: root,
-});
-
-// also build container image if sandboxing is enabled
-// skip (-s) npm install + build since we did that above
-const buildSandboxRequested =
-  process.env.BUILD_SANDBOX === '1' || process.env.BUILD_SANDBOX === 'true';
 
 function sandboxAvailable(): boolean {
   try {
@@ -110,14 +106,38 @@ function sandboxAvailable(): boolean {
   }
 }
 
-if (buildSandboxRequested && sandboxAvailable()) {
-  try {
-    execSync('bun scripts/build_sandbox.ts -s', {
-      stdio: 'inherit',
-      cwd: root,
-    });
-  } catch (error) {
-    console.error(`Sandbox image build failed: ${messageOf(error)}`);
-    throw error;
+function main(): void {
+  // npm install if node_modules was removed (e.g. via npm run clean or
+  // scripts/clean.ts)
+  if (!existsSync(join(root, 'node_modules'))) {
+    execSync('npm install', { stdio: 'inherit', cwd: root });
   }
+
+  // build all workspaces/packages
+  execSync('npm run generate', { stdio: 'inherit', cwd: root });
+  execSync(`npm run build ${workspaceBuildSelector()}`, {
+    stdio: 'inherit',
+    cwd: root,
+  });
+
+  // also build container image if sandboxing is enabled
+  // skip (-s) npm install + build since we did that above
+  const buildSandboxRequested =
+    process.env.BUILD_SANDBOX === '1' || process.env.BUILD_SANDBOX === 'true';
+
+  if (buildSandboxRequested && sandboxAvailable()) {
+    try {
+      execSync('bun scripts/build_sandbox.ts -s', {
+        stdio: 'inherit',
+        cwd: root,
+      });
+    } catch (error) {
+      console.error(`Sandbox image build failed: ${messageOf(error)}`);
+      throw error;
+    }
+  }
+}
+
+if (import.meta.main) {
+  main();
 }

--- a/scripts/build_package.ts
+++ b/scripts/build_package.ts
@@ -24,21 +24,27 @@ import { join } from 'node:path';
 /**
  * Environment switch that selects declaration-only emit (issue #2983).
  *
- * The compiled JavaScript under `packages/*\/dist` has exactly one consumer
- * class: nothing at runtime. Tests resolve TypeScript source through each
- * workspace's `bun` export condition, and the published CLI ships either raw
- * TypeScript or the separate publish-time bundle at
- * `packages/cli/bundle/llxprt.js` (issues #2999/#3013). What *does* read
- * `dist` is type resolution: three workspace tsconfigs map cross-workspace
- * imports at `dist/*.d.ts` (cli -> tools, core -> mcp, and a2a-server ->
- * settings/storage/tools), so type-aware lint and `tsc --noEmit` need those
- * declarations on disk.
+ * Who reads `packages/*\/dist`:
+ *
+ *  - **Type resolution does.** Three workspace tsconfigs map cross-workspace
+ *    imports at `dist/*.d.ts` (cli -> tools, core -> mcp, and a2a-server ->
+ *    settings/storage/tools), so type-aware lint and `tsc --noEmit` need those
+ *    declarations on disk.
+ *  - **npm consumers of the published library packages do.** Every workspace
+ *    except the CLI declares `main: dist/index.js` and ships `dist`, so a Node
+ *    consumer that resolves without the `bun` export condition loads compiled
+ *    JavaScript. The release build must keep emitting it.
+ *  - **The PR path does not.** Tests resolve TypeScript source through each
+ *    workspace's `bun` condition, and the published CLI runs raw TypeScript or
+ *    the separate publish-time bundle at `packages/cli/bundle/llxprt.js`
+ *    (issues #2999/#3013), which `prepack` builds and this script never
+ *    touches.
  *
  * When this variable is set to `1`, `tsc --build` runs with
  * `--emitDeclarationOnly`: declarations are still written, transpilation and
- * JavaScript file writes are skipped. The release path deliberately leaves it
- * unset, because every published workspace still declares
- * `main: dist/index.js` and ships `dist` in its `files` array.
+ * JavaScript emit are skipped. Non-code assets are still staged by
+ * `copy_files.ts` so `dist`-mapped JSON imports keep resolving. The release
+ * path deliberately leaves the variable unset.
  */
 export const DECLARATIONS_ONLY_ENV = 'LLXPRT_EMIT_DECLARATIONS_ONLY';
 

--- a/scripts/build_package.ts
+++ b/scripts/build_package.ts
@@ -21,28 +21,90 @@ import { execSync } from 'node:child_process';
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-if (!process.cwd().includes('packages')) {
-  console.error('must be invoked from a package directory');
-  process.exit(1);
+/**
+ * Environment switch that selects declaration-only emit (issue #2983).
+ *
+ * The compiled JavaScript under `packages/*\/dist` has exactly one consumer
+ * class: nothing at runtime. Tests resolve TypeScript source through each
+ * workspace's `bun` export condition, and the published CLI ships either raw
+ * TypeScript or the separate publish-time bundle at
+ * `packages/cli/bundle/llxprt.js` (issues #2999/#3013). What *does* read
+ * `dist` is type resolution: three workspace tsconfigs map cross-workspace
+ * imports at `dist/*.d.ts` (cli -> tools, core -> mcp, and a2a-server ->
+ * settings/storage/tools), so type-aware lint and `tsc --noEmit` need those
+ * declarations on disk.
+ *
+ * When this variable is set to `1`, `tsc --build` runs with
+ * `--emitDeclarationOnly`: declarations are still written, transpilation and
+ * JavaScript file writes are skipped. The release path deliberately leaves it
+ * unset, because every published workspace still declares
+ * `main: dist/index.js` and ships `dist` in its `files` array.
+ */
+export const DECLARATIONS_ONLY_ENV = 'LLXPRT_EMIT_DECLARATIONS_ONLY';
+
+/**
+ * True when the caller asked for declaration-only emit. Only the exact value
+ * `1` enables it, so a stray empty or `0` value cannot silently change what
+ * the release build emits.
+ */
+export function isDeclarationsOnly(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env[DECLARATIONS_ONLY_ENV] === '1';
 }
 
-const hasBuildConfig = existsSync('tsconfig.build.json');
-const tsconfig = hasBuildConfig ? 'tsconfig.build.json' : 'tsconfig.json';
+/**
+ * The `tsc --build` argument list for a package build.
+ *
+ * `--emitDeclarationOnly` is accepted in build mode, so declaration-only emit
+ * needs no parallel tsconfig tree — one pipeline, two emit modes.
+ */
+export function buildTscArgs(
+  tsconfig: string,
+  declarationsOnly: boolean,
+): string[] {
+  return declarationsOnly
+    ? ['--build', '--emitDeclarationOnly', tsconfig]
+    : ['--build', tsconfig];
+}
 
-// Perform a full clean of previous build artifacts _including_ the cached
-// incremental graph (.tsbuildinfo). We still preserve incremental rebuilds
-// by letting TypeScript regenerate a fresh cache right after the clean.
-// This avoids TS6305 ("output file has not been built") when dist is wiped
-// but the .tsbuildinfo still references old artifacts.
-execSync(`tsc --build --clean ${tsconfig}`, { stdio: 'inherit' });
+/** The tsconfig a package builds with: an explicit build config wins. */
+export function resolveTsconfigName(
+  hasBuildConfig: boolean = existsSync('tsconfig.build.json'),
+): string {
+  return hasBuildConfig ? 'tsconfig.build.json' : 'tsconfig.json';
+}
 
-// Re-build the project (this creates a new .tsbuildinfo for subsequent
-// fast incremental compilations).
-execSync(`tsc --build ${tsconfig}`, { stdio: 'inherit' });
+function main(): void {
+  if (!process.cwd().includes('packages')) {
+    console.error('must be invoked from a package directory');
+    process.exit(1);
+  }
 
-// copy .{md,json} files
-execSync('bun ../../scripts/copy_files.ts', { stdio: 'inherit' });
+  const tsconfig = resolveTsconfigName();
+  const declarationsOnly = isDeclarationsOnly();
 
-// touch dist/.last_build
-writeFileSync(join(process.cwd(), 'dist', '.last_build'), '');
-process.exit(0);
+  // Perform a full clean of previous build artifacts _including_ the cached
+  // incremental graph (.tsbuildinfo). We still preserve incremental rebuilds
+  // by letting TypeScript regenerate a fresh cache right after the clean.
+  // This avoids TS6305 ("output file has not been built") when dist is wiped
+  // but the .tsbuildinfo still references old artifacts.
+  execSync(`tsc --build --clean ${tsconfig}`, { stdio: 'inherit' });
+
+  // Re-build the project (this creates a new .tsbuildinfo for subsequent
+  // fast incremental compilations).
+  execSync(`tsc ${buildTscArgs(tsconfig, declarationsOnly).join(' ')}`, {
+    stdio: 'inherit',
+  });
+
+  // copy .{md,json} files
+  execSync('bun ../../scripts/copy_files.ts', { stdio: 'inherit' });
+
+  // touch dist/.last_build
+  writeFileSync(join(process.cwd(), 'dist', '.last_build'), '');
+  process.exit(0);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/chmod_executable.ts
+++ b/scripts/chmod_executable.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { chmodSync } from 'node:fs';
+import { chmodSync, existsSync } from 'node:fs';
 import { platform } from 'node:os';
+import { isDeclarationsOnly } from './build_package.ts';
 
 if (platform() === 'win32') {
   process.exit(0);
@@ -15,6 +16,14 @@ const target = process.argv[2];
 if (!target) {
   console.error('Usage: bun chmod_executable.ts <file>');
   process.exit(1);
+}
+
+// The declaration-only build (issue #2983) deliberately emits no JavaScript,
+// so the CLI entry this step marks executable does not exist in that mode.
+// This is the only case in which an absent target is expected; a full build
+// that failed to emit it must still fail loudly.
+if (isDeclarationsOnly() && !existsSync(target)) {
+  process.exit(0);
 }
 
 chmodSync(target, 0o755);

--- a/scripts/start.ts
+++ b/scripts/start.ts
@@ -22,7 +22,6 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { parseBootstrapArgs } from '../packages/cli/dist/src/config/profileBootstrap.js';
 import {
   isErrnoException,
   messageOf,
@@ -38,7 +37,6 @@ const root = join(__dirname, '..');
 const pkg = JSON.parse(
   readFileSync(join(root, 'package.json'), 'utf-8'),
 ) as PackageJson;
-parseBootstrapArgs();
 
 /**
  * Prepare NODE_OPTIONS for child processes in DEV mode.

--- a/scripts/tests/issue-2983-declaration-build.test.ts
+++ b/scripts/tests/issue-2983-declaration-build.test.ts
@@ -274,6 +274,39 @@ describe('issue #2983 — entry-point execution contract', () => {
       rmSync(outsidePackages, { recursive: true, force: true });
     }
   }, 120_000);
+
+  it('still runs build.ts when it is the entry point', () => {
+    // build.ts has no cwd guard — it anchors on import.meta.url and would run
+    // a real build. Emptying PATH makes its first action, `npm run generate`,
+    // fail immediately, so reaching that failure proves `main()` ran without
+    // building anything.
+    const emptyPath = mkdtempSync(join(tmpdir(), 'issue-2983-nopath-'));
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [join(REPO_ROOT, 'scripts', 'build.ts')],
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+          env: { ...process.env, PATH: emptyPath, Path: emptyPath },
+          timeout: 120_000,
+        },
+      );
+      const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+      expect(result.status, output).not.toBe(0);
+      expect(output).toContain('npm run generate');
+    } finally {
+      rmSync(emptyPath, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  it('refuses to build zero workspaces rather than re-entering itself', () => {
+    // A bare `npm run build` re-enters this script instead of fanning out.
+    expect(declarationBuildWorkspaces([])).toEqual([]);
+    expect(readRepoFile('scripts/build.ts')).toContain(
+      'Declaration build selected no workspaces',
+    );
+  });
 });
 
 describe('issue #2983 — declaration-only emit', () => {

--- a/scripts/tests/issue-2983-declaration-build.test.ts
+++ b/scripts/tests/issue-2983-declaration-build.test.ts
@@ -28,16 +28,18 @@ import { describe, it, expect } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import {
+  copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { delimiter, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   DECLARATIONS_ONLY_ENV,
@@ -45,11 +47,13 @@ import {
   isDeclarationsOnly,
   resolveTsconfigName,
 } from '../build_package.ts';
+import { declarationBuildWorkspaces } from '../build.ts';
 import { parseWorkflowYaml } from './typed-test-helpers.ts';
 import type { WorkflowJob, WorkflowStep } from './typed-test-helpers.ts';
 
 const REPO_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TSC_CLI = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+const NEWLINE = '\n';
 
 function readRepoFile(relativePath: string): string {
   return readFileSync(join(REPO_ROOT, relativePath), 'utf-8');
@@ -127,6 +131,125 @@ function compileFixture(declarationsOnly: boolean): {
   }
 }
 
+/**
+ * Runs the real `scripts/build_package.ts` against a throwaway package laid
+ * out exactly as a workspace is — `<root>/packages/<name>` next to a
+ * `<root>/scripts/copy_files.ts` — so the whole pipeline executes: clean,
+ * build, asset staging, `.last_build`. Returns every file the run left in
+ * `dist`.
+ */
+function runBuildPackage(declarationsOnly: boolean): {
+  status: number | null;
+  output: string;
+  distFiles: string[];
+} {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'issue-2983-pipeline-'));
+  const packageDir = join(fixtureRoot, 'packages', 'fixture');
+  try {
+    mkdirSync(join(packageDir, 'src'), { recursive: true });
+    mkdirSync(join(fixtureRoot, 'scripts'), { recursive: true });
+    copyFileSync(
+      join(REPO_ROOT, 'scripts', 'copy_files.ts'),
+      join(fixtureRoot, 'scripts', 'copy_files.ts'),
+    );
+
+    writeFileSync(
+      join(packageDir, 'src', 'index.ts'),
+      `export const answer: number = 42;${NEWLINE}`,
+    );
+    // A staged non-code asset: declaration builds must keep these, because
+    // `dist`-mapped JSON imports resolve against them.
+    writeFileSync(
+      join(packageDir, 'src', 'data.json'),
+      `{"ok":true}${NEWLINE}`,
+    );
+    writeFileSync(
+      join(packageDir, 'tsconfig.json'),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            target: 'es2022',
+            module: 'NodeNext',
+            moduleResolution: 'nodenext',
+            rootDir: 'src',
+            outDir: 'dist',
+            declaration: true,
+            composite: true,
+            strict: true,
+            types: [],
+          },
+          include: ['src/**/*.ts'],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const env = { ...process.env };
+    if (declarationsOnly) {
+      env[DECLARATIONS_ONLY_ENV] = '1';
+    } else {
+      delete env[DECLARATIONS_ONLY_ENV];
+    }
+    // `build_package.ts` shells out to a bare `tsc`, so the repository's
+    // TypeScript binary has to be reachable from the fixture's PATH.
+    env['PATH'] =
+      `${join(REPO_ROOT, 'node_modules', '.bin')}${delimiter}${env['PATH'] ?? ''}`;
+
+    const result = spawnSync(
+      process.execPath,
+      [join(REPO_ROOT, 'scripts', 'build_package.ts')],
+      { cwd: packageDir, encoding: 'utf8', env, timeout: 180_000 },
+    );
+
+    const distDir = join(packageDir, 'dist');
+    const distFiles = existsSync(distDir)
+      ? readdirSync(distDir, { recursive: true, withFileTypes: true })
+          .filter((entry) => entry.isFile())
+          .map((entry) => relative(distDir, join(entry.parentPath, entry.name)))
+      : [];
+
+    return {
+      status: result.status,
+      output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+      distFiles,
+    };
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+describe('issue #2983 — build_package pipeline', () => {
+  it('writes declarations and no JavaScript in declaration-only mode', () => {
+    const result = runBuildPackage(true);
+    expect(result.status, result.output).toBe(0);
+    expect(result.distFiles).toContain('index.d.ts');
+    expect(
+      result.distFiles.filter((file) => file.endsWith('.js')),
+      result.output,
+    ).toEqual([]);
+    expect(result.distFiles.filter((file) => file.endsWith('.js.map'))).toEqual(
+      [],
+    );
+  }, 240_000);
+
+  it('still stages non-code assets and the build stamp in declaration-only mode', () => {
+    const result = runBuildPackage(true);
+    expect(result.status, result.output).toBe(0);
+    expect(result.distFiles).toContain(join('src', 'data.json'));
+    expect(result.distFiles).toContain('.last_build');
+  }, 240_000);
+
+  it('writes JavaScript for the default (release) build', () => {
+    const result = runBuildPackage(false);
+    expect(result.status, result.output).toBe(0);
+    expect(result.distFiles).toContain('index.d.ts');
+    expect(result.distFiles).toContain('index.js');
+    expect(result.distFiles).toContain(join('src', 'data.json'));
+    expect(result.distFiles).toContain('.last_build');
+  }, 240_000);
+});
+
 describe('issue #2983 — declaration-only emit', () => {
   it('emits declarations and no JavaScript when declaration-only', () => {
     const result = compileFixture(true);
@@ -182,6 +305,33 @@ describe('issue #2983 — build scripts', () => {
     expect(readRepoFile('.github/workflows/release.yml')).toContain(
       'npm run build:packages',
     );
+  });
+
+  it('skips workspaces whose build cannot honour declaration-only emit', () => {
+    // packages/lsp builds with a bare `tsc -p`, which never sees
+    // --emitDeclarationOnly, and the VS Code companion ends in esbuild.
+    // Nothing type-checks against either package's declarations.
+    const selected = declarationBuildWorkspaces([
+      '@vybestack/llxprt-code-tools',
+      '@vybestack/llxprt-code-lsp',
+      'llxprt-code-vscode-ide-companion',
+    ]);
+    expect(selected).toEqual(['@vybestack/llxprt-code-tools']);
+  });
+
+  it('has no source importer or tsconfig mapping for the skipped lsp package', () => {
+    // The skip above is only safe while nothing type-resolves against
+    // @vybestack/llxprt-code-lsp. It is spawned as a process, not imported.
+    for (const configPath of [
+      'tsconfig.json',
+      'packages/core/tsconfig.json',
+      'packages/cli/tsconfig.json',
+      'packages/agents/tsconfig.json',
+      'packages/ide-integration/tsconfig.json',
+      'packages/a2a-server/tsconfig.json',
+    ]) {
+      expect(readRepoFile(configPath)).not.toContain('llxprt-code-lsp');
+    }
   });
 
   it('keeps the publish-time CLI bundle out of the declaration build', () => {

--- a/scripts/tests/issue-2983-declaration-build.test.ts
+++ b/scripts/tests/issue-2983-declaration-build.test.ts
@@ -1,0 +1,334 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #2983 — the build serves type resolution and nothing else.
+ *
+ * Two behaviors are pinned here:
+ *
+ *  1. The type-resolution build emits declarations and no JavaScript, while
+ *     the release build still emits JavaScript. Both are exercised against the
+ *     repository's real TypeScript compiler, not a description of it.
+ *  2. CI builds only where the output is actually consumed: the test shards no
+ *     longer build (except the two legs that run the agents API-surface guard,
+ *     which needs a built workspace until issue #2618 repoints those tsconfig
+ *     mappings at source), and the type-aware lint job builds declarations
+ *     only.
+ *
+ * Those two legs must run the FULL build. Bun applies tsconfig `paths` at
+ * runtime, so a declaration-only `dist` resolves cross-package imports to a
+ * `.d.ts` with no JavaScript behind it and every importing test dies. A
+ * complete `dist` or no `dist` both work; a partial one does not.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DECLARATIONS_ONLY_ENV,
+  buildTscArgs,
+  isDeclarationsOnly,
+  resolveTsconfigName,
+} from '../build_package.ts';
+import { parseWorkflowYaml } from './typed-test-helpers.ts';
+import type { WorkflowJob, WorkflowStep } from './typed-test-helpers.ts';
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const TSC_CLI = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(join(REPO_ROOT, relativePath), 'utf-8');
+}
+
+function rootPackageScripts(): Record<string, string> {
+  const pkg = JSON.parse(readRepoFile('package.json')) as {
+    scripts?: Record<string, string>;
+  };
+  return pkg.scripts ?? {};
+}
+
+function jobSteps(job: WorkflowJob | undefined): WorkflowStep[] {
+  return job?.steps ?? [];
+}
+
+function ciJobs(): Record<string, WorkflowJob> {
+  return parseWorkflowYaml(readRepoFile('.github/workflows/ci.yml')).jobs ?? {};
+}
+
+/**
+ * Builds a self-contained TypeScript project and returns its `dist` contents.
+ * Deliberately standalone (it does not extend the repo tsconfig) so the
+ * assertion is about the compiler flag, not about repository configuration.
+ */
+function compileFixture(declarationsOnly: boolean): {
+  hasDeclaration: boolean;
+  hasJavaScript: boolean;
+  stderr: string;
+  status: number | null;
+} {
+  const projectDir = mkdtempSync(join(tmpdir(), 'issue-2983-emit-'));
+  try {
+    mkdirSync(join(projectDir, 'src'));
+    writeFileSync(
+      join(projectDir, 'src', 'index.ts'),
+      'export const answer: number = 42;\n',
+    );
+    writeFileSync(
+      join(projectDir, 'tsconfig.json'),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            target: 'es2022',
+            module: 'NodeNext',
+            moduleResolution: 'nodenext',
+            rootDir: 'src',
+            outDir: 'dist',
+            declaration: true,
+            composite: true,
+            strict: true,
+            types: [],
+          },
+          include: ['src/**/*.ts'],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [TSC_CLI, ...buildTscArgs('tsconfig.json', declarationsOnly)],
+      { cwd: projectDir, encoding: 'utf8', timeout: 120_000 },
+    );
+
+    return {
+      hasDeclaration: existsSync(join(projectDir, 'dist', 'index.d.ts')),
+      hasJavaScript: existsSync(join(projectDir, 'dist', 'index.js')),
+      stderr: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+      status: result.status,
+    };
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+}
+
+describe('issue #2983 — declaration-only emit', () => {
+  it('emits declarations and no JavaScript when declaration-only', () => {
+    const result = compileFixture(true);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.hasDeclaration).toBe(true);
+    expect(result.hasJavaScript).toBe(false);
+  }, 180_000);
+
+  it('still emits JavaScript for the default (release) build', () => {
+    const result = compileFixture(false);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.hasDeclaration).toBe(true);
+    expect(result.hasJavaScript).toBe(true);
+  }, 180_000);
+
+  it('adds --emitDeclarationOnly only in declaration-only mode', () => {
+    expect(buildTscArgs('tsconfig.json', true)).toEqual([
+      '--build',
+      '--emitDeclarationOnly',
+      'tsconfig.json',
+    ]);
+    expect(buildTscArgs('tsconfig.json', false)).toEqual([
+      '--build',
+      'tsconfig.json',
+    ]);
+  });
+
+  it('enables declaration-only emit only for the exact opt-in value', () => {
+    expect(isDeclarationsOnly({})).toBe(false);
+    expect(isDeclarationsOnly({ [DECLARATIONS_ONLY_ENV]: '' })).toBe(false);
+    expect(isDeclarationsOnly({ [DECLARATIONS_ONLY_ENV]: '0' })).toBe(false);
+    expect(isDeclarationsOnly({ [DECLARATIONS_ONLY_ENV]: 'true' })).toBe(false);
+    expect(isDeclarationsOnly({ [DECLARATIONS_ONLY_ENV]: '1' })).toBe(true);
+  });
+
+  it('prefers an explicit build tsconfig over the default one', () => {
+    expect(resolveTsconfigName(true)).toBe('tsconfig.build.json');
+    expect(resolveTsconfigName(false)).toBe('tsconfig.json');
+  });
+});
+
+describe('issue #2983 — build scripts', () => {
+  it('exposes build:types as the declaration-only variant of build', () => {
+    const scripts = rootPackageScripts();
+    expect(scripts['build:types']).toContain(`${DECLARATIONS_ONLY_ENV}=1`);
+    expect(scripts['build:types']).toContain('npm run build');
+  });
+
+  it('leaves the release build on full JavaScript emit', () => {
+    const scripts = rootPackageScripts();
+    expect(scripts['build']).not.toContain(DECLARATIONS_ONLY_ENV);
+    expect(scripts['build:packages']).not.toContain(DECLARATIONS_ONLY_ENV);
+    expect(readRepoFile('.github/workflows/release.yml')).toContain(
+      'npm run build:packages',
+    );
+  });
+
+  it('keeps the publish-time CLI bundle out of the declaration build', () => {
+    // The bundle (issues #2999/#3013) is produced by the CLI package prepack
+    // through scripts/bun-build.config.ts. Coupling it to build_package.ts
+    // would put a publish artifact on the PR path and expose it to
+    // `tsc --build --clean`.
+    expect(readRepoFile('scripts/build_package.ts')).not.toContain(
+      'bun-build.config',
+    );
+    expect(readRepoFile('scripts/copy_files.ts')).not.toContain(
+      'bun-build.config',
+    );
+    const cliPkg = JSON.parse(readRepoFile('packages/cli/package.json')) as {
+      scripts?: Record<string, string>;
+    };
+    expect(cliPkg.scripts?.['prepack']).toContain('bun-build.config.ts');
+    expect(cliPkg.scripts?.['build']).not.toContain('bun-build.config.ts');
+  });
+});
+
+describe('issue #2983 — chmod_executable declaration-only contract', () => {
+  const script = join(REPO_ROOT, 'scripts', 'chmod_executable.ts');
+  const isWindows = process.platform === 'win32';
+
+  function runChmod(
+    target: string,
+    declarationsOnly: boolean,
+  ): { status: number | null; stderr: string } {
+    const env = { ...process.env };
+    if (declarationsOnly) {
+      env[DECLARATIONS_ONLY_ENV] = '1';
+    } else {
+      delete env[DECLARATIONS_ONLY_ENV];
+    }
+    const result = spawnSync(process.execPath, [script, target], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env,
+      timeout: 60_000,
+    });
+    return { status: result.status, stderr: result.stderr ?? '' };
+  }
+
+  it.skipIf(isWindows)(
+    'treats a missing target as a no-op in declaration-only mode',
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), 'issue-2983-chmod-'));
+      try {
+        expect(runChmod(join(dir, 'absent.js'), true).status).toBe(0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(isWindows)(
+    'still fails on a missing target in a full build',
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), 'issue-2983-chmod-'));
+      try {
+        expect(runChmod(join(dir, 'absent.js'), false).status).not.toBe(0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(isWindows)('marks an existing target executable', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'issue-2983-chmod-'));
+    const target = join(dir, 'present.js');
+    try {
+      writeFileSync(target, 'console.log(1);\n', { mode: 0o644 });
+      expect(runChmod(target, false).status).toBe(0);
+      expect(statSync(target).mode & 0o777).toBe(0o755);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('issue #2983 — CI keeps the build off the test path', () => {
+  const GUARD_SHARDS = ['agents', 'scripts'] as const;
+
+  it('keeps at most one build step in the test shards', () => {
+    const buildSteps = jobSteps(ciJobs()['test_shard']).filter((step) =>
+      String(step.run ?? '').includes('npm run build'),
+    );
+    expect(buildSteps).toHaveLength(1);
+  });
+
+  it('restricts the shard build to the guard-running legs', () => {
+    const buildSteps = jobSteps(ciJobs()['test_shard']).filter((step) =>
+      String(step.run ?? '').includes('npm run build'),
+    );
+    const condition = String(buildSteps[0].if ?? '');
+    for (const shard of GUARD_SHARDS) {
+      expect(condition).toContain(`matrix.shard == '${shard}'`);
+    }
+  });
+
+  it('never leaves a shard with a declaration-only workspace', () => {
+    // Bun applies tsconfig `paths` at runtime, so a partially built `dist`
+    // resolves cross-package imports to a `.d.ts` with no JavaScript behind
+    // it. Shards need a complete `dist` or none at all.
+    const buildSteps = jobSteps(ciJobs()['test_shard']).filter((step) =>
+      String(step.run ?? '').includes('npm run build'),
+    );
+    for (const step of buildSteps) {
+      expect(String(step.run)).not.toContain('npm run build:types');
+    }
+  });
+
+  it('drops the redundant per-shard agents API-surface guard step', () => {
+    const guardSteps = jobSteps(ciJobs()['test_shard']).filter((step) =>
+      String(step.run ?? '').includes('lint:agents-api-surface'),
+    );
+    expect(guardSteps).toEqual([]);
+  });
+
+  it('builds declarations before the type-aware lint', () => {
+    const lintSteps = jobSteps(ciJobs()['lint_javascript']);
+    const buildIndex = lintSteps.findIndex((step) =>
+      String(step.run ?? '').includes('npm run build:types'),
+    );
+    const guardIndex = lintSteps.findIndex((step) =>
+      String(step.run ?? '').includes('lint:agents-api-surface'),
+    );
+    expect(buildIndex).toBeGreaterThanOrEqual(0);
+    expect(guardIndex).toBeGreaterThan(buildIndex);
+    expect(
+      lintSteps.filter(
+        (step) =>
+          String(step.run ?? '').includes('npm run build') &&
+          !String(step.run).includes('npm run build:types'),
+      ),
+    ).toEqual([]);
+  });
+
+  it('names the real declaration dependents in the lint build comment', () => {
+    const ci = readRepoFile('.github/workflows/ci.yml');
+    const comment = ci.slice(
+      ci.indexOf('# Build must run BEFORE the type-aware lint'),
+      ci.indexOf("- name: 'Build declarations for type-aware lint'"),
+    );
+    expect(comment).toContain('cli -> tools');
+    expect(comment).toContain('core -> mcp');
+    expect(comment).toContain('a2a-server -> settings/storage/tools');
+  });
+});

--- a/scripts/tests/issue-2983-declaration-build.test.ts
+++ b/scripts/tests/issue-2983-declaration-build.test.ts
@@ -250,6 +250,32 @@ describe('issue #2983 — build_package pipeline', () => {
   }, 240_000);
 });
 
+describe('issue #2983 — entry-point execution contract', () => {
+  // build_package.ts and build.ts now guard their bodies with
+  // `import.meta.main` so their helpers can be imported. Nothing in the repo
+  // imports either for side effects (this file imports build.ts purely for
+  // `declarationBuildWorkspaces`, and the suite performs no build as a
+  // result), but the spawned entry path must still run.
+  it('still runs build_package.ts when it is the entry point', () => {
+    const outsidePackages = mkdtempSync(join(tmpdir(), 'issue-2983-entry-'));
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [join(REPO_ROOT, 'scripts', 'build_package.ts')],
+        { cwd: outsidePackages, encoding: 'utf8', timeout: 60_000 },
+      );
+      // The guarded body's first action is this cwd check, so reaching it
+      // proves `main()` ran.
+      expect(result.status).toBe(1);
+      expect(`${result.stdout ?? ''}${result.stderr ?? ''}`).toContain(
+        'must be invoked from a package directory',
+      );
+    } finally {
+      rmSync(outsidePackages, { recursive: true, force: true });
+    }
+  }, 120_000);
+});
+
 describe('issue #2983 — declaration-only emit', () => {
   it('emits declarations and no JavaScript when declaration-only', () => {
     const result = compileFixture(true);

--- a/scripts/tests/issue-2983-declaration-build.test.ts
+++ b/scripts/tests/issue-2983-declaration-build.test.ts
@@ -427,6 +427,10 @@ describe('issue #2983 — CI keeps the build off the test path', () => {
     const buildSteps = jobSteps(ciJobs()['test_shard']).filter((step) =>
       String(step.run ?? '').includes('npm run build'),
     );
+    expect(
+      buildSteps,
+      'expected exactly one build step in test_shard',
+    ).toHaveLength(1);
     const condition = String(buildSteps[0].if ?? '');
     for (const shard of GUARD_SHARDS) {
       expect(condition).toContain(`matrix.shard == '${shard}'`);
@@ -473,10 +477,20 @@ describe('issue #2983 — CI keeps the build off the test path', () => {
 
   it('names the real declaration dependents in the lint build comment', () => {
     const ci = readRepoFile('.github/workflows/ci.yml');
-    const comment = ci.slice(
-      ci.indexOf('# Build must run BEFORE the type-aware lint'),
-      ci.indexOf("- name: 'Build declarations for type-aware lint'"),
+    const startMarker = '# Build must run BEFORE the type-aware lint';
+    const endMarker = "- name: 'Build declarations for type-aware lint'";
+    const startIndex = ci.indexOf(startMarker);
+    const endIndex = ci.indexOf(endMarker);
+    // Without these guards a renamed marker yields indexOf === -1, and the
+    // resulting slice spans most of the file — broad enough to still contain
+    // every expected phrase, so the test would pass on stale content.
+    expect(startIndex, `missing marker: ${startMarker}`).toBeGreaterThanOrEqual(
+      0,
     );
+    expect(endIndex, `missing marker: ${endMarker}`).toBeGreaterThan(
+      startIndex,
+    );
+    const comment = ci.slice(startIndex, endIndex);
     expect(comment).toContain('cli -> tools');
     expect(comment).toContain('core -> mcp');
     expect(comment).toContain('a2a-server -> settings/storage/tools');

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -229,6 +229,7 @@
     "scripts/tests/issue-2603-smoke-helpers.test.ts",
     "scripts/tests/issue-2603-windows-lineage-helpers.test.ts",
     "scripts/tests/issue-2603-windows-probe.ts",
+    "scripts/tests/issue-2983-declaration-build.test.ts",
     "scripts/tests/issue-planner.test.ts",
     "scripts/tests/legacy-paths-ast-scanner.test.ts",
     "scripts/tests/legacy-paths-guard-helpers.ts",


### PR DESCRIPTION
## TLDR

The TypeScript build exists to serve type-aware lint and `tsc --noEmit`. This PR confines it to that job.

- **Four of six `test_shard` legs stop building.** Tests never read compiled output: every workspace declares a `bun` export condition resolving to TypeScript source, and `packages/cli/vitest.config.ts` aliases cross-workspace imports at source.
- **The retained lint/typecheck build stops transpiling.** `npm run build:types` runs `tsc --build --emitDeclarationOnly`, producing 2771 `.d.ts` files and zero compiler-emitted JavaScript.
- **The release path is untouched.** `release.yml` still runs `npm run build:packages` with full emit, because every published library workspace declares `main: dist/index.js` and ships `dist`.

Removing the build surfaced four places that quietly depended on compiled output. All four are fixed at the import/spawn site rather than by restoring the build.

Reviewers should look hardest at two things: the decision to keep a build on the `agents` and `scripts` legs (explained below, with measurements), and the fact that a *partially* built workspace is worse than an unbuilt one under Bun.

## Dive Deeper

### What actually consumes `packages/*/dist`

| Consumer | Reads `dist`? |
| --- | --- |
| Type-aware lint and `tsc --noEmit` | Yes — `cli -> tools`, `core -> mcp`, `a2a-server -> settings/storage/tools` map at `dist/*.d.ts` |
| npm consumers of the published library packages | Yes — `main`/`import` point at `dist/*.js` when a consumer resolves without the `bun` condition |
| The PR test path | No |
| The published CLI | No — raw TypeScript plus the separate publish-time bundle at `packages/cli/bundle/llxprt.js` (#2999 / #3013), which `prepack` builds and this PR never touches |

### Hidden consumers the change surfaced

Measured by deleting `packages/*/dist` and running every shard.

1. `scripts/start.ts` imported `parseBootstrapArgs` from `packages/cli/dist/src/config/profileBootstrap.js` and threw the result away. The call was added by the JS-to-TS script migration and duplicates what the spawned CLI already does. Removed.
2. Three CLI integration files spawned `node packages/cli/dist/index.js` (34 failing cases). Their own comments already described the child as booting from TypeScript source, so they now spawn `packages/cli/index.ts` with the Bun binary running the suite — which is what the shipped launcher does. They are also noticeably faster.
3. `packages/auth`'s package-boundary test asserted `dist/index.js` and `dist/index.d.ts` exist on disk. That only held because the shard built first, so it measured the CI harness. Its coverage is replaced by an end-to-end build test (below); the published contract stays pinned by the `main`/`types`/`exports` assertions in the same file.
4. `packages/cli`'s build chains `chmod_executable.ts dist/index.js`, which does not exist in declaration-only mode. The script now treats an absent target as a no-op **only** in that mode and still fails loudly otherwise.

### Why the `agents` and `scripts` legs still build

Both run the agents API-surface guard — `agents` through its package `pretest` hook, `scripts` through `scripts/tests/check-agents-api-surface.test.ts`. Despite its docblock, that guard needs dependency declarations: its temp tsconfig resolves `@vybestack/llxprt-code-{telemetry,mcp}` and several `storage/*` subpaths through `node_modules` to `dist/*.d.ts`, because `packages/agents/tsconfig.json` has no source mapping for them. Those subpaths are not expressible as wildcard `paths` entries — `@vybestack/llxprt-code-storage/storage/secure-store.js` resolves to `src/secure-store/secure-store.ts`, and `@vybestack/llxprt-code-tools/doubleEscapeUtils.js` to `src/formatters/doubleEscapeUtils.ts`. Repointing them is #2618, and the issue lists that work under **Out of scope**.

Everything else on those legs is fine without a build: with `dist` deleted, `bun scripts/test.ts --shard agents --skip-pretest` passes 337/340 files, and the three stragglers pass in isolation (they are load-sensitive 30s timeouts, not resolution failures).

The redundant per-shard `Run agents API-surface guard` step is removed: `lint_javascript` already runs it after its own build, and the `agents` shard covers it through the package `pretest` hook.

### Why those legs need the FULL build, not `build:types`

Bun applies tsconfig `paths` at runtime. `packages/core/tsconfig.json` maps `@vybestack/llxprt-code-mcp` to `../mcp/dist/mcp/index.d.ts`, and that mapping wins over the package's `bun` export condition whenever the file exists. With a declaration-only `dist`, cross-package imports therefore resolve to a `.d.ts` whose relative re-export has no JavaScript behind it.

Measured: 178 of 340 agents test files die at import with `Cannot find module './src/index.js' from packages/mcp/dist/mcp/index.d.ts`, and `bun scripts/start.ts` fails the same way. With **no** `dist`, resolution falls through to the `bun` condition and everything passes.

A complete `dist` works. No `dist` works. A partial one does not. `build:types` is therefore confined to `lint_javascript`, which executes no application code, and both `ci.yml` and the test suite pin that constraint so nobody moves it.

### Build plumbing

- `scripts/build_package.ts` appends `--emitDeclarationOnly` when `LLXPRT_EMIT_DECLARATIONS_ONLY=1`. Build mode accepts the flag, so no parallel tsconfig tree is needed — one pipeline, two emit modes. Only the exact value `1` enables it, so a stray `0` cannot change what the release build emits.
- Root `build:types` sets that variable and delegates to `build`. `build` and `build:packages` are untouched.
- `scripts/build.ts` skips two workspaces in declaration-only mode, because neither contributes declarations that any tsconfig maps: `vscode-ide-companion` ends its build in esbuild (which resolves workspace deps at `dist/*.js`), and `lsp` builds with a bare `tsc -p` that never sees the flag. Both still build normally on the release path, and `lsp` is reached at runtime by module resolution from a spawned process, never imported.

## Reviewer Test Plan

Confirm the emit contract:

    rm -rf packages/*/dist node_modules/.cache/tsbuildinfo
    npm run build:types
    find packages/*/dist -name '*.js' -o -name '*.js.map'

Only two files should appear, both example-extension assets copied verbatim by `copy_files.ts` (`examples/mcp-server/example.js`, `examples/hooks/scripts/on-start.js`). No compiler output. Then check `find packages/*/dist -name '*.d.ts' | wc -l` is in the thousands, and that lint and typecheck still pass against it:

    npm run typecheck
    npm run lint:ci
    npm run lint:agents-api-surface
    npm run lint:affected-shards
    npm run gate:agents-neutral

Confirm the shards no longer need a build:

    rm -rf packages/*/dist node_modules/.cache/tsbuildinfo
    bun scripts/test.ts --shard cli
    bun scripts/test.ts --shard core
    bun scripts/test.ts --shard providers
    bun scripts/test.ts --shard rest
    bun scripts/start.ts --profile-load <your profile> "write me a haiku and nothing else"

Confirm the release path is intact:

    npm run build
    ls -l packages/cli/dist/index.js        # present and mode 0755
    npm run bundle:cli                       # publish-time CLI bundle still builds
    npm run build:types                      # declaration build must not delete it
    ls -l packages/cli/bundle/llxprt.js

And the focused suite:

    bun test scripts/tests/issue-2983-declaration-build.test.ts

Note: run the CLI integration files through `bun scripts/test.ts --shard cli`, not a single combined `bun test a.ts b.ts c.ts`. The CLI runner spawns one process per file and the suite relies on that isolation for `LLXPRT_CONFIG_HOME`; sharing one process leaks settings between files. That is pre-existing and unrelated to this PR.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test`, `npm run lint:ci`, `npm run lint:eslint-guard`, `npm run typecheck`, `npm run format:check`, `npm run build`, `npm run build:types`, `npm run bundle:cli`, and the CLI smoke run. Windows and Linux are covered by the CI matrix; the two platform-sensitive spots are `chmod_executable.ts` (already a no-op on Windows) and `build:types`, which uses `cross-env`.

## Linked issues / bugs

Closes #2983

Contributes to #2702 (CI execution optimization) and #2578 (all-Bun).
Coordinates with #2999 / #3013: the publish-time CLI bundle stays decoupled from the declaration build, and no build path deletes `packages/cli/bundle/`.
Blocked on #2618 for the last two shard builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & CI**
  - Improved build workflows by separating declaration generation from full JavaScript builds.
  - Limited full builds to the workflows that require generated runtime files.

- **Bug Fixes**
  - Improved CLI integration test reliability by running TypeScript entry points directly.
  - Added handling for process-launch failures so tests complete with clear error results.

- **Tests**
  - Added comprehensive coverage for declaration-only builds, release builds, workspace selection, asset handling, and executable permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->