### PR TITLE
fix(providers): honor Anthropic resolved-token prompt placement (Fixes #3172)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1303,6 +1303,12 @@ export default tseslint.config(
           message:
             'Do not alias request-parameter isOAuth for indirect placement control flow (issue #3172).',
         },
+        {
+          selector:
+            'VariableDeclarator > ObjectPattern > Property[key.name="isOAuth"]',
+          message:
+            'Do not destructure request-parameter isOAuth for indirect placement control flow; pass the auth fact directly to an auth-specific helper (issue #3172).',
+        },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1252,6 +1252,65 @@ export default tseslint.config(
   // ============================================================================
 
   // ============================================================================
+  // Issue #3172 — placement decision must flow from SystemPromptPlacement
+  //
+  // AnthropicRequestPreparation selects system-context placement from the
+  // resolved SystemPromptPlacement (declared by the provider and resolved
+  // through the shared policy), never from a local auth flag. Placement-only
+  // message selection may not reference isOAuth, and request-parameter OAuth
+  // facts may not drive local control flow or be aliased for indirect control.
+  // Direct boolean parameters remain valid in auth-only helpers that build the
+  // vendor system field or assert the OAuth/placement compatibility invariant.
+  //
+  // The two general no-restricted-syntax selectors are repeated here because
+  // flat config REPLACES a rule's array value rather than merging it, so
+  // omitting them would loosen the file's existing guards.
+  {
+    files: ['packages/providers/src/anthropic/AnthropicRequestPreparation.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'CallExpression[callee.name="require"]',
+          message: 'Avoid using require(). Use ES6 imports instead.',
+        },
+        {
+          selector: 'ThrowStatement > Literal:not([value=/^\\w+Error:/])',
+          message:
+            'Do not throw string literals or non-Error objects. Throw new Error("...") instead.',
+        },
+        {
+          selector:
+            ':matches(FunctionDeclaration[id.name="placeSystemInstruction"], VariableDeclarator[id.name="placeSystemInstruction"]) Identifier[name="isOAuth"]',
+          message:
+            'placeSystemInstruction controls only WHERE the prompt goes; it must not reference isOAuth. Use the resolved SystemPromptPlacement for placement and let buildSystemField handle the vendor system field independently (issue #3172).',
+        },
+        {
+          selector:
+            ':matches(FunctionDeclaration, FunctionExpression, ArrowFunctionExpression):has(CallExpression[callee.name="formatContextPrefix"]) Identifier[name="isOAuth"]',
+          message:
+            'System-prompt context placement must not reference isOAuth; use the resolved SystemPromptPlacement (issue #3172).',
+        },
+        {
+          selector:
+            ':matches(IfStatement, ConditionalExpression, SwitchStatement):has(MemberExpression[property.name="isOAuth"])',
+          message:
+            'Request-parameter isOAuth must not drive local placement control flow; pass the auth fact only to an auth-specific helper (issue #3172).',
+        },
+        {
+          selector:
+            'VariableDeclarator[init.type="MemberExpression"][init.property.name="isOAuth"]',
+          message:
+            'Do not alias request-parameter isOAuth for indirect placement control flow (issue #3172).',
+        },
+      ],
+    },
+  },
+  // ============================================================================
+  // End Issue #3172
+  // ============================================================================
+
+  // ============================================================================
   // Issue #1581: subagent.ts decomposition - Size enforcement
   // ============================================================================
   //

--- a/packages/agents/src/compression/compressionMemoryExclusion.test.ts
+++ b/packages/agents/src/compression/compressionMemoryExclusion.test.ts
@@ -222,10 +222,8 @@ function buildCompressionContext(
     promptBaseDir: '/tmp/test-prompts',
     promptContext: { provider: 'test-provider', model: COMPRESSION_MODEL },
     promptId: 'test-prompt',
+    ...(overrides.config === undefined ? {} : { config: overrides.config }),
   };
-  if (overrides.config !== undefined) {
-    context.config = overrides.config;
-  }
   return context;
 }
 

--- a/packages/agents/src/core/ChatSessionFactory.byteCompatibility.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.byteCompatibility.test.ts
@@ -126,7 +126,7 @@ function makeConfig(row: Row): Config {
   } as unknown as Config;
 }
 
-const ROWS: readonly Row[] = [
+const ROWS: Row[] = [
   {
     name: 'JIT enabled: global+JIT+core+MCP all non-empty',
     jitEnabled: true,

--- a/packages/providers/src/IProvider.ts
+++ b/packages/providers/src/IProvider.ts
@@ -141,21 +141,17 @@ export interface IProvider {
   getDefaultModel(): string;
   /**
    * Declares WHERE this provider can accept the assembled system prompt for
-   * the given request (issue #3136).
+   * the given request (issue #3136/#3172).
    *
-   * This is a declaration, not a decision: it is intended to be consumed by the
-   * shared placement policy in `utils/systemPromptPlacement.ts` so that
-   * providers do not re-derive placement from transport details.
+   * This is a declaration, not a decision: it is consumed by the shared
+   * placement policy in `utils/systemPromptPlacement.ts` so that providers do
+   * not re-derive placement from transport details. Callers resolve runtime
+   * auth-token providers first and pass the resolved token string so placement
+   * and transport share one credential fact.
    *
    * Omitting it means `system-field`. Anthropic returns `context-prefix` when
-   * OAuth is active, because its `system` field may carry only the Claude Code
-   * string and the real prompt must go at the top of the context instead.
-   *
-   * NOT YET WIRED (issue #3162 finding D1): no production code calls this. The
-   * live Anthropic decision is still made from a local `isOAuth` flag in
-   * `anthropic/AnthropicRequestPreparation.ts`. This method and the transport
-   * flag also use different OAuth predicates, so they can disagree; reconcile
-   * them before making this the source of truth.
+   * the resolved token is OAuth, because its `system` field may carry only the
+   * Claude Code string and the real prompt must go at the top of the context.
    */
   getSystemPromptPlacement?(
     options: GenerateChatOptions,

--- a/packages/providers/src/anthropic/AnthropicMessageNormalizer.anchorCache.test.ts
+++ b/packages/providers/src/anthropic/AnthropicMessageNormalizer.anchorCache.test.ts
@@ -358,6 +358,7 @@ describe('Anthropic anchor cache breakpoint — gating & count via prepareAnthro
     baseURL: string;
     promptCaching: 'off' | '5m' | '1h';
     isOAuth: boolean;
+    placement: 'system-field' | 'context-prefix';
     contents: IContent[];
   }) {
     const callOpts = buildOptions(opts);
@@ -366,6 +367,7 @@ describe('Anthropic anchor cache breakpoint — gating & count via prepareAnthro
       tools: callOpts.tools,
       options: callOpts,
       isOAuth: opts.isOAuth,
+      placement: opts.placement,
       providerName: 'anthropic',
       config: undefined,
       getMaxTokensForModel: () => 4096,
@@ -409,6 +411,7 @@ describe('Anthropic anchor cache breakpoint — gating & count via prepareAnthro
       baseURL: 'https://api.anthropic.com',
       promptCaching: '5m',
       isOAuth: false,
+      placement: 'system-field',
       contents: anchoredHead,
     });
 
@@ -435,6 +438,7 @@ describe('Anthropic anchor cache breakpoint — gating & count via prepareAnthro
       baseURL: 'https://api.anthropic.com',
       promptCaching: '5m',
       isOAuth: true,
+      placement: 'context-prefix',
       contents: anchoredHead,
     });
 
@@ -460,6 +464,7 @@ describe('Anthropic anchor cache breakpoint — gating & count via prepareAnthro
       baseURL: 'https://api.anthropic.com',
       promptCaching: 'off',
       isOAuth: false,
+      placement: 'system-field',
       contents: anchoredHead,
     });
 
@@ -479,6 +484,7 @@ describe('Anthropic anchor cache breakpoint — gating & count via prepareAnthro
       baseURL: 'https://api.z.ai/v1',
       promptCaching: '5m',
       isOAuth: false,
+      placement: 'system-field',
       contents: anchoredHead,
     });
 
@@ -501,6 +507,7 @@ describe('Anthropic anchor cache breakpoint — gating & count via prepareAnthro
       baseURL: 'https://api.anthropic.com',
       promptCaching: '5m',
       isOAuth: false,
+      placement: 'system-field',
       contents: noMarkerHead,
     });
 

--- a/packages/providers/src/anthropic/AnthropicPlacementLintGuard.test.ts
+++ b/packages/providers/src/anthropic/AnthropicPlacementLintGuard.test.ts
@@ -76,6 +76,15 @@ function lintWithEffectiveRule(code: string) {
   });
 }
 
+function hasPlacementViolation(
+  messages: ReturnType<typeof lintWithEffectiveRule>,
+): boolean {
+  return messages.some(
+    (message) =>
+      message.severity === 2 && message.message.includes('issue #3172'),
+  );
+}
+
 describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', () => {
   it('registers an error-level rule in the EFFECTIVE config for the target file', () => {
     expect(effectiveRule).toBeDefined();
@@ -102,8 +111,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
         '}',
       ].join('\n'),
     );
-    expect(messages.length).toBeGreaterThanOrEqual(1);
-    expect(messages[0].severity).toBe(2);
+    expect(hasPlacementViolation(messages)).toBe(true);
   });
 
   it('rejects isOAuth when the placement helper is an arrow function', () => {
@@ -114,8 +122,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
         '};',
       ].join('\n'),
     );
