### PR TITLE
Fix request-scoped system-prompt parameters (Fixes #3176)

### DIFF
--- a/packages/agents/src/agents/executor.ts
+++ b/packages/agents/src/agents/executor.ts
@@ -55,6 +55,7 @@ import {
 } from './executor-tool-dispatch.js';
 import { callModelAndConsumeStream } from './executor-stream-processor.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
+import { resolveProviderForSystemPrompt } from '../core/systemPromptProvider.js';
 
 /**
  * Provider-neutral generation config shape.
@@ -930,6 +931,7 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
       coreMemory: this.runtimeContext.getCoreMemory(),
       mcpInstructions: this.runtimeContext.getMcpInstructions(),
       model: this.definition.modelConfig.model,
+      provider: resolveProviderForSystemPrompt(this.runtimeContext),
       // Derive from the FINAL declaration list, not toolConfig.tools, so the
       // auto-injected complete_task tool is described in the prompt. Otherwise
       // the prompt's tool list disagrees with what the model can actually call

--- a/packages/agents/src/compression/MiddleOutStrategy.ts
+++ b/packages/agents/src/compression/MiddleOutStrategy.ts
@@ -458,6 +458,8 @@ export class MiddleOutStrategy implements CompressionStrategy {
           resolvedOptions,
           invocation,
           fallbackModel: context.runtimeState.model,
+          runtimeState: context.runtimeState,
+          provider,
           source: 'MiddleOutStrategy.callProvider',
         }),
       );

--- a/packages/agents/src/compression/OneShotStrategy.ts
+++ b/packages/agents/src/compression/OneShotStrategy.ts
@@ -336,6 +336,8 @@ export class OneShotStrategy implements CompressionStrategy {
           resolvedOptions,
           invocation,
           fallbackModel: context.runtimeState.model,
+          runtimeState: context.runtimeState,
+          provider,
           source: 'OneShotStrategy.callProvider',
         }),
       );

--- a/packages/agents/src/compression/__tests__/compression-usage-sync.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-usage-sync.test.ts
@@ -85,6 +85,7 @@ function makeMockProvider(
   usage: UsageStats | null = MOCK_USAGE,
 ): IProvider {
   return {
+    name: 'usage-test-provider',
     generateChatCompletion: () => {
       async function* gen(): AsyncGenerator<IContent> {
         // Emit summary text chunk
@@ -396,6 +397,7 @@ describe('CompressionResultMetadata — usage field type (Issue #1211)', () => {
     };
 
     const provider: IProvider = {
+      name: 'usage-stream-test-provider',
       generateChatCompletion: () => {
         async function* gen(): AsyncGenerator<IContent> {
           // First chunk: text with early usage

--- a/packages/agents/src/compression/compressionMemoryExclusion.test.ts
+++ b/packages/agents/src/compression/compressionMemoryExclusion.test.ts
@@ -75,7 +75,8 @@ let projectDir: string;
  * Config is a large class whose real construction requires full session
  * initialization (McpClientManager, MessageBus, tool registry, ...). The MCP
  * accessor is a regression input that the previous compression assembler read;
- * the fixed assembler must ignore it while still reading isInteractive().
+ * the fixed assembler must ignore it. The strategy path still reads
+ * isInteractive() to derive the compressed session's interaction mode.
  */
 function createMcpConfigDouble(mcpInstructions: string): Config {
   const manager = {
@@ -260,10 +261,12 @@ describe('Compression memory exclusion (issue #3174)', () => {
   });
 
   it('excludes core memory and MCP instructions from the assembled compression system instruction', async () => {
-    const config = createMcpConfigDouble(MCP_SENTINEL);
     const instruction = await buildCompressionSystemInstruction(
-      config,
       COMPRESSION_MODEL,
+      {
+        provider: 'compression-test-provider',
+        interactionMode: 'non-interactive',
+      },
     );
 
     expect(typeof instruction).toBe('string');
@@ -276,8 +279,11 @@ describe('Compression memory exclusion (issue #3174)', () => {
   it('still produces a non-empty instruction even without core memory on disk', async () => {
     rmSync(join(projectDir, '.llxprt'), { recursive: true, force: true });
     const instruction = await buildCompressionSystemInstruction(
-      undefined,
       COMPRESSION_MODEL,
+      {
+        provider: 'compression-test-provider',
+        interactionMode: 'non-interactive',
+      },
     );
 
     expect(typeof instruction).toBe('string');

--- a/packages/agents/src/compression/compressionSystemPrompt.test.ts
+++ b/packages/agents/src/compression/compressionSystemPrompt.test.ts
@@ -14,7 +14,7 @@
  * helper now fills the gap.
  */
 
-import { describe, it, expect, vi } from 'bun:test';
+import { describe, it, expect, vi, type Mock } from 'bun:test';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type {
   CompressionContext,
@@ -26,14 +26,30 @@ import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/Ag
 import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
 import type { Logger } from '@vybestack/llxprt-code-core/core/logger.js';
 import type { PromptResolver } from '@vybestack/llxprt-code-core/prompt-config/prompt-resolver.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
 import { OneShotStrategy } from './OneShotStrategy.js';
+import { buildCompressionSystemInstruction } from './compressionSystemPrompt.js';
 import { MiddleOutStrategy } from './MiddleOutStrategy.js';
 import { runVerificationPass } from './utils.js';
+import {
+  CompressionLoadBalancingProvider,
+  type CompressionLoadBalancerCandidate,
+} from '../core/CompressionLoadBalancingProvider.js';
 
 const COMPRESSION_SYSTEM_PROMPT = 'COMPRESSION_CORE_PROMPT';
 
 void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
-  getCoreSystemPromptAsync: vi.fn(async () => COMPRESSION_SYSTEM_PROMPT),
+  // Echo interactionMode and provider into the returned prompt so tests can
+  // assert on OBSERVABLE PROMPT CONTENT (per dev-docs/RULES.md — no mock
+  // theater). When these args are absent the echo surfaces a sentinel,
+  // which is exactly the regression these tests guard against (issue #3176).
+  getCoreSystemPromptAsync: vi.fn(async (args: Record<string, unknown>) => {
+    const mode = args.interactionMode ?? 'NO_MODE';
+    const provider = args.provider ?? 'NO_PROVIDER';
+    const model = args.model ?? 'NO_MODEL';
+    return `${COMPRESSION_SYSTEM_PROMPT} mode=${mode} provider=${provider} model=${model}`;
+  }),
   getCompressionPrompt: vi.fn(() => 'COMPRESS_PROMPT'),
 }));
 
@@ -99,6 +115,8 @@ function buildContext(
     history: IContent[];
     preserveThreshold: number;
     compressionVerification: boolean;
+    subagentName: string;
+    config: Config;
   }> = {},
 ): CompressionContext {
   const contextProviderRuntime = {
@@ -107,7 +125,7 @@ function buildContext(
       set: () => {},
       getProviderSettings: () => ({}),
     },
-    config: undefined,
+    config: overrides.config,
     runtimeId: 'test-provider-runtime',
     metadata: { source: 'test' },
   };
@@ -115,6 +133,7 @@ function buildContext(
   const resolveProvider = (): CompressionProviderResult => ({
     provider,
     runtime: contextProviderRuntime,
+    config: overrides.config,
   });
 
   const runtimeState: AgentRuntimeState = {
@@ -123,6 +142,9 @@ function buildContext(
     model: 'test-model',
     sessionId: 'test-session',
     updatedAt: Date.now(),
+    ...(overrides.subagentName !== undefined
+      ? { subagentName: overrides.subagentName }
+      : {}),
   };
 
   const runtimeContext = {
@@ -169,6 +191,7 @@ function buildContext(
     },
     promptId: 'test-prompt',
     compressionVerification: overrides.compressionVerification,
+    config: overrides.config,
   };
 }
 
@@ -191,7 +214,7 @@ describe('Compression system instruction (issue #3136, Step 3)', () => {
     const sysInstr = captured[0].systemInstruction;
     expect(typeof sysInstr).toBe('string');
     expect((sysInstr as string).length).toBeGreaterThan(0);
-    expect(sysInstr).toBe(COMPRESSION_SYSTEM_PROMPT);
+    expect(sysInstr).toContain(COMPRESSION_SYSTEM_PROMPT);
   });
 
   it('MiddleOutStrategy.callProvider sends a non-empty systemInstruction', async () => {
@@ -211,7 +234,7 @@ describe('Compression system instruction (issue #3136, Step 3)', () => {
     const sysInstr = captured[0].systemInstruction;
     expect(typeof sysInstr).toBe('string');
     expect((sysInstr as string).length).toBeGreaterThan(0);
-    expect(sysInstr).toBe(COMPRESSION_SYSTEM_PROMPT);
+    expect(sysInstr).toContain(COMPRESSION_SYSTEM_PROMPT);
   });
 
   it('runVerificationPass sends a non-empty systemInstruction', async () => {
@@ -225,7 +248,7 @@ describe('Compression system instruction (issue #3136, Step 3)', () => {
     const sysInstr = captured[0].systemInstruction;
     expect(typeof sysInstr).toBe('string');
     expect((sysInstr as string).length).toBeGreaterThan(0);
-    expect(sysInstr).toBe(COMPRESSION_SYSTEM_PROMPT);
+    expect(sysInstr).toContain(COMPRESSION_SYSTEM_PROMPT);
   });
 
   it('OneShotStrategy with verification sends systemInstruction on BOTH calls', async () => {
@@ -243,7 +266,228 @@ describe('Compression system instruction (issue #3136, Step 3)', () => {
     // First call = initial compression, second = verification pass
     expect(captured.length).toBe(2);
     for (const opts of captured) {
-      expect(opts.systemInstruction).toBe(COMPRESSION_SYSTEM_PROMPT);
+      expect(opts.systemInstruction).toContain(COMPRESSION_SYSTEM_PROMPT);
     }
+  });
+});
+
+/**
+ * Issue #3176, findings D5 + D8 — compression prompt assembly must use the
+ * request-scoped provider and the compressed session's interaction mode.
+ *
+ * Each assertion is on the system instruction CONTENT delivered to the
+ * provider (the mock echoes mode= and provider= into the string).
+ */
+describe('Compression request-scoped provider and interactionMode (issue #3176, D5+D8)', () => {
+  function makeInteractiveConfig(interactive: boolean): Config {
+    return {
+      isInteractive: () => interactive,
+      getMcpClientManager: () => undefined,
+    } as unknown as Config;
+  }
+
+  // T8
+  it('renders interactionMode=subagent when compressing a subagent runtime (D8)', async () => {
+    const captured: RuntimeGenerateChatOptions[] = [];
+    const provider = createCapturingProvider(captured);
+    const history = generateHistory(20);
+    const context = buildContext(provider, {
+      history,
+      subagentName: 'typescript-expert',
+    });
+
+    const strategy = new OneShotStrategy();
+    await strategy.compress(context);
+
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+    expect(captured[0].systemInstruction).toContain('mode=subagent');
+  });
+
+  // T9
+  it('keeps interactive mode for a main-agent runtime (D8 regression)', async () => {
+    const captured: RuntimeGenerateChatOptions[] = [];
+    const provider = createCapturingProvider(captured);
+    const history = generateHistory(20);
+    const context = buildContext(provider, {
+      history,
+      config: makeInteractiveConfig(true),
+    });
+
+    const strategy = new OneShotStrategy();
+    await strategy.compress(context);
+
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+    const sysInstr = captured[0].systemInstruction as string;
+    expect(sysInstr).toContain('mode=interactive');
+    expect(sysInstr).not.toContain('mode=subagent');
+  });
+
+  it('keeps non-interactive mode for a non-interactive main-agent runtime', async () => {
+    const captured: RuntimeGenerateChatOptions[] = [];
+    const provider = createCapturingProvider(captured);
+    const history = generateHistory(20);
+    const context = buildContext(provider, {
+      history,
+      config: makeInteractiveConfig(false),
+    });
+
+    const strategy = new OneShotStrategy();
+    await strategy.compress(context);
+
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+    const sysInstr = captured[0].systemInstruction as string;
+    expect(sysInstr).toContain('mode=non-interactive');
+    expect(sysInstr).not.toContain('mode=subagent');
+  });
+
+  // T10
+  it('resolves the compression provider name, not the foreground one (D5)', async () => {
+    const captured: RuntimeGenerateChatOptions[] = [];
+    const provider = createCapturingProvider(captured);
+    // Override the name to a distinct compression provider identity.
+    (provider as { name: string }).name = 'compression-provider-beta';
+    const history = generateHistory(20);
+    const context = buildContext(provider, { history });
+
+    const strategy = new OneShotStrategy();
+    await strategy.compress(context);
+
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+    const sysInstr = captured[0].systemInstruction as string;
+    expect(sysInstr).toContain('provider=compression-provider-beta');
+    expect(sysInstr).not.toContain('provider=NO_PROVIDER');
+  });
+
+  it('assembles for a concrete provider named like the load-balancer wrapper', async () => {
+    const captured: RuntimeGenerateChatOptions[] = [];
+    const provider = createCapturingProvider(captured);
+    (provider as { name: string }).name = 'load-balancer';
+    const context = buildContext(provider, { history: generateHistory(20) });
+
+    const strategy = new OneShotStrategy();
+    await strategy.compress(context);
+
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+    expect(captured[0].systemInstruction).toContain('provider=load-balancer');
+  });
+
+  it('rejects a blank compression provider identity', async () => {
+    await expect(
+      buildCompressionSystemInstruction('model-a', {
+        provider: '   ',
+        interactionMode: 'non-interactive',
+      }),
+    ).rejects.toThrow('Compression provider identity is required');
+  });
+});
+
+function createLoadBalancerCandidate(
+  providerName: string,
+  model: string,
+  captured: RuntimeGenerateChatOptions[],
+  failure?: Error,
+): CompressionLoadBalancerCandidate {
+  const provider = createCapturingProvider(captured);
+  (provider as { name: string }).name = providerName;
+  if (failure) {
+    provider.generateChatCompletion = (options) => {
+      captured.push(options);
+      throw failure;
+    };
+  }
+  return {
+    profileName: `${providerName}-profile`,
+    provider,
+    runtime: {
+      settingsService:
+        {} as CompressionLoadBalancerCandidate['runtime']['settingsService'],
+    },
+    config: undefined,
+    resolved: { model },
+    invocation: {} as CompressionLoadBalancerCandidate['invocation'],
+  };
+}
+
+describe('Load-balanced compression prompt assembly (issue #3176, D5+D8)', () => {
+  it('renders the selected round-robin candidate provider and model', async () => {
+    const firstCalls: RuntimeGenerateChatOptions[] = [];
+    const secondCalls: RuntimeGenerateChatOptions[] = [];
+    const provider = new CompressionLoadBalancingProvider(
+      'round-robin',
+      [
+        createLoadBalancerCandidate('provider-a', 'model-a', firstCalls),
+        createLoadBalancerCandidate('provider-b', 'model-b', secondCalls),
+      ],
+      1,
+      'subagent',
+    );
+
+    for await (const _chunk of provider.generateChatCompletion({
+      contents: [],
+    })) {
+      // Drain the selected provider response.
+    }
+
+    expect(firstCalls).toHaveLength(0);
+    expect(secondCalls).toHaveLength(1);
+    expect(secondCalls[0].systemInstruction).toContain(
+      'mode=subagent provider=provider-b model=model-b',
+    );
+  });
+
+  it('re-renders provider and model for every failover candidate', async () => {
+    const firstCalls: RuntimeGenerateChatOptions[] = [];
+    const secondCalls: RuntimeGenerateChatOptions[] = [];
+    const provider = new CompressionLoadBalancingProvider(
+      'failover',
+      [
+        createLoadBalancerCandidate(
+          'provider-a',
+          'model-a',
+          firstCalls,
+          new Error('primary unavailable'),
+        ),
+        createLoadBalancerCandidate('provider-b', 'model-b', secondCalls),
+      ],
+      0,
+      'interactive',
+    );
+
+    for await (const _chunk of provider.generateChatCompletion({
+      contents: [],
+    })) {
+      // Drain the successful failover response.
+    }
+
+    expect(firstCalls[0].systemInstruction).toContain(
+      'mode=interactive provider=provider-a model=model-a',
+    );
+    expect(secondCalls[0].systemInstruction).toContain(
+      'mode=interactive provider=provider-b model=model-b',
+    );
+  });
+
+  it('defers assembly until OneShotStrategy selects a concrete candidate', async () => {
+    (
+      getCoreSystemPromptAsync as Mock<typeof getCoreSystemPromptAsync>
+    ).mockClear();
+    const calls: RuntimeGenerateChatOptions[] = [];
+    const provider = new CompressionLoadBalancingProvider(
+      'round-robin',
+      [createLoadBalancerCandidate('provider-a', 'model-a', calls)],
+      0,
+      'subagent',
+    );
+    const context = buildContext(provider, {
+      history: generateHistory(20),
+      subagentName: 'worker',
+    });
+
+    await new OneShotStrategy().compress(context);
+
+    expect(getCoreSystemPromptAsync).toHaveBeenCalledTimes(1);
+    expect(calls[0].systemInstruction).toContain(
+      'mode=subagent provider=provider-a model=model-a',
+    );
   });
 });

--- a/packages/agents/src/compression/compressionSystemPrompt.ts
+++ b/packages/agents/src/compression/compressionSystemPrompt.ts
@@ -27,14 +27,95 @@ import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/promp
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+
+type CompressionInteractionMode =
+  | 'interactive'
+  | 'non-interactive'
+  | 'subagent';
+
+export type { CompressionInteractionMode };
+
+/** Brands the compression-specific load-balancer wrapper. */
+export const COMPRESSION_LOAD_BALANCER_WRAPPER = Symbol(
+  'compression-load-balancer-wrapper',
+);
+
+interface CompressionLoadBalancerWrapper extends IProvider {
+  readonly [COMPRESSION_LOAD_BALANCER_WRAPPER]: true;
+}
+
+/**
+ * Derives the interaction mode from `config.isInteractive()` when no explicit
+ * mode is supplied. Shared by both compression entry points.
+ */
+function deriveInteractiveMode(
+  config: Config | undefined,
+): CompressionInteractionMode {
+  if (
+    config != null &&
+    typeof config.isInteractive === 'function' &&
+    config.isInteractive() === true
+  ) {
+    return 'interactive';
+  }
+  return 'non-interactive';
+}
+
+/**
+ * Returns `true` when the runtime state belongs to a subagent — the marker
+ * that makes compression render `'subagent'` (issue #3176, D8).
+ */
+function isSubagentRuntime(runtimeState: AgentRuntimeState): boolean {
+  return (
+    typeof runtimeState.subagentName === 'string' &&
+    runtimeState.subagentName.trim() !== ''
+  );
+}
+
+/**
+ * Single derivation point for the compressed session's interaction mode
+ * (issue #3176, D8). Returns `'subagent'` when the runtime state belongs to a
+ * subagent, otherwise falls back to `config.isInteractive()`.
+ *
+ * Used by {@link buildCompressionChatOptions} (ordinary compression) and by
+ * {@link CompressionLoadBalancingProvider} (load-balanced compression) so the
+ * mode is consistent across every candidate.
+ */
+export function deriveCompressionInteractionMode(
+  config: Config | undefined,
+  runtimeState: AgentRuntimeState,
+): CompressionInteractionMode {
+  return isSubagentRuntime(runtimeState)
+    ? 'subagent'
+    : deriveInteractiveMode(config);
+}
+
+/** Validates the concrete provider identity for ordinary compression. */
+function requireCompressionProvider(providerName: string): string {
+  if (providerName.trim() === '') {
+    throw new Error('Compression provider identity is required');
+  }
+  return providerName;
+}
+
+function isCompressionLoadBalancerWrapper(
+  provider: IProvider,
+): provider is CompressionLoadBalancerWrapper {
+  return (
+    COMPRESSION_LOAD_BALANCER_WRAPPER in provider &&
+    provider[COMPRESSION_LOAD_BALANCER_WRAPPER] === true
+  );
+}
 
 /**
  * Build the system instruction for a compression request.
  *
  * Passes no `userMemory`, an explicit empty `coreMemory` string, no
  * `mcpInstructions`, no tools (`includeSubagentDelegation` is therefore
- * `false`), and `interactionMode` derived from `config.isInteractive()`.
+ * `false`), and the caller-supplied request interaction mode.
  *
  * The empty `coreMemory` string (not `undefined`) is deliberate: when
  * `coreMemory` is `undefined`, `getCoreSystemPromptAsync` loads
@@ -45,28 +126,30 @@ import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/run
  * receives only the base instruction appropriate to its model and interaction
  * mode — never the caller's core memory or MCP instructions (issue #3174).
  *
- * `config` is still accepted so the interaction mode can be derived; it is no
- * longer consulted for MCP instructions.
+ * The `provider` and `interactionMode` are caller-supplied and request-scoped
+ * (issue #3176, D5 + D8). Ordinary compression derives them through
+ * {@link buildCompressionChatOptions}; load-balanced compression supplies the
+ * selected candidate provider and the compressed session's interaction mode.
  *
- * @param config - The Config to read interaction mode from
  * @param model  - The resolved model (same as `resolved.model` on the wire)
- * @returns The assembled system instruction, or `undefined` when the
- *          prompt is empty
+ * @param options - Request-scoped `provider` and `interactionMode`; both
+ *                  required, derived by {@link buildCompressionChatOptions}
+ * @returns The assembled system instruction
  */
 export async function buildCompressionSystemInstruction(
-  config: Config | undefined,
   model: string,
+  options: {
+    provider: string;
+    interactionMode: CompressionInteractionMode;
+  },
 ): Promise<string> {
-  const interactionMode =
-    config != null &&
-    typeof config.isInteractive === 'function' &&
-    config.isInteractive() === true
-      ? 'interactive'
-      : 'non-interactive';
+  const interactionMode = options.interactionMode;
+  const provider = requireCompressionProvider(options.provider);
 
   const corePrompt = await getCoreSystemPromptAsync({
     coreMemory: '',
     model,
+    provider,
     tools: undefined,
     includeSubagentDelegation: false,
     interactionMode,
@@ -96,12 +179,27 @@ export async function buildCompressionChatOptions(params: {
   invocation: RuntimeGenerateChatOptions['invocation'] | undefined;
   fallbackModel: string;
   source: string;
+  runtimeState: AgentRuntimeState;
+  provider: IProvider;
 }): Promise<RuntimeGenerateChatOptions> {
   const config = params.resolvedConfig ?? params.fallbackConfig;
-  const systemInstruction = await buildCompressionSystemInstruction(
+
+  // Single derivation point for the request-scoped provider and the
+  // compressed session's interaction mode (issue #3176, D5 + D8). All three
+  // call sites thread these through here so none can drift.
+  const providerName = requireCompressionProvider(params.provider.name);
+  const interactionMode = deriveCompressionInteractionMode(
     config,
-    params.resolvedOptions?.model ?? params.fallbackModel,
+    params.runtimeState,
   );
+  // Only the branded wrapper defers assembly. A concrete provider that happens
+  // to use the same display name must still receive its own prompt.
+  const systemInstruction = isCompressionLoadBalancerWrapper(params.provider)
+    ? undefined
+    : await buildCompressionSystemInstruction(
+        params.resolvedOptions?.model ?? params.fallbackModel,
+        { provider: providerName, interactionMode },
+      );
 
   return {
     contents: params.contents,

--- a/packages/agents/src/compression/utils.ts
+++ b/packages/agents/src/compression/utils.ts
@@ -296,6 +296,8 @@ export async function runVerificationPass(
         resolvedOptions,
         invocation,
         fallbackModel: context.runtimeState.model,
+        runtimeState: context.runtimeState,
+        provider,
         source: 'runVerificationPass',
       }),
     );

--- a/packages/agents/src/core/ChatSessionFactory.byteCompatibility.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.byteCompatibility.test.ts
@@ -246,6 +246,7 @@ describe('buildSystemInstruction byte-for-byte compatibility with pre-change mai
       makeConfig(row),
       [],
       row.envParts,
+      undefined,
       MODEL,
     );
     const legacy = await legacyBuildSystemInstruction(

--- a/packages/agents/src/core/ChatSessionFactory.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.test.ts
@@ -118,7 +118,9 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     getMcpInstructions: vi.fn().mockReturnValue(undefined),
     isInteractive: vi.fn().mockReturnValue(true),
     getWorkingDir: vi.fn().mockReturnValue('/workspace'),
-    getSettingsService: vi.fn().mockReturnValue({}),
+    getSettingsService: vi.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue(undefined),
+    }),
     getContentGeneratorConfig: vi.fn().mockReturnValue({}),
     getModel: vi.fn().mockReturnValue('gemini-2.5-flash'),
     getToolRegistry: vi.fn().mockReturnValue(undefined),
@@ -247,7 +249,7 @@ describe('buildSystemInstruction', () => {
       getUserMemory: vi.fn().mockReturnValue('remember this'),
     });
 
-    await buildSystemInstruction(config, ['tool_a'], [], MODEL);
+    await buildSystemInstruction(config, ['tool_a'], [], undefined, MODEL);
 
     expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
       expect.objectContaining({ userMemory: 'remember this' }),
@@ -259,7 +261,7 @@ describe('buildSystemInstruction', () => {
       getCoreMemory: vi.fn().mockReturnValue('core memory'),
     });
 
-    await buildSystemInstruction(config, ['tool_a'], [], MODEL);
+    await buildSystemInstruction(config, ['tool_a'], [], undefined, MODEL);
 
     expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
       expect.objectContaining({ coreMemory: 'core memory' }),
@@ -271,7 +273,7 @@ describe('buildSystemInstruction', () => {
       getMcpInstructions: vi.fn().mockReturnValue('use the mcp tool'),
     });
 
-    await buildSystemInstruction(config, [], [], MODEL);
+    await buildSystemInstruction(config, [], [], undefined, MODEL);
 
     expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
       expect.objectContaining({ mcpInstructions: 'use the mcp tool' }),
@@ -286,7 +288,13 @@ describe('buildSystemInstruction', () => {
       getCoreSystemPromptAsync as Mock<typeof getCoreSystemPromptAsync>
     ).mockResolvedValue('base prompt');
 
-    const result = await buildSystemInstruction(config, [], envParts, MODEL);
+    const result = await buildSystemInstruction(
+      config,
+      [],
+      envParts,
+      undefined,
+      MODEL,
+    );
 
     expect(result).toBe('CWD: /workspace\n\nbase prompt');
   });
@@ -298,7 +306,7 @@ describe('buildSystemInstruction', () => {
       getJitMemoryForPath: vi.fn().mockResolvedValue('jit memory content'),
     });
 
-    await buildSystemInstruction(config, [], [], MODEL);
+    await buildSystemInstruction(config, [], [], undefined, MODEL);
 
     expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -318,7 +326,13 @@ describe('buildSystemInstruction', () => {
     ).mockResolvedValueOnce(true);
 
     const config = makeConfig();
-    await buildSystemInstruction(config, ['task', 'list_subagents'], [], MODEL);
+    await buildSystemInstruction(
+      config,
+      ['task', 'list_subagents'],
+      [],
+      undefined,
+      MODEL,
+    );
 
     expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
       expect.objectContaining({ includeSubagentDelegation: true }),
@@ -330,7 +344,7 @@ describe('buildSystemInstruction', () => {
       isInteractive: vi.fn().mockReturnValue(false),
     });
 
-    await buildSystemInstruction(config, [], [], MODEL);
+    await buildSystemInstruction(config, [], [], undefined, MODEL);
 
     expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
       expect.objectContaining({ interactionMode: 'non-interactive' }),
@@ -846,7 +860,7 @@ describe('createChatSession: model identity in system prompt (issue #3138)', () 
     ).toHaveBeenCalledWith('profile-model', 'openai');
   });
 
-  it('reflects a provider switch in the prompt model on the next chat creation', async () => {
+  it('pairs the runtime provider with the current config model', async () => {
     const config = makeConfig({
       getModel: vi.fn().mockReturnValue('claude-opus-4'),
     });
@@ -868,7 +882,10 @@ describe('createChatSession: model identity in system prompt (issue #3138)', () 
     });
 
     expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'claude-opus-4' }),
+      expect.objectContaining({
+        model: 'claude-opus-4',
+        provider: 'openai',
+      }),
     );
   });
 

--- a/packages/agents/src/core/ChatSessionFactory.tokenReestimate.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.tokenReestimate.test.ts
@@ -109,7 +109,9 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     getMcpInstructions: vi.fn().mockReturnValue(undefined),
     isInteractive: vi.fn().mockReturnValue(true),
     getWorkingDir: vi.fn().mockReturnValue('/workspace'),
-    getSettingsService: vi.fn().mockReturnValue({}),
+    getSettingsService: vi.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue(undefined),
+    }),
     getContentGeneratorConfig: vi.fn().mockReturnValue({}),
     getModel: vi.fn().mockReturnValue('gemini-2.5-flash'),
     getToolRegistry: vi.fn().mockReturnValue(undefined),

--- a/packages/agents/src/core/ChatSessionFactory.ts
+++ b/packages/agents/src/core/ChatSessionFactory.ts
@@ -114,14 +114,15 @@ export function buildSettingsSnapshot(
  *
  * Memory sourcing is shared with the subagent builder via
  * {@link resolvePromptMemory} so both execution contexts apply the same JIT
- * policy (issue #3173). This is the FULL path used by startChat — differs from
- * the lightweight path in clientLlmUtilities which skips env context, core
- * memory, and JIT memory.
+ * policy (issue #3173). This is the FULL path used by startChat — it differs
+ * from the lightweight path in clientLlmUtilities, which skips env context and
+ * JIT memory; both paths pass core memory.
  */
 export async function buildSystemInstruction(
   config: Config,
   enabledToolNames: string[],
   envParts: Array<{ text?: string }>,
+  provider: string | undefined,
   model: string,
 ): Promise<string> {
   const { userMemory, coreMemory, mcpInstructions } =
@@ -138,6 +139,7 @@ export async function buildSystemInstruction(
     coreMemory,
     mcpInstructions,
     model,
+    provider,
     tools: enabledToolNames,
     includeSubagentDelegation,
     interactionMode,
@@ -330,6 +332,24 @@ async function buildChatFromRuntime(
 }
 
 /**
+ * Applies the config's tokenizer factory to a history service, if available.
+ */
+function applyTokenizerFactory(
+  config: Config,
+  historyService: HistoryService,
+): void {
+  const getTokenizerFactory = (config as Config & Record<string, unknown>)[
+    'getTokenizerFactory'
+  ];
+  if (typeof getTokenizerFactory === 'function') {
+    const tokenizerFactory = getTokenizerFactory.call(config);
+    if (tokenizerFactory) {
+      historyService.setTokenizerFactory(tokenizerFactory);
+    }
+  }
+}
+
+/**
  * Stateful factory: creates a ChatSession session.
  * Reuses stored HistoryService when available, creates a new one otherwise.
  * Configures thinking, loads the agent runtime, builds tool declarations.
@@ -361,15 +381,7 @@ export async function createChatSession(
     createHistoryService,
   );
 
-  const getTokenizerFactory = (config as Config & Record<string, unknown>)[
-    'getTokenizerFactory'
-  ];
-  if (typeof getTokenizerFactory === 'function') {
-    const tokenizerFactory = getTokenizerFactory.call(config);
-    if (tokenizerFactory) {
-      historyService.setTokenizerFactory(tokenizerFactory);
-    }
-  }
+  applyTokenizerFactory(config, historyService);
 
   const enabledToolNames = getEnabledToolNamesForPrompt(config);
   const envParts = await getEnvironmentContext(config);
@@ -381,16 +393,25 @@ export async function createChatSession(
     config,
     enabledToolNames,
     envParts,
+    runtimeState.provider,
     model,
   );
 
-  // Per-turn assembler: reuses the EXISTING buildSystemInstruction with a
-  // model sourced from the provider at request time (issue #3136). This
-  // keeps coreMemory explicit (already passed inside buildSystemInstruction)
-  // so no two-file disk read happens per turn.
+  // Per-turn assembler: reuses the EXISTING buildSystemInstruction with the
+  // provider and model sourced from the runtime at request time (issue #3136,
+  // #3176). This keeps coreMemory explicit (already passed inside
+  // buildSystemInstruction) so no two-file disk read happens per turn, and
+  // threads the request-scoped provider so template resolution stays coherent
+  // with the model at every boundary including load-balancer rerender.
   const systemPromptAssembler: SystemPromptAssembler = {
-    assemble: (turnModel: string) =>
-      buildSystemInstruction(config, enabledToolNames, envParts, turnModel),
+    assemble: (request: { provider: string | undefined; model: string }) =>
+      buildSystemInstruction(
+        config,
+        enabledToolNames,
+        envParts,
+        request.provider,
+        request.model,
+      ),
   };
 
   historyService.setActiveTokenizationTarget(model, runtimeState.provider);

--- a/packages/agents/src/core/CompressionLoadBalancingProvider.ts
+++ b/packages/agents/src/core/CompressionLoadBalancingProvider.ts
@@ -8,6 +8,11 @@ import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/r
 import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import {
+  buildCompressionSystemInstruction,
+  COMPRESSION_LOAD_BALANCER_WRAPPER,
+  type CompressionInteractionMode,
+} from '../compression/compressionSystemPrompt.js';
 
 /**
  * A single resolved candidate inside a load-balanced compression profile.
@@ -21,18 +26,41 @@ export interface CompressionLoadBalancerCandidate {
   invocation: NonNullable<RuntimeGenerateChatOptions['invocation']>;
 }
 
+function requireCandidateModel(
+  candidate: CompressionLoadBalancerCandidate,
+): string {
+  const model = candidate.resolved?.model;
+  if (!model?.trim()) {
+    throw new Error(
+      `Compression subprofile '${candidate.profileName}' has no resolved model`,
+    );
+  }
+  return model;
+}
+
 /**
  * IProvider adapter that fans out across multiple resolved compression
  * sub-profiles using either round-robin or failover strategy.
  */
 export class CompressionLoadBalancingProvider implements IProvider {
   readonly name = 'load-balancer';
+  readonly [COMPRESSION_LOAD_BALANCER_WRAPPER] = true;
   private readonly selectedRoundRobinCandidate?: CompressionLoadBalancerCandidate;
 
+  /**
+   * @param strategy - round-robin or failover fan-out strategy.
+   * @param candidates - resolved compression sub-profile candidates.
+   * @param initialIndex - starting round-robin index.
+   * @param interactionMode - the compressed session's interaction mode
+   *   (issue #3176, D8). Used to reassemble the system instruction per
+   *   candidate so the load-balancer wrapper name (`'load-balancer'`) is
+   *   never used as the executing provider template identity.
+   */
   constructor(
     private readonly strategy: 'round-robin' | 'failover',
     private readonly candidates: readonly CompressionLoadBalancerCandidate[],
     initialIndex: number,
+    private readonly interactionMode: CompressionInteractionMode,
   ) {
     if (candidates.length === 0) {
       throw new Error('Load-balanced compression profile requires subprofiles');
@@ -48,7 +76,7 @@ export class CompressionLoadBalancingProvider implements IProvider {
   }
 
   getDefaultModel(): string {
-    return this.candidates[0]?.resolved?.model ?? '';
+    return requireCandidateModel(this.candidates[0]);
   }
 
   getServerTools(): string[] {
@@ -109,6 +137,20 @@ export class CompressionLoadBalancingProvider implements IProvider {
     candidate: CompressionLoadBalancerCandidate,
     options: RuntimeGenerateChatOptions,
   ): AsyncIterableIterator<IContent> {
+    // Reassemble the system instruction per candidate using the candidate's
+    // CONCRETE provider name and resolved model — not the wrapper's
+    // 'load-balancer' name (issue #3176, D5). This runs on every round-robin
+    // selection and every failover attempt so each candidate gets its own
+    // provider/model-specific template.
+    const candidateModel = requireCandidateModel(candidate);
+    const systemInstruction = await buildCompressionSystemInstruction(
+      candidateModel,
+      {
+        provider: candidate.provider.name,
+        interactionMode: this.interactionMode,
+      },
+    );
+
     const candidateOptions: RuntimeGenerateChatOptions = {
       ...options,
       runtime: candidate.runtime,
@@ -120,6 +162,7 @@ export class CompressionLoadBalancingProvider implements IProvider {
         ...candidate.resolved,
       },
       invocation: candidate.invocation,
+      systemInstruction,
       metadata: {
         ...options.metadata,
         ...(candidate.invocation.metadata as Record<string, unknown>),

--- a/packages/agents/src/core/CompressionProfileResolver.ts
+++ b/packages/agents/src/core/CompressionProfileResolver.ts
@@ -19,12 +19,14 @@ import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runt
 import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { CompressionProviderResult } from '@vybestack/llxprt-code-core/core/compression/types.js';
 import { CompressionProfileNotFoundError } from '@vybestack/llxprt-code-core/core/compression/types.js';
 
 import { CompressionLoadBalancingProvider } from './CompressionLoadBalancingProvider.js';
 import type { CompressionLoadBalancerCandidate } from './CompressionLoadBalancingProvider.js';
+import { deriveCompressionInteractionMode } from '../compression/compressionSystemPrompt.js';
 
 /**
  * Callbacks and runtime state required to resolve a compression profile
@@ -33,6 +35,11 @@ import type { CompressionLoadBalancerCandidate } from './CompressionLoadBalancin
 export interface CompressionProfileResolverContext {
   /** The base provider-runtime snapshot (runtimeId, metadata, config). */
   readonly providerRuntime: ProviderRuntimeContext;
+  /**
+   * The runtime state of the session being compressed. Used to derive the
+   * interaction mode for load-balanced compression (issue #3176, D8).
+   */
+  readonly runtimeState: AgentRuntimeState;
   /**
    * Resolve an explicit provider by name for a compression sub-profile.
    * Throws CompressionProfileNotFoundError when unavailable.
@@ -460,10 +467,17 @@ export async function resolveLoadBalancedCompressionProvider(
       (initialIndex + 1) % candidates.length,
     );
   }
+  // Derive the interaction mode ONCE from the compressed session so every
+  // candidate gets the same mode (issue #3176, D8).
+  const interactionMode = deriveCompressionInteractionMode(
+    config,
+    ctx.runtimeState,
+  );
   const provider = new CompressionLoadBalancingProvider(
     strategy,
     candidates,
     initialIndex,
+    interactionMode,
   );
   const runtimeId = `${ctx.providerRuntime.runtimeId}::compression-profile:${profileName}`;
   const settings = new SettingsService();

--- a/packages/agents/src/core/__tests__/structuralAccess.characterization.test.ts
+++ b/packages/agents/src/core/__tests__/structuralAccess.characterization.test.ts
@@ -399,9 +399,11 @@ import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 
 function makeConfig(): Config {
   return {
-    getUserMemory: vi.fn().mockReturnValue(''),
-    getMcpInstructions: vi.fn().mockReturnValue(undefined),
-    isInteractive: vi.fn().mockReturnValue(true),
+    getUserMemory: () => '',
+    getCoreMemory: () => '',
+    getMcpInstructions: () => undefined,
+    getSettingsService: () => ({ get: () => 'test-provider' }),
+    isInteractive: () => true,
   } as unknown as Config;
 }
 

--- a/packages/agents/src/core/chatSession.systemPromptAssembly.test.ts
+++ b/packages/agents/src/core/chatSession.systemPromptAssembly.test.ts
@@ -179,7 +179,7 @@ describe('ChatSession per-turn system prompt assembly (issue #3136)', () => {
 
   it('sendMessage: renders the fresh provider model after a mid-session /model change', async () => {
     const assembler: SystemPromptAssembler = {
-      assemble: async (model) => `[model=${model}]`,
+      assemble: async ({ model }) => `[model=${model}]`,
     };
     const fx = buildFixture(assembler, 'old-model');
 
@@ -205,7 +205,7 @@ describe('ChatSession per-turn system prompt assembly (issue #3136)', () => {
 
   it('sendMessage: recomputes base token offset when the assembled prompt changes', async () => {
     const assembler: SystemPromptAssembler = {
-      assemble: async (model) => `Prompt for model ${model}.`,
+      assemble: async ({ model }) => `Prompt for model ${model}.`,
     };
     const fx = buildFixture(assembler, 'short');
 
@@ -229,7 +229,7 @@ describe('ChatSession per-turn system prompt assembly (issue #3136)', () => {
 
   it('sendMessageStream: renders the fresh provider model after a mid-session /model change', async () => {
     const assembler: SystemPromptAssembler = {
-      assemble: async (model) => `[stream model=${model}]`,
+      assemble: async ({ model }) => `[stream model=${model}]`,
     };
     const fx = buildFixture(assembler, 'old-stream-model');
 
@@ -262,7 +262,7 @@ describe('ChatSession per-turn system prompt assembly (issue #3136)', () => {
 
   it('generateDirectMessage: renders the fresh provider model after a mid-session /model change', async () => {
     const assembler: SystemPromptAssembler = {
-      assemble: async (model) => `[direct model=${model}]`,
+      assemble: async ({ model }) => `[direct model=${model}]`,
     };
     const fx = buildFixture(assembler, 'old-direct-model');
 
@@ -292,7 +292,7 @@ describe('ChatSession per-turn system prompt assembly (issue #3136)', () => {
 
     const fx = buildFixture(
       {
-        assemble: async (model: string) => {
+        assemble: async ({ model }) => {
           const id = ++turn;
           events.push(`resolve:start:${id}`);
           // Yield inside assembly to widen the interleaving window.
@@ -427,7 +427,7 @@ describe('router re-render port (issue #3157)', () => {
 
   it('sendMessage: carries the assembler port so a router can re-render for its selected model', async () => {
     const assembler: SystemPromptAssembler = {
-      assemble: async (model) => `[model=${model}]`,
+      assemble: async ({ model }) => `[model=${model}]`,
     };
     const fx = buildFixture(assembler, 'turn-model');
 
@@ -440,7 +440,10 @@ describe('router re-render port (issue #3157)', () => {
       throw new Error('expected systemPromptAssembler on provider options');
     }
     // A router re-renders for the model IT selected.
-    const routerRendered = await port.assemble('router-picked-model');
+    const routerRendered = await port.assemble({
+      provider: 'stub',
+      model: 'router-picked-model',
+    });
     expect(routerRendered).toBe('[model=router-picked-model]');
     // The turn assembly still names the turn model (one assembly per turn).
     expect(fx.capturedCalls[0].systemInstruction).toBe('[model=turn-model]');
@@ -450,7 +453,7 @@ describe('router re-render port (issue #3157)', () => {
 
   it('sendMessageStream: carries the assembler port so a router can re-render for its selected model', async () => {
     const assembler: SystemPromptAssembler = {
-      assemble: async (model) => `[stream model=${model}]`,
+      assemble: async ({ model }) => `[stream model=${model}]`,
     };
     const fx = buildFixture(assembler, 'turn-stream-model');
 
@@ -464,7 +467,10 @@ describe('router re-render port (issue #3157)', () => {
     if (port === undefined) {
       throw new Error('expected systemPromptAssembler on provider options');
     }
-    const routerRendered = await port.assemble('router-picked-model');
+    const routerRendered = await port.assemble({
+      provider: 'stub',
+      model: 'router-picked-model',
+    });
     expect(routerRendered).toBe('[stream model=router-picked-model]');
     expect(fx.capturedCalls[0].systemInstruction).toBe(
       '[stream model=turn-stream-model]',
@@ -475,7 +481,7 @@ describe('router re-render port (issue #3157)', () => {
 
   it('generateDirectMessage: carries the assembler port so a router can re-render for its selected model', async () => {
     const assembler: SystemPromptAssembler = {
-      assemble: async (model) => `[direct model=${model}]`,
+      assemble: async ({ model }) => `[direct model=${model}]`,
     };
     const fx = buildFixture(assembler, 'turn-direct-model');
 
@@ -486,7 +492,10 @@ describe('router re-render port (issue #3157)', () => {
     if (port === undefined) {
       throw new Error('expected systemPromptAssembler on provider options');
     }
-    const routerRendered = await port.assemble('router-picked-model');
+    const routerRendered = await port.assemble({
+      provider: 'stub',
+      model: 'router-picked-model',
+    });
     expect(routerRendered).toBe('[direct model=router-picked-model]');
     expect(fx.capturedCalls[0].systemInstruction).toBe(
       '[direct model=turn-direct-model]',

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -128,7 +128,10 @@ import { resolveModelForSystemPrompt } from './systemPromptModel.js';
  * as seeded at construction time.
  */
 export interface SystemPromptAssembler {
-  assemble(model: string): Promise<string>;
+  assemble(request: {
+    provider: string | undefined;
+    model: string;
+  }): Promise<string>;
 }
 
 /**
@@ -490,6 +493,7 @@ export class ChatSession {
   private getCompressionProfileResolverContext(): CompressionProfileResolverContext {
     return {
       providerRuntime: this.runtimeContext.providerRuntime,
+      runtimeState: this.runtimeState,
       resolveExplicitCompressionProvider:
         this.resolveExplicitCompressionProvider.bind(this),
       roundRobinIndexes: this.compressionLoadBalancerRoundRobinIndexes,
@@ -563,15 +567,14 @@ export class ChatSession {
     if (!this.systemPromptAssembler) {
       return;
     }
-    // Use the SAME resolver ChatSessionFactory uses at session start
-    // (issue #3138). Introducing a second mechanism here — e.g. asking the
-    // provider directly — would recreate the two-sources-disagree defect this
-    // issue exists to remove.
     const config = this.runtimeContext.providerRuntime.config;
     const model = config
       ? resolveModelForSystemPrompt(config)
       : this.runtimeState.model;
-    const systemInstruction = await this.systemPromptAssembler.assemble(model);
+    const systemInstruction = await this.systemPromptAssembler.assemble({
+      provider: this.runtimeState.provider,
+      model,
+    });
     this.generationConfig.systemInstruction = systemInstruction;
     const tokens = await this.historyService.estimateTokensForText(
       systemInstruction,

--- a/packages/agents/src/core/client-test-helpers.ts
+++ b/packages/agents/src/core/client-test-helpers.ts
@@ -182,6 +182,11 @@ function setupConfigMock(): ContentGeneratorConfig {
     getEphemeralSetting: vi.fn().mockReturnValue(undefined),
     isInteractive: vi.fn().mockReturnValue(true),
     getMcpInstructions: vi.fn().mockReturnValue(undefined),
+    getSettingsService: vi.fn().mockReturnValue({
+      get: vi.fn((key: string) =>
+        key === 'activeProvider' ? 'gemini' : undefined,
+      ),
+    }),
     getModelRouterService: vi.fn().mockReturnValue(undefined),
   };
   MockedConfig.mockImplementation(() => mockConfigObject as unknown as Config);

--- a/packages/agents/src/core/client.ts
+++ b/packages/agents/src/core/client.ts
@@ -370,6 +370,7 @@ export class AgentClient implements AgentClientContract {
       this.config,
       enabledToolNames,
       envParts,
+      this.runtimeState.provider,
       model,
     );
 
@@ -808,6 +809,7 @@ export class AgentClient implements AgentClientContract {
       model,
       { ...this.generateContentConfig, ...config },
       this.lastPromptId ?? this.config.getSessionId(),
+      this.runtimeState.provider,
     );
   }
 
@@ -827,6 +829,7 @@ export class AgentClient implements AgentClientContract {
       model,
       this.lastPromptId ?? this.config.getSessionId(),
       this.generateContentConfig,
+      this.runtimeState.provider,
     );
     return output;
   }

--- a/packages/agents/src/core/clientLlmUtilities.coreMemoryCache.test.ts
+++ b/packages/agents/src/core/clientLlmUtilities.coreMemoryCache.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3176, finding D7/C — real auxiliary-path test proving the
+ * config-scoped core-memory snapshot cache in `clientLlmUtilities.ts`.
+ *
+ * When JIT context is disabled (`config.getCoreMemory()` returns
+ * `undefined`), the auxiliary path must load `.LLXPRT_SYSTEM` from disk at
+ * most ONCE per Config lifetime, caching the result (including the empty
+ * string) so subsequent auxiliary calls reuse the snapshot without
+ * re-reading the disk.
+ *
+ * This test does NOT mock `getCoreSystemPromptAsync` or
+ * `loadCoreMemoryContent` — it writes real `.LLXPRT_SYSTEM` fixtures,
+ * calls the real `generateJson` auxiliary path twice, and proves the
+ * second call uses the first call's snapshot even after the disk fixture
+ * is changed.
+ *
+ * Module mocks are process-wide, so this file must be run separately from
+ * other tests that do not mock `clientToolGovernance.js`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import process from 'node:process';
+import { generateJson } from './clientLlmUtilities.js';
+import { initializePromptSystem } from '@vybestack/llxprt-code-core/core/prompts.js';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createConfigParams } from './chatSession-runtime-helpers.js';
+import type { BaseLLMClient } from './baseLlmClient.js';
+import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+
+// Mock only the tool-governance layer (not under test) to avoid needing a
+// full ToolRegistry. The prompts module is NOT mocked.
+void vi.mock('./clientToolGovernance.js', () => ({
+  getEnabledToolNamesForPrompt: () => [],
+  shouldIncludeSubagentDelegationForConfig: async () => false,
+}));
+
+const FIRST_SENTINEL = 'D7_CACHE_FIRST_SNAPSHOT';
+const SECOND_SENTINEL = 'D7_CACHE_SECOND_SNAPSHOT';
+const TEST_MODEL = 'test-model-d7';
+
+function createTextContent(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+function createCapturingBaseLlmClient(captured: string[]): BaseLLMClient {
+  return {
+    generateJson: async (opts: {
+      systemInstruction?: string;
+    }): Promise<Record<string, unknown>> => {
+      captured.push(opts.systemInstruction ?? '');
+      return { ok: true };
+    },
+  } as unknown as BaseLLMClient;
+}
+
+describe('Auxiliary core-memory snapshot cache (issue #3176, D7)', () => {
+  let tempCwd: string;
+  let tempPromptsDir: string;
+  let originalCwd: string;
+  let originalPromptsDir: string | undefined;
+  let coreMemoryPath: string;
+
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    originalPromptsDir = process.env.LLXPRT_PROMPTS_DIR;
+
+    tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'llxprt-d7-cache-'));
+    const coreMemoryDir = path.join(tempCwd, '.llxprt');
+    fs.mkdirSync(coreMemoryDir, { recursive: true });
+    coreMemoryPath = path.join(coreMemoryDir, '.LLXPRT_SYSTEM');
+    fs.writeFileSync(coreMemoryPath, FIRST_SENTINEL);
+
+    tempPromptsDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'llxprt-d7-cache-prompts-'),
+    );
+    process.env.LLXPRT_PROMPTS_DIR = tempPromptsDir;
+
+    process.chdir(tempCwd);
+    await initializePromptSystem();
+  });
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+    if (tempCwd && fs.existsSync(tempCwd)) {
+      fs.rmSync(tempCwd, { recursive: true, force: true });
+    }
+    if (tempPromptsDir && fs.existsSync(tempPromptsDir)) {
+      fs.rmSync(tempPromptsDir, { recursive: true, force: true });
+    }
+    if (originalPromptsDir === undefined) {
+      delete process.env.LLXPRT_PROMPTS_DIR;
+    } else {
+      process.env.LLXPRT_PROMPTS_DIR = originalPromptsDir;
+    }
+  });
+
+  it('caches the first disk snapshot so the second call does not re-read', async () => {
+    const settings = new SettingsService();
+    settings.set('model', TEST_MODEL);
+    const config = new Config(createConfigParams(settings));
+
+    // With JIT disabled, getCoreMemory() returns undefined, so the
+    // auxiliary path must fall back to the disk snapshot cache.
+    expect(config.getCoreMemory()).toBeUndefined();
+
+    const captured: string[] = [];
+    const baseLlmClient = createCapturingBaseLlmClient(captured);
+
+    // First call — reads disk, caches snapshot containing FIRST_SENTINEL.
+    await generateJson(
+      config,
+      {} as ContentGenerator,
+      baseLlmClient,
+      [createTextContent('next_speaker check')],
+      { type: 'object' },
+      new AbortController().signal,
+      TEST_MODEL,
+      {},
+      'core-memory-cache-test',
+    );
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toContain(FIRST_SENTINEL);
+
+    // Change the disk fixture AFTER the first call.
+    fs.writeFileSync(coreMemoryPath, SECOND_SENTINEL);
+
+    // Second call — must use the CACHED snapshot (FIRST_SENTINEL), not the
+    // new disk content (SECOND_SENTINEL).
+    await generateJson(
+      config,
+      {} as ContentGenerator,
+      baseLlmClient,
+      [createTextContent('next_speaker check')],
+      { type: 'object' },
+      new AbortController().signal,
+      TEST_MODEL,
+      {},
+      'core-memory-cache-test',
+    );
+    expect(captured).toHaveLength(2);
+    expect(captured[1]).toContain(FIRST_SENTINEL);
+    expect(captured[1]).not.toContain(SECOND_SENTINEL);
+  });
+
+  it('caches the empty string when no .LLXPRT_SYSTEM exists on disk', async () => {
+    // Remove the disk fixture entirely.
+    fs.unlinkSync(coreMemoryPath);
+
+    const settings = new SettingsService();
+    settings.set('model', TEST_MODEL);
+    const config = new Config(createConfigParams(settings));
+    expect(config.getCoreMemory()).toBeUndefined();
+
+    const captured: string[] = [];
+    const baseLlmClient = createCapturingBaseLlmClient(captured);
+
+    // First call — disk is empty, snapshot is ''.
+    await generateJson(
+      config,
+      {} as ContentGenerator,
+      baseLlmClient,
+      [createTextContent('next_speaker check')],
+      { type: 'object' },
+      new AbortController().signal,
+      TEST_MODEL,
+      {},
+      'core-memory-cache-test',
+    );
+    expect(captured).toHaveLength(1);
+
+    // Write a sentinel AFTER the first call.
+    fs.writeFileSync(coreMemoryPath, SECOND_SENTINEL);
+
+    // Second call — must still use the cached empty snapshot, NOT the
+    // newly-written sentinel.
+    await generateJson(
+      config,
+      {} as ContentGenerator,
+      baseLlmClient,
+      [createTextContent('next_speaker check')],
+      { type: 'object' },
+      new AbortController().signal,
+      TEST_MODEL,
+      {},
+      'core-memory-cache-test',
+    );
+    expect(captured).toHaveLength(2);
+    expect(captured[1]).not.toContain(SECOND_SENTINEL);
+  });
+});

--- a/packages/agents/src/core/clientLlmUtilities.test.ts
+++ b/packages/agents/src/core/clientLlmUtilities.test.ts
@@ -44,8 +44,12 @@ const EMBEDDING_MODEL = 'embedding-model';
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
     getUserMemory: vi.fn().mockReturnValue(USER_MEMORY),
+    getCoreMemory: vi.fn().mockReturnValue(undefined),
     getMcpInstructions: vi.fn().mockReturnValue(undefined),
     isInteractive: vi.fn().mockReturnValue(true),
+    getSettingsService: vi.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue(undefined),
+    }),
     ...overrides,
   } as unknown as Config;
 }
@@ -119,7 +123,7 @@ describe('generateJson', () => {
     expect(result).toStrictEqual({ key: 'value' });
   });
 
-  it('uses lightweight system prompt (getCoreSystemPromptAsync, no env context)', async () => {
+  it('uses the request provider in the lightweight system prompt', async () => {
     const contents = [
       {
         speaker: 'human',
@@ -137,12 +141,14 @@ describe('generateJson', () => {
       TEST_MODEL,
       {},
       SESSION_ID,
+      'request-provider',
     );
 
     expect(getCoreSystemPromptAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         userMemory: USER_MEMORY,
         model: TEST_MODEL,
+        provider: 'request-provider',
       }),
     );
   });
@@ -357,5 +363,110 @@ describe('generateEmbedding', () => {
       text: ['text1', 'text2'],
       model: EMBEDDING_MODEL,
     });
+  });
+});
+
+/**
+ * Issue #3176, finding D7 — the auxiliary (lightweight) prompt path must pass
+ * `coreMemory: config.getCoreMemory()` so the per-call `.LLXPRT_SYSTEM` disk
+ * read does not fire when core memory is available in memory.
+ *
+ * These tests use a mock that faithfully simulates the real
+ * `getCoreSystemPromptAsync` core-memory channel: when `coreMemory` is a
+ * non-empty string it echoes it; when it is `undefined` it returns a sentinel
+ * representing the disk fallback. The assertion is on the system instruction
+ * CONTENT delivered to the LLM client — not on mock-call bookkeeping.
+ */
+describe('buildLightweightSystemPrompt core memory (issue #3176, D7)', () => {
+  const DISK_FALLBACK_SENTINEL = 'DISK_FALLBACK_FIRED';
+  let contentGenerator: ContentGenerator;
+  let baseLlmClient: BaseLLMClient;
+  const abortSignal = new AbortController().signal;
+
+  beforeEach(() => {
+    contentGenerator = makeContentGenerator();
+    baseLlmClient = makeBaseLlmClient();
+    vi.clearAllMocks();
+    (
+      getCoreSystemPromptAsync as Mock<typeof getCoreSystemPromptAsync>
+    ).mockImplementation(async (userMemoryOrOptions) => {
+      const coreMemory =
+        typeof userMemoryOrOptions === 'object'
+          ? userMemoryOrOptions.coreMemory
+          : undefined;
+      if (typeof coreMemory === 'string' && coreMemory.trim()) {
+        return coreMemory;
+      }
+      return DISK_FALLBACK_SENTINEL;
+    });
+  });
+
+  function captureSystemInstruction(): string {
+    const callArgs = (
+      baseLlmClient.generateJson as Mock<typeof baseLlmClient.generateJson>
+    ).mock.calls[0]?.[0] as { systemInstruction?: string } | undefined;
+    return callArgs?.systemInstruction ?? '';
+  }
+
+  // T6
+  it('passes in-memory core memory and avoids the disk fallback (D7)', async () => {
+    const IN_MEMORY = 'IN_MEMORY_CORE_SENTINEL';
+    const configWithMemory = makeConfig({
+      getCoreMemory: vi.fn().mockReturnValue(IN_MEMORY),
+    });
+
+    await generateJson(
+      configWithMemory,
+      contentGenerator,
+      baseLlmClient,
+      [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'hello' }],
+        } as IContent,
+      ],
+      {},
+      abortSignal,
+      TEST_MODEL,
+      {},
+      SESSION_ID,
+    );
+
+    const sysInstr = captureSystemInstruction();
+    // The in-memory value reached the model …
+    expect(sysInstr).toContain(IN_MEMORY);
+    // … and the disk fallback did NOT fire.
+    expect(sysInstr).not.toContain(DISK_FALLBACK_SENTINEL);
+    // The config's getCoreMemory was the source, proving the wiring.
+    expect(configWithMemory.getCoreMemory).toHaveBeenCalled();
+  });
+
+  // T7
+  it('delivers the full core-memory content to the model (no suppression)', async () => {
+    const CORE_CONTENT = 'FULL_CORE_MEMORY_BODY';
+    const configWithMemory = makeConfig({
+      getCoreMemory: vi.fn().mockReturnValue(CORE_CONTENT),
+    });
+
+    await generateJson(
+      configWithMemory,
+      contentGenerator,
+      baseLlmClient,
+      [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'hello' }],
+        } as IContent,
+      ],
+      {},
+      abortSignal,
+      TEST_MODEL,
+      {},
+      SESSION_ID,
+    );
+
+    // The content must be the actual in-memory value, not an empty string
+    // (passing '' would suppress it — the issue explicitly forbids that).
+    expect(captureSystemInstruction()).toBe(CORE_CONTENT);
   });
 });

--- a/packages/agents/src/core/clientLlmUtilities.ts
+++ b/packages/agents/src/core/clientLlmUtilities.ts
@@ -4,11 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
+import {
+  getCoreSystemPromptAsync,
+  loadCoreMemoryContent,
+} from '@vybestack/llxprt-code-core/core/prompts.js';
+import process from 'node:process';
 import {
   getEnabledToolNamesForPrompt,
   shouldIncludeSubagentDelegationForConfig,
 } from './clientToolGovernance.js';
+import { resolveProviderForSystemPrompt } from './systemPromptProvider.js';
 import { reportError } from '@vybestack/llxprt-code-core/utils/errorReporting.js';
 import { retryWithBackoff } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { getErrorMessage } from '@vybestack/llxprt-code-core/utils/errors.js';
@@ -22,19 +27,55 @@ import type { BaseLLMClient } from './baseLlmClient.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 
+/**
+ * Config-scoped async snapshot for the on-disk core-memory content loaded
+ * when `config.getCoreMemory()` returns `undefined` (JIT context disabled).
+ *
+ * The exact `loadCoreMemoryContent(process.cwd())` result — including the
+ * empty string — is cached per Config so the two-file `.LLXPRT_SYSTEM` disk
+ * read happens at most once per Config lifetime, not once per auxiliary LLM
+ * call (issue #3176, finding D7). This mirrors the disk-load fallback in
+ * `resolveEffectiveMemories` but makes it a snapshot rather than a per-call
+ * re-read.
+ */
+const coreMemorySnapshotCache = new WeakMap<Config, Promise<string>>();
+
+/**
+ * Resolves a defined `coreMemory` value for the auxiliary prompt path.
+ * Prefers `config.getCoreMemory()` (in-memory when JIT is enabled); falls
+ * back to a cached disk snapshot otherwise so `getCoreSystemPromptAsync`
+ * never performs a per-call `.LLXPRT_SYSTEM` load.
+ */
+async function resolveAuxiliaryCoreMemory(config: Config): Promise<string> {
+  const explicit = config.getCoreMemory();
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  let snapshot = coreMemorySnapshotCache.get(config);
+  if (snapshot === undefined) {
+    snapshot = loadCoreMemoryContent(process.cwd());
+    coreMemorySnapshotCache.set(config, snapshot);
+  }
+  return snapshot;
+}
+
 async function buildLightweightSystemPrompt(
   config: Config,
   model: string,
+  provider: string | undefined,
 ): Promise<string> {
   const userMemory = config.getUserMemory();
+  const coreMemory = await resolveAuxiliaryCoreMemory(config);
   const mcpInstructions = config.getMcpInstructions();
   const enabledToolNames = getEnabledToolNamesForPrompt(config);
   const includeSubagentDelegation =
     await shouldIncludeSubagentDelegationForConfig(config, enabledToolNames);
   return getCoreSystemPromptAsync({
     userMemory,
+    coreMemory,
     mcpInstructions,
     model,
+    provider: provider ?? resolveProviderForSystemPrompt(config),
     includeSubagentDelegation,
     tools: enabledToolNames,
     interactionMode: config.isInteractive() ? 'interactive' : 'non-interactive',
@@ -57,11 +98,16 @@ export async function generateJson(
   model: string,
   generationConfig: ModelGenerationSettings = {},
   lastPromptId: string,
+  provider?: string,
 ): Promise<Record<string, unknown>> {
   const logger = new DebugLogger('llxprt:core:clientLlmUtilities');
 
   try {
-    const systemInstruction = await buildLightweightSystemPrompt(config, model);
+    const systemInstruction = await buildLightweightSystemPrompt(
+      config,
+      model,
+      provider,
+    );
 
     // Already neutral IContent[] — read TextBlock.text directly (no Google Part access).
     const iContents = contents;
@@ -140,6 +186,7 @@ export async function generateContent(
   model: string,
   lastPromptId: string,
   baseGenerateContentConfig: ModelGenerationSettings,
+  provider?: string,
 ): Promise<ModelOutput> {
   const configToUse: ModelGenerationSettings = {
     ...baseGenerateContentConfig,
@@ -147,7 +194,11 @@ export async function generateContent(
   };
 
   try {
-    const systemInstruction = await buildLightweightSystemPrompt(config, model);
+    const systemInstruction = await buildLightweightSystemPrompt(
+      config,
+      model,
+      provider,
+    );
 
     const icontents = contents;
 

--- a/packages/agents/src/core/subagentRuntimeSetup.assembler.test.ts
+++ b/packages/agents/src/core/subagentRuntimeSetup.assembler.test.ts
@@ -31,16 +31,20 @@ import {
 } from '@vybestack/llxprt-code-core/hooks/types.js';
 import { createConfigParams } from './chatSession-runtime-helpers.js';
 
-// Capture getCoreSystemPromptAsync calls so we can assert interactionMode
-// on both the creation-time call and the per-turn call. The mock echoes its
-// memory inputs verbatim so the rendered prompt reflects exactly which memory
-// channels were sourced — letting issue #3173 tests assert, for example, that
-// the MCP marker appears exactly once (only via the dedicated mcpInstructions
-// option) rather than also inside user memory.
+// Capture getCoreSystemPromptAsync calls so we can assert interactionMode,
+// provider, and model on both the creation-time call and the per-turn call.
+// The mock echoes those values and every memory channel into the rendered
+// prompt. That keeps the assertions on observable prompt content while the
+// issue #3173 tests can also prove MCP instructions appear exactly once.
 const mockGetCorePrompt = vi.fn(async (args: Record<string, unknown>) => {
   const mode =
     typeof args.interactionMode === 'string' ? args.interactionMode : 'unknown';
-  const sections: string[] = [`[CORE_PROMPT mode=${mode}]`];
+  const provider =
+    typeof args.provider === 'string' ? args.provider : 'NO_PROVIDER';
+  const model = typeof args.model === 'string' ? args.model : 'NO_MODEL';
+  const sections: string[] = [
+    `[CORE_PROMPT mode=${mode} provider=${provider} model=${model}]`,
+  ];
   const userMemory = typeof args.userMemory === 'string' ? args.userMemory : '';
   const coreMemory = typeof args.coreMemory === 'string' ? args.coreMemory : '';
   const mcp =
@@ -88,6 +92,7 @@ describe('Subagent per-turn assembler (issue #3136)', () => {
   async function buildSubagentFixture(opts: {
     persona: string;
     runtimeId: string;
+    provider?: string;
     userMemory?: string;
     coreMemory?: string;
     jitContextEnabled?: boolean;
@@ -103,8 +108,9 @@ describe('Subagent per-turn assembler (issue #3136)', () => {
       metadata: { source: 'subagent-assembler.test' },
     });
 
+    const providerName = opts.provider ?? 'stub';
     const provider: IProvider = {
-      name: 'stub',
+      name: providerName,
       isDefault: true,
       getModels: vi.fn(async () => []),
       getDefaultModel: () => 'sub-model-v1',
@@ -171,7 +177,7 @@ describe('Subagent per-turn assembler (issue #3136)', () => {
 
     const runtimeState = createAgentRuntimeState({
       runtimeId: opts.runtimeId,
-      provider: 'stub',
+      provider: providerName,
       model: 'sub-model-v1',
       sessionId: config.getSessionId(),
     });
@@ -241,7 +247,7 @@ describe('Subagent per-turn assembler (issue #3136)', () => {
 
     // The system instruction must contain BOTH the core prompt and persona
     const sysInstr = capturedCalls[0].systemInstruction as string;
-    expect(sysInstr).toContain('[CORE_PROMPT mode=subagent]');
+    expect(sysInstr).toContain('mode=subagent');
     expect(sysInstr).toContain(PERSONA);
   });
 
@@ -394,6 +400,41 @@ ${JIT}`);
       // Exactly one MCP marker reaches the provider.
       const rendered = capturedCalls[0].systemInstruction as string;
       expect(countOccurrences(rendered, MCP)).toBe(1);
+    });
+  });
+
+  describe('Subagent system-prompt provider (issue #3176, D5)', () => {
+    it('sends a prompt rendered for the executing provider, not ambient settings', async () => {
+      settingsService.set('activeProvider', 'foreground-provider-alpha');
+      const chat = await buildSubagentFixture({
+        persona: 'You are a subagent.',
+        runtimeId: 'test.subagent.provider',
+        provider: 'subagent-provider-beta',
+      });
+
+      await chat.sendMessage({ message: 'do the task' }, 'p1');
+
+      const sentPrompt = capturedCalls[0].systemInstruction as string;
+      expect(sentPrompt).toContain('provider=subagent-provider-beta');
+      expect(sentPrompt).not.toContain('provider=foreground-provider-alpha');
+    });
+
+    it('keeps the runtime provider while resolving the current request model', async () => {
+      settingsService.set('activeProvider', 'foreground-provider-alpha');
+      const chat = await buildSubagentFixture({
+        persona: 'You are a subagent.',
+        runtimeId: 'test.subagent.coherence',
+        provider: 'subagent-provider-beta',
+      });
+
+      settingsService.set('activeProvider', 'unrelated-provider-switch');
+      settingsService.set('model', 'sub-model-v2');
+      await chat.sendMessage({ message: 'go' }, 'p1');
+
+      const sentPrompt = capturedCalls[0].systemInstruction as string;
+      expect(sentPrompt).toContain('provider=subagent-provider-beta');
+      expect(sentPrompt).toContain('model=sub-model-v2');
+      expect(sentPrompt).not.toContain('provider=unrelated-provider-switch');
     });
   });
 });

--- a/packages/agents/src/core/subagentRuntimeSetup.ts
+++ b/packages/agents/src/core/subagentRuntimeSetup.ts
@@ -773,21 +773,23 @@ export async function createChatObject(
     combinedDeclarations,
     config,
     personaPrompt,
+    runtimeContext.state.provider,
     logger,
   );
 
   // Per-turn assembler: reuses the EXISTING buildSystemInstruction with the
-  // provider-resolved model, preserving subagent interactionMode and persona
-  // ordering (issue #3136).
+  // request-scoped provider and model, preserving subagent interactionMode
+  // and persona ordering (issue #3136, #3176).
   const systemPromptAssembler: SystemPromptAssembler = {
-    assemble: (turnModel: string) =>
+    assemble: (request: { provider: string | undefined; model: string }) =>
       buildSystemInstruction(
         environmentContextLoader,
         runtimeContext,
-        { ...modelConfig, model: turnModel },
+        { ...modelConfig, model: request.model },
         combinedDeclarations,
         config,
         personaPrompt,
+        request.provider,
         logger,
       ),
   };
@@ -811,6 +813,7 @@ async function buildSystemInstruction(
   combinedDeclarations: ToolDeclaration[],
   config: Config,
   personaPrompt: string,
+  provider: string | undefined,
   logger: { debug: (fn: () => string) => void },
 ): Promise<string> {
   const envParts = await environmentContextLoader(runtimeContext);
@@ -838,6 +841,7 @@ async function buildSystemInstruction(
     coreMemory,
     mcpInstructions,
     model: modelConfig.model,
+    provider,
     tools: toolNames,
     includeSubagentDelegation: false,
     interactionMode: 'subagent',

--- a/packages/agents/src/core/systemPromptProvider.nonForegroundProvider.test.ts
+++ b/packages/agents/src/core/systemPromptProvider.nonForegroundProvider.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import process from 'node:process';
+import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import {
+  getCoreSystemPromptAsync,
+  initializePromptSystem,
+} from '@vybestack/llxprt-code-core/core/prompts.js';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type { RuntimeGenerateChatOptions as GenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import {
+  createSettingsProviderRuntimeContext,
+  deactivateSettingsRuntimeContext,
+  setSettingsProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/settingsRuntimeAdapter.js';
+import {
+  createProviderAdapterFromManager,
+  createTelemetryAdapterFromConfig,
+  createToolRegistryViewFromRegistry,
+} from '@vybestack/llxprt-code-core/runtime/runtimeAdapters.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { ContextState } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  AfterModelHookOutput,
+  BeforeModelHookOutput,
+} from '@vybestack/llxprt-code-core/hooks/types.js';
+import { TestRuntimeProviderManager } from '../test-utils/runtimeProviderManager.js';
+import { createConfigParams } from './chatSession-runtime-helpers.js';
+import { createChatObject } from './subagentRuntimeSetup.js';
+
+const AMBIENT_PROVIDER = 'ambient-provider-alpha';
+const SUBAGENT_PROVIDER = 'subagent-provider-beta';
+const SUBAGENT_MODEL = 'sub-model-v1';
+const AMBIENT_SENTINEL = 'AMBIENT_PROVIDER_ALPHA_SENTINEL';
+const SUBAGENT_SENTINEL = 'SUBAGENT_BETA_MODEL_SENTINEL';
+
+describe('System prompt provider — non-foreground subagent (issue #3176, D5)', () => {
+  let tempDir: string;
+  let originalPromptsDir: string | undefined;
+
+  beforeAll(async () => {
+    originalPromptsDir = process.env.LLXPRT_PROMPTS_DIR;
+    tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'llxprt-nonforeground-provider-'),
+    );
+
+    for (const [provider, sentinel] of [
+      [AMBIENT_PROVIDER, AMBIENT_SENTINEL],
+      [SUBAGENT_PROVIDER, SUBAGENT_SENTINEL],
+    ] as const) {
+      const dir = path.join(
+        tempDir,
+        'providers',
+        provider,
+        'models',
+        SUBAGENT_MODEL,
+        'core',
+      );
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'default.md'), `${sentinel}\n`);
+    }
+
+    process.env.LLXPRT_PROMPTS_DIR = tempDir;
+    await initializePromptSystem();
+  });
+
+  afterEach(() => {
+    deactivateSettingsRuntimeContext();
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    if (originalPromptsDir === undefined) {
+      delete process.env.LLXPRT_PROMPTS_DIR;
+    } else {
+      process.env.LLXPRT_PROMPTS_DIR = originalPromptsDir;
+    }
+  });
+
+  it('would resolve the ambient template without an explicit request provider', async () => {
+    const settings = new SettingsService();
+    settings.set('activeProvider', AMBIENT_PROVIDER);
+    setSettingsProviderRuntimeContext(
+      createSettingsProviderRuntimeContext({ settingsService: settings }),
+    );
+
+    const prompt = await getCoreSystemPromptAsync({
+      model: SUBAGENT_MODEL,
+      coreMemory: '',
+    });
+
+    expect(prompt).toContain(AMBIENT_SENTINEL);
+    expect(prompt).not.toContain(SUBAGENT_SENTINEL);
+  });
+
+  it('sends the real template for the provider executing the subagent request', async () => {
+    const settings = new SettingsService();
+    settings.set('activeProvider', AMBIENT_PROVIDER);
+    settings.set('model', SUBAGENT_MODEL);
+    const config = new Config(createConfigParams(settings));
+    const capturedCalls: GenerateChatOptions[] = [];
+    const providerRuntime = createProviderRuntimeContext({
+      settingsService: settings,
+      config,
+      runtimeId: 'test.subagent.nonforeground',
+    });
+    const provider: IProvider = {
+      name: SUBAGENT_PROVIDER,
+      isDefault: true,
+      getModels: vi.fn(async () => []),
+      getDefaultModel: () => SUBAGENT_MODEL,
+      getCurrentModel: () => SUBAGENT_MODEL,
+      generateChatCompletion: vi.fn(async function* (
+        optionsOrContents:
+          | GenerateChatOptions
+          | GenerateChatOptions['contents'],
+      ): AsyncGenerator<IContent> {
+        if (Array.isArray(optionsOrContents)) {
+          throw new Error('Legacy chat arguments are not used by this test');
+        }
+        capturedCalls.push(optionsOrContents);
+        yield { speaker: 'ai', blocks: [{ type: 'text', text: 'done' }] };
+      }),
+      getServerTools: () => [],
+      invokeServerTool: vi.fn(),
+    };
+    const manager = new TestRuntimeProviderManager(providerRuntime);
+    manager.setConfig(config);
+    manager.registerProvider(provider);
+    config.setProviderManager(manager);
+    Object.defineProperties(config, {
+      getModel: { value: () => SUBAGENT_MODEL },
+      getCoreMemory: { value: () => '' },
+      getConversationLoggingEnabled: { value: () => false },
+      getEnableHooks: { value: () => false },
+      getHookSystem: {
+        value: () => ({
+          initialize: async () => undefined,
+          isInitialized: () => true,
+          fireBeforeModelEvent: async () => new BeforeModelHookOutput({}),
+          fireAfterModelEvent: async () => new AfterModelHookOutput({}),
+        }),
+      },
+    });
+    const runtimeContext = createAgentRuntimeContext({
+      state: createAgentRuntimeState({
+        runtimeId: 'test.subagent.nonforeground',
+        provider: SUBAGENT_PROVIDER,
+        model: SUBAGENT_MODEL,
+        sessionId: config.getSessionId(),
+        subagentName: 'test-subagent',
+      }),
+      history: new HistoryService(),
+      settings: {
+        compressionThreshold: 0.8,
+        contextLimit: 128000,
+        preserveThreshold: 0.2,
+        telemetry: { enabled: false, target: null },
+        'reasoning.includeInContext': true,
+      },
+      provider: createProviderAdapterFromManager(manager),
+      telemetry: createTelemetryAdapterFromConfig(config),
+      tools: createToolRegistryViewFromRegistry(config.getToolRegistry()),
+      providerRuntime,
+    });
+    const chat = await createChatObject({
+      promptConfig: { systemPrompt: 'You are a subagent.' },
+      modelConfig: { model: SUBAGENT_MODEL, temp: 0, top_p: 1 },
+      runtimeContext,
+      contentGenerator: {} as ContentGenerator,
+      environmentContextLoader: async () => [],
+      foregroundConfig: config,
+      context: new ContextState(),
+    });
+
+    expect(chat).not.toBeNull();
+    await chat?.sendMessage({ message: 'do the task' }, 'prompt-1');
+
+    expect(capturedCalls).toHaveLength(1);
+    const sentPrompt = capturedCalls[0].systemInstruction as string;
+    expect(sentPrompt).toContain(SUBAGENT_SENTINEL);
+    expect(sentPrompt).not.toContain(AMBIENT_SENTINEL);
+  });
+});

--- a/packages/agents/src/core/systemPromptProvider.ts
+++ b/packages/agents/src/core/systemPromptProvider.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+
+/**
+ * Resolves the active provider for legacy config-owned request paths such as
+ * auxiliary calls and the retained executor. Request runtimes and routers must
+ * instead pass their concrete provider explicitly; config state is not an
+ * authority at subagent or load-balancer boundaries (issue #3176, D5).
+ *
+ * An unset provider remains representable by the prompt layer's neutral
+ * fallback, so this compatibility resolver returns `undefined` rather than
+ * inventing an identity.
+ */
+export function resolveProviderForSystemPrompt(
+  config: Config,
+): string | undefined {
+  const provider = config.getSettingsService().get('activeProvider');
+  if (typeof provider === 'string' && provider.trim() !== '') {
+    return provider;
+  }
+  return undefined;
+}

--- a/packages/core/src/core/prompts.coreMemorySkipDisk.test.ts
+++ b/packages/core/src/core/prompts.coreMemorySkipDisk.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3176, finding D7 — real proof that passing `coreMemory` explicitly
+ * to `getCoreSystemPromptAsync` SKIPS the per-call `.LLXPRT_SYSTEM` disk read
+ * in `resolveEffectiveMemories`.
+ *
+ * The companion tests in `clientLlmUtilities.test.ts` (T6/T7) prove the
+ * wiring against a MOCK of `getCoreSystemPromptAsync`. This file proves the
+ * real mechanism by driving the UNMOCKED `getCoreSystemPromptAsync` with a
+ * real on-disk core-memory fixture:
+ *
+ *   - Case A: `coreMemory` is explicitly passed → the prompt contains the
+ *     in-memory sentinel and NOT the on-disk sentinel (proving the disk
+ *     fallback did not fire).
+ *   - Case B: `coreMemory` is omitted → the on-disk sentinel DOES appear
+ *     (proving the disk fixture is real and Case A's assertion is not
+ *     vacuous).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import process from 'node:process';
+import { getCoreSystemPromptAsync, initializePromptSystem } from './prompts.js';
+
+const ON_DISK_SENTINEL = 'REAL_ON_DISK_CORE_SENTINEL_3176';
+const IN_MEMORY_SENTINEL = 'REAL_IN_MEMORY_CORE_SENTINEL_3176';
+
+const TEST_PROVIDER = 'test-provider';
+const TEST_MODEL = 'test-model';
+
+describe('Core memory disk-skip (issue #3176, D7) — real getCoreSystemPromptAsync', () => {
+  let tempCwd: string;
+  let tempPromptsDir: string;
+  let originalCwd: string;
+  let originalPromptsDir: string | undefined;
+
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    originalPromptsDir = process.env.LLXPRT_PROMPTS_DIR;
+
+    // --- Real on-disk core-memory fixture ---
+    // loadCoreMemoryContent reads <cwd>/.llxprt/.LLXPRT_SYSTEM.
+    tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'llxprt-d7-disk-cwd-'));
+    const coreMemoryDir = path.join(tempCwd, '.llxprt');
+    fs.mkdirSync(coreMemoryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(coreMemoryDir, '.LLXPRT_SYSTEM'),
+      ON_DISK_SENTINEL,
+    );
+
+    // --- Real prompt templates ---
+    tempPromptsDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'llxprt-d7-prompts-'),
+    );
+    process.env.LLXPRT_PROMPTS_DIR = tempPromptsDir;
+
+    // Change cwd so loadCoreMemoryContent(process.cwd()) reads our fixture.
+    process.chdir(tempCwd);
+
+    await initializePromptSystem();
+  });
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+    if (tempCwd && fs.existsSync(tempCwd)) {
+      fs.rmSync(tempCwd, { recursive: true, force: true });
+    }
+    if (tempPromptsDir && fs.existsSync(tempPromptsDir)) {
+      fs.rmSync(tempPromptsDir, { recursive: true, force: true });
+    }
+    if (originalPromptsDir === undefined) {
+      delete process.env.LLXPRT_PROMPTS_DIR;
+    } else {
+      process.env.LLXPRT_PROMPTS_DIR = originalPromptsDir;
+    }
+  });
+
+  // Case A — the real proof
+  it('skips the on-disk read when coreMemory is explicitly passed (D7)', async () => {
+    const prompt = await getCoreSystemPromptAsync({
+      provider: TEST_PROVIDER,
+      model: TEST_MODEL,
+      coreMemory: IN_MEMORY_SENTINEL,
+    });
+
+    // The in-memory value reached the prompt …
+    expect(prompt).toContain(IN_MEMORY_SENTINEL);
+    // … and the disk fallback did NOT fire (the on-disk sentinel is absent).
+    expect(prompt).not.toContain(ON_DISK_SENTINEL);
+  });
+
+  // Case B — proves the disk fixture is real and Case A is not vacuous
+  it('reads from disk when coreMemory is omitted (proving the fixture is real)', async () => {
+    const prompt = await getCoreSystemPromptAsync({
+      provider: TEST_PROVIDER,
+      model: TEST_MODEL,
+    });
+
+    // The on-disk sentinel MUST appear, proving resolveEffectiveMemories
+    // actually read the fixture file — making Case A's "not toContain"
+    // assertion meaningful rather than vacuously true.
+    expect(prompt).toContain(ON_DISK_SENTINEL);
+  });
+});

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -219,9 +219,26 @@ export interface CoreSystemPromptOptions {
 
   model?: string;
   tools?: string[];
+  /**
+   * Caller-supplied, request-scoped provider identity for template resolution
+   * (issue #3176, finding D5). Request runtimes and routers pass the concrete
+   * provider that will execute the request so `provider` and `model` remain
+   * coherent. When omitted, `resolveProvider`
+   * falls back to the ambient runtime settings service — the legacy path
+   * that is request-scoped only by accident.
+   */
   provider?: string;
   includeSubagentDelegation?: boolean;
+  /**
+   * Settings-resolved (NOT caller-supplied). When omitted,
+   * `resolveAsyncSubagentSettings` reads the global and profile subagent
+   * settings from the runtime settings service. Callers should not pass
+   * these directly.
+   */
   asyncSubagentsEnabled?: boolean;
+  /**
+   * Settings-resolved (NOT caller-supplied). See `asyncSubagentsEnabled`.
+   */
   profileAsyncEnabled?: boolean;
   interactionMode?: 'interactive' | 'non-interactive' | 'subagent';
 }

--- a/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
+++ b/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
@@ -68,7 +68,10 @@ export type RuntimeUserMemoryInput = string | RuntimeUserMemoryProfileProvider;
  * invoke it when it is not overriding the model.
  */
 export interface RuntimeSystemPromptAssembler {
-  assemble(model: string): Promise<string>;
+  assemble(request: {
+    provider: string | undefined;
+    model: string;
+  }): Promise<string>;
 }
 
 export interface RuntimeGenerateChatOptions {

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -312,6 +312,7 @@ export class LoadBalancingProvider implements IProvider {
     // actually transmits.
     const targetOptions = await optionsWithSelectedModelPrompt(
       options,
+      subProfile.providerName,
       resolveSubProfileModel(subProfile),
     );
     const resolvedOptions = this.buildDelegateResolvedOptions(

--- a/packages/providers/src/__tests__/LoadBalancingProvider.systemPromptModel.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.systemPromptModel.test.ts
@@ -85,15 +85,25 @@ function createCapturingProvider(name: string): CapturingProvider {
  * Assembler that records every model it is asked to render, so tests can
  * assert invocation counts (at-most-once per selected attempt).
  */
-function trackingAssembler(render: (model: string) => string): {
-  assembler: { assemble: (model: string) => Promise<string> };
+function trackingAssembler(
+  render: (provider: string | undefined, model: string) => string,
+): {
+  assembler: {
+    assemble: (request: {
+      provider: string | undefined;
+      model: string;
+    }) => Promise<string>;
+  };
   invocations: string[];
 } {
   const invocations: string[] = [];
   const assembler = {
-    assemble: async (model: string): Promise<string> => {
-      invocations.push(model);
-      return render(model);
+    assemble: async (request: {
+      provider: string | undefined;
+      model: string;
+    }): Promise<string> => {
+      invocations.push(request.model);
+      return render(request.provider, request.model);
     },
   };
   return { assembler, invocations };
@@ -169,7 +179,7 @@ describe('LoadBalancingProvider - system prompt model rendering (issue #3157)', 
       );
 
       const { assembler, invocations } = trackingAssembler(
-        (m) => `[model=${m}]`,
+        (_p, m) => `[model=${m}]`,
       );
 
       await consume(lb, {
@@ -229,7 +239,7 @@ describe('LoadBalancingProvider - system prompt model rendering (issue #3157)', 
       );
 
       const { assembler, invocations } = trackingAssembler(
-        (m) => `[model=${m}]`,
+        (_p, m) => `[model=${m}]`,
       );
 
       await consume(lb, {
@@ -343,7 +353,7 @@ describe('LoadBalancingProvider - system prompt model rendering (issue #3157)', 
       );
 
       const { assembler, invocations } = trackingAssembler(
-        (m) => `[model=${m}]`,
+        (_p, m) => `[model=${m}]`,
       );
 
       await consume(lb, {
@@ -421,7 +431,7 @@ describe('LoadBalancingProvider - system prompt model rendering (issue #3157)', 
       );
 
       const { assembler, invocations } = trackingAssembler(
-        (m) => `[model=${m}]`,
+        (_p, m) => `[model=${m}]`,
       );
 
       await consume(lb, {
@@ -508,7 +518,7 @@ describe('LoadBalancingProvider - system prompt model rendering (issue #3157)', 
         providerManager,
       );
 
-      const { assembler } = trackingAssembler((m) => `[model=${m}]`);
+      const { assembler } = trackingAssembler((_p, m) => `[model=${m}]`);
 
       await consume(lb, {
         contents: [createTextContent('request')],
@@ -698,7 +708,7 @@ describe('LoadBalancingProvider - system prompt model rendering (issue #3157)', 
       );
       lb.setCompressionCallback(async () => [createTextContent('compressed')]);
 
-      const { assembler } = trackingAssembler((m) => `[model=${m}]`);
+      const { assembler } = trackingAssembler((_p, m) => `[model=${m}]`);
 
       await consume(lb, {
         contents: [createTextContent('large request')],
@@ -757,7 +767,7 @@ describe('LoadBalancingProvider - system prompt model rendering (issue #3157)', 
       providerManager.registerProvider(delegate);
 
       const { assembler, invocations } = trackingAssembler(
-        (m) => `[model=${m}]`,
+        (_p, m) => `[model=${m}]`,
       );
 
       const lb = new LoadBalancingProvider(
@@ -790,7 +800,7 @@ describe('LoadBalancingProvider - system prompt model rendering (issue #3157)', 
       providerManager.registerProvider(delegate);
 
       const { assembler, invocations } = trackingAssembler(
-        (m) => `[model=${m}]`,
+        (_p, m) => `[model=${m}]`,
       );
 
       const lbConfig: LoadBalancingProviderConfig = {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.systemPromptProvider.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.systemPromptProvider.test.ts
@@ -1,0 +1,258 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests proving the load balancer threads the concrete candidate
+ * provider name (not the wrapper's 'load-balancer' name) through the
+ * system-prompt assembler on every round-robin selection and every failover
+ * attempt (issue #3176, finding D).
+ *
+ * Mutation sensitivity: if provider forwarding were removed the assembler
+ * would receive `undefined` instead of the concrete provider name, and the
+ * rendered prompt would not contain the candidate's provider sentinel.
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { ProviderManager } from '../ProviderManager.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  LoadBalancingProvider,
+  type LoadBalancingProviderConfig,
+  type ResolvedSubProfile,
+} from '../LoadBalancingProvider.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+
+function createTextContent(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+function createResolvedSubProfile(
+  overrides: Partial<ResolvedSubProfile>,
+): ResolvedSubProfile {
+  return {
+    name: overrides.name ?? 'sub',
+    providerName: overrides.providerName ?? 'openai',
+    model: overrides.model ?? 'gpt-4.1',
+    authToken: overrides.authToken ?? 'test-token',
+    ephemeralSettings: overrides.ephemeralSettings ?? {},
+    modelParams: overrides.modelParams ?? {},
+  };
+}
+
+interface CapturingProvider extends IProvider {
+  readonly captured: GenerateChatOptions[];
+}
+
+function createCapturingProvider(name: string): CapturingProvider {
+  const captured: GenerateChatOptions[] = [];
+  return {
+    name,
+    captured,
+    async *generateChatCompletion(
+      optionsOrContents: GenerateChatOptions | IContent[],
+    ): AsyncGenerator<IContent> {
+      if (Array.isArray(optionsOrContents)) {
+        throw new Error('Legacy chat arguments are not used by this test');
+      }
+      captured.push(optionsOrContents);
+      yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
+    },
+    getModels: async () => [],
+    getDefaultModel: () => 'test',
+    getServerTools: () => [],
+    invokeServerTool: async () => ({}),
+  };
+}
+
+/**
+ * Assembler that encodes both provider and model into the rendered prompt so
+ * assertions can prove the concrete candidate identity reached the assembler.
+ */
+function providerModelAssembler(): {
+  assembler: {
+    assemble: (request: {
+      provider: string | undefined;
+      model: string;
+    }) => Promise<string>;
+  };
+  invocations: Array<{ provider: string | undefined; model: string }>;
+} {
+  const invocations: Array<{ provider: string | undefined; model: string }> =
+    [];
+  return {
+    assembler: {
+      assemble: async (request: {
+        provider: string | undefined;
+        model: string;
+      }): Promise<string> => {
+        invocations.push({
+          provider: request.provider,
+          model: request.model,
+        });
+        return `[provider=${request.provider} model=${request.model}]`;
+      },
+    },
+    invocations,
+  };
+}
+
+async function consume(
+  provider: LoadBalancingProvider,
+  options: GenerateChatOptions,
+): Promise<void> {
+  for await (const _ of provider.generateChatCompletion(options)) {
+    void _;
+  }
+}
+
+describe('LoadBalancingProvider - provider-specific prompt rendering (issue #3176)', () => {
+  let settingsService: SettingsService;
+  let config: Config;
+  let providerManager: ProviderManager;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    config = createRuntimeConfigStub(settingsService);
+    providerManager = new ProviderManager({ settingsService, config });
+  });
+
+  it('round-robin: each candidate renders its own provider+model sentinel', async () => {
+    const delegateOpenai = createCapturingProvider('openai');
+    const delegateAnthropic = createCapturingProvider('anthropic');
+    providerManager.registerProvider(delegateOpenai);
+    providerManager.registerProvider(delegateAnthropic);
+
+    const lbConfig: LoadBalancingProviderConfig = {
+      profileName: 'rr-provider-render',
+      strategy: 'round-robin',
+      contextLimit: 1_000_000,
+      subProfiles: [
+        createResolvedSubProfile({
+          name: 'a',
+          providerName: 'openai',
+          model: 'model-a',
+        }),
+        createResolvedSubProfile({
+          name: 'b',
+          providerName: 'anthropic',
+          model: 'model-b',
+        }),
+      ],
+    };
+    const lb = new LoadBalancingProvider(lbConfig, providerManager);
+
+    const { assembler, invocations } = providerModelAssembler();
+
+    await consume(lb, {
+      contents: [createTextContent('first')],
+      systemInstruction: '[provider=load-balancer]',
+      systemPromptAssembler: assembler,
+    });
+    await consume(lb, {
+      contents: [createTextContent('second')],
+      systemInstruction: '[provider=load-balancer]',
+      systemPromptAssembler: assembler,
+    });
+
+    expect(invocations).toEqual([
+      { provider: 'openai', model: 'model-a' },
+      { provider: 'anthropic', model: 'model-b' },
+    ]);
+    expect(delegateOpenai.captured[0].systemInstruction).toBe(
+      '[provider=openai model=model-a]',
+    );
+    expect(delegateAnthropic.captured[0].systemInstruction).toBe(
+      '[provider=anthropic model=model-b]',
+    );
+  });
+
+  it('failover: each attempted backend renders its own provider+model sentinel', async () => {
+    const openaiCaptured: GenerateChatOptions[] = [];
+    let openaiAttempts = 0;
+    const openai: IProvider = {
+      name: 'openai',
+      async *generateChatCompletion(
+        optionsOrContents: GenerateChatOptions | IContent[],
+      ): AsyncGenerator<IContent> {
+        if (Array.isArray(optionsOrContents)) {
+          throw new Error('Legacy chat arguments are not used by this test');
+        }
+        openaiCaptured.push(optionsOrContents);
+        openaiAttempts++;
+        if (openaiAttempts === 1) {
+          throw new Error('primary down');
+        }
+        yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'model-a',
+      getServerTools: () => [],
+      invokeServerTool: async () => ({}),
+    };
+    const anthropicCaptured: GenerateChatOptions[] = [];
+    const anthropic: IProvider = {
+      name: 'anthropic',
+      async *generateChatCompletion(
+        optionsOrContents: GenerateChatOptions | IContent[],
+      ): AsyncGenerator<IContent> {
+        if (Array.isArray(optionsOrContents)) {
+          throw new Error('Legacy chat arguments are not used by this test');
+        }
+        anthropicCaptured.push(optionsOrContents);
+        yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'model-b',
+      getServerTools: () => [],
+      invokeServerTool: async () => ({}),
+    };
+    providerManager.registerProvider(openai);
+    providerManager.registerProvider(anthropic);
+
+    const lbConfig: LoadBalancingProviderConfig = {
+      profileName: 'failover-provider-render',
+      strategy: 'failover',
+      contextLimit: 1_000_000,
+      lbProfileEphemeralSettings: {
+        failover_retry_count: 1,
+        failover_retry_delay_ms: 0,
+      },
+      subProfiles: [
+        createResolvedSubProfile({
+          name: 'a',
+          providerName: 'openai',
+          model: 'model-a',
+        }),
+        createResolvedSubProfile({
+          name: 'b',
+          providerName: 'anthropic',
+          model: 'model-b',
+        }),
+      ],
+    };
+    const lb = new LoadBalancingProvider(lbConfig, providerManager);
+
+    const { assembler, invocations } = providerModelAssembler();
+
+    await consume(lb, {
+      contents: [createTextContent('request')],
+      systemInstruction: '[provider=load-balancer]',
+      systemPromptAssembler: assembler,
+    });
+
+    expect(invocations).toEqual([
+      { provider: 'openai', model: 'model-a' },
+      { provider: 'anthropic', model: 'model-b' },
+    ]);
+    expect(openaiCaptured[0].systemInstruction).toBe(
+      '[provider=openai model=model-a]',
+    );
+    expect(anthropicCaptured[0].systemInstruction).toBe(
+      '[provider=anthropic model=model-b]',
+    );
+  });
+});

--- a/packages/providers/src/loadBalancing/selectedModelPrompt.test.ts
+++ b/packages/providers/src/loadBalancing/selectedModelPrompt.test.ts
@@ -33,16 +33,27 @@ const noopLogger = {
   info: () => {},
 } as unknown as import('@vybestack/llxprt-code-core/debug/DebugLogger.js').DebugLogger;
 
-function trackingAssembler(render: (model: string) => string): {
-  assembler: { assemble: (model: string) => Promise<string> };
-  invocations: string[];
+function trackingAssembler(
+  render: (provider: string | undefined, model: string) => string,
+): {
+  assembler: {
+    assemble: (request: {
+      provider: string | undefined;
+      model: string;
+    }) => Promise<string>;
+  };
+  invocations: Array<{ provider: string | undefined; model: string }>;
 } {
-  const invocations: string[] = [];
+  const invocations: Array<{ provider: string | undefined; model: string }> =
+    [];
   return {
     assembler: {
-      assemble: async (model: string): Promise<string> => {
-        invocations.push(model);
-        return render(model);
+      assemble: async (request: {
+        provider: string | undefined;
+        model: string;
+      }): Promise<string> => {
+        invocations.push({ provider: request.provider, model: request.model });
+        return render(request.provider, request.model);
       },
     },
     invocations,
@@ -61,28 +72,40 @@ function makeCtx(): OptionsBuildContext {
 
 describe('optionsWithSelectedModelPrompt — blank systemInstruction (issue #3157 review)', () => {
   it('empty-string systemInstruction: assembler not invoked and original value preserved', async () => {
-    const { assembler, invocations } = trackingAssembler((m) => `[model=${m}]`);
+    const { assembler, invocations } = trackingAssembler(
+      (_p, model) => `[model=${model}]`,
+    );
     const options: GenerateChatOptions = {
       contents: [],
       systemInstruction: '',
       systemPromptAssembler: assembler,
     };
 
-    const result = await optionsWithSelectedModelPrompt(options, 'model-a');
+    const result = await optionsWithSelectedModelPrompt(
+      options,
+      'openai',
+      'model-a',
+    );
 
     expect(invocations).toEqual([]);
     expect(result.systemInstruction).toBe('');
   });
 
   it('whitespace-only systemInstruction: assembler not invoked and original value preserved', async () => {
-    const { assembler, invocations } = trackingAssembler((m) => `[model=${m}]`);
+    const { assembler, invocations } = trackingAssembler(
+      (_p, model) => `[model=${model}]`,
+    );
     const options: GenerateChatOptions = {
       contents: [],
       systemInstruction: '   ',
       systemPromptAssembler: assembler,
     };
 
-    const result = await optionsWithSelectedModelPrompt(options, 'model-a');
+    const result = await optionsWithSelectedModelPrompt(
+      options,
+      'openai',
+      'model-a',
+    );
 
     expect(invocations).toEqual([]);
     expect(result.systemInstruction).toBe('   ');
@@ -91,7 +114,9 @@ describe('optionsWithSelectedModelPrompt — blank systemInstruction (issue #315
 
 describe('legacy whitespace modelId keeps parent prompt and model aligned (issue #3157 review)', () => {
   it('whitespace-only modelId: parent model inherited, prompt untouched, assembler never invoked', async () => {
-    const { assembler, invocations } = trackingAssembler((m) => `[model=${m}]`);
+    const { assembler, invocations } = trackingAssembler(
+      (_p, model) => `[model=${model}]`,
+    );
     const parentOptions: GenerateChatOptions = {
       contents: [],
       resolved: { model: 'parent-model' },
@@ -108,6 +133,7 @@ describe('legacy whitespace modelId keeps parent prompt and model aligned (issue
     const selectedModel = resolveSubProfileModel(subProfile);
     const promptOptions = await optionsWithSelectedModelPrompt(
       parentOptions,
+      subProfile.providerName,
       selectedModel,
     );
     const resolved = buildRoundRobinResolvedOptions(

--- a/packages/providers/src/loadBalancing/selectedModelPrompt.ts
+++ b/packages/providers/src/loadBalancing/selectedModelPrompt.ts
@@ -19,6 +19,7 @@ import type { GenerateChatOptions } from '../IProvider.js';
  */
 export async function optionsWithSelectedModelPrompt(
   options: GenerateChatOptions,
+  selectedProvider: string,
   selectedModel: string,
 ): Promise<GenerateChatOptions> {
   if (selectedModel.trim() === '') {
@@ -37,6 +38,9 @@ export async function optionsWithSelectedModelPrompt(
     // re-renders an existing prompt but never originates one.
     return options;
   }
-  const systemInstruction = await assembler.assemble(selectedModel);
+  const systemInstruction = await assembler.assemble({
+    provider: selectedProvider,
+    model: selectedModel,
+  });
   return { ...options, systemInstruction };
 }

--- a/packages/providers/src/types/providerRuntime.ts
+++ b/packages/providers/src/types/providerRuntime.ts
@@ -32,5 +32,8 @@ export type UserMemoryInput = string | UserMemoryProfileProvider;
  * three declarations with no adapter and no cross-package import.
  */
 export interface SystemPromptAssembler {
-  assemble(model: string): Promise<string>;
+  assemble(request: {
+    provider: string | undefined;
+    model: string;
+  }): Promise<string>;
 }

--- a/project-plans/issue3176-request-scoped-prompt-parameters.md
+++ b/project-plans/issue3176-request-scoped-prompt-parameters.md
@@ -1,0 +1,117 @@
+# Issue #3176 — Request-scoped system-prompt parameters
+
+## Scope
+
+Fix audit findings D5, D7, and D8:
+
+- D5: system-prompt template selection must use the concrete provider and model
+  for the request being executed.
+- D7: auxiliary prompt assembly must not reread `.LLXPRT_SYSTEM` on every call,
+  including when JIT context is disabled.
+- D8: compression prompt assembly must describe the session whose history is
+  being compressed.
+
+Out of scope:
+
+- D9 and the vestigial normalized `userMemory` channel.
+- General redesign of the `undefined` core-memory sentinel tracked by #3174.
+- Subagent JIT/MCP behavior tracked by #3173.
+- Removal of the retained executor path tracked by #3152.
+
+## Grounding
+
+Prompt templates are resolved through provider/model-specific paths. Before this
+change, callers supplied a request model but omitted the provider, leaving the
+provider to ambient settings. This could combine one runtime's provider with a
+different runtime's model.
+
+Load balancers add a second boundary: the wrapper cannot know the concrete
+provider/model pair until it selects a member. Prompt assembly therefore has to
+flow as a request-scoped port and rerun for each selected member or failover
+attempt.
+
+The auxiliary prompt path also omitted `coreMemory`. The core prompt layer
+interprets `undefined` as "load core memory from disk," causing repeated reads.
+The exact first disk result must be retained when no explicit in-memory value is
+available.
+
+Compression previously derived interaction mode only from `Config`. The
+existing authoritative subagent marker is a non-empty
+`AgentRuntimeState.subagentName`.
+
+## Accepted behavior
+
+### Provider/model coherence
+
+1. Main-agent initial and per-turn prompt assembly pairs the stable runtime
+   provider with the current config model.
+2. Live subagent initial and per-turn assembly uses the isolated runtime
+   provider, never foreground settings, while retaining current-model behavior.
+3. AgentClient auxiliary requests pass the AgentClient runtime provider.
+4. The retained executor uses its config-owned active provider because that
+   legacy path has no concrete runtime state.
+5. Main load-balancer round-robin and failover attempts reassemble with each
+   selected member's concrete provider and model.
+6. Ordinary compression uses the resolved compression provider and model.
+7. Compression load balancing defers wrapper-level assembly and reassembles for
+   every concrete round-robin selection and failover attempt.
+8. Missing or blank controlled compression provider/model identities fail fast.
+9. `asyncSubagentsEnabled` and `profileAsyncEnabled` remain settings-resolved;
+   they are not added to the request-scoped assembler contract.
+
+### Auxiliary core memory
+
+1. A defined `config.getCoreMemory()` value is passed through exactly.
+2. When it is undefined, `loadCoreMemoryContent(process.cwd())` runs once per
+   `Config`, and its promise/result is cached in a `WeakMap`.
+3. The empty string is a valid cached snapshot.
+4. Load failures are not swallowed by the cache.
+5. `getCoreSystemPromptAsync` always receives a defined value from the
+   auxiliary path, so it does not perform a second per-call disk fallback.
+
+### Compression interaction mode
+
+1. A non-empty `runtimeState.subagentName` produces `subagent`.
+2. Otherwise the existing config-based interactive/non-interactive derivation
+   is preserved.
+3. A compression load balancer derives the mode from the compressed session
+   once and passes the same mode to every candidate.
+
+## Test-first coverage
+
+All new or changed tests use Bun and `bun:test`.
+
+1. A real temporary provider/model template fixture drives an actual subagent
+   request. Ambient provider A differs from executing provider B; the sent
+   prompt must contain only provider B's sentinel.
+2. Subagent assembler tests prove the runtime provider remains stable while a
+   current-model change is reflected at the provider boundary.
+3. ChatSessionFactory and ChatSession tests prove runtime-provider/current-model
+   pairing and propagation of the assembler port.
+4. Main load-balancer tests cover mixed provider/model round-robin and failover
+   attempts.
+5. Ordinary compression tests cover provider identity plus subagent,
+   interactive, and non-interactive modes.
+6. Compression load-balancer tests cover candidate-specific round-robin and
+   failover assembly and prove OneShotStrategy does not perform wrapper-level
+   assembly first.
+7. Auxiliary tests prove explicit in-memory core memory is delivered.
+8. Real filesystem tests call the auxiliary API twice, mutate the disk fixture
+   after the first call, and prove the first exact snapshot remains in use.
+   A second case proves an empty result is cached.
+9. A core-layer filesystem test proves explicitly supplied core memory bypasses
+   the disk fallback without suppressing content.
+
+## Verification gates
+
+Before delivery:
+
+- Run all affected tests individually to avoid Bun's process-wide mock
+  collisions.
+- Run touched-workspace lint and typecheck plus the ESLint guard.
+- Run Open Code Review detached with a 20-minute floor and include changed test
+  files; run rustreviewer alongside it.
+- Run the full repository test, lint, typecheck, format, and build commands.
+- Run the `stepfun-37` smoke test.
+- Create one PR whose title and body reference and fix #3176, then remediate CI
+  and CodeRabbit findings until all checks are green and threads are resolved.


### PR DESCRIPTION
## TLDR

System-prompt assembly now receives the provider and model for the request that will actually execute, rather than combining request models with ambient foreground-provider state. The fix covers main agents, subagents, auxiliary LLM calls, ordinary and load-balanced compression, and general load-balanced providers.

It also caches auxiliary core-memory disk snapshots per Config and preserves the compressed session's interaction mode when building compression prompts.

## Dive Deeper

### Provider/model coherence

- Extends the system-prompt assembler contract to carry a provider/model pair.
- Main-agent initial and per-turn assembly uses the runtime provider with the current request model.
- Subagent assembly uses the isolated subagent runtime provider instead of foreground settings.
- Load balancers re-render prompts after selecting each concrete candidate, including every failover attempt.
- Auxiliary calls receive the AgentClient runtime provider; retained config-owned paths use a focused compatibility resolver.

### Core-memory behavior

- Auxiliary prompt assembly passes the Config's in-memory core memory when available.
- When JIT context is disabled and core memory is undefined, the first disk snapshot is cached per Config, including an empty result.
- Real filesystem tests prove explicit core memory bypasses the prompt layer's disk fallback without suppressing content.

### Compression behavior

- Ordinary compression renders against the resolved compression provider and model.
- Compression load balancing defers wrapper-level prompt assembly until a concrete candidate is selected.
- Compression derives subagent mode from the compressed runtime state and otherwise preserves interactive/non-interactive Config behavior.
- Blank controlled compression provider/model identities fail fast.

## Reviewer Test Plan

1. Run the focused prompt, auxiliary-memory, compression, subagent, and load-balancer Bun tests added or changed by this PR.
2. Configure different foreground and subagent providers with provider-specific templates; verify a subagent request receives only its executing provider's template.
3. Exercise a mixed-provider load-balanced profile in round-robin and failover modes; verify each selected backend gets a prompt rendered for its own provider/model pair.
4. Run compression from interactive, non-interactive, and subagent sessions and verify the rendered interaction mode matches the compressed session.
5. Run the repository verification gates:

       npm run test
       npm run lint
       npm run typecheck
       npm run format
       npm run build
       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

Local verification on macOS:

- Format, lint, typecheck, build, diff check, and the live stepfun-37 smoke test passed.
- The focused compression files and all three files that timed out in the final serialized full-suite attempt passed in isolation.
- The final full-suite attempt completed all workspaces but exited nonzero because three agents files hit wall-clock timeouts on a heavily contended shared host. The failures were timeout-only and did not reproduce after contention cleared; CI remains the authoritative clean full-suite gate.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3176


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * System prompts now consistently use the active runtime provider and selected model, including subagents and load-balanced requests.
  * Load balancing and failover provide provider- and model-specific prompt content for each attempt.
  * Compression requests now preserve interaction mode and provider context across strategies.
  * Core memory is included reliably in lightweight prompts, with improved reuse of previously loaded prompt data.

* **Bug Fixes**
  * Improved handling of missing or invalid provider and model information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->