### PR TITLE
Remove the reverted Codex synthetic AGENTS.md injection and its random call_id (Fixes #3131)

### DIFF
--- a/packages/providers/src/openai-responses/OpenAIResponsesProvider.emptyModelFallback.test.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProvider.emptyModelFallback.test.ts
@@ -94,7 +94,6 @@ function buildDeps(
     isCodexBaseURL: () => false,
     getCodexAccountId: async () => 'codex-account',
     resolveAuthTokenForPrompt: async () => '',
-    generateSyntheticCallId: () => 'call_synthetic_test',
     shouldRetryOnError: () => false,
     getDefaultModel: () => 'o3-mini',
     getGlobalConfig: () => undefined,

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderBase.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderBase.ts
@@ -37,8 +37,6 @@ import {
   getErrorStatus,
   isNetworkTransientError,
 } from '@vybestack/llxprt-code-core/utils/retry.js';
-import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
-import type { ResponsesInputItem } from './OpenAIResponsesTypes.js';
 
 export abstract class OpenAIResponsesProviderBase extends BaseProvider {
   protected logger: DebugLogger;
@@ -235,73 +233,6 @@ export abstract class OpenAIResponsesProviderBase extends BaseProvider {
 
   override clearState(): void {
     super.clearState?.();
-  }
-
-  /**
-   * Generate a unique synthetic call ID to avoid collisions.
-   * @issue #966
-   */
-  protected generateSyntheticCallId(): string {
-    const randomSuffix = Math.random().toString(36).substring(2, 10);
-    return `call_synthetic_${randomSuffix}`;
-  }
-
-  /**
-   * Inject a synthetic tool call/result pair that makes GPT think it already read AGENTS.md.
-   *
-   * The CODEX_SYSTEM_PROMPT instructs GPT to read AGENTS.md for project instructions.
-   * However, the user may have configured LLXPRT.md instead (or both), and sometimes
-   * AGENTS.md is deliberately reserved for a different agent (like Codex itself).
-   *
-   * This method:
-   * 1. Always claims to have read "AGENTS.md" in the synthetic function call
-   * 2. Returns the actual userMemory content (from LLXPRT.md, AGENTS.md, or both)
-   * 3. Prevents GPT from wasting a tool call trying to read AGENTS.md
-   *
-   * @issue #966
-   */
-  protected injectSyntheticConfigFileRead(
-    requestInput: ResponsesInputItem[],
-    options: NormalizedGenerateChatOptions,
-    userMemory: string | undefined,
-  ): void {
-    const syntheticCallId = this.generateSyntheticCallId();
-
-    // Note: We intentionally don't use configRef/filePaths here anymore.
-    // The goal is to NOT reveal which files were actually loaded.
-    // We just need to know if userMemory has content.
-
-    let output: string;
-
-    // Always pretend we read AGENTS.md - this is what CODEX_SYSTEM_PROMPT tells GPT to do
-    const targetFile = 'AGENTS.md';
-
-    if (userMemory && userMemory.trim().length > 0) {
-      // Return the ACTUAL userMemory content so GPT sees what was loaded,
-      // while making it think this came from reading AGENTS.md.
-      // Do NOT reveal actual source files - the goal is to convince GPT it read AGENTS.md.
-      output = JSON.stringify({
-        content: userMemory,
-      });
-    } else {
-      output = JSON.stringify({
-        error: 'File not found: AGENTS.md',
-      });
-    }
-
-    requestInput.unshift(
-      {
-        type: 'function_call',
-        call_id: syntheticCallId,
-        name: 'read_file',
-        arguments: JSON.stringify({ absolute_path: targetFile }),
-      },
-      {
-        type: 'function_call_output',
-        call_id: syntheticCallId,
-        output,
-      },
-    );
   }
 
   /**

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -61,7 +61,6 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
       isCodexBaseURL: (baseURL) => this.isCodexMode(baseURL),
       getCodexAccountId: () => this.getCodexAccountId(),
       resolveAuthTokenForPrompt: () => this.getAuthTokenForPrompt(),
-      generateSyntheticCallId: () => this.generateSyntheticCallId(),
       shouldRetryOnError: (error) => this.shouldRetryOnError(error),
       getDefaultModel: () => this.getDefaultModel(),
       getGlobalConfig: () => this.globalConfig,

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.noSyntheticInjection.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.noSyntheticInjection.test.ts
@@ -1,0 +1,432 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Behavioral regression tests for issue #3131.
+ *
+ * The Codex (ChatGPT backend) path used to prepend a fabricated
+ * `read_file("AGENTS.md")` function_call plus a matching
+ * function_call_output to the FRONT of the `input` array on every request,
+ * keyed by a randomized synthetic call id. That defeated prompt-prefix
+ * caching (the leading bytes changed every turn) and duplicated resolved user
+ * memory (it was already carried in `instructions`).
+ *
+ * These tests assert on the ACTUAL serialized request body captured through a
+ * mocked `fetch` — never on internal function calls or spy counts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  clearActiveProviderRuntimeContext,
+  createProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { OpenAIResponsesProvider } from '../OpenAIResponsesProvider.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { ResponsesInputItem } from '../OpenAIResponsesTypes.js';
+
+const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+const OPENAI_BASE_URL = 'https://api.openai.com/v1';
+const TEST_RUNTIME_ID = 'codex-no-synthetic-test-runtime';
+const USER_MEMORY_SENTINEL = 'ZZQ_MEM_SENTINEL_3131_ZZQ';
+
+const originalFetch = global.fetch;
+const mockFetch = vi.fn();
+
+function createMockStreamingResponse() {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode('data: {"type":"content.delta","delta":"ok"}\n\n'),
+      );
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+        ),
+      );
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+function buildCodexProviderWithOAuth(): OpenAIResponsesProvider {
+  const oauthManager = {
+    getOAuthToken: vi.fn(async () => ({
+      access_token: 'codex-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      refresh_token: 'test-refresh',
+      scope: 'openid',
+      account_id: 'acct_codex_123',
+    })),
+  };
+
+  return new OpenAIResponsesProvider(
+    'codex-api-key',
+    CODEX_BASE_URL,
+    undefined,
+    oauthManager as unknown as object,
+  );
+}
+
+function buildNonCodexProvider(): OpenAIResponsesProvider {
+  return new OpenAIResponsesProvider('test-api-key', OPENAI_BASE_URL);
+}
+
+interface CaptureOptions {
+  userMemory?: string;
+  ephemerals?: Record<string, unknown>;
+}
+
+async function captureRequestBody(
+  provider: OpenAIResponsesProvider,
+  contents: IContent[],
+  settings: SettingsService,
+  captureOptions: CaptureOptions = {},
+): Promise<Record<string, unknown>> {
+  const { userMemory, ephemerals = {} } = captureOptions;
+  let capturedBody: string | undefined;
+
+  mockFetch.mockImplementation(
+    async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      if (init?.body !== null && init?.body !== undefined) {
+        capturedBody =
+          typeof init.body === 'string'
+            ? init.body
+            : await new Response(init.body).text();
+      }
+      return createMockStreamingResponse();
+    },
+  );
+
+  const runtime = createProviderRuntimeContext({
+    settingsService: settings,
+    runtimeId: TEST_RUNTIME_ID,
+    config: createRuntimeConfigStub(settings),
+  });
+
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings,
+    providerName: provider.name,
+    ephemeralsSnapshot: ephemerals,
+    userMemory,
+  });
+
+  const options = createProviderCallOptions({
+    providerName: provider.name,
+    settings,
+    config: createRuntimeConfigStub(settings),
+    runtime,
+    invocation,
+    contents,
+    ephemeralSettings: ephemerals,
+    userMemory,
+  });
+
+  for await (const _content of provider.generateChatCompletion(options)) {
+    // drain
+  }
+
+  if (capturedBody === undefined) {
+    throw new Error('Request body was not captured');
+  }
+  try {
+    return JSON.parse(capturedBody) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error('Captured request body was not valid JSON', {
+      cause: error,
+    });
+  }
+}
+
+function inputItems(body: Record<string, unknown>): ResponsesInputItem[] {
+  const input = body['input'];
+  if (!Array.isArray(input)) {
+    throw new Error('Expected request body to contain an "input" array');
+  }
+  return input as ResponsesInputItem[];
+}
+
+function serializeBody(body: Record<string, unknown>): string {
+  return JSON.stringify(body);
+}
+
+function basicCodexContents(): IContent[] {
+  return [
+    {
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'what is 2+2' }],
+    },
+    {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: '4' }],
+      metadata: { id: 'resp_1', responsesStored: true },
+    },
+    {
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'and 3+3' }],
+    },
+  ];
+}
+
+/**
+ * Shared setup for request capture: install the mock fetch and an isolated
+ * provider runtime context. Both describe blocks need identical wiring.
+ */
+function setupRequestCaptureEnvironment(): void {
+  vi.clearAllMocks();
+  global.fetch = mockFetch as unknown as typeof fetch;
+
+  setActiveProviderRuntimeContext(
+    createProviderRuntimeContext({
+      settingsService: new SettingsService(),
+      runtimeId: TEST_RUNTIME_ID,
+    }),
+  );
+}
+
+function teardownRequestCaptureEnvironment(): void {
+  clearActiveProviderRuntimeContext();
+  global.fetch = originalFetch;
+}
+
+describe('OpenAIResponsesProvider Codex mode does not inject synthetic AGENTS.md read (#3131)', () => {
+  beforeEach(setupRequestCaptureEnvironment);
+
+  afterEach(teardownRequestCaptureEnvironment);
+
+  it('AC1: no synthetic read_file/AGENTS.md function_call and no synthetic call id', async () => {
+    const provider = buildCodexProviderWithOAuth();
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.6-sol');
+
+    const body = await captureRequestBody(
+      provider,
+      basicCodexContents(),
+      settings,
+    );
+    const items = inputItems(body);
+
+    const syntheticReadCalls = items.filter((item) => {
+      if (!('type' in item) || item.type !== 'function_call') return false;
+      if (item.name !== 'read_file') return false;
+      return item.arguments.includes('AGENTS.md');
+    });
+    expect(syntheticReadCalls).toHaveLength(0);
+
+    const syntheticPrefix = 'call_synthetic_';
+    const syntheticCallIds = items.filter((item) => {
+      if (!('call_id' in item)) return false;
+      return (
+        typeof item.call_id === 'string' &&
+        item.call_id.startsWith(syntheticPrefix)
+      );
+    });
+    expect(syntheticCallIds).toHaveLength(0);
+  });
+
+  it('AC3a: user memory appears exactly once, inside instructions, never in an input item', async () => {
+    const provider = buildCodexProviderWithOAuth();
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.6-sol');
+
+    const body = await captureRequestBody(
+      provider,
+      basicCodexContents(),
+      settings,
+      { userMemory: USER_MEMORY_SENTINEL },
+    );
+
+    const serialized = serializeBody(body);
+    const occurrences = serialized.split(USER_MEMORY_SENTINEL).length - 1;
+    expect(occurrences).toBe(1);
+
+    const items = inputItems(body);
+    const itemsContainingSentinel = items.filter((item) =>
+      JSON.stringify(item).includes(USER_MEMORY_SENTINEL),
+    );
+    expect(itemsContainingSentinel).toHaveLength(0);
+
+    const instructions = body['instructions'];
+    expect(typeof instructions).toBe('string');
+    expect(instructions as string).toContain(USER_MEMORY_SENTINEL);
+  });
+
+  it('AC3b: with no user memory, no input item contains "File not found: AGENTS.md"', async () => {
+    const provider = buildCodexProviderWithOAuth();
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.6-sol');
+
+    const body = await captureRequestBody(
+      provider,
+      basicCodexContents(),
+      settings,
+    );
+    const items = inputItems(body);
+
+    const notFoundItems = items.filter((item) =>
+      JSON.stringify(item).includes('File not found: AGENTS.md'),
+    );
+    expect(notFoundItems).toHaveLength(0);
+  });
+
+  it('AC4: Codex input is append-only across consecutive turns (leading item stable; turn N+1 strictly extends turn N)', async () => {
+    const provider = buildCodexProviderWithOAuth();
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.6-sol');
+
+    // Turn 1: a single human turn. Codex resends the full history every
+    // turn (store=false, no previous_response_id), so this is the baseline.
+    const turn1Contents: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'turn one question' }],
+      },
+    ];
+
+    // Turn 2: the prior human turn, an assistant turn that produced a
+    // reasoning item (the fixed reasoning id keeps the build deterministic),
+    // and a new human turn.
+    const turn2Contents: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'turn one question' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'thinking',
+            thought: 'turn one deliberation',
+            encryptedContent: 'base64-encrypted-reasoning-turn1',
+            providerMetadata: {
+              'openai.responses.reasoningId': 'rs_turn1_deterministic',
+            },
+          },
+          { type: 'text', text: 'turn one answer' },
+        ],
+      },
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'turn two question' }],
+      },
+    ];
+
+    const turn1Body = await captureRequestBody(
+      provider,
+      turn1Contents,
+      settings,
+    );
+    const turn2Body = await captureRequestBody(
+      provider,
+      turn2Contents,
+      settings,
+    );
+
+    const turn1Items = inputItems(turn1Body);
+    const turn2Items = inputItems(turn2Body);
+
+    expect(turn1Items.length).toBeGreaterThan(0);
+    expect(turn2Items.length).toBeGreaterThan(turn1Items.length);
+
+    // AC4: the leading input item is identical across consecutive turns of
+    // the same session.
+    expect(turn2Items[0]).toEqual(turn1Items[0]);
+
+    // Turn N+1 must strictly extend turn N (append-only). This invariant is
+    // what issue #3134 (Codex WebSocket incremental input delta) depends on
+    // to reuse a delta rather than resending the full history each turn.
+    expect(turn2Items.slice(0, turn1Items.length)).toEqual(turn1Items);
+  });
+});
+
+describe('OpenAIResponsesProvider non-Codex mode is unchanged by Codex-only input shaping (#3131)', () => {
+  beforeEach(setupRequestCaptureEnvironment);
+
+  afterEach(teardownRequestCaptureEnvironment);
+
+  it('AC5: non-Codex input preserves original ordering and does not hoist reasoning items', async () => {
+    const provider = buildNonCodexProvider();
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'o3');
+
+    // History whose serialization yields a reasoning item interleaved between
+    // a user turn and an assistant turn. In Codex mode the reasoning item
+    // would be hoisted to index 0; the non-Codex path must leave ordering
+    // untouched.
+    const contents: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'first question' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'thinking',
+            thought: 'deliberating',
+            encryptedContent: 'base64-encrypted-reasoning',
+            providerMetadata: {
+              'openai.responses.reasoningId': 'rs_ac5_deterministic',
+            },
+          },
+          { type: 'text', text: 'first answer' },
+        ],
+      },
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'second question' }],
+      },
+    ];
+
+    const body = await captureRequestBody(provider, contents, settings);
+    const items = inputItems(body);
+
+    const types = items.map((item) =>
+      'type' in item ? item.type : `role:${(item as { role?: string }).role}`,
+    );
+
+    // The reasoning item must NOT be hoisted to the front; the first item is
+    // the first user message, preserving natural conversation order.
+    expect(types[0]).toBe('role:user');
+
+    const reasoningIndex = types.indexOf('reasoning');
+    expect(reasoningIndex).toBeGreaterThan(-1);
+    // Reasoning sits after the first user message (its natural interleaved
+    // position), proving the Codex hoist did not leak.
+    expect(reasoningIndex).toBeGreaterThan(0);
+
+    // The second user message must still come last — original order preserved.
+    expect(types[types.length - 1]).toBe('role:user');
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
@@ -101,7 +101,6 @@ function buildDeps(
     isCodexBaseURL: () => false,
     getCodexAccountId: async () => 'codex-account',
     resolveAuthTokenForPrompt: async () => '',
-    generateSyntheticCallId: () => 'call_synthetic_test',
     shouldRetryOnError: () => true,
     getDefaultModel: () => 'gpt-5',
     getGlobalConfig: () => undefined,

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
@@ -94,7 +94,6 @@ function buildDeps(
     isCodexBaseURL: () => false,
     getCodexAccountId: async () => 'codex-account',
     resolveAuthTokenForPrompt: async () => '',
-    generateSyntheticCallId: () => 'call_synthetic_test',
     shouldRetryOnError: () => false,
     getDefaultModel: () => 'gpt-5',
     getGlobalConfig: () => undefined,

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts
@@ -148,7 +148,6 @@ function buildDeps(
     isCodexBaseURL: () => false,
     getCodexAccountId: async () => 'codex-account',
     resolveAuthTokenForPrompt: async () => '',
-    generateSyntheticCallId: () => 'call_synthetic_test',
     shouldRetryOnError: () => true,
     getDefaultModel: () => 'gpt-5',
     getGlobalConfig: () => undefined,

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -103,8 +103,6 @@ export interface ResponsesExecutorDeps {
    * Codex). This is the single auth contract for the executor.
    */
   readonly resolveAuthTokenForPrompt: () => Promise<string>;
-  /** Provide a fresh synthetic call ID generator for tool-call injection. */
-  readonly generateSyntheticCallId: () => string;
   /** Determine whether a streaming error is retryable (status-based). */
   readonly shouldRetryOnError: (error: Error | unknown) => boolean;
   /** Return the provider's default model ID for fallback when resolved model is empty. */
@@ -254,14 +252,7 @@ export async function buildRequestContext(
     deps,
     stateful.parentId !== undefined,
   );
-  const requestInput = buildRequestInput(
-    input,
-    isCodex,
-    options,
-    userMemory,
-    deps,
-  );
-  const request = createRequest(options, requestInput, requestOverrides, deps);
+  const request = createRequest(options, input, requestOverrides, deps);
   applyInstructionsAndTools(request, systemPrompt, options);
   const reasoning = applyReasoningSettings(
     request,
@@ -542,34 +533,6 @@ function normalizeBaseURL(baseURLCandidate: string): string {
   let baseURL = baseURLCandidate;
   while (baseURL.endsWith('/')) baseURL = baseURL.slice(0, -1);
   return baseURL;
-}
-
-function buildRequestInput(
-  input: ResponsesInputItem[],
-  isCodex: boolean,
-  options: NormalizedGenerateChatOptions,
-  userMemory: string | undefined,
-  deps: ResponsesExecutorDeps,
-): ResponsesInputItem[] {
-  if (!isCodex) return input;
-
-  const requestInput = input.filter(
-    (message) => !('role' in message) || (message.role as string) !== 'system',
-  );
-  const itemsForInjection = requestInput.filter(
-    (item) => !('type' in item && item.type === 'reasoning'),
-  );
-  injectSyntheticConfigFileRead(itemsForInjection, options, userMemory, deps);
-  const injectedItems = itemsForInjection.filter(
-    (item) => !requestInput.includes(item),
-  );
-  const reasoningItems = requestInput.filter(
-    (item) => 'type' in item && item.type === 'reasoning',
-  );
-  const nonReasoningItems = requestInput.filter(
-    (item) => !('type' in item && item.type === 'reasoning'),
-  );
-  return [...injectedItems, ...reasoningItems, ...nonReasoningItems];
 }
 
 function createRequest(
@@ -858,40 +821,4 @@ async function buildWebSocketHandshakeHeaders(
   }
   headers['OpenAI-Beta'] = CODEX_WEBSOCKET_BETA_HEADER;
   return headers;
-}
-
-function injectSyntheticConfigFileRead(
-  requestInput: ResponsesInputItem[],
-  options: NormalizedGenerateChatOptions,
-  userMemory: string | undefined,
-  deps: ResponsesExecutorDeps,
-): void {
-  const syntheticCallId = deps.generateSyntheticCallId();
-
-  let output: string;
-  const targetFile = 'AGENTS.md';
-
-  if (userMemory && userMemory.trim().length > 0) {
-    output = JSON.stringify({
-      content: userMemory,
-    });
-  } else {
-    output = JSON.stringify({
-      error: 'File not found: AGENTS.md',
-    });
-  }
-
-  requestInput.unshift(
-    {
-      type: 'function_call',
-      call_id: syntheticCallId,
-      name: 'read_file',
-      arguments: JSON.stringify({ absolute_path: targetFile }),
-    },
-    {
-      type: 'function_call_output',
-      call_id: syntheticCallId,
-      output,
-    },
-  );
 }

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
@@ -78,7 +78,6 @@ function buildDeps(
     isCodexBaseURL: (url) => (url ?? '').includes('backend-api/codex'),
     getCodexAccountId: async () => 'codex-account',
     resolveAuthTokenForPrompt: async () => 'codex-token',
-    generateSyntheticCallId: () => 'call_synthetic_test',
     shouldRetryOnError: () => false,
     getDefaultModel: () => 'gpt-5.6-sol',
     getGlobalConfig: () => undefined,

--- a/packages/providers/src/openai/OpenAIProvider.ts
+++ b/packages/providers/src/openai/OpenAIProvider.ts
@@ -164,10 +164,6 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
         throw new Error('Codex account ID not available for OpenAIProvider');
       },
       resolveAuthTokenForPrompt: async () => this.getAuthTokenForPrompt(),
-      generateSyntheticCallId: () => {
-        const randomSuffix = Math.random().toString(36).substring(2, 10);
-        return `call_synthetic_${randomSuffix}`;
-      },
       shouldRetryOnError: (error) => this.shouldRetryResponse(error),
       getDefaultModel: () => this.getDefaultModel(),
       getGlobalConfig: () => undefined,

--- a/project-plans/issue3131-remove-codex-synthetic-agents-injection.md
+++ b/project-plans/issue3131-remove-codex-synthetic-agents-injection.md
@@ -1,0 +1,164 @@
+# Issue #3131 — Remove the reverted Codex synthetic AGENTS.md injection and its random call_id
+
+## Problem
+
+`buildRequestInput()` in `packages/providers/src/openai-responses/openAIResponsesExecutor.ts`
+prepends a fabricated `read_file("AGENTS.md")` `function_call` plus its
+`function_call_output` to the head of the `input` array on **every** Codex request.
+The pair is keyed by a `call_synthetic_<random>` id produced by
+`Math.random()`, and when user memory is present the synthetic output embeds the
+entire resolved memory blob a second time (it is already inside `instructions`).
+
+This code was deliberately deleted in `5373ffd0ca` (#1189) once OpenAI stopped
+requiring the fixed `CODEX_SYSTEM_PROMPT` header, and was silently reintroduced by
+`ddec3b5fa` (#1156); the GPT-5.6 support PR (`63b88554b0` / #2497) only relocated it
+into `openAIResponsesExecutor.ts`. (The issue text attributes the reintroduction to
+#2497; git shows it was #1156 — see "Resolved: the two remaining Codex-only
+transforms" below.) The justifying comments still cite `CODEX_SYSTEM_PROMPT`, a
+constant that no longer exists anywhere in the repo.
+
+Harms:
+
+1. The random `call_id` mutates the leading bytes of the prompt every turn, which
+   defeats prompt-prefix caching.
+2. Resolved user memory is transmitted twice per request.
+3. It blocks #3134: the Codex WebSocket transport only reuses an incremental input
+   delta when the new input strictly extends the previous input, and a fresh random
+   head item breaks that check every turn.
+
+## Acceptance criteria
+
+- **AC1** No synthetic `read_file` / `AGENTS.md` `function_call` or
+  `function_call_output` is present in any Codex request `input`.
+- **AC2** `generateSyntheticCallId` and `injectSyntheticConfigFileRead` are deleted
+  from `OpenAIResponsesProviderBase.ts` and `openAIResponsesExecutor.ts`, the
+  `generateSyntheticCallId` member is removed from `ResponsesExecutorDeps` and every
+  implementation/mock of it, and the two `CODEX_SYSTEM_PROMPT` comments are gone.
+- **AC3** Resolved user memory appears exactly once in a serialized Codex request
+  (inside `instructions`), never inside an `input` item.
+- **AC4** The leading `input` item is byte-identical across two consecutive turns of
+  a Codex session, and the turn-N+1 `input` strictly extends the turn-N `input`
+  (append-only) — the precondition #3134 depends on.
+- **AC5** Non-Codex `openai-responses` request assembly is unchanged: `input` is
+  passed through untouched, with no filtering and no reordering on either path.
+- **AC6** Behavioral tests per `dev-docs/RULES.md` cover request shape and
+  memory-occurrence count; no test asserts the synthetic injection shape.
+
+## Resolved: the two remaining Codex-only transforms
+
+The issue's step 2 directed: "reduce `buildRequestInput` to its non-Codex behavior
+(system-message filtering and reasoning ordering only, if those are still required —
+verify each independently rather than preserving them by default)." Independent
+verification shows **neither is required**, so both are removed and
+`buildRequestInput` is deleted entirely.
+
+Verified history:
+
+- `5373ffd0ca` (#1189, Jan 2026) deliberately removed the Codex request-input
+  special-casing, leaving the Codex path as literally `const requestInput = input;`
+  — no system filter, no reasoning reorder, no injection.
+- `ddec3b5fa` (#1156, Jan 29 2026, "fix(openai-responses): emit reasoning blocks
+  from responses stream") re-added **all three** in a single commit:
+  `injectSyntheticConfigFileRead`, the `role !== 'system'` filter, and the reasoning
+  hoist.
+- `63b88554b0` (#2497) only **relocated** that block into `openAIResponsesExecutor.ts`.
+
+So the system filter and the reasoning hoist are not independent prior art — they
+are part of the same resurrected block that #1189 deleted. Both are removed because
+neither is required:
+
+- **System-role filter** — unreachable. The executor's input builder
+  (`OpenAIResponsesInputBuilder.ts`) emits only `role: 'user'` and
+  `role: 'assistant'` items; the system prompt travels in `instructions`, never as
+  an `input` item. There is nothing for the filter to remove.
+- **Reasoning hoist** — made AC4 false and blocked #3134. The hoist moved every
+  `type: 'reasoning'` item to the front of `input`, but Codex resends full history
+  every turn (`store = false`, no `previous_response_id`), so the head of `input`
+  grew a new reasoning item on every assistant turn — the leading item was NOT
+  stable across turns. Removing it restores the natural interleaved order that
+  `OpenAIResponsesInputBuilder` already produces (each reasoning item immediately
+  before the `role: 'assistant'` output it produced), which is exactly the shape the
+  Responses API requires, and makes Codex `input` strictly append-only across turns
+  — the precondition that #3134 (Codex WebSocket incremental input delta) depends on.
+
+## Boundary cases
+
+| Case | Expected |
+| --- | --- |
+| Codex + `userMemory` non-empty | memory only in `instructions`; no `input` item contains it |
+| Codex + `userMemory` empty/undefined | no `File not found: AGENTS.md` item; no synthetic pair |
+| Codex + history containing reasoning items | reasoning items remain in natural interleaved order (adjacent to the assistant turn that produced them); never hoisted to the front |
+| Codex + history containing a system-role message | n/a — no system-role `input` item is ever produced; the system prompt travels in `instructions` |
+| Non-Codex openai-responses | `input` returned identity-equal, no filtering, no reordering |
+| Two consecutive turns of one session | identical leading `input` item; turn N+1 `input` strictly extends turn N |
+
+## Test plan (test-first; must fail before the change)
+
+`packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.stateless.test.ts`
+(or a focused new file in the same directory, `bun:test` only):
+
+1. **AC1** — capture a Codex request body; assert no element of `input` is a
+   `function_call` named `read_file` with `AGENTS.md` arguments, and no element is a
+   `function_call_output` whose `call_id` matches `/^call_synthetic_/`.
+2. **AC3** — with a distinctive `userMemory` sentinel, assert the sentinel occurs
+   exactly once in the serialized request body and that occurrence is in
+   `instructions`, not in `input`.
+3. **AC3 (empty branch)** — with no `userMemory`, assert no `input` item contains
+   `File not found: AGENTS.md`.
+4. **AC4** — capture request bodies for two consecutive turns of one session: turn 1
+   history is a single human turn `[u1]`; turn 2 history is `[u1, assistantTurn, u2]`
+   where `assistantTurn` carries both a `thinking` block (with `encryptedContent` and a
+   fixed `providerMetadata['openai.responses.reasoningId']`) and a `text` block. Assert
+   `input[0]` deep-equals across both turns (leading item stable), and that the turn-2
+   `input` strictly extends the turn-1 `input` (`inputItems(turn2).slice(0,
+   inputItems(turn1).length)` deep-equals `inputItems(turn1)`) — the append-only
+   property #3134 depends on.
+5. **AC5** — assert a non-Codex `openai-responses` request's `input` preserves the
+   original conversation ordering and does not hoist reasoning items to the front,
+   proving no input shaping remains on either path. (No system-role `input` item is
+   produced on either path: `OpenAIResponsesInputBuilder` emits only `role:'user'`
+   and `role:'assistant'`, and the system prompt travels in `instructions`.)
+
+`OpenAIResponsesProvider.codex.malformedCallId.test.ts` — confirm the existing
+orphan-`function_call_output` invariant still holds with no synthetic ids present.
+
+## Implementation steps
+
+1. `packages/providers/src/openai-responses/OpenAIResponsesProviderBase.ts`
+   - delete `generateSyntheticCallId()` and `injectSyntheticConfigFileRead()` plus
+     their `CODEX_SYSTEM_PROMPT` / `@issue #966` doc comments;
+   - drop any imports left unused by the deletion.
+2. `packages/providers/src/openai-responses/openAIResponsesExecutor.ts`
+   - delete the module-level `injectSyntheticConfigFileRead()`;
+   - remove `generateSyntheticCallId` from `ResponsesExecutorDeps`;
+   - delete `buildRequestInput` entirely — both the system filter and the reasoning
+     hoist were verified unnecessary (see "Resolved: the two remaining Codex-only
+     transforms") — and pass `input` directly to `createRequest` at the
+     `buildRequestContext` call site. The `isCodex` local is retained (still used by
+     `computeStatefulConversation`, `applyCodexRequestSettings`, `applyPromptCaching`,
+     and `applyStatefulConversation`).
+3. Remove the `generateSyntheticCallId` wiring from
+   `OpenAIResponsesProviderCore.ts` and `packages/providers/src/openai/OpenAIProvider.ts`.
+4. Remove `generateSyntheticCallId` from the mock `ResponsesExecutorDeps` in the five
+   provider test files that declare it.
+5. Add the behavioral tests above.
+
+## Cache-hit measurement (AC of the issue, step 6)
+
+The before-baseline is the dataset recorded in the issue (90,569 local token-usage
+records): `codex/gpt-5.6-sol` 26,174 requests, 3,508,642,712 prompt tokens,
+2,561,123,840 cached, **73.0% hit rate**, versus `claudecode/claude-opus-5` at 98.8%.
+No equivalent analytics store exists in this checkout, so the after-figure cannot be
+produced from a unit test; it requires accumulated live Codex traffic on the merged
+change. The deterministic in-repo proof of the mechanism is AC4 (stable leading
+`input` item plus the append-only strict-extension assertion across turns). This
+limitation is stated in the PR.
+
+## Verification
+
+    npm run test
+    npm run lint
+    npm run typecheck
+    npm run format
+    npm run build
+    bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"


### PR DESCRIPTION
## TLDR

Every Codex request prepended a fabricated `read_file("AGENTS.md")` tool call plus its result to the head of `input`, keyed by a `call_synthetic_<random>` id from `Math.random()`, and duplicated the entire resolved user memory inside that fake result. The random id changed the leading bytes of the prompt on every turn, which is hostile to prompt-prefix caching.

This was not a design decision — it is code that `5373ffd0ca` (#1189) deliberately deleted and that was later resurrected. It is removed outright.

Reviewers should look at two things: (1) the deletion is total — `buildRequestInput` is gone, not reduced; (2) the removal of the **reasoning hoist** is deliberate and load-bearing, and is explained under "Dive Deeper". It is what makes acceptance criterion 4 actually true.

## Dive Deeper

### The injection

`buildRequestInput` unshifted a `function_call` / `function_call_output` pair onto `input` on every Codex request — streaming and non-streaming, HTTP and WebSocket, and on the token-projection path. Two harms: the random `call_id` broke prefix caching at index 0 every turn, and when user memory was present the fake result carried the whole memory blob a second time even though it was already in `instructions`.

The justifying comments on main still cited `CODEX_SYSTEM_PROMPT` — a constant deleted in #1189 that no longer exists anywhere in the repository. The original rationale (#966) was that the Codex endpoint forced us to send a header telling the model to read AGENTS.md, so we pre-empted the wasted tool call. That header requirement is gone; nothing instructs the model to read AGENTS.md, so nothing needs suppressing. Upstream Codex CLI performs no such injection either.

### Provenance correction

The issue attributes the reintroduction to the GPT-5.6 PR (`63b88554b0` / #2497). git says otherwise, and the distinction matters:

- `5373ffd0ca` (#1189, Jan 2026) left the Codex path as literally `const requestInput = input;` — no injection, no filter, no reorder.
- `ddec3b5fa` (#1156, Jan 29 2026, "emit reasoning blocks from responses stream") re-added **all three** in one commit: `injectSyntheticConfigFileRead`, the `role !== 'system'` filter, and the reasoning hoist.
- `63b88554b0` (#2497) only **relocated** that block into `openAIResponsesExecutor.ts`.

So the filter and the hoist are not independent prior art sitting next to the injection — they are the same resurrected block.

### Why the reasoning hoist also had to go

The issue directed: "reduce `buildRequestInput` to its non-Codex behavior (system-message filtering and reasoning ordering only, **if those are still required — verify each independently rather than preserving them by default**)." Both were verified. Neither is required.

**System-role filter — unreachable.** The executor builds input through `buildOpenAIResponsesInput`, which emits only `role:'user'` and `role:'assistant'`. The system prompt travels in `instructions`. There has never been anything for the filter to remove.

**Reasoning hoist — made AC4 false.** Codex is unconditionally `store=false` and never sends `previous_response_id`, so it resends full history every turn. The hoist moved every `type:'reasoning'` item to the front, so the head of `input` grew a new item on each assistant turn:

    turn 1:  [u1]                          -> input[0] = u1
    turn 2:  [r1, u1, a1, u2]              -> input[0] = r1   (changed)
    turn 3:  [r1, r2, u1, a1, u2, a2, u3]  -> index 1 changed

The shared prefix therefore terminated right after the reasoning blob and the entire conversation body was re-processed uncached every turn. That is a **larger** prefix hazard than the random `call_id` it sat beside — removing one while keeping the other would have been a half-fix that still failed the issue's own AC4 ("the leading item of `input` is stable across consecutive turns of a session").

It also blocks #3134, which reuses an incremental input delta only when the new `input` is a strict extension of the previous one. #3131 was filed partly to unblock #3134; keeping the hoist would not have delivered that.

Removing it restores the natural interleaved order the input builder already produces — each reasoning item immediately before the assistant output it produced, which is the adjacency the Responses API expects. Codex `input` is now strictly append-only across turns.

With both transforms gone, `buildRequestInput` is an identity function, so it is deleted entirely and `input` is passed straight to `createRequest`. The `isCodex` local is retained; it is still used by `computeStatefulConversation`, `applyCodexRequestSettings`, `applyPromptCaching`, and `applyStatefulConversation`.

### Cache-hit measurement (issue step 6)

**Before**, from the issue's 90,569 local token-usage records:

| provider/model | reqs | prompt tok | cached tok | hit% |
| --- | --- | --- | --- | --- |
| claudecode/claude-opus-5 | 50,106 | 21,193,115,793 | 20,947,104,472 | 98.8% |
| codex/gpt-5.6-sol | 26,174 | 3,508,642,712 | 2,561,123,840 | 73.0% |

**After: not yet available.** No equivalent analytics store exists in this checkout, so the after-figure cannot come from a unit test — it needs accumulated live Codex traffic on the merged change. The deterministic in-repo proof of the mechanism is the append-only assertion described below. Flagging this openly rather than claiming a win I cannot yet substantiate.

## Reviewer Test Plan

Automated (five behavioral tests in `OpenAIResponsesProvider.codex.noSyntheticInjection.test.ts`, all asserting on the **serialized request body captured at the mocked `fetch` boundary** with the real provider under test — no mock-verification assertions):

- **AC1** no `function_call` named `read_file` with `AGENTS.md` args, and no `call_synthetic_`-prefixed `call_id`, at **any** position in `input`
- **AC3a** a user-memory sentinel occurs **exactly once** in the whole serialized body, inside `instructions`, and in no `input` item
- **AC3b** with no user memory, no `input` item carries `File not found: AGENTS.md`
- **AC4** across two consecutive turns: `input[0]` is identical, **and** turn N+1 strictly extends turn N (the append-only invariant #3134 needs)
- **AC5** the non-Codex path preserves natural ordering and hoists nothing

Four of the five fail against the previous implementation. Verified directly — AC4 failed showing two differing `call_synthetic_<random>` ids, then, after the injection was removed but the hoist retained, failed again showing a hoisted `reasoning` item at `input[0]` against a `role:'user'` item.

Manual, for a reviewer with Codex access:

1. Run a multi-turn Codex session (`gpt-5.6-sol`) with a populated `LLXPRT.md`.
2. Confirm the model does **not** spuriously try to read `AGENTS.md` on turn 1.
3. Confirm project instructions from memory are still honoured — they arrive via `instructions`.
4. Over several turns, watch cached-token share; it should improve relative to a pre-merge session of comparable shape.

Note for anyone running the provider tests ad hoc: `bun test <dir>` on `packages/providers/src/openai-responses/__tests__/` runs many files in one process, and `OpenAIResponsesPromptEnvelopeProjection.test.ts` / `OpenAIResponsesProjectionEndpointParity.test.ts` register a process-global `vi.mock` of `@vybestack/llxprt-code-core/core/prompts.js` that stubs out `getCoreSystemPromptAsync` and discards `userMemory`. That leaks into AC3a. It is pre-existing and unrelated to this change — the repo runner (`scripts/run_bun_tests.ts`) spawns a fresh process per file, which is why `npm run test` is green. Bisected to those two files directly.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Full local verification on macOS: `npm run test` (0 failures), `npm run lint`, `npm run lint:eslint-guard`, `npm run typecheck`, `npm run format`, `npm run build`, and the `stepfun-37` smoke test all pass. Open Code Review reported 0 findings across all 10 changed files. The change is platform-independent (pure deletion in provider request assembly), so Windows and Linux are expected to follow CI.

## Linked issues / bugs

Fixes #3131

Unblocks #3134 — the append-only `input` invariant that its incremental WebSocket delta depends on is now asserted by AC4.

Context: #966 (original request for the injection; premise obsolete), #1177 / #1189 (removed it the first time), #1156 (reintroduced it), #2497 (relocated it).
