### PR TITLE
Bound CodeQL PR runner latency (Fixes #3187)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1482,6 +1482,12 @@ jobs:
   codeql:
     name: 'CodeQL'
     runs-on: 'ubuntu-latest'
+    # Issue #3187: bound CodeQL's pull-request runner time so candidate runs can
+    # satisfy the umbrella's under-ten-minute verdict target (#2702). Measured
+    # full push scans routinely take 70–79 minutes, so all non-PR events retain
+    # the 360-minute allowance. A timeout remains a non-success conclusion;
+    # candidate CI measures the end-to-end verdict.
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 9 || 360 }}
     needs:
       - 'skip_check'
     if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
@@ -1492,6 +1498,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # ratchet:actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: 'Initialize CodeQL'
         uses: 'github/codeql-action/init@bce182f857edf1feab116e9795a3393d21977282' # ratchet:github/codeql-action/init@v4

--- a/project-plans/issue-3187-codeql-latency.md
+++ b/project-plans/issue-3187-codeql-latency.md
@@ -1,0 +1,228 @@
+# Issue #3187 — bound CodeQL latency on the PR feedback path
+
+Contributes to #2702 (CI execution optimization umbrella).
+
+## Goal
+
+Bound CodeQL's pull-request job execution so candidate runs can satisfy the
+umbrella's under-ten-minute feedback target, while keeping failures fail-closed
+and preserving current languages, default queries, events, source coverage,
+permissions, and pinned actions.
+
+A complete verdict may be success or failure. A timeout or failure yields a
+non-success CodeQL check and is never converted to success. The job timeout does
+not bound dependency time, hosted queueing, or check propagation; candidate CI
+measured from workflow creation proves end-to-end acceptance.
+
+## Evidence and attribution
+
+### Before: successful pull-request runs
+
+| Run | CodeQL job | Perform CodeQL Analysis |
+| --- | ---: | ---: |
+| 31290737638 | 10m25s | 10m00s |
+| 31287893938 | 8m51s | 8m25s |
+| 31285748447 | 6m30s | 6m08s |
+| 31285400987 | 6m44s | 6m18s |
+| 31281280511 | 7m52s | 7m27s |
+| 31276892758 | 7m02s | 6m35s |
+
+These are GitHub Actions measurements, not local timings.
+
+### Main outlier: run 31271922174
+
+The 79m07s CodeQL job started about 48 seconds after workflow creation. Its
+78m37s analysis step spent the exceptional time in local query evaluation on
+the assigned hosted runner:
+
+- Extraction completed in about 2m32s. TRAP import took 36.6s and produced a
+  254.04 MiB relations database with an 88.03 MiB string pool.
+- The unchanged 89-query default suite ran for about 74m45s. Clear-text logging
+  took 35m54s, regular-expression injection took 68m11s, and insufficient
+  password hashing took 68m17s.
+- SARIF export took 506ms, upload took about 1.43s, and GitHub processing wait
+  took about 5.29s.
+- CodeQL scanned all configured inputs: 4972 TypeScript files, 41 JavaScript
+  files, and 21 GitHub Actions files.
+
+Representative PR run 31290737638 used the same CodeQL 2.26.2 release and default
+query count with a similarly sized database (257.90 MiB relations and 88.03 MiB
+string pool). Its extraction and TRAP import were comparable, but query
+execution took about 6m35s and backend processing about 5.13s. The PR event also
+used CodeQL's `pr-diff-range` extension, so main and PR are not a controlled
+same-mode benchmark.
+
+### Systematic full-push latency
+
+Repeated same-event push runs confirm that full-push analysis is systematically
+long, not a singular hosted-runner outlier:
+
+| Run | Event | Total CodeQL job |
+| --- | --- | ---: |
+| 31244295896 | push | 78m29s |
+| 31237401470 | push | 70m21s |
+| 31190066338 | push | 75m27s |
+| 31139694459 | push | 77m30s |
+
+### Attribution
+
+Run 31271922174 spent about 74m45s in local default-query evaluation; queueing,
+SARIF export/upload, and backend processing were not material contributors.
+However, current evidence cannot isolate the remaining cause between CodeQL
+full-event/query mode, repository workload, and hosted execution variance.
+Hosted-runner variance is an unavoidable factor in these timings; it is
+documented here for accuracy but cannot be shown to dominate the other
+candidates.
+
+## Accepted behavior
+
+### AC-1: successful CodeQL remains unchanged within the bound
+
+- **GIVEN** a non-duplicate pull-request CodeQL run that can finish within nine
+  job-runtime minutes,
+- **WHEN** the CodeQL job runs,
+- **THEN** checkout, JavaScript initialization, all default queries, SARIF
+  upload, and processing complete normally, and the real result remains
+  authoritative rather than being masked as success.
+
+### AC-2: pull-request hosted execution outliers fail closed
+
+- **GIVEN** a pull-request CodeQL job that has acquired a runner but has not
+  completed within nine minutes of CodeQL job execution,
+- **WHEN** the job timeout is reached,
+- **THEN** GitHub terminates it with a bounded non-success conclusion rather
+  than leaving the running CodeQL job pending.
+- **AND** the nine-minute cap bounds pull_request CodeQL job execution only; it
+  does not bound skip_check dependency time, hosted queueing, or check
+  propagation. Candidate-head evidence measured from workflow creation is what
+  proves the under-ten-minute issue acceptance.
+
+### AC-2b: non-pull-request events retain full-job timeout allowance
+
+- **GIVEN** a push, merge_group, or workflow_dispatch CodeQL run,
+- **WHEN** the CodeQL job runs,
+- **THEN** the timeout-minutes expression evaluates to 360 (six hours), matching
+  GitHub Actions' ordinary job limit and accommodating the measured 70–79-minute
+  full-push scans.
+
+### AC-3: security coverage is preserved
+
+- **GIVEN** any currently supported CI event,
+- **WHEN** the workflow is evaluated,
+- **THEN** CodeQL retains existing push, pull-request, merge-group, and manual
+  event coverage and remains gated only by the existing duplicate-run check.
+- **AND** the language remains `javascript`, the default query suite remains in
+  use, and no path exclusion, docs-only gate, custom config, or success wrapper
+  is introduced.
+
+### AC-4: least privilege and action integrity are preserved
+
+- **GIVEN** the CodeQL job configuration,
+- **WHEN** permissions and action references are inspected,
+- **THEN** permissions remain exactly `actions: read`, `contents: read`, and
+  `security-events: write`; checkout does not persist credentials; and checkout,
+  init, and analyze remain pinned to full commit SHAs with ratchet comments.
+
+### AC-5: candidate-head evidence gates completion
+
+- **GIVEN** the final PR candidate,
+- **WHEN** at least three non-skipped, successful pull-request-event CodeQL runs
+  are collected,
+- **THEN** each run records its URL/ID, head SHA, workflow creation time, CodeQL
+  start/completion times, job duration, analysis-step duration, queue/dependency
+  delay, and successful SARIF processing.
+- **AND** each accepted run reaches a CodeQL conclusion under ten minutes from
+  workflow creation, not merely under nine minutes from runner assignment.
+- **AND** the before/after range and unavoidable hosted-runner and queue variance
+  are documented in the PR and issues, then #2702 receives the re-baseline.
+
+## Boundary cases
+
+- Documentation-only PRs still run CodeQL; the existing behavioral contract
+  explicitly protects that behavior.
+- Only the existing duplicate-run mechanism may skip CodeQL.
+- Query, action, upload, and timeout failures yield a non-success CodeQL check
+  and are never converted to success.
+- The nine-minute timeout-minutes cap applies only to pull_request CodeQL job
+  execution; push, merge_group, and workflow_dispatch use a 360-minute
+  allowance compatible with measured 70–79-minute full-push scans.
+- Job timeout starts after runner assignment, so skip_check dependency time,
+  hosted queueing, and check propagation are not bounded by the nine-minute cap.
+  Candidate acceptance measures workflow creation to conclusion.
+- This issue bounds CodeQL's contribution to the umbrella path; it does not
+  authorize changes to unrelated CI jobs.
+
+## Test-first implementation plan
+
+### RED: behavioral workflow contract
+
+Add `scripts/tests/ci-codeql-latency.bun.test.ts` using `bun:test` and the
+existing real-workflow YAML helpers. Before changing the workflow, run it and
+observe failures for the absent timeout and persisted checkout credentials.
+
+The test will verify:
+
+- the CodeQL job timeout-minutes is an event-aware expression that caps
+  pull_request at 9 minutes and all other events at 360;
+- runner, dependency, duplicate-only condition, and docs-only behavior are
+  unchanged;
+- no job or CodeQL step uses `continue-on-error` (the no-success-masking
+  contract);
+- permissions remain exact and least privilege;
+- checkout does not persist credentials;
+- checkout/init/analyze use full pinned SHAs and retain ratchet comments;
+- init remains exactly JavaScript with default queries and no custom config;
+- analyze remains present at the same pinned CodeQL revision; and
+- current push, pull-request, merge-group, and manual event coverage remains
+  intact.
+
+### GREEN: smallest workflow change
+
+In `.github/workflows/ci.yml` only:
+
+- set an event-aware `timeout-minutes` expression on the `codeql` job that
+  evaluates to 9 for pull_request and 360 for all other events; and
+- set `persist-credentials: false` on its checkout step.
+
+No CodeQL path configuration, query/language change, docs gate, cache claim,
+action upgrade, dependency, diagnostic subsystem, or non-blocking handling is
+part of the implementation.
+
+### Verification
+
+1. Run the new targeted Bun test and the existing docs-only CI test.
+2. Run repository workflow lint/policy checks.
+3. Run the full required local verification and smoke test.
+4. Complete review and classify every finding as `Blocker-Fix`, `In-scope-Fix`,
+   `Reject`, or `Defer`.
+5. On the final candidate head, collect at least three successful PR-event
+   CodeQL executions and confirm complete under-ten-minute wall-clock verdicts.
+6. Record after evidence in PR/issue comments so an evidence-only commit does
+   not replace the measured candidate head, then update #2702.
+
+## Explicit non-goals
+
+- Moving CodeQL off pull requests or changing workflow event coverage.
+- Skipping docs, tests, fixtures, generated inputs, or any other analyzed path.
+- Removing/changing languages or default queries.
+- Turning failures, timeouts, or skipped jobs into success.
+- Adding custom CodeQL configuration, caching, diagnostics, runners,
+  dependencies, reusable workflows, public abstractions, or unrelated cleanup.
+- Weakening lint, complexity, safety, source-size, coverage, cross-platform, or
+  CI requirements.
+
+## Review triage
+
+| # | Finding | Classification | Disposition |
+| --- | --- | --- | --- |
+| 1 | Unconditional `timeout-minutes: 9` weakened full push/merge_group/workflow_dispatch scans that take 70–79 min. | Blocker-Fix | Made timeout event-aware: `pull_request` → 9, all other events → 360. No event, language, query, upload, or failure behavior gated, skipped, removed, or weakened. |
+| 2 | Plan root-cause attribution was unsupported (claimed hosted variance dominates). | In-scope-Fix | Rewrote attribution: 74m45s in local default-query evaluation; queueing/SARIF/backend not material. Added repeated push runs showing systematic long analysis. Cannot isolate remaining cause between full-event/query mode, repository workload, and hosted variance. PR uses pr-diff-range so is not a controlled comparison. Runner variance documented without claiming it dominates. |
+| 3 | 9-minute scope not clarified everywhere. | In-scope-Fix | Clarified in goal, AC-2, AC-2b, and boundary cases that 9 minutes bounds pull_request CodeQL job execution only; does not bound skip_check dependency time, hosted queueing, or check propagation. Candidate-head evidence measured from workflow creation proves the under-10-minute acceptance. |
+| 4 | Plan claimed failures make PR "unmergeable". | In-scope-Fix | Replaced with exact fail-closed semantics: timeout/failure yields a non-success CodeQL check and is never converted to success. No branch protection/rulesets created or changed. |
+| 5 | Test rationale for `always()` was misleading. | In-scope-Fix | Removed the misleading `always()` assertion/comment. `always()` affects dependency-result execution, not whether this job's own failure is converted to success. Preserved the `continue-on-error` no-success-masking contract. |
+| 6 | Optional broader action-integrity hardening. | Defer | Not implemented. Only the event-aware timeout behavior required by the findings was implemented. |
+| 7 | AC-2 called the non-success conclusion a blocking verdict without branch-policy evidence. | In-scope-Fix | Replaced it with the exact bounded non-success conclusion; no branch protection or ruleset change was added. |
+| 8 | Workflow comment extended the measured 70–79-minute range to unmeasured merge-group/manual runs. | In-scope-Fix | Limited the measured-duration claim to full push scans and stated separately that every non-PR event retains 360 minutes. |
+| 9 | Candidate-head after evidence is unavailable before the PR exists. | Defer | Collect at least three successful, non-skipped PR-event runs on the final candidate head before completion. |
+| 10 | Event-timeout tests asserted values from a local lookup table instead of the parsed workflow. | In-scope-Fix | Removed the tautological lookup table and its assertions; the remaining test pins the exact parsed GitHub expression that encodes the event condition and both timeout values. |
+| 11 | A second review comment reported the same self-referential test issue at the workflow line. | In-scope-Fix | Resolved by the same removal; no local expression evaluator or parallel implementation was introduced. |

