### PR TITLE
Make reasoning stream ids unique across API calls (Fixes #3128)

### DIFF
--- a/docs/providers/models-and-limits.md
+++ b/docs/providers/models-and-limits.md
@@ -168,6 +168,15 @@ Recommended settings:
 
 **Environment variable:** `export ANTHROPIC_API_KEY=sk-ant-...`
 
+> **Summarized thinking (not a streaming bug):** Anthropic returns a
+> **summary** of the model's reasoning, produced by a _different_ model than
+> the one that generated the raw thinking. Billing reflects the **full raw
+> thinking**, so the visible thinking text is typically far shorter than the
+> billed completion tokens (a median of roughly 4 visible characters per billed
+> token). A summary occasionally ends mid-sentence at a clean word boundary —
+> this is a summarizer artefact, not a truncation or streaming bug. LLxprt
+> records and displays exactly what the API returns.
+
 ### Claude Code OAuth (`claudecode` alias)
 
 Same context and output limits as the `anthropic` alias for current-generation

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/thoughtState.test.ts
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/thoughtState.test.ts
@@ -304,4 +304,43 @@ describe('applyThoughtToState identity-aware streaming updates', () => {
     expect(args.thinkingBlocksRef.current).toStrictEqual([]);
     expect(args.setPendingHistoryItem).not.toHaveBeenCalled();
   });
+
+  it('appends a new block when a different stream id follows a complete block (issue #3128)', () => {
+    // Models iterate within one user turn. Iteration 1 completes its reasoning
+    // (streamId A); iteration 2 begins reasoning under a distinct streamId B.
+    // The ref must hold BOTH blocks in order and preserve A verbatim — the bug
+    // was that providers reused the same id, so B replaced A.
+    const args = createArgs({
+      getContentPrefixIdentity: () => null,
+    });
+
+    applyThought(args, {
+      subject: '',
+      description: 'Why I called the first tool',
+      streamId: 'anthropic-thinking:aaa:0:block-0',
+      streamStatus: 'complete',
+    });
+    applyThought(args, {
+      subject: '',
+      description: 'Now reasoning about the result',
+      streamId: 'anthropic-thinking:bbb:0:block-0',
+      streamStatus: 'delta',
+    });
+
+    expect(args.thinkingBlocksRef.current).toHaveLength(2);
+    expect(
+      args.thinkingBlocksRef.current.map((block) => block.thought),
+    ).toStrictEqual([
+      'Why I called the first tool',
+      'Now reasoning about the result',
+    ]);
+    expect(
+      args.thinkingBlocksRef.current.map((block) => block.streamId),
+    ).toStrictEqual([
+      'anthropic-thinking:aaa:0:block-0',
+      'anthropic-thinking:bbb:0:block-0',
+    ]);
+    expect(args.thinkingBlocksRef.current[0]?.streamStatus).toBe('complete');
+    expect(args.thinkingBlocksRef.current[1]?.streamStatus).toBe('delta');
+  });
 });

--- a/packages/providers/src/anthropic/AnthropicProvider.thinking.streaming.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.thinking.streaming.test.ts
@@ -111,12 +111,11 @@ describe('AnthropicProvider Extended Thinking Streaming (issue #1723)', () => {
       'First part here',
       'First part here',
     ]);
