### PR TITLE
Resolve system-prompt model identity from config.getModel() not stale snapshot (Fixes #3138)

### DIFF
--- a/packages/agents/src/core/ChatSessionFactory.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.test.ts
@@ -95,6 +95,7 @@ import {
   buildSystemInstruction,
   createChatSession,
   createChatSessionSafe,
+  resolveModelForSystemPrompt,
 } from './ChatSessionFactory.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
 import { getEnvironmentContext } from '@vybestack/llxprt-code-core/utils/environmentContext.js';
@@ -119,6 +120,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     getWorkingDir: vi.fn().mockReturnValue('/workspace'),
     getSettingsService: vi.fn().mockReturnValue({}),
     getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+    getModel: vi.fn().mockReturnValue('gemini-2.5-flash'),
     getToolRegistry: vi.fn().mockReturnValue(undefined),
     getProviderManager: vi.fn().mockReturnValue(undefined),
     ...overrides,
@@ -723,5 +725,170 @@ describe('createChatSessionSafe', () => {
         toolRegistry: undefined,
       }),
     ).rejects.toThrow('Failed to initialize chat');
+  });
+});
+
+describe('resolveModelForSystemPrompt (issue #3138)', () => {
+  it('returns config.getModel() when it is non-blank', () => {
+    const config = makeConfig({
+      getModel: vi.fn().mockReturnValue('glm-5.2'),
+    });
+    expect(resolveModelForSystemPrompt(config)).toBe('glm-5.2');
+  });
+
+  it('throws when config.getModel() returns an empty string', () => {
+    const config = makeConfig({
+      getModel: vi.fn().mockReturnValue(''),
+    });
+    expect(() => resolveModelForSystemPrompt(config)).toThrow(
+      /no model identity/i,
+    );
+  });
+
+  it('throws when config.getModel() returns undefined', () => {
+    const config = makeConfig({
+      getModel: vi.fn().mockReturnValue(undefined),
+    });
+    expect(() => resolveModelForSystemPrompt(config)).toThrow(
+      /no model identity/i,
+    );
+  });
+
+  it('throws when config.getModel() returns only whitespace', () => {
+    const config = makeConfig({
+      getModel: vi.fn().mockReturnValue('   '),
+    });
+    expect(() => resolveModelForSystemPrompt(config)).toThrow(
+      /no model identity/i,
+    );
+  });
+});
+
+describe('createChatSession: model identity in system prompt (issue #3138)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (
+      getCoreSystemPromptAsync as Mock<typeof getCoreSystemPromptAsync>
+    ).mockResolvedValue('core system prompt');
+    (
+      getEnvironmentContext as Mock<typeof getEnvironmentContext>
+    ).mockResolvedValue([]);
+  });
+
+  it('uses config.getModel() for the system prompt, not the stale runtimeState snapshot', async () => {
+    const config = makeConfig({
+      getModel: vi.fn().mockReturnValue('glm-5.2'),
+    });
+    const runtimeState = makeRuntimeState({
+      model: 'gpt-5.5',
+      provider: 'openai',
+    });
+    const todoContinuationService = makeTodoContinuationService();
+
+    await createChatSession({
+      config,
+      runtimeState,
+      contentGenerator: makeContentGenerator(),
+      storedHistoryService: undefined,
+      clearStoredHistoryService: vi.fn(),
+      generateContentConfig: {},
+      todoContinuationService,
+      toolRegistry: undefined,
+    });
+
+    expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'glm-5.2' }),
+    );
+  });
+
+  it('uses config.getModel() for tokenization target, not runtimeState snapshot', async () => {
+    const config = makeConfig({
+      getModel: vi.fn().mockReturnValue('profile-model'),
+    });
+    const runtimeState = makeRuntimeState({
+      model: 'stale-default',
+      provider: 'openai',
+    });
+    const todoContinuationService = makeTodoContinuationService();
+
+    const mockHistoryInstance = {
+      add: vi.fn(),
+      generateTurnKey: vi.fn().mockReturnValue('turn-1'),
+      setBaseTokenOffset: vi.fn(),
+      estimateTokensForText: vi.fn().mockResolvedValue(42),
+      resetTokenAccounting: vi.fn(),
+      setActiveTokenizationTarget: vi.fn(),
+      recalculateTotalTokens: vi.fn().mockResolvedValue(undefined),
+      isEmpty: vi.fn().mockReturnValue(true),
+      getAll: vi.fn().mockReturnValue([]),
+    };
+    (
+      HistoryService as unknown as Mock<(...args: never[]) => unknown>
+    ).mockImplementation(() => mockHistoryInstance);
+
+    await createChatSession({
+      config,
+      runtimeState,
+      contentGenerator: makeContentGenerator(),
+      storedHistoryService: undefined,
+      clearStoredHistoryService: vi.fn(),
+      generateContentConfig: {},
+      todoContinuationService,
+      toolRegistry: undefined,
+    });
+
+    expect(
+      mockHistoryInstance.setActiveTokenizationTarget,
+    ).toHaveBeenCalledWith('profile-model', 'openai');
+  });
+
+  it('reflects a provider switch in the prompt model on the next chat creation', async () => {
+    const config = makeConfig({
+      getModel: vi.fn().mockReturnValue('claude-opus-4'),
+    });
+    const runtimeState = makeRuntimeState({
+      model: 'gpt-5.5',
+      provider: 'openai',
+    });
+    const todoContinuationService = makeTodoContinuationService();
+
+    await createChatSession({
+      config,
+      runtimeState,
+      contentGenerator: makeContentGenerator(),
+      storedHistoryService: undefined,
+      clearStoredHistoryService: vi.fn(),
+      generateContentConfig: {},
+      todoContinuationService,
+      toolRegistry: undefined,
+    });
+
+    expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'claude-opus-4' }),
+    );
+  });
+
+  it('throws when config has no model rather than substituting a vendor default', async () => {
+    const config = makeConfig({
+      getModel: vi.fn().mockReturnValue(''),
+    });
+    const runtimeState = makeRuntimeState({
+      model: 'gpt-5.5',
+      provider: 'openai',
+    });
+    const todoContinuationService = makeTodoContinuationService();
+
+    await expect(
+      createChatSession({
+        config,
+        runtimeState,
+        contentGenerator: makeContentGenerator(),
+        storedHistoryService: undefined,
+        clearStoredHistoryService: vi.fn(),
+        generateContentConfig: {},
+        todoContinuationService,
+        toolRegistry: undefined,
+      }),
+    ).rejects.toThrow(/no model identity/i);
   });
 });

