### PR TITLE
Resume the agent on the prompt submitted during cancelled-turn teardown (Fixes #3169)

### DIFF
--- a/packages/cli/src/ui/hooks/agentStream/__tests__/submitQueryTestFixtures.ts
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/submitQueryTestFixtures.ts
@@ -12,6 +12,9 @@ export function createQueueOperations(ref: { current: QueuedSubmission[] }) {
     enqueueSubmission: (submission: QueuedSubmission) => {
       ref.current = [...ref.current, submission];
     },
+    enqueueSubmissionFirst: (submission: QueuedSubmission) => {
+      ref.current = [submission, ...ref.current];
+    },
     requeueSubmission: (submission: QueuedSubmission) => {
       ref.current = [submission, ...ref.current];
     },

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useQueuedSubmissions.test.ts
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useQueuedSubmissions.test.ts
@@ -118,6 +118,63 @@ describe('useQueuedSubmissions', () => {
     });
   });
 
+  describe('enqueueSubmissionFirst', () => {
+    it('inserts a submission at the front of the queue', () => {
+      const { result } = renderHook(() => useQueuedSubmissions());
+
+      act(() => {
+        result.current.enqueueSubmission(makeSubmission('first'));
+        result.current.enqueueSubmission(makeSubmission('second'));
+        result.current.enqueueSubmissionFirst(makeSubmission('front'));
+      });
+
+      expect(result.current.queuedSubmissions.map(firstText)).toStrictEqual([
+        'front',
+        'first',
+        'second',
+      ]);
+    });
+
+    it('assigns a fresh unique queueId distinct from existing entries', () => {
+      const { result } = renderHook(() => useQueuedSubmissions());
+
+      act(() => {
+        result.current.enqueueSubmission(makeSubmission('a'));
+        result.current.enqueueSubmission(makeSubmission('b'));
+      });
+      const existingIds = result.current.queuedSubmissions.map(
+        (s) => s.queueId,
+      );
+
+      act(() => {
+        result.current.enqueueSubmissionFirst(makeSubmission('front'));
+      });
+
+      const frontEntry = result.current.queuedSubmissions[0];
+      expect(frontEntry.queueId).toBeDefined();
+      for (const id of existingIds) {
+        expect(frontEntry.queueId).not.toBe(id);
+      }
+    });
+
+    it('updates both the reactive state and the ref', () => {
+      const { result } = renderHook(() => useQueuedSubmissions());
+
+      act(() => {
+        result.current.enqueueSubmission(makeSubmission('existing'));
+        result.current.enqueueSubmissionFirst(makeSubmission('front'));
+      });
+
+      expect(result.current.queuedSubmissions.map(firstText)).toStrictEqual([
+        'front',
+        'existing',
+      ]);
+      expect(
+        result.current.queuedSubmissionsRef.current.map(firstText),
+      ).toStrictEqual(['front', 'existing']);
+    });
+  });
+
   describe('dequeueSubmission', () => {
     it('returns undefined when the queue is empty', () => {
       const { result } = renderHook(() => useQueuedSubmissions());

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.activationFailure.test.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.activationFailure.test.tsx
@@ -162,6 +162,7 @@ function renderUseSubmitQuery(deps: ActivationFailureDeps) {
     queuedSubmissionsRef: { current: [] },
     drainSuppressedRef: { current: false },
     enqueueSubmission: vi.fn(),
+    enqueueSubmissionFirst: vi.fn(),
     requeueSubmission: vi.fn(),
     dequeueSubmission: vi.fn(),
     clearSubmissions: vi.fn(),

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.cancelResumeRace.bun.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.cancelResumeRace.bun.tsx
@@ -31,6 +31,7 @@ import React, { act, type Dispatch, type SetStateAction } from 'react';
 import { renderHook, waitFor } from '../../../../test-utils/render.js';
 import {
   useSubmitQuery,
+  type SubmissionDisposition,
   type SubmissionExecutor,
   type UseSubmitQueryDeps,
 } from '../useSubmitQuery.js';
@@ -526,7 +527,7 @@ describe('useSubmitQuery — cancel-resume race (issue #3169)', () => {
     expect(result.current.drainSuppressedRef.current).toBe(true);
 
     // Invoke the executor with fromQueue=true
-    let disposition: string | undefined;
+    let disposition: SubmissionDisposition | undefined;
     await act(async () => {
       const executor = handles.submitQueryRef.current;
       expect(executor).not.toBeNull();

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.cancelResumeRace.bun.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.cancelResumeRace.bun.tsx
@@ -1,0 +1,717 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #3169 — "Fresh prompt can remain queued during
+ * cancelled-turn teardown."
+ *
+ * After an acknowledged prompt cancellation (Escape → "Request cancelled."),
+ * a NEW ordinary prompt submitted BEFORE the cancelled turn's aborted stream
+ * finishes async teardown is accepted into the queued-message drawer and stays
+ * there indefinitely because `drainSuppressedRef` is never cleared.
+ *
+ * These tests exercise the REAL `useSubmitQuery`, REAL `useCancellation`, and
+ * the REAL `useQueuedSubmissions` store — including its ref/state
+ * synchronisation and drain reservation — so queue ordering, suppression and
+ * active-turn ownership are all genuinely under test rather than stubbed.
+ *
+ * The Agent/provider boundary is faked via a deferred `runStreamRef` so a test
+ * can hold the aborted stream unresolved. `streamingState` is supplied as a
+ * prop (it is a render value owned by the orchestrator in production), and the
+ * event handlers, session stats, turn preparation and submission-error
+ * reporting collaborators are mocked because they are not part of this
+ * behavior.
+ */
+
+import { describe, it, expect, vi } from 'bun:test';
+import React, { act, type Dispatch, type SetStateAction } from 'react';
+import { renderHook, waitFor } from '../../../../test-utils/render.js';
+import {
+  useSubmitQuery,
+  type SubmissionExecutor,
+  type UseSubmitQueryDeps,
+} from '../useSubmitQuery.js';
+import { useCancellation } from '../useAgentStreamLifecycle.js';
+import { useQueuedSubmissions } from '../useQueuedSubmissions.js';
+import {
+  StreamingState,
+  MessageType,
+  type HistoryItemWithoutId,
+} from '../../../types.js';
+import { KeypressProvider } from '../../../contexts/KeypressContext.js';
+import { createFakeAgentFromMockClient } from '../../useAgentStream-test-helpers.js';
+import { PendingResponseBuffer } from '../pendingResponseBuffer.js';
+import { createStreamRuntimeForTest } from './streamRuntimeTestHelper.js';
+import { createDeferred } from './createDeferred.js';
+import {
+  createLoadedSettings,
+  createMockOverrides,
+} from './submitQueryTestFixtures.js';
+import type { AgentRequestInput } from '@vybestack/llxprt-code-core';
+
+// ─── Module mocks ───────────────────────────────────────────────────────────
+
+// prepareQueryForAgent must pass through the actual query so ordering tests
+// can verify which prompt each runStream call received.
+const prepareQueryForAgentMock = vi
+  .fn()
+  .mockImplementation(async (query: AgentRequestInput) => ({
+    queryToSend: query,
+    shouldProceed: true,
+  }));
+
+void vi.mock('../useStreamEventHandlers.js', () => ({
+  useStreamEventHandlers: () => ({
+    displayUserMessage: vi.fn(),
+    prepareQueryForAgent: prepareQueryForAgentMock,
+    handleLoopDetectedEvent: vi.fn(),
+  }),
+}));
+
+void vi.mock('../../../contexts/SessionContext.js', () => ({
+  useSessionStats: () => ({
+    startNewPrompt: vi.fn(),
+    getPromptCount: () => 0,
+  }),
+}));
+
+void vi.mock('../turnPreparation.js', () => ({
+  prepareTurnForQuery: vi.fn().mockResolvedValue(undefined),
+}));
+
+void vi.mock('../streamUtils.js', () => ({
+  handleSubmissionError: vi.fn(),
+  processSlashCommandResult: vi.fn(),
+}));
+
+function createMockAgent() {
+  return createFakeAgentFromMockClient({
+    getCurrentSequenceModel: () => 'test-model',
+  });
+}
+
+function createMockSetState(
+  calls: boolean[],
+): Dispatch<SetStateAction<boolean>> {
+  return (value) => {
+    if (typeof value === 'boolean') calls.push(value);
+  };
+}
+
+function KeypressTestWrapper({ children }: React.PropsWithChildren) {
+  return <KeypressProvider>{children}</KeypressProvider>;
+}
+
+// ─── Render helper (REAL queue store) ───────────────────────────────────────
+
+interface RaceTestHandles {
+  setIsRespondingCalls: boolean[];
+  setIsResponding: Dispatch<SetStateAction<boolean>>;
+  abortControllerRef: React.MutableRefObject<AbortController | null>;
+  runStreamRef: UseSubmitQueryDeps['runStreamRef'];
+  addItem: ReturnType<typeof vi.fn>;
+  flushPendingHistoryItem: ReturnType<typeof vi.fn>;
+  setPendingHistoryItem: ReturnType<typeof vi.fn>;
+  pendingHistoryItemRef: React.MutableRefObject<HistoryItemWithoutId | null>;
+  submitQueryRef: React.MutableRefObject<SubmissionExecutor | null>;
+}
+
+function createTestHandles(
+  runStream: ReturnType<typeof vi.fn>,
+): RaceTestHandles {
+  const setIsRespondingCalls: boolean[] = [];
+  return {
+    setIsRespondingCalls,
+    setIsResponding: createMockSetState(setIsRespondingCalls),
+    abortControllerRef: { current: null },
+    runStreamRef: { current: runStream },
+    addItem: vi.fn().mockReturnValue(1),
+    flushPendingHistoryItem: vi.fn(),
+    setPendingHistoryItem: vi.fn(),
+    pendingHistoryItemRef: { current: null },
+    submitQueryRef: { current: null },
+  };
+}
+
+interface RenderOptions {
+  initialStreamingState?: StreamingState;
+  wrapper?: React.ComponentType<{ children: React.ReactNode }>;
+}
+
+function renderWithRealQueue(
+  handles: RaceTestHandles,
+  options: RenderOptions = {},
+) {
+  const turnCancelledRef: React.MutableRefObject<boolean> = { current: false };
+  const drainSuppressedRef: React.MutableRefObject<boolean> = {
+    current: false,
+  };
+
+  return renderHook(
+    ({ streamingState }: { streamingState: StreamingState }) => {
+      // REAL queue store — not the createQueueOperations stub.
+      const queue = useQueuedSubmissions();
+
+      const submitDeps: UseSubmitQueryDeps = {
+        runtime: createStreamRuntimeForTest({}, createMockOverrides()),
+        agent: createMockAgent(),
+        addItem: handles.addItem,
+        removeItems: vi.fn(),
+        settings: createLoadedSettings(),
+        onDebugMessage: vi.fn(),
+        onCancelSubmit: vi.fn(),
+        onAuthError: vi.fn(),
+        recordingIntegration: undefined,
+        sanitizeContent: (text: string) => ({ text, blocked: false }),
+        flushPendingHistoryItem: handles.flushPendingHistoryItem,
+        pendingResponse: new PendingResponseBuffer(undefined),
+        pendingHistoryItemRef: handles.pendingHistoryItemRef,
+        thinkingBlocksRef: { current: [] },
+        turnCancelledRef,
+        setTurnCancelled: (v: boolean) => void (turnCancelledRef.current = v),
+        drainSuppressedRef,
+        queuedSubmissionsRef: queue.queuedSubmissionsRef,
+        enqueueSubmission: queue.enqueueSubmission,
+        enqueueSubmissionFirst: queue.enqueueSubmissionFirst,
+        requeueSubmission: queue.requeueSubmission,
+        dequeueSubmission: queue.dequeueSubmission,
+        clearSubmissions: queue.clearSubmissions,
+        tryReserveDrain: queue.tryReserveDrain,
+        releaseDrain: queue.releaseDrain,
+        setPendingHistoryItem: handles.setPendingHistoryItem,
+        setIsResponding: handles.setIsResponding,
+        setInitError: vi.fn(),
+        setThought: vi.fn(),
+        setLastAgentActivityTime: vi.fn(),
+        scheduleToolCalls: vi.fn(),
+        abortActiveStream: vi.fn(),
+        handleShellCommand: vi.fn().mockReturnValue(false),
+        handleSlashCommand: vi.fn().mockResolvedValue(false),
+        logger: null,
+        shellModeActive: false,
+        loopDetectedRef: { current: false },
+        lastProfileNameRef: { current: undefined },
+        lastModelInfoRef: { current: null },
+        lastModelIdentityRef: { current: null },
+        abortControllerRef: handles.abortControllerRef,
+        runStreamRef: handles.runStreamRef,
+        submitQueryRef: handles.submitQueryRef,
+        isResponding: false,
+        streamingState,
+      };
+
+      const submission = useSubmitQuery(submitDeps);
+      const cancellation = useCancellation(
+        streamingState,
+        turnCancelledRef,
+        (v: boolean) => void (turnCancelledRef.current = v),
+        handles.abortControllerRef,
+        vi.fn(),
+        handles.pendingHistoryItemRef,
+        handles.flushPendingHistoryItem,
+        handles.addItem,
+        handles.setPendingHistoryItem,
+        vi.fn(),
+        handles.setIsResponding,
+        vi.fn(),
+        drainSuppressedRef,
+      );
+      return {
+        ...submission,
+        ...cancellation,
+        queue,
+        turnCancelledRef,
+        drainSuppressedRef,
+      };
+    },
+    {
+      initialProps: {
+        streamingState: options.initialStreamingState ?? StreamingState.Idle,
+      },
+      wrapper: options.wrapper ?? KeypressTestWrapper,
+    },
+  );
+}
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+function queryText(q: AgentRequestInput): string {
+  if (typeof q === 'string') return q;
+  if (!Array.isArray(q)) return '';
+  const part = q[0];
+  return 'text' in part ? String(part.text) : '';
+}
+
+function observedRunStreamOrder(runStream: ReturnType<typeof vi.fn>): string[] {
+  return runStream.mock.calls.map((call) =>
+    queryText(call[0] as AgentRequestInput),
+  );
+}
+
+function assertCancelledInfoAdded(addItem: ReturnType<typeof vi.fn>): void {
+  const cancelItem = addItem.mock.calls.find(
+    (call) =>
+      (call[0] as { type: string }).type === MessageType.INFO &&
+      (call[0] as { text: string }).text === 'Request cancelled.',
+  );
+  expect(cancelItem).toBeDefined();
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('useSubmitQuery — cancel-resume race (issue #3169)', () => {
+  it('T1: fresh prompt during cancelled-turn teardown auto-drains after teardown', async () => {
+    const turnADeferred = createDeferred<void>();
+    const turnBDeferred = createDeferred<void>();
+    const runStream = vi
+      .fn()
+      .mockReturnValueOnce(turnADeferred.promise)
+      .mockReturnValueOnce(turnBDeferred.promise);
+    const handles = createTestHandles(runStream);
+    const { result, rerender } = renderWithRealQueue(handles);
+
+    // 1. Submit A
+    let turnAPromise!: Promise<void>;
+    await act(async () => {
+      turnAPromise = result.current.submitQuery('A');
+    });
+    await waitFor(() =>
+      expect(handles.setIsRespondingCalls).toStrictEqual([true]),
+    );
+    expect(runStream).toHaveBeenCalledTimes(1);
+    rerender({ streamingState: StreamingState.Responding });
+
+    // 2. Cancel A
+    const turnASignal = handles.abortControllerRef.current?.signal;
+    await act(async () => {
+      result.current.cancelOngoingRequest();
+    });
+    expect(handles.setIsRespondingCalls).toStrictEqual([true, false]);
+    expect(turnASignal?.aborted).toBe(true);
+    expect(result.current.turnCancelledRef.current).toBe(true);
+    expect(result.current.drainSuppressedRef.current).toBe(true);
+    assertCancelledInfoAdded(handles.addItem);
+    rerender({ streamingState: StreamingState.Idle });
+
+    // 3. Keep A's runStream UNRESOLVED. Submit B.
+    await act(async () => {
+      await result.current.submitQuery('B');
+    });
+
+    // 4. runStream STILL called once (no concurrent iterator). B is parked at
+    //    the front of the queue and suppression has been released so the
+    //    settle-time drain can run it without another Enter.
+    expect(runStream).toHaveBeenCalledTimes(1);
+    expect(result.current.drainSuppressedRef.current).toBe(false);
+    expect(
+      result.current.queue.queuedSubmissionsRef.current.map((s) =>
+        queryText(s.query),
+      ),
+    ).toStrictEqual(['B']);
+
+    // 5. Resolve A's deferred
+    await act(async () => {
+      turnADeferred.resolve();
+    });
+
+    // 6. runStream called twice, second with B, queue empty — no second Enter
+    await waitFor(() => expect(runStream).toHaveBeenCalledTimes(2));
+    expect(queryText(runStream.mock.calls[1][0] as AgentRequestInput)).toBe(
+      'B',
+    );
+    await waitFor(() =>
+      expect(result.current.queue.queuedSubmissionsRef.current).toHaveLength(0),
+    );
+
+    // 7. Resolve B; queue empty, responding released
+    rerender({ streamingState: StreamingState.Responding });
+    await act(async () => {
+      turnBDeferred.resolve();
+    });
+    // setIsResponding sequence: true(A), false(cancel), false(A finally),
+    // true(B drain), false(B finally)
+    await waitFor(() =>
+      expect(handles.setIsRespondingCalls).toStrictEqual([
+        true,
+        false,
+        false,
+        true,
+        false,
+      ]),
+    );
+    expect(result.current.queue.queuedSubmissionsRef.current).toHaveLength(0);
+
+    await act(async () => void turnAPromise.catch(() => {}));
+  });
+
+  it('T2: preserved pre-cancel entries drain AFTER the resume prompt (FIFO priority)', async () => {
+    const deferreds = [
+      createDeferred<void>(),
+      createDeferred<void>(),
+      createDeferred<void>(),
+      createDeferred<void>(),
+    ];
+    let started = 0;
+    // Fail fast rather than silently resolving: an extra turn would mean the
+    // queue drained more times than the four expected prompts.
+    const runStream = vi.fn((..._args: unknown[]) => {
+      if (started >= deferreds.length) {
+        throw new Error(`Unexpected turn ${started + 1} started`);
+      }
+      const deferred = deferreds[started];
+      started += 1;
+      return deferred.promise;
+    });
+    const handles = createTestHandles(runStream);
+    const { result, rerender } = renderWithRealQueue(handles);
+
+    // 1. Submit A, rerender Responding
+    let turnAPromise!: Promise<void>;
+    await act(async () => {
+      turnAPromise = result.current.submitQuery('A');
+    });
+    await waitFor(() =>
+      expect(handles.setIsRespondingCalls).toStrictEqual([true]),
+    );
+    expect(runStream).toHaveBeenCalledTimes(1);
+    rerender({ streamingState: StreamingState.Responding });
+
+    // Submit Q1, Q2 (both queued)
+    await act(async () => {
+      await result.current.submitQuery('Q1');
+      await result.current.submitQuery('Q2');
+    });
+    expect(result.current.queue.queuedSubmissionsRef.current).toHaveLength(2);
+
+    // 2. Cancel A, hold unresolved, rerender Idle
+    await act(async () => {
+      result.current.cancelOngoingRequest();
+    });
+    rerender({ streamingState: StreamingState.Idle });
+
+    // 3. Q1/Q2 still queued, runStream still once
+    expect(result.current.queue.queuedSubmissionsRef.current).toHaveLength(2);
+    expect(runStream).toHaveBeenCalledTimes(1);
+
+    // 4. Submit B (resume intent) — front-inserted ahead of Q1/Q2, and
+    //    cancellation's drain suppression is released.
+    await act(async () => {
+      await result.current.submitQuery('B');
+    });
+    expect(
+      result.current.queue.queuedSubmissionsRef.current.map((s) =>
+        queryText(s.query),
+      ),
+    ).toStrictEqual(['B', 'Q1', 'Q2']);
+    expect(result.current.drainSuppressedRef.current).toBe(false);
+
+    // 5. Resolve A, then each subsequent turn in order
+    await act(async () => {
+      deferreds[0].resolve();
+    });
+    // B should drain to the front and start
+    await waitFor(() => expect(runStream).toHaveBeenCalledTimes(2));
+    rerender({ streamingState: StreamingState.Responding });
+
+    await act(async () => {
+      deferreds[1].resolve();
+    });
+    rerender({ streamingState: StreamingState.Idle });
+    await waitFor(() => expect(runStream).toHaveBeenCalledTimes(3));
+    rerender({ streamingState: StreamingState.Responding });
+
+    await act(async () => {
+      deferreds[2].resolve();
+    });
+    rerender({ streamingState: StreamingState.Idle });
+    await waitFor(() => expect(runStream).toHaveBeenCalledTimes(4));
+    rerender({ streamingState: StreamingState.Responding });
+
+    await act(async () => {
+      deferreds[3].resolve();
+    });
+    rerender({ streamingState: StreamingState.Idle });
+
+    // 6. Order is A, B, Q1, Q2 — each exactly once
+    expect(observedRunStreamOrder(runStream)).toStrictEqual([
+      'A',
+      'B',
+      'Q1',
+      'Q2',
+    ]);
+    await waitFor(() =>
+      expect(result.current.queue.queuedSubmissionsRef.current).toHaveLength(0),
+    );
+
+    await act(async () => void turnAPromise.catch(() => {}));
+  });
+
+  it('T3: when teardown finishes BEFORE the fresh submission, B runs directly', async () => {
+    const turnADeferred = createDeferred<void>();
+    const turnBDeferred = createDeferred<void>();
+    const runStream = vi
+      .fn()
+      .mockReturnValueOnce(turnADeferred.promise)
+      .mockReturnValueOnce(turnBDeferred.promise);
+    const handles = createTestHandles(runStream);
+    const { result, rerender } = renderWithRealQueue(handles);
+
+    // Submit A
+    let turnAPromise!: Promise<void>;
+    await act(async () => {
+      turnAPromise = result.current.submitQuery('A');
+    });
+    await waitFor(() =>
+      expect(handles.setIsRespondingCalls).toStrictEqual([true]),
+    );
+    rerender({ streamingState: StreamingState.Responding });
+
+    // Cancel A
+    await act(async () => {
+      result.current.cancelOngoingRequest();
+    });
+
+    // Resolve A BEFORE submitting B (teardown wins)
+    await act(async () => {
+      turnADeferred.resolve();
+    });
+    rerender({ streamingState: StreamingState.Idle });
+
+    // Submit B — should run directly via fresh path
+    let turnBPromise!: Promise<void>;
+    await act(async () => {
+      turnBPromise = result.current.submitQuery('B');
+    });
+    await waitFor(() => expect(runStream).toHaveBeenCalledTimes(2));
+
+    // Queue was never non-empty
+    expect(result.current.queue.queuedSubmissionsRef.current).toHaveLength(0);
+
+    // Order is A, B
+    expect(observedRunStreamOrder(runStream)).toStrictEqual(['A', 'B']);
+
+    await act(async () => {
+      turnBDeferred.resolve();
+    });
+    await act(async () => {
+      void turnAPromise.catch(() => {});
+      void turnBPromise.catch(() => {});
+    });
+  });
+
+  it('T4: queue-originated retry (fromQueue=true) returns requeue and keeps suppression', async () => {
+    const turnADeferred = createDeferred<void>();
+    const runStream = vi.fn().mockReturnValueOnce(turnADeferred.promise);
+    const handles = createTestHandles(runStream);
+    const { result, rerender } = renderWithRealQueue(handles);
+
+    // Submit A to occupy the active turn
+    let turnAPromise!: Promise<void>;
+    await act(async () => {
+      turnAPromise = result.current.submitQuery('A');
+    });
+    await waitFor(() =>
+      expect(handles.setIsRespondingCalls).toStrictEqual([true]),
+    );
+    rerender({ streamingState: StreamingState.Responding });
+
+    // Cancel to set drainSuppressedRef = true
+    await act(async () => {
+      result.current.cancelOngoingRequest();
+    });
+    rerender({ streamingState: StreamingState.Idle });
+    expect(result.current.drainSuppressedRef.current).toBe(true);
+
+    // Invoke the executor with fromQueue=true
+    let disposition: string | undefined;
+    await act(async () => {
+      const executor = handles.submitQueryRef.current;
+      expect(executor).not.toBeNull();
+      if (executor) {
+        disposition = await executor('retry-item', undefined, undefined, true);
+      }
+    });
+
+    // A queue-originated attempt is requeued and must neither clear
+    // cancellation suppression nor enter the queue as a new entry.
+    expect(disposition).toBe('requeue');
+    expect(result.current.drainSuppressedRef.current).toBe(true);
+    expect(result.current.queue.queuedSubmissionsRef.current).toHaveLength(0);
+    expect(runStream).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      turnADeferred.resolve();
+    });
+    await act(async () => void turnAPromise.catch(() => {}));
+  });
+
+  it('T5: live-turn submission (Responding) appends to BACK and keeps suppression false', async () => {
+    const turnADeferred = createDeferred<void>();
+    const runStream = vi.fn().mockReturnValueOnce(turnADeferred.promise);
+    const handles = createTestHandles(runStream);
+    const { result, rerender } = renderWithRealQueue(handles);
+
+    // Submit A to start the live turn
+    let turnAPromise!: Promise<void>;
+    await act(async () => {
+      turnAPromise = result.current.submitQuery('A');
+    });
+    await waitFor(() =>
+      expect(handles.setIsRespondingCalls).toStrictEqual([true]),
+    );
+    rerender({ streamingState: StreamingState.Responding });
+
+    // Submit Q1 then B while Responding
+    await act(async () => {
+      await result.current.submitQuery('Q1');
+      await result.current.submitQuery('B');
+    });
+
+    // Both appended to the BACK in FIFO order
+    const texts = result.current.queue.queuedSubmissionsRef.current.map((s) =>
+      queryText(s.query),
+    );
+    expect(texts).toStrictEqual(['Q1', 'B']);
+
+    // Suppression is untouched by a live-turn submission.
+    expect(result.current.drainSuppressedRef.current).toBe(false);
+
+    // runStream still called once (no premature drain during live turn)
+    expect(runStream).toHaveBeenCalledTimes(1);
+
+    // Settle A while still Responding so the queue is never drained here: this
+    // test is only about where a live-turn submission lands.
+    await act(async () => {
+      turnADeferred.resolve();
+      await turnAPromise.catch(() => {});
+    });
+    expect(runStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('T6: cancellation alone preserves queued entries even after the stream settles', async () => {
+    const turnADeferred = createDeferred<void>();
+    const runStream = vi.fn().mockReturnValueOnce(turnADeferred.promise);
+    const handles = createTestHandles(runStream);
+    const { result, rerender } = renderWithRealQueue(handles);
+
+    // Submit A
+    let turnAPromise!: Promise<void>;
+    await act(async () => {
+      turnAPromise = result.current.submitQuery('A');
+    });
+    await waitFor(() =>
+      expect(handles.setIsRespondingCalls).toStrictEqual([true]),
+    );
+    rerender({ streamingState: StreamingState.Responding });
+
+    // Queue Q1 and Q2
+    await act(async () => {
+      await result.current.submitQuery('Q1');
+      await result.current.submitQuery('Q2');
+    });
+    expect(result.current.queue.queuedSubmissionsRef.current).toHaveLength(2);
+
+    // Cancel A
+    await act(async () => {
+      result.current.cancelOngoingRequest();
+    });
+
+    // Resolve A's stream and go Idle
+    await act(async () => {
+      turnADeferred.resolve();
+    });
+    rerender({ streamingState: StreamingState.Idle });
+
+    // Queue is unchanged — cancellation alone does not drain
+    await waitFor(() =>
+      expect(
+        result.current.queue.queuedSubmissionsRef.current.map((s) =>
+          queryText(s.query),
+        ),
+      ).toStrictEqual(['Q1', 'Q2']),
+    );
+    // Suppression is still engaged: only an explicit resume releases it.
+    expect(result.current.drainSuppressedRef.current).toBe(true);
+    // runStream still called once — no extra turn
+    expect(runStream).toHaveBeenCalledTimes(1);
+
+    await act(async () => void turnAPromise.catch(() => {}));
+  });
+
+  it('T7: resumes even when the cancelled turn still renders WaitingForConfirmation', async () => {
+    // streamingState is derived from tool calls flattened across EVERY
+    // scheduler, while cancellation only cancels the main one. So an
+    // awaiting_approval call owned by another scheduler keeps the public state
+    // at WaitingForConfirmation after the cancellation is acknowledged. The
+    // resume classification must not depend on that render value.
+    const turnADeferred = createDeferred<void>();
+    const turnBDeferred = createDeferred<void>();
+    const runStream = vi
+      .fn()
+      .mockReturnValueOnce(turnADeferred.promise)
+      .mockReturnValueOnce(turnBDeferred.promise);
+    const handles = createTestHandles(runStream);
+    const { result, rerender } = renderWithRealQueue(handles);
+
+    let turnAPromise!: Promise<void>;
+    await act(async () => {
+      turnAPromise = result.current.submitQuery('A');
+    });
+    await waitFor(() =>
+      expect(handles.setIsRespondingCalls).toStrictEqual([true]),
+    );
+
+    // Cancel from WaitingForConfirmation and keep that rendered state.
+    rerender({ streamingState: StreamingState.WaitingForConfirmation });
+    await act(async () => {
+      result.current.cancelOngoingRequest();
+    });
+    expect(result.current.turnCancelledRef.current).toBe(true);
+    expect(result.current.drainSuppressedRef.current).toBe(true);
+    assertCancelledInfoAdded(handles.addItem);
+
+    // Fresh prompt B while the state is still WaitingForConfirmation.
+    await act(async () => {
+      await result.current.submitQuery('B');
+    });
+    expect(
+      result.current.queue.queuedSubmissionsRef.current.map((s) =>
+        queryText(s.query),
+      ),
+    ).toStrictEqual(['B']);
+    expect(result.current.drainSuppressedRef.current).toBe(false);
+    expect(runStream).toHaveBeenCalledTimes(1);
+
+    // Once the cancelled stream settles and the confirmation clears, B runs
+    // automatically and exactly once.
+    await act(async () => {
+      turnADeferred.resolve();
+      await turnAPromise.catch(() => {});
+    });
+    rerender({ streamingState: StreamingState.Idle });
+    await waitFor(() => expect(runStream).toHaveBeenCalledTimes(2));
+    expect(observedRunStreamOrder(runStream)).toStrictEqual(['A', 'B']);
+    await waitFor(() =>
+      expect(result.current.queue.queuedSubmissionsRef.current).toHaveLength(0),
+    );
+
+    // B's turn promise is owned by the internal drain, not returned by
+    // submitQuery (which only enqueued it), so settle it by waiting for the
+    // observable responding release rather than by awaiting a returned promise.
+    await act(async () => {
+      turnBDeferred.resolve();
+    });
+    await waitFor(() =>
+      expect(handles.setIsRespondingCalls).toStrictEqual([
+        true,
+        false,
+        false,
+        true,
+        false,
+      ]),
+    );
+  });
+});

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.mcpDiscovery.test.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.mcpDiscovery.test.tsx
@@ -161,6 +161,9 @@ function renderUseSubmitQuery(
     enqueueSubmission: vi.fn((sub: QueuedSubmission) =>
       hookDeps.queuedSubmissionsRef.current.push(sub),
     ),
+    enqueueSubmissionFirst: vi.fn((sub: QueuedSubmission) =>
+      hookDeps.queuedSubmissionsRef.current.unshift(sub),
+    ),
     requeueSubmission: vi.fn((sub: QueuedSubmission) =>
       hookDeps.queuedSubmissionsRef.current.unshift(sub),
     ),

--- a/packages/cli/src/ui/hooks/agentStream/useAgentStreamOrchestration.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentStreamOrchestration.ts
@@ -392,6 +392,7 @@ function buildSubmitQueryDeps({
     drainSuppressedRef: st.drainSuppressedRef,
     queuedSubmissionsRef: st.queuedSubmissionsRef,
     enqueueSubmission: st.enqueueSubmission,
+    enqueueSubmissionFirst: st.enqueueSubmissionFirst,
     requeueSubmission: st.requeueSubmission,
     dequeueSubmission: st.dequeueSubmission,
     clearSubmissions: st.clearSubmissions,

--- a/packages/cli/src/ui/hooks/agentStream/useQueuedSubmissions.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useQueuedSubmissions.ts
@@ -15,7 +15,11 @@ import type { QueuedSubmission } from './types.js';
  * - `queuedSubmissions` (reactive state for rendering)
  * - `queuedSubmissionsRef` (stable ref for callback access)
  * - `enqueueSubmission` (immutable append — updates both ref and state)
- * - `requeueSubmission` (immutable front insertion for retry)
+ * - `enqueueSubmissionFirst` (immutable front insertion of a NEW submission,
+ *   minting a fresh `queueId`; used for post-cancel resume priority, issue
+ *   #3169)
+ * - `requeueSubmission` (immutable front insertion for retry — deliberately
+ *   preserves the existing `queueId` of an already-identified item)
  * - `dequeueSubmission` (FIFO shift — updates both ref and state)
  * - `clearSubmissions` (clear — updates both ref and state)
  *
@@ -41,13 +45,27 @@ export function useQueuedSubmissions() {
   const drainInFlightRef = useRef(false);
   const nextQueueIdRef = useRef(0);
 
-  const enqueueSubmission = useCallback(
-    (submission: QueuedSubmission): void => {
+  const withQueueId = useCallback(
+    (submission: QueuedSubmission): QueuedSubmission => {
       const queueId = nextQueueIdRef.current;
       nextQueueIdRef.current = queueId + 1;
-      setQueuedSubmissions((prev) => [...prev, { ...submission, queueId }]);
+      return { ...submission, queueId };
     },
-    [setQueuedSubmissions],
+    [],
+  );
+
+  const enqueueSubmission = useCallback(
+    (submission: QueuedSubmission): void => {
+      setQueuedSubmissions((prev) => [...prev, withQueueId(submission)]);
+    },
+    [setQueuedSubmissions, withQueueId],
+  );
+
+  const enqueueSubmissionFirst = useCallback(
+    (submission: QueuedSubmission): void => {
+      setQueuedSubmissions((prev) => [withQueueId(submission), ...prev]);
+    },
+    [setQueuedSubmissions, withQueueId],
   );
 
   const requeueSubmission = useCallback(
@@ -86,6 +104,7 @@ export function useQueuedSubmissions() {
     queuedSubmissions,
     queuedSubmissionsRef,
     enqueueSubmission,
+    enqueueSubmissionFirst,
     requeueSubmission,
     dequeueSubmission,
     clearSubmissions,

--- a/packages/cli/src/ui/hooks/agentStream/useStreamState.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useStreamState.ts
@@ -57,6 +57,7 @@ export interface UseStreamStateReturn {
   queuedSubmissionsRef: React.MutableRefObject<QueuedSubmission[]>;
   queuedSubmissions: readonly QueuedSubmission[];
   enqueueSubmission: (submission: QueuedSubmission) => void;
+  enqueueSubmissionFirst: (submission: QueuedSubmission) => void;
   requeueSubmission: (submission: QueuedSubmission) => void;
   dequeueSubmission: () => QueuedSubmission | undefined;
   clearSubmissions: () => void;
@@ -242,6 +243,7 @@ function useBasicStreamState() {
     queuedSubmissions,
     queuedSubmissionsRef,
     enqueueSubmission,
+    enqueueSubmissionFirst,
     requeueSubmission,
     dequeueSubmission,
     clearSubmissions,
@@ -275,6 +277,7 @@ function useBasicStreamState() {
     queuedSubmissions,
     queuedSubmissionsRef,
     enqueueSubmission,
+    enqueueSubmissionFirst,
     requeueSubmission,
     dequeueSubmission,
     clearSubmissions,

--- a/packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useSubmitQuery.ts
@@ -105,6 +105,7 @@ export interface UseSubmitQueryDeps {
   setTurnCancelled: (value: boolean) => void;
   queuedSubmissionsRef: React.MutableRefObject<QueuedSubmission[]>;
   enqueueSubmission: (submission: QueuedSubmission) => void;
+  enqueueSubmissionFirst: (submission: QueuedSubmission) => void;
   requeueSubmission: (submission: QueuedSubmission) => void;
   dequeueSubmission: () => QueuedSubmission | undefined;
   clearSubmissions: () => void;
@@ -610,6 +611,19 @@ function useSubmitQueryCallback(cbd: SubmitQueryCallbackDeps) {
         if (fromQueue) {
           return 'requeue';
         }
+        // Issue #3169: a fresh (non-queue-originated) submission arriving
+        // while an acknowledged cancellation still suppresses draining is
+        // explicit intent to resume. It must not inherit that suppression —
+        // which would leave it stuck in the drawer until the user pressed
+        // Enter again — and it must precede any preserved pre-cancel entries,
+        // so it is front-inserted and suppression is released. It still waits
+        // for the cancelled turn to release activeTurnRef, so serialization is
+        // unaffected.
+        if (isResumeAfterAcknowledgedCancellation(current)) {
+          current.enqueueSubmissionFirst({ query, promptId });
+          current.drainSuppressedRef.current = false;
+          return 'consumed';
+        }
         current.enqueueSubmission({
           query,
           promptId,
@@ -812,4 +826,28 @@ async function executeStream(
  */
 function isCurrentTurn(deps: UseSubmitQueryDeps, signal: AbortSignal): boolean {
   return deps.abortControllerRef.current?.signal === signal;
+}
+
+/**
+ * Issue #3169: detects a fresh submission that arrives while an acknowledged
+ * cancellation still suppresses queue draining.
+ *
+ * `drainSuppressedRef` is authoritative here because cancellation is its only
+ * writer of `true` (useCancellation), and the two paths that clear it —
+ * claiming a fresh turn below, and the explicit empty-Enter release in
+ * useAgentStreamOrchestration — both run before any turn can proceed. So
+ * observing it set on a non-queue-originated submission means exactly one
+ * thing: the user cancelled and is now resuming.
+ *
+ * Deliberately NOT gated on `streamingState`. That is a render value derived
+ * from tool calls flattened across every scheduler, so an `awaiting_approval`
+ * call owned by a non-main scheduler keeps it at WaitingForConfirmation even
+ * after cancellation has been acknowledged — which would misclassify the
+ * resume prompt as ordinary queued work and leave it stuck, the very bug this
+ * fixes.
+ */
+function isResumeAfterAcknowledgedCancellation(
+  deps: SubmitQueryCallbackDeps,
+): boolean {
+  return deps.drainSuppressedRef.current;
 }

--- a/project-plans/20260808-issue3169/plan.md
+++ b/project-plans/20260808-issue3169/plan.md
@@ -1,0 +1,223 @@
+# Issue 3169 — Fresh prompt can remain queued during cancelled-turn teardown
+
+## Problem (verified against source at `main` b45e8cdd7)
+
+`useCancellation` (`packages/cli/src/ui/hooks/agentStream/useAgentStreamLifecycle.ts:237-260`)
+synchronously:
+
+1. `setTurnCancelled(true)`
+2. `drainSuppressedRef.current = true`
+3. `abortControllerRef.current?.abort()`
+4. `setIsResponding(false)`
+
+`useStreamingState` (same file, lines 35-56) then reports `Idle`, because
+`turnCancelled === true` makes outstanding tool calls count as settled.
+
+The cancelled turn's `submitQuery` invocation, however, still owns
+`activeTurnRef` — it is only released in the outer `finally` of
+`useSubmitQueryCallback` (`useSubmitQuery.ts:650-660`) after `runStream`
+settles asynchronously.
+
+So a fresh prompt B submitted in that window hits
+`useSubmitQuery.ts:606-618`:
+
+```
+if (current.activeTurnRef.current || isQueueable(current.streamingState)) {
+  if (fromQueue) return 'requeue';
+  current.enqueueSubmission({ query, promptId });   // appended to the BACK
+  return 'consumed';                                // early return
+}
+current.activeTurnRef.current = true;
+current.drainSuppressedRef.current = false;         // NEVER REACHED
+```
+
+Two defects result:
+
+- **D1 (stuck prompt).** `drainSuppressedRef` is never cleared, so when A
+  finally settles and the `finally` calls `scheduleNextQueuedSubmission`,
+  `useScheduleNext` (`useSubmitQuery.ts:536-548`) rejects the drain because
+  `drainSuppressedRef.current` is still `true`. B remains in the drawer until
+  the user presses Enter on empty input, which routes through
+  `sendAllQueuedSubmissions` (`useAgentStreamOrchestration.ts:313-316`) — the
+  only place that clears suppression for queue-originated work.
+- **D2 (ordering).** B is appended to the back of the queue, so if pre-cancel
+  entries Q1/Q2 were preserved, an unsuppressed drain would run Q1, Q2, B.
+  The issue requires B (the explicit resume intent) to run first.
+
+Ownership analysis: `drainSuppressedRef.current === true` can only be observed
+by a *fresh* (`!fromQueue`) submission when no live fresh turn has started
+since the cancellation, because
+
+- `drainSuppressedRef` is set `true` only by `useCancellation`;
+- `useCancellation` early-returns unless `streamingState` is
+  `Responding`/`WaitingForConfirmation` and `!turnCancelledRef.current`, so it
+  cannot re-fire before a new turn's `initTurn` resets `turnCancelled`;
+- the only paths that clear it are the fresh-turn path in
+  `useSubmitQueryCallback` and `sendAllQueuedSubmissions`.
+
+Therefore `drainSuppressedRef.current === true && streamingState` not queueable
+is a sound, non-speculative signature for "acknowledged cancellation, teardown
+possibly still pending".
+
+## Accepted behavior
+
+**AB1.** A fresh (non-queue-originated) ordinary submission that arrives while
+drain is suppressed by an acknowledged cancellation and the public streaming
+state is not `Responding`/`WaitingForConfirmation` is treated as explicit
+intent to resume: it is placed at the **front** of the queued-submission store
+and cancellation drain-suppression is **cleared**.
+
+**AB2.** That prompt reaches the agent exactly once, automatically, once the
+cancelled turn's aborted stream settles and releases active-turn ownership. No
+second Enter is required.
+
+**AB3.** Existing stream serialization is unchanged: the resume prompt does not
+start while the cancelled turn still owns `activeTurnRef`, so no two agent
+loops run concurrently.
+
+**AB4.** Pre-cancel queued entries are preserved by cancellation itself and are
+not run merely because cancellation occurred. After a fresh post-cancel
+submission they drain once each, in FIFO order, **after** the resume prompt.
+
+**AB5.** Queue-originated retry attempts (`fromQueue === true`) still return
+`'requeue'` before any resume handling: they must not clear suppression nor
+bypass active-turn ownership.
+
+**AB6.** No behavior change for: ordinary submission during a genuinely live
+turn (`streamingState === Responding` → append to back, keep suppression state
+as-is), Ctrl+Enter steering, slash/shell queue restrictions, empty-Enter queue
+release, empty-Backspace queue clearing, queued-message steering, and the
+`#2259`/`#2296`/`#2882`/`#2954`/`#3048` regression suites.
+
+## Design (minimal, at the current owner)
+
+### Change 1 — `useQueuedSubmissions.ts`
+
+Extract the existing `queueId` assignment into a small local helper and add one
+front-insertion operation that assigns a fresh `queueId` (unlike
+`requeueSubmission`, which intentionally re-inserts an already-identified item
+for retry):
+
+```ts
+const enqueueSubmissionFirst = (submission: QueuedSubmission): void => {
+  setQueuedSubmissions((prev) => [withQueueId(submission), ...prev]);
+};
+```
+
+Export it from the hook. `types.ts` is unchanged.
+
+### Change 2 — `useStreamState.ts` / `useAgentStreamOrchestration.ts`
+
+Thread `enqueueSubmissionFirst` through `UseStreamStateReturn` and
+`buildSubmitQueryDeps` into `UseSubmitQueryDeps`. No new subsystem.
+
+### Change 3 — `useSubmitQuery.ts`
+
+In `useSubmitQueryCallback`, inside the existing queue branch and strictly
+after the `fromQueue` guard:
+
+```ts
+if (isResumeAfterAcknowledgedCancellation(current)) {
+  current.enqueueSubmissionFirst({ query, promptId });
+  current.drainSuppressedRef.current = false;
+  return 'consumed';
+}
+current.enqueueSubmission({ query, promptId });
+return 'consumed';
+```
+
+with
+
+```ts
+function isResumeAfterAcknowledgedCancellation(
+  deps: SubmitQueryCallbackDeps,
+): boolean {
+  return (
+    deps.drainSuppressedRef.current && !isQueueable(deps.streamingState)
+  );
+}
+```
+
+No new scheduling call is added: the branch is only reachable because
+`activeTurnRef.current === true`, and that turn's `finally` already calls
+`scheduleNextQueuedSubmission` after verifying `isCurrentTurn`. Adding a
+redundant schedule here would be speculative hardening.
+
+## Behavioral tests (Bun + `bun:test`, written first, must fail before the fix)
+
+New file:
+`packages/cli/src/ui/hooks/agentStream/__tests__/useSubmitQuery.cancelResumeRace.bun.tsx`
+
+It renders the **real** `useSubmitQuery` together with the **real**
+`useCancellation` and the **real** `useQueuedSubmissions` store (not the
+fixture stub) so queue state, drain reservation, suppression, and stale-turn
+guards are exercised for real. Only the Agent/provider boundary is faked, via a
+deferred `runStreamRef` that lets the test hold the aborted stream unresolved.
+
+### T1 — primary race
+
+1. Submit A; assert `runStream` called once and `setIsResponding(true)`;
+   rerender with `Responding`.
+2. `cancelOngoingRequest()`; assert `turnCancelledRef.current === true`,
+   `setIsResponding(false)`, A's signal aborted, and the `Request cancelled.`
+   history item added. Rerender with `Idle`.
+3. Keep A's `runStream` promise unresolved. Submit B.
+4. Assert `runStream` still called once (no concurrent second iterator).
+5. Resolve A's stream.
+6. Assert `runStream` called exactly twice with B's query and the drawer/queue
+   is empty — with **no** additional `sendAllQueuedSubmissions`/empty-Enter
+   call.
+7. Resolve B; assert queue empty and responding released.
+
+### T2 — queue preservation, priority, exactly-once
+
+1. Submit A; rerender `Responding`; submit Q1 and Q2 (both queued).
+2. Cancel A, hold its stream unresolved, rerender `Idle`.
+3. Assert Q1 and Q2 still queued and `runStream` still called once (cancellation
+   alone does not run them).
+4. Submit B.
+5. Resolve A, then resolve each subsequent turn's stream in order.
+6. Assert observed `runStream` query order is exactly `A, B, Q1, Q2`, each once.
+
+### T3 — timing counterpart (teardown wins)
+
+Cancel A, resolve A's stream *before* submitting B, then submit B: assert B runs
+directly (fresh path), queue stays empty, order `A, B`.
+
+### T4 — suppression preserved for queue-originated retry
+
+With suppression `true`, active turn held, invoke the executor via
+`submitQueryRef.current(..., fromQueue = true)`: assert it returns `'requeue'`
+and `drainSuppressedRef.current` is still `true`.
+
+### T5 — live-turn submission unchanged
+
+With `streamingState === Responding` and suppression `false`, a fresh
+submission is appended to the **back** of the queue (existing behavior), and
+suppression remains `false`.
+
+### T6 — cancellation alone still preserves the drawer
+
+Reuses the `#2882` invariant against the real store: after cancel with queued
+entries and no fresh submission, the queue is unchanged and no drain occurs.
+
+Also add to `useQueuedSubmissions.test.ts`: `enqueueSubmissionFirst` inserts at
+the front, assigns a fresh unique `queueId`, and updates both the ref and the
+reactive state.
+
+## Non-goals (explicitly out of scope)
+
+- No changes to providers, `AgenticLoop`, queue storage semantics beyond the one
+  front-insert operation, the scheduler algorithm, or retry policy.
+- No change to steering, slash/shell handling, drawer presentation, input
+  history, prompt restoration, or paste handling.
+- No auto-drain caused by Escape/Ctrl+C alone.
+- No defensive teardown wrappers, no swallowed errors, no extra redundant
+  schedule calls.
+- The separate pre-`Responding` Escape readiness gap is not addressed here.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, and
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.


### PR DESCRIPTION
## TLDR

Cancel a response, immediately type the next prompt, and that prompt could land in the queued-message drawer and stay there forever — you had to press Enter again on an empty input to get it to run. It now runs by itself as soon as the cancelled stream lets go.

The cause is a visibility gap, not a lost message. `useCancellation` synchronously flips `turnCancelled`, sets `drainSuppressedRef`, aborts the controller and clears `isResponding`, so `useStreamingState` says Idle — but the cancelled `submitQuery` invocation still owns `activeTurnRef` until its `runStream` settles on a later tick. A prompt arriving in that window took the "behind a live turn" branch, got appended to the queue, and returned early, skipping the fresh-turn path a few lines down that clears `drainSuppressedRef`. When the old stream finally settled and scheduled a drain, `useScheduleNext` refused it because suppression was still set.

Reviewers should look hardest at two things: the choice to key the resume decision on `drainSuppressedRef` alone (see below — gating it on `streamingState` as well looks safer but reintroduces the bug), and the front-insertion ordering guarantee.

## Dive Deeper

**The fix.** A fresh, non-queue-originated submission arriving while an acknowledged cancellation still suppresses draining is treated as intent to resume: it is front-inserted and suppression is released. It does not start a turn itself — it still waits for `activeTurnRef`, and the drain that eventually runs it is the one the settling turn already schedules. So stream serialization is untouched and no second agent loop can start.

**Why front insertion.** The issue requires both halves: messages queued before the cancel must survive and must not run merely because Escape was pressed, but they also must not overtake the prompt the user just submitted to resume. Appending would have produced Q1, Q2, B. The resulting order is B, Q1, Q2, each observed exactly once, FIFO.

**Why the predicate is `drainSuppressedRef` alone.** The obvious form is `drainSuppressedRef.current && !isQueueable(streamingState)` — require the UI to actually look idle. That is wrong, and it fails in exactly the way the original bug fails.

`streamingState` is derived from tool calls flattened across *every* scheduler (`useDerivedToolCallState`), while `cancelAllToolCalls` calls `cancelAll()` on the main scheduler only. `useStreamingState` also returns `WaitingForConfirmation` from its first branch, before it ever consults `turnCancelled`. So an `awaiting_approval` call belonging to a subagent scheduler holds the public state at `WaitingForConfirmation` after the cancellation has been acknowledged and "Request cancelled." has been displayed — and the resume prompt is misclassified as ordinary queued work and left stuck, with suppression retained. T7 covers that interleaving and fails against the `streamingState`-gated form.

`drainSuppressedRef` is authoritative instead: cancellation is its only writer of `true`, and the only two paths that clear it (claiming a fresh turn, and the explicit empty-Enter release in `sendAllQueuedSubmissions`) both run before any turn can proceed. Combined with the pre-existing `fromQueue` early return, observing it set means exactly one thing. Adding `turnCancelledRef` as well would be dead logic — suppression true already implies it.

**Why a new queue operation.** `requeueSubmission` also front-inserts, but it deliberately restores an *already-identified* item and preserves its `queueId` for retry accounting. This is a genuinely new submission and must mint a fresh `queueId`, which is what `QueuedMessagesPanel` keys React on. `enqueueSubmissionFirst` is that operation; the `queueId` minting shared with `enqueueSubmission` is extracted rather than duplicated.

**Starvation.** If the cancelled stream never settles, the resume prompt stays queued. That matches the issue's contract ("after the old aborted stream settles safely"), keeps serialization safe, and is no worse than before the change.

**Deliberately not done:** no changes to providers, `AgenticLoop`, the scheduler algorithm, retry policy, steering, slash/shell handling, drawer presentation, input history, prompt restoration or paste handling. No auto-drain from Escape/Ctrl+C alone. No defensive teardown wrappers, no swallowed errors, and no redundant extra `scheduleNextQueuedSubmission` call — the settling turn's `finally` already schedules it after its `isCurrentTurn` check.

**Files changed**

- `useSubmitQuery.ts` — the resume branch plus the `isResumeAfterAcknowledgedCancellation` predicate, and the new dep on the interface.
- `useQueuedSubmissions.ts` — `enqueueSubmissionFirst`, with `queueId` minting extracted for reuse.
- `useStreamState.ts`, `useAgentStreamOrchestration.ts` — threading the operation through the existing ownership seam.
- Test fixtures — the new dep added to three existing harnesses.
- `useSubmitQuery.cancelResumeRace.bun.tsx` — new, T1–T7.
- `useQueuedSubmissions.test.ts` — front position, fresh unique `queueId`, ref/state sync.

## Reviewer Test Plan

**Manual (this is the reported repro).**

1. Start the CLI, submit a prompt, wait until the agent is visibly responding.
2. Press Escape and confirm "Request cancelled." appears.
3. Immediately type a second prompt and press Enter, as fast as you can — the point is to beat the aborted stream's teardown.
4. Before this change the prompt could appear in the queued-message drawer and stay there. Now it should start on its own, with no second Enter.
5. Repeat, but wait a beat after cancelling before submitting. Same visible result — both sides of the race converge.

**Manual, queue preservation.** Submit A, then queue two more behind it while A is responding, then cancel A and immediately submit a fresh prompt. Expect the fresh prompt to run first, then the two preserved entries once each in order. Separately confirm cancelling with entries queued and *not* submitting anything still leaves them sitting in the drawer, and that empty-Enter release and empty-Backspace clear still behave as before.

**Automated.**

    cd packages/cli
    bun test ./src/ui/hooks/agentStream/__tests__/useSubmitQuery.cancelResumeRace.bun.tsx
    bun test ./src/ui/hooks/agentStream/__tests__/useQueuedSubmissions.test.ts

Note `.bun.tsx` files need an explicit `./path`, and module mocks are process-global so run files independently.

The tests drive the real `useSubmitQuery`, `useCancellation` and `useQueuedSubmissions` — including its ref/state synchronisation and drain reservation — with only the provider boundary deferred, because suppression, ordering and active-turn ownership *interacting* is the whole subject. To confirm they are not vacuous, revert the resume branch in `useSubmitQuery.ts`: T1 fails because the resume prompt never reaches the agent, and T2 fails on the ordering. Restore the `!isQueueable(streamingState)` clause and T7 fails. T3–T6 are guards for behaviour that must not move and pass either way by design.

Worth also re-running the prior regressions this area owns: `useSubmitQuery.doublecancel.bun.tsx` (2259/2882/2296), `useSubmitQuery.terminalError.bun.tsx` (2954), `useSubmitQuery.retryDiscard.bun.tsx` (3048), `useAgentStreamOrchestration.terminal.bun.tsx`, `useStreamingState.test.tsx`, `useCancellation.asyncTasks.test.tsx` and `useAgentStream.usercancel.test.tsx`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test` (all workspaces green, 681/681 CLI test files), `npm run lint`, `npm run lint:eslint-guard`, `npm run typecheck`, `npm run format`, `npm run build`, and the profile smoke run. The new suite also passes 35/35 under `--rerun-each 5`.

## Linked issues / bugs

Fixes #3169


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved submission handling during cancellation and resume flows.
  - New submissions can be prioritized at the front of the queue.
  - Resume prompts and retries now maintain the expected first-in, first-out behavior.

- **Bug Fixes**
  - Improved recovery after cancelled streams and teardown.
  - Prevented submissions from being incorrectly suppressed during resume scenarios.

- **Tests**
  - Added coverage for queue priority, cancellation/resume races, retries, and confirmation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->