-    expect(messages.length).toBeGreaterThanOrEqual(1);
-    expect(messages[0].severity).toBe(2);
+    expect(hasPlacementViolation(messages)).toBe(true);
   });
 
   it('rejects the exact removed isOAuth branch when reintroduced in buildSystemContext', () => {
@@ -129,8 +136,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
         '}',
       ].join('\n'),
     );
-    expect(messages.length).toBeGreaterThanOrEqual(1);
-    expect(messages[0].severity).toBe(2);
+    expect(hasPlacementViolation(messages)).toBe(true);
   });
 
   it('rejects an inline auth ternary after the placement helper is renamed', () => {
@@ -141,8 +147,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
         '}',
       ].join('\n'),
     );
-    expect(messages.length).toBeGreaterThanOrEqual(1);
-    expect(messages[0].severity).toBe(2);
+    expect(hasPlacementViolation(messages)).toBe(true);
   });
 
   it('rejects negation bypass: !params.isOAuth inside placeSystemInstruction', () => {
@@ -156,8 +161,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
         '}',
       ].join('\n'),
     );
-    expect(messages.length).toBeGreaterThanOrEqual(1);
-    expect(messages[0].severity).toBe(2);
+    expect(hasPlacementViolation(messages)).toBe(true);
   });
 
   it('rejects equality bypass: params.isOAuth === true inside placeSystemInstruction', () => {
@@ -171,7 +175,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
         '}',
       ].join('\n'),
     );
-    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(hasPlacementViolation(messages)).toBe(true);
   });
 
   it('rejects ternary bypass: params.isOAuth ? a : b inside placeSystemInstruction', () => {
@@ -183,19 +187,19 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
         '}',
       ].join('\n'),
     );
-    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(hasPlacementViolation(messages)).toBe(true);
   });
 
-  it('rejects alias/destructure bypass: const { isOAuth } = params', () => {
+  it('rejects file-wide destructure bypass: const { isOAuth } = params', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        'function renamedPlacement(params: { isOAuth: boolean }) {',
         '  const { isOAuth } = params;',
         '  return isOAuth ? [] : [];',
         '}',
       ].join('\n'),
     );
-    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(hasPlacementViolation(messages)).toBe(true);
   });
 
   it('rejects switch bypass: switch on params.isOAuth inside placeSystemInstruction', () => {
@@ -209,7 +213,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
         '}',
       ].join('\n'),
     );
