### PR TITLE
Expand pasted blocks before steering (Fixes #3158)

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.paste.spec.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.paste.spec.tsx
@@ -554,4 +554,452 @@ describe('InputPrompt paste functionality', () => {
       'pasted text from mouse',
     );
   });
+
+  it('should expand a single large paste before steering', async () => {
+    const mockDispatch = vi.fn();
+    const mockOnSteer = vi.fn(() => true);
+
+    const multiLineContent = 'Line 1\nLine 2\nLine 3\nLine 4';
+
+    render(
+      <AppDispatchProvider value={mockDispatch}>
+        <InputPrompt
+          buffer={mockBuffer}
+          onSubmit={mockOnSubmit}
+          onSteer={mockOnSteer}
+          userMessages={[]}
+          onClearScreen={mockOnClearScreen}
+          config={mockConfig}
+          slashCommands={[]}
+          commandContext={{} as unknown as CommandContext}
+          placeholder="Type a message..."
+          focus={true}
+          inputWidth={80}
+          suggestionsWidth={0}
+          shellModeActive={false}
+          setShellModeActive={mockSetShellModeActive}
+        />
+      </AppDispatchProvider>,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await sendKey({
+      name: 'paste',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      sequence: multiLineContent,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await sendKey({
+      name: 'return',
+      ctrl: true,
+      meta: false,
+      shift: false,
+      sequence: '\r',
+    });
+
+    expect(mockOnSteer).toHaveBeenCalledWith(multiLineContent);
+  });
+
+  it('should steer original content for a single-line 1000-code-point paste', async () => {
+    const mockDispatch = vi.fn();
+    const mockOnSteer = vi.fn(() => true);
+
+    // Exactly 1000 Unicode code points (998 ASCII + 2 astral-plane emoji).
+    // This crosses LARGE_PASTE_CHAR_THRESHOLD while staying on one line, so
+    // the buffer shows the character-count placeholder form rather than the
+    // line-count form.
+    const singleLinePaste = 'a'.repeat(998) + '\u{1F600}' + '\u{1F601}';
+
+    render(
+      <AppDispatchProvider value={mockDispatch}>
+        <InputPrompt
+          buffer={mockBuffer}
+          onSubmit={mockOnSubmit}
+          onSteer={mockOnSteer}
+          userMessages={[]}
+          onClearScreen={mockOnClearScreen}
+          config={mockConfig}
+          slashCommands={[]}
+          commandContext={{} as unknown as CommandContext}
+          placeholder="Type a message..."
+          focus={true}
+          inputWidth={80}
+          suggestionsWidth={0}
+          shellModeActive={false}
+          setShellModeActive={mockSetShellModeActive}
+        />
+      </AppDispatchProvider>,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await sendKey({
+      name: 'paste',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      sequence: singleLinePaste,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Single-line paste at the char threshold produces the character-count
+    // placeholder form, not the line-count form.
+    expect(mockBuffer.text).toMatch(/\[1000 characters pasted #\d+\]/);
+
+    await sendKey({
+      name: 'return',
+      ctrl: true,
+      meta: false,
+      shift: false,
+      sequence: '\r',
+    });
+
+    // onSteer receives the exact original content, not the display label.
+    expect(mockOnSteer).toHaveBeenCalledWith(singleLinePaste);
+  });
+
+  it('should preserve surrounding text when steering a large paste', async () => {
+    const mockDispatch = vi.fn();
+    const mockOnSteer = vi.fn(() => true);
+
+    const pasteContent = 'Pasted 1\nPasted 2\nPasted 3\nPasted 4';
+
+    render(
+      <AppDispatchProvider value={mockDispatch}>
+        <InputPrompt
+          buffer={mockBuffer}
+          onSubmit={mockOnSubmit}
+          onSteer={mockOnSteer}
+          userMessages={[]}
+          onClearScreen={mockOnClearScreen}
+          config={mockConfig}
+          slashCommands={[]}
+          commandContext={{} as unknown as CommandContext}
+          placeholder="Type a message..."
+          focus={true}
+          inputWidth={80}
+          suggestionsWidth={0}
+          shellModeActive={false}
+          setShellModeActive={mockSetShellModeActive}
+        />
+      </AppDispatchProvider>,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await sendKey({
+      name: 'paste',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      sequence: pasteContent,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    mockBuffer.text = `before ${mockBuffer.text} after`;
+    mockBuffer.lines = mockBuffer.text.split('\n');
+
+    await sendKey({
+      name: 'return',
+      ctrl: true,
+      meta: false,
+      shift: false,
+      sequence: '\r',
+    });
+
+    expect(mockOnSteer).toHaveBeenCalledWith(`before ${pasteContent} after`);
+  });
+
+  it('should expand multiple large pastes in order before steering', async () => {
+    const mockDispatch = vi.fn();
+    const mockOnSteer = vi.fn(() => true);
+
+    const firstPaste =
+      'Block 1 line 1\nBlock 1 line 2\nBlock 1 line 3\nBlock 1 line 4';
+    const secondPaste =
+      'Block 2 line 1\nBlock 2 line 2\nBlock 2 line 3\nBlock 2 line 4';
+
+    render(
+      <AppDispatchProvider value={mockDispatch}>
+        <InputPrompt
+          buffer={mockBuffer}
+          onSubmit={mockOnSubmit}
+          onSteer={mockOnSteer}
+          userMessages={[]}
+          onClearScreen={mockOnClearScreen}
+          config={mockConfig}
+          slashCommands={[]}
+          commandContext={{} as unknown as CommandContext}
+          placeholder="Type a message..."
+          focus={true}
+          inputWidth={80}
+          suggestionsWidth={0}
+          shellModeActive={false}
+          setShellModeActive={mockSetShellModeActive}
+        />
+      </AppDispatchProvider>,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await sendKey({
+      name: 'paste',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      sequence: firstPaste,
+    });
+
+    await sendKey({
+      name: 'paste',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      sequence: secondPaste,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await sendKey({
+      name: 'return',
+      ctrl: true,
+      meta: false,
+      shift: false,
+      sequence: '\r',
+    });
+
+    expect(mockOnSteer).toHaveBeenCalledWith(firstPaste + secondPaste);
+  });
+
+  it('should keep paste state usable when steer is declined then submit full paste', async () => {
+    const mockDispatch = vi.fn();
+    const mockOnSteer = vi.fn(() => false);
+
+    const multiLineContent = 'Line 1\nLine 2\nLine 3\nLine 4';
+
+    render(
+      <AppDispatchProvider value={mockDispatch}>
+        <InputPrompt
+          buffer={mockBuffer}
+          onSubmit={mockOnSubmit}
+          onSteer={mockOnSteer}
+          userMessages={[]}
+          onClearScreen={mockOnClearScreen}
+          config={mockConfig}
+          slashCommands={[]}
+          commandContext={{} as unknown as CommandContext}
+          placeholder="Type a message..."
+          focus={true}
+          inputWidth={80}
+          suggestionsWidth={0}
+          shellModeActive={false}
+          setShellModeActive={mockSetShellModeActive}
+        />
+      </AppDispatchProvider>,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await sendKey({
+      name: 'paste',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      sequence: multiLineContent,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Model the production newline behaviour in the declined scenario only:
+    // after the paste the cursor sits at the end of the placeholder, so
+    // newline appends \n and advances the cursor one row — matching what a
+    // real buffer would show after Ctrl+Enter falls through from declined steer.
+    (
+      mockBuffer.newline as unknown as Mock<(...args: never[]) => unknown>
+    ).mockImplementation(() => {
+      mockBuffer.text += '\n';
+      mockBuffer.lines = mockBuffer.text.split('\n');
+      mockBuffer.cursor = [mockBuffer.cursor[0] + 1, 0];
+    });
+
+    await sendKey({
+      name: 'return',
+      ctrl: true,
+      meta: false,
+      shift: false,
+      sequence: '\r',
+    });
+
+    // Steer receives the expanded multi-line content even though it declines.
+    expect(mockOnSteer).toHaveBeenCalledWith(multiLineContent);
+
+    // Declined steer falls through to NEWLINE: the buffer now holds the
+    // tracked placeholder followed by the inserted newline and was not cleared.
+    expect(mockBuffer.text).toMatch(/\[4 lines pasted #\d+\]\n$/);
+    expect(mockBuffer.text).not.toBe('');
+
+    await sendKey({
+      name: 'return',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      sequence: '\r',
+    });
+
+    // Normal Enter trims the fallback newline before expansion, so the
+    // original full paste content is submitted.
+    expect(mockOnSubmit).toHaveBeenCalledWith(multiLineContent);
+  });
+
+  it('should pass plain text unchanged when steering', async () => {
+    const mockDispatch = vi.fn();
+    const mockOnSteer = vi.fn(() => true);
+
+    render(
+      <AppDispatchProvider value={mockDispatch}>
+        <InputPrompt
+          buffer={mockBuffer}
+          onSubmit={mockOnSubmit}
+          onSteer={mockOnSteer}
+          userMessages={[]}
+          onClearScreen={mockOnClearScreen}
+          config={mockConfig}
+          slashCommands={[]}
+          commandContext={{} as unknown as CommandContext}
+          placeholder="Type a message..."
+          focus={true}
+          inputWidth={80}
+          suggestionsWidth={0}
+          shellModeActive={false}
+          setShellModeActive={mockSetShellModeActive}
+        />
+      </AppDispatchProvider>,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    mockBuffer.text = 'just plain text';
+    mockBuffer.lines = ['just plain text'];
+
+    await sendKey({
+      name: 'return',
+      ctrl: true,
+      meta: false,
+      shift: false,
+      sequence: '\r',
+    });
+
+    expect(mockOnSteer).toHaveBeenCalledWith('just plain text');
+  });
+
+  it('should steer exact unchanged content after a sub-threshold paste', async () => {
+    const mockDispatch = vi.fn();
+    const mockOnSteer = vi.fn(() => true);
+
+    // Sub-threshold: single line, well under the 4-line/1000-char limits.
+    // No placeholder is created — the sequence flows through handleInput.
+    const pasteContent = 'sub threshold single line paste';
+
+    render(
+      <AppDispatchProvider value={mockDispatch}>
+        <InputPrompt
+          buffer={mockBuffer}
+          onSubmit={mockOnSubmit}
+          onSteer={mockOnSteer}
+          userMessages={[]}
+          onClearScreen={mockOnClearScreen}
+          config={mockConfig}
+          slashCommands={[]}
+          commandContext={{} as unknown as CommandContext}
+          placeholder="Type a message..."
+          focus={true}
+          inputWidth={80}
+          suggestionsWidth={0}
+          shellModeActive={false}
+          setShellModeActive={mockSetShellModeActive}
+        />
+      </AppDispatchProvider>,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Give the fake handleInput enough behavior to place the pasted
+    // sequence into observable buffer state (sub-threshold pastes bypass
+    // the placeholder mechanism and delegate to buffer.handleInput).
+    (
+      mockBuffer.handleInput as unknown as Mock<(...args: never[]) => unknown>
+    ).mockImplementation((key: { sequence: string }) => {
+      mockBuffer.text += key.sequence;
+      mockBuffer.lines = mockBuffer.text.split('\n');
+    });
+
+    await sendKey({
+      name: 'paste',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      sequence: pasteContent,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await sendKey({
+      name: 'return',
+      ctrl: true,
+      meta: false,
+      shift: false,
+      sequence: '\r',
+    });
+
+    expect(mockOnSteer).toHaveBeenCalledWith(pasteContent);
+  });
+
+  it('should steer all queued submissions on Ctrl+Enter with empty buffer', async () => {
+    const mockDispatch = vi.fn();
+    const mockOnSteer = vi.fn(() => true);
+    const mockSteerAllQueuedSubmissions = vi.fn();
+
+    render(
+      <AppDispatchProvider value={mockDispatch}>
+        <InputPrompt
+          buffer={mockBuffer}
+          onSubmit={mockOnSubmit}
+          onSteer={mockOnSteer}
+          userMessages={[]}
+          onClearScreen={mockOnClearScreen}
+          config={mockConfig}
+          slashCommands={[]}
+          commandContext={{} as unknown as CommandContext}
+          placeholder="Type a message..."
+          focus={true}
+          inputWidth={80}
+          suggestionsWidth={0}
+          shellModeActive={false}
+          setShellModeActive={mockSetShellModeActive}
+          queuedSubmissionCount={3}
+          steerAllQueuedSubmissions={mockSteerAllQueuedSubmissions}
+        />
+      </AppDispatchProvider>,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await sendKey({
+      name: 'return',
+      ctrl: true,
+      meta: false,
+      shift: false,
+      sequence: '\r',
+    });
+
+    expect(mockSteerAllQueuedSubmissions).toHaveBeenCalled();
+    expect(mockOnSteer).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/ui/components/inputPromptHooks.ts
+++ b/packages/cli/src/ui/components/inputPromptHooks.ts
@@ -24,7 +24,10 @@ import {
 import { isSlashCommand } from '../utils/commandUtils.js';
 import type { InputHandlerDeps } from './inputPromptKeyHandlers.js';
 import { handleInputKey } from './inputPromptKeyHandlers.js';
-import { insertPathReference } from './inputPromptText.js';
+import {
+  expandLargePastePlaceholders,
+  insertPathReference,
+} from './inputPromptText.js';
 import type {
   InputPromptProps,
   InputPromptRuntimeProps,
@@ -95,17 +98,10 @@ const useSubmitHandlers = (
 ) => {
   const handleSubmitAndClear = useCallback(
     (submittedValue: string) => {
-      let actualValue = submittedValue;
-      const pendingPastes = pendingLargePastesRef.current;
-      if (pendingPastes.size > 0) {
-        pendingPastes.forEach((actualContent, placeholderLabel) => {
-          if (actualValue.includes(placeholderLabel)) {
-            actualValue = actualValue
-              .split(placeholderLabel)
-              .join(actualContent);
-          }
-        });
-      }
+      const actualValue = expandLargePastePlaceholders(
+        submittedValue,
+        pendingLargePastesRef.current,
+      );
 
       if (shellModeActive) {
         shellHistory.addCommandToHistory(actualValue);

--- a/packages/cli/src/ui/components/inputPromptKeyHandlers.ts
+++ b/packages/cli/src/ui/components/inputPromptKeyHandlers.ts
@@ -13,7 +13,10 @@ import { Command, keyMatchers } from '../keyMatchers.js';
 import { isAutoExecutableCommand } from '../utils/commandUtils.js';
 import { cpSlice } from '../utils/textUtils.js';
 import type { Suggestion } from './SuggestionsDisplay.js';
-import { handleLargePaste } from './inputPromptText.js';
+import {
+  expandLargePastePlaceholders,
+  handleLargePaste,
+} from './inputPromptText.js';
 import { logicalPosToOffset } from './shared/buffer-operations.js';
 import type { TextBuffer } from './shared/text-buffer.js';
 import type React from 'react';
@@ -543,7 +546,12 @@ const handleSubmitAndEditKeys = (key: Key, deps: InputHandlerDeps): boolean => {
       resetCompletionState();
       return true;
     }
-    const consumed = deps.handleSteer(buffer.text);
+    const consumed = deps.handleSteer(
+      expandLargePastePlaceholders(
+        buffer.text,
+        deps.pendingLargePastesRef.current,
+      ),
+    );
     if (consumed) {
       buffer.setText('');
       resetCompletionState();

--- a/packages/cli/src/ui/components/inputPromptText.ts
+++ b/packages/cli/src/ui/components/inputPromptText.ts
@@ -198,6 +198,23 @@ export const insertPathReference = (
   buffer.replaceRangeByOffset(offset, offset, textToInsert);
 };
 
+/** Expand tracked large-paste placeholder labels back to their original content. */
+export const expandLargePastePlaceholders = (
+  text: string,
+  pendingPastes: ReadonlyMap<string, string>,
+): string => {
+  if (pendingPastes.size === 0) {
+    return text;
+  }
+  let result = text;
+  pendingPastes.forEach((actualContent, placeholderLabel) => {
+    if (result.includes(placeholderLabel)) {
+      result = result.split(placeholderLabel).join(actualContent);
+    }
+  });
+  return result;
+};
+
 /** Handle a large paste by inserting a placeholder into the buffer. */
 export const handleLargePaste = (
   key: Key,

--- a/project-plans/issue3158-paste-steering.md
+++ b/project-plans/issue3158-paste-steering.md
@@ -1,0 +1,52 @@
+# Issue 3158: Expand large pastes before steering
+
+## Problem
+
+The Ink input prompt replaces a large pasted block with a tracked display label such as `[4 lines pasted #1]`. Normal submission resolves tracked labels to their pasted content, but Ctrl+Enter steering currently passes the display label to `onSteer` unchanged.
+
+## Accepted behavior
+
+1. While an agent response is active, Ctrl+Enter sends the content represented by every tracked large-paste label rather than the labels themselves.
+2. Expansion preserves the exact position of surrounding typed text and the order of multiple pasted blocks.
+3. Text without a tracked large-paste label, including ordinary typed text and sub-threshold pastes, is sent unchanged.
+4. Expansion is read-only. If steering declines the input, the visible buffer and pending paste state remain usable, and a later normal submission still sends the full pasted content.
+5. Existing normal-submit expansion and empty-input queued-steering behavior remain unchanged.
+
+## Boundaries and non-goals
+
+- Queued submissions are already expanded by the normal submit path before they enter the queue; no queued-steering change is included.
+- Paste resolution remains an input-prompt concern; the agent steering hook and public props are unchanged.
+- No explicit second paste-state cleanup path is added. Existing pruning removes entries after a consumed steer clears the buffer.
+- Recursive or malformed placeholder hardening, adjacent refactors, dependencies, workflows, quality configuration, and public abstractions are out of scope.
+
+## Behavioral evidence
+
+Extend the existing Bun test `packages/cli/src/ui/components/InputPrompt.paste.spec.tsx` test-first:
+
+- A four-line paste followed by Ctrl+Enter reaches `onSteer` as the full four-line content, not a display label.
+- Surrounding typed text remains around the expanded paste.
+- Multiple tracked paste labels all expand in order.
+- A declined steer does not consume the placeholder state; normal Enter afterward submits the full paste.
+- Plain text reaches steering unchanged.
+
+The first three scenarios must fail before production code changes and pass afterward.
+
+## Minimal design
+
+Add a pure module-internal paste-expansion helper beside `handleLargePaste` in `inputPromptText.ts`. Use it both in the existing normal-submit path and immediately before the existing `handleSteer` call. The helper reads a `ReadonlyMap`, preserves the current split/join replacement semantics, and does not mutate paste state.
+
+## Expected implementation surface
+
+- `packages/cli/src/ui/components/inputPromptText.ts`
+- `packages/cli/src/ui/components/inputPromptKeyHandlers.ts`
+- `packages/cli/src/ui/components/inputPromptHooks.ts`
+- `packages/cli/src/ui/components/InputPrompt.paste.spec.tsx`
+
+## Verification
+
+1. Focused Bun test in RED and GREEN states.
+2. CLI package test suite.
+3. Full project gates: test, lint, typecheck, format, build.
+4. Stepfun smoke test.
+5. Scoped code reviews and Open Code Review, with every finding classified as Blocker-Fix, In-scope-Fix, Reject, or Defer.
+6. PR CI and review threads green on the candidate head, with correct ancestry and no merge conflict.


### PR DESCRIPTION
## TLDR

Expand tracked large-paste display labels before Ctrl+Enter steering so the active agent receives the exact pasted content instead of a literal label such as [4 lines pasted #1]. Normal submission, declined-steer state, plain text, and empty-buffer queued steering retain their existing behavior.

## Dive Deeper

- Add one pure paste-expansion helper at the existing input-text boundary and reuse it from normal submission and direct steering.
- Expand a copy of the buffer text before calling the existing steer handler; the visible placeholder and pending-paste state are not mutated.
- Preserve surrounding typed text, multiple paste order, and the exact 1000-Unicode-code-point character threshold behavior.
- Keep queued-steer production code and public APIs unchanged because queued submissions already pass through normal paste expansion.
- Add Bun behavioral coverage for accepted and declined steering, multiline and character-count placeholders, surrounding and multiple blocks, plain and sub-threshold text, and queued steering.

Local review findings were classified before push. All Blocker-Fix and In-scope-Fix findings were resolved. Recursive placeholder hardening and broad test-fixture refactoring were rejected as outside issue scope.

Candidate head verification after rebasing onto current main:

- Focused Bun paste suite: 14 passed, 0 failed.
- npm run lint: passed with persisted exit status 0.
- npm run typecheck: passed.
- npm run format: passed with no additional changes.
- npm run build: passed.
- Stepfun smoke test: passed and returned only a haiku.
- Real-TTY tmux harness: passed.
- Full npm run test passed every core, agents, CLI, and other workspace suite except two unchanged test-utils quota-timing cases. Both failures reproduced in isolation and are outside this PR's files; PR CI remains the candidate-head cross-platform gate.

## Reviewer Test Plan

1. Start an agent response that remains active long enough to steer.
2. Paste a block of at least four lines into the Ink prompt and confirm the compact paste label is displayed.
3. Press Ctrl+Enter and confirm the agent receives/responds to the original pasted lines rather than the display label.
4. Repeat with text before and after the paste to confirm ordering is preserved.
5. Run the focused regression suite:

    bun test packages/cli/src/ui/components/InputPrompt.paste.spec.tsx

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | ❓  | -   | -   |

The macOS npm-run warning is the two unchanged test-utils quota-timing failures described above; all issue-focused tests and all core, agents, and CLI suites passed.

## Linked issues / bugs

Fixes #3158
