### PR TITLE
Fail fast on quota-exhaustion 429s instead of resending the prompt (Fixes #3140)

### DIFF
--- a/packages/agents/src/api/__tests__/mutationCoverage.auth.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/mutationCoverage.auth.behavior.test.ts
@@ -417,9 +417,15 @@ describe('mutation P23.e — rebuild with approval + display callbacks (REQ-005)
     async () => {
       await fc.assert(
         fc.asyncProperty(
+          // A model identity must be non-BLANK, not merely non-empty by
+          // length. resolveModelForSystemPrompt (ChatSessionFactory, issue
+          // #3138) fails fast when config.getModel() trims to ''. A
+          // whitespace-only string is therefore an input the system
+          // deliberately rejects, not a valid model name, and generating one
+          // made this property fail intermittently once that guard landed.
           fc
             .string({ minLength: 1, maxLength: 30 })
-            .filter((s) => !s.includes('__proto__')),
+            .filter((s) => !s.includes('__proto__') && s.trim() !== ''),
           async (model) => {
             const { agent, cleanup } = await buildAgent('plain-text.jsonl');
             try {

--- a/packages/providers/src/__tests__/RetryOrchestrator.quotaExhaustion.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.quotaExhaustion.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @fix issue3140
+ * End-to-end behavioral tests for terminal-quota 429 handling through a REAL
+ * RetryOrchestrator.
+ *
+ * The provider-level classifier closes the inner stream-retry loop, but the
+ * orchestrator runs its own retry loop on top of it. Without a matching
+ * decision in `shouldRetryError`, a terminal quota 429 is still retried
+ * `maxAttempts` times — and because the Responses path is stateless, every one
+ * of those attempts resends the entire conversation. These tests drive the
+ * orchestrator with a fake provider that throws errors built by the real
+ * `parseErrorResponse`, and assert the observable transport-attempt count.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import { parseErrorResponse } from '../openai/parseResponsesStream.js';
+import type { IProvider, GenerateChatOptions } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { IModel } from '../IModel.js';
+
+const SUCCESS_CONTENT: IContent = {
+  speaker: 'ai',
+  blocks: [{ type: 'text', text: 'test response' }],
+};
+
+/**
+ * Fake provider that throws on every attempt for which `buildError` returns an
+ * error, and yields a success chunk otherwise. Mirrors the helper used by the
+ * sibling RetryOrchestrator suites so the IProvider contract is honoured
+ * exactly. `onTransportCall` fires on every transport invocation, letting tests
+ * count real transport attempts without mocking the orchestrator under test.
+ */
+function createThrowingProvider(
+  buildError: () => Error | undefined,
+  onTransportCall: () => void,
+): IProvider {
+  return {
+    name: 'openai-responses',
+    async *generateChatCompletion(
+      _options: GenerateChatOptions,
+    ): AsyncIterableIterator<IContent> {
+      onTransportCall();
+      const error = buildError();
+      if (error !== undefined) throw error;
+      yield SUCCESS_CONTENT;
+    },
+    async getModels(): Promise<IModel[]> {
+      return [];
+    },
+    getDefaultModel(): string {
+      return 'gpt-5';
+    },
+    getServerTools(): string[] {
+      return [];
+    },
+    async invokeServerTool(): Promise<unknown> {
+      return null;
+    },
+  };
+}
+
+async function consumeStream(
+  stream: AsyncIterableIterator<IContent>,
+): Promise<IContent[]> {
+  const chunks: IContent[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+async function countAttemptsFor(body: string, status = 429): Promise<number> {
+  let transportCalls = 0;
+  const provider = createThrowingProvider(
+    () => parseErrorResponse(status, body, 'openai-responses'),
+    () => {
+      transportCalls += 1;
+    },
+  );
+  const orchestrator = new RetryOrchestrator(provider, {
+    maxAttempts: 6,
+    initialDelayMs: 1,
+  });
+
+  await consumeStream(
+    orchestrator.generateChatCompletion({ contents: [] }),
+  ).catch(() => undefined);
+
+  return transportCalls;
+}
+
+describe('RetryOrchestrator terminal-quota 429 handling @issue:3140', () => {
+  it('makes exactly ONE transport attempt for a quota-exhaustion 429', async () => {
+    const attempts = await countAttemptsFor(
+      '{"error":{"code":"insufficient_quota","message":"You exceeded your current quota"}}',
+    );
+    expect(attempts).toBe(1);
+  });
+
+  it('surfaces the quota message unwrapped rather than a retries-exhausted error', async () => {
+    const provider = createThrowingProvider(
+      () =>
+        parseErrorResponse(
+          429,
+          '{"error":{"code":"insufficient_quota","message":"You exceeded your current quota"}}',
+          'openai-responses',
+        ),
+      () => undefined,
+    );
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 6,
+      initialDelayMs: 1,
+    });
+
+    await expect(
+      consumeStream(orchestrator.generateChatCompletion({ contents: [] })),
+    ).rejects.toThrow(
+      'Quota or billing limit exhausted: You exceeded your current quota',
+    );
+  });
+
+  it('still retries a throttling 429 to the attempt limit', async () => {
+    const attempts = await countAttemptsFor(
+      '{"error":{"code":"rate_limit_exceeded","message":"Too many requests"}}',
+    );
+    expect(attempts).toBeGreaterThan(1);
+  });
+
+  it('still retries a bare 429 carrying no body code', async () => {
+    const attempts = await countAttemptsFor(
+      '{"error":{"message":"Too many requests"}}',
+    );
+    expect(attempts).toBeGreaterThan(1);
+  });
+
+  it('still retries a 5xx server error', async () => {
+    const attempts = await countAttemptsFor(
+      '{"error":{"message":"Internal error"}}',
+      500,
+    );
+    expect(attempts).toBeGreaterThan(1);
+  });
+
+  /**
+   * Regression guard for the property-collision hazard: the body-level error
+   * `type` must not be written to a bare `type` key, because `isOverloadError`
+   * reads that key and would make a 403 retryable, reversing issue #2917.
+   */
+  it('makes exactly ONE transport attempt for a 403 carrying type=api_error', async () => {
+    const attempts = await countAttemptsFor(
+      '{"error":{"type":"api_error","message":"Forbidden"}}',
+      403,
+    );
+    expect(attempts).toBe(1);
+  });
+});

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderBase.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderBase.ts
@@ -37,6 +37,7 @@ import {
   getErrorStatus,
   isNetworkTransientError,
 } from '@vybestack/llxprt-code-core/utils/retry.js';
+import { isQuotaExhaustionError } from '../utils/quotaExhaustion.js';
 
 export abstract class OpenAIResponsesProviderBase extends BaseProvider {
   protected logger: DebugLogger;
@@ -101,7 +102,11 @@ export abstract class OpenAIResponsesProviderBase extends BaseProvider {
    * @requirement REQ-RETRY-001: OpenAIResponsesProvider must use retryWithBackoff for all fetch calls
    *
    * Determines if an error should trigger a retry.
-   * - 429 (rate limit) errors are retried
+   * - 429 (rate limit) errors are retried, EXCEPT when the error body reports
+   *   quota or credit exhaustion, which no amount of retrying can clear. The
+   *   Responses path is stateless, so each retry resends the whole
+   *   conversation; retrying a terminal 429 burns the full prompt repeatedly
+   *   against a condition that cannot resolve (issue #3140).
    * - 5xx server errors are retried
    * - 400 (bad request) errors are NOT retried
    * - Network transient errors are retried
@@ -111,7 +116,8 @@ export abstract class OpenAIResponsesProviderBase extends BaseProvider {
     const status = getErrorStatus(error);
     if (status !== undefined) {
       if (status === 400) return false;
-      return status === 429 || (status >= 500 && status < 600);
+      if (status === 429) return !isQuotaExhaustionError(error);
+      return status >= 500 && status < 600;
     }
 
     return isNetworkTransientError(error);

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.retryClassification.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.retryClassification.test.ts
@@ -1,0 +1,429 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral retry-classification tests for the OpenAI Responses path
+ * (issue #3140).
+ *
+ * Drives the REAL executor with a stubbed global `fetch` and the REAL
+ * production `shouldRetryOnError` classification (via a test-only subclass
+ * that exposes the protected method). Asserts on observable outcomes only:
+ * number of fetch calls, the error message surfaced, and the inter-attempt
+ * wait duration.
+ *
+ * AC1: a quota-exhaustion 429 issues exactly one fetch and surfaces the
+ *      quota message immediately.
+ * AC2: a throttling 429 is retried; when Retry-After is present the
+ *      inter-attempt wait tracks the header rather than the configured retrywait.
+ * AC6: 500, network-transient, and 400 behave as before.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  executeOpenAIResponsesRequest,
+  type ResponsesExecutorDeps,
+} from '../openAIResponsesExecutor.js';
+import { OpenAIResponsesProviderBase } from '../OpenAIResponsesProviderBase.js';
+import { shouldRetryError } from '../../retryDelayPolicy.js';
+import type { NormalizedGenerateChatOptions } from '../../BaseProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+
+const TERMINAL_EVENT =
+  'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}\n\n';
+
+const OK_BODY =
+  'data: {"type":"response.output_text.delta","delta":"ok"}\n\n' +
+  TERMINAL_EVENT;
+
+/**
+ * Test-only subclass that exposes the protected `shouldRetryOnError` so the
+ * executor deps use the REAL production classification logic, not a stub.
+ */
+class TestableResponsesProvider extends OpenAIResponsesProviderBase {
+  retryDecision(error: Error | unknown): boolean {
+    return this.shouldRetryOnError(error);
+  }
+
+  protected override async *generateChatCompletionWithOptions(): AsyncIterableIterator<IContent> {
+    yield* [];
+  }
+}
+
+interface FetchMock {
+  readonly calls: { count: number };
+  readonly timestamps: number[];
+  restore(): void;
+}
+
+function installFetch(
+  handler: (callIndex: number) => Response | Promise<Response>,
+): FetchMock {
+  const original = globalThis.fetch;
+  const calls = { count: 0 };
+  const timestamps: number[] = [];
+  const impl: typeof fetch = () => {
+    const index = calls.count;
+    calls.count += 1;
+    timestamps.push(Date.now());
+    return Promise.resolve(handler(index));
+  };
+  globalThis.fetch = impl;
+  return {
+    calls,
+    timestamps,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function errorResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Response(text, {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+function okResponse(): Response {
+  return new Response(OK_BODY, { status: 200 });
+}
+
+function buildNormalizedOptions(
+  overrides: {
+    ephemerals?: Record<string, unknown>;
+  } & Partial<NormalizedGenerateChatOptions> = {},
+): NormalizedGenerateChatOptions {
+  const { ephemerals = {}, ...optionOverrides } = overrides;
+  const settings = new SettingsService();
+  const runtime = createProviderRuntimeContext({
+    settingsService: settings,
+    runtimeId: 'test-runtime',
+  });
+  const config = createRuntimeConfigStub(settings, {});
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings,
+    providerName: 'openai-responses',
+    ephemeralsSnapshot: ephemerals,
+    fallbackRuntimeId: 'test-runtime',
+  });
+  const base = {
+    contents: [
+      {
+        speaker: 'human' as const,
+        blocks: [{ type: 'text' as const, text: 'Hello' }],
+      },
+    ],
+    settings,
+    config,
+    runtime,
+    invocation,
+    userMemory: undefined,
+    tools: undefined,
+    metadata: {},
+    resolved: {
+      model: 'gpt-5',
+      baseURL: 'https://api.openai.com/v1',
+      authToken: 'test-token',
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+  return { ...base, ...optionOverrides };
+}
+
+function buildDeps(provider: TestableResponsesProvider): ResponsesExecutorDeps {
+  return {
+    providerName: 'openai-responses',
+    logger: {
+      debug: () => undefined,
+    } as unknown as ResponsesExecutorDeps['logger'],
+    getProviderBaseURL: () => 'https://api.openai.com/v1',
+    getCustomHeaders: () => undefined,
+    isCodexBaseURL: () => false,
+    getCodexAccountId: async () => 'codex-account',
+    resolveAuthTokenForPrompt: async () => 'test-token',
+    generateSyntheticCallId: () => 'call_synthetic_test',
+    shouldRetryOnError: (error) => provider.retryDecision(error),
+    getDefaultModel: () => 'gpt-5',
+    getGlobalConfig: () => undefined,
+  };
+}
+
+async function drain(iterator: AsyncIterableIterator<IContent>): Promise<{
+  messages: IContent[];
+  error: unknown | undefined;
+}> {
+  const messages: IContent[] = [];
+  let error: unknown | undefined;
+  try {
+    for await (const chunk of iterator) messages.push(chunk);
+  } catch (caught) {
+    error = caught;
+  }
+  return { messages, error };
+}
+
+describe('OpenAI Responses retry classification @issue:3140', () => {
+  let fetchMock: FetchMock | undefined;
+  let provider: TestableResponsesProvider;
+
+  beforeEach(() => {
+    fetchMock = undefined;
+    provider = new TestableResponsesProvider(
+      'test-key',
+      'https://api.openai.com/v1',
+      {
+        getEphemeralSettings: () => ({}),
+      },
+    );
+  });
+
+  afterEach(() => {
+    fetchMock?.restore();
+  });
+
+  it('AC1: quota-exhaustion 429 issues exactly ONE fetch and surfaces the quota message', async () => {
+    fetchMock = installFetch(() =>
+      errorResponse(429, {
+        error: {
+          code: 'insufficient_quota',
+          message: 'You exhausted your quota',
+        },
+      }),
+    );
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 6, retrywait: 0 },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(fetchMock.calls.count).toBe(1);
+    // AC5: the surfaced message must read as quota exhaustion, not throttling.
+    const message = (error as Error).message.toLowerCase();
+    expect(message).not.toContain('rate limit exceeded');
+    expect(message).toContain('quota');
+    expect(message).toContain('will not');
+  });
+
+  it('AC1: a quota 429 carrying insufficient_quota only under type is terminal', async () => {
+    fetchMock = installFetch(() =>
+      errorResponse(429, {
+        error: {
+          type: 'insufficient_quota',
+          message: 'You exhausted your quota',
+        },
+      }),
+    );
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 6, retrywait: 0 },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(fetchMock.calls.count).toBe(1);
+  });
+
+  it('AC1: billing_hard_limit_reached 429 issues exactly ONE fetch', async () => {
+    fetchMock = installFetch(() =>
+      errorResponse(429, {
+        error: {
+          code: 'billing_hard_limit_reached',
+          message: 'Billing hard limit reached',
+        },
+      }),
+    );
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 6, retrywait: 0 },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(fetchMock.calls.count).toBe(1);
+  });
+
+  it('AC2: throttling 429 is retried and then succeeds', async () => {
+    fetchMock = installFetch((call) => {
+      if (call === 0)
+        return errorResponse(429, {
+          error: { code: 'rate_limit_exceeded', message: 'Too many requests' },
+        });
+      return okResponse();
+    });
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 3, retrywait: 0 },
+    });
+    const { messages, error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeUndefined();
+    expect(fetchMock.calls.count).toBe(2);
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
+  it('AC2: Retry-After header is honored — wait tracks the header, not retrywait', async () => {
+    const retrywait = 4000;
+    fetchMock = installFetch((call) => {
+      if (call === 0)
+        return errorResponse(
+          429,
+          { error: { code: 'rate_limit_exceeded', message: 'slow down' } },
+          { 'Retry-After': '1' },
+        );
+      return okResponse();
+    });
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 2, retrywait },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeUndefined();
+    expect(fetchMock.calls.count).toBe(2);
+    // The inter-attempt gap must track Retry-After (1s): long enough to prove
+    // the header was actually waited on, short enough to prove the jittered
+    // retrywait fallback (2800-5200ms) was not used.
+    const gap = fetchMock.timestamps[1] - fetchMock.timestamps[0];
+    expect(gap).toBeGreaterThanOrEqual(900);
+    expect(gap).toBeLessThan(2500);
+  }, 15000);
+
+  it('boundary: a bare 429 with no body code is still retried', async () => {
+    fetchMock = installFetch((call) => {
+      if (call === 0)
+        return errorResponse(429, {
+          error: { message: 'Too many requests' },
+        });
+      return okResponse();
+    });
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 3, retrywait: 0 },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeUndefined();
+    expect(fetchMock.calls.count).toBe(2);
+  });
+
+  it('AC6: a 500 server error is still retried', async () => {
+    fetchMock = installFetch((call) => {
+      if (call === 0)
+        return errorResponse(500, { error: { message: 'Internal error' } });
+      return okResponse();
+    });
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 3, retrywait: 0 },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeUndefined();
+    expect(fetchMock.calls.count).toBe(2);
+  });
+
+  it('AC6: a network-transient TypeError is still retried', async () => {
+    const original = globalThis.fetch;
+    const calls = { count: 0 };
+    globalThis.fetch = (() => {
+      calls.count += 1;
+      if (calls.count === 1)
+        return Promise.reject(new TypeError('fetch failed'));
+      return Promise.resolve(okResponse());
+    }) as typeof fetch;
+    fetchMock = {
+      calls,
+      timestamps: [],
+      restore: () => {
+        globalThis.fetch = original;
+      },
+    };
+
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 3, retrywait: 0 },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeUndefined();
+    expect(fetchMock.calls.count).toBe(2);
+  });
+
+  /**
+   * Regression guard: the body-level error `type` must never be written to a
+   * bare `type` key on the thrown error. `isOverloadError` in core reads that
+   * key and treats `api_error` as retryable, which would silently reverse the
+   * "403 is never retried" invariant from issue #2917.
+   */
+  it('a 403 carrying type=api_error is still NOT retried', async () => {
+    fetchMock = installFetch(() =>
+      errorResponse(403, {
+        error: { type: 'api_error', message: 'Forbidden' },
+      }),
+    );
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 3, retrywait: 0 },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(fetchMock.calls.count).toBe(1);
+    expect(shouldRetryError(error)).toBe(false);
+  });
+
+  it('a 404 carrying type=rate_limit_error is still NOT retried', async () => {
+    fetchMock = installFetch(() =>
+      errorResponse(404, {
+        error: { type: 'rate_limit_error', message: 'Not found' },
+      }),
+    );
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 3, retrywait: 0 },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(fetchMock.calls.count).toBe(1);
+    expect(shouldRetryError(error)).toBe(false);
+  });
+
+  it('AC6: a 400 bad request is NOT retried', async () => {
+    fetchMock = installFetch(() =>
+      errorResponse(400, { error: { message: 'Bad request' } }),
+    );
+    const options = buildNormalizedOptions({
+      ephemerals: { retries: 3, retrywait: 0 },
+    });
+    const { error } = await drain(
+      executeOpenAIResponsesRequest(options, buildDeps(provider)),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(fetchMock.calls.count).toBe(1);
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
@@ -16,14 +16,7 @@
  * each test.
  */
 
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-  afterAll,
-} from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -38,30 +31,29 @@ import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtim
 import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
 
-// Sandbox the config home before Storage.getGlobalCacheDir() is evaluated, so
-// these tests never read, write, or delete inside the real user cache dir.
-const TEST_CONFIG_HOME = path.join(
-  os.tmpdir(),
-  `llxprt-errordump-test-${process.pid}`,
-);
 const originalConfigHome = process.env['LLXPRT_CONFIG_HOME'];
 const originalCacheHome = process.env['LLXPRT_CACHE_HOME'];
-delete process.env['LLXPRT_CACHE_HOME'];
-process.env['LLXPRT_CONFIG_HOME'] = TEST_CONFIG_HOME;
 
-const DUMP_DIR = path.join(Storage.getGlobalCacheDir(), 'dumps');
+/**
+ * Per-test sandbox for the dump directory. Each test gets a fresh empty temp
+ * config home, so these tests never read, write, or delete inside the real user
+ * cache directory, and the env override is scoped to the test rather than to
+ * the whole module import (which would leak into anything else resolving cache
+ * paths in the same process).
+ */
+let tempConfigHome: string;
 
-afterAll(async () => {
-  await fs.rm(TEST_CONFIG_HOME, { recursive: true, force: true });
-  if (originalConfigHome === undefined) {
-    delete process.env['LLXPRT_CONFIG_HOME'];
-  } else {
-    process.env['LLXPRT_CONFIG_HOME'] = originalConfigHome;
+function dumpDir(): string {
+  return path.join(Storage.getGlobalCacheDir(), 'dumps');
+}
+
+async function listDumpFiles(): Promise<string[]> {
+  try {
+    return await fs.readdir(dumpDir());
+  } catch {
+    return [];
   }
-  if (originalCacheHome !== undefined) {
-    process.env['LLXPRT_CACHE_HOME'] = originalCacheHome;
-  }
-});
+}
 
 interface FetchMock {
   readonly calls: { count: number };
@@ -157,21 +149,8 @@ function buildDeps(): ResponsesExecutorDeps {
 async function readJsonDump(
   filename: string,
 ): Promise<Record<string, unknown>> {
-  const content = await fs.readFile(path.join(DUMP_DIR, filename), 'utf-8');
+  const content = await fs.readFile(path.join(dumpDir(), filename), 'utf-8');
   return JSON.parse(content) as Record<string, unknown>;
-}
-
-async function snapshotFiles(): Promise<Set<string>> {
-  try {
-    return new Set(await fs.readdir(DUMP_DIR));
-  } catch {
-    return new Set();
-  }
-}
-
-async function newFilesSince(before: Set<string>): Promise<string[]> {
-  const after = await snapshotFiles();
-  return [...after].filter((f) => !before.has(f));
 }
 
 /**
@@ -200,21 +179,30 @@ async function drainExpectingError(
 
 describe('OpenAI Responses error-response dump @issue:3140', () => {
   let fetchMock: FetchMock | undefined;
-  const createdFiles: string[] = [];
 
-  beforeEach(() => {
+  beforeEach(async () => {
     fetchMock = undefined;
+    tempConfigHome = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'responses-errordump-'),
+    );
+    delete process.env['LLXPRT_CACHE_HOME'];
+    process.env['LLXPRT_CONFIG_HOME'] = tempConfigHome;
   });
 
   afterEach(async () => {
     fetchMock?.restore();
-    for (const file of createdFiles.splice(0)) {
-      await fs.rm(path.join(DUMP_DIR, file), { force: true });
+    if (originalConfigHome === undefined) {
+      delete process.env['LLXPRT_CONFIG_HOME'];
+    } else {
+      process.env['LLXPRT_CONFIG_HOME'] = originalConfigHome;
     }
+    if (originalCacheHome !== undefined) {
+      process.env['LLXPRT_CACHE_HOME'] = originalCacheHome;
+    }
+    await fs.rm(tempConfigHome, { recursive: true, force: true });
   });
 
   it("AC4: dumpcontext 'on' writes a linked error-response dump with status and body", async () => {
-    const before = await snapshotFiles();
     fetchMock = installFetch(() =>
       errorResponse(
         429,
@@ -237,11 +225,9 @@ describe('OpenAI Responses error-response dump @issue:3140', () => {
     expect(caught).toBeInstanceOf(Error);
     expect(fetchMock.calls.count).toBe(1);
 
-    const fresh = await newFilesSince(before);
-    createdFiles.push(...fresh);
-
-    const requestFile = fresh.find((f) => f.endsWith('-request.json'));
-    const responseFile = fresh.find((f) => f.endsWith('-response.json'));
+    const written = await listDumpFiles();
+    const requestFile = written.find((f) => f.endsWith('-request.json'));
+    const responseFile = written.find((f) => f.endsWith('-response.json'));
     expect(requestFile).toBeDefined();
     expect(responseFile).toBeDefined();
 
@@ -270,7 +256,6 @@ describe('OpenAI Responses error-response dump @issue:3140', () => {
   });
 
   it("AC4: dumpcontext 'error' writes both request and linked error-response dump", async () => {
-    const before = await snapshotFiles();
     fetchMock = installFetch(() =>
       errorResponse(500, { error: { message: 'Internal error' } }),
     );
@@ -284,11 +269,9 @@ describe('OpenAI Responses error-response dump @issue:3140', () => {
 
     expect(caught).toBeInstanceOf(Error);
 
-    const fresh = await newFilesSince(before);
-    createdFiles.push(...fresh);
-
-    const requestFile = fresh.find((f) => f.endsWith('-request.json'));
-    const responseFile = fresh.find((f) => f.endsWith('-response.json'));
+    const written = await listDumpFiles();
+    const requestFile = written.find((f) => f.endsWith('-request.json'));
+    const responseFile = written.find((f) => f.endsWith('-response.json'));
     expect(requestFile).toBeDefined();
     expect(responseFile).toBeDefined();
 
@@ -302,7 +285,6 @@ describe('OpenAI Responses error-response dump @issue:3140', () => {
   });
 
   it("AC4: dumpcontext 'off' writes NO dump", async () => {
-    const before = await snapshotFiles();
     fetchMock = installFetch(() =>
       errorResponse(429, { error: { code: 'insufficient_quota' } }),
     );
@@ -314,40 +296,34 @@ describe('OpenAI Responses error-response dump @issue:3140', () => {
 
     await drainExpectingError(options);
 
-    const fresh = await newFilesSince(before);
-    createdFiles.push(...fresh);
-    expect(fresh).toHaveLength(0);
+    expect(await listDumpFiles()).toHaveLength(0);
   });
 
   it('a FAILING dump does not mask or alter the original API error', async () => {
     // Make every dump write fail for real: replacing the dumps directory with
     // a regular file makes fs.mkdir(dumpDir, { recursive: true }) reject.
-    await fs.rm(DUMP_DIR, { recursive: true, force: true });
-    await fs.mkdir(path.dirname(DUMP_DIR), { recursive: true });
-    await fs.writeFile(DUMP_DIR, 'not a directory', 'utf-8');
+    const dumps = dumpDir();
+    await fs.mkdir(path.dirname(dumps), { recursive: true });
+    await fs.writeFile(dumps, 'not a directory', 'utf-8');
 
-    try {
-      fetchMock = installFetch(() =>
-        errorResponse(429, {
-          error: { code: 'insufficient_quota', message: 'exhausted' },
-        }),
-      );
-      const options = buildNormalizedOptions({
-        dumpcontext: 'on',
-        retries: 1,
-        retrywait: 0,
-      });
+    fetchMock = installFetch(() =>
+      errorResponse(429, {
+        error: { code: 'insufficient_quota', message: 'exhausted' },
+      }),
+    );
+    const options = buildNormalizedOptions({
+      dumpcontext: 'on',
+      retries: 1,
+      retrywait: 0,
+    });
 
-      const caught = await drainExpectingError(options);
+    const caught = await drainExpectingError(options);
 
-      // The caller still receives the original API error verbatim.
-      expect(caught).toBeInstanceOf(Error);
-      expect((caught as Error).message).toBe(
-        'Quota or billing limit exhausted: exhausted. Retrying will not help — resolve your quota or billing limits',
-      );
-      expect(await fs.stat(DUMP_DIR).then((s) => s.isFile())).toBe(true);
-    } finally {
-      await fs.rm(DUMP_DIR, { force: true });
-    }
+    // The caller still receives the original API error verbatim.
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe(
+      'Quota or billing limit exhausted: exhausted. Retrying will not help — resolve your quota or billing limits',
+    );
+    expect(await fs.stat(dumps).then((s) => s.isFile())).toBe(true);
   });
 });

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
@@ -1,0 +1,353 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the OpenAI Responses error-response dump (issue #3140).
+ *
+ * AC4: When dumpcontext is 'on' or 'error', a non-2xx Responses reply produces
+ *      a response dump containing the HTTP status and the raw error body,
+ *      linked to the request dump when one exists.
+ *
+ * Only the fetch boundary is faked. The real executor, the real SSE parser,
+ * and the real dump filesystem writer all run. Dump files are cleaned up after
+ * each test.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from 'bun:test';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { Storage } from '@vybestack/llxprt-code-storage';
+import {
+  executeOpenAIResponsesRequest,
+  type ResponsesExecutorDeps,
+} from './openAIResponsesExecutor.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+
+// Sandbox the config home before Storage.getGlobalCacheDir() is evaluated, so
+// these tests never read, write, or delete inside the real user cache dir.
+const TEST_CONFIG_HOME = path.join(
+  os.tmpdir(),
+  `llxprt-errordump-test-${process.pid}`,
+);
+const originalConfigHome = process.env['LLXPRT_CONFIG_HOME'];
+const originalCacheHome = process.env['LLXPRT_CACHE_HOME'];
+delete process.env['LLXPRT_CACHE_HOME'];
+process.env['LLXPRT_CONFIG_HOME'] = TEST_CONFIG_HOME;
+
+const DUMP_DIR = path.join(Storage.getGlobalCacheDir(), 'dumps');
+
+afterAll(async () => {
+  await fs.rm(TEST_CONFIG_HOME, { recursive: true, force: true });
+  if (originalConfigHome === undefined) {
+    delete process.env['LLXPRT_CONFIG_HOME'];
+  } else {
+    process.env['LLXPRT_CONFIG_HOME'] = originalConfigHome;
+  }
+  if (originalCacheHome !== undefined) {
+    process.env['LLXPRT_CACHE_HOME'] = originalCacheHome;
+  }
+});
+
+interface FetchMock {
+  readonly calls: { count: number };
+  restore(): void;
+}
+
+function installFetch(
+  handler: (callIndex: number) => Response | Promise<Response>,
+): FetchMock {
+  const original = globalThis.fetch;
+  const calls = { count: 0 };
+  globalThis.fetch = (() => {
+    const index = calls.count;
+    calls.count += 1;
+    return Promise.resolve(handler(index));
+  }) as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function errorResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Response(text, {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+function buildNormalizedOptions(
+  ephemerals: Record<string, unknown>,
+): NormalizedGenerateChatOptions {
+  const settings = new SettingsService();
+  const runtime = createProviderRuntimeContext({
+    settingsService: settings,
+    runtimeId: 'test-runtime',
+  });
+  const config = createRuntimeConfigStub(settings, {});
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings,
+    providerName: 'openai-responses',
+    ephemeralsSnapshot: ephemerals,
+    fallbackRuntimeId: 'test-runtime',
+  });
+  return {
+    contents: [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Hello' }],
+      },
+    ],
+    settings,
+    config,
+    runtime,
+    invocation,
+    userMemory: undefined,
+    tools: undefined,
+    metadata: {},
+    resolved: {
+      model: 'gpt-5',
+      baseURL: 'https://api.openai.com/v1',
+      authToken: 'test-token',
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+}
+
+function buildDeps(): ResponsesExecutorDeps {
+  return {
+    providerName: 'openai-responses',
+    logger: {
+      debug: () => undefined,
+    } as unknown as ResponsesExecutorDeps['logger'],
+    getProviderBaseURL: () => 'https://api.openai.com/v1',
+    getCustomHeaders: () => undefined,
+    isCodexBaseURL: () => false,
+    getCodexAccountId: async () => 'codex-account',
+    resolveAuthTokenForPrompt: async () => 'test-token',
+    generateSyntheticCallId: () => 'call_synthetic_test',
+    shouldRetryOnError: () => false,
+    getDefaultModel: () => 'gpt-5',
+    getGlobalConfig: () => undefined,
+  };
+}
+
+async function readJsonDump(
+  filename: string,
+): Promise<Record<string, unknown>> {
+  const content = await fs.readFile(path.join(DUMP_DIR, filename), 'utf-8');
+  return JSON.parse(content) as Record<string, unknown>;
+}
+
+async function snapshotFiles(): Promise<Set<string>> {
+  try {
+    return new Set(await fs.readdir(DUMP_DIR));
+  } catch {
+    return new Set();
+  }
+}
+
+async function newFilesSince(before: Set<string>): Promise<string[]> {
+  const after = await snapshotFiles();
+  return [...after].filter((f) => !before.has(f));
+}
+
+/**
+ * Drains the stream and returns the error it threw. A completed stream is a
+ * contract violation for every test in this file (all drive a non-2xx reply),
+ * so it fails here with a diagnostic message rather than leaking `undefined`
+ * into a downstream assertion.
+ */
+async function drainExpectingError(
+  options: NormalizedGenerateChatOptions,
+): Promise<unknown> {
+  try {
+    for await (const _chunk of executeOpenAIResponsesRequest(
+      options,
+      buildDeps(),
+    )) {
+      void _chunk;
+    }
+  } catch (error) {
+    return error;
+  }
+  throw new Error(
+    'Expected the Responses stream to throw on a non-2xx reply, but it completed successfully',
+  );
+}
+
+describe('OpenAI Responses error-response dump @issue:3140', () => {
+  let fetchMock: FetchMock | undefined;
+  const createdFiles: string[] = [];
+
+  beforeEach(() => {
+    fetchMock = undefined;
+  });
+
+  afterEach(async () => {
+    fetchMock?.restore();
+    for (const file of createdFiles.splice(0)) {
+      await fs.rm(path.join(DUMP_DIR, file), { force: true });
+    }
+  });
+
+  it("AC4: dumpcontext 'on' writes a linked error-response dump with status and body", async () => {
+    const before = await snapshotFiles();
+    fetchMock = installFetch(() =>
+      errorResponse(
+        429,
+        { error: { code: 'insufficient_quota', message: 'exhausted' } },
+        {
+          'Set-Cookie': 'session=secret',
+          Authorization: 'Bearer sk-leaked',
+          'Retry-After': '1',
+        },
+      ),
+    );
+    const options = buildNormalizedOptions({
+      dumpcontext: 'on',
+      retries: 1,
+      retrywait: 0,
+    });
+
+    const caught = await drainExpectingError(options);
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(fetchMock.calls.count).toBe(1);
+
+    const fresh = await newFilesSince(before);
+    createdFiles.push(...fresh);
+
+    const requestFile = fresh.find((f) => f.endsWith('-request.json'));
+    const responseFile = fresh.find((f) => f.endsWith('-response.json'));
+    expect(requestFile).toBeDefined();
+    expect(responseFile).toBeDefined();
+
+    const responseDump = await readJsonDump(responseFile!);
+    expect(responseDump['relatedRequestFile']).toBe(requestFile);
+
+    const responseBody = responseDump['response'] as {
+      body?: {
+        status?: number;
+        headers?: Record<string, string>;
+        body?: string;
+      };
+    };
+    expect(responseBody.body?.status).toBe(429);
+    expect(responseBody.body?.body).toContain('insufficient_quota');
+
+    // Redaction: credential-bearing values must not leak, but the header
+    // names must survive and diagnostic headers must be readable — capturing
+    // Retry-After is a core reason the dump exists.
+    const dumpedHeaders = responseBody.body?.headers ?? {};
+    expect(dumpedHeaders['set-cookie']).toBe('[REDACTED]');
+    expect(dumpedHeaders['authorization']).toBe('[REDACTED]');
+    expect(JSON.stringify(dumpedHeaders)).not.toContain('secret');
+    expect(JSON.stringify(dumpedHeaders)).not.toContain('sk-leaked');
+    expect(dumpedHeaders['retry-after']).toBe('1');
+  });
+
+  it("AC4: dumpcontext 'error' writes both request and linked error-response dump", async () => {
+    const before = await snapshotFiles();
+    fetchMock = installFetch(() =>
+      errorResponse(500, { error: { message: 'Internal error' } }),
+    );
+    const options = buildNormalizedOptions({
+      dumpcontext: 'error',
+      retries: 1,
+      retrywait: 0,
+    });
+
+    const caught = await drainExpectingError(options);
+
+    expect(caught).toBeInstanceOf(Error);
+
+    const fresh = await newFilesSince(before);
+    createdFiles.push(...fresh);
+
+    const requestFile = fresh.find((f) => f.endsWith('-request.json'));
+    const responseFile = fresh.find((f) => f.endsWith('-response.json'));
+    expect(requestFile).toBeDefined();
+    expect(responseFile).toBeDefined();
+
+    const responseDump = await readJsonDump(responseFile!);
+    expect(responseDump['relatedRequestFile']).toBe(requestFile);
+    const responseBody = responseDump['response'] as {
+      body?: { status?: number; body?: string };
+    };
+    expect(responseBody.body?.status).toBe(500);
+    expect(responseBody.body?.body).toContain('Internal error');
+  });
+
+  it("AC4: dumpcontext 'off' writes NO dump", async () => {
+    const before = await snapshotFiles();
+    fetchMock = installFetch(() =>
+      errorResponse(429, { error: { code: 'insufficient_quota' } }),
+    );
+    const options = buildNormalizedOptions({
+      dumpcontext: 'off',
+      retries: 1,
+      retrywait: 0,
+    });
+
+    await drainExpectingError(options);
+
+    const fresh = await newFilesSince(before);
+    createdFiles.push(...fresh);
+    expect(fresh).toHaveLength(0);
+  });
+
+  it('a FAILING dump does not mask or alter the original API error', async () => {
+    // Make every dump write fail for real: replacing the dumps directory with
+    // a regular file makes fs.mkdir(dumpDir, { recursive: true }) reject.
+    await fs.rm(DUMP_DIR, { recursive: true, force: true });
+    await fs.mkdir(path.dirname(DUMP_DIR), { recursive: true });
+    await fs.writeFile(DUMP_DIR, 'not a directory', 'utf-8');
+
+    try {
+      fetchMock = installFetch(() =>
+        errorResponse(429, {
+          error: { code: 'insufficient_quota', message: 'exhausted' },
+        }),
+      );
+      const options = buildNormalizedOptions({
+        dumpcontext: 'on',
+        retries: 1,
+        retrywait: 0,
+      });
+
+      const caught = await drainExpectingError(options);
+
+      // The caller still receives the original API error verbatim.
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toBe(
+        'Quota or billing limit exhausted: exhausted. Retrying will not help — resolve your quota or billing limits',
+      );
+      expect(await fs.stat(DUMP_DIR).then((s) => s.isFile())).toBe(true);
+    } finally {
+      await fs.rm(DUMP_DIR, { force: true });
+    }
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -68,6 +68,7 @@ import {
 import {
   shouldDumpSDKContext,
   dumpSDKRequestContext,
+  bestEffortDump,
 } from '../utils/dumpSDKContext.js';
 import type { DumpMode } from '../utils/dumpContext.js';
 
@@ -203,7 +204,11 @@ export async function* executeOpenAIResponsesRequest(
     deps,
   );
 
-  await dumpFinalizedRequest(requestContext, invocationEphemerals, deps);
+  const dumpResult = await dumpFinalizedRequest(
+    requestContext,
+    invocationEphemerals,
+    deps,
+  );
 
   yield* streamResponses(
     {
@@ -214,6 +219,8 @@ export async function* executeOpenAIResponsesRequest(
       streamRetryInitialDelayMs:
         (invocationEphemerals['retrywait'] as number | undefined) ?? 4000,
       normalizedOptions: options,
+      dumpBaseId: dumpResult.baseId,
+      dumpMode: dumpResult.dumpMode,
     },
     deps,
   );
@@ -745,30 +752,40 @@ function applyPromptCaching(
   if (!isCodex) request.prompt_cache_retention = '24h';
 }
 
+interface DumpFinalizedResult {
+  baseId?: string;
+  dumpMode?: DumpMode;
+}
+
 /**
  * Dumps the finalized Responses request at the common pre-transport seam when
  * context dumping is enabled, matching OpenAI Chat and Anthropic parity.
  * Best-effort: failures are logged and never block the request.
+ * Returns the dump base id and resolved mode so the transport can write a
+ * linked error-response dump on failure (issue #3140).
  */
 async function dumpFinalizedRequest(
   requestContext: RequestContext,
   invocationEphemerals: Record<string, unknown>,
   deps: ResponsesExecutorDeps,
-): Promise<void> {
+): Promise<DumpFinalizedResult> {
   const dumpMode = invocationEphemerals['dumpcontext'] as DumpMode | undefined;
-  if (!shouldDumpSDKContext(dumpMode, false)) return;
-  try {
-    await dumpSDKRequestContext(
-      deps.providerName,
-      '/responses',
-      requestContext.request,
-      requestContext.baseURL,
-    );
-  } catch (error) {
-    deps.logger.debug(
-      () => `Best-effort Responses request dump failed: ${String(error)}`,
-    );
+  if (!shouldDumpSDKContext(dumpMode, false)) {
+    return { dumpMode };
   }
+  const result = await bestEffortDump(
+    'request',
+    deps.providerName,
+    () =>
+      dumpSDKRequestContext(
+        deps.providerName,
+        '/responses',
+        requestContext.request,
+        requestContext.baseURL,
+      ),
+    deps.logger,
+  );
+  return { baseId: result?.baseId, dumpMode };
 }
 
 async function* streamResponses(

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -30,9 +30,20 @@ import {
   type ParseResponsesStreamOptions,
 } from '../openai/parseResponsesStream.js';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
-import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
+import {
+  getErrorStatus,
+  isNetworkTransientError,
+} from '@vybestack/llxprt-code-core/utils/retry.js';
 import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { tryConsumeTransportAttempt } from '../transportAttemptBudget.js';
+import { getDelayDuration, hasRetryAfterHeader } from '../retryDelayPolicy.js';
+import {
+  shouldDumpSDKContext,
+  dumpSDKResponseContext,
+  dumpSDKErrorRequestResponse,
+  bestEffortDump,
+} from '../utils/dumpSDKContext.js';
+import { redactSensitiveHeaders, type DumpMode } from '../utils/dumpContext.js';
 import type { ResponsesExecutorDeps } from './openAIResponsesExecutor.js';
 import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
 
@@ -48,6 +59,8 @@ export interface StreamResponsesParams {
   maxStreamingAttempts: number;
   streamRetryInitialDelayMs: number;
   normalizedOptions: NormalizedGenerateChatOptions;
+  dumpBaseId?: string;
+  dumpMode?: DumpMode;
 }
 
 interface FetchStreamParams {
@@ -83,16 +96,21 @@ export async function* streamOverHttp(
   deps.logger.debug(
     () => `Request body keys: ${JSON.stringify(Object.keys(params.request))}`,
   );
-  yield* fetchStreamWithRetries(
-    {
-      ...params,
-      responsesURL: `${params.baseURL}/responses`,
-      headers,
-      bodyBlob,
-      onStreamLiveness: params.normalizedOptions.onStreamLiveness,
-    },
-    deps,
-  );
+  try {
+    yield* fetchStreamWithRetries(
+      {
+        ...params,
+        responsesURL: `${params.baseURL}/responses`,
+        headers,
+        bodyBlob,
+        onStreamLiveness: params.normalizedOptions.onStreamLiveness,
+      },
+      deps,
+    );
+  } catch (error) {
+    await dumpErrorOnFailure(error, params, deps);
+    throw error;
+  }
 }
 
 export async function buildResponsesHeaders(
@@ -178,6 +196,7 @@ async function* fetchStreamWithRetries(
           streamingAttempt,
           maxStreamingAttempts: params.maxStreamingAttempts,
           currentDelay,
+          initialDelay: params.streamRetryInitialDelayMs,
         },
         params.abortSignal,
         deps,
@@ -240,7 +259,21 @@ async function throwApiError(
   deps.logger.debug(
     () => `API error ${response.status}: ${errorBody.substring(0, 500)}`,
   );
-  throw parseErrorResponse(response.status, errorBody, deps.providerName);
+  const headers = lowercaseHeaders(response.headers);
+  throw parseErrorResponse(
+    response.status,
+    errorBody,
+    deps.providerName,
+    headers,
+  );
+}
+
+function lowercaseHeaders(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    record[key.toLowerCase()] = value;
+  });
+  return record;
 }
 
 async function handleStreamRetry(
@@ -249,6 +282,7 @@ async function handleStreamRetry(
     streamingAttempt: number;
     maxStreamingAttempts: number;
     currentDelay: number;
+    initialDelay: number;
   },
   abortSignal: AbortSignal | undefined,
   deps: ResponsesExecutorDeps,
@@ -256,8 +290,14 @@ async function handleStreamRetry(
   if (error instanceof Error && error.name === 'AbortError') {
     throw error;
   }
+  // A definite HTTP status is authoritative. Falling back to message-substring
+  // heuristics would let provider prose ("account terminated for non-payment"
+  // matches the transient phrase "terminated") re-open a classification that
+  // was already made (issue #3140).
   const canRetryStream =
-    deps.shouldRetryOnError(error) || isNetworkTransientError(error);
+    getErrorStatus(error) !== undefined
+      ? deps.shouldRetryOnError(error)
+      : isNetworkTransientError(error);
   if (!canRetryStream || state.streamingAttempt >= state.maxStreamingAttempts) {
     deps.logger.debug(
       () =>
@@ -266,11 +306,72 @@ async function handleStreamRetry(
     throw error;
   }
 
+  const waitMs = getDelayDuration(error, state.currentDelay);
   deps.logger.debug(
     () =>
-      `Stream retry attempt ${state.streamingAttempt}/${state.maxStreamingAttempts}: Transient error detected, delay ${state.currentDelay}ms before retry. Error: ${String(error)}`,
+      `Stream retry attempt ${state.streamingAttempt}/${state.maxStreamingAttempts}: Transient error detected, delay ${waitMs}ms before retry. Error: ${String(error)}`,
   );
-  const jitter = state.currentDelay * 0.3 * (Math.random() * 2 - 1);
-  await delay(Math.max(0, state.currentDelay + jitter), abortSignal);
-  return Math.min(30000, state.currentDelay * 2);
+  await delay(waitMs, abortSignal);
+  return hasRetryAfterHeader(error)
+    ? state.initialDelay
+    : Math.min(30000, state.currentDelay * 2);
+}
+
+interface ErrorResponsePayload {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: string;
+  error?: string;
+}
+
+function buildErrorResponsePayload(error: unknown): ErrorResponsePayload {
+  if (typeof error === 'object' && error !== null && 'response' in error) {
+    const response = (
+      error as {
+        response?: {
+          status?: number;
+          headers?: Record<string, string>;
+          body?: string;
+        };
+      }
+    ).response;
+    if (response !== undefined) {
+      return {
+        status: response.status,
+        headers: redactSensitiveHeaders(response.headers),
+        body: response.body,
+      };
+    }
+  }
+  return { error: String(error) };
+}
+
+async function dumpErrorOnFailure(
+  error: unknown,
+  params: StreamResponsesParams,
+  deps: ResponsesExecutorDeps,
+): Promise<void> {
+  // A user cancellation is not a request failure; dumping it would write a
+  // full-prompt request file on every abort without diagnostic value.
+  if (error instanceof Error && error.name === 'AbortError') return;
+  if (!shouldDumpSDKContext(params.dumpMode, true)) return;
+  const payload = buildErrorResponsePayload(error);
+  await bestEffortDump('error-response', deps.providerName, async () => {
+    if (params.dumpBaseId !== undefined) {
+      await dumpSDKResponseContext(
+        params.dumpBaseId,
+        deps.providerName,
+        payload,
+        true,
+      );
+    } else {
+      await dumpSDKErrorRequestResponse(
+        deps.providerName,
+        '/responses',
+        params.request,
+        payload,
+        params.baseURL,
+      );
+    }
+  });
 }

--- a/packages/providers/src/openai/parseResponsesStream.test.ts
+++ b/packages/providers/src/openai/parseResponsesStream.test.ts
@@ -599,6 +599,20 @@ describe('parseErrorResponse quota-aware 429 and response attachment @issue:3140
     expect(error.message.toLowerCase()).toContain('will not');
   });
 
+  /**
+   * A 5xx is still retried by both retry layers, so it must never claim that
+   * retrying will not help — even if the body echoes a terminal quota code.
+   */
+  it('keeps server-error wording for a 5xx echoing a terminal quota code', () => {
+    const error = parseErrorResponse(
+      503,
+      '{"error":{"code":"insufficient_quota","message":"upstream said quota"}}',
+      'Responses',
+    );
+    expect(error.message).toBe('Server error: upstream said quota');
+    expect(error.message.toLowerCase()).not.toContain('will not help');
+  });
+
   it('keeps the exact Rate limit exceeded wording for a throttling 429', () => {
     const error = parseErrorResponse(
       429,

--- a/packages/providers/src/openai/parseResponsesStream.test.ts
+++ b/packages/providers/src/openai/parseResponsesStream.test.ts
@@ -500,3 +500,170 @@ describe('parseResponsesStream terminal events (issue #2333)', () => {
     expect(messages.find((m) => m.metadata?.id === 'r1')).toBeDefined();
   });
 });
+
+describe('parseErrorResponse quota-aware 429 and response attachment @issue:3140', () => {
+  it('uses quota-exhaustion wording for a 429 with insufficient_quota code', () => {
+    const error = parseErrorResponse(
+      429,
+      '{"error":{"code":"insufficient_quota","message":"You exhausted your quota"}}',
+      'Responses',
+    );
+    expect(error.message).not.toContain('Rate limit exceeded');
+    expect(error.message.toLowerCase()).toContain('quota');
+    expect(error.message.toLowerCase()).toContain('exhaust');
+    expect(error.message.toLowerCase()).toContain('will not');
+  });
+
+  it('uses quota-exhaustion wording for a 429 with billing_hard_limit_reached', () => {
+    const error = parseErrorResponse(
+      429,
+      '{"error":{"code":"billing_hard_limit_reached","message":"Billing hard limit reached"}}',
+      'Responses',
+    );
+    expect(error.message).not.toContain('Rate limit exceeded');
+    expect(error.message.toLowerCase()).toContain('billing');
+    expect(error.message.toLowerCase()).toContain('will not');
+  });
+
+  /**
+   * OpenAI reports the same condition under `type` on some payloads and `code`
+   * on others. Both the message and the classification-bearing fields must
+   * agree, otherwise a quota 429 reads as terminal but is still retried.
+   */
+  it('classifies and words a 429 carrying insufficient_quota only under type', () => {
+    const error = parseErrorResponse(
+      429,
+      '{"error":{"type":"insufficient_quota","message":"You exhausted your quota"}}',
+      'Responses',
+    );
+    expect(error.message).not.toContain('Rate limit exceeded');
+    expect(error.message.toLowerCase()).toContain('quota');
+    expect((error as { providerErrorType?: string }).providerErrorType).toBe(
+      'insufficient_quota',
+    );
+  });
+
+  it('lifts a top-level code and type onto the thrown error', () => {
+    const error = parseErrorResponse(
+      429,
+      '{"code":"insufficient_quota","type":"insufficient_quota","message":"exhausted"}',
+      'Responses',
+    );
+    expect((error as { code?: string }).code).toBe('insufficient_quota');
+    expect((error as { providerErrorType?: string }).providerErrorType).toBe(
+      'insufficient_quota',
+    );
+  });
+
+  /**
+   * `isOverloadError` in core reads a bare `type` key and treats `api_error`,
+   * `rate_limit_error`, and `overloaded_error` as retryable. Writing the
+   * provider's body-level type to that key would make a Responses 403 or 404
+   * retryable and reverse the "403 is never retried" invariant (issue #2917).
+   */
+  it('never writes the body error type to a bare `type` key', () => {
+    const error = parseErrorResponse(
+      403,
+      '{"error":{"type":"api_error","message":"Forbidden"}}',
+      'Responses',
+    );
+    expect((error as { type?: string }).type).toBeUndefined();
+    expect((error as { providerErrorType?: string }).providerErrorType).toBe(
+      'api_error',
+    );
+  });
+
+  it('reads the Codex detail envelope for code and type', () => {
+    const error = parseErrorResponse(
+      429,
+      '{"detail":{"code":"insufficient_quota","type":"insufficient_quota","message":"exhausted"}}',
+      'Responses',
+    );
+    expect((error as { code?: string }).code).toBe('insufficient_quota');
+    expect(error.message).toContain('Quota or billing limit exhausted');
+  });
+
+  /**
+   * OpenAI returns billing_hard_limit_reached as an HTTP 400, not a 429. The
+   * retry decision is unchanged (400 was already terminal), but the user must
+   * still be told this is a billing problem rather than a bad request.
+   */
+  it('uses quota wording for a 400 billing_hard_limit_reached', () => {
+    const error = parseErrorResponse(
+      400,
+      '{"error":{"code":"billing_hard_limit_reached","message":"Billing hard limit has been reached"}}',
+      'Responses',
+    );
+    expect(error.message).not.toContain('Client error');
+    expect(error.message).toContain('Quota or billing limit exhausted');
+    expect(error.message.toLowerCase()).toContain('will not');
+  });
+
+  it('keeps the exact Rate limit exceeded wording for a throttling 429', () => {
+    const error = parseErrorResponse(
+      429,
+      '{"error":{"code":"rate_limit_exceeded","message":"Too many requests"}}',
+      'Responses',
+    );
+    expect(error.message).toBe('Rate limit exceeded: Too many requests');
+  });
+
+  it('keeps the exact Rate limit exceeded wording for a bare 429 with no code', () => {
+    const error = parseErrorResponse(
+      429,
+      '{"error":{"message":"Too many requests"}}',
+      'Responses',
+    );
+    expect(error.message).toBe('Rate limit exceeded: Too many requests');
+  });
+
+  it('attaches response.headers when headers are passed', () => {
+    const error = parseErrorResponse(
+      429,
+      '{"error":{"code":"insufficient_quota"}}',
+      'Responses',
+      { 'retry-after': '5' },
+    );
+    const response = (error as { response?: unknown }).response as {
+      status?: number;
+      headers?: Record<string, string>;
+      body?: string;
+    };
+    expect(response).toBeDefined();
+    expect(response.headers?.['retry-after']).toBe('5');
+    expect(response.status).toBe(429);
+    expect(response.body).toBe('{"error":{"code":"insufficient_quota"}}');
+  });
+
+  it('attaches response with undefined headers when no headers are passed', () => {
+    const error = parseErrorResponse(
+      500,
+      '{"error":{"message":"boom"}}',
+      'Responses',
+    );
+    const response = (error as { response?: unknown }).response as {
+      status?: number;
+      headers?: Record<string, string>;
+      body?: string;
+    };
+    expect(response).toBeDefined();
+    expect(response.headers).toBeUndefined();
+    expect(response.status).toBe(500);
+    expect(response.body).toBe('{"error":{"message":"boom"}}');
+  });
+
+  it('attaches response on the invalid-JSON catch branch so headers survive', () => {
+    const error = parseErrorResponse(429, 'Not JSON at all', 'Responses', {
+      'retry-after': '3',
+    });
+    const response = (error as { response?: unknown }).response as {
+      status?: number;
+      headers?: Record<string, string>;
+      body?: string;
+    };
+    expect(response).toBeDefined();
+    expect(response.headers?.['retry-after']).toBe('3');
+    expect(response.status).toBe(429);
+    expect(response.body).toBe('Not JSON at all');
+  });
+});

--- a/packages/providers/src/openai/responsesErrorParsing.ts
+++ b/packages/providers/src/openai/responsesErrorParsing.ts
@@ -10,6 +10,59 @@
  * within the max-lines budget.
  */
 
+import { findTerminalQuotaCode } from '../utils/quotaExhaustion.js';
+
+interface ErrorWithResponse extends Error {
+  status?: number;
+  code?: string;
+  /**
+   * The provider's body-level error `type`. Deliberately NOT written to a bare
+   * `type` key: `isOverloadError` in core reads `type` and treats `api_error`,
+   * `rate_limit_error`, and `overloaded_error` as retryable, so a plain `type`
+   * would silently make a Responses 403 or 404 retryable and reverse the
+   * "403 is never retried" invariant from issue #2917 (issue #3140).
+   */
+  providerErrorType?: string;
+  response?: { status: number; headers?: Record<string, string>; body: string };
+}
+
+interface OpenAIErrorBody {
+  code?: unknown;
+  type?: unknown;
+  error?: { code?: unknown; type?: unknown };
+  detail?: { code?: unknown; type?: unknown };
+}
+
+function readStringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+/**
+ * OpenAI reports the same condition under `code` on some payloads and `type`
+ * on others, at the top level, under the standard `error` envelope, or under
+ * the Codex/ChatGPT-backend `detail` envelope. Both fields are lifted onto the
+ * thrown error so downstream classification sees whichever the provider sent.
+ */
+function resolveErrorCodeAndType(errorData: unknown): {
+  code: string | undefined;
+  type: string | undefined;
+} {
+  if (typeof errorData !== 'object' || errorData === null) {
+    return { code: undefined, type: undefined };
+  }
+  const body = errorData as OpenAIErrorBody;
+  return {
+    code:
+      readStringField(body.error?.code) ??
+      readStringField(body.detail?.code) ??
+      readStringField(body.code),
+    type:
+      readStringField(body.error?.type) ??
+      readStringField(body.detail?.type) ??
+      readStringField(body.type),
+  };
+}
+
 function resolveErrorMessage(errorData: unknown): string {
   if (typeof errorData === 'string' && errorData !== '') {
     return errorData;
@@ -40,7 +93,15 @@ function resolveErrorMessage(errorData: unknown): string {
   return 'Unknown error';
 }
 
-function resolveErrorPrefix(status: number): string {
+const QUOTA_PREFIX = 'Quota or billing limit exhausted';
+
+/**
+ * The quota prefix is chosen by error code rather than status because OpenAI
+ * returns `billing_hard_limit_reached` as a 400 and `insufficient_quota` as a
+ * 429; both require the same user action (issue #3140).
+ */
+function resolveErrorPrefix(status: number, isQuotaExhausted = false): string {
+  if (isQuotaExhausted) return QUOTA_PREFIX;
   switch (status) {
     case 409:
       return 'Conflict';
@@ -57,6 +118,34 @@ function resolveErrorPrefix(status: number): string {
       }
       return 'API Error';
   }
+}
+
+/**
+ * Suffix appended to quota-exhaustion 429 messages so the user knows retrying
+ * cannot help and that billing/quota must be resolved (issue #3140).
+ */
+const QUOTA_RETRY_SUFFIX =
+  '. Retrying will not help — resolve your quota or billing limits';
+
+/**
+ * Attaches status, code, and the raw response envelope to an error. The
+ * `response` object is the single seam that exposes Retry-After headers and
+ * the raw body to the retry layers and the error-response dump (issue #3140).
+ */
+function attachErrorMetadata(
+  error: Error,
+  status: number,
+  errorData: unknown,
+  headers: Record<string, string> | undefined,
+  body: string,
+): ErrorWithResponse {
+  const { code, type } = resolveErrorCodeAndType(errorData);
+  const enriched = error as ErrorWithResponse;
+  enriched.status = status;
+  if (code !== undefined) enriched.code = code;
+  if (type !== undefined) enriched.providerErrorType = type;
+  enriched.response = { status, headers, body };
+  return enriched;
 }
 
 /**
@@ -85,6 +174,7 @@ export function parseErrorResponse(
   status: number,
   body: string,
   providerName: string,
+  headers?: Record<string, string>,
 ): Error {
   // Try to parse JSON error response first
   try {
@@ -101,24 +191,25 @@ export function parseErrorResponse(
 
     // 418 I'm a teapot: return message without prefix
     if (status === 418) {
-      const teapotError = new Error(message);
-      (teapotError as { status?: number }).status = status;
-      (teapotError as { code?: string }).code =
-        errorData.error?.code ?? errorData.code;
-      return teapotError;
+      return attachErrorMetadata(
+        new Error(message),
+        status,
+        errorData,
+        headers,
+        body,
+      );
     }
 
-    const errorPrefix = resolveErrorPrefix(status);
-    const error = new Error(`${errorPrefix}: ${message}`);
-    (error as { status?: number }).status = status;
-    (error as { code?: string }).code = errorData.error?.code ?? errorData.code;
-    return error;
+    const isQuotaExhausted = findTerminalQuotaCode(errorData) !== undefined;
+    const errorPrefix = resolveErrorPrefix(status, isQuotaExhausted);
+    const quotaSuffix = isQuotaExhausted ? QUOTA_RETRY_SUFFIX : '';
+    const error = new Error(`${errorPrefix}: ${message}${quotaSuffix}`);
+    return attachErrorMetadata(error, status, errorData, headers, body);
   } catch {
     // For invalid JSON / empty body, include diagnostic body snippet.
     const errorPrefix = resolveErrorPrefix(status);
     const detail = buildDiagnosticMessage(status, body);
     const error = new Error(`${errorPrefix}: ${providerName} - ${detail}`);
-    (error as { status?: number }).status = status;
-    return error;
+    return attachErrorMetadata(error, status, undefined, headers, body);
   }
 }

--- a/packages/providers/src/openai/responsesErrorParsing.ts
+++ b/packages/providers/src/openai/responsesErrorParsing.ts
@@ -95,10 +95,15 @@ function resolveErrorMessage(errorData: unknown): string {
 
 const QUOTA_PREFIX = 'Quota or billing limit exhausted';
 
+function isClientErrorStatus(status: number): boolean {
+  return status >= 400 && status < 500;
+}
+
 /**
- * The quota prefix is chosen by error code rather than status because OpenAI
- * returns `billing_hard_limit_reached` as a 400 and `insufficient_quota` as a
- * 429; both require the same user action (issue #3140).
+ * Within the 4xx range the quota prefix is chosen by error code rather than by
+ * the specific status, because OpenAI returns `billing_hard_limit_reached` as a
+ * 400 and `insufficient_quota` as a 429 and both require the same user action
+ * (issue #3140).
  */
 function resolveErrorPrefix(status: number, isQuotaExhausted = false): string {
   if (isQuotaExhausted) return QUOTA_PREFIX;
@@ -200,7 +205,12 @@ export function parseErrorResponse(
       );
     }
 
-    const isQuotaExhausted = findTerminalQuotaCode(errorData) !== undefined;
+    // Only a 4xx is genuinely terminal. A 5xx that happens to echo a quota
+    // code is still retried by both layers, so claiming "retrying will not
+    // help" there would contradict what actually happens (issue #3140).
+    const isQuotaExhausted =
+      isClientErrorStatus(status) &&
+      findTerminalQuotaCode(errorData) !== undefined;
     const errorPrefix = resolveErrorPrefix(status, isQuotaExhausted);
     const quotaSuffix = isQuotaExhausted ? QUOTA_RETRY_SUFFIX : '';
     const error = new Error(`${errorPrefix}: ${message}${quotaSuffix}`);

--- a/packages/providers/src/retryDelayPolicy.test.ts
+++ b/packages/providers/src/retryDelayPolicy.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  shouldRetryError,
+  getDelayDuration,
+  hasRetryAfterHeader,
+} from './retryDelayPolicy.js';
+
+describe('shouldRetryError @issue:3140', () => {
+  it('returns false for a quota-exhaustion 429 (terminal)', () => {
+    const error = {
+      status: 429,
+      error: { code: 'insufficient_quota' },
+    };
+    expect(shouldRetryError(error)).toBe(false);
+  });
+
+  it('returns false for billing_hard_limit_reached 429 (terminal)', () => {
+    const error = {
+      status: 429,
+      error: { code: 'billing_hard_limit_reached' },
+    };
+    expect(shouldRetryError(error)).toBe(false);
+  });
+
+  it('returns false for a 429 carrying insufficient_quota only under type', () => {
+    const error = {
+      status: 429,
+      type: 'insufficient_quota',
+    };
+    expect(shouldRetryError(error)).toBe(false);
+  });
+
+  it('returns true for a throttling 429 (rate_limit_exceeded)', () => {
+    const error = {
+      status: 429,
+      error: { code: 'rate_limit_exceeded' },
+    };
+    expect(shouldRetryError(error)).toBe(true);
+  });
+
+  it('returns true for a bare 429 with no body code', () => {
+    const error = {
+      status: 429,
+      message: 'Too many requests',
+    };
+    expect(shouldRetryError(error)).toBe(true);
+  });
+
+  it('returns true for a 5xx server error', () => {
+    const error = {
+      status: 500,
+      error: { message: 'Internal error' },
+    };
+    expect(shouldRetryError(error)).toBe(true);
+  });
+
+  it('returns false for a 400 bad request', () => {
+    const error = {
+      status: 400,
+      error: { message: 'Bad request' },
+    };
+    expect(shouldRetryError(error)).toBe(false);
+  });
+});
+
+describe('getDelayDuration / hasRetryAfterHeader @issue:3140', () => {
+  it('honors Retry-After header when present', () => {
+    const error = {
+      status: 429,
+      response: { headers: { 'retry-after': '2' } },
+    };
+    expect(hasRetryAfterHeader(error)).toBe(true);
+    expect(getDelayDuration(error, 5000)).toBe(2000);
+  });
+
+  it('caps Retry-After at the 5 minute maximum', () => {
+    const error = {
+      status: 429,
+      response: { headers: { 'retry-after': '600' } },
+    };
+    expect(getDelayDuration(error, 5000)).toBe(300_000);
+  });
+
+  it('falls back to jittered exponential backoff when no Retry-After', () => {
+    const error = { status: 429 };
+    const delayMs = getDelayDuration(error, 4000);
+    // jitter is ±30%, so the result is within [4000 - 1200, 4000 + 1200]
+    expect(delayMs).toBeGreaterThanOrEqual(2800);
+    expect(delayMs).toBeLessThanOrEqual(5200);
+  });
+});

--- a/packages/providers/src/retryDelayPolicy.ts
+++ b/packages/providers/src/retryDelayPolicy.ts
@@ -11,6 +11,7 @@ import {
   isRetryableError,
 } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { isStreamTimeoutError } from './providerErrorObservation.js';
+import { isQuotaExhaustionError } from './utils/quotaExhaustion.js';
 
 /**
  * Determines if an error should trigger a retry.
@@ -30,6 +31,7 @@ export function shouldRetryError(error: unknown): boolean {
     return false;
   }
   if (status === 429 || isOverloadError(error)) {
+    if (isQuotaExhaustionError(error)) return false;
     return true;
   }
   if (status !== undefined && status >= 500 && status < 600) {

--- a/packages/providers/src/utils/dumpContext.test.ts
+++ b/packages/providers/src/utils/dumpContext.test.ts
@@ -137,6 +137,34 @@ describe('dumpContext', () => {
       expect(redacted.headers['x-api-key']).toBe('[REDACTED]');
     });
 
+    it('should redact every credential-bearing header name @issue:3140', () => {
+      const request = {
+        url: 'https://api.example.com',
+        method: 'POST',
+        headers: {
+          'proxy-authorization': 'Basic proxy-secret',
+          'x-goog-api-key': 'AIza-google-secret',
+          'X-Goog-Api-Key': 'AIza-google-secret-mixed-case',
+          'api-key': 'azure-secret',
+          cookie: 'session=cookie-secret',
+          'set-cookie': 'session=set-cookie-secret',
+          'Content-Type': 'application/json',
+        },
+        body: { test: 'data' },
+      };
+
+      const redacted = redactSensitiveData(request);
+
+      expect(redacted.headers['proxy-authorization']).toBe('[REDACTED]');
+      expect(redacted.headers['x-goog-api-key']).toBe('[REDACTED]');
+      expect(redacted.headers['X-Goog-Api-Key']).toBe('[REDACTED]');
+      expect(redacted.headers['api-key']).toBe('[REDACTED]');
+      expect(redacted.headers.cookie).toBe('[REDACTED]');
+      expect(redacted.headers['set-cookie']).toBe('[REDACTED]');
+      expect(redacted.headers['Content-Type']).toBe('application/json');
+      expect(JSON.stringify(redacted.headers)).not.toContain('secret');
+    });
+
     it('should redact credential headers case-insensitively', () => {
       const request = {
         url: 'https://api.example.com',

--- a/packages/providers/src/utils/dumpContext.ts
+++ b/packages/providers/src/utils/dumpContext.ts
@@ -52,6 +52,7 @@ const SENSITIVE_HEADER_NAMES = new Set([
   'authorization',
   'proxy-authorization',
   'x-api-key',
+  'x-goog-api-key',
   'api-key',
   'cookie',
   'set-cookie',

--- a/packages/providers/src/utils/dumpContext.ts
+++ b/packages/providers/src/utils/dumpContext.ts
@@ -43,25 +43,45 @@ export interface DumpData {
 }
 
 /**
+ * Header names whose values must never reach a dump file. Dumps are written to
+ * disk and routinely pasted into bug reports, and gateways and proxies echo
+ * request credentials back on responses, so the same set applies in both
+ * directions (issue #3140).
+ */
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'proxy-authorization',
+  'x-api-key',
+  'api-key',
+  'cookie',
+  'set-cookie',
+]);
+
+/**
+ * Redacts sensitive header values in place, preserving every header name so a
+ * dump still shows which headers were present (e.g. `retry-after`).
+ */
+export function redactSensitiveHeaders(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (headers === undefined) return undefined;
+  const redacted: Record<string, string> = { ...headers };
+  for (const headerName of Object.keys(redacted)) {
+    if (SENSITIVE_HEADER_NAMES.has(headerName.toLowerCase())) {
+      redacted[headerName] = '[REDACTED]';
+    }
+  }
+  return redacted;
+}
+
+/**
  * Redacts sensitive information from request data
  */
 export function redactSensitiveData(request: DumpRequest): DumpRequest {
   const redacted: DumpRequest = {
     ...request,
-    headers: request.headers ? { ...request.headers } : undefined,
+    headers: redactSensitiveHeaders(request.headers),
   };
-
-  if (redacted.headers) {
-    for (const headerName of Object.keys(redacted.headers)) {
-      const normalizedHeaderName = headerName.toLowerCase();
-      if (
-        normalizedHeaderName === 'authorization' ||
-        normalizedHeaderName === 'x-api-key'
-      ) {
-        redacted.headers[headerName] = '[REDACTED]';
-      }
-    }
-  }
 
   // Redact key query parameter in URL
   if (redacted.url.includes('?')) {

--- a/packages/providers/src/utils/quotaExhaustion.test.ts
+++ b/packages/providers/src/utils/quotaExhaustion.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { isQuotaExhaustionError } from './quotaExhaustion.js';
+
+describe('isQuotaExhaustionError @issue:3140', () => {
+  it('returns true for 429 with error.error.code insufficient_quota', () => {
+    const error = {
+      status: 429,
+      error: { code: 'insufficient_quota' },
+    };
+    expect(isQuotaExhaustionError(error)).toBe(true);
+  });
+
+  it('returns true for 429 with error.error.type insufficient_quota', () => {
+    const error = {
+      status: 429,
+      error: { type: 'insufficient_quota' },
+    };
+    expect(isQuotaExhaustionError(error)).toBe(true);
+  });
+
+  it('returns true for 429 with error.code billing_hard_limit_reached', () => {
+    const error = {
+      status: 429,
+      code: 'billing_hard_limit_reached',
+    };
+    expect(isQuotaExhaustionError(error)).toBe(true);
+  });
+
+  it('returns true for 429 with error.type billing_hard_limit_reached', () => {
+    const error = {
+      status: 429,
+      type: 'billing_hard_limit_reached',
+    };
+    expect(isQuotaExhaustionError(error)).toBe(true);
+  });
+
+  /**
+   * The Codex / ChatGPT backend wraps its error payload in `detail` rather
+   * than the standard OpenAI `error` envelope.
+   */
+  it('returns true for 429 with detail.code insufficient_quota', () => {
+    const error = {
+      status: 429,
+      detail: { code: 'insufficient_quota' },
+    };
+    expect(isQuotaExhaustionError(error)).toBe(true);
+  });
+
+  it('returns true for 429 with detail.type insufficient_quota', () => {
+    const error = {
+      status: 429,
+      detail: { type: 'insufficient_quota' },
+    };
+    expect(isQuotaExhaustionError(error)).toBe(true);
+  });
+
+  /**
+   * parseErrorResponse lifts the body-level `type` onto `providerErrorType`
+   * rather than `type`, so the classifier must read that position.
+   */
+  it('returns true for 429 with providerErrorType insufficient_quota', () => {
+    const error = {
+      status: 429,
+      providerErrorType: 'insufficient_quota',
+    };
+    expect(isQuotaExhaustionError(error)).toBe(true);
+  });
+
+  it('returns false for 429 with rate_limit_exceeded code', () => {
+    const error = {
+      status: 429,
+      error: { code: 'rate_limit_exceeded' },
+    };
+    expect(isQuotaExhaustionError(error)).toBe(false);
+  });
+
+  it('returns false for 429 with no code/type at all', () => {
+    const error = {
+      status: 429,
+      message: 'Too many requests',
+    };
+    expect(isQuotaExhaustionError(error)).toBe(false);
+  });
+
+  it('returns false when status is not 429 even with a terminal code', () => {
+    const error402 = {
+      status: 402,
+      error: { code: 'insufficient_quota' },
+    };
+    expect(isQuotaExhaustionError(error402)).toBe(false);
+
+    const error500 = {
+      status: 500,
+      error: { code: 'insufficient_quota' },
+    };
+    expect(isQuotaExhaustionError(error500)).toBe(false);
+  });
+
+  it('returns false for non-object input', () => {
+    expect(isQuotaExhaustionError(undefined)).toBe(false);
+    expect(isQuotaExhaustionError(null)).toBe(false);
+    expect(isQuotaExhaustionError('string error')).toBe(false);
+    expect(isQuotaExhaustionError(42)).toBe(false);
+  });
+
+  it('returns false for an unrecognized terminal-looking code', () => {
+    const error = {
+      status: 429,
+      error: { code: 'some_other_quota_thing' },
+    };
+    expect(isQuotaExhaustionError(error)).toBe(false);
+  });
+});

--- a/packages/providers/src/utils/quotaExhaustion.ts
+++ b/packages/providers/src/utils/quotaExhaustion.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getErrorStatus } from '@vybestack/llxprt-code-core/utils/retry.js';
+
+/**
+ * OpenAI error codes/types that indicate billing/credit exhaustion. A 429
+ * carrying one of these can never succeed on retry — the user must resolve
+ * their billing situation first (issue #3140).
+ */
+export const TERMINAL_QUOTA_CODES = new Set([
+  'insufficient_quota',
+  'billing_hard_limit_reached',
+]);
+
+interface CodeBearingEnvelope {
+  code?: unknown;
+  type?: unknown;
+}
+
+interface ErrorWithCode extends CodeBearingEnvelope {
+  error?: CodeBearingEnvelope;
+  detail?: CodeBearingEnvelope;
+  /**
+   * The provider's body-level error `type`, lifted onto a thrown Error by
+   * parseErrorResponse. Deliberately NOT named `type`: `isOverloadError` in
+   * core reads a bare `type` and treats `api_error` / `rate_limit_error` /
+   * `overloaded_error` as retryable, so writing the provider's type to that
+   * key would silently reclassify non-429 Responses errors (issue #3140).
+   */
+  providerErrorType?: unknown;
+}
+
+/**
+ * Collects every position at which a provider may report an error code or
+ * type: the top level, the standard OpenAI `error` envelope, the Codex /
+ * ChatGPT-backend `detail` envelope, and the `providerErrorType` field that
+ * parseErrorResponse lifts onto thrown errors.
+ */
+function collectCodeCandidates(errorData: unknown): unknown[] {
+  if (typeof errorData !== 'object' || errorData === null) return [];
+  const e = errorData as ErrorWithCode;
+  return [
+    e.code,
+    e.type,
+    e.providerErrorType,
+    e.error?.code,
+    e.error?.type,
+    e.detail?.code,
+    e.detail?.type,
+  ];
+}
+
+/**
+ * Checks whether any code/type field on the parsed error body is a terminal
+ * quota code. Shared by {@link isQuotaExhaustionError} (status-gated) and
+ * the code-aware quota message prefix in parseErrorResponse.
+ */
+export function findTerminalQuotaCode(errorData: unknown): string | undefined {
+  return collectCodeCandidates(errorData).find(
+    (value): value is string =>
+      typeof value === 'string' && TERMINAL_QUOTA_CODES.has(value),
+  );
+}
+
+/**
+ * Returns true only when the resolved HTTP status is 429 AND a terminal-quota
+ * code is found at any position {@link collectCodeCandidates} inspects.
+ *
+ * The 429 gate is deliberate: a terminal quota code on a 4xx that is already
+ * non-retryable (OpenAI returns `billing_hard_limit_reached` as a 400) needs no
+ * further classification, and a code echoed on a 5xx must stay retryable.
+ *
+ * Internal helper with exactly two production call sites
+ * (shouldRetryOnError / shouldRetryError). Not exported from the package index.
+ */
+export function isQuotaExhaustionError(error: unknown): boolean {
+  if (getErrorStatus(error) !== 429) return false;
+  return findTerminalQuotaCode(error) !== undefined;
+}

--- a/project-plans/issue3140/PLAN.md
+++ b/project-plans/issue3140/PLAN.md
@@ -1,0 +1,297 @@
+# Issue #3140 — Quota-exhaustion 429s must not be retried like transient rate limits
+
+## Problem
+
+HTTP 429 is treated as unconditionally retryable on the OpenAI Responses path.
+That status covers two conditions with opposite correct handling:
+
+- **Transient throttling** (`rate_limit_exceeded`) — retry with backoff is correct.
+- **Quota / credit exhaustion** (`insufficient_quota`) — retry can never succeed.
+
+Because the Responses path is stateless, each retry resends the entire
+conversation. A captured Codex sequence produced nine full-prompt requests
+(~1.13 MB each, ~9.7 MB total) for one logical turn, all failing.
+
+Two additional defects block diagnosis and correct backoff:
+
+- The error thrown by `parseErrorResponse` carries no response headers, so
+  `Retry-After` is invisible to every retry layer.
+- No error-response dump is written on the Responses path, so the failure body
+  is never captured even with `/dumpcontext on`.
+
+## Current behavior (verified against main)
+
+| Location | Current behavior |
+| --- | --- |
+| `packages/providers/src/openai-responses/OpenAIResponsesProviderBase.ts:111` | `shouldRetryOnError` returns `true` for any 429; body never consulted. |
+| `packages/providers/src/retryDelayPolicy.ts:18` | `shouldRetryError` (used by `RetryOrchestrator.decideRetryOrThrow`) returns `true` for any 429; body never consulted. |
+| `packages/providers/src/openai/responsesErrorParsing.ts:84` | `parseErrorResponse` attaches `status` and `code` only. No `response.headers`, no raw body, one fixed 429 prefix `Rate limit exceeded`. |
+| `packages/providers/src/openai-responses/openAIResponsesHttpStream.ts:237` | `throwApiError` discards `response.headers`. |
+| `packages/providers/src/openai-responses/openAIResponsesHttpStream.ts:246` | `handleStreamRetry` always uses fixed exponential backoff + jitter; `Retry-After` never consulted. |
+| `packages/providers/src/openai-responses/openAIResponsesExecutor.ts:648` | `dumpFinalizedRequest` dumps the request only, and only when `shouldDump(mode, false)`. No error-response dump exists anywhere on the Responses path. |
+
+Net effect: a terminal 429 is retried `maxStreamingAttempts` times inside the
+HTTP stream **and** again by the outer `RetryOrchestrator`, at full prompt cost
+per attempt, with no captured evidence of why.
+
+## Accepted behavior (acceptance criteria)
+
+**AC1 — Terminal quota 429 is not retried, at both retry layers.**
+A 429 whose body identifies quota/credit exhaustion is classified terminal by
+`OpenAIResponsesProviderBase.shouldRetryOnError` (inner stream loop) and by
+`shouldRetryError` (outer `RetryOrchestrator`). Exactly one HTTP request is
+issued and the error surfaces immediately.
+
+**AC2 — Throttling 429 is still retried and honors `Retry-After`.**
+A 429 whose body identifies transient rate limiting remains retryable. When the
+response carries a `Retry-After` header, the inner stream retry waits that
+duration (capped) instead of its fixed backoff schedule.
+
+**AC3 — Classification consults the error body, not only the HTTP status.**
+The terminal/retryable decision reads the OpenAI error `code`/`type` from the
+parsed body, at both the top-level and `error.*` nesting positions.
+
+**AC4 — Error responses are captured when dumping is enabled.**
+When `dumpcontext` is `on` or `error`, a non-2xx Responses reply produces a
+response dump containing the HTTP status and the raw error body, linked to the
+request dump when one exists.
+
+**AC5 — The user-facing message distinguishes quota exhaustion from throttling.**
+A quota-exhaustion 429 message states that quota/credit is exhausted and that
+retrying will not help. A throttling 429 keeps the existing throttling wording.
+
+**AC6 — Regression coverage.**
+Tests cover: quota 429, throttling 429, bare 429 (no body code), 5xx, 400, and
+network-transient errors.
+
+### Boundary cases (explicitly decided)
+
+| Input | Decision | Rationale |
+| --- | --- | --- |
+| 429, no parseable body / no code | **Retryable** (unchanged) | Conservative default; only a positively identified terminal code changes behavior. |
+| 429, code `insufficient_quota` | **Terminal** | Named in the issue. Documented OpenAI billing-exhaustion code. |
+| 429, code `billing_hard_limit_reached` | **Terminal** | Documented OpenAI billing-exhaustion code; identical user action. |
+| 429, code `rate_limit_exceeded` | **Retryable** | Named in the issue. |
+| 429, unrecognized code | **Retryable** | Conservative default. |
+| `Retry-After` absent or unparseable | Fixed exponential backoff + jitter (unchanged) | Preserves current behavior. |
+| `Retry-After` present on a 5xx | Honored by the shared delay helper | Existing `getDelayDuration` semantics; no new branch. |
+| Terminal quota error | No dump behavior change beyond AC4 | Dump fires once on the terminal failure, not per attempt. |
+| Non-429 statuses (400, 5xx) | Unchanged classification | Out of scope to alter. |
+
+### Explicitly out of scope
+
+- The statelessness of the Responses path (#3134).
+- The randomized synthetic `call_id` (#3131).
+- Unifying retry/recovery/failover budgets (#2532).
+- Chat-Completions transport retry classification.
+- WebSocket transport error dumps.
+- Any change to `packages/core/src/utils/retry.ts` classification.
+
+## Design
+
+### D1 — Terminal-quota predicate (new internal module)
+
+`packages/providers/src/utils/quotaExhaustion.ts`
+
+```
+export function isQuotaExhaustionError(error: unknown): boolean
+```
+
+Returns `true` only when the error is a 429 **and** an OpenAI error code/type
+in the terminal set is found at `error.code`, `error.error.code`,
+`error.error.type`, or `error.type`. Terminal set: `insufficient_quota`,
+`billing_hard_limit_reached`.
+
+Not exported from `packages/providers/src/index.ts`. Internal helper, consumed
+by exactly two call sites.
+
+### D2 — `parseErrorResponse` enrichment
+
+`packages/providers/src/openai/responsesErrorParsing.ts`
+
+- New optional 4th parameter `headers?: Record<string, string>` (lowercase keys).
+- Attach `(error as ...).response = { status, headers, body }` where `body` is
+  the raw response text. This is the single seam that makes both `Retry-After`
+  and the error-response dump payload available downstream.
+- 429 prefix becomes code-aware:
+  - terminal quota code → `Quota exhausted` prefix plus a trailing clause
+    stating retrying will not help and that quota/billing must be resolved.
+  - otherwise → `Rate limit exceeded` (unchanged).
+- All other statuses unchanged.
+
+`getErrorStatus` already prefers `error.status`, so adding `response.status`
+does not change status resolution.
+
+### D3 — `throwApiError` passes headers
+
+`openAIResponsesHttpStream.ts` converts `response.headers` to a lowercase-keyed
+plain record and passes it to `parseErrorResponse`.
+
+### D4 — Inner-loop classification and delay
+
+- `OpenAIResponsesProviderBase.shouldRetryOnError`: for status 429, return
+  `false` when `isQuotaExhaustionError(error)`; otherwise unchanged.
+- `handleStreamRetry`: replace the inline jitter computation with the existing
+  `getDelayDuration(error, currentDelay)` from `retryDelayPolicy.ts` (honors
+  `Retry-After`, caps at 5 minutes, falls back to jittered backoff). When
+  `hasRetryAfterHeader(error)` is true, reset the next delay to the initial
+  delay rather than doubling — matching `RetryOrchestrator` semantics.
+
+### D5 — Outer-loop classification
+
+`retryDelayPolicy.shouldRetryError`: in the existing `status === 429` branch,
+return `false` when `isQuotaExhaustionError(error)`. Required for AC1
+end-to-end; without it the orchestrator re-retries the terminal error.
+
+### D6 — Error-response dump
+
+- `dumpFinalizedRequest` returns the request dump `baseId` (or `undefined`).
+- `baseId` and the resolved `dumpMode` are threaded into `StreamResponsesParams`.
+- `streamOverHttp` wraps its delegation to `fetchStreamWithRetries` in
+  `try/catch`. On a thrown error, when `shouldDumpSDKContext(dumpMode, true)`:
+  - if a request `baseId` exists → `dumpSDKResponseContext(baseId, provider, payload, true)`
+  - otherwise → `dumpSDKErrorRequestResponse(provider, '/responses', request, payload, baseURL)`
+  Then rethrow. Best-effort: a dump failure must never mask the API error.
+- Dump payload: `{ status, headers, body }` extracted from `error.response`, or
+  `{ error: String(error) }` for non-HTTP failures.
+- Response headers are redacted for `set-cookie` and `authorization` before
+  being written, because this path newly writes response headers to a
+  user-shareable file.
+- Fires once per turn on the terminal failure, not once per retry attempt.
+
+## Test plan (RED first)
+
+All tests use `bun:test`.
+
+### T1 — `packages/providers/src/utils/quotaExhaustion.test.ts` (new)
+- 429 + `{"error":{"code":"insufficient_quota"}}` → `true`
+- 429 + `{"error":{"type":"insufficient_quota"}}` → `true`
+- 429 + `{"error":{"code":"billing_hard_limit_reached"}}` → `true`
+- 429 + `{"error":{"code":"rate_limit_exceeded"}}` → `false`
+- 429 + no code → `false`
+- 402/500 + `insufficient_quota` → `false` (status gate)
+- non-object / `undefined` → `false`
+
+### T2 — `packages/providers/src/openai/parseResponsesStream.test.ts` (extend)
+- quota 429 message contains quota-exhaustion wording and states retrying will
+  not help; does **not** read as plain throttling.
+- throttling 429 message keeps `Rate limit exceeded` wording.
+- `error.response.headers['retry-after']` is populated when headers are passed.
+- `error.response.body` holds the raw body text.
+- existing assertions unchanged.
+
+### T3 — `packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.retryClassification.test.ts` (new)
+
+Behavioral, driven through the real provider with a stubbed `fetch`:
+- 429 `insufficient_quota` → exactly **1** fetch call; rejects with the
+  quota-exhaustion message. (AC1)
+- 429 `rate_limit_exceeded` → more than one fetch call, then succeeds. (AC2)
+- 429 `rate_limit_exceeded` with `Retry-After: 1` → the observed inter-attempt
+  wait tracks the header rather than the configured `retrywait`. (AC2)
+- 429 with no body code → still retried. (boundary)
+- 500 → still retried. (AC6)
+- `TypeError('fetch failed')` → still retried. (AC6)
+- 400 → not retried. (AC6)
+
+### T4 — `packages/providers/src/retryDelayPolicy` coverage (extend or new)
+- `shouldRetryError` returns `false` for a quota-exhaustion 429 and `true` for
+  a throttling 429, a bare 429, and a 5xx. (AC1/AC6)
+
+### T5 — Error-response dump (new test alongside the executor tests)
+- With `dumpcontext: 'on'` and a non-2xx Responses reply, a response dump is
+  written containing the status and the raw error body, linked to the request
+  dump. (AC4)
+- With `dumpcontext: 'error'`, both a request and a linked error-response dump
+  are written. (AC4)
+- With `dumpcontext: 'off'`, no dump is written.
+- A dump failure does not change the error surfaced to the caller.
+- `set-cookie` / `authorization` response headers are not present in the dump.
+
+## Files changed
+
+| File | Change |
+| --- | --- |
+| `packages/providers/src/utils/quotaExhaustion.ts` | new — terminal-quota predicate |
+| `packages/providers/src/utils/quotaExhaustion.test.ts` | new — T1 |
+| `packages/providers/src/openai/responsesErrorParsing.ts` | headers/body attachment, code-aware 429 prefix |
+| `packages/providers/src/openai/parseResponsesStream.test.ts` | T2 |
+| `packages/providers/src/openai-responses/OpenAIResponsesProviderBase.ts` | 429 body classification |
+| `packages/providers/src/openai-responses/openAIResponsesHttpStream.ts` | pass headers, `getDelayDuration`, error dump |
+| `packages/providers/src/openai-responses/openAIResponsesExecutor.ts` | return/thread dump `baseId` + `dumpMode` |
+| `packages/providers/src/retryDelayPolicy.ts` | outer-loop 429 classification |
+| `packages/providers/src/retryDelayPolicy.test.ts` (or existing) | T4 |
+| `packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.retryClassification.test.ts` | new — T3 |
+| `packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts` | new — T5 |
+
+## Policy invariance
+
+- No new `eslint-disable*`, `@ts-ignore`, `@ts-expect-error`, `@ts-nocheck`.
+- No ESLint severity downgrades, no `ignores:` additions.
+- No increase to any complexity or size threshold (`max-lines` 800,
+  `max-lines-per-function` 80, `complexity` 25, `sonarjs/cognitive-complexity` 30).
+- New tests use Bun + `bun:test`. No Vitest/Node test suites added or modified.
+- Fix the underlying cause; never silence a rule.
+
+## Review triage
+
+Reviews performed: one architecture review and one Open Code Review, both on
+the full staged change. Every finding was classified.
+
+### Blocker — fixed
+
+| ID | Finding | Resolution |
+| --- | --- | --- |
+| B1 | Lifting the body's `type` onto the thrown `Error` collided with the key `isOverloadError` reads, making a Responses 403/404 carrying `type: api_error` retryable and reversing the "403 is never retried" invariant (#2917). | Renamed to `providerErrorType`; `findTerminalQuotaCode` reads that position. Two regression tests added, both proven to fail when the rename is reverted. |
+| B2 | The error-dump test wrote to and blanket-deleted from the real user cache directory, leaking full-prompt request files. | Sandboxed `LLXPRT_CONFIG_HOME` to a per-pid tmpdir before `Storage.getGlobalCacheDir()` is evaluated, matching `dumpContext.test.ts`; the sandbox is removed in `afterAll`. |
+
+### In-scope — fixed
+
+| ID | Finding | Resolution |
+| --- | --- | --- |
+| F1 | `\|\| isNetworkTransientError(error)` let message-substring heuristics re-open a terminal classification (provider prose "account terminated" matches the transient phrase "terminated"). | A definite HTTP status is now authoritative; the heuristic applies only when no status is present. |
+| F2 | The Codex/ChatGPT backend wraps errors in a `detail` envelope the classifier did not read. | Added `detail.code` / `detail.type` as structural positions. No speculative code strings were added — see "Known limitation". |
+| F3 | `billing_hard_limit_reached` is returned as HTTP 400, so the quota wording never fired for it. | The quota prefix is now selected by error code rather than status. The retry gate stays at 429. |
+| F4a / OCR-3 | Two divergent implementations of the code/type position walk. | `quotaExhaustion.ts` owns the position list; `responsesErrorParsing.ts` reads the same set. |
+| F4b / OCR-4 | Response-header redaction disagreed with request-header redaction. | Single `redactSensitiveHeaders` in `dumpContext.ts` covering `authorization`, `proxy-authorization`, `x-api-key`, `api-key`, `cookie`, `set-cookie`, used by both. |
+| F5 | `dumpFinalizedRequest` hand-rolled best-effort handling. | Uses the shared `bestEffortDump`. |
+| F6 | Redundant non-object guard in `isQuotaExhaustionError`. | Removed; `getErrorStatus` already covers it. |
+| F7 | No test proved AC1 through the outer `RetryOrchestrator`. | Added `RetryOrchestrator.quotaExhaustion.test.ts`, proven to fail when the outer-layer fix is removed. |
+| F8 | The "dump failure does not mask the error" test exercised the success path. | Now induces a real `fs.mkdir` failure and asserts the original error survives verbatim. |
+| F9 / OCR-2 | The Retry-After test had no lower bound; the dump test never asserted `retry-after` survived redaction. | Added both assertions. |
+| OCR-1 | `shouldRetryOnError` JSDoc still claimed all 429s are retried. | Updated. |
+
+### Deferred (out of scope for this issue)
+
+- Bucket failover may still fire on a terminal quota 429 when a throttling 429
+  preceded it in the same turn. Arguably correct — a different bucket has a
+  different quota — and it belongs to #2532's territory.
+- `response.body` retains the raw body uncapped; the dump needs it in full, so a
+  retention cap is a separate design question.
+- A quota 429 still carries the structured category `rate_limit` rather than
+  `quota`; no user-facing text derives from the category.
+- Successful responses are still not dumped on the Responses path. AC4 is scoped
+  to error responses.
+- Neither `getRetryAfterDelayMs` implementation reads OpenAI's `retry-after-ms`.
+
+## Known limitation
+
+The incident that motivated this issue came from the Codex backend, and the
+issue marks the specific error code **UNVERIFIED** because no error-response
+dump existed to capture it. This change reads the `detail` envelope the Codex
+backend uses, but only for the two documented OpenAI terminal codes. If Codex
+reports exhaustion under a different code string, that case remains retryable —
+deliberately, because misclassifying a throttle as terminal fails a recoverable
+turn, whereas missing a quota code merely preserves today's behavior. The
+error-response dump added here (AC4) is what makes the real body observable so
+the code can be confirmed and added.
+
+## Verification
+
+```
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```

--- a/project-plans/issue3140/PLAN.md
+++ b/project-plans/issue3140/PLAN.md
@@ -260,6 +260,27 @@ the full staged change. Every finding was classified.
 | F9 / OCR-2 | The Retry-After test had no lower bound; the dump test never asserted `retry-after` survived redaction. | Added both assertions. |
 | OCR-1 | `shouldRetryOnError` JSDoc still claimed all 429s are retried. | Updated. |
 
+### Second review round (PR)
+
+| Source | Finding | Resolution |
+| --- | --- | --- |
+| CodeRabbit | Quota wording fired on a 5xx echoing a terminal code, claiming "retrying will not help" while both layers correctly retry it. | Gated on the 4xx range rather than an explicit `400 \|\| 429` list — the invariant that matters is "only say retrying will not help when it genuinely will not be retried". Regression test added and verified load-bearing. |
+| CodeRabbit | `x-goog-api-key` was not redacted. | Added, plus coverage of every name in the set including a mixed-case form and a blanket "no secret substring" assertion. |
+| OCR (×2) | The dump test mutated `process.env` at module scope, so the override was live from import until `afterAll`. | Moved to `beforeEach` with a fresh `mkdtemp` per test, following `liveness.test.ts`. Starting from an empty directory also let the snapshot/diff helpers and the blanket `afterEach` delete go away. |
+
+### CI-unblocking fix (outside issue scope)
+
+`packages/agents` shard failed on `PROP setModel: for any non-empty model
+string`. The property generates with `fc.string({ minLength: 1 })`, which is
+non-empty by *length* and so includes whitespace-only strings, while
+`resolveModelForSystemPrompt` (added by #3141 for issue #3138, merged to main
+immediately before this branch rebased) fails fast when `config.getModel()`
+trims to empty. The two contracts disagree, so the property fails whenever the
+generator emits a blank string — seed-dependent, which is why the same code
+passed on the previous head. Reproduced deterministically by pinning the
+generator to `fc.constant(' ')`, which yields the identical error. Fixed by
+filtering blanks from the generator.
+
 ### Deferred (out of scope for this issue)
 
 - Bucket failover may still fire on a terminal quota 429 when a throttling 429


### PR DESCRIPTION
## TLDR

HTTP 429 was treated as unconditionally retryable on the OpenAI Responses path. That one status covers two conditions with opposite correct handling — transient throttling, where backoff works, and quota or credit exhaustion, where no number of retries can succeed. Because the Responses path is stateless, every attempt resends the entire conversation, so misclassifying the second case multiplied the cost of a turn that was always going to fail. The captured Codex incident produced **nine** full-prompt requests of 1,128,412 bytes each, ~9.7 MB, all failing.

This PR classifies the two apart by reading the error body, closes **both** retry layers so a terminal quota 429 issues exactly one request, honors `Retry-After` for genuine throttling, and fixes the observability gap that made the incident undiagnosable: the request was dumped but the failure body never was.

Reviewers should look hardest at two things:

1. **`providerErrorType`, not `type`.** The obvious way to expose the body-level error type is to write `error.type`. That is a trap. `isOverloadError` in `packages/core/src/utils/retry.ts` reads a bare `type` and treats `api_error` / `rate_limit_error` / `overloaded_error` as retryable, so a plain `type` would have silently made a Responses **403** retryable and reversed the deliberate "403 is never retried" invariant from #2917 / #3012. Two regression tests guard this, and both were verified to fail when the rename is reverted.
2. **Both retry layers.** Fixing only the provider classifier is not enough — `RetryOrchestrator` runs its own loop on top and would re-retry the terminal error. `RetryOrchestrator.quotaExhaustion.test.ts` proves the end-to-end claim and was verified to fail when the outer-layer change is removed.

## Dive Deeper

### What was wrong

| Location | Behavior before |
| --- | --- |
| `OpenAIResponsesProviderBase.shouldRetryOnError` | `true` for any 429; body never consulted. |
| `retryDelayPolicy.shouldRetryError` (used by `RetryOrchestrator`) | `true` for any 429; body never consulted. |
| `responsesErrorParsing.parseErrorResponse` | Attached `status` and `code` only — no response headers, so `Retry-After` was invisible to every retry layer, and no raw body. |
| `openAIResponsesHttpStream.throwApiError` | Discarded `response.headers` entirely. |
| `openAIResponsesHttpStream.handleStreamRetry` | Fixed exponential backoff; `Retry-After` never consulted. |
| `openAIResponsesExecutor.dumpFinalizedRequest` | Dumped the request only. No error-response dump existed anywhere on the Responses path. |

Net effect: a terminal 429 was retried by the inner stream loop *and* again by the orchestrator, at full prompt cost per attempt, with no captured evidence of why.

### What changed

**Classification (`packages/providers/src/utils/quotaExhaustion.ts`, new).** `isQuotaExhaustionError` returns true only when the status is 429 **and** a terminal code is found. Terminal set: `insufficient_quota`, `billing_hard_limit_reached`. Positions inspected: top level, the standard OpenAI `error` envelope, the Codex/ChatGPT-backend `detail` envelope, and `providerErrorType`. Consulted by exactly two production call sites — the inner loop and the outer orchestrator. Not exported from the package index.

**Error seam (`responsesErrorParsing.ts`).** `parseErrorResponse` takes optional lowercase-keyed response headers and attaches `response = { status, headers, body }`. This single seam is what makes `Retry-After` reachable by both retry layers and supplies the raw body to the dump. Worth noting: the orchestrator already had `Retry-After` support, but it was **dead** on this path because Responses errors carried no headers at all.

**Retry delay.** `handleStreamRetry` now uses the existing shared `getDelayDuration`, which honors `Retry-After`, caps it at 5 minutes, and otherwise falls back to the same jittered backoff as before. When `Retry-After` was used, the next delay resets to the initial delay instead of doubling, matching `RetryOrchestrator` and core `retryWithBackoff`. The 30s backoff ceiling is unchanged.

**Fail-fast over heuristics.** `handleStreamRetry` previously did `shouldRetryOnError(error) || isNetworkTransientError(error)`, so message-substring heuristics could re-open a classification that had already been made — the transient phrase list contains the bare token `terminated`, so provider prose such as "account terminated for non-payment" would have defeated the fix. A definite HTTP status is now authoritative; the heuristic applies only when no status is present.

**User-facing message.** A terminal quota code yields `Quota or billing limit exhausted: <message>. Retrying will not help — resolve your quota or billing limits`. Throttling keeps the existing byte-exact `Rate limit exceeded: <message>`. The quota prefix is selected by code rather than status because OpenAI returns `billing_hard_limit_reached` as a **400** and `insufficient_quota` as a **429**; both need the same user action. The retry gate stays at 429.

**Error-response dump.** `streamOverHttp` now writes one dump on the terminal failure — deliberately **once per turn, not once per attempt**, since per-attempt cost is the entire point of the issue. It links to the request dump's base id when one exists (`dumpcontext on`) and writes a fresh linked pair when none does (`dumpcontext off`→`error`). It is best-effort: a dump failure cannot mask or alter the API error, which is now proven by inducing a real `fs.mkdir` failure. User cancellation is excluded so pressing ESC does not write a full-prompt file. Header redaction was consolidated into one `redactSensitiveHeaders` in `dumpContext.ts` covering `authorization`, `proxy-authorization`, `x-api-key`, `api-key`, `cookie`, and `set-cookie` — previously requests and responses had two disagreeing allowlists.

### Boundary cases, decided explicitly

| Input | Decision | Why |
| --- | --- | --- |
| 429, no parseable body or no code | **Retryable** (unchanged) | Only a positively identified terminal code changes behavior. |
| 429, unrecognized code | **Retryable** | Misclassifying a throttle as terminal fails a recoverable turn; missing a quota code merely preserves today's behavior. The asymmetry drives the conservative default. |
| 400 `billing_hard_limit_reached` | Retry unchanged (400 was already terminal); message now says quota | Same user action as the 429 case. |
| `Retry-After` absent, unparseable, negative, or past-dated | Jittered exponential backoff (unchanged) | |
| Non-429 statuses | Classification unchanged | Out of scope. |

### Known limitation, stated plainly

The incident came from the Codex backend, and the issue marks the specific error code **UNVERIFIED** because no error-response dump existed to capture it. This PR reads the `detail` envelope the Codex backend uses, but only for the two documented OpenAI terminal codes. If Codex reports exhaustion under a different code string, that case remains retryable — deliberately, per the asymmetry above. **The error-response dump added here is precisely what makes the real body observable so the code can be confirmed and added in a follow-up.**

### Explicitly out of scope

Statelessness of the Responses path (#3134), the randomized synthetic `call_id` (#3131), unifying retry budgets (#2532), Chat-Completions transport classification, and WebSocket transport error dumps. Deferred findings from review are recorded in `project-plans/issue3140/PLAN.md`.

### Review record

Two independent reviews were run (architecture + Open Code Review) and every finding was classified Blocker / In-scope-Fix / Reject / Defer. Both blockers and all eleven in-scope fixes are resolved; the full triage table is in `project-plans/issue3140/PLAN.md`. The second blocker is worth calling out because it was destructive: the error-dump test originally wrote to and blanket-deleted from the **real user cache directory**, leaking full-prompt request files. It now sandboxes `LLXPRT_CONFIG_HOME` to a per-pid tmpdir before `Storage.getGlobalCacheDir()` is evaluated, matching the sibling `dumpContext.test.ts`.

## Reviewer Test Plan

All tests are behavioral: they drive the real executor, the real `parseErrorResponse`, the real SSE parser, and a real `RetryOrchestrator`, faking only `globalThis.fetch`. Assertions are on observable outcomes — number of fetch calls, the error surfaced, files written, and inter-attempt wait duration.

```bash
npm run test --workspace @vybestack/llxprt-code-providers
```

**Confirm the guards are load-bearing** (each should turn red):

```bash
# 1. Revert the property rename -> the two 403 api_error regression tests fail
#    in responsesErrorParsing.ts change `enriched.providerErrorType = type`
#    back to `enriched.type = type`

# 2. Delete the outer-layer line in retryDelayPolicy.shouldRetryError
#    -> RetryOrchestrator.quotaExhaustion.test.ts fails
sed -i '' '/if (isQuotaExhaustionError(error)) return false;/d' \
  packages/providers/src/retryDelayPolicy.ts
```

**Exercise by hand.** Point a Responses-capable provider at a mock returning `429` with `{"error":{"code":"insufficient_quota","message":"..."}}` and confirm one request is issued and the message reads as quota exhaustion, then swap the code to `rate_limit_exceeded` with `Retry-After: 2` and confirm it retries after ~2s rather than the configured `retrywait`. With `/dumpcontext on`, confirm a paired `-request.json` / `-response.json` now appears in the dumps directory with the failure body and a redacted header block.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test`, `npm run lint`, `npm run lint:eslint-guard`, `npm run typecheck`, `npm run format`, `npm run build`, and the `stepfun-37` runtime smoke test all pass. The change is pure TypeScript with no platform-specific code paths.

## Linked issues / bugs

Fixes #3140

Context (not changed by this PR): #3134, #3131, #2532. Guards the invariant from #2917.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Quota and billing-limit errors now stop immediately instead of triggering repeated retries.
  - Throttling, temporary server errors, and transient network failures continue to retry as expected.
  - Error messages now more clearly identify quota exhaustion and preserve relevant response details.
  - Retry timing honors `Retry-After` guidance with more predictable backoff behavior.
  - Request and response diagnostics now capture failed requests more reliably, while sensitive headers are redacted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->