### PR TITLE
Release per-turn stream state and prove the memory plateau (Fixes #3114)

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -961,9 +961,11 @@ memory limits, and all three must be sized correctly:
    per-container limit passed to the container runtime. You can set this higher
    than the VM memory, but the process will be OOM-killed when the VM runs out
    of memory first.
-3. **Node.js heap limit** (`--max-old-space-size`) — automatically derived from
+3. **Node.js heap limit** (`--max-old-space-size`) — derived from
    the container memory limit when `ui.autoConfigureMaxOldSpaceSize` is enabled
-   (the default).
+   (the default). This applies only when the sandbox CLI runs under Node.js;
+   under Bun, `--max-old-space-size` is not set because Bun does not honour the
+   V8 flag.
 
 If you set the container memory higher than the Podman VM memory, the container
 starts but the process gets OOM-killed (exit code 137) as soon as it tries to

--- a/packages/agents/src/core/turn.cooperative-cleanup.bun.test.ts
+++ b/packages/agents/src/core/turn.cooperative-cleanup.bun.test.ts
@@ -203,8 +203,9 @@ describe('Turn run - cooperative iterator cleanup (issue #3114)', () => {
       traceId: undefined,
     });
     expect(returnCalled).toBe(true);
-    // The bounded cleanup timeout is 1s. The turn must finish within a
-    // reasonable margin of that bound, not hang forever.
-    expect(elapsed).toBeLessThan(5_000);
+    // The bounded cleanup timeout is 1s. The margin absorbs scheduling jitter
+    // on a loaded CI runner while still failing a regression that adds another
+    // whole second to every turn.
+    expect(elapsed).toBeLessThan(2_500);
   });
 });

--- a/packages/agents/src/core/turn.cooperative-cleanup.bun.test.ts
+++ b/packages/agents/src/core/turn.cooperative-cleanup.bun.test.ts
@@ -18,7 +18,7 @@
  * except the ChatSession transport (an infrastructure boundary).
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from '../testApi.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
 import type { ServerAgentStreamEvent } from './turn.js';
 import { Turn, AgentEventType, DEFAULT_AGENT_ID } from './turn.js';
 import type { ChatSession } from './chatSession.js';
@@ -26,12 +26,12 @@ import { StreamEventType } from './chatSession.js';
 import { type MockedChatInstance, mockChunk } from './turn-test-helpers.js';
 import { waitForCondition } from '../test-utils/eventLoop.js';
 
-const { mockSendMessageStream, mockGetHistory } = vi.hoisted(() => ({
+const { mockSendMessageStream, mockGetHistory } = {
   mockSendMessageStream: vi.fn(),
   mockGetHistory: vi.fn(),
-}));
+};
 
-vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
+void vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
   reportError: vi.fn(),
 }));
 