-    expect(thinkingBlocks.map((block) => block.streamId)).toStrictEqual([
-      'anthropic-thinking:0:block-0',
-      'anthropic-thinking:0:block-0',
-      'anthropic-thinking:0:block-0',
-      'anthropic-thinking:0:block-0',
-    ]);
+    // Within one thinking block every delta plus the final complete emission
+    // must collapse onto ONE stream id (acceptance criterion 2).
+    const streamIds = thinkingBlocks.map((block) => block.streamId);
+    expect(new Set(streamIds).size).toBe(1);
+    expect(streamIds[0]?.startsWith('anthropic-thinking:')).toBe(true);
     expect(thinkingBlocks.map((block) => block.streamStatus)).toStrictEqual([
       'delta',
       'delta',
@@ -271,16 +270,21 @@ describe('AnthropicProvider Extended Thinking Streaming (issue #1723)', () => {
     expect(new Set(completedBlocks.map((block) => block.streamId)).size).toBe(
       2,
     );
+    // The two thinking blocks share the same source index (Anthropic reused 0)
+    // but must still carry distinct stream ids. Deltas + complete for each
+    // block collapse onto that block's single id.
     expect(thinkingBlocks.map((block) => block.streamId)).toStrictEqual([
       completedBlocks[0].streamId,
       completedBlocks[0].streamId,
       completedBlocks[1].streamId,
       completedBlocks[1].streamId,
     ]);
-    expect(completedBlocks.map((block) => block.streamId)).toStrictEqual([
-      'anthropic-thinking:0:block-0',
-      'anthropic-thinking:0:block-1',
-    ]);
+    expect(completedBlocks[0].streamId).not.toBe(completedBlocks[1].streamId);
+    expect(
+      completedBlocks.every(
+        (block) => block.streamId?.startsWith('anthropic-thinking:') === true,
+      ),
+    ).toBe(true);
   });
 
   it('should hide streaming thinking chunks when reasoning.includeInResponse is false', async () => {
@@ -388,9 +392,11 @@ describe('AnthropicProvider Extended Thinking Streaming (issue #1723)', () => {
       thought: '[redacted]',
       signature: 'encrypted-reasoning',
       isHidden: true,
-      streamId: 'anthropic-thinking:0:block-0',
       streamStatus: 'complete',
     });
+    expect(thinkingBlocks[0].streamId?.startsWith('anthropic-thinking:')).toBe(
+      true,
+    );
   });
 
   it('should not emit thinking chunks for empty thinking deltas or zero-length final text', async () => {
@@ -555,5 +561,87 @@ describe('AnthropicProvider Extended Thinking Streaming (issue #1723)', () => {
     expect(textChunks[1].blocks.find((b) => b.type === 'text')).toMatchObject({
       text: 'world',
     });
+  });
+
+  it('produces distinct thinking stream ids across consecutive API calls (issue #3128)', async () => {
+    // Each generateChatCompletion call drives one Anthropic API call. A user
+    // turn spans many such calls, and the UI ref that consumes these ids
+    // lives for the whole turn, so ids must be unique across calls.
+    const buildThinkingStream = (thought: string, signature: string) => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'thinking', thinking: '' },
+        };
+        yield {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'thinking_delta', thinking: thought },
+        };
+        yield {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'signature_delta', signature },
+        };
+        yield { type: 'content_block_stop', index: 0 };
+      },
+    });
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Think twice' }],
+      },
+    ];
+
+    const collectThinking = async (
+      thought: string,
+      signature: string,
+    ): Promise<ThinkingBlock[]> => {
+      mockMessagesCreate.mockResolvedValue(
+        buildThinkingStream(thought, signature),
+      );
+      const chunks: IContent[] = [];
+      for await (const chunk of provider.generateChatCompletion(
+        buildCallOptions(messages),
+      )) {
+        chunks.push(chunk);
+      }
+      return chunks.flatMap((chunk) =>
+        chunk.blocks.filter(
+          (block): block is ThinkingBlock => block.type === 'thinking',
+        ),
+      );
+    };
+
+    const firstCallBlocks = await collectThinking(
+      'Reasoning from the first iteration',
+      'sig-first',
+    );
+    const secondCallBlocks = await collectThinking(
+      'Reasoning from the second iteration',
+      'sig-second',
+    );
+
+    // Within each call, the single delta + the final complete share one id.
+    expect(new Set(firstCallBlocks.map((b) => b.streamId)).size).toBe(1);
+    expect(new Set(secondCallBlocks.map((b) => b.streamId)).size).toBe(1);
+
+    const firstId = firstCallBlocks[0].streamId;
+    const secondId = secondCallBlocks[0].streamId;
+
+    // Cross-call: the two iterations must NOT reuse the same id. This is the
+    // core regression — previously every call produced block-0 and the second
+    // iteration silently overwrote the first in the transcript.
+    expect(firstId).not.toBe(secondId);
+
+    // Cross-session safety: freshly generated ids must never equal the legacy
+    // format (`anthropic-thinking:0:block-0`) that a resumed session's
+    // persisted history would carry.
+    for (const id of [firstId, secondId]) {
+      expect(id).not.toBe('anthropic-thinking:0:block-0');
+      expect(id?.startsWith('anthropic-thinking:')).toBe(true);
+    }
   });
 });

