### PR TITLE
Make OCR transport tests failure-safe (Fixes #2744)

### DIFF
--- a/project-plans/issue2744.md
+++ b/project-plans/issue2744.md
@@ -1,0 +1,55 @@
+# Issue #2744 — Failure-safe, event-driven OCR transport integration tests
+
+## Changes since the issue was filed
+
+- The target tests moved from JavaScript/Vitest to strict TypeScript with `bun:test`.
+- OCR was upgraded from 1.7.16 to 1.8.4, and the repository now targets Bun 1.3.14 and Node 24.
+- PR #3100 made the abrupt partial-response scenario deterministic and added a local `try/finally` cleanup path for that scenario.
+- These changes did not resolve this issue on current `main`: the fixed 100 ms post-abort delay remained, and the other loopback scenarios could still bypass upstream cleanup when startup, traffic, or assertions failed.
+- A runtime or OCR upgrade cannot guarantee cleanup after a thrown test failure or prove abort propagation within a fixed delay. Explicit lifecycle ownership and observable network events are still required.
+
+## Accepted behavior
+
+1. Every OCR transport scenario owns its loopback resources through a failure-safe test scope before startup or traffic begins. The scope covers the local upstream server, the embedded monitor process/server, client requests and active responses created directly or internally by a scenario, and the sockets those resources own.
+2. The scope releases partially initialized and fully initialized resources on success and on any thrown test/assertion error. Cleanup destroys open client requests and responses, stops the embedded monitor, closes all upstream connections, and closes the upstream server.
+3. Cleanup preserves the original test/startup error. If cleanup also fails, the reported failure retains the original error together with the cleanup failure rather than replacing it.
+4. Behavior assertions run only after scenario resources have been released, so a failed assertion cannot strand a listener or request.
+5. The client-abort scenario aborts only after observing the first streamed response chunk, then waits with a bounded fail-fast condition for the client request destruction and response-stream closure events. It does not use a fixed post-abort sleep.
+6. Existing real-loopback coverage remains behaviorally unchanged for streaming and chunked bodies, HTTP 429 accounting, retry counts and retry headers, connection-error retries, concurrent non-retries, malformed/missing retry headers, partial upstream responses, upstream errors, and client aborts.
+7. No production behavior, workflow behavior, dependency, public abstraction, or unrelated test is changed.
+
+## Inputs and boundary cases
+
+- Upstream response sequences: 429 then 200; three 429 responses then 200; socket destruction before headers; 200 headers followed by a partial body and abrupt close; open-ended SSE response aborted by the client.
+- Retry header values: canonical `0` through `3`, missing, malformed `01`, concurrent and later repeated `0` values.
+- Streaming boundaries: request body split across writes; first SSE chunk observable before completion; request destruction and response-stream closure observable before monitor teardown.
+- Lifecycle boundaries: failure before monitor startup completes, readiness timeout after child spawn, failure during scenario traffic, a direct response callback that throws before later listeners run, and assertion failure after traffic completes.
+- Cleanup boundaries: server not yet listening, server listening with active connections, monitor termination failing once before fallback cleanup, a request callback failing before traffic starts, and directly or internally created client requests/responses still open.
+
+## Behavioral test evidence
+
+1. Add a lifecycle failure-path test that deliberately throws a sentinel scenario/assertion error after opening real loopback traffic. After the failure-safe scope exits, assert that:
+   - the exact original error remains the primary failure,
+   - the upstream server is not listening,
+   - the server-owned socket set is empty after real connection-close events,
+   - the tracked client request is destroyed and closed, and
+   - the monitor child is reaped and its temporary directory is removed before global fallback cleanup runs.
+2. Retain and strengthen monitor startup-failure tests for an invalid target and a readiness timeout after spawn. Add a partial-startup sentinel thrown from the real spawn callback to verify exact original-error identity. In every case, verify the child is reaped and its temporary directory is removed.
+3. Add a concurrent failure-path test in which one scope-created proxy request fails while a sibling response remains open. Verify scope cleanup destroys and closes the sibling, and deliberately induce an upstream cleanup failure to prove the scenario failure remains first in the resulting `AggregateError` while the cleanup failure remains represented.
+4. Rewrite each transport scenario to return captured behavior from the failure-safe scope and perform assertions after cleanup.
+5. In the abort test, consume the complete upstream request body before streaming the first response chunk, use that chunk as the abort trigger, and use bounded request-close and response-close events as proof that the intended client stream state was reached. Assert body completion, request destruction, and telemetry only after all resources are closed.
+6. Prove registration ordering with a standalone Bun real-loopback probe whose direct response callback throws: the response must already be owned, destroyed, and closed before manual upstream fallback cleanup. Also prove that a pre-traffic `onRequest` failure preserves its exact sentinel without a synthetic cleanup timeout.
+7. Force one real monitor termination failure and verify the scenario failure remains first, the cleanup failure remains present, global fallback ownership is retained, and fallback cleanup later reaps the exact child and removes its directory.
+8. Keep issue-specific lifecycle and failure-path cases in `scripts/tests/ocr-transport-lifecycle-2744.test.ts`, with lifecycle ownership in its sibling helper, so the existing concurrency canary remains within source-size limits.
+9. Run both focused Bun test files and the relevant script shard, then the repository test, lint, typecheck, format, build, and smoke-test gates.
+
+## Review-finding classification
+
+- PR 2732 discussion 3651993341 — **Blocker-Fix**: the issue explicitly requires all upstream resources to close after failures; current scenarios can leak when startup, traffic, or an assertion throws before `closeServer`.
+- PR 2732 discussion 3653265252 — **Blocker-Fix**: the fixed 100 ms abort-propagation delay violates the event-driven acceptance criterion and can be flaky on loaded runners.
+
+## Out of scope
+
+- Changes to the OCR workflow or embedded transport monitor implementation.
+- New dependencies or changes to test runners, CI workflows, lint rules, complexity limits, coverage requirements, or agent/project memory.
+- General-purpose production lifecycle abstractions or cleanup work outside the OCR transport integration scenarios.

--- a/scripts/tests/ocr-concurrency-canary-2673-helpers.ts
+++ b/scripts/tests/ocr-concurrency-canary-2673-helpers.ts
@@ -214,15 +214,17 @@ export function closeServer(
   });
 }
 
