### PR TITLE
docs(perf): design and specification for client-side performance telemetry (#3167)

### DIFF
--- a/project-plans/issue3167/PLAN.md
+++ b/project-plans/issue3167/PLAN.md
@@ -249,7 +249,8 @@ v25.2.1. These are primitive costs, **not** an end-to-end instrumentation budget
 | ------------------------------------------ | --------------------------------- | ----------------- |
 | `performance.now()`                        | 25.1 ns / 26.6 ns                 | `perfprobe.mjs.txt`   |
 | counter increment                          | 1.97 ns / 5.05 ns                 | `perfprobe.mjs.txt`   |
-| `process.memoryUsage()`                    | 0.42 us / 0.66 us (idle heap)     | `perfprobe.mjs.txt`   |
+| `process.memoryUsage()` idle heap          | 0.42 us / 0.66 us                 | `perfprobe.mjs.txt`   |
+| `process.memoryUsage()` 233 MB fragmented heap | 0.44 us / 0.65 us — **1.03x / 0.98x vs idle, so heap-size independent** | re-measured, see `specification.md` §8 |
 | a 33-field flat numeric record              | 688 B — **rejected schema, see below** | `recsize.mjs.txt`     |
 | gzip -6 on 2.29 MiB                        | 7.9x in 24 ms                     | `gziptest.mjs.txt`    |
 | concurrent `O_APPEND`, 8 writers, APFS     | 12,000/12,000 records, 0 torn     | `appendrace.mjs.txt`  |
@@ -371,11 +372,30 @@ process vs longitudinal report — rev.2 said both). Streams plain and gzip, sch
 truncated tail, groups by version/commit within matched dimensions, reports self-health. Tests: mixed schema
 versions, malformed and truncated records, thousands of files, Windows.
 
-### Phase 6 — Memory trend (separable)
+### Phase 6 — Memory trend (in scope, ships with this issue)
 
-REQ-3167 memory behaviour is a second feature and may ship as its own PR after Phases 1-5 prove the pipeline:
-per-turn and coarse-interval sampling of `rss / heapUsed / external / arrayBuffers`, dual slopes, its own
-report path. Memory costs must be re-measured at representative heap sizes rather than idle.
+Not separable and not a second PR: all accepted work for #3167 ships together.
+**Specified in [`specification.md`](./specification.md) §7 — implement from there.**
+
+Summary: memory columns ride the operation record for the per-operation axis, plus a
+`record_type: "memory_sample"` row carrying `ms_since_last_operation` for the per-minute axis. The two slopes
+together separate legitimate growth (tracks work) from a leak (tracks uptime) — the #3114 signature. Slopes are
+derived at read time, never stored. `external` / `arrayBuffers` are first-class: that is where the mass hid under
+Bun/JSC in #3112.
+
+**Zero new timers.** `useMemoryMonitor` already runs an unconditional 60 s interval calling
+`process.memoryUsage().rss`; extend it. Two defects in it must be fixed: it `clearInterval`s itself after warning
+once (so it stops monitoring exactly when memory is known to be a problem), and the live view needs a
+fixed-capacity ring rather than a growing array — the leak detector must not leak. `Footer.tsx`'s 2 s interval is
+explicitly **not** a host: it is gated on `showMemoryUsage` and on being mounted.
+
+**Independently disableable** via `telemetry.perf.memory`, separate from the `telemetry.perf` master; both
+default off. Disabling omits the fields rather than writing zeros, since a zero is indistinguishable from a
+measurement.
+
+Memory cost re-measured under load, resolving the earlier idle-heap caveat: cost is **independent of heap size
+and fragmentation** (1.03x Bun, 0.98x Node between an idle heap and a 233 MB fragmented one), which is the
+property that matters because leak investigations run when the heap is large.
 
 ### Phase 7 — Compression (optional, last)
 

--- a/project-plans/issue3167/PLAN.md
+++ b/project-plans/issue3167/PLAN.md
@@ -7,7 +7,12 @@ Issue: #3167
 Milestone: 0.11.0
 Requirements: REQ-3167-1 … REQ-3167-9
 
