### PR TITLE
Coalesce thinking blocks by streamId to stop unbounded history growth (Fixes #3111)

### DIFF
--- a/packages/agents/src/core/streamOutputAccumulator.bun.test.ts
+++ b/packages/agents/src/core/streamOutputAccumulator.bun.test.ts
@@ -1,0 +1,325 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for StreamOutputAccumulator thinking-block coalescing
+ * (issue #3111).
+ *
+ * Anthropic streams re-emit the *full accumulated* thought on every
+ * `thinking_delta` (streamStatus: 'delta'), then a single
+ * streamStatus: 'complete' block closes the span. The accumulator must keep
+ * only the latest block per `streamId` (see IContent.ThinkingBlock) instead of
+ * appending every delta, otherwise a long session retains N copies of an
+ * O(L)-byte thought per span — unbounded growth.
+ *
+ * These tests exercise the public add()/materialize() API with real blocks; no
+ * component is mocked.
+ *
+ * @plan issue3111
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type {
+  ModelStreamChunk,
+  ModelOutput,
+} from '@vybestack/llxprt-code-core/llm-types/index.js';
+import type {
+  ThinkingBlock,
+  TextBlock,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { StreamOutputAccumulator } from './streamOutputAccumulator.js';
+
+function chunk(
+  blocks: ModelStreamChunk['content']['blocks'],
+): ModelStreamChunk {
+  return { content: { speaker: 'ai', blocks } };
+}
+
+function thinking(partial: {
+  thought: string;
+  streamId: string;
+  streamStatus: 'delta' | 'complete';
+  signature?: string;
+  encryptedContent?: string;
+}): ThinkingBlock {
+  return { type: 'thinking', sourceField: 'thinking', ...partial };
+}
+
+function text(t: string): TextBlock {
+  return { type: 'text', text: t };
+}
+
+function thinkingBlocks(output: ModelOutput): ThinkingBlock[] {
+  return output.content.blocks.filter(
+    (b): b is ThinkingBlock => b.type === 'thinking',
+  );
+}
+
+describe('StreamOutputAccumulator thinking-block coalescing (issue #3111)', () => {
+  it('accumulates non-thinking blocks verbatim and in order', () => {
+    const accumulator = new StreamOutputAccumulator();
+    accumulator.add(chunk([text('Hello')]));
+    accumulator.add(chunk([text(' world')]));
+    accumulator.add(
+      chunk([{ type: 'tool_call', id: 't1', name: 'ls', parameters: {} }]),
+    );
+
+    const result = accumulator.materialize();
+    expect(result.content.blocks).toHaveLength(3);
+    expect(result.content.speaker).toBe('ai');
+  });
+
+  it('coalesces the delta updates of one thinking span into a single block', () => {
+    const accumulator = new StreamOutputAccumulator();
+    const streamId = 'anthropic-thinking:0:block-0';
+    // Simulate the leaky emission: each delta carries the full-so-far thought.
+    accumulator.add(
+      chunk([thinking({ thought: 'One', streamId, streamStatus: 'delta' })]),
+    );
+    accumulator.add(
+      chunk([
+        thinking({ thought: 'One Two', streamId, streamStatus: 'delta' }),
+      ]),
+    );
+    accumulator.add(
+      chunk([
+        thinking({ thought: 'One Two Three', streamId, streamStatus: 'delta' }),
+      ]),
+    );
+    // The closing block carries the final signature.
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'One Two Three',
+          streamId,
+          streamStatus: 'complete',
+          signature: 'sig-0',
+        }),
+      ]),
+    );
+
+    const blocks = thinkingBlocks(accumulator.materialize());
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].thought).toBe('One Two Three');
+    expect(blocks[0].streamStatus).toBe('complete');
+    expect(blocks[0].signature).toBe('sig-0');
+  });
+
+  it('coalesces each thinking span independently and preserves span order', () => {
+    const accumulator = new StreamOutputAccumulator();
+    const a = 'anthropic-thinking:0:block-0';
+    const b = 'anthropic-thinking:0:block-1';
+    accumulator.add(chunk([text('start')]));
+    accumulator.add(
+      chunk([thinking({ thought: 'A1', streamId: a, streamStatus: 'delta' })]),
+    );
+    accumulator.add(
+      chunk([thinking({ thought: 'B1', streamId: b, streamStatus: 'delta' })]),
+    );
+    accumulator.add(
+      chunk([thinking({ thought: 'A2', streamId: a, streamStatus: 'delta' })]),
+    );
+    accumulator.add(
+      chunk([thinking({ thought: 'B2', streamId: b, streamStatus: 'delta' })]),
+    );
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'A2',
+          streamId: a,
+          streamStatus: 'complete',
+          signature: 'sa',
+        }),
+      ]),
+    );
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'B2',
+          streamId: b,
+          streamStatus: 'complete',
+          signature: 'sb',
+        }),
+      ]),
+    );
+    accumulator.add(chunk([text('end')]));
+
+    const result = accumulator.materialize();
+    // Order: start, thinking-a, thinking-b, end  (each span keeps its first position).
+    expect(result.content.blocks.map((b) => b.type)).toEqual([
+      'text',
+      'thinking',
+      'thinking',
+      'text',
+    ]);
+    const spans = thinkingBlocks(result);
+    expect(spans).toHaveLength(2);
+    expect(spans[0]).toMatchObject({
+      streamId: a,
+      thought: 'A2',
+      signature: 'sa',
+    });
+    expect(spans[1]).toMatchObject({
+      streamId: b,
+      thought: 'B2',
+      signature: 'sb',
+    });
+  });
+
+  it('bounds retained thinking to one block regardless of delta count', () => {
+    const accumulator = new StreamOutputAccumulator();
+    const streamId = 'anthropic-thinking:0:block-0';
+    const deltaCount = 250;
+    for (let i = 1; i <= deltaCount; i++) {
+      accumulator.add(
+        chunk([
+          thinking({
+            thought: `delta ${i}`.repeat(1000),
+            streamId,
+            streamStatus: 'delta',
+          }),
+        ]),
+      );
+    }
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'final',
+          streamId,
+          streamStatus: 'complete',
+          signature: 's',
+        }),
+      ]),
+    );
+
+    const blocks = thinkingBlocks(accumulator.materialize());
+    // Before the fix this was deltaCount + 1 blocks; it must be exactly one.
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].thought).toBe('final');
+  });
+
+  it('coalesces both Anthropic and OpenAI-Responses streamId formats', () => {
+    // The accumulator is provider-agnostic: it matches the streamId string, so
+    // both critical reasoning emitters collapse each span to its final block:
+    //   - Anthropic: `anthropic-thinking:<src>:block-<n>` (complete carries signature)
+    //   - OpenAI Responses: `openai-responses-reasoning:<n>` (complete carries encryptedContent)
+    const accumulator = new StreamOutputAccumulator();
+    const anthropic = 'anthropic-thinking:0:block-0';
+    const responses = 'openai-responses-reasoning:0';
+
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'A-1',
+          streamId: anthropic,
+          streamStatus: 'delta',
+        }),
+      ]),
+    );
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'A-1 A-2',
+          streamId: anthropic,
+          streamStatus: 'delta',
+        }),
+      ]),
+    );
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'A-1 A-2',
+          streamId: anthropic,
+          streamStatus: 'complete',
+          signature: 'sig-A',
+        }),
+      ]),
+    );
+
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'R-1',
+          streamId: responses,
+          streamStatus: 'delta',
+        }),
+      ]),
+    );
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'R-1 R-2',
+          streamId: responses,
+          streamStatus: 'delta',
+        }),
+      ]),
+    );
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: 'R-1 R-2',
+          streamId: responses,
+          streamStatus: 'complete',
+          encryptedContent: 'enc-R',
+        }),
+      ]),
+    );
+
+    const spans = thinkingBlocks(accumulator.materialize());
+    expect(spans).toHaveLength(2);
+    expect(spans[0]).toMatchObject({
+      streamId: anthropic,
+      thought: 'A-1 A-2',
+      signature: 'sig-A',
+      streamStatus: 'complete',
+    });
+    expect(spans[1]).toMatchObject({
+      streamId: responses,
+      thought: 'R-1 R-2',
+      encryptedContent: 'enc-R',
+      streamStatus: 'complete',
+    });
+  });
+
+  it('appends (does not coalesce) thinking blocks that lack a streamId', () => {
+    const accumulator = new StreamOutputAccumulator();
+    // No streamId -> the coalescing guard (typeof streamId === 'string') is
+    // false, so each block is appended verbatim. This is the fallback path for
+    // providers that emit thinking without streaming metadata.
+    accumulator.add(
+      chunk([{ type: 'thinking', sourceField: 'thinking', thought: 'A' }]),
+    );
+    accumulator.add(
+      chunk([{ type: 'thinking', sourceField: 'thinking', thought: 'B' }]),
+    );
+
+    const blocks = thinkingBlocks(accumulator.materialize());
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].thought).toBe('A');
+    expect(blocks[1].thought).toBe('B');
+  });
+
+  it('retains the last delta when a thinking span never receives complete', () => {
+    const accumulator = new StreamOutputAccumulator();
+    const streamId = 'anthropic-thinking:0:block-0';
+    // Stream interrupted/errored before the closing complete block arrives.
+    accumulator.add(
+      chunk([
+        thinking({ thought: 'partial', streamId, streamStatus: 'delta' }),
+      ]),
+    );
+    accumulator.add(
+      chunk([
+        thinking({ thought: 'partial more', streamId, streamStatus: 'delta' }),
+      ]),
+    );
+
+    const blocks = thinkingBlocks(accumulator.materialize());
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].thought).toBe('partial more');
+    expect(blocks[0].streamStatus).toBe('delta');
+  });
+});

