### PR TITLE
Exclude memory from compression LLM requests (Fixes #3174)

### DIFF
--- a/packages/agents/src/compression/compressionMemoryExclusion.test.ts
+++ b/packages/agents/src/compression/compressionMemoryExclusion.test.ts
@@ -1,0 +1,319 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #3174: compression requests must exclude caller
+ * core memory (.LLXPRT_SYSTEM) and MCP-server instructions.
+ *
+ * Unlike the sibling compressionSystemPrompt.test.ts, this file does NOT mock
+ * getCoreSystemPromptAsync. It exercises the REAL compression system-prompt
+ * assembler against a real on-disk .LLXPRT_SYSTEM file and real MCP
+ * instructions exposed through config, then asserts neither leaks into the
+ * assembled compression instruction. It also proves the compression request
+ * still carries the <state_snapshot> template and that a valid snapshot
+ * response is applied.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+import { initializePromptSystem } from '@vybestack/llxprt-code-core/core/prompts.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import type {
+  CompressionContext,
+  CompressionProviderResult,
+} from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import type { PromptResolver } from '@vybestack/llxprt-code-core/prompt-config/prompt-resolver.js';
+import { buildCompressionSystemInstruction } from './compressionSystemPrompt.js';
+import { OneShotStrategy } from './OneShotStrategy.js';
+
+// ---------------------------------------------------------------------------
+// Sentinels
+// ---------------------------------------------------------------------------
+
+const CORE_MEMORY_SENTINEL = 'CORE_MEMORY_SENTINEL_3174_DO_NOT_LEAK';
+const MCP_SENTINEL = 'MCP_INSTRUCTIONS_SENTINEL_3174_DO_NOT_LEAK';
+const CORE_MEMORY_WRAPPER = 'Core System Memory';
+const VALID_SNAPSHOT =
+  '<state_snapshot><overall_goal>ship issue 3174</overall_goal></state_snapshot>';
+const COMPRESSION_MODEL = 'compression-test-model';
+
+// ---------------------------------------------------------------------------
+// Test-isolation state
+// ---------------------------------------------------------------------------
+
+let promptDir: string;
+let originalCwd: string;
+let projectDir: string;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal Config double that exposes MCP instructions containing the sentinel.
+ * Config is a large class whose real construction requires full session
+ * initialization (McpClientManager, MessageBus, tool registry, ...). The MCP
+ * accessor is a regression input that the previous compression assembler read;
+ * the fixed assembler must ignore it while still reading isInteractive().
+ */
+function createMcpConfigDouble(mcpInstructions: string): Config {
+  const manager = {
+    getMcpInstructions: () => mcpInstructions,
+  };
+  return {
+    getMcpClientManager: () => manager,
+    isInteractive: () => false,
+  } as unknown as Config;
+}
+
+function humanMsg(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+function aiTextMsg(text: string): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text }] };
+}
+
+function generateHistory(count: number): IContent[] {
+  const messages: IContent[] = [];
+  for (let i = 0; i < count; i++) {
+    messages.push(
+      i % 2 === 0
+        ? humanMsg(`user message ${i}`)
+        : aiTextMsg(`ai response ${i}`),
+    );
+  }
+  return messages;
+}
+
+function extractText(contents: readonly IContent[]): string {
+  const parts: string[] = [];
+  for (const msg of contents) {
+    for (const block of msg.blocks) {
+      if (block.type === 'text') {
+        parts.push(block.text);
+      }
+    }
+  }
+  return parts.join('\n');
+}
+
+function createOptionsCapturingProvider(
+  captured: RuntimeGenerateChatOptions[],
+  summaryText: string,
+): IProvider {
+  return {
+    name: 'options-capture-provider',
+    getModels: async () => [],
+    getDefaultModel: () => COMPRESSION_MODEL,
+    getServerTools: () => [],
+    invokeServerTool: async () => ({}),
+    async *generateChatCompletion(options: RuntimeGenerateChatOptions) {
+      captured.push(options);
+      yield {
+        speaker: 'ai' as const,
+        blocks: [{ type: 'text' as const, text: summaryText }],
+      };
+    },
+  } as unknown as IProvider;
+}
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  log: () => {},
+} as unknown as DebugLogger;
+
+function createStubProviderRuntime(): ProviderRuntimeContext {
+  return {
+    settingsService: {
+      get: () => undefined,
+      set: () => {},
+      getProviderSettings: () => ({}),
+    },
+    config: undefined,
+    runtimeId: 'test-provider-runtime',
+    metadata: { source: 'test' },
+  } as unknown as ProviderRuntimeContext;
+}
+
+function buildCompressionContext(
+  overrides: Partial<{
+    history: IContent[];
+    config: Config;
+    provider: IProvider;
+  }>,
+): CompressionContext {
+  const provider =
+    overrides.provider ?? createOptionsCapturingProvider([], VALID_SNAPSHOT);
+  const resolveProvider = (): CompressionProviderResult => ({
+    provider,
+    runtime: createStubProviderRuntime(),
+  });
+
+  const runtimeState: AgentRuntimeState = {
+    runtimeId: 'test-runtime',
+    provider: 'test-provider',
+    model: COMPRESSION_MODEL,
+    sessionId: 'test-session',
+    updatedAt: Date.now(),
+  };
+
+  const runtimeContext = {
+    state: runtimeState,
+    ephemerals: {
+      compressionThreshold: () => 0.8,
+      contextLimit: () => 100000,
+      preserveThreshold: () => 0.2,
+      topPreserveThreshold: () => 0.2,
+      compressionProfile: () => undefined,
+      toolFormatOverride: () => undefined,
+      reasoning: {
+        enabled: () => false,
+        includeInContext: () => false,
+        includeInResponse: () => false,
+        format: () => 'native' as const,
+        stripFromContext: () => 'none' as const,
+        effort: () => undefined,
+        maxTokens: () => undefined,
+        adaptiveThinking: () => undefined,
+      },
+    },
+    providerRuntime: createStubProviderRuntime(),
+  } as unknown as AgentRuntimeContext;
+
+  const promptResolver = {
+    resolveFile: () => ({ found: false, path: null, source: null }),
+  } as unknown as PromptResolver;
+
+  const context: CompressionContext = {
+    history: overrides.history ?? [],
+    runtimeContext,
+    runtimeState,
+    estimateTokens: async (contents: readonly IContent[]) =>
+      contents.length * 100,
+    currentTokenCount: 5000,
+    logger: noopLogger,
+    resolveProvider,
+    promptResolver,
+    promptBaseDir: '/tmp/test-prompts',
+    promptContext: { provider: 'test-provider', model: COMPRESSION_MODEL },
+    promptId: 'test-prompt',
+  };
+  if (overrides.config !== undefined) {
+    context.config = overrides.config;
+  }
+  return context;
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe('Compression memory exclusion (issue #3174)', () => {
+  beforeAll(async () => {
+    promptDir = mkdtempSync(join(tmpdir(), 'llxprt-compression-prompts-'));
+    process.env.LLXPRT_PROMPTS_DIR = promptDir;
+    await initializePromptSystem();
+  });
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    projectDir = mkdtempSync(join(tmpdir(), 'llxprt-compression-project-'));
+    mkdirSync(join(projectDir, '.llxprt'), { recursive: true });
+    writeFileSync(
+      join(projectDir, '.llxprt', '.LLXPRT_SYSTEM'),
+      `${CORE_MEMORY_SENTINEL}\nsuppress this core memory during compression`,
+    );
+    process.chdir(projectDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    rmSync(promptDir, { recursive: true, force: true });
+    delete process.env.LLXPRT_PROMPTS_DIR;
+  });
+
+  it('excludes core memory and MCP instructions from the assembled compression system instruction', async () => {
+    const config = createMcpConfigDouble(MCP_SENTINEL);
+    const instruction = await buildCompressionSystemInstruction(
+      config,
+      COMPRESSION_MODEL,
+    );
+
+    expect(typeof instruction).toBe('string');
+    expect(instruction.length).toBeGreaterThan(0);
+    expect(instruction).not.toContain(CORE_MEMORY_SENTINEL);
+    expect(instruction).not.toContain(MCP_SENTINEL);
+    expect(instruction).not.toContain(CORE_MEMORY_WRAPPER);
+  });
+
+  it('still produces a non-empty instruction even without core memory on disk', async () => {
+    rmSync(join(projectDir, '.llxprt'), { recursive: true, force: true });
+    const instruction = await buildCompressionSystemInstruction(
+      undefined,
+      COMPRESSION_MODEL,
+    );
+
+    expect(typeof instruction).toBe('string');
+    expect(instruction.length).toBeGreaterThan(0);
+    expect(instruction).not.toContain(CORE_MEMORY_WRAPPER);
+  });
+
+  it('strategy request excludes memory/MCP, keeps the state_snapshot template, and applies a valid snapshot', async () => {
+    const captured: RuntimeGenerateChatOptions[] = [];
+    const provider = createOptionsCapturingProvider(captured, VALID_SNAPSHOT);
+    const context = buildCompressionContext({
+      history: generateHistory(20),
+      config: createMcpConfigDouble(MCP_SENTINEL),
+      provider,
+    });
+
+    const strategy = new OneShotStrategy();
+    const result = await strategy.compress(context);
+
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+    const request = captured[0];
+    const sysInstr = request.systemInstruction;
+    expect(typeof sysInstr).toBe('string');
+    expect((sysInstr as string).length).toBeGreaterThan(0);
+    expect(sysInstr).not.toContain(CORE_MEMORY_SENTINEL);
+    expect(sysInstr).not.toContain(MCP_SENTINEL);
+    expect(sysInstr).not.toContain(CORE_MEMORY_WRAPPER);
+
+    const requestText = extractText(request.contents);
+    expect(requestText).toContain('<state_snapshot>');
+
+    expect(result.kind).toBe('applied');
+    const summarizedHistory =
+      result.kind === 'applied' ? result.newHistory : [];
+    expect(extractText(summarizedHistory)).toContain('<state_snapshot>');
+  });
+});