-Companion design with diagrams and measured evidence: [`design.html`](./design.html) — open in a browser.
+Companion documents:
+
+- [`specification.md`](./specification.md) — **the record schema, package placement, compatibility rules and
+  reuse decisions.** Read this before implementing anything; it is the contract between writer and reader.
+- [`decision.html`](./decision.html) — plain-language explainer of the one open decision, with diagrams.
+- [`design.html`](./design.html) — full design detail, measured evidence, and the rejected approaches.
 Reproducible benchmarks: [`benchmarks/`](./benchmarks) — every number quoted in this plan comes from one of
 these scripts. They are stored with a `.mjs.txt` suffix so the repo-wide
 `no-new-js` guard (issue #2745), which forbids new tracked `.js`/`.mjs` files,
@@ -323,9 +328,19 @@ No implementation until each of these is confirmed in the tree and written up in
 
 ### Phase 1 — Schema and writer contract
 
-REQ-3167-5, -7, -8. Record schema with `schema_version`; exclusive-create writer with run UUID; bounded queue;
-fail-open with self-disable; opt-in gate. Tests: run-id collision, reopen after restart, clock step backwards
-and forwards, EROFS/ENOSPC, abrupt exit leaving a partial line, disabled-by-default.
+REQ-3167-5, -7, -8. **The schema, placement, compatibility rules and reuse decisions are now written up in
+[`specification.md`](./specification.md)** — implement from there, not from this summary.
+
+Key points settled there: the record is declared once as a Zod schema from which both writer and reader derive
+their types; the sink is an extension of `packages/telemetry/src/debug/FileOutput.ts` rather than a parallel
+implementation (it already provides run-id filenames, size rolling, batching and drain-on-dispose, and needs
+four defects fixed — singleton-only construction, `fs.stat` per flush, unbounded `console.error`, and **zero
+eviction**, verified: no `unlink` call anywhere in the file); `IntervalUnion` is extracted from
+`sessionMetricsAggregator.ts` and its quadratic recompute fixed; and the live-writer rule needs no lock.
+
+Tests: run-id collision, reopen after restart, clock step backwards and forwards, EROFS/ENOSPC, abrupt exit
+leaving a partial line, disabled-by-default, and a round-trip test that asserts against a record produced by the
+**real writer** rather than a hand-authored fixture.
 
 ### Phase 2 — Operation lifecycle and identity
 

--- a/project-plans/issue3167/decision.html
+++ b/project-plans/issue3167/decision.html
@@ -1,0 +1,495 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>llxprt perf telemetry — the decision, explained</title>
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --panel2:#1c2128; --bd:#30363d;
+    --tx:#e6edf3; --mu:#8b949e; --dim:#6e7681;
+    --blue:#58a6ff; --green:#3fb950; --yellow:#d29922;
+    --red:#f85149; --purple:#bc8cff; --cyan:#39c5cf; --grey:#484f58;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--tx);
+    font:16px/1.7 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  .wrap{max-width:1060px;margin:0 auto;padding:52px 32px 120px}
+  header{border-bottom:1px solid var(--bd);padding-bottom:26px;margin-bottom:40px}
+  h1{font-size:33px;line-height:1.2;margin:0;letter-spacing:-.02em}
+  h1 small{display:block;font-size:15px;font-weight:400;color:var(--mu);margin-top:10px;letter-spacing:0}
+  h2{font-size:25px;margin:58px 0 8px;letter-spacing:-.01em}
+  h2 .n{color:var(--dim);font-variant-numeric:tabular-nums;margin-right:12px;font-weight:400}
+  h3{font-size:17.5px;margin:34px 0 8px;color:var(--blue)}
+  p{margin:14px 0}
+  .lead{font-size:18.5px;color:#c9d1d9}
+  code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13.5px;
+    background:var(--panel2);border:1px solid var(--bd);border-radius:5px;padding:1px 5px;color:#c9d1d9}
+  pre{background:var(--panel);border:1px solid var(--bd);border-radius:10px;padding:16px 18px;
+    overflow-x:auto;font-size:13px;line-height:1.6;font-family:ui-monospace,Menlo,monospace}
+  pre code{background:none;border:none;padding:0}
+  .fig{background:var(--panel);border:1px solid var(--bd);border-radius:12px;padding:24px;margin:28px 0}
+  .fig svg{display:block;width:100%;height:auto}
+  .cap{color:var(--mu);font-size:13.5px;margin-top:16px;padding-top:14px;border-top:1px solid var(--bd)}
+  .cap b{color:var(--tx)}
+  .panel{background:var(--panel);border:1px solid var(--bd);border-radius:12px;padding:20px 24px;margin:24px 0}
+  .good{border-left:3px solid var(--green);background:rgba(63,185,80,.07)}
+  .bad{border-left:3px solid var(--red);background:rgba(248,81,73,.07)}
+  .warn{border-left:3px solid var(--yellow);background:rgba(210,153,34,.07)}
+  .info{border-left:3px solid var(--blue);background:rgba(88,166,255,.07)}
+  table{width:100%;border-collapse:collapse;margin:20px 0;font-size:14.5px}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--bd);vertical-align:top}
+  th{color:var(--mu);font-weight:600;font-size:12.5px;text-transform:uppercase;letter-spacing:.06em}
+  tr:last-child td{border-bottom:none}
+  .keep{color:var(--green);font-weight:700}
+  .cut{color:var(--red);font-weight:700}
+  ul,ol{padding-left:22px}
+  li{margin:8px 0}
+  .legend{display:flex;flex-wrap:wrap;gap:20px;margin:4px 0 6px;font-size:13px;color:var(--mu)}
+  .legend i{display:inline-block;width:12px;height:12px;border-radius:3px;margin-right:7px;vertical-align:-1px}
+  .big{font-family:ui-monospace,Menlo,monospace;font-size:26px;color:var(--blue)}
+  .two{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+  @media (max-width:860px){.two{grid-template-columns:1fr}}
+  hr{border:none;border-top:1px solid var(--bd);margin:50px 0}
+  footer{margin-top:64px;padding-top:20px;border-top:1px solid var(--bd);color:var(--dim);font-size:13px}
+  .q{background:linear-gradient(180deg,rgba(88,166,255,.10),rgba(88,166,255,.03));
+     border:1px solid rgba(88,166,255,.35);border-radius:12px;padding:22px 26px;margin:30px 0}
+  .q h3{margin-top:0;color:var(--blue)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <h1>Performance telemetry: what I need you to decide
+    <small>llxprt-code &middot; issue #3167 &middot; plain-language companion to PLAN.md</small>
+  </h1>
+</header>
+
+<p class="lead">
+  There is one decision to make. Everything else is settled. This page explains what we are building, the one
+  mistake that shaped the design, and the two versions you can pick between &mdash; with the reasoning in
+  pictures rather than prose.
+</p>
+
+<hr>
+
+<h2><span class="n">01</span>What we are actually trying to learn</h2>
+
+<p>
+  Right now, when llxprt feels slow, we cannot tell whether <em>we</em> got slower or the <em>model</em> did.
+  Every number we record is about the provider. Worse, the arithmetic on the stats screen is built so that our
+  own time is invisible by construction:
+</p>
+
+<pre><code>apiTimePercent  = totalApiTime  / (API + Tool)
+toolTimePercent = totalToolTime / (API + Tool)
+                                   ^^^^^^^^^^
+                  API% + Tool% = 100%, always. There is no room for us.</code></pre>
+
+<p>
+  So the goal is a single trend line: <b>the time llxprt itself spends, per turn, tracked across releases.</b>
+  If that line drifts up between 0.11 and 0.12, we have a regression and we know it is ours.
+</p>
+
+<h2><span class="n">02</span>The mistake that shaped everything</h2>
+
+<p>
+  My first design said: take the whole turn, subtract the provider's time and the tools' time, and whatever is
+  left must be us. That is intuitive. It is also <b>wrong</b>, and the reason is worth seeing.
+</p>
+
+<div class="fig">
+<div class="legend">
+  <span><i style="background:var(--green)"></i>provider request (network + model)</span>
+  <span><i style="background:var(--purple)"></i>our render work</span>
+  <span><i style="background:var(--cyan)"></i>our stream handling</span>
+</div>
+<svg viewBox="0 0 1000 330" role="img" aria-label="Streaming overlap makes subtraction invalid">
+  <defs><style>
+    .t{fill:#e6edf3;font:600 13px ui-monospace,Menlo,monospace}
+    .s{fill:#8b949e;font:11.5px ui-monospace,Menlo,monospace}
+    .r{fill:#f85149;font:700 13px ui-monospace,Menlo,monospace}
+    .g{fill:#3fb950;font:700 13px ui-monospace,Menlo,monospace}
+    .ax{stroke:#484f58;stroke-width:1.2}
+    .tick{stroke:#30363d;stroke-width:1}
+  </style></defs>
+
+  <text class="s" x="0" y="16">WHAT I ASSUMED — neat, sequential, subtractable</text>
+  <rect x="0" y="26" width="620" height="34" rx="5" fill="#3fb950"/>
+  <text class="t" x="310" y="48" text-anchor="middle" fill="#0d1117">provider request</text>
+  <rect x="626" y="26" width="180" height="34" rx="5" fill="#39c5cf"/>
+  <text class="t" x="716" y="48" text-anchor="middle" fill="#0d1117">our work</text>
+  <rect x="812" y="26" width="188" height="34" rx="5" fill="#bc8cff"/>
+  <text class="t" x="906" y="48" text-anchor="middle" fill="#0d1117">our render</text>
+  <text class="g" x="0" y="82">subtract the green -> the rest is us. Correct, IF this were the shape.</text>
+
+  <line class="tick" x1="0" y1="108" x2="1000" y2="108"/>
+
+  <text class="s" x="0" y="136">WHAT ACTUALLY HAPPENS — streaming, so it is all one overlapping window</text>
+
+  <rect x="0" y="148" width="1000" height="34" rx="5" fill="#3fb950"/>
+  <text class="t" x="500" y="170" text-anchor="middle" fill="#0d1117">provider request — one streaming call, start to finish</text>
+
+  <!-- interleaved our-work chunks inside -->
+  <g>
+    <rect x="60"  y="192" width="34" height="26" rx="4" fill="#39c5cf"/>
+    <rect x="150" y="192" width="34" height="26" rx="4" fill="#39c5cf"/>
+    <rect x="240" y="192" width="34" height="26" rx="4" fill="#39c5cf"/>
+    <rect x="330" y="192" width="34" height="26" rx="4" fill="#39c5cf"/>
+    <rect x="430" y="192" width="34" height="26" rx="4" fill="#39c5cf"/>
+    <rect x="530" y="192" width="34" height="26" rx="4" fill="#39c5cf"/>
+    <rect x="640" y="192" width="34" height="26" rx="4" fill="#39c5cf"/>
+    <rect x="760" y="192" width="34" height="26" rx="4" fill="#39c5cf"/>
+    <rect x="880" y="192" width="34" height="26" rx="4" fill="#39c5cf"/>
+    <rect x="100" y="224" width="30" height="26" rx="4" fill="#bc8cff"/>
+    <rect x="200" y="224" width="30" height="26" rx="4" fill="#bc8cff"/>
+    <rect x="300" y="224" width="30" height="26" rx="4" fill="#bc8cff"/>
+    <rect x="400" y="224" width="30" height="26" rx="4" fill="#bc8cff"/>
+    <rect x="500" y="224" width="30" height="26" rx="4" fill="#bc8cff"/>
+    <rect x="610" y="224" width="30" height="26" rx="4" fill="#bc8cff"/>
+    <rect x="730" y="224" width="30" height="26" rx="4" fill="#bc8cff"/>
+    <rect x="850" y="224" width="30" height="26" rx="4" fill="#bc8cff"/>
+  </g>
+  <text class="s" x="0" y="210">decode delta</text>
+  <text class="s" x="0" y="242">paint frame</text>
+
+  <text class="r" x="0" y="278">Subtract the green and you subtract ALL of it. Result: "our time" = 0 ms.</text>
+  <text class="r" x="0" y="298">Then "core time = our time - render time" = NEGATIVE. On a completely normal turn.</text>
+  <text class="s" x="0" y="320">Clamping that to zero would not fix the model — it would just hide that the model is wrong.</text>
+</svg>
+<div class="cap">
+  <b>This is the whole reason the design changed.</b> A streaming request is not a period when we are idle
+  waiting &mdash; it is exactly when we are busiest, decoding tokens and repainting. The provider's clock and
+  our clock run <em>at the same time</em>, so you cannot get one by subtracting the other.
+</div>
+</div>
+
+<div class="panel good">
+  <p style="margin:0">
+    <b>The fix:</b> stop subtracting. Put a stopwatch directly on each piece of <em>our</em> work and add those
+    up. Report the provider's time separately and say plainly that the two overlap. Anything left unaccounted
+    for gets an honest name &mdash; <code>unclassified_elapsed_ms</code> &mdash; instead of being called "our
+    time" by default.
+  </p>
+</div>
+
+<h2><span class="n">03</span>What gets measured, in plain terms</h2>
+
+<p>Five stopwatches, each on a specific piece of our own work:</p>
+
+<table>
+  <tr><th>Stopwatch</th><th>What it times</th><th>How we get it</th></tr>
+  <tr><td><code>client_prepare_ms</code></td><td>Assembling the request before we send anything &mdash; history, prompt, token counting</td><td>Timer around the prepare step</td></tr>
+  <tr><td><code>stream_handler_ms</code></td><td>Our own CPU decoding each chunk as it arrives</td><td>Sum of small timers in the delta handler</td></tr>
+  <tr><td><code>ink_render_ms</code></td><td>Turning state into text for the terminal</td><td><b>Free</b> &mdash; Ink already measures this and hands it to us via <code>onRender</code></td></tr>
+  <tr><td><code>stdout_bytes</code></td><td>How much we actually wrote to the terminal</td><td>Counter at the one place Ink writes</td></tr>
+  <tr><td><code>client_finalize_ms</code></td><td>Cleanup after the last response</td><td>Timer around the finalize step</td></tr>
+</table>
+
+<p>
+  Plus the provider's and tools' time reported <em>alongside</em> rather than subtracted, and the context we need
+  to compare fairly: llxprt version, commit, provider, model, terminal size. One line of JSON per turn, written
+  to a file.
+</p>
+
+<div class="panel info">
+  <p style="margin:0">
+    <b>Why <code>stdout_bytes</code> matters more than it sounds.</b> It is a <em>count</em>, not a duration, so
+    it barely cares how busy your laptop is. If a change makes us repaint the whole screen instead of one line,
+    that number jumps immediately &mdash; on any machine. Durations are noisy; counts are much less so.
+  </p>
+</div>
+
+<h2><span class="n">04</span>The decision: two versions</h2>
+
+<p>
+  An architecture review argued the plan builds roughly twice the machinery the trend line needs. It agreed the
+  measurement model above is right, and objected to everything around it. Here are the pieces, and which
+  version keeps them.
+</p>
+
+<div class="fig">
+<svg viewBox="0 0 1000 560" role="img" aria-label="Full versus halved design, component by component">
+  <defs><style>
+    .hd{fill:#8b949e;font:600 12px ui-monospace,Menlo,monospace}
+    .cn{fill:#e6edf3;font:12.5px ui-monospace,Menlo,monospace}
+    .cs{fill:#6e7681;font:10.5px ui-monospace,Menlo,monospace}
+    .box{fill:#1c2128;stroke:#30363d}
+    .kbox{fill:rgba(63,185,80,.13);stroke:#3fb950}
+    .xbox{fill:rgba(248,81,73,.10);stroke:#f85149;stroke-dasharray:5 3}
+    .yes{fill:#3fb950;font:700 15px ui-monospace,Menlo,monospace}
+    .no{fill:#f85149;font:700 15px ui-monospace,Menlo,monospace}
+  </style></defs>
+
+  <text class="hd" x="14" y="20">COMPONENT</text>
+  <text class="hd" x="700" y="20" text-anchor="middle">FULL</text>
+  <text class="hd" x="880" y="20" text-anchor="middle">HALVED</text>
+  <line x1="0" y1="30" x2="1000" y2="30" stroke="#30363d"/>
+
+  <!-- rows: keep -->
+  <g>
+    <rect class="kbox" x="0" y="42" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="60">Five client stopwatches</text>
+    <text class="cs" x="14" y="75">the actual measurement — the whole point</text>
+    <text class="yes" x="700" y="68" text-anchor="middle">keep</text>
+    <text class="yes" x="880" y="68" text-anchor="middle">keep</text>
+
+    <rect class="kbox" x="0" y="90" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="108">Provider/tool time reported separately</text>
+    <text class="cs" x="14" y="123">cheap, and stops the subtraction mistake recurring</text>
+    <text class="yes" x="700" y="116" text-anchor="middle">keep</text>
+    <text class="yes" x="880" y="116" text-anchor="middle">keep</text>
+
+    <rect class="kbox" x="0" y="138" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="156">One file per run, created exclusively</text>
+    <text class="cs" x="14" y="171">measured: sharing one file destroyed 49% of records</text>
+    <text class="yes" x="700" y="164" text-anchor="middle">keep</text>
+    <text class="yes" x="880" y="164" text-anchor="middle">keep</text>
+
+    <rect class="kbox" x="0" y="186" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="204">Delete oldest when the folder gets big</text>
+    <text class="cs" x="14" y="219">the disk guarantee</text>
+    <text class="yes" x="700" y="212" text-anchor="middle">keep</text>
+    <text class="yes" x="880" y="212" text-anchor="middle">keep</text>
+
+    <rect class="kbox" x="0" y="234" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="252">A command that reads it and shows the trend</text>
+    <text class="cs" x="14" y="267">without this the data is inert — see #3164</text>
+    <text class="yes" x="700" y="260" text-anchor="middle">keep</text>
+    <text class="yes" x="880" y="260" text-anchor="middle">keep</text>
+
+    <rect class="kbox" x="0" y="282" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="300">Off by default, opt-in</text>
+    <text class="cs" x="14" y="315">required by our own privacy policy</text>
+    <text class="yes" x="700" y="308" text-anchor="middle">keep</text>
+    <text class="yes" x="880" y="308" text-anchor="middle">keep</text>
+  </g>
+
+  <line x1="0" y1="334" x2="1000" y2="334" stroke="#30363d" stroke-dasharray="4 4"/>
+  <text class="hd" x="14" y="352">THE DISPUTED HALF</text>
+
+  <g>
+    <rect class="xbox" x="0" y="360" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="378">New id threaded through the agent loop</text>
+    <text class="cs" x="14" y="393">the id already exists as a string prefix — see §05</text>
+    <text class="yes" x="700" y="386" text-anchor="middle">keep</text>
+    <text class="no"  x="880" y="386" text-anchor="middle">cut</text>
+
+    <rect class="xbox" x="0" y="408" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="426">Queue with a drop policy</text>
+    <text class="cs" x="14" y="441">one record per turn — there is no burst to absorb</text>
+    <text class="yes" x="700" y="434" text-anchor="middle">keep</text>
+    <text class="no"  x="880" y="434" text-anchor="middle">cut</text>
+
+    <rect class="xbox" x="0" y="456" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="474">Retry N times before giving up</text>
+    <text class="cs" x="14" y="489">a full disk does not heal — give up on the first failure</text>
+    <text class="yes" x="700" y="482" text-anchor="middle">keep</text>
+    <text class="no"  x="880" y="482" text-anchor="middle">cut</text>
+
+    <rect class="xbox" x="0" y="504" width="640" height="40" rx="6"/>
+    <text class="cn" x="14" y="522">A 10x/second timer + gzip + extra rolling</text>
+    <text class="cs" x="14" y="537">the timer costs more than what it measures; gzip saves 55 MB</text>
+    <text class="yes" x="700" y="530" text-anchor="middle">keep</text>
+    <text class="no"  x="880" y="530" text-anchor="middle">cut</text>
+  </g>
+</svg>
+<div class="cap">
+  <b>The top six are identical in both versions.</b> The disagreement is entirely about the bottom four, and
+  <em>none of them changes the trend number</em> &mdash; they are about robustness, storage efficiency, and
+  precision of contention measurement. That is what makes this a judgement call rather than a correctness one.
+</div>
+</div>
+
+<h2><span class="n">05</span>The single best argument for cutting</h2>
+
+<p>
+  My plan wanted to mint a new id at submission and thread it down through the agent loop, so all the sends
+  belonging to one of your prompts could be grouped together. The review pointed out that <b>this id already
+  exists</b> &mdash; it is right there in the prompt ids the code already generates:
+</p>
+
+<div class="fig">
+<svg viewBox="0 0 1000 300" role="img" aria-label="The operation id already exists as a prompt id prefix">
+  <defs><style>
+    .m{fill:#e6edf3;font:600 13px ui-monospace,Menlo,monospace}
+    .mm{fill:#8b949e;font:12px ui-monospace,Menlo,monospace}
+    .lb{fill:#6e7681;font:11px ui-monospace,Menlo,monospace}
+    .hi{fill:#3fb950;font:700 13px ui-monospace,Menlo,monospace}
+    .bk{fill:#1c2128;stroke:#30363d}
+  </style></defs>
+
+  <text class="lb" x="0" y="16">You type one thing. The agent then makes several calls on your behalf:</text>
+
+  <rect class="bk" x="0" y="30" width="1000" height="30" rx="5"/>
+  <text class="mm" x="12" y="50">send 1  <tspan class="hi">abc123#agentic-loop#f7e2</tspan></text>
+
+  <rect class="bk" x="0" y="66" width="1000" height="30" rx="5"/>
+  <text class="mm" x="12" y="86">send 2  <tspan class="hi">abc123#agentic-loop#f7e2</tspan>#continuation#1</text>
+
+  <rect class="bk" x="0" y="102" width="1000" height="30" rx="5"/>
+  <text class="mm" x="12" y="122">send 3  <tspan class="hi">abc123#agentic-loop#f7e2</tspan>#continuation#2</text>
+
+  <rect class="bk" x="0" y="138" width="1000" height="30" rx="5"/>
+  <text class="mm" x="12" y="158">send 4  <tspan class="hi">abc123#agentic-loop#f7e2</tspan>#continuation#3</text>
+
+  <path d="M300 176 L300 196" stroke="#3fb950" stroke-width="1.5" stroke-dasharray="3 3" fill="none"/>
+  <text class="hi" x="0" y="212">The green part is identical across all of them. That IS the group id.</text>
+
+  <rect x="0" y="228" width="1000" height="34" rx="6" fill="rgba(63,185,80,.13)" stroke="#3fb950"/>
+  <text class="m" x="12" y="250">operation_id = promptId.split('#continuation#')[0]      // computed when reading. zero plumbing.</text>
+
+  <text class="lb" x="0" y="286">Versus: mint a new id, pass it into the agent package, thread it through every call site, and keep it in sync forever.</text>
+</svg>
+<div class="cap">
+  <b>This is the finding that convinced me.</b> The grouping is already encoded in data we already write. Doing
+  it my way means touching <code>packages/agents</code> &mdash; and that package deliberately has no dependency
+  on the telemetry package at all. I would have been adding a "measure me" wire into business logic to rebuild
+  something a one-line string split already gives us.
+</div>
+</div>
+
+<h2><span class="n">06</span>Where the code has to live (this one is not a choice)</h2>
+
+<p>
+  I never said which package owns what, which was an oversight. The dependency graph settles it, because
+  packages can only depend downward:
+</p>
+
+<div class="fig">
+<svg viewBox="0 0 1000 340" role="img" aria-label="Package layering and ownership">
+  <defs>
+    <marker id="a" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L6,3 z" fill="#484f58"/>
+    </marker>
+    <style>
+      .pk{fill:#1c2128;stroke:#30363d}
+      .pt{fill:#e6edf3;font:600 13px ui-monospace,Menlo,monospace}
+      .ps{fill:#6e7681;font:10.5px ui-monospace,Menlo,monospace}
+      .ar{stroke:#484f58;stroke-width:1.5;fill:none;marker-end:url(#a)}
+      .own{fill:#58a6ff;font:11.5px ui-monospace,Menlo,monospace}
+      .hh{fill:#8b949e;font:600 12px ui-monospace,Menlo,monospace}
+    </style>
+  </defs>
+
+  <text class="hh" x="0" y="16">higher layers depend on lower ones — never the reverse</text>
+
+  <rect class="pk" x="0" y="28" width="220" height="52" rx="8"/>
+  <text class="pt" x="110" y="50" text-anchor="middle">packages/cli</text>
+  <text class="ps" x="110" y="68" text-anchor="middle">the terminal UI</text>
+  <text class="own" x="240" y="46">owns: turn boundaries, Ink wiring,</text>
+  <text class="own" x="240" y="64">the setting, and the report command</text>
+
+  <path class="ar" d="M110 84 L110 106"/>
+
+  <rect class="pk" x="0" y="112" width="220" height="52" rx="8"/>
+  <text class="pt" x="110" y="134" text-anchor="middle">packages/agents</text>
+  <text class="ps" x="110" y="152" text-anchor="middle">the agent loop</text>
+  <text class="own" x="240" y="130" style="fill:#3fb950">owns: NOTHING — and that is the point.</text>
+  <text class="own" x="240" y="148">It has no telemetry dependency. Keep it that way.</text>
+
+  <path class="ar" d="M110 168 L110 190"/>
+
+  <rect class="pk" x="0" y="196" width="220" height="52" rx="8"/>
+  <text class="pt" x="110" y="218" text-anchor="middle">packages/core</text>
+  <text class="ps" x="110" y="236" text-anchor="middle">shared machinery</text>
+  <text class="own" x="240" y="214">owns: just the stdout byte counter</text>
+  <text class="own" x="240" y="232">(the terminal write path lives here)</text>
+
+  <path class="ar" d="M110 252 L110 274"/>
+
+  <rect x="0" y="280" width="220" height="52" rx="8" fill="rgba(88,166,255,.14)" stroke="#58a6ff" stroke-width="1.8"/>
+  <text class="pt" x="110" y="302" text-anchor="middle" style="fill:#58a6ff">packages/telemetry</text>
+  <text class="ps" x="110" y="320" text-anchor="middle">lowest layer involved</text>
+  <text class="own" x="240" y="298">owns: the record format, the file writer,</text>
+  <text class="own" x="240" y="316">the delete-oldest logic. Reachable by everything above.</text>
+</svg>
+<div class="cap">
+  <b>Telemetry sits at the bottom, so putting the writer there means everything above can reach it without any
+  new dependency.</b> Put it in <code>cli</code> instead and the stdout counter in <code>core</code> cannot see
+  it. This also explains &sect;05: threading an id through <code>agents</code> would force a brand-new
+  <code>agents &rarr; telemetry</code> dependency purely to carry a measurement concern.
+</div>
+</div>
+
+<h2><span class="n">07</span>One thing that already exists and I missed it</h2>
+
+<div class="panel warn">
+  <p style="margin:0 0 10px">
+    <code>packages/telemetry/src/debug/FileOutput.ts</code> already does most of the file writer I proposed to
+    build: JSONL append into the global log directory, a unique id in the filename, day and size rolling, a
+    write queue, and flush-on-exit. My plan never mentions it.
+  </p>
+  <p style="margin:0">
+    It also has a real bug worth fixing while we are there: <b>it never deletes anything.</b>
+    <code>llxprt-debug-*.jsonl</code> grows forever &mdash; the same unbounded-growth problem as
+    <a href="https://github.com/vybestack/llxprt-code/issues/3164">#3164</a>, sitting in the package this
+    feature would join. Extending it fixes two things at once.
+  </p>
+</div>
+
+<h2><span class="n">08</span>The other thing I have to write before coding</h2>
+
+<div class="panel bad">
+  <p style="margin:0 0 10px">
+    <b>The record format itself does not exist yet.</b> My plan says "define the schema" as a task but never
+    defines it. That is the single most important artifact here, because it is the contract between the thing
+    that writes and the thing that reads.
+  </p>
+  <p style="margin:0">
+    And we have a live example of what happens when those two drift: <b>#3164</b> is a cleanup routine that
+    looked for <code>.json</code> files while the writer produced <code>.jsonl</code>. It matched nothing,
+    deleted nothing, for months &mdash; with passing tests, because the test fixtures used the old shape. That
+    is 3.8&nbsp;GB on your disk right now. So: one schema definition, both sides derive from it, and the test
+    must use a record produced by the real writer rather than one typed by hand.
+  </p>
+</div>
+
+<h2><span class="n">09</span>What you get at the end</h2>
+
+<pre><code>$ llxprt perf trend
+
+version   turns   client p50   render p50   stdout KB/turn
+0.10.2     4210        112ms         41ms            38.2
+0.11.0     3877        118ms         44ms            39.1
+0.12.0     2904        186ms         96ms           171.4      <-- something happened here
+                                     ^^^^^          ^^^^^
+                          render time doubled and we are writing
+                          4x the bytes. That is a rendering regression,
+                          not the model, and it is ours.</code></pre>
+
+<p>
+  That is the deliverable. One command, grouped by version, comparing like with like. The bytes column is the
+  tell-tale that does not care how busy your machine was.
+</p>
+
+<div class="q">
+  <h3>What I need from you</h3>
+  <p style="margin:0 0 12px">
+    <b>Full or halved?</b> Both produce the table above and are identical for the first six components. Halved
+    drops the id plumbing, the queue, the retry threshold, the 10&nbsp;Hz timer, gzip and the extra rolling.
+  </p>
+  <p style="margin:0 0 12px">
+    My recommendation is <b>halved</b>, for one reason beyond simplicity: the id-plumbing cut is the difference
+    between touching <code>packages/agents</code> and not touching it. Keeping a measurement concern out of the
+    agent loop is worth more than any of the features being dropped.
+  </p>
+  <p style="margin:0">
+    Two smaller calls that follow from it: whether the memory-trend work becomes its own issue (I think yes
+    &mdash; it is a separate feature that happens to share a file), and whether we produce the full
+    <code>specification.md</code> plus pseudocode structure that <code>dev-docs/PLAN.md</code> mandates, or
+    record a deliberate deviation.
+  </p>
+</div>
+
+<footer>
+  Companion to <a href="./PLAN.md">PLAN.md</a> (authoritative) and
+  <a href="./design.html">design.html</a> (detail and evidence). Written on branch
+  <code>issue3167-design</code>. Diagrams are schematic; the streaming-overlap shape in &sect;02 and the prompt-id
+  structure in &sect;05 are faithful to the code.
+</footer>
+
+</div>
+</body>
+</html>

--- a/project-plans/issue3167/specification.md
+++ b/project-plans/issue3167/specification.md
@@ -283,7 +283,55 @@ or full volume the guarantee degrades to "no further growth", because eviction i
 
 ---
 
-## 7. Still open
+## 7. Claim verification
+
+Every load-bearing claim above was checked against source rather than taken from a review. Earlier revisions of
+this plan propagated a finding that turned out to be a test artifact, so the evidence is recorded here to stop
+that recurring.
+
+**Dependency edges** — from the internal `dependencies` in each `package.json`:
+
+```
+agents    -> auth, core, ide-integration, policy, providers, settings, tools     <- no telemetry
+telemetry -> storage                                                              <- lowest layer
+core      -> auth, ide-integration, mcp, policy, settings, storage, telemetry, tools
+cli       -> agents, auth, core, ide-integration, mcp, providers, settings, storage, telemetry, tools
+```
+
+Confirms §4: `telemetry` sits below `core`, and `agents` genuinely has no telemetry edge.
+
+**`superseded` really is unreachable via the ownership release** — `useSubmitQuery.ts:650-659`:
+
+```ts
+} finally {
+  // Guard against stale cleanup: a terminal error/idle-timeout event
+  // may have already released interactive ownership ... (issue #2954)
+  if (isCurrentTurn(current, turnSignal)) {
+    current.activeTurnRef.current = false;
+    current.scheduleNextQueuedSubmission();
+  }
+}
+```
+
+The release is inside the guard, so a superseded turn never reaches it. There is also a **second** release site
+at `:293`, and the acquire at `:620` is unconditional. Confirms that finalisation needs its own registry and
+sweep rather than hanging off ownership.
+
+**`IntervalUnion` is private and quadratic** — `sessionMetricsAggregator.ts`: `add()` calls
+`recomputeDuration()`, which walks the entire interval list on every insertion. The file's only exports are
+`ApiAttemptRecord`, `ModelBreakdown`, `SessionMetricsSnapshot` and `SessionMetricsAggregator` — the class itself
+is not exported. Confirms §5: extract, export, and make the duration incremental.
+
+**`FileOutput` never deletes** — `grep -c 'unlink|rm(|rmSync'` over
+`packages/telemetry/src/debug/FileOutput.ts` returns **0**, alongside `private static instance`,
+`maxFileSize = 10 * 1024 * 1024`, `maxQueueSize = 1000`, `batchSize = 50`, `flushInterval = 1000`, and an
+unguarded `console.error`. Confirms §5.
+
+**Ink exposes render timing** — `ink/build/render.d.ts:44` declares
+`onRender?: (metrics: RenderMetrics) => void`, `ink.d.ts:9` exports the type, and `ink.js:74-76` throttles the
+callback so it fires per actual render pass. Confirms that `ink_render_ms` is a pure accumulate.
+
+## 8. Still open
 
 | Item                                                                    | Blocks                          |
 | ----------------------------------------------------------------------- | ------------------------------- |

--- a/project-plans/issue3167/specification.md
+++ b/project-plans/issue3167/specification.md
@@ -1,0 +1,292 @@
+# Specification: Client-Side Performance Telemetry
+
+Plan ID: PLAN-20260808-PERFTREND
+Issue: #3167
+Status: **schema and placement settled; two fields pending the full-vs-halved decision** (marked below)
+
+Companions: [`PLAN.md`](./PLAN.md) (phases, requirements, rejected approaches) ·
+[`decision.html`](./decision.html) (plain-language explainer) · [`design.html`](./design.html) (evidence)
+
+This document exists because the plan named "define the record schema" as a task and never did it. The schema is
+the contract between the writer and the reader, and #3164 is what happens when those two drift: a cleanup reader
+matched `.json` while the writer produced `.jsonl`, so it deleted nothing for months — with passing tests,
+because the fixtures encoded the old shape. That is 3.8 GB of accumulated files.
+
+Everything specified here is independent of the outstanding full-vs-halved decision except the two fields
+explicitly tagged **DECISION**.
+
+---
+
+## 1. Record schema
+
+One record per completed top-level operation. One JSON object per line.
+
+**Authoring rule:** this table is the source of truth for the *shape*; the implementation must declare it once as
+a Zod schema (`dev-docs/RULES.md` mandates schema-first with Zod) and both the writer and the report reader must
+derive their types from that single declaration. No hand-authored fixture may stand in for a real record in
+tests — the round-trip test asserts against output produced by the actual writer.
+
+### 1.1 Envelope
+
+| Field            | Type   | Notes                                                             |
+| ---------------- | ------ | ----------------------------------------------------------------- |
+| `schema_version` | number | Starts at 1. Compatibility rules in §2.                           |
+| `record_type`    | string | `operation` for now; discriminator so lifecycle rows can be added |
+| `ts`             | string | ISO 8601, operation end                                           |
+
+### 1.2 Identity — reuses #3130's shipped key names verbatim
+
+Adopting these character-for-character is what makes the perf log joinable to the token-usage log and the
+session recording. Inventing parallel names would produce three logs that cannot be joined.
+
+| Field               | Type              | Notes                                                                     |
+| ------------------- | ----------------- | ------------------------------------------------------------------------- |
+| `session_id`        | string            |                                                                           |
+| `operation_id`      | string            | Groups the sends belonging to one user submission. See §3.                |
+| `prompt_ids`        | string[] (capped) | The child sends this operation covers. **Must be capped or hashed** — see §1.7 |
+| `turn_ids`          | string[] (capped) | Same, and nullable per record in the token log                            |
+| `runtime_id`        | string            |                                                                           |
+| `parent_runtime_id` | string \| null    | `null` for the main agent                                                 |
+| `subagent_name`     | string \| null    | `null` for the main agent                                                 |
+| `project_hash`      | string            | Project identity as a field, so the file path can stay global             |
+
+**Do not join on `user_turn` or `step`.** `docs/token-usage-log.md` documents that both name the newest turn
+*already in history* rather than the turn being sent, and are `null` on a session's first request.
+
+### 1.3 Terminal status
+
+| Field    | Type   | Values                                                                                                                              |
+| -------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `status` | string | `completed` · `error` · `cancelled_before_send` · `cancelled_during_api` · `cancelled_during_tool` · `cancelled_during_approval` · `superseded` |
+
+`superseded` is load-bearing: the ownership release in `useSubmitQuery` is guarded by `isCurrentTurn`, so a
+superseded operation never reaches it. Without an explicit finalisation sweep those operations are silently
+dropped, and the trend would under-sample exactly the pathological cases worth measuring.
+
+### 1.4 Build identity — the x-axis
+
+| Field            | Type   | Source                                                                     |
+| ---------------- | ------ | -------------------------------------------------------------------------- |
+| `llxprt_version` | string | `getCliVersion()`; `CLI_VERSION` baked at build time                       |
+| `git_sha`        | string | `getGitCommitInfo()` — already exists, no build change. Stale on plain `npm run build`; correct for released and nightly artifacts |
+| `runtime`        | string | e.g. `bun-1.3.14` / `node-25.2.1`                                          |
+| `platform`       | string | e.g. `darwin-arm64`                                                        |
+
+### 1.5 Comparison dimensions — compare like with like, never pooled
+
+| Field                  | Type   | Why it is required                                                       |
+| ---------------------- | ------ | ------------------------------------------------------------------------ |
+| `provider`             | string | Never compare a fast model's operation against a slow one                |
+| `model`                | string |                                                                          |
+| `context_tokens`       | number | Cost scales with it; the primary normaliser                              |
+| `output_tokens`        | number | Normaliser for render-side cost                                          |
+| `terminal_cols`        | number | Render cost scales with geometry                                         |
+| `terminal_rows`        | number |                                                                          |
+| `render_mode`          | string | `alt-buffer` · `incremental` · `plain` · `screen-reader` — changes frame and byte counts independently of our code |
+| `concurrent_instances` | number | Other llxprt processes active. With 2+ concurrent 98.9% of observed time, self-contention is the dominant noise source |
+
+### 1.6 Measurements
+
+**Client work — directly measured, additive among themselves:**
+
+| Field                  | Type   | Notes                                                              |
+| ---------------------- | ------ | ------------------------------------------------------------------ |
+| `client_prepare_ms`    | number | Before the first send                                              |
+| `stream_handler_ms`    | number | Our synchronous CPU inside delta handling                          |
+| `ink_render_ms`        | number | From Ink's `onRender` — Ink computes it, so this is a pure accumulate |
+| `ink_render_count`     | number | Actual render passes, not stdout writes                            |
+| `stdout_bytes`         | number | Encoded bytes (`Buffer.byteLength` / `Uint8Array.byteLength`), never string length |
+| `stdout_write_calls`   | number | Distinct from `ink_render_count`; one write is not one frame        |
+| `stdout_write_sync_ms` | number | Synchronous invocation only — excludes drain and terminal flush. Candidate to defer; the wrapper is the riskiest edit in the design |
+| `client_finalize_ms`   | number | After the last send                                                |
+
+**Provider and tool work — explicitly overlapping, NOT additive with the above or each other:**
+
+| Field                     | Type   | Notes                                              |
+| ------------------------- | ------ | -------------------------------------------------- |
+| `provider_attempt_sum_ms` | number | Σ of attempt durations. Answers "how much provider work" |
+| `provider_union_ms`       | number | Merged intervals. Answers "how much elapsed time was covered" |
+| `provider_attempts`       | number | Retries and failover each count                    |
+| `tool_call_sum_ms`        | number | Σ of tool durations                                |
+| `tool_union_ms`           | number | Merged intervals                                   |
+| `tool_calls`              | number |                                                    |
+| `agent_activity_union_ms` | number | Union of provider and tool together               |
+
+**Elapsed:**
+
+| Field                     | Type   | Notes                                                            |
+| ------------------------- | ------ | ---------------------------------------------------------------- |
+| `operation_elapsed_ms`    | number | Wall time from operation start to terminal status                |
+| `approval_wait_ms`        | number | Time blocked on tool confirmation — human time, measured at the confirmation seam, not from `useStreamingState` |
+| `unclassified_elapsed_ms` | number | Elapsed minus everything attributed. **Reported honestly, never labelled "llxprt time" and never clamped.** A large value here is a finding, not an error to hide |
+
+**The record must not claim these sum.** That assumption is precisely what made rev.1 invalid.
+
+### 1.7 Pending the full-vs-halved decision
+
+| Field            | Type    | Present in                                                     |
+| ---------------- | ------- | -------------------------------------------------------------- |
+| `contended`      | boolean | **DECISION** — FULL only. Requires the ~10 Hz drift probe. If halved, `concurrent_instances` is the contention covariate and no timer is added |
+| `records_dropped`| number  | **DECISION** — FULL only. Meaningless without a bounded queue; if halved, the serialized write chain provides back-pressure and nothing is dropped |
+
+`operation_id` is present in **both** versions. Only how it is *produced* differs — derived from the prompt-id
+prefix (halved) or minted and propagated (full). See §3.
+
+### 1.8 Size
+
+The rev.2 "688 B" figure is withdrawn: it priced a rejected field set. The set above is larger, and
+`prompt_ids` / `turn_ids` make the record **variable length** — ids look like
+`${sessionId}#agentic-loop#${uuid}#continuation#${n}` at roughly 80–110 bytes each with no natural bound. A
+30-continuation operation would add kilobytes, which breaks the fixed-size arithmetic the eviction budget rests
+on.
+
+**Therefore:** cap the arrays at a documented maximum and record the true count separately, or store a hash of
+the set plus the count. Then measure the real record size and derive the retention budget from that — as a Bun
+benchmark under the owning package, not a throwaway script.
+
+---
+
+## 2. Compatibility rules
+
+Every llxprt version on a machine writes into one shared directory, so an old build reading a new record is
+routine, not exceptional. Dispatching on `schema_version` is not by itself a policy. The two rules:
+
+1. **Readers MUST ignore unknown fields.** Adding a field is therefore *not* a version bump. Without this rule
+   every future field addition breaks every older llxprt reading the same directory.
+2. **A bump means a field changed meaning or was removed.** A reader encountering a version above what it knows
+   must **skip the record and count it**, never coerce it.
+
+Reuse the mechanism that already exists rather than inventing one: `tokenUsageRecords.ts` has
+`TOKEN_USAGE_SCHEMA_VERSION`, a `record_type` discriminator, and tolerant normalisation of unversioned legacy
+records to `{schema_version: 0}` rather than throwing.
+
+Readers must additionally tolerate a **truncated final line** — guaranteed whenever a process is SIGKILLed
+mid-append — and count it rather than aborting. This is the justified kind of defensive handling: files on disk
+are genuinely external input.
+
+---
+
+## 3. `operation_id`
+
+One user submission produces several model sends: `useSubmitQuery` handles one new prompt while the agent drives
+continuation internally, and `AgenticLoop` derives a new prompt id per continuation. So a single perf record
+covers multiple `prompt_id` / `turn_id` values, and "one record joins on one turn_id" is false.
+
+The grouping identity **already exists in the data**:
+
+```
+send 1   abc123#agentic-loop#f7e2
+send 2   abc123#agentic-loop#f7e2#continuation#1
+send 3   abc123#agentic-loop#f7e2#continuation#2
+         └──────── shared prefix ────────┘
+```
+
+`AgenticLoop.generateContinuationPromptId()` returns `${initialPromptId}#continuation#${n}` and `run()` threads
+`initialPromptId` through every continuation.
+
+- **Halved:** `operation_id = promptId.split('#continuation#')[0]`, computed at read time. Zero plumbing,
+  `packages/agents` untouched.
+- **Full:** mint an id at submission and propagate it to every child send. Requires a new
+  `agents → telemetry` dependency (see §4).
+
+**Either way**, add a behavioural test asserting the prefix invariant, so a future change to
+`generateContinuationPromptId` fails loudly instead of silently un-grouping the data.
+
+Subagents are the one case where the prefix genuinely breaks, because a separate runtime restarts the namespace.
+Use the existing `runtime_id` / `parent_runtime_id` / `subagent_name` keys rather than inventing new ones.
+
+---
+
+## 4. Placement
+
+Verified dependency edges (from the `file:../` entries in each `package.json`):
+
+```
+storage    -> (none)
+settings   -> storage
+telemetry  -> storage ONLY
+core       -> telemetry, storage, settings, auth, policy, mcp, tools, ide-integration
+agents     -> core, providers, tools, policy, settings, auth, ide-integration     <- NO telemetry edge
+cli        -> core, agents, telemetry, providers, settings, storage, tools, ...
+```
+
+Layering is `storage < telemetry < core < agents < cli`. **`packages/telemetry` sits below `core`**, so anything
+placed there is reachable from everything above while itself importing only `storage`.
+
+| Package     | Owns                                                                                                  |
+| ----------- | ----------------------------------------------------------------------------------------------------- |
+| `telemetry` | The schema, the JSONL sink, directory retention, and the extracted interval-union helper               |
+| `core`      | Only the stdout byte/duration counter hook — `utils/stdio.ts` lives here and cannot move               |
+| `cli`       | Operation lifecycle and finalisation registry, Ink `onRender` wiring, the opt-in setting, `/perf` and the report command |
+| `agents`    | **Nothing.** It has no telemetry dependency and must not acquire one for this feature                 |
+
+This is the only arrangement that adds no new edges. Placing the writer in `cli` would make it unreachable from
+`core`'s stdout seam; threading ids through `agents` inverts the dependency direction to carry a measurement
+concern through business logic.
+
+If agents-side emission ever becomes genuinely necessary, copy `TokenUsageLogger`'s pattern — it writes gated
+JSONL from inside `agents` *without* a telemetry dependency by taking `enabled` and `logFilePath` as constructor
+parameters. Inject a narrow port; do not import the subsystem.
+
+---
+
+## 5. Reuse, not reinvention
+
+`packages/telemetry/src/debug/FileOutput.ts` already implements most of the proposed writer, in the package that
+should own it:
+
+| Capability                      | Where                                            |
+| ------------------------------- | ------------------------------------------------ |
+| JSONL append into the global log dir | `debugDir`, `currentLogFile`                |
+| Unique run id in the filename   | `debugRunId`                                     |
+| Size rolling                    | `maxFileSize = 10 * 1024 * 1024`                 |
+| Bounded queue                   | `maxQueueSize = 1000`                            |
+| Batch + interval flush          | `batchSize = 50`, `flushInterval = 1000`         |
+| Serialized-write guard          | `isWriting`                                      |
+| Drain on dispose                | `dispose()` / `disposeInstance()`                |
+
+**Extend it into a reusable JSONL sink rather than writing a parallel one** — and fix its real defects instead
+of reproducing them:
+
+1. It is a **singleton** (`private static instance`). A perf sink needs its own instance, so the reusable form
+   must be constructible, not singleton-only.
+2. It calls `fs.stat` on **every flush**. Stat once at open and count bytes in memory thereafter.
+3. It `console.error`s unbounded on every failure. Diagnostics must be rate-limited.
+4. **It never deletes anything.** `llxprt-debug-*.jsonl` grows forever — the same unbounded-growth bug as
+   #3164, sitting in the package this feature would join. Adding retention here fixes two problems at once.
+
+Directory retention should follow `errorReporting.ts`'s `rotateReports()` shape — bound on file **count and
+total bytes simultaneously**, oldest first — but not its guarantees: it protects only in-process paths and
+decrements its accounting even when `unlink` fails.
+
+`IntervalUnion` in `sessionMetricsAggregator.ts` has the correct merge semantics but is **private** and
+recomputes the whole duration on every insert (quadratic over a session, which bites the 24/7 workload
+specifically). Extract it, export it, fix it to maintain the duration incrementally, and have both the session
+aggregator and the perf recorder use the one implementation.
+
+---
+
+## 6. Live-writer safety
+
+Retention must never delete or archive a file a live writer still holds: unlinking it makes already-written
+records vanish while the next append silently recreates the path.
+
+**Rule, requiring no lock:** treat a file as potentially live — and skip it — when its day-key is today **and**
+its mtime falls within the maintenance interval. That is a pure function of the filename plus one `stat`, it is
+testable without spawning processes, and it deliberately avoids adding a lock. #3164 reports 417 stale lock
+files; `reconcileLock` has no PID-liveness reclaim and `CredentialWriteLock` is far more machinery than a log
+file warrants.
+
+The retention guarantee is therefore an **eventual bound with documented overshoot**, not an instantaneous
+ceiling. A hard cap, zero record loss, and no cross-process coordination cannot all hold at once. On a read-only
+or full volume the guarantee degrades to "no further growth", because eviction itself cannot run.
+
+---
+
+## 7. Still open
+
+| Item                                                                    | Blocks                          |
+| ----------------------------------------------------------------------- | ------------------------------- |
+| Full vs halved (`contended`, `records_dropped`, retry threshold, gzip, sub-rolling, id plumbing) | §1.7, §3, and Phase ordering |
+| Memory trend as its own issue                                            | Whether Phase 6 belongs here    |
+| Full `dev-docs/PLAN.md` structure (`analysis/pseudocode/`, numbered phase files) vs a recorded deviation | `@pseudocode` traceability at implementation time |

--- a/project-plans/issue3167/specification.md
+++ b/project-plans/issue3167/specification.md
@@ -2,7 +2,8 @@
 
 Plan ID: PLAN-20260808-PERFTREND
 Issue: #3167
-Status: **schema and placement settled; two fields pending the full-vs-halved decision** (marked below)
+Status: **settled.** Schema, placement, delivery shape and memory trend are all decided; see §9 for the one
+remaining process question.
 
 Companions: [`PLAN.md`](./PLAN.md) (phases, requirements, rejected approaches) ·
 [`decision.html`](./decision.html) (plain-language explainer) · [`design.html`](./design.html) (evidence)
@@ -12,8 +13,8 @@ the contract between the writer and the reader, and #3164 is what happens when t
 matched `.json` while the writer produced `.jsonl`, so it deleted nothing for months — with passing tests,
 because the fixtures encoded the old shape. That is 3.8 GB of accumulated files.
 
-Everything specified here is independent of the outstanding full-vs-halved decision except the two fields
-explicitly tagged **DECISION**.
+Scope note: all accepted work for #3167 — including the memory trend in §7 — ships as **one PR**. Fields that
+were considered and excluded are recorded in §1.7 so they are not silently reintroduced.
 
 ---
 
@@ -122,15 +123,29 @@ dropped, and the trend would under-sample exactly the pathological cases worth m
 
 **The record must not claim these sum.** That assumption is precisely what made rev.1 invalid.
 
-### 1.7 Pending the full-vs-halved decision
+**Memory, sampled at operation end:**
 
-| Field            | Type    | Present in                                                     |
-| ---------------- | ------- | -------------------------------------------------------------- |
-| `contended`      | boolean | **DECISION** — FULL only. Requires the ~10 Hz drift probe. If halved, `concurrent_instances` is the contention covariate and no timer is added |
-| `records_dropped`| number  | **DECISION** — FULL only. Meaningless without a bounded queue; if halved, the serialized write chain provides back-pressure and nothing is dropped |
+| Field                     | Type   | Notes                                                                 |
+| ------------------------- | ------ | --------------------------------------------------------------------- |
+| `rss_bytes`               | number |                                                                       |
+| `heap_used_bytes`         | number |                                                                       |
+| `external_bytes`          | number | First-class, not an afterthought — under Bun/JSC this is where the mass hid in #3112 |
+| `array_buffers_bytes`     | number | Same                                                                  |
+| `session_operation_index` | number | Monotonic per session. The x-axis for the per-**operation** slope     |
+| `uptime_ms`               | number | `performance.now()` at sample time. The x-axis for the per-**minute** slope |
 
-`operation_id` is present in **both** versions. Only how it is *produced* differs — derived from the prompt-id
-prefix (halved) or minted and propagated (full). See §3.
+Do **not** store a computed slope. Slopes are derived at read time from these columns, so a fix to the
+regression maths does not require re-collecting data, and a single record is never asked to describe a trend it
+cannot see.
+
+### 1.7 Excluded fields, and why
+
+Both were considered and are **not** in the schema. Recorded so they are not reintroduced without new argument.
+
+| Field             | Excluded because                                                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contended`       | Requires a ~10 Hz drift probe. At an observed peak of 182 concurrent instances that is ≈1,820 timer wakeups/second machine-wide — the measurement would materially contribute to the contention it reports. `concurrent_instances` (§1.5) carries the signal at zero timer cost. |
+| `records_dropped` | Meaningless without a bounded queue with a drop policy, and there is no burst to absorb: one record per operation, written through a serialized chain that provides its own back-pressure. |
 
 ### 1.8 Size
 
@@ -283,7 +298,86 @@ or full volume the guarantee degrades to "no further growth", because eviction i
 
 ---
 
-## 7. Claim verification
+## 7. Memory trend
+
+In scope for this issue and this PR, not deferred. It shares the schema, the sink and the retention, and is
+disableable on its own (§7.4).
+
+### 7.1 Why two slopes rather than one number
+
+Absolute memory tells you nothing: a 400k-token context legitimately uses a lot of it. What is diagnostic is
+**what the growth tracks**.
+
+| Signature                                     | Reading                                                      |
+| --------------------------------------------- | ------------------------------------------------------------ |
+| Grows per operation, flattens while idle       | Normal. More work, more memory.                              |
+| Grows per minute **while idle**                | Leak. Something is retained by uptime, not by activity.       |
+
+The second is exactly #3114, where memory climbed with how long llxprt had been running rather than with how
+much it had been asked to do. One RSS number can never show that; two slopes make it obvious. This is the live
+in-session equivalent of the offline plateau gate in `scripts/issue-2852-memory-runner.ts`, which already
+evaluates JSC heap, `external` and dirty WebKit Malloc independently.
+
+### 7.2 Two sample sources, one discriminated record stream
+
+The `record_type` discriminator from §1.1 earns its keep here:
+
+- `record_type: "operation"` — carries the memory columns from §1.6, giving the **per-operation** axis for free.
+  No extra sampling; it rides the record already being written.
+- `record_type: "memory_sample"` — a bare sample carrying only the four memory values, `uptime_ms` and
+  `ms_since_last_operation`, giving the **per-minute** axis. `ms_since_last_operation` is what makes an *idle*
+  sample identifiable, and idle samples are the ones that expose the #3114 signature.
+
+A reader that ignores unknown `record_type` values (§2) tolerates this addition without a version bump.
+
+### 7.3 Zero new timers — the performance answer
+
+`useMemoryMonitor` **already** runs an unconditional 60-second interval calling `process.memoryUsage().rss`
+(`MEMORY_CHECK_INTERVAL_MS = 60 * 1000`). 60 s is exactly the right cadence for an uptime slope. Extend that
+existing interval; do **not** add one.
+
+Two things must be fixed in that hook, both improvements in their own right:
+
+1. It calls `clearInterval(intervalId)` **immediately after warning once**, so today it stops monitoring
+   precisely when memory is known to be a problem. Separate the warn-once latch from the sampling loop.
+2. Give the sample a bounded in-memory ring for the live `/perf` view. It would be absurd for the leak detector
+   to leak; the ring must be fixed-capacity with overwrite, never a growing array.
+
+**Do not** piggyback `Footer.tsx`'s 2-second interval. It is gated on the `showMemoryUsage` setting and on the
+component being mounted, so telemetry hung off it would silently collect nothing depending on unrelated UI
+configuration.
+
+Measured cost (`darwin-arm64`, both runtimes) — and critically, measured on a **large fragmented heap** rather
+than an idle one, because idle is not the operating condition:
+
+| Runtime | idle heap | 233 MB fragmented heap | ratio |
+| ------- | --------- | ---------------------- | ----- |
+| Bun 1.3.14 | `full` 0.43 µs · `rss()` 0.39 µs | `full` 0.44 µs · `rss()` 0.38 µs | **1.03×** |
+| Node 25.2.1 | `full` 0.67 µs · `rss()` 0.44 µs | `full` 0.65 µs · `rss()` 0.43 µs | **0.98×** |
+
+The cost is **independent of heap size and fragmentation**, which is the property that matters — a leak
+investigation runs precisely when the heap is large, and the probe must not get more expensive exactly then. One
+full sample per 60 s is on the order of 1e-6 % of wall time. The earlier 0.42 µs figure was taken on an idle
+heap and was rightly flagged as unrepresentative; re-measured under load, it holds.
+
+### 7.4 Its own off switch
+
+Two independent settings, both defaulting to **false** (REQ-3167-8 requires the whole subsystem be opt-in per
+`docs/telemetry-privacy.md`):
+
+| Setting                 | Effect                                                                    |
+| ----------------------- | ------------------------------------------------------------------------- |
+| `telemetry.perf`        | Master. Off means nothing is collected and no file is opened.              |
+| `telemetry.perf.memory` | Memory columns and `memory_sample` records. Off means the memory columns are omitted and the 60 s hook reverts to its warn-only behaviour. |
+
+Semantics: memory requires the master to be on, and can be turned off while leaving timing collection running.
+The reverse is not offered — there is no configuration that collects memory without the perf record, because the
+memory columns live on that record.
+
+Turning memory off must **remove the fields**, not write zeros. A zero is indistinguishable from a real
+measurement; an absent field is unambiguous, and §2 already requires readers to tolerate absent fields.
+
+## 8. Claim verification
 
 Every load-bearing claim above was checked against source rather than taken from a review. Earlier revisions of
 this plan propagated a finding that turned out to be a test artifact, so the evidence is recorded here to stop
@@ -331,10 +425,33 @@ unguarded `console.error`. Confirms §5.
 `onRender?: (metrics: RenderMetrics) => void`, `ink.d.ts:9` exports the type, and `ink.js:74-76` throttles the
 callback so it fires per actual render pass. Confirms that `ink_render_ms` is a pure accumulate.
 
-## 8. Still open
+**A 60 s memory interval already exists, and it self-terminates** — `useMemoryMonitor.ts`:
+`MEMORY_CHECK_INTERVAL_MS = 60 * 1000`, the effect has no conditional guard, and the callback calls
+`clearInterval(intervalId)` inside the warning branch. Confirms §7.3: there is a host timer to extend, and its
+self-termination is a real defect to fix rather than a behaviour to preserve.
 
-| Item                                                                    | Blocks                          |
-| ----------------------------------------------------------------------- | ------------------------------- |
-| Full vs halved (`contended`, `records_dropped`, retry threshold, gzip, sub-rolling, id plumbing) | §1.7, §3, and Phase ordering |
-| Memory trend as its own issue                                            | Whether Phase 6 belongs here    |
-| Full `dev-docs/PLAN.md` structure (`analysis/pseudocode/`, numbered phase files) vs a recorded deviation | `@pseudocode` traceability at implementation time |
+**`Footer.tsx`'s 2 s interval is not a viable host** — `setInterval(updateMemory, 2000)` lives inside
+`ResponsiveMemoryDisplay`, which is gated on the `showMemoryUsage` setting and only samples while mounted.
+Confirms §7.3's exclusion.
+
+**`process.memoryUsage()` is heap-size independent** — measured full-call and `rss()` cost at an idle heap and
+again at a 233 MB fragmented heap with 900k live objects, punched holes and 75 MB of external buffers. Ratios
+1.03× (Bun) and 0.98× (Node). Confirms §7.3.
+
+## 9. Still open
+
+| Item                                                                                                     | Blocks                                            |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Full `dev-docs/PLAN.md` structure (`analysis/pseudocode/`, numbered phase files) vs a recorded deviation  | `@pseudocode` traceability at implementation time |
+
+### Decided
+
+- **Scope shape — one issue, one PR.** All accepted work for #3167 ships together, including the memory trend
+  (§7). Splitting a single issue across issues or stacked PRs is not the default here.
+- **Memory trend is in scope**, first-class rather than a separable trailing phase. Sampling design and its
+  independent off switch are specified in §7.
+- **Delivery is the reduced shape.** `contended` and `records_dropped` are dropped along with the ~10 Hz drift
+  probe, the bounded queue with drop policy, the retry-threshold self-disable, gzip and sub-rolling.
+  `concurrent_instances` carries the contention signal instead, and `operation_id` is derived from the prompt-id
+  prefix (§3) rather than plumbed through `packages/agents`. The deciding factor is the dependency direction
+  verified in §8: keeping a measurement concern out of the agent loop outweighs every feature dropped.


### PR DESCRIPTION
## TLDR

Planning documents only — no code, no behaviour change. Adds the design artifacts for #3167 (measuring llxprt's own performance, separately from provider latency) to `project-plans/issue3167/`.

Worth flagging for reviewers: **two earlier revisions of this design were wrong and the corrections are recorded rather than quietly dropped.** The headline model was algebraically invalid, and a storage scheme lost 49% of records under concurrency. The rejected approaches are documented in place so the reasoning is auditable.

Scope is **one issue, one PR** — that includes the memory-trend / leak-detection half, which is specified here rather than deferred.

Start with **`decision.html`** (open in a browser) — it explains the whole thing in four diagrams. `specification.md` is the binding contract; `PLAN.md` has the phases.

## Dive Deeper

### The mistake that shaped the design

The first design derived "llxprt time" by subtracting provider and tool time from elapsed time. That cannot work. `ApiAttemptRecord.durationMs` is the *whole* request wall duration and the entire interval enters the activity union — but during a streaming request we are decoding deltas and Ink is painting **inside** that interval. So the subtraction removes the very work it claims to measure, and `coreMs = llxprtMs − uiMs` can go negative on an ordinary turn. Provider/tool figures are also *sums* while the residual used a *union*, so the three quantities were never a partition.

Replaced by: directly measured client phases, provider/tool reported as explicitly overlapping `*_sum_ms` **and** `*_union_ms`, and the leftover named `unclassified_elapsed_ms` rather than assumed to be ours.

### What the documents settle

- **`specification.md`** — the record schema (which `PLAN.md` had listed as a task and never delivered), compatibility rules, package placement, reuse decisions, and the live-writer rule. Includes a verification appendix with line-level evidence for every load-bearing claim.
- **Placement**, from the verified dependency edges: `telemetry` sits *below* `core` and `agents` has **no** telemetry dependency. So `telemetry` owns the schema/sink/retention, `core` owns only the stdout hook, `cli` owns the lifecycle and consumers, and `agents` owns nothing.
- **Reuse over reinvention** — `packages/telemetry/src/debug/FileOutput.ts` already implements most of the proposed writer. It also **never deletes anything** (verified: zero `unlink` calls), so `llxprt-debug-*.jsonl` grows forever — the same unbounded-growth bug as #3164, in the package this feature would join.
- **Honest guarantees** — a hard instantaneous size cap, zero record loss, and no cross-process coordination cannot all hold. The retention guarantee is an eventual bound with documented overshoot.

### Memory trend is in scope, and adds no timers

Two axes, not one number. Absolute memory says nothing — a large context legitimately uses a lot of it. What is diagnostic is *what the growth tracks*: growth per operation that flattens while idle is normal; growth per minute **while idle** is a leak, and is exactly the #3114 signature. Memory columns ride the operation record for the per-operation axis; a `record_type: "memory_sample"` row carries `ms_since_last_operation` for the per-minute axis. Slopes are derived at read time, never stored. `external` / `arrayBuffers` are first-class — that is where the mass hid under Bun/JSC in #3112.

On not hurting the thing we're measuring:

- **Zero new timers.** `useMemoryMonitor` already runs an *unconditional* 60 s interval calling `process.memoryUsage().rss` — the right cadence for an uptime slope. Extend it. `Footer.tsx`'s 2 s interval is explicitly rejected as a host: it is gated on `showMemoryUsage` and on being mounted, so telemetry hung off it would silently collect nothing depending on unrelated UI config.
- **Two defects in that hook get fixed on the way:** it `clearInterval`s itself after warning once, so today it stops monitoring precisely when memory is known to be a problem; and the live view needs a fixed-capacity ring rather than a growing array, because a leak detector that leaks would be absurd.
- **Cost re-measured under load**, resolving an earlier idle-heap caveat. On a 233 MB fragmented heap (900k live objects, punched holes, 75 MB external): 0.44 µs on Bun, 0.65 µs on Node — ratios **1.03×** and **0.98×** versus idle. Cost is *independent of heap size and fragmentation*, which is the property that matters, since leak investigations run precisely when the heap is large. One sample per 60 s is ~1e-6 % of wall time.
- **Independently disableable** via `telemetry.perf.memory`, separate from the `telemetry.perf` master; both default off. Disabling omits the fields rather than writing zeros, because a zero is indistinguishable from a real measurement.

### Excluded, with reasons recorded

`contended` is dropped: its ~10 Hz drift probe would be ≈1,820 wakeups/second machine-wide at the observed 182-instance peak, so the measurement would materially contribute to the contention it reports. `concurrent_instances` carries that signal at zero timer cost. `records_dropped` is dropped: meaningless without a bounded queue, and one record per operation through a serialized write chain has no burst to absorb. `operation_id` is derived from the prompt-id prefix rather than plumbed through `packages/agents`, which keeps a measurement concern out of the agent loop — the deciding factor, given the verified dependency edges.

### Withdrawn claims, listed for transparency

The overhead budget (summed primitive costs, not end-to-end), the record-size and retention budgets (priced the rejected field set), the "load-invariant counters" claim (downgraded to covariates), and a "negative mtime age" finding that turned out to be an artifact of testing with `grace = 0`, a configuration the design never uses.

### Still open

One process question: whether we produce the full `dev-docs/PLAN.md` phase structure (`analysis/pseudocode/`, numbered phase files) or record a deliberate deviation. Noted in `specification.md` §9. Scope, schema, placement, delivery shape and memory are all settled.

## Reviewer Test Plan

No code to run. To review:

1. Open `project-plans/issue3167/decision.html` in a browser. §02 is why the original model was invalid; §04 is the component breakdown; §05 is the identity finding; §06 is placement.
2. Read `project-plans/issue3167/specification.md` — particularly §1 (schema), §2 (compatibility rules), §7 (memory trend and its sampling/off-switch design) and §8 (claim verification, which cites exact lines so you can check the reasoning rather than take it on trust).
3. Spot-check the verification appendix — every claim cites a file so you can disagree with evidence. For example `grep -c 'unlink' packages/telemetry/src/debug/FileOutput.ts` returns 0; `useSubmitQuery.ts:656` shows the `isCurrentTurn` guard that makes a superseded turn never finalise; and `useMemoryMonitor.ts` shows both the 60 s interval we intend to extend and the `clearInterval` that currently stops it.

Guards run locally, all passing: `format:check`, `lint:doc-placement`, `lint:doc-links`, `lint:no-new-js`, `lint:copyright-year`, `lint:legacy-paths`, `lint:eslint-guard`.

## Testing Matrix

Not applicable — documentation only, no runtime code paths touched.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | -   | -   | -   |
| npx      | -   | -   | -   |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs

This PR makes progress on #3167 — it adds the design and specification but implements none of it, so the issue stays open.

Related to #3164 (session cleanup non-functional): this design deliberately reacts to it — the perf log is global rather than under a project hash so it cannot become unreachable, and the `FileOutput` finding above is the same unbounded-growth class of bug.

Related to #3130 (token-usage telemetry), which has landed: the perf record reuses its identity keys verbatim so the two logs and the session recordings join.