--- a/packages/agents/src/core/ChatSessionFactory.tokenReestimate.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.tokenReestimate.test.ts
@@ -111,6 +111,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     getWorkingDir: vi.fn().mockReturnValue('/workspace'),
     getSettingsService: vi.fn().mockReturnValue({}),
     getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+    getModel: vi.fn().mockReturnValue('gemini-2.5-flash'),
     getToolRegistry: vi.fn().mockReturnValue(undefined),
     getProviderManager: vi.fn().mockReturnValue(undefined),
     ...overrides,
@@ -175,9 +176,11 @@ describe('createChatSession - token re-estimation on HistoryService reuse', () =
   });
 
   it('resets token accounting and re-estimates tokens when reusing HistoryService', async () => {
-    const config = makeConfig();
+    const config = makeConfig({
+      getModel: vi.fn().mockReturnValue('claude-3-5-sonnet-20241022'),
+    });
     const runtimeState = makeRuntimeState({
-      model: 'claude-3-5-sonnet-20241022',
+      model: 'stale-model-snapshot',
       provider: 'anthropic',
     });
     const todoContinuationService = makeTodoContinuationService();

--- a/packages/agents/src/core/ChatSessionFactory.ts
+++ b/packages/agents/src/core/ChatSessionFactory.ts
@@ -104,6 +104,28 @@ export function buildSettingsSnapshot(
 }
 
 /**
+ * Resolves the model identity for system-prompt assembly from the live
+ * configuration, never from a stale runtime-state snapshot or a provider's
+ * compiled-in default (issue #3138).
+ *
+ * The value returned here MUST match the model the provider sends as
+ * ``body.model``.  ``resolveModelField`` (runtimeNormalizer.ts) resolves the
+ * request model from the same live settings chain, so reading
+ * ``config.getModel()`` keeps both sides in sync.  If no model can be resolved
+ * the call fails fast rather than silently substituting a vendor default.
+ */
+export function resolveModelForSystemPrompt(config: Config): string {
+  const model = config.getModel();
+  if (typeof model !== 'string' || model.trim() === '') {
+    throw new Error(
+      'Cannot assemble system prompt: no model identity is resolved from the active configuration. ' +
+        'A model must be set before the system prompt can be built.',
+    );
+  }
+  return model;
+}
+
+/**
  * Builds the full system instruction: env context, core memory, JIT memory,
  * user memory, MCP instructions, subagent delegation.
  *
@@ -370,7 +392,7 @@ export async function createChatSession(
 
   const enabledToolNames = getEnabledToolNamesForPrompt(config);
   const envParts = await getEnvironmentContext(config);
-  const model = runtimeState.model;
+  const model = resolveModelForSystemPrompt(config);
 
   logger.debug(() => `DEBUG [client.startChat]: Model from config: ${model}`);
 

--- a/packages/agents/src/core/client.methods.test.ts
+++ b/packages/agents/src/core/client.methods.test.ts
@@ -566,6 +566,86 @@ sub memory
         }),
       );
     });
+
+    it('uses config.getModel() for the system prompt, not the stale runtimeState snapshot (issue #3138)', async () => {
+      const setSystemInstruction = vi.fn();
+      const estimateTokensForText = vi.fn().mockResolvedValue(100);
+      const setBaseTokenOffset = vi.fn();
+      const getHistoryService = vi.fn().mockReturnValue({
+        estimateTokensForText,
+        setBaseTokenOffset,
+      });
+
+      const mockChat = {
+        setSystemInstruction,
+        getHistoryService,
+      };
+
+      client['chat'] = mockChat as unknown as ChatSession;
+      client['contentGenerator'] = {
+        countTokens: vi.fn(),
+      } as unknown as ContentGenerator;
+
+      // runtimeState.model is 'test-model' (from setup), but the live config
+      // returns a different model after a profile or provider switch.
+      const config = client['config'] as unknown as {
+        getModel: () => string;
+        getUserMemory: () => string;
+      };
+      vi.spyOn(config, 'getUserMemory').mockReturnValue('memory');
+      vi.spyOn(config, 'getModel').mockReturnValue('glm-5.2');
+
+      (
+        getEnabledToolNamesForPrompt as Mock<
+          typeof getEnabledToolNamesForPrompt
+        >
+      ).mockReturnValue([]);
+      (
+        shouldIncludeSubagentDelegationForConfig as Mock<
+          typeof shouldIncludeSubagentDelegationForConfig
+        >
+      ).mockResolvedValue(false);
+
+      (
+        getCoreSystemPromptAsync as Mock<typeof getCoreSystemPromptAsync>
+      ).mockResolvedValue('prompt with live model');
+
+      await client.updateSystemInstruction();
+
+      expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'glm-5.2',
+        }),
+      );
+      expect(estimateTokensForText).toHaveBeenCalledWith(
+        expect.any(String),
+        'glm-5.2',
+      );
+    });
+
+    it('throws when config has no model rather than substituting a vendor default (issue #3138)', async () => {
+      const mockChat = {
+        setSystemInstruction: vi.fn(),
+        getHistoryService: vi.fn().mockReturnValue({
+          estimateTokensForText: vi.fn().mockResolvedValue(0),
+          setBaseTokenOffset: vi.fn(),
+        }),
+      };
+
+      client['chat'] = mockChat as unknown as ChatSession;
+      client['contentGenerator'] = {
+        countTokens: vi.fn(),
+      } as unknown as ContentGenerator;
+
+      const config = client['config'] as unknown as {
+        getModel: () => string;
+      };
+      vi.spyOn(config, 'getModel').mockReturnValue('');
+
+      await expect(client.updateSystemInstruction()).rejects.toThrow(
+        /no model identity/i,
+      );
+    });
   });
 
   describe('generateJson', () => {

--- a/packages/agents/src/core/client.ts
+++ b/packages/agents/src/core/client.ts
@@ -63,6 +63,7 @@ import { IdeContextTracker } from './IdeContextTracker.js';
 import { AgentHookManager } from './AgentHookManager.js';
 import {
   buildSystemInstruction as factoryBuildSystemInstruction,
+  resolveModelForSystemPrompt,
   createChatSessionSafe,
 } from './ChatSessionFactory.js';
 import {
@@ -364,7 +365,7 @@ export class AgentClient implements AgentClientContract {
 
     const enabledToolNames = getEnabledToolNamesForPrompt(this.config);
     const envParts = await getEnvironmentContext(this.config);
-    const model = this.runtimeState.model;
+    const model = resolveModelForSystemPrompt(this.config);
     const systemInstruction = await factoryBuildSystemInstruction(
       this.config,
       enabledToolNames,


### PR DESCRIPTION
## TLDR

The system prompt assembled by `createChatSession()` and `updateSystemInstruction()` used a stale model identity (`runtimeState.model` — a snapshot captured at session creation) instead of the live model from `config.getModel()`. After a profile or provider switch, the prompt would name the old model (e.g. `gpt-5.5`) while `body.model` correctly carried the new profile model (e.g. `glm-5.2`), causing wrong model-scoped prompt-config resolution.

This PR introduces `resolveModelForSystemPrompt(config)` — a single helper that calls `config.getModel()`, validates it is non-blank, and returns it. Both `createChatSession()` and `updateSystemInstruction()` now use this helper instead of `runtimeState.model`.

## Dive Deeper

### Root Cause

`AgentClient` captures `runtimeState` at session creation time. The `runtimeState.model` field is a snapshot of the model at that moment. When `updateSystemInstruction()` is called after a profile/provider switch (e.g. via `/switch`), it rebuilds the system prompt using the stale `runtimeState.model` while the actual provider request uses `config.getModel()` (the live value). This divergence means:

1. The prompt names the wrong model to the LLM
2. Model-scoped prompt-config sections resolve against the stale identity
3. The tokenization target is set for the wrong model

### Fix

- **New helper**: `resolveModelForSystemPrompt(config: Config): string` in `ChatSessionFactory.ts` — calls `config.getModel()`, validates the result is a non-blank string, throws a descriptive error if not. This is the "fail-fast" approach: if there is genuinely no model, we surface that immediately rather than silently substituting a vendor default.
- **`createChatSession()`**: Changed `const model = runtimeState.model` to `const model = resolveModelForSystemPrompt(config)`. The `model` variable drives `buildSystemInstruction`, `setActiveTokenizationTarget`, and `applySystemPromptTokenOffset`.
- **`updateSystemInstruction()`** (client.ts): Changed `const model = this.runtimeState.model` to `const model = resolveModelForSystemPrompt(this.config)`.

### Out of Scope

- `buildChatFromRuntime()` still uses `runtimeState.model` for thinking config — this is intentional since thinking config is provider-specific and bound to the runtime session, not the prompt.
- The broader `getCoreSystemPromptAsync` call-site divergence (9 sites documented in issue #3138) is tracked by #3136.

## Reviewer Test Plan

1. **Switch a provider mid-session** — start with one model, switch to another, then trigger a system prompt rebuild. Verify the prompt names the new model.
2. **Run the regression tests**: `cd packages/agents && bun test src/core/ChatSessionFactory.test.ts src/core/client.methods.test.ts src/core/ChatSessionFactory.tokenReestimate.test.ts` — all pass.
3. **Check fail-fast**: If `config.getModel()` returns empty/undefined, `createChatSession` and `updateSystemInstruction` throw a clear error instead of silently substituting a default.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System prompts now consistently use the currently configured model.
  * Switching providers or models is reflected immediately in prompt generation and token estimation.
  * Prevented stale model settings from being used after configuration changes.
  * Clear errors are now shown when no valid model is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->