--- a/packages/agents/src/core/streamOutputAccumulator.ts
+++ b/packages/agents/src/core/streamOutputAccumulator.ts
@@ -29,8 +29,31 @@ export class StreamOutputAccumulator {
   private envelope: ModelOutput = emptyModelOutput();
   private readonly blocks: ModelStreamChunk['content']['blocks'] = [];
 
+  /**
+   * Index of the most recent thinking block for each `streamId`. Anthropic
+   * streams re-emit the full accumulated thought on every `thinking_delta`
+   * (streamStatus: 'delta') and close the span with a single
+   * streamStatus: 'complete' block. Appending every delta retains N copies of
+   * an O(L)-byte thought per span — unbounded growth over a long session
+   * (issue #3111). The `streamId` field exists precisely to identify which
+   * incremental update a block replaces (see IContent.ThinkingBlock), so each
+   * span is collapsed to its latest block, kept at the span's original
+   * position so block order is preserved.
+   */
+  private readonly thinkingByStreamId = new Map<string, number>();
+
   add(chunk: ModelStreamChunk): void {
     for (const block of chunk.content.blocks) {
+      if (block.type === 'thinking' && typeof block.streamId === 'string') {
+        const existingIndex = this.thinkingByStreamId.get(block.streamId);
+        if (existingIndex !== undefined) {
+          this.blocks[existingIndex] = block;
+        } else {
+          this.thinkingByStreamId.set(block.streamId, this.blocks.length);
+          this.blocks.push(block);
+        }
+        continue;
+      }
       this.blocks.push(block);
     }
     this.envelope = accumulateModelStreamChunk(this.envelope, {


### PR DESCRIPTION
## TLDR

Fixes the primary steady-state memory leak from issue #3111. `StreamOutputAccumulator.add()` pushed **every** Anthropic/OpenAI-Responses thinking delta (`streamStatus:'delta'`) onto the blocks array, so a long session retained N full-so-far copies of an O(L)-byte thought per reasoning span — the ~11.8 GB leak. Heap attribution in the issue showed ~11,094 retained thinking blocks (held by 5 `blocks` arrays, ~2,219 each), of which only 5 were `complete`; the other ~11,089 were unsigned deltas. The accumulator now coalesces thinking blocks by `streamId`, keeping only the latest block per span (the `complete` block carrying `signature`/`encryptedContent`) at the span's original position.

## Dive Deeper

**Why coalescing in the accumulator is sufficient and correct:**

- Each reasoning span is streamed as a series of `delta` blocks (Anthropic re-emits the *full accumulated* thought per chunk) closed by a single `complete` block. Deltas and the terminal `complete` share one `streamId`:
  - Anthropic: `anthropic-thinking:<src>:block-<n>` — the `complete` block carries the `signature`.
  - OpenAI-Responses: `openai-responses-reasoning:<n>` — idempotent per span via `allocateReasoningStreamId()`, terminal `complete` carries `encryptedContent`.
- `StreamOutputAccumulator` is the sole path materialized thinking takes into conversation history, so coalescing there bounds retention. The **live UI stream** (yielded chunks) is unaffected — it still receives every delta for incremental rendering.
- `materialize()` is only called after successful stream completion (errors abort and discard), so a `complete` block is always present. The fix keeps the latest block per `streamId` regardless of `streamStatus`, so it is also correct for interrupted spans (last `delta` retained).

**The change:** a `Map<streamId, blockIndex>` on the accumulator. For a thinking block with a string `streamId`, if the id is known the block **replaces** the existing entry in place (so block order is preserved); otherwise it appends and records the index. Non-thinking blocks and `streamId`-less thinking blocks keep the existing append-only path (issue #2852 behavior intact).

This is O(1) per block and O(spans) retained. Before: O(deltas) retained → unbounded (issue #3111's measured ~9 MB/min → ~11.8 GB over 22h).

## Reviewer Test Plan

Pull and run the new behavioral tests (Bun/`bun:test`, per `dev-docs/RULES.md`):

    cd packages/agents && bun test src/core/streamOutputAccumulator.bun.test.ts

The 7 tests cover:

1. Non-thinking blocks accumulated verbatim and in order.
2. One span's deltas coalesced into the single `complete` block (carries `signature`).
3. Multiple spans coalesced **independently** with span order preserved.
4. Bounded to one block across 250 deltas — the leak reproduction (pre-fix this was 251 blocks).
5. **Cross-provider**: coalesces both `anthropic-thinking:0:block-0` (signature) and `openai-responses-reasoning:0` (encryptedContent) formats.
6. `streamId`-less thinking blocks are still appended (the non-coalescing fallback path), confirming the leak-tolerant contract.
7. An interrupted span (deltas, no `complete`) retains the last delta.

Optional end-to-end smoke:

    bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

(Confirmed a generation flows through the fixed accumulator.)

Targeted regression suites remain green: `StreamProcessor.accumulation`/`lifecycle` (#2852 append-only/efficiency intact), OpenAI `parseResponsesStream.*`, and `AnthropicStreamProcessor.retryOwnership`.

## Testing Matrix

Verified locally on macOS (Bun): `npm run test`, `lint`, `typecheck`, `format`, `build` all green. The full test suite had 7 flaky 30s-timeout failures in agents-package auth/config tests; these are **proven pre-existing** (they flake identically with this fix stashed — same test, same intermittent 30s hang, with and without the change) and have no code path to the accumulator.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3111