--- a/packages/agents/src/core/turn.cooperative-cleanup.bun.test.ts
+++ b/packages/agents/src/core/turn.cooperative-cleanup.bun.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for Turn.run() cooperative iterator cleanup (issue #3114).
+ *
+ * A turn must await its provider iterator's cooperative asynchronous cleanup
+ * (return()'s promise, or a generator's finally block) before the turn
+ * generator finishes — including when the consumer exits early — while a
+ * noncooperative iterator that never settles remains bounded by the existing
+ * cleanup timeout.
+ *
+ * These tests drive the public Turn.run() generator with real async iterators
+ * whose cleanup is controlled by a deferred release. No component is mocked
+ * except the ChatSession transport (an infrastructure boundary).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from '../testApi.js';
+import type { ServerAgentStreamEvent } from './turn.js';
+import { Turn, AgentEventType, DEFAULT_AGENT_ID } from './turn.js';
+import type { ChatSession } from './chatSession.js';
+import { StreamEventType } from './chatSession.js';
+import { type MockedChatInstance, mockChunk } from './turn-test-helpers.js';
+import { waitForCondition } from '../test-utils/eventLoop.js';
+
+const { mockSendMessageStream, mockGetHistory } = vi.hoisted(() => ({
+  mockSendMessageStream: vi.fn(),
+  mockGetHistory: vi.fn(),
+}));
+
+vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
+  reportError: vi.fn(),
+}));
+
+function streamIterable(
+  iterator: AsyncIterator<unknown>,
+): AsyncIterable<unknown> {
+  return {
+    [Symbol.asyncIterator]: () => iterator,
+  };
+}
+
+function chunkEvent(text: string): {
+  type: typeof StreamEventType.CHUNK;
+  value: ReturnType<typeof mockChunk>;
+} {
+  return { type: StreamEventType.CHUNK, value: mockChunk({ text }) };
+}
+
+describe('Turn run - cooperative iterator cleanup (issue #3114)', () => {
+  let turn: Turn;
+  let mockChatInstance: MockedChatInstance;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockChatInstance = {
+      sendMessageStream: mockSendMessageStream,
+      getHistory: mockGetHistory,
+      getConfig: () => undefined,
+    };
+    turn = new Turn(
+      mockChatInstance as unknown as ChatSession,
+      'prompt-id-1',
+      DEFAULT_AGENT_ID,
+      'test',
+    );
+    mockGetHistory.mockReturnValue([]);
+    mockSendMessageStream.mockResolvedValue((async function* () {})());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('awaits cooperative iterator cleanup before finishing after early consumer exit', async () => {
+    let releaseCleanup = (): void => {};
+    const cleanupReleased = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    let returnStarted = false;
+    let returnSettled = false;
+
+    const providerIterator: AsyncIterator<unknown> = {
+      next: async () => ({
+        done: false,
+        value: chunkEvent('first'),
+      }),
+      return: async () => {
+        returnStarted = true;
+        await cleanupReleased;
+        returnSettled = true;
+        return { done: true, value: undefined };
+      },
+    };
+    mockSendMessageStream.mockResolvedValue(streamIterable(providerIterator));
+
+    let consumerFinished = false;
+    const consumer = (async () => {
+      for await (const _event of turn.run(
+        [{ text: 'test' }],
+        new AbortController().signal,
+      )) {
+        break;
+      }
+      consumerFinished = true;
+    })();
+
+    // Wait until iterator.return() has been called — that proves the break
+    // triggered the generator finally block and cleanup started — rather than
+    // assuming one flushEventLoop call reached cleanup.
+    await waitForCondition(() => returnStarted);
+
+    // The consumer must NOT have finished: the cooperative cleanup is still
+    // pending on the deferred release.
+    expect(consumerFinished).toBe(false);
+    expect(returnSettled).toBe(false);
+
+    releaseCleanup();
+    await consumer;
+
+    expect(consumerFinished).toBe(true);
+    expect(returnSettled).toBe(true);
+  });
+
+  it('awaits cooperative iterator cleanup before finishing on normal stream completion', async () => {
+    let releaseCleanup = (): void => {};
+    const cleanupReleased = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    let returnStarted = false;
+    let returnSettled = false;
+
+    const providerIterator: AsyncIterator<unknown> = {
+      next: async () => ({
+        done: true,
+        value: undefined,
+      }),
+      return: async () => {
+        returnStarted = true;
+        await cleanupReleased;
+        returnSettled = true;
+        return { done: true, value: undefined };
+      },
+    };
+    mockSendMessageStream.mockResolvedValue(streamIterable(providerIterator));
+
+    let consumerFinished = false;
+    const consumer = (async () => {
+      const events: ServerAgentStreamEvent[] = [];
+      for await (const event of turn.run(
+        [{ text: 'test' }],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+      consumerFinished = true;
+    })();
+
+    // Wait until iterator.return() has been called — that proves normal
+    // completion triggered cleanup — rather than assuming one flushEventLoop
+    // call reached cleanup.
+    await waitForCondition(() => returnStarted);
+
+    // Normal completion still must wait for cooperative cleanup.
+    expect(consumerFinished).toBe(false);
+    expect(returnSettled).toBe(false);
+
+    releaseCleanup();
+    await consumer;
+
+    expect(consumerFinished).toBe(true);
+    expect(returnSettled).toBe(true);
+  });
+
+  it('preserves bounded cleanup timeout for a noncooperative iterator', async () => {
+    let returnCalled = false;
+    const providerIterator: AsyncIterator<unknown> = {
+      next: async () => ({ done: false, value: chunkEvent('first') }),
+      return: () => {
+        returnCalled = true;
+        return new Promise<IteratorResult<unknown>>(() => {});
+      },
+    };
+    mockSendMessageStream.mockResolvedValue(streamIterable(providerIterator));
+
+    const events: ServerAgentStreamEvent[] = [];
+    const start = Date.now();
+    for await (const event of turn.run(
+      [{ text: 'test' }],
+      new AbortController().signal,
+    )) {
+      events.push(event);
+      break;
+    }
+    const elapsed = Date.now() - start;
+
+    expect(events).toContainEqual({
+      type: AgentEventType.Content,
+      value: 'first',
+      traceId: undefined,
+    });
+    expect(returnCalled).toBe(true);
+    // The bounded cleanup timeout is 1s. The turn must finish within a
+    // reasonable margin of that bound, not hang forever.
+    expect(elapsed).toBeLessThan(5_000);
+  });
+});

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -690,7 +690,6 @@ export class Turn {
           watchdog,
           timeoutController,
           streamIterator,
-          timeoutSignal,
           signal,
           onParentAbort,
         );
@@ -707,22 +706,27 @@ export class Turn {
   }
 
   /**
-   * Tears down watchdog, timeout controller, and stream iterator without
+   * Tears down watchdog, stream iterator, and timeout controller without
    * letting a cleanup failure mask the original stream result. Iterator
    * cleanup rejections are logged as warnings but never rethrown.
+   *
+   * Iterator closure is awaited before the timeout controller is aborted so
+   * that a cooperative iterator's asynchronous cleanup (return()'s promise or
+   * a generator's finally block) completes before the turn finishes —
+   * including when the consumer exits early. The cleanup signal is omitted so
+   * the turn's own abort cannot short-circuit the wait; a noncooperative
+   * iterator is still bounded by closeIteratorBounded's internal timeout.
    */
   private async cleanupStreamResources(
     watchdog: StreamWatchdog,
     timeoutController: AbortController,
     streamIterator: AsyncIterator<StreamEvent> | undefined,
-    timeoutSignal: AbortSignal,
     signal: AbortSignal,
     onParentAbort: () => void,
   ): Promise<void> {
     watchdog.cancel();
-    timeoutController.abort();
     try {
-      await closeIteratorBounded(streamIterator, timeoutSignal);
+      await closeIteratorBounded(streamIterator);
     } catch (cleanupError) {
       this.logger.warn(
         () =>
@@ -733,6 +737,7 @@ export class Turn {
           }`,
       );
     }
+    timeoutController.abort();
     signal.removeEventListener('abort', onParentAbort);
   }
 

--- a/project-plans/issue3114-memory-plateau.md
+++ b/project-plans/issue3114-memory-plateau.md
@@ -1,0 +1,148 @@
+# Plan: Bound Long-Running Session Memory
+
+Plan ID: PLAN-20260807-ISSUE3114
+Generated: 2026-08-07
+Issue: https://github.com/vybestack/llxprt-code/issues/3114
+
+## Scope
+
+This plan completes the remaining accepted work for issue 3114. Several sub-issues were split out and merged independently while this work was in progress; none of them may be duplicated here.
+
+Already on `main` and therefore excluded from this change set:
+
+- **PR #3117 (issue #3111)** — thinking-block coalescing in `StreamOutputAccumulator`. The primary retention fix. Exercised as acceptance evidence by the reasoning workload below, but not re-implemented.
+- **PR #3123 (issue #3112)** — honest Bun memory footer and runtime-aware `--max-old-space-size` suppression.
+- **PR #3125 (issue #3109)** — read-only history view instead of deep cloning.
+- **PR #3124 (issue #3113)** — bounded and rotated error reports.
+
+### In scope
+
+- Await per-turn iterator cleanup before final timeout-controller teardown.
+- Extend the existing issue-2852 memory target and runner with a reasoning workload and plateau verdicts for JSC heap, Bun external memory, and dirty WebKit Malloc.
+- Correct the sandbox documentation that PR #3123 left describing the pre-#3112 behavior.
+
+### Out of scope
+
+- Issue 3109 history cloning, which was disproven as a retention cause and has since merged separately.
+- Issue 3113 error-report rotation and rate limiting, which is a separate subsystem and disk/allocation problem, and has since merged separately.
+- Shell output/backpressure candidates that were not the retained-string cause.
+- Dependencies, workflows, public abstractions, speculative hardening, and unrelated refactors.
+
+## Requirements and acceptance scenarios
+
+### REQ-3114-1: Lossless bounded reasoning retention
+
+**Requirement:** A reasoning span with a stable stream identifier retains one latest block regardless of streamed delta count, without losing complete reasoning content or provider metadata.
+
+- **Given** a provider emits many full-so-far thinking blocks for one span,
+- **when** the real stream accumulator materializes the response,
+- **then** it contains one thinking block with the final complete text and metadata.
+- **Boundary:** an interrupted span retains its latest delta; spans without identifiers preserve fallback behavior; unrelated content blocks retain their order.
+
+**Evidence:** Keep `packages/agents/src/core/streamOutputAccumulator.bun.test.ts` green and exercise the same accumulator from the memory target. No new production implementation is required.
+
+### REQ-3114-2: Cooperative stream cleanup completes at turn end
+
+**Requirement:** A turn must await its provider iterator's cooperative asynchronous cleanup before the turn generator finishes, without allowing the turn's own abort to short-circuit that wait.
+
+- **Given** `Turn.run()` is consuming a provider iterator whose `finally` waits on a controlled release,
+- **when** the turn completes or its consumer exits early,
+- **then** the turn remains unfinished until the provider cleanup release settles.
+- **Boundary:** a non-cooperative `return()` remains bounded by the existing cleanup timeout.
+
+**Integration contract:** `Turn.cleanupStreamResources()` owns final iterator closure and timeout-controller teardown. `closeIteratorBounded()` retains its existing external-abort behavior; only the caller's ordering and signal choice change.
+
+### REQ-3114-3: Multi-metric post-GC plateau proof
+
+**Requirement:** The existing issue-2852 harness must demonstrate that repeated equivalent reasoning turns plateau after GC rather than grow with turn count.
+
+- **Given** a reasoning-mode target repeatedly sends full-so-far thinking updates through the real `StreamOutputAccumulator`,
+- **when** the runner records post-GC checkpoints,
+- **then** it evaluates JSC heap, `process.memoryUsage().external`, and dirty WebKit Malloc independently with the existing 10% plateau tolerance,
+- **and** the overall verdict passes only when every required metric plateaus.
+- **Boundary:** the first post-GC sample remains warm-up; missing/insufficient metric samples fail rather than silently pass.
+
+**Integration contract:** add a `reasoning` mode to `scripts/issue-2852-memory-target.ts`; extend `scripts/issue-2852-memory-runner.ts`; reuse parsing and plateau helpers in `scripts/issue-2852-memory-benchmark.ts`.
+
+### REQ-3114-4: Honest Bun memory footer
+
+**Delivered upstream — not implemented here.** Issue #3112 was split out and merged as PR #3123 while this work was in progress. `Footer.tsx` now omits the V8 denominator under Bun and retains Heap, RSS, External and ArrayBuffers. Re-implementing it in this change would duplicate merged work, so the footer is taken unchanged from `main`.
+
+### REQ-3114-5: Runtime-aware memory arguments
+
+**Delivered upstream — not implemented here.** Also merged as PR #3123: `shouldRelaunchForMemory()` and `computeSandboxMemoryArgs()` return an empty argument list under Bun, with the Node paths unchanged.
+
+The one gap PR #3123 left is documentation: `docs/sandbox.md` still described the Node heap limit as automatically derived regardless of runtime. That correction is carried here so the documented behavior matches the shipped behavior.
+
+### REQ-3114-6: No silent content loss
+
+**Requirement:** The implementation must not introduce truncation or discard conversation content.
+
+- The reasoning accumulator's latest block contains the complete full-so-far reasoning value and metadata.
+- No new length, count, or disk bound is introduced by this plan.
+- Therefore no new truncation label is required.
+
+## Test-first implementation sequence
+
+### Phase 0: Preflight
+
+- Confirm the merged accumulator implementation and its Bun behavioral tests are in branch ancestry.
+- Confirm `Turn.run()` owns iterator finalization and that the existing cleanup timeout bounds non-cooperative iterators.
+- Confirm the memory target already emits process memory and the runner already captures dirty WebKit Malloc.
+- Confirm `process.versions.bun` is configurable in Bun tests so Node behavior can be simulated without a production testing hook or public abstraction.
+- Confirm CLI and agents test runners discover new Bun test files.
+
+### Phase 1: Turn cleanup RED/GREEN
+
+1. Add a Bun behavioral test that drives the public `Turn.run()` generator with a provider iterator whose asynchronous `finally` is controlled by a deferred release.
+2. Demonstrate RED: after early consumer exit, the turn incorrectly finishes before that release.
+3. Change `cleanupStreamResources()` to request and await bounded iterator closure before aborting the timeout controller, without handing cleanup the controller signal that finalization itself owns.
+4. Demonstrate GREEN and run existing iterator/Turn tests to preserve timeout and rejection behavior.
+
+### Phase 2: Memory harness RED/GREEN
+
+1. Add Bun-native tests for reasoning target selection, required metric extraction, and an overall verdict that fails if any one required metric grows.
+2. Demonstrate RED because reasoning mode and multi-metric verdicts do not exist.
+3. Add deterministic reasoning turns through the real accumulator, force post-turn GC, and verify each materialized result is one complete block.
+4. Extend runner output and failure logic to report plateau results for heap, external, and dirty WebKit Malloc.
+5. Demonstrate GREEN, then run the real reasoning target/runner on macOS with `--expose-gc` and preserve its captured output as verification evidence rather than a committed artifact.
+
+### Phase 3 and Phase 4: superseded by PR #3123
+
+The footer and bootstrap phases were planned before issue #3112 was split out and merged. Their implementation and tests now live on `main`, so both phases are dropped rather than duplicated. Only the sandbox documentation correction that PR #3123 did not make is carried here.
+
+Verify the footer still renders honestly through the tmux harness, since this change set rebases onto that merged behavior.
+
+### Phase 5: Verification and bounded review
+
+Run focused tests after each phase, then run:
+
+```sh
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Run the tmux-harness footer check, DeepThinker review, and detached Open Code Review with `--timeout 20`. Classify every finding as:
+
+- **Blocker-Fix:** violates safety, correctness, accepted requirements, architecture, tests, lint, or CI.
+- **In-scope-Fix:** a valid defect within REQ-3114-1 through REQ-3114-6.
+- **Reject:** factually incorrect or contradicted by source/behavior.
+- **Defer:** valid but outside the explicit scope above.
+
+Do not perform more than two review/remediation cycles. All Blocker-Fix and In-scope-Fix findings must be resolved before commit.
+
+## Completion gate
+
+Issue 3114 is complete only when:
+
+- Every requirement above has behavioral evidence.
+- The real reasoning memory run reports a post-GC plateau for all required metrics.
+- Full local verification and the Bun smoke test pass on the candidate head.
+- Footer behavior has been exercised in the tmux harness.
+- Reviews are complete and every finding is classified and resolved appropriately.
+- The PR candidate head has correct ancestry, no conflicts, green CI, and no unresolved required review threads.
+- No out-of-scope cleanup, hardening, workflow, dependency, or public abstraction change was added.

--- a/scripts/issue-2852-memory-benchmark.ts
+++ b/scripts/issue-2852-memory-benchmark.ts
@@ -116,7 +116,7 @@ export function parsePostGcRecords(
   return contents
     .split('\n')
     .map((line, index) => ({ line, lineNumber: index + 1 }))
-    .filter(({ line }) => line.length > 0)
+    .filter(({ line }) => line.trim().length > 0)
     .map(({ line, lineNumber }) => {
       try {
         return JSON.parse(line) as CheckpointRecord;

--- a/scripts/issue-2852-memory-benchmark.ts
+++ b/scripts/issue-2852-memory-benchmark.ts
@@ -94,6 +94,43 @@ export interface PlateauResult {
   readonly withinTolerance: boolean;
 }
 
+export interface CheckpointRecord {
+  readonly name?: string;
+  readonly jsc?: { readonly heapSize?: number };
+  readonly processMemory?: { readonly external?: number };
+}
+
+/**
+ * Parses the target's checkpoint JSONL and keeps the post-GC records.
+ *
+ * A parse failure names the 1-based line as it appears in the file, because a
+ * bare SyntaxError identifies neither the file nor which of several hundred
+ * records is malformed. Line numbers are captured before blank lines are
+ * dropped, so the reported number survives blank lines anywhere in the file.
+ * The error is re-thrown, never swallowed: a corrupt artifact must fail the run.
+ */
+export function parsePostGcRecords(
+  path: string,
+  contents: string,
+): CheckpointRecord[] {
+  return contents
+    .split('\n')
+    .map((line, index) => ({ line, lineNumber: index + 1 }))
+    .filter(({ line }) => line.length > 0)
+    .map(({ line, lineNumber }) => {
+      try {
+        return JSON.parse(line) as CheckpointRecord;
+      } catch (error) {
+        throw new Error(
+          `${path} line ${lineNumber} is not valid JSON: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    })
+    .filter((record) => record.name?.endsWith('-post-gc') === true);
+}
+
 export function evaluatePostGcPlateau(
   postGcHeapBytes: readonly number[],
   tolerance: number,

--- a/scripts/issue-2852-memory-benchmark.ts
+++ b/scripts/issue-2852-memory-benchmark.ts
@@ -125,6 +125,62 @@ export function evaluatePostGcPlateau(
   };
 }
 
+/**
+ * Post-GC memory readings for one turn, combining the three required metrics:
+ * JSC heap size, process.memoryUsage().external, and dirty WebKit Malloc.
+ */
+export interface PostGcMetrics {
+  readonly jscHeapBytes: number;
+  readonly externalBytes: number;
+  readonly webkitMallocDirtyBytes: number;
+}
+
+export interface MetricPlateauResult extends PlateauResult {
+  readonly name: string;
+}
+
+export interface MultiMetricPlateauResult {
+  readonly overallWithinTolerance: boolean;
+  readonly metrics: readonly MetricPlateauResult[];
+}
+
+/**
+ * Evaluates post-GC plateau for every required metric independently. The
+ * overall verdict passes only when every metric plateaus within the tolerance;
+ * the first post-GC sample is warm-up for each metric.
+ */
+export function evaluateMultiMetricPlateau(
+  samples: readonly PostGcMetrics[],
+  tolerance: number,
+): MultiMetricPlateauResult {
+  if (samples.length < 3) {
+    throw new Error('Plateau needs at least three post-GC turns');
+  }
+  if (!(tolerance > 0)) {
+    throw new Error('Tolerance must be positive');
+  }
+
+  const extractors: ReadonlyArray<{
+    name: string;
+    read: (s: PostGcMetrics) => number;
+  }> = [
+    { name: 'jscHeap', read: (s) => s.jscHeapBytes },
+    { name: 'external', read: (s) => s.externalBytes },
+    { name: 'webkitMallocDirty', read: (s) => s.webkitMallocDirtyBytes },
+  ];
+
+  const metricResults = extractors.map(({ name, read }) => {
+    const series = samples.map(read);
+    const result = evaluatePostGcPlateau(series, tolerance);
+    return { name, ...result };
+  });
+
+  return {
+    overallWithinTolerance: metricResults.every((m) => m.withinTolerance),
+    metrics: metricResults,
+  };
+}
+
 function requireMetric(output: string, pattern: RegExp, name: string): number {
   const match = output.match(pattern);
   if (match === null) {

--- a/scripts/issue-2852-memory-runner.ts
+++ b/scripts/issue-2852-memory-runner.ts
@@ -11,20 +11,22 @@ import process from 'node:process';
 import { spawn, spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import {
+  evaluateMultiMetricPlateau,
   evaluatePostGcPlateau,
   parseFootprintBytes,
   parsePsRssBytes,
   parseVmmapSummary,
   validateCheckpointOrder,
   validateExactPid,
+  type PostGcMetrics,
 } from './issue-2852-memory-benchmark.js';
 
 const artifactDir = resolve(
   process.argv[2] ?? `/tmp/llxprt-issue-2852-${Date.now()}`,
 );
 const mode = process.argv[3] ?? 'text';
-if (mode !== 'text' && mode !== 'media') {
-  throw new Error('Mode must be text or media');
+if (mode !== 'text' && mode !== 'media' && mode !== 'reasoning') {
+  throw new Error('Mode must be text, media, or reasoning');
 }
 const turns = Number.parseInt(process.argv[4] ?? '4', 10);
 if (!Number.isInteger(turns) || turns < 3) {
@@ -151,18 +153,41 @@ if (exitCode !== 0) {
 }
 
 validateCheckpointOrder(checkpoints.map((checkpoint) => checkpoint.name));
-const plateau = evaluatePostGcPlateau(
-  readPostGcHeapBytes(targetOutput),
-  PLATEAU_TOLERANCE,
-);
+const osByCheckpointName = new Map(checkpoints.map((cp) => [cp.name, cp]));
 writeFileSync(resolve(artifactDir, 'target.stdout'), Buffer.concat(stdout));
 writeFileSync(resolve(artifactDir, 'target.stderr'), Buffer.concat(stderr));
+
+// `reasoning` gates every retention metric because bounding reasoning blocks
+// must show up in external and dirty WebKit Malloc, not just the JSC heap.
+const plateau =
+  mode === 'reasoning'
+    ? evaluateMultiMetricPlateau(
+        readPostGcMetrics(targetOutput, osByCheckpointName),
+        PLATEAU_TOLERANCE,
+      )
+    : evaluatePostGcPlateau(
+        readPostGcHeapBytes(targetOutput),
+        PLATEAU_TOLERANCE,
+      );
+
 writeFileSync(
   resolve(artifactDir, 'os-checkpoints.json'),
   `${JSON.stringify({ targetPid: target.pid, mode, turns, plateau, checkpoints }, null, 2)}\n`,
 );
 process.stdout.write(`${artifactDir}\n`);
-if (!plateau.withinTolerance) {
+
+if ('overallWithinTolerance' in plateau) {
+  if (!plateau.overallWithinTolerance) {
+    const failed = plateau.metrics
+      .filter((metric) => !metric.withinTolerance)
+      .map(
+        (metric) =>
+          `${metric.name} grew ${(metric.growthRatio * 100).toFixed(1)}%`,
+      )
+      .join(', ');
+    throw new Error(`Post-GC plateau failed: ${failed}`);
+  }
+} else if (!plateau.withinTolerance) {
   throw new Error(
     `Post-GC JSC heap grew ${(plateau.growthRatio * 100).toFixed(1)}% across equivalent turns`,
   );
@@ -171,6 +196,7 @@ if (!plateau.withinTolerance) {
 interface CheckpointRecord {
   readonly name?: string;
   readonly jsc?: { readonly heapSize?: number };
+  readonly processMemory?: { readonly external?: number };
 }
 
 /** Post-GC JSC heap size for each turn, oldest first. */
@@ -189,6 +215,59 @@ function readPostGcHeapBytes(path: string): number[] {
       }
       return heapSize;
     });
+}
+
+/**
+ * Post-GC combined metrics for the multi-metric plateau verdict: JSC heap and
+ * process.memoryUsage().external from the target checkpoint, plus dirty WebKit
+ * Malloc from the matching OS (vmmap) checkpoint.
+ */
+function readPostGcMetrics(
+  path: string,
+  osCheckpoints: ReadonlyMap<string, OsCheckpoint>,
+): PostGcMetrics[] {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as CheckpointRecord)
+    .filter((record) => record.name?.endsWith('-post-gc') === true)
+    .map((record) => {
+      const osCheckpoint = osCheckpoints.get(record.name ?? '');
+      return {
+        jscHeapBytes: requireMetric(
+          record.jsc?.heapSize,
+          'jscHeap',
+          record.name,
+        ),
+        externalBytes: requireMetric(
+          record.processMemory?.external,
+          'external',
+          record.name,
+        ),
+        webkitMallocDirtyBytes: requireMetric(
+          osCheckpoint?.vmmap.webkitMallocDirtyBytes,
+          'webkitMallocDirty',
+          record.name,
+        ),
+      };
+    });
+}
+
+/**
+ * Fails fast, naming the metric and checkpoint, so a missing OS checkpoint or a
+ * malformed target record is diagnosable without inspecting the raw artifacts.
+ */
+function requireMetric(
+  value: unknown,
+  metric: string,
+  checkpointName: string | undefined,
+): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(
+      `Checkpoint ${checkpointName ?? '<unnamed>'} is missing required metric ${metric}`,
+    );
+  }
+  return value;
 }
 
 function captureOsCheckpoint(

--- a/scripts/issue-2852-memory-runner.ts
+++ b/scripts/issue-2852-memory-runner.ts
@@ -14,10 +14,12 @@ import {
   evaluateMultiMetricPlateau,
   evaluatePostGcPlateau,
   parseFootprintBytes,
+  parsePostGcRecords,
   parsePsRssBytes,
   parseVmmapSummary,
   validateCheckpointOrder,
   validateExactPid,
+  type CheckpointRecord,
   type PostGcMetrics,
 } from './issue-2852-memory-benchmark.js';
 
@@ -193,36 +195,9 @@ if ('overallWithinTolerance' in plateau) {
   );
 }
 
-interface CheckpointRecord {
-  readonly name?: string;
-  readonly jsc?: { readonly heapSize?: number };
-  readonly processMemory?: { readonly external?: number };
-}
-
-/**
- * Post-GC checkpoint records from the target's JSONL, oldest first.
- *
- * A parse failure names the offending line, because the alternative is a bare
- * SyntaxError that says nothing about which of several hundred checkpoint
- * records is malformed. The error is re-thrown, not swallowed: a corrupt
- * artifact must still fail the run.
- */
+/** Post-GC checkpoint records from the target's JSONL, oldest first. */
 function readPostGcRecords(path: string): CheckpointRecord[] {
-  return readFileSync(path, 'utf8')
-    .split('\n')
-    .filter((line) => line.length > 0)
-    .map((line, index) => {
-      try {
-        return JSON.parse(line) as CheckpointRecord;
-      } catch (error) {
-        throw new Error(
-          `${path} line ${index + 1} is not valid JSON: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
-    })
-    .filter((record) => record.name?.endsWith('-post-gc') === true);
+  return parsePostGcRecords(path, readFileSync(path, 'utf8'));
 }
 
 /** Post-GC JSC heap size for each turn, oldest first. */

--- a/scripts/issue-2852-memory-runner.ts
+++ b/scripts/issue-2852-memory-runner.ts
@@ -199,22 +199,37 @@ interface CheckpointRecord {
   readonly processMemory?: { readonly external?: number };
 }
 
-/** Post-GC JSC heap size for each turn, oldest first. */
-function readPostGcHeapBytes(path: string): number[] {
+/**
+ * Post-GC checkpoint records from the target's JSONL, oldest first.
+ *
+ * A parse failure names the offending line, because the alternative is a bare
+ * SyntaxError that says nothing about which of several hundred checkpoint
+ * records is malformed. The error is re-thrown, not swallowed: a corrupt
+ * artifact must still fail the run.
+ */
+function readPostGcRecords(path: string): CheckpointRecord[] {
   return readFileSync(path, 'utf8')
     .split('\n')
     .filter((line) => line.length > 0)
-    .map((line) => JSON.parse(line) as CheckpointRecord)
-    .filter((record) => record.name?.endsWith('-post-gc') === true)
-    .map((record) => {
-      const heapSize = record.jsc?.heapSize;
-      if (typeof heapSize !== 'number' || !Number.isFinite(heapSize)) {
+    .map((line, index) => {
+      try {
+        return JSON.parse(line) as CheckpointRecord;
+      } catch (error) {
         throw new Error(
-          `Checkpoint ${record.name} has no usable JSC heap size`,
+          `${path} line ${index + 1} is not valid JSON: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
         );
       }
-      return heapSize;
-    });
+    })
+    .filter((record) => record.name?.endsWith('-post-gc') === true);
+}
+
+/** Post-GC JSC heap size for each turn, oldest first. */
+function readPostGcHeapBytes(path: string): number[] {
+  return readPostGcRecords(path).map((record) =>
+    requireMetric(record.jsc?.heapSize, 'jscHeap', record.name),
+  );
 }
 
 /**
@@ -226,31 +241,22 @@ function readPostGcMetrics(
   path: string,
   osCheckpoints: ReadonlyMap<string, OsCheckpoint>,
 ): PostGcMetrics[] {
-  return readFileSync(path, 'utf8')
-    .split('\n')
-    .filter((line) => line.length > 0)
-    .map((line) => JSON.parse(line) as CheckpointRecord)
-    .filter((record) => record.name?.endsWith('-post-gc') === true)
-    .map((record) => {
-      const osCheckpoint = osCheckpoints.get(record.name ?? '');
-      return {
-        jscHeapBytes: requireMetric(
-          record.jsc?.heapSize,
-          'jscHeap',
-          record.name,
-        ),
-        externalBytes: requireMetric(
-          record.processMemory?.external,
-          'external',
-          record.name,
-        ),
-        webkitMallocDirtyBytes: requireMetric(
-          osCheckpoint?.vmmap.webkitMallocDirtyBytes,
-          'webkitMallocDirty',
-          record.name,
-        ),
-      };
-    });
+  return readPostGcRecords(path).map((record) => {
+    const osCheckpoint = osCheckpoints.get(record.name ?? '');
+    return {
+      jscHeapBytes: requireMetric(record.jsc?.heapSize, 'jscHeap', record.name),
+      externalBytes: requireMetric(
+        record.processMemory?.external,
+        'external',
+        record.name,
+      ),
+      webkitMallocDirtyBytes: requireMetric(
+        osCheckpoint?.vmmap.webkitMallocDirtyBytes,
+        'webkitMallocDirty',
+        record.name,
+      ),
+    };
+  });
 }
 
 /**

--- a/scripts/issue-2852-memory-target.ts
+++ b/scripts/issue-2852-memory-target.ts
@@ -29,6 +29,9 @@ import process from 'node:process';
 import { heapStats } from 'bun:jsc';
 import { EmojiFilter } from '../packages/core/src/filters/EmojiFilter.js';
 import { PendingResponseBuffer } from '../packages/cli/src/ui/hooks/agentStream/pendingResponseBuffer.js';
+import { StreamOutputAccumulator } from '../packages/agents/src/core/streamOutputAccumulator.js';
+import type { ModelStreamChunk } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import type { ThinkingBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 
 const [, , outputPath, mode = 'text', turnArg = '4'] = process.argv;
 if (
@@ -36,11 +39,11 @@ if (
   process.env['LLXPRT_MEMORY_PORT'] === undefined
 ) {
   throw new Error(
-    'Usage: LLXPRT_MEMORY_PORT=PORT bun issue-2852-memory-target.ts OUTPUT [text|media] [turns]',
+    'Usage: LLXPRT_MEMORY_PORT=PORT bun issue-2852-memory-target.ts OUTPUT [text|media|reasoning] [turns]',
   );
 }
-if (mode !== 'text' && mode !== 'media') {
-  throw new Error(`Mode must be 'text' or 'media', got: ${mode}`);
+if (mode !== 'text' && mode !== 'media' && mode !== 'reasoning') {
+  throw new Error(`Mode must be 'text', 'media', or 'reasoning', got: ${mode}`);
 }
 const port = process.env['LLXPRT_MEMORY_PORT'];
 if (!/^\d+$/.test(port) || Number(port) < 1 || Number(port) > 65_535) {
@@ -148,6 +151,111 @@ function runMediaTurn(): number {
   return bytes;
 }
 
+function reasoningChunk(
+  blocks: ModelStreamChunk['content']['blocks'],
+): ModelStreamChunk {
+  return { content: { speaker: 'ai', blocks } };
+}
+
+function reasoningThinking(partial: {
+  thought: string;
+  streamId: string;
+  streamStatus: 'delta' | 'complete';
+  signature?: string;
+}): ThinkingBlock {
+  return { type: 'thinking', sourceField: 'thinking', ...partial };
+}
+
+const REASONING_STEP_PREFIX = 'step '.repeat(20);
+
+/**
+ * Deterministic final reasoning string per turn: roughly 30 KB so 200 deltas of
+ * full-so-far prefixes accumulate several MB of cumulative materialized text
+ * per turn, reproducing the original duplicated-string pressure.
+ */
+const REASONING_FINAL_LENGTH = 30_000;
+
+function buildFinalReasoningThought(turn: number): string {
+  const filler = REASONING_STEP_PREFIX.repeat(
+    Math.ceil(REASONING_FINAL_LENGTH / REASONING_STEP_PREFIX.length),
+  );
+  return `turn ${turn} final complete reasoning
+${filler}`.slice(0, REASONING_FINAL_LENGTH);
+}
+
+function materializeReasoningPrefix(finalThought: string, end: number): string {
+  return Buffer.from(finalThought.slice(0, end), 'utf8').toString('utf8');
+}
+
+/**
+ * Drives the real StreamOutputAccumulator with full-so-far thinking deltas the
+ * way Anthropic streams them: each delta carries the complete accumulated
+ * thought-so-far. Each prefix is copied through a Buffer so the benchmark
+ * creates distinct string backing stores instead of engine-dependent substring
+ * views. The terminal complete block carries the exact full final string plus
+ * signature. The accumulator must collapse each span to one block with the
+ * final complete text — the unbounded-growth path this exercises.
+ */
+function runReasoningTurn(turn: number): number {
+  const streamId = `reasoning-span-${turn}`;
+  const accumulator = new StreamOutputAccumulator();
+  const finalThought = buildFinalReasoningThought(turn);
+  const signature = `sig-${turn}`;
+  const deltaCount = 200;
+  const stepSize = Math.ceil(finalThought.length / deltaCount);
+  for (let i = 1; i <= deltaCount; i++) {
+    accumulator.add(
+      reasoningChunk([
+        reasoningThinking({
+          thought: materializeReasoningPrefix(finalThought, stepSize * i),
+          streamId,
+          streamStatus: 'delta',
+        }),
+      ]),
+    );
+  }
+  accumulator.add(
+    reasoningChunk([
+      reasoningThinking({
+        thought: finalThought,
+        streamId,
+        streamStatus: 'complete',
+        signature,
+      }),
+    ]),
+  );
+  const output = accumulator.materialize();
+  const thinkingBlocks = output.content.blocks.filter(
+    (b): b is ThinkingBlock => b.type === 'thinking',
+  );
+  if (thinkingBlocks.length !== 1) {
+    throw new Error(
+      `Reasoning turn ${turn} produced ${thinkingBlocks.length} thinking blocks, expected 1`,
+    );
+  }
+  if (thinkingBlocks[0].thought !== finalThought) {
+    throw new Error(
+      `Reasoning turn ${turn} thought mismatch: got ${thinkingBlocks[0].thought.length} bytes, expected ${finalThought.length}`,
+    );
+  }
+  if (thinkingBlocks[0].streamStatus !== 'complete') {
+    throw new Error(
+      `Reasoning turn ${turn} streamStatus is ${thinkingBlocks[0].streamStatus}, expected complete`,
+    );
+  }
+  if (thinkingBlocks[0].streamId !== streamId) {
+    throw new Error(
+      `Reasoning turn ${turn} streamId is ${thinkingBlocks[0].streamId}, expected ${streamId}`,
+    );
+  }
+  if (thinkingBlocks[0].signature !== signature) {
+    throw new Error(
+      `Reasoning turn ${turn} signature is ${thinkingBlocks[0].signature}, expected ${signature}`,
+    );
+  }
+  return thinkingBlocks[0].thought.length;
+}
+
 const deltas = toDeltas(buildResponse());
 
 checkpoint('baseline');
@@ -156,6 +264,8 @@ await awaitSample('baseline');
 for (let turn = 1; turn <= turns; turn += 1) {
   if (mode === 'media') {
     runMediaTurn();
+  } else if (mode === 'reasoning') {
+    runReasoningTurn(turn);
   } else {
     runTurn(deltas);
   }

--- a/scripts/tests/issue-2852-memory-plateau.bun.test.ts
+++ b/scripts/tests/issue-2852-memory-plateau.bun.test.ts
@@ -130,10 +130,12 @@ describe('multi-metric post-GC plateau verdict (issue #3114)', () => {
   });
 
   describe('parsePostGcRecords', () => {
-    it('keeps only post-GC records and drops blank lines', () => {
+    it('keeps only post-GC records and drops blank and whitespace-only lines', () => {
       const contents = [
         JSON.stringify({ name: 'turn-1-pre-gc', jsc: { heapSize: 1 } }),
         '',
+        '   ',
+        '\t',
         JSON.stringify({ name: 'turn-1-post-gc', jsc: { heapSize: 2 } }),
         '',
       ].join('\n');

--- a/scripts/tests/issue-2852-memory-plateau.bun.test.ts
+++ b/scripts/tests/issue-2852-memory-plateau.bun.test.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the issue-2852 multi-metric plateau verdict and
+ * reasoning-mode target (issue #3114, REQ-3114-3).
+ *
+ * The plateau verdict must require JSC heap, process.memoryUsage().external,
+ * and dirty WebKit Malloc to each plateau independently — the overall verdict
+ * passes only when every required metric plateaus. The reasoning target must
+ * stream full-so-far thinking updates through the real StreamOutputAccumulator
+ * and verify each materialized result is one complete block.
+ *
+ * These tests exercise the real parsing and plateau logic; no component is
+ * mocked.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  evaluateMultiMetricPlateau,
+  type PostGcMetrics,
+} from '../issue-2852-memory-benchmark.js';
+import { StreamOutputAccumulator } from '../../packages/agents/src/core/streamOutputAccumulator.js';
+import type { ModelStreamChunk } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import type { ThinkingBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+
+function metrics(overrides: Partial<PostGcMetrics> = {}): PostGcMetrics {
+  return {
+    jscHeapBytes: 50_000_000,
+    externalBytes: 10_000_000,
+    webkitMallocDirtyBytes: 5_000_000,
+    ...overrides,
+  };
+}
+
+describe('multi-metric post-GC plateau verdict (issue #3114)', () => {
+  describe('evaluateMultiMetricPlateau', () => {
+    it('passes when all required metrics plateau', () => {
+      const result = evaluateMultiMetricPlateau(
+        [
+          metrics({ jscHeapBytes: 40_000_000, externalBytes: 8_000_000 }),
+          metrics(),
+          metrics({ jscHeapBytes: 50_500_000, externalBytes: 10_300_000 }),
+          metrics({ jscHeapBytes: 50_200_000, externalBytes: 10_100_000 }),
+        ],
+        0.1,
+      );
+      expect(result.overallWithinTolerance).toBe(true);
+      expect(result.metrics.every((m) => m.withinTolerance)).toBe(true);
+    });
+
+    it('fails when JSC heap grows beyond tolerance even if other metrics plateau', () => {
+      const result = evaluateMultiMetricPlateau(
+        [
+          metrics({ jscHeapBytes: 40_000_000 }),
+          metrics({ jscHeapBytes: 50_000_000 }),
+          metrics({ jscHeapBytes: 60_000_000 }),
+          metrics({ jscHeapBytes: 70_000_000 }),
+        ],
+        0.1,
+      );
+      expect(result.overallWithinTolerance).toBe(false);
+      const heap = result.metrics.find((m) => m.name === 'jscHeap');
+      expect(heap?.withinTolerance).toBe(false);
+    });
+
+    it('fails when external grows beyond tolerance even if heap plateaus', () => {
+      const result = evaluateMultiMetricPlateau(
+        [
+          metrics({ externalBytes: 8_000_000 }),
+          metrics({ externalBytes: 10_000_000 }),
+          metrics({ externalBytes: 15_000_000 }),
+          metrics({ externalBytes: 20_000_000 }),
+        ],
+        0.1,
+      );
+      expect(result.overallWithinTolerance).toBe(false);
+      const external = result.metrics.find((m) => m.name === 'external');
+      expect(external?.withinTolerance).toBe(false);
+    });
+
+    it('fails when dirty WebKit Malloc grows beyond tolerance', () => {
+      const result = evaluateMultiMetricPlateau(
+        [
+          metrics({ webkitMallocDirtyBytes: 4_000_000 }),
+          metrics({ webkitMallocDirtyBytes: 5_000_000 }),
+          metrics({ webkitMallocDirtyBytes: 8_000_000 }),
+          metrics({ webkitMallocDirtyBytes: 12_000_000 }),
+        ],
+        0.1,
+      );
+      expect(result.overallWithinTolerance).toBe(false);
+      const webkit = result.metrics.find((m) => m.name === 'webkitMallocDirty');
+      expect(webkit?.withinTolerance).toBe(false);
+    });
+
+    it('fails when any single metric out of three grows', () => {
+      const result = evaluateMultiMetricPlateau(
+        [metrics(), metrics(), metrics({ webkitMallocDirtyBytes: 8_000_000 })],
+        0.1,
+      );
+      expect(result.overallWithinTolerance).toBe(false);
+    });
+
+    it('requires at least three post-GC turns', () => {
+      expect(() =>
+        evaluateMultiMetricPlateau([metrics(), metrics()], 0.1),
+      ).toThrow('at least three');
+    });
+
+    it('reports per-metric settled baseline and growth ratio', () => {
+      const result = evaluateMultiMetricPlateau(
+        [
+          metrics({ jscHeapBytes: 40_000_000 }),
+          metrics({ jscHeapBytes: 50_000_000 }),
+          metrics({ jscHeapBytes: 55_000_000 }),
+        ],
+        0.05,
+      );
+      const heap = result.metrics.find((m) => m.name === 'jscHeap');
+      expect(heap?.settledBaselineBytes).toBe(50_000_000);
+      expect(heap?.withinTolerance).toBe(false);
+    });
+  });
+});
+
+const REASONING_STEP_PREFIX = 'step '.repeat(20);
+
+/**
+ * Drives the real StreamOutputAccumulator the way the reasoning-mode target
+ * does: each delta carries a complete prefix of one deterministic final
+ * reasoning string, closed by a complete block carrying that exact full final
+ * string plus signature. Proves the accumulator collapses each span to one
+ * block with the final complete text — the retention contract the target
+ * depends on.
+ */
+describe('reasoning target accumulator path (issue #3114)', () => {
+  function chunk(
+    blocks: ModelStreamChunk['content']['blocks'],
+  ): ModelStreamChunk {
+    return { content: { speaker: 'ai', blocks } };
+  }
+
+  function thinking(partial: {
+    thought: string;
+    streamId: string;
+    streamStatus: 'delta' | 'complete';
+    signature?: string;
+  }): ThinkingBlock {
+    return { type: 'thinking', sourceField: 'thinking', ...partial };
+  }
+
+  function buildFinalThought(turn: number): string {
+    const filler = REASONING_STEP_PREFIX.repeat(
+      Math.ceil(3000 / REASONING_STEP_PREFIX.length),
+    );
+    return `turn ${turn} final complete reasoning
+${filler}`.slice(0, 3000);
+  }
+
+  it('produces exactly one complete thinking block with the exact full final thought', () => {
+    const streamId = 'reasoning-span-0';
+    const accumulator = new StreamOutputAccumulator();
+    const finalThought = buildFinalThought(0);
+    const signature = 'sig-final';
+    const deltaCount = 50;
+    const stepSize = Math.ceil(finalThought.length / deltaCount);
+    for (let i = 1; i <= deltaCount; i++) {
+      accumulator.add(
+        chunk([
+          thinking({
+            thought: finalThought.slice(0, stepSize * i),
+            streamId,
+            streamStatus: 'delta',
+          }),
+        ]),
+      );
+    }
+    accumulator.add(
+      chunk([
+        thinking({
+          thought: finalThought,
+          streamId,
+          streamStatus: 'complete',
+          signature,
+        }),
+      ]),
+    );
+
+    const output = accumulator.materialize();
+    const thinkingBlocks = output.content.blocks.filter(
+      (b): b is ThinkingBlock => b.type === 'thinking',
+    );
+    expect(thinkingBlocks).toHaveLength(1);
+    expect(thinkingBlocks[0].thought).toBe(finalThought);
+    expect(thinkingBlocks[0].streamStatus).toBe('complete');
+    expect(thinkingBlocks[0].streamId).toBe(streamId);
+    expect(thinkingBlocks[0].signature).toBe(signature);
+  });
+});

--- a/scripts/tests/issue-2852-memory-plateau.bun.test.ts
+++ b/scripts/tests/issue-2852-memory-plateau.bun.test.ts
@@ -122,6 +122,8 @@ describe('multi-metric post-GC plateau verdict (issue #3114)', () => {
       );
       const heap = result.metrics.find((m) => m.name === 'jscHeap');
       expect(heap?.settledBaselineBytes).toBe(50_000_000);
+      expect(heap?.maxBytes).toBe(55_000_000);
+      expect(heap?.growthRatio).toBeCloseTo(0.1, 10);
       expect(heap?.withinTolerance).toBe(false);
     });
   });

--- a/scripts/tests/issue-2852-memory-plateau.bun.test.ts
+++ b/scripts/tests/issue-2852-memory-plateau.bun.test.ts
@@ -21,6 +21,7 @@
 import { describe, it, expect } from 'bun:test';
 import {
   evaluateMultiMetricPlateau,
+  parsePostGcRecords,
   type PostGcMetrics,
 } from '../issue-2852-memory-benchmark.js';
 import { StreamOutputAccumulator } from '../../packages/agents/src/core/streamOutputAccumulator.js';
@@ -125,6 +126,47 @@ describe('multi-metric post-GC plateau verdict (issue #3114)', () => {
       expect(heap?.maxBytes).toBe(55_000_000);
       expect(heap?.growthRatio).toBeCloseTo(0.1, 10);
       expect(heap?.withinTolerance).toBe(false);
+    });
+  });
+
+  describe('parsePostGcRecords', () => {
+    it('keeps only post-GC records and drops blank lines', () => {
+      const contents = [
+        JSON.stringify({ name: 'turn-1-pre-gc', jsc: { heapSize: 1 } }),
+        '',
+        JSON.stringify({ name: 'turn-1-post-gc', jsc: { heapSize: 2 } }),
+        '',
+      ].join('\n');
+
+      const records = parsePostGcRecords('/tmp/target.jsonl', contents);
+
+      expect(records).toHaveLength(1);
+      expect(records[0].name).toBe('turn-1-post-gc');
+      expect(records[0].jsc?.heapSize).toBe(2);
+    });
+
+    it('names the malformed line as it appears in the file, counting blank lines', () => {
+      // The bad record sits on physical line 4. Counting only non-blank lines
+      // would misreport it as line 2 and send a reader to the wrong place.
+      const contents = [
+        JSON.stringify({ name: 'turn-1-post-gc', jsc: { heapSize: 1 } }),
+        '',
+        '',
+        '{ not valid json',
+      ].join('\n');
+
+      expect(() => parsePostGcRecords('/tmp/target.jsonl', contents)).toThrow(
+        /\/tmp\/target\.jsonl line 4 is not valid JSON/,
+      );
+    });
+
+    it('fails rather than skipping a corrupt record', () => {
+      const contents = [
+        JSON.stringify({ name: 'turn-1-post-gc', jsc: { heapSize: 1 } }),
+        'truncated',
+      ].join('\n');
+
+      expect(() => parsePostGcRecords('/tmp/target.jsonl', contents)).toThrow();
     });
   });
 });


### PR DESCRIPTION
## TLDR

Long-running sessions grew memory with **uptime, not activity** — a 128 GiB machine was driven to 64 MB free and 98.5% swap exhaustion, with the two worst offenders being the two most *idle* sessions.

Most of umbrella issue #3114 has already landed as separate PRs. This lands the one attributed retention defect still outstanding, plus the measurement that proves the combined result actually holds.

**The bug:** `Turn.cleanupStreamResources` aborted the timeout controller *before* calling `closeIteratorBounded`. That helper early-returns when the signal it is handed is already aborted — so the abort raced ahead of its own cleanup and the branch that awaits `iterator.return()` was **unreachable on every single turn**. Cooperative provider iterators never finished unwinding, so the generator scope capturing each turn's stream state stayed alive.

**Reviewers should look at:** the ordering change in `turn.ts` (it is three lines and the whole fix), and whether the reasoning benchmark is a fair proxy for the real leak.

## Dive Deeper

### Already merged elsewhere — deliberately not re-implemented here

| Sub-issue | PR | What it covered |
| --- | --- | --- |
| #3111 | #3117 | Thinking-block coalescing in `StreamOutputAccumulator` — the primary retention site |
| #3112 | #3123 | Honest Bun memory footer + runtime-aware `--max-old-space-size` suppression |
| #3109 | #3125 | Read-only history view instead of deep cloning |
| #3113 | #3124 | Bounded and rotated error reports |

This branch was rebased onto those. An earlier revision of this PR independently implemented the #3112 footer/bootstrap work before #3123 merged; that work was **dropped in favour of the merged version** rather than re-landed.

### The iterator cleanup fix

Closure is now awaited first; the controller is aborted after.

The cleanup signal is omitted **deliberately** — passing the turn-owned signal is precisely what defeated the wait. A noncooperative iterator is still bounded by `closeIteratorBounded`'s own one-second timeout, so this cannot hang.

**There is no added cancellation latency.** `onParentAbort` already aborts the timeout controller from the parent signal, so on user cancel the controller is aborted *before* cleanup runs. The reordering only affects normal completion and early consumer exit.

This is a fail-fast fix at the attributed site, not a defensive guard: nothing was wrapped, no error is swallowed that was not already warning-only, and the existing bound is preserved rather than duplicated.

### Why a multi-metric plateau gate

The existing harness gated only on post-GC JSC heap. That would have declared victory here while the strings were still resident: the `vmmap` investigation attributed **32.9 GB to `external` against 0.5 GB of ArrayBuffers**, and under Bun `external` tracks JS string backing stores at roughly a byte per character.

The gate now evaluates **JSC heap, `process.memoryUsage().external`, and dirty WebKit Malloc** independently and passes only if all three settle. `evaluateMultiMetricPlateau` reuses the existing per-metric evaluator and warm-up handling rather than introducing a second notion of "plateau".

### Why the reasoning workload looks the way it does

`reasoning` mode drives the **real** `StreamOutputAccumulator` — not a stand-in — with 200 full-so-far thinking deltas per turn against a 30 KB final thought, which is the shape Anthropic actually streams.

Two details that matter for it being a real measurement:

- Each prefix is copied through a `Buffer` rather than produced by `String.prototype.slice`, so the workload allocates **distinct string backing stores** instead of engine-dependent substring views that would understate retention.
- Every turn asserts the span collapses to exactly one block carrying the full final text, stream id, status and signature — so the target **fails loudly** if coalescing ever regresses, rather than silently measuring a workload that no longer reproduces the pressure.

This extends `scripts/issue-2852-memory-runner.ts`; no parallel harness was added.

### No silent data loss

The reasoning span is retained **in full**. Only the duplicate partial copies of it are not. No new length, count, or disk bound is introduced, so no truncation label is required.

### Documentation

`docs/sandbox.md` still described the Node heap limit as automatically derived regardless of runtime, which #3123 made untrue when it stopped passing `--max-old-space-size` under Bun. Corrected so the docs match shipped behaviour.

## Reviewer Test Plan

**1. Confirm the cleanup tests are real (RED/GREEN), not mock theater.**

    cd packages/agents
    bun test src/core/turn.cooperative-cleanup.bun.test.ts    # 3 pass

Then revert just the fix and re-run:

    git stash push -- src/core/turn.ts   # or hand-restore the old ordering
    bun test src/core/turn.cooperative-cleanup.bun.test.ts

Expect the two cooperative cases to **fail** with `Expected: false, Received: true` — the turn finishing before cleanup released. The bounded-timeout case still passes, confirming the existing timeout behaviour is untouched. Restore afterwards.

These tests drive the public `Turn.run()` with a provider iterator whose `return()` settles only on a controlled release; they assert observable turn completion ordering, not that a mock was called.

**2. Run the real memory benchmark (macOS; uses `vmmap` / `footprint`).**

    bun scripts/issue-2852-memory-runner.ts /tmp/mem-3114 reasoning 4
    cat /tmp/mem-3114/os-checkpoints.json

Exit 0 and `overallWithinTolerance: true`. Observed on this branch:

| metric | growth |
| --- | ---: |
| JSC heap | +1.25% |
| external | +5.47% |
| dirty WebKit Malloc | +0.00% |

To see the gate actually bite, hand-edit one post-GC `external` value upward in the target JSONL and re-derive — the run fails naming the offending metric.

**3. Confirm the pre-existing text/media modes still work.**

    bun scripts/issue-2852-memory-runner.ts /tmp/mem-text text 4

**4. Long-session sanity.** Run an interactive session against a reasoning-capable model (Anthropic or an OpenAI Responses model), leave it idle across many turns, and watch the footer RSS/External. Growth should track activity, not uptime.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS 26.4 arm64 / Bun 1.3.14:

- `npm run test` — exit 0, **zero failures across all 17 workspaces** (agents 350/350, CLI 681/681, core 546/546)
- `npm run lint` — exit 0
- `npm run typecheck` — exit 0
- `npm run format` — clean
- `npm run build` — exit 0
- Smoke: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` — exit 0
- TUI: `bun scripts/tmux-harness.ts` — exit 0

The benchmark is macOS-specific by design (it shells out to `vmmap` and `footprint`), as was the pre-existing issue-2852 harness it extends. It is a developer tool, not part of CI.

### A note on agents-suite flakiness

While validating, the agents suite intermittently failed 1–4 files on **timeouts only**, with a different set each run. To rule out this change as the cause, the suite was run against the unmodified `turn.ts`: that baseline failed **more** files (`displayCallbacks`, `memoryControl`), which reproduces the flake independently of this PR. Every implicated file passes in isolation. The final clean run on this head is fully green.

## Linked issues / bugs

Fixes #3114

Depends on and builds atop #3117, #3123, #3125 and #3124, all merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when stopping or completing streamed responses, ensuring resources are cleaned up without unnecessary delays.
  - Added safeguards so unresponsive streams remain bounded and do not hang indefinitely.

- **Documentation**
  - Clarified how macOS sandbox memory limits affect Node.js and Bun runtime configurations.

- **Diagnostics**
  - Expanded memory benchmarking to evaluate multiple memory categories and reasoning-stream behavior.
  - Added clearer checkpoint validation and metric-specific reporting for memory plateau results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->