### PR TITLE
Align subagent JIT memory sourcing with main agent (Fixes #3173)

### DIFF
--- a/packages/agents/src/core/ChatSessionFactory.byteCompatibility.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.byteCompatibility.test.ts
@@ -1,0 +1,284 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Byte-for-byte compatibility characterization for the main-agent
+ * buildSystemInstruction (issue #3173). Centralizing memory derivation into
+ * resolvePromptMemory must not change the main-agent prompt bytes for any
+ * valid Config behavior.
+ *
+ * Unlike invocation-level tests, this file does NOT mock the core prompt
+ * assembler: buildSystemInstruction's complete returned string is compared
+ * against a test-local legacy copy of the pre-change main builder that uses
+ * the SAME real getCoreSystemPromptAsync. Infrastructure substitution is
+ * limited to clientToolGovernance (shouldIncludeSubagentDelegationForConfig)
+ * so the production memory policy, the production main builder, and the real
+ * core prompt assembler all remain under test.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'bun:test';
+import process from 'node:process';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Only clientToolGovernance is substituted: it is infrastructure that is
+// identical for both the production builder and the legacy reference, so it
+// cannot mask a memory-derivation divergence.
+void vi.mock('./clientToolGovernance.js', () => ({
+  getToolGovernanceEphemerals: vi.fn().mockReturnValue(undefined),
+  getEnabledToolNamesForPrompt: vi.fn().mockReturnValue([]),
+  shouldIncludeSubagentDelegationForConfig: vi.fn().mockResolvedValue(false),
+  buildToolDeclarationsFromView: vi.fn().mockReturnValue([]),
+}));
+
+import { buildSystemInstruction } from './ChatSessionFactory.js';
+import {
+  getCoreSystemPromptAsync,
+  initializePromptSystem,
+} from '@vybestack/llxprt-code-core/core/prompts.js';
+import { shouldIncludeSubagentDelegationForConfig } from './clientToolGovernance.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+
+const MODEL = 'gemini-2.5-flash';
+const MCP_TOKEN = 'MCP_TOKEN_3173';
+const ENV_TOKEN = 'ENV_PREFIX_TOKEN_3173';
+
+/**
+ * Faithful copy of the PRE-CHANGE main-agent buildSystemInstruction. It
+ * derives memory inline (the original code) and uses the same real
+ * getCoreSystemPromptAsync, so any byte divergence isolates the effect of the
+ * resolvePromptMemory centralization.
+ */
+async function legacyBuildSystemInstruction(
+  config: Config,
+  enabledToolNames: string[],
+  envParts: Array<{ text?: string }>,
+  model: string,
+): Promise<string> {
+  let userMemory = config.isJitContextEnabled()
+    ? config.getGlobalMemory()
+    : config.getUserMemory();
+  const coreMemory = config.getCoreMemory();
+
+  const jitMemory = await config.getJitMemoryForPath(config.getWorkingDir());
+  if (jitMemory) {
+    userMemory = userMemory ? `${userMemory}\n\n${jitMemory}` : jitMemory;
+  }
+
+  const mcpInstructions = config.getMcpInstructions();
+  const includeSubagentDelegation =
+    await shouldIncludeSubagentDelegationForConfig(config, enabledToolNames);
+  const interactionMode = config.isInteractive()
+    ? 'interactive'
+    : 'non-interactive';
+
+  let systemInstruction = await getCoreSystemPromptAsync({
+    userMemory,
+    coreMemory,
+    mcpInstructions,
+    model,
+    tools: enabledToolNames,
+    includeSubagentDelegation,
+    interactionMode,
+  });
+
+  const envContextText = envParts
+    .map((part) => ('text' in part && part.text ? part.text : ''))
+    .join('\n');
+  if (envContextText) {
+    systemInstruction = envContextText + '\n\n' + systemInstruction;
+  }
+
+  return systemInstruction;
+}
+
+interface Row {
+  readonly name: string;
+  readonly jitEnabled: boolean;
+  readonly global: string;
+  readonly user: string;
+  readonly jit: string;
+  readonly core: string | undefined;
+  readonly mcp: string | undefined;
+  readonly envParts: Array<{ text?: string }>;
+  /** Each token must occur exactly once in the assembled instruction. */
+  readonly mcpOnceTokens?: readonly string[];
+  /** Each token must prefix the assembled instruction. */
+  readonly envPrefixTokens?: readonly string[];
+  /** Tokens that must be present in the assembled instruction. */
+  readonly presentTokens?: readonly string[];
+  /** Tokens that must be absent from the assembled instruction. */
+  readonly absentTokens?: readonly string[];
+}
+
+function makeConfig(row: Row): Config {
+  return {
+    isJitContextEnabled: () => row.jitEnabled,
+    getGlobalMemory: () => row.global,
+    getUserMemory: () => row.user,
+    getJitMemoryForPath: async () => row.jit,
+    getCoreMemory: () => row.core,
+    getMcpInstructions: () => row.mcp,
+    getWorkingDir: () => '/proj/workspace',
+    isInteractive: () => true,
+  } as unknown as Config;
+}
+
+const ROWS: readonly Row[] = [
+  {
+    name: 'JIT enabled: global+JIT+core+MCP all non-empty',
+    jitEnabled: true,
+    global: 'GLOBAL_TOKEN_3173',
+    user: 'SHOULD_NOT_APPEAR',
+    jit: 'JIT_TOKEN_3173',
+    core: 'CORE_TOKEN_3173',
+    mcp: MCP_TOKEN,
+    envParts: [],
+    mcpOnceTokens: [MCP_TOKEN],
+    presentTokens: ['GLOBAL_TOKEN_3173', 'JIT_TOKEN_3173'],
+    absentTokens: ['SHOULD_NOT_APPEAR'],
+  },
+  {
+    name: 'JIT enabled: global and JIT both empty (separator boundary)',
+    jitEnabled: true,
+    global: '',
+    user: '',
+    jit: '',
+    core: 'CORE_TOKEN_3173',
+    mcp: undefined,
+    envParts: [],
+  },
+  {
+    name: 'JIT enabled: global empty, JIT present, MCP present',
+    jitEnabled: true,
+    global: '',
+    user: '',
+    jit: 'JIT_TOKEN_3173',
+    core: '',
+    mcp: MCP_TOKEN,
+    envParts: [],
+    mcpOnceTokens: [MCP_TOKEN],
+  },
+  {
+    name: 'JIT enabled: global present, JIT empty',
+    jitEnabled: true,
+    global: 'GLOBAL_TOKEN_3173',
+    user: '',
+    jit: '',
+    core: 'CORE_TOKEN_3173',
+    mcp: undefined,
+    envParts: [],
+  },
+  {
+    name: 'JIT disabled: user+core+MCP non-empty',
+    jitEnabled: false,
+    global: 'SHOULD_NOT_APPEAR',
+    user: 'USER_TOKEN_3173',
+    jit: '',
+    core: 'CORE_TOKEN_3173',
+    mcp: MCP_TOKEN,
+    envParts: [],
+    mcpOnceTokens: [MCP_TOKEN],
+    presentTokens: ['USER_TOKEN_3173'],
+    absentTokens: ['SHOULD_NOT_APPEAR'],
+  },
+  {
+    name: 'JIT disabled: all memory empty',
+    jitEnabled: false,
+    global: '',
+    user: '',
+    jit: '',
+    core: '',
+    mcp: undefined,
+    envParts: [],
+  },
+  {
+    name: 'JIT enabled with environment prefix: env precedes core prompt',
+    jitEnabled: true,
+    global: 'GLOBAL_TOKEN_3173',
+    user: '',
+    jit: 'JIT_TOKEN_3173',
+    core: 'CORE_TOKEN_3173',
+    mcp: MCP_TOKEN,
+    envParts: [{ text: ENV_TOKEN }],
+    mcpOnceTokens: [MCP_TOKEN],
+    envPrefixTokens: [ENV_TOKEN],
+  },
+  {
+    name: 'JIT disabled with environment prefix: env precedes core prompt',
+    jitEnabled: false,
+    global: '',
+    user: 'USER_TOKEN_3173',
+    jit: '',
+    core: '',
+    mcp: undefined,
+    envParts: [{ text: ENV_TOKEN }],
+    envPrefixTokens: [ENV_TOKEN],
+  },
+];
+
+describe('buildSystemInstruction byte-for-byte compatibility with pre-change main builder (issue #3173)', () => {
+  let originalPromptsDir: string | undefined;
+  let tempDir: string;
+
+  beforeAll(async () => {
+    originalPromptsDir = process.env.LLXPRT_PROMPTS_DIR;
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llxprt-bytecompat-'));
+    process.env.LLXPRT_PROMPTS_DIR = tempDir;
+    await initializePromptSystem();
+  });
+
+  afterAll(() => {
+    if (originalPromptsDir === undefined) {
+      delete process.env.LLXPRT_PROMPTS_DIR;
+    } else {
+      process.env.LLXPRT_PROMPTS_DIR = originalPromptsDir;
+    }
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each(ROWS)('$name', async (row) => {
+    const production = await buildSystemInstruction(
+      makeConfig(row),
+      [],
+      row.envParts,
+      MODEL,
+    );
+    const legacy = await legacyBuildSystemInstruction(
+      makeConfig(row),
+      [],
+      row.envParts,
+      MODEL,
+    );
+
+    // Strong byte-for-byte compatibility evidence: the centralized builder
+    // must produce an identical string to the pre-change inline derivation.
+    expect(production).toBe(legacy);
+
+    // MCP instructions must appear exactly once — they flow through the
+    // dedicated channel, never duplicated via environment memory.
+    for (const token of row.mcpOnceTokens ?? []) {
+      const occurrences = production.split(token).length - 1;
+      expect(occurrences).toBe(1);
+    }
+
+    // Environment context, when present, must prefix the core prompt.
+    for (const token of row.envPrefixTokens ?? []) {
+      expect(production.startsWith(token)).toBe(true);
+    }
+
+    // Preserve builder-level sourcing assertions: under JIT the global (not
+    // user/environment) memory channel is used; under JIT-disabled the user
+    // memory channel is used unchanged.
+    for (const token of row.presentTokens ?? []) {
+      expect(production).toContain(token);
+    }
+    for (const token of row.absentTokens ?? []) {
+      expect(production).not.toContain(token);
+    }
+  });
+});

--- a/packages/agents/src/core/ChatSessionFactory.ts
+++ b/packages/agents/src/core/ChatSessionFactory.ts
@@ -33,6 +33,7 @@ import { isThinkingSupported } from './clientHelpers.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
 import type { TodoContinuationService } from './TodoContinuationService.js';
+import { resolvePromptMemory } from './promptMemoryPolicy.js';
 
 /**
  * Assembles ephemeral settings into an immutable snapshot for the runtime.
@@ -111,8 +112,11 @@ export function buildSettingsSnapshot(
  * Builds the full system instruction: env context, core memory, JIT memory,
  * user memory, MCP instructions, subagent delegation.
  *
- * This is the FULL path used by startChat — differs from the lightweight path
- * in clientLlmUtilities which skips env context, core memory, and JIT memory.
+ * Memory sourcing is shared with the subagent builder via
+ * {@link resolvePromptMemory} so both execution contexts apply the same JIT
+ * policy (issue #3173). This is the FULL path used by startChat — differs from
+ * the lightweight path in clientLlmUtilities which skips env context, core
+ * memory, and JIT memory.
  */
 export async function buildSystemInstruction(
   config: Config,
@@ -120,17 +124,9 @@ export async function buildSystemInstruction(
   envParts: Array<{ text?: string }>,
   model: string,
 ): Promise<string> {
-  let userMemory = config.isJitContextEnabled()
-    ? config.getGlobalMemory()
-    : config.getUserMemory();
-  const coreMemory = config.getCoreMemory();
+  const { userMemory, coreMemory, mcpInstructions } =
+    await resolvePromptMemory(config);
 
-  const jitMemory = await config.getJitMemoryForPath(config.getWorkingDir());
-  if (jitMemory) {
-    userMemory = userMemory ? `${userMemory}\n\n${jitMemory}` : jitMemory;
-  }
-
-  const mcpInstructions = config.getMcpInstructions();
   const includeSubagentDelegation =
     await shouldIncludeSubagentDelegationForConfig(config, enabledToolNames);
   const interactionMode = config.isInteractive()

--- a/packages/agents/src/core/promptMemoryPolicy.test.ts
+++ b/packages/agents/src/core/promptMemoryPolicy.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for the shared prompt memory-derivation policy
+ * (issue #3173). The policy is consumed by both the main-agent and subagent
+ * system-prompt builders so that JIT memory sourcing is identical across
+ * execution contexts.
+ *
+ * These tests assert actual resolved values (user memory, core memory, MCP
+ * instructions, and the working-directory JIT lookup), never mock invocation
+ * counts in isolation.
+ */
+
+import { describe, it, expect, vi } from 'bun:test';
+import { resolvePromptMemory } from './promptMemoryPolicy.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    isJitContextEnabled: vi.fn().mockReturnValue(false),
+    getGlobalMemory: vi.fn().mockReturnValue(''),
+    getUserMemory: vi.fn().mockReturnValue(''),
+    getJitMemoryForPath: vi.fn().mockResolvedValue(''),
+    getCoreMemory: vi.fn().mockReturnValue(undefined),
+    getMcpInstructions: vi.fn().mockReturnValue(undefined),
+    getWorkingDir: vi.fn().mockReturnValue('/workspace'),
+    ...overrides,
+  } as unknown as Config;
+}
+
+describe('resolvePromptMemory (issue #3173)', () => {
+  describe('JIT enabled', () => {
+    it('sources user memory from global plus JIT memory for the working directory', async () => {
+      const getJitMemoryForPath = vi.fn().mockResolvedValue('JIT_MARKER');
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(true),
+        getGlobalMemory: vi.fn().mockReturnValue('GLOBAL_MARKER'),
+        getJitMemoryForPath,
+        getWorkingDir: vi.fn().mockReturnValue('/proj/sub'),
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.userMemory).toBe('GLOBAL_MARKER\n\nJIT_MARKER');
+      expect(getJitMemoryForPath).toHaveBeenCalledWith('/proj/sub');
+    });
+
+    it('does not consult getUserMemory when JIT is enabled', async () => {
+      const getUserMemory = vi
+        .fn()
+        .mockReturnValue('GLOBAL_MARKER\n\nENV_WITH_MCP_MARKER');
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(true),
+        getGlobalMemory: vi.fn().mockReturnValue('GLOBAL_MARKER'),
+        getJitMemoryForPath: vi.fn().mockResolvedValue('JIT_MARKER'),
+        getUserMemory,
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.userMemory).not.toContain('ENV_WITH_MCP_MARKER');
+      expect(getUserMemory).not.toHaveBeenCalled();
+    });
+
+    it('preserves core memory and MCP instructions from their dedicated sources', async () => {
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(true),
+        getCoreMemory: vi.fn().mockReturnValue('CORE_MARKER'),
+        getMcpInstructions: vi.fn().mockReturnValue('MCP_MARKER'),
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.coreMemory).toBe('CORE_MARKER');
+      expect(result.mcpInstructions).toBe('MCP_MARKER');
+    });
+
+    it('produces JIT-only user memory when global memory is empty', async () => {
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(true),
+        getGlobalMemory: vi.fn().mockReturnValue(''),
+        getJitMemoryForPath: vi.fn().mockResolvedValue('JIT_MARKER'),
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.userMemory).toBe('JIT_MARKER');
+    });
+
+    it('produces global-only user memory when JIT memory is empty', async () => {
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(true),
+        getGlobalMemory: vi.fn().mockReturnValue('GLOBAL_MARKER'),
+        getJitMemoryForPath: vi.fn().mockResolvedValue(''),
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.userMemory).toBe('GLOBAL_MARKER');
+    });
+
+    it('produces no synthetic whitespace when both global and JIT are empty', async () => {
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(true),
+        getGlobalMemory: vi.fn().mockReturnValue(''),
+        getJitMemoryForPath: vi.fn().mockResolvedValue(''),
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.userMemory).toBe('');
+    });
+  });
+
+  describe('JIT disabled', () => {
+    it('sources user memory from getUserMemory unchanged', async () => {
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(false),
+        getUserMemory: vi.fn().mockReturnValue('USER_MEMORY_MARKER'),
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.userMemory).toBe('USER_MEMORY_MARKER');
+    });
+
+    it('adds no JIT subdirectory memory', async () => {
+      // In production getJitMemoryForPath returns '' when JIT is disabled, so
+      // the policy appends nothing.
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(false),
+        getUserMemory: vi.fn().mockReturnValue('USER_MEMORY_MARKER'),
+        getJitMemoryForPath: vi.fn().mockResolvedValue(''),
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.userMemory).toBe('USER_MEMORY_MARKER');
+    });
+
+    it('preserves core memory and MCP instructions', async () => {
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(false),
+        getCoreMemory: vi.fn().mockReturnValue('CORE_MARKER'),
+        getMcpInstructions: vi.fn().mockReturnValue('MCP_MARKER'),
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.coreMemory).toBe('CORE_MARKER');
+      expect(result.mcpInstructions).toBe('MCP_MARKER');
+    });
+  });
+
+  describe('core-memory capture ordering (deferred-JIT regression)', () => {
+    it('captures core memory before awaiting JIT memory', async () => {
+      // Simulate a concurrent core-memory refresh: the value returned by
+      // getCoreMemory changes while getJitMemoryForPath is pending. The
+      // pre-extraction main builder read core memory before the JIT await, so
+      // the shared policy must capture the pre-await value (issue #3173
+      // review Blocker-Fix).
+      let coreMemoryValue = 'CORE_BEFORE';
+      const getCoreMemory = vi.fn(() => coreMemoryValue);
+      const getJitMemoryForPath = vi.fn(async () => {
+        coreMemoryValue = 'CORE_AFTER';
+        return 'JIT_MARKER';
+      });
+
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(true),
+        getGlobalMemory: vi.fn().mockReturnValue('GLOBAL_MARKER'),
+        getJitMemoryForPath,
+        getCoreMemory,
+        getMcpInstructions: vi.fn().mockReturnValue('MCP_MARKER'),
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.coreMemory).toBe('CORE_BEFORE');
+    });
+
+    it('reads MCP instructions after the JIT await to preserve main-agent ordering', async () => {
+      // MCP instructions were acquired after the JIT await in the
+      // pre-extraction main builder; the shared policy must keep that ordering.
+      let mcpValue = 'MCP_BEFORE';
+      const getMcpInstructions = vi.fn(() => mcpValue);
+      const getJitMemoryForPath = vi.fn(async () => {
+        mcpValue = 'MCP_AFTER';
+        return 'JIT_MARKER';
+      });
+
+      const config = makeConfig({
+        isJitContextEnabled: vi.fn().mockReturnValue(true),
+        getGlobalMemory: vi.fn().mockReturnValue('GLOBAL_MARKER'),
+        getJitMemoryForPath,
+        getMcpInstructions,
+      });
+
+      const result = await resolvePromptMemory(config);
+
+      expect(result.mcpInstructions).toBe('MCP_AFTER');
+    });
+  });
+});