-    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(hasPlacementViolation(messages)).toBe(true);
   });
 
   it('allows legitimate auth-only use of a direct isOAuth parameter', () => {

--- a/packages/providers/src/anthropic/AnthropicPlacementLintGuard.test.ts
+++ b/packages/providers/src/anthropic/AnthropicPlacementLintGuard.test.ts
@@ -18,8 +18,6 @@
 
 import { describe, it, expect } from 'bun:test';
 import { ESLint, Linter } from 'eslint';
-import { parser as tsParser } from 'typescript-eslint';
-import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
@@ -31,7 +29,7 @@ const TARGET_FILE = path.join(
 const PREPARATION_SOURCE_PATH = TARGET_FILE;
 
 type RuleEntry = { selector: string; message: string };
-type RuleConfig = [severity: number, ...entries: RuleEntry[]];
+type RuleConfig = [severity: Linter.RuleSeverity, ...entries: RuleEntry[]];
 
 function isRuleEntry(value: unknown): value is RuleEntry {
   if (typeof value !== 'object' || value === null) {
@@ -64,14 +62,11 @@ function lintWithEffectiveRule(code: string) {
   const linter = new Linter();
   return linter.verify(code, {
     languageOptions: {
-      parser: tsParser,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-      },
+      ecmaVersion: 'latest',
+      sourceType: 'module',
     },
     rules: {
-      'no-restricted-syntax': effectiveRule ?? ['off'],
+      'no-restricted-syntax': effectiveRule ?? 'off',
     },
   });
 }
@@ -93,7 +88,8 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   });
 
   it('preserves the pre-existing no-restricted-syntax entries under flat-config replacement', () => {
-    const selectors = effectiveRule!.slice(1).map((entry) => entry.selector);
+    const [, ...entries] = effectiveRule!;
+    const selectors = entries.map((entry) => entry.selector);
     expect(selectors).toContain('CallExpression[callee.name="require"]');
     expect(selectors).toContain(
       'ThrowStatement > Literal:not([value=/^\\w+Error:/])',
@@ -103,7 +99,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('rejects any isOAuth reference inside placeSystemInstruction', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        'function placeSystemInstruction(params) {',
         '  if (params.isOAuth) {',
         '    return [];',
         '  }',
@@ -117,7 +113,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('rejects isOAuth when the placement helper is an arrow function', () => {
     const messages = lintWithEffectiveRule(
       [
-        'const placeSystemInstruction = (params: { isOAuth: boolean }) => {',
+        'const placeSystemInstruction = (params) => {',
         '  return params.isOAuth ? [] : [];',
         '};',
       ].join('\n'),
@@ -128,7 +124,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('rejects the exact removed isOAuth branch when reintroduced in buildSystemContext', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function buildSystemContext(params: { isOAuth: boolean }) {',
+        'function buildSystemContext(params) {',
         '  if (params.isOAuth) {',
         '    return buildOAuthSystemContext(params);',
         '  }',
@@ -142,7 +138,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('rejects an inline auth ternary after the placement helper is renamed', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function renamedPlacement(params: { isOAuth: boolean }) {',
+        'function renamedPlacement(params) {',
         '  return params.isOAuth ? buildOAuthSystemContext(params) : [];',
         '}',
       ].join('\n'),
@@ -153,7 +149,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('rejects negation bypass: !params.isOAuth inside placeSystemInstruction', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        'function placeSystemInstruction(params) {',
         '  if (!params.isOAuth) {',
         '    return [];',
         '  }',
@@ -167,7 +163,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('rejects equality bypass: params.isOAuth === true inside placeSystemInstruction', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        'function placeSystemInstruction(params) {',
         '  if (params.isOAuth === true) {',
         '    return [];',
         '  }',
@@ -181,7 +177,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('rejects ternary bypass: params.isOAuth ? a : b inside placeSystemInstruction', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        'function placeSystemInstruction(params) {',
         '  const x = params.isOAuth ? [] : [];',
         '  return x;',
         '}',
@@ -193,7 +189,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('rejects file-wide destructure bypass: const { isOAuth } = params', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function renamedPlacement(params: { isOAuth: boolean }) {',
+        'function renamedPlacement(params) {',
         '  const { isOAuth } = params;',
         '  return isOAuth ? [] : [];',
         '}',
@@ -205,7 +201,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('rejects switch bypass: switch on params.isOAuth inside placeSystemInstruction', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        'function placeSystemInstruction(params) {',
         '  switch (params.isOAuth) {',
         '    case true: return [];',
         '    default: return [];',
@@ -219,7 +215,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('allows legitimate auth-only use of a direct isOAuth parameter', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function buildContextPrefixSystemField(isOAuth: boolean) {',
+        'function buildContextPrefixSystemField(isOAuth) {',
         '  if (isOAuth) {',
         '    return "vendor";',
         '  }',
@@ -233,7 +229,7 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
   it('allows placement-only branching without any isOAuth reference', () => {
     const messages = lintWithEffectiveRule(
       [
-        'function placeSystemInstruction(params: { placement: string }) {',
+        'function placeSystemInstruction(params) {',
         '  if (params.placement === "context-prefix") {',
         '    return [{ role: "user", content: "prompt" }];',
         '  }',
@@ -244,9 +240,9 @@ describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', 
     expect(messages).toStrictEqual([]);
   });
 
-  it('keeps the candidate AnthropicRequestPreparation.ts source lint-clean', () => {
-    const source = readFileSync(PREPARATION_SOURCE_PATH, 'utf8');
-    const messages = lintWithEffectiveRule(source);
-    expect(messages).toStrictEqual([]);
+  it('keeps the candidate AnthropicRequestPreparation.ts source lint-clean', async () => {
+    const eslint = new ESLint({ cwd: PROJECT_ROOT });
+    const [result] = await eslint.lintFiles(PREPARATION_SOURCE_PATH);
+    expect(result.messages).toStrictEqual([]);
   });
 });

--- a/packages/providers/src/anthropic/AnthropicPlacementLintGuard.test.ts
+++ b/packages/providers/src/anthropic/AnthropicPlacementLintGuard.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Structural proof (issue #3172 AC-4): the error-level, provider-scoped
+ * `no-restricted-syntax` guard in the EFFECTIVE eslint.config.js must reject
+ * auth-controlled placement in the original decision site and in the
+ * placement-only helper, while allowing direct auth facts inside auth-specific
+ * helpers.
+ *
+ * The rule is extracted from ESLint's calculated effective config for the
+ * target file — not merely scanned from the raw config entry — so a later
+ * flat-config block that silently drops the selector is detected.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ESLint, Linter } from 'eslint';
+import { parser as tsParser } from 'typescript-eslint';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const PROJECT_ROOT = fileURLToPath(new URL('../../../../', import.meta.url));
+const TARGET_FILE = path.join(
+  PROJECT_ROOT,
+  'packages/providers/src/anthropic/AnthropicRequestPreparation.ts',
+);
+const PREPARATION_SOURCE_PATH = TARGET_FILE;
+
+type RuleEntry = { selector: string; message: string };
+type RuleConfig = [severity: number, ...entries: RuleEntry[]];
+
+function isRuleEntry(value: unknown): value is RuleEntry {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    'selector' in candidate &&
+    typeof candidate['selector'] === 'string' &&
+    'message' in candidate &&
+    typeof candidate['message'] === 'string'
+  );
+}
+
+async function getEffectiveRule(): Promise<RuleConfig | undefined> {
+  const eslint = new ESLint({ cwd: PROJECT_ROOT });
+  const config = await eslint.calculateConfigForFile(TARGET_FILE);
+  const rule = config.rules?.['no-restricted-syntax'];
+  if (!Array.isArray(rule) || rule.length < 2) {
+    return undefined;
+  }
+  const severity = rule[0];
+  const entries = rule.slice(1).filter(isRuleEntry);
+  return [severity, ...entries] as RuleConfig;
+}
+
+const effectiveRule = await getEffectiveRule();
+
+function lintWithEffectiveRule(code: string) {
+  const linter = new Linter();
+  return linter.verify(code, {
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    rules: {
+      'no-restricted-syntax': effectiveRule ?? ['off'],
+    },
+  });
+}
+
+describe('AnthropicRequestPreparation placement lint guard (issue #3172 AC-4)', () => {
+  it('registers an error-level rule in the EFFECTIVE config for the target file', () => {
+    expect(effectiveRule).toBeDefined();
+    // calculateConfigForFile normalizes severity to numeric (2 = error).
+    expect(effectiveRule![0]).toBe(2);
+  });
+
+  it('preserves the pre-existing no-restricted-syntax entries under flat-config replacement', () => {
+    const selectors = effectiveRule!.slice(1).map((entry) => entry.selector);
+    expect(selectors).toContain('CallExpression[callee.name="require"]');
+    expect(selectors).toContain(
+      'ThrowStatement > Literal:not([value=/^\\w+Error:/])',
+    );
+  });
+
+  it('rejects any isOAuth reference inside placeSystemInstruction', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        '  if (params.isOAuth) {',
+        '    return [];',
+        '  }',
+        '  return [];',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(messages[0].severity).toBe(2);
+  });
+
+  it('rejects isOAuth when the placement helper is an arrow function', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'const placeSystemInstruction = (params: { isOAuth: boolean }) => {',
+        '  return params.isOAuth ? [] : [];',
+        '};',
+      ].join('\n'),
+    );
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(messages[0].severity).toBe(2);
+  });
+
+  it('rejects the exact removed isOAuth branch when reintroduced in buildSystemContext', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function buildSystemContext(params: { isOAuth: boolean }) {',
+        '  if (params.isOAuth) {',
+        '    return buildOAuthSystemContext(params);',
+        '  }',
+        '  return buildNonOAuthSystemContext(params);',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(messages[0].severity).toBe(2);
+  });
+
+  it('rejects an inline auth ternary after the placement helper is renamed', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function renamedPlacement(params: { isOAuth: boolean }) {',
+        '  return params.isOAuth ? buildOAuthSystemContext(params) : [];',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(messages[0].severity).toBe(2);
+  });
+
+  it('rejects negation bypass: !params.isOAuth inside placeSystemInstruction', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        '  if (!params.isOAuth) {',
+        '    return [];',
+        '  }',
+        '  return [];',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(messages[0].severity).toBe(2);
+  });
+
+  it('rejects equality bypass: params.isOAuth === true inside placeSystemInstruction', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        '  if (params.isOAuth === true) {',
+        '    return [];',
+        '  }',
+        '  return [];',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('rejects ternary bypass: params.isOAuth ? a : b inside placeSystemInstruction', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        '  const x = params.isOAuth ? [] : [];',
+        '  return x;',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('rejects alias/destructure bypass: const { isOAuth } = params', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        '  const { isOAuth } = params;',
+        '  return isOAuth ? [] : [];',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('rejects switch bypass: switch on params.isOAuth inside placeSystemInstruction', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function placeSystemInstruction(params: { isOAuth: boolean }) {',
+        '  switch (params.isOAuth) {',
+        '    case true: return [];',
+        '    default: return [];',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('allows legitimate auth-only use of a direct isOAuth parameter', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function buildContextPrefixSystemField(isOAuth: boolean) {',
+        '  if (isOAuth) {',
+        '    return "vendor";',
+        '  }',
+        '  return undefined;',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('allows placement-only branching without any isOAuth reference', () => {
+    const messages = lintWithEffectiveRule(
+      [
+        'function placeSystemInstruction(params: { placement: string }) {',
+        '  if (params.placement === "context-prefix") {',
+        '    return [{ role: "user", content: "prompt" }];',
+        '  }',
+        '  return [];',
+        '}',
+      ].join('\n'),
+    );
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('keeps the candidate AnthropicRequestPreparation.ts source lint-clean', () => {
+    const source = readFileSync(PREPARATION_SOURCE_PATH, 'utf8');
+    const messages = lintWithEffectiveRule(source);
+    expect(messages).toStrictEqual([]);
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts
+++ b/packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts
@@ -133,7 +133,7 @@ class InvalidPlacementProvider extends PlacementTestProvider {
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function lastItem<T>(items: readonly T[]): T | undefined {
@@ -211,7 +211,7 @@ describe('Anthropic system-prompt placement wiring (issue #3172)', () => {
 
   async function captureWirePayload(
     authToken: ResolvedAuthToken,
-  ): Promise<{ system: unknown; messages: unknown }> {
+  ): Promise<Record<string, unknown>> {
     const provider = new PlacementTestProvider();
     for await (const _chunk of provider.generateChatCompletion(
       buildOptions(authToken),
@@ -222,10 +222,7 @@ describe('Anthropic system-prompt placement wiring (issue #3172)', () => {
     if (!isObject(request)) {
       throw new Error('Expected an SDK request payload');
     }
-    return {
-      system: request['system'],
-      messages: request['messages'],
-    };
+    return request;
   }
 
   async function exhaustCompletion(

--- a/packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts
+++ b/packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts
@@ -136,6 +136,10 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function lastItem<T>(items: readonly T[]): T | undefined {
+  return items[items.length - 1];
+}
+
 function textFromBlocks(blocks: unknown): string {
   if (!Array.isArray(blocks)) {
     return '';
@@ -214,7 +218,7 @@ describe('Anthropic system-prompt placement wiring (issue #3172)', () => {
     )) {
       void _chunk;
     }
-    const request = FakeAnthropicClass.requests.at(-1)?.request;
+    const request = lastItem(FakeAnthropicClass.requests)?.request;
     if (!isObject(request)) {
       throw new Error('Expected an SDK request payload');
     }
@@ -312,7 +316,7 @@ describe('Anthropic system-prompt placement wiring (issue #3172)', () => {
     )) {
       void _chunk;
     }
-    const request = FakeAnthropicClass.requests.at(-1)?.request;
+    const request = lastItem(FakeAnthropicClass.requests)?.request;
     if (!isObject(request)) {
       throw new Error('Expected an SDK request payload');
     }
@@ -375,16 +379,16 @@ describe('Anthropic system-prompt placement wiring (issue #3172)', () => {
       .next();
 
     // The SDK constructor received the FIRST token, proving provide() ran once.
-    const transportOpts = FakeAnthropicClass.created.at(-1)?.options;
+    const transportOpts = lastItem(FakeAnthropicClass.created)?.options;
     expect(transportOpts?.['apiKey']).toBe(API_KEY);
     expect(callIndex).toBe(1);
 
     // Deep-compare against the direct-string baseline.
-    const transportRequest = FakeAnthropicClass.requests.at(-1)?.request;
+    const transportRequest = lastItem(FakeAnthropicClass.requests)?.request;
     FakeAnthropicClass.reset();
     const baselineProvider = new PlacementTestProvider();
     await baselineProvider.generateChatCompletion(buildOptions(API_KEY)).next();
-    const baselineRequest = FakeAnthropicClass.requests.at(-1)?.request;
+    const baselineRequest = lastItem(FakeAnthropicClass.requests)?.request;
 
     expect(isObject(transportRequest)).toBe(true);
     expect(isObject(baselineRequest)).toBe(true);
@@ -416,18 +420,18 @@ describe('Anthropic system-prompt placement wiring (issue #3172)', () => {
       .next();
 
     // The SDK constructor received the FIRST token (OAuth uses authToken).
-    const transportOpts = FakeAnthropicClass.created.at(-1)?.options;
+    const transportOpts = lastItem(FakeAnthropicClass.created)?.options;
     expect(transportOpts?.['authToken']).toBe(OAUTH_TOKEN);
     expect(callIndex).toBe(1);
 
     // Deep-compare against the direct-string baseline.
-    const transportRequest = FakeAnthropicClass.requests.at(-1)?.request;
+    const transportRequest = lastItem(FakeAnthropicClass.requests)?.request;
     FakeAnthropicClass.reset();
     const baselineProvider = new PlacementTestProvider();
     await baselineProvider
       .generateChatCompletion(buildOptions(OAUTH_TOKEN))
       .next();
-    const baselineRequest = FakeAnthropicClass.requests.at(-1)?.request;
+    const baselineRequest = lastItem(FakeAnthropicClass.requests)?.request;
 
     expect(isObject(transportRequest)).toBe(true);
     expect(isObject(baselineRequest)).toBe(true);

--- a/packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts
+++ b/packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts
@@ -362,9 +362,9 @@ describe('Anthropic system-prompt placement wiring (issue #3172)', () => {
     const options = buildOptions(rotatingProvider);
 
     // Projection resolves the token but creates no SDK client.
-    const requestsBeforeProjection = FakeAnthropicClass.requests.length;
+    const createdBeforeProjection = FakeAnthropicClass.created.length;
     const projection = await provider.projectPromptEnvelope(options);
-    expect(FakeAnthropicClass.requests.length).toBe(requestsBeforeProjection);
+    expect(FakeAnthropicClass.created.length).toBe(createdBeforeProjection);
 
     // Transport uses the prepared token without resolving again.
     await provider
@@ -404,9 +404,9 @@ describe('Anthropic system-prompt placement wiring (issue #3172)', () => {
     const provider = new PlacementTestProvider();
     const options = buildOptions(rotatingProvider);
 
-    const requestsBeforeProjection = FakeAnthropicClass.requests.length;
+    const createdBeforeProjection = FakeAnthropicClass.created.length;
     const projection = await provider.projectPromptEnvelope(options);
-    expect(FakeAnthropicClass.requests.length).toBe(requestsBeforeProjection);
+    expect(FakeAnthropicClass.created.length).toBe(createdBeforeProjection);
 
     await provider
       .generateChatCompletion({

--- a/packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts
+++ b/packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts
@@ -1,0 +1,436 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral test (issue #3172): the live Anthropic request path must select
+ * system-context placement from the provider's declared capability (resolved
+ * through the shared placement policy) based on the RESOLVED token string,
+ * never from a local auth flag or the unresolved provider object's shape.
+ *
+ * Coverage:
+ *  - Placement wiring for direct API-key and OAuth strings.
+ *  - Runtime-provider parity: deep-compare complete finalized SDK payloads
+ *    between direct strings and runtime-provider equivalents.
+ *  - Blocker-fix proof: a test provider that declares context-prefix while
+ *    auth is API-key — declaration controls placement but does NOT emit the
+ *    OAuth-only Claude Code system string.
+ *  - Prompt-envelope transport flow: projectPromptEnvelope followed by
+ *    generateChatCompletion with the prepared transport token for both token
+ *    classes, using rotating values to prove single resolution.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  clearActiveProviderRuntimeContext,
+  createProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { AnthropicProvider } from './AnthropicProvider.js';
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  ResolvedAuthToken,
+  RuntimeAuthTokenProvider,
+} from '../types/providerRuntime.js';
+import type { SystemPromptPlacement } from '../utils/systemPromptPlacement.js';
+
+void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn(async () => 'core-prompt'),
+}));
+
+void vi.mock('@anthropic-ai/sdk', () => {
+  class FakeAnthropic {
+    static created: Array<{
+      options: Record<string, unknown>;
+    }> = [];
+
+    static requests: Array<{
+      request: Record<string, unknown>;
+    }> = [];
+
+    static reset(): void {
+      FakeAnthropic.created = [];
+      FakeAnthropic.requests = [];
+    }
+
+    readonly options: Record<string, unknown>;
+    readonly messages: {
+      create: ReturnType<typeof vi.fn>;
+    };
+
+    constructor(opts: Record<string, unknown>) {
+      this.options = opts;
+      FakeAnthropic.created.push({ options: opts });
+      this.messages = {
+        create: vi.fn(async (request: Record<string, unknown>) => {
+          FakeAnthropic.requests.push({ request });
+          const req = request as { stream?: boolean };
+          if (req.stream === true) {
+            return {
+              async *[Symbol.asyncIterator]() {
+                yield {
+                  type: 'content_block_delta',
+                  delta: { type: 'text_delta', text: 'ok' },
+                };
+              },
+            };
+          }
+          return {
+            content: [{ type: 'text', text: 'ok' }],
+            usage: { input_tokens: 0, output_tokens: 0 },
+          };
+        }),
+      };
+    }
+  }
+  return { default: FakeAnthropic };
+});
+
+const FakeAnthropicClass = Anthropic as unknown as {
+  created: Array<{ options: Record<string, unknown> }>;
+  requests: Array<{ request: Record<string, unknown> }>;
+  reset(): void;
+};
+
+const OAUTH_SYSTEM_FIELD =
+  "You are Claude Code, Anthropic's official CLI for Claude.";
+const ASSEMBLED_PROMPT = 'ASSEMBLED_INSTRUCTION';
+const API_KEY = 'sk-ant-api03-example-key';
+const OAUTH_TOKEN = 'sk-ant-oat01-example-oauth';
+
+class PlacementTestProvider extends AnthropicProvider {
+  constructor() {
+    super(undefined, 'https://api.anthropic.com', {
+      getEphemeralSettings: () => ({}),
+    });
+  }
+
+  protected override async getAuthTokenForPrompt(): Promise<string> {
+    return 'ambient-unused';
+  }
+}
+
+class ContextPrefixApiKeyProvider extends PlacementTestProvider {
+  override getSystemPromptPlacement(): SystemPromptPlacement {
+    return 'context-prefix';
+  }
+}
+
+class SystemFieldOAuthProvider extends PlacementTestProvider {
+  override getSystemPromptPlacement(): SystemPromptPlacement {
+    return 'system-field';
+  }
+}
+
+class InvalidPlacementProvider extends PlacementTestProvider {
+  override getSystemPromptPlacement(): SystemPromptPlacement {
+    return 'invalid-placement' as SystemPromptPlacement;
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function textFromBlocks(blocks: unknown): string {
+  if (!Array.isArray(blocks)) {
+    return '';
+  }
+  return blocks
+    .filter(isObject)
+    .map((block) => (typeof block['text'] === 'string' ? block['text'] : ''))
+    .join('');
+}
+
+function systemFieldText(system: unknown): string {
+  if (typeof system === 'string') {
+    return system;
+  }
+  return textFromBlocks(system);
+}
+
+function firstMessageText(messages: unknown): string {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return '';
+  }
+  const first = messages[0];
+  if (!isObject(first)) {
+    return '';
+  }
+  const content = first['content'];
+  if (typeof content === 'string') {
+    return content;
+  }
+  return textFromBlocks(content);
+}
+
+describe('Anthropic system-prompt placement wiring (issue #3172)', () => {
+  let settingsService: SettingsService;
+
+  beforeEach(() => {
+    FakeAnthropicClass.reset();
+    settingsService = new SettingsService();
+    settingsService.setProviderSetting('anthropic', 'prompt-caching', 'off');
+    setActiveProviderRuntimeContext(
+      createProviderRuntimeContext({
+        settingsService,
+        runtimeId: 'anthropic-placement-wiring-test',
+      }),
+    );
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  function buildOptions(
+    authToken: ResolvedAuthToken,
+    systemInstruction = ASSEMBLED_PROMPT,
+  ) {
+    return createProviderCallOptions({
+      providerName: 'anthropic',
+      contents: [{ speaker: 'human', blocks: [{ type: 'text', text: 'Hi' }] }],
+      settings: settingsService,
+      systemInstruction,
+      resolved: {
+        model: 'claude-opus-5',
+        baseURL: 'https://api.anthropic.com',
+        authToken,
+        telemetry: { providerName: 'anthropic' },
+      },
+    });
+  }
+
+  async function captureWirePayload(
+    authToken: ResolvedAuthToken,
+  ): Promise<{ system: unknown; messages: unknown }> {
+    const provider = new PlacementTestProvider();
+    for await (const _chunk of provider.generateChatCompletion(
+      buildOptions(authToken),
+    )) {
+      void _chunk;
+    }
+    const request = FakeAnthropicClass.requests.at(-1)?.request;
+    if (!isObject(request)) {
+      throw new Error('Expected an SDK request payload');
+    }
+    return {
+      system: request['system'],
+      messages: request['messages'],
+    };
+  }
+
+  async function exhaustCompletion(
+    provider: AnthropicProvider,
+    authToken: ResolvedAuthToken,
+  ): Promise<void> {
+    for await (const _chunk of provider.generateChatCompletion(
+      buildOptions(authToken),
+    )) {
+      void _chunk;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Placement wiring: direct strings
+  // -------------------------------------------------------------------------
+
+  it('places the assembled instruction in the system field for a direct API-key string', async () => {
+    const { system } = await captureWirePayload(API_KEY);
+    expect(systemFieldText(system)).toBe(ASSEMBLED_PROMPT);
+  });
+
+  it('reserves the system field and context-prefixes the instruction for a direct OAuth string', async () => {
+    const { system, messages } = await captureWirePayload(OAUTH_TOKEN);
+    expect(systemFieldText(system)).toBe(OAUTH_SYSTEM_FIELD);
+    expect(firstMessageText(messages)).toContain(
+      `<system>\n${ASSEMBLED_PROMPT}\n</system>`,
+    );
+  });
+
+  it('resolves a rotating runtime provider once before API-key placement', async () => {
+    const tokens = [API_KEY, OAUTH_TOKEN];
+    let callIndex = 0;
+    const runtimeProvider: RuntimeAuthTokenProvider = {
+      provide: () =>
+        Promise.resolve(tokens[Math.min(callIndex++, tokens.length - 1)]),
+    };
+    const { system } = await captureWirePayload(runtimeProvider);
+    expect(systemFieldText(system)).toBe(ASSEMBLED_PROMPT);
+    expect(callIndex).toBe(1);
+  });
+
+  it('resolves a rotating runtime provider once before OAuth placement', async () => {
+    const tokens = [OAUTH_TOKEN, API_KEY];
+    let callIndex = 0;
+    const runtimeProvider: RuntimeAuthTokenProvider = {
+      provide: () =>
+        Promise.resolve(tokens[Math.min(callIndex++, tokens.length - 1)]),
+    };
+    const { system, messages } = await captureWirePayload(runtimeProvider);
+    expect(systemFieldText(system)).toBe(OAUTH_SYSTEM_FIELD);
+    expect(firstMessageText(messages)).toContain(
+      `<system>\n${ASSEMBLED_PROMPT}\n</system>`,
+    );
+    expect(callIndex).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Deep-compare parity: direct string vs runtime provider
+  // -------------------------------------------------------------------------
+
+  it('produces byte-identical SDK payloads for a direct API-key string and a runtime provider resolving to the same key', async () => {
+    const direct = await captureWirePayload(API_KEY);
+    const runtimeProvider: RuntimeAuthTokenProvider = {
+      provide: () => Promise.resolve(API_KEY),
+    };
+    const runtime = await captureWirePayload(runtimeProvider);
+    expect(runtime).toEqual(direct);
+  });
+
+  it('produces byte-identical SDK payloads for a direct OAuth string and a runtime provider resolving to the same token', async () => {
+    const direct = await captureWirePayload(OAUTH_TOKEN);
+    const runtimeProvider: RuntimeAuthTokenProvider = {
+      provide: () => Promise.resolve(OAUTH_TOKEN),
+    };
+    const runtime = await captureWirePayload(runtimeProvider);
+    expect(runtime).toEqual(direct);
+  });
+
+  // -------------------------------------------------------------------------
+  // Blocker-fix: declaration controls placement, not the vendor system string
+  // -------------------------------------------------------------------------
+
+  it('context-prefixes the instruction but does NOT emit the OAuth-only Claude Code system string when declaration is context-prefix and auth is API-key', async () => {
+    const provider = new ContextPrefixApiKeyProvider();
+    for await (const _chunk of provider.generateChatCompletion(
+      buildOptions(API_KEY),
+    )) {
+      void _chunk;
+    }
+    const request = FakeAnthropicClass.requests.at(-1)?.request;
+    if (!isObject(request)) {
+      throw new Error('Expected an SDK request payload');
+    }
+    // Declaration drove placement: prompt is in the context prefix.
+    expect(firstMessageText(request['messages'])).toContain(
+      `<system>\n${ASSEMBLED_PROMPT}\n</system>`,
+    );
+    // Auth classification independently controls the vendor system field:
+    // API-key auth does NOT emit the OAuth-only Claude Code string.
+    expect(request['system']).toBeUndefined();
+  });
+
+  it('fails fast before transport when OAuth is declared as system-field', async () => {
+    const provider = new SystemFieldOAuthProvider();
+    await expect(exhaustCompletion(provider, OAUTH_TOKEN)).rejects.toThrow(
+      'OAuth requires context-prefix placement',
+    );
+    expect(FakeAnthropicClass.requests).toHaveLength(0);
+  });
+
+  it('fails fast before transport for an unsupported placement declaration', async () => {
+    const provider = new InvalidPlacementProvider();
+    await expect(exhaustCompletion(provider, API_KEY)).rejects.toThrow(
+      'unsupported placement declaration invalid-placement',
+    );
+    expect(FakeAnthropicClass.requests).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Prompt-envelope transport: single resolution and exact transport replay
+  // -------------------------------------------------------------------------
+
+  it('resolves the API-key runtime provider once and transports the already-prepared exact request', async () => {
+    // Rotating values: if provide() is called twice the constructor receives
+    // the second value and the deep comparison fails — proving single
+    // resolution without mock-call-count.
+    const rotatingTokens = [API_KEY, 'sk-ant-api03-SHOULD-NOT-APPEAR'];
+    let callIndex = 0;
+    const rotatingProvider: RuntimeAuthTokenProvider = {
+      provide: () =>
+        Promise.resolve(
+          rotatingTokens[Math.min(callIndex++, rotatingTokens.length - 1)],
+        ),
+    };
+
+    const provider = new PlacementTestProvider();
+    const options = buildOptions(rotatingProvider);
+
+    // Projection resolves the token but creates no SDK client.
+    const requestsBeforeProjection = FakeAnthropicClass.requests.length;
+    const projection = await provider.projectPromptEnvelope(options);
+    expect(FakeAnthropicClass.requests.length).toBe(requestsBeforeProjection);
+
+    // Transport uses the prepared token without resolving again.
+    await provider
+      .generateChatCompletion({
+        ...options,
+        promptEnvelopeTransportToken: projection.transportToken,
+      })
+      .next();
+
+    // The SDK constructor received the FIRST token, proving provide() ran once.
+    const transportOpts = FakeAnthropicClass.created.at(-1)?.options;
+    expect(transportOpts?.['apiKey']).toBe(API_KEY);
+    expect(callIndex).toBe(1);
+
+    // Deep-compare against the direct-string baseline.
+    const transportRequest = FakeAnthropicClass.requests.at(-1)?.request;
+    FakeAnthropicClass.reset();
+    const baselineProvider = new PlacementTestProvider();
+    await baselineProvider.generateChatCompletion(buildOptions(API_KEY)).next();
+    const baselineRequest = FakeAnthropicClass.requests.at(-1)?.request;
+
+    expect(isObject(transportRequest)).toBe(true);
+    expect(isObject(baselineRequest)).toBe(true);
+    expect(transportRequest).toEqual(baselineRequest);
+  });
+
+  it('resolves the OAuth runtime provider once and transports the already-prepared exact request', async () => {
+    const rotatingTokens = [OAUTH_TOKEN, 'sk-ant-oat01-SHOULD-NOT-APPEAR'];
+    let callIndex = 0;
+    const rotatingProvider: RuntimeAuthTokenProvider = {
+      provide: () =>
+        Promise.resolve(
+          rotatingTokens[Math.min(callIndex++, rotatingTokens.length - 1)],
+        ),
+    };
+
+    const provider = new PlacementTestProvider();
+    const options = buildOptions(rotatingProvider);
+
+    const requestsBeforeProjection = FakeAnthropicClass.requests.length;
+    const projection = await provider.projectPromptEnvelope(options);
+    expect(FakeAnthropicClass.requests.length).toBe(requestsBeforeProjection);
+
+    await provider
+      .generateChatCompletion({
+        ...options,
+        promptEnvelopeTransportToken: projection.transportToken,
+      })
+      .next();
+
+    // The SDK constructor received the FIRST token (OAuth uses authToken).
+    const transportOpts = FakeAnthropicClass.created.at(-1)?.options;
+    expect(transportOpts?.['authToken']).toBe(OAUTH_TOKEN);
+    expect(callIndex).toBe(1);
+
+    // Deep-compare against the direct-string baseline.
+    const transportRequest = FakeAnthropicClass.requests.at(-1)?.request;
+    FakeAnthropicClass.reset();
+    const baselineProvider = new PlacementTestProvider();
+    await baselineProvider
+      .generateChatCompletion(buildOptions(OAUTH_TOKEN))
+      .next();
+    const baselineRequest = FakeAnthropicClass.requests.at(-1)?.request;
+
+    expect(isObject(transportRequest)).toBe(true);
+    expect(isObject(baselineRequest)).toBe(true);
+    expect(transportRequest).toEqual(baselineRequest);
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -21,14 +21,13 @@ import type { GenerateChatOptions } from '../IProvider.js';
 import {
   type SystemPromptPlacement,
   requireAssembledSystemInstruction,
+  resolveSystemPromptPlacement,
 } from '../utils/systemPromptPlacement.js';
+import { isRuntimeAuthTokenProvider } from '../utils/authToken.js';
 // @plan:PLAN-20260608-ISSUE1586.P15 — auth types from auth package
 import { type OAuthManager } from '@vybestack/llxprt-code-auth';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
-import type {
-  ProviderTelemetryContext,
-  RuntimeAuthTokenProvider,
-} from '../types/providerRuntime.js';
+import type { ProviderTelemetryContext } from '../types/providerRuntime.js';
 import type { DumpMode } from '../utils/dumpContext.js';
 import {
   type AnthropicRateLimitInfo,
@@ -372,30 +371,32 @@ export class AnthropicProvider extends BaseProvider {
   }
 
   /**
-   * Issue #3136: declare where the assembled system prompt may go.
+   * Issue #3136/#3172: declare where the assembled system prompt may go.
    *
    * Under OAuth (`claudecode`) Anthropic REJECTS any request whose `system`
    * field carries content other than the Claude Code string, so the prompt
-   * must be placed at the top of the context instead. This is a declaration
-   * consumed by the shared placement policy, not a placement decision made
-   * here.
+   * must be placed at the top of the context instead. Classification is driven
+   * by the RESOLVED token string: a runtime auth-token provider is resolved
+   * before placement is declared, so an unresolved provider object's shape
+   * alone never implies OAuth. This declaration is consumed by the shared
+   * placement policy, not a placement decision made in isolation here.
    */
   getSystemPromptPlacement(
     options: GenerateChatOptions,
   ): SystemPromptPlacement {
-    const authToken = options.resolved?.authToken;
-    if (typeof authToken === 'string') {
-      return this.classifyOAuthToken(authToken)
-        ? 'context-prefix'
-        : 'system-field';
+    const resolvedToken = options.resolved?.authToken;
+    if (isRuntimeAuthTokenProvider(resolvedToken)) {
+      throw new Error(
+        'SystemPromptPlacementError: Anthropic placement requires a resolved auth-token string (issue #3172).',
+      );
     }
-    // A RuntimeAuthTokenProvider is this provider's OAuth refresh mechanism
-    // (see resolveClientAuthToken), so it resolves to an sk-ant-oat token at
-    // request time. Treating it as system-field would put our prompt in the
-    // reserved OAuth `system` field and Anthropic would reject the request.
-    return isRuntimeAuthTokenProvider(authToken)
-      ? 'context-prefix'
-      : 'system-field';
+    if (
+      typeof resolvedToken === 'string' &&
+      this.classifyOAuthToken(resolvedToken)
+    ) {
+      return 'context-prefix';
+    }
+    return 'system-field';
   }
 
   /**
@@ -636,7 +637,7 @@ export class AnthropicProvider extends BaseProvider {
     const isOAuth = prepared?.isOAuth ?? this.classifyOAuthToken(authToken);
     const requestContext =
       prepared?.requestContext ??
-      (await this.prepareRequestContext(options, isOAuth));
+      (await this.prepareRequestContext(options, isOAuth, authToken));
 
     const customHeaders = this.buildCustomHeaders(requestContext, isOAuth);
 
@@ -677,12 +678,22 @@ export class AnthropicProvider extends BaseProvider {
   private async prepareRequestContext(
     options: NormalizedGenerateChatOptions,
     isOAuth: boolean,
+    authToken: string,
   ) {
+    // Issue #3172: placement is declared from the RESOLVED-token fact and
+    // resolved through the shared policy, never re-derived from isOAuth here.
+    const placement = resolveSystemPromptPlacement(
+      this.getSystemPromptPlacement({
+        ...options,
+        resolved: { ...options.resolved, authToken },
+      }),
+    );
     return prepareAnthropicRequest({
       content: options.contents,
       tools: options.tools,
       options,
       isOAuth,
+      placement,
       providerName: this.name,
       config: options.config ?? options.runtime?.config ?? this.globalConfig,
       getMaxTokensForModel: (m) => this.getMaxTokensForModel(m),
@@ -713,6 +724,7 @@ export class AnthropicProvider extends BaseProvider {
     const requestContext = await this.prepareRequestContext(
       normalized,
       isOAuth,
+      authToken,
     );
     const transportToken = Object.freeze({});
     this.preparedPromptEnvelopes.set(transportToken, {
@@ -838,14 +850,3 @@ export class AnthropicProvider extends BaseProvider {
 // Issue #2410: extracted to a standalone module to avoid a circular import
 // between AnthropicProvider and AnthropicRequestPreparation.
 export { isAnthropicOAuthBaseURL } from './AnthropicEndpointUtils.js';
-
-function isRuntimeAuthTokenProvider(
-  value: unknown,
-): value is RuntimeAuthTokenProvider {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'provide' in value &&
-    typeof value.provide === 'function'
-  );
-}

--- a/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
@@ -346,15 +346,9 @@ function placeSystemInstruction(params: {
 }
 
 /**
- * Build the vendor system field (issue #3172). The resolved auth
- * classification independently controls the vendor-required Claude Code system
- * value and other transport concerns.
- *
- * - system-field placement: the assembled instruction goes directly into the
- *   system field. Auth is necessarily non-OAuth here (OAuth requires
- *   context-prefix, enforced by buildSystemContext).
- * - context-prefix placement: the system field carries the OAuth vendor string
- *   when the resolved token is OAuth, or is undefined otherwise.
+ * Build the vendor system field for context-prefix placement (issue #3172).
+ * The field carries the Claude Code string when the resolved token is OAuth and
+ * remains absent for non-OAuth transports using context-prefix placement.
  */
 function buildContextPrefixSystemField(
   isOAuth: boolean,

--- a/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
@@ -573,7 +573,6 @@ function convertMessagesAndTools(params: {
   const {
     content,
     tools,
-    isOAuth,
     reasoningSettings,
     config,
     currentModel,
@@ -584,7 +583,7 @@ function convertMessagesAndTools(params: {
 
   // Convert IContent to Anthropic API format
   const anthropicMessages = convertToAnthropicMessages(content, {
-    isOAuth,
+    isOAuth: params.isOAuth,
     stripFromContext: reasoningSettings.stripFromContext,
     includeInContext: reasoningSettings.includeInContext,
     reasoningEnabled: reasoningSettings.reasoningEnabled as boolean,
@@ -596,7 +595,7 @@ function convertMessagesAndTools(params: {
   });
 
   // Convert tools to Anthropic format and stabilize ordering
-  let anthropicTools = convertToolsToAnthropic(tools, isOAuth);
+  let anthropicTools = convertToolsToAnthropic(tools, params.isOAuth);
 
   if (anthropicTools && anthropicTools.length > 0) {
     anthropicTools = [...anthropicTools]

--- a/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
@@ -34,7 +34,10 @@ import {
   isAnthropicOAuthBaseURL,
   ANTHROPIC_DEFAULT_BASE_URL,
 } from './AnthropicEndpointUtils.js';
-import { formatContextPrefix } from '../utils/systemPromptPlacement.js';
+import {
+  formatContextPrefix,
+  type SystemPromptPlacement,
+} from '../utils/systemPromptPlacement.js';
 
 /**
  * Request preparation context returned to caller
@@ -60,6 +63,7 @@ export interface PrepareRequestParams {
   tools: ProviderToolset | undefined;
   options: NormalizedGenerateChatOptions;
   isOAuth: boolean;
+  placement: SystemPromptPlacement;
   providerName: string;
   config: Config | undefined;
   getMaxTokensForModel: (model: string) => number;
@@ -270,14 +274,24 @@ function resolveRequestSettings(
   };
 }
 
-async function buildOAuthSystemContext(params: {
+/**
+ * Placement-only message selection (issue #3172). Positions the assembled
+ * instruction at the top of the context when placement is `context-prefix`.
+ *
+ * This helper has NO reason to reference the resolved auth classification:
+ * placement (WHERE the prompt goes) is independent of transport auth. The
+ * vendor system field is determined separately by buildSystemField.
+ */
+function placeSystemInstruction(params: {
+  placement: SystemPromptPlacement;
   anthropicMessages: readonly AnthropicMessage[];
   wantCaching: boolean;
   ttl: '5m' | '1h';
   cacheLogger: { debug: (fn: () => string) => void };
   systemInstruction: string | undefined;
-}): Promise<SystemContextResult> {
+}): AnthropicMessage[] {
   const {
+    placement,
     anthropicMessages,
     wantCaching,
     ttl,
@@ -287,87 +301,147 @@ async function buildOAuthSystemContext(params: {
 
   const messages = [...anthropicMessages];
 
-  // Issue #3136: the agent layer owns system-prompt assembly. The provider
-  // transports options.systemInstruction verbatim — it never rebuilds a core
-  // prompt or merges two prompts.
-  const systemMessage = systemInstruction ?? '';
-
-  if (systemMessage) {
-    // Issue #3136: Anthropic under OAuth declares `context-prefix` placement —
-    // its `system` field may carry ONLY the Claude Code string, so the real
-    // prompt is unshifted to the TOP OF THE CONTEXT (never inside history).
-    // The wrapper format is owned by the shared placement policy so this
-    // provider does not re-derive it.
-    const contextPrefixText = formatContextPrefix(systemMessage);
-
-    if (wantCaching) {
-      messages.unshift({
-        role: 'user',
-        content: [
-          {
-            type: 'text',
-            text: contextPrefixText,
-            cache_control: { type: 'ephemeral', ttl },
-          } as {
-            type: 'text';
-            text: string;
-            cache_control: { type: 'ephemeral'; ttl: '5m' | '1h' };
-          },
-        ],
-      });
-      cacheLogger.debug(() => 'Added cache_control to OAuth system message');
-    } else {
-      messages.unshift({
-        role: 'user',
-        content: contextPrefixText,
-      });
-    }
+  if (placement !== 'context-prefix') {
+    return messages;
   }
 
-  const oauthSystemField = buildAnthropicSystemPrompt({
+  const systemMessage = systemInstruction ?? '';
+  if (systemMessage === '') {
+    return messages;
+  }
+
+  // Issue #3136: Anthropic under OAuth declares `context-prefix` placement —
+  // its `system` field may carry ONLY the Claude Code string, so the real
+  // prompt is unshifted to the TOP OF THE CONTEXT (never inside history).
+  // The wrapper format is owned by the shared placement policy so this
+  // provider does not re-derive it.
+  const contextPrefixText = formatContextPrefix(systemMessage);
+
+  if (wantCaching) {
+    messages.unshift({
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: contextPrefixText,
+          cache_control: { type: 'ephemeral', ttl },
+        } as {
+          type: 'text';
+          text: string;
+          cache_control: { type: 'ephemeral'; ttl: '5m' | '1h' };
+        },
+      ],
+    });
+    cacheLogger.debug(
+      () => 'Added cache_control to context-prefixed system instruction',
+    );
+  } else {
+    messages.unshift({
+      role: 'user',
+      content: contextPrefixText,
+    });
+  }
+
+  return messages;
+}
+
+/**
+ * Build the vendor system field (issue #3172). The resolved auth
+ * classification independently controls the vendor-required Claude Code system
+ * value and other transport concerns.
+ *
+ * - system-field placement: the assembled instruction goes directly into the
+ *   system field. Auth is necessarily non-OAuth here (OAuth requires
+ *   context-prefix, enforced by buildSystemContext).
+ * - context-prefix placement: the system field carries the OAuth vendor string
+ *   when the resolved token is OAuth, or is undefined otherwise.
+ */
+function buildContextPrefixSystemField(
+  isOAuth: boolean,
+  wantCaching: boolean,
+  ttl: '5m' | '1h',
+): SystemContextResult['systemField'] {
+  if (!isOAuth) {
+    return undefined;
+  }
+  return buildAnthropicSystemPrompt({
     isOAuth: true,
     wantCaching,
     ttl,
   });
-
-  return { systemField: oauthSystemField, messages };
 }
 
-async function buildNonOAuthSystemContext(params: {
-  anthropicMessages: readonly AnthropicMessage[];
+function buildSystemField(params: {
+  placement: SystemPromptPlacement;
+  isOAuth: boolean;
   wantCaching: boolean;
   ttl: '5m' | '1h';
   systemInstruction: string | undefined;
-}): Promise<SystemContextResult> {
-  const { anthropicMessages, wantCaching, ttl, systemInstruction } = params;
+}): SystemContextResult['systemField'] {
+  const { placement, wantCaching, ttl, systemInstruction } = params;
 
-  // Issue #3136: the agent layer owns system-prompt assembly. The provider
-  // transports options.systemInstruction verbatim into the `system` field.
-  const systemFieldValue = buildAnthropicSystemPrompt({
-    corePromptText: systemInstruction ?? '',
-    isOAuth: false,
-    wantCaching,
-    ttl,
-  });
+  if (placement === 'system-field') {
+    return buildAnthropicSystemPrompt({
+      corePromptText: systemInstruction ?? '',
+      isOAuth: false,
+      wantCaching,
+      ttl,
+    });
+  }
 
-  return { systemField: systemFieldValue, messages: [...anthropicMessages] };
+  return buildContextPrefixSystemField(params.isOAuth, wantCaching, ttl);
+}
+
+function assertPlacementCompatibleWithAuth(
+  isOAuth: boolean,
+  placement: SystemPromptPlacement,
+): void {
+  if (isOAuth && placement !== 'context-prefix') {
+    throw new Error(
+      `SystemPromptPlacementError: OAuth requires context-prefix placement but placement is ${placement} (issue #3172).`,
+    );
+  }
 }
 
 /**
- * Build system context with OAuth or regular system field
+ * Build system context (issue #3172). Placement controls WHERE the assembled
+ * instruction goes; the resolved auth classification independently controls
+ * the vendor-required system field. Fail fast for the impossible
+ * OAuth/system-field combination rather than dropping or misplacing bytes.
  */
-async function buildSystemContext(params: {
+function buildSystemContext(params: {
+  placement: SystemPromptPlacement;
   isOAuth: boolean;
   anthropicMessages: readonly AnthropicMessage[];
   wantCaching: boolean;
   ttl: '5m' | '1h';
   cacheLogger: { debug: (fn: () => string) => void };
   systemInstruction: string | undefined;
-}): Promise<SystemContextResult> {
-  if (params.isOAuth) {
-    return buildOAuthSystemContext(params);
-  }
-  return buildNonOAuthSystemContext(params);
+}): SystemContextResult {
+  // OAuth requires context-prefix placement: the system field must carry ONLY
+  // the Claude Code string, so the assembled prompt must go at the top of the
+  // context. OAuth + system-field is impossible and must fail fast rather than
+  // drop or misplace prompt bytes.
+  assertPlacementCompatibleWithAuth(params.isOAuth, params.placement);
+
+  const messages = placeSystemInstruction({
+    placement: params.placement,
+    anthropicMessages: params.anthropicMessages,
+    wantCaching: params.wantCaching,
+    ttl: params.ttl,
+    cacheLogger: params.cacheLogger,
+    systemInstruction: params.systemInstruction,
+  });
+
+  const systemField = buildSystemField({
+    placement: params.placement,
+    isOAuth: params.isOAuth,
+    wantCaching: params.wantCaching,
+    ttl: params.ttl,
+    systemInstruction: params.systemInstruction,
+  });
+
+  return { systemField, messages };
 }
 
 function mapEffortLevel(
@@ -734,7 +808,8 @@ export async function prepareAnthropicRequest(
     );
   }
 
-  const systemContext = await buildSystemContext({
+  const systemContext = buildSystemContext({
+    placement: params.placement,
     isOAuth: params.isOAuth,
     anthropicMessages,
     wantCaching: effectiveWantCaching,

--- a/packages/providers/src/utils/authToken.ts
+++ b/packages/providers/src/utils/authToken.ts
@@ -7,7 +7,7 @@ import type { ResolvedAuthToken } from '../types/providerRuntime.js';
  */
 
 interface AuthTokenProviderLike {
-  provide?: () => Promise<string | undefined> | string | undefined;
+  provide: () => Promise<string | undefined> | string | undefined;
 }
 
 export function isRuntimeAuthTokenProvider(

--- a/packages/providers/src/utils/systemPromptPlacement.test.ts
+++ b/packages/providers/src/utils/systemPromptPlacement.test.ts
@@ -14,6 +14,7 @@ import {
 } from './systemPromptPlacement.js';
 import { AnthropicProvider } from '../anthropic/AnthropicProvider.js';
 import type { GenerateChatOptions } from '../IProvider.js';
+import type { RuntimeAuthTokenProvider } from '../types/providerRuntime.js';
 
 describe('system prompt placement policy (issue #3136)', () => {
   describe('resolveSystemPromptPlacement', () => {
@@ -29,6 +30,12 @@ describe('system prompt placement policy (issue #3136)', () => {
 
     it('defaults to system-field when a provider declares nothing', () => {
       expect(resolveSystemPromptPlacement(undefined)).toBe('system-field');
+    });
+
+    it('fails fast for an unsupported runtime declaration', () => {
+      expect(() => resolveSystemPromptPlacement('invalid-placement')).toThrow(
+        'SystemPromptPlacementError: unsupported placement declaration invalid-placement',
+      );
     });
   });
 
@@ -77,7 +84,7 @@ describe('system prompt placement policy (issue #3136)', () => {
   describe('Anthropic declares its placement capability', () => {
     const provider = new AnthropicProvider(undefined, undefined, undefined);
 
-    const optionsWithToken = (authToken: string): GenerateChatOptions =>
+    const optionsWithToken = (authToken: unknown): GenerateChatOptions =>
       ({
         resolved: { authToken },
       }) as unknown as GenerateChatOptions;
@@ -96,6 +103,15 @@ describe('system prompt placement policy (issue #3136)', () => {
           optionsWithToken('sk-ant-api03-example-key'),
         ),
       ).toBe('system-field');
+    });
+
+    it('fails fast when declaration receives an unresolved runtime provider', () => {
+      const runtimeProvider: RuntimeAuthTokenProvider = {
+        provide: () => 'sk-ant-oat01-example-oauth',
+      };
+      expect(() =>
+        provider.getSystemPromptPlacement(optionsWithToken(runtimeProvider)),
+      ).toThrow('requires a resolved auth-token string');
     });
   });
 });

--- a/packages/providers/src/utils/systemPromptPlacement.ts
+++ b/packages/providers/src/utils/systemPromptPlacement.ts
@@ -18,14 +18,12 @@
  * The intended contract is that providers DECLARE a capability
  * (`IProvider.getSystemPromptPlacement`) and this module DECIDES and formats.
  *
- * Only the FORMATTING half is live. `formatContextPrefix` below is the sole
- * producer of the context-prefix wrapper and is called by the Anthropic OAuth
- * path. The DECIDING half is not wired: `resolveSystemPromptPlacement` has no
- * production caller, nor does `IProvider.getSystemPromptPlacement`, and the
- * live Anthropic decision is still made from a local `isOAuth` flag in
- * `anthropic/AnthropicRequestPreparation.ts`. See issue #3162 finding D1,
- * which also records that the declaration and the transport flag use different
- * OAuth predicates and can disagree.
+ * Both halves are live. `formatContextPrefix` below is the sole producer of
+ * the context-prefix wrapper and is called by the Anthropic OAuth path.
+ * `resolveSystemPromptPlacement` is the DECIDING half: the live Anthropic
+ * request path declares placement from the RESOLVED token, passes it through
+ * this resolver, and branches system-context construction on the result rather
+ * than on a local `isOAuth` flag (issue #3172).
  */
 
 /**
@@ -64,16 +62,25 @@ export function formatContextPrefix(systemPrompt: string): string {
  * Decide placement from a provider's declared capability.
  *
  * `declaredPlacement` is what the provider states about the request it is
- * about to make. Anthropic declares `context-prefix` when OAuth is active and
- * `system-field` otherwise; every other provider declares `system-field`.
- * Callers must not re-derive this from transport details.
- *
- * NOT YET WIRED: no production caller (issue #3162 finding D1).
+ * about to make. Anthropic declares `context-prefix` when the resolved token
+ * is OAuth and `system-field` otherwise; every other provider declares
+ * `system-field`. Callers must not re-derive this from transport details.
  */
 export function resolveSystemPromptPlacement(
-  declaredPlacement: SystemPromptPlacement | undefined,
+  declaredPlacement: unknown,
 ): SystemPromptPlacement {
-  return declaredPlacement ?? 'system-field';
+  if (declaredPlacement === undefined) {
+    return 'system-field';
+  }
+  if (
+    declaredPlacement === 'system-field' ||
+    declaredPlacement === 'context-prefix'
+  ) {
+    return declaredPlacement;
+  }
+  throw new Error(
+    `SystemPromptPlacementError: unsupported placement declaration ${String(declaredPlacement)}.`,
+  );
 }
 
 /**

--- a/project-plans/issue3172-system-prompt-placement-contract.md
+++ b/project-plans/issue3172-system-prompt-placement-contract.md
@@ -1,0 +1,91 @@
+# Issue #3172 — Wire the system-prompt placement contract
+
+## Purpose
+
+Connect the existing provider declaration and shared placement policy to the live Anthropic request path without changing wire bytes. Reconcile OAuth classification first so both prompt placement and transport are driven by the resolved token rather than by the unresolved token/provider shape.
+
+## Accepted behavior
+
+### AC-1 — One resolved-token OAuth predicate
+
+- Anthropic OAuth classification is defined in one helper and recognizes a resolved token as OAuth exactly when it starts with `sk-ant-oat`.
+- Client authentication, transport behavior, projection, and system-prompt placement use that same predicate or a fact produced by it; no second Anthropic OAuth-prefix predicate is introduced.
+- A runtime auth-token provider is resolved before placement is declared.
+- A runtime provider that resolves to an `sk-ant-oat...` token produces OAuth transport behavior and `context-prefix` placement.
+- A runtime provider that resolves to an `sk-ant-api...` token produces API-key transport behavior and `system-field` placement. The provider object's structural shape alone must not imply OAuth.
+
+### AC-2 — The declared placement capability controls the live request
+
+- The live Anthropic request path invokes `AnthropicProvider.getSystemPromptPlacement` with the resolved-token fact.
+- The returned declaration is passed through `resolveSystemPromptPlacement`.
+- `AnthropicRequestPreparation` selects its system-context representation from the resolved `SystemPromptPlacement`; it does not select placement from `params.isOAuth`.
+- `isOAuth` remains available only for Anthropic transport concerns that are independent of placement, such as authentication headers, tool-name handling, and the vendor-required Claude Code system value.
+
+### AC-3 — Preserve current wire behavior
+
+- For an OAuth token, the Anthropic `system` field remains exactly `You are Claude Code, Anthropic's official CLI for Claude.` and contains no assembled prompt bytes.
+- For an OAuth token, the assembled instruction remains the first user context item with the existing `<system>...</system>` wrapper, boundary text, caching shape, and TTL behavior.
+- For a non-OAuth token, the assembled instruction remains in the Anthropic `system` field with the existing caching shape.
+- No non-Anthropic prompt assembly, formatting, or transport code changes. Existing non-Anthropic prompt bytes remain unchanged by construction and by the full providers test suite.
+
+### AC-4 — Structural enforcement
+
+- ESLint has an error-level, provider-scoped structural rule that rejects the local placement decision pattern this issue removes from `AnthropicRequestPreparation`.
+- The rule does not disable, downgrade, or loosen any existing lint or complexity policy.
+- CI exercises the rule through the existing lint workflow.
+
+### AC-5 — Remove the directly duplicated runtime-token guard
+
+- `AnthropicProvider` uses the existing shared `utils/authToken.ts` runtime-token type guard while resolving tokens.
+- The duplicate local `isRuntimeAuthTokenProvider` implementation is removed.
+- This cleanup is accepted only because it is on the predicate-reconciliation path; no broader auth-token refactor is included.
+
+## Inputs and boundary cases
+
+| Input | Expected OAuth fact | Expected placement | Expected Anthropic prompt location |
+| --- | --- | --- | --- |
+| Resolved string `sk-ant-oat...` | true | `context-prefix` | first user context item; fixed Claude Code string alone in `system` |
+| Resolved string `sk-ant-api...` | false | `system-field` | assembled instruction in `system` |
+| Runtime token provider resolving to `sk-ant-oat...` | true after resolution | `context-prefix` | same bytes as direct OAuth string |
+| Runtime token provider resolving to `sk-ant-api...` | false after resolution | `system-field` | same bytes as direct API-key string |
+| Provider with no placement declaration | n/a | shared default `system-field` | unchanged existing default policy |
+| Prepared prompt-envelope transport token | reuse the auth fact produced when the resolved token was prepared | same declaration and policy result as its underlying token | projection and transport remain byte-identical |
+
+Existing fail-fast behavior for a missing/blank system instruction is unchanged and remains outside the predicate change.
+
+## Behavioral proof (test first)
+
+1. Extend the Bun placement/provider tests with a failing case proving that an unresolved runtime provider object is not classified by shape: its resolved `sk-ant-api...` value declares `system-field` and reaches the non-OAuth wire shape.
+2. Add the complementary runtime-provider `sk-ant-oat...` case proving it declares `context-prefix` and preserves the OAuth wire shape.
+3. Add or extend a focused test proving the live path consumes the provider declaration through the shared resolver rather than selecting placement from `isOAuth`. The assertion must be against the resulting request payload, not a mock-call count.
+4. Keep `AnthropicProvider.systemPrompt.characterization.test.ts` unchanged and run it as the byte-for-byte tripwire.
+5. Run the focused Bun tests for system-prompt placement, Anthropic auth/prompt-envelope parity, and Anthropic prompt characterization; then run the complete repository verification suite.
+6. Run ESLint over the affected provider source. The removed `if (params.isOAuth)` placement branch is the forbidden structural form; the candidate source must pass while that form is rejected by the configured rule.
+
+All new or changed tests use `bun:test`; no Vitest or Node test suite is added or modified.
+
+## Implementation sequence
+
+1. RED: add runtime-token boundary tests that expose the current shape-versus-resolved-token disagreement and live placement wiring gap.
+2. GREEN: centralize Anthropic OAuth-token classification and make the declaration consume the resolved token.
+3. GREEN: resolve the declaration through `resolveSystemPromptPlacement`, pass placement into request preparation, and branch system-context construction on placement.
+4. REFACTOR: replace the duplicate local runtime-token guard with the existing shared guard.
+5. Add the error-level structural lint rule and verify the focused tests/lint.
+6. Run full verification, reviews, and PR gates.
+
+## Scope boundaries
+
+Included: Anthropic OAuth classification needed for placement parity, the existing `IProvider` placement capability signature/usage, Anthropic request preparation, shared auth/placement utilities as needed, focused Bun tests, and the required ESLint structural guard.
+
+Excluded: prompt content changes; changes to non-Anthropic providers; new provider/public subsystems; auth redesign; OAuth refresh behavior changes; caching changes; unrelated cleanup; dependencies; workflows; agent memory; quality-rule weakening; and edits to the characterization tripwire.
+
+## Review triage policy
+
+Every finding is recorded as one of:
+
+- **Blocker-Fix** — prevents an accepted behavior, verification gate, CI gate, conflict-free ancestry, or safe/correct delivery.
+- **In-scope-Fix** — improves or corrects implementation of an accepted behavior without expanding these boundaries.
+- **Reject** — factually incorrect, already satisfied, or harmful to an accepted invariant.
+- **Defer** — valid but outside the accepted scope; optional cleanup and speculative hardening are not implemented here.
+
+At most two local Open Code Review runs and two PR Open Code Review runs are permitted for this issue.


### PR DESCRIPTION
## TLDR

Wires Anthropic's declared system-prompt placement contract into the live request path using the already-resolved credential. API-key requests continue to place the assembled prompt in Anthropic's system field, while OAuth requests keep Anthropic's required Claude Code system value and place the assembled prompt at the front of context with unchanged wrapper, boundary, caching, and TTL bytes.

The change also enforces the placement/auth boundary structurally and adds live SDK-payload tests for direct and rotating runtime credentials.

## Dive Deeper

- Resolves runtime auth providers once, then reuses the same resolved string for client authentication, OAuth classification, placement declaration, projection, and prepared transport.
- Keeps IProvider.getSystemPromptPlacement synchronous: callers pass the resolved token, and unresolved runtime-provider objects fail fast at the Anthropic declaration boundary.
- Validates declarations through resolveSystemPromptPlacement. Unsupported values and OAuth combined with system-field placement fail before SDK transport.
- Separates prompt placement from OAuth-only Anthropic transport details. SystemPromptPlacement alone chooses where assembled instructions go; isOAuth still controls the vendor system value, headers, and tool behavior.
- Preserves the existing byte-level Anthropic characterization tripwire without modifying it.
- Adds an error-level ESLint structural guard that rejects reintroducing auth-controlled placement while preserving the file's existing restricted-syntax selectors.
- Adds Bun behavioral coverage for API-key and OAuth strings, rotating runtime providers, direct/runtime wire parity, projection-to-transport reuse, custom placement, invalid declarations, and pre-transport failures.

## Reviewer Test Plan

1. Run the focused placement and wire-shape coverage:

       bun test packages/providers/src/utils/systemPromptPlacement.test.ts packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts packages/providers/src/anthropic/AnthropicPlacementLintGuard.test.ts packages/providers/src/anthropic/AnthropicProvider.systemPrompt.characterization.test.ts packages/providers/src/anthropic/AnthropicPromptEnvelopeAuthParity.test.ts packages/providers/src/anthropic/AnthropicProvider.stateless.test.ts packages/providers/src/anthropic/AnthropicMessageNormalizer.anchorCache.test.ts

2. Confirm the structural lint boundary and policy guard:

       bunx eslint packages/providers/src/anthropic/AnthropicProvider.ts packages/providers/src/anthropic/AnthropicRequestPreparation.ts packages/providers/src/anthropic/AnthropicPlacementLintGuard.test.ts packages/providers/src/anthropic/AnthropicPlacementWiring.test.ts
       npm run lint:eslint-guard

3. Run repository verification:

       npm run test
       npm run lint
       npm run typecheck
       npm run format
       npm run build
       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

Local verification completed all workspace tests and all official CLI-discovery partitions. The aggregate test and lint commands exceeded the local command ceiling without diagnostics, so their remaining coverage was completed through the repository's workspace commands and disjoint official test/lint partitions. Typecheck, format, build, focused post-format tests, the ESLint policy guard, and the live-model smoke test all passed. After rebasing onto current main, 77 issue-focused and relevant overlap tests passed, along with repository-wide typecheck, format, build, targeted lint, and smoke verification.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent system-prompt placement handling for Anthropic requests.
  * Supports placement in either the provider’s system field or a context prefix.
  * Added validation for unsupported placements and incompatible OAuth configurations.
  * Ensured authentication tokens are resolved before placement and request transmission.

* **Tests**
  * Expanded coverage for placement behavior, token handling, caching, gateways, and prompt transport.
  * Added safeguards to prevent authentication logic from bypassing placement rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
