### PR TITLE
Bound and rotate error reports (Fixes #3113)

### DIFF
--- a/packages/agents/src/core/turn.errorReport.bun.test.ts
+++ b/packages/agents/src/core/turn.errorReport.bun.test.ts
@@ -1,0 +1,280 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Turn, AgentEventType, DEFAULT_AGENT_ID } from './turn.js';
+import type {
+  ContentBlock,
+  IContent,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { ChatSession } from './chatSession.js';
+import type { ServerAgentStreamEvent } from './turn.js';
+
+// Restated from the specification — tests are the specification
+const TURN_REPORT_HISTORY_TAIL = 8;
+const MAX_REPORT_BYTES = 131_072;
+const REPORT_FILE_PATTERN = /^llxprt-client-error-.*\.json$/;
+const TEMP_ENV_KEYS = ['TMPDIR', 'TMP', 'TEMP'] as const;
+type TempEnvKey = (typeof TEMP_ENV_KEYS)[number];
+
+interface ReportContext {
+  request: ContentBlock[];
+  recentHistory: IContent[];
+  omittedHistoryCount: number;
+}
+
+interface ParsedReport {
+  error: { message: string; stack?: string };
+  context?: ReportContext;
+  contextOmitted?: {
+    reason: string;
+    serializedBytes: number;
+    limitBytes: number;
+  };
+}
+
+/**
+ * Minimal ChatSession fixture — the provider/network boundary. Only the
+ * methods Turn.run actually calls before the error path are implemented;
+ * sendMessageStream throws to drive handleRunError into the reportError path.
+ */
+interface FixtureChat {
+  getHistory: (curated?: boolean) => IContent[];
+  getConfig: () => undefined;
+  sendMessageStream: () => Promise<never>;
+}
+
+function makeEntry(speaker: IContent['speaker'], text: string): IContent {
+  return {
+    speaker,
+    blocks: [{ type: 'text', text }],
+  };
+}
+
+function createTurn(history: IContent[], errorMessage: string): Turn {
+  const chat: FixtureChat = {
+    getHistory: () => history,
+    getConfig: () => undefined,
+    sendMessageStream: () => Promise.reject(new Error(errorMessage)),
+  };
+  return new Turn(
+    chat as unknown as ChatSession,
+    'prompt-test',
+    DEFAULT_AGENT_ID,
+    'fixture',
+  );
+}
+
+async function collectEvents(
+  turn: Turn,
+  req: ContentBlock[],
+): Promise<ServerAgentStreamEvent[]> {
+  const events: ServerAgentStreamEvent[] = [];
+  for await (const event of turn.run(req, new AbortController().signal)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe('Turn error report payload (issue 3113)', () => {
+  let tmpDir: string;
+  let stderrSpy: ReturnType<typeof spyOn>;
+  let savedTempEnv: Record<TempEnvKey, string | undefined>;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'llxprt-turn-report-'));
+    savedTempEnv = {
+      TMPDIR: process.env.TMPDIR,
+      TMP: process.env.TMP,
+      TEMP: process.env.TEMP,
+    };
+    const realTmpDir = await fs.realpath(tmpDir);
+    for (const key of TEMP_ENV_KEYS) {
+      process.env[key] = realTmpDir;
+    }
+    stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(async () => {
+    stderrSpy.mockRestore();
+    for (const key of TEMP_ENV_KEYS) {
+      const savedValue = savedTempEnv[key];
+      if (savedValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedValue;
+      }
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function listReportFiles(): Promise<string[]> {
+    const entries = await fs.readdir(tmpDir);
+    return entries.filter((name) => REPORT_FILE_PATTERN.test(name)).sort();
+  }
+
+  async function readReport(name: string): Promise<ParsedReport> {
+    const content = await fs.readFile(path.join(tmpDir, name), 'utf-8');
+    return JSON.parse(content) as ParsedReport;
+  }
+
+  // T1: 25 entries -> recentHistory has 8, omittedHistoryCount === 17
+  it('T1: bounds recentHistory to 8 entries with correct omittedHistoryCount', async () => {
+    const history: IContent[] = [];
+    for (let i = 0; i < 25; i++) {
+      history.push(makeEntry(i % 2 === 0 ? 'human' : 'ai', `Turn ${i}`));
+    }
+    const turn = createTurn(history, 'T1 distinct error message');
+    const req: ContentBlock[] = [{ text: 'T1 failing request' }];
+
+    await collectEvents(turn, req);
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const report = await readReport(files[0]);
+    if (report.context === undefined) {
+      throw new Error('Expected report context');
+    }
+    expect(report.context.recentHistory.length).toBe(8);
+    expect(report.context.omittedHistoryCount).toBe(17);
+    expect(report.context.recentHistory).toEqual(
+      history.slice(-TURN_REPORT_HISTORY_TAIL),
+    );
+  });
+
+  // T2: request is semantically separate, not part of recentHistory
+  it('T2: request is separate from recentHistory and deep-equals the request blocks', async () => {
+    const history: IContent[] = [makeEntry('human', 'T2 prior')];
+    const turn = createTurn(history, 'T2 distinct error message');
+    const req: ContentBlock[] = [{ text: 'T2 failing request' }];
+
+    await collectEvents(turn, req);
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const report = await readReport(files[0]);
+    if (report.context === undefined) {
+      throw new Error('Expected report context');
+    }
+    expect(report.context.request).toEqual(req);
+    expect(report.context.recentHistory).not.toContainEqual(req);
+  });
+
+  // T3: Empty history -> recentHistory is [], omittedHistoryCount === 0
+  it('T3: handles empty history with omittedHistoryCount 0 and empty recentHistory', async () => {
+    const turn = createTurn([], 'T3 distinct error message');
+    const req: ContentBlock[] = [{ text: 'T3 empty history request' }];
+
+    await collectEvents(turn, req);
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const report = await readReport(files[0]);
+    if (report.context === undefined) {
+      throw new Error('Expected report context');
+    }
+    expect(report.context.recentHistory).toEqual([]);
+    expect(report.context.omittedHistoryCount).toBe(0);
+    expect(report.context.request).toEqual(req);
+  });
+
+  // T4: 3 entries (shorter than tail) -> all 3, omittedHistoryCount === 0
+  it('T4: preserves all entries when history is shorter than the tail', async () => {
+    const history: IContent[] = [
+      makeEntry('human', 'T4 a'),
+      makeEntry('ai', 'T4 b'),
+      makeEntry('human', 'T4 c'),
+    ];
+    const turn = createTurn(history, 'T4 distinct error message');
+    const req: ContentBlock[] = [{ text: 'T4 short history request' }];
+
+    await collectEvents(turn, req);
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const report = await readReport(files[0]);
+    if (report.context === undefined) {
+      throw new Error('Expected report context');
+    }
+    expect(report.context.recentHistory).toEqual(history);
+    expect(report.context.omittedHistoryCount).toBe(0);
+  });
+
+  // T5: 200 entries of 20,000 chars -> file <= 131,072 bytes, 8 recentHistory
+  it('T5: bounds file size with large history entries', async () => {
+    const history: IContent[] = [];
+    for (let i = 0; i < 200; i++) {
+      history.push(makeEntry('ai', 'X'.repeat(20_000)));
+    }
+    const turn = createTurn(history, 'T5 distinct error message');
+    const req: ContentBlock[] = [{ text: 'T5 large history request' }];
+
+    await collectEvents(turn, req);
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const stat = await fs.stat(path.join(tmpDir, files[0]));
+    expect(stat.size).toBeLessThanOrEqual(MAX_REPORT_BYTES);
+    const report = await readReport(files[0]);
+    if (report.context === undefined) {
+      throw new Error('Expected report context');
+    }
+    expect(report.context.recentHistory.length).toBe(8);
+  });
+
+  // T6: Report text contains no newlines (compact JSON)
+  it('T6: writes compact JSON with no newlines', async () => {
+    const turn = createTurn(
+      [makeEntry('human', 'T6 prior')],
+      'T6 distinct error message',
+    );
+    const req: ContentBlock[] = [{ text: 'T6 compact request' }];
+
+    await collectEvents(turn, req);
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const raw = await fs.readFile(path.join(tmpDir, files[0]), 'utf-8');
+    expect(raw.includes('\n')).toBe(false);
+  });
+
+  // T7: Exactly one Error event is yielded with the unchanged structured error
+  it('T7: yields exactly one Error event with the structured error', async () => {
+    const turn = createTurn(
+      [makeEntry('human', 'T7 prior')],
+      'T7 distinct error message',
+    );
+    const req: ContentBlock[] = [{ text: 'T7 event check' }];
+
+    const events = await collectEvents(turn, req);
+    expect(events).toEqual([
+      {
+        type: AgentEventType.Error,
+        value: { error: { message: 'T7 distinct error message' } },
+      },
+    ]);
+  });
+
+  // T8: Exactly one report file with the expected type prefix
+  it('T8: writes exactly one report file with Turn.run-sendMessageStream type', async () => {
+    const turn = createTurn(
+      [makeEntry('human', 'T8 prior')],
+      'T8 distinct error message',
+    );
+    const req: ContentBlock[] = [{ text: 'T8 one file check' }];
+
+    await collectEvents(turn, req);
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(
+      /^llxprt-client-error-Turn\.run-sendMessageStream-/,
+    );
+  });
+});

--- a/packages/agents/src/core/turn.test.ts
+++ b/packages/agents/src/core/turn.test.ts
@@ -295,12 +295,7 @@ describe('Turn', () => {
         error: { message: 'API Error' },
       });
       expect(turn.getDebugResponses().length).toBe(0);
-      expect(reportError).toHaveBeenCalledWith(
-        error,
-        'Error when talking to test API',
-        [...historyContent, reqParts],
-        'Turn.run-sendMessageStream',
-      );
+      expect(reportError).toHaveBeenCalledTimes(1);
     });
 
     it('should handle function calls with undefined name or args', async () => {

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -61,6 +61,7 @@ import {
   safeJsonStringify,
 } from './turnJsonUtils.js';
 import { buildCitationEvent } from './turnCitations.js';
+import { buildErrorReportContext } from './turnErrorReportContext.js';
 import {
   DEFAULT_AGENT_ID,
   AgentEventType,
@@ -584,12 +585,10 @@ export class Turn {
     if (error instanceof UnauthorizedError) {
       throw error;
     }
-
-    const contextForReport = [...this.chat.getHistory(/*curated*/ true), req];
     await reportError(
       error,
       `Error when talking to ${this.providerName} API`,
-      contextForReport,
+      buildErrorReportContext(this.chat.getHistory(/*curated*/ true), req),
       'Turn.run-sendMessageStream',
     );
     const structuredError = buildStructuredError(error);

--- a/packages/agents/src/core/turnErrorReportContext.ts
+++ b/packages/agents/src/core/turnErrorReportContext.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+
+const TURN_REPORT_HISTORY_TAIL = 8;
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P06
+ * @requirement REQ-3113-1.1
+ * @pseudocode lines 300-322
+ */
+export function buildErrorReportContext(
+  history: IContent[],
+  request: string | object | readonly unknown[],
+): Record<string, unknown> {
+  return {
+    request,
+    recentHistory: history.slice(-TURN_REPORT_HISTORY_TAIL),
+    omittedHistoryCount: Math.max(0, history.length - TURN_REPORT_HISTORY_TAIL),
+  };
+}

--- a/packages/core/src/utils/errorReporting.bounding.bun.test.ts
+++ b/packages/core/src/utils/errorReporting.bounding.bun.test.ts
@@ -1,0 +1,389 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { reportError } from './errorReporting.js';
+
+// Constants restated from the specification (tests are the specification)
+const MAX_REPORT_STRING_CHARS = 4096;
+const MAX_REPORT_BYTES = 131072;
+const REPORT_FILE_PATTERN = /^llxprt-client-error-.*\.json$/;
+
+function clampExpectedString(value: string): string {
+  if (value.length <= MAX_REPORT_STRING_CHARS) {
+    return value;
+  }
+  return `${value.slice(0, MAX_REPORT_STRING_CHARS)} [truncated: ${value.length} chars]`;
+}
+
+function stringifyExpected(payload: unknown): string {
+  return JSON.stringify(payload, (_key, value) =>
+    typeof value === 'string' ? clampExpectedString(value) : value,
+  );
+}
+
+describe('errorReport bounding and compact output (issue 3113)', () => {
+  let testDir: string;
+  let stderrSpy: ReturnType<typeof spyOn>;
+  let stderrCalls: string[];
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'llxprt-bounding-'));
+    stderrCalls = [];
+    stderrSpy = spyOn(process.stderr, 'write').mockImplementation(
+      (data: unknown) => {
+        if (typeof data === 'string') {
+          stderrCalls.push(data);
+        }
+        return true;
+      },
+    );
+  });
+
+  afterEach(async () => {
+    stderrSpy.mockRestore();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  function expectStderrContaining(fragment: string): void {
+    const found = stderrCalls.some((call) => call.includes(fragment));
+    expect(found, `Expected stderr to contain "${fragment}"`).toBe(true);
+  }
+
+  async function listReportFiles(): Promise<string[]> {
+    const entries = await fs.readdir(testDir);
+    return entries.filter((name) => REPORT_FILE_PATTERN.test(name)).sort();
+  }
+
+  async function readReport(name: string): Promise<Record<string, unknown>> {
+    const content = await fs.readFile(path.join(testDir, name), 'utf-8');
+    return JSON.parse(content);
+  }
+
+  // B1: Compact JSON — no newlines in main report
+  it('B1: writes compact JSON with no newlines in the main report', async () => {
+    const error = new Error('B1 compact report test');
+    error.stack = 'B1 stack';
+    await reportError(
+      error,
+      'B1 base',
+      { data: 'B1 context' },
+      'b1-type',
+      testDir,
+    );
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const raw = await fs.readFile(path.join(testDir, files[0]), 'utf-8');
+    expect(raw.includes('\n')).toBe(false);
+    const parsed = JSON.parse(raw);
+    expect(parsed).toEqual({
+      error: { message: 'B1 compact report test', stack: 'B1 stack' },
+      context: { data: 'B1 context' },
+    });
+  });
+
+  // B2: Compact minimal fallback report
+  it('B2: writes compact minimal fallback report on serialization failure', async () => {
+    const error = new Error('B2 bigint test');
+    error.stack = 'B2 stack';
+    await reportError(error, 'B2 base', { big: BigInt(1) }, 'b2-type', testDir);
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const raw = await fs.readFile(path.join(testDir, files[0]), 'utf-8');
+    expect(raw.includes('\n')).toBe(false);
+    const parsed = JSON.parse(raw);
+    expect(parsed).toEqual({
+      error: { message: 'B2 bigint test', stack: 'B2 stack' },
+    });
+  });
+
+  // B3: Per-string clamp
+  it('B3: clamps strings exceeding MAX_REPORT_STRING_CHARS with marker', async () => {
+    const longString = 'a'.repeat(10_000);
+    await reportError(
+      new Error('B3 clamp test'),
+      'B3 base',
+      { blob: longString },
+      'b3-type',
+      testDir,
+    );
+
+    const files = await listReportFiles();
+    const parsed = await readReport(files[0]);
+    const context = parsed.context as { blob: string };
+    const expectedMarker = ` [truncated: ${longString.length} chars]`;
+    expect(context.blob.startsWith('a'.repeat(MAX_REPORT_STRING_CHARS))).toBe(
+      true,
+    );
+    expect(context.blob.endsWith(expectedMarker)).toBe(true);
+    expect(context.blob.length).toBe(
+      MAX_REPORT_STRING_CHARS + expectedMarker.length,
+    );
+  });
+
+  it('B3b: clamps error.message at 4096 chars with the exact marker', async () => {
+    const message = 'm'.repeat(MAX_REPORT_STRING_CHARS + 1);
+    await reportError(
+      new Error(message),
+      'B3b base',
+      undefined,
+      'b3b-type',
+      testDir,
+    );
+
+    const files = await listReportFiles();
+    const parsed = await readReport(files[0]);
+    const reportedError = parsed.error as { message: string };
+    expect(reportedError.message).toBe(
+      `${'m'.repeat(MAX_REPORT_STRING_CHARS)} [truncated: 4097 chars]`,
+    );
+  });
+
+  // B4: Boundary — exactly 4096 chars stored verbatim
+  it('B4: stores strings of exactly MAX_REPORT_STRING_CHARS verbatim', async () => {
+    const exactString = 'b'.repeat(MAX_REPORT_STRING_CHARS);
+    await reportError(
+      new Error('B4 boundary test'),
+      'B4 base',
+      { blob: exactString },
+      'b4-type',
+      testDir,
+    );
+
+    const files = await listReportFiles();
+    const parsed = await readReport(files[0]);
+    const context = parsed.context as { blob: string };
+    expect(context.blob).toBe(exactString);
+    expect(context.blob.includes('truncated')).toBe(false);
+  });
+
+  // B5: Array-context tail clamp
+  it('B5: clamps array context to last 8 entries with contextTruncated', async () => {
+    const entries = Array.from({ length: 200 }, (_, i) => ({
+      text: 'x'.repeat(3_000),
+      index: i,
+    }));
+    await reportError(
+      new Error('B5 array tail test'),
+      'B5 base',
+      entries,
+      'b5-type',
+      testDir,
+    );
+
+    const files = await listReportFiles();
+    const parsed = await readReport(files[0]);
+    const context = parsed.context as unknown[];
+    expect(context.length).toBe(8);
+    expect(context).toEqual(entries.slice(-8));
+    const truncated = parsed.contextTruncated as { omittedEntries: number };
+    expect(truncated.omittedEntries).toBe(192);
+  });
+
+  // B5b: File is at most 131072 bytes
+  it('B5b: array-clamped report file stays under MAX_REPORT_BYTES', async () => {
+    const entries = Array.from({ length: 200 }, (_, i) => ({
+      text: 'x'.repeat(3_000),
+      index: i,
+    }));
+    await reportError(
+      new Error('B5b size bound test'),
+      'B5b base',
+      entries,
+      'b5b-type',
+      testDir,
+    );
+
+    const files = await listReportFiles();
+    const stat = await fs.stat(path.join(testDir, files[0]));
+    expect(stat.size).toBeLessThanOrEqual(MAX_REPORT_BYTES);
+  });
+
+  // B6: Hard payload cap — array context with huge last 8 entries
+  it('B6: drops context entirely when array tail still exceeds limit', async () => {
+    const makeHugeEntry = (i: number): Record<string, string> => {
+      const obj: Record<string, string> = {};
+      for (let k = 0; k < 40; k++) {
+        obj[`key${k}`] = 'z'.repeat(4_000);
+      }
+      obj.index = String(i);
+      return obj;
+    };
+    const entries = Array.from({ length: 200 }, (_, i) => makeHugeEntry(i));
+    const error = new Error('B6 hard cap array test');
+    error.stack = 'B6 stack';
+    await reportError(error, 'B6 base', entries, 'b6-type', testDir);
+
+    const files = await listReportFiles();
+    const stat = await fs.stat(path.join(testDir, files[0]));
+    expect(stat.size).toBeLessThanOrEqual(MAX_REPORT_BYTES);
+    const parsed = await readReport(files[0]);
+    expect(parsed.context).toBeUndefined();
+    const omitted = parsed.contextOmitted as {
+      reason: string;
+      serializedBytes: number;
+      limitBytes: number;
+    };
+    expect(omitted.reason).toBe('payload-exceeded-limit');
+    expect(omitted.limitBytes).toBe(MAX_REPORT_BYTES);
+    const kept = entries.slice(-8);
+    const oversizedTail = stringifyExpected({
+      error: { message: error.message, stack: error.stack },
+      context: kept,
+      contextTruncated: { omittedEntries: entries.length - kept.length },
+    });
+    expect(omitted.serializedBytes).toBe(
+      Buffer.byteLength(oversizedTail, 'utf8'),
+    );
+  });
+
+  // B7: Non-array context hard cap
+  it('B7: drops non-array context when it exceeds the limit', async () => {
+    const hugeContext: Record<string, string> = {};
+    for (let k = 0; k < 200; k++) {
+      hugeContext[`key${k}`] = 'w'.repeat(4_000);
+    }
+    await reportError(
+      new Error('B7 hard cap object test'),
+      'B7 base',
+      hugeContext,
+      'b7-type',
+      testDir,
+    );
+
+    const files = await listReportFiles();
+    const stat = await fs.stat(path.join(testDir, files[0]));
+    expect(stat.size).toBeLessThanOrEqual(MAX_REPORT_BYTES);
+    const parsed = await readReport(files[0]);
+    expect(parsed.context).toBeUndefined();
+    const omitted = parsed.contextOmitted as {
+      reason: string;
+      serializedBytes: number;
+      limitBytes: number;
+    };
+    expect(omitted.reason).toBe('payload-exceeded-limit');
+    expect(omitted.limitBytes).toBe(MAX_REPORT_BYTES);
+    const oversizedPayload = stringifyExpected({
+      error: parsed.error,
+      context: hugeContext,
+    });
+    expect(omitted.serializedBytes).toBe(
+      Buffer.byteLength(oversizedPayload, 'utf8'),
+    );
+  });
+
+  // B8: Small context — exactly { error, context } with no extra keys
+  it('B8: writes exactly { error, context } for small context with no truncation keys', async () => {
+    await reportError(
+      new Error('B8 small context test'),
+      'B8 base',
+      { data: 'test context' },
+      'b8-type',
+      testDir,
+    );
+
+    const files = await listReportFiles();
+    const parsed = await readReport(files[0]);
+    expect(Object.keys(parsed).sort()).toEqual(['context', 'error']);
+    expect(parsed.context).toEqual({ data: 'test context' });
+  });
+
+  // B9: Stack clamping
+  it('B9: clamps error.stack with the same marker as context strings', async () => {
+    const error = new Error('B9 stack clamp test');
+    error.stack = 's'.repeat(10_000);
+    await reportError(error, 'B9 base', undefined, 'b9-type', testDir);
+
+    const files = await listReportFiles();
+    const parsed = await readReport(files[0]);
+    const err = parsed.error as { message: string; stack: string };
+    const expectedMarker = ` [truncated: ${10_000} chars]`;
+    expect(err.stack.startsWith('s'.repeat(MAX_REPORT_STRING_CHARS))).toBe(
+      true,
+    );
+    expect(err.stack.endsWith(expectedMarker)).toBe(true);
+    expect(err.stack.length).toBe(
+      MAX_REPORT_STRING_CHARS + expectedMarker.length,
+    );
+  });
+
+  // B10: Write failure fallback — preserved contract
+  it('B10: emits write-failure stderr messages for non-existent reportingDir', async () => {
+    const error = new Error('B10 write fail test');
+    const nonExistentDir = path.join(testDir, 'does-not-exist');
+    await reportError(
+      error,
+      'B10 base',
+      ['B10 context'],
+      'b10-type',
+      nonExistentDir,
+    );
+
+    expectStderrContaining(
+      'B10 base Additionally, failed to write detailed error report:',
+    );
+    expectStderrContaining('Original error that triggered report generation:');
+    expectStderrContaining('Original context:');
+  });
+
+  // B11: BigInt serialization failure fallback
+  it('B11: emits serialization-failure stderr messages for BigInt context', async () => {
+    const error = new Error('B11 bigint fail test');
+    error.stack = 'B11 stack';
+    await reportError(
+      error,
+      'B11 base',
+      { big: BigInt(1) },
+      'b11-type',
+      testDir,
+    );
+
+    expectStderrContaining(
+      'B11 base Could not stringify report content (likely due to context):',
+    );
+    expectStderrContaining('Original error that triggered report generation:');
+    expectStderrContaining(
+      'Original context could not be stringified or included in report.',
+    );
+    expectStderrContaining('Partial report (excluding context) available at:');
+  });
+
+  // B12: Filename format preserved
+  it('B12: writes file matching the frozen filename pattern', async () => {
+    await reportError(
+      new Error('B12 filename test'),
+      'B12 base',
+      undefined,
+      'contract-check',
+      testDir,
+    );
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/^llxprt-client-error-contract-check-.*\.json$/);
+  });
+
+  // B13: No context — exactly { error: { message, stack } }
+  it('B13: writes exactly { error } with no context keys when context is omitted', async () => {
+    const error = new Error('B13 no context test');
+    error.stack = 'B13 stack';
+    await reportError(error, 'B13 base', undefined, 'b13-type', testDir);
+
+    const files = await listReportFiles();
+    const parsed = await readReport(files[0]);
+    expect(Object.keys(parsed).sort()).toEqual(['error']);
+    expect(parsed.error).toEqual({
+      message: 'B13 no context test',
+      stack: 'B13 stack',
+    });
+  });
+});

--- a/packages/core/src/utils/errorReporting.dedupe.bun.test.ts
+++ b/packages/core/src/utils/errorReporting.dedupe.bun.test.ts
@@ -1,0 +1,397 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  spyOn,
+  setSystemTime,
+} from 'bun:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { reportError } from './errorReporting.js';
+
+// Constants restated from the specification (tests are the specification)
+const REPORT_FILE_PATTERN = /^llxprt-client-error-.*\.json$/;
+
+const EPOCH_ORIGIN = new Date('2026-08-07T00:00:00.000Z').getTime();
+const TEST_EPOCH_STRIDE_MS = 180_000;
+let nextTestEpochMs = EPOCH_ORIGIN;
+
+describe('errorReport duplicate coalescing (issue 3113)', () => {
+  let testDir: string;
+  let stderrSpy: ReturnType<typeof spyOn>;
+  let stderrCalls: string[];
+  let testEpochMs: number;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'llxprt-dedupe-'));
+    stderrCalls = [];
+    testEpochMs = nextTestEpochMs;
+    nextTestEpochMs += TEST_EPOCH_STRIDE_MS;
+    setSystemTime(new Date(testEpochMs));
+    stderrSpy = spyOn(process.stderr, 'write').mockImplementation(
+      (data: unknown) => {
+        if (typeof data === 'string') {
+          stderrCalls.push(data);
+        }
+        return true;
+      },
+    );
+  });
+
+  afterEach(async () => {
+    stderrSpy.mockRestore();
+    setSystemTime();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  function advanceTo(offsetMs: number): void {
+    setSystemTime(new Date(testEpochMs + offsetMs));
+  }
+
+  function reportName(type: string, offsetMs: number): string {
+    const timestamp = new Date(testEpochMs + offsetMs)
+      .toISOString()
+      .replace(/[:.]/g, '-');
+    return `llxprt-client-error-${type}-${timestamp}.json`;
+  }
+
+  function expectStderrContaining(fragment: string): void {
+    const found = stderrCalls.some((c) => c.includes(fragment));
+    expect(found, `Expected stderr to contain "${fragment}"`).toBe(true);
+  }
+
+  function expectStderrNotContaining(fragment: string): void {
+    const found = stderrCalls.some((c) => c.includes(fragment));
+    expect(found, `Expected stderr NOT to contain "${fragment}"`).toBe(false);
+  }
+
+  async function listMatchingFiles(dir: string = testDir): Promise<string[]> {
+    const entries = await fs.readdir(dir);
+    return entries.filter((n) => REPORT_FILE_PATTERN.test(n)).sort();
+  }
+
+  function latestFullReportPath(): string {
+    const marker = ' Full report available at: ';
+    for (let index = stderrCalls.length - 1; index >= 0; index--) {
+      const call = stderrCalls[index];
+      const markerIndex = call.indexOf(marker);
+      if (markerIndex >= 0) {
+        return call.slice(markerIndex + marker.length).trim();
+      }
+    }
+    throw new Error('Expected a Full report available stderr line');
+  }
+
+  it('D1: emits one stderr line per suppression with cumulative counts', async () => {
+    const error = new Error('D1 duplicate message');
+    await reportError(error, 'D1 base', undefined, 'd1-type', testDir);
+    const filesAfterFirst = await listMatchingFiles();
+    expect(filesAfterFirst.length).toBe(1);
+    const originalName = filesAfterFirst[0];
+    const originalPath = path.join(testDir, originalName);
+    const originalBytes = await fs.readFile(originalPath, 'utf-8');
+
+    advanceTo(1_000);
+    const firstSuppressionStart = stderrCalls.length;
+    await reportError(error, 'D1 base', undefined, 'd1-type', testDir);
+    expect(stderrCalls.slice(firstSuppressionStart)).toEqual([
+      `D1 base Duplicate error report suppressed (1 within 60s). Previous report: ${originalPath}
+`,
+    ]);
+
+    advanceTo(2_000);
+    const secondSuppressionStart = stderrCalls.length;
+    await reportError(error, 'D1 base', undefined, 'd1-type', testDir);
+    expect(stderrCalls.slice(secondSuppressionStart)).toEqual([
+      `D1 base Duplicate error report suppressed (2 within 60s). Previous report: ${originalPath}
+`,
+    ]);
+
+    expect(await listMatchingFiles()).toEqual([originalName]);
+    expect(await fs.readFile(originalPath, 'utf-8')).toBe(originalBytes);
+  });
+
+  // D2: different error messages -> two files, no suppression
+  it('D2: does not coalesce different error messages', async () => {
+    await reportError(
+      new Error('D2 message alpha'),
+      'D2 base',
+      undefined,
+      'd2-type',
+      testDir,
+    );
+    advanceTo(1_000);
+    await reportError(
+      new Error('D2 message beta'),
+      'D2 base',
+      undefined,
+      'd2-type',
+      testDir,
+    );
+
+    const files = await listMatchingFiles();
+    expect(files.length).toBe(2);
+    expectStderrNotContaining('Duplicate error report suppressed');
+  });
+
+  // D3: same message, different type -> two files
+  it('D3: does not coalesce identical messages with different types', async () => {
+    const error = new Error('D3 same message');
+    await reportError(error, 'D3 base', undefined, 'd3-type-a', testDir);
+    advanceTo(1_000);
+    await reportError(error, 'D3 base', undefined, 'd3-type-b', testDir);
+
+    const files = await listMatchingFiles();
+    expect(files.length).toBe(2);
+  });
+
+  // D4: same type and message, different baseMessage -> two files
+  it('D4: does not coalesce identical type+message with different baseMessage', async () => {
+    const error = new Error('D4 same message');
+    await reportError(
+      error,
+      'Error when talking to claudecode API',
+      undefined,
+      'd4-type',
+      testDir,
+    );
+    advanceTo(1_000);
+    await reportError(
+      error,
+      'Error when talking to codex API',
+      undefined,
+      'd4-type',
+      testDir,
+    );
+
+    const files = await listMatchingFiles();
+    expect(files.length).toBe(2);
+  });
+
+  // D5: window boundary — 59999ms suppressed, 60000ms written
+  it('D5: window boundary at exactly 60000ms opens a new window', async () => {
+    const error = new Error('D5 boundary message');
+    await reportError(error, 'D5 base', undefined, 'd5-type', testDir);
+    const t0Files = await listMatchingFiles();
+    expect(t0Files.length).toBe(1);
+
+    advanceTo(59_999);
+    await reportError(error, 'D5 base', undefined, 'd5-type', testDir);
+    const after59999 = await listMatchingFiles();
+    expect(after59999.length).toBe(1);
+
+    advanceTo(60_000);
+    await reportError(error, 'D5 base', undefined, 'd5-type', testDir);
+    const after60000 = await listMatchingFiles();
+    expect(after60000).toEqual([
+      reportName('d5-type', 0),
+      reportName('d5-type', 60_000),
+    ]);
+  });
+
+  // D6: Fixed window — suppressed occurrences don't extend the window
+  it('D6: suppressed occurrences do not extend the fixed window', async () => {
+    const error = new Error('D6 fixed window message');
+    await reportError(error, 'D6 base', undefined, 'd6-type', testDir);
+    const t0Files = await listMatchingFiles();
+    expect(t0Files.length).toBe(1);
+    const t0Name = t0Files[0];
+
+    advanceTo(30_000);
+    await reportError(error, 'D6 base', undefined, 'd6-type', testDir);
+    expect((await listMatchingFiles()).length).toBe(1);
+
+    advanceTo(59_000);
+    await reportError(error, 'D6 base', undefined, 'd6-type', testDir);
+    expect((await listMatchingFiles()).length).toBe(1);
+
+    advanceTo(60_000);
+    await reportError(error, 'D6 base', undefined, 'd6-type', testDir);
+    const files = await listMatchingFiles();
+    expect(files).toEqual([t0Name, reportName('d6-type', 60_000)]);
+  });
+
+  // D7: Suppressed call does not write a new file or rewrite the existing one
+  it('D7: suppressed call leaves original file byte-for-byte unchanged', async () => {
+    const error = new Error('D7 unchanged bytes message');
+    await reportError(error, 'D7 base', undefined, 'd7-type', testDir);
+    const t0Files = await listMatchingFiles();
+    expect(t0Files.length).toBe(1);
+    const t0Name = t0Files[0];
+    const originalBytes = await fs.readFile(
+      path.join(testDir, t0Name),
+      'utf-8',
+    );
+
+    advanceTo(1_000);
+    await reportError(error, 'D7 base', undefined, 'd7-type', testDir);
+
+    const files = await listMatchingFiles();
+    expect(files.length).toBe(1);
+    expect(files[0]).toBe(t0Name);
+    expect(files).not.toContain(reportName('d7-type', 1_000));
+    const afterBytes = await fs.readFile(path.join(testDir, t0Name), 'utf-8');
+    expect(afterBytes).toBe(originalBytes);
+  });
+
+  // D8: Failed write does not silence the next attempt
+  it('D8: failing write does not suppress the next identical attempt', async () => {
+    const error = new Error('D8 fail then succeed message');
+    const nonExistentDir = path.join(testDir, 'does-not-exist');
+    await reportError(error, 'D8 base', undefined, 'd8-type', nonExistentDir);
+
+    advanceTo(1_000);
+    await reportError(error, 'D8 base', undefined, 'd8-type', testDir);
+    const files = await listMatchingFiles();
+    expect(files.length).toBe(1);
+  });
+
+  it('D9: pins the registry at 64 entries and evicts entry 0 first', async () => {
+    const messages = Array.from({ length: 65 }, (_, i) => `D9 message ${i}`);
+    for (let i = 0; i < messages.length; i++) {
+      advanceTo(i * 10);
+      await reportError(
+        new Error(messages[i]),
+        'D9 base',
+        undefined,
+        'd9-type',
+        testDir,
+      );
+    }
+
+    stderrCalls = [];
+    advanceTo(650);
+    await reportError(
+      new Error(messages[1]),
+      'D9 base',
+      undefined,
+      'd9-type',
+      testDir,
+    );
+    expect(stderrCalls).toHaveLength(1);
+    expectStderrContaining('Duplicate error report suppressed');
+
+    const listingBeforeEvictedRetry = await listMatchingFiles();
+    stderrCalls = [];
+    advanceTo(660);
+    await reportError(
+      new Error(messages[0]),
+      'D9 base',
+      undefined,
+      'd9-type',
+      testDir,
+    );
+    expectStderrContaining('Full report available at:');
+    expectStderrNotContaining('Duplicate error report suppressed');
+    const newReportPath = latestFullReportPath();
+    expect(path.basename(newReportPath)).toBe(reportName('d9-type', 660));
+    expect(await fs.readFile(newReportPath, 'utf-8')).toContain(messages[0]);
+    expect(await listMatchingFiles()).not.toEqual(listingBeforeEvictedRetry);
+  });
+
+  it('D10: retains the newest fingerprint at the exact capacity boundary', async () => {
+    const messages = Array.from({ length: 65 }, (_, i) => `D10 message ${i}`);
+    for (let i = 0; i < messages.length; i++) {
+      advanceTo(i * 10);
+      await reportError(
+        new Error(messages[i]),
+        'D10 base',
+        undefined,
+        'd10-type',
+        testDir,
+      );
+    }
+    const newestPath = latestFullReportPath();
+    const newestBytes = await fs.readFile(newestPath, 'utf-8');
+
+    stderrCalls = [];
+    advanceTo(650);
+    await reportError(
+      new Error(messages[64]),
+      'D10 base',
+      undefined,
+      'd10-type',
+      testDir,
+    );
+
+    expect(stderrCalls).toEqual([
+      `D10 base Duplicate error report suppressed (1 within 60s). Previous report: ${newestPath}
+`,
+    ]);
+    expect(await fs.readFile(newestPath, 'utf-8')).toBe(newestBytes);
+  });
+
+  // D11: Long-prefix distinct errors are not coalesced
+  it('D11: distinct errors sharing a 1024-char prefix are not coalesced', async () => {
+    const prefix = 'a'.repeat(1_024);
+    const messageAlpha = prefix + '-alpha';
+    const messageBeta = prefix + '-beta';
+
+    await reportError(
+      new Error(messageAlpha),
+      'D11 base',
+      undefined,
+      'd11-type',
+      testDir,
+    );
+    advanceTo(1_000);
+    await reportError(
+      new Error(messageBeta),
+      'D11 base',
+      undefined,
+      'd11-type',
+      testDir,
+    );
+
+    const files = await listMatchingFiles();
+    expect(files.length).toBe(2);
+    expectStderrNotContaining('Duplicate error report suppressed');
+    // Both messages should be readable verbatim (1024 < 4096, no clamping)
+    const report1 = JSON.parse(
+      await fs.readFile(path.join(testDir, files[0]), 'utf-8'),
+    ) as { error: { message: string } };
+    const report2 = JSON.parse(
+      await fs.readFile(path.join(testDir, files[1]), 'utf-8'),
+    ) as { error: { message: string } };
+    const msgs = [report1.error.message, report2.error.message].sort();
+    expect(msgs).toEqual([messageAlpha, messageBeta].sort());
+  });
+
+  it('D12: length framing distinguishes triples that alias under NUL joining', async () => {
+    const type = 'd12-type';
+    const first = { baseMessage: 'a\0b', message: 'c' };
+    const second = { baseMessage: 'a', message: 'b\0c' };
+    expect(type.includes('\0')).toBe(false);
+    expect([type, first.baseMessage, first.message].join('\0')).toBe(
+      [type, second.baseMessage, second.message].join('\0'),
+    );
+
+    await reportError(
+      new Error(first.message),
+      first.baseMessage,
+      undefined,
+      type,
+      testDir,
+    );
+    advanceTo(1_000);
+    await reportError(
+      new Error(second.message),
+      second.baseMessage,
+      undefined,
+      type,
+      testDir,
+    );
+
+    expect(await listMatchingFiles()).toHaveLength(2);
+    expectStderrNotContaining('Duplicate error report suppressed');
+  });
+});

