### PR TITLE
Create the release tag via the Git Refs API, not the Releases API (Fixes #3115)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -509,6 +509,7 @@ jobs:
           else
             TARGET_REF="$(git rev-parse HEAD)"
           fi
+          TARGET_SHA="$(git rev-parse "${TARGET_REF}^{commit}")"
 
           # Ship the source-containing CLI npm tarball as the release asset
           # instead of the esbuild bundle (retired by S4). The tarball is
@@ -519,17 +520,36 @@ jobs:
             exit 1
           fi
 
+          TAG_OBJECT="$(gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${RELEASE_TAG}" \
+            --jq '.[] | select(.ref == "refs/tags/" + $ENV.RELEASE_TAG) | .object.type + " " + .object.sha')"
+
+          if [[ -n "$TAG_OBJECT" ]]; then
+            EXISTING_TYPE="${TAG_OBJECT%% *}"
+            EXISTING_SHA="${TAG_OBJECT##* }"
+            if [[ "$EXISTING_TYPE" == "tag" ]]; then
+              EXISTING_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${EXISTING_SHA}" --jq '.object.sha')"
+            fi
+            if [[ "$EXISTING_SHA" != "$TARGET_SHA" ]]; then
+              echo "Tag refs/tags/$RELEASE_TAG already exists at $EXISTING_SHA and does not match target commit $TARGET_SHA" >&2
+              exit 1
+            fi
+            echo "Reusing existing tag refs/tags/$RELEASE_TAG at $TARGET_SHA"
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f "ref=refs/tags/${RELEASE_TAG}" \
+              -f "sha=${TARGET_SHA}" \
+              --silent
+          fi
+
           if [[ -n "${VSIX_PATH}" && -f "${VSIX_PATH}" ]]; then
             gh release create "$RELEASE_TAG" \
               "$CLI_TARBALL" \
               "${VSIX_PATH}" \
-              --target "$TARGET_REF" \
               --title "Release $RELEASE_TAG" \
               --notes-file release-notes.md
           else
             gh release create "$RELEASE_TAG" \
               "$CLI_TARBALL" \
-              --target "$TARGET_REF" \
               --title "Release $RELEASE_TAG" \
               --notes-file release-notes.md
           fi