-interface ProxyRequestOptions {
+export interface ProxyRequestOptions {
   retryCount: string | null;
   body: string;
   authorization: string;
   pathSuffix?: string;
   headers?: Record<string, string>;
+  onRequest?: (request: http.ClientRequest) => void;
+  onResponse?: (response: http.IncomingMessage) => void;
 }
 
-interface ProxyResponse {
+export interface ProxyResponse {
   statusCode: number | undefined;
   headers: http.IncomingHttpHeaders;
   body: string;
@@ -236,6 +238,8 @@ export function proxyRequest(
     pathSuffix = '',
     retryCount = '0',
     headers = {},
+    onRequest,
+    onResponse,
   }: ProxyRequestOptions,
 ): Promise<ProxyResponse> {
   const url = new URL(proxyUrl);
@@ -257,6 +261,7 @@ export function proxyRequest(
         },
       },
       (response) => {
+        onResponse?.(response);
         const chunks: Buffer[] = [];
         response.on('data', (chunk: Buffer) => chunks.push(chunk));
         response.on('end', () =>
@@ -268,6 +273,7 @@ export function proxyRequest(
         );
       },
     );
+    onRequest?.(request);
     request.once('timeout', () => {
       request.destroy(new Error('proxy request timed out'));
     });
@@ -326,7 +332,7 @@ function toMonitorChild(
   };
 }
 
-interface MonitorResource {
+export interface MonitorResource {
   child: MonitorChild;
   directory: string;
   telemetryPath: string;
@@ -674,31 +680,30 @@ export async function startEmbeddedMonitor(
 export async function stopEmbeddedMonitor(
   resource: MonitorResource,
 ): Promise<Record<string, unknown>> {
-  let telemetry: Record<string, unknown>;
+  await terminateAndReap(resource.child);
   try {
-    await terminateAndReap(resource.child);
-    telemetry = asRecord(
+    return asRecord(
       JSON.parse(fs.readFileSync(resource.telemetryPath, 'utf8')),
     );
   } finally {
-    activeResources = activeResources.filter((item) => item !== resource);
     fs.rmSync(resource.directory, { recursive: true, force: true });
+    activeResources = activeResources.filter((item) => item !== resource);
   }
-  return telemetry;
 }
 
 export async function cleanEmbeddedMonitors(): Promise<void> {
   const failures: unknown[] = [];
+  const remainingResources: MonitorResource[] = [];
   for (const resource of activeResources) {
     try {
       await terminateAndReap(resource.child);
+      fs.rmSync(resource.directory, { recursive: true, force: true });
     } catch (error) {
       failures.push(error);
-    } finally {
-      fs.rmSync(resource.directory, { recursive: true, force: true });
+      remainingResources.push(resource);
     }
   }
-  activeResources = [];
+  activeResources = remainingResources;
   if (failures.length > 0) {
     throw new AggregateError(failures, 'monitor cleanup failed');
   }

--- a/scripts/tests/ocr-concurrency-canary-2673-helpers.ts
+++ b/scripts/tests/ocr-concurrency-canary-2673-helpers.ts
@@ -221,7 +221,6 @@ export interface ProxyRequestOptions {
   pathSuffix?: string;
   headers?: Record<string, string>;
   onRequest?: (request: http.ClientRequest) => void;
-  onResponse?: (response: http.IncomingMessage) => void;
 }
 
 export interface ProxyResponse {
@@ -239,7 +238,6 @@ export function proxyRequest(
     retryCount = '0',
     headers = {},
     onRequest,
-    onResponse,
   }: ProxyRequestOptions,
 ): Promise<ProxyResponse> {
   const url = new URL(proxyUrl);
@@ -261,7 +259,6 @@ export function proxyRequest(
         },
       },
       (response) => {
-        onResponse?.(response);
         const chunks: Buffer[] = [];
         response.on('data', (chunk: Buffer) => chunks.push(chunk));
         response.on('end', () =>

--- a/scripts/tests/ocr-concurrency-canary-2673.test.ts
+++ b/scripts/tests/ocr-concurrency-canary-2673.test.ts
@@ -15,16 +15,13 @@ import { commandText, stepNamed } from './ocr-review-workflow-helpers.ts';
 import {
   evaluateOcrConcurrency,
   extractEmbeddedSource,
-  waitFor,
   listen,
-  closeServer,
-  proxyRequest,
   withTempDirectory,
   loadWorkflow,
   startEmbeddedMonitor,
-  stopEmbeddedMonitor,
   cleanEmbeddedMonitors,
 } from './ocr-concurrency-canary-2673-helpers.ts';
+import { withOcrScenario } from './ocr-transport-lifecycle-2744-helpers.ts';
 
 afterEach(cleanEmbeddedMonitors);
 
@@ -213,59 +210,74 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
     });
 
     it('uses canonical retry headers 0 and 1 while preserving streaming and stripping connection-nominated headers', async () => {
-      const received: Array<Record<string, unknown>> = [];
-      const upstream = http.createServer((request, response) => {
-        const chunks: Buffer[] = [];
-        request.on('data', (chunk) => chunks.push(chunk));
-        request.on('end', () => {
-          received.push({
-            method: request.method,
-            url: request.url,
-            authorization: request.headers.authorization,
-            requestHop: request.headers['x-request-hop'],
-            body: Buffer.concat(chunks).toString('utf8'),
-          });
-          response.writeHead(received.length === 1 ? 429 : 200, {
-            connection: 'x-response-hop',
-            'content-type': 'application/json',
-            'x-response-hop': 'must-not-forward',
-            'x-upstream-test': 'preserved',
-          });
-          response.write(received.length === 1 ? '{"retry":' : '{"ok":');
-          response.end('true}');
-        });
-      });
-      const upstreamPort = await listen(upstream);
-      const resource = await startEmbeddedMonitor(
-        `http://127.0.0.1:${upstreamPort}/v1?mode=test`,
-      );
       const secret = 'Bearer transport-secret-2673';
       const body = '{"prompt":"sensitive prompt 2673"}';
-      const common = {
-        body,
-        authorization: secret,
-        headers: {
-          connection: 'x-request-hop',
-          'x-request-hop': 'must-not-forward',
-        },
-      };
-
-      const first = await proxyRequest(asString(resource.ready.proxy_url), {
-        ...common,
-        retryCount: '0',
+      const result = await withOcrScenario(async (scope) => {
+        const received: Array<Record<string, unknown>> = [];
+        const upstream = http.createServer((request, response) => {
+          const chunks: Buffer[] = [];
+          request.on('data', (chunk) => chunks.push(chunk));
+          request.on('end', () => {
+            received.push({
+              method: request.method,
+              url: request.url,
+              authorization: request.headers.authorization,
+              requestHop: request.headers['x-request-hop'],
+              body: Buffer.concat(chunks).toString('utf8'),
+            });
+            response.writeHead(received.length === 1 ? 429 : 200, {
+              connection: 'x-response-hop',
+              'content-type': 'application/json',
+              'x-response-hop': 'must-not-forward',
+              'x-upstream-test': 'preserved',
+            });
+            response.write(received.length === 1 ? '{"retry":' : '{"ok":');
+            response.end('true}');
+          });
+        });
+        scope.registerUpstream(upstream);
+        const upstreamPort = await listen(upstream);
+        const resource = await startEmbeddedMonitor(
+          `http://127.0.0.1:${upstreamPort}/v1?mode=test`,
+        );
+        scope.registerMonitor(resource);
+        const common = {
+          body,
+          authorization: secret,
+          headers: {
+            connection: 'x-request-hop',
+            'x-request-hop': 'must-not-forward',
+          },
+        };
+        const first = await scope.proxyRequest(
+          asString(resource.ready.proxy_url),
+          {
+            ...common,
+            retryCount: '0',
+          },
+        );
+        const second = await scope.proxyRequest(
+          asString(resource.ready.proxy_url),
+          {
+            ...common,
+            retryCount: '1',
+          },
+        );
+        return {
+          first,
+          second,
+          telemetry: await scope.stopMonitor(),
+          received,
+        };
       });
-      const second = await proxyRequest(asString(resource.ready.proxy_url), {
-        ...common,
-        retryCount: '1',
-      });
-      const telemetry = await stopEmbeddedMonitor(resource);
-      await closeServer(upstream);
 
-      expect([first.statusCode, second.statusCode]).toEqual([429, 200]);
-      expect(second.body).toBe('{"ok":true}');
-      expect(second.headers['x-upstream-test']).toBe('preserved');
-      expect(second.headers['x-response-hop']).toBeUndefined();
-      expect(received).toEqual([
+      expect([result.first.statusCode, result.second.statusCode]).toEqual([
+        429, 200,
+      ]);
+      expect(result.second.body).toBe('{"ok":true}');
+      expect(result.second.headers['x-upstream-test']).toBe('preserved');
+      expect(result.second.headers['x-response-hop']).toBeUndefined();
+      expect(result.received).toEqual([
         {
           method: 'POST',
           url: '/v1?mode=test',
@@ -281,7 +293,7 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
           body,
         },
       ]);
-      expect(telemetry).toMatchObject({
+      expect(result.telemetry).toMatchObject({
         total_requests: 2,
         http_429_responses: 1,
         retry_events: 1,
@@ -290,7 +302,7 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
         responses_by_status: { 200: 1, 429: 1 },
         shutdown_complete: true,
       });
-      const persisted = JSON.stringify(telemetry);
+      const persisted = JSON.stringify(result.telemetry);
       expect(persisted).not.toContain(secret);
       expect(persisted).not.toContain(body);
       expect(persisted).not.toContain('x-stainless-retry-count');
@@ -298,28 +310,30 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
     });
 
     it('counts every SDK retry request and every actual 429 response', async () => {
-      let requestCount = 0;
-      const upstream = http.createServer((request, response) => {
-        request.resume();
-        request.on('end', () => {
-          requestCount += 1;
-          response.writeHead(requestCount <= 3 ? 429 : 200).end('done');
+      const telemetry = await withOcrScenario(async (scope) => {
+        let requestCount = 0;
+        const upstream = http.createServer((request, response) => {
+          request.resume();
+          request.on('end', () => {
+            requestCount += 1;
+            response.writeHead(requestCount <= 3 ? 429 : 200).end('done');
+          });
         });
+        scope.registerUpstream(upstream);
+        const upstreamPort = await listen(upstream);
+        const resource = await startEmbeddedMonitor(
+          `http://127.0.0.1:${upstreamPort}/v1`,
+        );
+        scope.registerMonitor(resource);
+        for (const retryCount of ['0', '1', '2', '3']) {
+          await scope.proxyRequest(asString(resource.ready.proxy_url), {
+            body: '{}',
+            authorization: 'Bearer repeated-429-token',
+            retryCount,
+          });
+        }
+        return scope.stopMonitor();
       });
-      const upstreamPort = await listen(upstream);
-      const resource = await startEmbeddedMonitor(
-        `http://127.0.0.1:${upstreamPort}/v1`,
-      );
-
-      for (const retryCount of ['0', '1', '2', '3']) {
-        await proxyRequest(asString(resource.ready.proxy_url), {
-          body: '{}',
-          authorization: 'Bearer repeated-429-token',
-          retryCount,
-        });
-      }
-      const telemetry = await stopEmbeddedMonitor(resource);
-      await closeServer(upstream);
 
       expect(telemetry.retry_events).toBe(3);
       expect(telemetry.http_429_responses).toBe(3);
@@ -327,36 +341,48 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
     });
 
     it('counts a connection-error retry when the next SDK request reports retry count 1', async () => {
-      let requestCount = 0;
-      const upstream = http.createServer((request, response) => {
-        requestCount += 1;
-        if (requestCount === 1) {
-          request.socket.destroy();
-          return;
-        }
-        request.resume();
-        request.on('end', () => response.writeHead(200).end('ok'));
+      const result = await withOcrScenario(async (scope) => {
+        let requestCount = 0;
+        const upstream = http.createServer((request, response) => {
+          requestCount += 1;
+          if (requestCount === 1) {
+            request.socket.destroy();
+            return;
+          }
+          request.resume();
+          request.on('end', () => response.writeHead(200).end('ok'));
+        });
+        scope.registerUpstream(upstream);
+        const upstreamPort = await listen(upstream);
+        const resource = await startEmbeddedMonitor(
+          `http://127.0.0.1:${upstreamPort}/v1`,
+        );
+        scope.registerMonitor(resource);
+        const opts = {
+          body: '{}',
+          authorization: 'Bearer network-retry-token',
+        };
+        const first = await scope.proxyRequest(
+          asString(resource.ready.proxy_url),
+          {
+            ...opts,
+            retryCount: '0',
+          },
+        );
+        const second = await scope.proxyRequest(
+          asString(resource.ready.proxy_url),
+          {
+            ...opts,
+            retryCount: '1',
+          },
+        );
+        return { first, second, telemetry: await scope.stopMonitor() };
       });
-      const upstreamPort = await listen(upstream);
-      const resource = await startEmbeddedMonitor(
-        `http://127.0.0.1:${upstreamPort}/v1`,
-      );
 
-      const first = await proxyRequest(asString(resource.ready.proxy_url), {
-        body: '{}',
-        authorization: 'Bearer network-retry-token',
-        retryCount: '0',
-      });
-      const second = await proxyRequest(asString(resource.ready.proxy_url), {
-        body: '{}',
-        authorization: 'Bearer network-retry-token',
-        retryCount: '1',
-      });
-      const telemetry = await stopEmbeddedMonitor(resource);
-      await closeServer(upstream);
-
-      expect([first.statusCode, second.statusCode]).toEqual([502, 200]);
-      expect(telemetry).toMatchObject({
+      expect([result.first.statusCode, result.second.statusCode]).toEqual([
+        502, 200,
+      ]);
+      expect(result.telemetry).toMatchObject({
         total_requests: 2,
         upstream_errors: 1,
         retry_events: 1,
@@ -365,40 +391,42 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
     });
 
     it('does not infer retries from concurrent or later identical header-0 requests', async () => {
-      const pending: http.ServerResponse[] = [];
-      let requestCount = 0;
-      const upstream = http.createServer((request, response) => {
-        request.resume();
-        request.on('end', () => {
-          requestCount += 1;
-          if (requestCount <= 2) {
-            pending.push(response);
-            if (pending.length === 2) {
-              pending[0].writeHead(429).end('retry');
-              pending[1].writeHead(200).end('ok');
+      const telemetry = await withOcrScenario(async (scope) => {
+        const pending: http.ServerResponse[] = [];
+        let requestCount = 0;
+        const upstream = http.createServer((request, response) => {
+          request.resume();
+          request.on('end', () => {
+            requestCount += 1;
+            if (requestCount <= 2) {
+              pending.push(response);
+              if (pending.length === 2) {
+                pending[0].writeHead(429).end('retry');
+                pending[1].writeHead(200).end('ok');
+              }
+            } else {
+              response.writeHead(200).end('ok');
             }
-          } else {
-            response.writeHead(200).end('ok');
-          }
+          });
         });
+        scope.registerUpstream(upstream);
+        const upstreamPort = await listen(upstream);
+        const resource = await startEmbeddedMonitor(
+          `http://127.0.0.1:${upstreamPort}/v1`,
+        );
+        scope.registerMonitor(resource);
+        const req = {
+          body: '{"same":"body"}',
+          authorization: 'Bearer same-token',
+          retryCount: '0',
+        };
+        await Promise.all([
+          scope.proxyRequest(asString(resource.ready.proxy_url), req),
+          scope.proxyRequest(asString(resource.ready.proxy_url), req),
+        ]);
+        await scope.proxyRequest(asString(resource.ready.proxy_url), req);
+        return scope.stopMonitor();
       });
-      const upstreamPort = await listen(upstream);
-      const resource = await startEmbeddedMonitor(
-        `http://127.0.0.1:${upstreamPort}/v1`,
-      );
-      const request = {
-        body: '{"same":"body"}',
-        authorization: 'Bearer same-token',
-        retryCount: '0',
-      };
-
-      await Promise.all([
-        proxyRequest(asString(resource.ready.proxy_url), request),
-        proxyRequest(asString(resource.ready.proxy_url), request),
-      ]);
-      await proxyRequest(asString(resource.ready.proxy_url), request);
-      const telemetry = await stopEmbeddedMonitor(resource);
-      await closeServer(upstream);
 
       expect(telemetry.http_429_responses).toBe(1);
       expect(telemetry.retry_events).toBe(0);
@@ -406,27 +434,29 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
     });
 
     it('records only aggregate malformed and missing retry-header counts', async () => {
-      const upstream = http.createServer((request, response) => {
-        request.resume();
-        request.on('end', () => response.writeHead(200).end('ok'));
+      const telemetry = await withOcrScenario(async (scope) => {
+        const upstream = http.createServer((request, response) => {
+          request.resume();
+          request.on('end', () => response.writeHead(200).end('ok'));
+        });
+        scope.registerUpstream(upstream);
+        const upstreamPort = await listen(upstream);
+        const resource = await startEmbeddedMonitor(
+          `http://127.0.0.1:${upstreamPort}/v1`,
+        );
+        scope.registerMonitor(resource);
+        await scope.proxyRequest(asString(resource.ready.proxy_url), {
+          body: '{}',
+          authorization: 'Bearer malformed-token',
+          retryCount: null,
+        });
+        await scope.proxyRequest(asString(resource.ready.proxy_url), {
+          body: '{}',
+          authorization: 'Bearer malformed-token',
+          retryCount: '01',
+        });
+        return scope.stopMonitor();
       });
-      const upstreamPort = await listen(upstream);
-      const resource = await startEmbeddedMonitor(
-        `http://127.0.0.1:${upstreamPort}/v1`,
-      );
-
-      await proxyRequest(asString(resource.ready.proxy_url), {
-        body: '{}',
-        authorization: 'Bearer malformed-token',
-        retryCount: null,
-      });
-      await proxyRequest(asString(resource.ready.proxy_url), {
-        body: '{}',
-        authorization: 'Bearer malformed-token',
-        retryCount: '01',
-      });
-      const telemetry = await stopEmbeddedMonitor(resource);
-      await closeServer(upstream);
 
       expect(telemetry).toMatchObject({
         total_requests: 2,
@@ -438,266 +468,181 @@ describe('.github/workflows/ocr-review.yml — issue #2673 concurrency canary', 
     });
 
     it('streams delayed SSE responses and forwards chunked request bodies without buffering', async () => {
-      let upstreamCompleted = false;
-      let receivedBody = '';
-      const upstream = http.createServer((request, response) => {
-        request.on('data', (chunk) => {
-          receivedBody += chunk;
+      const result = await withOcrScenario(async (scope) => {
+        let upstreamCompleted = false;
+        let receivedBody = '';
+        const upstream = http.createServer((request, response) => {
+          request.on('data', (chunk) => {
+            receivedBody += chunk;
+          });
+          request.on('end', () => {
+            response.writeHead(200, { 'content-type': 'text/event-stream' });
+            response.write('data: first\n\n');
+            setTimeout(() => {
+              upstreamCompleted = true;
+              response.end('data: second\n\n');
+            }, 150);
+          });
         });
-        request.on('end', () => {
-          response.writeHead(200, { 'content-type': 'text/event-stream' });
-          response.write('data: first\n\n');
-          setTimeout(() => {
-            upstreamCompleted = true;
-            response.end('data: second\n\n');
-          }, 150);
-        });
-      });
-      const upstreamPort = await listen(upstream);
-      const resource = await startEmbeddedMonitor(
-        `http://127.0.0.1:${upstreamPort}/v1`,
-      );
-      const url = new URL(asString(resource.ready.proxy_url));
-      let firstChunkBeforeCompletion = false;
-
-      const responseBody = await new Promise<string>((resolve, reject) => {
-        const request = http.request(
-          url,
-          {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json',
-              'x-stainless-retry-count': '0',
-            },
-          },
-          (response) => {
-            const chunks: Buffer[] = [];
-            response.on('data', (chunk) => {
-              if (chunks.length === 0) {
-                firstChunkBeforeCompletion = !upstreamCompleted;
-              }
-              chunks.push(chunk);
-            });
-            response.on('end', () => resolve(Buffer.concat(chunks).toString()));
-          },
+        scope.registerUpstream(upstream);
+        const upstreamPort = await listen(upstream);
+        const resource = await startEmbeddedMonitor(
+          `http://127.0.0.1:${upstreamPort}/v1`,
         );
-        request.once('error', reject);
-        request.write('{"chunk":');
-        setTimeout(() => request.end('true}'), 25);
+        scope.registerMonitor(resource);
+        const url = new URL(asString(resource.ready.proxy_url));
+        let firstChunkBeforeCompletion = false;
+        const responseBody = await new Promise<string>((resolve, reject) => {
+          const request = http.request(
+            url,
+            {
+              method: 'POST',
+              headers: {
+                'content-type': 'application/json',
+                'x-stainless-retry-count': '0',
+              },
+            },
+            (response) => {
+              const chunks: Buffer[] = [];
+              response.on('data', (chunk) => {
+                if (chunks.length === 0)
+                  firstChunkBeforeCompletion = !upstreamCompleted;
+                chunks.push(chunk);
+              });
+              response.on('end', () =>
+                resolve(Buffer.concat(chunks).toString()),
+              );
+            },
+          );
+          scope.trackRequest(request);
+          request.once('error', reject);
+          request.write('{"chunk":');
+          setTimeout(() => request.end('true}'), 25);
+        });
+        const telemetry = await scope.stopMonitor();
+        return {
+          receivedBody,
+          responseBody,
+          firstChunkBeforeCompletion,
+          telemetry,
+        };
       });
-      const telemetry = await stopEmbeddedMonitor(resource);
-      await closeServer(upstream);
 
-      expect(receivedBody).toBe('{"chunk":true}');
-      expect(responseBody).toBe('data: first\n\ndata: second\n\n');
-      expect(firstChunkBeforeCompletion).toBe(true);
-      expect(telemetry.responses_by_status).toEqual({ 200: 1 });
+      expect(result.receivedBody).toBe('{"chunk":true}');
+      expect(result.responseBody).toBe('data: first\n\ndata: second\n\n');
+      expect(result.firstChunkBeforeCompletion).toBe(true);
+      expect(result.telemetry.responses_by_status).toEqual({ 200: 1 });
     });
 
     it('handles an upstream error after headers and partial body without crashing or double-counting', async () => {
       const partialSentinel = '{"partial":';
-      let triggerUpstreamReset: (() => void) | null = null;
-      const upstream = http.createServer((request, response) => {
-        request.resume();
-        request.on('end', () => {
-          response.writeHead(200, { 'content-type': 'application/json' });
-          response.write(partialSentinel);
-          triggerUpstreamReset = () => {
-            response.destroy(new Error('upstream mid-stream crash'));
-          };
+      const result = await withOcrScenario(async (scope) => {
+        let triggerUpstreamReset: (() => void) | null = null;
+        const upstream = http.createServer((request, response) => {
+          request.resume();
+          request.on('end', () => {
+            response.writeHead(200, { 'content-type': 'application/json' });
+            response.write(partialSentinel);
+            triggerUpstreamReset = () => {
+              response.destroy(new Error('upstream mid-stream crash'));
+            };
+          });
         });
-      });
-      const upstreamPort = await listen(upstream);
-      let resource:
-        | Awaited<ReturnType<typeof startEmbeddedMonitor>>
-        | undefined;
-      let monitorStopAttempted = false;
-
-      try {
-        const startedResource = await startEmbeddedMonitor(
+        scope.registerUpstream(upstream);
+        const upstreamPort = await listen(upstream);
+        const resource = await startEmbeddedMonitor(
           `http://127.0.0.1:${upstreamPort}/v1`,
         );
-        resource = startedResource;
-        const result = await new Promise<{ statusCode: number; body: string }>(
-          (resolve, reject) => {
-            const chunks: Buffer[] = [];
-            let terminatedCleanly = false;
-            let settled = false;
-            const proxyRequest = http.request(
-              new URL(asString(startedResource.ready.proxy_url)),
-              {
-                method: 'POST',
-                headers: {
-                  'content-type': 'application/json',
-                  'x-stainless-retry-count': '0',
-                },
+        scope.registerMonitor(resource);
+
+        const captured = await new Promise<{
+          statusCode: number;
+          body: string;
+        }>((resolve, reject) => {
+          const chunks: Buffer[] = [];
+          let terminatedCleanly = false;
+          let settled = false;
+          const clientRequest = http.request(
+            new URL(asString(resource.ready.proxy_url)),
+            {
+              method: 'POST',
+              headers: {
+                'content-type': 'application/json',
+                'x-stainless-retry-count': '0',
               },
-              (response) => {
-                const statusCode = response.statusCode;
-                if (statusCode === undefined) {
-                  settled = true;
-                  reject(new Error('response arrived without an HTTP status'));
+            },
+            (response) => {
+              const statusCode = response.statusCode;
+              if (statusCode === undefined) {
+                settled = true;
+                reject(new Error('response arrived without an HTTP status'));
+                return;
+              }
+              const resolveAbnormal = () => {
+                if (settled) {
                   return;
                 }
-                const resolveAbnormal = () => {
-                  if (settled) {
-                    return;
-                  }
-                  settled = true;
-                  resolve({
-                    statusCode,
-                    body: Buffer.concat(chunks).toString('utf8'),
-                  });
-                };
-                response.on('data', (chunk) => {
-                  chunks.push(chunk);
-                  if (
-                    triggerUpstreamReset !== null &&
-                    Buffer.concat(chunks).toString('utf8') === partialSentinel
-                  ) {
-                    const trigger = triggerUpstreamReset;
-                    triggerUpstreamReset = null;
-                    trigger();
-                  }
-                });
-                response.on('end', () => {
-                  terminatedCleanly = true;
-                  if (!settled) {
-                    settled = true;
-                    reject(
-                      new Error(
-                        'response ended cleanly; expected abnormal termination after the partial sentinel',
-                      ),
-                    );
-                  }
-                });
-                response.on('error', resolveAbnormal);
-                response.on('close', () => {
-                  if (!terminatedCleanly) {
-                    resolveAbnormal();
-                  }
-                });
-              },
-            );
-            proxyRequest.once('error', (error) => {
-              if (!settled) {
                 settled = true;
-                reject(
-                  new Error(
-                    `request-level error reached the client before response headers: ${
-                      error instanceof Error ? error.message : String(error)
-                    }`,
-                  ),
-                );
-              }
-            });
-            proxyRequest.end('{"test":true}');
-          },
-        );
-        monitorStopAttempted = true;
-        const telemetry = await stopEmbeddedMonitor(startedResource);
-
-        expect(result.statusCode).toBe(200);
-        expect(result.body).toBe(partialSentinel);
-        expect(telemetry.total_requests).toBe(1);
-        expect(telemetry.upstream_errors).toBe(0);
-        expect(telemetry.responses_by_status).toEqual({ 200: 1 });
-        expect(telemetry.shutdown_complete).toBe(true);
-      } finally {
-        try {
-          if (resource !== undefined && !monitorStopAttempted) {
-            monitorStopAttempted = true;
-            await stopEmbeddedMonitor(resource);
-          }
-        } finally {
-          await closeServer(upstream);
-        }
-      }
-    });
-
-    it('handles a client-aborted request during streaming without crashing or double-counting', async () => {
-      const upstream = http.createServer((request, response) => {
-        response.writeHead(200, { 'content-type': 'text/event-stream' });
-        response.write('data: first\n\n');
-      });
-      const upstreamPort = await listen(upstream);
-      const resource = await startEmbeddedMonitor(
-        `http://127.0.0.1:${upstreamPort}/v1`,
-      );
-
-      const proxyRequest = http.request(
-        new URL(asString(resource.ready.proxy_url)),
-        {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            'x-stainless-retry-count': '0',
-          },
-        },
-        (response) => {
-          response.on('data', () => {
-            proxyRequest.destroy();
-          });
-        },
-      );
-      proxyRequest.end('{"test":true}');
-      await waitFor(() => proxyRequest.destroyed, 3000);
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      const telemetry = await stopEmbeddedMonitor(resource);
-      await closeServer(upstream);
-
-      expect(telemetry.total_requests).toBe(1);
-      expect(telemetry.upstream_errors).toBe(0);
-      expect(telemetry.responses_by_status).toEqual({ 200: 1 });
-    });
-
-    it('cleans startup resources for invalid targets and readiness timeouts', async () => {
-      await expect(
-        startEmbeddedMonitor('file:///tmp/not-http'),
-      ).rejects.toThrow(/failed to start/);
-
-      let spawned:
-        | {
-            child: {
-              exitCode: number | null;
-              signalCode: NodeJS.Signals | null;
-              kill: (signal: string) => void;
-            };
-            directory: string;
-          }
-        | undefined;
-      try {
-        await expect(
-          startEmbeddedMonitor('https://provider.invalid/v1', {
-            startupTimeoutMs: 100,
-            monitorReadyFileName: 'unobserved-ready.json',
-            onSpawn: (resource) => {
-              spawned = resource;
+                resolve({
+                  statusCode,
+                  body: Buffer.concat(chunks).toString('utf8'),
+                });
+              };
+              response.on('data', (chunk) => {
+                chunks.push(chunk);
+                if (
+                  triggerUpstreamReset !== null &&
+                  Buffer.concat(chunks).toString('utf8') === partialSentinel
+                ) {
+                  const trigger = triggerUpstreamReset;
+                  triggerUpstreamReset = null;
+                  trigger();
+                }
+              });
+              response.on('end', () => {
+                terminatedCleanly = true;
+                if (!settled) {
+                  settled = true;
+                  reject(
+                    new Error(
+                      'response ended cleanly; expected abnormal termination after the partial sentinel',
+                    ),
+                  );
+                }
+              });
+              response.on('error', resolveAbnormal);
+              response.on('close', () => {
+                if (!terminatedCleanly) {
+                  resolveAbnormal();
+                }
+              });
             },
-          }),
-        ).rejects.toThrow(/monitor failed to start.*timed out/i);
-        expect(spawned).toBeDefined();
-        expect(
-          spawned?.child.exitCode ?? spawned?.child.signalCode,
-        ).not.toBeNull();
-        expect(fs.existsSync(spawned?.directory ?? '')).toBe(false);
-      } finally {
-        if (
-          spawned &&
-          spawned?.child.exitCode === null &&
-          spawned?.child.signalCode === null
-        ) {
-          spawned?.child.kill('SIGTERM');
-          await waitFor(
-            () =>
-              spawned?.child.exitCode !== null ||
-              spawned?.child.signalCode !== null,
           );
-        }
-        if (spawned) {
-          fs.rmSync(spawned?.directory, { recursive: true, force: true });
-        }
-      }
+          scope.trackRequest(clientRequest);
+          clientRequest.once('error', (error) => {
+            if (!settled) {
+              settled = true;
+              reject(
+                new Error(
+                  `request-level error reached the client before response headers: ${
+                    error instanceof Error ? error.message : String(error)
+                  }`,
+                ),
+              );
+            }
+          });
+          clientRequest.end('{"test":true}');
+        });
+        const telemetry = await scope.stopMonitor();
+        return { captured, telemetry };
+      });
+
+      expect(result.captured.statusCode).toBe(200);
+      expect(result.captured.body).toBe(partialSentinel);
+      expect(result.telemetry.total_requests).toBe(1);
+      expect(result.telemetry.upstream_errors).toBe(0);
+      expect(result.telemetry.responses_by_status).toEqual({ 200: 1 });
+      expect(result.telemetry.shutdown_complete).toBe(true);
     });
   });
 

--- a/scripts/tests/ocr-transport-lifecycle-2744-helpers.ts
+++ b/scripts/tests/ocr-transport-lifecycle-2744-helpers.ts
@@ -127,9 +127,11 @@ export async function withOcrScenario<T>(
   const cleanupFailures: unknown[] = [];
   for (const request of Array.from(clientRequests)) {
     try {
-      if (!request.destroyed) {
-        request.destroy();
+      if (request.destroyed) {
+        clientRequests.delete(request);
+        continue;
       }
+      request.destroy();
     } catch (error) {
       cleanupFailures.push(error);
     }

--- a/scripts/tests/ocr-transport-lifecycle-2744-helpers.ts
+++ b/scripts/tests/ocr-transport-lifecycle-2744-helpers.ts
@@ -28,7 +28,7 @@ export interface OcrScenarioScope {
   trackRequest(request: http.ClientRequest): http.ClientRequest;
   proxyRequest(
     proxyUrl: string | URL,
-    options: Omit<ProxyRequestOptions, 'onResponse'>,
+    options: ProxyRequestOptions,
   ): Promise<ProxyResponse>;
   stopMonitor(): Promise<Record<string, unknown>>;
 }
@@ -90,7 +90,6 @@ export async function withOcrScenario<T>(
             throw error;
           }
         },
-        onResponse: trackResponse,
       });
     },
     async stopMonitor() {

--- a/scripts/tests/ocr-transport-lifecycle-2744-helpers.ts
+++ b/scripts/tests/ocr-transport-lifecycle-2744-helpers.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import http from 'node:http';
+import {
+  closeServer,
+  proxyRequest,
+  stopEmbeddedMonitor,
+  waitFor,
+} from './ocr-concurrency-canary-2673-helpers.ts';
+import type {
+  MonitorResource,
+  ProxyRequestOptions,
+  ProxyResponse,
+} from './ocr-concurrency-canary-2673-helpers.ts';
+
+export type OcrScenarioServer = http.Server<
+  typeof http.IncomingMessage,
+  typeof http.ServerResponse
+>;
+
+export interface OcrScenarioScope {
+  registerUpstream(server: OcrScenarioServer): OcrScenarioServer;
+  registerMonitor(resource: MonitorResource): MonitorResource;
+  trackRequest(request: http.ClientRequest): http.ClientRequest;
+  proxyRequest(
+    proxyUrl: string | URL,
+    options: Omit<ProxyRequestOptions, 'onResponse'>,
+  ): Promise<ProxyResponse>;
+  stopMonitor(): Promise<Record<string, unknown>>;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function withOcrScenario<T>(
+  scenario: (scope: OcrScenarioScope) => Promise<T>,
+): Promise<T> {
+  let upstream: OcrScenarioServer | undefined;
+  let monitor: MonitorResource | undefined;
+  const clientRequests: Set<http.ClientRequest> = new Set();
+  const clientResponses: Set<http.IncomingMessage> = new Set();
+
+  const trackResponse = (
+    response: http.IncomingMessage,
+  ): http.IncomingMessage => {
+    if (!clientResponses.has(response)) {
+      clientResponses.add(response);
+      response.once('close', () => {
+        clientResponses.delete(response);
+      });
+    }
+    return response;
+  };
+
+  const trackRequest = (request: http.ClientRequest): http.ClientRequest => {
+    clientRequests.add(request);
+    request.prependOnceListener('response', trackResponse);
+    request.once('close', () => {
+      clientRequests.delete(request);
+    });
+    return request;
+  };
+
+  const scope: OcrScenarioScope = {
+    registerUpstream(server) {
+      upstream = server;
+      return server;
+    },
+    registerMonitor(resource) {
+      monitor = resource;
+      return resource;
+    },
+    trackRequest,
+    proxyRequest(proxyUrl, options) {
+      const onRequest = options.onRequest;
+      return proxyRequest(proxyUrl, {
+        ...options,
+        onRequest(createdRequest) {
+          trackRequest(createdRequest);
+          try {
+            onRequest?.(createdRequest);
+          } catch (error) {
+            createdRequest.destroy();
+            clientRequests.delete(createdRequest);
+            throw error;
+          }
+        },
+        onResponse: trackResponse,
+      });
+    },
+    async stopMonitor() {
+      if (monitor === undefined) {
+        throw new Error('no monitor registered with the scenario scope');
+      }
+      const target = monitor;
+      try {
+        return await stopEmbeddedMonitor(target);
+      } finally {
+        if (
+          target.child.exitCode !== null ||
+          target.child.signalCode !== null
+        ) {
+          monitor = undefined;
+        }
+      }
+    },
+  };
+
+  let outcome:
+    | { readonly ok: true; readonly value: T }
+    | {
+        readonly ok: false;
+        readonly error: unknown;
+      };
+  try {
+    const value = await scenario(scope);
+    outcome = { ok: true, value };
+  } catch (error) {
+    outcome = { ok: false, error };
+  }
+
+  const cleanupFailures: unknown[] = [];
+  for (const request of Array.from(clientRequests)) {
+    try {
+      if (!request.destroyed) {
+        request.destroy();
+      }
+    } catch (error) {
+      cleanupFailures.push(error);
+    }
+  }
+  for (const response of Array.from(clientResponses)) {
+    try {
+      if (response.complete || response.destroyed) {
+        clientResponses.delete(response);
+      } else {
+        response.destroy();
+      }
+    } catch (error) {
+      cleanupFailures.push(error);
+    }
+  }
+  if (clientRequests.size > 0 || clientResponses.size > 0) {
+    try {
+      await waitFor(
+        () => clientRequests.size === 0 && clientResponses.size === 0,
+        3000,
+      );
+    } catch (error) {
+      cleanupFailures.push(error);
+    }
+  }
+  if (monitor !== undefined) {
+    try {
+      await stopEmbeddedMonitor(monitor);
+    } catch (error) {
+      cleanupFailures.push(error);
+    }
+  }
+  if (upstream !== undefined) {
+    try {
+      await closeServer(upstream);
+    } catch (error) {
+      cleanupFailures.push(error);
+    }
+  }
+
+  let cleanupError: unknown;
+  if (cleanupFailures.length === 1) {
+    cleanupError = cleanupFailures[0];
+  } else if (cleanupFailures.length > 1) {
+    cleanupError = new AggregateError(
+      cleanupFailures,
+      'OCR scenario cleanup failed',
+    );
+  }
+
+  if (!outcome.ok) {
+    if (cleanupError !== undefined) {
+      const primary =
+        outcome.error instanceof Error
+          ? outcome.error
+          : new Error(errorMessage(outcome.error));
+      throw new AggregateError(
+        [primary, cleanupError],
+        `OCR scenario failed: ${errorMessage(outcome.error)}; cleanup also failed: ${errorMessage(cleanupError)}`,
+      );
+    }
+    throw outcome.error;
+  }
+  if (cleanupError !== undefined) {
+    throw cleanupError;
+  }
+  return outcome.value;
+}

--- a/scripts/tests/ocr-transport-lifecycle-2744.test.ts
+++ b/scripts/tests/ocr-transport-lifecycle-2744.test.ts
@@ -1,0 +1,520 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import type { Socket } from 'node:net';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  cleanEmbeddedMonitors,
+  closeServer,
+  listen,
+  startEmbeddedMonitor,
+  waitFor,
+} from './ocr-concurrency-canary-2673-helpers.ts';
+import type { MonitorResource } from './ocr-concurrency-canary-2673-helpers.ts';
+import { withOcrScenario } from './ocr-transport-lifecycle-2744-helpers.ts';
+import type { OcrScenarioServer } from './ocr-transport-lifecycle-2744-helpers.ts';
+import { asRecord, asString } from './typed-test-helpers.ts';
+
+interface SpawnedMonitorHandle {
+  child: {
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+    kill: (signal: string) => void;
+  };
+  directory: string;
+}
+
+function requireCaptured<T>(value: T | undefined, label: string): T {
+  if (value === undefined) {
+    throw new Error(`${label} was not captured`);
+  }
+  return value;
+}
+
+function captureError(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+}
+
+function responseCallbackFailureProbe(): Record<string, unknown> {
+  const lifecycleHelperUrl = pathToFileURL(
+    path.resolve('scripts/tests/ocr-transport-lifecycle-2744-helpers.ts'),
+  ).href;
+  const canaryHelperUrl = pathToFileURL(
+    path.resolve('scripts/tests/ocr-concurrency-canary-2673-helpers.ts'),
+  ).href;
+  const source = `
+    import http from 'node:http';
+    import { closeServer, listen } from ${JSON.stringify(canaryHelperUrl)};
+    import { withOcrScenario } from ${JSON.stringify(lifecycleHelperUrl)};
+
+    const sentinel = new Error('sentinel response callback failure 2744');
+    let callbackReject = () => {};
+    const callbackFailure = new Promise((_, reject) => {
+      callbackReject = reject;
+    });
+    let capturedResponse;
+    let responseClosed = false;
+    process.once('uncaughtException', (error) => callbackReject(error));
+
+    const upstream = http.createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.write('data: open\\n\\n');
+    });
+    const upstreamPort = await listen(upstream);
+    let result;
+    try {
+      const caught = await withOcrScenario(async (scope) => {
+        const request = http.request(
+          'http://127.0.0.1:' + upstreamPort,
+          (response) => {
+            capturedResponse = response;
+            response.once('close', () => {
+              responseClosed = true;
+            });
+            throw sentinel;
+          },
+        );
+        scope.trackRequest(request);
+        request.end();
+        await callbackFailure;
+      }).then(
+        () => undefined,
+        (error) => error,
+      );
+      result = {
+        exactPrimary: caught === sentinel,
+        responseClosed,
+        responseDestroyed: capturedResponse?.destroyed === true,
+      };
+    } finally {
+      await closeServer(upstream);
+    }
+    process.stdout.write(JSON.stringify(result));
+  `;
+  return asRecord(
+    JSON.parse(
+      execFileSync(process.execPath, ['-e', source], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+      }),
+    ),
+  );
+}
+
+afterEach(cleanEmbeddedMonitors);
+
+describe('OCR transport lifecycle — issue #2744', () => {
+  it('aborts only after streamed data and observes request and response closure', async () => {
+    const result = await withOcrScenario(async (scope) => {
+      let requestBodyCompleted = false;
+      const upstream = http.createServer((request, response) => {
+        request.resume();
+        request.once('end', () => {
+          requestBodyCompleted = true;
+          response.writeHead(200, { 'content-type': 'text/event-stream' });
+          response.write('data: first\n\n');
+        });
+      });
+      scope.registerUpstream(upstream);
+      const upstreamPort = await listen(upstream);
+      const resource = await startEmbeddedMonitor(
+        `http://127.0.0.1:${upstreamPort}/v1`,
+      );
+      scope.registerMonitor(resource);
+
+      let firstChunkObserved = false;
+      let requestClosed = false;
+      let responseClosed = false;
+      const clientRequest = http.request(
+        new URL(asString(resource.ready.proxy_url)),
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-stainless-retry-count': '0',
+          },
+        },
+        (response) => {
+          response.once('close', () => {
+            responseClosed = true;
+          });
+          response.on('data', () => {
+            if (!firstChunkObserved) {
+              firstChunkObserved = true;
+              clientRequest.destroy();
+            }
+          });
+        },
+      );
+      scope.trackRequest(clientRequest);
+      clientRequest.once('close', () => {
+        requestClosed = true;
+      });
+      clientRequest.end('{"test":true}');
+
+      await waitFor(() => firstChunkObserved, 3000);
+      await waitFor(() => requestClosed && responseClosed, 3000);
+      const telemetry = await scope.stopMonitor();
+      return {
+        telemetry,
+        firstChunkObserved,
+        requestBodyCompleted,
+        requestClosed,
+        requestDestroyed: clientRequest.destroyed,
+        responseClosed,
+      };
+    });
+
+    expect(result.firstChunkObserved).toBe(true);
+    expect(result.requestBodyCompleted).toBe(true);
+    expect(result.requestClosed).toBe(true);
+    expect(result.requestDestroyed).toBe(true);
+    expect(result.responseClosed).toBe(true);
+    expect(result.telemetry.total_requests).toBe(1);
+    expect(result.telemetry.upstream_errors).toBe(0);
+    expect(result.telemetry.responses_by_status).toEqual({ 200: 1 });
+  });
+
+  it('owns a direct response before its callback can fail', () => {
+    const result = responseCallbackFailureProbe();
+
+    expect(result.exactPrimary).toBe(true);
+    expect(result.responseDestroyed).toBe(true);
+    expect(result.responseClosed).toBe(true);
+  });
+
+  it('fails and reaps the monitor child for an invalid target', async () => {
+    let spawned: SpawnedMonitorHandle | undefined;
+    const caught = await captureError(
+      startEmbeddedMonitor('file:///tmp/not-http', {
+        onSpawn: (resource) => {
+          spawned = resource;
+        },
+      }),
+    );
+
+    expect(caught).toBeInstanceOf(Error);
+    if (!(caught instanceof Error)) {
+      throw new Error('invalid-target failure was not an Error');
+    }
+    expect(caught.message).toMatch(/monitor failed to start/i);
+    expect(caught.cause).toBeInstanceOf(Error);
+    if (!(caught.cause instanceof Error)) {
+      throw new Error('invalid-target failure did not retain its cause');
+    }
+    expect(caught.cause.message).toMatch(/exited before publishing readiness/i);
+    const monitor = requireCaptured(spawned, 'spawned monitor');
+    expect(monitor.child.exitCode ?? monitor.child.signalCode).not.toBeNull();
+    expect(fs.existsSync(monitor.directory)).toBe(false);
+  });
+
+  it('fails and reaps the monitor child for a readiness timeout after spawn', async () => {
+    let spawned: SpawnedMonitorHandle | undefined;
+    const caught = await captureError(
+      startEmbeddedMonitor('https://provider.invalid/v1', {
+        startupTimeoutMs: 100,
+        monitorReadyFileName: 'unobserved-ready.json',
+        onSpawn: (resource) => {
+          spawned = resource;
+        },
+      }),
+    );
+
+    expect(caught).toBeInstanceOf(Error);
+    if (!(caught instanceof Error)) {
+      throw new Error('readiness-timeout failure was not an Error');
+    }
+    expect(caught.message).toMatch(/monitor failed to start.*timed out/i);
+    expect(caught.cause).toBeInstanceOf(Error);
+    if (!(caught.cause instanceof Error)) {
+      throw new Error('readiness-timeout failure did not retain its cause');
+    }
+    expect(caught.cause.message).toMatch(/timed out/i);
+    const monitor = requireCaptured(spawned, 'spawned monitor');
+    expect(monitor.child.exitCode ?? monitor.child.signalCode).not.toBeNull();
+    expect(fs.existsSync(monitor.directory)).toBe(false);
+  });
+
+  it('preserves exact startup failure identity while reaping partial initialization', async () => {
+    const sentinel = new Error('sentinel monitor startup failure 2744');
+    let spawned: SpawnedMonitorHandle | undefined;
+    const caught = await captureError(
+      startEmbeddedMonitor('https://provider.invalid/v1', {
+        onSpawn: (resource) => {
+          spawned = resource;
+          throw sentinel;
+        },
+      }),
+    );
+
+    expect(caught).toBeInstanceOf(Error);
+    if (!(caught instanceof Error)) {
+      throw new Error('partial-startup failure was not an Error');
+    }
+    expect(caught.cause).toBe(sentinel);
+    const monitor = requireCaptured(spawned, 'spawned monitor');
+    expect(monitor.child.exitCode ?? monitor.child.signalCode).not.toBeNull();
+    expect(fs.existsSync(monitor.directory)).toBe(false);
+  });
+
+  it('releases every registered resource when a scenario throws after traffic', async () => {
+    const sentinel = new Error('sentinel lifecycle failure 2744');
+    let capturedServer: OcrScenarioServer | undefined;
+    let capturedRequest: http.ClientRequest | undefined;
+    let spawned: SpawnedMonitorHandle | undefined;
+    let requestClosed = false;
+    let upstreamReceivedBody = false;
+    const upstreamSockets = new Set<Socket>();
+    const caught = await captureError(
+      withOcrScenario(async (scope) => {
+        const upstream = http.createServer((request, response) => {
+          request.on('data', () => {
+            upstreamReceivedBody = true;
+          });
+          request.on('end', () => response.writeHead(200).end('ok'));
+        });
+        upstream.on('connection', (socket) => {
+          upstreamSockets.add(socket);
+          socket.once('close', () => upstreamSockets.delete(socket));
+        });
+        scope.registerUpstream(upstream);
+        capturedServer = upstream;
+        const upstreamPort = await listen(upstream);
+        const resource = await startEmbeddedMonitor(
+          `http://127.0.0.1:${upstreamPort}/v1`,
+          {
+            onSpawn: (monitor) => {
+              spawned = monitor;
+            },
+          },
+        );
+        scope.registerMonitor(resource);
+        const request = http.request(
+          new URL(asString(resource.ready.proxy_url)),
+          {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              'x-stainless-retry-count': '0',
+            },
+          },
+        );
+        scope.trackRequest(request);
+        capturedRequest = request;
+        request.once('close', () => {
+          requestClosed = true;
+        });
+        request.write('{"test":true}');
+        await waitFor(() => upstreamReceivedBody, 3000);
+        throw sentinel;
+      }),
+    );
+
+    const server = requireCaptured(capturedServer, 'upstream server');
+    const request = requireCaptured(capturedRequest, 'client request');
+    const monitor = requireCaptured(spawned, 'spawned monitor');
+    expect(caught).toBe(sentinel);
+    expect(server.listening).toBe(false);
+    expect(upstreamSockets.size).toBe(0);
+    expect(request.destroyed).toBe(true);
+    expect(requestClosed).toBe(true);
+    expect(monitor.child.exitCode ?? monitor.child.signalCode).not.toBeNull();
+    expect(fs.existsSync(monitor.directory)).toBe(false);
+  });
+
+  it('retains a monitor for fallback cleanup when termination fails', async () => {
+    const scenarioFailure = new Error('sentinel monitor scenario failure 2744');
+    const stopFailure = new Error('sentinel monitor stop failure 2744');
+    let resource: MonitorResource | undefined;
+    let originalKill: ((signal: string) => void) | undefined;
+    let caught: unknown;
+    let childRunningBeforeFallback = false;
+    let fallbackReapedChild = false;
+    let fallbackRemovedDirectory = false;
+
+    try {
+      caught = await captureError(
+        withOcrScenario(async (scope) => {
+          const upstream = http.createServer((_request, response) => {
+            response.writeHead(200).end('ok');
+          });
+          scope.registerUpstream(upstream);
+          const upstreamPort = await listen(upstream);
+          const monitor = await startEmbeddedMonitor(
+            `http://127.0.0.1:${upstreamPort}/v1`,
+          );
+          resource = monitor;
+          scope.registerMonitor(monitor);
+          originalKill = monitor.child.kill.bind(monitor.child);
+          let shouldFail = true;
+          monitor.child.kill = (signal) => {
+            if (shouldFail) {
+              shouldFail = false;
+              throw stopFailure;
+            }
+            originalKill?.(signal);
+          };
+          throw scenarioFailure;
+        }),
+      );
+
+      const monitor = requireCaptured(resource, 'monitor resource');
+      childRunningBeforeFallback =
+        monitor.child.exitCode === null && monitor.child.signalCode === null;
+      monitor.child.kill = requireCaptured(originalKill, 'original child kill');
+      await cleanEmbeddedMonitors();
+      fallbackReapedChild =
+        monitor.child.exitCode !== null || monitor.child.signalCode !== null;
+      fallbackRemovedDirectory = !fs.existsSync(monitor.directory);
+    } finally {
+      if (resource !== undefined && originalKill !== undefined) {
+        const monitor = resource;
+        monitor.child.kill = originalKill;
+        if (
+          monitor.child.exitCode === null &&
+          monitor.child.signalCode === null
+        ) {
+          originalKill('SIGKILL');
+          await waitFor(
+            () =>
+              monitor.child.exitCode !== null ||
+              monitor.child.signalCode !== null,
+          );
+        }
+        fs.rmSync(monitor.directory, { recursive: true, force: true });
+      }
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    if (!(caught instanceof AggregateError)) {
+      throw new Error('scenario and monitor stop failures were not aggregated');
+    }
+    expect(caught.errors[0]).toBe(scenarioFailure);
+    expect(caught.errors[1]).toBe(stopFailure);
+    expect(childRunningBeforeFallback).toBe(true);
+    expect(fallbackReapedChild).toBe(true);
+    expect(fallbackRemovedDirectory).toBe(true);
+  });
+
+  it('preserves a throwing request callback without a cleanup timeout', async () => {
+    const sentinel = new Error('sentinel request callback failure 2744');
+    let capturedRequest: http.ClientRequest | undefined;
+    const caught = await captureError(
+      withOcrScenario(async (scope) => {
+        await scope.proxyRequest('http://127.0.0.1:1', {
+          authorization: 'Bearer callback',
+          body: '{"request":"callback"}',
+          retryCount: '0',
+          onRequest: (request) => {
+            capturedRequest = request;
+            throw sentinel;
+          },
+        });
+      }),
+    );
+
+    const request = requireCaptured(capturedRequest, 'callback request');
+    expect(caught).toBe(sentinel);
+    expect(request.destroyed).toBe(true);
+  });
+
+  it('closes an internal sibling request and keeps cleanup failure secondary', async () => {
+    const cleanupFailure = new Error('sentinel upstream cleanup failure 2744');
+    const upstreamSockets = new Set<Socket>();
+    let openRequestSeen = false;
+    let openRequestClosed = false;
+    let openClientResponseClosed = false;
+    let capturedOpenRequest: http.ClientRequest | undefined;
+    let scenarioFailure: unknown;
+    const upstream = http.createServer((request, response) => {
+      if (request.url === '/open') {
+        openRequestSeen = true;
+        response.writeHead(200, { 'content-type': 'text/event-stream' });
+        response.write('data: open\n\n');
+        return;
+      }
+      request.socket.destroy();
+    });
+    upstream.on('connection', (socket) => {
+      upstreamSockets.add(socket);
+      socket.once('close', () => upstreamSockets.delete(socket));
+    });
+    upstream.closeAllConnections = () => {
+      throw cleanupFailure;
+    };
+
+    try {
+      const caught = await captureError(
+        withOcrScenario(async (scope) => {
+          scope.registerUpstream(upstream);
+          const upstreamPort = await listen(upstream);
+          const target = `http://127.0.0.1:${upstreamPort}`;
+          const openRequest = scope
+            .proxyRequest(target, {
+              authorization: 'Bearer open',
+              body: '{"request":"open"}',
+              pathSuffix: '/open',
+              retryCount: '0',
+              onRequest: (request) => {
+                capturedOpenRequest = request;
+                request.once('close', () => {
+                  openRequestClosed = true;
+                });
+                request.once('response', (response) => {
+                  response.once('close', () => {
+                    openClientResponseClosed = true;
+                  });
+                });
+              },
+            })
+            .catch(() => undefined);
+          await waitFor(() => openRequestSeen, 3000);
+          try {
+            await scope.proxyRequest(target, {
+              authorization: 'Bearer fail',
+              body: '{"request":"fail"}',
+              pathSuffix: '/fail',
+              retryCount: '0',
+            });
+          } catch (error) {
+            scenarioFailure = error;
+            throw error;
+          }
+          await openRequest;
+        }),
+      );
+
+      expect(caught).toBeInstanceOf(AggregateError);
+      if (!(caught instanceof AggregateError)) {
+        throw new Error('combined failure was not an AggregateError');
+      }
+      expect(caught.errors[0]).toBe(scenarioFailure);
+      expect(caught.errors[1]).toBe(cleanupFailure);
+      const openRequest = requireCaptured(
+        capturedOpenRequest,
+        'internally created open request',
+      );
+      expect(openRequest.destroyed).toBe(true);
+      expect(openRequestClosed).toBe(true);
+      expect(openClientResponseClosed).toBe(true);
+    } finally {
+      upstream.closeAllConnections = () => {
+        for (const socket of upstreamSockets) {
+          socket.destroy();
+        }
+      };
+      await closeServer(upstream);
+    }
+  });
+});

--- a/scripts/tests/ocr-transport-lifecycle-2744.test.ts
+++ b/scripts/tests/ocr-transport-lifecycle-2744.test.ts
@@ -107,6 +107,8 @@ function responseCallbackFailureProbe(): Record<string, unknown> {
       execFileSync(process.execPath, ['-e', source], {
         cwd: process.cwd(),
         encoding: 'utf8',
+        timeout: 30_000,
+        killSignal: 'SIGKILL',
       }),
     ),
   );

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -248,6 +248,8 @@
     "scripts/tests/ocr-concurrency-canary-2673-comparator.test.ts",
     "scripts/tests/ocr-concurrency-canary-2673-evidence.test.ts",
     "scripts/tests/ocr-concurrency-canary-2673-helpers.ts",
+    "scripts/tests/ocr-transport-lifecycle-2744-helpers.ts",
+    "scripts/tests/ocr-transport-lifecycle-2744.test.ts",
     "scripts/tests/ocr-canary-metrics.bun.test.ts",
     "scripts/tests/ocr-review-context.bun.test.ts",
     "scripts/tests/ocr-canary-embedding.bun.test.ts",


### PR DESCRIPTION
## TLDR

Makes the OCR real-loopback transport integration tests failure-safe and event-driven. Each scenario now owns its client requests and active responses, embedded monitor process and temporary directory, and upstream server/connections so failures cannot strand resources. The abort regression destroys the client only after the complete request body and first streamed response chunk are observed, then waits for bounded request/response close events instead of sleeping.

## Dive Deeper

- Adds a test-only OCR scenario scope that registers resources before traffic or callbacks can fail and cleans them in client, monitor, upstream order.
- Tracks responses before user response callbacks by prepending the ownership listener, including Bun's request-close-before-response-close behavior.
- Handles throwing pre-traffic request callbacks without converting the original failure into a cleanup timeout.
- Retains monitor ownership when termination fails so the global fallback can retry reaping the live child and removing its directory.
- Preserves the exact scenario/startup Error when cleanup succeeds. When cleanup also fails, an AggregateError retains the original failure first and the cleanup failure second.
- Moves assertions after scenario cleanup where they are not required to drive real traffic.
- Adds real-loopback regressions for startup failures, assertion/traffic failures, active sibling cleanup, direct callback failures, cleanup error ordering, and monitor fallback cleanup.
- Preserves the existing streaming, chunked request body, retry, HTTP 429, retry-header, concurrent request, partial-response, upstream-error, and telemetry behavior.
- Does not change workflow or production behavior, dependencies, or lint policy.

## Reviewer Test Plan

Run the focused lifecycle and existing transport suites independently:

    bun test --preload ./scripts/tests/test-setup.ts scripts/tests/ocr-transport-lifecycle-2744.test.ts
    bun test --preload ./scripts/tests/test-setup.ts scripts/tests/ocr-concurrency-canary-2673.test.ts

Then validate scripts typing and targeted lint:

    npx tsc --project tsconfig.scripts.json --noEmit
    npx eslint scripts/tests/ocr-concurrency-canary-2673-helpers.ts scripts/tests/ocr-concurrency-canary-2673.test.ts scripts/tests/ocr-transport-lifecycle-2744-helpers.ts scripts/tests/ocr-transport-lifecycle-2744.test.ts

Local evidence:

- Lifecycle suite passed three sequential runs: 9 tests and 48 assertions per run.
- Existing OCR canary suite passed: 15 tests and 75 assertions.
- Full core workspace suite passed: 363 of 363 files.
- Full build, typecheck, and format passed.
- ESLint guard, no-new-JS, copyright-year, doc-placement, test-shard, and test-file-coverage guards passed.
- StepFun smoke test passed with a valid three-line haiku.
- Root npm run test and npm run lint were attempted locally but did not complete before the shell's hard execution ceiling under concurrent system load. No failure was observed before termination, but these are intentionally not claimed as local passes; PR CI should provide the authoritative full-repository result.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ⚠️ focused/core/build/typecheck/format passed; root test/lint incomplete | ❓ | ❓ |
| npx      | ✅ scripts TypeScript and targeted ESLint | ❓ | ❓ |
| Docker   | ❓ | ❓ | ❓ |
| Podman   | ❓ | - | - |
| Seatbelt | ❓ | - | - |

## Linked issues / bugs

Fixes #2744


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR transport reliability for retries, streaming responses, connection failures, malformed headers, and aborted requests.
  * Improved cleanup after interrupted or failed OCR operations, including monitor processes, temporary resources, and network connections.
  * Preserved relevant errors and combined operation and cleanup failures for clearer diagnostics.
  * Ensured sensitive request data is excluded from telemetry.

* **Tests**
  * Expanded coverage for lifecycle handling, concurrent requests, telemetry, timeouts, startup failures, and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->