--- a/packages/agents/src/core/promptMemoryPolicy.ts
+++ b/packages/agents/src/core/promptMemoryPolicy.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+
+/**
+ * The memory inputs derived for a system-prompt assembly.
+ *
+ * `userMemory`, `coreMemory`, and `mcpInstructions` map one-to-one onto the
+ * options consumed by `getCoreSystemPromptAsync`. Core memory and MCP
+ * instructions are kept as separate channels so MCP instructions are never
+ * folded into user memory — which under JIT would otherwise deliver them twice
+ * (environment memory already carries the MCP block).
+ */
+export interface PromptMemoryInputs {
+  readonly userMemory: string | undefined;
+  readonly coreMemory: string | undefined;
+  readonly mcpInstructions: string | undefined;
+}
+
+/**
+ * Derives the user/core/MCP memory inputs for a system prompt from a single
+ * shared policy. Both the main-agent and subagent prompt builders consume this
+ * so JIT memory sourcing is identical across execution contexts (issue #3173).
+ *
+ * JIT enabled: user memory is `getGlobalMemory()` (which excludes environment
+ * memory) plus the JIT subdirectory memory for the configured working
+ * directory, joined with the existing two-newline separator. JIT disabled:
+ * user memory is `getUserMemory()` unchanged. Core memory comes from
+ * `getCoreMemory()` and MCP instructions from `getMcpInstructions()`, each
+ * through its own channel.
+ */
+export async function resolvePromptMemory(
+  config: Config,
+): Promise<PromptMemoryInputs> {
+  let userMemory = config.isJitContextEnabled()
+    ? config.getGlobalMemory()
+    : config.getUserMemory();
+  // Core memory is captured before the JIT await to match the pre-extraction
+  // main-builder ordering: under a concurrent core-memory refresh, reading it
+  // after the await would change main-agent prompt bytes (issue #3173).
+  const coreMemory = config.getCoreMemory();
+  const jitMemory = await config.getJitMemoryForPath(config.getWorkingDir());
+  if (jitMemory) {
+    userMemory = userMemory ? `${userMemory}\n\n${jitMemory}` : jitMemory;
+  }
+  return {
+    userMemory,
+    coreMemory,
+    // MCP instructions remain acquired after the JIT await, preserving the
+    // original main-agent access ordering.
+    mcpInstructions: config.getMcpInstructions(),
+  };
+}

