### PR TITLE
Discard abandoned stream attempts transactionally (Fixes #3048)

### DIFF
--- a/packages/a2a-server/src/agent/executor.retryDiscard.bun.ts
+++ b/packages/a2a-server/src/agent/executor.retryDiscard.bun.ts
@@ -1,0 +1,254 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3048 (REQ-3048-006): the a2a executor must discard tool-call requests
+ * collected during an abandoned model attempt when a Retry event arrives,
+ * while the successful attempt's own tool calls must still be scheduled. The
+ * existing informational logging of Retry through task.acceptAgentMessage is
+ * unchanged.
+ *
+ * The executor's private #processAgentTurnLoop is driven through the public
+ * execute() entry point by pre-seeding the executor's task cache with a
+ * recording Task double. Assertions are on the recorded scheduleToolCalls
+ * argument arrays and on the acceptAgentMessage event stream — observable
+ * outputs, not collaborator call counts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'bun:test';
+import { CoderAgentExecutor } from './executor.js';
+import type { Task } from './task.js';
+import type { ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server';
+import {
+  AgentEventType,
+  type ServerAgentStreamEvent,
+  type ToolCallRequestInfo,
+  type CompletedToolCall,
+} from '@vybestack/llxprt-code-core';
+
+function toolCallRequest(callId: string): ServerAgentStreamEvent {
+  const value: ToolCallRequestInfo = {
+    callId,
+    name: 'noop',
+    args: {},
+    isClientInitiated: false,
+    prompt_id: 'p',
+    agentId: 'default_agent',
+  };
+  return { type: AgentEventType.ToolCallRequest, value };
+}
+
+function retryEvent(): ServerAgentStreamEvent {
+  return { type: AgentEventType.Retry };
+}
+
+function contentEvent(text: string): ServerAgentStreamEvent {
+  return { type: AgentEventType.Content, value: text };
+}
+
+function finishedEvent(): ServerAgentStreamEvent {
+  return { type: AgentEventType.Finished, value: { reason: 'stop' } };
+}
+
+interface ScriptedTaskOptions {
+  firstTurnEvents: ServerAgentStreamEvent[];
+}
+
+function createScriptedTask(options: ScriptedTaskOptions): {
+  task: Task;
+  scheduledRequests: ToolCallRequestInfo[][];
+  acceptedEvents: ServerAgentStreamEvent[];
+} {
+  const scheduledRequests: ToolCallRequestInfo[][] = [];
+  const acceptedEvents: ServerAgentStreamEvent[] = [];
+  const firstTurnEvents = [...options.firstTurnEvents];
+  const completedTools: CompletedToolCall[] = [];
+
+  const task = {
+    id: 'retry-discard-task',
+    contextId: 'retry-discard-context',
+    taskState: 'working',
+    eventBus: undefined,
+    async *acceptUserMessage(
+      _requestContext: RequestContext,
+      _signal: AbortSignal,
+    ): AsyncGenerator<ServerAgentStreamEvent> {
+      for (const event of firstTurnEvents) {
+        yield event;
+      }
+    },
+    async acceptAgentMessage(event: ServerAgentStreamEvent): Promise<void> {
+      acceptedEvents.push(event);
+    },
+    async scheduleToolCalls(
+      requests: ToolCallRequestInfo[],
+      _signal: AbortSignal,
+    ): Promise<void> {
+      scheduledRequests.push([...requests]);
+    },
+    async waitForPendingTools(): Promise<void> {},
+    getAndClearCompletedTools(): CompletedToolCall[] {
+      return completedTools.splice(0, completedTools.length);
+    },
+    setTaskStateAndPublishUpdate(): void {},
+    cancelPendingTools(): void {},
+  } as unknown as Task;
+
+  return { task, scheduledRequests, acceptedEvents };
+}
+
+function createRecordingEventBus(): ExecutionEventBus {
+  return {
+    publish: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+    removeAllListeners: vi.fn(),
+    finished: vi.fn(),
+  } as unknown as ExecutionEventBus;
+}
+
+function createRequestContext(): RequestContext {
+  return {
+    userMessage: {
+      role: 'user',
+      parts: [{ kind: 'text', text: 'go' }],
+      messageId: 'm-1',
+      kind: 'message',
+      contextId: 'retry-discard-context',
+      taskId: 'retry-discard-task',
+    },
+  } as unknown as RequestContext;
+}
+
+interface ExecutorInternals {
+  tasks: Map<
+    string,
+    { task: Task; agentSettings: unknown; toSDKTask: () => unknown }
+  >;
+}
+
+/**
+ * Pre-seeds the executor's in-memory task cache so the public execute() path
+ * resolves the scripted Task double without hitting the store / createTask
+ * wiring. The executor then runs the real #processAgentTurnLoop against it.
+ */
+function seedExecutor(executor: CoderAgentExecutor, task: Task): void {
+  const internals = executor as unknown as ExecutorInternals;
+  internals.tasks.set('retry-discard-task', {
+    task,
+    agentSettings: {},
+    toSDKTask: () => task,
+  });
+}
+
+describe('a2a executor discards abandoned tool-call requests on Retry (issue 3048)', () => {
+  let executor: CoderAgentExecutor;
+  let eventBus: ExecutionEventBus;
+
+  beforeEach(() => {
+    executor = new CoderAgentExecutor();
+    eventBus = createRecordingEventBus();
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P05
+   * @requirement REQ-3048-006
+   * @scenario schedules only the successful attempt's tool calls
+   */
+  it("schedules only the successful attempt's tool calls", async () => {
+    const { task, scheduledRequests } = createScriptedTask({
+      firstTurnEvents: [
+        toolCallRequest('abandoned'),
+        retryEvent(),
+        toolCallRequest('kept'),
+        finishedEvent(),
+      ],
+    });
+    seedExecutor(executor, task);
+
+    await executor.execute(createRequestContext(), eventBus);
+
+    expect(scheduledRequests).toHaveLength(1);
+    expect(scheduledRequests[0].map((r) => r.callId)).toEqual(['kept']);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P05
+   * @requirement REQ-3048-006
+   * @scenario never schedules when the only tool calls belonged to an abandoned attempt
+   */
+  it('never schedules when the only tool calls belonged to an abandoned attempt', async () => {
+    const { task, scheduledRequests } = createScriptedTask({
+      firstTurnEvents: [
+        toolCallRequest('abandoned'),
+        retryEvent(),
+        finishedEvent(),
+      ],
+    });
+    seedExecutor(executor, task);
+
+    await executor.execute(createRequestContext(), eventBus);
+
+    expect(scheduledRequests).toHaveLength(0);
+  });
+
+  /**
+   * @requirement REQ-3048-006
+   * @scenario abandoned model output and tools are discarded together
+   */
+  it('accepts and schedules only the replacement attempt state', async () => {
+    const { task, acceptedEvents, scheduledRequests } = createScriptedTask({
+      firstTurnEvents: [
+        contentEvent('abandoned'),
+        toolCallRequest('abandoned'),
+        retryEvent(),
+        contentEvent('replacement'),
+        toolCallRequest('kept'),
+        finishedEvent(),
+      ],
+    });
+    seedExecutor(executor, task);
+
+    await executor.execute(createRequestContext(), eventBus);
+
+    expect(
+      acceptedEvents
+        .filter((event) => event.type === AgentEventType.Content)
+        .map((event) => event.value),
+    ).toEqual(['replacement']);
+    expect(
+      acceptedEvents.some((event) => event.type === AgentEventType.Retry),
+    ).toBe(true);
+    expect(scheduledRequests).toHaveLength(1);
+    expect(scheduledRequests[0].map((request) => request.callId)).toEqual([
+      'kept',
+    ]);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P05
+   * @requirement REQ-3048-006
+   * @scenario still logs the Retry event through acceptAgentMessage (informational classification unchanged)
+   */
+  it('still logs the Retry event through acceptAgentMessage', async () => {
+    const { task, acceptedEvents } = createScriptedTask({
+      firstTurnEvents: [
+        toolCallRequest('abandoned'),
+        retryEvent(),
+        toolCallRequest('kept'),
+        finishedEvent(),
+      ],
+    });
+    seedExecutor(executor, task);
+
+    await executor.execute(createRequestContext(), eventBus);
+
+    expect(acceptedEvents.some((e) => e.type === AgentEventType.Retry)).toBe(
+      true,
+    );
+  });
+});

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -473,6 +473,7 @@ export class CoderAgentExecutor implements AgentExecutor {
         `[CoderAgentExecutor] Task ${task.id}: Processing agent turn (LLM stream).`,
       );
       const toolCallRequests: ToolCallRequestInfo[] = [];
+      const attemptEvents: ServerAgentStreamEvent[] = [];
       for await (const event of agentEvents) {
         if (abortSignal.aborted) {
           logger.warn(
@@ -482,12 +483,20 @@ export class CoderAgentExecutor implements AgentExecutor {
         }
         if (event.type === AgentEventType.ToolCallRequest) {
           toolCallRequests.push(event.value);
-          continue;
+        } else if (event.type === AgentEventType.Retry) {
+          toolCallRequests.length = 0;
+          attemptEvents.length = 0;
+          await task.acceptAgentMessage(event);
+        } else {
+          attemptEvents.push(event);
         }
-        await task.acceptAgentMessage(event);
       }
 
       if (abortSignal.aborted) throw new Error('Execution aborted');
+
+      for (const event of attemptEvents) {
+        await task.acceptAgentMessage(event);
+      }
 
       if (toolCallRequests.length > 0) {
         logger.info(

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -498,9 +498,8 @@ export class CoderAgentExecutor implements AgentExecutor {
         }
       }
 
-      if (abortSignal.aborted) throw new Error('Execution aborted');
-
       for (const event of attemptEvents) {
+        throwIfAborted(abortSignal);
         await task.acceptAgentMessage(event);
       }
 

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -472,6 +472,12 @@ export class CoderAgentExecutor implements AgentExecutor {
       logger.info(
         `[CoderAgentExecutor] Task ${task.id}: Processing agent turn (LLM stream).`,
       );
+      // Intentional full-attempt buffering: stream events are accumulated in
+      // `attemptEvents` and published to the task (and thus the event bus)
+      // only after the iteration completes, because the event bus has no
+      // retraction primitive. A transport Retry clears both buffers to drop
+      // the abandoned partial output; an abort throws before publication,
+      // intentionally discarding buffered partial output for the same reason.
       const toolCallRequests: ToolCallRequestInfo[] = [];
       const attemptEvents: ServerAgentStreamEvent[] = [];
       for await (const event of agentEvents) {

--- a/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
@@ -184,6 +184,8 @@ function buildOrchestrator(options: BuildOptions = {}): {
       reset: vi.fn(),
       turnStarted: vi.fn().mockResolvedValue(false),
       addAndCheck: vi.fn().mockReturnValue(false),
+      checkpoint: vi.fn().mockReturnValue({}),
+      restore: vi.fn(),
     } as unknown as LoopDetectionService,
     todoContinuationService: {
       clearPausedState: vi.fn().mockResolvedValue(undefined),
@@ -206,6 +208,8 @@ function buildOrchestrator(options: BuildOptions = {}): {
       appendSystemReminderToRequest: vi.fn(),
       updateTodoToolAvailabilityFromDeclarations: vi.fn(),
       setLastTodoToolTurn: vi.fn(),
+      checkpoint: vi.fn().mockReturnValue({}),
+      restore: vi.fn(),
       shouldDeferStreamEvent: vi.fn().mockReturnValue(false),
     } as unknown as MessageStreamDeps['todoContinuationService'],
     ideContextTracker: {

--- a/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
@@ -201,6 +201,8 @@ function buildOrchestrator(options: BuildOptions = {}): {
     appendSystemReminderToRequest: vi.fn(),
     updateTodoToolAvailabilityFromDeclarations: vi.fn(),
     setLastTodoToolTurn: vi.fn(),
+    checkpoint: vi.fn().mockReturnValue({}),
+    restore: vi.fn(),
     shouldDeferStreamEvent: vi.fn().mockReturnValue(false),
   } as unknown as MessageStreamDeps['todoContinuationService'];
 
@@ -217,6 +219,8 @@ function buildOrchestrator(options: BuildOptions = {}): {
       reset: vi.fn(),
       turnStarted: vi.fn().mockResolvedValue(false),
       addAndCheck: vi.fn().mockReturnValue(false),
+      checkpoint: vi.fn().mockReturnValue({}),
+      restore: vi.fn(),
     } as unknown as LoopDetectionService,
     todoContinuationService,
     ideContextTracker: {
@@ -348,7 +352,8 @@ describe('MessageStreamOrchestrator — tool-call turns (issue #2657)', () => {
 
     const modelInfoResult = await iterator.next();
     expect(modelInfoResult.value.type).toBe(AgentEventType.ModelInfo);
-    await expect(iterator.next()).resolves.toMatchObject({
+    const contentResult = await iterator.next();
+    expect(contentResult).toMatchObject({
       done: false,
       value: { type: AgentEventType.Content, value: 'Hello' },
     });

--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -28,8 +28,14 @@ import {
 } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import type { ChatSession } from './chatSession.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
-import type { LoopDetectionService } from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
-import type { TodoContinuationService } from './TodoContinuationService.js';
+import type {
+  LoopDetectionService,
+  LoopDetectionSnapshot,
+} from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
+import type {
+  TodoContinuationService,
+  TodoContinuationSnapshot,
+} from './TodoContinuationService.js';
 import type { IdeContextTracker } from './IdeContextTracker.js';
 import type { AgentHookManager } from './AgentHookManager.js';
 import type { AfterAgentHookOutput } from '@vybestack/llxprt-code-core/hooks/types.js';
@@ -37,6 +43,7 @@ import { extractPromptText } from './clientHelpers.js';
 import type { Todo } from '@vybestack/llxprt-code-tools';
 import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
 import { handleTerminalEvent } from './MessageStreamTerminalHandler.js';
+import { applyRetryAwareLoopDetection } from './retryAwareLoopDetection.js';
 
 export interface MessageStreamDeps {
   config: Config;
@@ -99,6 +106,103 @@ interface PostTurnResult {
   done: boolean;
   retryCount: number;
   newBaseRequest: AgentMessageInput | undefined;
+}
+
+/**
+ * Mutable per-attempt accumulators owned by `_processStreamIteration`. Held in
+ * a single record so {@link discardAbandonedAttempt} can reset them by
+ * reference on a transport Retry.
+ */
+interface AttemptState {
+  hadThinking: boolean;
+  hadContent: boolean;
+  hadToolCallsThisTurn: boolean;
+}
+
+/**
+ * Snapshot of every attempt-mutable accumulator captured at stream-iteration
+ * entry and restored as one coherent operation on a transport Retry
+ * (issue #3048 review findings 2, 3, 4). Prompt-scoped state (prompt identity,
+ * turn counts) is deliberately excluded.
+ */
+interface AttemptCheckpoint {
+  /**
+   * Length of `ctx.responseChunks` at iteration entry. A Retry truncates back
+   * to this baseline so text contributed by earlier successful internal-loop
+   * iterations survives (finding 3).
+   */
+  readonly responseChunksBaseline: number;
+  readonly loopDetection: LoopDetectionSnapshot;
+  readonly todoContinuation: TodoContinuationSnapshot;
+}
+
+interface AttemptRollbackContext {
+  readonly ctx: StreamContext;
+  readonly state: AttemptState;
+  readonly hadToolCallsPrior: boolean;
+  readonly deferredEvents: ServerAgentStreamEvent[];
+  readonly checkpoint: AttemptCheckpoint;
+  readonly loopDetector: LoopDetectionService;
+  readonly todoContinuationService: TodoContinuationService;
+}
+
+function createAttemptRollbackContext(
+  ctx: StreamContext,
+  hadToolCallsPrior: boolean,
+  loopDetector: LoopDetectionService,
+  todoContinuationService: TodoContinuationService,
+): AttemptRollbackContext {
+  const state: AttemptState = {
+    hadThinking: false,
+    hadContent: false,
+    hadToolCallsThisTurn: hadToolCallsPrior,
+  };
+  const deferredEvents: ServerAgentStreamEvent[] = [];
+  return {
+    ctx,
+    state,
+    hadToolCallsPrior,
+    deferredEvents,
+    checkpoint: {
+      responseChunksBaseline: ctx.responseChunks.length,
+      loopDetection: loopDetector.checkpoint(),
+      todoContinuation: todoContinuationService.checkpoint(),
+    },
+    loopDetector,
+    todoContinuationService,
+  };
+}
+
+/**
+ * Discards every per-attempt accumulator when a transport retry restarts the
+ * turn mid-stream, so AfterAgent, post-turn flags, deferred events, loop
+ * detection and task-list continuation reflect only the successful attempt.
+ *
+ * `ctx.responseChunks` is truncated in place to the entry baseline (not zero)
+ * because the array is shared across internal-loop iterations with the
+ * AfterAgent hook; text from earlier successful iterations must survive
+ * (finding 3). `hadToolCallsThisTurn` resets to the value carried in (not
+ * `false`) so tool calls from an earlier loop iteration survive. The loop
+ * detector and task-list continuation service are restored to their entry
+ * snapshots so abandoned Content/ToolCallRequest cannot contaminate them
+ * (findings 2, 4). `finishedOutcome` is deliberately untouched — an abandoned
+ * attempt never reaches Finished.
+ *
+ * @plan PLAN-20260806-ISSUE3048.P08
+ * @requirement REQ-3048-007
+ * @pseudocode 004 lines 400-409
+ */
+function discardAbandonedAttempt(rollback: AttemptRollbackContext): void {
+  rollback.ctx.responseChunks.length =
+    rollback.checkpoint.responseChunksBaseline;
+  rollback.state.hadThinking = false;
+  rollback.state.hadContent = false;
+  rollback.state.hadToolCallsThisTurn = rollback.hadToolCallsPrior;
+  rollback.deferredEvents.length = 0;
+  rollback.loopDetector.restore(rollback.checkpoint.loopDetection);
+  rollback.todoContinuationService.restore(
+    rollback.checkpoint.todoContinuation,
+  );
 }
 
 function normalizeTodoSnapshotEntry(todo: Todo): Todo {
@@ -399,43 +503,49 @@ export class MessageStreamOrchestrator {
     hadToolCallsPrior: boolean,
     initialRequest: AgentMessageInput,
   ): AsyncGenerator<ServerAgentStreamEvent, IterationResult> {
-    const { loopDetector, todoContinuationService, updateTelemetryTokenCount } =
-      this.deps;
-
-    const loopDetected = await loopDetector.turnStarted(signal);
-    if (loopDetected) {
+    const { loopDetector, todoContinuationService } = this.deps;
+    if (await loopDetector.turnStarted(signal)) {
       yield { type: AgentEventType.LoopDetected };
       yield* this._fireAfterHookAndEmitClearContext(ctx);
       return this._earlyIterResult(hadToolCallsPrior);
     }
-
-    let hadThinking = false;
-    let hadContent = false;
-    let hadToolCallsThisTurn = hadToolCallsPrior;
-    const deferredEvents: ServerAgentStreamEvent[] = [];
+    const rollback = createAttemptRollbackContext(
+      ctx,
+      hadToolCallsPrior,
+      loopDetector,
+      todoContinuationService,
+    );
+    const { state, deferredEvents } = rollback;
     let finishedOutcome: ServerFinishedOutcome | undefined;
-
-    for await (const event of turn.run(iterRequest, signal)) {
-      if (loopDetector.addAndCheck(event)) {
+    const events = applyRetryAwareLoopDetection(
+      turn.run(iterRequest, signal),
+      loopDetector,
+    );
+    for await (const { event, loopDetected: eventLoopDetected } of events) {
+      if (eventLoopDetected) {
         yield { type: AgentEventType.LoopDetected };
         yield* this._fireAfterHookAndEmitClearContext(ctx);
-        return this._earlyIterResult(hadToolCallsThisTurn, {
-          hadThinking,
-          hadContent,
+        return this._earlyIterResult(state.hadToolCallsThisTurn, {
+          hadThinking: state.hadThinking,
+          hadContent: state.hadContent,
           deferredEvents,
           outcome: finishedOutcome,
         });
       }
 
       todoContinuationService.recordModelActivity(event);
+
+      if (event.type === AgentEventType.Retry) {
+        discardAbandonedAttempt(rollback);
+        yield event;
+        this.deps.updateTelemetryTokenCount();
+        continue;
+      }
+
       if (event.type === AgentEventType.ToolCallRequest)
-        hadToolCallsThisTurn = true;
-      // Pause detection happens in AgenticLoop.buildNextMessage(), which sees
-      // real scheduler tool responses. Turn.run() only emits ToolCallRequest
-      // events, so checking for ToolCallResponse here would be dead code — the
-      // real responses arrive later via the scheduler (issue #2657).
-      if (event.type === AgentEventType.Thought) hadThinking = true;
-      if (event.type === AgentEventType.Content) hadContent = true;
+        state.hadToolCallsThisTurn = true;
+      if (event.type === AgentEventType.Thought) state.hadThinking = true;
+      if (event.type === AgentEventType.Content) state.hadContent = true;
       if (event.type === AgentEventType.Finished && event.value.outcome)
         finishedOutcome = event.value.outcome;
       this._handleTodoToolCall(event, todoContinuationService);
@@ -447,7 +557,7 @@ export class MessageStreamOrchestrator {
       } else {
         yield event;
       }
-      updateTelemetryTokenCount();
+      this.deps.updateTelemetryTokenCount();
 
       const terminalResult = yield* handleTerminalEvent(
         this.deps,
@@ -455,20 +565,20 @@ export class MessageStreamOrchestrator {
         signal,
         ctx,
         deferredEvents,
-        { hadToolCallsThisTurn, hadThinking, hadContent },
+        {
+          hadToolCallsThisTurn: state.hadToolCallsThisTurn,
+          hadThinking: state.hadThinking,
+          hadContent: state.hadContent,
+        },
         initialRequest,
       );
       if (terminalResult) return terminalResult;
     }
 
-    return {
-      earlyReturn: false,
-      hadToolCallsThisTurn,
-      hadThinking,
-      hadContent,
-      deferredEvents,
-      outcome: finishedOutcome,
-    };
+    return Object.assign(
+      { earlyReturn: false, deferredEvents, outcome: finishedOutcome },
+      state,
+    );
   }
 
   private _earlyIterResult(

--- a/packages/agents/src/core/TodoContinuationService.ts
+++ b/packages/agents/src/core/TodoContinuationService.ts
@@ -148,6 +148,17 @@ export enum PostTurnAction {
   RetryWithReminder = 'retry-with-reminder',
 }
 
+/**
+ * Immutable snapshot of the attempt-local task-list continuation state. Only the
+ * three values mutated by an in-flight attempt are captured; reminder level,
+ * activity counters and prompt-scoped state are excluded.
+ */
+export interface TodoContinuationSnapshot {
+  readonly lastTodoToolTurn: number | undefined;
+  readonly consecutiveComplexTurns: number;
+  readonly lastTodoSnapshot: readonly Todo[] | undefined;
+}
+
 export interface PostTurnContext {
   hadToolCalls: boolean;
   hadThinking: boolean;
@@ -519,6 +530,39 @@ export class TodoContinuationService {
     this.lastComplexitySuggestionTurn = undefined;
     this.lastTodoToolTurn = undefined;
     this.lastTodoSnapshot = undefined;
+  }
+
+  /**
+   * Snapshot of the attempt-local task-list continuation state for transactional
+   * rollback. Captured at the start of a stream attempt and restored when a
+   * transport retry discards an abandoned attempt, so an abandoned task-list
+   * write cannot mutate reminder cadence for the replacement attempt.
+   *
+   * The task-list snapshot is deeply cloned so nested subtasks and tool-call
+   * metadata cannot alias the live state.
+   */
+  checkpoint(): TodoContinuationSnapshot {
+    return {
+      lastTodoToolTurn: this.lastTodoToolTurn,
+      consecutiveComplexTurns: this.consecutiveComplexTurns,
+      lastTodoSnapshot:
+        this.lastTodoSnapshot !== undefined
+          ? this.lastTodoSnapshot.map((todo) => structuredClone(todo))
+          : undefined,
+    };
+  }
+
+  /**
+   * Restores attempt-local task-list continuation state from a checkpoint.
+   * The task-list snapshot is cloned again so the live state does not alias it.
+   */
+  restore(snapshot: TodoContinuationSnapshot): void {
+    this.lastTodoToolTurn = snapshot.lastTodoToolTurn;
+    this.consecutiveComplexTurns = snapshot.consecutiveComplexTurns;
+    this.lastTodoSnapshot =
+      snapshot.lastTodoSnapshot !== undefined
+        ? snapshot.lastTodoSnapshot.map((todo) => structuredClone(todo))
+        : undefined;
   }
 
   setLastTodoToolTurn(turn: number): void {

--- a/packages/agents/src/core/TodoContinuationService.ts
+++ b/packages/agents/src/core/TodoContinuationService.ts
@@ -149,14 +149,18 @@ export enum PostTurnAction {
 }
 
 /**
- * Immutable snapshot of the attempt-local task-list continuation state. Only the
- * three values mutated by an in-flight attempt are captured; reminder level,
- * activity counters and prompt-scoped state are excluded.
+ * Immutable snapshot of the attempt-local task-list continuation state. The five
+ * values mutated by an in-flight attempt are captured; prompt-scoped state is
+ * excluded. `toolActivityCount` and `toolCallReminderLevel` are included
+ * because recordModelActivity updates them before a transport Retry rolls back
+ * the abandoned attempt.
  */
 export interface TodoContinuationSnapshot {
   readonly lastTodoToolTurn: number | undefined;
   readonly consecutiveComplexTurns: number;
   readonly lastTodoSnapshot: readonly Todo[] | undefined;
+  readonly toolActivityCount: number;
+  readonly toolCallReminderLevel: 'none' | 'base' | 'escalated';
 }
 
 export interface PostTurnContext {
@@ -549,6 +553,8 @@ export class TodoContinuationService {
         this.lastTodoSnapshot !== undefined
           ? this.lastTodoSnapshot.map((todo) => structuredClone(todo))
           : undefined,
+      toolActivityCount: this.toolActivityCount,
+      toolCallReminderLevel: this.toolCallReminderLevel,
     };
   }
 
@@ -563,6 +569,8 @@ export class TodoContinuationService {
       snapshot.lastTodoSnapshot !== undefined
         ? snapshot.lastTodoSnapshot.map((todo) => structuredClone(todo))
         : undefined;
+    this.toolActivityCount = snapshot.toolActivityCount;
+    this.toolCallReminderLevel = snapshot.toolCallReminderLevel;
   }
 
   setLastTodoToolTurn(turn: number): void {

--- a/packages/agents/src/core/TurnProcessor.ts
+++ b/packages/agents/src/core/TurnProcessor.ts
@@ -39,7 +39,10 @@ import {
   filterAfcByHookRestrictions,
 } from './hookToolRestrictions.js';
 import { canonicalizeToolName } from './toolGovernance.js';
-import { shouldRetryStreamAttempt } from './turnAbortHelpers.js';
+import {
+  shouldRetryStreamAttempt,
+  applyRetryTemperature,
+} from './turnAbortHelpers.js';
 
 import {
   AgentExecutionStoppedError,
@@ -260,7 +263,7 @@ export class TurnProcessor {
 
     let hasYieldedChunk = false;
     try {
-      const currentParams = this._applyRetryTemperature(params, attempt);
+      const currentParams = applyRetryTemperature(params, attempt);
       const stream = await this.streamProcessor.makeApiCallAndProcessStream(
         currentParams,
         prompt_id,
@@ -304,29 +307,14 @@ export class TurnProcessor {
         return { error: null, action: 'stop' };
       }
       if (
-        !hasYieldedChunk &&
-        shouldRetryStreamAttempt(error, params, attempt)
+        shouldRetryStreamAttempt(error, params, attempt, {
+          hasYieldedOutput: hasYieldedChunk,
+        })
       ) {
         return { error, action: 'retry' };
       }
       return { error, action: 'stop' };
     }
-  }
-
-  private _applyRetryTemperature(
-    params: SendMessageParams,
-    attempt: number,
-  ): SendMessageParams {
-    if (attempt === 0) return params;
-    const baselineTemperature = Math.max(params.config?.temperature ?? 1, 1);
-    const newTemperature = Math.min(
-      Math.max(baselineTemperature + attempt * 0.1, 0),
-      2,
-    );
-    return {
-      ...params,
-      config: { ...params.config, temperature: newTemperature },
-    };
   }
 
   private _normalizeUserContent(params: SendMessageParams): IContent[] {

--- a/packages/agents/src/core/agenticLoop/AgenticLoop.ts
+++ b/packages/agents/src/core/agenticLoop/AgenticLoop.ts
@@ -537,9 +537,9 @@ export class AgenticLoop {
       yield { kind: 'stream', event };
       if (event.type === AgentEventType.ToolCallRequest) {
         toolCallRequests.push(event.value);
-        continue;
-      }
-      if (isTerminalStreamOutcome(event.type)) {
+      } else if (event.type === AgentEventType.Retry) {
+        toolCallRequests.length = 0;
+      } else if (isTerminalStreamOutcome(event.type)) {
         toolCallRequests.length = 0;
         shouldScheduleTools = false;
       }

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.retryDiscard.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.retryDiscard.test.ts
@@ -1,0 +1,221 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3048 (REQ-3048-006): tool-call requests collected during an abandoned
+ * model attempt must be discarded by AgenticLoop when a Retry event arrives,
+ * while the successful attempt's own tool calls must still be scheduled. The
+ * turn is NOT terminal on Retry, so `shouldScheduleTools` stays true.
+ *
+ * The loop, CoreToolScheduler, MockTool and confirmation bus are REAL. The only
+ * double is the agentClient.sendMessageStream scripted event source
+ * (infrastructure boundary). Assertions are on observable output: the
+ * `tools_complete` completed calls' callIds, the presence/absence of
+ * `tools_complete`, and the ordering of yielded stream events.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from '../../../testApi.js';
+import { AgenticLoop } from '../AgenticLoop.js';
+import { MockTool } from '@vybestack/llxprt-code-core/test-utils/mock-tool.js';
+import { clearAllSchedulers } from '@vybestack/llxprt-code-core/config/schedulerSingleton.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import {
+  AgentEventType,
+  createScriptedAgentClient,
+  createTestConfig,
+  createToolRegistryForTest,
+  createAllowPolicyEngine,
+  collectEvents,
+  isToolsComplete,
+  isStream,
+  toolCallRequestEvent,
+  contentEvent,
+  finishedEvent,
+  type AgenticLoopEvent,
+  type ServerAgentStreamEvent,
+} from './agenticLoop-test-helpers.js';
+
+function retryEvent(): ServerAgentStreamEvent {
+  return { type: AgentEventType.Retry };
+}
+
+describe('AgenticLoop discards abandoned tool-call requests on Retry (issue 3048)', () => {
+  beforeEach(() => {
+    clearAllSchedulers();
+  });
+  afterEach(() => {
+    clearAllSchedulers();
+  });
+
+  function buildLoop(scripts: ServerAgentStreamEvent[][]) {
+    const tool = new MockTool({ name: 'echo' });
+    const toolRegistry = createToolRegistryForTest([tool]);
+    const messageBus = new MessageBus(createAllowPolicyEngine(), false);
+    const config = createTestConfig({
+      messageBus,
+      toolRegistry,
+      policyEngine: createAllowPolicyEngine(),
+      interactive: false,
+      approvalMode: ApprovalMode.YOLO,
+    });
+    const scripted = createScriptedAgentClient(scripts);
+    const loop = new AgenticLoop({
+      agentClient: scripted.client,
+      config,
+      messageBus,
+    });
+    return { loop, ...scripted };
+  }
+
+  /** CallIds of completed tool calls, in order, from the tools_complete event. */
+  function completedCallIds(events: readonly AgenticLoopEvent[]): string[] {
+    const complete = events.find(isToolsComplete);
+    if (!complete) return [];
+    return complete.completed.map((call) => call.request.callId);
+  }
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P05
+   * @requirement REQ-3048-006
+   * @scenario schedules only the successful attempt's tool calls
+   */
+  it("schedules only the successful attempt's tool calls", async () => {
+    const { loop } = buildLoop([
+      [
+        toolCallRequestEvent('echo', 'abandoned'),
+        retryEvent(),
+        toolCallRequestEvent('echo', 'kept'),
+        finishedEvent(),
+      ],
+      // Continuation turn after the tool result so the loop terminates cleanly.
+      [contentEvent('all done'), finishedEvent()],
+    ]);
+
+    const events = await collectEvents(
+      loop,
+      'go',
+      new AbortController().signal,
+    );
+
+    expect(completedCallIds(events)).toEqual(['kept']);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P05
+   * @requirement REQ-3048-006
+   * @scenario never schedules when the only tool calls belonged to an abandoned attempt
+   */
+  it('never schedules when the only tool calls belonged to an abandoned attempt', async () => {
+    const { loop } = buildLoop([
+      [
+        toolCallRequestEvent('echo', 'abandoned'),
+        retryEvent(),
+        finishedEvent(),
+      ],
+    ]);
+
+    const events = await collectEvents(
+      loop,
+      'go',
+      new AbortController().signal,
+    );
+
+    expect(events.some(isToolsComplete)).toBe(false);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P05
+   * @requirement REQ-3048-006
+   * @scenario forwards the Retry event to consumers before discarding
+   */
+  it('forwards the Retry event to consumers before discarding', async () => {
+    const { loop } = buildLoop([
+      [
+        toolCallRequestEvent('echo', 'abandoned'),
+        retryEvent(),
+        toolCallRequestEvent('echo', 'kept'),
+        finishedEvent(),
+      ],
+      [contentEvent('all done'), finishedEvent()],
+    ]);
+
+    const events = await collectEvents(
+      loop,
+      'go',
+      new AbortController().signal,
+    );
+
+    const streamEvents = events.filter(isStream);
+    const retryIndex = streamEvents.findIndex(
+      (e) => e.event.type === AgentEventType.Retry,
+    );
+    const keptIndex = streamEvents.findIndex(
+      (e) =>
+        e.event.type === AgentEventType.ToolCallRequest &&
+        e.event.value.callId === 'kept',
+    );
+    expect(retryIndex).toBeGreaterThanOrEqual(0);
+    expect(keptIndex).toBeGreaterThanOrEqual(0);
+    expect(retryIndex).toBeLessThan(keptIndex);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P05
+   * @requirement REQ-3048-006
+   * @scenario keeps the turn alive across a Retry (shouldScheduleTools stays true)
+   */
+  it('keeps the turn alive across a Retry', async () => {
+    const { loop } = buildLoop([
+      [
+        toolCallRequestEvent('echo', 'abandoned'),
+        retryEvent(),
+        toolCallRequestEvent('echo', 'kept'),
+        finishedEvent(),
+      ],
+      [contentEvent('all done'), finishedEvent()],
+    ]);
+
+    const events = await collectEvents(
+      loop,
+      'go',
+      new AbortController().signal,
+    );
+
+    // A tools_complete event proves the turn was NOT treated as terminal and
+    // the successful attempt's tool call was actually scheduled and run.
+    expect(events.some(isToolsComplete)).toBe(true);
+  });
+
+  /**
+   * Fence: the existing terminal-Error discard behaviour is unchanged.
+   */
+  it('still drops tool calls and stops on a terminal Error event', async () => {
+    const { loop } = buildLoop([
+      [
+        toolCallRequestEvent('echo', 'doomed'),
+        {
+          type: AgentEventType.Error,
+          value: { error: { message: 'provider failed' } },
+        },
+      ],
+    ]);
+
+    const events = await collectEvents(
+      loop,
+      'go',
+      new AbortController().signal,
+    );
+
+    expect(events.some(isToolsComplete)).toBe(false);
+  });
+});

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.retryDiscard.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.retryDiscard.test.ts
@@ -77,11 +77,11 @@ describe('AgenticLoop discards abandoned tool-call requests on Retry (issue 3048
     return { loop, ...scripted };
   }
 
-  /** CallIds of completed tool calls, in order, from the tools_complete event. */
+  /** CallIds of completed tool calls, in order, across all completion batches. */
   function completedCallIds(events: readonly AgenticLoopEvent[]): string[] {
-    const complete = events.find(isToolsComplete);
-    if (!complete) return [];
-    return complete.completed.map((call) => call.request.callId);
+    return events
+      .filter(isToolsComplete)
+      .flatMap((event) => event.completed.map((call) => call.request.callId));
   }
 
   /**

--- a/packages/agents/src/core/chatSession.issue2150.test.ts
+++ b/packages/agents/src/core/chatSession.issue2150.test.ts
@@ -249,7 +249,21 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
 
     const events = await collectEvents(stream);
     expect(attempt).toBe(2);
-    expect(events.some((event) => event.type === 'retry')).toBe(true);
+    const retryIndex = events.findIndex((event) => event.type === 'retry');
+    expect(retryIndex).toBeGreaterThanOrEqual(0);
+    const replacementBlocks = events
+      .slice(retryIndex + 1)
+      .flatMap((event) =>
+        event.type === 'chunk' ? event.value.content.blocks : [],
+      );
+    expect(
+      replacementBlocks.some(
+        (block) => block.type === 'text' && block.text === 'recovered response',
+      ),
+    ).toBe(true);
+    expect(replacementBlocks.some((block) => block.type === 'tool_call')).toBe(
+      false,
+    );
   });
 
   it('restarts the turn after a connection error that followed hidden thinking metadata', async () => {
@@ -290,7 +304,21 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
 
     const events = await collectEvents(stream);
     expect(attempt).toBe(2);
-    expect(events.some((event) => event.type === 'retry')).toBe(true);
+    const retryIndex = events.findIndex((event) => event.type === 'retry');
+    expect(retryIndex).toBeGreaterThanOrEqual(0);
+    const replacementBlocks = events
+      .slice(retryIndex + 1)
+      .flatMap((event) =>
+        event.type === 'chunk' ? event.value.content.blocks : [],
+      );
+    expect(
+      replacementBlocks.some(
+        (block) => block.type === 'text' && block.text === 'recovered response',
+      ),
+    ).toBe(true);
+    expect(replacementBlocks.some((block) => block.type === 'thinking')).toBe(
+      false,
+    );
   });
 
   it('does NOT retry a non-transient error thrown mid-stream and stops the loop', async () => {

--- a/packages/agents/src/core/chatSession.issue2150.test.ts
+++ b/packages/agents/src/core/chatSession.issue2150.test.ts
@@ -204,14 +204,19 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
     const events = await collectEvents(stream);
     expect(attempt).toBe(2);
     expect(generateChatCompletionMock).toHaveBeenCalledTimes(2);
-    const texts = events.flatMap((event) =>
-      event.type === 'chunk'
-        ? event.value.content.blocks
-            .filter((block) => block.type === 'text')
-            .map((block) => (block as { text: string }).text)
-        : [],
-    );
-    expect(texts).toContain('recovered response');
+    const retryIndex = events.findIndex((event) => event.type === 'retry');
+    expect(retryIndex).toBeGreaterThanOrEqual(0);
+    const replacementTexts = events
+      .slice(retryIndex + 1)
+      .flatMap((event) =>
+        event.type === 'chunk'
+          ? event.value.content.blocks.flatMap((block) =>
+              block.type === 'text' ? [block.text] : [],
+            )
+          : [],
+      );
+    expect(replacementTexts).toContain('recovered response');
+    expect(replacementTexts).not.toContain('partial');
   });
 
   it('restarts the turn after a connection error that followed a tool call', async () => {

--- a/packages/agents/src/core/chatSession.issue2150.test.ts
+++ b/packages/agents/src/core/chatSession.issue2150.test.ts
@@ -20,6 +20,12 @@
  * StreamProcessor) with a fake provider, using the real network-error
  * classifier (retry.ts is intentionally NOT mocked) so the behavior is
  * end-to-end and faithful to production.
+ *
+ * Issue #3048 replaced the post-output no-retry contract with
+ * discard-and-restart: a transient transport failure that follows visible
+ * output now restarts the turn once under the existing bounded budget. The
+ * abort, non-transient, InvalidStreamError and EmptyStreamError cases below are
+ * unchanged and are the regression fence for that boundary.
  */
 
 import { describe, it, expect, beforeEach, vi } from '../testApi.js';
@@ -164,7 +170,7 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
     return events;
   }
 
-  it('does not retry a connection error after visible content was emitted', async () => {
+  it('restarts the turn after a connection error that followed visible content', async () => {
     let attempt = 0;
     const generateChatCompletionMock = vi.fn(async function* (
       _options: GenerateChatOptions,
@@ -180,7 +186,7 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
         };
         throw createConnectionError();
       }
-      // Second attempt: the turn is retried from scratch and completes.
+      // Second attempt: the turn is restarted from scratch and completes.
       yield {
         speaker: 'ai',
         blocks: [{ type: 'text', text: 'recovered response' }],
@@ -195,29 +201,43 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-issue-2150-midstream',
     );
 
-    await expect(collectEvents(stream)).rejects.toThrow('Connection error.');
-    expect(attempt).toBe(1);
-    expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
+    const events = await collectEvents(stream);
+    expect(attempt).toBe(2);
+    expect(generateChatCompletionMock).toHaveBeenCalledTimes(2);
+    const texts = events.flatMap((event) =>
+      event.type === 'chunk'
+        ? event.value.content.blocks
+            .filter((block) => block.type === 'text')
+            .map((block) => (block as { text: string }).text)
+        : [],
+    );
+    expect(texts).toContain('recovered response');
   });
 
-  it('does not retry a connection error after a tool call was emitted', async () => {
+  it('restarts the turn after a connection error that followed a tool call', async () => {
     let attempt = 0;
     const generateChatCompletionMock = vi.fn(async function* (
       _options: GenerateChatOptions,
     ) {
       attempt++;
+      if (attempt === 1) {
+        yield {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'tool_call',
+              id: 'call-1',
+              name: 'read_file',
+              parameters: { file_path: 'README.md' },
+            },
+          ],
+        };
+        throw createConnectionError();
+      }
       yield {
         speaker: 'ai',
-        blocks: [
-          {
-            type: 'tool_call',
-            id: 'call-1',
-            name: 'read_file',
-            parameters: { file_path: 'README.md' },
-          },
-        ],
+        blocks: [{ type: 'text', text: 'recovered response' }],
       };
-      throw createConnectionError();
     });
     registerProvider(generateChatCompletionMock);
 
@@ -227,32 +247,38 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-issue-2150-tool-call',
     );
 
-    await expect(collectEvents(stream)).rejects.toThrow('Connection error.');
-    expect(attempt).toBe(1);
-    expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
+    const events = await collectEvents(stream);
+    expect(attempt).toBe(2);
+    expect(events.some((event) => event.type === 'retry')).toBe(true);
   });
 
-  it('does not retry after hidden thinking metadata was emitted', async () => {
+  it('restarts the turn after a connection error that followed hidden thinking metadata', async () => {
     let attempt = 0;
     const generateChatCompletionMock = vi.fn(async function* (
       _options: GenerateChatOptions,
     ) {
       attempt++;
+      if (attempt === 1) {
+        yield {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'thinking',
+              thought: '',
+              sourceField: 'thinking',
+              signature: 'state-token',
+              streamId: 'reasoning-1',
+              streamStatus: 'complete',
+              isHidden: true,
+            },
+          ],
+        };
+        throw createConnectionError();
+      }
       yield {
         speaker: 'ai',
-        blocks: [
-          {
-            type: 'thinking',
-            thought: '',
-            sourceField: 'thinking',
-            signature: 'state-token',
-            streamId: 'reasoning-1',
-            streamStatus: 'complete',
-            isHidden: true,
-          },
-        ],
+        blocks: [{ type: 'text', text: 'recovered response' }],
       };
-      throw createConnectionError();
     });
     registerProvider(generateChatCompletionMock);
 
@@ -262,9 +288,9 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-issue-2150-thinking-metadata',
     );
 
-    await expect(collectEvents(stream)).rejects.toThrow('Connection error.');
-    expect(attempt).toBe(1);
-    expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
+    const events = await collectEvents(stream);
+    expect(attempt).toBe(2);
+    expect(events.some((event) => event.type === 'retry')).toBe(true);
   });
 
   it('does NOT retry a non-transient error thrown mid-stream and stops the loop', async () => {
@@ -290,7 +316,7 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
 
     // A non-transient error must still propagate (loop breaks) and must NOT be
     // retried, so the provider is invoked exactly once.
-    await expect(collectEvents(stream)).rejects.toThrow('Bad request');
+    expect(collectEvents(stream)).rejects.toThrow('Bad request');
     expect(attempt).toBe(1);
     expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
   });
@@ -323,13 +349,13 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-issue-2150-abort',
     );
 
-    await expect(collectEvents(stream)).rejects.toThrow('Request aborted');
+    expect(collectEvents(stream)).rejects.toThrow('Request aborted');
     // The abort must terminate immediately without a retry.
     expect(attempt).toBe(1);
     expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
   });
 
-  it('stops retrying a persistently failing connection error after exhausting the retry budget', async () => {
+  it('stops retrying a persistently failing connection error after exhausting the restart budget', async () => {
     let attempt = 0;
     const generateChatCompletionMock = vi.fn(async function* (
       _options: GenerateChatOptions,
@@ -351,9 +377,10 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-issue-2150-persistent',
     );
 
-    await expect(collectEvents(stream)).rejects.toThrow('Connection error.');
-    expect(attempt).toBe(1);
-    expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
+    // One restart is permitted (maxAttempts: 2); a second failure propagates.
+    expect(collectEvents(stream)).rejects.toThrow('Connection error.');
+    expect(attempt).toBe(2);
+    expect(generateChatCompletionMock).toHaveBeenCalledTimes(2);
   });
 
   it('does NOT retry when the request was aborted via the abort signal (no AbortError name)', async () => {
@@ -392,7 +419,7 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
     );
 
     // The error propagates; the aborted signal must suppress the retry.
-    await expect(collectEvents(stream)).rejects.toThrow('terminated');
+    expect(collectEvents(stream)).rejects.toThrow('terminated');
     expect(attempt).toBe(1);
     expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
   });
@@ -426,13 +453,13 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-issue-2150-abort-code',
     );
 
-    await expect(collectEvents(stream)).rejects.toThrow('terminated');
+    expect(collectEvents(stream)).rejects.toThrow('terminated');
     // The ABORT_ERR code must classify this as an abort and suppress retry.
     expect(attempt).toBe(1);
     expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not commit a failed response after visible content was emitted', async () => {
+  it('records only the successful attempt in history after a discard-and-restart', async () => {
     const history = new HistoryService();
     let attempt = 0;
     const generateChatCompletionMock = vi.fn(async function* (
@@ -460,13 +487,20 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-issue-2150-history-safety',
     );
 
-    await expect(collectEvents(stream)).rejects.toThrow('Connection error.');
-    expect(attempt).toBe(1);
+    const events = await collectEvents(stream);
+    expect(attempt).toBe(2);
+    expect(events.some((event) => event.type === 'retry')).toBe(true);
 
     await chat.waitForIdle();
 
     const ai = history.getAll().filter((content) => content.speaker === 'ai');
-    expect(ai).toHaveLength(0);
+    expect(ai).toHaveLength(1);
+    const aiText = ai[0].blocks
+      .filter((block) => block.type === 'text')
+      .map((block) => (block as { text: string }).text)
+      .join('');
+    expect(aiText).toBe('recovered response');
+    expect(aiText).not.toContain('partial');
   });
 
   it('does not retry InvalidStreamError after a chunk was already emitted', async () => {
@@ -499,7 +533,7 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-issue-2150-invalid-stream',
     );
 
-    await expect(collectEvents(stream)).rejects.toThrow(InvalidStreamError);
+    expect(collectEvents(stream)).rejects.toThrow(InvalidStreamError);
     expect(attempt).toBe(1);
   });
 
@@ -530,7 +564,7 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-issue-2150-empty-stream',
     );
 
-    await expect(collectEvents(stream)).rejects.toThrow(EmptyStreamError);
+    expect(collectEvents(stream)).rejects.toThrow(EmptyStreamError);
     expect(attempt).toBe(1);
   });
 
@@ -562,7 +596,7 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       'prompt-shared-transport-budget',
     );
 
-    await expect(collectEvents(stream)).rejects.toMatchObject({
+    expect(collectEvents(stream)).rejects.toMatchObject({
       name: 'RetriesExhaustedError',
       category: 'server_error',
       isRetryable: false,

--- a/packages/agents/src/core/chatSession.issue3048.discardRestart.test.ts
+++ b/packages/agents/src/core/chatSession.issue3048.discardRestart.test.ts
@@ -1,0 +1,664 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3048: a transient transport failure that surfaces AFTER the model has
+ * already emitted output (text, thinking, or a tool call) must trigger a
+ * bounded discard-and-restart of the turn, not a fatal error. Every layer that
+ * accumulated state for the abandoned attempt throws it away; the turn restarts
+ * from a fresh StreamProcessor accumulator/history boundary under the existing
+ * `INVALID_CONTENT_RETRY_OPTIONS` budget (exactly one restart per turn).
+ *
+ * Before output, the existing classification is unchanged: InvalidStreamError,
+ * EmptyStreamError and transient network errors retry. After output, only a
+ * transient transport failure (isNetworkTransientError) qualifies. Abort,
+ * non-transient, terminal and exhausted cases still fail.
+ *
+ * These tests drive the REAL stack (ChatSession -> TurnProcessor ->
+ * StreamProcessor) with a fake provider, using the real network-error
+ * classifier (retry.ts is intentionally NOT mocked) so the behavior is
+ * end-to-end and faithful to production. The only double is the provider's
+ * generateChatCompletion async generator.
+ */
+
+import { describe, it, expect, beforeEach, vi } from '../testApi.js';
+import { ChatSession } from './chatSession.js';
+import type { StreamEvent } from './chatSession.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { TestRuntimeProviderManager } from '../test-utils/runtimeProviderManager.js';
+import {
+  createProviderRuntimeContext,
+  type ProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import {
+  createProviderAdapterFromManager,
+  createTelemetryAdapterFromConfig,
+  createToolRegistryViewFromRegistry,
+} from '@vybestack/llxprt-code-core/runtime/runtimeAdapters.js';
+import { createConfigParams } from './chatSession-runtime-helpers.js';
+import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type { RuntimeGenerateChatOptions as GenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import {
+  StreamEventType,
+  InvalidStreamError,
+} from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
+
+describe('Issue 3048: discard-and-restart after a transient transport failure that followed partial output', () => {
+  let settingsService: SettingsService;
+  let config: Config;
+  let manager: TestRuntimeProviderManager;
+  let providerRuntime: ProviderRuntimeContext;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    config = new Config(createConfigParams(settingsService));
+
+    settingsService.set('providers.stub.base-url', 'https://stub.example.com');
+    settingsService.set('providers.stub.auth-key', 'stub-api-key');
+    settingsService.set('providers.stub.model', 'stub-model');
+
+    providerRuntime = createProviderRuntimeContext({
+      settingsService,
+      config,
+      runtimeId: 'test.runtime',
+      metadata: { source: 'chatSession.issue3048.test' },
+    });
+
+    manager = new TestRuntimeProviderManager(providerRuntime);
+    manager.setConfig(config);
+    config.setProviderManager(manager);
+  });
+
+  function buildChatSession(history?: HistoryService): ChatSession {
+    const runtimeState = createAgentRuntimeState({
+      runtimeId: 'runtime-test-3048',
+      provider: 'stub',
+      model: config.getModel(),
+      sessionId: config.getSessionId(),
+    });
+    const view = createAgentRuntimeContext({
+      state: runtimeState,
+      history: history ?? new HistoryService(),
+      settings: {
+        compressionThreshold: 0.8,
+        contextLimit: 128000,
+        preserveThreshold: 0.2,
+        telemetry: {
+          enabled: true,
+          target: null,
+        },
+        'reasoning.includeInContext': true,
+      },
+      provider: createProviderAdapterFromManager(config.getProviderManager()),
+      telemetry: createTelemetryAdapterFromConfig(config),
+      tools: createToolRegistryViewFromRegistry(config.getToolRegistry()),
+      providerRuntime: { ...providerRuntime },
+    });
+
+    return new ChatSession(view, {} as unknown as ContentGenerator, {}, []);
+  }
+
+  function registerProvider(
+    generateChatCompletion: (
+      options: GenerateChatOptions,
+    ) => AsyncGenerator<unknown>,
+  ): IProvider {
+    const provider: IProvider = {
+      name: 'stub',
+      isDefault: true,
+      getModels: vi.fn(async () => []),
+      getDefaultModel: () => 'stub-model',
+      generateChatCompletion:
+        generateChatCompletion as IProvider['generateChatCompletion'],
+      getServerTools: () => [],
+      invokeServerTool: vi.fn(),
+      getAuthToken: vi.fn(async () => 'stub-auth-token'),
+    } as unknown as IProvider;
+    manager.registerProvider(provider);
+    return provider;
+  }
+
+  function createConnectionError(): Error {
+    const error = new Error('Connection error.') as Error & {
+      status?: number;
+    };
+    error.status = undefined;
+    return error;
+  }
+
+  function createBadRequestError(): Error {
+    const error = new Error('Bad request') as Error & { status?: number };
+    error.status = 400;
+    return error;
+  }
+
+  async function collectEvents(
+    stream: AsyncGenerator<StreamEvent>,
+  ): Promise<StreamEvent[]> {
+    const events: StreamEvent[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    return events;
+  }
+
+  /** Collects every text fragment carried by CHUNK stream events, in order. */
+  function collectChunkText(events: readonly StreamEvent[]): string[] {
+    const texts: string[] = [];
+    for (const event of events) {
+      if (event.type !== StreamEventType.CHUNK) continue;
+      for (const block of event.value.content.blocks) {
+        if (block.type === 'text' && block.text.length > 0) {
+          texts.push(block.text);
+        }
+      }
+    }
+    return texts;
+  }
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P02
+   * @requirement REQ-3048-002
+   * @scenario Transient transport failure after partial output
+   * @given attempt 1 yields 'partial' then throws Error('Connection error.')
+   * @when the caller drains chat.sendMessageStream(...)
+   * @then the provider is invoked twice and the stream completes
+   * @and exactly one RETRY event precedes every attempt-2 chunk
+   */
+  it('restarts the turn after a transient transport failure that followed partial output', async () => {
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      if (attempt === 1) {
+        yield {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'partial' }],
+        };
+        throw createConnectionError();
+      }
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'recovered response' }],
+      };
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      { message: 'trigger mid-stream connection error' },
+      'prompt-issue-3048-partial',
+    );
+
+    const events = await collectEvents(stream);
+
+    expect(attempt).toBe(2);
+    expect(generateChatCompletionMock).toHaveBeenCalledTimes(2);
+
+    const retryIndices = events
+      .map((event, index) =>
+        event.type === StreamEventType.RETRY ? index : -1,
+      )
+      .filter((index) => index >= 0);
+    expect(retryIndices).toHaveLength(1);
+    const retryIndex = retryIndices[0];
+
+    // No chunk after the RETRY carries abandoned text; only recovered text.
+    const postRetryTexts = collectChunkText(events.slice(retryIndex + 1));
+    expect(postRetryTexts).not.toContain('partial');
+    expect(postRetryTexts).toContain('recovered response');
+
+    // No chunk before the RETRY carries the recovered text.
+    const preRetryTexts = collectChunkText(events.slice(0, retryIndex));
+    expect(preRetryTexts).toContain('partial');
+    expect(preRetryTexts).not.toContain('recovered response');
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P02
+   * @requirement REQ-3048-002
+   * @scenario Transient transport failure after an abandoned tool_call block
+   */
+  it('restarts after an abandoned tool_call block', async () => {
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      if (attempt === 1) {
+        yield {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'tool_call',
+              id: 'abandoned-call',
+              name: 'read_file',
+              parameters: { file_path: 'README.md' },
+            },
+          ],
+        };
+        throw createConnectionError();
+      }
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'recovered response' }],
+      };
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      { message: 'trigger tool call before a connection error' },
+      'prompt-issue-3048-tool-call',
+    );
+
+    const events = await collectEvents(stream);
+
+    expect(attempt).toBe(2);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      true,
+    );
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P02
+   * @requirement REQ-3048-002
+   * @scenario Transient transport failure after abandoned hidden thinking
+   */
+  it('restarts after abandoned hidden thinking metadata', async () => {
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      if (attempt === 1) {
+        yield {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'thinking',
+              thought: '',
+              sourceField: 'thinking',
+              signature: 'state-token',
+              streamId: 'reasoning-1',
+              streamStatus: 'complete',
+              isHidden: true,
+            },
+          ],
+        };
+        throw createConnectionError();
+      }
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'recovered response' }],
+      };
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      { message: 'trigger hidden thinking before a connection error' },
+      'prompt-issue-3048-thinking',
+    );
+
+    const events = await collectEvents(stream);
+
+    expect(attempt).toBe(2);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      true,
+    );
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P02
+   * @requirement REQ-3048-005
+   * @scenario Durable history is the successful attempt alone
+   */
+  it('records only the successful attempt in history', async () => {
+    const history = new HistoryService();
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      if (attempt === 1) {
+        yield {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'partial' }],
+        };
+        throw createConnectionError();
+      }
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'recovered response' }],
+      };
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession(history);
+    const stream = await chat.sendMessageStream(
+      { message: 'history-safety discard restart' },
+      'prompt-issue-3048-history',
+    );
+    await collectEvents(stream);
+
+    await chat.waitForIdle();
+
+    const ai = history.getAll().filter((content) => content.speaker === 'ai');
+    expect(ai).toHaveLength(1);
+    const aiText = ai[0].blocks
+      .filter((block) => block.type === 'text')
+      .map((block) => (block as { text: string }).text)
+      .join('');
+    expect(aiText).toBe('recovered response');
+    expect(aiText).not.toContain('partial');
+
+    const human = history
+      .getAll()
+      .filter((content) => content.speaker === 'human');
+    expect(human).toHaveLength(1);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P02
+   * @requirement REQ-3048-003
+   * @scenario Restart budget exhaustion still fails
+   */
+  it('fails after the restart budget is spent', async () => {
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'partial' }],
+      };
+      // Every attempt fails with the same transient connection error.
+      throw createConnectionError();
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      { message: 'trigger persistent connection error after output' },
+      'prompt-issue-3048-budget',
+    );
+
+    expect(collectEvents(stream)).rejects.toThrow('Connection error.');
+    expect(attempt).toBe(2);
+    expect(generateChatCompletionMock).toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P02
+   * @requirement REQ-3048-003
+   * @scenario Non-transient failure after output does not restart
+   */
+  it('does not restart a non-transient failure after output', async () => {
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'partial' }],
+      };
+      throw createBadRequestError();
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      { message: 'trigger non-transient error after output' },
+      'prompt-issue-3048-nontransient',
+    );
+
+    expect(collectEvents(stream)).rejects.toThrow('Bad request');
+    expect(attempt).toBe(1);
+    expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P02
+   * @requirement REQ-3048-003
+   * @scenario Content-validity verdict after output is not a transport failure
+   */
+  it('does not restart an InvalidStreamError raised after output', async () => {
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      if (attempt === 1) {
+        yield {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'partial' }],
+        };
+        throw new InvalidStreamError(
+          'stream produced no usable text',
+          'NO_RESPONSE_TEXT',
+        );
+      }
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'recovered response' }],
+      };
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      { message: 'trigger InvalidStreamError after output' },
+      'prompt-issue-3048-invalid-stream',
+    );
+
+    expect(collectEvents(stream)).rejects.toThrow(InvalidStreamError);
+    expect(attempt).toBe(1);
+    expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P02
+   * @requirement REQ-3048-004
+   * @scenario Abort wins even after output, on every abort mechanism
+   */
+  it('does not restart when the failure is an abort (name + code) after output', async () => {
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'partial' }],
+      };
+      const abortError = new Error('Request aborted') as Error & {
+        code?: string;
+      };
+      abortError.name = 'AbortError';
+      abortError.code = 'ABORT_ERR';
+      throw abortError;
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      { message: 'trigger abort after output' },
+      'prompt-issue-3048-abort',
+    );
+
+    expect(collectEvents(stream)).rejects.toThrow('Request aborted');
+    expect(attempt).toBe(1);
+    expect(generateChatCompletionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not restart on an ABORT_ERR code (without AbortError name) after output', async () => {
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'partial' }],
+      };
+      const err = new Error('terminated') as Error & { code?: string };
+      err.code = 'ABORT_ERR';
+      throw err;
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      { message: 'trigger ABORT_ERR code after output' },
+      'prompt-issue-3048-abort-code',
+    );
+
+    expect(collectEvents(stream)).rejects.toThrow('terminated');
+    expect(attempt).toBe(1);
+  });
+
+  it('does not restart when the abort signal fired (transient phrase, no abort name/code) after output', async () => {
+    const abortController = new AbortController();
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'partial' }],
+      };
+      abortController.abort();
+      throw new Error('terminated');
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      {
+        message: 'trigger aborted signal after output',
+        config: { abortSignal: abortController.signal },
+      },
+      'prompt-issue-3048-abort-signal',
+    );
+
+    expect(collectEvents(stream)).rejects.toThrow('terminated');
+    expect(attempt).toBe(1);
+  });
+
+  /**
+   * @plan PLAN-20260806-ISSUE3048.P02
+   * @requirement REQ-3048-011
+   * @scenario Eagerly recorded tool-response ids survive the discard
+   * @given a tool response is eagerly recorded before the next send, and the
+   *        next turn's message carries that same tool_response, and the stream
+   *        restarts once after a transient failure following partial output
+   * @then the final history contains exactly one tool_response block for that
+   *       callId (not a duplicate from the successful attempt)
+   */
+  it('keeps eagerly recorded tool-response ids across a discard', async () => {
+    const history = new HistoryService();
+    let attempt = 0;
+    const generateChatCompletionMock = vi.fn(async function* (
+      _options: GenerateChatOptions,
+    ) {
+      attempt++;
+      if (attempt === 1) {
+        yield {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'partial' }],
+        };
+        throw createConnectionError();
+      }
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Done.' }],
+      };
+    });
+    registerProvider(generateChatCompletionMock);
+
+    const chat = buildChatSession(history);
+
+    const completed = [
+      {
+        status: 'success' as const,
+        request: {
+          callId: 'toolu_eager_1',
+          name: 'read_file',
+          args: { file_path: '/test/package.json' },
+          prompt_id: 'prompt-eager-1',
+          agentId: 'default_agent',
+          isClientInitiated: false,
+        },
+        response: {
+          callId: 'toolu_eager_1',
+          responseParts: [
+            {
+              type: 'tool_call',
+              id: 'toolu_eager_1',
+              name: 'read_file',
+              parameters: { file_path: '/test/package.json' },
+            },
+            {
+              type: 'tool_response',
+              callId: 'toolu_eager_1',
+              toolName: 'read_file',
+              result: { output: 'package-json' },
+            },
+          ],
+          resultDisplay: 'package-json',
+        },
+        invocation: { execute: vi.fn() },
+      },
+    ];
+    chat.recordCompletedToolCalls('stub-model', completed);
+
+    const stream = await chat.sendMessageStream(
+      {
+        message: {
+          speaker: 'tool',
+          blocks: [
+            {
+              type: 'tool_response',
+              callId: 'toolu_eager_1',
+              toolName: 'read_file',
+              result: { output: 'package-json' },
+            },
+            { type: 'text', text: 'Continue with the analysis.' },
+          ],
+        },
+      },
+      'prompt-eager-1',
+    );
+    await collectEvents(stream);
+
+    await chat.waitForIdle();
+    expect(attempt).toBe(2);
+
+    const toolResponseCount = history
+      .getAll()
+      .reduce(
+        (count, content) =>
+          count +
+          content.blocks.filter(
+            (block) =>
+              block.type === 'tool_response' &&
+              (block as { callId?: string }).callId === 'toolu_eager_1',
+          ).length,
+        0,
+      );
+    expect(toolResponseCount).toBe(1);
+  });
+});

--- a/packages/agents/src/core/chatSession.issue3048.discardRestart.test.ts
+++ b/packages/agents/src/core/chatSession.issue3048.discardRestart.test.ts
@@ -240,9 +240,15 @@ describe('Issue 3048: discard-and-restart after a transient transport failure th
           blocks: [
             {
               type: 'tool_call',
-              id: 'abandoned-call',
+              id: 'abandoned-call-1',
               name: 'read_file',
               parameters: { file_path: 'README.md' },
+            },
+            {
+              type: 'tool_call',
+              id: 'abandoned-call-2',
+              name: 'read_file',
+              parameters: { file_path: 'CHANGELOG.md' },
             },
           ],
         };
@@ -264,8 +270,35 @@ describe('Issue 3048: discard-and-restart after a transient transport failure th
     const events = await collectEvents(stream);
 
     expect(attempt).toBe(2);
-    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
-      true,
+    const retryIndex = events.findIndex(
+      (event) => event.type === StreamEventType.RETRY,
+    );
+    expect(retryIndex).toBeGreaterThanOrEqual(0);
+    const abandonedToolCallIds = events
+      .slice(0, retryIndex)
+      .flatMap((event) =>
+        event.type === StreamEventType.CHUNK
+          ? event.value.content.blocks.flatMap((block) =>
+              block.type === 'tool_call' ? [block.id] : [],
+            )
+          : [],
+      );
+    expect(abandonedToolCallIds).toEqual([
+      'abandoned-call-1',
+      'abandoned-call-2',
+    ]);
+    const replacementBlocks = events
+      .slice(retryIndex + 1)
+      .flatMap((event) =>
+        event.type === StreamEventType.CHUNK ? event.value.content.blocks : [],
+      );
+    expect(
+      replacementBlocks.some(
+        (block) => block.type === 'text' && block.text === 'recovered response',
+      ),
+    ).toBe(true);
+    expect(replacementBlocks.some((block) => block.type === 'tool_call')).toBe(
+      false,
     );
   });
 

--- a/packages/agents/src/core/messageStreamOrchestrator.checkpoint.bun.test.ts
+++ b/packages/agents/src/core/messageStreamOrchestrator.checkpoint.bun.test.ts
@@ -1,0 +1,696 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the unified attempt checkpoint in
+ * MessageStreamOrchestrator (issue #3048 review findings 2, 3, 4).
+ *
+ * These tests exercise the REAL LoopDetectionService and REAL
+ * TodoContinuationService through the orchestrator's public `execute` loop, and
+ * prove that Retry restores attempt-mutable detector/task-list state and
+ * preserves response text contributed by earlier successful internal-loop
+ * iterations.
+ *
+ * @requirement REQ-3048-007 (review findings 2, 3, 4)
+ */
+
+import { describe, it, expect, vi, beforeEach } from '../testApi.js';
+import type { AgentMessageInput } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import type {
+  ServerAgentStreamEvent,
+  ServerFinishedOutcome,
+  ThoughtSummary,
+  ToolCallRequestInfo,
+} from './turn.js';
+import { AgentEventType } from './turn.js';
+import type { ChatSession } from './chatSession.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
+import { LoopDetectionService } from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
+import { TodoContinuationService } from './TodoContinuationService.js';
+import { TodoReminderService } from '@vybestack/llxprt-code-core/services/todo-reminder-service.js';
+import type { Todo } from '@vybestack/llxprt-code-tools';
+
+const mockTurnRun = vi.fn();
+
+vi.mock('./turn.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./turn.js')>();
+  class MockTurn {
+    pendingToolCalls: unknown[] = [];
+    run = mockTurnRun;
+  }
+  return {
+    ...actual,
+    Turn: MockTurn as unknown as typeof actual.Turn,
+  };
+});
+
+vi.mock('@vybestack/llxprt-code-tools', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@vybestack/llxprt-code-tools')>();
+  const fakeStore = () => ({
+    readTodos: vi.fn().mockResolvedValue([]),
+    readPausedState: vi.fn().mockResolvedValue(false),
+    writePausedState: vi.fn().mockResolvedValue(undefined),
+  });
+  return {
+    ...actual,
+    LocalTodoStore: vi.fn().mockImplementation(fakeStore),
+  };
+});
+
+import {
+  MessageStreamOrchestrator,
+  type MessageStreamDeps,
+} from './MessageStreamOrchestrator.js';
+
+// --- scripted event constructors ---
+
+function content(text: string): ServerAgentStreamEvent {
+  return { type: AgentEventType.Content, value: text };
+}
+
+function retryEvent(): ServerAgentStreamEvent {
+  return { type: AgentEventType.Retry };
+}
+
+function thoughtEvent(): ServerAgentStreamEvent {
+  const value: ThoughtSummary = {
+    subject: 'planning',
+    description: 'reasoning',
+  };
+  return { type: AgentEventType.Thought, value };
+}
+
+function finishedEvent(
+  outcome?: Partial<ServerFinishedOutcome>,
+): ServerAgentStreamEvent {
+  const full: ServerFinishedOutcome = {
+    hadVisibleOutput: outcome?.hadVisibleOutput ?? true,
+    hadThinking: outcome?.hadThinking ?? false,
+    hadToolCalls: outcome?.hadToolCalls ?? false,
+  };
+  return {
+    type: AgentEventType.Finished,
+    value: { reason: 'stop', outcome: full },
+  };
+}
+
+function toolCallRequest(callId: string): ServerAgentStreamEvent {
+  const value: ToolCallRequestInfo = {
+    callId,
+    name: 'read_file',
+    args: { file_path: '/tmp/x' },
+    isClientInitiated: false,
+    prompt_id: 'prompt-1',
+  };
+  return { type: AgentEventType.ToolCallRequest, value };
+}
+
+function todoWriteRequest(
+  callId: string,
+  todos: readonly Todo[],
+): ServerAgentStreamEvent {
+  const value: ToolCallRequestInfo = {
+    callId,
+    name: 'todo_write',
+    args: { todos: [...todos] },
+    isClientInitiated: false,
+    prompt_id: 'prompt-1',
+  };
+  return { type: AgentEventType.ToolCallRequest, value };
+}
+
+function streamFrom(
+  events: readonly ServerAgentStreamEvent[],
+): AsyncGenerator<ServerAgentStreamEvent> {
+  return (async function* (): AsyncGenerator<ServerAgentStreamEvent> {
+    for (const e of events) yield e;
+  })();
+}
+
+// --- real service construction ---
+
+function makeLoopConfig(toolCallThreshold: number): Config {
+  return {
+    getEphemeralSetting: (key: string) =>
+      key === 'toolCallLoopThreshold' ? toolCallThreshold : undefined,
+    getMaxSessionTurns: () => 100,
+    getIdeMode: () => false,
+    getContinueOnFailedApiCall: () => false,
+    getSettingsService: () => ({
+      getCurrentProfileName: () => null,
+      get: () => undefined,
+    }),
+    getSessionId: () => 'test-session',
+  } as unknown as Config;
+}
+
+function makeRealLoopDetector(threshold: number): LoopDetectionService {
+  return new LoopDetectionService(makeLoopConfig(threshold));
+}
+
+function makeRealTodoContinuationService(): TodoContinuationService {
+  return new TodoContinuationService({
+    config: makeLoopConfig(50),
+    todoReminderService: new TodoReminderService(),
+    complexitySuggestionCooldown: 300000,
+    todoDataDirResolver: () => '/mock/data/dir',
+  });
+}
+
+interface HarnessOptions {
+  streams: ReadonlyArray<readonly ServerAgentStreamEvent[]>;
+  loopDetector?: LoopDetectionService;
+  todoContinuationService?: TodoContinuationService;
+  complexity?: {
+    isComplex?: boolean;
+    shouldSuggestTodos?: boolean;
+  };
+}
+
+interface Harness {
+  orchestrator: MessageStreamOrchestrator;
+  deps: MessageStreamDeps;
+  afterAgentTexts: string[];
+  loopDetector: LoopDetectionService;
+  todoContinuationService: TodoContinuationService;
+}
+
+function buildHarness(options: HarnessOptions): Harness {
+  const afterAgentTexts: string[] = [];
+  const mockChat = {
+    addHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+    getContextLimit: vi.fn().mockReturnValue(1_000_000),
+  };
+
+  const config = makeLoopConfig(50);
+
+  const loopDetector = options.loopDetector ?? makeRealLoopDetector(50);
+  const todoContinuationService =
+    options.todoContinuationService ?? makeRealTodoContinuationService();
+
+  // Queue of per-iteration streams. Each turn.run() call consumes one entry;
+  // if more iterations run than provided, the last stream repeats.
+  let queueIndex = 0;
+  const streams = [...options.streams];
+  mockTurnRun.mockImplementation(() => {
+    const events = streams[Math.min(queueIndex, streams.length - 1)];
+    queueIndex += 1;
+    return streamFrom(events);
+  });
+
+  const deps: MessageStreamDeps = {
+    config,
+    getChat: () => mockChat as unknown as ChatSession,
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    } as unknown as DebugLogger,
+    loopDetector,
+    todoContinuationService,
+    ideContextTracker: {
+      getContextParts: vi.fn().mockReturnValue({
+        contextParts: [],
+        newIdeContext: undefined,
+      }),
+      recordSentContext: vi.fn(),
+    } as unknown as MessageStreamDeps['ideContextTracker'],
+    agentHookManager: {
+      cleanupOldHookState: vi.fn(),
+      fireBeforeAgentHookSafe: vi.fn().mockResolvedValue(undefined),
+      fireAfterAgentHookSafe: vi.fn(
+        (_id: string, _promptText: string, responseText: string) => {
+          afterAgentTexts.push(responseText);
+          return Promise.resolve(undefined);
+        },
+      ),
+    } as unknown as MessageStreamDeps['agentHookManager'],
+    getEffectiveModelIdentity: () => ({
+      providerName: 'openai',
+      model: 'gpt-4',
+    }),
+    getHistory: vi.fn().mockResolvedValue([]),
+    getSessionTurnCount: vi.fn().mockReturnValue(1),
+    incrementSessionTurnCount: vi.fn(),
+    lazyInitialize: vi.fn().mockResolvedValue(undefined),
+    startChat: vi.fn().mockResolvedValue(mockChat),
+    getPreviousHistory: vi.fn().mockReturnValue(undefined),
+    setChat: vi.fn(),
+    hasChat: vi.fn().mockReturnValue(true),
+    complexityAnalyzer: {
+      analyzeComplexity: vi.fn().mockReturnValue({
+        complexityScore: 0.1,
+        isComplex: options.complexity?.isComplex ?? false,
+        detectedTasks: [],
+        sequentialIndicators: [],
+        questionCount: 0,
+        shouldSuggestTodos: options.complexity?.shouldSuggestTodos ?? false,
+      }),
+    } as unknown as ComplexityAnalyzer,
+    getLastPromptId: () => undefined,
+    setLastPromptId: vi.fn(),
+    resetCurrentSequenceModel: vi.fn(),
+    updateTelemetryTokenCount: vi.fn(),
+    sendMessageStream: vi.fn(
+      async function* (): AsyncGenerator<ServerAgentStreamEvent> {
+        /* empty recovery stream */
+      },
+    ),
+  };
+
+  return {
+    orchestrator: new MessageStreamOrchestrator(deps),
+    deps,
+    afterAgentTexts,
+    loopDetector,
+    todoContinuationService,
+  };
+}
+
+async function drain(
+  orchestrator: MessageStreamOrchestrator,
+): Promise<ServerAgentStreamEvent[]> {
+  const events: ServerAgentStreamEvent[] = [];
+  for await (const event of orchestrator.execute(
+    [{ text: 'hi' }] as AgentMessageInput,
+    new AbortController().signal,
+    'prompt-1',
+    1,
+    false,
+  )) {
+    events.push(event);
+  }
+  return events;
+}
+
+const VISIBLE = (
+  overrides: Partial<ServerFinishedOutcome> = {},
+): ServerFinishedOutcome => ({
+  hadVisibleOutput: true,
+  hadThinking: false,
+  hadToolCalls: false,
+  ...overrides,
+});
+
+describe('MessageStreamOrchestrator — attempt checkpoint rollback (issue #3048 review)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ----- Finding 2: loop detection transactional rollback -----
+
+  describe('loop detection rollback (finding 2)', () => {
+    /**
+     * @requirement REQ-3048-007
+     * @given a real LoopDetectionService with toolCallLoopThreshold=2.
+     * @when an abandoned tool A is fed, then a transport Retry, then a
+     *   replacement tool A (same signature).
+     * @then the replacement tool A is forwarded (not rejected as a loop),
+     *   because the abandoned attempt's detector state was rolled back.
+     */
+    it('forwards the replacement tool call after an abandoned identical one (threshold 2)', async () => {
+      const loopDetector = makeRealLoopDetector(2);
+      const { orchestrator } = buildHarness({
+        loopDetector,
+        streams: [
+          [
+            toolCallRequest('abandoned-a'),
+            retryEvent(),
+            toolCallRequest('replacement-a'),
+            finishedEvent(VISIBLE()),
+          ],
+        ],
+      });
+
+      const events = await drain(orchestrator);
+
+      const loopDetected = events.some(
+        (e) => e.type === AgentEventType.LoopDetected,
+      );
+      expect(loopDetected).toBe(false);
+
+      const forwardedToolCalls = events.filter(
+        (event) =>
+          event.type === AgentEventType.ToolCallRequest &&
+          event.value.callId === 'replacement-a',
+      );
+      expect(forwardedToolCalls).toHaveLength(1);
+    });
+
+    /**
+     * @requirement REQ-3048-007
+     * @given two identical tool calls in an abandoned attempt reach the detector
+     *   threshold immediately before the transport Retry signal.
+     * @when the replacement attempt emits the same tool once.
+     * @then the pending loop verdict is discarded with the abandoned attempt and
+     *   the replacement call is forwarded.
+     */
+    it('discards a loop verdict reached by the abandoned attempt before retry', async () => {
+      const loopDetector = makeRealLoopDetector(2);
+      const { orchestrator } = buildHarness({
+        loopDetector,
+        streams: [
+          [
+            toolCallRequest('abandoned-a-1'),
+            toolCallRequest('abandoned-a-2'),
+            retryEvent(),
+            toolCallRequest('replacement-a'),
+            finishedEvent(VISIBLE()),
+          ],
+        ],
+      });
+
+      const events = await drain(orchestrator);
+
+      expect(
+        events.some((event) => event.type === AgentEventType.LoopDetected),
+      ).toBe(false);
+      expect(
+        events.some(
+          (event) =>
+            event.type === AgentEventType.ToolCallRequest &&
+            event.value.callId === 'replacement-a',
+        ),
+      ).toBe(true);
+    });
+
+    /**
+     * @requirement REQ-3048-007
+     * @given threshold 2 and the SAME detector without rollback wiring would
+     *   flag the second identical tool call as a loop. This fence proves the
+     *   detector still catches a genuine repeated tool call within ONE attempt.
+     */
+    it('still detects a genuine repeated tool call within a single attempt', async () => {
+      const loopDetector = makeRealLoopDetector(2);
+      const { orchestrator } = buildHarness({
+        loopDetector,
+        streams: [
+          [
+            toolCallRequest('first'),
+            toolCallRequest('second'), // same signature -> 2nd -> loop
+            finishedEvent(VISIBLE()),
+          ],
+        ],
+      });
+
+      const events = await drain(orchestrator);
+
+      expect(events.some((e) => e.type === AgentEventType.LoopDetected)).toBe(
+        true,
+      );
+    });
+
+    /**
+     * @requirement REQ-3048-007
+     * @scenario content detector rollback: abandoned content must not
+     *   contaminate the content-chanting detector for the replacement attempt.
+     */
+    it('rolls back content detector state on retry', async () => {
+      const loopDetector = makeRealLoopDetector(50);
+      const repeatedChunk = 'A'.repeat(50);
+      // Abandoned attempt emits the chunk once; replacement attempt emits it
+      // only once more. Without rollback, the abandoned chunk persists in the
+      // history and the second chunk could look like a repeat.
+      const { orchestrator } = buildHarness({
+        loopDetector,
+        streams: [
+          [
+            content(repeatedChunk),
+            retryEvent(),
+            content(repeatedChunk),
+            finishedEvent(VISIBLE()),
+          ],
+        ],
+      });
+
+      const events = await drain(orchestrator);
+      expect(events.some((e) => e.type === AgentEventType.LoopDetected)).toBe(
+        false,
+      );
+    });
+  });
+
+  // ----- Finding 3: earlier successful internal-loop response preservation -----
+
+  describe('response text preservation across internal iterations (finding 3)', () => {
+    /**
+     * @requirement REQ-3048-007
+     * @given an earlier internal-loop iteration contributes text, then the loop
+     *   continues; a later iteration emits abandoned text, then Retry, then
+     *   replacement text.
+     * @when the AfterAgent hook fires for the completed turn.
+     * @then its responseText is earlier + replacement text, excluding the
+     *   abandoned text.
+     */
+    it('preserves earlier iteration text and excludes abandoned text on AfterAgent', async () => {
+      const { orchestrator, afterAgentTexts } = buildHarness({
+        // Iteration 1: contributes "earlier " but is classified thinking-only
+        // (Finished outcome hadVisibleOutput:false, hadThinking:true), so the
+        // internal loop continues without firing AfterAgent.
+        streams: [
+          [
+            content('earlier '),
+            thoughtEvent(),
+            finishedEvent({ hadVisibleOutput: false, hadThinking: true }),
+          ],
+          // Iteration 2: abandoned text, then transport Retry, then replacement.
+          [
+            content('abandoned '),
+            retryEvent(),
+            content('replacement'),
+            finishedEvent(VISIBLE()),
+          ],
+        ],
+      });
+
+      await drain(orchestrator);
+
+      expect(afterAgentTexts).toHaveLength(1);
+      expect(afterAgentTexts[0]).toBe('earlier replacement');
+    });
+  });
+
+  // ----- Finding 4: TodoContinuationService transactional rollback -----
+
+  describe('task-list continuation rollback (finding 4)', () => {
+    /**
+     * @requirement REQ-3048-007
+     * @given a real TodoContinuationService whose complexity analysis has
+     *   incremented consecutiveComplexTurns to 1 at stream-iteration entry.
+     * @when an abandoned task-list write resets consecutiveComplexTurns,
+     *   then Retry occurs and the replacement produces no task-list call.
+     * @then consecutiveComplexTurns is restored to its pre-attempt value (1),
+     *   not left at the abandoned attempt's 0.
+     */
+    it('restores consecutiveComplexTurns after an abandoned todo_write on retry', async () => {
+      const todoContinuationService = makeRealTodoContinuationService();
+      // Enable complexity tracking so the entry value is non-zero.
+      todoContinuationService.updateTodoToolAvailabilityFromDeclarations([
+        { name: 'todo_write' },
+        { name: 'todo_read' },
+      ]);
+
+      const { orchestrator } = buildHarness({
+        todoContinuationService,
+        complexity: { isComplex: true, shouldSuggestTodos: true },
+        streams: [
+          [
+            todoWriteRequest('abandoned-todo', [
+              { id: 'abandoned', content: 'abandoned task', status: 'pending' },
+            ]),
+            retryEvent(),
+            finishedEvent(VISIBLE()),
+          ],
+        ],
+      });
+
+      await drain(orchestrator);
+
+      // processComplexityAnalysis incremented this to 1 at entry; the
+      // The abandoned task-list write reset the counter; restoration must
+      // return it to the value captured at attempt entry.
+      expect(todoContinuationService.consecutiveComplexTurns).toBe(1);
+    });
+
+    /**
+     * @requirement REQ-3048-007
+     * @scenario an abandoned task-list write must not leak its snapshot:
+     *   restoration retains the snapshot captured at attempt entry.
+     */
+    it('does not leak the abandoned todo snapshot after rollback', async () => {
+      const todoContinuationService = makeRealTodoContinuationService();
+      todoContinuationService.lastTodoSnapshot = [
+        { id: 'orig', content: 'original task', status: 'in_progress' },
+      ];
+
+      const { orchestrator } = buildHarness({
+        todoContinuationService,
+        streams: [
+          [
+            todoWriteRequest('abandoned-todo', [
+              { id: 'abandoned', content: 'abandoned task', status: 'pending' },
+            ]),
+            retryEvent(),
+            // End without another task-list call so the restored snapshot can
+            // be observed without further mutation.
+            finishedEvent(VISIBLE()),
+          ],
+        ],
+      });
+
+      await drain(orchestrator);
+
+      expect(
+        todoContinuationService.lastTodoSnapshot.some(
+          (task) => task.id === 'abandoned',
+        ),
+      ).toBe(false);
+    });
+
+    /**
+     * @requirement REQ-3048-007
+     * @scenario reminder behavior is unaffected by the rollback: the restored
+     *   lastTodoToolTurn keeps escalation logic tied to the prior value.
+     */
+    it('keeps reminder escalation behavior tied to the restored lastTodoToolTurn', async () => {
+      const todoContinuationService = makeRealTodoContinuationService();
+      todoContinuationService.consecutiveComplexTurns = 3;
+      todoContinuationService.setLastTodoToolTurn(3);
+
+      const snapshot = todoContinuationService.checkpoint();
+
+      // Simulate an abandoned attempt mutating state.
+      todoContinuationService.setLastTodoToolTurn(99);
+      todoContinuationService.consecutiveComplexTurns = 1;
+
+      todoContinuationService.restore(snapshot);
+
+      // Three turns and three consecutive complex results satisfy the
+      // escalation policy after state restoration.
+      expect(todoContinuationService.shouldEscalateReminder(6)).toBe(true);
+    });
+  });
+
+  // ----- Direct checkpoint/restore API contracts -----
+
+  describe('LoopDetectionService checkpoint/restore (direct contract)', () => {
+    it('snapshots and restores attempt-mutable tool-call state', () => {
+      const loopDetector = makeRealLoopDetector(2);
+      const toolA = {
+        type: AgentEventType.ToolCallRequest,
+        value: { callId: 'a', name: 'read_file', args: { file_path: '/x' } },
+      };
+      // Checkpoint at entry (before any event), matching the orchestrator.
+      const checkpoint = loopDetector.checkpoint();
+      // First identical tool call -> count 1 (no loop).
+      expect(loopDetector.addAndCheck(toolA)).toBe(false);
+      // Second identical -> count 2 -> loop.
+      expect(loopDetector.addAndCheck(toolA)).toBe(true);
+      // Restore undoes both abandoned calls back to entry state.
+      loopDetector.restore(checkpoint);
+      // The replacement first call is again count 1 -> no loop.
+      expect(loopDetector.addAndCheck(toolA)).toBe(false);
+    });
+
+    it('preserves prompt identity and turn counts across checkpoint/restore', async () => {
+      const loopDetector = makeRealLoopDetector(50);
+      loopDetector.reset('prompt-X');
+      await loopDetector.turnStarted(new AbortController().signal);
+      const checkpoint = loopDetector.checkpoint();
+      loopDetector.addAndCheck({
+        type: AgentEventType.Content,
+        value: 'some content',
+      });
+      loopDetector.restore(checkpoint);
+      // Re-running reset on the same prompt id is a no-op identity-wise; the
+      // point is restore did not wipe prompt-scoped counters. A fresh prompt
+      // resets cleanly afterward.
+      loopDetector.reset('prompt-Y');
+      expect(await loopDetector.turnStarted(new AbortController().signal)).toBe(
+        false,
+      );
+    });
+
+    it('deep-copies content stats so restore removes abandoned content', () => {
+      const loopDetector = makeRealLoopDetector(50);
+      const unique = 'Unique distinctive paragraph number one. ';
+      // Feed enough distinct content to populate the content detector.
+      loopDetector.addAndCheck({
+        type: AgentEventType.Content,
+        value: unique.repeat(2),
+      });
+      const checkpoint = loopDetector.checkpoint();
+      // Abandoned attempt adds different content.
+      loopDetector.addAndCheck({
+        type: AgentEventType.Content,
+        value: 'Completely different abandoned filler content here. ',
+      });
+      // Restore must wipe the abandoned content so the detector only sees the
+      // pre-attempt history going forward.
+      loopDetector.restore(checkpoint);
+      // Re-feeding the original content does not falsely amplify counts.
+      const result = loopDetector.addAndCheck({
+        type: AgentEventType.Content,
+        value: unique,
+      });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('TodoContinuationService checkpoint/restore (direct contract)', () => {
+    it('snapshots and restores all three attempt-local fields', () => {
+      const service = makeRealTodoContinuationService();
+      service.consecutiveComplexTurns = 3;
+      service.setLastTodoToolTurn(4);
+      service.lastTodoSnapshot = [
+        { id: 'orig', content: 'task', status: 'in_progress' },
+      ];
+
+      const snapshot = service.checkpoint();
+
+      // Simulate an abandoned attempt.
+      service.consecutiveComplexTurns = 9;
+      service.setLastTodoToolTurn(40);
+      service.lastTodoSnapshot = [
+        { id: 'gone', content: 'x', status: 'pending' },
+      ];
+
+      service.restore(snapshot);
+
+      expect(service.consecutiveComplexTurns).toBe(3);
+      // Restored cadence and complexity counters satisfy the escalation policy.
+      expect(service.shouldEscalateReminder(7)).toBe(true);
+      expect(service.lastTodoSnapshot[0]?.id).toBe('orig');
+    });
+
+    it('clones the todo snapshot so restore does not alias live state', () => {
+      const service = makeRealTodoContinuationService();
+      service.lastTodoSnapshot = [
+        { id: 'orig', content: 'task', status: 'pending' },
+      ];
+      const snapshot = service.checkpoint();
+      service.lastTodoSnapshot = [
+        { id: 'mutated', content: 'other', status: 'pending' },
+      ];
+
+      service.restore(snapshot);
+      const firstRestore = service.lastTodoSnapshot;
+      firstRestore[0] = {
+        id: 'tampered',
+        content: 'changed',
+        status: 'pending',
+      };
+      service.restore(snapshot);
+
+      expect(service.lastTodoSnapshot[0]?.id).toBe('orig');
+    });
+  });
+});

--- a/packages/agents/src/core/messageStreamOrchestrator.checkpoint.bun.test.ts
+++ b/packages/agents/src/core/messageStreamOrchestrator.checkpoint.bun.test.ts
@@ -135,10 +135,17 @@ function streamFrom(
 
 // --- real service construction ---
 
-function makeLoopConfig(toolCallThreshold: number): Config {
+function makeLoopConfig(
+  toolCallThreshold: number,
+  maxTurnsPerPrompt?: number,
+): Config {
   return {
-    getEphemeralSetting: (key: string) =>
-      key === 'toolCallLoopThreshold' ? toolCallThreshold : undefined,
+    getEphemeralSetting: (key: string) => {
+      if (key === 'toolCallLoopThreshold') return toolCallThreshold;
+      if (key === 'maxTurnsPerPrompt' && maxTurnsPerPrompt !== undefined)
+        return maxTurnsPerPrompt;
+      return undefined;
+    },
     getMaxSessionTurns: () => 100,
     getIdeMode: () => false,
     getContinueOnFailedApiCall: () => false,
@@ -150,8 +157,11 @@ function makeLoopConfig(toolCallThreshold: number): Config {
   } as unknown as Config;
 }
 
-function makeRealLoopDetector(threshold: number): LoopDetectionService {
-  return new LoopDetectionService(makeLoopConfig(threshold));
+function makeRealLoopDetector(
+  threshold: number,
+  maxTurnsPerPrompt?: number,
+): LoopDetectionService {
+  return new LoopDetectionService(makeLoopConfig(threshold, maxTurnsPerPrompt));
 }
 
 function makeRealTodoContinuationService(): TodoContinuationService {
@@ -600,22 +610,25 @@ describe('MessageStreamOrchestrator — attempt checkpoint rollback (issue #3048
       expect(loopDetector.addAndCheck(toolA)).toBe(false);
     });
 
-    it('preserves prompt identity and turn counts across checkpoint/restore', async () => {
-      const loopDetector = makeRealLoopDetector(50);
+    it('preserves prompt turn counts across checkpoint/restore (maxTurnsPerPrompt=3)', async () => {
+      const loopDetector = makeRealLoopDetector(50, 3);
       loopDetector.reset('prompt-X');
+      // Two turns accumulate turnsInCurrentPrompt=2 (< 3 threshold).
+      await loopDetector.turnStarted(new AbortController().signal);
       await loopDetector.turnStarted(new AbortController().signal);
       const checkpoint = loopDetector.checkpoint();
+      // Abandoned attempt mutates attempt-scoped detector state only.
       loopDetector.addAndCheck({
         type: AgentEventType.Content,
         value: 'some content',
       });
+      // Restore undoes attempt-scoped mutations but must NOT reset
+      // turnsInCurrentPrompt (prompt-scoped, excluded from the snapshot). If
+      // restore had cleared it to 0, the next turn would be turn 1 and return
+      // false; with correct restore it is turn 3, hitting the threshold.
       loopDetector.restore(checkpoint);
-      // Re-running reset on the same prompt id is a no-op identity-wise; the
-      // point is restore did not wipe prompt-scoped counters. A fresh prompt
-      // resets cleanly afterward.
-      loopDetector.reset('prompt-Y');
       expect(await loopDetector.turnStarted(new AbortController().signal)).toBe(
-        false,
+        true,
       );
     });
 
@@ -646,26 +659,35 @@ describe('MessageStreamOrchestrator — attempt checkpoint rollback (issue #3048
   });
 
   describe('TodoContinuationService checkpoint/restore (direct contract)', () => {
-    it('snapshots and restores all three attempt-local fields', () => {
+    it('snapshots and restores all five attempt-local fields', () => {
       const service = makeRealTodoContinuationService();
       service.consecutiveComplexTurns = 3;
       service.setLastTodoToolTurn(4);
       service.lastTodoSnapshot = [
         { id: 'orig', content: 'task', status: 'in_progress' },
       ];
+      // recordModelActivity mutates these mid-attempt, so they must survive a
+      // transport Retry rollback (MessageStreamOrchestrator records model
+      // activity before the Retry signal clears abandoned state).
+      service.toolActivityCount = 4;
+      service.toolCallReminderLevel = 'base';
 
       const snapshot = service.checkpoint();
 
-      // Simulate an abandoned attempt.
+      // Simulate an abandoned attempt mutating every attempt-local field.
       service.consecutiveComplexTurns = 9;
       service.setLastTodoToolTurn(40);
       service.lastTodoSnapshot = [
         { id: 'gone', content: 'x', status: 'pending' },
       ];
+      service.toolActivityCount = 99;
+      service.toolCallReminderLevel = 'escalated';
 
       service.restore(snapshot);
 
       expect(service.consecutiveComplexTurns).toBe(3);
+      expect(service.toolActivityCount).toBe(4);
+      expect(service.toolCallReminderLevel).toBe('base');
       // Restored cadence and complexity counters satisfy the escalation policy.
       expect(service.shouldEscalateReminder(7)).toBe(true);
       expect(service.lastTodoSnapshot[0]?.id).toBe('orig');

--- a/packages/agents/src/core/messageStreamOrchestrator.retryDiscard.test.ts
+++ b/packages/agents/src/core/messageStreamOrchestrator.retryDiscard.test.ts
@@ -1,0 +1,380 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for MessageStreamOrchestrator per-attempt discard on
+ * AgentEventType.Retry (issue #3048, REQ-3048-007).
+ *
+ * When a transport retry restarts the turn mid-stream, every per-attempt
+ * accumulator owned by this loop must be discarded so the AfterAgent hook,
+ * post-turn flags and deferred events reflect only the successful attempt.
+ *
+ * @plan PLAN-20260806-ISSUE3048.P07
+ * @requirement REQ-3048-007
+ */
+
+import { describe, it, expect, vi, beforeEach } from '../testApi.js';
+import type { AgentMessageInput } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import type {
+  ServerAgentStreamEvent,
+  ServerFinishedOutcome,
+  ThoughtSummary,
+  ToolCallRequestInfo,
+} from './turn.js';
+import { AgentEventType } from './turn.js';
+import type { ChatSession } from './chatSession.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { LoopDetectionService } from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
+import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
+
+const mockTurnRun = vi.fn();
+
+vi.mock('./turn.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./turn.js')>();
+  class MockTurn {
+    pendingToolCalls: unknown[] = [];
+    run = mockTurnRun;
+  }
+  return {
+    ...actual,
+    Turn: MockTurn as unknown as typeof actual.Turn,
+  };
+});
+
+import {
+  MessageStreamOrchestrator,
+  type MessageStreamDeps,
+} from './MessageStreamOrchestrator.js';
+
+// --- scripted event constructors (fully typed) ---
+
+function content(text: string): ServerAgentStreamEvent {
+  return { type: AgentEventType.Content, value: text };
+}
+
+function citation(text: string): ServerAgentStreamEvent {
+  return { type: AgentEventType.Citation, value: text };
+}
+
+function retryEvent(): ServerAgentStreamEvent {
+  return { type: AgentEventType.Retry };
+}
+
+function thoughtEvent(): ServerAgentStreamEvent {
+  const value: ThoughtSummary = {
+    subject: 'planning',
+    description: 'abandoned reasoning',
+  };
+  return { type: AgentEventType.Thought, value };
+}
+
+function finishedEvent(
+  outcome?: ServerFinishedOutcome,
+): ServerAgentStreamEvent {
+  return outcome
+    ? { type: AgentEventType.Finished, value: { reason: 'stop', outcome } }
+    : { type: AgentEventType.Finished, value: { reason: 'stop' } };
+}
+
+function invalidStreamEvent(): ServerAgentStreamEvent {
+  return { type: AgentEventType.InvalidStream };
+}
+
+function toolCallRequest(callId: string): ServerAgentStreamEvent {
+  const value: ToolCallRequestInfo = {
+    callId,
+    name: 'read_file',
+    args: { file_path: '/tmp/x' },
+    isClientInitiated: false,
+    prompt_id: 'prompt-1',
+  };
+  return { type: AgentEventType.ToolCallRequest, value };
+}
+
+function streamFrom(
+  events: readonly ServerAgentStreamEvent[],
+): AsyncGenerator<ServerAgentStreamEvent> {
+  return (async function* (): AsyncGenerator<ServerAgentStreamEvent> {
+    for (const e of events) yield e;
+  })();
+}
+
+interface BuildOptions {
+  stream: readonly ServerAgentStreamEvent[];
+  continueOnFailedApiCall?: boolean;
+}
+
+interface Harness {
+  orchestrator: MessageStreamOrchestrator;
+  deps: MessageStreamDeps;
+  afterAgentTexts: string[];
+}
+
+function buildHarness(options: BuildOptions): Harness {
+  const afterAgentTexts: string[] = [];
+
+  const mockChat = {
+    addHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+    getContextLimit: vi.fn().mockReturnValue(1_000_000),
+  };
+
+  const config = {
+    getMaxSessionTurns: vi.fn(() => 100),
+    getIdeMode: vi.fn(() => false),
+    getContinueOnFailedApiCall: vi.fn(
+      () => options.continueOnFailedApiCall ?? false,
+    ),
+    getSettingsService: vi.fn(() => ({
+      getCurrentProfileName: vi.fn(() => null),
+      get: vi.fn(() => undefined),
+    })),
+  } as unknown as Config;
+
+  mockTurnRun.mockReturnValue(streamFrom(options.stream));
+
+  const deps: MessageStreamDeps = {
+    config,
+    getChat: () => mockChat as unknown as ChatSession,
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    } as unknown as DebugLogger,
+    loopDetector: {
+      reset: vi.fn(),
+      turnStarted: vi.fn().mockResolvedValue(false),
+      addAndCheck: vi.fn().mockReturnValue(false),
+      checkpoint: vi.fn().mockReturnValue({}),
+      restore: vi.fn(),
+    } as unknown as LoopDetectionService,
+    todoContinuationService: {
+      clearPausedState: vi.fn().mockResolvedValue(undefined),
+      toolActivityCount: 0,
+      toolCallReminderLevel: 'none',
+      consecutiveComplexTurns: 0,
+      lastTodoSnapshot: [],
+      recordModelActivity: vi.fn(),
+      isTodoToolCall: vi.fn().mockReturnValue(false),
+      applyPendingReminder: vi.fn((r: AgentMessageInput) => Promise.resolve(r)),
+      getTodoReminderForCurrentState: vi.fn().mockResolvedValue({
+        todos: [],
+        activeTodos: [],
+        reminder: undefined,
+      }),
+      areTodoSnapshotsEqual: vi.fn().mockReturnValue(true),
+      processComplexityAnalysis: vi.fn().mockReturnValue(undefined),
+      appendTodoSuffixToRequest: vi.fn(),
+      appendSystemReminderToRequest: vi.fn(),
+      updateTodoToolAvailabilityFromDeclarations: vi.fn(),
+      setLastTodoToolTurn: vi.fn(),
+      checkpoint: vi.fn().mockReturnValue({}),
+      restore: vi.fn(),
+      // Faithful to production: Finished and Citation are deferred.
+      shouldDeferStreamEvent: vi.fn(
+        (event: ServerAgentStreamEvent) =>
+          event.type === AgentEventType.Finished ||
+          event.type === AgentEventType.Citation,
+      ),
+    } as unknown as MessageStreamDeps['todoContinuationService'],
+    ideContextTracker: {
+      getContextParts: vi.fn().mockReturnValue({
+        contextParts: [],
+        newIdeContext: undefined,
+      }),
+      recordSentContext: vi.fn(),
+    } as unknown as MessageStreamDeps['ideContextTracker'],
+    agentHookManager: {
+      cleanupOldHookState: vi.fn(),
+      fireBeforeAgentHookSafe: vi.fn().mockResolvedValue(undefined),
+      fireAfterAgentHookSafe: vi.fn(
+        (_id: string, _promptText: string, responseText: string) => {
+          afterAgentTexts.push(responseText);
+          return Promise.resolve(undefined);
+        },
+      ),
+    } as unknown as MessageStreamDeps['agentHookManager'],
+    getEffectiveModelIdentity: () => ({
+      providerName: 'openai',
+      model: 'gpt-4',
+    }),
+    getHistory: vi.fn().mockResolvedValue([]),
+    getSessionTurnCount: vi.fn().mockReturnValue(1),
+    incrementSessionTurnCount: vi.fn(),
+    lazyInitialize: vi.fn().mockResolvedValue(undefined),
+    startChat: vi.fn().mockResolvedValue(mockChat),
+    getPreviousHistory: vi.fn().mockReturnValue(undefined),
+    setChat: vi.fn(),
+    hasChat: vi.fn().mockReturnValue(true),
+    complexityAnalyzer: {
+      analyzeComplexity: vi.fn().mockReturnValue({
+        complexityScore: 0.1,
+        isComplex: false,
+        detectedTasks: [],
+        sequentialIndicators: [],
+        questionCount: 0,
+        shouldSuggestTodos: false,
+      }),
+    } as unknown as ComplexityAnalyzer,
+    getLastPromptId: () => undefined,
+    setLastPromptId: vi.fn(),
+    resetCurrentSequenceModel: vi.fn(),
+    updateTelemetryTokenCount: vi.fn(),
+    sendMessageStream: vi.fn(
+      async function* (): AsyncGenerator<ServerAgentStreamEvent> {
+        /* empty recovery stream */
+      },
+    ),
+  };
+
+  return {
+    orchestrator: new MessageStreamOrchestrator(deps),
+    deps,
+    afterAgentTexts,
+  };
+}
+
+async function drain(
+  orchestrator: MessageStreamOrchestrator,
+  isInvalidStreamRetry = false,
+): Promise<ServerAgentStreamEvent[]> {
+  const events: ServerAgentStreamEvent[] = [];
+  for await (const event of orchestrator.execute(
+    [{ text: 'hi' }] as AgentMessageInput,
+    new AbortController().signal,
+    'prompt-1',
+    1,
+    isInvalidStreamRetry,
+  )) {
+    events.push(event);
+  }
+  return events;
+}
+
+const VISIBLE = (
+  overrides: Partial<ServerFinishedOutcome> = {},
+): ServerFinishedOutcome => ({
+  hadVisibleOutput: true,
+  hadThinking: false,
+  hadToolCalls: false,
+  ...overrides,
+});
+
+describe('MessageStreamOrchestrator — per-attempt discard on Retry (issue #3048)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes only the successful attempt text to the AfterAgent hook', async () => {
+    const { orchestrator, afterAgentTexts } = buildHarness({
+      stream: [
+        content('abandoned '),
+        retryEvent(),
+        content('kept'),
+        finishedEvent(VISIBLE()),
+      ],
+    });
+
+    await drain(orchestrator);
+
+    expect(afterAgentTexts).toHaveLength(1);
+    expect(afterAgentTexts[0]).toBe('kept');
+  });
+
+  it('drops deferred citations from the abandoned attempt', async () => {
+    const { orchestrator } = buildHarness({
+      stream: [
+        content('abandoned '),
+        citation('abandoned-citation'),
+        retryEvent(),
+        content('kept'),
+        finishedEvent(VISIBLE()),
+      ],
+    });
+
+    const events = await drain(orchestrator);
+    const citations = events.filter((e) => e.type === AgentEventType.Citation);
+
+    expect(citations).toHaveLength(0);
+    expect(
+      events.some(
+        (e) => e.type === AgentEventType.Content && e.value === 'kept',
+      ),
+    ).toBe(true);
+  });
+
+  it('reports hadContent false when the only content belonged to the abandoned attempt', async () => {
+    // An InvalidStream after the retry can only trigger recovery when
+    // canRetryFailedStream sees no content — i.e. the abandoned content was
+    // discarded. This observes hadContent === false.
+    const { orchestrator, deps } = buildHarness({
+      stream: [content('abandoned'), retryEvent(), invalidStreamEvent()],
+      continueOnFailedApiCall: true,
+    });
+
+    await drain(orchestrator, false);
+
+    expect(deps.sendMessageStream).toHaveBeenCalled();
+  });
+
+  it('keeps hadToolCallsThisTurn reset to the prior value across a Retry', async () => {
+    // An abandoned tool call must not leave hadToolCallsThisTurn true, which
+    // would block InvalidStream recovery via canRetryFailedStream.
+    const { orchestrator, deps } = buildHarness({
+      stream: [
+        toolCallRequest('abandoned-tool'),
+        retryEvent(),
+        invalidStreamEvent(),
+      ],
+      continueOnFailedApiCall: true,
+    });
+
+    await drain(orchestrator, false);
+
+    expect(deps.sendMessageStream).toHaveBeenCalled();
+  });
+
+  it('still yields the Retry event to consumers before replacement content', async () => {
+    const { orchestrator } = buildHarness({
+      stream: [
+        content('abandoned'),
+        retryEvent(),
+        content('kept'),
+        finishedEvent(VISIBLE()),
+      ],
+    });
+
+    const events = await drain(orchestrator);
+    const retryIndex = events.findIndex((e) => e.type === AgentEventType.Retry);
+    const keptIndex = events.findIndex(
+      (e) => e.type === AgentEventType.Content && e.value === 'kept',
+    );
+
+    expect(retryIndex).toBeGreaterThanOrEqual(0);
+    expect(retryIndex).toBeLessThan(keptIndex);
+  });
+
+  it('does not reset finishedOutcome when discarding an abandoned attempt', async () => {
+    // Fence: a Finished outcome set before the retry must survive the
+    // discard. Here hadVisibleOutput stays true, so the turn ends normally
+    // instead of entering the thinking-only retry loop (which would consume
+    // the turn stream more than once).
+    const { orchestrator } = buildHarness({
+      stream: [
+        finishedEvent(VISIBLE()),
+        retryEvent(),
+        thoughtEvent(),
+        finishedEvent(),
+      ],
+    });
+
+    await drain(orchestrator);
+
+    expect(mockTurnRun).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agents/src/core/retryAwareLoopDetection.ts
+++ b/packages/agents/src/core/retryAwareLoopDetection.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { LoopDetectionService } from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
+import { AgentEventType, type ServerAgentStreamEvent } from './turn.js';
+
+export interface LoopCheckedEvent {
+  readonly event: ServerAgentStreamEvent;
+  readonly loopDetected: boolean;
+}
+
+/**
+ * Defers a loop verdict until the next stream event establishes whether the
+ * triggering output belongs to an abandoned attempt. A Retry discards the
+ * pending verdict; any other event confirms it.
+ */
+export async function* applyRetryAwareLoopDetection(
+  events: AsyncIterable<ServerAgentStreamEvent>,
+  loopDetector: LoopDetectionService,
+): AsyncGenerator<LoopCheckedEvent> {
+  let pendingLoopEvent: ServerAgentStreamEvent | undefined;
+
+  for await (const event of events) {
+    if (pendingLoopEvent !== undefined) {
+      if (event.type === AgentEventType.Retry) {
+        pendingLoopEvent = undefined;
+        yield { event, loopDetected: false };
+        continue;
+      }
+      yield { event: pendingLoopEvent, loopDetected: true };
+      return;
+    }
+
+    if (event.type === AgentEventType.Retry) {
+      yield { event, loopDetected: false };
+    } else if (loopDetector.addAndCheck(event)) {
+      pendingLoopEvent = event;
+    } else {
+      yield { event, loopDetected: false };
+    }
+  }
+
+  if (pendingLoopEvent !== undefined) {
+    yield { event: pendingLoopEvent, loopDetected: true };
+  }
+}

--- a/packages/agents/src/core/turnAbortHelpers.ts
+++ b/packages/agents/src/core/turnAbortHelpers.ts
@@ -14,6 +14,9 @@
  *
  * {@link shouldRetryStreamAttempt} centralizes the pure retry/stop decision
  * for errors that escape the stream loop in TurnProcessor._runStreamAttempt.
+ *
+ * @plan PLAN-20260806-ISSUE3048.P04
+ * @requirement REQ-3048-002 REQ-3048-003 REQ-3048-004
  */
 
 import type { SendMessageParams } from './chatSession.js';
@@ -70,18 +73,39 @@ export function isAbortError(
 }
 
 /**
+ * True when the attempt already yielded model output (non-empty text, thinking,
+ * or a tool call) to the consumer. Post-output restarts are
+ * discard-and-restart: the whole attempt is abandoned, so a content-validity
+ * verdict about output being discarded is not a reason to restart — only a
+ * transport condition qualifies.
+ */
+export interface StreamAttemptContext {
+  readonly hasYieldedOutput: boolean;
+}
+
+/**
  * Decides whether a mid-stream error in _runStreamAttempt should trigger a
  * bounded turn-level retry. Returns true only for retryable content/stream
  * errors or transient network errors that are NOT user-initiated aborts, and
  * only while the retry budget remains.
+ *
+ * Before output the classification is bit-for-bit identical to the pre-#3048
+ * contract. After output only a transient transport failure
+ * (`isNetworkTransientError`) that is not an abort may restart the turn: a
+ * content-validity verdict about discarded output is not a transport failure,
+ * and the abandoned attempt must not be re-sent on its own merits.
  */
 export function shouldRetryStreamAttempt(
   error: unknown,
   params: SendMessageParams,
   attempt: number,
+  context: StreamAttemptContext,
 ): boolean {
   const withinBudget = attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts - 1;
   if (!withinBudget || isTerminalRetryError(error)) return false;
+  if (context.hasYieldedOutput) {
+    return isNetworkTransientError(error) && !isAbortError(error, params);
+  }
   if (
     error instanceof InvalidStreamError ||
     error instanceof EmptyStreamError
@@ -89,4 +113,26 @@ export function shouldRetryStreamAttempt(
     return true;
   }
   return isNetworkTransientError(error) && !isAbortError(error, params);
+}
+
+/**
+ * Returns the request params for a given turn attempt, bumping the sampling
+ * temperature on every restart so the regeneration does not deterministically
+ * repeat. Relocated verbatim from TurnProcessor so that file stays under the
+ * lint `max-lines` budget; behaviour is unchanged.
+ */
+export function applyRetryTemperature(
+  params: SendMessageParams,
+  attempt: number,
+): SendMessageParams {
+  if (attempt === 0) return params;
+  const baselineTemperature = Math.max(params.config?.temperature ?? 1, 1);
+  const newTemperature = Math.min(
+    Math.max(baselineTemperature + attempt * 0.1, 0),
+    2,
+  );
+  return {
+    ...params,
+    config: { ...params.config, temperature: newTemperature },
+  };
 }

--- a/packages/agents/src/core/turnAbortHelpers.ts
+++ b/packages/agents/src/core/turnAbortHelpers.ts
@@ -89,11 +89,14 @@ export interface StreamAttemptContext {
  * errors or transient network errors that are NOT user-initiated aborts, and
  * only while the retry budget remains.
  *
- * Before output the classification is bit-for-bit identical to the pre-#3048
- * contract. After output only a transient transport failure
- * (`isNetworkTransientError`) that is not an abort may restart the turn: a
- * content-validity verdict about discarded output is not a transport failure,
- * and the abandoned attempt must not be re-sent on its own merits.
+ * A user/system abort is checked before any content/stream-error
+ * classification in every branch, so an abort that surfaces as a pre-output
+ * InvalidStreamError/EmptyStreamError is never retried. For non-abort errors
+ * before output the classification matches the pre-#3048 contract. After
+ * output only a transient transport failure (`isNetworkTransientError`) may
+ * restart the turn: a content-validity verdict about discarded output is not a
+ * transport failure, and the abandoned attempt must not be re-sent on its own
+ * merits.
  */
 export function shouldRetryStreamAttempt(
   error: unknown,
@@ -103,8 +106,12 @@ export function shouldRetryStreamAttempt(
 ): boolean {
   const withinBudget = attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts - 1;
   if (!withinBudget || isTerminalRetryError(error)) return false;
+  // Abort must win before any content/stream-error classification: a
+  // user/system cancellation is never retryable even if it surfaces as a
+  // pre-output InvalidStreamError/EmptyStreamError.
+  if (isAbortError(error, params)) return false;
   if (context.hasYieldedOutput) {
-    return isNetworkTransientError(error) && !isAbortError(error, params);
+    return isNetworkTransientError(error);
   }
   if (
     error instanceof InvalidStreamError ||
@@ -112,7 +119,7 @@ export function shouldRetryStreamAttempt(
   ) {
     return true;
   }
-  return isNetworkTransientError(error) && !isAbortError(error, params);
+  return isNetworkTransientError(error);
 }
 
 /**

--- a/packages/agents/src/core/turnProcessorIdleTimeoutContract.test.ts
+++ b/packages/agents/src/core/turnProcessorIdleTimeoutContract.test.ts
@@ -57,6 +57,11 @@ describe('TurnProcessor stream idle timeout error contract (issue #2817)', () =>
     const params = { message: [] } as unknown as SendMessageParams;
 
     expect(isNetworkTransientError(error)).toBe(false);
-    expect(shouldRetryStreamAttempt(error, params, 0)).toBe(false);
+    expect(
+      shouldRetryStreamAttempt(error, params, 0, { hasYieldedOutput: false }),
+    ).toBe(false);
+    expect(
+      shouldRetryStreamAttempt(error, params, 0, { hasYieldedOutput: true }),
+    ).toBe(false);
   });
 });

--- a/packages/agents/src/core/turnRetryPolicy.discardRestart.test.ts
+++ b/packages/agents/src/core/turnRetryPolicy.discardRestart.test.ts
@@ -66,6 +66,22 @@ const policyTable: readonly PolicyRow[] = [
     expected: true,
   },
   {
+    name: 'pre-output InvalidStreamError with aborted signal does not retry',
+    error: new InvalidStreamError('no text', 'NO_RESPONSE_TEXT'),
+    attempt: 0,
+    hasYieldedOutput: false,
+    params: paramsWithAbortSignal(true),
+    expected: false,
+  },
+  {
+    name: 'pre-output EmptyStreamError with aborted signal does not retry',
+    error: new EmptyStreamError('empty'),
+    attempt: 0,
+    hasYieldedOutput: false,
+    params: paramsWithAbortSignal(true),
+    expected: false,
+  },
+  {
     name: 'pre-output transient connection error retries',
     error: new Error('Connection error.'),
     attempt: 0,

--- a/packages/agents/src/core/turnRetryPolicy.discardRestart.test.ts
+++ b/packages/agents/src/core/turnRetryPolicy.discardRestart.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for the post-#3048 turn retry policy (REQ-3048-002/003/004).
+ *
+ * `shouldRetryStreamAttempt` now takes a `StreamAttemptContext` that makes the
+ * post-output status explicit. Before output the classification is bit-for-bit
+ * identical to the pre-#3048 contract. After output only a transient transport
+ * failure (`isNetworkTransientError`) that is not an abort may restart the turn,
+ * and only within the existing bounded budget. The behaviour table below is the
+ * complete enumeration from `analysis/pseudocode/001-turn-retry-policy.md`.
+ */
+
+import { describe, expect, it } from '../testApi.js';
+import {
+  shouldRetryStreamAttempt,
+  applyRetryTemperature,
+} from './turnAbortHelpers.js';
+import type { SendMessageParams } from './chatSession.js';
+import {
+  InvalidStreamError,
+  EmptyStreamError,
+} from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
+
+const baseParams: SendMessageParams = {
+  message: [],
+};
+
+function paramsWithAbortSignal(aborted: boolean): SendMessageParams {
+  const controller = new AbortController();
+  if (aborted) controller.abort();
+  return {
+    message: [],
+    config: { abortSignal: controller.signal },
+  };
+}
+
+interface PolicyRow {
+  readonly name: string;
+  readonly error: unknown;
+  readonly attempt: number;
+  readonly hasYieldedOutput: boolean;
+  readonly params: SendMessageParams;
+  readonly expected: boolean;
+}
+
+const policyTable: readonly PolicyRow[] = [
+  {
+    name: 'pre-output InvalidStreamError retries',
+    error: new InvalidStreamError('no text', 'NO_RESPONSE_TEXT'),
+    attempt: 0,
+    hasYieldedOutput: false,
+    params: baseParams,
+    expected: true,
+  },
+  {
+    name: 'pre-output EmptyStreamError retries',
+    error: new EmptyStreamError('empty'),
+    attempt: 0,
+    hasYieldedOutput: false,
+    params: baseParams,
+    expected: true,
+  },
+  {
+    name: 'pre-output transient connection error retries',
+    error: new Error('Connection error.'),
+    attempt: 0,
+    hasYieldedOutput: false,
+    params: baseParams,
+    expected: true,
+  },
+  {
+    name: 'pre-output non-transient (400) does not retry',
+    error: Object.assign(new Error('Bad request'), { status: 400 }),
+    attempt: 0,
+    hasYieldedOutput: false,
+    params: baseParams,
+    expected: false,
+  },
+  {
+    name: 'post-output transient connection error restarts (new)',
+    error: new Error('Connection error.'),
+    attempt: 0,
+    hasYieldedOutput: true,
+    params: baseParams,
+    expected: true,
+  },
+  {
+    name: 'post-output transient connection error is bounded by budget',
+    error: new Error('Connection error.'),
+    attempt: 1,
+    hasYieldedOutput: true,
+    params: baseParams,
+    expected: false,
+  },
+  {
+    name: 'pre-output transient connection error is bounded by budget',
+    error: new Error('Connection error.'),
+    attempt: 1,
+    hasYieldedOutput: false,
+    params: baseParams,
+    expected: false,
+  },
+  {
+    name: 'post-output non-transient (400) does not restart',
+    error: Object.assign(new Error('Bad request'), { status: 400 }),
+    attempt: 0,
+    hasYieldedOutput: true,
+    params: baseParams,
+    expected: false,
+  },
+  {
+    name: 'post-output InvalidStreamError is not a transport failure (AD-3)',
+    error: new InvalidStreamError('no text', 'NO_RESPONSE_TEXT'),
+    attempt: 0,
+    hasYieldedOutput: true,
+    params: baseParams,
+    expected: false,
+  },
+  {
+    name: 'post-output EmptyStreamError is not a transport failure (AD-3)',
+    error: new EmptyStreamError('empty'),
+    attempt: 0,
+    hasYieldedOutput: true,
+    params: baseParams,
+    expected: false,
+  },
+  {
+    name: 'post-output AbortError name does not restart',
+    error: Object.assign(new Error('Request aborted'), {
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+    }),
+    attempt: 0,
+    hasYieldedOutput: true,
+    params: baseParams,
+    expected: false,
+  },
+  {
+    name: 'post-output ABORT_ERR code does not restart',
+    error: Object.assign(new Error('terminated'), { code: 'ABORT_ERR' }),
+    attempt: 0,
+    hasYieldedOutput: true,
+    params: baseParams,
+    expected: false,
+  },
+  {
+    name: 'post-output transient phrase with aborted signal does not restart',
+    error: new Error('terminated'),
+    attempt: 0,
+    hasYieldedOutput: true,
+    params: paramsWithAbortSignal(true),
+    expected: false,
+  },
+  {
+    name: 'post-output terminal (isRetryable:false) aggregate does not restart',
+    error: Object.assign(new Error('Retries exhausted'), {
+      isRetryable: false,
+    }),
+    attempt: 0,
+    hasYieldedOutput: true,
+    params: baseParams,
+    expected: false,
+  },
+];
+
+describe('Turn retry policy discard-and-restart (issue 3048)', () => {
+  it.each(policyTable)(
+    '$name',
+    ({ error, attempt, hasYieldedOutput, params, expected }) => {
+      const result = shouldRetryStreamAttempt(error, params, attempt, {
+        hasYieldedOutput,
+      });
+      expect(result).toBe(expected);
+    },
+  );
+
+  it('exports applyRetryTemperature and returns params unchanged for attempt 0', () => {
+    const params: SendMessageParams = {
+      message: [],
+      config: { temperature: 0.5 },
+    };
+    expect(applyRetryTemperature(params, 0)).toBe(params);
+  });
+
+  it('bumps temperature for attempt 1 within the clamped [0, 2] range', () => {
+    const params: SendMessageParams = {
+      message: [],
+      config: { temperature: 0.5 },
+    };
+    const result = applyRetryTemperature(params, 1);
+    expect(result).not.toBe(params);
+    expect(result.config?.temperature).toBeCloseTo(1.1, 5);
+  });
+
+  it('clamps retry temperature to the upper bound', () => {
+    const params: SendMessageParams = {
+      message: [],
+      config: { temperature: 1.9 },
+    };
+    expect(applyRetryTemperature(params, 1).config?.temperature).toBe(2);
+  });
+});

--- a/packages/cli/src/nonInteractiveCliSupport.retryDiscard.bun.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.retryDiscard.bun.ts
@@ -71,7 +71,7 @@ function parseJsonResult(spy: StdoutSpy): Record<string, unknown> {
 
 let sharedConfig: Config | null = null;
 
-function getConfig(): Config {
+function getRetryDiscardConfig(): Config {
   if (sharedConfig === null) {
     const config = new Config({
       sessionId: 'retry-discard-session',
@@ -105,7 +105,7 @@ function createContext(overrides?: {
   const streamFormatter =
     overrides?.streamFormatter === undefined ? null : overrides.streamFormatter;
   return {
-    config: getConfig(),
+    config: getRetryDiscardConfig(),
     jsonOutput: overrides?.jsonOutput ?? false,
     streamJsonOutput: streamFormatter !== null,
     quiet: overrides?.quiet ?? false,

--- a/packages/cli/src/nonInteractiveCliSupport.retryDiscard.bun.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.retryDiscard.bun.ts
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan PLAN-20260806-ISSUE3048.P13
+ * @requirement REQ-3048-010
+ *
+ * Behavioural tests for the non-interactive CLI retry discard contract.
+ *
+ * On a `{ type: 'retry' }` AgentEvent, the non-interactive consumer MUST
+ * throw away the buffered state of the abandoned attempt — the JSON
+ * `responseText`, the `--quiet` text buffer and the thought buffer — and MUST
+ * drain (and discard) the emoji filter's held-back partial chunk, while
+ * leaving `pendingDone` untouched so a following `done` still finalizes the
+ * turn. Already-written plain stdout / stream-json deltas are an unretractable
+ * limitation (specification §8) and are not compensated.
+ *
+ * These tests drive the REAL `processAgentStream` with scripted `AgentEvent`
+ * async iterables; only `process.stdout`/`process.stderr` are captured by
+ * spies, and every assertion is on observable emitted output.
+ */
+
+import {
+  Config,
+  EmojiFilter,
+  StreamJsonFormatter,
+  JsonStreamEventType,
+  uiTelemetryService,
+} from '@vybestack/llxprt-code-core';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { processAgentStream } from './nonInteractiveCliSupport.js';
+
+type StdoutSpy = ReturnType<typeof spyOn<typeof process.stdout, 'write'>>;
+
+async function* streamFromEvents(
+  events: readonly AgentEvent[],
+): AsyncIterable<AgentEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function callsToText(spy: StdoutSpy): string {
+  return spy.mock.calls.map((call) => String(call[0])).join('');
+}
+
+type ParsedStreamEvent = {
+  type: string;
+  role?: string;
+  content?: string;
+};
+
+function parseStreamEvents(spy: StdoutSpy): ParsedStreamEvent[] {
+  return spy.mock.calls
+    .map((call) => String(call[0]).trimEnd())
+    .filter((line) => line.startsWith('{'))
+    .map((line) => JSON.parse(line) as ParsedStreamEvent);
+}
+
+function parseJsonResult(spy: StdoutSpy): Record<string, unknown> {
+  const jsonLine = spy.mock.calls
+    .map((call) => String(call[0]).trimEnd())
+    .filter((line) => line.startsWith('{') && line.includes('"response"'))
+    .join('');
+  return JSON.parse(jsonLine) as Record<string, unknown>;
+}
+
+let sharedConfig: Config | null = null;
+
+function getConfig(): Config {
+  if (sharedConfig === null) {
+    const config = new Config({
+      sessionId: 'retry-discard-session',
+      targetDir: '/tmp/llxprt-retry-discard',
+      debugMode: false,
+      cwd: '/tmp/llxprt-retry-discard',
+      model: 'gemini-2.0-flash-exp',
+    });
+    config.setEphemeralSetting('reasoning.includeInResponse', true);
+    sharedConfig = config;
+  }
+  return sharedConfig;
+}
+
+type StreamContextShape = {
+  config: Config;
+  jsonOutput: boolean;
+  streamJsonOutput: boolean;
+  quiet: boolean;
+  streamFormatter: StreamJsonFormatter | null;
+  emojiFilter: EmojiFilter | undefined;
+  createProfileNameWriter: () => () => void;
+};
+
+function createContext(overrides?: {
+  jsonOutput?: boolean;
+  quiet?: boolean;
+  streamFormatter?: StreamJsonFormatter | null;
+  emojiFilter?: EmojiFilter | undefined;
+}): StreamContextShape {
+  const streamFormatter =
+    overrides?.streamFormatter === undefined ? null : overrides.streamFormatter;
+  return {
+    config: getConfig(),
+    jsonOutput: overrides?.jsonOutput ?? false,
+    streamJsonOutput: streamFormatter !== null,
+    quiet: overrides?.quiet ?? false,
+    streamFormatter,
+    emojiFilter: overrides?.emojiFilter,
+    createProfileNameWriter: () => () => {},
+  };
+}
+
+describe('processAgentStream — retry discard (REQ-3048-010)', () => {
+  let stdoutSpy: StdoutSpy;
+  let stderrSpy: ReturnType<typeof spyOn<typeof process.stderr, 'write'>>;
+
+  beforeEach(() => {
+    stdoutSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('json mode emits only the successful attempt text after a retry', async () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'abandoned' },
+      { type: 'retry' },
+      { type: 'text', text: 'kept' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ jsonOutput: true }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const result = parseJsonResult(stdoutSpy);
+    expect(result.response).toBe('kept');
+    expect(String(result.response)).not.toContain('abandoned');
+  });
+
+  it('quiet mode emits only the successful attempt text after a retry', async () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'abandoned' },
+      { type: 'retry' },
+      { type: 'text', text: 'kept' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ quiet: true }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const output = callsToText(stdoutSpy);
+    expect(output).toBe('kept\n');
+    expect(output).not.toContain('abandoned');
+  });
+
+  it('drops thoughts accumulated by the abandoned attempt', async () => {
+    const events: AgentEvent[] = [
+      {
+        type: 'thinking',
+        thought: { subject: 'Abandoned reasoning', description: '' },
+      },
+      { type: 'retry' },
+      { type: 'text', text: 'kept' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const output = callsToText(stdoutSpy);
+    expect(output).toContain('kept');
+    expect(output).not.toContain('Abandoned reasoning');
+    expect(output).not.toContain('<think>');
+  });
+
+  it('discards the emoji filter held partial chunk from the abandoned attempt', async () => {
+    // 'held✅' has no safe trailing boundary, so the filter holds it back
+    // rather than emitting it. Without the retry drain, that fragment is
+    // concatenated onto the successful attempt's text at finalize.
+    const emojiFilter = new EmojiFilter({ mode: 'auto' });
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'held✅' },
+      { type: 'retry' },
+      { type: 'text', text: 'kept' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ jsonOutput: true, emojiFilter }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const result = parseJsonResult(stdoutSpy);
+    expect(result.response).toBe('kept');
+    expect(String(result.response)).not.toContain('held');
+  });
+
+  it('does not disturb pendingDone — a done after the retry still finalizes', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'abandoned' },
+      { type: 'retry' },
+      { type: 'text', text: 'kept' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ quiet: true, streamFormatter }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const streamEvents = parseStreamEvents(stdoutSpy);
+    const messages = streamEvents.filter(
+      (event) =>
+        event.type === JsonStreamEventType.MESSAGE &&
+        event.role === 'assistant',
+    );
+    const result = streamEvents.find(
+      (event) => event.type === JsonStreamEventType.RESULT,
+    );
+    // pendingDone survived the retry, so handleDone emitted the assistant
+    // message and the terminal RESULT.
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe('kept');
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -504,6 +504,25 @@ function handleQuietEvent(event: AgentEvent, state: StreamState): boolean {
   }
 }
 
+/**
+ * Discards every per-attempt accumulator that the abandoned attempt populated
+ * (REQ-3048-010). The emoji filter's held partial chunk belongs to that
+ * attempt, so it is drained via flushBuffer() and the returned fragment is
+ * thrown away. pendingDone is intentionally untouched — a retry precedes the
+ * replacement attempt, and clearing it would mask an ordering bug.
+ * Already-written stdout / stream-json deltas are unretractable (spec §8) and
+ * are not compensated.
+ */
+function discardAbandonedAttempt(
+  state: StreamState,
+  context: StreamConsumerContext,
+): void {
+  context.emojiFilter?.flushBuffer();
+  state.responseText = '';
+  state.quietTextBuffer = '';
+  state.thoughtBuffer = [];
+}
+
 function dispatchAgentEvent(
   event: AgentEvent,
   state: StreamState,
@@ -511,9 +530,7 @@ function dispatchAgentEvent(
   writeProfileName: () => void,
   includeThinking: boolean,
 ): void {
-  if (context.quiet && handleQuietEvent(event, state)) {
-    return;
-  }
+  if (context.quiet && handleQuietEvent(event, state)) return;
   switch (event.type) {
     case 'thinking':
       state.thoughtBuffer = handleThinking(
@@ -567,9 +584,7 @@ function dispatchAgentEvent(
       return;
     }
     case 'idle-timeout':
-      if (context.quiet) {
-        throw reconstructError(event.error);
-      }
+      if (context.quiet) throw reconstructError(event.error);
       return throwStructuredStreamError(
         event.error,
         context.streamFormatter,
@@ -579,6 +594,9 @@ function dispatchAgentEvent(
       return throwStructuredStreamError(event.error, context.streamFormatter);
     case 'done':
       state.pendingDone = event;
+      return;
+    case 'retry':
+      discardAbandonedAttempt(state, context);
       return;
     default:
       return;

--- a/packages/cli/src/ui/AppContainerRuntime.tsx
+++ b/packages/cli/src/ui/AppContainerRuntime.tsx
@@ -86,6 +86,7 @@ function buildInputParams(
     subagentManager: bootstrap.uiRuntime.app.getSubagentManager(),
     history: bootstrap.history,
     addItem: bootstrap.addItem,
+    removeItems: bootstrap.removeItems,
     clearItems: bootstrap.clearItems,
     loadHistory: bootstrap.loadHistory,
     todos: bootstrap.todos,

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppBootstrap.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppBootstrap.ts
@@ -16,7 +16,7 @@ import {
   DEFAULT_HISTORY_MAX_BYTES,
   DEFAULT_HISTORY_MAX_ITEMS,
 } from '../../../../constants/historyLimits.js';
-import { useHistory } from '../../../hooks/useHistoryManager.js';
+import { useRetractableHistory } from '../../../hooks/useHistoryManager.js';
 import { useMemoryMonitor } from '../../../hooks/useMemoryMonitor.js';
 import {
   type IContent,
@@ -87,6 +87,7 @@ export interface AppBootstrapResult {
     baseTimestamp?: number,
     isResuming?: boolean,
   ) => number;
+  removeItems: (ids: readonly number[]) => void;
   clearItems: () => void;
   loadHistory: (newHistory: HistoryItem[]) => void;
   llxprtMdFileCount: number;
@@ -148,8 +149,8 @@ function useBootstrapHistory(props: AppBootstrapProps) {
     }),
     [settings.merged.ui.historyMaxItems, settings.merged.ui.historyMaxBytes],
   );
-  const { history, addItem, clearItems, loadHistory } =
-    useHistory(historyLimits);
+  const { history, addItem, removeItems, clearItems, loadHistory } =
+    useRetractableHistory(historyLimits);
   const {
     llxprtMdFileCount,
     setLlxprtMdFileCount,
@@ -175,6 +176,7 @@ function useBootstrapHistory(props: AppBootstrapProps) {
     nightly,
     history,
     addItem,
+    removeItems,
     clearItems,
     loadHistory,
     llxprtMdFileCount,
@@ -286,6 +288,7 @@ export function useAppBootstrap(props: AppBootstrapProps): AppBootstrapResult {
     isNarrow: h.isNarrow,
     history: h.history,
     addItem: h.addItem,
+    removeItems: h.removeItems,
     clearItems: h.clearItems,
     loadHistory: h.loadHistory,
     llxprtMdFileCount: h.llxprtMdFileCount,

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts
@@ -47,6 +47,7 @@ export interface AppInputParams {
   subagentManager?: UiSubagentManager;
   history: AppBootstrapResult['history'];
   addItem: (item: Omit<HistoryItem, 'id'>, baseTimestamp?: number) => number;
+  removeItems: (ids: readonly number[]) => void;
   clearItems: AppBootstrapResult['clearItems'];
   loadHistory: AppBootstrapResult['loadHistory'];
   todos: AppBootstrapResult['todos'];
@@ -316,6 +317,7 @@ function useInputStreamSetup(
     settings,
     history,
     addItem,
+    removeItems,
     recordingIntegration,
     runtimeMessageBus,
     stdout,
@@ -351,6 +353,7 @@ function useInputStreamSetup(
     recordingIntegration,
     runtimeMessageBus,
     p.subagentManager,
+    removeItems,
   );
   return { ...bufferSetup, agentStreamResult };
 }

--- a/packages/cli/src/ui/hooks/__tests__/useHistoryManager.removeItems.test.ts
+++ b/packages/cli/src/ui/hooks/__tests__/useHistoryManager.removeItems.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for `useRetractableHistory().removeItems` (issue #3048 REQ-3048-009).
+ * A discard-and-restart retracts exactly the static history item ids the
+ * abandoned attempt committed, so the retraction surface must: remove only the
+ * requested ids, preserve order, ignore unknown ids, recompute the byte/length
+ * budget, and be a no-op (returning the prior state) when nothing matches.
+ *
+ * Drives the REAL `useHistory` hook via `renderHook`. No mocks.
+ *
+ * @plan PLAN-20260806-ISSUE3048.P11
+ * @requirement REQ-3048-009
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { act } from 'react';
+import { renderHook } from '../../../test-utils/render.js';
+import { useRetractableHistory } from '../useHistoryManager.js';
+
+function addItem(
+  result: { current: ReturnType<typeof useRetractableHistory> },
+  text: string,
+  timestamp = 1_000,
+): number {
+  let id = -1;
+  act(() => {
+    id = result.current.addItem({ type: 'info', text }, timestamp);
+  });
+  return id;
+}
+
+function textsOf(result: {
+  current: ReturnType<typeof useRetractableHistory>;
+}): string[] {
+  return result.current.history
+    .map((item) => (item.type === 'info' ? item.text : undefined))
+    .filter((text): text is string => text !== undefined);
+}
+
+describe('useRetractableHistory().removeItems (issue #3048 REQ-3048-009)', () => {
+  it('removes exactly the given ids and preserves order', () => {
+    const { result } = renderHook(() => useRetractableHistory());
+    const a = addItem(result, 'a');
+    const b = addItem(result, 'b');
+    const c = addItem(result, 'c');
+
+    act(() => {
+      result.current.removeItems([b]);
+    });
+
+    const remaining = textsOf(result);
+    expect(remaining).toStrictEqual(['a', 'c']);
+    expect(result.current.history.some((item) => item.id === b)).toBe(false);
+    expect(result.current.history.some((item) => item.id === a)).toBe(true);
+    expect(result.current.history.some((item) => item.id === c)).toBe(true);
+  });
+
+  it('removes multiple ids at once while preserving order', () => {
+    const { result } = renderHook(() => useRetractableHistory());
+    const a = addItem(result, 'a');
+    const b = addItem(result, 'b');
+    const c = addItem(result, 'c');
+    const d = addItem(result, 'd');
+
+    act(() => {
+      result.current.removeItems([a, c]);
+    });
+
+    expect(textsOf(result)).toStrictEqual(['b', 'd']);
+    expect(result.current.history.some((item) => item.id === b)).toBe(true);
+    expect(result.current.history.some((item) => item.id === d)).toBe(true);
+  });
+
+  it('ignores unknown ids without disturbing existing entries', () => {
+    const { result } = renderHook(() => useRetractableHistory());
+    const a = addItem(result, 'a');
+    addItem(result, 'b');
+
+    act(() => {
+      result.current.removeItems([a, 9_999_999]);
+    });
+
+    expect(textsOf(result)).toStrictEqual(['b']);
+  });
+
+  it('is a no-op for an empty id list (state identity preserved)', () => {
+    const { result } = renderHook(() => useRetractableHistory());
+    addItem(result, 'a');
+    addItem(result, 'b');
+    const before = result.current.history;
+
+    act(() => {
+      result.current.removeItems([]);
+    });
+
+    expect(result.current.history).toBe(before);
+    expect(textsOf(result)).toStrictEqual(['a', 'b']);
+  });
+
+  it('is a no-op when no id matches (state identity preserved)', () => {
+    const { result } = renderHook(() => useRetractableHistory());
+    addItem(result, 'a');
+    addItem(result, 'b');
+    const before = result.current.history;
+
+    act(() => {
+      result.current.removeItems([888_888, 999_999]);
+    });
+
+    expect(result.current.history).toBe(before);
+    expect(textsOf(result)).toStrictEqual(['a', 'b']);
+  });
+
+  it('recomputes the item budget so a later add is not trimmed against stale state', () => {
+    // maxItems: 2 — a third add would normally trim the oldest. Removing one
+    // must free that slot so the next add is retained alongside the survivor.
+    const { result } = renderHook(() => useRetractableHistory({ maxItems: 2 }));
+    addItem(result, 'a');
+    const b = addItem(result, 'b');
+
+    act(() => {
+      result.current.removeItems([b]);
+    });
+    expect(textsOf(result)).toStrictEqual(['a']);
+
+    addItem(result, 'c', 3_000);
+
+    // 'a' survived AND 'c' was retained: removal recomputed the budget.
+    expect(textsOf(result)).toStrictEqual(['a', 'c']);
+  });
+
+  it('retracts ids committed during an abandoned attempt without touching unrelated items', () => {
+    const { result } = renderHook(() => useRetractableHistory());
+    // Earlier, completed items (a user turn, a prior assistant message).
+    let user = -1;
+    act(() => {
+      user = result.current.addItem({ type: 'user', text: 'question' }, 1_000);
+    });
+    const priorAi = addItem(result, 'old answer');
+
+    // Abandoned attempt committed two static segments.
+    const abandoned1 = addItem(result, 'para one');
+    const abandoned2 = addItem(result, 'para two');
+
+    act(() => {
+      result.current.removeItems([abandoned1, abandoned2]);
+    });
+
+    expect(result.current.history.some((item) => item.id === user)).toBe(true);
+    expect(result.current.history.some((item) => item.id === priorAi)).toBe(
+      true,
+    );
+    expect(result.current.history.some((item) => item.id === abandoned1)).toBe(
+      false,
+    );
+    expect(result.current.history.some((item) => item.id === abandoned2)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/committedSegmentLedger.test.ts
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/committedSegmentLedger.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for CommittedSegmentLedger — the per-stream ledger that tracks
+ * static history item ids committed for the in-flight assistant attempt, so a
+ * discard-and-restart (issue #3048) can retract exactly those ids.
+ *
+ * @plan PLAN-20260806-ISSUE3048.P09
+ * @requirement REQ-3048-009
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { CommittedSegmentLedger } from '../committedSegmentLedger.js';
+
+describe('CommittedSegmentLedger', () => {
+  it('starts empty before any assistant message begins', () => {
+    const ledger = new CommittedSegmentLedger();
+    expect(ledger.ids).toStrictEqual([]);
+    expect(ledger.drain()).toStrictEqual([]);
+  });
+
+  it('records ids appended during an assistant message', () => {
+    const ledger = new CommittedSegmentLedger();
+    ledger.begin();
+    ledger.record(1);
+    ledger.record(2);
+    expect(ledger.ids).toStrictEqual([1, 2]);
+  });
+
+  it('drain returns the recorded ids and clears them', () => {
+    const ledger = new CommittedSegmentLedger();
+    ledger.begin();
+    ledger.record(5);
+    ledger.record(7);
+    expect(ledger.drain()).toStrictEqual([5, 7]);
+    expect(ledger.ids).toStrictEqual([]);
+  });
+
+  it('a second drain returns an empty list so a retry cannot re-remove ids', () => {
+    const ledger = new CommittedSegmentLedger();
+    ledger.begin();
+    ledger.record(11);
+    ledger.drain();
+    expect(ledger.drain()).toStrictEqual([]);
+  });
+
+  it('begin drops ids from a previous assistant message', () => {
+    const ledger = new CommittedSegmentLedger();
+    ledger.begin();
+    ledger.record(1);
+    ledger.record(2);
+    ledger.begin();
+    expect(ledger.ids).toStrictEqual([]);
+  });
+
+  it('exposes ids as a read-only view', () => {
+    const ledger = new CommittedSegmentLedger();
+    ledger.begin();
+    ledger.record(3);
+    const snapshot = ledger.ids;
+    expect(snapshot).toStrictEqual([3]);
+    ledger.record(4);
+    expect(ledger.ids).toStrictEqual([3, 4]);
+  });
+
+  /**
+   * @requirement REQ-3048-009 (review finding: ledger lifecycle)
+   * @scenario A normally-completed assistant message ends the ledger so its
+   *   committed ids become permanent and cannot be retracted by a later turn.
+   */
+  it('end clears recorded ids without retracting them', () => {
+    const ledger = new CommittedSegmentLedger();
+    ledger.begin();
+    ledger.record(9);
+    ledger.record(10);
+    ledger.end();
+    expect(ledger.ids).toStrictEqual([]);
+    // After end, a drain (the retry path) returns nothing: the ids are gone,
+    // not retracted.
+    expect(ledger.drain()).toStrictEqual([]);
+  });
+
+  it('end bounds the ledger to a single message lifecycle', () => {
+    const ledger = new CommittedSegmentLedger();
+    // First message: committed ids, then completed.
+    ledger.begin();
+    ledger.record(1);
+    ledger.end();
+    // A later message begins; its ids are tracked independently.
+    ledger.begin();
+    ledger.record(2);
+    expect(ledger.drain()).toStrictEqual([2]);
+  });
+});

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useAgentStreamOrchestration.terminal.bun.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useAgentStreamOrchestration.terminal.bun.tsx
@@ -161,6 +161,7 @@ function useOrchestration(
     [],
   );
   const addItem = React.useMemo(() => vi.fn().mockReturnValue(1), []);
+  const removeItems = React.useMemo(() => vi.fn(), []);
   const commandEffect = React.useMemo<string[]>(() => [], []);
   const handleSlashCommand = React.useMemo(
     () =>
@@ -175,6 +176,7 @@ function useOrchestration(
     runtime,
     agent,
     addItem,
+    removeItems,
     settings: createLoadedSettings(),
     onDebugMessage: vi.fn(),
     onCancelSubmit: vi.fn(),

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.doublecancel.bun.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.doublecancel.bun.tsx
@@ -159,6 +159,7 @@ function createUseSubmitQueryDeps(
       createStreamRuntimeForTest({}, createMockOverrides()),
     agent: createMockAgent(),
     addItem: overrides.addItem ?? vi.fn().mockReturnValue(1),
+    removeItems: vi.fn(),
     settings: createLoadedSettings(),
     onDebugMessage: vi.fn(),
     onCancelSubmit: vi.fn(),

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx
@@ -1,0 +1,631 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #3048 — discard-and-restart in the interactive CLI.
+ *
+ * Drives the REAL `useSubmitQuery` event-routing lifecycle (real
+ * `useStreamEventHandlers`, real `dispatchAgentEvent`, real
+ * `PendingResponseBuffer`, real `CommittedSegmentLedger`). Only leaf
+ * infrastructure (`turnPreparation`, `SessionContext`) is stubbed. React host
+ * state (pending history item, thought) is captured by holders that mirror real
+ * `setState` semantics so assertions read observable rendered values.
+ *
+ * @plan PLAN-20260806-ISSUE3048.P09 P11
+ * @requirement REQ-3048-008 REQ-3048-009
+ */
+
+import { describe, it, expect } from 'bun:test';
+import React, { act, type Dispatch, type SetStateAction } from 'react';
+import { vi } from '../../../../test-utils/bunTest.js';
+import { renderHook, waitFor } from '../../../../test-utils/render.js';
+import { useSubmitQuery, type UseSubmitQueryDeps } from '../useSubmitQuery.js';
+import { StreamingState, type HistoryItemWithoutId } from '../../../types.js';
+import type {
+  ThinkingBlock,
+  ThoughtSummary,
+} from '@vybestack/llxprt-code-core';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+import type { QueuedSubmission } from '../types.js';
+import type { UseHistoryManagerReturn } from '../../useHistoryManager.js';
+import { PendingResponseBuffer } from '../pendingResponseBuffer.js';
+import { createStreamRuntimeForTest } from './streamRuntimeTestHelper.js';
+import { createDeferred } from './createDeferred.js';
+import { createFakeAgentFromMockClient } from '../../useAgentStream-test-helpers.js';
+import type { StreamRuntime } from '../../../cliUiRuntime.js';
+import {
+  createLoadedSettings,
+  createMockOverrides,
+  createQueueOperations,
+} from './submitQueryTestFixtures.js';
+
+vi.mock('../turnPreparation.js', () => ({
+  prepareTurnForQuery: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../contexts/SessionContext.js', () => ({
+  useSessionStats: () => ({
+    startNewPrompt: vi.fn(),
+    getPromptCount: () => 0,
+  }),
+}));
+
+function createMockAgent() {
+  return createFakeAgentFromMockClient({
+    getCurrentSequenceModel: () => 'test-model',
+  });
+}
+
+interface CoordinatedState {
+  pendingHistoryItemRef: React.MutableRefObject<HistoryItemWithoutId | null>;
+  setPendingHistoryItem: Dispatch<SetStateAction<HistoryItemWithoutId | null>>;
+  thinkingBlocksRef: React.MutableRefObject<ThinkingBlock[]>;
+  thoughtRef: React.MutableRefObject<ThoughtSummary | null>;
+  setThought: Dispatch<SetStateAction<ThoughtSummary | null>>;
+}
+
+function createCoordinatedState(): CoordinatedState {
+  let pending: HistoryItemWithoutId | null = null;
+  const thoughtRef: React.MutableRefObject<ThoughtSummary | null> = {
+    current: null,
+  };
+  const thinkingBlocksRef: React.MutableRefObject<ThinkingBlock[]> = {
+    current: [],
+  };
+  return {
+    pendingHistoryItemRef: {
+      get current() {
+        return pending;
+      },
+      set current(value: HistoryItemWithoutId | null) {
+        pending = value;
+      },
+    },
+    setPendingHistoryItem: (
+      updater:
+        | HistoryItemWithoutId
+        | null
+        | ((prev: HistoryItemWithoutId | null) => HistoryItemWithoutId | null),
+    ) => {
+      pending = typeof updater === 'function' ? updater(pending) : updater;
+    },
+    thinkingBlocksRef,
+    thoughtRef,
+    setThought: (
+      updater:
+        | ThoughtSummary
+        | null
+        | ((prev: ThoughtSummary | null) => ThoughtSummary | null),
+    ) => {
+      thoughtRef.current =
+        typeof updater === 'function' ? updater(thoughtRef.current) : updater;
+    },
+  };
+}
+
+interface AddItemRecorder {
+  calls: Array<{
+    id: number;
+    item: Parameters<UseHistoryManagerReturn['addItem']>[0];
+    timestamp: number;
+  }>;
+  addItem: UseHistoryManagerReturn['addItem'];
+}
+
+function createRecordingAddItem(seedId = 1000): AddItemRecorder {
+  const calls: AddItemRecorder['calls'] = [];
+  let nextId = seedId;
+  return {
+    calls,
+    addItem: (item, timestamp = Date.now()) => {
+      const id = nextId;
+      nextId += 1;
+      calls.push({ id, item, timestamp });
+      return id;
+    },
+  };
+}
+
+interface RemoveItemsRecorder {
+  calls: Array<{ ids: readonly number[] }>;
+  removeItems: (ids: readonly number[]) => void;
+}
+
+function createRecordingRemoveItems(): RemoveItemsRecorder {
+  const calls: Array<{ ids: readonly number[] }> = [];
+  return {
+    calls,
+    removeItems: (ids) => {
+      calls.push({ ids: [...ids] });
+    },
+  };
+}
+
+interface RetryDiscardDeps {
+  coordinated: CoordinatedState;
+  addItemRecorder: AddItemRecorder;
+  removeItemsRecorder: RemoveItemsRecorder;
+  pendingResponse: PendingResponseBuffer;
+  setIsRespondingCalls: boolean[];
+  setIsResponding: Dispatch<SetStateAction<boolean>>;
+  abortControllerRef: React.MutableRefObject<AbortController | null>;
+  runStreamRef: UseSubmitQueryDeps['runStreamRef'];
+  flushCalls: number[];
+  queuedSubmissionsRef: React.MutableRefObject<QueuedSubmission[]>;
+}
+
+function createRetryDiscardDeps(
+  options: {
+    pendingHistoryItemRef?: React.MutableRefObject<HistoryItemWithoutId | null>;
+    setPendingHistoryItem?: Dispatch<
+      SetStateAction<HistoryItemWithoutId | null>
+    >;
+  } = {},
+): RetryDiscardDeps {
+  const coordinated = createCoordinatedState();
+  const setIsRespondingCalls: boolean[] = [];
+  const addItemRecorder = createRecordingAddItem();
+  const removeItemsRecorder = createRecordingRemoveItems();
+  const flushCalls: number[] = [];
+  const queuedSubmissionsRef: React.MutableRefObject<QueuedSubmission[]> = {
+    current: [],
+  };
+  return {
+    coordinated: {
+      ...coordinated,
+      ...(options.pendingHistoryItemRef
+        ? { pendingHistoryItemRef: options.pendingHistoryItemRef }
+        : {}),
+      ...(options.setPendingHistoryItem
+        ? { setPendingHistoryItem: options.setPendingHistoryItem }
+        : {}),
+    },
+    addItemRecorder,
+    removeItemsRecorder,
+    pendingResponse: new PendingResponseBuffer(undefined),
+    setIsRespondingCalls,
+    setIsResponding: createMockSetState(setIsRespondingCalls),
+    abortControllerRef: { current: null },
+    runStreamRef: { current: null },
+    flushCalls,
+    queuedSubmissionsRef,
+  };
+}
+
+function createMockSetState(
+  calls: boolean[],
+): Dispatch<SetStateAction<boolean>> {
+  return (value) => {
+    if (typeof value === 'boolean') calls.push(value);
+  };
+}
+
+function buildUseSubmitQueryDeps(
+  deps: RetryDiscardDeps,
+  overrides: {
+    runtime?: StreamRuntime;
+  } = {},
+): (streamingState: StreamingState) => UseSubmitQueryDeps {
+  const queueOperations = createQueueOperations(deps.queuedSubmissionsRef);
+  const flushPendingHistoryItem = (timestamp: number) => {
+    deps.flushCalls.push(timestamp);
+  };
+  const stableDeps = {
+    runtime:
+      overrides.runtime ??
+      createStreamRuntimeForTest({}, createMockOverrides()),
+    agent: createMockAgent(),
+    addItem: deps.addItemRecorder.addItem,
+    removeItems: deps.removeItemsRecorder.removeItems,
+    settings: createLoadedSettings(),
+    onDebugMessage: vi.fn(),
+    onCancelSubmit: vi.fn(),
+    onAuthError: vi.fn(),
+    recordingIntegration: undefined,
+    sanitizeContent: (text: string) => ({ text, blocked: false }),
+    flushPendingHistoryItem,
+    pendingResponse: deps.pendingResponse,
+    pendingHistoryItemRef: deps.coordinated.pendingHistoryItemRef,
+    thinkingBlocksRef: deps.coordinated.thinkingBlocksRef,
+    turnCancelledRef: { current: false },
+    setTurnCancelled: vi.fn(),
+    queuedSubmissionsRef: deps.queuedSubmissionsRef,
+    ...queueOperations,
+    drainSuppressedRef: { current: false },
+    tryReserveDrain: vi.fn().mockReturnValue(true),
+    releaseDrain: vi.fn(),
+    setPendingHistoryItem: deps.coordinated.setPendingHistoryItem,
+    setIsResponding: deps.setIsResponding,
+    setInitError: vi.fn(),
+    setThought: deps.coordinated.setThought,
+    setLastAgentActivityTime: vi.fn(),
+    scheduleToolCalls: vi.fn(),
+    abortActiveStream: vi.fn(),
+    handleShellCommand: vi.fn().mockReturnValue(false),
+    handleSlashCommand: vi.fn().mockResolvedValue(false),
+    logger: null,
+    shellModeActive: false,
+    loopDetectedRef: { current: false },
+    lastProfileNameRef: { current: undefined },
+    lastModelInfoRef: { current: null },
+    lastModelIdentityRef: { current: null },
+    abortControllerRef: deps.abortControllerRef,
+    runStreamRef: deps.runStreamRef,
+    submitQueryRef: { current: null },
+    isResponding: false,
+  };
+  return (streamingState) => ({ ...stableDeps, streamingState });
+}
+
+function renderUseSubmitQuery(
+  deps: RetryDiscardDeps,
+  overrides: {
+    runtime?: StreamRuntime;
+    initialStreamingState?: StreamingState;
+  } = {},
+) {
+  const getDeps = buildUseSubmitQueryDeps(deps, overrides);
+  return renderHook(
+    ({ streamingState }: { streamingState: StreamingState }) =>
+      useSubmitQuery(getDeps(streamingState)),
+    {
+      initialProps: {
+        streamingState: overrides.initialStreamingState ?? StreamingState.Idle,
+      },
+    },
+  );
+}
+
+async function startActiveTurn(
+  result: { current: ReturnType<typeof useSubmitQuery> },
+  rerender: (props: { streamingState: StreamingState }) => void,
+  deps: RetryDiscardDeps,
+): Promise<AbortSignal> {
+  deps.runStreamRef.current = vi.fn(() => {
+    const deferred = createDeferred<void>();
+    return deferred.promise;
+  });
+  await act(async () => {
+    void result.current.submitQuery('turn-1');
+  });
+  await waitFor(() => expect(deps.setIsRespondingCalls).toStrictEqual([true]));
+  await act(async () => {
+    rerender({ streamingState: StreamingState.Responding });
+  });
+  const controller = deps.abortControllerRef.current;
+  if (!controller) throw new Error('AbortController not set after submit');
+  return controller.signal;
+}
+
+async function route(
+  result: { current: ReturnType<typeof useSubmitQuery> },
+  event: AgentEvent,
+  signal: AbortSignal,
+): Promise<void> {
+  await act(async () => {
+    result.current.processAgentEvent(event, Date.now(), signal);
+  });
+}
+
+/**
+ * Type-safe accessor for the pending item's text. Uses a discriminated check
+ * instead of a type assertion.
+ */
+function pendingText(item: HistoryItemWithoutId | null): string | undefined {
+  if (item === null) return undefined;
+  if ('text' in item) return item.text;
+  return undefined;
+}
+
+const THINKING_EVENT: AgentEvent = {
+  type: 'thinking',
+  thought: { subject: 'reasoning', description: 'about the answer' },
+};
+
+describe('useSubmitQuery — discard-and-restart (issue #3048, REQ-3048-008)', () => {
+  it('renders only the successful attempt text after a retry', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    await route(result, { type: 'text', text: 'abandoned partial' }, signal);
+    await route(result, { type: 'retry' }, signal);
+    await route(result, { type: 'text', text: 'kept' }, signal);
+
+    expect(pendingText(deps.coordinated.pendingHistoryItemRef.current)).toBe(
+      'kept',
+    );
+  });
+
+  it('does not commit the abandoned pending item to history', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    await route(result, { type: 'text', text: 'abandoned partial' }, signal);
+    await route(result, { type: 'retry' }, signal);
+    await route(result, { type: 'text', text: 'kept' }, signal);
+
+    const abandonedCommits = deps.addItemRecorder.calls.filter(
+      (call) =>
+        typeof call.item.text === 'string' &&
+        call.item.text.includes('abandoned partial'),
+    );
+    expect(abandonedCommits).toStrictEqual([]);
+  });
+
+  it('resets the pending response buffer', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    await route(result, { type: 'text', text: 'abandoned partial' }, signal);
+    expect(deps.pendingResponse.stableText).toBe('abandoned partial');
+
+    await route(result, { type: 'retry' }, signal);
+
+    expect(deps.pendingResponse.stableText).toBe('');
+    expect(deps.pendingResponse.displayText).toBe('');
+  });
+
+  it('clears thinking state produced by the abandoned attempt', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    await route(result, THINKING_EVENT, signal);
+    expect(deps.coordinated.thinkingBlocksRef.current.length).toBe(1);
+    expect(deps.coordinated.thoughtRef.current).not.toBe(null);
+
+    await route(result, { type: 'retry' }, signal);
+
+    expect(deps.coordinated.thinkingBlocksRef.current).toStrictEqual([]);
+    expect(deps.coordinated.thoughtRef.current).toBe(null);
+  });
+
+  it('leaves a pending tool_group item untouched', async () => {
+    const toolGroupItem: HistoryItemWithoutId = {
+      type: 'tool_group',
+      tools: [],
+    };
+    const deps = createRetryDiscardDeps({
+      pendingHistoryItemRef: { current: toolGroupItem },
+    });
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    await route(result, { type: 'retry' }, signal);
+
+    expect(deps.coordinated.pendingHistoryItemRef.current).toBe(toolGroupItem);
+  });
+
+  it('does not release the turn or clear the submission queue', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+    const respondingCallsBefore = [...deps.setIsRespondingCalls];
+
+    await route(result, { type: 'retry' }, signal);
+
+    expect(deps.setIsRespondingCalls).toStrictEqual(respondingCallsBefore);
+    expect(deps.queuedSubmissionsRef.current).toStrictEqual([]);
+  });
+
+  it('returns the dispatcher buffer as an empty string for retry', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    await route(result, { type: 'text', text: 'abandoned' }, signal);
+    await route(result, { type: 'retry' }, signal);
+    await route(result, { type: 'text', text: 'x' }, signal);
+
+    expect(pendingText(deps.coordinated.pendingHistoryItemRef.current)).toBe(
+      'x',
+    );
+  });
+});
+
+describe('useSubmitQuery — committed segment retraction (issue #3048, REQ-3048-009)', () => {
+  it('retracts stable segments committed by the abandoned attempt', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    // Stream text with a paragraph break so the content processor commits a
+    // stable prefix via addItem. The ledger records the returned id.
+    await route(result, { type: 'text', text: 'para one\n\npara two' }, signal);
+
+    const committedTexts = deps.addItemRecorder.calls
+      .filter((c) => typeof c.item.text === 'string')
+      .map((c) => c.item.text)
+      .filter((text): text is string => text?.includes('para one') === true);
+    expect(committedTexts.length).toBe(1);
+
+    await route(result, { type: 'retry' }, signal);
+
+    expect(deps.removeItemsRecorder.calls.length).toBe(1);
+    const retracted = deps.removeItemsRecorder.calls[0]?.ids ?? [];
+    expect(retracted.length).toBe(1);
+    // The retracted id must be the one addItem returned for the committed segment
+    const committedSegmentCall = deps.addItemRecorder.calls.find(
+      (c) =>
+        typeof c.item.text === 'string' && c.item.text.includes('para one'),
+    );
+    if (committedSegmentCall === undefined) {
+      throw new Error('Expected the stable segment to be committed');
+    }
+    expect(retracted[0]).toBe(committedSegmentCall.id);
+  });
+
+  it('preserves items from before the assistant message', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    // Add a user item that should survive the retraction
+    await route(result, { type: 'text', text: 'para one\n\npara two' }, signal);
+    await route(result, { type: 'retry' }, signal);
+
+    // The removeItems call should only target the committed segment id,
+    // not any earlier items
+    expect(deps.removeItemsRecorder.calls.length).toBe(1);
+    const retracted = deps.removeItemsRecorder.calls[0]?.ids ?? [];
+    expect(retracted.length).toBe(1);
+  });
+
+  it('drains nothing on a second retry', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps);
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    await route(result, { type: 'text', text: 'para one\n\npara two' }, signal);
+    await route(result, { type: 'retry' }, signal);
+
+    // First retry retracts the committed segment
+    expect(deps.removeItemsRecorder.calls.length).toBe(1);
+
+    // Second retry: the ledger was drained, so nothing to retract
+    await route(result, { type: 'retry' }, signal);
+    expect(deps.removeItemsRecorder.calls.length).toBe(1);
+  });
+
+  /**
+   * Runs a turn to completion: starts an active submission, routes the scripted
+   * events, resolves the held `runStream` promise, and waits for the turn to
+   * settle back to idle. Returns the turn's abort signal so a later turn can be
+   * distinguished from it.
+   */
+  async function runTurnToCompletion(
+    result: { current: ReturnType<typeof useSubmitQuery> },
+    rerender: (props: { streamingState: StreamingState }) => void,
+    deps: RetryDiscardDeps,
+    events: readonly AgentEvent[],
+  ): Promise<AbortSignal> {
+    let resolveRun!: () => void;
+    deps.runStreamRef.current = vi.fn(() => {
+      const deferred = createDeferred<void>();
+      resolveRun = deferred.resolve;
+      return deferred.promise;
+    });
+    await act(async () => {
+      void result.current.submitQuery('turn');
+    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls.at(-1) ?? false).toBe(true),
+    );
+    await act(async () => {
+      rerender({ streamingState: StreamingState.Responding });
+    });
+    const controller = deps.abortControllerRef.current;
+    if (!controller) throw new Error('AbortController not set after submit');
+    const signal = controller.signal;
+    for (const event of events) {
+      await route(result, event, signal);
+    }
+    await act(async () => {
+      resolveRun();
+    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls.at(-1) ?? true).toBe(false),
+    );
+    await act(async () => {
+      rerender({ streamingState: StreamingState.Idle });
+    });
+    return signal;
+  }
+
+  /**
+   * Starts a subsequent turn while a previous turn has already completed. Unlike
+   * {@link startActiveTurn} (which asserts the first-ever responding call), this
+   * checks the *latest* responding call so it works after an earlier turn.
+   */
+  async function startNextActiveTurn(
+    result: { current: ReturnType<typeof useSubmitQuery> },
+    rerender: (props: { streamingState: StreamingState }) => void,
+    deps: RetryDiscardDeps,
+  ): Promise<AbortSignal> {
+    deps.runStreamRef.current = vi.fn(() => {
+      const deferred = createDeferred<void>();
+      return deferred.promise;
+    });
+    await act(async () => {
+      void result.current.submitQuery('turn-next');
+    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls.at(-1) ?? false).toBe(true),
+    );
+    await act(async () => {
+      rerender({ streamingState: StreamingState.Responding });
+    });
+    const controller = deps.abortControllerRef.current;
+    if (!controller) throw new Error('AbortController not set after submit');
+    return controller.signal;
+  }
+
+  describe('useSubmitQuery — committed segment ledger lifecycle across turns (issue #3048 review)', () => {
+    /**
+     * @requirement REQ-3048-009 (review finding: ledger lifecycle)
+     * @scenario A completed turn's committed segment must survive a later turn
+     *   that emits thinking/tool output then Retry before any Content.
+     * @given turn A streams a multi-paragraph message that commits a stable
+     *   segment, then completes via `done`.
+     * @when turn B emits a thinking event then Retry before any Content.
+     * @then turn A's history is retracted by nothing; only current-attempt ids
+     *   can be drained.
+     */
+    it('preserves a completed turn history when a later turn retries before content', async () => {
+      const deps = createRetryDiscardDeps();
+      const { result, rerender } = renderUseSubmitQuery(deps);
+
+      // Turn A: commits a stable paragraph segment, then completes.
+      await runTurnToCompletion(result, rerender, deps, [
+        { type: 'text', text: 'para one\n\npara two' },
+        { type: 'done', reason: 'stop' },
+      ]);
+
+      // Turn A committed exactly one stable segment to history.
+      const turnACommitted = deps.addItemRecorder.calls.filter((entry) => {
+        const text = entry.item.text;
+        return typeof text === 'string' && text.includes('para one');
+      });
+      expect(turnACommitted.length).toBe(1);
+      // No retraction happened during turn A.
+      expect(deps.removeItemsRecorder.calls).toStrictEqual([]);
+
+      // Turn B: thinking then Retry BEFORE any Content.
+      const turnBSignal = await startNextActiveTurn(result, rerender, deps);
+
+      await route(result, THINKING_EVENT, turnBSignal);
+      await route(result, { type: 'retry' }, turnBSignal);
+
+      // Turn A's committed segment MUST survive: no retraction requested.
+      expect(deps.removeItemsRecorder.calls).toStrictEqual([]);
+
+      // The discard handler must still preserve a scheduler-owned tool_group
+      // pending item during turn B (REQ-3048-008): the retry must not null it.
+      const toolGroupItem: HistoryItemWithoutId = {
+        type: 'tool_group',
+        tools: [],
+      };
+      deps.coordinated.pendingHistoryItemRef.current = toolGroupItem;
+      await route(result, { type: 'retry' }, turnBSignal);
+      expect(deps.coordinated.pendingHistoryItemRef.current).toBe(
+        toolGroupItem,
+      );
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx
@@ -207,19 +207,28 @@ function buildUseSubmitQueryDeps(
   deps: RetryDiscardDeps,
   overrides: {
     runtime?: StreamRuntime;
+    /**
+     * When the key is present (even as undefined) it replaces the history
+     * retraction wiring, letting a test simulate an unwired hook.
+     */
+    removeItems?: (ids: readonly number[]) => void;
   } = {},
 ): (streamingState: StreamingState) => UseSubmitQueryDeps {
   const queueOperations = createQueueOperations(deps.queuedSubmissionsRef);
   const flushPendingHistoryItem = (timestamp: number) => {
     deps.flushCalls.push(timestamp);
   };
+  const hasRemoveItemsOverride = 'removeItems' in overrides;
+  const removeItems = hasRemoveItemsOverride
+    ? overrides.removeItems
+    : deps.removeItemsRecorder.removeItems;
   const stableDeps = {
     runtime:
       overrides.runtime ??
       createStreamRuntimeForTest({}, createMockOverrides()),
     agent: createMockAgent(),
     addItem: deps.addItemRecorder.addItem,
-    removeItems: deps.removeItemsRecorder.removeItems,
+    removeItems,
     settings: createLoadedSettings(),
     onDebugMessage: vi.fn(),
     onCancelSubmit: vi.fn(),
@@ -265,6 +274,7 @@ function renderUseSubmitQuery(
   overrides: {
     runtime?: StreamRuntime;
     initialStreamingState?: StreamingState;
+    removeItems?: (ids: readonly number[]) => void;
   } = {},
 ) {
   const getDeps = buildUseSubmitQueryDeps(deps, overrides);
@@ -475,7 +485,13 @@ describe('useSubmitQuery — committed segment retraction (issue #3048, REQ-3048
 
     const signal = await startActiveTurn(result, rerender, deps);
 
-    // Add a user item that should survive the retraction
+    // Add a real earlier history item (a prior user message) and capture its
+    // actual id. It must survive the retraction of the abandoned attempt.
+    const earlierItemId = deps.addItemRecorder.addItem(
+      { type: 'user', text: 'an earlier message' },
+      0,
+    );
+    // Stream the assistant message, then abandon it.
     await route(result, { type: 'text', text: 'para one\n\npara two' }, signal);
     await route(result, { type: 'retry' }, signal);
 
@@ -484,6 +500,8 @@ describe('useSubmitQuery — committed segment retraction (issue #3048, REQ-3048
     expect(deps.removeItemsRecorder.calls.length).toBe(1);
     const retracted = deps.removeItemsRecorder.calls[0]?.ids ?? [];
     expect(retracted.length).toBe(1);
+    // The earlier history item's id must be absent from the retraction set.
+    expect(retracted).not.toContain(earlierItemId);
   });
 
   it('drains nothing on a second retry', async () => {
@@ -501,6 +519,51 @@ describe('useSubmitQuery — committed segment retraction (issue #3048, REQ-3048
     // Second retry: the ledger was drained, so nothing to retract
     await route(result, { type: 'retry' }, signal);
     expect(deps.removeItemsRecorder.calls.length).toBe(1);
+  });
+
+  it('fails fast without losing ledger ids when retraction is unwired', async () => {
+    const deps = createRetryDiscardDeps();
+    const { result, rerender } = renderUseSubmitQuery(deps, {
+      removeItems: undefined,
+    });
+
+    const signal = await startActiveTurn(result, rerender, deps);
+
+    // Stream a multi-paragraph message so the content processor commits a
+    // stable segment and records its id in the committed-segment ledger.
+    await route(
+      result,
+      { type: 'text', text: ['para one', '', 'para two'].join('\n') },
+      signal,
+    );
+
+    const committedCall = deps.addItemRecorder.calls.find(
+      (c) =>
+        typeof c.item.text === 'string' && c.item.text.includes('para one'),
+    );
+    if (committedCall === undefined) {
+      throw new Error('Expected a committed stable segment');
+    }
+    const committedId = committedCall.id;
+
+    // With retraction unwired (removeItems undefined), routing the retry must
+    // throw BEFORE draining the ledger so the committed id is not lost.
+    let caught: unknown;
+    try {
+      await route(result, { type: 'retry' }, signal);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught instanceof Error).toBe(true);
+    expect(
+      caught instanceof Error &&
+        caught.message.includes('History retraction is required'),
+    ).toBe(true);
+
+    // The ledger was not drained: the committed id survives for a later,
+    // correctly-wired retraction.
+    const retained = deps.pendingResponse.drainCommittedSegments();
+    expect(retained).toContain(committedId);
   });
 
   /**

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.terminalError.bun.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.terminalError.bun.tsx
@@ -160,6 +160,7 @@ function createUseSubmitQueryDeps(
       createStreamRuntimeForTest({}, createMockOverrides()),
     agent: createMockAgent(),
     addItem: overrides.addItem ?? vi.fn().mockReturnValue(1),
+    removeItems: vi.fn(),
     settings: createLoadedSettings(),
     onDebugMessage: vi.fn(),
     onCancelSubmit: vi.fn(),

--- a/packages/cli/src/ui/hooks/agentStream/agentEventDispatcher.ts
+++ b/packages/cli/src/ui/hooks/agentStream/agentEventDispatcher.ts
@@ -39,6 +39,7 @@ import {
   buildFinishReasonMessage,
 } from './streamUtils.js';
 import { observeAssistantMessageCommitted } from '../../../observation/jspWiring.js';
+import type { PendingResponseBuffer } from './pendingResponseBuffer.js';
 
 export interface AgentEventDeps {
   addItem: (item: HistoryItemWithoutId, timestamp: number) => void;
@@ -48,6 +49,13 @@ export interface AgentEventDeps {
     feedback?: string;
   };
   flushPendingHistoryItem: (timestamp: number) => void;
+  /**
+   * The per-turn pending response buffer. The dispatcher ends the committed
+   * segment ledger when an assistant message is flushed (finalized) so a later
+   * turn's retry cannot retract an earlier completed message's prefixes
+   * (issue #3048 review finding).
+   */
+  pendingResponse: PendingResponseBuffer;
   pendingHistoryItemRef: React.MutableRefObject<HistoryItemWithoutId | null>;
   thinkingBlocksRef: React.MutableRefObject<ThinkingBlock[]>;
   turnCancelledRef: React.MutableRefObject<boolean>;
@@ -85,6 +93,10 @@ export interface AgentEventDeps {
     remainingTokenCount: number,
   ) => void;
   handleCitationEvent: (text: string, timestamp: number) => void;
+  /**
+   * Discards the abandoned attempt's render state on retry (issue #3048).
+   */
+  handleStreamAttemptDiscarded: () => void;
 }
 
 type DispatchResult = {
@@ -130,6 +142,9 @@ function flushPendingAiContent(
     }
     deps.flushPendingHistoryItem(userMessageTimestamp);
     deps.setPendingHistoryItem(null);
+    // The assistant message is now permanent history: end the committed
+    // segment ledger so a later turn's retry cannot retract its prefixes.
+    deps.pendingResponse.endCommittedSegments();
   }
 }
 
@@ -351,11 +366,13 @@ export function dispatchAgentEvent(
         event.type,
         dispatchDoneEvent(event, deps, userMessageTimestamp),
       );
+    case 'retry':
+      deps.handleStreamAttemptDiscarded();
+      return { agentMessageBuffer: '' };
     case 'tool-call':
     case 'tool-result':
     case 'tool-confirmation':
     case 'tool-status':
-    case 'retry':
     case 'invalid-stream':
     case 'notice':
       // No state change — display flows through displayCallbacks or is

--- a/packages/cli/src/ui/hooks/agentStream/committedSegmentLedger.ts
+++ b/packages/cli/src/ui/hooks/agentStream/committedSegmentLedger.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Per-stream ledger of static history item ids committed for the assistant
+ * message currently being streamed.
+ *
+ * The content event processor commits stable prefixes of an in-flight assistant
+ * message to the CLI's static history list (issue #2852) as soon as a
+ * markdown-safe paragraph break arrives. Issue #3048's discard-and-restart
+ * needs to retract exactly those ids when the attempt is abandoned, without
+ * touching earlier completed messages.
+ *
+ * The ledger starts tracking at the boundary of a NEW assistant message
+ * ({@link begin}) so ids from a previous, completed message are never retracted
+ * by a later turn's retry. A discard drains the ledger (take + clear) so a
+ * second retry cannot attempt to re-remove already-retracted ids.
+ *
+ * Owned per stream — same lifetime as {@link PendingResponseBuffer}.
+ *
+ * @plan PLAN-20260806-ISSUE3048.P10
+ * @requirement REQ-3048-009
+ */
+export class CommittedSegmentLedger {
+  private recorded: number[] = [];
+
+  /**
+   * Marks the start of a new assistant message. Drops any ids recorded for a
+   * previous message so a subsequent retry retracts only the current message's
+   * committed prefixes.
+   */
+  begin(): void {
+    this.recorded = [];
+  }
+
+  /**
+   * Records a static history item id committed for the current message.
+   */
+  record(id: number): void {
+    this.recorded.push(id);
+  }
+
+  /**
+   * Returns the ids recorded for the current message and clears them. Used by
+   * the discard handler so the retracted ids are consumed exactly once.
+   */
+  drain(): readonly number[] {
+    const taken = [...this.recorded];
+    this.recorded = [];
+    return taken;
+  }
+
+  /**
+   * Ends the ledger for an assistant message that completed normally. Its
+   * committed prefixes are now permanent, so the ids are cleared without being
+   * retracted. Bounds the ledger to a single message lifecycle (issue #3048
+   * review finding).
+   */
+  end(): void {
+    this.recorded = [];
+  }
+
+  /**
+   * Read-only view of the ids recorded so far.
+   */
+  get ids(): readonly number[] {
+    return [...this.recorded];
+  }
+}

--- a/packages/cli/src/ui/hooks/agentStream/contentEventProcessor.ts
+++ b/packages/cli/src/ui/hooks/agentStream/contentEventProcessor.ts
@@ -52,6 +52,7 @@ function ensureAiPendingItem(
   liveProfileName: string | null,
   thinkingBlocksRef: React.MutableRefObject<ThinkingBlock[]>,
   userMessageTimestamp: number,
+  pendingResponse: PendingResponseBuffer,
 ): void {
   if (
     pendingHistoryItemRef.current?.type !== 'gemini' &&
@@ -59,6 +60,7 @@ function ensureAiPendingItem(
   ) {
     if (pendingHistoryItemRef.current)
       flushPendingHistoryItem(userMessageTimestamp);
+    pendingResponse.beginCommittedSegments();
     setPendingHistoryItem({
       type: 'gemini',
       text: '',
@@ -94,9 +96,10 @@ function applySplitResult(
   addItem: UseHistoryManagerReturn['addItem'],
   afterItem: HistoryItemAiContent,
   userMessageTimestamp: number,
+  pendingResponse: PendingResponseBuffer,
 ): string {
   if (beforeText) {
-    addItem(
+    const committedId = addItem(
       {
         type: pendingType,
         text: beforeText,
@@ -107,6 +110,7 @@ function applySplitResult(
       },
       userMessageTimestamp,
     );
+    pendingResponse.recordCommittedSegment(committedId);
     thinkingBlocksRef.current = [];
   }
   setPendingHistoryItem(afterItem);
@@ -200,6 +204,7 @@ export function processContentEvent(
     liveProfileIdentity,
     deps.thinkingBlocksRef,
     userMessageTimestamp,
+    deps.pendingResponse,
   );
 
   const existingProfileName = (
@@ -241,5 +246,6 @@ export function processContentEvent(
     deps.addItem,
     afterItem,
     userMessageTimestamp,
+    deps.pendingResponse,
   );
 }

--- a/packages/cli/src/ui/hooks/agentStream/pendingResponseBuffer.ts
+++ b/packages/cli/src/ui/hooks/agentStream/pendingResponseBuffer.ts
@@ -5,6 +5,7 @@
  */
 
 import type { EmojiFilter } from '@vybestack/llxprt-code-core';
+import { CommittedSegmentLedger } from './committedSegmentLedger.js';
 import { IncrementalSplitScanner } from './incrementalSplitScanner.js';
 import { StreamingSanitizer } from './streamingSanitizer.js';
 
@@ -32,6 +33,7 @@ export interface PendingResponsePushResult {
 export class PendingResponseBuffer {
   private readonly sanitizer: StreamingSanitizer;
   private readonly scanner = new IncrementalSplitScanner();
+  private readonly committedSegments = new CommittedSegmentLedger();
   private provisional = '';
 
   constructor(filter: EmojiFilter | undefined) {
@@ -95,6 +97,30 @@ export class PendingResponseBuffer {
       blocked: false,
       ...(flushed.feedback !== undefined ? { feedback: flushed.feedback } : {}),
     };
+  }
+
+  beginCommittedSegments(): void {
+    this.committedSegments.begin();
+  }
+
+  recordCommittedSegment(id: number): void {
+    this.committedSegments.record(id);
+  }
+
+  drainCommittedSegments(): readonly number[] {
+    return this.committedSegments.drain();
+  }
+
+  /**
+   * Ends the committed-segment lifecycle for the assistant message that just
+   * completed normally. Its committed prefixes are now permanent history, so
+   * the ledger is cleared without retracting them. This bounds the ledger to a
+   * single assistant message/stream: a later turn that emits only thinking or
+   * tool state before a retry cannot drain an earlier completed message's ids
+   * (issue #3048 review finding).
+   */
+  endCommittedSegments(): void {
+    this.committedSegments.end();
   }
 
   reset(): void {

--- a/packages/cli/src/ui/hooks/agentStream/useAgentStream.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentStream.ts
@@ -26,7 +26,10 @@ import {
   type HistoryItemWithoutId,
   type SlashCommandProcessorResult,
 } from '../../types.js';
-import { type UseHistoryManagerReturn } from '../useHistoryManager.js';
+import {
+  type RemoveHistoryItems,
+  type UseHistoryManagerReturn,
+} from '../useHistoryManager.js';
 import { mergePendingToolGroupsForDisplay } from './streamUtils.js';
 import { useCheckpointPersistence } from './checkpointPersistence.js';
 import type { useStreamState } from './useStreamState.js';
@@ -57,10 +60,12 @@ export const useAgentStream = (
   recordingIntegration?: RecordingIntegration,
   runtimeMessageBus?: MessageBus,
   subagentManager?: UiSubagentManager,
+  removeItems?: RemoveHistoryItems,
 ) => {
   const orchestration = useAgentStreamOrchestration({
     agent,
     addItem,
+    removeItems,
     runtime,
     settings,
     onDebugMessage,
@@ -85,6 +90,7 @@ export const useAgentStream = (
     runtime,
     history,
     agent,
+
     onDebugMessage,
   );
 };

--- a/packages/cli/src/ui/hooks/agentStream/useAgentStreamOrchestration.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentStreamOrchestration.ts
@@ -19,7 +19,10 @@ import {
   type HistoryItemWithoutId,
   type SlashCommandProcessorResult,
 } from '../../types.js';
-import { type UseHistoryManagerReturn } from '../useHistoryManager.js';
+import {
+  type RemoveHistoryItems,
+  type UseHistoryManagerReturn,
+} from '../useHistoryManager.js';
 import { type TrackedToolCall } from '../useReactToolScheduler.js';
 import { mapToDisplay as mapTrackedToolCallsToDisplay } from '../toolMapping.js';
 import { useStreamState } from './useStreamState.js';
@@ -40,6 +43,7 @@ import type { StreamRuntime, UiSubagentManager } from '../../cliUiRuntime.js';
 export interface AgentStreamOrchestrationDeps {
   agent: Agent;
   addItem: UseHistoryManagerReturn['addItem'];
+  removeItems?: RemoveHistoryItems;
   runtime: StreamRuntime;
   settings: LoadedSettings;
   onDebugMessage: (message: string) => void;
@@ -276,6 +280,7 @@ function useEventStreamForAgent(
     processAgentEventRef,
     flushPendingHistoryItem: st.flushPendingHistoryItem,
     clearPendingHistoryItem: () => {
+      st.pendingResponse.endCommittedSegments();
       st.setPendingHistoryItem(null);
       st.pendingResponse.reset();
     },
@@ -371,6 +376,7 @@ function buildSubmitQueryDeps({
     runtime: args.runtime,
     agent: args.agent,
     addItem: args.addItem,
+    removeItems: args.removeItems,
     settings: args.settings,
     onDebugMessage: args.onDebugMessage,
     onCancelSubmit: args.onCancelSubmit,

--- a/packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts
@@ -38,7 +38,10 @@ import {
   ToolCallStatus,
   type SlashCommandProcessorResult,
 } from '../../types.js';
-import { type UseHistoryManagerReturn } from '../useHistoryManager.js';
+import {
+  type RemoveHistoryItems,
+  type UseHistoryManagerReturn,
+} from '../useHistoryManager.js';
 import {
   showCitations,
   getCurrentProfileName,
@@ -107,6 +110,12 @@ interface StreamEventHandlersResult {
     estimatedRequestTokenCount: number,
     remainingTokenCount: number,
   ) => void;
+  /**
+   * Discards the abandoned attempt's render state (issue #3048): nulls the
+   * pending AI item without flushing, resets buffer/thinking state, and
+   * retracts committed stable segments. The turn stays responding.
+   */
+  handleStreamAttemptDiscarded: () => void;
   handleLoopDetectedEvent: () => void;
   displayUserMessage: (
     trimmedQuery: string,
@@ -131,6 +140,7 @@ interface StreamEventHandlerDeps {
   agent: Agent;
   settings: LoadedSettings;
   addItem: UseHistoryManagerReturn['addItem'];
+  removeItems?: RemoveHistoryItems;
   onDebugMessage: (message: string) => void;
   onCancelSubmit: (shouldRestorePrompt?: boolean) => void;
   sanitizeContent: (text: string) => {
@@ -178,6 +188,7 @@ export function useStreamEventHandlers(
   deps: StreamEventHandlerDeps,
 ): StreamEventHandlersResult {
   const handleContentEvent = useContentEventHandler(deps);
+  const handleStreamAttemptDiscarded = useStreamAttemptDiscardedHandler(deps);
   const handleLoopDetectedEvent = useCallback(
     () =>
       deps.addItem(
@@ -192,6 +203,7 @@ export function useStreamEventHandlers(
   const handlers = useStreamHandlers(
     deps,
     handleContentEvent,
+    handleStreamAttemptDiscarded,
     handleLoopDetectedEvent,
   );
   const displayUserMessage = useDisplayUserMessage(deps);
@@ -222,6 +234,53 @@ function useContentEventHandler(deps: StreamEventHandlerDeps) {
   );
 }
 
+/**
+ * REQ-3048-008/009: resets the uncommitted render state of the abandoned
+ * attempt and retracts stable segments it already committed.
+ */
+function useStreamAttemptDiscardedHandler(deps: StreamEventHandlerDeps) {
+  const {
+    pendingHistoryItemRef,
+    setPendingHistoryItem,
+    pendingResponse,
+    thinkingBlocksRef,
+    setThought,
+    removeItems,
+  } = deps;
+  return useCallback(() => {
+    const pending = pendingHistoryItemRef.current;
+    if (
+      pending &&
+      (pending.type === 'gemini' || pending.type === 'gemini_content')
+    ) {
+      setPendingHistoryItem(null);
+    }
+    pendingResponse.reset();
+    const retracted = pendingResponse.drainCommittedSegments();
+    if (retracted.length > 0) {
+      requireHistoryRetraction(removeItems)(retracted);
+    }
+    thinkingBlocksRef.current = [];
+    setThought(null);
+  }, [
+    pendingHistoryItemRef,
+    setPendingHistoryItem,
+    pendingResponse,
+    removeItems,
+    thinkingBlocksRef,
+    setThought,
+  ]);
+}
+
+function requireHistoryRetraction(
+  removeItems: RemoveHistoryItems | undefined,
+): RemoveHistoryItems {
+  if (!removeItems) {
+    throw new Error('History retraction is required after streamed content');
+  }
+  return removeItems;
+}
+
 function useStreamHandlers(
   deps: StreamEventHandlerDeps,
   handleContentEvent: (
@@ -229,10 +288,12 @@ function useStreamHandlers(
     currentAgentMessageBuffer: string,
     userMessageTimestamp: number,
   ) => string,
+  handleStreamAttemptDiscarded: () => void,
   handleLoopDetectedEvent: () => void,
 ): HandlerMap {
   return {
     handleContentEvent,
+    handleStreamAttemptDiscarded,
     handleUserCancelledEvent: useUserCancelledHandler(deps),
     handleErrorEvent: useErrorEventHandler(deps),
     handleCitationEvent: useCitationEventHandler(deps),
@@ -253,6 +314,7 @@ function useUserCancelledHandler(deps: StreamEventHandlerDeps) {
     setPendingHistoryItem,
     setThought,
     turnCancelledRef,
+    pendingResponse,
   } = deps;
 
   return useCallback(
@@ -274,6 +336,7 @@ function useUserCancelledHandler(deps: StreamEventHandlerDeps) {
         } else {
           flushPendingHistoryItem(userMessageTimestamp);
         }
+        pendingResponse.endCommittedSegments();
         setPendingHistoryItem(null);
       }
       addItem(
@@ -287,6 +350,7 @@ function useUserCancelledHandler(deps: StreamEventHandlerDeps) {
       addItem,
       flushPendingHistoryItem,
       pendingHistoryItemRef,
+      pendingResponse,
       setIsResponding,
       setPendingHistoryItem,
       setThought,
@@ -304,6 +368,7 @@ function useErrorEventHandler(deps: StreamEventHandlerDeps) {
     clearSubmissions,
     setPendingHistoryItem,
     setThought,
+    pendingResponse,
   } = deps;
 
   return useCallback(
@@ -316,6 +381,7 @@ function useErrorEventHandler(deps: StreamEventHandlerDeps) {
       setThought(null);
       if (pendingHistoryItemRef.current) {
         flushPendingHistoryItem(userMessageTimestamp);
+        pendingResponse.endCommittedSegments();
         setPendingHistoryItem(null);
       }
       const apiErrorInfo = buildApiErrorInfo(runtime);
@@ -338,6 +404,7 @@ function useErrorEventHandler(deps: StreamEventHandlerDeps) {
       addItem,
       runtime,
       flushPendingHistoryItem,
+      pendingResponse,
       pendingHistoryItemRef,
       clearSubmissions,
       setPendingHistoryItem,
@@ -353,6 +420,7 @@ function useCitationEventHandler(deps: StreamEventHandlerDeps) {
     flushPendingHistoryItem,
     pendingHistoryItemRef,
     setPendingHistoryItem,
+    pendingResponse,
     settings,
   } = deps;
 
@@ -361,6 +429,7 @@ function useCitationEventHandler(deps: StreamEventHandlerDeps) {
       if (!showCitations(settings, runtime)) return;
       if (pendingHistoryItemRef.current) {
         flushPendingHistoryItem(userMessageTimestamp);
+        pendingResponse.endCommittedSegments();
         setPendingHistoryItem(null);
       }
       addItem({ type: MessageType.INFO, text }, userMessageTimestamp);
@@ -370,6 +439,7 @@ function useCitationEventHandler(deps: StreamEventHandlerDeps) {
       runtime,
       flushPendingHistoryItem,
       pendingHistoryItemRef,
+      pendingResponse,
       setPendingHistoryItem,
       settings,
     ],
@@ -396,8 +466,13 @@ function useFinishedNoticeHandler(deps: StreamEventHandlerDeps) {
 }
 
 function useChatCompressionHandler(deps: StreamEventHandlerDeps) {
-  const { addItem, runtime, pendingHistoryItemRef, setPendingHistoryItem } =
-    deps;
+  const {
+    addItem,
+    runtime,
+    pendingHistoryItemRef,
+    pendingResponse,
+    setPendingHistoryItem,
+  } = deps;
   return useCallback(
     (
       eventValue: ServerChatCompressedEvent['value'],
@@ -405,6 +480,7 @@ function useChatCompressionHandler(deps: StreamEventHandlerDeps) {
     ) => {
       if (pendingHistoryItemRef.current) {
         addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        pendingResponse.endCommittedSegments();
         setPendingHistoryItem(null);
       }
       return addItem(
@@ -419,7 +495,13 @@ function useChatCompressionHandler(deps: StreamEventHandlerDeps) {
         Date.now(),
       );
     },
-    [addItem, runtime, pendingHistoryItemRef, setPendingHistoryItem],
+    [
+      addItem,
+      runtime,
+      pendingHistoryItemRef,
+      pendingResponse,
+      setPendingHistoryItem,
+    ],
   );
 }
 
@@ -564,6 +646,7 @@ function useDisplayUserMessage(deps: StreamEventHandlerDeps) {
 type HandlerMap = Pick<
   StreamEventHandlersResult,
   | 'handleContentEvent'
+  | 'handleStreamAttemptDiscarded'
   | 'handleUserCancelledEvent'
   | 'handleErrorEvent'
   | 'handleChatCompressionEvent'

--- a/packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts
@@ -256,9 +256,14 @@ function useStreamAttemptDiscardedHandler(deps: StreamEventHandlerDeps) {
       setPendingHistoryItem(null);
     }
     pendingResponse.reset();
+    // Resolve the retraction capability before draining the ledger so a
+    // missing removeItems wiring fails fast without losing committed segment
+    // IDs. reset() does not touch the ledger, so an early throw preserves the
+    // ids for a later, correctly-wired retraction.
+    const retract = requireHistoryRetraction(removeItems);
     const retracted = pendingResponse.drainCommittedSegments();
     if (retracted.length > 0) {
-      requireHistoryRetraction(removeItems)(retracted);
+      retract(retracted);
     }
     thinkingBlocksRef.current = [];
     setThought(null);

--- a/packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts
@@ -86,6 +86,7 @@ export interface UseSubmitQueryDeps {
     timestamp?: number,
     isResuming?: boolean,
   ) => number;
+  removeItems?: (ids: readonly number[]) => void;
   settings: Parameters<typeof useStreamEventHandlers>[0]['settings'];
   onDebugMessage: (message: string) => void;
   onCancelSubmit: (shouldRestorePrompt?: boolean) => void;
@@ -190,6 +191,7 @@ export function useSubmitQuery(deps: UseSubmitQueryDeps): UseSubmitQueryReturn {
     agent: deps.agent,
     settings: deps.settings,
     addItem: deps.addItem,
+    removeItems: deps.removeItems,
     onDebugMessage: deps.onDebugMessage,
     onCancelSubmit: deps.onCancelSubmit,
     sanitizeContent: deps.sanitizeContent,
@@ -256,6 +258,7 @@ function useProcessAgentEvent(
   handlers: Pick<
     ReturnType<typeof useStreamEventHandlers>,
     | 'handleContentEvent'
+    | 'handleStreamAttemptDiscarded'
     | 'handleUserCancelledEvent'
     | 'handleErrorEvent'
     | 'handleChatCompressionEvent'
@@ -299,6 +302,7 @@ function useProcessAgentEvent(
           addItem: latestDeps.current.addItem,
           sanitizeContent: latestDeps.current.sanitizeContent,
           flushPendingHistoryItem: latestDeps.current.flushPendingHistoryItem,
+          pendingResponse: latestDeps.current.pendingResponse,
           pendingHistoryItemRef: latestDeps.current.pendingHistoryItemRef,
           thinkingBlocksRef: latestDeps.current.thinkingBlocksRef,
           turnCancelledRef: latestDeps.current.turnCancelledRef,
@@ -685,6 +689,10 @@ async function runSubmitQueryCore(
   cbd.setIsResponding(true);
   cbd.setInitError(null);
   observeTurnStarted();
+  // Establish a fresh committed-segment boundary for this top-level turn
+  // before any event can arrive, so ids left over from a previous completed
+  // message cannot be retracted by this turn's retry (issue #3048 review).
+  cbd.pendingResponse.beginCommittedSegments();
 
   try {
     await executeStream(cbd, cbd.handleLoopDetectedEvent, queryToSend, turn);

--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -46,6 +46,13 @@ export interface UseHistoryManagerReturn {
   loadHistory: (newHistory: HistoryItem[]) => void;
 }
 
+export interface RetractableHistoryManagerReturn
+  extends UseHistoryManagerReturn {
+  removeItems: (ids: readonly number[]) => void;
+}
+
+export type RemoveHistoryItems = RetractableHistoryManagerReturn['removeItems'];
+
 export interface UseHistoryOptions {
   maxItems?: number;
   maxBytes?: number;
@@ -71,6 +78,12 @@ const EMPTY_HISTORY_STATE: HistoryState = { entries: [], totalBytes: 0 };
 export function useHistory(
   options?: UseHistoryOptions,
 ): UseHistoryManagerReturn {
+  return useRetractableHistory(options);
+}
+
+export function useRetractableHistory(
+  options?: UseHistoryOptions,
+): RetractableHistoryManagerReturn {
   const maxItems = options?.maxItems;
   const maxBytes = options?.maxBytes;
   const limits = useMemo(
@@ -119,6 +132,13 @@ export function useHistory(
     [limits],
   );
 
+  const removeItems = useCallback(
+    (ids: readonly number[]) => {
+      setState((previous) => removeHistoryItems(previous, ids, limits));
+    },
+    [limits],
+  );
+
   const clearItems = useCallback(() => {
     setState(EMPTY_HISTORY_STATE);
     ConversationContext.startNewConversation();
@@ -130,8 +150,15 @@ export function useHistory(
   );
 
   return useMemo(
-    () => ({ history, addItem, updateItem, clearItems, loadHistory }),
-    [history, addItem, updateItem, clearItems, loadHistory],
+    () => ({
+      history,
+      addItem,
+      updateItem,
+      removeItems,
+      clearItems,
+      loadHistory,
+    }),
+    [history, addItem, updateItem, removeItems, clearItems, loadHistory],
   );
 }
 
@@ -266,6 +293,25 @@ function updateHistoryItem(
     updatedEntry === undefined
       ? previous.totalBytes
       : previous.totalBytes - oldEntry.bytes + updatedEntry.bytes;
+  return trimHistoryState({ entries, totalBytes }, limits);
+}
+
+function removeHistoryItems(
+  previous: HistoryState,
+  ids: readonly number[],
+  limits: HistoryLimits,
+): HistoryState {
+  if (ids.length === 0) {
+    return previous;
+  }
+  const removal = new Set(ids);
+  const entries = previous.entries.filter(
+    (entry) => !removal.has(entry.item.id),
+  );
+  if (entries.length === previous.entries.length) {
+    return previous;
+  }
+  const totalBytes = entries.reduce((total, entry) => total + entry.bytes, 0);
   return trimHistoryState({ entries, totalBytes }, limits);
 }
 

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -23,6 +23,32 @@ const DEFAULT_TOOL_CALL_LOOP_THRESHOLD = 50;
 const DEFAULT_CONTENT_LOOP_THRESHOLD = 50;
 
 /**
+ * Immutable snapshot of the attempt-mutable loop-detection state. The
+ * `contentStats` map is deep-copied (each index array cloned) so restoring
+ * cannot alias the live detector's arrays.
+ */
+export interface LoopDetectionSnapshot {
+  readonly lastToolCallKey: string | null;
+  readonly toolCallRepetitionCount: number;
+  readonly streamContentHistory: string;
+  readonly contentStats: ReadonlyMap<string, number[]>;
+  readonly lastContentIndex: number;
+  readonly loopDetected: boolean;
+  readonly inCodeBlock: boolean;
+}
+
+/** Deep-copies a content-stats map so snapshots and restores do not alias. */
+function copyContentStats(
+  source: ReadonlyMap<string, readonly number[]>,
+): Map<string, number[]> {
+  const copy = new Map<string, number[]>();
+  for (const [hash, indices] of source) {
+    copy.set(hash, [...indices]);
+  }
+  return copy;
+}
+
+/**
  * Counts non-overlapping occurrences of a literal substring.
  */
 function countOccurrences(haystack: string, needle: string): number {
@@ -478,6 +504,41 @@ export class LoopDetectionService {
     this.resetContentTracking();
     this.resetTurnTracking();
     this.loopDetected = false;
+  }
+
+  /**
+   * Snapshot of the attempt-mutable detector state for transactional rollback.
+   * Captured at the start of a stream attempt and restored when a transport
+   * retry discards the abandoned attempt, so abandoned Content/ToolCallRequest
+   * cannot contaminate the detector (issue #3048 review finding).
+   *
+   * Prompt identity ({@link promptId}) and {@link turnsInCurrentPrompt} are
+   * deliberately excluded: they are prompt-scoped, not attempt-scoped.
+   */
+  checkpoint(): LoopDetectionSnapshot {
+    return {
+      lastToolCallKey: this.lastToolCallKey,
+      toolCallRepetitionCount: this.toolCallRepetitionCount,
+      streamContentHistory: this.streamContentHistory,
+      contentStats: copyContentStats(this.contentStats),
+      lastContentIndex: this.lastContentIndex,
+      loopDetected: this.loopDetected,
+      inCodeBlock: this.inCodeBlock,
+    };
+  }
+
+  /**
+   * Restores attempt-mutable detector state from a snapshot taken by
+   * {@link checkpoint}. Prompt identity and turn counts are preserved.
+   */
+  restore(snapshot: LoopDetectionSnapshot): void {
+    this.lastToolCallKey = snapshot.lastToolCallKey;
+    this.toolCallRepetitionCount = snapshot.toolCallRepetitionCount;
+    this.streamContentHistory = snapshot.streamContentHistory;
+    this.contentStats = copyContentStats(snapshot.contentStats);
+    this.lastContentIndex = snapshot.lastContentIndex;
+    this.loopDetected = snapshot.loopDetected;
+    this.inCodeBlock = snapshot.inCodeBlock;
   }
 
   private resetToolCallCount(): void {

--- a/packages/providers/src/__tests__/RetryOrchestrator.partialOutputBoundary.bun.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.partialOutputBoundary.bun.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Fence test for issue #3048 (REQ-3048-001).
+ *
+ * The discard-and-restart contract depends on a property that already exists:
+ * `RetryOrchestrator.yieldStreamUnprotected` marks any error raised after an
+ * `IContent` was yielded as terminal and refuses to retry inside the SAME
+ * iterator, because doing so would splice two generations into one stream. The
+ * turn-level restart happens at the fresh-attempt boundary owned by
+ * `TurnProcessor` instead (specification AD-1).
+ *
+ * This test passes on unmodified source. It exists so a future "just let the
+ * orchestrator retry after output" edit fails loudly — that edit would break the
+ * anti-mixing rule the whole fix relies on.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type {
+  GenerateChatOptions,
+  IProvider,
+  ProviderToolset,
+} from '../IProvider.js';
+import type { IModel } from '../IModel.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import {
+  isTerminalRetryError,
+  markErrorAfterStreamOutput,
+} from '../retryErrorClassification.js';
+
+describe('RetryOrchestrator partial-output boundary (issue 3048 fence)', () => {
+  it('does not retry inside one iterator after yielding output and propagates the same error', async () => {
+    const thrownError = new Error('Connection error.');
+
+    let generateCallCount = 0;
+    class PartialOutputProvider implements IProvider {
+      readonly name = 'partial-output-boundary-provider';
+
+      generateChatCompletion(
+        options: GenerateChatOptions,
+      ): AsyncIterableIterator<IContent>;
+      generateChatCompletion(
+        content: IContent[],
+        tools?: ProviderToolset,
+        signal?: AbortSignal,
+      ): AsyncIterableIterator<IContent>;
+      async *generateChatCompletion(
+        _optionsOrContent: GenerateChatOptions | IContent[],
+        _tools?: ProviderToolset,
+        _signal?: AbortSignal,
+      ): AsyncIterableIterator<IContent> {
+        generateCallCount += 1;
+        yield {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'partial' }],
+        };
+        throw thrownError;
+      }
+
+      async getModels(): Promise<IModel[]> {
+        return [];
+      }
+
+      getDefaultModel(): string {
+        return 'test-model';
+      }
+
+      getServerTools(): string[] {
+        return [];
+      }
+
+      async invokeServerTool(): Promise<unknown> {
+        return null;
+      }
+    }
+    const provider = new PartialOutputProvider();
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 6,
+      initialDelayMs: 0,
+    });
+
+    const collected: IContent[] = [];
+    let rejected: unknown;
+    try {
+      for await (const chunk of orchestrator.generateChatCompletion({
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+        ],
+      })) {
+        collected.push(chunk);
+      }
+    } catch (error) {
+      rejected = error;
+    }
+    expect(rejected).toBe(thrownError);
+
+    expect(generateCallCount).toBe(1);
+    expect(collected).toStrictEqual([
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'partial' }],
+      },
+    ]);
+
+    expect('isRetryable' in thrownError).toBe(false);
+    expect(isTerminalRetryError(thrownError)).toBe(true);
+  });
+
+  it('marks an after-output error terminal via the provider WeakSet (agents layer must not see it)', () => {
+    // The agents-layer predicate (turnAbortHelpers.isTerminalRetryError) keys off
+    // `isRetryable === false`. The provider mark keys off a private WeakSet, so a
+    // post-output transient transport error is terminal in providers but NOT
+    // terminal in agents — that is what lets the turn layer restart it. This pins
+    // the asymmetry directly against the two classification mechanisms.
+    const error = new Error('Connection error.');
+    expect('isRetryable' in error).toBe(false);
+    const marked = markErrorAfterStreamOutput(error);
+    expect(marked).toBe(error);
+    expect(isTerminalRetryError(marked)).toBe(true);
+  });
+});

--- a/project-plans/issue3048/analysis/preflight.md
+++ b/project-plans/issue3048/analysis/preflight.md
@@ -1,0 +1,227 @@
+# Phase 0.5 — Preflight Verification (issue #3048)
+
+Plan ID: `PLAN-20260806-ISSUE3048`
+Generated: 2026-08-06
+Branch: `issue3048`
+Base commit: `05d50c1e8` ("Run every test by discovery, not by an allowlist")
+
+Every claim below was verified by reading the working tree on this branch. No
+assumption in `specification.md` or `plan.md` is carried without an entry here.
+
+---
+
+## A. Call-path verification
+
+| # | Claim under test | Verdict | Evidence |
+|---|------------------|---------|----------|
+| A1 | `RetryOrchestrator.yieldStreamUnprotected` marks any post-output error terminal | CONFIRMED | `packages/providers/src/RetryOrchestrator.ts` — `chunksYielded` set before each `yield`; on `catch` with `chunksYielded === true` it throws `markErrorAfterStreamOutput(streamError)` |
+| A2 | The provider-side terminal mark is a provider-private `WeakSet`, not a field on the error | CONFIRMED | `packages/providers/src/retryErrorClassification.ts` — `const errorsAfterStreamOutput = new WeakSet<object>()`; `markErrorAfterStreamOutput` returns the *same object* for object-like errors; `isTerminalRetryError` = `AbortError name` OR WeakSet membership |
+| A3 | The agents-layer `isTerminalRetryError` is a **different predicate** and does NOT see the provider WeakSet | CONFIRMED | `packages/agents/src/core/turnAbortHelpers.ts` — `'isRetryable' in error && error.isRetryable === false` |
+| A4 | Therefore a post-output transient transport error arrives at the agents layer **unwrapped and not classified terminal** | CONFIRMED | `RetryOrchestrator.handleRetryError` returns `{ type: 'throw', error }` for `isTerminalRetryError(error)` — the raw error, NOT a `RetriesExhaustedError`. `createRetriesExhaustedError` (which sets `isRetryable: false`) is only reached on budget exhaustion (`packages/providers/src/retryExhaustion.ts` via `decideRetryOrThrow` / `runRetryRequest`) |
+| A5 | The **only** blocker to a turn-level restart after output is the `!hasYieldedChunk` conjunct | CONFIRMED | `packages/agents/src/core/TurnProcessor.ts:306-311` — `if (!hasYieldedChunk && shouldRetryStreamAttempt(error, params, attempt))`. With `hasYieldedChunk === false` the same error already retries today (`chatSession.issue2150.test.ts` proves the pre-output path) |
+| A6 | `shouldRetryStreamAttempt` already accepts transient transport errors and already rejects aborts | CONFIRMED | `turnAbortHelpers.ts:78-92` — `isNetworkTransientError(error) && !isAbortError(error, params)`; `isAbortError` covers `name === 'AbortError'`, `code === 'ABORT_ERR'`, and `params.config?.abortSignal?.aborted === true` |
+| A7 | Each turn attempt gets a **fresh** `StreamProcessor` accumulator | CONFIRMED | `TurnProcessor._runStreamAttempt` calls `streamProcessor.makeApiCallAndProcessStream(...)` per attempt → `_createCancellableStream` → `processStreamResponse`, whose first statement is `const accumulator = new StreamOutputAccumulator()` (`packages/agents/src/core/StreamProcessor.ts`) |
+| A8 | A failed attempt writes **nothing** to `HistoryService` | CONFIRMED | `processStreamResponse` calls `_finalizeStreamProcessing` only **after** the `for await` completes; there is no `finally`. `_finalizeStreamProcessing` → `recordHistoryWithUsage` (`streamValidationHelpers.ts:159`) is the only site that records both the user turn and the AI turn |
+| A9 | `StreamEventType.RETRY` already propagates to `AgentEventType.Retry` and to the public `{type:'retry'}` event | CONFIRMED | `TurnProcessor.ts:258` → `packages/agents/src/core/turn.ts:474-478` → `packages/agents/src/api/eventAdapter.ts:402-404` (`yield { type: 'retry' }`); schema at `packages/agents/src/api/event-schema.ts:139`, type at `event-types.ts:150` |
+| A10 | `turn.ts` already resets the cumulative response outcome on RETRY | CONFIRMED | `packages/agents/src/core/turn.ts:474-478` — `const outcome = this.createEmptyResponseOutcome();` returned as the new cumulative outcome |
+| A11 | `AgenticLoop` collects `ToolCallRequest` values and never clears them on RETRY | CONFIRMED | `packages/agents/src/core/agenticLoop/AgenticLoop.ts:524-547` — `toolCallRequests.push(event.value)`; cleared only by `isTerminalStreamOutcome` (Error / StreamIdleTimeout / UserCancelled / LoopDetected) |
+| A12 | The CLI dispatcher treats `'retry'` as a no-op | CONFIRMED | `packages/cli/src/ui/hooks/agentStream/agentEventDispatcher.ts:354-361` — `case 'retry':` shares the "No state change" fallthrough group |
+| A13 | The a2a-server executor collects `ToolCallRequest` in the same pattern and treats `Retry` as informational log-only | CONFIRMED | `packages/a2a-server/src/agent/executor.ts:476-497`; `packages/a2a-server/src/agent/task-support.ts:128,161,223` classify `AgentEventType.Retry` as `LOG_INFO_TYPES` |
+| A14 | `MessageStreamOrchestrator` accumulates per-attempt state that survives a RETRY | CONFIRMED | `packages/agents/src/core/MessageStreamOrchestrator.ts:412-462` — `hadThinking`, `hadContent`, `hadToolCallsThisTurn`, `deferredEvents`, and `ctx.responseChunks.push(event.value)` on `AgentEventType.Content` |
+| A15 | `ctx.responseChunks` is the AfterAgent hook's `responseText` | CONFIRMED | `MessageStreamOrchestrator._fireAfterHook` (`ctx.responseChunks.join('')`) and `MessageStreamTerminalHandler.fireAfterHook` (same) |
+| A16 | The non-interactive CLI accumulates `responseText` / `quietTextBuffer` that feed the final JSON result | CONFIRMED | `packages/cli/src/nonInteractiveCliSupport.ts` — `handleText` returns `responseText + outputValue` in `jsonOutput` mode; `handleQuietText` appends to `quietTextBuffer`; `finalizeStream` emits one of them |
+| A17 | Zed/ACP maps `'retry'` to `null` (ignored) | CONFIRMED | `packages/cli/src/zed-integration/zed-agent-event-handler.ts:104-106` |
+
+## B. Type/interface verification
+
+| # | Symbol | Expected | Actual | Match |
+|---|--------|----------|--------|-------|
+| B1 | `shouldRetryStreamAttempt` | `(error, params, attempt) => boolean` | `(error: unknown, params: SendMessageParams, attempt: number): boolean` | YES |
+| B2 | `INVALID_CONTENT_RETRY_OPTIONS` | bounded turn budget | `{ maxAttempts: 2, initialDelayMs: 500 }` (`packages/core/src/core/chatSessionTypes.ts:47`) → `withinBudget = attempt < 1` → **exactly one restart per turn** | YES |
+| B3 | `StreamOutputAccumulator` | has `add` / `materialize`, **no** `reset` | `packages/agents/src/core/streamOutputAccumulator.ts` — `add`, `materialize` only | YES |
+| B4 | `PendingResponseBuffer` | has a `reset()` | `packages/cli/src/ui/hooks/agentStream/pendingResponseBuffer.ts` — `reset()` resets sanitizer, scanner and provisional tail | YES |
+| B5 | `UseHistoryManagerReturn` | has a removal API | `{ history, addItem, updateItem, clearItems, loadHistory }` — **no removal API** | **NO — see finding F5** |
+| B6 | `AgentEventDeps` (CLI dispatcher) | has access to `pendingResponse` | It does **not**; `pendingResponse` lives only in `ContentEventDeps` / `StreamEventHandlerDeps` | **NO — see finding F6** |
+| B7 | `AgentEvent` `'retry'` variant | payload-free | `{ type: 'retry' }` — no fields | YES |
+
+## C. Test-infrastructure verification
+
+| # | Check | Result |
+|---|-------|--------|
+| C1 | Test discovery is structural (no manifest/allowlist) | CONFIRMED — `scripts/bun-test-roots.ts` (`DEFAULT_TEST_FILE_PATTERN = /\.(test\|spec\|bun)\.(ts\|tsx\|js)$/`, "deliberately **no** `files`, `include`, or `exclude` member"); `packages/cli/run-bun-tests.ts` and `packages/agents/run-bun-tests.ts` walk the filesystem. **No registration step is required for a new test file.** |
+| C2 | `packages/agents` test API | `packages/agents/src/testApi.ts` re-exports `bun:test` — agents suites import `'../testApi.js'` |
+| C3 | `packages/providers` already has direct `bun:test` suites | CONFIRMED — 39 files import `from 'bun:test'` (e.g. `src/auth/proxy/__tests__/github-broker-unknown-param.bun.test.ts`). Older `RetryOrchestrator.*.test.ts` files import `'vitest'`, which the `test-setup/augment-bun-vi.ts` preload shims onto Bun. **New files use `bun:test` directly.** |
+| C4 | CLI React-hook harness for stream events | CONFIRMED — `packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.terminalError.bun.tsx` drives the REAL `useSubmitQuery` + real `dispatchAgentEvent` + real `PendingResponseBuffer`, stubbing only `turnPreparation` and `SessionContext`. This is the harness the CLI phases reuse. |
+| C5 | Integrated agents harness with a fake provider | CONFIRMED — `packages/agents/src/core/chatSession.issue2150.test.ts` builds a real `ChatSession` → `TurnProcessor` → `StreamProcessor` over a `TestRuntimeProviderManager`, with `retry.ts` deliberately NOT mocked. This is the harness the integrated phase reuses. |
+| C6 | AgenticLoop harness | CONFIRMED — `packages/agents/src/core/agenticLoop/__tests__/agenticLoop-test-helpers.ts` exposes `AgentEventType.ToolCallRequest` builders; sibling suites (`agenticLoop.terminal-outcomes.test.ts`) already assert scheduling behaviour |
+| C7 | Copyright year guard | `scripts/check-copyright-year.ts` requires the **current** calendar year in headers of **added** files → new `.ts`/`.tsx` files must say `Copyright 2026 Vybestack LLC` |
+| C8 | New-JS guard | `scripts/check-no-new-js-files.ts` — new files must be TypeScript |
+| C9 | Doc-placement guard | `scripts/check-doc-placement.ts` — plans live in `project-plans/`, never `dev-docs/plans/` |
+
+## D. Size / lint-budget verification (blocking)
+
+ESLint config (`eslint.config.js:248-255`): `complexity: 25`, `max-lines: 800`
+(`skipBlankLines`, `skipComments`), `max-lines-per-function: 80` (same skips).
+`sonarjs/cognitive-complexity: 30`.
+
+Effective (non-blank, non-comment) line counts measured on this branch:
+
+| File | raw | effective | headroom to 800 |
+|------|-----|-----------|-----------------|
+| `packages/agents/src/core/TurnProcessor.ts` | 937 | **797** | **3** |
+| `packages/agents/src/core/MessageStreamOrchestrator.ts` | 821 | 702 | 98 |
+| `packages/agents/src/core/agenticLoop/AgenticLoop.ts` | 780 | 573 | 227 |
+| `packages/agents/src/core/turnAbortHelpers.ts` | 92 | 52 | 748 |
+| `packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts` | 816 | 686 | 114 |
+| `packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts` | 575 | 516 | 284 |
+| `packages/cli/src/ui/hooks/agentStream/agentEventDispatcher.ts` | 435 | 376 | 424 |
+| `packages/cli/src/ui/hooks/agentStream/contentEventProcessor.ts` | 245 | 215 | 585 |
+| `packages/cli/src/ui/hooks/useHistoryManager.ts` | 390 | 334 | 466 |
+| `packages/cli/src/nonInteractiveCliSupport.ts` | 701 (a2a executor 701/623 measured separately) | see note | — |
+| `packages/a2a-server/src/agent/executor.ts` | 701 | 623 | 177 |
+
+`MessageStreamOrchestrator._processStreamIteration` (lines 394-472) measures **68**
+effective lines against the 80-line function budget → 12 lines of headroom.
+
+`npx eslint packages/agents/src/core/TurnProcessor.ts` exits 0 today.
+
+## E. Findings that change the plan
+
+### F1 — `StreamOutputAccumulator.reset()` is unnecessary (issue item 2 is obsolete)
+
+Issue #3048 asks for `StreamOutputAccumulator` to be "resettable" and for
+`StreamProcessor` to reset it on the retry signal. **That is no longer needed.**
+Evidence A7 + A8: `processStreamResponse` constructs a brand-new accumulator on
+every call, `TurnProcessor` calls `makeApiCallAndProcessStream` once per attempt,
+and the accumulator is never observed across attempts because
+`_finalizeStreamProcessing` is only reached on normal completion. Adding a
+`reset()` would be dead code and a new, untested state transition on a class whose
+own doc comment already states the invariant ("State is per-instance and
+per-stream, so a cancelled, errored, or stalled stream releases everything it had
+collected rather than carrying it into the next turn").
+
+**Decision: do not add `StreamOutputAccumulator.reset`.** A behavioural test pins
+the *observable* property instead (one AI history entry after a discard+restart).
+
+### F2 — The provider layer needs no change; it must be fenced instead
+
+Evidence A1-A4. `markErrorAfterStreamOutput` is exactly right: it stops the
+orchestrator from splicing two attempts into one iterator. The restart must
+happen at the **fresh-attempt boundary** owned by `TurnProcessor`. The plan
+therefore adds provider-layer *invariant fence* tests rather than provider-layer
+behaviour changes.
+
+### F3 — `TurnProcessor.ts` has 3 effective lines of `max-lines` headroom
+
+Evidence D. Any net addition to `TurnProcessor.ts` risks tripping
+`max-lines: 800`. Because suppression directives and threshold changes are
+forbidden, the GREEN phase that touches `_runStreamAttempt` **must** relocate the
+pure helper `_applyRetryTemperature` (TurnProcessor.ts:316-330, referenced only
+from TurnProcessor.ts:263 — verified by repo-wide grep) into
+`turnAbortHelpers.ts`, whose file header already describes itself as
+"Retry-decision helpers extracted from TurnProcessor". That relocation frees
+~12 effective lines and puts the temperature policy next to the retry policy.
+
+### F4 — The turn budget and the provider budget are separate, and that is correct
+
+`attachTransportAttemptBudget` (`packages/providers/src/transportAttemptBudget.ts`)
+stores the budget on a **copy** of the options metadata, not on the caller's
+`providerRequestContext` object, so each turn attempt starts a fresh provider
+budget. Total worst-case transports for one turn become
+`INVALID_CONTENT_RETRY_OPTIONS.maxAttempts (2) × retries`. This is bounded and
+deterministic, and the second turn attempt legitimately needs its own transport
+budget because it is a new request. No change; documented in the specification so
+reviewers do not read it as unbounded.
+
+### F5 — NEW: the CLI already commits part of an in-flight attempt to static history
+
+`packages/cli/src/ui/hooks/agentStream/contentEventProcessor.ts:166-243`:
+when `getSplitPoint() !== stableText.length` — i.e. as soon as the streamed text
+contains a markdown-safe `\n\n` outside a code fence — `applySplitResult`
+(line 86) calls `deps.addItem(...)`, committing the stable prefix to the CLI's
+**static** history list, and `pendingResponse.consume(splitPoint)` drops it from
+the retractable buffer.
+
+Consequence: resetting the agent message buffer, the `PendingResponseBuffer`, the
+pending history item and the thinking state — the rollback set named in issue
+#3048 item 3 — is **not sufficient** for acceptance criterion 3. Any multi-
+paragraph partial response leaves committed static blocks that the retry then
+duplicates.
+
+`UseHistoryManagerReturn` has no removal API (B5), so closing this gap requires
+one. **Decision: in scope** (see `REQ-3048-009`); rejected alternatives are
+recorded in `specification.md` §7.
+
+### F6 — The CLI dispatcher cannot reach the discard surface directly
+
+`AgentEventDeps` (agentEventDispatcher.ts:43) has `addItem`,
+`flushPendingHistoryItem`, `pendingHistoryItemRef`, `thinkingBlocksRef`,
+`setPendingHistoryItem`, `setThought` … but **not** `pendingResponse`. The
+existing pattern for this is a named handler produced by
+`useStreamEventHandlers` and spread into the dispatcher deps
+(`useSubmitQuery.ts:296-316` spreads `...latestHandlers.current`). The discard
+must follow that pattern (`handleStreamAttemptDiscarded`) rather than widening
+`AgentEventDeps` with raw state.
+
+### F7 — Three existing agents assertions encode the pre-#3048 contract and must be rewritten
+
+`packages/agents/src/core/chatSession.issue2150.test.ts` currently asserts
+`attempt === 1` (no restart) for:
+
+1. `'does not retry a connection error after visible content was emitted'`
+2. `'does not retry a connection error after a tool call was emitted'`
+3. `'does not retry after hidden thinking metadata was emitted'`
+
+and asserts zero AI history entries in
+`'does not commit a failed response after visible content was emitted'`.
+
+These are not bugs being enshrined — they were the deliberate contract before
+#3048. Issue #3048 replaces that contract, so the assertions are rewritten to the
+new expected behaviour (restart occurs; exactly one AI entry from the successful
+attempt). The file's *other* assertions — non-transient mid-stream error,
+`AbortError`, `ABORT_ERR`, aborted-signal, `InvalidStreamError` after a chunk,
+`EmptyStreamError` after a chunk — stay **exactly as they are** and become the
+regression fence for AC4/AC5/AC6.
+
+### F8 — Post-output retry is narrowed to transport failures only
+
+`shouldRetryStreamAttempt` currently returns `true` for `InvalidStreamError` /
+`EmptyStreamError` regardless of transient-ness. If `!hasYieldedChunk` were simply
+deleted, those two would also restart after partial output, changing two more
+existing tests and widening the contract beyond the issue ("transient transport
+failure"). **Decision: after output, only `isNetworkTransientError` qualifies.**
+Content-validity verdicts on output that is being discarded are not a transport
+condition and stay out of scope. Before output, behaviour is bit-for-bit
+unchanged.
+
+### F9 — Zed/ACP cannot retract already-sent chunks
+
+`zed-agent-event-handler.ts` streams `agent_message_chunk` updates through
+`StreamBatcher`, and ACP `SessionUpdate` has no retraction primitive. Partial
+mitigation (dropping only the not-yet-flushed batch) would be timing-dependent
+and therefore non-deterministic. **Decision: out of scope, documented limitation
+plus a follow-up issue** (see specification §8). The interactive CLI (AC3) and
+the non-interactive JSON result are fixed in this issue.
+
+### F10 — Per-chunk AfterModel hooks cannot be un-fired
+
+`StreamProcessor._processAfterModelHook` fires the AfterModel hook per streamed
+chunk. Hooks are user-authored side-effecting processes; there is no
+compensating "attempt abandoned" event in `packages/core/src/hooks/types.ts`.
+**Decision: no change.** This matches today's contract for any stream that fails
+mid-way (the hooks already fired and the turn ended in error). Documented in the
+audit table with a follow-up suggestion, not implemented.
+
+## F. Blocking issues
+
+None. Every dependency, type and call path required by `plan.md` exists on this
+branch. The two constraints that alter the implementation shape (F3 file-size
+budget, F5 CLI static commits) are folded into the phase instructions.
+
+## Verification gate
+
+- [x] All dependencies verified (no new third-party dependency is introduced)
+- [x] All types match the plan's assumptions, or the mismatch is recorded (B5, B6)
+- [x] All call paths are possible
+- [x] Test infrastructure exists and requires no registration step
+- [x] Lint/size budgets measured; the one tight budget has a concrete remedy (F3)

--- a/project-plans/issue3048/analysis/pseudocode/001-turn-retry-policy.md
+++ b/project-plans/issue3048/analysis/pseudocode/001-turn-retry-policy.md
@@ -1,0 +1,115 @@
+# Pseudocode 001 — Turn retry policy (`turnAbortHelpers.ts`)
+
+Plan ID: `PLAN-20260806-ISSUE3048`
+Target file: `packages/agents/src/core/turnAbortHelpers.ts`
+Requirements: REQ-3048-002, REQ-3048-003, REQ-3048-004
+Referenced by: plan phase **P04**
+
+---
+
+## Interface contracts
+
+```ts
+// INPUTS
+interface StreamAttemptContext {
+  readonly hasYieldedOutput: boolean; // attempt already emitted model output
+}
+shouldRetryStreamAttempt(
+  error: unknown,
+  params: SendMessageParams,
+  attempt: number,
+  context: StreamAttemptContext,
+): boolean
+
+applyRetryTemperature(
+  params: SendMessageParams,
+  attempt: number,
+): SendMessageParams
+
+// OUTPUTS
+//  shouldRetryStreamAttempt -> true iff the turn may be restarted
+//  applyRetryTemperature    -> params (attempt 0) or params with bumped temperature
+
+// DEPENDENCIES (all already imported by this module or trivially importable)
+//  INVALID_CONTENT_RETRY_OPTIONS  @vybestack/llxprt-code-core/core/chatSessionTypes.js
+//  InvalidStreamError, EmptyStreamError            (same module)
+//  isNetworkTransientError        @vybestack/llxprt-code-core/utils/retry.js
+//  isTerminalRetryError, isAbortError              (local, unchanged)
+```
+
+## Integration points (line by line)
+
+```
+Line 20: READ INVALID_CONTENT_RETRY_OPTIONS.maxAttempts
+         - the ONLY retry bound; do not introduce a second budget constant
+Line 24: CALL isTerminalRetryError(error)
+         - agents-local predicate (`isRetryable === false`); catches the
+           provider's RetriesExhaustedError aggregate
+Line 30: CALL isAbortError(error, params)
+         - must be evaluated on BOTH branches; never short-circuited away
+Line 33: CALL isNetworkTransientError(error)
+         - the centralized classifier; do NOT re-implement phrase matching here
+```
+
+## Anti-pattern warnings
+
+```
+DO NOT: delete the post-output distinction and let InvalidStreamError /
+        EmptyStreamError restart after output — see spec AD-3 / preflight F8.
+DO NOT: add a second retry-budget constant. maxAttempts is the bound.
+DO NOT: swallow the error or return a "best effort" default. Fail fast.
+DO NOT: reorder so isAbortError is skipped when hasYieldedOutput is false —
+        the pre-output branch must stay bit-for-bit identical to today.
+```
+
+---
+
+## Numbered pseudocode
+
+```
+010: FUNCTION shouldRetryStreamAttempt(error, params, attempt, context)
+011:   SET withinBudget = attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts - 1
+012:   IF NOT withinBudget
+013:     RETURN false                     // bounded budget (REQ-3048-003)
+014:   IF isTerminalRetryError(error)
+015:     RETURN false                     // provider already declared it terminal
+016:   IF context.hasYieldedOutput
+017:     // Discard-and-restart: the whole attempt is abandoned, so a verdict
+018:     // about the CONTENT we are discarding is not a reason to restart.
+019:     // Only a transport condition qualifies (REQ-3048-002 / AD-3).
+020:     RETURN isNetworkTransientError(error) AND NOT isAbortError(error, params)
+021:   // Pre-output path: unchanged from before issue #3048.
+022:   IF error IS InvalidStreamError OR error IS EmptyStreamError
+023:     RETURN true
+024:   RETURN isNetworkTransientError(error) AND NOT isAbortError(error, params)
+025: END FUNCTION
+
+030: FUNCTION applyRetryTemperature(params, attempt)
+031:   // Relocated verbatim from TurnProcessor._applyRetryTemperature so that
+032:   // TurnProcessor.ts stays under max-lines (preflight F3). Behaviour is
+033:   // byte-for-byte identical; only the home module changes.
+034:   IF attempt EQUALS 0
+035:     RETURN params
+036:   SET baselineTemperature = MAX(params.config?.temperature ?? 1, 1)
+037:   SET newTemperature = MIN(MAX(baselineTemperature + attempt * 0.1, 0), 2)
+038:   RETURN { ...params, config: { ...params.config, temperature: newTemperature } }
+039: END FUNCTION
+```
+
+## Behaviour table (the tests in P03 enumerate exactly these rows)
+
+| `hasYieldedOutput` | error | `attempt` | aborted? | result |
+|---|---|---|---|---|
+| false | `InvalidStreamError` | 0 | no | `true` (unchanged) |
+| false | `EmptyStreamError` | 0 | no | `true` (unchanged) |
+| false | `Connection error.` | 0 | no | `true` (unchanged) |
+| false | `status: 400` | 0 | no | `false` (unchanged) |
+| **true** | `Connection error.` | 0 | no | **`true` (new)** |
+| **true** | `Connection error.` | 1 | no | `false` (budget) |
+| **true** | `status: 400` | 0 | no | `false` |
+| **true** | `InvalidStreamError` | 0 | no | `false` (AD-3) |
+| **true** | `EmptyStreamError` | 0 | no | `false` (AD-3) |
+| true | `name: 'AbortError'` | 0 | — | `false` |
+| true | `code: 'ABORT_ERR'` | 0 | — | `false` |
+| true | `terminated` | 0 | **yes** | `false` |
+| true | `isRetryable: false` aggregate | 0 | no | `false` |

--- a/project-plans/issue3048/analysis/pseudocode/002-turn-processor-attempt-loop.md
+++ b/project-plans/issue3048/analysis/pseudocode/002-turn-processor-attempt-loop.md
@@ -1,0 +1,135 @@
+# Pseudocode 002 — TurnProcessor attempt loop
+
+Plan ID: `PLAN-20260806-ISSUE3048`
+Target file: `packages/agents/src/core/TurnProcessor.ts`
+Requirements: REQ-3048-002, REQ-3048-003, REQ-3048-004, REQ-3048-005
+Referenced by: plan phase **P04**
+
+---
+
+## Interface contracts
+
+```ts
+// INPUTS (unchanged)
+_runStreamAttempt(
+  params: SendMessageParams,
+  prompt_id: string,
+  userContents: IContent[],
+  attempt: number,
+): AsyncGenerator<StreamEvent, { error: unknown; action: 'retry' | 'stop' }>
+
+// OUTPUTS (unchanged shape)
+//  yields StreamEvent (RETRY | CHUNK | AGENT_EXECUTION_*)
+//  returns { error, action }
+
+// DEPENDENCIES
+//  streamProcessor.makeApiCallAndProcessStream  -> REAL, injected via constructor
+//  shouldRetryStreamAttempt / applyRetryTemperature -> turnAbortHelpers.js
+```
+
+## Integration points (line by line)
+
+```
+Line 112: CALL streamProcessor.makeApiCallAndProcessStream(...)
+          - MUST be called once per attempt. This is what makes the restart a
+            fresh StreamOutputAccumulator + fresh history-recording closure
+            (spec AD-1 / AD-7). Never hoist it out of the attempt.
+Line 130: CALL shouldRetryStreamAttempt(error, params, attempt,
+                                        { hasYieldedOutput: hasYieldedChunk })
+          - `hasYieldedChunk` is computed from the SAME block predicate as today
+            (non-empty text | thinking | tool_call). Do not widen it to include
+            metadata-only chunks: usage metadata is not user-visible output.
+Line 105: yield { type: StreamEventType.RETRY }
+          - unchanged position: start of every attempt after the first, i.e.
+            AFTER the backoff delay and BEFORE the new provider call, so every
+            consumer receives the discard signal before any replacement chunk.
+```
+
+## Anti-pattern warnings
+
+```
+DO NOT: add any net lines to TurnProcessor.ts without removing at least as many.
+        The file measures 797 effective lines against max-lines: 800
+        (preflight F3/D). The relocation at lines 150-153 is mandatory, not
+        optional, and must land in the SAME commit as the call-site change.
+DO NOT: introduce a `try/finally` that records history for a failed attempt.
+DO NOT: reset the accumulator, add StreamOutputAccumulator.reset, or otherwise
+        try to "clean" the abandoned attempt — it is dropped with the generator.
+DO NOT: leave a duplicated copy of _applyRetryTemperature behind.
+```
+
+---
+
+## Numbered pseudocode
+
+```
+100: METHOD _runStreamAttempt(params, prompt_id, userContents, attempt)
+101:   // ---- unchanged prologue -------------------------------------------
+102:   IF attempt > 0
+103:     // Discard signal for every downstream consumer. Emitted before the new
+104:     // provider call so no replacement chunk can precede it.
+105:     YIELD { type: StreamEventType.RETRY }
+106:   SET hasYieldedChunk = false
+107:   TRY
+108:     // applyRetryTemperature now comes from turnAbortHelpers (line 150)
+109:     SET currentParams = applyRetryTemperature(params, attempt)
+110:     // Fresh attempt boundary: new provider stream, new accumulator, new
+111:     // history closure. This is the whole basis of discard-and-restart.
+112:     SET stream = AWAIT streamProcessor.makeApiCallAndProcessStream(
+113:                    currentParams, prompt_id, userContents)
+114:     FOR AWAIT chunk IN stream
+115:       SET hasYieldedChunk = hasYieldedChunk OR chunk HAS a block that is
+116:           (text with length > 0) OR thinking OR tool_call
+117:       YIELD wrapChunk(chunk)
+118:     RETURN { error: null, action: 'stop' }
+119:   CATCH error
+120:     // ---- unchanged hook-control branches ----------------------------
+121:     IF error IS AgentExecutionStoppedError
+122:       YIELD AGENT_EXECUTION_STOPPED event
+123:       RETURN { error: null, action: 'stop' }
+124:     IF error IS AgentExecutionBlockedError
+125:       YIELD AGENT_EXECUTION_BLOCKED event
+126:       IF error.blockedOutput EXISTS
+127:         YIELD CHUNK event with error.blockedOutput
+128:       RETURN { error: null, action: 'stop' }
+129:     // ---- CHANGED: the post-output case is no longer excluded ---------
+130:     IF shouldRetryStreamAttempt(error, params, attempt,
+131:                                 { hasYieldedOutput: hasYieldedChunk })
+132:       RETURN { error, action: 'retry' }
+133:     RETURN { error, action: 'stop' }
+134: END METHOD
+
+140: // _createStreamGenerator is UNCHANGED. Recorded here because the restart
+141: // semantics depend on it and a reviewer must be able to check them.
+142: METHOD _createStreamGenerator(params, prompt_id, userContents, onDone)
+143:   LOOP WHILE retrying AND attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts
+144:     SET outcome = YIELD* _runStreamAttempt(params, prompt_id, userContents, attempt)
+145:     IF outcome.action IS NOT 'retry' THEN stop looping
+146:     ELSE AWAIT delay(initialDelayMs * (attempt + 1), params.config?.abortSignal)
+147:          // delay() rejects on abort -> an abort during backoff wins and
+148:          // propagates as an AbortError (REQ-3048-004)
+149:          INCREMENT attempt
+150: END METHOD
+
+150: // ---- Relocation (mandatory, preflight F3) --------------------------
+151: DELETE private method _applyRetryTemperature from TurnProcessor.ts
+152: ADD    exported function applyRetryTemperature to turnAbortHelpers.ts
+153:        (body copied verbatim; see pseudocode 001 lines 030-039)
+154: IMPORT applyRetryTemperature alongside shouldRetryStreamAttempt
+155: REPLACE the single call site (was `this._applyRetryTemperature(params, attempt)`)
+156:        with `applyRetryTemperature(params, attempt)`
+```
+
+## Verification of the size budget after the edit
+
+```
+Before: TurnProcessor.ts = 797 effective lines
+  - remove _applyRetryTemperature body + signature  ≈ -12
+  + widen the shouldRetryStreamAttempt call         ≈ +1
+  + import binding                                  ≈  0 (same import statement)
+After:  ≈ 786 effective lines  (14 lines of headroom)
+```
+
+The implementer MUST confirm with
+`npx eslint packages/agents/src/core/TurnProcessor.ts` (exit 0) rather than
+trusting this estimate.

--- a/project-plans/issue3048/analysis/pseudocode/003-agentic-loop-and-a2a-discard.md
+++ b/project-plans/issue3048/analysis/pseudocode/003-agentic-loop-and-a2a-discard.md
@@ -1,0 +1,128 @@
+# Pseudocode 003 — Abandoned tool-call discard (AgenticLoop + a2a executor)
+
+Plan ID: `PLAN-20260806-ISSUE3048`
+Target files:
+- `packages/agents/src/core/agenticLoop/AgenticLoop.ts`
+- `packages/a2a-server/src/agent/executor.ts`
+
+Requirement: REQ-3048-006
+Referenced by: plan phase **P06**
+
+---
+
+## Interface contracts
+
+```ts
+// INPUTS (both consumers)
+//   AsyncIterable<ServerAgentStreamEvent> from agentClient.sendMessageStream /
+//   task.acceptUserMessage
+// OUTPUTS
+//   AgenticLoop:   AsyncGenerator<AgenticLoopEvent, StreamCollectionResult>
+//   a2a executor:  side effect — task.scheduleToolCalls(requests, signal)
+// DEPENDENCIES (never stubbed in production)
+//   ToolSchedulerContract via config.getOrCreateScheduler (AgenticLoop)
+//   task.scheduleToolCalls (a2a)
+```
+
+## Integration points (line by line)
+
+```
+Line 210: YIELD { kind: 'stream', event }
+          - the Retry event MUST still be forwarded to consumers BEFORE the
+            local discard, because the CLI/ACP consumers use it as their own
+            discard signal (spec §4 ordering guarantee).
+Line 213: toolCallRequests.length = 0
+          - in-place truncation, because the array is owned by the caller
+            (runTurn passes it in by reference). Reassignment would silently
+            leave the caller holding the abandoned list.
+Line 215: CONTINUE
+          - Retry must NOT set shouldScheduleTools = false. The turn is still
+            alive; the replacement attempt schedules its own tools.
+```
+
+## Anti-pattern warnings
+
+```
+DO NOT: add Retry to isTerminalStreamOutcome. That would set
+        shouldScheduleTools = false and end the turn — the exact bug #3048
+        is fixing, just relocated.
+DO NOT: reassign `toolCallRequests = []` (the caller keeps the old reference).
+DO NOT: skip the a2a executor. AC4 is a system property; a2a is a second,
+        independent scheduler over the same event stream.
+DO NOT: reclassify AgentEventType.Retry in a2a task-support.ts — it stays an
+        informational log-only event there; only the executor's collection
+        changes.
+```
+
+---
+
+## Numbered pseudocode — AgenticLoop.streamAndCollect
+
+```
+200: METHOD streamAndCollect(message, signal, promptId, toolCallRequests)
+201:   SET stream = agentClient.sendMessageStream(message, signal, promptId)
+202:   SET shouldScheduleTools = true
+203:   FOR AWAIT event IN stream
+204:     YIELD { kind: 'stream', event }          // forward FIRST, always
+205:     IF event.type IS AgentEventType.ToolCallRequest
+206:       APPEND event.value TO toolCallRequests
+207:       CONTINUE
+208:     // ---- NEW (REQ-3048-006) ----------------------------------------
+209:     IF event.type IS AgentEventType.Retry
+210:       // The attempt that produced these requests was abandoned. Drop them
+211:       // in place; the replacement attempt emits its own ToolCallRequests.
+212:       // The turn is NOT terminal, so shouldScheduleTools stays true.
+213:       SET toolCallRequests.length = 0
+214:       CONTINUE
+215:     // ---- unchanged terminal handling -------------------------------
+216:     IF isTerminalStreamOutcome(event.type)
+217:       SET toolCallRequests.length = 0
+218:       SET shouldScheduleTools = false
+219:   RETURN { shouldScheduleTools }
+220: END METHOD
+```
+
+Downstream (unchanged, recorded so the reviewer can trace the consequence):
+
+```
+230: METHOD runTurn(...)
+231:   SET toolCallRequests = []
+232:   SET streamResult = YIELD* streamAndCollect(..., toolCallRequests)
+233:   IF signal.aborted OR NOT streamResult.shouldScheduleTools
+234:     RETURN { continueLoop: false, ... }
+235:   IF toolCallRequests IS EMPTY
+236:     RETURN { continueLoop: false, allowSteerContinuation: true }
+237:   // => a turn whose ONLY tool calls were abandoned reaches line 236 and
+238:   //    finishes normally; the scheduler is never constructed (AC4).
+239:   SET dedupedRequests = deduplicateToolCallRequests(toolCallRequests)
+240:   ... schedule ...
+```
+
+---
+
+## Numbered pseudocode — a2a executor `#processAgentTurnLoop`
+
+```
+300: WHILE agentTurnActive
+301:   SET toolCallRequests = []
+302:   FOR AWAIT event IN agentEvents
+303:     IF abortSignal.aborted THEN THROW Error('Execution aborted')
+304:     IF event.type IS AgentEventType.ToolCallRequest
+305:       APPEND event.value TO toolCallRequests
+306:       CONTINUE
+307:     // ---- NEW (REQ-3048-006) ----------------------------------------
+308:     IF event.type IS AgentEventType.Retry
+309:       SET toolCallRequests.length = 0
+310:       // fall through so task.acceptAgentMessage still logs the Retry via
+311:       // the existing informational classification in task-support.ts
+312:     AWAIT task.acceptAgentMessage(event)
+313:   IF toolCallRequests IS NOT EMPTY
+314:     AWAIT task.scheduleToolCalls(toolCallRequests, abortSignal)
+315:   ... unchanged ...
+```
+
+Note on line 310-312: unlike `AgenticLoop`, the a2a loop forwards non-tool
+events *after* the classification block, so the Retry branch clears and then
+falls through to `acceptAgentMessage`. Keeping the existing logging path intact
+is deliberate — `task-support.ts` already classifies `AgentEventType.Retry` as
+`LOG_INFO_TYPES`, and that classification is not part of this change.

--- a/project-plans/issue3048/analysis/pseudocode/004-message-stream-orchestrator-discard.md
+++ b/project-plans/issue3048/analysis/pseudocode/004-message-stream-orchestrator-discard.md
@@ -1,0 +1,113 @@
+# Pseudocode 004 — MessageStreamOrchestrator per-attempt discard
+
+Plan ID: `PLAN-20260806-ISSUE3048`
+Target file: `packages/agents/src/core/MessageStreamOrchestrator.ts`
+Requirement: REQ-3048-007
+Referenced by: plan phase **P08**
+
+---
+
+## Interface contracts
+
+```ts
+// INPUTS
+//   ServerAgentStreamEvent stream from turn.run(iterRequest, signal)
+//   StreamContext ctx (mutable: ctx.responseChunks)
+//   hadToolCallsPrior: boolean  — carried in from earlier loop iterations
+// OUTPUTS
+//   IterationResult { earlyReturn, hadToolCallsThisTurn, hadThinking,
+//                     hadContent, deferredEvents, outcome }
+// DEPENDENCIES (real, never stubbed)
+//   loopDetector.addAndCheck, todoContinuationService, agentHookManager
+```
+
+## Integration points (line by line)
+
+```
+Line 415: ctx.responseChunks.length = 0
+          - ctx is shared with MessageStreamTerminalHandler.fireAfterHook and
+            MessageStreamOrchestrator._fireAfterHook, both of which read
+            ctx.responseChunks.join(''). Truncate in place; do not reassign.
+Line 417: hadToolCallsThisTurn = hadToolCallsPrior
+          - reset to the value carried IN, not to false: tool calls from an
+            EARLIER loop iteration are not part of the abandoned attempt.
+Line 419: deferredEvents.length = 0
+          - shouldDeferStreamEvent defers Finished and Citation; an abandoned
+            attempt can have deferred a Citation.
+```
+
+## Anti-pattern warnings
+
+```
+DO NOT: reset finishedOutcome — an abandoned attempt throws before Finished, so
+        a non-undefined value there would indicate a different bug and must not
+        be masked.
+DO NOT: call loopDetector.reset(promptId) — it also resets turn tracking
+        (turnsInCurrentPrompt), which would defeat maxTurnsPerPrompt. See
+        spec §6 row 16 for why content tracking is deliberately left alone.
+DO NOT: let this method exceed max-lines-per-function: 80. It measures 68
+        effective lines today; the discard block is extracted to a module-level
+        helper so the growth is +1 call line, not +6 inline lines.
+```
+
+---
+
+## Numbered pseudocode
+
+```
+400: // NEW module-level helper (keeps _processStreamIteration under 80 lines)
+401: FUNCTION discardAbandonedAttempt(ctx, state, hadToolCallsPrior, deferredEvents)
+402:   // Every per-attempt accumulator owned by this loop. See spec §6 rows
+403:   // 10, 11, 12 for the audit that produced exactly this set.
+404:   SET ctx.responseChunks.length = 0
+405:   SET state.hadThinking = false
+406:   SET state.hadContent = false
+407:   SET state.hadToolCallsThisTurn = hadToolCallsPrior
+408:   SET deferredEvents.length = 0
+409: END FUNCTION
+
+410: METHOD _processStreamIteration(iterRequest, signal, turn, ctx,
+411:                                hadToolCallsPrior, initialRequest)
+412:   ... unchanged prologue (loopDetector.turnStarted, early return) ...
+413:   SET state = { hadThinking: false, hadContent: false,
+414:                 hadToolCallsThisTurn: hadToolCallsPrior }
+415:   SET deferredEvents = []
+416:   SET finishedOutcome = undefined
+417:   FOR AWAIT event IN turn.run(iterRequest, signal)
+418:     IF loopDetector.addAndCheck(event) THEN ... unchanged early return ...
+419:     CALL todoContinuationService.recordModelActivity(event)
+420:     // ---- NEW (REQ-3048-007) ----------------------------------------
+421:     IF event.type IS AgentEventType.Retry
+422:       CALL discardAbandonedAttempt(ctx, state, hadToolCallsPrior, deferredEvents)
+423:       YIELD event                       // consumers still need the signal
+424:       CALL updateTelemetryTokenCount()
+425:       CONTINUE
+426:     // ---- unchanged classification ----------------------------------
+427:     IF event.type IS ToolCallRequest THEN state.hadToolCallsThisTurn = true
+428:     IF event.type IS Thought         THEN state.hadThinking = true
+429:     IF event.type IS Content         THEN state.hadContent = true
+430:     IF event.type IS Finished AND event.value.outcome
+431:       SET finishedOutcome = event.value.outcome
+432:     CALL _handleTodoToolCall(event, todoContinuationService)
+433:     IF event.type IS Content AND event.value
+434:       APPEND event.value TO ctx.responseChunks
+435:     IF todoContinuationService.shouldDeferStreamEvent(event)
+436:       APPEND event TO deferredEvents
+437:     ELSE
+438:       YIELD event
+439:     CALL updateTelemetryTokenCount()
+440:     SET terminalResult = YIELD* handleTerminalEvent(deps, event, signal, ctx,
+441:            deferredEvents, state, initialRequest)
+442:     IF terminalResult THEN RETURN terminalResult
+443:   RETURN { earlyReturn: false, ...state, deferredEvents, outcome: finishedOutcome }
+444: END METHOD
+```
+
+## Refactor note (mechanical, behaviour-preserving)
+
+Lines 413 and 427-429 replace three separate `let` locals (`hadThinking`,
+`hadContent`, `hadToolCallsThisTurn`) with one mutable `state` record so the
+discard helper can reset them by reference. This is the minimum restructuring
+needed; the values, their initial state and every read site keep identical
+semantics, and lines 440-443 pass `state` where they previously passed an object
+literal built from the same three values.

--- a/project-plans/issue3048/analysis/pseudocode/005-cli-interactive-discard.md
+++ b/project-plans/issue3048/analysis/pseudocode/005-cli-interactive-discard.md
@@ -1,0 +1,209 @@
+# Pseudocode 005 — Interactive CLI discard handler
+
+Plan ID: `PLAN-20260806-ISSUE3048`
+Target files:
+- `packages/cli/src/ui/hooks/agentStream/committedSegmentLedger.ts` (NEW)
+- `packages/cli/src/ui/hooks/agentStream/contentEventProcessor.ts`
+- `packages/cli/src/ui/hooks/agentStream/useStreamState.ts`
+- `packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts`
+- `packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts`
+- `packages/cli/src/ui/hooks/agentStream/agentEventDispatcher.ts`
+- `packages/cli/src/ui/hooks/useHistoryManager.ts`
+- plumbing: `useAgentStream.ts`, `useAgentStreamOrchestration.ts`,
+  `useAppInput.ts`, `useAppBootstrap.ts`, `AppContainerRuntime.tsx`
+
+Requirements: REQ-3048-008, REQ-3048-009
+Referenced by: plan phases **P10** (pending state) and **P12** (retraction)
+
+---
+
+## Interface contracts
+
+```ts
+// NEW value object — mirrors PendingResponseBuffer's ownership model
+class CommittedSegmentLedger {
+  begin(): void;                 // new assistant message starts
+  record(id: number): void;      // a stable prefix was committed to history
+  drain(): readonly number[];    // take + clear (used by the discard)
+  get ids(): readonly number[];  // read-only view for assertions
+}
+
+// CHANGED — history manager gains retraction
+interface UseHistoryManagerReturn {
+  removeItems: (ids: readonly number[]) => void;
+}
+
+// CHANGED — ContentEventDeps gains the ledger (required, not optional)
+interface ContentEventDeps {
+  committedSegments: CommittedSegmentLedger;
+}
+
+// NEW — the handler the dispatcher calls
+handleStreamAttemptDiscarded(): void
+
+// CHANGED — dispatcher deps
+interface AgentEventDeps {
+  handleStreamAttemptDiscarded: () => void;
+}
+```
+
+## Integration points (line by line)
+
+```
+Line 520: deps.committedSegments.begin()
+          - called from ensureAiPendingItem, i.e. exactly when a NEW assistant
+            message's pending item is created. That is the message lifecycle
+            boundary; it guarantees the ledger never holds ids belonging to a
+            previous assistant message or a previous turn.
+Line 545: deps.committedSegments.record(id)
+          - addItem's return value; today it is discarded at
+            contentEventProcessor.ts:99 (inside applySplitResult, which starts
+            at line 86).
+Line 610: deps.removeItems(deps.committedSegments.drain())
+          - retraction is drain-then-remove so a second retry cannot re-remove
+            ids that were already retracted.
+Line 604: DO NOT call flushPendingHistoryItem
+          - flushing commits the abandoned text. The whole point is to drop it.
+Line 606: only drop 'gemini' / 'gemini_content' pending items
+          - a 'tool_group' pending item belongs to the scheduler, not to the
+            model attempt (spec §6 row 21/24).
+```
+
+## Anti-pattern warnings
+
+```
+DO NOT: make removeItems or committedSegments optional with a no-op default.
+        A missing wire must fail typecheck, not silently skip the discard
+        (spec AD-8).
+DO NOT: widen AgentEventDeps with raw pendingResponse / removeItems. The
+        established pattern is a named handler from useStreamEventHandlers
+        spread into the deps (useSubmitQuery.ts:296-316); follow it.
+DO NOT: clear turnCancelledRef, loopDetectedRef, the submission queue,
+        setIsResponding, or the tool-call display. A retry is not a terminal
+        event; the turn is still running.
+DO NOT: call clearItems(). It wipes the whole transcript and starts a new
+        ConversationContext.
+```
+
+---
+
+## Numbered pseudocode
+
+### 500 — CommittedSegmentLedger (new file)
+
+```
+500: CLASS CommittedSegmentLedger
+501:   PRIVATE recorded = []
+502:   METHOD begin()
+503:     SET recorded = []          // new assistant message; drop stale ids
+504:   METHOD record(id)
+505:     APPEND id TO recorded
+506:   METHOD drain()
+507:     SET taken = recorded
+508:     SET recorded = []
+509:     RETURN taken
+510:   GETTER ids
+511:     RETURN recorded (read-only)
+512: END CLASS
+```
+
+### 520 — contentEventProcessor: record what was committed
+
+```
+520: FUNCTION ensureAiPendingItem(..., committedSegments, ...)
+521:   IF pendingHistoryItemRef.current IS NOT 'gemini' AND NOT 'gemini_content'
+522:     IF pendingHistoryItemRef.current EXISTS
+523:       CALL flushPendingHistoryItem(userMessageTimestamp)
+524:     CALL committedSegments.begin()     // NEW: a new assistant message starts
+525:     CALL setPendingHistoryItem({ type: 'gemini', text: '', ... })
+526: END FUNCTION
+
+540: FUNCTION applySplitResult(beforeText, pendingType, ..., committedSegments, ...)
+541:   IF beforeText IS NON-EMPTY
+542:     SET id = addItem({ type: pendingType, text: beforeText, ... },
+543:                      userMessageTimestamp)
+544:     // NEW: remember the id so a discard can retract exactly this segment
+545:     CALL committedSegments.record(id)
+546:     SET thinkingBlocksRef.current = []
+547:   CALL setPendingHistoryItem(afterItem)
+548:   RETURN afterItem.text
+549: END FUNCTION
+```
+
+### 560 — useHistoryManager: retraction
+
+```
+560: FUNCTION removeHistoryItems(previous, ids, limits)
+561:   IF ids IS EMPTY THEN RETURN previous
+562:   SET removal = new Set(ids)
+563:   SET entries = previous.entries FILTERED WHERE entry.item.id NOT IN removal
+564:   IF entries.length EQUALS previous.entries.length THEN RETURN previous
+565:   SET totalBytes = SUM of entry.bytes OVER entries
+566:   RETURN trimHistoryState({ entries, totalBytes }, limits)
+567: END FUNCTION
+
+570: IN useHistory():
+571:   SET removeItems = useCallback((ids) =>
+572:         setState(previous => removeHistoryItems(previous, ids, limits)),
+573:       [limits])
+574:   ADD removeItems TO the returned object AND to its useMemo dependency list
+575:   ADD removeItems TO UseHistoryManagerReturn
+```
+
+### 600 — the discard handler (useStreamEventHandlers)
+
+```
+600: FUNCTION useStreamAttemptDiscardedHandler(deps)
+601:   RETURN useCallback(() => {
+602:     // 1. Pending, uncommitted assistant render state (REQ-3048-008)
+603:     SET pending = deps.pendingHistoryItemRef.current
+604:     // NOTE: deliberately NOT flushPendingHistoryItem — that would commit it
+605:     IF pending EXISTS AND (pending.type IS 'gemini' OR 'gemini_content')
+606:       CALL deps.setPendingHistoryItem(null)
+607:     CALL deps.pendingResponse.reset()
+608:     // 2. Stable prefixes this attempt already committed (REQ-3048-009)
+609:     SET retracted = deps.committedSegments.drain()
+610:     IF retracted IS NON-EMPTY THEN CALL deps.removeItems(retracted)
+611:     // 3. Thinking state produced by the abandoned attempt
+612:     SET deps.thinkingBlocksRef.current = []
+613:     CALL deps.setThought(null)
+614:   }, [ ...stable deps... ])
+615: END FUNCTION
+```
+
+### 630 — dispatcher wiring
+
+```
+630: IN dispatchAgentEvent(event, deps, agentMessageBuffer, userMessageTimestamp)
+631:   CASE 'retry':
+632:     CALL deps.handleStreamAttemptDiscarded()
+633:     // The agent message buffer is the dispatcher's own accumulator; the
+634:     // discard is expressed by returning the empty string (REQ-3048-008).
+635:     RETURN { agentMessageBuffer: '' }
+636:   // 'tool-call' | 'tool-result' | 'tool-confirmation' | 'tool-status' |
+637:   // 'invalid-stream' | 'notice' keep the existing no-op group; 'retry' is
+638:   // removed from it.
+```
+
+### 650 — plumbing (mechanical, typecheck-enforced)
+
+```
+650: useHistory()                    -> add removeItems to the return
+651: useAppBootstrap                 -> destructure + return removeItems
+652: AppContainerRuntime.buildInputParams -> removeItems: b.removeItems
+653: AppInputParams                  -> removeItems: AppBootstrapResult['removeItems']
+654: useAgentStream(...)             -> new required parameter `removeItems`
+655:                                    inserted immediately after `addItem`
+656: AgentStreamOrchestrationDeps    -> removeItems
+657: useStreamState(addItem, runtime)-> also construct and expose
+658:                                    committedSegments (same useMemo lifetime
+659:                                    as pendingResponse)
+660: useSubmitQuery deps             -> removeItems + committedSegments
+661: StreamEventHandlerDeps          -> removeItems + committedSegments
+662: useProcessAgentEvent handlers Pick -> add 'handleStreamAttemptDiscarded'
+663: useAgentStream.subagent.spec.tsx  -> 4 call sites gain the new argument.
+664:   This is a MECHANICAL argument update at existing call sites forced by the
+665:   signature change: no assertion, no framework and no semantics change, and
+666:   the file continues to run under Bun via the vitest shim preload. No new
+667:   Vitest suite is created.
+```

--- a/project-plans/issue3048/analysis/pseudocode/006-cli-noninteractive-discard.md
+++ b/project-plans/issue3048/analysis/pseudocode/006-cli-noninteractive-discard.md
@@ -1,0 +1,82 @@
+# Pseudocode 006 — Non-interactive CLI discard
+
+Plan ID: `PLAN-20260806-ISSUE3048`
+Target file: `packages/cli/src/nonInteractiveCliSupport.ts`
+Requirement: REQ-3048-010
+Referenced by: plan phase **P14**
+
+---
+
+## Interface contracts
+
+```ts
+// INPUTS
+//   AgentEvent stream (public API), StreamState, StreamConsumerContext
+interface StreamState {
+  thoughtBuffer: ThoughtBuffer;
+  responseText: string;      // accumulated ONLY in --output-format json mode
+  quietTextBuffer: string;   // accumulated ONLY in --quiet mode
+  pendingDone: Extract<AgentEvent, { type: 'done' }> | null;
+}
+// OUTPUTS
+//   finalizeStream emits exactly one of responseText / quietTextBuffer
+// DEPENDENCIES
+//   context.emojiFilter (real EmojiFilter; holds a partial stream chunk)
+//   context.streamFormatter (real StreamJsonFormatter or null)
+```
+
+## Integration points (line by line)
+
+```
+Line 706: context.emojiFilter?.flushBuffer()
+          - flushBuffer() DRAINS the filter's held-back partial chunk and
+            returns it. The return value is deliberately discarded here: that
+            fragment belongs to the abandoned attempt. Without this, the
+            fragment reappears via flushEmojiBuffer() at finalizeStream.
+Line 700: quiet mode is handled by handleQuietEvent FIRST
+          - handleQuietEvent returns false for 'retry' today, so the event
+            falls through to dispatchAgentEvent. Reset both buffers in the one
+            'retry' case rather than adding a second branch in handleQuietEvent.
+```
+
+## Anti-pattern warnings
+
+```
+DO NOT: attempt to un-write plain stdout or already-emitted stream-json deltas.
+        They are gone; the limitation is documented in spec §8. Emitting a
+        compensating "ignore the previous text" event is a protocol change and
+        is out of scope.
+DO NOT: reset state.pendingDone — a retry cannot follow a done for the same
+        turn, and clearing it would mask an ordering bug.
+DO NOT: swallow a throw from flushBuffer(). Fail fast.
+```
+
+---
+
+## Numbered pseudocode
+
+```
+700: FUNCTION dispatchAgentEvent(event, state, context, writeProfileName,
+701:                             includeThinking)
+702:   IF context.quiet AND handleQuietEvent(event, state) THEN RETURN
+703:   SWITCH event.type
+704:     ... unchanged cases ...
+705:     CASE 'retry':                       // NEW (REQ-3048-010)
+706:       CALL context.emojiFilter?.flushBuffer()   // drain and DISCARD
+707:       SET state.responseText = ''
+708:       SET state.quietTextBuffer = ''
+709:       SET state.thoughtBuffer = []
+710:       RETURN
+711:     ... unchanged default ...
+712: END FUNCTION
+```
+
+## Observable consequences
+
+| Mode | Before | After |
+|------|--------|-------|
+| `--output-format json` | result text = `'abandoned' + 'kept'` | result text = `'kept'` |
+| `--quiet` | emitted text = `'abandonedkept'` | emitted text = `'kept'` |
+| plain stdout | `abandoned` already printed, then `kept` | unchanged (documented limitation) |
+| `--output-format stream-json` | both deltas already emitted | unchanged (documented limitation) |
+| thinking output | abandoned thoughts flushed with the answer | abandoned thoughts dropped |

--- a/project-plans/issue3048/plan.md
+++ b/project-plans/issue3048/plan.md
@@ -1,0 +1,1183 @@
+# Plan: Safe retry after partial model output (discard-and-restart)
+
+Plan ID: `PLAN-20260806-ISSUE3048`
+Generated: 2026-08-06
+Issue: #3048 (follow-up to #3034 / PR #3047; related: #3049, #3094)
+Branch: `issue3048`
+Total phases: 16 — `P01, P02, P03, P04, P05, P06, P07, P08, P09, P10, P11, P12, P13, P14, P15, P16`
+Requirements: `REQ-3048-001` … `REQ-3048-011`
+Specification: [`specification.md`](./specification.md)
+Preflight: [`analysis/preflight.md`](./analysis/preflight.md)
+Pseudocode: [`analysis/pseudocode/`](./analysis/pseudocode/)
+
+---
+
+## 0. Critical reminders
+
+1. **Execute phases in strict numerical order.** `P01 → P02 → … → P16`. Never
+   skip, never batch (`dev-docs/COORDINATING.md`).
+2. **RED before GREEN, always.** Every odd-numbered implementation phase is
+   preceded by a phase that adds failing behavioural tests. A GREEN phase that
+   also writes tests is a plan violation.
+3. **A RED phase must be *observed* red.** Run the new tests and paste the
+   failure output into the completion marker. A "RED" phase whose tests pass on
+   unmodified source is either a fence test (explicitly labelled as such in
+   P03/P05) or a bug in the test.
+4. **Do not modify tests during a GREEN phase.** If a test looks wrong, stop and
+   return to the preceding RED phase.
+5. **Bun only.** New and changed tests use `bun:test` — directly in `cli`,
+   `providers` and `a2a-server`; through `packages/agents/src/testApi.js` in
+   `agents`. Do not create or convert Vitest/Node suites. The one permitted
+   touch of a Vitest-importing file is the mechanical argument threading in P12
+   (pseudocode 005 lines 663-667).
+6. **No suppression, ever.** No `eslint-disable`, no `@ts-expect-error`, no
+   threshold/exclusion edits. `TurnProcessor.ts` has 3 effective lines of
+   `max-lines` headroom — P04 fixes that by relocation (preflight F3).
+7. **No mock theater.** Fake the transport / `fetch` / React host state only.
+   Assert on emitted events, history contents, scheduler input and rendered
+   items — never on "was this mock called".
+8. **No stub phases.** Every change here modifies established, already-integrated
+   code; there is nothing to stub. Tests fail with real assertion mismatches, not
+   with `NotYetImplemented`.
+
+---
+
+## 1. Execution tracker
+
+| Phase | ID | Kind | Status | Semantic verified? | Summary |
+|-------|----|------|--------|--------------------|---------|
+| 01 | P01 | gate | [ ] | n/a | Preflight re-verification |
+| 02 | P02 | RED | [ ] | [ ] | Integrated agents contract (content→failure→success) |
+| 03 | P03 | RED + fence | [ ] | [ ] | Provider boundary fence; turn policy unit; rewrite obsolete assertions |
+| 04 | P04 | GREEN | [ ] | [ ] | `turnAbortHelpers` + `TurnProcessor` |
+| 05 | P05 | RED | [ ] | [ ] | Abandoned tool calls (AgenticLoop, a2a) |
+| 06 | P06 | GREEN | [ ] | [ ] | `AgenticLoop.streamAndCollect` + a2a executor |
+| 07 | P07 | RED | [ ] | [ ] | Message-stream per-attempt accumulators |
+| 08 | P08 | GREEN | [ ] | [ ] | `MessageStreamOrchestrator` |
+| 09 | P09 | RED | [ ] | [ ] | CLI pending-render discard + ledger unit |
+| 10 | P10 | GREEN | [ ] | [ ] | Ledger, `contentEventProcessor`, discard handler, dispatcher |
+| 11 | P11 | RED | [ ] | [ ] | CLI static-segment retraction |
+| 12 | P12 | GREEN | [ ] | [ ] | `removeItems` + plumbing + retraction |
+| 13 | P13 | RED | [ ] | [ ] | Non-interactive discard |
+| 14 | P14 | GREEN | [ ] | [ ] | `nonInteractiveCliSupport` |
+| 15 | P15 | gate | [ ] | [ ] | Full verification cycle + semantic gates |
+| 16 | P16 | docs | [ ] | n/a | Docs + follow-up issues |
+
+Update this table after every phase.
+
+---
+
+## 2. Complete test inventory
+
+New files (all Bun):
+
+| File | Workspace | Phase | Requirements |
+|------|-----------|-------|--------------|
+| `packages/agents/src/core/chatSession.issue3048.discardRestart.test.ts` | agents | P02 | 002, 003, 004, 005, 011 |
+| `packages/providers/src/__tests__/RetryOrchestrator.partialOutputBoundary.bun.ts` | providers | P03 | 001 |
+| `packages/agents/src/core/turnRetryPolicy.discardRestart.test.ts` | agents | P03 | 002, 003, 004 |
+| `packages/agents/src/core/agenticLoop/__tests__/agenticLoop.retryDiscard.test.ts` | agents | P05 | 006 |
+| `packages/a2a-server/src/agent/executor.retryDiscard.bun.ts` | a2a-server | P05 | 006 |
+| `packages/agents/src/core/messageStreamOrchestrator.retryDiscard.test.ts` | agents | P07 | 007 |
+| `packages/cli/src/ui/hooks/agentStream/__tests__/committedSegmentLedger.test.ts` | cli | P09 | 009 |
+| `packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx` | cli | P09, P11 | 008, 009 |
+| `packages/cli/src/ui/hooks/__tests__/useHistoryManager.removeItems.test.ts` | cli | P11 | 009 |
+| `packages/cli/src/nonInteractiveCliSupport.retryDiscard.bun.ts` | cli | P13 | 010 |
+
+Placement follows each workspace's existing convention, verified on this branch:
+`packages/a2a-server/src/agent/` holds its suites beside the source
+(`task-support.test.ts`), `packages/cli/src/` holds the non-interactive suites
+beside `nonInteractiveCliSupport.ts` (`nonInteractiveCli.quiet.test.ts`), and
+`packages/cli/src/ui/hooks/__tests__/` is the hooks suite directory. Test-utils
+imports: `packages/cli/src/test-utils/render.js` (`../../../test-utils/render.js`
+from `ui/hooks/__tests__/`, `../../../../test-utils/render.js` from
+`ui/hooks/agentStream/__tests__/`).
+
+Existing files whose assertions change (P03 only, with justification in
+preflight F7):
+
+| File | Change |
+|------|--------|
+| `packages/agents/src/core/chatSession.issue2150.test.ts` | Rewrite the three "does not retry after output" cases and the history-safety case to the post-#3048 contract. **Preserve unchanged**: non-transient mid-stream, `AbortError`, `ABORT_ERR`, aborted-signal, `InvalidStreamError`-after-chunk, `EmptyStreamError`-after-chunk, shared-transport-budget cases. |
+| `packages/agents/src/core/turnProcessorIdleTimeoutContract.test.ts` | Update the `shouldRetryStreamAttempt(error, params, 0)` call to the 4-argument signature with `{ hasYieldedOutput: false }`. Assertion unchanged. |
+
+Existing files touched mechanically (no assertion change):
+
+| File | Change | Phase |
+|------|--------|-------|
+| `packages/cli/src/ui/hooks/useAgentStream.subagent.spec.tsx` | 4 `useAgentStream(...)` call sites gain the `removeItems` argument | P12 |
+| `packages/cli/src/ui/hooks/agentStream/__tests__/submitQueryTestFixtures.ts` and any deps builder used by the existing agentStream suites | add `removeItems` / `committedSegments` to the fixture deps | P10, P12 |
+
+Nothing is registered anywhere: discovery is structural (preflight C1).
+
+---
+
+## 3. Phases
+
+---
+
+### Phase 01 — Preflight re-verification
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P01`
+**Kind:** gate (no source or test changes)
+
+#### Prerequisites
+- Branch `issue3048` checked out, `git status` clean.
+
+#### Tasks
+Re-run every check in `analysis/preflight.md` against the current working tree
+and record any drift.
+
+```bash
+# A5 — the single blocker
+grep -n "hasYieldedChunk" packages/agents/src/core/TurnProcessor.ts
+
+# A11/A12/A13 — consumers that ignore the discard signal
+grep -n "AgentEventType.Retry" packages/agents/src/core/agenticLoop/AgenticLoop.ts   # expect: no match
+grep -n "case 'retry'" packages/cli/src/ui/hooks/agentStream/agentEventDispatcher.ts
+grep -n "AgentEventType.ToolCallRequest" packages/a2a-server/src/agent/executor.ts
+
+# F3 — size budget
+npx eslint packages/agents/src/core/TurnProcessor.ts   # expect exit 0 today
+
+# F5 — the CLI already commits stable prefixes mid-attempt
+grep -n "addItem(" packages/cli/src/ui/hooks/agentStream/contentEventProcessor.ts
+
+# B5 — no removal API yet
+grep -n "removeItems\|clearItems" packages/cli/src/ui/hooks/useHistoryManager.ts
+
+# Baseline: the whole suite is green before we start
+npm run test
+```
+
+#### Success criteria
+- Every preflight row still holds, or the deviation is written into
+  `analysis/preflight.md` **and** the affected phase is updated before P02.
+- Baseline `npm run test` is green.
+
+#### Failure recovery
+Stop. Update the specification/plan first. Do not start P02 on a red baseline.
+
+#### Completion marker
+`project-plans/issue3048/.completed/P01.md` — paste the command outputs.
+
+---
+
+### Phase 02 — RED: integrated agents contract (vertical slice first)
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P02`
+**Kind:** RED
+
+#### Prerequisites
+- P01 complete.
+
+#### Requirements implemented (expanded)
+
+**REQ-3048-002 — Transient transport failure after output restarts the turn.**
+GIVEN a provider that yields `text:'partial'` then throws `Error('Connection error.')`
+on attempt 1 and yields `text:'recovered response'` on attempt 2; WHEN the caller
+consumes `chat.sendMessageStream(...)`; THEN the provider is invoked exactly twice,
+the stream completes without throwing, and exactly one `StreamEventType.RETRY` is
+emitted strictly before any attempt-2 chunk.
+*Why it matters:* a dropped connection mid-answer currently kills the agentic loop.
+
+**REQ-3048-003 — Bounded; non-transient and exhausted still fail.**
+GIVEN the same provider failing on every attempt; THEN exactly two invocations and
+the stream rejects with `Connection error.`. GIVEN a `status: 400` failure after
+output; THEN exactly one invocation and the stream rejects with `Bad request`.
+*Why it matters:* an unbounded restart burns quota silently.
+
+**REQ-3048-004 — Abort wins.** As specified in `specification.md` §7.
+*Why it matters:* transient phrasing overlaps abort phrasing.
+
+**REQ-3048-005 — Durable history is the successful attempt alone.**
+GIVEN the restart scenario; WHEN `chat.waitForIdle()` resolves; THEN exactly one
+`speaker === 'ai'` entry whose text is `'recovered response'` and does not contain
+`'partial'`, and exactly one `speaker === 'human'` entry.
+*Why it matters:* a concatenated entry poisons every later request.
+
+**REQ-3048-011 — Audited no-change decisions are pinned** (eager tool-response ids).
+
+#### Files to create
+
+`packages/agents/src/core/chatSession.issue3048.discardRestart.test.ts`
+
+- Header: `Copyright 2026 Vybestack LLC`, `SPDX-License-Identifier: Apache-2.0`
+- Imports: `import { describe, it, expect, beforeEach, vi } from '../testApi.js';`
+- Harness: copy the *real-stack* setup from
+  `packages/agents/src/core/chatSession.issue2150.test.ts` — real `ChatSession`
+  → `TurnProcessor` → `StreamProcessor`, `TestRuntimeProviderManager`, real
+  `retry.ts` (never mocked). The only double is the provider's
+  `generateChatCompletion` async generator.
+- Every test carries:
+
+```ts
+/**
+ * @plan PLAN-20260806-ISSUE3048.P02
+ * @requirement REQ-3048-002
+ * @scenario Transient transport failure after partial output
+ * @given attempt 1 yields 'partial' then throws Error('Connection error.')
+ * @when the caller drains chat.sendMessageStream(...)
+ * @then the provider is invoked twice and the stream completes
+ * @and exactly one RETRY event precedes every attempt-2 chunk
+ */
+```
+
+Scenarios (each an `it`):
+
+1. **`restarts the turn after a transient transport failure that followed partial output`** — REQ-3048-002.
+   Assert `attempt === 2`; the collected `StreamEvent[]` contains exactly one
+   `StreamEventType.RETRY`; the index of that RETRY is lower than the index of
+   every CHUNK carrying `'recovered response'`; no CHUNK after the RETRY carries
+   `'partial'`.
+2. **`restarts after an abandoned tool_call block`** — REQ-3048-002. Attempt 1
+   yields a `tool_call` block then fails; attempt 2 yields text. Assert
+   `attempt === 2` and the stream completes.
+3. **`restarts after abandoned hidden thinking metadata`** — REQ-3048-002.
+4. **`records only the successful attempt in history`** — REQ-3048-005. Build the
+   session with an explicit `HistoryService`; after `waitForIdle()`, assert one
+   `ai` entry equal to `'recovered response'`, `expect(text).not.toContain('partial')`,
+   and one `human` entry.
+5. **`fails after the restart budget is spent`** — REQ-3048-003. Provider always
+   yields `'partial'` then throws. Assert `attempt === 2` and rejection with
+   `Connection error.`.
+6. **`does not restart a non-transient failure after output`** — REQ-3048-003.
+   `status: 400`; assert `attempt === 1` and rejection with `Bad request`.
+7. **`does not restart an InvalidStreamError raised after output`** — REQ-3048-003 /
+   AD-3. Assert `attempt === 1`.
+8. **`does not restart when the failure is an abort after output`** — REQ-3048-004.
+   Three sub-cases: `name:'AbortError'` + `code:'ABORT_ERR'`; `code:'ABORT_ERR'`
+   only; `Error('terminated')` with the request's own signal aborted mid-stream.
+   Each asserts `attempt === 1` **and** that no `StreamEventType.RETRY` was emitted.
+9. **`keeps eagerly recorded tool-response ids across a discard`** — REQ-3048-011.
+   Drive the real eager-recording path: call
+   `chat.recordCompletedToolCalls(model, [completedToolCall])`
+   (`packages/agents/src/core/chatSession.ts:657-698`, which persists the
+   `tool` turn and then calls `markToolResponsesRecorded` on both processors),
+   then run the restart scenario with that same `tool_response` as the next
+   turn's message. Assert the final history contains **exactly one**
+   `tool_response` block for that `callId`, not two. This pins specification §6
+   row 7: the eager ids must survive the discard, or the successful attempt
+   re-records a duplicate.
+
+#### Expected RED output
+Cases 1-5 and 9 fail. Typical first failure: `expect(attempt).toBe(2)` receives
+`1`, and case 1's stream rejects instead of completing. Cases 6-8 pass already —
+they are the fence for AC5/AC6 and must stay green through every later phase.
+
+#### Verification
+```bash
+cd packages/agents && bun test ./src/core/chatSession.issue3048.discardRestart.test.ts
+npm run lint && npm run typecheck
+```
+
+#### Semantic verification checklist
+- [ ] Would each failing test still fail if the production change were reverted?
+      (Re-run after P04 with the change stashed.)
+- [ ] Is the provider double limited to `generateChatCompletion`? No mocking of
+      `retry.ts`, `TurnProcessor`, or `StreamProcessor`.
+- [ ] Are all assertions on observable output (events, history, invocation count)?
+      No `toHaveBeenCalledWith` on internal collaborators.
+
+#### Failure recovery
+`git checkout -- packages/agents/src/core/chatSession.issue3048.discardRestart.test.ts`
+
+#### Completion marker
+`.completed/P02.md` — paste the red output and the pass/fail split.
+
+---
+
+### Phase 03 — RED + fence: provider boundary, turn policy, obsolete assertions
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P03`
+**Kind:** RED (turn policy) + fence (provider)
+
+#### Prerequisites
+- P02 complete; `grep -rn "PLAN-20260806-ISSUE3048.P02" packages/` finds the P02 file.
+
+#### Requirements implemented (expanded)
+
+**REQ-3048-001 — Provider boundary stays terminal after output.**
+GIVEN a provider stream that yields one `IContent` then throws a transient
+transport error; WHEN consumed through `RetryOrchestrator`; THEN the wrapped
+provider is invoked exactly once, the consumer sees that one `IContent` then a
+rejection, the rejected value is the *same object* the transport threw, and
+`isTerminalRetryError` is `true` in providers and `false` in agents.
+*Why it matters:* the anti-mixing rule is what makes the turn-level restart safe.
+
+**REQ-3048-002/003/004 at the policy level** — the full behaviour table in
+`analysis/pseudocode/001-turn-retry-policy.md`.
+
+#### Files to create
+
+**`packages/providers/src/__tests__/RetryOrchestrator.partialOutputBoundary.bun.ts`** (fence)
+- `import { describe, it, expect } from 'bun:test';`
+- Real `RetryOrchestrator` over a hand-written provider double whose
+  `generateChatCompletion` yields one `IContent` then throws.
+- Assertions:
+  - transport invocation count is exactly `1` even with `maxAttempts: 6`;
+  - the consumer collected exactly the one yielded `IContent`;
+  - `await expect(...).rejects.toBe(thrownError)` — object identity, proving no
+    wrapper was introduced;
+  - `expect('isRetryable' in thrownError).toBe(false)` — the agents-side
+    predicate must not see it as terminal;
+  - `expect(isTerminalRetryError(thrownError)).toBe(true)` using the **providers**
+    `retryErrorClassification.js` export.
+- Label in the file header: *fence test — passes on unmodified source; it exists
+  so a future "just let the orchestrator retry" edit fails loudly.*
+
+**`packages/agents/src/core/turnRetryPolicy.discardRestart.test.ts`** (RED)
+- `import { describe, it, expect } from '../testApi.js';`
+- Drives `shouldRetryStreamAttempt` directly with the 4-argument signature.
+- One `it` per row of the behaviour table in pseudocode 001 (13 rows). Use
+  `it.each` over an explicit table so a missing row is visible.
+- Additionally asserts `applyRetryTemperature` is exported from
+  `turnAbortHelpers.js` and returns `params` unchanged for `attempt === 0` and a
+  bumped temperature for `attempt === 1`.
+
+#### Files to modify (assertions only — justified by preflight F7)
+
+`packages/agents/src/core/chatSession.issue2150.test.ts`
+
+| Test | Before | After |
+|------|--------|-------|
+| `does not retry a connection error after visible content was emitted` | `attempt === 1`, rejects | rename to `restarts the turn after a connection error that followed visible content`; `attempt === 2`, stream completes with `'recovered response'` |
+| `does not retry a connection error after a tool call was emitted` | `attempt === 1` | rename to `restarts …after a tool call was emitted`; `attempt === 2` |
+| `does not retry after hidden thinking metadata was emitted` | `attempt === 1` | rename to `restarts …after hidden thinking metadata`; `attempt === 2` |
+| `does not commit a failed response after visible content was emitted` | zero `ai` entries after rejection | one `ai` entry equal to the successful attempt's text |
+
+Add to the file's header comment: *"Issue #3048 replaced the post-output
+no-retry contract with discard-and-restart. The abort, non-transient,
+InvalidStreamError and EmptyStreamError cases below are unchanged and are the
+regression fence for that boundary."*
+
+`packages/agents/src/core/turnProcessorIdleTimeoutContract.test.ts`
+- `shouldRetryStreamAttempt(error, params, 0)` →
+  `shouldRetryStreamAttempt(error, params, 0, { hasYieldedOutput: false })`.
+  The `.toBe(false)` assertion is unchanged.
+
+#### Expected output
+- Provider fence: **green immediately.**
+- `turnRetryPolicy.discardRestart.test.ts`: fails to compile / run — the 4th
+  argument does not exist and `applyRetryTemperature` is not exported. That is
+  the RED signal.
+- `chatSession.issue2150.test.ts`: the four rewritten cases fail.
+
+#### Verification
+```bash
+cd packages/providers && bun test ./src/__tests__/RetryOrchestrator.partialOutputBoundary.bun.ts
+cd packages/agents && bun test ./src/core/turnRetryPolicy.discardRestart.test.ts
+cd packages/agents && bun test ./src/core/chatSession.issue2150.test.ts
+```
+
+#### Semantic verification checklist
+- [ ] The provider fence asserts error **identity** (`rejects.toBe`), not just message.
+- [ ] The rewritten 2150 cases changed only the four listed tests; `git diff` shows
+      no edits to the abort / non-transient / Invalid / Empty cases.
+- [ ] The policy table has a row for every branch in pseudocode 001 lines 010-025.
+
+#### Failure recovery
+`git checkout -- packages/agents/src/core/chatSession.issue2150.test.ts` and re-apply.
+
+#### Completion marker
+`.completed/P03.md`.
+
+---
+
+### Phase 04 — GREEN: turn retry policy and TurnProcessor
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P04`
+**Kind:** GREEN
+**Pseudocode:** `analysis/pseudocode/001-turn-retry-policy.md` lines **010-039**;
+`analysis/pseudocode/002-turn-processor-attempt-loop.md` lines **100-156**
+
+#### Prerequisites
+- P03 complete; the P02 and P03 suites are red for the expected reasons.
+
+#### Files to modify
+
+**`packages/agents/src/core/turnAbortHelpers.ts`**
+- Add `export interface StreamAttemptContext { readonly hasYieldedOutput: boolean }`
+  (pseudocode 001, contracts block).
+- Extend `shouldRetryStreamAttempt` to the 4-argument signature and implement
+  pseudocode 001 **lines 010-025** exactly, in order:
+  - line 011-013 budget check first;
+  - line 014-015 `isTerminalRetryError` second;
+  - line 016-020 the post-output branch — `isNetworkTransientError && !isAbortError`;
+  - line 021-024 the pre-output branch, byte-for-byte the previous behaviour.
+- Add `export function applyRetryTemperature(...)` implementing pseudocode 001
+  **lines 030-039** (body moved verbatim from `TurnProcessor._applyRetryTemperature`).
+- Extend the file-header JSDoc with one sentence naming the post-output rule and
+  `@plan PLAN-20260806-ISSUE3048.P04`, `@requirement REQ-3048-002 REQ-3048-003 REQ-3048-004`.
+
+**`packages/agents/src/core/TurnProcessor.ts`**
+- Pseudocode 002 **lines 130-132**: replace the `!hasYieldedChunk && …` conjunct
+  with `shouldRetryStreamAttempt(error, params, attempt, { hasYieldedOutput: hasYieldedChunk })`.
+- Pseudocode 002 **lines 151-156** (mandatory, preflight F3): delete
+  `_applyRetryTemperature`, import `applyRetryTemperature` from
+  `turnAbortHelpers.js` alongside `shouldRetryStreamAttempt`, and update the single
+  call site at what is currently line 263.
+- Leave the `RETRY` emission position (line 258) unchanged — see specification §4.
+- Do **not** touch `_createStreamGenerator`, the accumulator, or history recording.
+
+#### Explicit code shape
+
+```ts
+// turnAbortHelpers.ts
+export function shouldRetryStreamAttempt(
+  error: unknown,
+  params: SendMessageParams,
+  attempt: number,
+  context: StreamAttemptContext,
+): boolean {
+  const withinBudget = attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts - 1;
+  if (!withinBudget || isTerminalRetryError(error)) return false;
+  if (context.hasYieldedOutput) {
+    return isNetworkTransientError(error) && !isAbortError(error, params);
+  }
+  if (error instanceof InvalidStreamError || error instanceof EmptyStreamError) {
+    return true;
+  }
+  return isNetworkTransientError(error) && !isAbortError(error, params);
+}
+```
+
+```ts
+// TurnProcessor._runStreamAttempt (catch tail)
+      if (
+        shouldRetryStreamAttempt(error, params, attempt, {
+          hasYieldedOutput: hasYieldedChunk,
+        })
+      ) {
+        return { error, action: 'retry' };
+      }
+      return { error, action: 'stop' };
+```
+
+#### Expected outcome
+Every P02 and P03 test passes, including the six that were already green.
+
+#### Verification
+```bash
+cd packages/agents && bun test ./src/core/turnRetryPolicy.discardRestart.test.ts
+cd packages/agents && bun test ./src/core/chatSession.issue3048.discardRestart.test.ts
+cd packages/agents && bun test ./src/core/chatSession.issue2150.test.ts
+cd packages/agents && bun test ./src/core/turnProcessorIdleTimeoutContract.test.ts
+cd packages/agents && bun test ./src/core/processorRetryBoundary.test.ts
+cd packages/providers && bun test ./src/__tests__/RetryOrchestrator.partialOutputBoundary.bun.ts
+
+# Size budget — the reason the relocation is mandatory
+npx eslint packages/agents/src/core/TurnProcessor.ts
+npx eslint packages/agents/src/core/turnAbortHelpers.ts
+npm run typecheck
+```
+
+#### Deferred-implementation detection (mandatory)
+```bash
+git diff --name-only | grep -E '^packages/(agents)/' | xargs grep -nE \
+  "(TODO|FIXME|HACK|STUB|XXX|TEMPORARY|WIP|in a real|for now|placeholder)" || echo OK
+git diff | grep -nE "eslint-disable|@ts-(expect-error|ignore|nocheck)" && exit 1 || echo OK
+grep -n "_applyRetryTemperature" packages/agents/src/core/TurnProcessor.ts || echo "relocation complete"
+```
+
+#### Semantic verification checklist
+- [ ] Read `shouldRetryStreamAttempt` and state, in your own words, why an abort
+      after output returns `false` on both mechanisms (`name`/`code`) *and* on the
+      aborted-signal mechanism.
+- [ ] Trace one full path: provider throws → `RetryOrchestrator` marks and rethrows
+      → `StreamProcessor` propagates without finalizing → `_runStreamAttempt` catch
+      → policy `true` → `delay` → `RETRY` yielded → new `makeApiCallAndProcessStream`.
+      Name the file and function at each hop.
+- [ ] Confirm `markErrorAfterStreamOutput` is untouched: `git diff packages/providers` is empty.
+- [ ] Confirm exactly one restart is possible: `INVALID_CONTENT_RETRY_OPTIONS.maxAttempts`
+      is still `2` and no new budget constant was added.
+- [ ] Would the P02 tests fail if this change were reverted? Verify by
+      `git stash` → run → `git stash pop`, and paste both outputs.
+
+#### Failure recovery
+`git checkout -- packages/agents/src/core/TurnProcessor.ts packages/agents/src/core/turnAbortHelpers.ts`
+
+#### Completion marker
+`.completed/P04.md` including the holistic assessment (what was implemented, how
+it satisfies each requirement, the traced data flow, what could go wrong, verdict).
+
+---
+
+### Phase 05 — RED: abandoned tool calls are never scheduled
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P05`
+**Kind:** RED
+
+#### Prerequisites
+- P04 complete and green.
+
+#### Requirements implemented (expanded)
+
+**REQ-3048-006 — Abandoned tool calls are never scheduled.**
+GIVEN a model stream emitting `ToolCallRequest('abandoned')`, `Retry`,
+`ToolCallRequest('kept')`, end; WHEN the loop runs one turn; THEN the scheduler
+receives exactly one request, `callId === 'kept'`. GIVEN the same stream without
+the second tool call; THEN the scheduler is never invoked and the loop terminates
+normally. Both properties hold for `AgenticLoop` **and** the a2a executor.
+*Why it matters:* scheduling a tool call from a discarded generation executes side
+effects the model never committed to.
+
+#### Files to create
+
+**`packages/agents/src/core/agenticLoop/__tests__/agenticLoop.retryDiscard.test.ts`**
+- `import { describe, it, expect } from '../../../testApi.js';`
+- Reuse `agenticLoop-test-helpers.ts` builders; the double is the
+  `agentClient.sendMessageStream` event source and a recording
+  `ToolSchedulerContract` obtained through `config.getOrCreateScheduler`.
+- Scenarios:
+  1. `schedules only the successful attempt's tool calls` — assert the recorded
+     `schedule()` argument array is exactly `[{ callId: 'kept', … }]`.
+  2. `never schedules when the only tool calls belonged to an abandoned attempt` —
+     assert `schedule()` was never reached (no scheduler was created) and the loop
+     returned without a `tools_complete` event.
+  3. `forwards the Retry event to consumers before discarding` — assert the
+     yielded `AgenticLoopEvent[]` contains `{ kind: 'stream', event: { type: Retry } }`
+     and that its index precedes the `kept` `ToolCallRequest` stream event.
+  4. `keeps the turn alive across a Retry` — assert `shouldScheduleTools` remained
+     true by observing that scenario 1 actually scheduled.
+  5. **Fence:** `still drops tool calls and stops on a terminal Error event` —
+     unchanged existing behaviour.
+
+**`packages/a2a-server/src/agent/executor.retryDiscard.bun.ts`**
+- `import { describe, it, expect, vi } from 'bun:test';` (matching
+  `packages/a2a-server/src/agent/task-support.test.ts`)
+- Drive `#processAgentTurnLoop` through its public entry with a fake agent-event
+  generator and a `Task` double that records `scheduleToolCalls` arguments.
+- Scenarios 1 and 2 above, plus: `still logs the Retry event through
+  acceptAgentMessage` (the informational classification is unchanged).
+
+#### Expected RED output
+Scenario 1 fails with two scheduled requests (`abandoned` + `kept`); scenario 2
+fails because the scheduler was invoked. Scenarios 3-5 pass.
+
+#### Verification
+```bash
+cd packages/agents && bun test ./src/core/agenticLoop/__tests__/agenticLoop.retryDiscard.test.ts
+cd packages/a2a-server && bun test ./src/agent/executor.retryDiscard.bun.ts
+```
+
+> Bun treats a bare argument as a *name filter* and only as a path when it is
+> explicitly relative, and a `.bun.ts` file contains neither `.test` nor `.spec`.
+> Always pass `./`-prefixed paths for `.bun.*` suites
+> (`packages/cli/run-bun-tests.ts` documents the same trap).
+
+#### Semantic verification checklist
+- [ ] Is the scheduler a *recording* double asserting on its **input**, not a mock
+      asserting it was called?
+- [ ] Does scenario 2 assert an observable outcome (no tools ran, loop ended) rather
+      than an internal flag?
+
+#### Completion marker
+`.completed/P05.md`.
+
+---
+
+### Phase 06 — GREEN: AgenticLoop and a2a executor
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P06`
+**Kind:** GREEN
+**Pseudocode:** `analysis/pseudocode/003-agentic-loop-and-a2a-discard.md`
+lines **200-220** (AgenticLoop) and **300-315** (a2a)
+
+#### Files to modify
+- `packages/agents/src/core/agenticLoop/AgenticLoop.ts` —
+  `streamAndCollect`, pseudocode lines **208-214**. Insert the `Retry` branch
+  **after** the `yield { kind: 'stream', event }` (line 204) and **before** the
+  `isTerminalStreamOutcome` check (line 216). Use in-place truncation
+  (`toolCallRequests.length = 0`) and `continue`. Do **not** touch
+  `isTerminalStreamOutcome`.
+- `packages/a2a-server/src/agent/executor.ts` — `#processAgentTurnLoop`,
+  pseudocode lines **307-312**. Clear then fall through to `acceptAgentMessage`.
+- Add `@plan PLAN-20260806-ISSUE3048.P06` / `@requirement REQ-3048-006` markers.
+
+#### Verification
+```bash
+cd packages/agents && bun test ./src/core/agenticLoop/
+cd packages/a2a-server && bun test ./src/agent/
+npm run lint && npm run typecheck
+```
+
+#### Semantic verification checklist
+- [ ] Confirm `isTerminalStreamOutcome` is unchanged (`git diff` shows no edit to it).
+- [ ] Confirm the discard uses `length = 0`, not reassignment — the array is owned
+      by `runTurn` (AgenticLoop.ts:435) and reassignment would leave the caller
+      holding the abandoned list. State this from the code, not from the plan.
+- [ ] Trace: `Retry` event → `streamAndCollect` branch → `runTurn` sees an empty
+      `toolCallRequests` → `continueLoop: false, allowSteerContinuation: true` when
+      the replacement attempt also had no tools.
+
+#### Completion marker
+`.completed/P06.md` with the holistic assessment.
+
+---
+
+### Phase 07 — RED: message-stream per-attempt accumulators
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P07`
+**Kind:** RED
+
+#### Requirements implemented (expanded)
+
+**REQ-3048-007 — Message-stream per-attempt accumulators are discarded.**
+GIVEN a stream emitting `Content('abandoned ')`, a deferred `Citation`, `Retry`,
+`Content('kept')`, `Finished`; WHEN the AfterAgent hook fires; THEN its
+`responseText` argument is exactly `'kept'` and the abandoned citation is not
+emitted. GIVEN `Content('abandoned')`, `Retry`, then only a `ToolCallRequest`;
+THEN the iteration result reports `hadContent === false`.
+*Why it matters:* `responseChunks` is what user-authored AfterAgent hooks see, and
+the flags gate post-turn recovery.
+
+#### Files to create
+
+**`packages/agents/src/core/messageStreamOrchestrator.retryDiscard.test.ts`**
+- `import { describe, it, expect, vi } from '../testApi.js';` (the path used by
+  every sibling suite in `packages/agents/src/core/`)
+- Real `MessageStreamOrchestrator` with a `Turn` double whose `run()` yields the
+  scripted `ServerAgentStreamEvent` sequence; a recording `agentHookManager` whose
+  `fireAfterAgentHookSafe` captures its `responseText` argument (recording the
+  **argument**, then returning a real-shaped output — not asserting the call).
+- Scenarios:
+  1. `passes only the successful attempt's text to the AfterAgent hook`
+  2. `drops deferred citations from the abandoned attempt`
+  3. `reports hadContent false when the only content belonged to the abandoned attempt`
+  4. `keeps hadToolCallsThisTurn from earlier loop iterations across a Retry`
+     (pass `hadToolCallsPrior: true`; assert it is still `true` after the discard)
+  5. `still yields the Retry event to consumers`
+  6. **Fence:** `does not reset finishedOutcome` — a `Finished` before the stream
+     ends still surfaces its outcome.
+
+#### Expected RED output
+Scenarios 1-4 fail (`responseText` is `'abandoned kept'`, the citation is emitted,
+`hadContent` is `true`, `hadToolCallsThisTurn` is `false` after the reset attempt).
+
+#### Verification
+```bash
+cd packages/agents && bun test ./src/core/messageStreamOrchestrator.retryDiscard.test.ts
+```
+
+#### Semantic verification checklist
+- [ ] The hook double **records** the argument and returns a realistic output; it
+      does not assert "was called".
+- [ ] Scenario 4 proves the reset target is `hadToolCallsPrior`, not `false`.
+
+#### Completion marker
+`.completed/P07.md`.
+
+---
+
+### Phase 08 — GREEN: MessageStreamOrchestrator
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P08`
+**Kind:** GREEN
+**Pseudocode:** `analysis/pseudocode/004-message-stream-orchestrator-discard.md`
+lines **400-444**
+
+#### Files to modify
+`packages/agents/src/core/MessageStreamOrchestrator.ts`
+- Add the module-level `discardAbandonedAttempt` helper (pseudocode lines 400-409).
+- Restructure the three per-iteration booleans into one mutable `state` record
+  (pseudocode lines 413, 427-429, 440-443) — mechanical, value-preserving.
+- Add the `Retry` branch (pseudocode lines 420-425): discard, yield the event,
+  update telemetry, `continue`.
+- Do **not** reset `finishedOutcome`; do **not** call `loopDetector.reset`.
+- Markers: `@plan PLAN-20260806-ISSUE3048.P08`, `@requirement REQ-3048-007`,
+  `@pseudocode 004 lines 400-444`.
+
+#### Verification
+```bash
+cd packages/agents && bun test ./src/core/messageStreamOrchestrator.retryDiscard.test.ts
+cd packages/agents && bun test ./src/core/MessageStreamOrchestrator.modelinfo.test.ts \
+                              ./src/core/MessageStreamOrchestrator.todoPause.test.ts
+npx eslint packages/agents/src/core/MessageStreamOrchestrator.ts   # max-lines-per-function: 80
+npm run typecheck
+```
+
+#### Semantic verification checklist
+- [ ] `_processStreamIteration` is still under 80 effective lines (eslint exit 0).
+- [ ] `ctx.responseChunks` is truncated in place — `ctx` is shared with
+      `MessageStreamTerminalHandler`; reassignment would silently leave the old array.
+- [ ] Every read site of the three flags was migrated to the `state` record and
+      none changed meaning.
+
+#### Completion marker
+`.completed/P08.md` with the holistic assessment.
+
+---
+
+### Phase 09 — RED: interactive CLI pending-render discard
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P09`
+**Kind:** RED
+
+#### Requirements implemented (expanded)
+
+**REQ-3048-008 — The interactive CLI discards the abandoned attempt's pending
+render state.** GIVEN an active turn that rendered `'abandoned partial'`; WHEN
+`processAgentEvent({type:'retry'}, ts, signal)` is routed; THEN the next
+`{type:'text', text:'kept'}` renders a pending item whose text is exactly `'kept'`,
+no history item containing `'abandoned partial'` was added,
+`pendingResponse.stableText` is `''`, `thinkingBlocksRef.current` is `[]` and the
+thought was cleared. GIVEN the pending item is a `tool_group`; THEN it is unchanged.
+*Why it matters:* otherwise the retry appends to the abandoned text and the user
+reads a spliced answer.
+
+#### Files to create
+
+**`packages/cli/src/ui/hooks/agentStream/__tests__/committedSegmentLedger.test.ts`**
+- `import { describe, it, expect } from 'bun:test';`
+- Pure unit tests of the new value object: `begin` clears, `record` appends,
+  `drain` returns and clears, `drain` twice returns empty the second time,
+  `begin` after `record` drops the previous message's ids.
+
+**`packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx`**
+- Model it on `useSubmitQuery.terminalError.bun.tsx`: real `useSubmitQuery`, real
+  `useStreamEventHandlers`, real `dispatchAgentEvent`, real
+  `PendingResponseBuffer`, real `CommittedSegmentLedger`; only `turnPreparation`
+  and `SessionContext` are stubbed. React host state (`addItem`,
+  `setPendingHistoryItem`, `pendingHistoryItemRef`) is captured by simple
+  recorders whose contents are asserted.
+- Scenarios (P09 subset — REQ-3048-008):
+  1. `renders only the successful attempt's text after a retry` — route
+     `text('abandoned partial')`, `retry`, `text('kept')`; assert the final pending
+     item text is exactly `'kept'`.
+  2. `does not commit the abandoned pending item to history` — assert no recorded
+     `addItem` payload contains `'abandoned partial'`.
+  3. `resets the pending response buffer` — assert `pendingResponse.stableText === ''`
+     and `pendingResponse.displayText === ''` immediately after the retry.
+  4. `clears thinking state` — route a `thinking` event before the retry; assert
+     `thinkingBlocksRef.current` is `[]` afterwards.
+  5. `leaves a pending tool_group item untouched` — set
+     `pendingHistoryItemRef.current` to a `tool_group`; assert it is unchanged and
+     `setPendingHistoryItem(null)` was not applied to it.
+  6. `does not clear the submission queue or release the turn` — assert queued
+     submissions and `setIsResponding` calls are unchanged across the retry
+     (a retry is not a terminal event).
+
+#### Expected RED output
+Scenarios 1-4 fail: the pending item reads `'abandoned partialkept'`,
+`stableText` still holds the abandoned text, thinking blocks persist. Scenario 5
+and 6 pass (fence).
+
+#### Verification
+```bash
+cd packages/cli && bun test ./src/ui/hooks/agentStream/__tests__/committedSegmentLedger.test.ts
+cd packages/cli && bun test ./src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx
+```
+
+#### Semantic verification checklist
+- [ ] Is the dispatcher real (`dispatchAgentEvent` not mocked)?
+- [ ] Is `PendingResponseBuffer` a real instance?
+- [ ] Do the assertions read rendered/recorded values, not handler invocation counts?
+
+#### Completion marker
+`.completed/P09.md`.
+
+---
+
+### Phase 10 — GREEN: CLI ledger, discard handler, dispatcher
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P10`
+**Kind:** GREEN
+**Pseudocode:** `analysis/pseudocode/005-cli-interactive-discard.md` lines
+**500-512** (ledger), **520-549** (recording), **600-615** (handler),
+**630-638** (dispatcher)
+
+#### Files to create
+`packages/cli/src/ui/hooks/agentStream/committedSegmentLedger.ts`
+- `Copyright 2026 Vybestack LLC`; implements pseudocode lines 500-512.
+
+#### Files to modify
+- `packages/cli/src/ui/hooks/agentStream/contentEventProcessor.ts` — add
+  `committedSegments: CommittedSegmentLedger` to `ContentEventDeps` (required);
+  call `begin()` in `ensureAiPendingItem` (pseudocode line 524) and `record(id)`
+  in `applySplitResult` (pseudocode line 545).
+- `packages/cli/src/ui/hooks/agentStream/useStreamState.ts` — construct the ledger
+  in the same `useMemo` lifetime as `pendingResponse` and expose it (pseudocode
+  lines 657-659).
+- `packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts` — add
+  `committedSegments` to `StreamEventHandlerDeps` and `ContentEventDeps` wiring;
+  add `handleStreamAttemptDiscarded` (pseudocode lines 600-615) **without** the
+  retraction step (line 609-610 lands in P12) and export it from
+  `StreamEventHandlersResult`.
+- `packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts` — add
+  `committedSegments` to `UseSubmitQueryDeps`; add
+  `'handleStreamAttemptDiscarded'` to the `Pick<…>` handler list in
+  `useProcessAgentEvent`.
+- `packages/cli/src/ui/hooks/agentStream/agentEventDispatcher.ts` — add
+  `handleStreamAttemptDiscarded` to `AgentEventDeps`; move `'retry'` out of the
+  no-op group into its own case (pseudocode lines 630-638).
+- `packages/cli/src/ui/hooks/agentStream/useAgentStreamOrchestration.ts` — pass
+  `st.committedSegments` through.
+- Existing agentStream test fixtures — add `committedSegments` to the deps
+  builders so the suites still compile.
+
+#### Verification
+```bash
+cd packages/cli && bun test ./src/ui/hooks/agentStream/
+npm run lint && npm run typecheck
+```
+
+#### Deferred-implementation detection
+```bash
+git diff packages/cli | grep -nE "eslint-disable|@ts-(expect-error|ignore)" && exit 1 || echo OK
+grep -n "committedSegments?" packages/cli/src/ui/hooks/agentStream/*.ts && \
+  echo "FAIL: optional dep — must be required (spec AD-8)" || echo OK
+```
+
+#### Semantic verification checklist
+- [ ] `handleStreamAttemptDiscarded` never calls `flushPendingHistoryItem`. Read
+      the code and explain why flushing would be wrong.
+- [ ] It only nulls `'gemini'` / `'gemini_content'` pending items.
+- [ ] `'retry'` no longer shares the no-op `case` group.
+- [ ] The dispatcher returns `{ agentMessageBuffer: '' }` for `'retry'`.
+- [ ] `begin()` fires exactly once per assistant message — trace
+      `ensureAiPendingItem`'s guard and state why a `gemini → gemini_content`
+      transition does not re-fire it.
+
+#### Completion marker
+`.completed/P10.md` with the holistic assessment.
+
+---
+
+### Phase 11 — RED: retraction of committed stable segments
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P11`
+**Kind:** RED
+
+#### Requirements implemented (expanded)
+
+**REQ-3048-009 — The interactive CLI retracts stable segments committed by the
+abandoned attempt.** GIVEN an active turn whose streamed text contained a
+markdown-safe paragraph break, so `contentEventProcessor` committed one or more
+`gemini`/`gemini_content` items; WHEN the retry event is routed; THEN those items
+are gone from `history` and everything added before this assistant message is
+untouched. GIVEN a *completed* assistant message followed by a new, discarded
+turn; THEN the completed message's items are untouched.
+*Why it matters:* preflight F5 — a single `\n\n` in the partial response is enough
+to make part of it unretractable today, which fails AC3.
+
+#### Files to create
+
+**`packages/cli/src/ui/hooks/__tests__/useHistoryManager.removeItems.test.ts`**
+- `import { describe, it, expect } from 'bun:test';` + the CLI `renderHook` helper.
+- Scenarios: removes exactly the given ids and preserves order; ignores unknown
+  ids without mutating state identity; recomputes the byte budget so a later
+  `addItem` is not trimmed against stale bytes; an empty id list is a no-op.
+
+#### Files to modify
+`packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx`
+— add REQ-3048-009 scenarios:
+7. `retracts stable segments committed by the abandoned attempt` — stream text
+   containing `"para one\n\npara two"` (forcing at least one `applySplitResult`
+   commit), then `retry`, then `'kept'`; assert the recorded history no longer
+   contains any item whose text includes `'para one'`.
+8. `leaves items from before the assistant message untouched` — add a `user` item
+   and a `tool_group` item first; assert both survive.
+9. `does not retract a previous, completed assistant message` — complete one
+   assistant message (route `done`), start a second turn, commit a segment, then
+   retry; assert the first message's items survive.
+10. `retracts nothing on a second retry` — assert `removeItems` is not asked to
+    remove already-retracted ids (drain semantics).
+
+#### Expected RED output
+Scenario 7-9 fail (`removeItems` does not exist / abandoned static items remain);
+the `useHistoryManager` suite fails to compile.
+
+#### Verification
+```bash
+cd packages/cli && bun test ./src/ui/hooks/__tests__/useHistoryManager.removeItems.test.ts
+cd packages/cli && bun test ./src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx
+```
+
+#### Completion marker
+`.completed/P11.md`.
+
+---
+
+### Phase 12 — GREEN: history retraction and plumbing
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P12`
+**Kind:** GREEN
+**Pseudocode:** `analysis/pseudocode/005-cli-interactive-discard.md` lines
+**560-575** (history manager), **608-610** (handler step), **650-667** (plumbing)
+
+#### Files to modify
+- `packages/cli/src/ui/hooks/useHistoryManager.ts` — `removeHistoryItems` +
+  `removeItems` (pseudocode lines 560-575); add `removeItems` to
+  `UseHistoryManagerReturn` and to the return `useMemo` dependency list.
+- `packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts` — add the
+  retraction step (pseudocode lines 608-610) to `handleStreamAttemptDiscarded`;
+  add `removeItems` to `StreamEventHandlerDeps`.
+- Plumbing (pseudocode lines 650-662), each a single required field/parameter:
+  `useAppBootstrap.ts` → `AppContainerRuntime.tsx` (`buildInputParams`) →
+  `useAppInput.ts` (`AppInputParams` + the `useAgentStream` call) →
+  `useAgentStream.ts` (new required parameter immediately after `addItem`) →
+  `useAgentStreamOrchestration.ts` (`AgentStreamOrchestrationDeps`) →
+  `useSubmitQuery.ts` (`UseSubmitQueryDeps`).
+- `packages/cli/src/ui/hooks/useAgentStream.subagent.spec.tsx` — 4 mechanical call
+  sites (pseudocode lines 663-667). **Argument threading only**; no assertion,
+  framework or semantics change.
+- Existing agentStream deps fixtures — add `removeItems`.
+
+#### Verification
+```bash
+cd packages/cli && bun test ./src/ui/hooks/
+npm run lint && npm run typecheck
+npm run lint:cli-test-discovery
+```
+
+#### Semantic verification checklist
+- [ ] `removeItems` is a **required** member everywhere — no `?`, no default no-op
+      (spec AD-8). Grep the diff for `removeItems?`.
+- [ ] `removeHistoryItems` returns the previous state object unchanged when nothing
+      matched, so React does not re-render needlessly.
+- [ ] `totalBytes` is recomputed from the surviving entries, not decremented
+      approximately.
+- [ ] The discard drains before removing, so a second retry cannot re-remove.
+- [ ] The 4 spec call sites changed by exactly one argument each — paste the diff.
+
+#### Completion marker
+`.completed/P12.md` with the holistic assessment, including a manual-run note for
+the AC3 scenario.
+
+---
+
+### Phase 13 — RED: non-interactive discard
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P13`
+**Kind:** RED
+
+#### Requirements implemented (expanded)
+
+**REQ-3048-010 — The non-interactive CLI discards abandoned buffered output.**
+GIVEN `--output-format json` and a stream emitting `text:'abandoned'`, `retry`,
+`text:'kept'`, `done`; THEN the emitted JSON result's response text is exactly
+`'kept'`. GIVEN `--quiet` and the same stream; THEN the emitted text is exactly
+`'kept'`.
+*Why it matters:* the JSON result is machine-consumed; a spliced answer is
+silently wrong.
+
+#### Files to create
+`packages/cli/src/nonInteractiveCliSupport.retryDiscard.bun.ts`
+- `import { describe, it, expect } from 'bun:test';`
+- Drive the real `processAgentStream` with a scripted `AgentEvent` async iterable
+  and a `StreamConsumerContext` whose emitters are recorders.
+- Scenarios:
+  1. `json mode emits only the successful attempt's text`
+  2. `quiet mode emits only the successful attempt's text`
+  3. `drops thoughts from the abandoned attempt`
+  4. `drops the emoji filter's held partial chunk from the abandoned attempt` —
+     supply a real `EmojiFilter` and a partial chunk that would otherwise be
+     flushed at finalize
+  5. **Fence:** `does not disturb pendingDone` — a `done` after the retry still
+     drives the final result
+
+#### Expected RED output
+Scenarios 1-4 fail with `'abandonedkept'` (or the partial fragment appended).
+
+#### Verification
+```bash
+cd packages/cli && bun test ./src/nonInteractiveCliSupport.retryDiscard.bun.ts
+```
+
+#### Completion marker
+`.completed/P13.md`.
+
+---
+
+### Phase 14 — GREEN: non-interactive dispatcher
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P14`
+**Kind:** GREEN
+**Pseudocode:** `analysis/pseudocode/006-cli-noninteractive-discard.md` lines
+**700-712**
+
+#### Files to modify
+`packages/cli/src/nonInteractiveCliSupport.ts` — add the `case 'retry':` branch
+(pseudocode lines 705-710): drain and discard `context.emojiFilter?.flushBuffer()`,
+reset `responseText`, `quietTextBuffer` and `thoughtBuffer`. Do not touch
+`pendingDone`. Marker: `@plan PLAN-20260806-ISSUE3048.P14`,
+`@requirement REQ-3048-010`.
+
+#### Verification
+```bash
+cd packages/cli && bun test ./src/nonInteractiveCliSupport.retryDiscard.bun.ts
+cd packages/cli && bun test ./src/nonInteractiveCli.test.ts ./src/nonInteractiveCli.quiet.test.ts
+npm run lint && npm run typecheck
+```
+
+#### Semantic verification checklist
+- [ ] `flushBuffer()`'s return value is deliberately discarded, with a comment
+      saying why (it belongs to the abandoned attempt).
+- [ ] The quiet path is reached: `handleQuietEvent` returns `false` for `'retry'`,
+      so the single case covers both modes. Verify by reading `handleQuietEvent`.
+- [ ] Already-written stdout is untouched — the documented limitation is not
+      papered over with a compensating write.
+
+#### Completion marker
+`.completed/P14.md` with the holistic assessment.
+
+---
+
+### Phase 15 — Full verification and semantic gates
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P15`
+**Kind:** gate
+
+#### Prerequisites
+- P01-P14 complete, every completion marker present.
+
+#### Repository verification cycle
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+#### Guard checks
+```bash
+npm run lint:eslint-guard        # no policy weakening
+npm run lint:copyright-year      # new files say 2026
+npm run lint:no-new-js           # no new .js
+npm run lint:doc-placement       # plans stay in project-plans/
+npm run lint:test-file-coverage  # every new test is discovered exactly once
+npm run lint:cli-test-discovery
+```
+
+#### Plan-integrity checks
+```bash
+# every phase left a trace
+for p in 04 06 08 10 12 14; do
+  echo -n "P$p: "; grep -rl "PLAN-20260806-ISSUE3048.P$p" packages/ | wc -l
+done
+
+# no suppression or deferred work was introduced
+git diff origin/main...HEAD | grep -nE "eslint-disable|@ts-(expect-error|ignore|nocheck)" && exit 1 || echo OK
+git diff origin/main...HEAD --name-only | grep -E '^packages/.*\.(ts|tsx)$' | grep -v -E '\.(test|spec|bun)\.' \
+  | xargs grep -nE "(TODO|FIXME|HACK|STUB|XXX|TEMPORARY|WIP|in a real|for now|placeholder)" || echo OK
+
+# the provider anti-mixing rule is intact
+grep -n "markErrorAfterStreamOutput" packages/providers/src/RetryOrchestrator.ts
+git diff origin/main...HEAD -- packages/providers/src/RetryOrchestrator.ts \
+  packages/providers/src/retryErrorClassification.ts   # expect: empty
+
+# no Vitest/Node test was added, and the only modified vitest-importing file is
+# the mechanical call-site update
+git diff origin/main...HEAD --name-only | grep -E '\.(test|spec|bun)\.(ts|tsx)$' \
+  | xargs grep -l "from 'vitest'" || echo "no vitest suites touched"
+```
+
+#### Acceptance-criteria walkthrough (semantic gate)
+
+For each row, run the named test and paste its output:
+
+| Issue AC | Test |
+|----------|------|
+| AC1 | `chatSession.issue3048.discardRestart.test.ts` → "restarts the turn after a transient transport failure that followed partial output" |
+| AC2 | same file → "records only the successful attempt in history" |
+| AC3 | `packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.retryDiscard.bun.tsx` → "renders only the successful attempt's text after a retry" + "retracts stable segments committed by the abandoned attempt"; `packages/cli/src/nonInteractiveCliSupport.retryDiscard.bun.ts` → json/quiet cases |
+| AC4 | `packages/agents/src/core/agenticLoop/__tests__/agenticLoop.retryDiscard.test.ts` + `packages/a2a-server/src/agent/executor.retryDiscard.bun.ts` |
+| AC5 | `turnRetryPolicy.discardRestart.test.ts` abort rows + the preserved abort cases in `chatSession.issue2150.test.ts` |
+| AC6 | `chatSession.issue3048.discardRestart.test.ts` → budget-exhaustion + 400 + InvalidStreamError cases |
+| AC7 | `RetryOrchestrator.partialOutputBoundary.bun.ts` (provider), the agents suites, the CLI suites |
+
+#### Holistic functionality assessment (mandatory, written out)
+Answer in `.completed/P15.md`:
+1. **What was implemented?** In your own words, from reading the code.
+2. **Does it satisfy each requirement?** Cite file:function for each of
+   REQ-3048-001 … REQ-3048-011.
+3. **What is the data flow?** Trace one complete discard-and-restart from the
+   transport error to the rendered replacement, naming every hop.
+4. **What could go wrong?** Edge cases and integration risks you observed.
+5. **Verdict** with justification.
+
+#### Mutation-resistance spot check
+Temporarily invert each of the following, confirm at least one test fails, then
+revert. Paste the failing test names.
+
+| Mutation | Expected failure |
+|----------|------------------|
+| `hasYieldedOutput` branch returns `false` unconditionally | P02 scenario 1 |
+| Post-output branch drops the `!isAbortError` conjunct | P03 abort rows, P02 scenario 8 |
+| `AgenticLoop` Retry branch removed | P05 scenario 1 |
+| `MessageStreamOrchestrator` `responseChunks` truncation removed | P07 scenario 1 |
+| CLI discard skips `pendingResponse.reset()` | P09 scenario 3 |
+| CLI discard skips the retraction | P11 scenario 7 |
+| Non-interactive `responseText` reset removed | P13 scenario 1 |
+
+#### Completion marker
+`.completed/P15.md`.
+
+---
+
+### Phase 16 — Documentation and follow-ups
+
+**Phase ID:** `PLAN-20260806-ISSUE3048.P16`
+**Kind:** docs
+
+#### Tasks
+1. Document the discard-and-restart contract where retry behaviour is already
+   described for users. Check first, then extend the file that actually covers it:
+   ```bash
+   grep -rln "retries\|retry" docs/ | head -20
+   ```
+   Add: one restart per turn after partial output, transport failures only,
+   abort wins, and the two documented limitations (ACP/Zed, already-written
+   stdout).
+2. File follow-up issues with `gh` (never web fetch), each referencing #3048:
+   - **ACP/Zed retraction:** already-sent `agent_message_chunk` updates cannot be
+     retracted; propose an ACP-level retraction or an explicit user-visible notice
+     (specification §8, preflight F9).
+   - **AfterModel per-chunk hooks on an abandoned attempt:** no compensating
+     event exists; propose an "attempt abandoned" hook event
+     (specification §6 row 8, preflight F10).
+   - **Retry temperature conflation:** `applyRetryTemperature` bumps temperature
+     for transport retries as well as content retries (specification §8).
+3. Do **not** modify unrelated project-plan files.
+
+#### Verification
+```bash
+npm run lint:doc-links
+npm run lint:doc-placement
+npm run format
+```
+
+#### Completion marker
+`.completed/P16.md` listing the created issue numbers.
+
+---
+
+## 4. Integration checklist (verify before P02 starts)
+
+- [x] Identified all touch points with the existing system (specification §5.1)
+- [x] Listed the exact code being replaced/corrected (specification §5.2)
+- [x] Identified how users reach the behaviour (specification §5.3)
+- [x] No migration needed, and that is justified (specification §5.4)
+- [x] Integration tests are written FIRST (P02, before every unit-level phase)
+- [x] The feature cannot be built in isolation — every phase modifies established,
+      already-wired code; **no new module is reachable only from tests** (the one
+      new file, `CommittedSegmentLedger`, is constructed in `useStreamState` and
+      consumed by `contentEventProcessor` and the discard handler in the same phase)
+
+## 5. Red flags that would invalidate this plan
+
+1. Any change to `markErrorAfterStreamOutput` or
+   `RetryOrchestrator.yieldStreamUnprotected` — the anti-mixing rule is the
+   foundation, not an obstacle (AD-1).
+2. Adding `StreamOutputAccumulator.reset()` — dead code (AD-7, preflight F1).
+3. A retry budget other than `INVALID_CONTENT_RETRY_OPTIONS` (AD-5).
+4. `AgentEventType.Retry` added to `isTerminalStreamOutcome` — that ends the turn.
+5. Any `eslint-disable`, TS suppression, or threshold/exclusion edit.
+6. An optional or defaulted discard dependency (AD-8).
+7. A test asserting `toHaveBeenCalled` on a collaborator instead of on output.
+8. A new Vitest/Node suite.
+9. A GREEN phase that adds or edits tests.
+10. A phase executed out of numerical order.

--- a/project-plans/issue3048/specification.md
+++ b/project-plans/issue3048/specification.md
@@ -1,0 +1,665 @@
+# Feature Specification: Safe retry after partial model output (discard-and-restart)
+
+Issue: [#3048](https://github.com/acoliver/llxprt-code/issues/3048)
+Plan ID: `PLAN-20260806-ISSUE3048`
+Generated: 2026-08-06
+Branch: `issue3048`
+Follow-up to: #3034 / PR #3047. Related transport behaviour: #3049, #3094.
+
+---
+
+## 1. Purpose
+
+A provider stream that fails **after** content has already crossed the boundary
+to the consumer is unrecoverable today: it ends the turn with an API error and
+stops the agentic loop. #3034 fixed the cases where the failure happens *before*
+any content crosses. This is the residual half.
+
+The fix is a **discard-and-restart contract**: when a transient transport failure
+kills an attempt that had already emitted output, every layer that accumulated
+state for that attempt throws it away, and the turn is restarted from a clean
+boundary under a bounded budget. Nothing from the abandoned attempt reaches
+durable history, the model's next request, the scheduler, or the rendered
+transcript.
+
+---
+
+## 2. Architectural decisions
+
+### AD-1 — The restart boundary is the turn attempt, not the provider iterator
+
+`RetryOrchestrator.yieldStreamUnprotected`
+(`packages/providers/src/RetryOrchestrator.ts`) marks any error raised after a
+chunk was yielded with `markErrorAfterStreamOutput` and refuses to retry inside
+the same iterator, because doing so would splice two generations into one
+`IContent` stream. **That behaviour is correct and stays.** Retrying inside one
+iterator is precisely the failure mode #3049 is removing from the HTTP/SSE path;
+re-introducing it here would contradict both.
+
+`TurnProcessor._runStreamAttempt` (`packages/agents/src/core/TurnProcessor.ts`)
+already has the property the restart needs: **each attempt calls
+`StreamProcessor.makeApiCallAndProcessStream` afresh**, which builds a new
+provider stream, a new `StreamOutputAccumulator`, and a new history-recording
+closure. It is the only place in the stack where "discard everything and start
+over" is expressible without splicing.
+
+> **Consequence:** the provider layer gets *fence tests*, not behaviour changes.
+> Weakening `markErrorAfterStreamOutput` is a plan-level violation.
+
+### AD-2 — The discard signal already exists end-to-end; only the consumers are missing
+
+`StreamEventType.RETRY` (`packages/core/src/core/chatSessionTypes.ts`) is
+documented as "The UI should discard any partial content from the attempt that
+just failed". It is emitted by `TurnProcessor._runStreamAttempt` at the start of
+every attempt after the first, mapped by `turn.ts` to `AgentEventType.Retry`
+(which already resets the cumulative response outcome), and mapped by
+`eventAdapter.ts` to the public `{ type: 'retry' }` event.
+
+**No new event type, no new protocol field.** The work is to make each consumer
+that accumulates per-attempt state honour the signal.
+
+### AD-3 — After output, only a *transport* condition may restart
+
+Before any output, the existing classification is unchanged: `InvalidStreamError`
+and `EmptyStreamError` (content-validity verdicts) plus transient network errors
+retry. After output, only `isNetworkTransientError` qualifies. A content-validity
+verdict about output that is being **discarded** is not a transport failure, and
+widening the post-output path to include it would exceed the issue's stated
+scope. See preflight F8.
+
+### AD-4 — Abort is checked before, and independently of, the retry classification
+
+`isAbortError` already covers three independent signals (`name === 'AbortError'`,
+`code === 'ABORT_ERR'`, and `params.config?.abortSignal?.aborted === true`) and is
+applied on the post-output path exactly as on the pre-output path. An abort is
+never reclassified as a retryable transport failure, at any layer.
+
+### AD-5 — The bound is the existing turn budget; nothing new is introduced
+
+`INVALID_CONTENT_RETRY_OPTIONS = { maxAttempts: 2, initialDelayMs: 500 }`
+(`packages/core/src/core/chatSessionTypes.ts`) gives `withinBudget = attempt < 1`:
+**exactly one restart per turn.** When that restart also fails, the error
+propagates unchanged to `AgentEventType.Error` and the loop stops, as today.
+
+Each restart legitimately obtains a fresh provider transport budget (a restart is
+a new request). Worst-case transports for one turn are therefore
+`2 × retries` — bounded, deterministic, and stated here so it is not mistaken for
+an unbounded spiral (preflight F4).
+
+### AD-6 — Discard is applied at every layer that accumulates per-attempt state
+
+The contract is only sound if *every* accumulator is enumerated and given an
+explicit decision. §6 is that enumeration. Silence is not an acceptable answer
+for any row.
+
+### AD-7 — `StreamOutputAccumulator` needs no `reset()`
+
+Every turn attempt constructs its own accumulator inside `processStreamResponse`,
+and `_finalizeStreamProcessing` — the sole history-recording site — runs only when
+the stream loop completes normally. A failed attempt's accumulator is simply
+dropped with the generator. Adding `reset()` would create a dead, untested state
+transition. Issue item 2 is obsolete; preflight F1 records the evidence.
+
+### AD-8 — Prefer fail-fast; no fallback layers
+
+No `try/catch`-and-continue around discard, no optional/defaulted discard
+callbacks, no "best effort" flags. A discard handler that cannot reach the state
+it must clear is a wiring bug that must fail the type checker, not degrade
+silently at run time.
+
+---
+
+## 3. Technical environment
+
+- **Type:** CLI tool + agent engine (monorepo, npm workspaces, Bun toolchain)
+- **Runtime:** Bun (tests, scripts, dev start), Node ≥ 20 for the published CLI
+- **Language:** TypeScript, strict mode
+- **Test framework:** `bun:test` only. Agents suites import the
+  `packages/agents/src/testApi.ts` facade; CLI/providers suites import
+  `bun:test` directly. Discovery is structural — no manifest entry is required
+  for a new test file (preflight C1).
+- **New third-party dependencies:** none.
+
+---
+
+## 4. Data and event flow
+
+```mermaid
+sequenceDiagram
+    participant P as Provider transport
+    participant RO as RetryOrchestrator
+    participant SP as StreamProcessor
+    participant TP as TurnProcessor
+    participant T as turn.ts
+    participant MSO as MessageStreamOrchestrator
+    participant AL as AgenticLoop
+    participant EA as eventAdapter
+    participant UI as CLI dispatcher
+
+    Note over TP: attempt 0
+    TP->>SP: makeApiCallAndProcessStream()
+    SP->>RO: generateChatCompletion()
+    RO->>P: transport attempt
+    P-->>RO: IContent (text)
+    RO-->>SP: IContent
+    SP-->>TP: ModelStreamChunk (accumulator #1)
+    TP-->>T: CHUNK
+    T-->>MSO: Content
+    MSO-->>AL: Content
+    AL-->>EA: Content
+    EA-->>UI: text  (rendered, partly committed)
+    P-->>RO: transient transport failure
+    RO->>RO: markErrorAfterStreamOutput -> terminal in THIS iterator
+    RO-->>SP: throw (raw error, unwrapped)
+    SP-->>TP: throw (accumulator #1 dropped, no history write)
+    TP->>TP: shouldRetryStreamAttempt(..., hasYieldedOutput: true) -> true
+    TP->>TP: await delay(500ms), attempt := 1
+
+    Note over TP: attempt 1
+    TP-->>T: RETRY
+    T->>T: cumulative outcome := empty
+    T-->>MSO: Retry
+    MSO->>MSO: drop responseChunks / flags / deferred events
+    MSO-->>AL: Retry
+    AL->>AL: drop collected toolCallRequests
+    AL-->>EA: Retry
+    EA-->>UI: retry
+    UI->>UI: DISCARD: buffer, PendingResponseBuffer, pending item,<br/>thinking state, committed stable segments
+    TP->>SP: makeApiCallAndProcessStream()  (accumulator #2)
+    P-->>RO: full successful generation
+    SP->>SP: _finalizeStreamProcessing -> ONE user + ONE ai history entry
+```
+
+**Ordering guarantee that AC3 depends on:** `RETRY` is yielded by
+`_runStreamAttempt` *before* the new provider call is made
+(`TurnProcessor.ts:256-266`), so every consumer receives the discard signal
+strictly before the first chunk of the replacement attempt. Consumers must not
+assume the reverse.
+
+**Deliberate non-change:** `RETRY` is emitted *after* the backoff delay, not at
+the moment the retry decision is taken. Moving it earlier would change the
+existing pre-output retry sequencing for no acceptance-criterion benefit. The
+visible effect is that the abandoned text lingers for `initialDelayMs` before it
+disappears. If an abort lands during that window no `RETRY` is emitted, the
+partial text is committed by the existing cancellation path, and the user sees
+exactly the "cancelled mid-response" rendering they see today — which is correct,
+because there is no second attempt to duplicate it.
+
+---
+
+## 5. Integration points (mandatory)
+
+### 5.1 Existing code that will USE this feature
+
+| File | Symbol | Role |
+|------|--------|------|
+| `packages/agents/src/core/TurnProcessor.ts` | `_runStreamAttempt` | Decides the restart; already owns the fresh-attempt boundary |
+| `packages/agents/src/core/turnAbortHelpers.ts` | `shouldRetryStreamAttempt` | Retry/stop policy, extended with the post-output rule |
+| `packages/agents/src/core/agenticLoop/AgenticLoop.ts` | `streamAndCollect` | Drops abandoned tool-call requests |
+| `packages/agents/src/core/MessageStreamOrchestrator.ts` | `_processStreamIteration` | Drops abandoned per-attempt accumulators |
+| `packages/a2a-server/src/agent/executor.ts` | `#processAgentTurnLoop` | Drops abandoned tool-call requests (second scheduler) |
+| `packages/cli/src/ui/hooks/agentStream/agentEventDispatcher.ts` | `dispatchAgentEvent` | Routes `'retry'` to the discard handler |
+| `packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts` | `useStreamHandlers` | Owns the discard handler |
+| `packages/cli/src/ui/hooks/agentStream/contentEventProcessor.ts` | `processContentEvent` / `applySplitResult` | Records retractable committed segments |
+| `packages/cli/src/nonInteractiveCliSupport.ts` | `dispatchAgentEvent` | Drops abandoned non-interactive text |
+
+### 5.2 Existing code to be REPLACED / corrected
+
+| What | Where | Why |
+|------|-------|-----|
+| `!hasYieldedChunk &&` guard | `TurnProcessor.ts:306-311` | The single blocker; replaced by an explicit post-output policy branch |
+| `_applyRetryTemperature` private method (lines 316-330, sole call site line 263) | `TurnProcessor.ts` | Relocated to `turnAbortHelpers.ts` — pure retry policy, and `TurnProcessor.ts` has 3 effective lines of `max-lines` headroom (preflight F3) |
+| `case 'retry':` no-op | `agentEventDispatcher.ts:354-361` | Becomes an explicit discard |
+| Three "does not retry after output" assertions | `chatSession.issue2150.test.ts` | Encode the pre-#3048 contract (preflight F7) |
+| `Retry` = log-only | `packages/a2a-server/src/agent/task-support.ts` classification stays; the *executor* stops treating collected tool calls as durable | AC4 applies to every scheduler |
+
+### 5.3 User access points
+
+- Interactive CLI: any turn whose provider stream drops mid-response.
+  Observable as: the partial response disappearing and being replaced by one
+  complete response, instead of `[API Error: ...]` ending the turn.
+- Non-interactive CLI (`--output-format json` / `--quiet`): the emitted result
+  contains only the successful attempt's text.
+- ACP/Zed and a2a-server: the loop continues instead of stopping; a2a
+  additionally never schedules abandoned tool calls.
+
+### 5.4 Migration requirements
+
+None. No persisted data, settings schema, or wire format changes. The
+`retries` / `retrywait` ephemerals keep their meaning.
+
+---
+
+## 6. The discard contract — complete accumulator audit
+
+Every per-attempt accumulator reachable from a model stream, with an explicit,
+source-grounded decision. This table satisfies issue item 5.
+
+| # | Accumulator | Location | Decision | Rationale |
+|---|-------------|----------|----------|-----------|
+| 1 | `StreamOutputAccumulator` | `streamOutputAccumulator.ts` | **No change** | Fresh instance per attempt; never observed across the boundary (preflight A7, F1) |
+| 2 | `HistoryService` entries | `_finalizeStreamProcessing` → `recordHistoryWithUsage` | **No change** | Only reached on normal completion; a failed attempt writes neither the user nor the AI turn (preflight A8). Pinned by a behavioural test |
+| 3 | `currentPromptEnvelopeEstimate` | `StreamProcessor._convertIContentStream` catch | **No change** | Already nulled on stream error |
+| 4 | `compressionHandler.lastPromptTokenCount` | `trackPromptTokens` | **No change** | Overwritten by the successful attempt with the same prompt's value |
+| 5 | API-response telemetry + `recordActualTokenUsage` | `StreamProcessor._logTelemetry` | **No change** | Runs only after the stream loop completes; an abandoned attempt logs no response and no actual token usage |
+| 6 | Finalized prompt-envelope estimate | `recordFinalizedPromptEnvelopeEstimate` | **No change** | Re-recorded per attempt under the same `promptId`; last (successful) write wins |
+| 7 | `eagerlyRecordedToolResponseCallIds` | `StreamProcessor` / `TurnProcessor` | **No change — deliberately NOT reset** | These record tool responses the *client* already put in history before the send. They belong to the turn, not the attempt. Clearing them on discard would make the successful attempt re-record duplicates via `prepareHistoryUserInput` |
+| 8 | Per-chunk AfterModel hooks | `StreamProcessor._processAfterModelHook` | **No change** (documented) | Hooks are user-authored side effects already executed; `packages/core/src/hooks/types.ts` has no compensating event. Identical to today's contract for any mid-stream failure. Follow-up candidate (§8) |
+| 9 | `cumulativeOutcome` | `turn.ts:474-478` | **Already correct** | Reset to `createEmptyResponseOutcome()` on `RETRY` |
+| 10 | `ctx.responseChunks` | `MessageStreamOrchestrator` | **CHANGE — truncate to entry baseline on Retry** | Feeds the AfterAgent hook's `responseText`. The array is shared across internal-loop iterations, so a Retry truncates to the length captured at `_processStreamIteration` entry (not zero), preserving text contributed by earlier successful internal-loop iterations while discarding the abandoned attempt's text |
+| 11 | `hadContent` / `hadThinking` / `hadToolCallsThisTurn` | `MessageStreamOrchestrator._processStreamIteration` | **CHANGE — reset on Retry** (`hadToolCallsThisTurn` back to `hadToolCallsPrior`) | They gate `canRetryFailedStream` and post-turn evaluation; an abandoned attempt must not contribute |
+| 12 | `deferredEvents` | same | **CHANGE — clear on Retry** | `shouldDeferStreamEvent` defers `Finished` and `Citation`; an abandoned attempt can emit deferred citations |
+| 13 | `finishedOutcome` | same | **No change** | Only set by `AgentEventType.Finished`, which an abandoned (throwing) attempt never reaches |
+| 14 | `AgenticLoop` `toolCallRequests` | `AgenticLoop.streamAndCollect` | **CHANGE — clear on Retry, keep `shouldScheduleTools === true`** | AC4. The successful attempt must still schedule its own tools |
+| 15 | a2a-server `toolCallRequests` | `executor.#processAgentTurnLoop` | **CHANGE — clear on Retry** | Second scheduler; AC4 is a property of the system, not of one consumer |
+| 16 | `LoopDetectionService` content/tool tracking | `loopDetectionService.addAndCheck` | **CHANGE — checkpoint/restore on Retry** | `MessageStreamOrchestrator._processStreamIteration` captures a `LoopDetectionService.checkpoint()` at iteration entry (after `turnStarted`) and calls `restore()` on every transport Retry, so abandoned Content/ToolCallRequest cannot contaminate the detector. The snapshot covers only attempt-mutable state (`lastToolCallKey`, repetition count, `streamContentHistory`, deep-copied `contentStats`, `lastContentIndex`, `loopDetected`, `inCodeBlock`); prompt identity and `turnsInCurrentPrompt` are explicitly preserved. With `toolCallLoopThreshold=2`, an abandoned tool A + Retry + replacement tool A is no longer rejected as a loop |
+| 17 | `TodoContinuationService.recordModelActivity` | `MessageStreamOrchestrator` loop | **No change** | Only reacts to `ToolCallResponse`, which `turn.run()` never emits |
+| 18 | `TodoContinuationService.lastTodoSnapshot` / `lastTodoToolTurn` / `consecutiveComplexTurns` | `_handleTodoToolCall` | **CHANGE — checkpoint/restore on Retry** | `_handleTodoToolCall` mutates all three before a possible Retry. `MessageStreamOrchestrator._processStreamIteration` captures a `TodoContinuationService.checkpoint()` at iteration entry and calls `restore()` on every transport Retry. The snapshot covers exactly these three attempt-local values (the todo snapshot is cloned on both capture and restore to prevent aliasing); prompt identity, reminder level and activity counters are excluded. An abandoned `todo_write` no longer shifts reminder cadence for the replacement attempt |
+| 19 | CLI `agentBufferRef` | `useSubmitQuery.useProcessAgentEvent` | **CHANGE — reset to `''`** | AC3 |
+| 20 | CLI `PendingResponseBuffer` | `useStreamState` | **CHANGE — `reset()`** | AC3; holds the sanitiser's unstable tail plus the retained stable text |
+| 21 | CLI pending history item | `pendingHistoryItemRef` / `setPendingHistoryItem` | **CHANGE — drop WITHOUT flushing, AI-content items only** | Flushing would commit the abandoned text. A `tool_group` pending item belongs to the scheduler, not to the model attempt, and must be left alone |
+| 22 | CLI thinking state | `thinkingBlocksRef`, `setThought` | **CHANGE — clear** | Abandoned thinking must not be attached to the successful message |
+| 23 | CLI committed stable segments | `contentEventProcessor.applySplitResult` → `addItem` | **CHANGE — retract** | Preflight F5. Without this, any multi-paragraph partial response is duplicated on screen and AC3 fails |
+| 24 | CLI displayed tool state | scheduler `onToolCallsUpdate` → `replaceToolCalls` | **No change — no pre-scheduling state exists** | `dispatchAgentEvent` treats `'tool-call'` as a no-op; tool rows appear only from scheduler callbacks, and abandoned tool calls are never scheduled (row 14). Verified against `agentEventDispatcher.ts:354-361` |
+| 25 | Non-interactive `responseText` / `quietTextBuffer` / `thoughtBuffer` | `nonInteractiveCliSupport.ts` | **CHANGE — reset on retry, discarding the emoji filter's held buffer** | `--output-format json` and `--quiet` emit these as the final result |
+| 26 | Non-interactive already-written stdout / `stream-json` deltas | same | **No change — documented limitation** | Bytes already on stdout cannot be retracted |
+| 27 | Zed/ACP already-sent `agent_message_chunk` | `zed-agent-event-handler.ts`, `zed-stream-batcher.ts` | **No change — documented limitation + follow-up** | ACP `SessionUpdate` has no retraction primitive; dropping only the un-flushed batch would be timing-dependent (preflight F9) |
+
+---
+
+## 7. Formal requirements
+
+### [REQ-3048-001] Provider boundary stays terminal after output
+
+**Full text:** `RetryOrchestrator` MUST NOT retry inside a single provider
+iterator once an `IContent` has been yielded, and MUST propagate the original
+error object so the turn layer can classify it.
+
+- **GIVEN** a provider whose stream yields one `IContent` and then throws a
+  transient transport error
+- **WHEN** the stream is consumed through `RetryOrchestrator`
+- **THEN** the wrapped provider's `generateChatCompletion` is invoked exactly once
+- **AND** the consumer observes exactly the one yielded `IContent` followed by a
+  rejection
+- **AND** the rejected value is the same error object the transport threw
+  (no `RetriesExhaustedError` wrapper, `isRetryable` still absent)
+- **AND** `isTerminalRetryError(error)` is `true` in the **providers** module and
+  `false` in the **agents** module
+
+**Why this matters:** the anti-mixing rule is what makes the turn-level restart
+safe. If the orchestrator ever spliced two generations into one iterator, the
+turn layer could not tell them apart and history would concatenate them.
+
+### [REQ-3048-002] Transient transport failure after output restarts the turn
+
+**Full text:** When a turn attempt has already emitted output and then fails with
+a transient transport error, and the abort signal is clear and the turn retry
+budget has room, the turn MUST be restarted from a fresh attempt instead of
+ending in an error.
+
+- **GIVEN** a provider that, on attempt 1, yields `text: 'partial'` and then
+  throws `Error('Connection error.')` (no HTTP status), and on attempt 2 yields
+  `text: 'recovered response'`
+- **WHEN** the caller consumes `chat.sendMessageStream(...)` to completion
+- **THEN** the provider's `generateChatCompletion` is invoked exactly twice
+- **AND** the stream completes without throwing
+- **AND** a `StreamEventType.RETRY` event is emitted exactly once, strictly before
+  any chunk of attempt 2
+- **AND** the same holds when the abandoned attempt emitted a `tool_call` block
+  or a hidden `thinking` block instead of text
+
+**Why this matters:** this is the whole point of the issue — a dropped connection
+mid-answer currently kills the agentic loop.
+
+### [REQ-3048-003] The restart is bounded, and exhausted or non-transient failures still fail
+
+**Full text:** At most one restart per turn is permitted
+(`INVALID_CONTENT_RETRY_OPTIONS.maxAttempts`). A non-transient error after output
+MUST NOT restart. A second failure MUST propagate.
+
+- **GIVEN** a provider that yields `text: 'partial'` and then throws
+  `Error('Connection error.')` on **every** attempt
+- **WHEN** the caller consumes the stream
+- **THEN** `generateChatCompletion` is invoked exactly twice
+- **AND** the stream rejects with `Connection error.`
+- **GIVEN** a provider that yields `text: 'partial'` and then throws an error with
+  `status: 400`
+- **WHEN** the caller consumes the stream
+- **THEN** `generateChatCompletion` is invoked exactly once and the stream rejects
+  with `Bad request`
+- **GIVEN** the same provider but throwing `InvalidStreamError` or
+  `EmptyStreamError` after output
+- **THEN** `generateChatCompletion` is invoked exactly once and the stream rejects
+  (post-output restart is transport-only — AD-3)
+
+**Why this matters:** an unbounded or indiscriminate restart converts a hard
+failure into a silent retry loop that burns quota.
+
+### [REQ-3048-004] Abort wins and is never confused with a retry
+
+**Full text:** A user/system abort MUST terminate the turn immediately, whether it
+is signalled by `name === 'AbortError'`, `code === 'ABORT_ERR'`, or
+`params.config.abortSignal.aborted`, and regardless of whether output was already
+emitted or the error text matches a transient phrase.
+
+- **GIVEN** a provider that yields `text: 'partial'` and then throws an error with
+  `name = 'AbortError'`, `code = 'ABORT_ERR'`
+- **WHEN** the caller consumes the stream
+- **THEN** `generateChatCompletion` is invoked exactly once and the stream rejects
+- **AND** no `StreamEventType.RETRY` event is emitted
+- **GIVEN** a provider that yields `text: 'partial'`, aborts the request's own
+  signal, and then throws `Error('terminated')` (a transient-matching phrase with
+  no abort name or code)
+- **THEN** `generateChatCompletion` is invoked exactly once and no `RETRY` is
+  emitted
+
+**Why this matters:** transient-error phrasing overlaps with abort phrasing
+("request aborted", "terminated"); the classifier alone would restart a
+cancellation the user just requested.
+
+### [REQ-3048-005] Durable history contains only the successful attempt
+
+**Full text:** After a discard-and-restart, `HistoryService` MUST contain exactly
+one AI entry for the turn — the successful attempt's — and exactly one copy of the
+user turn, with no text from the abandoned attempt.
+
+- **GIVEN** the REQ-3048-002 provider (partial → transport failure → success)
+- **WHEN** the stream completes and `chat.waitForIdle()` resolves
+- **THEN** `history.getAll().filter(c => c.speaker === 'ai')` has length 1
+- **AND** that entry's text is exactly `'recovered response'` and does not contain
+  `'partial'`
+- **AND** `history.getAll().filter(c => c.speaker === 'human')` has length 1
+
+**Why this matters:** a concatenated assistant entry poisons every subsequent
+request in the conversation.
+
+### [REQ-3048-006] Abandoned tool calls are never scheduled
+
+**Full text:** Tool-call requests collected during an abandoned attempt MUST be
+discarded by every consumer that schedules tools, while the successful attempt's
+own tool calls MUST still be scheduled.
+
+- **GIVEN** an `AgenticLoop` whose model stream emits
+  `ToolCallRequest(callId: 'abandoned')`, then `Retry`, then
+  `ToolCallRequest(callId: 'kept')`, then ends
+- **WHEN** the loop runs one turn
+- **THEN** the scheduler receives exactly one request, with `callId === 'kept'`
+- **GIVEN** a stream that emits `ToolCallRequest(callId:'abandoned')`, then
+  `Retry`, then ends with no further tool call
+- **THEN** the scheduler is never invoked and the loop terminates normally
+- **AND** the same two properties hold for
+  `packages/a2a-server/src/agent/executor.ts`
+
+**Why this matters:** scheduling a tool call from a generation that was thrown
+away executes side effects the model never actually committed to.
+
+### [REQ-3048-007] Message-stream per-attempt accumulators are discarded
+
+**Full text:** On `AgentEventType.Retry`, `MessageStreamOrchestrator` MUST discard
+the current attempt's accumulated response text, output flags and deferred
+events.
+
+- **GIVEN** a model stream that emits `Content('abandoned ')`, a deferred
+  `Citation`, then `Retry`, then `Content('kept')` and finishes
+- **WHEN** the AfterAgent hook fires at the end of the message stream
+- **THEN** the hook's `responseText` argument is exactly `'kept'`
+- **AND** the abandoned attempt's deferred citation is not emitted
+- **GIVEN** a stream that emits `Content('abandoned')`, `Retry`, then only a
+  `ToolCallRequest` and finishes
+- **THEN** the iteration result reports `hadContent === false`
+
+**Why this matters:** `responseChunks` is what user-authored AfterAgent hooks see;
+the flags gate post-turn recovery decisions.
+
+### [REQ-3048-008] The interactive CLI discards the abandoned attempt's pending render state
+
+**Full text:** On the public `{type:'retry'}` event, the CLI MUST reset the agent
+message buffer, the `PendingResponseBuffer`, the pending AI history item (without
+committing it) and the thinking state, and MUST leave a pending `tool_group` item
+untouched.
+
+- **GIVEN** an active turn that has rendered `'abandoned partial'`
+- **WHEN** `processAgentEvent({type:'retry'}, ts, signal)` is routed
+- **THEN** the next `{type:'text', text:'kept'}` event renders a pending item whose
+  text is exactly `'kept'`
+- **AND** no history item containing `'abandoned partial'` was added
+- **AND** `pendingResponse.stableText` is `''` immediately after the retry
+- **AND** `thinkingBlocksRef.current` is `[]` and `setThought(null)` was applied
+- **GIVEN** the pending history item is a `tool_group`
+- **WHEN** the retry event is routed
+- **THEN** the pending item is unchanged
+
+**Why this matters:** without it the retry appends to the abandoned text and the
+user reads a spliced answer.
+
+### [REQ-3048-009] The interactive CLI retracts stable segments committed by the abandoned attempt
+
+**Full text:** Stable prefixes of an in-flight assistant message that were
+committed to the static history list during an attempt MUST be removed when that
+attempt is discarded, and only those.
+
+- **GIVEN** an active turn whose streamed text contains a markdown-safe paragraph
+  break, so `contentEventProcessor` committed one or more `gemini` /
+  `gemini_content` items to history
+- **WHEN** the retry event is routed
+- **THEN** those items are no longer present in `history`
+- **AND** items added before this assistant message (the user turn, earlier tool
+  groups, earlier assistant messages) are untouched
+- **GIVEN** a completed assistant message followed by a *new* turn that is then
+  discarded
+- **THEN** the completed message's committed items are untouched
+
+**Why this matters:** preflight F5 — a `\n\n` in the partial response is enough to
+make part of it unretractable today, which would make the retry visibly duplicate
+text and fail AC3.
+
+### [REQ-3048-010] The non-interactive CLI discards abandoned buffered output
+
+**Full text:** On `{type:'retry'}`, the non-interactive consumer MUST reset the
+buffered response text, the quiet-mode buffer and the thought buffer, and MUST
+discard the emoji filter's held-back partial chunk.
+
+- **GIVEN** `--output-format json` and a stream emitting `text:'abandoned'`,
+  `retry`, `text:'kept'`, `done`
+- **WHEN** the stream is processed
+- **THEN** the emitted JSON result's response text is exactly `'kept'`
+- **GIVEN** `--quiet` and the same stream
+- **THEN** the emitted text is exactly `'kept'`
+
+**Why this matters:** the JSON result is a machine-consumed artifact; a spliced
+answer is silently wrong.
+
+### [REQ-3048-011] Audited no-change decisions are pinned
+
+**Full text:** The accumulators listed as "No change" in §6 MUST have their
+behaviour pinned by test or by an explicit statement in this specification, so a
+future edit cannot silently break the contract.
+
+- **GIVEN** the discard-and-restart scenario
+- **THEN** `eagerlyRecordedToolResponseCallIds` is not cleared (pinned by a test
+  that a tool response recorded eagerly before the send is still de-duplicated
+  after a restart)
+- **AND** `StreamOutputAccumulator` has no `reset` method (pinned by REQ-3048-005)
+- **AND** the remaining rows are documented decisions with rationale in §6
+
+---
+
+## 8. Non-goals and documented limitations
+
+- **Not** re-enabling retry inside a single provider iterator. #3049 removes that
+  from the HTTP/SSE path; this issue must not restore it elsewhere.
+- **Not** accepting a truncated response as success. A discarded attempt is
+  discarded, never committed.
+- **Not** Codex WebSocket connection-lifecycle recovery (#2771) or connection
+  metadata / idle timeout (#2772).
+- **Not** changing the retry-temperature policy. `applyRetryTemperature` bumps
+  temperature on every turn restart, which conflates content retries with
+  transport retries. That conflation predates this issue (it already applies to
+  pre-output transient retries) and regeneration is non-deterministic regardless.
+  **Follow-up candidate.**
+- **Limitation — Zed/ACP:** already-sent `agent_message_chunk` updates cannot be
+  retracted; ACP has no such primitive. **File a follow-up issue** proposing
+  either an ACP-level retraction or an explicit user-visible notice.
+- **Limitation — non-interactive stdout / `stream-json`:** bytes already written
+  cannot be recalled. The buffered artifacts (`json` result, `--quiet` text) are
+  fixed by REQ-3048-010.
+- **Limitation — per-chunk AfterModel hooks:** already-fired hooks are not
+  compensated. **Follow-up candidate:** an "attempt abandoned" hook event.
+
+---
+
+## 9. Constraints
+
+- TDD is mandatory: every production edit is made in response to a failing
+  behavioural test written first.
+- `bun:test` only. No new or modified Vitest/Node suites. The one exception is
+  mechanical argument threading at existing call sites forced by a signature
+  change (§11) — no assertion, framework or semantics change.
+- No `eslint-disable`, no `@ts-expect-error`/`@ts-ignore`, no threshold or
+  exclusion changes anywhere. `TurnProcessor.ts` sits 3 effective lines under
+  `max-lines: 800`; the fix is the relocation in §5.2, not a suppression.
+- No mock theater: tests drive the real components. Test doubles are limited to
+  infrastructure boundaries (the provider transport, `fetch`, React host state)
+  and every assertion is on observable output.
+- Immutability and strict typing per `dev-docs/RULES.md`. No `any`, no type
+  assertions to paper over the new deps.
+- New files carry `Copyright 2026 Vybestack LLC` (guard:
+  `scripts/check-copyright-year.ts`).
+
+---
+
+## 10. Example data
+
+```jsonc
+// Transient transport failure (Anthropic SDK shape: no HTTP status)
+{ "message": "Connection error.", "status": undefined }
+
+// Non-transient failure that must NOT restart
+{ "message": "Bad request", "status": 400 }
+
+// Abort shapes that must NOT restart
+{ "message": "Request aborted", "name": "AbortError", "code": "ABORT_ERR" }
+{ "message": "terminated" }  // with params.config.abortSignal.aborted === true
+
+// Attempt 1 chunk (abandoned)
+{ "speaker": "ai", "blocks": [{ "type": "text", "text": "partial" }] }
+
+// Attempt 2 chunk (durable)
+{ "speaker": "ai", "blocks": [{ "type": "text", "text": "recovered response" }] }
+
+// Abandoned tool call that must never be scheduled
+{ "speaker": "ai", "blocks": [{ "type": "tool_call", "id": "abandoned",
+  "name": "read_file", "parameters": { "file_path": "README.md" } }] }
+```
+
+---
+
+## 11. Contracts introduced or changed
+
+```ts
+// packages/agents/src/core/turnAbortHelpers.ts  (CHANGED signature)
+export interface StreamAttemptContext {
+  /**
+   * True when the attempt already yielded model output (non-empty text,
+   * thinking, or a tool call) to the consumer. Post-output restarts are
+   * discard-and-restart and are restricted to transient transport failures.
+   */
+  readonly hasYieldedOutput: boolean;
+}
+
+export function shouldRetryStreamAttempt(
+  error: unknown,
+  params: SendMessageParams,
+  attempt: number,
+  context: StreamAttemptContext,
+): boolean;
+
+// packages/agents/src/core/turnAbortHelpers.ts  (RELOCATED from TurnProcessor)
+export function applyRetryTemperature(
+  params: SendMessageParams,
+  attempt: number,
+): SendMessageParams;
+
+// packages/cli/src/ui/hooks/agentStream/committedSegmentLedger.ts  (NEW)
+/**
+ * Ids of static history items committed for the assistant message currently
+ * being streamed. Owned per stream (same lifetime as PendingResponseBuffer)
+ * so a discard can retract exactly this attempt's committed prefixes.
+ */
+export class CommittedSegmentLedger {
+  /** Starts a new assistant message; drops any ids from the previous one. */
+  begin(): void;
+  /** Records a static history item id committed for the current message. */
+  record(id: number): void;
+  /** Returns and clears the ids recorded for the current message. */
+  drain(): readonly number[];
+  /** Ids recorded so far, for assertions and rendering decisions. */
+  readonly ids: readonly number[];
+}
+
+// packages/cli/src/ui/hooks/useHistoryManager.ts  (CHANGED)
+export interface UseHistoryManagerReturn {
+  // ... existing members ...
+  /** Removes the given item ids. Unknown ids are ignored; order is preserved. */
+  removeItems: (ids: readonly number[]) => void;
+}
+
+// packages/cli/src/ui/hooks/agentStream/useStreamEventHandlers.ts  (NEW handler)
+interface StreamEventHandlersResult {
+  // ... existing members ...
+  /**
+   * Discards everything rendered for the model attempt that was just
+   * abandoned: agent message buffer (via the dispatcher's return value),
+   * PendingResponseBuffer, pending AI history item (WITHOUT committing it),
+   * thinking state, and the stable segments this attempt committed to history.
+   * A pending tool_group item is left untouched.
+   */
+  handleStreamAttemptDiscarded: () => void;
+}
+
+// packages/cli/src/ui/hooks/agentStream/agentEventDispatcher.ts  (CHANGED deps)
+export interface AgentEventDeps {
+  // ... existing members ...
+  handleStreamAttemptDiscarded: () => void;
+}
+```
+
+**Rejected alternatives for REQ-3048-009**
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Accept the duplicated static text | Fails AC3 for any multi-paragraph partial response — the common case |
+| Stop committing stable prefixes mid-stream | Undoes the #2852 optimisation; a growing string re-renders every Ink frame |
+| Buffer committed prefixes as extra *pending* items | Same re-render cost as above — `<Static>` is the whole point |
+| Blank the items via `updateItem` instead of removing | Same plumbing cost, and leaves empty rows in the scrollback |
+| Optional/defaulted `removeItems` so call sites need not change | A silent no-op fallback; violates AD-8 fail-fast |
+
+---
+
+## 12. Acceptance-criteria mapping
+
+| Issue AC | Requirement(s) | Primary proving test |
+|----------|----------------|----------------------|
+| AC1 — transient transport failure after partial output is retried, one provider path, bounded budget | REQ-3048-002, REQ-3048-003 | `chatSession.issue3048.discardRestart.test.ts` → "restarts the turn after a transient transport failure that followed partial output" |
+| AC2 — exactly one assistant history entry, no concatenation | REQ-3048-005 | same file → "records only the successful attempt in history" |
+| AC3 — UI shows no duplicated or interleaved abandoned text | REQ-3048-008, REQ-3048-009, REQ-3048-010 | `useSubmitQuery.retryDiscard.bun.tsx` → "renders only the successful attempt's text" + "retracts stable segments committed by the abandoned attempt" |
+| AC4 — abandoned tool calls are never scheduled | REQ-3048-006 | `agenticLoop/__tests__/agenticLoop.retryDiscard.test.ts` + `a2a-server/src/agent/executor.retryDiscard.bun.ts` |
+| AC5 — abort still wins | REQ-3048-004 | `turnRetryPolicy.discardRestart.test.ts` + the preserved abort cases in `chatSession.issue2150.test.ts` |
+| AC6 — non-transient and post-budget failures still fail clearly | REQ-3048-003 | `chatSession.issue3048.discardRestart.test.ts` → budget-exhaustion and 400 cases |
+| AC7 — behavioural provider/agents/CLI tests incl. end-to-end content→failure→success | REQ-3048-001 … REQ-3048-010 | `RetryOrchestrator.partialOutputBoundary.bun.ts` (provider), the agents integrated suite (P02), the CLI suites (P09-P12) |
+| Issue item 5 — defined story for hooks, telemetry, eager tool responses, other consumers | REQ-3048-007, REQ-3048-011, §6, §8 | `messageStreamOrchestrator.retryDiscard.test.ts` + §6 audit table |
+
+---
+
+## 13. Success metrics
+
+- All ten requirements covered by behavioural tests that fail before the
+  corresponding production edit and pass after it.
+- `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+  `npm run build` clean.
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+  succeeds (live smoke).
+- Zero `eslint-disable` / TS-suppression additions; zero threshold or exclusion
+  changes (`npm run lint:eslint-guard`).
+- No new Vitest/Node test file; every new test discovered by structural
+  discovery (`npm run lint:test-file-coverage`, `npm run lint:cli-test-discovery`).


### PR DESCRIPTION
## TLDR

Makes retries after partial model output safe by discarding the failed generation as one transaction before restarting the turn. The successful attempt is the only one committed to model history, CLI history, tool scheduling, loop detection, todo-continuation state, and non-interactive output.

## Dive Deeper

- Keeps the provider iterator boundary strict: once a provider iterator yields output, it still terminates with the original error instead of splicing another generation into the same stream.
- Lets the turn layer restart once for recognized transient transport failures, using its existing bounded retry budget and a fresh stream accumulator/history boundary.
- Preserves abort-first behavior and keeps non-transient, terminal, budget-exhausted, InvalidStreamError, EmptyStreamError, and idle-timeout outcomes terminal after output.
- Treats Retry as a transaction boundary throughout agents and A2A:
  - drops abandoned tool-call requests before scheduling,
  - rolls back loop-detection and todo-continuation attempt state,
  - removes abandoned response text, flags, and deferred events while retaining earlier successful internal iterations,
  - buffers A2A attempt output until the attempt completes successfully.
- Makes the interactive CLI retract both pending output and stable segments already committed to static history, while preserving prior completed messages and scheduler-owned tool groups.
- Resets buffered JSON, quiet-mode, thinking, and emoji-filter output for non-interactive consumers.
- Adds Bun behavioral coverage at provider, agents, A2A, interactive CLI, and non-interactive CLI boundaries, plus a test-first specification and implementation plan under project-plans/issue3048.

Reviewers should pay particular attention to the attempt checkpoint/restore boundary in MessageStreamOrchestrator, the committed-segment lifecycle in the CLI, and the distinction between provider-terminal and turn-retryable errors.

## Reviewer Test Plan

1. Run the full suite with constrained agents concurrency:

       LLXPRT_AGENTS_TEST_CONCURRENCY=2 npm run test

2. Run lint, typecheck, formatting, and build:

       npm run lint
       npm run typecheck
       npm run format
       npm run build

3. Run the live smoke test:

       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

4. For focused behavior, run the new retry/discard suites in providers, agents, A2A, and CLI. The key end-to-end scenario is partial text, transient transport failure, Retry, then successful replacement text; assert only the replacement attempt remains in history and rendered output.

5. The tmux harness was run successfully for the terminal UI path.

Local note: this checkout contains ignored vendored research trees that pollute the root TypeScript project and test-discovery scan. Required lint passes with that ignored local-only research directory temporarily outside the project; issue source/tests themselves pass all focused and full required checks.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3048

Follow-up to #3034 and the transport-boundary behavior established by #3049.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retry handling across agent responses, CLI streams, and tool calls.
  - Discarded incomplete text, thoughts, citations, and tool requests from failed attempts.
  - Preserved only successful output in conversation history and maintained correct retry ordering.
  - Prevented retries after output for unsupported or terminal failures.
  - Preserved active turns, completion state, and earlier successful content during recovery.

- **Improvements**
  - Added safer history cleanup when abandoned response segments are retracted.
  - Improved loop detection and TODO continuation behavior across retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->