### PR TITLE
Validate every pid before signalling so Esc cannot kill llxprt itself (Fixes #3126)

### DIFF
--- a/packages/core/src/services/shellCpExecution.ts
+++ b/packages/core/src/services/shellCpExecution.ts
@@ -11,7 +11,10 @@ import type {
 } from './shellExecutionTypes.js';
 import { createExitGuard } from './shellExitGuard.js';
 import { makeInactivityTimer } from './shellOutputUtils.js';
-import { killProcessWithEscalation } from './shellProcessKill.js';
+import {
+  isKillablePid,
+  killProcessWithEscalation,
+} from './shellProcessKill.js';
 import {
   type CpExecState,
   handleCpOutput,
@@ -107,12 +110,10 @@ function setupCpAbortHandler(state: CpExecState): () => void {
 
 /** Kill the child process group on abort or inactivity timeout. */
 async function cpKillOnAbort(state: CpExecState): Promise<void> {
-  // Preserve old truthiness semantics: skip pid 0 and undefined
-  if (
-    state.child.pid !== undefined &&
-    state.child.pid !== 0 &&
-    !state.exitedGuard.isExited()
-  ) {
+  // Guard the pid before it can reach process.kill(-pid): pid 0 would signal
+  // the caller's own process group. isKillablePid also rejects negative and
+  // non-finite pids, which the previous `!== 0` check let through.
+  if (isKillablePid(state.child.pid) && !state.exitedGuard.isExited()) {
     await killProcessWithEscalation(
       state.child.pid,
       state.isWindows,

--- a/packages/core/src/services/shellExecutionService.terminatePty.test.ts
+++ b/packages/core/src/services/shellExecutionService.terminatePty.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import os from 'node:os';
+import { spawn } from 'node:child_process';
+
+import headless from '@xterm/headless';
+import type { IPty } from '@lydell/node-pty';
+import type { ActivePty } from './shellPtyHelpers.js';
+import { ShellExecutionService } from './shellExecutionService.js';
+
+const { Terminal } = headless;
+
+const isWindows = os.platform() === 'win32';
+
+// The private static pty registry is accessed via a typed cast; this is the
+// observable boundary that determines whether terminatePty reaches its kill
+// path (no public API registers an arbitrary pid).
+const serviceInternals = ShellExecutionService as unknown as {
+  activePtys: Map<number, ActivePty>;
+};
+
+/** Signal-0 liveness check. */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Polls until the pid is gone, up to `timeoutMs`. Polling rather than a fixed
+ * sleep keeps the assertion stable on a loaded CI runner, where taskkill can
+ * take noticeably longer than the happy path.
+ */
+async function waitForPidGone(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+/** Best-effort cleanup of a registered fake entry and its escalation timer. */
+function removeFakeEntry(pid: number): void {
+  const entry = serviceInternals.activePtys.get(pid);
+  if (entry) {
+    if (entry.terminationTimeout) {
+      clearTimeout(entry.terminationTimeout);
+      entry.terminationTimeout = undefined;
+    }
+    serviceInternals.activePtys.delete(pid);
+  }
+}
+
+/**
+ * Best-effort direct reap of a Windows pid (cleanup only). Awaits taskkill's
+ * exit so the tree is actually gone before the test ends; returning early
+ * would let the runner exit while taskkill is still running, leaking
+ * processes onto the CI agent.
+ */
+async function reapWindowsPid(pid: number): Promise<void> {
+  if (pid <= 0) return;
+  try {
+    const killer = spawn('taskkill', ['/pid', String(pid), '/f', '/t'], {
+      windowsHide: true,
+      stdio: 'ignore',
+    });
+    await new Promise<void>((resolve) => {
+      killer.on('exit', () => resolve());
+      killer.on('error', () => resolve());
+    });
+  } catch {
+    // Already gone.
+  }
+}
+
+describe.skipIf(isWindows)(
+  'ShellExecutionService.terminatePty pid validation (POSIX)',
+  () => {
+    afterEach(() => {
+      for (const pid of [...serviceInternals.activePtys.keys()]) {
+        removeFakeEntry(pid);
+      }
+    });
+
+    it('pid 0 does not signal the caller process group even when registered', async () => {
+      // Registering under pid 0 is what makes this reachable: before the fix
+      // terminatePty(0) found the entry and ran process.kill(-0), which is
+      // process.kill(0) — a signal to the CALLER's own process group. A
+      // sibling sharing this process's group must survive.
+      const sibling = spawn('sleep', ['30'], { stdio: 'ignore' });
+      sibling.unref();
+      // Without an 'error' listener a failed spawn raises an uncaught exception
+      // that crashes the runner and skips the finally cleanup below.
+      sibling.on('error', () => {});
+      expect(sibling.pid).toBeGreaterThan(0);
+
+      const terminal = new Terminal({
+        allowProposedApi: true,
+        cols: 80,
+        rows: 30,
+        scrollback: 10,
+      });
+      const fakePty = { pid: 0, kill: () => undefined } as unknown as IPty;
+      serviceInternals.activePtys.set(0, {
+        ptyProcess: fakePty,
+        headlessTerminal: terminal,
+        supportsProcessGroupKill: true,
+      });
+
+      try {
+        expect(() => ShellExecutionService.terminatePty(0)).not.toThrow();
+        // Observe survival through the child handle, not a signal-0 probe: this
+        // process is the sibling's parent, so a wrongly-killed sibling lingers
+        // as a zombie for which signal 0 still succeeds, which would pass this
+        // test for exactly the wrong reason.
+        await Promise.race([
+          new Promise<never>((_, reject) => {
+            sibling.on('exit', (_code, signal) =>
+              reject(new Error(`sibling was terminated (signal ${signal})`)),
+            );
+          }),
+          new Promise((resolve) => setTimeout(resolve, 500)),
+        ]);
+        // Reaching this line also proves the test runner itself survived.
+      } finally {
+        removeFakeEntry(0);
+        try {
+          terminal.dispose();
+        } catch {
+          // May already be disposed.
+        }
+        // The sibling shares this process's group and is NOT a group leader,
+        // so it must be reaped through its own handle, not as a group.
+        sibling.kill('SIGKILL');
+      }
+    }, 20000);
+  },
+);
+
+describe.skipIf(!isWindows)(
+  'ShellExecutionService.terminatePty (Windows)',
+  () => {
+    afterEach(() => {
+      // Defensive: clear any strays without assuming a specific pid.
+      for (const pid of [...serviceInternals.activePtys.keys()]) {
+        removeFakeEntry(pid);
+      }
+    });
+
+    it('reaps a registered pty via the taskkill path, not a POSIX process-group kill', async () => {
+      // Spawn a real long-lived child and register it as an ActivePty entry.
+      // Before the fix terminatePty used process.kill(-pid) on Windows, which
+      // throws (no process groups) and leaves the tree alive. After the fix the
+      // isWindows branch uses taskkillTree and the process is reaped.
+      const child = spawn(
+        'powershell.exe',
+        ['-NoProfile', '-Command', 'Start-Sleep -Seconds 60'],
+        { windowsHide: true, stdio: 'ignore' },
+      );
+      child.unref();
+      const childPid = child.pid ?? 0;
+      expect(childPid).toBeGreaterThan(0);
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      const terminal = new Terminal({
+        allowProposedApi: true,
+        cols: 80,
+        rows: 30,
+        scrollback: 10,
+      });
+      const fakePty = {
+        pid: childPid,
+        kill: () => undefined,
+      } as unknown as IPty;
+      const entry: ActivePty = {
+        ptyProcess: fakePty,
+        headlessTerminal: terminal,
+        supportsProcessGroupKill: true,
+      };
+      serviceInternals.activePtys.set(childPid, entry);
+
+      try {
+        ShellExecutionService.terminatePty(childPid);
+        await waitForPidGone(childPid, 8000);
+        expect(isPidAlive(childPid)).toBe(false);
+      } finally {
+        removeFakeEntry(childPid);
+        try {
+          terminal.dispose();
+        } catch {
+          // May already be disposed.
+        }
+        await reapWindowsPid(childPid);
+      }
+    }, 20000);
+  },
+);

--- a/packages/core/src/services/shellExecutionService.terminatePty.test.ts
+++ b/packages/core/src/services/shellExecutionService.terminatePty.test.ts
@@ -49,6 +49,22 @@ async function waitForPidGone(pid: number, timeoutMs: number): Promise<void> {
   }
 }
 
+/**
+ * Poll until a pid is observable by taskkill, up to `timeoutMs`. A static
+ * delay is flaky on a loaded CI runner where the child may take longer than
+ * the fixed window to be observable; polling keeps the readiness gate stable.
+ */
+async function waitForPidVisible(
+  pid: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (isPidAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
 /** Best-effort cleanup of a registered fake entry and its escalation timer. */
 function removeFakeEntry(pid: number): void {
   const entry = serviceInternals.activePtys.get(pid);
@@ -167,10 +183,13 @@ describe.skipIf(!isWindows)(
         ['-NoProfile', '-Command', 'Start-Sleep -Seconds 60'],
         { windowsHide: true, stdio: 'ignore' },
       );
+      child.on('error', () => {});
       child.unref();
       const childPid = child.pid ?? 0;
       expect(childPid).toBeGreaterThan(0);
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      // Wait until the pid is observable by taskkill rather than a fixed
+      // delay, which can be too short on a loaded CI runner.
+      await waitForPidVisible(childPid, 8000);
 
       const terminal = new Terminal({
         allowProposedApi: true,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -16,7 +16,11 @@ import type {
   ShellOutputEvent,
 } from './shellExecutionTypes.js';
 import { ensurePromptvarsDisabled } from './shellOutputUtils.js';
-import { SIGKILL_TIMEOUT_MS } from './shellProcessKill.js';
+import {
+  SIGKILL_TIMEOUT_MS,
+  isKillablePid,
+  taskkillTree,
+} from './shellProcessKill.js';
 import {
   isIgnorablePtyExitError,
   cleanupPtyEntryResources,
@@ -243,14 +247,30 @@ export class ShellExecutionService {
     return this.lastActivePtyIdRef.value;
   }
 
-  /** Terminates the pseudo-terminal (PTY) process. */
-  static terminatePty(pid: number): void {
+  /**
+   * Terminates the pseudo-terminal (PTY) process.
+   *
+   * `pid` is deliberately widened to `number | undefined` to match the pid type
+   * carried by the shell job records. A narrower `number` would push callers
+   * holding an optional pid into writing `pid ?? 0`, and pid 0 is precisely the
+   * value that makes the process.kill(-pid) below signal the caller's own
+   * process group. The guard runs before the registry lookup so a non-killable
+   * pid can never select an unrelated PTY entry.
+   */
+  static terminatePty(pid: number | undefined): void {
+    if (!isKillablePid(pid)) {
+      return;
+    }
     const activePty = this.activePtys.get(pid);
     if (!activePty) {
       return;
     }
 
-    if (activePty.supportsProcessGroupKill) {
+    const isWindows = os.platform() === 'win32';
+    if (isWindows) {
+      // Windows has no POSIX process groups; walk the descendant tree only.
+      taskkillTree(pid);
+    } else if (activePty.supportsProcessGroupKill) {
       try {
         process.kill(-pid, 'SIGTERM');
       } catch {
@@ -268,7 +288,9 @@ export class ShellExecutionService {
       if (!this.activePtys.has(pid)) {
         return;
       }
-      if (activePty.supportsProcessGroupKill) {
+      if (isWindows) {
+        taskkillTree(pid);
+      } else if (activePty.supportsProcessGroupKill) {
         try {
           process.kill(-pid, 'SIGKILL');
         } catch {

--- a/packages/core/src/services/shellJobInternal.test.ts
+++ b/packages/core/src/services/shellJobInternal.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import os from 'node:os';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import { killProcessGroupSafe } from './shellJobInternal.js';
+
+const isWindows = os.platform() === 'win32';
+
+/**
+ * Spawns a `sleep 30` sibling into the CALLER's process group.
+ *
+ * The 'error' listener is required: an unhandled 'error' event (for example if
+ * `sleep` were missing from PATH) is thrown as an uncaught exception, which
+ * would crash the runner and skip the `finally` cleanup that reaps the child.
+ */
+function spawnSibling(): ChildProcess {
+  const sibling = spawn('sleep', ['30'], { stdio: 'ignore' });
+  sibling.unref();
+  sibling.on('error', () => {});
+  return sibling;
+}
+
+/**
+ * Waits `ms`, rejecting immediately if the sibling exits first.
+ *
+ * Survival is observed through the child handle rather than a
+ * `process.kill(pid, 0)` probe: this process is the sibling's parent, so after
+ * a wrongful kill the pid lingers as a zombie until the runtime reaps it, and
+ * signal 0 still SUCCEEDS for a zombie. Probing would therefore report a killed
+ * sibling as alive and pass the test for exactly the wrong reason.
+ */
+async function expectSurvivesFor(
+  sibling: ChildProcess,
+  ms: number,
+): Promise<void> {
+  await Promise.race([
+    new Promise<never>((_, reject) => {
+      sibling.once('exit', (_code, signal) =>
+        reject(new Error(`sibling was terminated (signal ${signal})`)),
+      );
+    }),
+    new Promise((resolve) => setTimeout(resolve, ms)),
+  ]);
+}
+
+/** Kill an entire detached process group (no-op if already gone). POSIX only. */
+function reapGroup(pgid: number): void {
+  // Guard the cleanup path against the very bug under test: a spawn that
+  // produced no pid yields 0 here, and `process.kill(-0)` is `process.kill(0)`,
+  // which would signal the TEST RUNNER's own process group.
+  if (!Number.isInteger(pgid) || pgid <= 0) return;
+  try {
+    process.kill(-pgid, 'SIGKILL');
+  } catch {
+    // Already gone.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// killProcessGroupSafe — POSIX-only (production behavior is POSIX-gated)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(isWindows)(
+  'killProcessGroupSafe pid validation (POSIX)',
+  () => {
+    it('pid 0 is a no-op: a same-group sibling survives and the test process survives', async () => {
+      // killProcessGroupSafe computes process.kill(-pid, signal). For pid 0
+      // that is process.kill(0), which signals the CALLER's own process group.
+      // A sibling child spawned into the caller's group must survive.
+      const sibling = spawnSibling();
+      expect(sibling.pid).toBeGreaterThan(0);
+      try {
+        killProcessGroupSafe(0, 'SIGTERM');
+        // Rejects the moment a (buggy) group signal reaches the sibling;
+        // otherwise settles after the grace window with the sibling alive.
+        await expectSurvivesFor(sibling, 500);
+        // Reaching this line also proves the test runner itself survived.
+      } finally {
+        // The sibling shares this process's group and is NOT a group leader,
+        // so it must be reaped through its own handle, not as a group.
+        sibling.kill('SIGKILL');
+      }
+    });
+
+    it('pid -1 / NaN / Infinity are no-ops and do not throw', async () => {
+      const sibling = spawnSibling();
+      expect(sibling.pid).toBeGreaterThan(0);
+      try {
+        expect(() => killProcessGroupSafe(-1, 'SIGTERM')).not.toThrow();
+        expect(() => killProcessGroupSafe(Number.NaN, 'SIGTERM')).not.toThrow();
+        expect(() =>
+          killProcessGroupSafe(Number.POSITIVE_INFINITY, 'SIGTERM'),
+        ).not.toThrow();
+        await expectSurvivesFor(sibling, 500);
+      } finally {
+        sibling.kill('SIGKILL');
+      }
+    });
+
+    it('a valid pid still terminates that process group', async () => {
+      const child = spawn('sleep', ['30'], { detached: true, stdio: 'ignore' });
+      child.unref();
+      child.on('error', () => {});
+      const childPid = child.pid ?? 0;
+      expect(childPid).toBeGreaterThan(0);
+      // Observe the exit via the child handle rather than a signal-0 probe and
+      // a fixed sleep: this process is the child's parent, so between the
+      // signal and the runtime's SIGCHLD reap the pid is a zombie for which
+      // `process.kill(pid, 0)` still SUCCEEDS.
+      const exited = new Promise<NodeJS.Signals | null>((resolve) => {
+        child.once('exit', (_code, signal) => resolve(signal));
+      });
+      try {
+        killProcessGroupSafe(childPid, 'SIGTERM');
+        const signal = await Promise.race([
+          exited,
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error(`pid ${childPid} was not terminated`)),
+              8000,
+            ),
+          ),
+        ]);
+        // The guard must not have suppressed delivery for a legitimate pid.
+        expect(signal).toBe('SIGTERM');
+      } finally {
+        reapGroup(childPid);
+      }
+    }, 20000);
+  },
+);

--- a/packages/core/src/services/shellJobInternal.ts
+++ b/packages/core/src/services/shellJobInternal.ts
@@ -9,6 +9,7 @@ import type { ChildProcess } from 'node:child_process';
 import type { ShellJobState, TerminalDetails } from './shellJobTypes.js';
 import type { ShellJobRecord } from './shellJobTypes.js';
 import { toPublicJob } from './shellJobTypes.js';
+import { isKillablePid } from './shellProcessKill.js';
 import { TerminalTransitionGuard } from './shellJobTransition.js';
 
 /**
@@ -108,9 +109,14 @@ export function pidIsAlive(pid: number): boolean {
 }
 
 export function killProcessGroupSafe(
-  pid: number,
+  pid: number | undefined,
   signal: NodeJS.Signals,
 ): void {
+  // pid 0 would collapse to process.kill(0), signalling the caller's own
+  // process group. A non-killable pid is a silent no-op.
+  if (!isKillablePid(pid)) {
+    return;
+  }
   try {
     process.kill(-pid, signal);
   } catch {

--- a/packages/core/src/services/shellJobManager.test.ts
+++ b/packages/core/src/services/shellJobManager.test.ts
@@ -82,6 +82,21 @@ function pgidOf(pid: number): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
+/**
+ * Kill a process group for test cleanup, refusing any pgid that POSIX kill(2)
+ * would reinterpret. `pgidOf` returns null on failure and `Number(null)` is 0,
+ * so an unguarded `process.kill(-pgid)` would become `process.kill(0)` and
+ * signal the TEST RUNNER's own process group.
+ */
+function reapGroupSafe(pgid: number | null | undefined): void {
+  if (typeof pgid !== 'number' || !Number.isInteger(pgid) || pgid <= 0) return;
+  try {
+    process.kill(-pgid, 'SIGKILL');
+  } catch {
+    // Already gone.
+  }
+}
+
 function isProcessGroupGone(pid: number): boolean {
   const pgid = pgidOf(pid);
   if (pgid === null) {
@@ -196,6 +211,42 @@ describe.skipIf(os.platform() === 'win32')('ShellJobManager', () => {
       const terminal2 = await waitForTerminal(manager, job2.id);
       expect(terminal2?.state).toBe('completed');
     });
+
+    // Regression guard for issue #3126: a job whose spawn failed carries a
+    // sentinel/absent pid. Cancelling it must never deliver a signal to the
+    // caller's own process group, and the job must already be (or reach) a
+    // terminal state. The genuinely dangerous pid (0) is exercised at the
+    // primitive chokepoints (killProcessGroupSafe/escalateKillUnix); this
+    // guards the full manager cancel path end-to-end.
+    it('cancel of a spawn-failed job does not signal the caller process group', async () => {
+      const badCwd = path.join(baseDir, 'does-not-exist');
+      // A sibling sharing the test process's own group must survive any cancel.
+      const sibling = spawn('sleep', ['30'], { stdio: 'ignore' });
+      sibling.unref();
+      const siblingPid = sibling.pid ?? 0;
+      expect(siblingPid).toBeGreaterThan(0);
+      try {
+        const job = manager.launch({ command: 'echo hi', cwd: badCwd });
+        const terminal = await waitForTerminal(manager, job.id, 5000);
+        expect(terminal?.state).toBe('failed');
+
+        // Cancel is a no-op for an already-terminal job; it must not signal.
+        await manager.cancel(job.id);
+
+        // There is no event to await for the ABSENCE of a signal, so a fixed
+        // settle window is the only available construct. It is not a flake
+        // risk in the failing direction: a loaded runner that delivers a
+        // stray signal after the window makes this test pass spuriously, not
+        // fail spuriously, so the window is a lower bound on confidence
+        // rather than a deadline that can expire.
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        const siblingPgid = pgidOf(siblingPid);
+        expect(siblingPgid).not.toBeNull();
+        expect(() => process.kill(siblingPid, 0)).not.toThrow();
+      } finally {
+        reapGroupSafe(pgidOf(siblingPid));
+      }
+    });
   });
 
   describe('external signal kill', () => {
@@ -209,11 +260,7 @@ describe.skipIf(os.platform() === 'win32')('ShellJobManager', () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       // Kill the process group externally
-      try {
-        process.kill(-job.pid, 'SIGKILL');
-      } catch {
-        // May already be gone.
-      }
+      reapGroupSafe(job.pid);
 
       const terminal = await waitForTerminal(manager, job.id, 5000);
       expect(terminal).toBeDefined();
@@ -704,7 +751,7 @@ describe.skipIf(os.platform() !== 'win32')('ShellJobManager on Windows', () => {
         command: buildInnerPidMarkerCommand(innerMarker),
         cwd: os.tmpdir(),
       });
-      survivorPid = job.pid;
+      survivorPid = job.pid ?? 0;
       expect(survivorPid).toBeGreaterThan(0);
       innerPid = await readInnerPidFromMarker(innerMarker, 10000);
       expect(innerPid).toBeGreaterThan(0);
@@ -730,7 +777,9 @@ describe.skipIf(os.platform() !== 'win32')('ShellJobManager on Windows', () => {
         true,
       );
     }
-  });
+    // Waiting for the inner PowerShell marker alone allows up to 10s, so the
+    // 5s default timeout could never cover this test on a loaded machine.
+  }, 30000);
 
   // --- G1/H4: dispose must not kill unrelated processes via PID reuse ---
   // Re-expressed against the PURE reap-eligibility helper (no production
@@ -750,7 +799,7 @@ describe.skipIf(os.platform() !== 'win32')('ShellJobManager on Windows', () => {
     });
     const exitedEntry: SurvivorEntry = {
       child: exited,
-      pid: exited.pid ?? 0,
+      pid: exited.pid,
     };
     expect(survivorNeedsReap(exitedEntry)).toBe(false);
 
@@ -790,7 +839,10 @@ describe.skipIf(os.platform() !== 'win32')('ShellJobManager on Windows', () => {
         command: buildInnerPidMarkerCommand(innerMarker),
         cwd: os.tmpdir(),
       });
-      pid = job.pid;
+      pid = job.pid ?? 0;
+      // Fail fast rather than proceeding with pid 0, which the guarded cleanup
+      // helpers would silently skip.
+      expect(pid).toBeGreaterThan(0);
       innerPid = await readInnerPidFromMarker(innerMarker, 10000);
       await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -834,7 +886,10 @@ describe.skipIf(os.platform() !== 'win32')('ShellJobManager on Windows', () => {
         ),
         cwd: os.tmpdir(),
       });
-      pid = job.pid;
+      pid = job.pid ?? 0;
+      // Fail fast rather than proceeding with pid 0, which the guarded cleanup
+      // helpers would silently skip.
+      expect(pid).toBeGreaterThan(0);
       innerPid = await readInnerPidFromMarker(innerMarker, 10000);
 
       // Wait for the cap to be exceeded and at least one poll to fire.

--- a/packages/core/src/services/shellJobManager.test.ts
+++ b/packages/core/src/services/shellJobManager.test.ts
@@ -87,9 +87,15 @@ function pgidOf(pid: number): number | null {
  * would reinterpret. `pgidOf` returns null on failure and `Number(null)` is 0,
  * so an unguarded `process.kill(-pgid)` would become `process.kill(0)` and
  * signal the TEST RUNNER's own process group.
+ *
+ * It also refuses the runner's OWN pgid. A child spawned without
+ * `detached: true` inherits that group, so `reapGroupSafe(pgidOf(childPid))`
+ * would resolve to a perfectly valid, positive pgid that nonetheless kills the
+ * whole test process. Only reap a group whose leader we deliberately created.
  */
 function reapGroupSafe(pgid: number | null | undefined): void {
   if (typeof pgid !== 'number' || !Number.isInteger(pgid) || pgid <= 0) return;
+  if (pgid === pgidOf(process.pid)) return;
   try {
     process.kill(-pgid, 'SIGKILL');
   } catch {
@@ -244,7 +250,10 @@ describe.skipIf(os.platform() === 'win32')('ShellJobManager', () => {
         expect(siblingPgid).not.toBeNull();
         expect(() => process.kill(siblingPid, 0)).not.toThrow();
       } finally {
-        reapGroupSafe(pgidOf(siblingPid));
+        // The sibling is NOT detached, so it lives in this test process's own
+        // group; reaping that group would kill the test runner. Signal the
+        // single child through its handle instead.
+        sibling.kill('SIGKILL');
       }
     });
   });

--- a/packages/core/src/services/shellJobManager.ts
+++ b/packages/core/src/services/shellJobManager.ts
@@ -72,7 +72,7 @@ export interface ShellJobPrefixLookup {
  */
 export interface SurvivorEntry {
   readonly child: ChildProcess;
-  readonly pid: number;
+  readonly pid: number | undefined;
 }
 
 /**
@@ -91,7 +91,7 @@ export function survivorNeedsReap(entry: SurvivorEntry): boolean {
  */
 export interface SurvivorInfo {
   readonly id: string;
-  readonly pid: number;
+  readonly pid: number | undefined;
   readonly remediation: string;
 }
 
@@ -413,7 +413,16 @@ export class ShellJobManager {
    * enforcement, and dispose so no path can hang or leak an unhandled
    * rejection.
    */
-  private safeWindowsKill(pid: number): Promise<TaskkillResult> {
+  private safeWindowsKill(pid: number | undefined): Promise<TaskkillResult> {
+    // An absent pid (spawn never produced one) cannot be taskkilled; resolve
+    // as a no-op failure rather than entering the timeout race, so no
+    // taskkill process is ever spawned for an unknown pid.
+    if (pid === undefined) {
+      return Promise.resolve({
+        ok: false,
+        error: new Error('Cannot taskkill: process has no pid'),
+      });
+    }
     return new Promise<TaskkillResult>((resolve) => {
       let settled = false;
       const finish = (result: TaskkillResult): void => {
@@ -795,7 +804,10 @@ export class ShellJobManager {
       .map(([id, entry]) => ({
         id,
         pid: entry.pid,
-        remediation: `taskkill /T /F /PID ${entry.pid}`,
+        remediation:
+          entry.pid === undefined
+            ? 'pid unknown; cannot emit taskkill remediation'
+            : `taskkill /T /F /PID ${entry.pid}`,
       }));
     if (remaining.length > 0) {
       debugLogger.warn(

--- a/packages/core/src/services/shellJobManager.ts
+++ b/packages/core/src/services/shellJobManager.ts
@@ -13,6 +13,7 @@ import { debugLogger } from '../utils/debugLogger.js';
 import {
   SIGKILL_TIMEOUT_MS,
   boundedTaskkill,
+  isKillablePid,
   type TaskkillResult,
 } from './shellProcessKill.js';
 import { ShellJobBudget } from './shellJobBudget.js';
@@ -414,13 +415,15 @@ export class ShellJobManager {
    * rejection.
    */
   private safeWindowsKill(pid: number | undefined): Promise<TaskkillResult> {
-    // An absent pid (spawn never produced one) cannot be taskkilled; resolve
-    // as a no-op failure rather than entering the timeout race, so no
-    // taskkill process is ever spawned for an unknown pid.
-    if (pid === undefined) {
+    // A non-killable pid (undefined, 0, negative, NaN, Infinity, or fractional)
+    // must never reach taskkill: 0 would be reinterpreted and an absent/invalid
+    // pid would only error. Resolve as a no-op failure BEFORE entering the
+    // timeout race, so no taskkill process is ever spawned and the
+    // never-rejecting contract is preserved.
+    if (!isKillablePid(pid)) {
       return Promise.resolve({
         ok: false,
-        error: new Error('Cannot taskkill: process has no pid'),
+        error: new Error(`Cannot taskkill non-killable pid: ${String(pid)}`),
       });
     }
     return new Promise<TaskkillResult>((resolve) => {
@@ -804,10 +807,9 @@ export class ShellJobManager {
       .map(([id, entry]) => ({
         id,
         pid: entry.pid,
-        remediation:
-          entry.pid === undefined
-            ? 'pid unknown; cannot emit taskkill remediation'
-            : `taskkill /T /F /PID ${entry.pid}`,
+        remediation: !isKillablePid(entry.pid)
+          ? 'pid unknown; cannot emit taskkill remediation'
+          : `taskkill /T /F /PID ${entry.pid}`,
       }));
     if (remaining.length > 0) {
       debugLogger.warn(

--- a/packages/core/src/services/shellJobManagerCancelRace.test.ts
+++ b/packages/core/src/services/shellJobManagerCancelRace.test.ts
@@ -84,7 +84,7 @@ describe.skipIf(os.platform() !== 'win32')(
           command: buildInnerPidMarkerCommand(innerMarker, 60),
           cwd: os.tmpdir(),
         });
-        outerPid = job.pid;
+        outerPid = job.pid ?? 0;
         innerPid = await readInnerPidFromMarker(innerMarker, 10_000);
 
         const firstCancellation = manager.cancel(job.id);
@@ -119,7 +119,7 @@ describe.skipIf(os.platform() !== 'win32')(
           ),
           cwd: os.tmpdir(),
         });
-        outerPid = job.pid;
+        outerPid = job.pid ?? 0;
         innerPid = await readInnerPidFromMarker(innerMarker, 10_000);
 
         const cancellation = manager.cancel(job.id);
@@ -154,7 +154,7 @@ describe.skipIf(os.platform() !== 'win32')(
           ),
           cwd: os.tmpdir(),
         });
-        outerPid = job.pid;
+        outerPid = job.pid ?? 0;
         innerPid = await readInnerPidFromMarker(innerMarker, 10_000);
 
         await taskkillStarted;

--- a/packages/core/src/services/shellJobManagerSurvivors.test.ts
+++ b/packages/core/src/services/shellJobManagerSurvivors.test.ts
@@ -140,7 +140,7 @@ describe.skipIf(os.platform() !== 'win32')(
           command: buildInnerPidMarkerCommand(innerMarker),
           cwd: os.tmpdir(),
         });
-        survivorPid = job.pid;
+        survivorPid = job.pid ?? 0;
         innerPid = await readInnerPidFromMarker(innerMarker, 10000);
         await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -187,7 +187,7 @@ describe.skipIf(os.platform() !== 'win32')(
           command: buildInnerPidMarkerCommand(innerMarker),
           cwd: os.tmpdir(),
         });
-        survivorPid = job.pid;
+        survivorPid = job.pid ?? 0;
         innerPid = await readInnerPidFromMarker(innerMarker, 10000);
         await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -208,6 +208,55 @@ describe.skipIf(os.platform() !== 'win32')(
         await reapAndRemoveWindowsTestDir(h3Dir, h3Manager, [
           survivorPid,
           innerPid,
+        ]);
+      }
+    }, 30000);
+
+    // --- Defense-in-depth: the taskkill boundary must only ever see valid pids
+    // ---
+    //
+    // The injected taskkillImpl is the exact observable boundary where a bad
+    // pid would be visible. Every pid it receives must be strictly positive:
+    // a 0 / negative / non-finite pid reaching taskkill is the regression this
+    // issue (#3126) guards against at the primitive chokepoints. This asserts
+    // the invariant survives the full manager cancel/dispose flow.
+
+    it('never passes a non-positive pid to taskkillImpl across cancel and dispose', async () => {
+      const guardDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pid-guard-'));
+      const receivedPids: number[] = [];
+      const guardManager = new ShellJobManager({
+        baseDir: guardDir,
+        taskkillImpl: (pid: number): Promise<TaskkillResult> => {
+          receivedPids.push(pid);
+          return boundedTaskkill(pid);
+        },
+      });
+      let survivorPid = 0;
+      try {
+        const job = guardManager.launch({
+          command: 'Start-Sleep -Seconds 300',
+          cwd: os.tmpdir(),
+        });
+        // A successful Windows launch must yield a real pid; assert rather
+        // than coerce, so an absent pid fails the test instead of silently
+        // becoming 0 (the very value this issue exists to keep out of kills).
+        expect(job.pid).toBeGreaterThan(0);
+        survivorPid = job.pid as number;
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        await guardManager.cancel(job.id);
+        await guardManager.dispose();
+        await waitForPidGoneWindows(survivorPid, 10000);
+        survivorPid = 0;
+
+        // Every pid the manager asked taskkill to reap must be a real process.
+        expect(receivedPids.length).toBeGreaterThan(0);
+        for (const pid of receivedPids) {
+          expect(pid).toBeGreaterThan(0);
+        }
+      } finally {
+        await reapAndRemoveWindowsTestDir(guardDir, guardManager, [
+          survivorPid,
         ]);
       }
     }, 30000);
@@ -236,7 +285,7 @@ describe.skipIf(os.platform() !== 'win32')(
             command: buildInnerPidMarkerCommand(marker),
             cwd: os.tmpdir(),
           });
-          survivorPids.push(job.pid);
+          survivorPids.push(job.pid ?? 0);
         }
         for (const marker of innerMarkers) {
           innerPids.push(await readInnerPidFromMarker(marker, 10000));
@@ -290,7 +339,7 @@ describe.skipIf(os.platform() !== 'win32')(
           command: buildInnerPidMarkerCommand(innerMarker),
           cwd: os.tmpdir(),
         });
-        survivorPid = job.pid;
+        survivorPid = job.pid ?? 0;
         survivorLogPath = path.join(i2Dir, `${job.id}.log`);
         innerPid = await readInnerPidFromMarker(innerMarker, 10000);
         await new Promise((resolve) => setTimeout(resolve, 500));
@@ -342,7 +391,7 @@ describe.skipIf(os.platform() !== 'win32')(
           command: 'Start-Sleep -Seconds 300',
           cwd: os.tmpdir(),
         });
-        survivorPid = job.pid;
+        survivorPid = job.pid ?? 0;
         await new Promise((resolve) => setTimeout(resolve, 500));
 
         // Start disposal WITHOUT awaiting. The public dispose() sets the
@@ -402,7 +451,7 @@ describe.skipIf(os.platform() !== 'win32')(
           command: 'Start-Sleep -Seconds 300',
           cwd: os.tmpdir(),
         });
-        survivorPid = job.pid;
+        survivorPid = job.pid ?? 0;
         await new Promise((resolve) => setTimeout(resolve, 500));
 
         const disposalPromise = microManager.dispose();

--- a/packages/core/src/services/shellJobSpawn.ts
+++ b/packages/core/src/services/shellJobSpawn.ts
@@ -49,7 +49,7 @@ interface BunSpawnGlobal {
  * Under Node.js, we use `node:child_process.spawn` with the `exit` event.
  */
 export interface SpawnedProcess {
-  readonly pid: number;
+  readonly pid: number | undefined;
   readonly child: ChildProcess;
   readonly exited: Promise<ProcessExitInfo>;
   readonly onError: (handler: (err: Error) => void) => void;
@@ -165,7 +165,10 @@ function spawnWithBun(
 function makeErrorSpawn(error: Error): SpawnedProcess {
   const fakeChild = new EventEmitter() as unknown as ChildProcess;
   return {
-    pid: -1,
+    // No real process was created, so there is no pid. Representing "no pid"
+    // explicitly avoids a sentinel number (e.g. -1) flowing into a kill
+    // primitive as process.kill(1).
+    pid: undefined,
     child: fakeChild,
     // Never resolves: the error is delivered via onError, which triggers
     // the terminal transition through handleError → finalizeJob.
@@ -203,7 +206,7 @@ function spawnWithNodeChildProcess(
   });
 
   return {
-    pid: child.pid ?? -1,
+    pid: child.pid,
     child,
     exited,
     onError: (handler) => {
@@ -330,7 +333,7 @@ export function spawnWindowsBackground(
   });
 
   return {
-    pid: child.pid ?? -1,
+    pid: child.pid,
     child,
     exited,
     onError: (handler) => {

--- a/packages/core/src/services/shellJobTypes.ts
+++ b/packages/core/src/services/shellJobTypes.ts
@@ -33,7 +33,7 @@ export interface ShellJob {
   state: ShellJobState;
   startedAt: number;
   endedAt?: number;
-  pid: number;
+  pid: number | undefined;
   exitCode?: number;
   signal?: string;
   failureReason?: string;
@@ -70,7 +70,7 @@ export interface ShellJobRecord {
   phase: ShellJobPhase;
   startedAt: number;
   endedAt?: number;
-  pid: number;
+  pid: number | undefined;
   exitCode?: number;
   signal?: string;
   failureReason?: string;

--- a/packages/core/src/services/shellProcessKill.test.ts
+++ b/packages/core/src/services/shellProcessKill.test.ts
@@ -210,9 +210,16 @@ describe.skipIf(isWindows)('escalateKillUnix pid validation (POSIX)', () => {
     const helperPid = helper.pid ?? 0;
     try {
       const result = await waitForMarker(outMarker, 8000);
-      // With the guard the kill fallback is never invoked for bad pids.
+      // With the guard the kill fallback is never invoked for bad pids. This
+      // is the assertion that fails without the fix: pre-guard, -1 reaches
+      // process.kill(1) (EPERM) and NaN/Infinity throw, so all three land in
+      // the fallback and the marker reads "3".
+      //
+      // Deliberately no liveness assertion on the helper: it calls
+      // process.exit(0) immediately after writing the marker, so by the time
+      // the parent observes the marker the helper has already exited on
+      // purpose. Asserting it is alive races its own normal exit.
       expect(result).toBe('0');
-      expect(isPidAlive(helperPid)).toBe(true);
     } finally {
       reapGroup(helperPid);
       fs.rmSync(dir, { recursive: true, force: true });
@@ -246,7 +253,12 @@ describe.skipIf(isWindows)('escalateKillUnix pid validation (POSIX)', () => {
         ),
       ]);
       // The guard must not have suppressed the kill for a legitimate pid.
-      expect(signal).toBe('SIGKILL');
+      // escalateKillUnix sends SIGTERM first and only escalates to SIGKILL
+      // after SIGKILL_TIMEOUT_MS, so a well-behaved `sleep` dies on SIGTERM.
+      // Asserting SIGKILL specifically would assert the escalation timer
+      // rather than the guard; what matters here is that a signal was
+      // delivered at all.
+      expect(signal === 'SIGTERM' || signal === 'SIGKILL').toBe(true);
     } finally {
       reapGroup(childPid);
     }

--- a/packages/core/src/services/shellProcessKill.test.ts
+++ b/packages/core/src/services/shellProcessKill.test.ts
@@ -1,0 +1,369 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+import {
+  boundedTaskkill,
+  escalateKillUnix,
+  isKillablePid,
+  taskkillTree,
+} from './shellProcessKill.js';
+import { createExitGuard } from './shellExitGuard.js';
+
+const isWindows = os.platform() === 'win32';
+
+/** Signal-0 existence check, portable across POSIX and Windows. */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Poll until `markerPath` exists and contains non-whitespace, returning its trimmed content. */
+async function waitForMarker(
+  markerPath: string,
+  timeoutMs = 8000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const content = fs.readFileSync(markerPath, 'utf8').trim();
+      if (content !== '') return content;
+    } catch {
+      // Not written yet.
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Marker ${markerPath} not written within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+/** Kill an entire detached process group (no-op if already gone). POSIX only. */
+function reapGroup(pgid: number): void {
+  // Guard the cleanup path against the very bug under test: a spawn that
+  // produced no pid yields 0 here, and `process.kill(-0)` is `process.kill(0)`,
+  // which would signal the TEST RUNNER's own process group.
+  if (!Number.isInteger(pgid) || pgid <= 0) return;
+  try {
+    process.kill(-pgid, 'SIGKILL');
+  } catch {
+    // Already gone.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// isKillablePid — the single chokepoint, platform independent
+// ---------------------------------------------------------------------------
+
+describe('isKillablePid', () => {
+  it('rejects every pid that POSIX kill(2) would reinterpret', () => {
+    // 0 signals the caller's own process group and -1 signals every
+    // signalable process; both are the catastrophic cases this guard exists
+    // for. Negative values target a process group rather than a process.
+    expect(isKillablePid(0)).toBe(false);
+    expect(isKillablePid(-0)).toBe(false);
+    expect(isKillablePid(-1)).toBe(false);
+    expect(isKillablePid(-1234)).toBe(false);
+  });
+
+  it('rejects non-finite and non-integer numbers', () => {
+    expect(isKillablePid(Number.NaN)).toBe(false);
+    expect(isKillablePid(Number.POSITIVE_INFINITY)).toBe(false);
+    expect(isKillablePid(Number.NEGATIVE_INFINITY)).toBe(false);
+    // A fractional value could be truncated after the `-pid` negation and
+    // land on an unrelated process group.
+    expect(isKillablePid(1.5)).toBe(false);
+    expect(isKillablePid(0.5)).toBe(false);
+  });
+
+  it('rejects absent and non-numeric values', () => {
+    expect(isKillablePid(undefined)).toBe(false);
+    expect(isKillablePid(null)).toBe(false);
+    expect(isKillablePid('1234')).toBe(false);
+    expect(isKillablePid({})).toBe(false);
+  });
+
+  it('accepts whole positive pids', () => {
+    expect(isKillablePid(1)).toBe(true);
+    expect(isKillablePid(1234)).toBe(true);
+    expect(isKillablePid(process.pid)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escalateKillUnix — POSIX-only (production behavior is POSIX-gated)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(isWindows)('escalateKillUnix pid validation (POSIX)', () => {
+  it('pid 0 does NOT signal the caller process group (caller + sibling survive)', async () => {
+    // The helper runs in its OWN process group (detached/setsid). It spawns a
+    // sibling into that same group, then calls escalateKillUnix(0). With the
+    // bug present, process.kill(0) reaps the helper's entire group (helper +
+    // sibling). With the guard, it is a no-op and both survive. The parent
+    // test process lives in a different group, so it is never in the blast
+    // radius — this is the assertion that actually catches kill(0).
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'escalate-pid0-'));
+    const siblingMarker = path.join(dir, 'sibling.pid');
+    const calledMarker = path.join(dir, 'called');
+    const scriptPath = path.join(dir, 'probe.ts');
+    const modulePath = path
+      .join(__dirname, 'shellProcessKill.ts')
+      .replace(/\\/g, '/');
+    const guardPath = path
+      .join(__dirname, 'shellExitGuard.ts')
+      .replace(/\\/g, '/');
+
+    const script = [
+      `import { spawn } from 'node:child_process';`,
+      `import { writeFile } from 'node:fs/promises';`,
+      `import { escalateKillUnix } from '${modulePath}';`,
+      `import { createExitGuard } from '${guardPath}';`,
+      `const siblingMarker = process.argv[2];`,
+      `const calledMarker = process.argv[3];`,
+      `// Sibling shares THIS helper's process group (not detached).`,
+      `const sibling = spawn('sleep', ['30'], { stdio: 'ignore' });`,
+      `await writeFile(siblingMarker, String(sibling.pid));`,
+      `await writeFile(calledMarker, 'called');`,
+      `const guard = createExitGuard();`,
+      `// If the bug is present this reaps our own group (SIGTERM then SIGKILL).`,
+      `await escalateKillUnix(0, guard, () => {});`,
+      `// Survived: stay alive briefly so the parent can observe liveness.`,
+      `await new Promise((r) => setTimeout(r, 4000));`,
+      `try { sibling.kill('SIGKILL'); } catch { /* already gone */ }`,
+      `process.exit(0);`,
+    ].join('\n');
+    fs.writeFileSync(scriptPath, script);
+
+    const helper = spawn(
+      process.execPath,
+      [scriptPath, siblingMarker, calledMarker],
+      { detached: true, stdio: 'ignore' },
+    );
+    helper.unref();
+    const helperPid = helper.pid ?? 0;
+    let siblingPid = 0;
+    try {
+      siblingPid = Number(await waitForMarker(siblingMarker, 8000));
+      // Proves the helper reached the escalateKillUnix(0) call.
+      await waitForMarker(calledMarker, 8000);
+      // Allow time for the SIGTERM (t=0) + SIGKILL escalation (t=200ms).
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // THE assertion that catches kill(0): the "caller" (helper) and its
+      // same-group sibling must both still be alive.
+      expect(helperPid).toBeGreaterThan(0);
+      expect(isPidAlive(helperPid)).toBe(true);
+      expect(siblingPid).toBeGreaterThan(0);
+      expect(isPidAlive(siblingPid)).toBe(true);
+    } finally {
+      reapGroup(helperPid);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('pid -1 / NaN / Infinity do not signal anything and do not invoke the kill fallback', async () => {
+    // Without the guard, escalateKillUnix(-1) => process.kill(1) (EPERM, caught
+    // => killFallback); NaN/Infinity => process.kill throws (caught =>
+    // killFallback). With the guard, all three short-circuit before any kill.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'escalate-bad-'));
+    const outMarker = path.join(dir, 'fallback.txt');
+    const scriptPath = path.join(dir, 'probe.ts');
+    const modulePath = path
+      .join(__dirname, 'shellProcessKill.ts')
+      .replace(/\\/g, '/');
+    const guardPath = path
+      .join(__dirname, 'shellExitGuard.ts')
+      .replace(/\\/g, '/');
+
+    const script = [
+      `import { writeFile } from 'node:fs/promises';`,
+      `import { escalateKillUnix } from '${modulePath}';`,
+      `import { createExitGuard } from '${guardPath}';`,
+      `const out = process.argv[2];`,
+      `let fallbackCalls = 0;`,
+      `const guard = createExitGuard();`,
+      `await escalateKillUnix(-1, guard, () => { fallbackCalls++; });`,
+      `await escalateKillUnix(NaN, guard, () => { fallbackCalls++; });`,
+      `await escalateKillUnix(Infinity, guard, () => { fallbackCalls++; });`,
+      `await writeFile(out, String(fallbackCalls));`,
+      `process.exit(0);`,
+    ].join('\n');
+    fs.writeFileSync(scriptPath, script);
+
+    const helper = spawn(process.execPath, [scriptPath, outMarker], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    helper.unref();
+    const helperPid = helper.pid ?? 0;
+    try {
+      const result = await waitForMarker(outMarker, 8000);
+      // With the guard the kill fallback is never invoked for bad pids.
+      expect(result).toBe('0');
+      expect(isPidAlive(helperPid)).toBe(true);
+    } finally {
+      reapGroup(helperPid);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('a valid pid of a real detached child is still killed (guard did not break the feature)', async () => {
+    // A detached child becomes its own process-group leader (setsid), so
+    // process.kill(-pid) targets only that group.
+    const child = spawn('sleep', ['30'], { detached: true, stdio: 'ignore' });
+    child.unref();
+    const childPid = child.pid ?? 0;
+    expect(childPid).toBeGreaterThan(0);
+    // Observe the exit via the child handle rather than a signal-0 probe: this
+    // process is the child's parent, so between SIGKILL and the runtime's
+    // SIGCHLD reap the pid is a zombie and `process.kill(pid, 0)` still
+    // SUCCEEDS. Awaiting 'exit' proves termination without that race.
+    const exited = new Promise<NodeJS.Signals | null>((resolve) => {
+      child.on('exit', (_code, signal) => resolve(signal));
+    });
+    try {
+      const guard = createExitGuard();
+      await escalateKillUnix(childPid, guard, () => {});
+      const signal = await Promise.race([
+        exited,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error(`pid ${childPid} was not killed`)),
+            8000,
+          ),
+        ),
+      ]);
+      // The guard must not have suppressed the kill for a legitimate pid.
+      expect(signal).toBe('SIGKILL');
+    } finally {
+      reapGroup(childPid);
+    }
+  }, 20000);
+});
+
+// ---------------------------------------------------------------------------
+// boundedTaskkill / taskkillTree — Windows-only (production behavior gated)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!isWindows)(
+  'taskkill primitives pid validation (Windows)',
+  () => {
+    it('boundedTaskkill resolves {ok:false} for invalid pids and never rejects', async () => {
+      // Deliberately-invalid values that exercise the runtime guard. The cast
+      // bridges the pre-fix `number` signature; the guard validates at runtime.
+      const badPids = [
+        { label: 'zero', value: 0 },
+        { label: 'negative', value: -1 },
+        { label: 'NaN', value: Number.NaN },
+        { label: 'undefined', value: undefined },
+      ];
+      for (const { value } of badPids) {
+        const result = await boundedTaskkill(value as never);
+        expect(result.ok).toBe(false);
+        expect(result.error).toBeInstanceOf(Error);
+        // A validation-rejection error proves the guard fired BEFORE spawning
+        // taskkill — distinct from a taskkill subprocess exit-code error.
+        expect(result.error?.message).toMatch(/non-killable|invalid.*pid/i);
+      }
+    });
+
+    it('taskkillTree with invalid pids does not throw (fire-and-forget guard)', () => {
+      const badPids = [
+        { label: 'zero', value: 0 },
+        { label: 'negative', value: -1 },
+        { label: 'NaN', value: Number.NaN },
+        { label: 'undefined', value: undefined },
+      ];
+      for (const { value } of badPids) {
+        expect(() => taskkillTree(value as never)).not.toThrow();
+      }
+    });
+
+    it('boundedTaskkill with a valid pid still spawns taskkill and reaps the process', async () => {
+      const child = spawn(
+        'powershell.exe',
+        ['-NoProfile', '-Command', 'Start-Sleep -Seconds 60'],
+        { windowsHide: true, stdio: 'ignore' },
+      );
+      child.unref();
+      const childPid = child.pid ?? 0;
+      expect(childPid).toBeGreaterThan(0);
+      // Give the process a moment to be observable by taskkill.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      try {
+        const result = await boundedTaskkill(childPid);
+        expect(result.ok).toBe(true);
+        await waitForPidGone(childPid, 8000);
+        expect(isPidAlive(childPid)).toBe(false);
+      } finally {
+        reapWindowsPid(childPid);
+      }
+    }, 20000);
+
+    it('taskkillTree with a valid pid terminates a live child', async () => {
+      const child = spawn(
+        'powershell.exe',
+        ['-NoProfile', '-Command', 'Start-Sleep -Seconds 60'],
+        { windowsHide: true, stdio: 'ignore' },
+      );
+      child.on('error', () => {});
+      const childPid = child.pid ?? 0;
+      expect(childPid).toBeGreaterThan(0);
+      // Observe the exit through the handle rather than a signal-0 probe: a
+      // killed child stays visible as a zombie until the runtime reaps it.
+      const exited = new Promise<void>((resolve) => {
+        child.once('exit', () => resolve());
+      });
+      // Give the process a moment to be observable by taskkill.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      try {
+        taskkillTree(childPid);
+        await Promise.race([
+          exited,
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error(`pid ${childPid} was not killed`)),
+              8000,
+            ),
+          ),
+        ]);
+      } finally {
+        reapWindowsPid(childPid);
+      }
+    }, 20000);
+  },
+);
+
+/** Poll until a Windows pid is confirmed gone. */
+async function waitForPidGone(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+}
+
+/** Best-effort direct reap of a Windows pid (cleanup only). */
+function reapWindowsPid(pid: number): void {
+  if (pid <= 0) return;
+  try {
+    spawn('taskkill', ['/pid', String(pid), '/f', '/t'], {
+      windowsHide: true,
+      stdio: 'ignore',
+    });
+  } catch {
+    // Already gone.
+  }
+}

--- a/packages/core/src/services/shellProcessKill.test.ts
+++ b/packages/core/src/services/shellProcessKill.test.ts
@@ -117,6 +117,7 @@ describe.skipIf(isWindows)('escalateKillUnix pid validation (POSIX)', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'escalate-pid0-'));
     const siblingMarker = path.join(dir, 'sibling.pid');
     const calledMarker = path.join(dir, 'called');
+    const returnedMarker = path.join(dir, 'returned');
     const scriptPath = path.join(dir, 'probe.ts');
     const modulePath = path
       .join(__dirname, 'shellProcessKill.ts')
@@ -132,6 +133,7 @@ describe.skipIf(isWindows)('escalateKillUnix pid validation (POSIX)', () => {
       `import { createExitGuard } from '${guardPath}';`,
       `const siblingMarker = process.argv[2];`,
       `const calledMarker = process.argv[3];`,
+      `const returnedMarker = process.argv[4];`,
       `// Sibling shares THIS helper's process group (not detached).`,
       `const sibling = spawn('sleep', ['30'], { stdio: 'ignore' });`,
       `await writeFile(siblingMarker, String(sibling.pid));`,
@@ -139,6 +141,10 @@ describe.skipIf(isWindows)('escalateKillUnix pid validation (POSIX)', () => {
       `const guard = createExitGuard();`,
       `// If the bug is present this reaps our own group (SIGTERM then SIGKILL).`,
       `await escalateKillUnix(0, guard, () => {});`,
+      `// Written only AFTER escalateKillUnix(0) returned, so the parent waiting`,
+      `// on this marker proves the helper SURVIVED the call, not merely that it`,
+      `// reached it (the pre-call marker can only prove reachability).`,
+      `await writeFile(returnedMarker, 'returned');`,
       `// Survived: stay alive briefly so the parent can observe liveness.`,
       `await new Promise((r) => setTimeout(r, 4000));`,
       `try { sibling.kill('SIGKILL'); } catch { /* already gone */ }`,
@@ -148,7 +154,7 @@ describe.skipIf(isWindows)('escalateKillUnix pid validation (POSIX)', () => {
 
     const helper = spawn(
       process.execPath,
-      [scriptPath, siblingMarker, calledMarker],
+      [scriptPath, siblingMarker, calledMarker, returnedMarker],
       { detached: true, stdio: 'ignore' },
     );
     helper.unref();
@@ -156,8 +162,14 @@ describe.skipIf(isWindows)('escalateKillUnix pid validation (POSIX)', () => {
     let siblingPid = 0;
     try {
       siblingPid = Number(await waitForMarker(siblingMarker, 8000));
-      // Proves the helper reached the escalateKillUnix(0) call.
+      // Diagnosability: proves the helper reached the escalateKillUnix(0) call.
       await waitForMarker(calledMarker, 8000);
+      // THE gate: this marker is written only AFTER escalateKillUnix(0)
+      // returned, so reaching here proves the helper SURVIVED the call rather
+      // than merely reaching it. A future change that hangs inside
+      // escalateKillUnix before the guard would never write this marker and
+      // this wait would time out, instead of wrongly passing.
+      await waitForMarker(returnedMarker, 8000);
       // Allow time for the SIGTERM (t=0) + SIGKILL escalation (t=200ms).
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -309,11 +321,13 @@ describe.skipIf(!isWindows)(
         ['-NoProfile', '-Command', 'Start-Sleep -Seconds 60'],
         { windowsHide: true, stdio: 'ignore' },
       );
+      child.on('error', () => {});
       child.unref();
       const childPid = child.pid ?? 0;
       expect(childPid).toBeGreaterThan(0);
-      // Give the process a moment to be observable by taskkill.
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      // Wait until the pid is observable by taskkill rather than a fixed
+      // delay, which can be too short on a loaded CI runner.
+      await waitForPidVisible(childPid, 8000);
       try {
         const result = await boundedTaskkill(childPid);
         expect(result.ok).toBe(true);
@@ -338,8 +352,9 @@ describe.skipIf(!isWindows)(
       const exited = new Promise<void>((resolve) => {
         child.once('exit', () => resolve());
       });
-      // Give the process a moment to be observable by taskkill.
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      // Wait until the pid is observable by taskkill rather than a fixed
+      // delay, which can be too short on a loaded CI runner.
+      await waitForPidVisible(childPid, 8000);
       try {
         taskkillTree(childPid);
         await Promise.race([
@@ -364,6 +379,22 @@ async function waitForPidGone(pid: number, timeoutMs: number): Promise<void> {
   while (Date.now() < deadline) {
     if (!isPidAlive(pid)) return;
     await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+}
+
+/**
+ * Poll until a pid is observable by taskkill, up to `timeoutMs`. A static
+ * delay is flaky on a loaded CI runner where the child may take longer than
+ * the fixed window to be observable; polling keeps the readiness gate stable.
+ */
+async function waitForPidVisible(
+  pid: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (isPidAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
   }
 }
 

--- a/packages/core/src/services/shellProcessKill.ts
+++ b/packages/core/src/services/shellProcessKill.ts
@@ -10,11 +10,29 @@ import type { ExitGuard } from './shellExitGuard.js';
 export const SIGKILL_TIMEOUT_MS = 200;
 
 /**
+ * The single chokepoint that keeps a non-killable pid away from every
+ * process-kill primitive. POSIX `kill(2)` overloads its pid argument:
+ * `0` signals the caller's own process group, negative values target a group
+ * (or, for `-1`, every signalable process), and `NaN`/`Infinity` are never
+ * valid. Rejecting those here turns a catastrophic `kill(0)` into a no-op.
+ *
+ * Integrality is required as well: a fractional value could be truncated by
+ * the runtime after the `-pid` negation and land on an unrelated process
+ * group, so only whole positive numbers are accepted.
+ */
+export function isKillablePid(pid: unknown): pid is number {
+  return typeof pid === 'number' && Number.isInteger(pid) && pid > 0;
+}
+
+/**
  * Fire-and-forget taskkill on Windows.  The arguments are explicit and
  * fully controlled; `sonarjs/no-os-command-from-path` is centrally
  * disabled for this codebase.
  */
-export function taskkillTree(pid: number): void {
+export function taskkillTree(pid: number | undefined): void {
+  if (!isKillablePid(pid)) {
+    return;
+  }
   cpSpawn('taskkill', ['/pid', pid.toString(), '/f', '/t']);
 }
 
@@ -34,7 +52,18 @@ export const TASKKILL_TIMEOUT_MS = 5000;
  * operation and is cleared on settle, guaranteeing forward progress even though
  * the taskkill child itself is unref'd.
  */
-export function boundedTaskkill(pid: number): Promise<TaskkillResult> {
+export function boundedTaskkill(
+  pid: number | undefined,
+): Promise<TaskkillResult> {
+  if (!isKillablePid(pid)) {
+    // Preserve the never-rejecting contract: an invalid pid is rejected here
+    // rather than handed to taskkill, which on Windows would either error or,
+    // worse, accept a misleading value.
+    return Promise.resolve({
+      ok: false,
+      error: new Error(`Refusing taskkill of non-killable pid: ${String(pid)}`),
+    });
+  }
   return new Promise((resolve) => {
     let settled = false;
     // Declared before the guarded cpSpawn so a synchronous spawn throw can
@@ -101,10 +130,15 @@ export function boundedTaskkill(pid: number): Promise<TaskkillResult> {
  * process that exits during the grace period is not killed again.
  */
 export async function escalateKillUnix(
-  pid: number,
+  pid: number | undefined,
   exitedGuard: ExitGuard,
   killFallback: () => void,
 ): Promise<void> {
+  if (!isKillablePid(pid)) {
+    // A non-killable pid must never reach process.kill(-pid): pid 0 would
+    // signal the caller's own process group. Treat it as already gone.
+    return;
+  }
   try {
     process.kill(-pid, 'SIGTERM');
     await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
@@ -123,11 +157,14 @@ export async function escalateKillUnix(
  * paths.  Windows uses taskkill; Unix uses SIGTERM → SIGKILL.
  */
 export async function killProcessWithEscalation(
-  pid: number,
+  pid: number | undefined,
   isWindows: boolean,
   killChildFallback: () => void,
   exitedGuard: ExitGuard,
 ): Promise<void> {
+  if (!isKillablePid(pid)) {
+    return;
+  }
   if (isWindows) {
     taskkillTree(pid);
     return;

--- a/packages/core/src/services/shellPtyLifecycle.test.ts
+++ b/packages/core/src/services/shellPtyLifecycle.test.ts
@@ -1,0 +1,266 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import type { IPty } from '@lydell/node-pty';
+import headless from '@xterm/headless';
+
+import type { PtyExecState } from './shellPtyState.js';
+import type {
+  ShellExecutionConfig,
+  ShellExecutionResult,
+} from './shellExecutionTypes.js';
+import { createExitGuard } from './shellExitGuard.js';
+import {
+  ptyAbortAction,
+  ptyInactivityAbortAction,
+} from './shellPtyLifecycle.js';
+import type { PtyImplementation } from '../utils/getPty.js';
+
+const { Terminal } = headless;
+
+/**
+ * The abort actions take an exhaustive state bag; only a handful of fields
+ * are read on the paths under test. The collaborator under observation is the
+ * ptyProcess double (an infrastructure boundary, not the unit under test): we
+ * assert it is NOT signalled when the pid is non-killable.
+ */
+interface FakeStateInputs {
+  readonly pid: number;
+  readonly isWindows: boolean;
+  readonly supportsProcessGroupKill: boolean;
+}
+
+function makeFakeState(inputs: FakeStateInputs): {
+  state: PtyExecState;
+  killSignals: string[];
+} {
+  const killSignals: string[] = [];
+  const ptyProcess = {
+    pid: inputs.pid,
+    kill: (signal?: string | number): void => {
+      killSignals.push(signal === undefined ? '<none>' : String(signal));
+    },
+    onData: () => ({ dispose: () => undefined }),
+    onExit: () => ({ dispose: () => undefined }),
+  } as unknown as IPty;
+
+  const headlessTerminal = new Terminal({
+    allowProposedApi: true,
+    cols: 80,
+    rows: 30,
+    scrollback: 10,
+  });
+
+  const inactivityAbortController = new AbortController();
+
+  const state = {
+    ptyProcess,
+    headlessTerminal,
+    activePtyEntry: {
+      ptyProcess,
+      headlessTerminal,
+      supportsProcessGroupKill: inputs.supportsProcessGroupKill,
+    },
+    isWindows: inputs.isWindows,
+    abortSignal: new AbortController().signal,
+    onOutputEvent: () => undefined,
+    shellExecutionConfig: {} as ShellExecutionConfig,
+    ptyInfo: { name: 'node-pty', module: {} } as NonNullable<PtyImplementation>,
+    supportsProcessGroupKill: inputs.supportsProcessGroupKill,
+    inactivityAbortController,
+    resetInactivityTimer: () => undefined,
+    exitedGuard: createExitGuard(),
+    decoder: null,
+    output: null,
+    outputChunks: [],
+    error: null,
+    isStreamingRawContent: true,
+    sniffedBytes: 0,
+    isWriting: false,
+    hasStartedOutput: false,
+    hasResolved: false,
+    abortFinalizeTimeout: null,
+    processingChain: Promise.resolve(),
+  } as unknown as PtyExecState;
+
+  return { state, killSignals };
+}
+
+/**
+ * Clear any finalization timer the abort action schedules, so the deferred
+ * resolveResult call (which builds a result from terminal state) never fires
+ * and the test focuses purely on whether the pid was signalled.
+ */
+function clearFinalizeTimer(state: PtyExecState): void {
+  if (state.abortFinalizeTimeout !== null) {
+    clearTimeout(state.abortFinalizeTimeout);
+    state.abortFinalizeTimeout = null;
+  }
+}
+
+/**
+ * Release the timer and the headless terminal each fake state holds. The
+ * terminal owns internal buffers and listeners, so leaving it undisposed
+ * across many cases leaks memory in the test process.
+ */
+function disposeFakeState(state: PtyExecState): void {
+  clearFinalizeTimer(state);
+  state.inactivityAbortController.abort();
+  state.headlessTerminal.dispose();
+}
+
+describe('ptyAbortAction pid validation', () => {
+  const createdStates: PtyExecState[] = [];
+
+  afterEach(() => {
+    for (const state of createdStates) {
+      disposeFakeState(state);
+    }
+    createdStates.length = 0;
+  });
+
+  it('does not signal a NaN pid (=== 0 guard previously let NaN through)', async () => {
+    const { state, killSignals } = makeFakeState({
+      pid: Number.NaN,
+      isWindows: false,
+      supportsProcessGroupKill: true,
+    });
+    createdStates.push(state);
+
+    const noopResolve = (_: ShellExecutionResult): void => undefined;
+    await ptyAbortAction(state, noopResolve);
+    clearFinalizeTimer(state);
+
+    // Before the fix the `=== 0` check let NaN pass; process.kill(-NaN) threw
+    // synchronously and the catch fallback invoked ptyProcess.kill. After the
+    // fix the isKillablePid guard short-circuits before any signal attempt.
+    expect(killSignals).toEqual([]);
+  });
+
+  it('does not signal an Infinity pid', async () => {
+    const { state, killSignals } = makeFakeState({
+      pid: Number.POSITIVE_INFINITY,
+      isWindows: false,
+      supportsProcessGroupKill: true,
+    });
+    createdStates.push(state);
+
+    await ptyAbortAction(state, () => undefined);
+    clearFinalizeTimer(state);
+
+    expect(killSignals).toEqual([]);
+  });
+
+  it('does not signal a negative pid', async () => {
+    const { state, killSignals } = makeFakeState({
+      pid: -1,
+      isWindows: false,
+      supportsProcessGroupKill: true,
+    });
+    createdStates.push(state);
+
+    await ptyAbortAction(state, () => undefined);
+    clearFinalizeTimer(state);
+
+    expect(killSignals).toEqual([]);
+  });
+
+  it('does not signal pid 0 (would signal the caller process group)', async () => {
+    const { state, killSignals } = makeFakeState({
+      pid: 0,
+      isWindows: false,
+      supportsProcessGroupKill: true,
+    });
+    createdStates.push(state);
+
+    await ptyAbortAction(state, () => undefined);
+    clearFinalizeTimer(state);
+
+    // pid 0 was already covered by the old `=== 0` check, so this is a
+    // regression guard rather than a red test: it pins the single most
+    // dangerous value, for which process.kill(-0) === process.kill(0)
+    // signals every process in llxprt's own process group.
+    expect(killSignals).toEqual([]);
+  });
+
+  it('still signals a valid positive pid (guard is not over-broad)', async () => {
+    // supportsProcessGroupKill is deliberately false: with it true this path
+    // runs process.kill(-pid) against a REAL process group, and a made-up pid
+    // would signal an unrelated group on a CI runner - the exact hazard this
+    // issue is about. With it false the only kill is the fake pty's, so the
+    // assertion still proves isKillablePid admits valid pids.
+    const { state, killSignals } = makeFakeState({
+      pid: 12345,
+      isWindows: false,
+      supportsProcessGroupKill: false,
+    });
+    createdStates.push(state);
+
+    await ptyAbortAction(state, () => undefined);
+    clearFinalizeTimer(state);
+
+    expect(killSignals).toContain('SIGTERM');
+  });
+});
+
+describe('ptyInactivityAbortAction pid validation', () => {
+  const createdStates: PtyExecState[] = [];
+
+  afterEach(() => {
+    for (const state of createdStates) {
+      disposeFakeState(state);
+    }
+    createdStates.length = 0;
+  });
+
+  it('does not signal a NaN pid (=== 0 guard previously let NaN through)', async () => {
+    const { state, killSignals } = makeFakeState({
+      pid: Number.NaN,
+      isWindows: false,
+      supportsProcessGroupKill: true,
+    });
+    createdStates.push(state);
+
+    await ptyInactivityAbortAction(state, () => undefined);
+    clearFinalizeTimer(state);
+
+    // Before the fix NaN slipped past `=== 0`; process.kill(-NaN) threw, the
+    // catch escalated to ptyProcess.kill('SIGKILL'). After the fix no kill is
+    // attempted.
+    expect(killSignals).toEqual([]);
+  });
+
+  it('does not signal pid 0 (would signal the caller process group)', async () => {
+    const { state, killSignals } = makeFakeState({
+      pid: 0,
+      isWindows: false,
+      supportsProcessGroupKill: true,
+    });
+    createdStates.push(state);
+
+    await ptyInactivityAbortAction(state, () => undefined);
+    clearFinalizeTimer(state);
+
+    expect(killSignals).toEqual([]);
+  });
+
+  it('still signals a valid positive pid (guard is not over-broad)', async () => {
+    // supportsProcessGroupKill false for the same reason as the abort path:
+    // never aim process.kill(-pid) at a fabricated pid on a real machine.
+    const { state, killSignals } = makeFakeState({
+      pid: 12345,
+      isWindows: false,
+      supportsProcessGroupKill: false,
+    });
+    createdStates.push(state);
+
+    await ptyInactivityAbortAction(state, () => undefined);
+    clearFinalizeTimer(state);
+
+    expect(killSignals.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -14,7 +14,11 @@ import type {
 } from './shellExecutionTypes.js';
 import { createExitGuard } from './shellExitGuard.js';
 import { makeInactivityTimer } from './shellOutputUtils.js';
-import { SIGKILL_TIMEOUT_MS, taskkillTree } from './shellProcessKill.js';
+import {
+  SIGKILL_TIMEOUT_MS,
+  isKillablePid,
+  taskkillTree,
+} from './shellProcessKill.js';
 import type { PtyExecState } from './shellPtyState.js';
 import type { ActivePty } from './shellPtyHelpers.js';
 import {
@@ -218,11 +222,13 @@ function setupPtyInactivityHandler(
   state.resetInactivityTimer();
 }
 
-async function ptyInactivityAbortAction(
+export async function ptyInactivityAbortAction(
   state: PtyExecState,
   resolveResult: (resultValue: ShellExecutionResult) => void,
 ): Promise<void> {
-  if (state.ptyProcess.pid === 0 || state.exitedGuard.isExited()) {
+  // A non-killable pid (0, negative, NaN, Infinity) must never reach
+  // process.kill(-pid): pid 0 would signal the caller's own process group.
+  if (!isKillablePid(state.ptyProcess.pid) || state.exitedGuard.isExited()) {
     return;
   }
   const pid = state.ptyProcess.pid;
@@ -274,12 +280,13 @@ function setupPtyAbortHandler(
   };
 }
 
-async function ptyAbortAction(
+export async function ptyAbortAction(
   state: PtyExecState,
   resolveResult: (resultValue: ShellExecutionResult) => void,
 ): Promise<void> {
-  // Preserve old truthiness semantics: skip pid 0 (invalid process ID)
-  if (state.ptyProcess.pid === 0 || state.exitedGuard.isExited()) {
+  // A non-killable pid (0, negative, NaN, Infinity) must never reach
+  // process.kill(-pid): pid 0 would signal the caller's own process group.
+  if (!isKillablePid(state.ptyProcess.pid) || state.exitedGuard.isExited()) {
     return;
   }
   const pid = state.ptyProcess.pid;

--- a/packages/tools/src/interfaces/IShellToolHost.ts
+++ b/packages/tools/src/interfaces/IShellToolHost.ts
@@ -114,7 +114,8 @@ export interface HostShellJobInfo {
   state: HostShellJobState;
   startedAt: number;
   endedAt?: number;
-  pid: number;
+  /** Process ID of the spawned process; undefined when spawn produced none. */
+  pid: number | undefined;
   exitCode?: number;
   signal?: string;
   failureReason?: string;

--- a/project-plans/issue-3126-kill-pid-validation.md
+++ b/project-plans/issue-3126-kill-pid-validation.md
@@ -1,0 +1,206 @@
+# Issue #3126 — Esc during shell exec can kill llxprt and its parent supervisor
+
+Pressing <kbd>Esc</kbd> to cancel an in-flight shell tool call can terminate
+llxprt itself and its parent supervisor (`jefe`), returning the user to the OS
+shell. The cancel path funnels a raw, unvalidated pid into
+`process.kill(-pid, signal)`.
+
+POSIX `kill(2)` overloads its pid argument: `pid > 0` targets one process,
+`pid == 0` targets **every process in the caller's own process group**,
+`pid == -1` targets every process the caller may signal, and `pid < -1` targets
+group `|pid|`. Because the code computes `process.kill(-pid, ...)`, a `pid` of
+`0` collapses to `kill(0, sig)` — llxprt signalling its own process group. When
+llxprt shares a process group with its supervisor (a `jefe`-launched child, or a
+tmux pane), that one call reaps llxprt, `jefe`, and the pane shell together.
+
+## Scope
+
+Enforce a single invariant at every process-kill boundary in `packages/core`:
+
+> **A non-positive or non-finite pid is never passed to `process.kill` or
+> `taskkill`.**
+
+Product changes are limited to pid validation at those boundaries, removal of
+the ambiguous `-1` spawn sentinel that feeds them, and identity-based guarding
+on the foreground kill paths. Spawn options are explicitly **out of scope** —
+`detached: !isWindows` is already correct (POSIX children get their own group
+via setsid; Windows children are descendants so `taskkill /T` walks downward
+only), and `shellJobSpawn.ts` documents that `detached: true` breaks the Windows
+PowerShell strategy.
+
+Hard constraint carried into every fix: **no test may be neutered to pass.** No
+deleted assertions, no matchers broadened until they cannot fail, and no
+platform skips except where the production code under test is itself
+platform-gated, with the gate mirroring the production one.
+
+### Sandbox kill sites: assessed, deliberately excluded
+
+A repo-wide sweep for `process.kill(-` found four further group-kill sites
+outside the shell services: `sandbox-containers.ts` (`-sandboxPid`) and
+`sandbox-seatbelt.ts` (`-proxyPid` twice, and `-pid`). They are **knowingly left
+alone**:
+
+- They are not on the Esc/cancel path, so they are not this issue's defect.
+- Their pids come from `spawn` handles held in a narrow local lifecycle scope,
+  not from the `-1` sentinel that made the shell paths dangerous.
+- Touching sandbox teardown would need its own behavioral tests against real
+  container and seatbelt lifecycles, which is a materially different change.
+
+Two further kill sites outside the shell services are likewise untouched:
+`packages/lsp/src/service/process-termination.ts` (`runTaskkill`) and
+`packages/auth/src/lock-owner.ts` (`process.kill(pid, signal)`). Neither is on
+the Esc/cancel path, and neither takes a negated pid, so neither can signal the
+caller's own process group.
+
+Recorded here so reviewers can see the sites were examined rather than missed.
+Worth a follow-up issue applying the same `isKillablePid` chokepoint there.
+
+## Defects
+
+All confirmed present on `main` @ `a805a219f`.
+
+| # | Location | Defect |
+| --- | --- | --- |
+| 1 | `shellJobInternal.ts` `killProcessGroupSafe` | The central defect. No validation at all before `process.kill(-pid, signal)`. Reached from `ShellJobManager.sendTermAndEscalate` and `failJobIfOverCapSync`. |
+| 2 | `shellProcessKill.ts` `escalateKillUnix` | No validation before `process.kill(-pid, 'SIGTERM')` / `'SIGKILL'`. |
+| 3 | `shellExecutionService.ts` `terminatePty` | No `pid <= 0` guard **and** no `isWindows` branch, unlike `ptyAbortAction`. Currently has no production callers — a latent public-API landmine. |
+| 4 | `shellPtyLifecycle.ts` `ptyAbortAction` / `ptyInactivityAbortAction` | Guard only `pid === 0`, not `<= 0` and not `NaN`, so a non-finite pid reaches the escalation calls. |
+| 5 | `shellProcessKill.ts` `taskkillTree` / `boundedTaskkill` | No validation before `taskkill /pid <pid> /f /t`. |
+| 6 | `shellJobSpawn.ts:168`, `:206`, `:333` | `pid: -1` and `pid: child.pid ?? -1` encode "no pid" as a number that flows straight into the kill primitives, producing `process.kill(1)` — a signal aimed at init. |
+
+Already-guarded, for contrast: `cpKillOnAbort` (`shellCpExecution.ts`) checks
+`pid !== undefined && pid !== 0`, and the Windows branch of
+`sendTermAndEscalate` gates on `childIsRunning(record.child)`. The same
+hardening was never propagated to the shared primitives those callers invoke.
+
+## Trigger path
+
+`Esc` → `handleEscapeKeypress` (`useAgentStreamLifecycle.ts`, registered with
+`isActive: true`, so it fires even while shell input is focused) →
+`cancelOngoingRequest()` → `abortControllerRef.current?.abort()` +
+`cancelAllToolCalls()` → the per-execution abort handlers → the unguarded kill
+primitives.
+
+Ruled out: no `process.exit` and no unhandled rejection is reachable from the
+cancel path. The termination is genuinely signal-driven.
+
+## Platform reality
+
+- **POSIX** — the lethal path. `kill(0)` on a shared process group reproduces
+  the report exactly.
+- **Windows** — `taskkill /T` walks the process tree *downward only*. llxprt is
+  the parent of the shell child and `jefe` is an ancestor, so under a **valid**
+  pid neither is in the tree. Invalid pids are rejected by `taskkill` with an
+  error rather than causing harm. Two narrower Windows defects remain real: the
+  **foreground** kill paths target a bare numeric pid with no pid validation,
+  so a non-killable pid can reach the kill primitive (stale/reused pids are
+  already covered there by `exitedGuard` — see fix step 5); and
+  `supportsProcessGroupKill` is computed as `ptyInfo.name !== 'bun-pty'`, which
+  is `true` on Windows where POSIX process groups do not exist — harmless only
+  because every Windows branch checks `isWindows` first, **except**
+  `terminatePty`.
+- **Multiplexer** — not the mechanism, but it sets the blast radius. tmux places
+  each pane's foreground process in its own process group; if `jefe` launches
+  llxprt in that pane without llxprt creating a new session, the two share a
+  group and `kill(0)` reaps both. There is no multiplexer-aware logic in the
+  kill paths, and none is being added — correct pid validation makes the
+  question moot.
+
+## TDD plan
+
+Red first: every test below must fail against current `main` for the stated
+reason before any production line changes.
+
+### 1. `shellProcessKill.test.ts` (new)
+
+No test file exists for this module today. Behavioral, real processes, no mocks.
+
+- `escalateKillUnix` with pid `0`, `-1`, `NaN`, `Infinity`: the calling process
+  must survive. Assert `process.kill(process.pid, 0)` still succeeds afterward,
+  and that a real sibling child spawned into the caller's own process group is
+  **still alive** — this is the assertion that actually catches `kill(0)`.
+  POSIX-gated, mirroring the production gate.
+- `escalateKillUnix` with a valid pid of a real detached child: the child's
+  group dies (unchanged behavior — proves the guard did not break the feature).
+- `taskkillTree` / `boundedTaskkill` with `0`, `-1`, `NaN`, `undefined`: no
+  `taskkill` process is spawned at all; `boundedTaskkill` resolves
+  `{ ok: false, error }` and never rejects, preserving its contract.
+- `boundedTaskkill` with a valid pid still spawns and resolves `{ ok: true }`.
+
+### 2. `shellJobInternal.test.ts` (new)
+
+No test file exists for this module today.
+
+- `killProcessGroupSafe(0, 'SIGTERM')` is a no-op: a real child in the caller's
+  own process group survives, and the test process survives.
+- `killProcessGroupSafe(-1, ...)`, `NaN`, `Infinity`: no-ops, no throw.
+- `killProcessGroupSafe(validPid, 'SIGTERM')` still terminates that group.
+
+### 3. `shellJobManager` cancel path
+
+Extend the existing suites rather than duplicating them.
+
+- Cancel a job whose spawn failed (the `-1` / absent-pid sentinel): assert no
+  signal is delivered to the caller's process group and the manager still
+  transitions the job to a terminal state. Fails today because the sentinel
+  reaches `process.kill(1)`.
+- `failJobIfOverCapSync` with a sentinel pid: same assertion.
+- In `shellJobManagerSurvivors.test.ts` and `shellJobWindowsSpawn.test.ts`, the
+  injected `taskkillImpl` spy is exactly the boundary where a bad pid is
+  observable. Assert every received pid is `> 0`, and add a case where the job
+  carries a sentinel pid asserting `taskkillImpl` is **never** called.
+
+### 4. `shellPtyLifecycle` abort guards
+
+- `ptyAbortAction` / `ptyInactivityAbortAction` with a `NaN` pid: no
+  `process.kill` is attempted. Fails today because the `=== 0` check lets `NaN`
+  through.
+
+### 5. `terminatePty`
+
+- With a non-positive pid: no signal is sent.
+- On Windows with a registered pty: uses the taskkill path, not
+  `process.kill(-pid)`.
+
+## Fix
+
+Applied only after the tests above are red.
+
+1. Add `isKillablePid(pid: unknown): pid is number` — true only for a whole
+   number `> 0`. Rejects `undefined`, `0`, `-1`, `NaN`, `Infinity`, fractional
+   values (which the runtime could truncate onto an unrelated group after the
+   `-pid` negation), and non-numbers. One chokepoint, placed alongside the kill
+   primitives.
+2. Apply it as an early no-op guard in `killProcessGroupSafe`,
+   `escalateKillUnix`, `taskkillTree`, `boundedTaskkill` (resolving
+   `{ ok: false, error }` to preserve the never-rejecting contract), and
+   `terminatePty`. Replace the narrow `pid === 0` checks in `ptyAbortAction` and
+   `ptyInactivityAbortAction` with it. Purely additive — a valid pid still
+   proceeds on every path, so no correct kill changes behavior.
+3. Give `terminatePty` the `isWindows` branch it is missing, so it uses taskkill
+   on Windows instead of a meaningless `process.kill(-pid)`.
+4. Replace the `-1` spawn sentinel with an explicit absent pid so "no pid" is
+   representable in the type system rather than encoded as a dangerous-looking
+   number. This touches `shellJobSpawn.ts` and the `pid` fields in
+   `shellJobTypes.ts`; update readers accordingly.
+5. Confirm the foreground kill paths cannot act on a stale or reused pid.
+   **Outcome: no code change required.** The background paths use
+   `childIsRunning(child)` because they hold a `ChildProcess`. The foreground
+   pty paths hold an `IPty`, which is not a `ChildProcess`, so that helper does
+   not apply — but they already carry the equivalent identity signal:
+   `state.exitedGuard.isExited()` is checked before the initial signal and
+   re-checked before every SIGKILL escalation, so a pid whose process has
+   already exited is never signalled. Adding a second, parallel mechanism would
+   be premature abstraction (`dev-docs/RULES.md` anti-pattern #1). What the
+   foreground paths genuinely lacked was pid validation, which step 2 supplies.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, and
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+
+Note that `packages/core` runs under Bun; new tests are TypeScript Bun tests.
+The POSIX process-group assertions are gated to POSIX because the production
+behavior they cover (`process.kill(-pid)`) is itself POSIX-gated; the Windows
+`taskkill` assertions are gated to Windows for the same reason.


### PR DESCRIPTION
## TLDR

Pressing <kbd>Esc</kbd> to cancel a running shell tool could kill llxprt itself
and its parent supervisor (`jefe`), dropping the user back to the OS shell.

The cancel path fed a raw, unvalidated pid into `process.kill(-pid, signal)`.
POSIX `kill(2)` overloads that argument: `pid > 0` targets one process, but
**`pid == 0` targets every process in the caller's own process group**. Because
the code computes `-pid`, a pid of `0` collapses to `kill(0, sig)` — llxprt
signalling its own process group. When llxprt shares a process group with its
supervisor or a tmux pane, that single call reaps llxprt, `jefe`, and the pane
shell together.

This PR adds one validation chokepoint, `isKillablePid`, and applies it at
every process-kill boundary, so a non-positive or non-finite pid can never
reach `process.kill` or `taskkill`.

## Dive Deeper

### Root cause

`kill(2)` pid semantics:

| pid     | meaning                                             |
| ------- | --------------------------------------------------- |
| `> 0`   | that one process                                    |
| `== 0`  | **every process in the caller's own process group** |
| `== -1` | every process the caller may signal                 |
| `< -1`  | process group `abs(pid)`                            |

Every group-kill site computed `process.kill(-pid, ...)` with no validation, so
a `0` pid inverted the intent from "kill the child's group" into "kill my own
group". The ambiguous `pid: -1` spawn sentinel made it worse: `-(-1)` is `1`, so
a failed spawn aimed a signal at init (EPERM, silently swallowed) — proof that
unvalidated sentinels really did reach the primitives.

The multiplexer is not the mechanism, it is the blast radius. tmux puts each
pane's foreground process in its own process group; if `jefe` launches llxprt in
that pane without a new session, they share a group and `kill(0)` reaps both.

### Fix

1. **One chokepoint.** `isKillablePid(pid: unknown): pid is number` in
   `shellProcessKill.ts` — true only for a whole number `> 0`. Rejects
   `undefined`, `0`, `-1`, `NaN`, `Infinity`, non-numbers, and fractional
   values (a fractional pid could be truncated by the runtime after the `-pid`
   negation and land on an unrelated process group).
2. **Applied at every kill boundary**, as a no-op early return:
   `killProcessGroupSafe`, `escalateKillUnix`, `killProcessWithEscalation`,
   `taskkillTree`, `boundedTaskkill` (resolves `{ok: false, error}` to preserve
   its documented never-rejecting contract), `terminatePty`, and `cpKillOnAbort`.
   In `ptyAbortAction` / `ptyInactivityAbortAction` it **replaces** the narrow
   `pid === 0` checks, which let `NaN` and `Infinity` through.
3. **`terminatePty` gained the `isWindows` branch it was missing.** Every other
   Windows path already branched; this one issued a meaningless
   `process.kill(-pid)` on a platform with no POSIX process groups. It now uses
   `taskkillTree` in both the SIGTERM and SIGKILL stages.
4. **The `-1` spawn sentinel is gone.** "No pid" is now representable in the
   type system: `pid` is `number | undefined` through `SpawnedProcess`,
   `ShellJob`, `ShellJobRecord`, `SurvivorEntry`, `SurvivorInfo`,
   `safeWindowsKill`, and `HostShellJobInfo`. No `?? 0`, `?? -1`, non-null
   assertion, or cast was used to absorb the widened type in production code —
   that would have reintroduced the exact dangerous value this PR removes.

The change is deliberately additive: a valid pid still proceeds on every path,
so no correct kill changes behavior.

### Deliberately out of scope

- **Spawn options are untouched.** `detached: !isWindows` is correct: POSIX
  children get their own group via setsid, and Windows children are descendants
  so `taskkill /T` walks downward only. Adding `detached: true` on Windows would
  break the PowerShell strategy.
- No multiplexer/tmux-aware logic — correct pid validation makes it moot.

### Windows

`taskkill /T` walks the process tree _downward only_. llxprt is the parent of
the shell child and `jefe` is an ancestor, so under a valid pid neither is in
the tree; invalid pids were rejected by `taskkill` with an error rather than
causing harm. Windows was therefore never the lethal path, but the same
validation is applied there for defense in depth.

## Reviewer Test Plan

The behavioral tests are the test plan — they spawn **real** processes and
assert on **real** survival and death, with no mocking of `process.kill`.

The assertion that actually catches the bug (`shellProcessKill.test.ts`): a real
helper is spawned detached into its **own** process group, that helper spawns a
sibling into that same group, the helper calls the primitive with pid `0`, and
the parent asserts **both helper and sibling are still alive**. Before the fix
`kill(0)` reaped the helper's entire group. A test asserting only "does not
throw" would not catch this, which is why it is written this way.

To exercise it by hand:

1. Run llxprt under a supervisor or inside a tmux pane so it shares a process
   group with its parent.
2. Start a long-running shell tool call (e.g. `sleep 300`).
3. Press <kbd>Esc</kbd> to cancel.
4. **Expected:** the tool call is cancelled and llxprt stays alive at the
   prompt. Before this change, llxprt and its parent could both die.

Targeted suites:

```
bun test packages/core/src/services/shellProcessKill.test.ts
bun test packages/core/src/services/shellJobInternal.test.ts
bun test packages/core/src/services/shellPtyLifecycle.test.ts
bun test packages/core/src/services/shellExecutionService.terminatePty.test.ts
bun test packages/core/src/services/shellJobManager.test.ts
bun test packages/core/src/services/shellJobManagerSurvivors.test.ts
```

Note that the process-group tests are POSIX-gated (mirroring the production
gate) and the `taskkill` tests are Windows-gated, so each platform runs the
half that genuinely applies to it.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | -   | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on Windows: `lint`, `typecheck`, `format` and `build` all
clean, plus a live provider smoke run. The affected suites were run targeted
(`shellProcessKill`, `shellJobInternal`, `shellPtyLifecycle`,
`terminatePty`, `shellJobManager`, `shellJobManagerSurvivors`,
`shellJobManagerCancelRace`) with 0 failures. A full `npm run test` does not
complete on this Windows machine because of a pre-existing hang in
`shellJobWindowsSpawn.test.ts`, which reproduces identically on the base commit
and is not touched by this PR.

The POSIX-gated process-group tests skip on Windows by design and run for the
first time on CI's Linux and macOS runners — that is the part of this change
most worth watching in CI.

## Linked issues / bugs

Fixes #3126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell process cleanup to safely handle missing, invalid, or unavailable process IDs.
  * Prevented cancellation and timeout handling from accidentally signaling unrelated process groups.
  * Improved Windows process termination when child processes cannot provide a process ID.
* **Tests**
  * Added extensive coverage for invalid process IDs, cancellation races, process cleanup, and platform-specific termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->