--- a/packages/agents/src/core/subagentRuntimeSetup.assembler.test.ts
+++ b/packages/agents/src/core/subagentRuntimeSetup.assembler.test.ts
@@ -32,10 +32,23 @@ import {
 import { createConfigParams } from './chatSession-runtime-helpers.js';
 
 // Capture getCoreSystemPromptAsync calls so we can assert interactionMode
-// on both the creation-time call and the per-turn call.
+// on both the creation-time call and the per-turn call. The mock echoes its
+// memory inputs verbatim so the rendered prompt reflects exactly which memory
+// channels were sourced — letting issue #3173 tests assert, for example, that
+// the MCP marker appears exactly once (only via the dedicated mcpInstructions
+// option) rather than also inside user memory.
 const mockGetCorePrompt = vi.fn(async (args: Record<string, unknown>) => {
-  const mode = args.interactionMode ?? 'unknown';
-  return `[CORE_PROMPT mode=${mode}]`;
+  const mode =
+    typeof args.interactionMode === 'string' ? args.interactionMode : 'unknown';
+  const sections: string[] = [`[CORE_PROMPT mode=${mode}]`];
+  const userMemory = typeof args.userMemory === 'string' ? args.userMemory : '';
+  const coreMemory = typeof args.coreMemory === 'string' ? args.coreMemory : '';
+  const mcp =
+    typeof args.mcpInstructions === 'string' ? args.mcpInstructions : '';
+  if (userMemory.length > 0) sections.push(userMemory);
+  if (coreMemory.length > 0) sections.push(coreMemory);
+  if (mcp.length > 0) sections.push(mcp);
+  return sections.join('\n\n');
 });
 
 void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
@@ -77,6 +90,11 @@ describe('Subagent per-turn assembler (issue #3136)', () => {
     runtimeId: string;
     userMemory?: string;
     coreMemory?: string;
+    jitContextEnabled?: boolean;
+    globalMemory?: string;
+    jitMemory?: string;
+    mcpInstructions?: string;
+    workingDir?: string;
   }): Promise<ChatSession> {
     const providerRuntime = createProviderRuntimeContext({
       settingsService,
@@ -114,6 +132,27 @@ describe('Subagent per-turn assembler (issue #3136)', () => {
     }
     if (opts.coreMemory !== undefined) {
       memoryOverrides['getCoreMemory'] = { value: () => opts.coreMemory };
+    }
+    if (opts.jitContextEnabled !== undefined) {
+      memoryOverrides['isJitContextEnabled'] = {
+        value: () => opts.jitContextEnabled,
+      };
+    }
+    if (opts.globalMemory !== undefined) {
+      memoryOverrides['getGlobalMemory'] = { value: () => opts.globalMemory };
+    }
+    if (opts.jitMemory !== undefined) {
+      memoryOverrides['getJitMemoryForPath'] = {
+        value: async () => opts.jitMemory,
+      };
+    }
+    if (opts.mcpInstructions !== undefined) {
+      memoryOverrides['getMcpInstructions'] = {
+        value: () => opts.mcpInstructions,
+      };
+    }
+    if (opts.workingDir !== undefined) {
+      memoryOverrides['getWorkingDir'] = { value: () => opts.workingDir };
     }
 
     Object.defineProperties(config, {
@@ -224,6 +263,7 @@ describe('Subagent per-turn assembler (issue #3136)', () => {
     const chat = await buildSubagentFixture({
       persona: 'You are a subagent.',
       runtimeId: 'test.subagent.memory',
+      jitContextEnabled: false,
       userMemory: USER_MEMORY,
       coreMemory: CORE_MEMORY,
     });
@@ -240,6 +280,120 @@ describe('Subagent per-turn assembler (issue #3136)', () => {
     expect(mockGetCorePrompt.mock.calls[1][0]).toMatchObject({
       userMemory: USER_MEMORY,
       coreMemory: CORE_MEMORY,
+    });
+  });
+
+  describe('Subagent JIT memory sourcing (issue #3173)', () => {
+    /**
+     * Distinct markers used to trace which memory channel sourced each piece of
+     * the prompt. ENV_WITH_MCP_MARKER deliberately embeds the MCP token so that
+     * the pre-fix subagent path (which sources getUserMemory() under JIT and so
+     * folds in environment memory that already carries MCP instructions) can be
+     * shown to deliver the MCP block more than once.
+     */
+    const GLOBAL = 'GLOBAL_MARKER';
+    const JIT = 'JIT_MARKER';
+    const MCP = 'MCP_MARKER';
+    const ENV_WITH_MCP = 'ENV_WITH_MCP_MARKER';
+    const CORE = 'CORE_MARKER';
+    const PERSONA = 'You are a focused subagent.';
+
+    function countOccurrences(haystack: string, needle: string): number {
+      if (!needle) return 0;
+      return haystack.split(needle).length - 1;
+    }
+
+    it('sources global plus JIT user memory and delivers the MCP block exactly once when JIT is enabled', async () => {
+      const chat = await buildSubagentFixture({
+        persona: PERSONA,
+        runtimeId: 'test.subagent.jit.enabled',
+        jitContextEnabled: true,
+        globalMemory: GLOBAL,
+        // Under JIT, Config.getUserMemory() folds in environment memory (which
+        // already carries MCP instructions). Simulate that contract so the test
+        // proves the shared policy avoids that accessor under JIT.
+        userMemory: `${GLOBAL}
+
+${ENV_WITH_MCP}`,
+        jitMemory: JIT,
+        mcpInstructions: MCP,
+        coreMemory: CORE,
+        workingDir: '/sub/work',
+      });
+
+      // --- Creation-time assembly ---
+      expect(mockGetCorePrompt).toHaveBeenCalledTimes(1);
+      const creationArgs = mockGetCorePrompt.mock.calls[0][0];
+      expect(creationArgs).toMatchObject({
+        interactionMode: 'subagent',
+        includeSubagentDelegation: false,
+        coreMemory: CORE,
+        mcpInstructions: MCP,
+      });
+      // User memory must carry global + JIT subdirectory memory and must NOT
+      // carry the environment-memory channel (which would double MCP).
+      expect(creationArgs.userMemory).toBe(`${GLOBAL}
+
+${JIT}`);
+      expect(creationArgs.userMemory).not.toContain(ENV_WITH_MCP);
+      expect(creationArgs.userMemory).not.toContain(MCP);
+
+      // --- Per-turn assembly ---
+      await chat.sendMessage({ message: 'do it' }, 'p1');
+      expect(mockGetCorePrompt).toHaveBeenCalledTimes(2);
+      const turnArgs = mockGetCorePrompt.mock.calls[1][0];
+      expect(turnArgs).toMatchObject({
+        interactionMode: 'subagent',
+        coreMemory: CORE,
+        mcpInstructions: MCP,
+      });
+      expect(turnArgs.userMemory).toBe(`${GLOBAL}
+
+${JIT}`);
+      expect(turnArgs.userMemory).not.toContain(MCP);
+
+      // The rendered prompt the provider receives must contain the JIT
+      // subdirectory marker and the MCP marker exactly once.
+      const rendered = capturedCalls[0].systemInstruction as string;
+      expect(rendered).toContain(JIT);
+      expect(countOccurrences(rendered, MCP)).toBe(1);
+      expect(rendered).toContain(PERSONA);
+    });
+
+    it('preserves the getUserMemory path and a single MCP block when JIT is disabled', async () => {
+      const USER = 'USER_MEMORY_MARKER';
+      const chat = await buildSubagentFixture({
+        persona: PERSONA,
+        runtimeId: 'test.subagent.jit.disabled',
+        jitContextEnabled: false,
+        userMemory: USER,
+        // Production returns '' when JIT is disabled.
+        jitMemory: '',
+        mcpInstructions: MCP,
+        coreMemory: CORE,
+      });
+
+      // Creation-time assembly: unchanged user-memory path, no JIT memory.
+      const creationArgs = mockGetCorePrompt.mock.calls[0][0];
+      expect(creationArgs).toMatchObject({
+        interactionMode: 'subagent',
+        coreMemory: CORE,
+        mcpInstructions: MCP,
+      });
+      expect(creationArgs.userMemory).toBe(USER);
+
+      // Per-turn assembly: identical policy behavior.
+      await chat.sendMessage({ message: 'go' }, 'p1');
+      const turnArgs = mockGetCorePrompt.mock.calls[1][0];
+      expect(turnArgs.userMemory).toBe(USER);
+      expect(turnArgs).toMatchObject({
+        coreMemory: CORE,
+        mcpInstructions: MCP,
+      });
+
+      // Exactly one MCP marker reaches the provider.
+      const rendered = capturedCalls[0].systemInstruction as string;
+      expect(countOccurrences(rendered, MCP)).toBe(1);
     });
   });
 });

--- a/packages/agents/src/core/subagentRuntimeSetup.ts
+++ b/packages/agents/src/core/subagentRuntimeSetup.ts
@@ -50,6 +50,7 @@ import {
 } from './toolGovernance.js';
 import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
+import { resolvePromptMemory } from './promptMemoryPolicy.js';
 import {
   EmojiFilter,
   type EmojiFilterMode,
@@ -826,25 +827,15 @@ async function buildSystemInstruction(
     ),
   );
 
-  const mcpInstructions = config.getMcpInstructions();
-  // Issue #3136: a subagent's user/core memory previously reached the model
-  // only because the provider layer rebuilt its own core prompt. Supply both
-  // here so collapsing to a single assembler cannot strip subagent memory.
-  // Passing coreMemory skips the two-file .LLXPRT_SYSTEM disk read that
-  // getCoreSystemPromptAsync performs when it is undefined — but only when JIT
-  // context is enabled, since Config.getCoreMemory() returns undefined
-  // otherwise and the read happens anyway.
-  //
-  // This differs from ChatSessionFactory, which branches on
-  // isJitContextEnabled(): with JIT on it uses getGlobalMemory() and appends
-  // getJitMemoryForPath(), and with JIT off it uses getUserMemory() like this
-  // site does. So the two agree only when JIT is off. With JIT on, subagents
-  // miss JIT subdirectory memory, and because getUserMemory() then also folds in
-  // environment memory (which already carries the MCP block) they can receive
-  // MCP instructions twice. See issue #3162 findings D2 and D4.
+  // Memory sourcing is shared with the main-agent builder (ChatSessionFactory)
+  // via resolvePromptMemory so subagents get the same JIT policy: under JIT,
+  // global memory plus the working directory's JIT subdirectory memory, with
+  // MCP instructions carried only through their dedicated option (issue #3173).
+  const { userMemory, coreMemory, mcpInstructions } =
+    await resolvePromptMemory(config);
   const coreSystemPrompt: unknown = await getCoreSystemPromptAsync({
-    userMemory: config.getUserMemory(),
-    coreMemory: config.getCoreMemory(),
+    userMemory,
+    coreMemory,
     mcpInstructions,
     model: modelConfig.model,
     tools: toolNames,

--- a/packages/test-utils/src/interactive-run.test.ts
+++ b/packages/test-utils/src/interactive-run.test.ts
@@ -345,6 +345,9 @@ describe('InteractiveRun quota guard integration', () => {
         true,
       );
 
+      // Buffer the quota signal before testing expectExit's timeout-path scan.
+      await run.expectText('HTTP 429 Too Many Requests', 5000);
+
       const error = await captureRejection(run.expectExit(1000));
 
       expect(error.message).toContain('[QUOTA/RATE-LIMIT]');

--- a/project-plans/issue3173-subagent-jit-memory.md
+++ b/project-plans/issue3173-subagent-jit-memory.md
@@ -1,0 +1,104 @@
+# Issue 3173: Align Main-Agent and Subagent Prompt Memory Sourcing
+
+Plan ID: PLAN-20260808-ISSUE3173
+
+## Accepted Behavior
+
+### REQ-3173-01: Shared memory derivation policy
+
+Both the main-agent and subagent system-prompt builders must consume one internal memory-derivation policy rather than independently choosing configuration accessors.
+
+The policy produces the existing prompt inputs for user memory, core memory, and MCP instructions. It must remain internal to the existing prompt-assembly implementation; this issue does not add a public API.
+
+### REQ-3173-02: JIT-enabled memory
+
+Given JIT context is enabled:
+
+- user memory starts with `Config.getGlobalMemory()`, not `Config.getUserMemory()`;
+- JIT memory is loaded for `Config.getWorkingDir()` through `Config.getJitMemoryForPath()`;
+- non-empty global and JIT memories are joined with the existing two-newline separator;
+- an empty global memory or empty JIT memory does not introduce an extra separator;
+- core memory continues to come from `Config.getCoreMemory()`;
+- MCP instructions continue to come from `Config.getMcpInstructions()` and are supplied through the existing dedicated prompt option.
+
+The resulting subagent prompt therefore contains the same subdirectory `LLXPRT.md` memory as the main-agent prompt and contains the MCP instruction block exactly once.
+
+### REQ-3173-03: JIT-disabled memory
+
+Given JIT context is disabled:
+
+- user memory continues to come from `Config.getUserMemory()`;
+- no JIT subdirectory memory is added;
+- core memory and MCP instructions retain their existing sources and placement;
+- main-agent and subagent prompt behavior remains otherwise unchanged.
+
+### REQ-3173-04: Main-agent compatibility
+
+For every supported combination of empty/non-empty user, global, JIT, core, and MCP memory, the main-agent system-prompt text must be byte-for-byte identical to the text produced by the existing implementation under the same valid `Config` behavior.
+
+The existing ordering remains environment context, core prompt, and any path-specific additions already owned by the main-agent builder. This issue does not reorder prompt sections or alter prompt formatting.
+
+## Relevant Inputs and Boundaries
+
+- JIT mode: enabled or disabled.
+- Execution mode: main agent or subagent.
+- Working directory: the exact value returned by `Config.getWorkingDir()`.
+- Global/user/JIT/core/MCP memory: empty, undefined where the current accessor permits it, or non-empty.
+- Per-turn behavior: subagent creation-time and subsequent turn assembly must use the same policy.
+- MCP content may also be present in JIT environment memory when `getUserMemory()` is used. The JIT-enabled policy must avoid that accessor rather than deduplicating prompt text after assembly.
+- Memory loading errors, filesystem traversal semantics, trusted-root rules, `allMemoriesAreCore`, compression prompts, auxiliary prompt call sites, provider placement, and core-memory disk fallback are outside this issue.
+
+## Behavioral Test Evidence
+
+Tests must be written or adjusted before production code and must use Bun with `bun:test`.
+
+1. **Main agent, JIT enabled**
+   - Build the main-agent instruction with distinct global, user/environment, JIT, core, and MCP markers.
+   - Assert the prompt inputs use global plus JIT memory, exclude the JIT-mode `getUserMemory()` marker, preserve core memory, and carry MCP instructions once through the dedicated option.
+   - Assert JIT memory is requested for the configured working directory.
+
+2. **Main agent, JIT disabled**
+   - Build the main-agent instruction with distinct user and global markers.
+   - Assert the existing user-memory path and exact assembled text remain unchanged and no JIT memory is added.
+
+3. **Subagent, JIT enabled**
+   - Exercise the real subagent assembler at creation and on a subsequent turn.
+   - Assert both assemblies receive global plus JIT user memory, preserve core memory and subagent interaction mode, and exclude environment memory from the user-memory channel.
+   - Assert the rendered prompt contains the JIT subdirectory marker and exactly one MCP marker.
+
+4. **Subagent, JIT disabled**
+   - Exercise creation-time and per-turn assembly.
+   - Assert both use `getUserMemory()` unchanged, do not add JIT memory, preserve core memory, and contain exactly one MCP marker when MCP instructions are configured.
+
+5. **Boundary formatting**
+   - Cover empty base memory and empty JIT memory so the shared policy preserves existing separator behavior and produces no synthetic whitespace.
+
+Tests must assert prompt content or exact prompt inputs, not merely mock invocation counts. Any infrastructure substitution must leave the production memory policy and assembler under test.
+
+## Implementation Scope
+
+- Add one private/internal shared memory-derivation helper in the existing agents prompt-assembly area.
+- Replace only the duplicated main-agent and subagent memory derivation with that helper.
+- Update only directly affected Bun tests and this plan.
+- Remove or update the issue-specific explanatory comment in `subagentRuntimeSetup.ts` once it no longer describes current behavior.
+
+No dependency, workflow, settings schema, public abstraction, memory file-loading behavior, unrelated prompt call site, or adjacent audit finding is part of this issue.
+
+## Review Finding Triage
+
+Every finding is classified before action:
+
+- **Blocker-Fix**: breaks an accepted behavior, required gate, safety rule, or candidate-head correctness.
+- **In-scope-Fix**: improves correctness or test evidence within the behavior and files above.
+- **Reject**: factually incorrect, already covered, or contrary to the accepted behavior.
+- **Defer**: valid but outside this issue, including adjacent prompt architecture or memory-policy work.
+
+Only Blocker-Fix and In-scope-Fix findings authorize changes in this effort.
+
+## Completion Gates
+
+- Behavioral evidence exists for every requirement and boundary above.
+- Focused tests and the full local verification suite pass on the candidate head.
+- The smoke test passes.
+- DeepThinker and Open Code Review findings are triaged; all Blocker-Fix and In-scope-Fix findings are resolved.
+- PR CI is green, review threads are resolved or explicitly awaiting user judgment, ancestry is correct, and the PR is conflict-free.


### PR DESCRIPTION
## TLDR

Aligns subagent prompt-memory sourcing with the main agent when JIT context is enabled. Both builders now use one internal policy that selects global memory, appends working-directory JIT memory, preserves core memory, and carries MCP instructions through their dedicated channel exactly once.

The main-agent output remains byte-for-byte compatible with the previous implementation.

## Dive Deeper

- Adds a shared internal prompt-memory resolver used by both main-agent and subagent prompt assembly.
- Preserves JIT-disabled behavior by continuing to use user memory unchanged.
- Preserves main-agent accessor ordering around the asynchronous JIT lookup so concurrent memory refreshes cannot change existing prompt bytes.
- Applies the same policy to subagent creation-time and per-turn prompt assembly.
- Prevents JIT-mode subagents from folding environment memory into the user-memory channel and duplicating MCP instructions.
- Adds behavioral coverage for JIT-enabled and JIT-disabled paths, empty-memory boundaries, working-directory lookup, MCP placement, per-turn subagent assembly, and main-agent byte compatibility.
- Includes a small test-harness sequencing correction discovered during full verification: the quota signal is now buffered before the exit-timeout path is asserted.

Local verification completed on macOS:

- Full workspace test coverage, split into equivalent bounded runner shards where the aggregate command exceeded the local synchronous command ceiling
- Full lint coverage, split into equivalent root ESLint scopes plus the separate LSP lint
- npm run typecheck
- npm run format
- npm run build
- Live StepFun profile smoke test
- Open Code Review and DeepThinker review, with all in-scope findings resolved

## Reviewer Test Plan

1. Run the focused agents tests for promptMemoryPolicy, ChatSessionFactory byte compatibility, and subagentRuntimeSetup assembler behavior.
2. Confirm the JIT-enabled subagent cases receive global plus working-directory JIT memory and only one MCP marker at creation and on a later turn.
3. Confirm JIT-disabled cases preserve the existing user-memory path.
4. Run the agents workspace test suite, typecheck, lint, and build.
5. Optionally run the live profile smoke command documented by the repository workflow.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3173
