### PR TITLE
Stop reporting Bun's nonexistent heap ceiling (Fixes #3112)

### DIFF
--- a/packages/cli/src/cliSandbox.ts
+++ b/packages/cli/src/cliSandbox.ts
@@ -47,8 +47,9 @@ export function resolveContainerMemoryMB(): number | undefined {
 
 /**
  * Compute the memory args to pass when relaunching into the sandbox.
- * Always returns args (the sandbox starts fresh with Node's default heap),
- * unlike the host-relaunch heuristic at the top of main().
+ * Under Bun this returns an empty array (Bun ignores --max-old-space-size);
+ * under Node it returns the computed heap argument unless auto-configure is
+ * disabled, unlike the host-relaunch heuristic at the top of main().
  */
 export function computeSandboxMemoryArgsFromEnv(
   config: Config,

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -5,8 +5,22 @@
  */
 
 import { render } from '../../test-utils/render.js';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { vi } from '../../test-utils/bunTest.js';
+import { act } from 'react';
 import { Footer } from './Footer.js';
+
+let mockProcessVersions: NodeJS.ProcessVersions;
+const mockHeapStatistics: { heap_size_limit: number } = {
+  heap_size_limit: 8 * 1024 ** 3,
+};
+const mockMemoryUsage: NodeJS.MemoryUsage = {
+  rss: 1024 * 1024 * 1024,
+  heapUsed: 100 * 1024 * 1024,
+  heapTotal: 200 * 1024 * 1024,
+  external: 10 * 1024 * 1024,
+  arrayBuffers: 5 * 1024 * 1024,
+};
 
 // Mock the responsive hooks and utilities
 vi.mock('../hooks/useResponsive.js', () => ({
@@ -25,17 +39,13 @@ vi.mock('node:process', async (importOriginal) => {
   // directly (no .default wrapper), so normalize the shape.
   const actualDefault =
     (actual as { default?: typeof process }).default ?? actual;
+  mockProcessVersions = { ...actualDefault.versions };
   return {
     ...actual,
     default: {
       ...actualDefault,
-      memoryUsage: vi.fn(() => ({
-        rss: 1024 * 1024 * 1024,
-        heapUsed: 100 * 1024 * 1024,
-        heapTotal: 200 * 1024 * 1024,
-        external: 10 * 1024 * 1024,
-        arrayBuffers: 5 * 1024 * 1024,
-      })),
+      memoryUsage: vi.fn(() => ({ ...mockMemoryUsage })),
+      versions: mockProcessVersions,
       env: {
         ...actualDefault.env,
         SANDBOX: 'test-sandbox',
@@ -46,9 +56,7 @@ vi.mock('node:process', async (importOriginal) => {
 
 vi.mock('node:v8', () => ({
   default: {
-    getHeapStatistics: vi.fn(() => ({
-      heap_size_limit: 8 * 1024 * 1024 * 1024,
-    })),
+    getHeapStatistics: vi.fn(() => mockHeapStatistics),
   },
 }));
 
@@ -81,6 +89,13 @@ describe('Footer', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProcessVersions.bun = '';
+    mockHeapStatistics.heap_size_limit = 8 * 1024 ** 3;
+    mockMemoryUsage.rss = 1024 * 1024 * 1024;
+    mockMemoryUsage.heapUsed = 100 * 1024 * 1024;
+    mockMemoryUsage.heapTotal = 200 * 1024 * 1024;
+    mockMemoryUsage.external = 10 * 1024 * 1024;
+    mockMemoryUsage.arrayBuffers = 5 * 1024 * 1024;
   });
 
   describe('branch and path display order', () => {
@@ -426,6 +441,7 @@ describe('Footer', () => {
 
   describe('memory display uses actual heap limit', () => {
     it('should calculate percentage against actual heap limit and show correct denominator', () => {
+      mockProcessVersions.bun = '';
       mockUseResponsive.mockReturnValue({
         width: 180,
         breakpoint: 'WIDE',
@@ -440,6 +456,165 @@ describe('Footer', () => {
 
       expect(textContent).toContain('8.0GB');
       expect(textContent).not.toContain('4.8GB');
+    });
+  });
+
+  describe('Bun memory display (no heap denominator)', () => {
+    afterEach(() => {
+      mockProcessVersions.bun = '';
+    });
+
+    it('compact: Heap shows used heap only with G suffix, no denominator, RSS present', () => {
+      mockProcessVersions.bun = '1.3.14';
+      mockUseResponsive.mockReturnValue({
+        width: 70,
+        breakpoint: 'NARROW',
+        isNarrow: true,
+        isStandard: false,
+        isWide: false,
+      });
+
+      const { lastFrame } = render(<Footer {...defaultProps} />);
+
+      const textContent = lastFrame() ?? '';
+      expect(textContent).toContain('Heap: 0.1G');
+      expect(textContent).not.toContain('0.1G/');
+      expect(textContent).toContain('RSS:');
+    });
+
+    it('standard: Heap shows used heap only with GB suffix, no denominator, RSS present', () => {
+      mockProcessVersions.bun = '1.3.14';
+      mockUseResponsive.mockReturnValue({
+        width: 120,
+        breakpoint: 'STANDARD',
+        isNarrow: false,
+        isStandard: true,
+        isWide: false,
+      });
+
+      const { lastFrame } = render(<Footer {...defaultProps} />);
+
+      const textContent = lastFrame() ?? '';
+      expect(textContent).toContain('Heap: 0.1GB');
+      expect(textContent).not.toContain('0.1GB/');
+      expect(textContent).toContain('RSS:');
+    });
+
+    it('wide: Heap, External, ArrayBuffers, and RSS all present with no denominator', () => {
+      mockProcessVersions.bun = '1.3.14';
+      mockUseResponsive.mockReturnValue({
+        width: 180,
+        breakpoint: 'WIDE',
+        isNarrow: false,
+        isStandard: false,
+        isWide: true,
+      });
+
+      const { lastFrame } = render(<Footer {...defaultProps} />);
+
+      const textContent = lastFrame() ?? '';
+      expect(textContent).toContain('Heap: 0.1GB');
+      expect(textContent).not.toContain('0.1GB/');
+      expect(textContent).toContain('External:');
+      expect(textContent).toContain('ArrayBuffers:');
+      expect(textContent).toContain('RSS:');
+    });
+
+    it('does not show the heap-limit denominator even when v8 reports a large limit', () => {
+      mockProcessVersions.bun = '1.3.14';
+      mockHeapStatistics.heap_size_limit = 8 * 1024 ** 3;
+      mockUseResponsive.mockReturnValue({
+        width: 120,
+        breakpoint: 'STANDARD',
+        isNarrow: false,
+        isStandard: true,
+        isWide: false,
+      });
+
+      const { lastFrame } = render(<Footer {...defaultProps} />);
+
+      const textContent = lastFrame() ?? '';
+      expect(textContent).not.toContain('8.0GB');
+    });
+  });
+
+  describe('Node memory display re-reads heap statistic on refresh', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('updates the denominator when the heap statistic changes on the two-second refresh', async () => {
+      mockProcessVersions.bun = '';
+      mockHeapStatistics.heap_size_limit = 4 * 1024 ** 3;
+
+      mockUseResponsive.mockReturnValue({
+        width: 120,
+        breakpoint: 'STANDARD',
+        isNarrow: false,
+        isStandard: true,
+        isWide: false,
+      });
+
+      vi.useFakeTimers();
+
+      const { lastFrame } = render(<Footer {...defaultProps} />);
+
+      let textContent = lastFrame() ?? '';
+      expect(textContent).toContain('0.1GB/4.0GB');
+
+      mockHeapStatistics.heap_size_limit = 8 * 1024 ** 3;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      textContent = lastFrame() ?? '';
+      expect(textContent).toContain('0.1GB/8.0GB');
+      expect(textContent).not.toContain('4.0GB');
+    });
+  });
+
+  describe('Bun memory display refreshes on the two-second timer', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+      mockProcessVersions.bun = '';
+    });
+
+    it('renders updated heap and RSS values after the refresh with no heap-limit denominator', async () => {
+      mockProcessVersions.bun = '1.3.14';
+      mockUseResponsive.mockReturnValue({
+        width: 180,
+        breakpoint: 'WIDE',
+        isNarrow: false,
+        isStandard: false,
+        isWide: true,
+      });
+
+      vi.useFakeTimers();
+
+      const { lastFrame } = render(<Footer {...defaultProps} />);
+
+      let textContent = lastFrame() ?? '';
+      expect(textContent).toContain('Heap: 0.1GB');
+      expect(textContent).toContain('RSS: 1.0GB');
+      expect(textContent).not.toContain('0.1GB/');
+
+      mockMemoryUsage.heapUsed = 300 * 1024 * 1024;
+      mockMemoryUsage.rss = 2 * 1024 * 1024 * 1024;
+      mockMemoryUsage.external = 20 * 1024 * 1024;
+      mockMemoryUsage.arrayBuffers = 8 * 1024 * 1024;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      textContent = lastFrame() ?? '';
+      expect(textContent).toContain('Heap: 0.3GB');
+      expect(textContent).toContain('RSS: 2.0GB');
+      expect(textContent).toContain('External: 0.0GB');
+      expect(textContent).toContain('ArrayBuffers: 0.0GB');
+      expect(textContent).not.toContain('0.3GB/');
+      expect(textContent).not.toContain('8.0GB');
     });
   });
 });

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -26,15 +26,15 @@ import { ThemedGradient } from './ThemedGradient.js';
 
 const DEFAULT_HEAP_LIMIT = 4.8 * 1024 * 1024 * 1024;
 
-// Lazily compute the heap limit so test mocks for `node:v8` can take effect
-// before the value is first read.
-let _heapSizeLimit: number | undefined;
+function isBunRuntime(): boolean {
+  return (
+    typeof process.versions.bun === 'string' && process.versions.bun.length > 0
+  );
+}
+
 function getHeapSizeLimit(): number {
-  if (_heapSizeLimit === undefined) {
-    const rawHeapLimit = v8.getHeapStatistics().heap_size_limit;
-    _heapSizeLimit = rawHeapLimit > 0 ? rawHeapLimit : DEFAULT_HEAP_LIMIT;
-  }
-  return _heapSizeLimit;
+  const rawHeapLimit = v8.getHeapStatistics().heap_size_limit;
+  return rawHeapLimit > 0 ? rawHeapLimit : DEFAULT_HEAP_LIMIT;
 }
 
 function areFooterStablePropsEqual(
@@ -108,10 +108,12 @@ function formatMemoryUsage(
   detailed: boolean,
 ): string {
   const heapUsed = formatGigabytes(usage.heapUsed);
-  const heapLimit = formatGigabytes(getHeapSizeLimit());
   const rssValue = formatGigabytes(usage.rss);
-  const heap = `Heap: ${heapUsed}${compact ? 'G' : 'GB'}/${heapLimit}${compact ? 'G' : 'GB'}`;
+  const heapSuffix = compact ? 'G' : 'GB';
   const rss = `RSS: ${rssValue}${compact ? 'G' : 'GB'}`;
+  const heap = isBunRuntime()
+    ? `Heap: ${heapUsed}${heapSuffix}`
+    : `Heap: ${heapUsed}${heapSuffix}/${formatGigabytes(getHeapSizeLimit())}${heapSuffix}`;
   if (compact || !detailed) {
     return `${heap} ${rss}`;
   }

--- a/packages/cli/src/utils/bootstrap.test.ts
+++ b/packages/cli/src/utils/bootstrap.test.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { vi } from '../test-utils/bunTest.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
 import os from 'node:os';
 import v8 from 'node:v8';
@@ -18,6 +19,25 @@ import {
 } from './bootstrap.js';
 
 describe('bootstrap utilities', () => {
+  const originalBunDescriptor = Object.getOwnPropertyDescriptor(
+    process.versions,
+    'bun',
+  );
+
+  beforeEach(() => {
+    Object.defineProperty(process.versions, 'bun', {
+      value: '',
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalBunDescriptor) {
+      Object.defineProperty(process.versions, 'bun', originalBunDescriptor);
+    }
+  });
+
   describe('isDebugMode', () => {
     const originalEnv = process.env;
 
@@ -401,6 +421,104 @@ describe('bootstrap utilities', () => {
   describe('MAX_HEAP_CAP_MB', () => {
     it('should be 8192 (8GB)', () => {
       expect(MAX_HEAP_CAP_MB).toBe(8192);
+    });
+  });
+
+  describe('Bun never relaunches for --max-old-space-size', () => {
+    const originalNoRelaunch = process.env.LLXPRT_CODE_NO_RELAUNCH;
+    let totalmemSpy: ReturnType<typeof vi.spyOn>;
+    let heapStatsSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      Object.defineProperty(process.versions, 'bun', {
+        value: '1.3.14',
+        writable: true,
+        configurable: true,
+      });
+      delete process.env.LLXPRT_CODE_NO_RELAUNCH;
+      totalmemSpy = vi.spyOn(os, 'totalmem').mockReturnValue(17179869184);
+      heapStatsSpy = vi.spyOn(v8, 'getHeapStatistics').mockReturnValue({
+        total_heap_size: 0,
+        total_heap_size_executable: 0,
+        total_physical_size: 0,
+        total_available_size: 0,
+        used_heap_size: 0,
+        heap_size_limit: 1073741824,
+        malloced_memory: 0,
+        peak_malloced_memory: 0,
+        does_zap_garbage: 0,
+        number_of_native_contexts: 0,
+        number_of_detached_contexts: 0,
+        total_global_handles_size: 0,
+        used_global_handles_size: 0,
+        external_memory: 0,
+      });
+    });
+
+    afterEach(() => {
+      totalmemSpy.mockRestore();
+      heapStatsSpy.mockRestore();
+      if (originalNoRelaunch === undefined) {
+        delete process.env.LLXPRT_CODE_NO_RELAUNCH;
+      } else {
+        process.env.LLXPRT_CODE_NO_RELAUNCH = originalNoRelaunch;
+      }
+    });
+
+    it('shouldRelaunchForMemory returns [] even with inputs that produce a flag on Node', () => {
+      const result = shouldRelaunchForMemory(false, 4096);
+      expect(result).toStrictEqual([]);
+    });
+
+    it('shouldRelaunchForMemory returns [] with a large custom cap that would flag on Node', () => {
+      const result = shouldRelaunchForMemory(false, 32768);
+      expect(result).toStrictEqual([]);
+    });
+
+    it('shouldRelaunchForMemory returns [] in debug mode', () => {
+      const result = shouldRelaunchForMemory(true, 4096);
+      expect(result).toStrictEqual([]);
+    });
+
+    it('shouldRelaunchForMemory returns [] when LLXPRT_CODE_NO_RELAUNCH is set', () => {
+      process.env.LLXPRT_CODE_NO_RELAUNCH = 'true';
+      const result = shouldRelaunchForMemory(false, 4096);
+      expect(result).toStrictEqual([]);
+      delete process.env.LLXPRT_CODE_NO_RELAUNCH;
+    });
+
+    it('shouldRelaunchForMemory returns [] even when os.totalmem and v8.getHeapStatistics would throw if evaluated', () => {
+      totalmemSpy.mockImplementation(() => {
+        throw new Error('totalmem unavailable');
+      });
+      heapStatsSpy.mockImplementation(() => {
+        throw new Error('getHeapStatistics unavailable');
+      });
+      const result = shouldRelaunchForMemory(false, 4096);
+      expect(result).toStrictEqual([]);
+    });
+
+    it('computeSandboxMemoryArgs returns [] with explicit container memory', () => {
+      const result = computeSandboxMemoryArgs(false, 6144);
+      expect(result).toStrictEqual([]);
+    });
+
+    it('computeSandboxMemoryArgs returns [] with a custom cap', () => {
+      const result = computeSandboxMemoryArgs(false, 131072, 2048);
+      expect(result).toStrictEqual([]);
+    });
+
+    it('computeSandboxMemoryArgs returns [] in debug mode with container memory', () => {
+      const result = computeSandboxMemoryArgs(true, 6144);
+      expect(result).toStrictEqual([]);
+    });
+
+    it('computeSandboxMemoryArgs returns [] with host-derived memory even when os.totalmem would throw if evaluated', () => {
+      totalmemSpy.mockImplementation(() => {
+        throw new Error('totalmem unavailable');
+      });
+      const result = computeSandboxMemoryArgs(false);
+      expect(result).toStrictEqual([]);
     });
   });
 });

--- a/packages/cli/src/utils/bootstrap.ts
+++ b/packages/cli/src/utils/bootstrap.ts
@@ -24,6 +24,16 @@ export const RELAUNCH_EXIT_CODE = 75;
 export const MAX_HEAP_CAP_MB = 8192;
 
 /**
+ * Bun does not honor --max-old-space-size, so the established non-empty
+ * `process.versions.bun` convention is the same check the launcher uses.
+ */
+function isBunRuntime(): boolean {
+  return (
+    typeof process.versions.bun === 'string' && process.versions.bun.length > 0
+  );
+}
+
+/**
  * Check if debug mode is enabled via environment variables.
  * This is a lightweight check that doesn't require loading any configuration.
  */
@@ -45,6 +55,10 @@ export function shouldRelaunchForMemory(
   debugMode: boolean,
   maxHeapCapMB: number = MAX_HEAP_CAP_MB,
 ): string[] {
+  if (isBunRuntime()) {
+    return [];
+  }
+
   const cap = Math.floor(maxHeapCapMB);
   const totalMemoryMB = os.totalmem() / (1024 * 1024);
   const heapStats = v8.getHeapStatistics();
@@ -126,19 +140,22 @@ export function parseDockerMemoryToMB(memoryStr: string): number | undefined {
 }
 
 /**
- * Compute --max-old-space-size for a NEW sandbox process.
- * Unlike shouldRelaunchForMemory(), this ALWAYS returns memory args
- * because the sandbox process starts fresh with Node.js defaults (~950MB).
+ * Compute --max-old-space-size for a new Node sandbox process.
+ * Bun ignores this flag, so Bun-fronted sandbox launches receive no memory args.
  *
  * @param debugMode - Whether to log debug information
  * @param containerMemoryMB - Container memory limit in MB, or undefined to use host memory
- * @returns Array containing a single --max-old-space-size argument
+ * @returns A Node heap argument, or an empty array when running under Bun
  */
 export function computeSandboxMemoryArgs(
   debugMode: boolean,
   containerMemoryMB?: number,
   maxHeapCapMB: number = MAX_HEAP_CAP_MB,
 ): string[] {
+  if (isBunRuntime()) {
+    return [];
+  }
+
   const cap = Math.floor(maxHeapCapMB);
   const totalMemoryMB = containerMemoryMB ?? os.totalmem() / (1024 * 1024);
   const targetMaxOldSpaceSizeInMB = Math.max(

--- a/project-plans/issue3112/plan/00a-preflight-verification.md
+++ b/project-plans/issue3112/plan/00a-preflight-verification.md
@@ -1,0 +1,83 @@
+# Phase 0.5: Preflight Verification
+
+Plan ID: `PLAN-20260807-ISSUE3112`
+Verified: 2026-08-07
+
+## Dependencies verified
+
+- `node:process`, `node:os`, and `node:v8` are built-in modules already used by
+  the affected production files.
+- `bun:test` is the workspace's required test API and is discovered by
+  `packages/cli/run-bun-tests.ts`.
+- `packages/cli/src/test-utils/bunTest.ts` already provides the CLI's Bun module
+  mocking compatibility facade.
+- No new dependency is required.
+
+## Types and runtime detection verified
+
+- `process.versions.bun` is declared by the installed runtime types and is
+  already the CLI launcher's Bun detection mechanism.
+- The established condition requires a non-empty string.
+- `NodeJS.MemoryUsage` already supplies `heapUsed`, `rss`, `external`, and
+  `arrayBuffers` to the footer formatter.
+- Core has a private-package runtime helper, but it is not exported through the
+  package root. Expanding the core public surface is unnecessary and outside the
+  accepted scope.
+
+## Call paths verified
+
+- `cliBootstrap.maybeRelaunchForMemory` calls
+  `shouldRelaunchForMemory`; an empty array bypasses the relaunch path.
+- `cliSandbox.computeSandboxMemoryArgsFromEnv` calls
+  `computeSandboxMemoryArgs`; `maybeHopIntoSandbox` passes the returned array
+  directly to `start_sandbox`, so `[]` is an existing valid contract.
+- `Footer` reaches `ResponsiveMemoryDisplay` whenever
+  `showMemoryUsage` is enabled and refreshes through its existing two-second
+  interval.
+
+## Existing behavior to replace
+
+- `Footer.tsx` memoizes and displays `heap_size_limit` as a denominator for all
+  runtimes.
+- `bootstrap.ts` calculates and returns `--max-old-space-size` arguments without
+  checking whether the runtime honors them.
+- No separate migration, registration, or user access wiring is needed.
+
+## Test infrastructure verified
+
+- `packages/cli/src/ui/components/Footer.test.tsx` renders the actual footer and
+  already mocks only surrounding infrastructure.
+- `packages/cli/src/utils/bootstrap.test.ts` exercises the actual exported
+  bootstrap functions and already covers Node calculations.
+- The CLI runner discovers both test files and executes each in an isolated Bun
+  process.
+- Touched suites can migrate their test API imports to `bun:test` while retaining
+  `vi` from the existing compatibility facade.
+
+## Remaining heap-flag audit
+
+| Location | Classification | Decision |
+|---|---|---|
+| `packages/cli/src/utils/bootstrap.ts` | Bun-fronted production policy | Fix with runtime-aware empty result |
+| `packages/cli/src/cliBootstrap.tsx` | Caller of corrected policy | Leave API/call path unchanged |
+| `packages/cli/src/cliSandbox.ts` | Caller of corrected policy | Leave API/call path unchanged |
+| `packages/cli/src/utils/relaunch.ts` | Generic argument transport | Leave unchanged |
+| CLI test literals/mocks | Test data for transport and wiring | Leave except accepted suites |
+| root `package.json` test/lint `NODE_OPTIONS` | Real Node process | Leave unchanged |
+| `scripts/run-lint.ts` and its tests | Real Node eslint child | Leave unchanged |
+| CI workflow `NODE_OPTIONS` | Real Node process | Leave unchanged |
+
+## Blocking issues found
+
+None. The accepted behavior can be implemented by modifying the existing footer
+and bootstrap decisions plus their existing tests. No public abstraction,
+dependency, workflow, or unrelated refactor is needed.
+
+## Verification gate
+
+- [x] Dependencies verified
+- [x] Types and runtime detection verified
+- [x] Call paths verified
+- [x] Test infrastructure ready
+- [x] Remaining uses classified
+- [x] No blocking issue found

--- a/project-plans/issue3112/specification.md
+++ b/project-plans/issue3112/specification.md
@@ -1,0 +1,138 @@
+# Feature Specification: Honest Bun memory reporting and startup behavior
+
+Issue: [#3112](https://github.com/vybestack/llxprt-code/issues/3112)
+Plan ID: `PLAN-20260807-ISSUE3112`
+Generated: 2026-08-07
+Branch: `issue3112`
+
+## Purpose
+
+The CLI currently presents Bun's growing `v8.getHeapStatistics().heap_size_limit`
+value as a fixed heap ceiling and relaunches Bun with a
+`--max-old-space-size` argument that Bun silently ignores. The delivered behavior
+must stop making either claim while preserving the meaningful Node runtime path.
+The memory-retention problem investigated in #3108 is explicitly outside this
+issue.
+
+## Accepted behavior
+
+### [REQ-3112-001] Bun footer never presents a heap ceiling
+
+- **GIVEN** the footer is rendered by Bun with memory reporting enabled
+- **WHEN** memory usage is displayed at narrow, standard, or wide breakpoints
+- **THEN** `Heap:` reports only the current used heap and has no `/limit`
+  denominator
+- **AND** `RSS:` remains visible at every breakpoint
+- **AND** wide/detailed output continues to include `External:` and
+  `ArrayBuffers:`
+- **AND** compact output retains its existing `G` suffix while non-compact
+  output retains `GB`
+
+This is deliberately a reporting correction only. It does not introduce an
+in-process memory ceiling or change the existing RSS warning threshold.
+
+### [REQ-3112-002] Node footer behavior remains meaningful and non-stale
+
+- **GIVEN** the same footer code is executed by Node
+- **WHEN** memory usage is displayed
+- **THEN** the existing Node heap-limit denominator remains available
+- **AND** each periodic memory snapshot reads the current heap statistic instead
+  of reusing a module-level memoized value
+
+This preserves the runtime where `--max-old-space-size` and
+`heap_size_limit` have real semantics while removing the stale-value defect.
+
+### [REQ-3112-003] Bun never relaunches for `--max-old-space-size`
+
+- **GIVEN** startup is running under Bun
+- **WHEN** `shouldRelaunchForMemory` is evaluated with any host-memory size,
+  heap statistic, debug mode, configured cap, or
+  `LLXPRT_CODE_NO_RELAUNCH` state
+- **THEN** it returns `[]`
+- **AND** no `--max-old-space-size` argument is produced
+
+The no-relaunch environment guard remains unchanged for Node. Bun exits before
+performing calculations whose result cannot affect its memory behavior.
+
+### [REQ-3112-004] Bun sandbox launches receive no ignored heap flag
+
+- **GIVEN** a sandbox child is being prepared by a Bun-fronted CLI
+- **WHEN** `computeSandboxMemoryArgs` is called with host-derived memory,
+  container-derived memory, or a custom heap cap
+- **THEN** it returns `[]`
+- **AND** the sandbox launch continues with that empty argument list
+
+Node executions retain the existing 50%, minimum, cap, rounding, and debug
+behavior. Existing settings remain in place because they are still meaningful
+for Node and removing or migrating them is outside scope.
+
+### [REQ-3112-005] Remaining heap-flag uses are classified, not removed broadly
+
+- Bun-fronted live production calls in `packages/cli/src/utils/bootstrap.ts` are
+  the dead behavior corrected by REQ-3112-003 and REQ-3112-004.
+- `packages/cli/src/cliBootstrap.tsx` and
+  `packages/cli/src/cliSandbox.ts` are their callers and require no new public
+  contract.
+- CLI test fixtures and relaunch utility examples are not independent runtime
+  policy decisions.
+- Root `package.json`, lint scripts, and CI `NODE_OPTIONS` uses front real Node
+  processes and remain untouched.
+
+## Relevant inputs and boundary cases
+
+| Input or boundary | Accepted result |
+|---|---|
+| Bun version is a non-empty `process.versions.bun` string | Bun behavior is selected |
+| Bun footer at compact width | `Heap: <used>G RSS: <rss>G`, with no denominator |
+| Bun footer at standard width | `Heap: <used>GB RSS: <rss>GB`, with no denominator |
+| Bun footer at wide width | Heap, external, array buffers, and RSS values, with no denominator |
+| Memory changes after the two-second refresh | Rendered current metrics update |
+| Node heap statistic changes between snapshots | The new denominator is rendered; no stale memoized limit |
+| Bun host with large memory and a small reported heap statistic | No relaunch argument |
+| Bun sandbox with explicit container memory and custom cap | No sandbox memory argument |
+| Node with `LLXPRT_CODE_NO_RELAUNCH` set | Existing empty result remains |
+| Node target at or below current heap limit | Existing empty result remains |
+| Node target above current heap limit | Existing integer `--max-old-space-size=<MB>` result remains |
+| Node sandbox cap/minimum/fractional cases | Existing calculation remains |
+
+## Behavioral evidence
+
+Tests must be written first and observed failing before production changes.
+Changed test files must import assertions and lifecycle hooks from `bun:test`;
+where module-mocking compatibility is needed, they must import `vi` from the
+existing CLI Bun test facade.
+
+1. `Footer.test.tsx` renders the real footer under a Bun-like runtime and proves
+   the absence of a heap denominator plus the continued presence of Heap, RSS,
+   External, and ArrayBuffers values.
+2. `Footer.test.tsx` drives the existing two-second refresh under a Node-like
+   runtime with changing heap statistics and proves the denominator updates.
+3. `bootstrap.test.ts` establishes Node-like runtime state for the existing
+   calculation coverage, preserving all current Node-path assertions.
+4. `bootstrap.test.ts` adds Bun cases proving both exported memory-argument
+   functions return empty arrays for values that otherwise produce flags.
+5. Static call-path evidence confirms that `[]` from `computeSandboxMemoryArgs`
+   under Bun is safe: `computeSandboxMemoryArgsFromEnv` returns it unchanged to
+   `maybeHopIntoSandbox`, which passes it as `sandboxMemoryArgs` to
+   `start_sandbox(config, sandboxMemoryArgs, …)`. `start_sandbox` defaults
+   `nodeArgs` to `[]` and spreads it into `NODE_OPTIONS` via
+   `addContainerEnvVars` (container path) or into the seatbelt `nodeOptions`
+   join (seatbelt path); an empty array contributes nothing to either. The
+   existing mocked `cli-sandbox.test.tsx` verifies wiring with a non-empty mock
+   return; the empty-array safety is proven by the static spread/default
+   analysis, not by a behavioral integration test.
+6. The focused Bun test run, full repository verification, smoke test, and tmux
+   footer observation must all pass on the candidate head.
+
+## Implementation constraints
+
+- No new dependency, workflow, setting, environment variable, public API, or
+  runtime subsystem.
+- Runtime detection uses the established non-empty
+  `process.versions.bun` convention at the two existing decision points; a
+  cross-package export is not introduced for this bounded change.
+- No change to #3108 accumulation behavior and no in-process memory limiter.
+- No package.json, lint-script, CI, relaunch utility, or unrelated test cleanup.
+- No lint/type suppressions, lint-rule changes, complexity threshold changes, or
+  ignored source.
+- Prefer a direct fail-fast Bun branch over fallback or defensive layers.


### PR DESCRIPTION
## TLDR

Stop treating Bun's compatibility V8 heap statistic as a real memory ceiling. Bun now shows current heap usage without a fabricated denominator and skips both host and sandbox relaunch arguments that Bun ignores. The meaningful Node behavior remains unchanged, including a live heap-limit denominator that is refreshed rather than memoized.

## Dive Deeper

- Detect Bun using the established non-empty process.versions.bun convention at the existing CLI decision points.
- Render Bun memory as used heap plus RSS, retaining External and ArrayBuffers in the wide footer without implying a hard ceiling.
- Preserve the Node denominator while reading the current heap statistic for each periodic snapshot.
- Return no max-old-space-size arguments for Bun host relaunches or Bun-fronted sandbox launches before OS or V8 calculations.
- Keep all Node cap, floor, rounding, debug, and no-relaunch behavior intact.
- Audit remaining heap-flag uses and leave Node-fronted package, lint, and CI settings unchanged.
- Document the accepted behavior and preflight classification in project-plans/issue3112.

Review findings were classified as Blocker-Fix, In-scope-Fix, Reject, or Defer. DeepThinker and local Open Code Review completed; all valid in-scope findings were resolved. No public API, dependency, workflow, lint-rule, or memory-retention change was introduced.

## Reviewer Test Plan

1. Run the focused behavioral tests:

       cd packages/cli
       bun test --timeout 30000 ./src/ui/components/Footer.test.tsx ./src/utils/bootstrap.test.ts

   Expected: 82 tests pass.

2. Start the CLI with memory display enabled under Bun and confirm the footer resembles:

       Heap: 0.2GB RSS: 0.4GB

   It must not contain a slash denominator. At wide width it should also show External and ArrayBuffers.

3. Review the Node-like test cases to confirm the heap denominator remains and changes after the two-second refresh when the mocked V8 statistic changes.

4. Review the bootstrap Bun cases to confirm both memory-argument functions return an empty array before host/V8 calculations, while the inherited Node calculation cases remain green.

Local evidence on macOS:
- Focused issue tests: 82 passed, 0 failed.
- Direct ESLint on all changed TypeScript/TSX files: passed with zero warnings.
- ESLint guard: passed.
- Typecheck: passed after the dependency-ordered build.
- Build: passed.
- Format: passed.
- StepFun smoke test: passed with a valid haiku.
- Tmux harness: passed; raw output showed Heap: 0.2GB RSS: 0.4GB with no denominator.
- Isolated agents profiles suite: 22 passed, 0 failed.
- Isolated agents hooks suite: 17 passed, 0 failed.

Repository-wide local caveats, reported without weakening gates or expanding this issue:
- npm run test completed with exit 1 because the agents workspace runner labeled hooks.spec.ts failed despite that file's captured output and isolated run showing 17 passed and 0 failed. A prior run similarly labeled profiles.spec.ts failed despite 22 passed and 0 failed in isolation.
- npm run lint completed with 231 errors in unchanged existing Bun-migration test files. Every changed file passes direct ESLint, and the lint guard passes. CI remains authoritative and will be watched to completion.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ focused/build/typecheck/format/smoke; full test/lint caveats above | ❓ | ❓ |
| npx      | ✅ changed-file ESLint | ❓ | ❓ |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ✅ tmux harness | -   | -   |

## Linked issues / bugs

Fixes #3112

Related to #3108


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory usage displays when running under Bun by removing unsupported heap-limit values.
  * Updated memory management behavior to avoid applying Node-specific heap arguments in Bun environments.
  * Refreshed heap-limit information on demand for more accurate memory reporting.
  * Improved memory and RSS updates after automatic refresh intervals.

* **Documentation**
  * Clarified runtime-specific memory configuration and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->