--- a/packages/core/src/utils/errorReporting.rotation.bun.test.ts
+++ b/packages/core/src/utils/errorReporting.rotation.bun.test.ts
@@ -1,0 +1,327 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  spyOn,
+  setSystemTime,
+} from 'bun:test';
+import { Buffer } from 'node:buffer';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { reportError } from './errorReporting.js';
+
+// Constants restated from the specification (tests are the specification)
+const MAX_REPORT_FILES = 20;
+const MAX_REPORT_TOTAL_BYTES = 1_048_576;
+const REPORT_FILE_PATTERN = /^llxprt-client-error-.*\.json$/;
+
+async function seedReport(
+  dir: string,
+  ordinal: number,
+  content: string,
+): Promise<string> {
+  const padded = String(ordinal).padStart(2, '0');
+  const name = `llxprt-client-error-seed-${padded}-2026-08-07T00-00-${padded}-000Z.json`;
+  const filePath = path.join(dir, name);
+  await fs.writeFile(filePath, content);
+  return filePath;
+}
+
+async function listMatchingFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir);
+  return entries.filter((name) => REPORT_FILE_PATTERN.test(name)).sort();
+}
+
+async function sumMatchingBytes(dir: string): Promise<number> {
+  const files = await listMatchingFiles(dir);
+  let total = 0;
+  for (const name of files) {
+    const stat = await fs.stat(path.join(dir, name));
+    total += stat.size;
+  }
+  return total;
+}
+
+describe('errorReport rotation (issue 3113)', () => {
+  let testDir: string;
+  let stderrSpy: ReturnType<typeof spyOn>;
+  let stderrCalls: string[];
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'llxprt-rotation-'));
+    stderrCalls = [];
+    stderrSpy = spyOn(process.stderr, 'write').mockImplementation(
+      (data: unknown) => {
+        if (typeof data === 'string') {
+          stderrCalls.push(data);
+        }
+        return true;
+      },
+    );
+  });
+
+  afterEach(async () => {
+    stderrSpy.mockRestore();
+    setSystemTime();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  // R1: 20 files + 1 more -> exactly 20 remain
+  it('R1: caps matching file count at MAX_REPORT_FILES after one more write', async () => {
+    for (let i = 0; i < 20; i++) {
+      await seedReport(testDir, i, `seed-${i}`);
+    }
+
+    await reportError(
+      new Error('R1 rotation test error'),
+      'R1 base',
+      undefined,
+      'r1-type',
+      testDir,
+    );
+
+    const files = await listMatchingFiles(testDir);
+    expect(files.length).toBe(MAX_REPORT_FILES);
+  });
+
+  it('R2: orders by mtime first and filename for equal mtimes', async () => {
+    const oldestMtime = new Date('2026-08-04T00:00:00.000Z');
+    const tiedMtime = new Date('2026-08-05T00:00:00.000Z');
+    const newerMtime = new Date('2026-08-06T00:00:00.000Z');
+    for (let i = 0; i < 21; i++) {
+      const seededPath = await seedReport(testDir, i, `seed-${i}`);
+      let mtime = newerMtime;
+      if (i === 19) {
+        mtime = oldestMtime;
+      } else if (i <= 1) {
+        mtime = tiedMtime;
+      }
+      await fs.utimes(seededPath, mtime, mtime);
+    }
+
+    await reportError(
+      new Error('R2 oldest-first test error'),
+      'R2 base',
+      undefined,
+      'r2-type',
+      testDir,
+    );
+
+    const files = await listMatchingFiles(testDir);
+    expect(files.length).toBe(MAX_REPORT_FILES);
+    expect(files.some((name) => name.includes('seed-19-'))).toBe(false);
+    expect(files.some((name) => name.includes('seed-00-'))).toBe(false);
+    expect(files.some((name) => name.includes('seed-01-'))).toBe(true);
+    const newReportFile = files.find((name) => name.includes('r2-type'));
+    expect(newReportFile).toBeDefined();
+    const raw = await fs.readFile(path.join(testDir, newReportFile!), 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect((parsed.error as { message: string }).message).toBe(
+      'R2 oldest-first test error',
+    );
+  });
+
+  // R3: 8 files whose total exceeds the byte budget after one more write
+  it('R3: enforces total-byte budget, deleting oldest to stay under limit', async () => {
+    const content128KiB = 'r'.repeat(131_072);
+    for (let i = 0; i < 8; i++) {
+      await seedReport(testDir, i, content128KiB);
+    }
+
+    await reportError(
+      new Error('R3 byte cap test error'),
+      'R3 base',
+      undefined,
+      'r3-type',
+      testDir,
+    );
+
+    const files = await listMatchingFiles(testDir);
+    expect(files.length).toBe(8);
+    const seed00Name = files.find((f) => f.includes('seed-00-'));
+    expect(seed00Name).toBeUndefined();
+    const totalBytes = await sumMatchingBytes(testDir);
+    expect(totalBytes).toBeLessThanOrEqual(MAX_REPORT_TOTAL_BYTES);
+  });
+
+  it('R3b: does not rotate at exact total-byte equality', async () => {
+    const error = new Error('R3b equality boundary');
+    error.stack = 'R3b stack';
+    const newReport = JSON.stringify({
+      error: { message: error.message, stack: error.stack },
+    });
+    const newReportBytes = Buffer.byteLength(newReport, 'utf8');
+    const seedPath = await seedReport(
+      testDir,
+      0,
+      'e'.repeat(MAX_REPORT_TOTAL_BYTES - newReportBytes),
+    );
+
+    await reportError(error, 'R3b base', undefined, 'r3b-type', testDir);
+
+    const files = await listMatchingFiles(testDir);
+    expect(files.length).toBe(2);
+    expect(files).toContain(path.basename(seedPath));
+    expect(await sumMatchingBytes(testDir)).toBe(MAX_REPORT_TOTAL_BYTES);
+  });
+
+  // R4: Non-matching files survive; directories named like reports excluded
+  it('R4: preserves unrelated files and excludes directories from rotation', async () => {
+    for (let i = 0; i < 20; i++) {
+      await seedReport(testDir, i, `seed-${i}`);
+    }
+    // Unrelated files
+    await fs.writeFile(path.join(testDir, 'unrelated.json'), 'unrelated');
+    await fs.writeFile(
+      path.join(testDir, 'llxprt-client-error-x.json.tmp'),
+      'tmp',
+    );
+    await fs.writeFile(path.join(testDir, 'notes.txt'), 'notes');
+    // Directory named like a report
+    await fs.mkdir(path.join(testDir, 'llxprt-client-error-dir.json'));
+
+    await reportError(
+      new Error('R4 unrelated files test error'),
+      'R4 base',
+      undefined,
+      'r4-type',
+      testDir,
+    );
+
+    const allEntries = await fs.readdir(testDir);
+    const matchingRegularFiles: string[] = [];
+    for (const name of allEntries) {
+      if (!REPORT_FILE_PATTERN.test(name)) continue;
+      const stat = await fs.stat(path.join(testDir, name));
+      if (stat.isFile()) matchingRegularFiles.push(name);
+    }
+    expect(matchingRegularFiles.length).toBe(MAX_REPORT_FILES);
+    // All non-matching entries survive
+    expect(await fs.stat(path.join(testDir, 'unrelated.json'))).toBeDefined();
+    expect(
+      await fs.stat(path.join(testDir, 'llxprt-client-error-x.json.tmp')),
+    ).toBeDefined();
+    expect(await fs.stat(path.join(testDir, 'notes.txt'))).toBeDefined();
+    expect(
+      await fs.stat(path.join(testDir, 'llxprt-client-error-dir.json')),
+    ).toBeDefined();
+  });
+
+  // R6: 3 files under both budgets -> all 4 exist after one more write
+  it('R6: does not rotate when under both budgets', async () => {
+    for (let i = 0; i < 3; i++) {
+      await seedReport(testDir, i, `seed-${i}`);
+    }
+
+    await reportError(
+      new Error('R6 no rotation test error'),
+      'R6 base',
+      undefined,
+      'r6-type',
+      testDir,
+    );
+
+    const files = await listMatchingFiles(testDir);
+    expect(files.length).toBe(4);
+  });
+
+  // R7: Write failure -> no rotation, all seeded files survive
+  it('R7: does not rotate after a failed write', async () => {
+    for (let i = 0; i < 25; i++) {
+      await seedReport(testDir, i, `seed-${i}`);
+    }
+    setSystemTime(new Date('2026-08-07T12:34:56.789Z'));
+    const blockedName =
+      'llxprt-client-error-r7-type-2026-08-07T12-34-56-789Z.json';
+    await fs.mkdir(path.join(testDir, blockedName));
+
+    await reportError(
+      new Error('R7 no rotate on fail test error'),
+      'R7 base',
+      ['R7 context'],
+      'r7-type',
+      testDir,
+    );
+
+    const files = await listMatchingFiles(testDir);
+    expect(files.length).toBe(26);
+    const regularReports = [];
+    for (const name of files) {
+      const stat = await fs.stat(path.join(testDir, name));
+      if (stat.isFile()) {
+        regularReports.push(name);
+      }
+    }
+    expect(regularReports.length).toBe(25);
+    const stderr = stderrCalls.join('');
+    expect(stderr).toContain(
+      'Additionally, failed to write detailed error report:',
+    );
+    expect(stderr).toContain(
+      'Original error that triggered report generation:',
+    );
+    expect(stderr).toContain('Original context:');
+  });
+
+  it('R8: protects an overlapping cohort until a sequential write restores both budgets', async () => {
+    for (let i = 0; i < 5; i++) {
+      await seedReport(testDir, i, `seed-${i}`);
+    }
+    await fs.writeFile(path.join(testDir, 'unrelated.json'), 'unrelated');
+    const largeContext = Object.fromEntries(
+      Array.from({ length: 16 }, (_, i) => [`field-${i}`, 'x'.repeat(4_000)]),
+    );
+    const concurrentTypes = Array.from(
+      { length: 25 },
+      (_, i) => `r8-concurrent-${i}`,
+    );
+
+    await Promise.all(
+      concurrentTypes.map((type) =>
+        reportError(
+          new Error(`R8 concurrent ${type}`),
+          'R8 base',
+          largeContext,
+          type,
+          testDir,
+        ),
+      ),
+    );
+
+    const concurrentFiles = await listMatchingFiles(testDir);
+    for (const type of concurrentTypes) {
+      expect(
+        concurrentFiles.some((name) => name.includes(type)),
+        `${type} should survive every overlapping rotation`,
+      ).toBe(true);
+    }
+    expect(await sumMatchingBytes(testDir)).toBeGreaterThan(
+      MAX_REPORT_TOTAL_BYTES,
+    );
+    expect(await fs.stat(path.join(testDir, 'unrelated.json'))).toBeDefined();
+
+    await reportError(
+      new Error('R8 final sequential'),
+      'R8 base',
+      undefined,
+      'r8-final',
+      testDir,
+    );
+
+    const files = await listMatchingFiles(testDir);
+    expect(files.length).toBeLessThanOrEqual(MAX_REPORT_FILES);
+    expect(await sumMatchingBytes(testDir)).toBeLessThanOrEqual(
+      MAX_REPORT_TOTAL_BYTES,
+    );
+    expect(files.some((name) => name.includes('r8-final'))).toBe(true);
+  });
+});

--- a/packages/core/src/utils/errorReporting.rotation.bun.test.ts
+++ b/packages/core/src/utils/errorReporting.rotation.bun.test.ts
@@ -300,7 +300,9 @@ describe('errorReport rotation (issue 3113)', () => {
     const concurrentFiles = await listMatchingFiles(testDir);
     for (const type of concurrentTypes) {
       expect(
-        concurrentFiles.some((name) => name.includes(type)),
+        concurrentFiles.some((name) =>
+          name.startsWith(`llxprt-client-error-${type}-`),
+        ),
         `${type} should survive every overlapping rotation`,
       ).toBe(true);
     }

--- a/packages/core/src/utils/errorReporting.ts
+++ b/packages/core/src/utils/errorReporting.ts
@@ -7,6 +7,34 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
+import type { Stats } from 'node:fs';
+
+const MAX_REPORT_STRING_CHARS = 4_096;
+const MAX_REPORT_CONTEXT_ENTRIES = 8;
+const MAX_REPORT_BYTES = 131_072;
+const MAX_REPORT_FILES = 20;
+const MAX_REPORT_TOTAL_BYTES = 1_048_576;
+const REPORT_DEDUPE_WINDOW_MS = 60_000;
+const MAX_TRACKED_FINGERPRINTS = 64;
+const FINGERPRINT_ALGORITHM = 'sha256';
+const FINGERPRINT_FIELD_SEPARATOR = '\u0000';
+const REPORT_FILE_PATTERN = /^llxprt-client-error-.*\.json$/;
+
+interface RecentReportEntry {
+  windowStartMs: number;
+  suppressedCount: number;
+  lastReportPath: string;
+}
+
+interface RotationCohort {
+  activeCallers: number;
+  protectedPaths: Set<string>;
+}
+
+const recentReports = new Map<string, RecentReportEntry>();
+const rotationCohorts = new Map<string, RotationCohort>();
 
 function reportToStderr(message: string, ...extras: unknown[]): void {
   const parts = [message, ...extras];
@@ -52,24 +80,306 @@ function normaliseError(error: Error | unknown): {
   return { message: String(error) };
 }
 
-/** Writes a minimal error report (excluding context) as a fallback when context can't be stringified. */
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-1.2
+ * @pseudocode lines 010-014
+ */
+function clampString(value: string): string {
+  if (value.length <= MAX_REPORT_STRING_CHARS) {
+    return value;
+  }
+  return (
+    value.slice(0, MAX_REPORT_STRING_CHARS) +
+    ` [truncated: ${value.length} chars]`
+  );
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-1.2, REQ-3113-2
+ * @pseudocode lines 020-029
+ */
+function stringifyClamped(payload: unknown): string {
+  return JSON.stringify(payload, (_key, value) =>
+    typeof value === 'string' ? clampString(value) : value,
+  );
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-1.2, REQ-3113-1.3, REQ-3113-1.4
+ * @pseudocode lines 040-061
+ */
+function serializeBoundedReport(
+  errorToReport: { message: string; stack?: string },
+  context?: unknown[] | Record<string, unknown>,
+): string {
+  const base: ErrorReportData = { error: errorToReport };
+  if (context) {
+    base.context = context;
+  }
+
+  let text = stringifyClamped(base);
+  if (Buffer.byteLength(text, 'utf8') <= MAX_REPORT_BYTES) {
+    return text;
+  }
+
+  if (Array.isArray(context)) {
+    const kept = context.slice(-MAX_REPORT_CONTEXT_ENTRIES);
+    const omitted = context.length - kept.length;
+    text = stringifyClamped({
+      error: errorToReport,
+      context: kept,
+      contextTruncated: { omittedEntries: omitted },
+    });
+    if (Buffer.byteLength(text, 'utf8') <= MAX_REPORT_BYTES) {
+      return text;
+    }
+  }
+
+  return stringifyClamped({
+    error: errorToReport,
+    contextOmitted: {
+      reason: 'payload-exceeded-limit',
+      serializedBytes: Buffer.byteLength(text, 'utf8'),
+      limitBytes: MAX_REPORT_BYTES,
+    },
+  });
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-4
+ * @pseudocode lines 070-079
+ */
+function buildFingerprint(
+  type: string,
+  baseMessage: string,
+  message: string,
+): string {
+  const digest = createHash(FINGERPRINT_ALGORITHM);
+  for (const component of [type, baseMessage, message]) {
+    const bytes = Buffer.from(component, 'utf8');
+    digest.update(String(bytes.length));
+    digest.update(FINGERPRINT_FIELD_SEPARATOR);
+    digest.update(bytes);
+    digest.update(FINGERPRINT_FIELD_SEPARATOR);
+  }
+  return digest.digest('hex');
+}
+
+interface DuplicateResult {
+  suppressed: boolean;
+  count?: number;
+  lastReportPath?: string;
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-4
+ * @pseudocode lines 080-093
+ */
+function consumeDuplicate(fingerprint: string, nowMs: number): DuplicateResult {
+  const entry = recentReports.get(fingerprint);
+  if (entry === undefined) {
+    return { suppressed: false };
+  }
+  if (nowMs - entry.windowStartMs >= REPORT_DEDUPE_WINDOW_MS) {
+    recentReports.delete(fingerprint);
+    return { suppressed: false };
+  }
+  entry.suppressedCount = entry.suppressedCount + 1;
+  return {
+    suppressed: true,
+    count: entry.suppressedCount,
+    lastReportPath: entry.lastReportPath,
+  };
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-4
+ * @pseudocode lines 100-111
+ */
+function rememberReport(
+  fingerprint: string,
+  nowMs: number,
+  reportPath: string,
+): void {
+  for (const [key, entry] of recentReports) {
+    if (nowMs - entry.windowStartMs >= REPORT_DEDUPE_WINDOW_MS) {
+      recentReports.delete(key);
+    }
+  }
+  while (recentReports.size >= MAX_TRACKED_FINGERPRINTS) {
+    let oldestKey: string | undefined;
+    let oldestMs = Infinity;
+    for (const [key, entry] of recentReports) {
+      if (entry.windowStartMs < oldestMs) {
+        oldestMs = entry.windowStartMs;
+        oldestKey = key;
+      }
+    }
+    if (oldestKey !== undefined) {
+      recentReports.delete(oldestKey);
+    }
+  }
+  recentReports.set(fingerprint, {
+    windowStartMs: nowMs,
+    suppressedCount: 0,
+    lastReportPath: reportPath,
+  });
+}
+
+interface ReportFileEntry {
+  path: string;
+  size: number;
+  mtimeMs: number;
+  name: string;
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-3
+ * @pseudocode lines 120-135
+ */
+async function collectReportFiles(
+  reportingDir: string,
+): Promise<ReportFileEntry[]> {
+  let names: string[];
+  try {
+    names = await fs.readdir(reportingDir);
+  } catch {
+    // A missing or unreadable reporting directory makes rotation a no-op.
+    return [];
+  }
+  const matching = names.filter((name) => REPORT_FILE_PATTERN.test(name));
+  const matched: ReportFileEntry[] = [];
+  for (const name of matching) {
+    const full = path.join(reportingDir, name);
+    let info: Stats;
+    try {
+      info = await fs.stat(full);
+    } catch {
+      // A report may vanish or become unreadable after the directory scan.
+      continue;
+    }
+    if (info.isFile()) {
+      matched.push({
+        path: full,
+        size: info.size,
+        mtimeMs: info.mtimeMs,
+        name,
+      });
+    }
+  }
+  return matched;
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-3
+ * @pseudocode lines 145-148
+ */
+function compareReportAge(a: ReportFileEntry, b: ReportFileEntry): number {
+  const byTime = a.mtimeMs - b.mtimeMs;
+  if (byTime !== 0) return byTime;
+  return a.name < b.name ? -1 : 1;
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-3
+ * @pseudocode lines 140-161
+ */
+async function rotateReports(
+  reportingDir: string,
+  protectedPaths: ReadonlySet<string>,
+): Promise<void> {
+  const entries = await collectReportFiles(reportingDir);
+  let count = entries.length;
+  let total = entries.reduce((sum, e) => sum + e.size, 0);
+  const candidates = entries
+    .filter((e) => !protectedPaths.has(e.path))
+    .sort(compareReportAge);
+
+  while (
+    candidates.length > 0 &&
+    (count > MAX_REPORT_FILES || total > MAX_REPORT_TOTAL_BYTES)
+  ) {
+    const victim = candidates[0];
+    candidates.splice(0, 1);
+    try {
+      await fs.unlink(victim.path);
+    } catch {
+      // Rotation is best-effort because files can change between stat and unlink.
+    }
+    count -= 1;
+    total -= victim.size;
+  }
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-3
+ * @pseudocode lines 140-161
+ */
+function joinRotationCohort(
+  reportingDir: string,
+  reportPath: string,
+): RotationCohort {
+  let cohort = rotationCohorts.get(reportingDir);
+  if (cohort === undefined) {
+    cohort = { activeCallers: 0, protectedPaths: new Set<string>() };
+    rotationCohorts.set(reportingDir, cohort);
+  }
+  cohort.activeCallers += 1;
+  cohort.protectedPaths.add(reportPath);
+  return cohort;
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-3
+ * @pseudocode lines 140-161
+ */
+function leaveRotationCohort(
+  reportingDir: string,
+  cohort: RotationCohort,
+): void {
+  cohort.activeCallers -= 1;
+  if (
+    cohort.activeCallers === 0 &&
+    rotationCohorts.get(reportingDir) === cohort
+  ) {
+    rotationCohorts.delete(reportingDir);
+  }
+}
+
+/**
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-2, REQ-3113-5
+ * @pseudocode lines 170-182
+ */
 async function writeMinimalReport(
   errorToReport: { message: string; stack?: string },
   baseMessage: string,
   reportPath: string,
-): Promise<void> {
+): Promise<boolean> {
   try {
-    const minimalReportContent = { error: errorToReport };
-    const stringifiedContent = JSON.stringify(minimalReportContent, null, 2);
-    await fs.writeFile(reportPath, stringifiedContent);
+    const content = stringifyClamped({ error: errorToReport });
+    await fs.writeFile(reportPath, content);
     reportToStderr(
       `${baseMessage} Partial report (excluding context) available at: ${reportPath}`,
     );
+    return true;
   } catch (minimalWriteError) {
     reportToStderr(
       `${baseMessage} Failed to write even a minimal error report:`,
       minimalWriteError,
     );
+    return false;
   }
 }
 
@@ -79,58 +389,89 @@ async function writeMinimalReport(
  * @param context The relevant context (e.g., chat history, request contents).
  * @param type A string to identify the type of error (e.g., 'startChat', 'generateJson-api').
  * @param baseMessage The initial message to log to console.error before the report path.
+ * @plan PLAN-20260807-ISSUE3113.P05
+ * @requirement REQ-3113-1.2, REQ-3113-1.3, REQ-3113-1.4, REQ-3113-2, REQ-3113-3, REQ-3113-4, REQ-3113-5
+ * @pseudocode lines 190-240
  */
 export async function reportError(
   error: Error | unknown,
   baseMessage: string,
   context?: unknown[] | Record<string, unknown>,
   type = 'general',
-  reportingDir = os.tmpdir(), // for testing
+  reportingDir = os.tmpdir(),
 ): Promise<void> {
+  const errorToReport = normaliseError(error);
+  const fingerprint = buildFingerprint(
+    type,
+    baseMessage,
+    errorToReport.message,
+  );
+  const nowMs = Date.now();
+  const duplicate = consumeDuplicate(fingerprint, nowMs);
+  if (duplicate.suppressed) {
+    reportToStderr(
+      `${baseMessage} Duplicate error report suppressed (${duplicate.count} within ${REPORT_DEDUPE_WINDOW_MS / 1000}s). Previous report: ${duplicate.lastReportPath}`,
+    );
+    return;
+  }
+
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const reportFileName = `llxprt-client-error-${type}-${timestamp}.json`;
   const reportPath = path.join(reportingDir, reportFileName);
 
-  const errorToReport = normaliseError(error);
-
-  const reportContent: ErrorReportData = { error: errorToReport };
-
-  if (context) {
-    reportContent.context = context;
-  }
-
   let stringifiedReportContent: string;
   try {
-    stringifiedReportContent = JSON.stringify(reportContent, null, 2);
+    stringifiedReportContent = serializeBoundedReport(errorToReport, context);
   } catch (stringifyError) {
-    // This can happen if context contains something like BigInt
     reportToStderr(
       `${baseMessage} Could not stringify report content (likely due to context):`,
       stringifyError,
     );
     reportToStderr('Original error that triggered report generation:', error);
-    if (context) {
+    if (context !== undefined) {
       reportToStderr(
         'Original context could not be stringified or included in report.',
       );
     }
-    await writeMinimalReport(errorToReport, baseMessage, reportPath);
+    const cohort = joinRotationCohort(reportingDir, reportPath);
+    try {
+      const written = await writeMinimalReport(
+        errorToReport,
+        baseMessage,
+        reportPath,
+      );
+      if (written) {
+        rememberReport(fingerprint, nowMs, reportPath);
+        await rotateReports(reportingDir, cohort.protectedPaths);
+      }
+    } finally {
+      leaveRotationCohort(reportingDir, cohort);
+    }
     return;
   }
 
+  const cohort = joinRotationCohort(reportingDir, reportPath);
   try {
     await fs.writeFile(reportPath, stringifiedReportContent);
-    reportToStderr(`${baseMessage} Full report available at: ${reportPath}`);
   } catch (writeError) {
     reportToStderr(
       `${baseMessage} Additionally, failed to write detailed error report:`,
       writeError,
     );
-    // Log the original error as a fallback if report writing fails
     reportToStderr('Original error that triggered report generation:', error);
-    if (context) {
+    if (context !== undefined) {
       logContextFallback(context);
     }
+    leaveRotationCohort(reportingDir, cohort);
+    return;
+  }
+
+  try {
+    reportToStderr(`${baseMessage} Full report available at: ${reportPath}`);
+    rememberReport(fingerprint, nowMs, reportPath);
+    await rotateReports(reportingDir, cohort.protectedPaths);
+  } finally {
+    leaveRotationCohort(reportingDir, cohort);
   }
 }
 

--- a/project-plans/issue3113/plan.md
+++ b/project-plans/issue3113/plan.md
@@ -1,0 +1,295 @@
+# Execution Plan — issue #3113
+
+Plan ID: PLAN-20260807-ISSUE3113
+Generated: 2026-08-07
+Branch: `issue3113`
+Base commit: `2ae245b8d`
+
+Artifacts: [`specification.md`](./specification.md) ·
+[`preflight-verification.md`](./preflight-verification.md) ·
+[`pseudocode.md`](./pseudocode.md) ·
+[`test-matrix.md`](./test-matrix.md)
+
+Preflight gate: **PASSED**, no blocking issues (`preflight-verification.md`
+section 7).
+
+---
+
+## Scope, in one paragraph
+
+`packages/core/src/utils/errorReporting.ts` gains a bounded serialization
+pipeline, compact output, oldest-first rotation under a count and total-byte
+budget, and fixed-window duplicate coalescing — all module-private, with its
+public signature, filename format, and both fallbacks preserved.
+`packages/agents/src/core/turn.ts` stops concatenating the request onto the full
+curated history and instead passes `{ request, recentHistory, omittedHistoryCount }`
+with an 8-entry tail. Nothing else changes.
+
+---
+
+## Phases
+
+Phases run in order. A phase may not start until the previous one is verified.
+
+### P01 — RED: core bounding, compact output, and preserved contract
+
+Create `packages/core/src/utils/errorReporting.bounding.bun.test.ts` importing
+`describe`, `it`, `expect`, `beforeEach`, `afterEach`, `spyOn` from `bun:test`.
+Implement matrix rows **B1-B13**. One temp-dir lifecycle for the file.
+
+Run and record output. Rows marked RED must fail; rows marked GUARD must pass.
+
+```bash
+cd packages/core && bun test src/utils/errorReporting.bounding.bun.test.ts
+```
+
+**Gate:** every RED row observed failing, with the failure message captured into
+`## RED evidence` below. A RED row that passes means the test does not actually
+exercise the accepted behavior — fix the test, do not proceed.
+
+### P02 — RED: rotation
+
+Create `packages/core/src/utils/errorReporting.rotation.bun.test.ts`. Implement
+rows **R1, R2, R3, R4, R6, R7, R8**. Seed pre-existing reports directly with
+`fs.writeFile` using zero-padded ordinals. Same gate as P01.
+
+### P03 — RED: duplicate coalescing
+
+Create `packages/core/src/utils/errorReporting.dedupe.bun.test.ts` importing
+`setSystemTime` directly from `bun:test`; reset it in `afterEach`. Implement
+rows **D1-D11**, observing the mandatory clock discipline in `test-matrix.md`:
+pin `t0` in `beforeEach` and advance the clock through the single `advanceTo`
+helper before every subsequent `reportError` call into the same directory.
+
+Two incidental-pass traps are in force in this phase and the gate below checks
+both:
+
+- Without a clock advance, two same-millisecond writes of one `type` collapse
+  onto one path on the base commit, so D1 and D7 would pass with no
+  deduplication at all.
+- With rotation capping the directory at `MAX_REPORT_FILES`, a file-count
+  assertion proves nothing about the registry, which is why D9 asserts
+  observable suppression instead.
+
+**Gate:** as P01, plus an explicit check that D1, D7, and D9 fail on the base
+commit for the stated reason and not for a filename collision — the recorded
+failure message must show the *two distinct advanced filenames* (D1, D7) or the
+`Full report available at:` line where `Duplicate error report suppressed` was
+expected (D9).
+
+### P04 — RED: Turn payload, end to end
+
+Create `packages/agents/src/core/turn.errorReport.bun.test.ts` importing from
+`bun:test` directly. Real `Turn`, real core `reportError`, `ChatSession`
+fixture, `process.env.TMPDIR` redirected to a `mkdtemp` directory and restored
+in `afterEach`. Compare against `fs.realpath` of that directory when asserting
+paths, because `os.tmpdir()` returns `TMPDIR` verbatim. Implement rows
+**T1-T8**.
+
+```bash
+cd packages/agents && bun test src/core/turn.errorReport.bun.test.ts
+```
+
+Same gate as P01.
+
+### P05 — Implement the core writer
+
+Modify `packages/core/src/utils/errorReporting.ts` only, following
+`pseudocode.md` component 1 line by line. Each helper carries
+`@plan PLAN-20260807-ISSUE3113.P05`, its `@requirement`, and its `@pseudocode`
+line range.
+
+Order of work, each step keeping the file compiling:
+
+1. Add the `node:buffer` and `node:crypto` imports and the module-private constants (constants block). Both are Node built-ins already used in `packages/core`; neither is a dependency or a public abstraction.
+2. `clampString`, `stringifyClamped` (lines 010-029) — REQ-3113-1.2, REQ-3113-2.
+3. `serializeBoundedReport` (lines 040-061) — REQ-3113-1.2/1.3/1.4.
+4. `buildFingerprint` (lines 070-079, fixed-size SHA-256 over the complete framed components — no slice), `consumeDuplicate`, `rememberReport` (lines 080-111) — REQ-3113-4.
+5. `collectReportFiles`, `rotateReports` (lines 120-161) — REQ-3113-3.
+6. `writeMinimalReport` returns `boolean` and emits compact JSON (lines 170-182).
+7. Rewire `reportError` (lines 190-240).
+
+Constraints enforced while writing, not afterwards: no export beyond
+`reportError`; no `JSON.stringify` call before pseudocode line 209 (the digest
+adds none); the fingerprint is never sliced, truncated, or built by
+concatenating its components into one string; helpers each well under
+`max-lines-per-function: 80`; swallowing uses `} catch {` with a justifying
+comment; no suppression directive of any kind.
+
+```bash
+cd packages/core && bun test src/utils/errorReporting.bounding.bun.test.ts \
+  src/utils/errorReporting.rotation.bun.test.ts \
+  src/utils/errorReporting.dedupe.bun.test.ts src/utils/errorReporting.test.ts
+```
+
+**Gate:** all four files green, including the **unmodified** Vitest-importing
+`errorReporting.test.ts`. `git diff --stat` shows `errorReporting.test.ts` with
+zero changes.
+
+### P06 — Implement the Turn caller
+
+Modify `packages/agents/src/core/turn.ts` only: add the module-private
+`TURN_REPORT_HISTORY_TAIL = 8` and replace lines 588-594 per `pseudocode.md`
+component 2 (lines 300-322). Delete the superseded assertion at
+`packages/agents/src/core/turn.test.ts:298-303` — deletion only; no other line
+of that file changes and its framework import is untouched.
+
+```bash
+cd packages/agents && bun test src/core/turn.errorReport.bun.test.ts src/core/turn.test.ts
+```
+
+**Gate:** both green. `git diff packages/agents/src/core/turn.test.ts` shows only
+removed lines.
+
+### P07 — Full verification
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Plus the defect-closure check — run a real session that provokes a provider
+error and confirm the reporting directory stays inside both budgets:
+
+```bash
+T=$(node -p 'require("os").tmpdir()')
+find "$T" -maxdepth 1 -name 'llxprt-client-error-*.json' -type f -exec stat -f '%z' {} + \
+  | awk '{s+=$1; n++} END {printf "count=%d total_bytes=%d\n", n, s}'
+# Expected after the change, for reports written by the new build:
+#   count <= 20 and total_bytes <= 1048576
+```
+
+Note: the ~4,380 files already on disk predate the fix. Move them aside before
+measuring; migrating existing accumulation is **Defer** (rubric section below).
+
+**Gate:** all commands exit 0; no new lint warning (`lint:ci` runs
+`--max-warnings 0`).
+
+### P08 — Review
+
+1. DeepThinker review for issue intent and specification compliance.
+2. Open Code Review, detached, with test files included:
+
+```bash
+nohup ocr review --audience agent --timeout 20 > /tmp/ocr_review_3113.log 2>&1 & echo PID=$!
+```
+
+Poll the log and the PID until the process exits. Do not run it in the
+foreground. If stdout is lost, recover findings from
+`~/.opencodereview/sessions/*/*.jsonl` by grepping for `code_comment`.
+
+3. Triage every finding with the rubric below, then re-run P07.
+
+### P09 — PR and CI
+
+Push, open the PR with `gh` including `Fixes #3113`, then watch CI with a
+5-minute interval and a tool timeout comfortably above it. Triage CodeRabbit
+findings with the same rubric, fix, re-verify, push, and watch again until every
+check is green and every required thread is resolved. Do not merge; report status
+and wait for explicit confirmation.
+
+---
+
+## Requirement -> evidence map
+
+| Requirement | Production change | Behavioral evidence |
+|---|---|---|
+| REQ-3113-1.1 Turn separates request from bounded tail | `turn.ts` lines 300-322 of pseudocode | T1, T2, T3, T4 |
+| REQ-3113-1.2 Per-string clamp | `clampString` / `stringifyClamped` | B3, B4, B9 |
+| REQ-3113-1.3 Array-context tail clamp | `serializeBoundedReport` S3 | B5, B5b |
+| REQ-3113-1.4 Hard payload cap | `serializeBoundedReport` S4 | B6, B7, B8, T5 |
+| REQ-3113-2 Compact JSON | both `JSON.stringify` sites | B1, B2, T6 |
+| REQ-3113-3 Rotation | `collectReportFiles` / `rotateReports` | R1, R2, R3, R4, R6, R7, R8 |
+| REQ-3113-4 Coalescing | `buildFingerprint` / `consumeDuplicate` / `rememberReport` | D1-D11 (D9 registry bound, D10 eviction direction, D11 no truncation collision) |
+| REQ-3113-5 Preserved contract | signature, filename, both fallbacks untouched | B10, B11, B12, B13, T7, T8, and `errorReporting.test.ts` unmodified and green |
+
+---
+
+## RED evidence
+
+Filled in during P01-P04, before any production edit. Each entry records the
+test ID and the observed failure against the base commit.
+
+| Test ID | Observed failure on base commit |
+|---|---|
+| B1 | `expect(raw.includes('
+')).toBe(false)` — Received: true (pretty-printed) |
+| B2 | `expect(raw.includes('
+')).toBe(false)` — Received: true (minimal report pretty-printed) |
+| B3 | `context.blob.endsWith(expectedMarker)` — Received: false (no clamping; full 10k chars stored) |
+| B5 | `expect(context.length).toBe(8)` — Received: 200 (no array tail clamp) |
+| B5b | `expect(stat.size).toBeLessThanOrEqual(131072)` — Received: 610151 |
+| B6 | `expect(stat.size).toBeLessThanOrEqual(131072)` — Received: 32156957 |
+| B7 | `expect(stat.size).toBeLessThanOrEqual(131072)` — Received: 803759 |
+| B9 | `err.stack.endsWith(expectedMarker)` — Received: false (stack not clamped) |
+| R1 | `expect(files.length).toBe(20)` — Received: 21 (no rotation) |
+| R2 | `seed00Name` expected undefined — Received: "llxprt-client-error-seed-00-..." (oldest not deleted) |
+| R3 | `seed00Name` expected undefined — Received: "llxprt-client-error-seed-00-..." (byte cap not enforced) |
+| R4 | `expect(files.length).toBe(20)` — Received: 22 (no rotation; dir not excluded) |
+| R8 | `expect(files.length).toBeLessThanOrEqual(20)` — Received: 31 (no rotation) |
+| D1 | `expect(filesAfterSecond.length).toBe(1)` — Received: 2 (two distinct filenames T00-00-00-000Z and T00-00-01-000Z) |
+| D5 | `expect(after59999.length).toBe(1)` — Received: 2 (no dedupe) |
+| D6 | `expect((await listMatchingFiles()).length).toBe(1)` — Received: 2 (no fixed window) |
+| D7 | `expect(files.length).toBe(1)` — Received: 2 (suppressed call writes new file) |
+| D9 | `expectStderrContaining('Duplicate error report suppressed')` — false (no registry; stderr shows `Full report available at:` instead) |
+| T1 | `report.recentHistory` is undefined — context is flat 26-element array |
+| T2 | `report.request` is undefined — request is last element of flat array |
+| T3 | `report.recentHistory` is undefined — context is `[reqParts]` |
+| T4 | `report.recentHistory` is undefined — context is flat 4-element array |
+| T5 | `expect(stat.size).toBeLessThanOrEqual(131072)` — Received: 4026692 (unbounded context) |
+| T6 | `raw.includes('
+')` — Received: true (pretty-printed) |
+
+GUARD rows passing: B4, B8, B10, B11, B12, B13, R6, R7, D2, D3, D4, D8, D10, D11, T7, T8.
+
+An implementation phase may not begin until this table covers every RED row in
+`test-matrix.md`.
+
+---
+
+## Review-finding triage rubric
+
+Every finding from Open Code Review, DeepThinker, CodeRabbit, or a human
+reviewer is labeled with **exactly one** category, recorded with a one-line
+reason.
+
+| Category | Definition | Action |
+|---|---|---|
+| **Blocker-Fix** | An accepted behavior (REQ-3113-1..5) is not met, a preserved contract is broken, a test is non-behavioral or would pass against unchanged code, a prohibited construct was introduced (`eslint-disable`, `@ts-ignore`/`@ts-expect-error`/`@ts-nocheck`, severity downgrade, ignore-file addition, threshold increase), or verification/CI fails. | Fix before push or merge. Non-negotiable. |
+| **In-scope-Fix** | Correct and inside issue #3113's four behaviors: a wrong constant, non-deterministic ordering, a residual unbounded path, a missing boundary test, a misleading name or comment in the changed code. | Fix in this PR. |
+| **Reject** | Factually wrong, or contradicts a recorded decision — for example "add a setting for full-history capture", "use a sliding window", "add age-based expiry", "truncate the fingerprint instead of hashing it", "`node:crypto` is a new dependency", "also fix the MCP `reportError`", "export the constants so tests can import them". | Reply citing the deciding section of `specification.md`. No code change. |
+| **Defer** | Legitimate but outside issue #3113: the pre-existing filename collision when two distinct errors land in the same millisecond (worked around in tests by clock advancement, not fixed here), a retention/redaction policy for sensitive report content, telemetry for suppressed reports, cleanup of the ~4,380 files already accumulated on developer machines. | File a follow-up issue, link it in the PR thread. No code change here. |
+
+Cap: at most two local OCR passes and two PR OCR passes.
+
+---
+
+## Completion conditions
+
+- Every accepted behavior has direct behavioral evidence, and every RED row was
+  observed failing before the corresponding production edit **for the reason the
+  row states** — not because two writes collided on one millisecond-resolution
+  filename, and not because rotation held a file count constant.
+- The fingerprint is a fixed-size digest over the complete `type`,
+  `baseMessage`, and normalized message; no code path truncates it or its
+  inputs, and D11 demonstrates that two messages differing only after character
+  512 are not coalesced.
+- `packages/core/src/utils/errorReporting.test.ts` is byte-identical to the base
+  commit and still green.
+- `reportError`'s signature, filename format, and both fallbacks are unchanged.
+- No dependency, setting, workflow, agent memory, quality-tool change, public
+  abstraction, unrelated refactor, suppression directive, or threshold change was
+  introduced. `package.json` and the lockfile are untouched: the only additions
+  are the Node built-ins `node:buffer` and `node:crypto`.
+- `packages/agents/src/core/turn.test.ts` is changed by deletion only.
+- Full local verification passes on the candidate head.
+- Reviews are complete and every finding is triaged into exactly one rubric
+  category, with all Blocker-Fix and In-scope-Fix findings resolved.
+- CI is green on the candidate head, required threads are resolved, ancestry is
+  current, and the PR is conflict-free.
+- Merge is **not** performed; status is reported and explicit confirmation is
+  awaited.

--- a/project-plans/issue3113/preflight-verification.md
+++ b/project-plans/issue3113/preflight-verification.md
@@ -1,0 +1,214 @@
+# Preflight Verification — issue #3113
+
+Plan ID: PLAN-20260807-ISSUE3113
+Performed: 2026-08-07
+Branch: `issue3113` (verified with `git branch --show-current`)
+Base commit: `2ae245b8d`
+
+Every assumption in `specification.md` and `pseudocode.md` is verified here
+against the actual repository. No implementation was performed.
+
+---
+
+## 1. Defect reproduction (live)
+
+```bash
+T=$(node -p 'require("os").tmpdir()')
+find "$T" -maxdepth 1 -name 'llxprt-client-error-*.json' -type f -exec stat -f '%z %m %N' {} + \
+  | awk '{s+=$1; n++; if($1>m)m=$1} END {printf "count=%d total_bytes=%d largest=%d\n", n, s, m}'
+```
+
+Observed:
+
+```
+count=4380 total_bytes=57597083 largest=11421098      (54.9 MB; largest report 10.9 MB)
+by type:  4076 Turn.run-sendMessageStream
+           301 generateJson-api
+             3 startChat
+```
+
+Matches and exceeds the issue's reported 3,565 files / 62 MB. Defect confirmed
+present on the base commit. Status: **CONFIRMED**.
+
+---
+
+## 2. Production call sites
+
+| Assumption | Evidence | Status |
+|---|---|---|
+| `reportError` is exported only from `packages/core/src/utils/errorReporting.ts` | `errorReporting.ts:83` `export async function reportError(` | OK |
+| Signature is `(error, baseMessage, context?, type='general', reportingDir=os.tmpdir())` | `errorReporting.ts:83-89`; mirrored in `packages/core/dist/src/utils/errorReporting.d.ts:13` | OK |
+| It is the only export of the module | `grep -n "^export" packages/core/src/utils/errorReporting.ts` -> one hit | OK |
+| Subpath export exists for cross-package import | `packages/core/package.json:490-493` `"./utils/errorReporting.js"` with `bun` -> `./src/utils/errorReporting.ts` | OK |
+| Pretty-printing at both sites | `errorReporting.ts:60` and `:100` both pass `null, 2` | OK |
+| Filename construction | `errorReporting.ts:84-86` | OK |
+| No rotation/cleanup anywhere | `grep -rn "llxprt-client-error" packages --include=*.ts` -> only the writer and its test | OK |
+
+### Core-`reportError` callers (complete)
+
+| Caller | Line | `type` | Context shape today |
+|---|---|---|---|
+| `packages/agents/src/core/turn.ts` | 589 | `Turn.run-sendMessageStream` | `[...getHistory(true), req]` — array, unbounded |
+| `packages/agents/src/agents/executor.ts` | 753 | `startChat` | `startHistory` — array |
+| `packages/agents/src/core/ChatSessionFactory.ts` | 428 | `startChat` | `deps.extraHistory ?? []` — array |
+| `packages/agents/src/core/subagentRuntimeSetup.ts` | 865 | `startChat` | `startHistory` — array (fire-and-forget `void`) |
+| `packages/agents/src/core/clientLlmUtilities.ts` | 119 | `generateJson-api` | `contents` — array |
+| `packages/agents/src/core/clientLlmUtilities.ts` | 178 | `generateContent-api` | `{ requestContents, requestConfig }` — object |
+
+Only `turn.ts` conflates request and history, so only `turn.ts` changes
+(REQ-3113-1.1). Status: **OK**.
+
+### Out-of-scope same-name helpers (confirmed unrelated)
+
+| Location | Nature | Evidence |
+|---|---|---|
+| `packages/mcp/src/client/mcp-client-manager-helpers.ts:85,150,263` | Injected callback parameter `(error: unknown) => void` / `(message, error) => void` | Supplied at `mcp-client-manager.ts:339,782,944`; no import of the core module |
+| `packages/cli/src/ui/hooks/usePermissionsTrustDialogFlow.ts:43` | Local `function reportError(addItem, message)` | Local declaration |
+| `packages/cli/src/config/extensions/extensionLoader.ts:44` | `deps.reportError: (message: string) => void` | Interface member |
+| `packages/cli/src/session/nonInteractiveSession.ts:32` | `catch (reportError)` — a catch binding | Not a function |
+
+Status: **OK — out of scope, no shared code.**
+
+---
+
+## 3. Type verification
+
+| Type | Expected | Actual | Match |
+|---|---|---|---|
+| `ErrorReportData` | `{ error, context?, additionalInfo? }` | `errorReporting.ts:34-38` — exactly that, module-private | YES |
+| `normaliseError` return | `{ message: string; stack?: string }` | `errorReporting.ts:40-43` | YES |
+| `TurnRequest` | `string \| object \| readonly unknown[]` | `turn.ts:72` | YES |
+| `ChatSession.getHistory` | `(curated?: boolean) => IContent[]` | `chatSession.ts:565-567` | YES |
+| `context` parameter accepts an object literal | `unknown[] \| Record<string, unknown>` — a fresh object literal `{ request, recentHistory, omittedHistoryCount }` is assignable to `Record<string, unknown>` | `errorReporting.ts:86` | YES |
+| `Buffer.byteLength` available | `node:buffer` is a builtin in both Node and Bun; the file already imports `node:fs/promises`, `node:os`, `node:path` | — | YES |
+| `createHash` available and already used in `packages/core` | `node:crypto` is a builtin in both Node and Bun; `packages/core/src/services/loopDetectionService.ts:7`, `utils/llm-edit-fixer.ts:7`, and `prompt-config/installer/manifest-operations.ts:11` already `import { createHash } from 'node:crypto'` | — | YES |
+
+### Fingerprint digest probe (executed on Bun 1.3.14)
+
+The framed, incremental SHA-256 fingerprint of `pseudocode.md` lines 070-079 was
+executed directly, alongside the rejected 512-character truncated concatenation,
+on a pair of messages sharing a 1,024-character prefix:
+
+```json
+{
+  "runtime": "bun 1.3.14",
+  "lenA": 64,
+  "distinct": true,
+  "stable": true,
+  "truncatedWouldCollide": true,
+  "framingInjective": true,
+  "nulSafe": true
+}
+```
+
+| Observation | Meaning | Status |
+|---|---|---|
+| `lenA = 64` | The key is fixed-size hex regardless of input length; the registry bound in `specification.md` section 8 is exact | OK |
+| `distinct = true` | Messages differing only after character 512 produce different fingerprints, so the second failure is reported, not suppressed | OK |
+| `truncatedWouldCollide = true` | The rejected 512-character slice **does** collide on the same pair, silently suppressing a distinct real failure. This is the measured justification for replacing it | OK — rejected design falsified |
+| `stable = true` | Equal inputs produce an equal digest, so genuine duplicates still coalesce | OK |
+| `framingInjective = true` | `('ab','c','x')` and `('a','bc','x')` differ: the length-prefixed framing is not re-splittable | OK |
+| `nulSafe = true` | A component containing U+0000 does not alias a different component split | OK |
+
+Status: **OK**.
+
+---
+
+## 4. Test infrastructure
+
+| Assumption | Evidence | Status |
+|---|---|---|
+| `packages/core` runs its suite under Bun | `packages/core/package.json` `"test": "bun run-bun-tests.ts"` | OK |
+| Core runs **one process per test file** | `packages/core/run-bun-tests.ts` header + `['test', '--preload', PRELOAD, file]` at line 99 | OK — module-level dedupe state cannot leak across files |
+| Core discovers `*.bun.test.ts` | `run-bun-tests.ts:58-62` matches any `.test.ts` suffix; `packages/core/src/services/shellPtySignal.bun.test.ts` already exists and runs | OK |
+| Core preloads the `vi` augmentation | `packages/core/bunfig.toml` -> `preload = ["../../test-setup/augment-bun-vi.ts", "./bun-preload.ts"]` | OK |
+| 21 core test files already import `bun:test` directly | `grep -rln "from 'bun:test'" packages/core/src \| wc -l` -> 21 | OK — established convention |
+| `packages/agents` runs under Bun, one process per file | `packages/agents/package.json` `"test": "bun run-bun-tests.ts && bun ../../scripts/run_bun_tests.ts --workspace agents"`; `packages/agents/run-bun-tests.ts:52` `TEST_ROOTS = ['src']` | OK |
+| Agents already has a direct-`bun:test` file under `src/core` | `packages/agents/src/core/streamOutputAccumulator.bun.test.ts:25` `import { describe, it, expect } from 'bun:test';` | OK — precedent for the new file's name and imports |
+| `setSystemTime` is importable from `bun:test` and moves `Date.now()` | Probe executed on Bun 1.3.14: set, re-set +61 s, and restore all observed; `1 pass 0 fail` | OK |
+| **A frozen clock makes two identical writes collapse onto one path on the base commit** | Probe against the unmodified `reportError`: clock pinned at `2026-08-07T00:00:00.000Z`, two identical calls with one `type` into one `mkdtemp` dir -> `SAME_MS_FILE_COUNT=1`, single file `llxprt-client-error-probe-type-2026-08-07T00-00-00-000Z.json`, and stderr showed the **same** path twice | **OK — hazard confirmed.** A "exactly one report file exists" duplicate assertion would pass against unchanged code. Every dedupe test must advance the clock (`test-matrix.md`, "Clock discipline"). |
+| `setSystemTime` also moves the report **filename**, not just `Date.now()` | Same probe, second case: advancing `+1_000` ms between the two identical calls produced `ADVANCED_FILE_COUNT=2` with `...T00-00-00-000Z.json` and `...T00-00-01-000Z.json` | OK — clock advancement yields genuinely distinct paths, so the duplicate rows are RED for the right reason |
+| Rotation would pin a file count regardless of deduplication | `MAX_REPORT_FILES = 20`; once a directory is at the cap, "the matching file count is unchanged" holds whether or not a duplicate was suppressed | **OK — hazard confirmed.** The registry-bound row (D9) asserts observable suppression (stderr line with the original path, unchanged original bytes, unchanged listing **set**) rather than a count. |
+| `os.tmpdir()` honors `TMPDIR` **at call time** under Bun on darwin | Probe: `before=/var/folders/.../T`, after setting `TMPDIR`, `after=/tmp/llxprt-probe-dir`, `honored=true` | OK — enables the end-to-end Turn->disk test with no mocking of `reportError` |
+| `turn.test.ts` runs under Bun | `packages/agents/src/core/turn.test.ts:7` imports from `'../testApi.js'`, which re-exports `bun:test` (`packages/agents/src/testApi.ts:46-58`) | OK — it does **not** import Vitest |
+| `turn.test.ts` has no `.rejects`/`.resolves` coupling | `grep -c "\.rejects\|\.resolves"` -> 0; `vi.mock` count -> 1 | OK |
+
+Status: **OK**.
+
+---
+
+## 5. Quality-gate headroom
+
+| Gate | Threshold | Current state | Status |
+|---|---|---|---|
+| ESLint on the two target files | — | `npx eslint packages/core/src/utils/errorReporting.ts packages/agents/src/core/turn.ts` -> exit 0, no output | OK (clean baseline) |
+| `max-lines` | 800 (blank/comment-skipped) | `errorReporting.ts` 156 raw lines; `turn.ts` 912 raw lines and currently passing | OK — `turn.ts` gains only a few lines; `errorReporting.ts` has large headroom |
+| `max-lines-per-function` | 80 (blank/comment-skipped) | New helpers are each far under 80; `reportError` is decomposed rather than grown | OK — enforced by design, verified at implementation |
+| `complexity` | 25 | Each new helper is single-purpose | OK |
+| `sonarjs/cognitive-complexity` | 30 | Same | OK |
+| `sonarjs/no-ignored-exceptions` | error | Existing file already uses `} catch {` with no binding (`errorReporting.ts:16`); rotation reuses that exact form | OK |
+| Doc placement | `project-plans/` only | `scripts/check-doc-placement.ts` bans `dev-docs/plans/`; all artifacts written to `project-plans/issue3113/` | OK |
+| `no-restricted-imports` on `node:crypto` | — | The only Node-builtin import restriction in `eslint.config.js` targets `packages/cli/src/ui/components/shared/*` domain modules and bans `node:fs`/`node:child_process`/`node:os`. `packages/core/src/utils/errorReporting.ts` is outside that glob and already imports `node:fs/promises` and `node:os` with a clean ESLint baseline. | OK |
+
+Status: **OK**.
+
+---
+
+## 6. Existing-test compatibility gate
+
+`packages/core/src/utils/errorReporting.test.ts` imports Vitest and **must not
+be modified**. All six of its cases were audited line by line against the new
+design in `specification.md` section 10. Two facts make the audit hold:
+
+1. Each case creates its own `fs.mkdtemp` directory, so rotation never sees more
+   than one report and deletes nothing.
+2. All six error messages are distinct (`Test error`, `Test plain object error`,
+   `Just a string error`, `Main error` x2 with distinct `type`, `Error without
+   context`), so the fingerprint registry never suppresses a case.
+
+The one genuinely fragile case is the BigInt case, which mocks `JSON.stringify`
+and throws on **call #1**. The design guarantees the first `JSON.stringify` call
+inside `reportError` remains the main-payload serialization: fingerprinting is
+string concatenation and rotation performs no serialization.
+
+Status: **OK — no modification required, no case at risk.**
+
+---
+
+## 7. Blocking issues found
+
+**None.** Every dependency is a Node builtin (`node:buffer` and `node:crypto`
+are the two additions, both already used elsewhere in `packages/core`), every
+type matches the plan, every call path exists, both test runners provide
+per-file process isolation, and all required Bun capabilities (`setSystemTime`
+over both `Date.now()` and the report filename, call-time `TMPDIR` resolution,
+`createHash`) were executed and observed.
+
+Two **false-pass hazards** were found and are recorded rather than deferred,
+because each would have produced test evidence that proved nothing:
+
+1. Same-millisecond writes collapse onto one report path, so a duplicate
+   assertion could pass against unchanged code. Neutralized by the mandatory
+   clock discipline in `test-matrix.md`.
+2. Rotation holds the matching-file count at `MAX_REPORT_FILES`, so a
+   count-based registry assertion could pass without any suppression.
+   Neutralized by asserting observable suppression in D9.
+
+Neither is a code defect in the plan's scope; the underlying millisecond
+filename collision remains **Defer** (the filename format is frozen by
+REQ-3113-5).
+
+## 8. Verification gate
+
+- [x] All dependencies verified (no new dependency required; `node:buffer` and
+      `node:crypto` are Node builtins with existing `packages/core` precedent)
+- [x] All types match plan assumptions
+- [x] All call paths verified against actual source lines
+- [x] Test infrastructure verified, including per-file process isolation
+- [x] Defect reproduced on the base commit with measurements
+- [x] Unmodifiable existing test audited case by case
+- [x] Quality-gate headroom confirmed with a clean ESLint baseline
+- [x] Fingerprint design measured: fixed-size digest distinguishes the pair that
+      the rejected truncated key collides on
+- [x] Both false-pass hazards measured against the base commit and neutralized
+      in the test matrix

--- a/project-plans/issue3113/pseudocode.md
+++ b/project-plans/issue3113/pseudocode.md
@@ -1,0 +1,442 @@
+# Numbered Pseudocode — issue #3113
+
+Plan ID: PLAN-20260807-ISSUE3113
+Generated: 2026-08-07
+
+Implementation MUST cite these line numbers in `@pseudocode` markers. This is
+pseudocode, not TypeScript; no line may be copied verbatim as code.
+
+---
+
+## Contracts
+
+### Inputs (unchanged public contract)
+
+```
+reportError(
+  error:        Error | unknown
+  baseMessage:  string
+  context?:     unknown[] | Record<string, unknown>
+  type:         string = 'general'
+  reportingDir: string = os.tmpdir()
+) -> Promise<void>          // never rejects
+```
+
+### Outputs
+
+```
+// written report, normal
+{ "error": { "message": string, "stack"?: string }, "context"?: unknown }
+
+// written report, array context tail-clamped  (REQ-3113-1.3)
+{ "error": {...}, "context": unknown[], "contextTruncated": { "omittedEntries": number } }
+
+// written report, context dropped            (REQ-3113-1.4)
+{ "error": {...}, "contextOmitted": { "reason": "payload-exceeded-limit",
+                                      "serializedBytes": number, "limitBytes": number } }
+
+// minimal fallback report (unchanged shape, now compact)
+{ "error": { "message": string, "stack"?: string } }
+```
+
+All four are emitted with **no** `space` argument to `JSON.stringify`.
+
+### Module-private state and constants (nothing exported)
+
+```
+MAX_REPORT_STRING_CHARS     = 4096
+MAX_REPORT_CONTEXT_ENTRIES  = 8
+MAX_REPORT_BYTES            = 131072
+MAX_REPORT_FILES            = 20
+MAX_REPORT_TOTAL_BYTES      = 1048576
+REPORT_DEDUPE_WINDOW_MS     = 60000
+MAX_TRACKED_FINGERPRINTS    = 64
+FINGERPRINT_ALGORITHM       = "sha256"   // fixed 64-hex-char key, never sliced
+FINGERPRINT_FIELD_SEPARATOR = "\u0000"   // not a decimal digit: self-delimiting
+REPORT_FILE_PATTERN         = /^llxprt-client-error-.*\.json$/
+
+recentReports : Map<string, { windowStartMs: number,
+                              suppressedCount: number,
+                              lastReportPath: string }>
+```
+
+### Dependencies (all Node builtins already available; none injected, none new)
+
+```
+fs         from 'node:fs/promises' // readdir, stat, unlink, writeFile (already imported)
+os         from 'node:os'                                             (already imported)
+path       from 'node:path'                                           (already imported)
+Buffer     from 'node:buffer'      // byteLength, from                 (NEW import)
+createHash from 'node:crypto'      // fingerprint digest only          (NEW import)
+```
+
+Both new imports are Node built-ins, present in Node and Bun, already used
+elsewhere in `packages/core` (`services/loopDetectionService.ts:7` imports
+`createHash`). Neither adds a package, a lockfile entry, or an export.
+
+---
+
+## Component 1 — `packages/core/src/utils/errorReporting.ts`
+
+### 1.1 `clampString(value)` — REQ-3113-1.2
+
+```
+010: FUNCTION clampString(value: string) -> string
+011:   IF value.length <= MAX_REPORT_STRING_CHARS
+012:     RETURN value
+013:   RETURN value.slice(0, MAX_REPORT_STRING_CHARS)
+014:          + " [truncated: " + value.length + " chars]"
+```
+
+### 1.2 `stringifyClamped(payload)` — REQ-3113-1.2, REQ-3113-2
+
+```
+020: FUNCTION stringifyClamped(payload: unknown) -> string
+021:   // No `space` argument: compact output (REQ-3113-2).
+022:   // The replacer runs for every value, so error.message, error.stack and
+023:   // every context string are clamped uniformly.
+024:   RETURN JSON.stringify(payload, replacer)
+025:     WHERE replacer(key, value) =
+026:       IF typeof value is "string" THEN clampString(value) ELSE value
+027:   // NOTE: this function does NOT catch. A BigInt/circular payload still
+028:   // throws to the caller so the existing serialization fallback runs
+029:   // unchanged (REQ-3113-5).
+```
+
+### 1.3 `serializeBoundedReport(errorToReport, context)` — REQ-3113-1.2/1.3/1.4
+
+```
+040: FUNCTION serializeBoundedReport(errorToReport, context?) -> string
+041:   base = { error: errorToReport }
+042:   IF context is provided
+043:     base.context = context
+044:   text = stringifyClamped(base)                  // S1 — FIRST JSON.stringify call
+045:   IF Buffer.byteLength(text, "utf8") <= MAX_REPORT_BYTES
+046:     RETURN text                                  // S2
+047:   IF context is an Array
+048:     kept    = context.slice(-MAX_REPORT_CONTEXT_ENTRIES)
+049:     omitted = context.length - kept.length
+050:     text    = stringifyClamped({ error: errorToReport,
+051:                                  context: kept,
+052:                                  contextTruncated: { omittedEntries: omitted } })
+053:     IF Buffer.byteLength(text, "utf8") <= MAX_REPORT_BYTES
+054:       RETURN text                                // S3
+055:   RETURN stringifyClamped({ error: errorToReport,
+056:                             contextOmitted: {
+057:                               reason: "payload-exceeded-limit",
+058:                               serializedBytes: Buffer.byteLength(text, "utf8"),
+059:                               limitBytes: MAX_REPORT_BYTES } })   // S4
+060:   // S4 is bounded: `error` holds at most two clamped strings, so the
+061:   // result is always well under MAX_REPORT_BYTES. This is the hard cap.
+```
+
+### 1.4 `buildFingerprint(type, baseMessage, message)` — REQ-3113-4
+
+```
+070: FUNCTION buildFingerprint(type, baseMessage, message) -> string
+071:   digest = createHash(FINGERPRINT_ALGORITHM)
+072:   FOR EACH component IN [type, baseMessage, message]      // fixed order
+073:     bytes = Buffer.from(component, "utf8")
+074:     digest.update(String(bytes.length))                   // length prefix
+075:     digest.update(FINGERPRINT_FIELD_SEPARATOR)
+076:     digest.update(bytes)                                  // complete, untruncated
+077:     digest.update(FINGERPRINT_FIELD_SEPARATOR)
+078:   RETURN digest.digest("hex")
+079:   // 64 hex characters, fixed size for any input. No slice anywhere.
+```
+
+Three properties this shape buys, each load-bearing:
+
+1. **No truncation, so no false coalescing.** The whole message participates.
+   Two errors that share a 512-character prefix and differ afterwards produce
+   different digests, so the second is reported rather than silently suppressed.
+   The accepted behavior is that *identical* failures coalesce; a truncated key
+   would coalesce non-identical ones.
+2. **Injective, length-safe framing.** Each component is written as
+   `decimalByteLength · SEP · bytes · SEP`. The decimal count is self-delimiting
+   because `SEP` is not a digit, so the byte stream cannot be reinterpreted as a
+   different split — `("ab","c","x")` and `("a","bc","x")` differ, and a
+   component that itself contains U+0000 does not alias another triple.
+3. **Incremental, no intermediate copy.** `update` is called per component;
+   `type + SEP + baseMessage + SEP + message` is never materialized. The message
+   can be megabytes, and allocating a full copy of it is exactly the cost this
+   issue exists to remove.
+
+`error.stack` and `context` remain excluded (specification section 8): stacks
+vary by frame across retries of the same failure, and hashing unbounded context
+would reintroduce the cost being removed.
+
+### 1.5 `consumeDuplicate(fingerprint, nowMs)` — REQ-3113-4
+
+```
+080: FUNCTION consumeDuplicate(fingerprint, nowMs)
+081:        -> { suppressed: false } | { suppressed: true, count, lastReportPath }
+082:   entry = recentReports.get(fingerprint)
+083:   IF entry is absent
+084:     RETURN { suppressed: false }
+085:   IF nowMs - entry.windowStartMs >= REPORT_DEDUPE_WINDOW_MS
+086:     // Fixed window expired. Drop the entry; a fresh window opens only
+087:     // when the next report is actually written (line 109).
+088:     recentReports.delete(fingerprint)
+089:     RETURN { suppressed: false }
+090:   entry.suppressedCount = entry.suppressedCount + 1
+091:   RETURN { suppressed: true,
+092:            count: entry.suppressedCount,
+093:            lastReportPath: entry.lastReportPath }
+```
+
+### 1.6 `rememberReport(fingerprint, nowMs, reportPath)` — REQ-3113-4
+
+```
+100: FUNCTION rememberReport(fingerprint, nowMs, reportPath)
+101:   // Called ONLY after a successful write, so a failing disk never
+102:   // silences the next attempt.
+103:   FOR EACH [key, entry] IN recentReports
+104:     IF nowMs - entry.windowStartMs >= REPORT_DEDUPE_WINDOW_MS
+105:       recentReports.delete(key)
+106:   WHILE recentReports.size >= MAX_TRACKED_FINGERPRINTS
+107:     oldestKey = key of the entry with the smallest windowStartMs
+108:     recentReports.delete(oldestKey)
+109:   recentReports.set(fingerprint, { windowStartMs: nowMs,
+110:                                    suppressedCount: 0,
+111:                                    lastReportPath: reportPath })
+```
+
+### 1.7 `collectReportFiles(reportingDir)` — REQ-3113-3
+
+```
+120: FUNCTION collectReportFiles(reportingDir)
+121:        -> Array<{ path, size, mtimeMs, name }>
+122:   TRY names = await fs.readdir(reportingDir)
+123:   CATCH  RETURN []        // missing/unreadable dir: rotation is a no-op
+124:   results = []
+125:   FOR EACH name IN names
+126:     IF NOT REPORT_FILE_PATTERN.test(name)
+127:       CONTINUE            // every non-matching entry is left untouched
+128:     full = path.join(reportingDir, name)
+129:     TRY   info = await fs.stat(full)
+130:     CATCH CONTINUE        // vanished or unreadable: skip
+131:     IF NOT info.isFile()
+132:       CONTINUE            // a directory named like a report is not a report
+133:     results.push({ path: full, size: info.size,
+134:                    mtimeMs: info.mtimeMs, name: name })
+135:   RETURN results
+```
+
+### 1.8 `rotateReports(reportingDir, keepPath)` — REQ-3113-3
+
+```
+140: FUNCTION rotateReports(reportingDir, keepPath)
+141:   entries = await collectReportFiles(reportingDir)
+142:   count = entries.length                  // includes keepPath when present
+143:   total = SUM(entry.size FOR entry IN entries)
+144:   candidates = entries WHERE entry.path != keepPath
+145:   SORT candidates ASCENDING BY (mtimeMs, THEN name)
+146:     // mtimeMs ties are common on fast writes; the embedded ISO-8601
+147:     // timestamp sorts lexicographically in chronological order, so the
+148:     // name tie-break agrees with creation order. Fully deterministic.
+149:   WHILE candidates is not empty
+150:         AND (count > MAX_REPORT_FILES OR total > MAX_REPORT_TOTAL_BYTES)
+151:     victim = candidates.shift()           // oldest first
+152:     TRY   await fs.unlink(victim.path)
+153:     CATCH { }                             // concurrent deletion / permission:
+154:                                           // best-effort janitor, never throws
+155:     count = count - 1
+156:     total = total - victim.size           // decremented even on unlink
+157:                                           // failure so the loop terminates
+158:   // Post-condition after a completed non-concurrent pass:
+159:   //   matching files <= MAX_REPORT_FILES
+160:   //   sum of their sizes <= MAX_REPORT_TOTAL_BYTES
+161:   //   keepPath still present; no non-matching entry touched
+```
+
+### 1.9 `writeMinimalReport(errorToReport, baseMessage, reportPath)` — REQ-3113-2, REQ-3113-5
+
+```
+170: FUNCTION writeMinimalReport(errorToReport, baseMessage, reportPath) -> boolean
+171:   TRY
+172:     content = stringifyClamped({ error: errorToReport })   // compact
+173:     await fs.writeFile(reportPath, content)
+174:     reportToStderr(baseMessage +
+175:       " Partial report (excluding context) available at: " + reportPath)
+176:     RETURN true
+177:   CATCH minimalWriteError
+178:     reportToStderr(baseMessage +
+179:       " Failed to write even a minimal error report:", minimalWriteError)
+180:     RETURN false
+181:   // Only change versus today: compact output and a boolean result so the
+182:   // caller owns dedupe bookkeeping and rotation in exactly one place.
+```
+
+### 1.10 `reportError(...)` — orchestration
+
+```
+190: EXPORTED ASYNC FUNCTION reportError(error, baseMessage,
+191:                                     context?, type = "general",
+192:                                     reportingDir = os.tmpdir())
+193:   errorToReport = normaliseError(error)                    // unchanged
+194:   fingerprint   = buildFingerprint(type, baseMessage, errorToReport.message)
+195:   nowMs         = Date.now()
+196:   duplicate     = consumeDuplicate(fingerprint, nowMs)
+197:   IF duplicate.suppressed
+198:     reportToStderr(baseMessage +
+199:       " Duplicate error report suppressed (" + duplicate.count +
+200:       " within " + (REPORT_DEDUPE_WINDOW_MS / 1000) + "s). Previous report: " +
+201:       duplicate.lastReportPath)
+202:     RETURN                                                  // no file written
+203:
+204:   timestamp      = new Date().toISOString().replace(/[:.]/g, "-")
+205:   reportFileName = "llxprt-client-error-" + type + "-" + timestamp + ".json"
+206:   reportPath     = path.join(reportingDir, reportFileName)   // format frozen
+207:
+208:   TRY
+209:     stringifiedReportContent = serializeBoundedReport(errorToReport, context)
+210:   CATCH stringifyError
+211:     // Existing serialization fallback, byte for byte unchanged.
+212:     reportToStderr(baseMessage +
+213:       " Could not stringify report content (likely due to context):",
+214:       stringifyError)
+215:     reportToStderr("Original error that triggered report generation:", error)
+216:     IF context
+217:       reportToStderr(
+218:         "Original context could not be stringified or included in report.")
+219:     written = await writeMinimalReport(errorToReport, baseMessage, reportPath)
+220:     IF written
+221:       rememberReport(fingerprint, nowMs, reportPath)
+222:       await rotateReports(reportingDir, reportPath)
+223:     RETURN
+224:
+225:   TRY
+226:     await fs.writeFile(reportPath, stringifiedReportContent)
+227:   CATCH writeError
+228:     // Existing write fallback, byte for byte unchanged. No dedupe entry is
+229:     // recorded and no rotation runs, so a failing disk neither silences
+230:     // the next attempt nor deletes anything.
+231:     reportToStderr(baseMessage +
+232:       " Additionally, failed to write detailed error report:", writeError)
+233:     reportToStderr("Original error that triggered report generation:", error)
+234:     IF context
+235:       logContextFallback(context)
+236:     RETURN
+237:
+238:   reportToStderr(baseMessage + " Full report available at: " + reportPath)
+239:   rememberReport(fingerprint, nowMs, reportPath)
+240:   await rotateReports(reportingDir, reportPath)
+```
+
+`logContextFallback` and `formatContextFallback` (`errorReporting.ts:130-156`)
+are **unchanged**.
+
+### Anti-pattern warnings for component 1
+
+```
+DO NOT: export any constant, helper, or the recentReports map
+    DO: keep every addition module-private; tests restate the values
+
+DO NOT: add a `reportingLimits` / `ErrorReportOptions` parameter or object
+    DO: keep the five-parameter signature exactly as it is (REQ-3113-5)
+
+DO NOT: call JSON.stringify anywhere before line 209
+    DO: keep fingerprinting a node:crypto digest over three strings
+        (errorReporting.test.ts mocks JSON.stringify by call count and must
+        keep passing; a digest adds no JSON.stringify call)
+
+DO NOT: slice, truncate, or otherwise shorten the fingerprint or its inputs
+    DO: hash the complete type, baseMessage and message — the digest is already
+        fixed-size, and truncation would coalesce two non-identical long errors
+
+DO NOT: build `type + SEP + baseMessage + SEP + message` and hash that string
+    DO: call digest.update once per framed component (lines 073-077); the
+        message can be megabytes and must never be copied
+
+DO NOT: drop the decimal length prefix and rely on the separator alone
+    DO: keep `length · SEP · bytes · SEP` framing so the encoding is injective
+
+DO NOT: fingerprint error.stack or context
+    DO: hash exactly type, baseMessage and the normalised message
+
+DO NOT: add a uniqueness suffix, counter, or PID to the report filename
+    DO: keep `llxprt-client-error-${type}-${timestamp}.json` frozen
+
+DO NOT: rotate before the write, or rotate after a failed write
+    DO: rotate once, after a successful write, with the new file protected
+
+DO NOT: rewrite an existing report to bump an occurrence counter
+    DO: emit the count on stderr (line 198-201)
+
+DO NOT: wrap rotation in a mutex, queue, or lock file
+    DO: swallow ENOENT and document the best-effort concurrency contract
+
+DO NOT: swallow the stringify error inside stringifyClamped
+    DO: let it propagate so the existing fallback at line 210 runs
+
+DO NOT: use `catch (e) { }` — sonarjs/no-ignored-exceptions is an error
+    DO: use `} catch {` with a comment stating why, as reportToStderr already does
+```
+
+---
+
+## Component 2 — `packages/agents/src/core/turn.ts`
+
+Module-private constant, placed next to the existing module constants near
+`turn.ts:72`:
+
+```
+300: CONSTANT TURN_REPORT_HISTORY_TAIL = 8
+301:   // Matches MAX_REPORT_CONTEXT_ENTRIES in the core writer so a Turn report
+302:   // looks the same whether the caller or the writer bounded it.
+```
+
+Replacing `turn.ts:588-594` inside `handleRunError`:
+
+```
+310: history             = this.chat.getHistory(/* curated */ true)
+311: recentHistory       = history.slice(-TURN_REPORT_HISTORY_TAIL)
+312:   // slice(-8) on [] yields []; on a 3-entry history yields all 3.
+313: omittedHistoryCount = MAX(0, history.length - TURN_REPORT_HISTORY_TAIL)
+314: await reportError(
+315:   error,
+316:   "Error when talking to " + this.providerName + " API",
+317:   { request: req,                    // the failed request, semantically separate
+318:     recentHistory: recentHistory,    // bounded tail, never the whole conversation
+319:     omittedHistoryCount: omittedHistoryCount },
+320:   "Turn.run-sendMessageStream")
+321: structuredError = buildStructuredError(error)
+322: YIELD { type: AgentEventType.Error, value: { error: structuredError } }
+```
+
+### Integration points
+
+```
+Line 310: this.chat.getHistory(true) -> IContent[]
+          Real ChatSession dependency, already injected via the constructor.
+          Unchanged call; only what is done with the result changes.
+
+Line 314: reportError(...) from '@vybestack/llxprt-code-core/utils/errorReporting.js'
+          Already imported at turn.ts:27. MUST stay awaited — the existing call
+          is awaited and fire-and-forget would lose the report on process exit.
+          The object literal is assignable to `Record<string, unknown>`.
+
+Line 321: buildStructuredError / the yielded Error event are UNCHANGED.
+          Every existing turn test that asserts the emitted events keeps passing.
+```
+
+### Anti-pattern warnings for component 2
+
+```
+DO NOT: [...history, req]                       // the defect: request lost in history
+    DO: { request, recentHistory, omittedHistoryCount }
+
+DO NOT: history.slice(0, 8)                     // head, not tail — wrong end
+    DO: history.slice(-TURN_REPORT_HISTORY_TAIL)
+
+DO NOT: export TURN_REPORT_HISTORY_TAIL or read it from a setting
+    DO: module-private constant
+
+DO NOT: add a debug flag that restores full-history capture
+    DO: nothing — opt-in full history is explicitly out of scope
+
+DO NOT: change the yielded events, the error mapping, or any other branch of
+        handleRunError
+    DO: change only the reportError context argument
+```

--- a/project-plans/issue3113/specification.md
+++ b/project-plans/issue3113/specification.md
@@ -1,0 +1,317 @@
+# Specification: Bounded, Rotated, Rate-Limited Error Reports (issue #3113)
+
+Plan ID: PLAN-20260807-ISSUE3113
+Generated: 2026-08-07
+Branch: `issue3113`
+Requirements: REQ-3113-1, REQ-3113-2, REQ-3113-3, REQ-3113-4, REQ-3113-5
+
+## 1. Purpose
+
+`reportError` in `packages/core/src/utils/errorReporting.ts` writes one
+pretty-printed JSON file per API failure into `os.tmpdir()`. The payload embeds
+the **entire curated conversation**, so report size scales with context size,
+and nothing ever deletes, caps, or coalesces the files.
+
+Live reproduction on the development machine at plan time (see
+`preflight-verification.md` for the command):
+
+```
+count       = 4,380 files
+total       = 57,597,083 bytes (54.9 MB)
+largest     = 11,421,098 bytes (10.9 MB, one report)
+by type     = 4,076 Turn.run-sendMessageStream / 301 generateJson-api / 3 startChat
+```
+
+This is the same directory the issue reported at 3,565 files / 62 MB; it has
+continued to grow. The failure mode is unbounded disk consumption proportional
+to (error rate) x (context size), plus an unmanaged accumulation of full
+conversation text in a shared temp directory.
+
+## 2. Accepted behavior (exactly four behaviors)
+
+The issue proposes four remedies. All four are accepted, and nothing else is.
+
+| # | Accepted behavior | Requirement |
+|---|---|---|
+| 1 | A default report contains the normalized error, the failed request, and only a bounded recent history tail — never the complete curated conversation. All report output stays bounded as context grows. | REQ-3113-1 |
+| 2 | Report JSON is compact, not pretty-printed, including the minimal fallback report. | REQ-3113-2 |
+| 3 | The shared core report writer rotates every `llxprt-client-error-*.json` file in its reporting directory under a small fixed count budget and a total-byte budget, removing oldest reports during a write. | REQ-3113-3 |
+| 4 | Identical failures repeated within a bounded interval are coalesced/rate-limited so a retry loop does not produce one file per attempt. | REQ-3113-4 |
+
+REQ-3113-5 is the preservation contract that constrains all four.
+
+## 3. Non-goals and explicit exclusions
+
+- **No new dependency.** Only Node built-ins: `node:fs/promises`, `node:os`,
+  `node:path`, `node:buffer`, and `node:crypto`. All five are available in both
+  Node and Bun, and `node:crypto`/`createHash` is already used elsewhere in
+  `packages/core` (for example `services/loopDetectionService.ts:7`). A Node
+  built-in import is **not** a dependency and **not** a public abstraction: it
+  adds nothing to `package.json`, nothing to the lockfile, and nothing to the
+  module's export surface.
+- **No new setting, flag, env var, or config key.** The limits are internal constants; a debug/opt-in "full history" mode is explicitly *not* implemented.
+- **No new public abstraction.** Every constant and helper introduced is module-private. `reportError` remains the only export of `errorReporting.ts`.
+- **No workflow, agent-memory, or quality-tool change.**
+- **`packages/mcp/src/client/mcp-client-manager-helpers.ts` is out of scope.** Its `reportError` is a locally injected `(error: unknown) => void` callback (see `mcp-client-manager.ts:339`, `:782`, `:944`) that logs; it is not the core disk writer and shares no code with it. `packages/cli/src/ui/hooks/usePermissionsTrustDialogFlow.ts:43` and `packages/cli/src/config/extensions/extensionLoader.ts:44` are likewise unrelated local helpers of the same name.
+- **Other core-`reportError` callers are not rewritten.** They inherit the centralized cap, rotation, and rate limit. Only the Turn caller changes, because accepted behavior 1 requires the request and the bounded history tail to be *semantically separate*, and only Turn currently concatenates them.
+- **No age-based expiry.** The issue offers "count and/or total bytes and/or age". Count + total bytes are sufficient, deterministic, and testable without clock control in the rotation path; age adds a third knob with no additional guarantee. Rejected as scope.
+- **The report filename format is frozen.** `llxprt-client-error-${type}-${timestamp}.json` is unchanged. Adding a uniqueness suffix would break `errorReporting.test.ts`, which must not be modified.
+
+## 4. Preserved contract (REQ-3113-5)
+
+**Requirement text:** `reportError`'s public call signature, its report filename
+format, and its existing fallback behavior must be unchanged.
+
+```typescript
+export async function reportError(
+  error: Error | unknown,
+  baseMessage: string,
+  context?: unknown[] | Record<string, unknown>,
+  type = 'general',
+  reportingDir = os.tmpdir(),
+): Promise<void>;
+```
+
+Preserved verbatim:
+
+1. **Signature and arity.** No parameter added, removed, reordered, or retyped.
+2. **Filename.** `path.join(reportingDir, \`llxprt-client-error-${type}-${timestamp}.json\`)` with `timestamp = new Date().toISOString().replace(/[:.]/g, '-')`.
+3. **Serialization-failure fallback.** When `JSON.stringify` throws (BigInt, circular), the same three stderr messages are emitted and `writeMinimalReport` writes `{ error }` to the same path.
+4. **Write-failure fallback.** When `fs.writeFile` rejects, the same stderr messages are emitted and `logContextFallback` prints the original context truncated to 1000 characters.
+5. **Minimal-write-failure fallback.** Same stderr message.
+6. **Never throws.** `reportError` continues to resolve on every path.
+
+Consequence: `packages/core/src/utils/errorReporting.test.ts` (Vitest-importing,
+must not be modified) keeps passing unchanged. Section 9 audits each of its six
+cases against the new design.
+
+## 5. REQ-3113-1: Bounded report payload
+
+**Requirement text:** A default report contains the normalized error, the failed
+request, and only a bounded recent history tail. Report output must remain
+bounded as context grows, for every caller.
+
+Boundedness is enforced at two levels, because the two levels answer two
+different questions:
+
+- The **caller-side tail** (Turn) answers *"what is worth reporting?"* — it keeps
+  the report semantically meaningful and small in the common case.
+- The **writer-side cap** (core) answers *"what is the hard ceiling?"* — it is the
+  guarantee that holds for `startChat`, `generateJson-api`,
+  `generateContent-api`, and any future caller, without rewriting them.
+
+### REQ-3113-1.1 — Turn separates request from bounded history tail
+
+- GIVEN a `Turn.run` stream failure with curated history of length `n`
+- WHEN the error report is produced
+- THEN the context passed to `reportError` is the object
+  `{ request, recentHistory, omittedHistoryCount }`
+- AND `recentHistory` is the last `min(n, 8)` curated entries
+- AND `omittedHistoryCount === max(0, n - 8)`
+- AND `request` is the failed `TurnRequest`, not appended to history
+
+Current code (`packages/agents/src/core/turn.ts:588`) passes
+`[...this.chat.getHistory(true), req]` — one flat array in which the request is
+indistinguishable from history and the history is unbounded.
+
+### REQ-3113-1.2 — Per-string clamp in the writer
+
+- GIVEN any string value anywhere in the serialized report
+- WHEN its length exceeds `MAX_REPORT_STRING_CHARS`
+- THEN the stored value is its first `MAX_REPORT_STRING_CHARS` characters
+  followed by `` ` [truncated: ${originalLength} chars]` ``
+- AND this applies uniformly to `error.message`, `error.stack`, and every
+  context string
+
+### REQ-3113-1.3 — Array-context tail clamp in the writer
+
+- GIVEN a serialized report larger than `MAX_REPORT_BYTES` whose `context` is an array of length `n`
+- WHEN the report is written
+- THEN `context` is replaced by its last `min(n, MAX_REPORT_CONTEXT_ENTRIES)` entries
+- AND a sibling field `contextTruncated: { omittedEntries: n - kept }` records what was dropped
+
+### REQ-3113-1.4 — Hard payload cap in the writer
+
+- GIVEN a serialized report still larger than `MAX_REPORT_BYTES` after 1.2 and 1.3
+- WHEN the report is written
+- THEN the `context` key is absent
+- AND the report is `{ error, contextOmitted: { reason: 'payload-exceeded-limit', serializedBytes, limitBytes } }`
+- AND the written file is smaller than `MAX_REPORT_BYTES`
+
+This is a hard bound: the fallback payload contains only the normalized error,
+whose `message` and `stack` are each already clamped by 1.2, so its size is
+bounded by roughly `2 * MAX_REPORT_STRING_CHARS` plus a fixed envelope.
+
+**Ordered serialization pipeline** (exactly one attempt per stage, no loops):
+
+```
+S1  text = stringify({ error, context? }, clampStrings)
+S2  if byteLength(text) <= MAX_REPORT_BYTES            -> emit text
+S3  if context is Array:
+      text = stringify({ error, context: tail, contextTruncated }, clampStrings)
+      if byteLength(text) <= MAX_REPORT_BYTES          -> emit text
+S4  emit stringify({ error, contextOmitted }, clampStrings)
+```
+
+`JSON.stringify` is called at most three times and **the first call is S1**, so
+`errorReporting.test.ts`'s call-count-based stringify mock keeps behaving
+exactly as before (section 9, case 5).
+
+## 6. REQ-3113-2: Compact JSON
+
+**Requirement text:** Report JSON must be compact, not pretty-printed, in both
+the main report and the minimal fallback report.
+
+- GIVEN any successfully written report
+- WHEN the file bytes are read as text
+- THEN the text contains no `\n` and no indentation
+- AND `JSON.parse(text)` yields the same value the pretty-printed form would have
+
+Both `JSON.stringify(..., null, 2)` call sites drop the `null, 2` arguments:
+the main serialization (`errorReporting.ts:100`) and `writeMinimalReport`
+(`errorReporting.ts:60`).
+
+## 7. REQ-3113-3: Rotation
+
+**Requirement text:** During a write, the shared core report writer removes the
+oldest `llxprt-client-error-*.json` files in its reporting directory until the
+directory satisfies a fixed count budget and a total-byte budget.
+
+- GIVEN a `reportingDir` containing report files and unrelated files
+- WHEN `reportError` **successfully** writes a report
+- THEN afterwards the directory holds at most `MAX_REPORT_FILES` files matching `/^llxprt-client-error-.*\.json$/`
+- AND their combined size is at most `MAX_REPORT_TOTAL_BYTES`
+- AND deletions happened oldest-first
+- AND the report just written was not deleted
+- AND no file that does not match the pattern was touched
+
+### Exact semantics
+
+| Aspect | Decision | Rationale |
+|---|---|---|
+| Trigger point | After a **successful** `fs.writeFile`, in the same `reportError` call, for both the main and the minimal report. Never after a failed write. | "Removing oldest reports during a write". Post-write accounting makes the post-condition exact: the just-written file is included in the totals. |
+| Passes per call | Exactly one. | Determinism; no re-entrancy. |
+| Candidate set | Directory entries matching `/^llxprt-client-error-.*\.json$/` that `fs.stat` reports as regular files. | Matches the writer's own filename format. Directories and every other name are excluded, so unrelated temp files survive. |
+| Age key | `stat.mtimeMs`. | Works for foreign/pre-existing files that may not carry a parseable embedded timestamp. |
+| Ordering | `mtimeMs` ascending. | Oldest first. |
+| Tie-break | Filename ascending (lexicographic `<`). | `mtimeMs` ties are common on fast writes. The embedded ISO-8601 timestamp sorts lexicographically in chronological order, so the tie-break agrees with creation order for same-`type` files. Fully deterministic. |
+| Protected file | The path just written is never a deletion candidate. | A report that deletes itself is useless. Safe because one report is at most `MAX_REPORT_BYTES` (128 KiB) < `MAX_REPORT_TOTAL_BYTES` (1 MiB), so the budget is always reachable while keeping it. |
+| Loop | `while (candidates.length > 0 && (count > MAX_REPORT_FILES \|\| total > MAX_REPORT_TOTAL_BYTES))`: shift the oldest candidate, unlink it, decrement `count`, subtract its size from `total`. | `count` and `total` include the protected file. The candidate list strictly shrinks, so the loop terminates. |
+| Error handling | `readdir`, `stat`, and `unlink` failures are swallowed individually. A file whose `stat` fails is skipped; an `unlink` failure still removes the entry from the candidate list and still decrements the running totals. Rotation never throws and never changes `reportError`'s stderr output. | Genuine filesystem/external-input handling — the only place defensive handling is permitted. A missing directory (`ENOENT`) must not convert the existing write-failure fallback into a different failure. |
+| Concurrency | No lock is added. Two concurrent calls may enumerate the same oldest file; the loser's `unlink` fails with `ENOENT` and is swallowed. Each call always preserves its own file. | A lock would be a public abstraction and a new failure mode for a best-effort janitor. |
+
+**Concurrency post-condition (the guarantee under test):** concurrent
+`reportError` calls never reject, never delete a non-matching file, and never
+delete a caller's own report. The count and byte budgets are guaranteed after
+any **completed non-concurrent** write. Interleaved passes may transiently
+observe more than `MAX_REPORT_FILES` files; a single subsequent sequential
+report restores the budget.
+
+## 8. REQ-3113-4: Duplicate coalescing / rate limiting
+
+**Requirement text:** Identical failures repeated within a bounded interval must
+not each produce a report file.
+
+- GIVEN a report was written for fingerprint `F` at time `t0`
+- WHEN `reportError` is called again with fingerprint `F` at time `t` where `t - t0 < REPORT_DEDUPE_WINDOW_MS`
+- THEN no file is written and no existing file is modified
+- AND exactly one stderr line is emitted carrying the occurrence count and the path of the report that represents the group
+- WHEN `t - t0 >= REPORT_DEDUPE_WINDOW_MS`
+- THEN a new report is written and a new window opens at `t`
+- AND a call whose fingerprint differs is never suppressed
+
+### Exact semantics
+
+| Aspect | Decision | Rationale |
+|---|---|---|
+| Fingerprint | A lowercase-hex **SHA-256 digest** (`FINGERPRINT_ALGORITHM`), always 64 characters, computed over the **complete, untruncated** `type`, `baseMessage`, and normalized `error.message`. | Fixed size for any input length, and it discriminates on the whole message. `type` alone is far too coarse (4,076 of the 4,380 observed files share one `type`). `baseMessage` carries the provider name, so a simultaneous `claudecode` and `codex` outage — exactly the reported scenario — yields two independent groups. |
+| Why not a truncated concatenation | **Rejected.** `` `${type}\u0000${baseMessage}\u0000${message}` `` sliced to 512 characters was the earlier design. | It violates the accepted behavior. Two *different* long errors sharing a 512-character prefix produce the same key, so a real, distinct failure is silently suppressed and never reported. Verified: with a 1,024-character shared prefix, the truncated form collides while the digest does not (`preflight-verification.md` section 3). Truncation trades a correctness property for a size property that hashing gives for free. |
+| Digest framing | For each component in the fixed order `type`, `baseMessage`, `message`: `update(String(utf8ByteLength))`, `update(FINGERPRINT_FIELD_SEPARATOR)`, `update(utf8Bytes)`, `update(FINGERPRINT_FIELD_SEPARATOR)`. | Length-prefixed framing is injective. The decimal byte count is terminated by a separator that cannot be a decimal digit, so each component's extent is unambiguous even if the component itself contains U+0000. Bare separator-joining is *not* injective. Verified: `('ab','c','x')` and `('a','bc','x')` digest differently, and a component containing U+0000 does not alias a different split. |
+| Incremental computation | Components are fed to the hash one `update` at a time. No concatenated intermediate string or buffer is materialized. | The error message can be megabytes. Building `type + SEP + baseMessage + SEP + message` would allocate a full copy of precisely the payload this issue exists to stop copying. |
+| Coalescing precision | Two fingerprints are equal **iff** the `(type, baseMessage, message)` triple is identical, up to SHA-256 collision resistance. | This is the exact statement of accepted behavior 4: only identical failures coalesce. No non-identical pair is suppressed. |
+| Not fingerprinted | `error.stack`, `context`. | Stacks vary by frame across retries of the same failure, which would defeat coalescing. Context is unbounded and hashing it would reintroduce the cost being removed. |
+| Window type | **Fixed**, anchored at the last written report. Suppressed occurrences never extend it. | A sliding window can suppress forever during a sustained outage. Fixed gives the exact bound: at most one report per fingerprint per window. |
+| Window length | `REPORT_DEDUPE_WINDOW_MS = 60_000` | A provider retry loop with backoff completes within tens of seconds, so one window collapses a whole storm. A genuinely persistent outage still yields a fresh report each minute: at most 60/hour/fingerprint versus the 327/hour observed. |
+| When recorded | Only after a **successful** write (main or minimal). | A failed write must not silence the next attempt. |
+| Registry | Module-private `Map<string, { windowStartMs, suppressedCount, lastReportPath }>`. |  |
+| Registry bound | On insert, first drop entries whose window has expired; if still at `MAX_TRACKED_FINGERPRINTS`, evict the smallest `windowStartMs`. Eviction therefore removes the **oldest** window and never the entry being inserted. | Keeps the registry at 64 entries of a fixed 64-character key plus a short path — a few kilobytes — with no unbounded retention. The digest's fixed size is what makes the bound exact: an entry can no longer be as large as the error message it represents. |
+| Clock | `Date.now()` for the window; the pre-existing `new Date().toISOString()` for the filename. | Both are controllable in tests via `setSystemTime` from `bun:test`, and both move together (verified, `preflight-verification.md` section 4). Advancing the clock between calls is what makes a duplicate test observable: without it, two same-millisecond calls of the same `type` resolve to the *same* frozen filename and the second silently overwrites the first. |
+| Suppressed output | One stderr line: `` `${baseMessage} Duplicate error report suppressed (${suppressedCount} within ${REPORT_DEDUPE_WINDOW_MS / 1000}s). Previous report: ${lastReportPath}` `` | Preserves the issue's "occurrence count" intent without rewriting a file per retry, which would reintroduce per-attempt disk writes. |
+| Not done | The written file is **not** rewritten to update an occurrence counter. | Rewriting per retry is the write amplification the issue is about. |
+| Scope of state | Process-lifetime module state. Each Bun test file runs in its own process (both `packages/core/run-bun-tests.ts` and `scripts/run_bun_tests.ts` spawn one process per file), so tests are isolated by construction; within a file, tests use distinct fingerprints. |  |
+
+## 9. Constants
+
+All constants are **module-private** in `packages/core/src/utils/errorReporting.ts`
+except the Turn tail, which is module-private in
+`packages/agents/src/core/turn.ts`. Nothing is exported; tests restate the
+values so the tests are the specification.
+
+| Constant | Value | Justification |
+|---|---|---|
+| `MAX_REPORT_STRING_CHARS` | `4_096` | Long enough for a full stack trace or a substantial prompt fragment; short enough that no single string can dominate a report. |
+| `MAX_REPORT_CONTEXT_ENTRIES` | `8` | The failing exchange plus the few turns that shaped it. Matches the Turn tail so a report looks the same however it was bounded. |
+| `MAX_REPORT_BYTES` | `131_072` (128 KiB) | Comfortably holds an 8-entry tail whose strings are each clamped at 4 KiB (worst realistic case ~100 KiB), so the common Turn report is never degraded to `contextOmitted`. 87x smaller than the largest observed report (10.9 MB). |
+| `MAX_REPORT_FILES` | `20` | Enough history to diagnose a burst; small enough that a directory listing stays readable. |
+| `MAX_REPORT_TOTAL_BYTES` | `1_048_576` (1 MiB) | 1.8% of the 54.9 MB observed. Deliberately less than `MAX_REPORT_FILES * MAX_REPORT_BYTES` (2.5 MiB) so **both** budgets are reachable: many small reports hit the count cap, few large reports hit the byte cap. Neither is dead code. |
+| `REPORT_DEDUPE_WINDOW_MS` | `60_000` | Section 8. |
+| `MAX_TRACKED_FINGERPRINTS` | `64` | Section 8. |
+| `FINGERPRINT_ALGORITHM` | `'sha256'` | Section 8. Ships with `node:crypto`; produces a fixed 64-character hex key for any input size. Not a security control — it is a collision-resistant identity key for grouping — but a truncated or non-cryptographic hash would reintroduce exactly the false-coalescing failure this constant exists to prevent. |
+| `FINGERPRINT_FIELD_SEPARATOR` | `'\u0000'` | Section 8. Terminates each decimal length prefix and each component. Chosen because it is not a decimal digit, so the length prefix is self-delimiting. |
+| `TURN_REPORT_HISTORY_TAIL` (agents) | `8` | Matches `MAX_REPORT_CONTEXT_ENTRIES`. |
+
+**Resulting worst case:** at most 1 MiB of reports on disk plus one in-flight
+report of at most 128 KiB, and at most one written report per distinct
+fingerprint per 60 s. Against the measured incident: 54.9 MB -> <=1.125 MiB, and
+327 files/hour -> <=60 files/hour/fingerprint.
+
+## 10. Compatibility audit of `errorReporting.test.ts` (unmodifiable)
+
+| # | Existing case | Effect of the new design | Verdict |
+|---|---|---|---|
+| 1 | `should generate a report and log the path` — context `{ data: 'test context' }`, `toStrictEqual({ error, context })` | Payload is far below `MAX_REPORT_BYTES`; strings are far below `MAX_REPORT_STRING_CHARS`; compact output parses identically; filename unchanged; fresh `mkdtemp` dir holds one report so rotation deletes nothing; fingerprint unique in file. | PASSES |
+| 2 | plain-object error, `type='general'` | Same. Message `'Test plain object error'` differs from every other case, so no suppression. | PASSES |
+| 3 | string error, `type='general'` | Same; message `'Just a string error'`. | PASSES |
+| 4 | write failure into a non-existent dir | Rotation runs only after a **successful** write, so it never runs here. Both stderr fallbacks are unchanged. | PASSES |
+| 5 | BigInt stringify failure, `JSON.stringify` mocked to throw on call #1 | S1 is still the first `JSON.stringify` call. Fingerprinting is a `node:crypto` digest over three strings and rotation performs no serialization, so neither adds a `JSON.stringify` call. The minimal report is call #2 and passes through; dropping `null, 2` does not change its parsed value. | PASSES |
+| 6 | no context supplied | `{ error }` only; unchanged. | PASSES |
+
+Cross-case interference is impossible: every case uses its own `mkdtemp`
+directory, and all six error messages are distinct, so their digests are
+distinct and no case is ever suppressed.
+
+## 11. Integration points
+
+| Location | Change |
+|---|---|
+| `packages/core/src/utils/errorReporting.ts` | Bounded serialization pipeline, compact output, rotation, dedupe registry. All additions module-private. |
+| `packages/agents/src/core/turn.ts:588-594` | Replace the flat `[...history, req]` context with `{ request, recentHistory, omittedHistoryCount }`. |
+| `packages/agents/src/agents/executor.ts:753` (`startChat`) | Unchanged. Inherits the cap: an oversized `startHistory` array is tail-clamped by REQ-3113-1.3 rather than written whole. |
+| `packages/agents/src/core/ChatSessionFactory.ts:428` (`startChat`) | Unchanged; same inheritance. |
+| `packages/agents/src/core/subagentRuntimeSetup.ts:865` (`startChat`) | Unchanged; same inheritance. |
+| `packages/agents/src/core/clientLlmUtilities.ts:119` (`generateJson-api`) | Unchanged. Array context, so it gains a meaningful 8-entry tail instead of the full `contents`. 301 of the observed files come from here. |
+| `packages/agents/src/core/clientLlmUtilities.ts:178` (`generateContent-api`) | Unchanged. Object context, so an oversized payload degrades to `contextOmitted` — bounded, which is the accepted behavior. |
+| `packages/mcp/**`, `packages/cli/**` local `reportError` helpers | Untouched; different functions. |
+
+## 12. Review-finding triage rubric
+
+Every review finding — Open Code Review, DeepThinker, CodeRabbit, human — is
+labeled with **exactly one** of these four categories, and the label is recorded
+with a one-line reason.
+
+| Category | Definition | Action |
+|---|---|---|
+| **Blocker-Fix** | The finding shows an accepted behavior (REQ-3113-1..5) is not met, a preserved contract is broken, a test is non-behavioral or would pass against unchanged code, a prohibited construct was introduced (suppression directive, lint downgrade, ignore addition, threshold increase), or CI/local verification fails. | Fix before push/merge. Non-negotiable. |
+| **In-scope-Fix** | The finding is correct and lies inside issue #3113's four behaviors — wrong constant, non-deterministic ordering, unbounded growth path, missing boundary test, misleading name or comment in the changed code. | Fix in this PR. |
+| **Reject** | The finding is factually wrong, contradicts an explicitly recorded decision in this specification (for example: "add a setting for full history", "use a sliding window", "add age-based expiry", "truncate the fingerprint instead of hashing it", "also fix the MCP `reportError`"), or asks for a prohibited change. | Reply with the specification section that decided it. No code change. |
+| **Defer** | The finding is legitimate but outside issue #3113 — the pre-existing filename collision when two distinct errors land in the same millisecond (section 8 "Clock"; it is why every duplicate test advances the clock rather than being fixed here), retention policy for sensitive content, telemetry for suppressed reports, migration of the already-accumulated temp files. | File a follow-up issue, link it in the PR thread, no code change here. |
+
+## 13. Constraints
+
+- No `eslint-disable` of any form, no `@ts-ignore` / `@ts-expect-error` / `@ts-nocheck`, no lint severity downgrade, no `.eslintignore`/`.prettierignore`/`.gitignore` addition, no increase to any complexity or size threshold. Current thresholds (`complexity: 25`, `max-lines: 800`, `max-lines-per-function: 80`, `sonarjs/cognitive-complexity: 30`) must be met by decomposing into small named helpers.
+- `errorReporting.ts` is 156 lines and `turn.ts` is 912 raw lines; both currently pass ESLint (verified). Helpers stay well under `max-lines-per-function: 80`.
+- Fail-fast over defensive layers. The **only** permitted defensive handling is genuine filesystem/external-input handling: `readdir`/`stat`/`unlink` in rotation, and the pre-existing stringify/write fallbacks. No optional-chaining shields, no silent `?? {}` defaults, no try/catch around pure logic.
+- `sonarjs/no-ignored-exceptions` is an error: swallowing uses `} catch {` with no binding plus a comment stating why, matching the existing `reportToStderr` pattern in the same file.
+- Tests are behavioral, use Bun, and import directly from `bun:test`. No `toHaveBeenCalled*` as a substitute for output verification; assertions read real files and real return values.
+- A test that writes more than one report into one directory **must** advance the clock with `setSystemTime` between writes. The frozen filename format is millisecond-resolution, so two same-millisecond writes of the same `type` collapse onto one path and the second silently overwrites the first — which can make a duplicate-suppression assertion pass against unchanged code. Advancing the clock is the difference between evidence and coincidence (`test-matrix.md`, "Clock discipline").
+- Strictly issue #3113. No unrelated refactor, rename, or drive-by cleanup.

--- a/project-plans/issue3113/test-matrix.md
+++ b/project-plans/issue3113/test-matrix.md
@@ -1,0 +1,256 @@
+# Behavioral Test Matrix — issue #3113
+
+Plan ID: PLAN-20260807-ISSUE3113
+Generated: 2026-08-07
+
+Every accepted requirement is marked and mapped to concrete evidence. Each row
+states whether the test is **RED** (fails against the base commit `2ae245b8d`,
+proving the accepted behavior) or **GUARD** (passes today and must keep passing,
+proving a preserved contract or protecting against over-correction). A plan with
+only RED rows silently permits regressions; a plan with only GUARD rows proves
+nothing new. Both are required.
+
+A GUARD row may additionally be annotated **"fails against \<rejected
+design\>"**. That is the strongest form of GUARD: the base commit cannot
+exercise the behavior at all, so no RED classification is available, but the row
+still discriminates the accepted design from a specific rejected one. D11 is
+such a row.
+
+Every row must also survive the question *"could this pass against unchanged
+code for an incidental reason?"* — see the self-check at the end of this file.
+Two incidental-pass mechanisms exist in this codebase and are neutralized
+explicitly below: the millisecond-resolution filename collapsing two writes onto
+one path, and rotation pinning the matching-file count at `MAX_REPORT_FILES`
+regardless of deduplication.
+
+## Test files
+
+| File | Framework import | Purpose |
+|---|---|---|
+| `packages/core/src/utils/errorReporting.bounding.bun.test.ts` | `bun:test` (direct) | REQ-3113-1.2/1.3/1.4, REQ-3113-2, REQ-3113-5 |
+| `packages/core/src/utils/errorReporting.rotation.bun.test.ts` | `bun:test` (direct) | REQ-3113-3 |
+| `packages/core/src/utils/errorReporting.dedupe.bun.test.ts` | `bun:test` (direct) | REQ-3113-4 |
+| `packages/agents/src/core/turn.errorReport.bun.test.ts` | `bun:test` (direct) | REQ-3113-1.1 end to end |
+| `packages/agents/src/core/turn.test.ts` | unchanged (`../testApi.js`, a typed re-export of `bun:test`) | **Deletion only** of the superseded assertion at lines 298-303 |
+| `packages/core/src/utils/errorReporting.test.ts` | Vitest | **NOT MODIFIED.** Compatibility audited in `specification.md` section 10. |
+
+### Why the split into three core files
+
+Each Bun test file runs in its own process (`packages/core/run-bun-tests.ts`
+spawns `bun test <file>` per file), so the module-private dedupe registry cannot
+leak between files. Rotation cases therefore never contend with dedupe state and
+vice versa.
+
+### Distinct-fingerprint discipline (all four new files)
+
+The dedupe registry is **process-scoped**, not directory-scoped: a fresh
+`mkdtemp` directory per test does **not** reset it. Two tests in the same file
+that report the same `(type, baseMessage, message)` triple within 60 s would see
+the second one suppressed, so no report file would be written and the assertion
+would fail for a reason unrelated to what it tests.
+
+Therefore every test in every new file uses a distinct error message (or a
+distinct `type`) unless the row is deliberately exercising coalescing. This
+binds hardest in `turn.errorReport.bun.test.ts`, where `type`
+(`Turn.run-sendMessageStream`) and `baseMessage`
+(`Error when talking to ${providerName} API`) are fixed by the production code:
+there, **the error message is the only free component**, so each of T1-T8 must
+throw a distinctly-worded error from its `ChatSession` fixture.
+
+### Why `turn.test.ts` is only edited by deletion
+
+Its assertion at lines 298-303 encodes the defective contract
+(`[...historyContent, reqParts]`). RULES.md forbids leaving a passing test that
+asserts superseded behavior. The replacement assertion is stronger — it reads
+the real report file instead of inspecting mock arguments — and lives in the new
+file that imports `bun:test` directly, so **every changed or added assertion for
+this issue sits in a direct-`bun:test` file**. `turn.test.ts` keeps its
+`reportError` import, which is still used by its lines 243 and 271, and its
+`vi.mock` is process-local so it cannot affect the new file.
+
+### Shared setup discipline
+
+Each file declares **exactly one** temp-directory lifecycle
+(`beforeEach` create via `fs.mkdtemp`, `afterEach` `fs.rm(..., { recursive: true, force: true })`)
+at the top of its single `describe`. No `beforeEach` block is duplicated across
+`describe` blocks (RULES.md, "DRY setup").
+
+---
+
+## REQ-3113-1 — Bounded report payload
+
+### REQ-3113-1.1 — Turn separates request from bounded history tail
+
+File: `packages/agents/src/core/turn.errorReport.bun.test.ts`.
+Real `Turn` + real core `reportError`; `reportError` is **not** mocked. The
+`ChatSession` collaborator is a fixture because it is the provider/network
+boundary. `process.env.TMPDIR` is set to the realpath of a fresh `mkdtemp`
+directory in `beforeEach` and restored in `afterEach`; `os.tmpdir()` was
+verified to resolve `TMPDIR` at call time under Bun (see
+`preflight-verification.md` section 4). Assertions read the file that
+`reportError` actually wrote.
+
+| ID | Given / When / Then | Evidence | Base-commit result |
+|---|---|---|---|
+| T1 | GIVEN curated history of 25 entries; WHEN `Turn.run` fails; THEN `context.recentHistory` has length 8 and deep-equals `history.slice(-8)`, and `context.omittedHistoryCount === 17` | parsed report file | **RED** — today `context` is a flat 26-element array with no `recentHistory` key |
+| T2 | GIVEN the same failure; THEN `context.request` deep-equals the request blocks and is not an element of `context.recentHistory` | parsed report file | **RED** — today the request is the last element of the flat array |
+| T3 | GIVEN empty curated history; THEN `context.recentHistory` is `[]` and `context.omittedHistoryCount === 0` and `context.request` is present | parsed report file | **RED** — today `context` is `[reqParts]` |
+| T4 | GIVEN 3 curated entries (shorter than the tail); THEN `context.recentHistory` has all 3 and `omittedHistoryCount === 0` | parsed report file | **RED** |
+| T5 | GIVEN 200 curated entries each carrying a 20,000-character text block; THEN the written report file is at most 131,072 bytes and still contains 8 `recentHistory` entries | `fs.stat().size` of the written file | **RED** — today the file is multiple MB (the defect: size scales with context) |
+| T6 | GIVEN any Turn failure; THEN the written report text contains no `\n` | raw file text | **RED** — today pretty-printed |
+| T7 | GIVEN any Turn failure; THEN exactly one `AgentEventType.Error` event is yielded with the unchanged structured error | yielded events | **GUARD** — the surrounding `handleRunError` behavior must not change |
+| T8 | GIVEN a Turn failure; THEN exactly one `llxprt-client-error-Turn.run-sendMessageStream-*.json` file exists in the reporting directory | directory listing | **GUARD** — reporting is not accidentally disabled |
+
+### REQ-3113-1.2 — Per-string clamp
+
+File: `errorReporting.bounding.bun.test.ts`.
+
+| ID | Given / When / Then | Evidence | Base-commit result |
+|---|---|---|---|
+| B3 | GIVEN `context = { blob: 'a'.repeat(10_000) }`; THEN the stored string starts with the first 4,096 `'a'`s, ends with `' [truncated: 10000 chars]'`, and its length is `4096 + marker.length` | parsed report | **RED** — today all 10,000 characters are stored |
+| B4 | GIVEN a string of exactly 4,096 characters; THEN it is stored verbatim with no marker | parsed report | **GUARD** — boundary: the clamp must be `>` not `>=` |
+| B9 | GIVEN an `Error` whose `stack` is 10,000 characters; THEN `error.stack` in the report is clamped with the same marker | parsed report | **RED** — proves the clamp is uniform, not context-only |
+
+### REQ-3113-1.3 — Array-context tail clamp
+
+| ID | Given / When / Then | Evidence | Base-commit result |
+|---|---|---|---|
+| B5 | GIVEN `context` = 200 entries of `{ text: 'x'.repeat(3_000) }` (serializes far above 128 KiB); THEN `context` has 8 entries deep-equal to the last 8 inputs and `contextTruncated.omittedEntries === 192` | parsed report | **RED** — today all 200 entries are written |
+| B5b | GIVEN the same report; THEN the file is at most 131,072 bytes | `fs.stat().size` | **RED** |
+
+### REQ-3113-1.4 — Hard payload cap
+
+| ID | Given / When / Then | Evidence | Base-commit result |
+|---|---|---|---|
+| B6 | GIVEN an **array** context of 200 entries whose last 8 entries still exceed 128 KiB (each entry an object with 40 keys of 4,000-character strings); THEN the report has no `context` key and carries `contextOmitted.reason === 'payload-exceeded-limit'` and `contextOmitted.limitBytes === 131072`, and the file is under 131,072 bytes | parsed report + `fs.stat().size` | **RED** — proves the S3 -> S4 fallthrough |
+| B7 | GIVEN a **non-array** context (an object with 200 keys of 4,000-character strings); THEN the same `contextOmitted` shape and size bound hold | parsed report + `fs.stat().size` | **RED** — this is the `generateContent-api` caller shape |
+| B8 | GIVEN a small context `{ data: 'test context' }`; THEN the report is exactly `{ error, context }` with no `contextTruncated` and no `contextOmitted` key | parsed report | **GUARD** — over-eager clamping would break the unmodifiable Vitest test |
+
+---
+
+## REQ-3113-2 — Compact JSON
+
+| ID | Given / When / Then | Evidence | Base-commit result |
+|---|---|---|---|
+| B1 | GIVEN any successful report write; THEN the raw file text contains no `\n`, and `JSON.parse` of it equals the expected object | raw text + parse | **RED** — today `JSON.stringify(..., null, 2)` |
+| B2 | GIVEN `context = { big: BigInt(1) }` so serialization throws; THEN the **minimal** fallback file is written, contains no `\n`, and parses to `{ error: { message, stack } }` | raw text of the minimal report | **RED** — the minimal report is pretty-printed today |
+
+---
+
+## REQ-3113-3 — Rotation
+
+File: `errorReporting.rotation.bun.test.ts`. Pre-existing reports are seeded
+directly with `fs.writeFile` using zero-padded ordinals
+(`llxprt-client-error-seed-00-...json` .. `seed-NN-...json`) so lexicographic
+name order equals creation order; this makes oldest-first deletion deterministic
+even when `mtimeMs` ties on fast writes. Distinct `type` values also guarantee
+distinct fingerprints, so REQ-3113-4 never interferes.
+
+| ID | Given / When / Then | Evidence | Base-commit result |
+|---|---|---|---|
+| R1 | GIVEN a directory seeded with exactly 20 small report files; WHEN one more report is written; THEN exactly 20 files matching `/^llxprt-client-error-.*\.json$/` remain | directory listing | **RED** — today 21 remain |
+| R2 | GIVEN R1's arrangement; THEN the surviving set is exactly `seed-01`..`seed-19` plus the newly written report; `seed-00` is gone and the new report is present and parseable | directory listing + read | **RED** — proves oldest-first and that the new report is never its own victim |
+| R3 | GIVEN a directory seeded with 8 report files of 130,000 bytes each (1,040,000 bytes, under both budgets); WHEN one more small report is written; THEN the total size of matching files is at most 1,048,576 and exactly 8 files remain, with `seed-00` deleted | listing + summed `fs.stat().size` | **RED** — today 9 files totalling ~1.04 MB plus the new report |
+| R4 | GIVEN a directory seeded with 20 reports plus `unrelated.json`, `llxprt-client-error-x.json.tmp`, `notes.txt`, and a **directory** named `llxprt-client-error-dir.json`; WHEN one more report is written; THEN matching regular files number exactly 20 **and** all four non-matching entries still exist | listing + `fs.stat` | **RED** via the count assertion; simultaneously proves the pattern and `isFile()` guards |
+| R6 | GIVEN a directory with 3 reports (well under both budgets); WHEN one more is written; THEN all 4 exist | listing | **GUARD** — rotation must not delete when it has no reason to |
+| R7 | GIVEN a fixed system time and a directory seeded with 25 report files, where a **directory** already occupies the exact path the next report would take (so `fs.writeFile` fails with `EISDIR`); WHEN `reportError` is called; THEN it resolves, emits the existing write-failure stderr fragments, and all 25 seeded files still exist | listing + captured stderr | **GUARD** — proves rotation runs only after a **successful** write and that a failed write deletes nothing |
+| R8 | GIVEN a directory seeded with 5 reports and one `unrelated.json`; WHEN 25 `reportError` calls with distinct types run under a single `Promise.all`; THEN the aggregate promise resolves with no rejection and `unrelated.json` survives; AND WHEN one further sequential `reportError` with a **26th distinct type** completes; THEN matching files number at most 20 | listing after each stage | **RED** on the final assertion — today the count grows without bound. Encodes the documented concurrency contract: best-effort during overlap, exact after any completed non-concurrent write. The 26 distinct types give 26 distinct fingerprints *and* 26 distinct filenames, so neither REQ-3113-4 suppression nor a same-millisecond path collision can interfere — the final call must actually write and therefore must actually rotate. |
+
+---
+
+## REQ-3113-4 — Duplicate coalescing
+
+File: `errorReporting.dedupe.bun.test.ts`. `setSystemTime` is imported directly
+from `bun:test` (availability verified in `preflight-verification.md` section 4)
+and reset to real time in `afterEach`.
+
+### Clock discipline (mandatory, applies to every row in this section)
+
+The report filename is frozen at millisecond resolution
+(`llxprt-client-error-${type}-${timestamp}.json`, REQ-3113-5). Two calls with
+the same `type` in the same millisecond therefore resolve to the **same path**,
+and the second write silently overwrites the first. Measured against the base
+commit with a frozen clock, two identical `reportError` calls left exactly one
+file (`SAME_MS_FILE_COUNT=1`, `preflight-verification.md` section 4): a naive
+"exactly one report file exists" assertion **passes with no deduplication
+whatsoever**. That is a false GREEN, not evidence.
+
+Every test in this file therefore:
+
+1. Pins `t0 = new Date('2026-08-07T00:00:00.000Z').getTime()` with
+   `setSystemTime(new Date(t0))` in `beforeEach`.
+2. Advances the clock via a single module-private `advanceTo(offsetMs)` helper
+   before **every** `reportError` call after the first that targets the same
+   directory — by the offset the row names, or by `+1_000` ms when the row does
+   not depend on the exact offset. Measured against the base commit, the same
+   two identical calls separated by 1,000 ms produced two distinct filenames
+   (`...T00-00-00-000Z.json` and `...T00-00-01-000Z.json`,
+   `ADVANCED_FILE_COUNT=2`), so "exactly one file" is genuinely RED.
+3. Keeps every advance strictly inside `REPORT_DEDUPE_WINDOW_MS` unless the row
+   is explicitly probing the boundary (D5, D6).
+4. Restores real time with `setSystemTime()` in `afterEach`.
+
+`advanceTo` is declared once; no `setSystemTime` call is repeated inline per
+assertion (RULES.md, "DRY setup").
+
+| ID | Given / When / Then | Evidence | Base-commit result |
+|---|---|---|---|
+| D1 | GIVEN a report written at `t0`; WHEN an identical `error`, `baseMessage`, and `type` are reported at `t0 + 1_000`; THEN exactly one report file exists **and its name is the `t0` name**, and the second call emits a stderr line containing `Duplicate error report suppressed` and the `t0` report's path | listing + captured stderr | **RED** — today two files, measured: `...T00-00-00-000Z.json` and `...T00-00-01-000Z.json`. The clock advance is what makes this RED; without it the base commit overwrites one path and the row would pass unchanged. |
+| D2 | GIVEN two calls with different error messages at `t0` and `t0 + 1_000`; THEN two report files exist and neither emits the suppression line | listing + stderr | **GUARD** — coalescing must not swallow distinct failures. The advance is mandatory: same `type` in the same millisecond would collapse both onto one path and fail this GUARD for an unrelated reason. |
+| D3 | GIVEN identical messages but different `type`, at `t0` and `t0 + 1_000`; THEN two report files exist | listing | **GUARD** — `type` is part of the fingerprint |
+| D4 | GIVEN identical `type` and message but different `baseMessage` (`Error when talking to claudecode API` vs `... codex API`), at `t0` and `t0 + 1_000`; THEN two report files exist | listing | **GUARD** — the exact simultaneous-two-provider scenario from the issue. Same `type`, so the advance is mandatory here too. |
+| D5 | GIVEN a report written at `t0`; WHEN an identical call occurs at `t0 + 59_999` ms and another at `t0 + 60_000` ms; THEN exactly two report files exist, named for `t0` and `t0 + 60_000` | listing with `setSystemTime` | **RED** — today three files. Pins the window boundary to `>=`. |
+| D6 | GIVEN a report at `t0` and identical suppressed calls at `t0 + 30_000` and `t0 + 59_000`; WHEN another identical call occurs at `t0 + 60_000`; THEN exactly two report files exist, named for `t0` and `t0 + 60_000` | listing with `setSystemTime` | **RED** — today four files. Proves the window is **fixed**, not extended by suppressed occurrences. |
+| D7 | GIVEN a report written at `t0` whose bytes are captured; WHEN an identical call is made at `t0 + 1_000`; THEN the `t0` file's bytes are byte-for-byte unchanged, **no file exists at the `t0 + 1_000` path**, and the matching file count is still 1 | file bytes + listing | **RED** — today a second file appears at the advanced path. Proves coalescing neither writes a new report nor rewrites a counter into the existing one. Without the advance both the byte comparison and the count would pass on the base commit, since the overwrite rewrites identical content to the same path. |
+| D8 | GIVEN a first call at `t0` whose write fails (non-existent `reportingDir`); WHEN an identical call at `t0 + 1_000` targets a writable directory; THEN a report file **is** written there | listing | **GUARD** — a failing disk must not silence the next attempt |
+| D9 | GIVEN 69 (`MAX_TRACKED_FINGERPRINTS + 5`) reports written with 69 distinct error messages under D9's own `type`, the clock advanced `+10` ms per call (680 ms total, so every window is still open), with the newest report's path (deterministic under the pinned clock, and confirmed by its `Full report available at:` stderr line), its bytes, and the sorted listing of matching files all captured; WHEN that newest fingerprint is repeated at the next `+10` ms tick; THEN stderr contains `Duplicate error report suppressed` **and the captured newest path**, AND that file's bytes are byte-for-byte unchanged, AND the sorted listing of matching files is **identical** to the captured one | captured stderr + file bytes + listing set before/after | **RED** — today there is no registry, so the repeat writes a new file at the advanced path: stderr carries `Full report available at:` instead of the suppression line, and the listing gains a name and loses none. Proves eviction never evicts the newest entry. A file-**count** assertion is deliberately not used: rotation pins the count at `MAX_REPORT_FILES` either way, so it would pass without any suppression. |
+| D10 | GIVEN the same 69-report arrangement rebuilt under **D10's own `type`** (disjoint fingerprints and filenames from D9, since the registry is process-scoped and only ~700 ms elapse), so D10's 5 oldest fingerprints have been evicted from the 64-entry registry; WHEN D10's **first**, evicted fingerprint is repeated at the next `+10` ms tick; THEN stderr contains `Full report available at:` and does **not** contain `Duplicate error report suppressed`, and a report file exists at the newly reported path | captured stderr + listing | **GUARD** — passes today because nothing is ever suppressed. It fails against an *unbounded* registry (only ~700 ms have elapsed, so an unevicted entry would suppress) and against an eviction policy that discards the newest instead of the oldest. Together D9 and D10 pin the eviction direction from both ends. |
+| D11 | GIVEN two errors whose messages share a 1,024-character prefix and differ only after it (`'a'.repeat(1_024) + '-alpha'` vs `+ '-beta'`), with identical `type` and `baseMessage`, reported at `t0` and `t0 + 1_000`; THEN two report files exist, neither call emits `Duplicate error report suppressed`, and the two parsed reports carry the two distinct full messages | listing + stderr + parsed reports | **GUARD**, annotated **fails against the rejected truncated-concatenation fingerprint**. The base commit has no coalescing, so two files appear today. Against a 512-character-sliced key the two fingerprints are byte-identical (measured, `preflight-verification.md` section 3) and the `-beta` failure would be silently suppressed — a real, distinct error never reported. 1,024 < `MAX_REPORT_STRING_CHARS` (4,096), so neither message is clamped and both are readable back verbatim. |
+
+---
+
+## REQ-3113-5 — Preserved contract
+
+| ID | Given / When / Then | Evidence | Base-commit result |
+|---|---|---|---|
+| B10 | GIVEN a non-existent `reportingDir`; THEN `reportError` resolves and stderr contains `Additionally, failed to write detailed error report:`, `Original error that triggered report generation:`, and `Original context:` | captured stderr | **GUARD** — write-failure fallback unchanged |
+| B11 | GIVEN a BigInt context; THEN stderr contains `Could not stringify report content (likely due to context):`, `Original error that triggered report generation:`, `Original context could not be stringified or included in report.`, and `Partial report (excluding context) available at:` | captured stderr | **GUARD** — serialization-failure fallback unchanged |
+| B12 | GIVEN `type = 'contract-check'`; THEN the written file's basename matches `/^llxprt-client-error-contract-check-.*\.json$/` | directory listing | **GUARD** — filename format frozen |
+| B13 | GIVEN `context` omitted entirely; THEN the report is exactly `{ error: { message, stack } }` | parsed report | **GUARD** — no `contextOmitted`/`contextTruncated` noise when there was no context |
+| — | The six existing cases in `errorReporting.test.ts` continue to pass **unmodified** | `npm run test --workspace @vybestack/llxprt-code-core` | **GUARD** — the primary preservation signal; audit in `specification.md` section 10 |
+
+---
+
+## Anti-mock-theater self-check
+
+Applied to every row above:
+
+1. **If the real implementation is deleted, does the test fail?** Yes — every
+   assertion reads a real file written to a real temp directory, real stderr
+   text, or a real yielded event.
+2. **Is any assertion of the form "a mock was called"?** No. The superseded
+   `toHaveBeenCalledWith` in `turn.test.ts` is deleted rather than adapted, and
+   its replacement (T1-T8) reads the report file produced by the real writer.
+3. **Is the component under test mocked?** No. `reportError` and `Turn` are both
+   real in every test. The only fixture is `ChatSession`, which is the
+   provider/network boundary.
+4. **Could a `return 'expected'` implementation pass?** No — the tests assert
+   file counts, byte sizes, deletion identity, ordering, and parsed structure.
+5. **Could a RED row pass against unchanged code for an incidental reason?**
+   Two such mechanisms exist here and each is neutralized by construction:
+   - *Millisecond filename collision.* Two same-millisecond writes of one `type`
+     land on one path, so the base commit's second write overwrites the first
+     and a "one file" assertion passes with no deduplication. Neutralized by the
+     mandatory clock discipline above, and measured both ways against the base
+     commit (1 file frozen, 2 files advanced).
+   - *Rotation pinning the count.* With `MAX_REPORT_FILES = 20`, any assertion
+     of the form "the matching file count is unchanged" is satisfied by rotation
+     alone once the directory is at the cap, whether or not the duplicate was
+     suppressed. Neutralized in D9 by replacing the count assertion with
+     observable suppression: the stderr suppression line carrying the original
+     report path, byte-for-byte-unchanged original report bytes, and an
+     unchanged directory listing **set** (an unsuppressed write would add one
+     name and evict another while leaving the count at 20).
+6. **Does every row still discriminate after the production change?** Yes —
+   each GUARD row names the specific wrong implementation it rejects, and D11
+   additionally names the rejected fingerprint design it rules out.


### PR DESCRIPTION
## TLDR

Bounds machine-written error reports so a provider outage cannot keep writing full-history, unbounded temp files. Reports now retain the failed request and the latest eight curated history entries, use compact bounded JSON, rotate within fixed count and byte budgets, and coalesce repeated identical failures.

## Dive Deeper

- clamps every serialized string at 4,096 characters and caps report payloads at 131,072 bytes
- falls back from full context to the last eight array entries, then to explicit context-omitted metadata when needed
- rotates matching regular report files after successful writes to at most 20 files and 1,048,576 bytes, with deterministic oldest-first ordering
- protects every report written by an overlapping rotation cohort and restores exact budgets on the next sequential write
- coalesces identical normalized failures for a fixed 60-second window using length-framed SHA-256 fingerprints and a bounded 64-entry registry
- keeps the public reportError signature, filename format, compact minimal fallback, stderr fallbacks, and never-throws behavior
- changes Turn reports to separate the failed request from a bounded recent-history tail with an omitted count

## Reviewer Test Plan

1. Run the focused error-report and Turn suites:

       bun test packages/core/src/utils/errorReporting.bounding.bun.test.ts packages/core/src/utils/errorReporting.rotation.bun.test.ts packages/core/src/utils/errorReporting.dedupe.bun.test.ts packages/core/src/utils/errorReporting.test.ts
       bun test packages/agents/src/core/turn.errorReport.bun.test.ts packages/agents/src/core/turn.test.ts

2. Run the repository gates:

       npm run test
       npm run lint
       npm run typecheck
       npm run format
       npm run build

3. Trigger repeated identical provider failures and confirm one report is written during the coalescing window, suppression messages reference the original path, report files remain compact and bounded, and a later distinct/sequential write restores rotation budgets.

Local evidence:
- focused core: 41 passed
- focused agents: 25 passed
- lint, typecheck, format, build, and stepfun-37 live smoke passed
- full monorepo run reached 354/355 core files and 348/348 agents files; its sole failure was a pre-existing load-sensitive timeout in config.mcp-lazy.test.ts, which passed 9/9 immediately in isolation
- Open Code Review completed with both findings addressed

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3113
