### PR TITLE
Return conversation history as a read-only view instead of deep-cloning it on every call (Fixes #3109)

### DIFF
--- a/packages/agents/src/api/__tests__/clientContract.characterization.spec.ts
+++ b/packages/agents/src/api/__tests__/clientContract.characterization.spec.ts
@@ -9,7 +9,7 @@
  * @requirement:REQ-INT-001.2
  *
  * Characterization tests for the client-surface contract. These pin the
- * OBSERVABLE behavior (history round-trip incl. clone + idle-wait,
+ * OBSERVABLE behavior (history round-trip incl. array isolation + idle-wait,
  * direct-message observable output, sendMessageStream event SEQUENCE) as
  * it exists TODAY so the P21 atomic cross-package flip provably preserves it.
  *
@@ -49,7 +49,7 @@ const contentArb = fc.array(
 );
 
 describe('clientContract.characterization — @plan:PLAN-20260707-AGENTNEUTRAL.P20 @requirement:REQ-INT-001.2', () => {
-  describe('history round-trip with defensive clone', () => {
+  describe('history round-trip with array isolation', () => {
     it('returns equivalent content after addHistory → getHistory', () => {
       const harness = createFullLoopHarness(
         vi.fn(async function* () {
@@ -76,7 +76,7 @@ describe('clientContract.characterization — @plan:PLAN-20260707-AGENTNEUTRAL.P
       });
     });
 
-    it('returns a clone, not a live reference (mutating result does not mutate source)', () => {
+    it('returns array isolation with shared entry references (no deep clone)', () => {
       const harness = createFullLoopHarness(
         vi.fn(async function* () {
           yield {
@@ -88,19 +88,33 @@ describe('clientContract.characterization — @plan:PLAN-20260707-AGENTNEUTRAL.P
       const { chat } = harness;
       chat.clearHistory();
       chat.addHistory(makeUserContent('original'));
-      const raw = chat.getHistory();
-      const result = historyContent(raw);
-      expect(result.length).toBeGreaterThan(0);
-      const firstBlock = result[0].blocks[0];
-      const originalText = firstBlock.type === 'text' ? firstBlock.text : '';
-      // Mutate the result
-      (result[0].blocks as Array<{ text: string }>)[0].text = 'mutated';
-      // Re-read — the live history should be unchanged
+
+      // Two successive calls return distinct arrays
+      const raw1 = chat.getHistory();
       const raw2 = chat.getHistory();
-      const result2 = historyContent(raw2);
-      const firstBlock2 = result2[0].blocks[0];
-      const finalText = firstBlock2.type === 'text' ? firstBlock2.text : '';
-      expect(finalText).toBe(originalText);
+      expect(raw1).not.toBe(raw2);
+
+      // But the entries are shared by reference (no deep clone)
+      expect(raw1.length).toBe(raw2.length);
+      for (let i = 0; i < raw1.length; i++) {
+        expect(raw1[i]).toBe(raw2[i]);
+      }
+
+      // Array-level isolation only: getAll()/getCurated() each build a fresh
+      // array, so pushing or splicing the result cannot reach live history.
+      // This says nothing about entry contents — those are SHARED by reference
+      // (asserted above), so it does NOT show that entry.blocks is protected.
+      // See the contract comment on ConversationManager.getHistory.
+      (raw1 as IContent[]).push(makeModelContent('injected'));
+      const raw3 = chat.getHistory();
+      expect(raw3.length).toBe(raw2.length);
+
+      // The live history's content is unchanged
+      const result = historyContent(raw3);
+      expect(result[0].blocks[0]).toMatchObject({
+        type: 'text',
+        text: 'original',
+      });
     });
 
     it('property: history round-trip preserves block count for ANY history', () => {

--- a/packages/agents/src/api/__tests__/helpers/clientContractObservers.ts
+++ b/packages/agents/src/api/__tests__/helpers/clientContractObservers.ts
@@ -15,9 +15,12 @@
  * Current state (post-P21):
  *  - `generateDirectMessage` returns `ModelOutput` (neutral, post-P13).
  *    `visibleText`/`usageCounts` read `content.blocks` / `usage`.
- *  - `getHistory()` returns `IContent[]` (neutral, post-P21).
+ *  - `getHistory()` returns `readonly IContent[]` (neutral, post-P21, issue #3109).
  *    `historyContent` returns a deep clone of the neutral history so the
- *    spec asserts content-equivalence and clone-independence.
+ *    spec can freely inspect/mutate without touching the live contract value.
+ *    The live contract value shares entries by reference (no deep clone);
+ *    `historyContent` clones defensively so spec assertions never observe
+ *    aliasing artifacts.
  *  - `sendMessageStream` yields `ServerAgentStreamEvent`.
  *
  * @plan:PLAN-20260707-AGENTNEUTRAL.P20
@@ -96,15 +99,17 @@ export function visibleText(directResult: unknown): string {
 /**
  * Returns a DEEP CLONE of the neutral `IContent[]` history from
  * `getHistory()` so callers can freely inspect/mutate without touching
- * the live contract value. Post-P21, `getHistory()` returns `IContent[]`
- * directly, so this is a pass-through clone (no provider conversion).
+ * the live contract value. Post-P21, `getHistory()` returns `readonly IContent[]`
+ * directly (entries shared by reference, issue #3109), so this is a
+ * pass-through clone (no provider conversion).
  */
 export function historyContent(historyResult: unknown): IContent[] {
   if (!Array.isArray(historyResult)) {
     return [];
   }
-  // Post-P21: getHistory() returns neutral IContent[] directly — no
-  // conversion needed, just a defensive deep clone.
+  // Post-P21 / #3109: getHistory() returns neutral readonly IContent[]
+  // directly (entries by reference, no deep clone) — no conversion needed,
+  // just a defensive deep clone for spec safety.
   const neutral = historyResult as IContent[];
   return neutral.map((entry) => structuredClone(entry));
 }

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -878,8 +878,7 @@ export class AgentImpl implements Agent {
   }
 
   async getHistory(): Promise<readonly AgentMessage[]> {
-    const client = this.deps.resolveClient();
-    return (await client.getHistory()) as readonly AgentMessage[];
+    return this.deps.resolveClient().getHistory();
   }
 
   async setHistory(

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -272,7 +272,7 @@ export class SessionControl implements AgentSessionControl {
   private async commitPreparedSession(
     recording: SessionRecordingService,
     lockHandle: LockHandle,
-    history: IContent[],
+    history: readonly IContent[],
   ): Promise<void> {
     const priorRecording = this.recording;
     const priorIntegration = this.integration;

--- a/packages/agents/src/core/ChatSessionFactory.ts
+++ b/packages/agents/src/core/ChatSessionFactory.ts
@@ -159,7 +159,7 @@ export interface CreateChatSessionDeps {
   contentGenerator: ContentGenerator;
   storedHistoryService: HistoryService | undefined;
   clearStoredHistoryService: () => void;
-  extraHistory?: IContent[];
+  extraHistory?: readonly IContent[];
   generateContentConfig: ModelGenerationSettings;
   todoContinuationService: TodoContinuationService;
   toolRegistry: ToolRegistry | undefined;
@@ -176,7 +176,7 @@ export interface CreateChatSessionDeps {
  */
 function loadExtraHistory(
   historyService: HistoryService,
-  extraHistory: IContent[] | undefined,
+  extraHistory: readonly IContent[] | undefined,
   currentModel: string,
 ): void {
   if (!extraHistory || extraHistory.length === 0) {
@@ -204,7 +204,7 @@ function loadExtraHistory(
  */
 function setupHistoryService(
   storedHistoryService: HistoryService | undefined,
-  extraHistory: IContent[] | undefined,
+  extraHistory: readonly IContent[] | undefined,
   runtimeState: AgentRuntimeState,
   createHistoryService: () => HistoryService,
 ): { historyService: HistoryService; reused: boolean } {
@@ -428,7 +428,7 @@ export async function createChatSessionSafe(
     await reportError(
       error,
       'Error initializing chat session.',
-      deps.extraHistory ?? [],
+      deps.extraHistory ? [...deps.extraHistory] : [],
       'startChat',
     );
     throw new Error(`Failed to initialize chat: ${getErrorMessage(error)}`);

--- a/packages/agents/src/core/ConversationManager.historyView.test.ts
+++ b/packages/agents/src/core/ConversationManager.historyView.test.ts
@@ -1,0 +1,379 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for ConversationManager.getHistory() return semantics
+ * (issue #3109).
+ *
+ * getHistory() returns live HistoryService entries BY REFERENCE — no deep
+ * clone. The returned array is a distinct instance (HistoryService.getAll()
+ * and getCurated() already return fresh arrays), so array-level mutations
+ * (push/splice) do not corrupt the live history. The readonly type enforces
+ * the read-only contract at compile time.
+ *
+ * These tests build a REAL ConversationManager on top of a REAL
+ * HistoryService + REAL AgentRuntimeContext (no mock theater) and assert
+ * reference identity, array isolation, curation semantics, and content
+ * equivalence.
+ */
+
+import * as fc from 'fast-check';
+import { describe, it, expect, beforeEach, vi } from '../testApi.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  createProviderRuntimeContext,
+  type ProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import {
+  createProviderAdapterFromManager,
+  createTelemetryAdapterFromConfig,
+  createToolRegistryViewFromRegistry,
+} from '@vybestack/llxprt-code-core/runtime/runtimeAdapters.js';
+import { ConversationManager } from './ConversationManager.js';
+import { TestRuntimeProviderManager } from '../test-utils/runtimeProviderManager.js';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import { createConfigParams } from './chatSession-runtime-helpers.js';
+
+const GENERATING_MODEL = 'claude-opus-4-8';
+
+function buildConversationManager(): {
+  conversationManager: ConversationManager;
+  historyService: HistoryService;
+} {
+  const settingsService = new SettingsService();
+  const config = new Config(createConfigParams(settingsService));
+
+  settingsService.set('providers.stub.base-url', 'https://stub.example.com');
+  settingsService.set('providers.stub.auth-key', 'stub-api-key');
+  settingsService.set('providers.stub.model', 'stub-model');
+
+  const providerRuntime: ProviderRuntimeContext = createProviderRuntimeContext({
+    settingsService,
+    config,
+    runtimeId: 'test.runtime.conversationManager.historyView',
+    metadata: { source: 'ConversationManager.historyView.test' },
+  });
+
+  const manager = new TestRuntimeProviderManager(providerRuntime);
+  manager.setConfig(config);
+  config.setProviderManager(manager);
+
+  const provider: IProvider = {
+    name: 'stub',
+    isDefault: true,
+    getModels: vi.fn(async () => []),
+    getDefaultModel: () => GENERATING_MODEL,
+    generateChatCompletion: vi.fn(async function* () {}),
+    getServerTools: () => [],
+    invokeServerTool: vi.fn(),
+    getAuthToken: vi.fn(async () => 'stub-auth-token'),
+  };
+  manager.registerProvider(provider);
+
+  const runtimeState = createAgentRuntimeState({
+    runtimeId: 'runtime-conversationManager-historyView',
+    provider: provider.name,
+    model: GENERATING_MODEL,
+    sessionId: config.getSessionId(),
+  });
+  const historyService = new HistoryService();
+  const view = createAgentRuntimeContext({
+    state: runtimeState,
+    history: historyService,
+    settings: {
+      compressionThreshold: 0.8,
+      contextLimit: 200000,
+      preserveThreshold: 0.2,
+      telemetry: { enabled: true, target: null },
+      'reasoning.includeInContext': true,
+    },
+    provider: createProviderAdapterFromManager(config.getProviderManager()),
+    telemetry: createTelemetryAdapterFromConfig(config),
+    tools: createToolRegistryViewFromRegistry(config.getToolRegistry()),
+    providerRuntime: { ...providerRuntime },
+  });
+
+  const conversationManager = new ConversationManager(historyService, view);
+
+  return { conversationManager, historyService };
+}
+
+function makeHumanContent(text: string): IContent {
+  return {
+    speaker: 'human',
+    blocks: [{ type: 'text', text }],
+  };
+}
+
+function makeAiContent(text: string): IContent {
+  return {
+    speaker: 'ai',
+    blocks: [{ type: 'text', text }],
+  };
+}
+
+/**
+ * getHistory() is typed `readonly IContent[]`, so TypeScript forbids callers
+ * from push/splice. These tests deliberately re-type the SAME runtime array as
+ * mutable to prove the RUNTIME guarantee behind that type: the array is a fresh
+ * instance, so even an untyped JS consumer that ignores the readonly contract
+ * cannot splice or reorder the live history.
+ *
+ * This covers MEMBERSHIP only. Entry contents are shared by reference (see the
+ * AC1 tests), so nothing here implies `entry.blocks` is protected from in-place
+ * mutation — that is an invariant of the history layer, pinned by the AC3 test.
+ */
+function asMutable(history: readonly IContent[]): IContent[] {
+  return history as IContent[];
+}
+
+function makeToolContent(): IContent {
+  return {
+    speaker: 'tool',
+    blocks: [
+      {
+        type: 'tool_response',
+        callId: 'test_tool',
+        toolName: 'test_tool',
+        result: { value: 42 },
+      },
+    ],
+  };
+}
+
+describe('ConversationManager.getHistory() — reference semantics (issue #3109)', () => {
+  let conversationManager: ConversationManager;
+  let historyService: HistoryService;
+
+  beforeEach(() => {
+    ({ conversationManager, historyService } = buildConversationManager());
+  });
+
+  describe('AC1 — entries returned by reference, no deep clone', () => {
+    it('returns entries that are reference-identical to HistoryService.getAll() entries', () => {
+      conversationManager.addHistory(makeHumanContent('hello'));
+      conversationManager.addHistory(makeAiContent('world'));
+
+      const all = historyService.getAll();
+      const result = conversationManager.getHistory();
+
+      expect(result.length).toBe(all.length);
+      for (let i = 0; i < result.length; i++) {
+        expect(result[i]).toBe(all[i]);
+      }
+    });
+
+    it('nested block objects are reference-identical (not deep copies)', () => {
+      conversationManager.addHistory(makeHumanContent('hello'));
+      const all = historyService.getAll();
+      const result = conversationManager.getHistory();
+
+      expect(result[0].blocks).toBe(all[0].blocks);
+    });
+
+    it('a large text block is the same object reference, not a copy', () => {
+      const largeText = 'x'.repeat(100_000);
+      conversationManager.addHistory(makeHumanContent(largeText));
+
+      const all = historyService.getAll();
+      const result = conversationManager.getHistory();
+
+      // The block object itself must be === (no deep clone of the 100KB text)
+      expect(result[0].blocks[0]).toBe(all[0].blocks[0]);
+    });
+  });
+
+  describe('AC2 — array isolation preserved', () => {
+    for (const curated of [false, true]) {
+      it(`pushing onto the returned array does not affect a later getHistory() (curated: ${curated})`, () => {
+        conversationManager.addHistory(makeHumanContent('hello'));
+        conversationManager.addHistory(makeAiContent('world'));
+
+        asMutable(conversationManager.getHistory(curated)).push(
+          makeHumanContent('injected'),
+        );
+
+        const after = conversationManager.getHistory(curated);
+        expect(after).toHaveLength(2);
+        expect(after.map((entry) => entry.speaker)).toEqual(['human', 'ai']);
+      });
+
+      it(`splicing the returned array does not affect a later getHistory() (curated: ${curated})`, () => {
+        conversationManager.addHistory(makeHumanContent('hello'));
+        conversationManager.addHistory(makeAiContent('world'));
+
+        asMutable(conversationManager.getHistory(curated)).splice(0, 1);
+
+        const after = conversationManager.getHistory(curated);
+        expect(after).toHaveLength(2);
+        expect(after.map((entry) => entry.speaker)).toEqual(['human', 'ai']);
+      });
+    }
+
+    it('two successive calls return distinct arrays but identical entry references', () => {
+      conversationManager.addHistory(makeHumanContent('hello'));
+      conversationManager.addHistory(makeAiContent('world'));
+
+      const result1 = conversationManager.getHistory();
+      const result2 = conversationManager.getHistory();
+
+      expect(result1).not.toBe(result2);
+      expect(result1.length).toBe(result2.length);
+      for (let i = 0; i < result1.length; i++) {
+        expect(result1[i]).toBe(result2[i]);
+      }
+    });
+  });
+
+  describe('AC3 — entries are shared, so the history layer must stay copy-on-write', () => {
+    /**
+     * Sharing entries by reference is only safe while every post-insertion
+     * edit path REPLACES the array slot instead of mutating the stored entry.
+     * This pins that invariant: if someone later makes replaceToolResponseBlock
+     * (or any sibling edit path) mutate in place, a previously handed-out
+     * history would silently change underneath its holder, and this test fails.
+     */
+    it('a previously returned history is not altered when a stored entry is edited', async () => {
+      conversationManager.addHistory(makeHumanContent('run the tool'));
+      conversationManager.addHistory({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-1',
+            name: 'test_tool',
+            parameters: {},
+          },
+        ],
+      });
+      conversationManager.addHistory(makeToolContent());
+
+      const captured = conversationManager.getHistory();
+      const capturedToolEntry = captured[2];
+      const capturedBlocks = capturedToolEntry.blocks;
+
+      const replaced = await historyService.replaceToolResponseBlock(
+        2,
+        0,
+        {
+          type: 'tool_response',
+          callId: 'test_tool',
+          toolName: 'test_tool',
+          result: { value: 'edited' },
+        },
+        GENERATING_MODEL,
+      );
+      expect(replaced).toBe(true);
+
+      // The captured entry and its blocks are untouched by the live edit.
+      expect(captured[2]).toBe(capturedToolEntry);
+      expect(capturedToolEntry.blocks).toBe(capturedBlocks);
+      expect(capturedBlocks[0]).toMatchObject({ result: { value: 42 } });
+
+      // ...and the live history really did change, so this is not vacuous.
+      const fresh = conversationManager.getHistory();
+      expect(fresh[2]).not.toBe(capturedToolEntry);
+      expect(fresh[2].blocks[0]).toMatchObject({ result: { value: 'edited' } });
+    });
+  });
+
+  describe('AC4 — curation semantics unchanged', () => {
+    it('empty history returns an empty array for curated: false', () => {
+      const result = conversationManager.getHistory(false);
+      expect(result).toEqual([]);
+    });
+
+    it('empty history returns an empty array for curated: true', () => {
+      const result = conversationManager.getHistory(true);
+      expect(result).toEqual([]);
+    });
+
+    it('curated:true drops an invalid/empty AI entry while getAll keeps it', () => {
+      conversationManager.addHistory(makeHumanContent('question'));
+      conversationManager.addHistory({
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: '' }],
+      });
+
+      const all = conversationManager.getHistory(false);
+      const curated = conversationManager.getHistory(true);
+
+      // getAll keeps both entries
+      expect(all.length).toBe(2);
+      // curated drops the invalid AI entry
+      expect(curated.length).toBe(1);
+      expect(curated[0].speaker).toBe('human');
+    });
+
+    it('human and tool entries always survive curation', () => {
+      conversationManager.addHistory(makeHumanContent('do something'));
+      conversationManager.addHistory(makeToolContent());
+      conversationManager.addHistory({
+        speaker: 'ai',
+        blocks: [],
+      });
+
+      const curated = conversationManager.getHistory(true);
+      expect(curated.length).toBe(2);
+      expect(curated[0].speaker).toBe('human');
+      expect(curated[1].speaker).toBe('tool');
+    });
+  });
+
+  describe('AC5 — content equivalence unchanged', () => {
+    it('addHistory → getHistory returns same length, speakers, and blocks', () => {
+      conversationManager.addHistory(makeHumanContent('hello'));
+      conversationManager.addHistory(makeAiContent('world'));
+      conversationManager.addHistory(makeToolContent());
+
+      const result = conversationManager.getHistory();
+      expect(result).toHaveLength(3);
+      expect(result[0].speaker).toBe('human');
+      expect(result[0].blocks[0]).toMatchObject({
+        type: 'text',
+        text: 'hello',
+      });
+      expect(result[1].speaker).toBe('ai');
+      expect(result[1].blocks[0]).toMatchObject({
+        type: 'text',
+        text: 'world',
+      });
+      expect(result[2].speaker).toBe('tool');
+      expect(result[2].blocks[0]).toMatchObject({ type: 'tool_response' });
+    });
+
+    it('property: addHistory → getHistory preserves speaker and block count for ANY history', () => {
+      const contentArb: fc.Arbitrary<IContent> = fc.oneof(
+        fc.string({ minLength: 1 }).map(makeHumanContent),
+        fc.string({ minLength: 1 }).map(makeAiContent),
+        fc.constant(makeToolContent()),
+      );
+
+      fc.assert(
+        fc.property(fc.array(contentArb, { maxLength: 20 }), (entries) => {
+          conversationManager.clearHistory();
+          for (const entry of entries) {
+            conversationManager.addHistory(entry);
+          }
+
+          const result = conversationManager.getHistory();
+          expect(result).toHaveLength(entries.length);
+          expect(result.map((entry) => entry.speaker)).toEqual(
+            entries.map((entry) => entry.speaker),
+          );
+          expect(result.map((entry) => entry.blocks.length)).toEqual(
+            entries.map((entry) => entry.blocks.length),
+          );
+        }),
+      );
+    });
+  });
+});

--- a/packages/agents/src/core/ConversationManager.ts
+++ b/packages/agents/src/core/ConversationManager.ts
@@ -187,7 +187,10 @@ export class ConversationManager {
    * Validates the history and converts each IContent before adding.
    * Called from ChatSession constructor after ConversationManager is created.
    */
-  importInitialHistory(initialHistory: IContent[], model: string): void {
+  importInitialHistory(
+    initialHistory: readonly IContent[],
+    model: string,
+  ): void {
     if (initialHistory.length === 0) {
       return;
     }
@@ -529,16 +532,25 @@ export class ConversationManager {
   /**
    * Gets the conversation history in neutral IContent format.
    * @param curated - If true, returns curated history; otherwise returns all history
+   *
+   * Entries are returned BY REFERENCE — no deep clone (issue #3109). Two
+   * separate guarantees are at work, and they are not the same strength:
+   *
+   * - Membership is isolated: both HistoryService.getAll() and getCurated()
+   *   already build a fresh array, so splicing or reordering the result cannot
+   *   reach the live history. `readonly` makes that a compile error too.
+   * - Entry contents are SHARED. `readonly IContent[]` is shallow, so it does
+   *   NOT stop a caller from mutating `entry.blocks` or a block in place. That
+   *   entries are not mutated after insertion is an invariant maintained by the
+   *   history layer (post-insertion edits replace the array slot — see
+   *   HistoryService.replaceToolResponse and applyDensityMutations), not
+   *   something the type system enforces. This matches what
+   *   HistoryService.getAll()/getCurated() have always exposed to their callers.
    */
-  getHistory(curated: boolean = false): IContent[] {
-    // Get history from HistoryService in IContent format (already neutral)
-    const iContents = curated
+  getHistory(curated: boolean = false): readonly IContent[] {
+    return curated
       ? this.historyService.getCurated()
       : this.historyService.getAll();
-
-    // Deep copy the history to avoid mutating the history outside of the
-    // chat session.
-    return structuredClone(iContents);
   }
 
   /**
@@ -563,7 +575,7 @@ export class ConversationManager {
   /**
    * Sets the full chat history, replacing any existing history.
    */
-  setHistory(history: IContent[]): void {
+  setHistory(history: readonly IContent[]): void {
     // The second argument to historyService.add is only a logging/token-
     // estimation hint, not attribution. This is a restore path that may run
     // before any provider is active, so read the runtime-state model directly

--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -54,12 +54,12 @@ export interface MessageStreamDeps {
   ideContextTracker: IdeContextTracker;
   agentHookManager: AgentHookManager;
   getEffectiveModelIdentity: () => EffectiveModelIdentity;
-  getHistory: () => Promise<IContent[]>;
+  getHistory: () => Promise<readonly IContent[]>;
   getSessionTurnCount: () => number;
   incrementSessionTurnCount: () => void;
   lazyInitialize: () => Promise<void>;
-  startChat: (extraHistory?: IContent[]) => Promise<ChatSession>;
-  getPreviousHistory: () => IContent[] | undefined;
+  startChat: (extraHistory?: readonly IContent[]) => Promise<ChatSession>;
+  getPreviousHistory: () => readonly IContent[] | undefined;
   setChat: (chat: ChatSession) => void;
   hasChat: () => boolean;
   complexityAnalyzer: ComplexityAnalyzer;

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -195,7 +195,7 @@ export class ChatSession {
     view: AgentRuntimeContext,
     contentGenerator: ContentGenerator,
     generationConfig: ChatSessionConfig = {},
-    initialHistory: IContent[] = [],
+    initialHistory: readonly IContent[] = [],
     triggerCompressionHook: typeof triggerPreCompressHook = triggerPreCompressHook,
   ) {
     this.runtimeContext = view;
@@ -562,7 +562,7 @@ export class ChatSession {
     this.generationConfig.tools = undefined;
   }
 
-  getHistory(curated: boolean = false): IContent[] {
+  getHistory(curated: boolean = false): readonly IContent[] {
     return this.conversationManager.getHistory(curated);
   }
 
@@ -574,7 +574,7 @@ export class ChatSession {
     this.conversationManager.addHistory(content);
   }
 
-  setHistory(history: IContent[]): void {
+  setHistory(history: readonly IContent[]): void {
     this.conversationManager.setHistory(history);
   }
 

--- a/packages/agents/src/core/client.ts
+++ b/packages/agents/src/core/client.ts
@@ -87,7 +87,7 @@ export class AgentClient implements AgentClientContract {
   private sessionTurnCount = 0;
   private readonly MAX_TURNS = 100;
   private _pendingConfig?: ContentGeneratorConfig;
-  private _previousHistory?: IContent[];
+  private _previousHistory?: readonly IContent[];
   private _storedHistoryService?: HistoryService;
   private currentSequenceModel: string | null = null;
   private activeStreamCount = 0;
@@ -216,7 +216,8 @@ export class AgentClient implements AgentClientContract {
         this.sessionTurnCount++;
       },
       lazyInitialize: () => this.lazyInitialize(),
-      startChat: (extraHistory?) => this.startChat(extraHistory),
+      startChat: (extraHistory?: readonly IContent[]) =>
+        this.startChat(extraHistory),
       getPreviousHistory: () => this._previousHistory,
       setChat: (chat) => {
         this.chat = chat;
@@ -288,7 +289,8 @@ export class AgentClient implements AgentClientContract {
   }
 
   async initialize(contentGeneratorConfig: ContentGeneratorConfig) {
-    const previousHistory = this.chat?.getHistory() ?? this._previousHistory;
+    const previousHistory: readonly IContent[] | undefined =
+      this.chat?.getHistory() ?? this._previousHistory;
 
     // Reset the client to force reinitialization with new auth
     this.contentGenerator = undefined;
@@ -413,12 +415,12 @@ export class AgentClient implements AgentClientContract {
     return this.chat !== undefined && this.contentGenerator !== undefined;
   }
 
-  async getHistory(): Promise<IContent[]> {
+  async getHistory(): Promise<readonly IContent[]> {
     // If chat is initialized, get its current history (already neutral IContent[])
     if (this.hasChatInitialized()) {
       const chat = this.getChat() as unknown as {
         waitForIdle?: () => Promise<void>;
-        getHistory: () => IContent[];
+        getHistory: () => readonly IContent[];
       };
       if (typeof chat.waitForIdle === 'function') {
         await chat.waitForIdle();
@@ -427,7 +429,11 @@ export class AgentClient implements AgentClientContract {
     }
 
     if (this._previousHistory) {
-      return this._previousHistory;
+      // Fresh array so every branch of this accessor gives the caller the same
+      // membership-isolation guarantee the chat-backed branch does. `_previousHistory`
+      // is the live field, not a per-call snapshot, so returning it directly would
+      // let a caller splice the pending history.
+      return [...this._previousHistory];
     }
 
     if (this._storedHistoryService) {
@@ -441,10 +447,10 @@ export class AgentClient implements AgentClientContract {
   }
 
   async setHistory(
-    history: IContent[],
+    history: readonly IContent[],
     { stripThoughts = false }: { stripThoughts?: boolean } = {},
   ): Promise<void> {
-    const historyToSet = stripThoughts
+    const historyToSet: readonly IContent[] = stripThoughts
       ? history.map((content) => {
           const newContent = { ...content };
           newContent.blocks = newContent.blocks.map((block) => {
@@ -477,7 +483,7 @@ export class AgentClient implements AgentClientContract {
    * This is used when resuming a chat before authentication.
    * The history will be restored when lazyInitialize() is called.
    */
-  storeHistoryForLaterUse(history: IContent[]): void {
+  storeHistoryForLaterUse(history: readonly IContent[]): void {
     this.logger.debug('Storing history for later use', {
       historyLength: history.length,
     });
@@ -593,7 +599,7 @@ export class AgentClient implements AgentClientContract {
     this._previousHistory = [];
   }
 
-  async resumeChat(history: IContent[]): Promise<void> {
+  async resumeChat(history: readonly IContent[]): Promise<void> {
     this.chat = await this.startChat(history);
   }
 
@@ -608,7 +614,7 @@ export class AgentClient implements AgentClientContract {
    * @returns Promise that resolves when history is fully restored and chat is ready
    * @throws Error if initialization fails (e.g., auth not ready, config missing)
    */
-  async restoreHistory(historyItems: IContent[]): Promise<void> {
+  async restoreHistory(historyItems: readonly IContent[]): Promise<void> {
     this.logger.debug('restoreHistory called', {
       itemCount: historyItems.length,
       hasContentGenerator: !!this.contentGenerator,
@@ -703,7 +709,7 @@ export class AgentClient implements AgentClientContract {
     return this.getChat().generateDirectMessage(params, promptId);
   }
 
-  async startChat(extraHistory?: IContent[]): Promise<ChatSession> {
+  async startChat(extraHistory?: readonly IContent[]): Promise<ChatSession> {
     this.ideContextTracker.resetContext();
     await this.lazyInitialize();
 

--- a/packages/core/src/config/agentClientLifecycle.ts
+++ b/packages/core/src/config/agentClientLifecycle.ts
@@ -25,7 +25,9 @@ import type { Config } from './config.js';
  * History IContent[] is external data that was serialized/deserialized,
  * so blocks are validated at this boundary.
  */
-export function stripThoughtSignatures(history: IContent[]): IContent[] {
+export function stripThoughtSignatures(
+  history: readonly IContent[],
+): IContent[] {
   return history.map((content) => ({
     ...content,
     blocks: content.blocks.map((block) => {
@@ -89,7 +91,7 @@ export async function extractExistingState(
   logger: DebugLogger,
   agentClient: AgentClientContract | null | undefined,
 ): Promise<{
-  history: IContent[];
+  history: readonly IContent[];
   historyService: ReturnType<AgentClientContract['getHistoryService']>;
 }> {
   if (agentClient === null || agentClient === undefined) {
@@ -179,7 +181,7 @@ export function buildNewContentGeneratorConfig(
 export function transferHistoryToNewClient(
   logger: DebugLogger,
   newAgentClient: AgentClientContract,
-  existingHistory: IContent[],
+  existingHistory: readonly IContent[],
   existingHistoryService: ReturnType<AgentClientContract['getHistoryService']>,
   newContentGeneratorConfig: ReturnType<typeof createContentGeneratorConfig>,
   previousVertexai: boolean | undefined,

--- a/packages/core/src/core/clientContract.ts
+++ b/packages/core/src/core/clientContract.ts
@@ -92,8 +92,8 @@ export interface AgentChatContract {
     params: AgentClientMessageParams,
     prompt_id: string,
   ): Promise<ModelOutput>;
-  getHistory(): IContent[];
-  setHistory(history: IContent[]): void;
+  getHistory(): readonly IContent[];
+  setHistory(history: readonly IContent[]): void;
   clearHistory(): void;
   getHistoryService(): HistoryService | null;
   wasRecentlyCompressed(): boolean;
@@ -113,25 +113,25 @@ export interface AgentClientContract {
   isInitialized(): boolean;
   hasChatInitialized(): boolean;
   getChat(): AgentChatContract;
-  getHistory(): Promise<IContent[]>;
+  getHistory(): Promise<readonly IContent[]>;
   getHistoryService(): HistoryService | null;
   storeHistoryServiceForReuse(service: HistoryService): void;
-  storeHistoryForLaterUse(history: IContent[]): void;
+  storeHistoryForLaterUse(history: readonly IContent[]): void;
   dispose(): void;
   setTools(): Promise<void>;
   clearTools(): void;
   updateSystemInstruction(): Promise<void>;
   addHistory(content: IContent): Promise<void>;
   resetChat(): Promise<void>;
-  resumeChat(history: IContent[]): Promise<void>;
+  resumeChat(history: readonly IContent[]): Promise<void>;
   setHistory(
-    history: IContent[],
+    history: readonly IContent[],
     options?: { stripThoughts?: boolean },
   ): Promise<void>;
-  restoreHistory(historyItems: IContent[]): Promise<void>;
+  restoreHistory(historyItems: readonly IContent[]): Promise<void>;
   addDirectoryContext(): Promise<void>;
   getContentGenerator(): ContentGenerator;
-  startChat(extraHistory?: IContent[]): Promise<AgentChatContract>;
+  startChat(extraHistory?: readonly IContent[]): Promise<AgentChatContract>;
   generateDirectMessage(
     params: AgentClientMessageParams,
     promptId: string,

--- a/packages/core/src/services/history/HistoryService.addAll.test.ts
+++ b/packages/core/src/services/history/HistoryService.addAll.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for HistoryService.addAll (issue #3109).
+ *
+ * `addAll` accepts `readonly IContent[]`, which makes `getRawHistory()` — the
+ * accessor that hands out the backing array itself — a legal argument. `add`
+ * appends to that same array, so iterating the caller's array live would let
+ * the loop consume its own appends and never terminate. `addAll` therefore
+ * iterates a snapshot.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { HistoryService } from './HistoryService.js';
+import type { IContent } from './IContent.js';
+
+function makeEntry(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+describe('HistoryService.addAll', () => {
+  it('terminates and doubles the history when fed its own backing array', () => {
+    const service = new HistoryService();
+    service.addAll([makeEntry('one'), makeEntry('two')]);
+
+    service.addAll(service.getRawHistory());
+
+    const all = service.getAll();
+    expect(all).toHaveLength(4);
+    expect(all.map((entry) => entry.blocks[0])).toMatchObject([
+      { text: 'one' },
+      { text: 'two' },
+      { text: 'one' },
+      { text: 'two' },
+    ]);
+  });
+
+  it('appends every entry of an unrelated array in order', () => {
+    const service = new HistoryService();
+    service.addAll([makeEntry('first')]);
+    service.addAll([makeEntry('second'), makeEntry('third')]);
+
+    expect(service.getAll().map((entry) => entry.blocks[0])).toMatchObject([
+      { text: 'first' },
+      { text: 'second' },
+      { text: 'third' },
+    ]);
+  });
+
+  it('is a no-op for an empty array', () => {
+    const service = new HistoryService();
+    service.addAll([makeEntry('only')]);
+
+    service.addAll([]);
+
+    expect(service.getAll()).toHaveLength(1);
+  });
+});

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -590,7 +590,7 @@ export class HistoryService
   /**
    * Add multiple contents to the history
    */
-  addAll(contents: IContent[], modelName?: string): void {
+  addAll(contents: readonly IContent[], modelName?: string): void {
     for (const content of contents) {
       this.add(content, modelName);
     }

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -588,10 +588,15 @@ export class HistoryService
   }
 
   /**
-   * Add multiple contents to the history
+   * Add multiple contents to the history.
+   *
+   * Iterates a snapshot because `add` appends to `this.history`: if `contents`
+   * aliases the backing array (`getRawHistory()`), a live iterator would keep
+   * consuming its own appends and never terminate. `replaceAll` is already
+   * immune the same way — its `filter` produces a fresh array before use.
    */
   addAll(contents: readonly IContent[], modelName?: string): void {
-    for (const content of contents) {
+    for (const content of [...contents]) {
       this.add(content, modelName);
     }
   }

--- a/packages/core/src/utils/checkpointUtils.ts
+++ b/packages/core/src/utils/checkpointUtils.ts
@@ -14,7 +14,7 @@ import type { ToolCallRequestInfo } from '../core/turn.js';
 
 export interface ToolCallData<HistoryType = unknown, ArgsType = unknown> {
   history?: HistoryType;
-  clientHistory?: IContent[];
+  clientHistory?: readonly IContent[];
   commitHash?: string;
   toolCall: {
     name: string;

--- a/project-plans/issue3109/plan.md
+++ b/project-plans/issue3109/plan.md
@@ -194,6 +194,12 @@ awaiting-approval path."
 | 12 | Add an assertion pinning that mutating `raw1[0].blocks[0].text` DOES corrupt live history | **Reject** | `dev-docs/RULES.md` forbids writing a passing test that enshrines undesirable behavior as specification — it would make a future hardening (deep-readonly, freezing) look like a regression. The detection this asks for already exists without that cost: the reference-identity assertions (`expect(raw1[i]).toBe(raw2[i])`, plus the AC1 tests) fail if a deep clone or entry-level copy-on-read is reintroduced. Verified by reinstating `structuredClone` locally — 4 tests went red. |
 | 13-14 | `AgentClientContract.generateJson` / `generateContent` still take `IContent[]`, not `readonly IContent[]` | **Defer** | Those take caller-supplied content, not history from `getHistory()`; nothing in this ripple reaches them and OCR confirms "No correctness bug." Widening them is adjacent cleanup outside this issue. |
 
+### CodeRabbit triage (PR #3125)
+
+| # | Finding | Class | Action |
+| --- | --- | --- | --- |
+| 15 | Widening `HistoryService.addAll` to `readonly IContent[]` made `addAll(getRawHistory())` type-check, and `add` appends to the array being iterated — a non-terminating loop | **In-scope-Fix** | Valid, and specifically a barrier this PR removed: `getRawHistory()` already returned `readonly IContent[]`, so before the widening that call was a type error. Fixed by iterating a snapshot (`[...contents]`), matching how `replaceAll` is already immune (its `filter` yields a fresh array). Rejected CodeRabbit's suggested `contents === this.history ? [...contents] : contents` identity check — an ad-hoc guard that only covers one aliasing source, where an unconditional snapshot is simpler and uniform. Pinned by `HistoryService.addAll.test.ts`; verified RED (the test hangs without the snapshot). |
+
 ### Known-flaky local suite
 
 `packages/agents/src/core/__tests__/subagentOrchestrator-loadBalancer.test.ts`

--- a/project-plans/issue3109/plan.md
+++ b/project-plans/issue3109/plan.md
@@ -1,0 +1,208 @@
+# Issue #3109 — `getHistory()` deep-clones the entire conversation on every call
+
+Performance task. The retention-causation claim in the original issue body was
+**disproven** by the instrumented probe in #3111 (0/8 tracked `structuredClone`
+results survived a forced `Bun.gc(true)`); the steady-state leak is unbounded
+thinking-block accumulation, tracked separately. What remains valid and is the
+whole of this task: `ConversationManager.getHistory()` deep-copies the entire
+conversation on every call, from many per-turn call sites, when every caller
+needs only a read-only view.
+
+## Current behaviour
+
+`packages/agents/src/core/ConversationManager.ts`:
+
+    getHistory(curated: boolean = false): IContent[] {
+      const iContents = curated
+        ? this.historyService.getCurated()
+        : this.historyService.getAll();
+      return structuredClone(iContents);
+    }
+
+`HistoryService.getAll()` already returns `[...this.history]` and
+`getCurated()` already builds a fresh array via `buildCuratedHistory`. So the
+array is **already** isolated from the live history before `structuredClone`
+runs. The only thing the deep clone adds is per-entry (deep) isolation, at the
+cost of materialising the system prompt, the LLXPRT.md context block, every
+prior turn, all tool I/O, and all serialised request bodies on every call.
+
+## Call-site audit (evidence for the change)
+
+Every non-test call site was inspected. **None mutates the returned entries.**
+
+| Call site | Use | Mutates entries? |
+| --- | --- | --- |
+| `agents/src/core/MessageStreamOrchestrator.ts:404` | reads `length` + last entry's blocks (**per turn**) | no |
+| `agents/src/core/turn.ts:588` | `[...getHistory(true), req]` → `reportError` (serialise) | no |
+| `agents/src/core/client.ts:291` | snapshot into `_previousHistory` across auth re-init | no |
+| `agents/src/core/client.ts:426` | client-level accessor pass-through | no |
+| `agents/src/api/agentImpl.ts:882` | public `getHistory()` — **already typed `readonly`** | no |
+| `agents/src/api/agentImpl.ts:1229` | `carriedHistory` → `startChat(...)` | no |
+| `agents/src/api/control/sessionControl.ts:220` | returned to caller | no |
+| `agents/src/api/control/sessionControl.ts:282` | `priorHistory` rollback snapshot → `setHistory` | no |
+| `agents/src/api/control/sessionControl.ts:647` | → `HistoryMutationService.clear(history: readonly IContent[], …)` | no |
+| `agents/src/api/control/sessionControl.ts:890` | `recordContent(item)` per entry | no |
+| `core/src/config/agentClientLifecycle.ts:114` | `length` + copy-on-write `stripThoughtSignatures` | no |
+| `core/src/config/config.ts:367` | `length` only | no |
+| `core/src/utils/checkpointUtils.ts:124` | `JSON.stringify` | no |
+| `cli/src/ui/hooks/agentStream/checkpointPersistence.ts:101` | `JSON.stringify` | no |
+| `cli/src/ui/commands/copyCommand.ts:30` | `filter` / `map` | no |
+| `cli/src/ui/commands/chatCommand.ts:445` | → `HistoryMutationService.clear` (readonly param) | no |
+| `cli/src/ui/commands/chatCommand.ts:494` | → `HistoryMutationService.restore` (readonly param) | no |
+| `cli/src/ui/commands/chatCommand.ts:669` | `length` only | no |
+| `cli/src/zed-integration/zed-session-loader.ts:141` | `[...history]` | no |
+
+Corroborating invariant: the history layer already treats stored `IContent`
+entries as **immutable**. Every in-place edit path replaces the array slot
+rather than mutating the entry —
+`HistoryService.replaceToolResponse` (`this.history[i] = { ...entry, blocks }`),
+`applyDensityMutations` (`history[index] = replacement`),
+`client.setHistory({ stripThoughts: true })` (maps to new objects),
+`agentClientLifecycle.stripThoughtSignatures` (maps to new objects).
+Because entries are already copy-on-write, sharing them with readers is safe.
+
+Therefore no caller needs an isolated mutable deep copy, and **no
+`cloneForMutation()` escape hatch is added** — a clone API with zero callers
+would be speculative dead code.
+
+## Accepted behaviour (acceptance criteria)
+
+**AC1 — No deep clone.** `ConversationManager.getHistory()` returns the entries
+held by the live `HistoryService` **by reference**. Given a recorded history,
+`conversationManager.getHistory()[i]` is reference-identical (`===`) to
+`historyService.getAll()[i]`, and the nested block object is reference-identical
+too. This is the direct, deterministic proof that no deep copy occurred (better
+evidence than timing).
+
+**AC2 — Array isolation is preserved.** The returned array is a distinct array
+instance from the live internal array. `push`/`splice`/reorder on the returned
+array does not change what a subsequent `getHistory()` returns, for both
+`curated: false` and `curated: true`.
+
+**AC3 — The read-only contract is expressed in the type, and the sharing it
+implies is pinned by a test.** `getHistory()` returns `readonly IContent[]`,
+propagated through `chatSession.getHistory()`, `AgentChatContract.getHistory()`,
+`AgentClientContract.getHistory()` and `AgentClient.getHistory()`.
+
+Be precise about what this does and does not buy, because `readonly T[]` in
+TypeScript is **shallow**:
+
+- It *does* make `push`/`splice`/reorder on the result a compile error, which is
+  the mutation that could corrupt history membership.
+- It does *not* stop `entry.blocks[0].text = …`. Entries are shared by
+  reference, so entry-level immutability is an **invariant maintained by the
+  history layer**, not a compile-time guarantee: every post-insertion edit path
+  replaces the array slot (`HistoryService.replaceToolResponseBlock`,
+  `applyDensityMutations`) rather than mutating the stored entry. The one
+  in-place write is the additive `metadata.chronology` stamp at the insertion
+  boundary (`ChronologyStamper.stamp`), which is documented as an ownership
+  transfer and happens before the entry is observable through `getHistory()`.
+
+That invariant is what makes reference-sharing safe, so it is pinned by a
+regression test: a previously returned history must not change when a stored
+entry is subsequently edited (`ConversationManager.historyView.test.ts`, AC3).
+
+This is the same exposure `HistoryService.getAll()` / `getCurated()` — both
+public, and both reachable from the client contracts via `getHistoryService()` —
+have always given their callers. The issue explicitly asks `getHistory()` to
+follow that existing pattern.
+
+**AC4 — Curation semantics unchanged.** `getHistory(true)` still excludes
+invalid/empty AI entries and still includes all human and tool entries;
+`getHistory(false)` still returns everything.
+
+**AC5 — Content equivalence unchanged.** `addHistory` → `getHistory` still
+returns equivalent content (same length, same speakers, same blocks), including
+for arbitrary generated histories.
+
+**AC6 — No behavioural regression.** The existing agents/core/cli suites pass
+unchanged, including the resume/restore/clear, checkpoint, `--continue`, and
+auth-refresh history-carry paths.
+
+### Boundary cases covered
+
+- empty history; `curated` true and false
+- history whose only AI entry is invalid/empty (curated drops it, `getAll` keeps it)
+- entries carrying a large text block (reference identity proves no copy)
+- `getHistory()` called twice: both calls return distinct arrays, identical entries
+- client-level `getHistory()` before chat init (`_previousHistory` / stored
+  `HistoryService` fallbacks) and after chat init
+
+## Change set
+
+Type-only ripple, measured by a spike: 8 real sites. (A separate 3-error
+pre-existing failure — `LoopDetectionSnapshot` / `checkpoint` / `restore` in
+`MessageStreamOrchestrator.ts` — reproduces on unmodified `main` from a stale
+`packages/core/dist` and is not part of this change.)
+
+1. `packages/agents/src/core/ConversationManager.ts` — drop `structuredClone`,
+   return `readonly IContent[]`.
+2. `packages/agents/src/core/chatSession.ts` — `getHistory(): readonly IContent[]`.
+3. `packages/core/src/core/clientContract.ts` — `AgentChatContract.getHistory():
+   readonly IContent[]`; `AgentClientContract.getHistory(): Promise<readonly
+   IContent[]>`; widen the non-mutating history **parameters** the ripple
+   requires (`setHistory`, `startChat`, `restoreHistory`, `resumeChat`,
+   `storeHistoryForLaterUse`) to `readonly IContent[]`. Widening a parameter is
+   source-compatible for existing callers.
+4. `packages/agents/src/core/client.ts` — `getHistory(): Promise<readonly
+   IContent[]>`; `_previousHistory?: readonly IContent[]`; orchestrator dep
+   `getHistory` type.
+5. `packages/agents/src/core/MessageStreamOrchestrator.ts` — dep signature.
+6. `packages/agents/src/api/agentImpl.ts` — `startChat(carriedHistory)`.
+7. `packages/agents/src/api/control/sessionControl.ts` — `setHistory(history)` at
+   two sites.
+8. `packages/core/src/config/agentClientLifecycle.ts` +
+   `packages/core/src/utils/checkpointUtils.ts` — `readonly IContent[]` on the
+   history fields they carry.
+
+## Explicitly deferred (not in this change)
+
+The issue's proposed fix item 3 asked checkpoint persistence to serialise "a
+curated/minimal projection rather than the whole history, and only when
+checkpoints are enabled and a restorable tool call is actually in the
+awaiting-approval path."
+
+- The gating half is **already implemented**:
+  `checkpointPersistence.saveRestorableToolCalls` returns early unless
+  `checkpoint.getCheckpointingEnabled()` is true, and filters to
+  `status === 'awaiting_approval'` restorable (`replace` / `write_file`) calls.
+- The projection half would change the **on-disk checkpoint format** and reduce
+  restore fidelity. That is a functional/format change with restore-correctness
+  risk, not a performance change, and this issue was explicitly re-scoped to
+  performance. Deferred; the deep clone is removed from that path regardless.
+
+## Review triage
+
+| # | Finding | Class | Action |
+| --- | --- | --- | --- |
+| 1 | `readonly IContent[]` is shallow, so entry/block mutation still compiles; the plan claimed any mutation attempt is a compile error | In-scope-Fix (partial) | AC3 and the `getHistory()` comment rewritten to state exactly what `readonly` does and does not guarantee. See #2 for the rejected half. |
+| 2 | Proposed remedy: restore an isolated deep-clone snapshot at the "public" boundary and add an internal borrowed `getHistoryView()` | **Reject** | The public boundary (`AgentImpl.getHistory`) is one of the per-turn call sites the issue names, so cloning there reinstates exactly the cost this issue exists to remove. It is also defence-in-depth against a hypothetical external mutator while the identical exposure stays wide open through `getHistoryService().getAll()/getCurated()` — both already public on `AgentChatContract`/`AgentClientContract` and unchanged here. The issue explicitly directs `getHistory()` to follow the existing non-cloning `getCurated()` pattern. |
+| 3 | Deep-readonly (`DeepReadonly<IContent>`) instead of shallow `readonly` | **Defer** | Would fully close the typing gap, but `DeepReadonly<IContent>` is not assignable to `IContent`, so every consumer that builds new turns from history entries would need casts. That is a data-model change across packages, far beyond this issue. |
+| 4 | `AgentClient.getHistory()` returned `_previousHistory` directly, so the membership-isolation guarantee did not hold on the pre-chat-init branch | In-scope-Fix | Returns `[...this._previousHistory]`. Cold path only (no chat yet), so it does not reintroduce per-turn cost. |
+| 5 | No test would catch a future contributor making a history edit path mutate in place | In-scope-Fix | Added AC3 regression test: a previously returned history must not change when a stored entry is edited via `replaceToolResponseBlock`, and the live history must actually have changed (so the test is not vacuous). |
+| 6 | `client.ts` structural cast still declared `getHistory: () => IContent[]`; concrete `storeHistoryForLaterUse` still took `IContent[]` | In-scope-Fix | Both widened to `readonly IContent[]`. |
+| 7 | "Copy-on-write" overstated: `ChronologyStamper.stamp` writes `metadata.chronology` in place | In-scope-Fix | Documented precisely — it is an additive stamp at the insertion boundary (documented ownership transfer) that happens before the entry is observable through `getHistory()`. |
+| 8 | Stale describe label `history round-trip with defensive clone` | In-scope-Fix | Renamed to `history round-trip with array isolation`. |
+| 9 | `ChatSessionFactory` spreads `extraHistory` for `reportError(context?: unknown[])`; widening `reportError` would be cleaner | **Reject** | Reviewer agrees it is not a correctness problem. Error path only; widening a shared core utility is out of scope. |
+| 10 | Checkpoint "curated/minimal projection" not implemented | **Defer** | See *Explicitly deferred* above; reviewer agreed the deferral is defensible. |
+
+### Open Code Review triage (2 local runs; run 1 found 0, run 2 found 4)
+
+| # | Finding | Class | Action |
+| --- | --- | --- | --- |
+| 11 | `clientContract.characterization.spec.ts` comment claimed the push "proves … even an untyped consumer cannot corrupt live history" — misleading, it only proves membership isolation | In-scope-Fix | Comment corrected in both that spec and the new test file to scope the claim to membership. |
+| 12 | Add an assertion pinning that mutating `raw1[0].blocks[0].text` DOES corrupt live history | **Reject** | `dev-docs/RULES.md` forbids writing a passing test that enshrines undesirable behavior as specification — it would make a future hardening (deep-readonly, freezing) look like a regression. The detection this asks for already exists without that cost: the reference-identity assertions (`expect(raw1[i]).toBe(raw2[i])`, plus the AC1 tests) fail if a deep clone or entry-level copy-on-read is reintroduced. Verified by reinstating `structuredClone` locally — 4 tests went red. |
+| 13-14 | `AgentClientContract.generateJson` / `generateContent` still take `IContent[]`, not `readonly IContent[]` | **Defer** | Those take caller-supplied content, not history from `getHistory()`; nothing in this ripple reaches them and OCR confirms "No correctness bug." Widening them is adjacent cleanup outside this issue. |
+
+### Known-flaky local suite
+
+`packages/agents/src/core/__tests__/subagentOrchestrator-loadBalancer.test.ts`
+fails non-deterministically under local parallel load (5s per-test timeouts):
+different tests fail on each run, and it also fails on a stashed, unmodified
+tree. Not a regression from this change; CI is the arbiter.
+
+## Non-goals
+
+- No change to `HistoryService` storage, curation, compression, or density.
+- No new public abstraction, no `cloneForMutation()` (zero callers).
+- No lint/complexity rule changes and no suppression directives.


### PR DESCRIPTION
## TLDR

`ConversationManager.getHistory()` ended with `return structuredClone(iContents);` — a **full deep clone of the entire conversation on every call**. That materialises fresh copies of the system prompt, the LLXPRT.md context block, every prior turn, all tool I/O and all serialised request bodies, and it runs from per-turn hot paths (the orchestrator's IDE-context injection, the error-report path, checkpoint writes, session control, auth refresh).

This PR removes the deep clone. `getHistory()` now returns `readonly IContent[]` with entries shared by reference — exactly the pattern `HistoryService.getAll()` / `getCurated()` have always used, and which the issue explicitly asks `getHistory()` to follow.

**Scope note for reviewers:** this is a **performance** change only. The issue's original "this is the memory-leak root cause" claim was disproven in the issue comments (a WeakRef probe found 0/8 clones retained across a forced `Bun.gc(true)`); the actual retention bug is tracked separately. This PR does not claim to bound long-session memory growth.

The two things worth reviewer attention:

1. **Why removing the clone is safe** — the call-site audit and the copy-on-write invariant, both summarised below.
2. **`readonly T[]` is shallow** — that limit is stated honestly in the code and the plan rather than oversold, and the invariant it does *not* cover is pinned by a regression test.

## Dive Deeper

### Why the clone was pure overhead

`HistoryService.getAll()` already returns `[...this.history]`, and `getCurated()` already builds a fresh array via `buildCuratedHistory`. **Membership isolation already existed before the clone ran.** The `structuredClone` only added per-*entry* deep isolation, at the cost of copying the whole conversation.

### Call-site audit — every non-test caller is read-only

| Call site | Use | Mutates entries? |
| --- | --- | --- |
| `agents/core/MessageStreamOrchestrator.ts:404` | reads `length` + last entry's blocks (**per turn**) | no |
| `agents/core/turn.ts:588` | `[...getHistory(true), req]` into `reportError` | no |
| `agents/core/client.ts:291` | snapshot into `_previousHistory` across auth re-init | no |
| `agents/core/client.ts:426` | client-level accessor pass-through | no |
| `agents/api/agentImpl.ts:882` | public `getHistory()` — **already typed `readonly`** | no |
| `agents/api/agentImpl.ts:1229` | `carriedHistory` into `startChat(...)` | no |
| `agents/api/control/sessionControl.ts` x4 | recording, rollback snapshot, `HistoryMutationService` (readonly param) | no |
| `core/config/agentClientLifecycle.ts:114` | `length` + copy-on-write `stripThoughtSignatures` | no |
| `core/config/config.ts:367` | `length` only | no |
| `core/utils/checkpointUtils.ts:124`, `cli/.../checkpointPersistence.ts:101` | `JSON.stringify` | no |
| `cli/.../copyCommand.ts:30` | `filter` / `map` | no |
| `cli/.../chatCommand.ts` x3 | `length`; `HistoryMutationService.clear/restore` (readonly params) | no |
| `cli/zed-integration/zed-session-loader.ts:141` | `[...history]` | no |

Because **zero** callers need an isolated mutable copy, **no `cloneForMutation()` escape hatch was added** — an API with no callers is speculative dead code.

### The invariant that makes reference-sharing safe

The history layer already treats stored entries as immutable. Every post-insertion edit path **replaces the array slot** instead of mutating the entry:

- `HistoryService.replaceToolResponseBlock` does `this.history[i] = { ...entry, blocks: newBlocks }`
- `applyDensityMutations` does `history[index] = replacement`
- `client.setHistory({ stripThoughts: true })` and `agentClientLifecycle.stripThoughtSignatures` map to new objects

The single in-place write is the additive `metadata.chronology` stamp in `ChronologyStamper.stamp`, which is documented as an ownership transfer at the insertion boundary and happens *before* the entry is observable through `getHistory()`.

### Being precise about `readonly IContent[]`

`readonly T[]` in TypeScript is **shallow**. Stated plainly so nobody is misled:

- It **does** make `push`/`splice`/reorder a compile error — the mutation that could corrupt history *membership*.
- It **does not** stop `entry.blocks[0].text = ...`. Entry-level immutability is the history-layer invariant above, not a type guarantee.

This is the same exposure `HistoryService.getAll()` / `getCurated()` already give their callers — both are public and already reachable from the client contracts via `getHistoryService()`, and `client.getHistory()` already returned `_storedHistoryService.getAll()` un-cloned before this PR. So the change introduces no new *class* of exposure; it makes one accessor consistent with the sanctioned pattern.

Because that invariant is now load-bearing, it is **pinned by a regression test**: a previously returned history must not change when a stored entry is edited via `replaceToolResponseBlock`, and the live history must actually have changed (so the test is not vacuous). A future in-place edit path fails the build instead of silently corrupting a handed-out history.

### The rest of the diff

Mechanical `readonly` ripple through the chat/client contracts, widening non-mutating history *parameters* (`setHistory`, `startChat`, `restoreHistory`, `resumeChat`, `storeHistoryForLaterUse`, `addAll`, `extraHistory`). Widening a parameter to `readonly` is source-compatible for existing callers. One additional fix: `AgentClient.getHistory()`'s pre-chat-init branch returned the live `_previousHistory` field directly, so the membership guarantee did not hold there; it now returns a fresh array (cold path only).

### Deliberately deferred

The issue's proposed fix item 3 asked checkpoint persistence to serialise "a curated/minimal projection ... and only when checkpoints are enabled and a restorable tool call is actually in the awaiting-approval path."

- The **gating half is already implemented**: `saveRestorableToolCalls` returns early unless `checkpoint.getCheckpointingEnabled()`, and filters to `status === 'awaiting_approval'` restorable (`replace` / `write_file`) calls.
- The **projection half** would change the on-disk checkpoint format and reduce restore fidelity — a functional/format change with restore-correctness risk, not a performance change. Deferred; the deep clone is removed from that path regardless.

Full acceptance criteria, the complete audit, and the review triage (deepthinker plus 2 Open Code Review runs, each finding classified Fix / Reject / Defer with rationale) are in `project-plans/issue3109/plan.md`.

## Reviewer Test Plan

**Prove the clone is gone (the core claim).** The evidence is reference identity, not timing — deterministic and not machine-dependent:

    bun test packages/agents/src/core/ConversationManager.historyView.test.ts

15 tests. To confirm they are not vacuous, reinstate the clone in `ConversationManager.getHistory()`:

    return structuredClone(
      curated ? this.historyService.getCurated() : this.historyService.getAll(),
    );

...and re-run — **4 tests go red** (entry identity, nested block identity, the 100KB block, and cross-call entry identity). Revert to get them green again.

**Prove the contract still holds at the agent-API level:**

    bun test packages/agents/src/api/__tests__/clientContract.characterization.spec.ts

**Exercise it end to end.** The change sits on the per-turn path, so any real multi-turn session with tool use exercises it — the orchestrator calls `getHistory()` every turn:

    bun scripts/start.ts --profile-load <your-profile>

Then drive a few turns with tool calls and confirm conversation context is preserved across turns. Worth specifically exercising the paths that snapshot history:

- `/chat clear` and `/chat restore N` (history mutation via `HistoryMutationService`)
- `/copy` (reads the last AI message out of history)
- `--continue` / session resume (carried history across a client rebuild)
- a provider/model switch mid-session (auth refresh into the `_previousHistory` carry)
- checkpointing enabled, then trigger a `write_file`/`replace` approval prompt (checkpoint JSON still contains full history)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the `stepfun-37` profile smoke test.

One caveat, stated rather than hidden: the local agents/core suites show timeout-based flakiness under parallel load — *different* files fail on each run, they pass in isolation, and the same behaviour reproduces on an unmodified tree. Nothing that failed locally is related to this change (e.g. MCP folder-trust wiring, the interactive-run harness). CI is the arbiter.

## Linked issues / bugs

Fixes #3109

Related to #3111 and #3114 — those track the actual unbounded-retention bug (thinking/reasoning blocks accumulating in `content.blocks`). This PR does **not** fix that and does not claim to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - History APIs now protect conversation history arrays from accidental modification.
  - Reading history returns an isolated array, so adding or removing items from a returned result no longer changes the active conversation.
  - History entries retain their existing content and references, preserving expected conversation behavior while improving consistency across chat sessions and history transfers.

- **Tests**
  - Added comprehensive coverage for history isolation, editing behavior, curation, and content preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->