### PR TITLE
Emit the public done once, at loop end (Fixes #3087)

### DIFF
--- a/packages/agents/src/api/__tests__/event-adapter-projection.spec.ts
+++ b/packages/agents/src/api/__tests__/event-adapter-projection.spec.ts
@@ -38,7 +38,10 @@ import {
   streamStopped,
   streamBlocked,
   streamContent,
+  streamError,
   streamFinished,
+  streamFinishedWithUsage,
+  streamUserCancelled,
   wrapStream,
   loopStream,
   isToolResultEvent,
@@ -291,9 +294,9 @@ describe('Event adapter projection @plan:PLAN-20260617-COREAPI.P14 @requirement:
     expect('systemMessage' in blocked[0].info).toBe(false);
   });
 
-  // ─── loop-end done synthesis vs self-emitted done ─────────────────────────
+  // ─── loop-end done synthesis (the SOLE done emission point) ──────────────
 
-  it('Finished stream event self-emits exactly one done{stop} with the finished payload; no duplicate loop-end done @plan:PLAN-20260617-COREAPI.P14 @requirement:REQ-003', async () => {
+  it('Finished stream event yields exactly one done{stop} carrying the finished payload @plan:PLAN-20260617-COREAPI.P14 @requirement:REQ-003', async () => {
     const events = await runAdapterStatic(loopStream(streamFinished()));
     const done = events.filter(isDoneEvent);
     expect(done).toHaveLength(1);
@@ -318,6 +321,134 @@ describe('Event adapter projection @plan:PLAN-20260617-COREAPI.P14 @requirement:
     expect(done).toHaveLength(1);
     expect(done[0].reason).toBe('stop');
     expect(events[events.length - 1].type).toBe('done');
+  });
+
+  // ─── done is terminal: never before a turn's tool activity (@issue:3087) ──
+  //
+  // A model iteration that requested tools emits its Finished (and, when the
+  // AfterAgent hook clears context, its AgentExecutionStopped) BEFORE the loop
+  // schedules those tools. The adapter must therefore defer every terminal
+  // reason to loop end so the single public `done` is genuinely last.
+
+  it('Finished on a tool-bearing iteration yields ONE done{stop} AFTER the tool events @issue:3087', async () => {
+    const events = await runAdapterStatic([
+      wrapStream(streamFinished()),
+      loopToolUpdate('c-1', 'search', 'executing'),
+      loopToolsComplete('c-1', 'search', 'found it'),
+      wrapStream(streamFinished()),
+    ]);
+    const done = events.filter(isDoneEvent);
+    expect(done).toHaveLength(1);
+    expect(done[0].reason).toBe('stop');
+    expect(events[events.length - 1].type).toBe('done');
+    expect(events.indexOf(events.filter(isToolResultEvent)[0])).toBeLessThan(
+      events.indexOf(done[0]),
+    );
+  });
+
+  it('AgentExecutionStopped on a tool-bearing iteration yields ONE done{hook-stopped} AFTER the tool events, carrying stop @issue:3087', async () => {
+    const events = await runAdapterStatic([
+      wrapStream(streamFinished()),
+      wrapStream(streamStopped('context cleared by hook')),
+      loopToolUpdate('c-2', 'search', 'executing'),
+      loopToolsComplete('c-2', 'search', 'found it'),
+    ]);
+    const done = events.filter(isDoneEvent);
+    expect(done).toHaveLength(1);
+    expect(done[0].reason).toBe('hook-stopped');
+    expect(done[0].stop?.reason).toBe('context cleared by hook');
+    expect(events[events.length - 1].type).toBe('done');
+    expect(events.indexOf(events.filter(isToolResultEvent)[0])).toBeLessThan(
+      events.indexOf(done[0]),
+    );
+  });
+
+  it('UserCancelled followed by loop tool events yields ONE done{aborted} that is last @issue:3087', async () => {
+    const events = await runAdapterStatic([
+      wrapStream(streamUserCancelled()),
+      loopToolUpdate('c-3', 'search', 'cancelled'),
+      loopToolsCompleteCancelled('c-3', 'search', true),
+    ]);
+    const done = events.filter(isDoneEvent);
+    expect(done).toHaveLength(1);
+    expect(done[0].reason).toBe('aborted');
+    expect(events[events.length - 1].type).toBe('done');
+  });
+
+  it('Error followed by a later Finished keeps the explicit done{error} @issue:3087', async () => {
+    const events = await runAdapterStatic(
+      loopStream(streamError({ message: 'boom' }), streamFinished()),
+    );
+    const done = events.filter(isDoneEvent);
+    expect(done).toHaveLength(1);
+    expect(done[0].reason).toBe('error');
+    expect(events[events.length - 1].type).toBe('done');
+  });
+
+  it('AgentExecutionStopped followed by a later Finished keeps done{hook-stopped} @issue:3087', async () => {
+    const events = await runAdapterStatic(
+      loopStream(streamStopped('cleared'), streamFinished()),
+    );
+    const done = events.filter(isDoneEvent);
+    expect(done).toHaveLength(1);
+    expect(done[0].reason).toBe('hook-stopped');
+    expect(done[0].stop?.reason).toBe('cleared');
+  });
+
+  it('an entirely empty loop stream emits NO events at all @issue:3087', async () => {
+    const events = await runAdapterStatic([]);
+    expect(events).toStrictEqual([]);
+  });
+
+  it('the terminal done keeps the last REPORTED usage when the final iteration reports none @issue:3087', async () => {
+    // A provider reports usage only on the iterations whose terminal chunk
+    // carries token counts. Collapsing to one done must not lose the counts a
+    // consumer used to keep from an earlier per-iteration done.
+    const events = await runAdapterStatic([
+      wrapStream(
+        streamFinishedWithUsage({
+          promptTokens: 42,
+          completionTokens: 8,
+          totalTokens: 50,
+        }),
+      ),
+      loopToolsComplete('c-usage', 'search', 'found it'),
+      wrapStream(streamFinished()),
+    ]);
+    const done = events.filter(isDoneEvent);
+    expect(done).toHaveLength(1);
+    expect(done[0].finished?.usageMetadata).toStrictEqual({
+      promptTokenCount: 42,
+      candidatesTokenCount: 8,
+      totalTokenCount: 50,
+    });
+  });
+
+  it('a later Finished that DOES report usage overrides the earlier counts @issue:3087', async () => {
+    const events = await runAdapterStatic([
+      wrapStream(
+        streamFinishedWithUsage({
+          promptTokens: 42,
+          completionTokens: 8,
+          totalTokens: 50,
+        }),
+      ),
+      loopToolsComplete('c-usage-2', 'search', 'found it'),
+      wrapStream(
+        streamFinishedWithUsage({
+          promptTokens: 90,
+          completionTokens: 10,
+          totalTokens: 100,
+        }),
+      ),
+    ]);
+    const done = events.filter(isDoneEvent);
+    expect(done).toHaveLength(1);
+    expect(done[0].finished?.usageMetadata).toStrictEqual({
+      promptTokenCount: 90,
+      candidatesTokenCount: 10,
+      totalTokenCount: 100,
+    });
   });
 
   // ─── property-based invariants ───────────────────────────────────────────

--- a/packages/agents/src/api/__tests__/helpers/eventAdapterStatic.ts
+++ b/packages/agents/src/api/__tests__/helpers/eventAdapterStatic.ts
@@ -61,7 +61,6 @@ export function driveSingleStreamEvent(
   event: ServerAgentStreamEvent,
 ): readonly AgentEvent[] {
   const state = {
-    emittedDone: false,
     lastFinished: null,
     lastStop: null,
     pendingDoneReason: null,

--- a/packages/agents/src/api/__tests__/helpers/eventHarness.ts
+++ b/packages/agents/src/api/__tests__/helpers/eventHarness.ts
@@ -167,6 +167,26 @@ export function streamFinished(
   };
 }
 
+/**
+ * A Finished carrying neutral UsageStats, as a provider reports on the
+ * iterations whose terminal chunk includes token counts. Providers do NOT
+ * report it on every iteration, so `streamFinished` (which omits it) is the
+ * companion builder for the usage-less case.
+ */
+export function streamFinishedWithUsage(
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  },
+  reason: CanonicalFinishReason = 'stop',
+): ServerAgentStreamEvent {
+  return {
+    type: AgentEventType.Finished,
+    value: { reason, usageMetadata: usage },
+  };
+}
+
 export function streamUserCancelled(): ServerAgentStreamEvent {
   return { type: AgentEventType.UserCancelled };
 }

--- a/packages/agents/src/api/eventAdapter.ts
+++ b/packages/agents/src/api/eventAdapter.ts
@@ -38,9 +38,16 @@ import type {
   ChatCompressionInfo as CompressionInfo,
 } from './event-types.js';
 
-// @pseudocode event-adapter.md steps 10-12: mutable per-stream adapter state.
+/**
+ * Mutable per-stream adapter state.
+ *
+ * No field records "a done was already emitted" because no per-event branch
+ * emits one. Every terminal signal is accumulated here and the single public
+ * `done` is synthesized once, at loop end. See {@link mapLoopStream}.
+ *
+ * @pseudocode event-adapter.md steps 10-12: mutable per-stream adapter state.
+ */
 interface AdapterState {
-  emittedDone: boolean;
   lastFinished: FinishedValue | null;
   lastStop: AgentStopInfo | null;
   pendingDoneReason: DoneReason | null;
@@ -258,7 +265,8 @@ function mapFinishReason(stopReason: string | undefined): DoneReason {
 }
 
 /**
- * Builds the terminal done event from the current adapter state.
+ * Builds the single terminal done event from the accumulated adapter state.
+ * Called exactly once, from {@link mapLoopStream}'s loop-end synthesis.
  * @pseudocode event-adapter.md steps 250-252: makeDone
  */
 function makeDone(state: AdapterState, reason: DoneReason): AgentEvent {
@@ -365,21 +373,35 @@ function* mapValueEventComplex(
       state.pendingDoneReason = 'context-overflow';
       return;
     }
+    // Finished means "this MODEL ITERATION ended", not "the agentic turn
+    // ended": turn.ts emits it for every provider chunk carrying a
+    // finishReason, tool-call turns included, and
+    // MessageStreamOrchestrator flushes it BEFORE AgenticLoop schedules the
+    // turn's tools. Projecting it straight to a public `done` therefore
+    // published a terminal event mid-turn and once per iteration (@issue:3087).
+    // It only records the finished payload now; the terminal done is
+    // synthesized at loop end.
     case AgentEventType.Finished: {
       const v = value as {
         reason: string;
         stopReason?: string;
         usageMetadata?: UsageStats;
       };
-      const publicUsage = usageStatsToPublicUsageMetadata(v.usageMetadata);
-      const finishedValue: FinishedValue = {
+      // A tool turn spans several model iterations and a provider only reports
+      // usage on the iterations whose terminal chunk carries it. The single
+      // terminal done must still surface the turn's most recent usage: while
+      // one done per iteration was emitted, consumers kept the last DEFINED
+      // usageMetadata (see drainToResult in agentBootstrap.ts), so letting a
+      // usage-less final iteration blank it would silently drop token
+      // accounting.
+      const publicUsage =
+        usageStatsToPublicUsageMetadata(v.usageMetadata) ??
+        state.lastFinished?.usageMetadata;
+      state.lastFinished = {
         reason: v.reason,
         ...(publicUsage !== undefined ? { usageMetadata: publicUsage } : {}),
         ...(v.stopReason !== undefined ? { stopReason: v.stopReason } : {}),
       };
-      state.lastFinished = finishedValue;
-      yield makeDone(state, mapFinishReason(v.stopReason));
-      state.emittedDone = true;
       return;
     }
     default:
@@ -390,8 +412,9 @@ function* mapValueEventComplex(
 /**
  * The 21-variant stream-event mapping table. Returns the public events
  * emitted for a single inner ServerAgentStreamEvent and mutates `state`
- * for terminal tracking (emittedDone / pendingDoneReason / lastFinished /
- * lastStop).
+ * for terminal tracking (pendingDoneReason / lastFinished / lastStop).
+ * It NEVER yields a `done`: terminal variants only record their reason so
+ * {@link mapLoopStream} can emit the single terminal event at loop end.
  * @pseudocode event-adapter.md steps 210-246: mapStreamEvent
  */
 function* mapStreamEvent(
@@ -421,8 +444,7 @@ function* mapStreamEvent(
   }
   // @pseudocode event-adapter.md steps 238-239: UserCancelled
   if (e.type === AgentEventType.UserCancelled) {
-    yield makeDone(state, 'aborted');
-    state.emittedDone = true;
+    state.pendingDoneReason = 'aborted';
     return;
   }
   // @pseudocode event-adapter.md step 240: AgentExecutionBlocked (NON-terminal)
@@ -431,10 +453,13 @@ function* mapStreamEvent(
     return;
   }
   // @pseudocode event-adapter.md steps 241-242: AgentExecutionStopped
+  // The AfterAgent hook can raise this from the same end-of-iteration flush
+  // that carries Finished, i.e. still before AgenticLoop schedules the
+  // turn's tools, so it records the stop and defers the done to loop end
+  // exactly like Finished does (@issue:3087).
   if (e.type === AgentEventType.AgentExecutionStopped) {
     state.lastStop = toStopInfo(e);
-    yield makeDone(state, 'hook-stopped');
-    state.emittedDone = true;
+    state.pendingDoneReason = 'hook-stopped';
     return;
   }
   // All value-bearing variants share the value discriminator.
@@ -442,9 +467,29 @@ function* mapStreamEvent(
 }
 
 /**
- * Drives an AgenticLoopEvent stream, projecting each to public AgentEvent(s)
- * and guaranteeing exactly one terminal `done` at loop end (unless the stream
- * consisted solely of a non-terminal AgentExecutionBlocked).
+ * Drives an AgenticLoopEvent stream, projecting each to public AgentEvent(s).
+ *
+ * Contract: AT MOST ONE `done` is emitted, and when it is emitted it is the
+ * FINAL public event of the stream. No terminal reason is projected where it
+ * arrives — the inner stream's terminal variants (Finished, UserCancelled,
+ * AgentExecutionStopped, Error, LoopDetected, MaxSessionTurns,
+ * ContextWindowWillOverflow, StreamIdleTimeout) only record their reason and
+ * payload in the adapter state. The loop stream ending is the sole honest
+ * signal that the agentic turn is over, because a model iteration that
+ * requested tools finishes — and flushes its Finished event — before those
+ * tools are scheduled (@issue:3087).
+ *
+ * No `done` is emitted when the stream carried no activity at all, i.e. an
+ * empty stream or one consisting solely of a non-terminal
+ * AgentExecutionBlocked.
+ *
+ * NOTE ON THE `@pseudocode` ANCHORS in this file: they point at
+ * project-plans/issue1594/analysis/pseudocode/event-adapter.md, which predates
+ * @issue:3087 and still describes an `emittedDone` flag plus immediate `done`
+ * projection from Finished / UserCancelled / AgentExecutionStopped. Those
+ * emission steps are SUPERSEDED by the single loop-end synthesis below; the
+ * anchors are retained only as a map of the projection table.
+ *
  * @pseudocode event-adapter.md steps 10-205: mapLoopStream
  */
 export async function* mapLoopStream(
@@ -452,7 +497,6 @@ export async function* mapLoopStream(
 ): AsyncIterable<AgentEvent> {
   // @pseudocode event-adapter.md steps 11-12: initialize state
   const state: AdapterState = {
-    emittedDone: false,
     lastFinished: null,
     lastStop: null,
     pendingDoneReason: null,
@@ -471,14 +515,19 @@ export async function* mapLoopStream(
     yield* mapLoopEvent(ev, state);
   }
 
-  // @pseudocode event-adapter.md steps 200-205: loop-end done synthesis
-  if (
-    !state.emittedDone &&
-    (state.sawActivity || state.pendingDoneReason !== null)
-  ) {
-    // A stronger pending terminal reason wins; otherwise derive the reason
-    // from any stored Finished value so a preserved refusal stopReason is
-    // honored even on the synthesized-completion path (@issue:2329).
+  // @pseudocode event-adapter.md steps 200-205: loop-end done synthesis —
+  // the single emission point for the public terminal event.
+  if (state.sawActivity || state.pendingDoneReason !== null) {
+    // An explicit terminal reason takes precedence over the Finished-derived
+    // one, because Finished only reports how a MODEL ITERATION ended while
+    // error / overflow / max-turns / loop-detected / aborted / hook-stopped
+    // report how the TURN ended. There is no priority ordering AMONG those
+    // explicit reasons: each branch assigns pendingDoneReason outright, so the
+    // last one recorded is the one reported.
+    //
+    // With no explicit reason the reason is derived from the stored Finished
+    // value, so a preserved refusal stopReason is honored on the
+    // synthesized-completion path (@issue:2329).
     const reason: DoneReason =
       state.pendingDoneReason ??
       mapFinishReason(state.lastFinished?.stopReason);
@@ -493,15 +542,9 @@ function* mapLoopEvent(
 ): Iterable<AgentEvent> {
   switch (ev.kind) {
     // @pseudocode event-adapter.md steps 32-36: stream
-    case 'stream': {
-      for (const pub of mapStreamEvent(ev.event, state)) {
-        if (pub.type === 'done') {
-          state.emittedDone = true;
-        }
-        yield pub;
-      }
+    case 'stream':
+      yield* mapStreamEvent(ev.event, state);
       return;
-    }
     // @pseudocode event-adapter.md steps 37-39: tool_update
     case 'tool_update': {
       for (const tc of ev.toolCalls) {

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.doneOrdering.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.doneOrdering.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the public AgentEvent `done` ordering contract
+ * (issue #3087).
+ *
+ * `mapLoopStream` must emit AT MOST ONE `done`, and when emitted it must be
+ * the FINAL public event of the stream. Before this fix, the inner
+ * `AgentEventType.Finished` (which means "this model iteration ended", not
+ * "the agentic turn ended") was mapped straight to a public `done`, so a
+ * tool-bearing turn emitted a premature `done` before the tool results and a
+ * duplicate `done` at loop end.
+ *
+ * These tests drive a real `AgenticLoop` with a real `CoreToolScheduler` and
+ * a real `MessageBus`; only the provider stream is scripted. They script the
+ * exact scenario from the issue: turn 1 requests a normal tool (`get_info`)
+ * then finishes; turn 2 just finishes.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from '../../../testApi.js';
+import { AgenticLoop } from '../AgenticLoop.js';
+import { MockTool } from '@vybestack/llxprt-code-core/test-utils/mock-tool.js';
+import { clearAllSchedulers } from '@vybestack/llxprt-code-core/config/schedulerSingleton.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import { mapLoopStream } from '../../../api/eventAdapter.js';
+import type { AgentEvent } from '../../../api/event-types.js';
+import {
+  createScriptedAgentClient,
+  createTestConfig,
+  createToolRegistryForTest,
+  createAskPolicyEngine,
+  toolCallRequestEvent,
+  finishedEvent,
+} from './agenticLoop-test-helpers.js';
+
+describe('AgenticLoop done ordering through mapLoopStream (issue #3087)', () => {
+  beforeEach(() => {
+    clearAllSchedulers();
+  });
+  afterEach(() => {
+    clearAllSchedulers();
+  });
+
+  it('emits exactly one done AFTER every tool event for a normal tool call then a clean finish', async () => {
+    const getInfoTool = new MockTool({
+      name: 'get_info',
+      execute: async () => ({
+        llmContent: 'info result',
+        returnDisplay: 'info result',
+      }),
+    });
+
+    const toolRegistry = createToolRegistryForTest([getInfoTool]);
+    const messageBus = new MessageBus(createAskPolicyEngine(), false);
+    const config = createTestConfig({
+      messageBus,
+      toolRegistry,
+      policyEngine: createAskPolicyEngine(),
+      interactive: true,
+      approvalMode: ApprovalMode.YOLO,
+    });
+
+    // Turn 1: model requests get_info, then finishes the iteration.
+    // Turn 2: model just finishes (clean completion).
+    const { client } = createScriptedAgentClient([
+      [toolCallRequestEvent('get_info', 'info-1', {}), finishedEvent()],
+      [finishedEvent()],
+    ]);
+
+    const loop = new AgenticLoop({
+      agentClient: client,
+      config,
+      messageBus,
+      interactiveMode: true,
+    });
+
+    const agentEvents: AgentEvent[] = [];
+    for await (const ev of mapLoopStream(
+      loop.run(
+        [{ type: 'text', text: 'get info' }],
+        new AbortController().signal,
+      ),
+    )) {
+      agentEvents.push(ev);
+    }
+
+    // Exactly one done event.
+    const doneEvents = agentEvents.filter((e) => e.type === 'done');
+    expect(doneEvents).toHaveLength(1);
+
+    // The single done is the LAST event in the stream.
+    const doneIndex = agentEvents.indexOf(doneEvents[0]);
+    expect(doneIndex).toBe(agentEvents.length - 1);
+
+    // Every tool-call, tool-status, and tool-result index is strictly less
+    // than the done index.
+    const toolEventIndices = agentEvents
+      .map((e, i) =>
+        e.type === 'tool-call' ||
+        e.type === 'tool-status' ||
+        e.type === 'tool-result'
+          ? i
+          : -1,
+      )
+      .filter((i) => i >= 0);
+
+    expect(toolEventIndices.length).toBeGreaterThan(0);
+    for (const idx of toolEventIndices) {
+      expect(idx).toBeLessThan(doneIndex);
+    }
+  });
+});

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.todoPause.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.todoPause.test.ts
@@ -249,18 +249,17 @@ describe('AgenticLoop pause loop-break (issue #2653)', () => {
     expect(turnMessages).toHaveLength(2);
   });
 
-  it('emits the terminal done BEFORE the todo_pause tool-result through mapLoopStream (issue #3071 ordering)', async () => {
-    // CHARACTERIZATION GUARD. The CLI observation tap
-    // (packages/cli/src/observation/observationTap.ts) opens the user_input
-    // wait for issue #3071 from onStreamSettled(), NOT from endTurn, precisely
-    // because the terminal `done` is emitted BEFORE the pause tool-result
-    // (turn.ts emits Finished on the provider chunk's finishReason, the
-    // deferred-events flush runs before the loop schedules the tool, and the
-    // adapter maps Finished to an immediate `done`). endTurn therefore runs on
-    // the early done while the pause has not yet been observed, so opening the
-    // wait there would be dead code. If this ordering ever changes (done after
-    // the result, or the result projected with an empty name / an error), the
-    // tap's onStreamSettled design must be revisited.
+  it('emits exactly one terminal done AFTER the todo_pause tool-result through mapLoopStream (issue #3087 ordering)', async () => {
+    // ORDERING GUARD. The public stream must publish exactly ONE `done` and
+    // it must be the LAST event, so that the turn's tool activity is fully
+    // reported before the turn is declared over. turn.ts emits Finished on the
+    // provider chunk's finishReason and MessageStreamOrchestrator flushes it
+    // before the loop schedules the tool, so the adapter deliberately does NOT
+    // project Finished to a `done` — it defers to the loop-end synthesis.
+    // The CLI observation tap
+    // (packages/cli/src/observation/observationTap.ts) depends on this: it
+    // opens the user_input wait from endTurn, which is only correct while the
+    // pause tool-result precedes the terminal `done`.
     const pauseTool = new MockTool({
       name: 'todo_pause',
       execute: async () => ({
@@ -302,7 +301,7 @@ describe('AgenticLoop pause loop-break (issue #2653)', () => {
       agentEvents.push(ev);
     }
 
-    const doneIndex = agentEvents.findIndex((e) => e.type === 'done');
+    const doneEvents = agentEvents.filter((e) => e.type === 'done');
     const pauseResult = agentEvents.find(
       (e): e is Extract<AgentEvent, { type: 'tool-result' }> =>
         e.type === 'tool-result' && e.result.name === 'todo_pause',
@@ -312,9 +311,11 @@ describe('AgenticLoop pause loop-break (issue #2653)', () => {
     expect(pauseResult).not.toBeUndefined();
     expect(pauseResult?.result.isError).toBe(false);
 
-    // CRITICAL ordering: the terminal `done` precedes the pause result.
-    expect(doneIndex).toBeGreaterThanOrEqual(0);
+    // CRITICAL: exactly one terminal `done`, and it follows the pause result.
+    expect(doneEvents).toHaveLength(1);
+    const doneIndex = agentEvents.indexOf(doneEvents[0]);
     const pauseResultIndex = agentEvents.indexOf(pauseResult!);
-    expect(doneIndex).toBeLessThan(pauseResultIndex);
+    expect(pauseResultIndex).toBeLessThan(doneIndex);
+    expect(doneIndex).toBe(agentEvents.length - 1);
   });
 });

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -591,10 +591,10 @@ function dispatchAgentEvent(
  * write, JSON accumulation, stream-JSON emission), preserving the user-visible
  * output, exit-code, and stderr behavior of the legacy manual turn loop.
  *
- * The loop emits a per-turn `done` (from `Finished`); when a tool is requested
- * the loop continues past it. This consumer records each `done` and acts only
- * on the final one at stream exhaustion — returning early would abandon the
- * generator mid-loop and prevent tool execution.
+ * The loop emits a single terminal `done` as its LAST event (issue #3087).
+ * This consumer still records it and acts on it only at stream exhaustion:
+ * returning early on `done` would abandon the generator instead of letting it
+ * complete.
  */
 export async function processAgentStream(
   events: AsyncIterable<AgentEvent>,

--- a/packages/cli/src/observation/jspWiring.ts
+++ b/packages/cli/src/observation/jspWiring.ts
@@ -305,17 +305,6 @@ export function observeTurnCancelled(): void {
   isolate(() => tap.onTurnEnded('cancelled'));
 }
 
-/**
- * Signal that the agent stream for the current turn has fully settled and
- * control has returned to the prompt. The terminal `done` event fires before
- * the turn's tool results arrive, so a pause that ends the turn is only
- * observable once the stream has settled. This is the hook that lets the tap
- * open a `user_input` wait at the honest moment (issue #3071).
- */
-export function observeTurnSettled(): void {
-  isolate(() => tap.onStreamSettled());
-}
-
 export function observeAgentEvent(event: AgentEvent): void {
   isolate(() => tap.processEvent(event));
 }

--- a/packages/cli/src/observation/observationTap.test.ts
+++ b/packages/cli/src/observation/observationTap.test.ts
@@ -400,22 +400,22 @@ describe('createObservationTap', () => {
     expect(phases).toStrictEqual(['awaiting_approval', 'cancelled']);
   });
 
-  // ─── pause tool opens a user_input wait (#3071) ────────────────────────
+  // ─── pause tool opens a user_input wait (#3071, ordering per #3087) ─────
   //
   // Production event ordering for a pause turn (recorded against the real
-  // AgenticLoop + CoreToolScheduler + the pause MockTool through mapLoopStream):
+  // AgenticLoop + CoreToolScheduler + the pause MockTool through mapLoopStream,
+  // see agenticLoop.todoPause.test.ts):
   //
   //   tool-call (pause tool)
-  //   done reason=stop            <- turn.ended fires here (early)
-  //   tool-status (pause):success
+  //   tool-status (pause):validating/scheduled/executing/success
   //   tool-result name="pause tool" isError=false
+  //   done reason=stop            <- the single terminal event, LAST
   //
-  // `done` arrives BEFORE the tool-result, so the user_input wait cannot open
-  // from endTurn (the pause has not been observed yet). It opens from
-  // onStreamSettled(), which runs once the stream — including the late result —
-  // has arrived. Every pause test below drives this ordering and the hook.
+  // Because `done` is genuinely terminal, endTurn sees the pause result
+  // already recorded and opens the user_input wait itself. Every pause test
+  // below drives this ordering.
 
-  it('opens a user_input wait after a successful todo_pause settles on a completed turn', () => {
+  it('opens a user_input wait when a successful todo_pause ends a completed turn', () => {
     const calls: string[] = [];
     const tap = createObservationTap({
       ...noopTarget(calls),
@@ -424,18 +424,17 @@ describe('createObservationTap', () => {
 
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent(pauseOkResultEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
-    // turn.ended is published first; the wait opens only once control has
-    // returned (after settle).
+    // turn.ended is published first; the wait opens immediately after, so a
+    // consumer never sees the agent claimed blocked before control returned.
     expect(calls[calls.length - 2]).toBe('turn.ended:completed');
     expect(calls[calls.length - 1]).toBe('wait.opened:user_input');
   });
 
-  it('does not open a wait when onStreamSettled runs before any pause', () => {
+  it('does not open a wait for a turn that ends without any pause', () => {
     const opened: string[] = [];
     const tap = createObservationTap({
       ...noopTarget([]),
@@ -444,7 +443,6 @@ describe('createObservationTap', () => {
 
     tap.onTurnStarted();
     tap.processEvent(doneEvent);
-    tap.onStreamSettled();
 
     expect(opened).toStrictEqual([]);
   });
@@ -458,7 +456,6 @@ describe('createObservationTap', () => {
 
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent({
       type: 'tool-result',
@@ -469,7 +466,7 @@ describe('createObservationTap', () => {
         isError: true,
       },
     } as AgentEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
     expect(opened).toStrictEqual([]);
   });
@@ -483,7 +480,6 @@ describe('createObservationTap', () => {
 
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent({
       type: 'tool-result',
@@ -494,7 +490,7 @@ describe('createObservationTap', () => {
         errorType: 'validation',
       },
     } as AgentEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
     expect(opened).toStrictEqual([]);
   });
@@ -513,7 +509,6 @@ describe('createObservationTap', () => {
 
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseCancelledStatusEvent);
     tap.processEvent({
       type: 'tool-result',
@@ -524,7 +519,7 @@ describe('createObservationTap', () => {
         isError: false,
       },
     } as AgentEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
     expect(opened).toStrictEqual([]);
   });
@@ -541,7 +536,6 @@ describe('createObservationTap', () => {
       type: 'tool-call',
       call: { id: 'pause-1', name: 'TODO_PAUSE', args: {} },
     } as AgentEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent({
       type: 'tool-status',
       update: { id: 'pause-1', name: 'TODO_PAUSE', status: 'success' },
@@ -555,16 +549,16 @@ describe('createObservationTap', () => {
         isError: false,
       },
     } as AgentEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
     expect(opened).toStrictEqual(['user_input']);
   });
 
   it('opens the wait via toolLabels correlation when the result name is empty', () => {
-    // A result whose projection carries name: '' is correlated through the
-    // call id. After the terminal done resets turn-scoped state, the
-    // intervening tool-status re-establishes the label correlation, so the
-    // empty result name still resolves to the pause tool.
+    // The raw a2a ToolCallResponse projection carries name: '' because only
+    // the loop-native tools_complete path knows the originating request. The
+    // label therefore has to come from the tool-call / tool-status
+    // correlation keyed by call id.
     const opened: string[] = [];
     const tap = createObservationTap({
       ...noopTarget([]),
@@ -573,13 +567,12 @@ describe('createObservationTap', () => {
 
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent({
       type: 'tool-result',
       result: { id: 'pause-1', name: '', output: 'paused', isError: false },
     } as AgentEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
     expect(opened).toStrictEqual(['user_input']);
   });
@@ -594,34 +587,31 @@ describe('createObservationTap', () => {
 
       tap.onTurnStarted();
       tap.processEvent(pauseToolCallEvent);
-      tap.processEvent({ type: 'done', reason } as AgentEvent);
       tap.processEvent(pauseSuccessStatusEvent);
       tap.processEvent(pauseOkResultEvent);
-      tap.onStreamSettled();
+      tap.processEvent({ type: 'done', reason } as AgentEvent);
 
       expect(opened).toStrictEqual([]);
     }
   });
 
-  it('does not reuse a completed outcome when the next turn settles without done', () => {
+  it('does not carry a pause across turns when the turn never receives a terminal done', () => {
     const opened: string[] = [];
     const tap = createObservationTap({
       ...noopTarget([]),
       onWaitOpened: (reason) => opened.push(reason),
     });
 
-    // Turn 1 completes normally and records a completed outcome.
-    tap.onTurnStarted();
-    tap.processEvent(doneEvent);
-    tap.onStreamSettled();
-
-    // Turn 2 observes a pause result but never receives its own terminal done.
-    // Its settle must not reuse Turn 1's completed outcome.
+    // Turn 1 observes a pause result but never receives its own terminal done,
+    // so no wait opens and the pause must not leak into the next turn.
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent(pauseOkResultEvent);
-    tap.onStreamSettled();
+
+    // Turn 2 completes normally with no pause of its own.
+    tap.onTurnStarted();
+    tap.processEvent(doneEvent);
 
     expect(opened).toStrictEqual([]);
   });
@@ -637,10 +627,9 @@ describe('createObservationTap', () => {
     // Turn 1: a pause opens a wait.
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent(pauseOkResultEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
     expect(calls).toContain('wait.opened:user_input');
 
     // Turn 2: the lingering pause wait resolves once, before turn.started.
@@ -652,13 +641,12 @@ describe('createObservationTap', () => {
     calls.length = 0;
     tap.onTurnStarted();
     tap.processEvent(toolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(okResultEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
     expect(calls.filter((c) => c === 'wait.resolved')).toStrictEqual([]);
   });
 
-  it('opens at most one pause wait per turn and survives a duplicate settle', () => {
+  it('opens at most one pause wait per turn when the turn contains two pauses', () => {
     const opened: string[] = [];
     const tap = createObservationTap({
       ...noopTarget([]),
@@ -667,7 +655,6 @@ describe('createObservationTap', () => {
 
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent(pauseOkResultEvent);
     tap.processEvent({
@@ -687,9 +674,7 @@ describe('createObservationTap', () => {
         isError: false,
       },
     } as AgentEvent);
-    tap.onStreamSettled();
-    // A duplicate settle must not open a second wait.
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
     expect(opened).toStrictEqual(['user_input']);
   });
@@ -708,13 +693,12 @@ describe('createObservationTap', () => {
     // The permission is never cleared (no executing/success status), so it is
     // stranded when the turn ends. Meanwhile, a pause also lands.
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent(pauseOkResultEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
-    // The stranded permission resolves (from resetTurnScopedState on done),
-    // then the turn ends, then the pause wait opens once settled -- in order.
+    // The stranded permission resolves (from resetTurnScopedState in endTurn),
+    // then the turn ends, then the pause wait opens -- in that order.
     expect(calls.slice(-3)).toStrictEqual([
       'wait.resolved',
       'turn.ended:completed',
@@ -733,19 +717,17 @@ describe('createObservationTap', () => {
     // Turn 1: pause opens a wait.
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent(pauseOkResultEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
     // Turn 2: another pause resolves the prior wait, then re-opens it.
     calls.length = 0;
     tap.onTurnStarted();
     tap.processEvent(pauseToolCallEvent);
-    tap.processEvent(doneEvent);
     tap.processEvent(pauseSuccessStatusEvent);
     tap.processEvent(pauseOkResultEvent);
-    tap.onStreamSettled();
+    tap.processEvent(doneEvent);
 
     expect(calls.filter((c) => c === 'wait.resolved')).toStrictEqual([
       'wait.resolved',
@@ -754,24 +736,21 @@ describe('createObservationTap', () => {
       'wait.opened',
     ]);
     // The wait resolves (on turn start) before turn.started, then re-opens
-    // after the second settle.
-    expect(calls).toContain('wait.resolved');
+    // once the second turn ends.
     expect(calls[calls.length - 1]).toBe('wait.opened');
   });
 
-  it('stays inert with observation disabled through the pause sequence including settle', () => {
+  it('stays inert with observation disabled through the pause sequence', () => {
     const tap = createObservationTap(null);
 
     expect(() => {
       tap.onTurnStarted();
       tap.processEvent(pauseToolCallEvent);
-      tap.processEvent(doneEvent);
       tap.processEvent(pauseSuccessStatusEvent);
       tap.processEvent(pauseOkResultEvent);
-      tap.onStreamSettled();
+      tap.processEvent(doneEvent);
       tap.onTurnStarted();
       tap.onTurnEnded('completed');
-      tap.onStreamSettled();
     }).not.toThrow();
   });
 });

--- a/packages/cli/src/observation/observationTap.ts
+++ b/packages/cli/src/observation/observationTap.ts
@@ -34,15 +34,6 @@ export interface ObservationTap {
   onTurnEnded(outcome: JspTurnOutcome): void;
   processEvent(event: AgentEvent): void;
   onFlushCommitted(content: string, committedMs: number): void;
-  /**
-   * The agent stream for the current turn has fully settled and control has
-   * returned to the prompt. This is distinct from `done`/`endTurn`: the
-   * terminal `done` event fires before the turn's tool results arrive, so a
-   * turn that ended with the pause tool still has its tool result pending at
-   * `endTurn`. Settled is the honest moment to decide whether a user_input
-   * wait should open, because every event the turn will produce has arrived.
-   */
-  onStreamSettled(): void;
 }
 
 /**
@@ -172,9 +163,10 @@ function routeToolEvent(
   if (event.type === 'tool-status') {
     const label = scope.toolLabels.get(event.update.id) ?? event.update.name;
     // Refresh the call-id → label correlation from the status update's name.
-    // The terminal `done` resets turn-scoped state (clearing toolLabels) before
-    // a turn's tool results arrive, so a result whose projection carries an
-    // empty name must be re-correlated from the intervening status updates.
+    // A `tool-result` projected from the raw a2a `ToolCallResponse` stream
+    // variant carries an EMPTY name (only the loop-native `tools_complete`
+    // path knows the originating request), so the label has to come from the
+    // `tool-call` or an intervening status update.
     if (event.update.name.length > 0) {
       scope.toolLabels.set(event.update.id, event.update.name);
     }
@@ -281,7 +273,6 @@ export function createObservationTap(
       onTurnEnded: () => undefined,
       processEvent: () => undefined,
       onFlushCommitted: () => undefined,
-      onStreamSettled: () => undefined,
     };
   }
   const scope: TurnScope = {
@@ -322,31 +313,34 @@ export function createObservationTap(
   };
 
   /**
-   * A turn can now be closed from three places: a terminal `done` event, the
+   * A turn can be closed from three places: the terminal `done` event, the
    * submit path's failure handler, and the interactive cancel handler. Only the
    * first of those may take effect, or the observer would see several ends for
    * one turn. Ending a turn that was never started is likewise a no-op.
    *
-   * The wait is NOT opened here. The terminal `done` event fires before the
-   * turn's tool results arrive (the scheduler flushes deferred Finished events
-   * before scheduling tools), so at this point a pause result has not
-   * been observed yet. Opening the wait here would be dead code. The wait opens
-   * in `onStreamSettled`, which runs once the stream — including those late
-   * results — has fully arrived.
+   * This is also where a pause-ended turn opens its `user_input` wait. The
+   * public stream emits exactly one `done` and it is the LAST event of the
+   * turn (issue #3087), so by the time a `done` reaches here every tool result
+   * — including a pause's — has already been observed. `turn.ended` is
+   * published FIRST and the wait second: the wait must not claim the agent is
+   * blocked on a human before control has actually returned. The two are
+   * separate revisions, so a consumer sampling between them momentarily sees
+   * the idle state.
    */
   let turnOpen = false;
-  let lastOutcome: JspTurnOutcome | null = null;
   const endTurn = (outcome: JspTurnOutcome): void => {
     if (!turnOpen) {
       return;
     }
     turnOpen = false;
+    // Read the pause flag before the reset clears it.
+    const pauseEndedTurn = scope.successfulPauseObserved;
     resetTurnScopedState();
-    // Record the outcome before publishing turn.ended so onStreamSettled (which
-    // runs after the turn's tool results arrive) can gate the user_input wait
-    // on the turn's actual outcome rather than re-deriving it.
-    lastOutcome = outcome;
     target.onTurnEnded(outcome);
+    if (pauseEndedTurn && outcome === 'completed' && !pauseWaitOpen) {
+      target.onWaitOpened('user_input');
+      pauseWaitOpen = true;
+    }
   };
 
   return {
@@ -360,7 +354,6 @@ export function createObservationTap(
         pauseWaitOpen = false;
       }
       resetTurnScopedState();
-      lastOutcome = null;
       turnOpen = true;
       target.onTurnStarted();
     },
@@ -373,26 +366,6 @@ export function createObservationTap(
     onFlushCommitted(content: string, committedMs: number): void {
       if (content.length > 0) {
         target.onAssistantMessageCommitted(content, committedMs);
-      }
-    },
-    onStreamSettled(): void {
-      // The stream has settled: every event the turn will produce — including
-      // the tool results that arrive after the terminal `done` — has arrived.
-      // Only now can a successful pause be observed truthfully, so this is
-      // the honest moment to open the user_input wait.
-      //
-      // turn.ended (published by endTurn on the early `done`) and wait.opened
-      // are published as two separate revisions, so a consumer sampling between
-      // them momentarily sees the idle state. Ordering (turn.ended first) is
-      // still correct: the wait must not claim the agent is blocked before
-      // control has actually returned.
-      if (
-        scope.successfulPauseObserved &&
-        lastOutcome === 'completed' &&
-        !pauseWaitOpen
-      ) {
-        target.onWaitOpened('user_input');
-        pauseWaitOpen = true;
       }
     },
   };

--- a/packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts
@@ -44,7 +44,6 @@ import type { StreamRuntime, UiSubagentManager } from '../../cliUiRuntime.js';
 import {
   observeAgentEvent,
   observeTurnFailed,
-  observeTurnSettled,
   observeTurnStarted,
 } from '../../../observation/jspWiring.js';
 
@@ -717,14 +716,6 @@ async function runSubmitQueryCore(
       } catch {
         /* non-fatal */
       }
-    }
-    // The stream has settled: every event for this turn, including tool
-    // results that arrive after the terminal `done`, has been processed. This
-    // is the honest moment a pause-ended turn can open a user_input
-    // wait (issue #3071). Guarded so a superseded turn cannot open a wait for
-    // a turn that no longer owns the controller.
-    if (isCurrentTurn(cbd, turn.abortSignal)) {
-      observeTurnSettled();
     }
   }
 }

--- a/packages/cli/src/ui/hooks/useAgentStream-test-helpers.ts
+++ b/packages/cli/src/ui/hooks/useAgentStream-test-helpers.ts
@@ -94,7 +94,6 @@ function mapRawStream(
     // Mirror the real mapLoopStream adapter state (eventAdapter.ts) so the
     // test helper's done-synthesis matches production behavior.
     const state: Parameters<typeof mapStreamEvent>[1] = {
-      emittedDone: false,
       lastFinished: null,
       lastStop: null,
       pendingDoneReason: null,
@@ -102,28 +101,21 @@ function mapRawStream(
     };
     for await (const rawEvent of rawStream) {
       // sawActivity gate: set true for any event that is not a standalone
-      // AgentExecutionBlocked (mirrors eventAdapter.ts:405-410).
+      // AgentExecutionBlocked (mirrors eventAdapter.ts).
       const isStandaloneBlocked =
         (rawEvent as { type?: string }).type === 'AgentExecutionBlocked';
       if (!isStandaloneBlocked) {
         state.sawActivity = true;
       }
-      for (const pub of mapStreamEvent(
+      yield* mapStreamEvent(
         rawEvent as Parameters<typeof mapStreamEvent>[0],
         state,
-      )) {
-        if (pub.type === 'done') {
-          state.emittedDone = true;
-        }
-        yield pub;
-      }
+      );
     }
-    // Loop-end done synthesis: only yield a synthetic done if we saw real
-    // activity or have a pending done reason (mirrors eventAdapter.ts:415-427).
-    if (
-      !state.emittedDone &&
-      (state.sawActivity || state.pendingDoneReason !== null)
-    ) {
+    // Loop-end done synthesis: the SOLE done emission point, and only when we
+    // saw real activity or have a pending done reason (mirrors
+    // eventAdapter.ts).
+    if (state.sawActivity || state.pendingDoneReason !== null) {
       const reason =
         state.pendingDoneReason ??
         (state.lastFinished?.stopReason === 'refusal' ? 'refusal' : 'stop');

--- a/packages/cli/src/ui/hooks/useAgentStream-test-helpers.ts
+++ b/packages/cli/src/ui/hooks/useAgentStream-test-helpers.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IContent } from '@vybestack/llxprt-code-core';
+import { AgentEventType } from '@vybestack/llxprt-code-core';
 
 import { vi } from 'vitest';
 import type {
@@ -101,9 +102,12 @@ function mapRawStream(
     };
     for await (const rawEvent of rawStream) {
       // sawActivity gate: set true for any event that is not a standalone
-      // AgentExecutionBlocked (mirrors eventAdapter.ts).
+      // AgentExecutionBlocked (mirrors eventAdapter.ts). Compared against the
+      // enum member, not its name: the discriminant on the wire is the enum
+      // VALUE ('agent_execution_blocked').
       const isStandaloneBlocked =
-        (rawEvent as { type?: string }).type === 'AgentExecutionBlocked';
+        (rawEvent as { type?: string }).type ===
+        AgentEventType.AgentExecutionBlocked;
       if (!isStandaloneBlocked) {
         state.sawActivity = true;
       }
@@ -125,6 +129,9 @@ function mapRawStream(
         ...(state.lastFinished !== null
           ? { finished: state.lastFinished }
           : {}),
+        // AgentExecutionStopped now defers its done to this synthesis, so the
+        // stop payload has to be carried here too (mirrors makeDone).
+        ...(state.lastStop !== null ? { stop: state.lastStop } : {}),
       } as AgentEvent;
     }
   })();

--- a/project-plans/issue3087/PLAN.md
+++ b/project-plans/issue3087/PLAN.md
@@ -1,0 +1,151 @@
+# Issue #3087 — Public `AgentEvent` stream emits `done` before tool activity, and twice on tool turns
+
+## 1. Defect
+
+`packages/agents/src/api/eventAdapter.ts` maps an inner `AgentEventType.Finished`
+straight to a public `done`. `Finished` means "this **model iteration** ended",
+not "the agentic turn ended":
+
+- `packages/agents/src/core/turn.ts` emits `Finished` for every provider chunk
+  carrying a `finishReason`, including tool-call turns.
+- `TodoContinuationService.shouldDeferStreamEvent` defers `Finished`;
+  `MessageStreamOrchestrator._finishWithToolCalls` flushes the deferred events
+  at the end of the model iteration — i.e. **before** `AgenticLoop` schedules
+  the turn's tools.
+- The adapter's `Finished` branch yields `makeDone(...)` unconditionally, so a
+  second iteration produces a second `done`. Only the loop-end synthesis path
+  is guarded by `!state.emittedDone`.
+
+Observed public order for one tool call followed by a normal finish:
+
+    tool-call get_info
+    done reason=stop            <- premature
+    tool-status get_info:validating/scheduled/executing/success
+    tool-result get_info
+    done reason=stop            <- duplicate
+
+The same defect shape exists for `AgentEventType.AgentExecutionStopped`, which
+`MessageStreamOrchestrator._finishWithToolCalls` can emit from the AfterAgent
+hook immediately after the deferred `Finished` and still before tool
+scheduling. Its adapter branch also yields `done` unconditionally, so a
+hook-clearing turn emits two `done` events **both** before tool activity.
+
+## 2. Accepted behavior
+
+**Contract:** `mapLoopStream` emits **at most one** `done`, and when it is
+emitted it is the **final** public event of the stream.
+
+Concretely:
+
+- `AgentEventType.Finished` no longer yields `done`. It records the
+  `FinishedValue` (`reason`, `usageMetadata`, `stopReason`) in adapter state.
+- `AgentEventType.UserCancelled` no longer yields `done`. It records the
+  pending done reason `aborted`.
+- `AgentEventType.AgentExecutionStopped` no longer yields `done`. It records
+  `lastStop` and the pending done reason `hook-stopped`.
+- The existing loop-end synthesis becomes the **single** `done` emitter. Its
+  reason is `pendingDoneReason ?? mapFinishReason(lastFinished?.stopReason)`,
+  i.e. a stronger terminal reason (`error`, `context-overflow`, `max-turns`,
+  `loop-detected`, `aborted`, `hook-stopped`) wins over the `Finished`-derived
+  `stop` / `refusal`, exactly as the synthesis path already does today.
+- The `done` payload keeps carrying `finished` (from the most recent
+  `Finished`) and `stop` (from the most recent `AgentExecutionStopped`) — the
+  same `makeDone` projection used today. One refinement is required to keep
+  the payload equivalent: a provider reports `usageMetadata` only on the
+  iterations whose terminal chunk carries token counts, and with one `done`
+  per iteration consumers kept the last **defined** usage (see `drainToResult`
+  in `agentBootstrap.ts`). `state.lastFinished` therefore carries the most
+  recently reported `usageMetadata` forward when a later `Finished` reports
+  none, so collapsing to a single `done` cannot blank token accounting. A
+  later `Finished` that *does* report usage still overrides it.
+- The emission gate is unchanged: `sawActivity || pendingDoneReason !== null`.
+  A stream consisting solely of a non-terminal `AgentExecutionBlocked` still
+  yields **no** `done`; an entirely empty stream still yields no `done`.
+- `state.emittedDone` becomes unreachable once every branch defers, so it is
+  removed rather than left as a dead guard. The `if (pub.type === 'done')`
+  book-keeping in `mapLoopEvent` goes with it.
+
+**Consumer follow-through required by the issue (in scope):**
+
+- `packages/cli/src/observation/observationTap.ts` — `endTurn` now runs after
+  the turn's tool results, so a successful `todo_pause` **is** observable at
+  turn close. The `user_input` wait moves back into `endTurn` (published after
+  `turn.ended`, preserving today's ordering). The `onStreamSettled` seam and
+  its `lastOutcome` bookkeeping, which existed only because `done` was early,
+  are removed along with `observeTurnSettled` in
+  `packages/cli/src/observation/jspWiring.ts` and its `useSubmitQuery.ts`
+  call site.
+- The characterization test
+  `packages/agents/src/core/agenticLoop/__tests__/agenticLoop.todoPause.test.ts`
+  ("emits the terminal done BEFORE the todo_pause tool-result …") pinned the
+  defect. It is rewritten to assert the corrected ordering.
+- `packages/cli/src/ui/hooks/useAgentStream-test-helpers.ts` and
+  `packages/agents/src/api/__tests__/helpers/eventAdapterStatic.ts` mirror the
+  private `AdapterState`; both are updated to the new shape.
+
+## 3. Explicitly out of scope
+
+- Changing when `turn.ts` emits `Finished`, when
+  `TodoContinuationService.shouldDeferStreamEvent` defers it, or when
+  `MessageStreamOrchestrator._finishWithToolCalls` flushes it. The inner
+  stream keeps its per-iteration semantics; only the **public** projection
+  changes.
+- Whether `AgentExecutionStopped` should stop the `AgenticLoop` (today it does
+  not appear in `isTerminalStreamOutcome`). Only its `done` projection moves.
+- Accumulating `usageMetadata` across iterations. `state.lastFinished` already
+  keeps only the most recent `Finished` today, and today's terminal `done` for
+  a multi-iteration turn already carries that same most-recent value.
+
+## 4. Boundary cases the tests must cover
+
+| Case | Expected public stream |
+| --- | --- |
+| One tool call, then a normal finish (2 model iterations) | exactly one `done{stop}`, strictly after every `tool-call` / `tool-status` / `tool-result` |
+| Turn ended by a successful `todo_pause` | exactly one `done{stop}`, strictly after the `todo_pause` `tool-result` |
+| Single iteration, `Finished` only | one `done{stop}` (unchanged) |
+| `Finished` with `stopReason: 'refusal'` | one `done{refusal}` carrying `finished.stopReason === 'refusal'` (unchanged) |
+| `Finished` with a non-refusal `stopReason` | one `done{stop}` carrying that `stopReason` (unchanged) |
+| `UserCancelled` | one `done{aborted}`, last (unchanged reason) |
+| `AgentExecutionStopped` | one `done{hook-stopped}` carrying `stop`, last (unchanged reason) |
+| `AgentExecutionStopped` emitted on a tool iteration (hook context-clear) | exactly one `done{hook-stopped}`, after the tool events |
+| `Error` / `StreamIdleTimeout` / `ContextWindowWillOverflow` / `LoopDetected` / `MaxSessionTurns` | one `done` with the stronger reason, last (unchanged) |
+| `Error` then a later `Finished` | one `done{error}` (the stronger pending reason still wins) |
+| `AgentExecutionStopped` then a later `Finished` | one `done{hook-stopped}` (the explicit terminal signal stays authoritative) |
+| Content-only stream, no terminal event | one synthesized `done{stop}`, last (unchanged) |
+| Standalone `AgentExecutionBlocked` only | **no** `done` (unchanged) |
+| Empty loop stream | **no** events at all (unchanged) |
+| `Finished` with usage, then a `Finished` without | the `done` carries the earlier reported usage |
+| `Finished` with usage, then a `Finished` with different usage | the `done` carries the later usage |
+
+## 5. Test plan (test-first, behavioral, per dev-docs/RULES.md)
+
+All new/changed tests use `bun:test` (via `packages/agents/src/testApi.ts`
+inside the agents package). No mock theater: the ordering tests drive the real
+`AgenticLoop` with a real `CoreToolScheduler` and a real `MessageBus`; only the
+provider stream is scripted.
+
+1. **`packages/agents/src/core/agenticLoop/__tests__/agenticLoop.todoPause.test.ts`**
+   - Replace the characterization test with:
+     "emits exactly one terminal done AFTER the todo_pause tool-result through
+     mapLoopStream (issue #3087)" — asserts `done` count is 1 and its index is
+     greater than the pause `tool-result` index and is the last event.
+2. **New `packages/agents/src/core/agenticLoop/__tests__/agenticLoop.doneOrdering.test.ts`**
+   - Real loop + real scheduler, one normal tool call then a clean finish:
+     asserts exactly one `done`, that it is the final event, and that every
+     `tool-call` / `tool-status` / `tool-result` precedes it.
+3. **`packages/agents/src/api/__tests__/event-adapter-projection.spec.ts`** —
+   synthetic `AgenticLoopEvent` streams through the real `mapLoopStream` for
+   the table in §4, including the `AgentExecutionStopped`-on-a-tool-iteration
+   case, the `Error`-then-`Finished` and
+   `AgentExecutionStopped`-then-`Finished` precedence cases, the empty stream,
+   and both usage-carry-forward cases.
+4. **`packages/cli/src/observation/observationTap.test.ts`** — rewritten pause
+   tests drive the corrected ordering (`tool-call`, `tool-status`,
+   `tool-result`, then `done`) and assert `turn.ended:completed` is published
+   before `wait.opened:user_input`, with no `onStreamSettled` call.
+
+## 6. Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, and
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.


### PR DESCRIPTION
## TLDR

The public `AgentEvent` stream emitted `done` **before** a turn's tool activity, and **again** at the end of any turn that called a tool. This makes the single terminal `done` the last event of the stream.

`AgentEventType.Finished` means "this **model iteration** ended", not "the agentic turn ended". `packages/agents/src/core/turn.ts` emits it for every provider chunk carrying a `finishReason` (tool-call turns included), and `MessageStreamOrchestrator._finishWithToolCalls` flushes the deferred `Finished` at the end of the model iteration — before `AgenticLoop` schedules the turn's tools. `eventAdapter.ts` projected it straight to a public `done`.

Reviewers should look at three things: the new adapter contract in `mapLoopStream`, the `usageMetadata` carry-forward (see Dive Deeper), and the observation-tap rework that issue #3087 explicitly asked for in-scope.

## Dive Deeper

### The defect

Observed public order for one tool call followed by a normal finish:

    tool-call get_info
    done reason=stop            <- premature
    tool-status get_info:validating / scheduled / executing / success
    tool-result get_info
    done reason=stop            <- duplicate

The adapter's `Finished` branch yielded `makeDone(...)` unconditionally and set `state.emittedDone`; only the loop-end synthesis was guarded by `!state.emittedDone`, so a second iteration produced a second `done`. `AgentEventType.AgentExecutionStopped` (raised by the AfterAgent hook from the same end-of-iteration flush) had the identical defect.

### The fix

Every terminal variant in `packages/agents/src/api/eventAdapter.ts` now only **records** its reason and payload; the pre-existing loop-end synthesis becomes the single `done` emitter.

**Contract:** `mapLoopStream` emits **at most one** `done`, and when emitted it is the **final** public event of the stream.

- `Finished` records the `FinishedValue`.
- `UserCancelled` records `pendingDoneReason = 'aborted'`.
- `AgentExecutionStopped` records `lastStop` and `pendingDoneReason = 'hook-stopped'`.
- The synthesis reason stays `pendingDoneReason ?? mapFinishReason(lastFinished?.stopReason)`: an explicit terminal reason (how the **turn** ended) takes precedence over the `Finished`-derived one (how a **model iteration** ended). There is no priority ordering *among* the explicit reasons — each branch assigns outright, so the last recorded is reported. The comment in the code now says exactly that; it previously claimed a strength ordering that never existed.
- `state.emittedDone` became unreachable and is **removed** rather than left as a dead guard.

The "no `done`" cases are unchanged: an empty stream, or one consisting solely of a non-terminal `AgentExecutionBlocked`.

### Preserving token accounting

Collapsing to one `done` would have silently blanked usage reporting. Providers report `usageMetadata` only on the iterations whose terminal chunk carries token counts (pinned by `usageMetadata.characterization.spec.ts`), and with one `done` per iteration consumers kept the last **defined** usage — `drainToResult` in `agentBootstrap.ts` guards its assignment with `if (event.finished?.usageMetadata !== undefined)`. A turn whose first iteration reported usage and whose last did not would therefore have gone from populated `AgentResult.usage` to `undefined`.

`state.lastFinished` now carries the most recently reported `usageMetadata` forward when a later `Finished` reports none. A later `Finished` that *does* report usage still overrides it. Both directions have a test.

### Observation-tap rework (required in-scope by the issue)

`packages/cli/src/observation/observationTap.ts` was deliberately built around the broken ordering: because `done` arrived before the pause tool-result, opening the `user_input` wait from `endTurn` would have been dead code, so #3071 added an `onStreamSettled` seam driven from the submit path's `finally` block.

`done` is now genuinely terminal, so:

- the `user_input` wait opens in `endTurn`, published **after** `turn.ended` (the wait must not claim the agent is blocked before control has returned);
- `onStreamSettled` and the `lastOutcome` bookkeeping that existed only to serve it are removed, along with `observeTurnSettled` in `jspWiring.ts` and its `useSubmitQuery.ts` call site.

The other turn-closing paths were checked and are unaffected: the submit failure handler closes `failed` and the interactive cancel handler closes `cancelled`, neither of which can open a pause wait (the gate requires `completed`). A late `done` after either is still swallowed by the pre-existing `turnOpen` guard.

Two now-false comments were corrected rather than left behind: the `routeToolEvent` re-correlation comment (an empty result name comes from the raw a2a `ToolCallResponse` projection, not from a state reset) and the `processAgentStream` comment in `nonInteractiveCliSupport.ts`.

### Consumer impact

No consumer breaks out of the stream on `done`, so none is cut short by the change:

- **`drainToResult`** drains fully; `finishReason` now comes from one final `done`, and an explicit `error` / `aborted` / `hook-stopped` is no longer overwritten by a later iteration's `stop`. Usage is preserved by the carry-forward above.
- **CLI dispatcher** does the pending-content flush, finish notice and buffer reset once at turn end. Content-above-tools ordering does not depend on the early `done`: `useAgentEventStream.handleToolsComplete` already flushes pending AI content before the tool group.
- **Zed** stores the latest stop reason and keeps iterating; tool events now arrive before the terminal state.
- **Non-interactive CLI** already recorded `done` into `pendingDone` and acted on it only at exhaustion.

### Deliberately out of scope

The inner stream keeps its per-iteration semantics: this does not change when `turn.ts` emits `Finished`, when `TodoContinuationService.shouldDeferStreamEvent` defers it, or when `MessageStreamOrchestrator._finishWithToolCalls` flushes it. Only the **public** projection changes. Whether `AgentExecutionStopped` should terminate the `AgenticLoop` (it is not in `isTerminalStreamOutcome` today) is untouched, as is any notion of summing usage across iterations.

## Reviewer Test Plan

The fastest confirmation is the new real-loop test, which drives a real `AgenticLoop` with a real `CoreToolScheduler` and a real `MessageBus` through `mapLoopStream` and scripts exactly the scenario in the issue (turn 1 requests `get_info` then finishes; turn 2 finishes):

    cd packages/agents
    bun test src/core/agenticLoop/__tests__/agenticLoop.doneOrdering.test.ts
    bun test src/core/agenticLoop/__tests__/agenticLoop.todoPause.test.ts
    bun test src/api/__tests__/event-adapter-projection.spec.ts

    cd ../cli
    bun test src/observation/observationTap.test.ts

To see the defect, stash the `eventAdapter.ts` change and re-run `agenticLoop.doneOrdering.test.ts`: it reports two `done` events, the first before the tool was scheduled.

Interactive check for the observation-tap half: run the CLI with observation enabled, give the agent a task it will end with the pause tool, and confirm the observer reports `turn.ended` **after** the pause tool phases and then opens a `user_input` wait — rather than ending the turn before any tool phase for that turn.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the `bun scripts/start.ts --profile-load stepfun-37` smoke test.

## Linked issues / bugs

Fixes #3087

Revisits the `onStreamSettled` seam introduced for #3071, as that issue's follow-up note required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured agent streams emit exactly one terminal completion event, always after tool activity and as the final event.
  - Preserved token usage details across multi-step runs and applied the correct completion reason for cancellations or interruptions.
  - Improved handling of empty, cancelled, failed, and incomplete streams.
  - Corrected pause-tool behavior so user-input waits appear only after successful, completed pauses.
- **Documentation**
  - Clarified stream completion and terminal-event behavior for integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->