### PR TITLE
Split CLI test shard into three CI partitions (Fixes #3185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -929,20 +929,23 @@ jobs:
   # critical path is max(shard) rather than sum(all workspaces). The shard map
   # lives in scripts/test-shards.ts and is enforced by
   # scripts/check-test-shards.ts (run below and via `lint:test-shards`). Each
-  # shard is a matrix leg; the `scripts` shard runs the root script harness
-  # instead of workspace tests. The selector emits ubuntu-only rows (issue
-  # #2876); macOS coverage moved to the nightly workflow.
+  # logical shard expands into one or more physical matrix rows (issue #3185:
+  # cli splits into 1of3/2of3/3of3; other shards carry 1of1); the `scripts`
+  # shard runs the root script harness instead of workspace tests. All physical
+  # rows are ubuntu-only (issue #2876); macOS coverage moved to the nightly
+  # workflow.
   #
   # Issue #2709: the matrix is now dynamic — shard_selector outputs a JSON
-  # matrix of only the shards that can observe the PR's changed files. When
-  # shard_selector fails or is skipped, the `if` condition prevents test_shard
-  # from running entirely, and the `test` aggregator converts that into a
-  # failure (see test job). When the selector succeeds but selects zero
-  # shards (has_tests=false), the matrix is empty and no legs run; the
-  # `test` aggregator treats that as success (the selector explicitly said
-  # there are no tests to run).
+  # matrix of physical partition rows expanded from only the logical shards
+  # that can observe the PR's changed files (issue #3185 expands cli into
+  # 1of3/2of3/3of3). When shard_selector fails or is skipped, the `if`
+  # condition prevents test_shard from running entirely, and the `test`
+  # aggregator converts that into a failure (see test job). When the selector
+  # succeeds but selects zero shards (has_tests=false), the matrix is empty
+  # and no legs run; the `test` aggregator treats that as success (the
+  # selector explicitly said there are no tests to run).
   test_shard:
-    name: 'Test (${{ matrix.os }}) [${{ matrix.shard }}]'
+    name: 'Test (${{ matrix.os }}) [${{ matrix.shard }} ${{ matrix.partition }}]'
     runs-on: '${{ matrix.os }}'
     # The cli shard is the longest (~12 min pre-cost-reduction); cap so a
     # hung shard fails instead of occupying a runner for the 6h default.
@@ -1055,6 +1058,10 @@ jobs:
           NO_COLOR: true
           # Ensure OAuth tests are skipped in CI (they require browser interaction)
           CI: true
+          # Issue #3185: partition identity consumed by the CLI runner
+          # (packages/cli/run-bun-tests.ts). The selector expands cli into
+          # 1of3/2of3/3of3; other shards carry 1of1 and are unaffected.
+          LLXPRT_CLI_TEST_PARTITION: ${{ matrix.partition }}
         # The orchestrator expands --shard to the shard's workspaces (or runs
         # npm run test:scripts for the scripts shard). Each workspace's tests
         # run under whichever runner its own `test` script selects — Bun-native
@@ -1082,8 +1089,9 @@ jobs:
         run: npm run test:shell
 
       - name: 'Smoke test CLI entry (launcher -> Bun -> TypeScript, no Node)'
-        # The CLI entry is exercised by the cli shard's tests; keep a direct
-        # smoke on the cli shard only to avoid per-leg duplication.
+        # The CLI entry is exercised by the cli shard's tests. This step
+        # retains the logical-shard condition (matrix.shard == 'cli'), so it
+        # runs once in each CLI partition leg (1of3, 2of3, 3of3).
         if: matrix.shard == 'cli'
         run: './packages/cli/bin/llxprt --version'
 
@@ -1098,7 +1106,7 @@ jobs:
           ${{ always() && matrix.shard != 'scripts' && (github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: 'dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2' # ratchet:dorny/test-reporter@v3
         with:
-          name: 'Test Results [${{ matrix.shard }}] (Node ${{ matrix.node-version }}, ${{ matrix.os }})'
+          name: 'Test Results [${{ matrix.shard }} ${{ matrix.partition }}] (Node ${{ matrix.node-version }}, ${{ matrix.os }})'
           path: 'packages/*/junit.xml'
           reporter: 'java-junit'
           fail-on-error: 'false'
@@ -1108,7 +1116,7 @@ jobs:
           ${{ always() && matrix.shard != 'scripts' && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # ratchet:actions/upload-artifact@v7
         with:
-          name: 'test-results-fork-${{ matrix.shard }}-${{ matrix.node-version }}-${{ matrix.os }}'
+          name: 'test-results-fork-${{ matrix.shard }}-${{ matrix.partition }}-${{ matrix.node-version }}-${{ matrix.os }}'
           path: 'packages/*/junit.xml'
 
   #

--- a/packages/cli/run-bun-tests.ts
+++ b/packages/cli/run-bun-tests.ts
@@ -126,6 +126,106 @@ export function isTestFile(fileName: string): boolean {
   return TEST_FILE_PATTERN.test(fileName);
 }
 
+// ---------------------------------------------------------------------------
+// Partition selection (issue #3185)
+// ---------------------------------------------------------------------------
+
+/**
+ * Environment variable consumed by this runner for partition selection.
+ * Exported so the workflow wiring test can assert the YAML env key matches,
+ * preventing string drift between the runner and the workflow.
+ */
+export const PARTITION_ENV_VAR = 'LLXPRT_CLI_TEST_PARTITION';
+
+/**
+ * A one-based partition identity parsed from the canonical `NofM` form
+ * (e.g. `2of3`). `null` from {@link parsePartitionIdentity} means "no
+ * partition" — run the full discovered inventory.
+ */
+export interface PartitionIdentity {
+  /** One-based partition index (1..count). */
+  readonly index: number;
+  /** Number of partitions (positive integer ≥ 1). */
+  readonly count: number;
+}
+
+/**
+ * Canonical form: one-or-more digits, literal `of`, one-or-more digits. The
+ * first digit must be 1-9 so leading zeros (`01of3`) are rejected as
+ * noncanonical.
+ */
+const PARTITION_RE = /^([1-9][0-9]*)of([1-9][0-9]*)$/;
+
+/**
+ * Parses an optional partition identity from the canonical `NofM` form (e.g.
+ * `2of3`). Returns `null` when the input is absent or blank, meaning the full
+ * discovered inventory should run.
+ *
+ * Throws on any noncanonical, zero, negative, unsafe, or out-of-range value so
+ * a misconfigured {@link PARTITION_ENV_VAR} never silently runs a partial
+ * suite. The variable name appears in every error so the cause is obvious.
+ *
+ * Blank semantics: undefined, empty, and whitespace-only values are treated as
+ * "no partition" (full run). Every nonblank value must match canonical `NofM`
+ * exactly — the raw string is validated, not a trimmed copy — so surrounding
+ * whitespace (` 1of3 `) is rejected rather than silently starting a partial run.
+ */
+export function parsePartitionIdentity(
+  raw: string | undefined,
+): PartitionIdentity | null {
+  if (raw === undefined || raw.trim() === '') return null;
+  const match = PARTITION_RE.exec(raw);
+  if (match === null) {
+    throw new Error(
+      `${PARTITION_ENV_VAR}='${raw}' is not a canonical partition identity (expected NofM, e.g. 2of3)`,
+    );
+  }
+  const indexStr = match[1];
+  const countStr = match[2];
+  const index = Number.parseInt(indexStr, 10);
+  const count = Number.parseInt(countStr, 10);
+  // Number.isSafeInteger rejects values outside [-(2^53 - 1), 2^53 - 1],
+  // including 2^53 which round-trips through String() without precision loss
+  // but is still not safely representable.
+  if (!Number.isSafeInteger(index) || !Number.isSafeInteger(count)) {
+    throw new Error(`${PARTITION_ENV_VAR}='${raw}' contains an unsafe integer`);
+  }
+  if (index > count) {
+    throw new Error(
+      `${PARTITION_ENV_VAR}='${raw}' has index ${index} greater than count ${count}`,
+    );
+  }
+  return { index, count };
+}
+
+/**
+ * Selects one partition from a sorted list by round-robin: file position
+ * modulo partition count equals partition index minus one. This maps every
+ * array position to exactly one partition and preserves relative order.
+ *
+ * Returns the full list (a copy) when there is no partition (`null`) or when
+ * the identity is `1of1`. Throws when a well-formed partitioned identity
+ * (count > 1) selects no files, so an empty explicit selection fails fast
+ * rather than producing a green no-op run.
+ */
+export function selectPartition(
+  files: readonly string[],
+  identity: PartitionIdentity | null,
+): readonly string[] {
+  if (identity === null || identity.count === 1) {
+    return [...files];
+  }
+  const selected = files.filter(
+    (_, i) => i % identity.count === identity.index - 1,
+  );
+  if (selected.length === 0) {
+    throw new Error(
+      `${PARTITION_ENV_VAR}='${identity.index}of${identity.count}' selected 0 of ${files.length} discovered test files`,
+    );
+  }
+  return selected;
+}
+
 function collectTestFiles(
   dir: string,
   results: string[],
@@ -469,10 +569,24 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const concurrency = parseConcurrency();
-  console.log(
-    `Running ${testFiles.length} CLI test files with concurrency ${concurrency}`,
+  // Partition selection (issue #3185): apply only AFTER full discovery so the
+  // test-file coverage guard always inspects the complete inventory. Discovery
+  // itself never reads this env var.
+  const partitionIdentity = parsePartitionIdentity(
+    process.env[PARTITION_ENV_VAR],
   );
+  const selectedFiles = selectPartition(testFiles, partitionIdentity);
+
+  const concurrency = parseConcurrency();
+  if (partitionIdentity !== null && partitionIdentity.count > 1) {
+    console.log(
+      `Running ${selectedFiles.length}/${testFiles.length} CLI test files with concurrency ${concurrency} (${PARTITION_ENV_VAR}=${partitionIdentity.index}of${partitionIdentity.count})`,
+    );
+  } else {
+    console.log(
+      `Running ${testFiles.length} CLI test files with concurrency ${concurrency}`,
+    );
+  }
 
   const results: TestResult[] = [];
   let nextIndex = 0;
@@ -481,13 +595,13 @@ async function main(): Promise<void> {
   async function worker(): Promise<void> {
     for (;;) {
       const index = nextIndex++;
-      if (index >= testFiles.length) return;
-      const result = await runTestFile(testFiles[index]);
+      if (index >= selectedFiles.length) return;
+      const result = await runTestFile(selectedFiles[index]);
       results.push(result);
       completed++;
       if (!result.passed) {
         console.error(
-          `FAIL (${completed}/${testFiles.length}) ${result.file}${
+          `FAIL (${completed}/${selectedFiles.length}) ${result.file}${
             result.timedOut ? ' [timeout]' : ''
           }`,
         );
@@ -496,7 +610,7 @@ async function main(): Promise<void> {
   }
 
   await Promise.all(
-    Array.from({ length: Math.min(concurrency, testFiles.length) }, worker),
+    Array.from({ length: Math.min(concurrency, selectedFiles.length) }, worker),
   );
 
   results.sort((a, b) => a.file.localeCompare(b.file));

--- a/packages/cli/test/run-bun-tests.test.ts
+++ b/packages/cli/test/run-bun-tests.test.ts
@@ -20,7 +20,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import {
   discoverTestFiles,
   escapeXml,
@@ -29,10 +29,13 @@ import {
   isTestFile,
   fileTimeoutForFile,
   parseCaseCounts,
+  parsePartitionIdentity,
+  selectPartition,
   stripAnsi,
   timeoutForFile,
   toPathArgument,
 } from '../run-bun-tests.js';
+import type { PartitionIdentity } from '../run-bun-tests.js';
 
 describe('isTestFile', () => {
   it('selects every test and spec extension the workspace uses', () => {
@@ -398,5 +401,338 @@ describe('failureExcerpt', () => {
     const output = `${truncatedWarning}${nl}${padding}${nl}${assertion}${nl}${summary}${nl}`;
     const excerpt = failureExcerpt(output, 600);
     expect(excerpt).toContain(assertion);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition selection (issue #3185): split the CLI test suite into parallel
+// CI legs via LLXPRT_CLI_TEST_PARTITION. These tests pin the parsing contract
+// and the mathematical properties of round-robin selection so a partition can
+// never silently drop, duplicate, or reorder files.
+// ---------------------------------------------------------------------------
+
+/** Wraps parsePartitionIdentity to satisfy the type checker without `!`. */
+function requirePartition(id: string): PartitionIdentity {
+  const parsed = parsePartitionIdentity(id);
+  if (parsed === null) {
+    throw new Error(`expected non-null partition for '${id}'`);
+  }
+  return parsed;
+}
+
+describe('parsePartitionIdentity', () => {
+  it('returns null for an absent identity (no partition)', () => {
+    expect(parsePartitionIdentity(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty identity', () => {
+    expect(parsePartitionIdentity('')).toBeNull();
+  });
+
+  it('returns null for a whitespace-only identity', () => {
+    expect(parsePartitionIdentity('   ')).toBeNull();
+  });
+
+  it('parses 1of1 as identity selection', () => {
+    expect(parsePartitionIdentity('1of1')).toEqual({ index: 1, count: 1 });
+  });
+
+  it('parses 1of3', () => {
+    expect(parsePartitionIdentity('1of3')).toEqual({ index: 1, count: 3 });
+  });
+
+  it('parses 2of3', () => {
+    expect(parsePartitionIdentity('2of3')).toEqual({ index: 2, count: 3 });
+  });
+
+  it('parses 3of3', () => {
+    expect(parsePartitionIdentity('3of3')).toEqual({ index: 3, count: 3 });
+  });
+
+  it('rejects surrounding spaces around an otherwise canonical identity', () => {
+    expect(() => parsePartitionIdentity(' 1of3 ')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('rejects a trailing newline after an otherwise canonical identity', () => {
+    expect(() => parsePartitionIdentity('1of3\n')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('rejects a leading tab before an otherwise canonical identity', () => {
+    expect(() => parsePartitionIdentity('\t1of3')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails on a bare number', () => {
+    expect(() => parsePartitionIdentity('2')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails on arbitrary text', () => {
+    expect(() => parsePartitionIdentity('abc')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails on a zero index', () => {
+    expect(() => parsePartitionIdentity('0of3')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails on a zero count', () => {
+    expect(() => parsePartitionIdentity('1of0')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails when index exceeds count', () => {
+    expect(() => parsePartitionIdentity('4of3')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails on a negative index', () => {
+    expect(() => parsePartitionIdentity('-1of3')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails on a fractional value', () => {
+    expect(() => parsePartitionIdentity('1.5of3')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails on leading zeros (noncanonical)', () => {
+    expect(() => parsePartitionIdentity('01of3')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails on an unsafe integer (precision loss)', () => {
+    // MAX_SAFE_INTEGER + 2 — parseInt loses precision so the round-trip check
+    // must reject it.
+    expect(() => parsePartitionIdentity('9007199254740993of3')).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+
+  it('fails on the first non-safe integer that round-trips (2^53)', () => {
+    // 2^53 = MAX_SAFE_INTEGER + 1 round-trips through String(parseInt(...))
+    // without precision loss, so a round-trip check wrongly accepts it.
+    // Number.isSafeInteger(9007199254740992) is false — it must be rejected.
+    expect(() =>
+      parsePartitionIdentity('9007199254740992of9007199254740992'),
+    ).toThrow(/LLXPRT_CLI_TEST_PARTITION/);
+  });
+});
+
+describe('selectPartition', () => {
+  const FILES = Array.from({ length: 10 }, (_, i) => `src/file${i}.test.ts`);
+
+  it('returns all files when there is no partition (null)', () => {
+    expect(selectPartition(FILES, null)).toEqual(FILES);
+  });
+
+  it('returns all files for 1of1 (identity selection)', () => {
+    expect(selectPartition(FILES, requirePartition('1of1'))).toEqual(FILES);
+  });
+
+  it('selects a deterministic round-robin partition for 2of3', () => {
+    // positions 1, 4, 7 → indices where i % 3 === 1
+    expect(selectPartition(FILES, requirePartition('2of3'))).toEqual([
+      'src/file1.test.ts',
+      'src/file4.test.ts',
+      'src/file7.test.ts',
+    ]);
+  });
+
+  it('selects a deterministic round-robin partition for 1of3', () => {
+    expect(selectPartition(FILES, requirePartition('1of3'))).toEqual([
+      'src/file0.test.ts',
+      'src/file3.test.ts',
+      'src/file6.test.ts',
+      'src/file9.test.ts',
+    ]);
+  });
+
+  it('selects a deterministic round-robin partition for 3of3', () => {
+    expect(selectPartition(FILES, requirePartition('3of3'))).toEqual([
+      'src/file2.test.ts',
+      'src/file5.test.ts',
+      'src/file8.test.ts',
+    ]);
+  });
+
+  it('produces the same result on repeated calls (deterministic)', () => {
+    const identity = requirePartition('2of3');
+    expect(selectPartition(FILES, identity)).toEqual(
+      selectPartition(FILES, identity),
+    );
+  });
+
+  it('preserves the relative order of the sorted input', () => {
+    const sorted = [...FILES].sort();
+    for (const id of ['1of3', '2of3', '3of3']) {
+      const selected = selectPartition(sorted, requirePartition(id));
+      const positions = selected.map((f) => sorted.indexOf(f));
+      const sortedPositions = [...positions].sort((a, b) => a - b);
+      expect(positions).toEqual(sortedPositions);
+    }
+  });
+
+  it('is exhaustive: the union of all partitions equals the full list', () => {
+    const sorted = [...FILES].sort();
+    const p1 = selectPartition(sorted, requirePartition('1of3'));
+    const p2 = selectPartition(sorted, requirePartition('2of3'));
+    const p3 = selectPartition(sorted, requirePartition('3of3'));
+    expect([...p1, ...p2, ...p3].sort()).toEqual(sorted);
+  });
+
+  it('is pairwise disjoint: no file appears in two partitions', () => {
+    const sorted = [...FILES].sort();
+    const sets = ['1of3', '2of3', '3of3'].map(
+      (id) => new Set(selectPartition(sorted, requirePartition(id))),
+    );
+    for (let a = 0; a < sets.length; a++) {
+      for (let b = a + 1; b < sets.length; b++) {
+        for (const file of sets[a]) {
+          expect(sets[b].has(file)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('is balanced: partition sizes differ by at most one', () => {
+    const sorted = [...FILES].sort();
+    const sizes = ['1of3', '2of3', '3of3'].map(
+      (id) => selectPartition(sorted, requirePartition(id)).length,
+    );
+    expect(Math.max(...sizes) - Math.min(...sizes)).toBeLessThanOrEqual(1);
+  });
+
+  it('never introduces a path that the input did not contain', () => {
+    const sorted = [...FILES].sort();
+    for (const id of ['1of3', '2of3', '3of3']) {
+      const selected = selectPartition(sorted, requirePartition(id));
+      for (const file of selected) {
+        expect(sorted).toContain(file);
+      }
+    }
+  });
+
+  it('fails fast when a well-formed identity selects zero files', () => {
+    const tiny = ['src/a.test.ts', 'src/b.test.ts'];
+    // 3of3 on 2 files: no index i in {0,1} satisfies i % 3 === 2.
+    expect(() => selectPartition(tiny, requirePartition('3of3'))).toThrow(
+      /LLXPRT_CLI_TEST_PARTITION/,
+    );
+  });
+});
+
+describe('discoverTestFiles ignores LLXPRT_CLI_TEST_PARTITION', () => {
+  it('returns the complete inventory even while the env var is set', () => {
+    const root = mkdtempSync(join(tmpdir(), 'cli-runner-partition-env-'));
+    try {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      for (let i = 0; i < 5; i++) {
+        writeFileSync(join(root, 'src', `f${i}.test.ts`), '');
+      }
+
+      const saved = process.env.LLXPRT_CLI_TEST_PARTITION;
+      process.env.LLXPRT_CLI_TEST_PARTITION = '2of3';
+      try {
+        expect(discoverTestFiles(root)).toHaveLength(5);
+      } finally {
+        if (saved === undefined) {
+          delete process.env.LLXPRT_CLI_TEST_PARTITION;
+        } else {
+          process.env.LLXPRT_CLI_TEST_PARTITION = saved;
+        }
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('partition placement over the real discovered inventory', () => {
+  it('adding a test fixture places it in exactly one partition', () => {
+    const root = mkdtempSync(join(tmpdir(), 'cli-runner-partition-add-'));
+    try {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      for (let i = 0; i < 9; i++) {
+        const name = `file${String(i).padStart(2, '0')}.test.ts`;
+        writeFileSync(join(root, 'src', name), '');
+      }
+      // Add a fixture that sorts between existing files.
+      writeFileSync(join(root, 'src', 'file04b.test.ts'), '');
+
+      const discovered = discoverTestFiles(root);
+      expect(discovered).toContain('src/file04b.test.ts');
+
+      const partitions = ['1of3', '2of3', '3of3'].map((id) =>
+        selectPartition(discovered, requirePartition(id)),
+      );
+      let appearances = 0;
+      for (const partition of partitions) {
+        if (partition.includes('src/file04b.test.ts')) {
+          appearances++;
+        }
+      }
+      expect(appearances).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('three partitions over the real packages/cli inventory (issue #3185)', () => {
+  it('are exhaustive, pairwise disjoint, order-preserving, and balanced', () => {
+    const cliRoot = resolve(import.meta.dir, '..');
+    const discovered = discoverTestFiles(cliRoot);
+    expect(discovered.length).toBeGreaterThan(0);
+
+    const partitions = ['1of3', '2of3', '3of3'].map((id) =>
+      selectPartition(discovered, requirePartition(id)),
+    );
+
+    // Pairwise disjoint: no file appears in two partitions.
+    const sets = partitions.map((p) => new Set(p));
+    for (let a = 0; a < sets.length; a++) {
+      for (let b = a + 1; b < sets.length; b++) {
+        for (const file of sets[a]) {
+          expect(sets[b].has(file)).toBe(false);
+        }
+      }
+    }
+
+    // Exhaustive: the sorted union of all partitions equals the real inventory.
+    expect(
+      [...partitions[0], ...partitions[1], ...partitions[2]].sort(),
+    ).toEqual([...discovered].sort());
+
+    // Order-preserving: each partition's elements appear in the same relative
+    // order as in the discovered inventory.
+    for (const partition of partitions) {
+      const positions = partition.map((f) => discovered.indexOf(f));
+      const sortedPositions = [...positions].sort((x, y) => x - y);
+      expect(positions).toEqual(sortedPositions);
+    }
+
+    // Balanced: partition sizes differ by at most one.
+    const sizes = partitions.map((p) => p.length);
+    expect(Math.max(...sizes) - Math.min(...sizes)).toBeLessThanOrEqual(1);
+
+    // Evidence of the current inventory size (count-agnostic, not hard-coded).
+    expect(partitions.reduce((sum, p) => sum + p.length, 0)).toBe(
+      discovered.length,
+    );
   });
 });

--- a/project-plans/issue3185/plan.md
+++ b/project-plans/issue3185/plan.md
@@ -1,0 +1,200 @@
+# Issue 3185: CLI CI Partition Plan
+
+## Scope
+
+Split only the existing logical `cli` test shard into parallel GitHub Actions matrix legs. Keep the logical shard name, package selection, test discovery, per-file process isolation, canonical local suite, and required `Test` aggregator unchanged.
+
+The implementation must not add dependencies, a new orchestration subsystem, code-coverage instrumentation, test exclusions, shared cross-file state, or unrelated workflow changes.
+
+## Verified baseline
+
+The issue cites four successful CLI-bearing CI runs:
+
+| Run | Complete verdict | CLI job |
+| --- | ---: | ---: |
+| 31290737638 | 14m34s | 12m34s |
+| 31285748447 | 15m00s | 10m00s |
+| 31285400987 | 14m17s | 12m26s |
+| 31276892758 | 14m04s | 12m27s |
+| Mean | 14m29s | 11m52s |
+
+The timestamps and conclusions were re-read from GitHub Actions before implementation. Current CLI discovery returns 682 sorted test files. The current runner executes each file in a separate `bun test` process and writes `packages/cli/junit.xml`. The PR workflow emits one matrix row per logical shard and runs the test matrix after `node_consumer_smoke`.
+
+The repository currently has test-file coverage, not PR code-coverage instrumentation: `scripts/check-test-file-coverage.ts` verifies that every discovered test file belongs to exactly one executor. “Coverage evidence” below therefore means this test-file coverage invariant plus complete JUnit inventories.
+
+## Accepted behavior
+
+1. A representative CLI-affecting pull request receives its complete CI verdict in under 10 minutes on average across at least three successful GitHub Actions runs carrying the same partition implementation.
+2. The union of CLI partitions equals the complete, structurally discovered CLI test inventory. No test is deleted, skipped, excluded, duplicated, or silently omitted.
+3. Partition assignment is deterministic, pairwise disjoint, balanced by file count, and total for every discovered path. Adding or moving a conforming CLI test automatically places it in exactly one partition; it cannot fall outside an allow-list because no allow-list or manifest is used.
+4. Missing or malformed external partition identity fails before any test process starts. An explicitly selected empty partition also fails rather than producing a green no-op run.
+5. `discoverTestFiles()` remains unpartitioned so the repository test-file coverage guard continues to inspect the complete inventory.
+6. Test isolation remains unchanged: every selected file still runs in its own Bun process with existing concurrency, timeout, and process-tree handling.
+7. Each partition produces a complete JUnit document for its selected files. Matrix job names, reporter check names, and fork artifact names are unique per partition; the existing JUnit path remains consumable.
+8. Unset partition identity remains a complete run. `npm run test`, `bun scripts/test.ts`, `bun scripts/test.ts --shard cli`, and nightly execution retain their complete local behavior.
+9. Before/after workflow wall-clock, each partition’s job and test-step duration, inventory and case counts, JUnit checks, and test-file coverage are recorded from candidate-head CI.
+
+## Inputs and boundary cases
+
+### CLI runner input
+
+`LLXPRT_CLI_TEST_PARTITION` is the only new external input.
+
+- Unset, empty, or whitespace: run the full discovered inventory.
+- `1of1`: run the full discovered inventory.
+- `1of3`, `2of3`, `3of3`: run the corresponding one-based sorted round-robin partition.
+- Noncanonical forms, zero/negative values, unsafe integers, or index greater than count: fail fast with an error naming the variable and received value.
+- A well-formed identity that selects no files: fail fast with a distinct error.
+
+### Matrix input
+
+- No selected logical shards: no rows, preserving the existing docs-only/no-tests path.
+- `cli`: three Ubuntu/Node 24 rows carrying `1of3`, `2of3`, and `3of3`.
+- Any other shard: one row carrying `1of1`.
+- Full logical selection: all current logical shards remain represented and every `(shard, partition, os, node-version)` tuple is unique.
+
+## Design
+
+### Runner partition
+
+After `discoverTestFiles(root)` returns the complete sorted list, parse the optional partition identity and select files by:
+
+```text
+file position modulo partition count equals partition index minus one
+```
+
+This maps every array position to exactly one partition and preserves relative order. With the current inventory, three partitions contain 228, 227, and 227 files. Discovery itself must not read the partition input.
+
+### Matrix expansion
+
+Keep `selectedShards` and the canonical shard map logical. A small matrix builder in `scripts/affected-test-shards.ts` expands `cli` into three physical rows and assigns `1of1` to other logical shards. This avoids changes to `scripts/test.ts`, `scripts/test-shards.ts`, the checked-in affected-shard graph, the coverage-complete calculation, and the required `Test` aggregator.
+
+The workflow passes each row’s identity through `LLXPRT_CLI_TEST_PARTITION`. Only the CLI runner consumes it. Matrix job names, JUnit reporter names, and fork artifact names include the identity.
+
+## Test-first sequence
+
+All changed/new tests use `bun:test`.
+
+### RED 1: CLI runner behavior
+
+Extend `packages/cli/test/run-bun-tests.test.ts` first to prove:
+
+- absent and blank identities mean no partition;
+- canonical identity parses;
+- malformed, out-of-range, and unsafe identities fail;
+- `1of1` is identity selection;
+- partitions are deterministic, order-preserving, balanced, exhaustive, and disjoint across the real discovered inventory;
+- adding a test fixture causes it to appear in exactly one partition;
+- discovery returns the complete fixture inventory even while the environment variable is set;
+- selection never introduces an input path that discovery did not return.
+
+Run this file and record the expected RED failure before production edits, then implement only the runner behavior needed to make it green.
+
+### RED 2: selector matrix behavior
+
+Extend `scripts/tests/affected-test-shards.test.ts` first to prove:
+
+- CLI-only selection creates exactly the three expected rows;
+- a non-CLI shard creates one `1of1` row;
+- an empty selection creates no rows;
+- full selection preserves every logical shard;
+- every physical row is unique and Ubuntu-only;
+- GitHub output still reports unchanged logical shard, test-presence, and coverage-complete values while its matrix contains all CLI rows;
+- configured partition counts name real logical shards and are positive integers.
+
+Run this file and record RED before implementing matrix expansion.
+
+### RED 3: workflow wiring
+
+Add a focused Bun test under `scripts/tests/` using the existing workflow YAML parser. Prove that the `test_shard` job:
+
+- includes partition identity in its display name;
+- passes the exact environment variable to the shard test step;
+- retains the logical `bun scripts/test.ts --shard` command;
+- includes partition identity in reporter and fork artifact names;
+- retains the existing JUnit glob and logical shard conditions.
+
+Run it RED before editing `.github/workflows/ci.yml`, then make only the required wiring changes.
+
+## Local verification
+
+Required targeted checks:
+
+- CLI runner test file
+- affected-shard selector test file
+- workflow wiring test file
+- `bun scripts/check-test-file-coverage.ts`
+- `npm run lint:test-shards`
+- CLI partition invocations for all three identities, confirming the union count
+- unpartitioned `bun scripts/test.ts --shard cli`, confirming the complete inventory
+
+Required repository gates before push:
+
+- `npm run test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run format`
+- `npm run build`
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+
+## Candidate-head CI evidence
+
+For at least three successful runs carrying the same implementation:
+
+1. Measure workflow `created_at` to the latest completed job and compute the mean. Acceptance requires a mean below 600 seconds.
+2. Record all three CLI partition job durations and their `Run shard tests` step durations.
+3. Extract each runner header, passed-file summary, and case-count summary. Confirm identities are exactly `1of3`, `2of3`, `3of3`, each reports the same discovered total, and selected file counts sum to the discovered total.
+4. Confirm three distinct successful JUnit reporter checks and, where applicable, unique fork artifacts.
+5. Confirm the test-file coverage guard is green with zero uncovered and zero multiply owned files.
+6. Compare candidate partitioning files across measured heads; implementation changes reset the three-run evidence set.
+7. Record the completed evidence here, in the PR, on issue 3185, and on parent issue 2702.
+
+## Review finding triage
+
+Every finding is assigned exactly one class:
+
+- **Blocker-Fix:** accepted behavior, correctness, data/test loss, security, required gate, or mergeability would fail.
+- **In-scope-Fix:** directly improves the bounded partition implementation or its required evidence without expanding architecture.
+- **Reject:** factually incorrect, already covered, or conflicts with accepted behavior.
+- **Defer:** valid but outside this issue, requiring another subsystem, public abstraction, dependency, unrelated workflow change, or adjacent cleanup.
+
+Only Blocker-Fix and In-scope-Fix findings authorize changes in this effort.
+
+## Explicitly out of scope
+
+- New dependencies, orchestration systems, logical shard families, timing manifests, or public partition APIs.
+- Code-coverage instrumentation or coverage-threshold changes.
+- Changes to unrelated packages, individual CLI test behavior, test concurrency/timeouts, nightly workflow, selector dependency graph, `node_consumer_smoke` gating, or required-check aggregation.
+- Test deletion, exclusion, consolidation, shared state, or `isolate=false`.
+- Lint/complexity/safety weakening, suppression directives, ignores, or unrelated refactors/documentation cleanup.
+
+## Local implementation evidence
+
+- Focused partition, selector, and workflow tests: 156 passed, 0 failed.
+- Test-file coverage guard: zero uncovered and zero doubly executed files.
+- Logical shard guard: all 16 workspaces remain covered by the six canonical shards.
+- Actual local CLI partition executions selected 228, 227, and 227 of the same 682 discovered files. Their case totals sum to 8,835 passed, 5 pre-existing skipped, 13 todo, and 8,853 total, matching the canonical unpartitioned CLI run.
+- `npm run format`, `npm run lint`, `npm run typecheck`, and `npm run build` passed. The `stepfun-37` real-model smoke test passed.
+- Two exact `npm run test` attempts and two runs with the supported agents concurrency override completed the unchanged workspaces but encountered changing `packages/agents` per-file child-process watchdog failures on macOS. Every reported file passed immediately when rerun alone. This implementation does not touch agents code, its runner, concurrency, or timeouts. No clean exact full-suite result was obtained locally; candidate-head Linux CI must therefore be green before completion, and any reproduced agents failure is a mergeability blocker.
+- The original implementation subagent was instructed to work test-first but timed out without returning its RED transcript, so temporal RED evidence for the initial three slices is unavailable and is not claimed. Review remediation has captured RED evidence for unsafe-integer and noncanonical-whitespace inputs before their production fixes.
+
+## DeepThinker review triage
+
+| Finding | Class | Disposition |
+| --- | --- | --- |
+| Whitespace-wrapped noncanonical identities were accepted | Blocker-Fix | Fixed test-first by validating the original nonblank value; surrounding space, newline, and tab cases now fail. |
+| Matrix construction mutated an accumulator | In-scope-Fix | Replaced with immutable `flatMap`/`Array.from` transformation. |
+| Directly affected matrix and smoke comments were stale | In-scope-Fix | Corrected without changing workflow behavior. |
+| Required full-suite gate lacked a clean result | Blocker-Fix | No unrelated runner change made; bounded evidence recorded above, with candidate-head CI retained as a hard completion gate. |
+| Initial temporal RED transcript was unavailable | In-scope-Fix | Limitation recorded honestly above; no evidence was fabricated. |
+| Change the unrelated agents harness | Defer | Outside issue scope absent a candidate-head failure. |
+| Round-robin is nondeterministic, incomplete, duplicated, or unbalanced | Reject | Contradicted by real-inventory behavioral tests and all three actual partition runs. |
+| Add partition-specific JUnit paths or alter the logical CLI smoke condition | Reject | Matrix workspaces are isolated; existing paths remain consumable and names are already partition-unique. |
+
+## Open Code Review triage
+
+OCR reviewed six of seven code/test/workflow files and returned one Medium finding; its `scripts/affected-test-shards.ts` task failed after an invalid line-range tool request. DeepThinker had already completed a full review of that file, and the two-review-cycle limit prevents another independent review round.
+
+| Finding | Class | Disposition |
+| --- | --- | --- |
+| JavaScript `$` allegedly accepts `1of3` followed by a newline | Reject | Bun 1.3.14 returns `null` for the anchored regex against that input, and the behavioral trailing-newline rejection test passes. The claimed defect is not reproducible in the actual runner. |

--- a/scripts/affected-test-shards.ts
+++ b/scripts/affected-test-shards.ts
@@ -825,21 +825,63 @@ function sanitizeGhValue(value: string): string {
   return value.replace(CRLF_RE, ' ');
 }
 
+// ---------------------------------------------------------------------------
+// Matrix expansion (issue #3185)
+// ---------------------------------------------------------------------------
+
+/**
+ * One physical matrix row consumed by the `test_shard` job's
+ * `fromJSON(needs.shard_selector.outputs.matrix)`.
+ */
+export interface MatrixRow {
+  readonly shard: string;
+  readonly os: string;
+  readonly 'node-version': string;
+  readonly partition: string;
+}
+
+/**
+ * Maps a logical shard name to the number of physical CI legs it expands into.
+ * A shard absent from this map gets a single `1of1` leg. Only `cli` is
+ * partitioned (issue #3185): it is the longest shard (~12 min) and splits into
+ * three balanced legs to target a sub-10-minute critical path.
+ */
+export const SHARD_PARTITION_COUNTS: Readonly<Record<string, number>> = {
+  cli: 3,
+};
+
+/**
+ * Expands logical shard names into physical matrix rows. Each shard expands
+ * into one or more rows carrying a canonical `NofM` partition identity that
+ * the CLI runner consumes via `LLXPRT_CLI_TEST_PARTITION`.
+ *
+ * Pure: no I/O, no env, no side effects. The selection logic, coverage
+ * calculation, and logical shard output are untouched — only the physical
+ * matrix shape changes.
+ */
+export function buildMatrix(
+  selectedShards: readonly string[],
+): readonly MatrixRow[] {
+  return selectedShards.flatMap((shard) => {
+    const count = SHARD_PARTITION_COUNTS[shard] ?? 1;
+    return Array.from({ length: count }, (_, i) => ({
+      shard,
+      os: 'ubuntu-latest',
+      'node-version': '24.x',
+      partition: `${i + 1}of${count}`,
+    }));
+  });
+}
+
 function outputGithubActions(result: SelectionResult, event: string): void {
   const ghOutputPath = process.env.GITHUB_OUTPUT;
   const ghSummaryPath = process.env.GITHUB_STEP_SUMMARY;
 
-  // Build the matrix: one entry per selected shard (issue #2876).
-  // macOS test coverage moved to the nightly workflow (nightly.yml), so
-  // the PR test matrix is ubuntu-only — macOS is nightly-only like Windows.
-  const matrix: Array<{
-    readonly shard: string;
-    readonly os: string;
-    readonly 'node-version': string;
-  }> = [];
-  for (const shard of result.selectedShards) {
-    matrix.push({ shard, os: 'ubuntu-latest', 'node-version': '24.x' });
-  }
+  // Build the matrix via the pure expander (issue #3185): logical shards
+  // expand to physical partition rows — cli into 1of3/2of3/3of3; other
+  // shards remain a single 1of1 row. All physical rows are ubuntu-only
+  // (issue #2876); macOS test coverage moved to the nightly workflow.
+  const matrix = buildMatrix(result.selectedShards);
 
   const selectedStr = sanitizeGhValue(result.selectedShards.join(','));
   const matrixStr = sanitizeGhValue(JSON.stringify(matrix));

--- a/scripts/tests/affected-test-shards-partition.test.ts
+++ b/scripts/tests/affected-test-shards-partition.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3185: CLI partition matrix expansion tests.
+ *
+ * These tests prove that the affected-test-shard selector expands the
+ * logical `cli` shard into three physical matrix rows (1of3/2of3/3of3)
+ * while other shards remain single-row (1of1). They exercise the REAL
+ * selector (`scripts/affected-test-shards.ts`) via its CLI entry point
+ * and the REAL checked-in graph.
+ *
+ * Split from affected-test-shards.test.ts to keep that file within the
+ * 800-line lint limit.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { asRecordArray, asString } from './typed-test-helpers.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const SELECTOR_PATH = join(REPO_ROOT, 'scripts', 'affected-test-shards.ts');
+
+interface MatrixRow {
+  readonly shard: string;
+  readonly os: string;
+  readonly 'node-version': string;
+  readonly partition: string;
+}
+
+interface SelectorModule {
+  buildMatrix: (selectedShards: readonly string[]) => readonly MatrixRow[];
+  SHARD_PARTITION_COUNTS: Readonly<Record<string, number>>;
+}
+
+async function loadSelector(): Promise<SelectorModule> {
+  return await import(SELECTOR_PATH);
+}
+
+const PR_EVENT = 'pull_request';
+const ALL_SHARDS = ['cli', 'agents', 'providers', 'core', 'rest', 'scripts'];
+
+/** Runs the selector CLI and returns the raw GITHUB_OUTPUT lines. */
+function runSelectorRecords(paths: readonly string[]): string[] {
+  const dir = mkdtempSync(join(tmpdir(), 'af-part-'));
+  try {
+    const files = join(dir, 'f.txt');
+    const output = join(dir, 'o.txt');
+    writeFileSync(files, paths.join('\n'));
+    const run = spawnSync(
+      process.execPath,
+      [
+        SELECTOR_PATH,
+        '--event',
+        PR_EVENT,
+        '--files-from',
+        files,
+        '--output',
+        'github-actions',
+      ],
+      { env: { ...process.env, GITHUB_OUTPUT: output } },
+    );
+    expect(run.stderr?.toString() ?? '').toBe('');
+    expect(run.status).toBe(0);
+    return readFileSync(output, 'utf8').split('\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function recordsToMatrix(records: readonly string[]): readonly MatrixRow[] {
+  const rec = records.find((l) => l.startsWith('matrix='));
+  if (!rec) throw new Error('no matrix= record');
+  return asRecordArray(JSON.parse(rec.substring('matrix='.length))).map(
+    (row) => ({
+      shard: asString(row['shard']),
+      os: asString(row['os']),
+      'node-version': asString(row['node-version']),
+      partition: asString(row['partition']),
+    }),
+  );
+}
+
+function recordsKey(records: readonly string[], key: string): string {
+  const rec = records.find((l) => l.startsWith(`${key}=`));
+  if (!rec) throw new Error(`no ${key}= record`);
+  return rec.substring(`${key}=`.length);
+}
+
+describe('affected-test-shards selector — CLI partition matrix (issue #3185)', () => {
+  it('cli-only selection creates exactly three rows with logical shard cli', () => {
+    const matrix = recordsToMatrix(
+      runSelectorRecords(['schemas/settings.schema.json']),
+    );
+    expect(matrix).toHaveLength(3);
+    expect(matrix.map((r) => r.partition).sort()).toEqual([
+      '1of3',
+      '2of3',
+      '3of3',
+    ]);
+    for (const row of matrix) expect(row.shard).toBe('cli');
+  });
+
+  it('a non-cli shard creates one 1of1 row', () => {
+    const matrix = recordsToMatrix(
+      runSelectorRecords(['packages/providers/src/BaseProvider.test.ts']),
+    );
+    expect(matrix).toHaveLength(1);
+    expect(matrix[0]?.shard).toBe('providers');
+    expect(matrix[0]?.partition).toBe('1of1');
+  });
+
+  it('empty selection (docs-only) creates no rows', () => {
+    const matrix = recordsToMatrix(
+      runSelectorRecords(['docs/getting-started.md']),
+    );
+    expect(matrix).toEqual([]);
+  });
+
+  it('full selection preserves every logical shard and unique tuples', () => {
+    const matrix = recordsToMatrix(runSelectorRecords(['package.json']));
+    expect([...new Set(matrix.map((r) => r.shard))]).toEqual(ALL_SHARDS);
+    const tuples = matrix.map(
+      (r) => `${r.shard}|${r.partition}|${r.os}|${r['node-version']}`,
+    );
+    expect(new Set(tuples).size).toBe(tuples.length);
+    for (const row of matrix) {
+      expect(row.os).toBe('ubuntu-latest');
+      expect(row['node-version']).toBe('24.x');
+    }
+  });
+
+  it('github output still reports unchanged logical shard values', () => {
+    const recs = runSelectorRecords(['schemas/settings.schema.json']);
+    expect(recordsKey(recs, 'selected_shards')).toBe('cli');
+    expect(recordsKey(recs, 'has_tests')).toBe('true');
+    expect(recordsKey(recs, 'coverage_complete')).toBe('false');
+  });
+
+  it('configured partition counts name real logical shards and are positive integers', async () => {
+    const { SHARD_PARTITION_COUNTS } = await loadSelector();
+    for (const [shard, count] of Object.entries(SHARD_PARTITION_COUNTS)) {
+      expect(ALL_SHARDS).toContain(shard);
+      expect(Number.isInteger(count)).toBe(true);
+      expect(count).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('buildMatrix: cli→three rows, non-cli→one 1of1, empty→none, full→all shards unique', async () => {
+    const { buildMatrix } = await loadSelector();
+    const cli = buildMatrix(['cli']);
+    expect(cli).toHaveLength(3);
+    expect(cli.map((r) => r.partition)).toEqual(['1of3', '2of3', '3of3']);
+    expect(buildMatrix(['core'])[0]?.partition).toBe('1of1');
+    expect(buildMatrix([])).toEqual([]);
+    const full = buildMatrix(ALL_SHARDS);
+    expect([...new Set(full.map((r) => r.shard))]).toEqual(ALL_SHARDS);
+    const tuples = full.map(
+      (r) => `${r.shard}|${r.partition}|${r.os}|${r['node-version']}`,
+    );
+    expect(new Set(tuples).size).toBe(tuples.length);
+  });
+});

--- a/scripts/tests/affected-test-shards-partition.test.ts
+++ b/scripts/tests/affected-test-shards-partition.test.ts
@@ -159,7 +159,9 @@ describe('affected-test-shards selector — CLI partition matrix (issue #3185)',
     const cli = buildMatrix(['cli']);
     expect(cli).toHaveLength(3);
     expect(cli.map((r) => r.partition)).toEqual(['1of3', '2of3', '3of3']);
-    expect(buildMatrix(['core'])[0]?.partition).toBe('1of1');
+    const core = buildMatrix(['core']);
+    expect(core).toHaveLength(1);
+    expect(core[0]?.partition).toBe('1of1');
     expect(buildMatrix([])).toEqual([]);
     const full = buildMatrix(ALL_SHARDS);
     expect([...new Set(full.map((r) => r.shard))]).toEqual(ALL_SHARDS);

--- a/scripts/tests/affected-test-shards.test.ts
+++ b/scripts/tests/affected-test-shards.test.ts
@@ -67,6 +67,13 @@ interface ReplayResult {
   readonly criticalPathSavingSeconds: number;
 }
 
+interface MatrixRow {
+  readonly shard: string;
+  readonly os: string;
+  readonly 'node-version': string;
+  readonly partition: string;
+}
+
 interface SelectorModule {
   selectAffectedShards: (params: {
     readonly event: string;
@@ -76,6 +83,8 @@ interface SelectorModule {
     readonly count: number;
     readonly base?: string;
   }) => ReplayResult;
+  buildMatrix: (selectedShards: readonly string[]) => readonly MatrixRow[];
+  SHARD_PARTITION_COUNTS: Readonly<Record<string, number>>;
 }
 
 async function loadSelector(): Promise<SelectorModule> {
@@ -771,7 +780,7 @@ describe('affected-test-shards selector — ubuntu-only PR matrix (issue #2876)'
     }
   });
 
-  it('does not emit any macOS matrix rows for full-run pull_request events', () => {
+  it('does not emit any macOS matrix rows for full-run pull_request events', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'affected-shards-no-macos-'));
     try {
       const files = join(dir, 'files.txt');
@@ -796,12 +805,19 @@ describe('affected-test-shards selector — ubuntu-only PR matrix (issue #2876)'
       expect(run.status).toBe(0);
       const records = readFileSync(output, 'utf8').split('\n');
       const matrixRecord = records.find((line) => line.startsWith('matrix='));
-      expect(matrixRecord).toBeDefined();
+      if (!matrixRecord) throw new Error('expected matrix= record in output');
+      const { SHARD_PARTITION_COUNTS } = await loadSelector();
+      const expectedRows = ALL_SHARDS.reduce(
+        (sum, shard) => sum + (SHARD_PARTITION_COUNTS[shard] ?? 1),
+        0,
+      );
       const matrixJson = JSON.parse(
-        matrixRecord!.substring('matrix='.length),
+        matrixRecord.substring('matrix='.length),
       ) as ReadonlyArray<{ readonly os: string }>;
-      // Full-run selects all shards, but all on ubuntu-latest.
-      expect(matrixJson.length).toBe(ALL_SHARDS.length);
+      // Full-run selects all shards, all on ubuntu-latest. The expected row
+      // count is derived from SHARD_PARTITION_COUNTS (issue #3185 expands cli
+      // into three legs) rather than a hard-coded adjustment.
+      expect(matrixJson.length).toBe(expectedRows);
       for (const entry of matrixJson) {
         expect(entry.os).toBe('ubuntu-latest');
       }

--- a/scripts/tests/ci-secure-store-workflow.test.ts
+++ b/scripts/tests/ci-secure-store-workflow.test.ts
@@ -75,13 +75,13 @@ describe('Issue #2147: SecureStore backend coverage is separated from full CI su
     secureStoreJob = jobs['secure_store_backend'];
   });
 
-  it('runs the full test suite once per OS per shard under normal keyring behavior', () => {
+  it('runs partition-aware shard jobs under normal keyring behavior', () => {
     expect(
       testShardJob,
       'ci.yml must contain the test_shard matrix job',
     ).toBeTruthy();
     expect(testShardJob?.name).toBe(
-      'Test (${{ matrix.os }}) [${{ matrix.shard }}]',
+      'Test (${{ matrix.os }}) [${{ matrix.shard }} ${{ matrix.partition }}]',
     );
     const matrix = asOptionalRecord(
       asOptionalRecord(testShardJob?.strategy)?.['matrix'],
@@ -112,7 +112,7 @@ describe('Issue #2147: SecureStore backend coverage is separated from full CI su
       'Upload Test Results Artifact (for forks)',
     );
     expect(forkArtifact.with?.['name']).toBe(
-      'test-results-fork-${{ matrix.shard }}-${{ matrix.node-version }}-${{ matrix.os }}',
+      'test-results-fork-${{ matrix.shard }}-${{ matrix.partition }}-${{ matrix.node-version }}-${{ matrix.os }}',
     );
 
     // Issue #2970: the dead coverage pipeline (Upload coverage reports step)

--- a/scripts/tests/ci-test-shard-partition.test.ts
+++ b/scripts/tests/ci-test-shard-partition.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3185: verify the `test_shard` job in `.github/workflows/ci.yml`
+ * passes the partition identity through to the CLI runner and includes it in
+ * display, reporter, and artifact names — while retaining the logical shard
+ * command, JUnit glob, and existing conditions.
+ *
+ * Uses the existing typed workflow YAML helper (typed-test-helpers.ts) to
+ * parse the committed workflow, so the tests pin the real wiring, not a
+ * re-implementation.
+ */
+
+import { describe, expect, it, beforeAll } from 'bun:test';
+import {
+  asString,
+  asRecord,
+  parseWorkflowYaml,
+  workflowJob,
+  type WorkflowDocument,
+} from './typed-test-helpers.ts';
+import { readRootFile, stepNamed } from './ocr-review-workflow-helpers.ts';
+import { PARTITION_ENV_VAR } from '../../packages/cli/run-bun-tests.js';
+
+function loadCiWorkflow(): WorkflowDocument {
+  const source = readRootFile('.github/workflows/ci.yml');
+  return parseWorkflowYaml(source);
+}
+
+describe('Issue #3185: test_shard partition wiring', () => {
+  let workflow: WorkflowDocument;
+
+  beforeAll(() => {
+    workflow = loadCiWorkflow();
+  });
+
+  it('includes partition identity in the job display name', () => {
+    const testShard = workflowJob(workflow, 'test_shard');
+    const name = asString(testShard['name']);
+    expect(name).toContain('matrix.partition');
+  });
+
+  it('passes the exact partition env var to the shard test step', () => {
+    const testShard = workflowJob(workflow, 'test_shard');
+    const step = stepNamed(testShard, 'Run shard tests (issue #2707)');
+    const env = asRecord(step['env']);
+    // The YAML env key is looked up via the runner's PARTITION_ENV_VAR
+    // constant, so a workflow/runner name mismatch fails here (no drift).
+    expect(env[PARTITION_ENV_VAR]).toBe('${{ matrix.partition }}');
+  });
+
+  it('retains the logical shard command (bun scripts/test.ts --shard)', () => {
+    const testShard = workflowJob(workflow, 'test_shard');
+    const step = stepNamed(testShard, 'Run shard tests (issue #2707)');
+    expect(asString(step['run'])).toContain(
+      'bun scripts/test.ts --shard "${{ matrix.shard }}"',
+    );
+  });
+
+  it('includes partition identity in the reporter check name', () => {
+    const testShard = workflowJob(workflow, 'test_shard');
+    const step = stepNamed(testShard, 'Publish Test Report (for non-forks)');
+    const withBlock = asRecord(step['with']);
+    const name = asString(withBlock['name']);
+    expect(name).toContain('matrix.partition');
+  });
+
+  it('includes partition identity in the fork artifact name', () => {
+    const testShard = workflowJob(workflow, 'test_shard');
+    const step = stepNamed(
+      testShard,
+      'Upload Test Results Artifact (for forks)',
+    );
+    const withBlock = asRecord(step['with']);
+    const name = asString(withBlock['name']);
+    expect(name).toContain('matrix.partition');
+  });
+
+  it('retains the packages/*/junit.xml JUnit glob in the reporter step', () => {
+    const testShard = workflowJob(workflow, 'test_shard');
+    const step = stepNamed(testShard, 'Publish Test Report (for non-forks)');
+    const withBlock = asRecord(step['with']);
+    expect(asString(withBlock['path'])).toBe('packages/*/junit.xml');
+  });
+
+  it('retains the packages/*/junit.xml JUnit glob in the fork artifact step', () => {
+    const testShard = workflowJob(workflow, 'test_shard');
+    const step = stepNamed(
+      testShard,
+      'Upload Test Results Artifact (for forks)',
+    );
+    const withBlock = asRecord(step['with']);
+    expect(asString(withBlock['path'])).toBe('packages/*/junit.xml');
+  });
+
+  it('retains the cli smoke step condition (matrix.shard == cli)', () => {
+    const testShard = workflowJob(workflow, 'test_shard');
+    const steps = testShard['steps'] ?? [];
+    const smokeStep = steps.find((s) => {
+      const name = s['name'];
+      return typeof name === 'string' && name.includes('Smoke test CLI entry');
+    });
+    expect(smokeStep).toBeDefined();
+    expect(asString(smokeStep?.['if'])).toContain("matrix.shard == 'cli'");
+  });
+
+  it('retains the job-level if condition referencing shard_selector outputs', () => {
+    const testShard = workflowJob(workflow, 'test_shard');
+    expect(asString(testShard['if'])).toContain(
+      'needs.shard_selector.outputs.has_tests',
+    );
+  });
+});


### PR DESCRIPTION
## TLDR

Splits the existing logical CLI test shard into three deterministic physical GitHub Actions matrix legs so CLI-affected pull requests no longer wait on one roughly 12-minute test job.

All 682 currently discovered CLI test files remain structurally discovered before partitioning. Sorted round-robin assignment produces inventories of 228, 227, and 227 files, while unpartitioned local and nightly execution remains unchanged.

## Dive Deeper

- Keeps the logical shard name as cli, preserving affected-shard selection, completeness guards, and the required Test aggregator.
- Expands cli into physical identities 1of3, 2of3, and 3of3; non-CLI rows carry 1of1.
- Passes partition identity through LLXPRT_CLI_TEST_PARTITION and selects files only after complete discovery.
- Rejects malformed, noncanonical, unsafe, out-of-range, and explicitly empty partitions before any test worker starts.
- Preserves one Bun process per test file, existing concurrency and timeout handling, JUnit generation, and canonical complete local execution.
- Adds behavioral tests over temporary fixtures, selector output, actual workflow YAML, and the real CLI inventory.
- Includes partition identity in matrix job, test reporter, and fork artifact names so each JUnit result remains distinct and consumable.

The implementation plan and evidence ledger are in project-plans/issue3185/plan.md. Authoritative candidate-head wall-clock evidence will be appended after at least three successful GitHub Actions runs on this identical implementation.

## Reviewer Test Plan

1. Run the focused behavior suite:

       bun test packages/cli/test/run-bun-tests.test.ts scripts/tests/affected-test-shards.test.ts scripts/tests/affected-test-shards-partition.test.ts scripts/tests/ci-test-shard-partition.test.ts

2. Verify complete and unique test-file ownership:

       bun scripts/check-test-file-coverage.ts
       npm run lint:test-shards

3. Exercise each physical CLI partition:

       LLXPRT_CLI_TEST_PARTITION=1of3 bun scripts/test.ts --shard cli
       LLXPRT_CLI_TEST_PARTITION=2of3 bun scripts/test.ts --shard cli
       LLXPRT_CLI_TEST_PARTITION=3of3 bun scripts/test.ts --shard cli

4. Confirm an unpartitioned CLI run still executes the full inventory:

       bun scripts/test.ts --shard cli

5. Inspect the Actions matrix for three distinct CLI jobs and distinct JUnit reporter names. Confirm the required Test aggregator waits for every selected matrix leg.

Local evidence:

- Focused behavior suite: 156 passed, 0 failed.
- Physical inventories: 228/682, 227/682, and 227/682 files.
- Aggregate partition cases: 8835 passed, 0 failed, 5 pre-existing skipped, 13 todo; identical to the canonical complete CLI run.
- Test-file coverage guard: zero uncovered and zero doubly executed files.
- Logical shard guard: all 16 workspaces remain covered by six logical shards.
- Format, lint, typecheck, build, and the stepfun-37 real-model smoke test passed.

Full-suite local caveat: repeated exact npm run test executions completed all workspaces but returned failure because different packages/agents child processes hit the existing 180-second watchdog under local macOS process contention. Every reported agents file passed promptly when rerun alone, no agents file is changed here, and the CLI suite itself completed 682/682 files with the case totals above. Candidate-head GitHub Actions remains the required merge gate and authoritative performance environment.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️ focused gates pass; full-suite caveat above | ❓ | CI pending |
| npx      | - | - | - |
| Docker   | - | - | - |
| Podman   | - | - | - |
| Seatbelt | - | - | - |

## Linked issues / bugs

Fixes #3185

Part of #2702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * CLI tests now run across three parallel partitions in CI, reducing feedback time.
  * Test files are distributed evenly and deterministically across partitions.

* **Bug Fixes**
  * Invalid or empty test partition configurations now fail fast with clear validation.

* **Testing**
  * Added comprehensive coverage for partition selection, CI wiring, reporting, artifacts, and test completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->