--- a/packages/providers/src/anthropic/AnthropicStreamProcessor.ts
+++ b/packages/providers/src/anthropic/AnthropicStreamProcessor.ts
@@ -11,6 +11,7 @@ import type {
   TextDelta,
   InputJSONDelta,
 } from '@anthropic-ai/sdk/resources/messages/index.js';
+import { randomUUID } from 'node:crypto';
 import type {
   IContent,
   ThinkingBlock,
@@ -48,11 +49,28 @@ type ThinkingBlockIdentity = {
   nextStreamId: (sourceIndex: number) => string;
 };
 
+/**
+ * Creates a scoped thinking-block identity for a single Anthropic streaming
+ * response (one API call).
+ *
+ * The epoch is process-unique (generated fresh per call) so the stream ids
+ * produced here can never collide with ids from another API call in the same
+ * turn, nor with ids replayed from a resumed session's persisted history
+ * (legacy records literally contain `anthropic-thinking:0:block-0`). A bare
+ * counter from 0 would repeat those exact ids and let a later model iteration
+ * silently overwrite an earlier iteration's reasoning in the transcript
+ * (issue #3128).
+ *
+ * Within one call the lifecycle counter still differentiates distinct thinking
+ * blocks, and every delta plus the final complete emission for a single block
+ * share that block's id (the replace-by-id semantic the consumer relies on).
+ */
 function createThinkingBlockIdentity(): ThinkingBlockIdentity {
+  const epoch = randomUUID();
   let nextLifecycleId = 0;
   return {
     nextStreamId: (sourceIndex: number): string =>
-      `anthropic-thinking:${sourceIndex}:block-${nextLifecycleId++}`,
+      `anthropic-thinking:${epoch}:${sourceIndex}:block-${nextLifecycleId++}`,
   };
 }
 

--- a/packages/providers/src/openai/parseResponsesStream.reasoning.test.ts
+++ b/packages/providers/src/openai/parseResponsesStream.reasoning.test.ts
@@ -216,9 +216,10 @@ describe('parseResponsesStream - Reasoning/Thinking Support', () => {
       'Let me think',
     ]);
     const streamIds = thinkingBlocks.map((block) => block.streamId);
-    expect(new Set(streamIds)).toStrictEqual(
-      new Set(['openai-responses-reasoning:0']),
-    );
+    // Within one reasoning lifecycle every delta plus the final complete
+    // emission must collapse onto ONE stream id.
+    expect(new Set(streamIds).size).toBe(1);
+    expect(streamIds[0]?.startsWith('openai-responses-reasoning:')).toBe(true);
     expect(thinkingBlocks.map((block) => block.streamStatus)).toStrictEqual([
       'delta',
       'delta',
@@ -245,10 +246,9 @@ describe('parseResponsesStream - Reasoning/Thinking Support', () => {
       'Checking',
       'Checking',
     ]);
-    expect(thinkingBlocks.map((block) => block.streamId)).toStrictEqual([
-      'openai-responses-reasoning:0',
-      'openai-responses-reasoning:0',
-    ]);
+    const streamIds = thinkingBlocks.map((block) => block.streamId);
+    expect(new Set(streamIds).size).toBe(1);
+    expect(streamIds[0]?.startsWith('openai-responses-reasoning:')).toBe(true);
     expect(thinkingBlocks.map((block) => block.streamStatus)).toStrictEqual([
       'delta',
       'complete',
@@ -277,12 +277,17 @@ describe('parseResponsesStream - Reasoning/Thinking Support', () => {
       'Second',
       'Second',
     ]);
-    expect(thinkingBlocks.map((block) => block.streamId)).toStrictEqual([
-      'openai-responses-reasoning:0',
-      'openai-responses-reasoning:0',
-      'openai-responses-reasoning:1',
-      'openai-responses-reasoning:1',
-    ]);
+    const streamIds = thinkingBlocks.map((block) => block.streamId);
+    // First lifecycle (delta + complete) shares one id; second lifecycle a
+    // different id; the two never collide.
+    expect(streamIds[0]).toBe(streamIds[1]);
+    expect(streamIds[2]).toBe(streamIds[3]);
+    expect(streamIds[0]).not.toBe(streamIds[2]);
+    expect(
+      streamIds.every(
+        (id) => id?.startsWith('openai-responses-reasoning:') === true,
+      ),
+    ).toBe(true);
     expect(thinkingBlocks.map((block) => block.streamStatus)).toStrictEqual([
       'delta',
       'complete',
@@ -539,8 +544,10 @@ describe('parseResponsesStream - Reasoning/Thinking Support', () => {
       'delta',
       'complete',
     ]);
-    expect(thinkingBlocks[1]?.streamId).toBe('openai-responses-reasoning:0');
-    expect(thinkingBlocks[2]?.streamId).toBe('openai-responses-reasoning:0');
+    expect(thinkingBlocks[1]?.streamId).toBe(thinkingBlocks[2]?.streamId);
+    expect(
+      thinkingBlocks[1]?.streamId?.startsWith('openai-responses-reasoning:'),
+    ).toBe(true);
   });
 
   it('should re-emit hidden ThinkingBlock with encrypted_content after visible emission', async () => {
@@ -600,5 +607,43 @@ describe('parseResponsesStream - Reasoning/Thinking Support', () => {
       'delta',
       'complete',
     ]);
+  });
+
+  it('produces distinct reasoning stream ids across consecutive streams (issue #3128)', async () => {
+    // Each parseResponsesStream call drives one OpenAI Responses API call. A
+    // user turn spans many such calls, and the UI ref that consumes these ids
+    // lives for the whole turn, so ids must be unique across calls.
+    const nl = String.fromCharCode(10);
+    const buildChunks = (thought: string): string[] => [
+      `data: {"type":"response.reasoning_text.delta","sequence_number":1,"delta":"${thought}"}${nl}${nl}`,
+      `data: {"type":"response.reasoning_text.done","sequence_number":2}${nl}${nl}`,
+    ];
+
+    const collectStreamIds = async (thought: string): Promise<string[]> => {
+      const stream = createSSEStream(buildChunks(thought));
+      let messages: IContent[] = [];
+      for await (const message of parseResponsesStream(stream)) {
+        messages = [...messages, message];
+      }
+      return collectThinkingBlocks(messages).map((block) => block.streamId);
+    };
+
+    const firstIds = await collectStreamIds('First iteration reasoning');
+    const secondIds = await collectStreamIds('Second iteration reasoning');
+
+    // Within each stream, the delta + complete share one id.
+    expect(new Set(firstIds).size).toBe(1);
+    expect(new Set(secondIds).size).toBe(1);
+
+    // Cross-stream: the two iterations must NOT reuse the same id.
+    expect(firstIds[0]).not.toBe(secondIds[0]);
+
+    // Cross-session safety: freshly generated ids must never equal the legacy
+    // format (`openai-responses-reasoning:0`) carried by a resumed session's
+    // persisted history.
+    for (const id of [...firstIds, ...secondIds]) {
+      expect(id).not.toBe('openai-responses-reasoning:0');
+      expect(id.startsWith('openai-responses-reasoning:')).toBe(true);
+    }
   });
 });

--- a/packages/providers/src/openai/parseResponsesStream.ts
+++ b/packages/providers/src/openai/parseResponsesStream.ts
@@ -13,6 +13,7 @@ import {
 import { createStreamInterruptionError } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type { StreamLivenessListener } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+import { randomUUID } from 'node:crypto';
 import { isAcceptedTerminalEventType } from './responsesTerminalEvents.js';
 import { mapFinishReasonToStopReason } from './finishReasonMapping.js';
 import type {
@@ -868,6 +869,7 @@ export async function* parseResponsesStream(
     hasEmittedVisibleThinking: false,
     reasoningText: '',
     reasoningSummaryText: '',
+    reasoningStreamEpoch: randomUUID(),
     nextReasoningStreamIndex: 0,
   };
 

--- a/packages/providers/src/openai/parseResponsesStreamReasoning.ts
+++ b/packages/providers/src/openai/parseResponsesStreamReasoning.ts
@@ -41,7 +41,11 @@ export function allocateReasoningStreamId(state: DispatchState): {
     return { state, streamId: state.currentReasoningStreamId };
   }
 
-  const streamId = `${OPENAI_REASONING_STREAM_ID_PREFIX}:${state.nextReasoningStreamIndex}`;
+  // The per-stream epoch makes the id unique across API calls within one turn
+  // (and across resumed sessions); the index differentiates lifecycles within
+  // a single stream. Without the epoch every call restarts at index 0 and a
+  // later model iteration silently overwrites an earlier one (issue #3128).
+  const streamId = `${OPENAI_REASONING_STREAM_ID_PREFIX}:${state.reasoningStreamEpoch}:${state.nextReasoningStreamIndex}`;
   return {
     state: {
       ...state,

--- a/packages/providers/src/openai/parseResponsesStreamTypes.ts
+++ b/packages/providers/src/openai/parseResponsesStreamTypes.ts
@@ -72,6 +72,13 @@ export type DispatchState = {
   hasEmittedVisibleThinking: boolean;
   reasoningText: string;
   reasoningSummaryText: string;
+  /**
+   * Per-stream epoch so reasoning stream ids stay unique across API calls
+   * within one user turn (and across resumed sessions). Generated fresh for
+   * each stream so the index below can restart at 0 without colliding with
+   * ids from another call (issue #3128).
+   */
+  reasoningStreamEpoch: string;
   nextReasoningStreamIndex: number;
   currentReasoningStreamId?: string;
   visibleReasoningSource?: ReasoningDeltaSource;

--- a/project-plans/issue3128-reasoning-stream-identity.md
+++ b/project-plans/issue3128-reasoning-stream-identity.md
@@ -1,0 +1,167 @@
+# Issue #3128 — Reasoning stream identity collides across model iterations
+
+## Origin
+
+Issue #3128 reported that a thinking block in the Ink UI appeared cut off mid-sentence
+at the word "I", while the same assistant turn continued normally with text and two
+tool calls.
+
+## Root cause of the reported symptom: NOT an llxprt bug
+
+The event was located in a real session recording
+(`~/Library/Logs/llxprt-code/tmp/1e1db339.../chats/session-2026-08-06T06-33-31-2d7489ef-cbb.jsonl`,
+seq 1082, provider `claudecode`, model `claude-opus-5`).
+
+Evidence that the stream was healthy:
+
+- the block carries `streamStatus: "complete"` and a valid non-empty `signature`
+  (Anthropic emits `signature_delta` only immediately before `content_block_stop`)
+- the same assistant message contains a `text` block and two `tool_call` blocks
+- the recording contains zero retry / discard / error / invalid-stream events
+
+Evidence that the truncation originates upstream of llxprt:
+
+- the display path and the recording path are independent, and both produced the
+  identical 147 characters; the recording path never touches Ink
+- across 244 thinking blocks in that session, only 3 (1.2%) end mid-sentence, and
+  all 3 end at a clean word boundary rather than mid-word
+- median ratio of (thought characters / 4) to billed `completionTokens` is 0.188
+
+Anthropic documents that thinking text is a summary produced by a *different model*,
+and that billing reflects the full raw thinking rather than the summary. A summary
+that stops mid-sentence is a summarizer artefact. llxprt recorded and displayed
+exactly what the API returned.
+
+`summary_status` was evaluated as a detection signal and **rejected**: it appears only
+in AWS Bedrock's older Claude 4 documentation, is absent from the current Claude
+platform thinking documentation, and is not typed by the pinned
+`@anthropic-ai/sdk@0.55.1`. There is no supported signal to detect this condition, so
+nothing is implemented against it.
+
+## The defect this investigation surfaced (what this change fixes)
+
+Reasoning stream identifiers are only unique *within a single API call*, but the UI
+state that consumes them lives for the whole user turn, which spans many API calls.
+
+- `packages/providers/src/anthropic/AnthropicStreamProcessor.ts:51-57` —
+  `createThinkingBlockIdentity()` allocates a fresh `nextLifecycleId = 0` closure per
+  API call, so every iteration's first thinking block is `anthropic-thinking:0:block-0`.
+  Confirmed empirically: 244 thinking blocks in one session, **1 distinct streamId**.
+- `packages/providers/src/openai/parseResponsesStream.ts:871` — `nextReasoningStreamIndex: 0`
+  is initialised per stream, so `openai-responses-reasoning:0` repeats every API call.
+- `packages/cli/src/ui/hooks/agentStream/thoughtState.ts:69-93` — `findStreamBlockIndex`
+  matches the stale block from the previous iteration and overwrites its text.
+- `thinkingBlocksRef` is cleared on a new user prompt (`turnPreparation.ts:27`), on
+  pending-item commit (`useStreamState.ts:188`), and on a content split
+  (`contentEventProcessor.ts:114`) — but **not between model iterations within one turn**.
+
+Consequence in principle: when an iteration produces thinking followed by a tool call
+and no text, no content split occurs, so the next iteration's reasoning could replace
+the previous iteration's reasoning in the transcript.
+
+### Verified reachability: NOT currently reachable
+
+This was tested rather than assumed. The same scripted tmux-harness scenario
+(`opus5`/`claude-opus-5`, three sequential shell commands with reasoning between each)
+was run against clean `main` and against this branch. Both rendered all three reasoning
+segments in order. There is no observable difference.
+
+The mitigating path is `handleToolsComplete`
+(`packages/cli/src/ui/hooks/agentStream/useAgentEventStream.ts:111`), which calls
+`flushPendingHistoryItem` before rendering each tool group. That commits the pending AI
+item and clears `thinkingBlocksRef` (`useStreamState.ts:188`). Tool completion is exactly
+the iteration boundary, so the ref is already empty when the next iteration's thinking
+arrives. Concurrent subagents were also checked: there is no path from subagent thinking
+into the parent UI's thought state.
+
+**So this change is latent-correctness hardening, not a user-facing bug fix.** It is worth
+making because `streamId` exists solely to identify a stream yet repeated on every API
+call, and was rendered harmless only by an incidental flush in unrelated code. Any change
+to that flush would reintroduce silent reasoning loss with nothing to catch it. The
+regression tests are the durable value: they pin the invariant so it is enforced rather
+than accidental.
+
+## Design decision
+
+**Within one thinking block: replace.** The provider emits cumulative snapshots on each
+`thinking_delta` and a final identical snapshot at `content_block_stop`. Replace-by-id
+is the correct semantic and already works. There is no late-arriving "final summary"
+that supersedes the streamed text; per Anthropic's documentation the summary *is* what
+streams.
+
+**Across thinking blocks: append, never replace.** Each thinking block is a distinct
+reasoning segment bound to the tool call that follows it. Collapsing segments destroys
+the causal record of why a tool was chosen.
+
+The fix therefore targets the root cause — non-unique identity — rather than adding
+clearing logic or defensive guards in the UI. This mirrors the pattern the Anthropic
+processor already uses for tool call ids, for exactly the same reason:
+
+    // Global counter appended to tool call IDs so providers that reset indices per
+    // API call (e.g. Kimi on Fireworks) never produce duplicates across turns.
+    let toolCallSequence = 0;
+
+## Acceptance criteria
+
+1. Two consecutive API calls within one user turn produce thinking blocks with
+   **distinct** `streamId` values, for both the Anthropic and OpenAI Responses paths.
+2. Cumulative delta snapshots within a single thinking block still collapse onto one
+   rendered block (no regression in streaming behaviour).
+3. Given thinking from iteration 1 followed by thinking from iteration 2 with no
+   intervening text block, `thinkingBlocksRef` retains **both** blocks in order.
+4. Identity remains unique across a resumed session, so replayed history cannot collide
+   with newly generated ids.
+5. No change to recording/history content shape beyond the streamId value.
+
+## Test plan (behavioral, bun:test, extend existing files)
+
+All new/changed tests use `bun:test`. No Vitest. No mock theater — assert observable
+behaviour through the real functions.
+
+1. `packages/providers/src/anthropic/AnthropicProvider.thinking.streaming.test.ts`
+   - Drive two separate streams through the processor with the same Anthropic event
+     shape (`content_block_start` thinking at index 0, `thinking_delta`, `signature_delta`,
+     `content_block_stop`) and assert the emitted `streamId` values differ between calls.
+   - Assert that within one stream, every delta plus the final complete emission share
+     one `streamId`.
+
+2. `packages/cli/src/ui/hooks/agentStream/__tests__/thoughtState.test.ts`
+   - Apply a `complete` thought with streamId A, then a `delta` thought with a
+     *different* streamId B, and assert `thinkingBlocksRef.current` has length 2 and
+     preserves the first block's text verbatim.
+   - Keep the existing same-streamId replacement test green.
+
+3. OpenAI Responses reasoning identity — extend the existing reasoning stream test file
+   under `packages/providers/src/openai/` (locate the one covering
+   `allocateReasoningStreamId` / `parseResponsesStream` reasoning) with an equivalent
+   two-call distinctness assertion.
+
+## Implementation steps
+
+1. Make the Anthropic thinking identity unique beyond the single call, following the
+   `toolCallSequence` precedent in the same file. Ensure uniqueness also holds against
+   ids replayed from a resumed session.
+2. Apply the same treatment to the OpenAI Responses reasoning identity.
+3. Do not add clearing logic to `thinkingBlocksRef` and do not add defensive guards in
+   `thoughtState.ts`; the identity fix is the root-cause fix.
+4. Add a short note to the reasoning/provider documentation describing Anthropic's
+   summarized thinking, so future "thinking cut off" reports are triaged as a summarizer
+   artefact rather than chased as a streaming bug.
+
+## Verification
+
+    npm run test
+    npm run lint
+    npm run typecheck
+    npm run format
+    npm run build
+    bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+
+Plus a tmux-harness check of the transcript, since this changes terminal UI behaviour.
+
+## Constraints
+
+- No `eslint-disable*`, no `@ts-ignore` / `@ts-expect-error` / `@ts-nocheck`, no lint
+  severity downgrades, no complexity/size threshold increases. Fix the underlying issue.
+- TypeScript strict; no `any`, no type assertions used to dodge typing.
+- New files carry a 2026 copyright year.


### PR DESCRIPTION
## TLDR

Issue #3128 reported a thinking block that appeared cut off mid-sentence at the word "I". **The cut-off itself is not an llxprt bug** — it is an artefact of Anthropic's thinking summarizer. This PR documents that so the next such report is not chased as a streaming bug.

Investigating it surfaced a genuine latent defect, which this PR fixes: reasoning `streamId` values were unique only *within* a single API call, so every model iteration emitted the same id. **I verified by A/B test that this is not currently user-visible**, so this is latent-correctness hardening, not a user-facing bug fix. The regression tests are the durable value.

Reviewers should look at: the honesty of the reachability claim (below), and that `streamId` is genuinely opaque to every consumer.

## Dive Deeper

### The reported symptom is the Anthropic summarizer

I located the actual event in a real session recording (provider `claudecode`, model `claude-opus-5`, two minutes before the issue was filed). The persisted thinking block is byte-identical to what was reported.

Evidence the stream was healthy:

- `streamStatus: "complete"` **with a valid non-empty `signature`** — Anthropic emits `signature_delta` only immediately before `content_block_stop`
- the same assistant message contains a `text` block and two `tool_call` blocks
- zero retry / discard / error / invalid-stream events in the whole recording

Evidence the truncation originates upstream:

- the display path and the recording path are independent and both produced the same 147 characters; the recording path never touches Ink
- of 244 thinking blocks in that session, 3 (1.2%) end mid-sentence, and all 3 end on a clean **word boundary**, never mid-word — that indicates a generation stopping, not byte/chunk splitting
- median ratio of visible thought characters/4 to billed `completionTokens` is **0.188**

Anthropic documents that thinking text is a summary produced by a *different model*, and that billing reflects the full raw thinking rather than the summary. `signature` stays valid because it encrypts the raw reasoning. A summary that stops mid-sentence is a summarizer artefact.

I evaluated reading Anthropic's `summary_status` to detect this and **rejected it**: that field appears only in AWS Bedrock's older Claude 4 docs, is absent from the current Claude platform thinking docs, and is not typed by the pinned `@anthropic-ai/sdk@0.55.1`. There is no supported signal, so nothing is implemented against it.

### The latent defect this fixes

`createThinkingBlockIdentity()` allocated a fresh counter per API call, so every iteration's first thinking block was `anthropic-thinking:0:block-0`. Confirmed empirically: 244 thinking blocks in one session, **1 distinct streamId**. The OpenAI Responses path had the same shape via `nextReasoningStreamIndex: 0` initialised per stream.

`thinkingBlocksRef` in the CLI is keyed by that id, so a repeated id means a later iteration can match and overwrite an earlier iteration's rendered reasoning.

### Reachability: verified NOT currently reachable

I did not assume impact — I tested it. I ran the same scripted tmux-harness scenario (`opus5`/`claude-opus-5`, three sequential shell commands with reasoning between each) against clean `main` and against this branch. **Both rendered all three reasoning segments in order. No observable difference.**

The mitigating path is `handleToolsComplete` (`useAgentEventStream.ts:111`), which calls `flushPendingHistoryItem` before rendering each tool group; that commits the pending item and clears `thinkingBlocksRef`. Tool completion is exactly the iteration boundary. I also checked concurrent subagents and found no path from subagent thinking into the parent UI's thought state.

An earlier comment of mine on the issue claimed a 75% blast radius. **That was wrong and I have publicly retracted it** — those cases are the ones that DO hit the flush, i.e. the safe ones.

### Why fix it anyway

`streamId` exists solely to identify a stream, yet repeated on every call, and was harmless only by accident of unrelated tool-completion code. Anyone who touches that flush reintroduces silent reasoning loss with nothing to catch it. Scoping each id to a per-stream epoch makes it unique across calls and across resumed sessions (legacy records literally contain `anthropic-thinking:0:block-0`), and the tests pin the invariant.

### Design decision

- **Within one thinking block: replace.** Providers emit cumulative snapshots per delta plus an identical final snapshot at stop; replace-by-id is correct and unchanged. Per Anthropic's docs the summary *is* what streams — there is no late-arriving final summary.
- **Across thinking blocks: append, never replace.** Each block is a reasoning segment bound to the tool call that follows it.

Fixing identity rather than adding UI guards follows the repo's fail-fast preference, and mirrors the existing `toolCallSequence` precedent in the same file.

### Side effects checked

- No code anywhere parses `streamId` — every consumer uses it as an opaque map key or equality check
- `event-schema.ts` types it as plain `z.string()`
- `AnthropicMessageNormalizer` whitelists `{type, thinking, signature}`, so `streamId` never reaches the API (important: Anthropic rejects modified thinking blocks)
- No golden/fixture files reference the old format; the Zed handler ignores it
- `randomUUID` from `node:crypto` was already used in this package (`RetryOrchestrator.ts`); one call per API call

## Reviewer Test Plan

1. `bun test packages/providers/src/anthropic/AnthropicProvider.thinking.streaming.test.ts packages/providers/src/openai/parseResponsesStream.reasoning.test.ts packages/cli/src/ui/hooks/agentStream/__tests__/thoughtState.test.ts` — 44 tests.
2. Revert just the two id-generation changes and confirm the new cross-call tests fail.
3. Interactively with an Anthropic reasoning model (e.g. `opus5`), ask for three shell commands run one at a time with reasoning between each; confirm every reasoning segment renders in order attached to its own tool call, and that streaming a single thought still updates in place rather than duplicating.
4. Resume an older session recorded before this change and confirm replayed thinking blocks still render correctly alongside newly generated ones.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test`, `npm run lint`, `npm run lint:eslint-guard`, `npm run typecheck`, `npm run format`, `npm run build`, the `stepfun-37` smoke test, and the tmux-harness A/B.

Note on the full suite: this branch showed 1 failure, a 30s timeout in `config.mcp-lazy.test.ts` that passes in 84ms in isolation. I ran the full suite on clean `main` for comparison and it produced **5** such timeout failures in different files. These are load-dependent flakes in the local concurrent runner, not regressions from this change, and `main` fared worse.

## Linked issues / bugs

Fixes #3128