--- a/scripts/tests/ci-codeql-latency.bun.test.ts
+++ b/scripts/tests/ci-codeql-latency.bun.test.ts
@@ -54,16 +54,15 @@ function extractCommitSha(usesReference: string): string {
 
 /**
  * Asserts the raw workflow source retains a `# ratchet:` comment on the line
- * holding the quoted `uses` reference. Parsed YAML strips comments, so this
- * check operates on the verbatim source text to prove the pin is
- * ratchet-managed.
+ * holding the `uses` reference. Parsed YAML strips comments, so this check
+ * operates on the verbatim source text to prove the pin is ratchet-managed.
  */
 function expectRatchetCommentInSource(
   source: string,
   usesReference: string,
 ): void {
   const escaped = usesReference.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = new RegExp(`${escaped}'?\\s*#\\s*ratchet:`);
+  const pattern = new RegExp(`${escaped}['"]?\\s*#\\s*ratchet:`);
   if (!pattern.test(source)) {
     throw new Error(
       `workflow source should retain a ratchet comment for: ${usesReference}`,

--- a/scripts/tests/ci-codeql-latency.bun.test.ts
+++ b/scripts/tests/ci-codeql-latency.bun.test.ts
@@ -1,0 +1,234 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3187: bound CodeQL latency on the PR feedback path.
+ *
+ * A behavioral workflow contract against the real parsed
+ * `.github/workflows/ci.yml` (not a mock). Pins the CodeQL job's event-aware
+ * timeout (9 minutes for pull_request, 360 for all other events) and
+ * credential-free checkout while proving the job's runner, duplicate-only
+ * gate, least-privilege permissions, pinned SHA actions, default-query
+ * JavaScript configuration, and event coverage remain unchanged.
+ */
+
+import { describe, it, expect, beforeAll } from 'bun:test';
+import type {
+  WorkflowDocument,
+  WorkflowJob,
+  WorkflowStep,
+} from './typed-test-helpers.ts';
+import {
+  parseWorkflowYaml,
+  workflowJob,
+  workflowOn,
+  jobSteps,
+  stepWith,
+  asBoolean,
+  asString,
+  asStringArray,
+  asRecord,
+} from './typed-test-helpers.ts';
+import { readRootFile, stepNamed } from './ocr-review-workflow-helpers.ts';
+
+/** Full Git commit SHA: 40 lowercase hex characters. */
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+/** Normalizes a job `needs` field (string or array) into a string array. */
+function jobNeedsArray(needs: string | string[] | undefined): string[] {
+  if (needs === undefined) return [];
+  return Array.isArray(needs) ? [...needs] : [needs];
+}
+
+/** Extracts the commit SHA (text after the last @) from a `uses` reference. */
+function extractCommitSha(usesReference: string): string {
+  const atIndex = usesReference.lastIndexOf('@');
+  if (atIndex < 0) {
+    throw new Error(`uses reference should contain @: ${usesReference}`);
+  }
+  return usesReference.slice(atIndex + 1);
+}
+
+/**
+ * Asserts the raw workflow source retains a `# ratchet:` comment on the line
+ * holding the quoted `uses` reference. Parsed YAML strips comments, so this
+ * check operates on the verbatim source text to prove the pin is
+ * ratchet-managed.
+ */
+function expectRatchetCommentInSource(
+  source: string,
+  usesReference: string,
+): void {
+  const escaped = usesReference.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`${escaped}'?\\s*#\\s*ratchet:`);
+  if (!pattern.test(source)) {
+    throw new Error(
+      `workflow source should retain a ratchet comment for: ${usesReference}`,
+    );
+  }
+}
+
+describe('Issue #3187: bound CodeQL latency on the PR feedback path', () => {
+  let workflowSource: string;
+  let workflow: WorkflowDocument;
+  let on: Record<string, unknown>;
+  let codeql: WorkflowJob;
+  let steps: WorkflowStep[];
+  let checkoutStep: WorkflowStep;
+  let initStep: WorkflowStep;
+  let analyzeStep: WorkflowStep;
+
+  beforeAll(() => {
+    workflowSource = readRootFile('.github/workflows/ci.yml');
+    workflow = parseWorkflowYaml(workflowSource);
+    on = workflowOn(workflow);
+    codeql = workflowJob(workflow, 'codeql');
+    steps = jobSteps(codeql);
+    checkoutStep = stepNamed(codeql, 'Checkout');
+    initStep = stepNamed(codeql, 'Initialize CodeQL');
+    analyzeStep = stepNamed(codeql, 'Perform CodeQL Analysis');
+  });
+
+  describe('event-aware latency bound (timeout-minutes)', () => {
+    it('caps pull_request at 9 and all other events at 360', () => {
+      expect(asString(codeql['timeout-minutes'])).toBe(
+        "${{ github.event_name == 'pull_request' && 9 || 360 }}",
+      );
+    });
+  });
+
+  describe('credential-free checkout', () => {
+    it('CodeQL checkout does not persist credentials', () => {
+      const withInputs = stepWith(checkoutStep);
+      expect(asBoolean(withInputs['persist-credentials'])).toBe(false);
+    });
+  });
+
+  describe('unchanged runner and gating', () => {
+    it('runs-on remains ubuntu-latest', () => {
+      expect(asString(codeql['runs-on'])).toBe('ubuntu-latest');
+    });
+
+    it('needs remains exactly skip_check', () => {
+      expect(jobNeedsArray(codeql.needs)).toEqual(['skip_check']);
+    });
+
+    it('if remains the duplicate-only condition with no docs-only gate', () => {
+      const condition = asString(codeql.if);
+      expect(condition).toBe(
+        "${{ needs.skip_check.outputs.should_skip != 'true' }}",
+      );
+      expect(condition).not.toContain('doc_change_filter');
+    });
+  });
+
+  describe('no success-masking mechanism', () => {
+    it('codeql job declares no continue-on-error', () => {
+      expect(codeql['continue-on-error']).toBeUndefined();
+    });
+
+    it('no codeql step uses continue-on-error', () => {
+      for (const step of steps) {
+        expect(step['continue-on-error']).toBeUndefined();
+      }
+    });
+  });
+
+  describe('least-privilege permissions', () => {
+    it('permissions are exactly actions: read, contents: read, security-events: write', () => {
+      expect(codeql.permissions).toEqual({
+        actions: 'read',
+        contents: 'read',
+        'security-events': 'write',
+      });
+    });
+  });
+
+  describe('pinned SHA actions with ratchet comments', () => {
+    it('checkout, init, and analyze are pinned to full 40-hex commit SHAs', () => {
+      const references = [
+        asString(checkoutStep['uses']),
+        asString(initStep['uses']),
+        asString(analyzeStep['uses']),
+      ];
+      for (const uses of references) {
+        expect(extractCommitSha(uses)).toMatch(COMMIT_SHA_PATTERN);
+      }
+    });
+
+    it('each action retains a ratchet comment in the workflow source', () => {
+      expectRatchetCommentInSource(
+        workflowSource,
+        asString(checkoutStep['uses']),
+      );
+      expectRatchetCommentInSource(workflowSource, asString(initStep['uses']));
+      expectRatchetCommentInSource(
+        workflowSource,
+        asString(analyzeStep['uses']),
+      );
+    });
+
+    it('init and analyze use the same CodeQL action revision', () => {
+      const initSha = extractCommitSha(asString(initStep['uses']));
+      const analyzeSha = extractCommitSha(asString(analyzeStep['uses']));
+      expect(initSha).toBe(analyzeSha);
+    });
+  });
+
+  describe('init configuration (default queries, full coverage)', () => {
+    it('init with-inputs are exactly languages: javascript', () => {
+      expect(stepWith(initStep)).toEqual({ languages: 'javascript' });
+    });
+
+    it('init declares no queries, config-file, or path exclusions', () => {
+      const initWith = stepWith(initStep);
+      const forbiddenKeys = [
+        'queries',
+        'config-file',
+        'paths',
+        'paths-ignore',
+        'packs',
+      ];
+      for (const key of forbiddenKeys) {
+        expect(initWith[key]).toBeUndefined();
+      }
+    });
+  });
+
+  describe('analyze step present', () => {
+    it('Perform CodeQL Analysis step runs the CodeQL analyze action', () => {
+      expect(asString(analyzeStep['uses'])).toContain(
+        'github/codeql-action/analyze',
+      );
+    });
+  });
+
+  describe('event coverage unchanged', () => {
+    it('push retains branches main and release/**', () => {
+      const pushConfig = asRecord(on['push']);
+      expect(asStringArray(pushConfig['branches'])).toEqual([
+        'main',
+        'release/**',
+      ]);
+    });
+
+    it('pull_request retains branches main and release/**', () => {
+      const prConfig = asRecord(on['pull_request']);
+      expect(asStringArray(prConfig['branches'])).toEqual([
+        'main',
+        'release/**',
+      ]);
+    });
+
+    it('merge_group remains present', () => {
+      expect(on['merge_group']).toBeDefined();
+    });
+
+    it('workflow_dispatch remains present', () => {
+      expect(on['workflow_dispatch']).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## TLDR

Bounds CodeQL runner execution to nine minutes on pull_request events so a service or query-time outlier produces a bounded non-success conclusion instead of delaying PR feedback indefinitely. Non-PR events retain the ordinary 360-minute allowance so full push, merge-group, and manual scans can still complete. CodeQL languages, default queries, events, permissions, action revisions, and failure behavior remain unchanged.

Also makes the CodeQL checkout credential-free and adds a Bun behavioral contract against the real parsed CI workflow.

## Dive Deeper

### Why this design

The six issue-cited successful PR samples ranged from 6m30s to 10m25s at job level. The exceptional main run 31271922174 spent 78m37s in Perform CodeQL Analysis, including roughly 74m45s evaluating the existing 89 default queries. Queue delay, SARIF export/upload, and backend processing were only seconds and did not explain the outlier.

Full push scans on comparable repository heads routinely take 70–79 minutes, while PR scans use a PR diff range. A global timeout would therefore reduce full-event security coverage. This PR applies the bound only when github.event_name is pull_request and preserves 360 minutes for every other existing event.

The timeout starts when the CodeQL job begins executing. It does not bound skip_check dependency time, hosted-runner queue time, or check propagation, so acceptance is measured from workflow creation to CodeQL conclusion on candidate CI.

### Fail-closed and coverage-preserving behavior

- A timeout remains a non-success conclusion; no continue-on-error behavior was added.
- CodeQL remains on pull_request, push, merge_group, and workflow_dispatch.
- main and release/** branch coverage remains unchanged.
- JavaScript analysis and the default query suite remain unchanged.
- No path exclusions, custom CodeQL configuration, caching claim, docs-only gate, runner change, or dependency change was added.
- Permissions remain actions: read, contents: read, and security-events: write.
- Checkout, CodeQL init, and CodeQL analyze remain pinned to their existing full commit SHAs with ratchet comments.
- Checkout now sets persist-credentials to false.

### TDD and review evidence

The workflow contract was written first. Against the original workflow it failed because the timeout and credential-free checkout were absent. After implementation, the CodeQL contract and the existing docs-only contract pass together.

Two DeepThinker review cycles and two local Open Code Review cycles were completed. Every finding is classified in project-plans/issue-3187-codeql-latency.md. All Blocker-Fix and In-scope-Fix findings were resolved. The broader optional action-identity hardening suggestion was deferred as outside this issue, and candidate CI timing evidence remains pending on this PR head.

### Verification completed locally

- Focused Bun workflow contracts: 37 passed, 0 failed, 76 assertions.
- npm run typecheck: passed.
- npm run format: passed.
- npm run build: passed.
- actionlint on ci.yml: passed.
- git diff --check: passed.
- Live smoke with the stepfun-37 profile: passed and returned a haiku.
- Full npm run lint passed in the implementation verification cycle; later independent repetitions exceeded the local command runner ceiling.
- Full npm run test was invoked, but the local command runner terminated the still-progressing suite at its 900-second ceiling without an observed test failure. Candidate CI is therefore required before this PR is declared ready.

### Candidate evidence required before completion

This PR will not be declared ready solely from the static timeout. At least three successful, non-skipped pull_request CodeQL runs on the final candidate SHA will be recorded. Each accepted sample must conclude under ten minutes from workflow creation and include job and analysis-step duration, dependency/queue delay, conclusion, and successful SARIF processing. Hosted-runner variance will be documented explicitly, then #2702 will receive the before/after re-baseline.

## Reviewer Test Plan

1. Run: bun test --preload ./scripts/tests/test-setup.ts scripts/tests/ci-codeql-latency.bun.test.ts scripts/tests/ci-docs-only-skip.bun.test.ts
2. Inspect the CodeQL job in .github/workflows/ci.yml and confirm the timeout expression is nine minutes only for pull_request and 360 otherwise.
3. Confirm there is no continue-on-error at the CodeQL job or step level.
4. Confirm events, branches, JavaScript language, default queries, exact permissions, pinned action revisions, and the duplicate-only gate are unchanged.
5. Confirm the CodeQL checkout sets persist-credentials to false.
6. Review the candidate-head timing evidence that will be posted after three successful PR-event runs.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | Focused tests, typecheck, format, build, actionlint, and smoke passed; aggregate test rerun hit the local command ceiling | CI pending | CI pending |
| npx      | Not applicable | Not applicable | Not applicable |
| Docker   | Not applicable | Not applicable | Not applicable |
| Podman   | Not applicable | - | - |
| Seatbelt | Not applicable | - | - |

## Linked issues / bugs

Fixes #3187

Contributes to #2702. The umbrella issue will be updated after three successful candidate-head CodeQL measurements are collected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved automated code security checks with faster feedback for pull requests.
  * Strengthened repository security by limiting checkout credentials and enforcing least-privilege permissions.
  * Added safeguards to ensure required analysis runs reliably across supported workflow events.
* **Tests**
  * Added comprehensive validation for workflow timing, security settings, action integrity, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->