--- a/packages/agents/src/compression/compressionSystemPrompt.ts
+++ b/packages/agents/src/compression/compressionSystemPrompt.ts
@@ -32,19 +32,23 @@ import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/run
 /**
  * Build the system instruction for a compression request.
  *
- * Passes no `userMemory` and no `coreMemory`, no tools
- * (`includeSubagentDelegation` is therefore `false`), and `interactionMode`
- * derived from `config.isInteractive()`.
+ * Passes no `userMemory`, an explicit empty `coreMemory` string, no
+ * `mcpInstructions`, no tools (`includeSubagentDelegation` is therefore
+ * `false`), and `interactionMode` derived from `config.isInteractive()`.
  *
- * NOTE: omitting `coreMemory` does NOT omit core memory. When `coreMemory` is
- * `undefined`, `getCoreSystemPromptAsync` loads `.LLXPRT_SYSTEM` from disk
- * (`resolveEffectiveMemories` in `packages/core/src/core/prompts.ts`) and
- * `mcpInstructions` is merged into the same channel, so the compression LLM
- * does receive core memory and MCP instructions. Only user memory
- * (`LLXPRT.md`) is actually excluded. Suppressing core memory here would be a
- * behaviour change; see issue #3162 finding D3.
+ * The empty `coreMemory` string (not `undefined`) is deliberate: when
+ * `coreMemory` is `undefined`, `getCoreSystemPromptAsync` loads
+ * `.LLXPRT_SYSTEM` from disk (`resolveEffectiveMemories` in
+ * `packages/core/src/core/prompts.ts`) and merges `mcpInstructions` into the
+ * same channel. Passing `''` short-circuits that disk fallback, and omitting
+ * `mcpInstructions` keeps MCP-server instructions out, so the compression LLM
+ * receives only the base instruction appropriate to its model and interaction
+ * mode — never the caller's core memory or MCP instructions (issue #3174).
  *
- * @param config - The Config to read MCP instructions and interaction mode from
+ * `config` is still accepted so the interaction mode can be derived; it is no
+ * longer consulted for MCP instructions.
+ *
+ * @param config - The Config to read interaction mode from
  * @param model  - The resolved model (same as `resolved.model` on the wire)
  * @returns The assembled system instruction, or `undefined` when the
  *          prompt is empty
@@ -53,14 +57,6 @@ export async function buildCompressionSystemInstruction(
   config: Config | undefined,
   model: string,
 ): Promise<string> {
-  const mcpClientManager =
-    config != null && typeof config.getMcpClientManager === 'function'
-      ? config.getMcpClientManager()
-      : undefined;
-  const mcpInstructions = mcpClientManager
-    ? mcpClientManager.getMcpInstructions()
-    : undefined;
-
   const interactionMode =
     config != null &&
     typeof config.isInteractive === 'function' &&
@@ -69,7 +65,7 @@ export async function buildCompressionSystemInstruction(
       : 'non-interactive';
 
   const corePrompt = await getCoreSystemPromptAsync({
-    mcpInstructions,
+    coreMemory: '',
     model,
     tools: undefined,
     includeSubagentDelegation: false,

--- a/project-plans/issue3174-compression-memory-exclusion.md
+++ b/project-plans/issue3174-compression-memory-exclusion.md
@@ -1,0 +1,76 @@
+# Issue 3174: Compression memory exclusion
+
+## Accepted contract
+
+Adopt option 1 from the issue: compression requests exclude caller memory and MCP-server instructions.
+
+The compression agent still receives the normal assembled base instruction appropriate to its model and interaction mode, plus the existing compression request content that requires a `<state_snapshot>` result. This change does not alter provider transport rules. In particular, Claude Code (Anthropic OAuth) must continue to put its required Claude Code identity string in the Anthropic `system` field while transporting the assembled compression instruction through the existing context-prefix path.
+
+## Acceptance criteria
+
+### AC1: Core memory is absent from compression requests
+
+- **Given** a real `.llxprt/.LLXPRT_SYSTEM` file containing a unique sentinel under the compression process working directory,
+- **When** a compression request is assembled,
+- **Then** its captured `systemInstruction` does not contain the sentinel or a core-memory wrapper.
+- **And** omission is not used to express suppression: the compression assembler explicitly supplies an empty core-memory value so the disk fallback cannot run.
+
+### AC2: MCP instructions are absent from compression requests
+
+- **Given** the compression configuration exposes MCP instructions containing a unique sentinel,
+- **When** a compression request is assembled,
+- **Then** its captured `systemInstruction` does not contain the MCP sentinel.
+- **And** the compression assembler does not forward MCP instructions into core prompt assembly.
+
+### AC3: Compression behavior remains intact
+
+- The captured request still contains the existing compression instructions requiring the `<state_snapshot>` XML structure.
+- A provider response containing a valid `<state_snapshot>` still produces an applied compression result whose summary retains that structure.
+- Initial compression and the optional verification pass continue to receive a non-empty assembled instruction.
+
+### AC4: Other prompt paths and provider placement are unchanged
+
+- Main-agent and subagent prompt assemblers are not modified.
+- The shared `undefined`-loads-from-disk convention is not changed in this issue.
+- `clientLlmUtilities.ts` and audit finding D7 are not changed.
+- Anthropic OAuth system-prompt placement and its required Claude Code identity string are not changed.
+
+## Relevant inputs and boundaries
+
+| Input or boundary | Accepted behavior |
+| --- | --- |
+| `.LLXPRT_SYSTEM` absent | Compression request is assembled normally without memory. |
+| `.LLXPRT_SYSTEM` present and non-empty | Its content is not read into or emitted in the compression instruction. |
+| MCP manager absent or returns no instructions | Compression request is assembled normally. |
+| MCP manager returns non-empty instructions | The instructions are not forwarded or emitted. |
+| Interactive/non-interactive configuration | Existing interaction-mode selection is preserved. |
+| Initial compression vs. verification pass | Both continue to use the shared compression instruction path and exclude memory/MCP content. |
+| Claude Code (Anthropic OAuth) transport | Required Claude Code identity remains in the provider `system` field; this issue changes only compression instruction content. |
+
+## Test-first implementation plan
+
+1. **RED:** Add a Bun behavioral test that creates a real temporary project core-memory file, supplies MCP instructions, captures a compression request, and proves both sentinels currently leak into its assembled instruction. The test must exercise the real compression prompt assembler rather than mock `getCoreSystemPromptAsync`.
+2. **GREEN:** In `packages/agents/src/compression/compressionSystemPrompt.ts`, pass explicit empty `coreMemory` and stop obtaining/forwarding MCP instructions. Make no changes to shared core prompt resolution.
+3. Assert the captured request still contains the `<state_snapshot>` compression template and that a valid snapshot response remains an applied compression result. Preserve coverage for the verification pass and all shared compression call sites.
+4. Run the focused Bun tests, then the repository verification suite.
+
+## Scope
+
+Planned production change:
+
+- `packages/agents/src/compression/compressionSystemPrompt.ts`
+
+Planned behavioral tests:
+
+- compression-system-prompt tests under `packages/agents/src/compression/`
+
+No public abstraction, dependency, workflow, agent-memory mechanism, shared prompt API, main-agent assembly path, subagent assembly path, or unrelated refactor is accepted into scope.
+
+## Review triage policy
+
+Every finding is classified before action:
+
+- **Blocker-Fix:** Prevents an accepted criterion, required verification, safety/architecture invariant, correct ancestry, or conflict-free merge.
+- **In-scope-Fix:** Improves correctness, behavioral evidence, or maintainability within the files and contract above.
+- **Reject:** Factually incorrect, already covered, or conflicts with the accepted contract.
+- **Defer:** Valid but belongs to shared fallback cleanup, auxiliary LLM behavior, another subsystem, or optional hardening outside this issue.


### PR DESCRIPTION
## TLDR

Compression LLM requests now explicitly suppress core memory and stop forwarding MCP-server instructions. This prevents project/global .LLXPRT_SYSTEM content and MCP instructions from leaking into compression while preserving the normal compression base instruction, state_snapshot request, initial compression, verification, and provider-specific transport.

## Dive Deeper

The shared core prompt resolver intentionally loads .LLXPRT_SYSTEM from disk when coreMemory is undefined. Compression previously omitted coreMemory, so it unintentionally triggered that fallback, then also merged MCP instructions into the same core channel.

This PR keeps the shared convention unchanged and fixes only the compression boundary:

- passes an explicit empty coreMemory value during compression prompt assembly
- no longer reads or forwards MCP instructions for compression
- leaves user memory omitted as before
- leaves main-agent and subagent prompt assembly unchanged
- leaves Anthropic OAuth transport unchanged, including the exact Claude Code identity in the provider system field

A Bun behavioral test exercises the real prompt assembler with a real temporary .llxprt/.LLXPRT_SYSTEM sentinel and an MCP sentinel, captures an actual OneShot compression request, verifies both are absent, verifies the state_snapshot request remains present, and confirms a valid snapshot response is applied.

Review completed with Open Code Review and a TypeScript issue-intent review. One stale test comment was corrected. Two duplicate OCR singleton-reset suggestions were rejected because the canonical agents runner executes each test file in an isolated Bun process, and exporting/resetting the core singleton would expand the public/shared prompt surface outside this issue.

Local verification completed:

- focused compression behavioral tests: 7 passed
- changed-file ESLint: passed
- full typecheck: passed
- full format: passed
- full build: passed
- real-model stepfun-37 smoke test: passed
- ESLint policy, no-Vitest, no-new-JavaScript, copyright-year, and documentation-placement guards: passed
- git diff whitespace check: passed

The complete local npm test and npm lint commands exceeded the configured shell execution ceiling without reporting an issue-related failure. Pull-request CI is therefore the authoritative complete-suite run for the candidate head.

## Reviewer Test Plan

1. Run the two compression test files with Bun and the repository test preload.
2. Confirm the memory-exclusion test creates a real .LLXPRT_SYSTEM sentinel and supplies an MCP sentinel without mocking the core prompt assembler.
3. Confirm the captured compression systemInstruction contains neither sentinel nor the core-memory wrapper.
4. Confirm the captured request content still asks for state_snapshot and a valid provider snapshot remains applied.
5. Review compressionSystemPrompt.ts and verify coreMemory is explicitly empty, MCP instructions are not fetched, and interaction-mode selection remains unchanged.
6. Confirm no main-agent, subagent, core fallback, or Anthropic provider transport file changed.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅ | ❓ | ❓ |
| npx      | ❓ | ❓ | ❓ |
| Docker   | ❓ | ❓ | ❓ |
| Podman   | ❓ | - | - |
| Seatbelt | ❓ | - | - |

## Linked issues / bugs

Fixes #3174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compression requests now exclude MCP instructions and disk-based core memory.
  * Compression behavior remains available across interaction modes without unintended instruction leakage.

* **Tests**
  * Added coverage confirming excluded instructions do not appear in compression prompts.
  * Added validation for compression requests without stored core memory.
  * Verified one-shot requests retain state snapshot handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->