--- a/project-plans/20260806-issue3115-release-tag-push/plan.md
+++ b/project-plans/20260806-issue3115-release-tag-push/plan.md
@@ -1,0 +1,105 @@
+# Issue #3115 — Release workflow 403s creating the GitHub Release when main moves mid-run
+
+## Problem
+
+`.github/workflows/release.yml`, step `Create GitHub Release and Tag`, runs:
+
+    gh release create "$RELEASE_TAG" "$CLI_TARBALL" --target "$TARGET_REF" \
+      --title "Release $RELEASE_TAG" --notes-file release-notes.md
+
+`--target` makes the **Releases API** materialize the tag. Since GitHub's Nov-2023
+"Enforcing workflow scope when creating a release" change, `POST /repos/{o}/{r}/releases`
+advertises:
+
+    X-Accepted-GitHub-Permissions: contents=write; contents=write,workflows=write
+
+When `--target <sha>` names a commit whose `.github/workflows/` tree has drifted from the
+default branch tip, the endpoint additionally demands `workflows: write`. That scope cannot
+be granted to `GITHUB_TOKEN` through a `permissions:` block — it exists only on PATs and
+GitHub App installation tokens. The refusal surfaces as the opaque:
+
+    HTTP 403: Resource not accessible by integration
+
+## Evidence
+
+Run 31112396891 (failure issue #3106), tag `v0.11.0-nightly.260806.904a0d062`:
+
+    14:45:09Z  dispatched on 904a0d062       (main's tip at that moment)
+    14:58:14Z  05d50c1e89 merged to main     (PR #3103, changed .github/workflows/ci.yml)
+    15:48:16Z  gh release create --target 904a0d062  ->  HTTP 403
+
+Negative control — during the last successful run (8/5 16:35Z–17:39Z) `main` never moved,
+so the target stayed at the default branch tip and the identical command succeeded. The
+workflow file is byte-identical between the two runs.
+
+Consequence of the failure: npm and ghcr publishes had already completed, so the release
+split — npm carries `0.11.0-nightly.260806.904a0d062` with the `nightly` dist-tag pointing
+at it, while the repo has no tag and no GitHub Release.
+
+This is a race with a roughly one-hour exposure window on every release run, not a
+regression.
+
+## Fix
+
+Create the tag through the Git References REST API, then create the release from the
+pre-existing tag. A smart-HTTP git tag push does not bypass the workflow-file guard:
+[actions/checkout#1421](https://github.com/actions/checkout/issues/1421) documents the same
+race when the branch advances before a tag is pushed. `POST /repos/{owner}/{repo}/git/refs`
+requires `contents: write` and does not pass through receive-pack, so it can create the ref
+without requiring an unavailable `workflows` permission. Dropping `--target` alone is wrong:
+the Releases API would fall back to the default branch tip and tag a different commit than
+the one that was built and published.
+
+Shape of the replacement (illustrative, not prescriptive):
+
+    TARGET_SHA="$(git rev-parse "${TARGET_REF}^{commit}")"
+
+    query git/matching-refs/tags/${RELEASE_TAG} with gh api and exact-name jq filtering
+    if tag exists:
+      peel an annotated tag object; if its commit differs from TARGET_SHA -> hard error
+      otherwise reuse it
+    else:
+      create refs/tags/${RELEASE_TAG} at TARGET_SHA with POST git/refs
+
+    gh release create "${RELEASE_TAG}" "${CLI_TARBALL}" [ "${VSIX_PATH}" ] \
+      --title "Release ${RELEASE_TAG}" --notes-file release-notes.md
+
+## Constraints
+
+- Both `TARGET_REF` paths must keep working: the release-branch path (`SHOULD_CREATE_BRANCH
+  == true`, `TARGET_REF` is the already-pushed `release/<tag>` branch) and the nightly path
+  (`TARGET_REF` is `git rev-parse HEAD`).
+- The step's existing `if:` guard already excludes dry runs and duplicate nightlies; tag
+  creation must stay inside that guard so a dry run never writes a tag.
+- Fail fast. A tag that already exists at the wrong commit is a hard error, not something to
+  paper over. No retry loops, no `|| true`.
+- Version values stay threaded through `env:`, never inline `${{ }}` expansion in the shell
+  body — the current step does this deliberately to avoid shell injection.
+- No new secrets, no GitHub App token, no lint/complexity rule changes, no suppression
+  directives.
+
+## Tests
+
+Behavioral coverage over the workflow step, in the style of the existing
+`scripts/tests/*workflow*.test.ts` files. New tests must be Bun (`bun:test`), not Vitest.
+
+At minimum:
+
+1. The step no longer passes `--target` to `gh release create`.
+2. The step creates `refs/tags/$RELEASE_TAG` through `gh api` before invoking
+   `gh release create`, verified from the API simulator's state at release-creation time.
+3. Executing the step body under `bash` against a throwaway git repository with a stateful
+   fake `gh` on `PATH`:
+   - creates the tag at exactly `TARGET_REF`'s commit through the Git References API;
+   - reuses lightweight and annotated tags that resolve to the release commit;
+   - rejects an existing tag at another commit;
+   - distinguishes an exact tag from names that merely share its prefix;
+   - fails fast when the matching-refs API lookup fails;
+   - still fails before GitHub calls when the CLI tarball is missing.
+4. Both the VSIX and non-VSIX branches retain their exact release assets and options without
+   `--target`.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.

--- a/scripts/tests/release-tag-creation.bun.test.ts
+++ b/scripts/tests/release-tag-creation.bun.test.ts
@@ -1,0 +1,508 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { stepNamed } from './ocr-review-workflow-helpers.ts';
+import {
+  asRecordArray,
+  asString,
+  asStringArray,
+  parseJsonObject,
+  workflowJob,
+  parseWorkflowYaml,
+} from './typed-test-helpers.ts';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const RELEASE_TAG = 'v1.2.3';
+const RELEASE_VERSION = '1.2.3';
+const RELEASE_BRANCH = `release/${RELEASE_TAG}`;
+const CLI_TARBALL = 'packages/cli/dist/vybestack-llxprt-code-1.2.3.tgz';
+const VSIX_PATH = 'packages/vscode/llxprt-code.vsix';
+const REPOSITORY = 'vybestack/llxprt-code';
+
+type TargetMode = 'branch' | 'head';
+type ExistingTag = 'lightweight' | 'annotated' | 'different' | 'near-miss';
+
+interface ScenarioOptions {
+  targetMode: TargetMode;
+  includeCliTarball?: boolean;
+  includeVsix?: boolean;
+  existingTag?: ExistingTag;
+  failLookup?: boolean;
+}
+
+interface ScenarioResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+  events: Array<Record<string, unknown>>;
+  refs: Array<Record<string, unknown>>;
+  targetSha: string;
+}
+
+const FAKE_GH_SOURCE = `#!/usr/bin/env bun
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (value === undefined) throw new Error('missing environment variable ' + name);
+  return value;
+}
+
+const args = process.argv.slice(2);
+const eventLog = requiredEnv('GH_EVENT_LOG');
+const statePath = requiredEnv('GH_REF_STORE');
+const state = JSON.parse(readFileSync(statePath, 'utf8'));
+
+function record(kind, details = {}) {
+  appendFileSync(eventLog, JSON.stringify({ kind, args, ...details }) + '\\n');
+}
+
+function argumentValue(name) {
+  const index = args.indexOf(name);
+  return index < 0 ? undefined : args[index + 1];
+}
+
+function formValue(name) {
+  for (let index = 0; index < args.length - 1; index += 1) {
+    if (args[index] === '-f' && args[index + 1].startsWith(name + '=')) {
+      return args[index + 1].slice(name.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function saveState(nextState) {
+  writeFileSync(statePath, JSON.stringify(nextState));
+}
+
+function commitForRef(ref) {
+  const found = state.refs.find((candidate) => candidate.ref === ref);
+  if (found === undefined) return undefined;
+  if (found.type === 'commit') return found.sha;
+  return state.tags.find((tag) => tag.sha === found.sha)?.targetSha;
+}
+
+record('invocation');
+
+if (args[0] === 'api') {
+  const endpoint = args[1];
+  const matchingMarker = '/git/matching-refs/tags/';
+  if (endpoint.includes(matchingMarker)) {
+    const prefix = decodeURIComponent(endpoint.split(matchingMarker)[1]);
+    const candidates = state.refs.filter((candidate) =>
+      candidate.ref.startsWith('refs/tags/' + prefix),
+    );
+    const exactJq = '.[] | select(.ref == "refs/tags/" + $ENV.RELEASE_TAG) | .object.type + " " + .object.sha';
+    const selected = argumentValue('--jq') === exactJq
+      ? candidates.filter((candidate) =>
+          candidate.ref === 'refs/tags/' + process.env.RELEASE_TAG,
+        )
+      : candidates;
+    record('matching-response', {
+      candidateRefs: candidates.map((candidate) => candidate.ref),
+      selectedRefs: selected.map((candidate) => candidate.ref),
+    });
+    if (process.env.FAIL_API_LOOKUP === 'true') process.exit(42);
+    for (const ref of selected) console.log(ref.type + ' ' + ref.sha);
+    process.exit(0);
+  }
+
+  const tagMarker = '/git/tags/';
+  if (endpoint.includes(tagMarker)) {
+    const objectSha = endpoint.split(tagMarker)[1];
+    const tag = state.tags.find((candidate) => candidate.sha === objectSha);
+    if (tag === undefined) process.exit(43);
+    record('tag-response', { objectSha, targetSha: tag.targetSha });
+    console.log(tag.targetSha);
+    process.exit(0);
+  }
+
+  if (endpoint.endsWith('/git/refs')) {
+    const ref = formValue('ref');
+    const sha = formValue('sha');
+    if (ref === undefined || sha === undefined) process.exit(44);
+    if (state.refs.some((candidate) => candidate.ref === ref)) process.exit(45);
+    saveState({
+      ...state,
+      refs: [...state.refs, { ref, type: 'commit', sha }],
+    });
+    record('ref-created', { ref, sha });
+    process.exit(0);
+  }
+}
+
+if (args[0] === 'release' && args[1] === 'create') {
+  const ref = 'refs/tags/' + process.env.RELEASE_TAG;
+  const actualSha = commitForRef(ref);
+  const expectedSha = requiredEnv('EXPECTED_TARGET_SHA');
+  const correctTagExists = actualSha === expectedSha;
+  record('release-observation', { ref, actualSha, expectedSha, correctTagExists });
+  process.exit(correctTagExists ? 0 : 46);
+}
+
+process.exit(47);
+`;
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function releaseScript(): string {
+  const source = readFileSync(
+    join(ROOT, '.github/workflows/release.yml'),
+    'utf8',
+  );
+  const workflow = parseWorkflowYaml(source);
+  return (
+    stepNamed(workflowJob(workflow, 'release'), 'Create GitHub Release and Tag')
+      .run ?? ''
+  );
+}
+
+function createCommit(
+  repository: string,
+  contents: string,
+  message: string,
+): string {
+  writeFileSync(join(repository, 'tracked.txt'), contents);
+  git(repository, ['add', 'tracked.txt']);
+  git(repository, ['commit', '-m', message]);
+  return git(repository, ['rev-parse', 'HEAD']);
+}
+
+function initialState(
+  existingTag: ExistingTag | undefined,
+  targetSha: string,
+  differentSha: string,
+): Record<string, unknown> {
+  if (existingTag === 'annotated') {
+    return {
+      refs: [
+        { ref: `refs/tags/${RELEASE_TAG}`, type: 'tag', sha: 'tag-object' },
+      ],
+      tags: [{ sha: 'tag-object', targetSha }],
+    };
+  }
+  if (existingTag === 'near-miss') {
+    return {
+      refs: [{ ref: 'refs/tags/v1.2.30', type: 'commit', sha: differentSha }],
+      tags: [],
+    };
+  }
+  if (existingTag !== undefined) {
+    return {
+      refs: [
+        {
+          ref: `refs/tags/${RELEASE_TAG}`,
+          type: 'commit',
+          sha: existingTag === 'different' ? differentSha : targetSha,
+        },
+      ],
+      tags: [],
+    };
+  }
+  return { refs: [], tags: [] };
+}
+
+function readEvents(path: string): Array<Record<string, unknown>> {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map(parseJsonObject);
+}
+
+function runWorkflow(
+  repository: string,
+  fakeBin: string,
+  statePath: string,
+  eventLog: string,
+  options: ScenarioOptions,
+  targetSha: string,
+) {
+  return spawnSync(
+    'bash',
+    ['--noprofile', '--norc', '-e', '-c', releaseScript()],
+    {
+      cwd: repository,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        GH_EVENT_LOG: eventLog,
+        GH_REF_STORE: statePath,
+        GITHUB_REPOSITORY: REPOSITORY,
+        EXPECTED_TARGET_SHA: targetSha,
+        FAIL_API_LOOKUP: options.failLookup === true ? 'true' : 'false',
+        RELEASE_TAG,
+        RELEASE_VERSION,
+        RELEASE_BRANCH: options.targetMode === 'branch' ? RELEASE_BRANCH : '',
+        SHOULD_CREATE_BRANCH:
+          options.targetMode === 'branch' ? 'true' : 'false',
+        VSIX_PATH: options.includeVsix === true ? VSIX_PATH : '',
+      },
+    },
+  );
+}
+
+function runScenario(options: ScenarioOptions): ScenarioResult {
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'release-tag-creation-'));
+  const repository = join(temporaryRoot, 'work');
+  const fakeBin = join(temporaryRoot, 'bin');
+  const statePath = join(temporaryRoot, 'refs.json');
+  const eventLog = join(temporaryRoot, 'events.jsonl');
+
+  try {
+    mkdirSync(repository);
+    mkdirSync(fakeBin);
+    git(repository, ['init', '--initial-branch=main']);
+    git(repository, ['config', 'user.name', 'Release Test']);
+    git(repository, ['config', 'user.email', 'release-test@example.com']);
+    const baseSha = createCommit(repository, 'base\n', 'base');
+    const releaseSha = createCommit(repository, 'release\n', 'release');
+    git(repository, ['branch', RELEASE_BRANCH, releaseSha]);
+    const headSha = createCommit(repository, 'nightly\n', 'nightly');
+    const targetSha = options.targetMode === 'branch' ? releaseSha : headSha;
+
+    mkdirSync(join(repository, 'packages/cli/dist'), { recursive: true });
+    if (options.includeCliTarball !== false) {
+      writeFileSync(join(repository, CLI_TARBALL), 'cli tarball');
+    }
+    mkdirSync(join(repository, 'packages/vscode'), { recursive: true });
+    if (options.includeVsix === true) {
+      writeFileSync(join(repository, VSIX_PATH), 'vsix');
+    }
+    writeFileSync(join(repository, 'release-notes.md'), 'Release notes\n');
+    writeFileSync(
+      statePath,
+      JSON.stringify(initialState(options.existingTag, targetSha, baseSha)),
+    );
+    const fakeGh = join(fakeBin, 'gh');
+    writeFileSync(fakeGh, FAKE_GH_SOURCE);
+    chmodSync(fakeGh, 0o755);
+
+    const result = runWorkflow(
+      repository,
+      fakeBin,
+      statePath,
+      eventLog,
+      options,
+      targetSha,
+    );
+    const state = parseJsonObject(readFileSync(statePath, 'utf8'));
+    return {
+      status: result.status ?? -1,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      events: readEvents(eventLog),
+      refs: asRecordArray(state['refs']),
+      targetSha,
+    };
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+function eventsNamed(
+  result: ScenarioResult,
+  kind: string,
+): Array<Record<string, unknown>> {
+  return result.events.filter((event) => event['kind'] === kind);
+}
+
+function invocationArguments(
+  result: ScenarioResult,
+  predicate: (args: string[]) => boolean,
+): string[][] {
+  return eventsNamed(result, 'invocation')
+    .map((event) => asStringArray(event['args']))
+    .filter(predicate);
+}
+
+function refCreationInvocations(result: ScenarioResult): string[][] {
+  return invocationArguments(
+    result,
+    (args) => args[0] === 'api' && args[1] === `repos/${REPOSITORY}/git/refs`,
+  );
+}
+
+function releaseInvocations(result: ScenarioResult): string[][] {
+  return invocationArguments(
+    result,
+    (args) => args[0] === 'release' && args[1] === 'create',
+  );
+}
+
+function releaseArguments(result: ScenarioResult): string[] {
+  const invocation = releaseInvocations(result)[0];
+  if (invocation === undefined)
+    throw new Error('release create was not invoked');
+  return invocation;
+}
+
+function releaseRef(
+  result: ScenarioResult,
+): Record<string, unknown> | undefined {
+  return result.refs.find(
+    (candidate) => candidate['ref'] === `refs/tags/${RELEASE_TAG}`,
+  );
+}
+
+function exactReleaseRef(result: ScenarioResult): Record<string, unknown> {
+  const ref = releaseRef(result);
+  if (ref === undefined) throw new Error('release tag ref was not found');
+  return ref;
+}
+
+function releaseObservation(result: ScenarioResult): Record<string, unknown> {
+  const event = eventsNamed(result, 'release-observation')[0];
+  if (event === undefined)
+    throw new Error('release observation was not recorded');
+  return event;
+}
+
+function expectSuccessfulRelease(
+  result: ScenarioResult,
+  expectedArguments: string[],
+): void {
+  expect(result.status).toBe(0);
+  expect(releaseArguments(result)).toEqual(expectedArguments);
+  expect(releaseArguments(result)).not.toContain('--target');
+  expect(releaseObservation(result)).toMatchObject({
+    ref: `refs/tags/${RELEASE_TAG}`,
+    actualSha: result.targetSha,
+    expectedSha: result.targetSha,
+    correctTagExists: true,
+  });
+}
+
+const NON_VSIX_RELEASE_ARGUMENTS = [
+  'release',
+  'create',
+  RELEASE_TAG,
+  CLI_TARBALL,
+  '--title',
+  `Release ${RELEASE_TAG}`,
+  '--notes-file',
+  'release-notes.md',
+];
+
+const VSIX_RELEASE_ARGUMENTS = [
+  'release',
+  'create',
+  RELEASE_TAG,
+  CLI_TARBALL,
+  VSIX_PATH,
+  '--title',
+  `Release ${RELEASE_TAG}`,
+  '--notes-file',
+  'release-notes.md',
+];
+
+describe('Create GitHub Release and Tag workflow step', () => {
+  it('tags the exact release-branch head through the API before creating a non-VSIX release', () => {
+    const result = runScenario({ targetMode: 'branch' });
+
+    expectSuccessfulRelease(result, NON_VSIX_RELEASE_ARGUMENTS);
+    expect(exactReleaseRef(result)).toMatchObject({
+      ref: `refs/tags/${RELEASE_TAG}`,
+      type: 'commit',
+      sha: result.targetSha,
+    });
+    expect(refCreationInvocations(result)).toHaveLength(1);
+  });
+
+  it('tags the exact nightly HEAD through the API before creating a VSIX release', () => {
+    const result = runScenario({ targetMode: 'head', includeVsix: true });
+
+    expectSuccessfulRelease(result, VSIX_RELEASE_ARGUMENTS);
+    expect(asString(exactReleaseRef(result)['sha'])).toBe(result.targetSha);
+  });
+
+  it('reuses a lightweight tag at the release commit', () => {
+    const result = runScenario({
+      targetMode: 'branch',
+      existingTag: 'lightweight',
+    });
+
+    expectSuccessfulRelease(result, NON_VSIX_RELEASE_ARGUMENTS);
+    expect(refCreationInvocations(result)).toHaveLength(0);
+    expect(result.stdout).toContain('Reusing existing tag');
+  });
+
+  it('peels and reuses an annotated tag at the release commit', () => {
+    const result = runScenario({
+      targetMode: 'branch',
+      existingTag: 'annotated',
+    });
+
+    expectSuccessfulRelease(result, NON_VSIX_RELEASE_ARGUMENTS);
+    expect(eventsNamed(result, 'tag-response')).toHaveLength(1);
+    expect(refCreationInvocations(result)).toHaveLength(0);
+  });
+
+  it('rejects a tag at a different commit before ref or release creation', () => {
+    const result = runScenario({
+      targetMode: 'branch',
+      existingTag: 'different',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('does not match target commit');
+    expect(refCreationInvocations(result)).toHaveLength(0);
+    expect(releaseInvocations(result)).toHaveLength(0);
+  });
+
+  it('does not treat a prefix-matching tag as the release tag', () => {
+    const result = runScenario({
+      targetMode: 'branch',
+      existingTag: 'near-miss',
+    });
+
+    expectSuccessfulRelease(result, NON_VSIX_RELEASE_ARGUMENTS);
+    expect(eventsNamed(result, 'matching-response')[0]).toMatchObject({
+      candidateRefs: ['refs/tags/v1.2.30'],
+      selectedRefs: [],
+    });
+    expect(asString(exactReleaseRef(result)['sha'])).toBe(result.targetSha);
+  });
+
+  it('fails fast when the matching-refs lookup fails', () => {
+    const result = runScenario({ targetMode: 'head', failLookup: true });
+
+    expect(result.status).not.toBe(0);
+    expect(eventsNamed(result, 'matching-response')).toHaveLength(1);
+    expect(refCreationInvocations(result)).toHaveLength(0);
+    expect(releaseInvocations(result)).toHaveLength(0);
+  });
+
+  it('fails on a missing CLI tarball before any GitHub API call', () => {
+    const result = runScenario({
+      targetMode: 'head',
+      includeCliTarball: false,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      `CLI tarball not found at ${CLI_TARBALL}; cannot create release`,
+    );
+    expect(result.events).toHaveLength(0);
+    expect(releaseRef(result)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## TLDR

The nightly Release workflow intermittently loses its git tag and GitHub Release while
still publishing to npm and ghcr. Root cause is `gh release create --target <sha>`: that
asks the **Releases API** to materialize the tag, and GitHub requires an unobtainable
`workflows: write` scope to do so once the target commit's `.github/workflows/` tree has
drifted from the default branch tip. Because a release run takes about an hour, any PR
touching `.github/` that merges to `main` mid-run creates that drift.

This creates the tag through `POST /repos/{owner}/{repo}/git/refs` instead, then creates
the Release from the now pre-existing tag with no `--target`.

Reviewers should focus on the rewritten `Create GitHub Release and Tag` step in
`.github/workflows/release.yml` -- it is 22 added lines and is the entire functional change.

## Dive Deeper

### Root cause

Since GitHub's Nov-2023 change ["enforcing workflow scope when creating a
release"](https://github.blog/changelog/2023-11-02-github-actions-enforcing-workflow-scope-when-creating-a-release/),
`POST /repos/{owner}/{repo}/releases` advertises:

    X-Accepted-GitHub-Permissions: contents=write; contents=write,workflows=write

When `--target <sha>` names a commit whose `.github/workflows/` tree differs from the
default branch tip, the endpoint additionally requires `workflows: write`. That scope
**cannot be granted to GITHUB_TOKEN** through a `permissions:` block -- it exists only on
PATs and GitHub App installation tokens. The refusal arrives as the famously unhelpful
`HTTP 403: Resource not accessible by integration`.

Timeline of run 31112396891, which produced failure issue #3106:

    14:45:09Z  dispatched on 904a0d062      <- main's tip at that moment
    14:58:14Z  05d50c1e89 merged to main    <- PR #3103, changed .github/workflows/ci.yml
    15:48:16Z  gh release create --target 904a0d062  ->  HTTP 403

Everything upstream succeeded, so the release split: npm carries
`0.11.0-nightly.260806.904a0d062` with the `nightly` dist-tag pointing at it, while the
repository has no tag and no Release.

### What was ruled out

| Hypothesis | Evidence against |
| --- | --- |
| Missing `contents: write` | Runner header printed `Contents: write` |
| Repo default workflow perms are `read` | True, but the explicit `permissions:` block overrides it, and the header proves write was granted |
| Token expiry (job ran over 1h) | The **successful** 8/5 run reached the same step at 1h03m55s; the failed one at 1h02m56s |
| Ruleset / tag protection | Only ruleset is `blockforcedelete`, `enforcement: disabled`; `/tags/protection` returns 404 |
| Immutable releases | `/repos/vybestack/llxprt-code/immutable-releases` returns `{"enabled":false}` |
| Token broken generally | The next step, `gh issue create`, succeeded with the same token |
| Workflow file regression | `git diff bb700c00e 904a0d062 -- .github/workflows/release.yml` is empty |

Negative control: during the last successful run (8/5, 16:35Z-17:39Z) `main` never moved,
so the target stayed at the default branch tip and the identical command succeeded. This is
a race, not a regression.

### Why the Git Refs API and not a git tag push

The obvious fix -- `git tag` plus `git push origin refs/tags/<tag>` -- does **not** work.
Smart-HTTP ref pushes go through receive-pack, which enforces the same workflow-file guard:

    ! [remote rejected] <tag> -> <tag> (refusing to allow a GitHub App to create or update
      workflow `.github/workflows/x.yml` without `workflows` permission)

[actions/checkout#1421](https://github.com/actions/checkout/issues/1421) documents exactly
our race: "If any commits are made to `main` in the intervening period ... then it fails at
the point it tries to push a new tag." A first draft of this PR used a tag push and was
rejected in review for this reason.

`POST /repos/{owner}/{repo}/git/refs` requires only `contents: write` and does not pass
through receive-pack, so the guard never applies. This is the same remedy several other
projects landed after hitting the identical wall.

Dropping `--target` on its own would be **worse than the bug**: the Releases API would then
default the tag to the default branch tip and silently tag a commit other than the one that
was built and published.

### Details worth reviewing

- **Idempotency.** An existing tag is peeled if annotated and reused when it resolves to the
  release commit; a tag at a different commit is a hard error before anything is created.
  This makes a re-run of a partially failed release recoverable.
- **Fail-fast probing.** The existence probe uses `git/matching-refs`, which returns HTTP 200
  with an empty array when nothing matches. Any non-zero `gh` exit is therefore a genuine
  transport/auth/server failure that aborts the step under `bash -e`. The alternative
  `git/ref` endpoint 404s on the normal "absent" path, which would have forced error
  swallowing. There is deliberately no `cmd | parser` pipeline in the step, because GitHub
  runs `run:` blocks as `/usr/bin/bash -e {0}` with **no** `pipefail`, so a pipeline would
  silently mask a failed lookup.
- **Exact-match filtering.** `matching-refs` is a prefix search, so the result is filtered
  for exact ref equality. This repository has real prefix collisions -- `v0.11.0` matches
  every `v0.11.0-nightly.*` tag. Verified against the live API:
  `git/matching-refs/tags/v0.10.0` returns `v0.10.0` plus dozens of
  `v0.10.0-nightly.*` refs.
- **No injection surface.** Version values stay threaded through `env:`; the jq filter reads
  the tag from `$ENV.RELEASE_TAG` rather than string-splicing it into the jq program. The
  repository is read from the `GITHUB_REPOSITORY` built-in rather than inline `${{ }}`.
- **No new secrets, no GitHub App token, no change to the job's `permissions:` block.**

### Tests

`scripts/tests/release-tag-creation.bun.test.ts` extracts the real `run:` body from the
workflow YAML and executes it under `bash --noprofile --norc -e -c` -- `-e` only, no
`pipefail`, mirroring `/usr/bin/bash -e {0}` exactly so the harness can never pass under
stricter options than production uses. `git rev-parse` runs against a real throwaway
repository; the two GitHub endpoints are served by a stateful fake `gh` that maintains a ref
store on disk, reproduces prefix-matching semantics, serves annotated tag objects, and
appends every invocation to an event log.

Eight behaviours are covered: exact release-branch target, exact nightly HEAD target,
ref created at exactly `TARGET_SHA`, both VSIX and non-VSIX asset sets with no `--target`,
lightweight tag reuse, annotated tag peeling and reuse, hard failure on a conflicting tag,
prefix near-miss rejection, fail-fast on a failing lookup, and the pre-existing missing
tarball failure. Ordering is asserted behaviourally -- the fake `gh` records the tag state
observed at `release create` time -- rather than by comparing string offsets in the YAML.

## Reviewer Test Plan

    bun test scripts/tests/release-tag-creation.bun.test.ts

Read the rewritten step in `.github/workflows/release.yml` and sanity-check the API
semantics against the live repository:

    # empty array + exit 0 for a tag that does not exist
    gh api repos/vybestack/llxprt-code/git/matching-refs/tags/v0.11.0-nightly.260806.904a0d062

    # prefix collision this PR must not fall for
    gh api repos/vybestack/llxprt-code/git/matching-refs/tags/v0.10.0 --jq '.[].ref' | head

    # the exact-match filter used by the step
    RELEASE_TAG=v0.10.0 gh api repos/vybestack/llxprt-code/git/matching-refs/tags/v0.10.0 \
      --jq '.[] | select(.ref == "refs/tags/" + $ENV.RELEASE_TAG) | .object.type + " " + .object.sha'

End-to-end validation only happens on a real release run, since the failure requires
GITHUB_TOKEN semantics that no local harness can reproduce. The next nightly exercises it.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | -   | -   | -   |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Local verification on macOS: `npm run test`, `npm run lint`, `npm run typecheck`,
`npm run format`, `npm run build`, and the stepfun-37 smoke test all pass. Four
`packages/agents` tests hit their 30 000 ms ceiling during the full concurrent run and pass
in under a second in isolation; they share no code with this change. Open Code Review
reported 0 findings.

Not applicable rows are workflow-only concerns -- this PR changes no shipped code.

## Linked issues / bugs

Fixes #3115

Explains the failure recorded in #3106. That release remains split: npm carries
`0.11.0-nightly.260806.904a0d062` with the `nightly` dist-tag while the repository has no
corresponding tag or Release. This PR prevents recurrence but does not backfill that
release; the next nightly supersedes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release creation by ensuring tags point to the intended commit.
  * Reuses valid existing tags and rejects tags that reference a different commit.
  * Added validation for lightweight and annotated tags, tag-name mismatches, lookup failures, and missing release tooling.

* **Tests**
  * Added integration coverage for release and tag creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->