### PR TITLE
Bound foreground shell output acquisition across platforms (Fixes #3200)

### DIFF
--- a/docs/reference/ephemerals.md
+++ b/docs/reference/ephemerals.md
@@ -93,6 +93,14 @@ Prevent tools from flooding the context. Applied to all tools via the batch sche
 
 Built-in visual-model aliases provide conservative advisory defaults: Claude Opus/Sonnet use `1568`/`1568`/`1229312`; OpenAI `gpt-*` uses `2048`/`2048`/`1572864`; Kimi uses `4096`/`2160`/`8847360` (long edge/short edge/pixels). These are useful-resolution targets, not universal provider hard limits. Explicit profile values take precedence over model defaults. When no limit is configured, image reads retain legacy byte-for-byte behavior. Setting `image-resize.enabled false` disables all automatic limits for the profile. For one `read_file` call, pass `skip_image_resize: true` to return the original image; `read_many_files` has no per-call opt-out.
 
+## Shell Output Acquisition
+
+| Setting                            | Type   | Default   | Profile | Description                                                                                                                                                                   |
+| ---------------------------------- | ------ | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shell-output-retention-max-bytes` | number | `4194304` | yes     | Maximum shell-output bytes retained during command execution. Excess output keeps draining but is retained as bounded head/tail data. `-1` selects the finite 64 MiB ceiling. |
+
+This acquisition-time byte bound protects process memory before model-facing token truncation runs. Values below 1024 bytes are raised to 1024, and values above 64 MiB are clamped to the hard ceiling.
+
 ## Timeouts
 
 Prevent commands and tasks from hanging indefinitely. In seconds (not milliseconds, despite older docs).

--- a/docs/settings-and-profiles.md
+++ b/docs/settings-and-profiles.md
@@ -189,6 +189,14 @@ These prevent a single tool call from flooding the context. This matters more th
 
 `tool-output-truncate-mode` controls what happens when a tool exceeds its limits. `warn` drops the output entirely and tells the model the results were too large — the model gets nothing back, just a message suggesting it narrow its query. `truncate` cuts the output to fit and silently includes what fits. `sample` picks evenly-spaced lines from the output to give a representative cross-section. `warn` is the default because it forces the model to be more surgical, which usually produces better results than shoveling truncated output into context.
 
+### Shell output acquisition
+
+| Setting                            | Description                                                                                                         | Default   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------- |
+| `shell-output-retention-max-bytes` | Shell bytes retained in memory while a command runs; excess is represented by bounded head/tail output and metadata | `4194304` |
+
+This byte budget is enforced while output is acquired, before the separate model-facing token limiter. Commands continue to drain and complete after the budget fills. Values are clamped to a minimum of 1024 bytes and a hard maximum of 64 MiB; `-1` selects that finite hard maximum rather than disabling the bound.
+
 ### Timeouts
 
 | Setting                         | Description                                                 | Default         |

--- a/docs/settings-and-profiles.md
+++ b/docs/settings-and-profiles.md
@@ -195,7 +195,7 @@ These prevent a single tool call from flooding the context. This matters more th
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------- |
 | `shell-output-retention-max-bytes` | Shell bytes retained in memory while a command runs; excess is represented by bounded head/tail output and metadata | `4194304` |
 
-This byte budget is enforced while output is acquired, before the separate model-facing token limiter. Commands continue to drain and complete after the budget fills. Values are clamped to a minimum of 1024 bytes and a hard maximum of 64 MiB; `-1` selects that finite hard maximum rather than disabling the bound.
+This byte budget is enforced while output is acquired, before the separate model-facing token limiter. Commands continue to drain and complete after the budget fills. For PTY commands, the same budget also constrains in-memory terminal display scrollback when its byte-derived line limit is lower than `ptyScrollbackLimit`. Values are clamped to a minimum of 1024 bytes and a hard maximum of 64 MiB; `-1` selects that finite hard maximum rather than disabling the bound.
 
 ### Timeouts
 

--- a/packages/agents/src/core/agenticLoop/AgenticLoop.ts
+++ b/packages/agents/src/core/agenticLoop/AgenticLoop.ts
@@ -114,18 +114,26 @@ interface TurnRunResult {
  */
 function createCompletionController(): {
   resolveCompletion: (calls: CompletedToolCall[]) => void;
+  rejectCompletion: (error: unknown) => void;
   completionPromise: Promise<CompletedToolCall[]>;
 } {
   let resolver: ((calls: CompletedToolCall[]) => void) | null = null;
-  let resolved = false;
+  let rejecter: ((error: unknown) => void) | null = null;
+  let settled = false;
   return {
     resolveCompletion(calls: CompletedToolCall[]) {
-      if (resolved) return;
-      resolved = true;
+      if (settled) return;
+      settled = true;
       resolver?.(calls);
     },
-    completionPromise: new Promise<CompletedToolCall[]>((resolve) => {
+    rejectCompletion(error: unknown) {
+      if (settled) return;
+      settled = true;
+      rejecter?.(error);
+    },
+    completionPromise: new Promise<CompletedToolCall[]>((resolve, reject) => {
       resolver = resolve;
+      rejecter = reject;
     }),
   };
 }
@@ -503,7 +511,7 @@ export class AgenticLoop {
     const queue = new AgenticEventQueue();
     const sessionId = this.schedulerSessionId;
 
-    const { resolveCompletion, completionPromise } =
+    const { resolveCompletion, rejectCompletion, completionPromise } =
       createCompletionController();
 
     let acceptedToolUpdateSeen = false;
@@ -513,6 +521,7 @@ export class AgenticLoop {
       sessionId,
       queue,
       resolveCompletion,
+      rejectCompletion,
       forwardingState,
       () => {
         acceptedToolUpdateSeen = true;
@@ -597,10 +606,27 @@ export class AgenticLoop {
     sessionId: string,
     queue: AgenticEventQueue,
     resolveCompletion: (calls: CompletedToolCall[]) => void,
+    rejectCompletion: (error: unknown) => void,
     forwardingState: { active: boolean },
     markAcceptedUpdate: () => void,
   ): Promise<ToolSchedulerContract> {
     const display = this.displayCallbacks;
+    const pushQueueEvent = (event: AgenticLoopEvent): boolean => {
+      try {
+        queue.push(event);
+        return true;
+      } catch (error) {
+        forwardingState.active = false;
+        logger.debug(
+          () =>
+            `agentic event queue rejected a scheduler event: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+        );
+        rejectCompletion(error);
+        return false;
+      }
+    };
 
     return this.config.getOrCreateScheduler(
       sessionId,
@@ -609,8 +635,15 @@ export class AgenticLoop {
           if (!forwardingState.active) {
             return;
           }
-          if (update.mode === 'append') {
-            queue.push({ kind: 'tool_output', callId, chunk: update.data });
+          if (
+            update.mode === 'append' &&
+            !pushQueueEvent({
+              kind: 'tool_output',
+              callId,
+              chunk: update.data,
+            })
+          ) {
+            return;
           }
           display?.outputUpdateHandler?.(callId, update);
         },
@@ -621,18 +654,26 @@ export class AgenticLoop {
           if (toolCalls.length > 0) {
             markAcceptedUpdate();
           }
-          queue.push({ kind: 'tool_update', toolCalls });
-          if (toolCalls.some((tc) => tc.status === 'awaiting_approval')) {
-            queue.push({ kind: 'awaiting_approval', toolCalls });
+          if (!pushQueueEvent({ kind: 'tool_update', toolCalls })) {
+            return;
+          }
+          if (
+            toolCalls.some((tc) => tc.status === 'awaiting_approval') &&
+            !pushQueueEvent({ kind: 'awaiting_approval', toolCalls })
+          ) {
+            return;
           }
           display?.onToolCallsUpdate?.(toolCalls);
         },
         onAllToolCallsComplete: async (completed) => {
-          if (forwardingState.active) {
-            queue.push({ kind: 'tool_update', toolCalls: [] });
-            display?.onToolCallsUpdate?.([]);
+          try {
+            if (forwardingState.active) {
+              pushQueueEvent({ kind: 'tool_update', toolCalls: [] });
+              display?.onToolCallsUpdate?.([]);
+            }
+          } finally {
+            resolveCompletion(completed);
           }
-          resolveCompletion(completed);
         },
         getPreferredEditor: display?.getPreferredEditor ?? (() => undefined),
         onEditorOpen: display?.onEditorOpen ?? (() => {}),

--- a/packages/agents/src/core/agenticLoop/AgenticLoop.ts
+++ b/packages/agents/src/core/agenticLoop/AgenticLoop.ts
@@ -49,6 +49,7 @@ import {
 import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools/types/tool-confirmation-types.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type { AgenticLoopEvent, AgenticLoopOptions } from './types.js';
+import { AgenticEventQueue } from './agenticEventQueue.js';
 import {
   buildToolResponses,
   classifyCompletedTools,
@@ -83,64 +84,6 @@ function isTerminalStreamOutcome(type: AgentEventType): boolean {
     type === AgentEventType.UserCancelled ||
     type === AgentEventType.LoopDetected
   );
-}
-
-/**
- * A callback-to-generator bridge: scheduler callbacks push events into this
- * queue and `run` drains them. Resolves the tension between callback-driven
- * scheduler events and the generator-based loop body.
- */
-class EventQueue {
-  private readonly buffered: AgenticLoopEvent[] = [];
-  private resolveWait: (() => void) | null = null;
-  private closed = false;
-
-  push(event: AgenticLoopEvent): void {
-    if (this.closed) {
-      return;
-    }
-    this.buffered.push(event);
-    this.resolveWait?.();
-    this.resolveWait = null;
-  }
-
-  popBuffered(): AgenticLoopEvent | undefined {
-    return this.buffered.shift();
-  }
-
-  waitForNext(signal: AbortSignal): Promise<void> {
-    if (this.buffered.length > 0 || this.closed || signal.aborted) {
-      return Promise.resolve();
-    }
-    return new Promise<void>((resolve) => {
-      let settled = false;
-      const settle = () => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        signal.removeEventListener('abort', onAbort);
-        this.resolveWait = null;
-        resolve();
-      };
-      const onAbort = () => {
-        settle();
-      };
-      this.resolveWait = () => {
-        settle();
-      };
-      signal.addEventListener('abort', onAbort, { once: true });
-      if (signal.aborted) {
-        settle();
-      }
-    });
-  }
-
-  close(): void {
-    this.closed = true;
-    this.resolveWait?.();
-    this.resolveWait = null;
-  }
 }
 
 /** A mutable holder so promise callbacks can communicate state to the loop. */
@@ -557,7 +500,7 @@ export class AgenticLoop {
     requests: ToolCallRequestInfo[],
     signal: AbortSignal,
   ): AsyncGenerator<AgenticLoopEvent, TurnToolResult> {
-    const queue = new EventQueue();
+    const queue = new AgenticEventQueue();
     const sessionId = this.schedulerSessionId;
 
     const { resolveCompletion, completionPromise } =
@@ -617,6 +560,10 @@ export class AgenticLoop {
       }
 
       const completed = await Promise.race([completionTask, abortPromise]);
+      if (completed !== null && !signal.aborted) {
+        queue.flushOutputOmissionNotices();
+        yield* flushBuffered(queue);
+      }
       normalExit = completed !== null && !signal.aborted;
       return { completed };
     } finally {
@@ -648,7 +595,7 @@ export class AgenticLoop {
 
   private async createSchedulerWithCallbacks(
     sessionId: string,
-    queue: EventQueue,
+    queue: AgenticEventQueue,
     resolveCompletion: (calls: CompletedToolCall[]) => void,
     forwardingState: { active: boolean },
     markAcceptedUpdate: () => void,
@@ -706,7 +653,7 @@ export class AgenticLoop {
   private async *drainWhileRunning(
     completionTask: Promise<CompletedToolCall[] | null>,
     state: TurnState,
-    queue: EventQueue,
+    queue: AgenticEventQueue,
     signal: AbortSignal,
   ): AsyncGenerator<AgenticLoopEvent> {
     while (!state.completionSettled && !signal.aborted) {
@@ -756,7 +703,7 @@ export class AgenticLoop {
 }
 
 /** Yields all currently-buffered events without blocking. */
-function* flushBuffered(queue: EventQueue): Generator<AgenticLoopEvent> {
+function* flushBuffered(queue: AgenticEventQueue): Generator<AgenticLoopEvent> {
   let event = queue.popBuffered();
   while (event !== undefined) {
     yield event;

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticEventQueue.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticEventQueue.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { ToolCall } from '@vybestack/llxprt-code-core/scheduler/types.js';
+import { AgenticEventQueue } from '../agenticEventQueue.js';
+import type { AgenticLoopEvent } from '../types.js';
+
+type ToolOutputEvent = Extract<AgenticLoopEvent, { kind: 'tool_output' }>;
+
+function toolCall(callId: string): ToolCall {
+  return {
+    status: 'error',
+    request: {
+      callId,
+      name: 'test-tool',
+      args: {},
+      isClientInitiated: false,
+      prompt_id: 'test-prompt',
+    },
+    response: {
+      callId,
+      responseParts: [],
+      resultDisplay: undefined,
+      error: undefined,
+      errorType: undefined,
+    },
+  };
+}
+
+function requireEvent(queue: AgenticEventQueue): AgenticLoopEvent {
+  const event = queue.popBuffered();
+  if (event === undefined) {
+    throw new Error('Expected a buffered agentic-loop event');
+  }
+  return event;
+}
+
+function toolOutputEvents(events: AgenticLoopEvent[]): ToolOutputEvent[] {
+  return events.filter(
+    (event): event is ToolOutputEvent => event.kind === 'tool_output',
+  );
+}
+
+describe('AgenticEventQueue', () => {
+  it('coalesces replace-style tool snapshots for a slow consumer', () => {
+    const queue = new AgenticEventQueue({ maxBufferedEvents: 8 });
+
+    for (let index = 0; index < 10_000; index += 1) {
+      queue.push({ kind: 'tool_update', toolCalls: [toolCall(String(index))] });
+    }
+
+    expect(queue.bufferedEventCount).toBe(1);
+    const event = requireEvent(queue);
+    expect(event.kind).toBe('tool_update');
+    const update = event as Extract<AgenticLoopEvent, { kind: 'tool_update' }>;
+    expect(update.toolCalls[0].request.callId).toBe('9999');
+  });
+
+  it('preserves the final tool snapshot before the scheduler clears it', () => {
+    const queue = new AgenticEventQueue({ maxBufferedEvents: 8 });
+    queue.push({ kind: 'tool_update', toolCalls: [toolCall('cancelled')] });
+    queue.push({ kind: 'tool_update', toolCalls: [] });
+
+    const updates = drain(queue).filter(
+      (event): event is Extract<AgenticLoopEvent, { kind: 'tool_update' }> =>
+        event.kind === 'tool_update',
+    );
+
+    expect(updates).toHaveLength(2);
+    expect(updates[0].toolCalls[0].request.callId).toBe('cancelled');
+    expect(updates[1].toolCalls).toEqual([]);
+  });
+
+  it('bounds many tiny append events by item count and reports the loss', () => {
+    const queue = new AgenticEventQueue({
+      maxBufferedEvents: 16,
+      maxBufferedOutputBytes: 1024,
+    });
+
+    for (let index = 0; index < 10_000; index += 1) {
+      queue.push({ kind: 'tool_output', callId: 'call-1', chunk: 'x' });
+    }
+    queue.push({ kind: 'tools_complete', completed: [] });
+
+    expect(queue.bufferedEventCount).toBeLessThanOrEqual(16);
+    expect(queue.bufferedLiveOutputBytes).toBeLessThanOrEqual(1024);
+    const events = drain(queue);
+    const output = toolOutputEvents(events)
+      .map((event) => event.chunk)
+      .join('');
+    expect(output).toContain('LLXPRT live tool output omitted');
+    expect(output).toContain('9,989 bytes');
+    expect(events[events.length - 1]?.kind).toBe('tools_complete');
+  });
+
+  it('bounds one oversized UTF-8 chunk without splitting a character', () => {
+    const queue = new AgenticEventQueue({
+      maxBufferedEvents: 8,
+      maxBufferedOutputBytes: 1024,
+    });
+    const chunk = '🙂'.repeat(1000);
+
+    queue.push({ kind: 'tool_output', callId: 'call-1', chunk });
+    queue.push({ kind: 'tools_complete', completed: [] });
+
+    const outputs = toolOutputEvents(drain(queue));
+    const retained = outputs.find((event) => event.chunk.startsWith('🙂'));
+    const retainedBytes = Buffer.byteLength(retained?.chunk ?? '', 'utf8');
+    expect(retained).toBeDefined();
+    expect(retainedBytes).toBeGreaterThan(0);
+    expect(retainedBytes).toBeLessThanOrEqual(1024);
+    expect(retained?.chunk).not.toContain('�');
+    const notice = outputs.find((event) =>
+      event.chunk.includes('LLXPRT live tool output omitted'),
+    );
+    expect(notice).toBeDefined();
+    expect(notice?.chunk).toContain(
+      `${(Buffer.byteLength(chunk, 'utf8') - retainedBytes).toLocaleString('en-US')} bytes`,
+    );
+    expect(queue.bufferedLiveOutputBytes).toBe(0);
+  });
+
+  it('aggregates excess call IDs without losing omission accounting', () => {
+    const queue = new AgenticEventQueue({
+      maxBufferedEvents: 16,
+      maxBufferedOutputBytes: 1024,
+    });
+    for (let index = 0; index < 11; index += 1) {
+      queue.push({ kind: 'tool_output', callId: 'retained', chunk: 'x' });
+    }
+    for (let index = 0; index < 10; index += 1) {
+      queue.push({
+        kind: 'tool_output',
+        callId: `omitted-${index}`,
+        chunk: 'y',
+      });
+    }
+    queue.push({ kind: 'tools_complete', completed: [] });
+
+    expect(queue.bufferedEventCount).toBeLessThanOrEqual(16);
+    expect(queue.bufferedLiveOutputBytes).toBeLessThanOrEqual(1024);
+    const notices = toolOutputEvents(drain(queue)).filter((event) =>
+      event.chunk.includes('LLXPRT live tool output omitted'),
+    );
+    const omittedBytes = notices.reduce((total, event) => {
+      const match = /omitted: ([\d,]+) bytes/.exec(event.chunk);
+      return total + Number((match?.[1] ?? '0').replaceAll(',', ''));
+    }, 0);
+
+    expect(notices.length).toBeGreaterThan(0);
+    expect(notices.length).toBeLessThanOrEqual(4);
+    expect(omittedBytes).toBe(10);
+    expect(
+      notices.some((event) =>
+        event.chunk.includes('across additional tool calls'),
+      ),
+    ).toBe(true);
+  });
+
+  it('reserves report and completion capacity after output is omitted', () => {
+    const queue = new AgenticEventQueue({
+      maxBufferedEvents: 16,
+      maxBufferedOutputBytes: 1024,
+    });
+    for (let index = 0; index < 11; index += 1) {
+      queue.push({ kind: 'tool_output', callId: 'retained', chunk: 'x' });
+    }
+    queue.push({ kind: 'tool_output', callId: 'omitted', chunk: 'y' });
+    for (let index = 0; index < 3; index += 1) {
+      queue.push({
+        kind: 'awaiting_approval',
+        toolCalls: [toolCall(String(index))],
+      });
+    }
+
+    expect(() =>
+      queue.push({
+        kind: 'awaiting_approval',
+        toolCalls: [toolCall('overflow')],
+      }),
+    ).toThrow('reserved its remaining capacity');
+    queue.push({ kind: 'tools_complete', completed: [] });
+
+    const events = drain(queue);
+    const notices = toolOutputEvents(events).filter((event) =>
+      event.chunk.includes('LLXPRT live tool output omitted'),
+    );
+    expect(events).toHaveLength(16);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]?.chunk).toContain('1 byte');
+    expect(events[events.length - 1]?.kind).toBe('tools_complete');
+  });
+
+  it('uses amortized compaction while preserving FIFO semantic events', () => {
+    const queue = new AgenticEventQueue({ maxBufferedEvents: 5000 });
+    for (let index = 0; index < 5000; index += 1) {
+      queue.push({
+        kind: 'awaiting_approval',
+        toolCalls: [toolCall(String(index))],
+      });
+    }
+
+    for (let index = 0; index < 5000; index += 1) {
+      const event = requireEvent(queue);
+      expect(event.kind).toBe('awaiting_approval');
+      const approval = event as Extract<
+        AgenticLoopEvent,
+        { kind: 'awaiting_approval' }
+      >;
+      expect(approval.toolCalls[0].request.callId).toBe(String(index));
+    }
+    expect(queue.bufferedEventCount).toBe(0);
+  });
+
+  it('fails fast rather than silently dropping semantic events', () => {
+    const queue = new AgenticEventQueue({ maxBufferedEvents: 4 });
+    for (let index = 0; index < 4; index += 1) {
+      queue.push({
+        kind: 'awaiting_approval',
+        toolCalls: [toolCall(String(index))],
+      });
+    }
+
+    expect(() =>
+      queue.push({
+        kind: 'awaiting_approval',
+        toolCalls: [toolCall('overflow')],
+      }),
+    ).toThrow('Agentic event queue exceeded 4 buffered events');
+  });
+});
+
+function drain(queue: AgenticEventQueue): AgenticLoopEvent[] {
+  const events: AgenticLoopEvent[] = [];
+  let event = queue.popBuffered();
+  while (event !== undefined) {
+    events.push(event);
+    event = queue.popBuffered();
+  }
+  return events;
+}

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.output-bound.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.output-bound.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { clearAllSchedulers } from '@vybestack/llxprt-code-core/config/schedulerSingleton.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-core';
+import { MockTool } from '@vybestack/llxprt-code-core/test-utils/mock-tool.js';
+import { AgenticLoop } from '../AgenticLoop.js';
+import {
+  collectEvents,
+  contentEvent,
+  createAllowPolicyEngine,
+  createScriptedAgentClient,
+  createTestConfig,
+  createToolRegistryForTest,
+  finishedEvent,
+  toolCallRequestEvent,
+} from './agenticLoop-test-helpers.js';
+
+const LIVE_CHUNK_COUNT = 2_000;
+
+describe('AgenticLoop live-output acquisition bound', () => {
+  beforeEach(() => {
+    clearAllSchedulers();
+  });
+
+  afterEach(() => {
+    clearAllSchedulers();
+  });
+
+  it('emits one omission notice before completion when a producer outruns the consumer', async () => {
+    const tool = new MockTool({
+      name: 'verbose_tool',
+      canUpdateOutput: true,
+    });
+    tool.executeFn.mockImplementation(
+      async (
+        _params: Record<string, unknown>,
+        _signal: AbortSignal,
+        updateOutput?: (update: LiveOutputUpdate) => void,
+      ) => {
+        for (let index = 0; index < LIVE_CHUNK_COUNT; index += 1) {
+          updateOutput?.({ mode: 'append', data: 'x' });
+        }
+        return { llmContent: 'done', returnDisplay: 'done' };
+      },
+    );
+
+    const messageBus = new MessageBus(createAllowPolicyEngine(), false);
+    const config = createTestConfig({
+      messageBus,
+      toolRegistry: createToolRegistryForTest([tool]),
+      policyEngine: createAllowPolicyEngine(),
+      interactive: false,
+      approvalMode: ApprovalMode.YOLO,
+    });
+    const { client } = createScriptedAgentClient([
+      [
+        toolCallRequestEvent('verbose_tool', 'call-verbose', {}),
+        finishedEvent(),
+      ],
+      [contentEvent('final'), finishedEvent()],
+    ]);
+
+    const events = await collectEvents(
+      new AgenticLoop({ agentClient: client, config, messageBus }),
+      'go',
+      new AbortController().signal,
+    );
+    const outputEvents = events.filter((event) => event.kind === 'tool_output');
+    const notices = outputEvents.filter((event) =>
+      event.chunk.includes('LLXPRT live tool output omitted'),
+    );
+    const completionIndex = events.findIndex(
+      (event) => event.kind === 'tools_complete',
+    );
+    const noticeIndex = events.findIndex(
+      (event) =>
+        event.kind === 'tool_output' &&
+        event.chunk.includes('LLXPRT live tool output omitted'),
+    );
+
+    expect(outputEvents.length).toBeLessThan(LIVE_CHUNK_COUNT);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]?.callId).toBe('call-verbose');
+    expect(noticeIndex).toBeGreaterThanOrEqual(0);
+    expect(completionIndex).toBeGreaterThan(noticeIndex);
+  });
+});

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.output-bound.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.output-bound.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { DEFAULT_ACQUISITION_BUDGET_BYTES } from '@vybestack/llxprt-code-tools/acquisition.js';
 import { clearAllSchedulers } from '@vybestack/llxprt-code-core/config/schedulerSingleton.js';
 import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
@@ -22,7 +23,8 @@ import {
   toolCallRequestEvent,
 } from './agenticLoop-test-helpers.js';
 
-const LIVE_CHUNK_COUNT = 2_000;
+const LIVE_CHUNK_COUNT = 600;
+const LIVE_CHUNK = 'x'.repeat(8192);
 
 describe('AgenticLoop live-output acquisition bound', () => {
   beforeEach(() => {
@@ -45,7 +47,7 @@ describe('AgenticLoop live-output acquisition bound', () => {
         updateOutput?: (update: LiveOutputUpdate) => void,
       ) => {
         for (let index = 0; index < LIVE_CHUNK_COUNT; index += 1) {
-          updateOutput?.({ mode: 'append', data: 'x' });
+          updateOutput?.({ mode: 'append', data: LIVE_CHUNK });
         }
         return { llmContent: 'done', returnDisplay: 'done' };
       },
@@ -85,10 +87,21 @@ describe('AgenticLoop live-output acquisition bound', () => {
         event.chunk.includes('LLXPRT live tool output omitted'),
     );
 
+    const retainedDataBytes = outputEvents
+      .filter(
+        (event) => !event.chunk.includes('LLXPRT live tool output omitted'),
+      )
+      .reduce((total, event) => total + Buffer.byteLength(event.chunk), 0);
+
+    expect(Buffer.byteLength(LIVE_CHUNK) * LIVE_CHUNK_COUNT).toBeGreaterThan(
+      DEFAULT_ACQUISITION_BUDGET_BYTES,
+    );
+    expect(retainedDataBytes).toBeLessThanOrEqual(
+      DEFAULT_ACQUISITION_BUDGET_BYTES,
+    );
     expect(outputEvents.length).toBeLessThan(LIVE_CHUNK_COUNT);
     expect(notices).toHaveLength(1);
     expect(notices[0]?.callId).toBe('call-verbose');
-    expect(noticeIndex).toBeGreaterThanOrEqual(0);
     expect(completionIndex).toBeGreaterThan(noticeIndex);
   });
 });

--- a/packages/agents/src/core/agenticLoop/agenticEventQueue.ts
+++ b/packages/agents/src/core/agenticLoop/agenticEventQueue.ts
@@ -331,22 +331,46 @@ export class AgenticEventQueue {
       };
     }
 
-    this.omittedOutputBytes.clear();
-    this.aggregateOmission = null;
-    for (const notice of notices) {
-      this.enqueueOmissionNotice(
+    const preparedNotices = notices.map((notice) =>
+      this.prepareOmissionNotice(
         notice.callId,
         notice.omittedBytes,
         notice.aggregatesCalls,
+      ),
+    );
+    const preparedBytes = preparedNotices.reduce(
+      (total, notice) => total + notice.chunkBytes,
+      0,
+    );
+    if (
+      this.bufferedEventCount + preparedNotices.length >
+        this.maxBufferedEvents ||
+      this.bufferedOutputBytes + preparedBytes > this.maxBufferedOutputBytes
+    ) {
+      throw new Error(
+        'Agentic output omission notices exceeded their reservation',
       );
+    }
+
+    // Preparation and capacity checks above are the only failure points. Clear
+    // accounting before the now-infallible enqueue loop so an internal enqueue
+    // regression cannot cause the same omission to be reported twice.
+    this.omittedOutputBytes.clear();
+    this.aggregateOmission = null;
+    for (const notice of preparedNotices) {
+      this.enqueue(notice.event);
+      this.bufferedOutputBytes += notice.chunkBytes;
     }
   }
 
-  private enqueueOmissionNotice(
+  private prepareOmissionNotice(
     callId: string,
     omittedBytes: number,
     aggregatesCalls: boolean,
-  ): void {
+  ): {
+    event: Extract<AgenticLoopEvent, { kind: 'tool_output' }>;
+    chunkBytes: number;
+  } {
     const scope = aggregatesCalls ? ' across additional tool calls' : '';
     const chunk = `[${LIVE_OUTPUT_OMISSION_NOTICE}: ${omittedBytes.toLocaleString('en-US')} bytes${scope}]`;
     const chunkBytes = Buffer.byteLength(chunk, 'utf8');
@@ -355,8 +379,7 @@ export class AgenticEventQueue {
         'Agentic output omission notice exceeded its reservation',
       );
     }
-    this.enqueue({ kind: 'tool_output', callId, chunk });
-    this.bufferedOutputBytes += chunkBytes;
+    return { event: { kind: 'tool_output', callId, chunk }, chunkBytes };
   }
 
   private enqueue(event: AgenticLoopEvent): void {

--- a/packages/agents/src/core/agenticLoop/agenticEventQueue.ts
+++ b/packages/agents/src/core/agenticLoop/agenticEventQueue.ts
@@ -1,0 +1,383 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ACQUISITION_HARD_MAX_BYTES,
+  DEFAULT_ACQUISITION_BUDGET_BYTES,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
+import type { AgenticLoopEvent } from './types.js';
+
+const DEFAULT_MAX_BUFFERED_EVENTS = 1024;
+const MIN_BUFFERED_OUTPUT_BYTES = 1024;
+const MIN_BUFFERED_EVENTS = 4;
+const MAX_OMISSION_NOTICES = 128;
+const MAX_OMISSION_NOTICE_BYTES = 96;
+const COMPACTION_THRESHOLD = 4096;
+const LIVE_OUTPUT_OMISSION_NOTICE = 'LLXPRT live tool output omitted';
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export interface AgenticEventQueueOptions {
+  maxBufferedOutputBytes?: number;
+  maxBufferedEvents?: number;
+}
+
+function normalizePositiveInteger(
+  value: number | undefined,
+  fallback: number,
+): number {
+  return value !== undefined && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+function saturatingAdd(left: number, right: number): number {
+  return Math.min(Number.MAX_SAFE_INTEGER, left + right);
+}
+
+function retainUtf8Prefix(
+  text: string,
+  maxBytes: number,
+): { retained: string; retainedBytes: number; omittedBytes: number } {
+  const observedBytes = Buffer.byteLength(text, 'utf8');
+  if (observedBytes <= maxBytes) {
+    return { retained: text, retainedBytes: observedBytes, omittedBytes: 0 };
+  }
+  if (maxBytes === 0) {
+    return { retained: '', retainedBytes: 0, omittedBytes: observedBytes };
+  }
+
+  const target = new Uint8Array(maxBytes);
+  const { written } = textEncoder.encodeInto(text, target);
+  return {
+    retained: textDecoder.decode(target.subarray(0, written)),
+    retainedBytes: written,
+    omittedBytes: observedBytes - written,
+  };
+}
+
+/**
+ * Bounded callback-to-generator bridge for agentic-loop events.
+ *
+ * Scheduler callbacks can outpace an async-generator consumer. Replace-style
+ * snapshots are coalesced to the latest pending snapshot, while append-style
+ * live output is bounded by both bytes and queue items. Durable tool results
+ * still arrive through `tools_complete`; when live preview bytes are dropped,
+ * one explicit notice per affected call is queued before completion.
+ */
+export class AgenticEventQueue {
+  private buffered: AgenticLoopEvent[] = [];
+  private head = 0;
+  private resolveWait: (() => void) | null = null;
+  private closed = false;
+  private pendingToolUpdateIndex: number | null = null;
+  private bufferedOutputBytes = 0;
+  private readonly omittedOutputBytes = new Map<string, number>();
+  private aggregateOmission: { callId: string; omittedBytes: number } | null =
+    null;
+  private readonly maxBufferedOutputBytes: number;
+  private readonly maxBufferedEvents: number;
+  private readonly maxOmissionNotices: number;
+  private readonly retainedOutputByteLimit: number;
+  private readonly bufferedEventLimitBeforeNotices: number;
+
+  constructor(options: AgenticEventQueueOptions = {}) {
+    this.maxBufferedOutputBytes = Math.min(
+      ACQUISITION_HARD_MAX_BYTES,
+      Math.max(
+        MIN_BUFFERED_OUTPUT_BYTES,
+        normalizePositiveInteger(
+          options.maxBufferedOutputBytes,
+          DEFAULT_ACQUISITION_BUDGET_BYTES,
+        ),
+      ),
+    );
+    this.maxBufferedEvents = Math.max(
+      MIN_BUFFERED_EVENTS,
+      normalizePositiveInteger(
+        options.maxBufferedEvents,
+        DEFAULT_MAX_BUFFERED_EVENTS,
+      ),
+    );
+    this.maxOmissionNotices = Math.min(
+      MAX_OMISSION_NOTICES,
+      Math.max(1, Math.floor(this.maxBufferedEvents / 4)),
+      Math.floor(this.maxBufferedOutputBytes / MAX_OMISSION_NOTICE_BYTES),
+    );
+    this.retainedOutputByteLimit =
+      this.maxBufferedOutputBytes -
+      this.maxOmissionNotices * MAX_OMISSION_NOTICE_BYTES;
+    this.bufferedEventLimitBeforeNotices =
+      this.maxBufferedEvents - this.maxOmissionNotices - 1;
+  }
+
+  get bufferedEventCount(): number {
+    return this.buffered.length - this.head;
+  }
+
+  get bufferedLiveOutputBytes(): number {
+    return this.bufferedOutputBytes;
+  }
+
+  push(event: AgenticLoopEvent): void {
+    if (this.closed) {
+      return;
+    }
+    if (event.kind === 'tool_update') {
+      this.pushToolUpdate(event);
+    } else if (event.kind === 'tool_output') {
+      this.pushToolOutput(event);
+    } else if (event.kind === 'tools_complete') {
+      this.flushOutputOmissionNotices(
+        this.maxBufferedEvents - this.bufferedEventCount - 1,
+      );
+      this.enqueue(event);
+    } else {
+      this.ensureCompletionCapacity();
+      this.enqueue(event);
+    }
+    this.wakeConsumer();
+  }
+
+  popBuffered(): AgenticLoopEvent | undefined {
+    if (this.head >= this.buffered.length) {
+      return undefined;
+    }
+    const event = this.buffered[this.head];
+    if (this.pendingToolUpdateIndex === this.head) {
+      this.pendingToolUpdateIndex = null;
+    }
+    if (event.kind === 'tool_output') {
+      this.bufferedOutputBytes -= Buffer.byteLength(event.chunk, 'utf8');
+    }
+    this.head += 1;
+    this.compactIfNeeded();
+    return event;
+  }
+
+  waitForNext(signal: AbortSignal): Promise<void> {
+    if (this.bufferedEventCount > 0 || this.closed || signal.aborted) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const settle = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        signal.removeEventListener('abort', onAbort);
+        this.resolveWait = null;
+        resolve();
+      };
+      const onAbort = () => {
+        settle();
+      };
+      this.resolveWait = settle;
+      signal.addEventListener('abort', onAbort, { once: true });
+      if (signal.aborted) {
+        settle();
+      }
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.wakeConsumer();
+  }
+
+  private pushToolUpdate(
+    event: Extract<AgenticLoopEvent, { kind: 'tool_update' }>,
+  ): void {
+    const index = this.pendingToolUpdateIndex;
+    if (index !== null && index >= this.head) {
+      const pending = this.buffered[index];
+      const canCoalesce =
+        pending.kind === 'tool_update' &&
+        pending.toolCalls.length > 0 &&
+        event.toolCalls.length > 0;
+      if (canCoalesce) {
+        this.buffered[index] = event;
+        return;
+      }
+    }
+    this.ensureCompletionCapacity();
+    this.enqueue(event);
+    this.pendingToolUpdateIndex = this.buffered.length - 1;
+  }
+
+  private pushToolOutput(
+    event: Extract<AgenticLoopEvent, { kind: 'tool_output' }>,
+  ): void {
+    const remainingBytes = Math.max(
+      0,
+      this.retainedOutputByteLimit - this.bufferedOutputBytes,
+    );
+    if (this.bufferedEventCount >= this.bufferedEventLimitBeforeNotices) {
+      this.recordOmission(event.callId, Buffer.byteLength(event.chunk, 'utf8'));
+      return;
+    }
+
+    const bounded = retainUtf8Prefix(event.chunk, remainingBytes);
+    if (bounded.retainedBytes > 0) {
+      this.enqueue({ ...event, chunk: bounded.retained });
+      this.bufferedOutputBytes += bounded.retainedBytes;
+    }
+    this.recordOmission(event.callId, bounded.omittedBytes);
+  }
+
+  private recordOmission(callId: string, omittedBytes: number): void {
+    if (omittedBytes === 0) {
+      return;
+    }
+    this.ensureOmissionReportCapacity();
+    const existing = this.omittedOutputBytes.get(callId);
+    if (existing !== undefined) {
+      this.omittedOutputBytes.set(
+        callId,
+        saturatingAdd(existing, omittedBytes),
+      );
+      return;
+    }
+    if (this.omittedOutputBytes.size < this.maxOmissionNotices - 1) {
+      this.omittedOutputBytes.set(callId, omittedBytes);
+      return;
+    }
+    if (this.aggregateOmission === null) {
+      this.aggregateOmission = { callId, omittedBytes };
+      return;
+    }
+    this.aggregateOmission.omittedBytes = saturatingAdd(
+      this.aggregateOmission.omittedBytes,
+      omittedBytes,
+    );
+  }
+
+  private hasPendingOmissions(): boolean {
+    return this.omittedOutputBytes.size > 0 || this.aggregateOmission !== null;
+  }
+
+  private ensureOmissionReportCapacity(): void {
+    if (this.bufferedEventCount > this.maxBufferedEvents - 2) {
+      throw new Error(
+        'Agentic event queue cannot report omitted output and completion within its event limit',
+      );
+    }
+  }
+
+  private ensureCompletionCapacity(): void {
+    if (
+      this.hasPendingOmissions() &&
+      this.bufferedEventCount >= this.maxBufferedEvents - 2
+    ) {
+      throw new Error(
+        'Agentic event queue reserved its remaining capacity for omitted output and completion',
+      );
+    }
+  }
+
+  flushOutputOmissionNotices(
+    maxNotices: number = this.maxOmissionNotices,
+  ): void {
+    const omissions = Array.from(
+      this.omittedOutputBytes,
+      ([callId, omittedBytes]) => ({
+        callId,
+        omittedBytes,
+        aggregatesCalls: false,
+      }),
+    );
+    if (this.aggregateOmission !== null) {
+      omissions.push({
+        ...this.aggregateOmission,
+        aggregatesCalls: true,
+      });
+    }
+    if (omissions.length === 0) {
+      return;
+    }
+    const noticeLimit = Math.min(
+      this.maxOmissionNotices,
+      Math.floor(maxNotices),
+    );
+    if (!Number.isFinite(noticeLimit) || noticeLimit < 1) {
+      throw new Error(
+        'Agentic event queue has no capacity to report omitted output before completion',
+      );
+    }
+
+    const notices = omissions.slice(0, noticeLimit);
+    if (omissions.length > noticeLimit) {
+      const aggregateIndex = noticeLimit - 1;
+      const aggregated = omissions.slice(aggregateIndex);
+      const firstAggregate = aggregated[0];
+      notices[aggregateIndex] = {
+        callId: firstAggregate.callId,
+        omittedBytes: aggregated.reduce(
+          (total, omission) => saturatingAdd(total, omission.omittedBytes),
+          0,
+        ),
+        aggregatesCalls: true,
+      };
+    }
+
+    this.omittedOutputBytes.clear();
+    this.aggregateOmission = null;
+    for (const notice of notices) {
+      this.enqueueOmissionNotice(
+        notice.callId,
+        notice.omittedBytes,
+        notice.aggregatesCalls,
+      );
+    }
+  }
+
+  private enqueueOmissionNotice(
+    callId: string,
+    omittedBytes: number,
+    aggregatesCalls: boolean,
+  ): void {
+    const scope = aggregatesCalls ? ' across additional tool calls' : '';
+    const chunk = `[${LIVE_OUTPUT_OMISSION_NOTICE}: ${omittedBytes.toLocaleString('en-US')} bytes${scope}]`;
+    const chunkBytes = Buffer.byteLength(chunk, 'utf8');
+    if (chunkBytes > MAX_OMISSION_NOTICE_BYTES) {
+      throw new Error(
+        'Agentic output omission notice exceeded its reservation',
+      );
+    }
+    this.enqueue({ kind: 'tool_output', callId, chunk });
+    this.bufferedOutputBytes += chunkBytes;
+  }
+
+  private enqueue(event: AgenticLoopEvent): void {
+    if (this.bufferedEventCount >= this.maxBufferedEvents) {
+      throw new Error(
+        `Agentic event queue exceeded ${this.maxBufferedEvents.toLocaleString('en-US')} buffered events`,
+      );
+    }
+    this.buffered.push(event);
+  }
+
+  private wakeConsumer(): void {
+    this.resolveWait?.();
+    this.resolveWait = null;
+  }
+
+  private compactIfNeeded(): void {
+    if (
+      this.head < COMPACTION_THRESHOLD ||
+      this.head * 2 < this.buffered.length
+    ) {
+      return;
+    }
+    const oldHead = this.head;
+    this.buffered = this.buffered.slice(oldHead);
+    if (this.pendingToolUpdateIndex !== null) {
+      this.pendingToolUpdateIndex -= oldHead;
+    }
+    this.head = 0;
+  }
+}

--- a/packages/agents/src/core/agenticLoop/agenticEventQueue.ts
+++ b/packages/agents/src/core/agenticLoop/agenticEventQueue.ts
@@ -122,6 +122,13 @@ export class AgenticEventQueue {
     return this.bufferedOutputBytes;
   }
 
+  /**
+   * Enqueue a scheduler event.
+   *
+   * @throws When a semantic event would consume capacity reserved for reporting
+   * output omission and terminal completion, or when the hard queue bound is
+   * exhausted. Scheduler callback adapters must contain this failure.
+   */
   push(event: AgenticLoopEvent): void {
     if (this.closed) {
       return;

--- a/packages/cli/src/services/prompt-processors/injectionOutputBudget.bun.test.ts
+++ b/packages/cli/src/services/prompt-processors/injectionOutputBudget.bun.test.ts
@@ -1,0 +1,289 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  buildBoundedPrompt,
+  StreamingInjectionBuilder,
+  DEFAULT_INJECTION_OUTPUT_BUDGET_BYTES,
+} from './injectionOutputBudget.js';
+import { createByteBudget } from '@vybestack/llxprt-code-tools/acquisition.js';
+import type { PromptSegment } from './injectionOutputBudget.js';
+
+function literal(text: string): PromptSegment {
+  return { kind: 'literal', text };
+}
+
+function output(out: string, statusSuffix = ''): PromptSegment {
+  return { kind: 'output', output: out, statusSuffix };
+}
+
+function omittedByteCount(text: string): number {
+  const suffix = ' bytes omitted';
+  const end = text.indexOf(suffix);
+  if (end < 0) {
+    throw new Error('Expected an omitted-byte count in the truncation notice');
+  }
+  const start = text.lastIndexOf(': ', end);
+  if (start < 0) {
+    throw new Error('Expected a byte-count separator in the truncation notice');
+  }
+  return Number(
+    text
+      .slice(start + 2, end)
+      .split(',')
+      .join(''),
+  );
+}
+
+describe('buildBoundedPrompt - aggregate injection bounding (issue #3200 finding 2)', () => {
+  it('assembles all segments when aggregate output is under budget', () => {
+    const segments: PromptSegment[] = [
+      literal('Status: '),
+      output('On branch main'),
+      literal(' in '),
+      output('/home/user'),
+    ];
+    const result = buildBoundedPrompt(segments, createByteBudget(4096));
+    expect(result).toBe('Status: On branch main in /home/user');
+  });
+
+  it('does not bound literal text even when outputs are large', () => {
+    const bigOutput = 'X'.repeat(10000);
+    const segments: PromptSegment[] = [
+      literal('LITERAL_MARKER_START '),
+      output(bigOutput),
+      literal(' LITERAL_MARKER_END'),
+    ];
+    const result = buildBoundedPrompt(segments, createByteBudget(1024));
+    // Literal text is always preserved.
+    expect(result).toContain('LITERAL_MARKER_START');
+    expect(result).toContain('LITERAL_MARKER_END');
+    // Exactly one omission notice.
+    expect(result.match(/injection output truncated/g)).toHaveLength(1);
+  });
+
+  it('bounds the aggregate across multiple injections, keeping head and tail', () => {
+    // 6 outputs of 1000 bytes each = 6000 bytes total, budget = 2048.
+    const segments: PromptSegment[] = [];
+    for (let i = 0; i < 6; i++) {
+      segments.push(output(`HEAD${i}_` + 'a'.repeat(992) + `_TAIL${i}\n`));
+    }
+    const result = buildBoundedPrompt(segments, createByteBudget(2048));
+
+    // The first output (head) is retained.
+    expect(result).toContain('HEAD0_');
+    // The last output (tail) is retained.
+    expect(result).toContain('TAIL5');
+    // Exactly one notice.
+    expect(result.match(/injection output truncated/g)).toHaveLength(1);
+    // The notice reports an accurate nonzero omitted byte count.
+    expect(omittedByteCount(result)).toBeGreaterThan(0);
+    // Bounded: total retained output is well under 6000.
+    expect(result.length).toBeLessThan(5000);
+  });
+
+  it('preserves command status suffixes for retained outputs', () => {
+    const segments: PromptSegment[] = [
+      output('ok', '\n[exited with code 0]'),
+      literal(' --- '),
+      output('fail', '\n[exited with code 1]'),
+    ];
+    const result = buildBoundedPrompt(segments, createByteBudget(4096));
+    expect(result).toContain('[exited with code 0]');
+    expect(result).toContain('[exited with code 1]');
+  });
+
+  it('emits exactly one omission notice even with many dropped middle outputs', () => {
+    const segments: PromptSegment[] = [];
+    for (let i = 0; i < 20; i++) {
+      segments.push(output(`out${i}_` + 'z'.repeat(2000) + `\n`));
+    }
+    const result = buildBoundedPrompt(segments, createByteBudget(2048));
+    expect(result.match(/injection output truncated/g)).toHaveLength(1);
+  });
+
+  it('handles a single oversized output', () => {
+    const segments: PromptSegment[] = [
+      literal('before '),
+      output('A'.repeat(100000)),
+      literal(' after'),
+    ];
+    const result = buildBoundedPrompt(segments, createByteBudget(2048));
+    expect(result).toContain('before');
+    expect(result).toContain('after');
+    expect(result.match(/injection output truncated/g)).toHaveLength(1);
+  });
+
+  it('preserves interleaving order of literals and outputs', () => {
+    const segments: PromptSegment[] = [
+      literal('A'),
+      output('1'),
+      literal('B'),
+      output('2'),
+      literal('C'),
+    ];
+    const result = buildBoundedPrompt(segments, createByteBudget(4096));
+    expect(result).toBe('A1B2C');
+  });
+
+  it('default budget is finite and positive', () => {
+    expect(DEFAULT_INJECTION_OUTPUT_BUDGET_BYTES).toBeGreaterThan(0);
+    expect(Number.isFinite(DEFAULT_INJECTION_OUTPUT_BUDGET_BYTES)).toBe(true);
+  });
+});
+
+describe('StreamingInjectionBuilder - bounded retained state (issue #3200 finding 2)', () => {
+  it('retained output state never exceeds the budget for many near-budget injections', () => {
+    // 50 injections each producing ~4000 bytes (200,000 total) against a 2048
+    // budget. The builder must retain at most the budget regardless of count.
+    const budget = createByteBudget(2048);
+    const builder = new StreamingInjectionBuilder(budget);
+    for (let i = 0; i < 50; i++) {
+      builder.appendLiteral(`cmd${i}:`);
+      builder.appendOutput(
+        'Z'.repeat(4000),
+        `
+[exit ${i}]`,
+      );
+      builder.appendLiteral('|');
+    }
+
+    // Retained output bytes stay within the single global budget.
+    expect(builder.retainedOutputBytes).toBeLessThanOrEqual(budget.bytes);
+    expect(builder.observedOutputBytes).toBe(50 * 4000);
+    const result = builder.build();
+    // The result also carries literals + statuses (small), but the OUTPUT
+    // content within it must be bounded.
+    expect(result.match(/injection output truncated/g)).toHaveLength(1);
+  });
+
+  it('never retains all command outputs simultaneously (peak retained is bounded)', () => {
+    // Feed many large outputs one at a time; after each append the retained
+    // state must remain bounded by the budget, proving the full outputs are
+    // not accumulated.
+    const budget = createByteBudget(1024);
+    const builder = new StreamingInjectionBuilder(budget);
+    let peakRetained = 0;
+    for (let i = 0; i < 30; i++) {
+      builder.appendOutput('Q'.repeat(8000), `[${i}]`);
+      if (builder.retainedOutputBytes > peakRetained) {
+        peakRetained = builder.retainedOutputBytes;
+      }
+    }
+    expect(peakRetained).toBeLessThanOrEqual(budget.bytes);
+  });
+
+  it('preserves every command status exactly once even when outputs are dropped', () => {
+    const budget = createByteBudget(1024);
+    const builder = new StreamingInjectionBuilder(budget);
+    for (let i = 0; i < 25; i++) {
+      builder.appendOutput(
+        'D'.repeat(2000),
+        `
+[exit ${i}]`,
+      );
+    }
+    const result = builder.build();
+    // Every status appears exactly once, including the middle outputs whose
+    // text was entirely dropped.
+    for (let i = 0; i < 25; i++) {
+      const count = result.split(`[exit ${i}]`).length - 1;
+      expect(count).toBe(1);
+    }
+  });
+
+  it('does not duplicate or omit statuses at the head/tail boundary', () => {
+    const budget = createByteBudget(2048);
+    const builder = new StreamingInjectionBuilder(budget);
+    // Each output ~1000 bytes; boundary falls inside output 1 or 2.
+    for (let i = 0; i < 6; i++) {
+      builder.appendOutput(
+        `H${i}_` + 'a'.repeat(990) + `_T${i}`,
+        `
+[st ${i}]`,
+      );
+    }
+    const result = builder.build();
+    for (let i = 0; i < 6; i++) {
+      expect(result.split(`[st ${i}]`).length - 1).toBe(1);
+    }
+  });
+
+  it('emits exactly one accurate aggregate notice with correct omitted byte count', () => {
+    const budget = createByteBudget(2048);
+    const builder = new StreamingInjectionBuilder(budget);
+    builder.appendOutput('A'.repeat(10000), '');
+    builder.appendOutput('B'.repeat(10000), '');
+    const result = builder.build();
+    const notices = result.match(/injection output truncated/g);
+    expect(notices).toHaveLength(1);
+    const omitted = omittedByteCount(result);
+    // 20000 observed, ≤ 2048 retained → ≥ ~17952 omitted.
+    expect(omitted).toBeGreaterThanOrEqual(17000);
+    // omitted + retained == observed.
+    expect(omitted + builder.retainedOutputBytes).toBe(
+      builder.observedOutputBytes,
+    );
+  });
+
+  it('respects UTF-8 boundaries when splitting output at the head/tail edge', () => {
+    // Multibyte chars (3 bytes each) placed so the head boundary cuts through
+    // one. The retained head must not sever a multibyte character.
+    const budget = createByteBudget(1024);
+    const builder = new StreamingInjectionBuilder(budget);
+    const threeByte = Buffer.from([0xe4, 0xb8, 0x96]); // one CJK char
+    // 400 chars * 3 bytes = 1200 bytes > 1024 budget.
+    builder.appendOutput(
+      Buffer.concat(Array(400).fill(threeByte)).toString('utf8'),
+      '',
+    );
+    const result = builder.build();
+    // No replacement characters at the split boundary.
+    expect(result).not.toContain('\uFFFD');
+  });
+
+  it('resolves the budget from the configured acquisition setting', () => {
+    // The builder accepts any validated ByteBudget; production code resolves it
+    // from config via resolveByteBudgetFromSetting. Verify a configured budget
+    // is honored exactly.
+    const budget = createByteBudget(4096);
+    const builder = new StreamingInjectionBuilder(budget);
+    builder.appendOutput('X'.repeat(4096), '');
+    // Exactly at budget: no truncation.
+    expect(builder.build()).not.toContain('injection output truncated');
+  });
+
+  it('places a status after both retained portions of one output', () => {
+    const builder = new StreamingInjectionBuilder(createByteBudget(1024));
+    builder.appendOutput(`HEAD${'x'.repeat(1988)}TAIL`, '[status]');
+
+    const result = builder.build();
+    expect(result.indexOf('HEAD')).toBeLessThan(
+      result.indexOf('injection output truncated'),
+    );
+    expect(result.indexOf('injection output truncated')).toBeLessThan(
+      result.indexOf('TAIL'),
+    );
+    expect(result.indexOf('TAIL')).toBeLessThan(result.indexOf('[status]'));
+  });
+
+  it('preserves the literal preceding the first tail-only output', () => {
+    const builder = new StreamingInjectionBuilder(createByteBudget(1024));
+    builder.appendLiteral('before-head:');
+    builder.appendOutput('A'.repeat(1000), '[first-status]');
+    builder.appendLiteral(':before-tail:');
+    builder.appendOutput('B'.repeat(1000), '[second-status]');
+
+    const result = builder.build();
+    expect(result.indexOf(':before-tail:')).toBeLessThan(
+      result.indexOf('injection output truncated'),
+    );
+    expect(result.indexOf('injection output truncated')).toBeLessThan(
+      result.indexOf('[second-status]'),
+    );
+  });
+});

--- a/packages/cli/src/services/prompt-processors/injectionOutputBudget.bun.test.ts
+++ b/packages/cli/src/services/prompt-processors/injectionOutputBudget.bun.test.ts
@@ -246,7 +246,7 @@ describe('StreamingInjectionBuilder - bounded retained state (issue #3200 findin
     expect(result).not.toContain('\uFFFD');
   });
 
-  it('resolves the budget from the configured acquisition setting', () => {
+  it('honors the validated acquisition budget supplied by the caller', () => {
     // The builder accepts any validated ByteBudget; production code resolves it
     // from config via resolveByteBudgetFromSetting. Verify a configured budget
     // is honored exactly.

--- a/packages/cli/src/services/prompt-processors/injectionOutputBudget.ts
+++ b/packages/cli/src/services/prompt-processors/injectionOutputBudget.ts
@@ -163,6 +163,7 @@ export class StreamingInjectionBuilder {
         if (hasTail) {
           // Boundary output: its remainder survived in the tail. Emit the
           // notice between the retained head and tail of this one output.
+          enteredTail = true;
           emitNotice();
           parts.push(out.tailText);
         }

--- a/packages/cli/src/services/prompt-processors/injectionOutputBudget.ts
+++ b/packages/cli/src/services/prompt-processors/injectionOutputBudget.ts
@@ -1,0 +1,292 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createByteBudget,
+  completeUtf8PrefixLength,
+  completeUtf8SuffixStart,
+  type ByteBudget,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
+
+/**
+ * One segment of the final assembled prompt. Literal segments carry template
+ * text verbatim; output segments carry an executed injection's output plus an
+ * optional status/error suffix.
+ */
+export type PromptSegment =
+  | { readonly kind: 'literal'; readonly text: string }
+  | {
+      readonly kind: 'output';
+      /** Command stdout/stderr text. */
+      readonly output: string;
+      /** Status suffix, e.g. `\n[exited with code 42]`, or empty string. */
+      readonly statusSuffix: string;
+    };
+
+/**
+ * Default aggregate byte budget for all injection outputs combined when a
+ * caller does not supply a resolved budget. Production callers resolve the
+ * budget from the configured shell acquisition setting
+ * (`outputRetentionMaxBytes`) via {@link resolveByteBudgetFromSetting}; this
+ * constant only provides a finite fallback for the segment-based convenience
+ * wrapper.
+ */
+export const DEFAULT_INJECTION_OUTPUT_BUDGET_BYTES = 4 * 1024 * 1024;
+
+const INJECTION_OMISSION_NOTICE = 'LLXPRT injection output truncated';
+
+function byteLengthUtf8(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
+}
+
+interface OutputRecord {
+  /** Status/error suffix, emitted exactly once regardless of truncation. */
+  readonly statusSuffix: string;
+  /** Retained head portion (may be a partial prefix of the original output). */
+  headText: string;
+  /** Retained tail portion (may be a partial suffix; '' when fully dropped). */
+  tailText: string;
+}
+
+/**
+ * Streaming aggregate-output builder that bounds the SUM of all command-output
+ * bytes across every injection site to a single finite {@link ByteBudget},
+ * while preserving literal template placement and emitting each command's
+ * status/error suffix exactly once.
+ *
+ * Design (issue #3200 finding 2):
+ * - **Streaming / bounded retention:** each command's full output is fed to
+ *   {@link appendOutput} and immediately reduced to a bounded head/tail
+ *   portion; the full output text is never retained by the builder. The
+ *   builder therefore never holds all command outputs simultaneously, and its
+ *   retained output state is bounded by the budget regardless of how many
+ *   injections run.
+ * - **One global budget:** a head region (first half of the budget) fills
+ *   first; once it is full the builder switches to a sliding tail region
+ *   (second half) that evicts the oldest retained tail content. Total
+ *   retained output bytes never exceed the budget.
+ * - **Statuses preserved exactly once:** every command's status suffix is
+ *   emitted exactly once in {@link build}, even when the command's output is
+ *   entirely dropped into the truncated middle.
+ * - **One accurate notice:** a single omission notice carrying the exact
+ *   omitted byte count is emitted at the head/tail boundary.
+ * - **UTF-8 safety:** head/tail splits and tail eviction trim on complete
+ *   UTF-8 character boundaries so multibyte characters are never severed.
+ */
+export class StreamingInjectionBuilder {
+  private readonly headBudget: number;
+  private readonly tailBudget: number;
+  private readonly literals: string[] = [];
+  private readonly outputs: OutputRecord[] = [];
+  /** Output indices that currently hold tail content, in arrival order. */
+  private tailOrder: number[] = [];
+  private tailOrderHead = 0;
+  private pendingLiteral = '';
+  private headBytesUsed = 0;
+  private tailBytesUsed = 0;
+  private headClosed = false;
+  private totalOutputBytes = 0;
+
+  constructor(budget: ByteBudget) {
+    this.headBudget = Math.floor(budget.bytes / 2);
+    this.tailBudget = budget.bytes - this.headBudget;
+  }
+
+  /** Append literal template text (never bounded). */
+  appendLiteral(text: string): void {
+    this.pendingLiteral += text;
+  }
+
+  /**
+   * Append one command's output and status suffix. The full `output` text is
+   * reduced to a bounded head/tail portion immediately and is not retained.
+   */
+  appendOutput(output: string, statusSuffix: string): void {
+    this.literals.push(this.pendingLiteral);
+    this.pendingLiteral = '';
+    const totalBytes = byteLengthUtf8(output);
+    this.totalOutputBytes += totalBytes;
+    const record: OutputRecord = { statusSuffix, headText: '', tailText: '' };
+    this.outputs.push(record);
+    this.placeOutput(this.outputs.length - 1, output, totalBytes);
+  }
+
+  /** Total output bytes observed across all injections (monotonic). */
+  get observedOutputBytes(): number {
+    return this.totalOutputBytes;
+  }
+
+  /** Output bytes currently retained (head + tail), always ≤ budget. */
+  get retainedOutputBytes(): number {
+    return this.headBytesUsed + this.tailBytesUsed;
+  }
+
+  /** Assemble the final bounded prompt string. */
+  build(): string {
+    this.literals.push(this.pendingLiteral);
+    this.pendingLiteral = '';
+    const n = this.outputs.length;
+    const omittedBytes = Math.max(
+      0,
+      this.totalOutputBytes - this.retainedOutputBytes,
+    );
+    const truncated = omittedBytes > 0;
+    const parts: string[] = [];
+    let noticeEmitted = false;
+    const emitNotice = (): void => {
+      if (truncated && !noticeEmitted) {
+        parts.push(
+          `[${INJECTION_OMISSION_NOTICE}: ${omittedBytes.toLocaleString('en-US')} bytes omitted]`,
+        );
+        noticeEmitted = true;
+      }
+    };
+
+    let enteredTail = false;
+    for (let i = 0; i < n; i++) {
+      const out = this.outputs[i];
+      const hasHead = out.headText !== '';
+      const hasTail = out.tailText !== '';
+      parts.push(this.literals[i]);
+      // The first output with no head content marks the transition into the
+      // tail/dropped region. Its preceding literal must remain before the
+      // notice so template and substitution order are unchanged.
+      if (!hasHead && !enteredTail) {
+        enteredTail = true;
+        emitNotice();
+      }
+      if (hasHead) {
+        parts.push(out.headText);
+        if (hasTail) {
+          // Boundary output: its remainder survived in the tail. Emit the
+          // notice between the retained head and tail of this one output.
+          emitNotice();
+          parts.push(out.tailText);
+        }
+        parts.push(out.statusSuffix);
+      } else if (hasTail) {
+        parts.push(out.tailText);
+        parts.push(out.statusSuffix);
+      } else {
+        // Fully dropped middle output: preserve the status exactly once.
+        parts.push(out.statusSuffix);
+      }
+    }
+    parts.push(this.literals[n]);
+    return parts.join('');
+  }
+
+  private placeOutput(index: number, text: string, totalBytes: number): void {
+    if (!this.headClosed) {
+      const remaining = this.headBudget - this.headBytesUsed;
+      if (totalBytes <= remaining) {
+        this.outputs[index].headText = text;
+        this.headBytesUsed += totalBytes;
+        return;
+      }
+      // This output straddles the head boundary: keep a head prefix and route
+      // the remainder to the sliding tail.
+      if (remaining > 0) {
+        const buf = Buffer.from(text, 'utf8');
+        let headEnd = Math.min(remaining, buf.length);
+        headEnd = completeUtf8PrefixLength(buf.subarray(0, headEnd));
+        const headPart = buf.subarray(0, headEnd).toString('utf8');
+        this.outputs[index].headText = headPart;
+        this.headBytesUsed += headEnd;
+        this.headClosed = true;
+        const remainder = buf.subarray(headEnd).toString('utf8');
+        this.addToTail(index, remainder);
+        return;
+      }
+      this.headClosed = true;
+      this.addToTail(index, text);
+      return;
+    }
+    this.addToTail(index, text);
+  }
+
+  private addToTail(index: number, text: string): void {
+    if (text === '') {
+      return;
+    }
+    this.outputs[index].tailText = text;
+    this.tailOrder.push(index);
+    this.tailBytesUsed += byteLengthUtf8(text);
+    this.evictTail();
+  }
+
+  /**
+   * Evict the oldest retained tail content (whole segments first, then a
+   * leading byte trim) until the tail region is back within its budget.
+   * Trimmed/dropped outputs keep their status suffix (emitted in build()).
+   */
+  private evictTail(): void {
+    while (
+      this.tailBytesUsed > this.tailBudget &&
+      this.tailOrderHead < this.tailOrder.length
+    ) {
+      const firstIndex = this.tailOrder[this.tailOrderHead];
+      const firstText = this.outputs[firstIndex].tailText;
+      const firstLen = byteLengthUtf8(firstText);
+      const excess = this.tailBytesUsed - this.tailBudget;
+      const hasNewerTail = this.tailOrderHead + 1 < this.tailOrder.length;
+      if (firstLen <= excess && hasNewerTail) {
+        // Fully drop the oldest segment; newer content remains in the tail.
+        this.outputs[firstIndex].tailText = '';
+        this.tailOrderHead += 1;
+        this.tailBytesUsed -= firstLen;
+        this.compactTailOrder();
+      } else {
+        // Trim leading bytes of the oldest segment down to the budget. This
+        // also handles a single oversized segment (keep its last tailBudget
+        // bytes) so one huge output cannot exceed the tail bound.
+        const buf = Buffer.from(firstText, 'utf8');
+        const dropStart =
+          excess + completeUtf8SuffixStart(buf.subarray(excess));
+        this.outputs[firstIndex].tailText = buf
+          .subarray(dropStart)
+          .toString('utf8');
+        this.tailBytesUsed -= dropStart;
+        return;
+      }
+    }
+  }
+
+  private compactTailOrder(): void {
+    if (
+      this.tailOrderHead < 4096 ||
+      this.tailOrderHead * 2 < this.tailOrder.length
+    ) {
+      return;
+    }
+    this.tailOrder = this.tailOrder.slice(this.tailOrderHead);
+    this.tailOrderHead = 0;
+  }
+}
+
+/**
+ * Assemble the final prompt string from ordered segments, bounding the
+ * aggregate command-output bytes (across all output segments) to `budget`.
+ *
+ * This convenience wrapper feeds pre-assembled segments into a
+ * {@link StreamingInjectionBuilder}. Production callers that execute commands
+ * incrementally should use the builder directly so that full command outputs
+ * are never retained simultaneously.
+ */
+export function buildBoundedPrompt(
+  segments: readonly PromptSegment[],
+  budget: ByteBudget = createByteBudget(DEFAULT_INJECTION_OUTPUT_BUDGET_BYTES),
+): string {
+  const builder = new StreamingInjectionBuilder(budget);
+  for (const segment of segments) {
+    if (segment.kind === 'literal') {
+      builder.appendLiteral(segment.text);
+    } else {
+      builder.appendOutput(segment.output, segment.statusSuffix);
+    }
+  }
+  return builder.build();
+}

--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -24,6 +24,8 @@ import {
   SHELL_INJECTION_TRIGGER,
   SHORTHAND_ARGS_PLACEHOLDER,
 } from './types.js';
+import { StreamingInjectionBuilder } from './injectionOutputBudget.js';
+import { resolveByteBudgetFromSetting } from '@vybestack/llxprt-code-tools/acquisition.js';
 
 type ShellProcessorRuntime = ShellPermissionConfig &
   ApprovalState &
@@ -160,18 +162,28 @@ export class ShellProcessor implements IPromptProcessor {
     config: ShellProcessorRuntime,
     userArgsRaw: string,
   ): Promise<string> {
-    let processedPrompt = '';
+    // Resolve the aggregate injection-output budget from the configured shell
+    // acquisition setting so prompt injection is bounded by the same finite
+    // policy as direct shell execution (issue #3200 finding 2). The streaming
+    // builder retains at most one global output budget across all injections
+    // and never holds all command outputs simultaneously.
+    const builder = new StreamingInjectionBuilder(
+      resolveByteBudgetFromSetting(
+        config.getShellExecutionConfig().outputRetentionMaxBytes,
+      ),
+    );
     let lastIndex = 0;
 
     for (const injection of resolvedInjections) {
-      // Append the text segment BEFORE the injection, substituting {{args}} with RAW input.
+      // Literal text BEFORE this injection, substituting {{args}} with RAW input.
       const segment = prompt.substring(lastIndex, injection.startIndex);
-      processedPrompt += segment.replaceAll(
-        SHORTHAND_ARGS_PLACEHOLDER,
-        userArgsRaw,
+      builder.appendLiteral(
+        segment.replaceAll(SHORTHAND_ARGS_PLACEHOLDER, userArgsRaw),
       );
 
-      // Execute the resolved command (which already has ESCAPED input).
+      // Execute the resolved command (which already has ESCAPED input) so side
+      // effects always run, then feed the output to the streaming builder so
+      // the full output is reduced to a bounded head/tail immediately.
       if (injection.resolvedCommand) {
         const { result } = await ShellExecutionService.execute(
           injection.resolvedCommand,
@@ -191,33 +203,35 @@ export class ShellProcessor implements IPromptProcessor {
           );
         }
 
-        // Append the output, making stderr explicit for the model.
-        processedPrompt += executionResult.output;
-
-        // Append a status message if the command did not succeed.
+        // Build the status suffix preserving exit/signal/abort semantics.
+        let statusSuffix = '';
         if (executionResult.aborted) {
-          processedPrompt += `\n[Shell command '${injection.resolvedCommand}' aborted]`;
+          statusSuffix = `\n[Shell command '${injection.resolvedCommand}' aborted]`;
         } else if (
           executionResult.exitCode !== 0 &&
           executionResult.exitCode !== null
         ) {
-          processedPrompt += `\n[Shell command '${injection.resolvedCommand}' exited with code ${executionResult.exitCode}]`;
+          statusSuffix = `\n[Shell command '${injection.resolvedCommand}' exited with code ${executionResult.exitCode}]`;
         } else if (executionResult.signal !== null) {
-          processedPrompt += `\n[Shell command '${injection.resolvedCommand}' terminated by signal ${executionResult.signal}]`;
+          statusSuffix = `\n[Shell command '${injection.resolvedCommand}' terminated by signal ${executionResult.signal}]`;
         }
+
+        builder.appendOutput(executionResult.output, statusSuffix);
       }
 
       lastIndex = injection.endIndex;
     }
 
-    // Append the remaining text AFTER the last injection, substituting {{args}} with RAW input.
+    // Remaining literal text AFTER the last injection.
     const finalSegment = prompt.substring(lastIndex);
-    processedPrompt += finalSegment.replaceAll(
-      SHORTHAND_ARGS_PLACEHOLDER,
-      userArgsRaw,
+    builder.appendLiteral(
+      finalSegment.replaceAll(SHORTHAND_ARGS_PLACEHOLDER, userArgsRaw),
     );
 
-    return processedPrompt;
+    // Build the final prompt with bounded aggregate output: every command has
+    // already executed for side effects, the aggregate output bytes are bounded
+    // with one accurate omission notice, and each status appears exactly once.
+    return builder.build();
   }
 
   /**

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
@@ -379,6 +379,49 @@ describe('useShellCommandProcessor', () => {
       );
     });
 
+    it('bounds direct-shell live output while preserving its head and tail', async () => {
+      mockConfig.getShellExecutionConfig = () => ({
+        showColor: false,
+        scrollback: 600000,
+        terminalWidth: 80,
+        terminalHeight: 24,
+        outputRetentionMaxBytes: 1024,
+      });
+      const { result } = renderProcessorHook();
+      await act(async () => {
+        result.current.handleShellCommand(
+          'stream',
+          new AbortController().signal,
+        );
+        await Promise.resolve();
+        await advanceTimersByTimeAsync(1);
+      });
+
+      act(() => {
+        mockShellOutputCallback({ type: 'data', chunk: 'H'.repeat(800) });
+      });
+      await act(async () => {
+        await advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+      });
+      act(() => {
+        mockShellOutputCallback({ type: 'data', chunk: 'T'.repeat(800) });
+      });
+
+      const display =
+        pendingHistoryItemState?.type === 'tool_group'
+          ? pendingHistoryItemState.tools[0].resultDisplay
+          : undefined;
+      expect(typeof display).toBe('string');
+      expect(display).toStartWith('H'.repeat(512));
+      expect(
+        typeof display === 'string'
+          ? display.match(/LLXPRT output truncated/g)
+          : [],
+      ).toHaveLength(1);
+      expect(display).toContain('576 bytes omitted');
+      expect(display).toEndWith('T'.repeat(512));
+    });
+
     it('should show binary progress messages correctly', async () => {
       const { result } = renderProcessorHook();
       await act(async () => {

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
@@ -422,6 +422,52 @@ describe('useShellCommandProcessor', () => {
       expect(display).toEndWith('T'.repeat(512));
     });
 
+    it('caps live display below a larger shell retention budget', async () => {
+      mockConfig.getShellExecutionConfig = () => ({
+        showColor: false,
+        scrollback: 600000,
+        terminalWidth: 80,
+        terminalHeight: 24,
+        outputRetentionMaxBytes: 4 * 1024 * 1024,
+      });
+      const { result } = renderProcessorHook();
+      await act(async () => {
+        result.current.handleShellCommand(
+          'stream',
+          new AbortController().signal,
+        );
+        await Promise.resolve();
+        await advanceTimersByTimeAsync(1);
+      });
+
+      act(() => {
+        mockShellOutputCallback({ type: 'data', chunk: 'H'.repeat(300_000) });
+      });
+      await act(async () => {
+        await advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+      });
+      act(() => {
+        mockShellOutputCallback({ type: 'data', chunk: 'T'.repeat(300_000) });
+      });
+
+      const display =
+        pendingHistoryItemState?.type === 'tool_group'
+          ? pendingHistoryItemState.tools[0].resultDisplay
+          : undefined;
+      expect(typeof display).toBe('string');
+      expect(display).toStartWith('H'.repeat(256 * 1024));
+      expect(mockShellExecutionService).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Function),
+        expect.any(Object),
+        false,
+        expect.objectContaining({ outputRetentionMaxBytes: 4 * 1024 * 1024 }),
+      );
+      expect(display).toContain('75,712 bytes omitted');
+      expect(display).toEndWith('T'.repeat(256 * 1024));
+    });
+
     it('should show binary progress messages correctly', async () => {
       const { result } = renderProcessorHook();
       await act(async () => {

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -24,6 +24,7 @@ import { debugLogger } from '@vybestack/llxprt-code-telemetry';
 import type { Agent } from '@vybestack/llxprt-code-agents';
 import {
   BoundedStreamCollector,
+  createByteBudget,
   resolveByteBudgetFromSetting,
 } from '@vybestack/llxprt-code-tools/acquisition.js';
 import { type UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -44,6 +45,7 @@ type ShellCommandRuntime = ShellState & SessionIdentity;
 // Throttle interval for PTY output updates to avoid excessive re-renders.
 // Using 100ms provides smooth visual updates without overwhelming React.
 export const OUTPUT_UPDATE_INTERVAL_MS = 100;
+const LIVE_DISPLAY_MAX_BYTES = 512 * 1024;
 const MAX_OUTPUT_LENGTH = 10000;
 
 interface ShellExecutionParams {
@@ -78,6 +80,7 @@ interface ShellEventState {
   binaryBytesReceived: number;
   cumulativeStdout: string | AnsiOutput;
   liveDisplayCollector: BoundedStreamCollector;
+  lastMaterializedLiveBytes: number;
   lastUpdateTime: number;
 }
 
@@ -253,8 +256,16 @@ function createShellEventHandler(
       event.type === 'data' && config.getShouldUseNodePtyShell();
     if (!isPtyData && !pastThrottle) return;
 
-    if (event.type === 'data' && !isPtyData && !state.isBinaryStream) {
+    if (
+      event.type === 'data' &&
+      !isPtyData &&
+      !state.isBinaryStream &&
+      state.liveDisplayCollector.observedByteCount !==
+        state.lastMaterializedLiveBytes
+    ) {
       state.cumulativeStdout = state.liveDisplayCollector.getResult().text;
+      state.lastMaterializedLiveBytes =
+        state.liveDisplayCollector.observedByteCount;
     }
     const currentDisplayOutput = computeDisplayOutput(
       state.isBinaryStream,
@@ -475,15 +486,20 @@ function handleExecutionResult(
 
 async function initiateShellExecution(params: ShellExecutionParams) {
   const shellExecutionConfig = params.config.getShellExecutionConfig();
+  const outputBudget = resolveByteBudgetFromSetting(
+    shellExecutionConfig.outputRetentionMaxBytes,
+  );
+  const liveDisplayBudget = createByteBudget(
+    Math.min(outputBudget.bytes, LIVE_DISPLAY_MAX_BYTES),
+  );
   const state: ShellEventState = {
     isBinaryStream: false,
     binaryBytesReceived: 0,
     cumulativeStdout: '',
     liveDisplayCollector: new BoundedStreamCollector({
-      budget: resolveByteBudgetFromSetting(
-        shellExecutionConfig.outputRetentionMaxBytes,
-      ),
+      budget: liveDisplayBudget,
     }),
+    lastMaterializedLiveBytes: 0,
     lastUpdateTime: -Infinity,
   };
 

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -22,6 +22,10 @@ import {
 } from '@vybestack/llxprt-code-core';
 import { debugLogger } from '@vybestack/llxprt-code-telemetry';
 import type { Agent } from '@vybestack/llxprt-code-agents';
+import {
+  BoundedStreamCollector,
+  resolveByteBudgetFromSetting,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
 import { type UseHistoryManagerReturn } from './useHistoryManager.js';
 import { SHELL_COMMAND_NAME } from '../constants.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
@@ -67,6 +71,14 @@ interface ShellExecutionParams {
   terminalWidth: number | undefined;
   terminalHeight: number | undefined;
   resolve: (value: void | PromiseLike<void>) => void;
+}
+
+interface ShellEventState {
+  isBinaryStream: boolean;
+  binaryBytesReceived: number;
+  cumulativeStdout: string | AnsiOutput;
+  liveDisplayCollector: BoundedStreamCollector;
+  lastUpdateTime: number;
 }
 
 function addShellCommandToAgentHistory(
@@ -188,11 +200,7 @@ function applyResultDisplayUpdate(
 function processShellEvent(
   event: ShellOutputEvent,
   config: ShellCommandRuntime,
-  state: {
-    isBinaryStream: boolean;
-    binaryBytesReceived: number;
-    cumulativeStdout: string | AnsiOutput;
-  },
+  state: ShellEventState,
 ): boolean {
   if (event.type === 'data' && state.isBinaryStream) return false;
 
@@ -202,11 +210,8 @@ function processShellEvent(
       if (config.getShouldUseNodePtyShell()) {
         state.cumulativeStdout = event.chunk;
         shouldUpdate = true;
-      } else if (
-        typeof event.chunk === 'string' &&
-        typeof state.cumulativeStdout === 'string'
-      ) {
-        state.cumulativeStdout += event.chunk;
+      } else if (typeof event.chunk === 'string') {
+        state.liveDisplayCollector.append(Buffer.from(event.chunk, 'utf-8'));
         shouldUpdate = true;
       }
       break;
@@ -236,28 +241,26 @@ function createShellEventHandler(
     React.SetStateAction<HistoryItemWithoutId | null>
   >,
   setLastShellOutputTime: React.Dispatch<React.SetStateAction<number>>,
-  state: {
-    isBinaryStream: boolean;
-    binaryBytesReceived: number;
-    cumulativeStdout: string | AnsiOutput;
-    lastUpdateTime: number;
-  },
+  state: ShellEventState,
 ) {
   return (event: ShellOutputEvent) => {
     const shouldUpdate = processShellEvent(event, config, state);
     if (!shouldUpdate) return;
-
-    const currentDisplayOutput = computeDisplayOutput(
-      state.isBinaryStream,
-      state.binaryBytesReceived,
-      state.cumulativeStdout,
-    );
 
     const pastThrottle =
       Date.now() - state.lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS;
     const isPtyData =
       event.type === 'data' && config.getShouldUseNodePtyShell();
     if (!isPtyData && !pastThrottle) return;
+
+    if (event.type === 'data' && !isPtyData && !state.isBinaryStream) {
+      state.cumulativeStdout = state.liveDisplayCollector.getResult().text;
+    }
+    const currentDisplayOutput = computeDisplayOutput(
+      state.isBinaryStream,
+      state.binaryBytesReceived,
+      state.cumulativeStdout,
+    );
 
     setLastShellOutputTime(Date.now());
     applyResultDisplayUpdate(
@@ -471,15 +474,16 @@ function handleExecutionResult(
 }
 
 async function initiateShellExecution(params: ShellExecutionParams) {
-  const state: {
-    isBinaryStream: boolean;
-    binaryBytesReceived: number;
-    cumulativeStdout: string | AnsiOutput;
-    lastUpdateTime: number;
-  } = {
+  const shellExecutionConfig = params.config.getShellExecutionConfig();
+  const state: ShellEventState = {
     isBinaryStream: false,
     binaryBytesReceived: 0,
     cumulativeStdout: '',
+    liveDisplayCollector: new BoundedStreamCollector({
+      budget: resolveByteBudgetFromSetting(
+        shellExecutionConfig.outputRetentionMaxBytes,
+      ),
+    }),
     lastUpdateTime: -Infinity,
   };
 
@@ -504,7 +508,7 @@ async function initiateShellExecution(params: ShellExecutionParams) {
     params.abortSignal,
     params.config.getShouldUseNodePtyShell(),
     {
-      ...params.config.getShellExecutionConfig(),
+      ...shellExecutionConfig,
       terminalWidth: effectiveTerminalWidth,
       terminalHeight: effectiveTerminalHeight,
     },

--- a/packages/cli/src/zed-integration/terminalOutputDelta.bun.test.ts
+++ b/packages/cli/src/zed-integration/terminalOutputDelta.bun.test.ts
@@ -33,6 +33,16 @@ describe('computeBoundedDelta - bounded linear-time overlap (issue #3200 finding
     expect(result.discontinuity).toBe(false);
   });
 
+  it('avoids replaying overlap during a non-truncated rewrite', () => {
+    const previous = 'old-kept-content';
+    const current = 'kept-content plus output';
+
+    const result = computeBoundedDelta(previous, current, false);
+
+    expect(result.delta).toBe(' plus output');
+    expect(result.discontinuity).toBe(false);
+  });
+
   it('recovers the overlap when the peer evicts the head (truncated)', () => {
     // The peer evicted "head-evicted-" from the beginning.
     const previous = 'head-evicted-kept-content';

--- a/packages/cli/src/zed-integration/terminalOutputDelta.bun.test.ts
+++ b/packages/cli/src/zed-integration/terminalOutputDelta.bun.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  computeBoundedDelta,
+  boundSnapshot,
+  boundSnapshotBytes,
+  OVERLAP_SEARCH_BOUND,
+  TERMINAL_DISCONTINUITY_NOTICE,
+  MAX_RETAINED_SNAPSHOT_CHARS,
+} from './terminalOutputDelta.js';
+
+describe('computeBoundedDelta - bounded linear-time overlap (issue #3200 finding 6)', () => {
+  it('returns clean delta for a monotonic append', () => {
+    const result = computeBoundedDelta('hello', 'hello world', false);
+    expect(result.delta).toBe(' world');
+    expect(result.discontinuity).toBe(false);
+  });
+
+  it('returns the full current when previous is empty', () => {
+    const result = computeBoundedDelta('', 'first output', false);
+    expect(result.delta).toBe('first output');
+    expect(result.discontinuity).toBe(false);
+  });
+
+  it('returns full current for a non-truncated reset', () => {
+    const result = computeBoundedDelta('old content', 'new content', false);
+    expect(result.delta).toBe('new content');
+    expect(result.discontinuity).toBe(false);
+  });
+
+  it('recovers the overlap when the peer evicts the head (truncated)', () => {
+    // The peer evicted "head-evicted-" from the beginning.
+    const previous = 'head-evicted-kept-content';
+    const current = 'kept-content' + ' more output';
+    const result = computeBoundedDelta(previous, current, true);
+    expect(result.delta).toBe(' more output');
+    expect(result.discontinuity).toBe(true);
+  });
+
+  it('emits a discontinuity notice when no overlap is found within the bound', () => {
+    // Completely different content, truncated flag set.
+    const previous = 'a'.repeat(100);
+    const current = 'b'.repeat(100);
+    const result = computeBoundedDelta(previous, current, true);
+    expect(result.discontinuity).toBe(true);
+    expect(result.delta).toContain(TERMINAL_DISCONTINUITY_NOTICE);
+  });
+
+  it('does not replay the entire window when overlap is small', () => {
+    const previous = 'AAAA' + 'z'.repeat(1000);
+    const current = 'z' + 'B'.repeat(1000);
+    const result = computeBoundedDelta(previous, current, true);
+    // Only a 1-char overlap: the delta is the current minus the 1-char overlap.
+    expect(result.delta).toBe('B'.repeat(1000));
+    expect(result.discontinuity).toBe(true);
+  });
+
+  it('bounds the overlap search to OVERLAP_SEARCH_BOUND', () => {
+    // previous and current share a long overlap (>BOUND), plus eviction.
+    // The overlap exceeds the bound, so the search caps at k=BOUND and the
+    // delta contains the remaining shared bytes plus the new tail.
+    const extra = 5000;
+    const shared = 'S'.repeat(OVERLAP_SEARCH_BOUND + extra);
+    const evicted = 'EVICTED_HEAD_';
+    const previous = evicted + shared;
+    const current = shared + 'TAIL';
+    const result = computeBoundedDelta(previous, current, true);
+    // k = BOUND matches (the shared suffix/prefix). The delta is current minus
+    // the first BOUND chars: the remaining `extra` shared S's + TAIL.
+    expect(result.delta).toBe('S'.repeat(extra) + 'TAIL');
+    expect(result.discontinuity).toBe(true);
+  });
+
+  it('handles disjoint content larger than both bounded search operands', () => {
+    const previous = 'A'.repeat(OVERLAP_SEARCH_BOUND * 4);
+    const current = 'B'.repeat(OVERLAP_SEARCH_BOUND * 4);
+
+    const result = computeBoundedDelta(previous, current, true);
+
+    expect(result.discontinuity).toBe(true);
+    expect(result.delta).toContain(TERMINAL_DISCONTINUITY_NOTICE);
+  });
+
+  it('recovers the longest overlap for a fully-overlapping prefix (KMP correctness)', () => {
+    // previous is a suffix of a repeated pattern; current is the same repeated
+    // pattern continuing. Verifies the KMP matcher returns the FULL overlap
+    // (not 0), which a naive backward scan would also find but a buggy reset
+    // could lose.
+    const previous = 'ababab';
+    const current = 'ababab' + ' tail';
+    const result = computeBoundedDelta(previous, current, true);
+    expect(result.delta).toBe(' tail');
+    expect(result.discontinuity).toBe(false);
+  });
+
+  it('recovers a repeated-pattern overlap ending mid-pattern (KMP fallback)', () => {
+    // current begins with a suffix that is the tail of a repeated unit.
+    const previous = 'xaxabx' + 'ababab';
+    const current = 'abab' + 'ZZZ';
+    const result = computeBoundedDelta(previous, current, true);
+    // Longest suffix of previous = prefix of current: 'abab' (4).
+    expect(result.delta).toBe('ZZZ');
+    expect(result.discontinuity).toBe(true);
+  });
+});
+
+describe('boundSnapshotBytes - configured byte-budget bounding (issue #3200 finding 4)', () => {
+  it('returns the string unchanged when under the budget', () => {
+    expect(boundSnapshotBytes('hello', 64)).toBe('hello');
+  });
+
+  it('keeps only the tail within the byte budget', () => {
+    const big = 'A'.repeat(100);
+    const bounded = boundSnapshotBytes(big, 40);
+    expect(Buffer.byteLength(bounded, 'utf8')).toBeLessThanOrEqual(40);
+    expect(bounded).toBe('A'.repeat(40));
+  });
+
+  it('bounds by UTF-8 bytes, not chars, for multibyte content', () => {
+    // Each char is 3 bytes in UTF-8. Budget 30 bytes -> retain 10 chars.
+    const text = 'A'.repeat(5) + '\u4e16'.repeat(20);
+    const bounded = boundSnapshotBytes(text, 30);
+    expect(Buffer.byteLength(bounded, 'utf8')).toBeLessThanOrEqual(30);
+    // No replacement chars (no split multibyte sequence).
+    expect(bounded).not.toContain('\uFFFD');
+  });
+
+  it('never splits a multibyte character at the start boundary', () => {
+    // Budget lands inside a multibyte char; the start must advance to the next
+    // character boundary.
+    const text = '\u4e16'.repeat(10);
+    const bounded = boundSnapshotBytes(text, 7);
+    expect(bounded).not.toContain('\uFFFD');
+    expect(Buffer.byteLength(bounded, 'utf8')).toBeLessThanOrEqual(7);
+  });
+
+  it('returns empty for a nonpositive budget', () => {
+    expect(boundSnapshotBytes('hello', 0)).toBe('');
+    expect(boundSnapshotBytes('hello', -5)).toBe('');
+  });
+});
+
+describe('boundSnapshot - retained polling state bounding (issue #3200 finding 4)', () => {
+  it('returns the string unchanged when under the cap', () => {
+    expect(boundSnapshot('hello')).toBe('hello');
+  });
+
+  it('keeps only the tail when over the cap', () => {
+    const big = 'A'.repeat(MAX_RETAINED_SNAPSHOT_CHARS + 1000);
+    const bounded = boundSnapshot(big);
+    expect(bounded.length).toBe(MAX_RETAINED_SNAPSHOT_CHARS);
+    expect(bounded.endsWith('A'.repeat(100))).toBe(true);
+  });
+
+  it('does not retain a low surrogate at the trim boundary', () => {
+    const tail = 'A'.repeat(MAX_RETAINED_SNAPSHOT_CHARS - 1);
+    const text = `P\uD83D\uDE00${tail}`;
+
+    const bounded = boundSnapshot(text);
+
+    expect(bounded).toBe(tail);
+    expect(Buffer.from(bounded, 'utf8').toString('utf8')).not.toContain(
+      '\uFFFD',
+    );
+  });
+});

--- a/packages/cli/src/zed-integration/terminalOutputDelta.ts
+++ b/packages/cli/src/zed-integration/terminalOutputDelta.ts
@@ -81,15 +81,15 @@ function longestSuffixPrefixOverlap(pattern: string, text: string): number {
  * bounded, truly-linear (KMP) overlap search (issue #3200 finding 6).
  *
  * - **Clean append** (current starts with previous): O(previous.length) slice.
- * - **Truncated / evicted**: a bounded overlap search (capped at
+ * - **Non-prefix snapshot**: a bounded overlap search (capped at
  *   {@link OVERLAP_SEARCH_BOUND}) finds the longest suffix of `previous` that
  *   is a prefix of `current` in O(bound) time via the KMP prefix function. If
- *   found, the delta skips the overlap. If no overlap is found within the
- *   bound, a {@link TERMINAL_DISCONTINUITY_NOTICE} is emitted instead of
- *   silently replaying the entire window. If the true overlap extends beyond
- *   the bounded search operands, content outside the detected overlap may be
- *   replayed; the discontinuity flag makes that uncertainty explicit.
- * - **Non-truncated, non-prefix** (output reset): the full current is the delta.
+ *   found, the delta skips the overlap. For truncated snapshots with no overlap,
+ *   a {@link TERMINAL_DISCONTINUITY_NOTICE} is emitted instead of silently
+ *   replaying the entire window. If the true overlap extends beyond the bounded
+ *   search operands, content outside the detected overlap may be replayed; the
+ *   discontinuity flag makes that uncertainty explicit for truncated output.
+ *   A non-truncated snapshot with no overlap is treated as a reset.
  */
 export function computeBoundedDelta(
   previous: string,
@@ -105,13 +105,9 @@ export function computeBoundedDelta(
     return { delta: current.slice(previous.length), discontinuity: false };
   }
 
-  if (!truncated) {
-    // No truncation flag — the peer reset/replaced the output entirely.
-    return { delta: current, discontinuity: false };
-  }
-
-  // Truncated: bounded KMP overlap search for the longest suffix of `previous`
-  // that is a prefix of `current`. Both operands are capped to the bound.
+  // The snapshot is not a clean append. Search a bounded suffix/prefix window
+  // even when the peer did not report truncation so screen rewrites do not
+  // replay bytes that are still present at the snapshot boundary.
   const maxK = Math.min(previous.length, current.length, OVERLAP_SEARCH_BOUND);
   const prevTail = previous.slice(previous.length - maxK);
   const currHead = current.slice(0, maxK);
@@ -120,8 +116,13 @@ export function computeBoundedDelta(
   if (overlap > 0) {
     return {
       delta: current.slice(overlap),
-      discontinuity: overlap < previous.length,
+      discontinuity: truncated && overlap < previous.length,
     };
+  }
+
+  if (!truncated) {
+    // No truncation flag and no overlap: the peer replaced the snapshot.
+    return { delta: current, discontinuity: false };
   }
 
   // No overlap found within the bounded search — represent the discontinuity

--- a/packages/cli/src/zed-integration/terminalOutputDelta.ts
+++ b/packages/cli/src/zed-integration/terminalOutputDelta.ts
@@ -1,0 +1,178 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Maximum number of bytes/code units to scan when searching for an overlap
+ * between the previous and current terminal snapshots after the peer reports
+ * truncation. Keeps the search bounded (issue #3200 finding 6) so a hostile or
+ * pathological peer cannot cause super-linear work.
+ */
+export const OVERLAP_SEARCH_BOUND = 8192;
+
+/**
+ * Marker inserted into the output delta when the terminal peer evicts
+ * scrollback content and no bounded overlap is found, so the model sees an
+ * explicit discontinuity rather than a silent replay or data loss.
+ */
+export const TERMINAL_DISCONTINUITY_NOTICE =
+  '[... terminal output truncated/evicted by peer ...]\n';
+
+export interface DeltaResult {
+  /** The incremental chunk to emit (may include a discontinuity notice). */
+  readonly delta: string;
+  /** True when peer eviction left some prior content unmatched or lost. */
+  readonly discontinuity: boolean;
+}
+
+/**
+ * Compute the KMP prefix (failure) function for `pattern` in O(pattern.length).
+ * Used by {@link longestSuffixPrefixOverlap} to avoid the O(n^2) nested scan.
+ */
+function computePrefixFunction(pattern: string): number[] {
+  const pi = new Array<number>(pattern.length).fill(0);
+  let k = 0;
+  for (let i = 1; i < pattern.length; i++) {
+    while (k > 0 && pattern.charCodeAt(k) !== pattern.charCodeAt(i)) {
+      k = pi[k - 1];
+    }
+    if (pattern.charCodeAt(k) === pattern.charCodeAt(i)) {
+      k += 1;
+    }
+    pi[i] = k;
+  }
+  return pi;
+}
+
+/**
+ * Return the length of the longest suffix of `text` that equals a prefix of
+ * `pattern`, using KMP matching in O(|pattern| + |text|) time (issue #3200
+ * finding 6). No sentinel character is needed: the failure function is computed
+ * only on `pattern`, and the matcher never indexes past it.
+ */
+function longestSuffixPrefixOverlap(pattern: string, text: string): number {
+  if (pattern.length === 0 || text.length === 0) {
+    return 0;
+  }
+  const pi = computePrefixFunction(pattern);
+  const m = pattern.length;
+  let q = 0;
+  for (let i = 0; i < text.length; i++) {
+    // When the full pattern is already matched, fall back via the failure
+    // function before trying to extend, so pattern[m] is never indexed.
+    if (q === m) {
+      q = pi[m - 1];
+    }
+    const c = text.charCodeAt(i);
+    while (q > 0 && pattern.charCodeAt(q) !== c) {
+      q = pi[q - 1];
+    }
+    if (pattern.charCodeAt(q) === c) {
+      q += 1;
+    }
+  }
+  return q;
+}
+
+/**
+ * Compute the incremental delta between two terminal output snapshots using a
+ * bounded, truly-linear (KMP) overlap search (issue #3200 finding 6).
+ *
+ * - **Clean append** (current starts with previous): O(previous.length) slice.
+ * - **Truncated / evicted**: a bounded overlap search (capped at
+ *   {@link OVERLAP_SEARCH_BOUND}) finds the longest suffix of `previous` that
+ *   is a prefix of `current` in O(bound) time via the KMP prefix function. If
+ *   found, the delta skips the overlap. If no overlap is found within the
+ *   bound, a {@link TERMINAL_DISCONTINUITY_NOTICE} is emitted instead of
+ *   silently replaying the entire window. If the true overlap extends beyond
+ *   the bounded search operands, content outside the detected overlap may be
+ *   replayed; the discontinuity flag makes that uncertainty explicit.
+ * - **Non-truncated, non-prefix** (output reset): the full current is the delta.
+ */
+export function computeBoundedDelta(
+  previous: string,
+  current: string,
+  truncated: boolean,
+): DeltaResult {
+  if (previous.length === 0) {
+    return { delta: current, discontinuity: false };
+  }
+
+  // Fast path: clean monotonic append.
+  if (current.startsWith(previous)) {
+    return { delta: current.slice(previous.length), discontinuity: false };
+  }
+
+  if (!truncated) {
+    // No truncation flag — the peer reset/replaced the output entirely.
+    return { delta: current, discontinuity: false };
+  }
+
+  // Truncated: bounded KMP overlap search for the longest suffix of `previous`
+  // that is a prefix of `current`. Both operands are capped to the bound.
+  const maxK = Math.min(previous.length, current.length, OVERLAP_SEARCH_BOUND);
+  const prevTail = previous.slice(previous.length - maxK);
+  const currHead = current.slice(0, maxK);
+  const overlap = longestSuffixPrefixOverlap(currHead, prevTail);
+
+  if (overlap > 0) {
+    return {
+      delta: current.slice(overlap),
+      discontinuity: overlap < previous.length,
+    };
+  }
+
+  // No overlap found within the bounded search — represent the discontinuity
+  // explicitly rather than replaying the entire window.
+  return {
+    delta: TERMINAL_DISCONTINUITY_NOTICE + current,
+    discontinuity: true,
+  };
+}
+
+/**
+ * Bound a snapshot string to its tail by UTF-8 byte budget, never splitting a
+ * multibyte character. Used to keep retained polling state bounded to the
+ * configured acquisition budget rather than a fixed character cap (issue #3200
+ * finding 4).
+ */
+export function boundSnapshotBytes(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) {
+    return '';
+  }
+  if (Buffer.byteLength(text, 'utf8') <= maxBytes) {
+    return text;
+  }
+  // Keep the tail: find the smallest start byte offset such that the retained
+  // tail is within the byte budget and begins on a character boundary (a byte
+  // that is not a UTF-8 continuation byte).
+  const encoded = Buffer.from(text, 'utf8');
+  let start = encoded.length - maxBytes;
+  if (start < 0) {
+    start = 0;
+  }
+  while (start < encoded.length && (encoded[start] & 0xc0) === 0x80) {
+    start += 1;
+  }
+  return encoded.toString('utf8', start);
+}
+
+/**
+ * Legacy character-cap snapshot bounding. Prefer {@link boundSnapshotBytes} with
+ * the configured byte budget. Retained for existing callers/tests.
+ */
+export const MAX_RETAINED_SNAPSHOT_CHARS = 1024 * 1024;
+
+export function boundSnapshot(text: string): string {
+  if (text.length <= MAX_RETAINED_SNAPSHOT_CHARS) {
+    return text;
+  }
+  let start = text.length - MAX_RETAINED_SNAPSHOT_CHARS;
+  const code = text.charCodeAt(start);
+  if (code >= 0xdc00 && code <= 0xdfff) {
+    start += 1;
+  }
+  return text.slice(start);
+}

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -280,7 +280,7 @@ export class TerminalManager {
       this.logger.debug(
         () => `Terminal output poll failed: ${errorMessage(error)}`,
       );
-      throw error;
+      return;
     }
     this.applyTerminalSnapshot(state, current, onOutput);
   }
@@ -365,6 +365,7 @@ export class TerminalManager {
             observedBytes: state.maxObservedBytes,
             retainedBytes,
             omittedBytes,
+            omittedBytesExact: false,
             truncated: true,
             budgetBytes: this.outputBudget.bytes,
           }

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -16,9 +16,17 @@ import type {
   ShellExecutionResult,
   ShellOutputEvent,
 } from '@vybestack/llxprt-code-tools';
+import type {
+  ByteBudget,
+  TruncationMetadata,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
+import {
+  computeBoundedDelta,
+  boundSnapshotBytes,
+  TERMINAL_DISCONTINUITY_NOTICE,
+} from './terminalOutputDelta.js';
 
 const OUTPUT_POLL_INTERVAL_MS = 100;
-const APPROXIMATE_BYTES_PER_TOKEN = 4;
 const KILL_GRACE_PERIOD_MS = 5000;
 
 type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
@@ -36,6 +44,23 @@ interface ActiveTerminal {
   toolCallId: string | undefined;
 }
 
+interface TerminalWaitState {
+  exit: acp.WaitForTerminalExitResponse | undefined;
+  exitError: unknown;
+  previousOutput: string;
+  killed: boolean;
+  killDeadline: number;
+  evictionNoticeEmitted: boolean;
+  maxObservedBytes: number;
+}
+
+function terminalWaitDone(state: TerminalWaitState): boolean {
+  return (
+    state.exit !== undefined ||
+    state.exitError !== undefined ||
+    (state.killed && Date.now() >= state.killDeadline)
+  );
+}
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -50,7 +75,8 @@ export class TerminalManager {
     private readonly targetDir: string,
     private readonly sendUpdate: SendUpdateFn,
     private readonly logger: DebugLogger,
-    private readonly maxOutputTokens?: number,
+    /** Validated byte budget resolved at the ACP integration boundary. */
+    private readonly outputBudget: ByteBudget,
   ) {}
 
   static isShellToolCall(
@@ -121,11 +147,7 @@ export class TerminalManager {
       args: [...shell.argsPrefix, command],
       cwd,
       sessionId: this.sessionId,
-      ...(this.maxOutputTokens === undefined
-        ? {}
-        : {
-            outputByteLimit: this.maxOutputTokens * APPROXIMATE_BYTES_PER_TOKEN,
-          }),
+      outputByteLimit: this.outputBudget.bytes,
     });
     const active: ActiveTerminal = {
       handle,
@@ -189,101 +211,198 @@ export class TerminalManager {
     onOutput: (event: ShellOutputEvent) => void,
     signal: AbortSignal,
   ): Promise<ShellExecutionResult> {
-    let exit: acp.WaitForTerminalExitResponse | undefined;
-    let exitError: unknown;
-    const exitPromise = active.handle
-      .waitForExit()
-      .then((result) => {
-        exit = result;
-      })
-      .catch((error: unknown) => {
-        exitError = error;
-      });
-    let previousOutput = '';
-    let killed = false;
-    let killDeadline = 0;
-    let done = false;
-    while (!done) {
-      if (signal.aborted && !killed) {
-        killed = true;
-        killDeadline = Date.now() + KILL_GRACE_PERIOD_MS;
-        await this.kill(active);
-      }
-      done =
-        exit !== undefined ||
-        exitError !== undefined ||
-        (killed && Date.now() >= killDeadline);
-      if (!done) {
-        const pollDelay = delay(OUTPUT_POLL_INTERVAL_MS);
-        try {
-          await Promise.race([exitPromise, pollDelay.promise]);
-        } finally {
-          pollDelay.cancel();
-        }
-        let current: acp.TerminalOutputResponse;
-        try {
-          current = await active.handle.currentOutput();
-        } catch (error) {
-          this.logger.debug(
-            () => `Terminal output poll failed: ${errorMessage(error)}`,
-          );
-          throw error;
-        }
-        const chunk = outputDelta(
-          previousOutput,
-          current.output,
-          current.truncated,
-        );
-        if (chunk !== '') {
-          onOutput({ type: 'data', chunk });
-        }
-        previousOutput = current.output;
+    const state: TerminalWaitState = {
+      exit: undefined,
+      exitError: undefined,
+      previousOutput: '',
+      killed: false,
+      killDeadline: 0,
+      evictionNoticeEmitted: false,
+      maxObservedBytes: 0,
+    };
+    const exitPromise = this.observeTerminalExit(active, state);
+    while (!terminalWaitDone(state)) {
+      await this.applyAbort(active, state, signal);
+      if (!terminalWaitDone(state)) {
+        await this.pollTerminal(active, state, onOutput, exitPromise);
       }
     }
-    if (exitError === undefined) {
-      previousOutput = await this.pollFinalOutput(
-        active,
-        previousOutput,
-        onOutput,
+    const finalEviction = await this.finishTerminalOutput(
+      active,
+      state,
+      onOutput,
+    );
+    return this.buildTerminalResult(state, finalEviction, signal);
+  }
+
+  private async observeTerminalExit(
+    active: ActiveTerminal,
+    state: TerminalWaitState,
+  ): Promise<void> {
+    try {
+      state.exit = await active.handle.waitForExit();
+    } catch (error) {
+      state.exitError = error;
+    }
+  }
+
+  private async applyAbort(
+    active: ActiveTerminal,
+    state: TerminalWaitState,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (!signal.aborted || state.killed) {
+      return;
+    }
+    state.killed = true;
+    state.killDeadline = Date.now() + KILL_GRACE_PERIOD_MS;
+    await this.kill(active);
+  }
+
+  private async pollTerminal(
+    active: ActiveTerminal,
+    state: TerminalWaitState,
+    onOutput: (event: ShellOutputEvent) => void,
+    exitPromise: Promise<void>,
+  ): Promise<void> {
+    const pollDelay = delay(OUTPUT_POLL_INTERVAL_MS);
+    try {
+      // Exit only short-circuits this polling delay. finishTerminalOutput() still
+      // performs the authoritative final output poll after the wait resolves.
+      await Promise.race([exitPromise, pollDelay.promise]);
+    } finally {
+      pollDelay.cancel();
+    }
+    let current: acp.TerminalOutputResponse;
+    try {
+      current = await active.handle.currentOutput();
+    } catch (error) {
+      this.logger.debug(
+        () => `Terminal output poll failed: ${errorMessage(error)}`,
+      );
+      throw error;
+    }
+    this.applyTerminalSnapshot(state, current, onOutput);
+  }
+
+  private applyTerminalSnapshot(
+    state: TerminalWaitState,
+    current: acp.TerminalOutputResponse,
+    onOutput: (event: ShellOutputEvent) => void,
+  ): void {
+    const observedNow = Buffer.byteLength(current.output, 'utf8');
+    if (observedNow > this.outputBudget.bytes) {
+      throw new Error(
+        `Terminal peer exceeded output byte budget (${this.outputBudget.bytes} bytes)`,
       );
     }
-    if (exitError !== undefined) {
-      throw exitError;
+    state.maxObservedBytes = Math.max(state.maxObservedBytes, observedNow);
+    const { delta, discontinuity } = computeBoundedDelta(
+      state.previousOutput,
+      current.output,
+      current.truncated,
+    );
+    let streamedDelta = delta;
+    if (discontinuity) {
+      const deltaContainsNotice = streamedDelta.startsWith(
+        TERMINAL_DISCONTINUITY_NOTICE,
+      );
+      if (!state.evictionNoticeEmitted) {
+        if (!deltaContainsNotice) {
+          onOutput({ type: 'data', chunk: TERMINAL_DISCONTINUITY_NOTICE });
+        }
+        state.evictionNoticeEmitted = true;
+      } else if (deltaContainsNotice) {
+        streamedDelta = streamedDelta.slice(
+          TERMINAL_DISCONTINUITY_NOTICE.length,
+        );
+      }
     }
+    if (streamedDelta !== '') {
+      onOutput({ type: 'data', chunk: streamedDelta });
+    }
+    state.previousOutput = boundSnapshotBytes(
+      current.output,
+      this.outputBudget.bytes,
+    );
+  }
+
+  private async finishTerminalOutput(
+    active: ActiveTerminal,
+    state: TerminalWaitState,
+    onOutput: (event: ShellOutputEvent) => void,
+  ): Promise<boolean> {
+    let finalEviction = state.evictionNoticeEmitted;
+    if (state.exitError === undefined) {
+      const finalPollEviction = await this.pollFinalOutput(
+        active,
+        state,
+        onOutput,
+      );
+      finalEviction ||= finalPollEviction;
+    }
+    if (state.exitError !== undefined) {
+      throw state.exitError;
+    }
+    return finalEviction;
+  }
+
+  private buildTerminalResult(
+    state: TerminalWaitState,
+    finalEviction: boolean,
+    signal: AbortSignal,
+  ): ShellExecutionResult {
+    const retainedBytes = Buffer.byteLength(state.previousOutput, 'utf8');
+    const omittedBytes = Math.max(0, state.maxObservedBytes - retainedBytes);
+    const output =
+      finalEviction &&
+      !state.previousOutput.startsWith(TERMINAL_DISCONTINUITY_NOTICE)
+        ? TERMINAL_DISCONTINUITY_NOTICE + state.previousOutput
+        : state.previousOutput;
+    const outputTruncation: TruncationMetadata | undefined =
+      omittedBytes > 0
+        ? {
+            observedBytes: state.maxObservedBytes,
+            retainedBytes,
+            omittedBytes,
+            truncated: true,
+            budgetBytes: this.outputBudget.bytes,
+          }
+        : undefined;
     return {
-      output: previousOutput,
-      exitCode: exit?.exitCode ?? null,
-      signal: exit?.signal ?? null,
+      output,
+      exitCode: state.exit?.exitCode ?? null,
+      signal: state.exit?.signal ?? null,
       error: null,
       aborted: signal.aborted,
       pid: undefined,
+      outputTruncation,
     };
   }
 
   private async pollFinalOutput(
     active: ActiveTerminal,
-    previousOutput: string,
+    state: TerminalWaitState,
     onOutput: (event: ShellOutputEvent) => void,
-  ): Promise<string> {
+  ): Promise<boolean> {
+    let final: acp.TerminalOutputResponse | undefined;
     try {
-      const final = await withTimeout(
+      final = await withTimeout(
         active.handle.currentOutput(),
         OUTPUT_POLL_INTERVAL_MS * 5,
       );
-      if (final === undefined) {
-        return previousOutput;
-      }
-      const chunk = outputDelta(previousOutput, final.output, final.truncated);
-      if (chunk !== '') {
-        onOutput({ type: 'data', chunk });
-      }
-      return final.output;
     } catch (error) {
       this.logger.debug(
         () => `Terminal post-exit output poll failed: ${errorMessage(error)}`,
       );
-      return previousOutput;
+      return false;
     }
+    if (final === undefined) {
+      return false;
+    }
+    const hadEviction = state.evictionNoticeEmitted;
+    this.applyTerminalSnapshot(state, final, onOutput);
+    return !hadEviction && state.evictionNoticeEmitted;
   }
 
   private async killAndRelease(active: ActiveTerminal): Promise<void> {
@@ -454,29 +573,6 @@ function abortedResult(): ShellExecutionResult {
     aborted: true,
     pid: undefined,
   };
-}
-
-function outputDelta(
-  previous: string,
-  current: string,
-  truncated: boolean,
-): string {
-  if (current.startsWith(previous)) {
-    return current.slice(previous.length);
-  }
-  if (!truncated) {
-    return current;
-  }
-  for (
-    let overlap = Math.min(previous.length, current.length);
-    overlap > 0;
-    overlap--
-  ) {
-    if (previous.endsWith(current.slice(0, overlap))) {
-      return current.slice(overlap);
-    }
-  }
-  return current;
 }
 
 async function withTimeout<T>(

--- a/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
@@ -16,6 +16,11 @@ import {
   type IShellToolHost,
   type ToolRegistry,
 } from '@vybestack/llxprt-code-tools';
+import {
+  ACQUISITION_HARD_MAX_BYTES,
+  ACQUISITION_MIN_BYTES,
+  DEFAULT_ACQUISITION_BUDGET_BYTES,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
 import { buildZedTerminalSetup } from './zed-terminal-setup.js';
 import { RecordingConnection } from './zed-test-helpers.js';
 
@@ -24,7 +29,8 @@ function configFixture(outputLimit?: number): Config {
     getPolicyEngine: () => undefined,
     getDebugMode: () => false,
     getTargetDir: () => '/project',
-    getEphemeralSetting: () => outputLimit,
+    getEphemeralSetting: (key: string) =>
+      key === 'shell-output-retention-max-bytes' ? outputLimit : undefined,
   } as unknown as Config;
 }
 
@@ -68,44 +74,28 @@ describe('buildZedTerminalSetup', () => {
     expect(tool).not.toBe(baseShellTool);
   });
 
-  it.each([-1, 0])(
-    'ignores a non-positive terminal output token limit of %i',
-    async (limit) => {
-      const baseRegistry = {
-        getAllTools: vi.fn(() => []),
-      } as unknown as ToolRegistry;
-      const connection = new RecordingConnection();
-      const setup = buildZedTerminalSetup(
-        'session-1',
-        configFixture(limit),
-        baseRegistry,
-        connection as unknown as acp.AgentSideConnection,
-        new DebugLogger('llxprt:zed-terminal-setup-test'),
-        messageBus,
-      );
-
-      await setup.terminals.executeShellCommand(
-        'echo test',
-        '/project',
-        () => undefined,
-        new AbortController().signal,
-      );
-
-      expect(connection.createTerminalCalls).toHaveLength(1);
-      expect(connection.createTerminalCalls[0]).not.toHaveProperty(
-        'outputByteLimit',
-      );
-    },
-  );
-
-  it('converts a positive output token limit to bytes', async () => {
+  it.each([
+    [
+      'the default for an absent setting',
+      undefined,
+      DEFAULT_ACQUISITION_BUDGET_BYTES,
+    ],
+    ['the hard maximum for -1', -1, ACQUISITION_HARD_MAX_BYTES],
+    ['the default for an invalid zero', 0, DEFAULT_ACQUISITION_BUDGET_BYTES],
+    ['the minimum for a small positive value', 100, ACQUISITION_MIN_BYTES],
+    [
+      'the hard maximum for an excessive value',
+      ACQUISITION_HARD_MAX_BYTES + 1,
+      ACQUISITION_HARD_MAX_BYTES,
+    ],
+  ])('passes %s to ACP', async (_description, setting, expectedLimit) => {
     const baseRegistry = {
       getAllTools: vi.fn(() => []),
     } as unknown as ToolRegistry;
     const connection = new RecordingConnection();
     const setup = buildZedTerminalSetup(
       'session-1',
-      configFixture(100),
+      configFixture(setting),
       baseRegistry,
       connection as unknown as acp.AgentSideConnection,
       new DebugLogger('llxprt:zed-terminal-setup-test'),
@@ -120,7 +110,8 @@ describe('buildZedTerminalSetup', () => {
     );
 
     expect(connection.createTerminalCalls).toHaveLength(1);
-    // Terminal output limits approximate one token as four bytes.
-    expect(connection.createTerminalCalls[0]?.outputByteLimit).toBe(400);
+    expect(connection.createTerminalCalls[0]?.outputByteLimit).toBe(
+      expectedLimit,
+    );
   });
 });

--- a/packages/cli/src/zed-integration/zed-terminal-setup.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-setup.ts
@@ -14,6 +14,7 @@ import {
   CoreToolRegistryHostAdapter,
 } from '@vybestack/llxprt-code-core';
 import { ShellTool, ToolRegistry } from '@vybestack/llxprt-code-tools';
+import { resolveByteBudgetFromSetting } from '@vybestack/llxprt-code-tools/acquisition.js';
 import { AcpTerminalShellHost } from './acp-terminal-shell-host.js';
 import { TerminalManager } from './zed-terminal-manager.js';
 
@@ -30,18 +31,18 @@ export function buildZedTerminalSetup(
   logger: DebugLogger,
   messageBus: MessageBus,
 ): ZedTerminalSetup {
-  const outputLimit = config.getEphemeralSetting('tool-output-max-tokens');
+  // ACP receives the same finite acquisition budget as local shell execution,
+  // rather than approximating bytes from the model-facing token limit.
+  const outputBudget = resolveByteBudgetFromSetting(
+    config.getEphemeralSetting('shell-output-retention-max-bytes'),
+  );
   const terminals = new TerminalManager(
     sessionId,
     connection,
     config.getTargetDir(),
     (update) => connection.sessionUpdate({ sessionId, update }),
     logger,
-    typeof outputLimit === 'number' &&
-    Number.isFinite(outputLimit) &&
-    outputLimit > 0
-      ? outputLimit
-      : undefined,
+    outputBudget,
   );
   const messageBusAdapter = new CoreMessageBusAdapter(messageBus);
   const registry = new ToolRegistry(

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -188,6 +188,7 @@ export class RecordingConnection {
   releaseCalls = 0;
 
   private terminalOutput = '';
+  private terminalTruncated = false;
   private terminalExitDelayed = false;
   private terminalExitResolvers = new Map<string, Array<() => void>>();
   private terminalCreationWaiters = new Set<() => void>();
@@ -195,6 +196,10 @@ export class RecordingConnection {
 
   setTerminalOutput(output: string): void {
     this.terminalOutput = output;
+  }
+
+  setTerminalTruncated(truncated: boolean): void {
+    this.terminalTruncated = truncated;
   }
 
   delayTerminalExit(): void {
@@ -433,7 +438,7 @@ export class RecordingConnection {
       currentOutput: vi.fn(async () => ({
         output: this.terminalOutput,
         exitStatus: null,
-        truncated: false,
+        truncated: this.terminalTruncated,
       })),
       waitForExit: vi.fn(async () => {
         if (this.terminalExitDelayed) {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -189,6 +189,7 @@ export class RecordingConnection {
 
   private terminalOutput = '';
   private terminalTruncated = false;
+  private terminalOutputFailuresRemaining = 0;
   private terminalExitDelayed = false;
   private terminalExitResolvers = new Map<string, Array<() => void>>();
   private terminalCreationWaiters = new Set<() => void>();
@@ -200,6 +201,10 @@ export class RecordingConnection {
 
   setTerminalTruncated(truncated: boolean): void {
     this.terminalTruncated = truncated;
+  }
+
+  failNextTerminalOutputPoll(): void {
+    this.terminalOutputFailuresRemaining += 1;
   }
 
   delayTerminalExit(): void {
@@ -435,11 +440,17 @@ export class RecordingConnection {
   private buildFakeTerminalHandle(terminalId: string): FakeTerminalHandle {
     const handle = {
       id: terminalId,
-      currentOutput: vi.fn(async () => ({
-        output: this.terminalOutput,
-        exitStatus: null,
-        truncated: this.terminalTruncated,
-      })),
+      currentOutput: vi.fn(async () => {
+        if (this.terminalOutputFailuresRemaining > 0) {
+          this.terminalOutputFailuresRemaining -= 1;
+          throw new Error('transient terminal output failure');
+        }
+        return {
+          output: this.terminalOutput,
+          exitStatus: null,
+          truncated: this.terminalTruncated,
+        };
+      }),
       waitForExit: vi.fn(async () => {
         if (this.terminalExitDelayed) {
           await new Promise<void>((resolve) => {

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -12,9 +12,14 @@ import {
 } from '@vybestack/llxprt-code-core';
 import type { AgentEvent } from '@vybestack/llxprt-code-agents';
 import { buildCommandToExecute } from '@vybestack/llxprt-code-tools';
+import {
+  createByteBudget,
+  DEFAULT_ACQUISITION_BUDGET_BYTES,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
 
 import { Session } from './zedIntegration.js';
 import { TerminalManager } from './zed-terminal-manager.js';
+import { TERMINAL_DISCONTINUITY_NOTICE } from './terminalOutputDelta.js';
 import {
   buildFakeAgent,
   RecordingConnection,
@@ -47,6 +52,7 @@ function terminalManager(
   connection: RecordingConnection,
   sendUpdate: (update: acp.SessionUpdate) => Promise<void> = (update) =>
     connection.sessionUpdate({ sessionId: 'test-session-id', update }),
+  outputByteLimit?: number,
 ): TerminalManager {
   return new TerminalManager(
     'test-session-id',
@@ -54,6 +60,7 @@ function terminalManager(
     '/project',
     sendUpdate,
     new DebugLogger('llxprt:zed-terminal-test'),
+    createByteBudget(outputByteLimit ?? DEFAULT_ACQUISITION_BUDGET_BYTES),
   );
 }
 
@@ -137,6 +144,7 @@ describe('Zed terminal execution', () => {
         args: [...shell.argsPrefix, preparedEcho],
         cwd: '/project',
         sessionId: 'test-session-id',
+        outputByteLimit: DEFAULT_ACQUISITION_BUDGET_BYTES,
       },
     ]);
     expect(result).toMatchObject({ output: 'hello\n', exitCode: 0 });
@@ -457,5 +465,149 @@ describe('Zed terminal command correlation does not over-match', () => {
     expect(updates).not.toContainEqual(
       expect.objectContaining({ toolCallId: 'shell-no-match' }),
     );
+  });
+});
+
+describe('Zed terminal byte-budget enforcement (issue #3200 finding 4)', () => {
+  afterEach(async () => {
+    await Promise.allSettled(
+      createdSessions.splice(0).map((session) => session.dispose()),
+    );
+  });
+
+  it('fails fast and releases a hostile peer that exceeds the byte budget', async () => {
+    const connection = new RecordingConnection();
+    // Set terminal output far exceeding the small budget.
+    connection.setTerminalOutput('X'.repeat(100000));
+    const terminals = terminalManager(connection, undefined, 1024);
+
+    await expectRejection(
+      terminals.executeShellCommand(
+        preparedEcho,
+        '/project',
+        () => undefined,
+        new AbortController().signal,
+      ),
+      'exceeded output byte budget',
+    );
+
+    // The terminal must be killed and released (fail fast).
+    expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+    expect(connection.releaseCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits truthful quantifiable metadata and one notice when the peer evicts content', async () => {
+    // The peer first shows a large output, then evicts the head and reports a
+    // small disjoint tail with truncated=true. The manager must surface the
+    // quantifiable loss (observed > retained) as exact metadata and include one
+    // visible discontinuity notice in the returned output.
+    const connection = new RecordingConnection();
+    connection.delayTerminalExit();
+    const bigOutput = 'HEAD_MARKER' + 'X'.repeat(8000);
+    connection.setTerminalOutput(bigOutput);
+    let resolveBig: () => void = () => undefined;
+    const sawBig = new Promise<void>((resolve) => {
+      resolveBig = resolve;
+    });
+    const budget = 16384; // larger than bigOutput so it is not fail-fast killed
+    const streamedChunks: string[] = [];
+    const terminals = terminalManager(connection, undefined, budget);
+    const execution = terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      (event) => {
+        if (event.type !== 'data' || typeof event.chunk !== 'string') {
+          return;
+        }
+        streamedChunks.push(event.chunk);
+        if (
+          event.chunk.includes('HEAD_MARKER') &&
+          !event.chunk.includes(TERMINAL_DISCONTINUITY_NOTICE)
+        ) {
+          resolveBig();
+        }
+      },
+      new AbortController().signal,
+    );
+    await connection.waitForTerminalProcessCreated();
+    // Wait until the first poll has delivered the big output, then simulate the
+    // peer evicting it to a small disjoint tail.
+    await sawBig;
+    connection.setTerminalOutput('TAIL_ONLY_ZZZ');
+    connection.setTerminalTruncated(true);
+    connection.resolveDelayedTerminalExit();
+    const result = await execution;
+
+    // Quantifiable loss: observed (the big peak) exceeds retained (the tail).
+    expect(result.outputTruncation).toBeDefined();
+    expect(result.outputTruncation?.truncated).toBe(true);
+    expect(result.outputTruncation?.omittedBytes).toBeGreaterThan(0);
+    expect(result.outputTruncation?.budgetBytes).toBe(budget);
+    // Exactly one durable discontinuity notice is streamed and retained.
+    expect(
+      streamedChunks.join('').split(TERMINAL_DISCONTINUITY_NOTICE).length - 1,
+    ).toBe(1);
+    expect(result.output.split(TERMINAL_DISCONTINUITY_NOTICE).length - 1).toBe(
+      1,
+    );
+    expect(result.output).toContain('TAIL_ONLY_ZZZ');
+  });
+
+  it('does not fabricate exact metadata when the peer reports truncated but no loss is observed', async () => {
+    // A peer that reports truncated=true but whose output never shrinks (we
+    // never observe an eviction) must NOT claim observed==retained with
+    // omittedBytes 0 as exact metadata — that would be a fabricated guarantee.
+    const connection = new RecordingConnection();
+    connection.setTerminalOutput('some output\n');
+    connection.setTerminalTruncated(true);
+    const terminals = terminalManager(connection, undefined, 4096);
+
+    const result = await terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      new AbortController().signal,
+    );
+
+    // No quantifiable loss was observed, so no exact-count metadata is emitted.
+    expect(result.outputTruncation).toBeUndefined();
+    expect(result.output).toBe('some output\n');
+  });
+
+  it('does not set truncation metadata when the peer is not truncated', async () => {
+    const connection = new RecordingConnection();
+    connection.setTerminalOutput('clean output\n');
+    const terminals = terminalManager(connection, undefined, 4096);
+
+    const result = await terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      new AbortController().signal,
+    );
+
+    expect(result.outputTruncation).toBeUndefined();
+  });
+
+  it('enforces the configured byte budget as the retention bound', async () => {
+    // Output exactly at the configured budget is retained fully (byte-accurate),
+    // confirming the configured budget — not a fixed character cap — governs
+    // retention. Combined with the fail-fast test above, retained state is
+    // always bounded by the configured budget.
+    const connection = new RecordingConnection();
+    const budget = 4096;
+    connection.setTerminalOutput('B'.repeat(budget));
+    const terminals = terminalManager(connection, undefined, budget);
+
+    const result = await terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      new AbortController().signal,
+    );
+
+    expect(Buffer.byteLength(result.output, 'utf8')).toBe(budget);
+    expect(result.exitCode).toBe(0);
+    expect(result.outputTruncation).toBeUndefined();
   });
 });

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -64,6 +64,27 @@ function terminalManager(
   );
 }
 
+function waitForTestSignal(
+  signal: Promise<void>,
+  description: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${description}`));
+    }, 2000);
+    void signal.then(
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
 function shellToolCallEvent(toolCallId: string, command: string): AgentEvent {
   return {
     type: 'tool-call',
@@ -186,7 +207,7 @@ describe('Zed terminal execution', () => {
     );
 
     await connection.waitForTerminalProcessCreated();
-    await sawOutput;
+    await waitForTestSignal(sawOutput, 'recovered terminal output');
     connection.resolveDelayedTerminalExit();
     const result = await execution;
 
@@ -568,7 +589,7 @@ describe('Zed terminal byte-budget enforcement (issue #3200 finding 4)', () => {
     await connection.waitForTerminalProcessCreated();
     // Wait until the first poll has delivered the big output, then simulate the
     // peer evicting it to a small disjoint tail.
-    await sawBig;
+    await waitForTestSignal(sawBig, 'initial bounded terminal snapshot');
     connection.setTerminalOutput('TAIL_ONLY_ZZZ');
     connection.setTerminalTruncated(true);
     connection.resolveDelayedTerminalExit();
@@ -634,7 +655,13 @@ describe('Zed terminal byte-budget enforcement (issue #3200 finding 4)', () => {
     // always bounded by the configured budget.
     const connection = new RecordingConnection();
     const budget = 4096;
-    connection.setTerminalOutput('B'.repeat(budget));
+    const multibyteUnit = '世';
+    const unitBytes = Buffer.byteLength(multibyteUnit, 'utf8');
+    const output =
+      multibyteUnit.repeat(Math.floor(budget / unitBytes)) +
+      'B'.repeat(budget % unitBytes);
+    expect(Buffer.byteLength(output, 'utf8')).toBe(budget);
+    connection.setTerminalOutput(output);
     const terminals = terminalManager(connection, undefined, budget);
 
     const result = await terminals.executeShellCommand(

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -159,6 +159,42 @@ describe('Zed terminal execution', () => {
     expect(connection.releaseCalls).toBe(1);
   });
 
+  it('retries after a transient terminal output poll failure', async () => {
+    const connection = new RecordingConnection();
+    connection.delayTerminalExit();
+    connection.setTerminalOutput('recovered output\n');
+    connection.failNextTerminalOutputPoll();
+    const terminals = terminalManager(connection);
+    let resolveOutput: () => void = () => undefined;
+    const sawOutput = new Promise<void>((resolve) => {
+      resolveOutput = resolve;
+    });
+
+    const execution = terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      (event) => {
+        if (
+          event.type === 'data' &&
+          typeof event.chunk === 'string' &&
+          event.chunk.includes('recovered output')
+        ) {
+          resolveOutput();
+        }
+      },
+      new AbortController().signal,
+    );
+
+    await connection.waitForTerminalProcessCreated();
+    await sawOutput;
+    connection.resolveDelayedTerminalExit();
+    const result = await execution;
+
+    expect(result.output).toBe('recovered output\n');
+    expect(connection.killCalls).toBe(0);
+    expect(connection.releaseCalls).toBe(1);
+  });
+
   it('correlates a raw command that already ends with a semicolon', async () => {
     const connection = new RecordingConnection();
     const terminals = terminalManager(connection);
@@ -538,10 +574,12 @@ describe('Zed terminal byte-budget enforcement (issue #3200 finding 4)', () => {
     connection.resolveDelayedTerminalExit();
     const result = await execution;
 
-    // Quantifiable loss: observed (the big peak) exceeds retained (the tail).
+    // Quantifiable lower bound: observed (the big peak) exceeds retained (the
+    // tail), but the peer may have evicted bytes before they were observed.
     expect(result.outputTruncation).toBeDefined();
     expect(result.outputTruncation?.truncated).toBe(true);
     expect(result.outputTruncation?.omittedBytes).toBeGreaterThan(0);
+    expect(result.outputTruncation?.omittedBytesExact).toBe(false);
     expect(result.outputTruncation?.budgetBytes).toBe(budget);
     // Exactly one durable discontinuity notice is streamed and retained.
     expect(

--- a/packages/core/src/config/config.ephemeral.test.ts
+++ b/packages/core/src/config/config.ephemeral.test.ts
@@ -135,6 +135,18 @@ describe('Config - Ephemeral Settings', () => {
     });
   });
 
+  describe('shell acquisition setting', () => {
+    it('preserves an absent retention limit for downstream default resolution', () => {
+      expect(
+        config.getShellExecutionConfig().outputRetentionMaxBytes,
+      ).toBeUndefined();
+
+      config.setEphemeralSetting('shell-output-retention-max-bytes', -1);
+
+      expect(config.getShellExecutionConfig().outputRetentionMaxBytes).toBe(-1);
+    });
+  });
+
   describe('ephemeral settings persistence', () => {
     it('should persist ephemeral setting values across get/set operations', () => {
       // Given multiple ephemeral settings

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -666,21 +666,21 @@ export class Config extends ConfigBase {
 
   getShellExecutionConfig(): ShellExecutionConfig {
     const ephemeralSettings = this.getEphemeralSettings();
-    const inactivityTimeoutSeconds =
-      (ephemeralSettings['shell-inactivity-timeout-seconds'] as
-        | number
-        | undefined) ?? 120; // Default 120 seconds
-    const inactivityTimeoutMs =
-      inactivityTimeoutSeconds === -1
-        ? undefined
-        : inactivityTimeoutSeconds * 1000;
+    const inactivitySeconds = Number(
+      ephemeralSettings['shell-inactivity-timeout-seconds'] ?? 120,
+    );
+
+    const rawLimit = ephemeralSettings['shell-output-retention-max-bytes'];
 
     return {
       terminalWidth: this.getPtyTerminalWidth(),
       terminalHeight: this.getPtyTerminalHeight(),
       showColor: this.getAllowPtyThemeOverride(),
       scrollback: this.getPtyScrollbackLimit(),
-      inactivityTimeoutMs,
+      inactivityTimeoutMs:
+        inactivitySeconds === -1 ? undefined : inactivitySeconds * 1000,
+      outputRetentionMaxBytes:
+        typeof rawLimit === 'number' ? rawLimit : undefined,
       isSandboxOrCI: !!this.getSandbox() || process.env.CI === 'true',
     };
   }

--- a/packages/core/src/services/shellAcquisitionConfig.ts
+++ b/packages/core/src/services/shellAcquisitionConfig.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createByteBudget,
+  resolveByteBudgetFromSetting,
+  DEFAULT_ACQUISITION_BUDGET_BYTES,
+  type ByteBudget,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
+
+/**
+ * Resolve the shell output retention byte budget from the execution config.
+ *
+ * The budget is always finite: absent or invalid values use
+ * {@link DEFAULT_ACQUISITION_BUDGET_BYTES}, while -1 selects the finite hard
+ * maximum and never means "unbounded".
+ */
+export function resolveShellRetentionBudget(
+  outputRetentionMaxBytes: number | undefined,
+): ByteBudget {
+  if (outputRetentionMaxBytes === undefined) {
+    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES);
+  }
+  return resolveByteBudgetFromSetting(outputRetentionMaxBytes);
+}

--- a/packages/core/src/services/shellBoundedAcquisition.bun.test.ts
+++ b/packages/core/src/services/shellBoundedAcquisition.bun.test.ts
@@ -37,10 +37,11 @@ import { ShellExecutionService } from './shellExecutionService.js';
  * Cross-platform producer script. Written to a temp file so the command
  * avoids shell-quoting issues across bash/zsh/PowerShell/cmd.exe.
  *
- * Usage: node producer.mjs <size> <stream> <mode>
- *   size:   number of bytes to write
- *   stream: "stdout" | "stderr" | "both"
- *   mode:   "ascii" | "multibyte" | "tiny"
+ * Usage: node producer.mjs <size> <stream> <mode> <exit-code>
+ *   size:      number of bytes to write
+ *   stream:    "stdout" | "stderr" | "both"
+ *   mode:      "ascii" | "multibyte" | "tiny"
+ *   exit-code: optional process exit code (defaults to zero)
  */
 let producerDir = '';
 let producerScript = '';
@@ -49,6 +50,7 @@ const PRODUCER_CODE = `
 const size = parseInt(process.argv[2] || '1024', 10);
 const stream = process.argv[3] || 'stdout';
 const mode = process.argv[4] || 'ascii';
+process.exitCode = parseInt(process.argv[5] || '0', 10);
 
 if (mode === 'tiny') {
   // Write single bytes in a loop (many tiny chunks).
@@ -101,8 +103,9 @@ function producerCommand(
   size: number,
   stream: 'stdout' | 'stderr' | 'both' = 'stdout',
   mode: 'ascii' | 'multibyte' | 'tiny' = 'ascii',
+  exitCode = 0,
 ): string {
-  return `"${process.execPath}" "${producerScript}" ${size} ${stream} ${mode}`;
+  return `"${process.execPath}" "${producerScript}" ${size} ${stream} ${mode} ${exitCode}`;
 }
 
 /**
@@ -175,11 +178,12 @@ describe('Shell bounded acquisition - child_process path (cross-platform)', () =
   });
 
   it('does not bound output when it fits within the budget', async () => {
-    const result = await executeAndCollect('echo "hello world"', {
-      outputRetentionMaxBytes: 65536,
-    });
+    const result = await executeAndCollect(
+      producerCommand(11, 'stdout', 'ascii'),
+      { outputRetentionMaxBytes: 65536 },
+    );
 
-    expect(result.output).toContain('hello world');
+    expect(result.output).toBe('A'.repeat(11));
     expect(result.output).not.toMatch(/truncat/i);
   });
 
@@ -225,10 +229,10 @@ describe('Shell bounded acquisition - child_process path (cross-platform)', () =
   });
 
   it('preserves exit status of a failing command despite bounded output', async () => {
-    const cmd = `${producerCommand(524288, 'stdout', 'ascii')}; exit 42`;
-    const result = await executeAndCollect(cmd, {
-      outputRetentionMaxBytes: 4096,
-    });
+    const result = await executeAndCollect(
+      producerCommand(524288, 'stdout', 'ascii', 42),
+      { outputRetentionMaxBytes: 4096 },
+    );
 
     expect(result.exitCode).toBe(42);
   });

--- a/packages/core/src/services/shellBoundedAcquisition.bun.test.ts
+++ b/packages/core/src/services/shellBoundedAcquisition.bun.test.ts
@@ -1,0 +1,283 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type {
+  ShellExecutionConfig,
+  ShellExecutionResult,
+} from './shellExecutionService.js';
+import { ShellExecutionService } from './shellExecutionService.js';
+
+/**
+ * Behavioral tests for bounded foreground shell output acquisition
+ * (Issue #3200).
+ *
+ * These tests exercise the REAL child_process fallback path with real
+ * subprocesses — no mock theater. They use cross-platform Node.js fixture
+ * scripts (via process.execPath) rather than POSIX-only utilities so they
+ * run identically on macOS, Linux, and Windows.
+ *
+ * Coverage:
+ * - Output is bounded DURING acquisition, not merely truncated after.
+ * - Continue-and-drain semantics preserve side effects and exit codes.
+ * - Truncation metadata/notice is surfaced.
+ * - rawOutput buffer is bounded (no full-size concat).
+ * - UTF-8 multibyte correctness.
+ * - One-huge-chunk and many-tiny-chunks patterns.
+ * - Interleaved stdout/stderr under shared budget.
+ */
+
+/**
+ * Cross-platform producer script. Written to a temp file so the command
+ * avoids shell-quoting issues across bash/zsh/PowerShell/cmd.exe.
+ *
+ * Usage: node producer.mjs <size> <stream> <mode>
+ *   size:   number of bytes to write
+ *   stream: "stdout" | "stderr" | "both"
+ *   mode:   "ascii" | "multibyte" | "tiny"
+ */
+let producerDir = '';
+let producerScript = '';
+
+const PRODUCER_CODE = `
+const size = parseInt(process.argv[2] || '1024', 10);
+const stream = process.argv[3] || 'stdout';
+const mode = process.argv[4] || 'ascii';
+
+if (mode === 'tiny') {
+  // Write single bytes in a loop (many tiny chunks).
+  const target = stream === 'stderr' ? process.stderr : process.stdout;
+  for (let i = 0; i < size; i++) {
+    target.write(String.fromCharCode(48 + (i % 10)));
+  }
+  target.end();
+} else if (mode === 'multibyte') {
+  // Write multibyte UTF-8 characters.
+  // Each \u4e16 is 3 bytes. Write enough to reach the target size.
+  const char = '\u4e16';
+  const charBytes = Buffer.byteLength(char, 'utf-8');
+  const count = Math.ceil(size / charBytes);
+  const data = char.repeat(count).slice(0, size);
+  const target = stream === 'stderr' ? process.stderr : process.stdout;
+  target.write(data);
+  target.end();
+} else {
+  // ASCII filler.
+  const data = 'A'.repeat(size);
+  if (stream === 'both') {
+    process.stdout.write(data);
+    process.stderr.write('ERR:' + data.slice(0, Math.min(size, 1024)));
+  } else {
+    const target = stream === 'stderr' ? process.stderr : process.stdout;
+    target.write(data);
+  }
+  process.stdout.end();
+  process.stderr.end();
+}
+`;
+
+beforeAll(() => {
+  producerDir = mkdtempSync(join(tmpdir(), 'llxprt-bounded-tests-'));
+  producerScript = join(producerDir, 'producer.mjs');
+  writeFileSync(producerScript, PRODUCER_CODE);
+});
+
+afterAll(() => {
+  rmSync(producerDir, { recursive: true, force: true });
+});
+
+/**
+ * Build a cross-platform command that runs the producer script.
+ * The execPath and script path are quoted with double quotes which works
+ * on bash, zsh, PowerShell, and cmd.exe.
+ */
+function producerCommand(
+  size: number,
+  stream: 'stdout' | 'stderr' | 'both' = 'stdout',
+  mode: 'ascii' | 'multibyte' | 'tiny' = 'ascii',
+): string {
+  return `"${process.execPath}" "${producerScript}" ${size} ${stream} ${mode}`;
+}
+
+/**
+ * Execute a shell command via the child_process fallback and collect the
+ * final result.
+ *
+ * The onOutput callback is a no-op: tests that assert output is bounded must
+ * NOT themselves retain every live event in an array (that would contradict
+ * the memory-bounds claim by pinning all data in memory). The authoritative
+ * bounded state lives in the acquisition collector, surfaced via `result`.
+ */
+async function executeAndCollect(
+  command: string,
+  config: ShellExecutionConfig = {},
+): Promise<ShellExecutionResult> {
+  const controller = new AbortController();
+  const handle = await ShellExecutionService.execute(
+    command,
+    process.cwd(),
+    () => undefined,
+    controller.signal,
+    false, // shouldUseNodePty = false -> child_process fallback
+    config,
+  );
+  return handle.result;
+}
+
+describe('Shell bounded acquisition - child_process path (cross-platform)', () => {
+  it('bounds output to the configured retention budget during acquisition', async () => {
+    const result = await executeAndCollect(
+      producerCommand(2 * 1024 * 1024, 'stdout', 'ascii'), // 2 MB
+      { outputRetentionMaxBytes: 65536 },
+    );
+
+    const outputLength = result.output.length;
+    // Output must be bounded well below the 2 MB produced.
+    expect(outputLength).toBeLessThan(200000);
+    // But should retain at least some content (head + tail + notice).
+    expect(outputLength).toBeGreaterThan(100);
+  });
+
+  it('includes a visible truncation notice when output exceeds the budget', async () => {
+    const result = await executeAndCollect(
+      producerCommand(1024 * 1024, 'stdout', 'ascii'), // 1 MB
+      { outputRetentionMaxBytes: 8192 },
+    );
+
+    expect(result.output).toMatch(/truncat/i);
+  });
+
+  it('preserves exit code and completes despite bounded output', async () => {
+    // Produce output beyond the budget, then write a tail marker.
+    const cmd = `${producerCommand(524288, 'stdout', 'ascii')} && echo END_MARKER_42`;
+    const result = await executeAndCollect(cmd, {
+      outputRetentionMaxBytes: 4096,
+    });
+
+    expect(result.exitCode).toBe(0);
+    // The final marker should be present (tail retention).
+    expect(result.output).toContain('END_MARKER_42');
+  });
+
+  it('bounds rawOutput buffer to the retention budget', async () => {
+    const result = await executeAndCollect(
+      producerCommand(1024 * 1024, 'stdout', 'ascii'), // 1 MB
+      { outputRetentionMaxBytes: 16384 },
+    );
+
+    expect(result.rawOutput.length).toBeLessThanOrEqual(16384);
+  });
+
+  it('does not bound output when it fits within the budget', async () => {
+    const result = await executeAndCollect('echo "hello world"', {
+      outputRetentionMaxBytes: 65536,
+    });
+
+    expect(result.output).toContain('hello world');
+    expect(result.output).not.toMatch(/truncat/i);
+  });
+
+  it('bounds interleaved stdout and stderr under one shared budget', async () => {
+    const result = await executeAndCollect(
+      producerCommand(524288, 'both', 'ascii'), // stdout + stderr
+      { outputRetentionMaxBytes: 8192 },
+    );
+
+    // Both streams should have content in the head.
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  it('handles UTF-8 multibyte output without corruption', async () => {
+    const result = await executeAndCollect(
+      producerCommand(32768, 'stdout', 'multibyte'), // 32 KB of \u4e16
+      { outputRetentionMaxBytes: 16384 },
+    );
+
+    expect(result.output.length).toBeGreaterThan(0);
+    // Should contain valid multibyte chars without replacement chars.
+    expect(result.output).not.toContain('\uFFFD');
+  });
+
+  it('handles one huge chunk (large single write)', async () => {
+    const result = await executeAndCollect(
+      producerCommand(524288, 'stdout', 'ascii'), // 512 KB single write
+      { outputRetentionMaxBytes: 4096 },
+    );
+
+    expect(result.output.length).toBeLessThan(10000);
+    expect(result.rawOutput.length).toBeLessThanOrEqual(4096);
+  });
+
+  it('handles many tiny chunks (byte-at-a-time writes)', async () => {
+    const result = await executeAndCollect(
+      producerCommand(10000, 'stdout', 'tiny'), // 10000 single-byte writes
+      { outputRetentionMaxBytes: 4096 },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output.length).toBeLessThan(10000);
+  });
+
+  it('preserves exit status of a failing command despite bounded output', async () => {
+    const cmd = `${producerCommand(524288, 'stdout', 'ascii')}; exit 42`;
+    const result = await executeAndCollect(cmd, {
+      outputRetentionMaxBytes: 4096,
+    });
+
+    expect(result.exitCode).toBe(42);
+  });
+
+  it('does not duplicate rawOutput at full size', async () => {
+    const result = await executeAndCollect(
+      producerCommand(2 * 1024 * 1024, 'stdout', 'ascii'), // 2 MB
+      { outputRetentionMaxBytes: 32768 },
+    );
+
+    expect(result.rawOutput.length).toBeLessThanOrEqual(32768);
+  });
+});
+
+/**
+ * Windows-specific tests for the child_process path. These only run on
+ * win32 and test Windows-specific behaviors (PowerShell, CLIXML).
+ */
+describe.skipIf(process.platform !== 'win32')(
+  'Shell bounded acquisition - Windows child_process path',
+  () => {
+    it('decodes genuine PowerShell CLIXML error records rather than leaking raw XML', async () => {
+      // A non-interactive PowerShell host serialises error/warning stream
+      // records as CLIXML (prefixed with "#< CLIXML") on stderr. The bounded
+      // acquisition path must decode these into human-readable text so the
+      // model never sees raw <S S="Error"> markup. We force a real error
+      // record via Write-Error which reliably produces CLIXML.
+      const result = await executeAndCollect(
+        'powershell -NoProfile -Command "Write-Error LLXPRT_CLIXML_BOUND_MARKER; 1..50000 | ForEach-Object { Write-Error $_ }"',
+        { outputRetentionMaxBytes: 8192 },
+      );
+
+      expect(result.rawOutput.length).toBeLessThanOrEqual(8192);
+      expect(result.outputTruncation?.truncated).toBe(true);
+      expect(result.output).toContain('LLXPRT_CLIXML_BOUND_MARKER');
+      expect(result.output).not.toContain('<S S=');
+      expect(result.output).not.toContain('#< CLIXML');
+    });
+
+    it('bounds and drains output from a Windows batch command', async () => {
+      const result = await executeAndCollect(
+        'cmd /d /s /c "(for /L %i in (1,1,20000) do @echo WINDOWS_OUTPUT_%i) & echo WINDOWS_FINAL_MARKER"',
+        { outputRetentionMaxBytes: 4096 },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.rawOutput.length).toBeLessThanOrEqual(4096);
+      expect(result.outputTruncation?.truncated).toBe(true);
+      expect(result.output).toContain('WINDOWS_FINAL_MARKER');
+    });
+  },
+);

--- a/packages/core/src/services/shellCpExecution.ts
+++ b/packages/core/src/services/shellCpExecution.ts
@@ -22,6 +22,8 @@ import {
   buildCpExitResult,
   registerCpExitHandlers,
 } from './shellCpHelpers.js';
+import { resolveShellRetentionBudget } from './shellAcquisitionConfig.js';
+import { MAX_SNIFF_SIZE } from './shellOutputUtils.js';
 
 /** Create the child_process result promise with all event handlers. */
 export function createCpResultPromise(
@@ -30,10 +32,13 @@ export function createCpResultPromise(
   onOutputEvent: (event: ShellOutputEvent) => void,
   abortSignal: AbortSignal,
   inactivityTimeoutMs: number | undefined,
+  outputRetentionMaxBytes: number | undefined,
 ): Promise<ShellExecutionResult> {
   const exitedGuard = createExitGuard();
   const { reset: resetInactivityTimer, controller: inactivityAbortController } =
     makeInactivityTimer(inactivityTimeoutMs, exitedGuard);
+
+  const budget = resolveShellRetentionBudget(outputRetentionMaxBytes);
 
   const state: CpExecState = {
     child,
@@ -45,16 +50,12 @@ export function createCpResultPromise(
     exitedGuard,
     stdoutDecoder: null,
     stderrDecoder: null,
-    stdout: '',
-    stderr: '',
-    stdoutTruncated: false,
-    stderrTruncated: false,
-    outputChunks: [],
+    retentionBudget: budget,
+    rawCollector: null,
     error: null,
     isStreamingRawContent: true,
     sniffedBytes: 0,
-    sniffBuffer: Buffer.alloc(0),
-    totalBytesReceived: 0,
+    sniffBuffer: Buffer.alloc(MAX_SNIFF_SIZE),
     hasResolved: false,
     cleanedUp: false,
   };
@@ -72,8 +73,12 @@ export function createCpResultPromise(
       resolve(buildCpExitResult(state, code, signal, finalBuffer));
     };
 
-    child.stdout?.on('data', (data) => handleCpOutput(state, data, 'stdout'));
-    child.stderr?.on('data', (data) => handleCpOutput(state, data, 'stderr'));
+    child.stdout?.on('data', (data: Buffer) =>
+      handleCpOutput(state, data, 'stdout'),
+    );
+    child.stderr?.on('data', (data: Buffer) =>
+      handleCpOutput(state, data, 'stderr'),
+    );
     child.on('error', (err) => {
       state.error = err;
       handleExit(1, null);

--- a/packages/core/src/services/shellCpHelpers.ts
+++ b/packages/core/src/services/shellCpHelpers.ts
@@ -15,8 +15,8 @@ import type {
 } from './shellExecutionTypes.js';
 import type { ExitGuard } from './shellExitGuard.js';
 import { stripAnsiIfPresent, MAX_SNIFF_SIZE } from './shellOutputUtils.js';
-
-export const MAX_CHILD_PROCESS_BUFFER_SIZE = 16 * 1024 * 1024; // 16MB
+import { BoundedCombinedCollector } from '@vybestack/llxprt-code-tools/acquisition.js';
+import type { ByteBudget } from '@vybestack/llxprt-code-tools/acquisition.js';
 
 /** State bag shared across child_process helper closures. */
 export interface CpExecState {
@@ -29,62 +29,48 @@ export interface CpExecState {
   exitedGuard: ExitGuard;
   stdoutDecoder: TextDecoder | null;
   stderrDecoder: TextDecoder | null;
-  stdout: string;
-  stderr: string;
-  stdoutTruncated: boolean;
-  stderrTruncated: boolean;
-  outputChunks: Buffer[];
+  retentionBudget: ByteBudget;
+  rawCollector: BoundedCombinedCollector | null;
   error: Error | null;
   isStreamingRawContent: boolean;
   sniffedBytes: number;
   sniffBuffer: Buffer;
-  totalBytesReceived: number;
   hasResolved: boolean;
   cleanedUp: boolean;
 }
 
-/** Append a decoded chunk to stdout or stderr with truncation tracking. */
-export function appendDecodedChunk(
-  currentBuffer: string,
-  strippedChunk: string,
-  maxSize: number,
-): { newBuffer: string; truncated: boolean } {
-  const chunkLength = strippedChunk.length;
-  const currentLength = currentBuffer.length;
-  const newTotalLength = currentLength + chunkLength;
-
-  if (newTotalLength <= maxSize) {
-    return { newBuffer: currentBuffer + strippedChunk, truncated: false };
+/** Create decoders and the bounded collector from the detected encoding. */
+export function ensureDecoders(
+  state: CpExecState,
+  data: Buffer,
+): BoundedCombinedCollector {
+  if (state.stdoutDecoder && state.stderrDecoder && state.rawCollector) {
+    return state.rawCollector;
   }
-
-  if (chunkLength >= maxSize) {
-    return {
-      newBuffer: strippedChunk.substring(chunkLength - maxSize),
-      truncated: true,
-    };
-  }
-
-  const charsToTrim = newTotalLength - maxSize;
-  const truncatedBuffer = currentBuffer.substring(charsToTrim);
-  return { newBuffer: truncatedBuffer + strippedChunk, truncated: true };
-}
-
-/** Create decoders for stdout/stderr from the first data chunk's encoding. */
-export function ensureDecoders(state: CpExecState, data: Buffer): void {
-  if (state.stdoutDecoder && state.stderrDecoder) {
-    return;
-  }
-  const encoding = getCachedEncodingForBuffer(data);
+  const detectedEncoding = getCachedEncodingForBuffer(data);
+  let encoding = detectedEncoding;
   try {
     state.stdoutDecoder = new TextDecoder(encoding);
     state.stderrDecoder = new TextDecoder(encoding);
   } catch {
-    state.stdoutDecoder = new TextDecoder('utf-8');
-    state.stderrDecoder = new TextDecoder('utf-8');
+    encoding = 'utf-8';
+    state.stdoutDecoder = new TextDecoder(encoding);
+    state.stderrDecoder = new TextDecoder(encoding);
   }
+  state.rawCollector = new BoundedCombinedCollector({
+    budget: state.retentionBudget,
+    encoding,
+  });
+  return state.rawCollector;
 }
 
-/** Sniff initial output for binary content detection. */
+/**
+ * Sniff initial output for binary content detection.
+ *
+ * Uses a fixed-capacity pre-allocated buffer (state.sniffBuffer is
+ * Buffer.alloc(MAX_SNIFF_SIZE) at init) and writes incrementally with
+ * Buffer.copy — O(1) per chunk, no quadratic concat (Issue #3200).
+ */
 function checkBinarySniff(state: CpExecState, data: Buffer): void {
   if (!state.isStreamingRawContent || state.sniffedBytes >= MAX_SNIFF_SIZE) {
     return;
@@ -93,14 +79,11 @@ function checkBinarySniff(state: CpExecState, data: Buffer): void {
   if (remaining <= 0) {
     return;
   }
-  const slice = data.subarray(0, remaining);
-  state.sniffBuffer =
-    state.sniffBuffer.length === 0
-      ? Buffer.from(slice)
-      : Buffer.concat([state.sniffBuffer, slice]);
-  state.sniffedBytes = state.sniffBuffer.length;
+  const writeLen = Math.min(data.length, remaining);
+  data.copy(state.sniffBuffer, state.sniffedBytes, 0, writeLen);
+  state.sniffedBytes += writeLen;
 
-  if (isBinary(state.sniffBuffer)) {
+  if (isBinary(state.sniffBuffer.subarray(0, state.sniffedBytes))) {
     state.isStreamingRawContent = false;
     state.onOutputEvent({ type: 'binary_detected' });
   }
@@ -113,10 +96,8 @@ export function handleCpOutput(
   stream: 'stdout' | 'stderr',
 ): void {
   state.resetInactivityTimer();
-  ensureDecoders(state, data);
-
-  state.totalBytesReceived += data.length;
-  state.outputChunks.push(data);
+  const rawCollector = ensureDecoders(state, data);
+  rawCollector.append(data, stream);
 
   checkBinarySniff(state, data);
 
@@ -125,56 +106,31 @@ export function handleCpOutput(
   const decodedChunk = decoder!.decode(data, { stream: true });
   const strippedChunk = stripAnsiIfPresent(decodedChunk);
 
-  if (stream === 'stdout') {
-    const { newBuffer, truncated } = appendDecodedChunk(
-      state.stdout,
-      strippedChunk,
-      MAX_CHILD_PROCESS_BUFFER_SIZE,
-    );
-    state.stdout = newBuffer;
-    if (truncated) {
-      state.stdoutTruncated = true;
-    }
-  } else {
-    const { newBuffer, truncated } = appendDecodedChunk(
-      state.stderr,
-      strippedChunk,
-      MAX_CHILD_PROCESS_BUFFER_SIZE,
-    );
-    state.stderr = newBuffer;
-    if (truncated) {
-      state.stderrTruncated = true;
-    }
-  }
-
   if (state.isStreamingRawContent) {
     state.onOutputEvent({ type: 'data', chunk: strippedChunk });
   } else {
     state.onOutputEvent({
       type: 'binary_progress',
-      bytesReceived: state.totalBytesReceived,
+      bytesReceived: rawCollector.observedByteCount,
     });
   }
 }
 
-function flushDecoder(
+function emitFinalDecodedChunk(
+  state: CpExecState,
   decoder: TextDecoder | null,
-  append: (text: string) => void,
 ): void {
-  if (!decoder) {
-    return;
-  }
-  const remaining = decoder.decode();
-  if (remaining) {
-    append(remaining);
+  const finalChunk = stripAnsiIfPresent(decoder?.decode() ?? '');
+  if (state.isStreamingRawContent && finalChunk !== '') {
+    state.onOutputEvent({ type: 'data', chunk: finalChunk });
   }
 }
 
-/** Clean up child_process listeners and flush remaining decoder bytes. */
+/** Clean up child_process listeners and materialize bounded raw output. */
 export function cleanupCpResources(
   state: CpExecState,
   abortHandler: () => void,
-): { stdout: string; stderr: string; finalBuffer: Buffer } {
+): { finalBuffer: Buffer } {
   state.exitedGuard.markExited();
   state.abortSignal.removeEventListener('abort', abortHandler);
 
@@ -187,15 +143,12 @@ export function cleanupCpResources(
     state.child.removeAllListeners('close');
   }
 
-  flushDecoder(state.stdoutDecoder, (text) => {
-    state.stdout += stripAnsiIfPresent(text);
-  });
-  flushDecoder(state.stderrDecoder, (text) => {
-    state.stderr += stripAnsiIfPresent(text);
-  });
+  emitFinalDecodedChunk(state, state.stdoutDecoder);
+  emitFinalDecodedChunk(state, state.stderrDecoder);
 
-  const finalBuffer = Buffer.concat(state.outputChunks);
-  return { stdout: state.stdout, stderr: state.stderr, finalBuffer };
+  const finalBuffer =
+    state.rawCollector?.getBoundedRawBuffer() ?? Buffer.alloc(0);
+  return { finalBuffer };
 }
 
 /** Build the ShellExecutionResult for a child_process exit. */
@@ -205,22 +158,26 @@ export function buildCpExitResult(
   signal: NodeJS.Signals | null,
   finalBuffer: Buffer,
 ): ShellExecutionResult {
-  const separator = state.stdout.endsWith('\n') ? '' : '\n';
-  let combinedOutput = state.stdout;
-  if (state.stderr) {
-    combinedOutput += (state.stdout !== '' ? separator : '') + state.stderr;
-  }
+  const rawResult = state.rawCollector?.getResult();
+  const rawMetadata = rawResult?.metadata;
 
-  if (state.stdoutTruncated || state.stderrTruncated) {
-    const truncationMessage = `\n[LLXPRT_CODE_WARNING: Output truncated. The buffer is limited to ${
-      MAX_CHILD_PROCESS_BUFFER_SIZE / (1024 * 1024)
-    }MB.]`;
-    combinedOutput += truncationMessage;
+  let combinedOutput = '';
+  if (rawResult?.metadata.truncated === true) {
+    combinedOutput = stripAnsiIfPresent(rawResult.text);
+  } else if (rawResult !== undefined) {
+    const stdout = stripAnsiIfPresent(rawResult.stdoutText);
+    const stderr = stripAnsiIfPresent(rawResult.stderrText);
+    const separator = stdout.endsWith('\n') ? '' : '\n';
+    combinedOutput = stdout;
+    if (stderr !== '') {
+      combinedOutput += (stdout !== '' ? separator : '') + stderr;
+    }
   }
 
   return {
     rawOutput: finalBuffer,
     output: combinedOutput.trim(),
+    outputTruncation: rawMetadata?.truncated === true ? rawMetadata : undefined,
     exitCode: code,
     signal: signal ? os.constants.signals[signal] : null,
     error: state.error,

--- a/packages/core/src/services/shellCpHelpers.ts
+++ b/packages/core/src/services/shellCpHelpers.ts
@@ -14,6 +14,7 @@ import type {
   ShellExecutionResult,
 } from './shellExecutionTypes.js';
 import type { ExitGuard } from './shellExitGuard.js';
+import { decodeClixmlStderr } from './shellJobTail.js';
 import { stripAnsiIfPresent, MAX_SNIFF_SIZE } from './shellOutputUtils.js';
 import { BoundedCombinedCollector } from '@vybestack/llxprt-code-tools/acquisition.js';
 import type { ByteBudget } from '@vybestack/llxprt-code-tools/acquisition.js';
@@ -151,6 +152,16 @@ export function cleanupCpResources(
   return { finalBuffer };
 }
 
+function combineOutputSections(first: string, second: string): string {
+  if (first === '') {
+    return second;
+  }
+  if (second === '') {
+    return first;
+  }
+  return first + (first.endsWith('\n') ? '' : '\n') + second;
+}
+
 /** Build the ShellExecutionResult for a child_process exit. */
 export function buildCpExitResult(
   state: CpExecState,
@@ -162,15 +173,23 @@ export function buildCpExitResult(
   const rawMetadata = rawResult?.metadata;
 
   let combinedOutput = '';
-  if (rawResult?.metadata.truncated === true) {
-    combinedOutput = stripAnsiIfPresent(rawResult.text);
-  } else if (rawResult !== undefined) {
+  if (rawResult !== undefined) {
     const stdout = stripAnsiIfPresent(rawResult.stdoutText);
-    const stderr = stripAnsiIfPresent(rawResult.stderrText);
-    const separator = stdout.endsWith('\n') ? '' : '\n';
-    combinedOutput = stdout;
-    if (stderr !== '') {
-      combinedOutput += (stdout !== '' ? separator : '') + stderr;
+    const retainedStderr = rawResult.stderrText;
+    const decodedStderr = state.isWindows
+      ? decodeClixmlStderr(retainedStderr)
+      : retainedStderr;
+    const stderr = stripAnsiIfPresent(decodedStderr);
+    const sourceOutput = combineOutputSections(stdout, stderr);
+    const decodedClixml = decodedStderr !== retainedStderr;
+
+    if (rawResult.metadata.truncated && !decodedClixml) {
+      combinedOutput = stripAnsiIfPresent(rawResult.text);
+    } else {
+      combinedOutput = combineOutputSections(
+        sourceOutput,
+        rawResult.metadata.truncated ? (rawResult.omissionNotice ?? '') : '',
+      );
     }
   }
 

--- a/packages/core/src/services/shellExecutionService.fallback.test.ts
+++ b/packages/core/src/services/shellExecutionService.fallback.test.ts
@@ -483,6 +483,45 @@ describe('ShellExecutionService child_process fallback', () => {
       );
     });
 
+    it('decodes PowerShell CLIXML stderr on Windows', async () => {
+      mockPlatform.mockReturnValue('win32');
+      stubProcessPlatform('win32');
+      const clixml =
+        '#< CLIXML\r\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><S S="Error">kaboom_x000D__x000A_</S></Objs>';
+
+      const { result } = await simulateExecution('Write-Error kaboom', (cp) => {
+        cp.stderr?.emit('data', Buffer.from(clixml));
+        cp.emit('exit', 1, null);
+      });
+
+      expect(result.output).toBe('kaboom');
+      expect(result.output).not.toContain('#< CLIXML');
+    });
+
+    it('decodes retained CLIXML and reports truncation once', async () => {
+      mockPlatform.mockReturnValue('win32');
+      stubProcessPlatform('win32');
+      const clixml =
+        '#< CLIXML\r\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><S S="Error">kaboom_x000D__x000A_</S></Objs>';
+
+      const { result } = await simulateExecution(
+        'Write-Error kaboom',
+        (cp) => {
+          cp.stdout?.emit('data', Buffer.from('x'.repeat(1600)));
+          cp.stderr?.emit('data', Buffer.from(clixml));
+          cp.emit('exit', 1, null);
+        },
+        true,
+        { ...defaultShellConfig, outputRetentionMaxBytes: 1024 },
+      );
+
+      expect(result.output).toContain('kaboom');
+      expect(result.output).not.toContain('#< CLIXML');
+      expect(result.output.match(/LLXPRT output truncated/g)).toHaveLength(1);
+      expect(result.outputTruncation?.truncated).toBe(true);
+      expect(result.outputTruncation?.retainedBytes).toBe(1024);
+    });
+
     it('should use bash and detached process group on Linux', async () => {
       mockPlatform.mockReturnValue('linux');
       await simulateExecution('ls "foo bar"', (cp) => cp.emit('exit', 0, null));

--- a/packages/core/src/services/shellExecutionService.fallback.test.ts
+++ b/packages/core/src/services/shellExecutionService.fallback.test.ts
@@ -18,7 +18,10 @@ import {
 import EventEmitter from 'events';
 import type { Readable } from 'stream';
 import { type ChildProcess } from 'child_process';
-import type { ShellOutputEvent } from './shellExecutionService.js';
+import type {
+  ShellExecutionConfig,
+  ShellOutputEvent,
+} from './shellExecutionService.js';
 import { ShellExecutionService } from './shellExecutionService.js';
 
 // Hoisted Mocks
@@ -107,7 +110,7 @@ describe('ShellExecutionService child_process fallback', () => {
   });
 
   // Default shell execution config for tests
-  const defaultShellConfig = {
+  const defaultShellConfig: ShellExecutionConfig = {
     showColor: false,
     scrollback: 600000,
     terminalWidth: 80,
@@ -119,6 +122,7 @@ describe('ShellExecutionService child_process fallback', () => {
     command: string,
     simulation: (cp: typeof mockChildProcess, ac: AbortController) => void,
     shouldUseNodePty = true,
+    shellConfig = defaultShellConfig,
   ) => {
     const abortController = new AbortController();
     const handle = await ShellExecutionService.execute(
@@ -127,7 +131,7 @@ describe('ShellExecutionService child_process fallback', () => {
       onOutputEventMock,
       abortController.signal,
       shouldUseNodePty,
-      defaultShellConfig,
+      shellConfig,
     );
 
     await new Promise((resolve) => setImmediate(resolve));
@@ -202,6 +206,19 @@ describe('ShellExecutionService child_process fallback', () => {
       expect(result.output).toBe('你好');
     });
 
+    it('emits decoder flush output for an incomplete final sequence', async () => {
+      const { result } = await simulateExecution('partial-output', (cp) => {
+        cp.stdout?.emit('data', Buffer.from([0xe2, 0x82]));
+        cp.emit('exit', 0, null);
+      });
+
+      expect(result.output).toBe('\uFFFD');
+      expect(onOutputEventMock).toHaveBeenCalledWith({
+        type: 'data',
+        chunk: '\uFFFD',
+      });
+    });
+
     it('should handle commands with no output', async () => {
       const { result } = await simulateExecution('touch file', (cp) => {
         cp.emit('exit', 0, null);
@@ -211,35 +228,35 @@ describe('ShellExecutionService child_process fallback', () => {
       expect(onOutputEventMock).not.toHaveBeenCalled();
     });
 
-    it('should truncate stdout using a sliding window and show a warning', async () => {
-      const MAX_SIZE = 16 * 1024 * 1024;
-      const chunk1 = 'a'.repeat(MAX_SIZE / 2 - 5);
-      const chunk2 = 'b'.repeat(MAX_SIZE / 2 - 5);
-      const chunk3 = 'c'.repeat(20);
+    it('bounds retained stdout with one accurate omission notice', async () => {
+      const retentionBytes = 1024;
+      const firstChunk = 'a'.repeat(retentionBytes);
+      const finalMarker = 'FINAL_MARKER';
 
-      const { result } = await simulateExecution('large-output', (cp) => {
-        cp.stdout?.emit('data', Buffer.from(chunk1));
-        cp.stdout?.emit('data', Buffer.from(chunk2));
-        cp.stdout?.emit('data', Buffer.from(chunk3));
-        cp.emit('exit', 0, null);
+      const { result } = await simulateExecution(
+        'large-output',
+        (cp) => {
+          cp.stdout?.emit('data', Buffer.from(firstChunk));
+          cp.stdout?.emit('data', Buffer.from('b'.repeat(retentionBytes)));
+          cp.stdout?.emit('data', Buffer.from(finalMarker));
+          cp.emit('exit', 0, null);
+        },
+        true,
+        { ...defaultShellConfig, outputRetentionMaxBytes: retentionBytes },
+      );
+
+      expect(result.rawOutput.length).toBeLessThanOrEqual(retentionBytes);
+      expect(result.output.startsWith('a'.repeat(20))).toBe(true);
+      expect(result.output.endsWith(finalMarker)).toBe(true);
+      expect(result.output.match(/LLXPRT output truncated/g)).toHaveLength(1);
+      expect(result.outputTruncation).toEqual({
+        observedBytes: retentionBytes * 2 + finalMarker.length,
+        retainedBytes: retentionBytes,
+        omittedBytes: retentionBytes + finalMarker.length,
+        truncated: true,
+        budgetBytes: retentionBytes,
       });
-
-      const truncationMessage =
-        '[LLXPRT_CODE_WARNING: Output truncated. The buffer is limited to 16MB.]';
-      expect(result.output).toContain(truncationMessage);
-
-      const outputWithoutMessage = result.output
-        .substring(0, result.output.indexOf(truncationMessage))
-        .trimEnd();
-
-      expect(outputWithoutMessage.length).toBe(MAX_SIZE);
-
-      const expectedStart = (chunk1 + chunk2 + chunk3).slice(-MAX_SIZE);
-      expect(
-        outputWithoutMessage.startsWith(expectedStart.substring(0, 10)),
-      ).toBe(true);
-      expect(outputWithoutMessage.endsWith('c'.repeat(20))).toBe(true);
-    }, 20000);
+    });
   });
 
   describe('Failed Execution', () => {

--- a/packages/core/src/services/shellExecutionService.main.test.ts
+++ b/packages/core/src/services/shellExecutionService.main.test.ts
@@ -229,6 +229,10 @@ describe('ShellExecutionService', () => {
           }
           pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
         },
+        {
+          ...shellExecutionConfig,
+          outputRetentionMaxBytes: 8 * 1024 * 1024,
+        },
       );
 
       expect(result.exitCode).toBe(0);
@@ -270,7 +274,7 @@ describe('ShellExecutionService', () => {
       expect(result.output).toBe('value\nvalue2    ');
     });
 
-    it('should truncate output exceeding the scrollback limit', async () => {
+    it('should recover output evicted from scrollback within the retention budget', async () => {
       const scrollbackLimit = 100;
       const totalLines = 150;
       const lines = Array.from({ length: totalLines }, (_, i) => `line ${i}`);
@@ -287,17 +291,10 @@ describe('ShellExecutionService', () => {
 
       expect(result.exitCode).toBe(0);
 
-      const outputLines = result.output
-        .trim()
-        .split('\n')
-        .map((l) => l.trimEnd());
-
-      expect(outputLines.length).toBeLessThan(totalLines);
-      expect(outputLines[0]).not.toBe('line 0');
-
-      expect(outputLines[outputLines.length - 1]).toBe(
-        `line ${totalLines - 1}`,
-      );
+      expect(result.output).toContain('[Retained PTY output]');
+      expect(result.output).toContain('line 0');
+      expect(result.output).toContain(`line ${totalLines - 1}`);
+      expect(result.outputTruncation).toBeUndefined();
     });
 
     it('should call onPid with the process id', async () => {

--- a/packages/core/src/services/shellExecutionService.main.test.ts
+++ b/packages/core/src/services/shellExecutionService.main.test.ts
@@ -87,6 +87,7 @@ describe('ShellExecutionService', () => {
     mockGetPty.mockResolvedValue({
       module: { spawn: mockPtySpawn },
       name: 'mock-pty',
+      supportsBackpressure: true,
     });
 
     onOutputEventMock = vi.fn();

--- a/packages/core/src/services/shellExecutionService.raceCondition.test.ts
+++ b/packages/core/src/services/shellExecutionService.raceCondition.test.ts
@@ -78,6 +78,7 @@ describe('ShellExecutionService - Issue #983 Race Condition Tests', () => {
     mockGetPty.mockResolvedValue({
       module: { spawn: mockPtySpawn },
       name: 'mock-pty',
+      supportsBackpressure: true,
     });
 
     onOutputEventMock = vi.fn();

--- a/packages/core/src/services/shellExecutionService.selection.test.ts
+++ b/packages/core/src/services/shellExecutionService.selection.test.ts
@@ -417,6 +417,7 @@ describe('ShellExecutionService execution method selection', () => {
     mockGetPty.mockResolvedValue({
       module: { spawn: mockPtySpawn },
       name: 'mock-pty',
+      supportsBackpressure: true,
     });
 
     // Mock for child_process
@@ -545,6 +546,7 @@ describe('ShellExecutionService environment sanitization wiring', () => {
     mockGetPty.mockResolvedValue({
       module: { spawn: mockPtySpawn },
       name: 'mock-pty',
+      supportsBackpressure: true,
     });
 
     // Mock for child_process

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -127,6 +127,7 @@ export class ShellExecutionService {
         onOutputEvent,
         abortSignal,
         shellExecutionConfig.inactivityTimeoutMs,
+        shellExecutionConfig.outputRetentionMaxBytes,
       );
 
       return { pid: child.pid, result };

--- a/packages/core/src/services/shellExecutionTypes.ts
+++ b/packages/core/src/services/shellExecutionTypes.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { TruncationMetadata } from '@vybestack/llxprt-code-tools/acquisition.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import type { EnvironmentSanitizationConfig } from './environmentSanitization.js';
 
@@ -15,6 +16,8 @@ export interface ShellExecutionResult {
   rawOutput: Buffer;
   /** The combined, decoded output as a string. */
   output: string;
+  /** Acquisition-time truncation details when output exceeded retention. */
+  outputTruncation?: TruncationMetadata;
   /** The process exit code, or null if terminated by a signal. */
   exitCode: number | null;
   /** The signal that terminated the process, if any. */
@@ -49,6 +52,13 @@ export interface ShellExecutionConfig {
   inactivityTimeoutMs?: number;
   isSandboxOrCI?: boolean;
   sanitizationConfig?: EnvironmentSanitizationConfig;
+  /**
+   * Maximum bytes of output retained during acquisition (child_process and
+   * PTY paths). Must be a finite positive number. When unset, callers should
+   * apply the shared finite default acquisition policy. Separate from
+   * model-facing token limits.
+   */
+  outputRetentionMaxBytes?: number;
 }
 
 export type ShellOutputEvent =

--- a/packages/core/src/services/shellPtyExecution.bun.test.ts
+++ b/packages/core/src/services/shellPtyExecution.bun.test.ts
@@ -1,0 +1,422 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { IPty } from '@lydell/node-pty';
+import { Terminal } from '@xterm/headless';
+import {
+  BoundedCombinedCollector,
+  createByteBudget,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
+import { createExitGuard } from './shellExitGuard.js';
+import {
+  buildPtyResult,
+  PTY_QUEUE_HARD_LIMIT_BYTES,
+  PTY_QUEUE_HARD_LIMIT_ITEMS,
+  PTY_QUEUE_HIGH_WATER_ITEMS,
+  registerPtyDataHandler,
+} from './shellPtyExecution.js';
+import type { PtyExecState } from './shellPtyState.js';
+
+interface FakePtyHarness {
+  state: PtyExecState;
+  emitData(data: string): void;
+  pauseCount(): number;
+  resumeCount(): number;
+}
+
+function createFakePtyState(supportsBackpressure: boolean): FakePtyHarness {
+  let dataListener: ((data: string) => void) | undefined;
+  let pauses = 0;
+  let resumes = 0;
+  const ptyProcess = {
+    pid: 12345,
+    onData(listener: (data: string) => void) {
+      dataListener = listener;
+      return { dispose() {} };
+    },
+    pause() {
+      pauses += 1;
+    },
+    resume() {
+      resumes += 1;
+    },
+  } as unknown as IPty;
+  const headlessTerminal = {
+    buffer: {
+      active: {
+        length: 0,
+        cursorY: 0,
+        getLine: () => undefined,
+      },
+    },
+    write(_data: string, callback: () => void) {
+      callback();
+    },
+  };
+  const inactivityAbortController = new AbortController();
+  const budget = createByteBudget(1024);
+  const state = {
+    ptyProcess,
+    headlessTerminal,
+    activePtyEntry: {
+      ptyProcess,
+      headlessTerminal,
+      supportsProcessGroupKill: true,
+    },
+    isWindows: false,
+    abortSignal: new AbortController().signal,
+    onOutputEvent: () => undefined,
+    shellExecutionConfig: {},
+    ptyInfo: { name: 'node-pty', module: {} },
+    supportsProcessGroupKill: true,
+    inactivityAbortController,
+    resetInactivityTimer: () => undefined,
+    exitedGuard: createExitGuard(),
+    output: null,
+    rawCollector: new BoundedCombinedCollector({ budget }),
+    error: null,
+    isStreamingRawContent: true,
+    sniffedBytes: 0,
+    isWriting: false,
+    hasStartedOutput: false,
+    hasResolved: false,
+    abortFinalizeTimeout: null,
+    processingChain: Promise.resolve(),
+    pendingQueueBytes: 0,
+    pendingQueueItems: 0,
+    supportsBackpressure,
+    backpressurePaused: false,
+    queueOverflowed: false,
+    terminalMaxBufferLines: 600024,
+    terminalScrollbackCapacity: 600000,
+    terminalScrollbackAtCapacity: false,
+    terminalContentEvicted: false,
+  } as unknown as PtyExecState;
+
+  return {
+    state,
+    emitData(data: string) {
+      if (!dataListener) {
+        throw new Error('PTY data listener was not registered');
+      }
+      dataListener(data);
+    },
+    pauseCount: () => pauses,
+    resumeCount: () => resumes,
+  };
+}
+
+describe('PTY bounded processing queue', () => {
+  it('pauses at the item high-water mark and resumes after draining', async () => {
+    const harness = createFakePtyState(true);
+    const overflows: Error[] = [];
+    registerPtyDataHandler(
+      harness.state,
+      () => undefined,
+      createByteBudget(1024),
+      (error) => overflows.push(error),
+    );
+
+    for (let i = 0; i < PTY_QUEUE_HIGH_WATER_ITEMS; i += 1) {
+      harness.emitData('x');
+    }
+
+    expect(harness.pauseCount()).toBe(1);
+    expect(harness.state.backpressurePaused).toBe(true);
+    await harness.state.processingChain;
+    expect(harness.resumeCount()).toBe(1);
+    expect(harness.state.pendingQueueItems).toBe(0);
+    expect(harness.state.pendingQueueBytes).toBe(0);
+    expect(overflows).toHaveLength(0);
+    expect(harness.state.error).toBeNull();
+  });
+
+  it('fails fast when tiny chunks exceed the hard item bound', async () => {
+    const harness = createFakePtyState(false);
+    const overflows: Error[] = [];
+    registerPtyDataHandler(
+      harness.state,
+      () => undefined,
+      createByteBudget(1024),
+      (error) => overflows.push(error),
+    );
+
+    for (let i = 0; i <= PTY_QUEUE_HARD_LIMIT_ITEMS; i += 1) {
+      harness.emitData('x');
+    }
+
+    expect(overflows).toHaveLength(1);
+    expect(harness.state.queueOverflowed).toBe(true);
+    expect(harness.state.rawCollector.observedByteCount).toBe(
+      PTY_QUEUE_HARD_LIMIT_ITEMS + 1,
+    );
+    await harness.state.processingChain;
+    expect(harness.state.pendingQueueItems).toBe(0);
+    expect(harness.state.pendingQueueBytes).toBe(0);
+  });
+  it('fails fast on one oversized callback with bounded retained bytes', async () => {
+    const harness = createFakePtyState(false);
+    const overflows: Error[] = [];
+    registerPtyDataHandler(
+      harness.state,
+      () => undefined,
+      createByteBudget(1024),
+      (error) => overflows.push(error),
+    );
+    const tailMarker = 'OVERSIZED_CALLBACK_TAIL';
+    const output =
+      'OVERSIZED_CALLBACK_HEAD' +
+      'x'.repeat(PTY_QUEUE_HARD_LIMIT_BYTES) +
+      tailMarker;
+
+    harness.emitData(output);
+
+    expect(overflows).toHaveLength(1);
+    expect(harness.state.queueOverflowed).toBe(true);
+    expect(harness.state.rawCollector.observedByteCount).toBe(
+      Buffer.byteLength(output),
+    );
+    expect(
+      harness.state.rawCollector.getResult().tailText.endsWith(tailMarker),
+    ).toBe(true);
+    await harness.state.processingChain;
+    expect(harness.state.pendingQueueItems).toBe(0);
+    expect(harness.state.pendingQueueBytes).toBe(0);
+  });
+
+  it('preserves a surrogate pair across the internal encoding slice boundary', async () => {
+    const harness = createFakePtyState(true);
+    const output = `${'x'.repeat(64 * 1024 - 1)}😀tail`;
+    const budget = createByteBudget(128 * 1024);
+    harness.state.rawCollector = new BoundedCombinedCollector({ budget });
+    registerPtyDataHandler(
+      harness.state,
+      () => undefined,
+      budget,
+      () => {
+        throw new Error('Unexpected PTY queue overflow');
+      },
+    );
+
+    harness.emitData(output);
+    await harness.state.processingChain;
+
+    const result = harness.state.rawCollector.getResult();
+    expect(result.metadata.observedBytes).toBe(Buffer.byteLength(output));
+    expect(result.text).toBe(output);
+    expect(result.text).not.toContain('�');
+  });
+
+  it('releases paused backpressure after a hard overflow drains the queue', async () => {
+    const harness = createFakePtyState(true);
+    const overflows: Error[] = [];
+    registerPtyDataHandler(
+      harness.state,
+      () => undefined,
+      createByteBudget(1024),
+      (error) => overflows.push(error),
+    );
+
+    for (let i = 0; i <= PTY_QUEUE_HARD_LIMIT_ITEMS; i += 1) {
+      harness.emitData('x');
+    }
+
+    expect(overflows).toHaveLength(1);
+    expect(harness.pauseCount()).toBe(1);
+    expect(harness.resumeCount()).toBe(1);
+    expect(harness.state.backpressurePaused).toBe(false);
+    expect(harness.state.queueOverflowed).toBe(true);
+
+    await harness.state.processingChain;
+
+    expect(harness.resumeCount()).toBe(1);
+    expect(harness.state.pendingQueueItems).toBe(0);
+    expect(harness.state.pendingQueueBytes).toBe(0);
+  });
+
+  describe('PTY bounded result', () => {
+    it('reports truncation exactly once with structured metadata', async () => {
+      const retentionBytes = 1024;
+      const finalMarker = 'FINAL_PTY_MARKER';
+      const output =
+        'HEAD_PTY_MARKER' + 'x'.repeat(retentionBytes * 4) + finalMarker;
+      const harness = createFakePtyState(true);
+      const terminal = new Terminal({
+        cols: 80,
+        rows: 24,
+        scrollback: 100,
+        allowProposedApi: true,
+      });
+      harness.state.headlessTerminal = terminal;
+      harness.state.rawCollector = new BoundedCombinedCollector({
+        budget: createByteBudget(retentionBytes),
+      });
+
+      try {
+        harness.state.rawCollector.append(Buffer.from(output), 'stdout');
+        await new Promise<void>((resolve) => terminal.write(output, resolve));
+
+        const result = buildPtyResult(harness.state, 0, null, false);
+        const observedBytes = Buffer.byteLength(output);
+
+        expect(result.rawOutput.length).toBeLessThanOrEqual(retentionBytes);
+        expect(result.output).toContain('HEAD_PTY_MARKER');
+        expect(result.output).toContain(finalMarker);
+        expect(result.output.match(/LLXPRT output truncated/g)).toHaveLength(1);
+        expect(result.outputTruncation).toEqual({
+          observedBytes,
+          retainedBytes: retentionBytes,
+          omittedBytes: observedBytes - retentionBytes,
+          truncated: true,
+          budgetBytes: retentionBytes,
+        });
+      } finally {
+        terminal.dispose();
+      }
+    });
+
+    it('uses retained raw text when xterm scrollback evicts complete output', async () => {
+      // Low-byte / high-line scenario: xterm evicts earlier screen content while
+      // the raw collector remains within budget. The final model-facing result
+      // must therefore recover the complete retained stream rather than claim
+      // that output was lost.
+      const harness = createFakePtyState(true);
+      const terminal = new Terminal({
+        cols: 80,
+        rows: 4,
+        scrollback: 4,
+        allowProposedApi: true,
+      });
+      harness.state.headlessTerminal = terminal;
+      harness.state.terminalMaxBufferLines = 8;
+      // Collector budget large enough that the small output never truncates.
+      harness.state.rawCollector = new BoundedCombinedCollector({
+        budget: createByteBudget(4096),
+      });
+
+      try {
+        // Write enough distinct short lines to force scrollback eviction.
+        const lines: string[] = [];
+        for (let i = 0; i < 40; i += 1) {
+          lines.push(`line-${i}
+`);
+        }
+        const data = lines.join('');
+        harness.state.rawCollector.append(Buffer.from(data), 'stdout');
+        await new Promise<void>((resolve) => terminal.write(data, resolve));
+        harness.state.terminalContentEvicted = true;
+
+        const result = buildPtyResult(harness.state, 0, null, false);
+        expect(result.output).toContain('[Retained PTY output]');
+        expect(result.output).toContain('line-0');
+        expect(result.output).toContain('line-39');
+        expect(result.output).not.toContain('LLXPRT output truncated');
+        expect(result.outputTruncation).toBeUndefined();
+        expect(result.rawOutput.toString('utf8')).toContain('line-0');
+      } finally {
+        terminal.dispose();
+      }
+    });
+
+    it('preserves the raw collector head and tail bytes', () => {
+      const retentionBytes = 1024;
+      const harness = createFakePtyState(true);
+      const terminal = new Terminal({
+        cols: 80,
+        rows: 24,
+        scrollback: 100,
+        allowProposedApi: true,
+      });
+      harness.state.headlessTerminal = terminal;
+      harness.state.rawCollector = new BoundedCombinedCollector({
+        budget: createByteBudget(retentionBytes),
+      });
+
+      try {
+        const headMarker = 'PTY_RAW_HEAD_MARKER';
+        const tailMarker = 'PTY_RAW_TAIL_MARKER';
+        const output = headMarker + 'x'.repeat(retentionBytes * 8) + tailMarker;
+        harness.state.rawCollector.append(Buffer.from(output), 'stdout');
+
+        const result = buildPtyResult(harness.state, 0, null, false);
+        // rawOutput carries the bounded raw head + tail.
+        expect(result.rawOutput.length).toBeLessThanOrEqual(retentionBytes);
+        const raw = result.rawOutput.toString('utf8');
+        expect(raw).toContain(headMarker);
+        expect(raw).toContain(tailMarker);
+      } finally {
+        terminal.dispose();
+      }
+    });
+
+    it('preserves long wrapped lines without corruption', async () => {
+      const harness = createFakePtyState(true);
+      const terminal = new Terminal({
+        cols: 20,
+        rows: 24,
+        scrollback: 1000,
+        allowProposedApi: true,
+      });
+      harness.state.headlessTerminal = terminal;
+      harness.state.rawCollector = new BoundedCombinedCollector({
+        budget: createByteBudget(8192),
+      });
+
+      try {
+        // A single line far longer than the 20-col terminal width wraps across
+        // many visual rows; buildPtyResult must still surface the content.
+        const longLine = 'W'.repeat(500);
+        const data = `${longLine}
+`;
+        harness.state.rawCollector.append(Buffer.from(data), 'stdout');
+        await new Promise<void>((resolve) => terminal.write(data, resolve));
+
+        const result = buildPtyResult(harness.state, 0, null, false);
+        expect(result.output).toContain('W'.repeat(20));
+        expect(result.outputTruncation).toBeUndefined();
+      } finally {
+        terminal.dispose();
+      }
+    });
+
+    it('marks queue-overflow byte loss as unquantifiable', () => {
+      // High item / low byte overflow terminates acquisition before all producer
+      // bytes can be observed. Retained accounting remains exact while metadata
+      // explicitly marks the additional omission count as unknown.
+      const harness = createFakePtyState(false);
+      const terminal = new Terminal({
+        cols: 80,
+        rows: 24,
+        scrollback: 100,
+        allowProposedApi: true,
+      });
+      harness.state.headlessTerminal = terminal;
+      harness.state.rawCollector = new BoundedCombinedCollector({
+        budget: createByteBudget(1024),
+      });
+      harness.state.queueOverflowed = true;
+
+      try {
+        // Only a few bytes collected — well within budget.
+        harness.state.rawCollector.append(Buffer.from('tiny output'), 'stdout');
+
+        const result = buildPtyResult(harness.state, 0, null, false);
+        expect(result.output.match(/LLXPRT output truncated/g)).toHaveLength(1);
+        expect(result.outputTruncation).toEqual({
+          observedBytes: 11,
+          retainedBytes: 11,
+          omittedBytes: 0,
+          omittedBytesExact: false,
+          truncated: true,
+          budgetBytes: 1024,
+        });
+      } finally {
+        terminal.dispose();
+      }
+    });
+  });
+});

--- a/packages/core/src/services/shellPtyExecution.bun.test.ts
+++ b/packages/core/src/services/shellPtyExecution.bun.test.ts
@@ -71,7 +71,11 @@ function createFakePtyState(supportsBackpressure: boolean): FakePtyHarness {
     abortSignal: new AbortController().signal,
     onOutputEvent: () => undefined,
     shellExecutionConfig: {},
-    ptyInfo: { name: 'node-pty', module: {} },
+    ptyInfo: {
+      name: 'node-pty',
+      module: {},
+      supportsBackpressure: true,
+    },
     supportsProcessGroupKill: true,
     inactivityAbortController,
     resetInactivityTimer: () => undefined,
@@ -133,6 +137,28 @@ describe('PTY bounded processing queue', () => {
     expect(harness.state.pendingQueueBytes).toBe(0);
     expect(overflows).toHaveLength(0);
     expect(harness.state.error).toBeNull();
+  });
+
+  it('finalizes queue accounting when terminal rendering throws', async () => {
+    const harness = createFakePtyState(true);
+    registerPtyDataHandler(
+      harness.state,
+      () => {
+        throw new Error('render failed');
+      },
+      createByteBudget(1024),
+      () => {
+        throw new Error('Unexpected PTY queue overflow');
+      },
+    );
+
+    harness.emitData('output');
+    await harness.state.processingChain;
+
+    expect(harness.state.error?.message).toBe('render failed');
+    expect(harness.state.isWriting).toBe(false);
+    expect(harness.state.pendingQueueItems).toBe(0);
+    expect(harness.state.pendingQueueBytes).toBe(0);
   });
 
   it('fails fast when tiny chunks exceed the hard item bound', async () => {

--- a/packages/core/src/services/shellPtyExecution.ts
+++ b/packages/core/src/services/shellPtyExecution.ts
@@ -4,22 +4,99 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { TextDecoder } from 'node:util';
-import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
 import { isBinary } from '../utils/textUtils.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import { DebugLogger } from '../debug/DebugLogger.js';
 import type { PtyExecState } from './shellPtyState.js';
 import type { ShellExecutionResult } from './shellExecutionTypes.js';
-import { MAX_SNIFF_SIZE } from './shellOutputUtils.js';
+import { MAX_SNIFF_SIZE, stripAnsiIfPresent } from './shellOutputUtils.js';
 import {
   getFullBufferText,
   serializeTerminalForRender,
   findLastNonEmptyLineIndex,
   maybeEmitRenderedOutput,
 } from './shellPtyHelpers.js';
+import type {
+  ByteBudget,
+  CombinedAcquisitionResult,
+  TruncationMetadata,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
 
 const shellDebug = new DebugLogger('llxprt:shell:render');
+
+export const PTY_QUEUE_HIGH_WATER_BYTES = 2 * 1024 * 1024;
+export const PTY_QUEUE_LOW_WATER_BYTES = 1024 * 1024;
+export const PTY_QUEUE_HARD_LIMIT_BYTES = 8 * 1024 * 1024;
+export const PTY_QUEUE_HIGH_WATER_ITEMS = 1024;
+export const PTY_QUEUE_LOW_WATER_ITEMS = 512;
+export const PTY_QUEUE_HARD_LIMIT_ITEMS = 4096;
+const PTY_UTF8_ENCODING_CHUNK_CODE_UNITS = 64 * 1024;
+
+const PTY_QUEUE_OVERFLOW_NOTICE =
+  '[LLXPRT output truncated: processing queue overflow terminated output acquisition]';
+const PTY_RETAINED_OUTPUT_LABEL = '[Retained PTY output]';
+const PTY_FINAL_SCREEN_LABEL = '[Final terminal screen]';
+
+function joinNonEmptySections(sections: Array<string | null>): string {
+  return sections
+    .filter(
+      (section): section is string => section !== null && section.length > 0,
+    )
+    .join('\n');
+}
+
+function buildRetainedPtyText(
+  acquisition: CombinedAcquisitionResult,
+  notice: string | null,
+): string {
+  if (!acquisition.metadata.truncated) {
+    return joinNonEmptySections([stripAnsiIfPresent(acquisition.text), notice]);
+  }
+  return joinNonEmptySections([
+    stripAnsiIfPresent(acquisition.headText),
+    notice,
+    stripAnsiIfPresent(acquisition.tailText),
+  ]);
+}
+
+function buildPtyTextOutput(
+  state: PtyExecState,
+  acquisition: CombinedAcquisitionResult,
+  terminalOutput: string,
+): string {
+  const useRetainedOutput =
+    state.queueOverflowed ||
+    state.terminalContentEvicted ||
+    acquisition.metadata.truncated;
+  if (!useRetainedOutput) {
+    return terminalOutput;
+  }
+
+  const notice = state.queueOverflowed
+    ? PTY_QUEUE_OVERFLOW_NOTICE
+    : acquisition.omissionNotice;
+  const retainedOutput = buildRetainedPtyText(acquisition, notice);
+  return joinNonEmptySections([
+    PTY_RETAINED_OUTPUT_LABEL,
+    retainedOutput,
+    terminalOutput.length > 0 ? PTY_FINAL_SCREEN_LABEL : null,
+    terminalOutput,
+  ]);
+}
+
+function buildPtyTruncationMetadata(
+  state: PtyExecState,
+  acquisition: CombinedAcquisitionResult,
+): TruncationMetadata | undefined {
+  if (state.queueOverflowed) {
+    return {
+      ...acquisition.metadata,
+      omittedBytesExact: false,
+      truncated: true,
+    };
+  }
+  return acquisition.metadata.truncated ? acquisition.metadata : undefined;
+}
 
 /** Build a ShellExecutionResult for the PTY path. */
 export function buildPtyResult(
@@ -28,9 +105,13 @@ export function buildPtyResult(
   signal: number | null,
   aborted: boolean,
 ): ShellExecutionResult {
+  const acquisition = state.rawCollector.getResult();
+  const terminalOutput = getFullBufferText(state.headlessTerminal);
+
   return {
-    rawOutput: Buffer.concat(state.outputChunks),
-    output: getFullBufferText(state.headlessTerminal),
+    rawOutput: state.rawCollector.getBoundedRawBuffer(),
+    output: buildPtyTextOutput(state, acquisition, terminalOutput),
+    outputTruncation: buildPtyTruncationMetadata(state, acquisition),
     exitCode,
     signal,
     error: state.error,
@@ -91,73 +172,266 @@ function renderTerminalOutput(state: PtyExecState): void {
   );
 }
 
-/** PTY data handler factory — processes incoming output chunks. */
+/**
+ * Error thrown when the PTY pending processing queue exceeds the hard bound.
+ * Callers should terminate the process tree and resolve with a truncated
+ * result (Issue #3200).
+ */
+export class PtyQueueOverflowError extends Error {
+  constructor(
+    message: string,
+    readonly pendingBytes: number,
+    readonly byteLimit: number,
+    readonly pendingItems: number,
+    readonly itemLimit: number,
+  ) {
+    super(message);
+    this.name = 'PtyQueueOverflowError';
+  }
+}
+
+/**
+ * PTY data handler factory — processes incoming output chunks.
+ *
+ * Each chunk is fed to xterm in order (no head/tail dropping for the terminal
+ * stream) while the raw byte collector bounds retention for rawOutput
+ * compatibility (Issue #3200). The pending queue is tracked so backends
+ * without usable backpressure can fail fast.
+ *
+ * @param onOverflow Called when the pending queue exceeds the hard limit on
+ *   a backend without usable backpressure. The caller should terminate the
+ *   process tree and resolve with a truncated result.
+ */
+function exceedsQueueHardLimit(state: PtyExecState): boolean {
+  return (
+    state.pendingQueueBytes > PTY_QUEUE_HARD_LIMIT_BYTES ||
+    state.pendingQueueItems > PTY_QUEUE_HARD_LIMIT_ITEMS
+  );
+}
+
+function triggerQueueOverflow(
+  state: PtyExecState,
+  onOverflow: (error: PtyQueueOverflowError) => void,
+): void {
+  if (state.queueOverflowed) {
+    return;
+  }
+  state.queueOverflowed = true;
+  if (state.backpressurePaused) {
+    try {
+      state.ptyProcess.resume();
+    } catch {
+      // Termination below remains authoritative if the backend cannot resume.
+    }
+    state.backpressurePaused = false;
+  }
+  onOverflow(
+    new PtyQueueOverflowError(
+      'PTY pending queue exceeded its hard byte or item limit; terminating the process tree',
+      state.pendingQueueBytes,
+      PTY_QUEUE_HARD_LIMIT_BYTES,
+      state.pendingQueueItems,
+      PTY_QUEUE_HARD_LIMIT_ITEMS,
+    ),
+  );
+}
+
+function pausePtyAtHighWater(
+  state: PtyExecState,
+  onOverflow: (error: PtyQueueOverflowError) => void,
+): void {
+  if (
+    !state.supportsBackpressure ||
+    state.backpressurePaused ||
+    (state.pendingQueueBytes < PTY_QUEUE_HIGH_WATER_BYTES &&
+      state.pendingQueueItems < PTY_QUEUE_HIGH_WATER_ITEMS)
+  ) {
+    return;
+  }
+  try {
+    state.ptyProcess.pause();
+    state.backpressurePaused = true;
+  } catch {
+    state.supportsBackpressure = false;
+    if (exceedsQueueHardLimit(state)) {
+      triggerQueueOverflow(state, onOverflow);
+    }
+  }
+}
+
+function finishQueueEntry(
+  state: PtyExecState,
+  dataLength: number,
+  onOverflow: (error: PtyQueueOverflowError) => void,
+): void {
+  state.pendingQueueBytes = Math.max(0, state.pendingQueueBytes - dataLength);
+  state.pendingQueueItems = Math.max(0, state.pendingQueueItems - 1);
+  if (
+    state.queueOverflowed ||
+    !state.backpressurePaused ||
+    state.pendingQueueBytes > PTY_QUEUE_LOW_WATER_BYTES ||
+    state.pendingQueueItems > PTY_QUEUE_LOW_WATER_ITEMS
+  ) {
+    return;
+  }
+  try {
+    state.ptyProcess.resume();
+    state.backpressurePaused = false;
+  } catch {
+    triggerQueueOverflow(state, onOverflow);
+  }
+}
+
+function appendPtyOutput(
+  state: PtyExecState,
+  data: string | Buffer,
+): { text: string; byteLength: number } {
+  if (Buffer.isBuffer(data)) {
+    state.rawCollector.append(data, 'stdout');
+    return { text: data.toString('utf8'), byteLength: data.length };
+  }
+
+  let offset = 0;
+  let observedBytes = 0;
+  while (offset < data.length) {
+    let end = Math.min(
+      offset + PTY_UTF8_ENCODING_CHUNK_CODE_UNITS,
+      data.length,
+    );
+    const finalCodeUnit = data.charCodeAt(end - 1);
+    if (
+      end < data.length &&
+      finalCodeUnit >= 0xd800 &&
+      finalCodeUnit <= 0xdbff
+    ) {
+      end -= 1;
+    }
+    const encoded = Buffer.from(data.slice(offset, end), 'utf8');
+    state.rawCollector.append(encoded, 'stdout');
+    observedBytes += encoded.length;
+    offset = end;
+  }
+  return { text: data, byteLength: observedBytes };
+}
+
+function inspectPtyBinaryPrefix(state: PtyExecState, budget: ByteBudget): void {
+  if (!state.isStreamingRawContent || state.sniffedBytes >= MAX_SNIFF_SIZE) {
+    return;
+  }
+  const sniffBuffer = state.rawCollector.getHeadBytes(
+    Math.min(MAX_SNIFF_SIZE, budget.bytes),
+  );
+  state.sniffedBytes = Math.min(
+    state.rawCollector.observedByteCount,
+    MAX_SNIFF_SIZE,
+    budget.bytes,
+  );
+  if (isBinary(sniffBuffer)) {
+    state.isStreamingRawContent = false;
+    state.onOutputEvent({ type: 'binary_detected' });
+  }
+}
+
+function processPtyChunk(
+  state: PtyExecState,
+  data: string,
+  dataByteLength: number,
+  render: () => void,
+  budget: ByteBudget,
+  onOverflow: (error: PtyQueueOverflowError) => void,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let finished = false;
+    const finish = () => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      finishQueueEntry(state, dataByteLength, onOverflow);
+      resolve();
+    };
+    const fail = (error: unknown) => {
+      if (!finished) {
+        finished = true;
+        finishQueueEntry(state, dataByteLength, onOverflow);
+      }
+      reject(error);
+    };
+
+    try {
+      if (state.hasResolved || state.queueOverflowed) {
+        finish();
+        return;
+      }
+      inspectPtyBinaryPrefix(state, budget);
+      if (!state.isStreamingRawContent) {
+        state.onOutputEvent({
+          type: 'binary_progress',
+          bytesReceived: state.rawCollector.observedByteCount,
+        });
+        finish();
+        return;
+      }
+      state.isWriting = true;
+      const wasAtCap =
+        state.headlessTerminal.buffer.active.length >=
+        state.terminalMaxBufferLines;
+      state.headlessTerminal.write(data, () => {
+        if (
+          wasAtCap &&
+          state.headlessTerminal.buffer.active.length >=
+            state.terminalMaxBufferLines
+        ) {
+          state.terminalContentEvicted = true;
+        }
+        render();
+        state.isWriting = false;
+        finish();
+      });
+    } catch (error) {
+      state.isWriting = false;
+      fail(error);
+    }
+  });
+}
+
 export function registerPtyDataHandler(
   state: PtyExecState,
   render: () => void,
+  budget: ByteBudget,
+  onOverflow: (error: PtyQueueOverflowError) => void,
 ): void {
-  const handleOutput = (data: Buffer) => {
+  const handleOutput = (data: string | Buffer) => {
+    if (state.hasResolved || state.queueOverflowed || data.length === 0) {
+      return;
+    }
     state.resetInactivityTimer();
+    const { text, byteLength: dataByteLength } = appendPtyOutput(state, data);
+    state.pendingQueueBytes += dataByteLength;
+    state.pendingQueueItems += 1;
 
-    state.processingChain = state.processingChain.then(
-      () =>
-        new Promise<void>((res) => {
-          if (!state.decoder) {
-            const encoding = getCachedEncodingForBuffer(data);
-            try {
-              state.decoder = new TextDecoder(encoding);
-            } catch {
-              state.decoder = new TextDecoder('utf-8');
-            }
-          }
+    if (exceedsQueueHardLimit(state)) {
+      triggerQueueOverflow(state, onOverflow);
+      finishQueueEntry(state, dataByteLength, onOverflow);
+      return;
+    }
+    pausePtyAtHighWater(state, onOverflow);
 
-          state.outputChunks.push(data);
-
-          if (
-            state.isStreamingRawContent &&
-            state.sniffedBytes < MAX_SNIFF_SIZE
-          ) {
-            const sniffBuffer = Buffer.concat(state.outputChunks.slice(0, 20));
-            state.sniffedBytes = sniffBuffer.length;
-
-            if (isBinary(sniffBuffer)) {
-              state.isStreamingRawContent = false;
-              state.onOutputEvent({ type: 'binary_detected' });
-            }
-          }
-
-          if (state.isStreamingRawContent) {
-            const decodedChunk = state.decoder.decode(data, { stream: true });
-            if (decodedChunk.length === 0) {
-              res();
-              return;
-            }
-            state.isWriting = true;
-            state.headlessTerminal.write(decodedChunk, () => {
-              render();
-              state.isWriting = false;
-              res();
-            });
-          } else {
-            const totalBytes = state.outputChunks.reduce(
-              (sum, chunk) => sum + chunk.length,
-              0,
-            );
-            state.onOutputEvent({
-              type: 'binary_progress',
-              bytesReceived: totalBytes,
-            });
-            res();
-          }
-        }),
-    );
-    state.processingChain.catch(() => {});
+    state.processingChain = state.processingChain
+      .then(() =>
+        processPtyChunk(
+          state,
+          text,
+          dataByteLength,
+          render,
+          budget,
+          onOverflow,
+        ),
+      )
+      .catch((error: unknown) => {
+        state.error = error instanceof Error ? error : new Error(String(error));
+      });
   };
 
-  state.activePtyEntry.onDataDisposable = state.ptyProcess.onData(
-    (data: string) => {
-      const bufferData = Buffer.from(data, 'utf-8');
-      handleOutput(bufferData);
-    },
-  );
+  state.activePtyEntry.onDataDisposable = state.ptyProcess.onData(handleOutput);
 }

--- a/packages/core/src/services/shellPtyExecution.ts
+++ b/packages/core/src/services/shellPtyExecution.ts
@@ -377,15 +377,21 @@ function processPtyChunk(
         state.headlessTerminal.buffer.active.length >=
         state.terminalMaxBufferLines;
       state.headlessTerminal.write(data, () => {
-        if (
-          wasAtCap &&
-          state.headlessTerminal.buffer.active.length >=
-            state.terminalMaxBufferLines
-        ) {
-          state.terminalContentEvicted = true;
+        try {
+          if (
+            wasAtCap &&
+            state.headlessTerminal.buffer.active.length >=
+              state.terminalMaxBufferLines
+          ) {
+            state.terminalContentEvicted = true;
+          }
+          render();
+        } catch (error) {
+          fail(error);
+          return;
+        } finally {
+          state.isWriting = false;
         }
-        render();
-        state.isWriting = false;
         finish();
       });
     } catch (error) {

--- a/packages/core/src/services/shellPtyHelpers.ts
+++ b/packages/core/src/services/shellPtyHelpers.ts
@@ -115,6 +115,10 @@ export function cleanupPtyEntryByPid(
 export function getFullBufferText(terminal: Terminal): string {
   const buffer = terminal.buffer.active;
   const lines: string[] = [];
+  // Accumulate wrapped-line segments in a temporary array and join once per
+  // logical line, avoiding O(n²) repeated string concatenation for long
+  // wrapped lines (Issue #3200 finding 3).
+  let wrapGroup: string[] = [];
   for (let i = 0; i < buffer.length; i++) {
     const line = buffer.getLine(i);
     if (!line) {
@@ -130,11 +134,17 @@ export function getFullBufferText(terminal: Terminal): string {
 
     const lineContent = line.translateToString(trimRight);
 
-    if (line.isWrapped && lines.length > 0) {
-      lines[lines.length - 1] += lineContent;
+    if (line.isWrapped) {
+      wrapGroup.push(lineContent);
     } else {
-      lines.push(lineContent);
+      if (wrapGroup.length > 0) {
+        lines.push(wrapGroup.join(''));
+      }
+      wrapGroup = [lineContent];
     }
+  }
+  if (wrapGroup.length > 0) {
+    lines.push(wrapGroup.join(''));
   }
 
   while (lines.length > 0 && lines[lines.length - 1] === '') {

--- a/packages/core/src/services/shellPtyLifecycle.test.ts
+++ b/packages/core/src/services/shellPtyLifecycle.test.ts
@@ -73,7 +73,11 @@ function makeFakeState(inputs: FakeStateInputs): {
     abortSignal: new AbortController().signal,
     onOutputEvent: () => undefined,
     shellExecutionConfig: {} as ShellExecutionConfig,
-    ptyInfo: { name: 'node-pty', module: {} } as NonNullable<PtyImplementation>,
+    ptyInfo: {
+      name: 'node-pty',
+      module: {},
+      supportsBackpressure: true,
+    } as NonNullable<PtyImplementation>,
     supportsProcessGroupKill: inputs.supportsProcessGroupKill,
     inactivityAbortController,
     resetInactivityTimer: () => undefined,

--- a/packages/core/src/services/shellPtyLifecycle.test.ts
+++ b/packages/core/src/services/shellPtyLifecycle.test.ts
@@ -19,6 +19,10 @@ import {
   ptyInactivityAbortAction,
 } from './shellPtyLifecycle.js';
 import type { PtyImplementation } from '../utils/getPty.js';
+import {
+  BoundedCombinedCollector,
+  createByteBudget,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
 
 const { Terminal } = headless;
 
@@ -74,9 +78,10 @@ function makeFakeState(inputs: FakeStateInputs): {
     inactivityAbortController,
     resetInactivityTimer: () => undefined,
     exitedGuard: createExitGuard(),
-    decoder: null,
     output: null,
-    outputChunks: [],
+    rawCollector: new BoundedCombinedCollector({
+      budget: createByteBudget(1024),
+    }),
     error: null,
     isStreamingRawContent: true,
     sniffedBytes: 0,
@@ -85,6 +90,11 @@ function makeFakeState(inputs: FakeStateInputs): {
     hasResolved: false,
     abortFinalizeTimeout: null,
     processingChain: Promise.resolve(),
+    pendingQueueBytes: 0,
+    pendingQueueItems: 0,
+    supportsBackpressure: true,
+    backpressurePaused: false,
+    queueOverflowed: false,
   } as unknown as PtyExecState;
 
   return { state, killSignals };

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -30,10 +30,52 @@ import {
   ptyRenderFn,
   registerPtyDataHandler,
 } from './shellPtyExecution.js';
+import { resolveShellRetentionBudget } from './shellAcquisitionConfig.js';
+import {
+  BoundedCombinedCollector,
+  type ByteBudget,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
 const { Terminal } = headless;
 
-// We want to allow shell outputs that are close to the context window in size.
-export const SCROLLBACK_LIMIT = 600000;
+/**
+ * Default scrollback limit when no explicit scrollback is configured.
+ * This is intentionally bounded (Issue #3200); the old value of 600,000
+ * lines could retain hundreds of MB of terminal state.
+ */
+export const SCROLLBACK_LIMIT = 10000;
+
+/**
+ * Maximum scrollback lines. Even when an explicit scrollback is configured
+ * via settings, it is capped at this value to prevent unbounded terminal
+ * state growth (Issue #3200).
+ */
+const MAX_SCROLLBACK_LINES = 50000;
+
+/** Derive the effective xterm scrollback without exceeding the byte budget. */
+function deriveScrollbackFromBudget(
+  budget: ByteBudget,
+  cols: number,
+  configuredScrollback: number | undefined,
+): number {
+  const effectiveCols = Math.max(cols, 1);
+  const budgetLineLimit = Math.min(
+    Math.floor(budget.bytes / (effectiveCols * 8)),
+    MAX_SCROLLBACK_LINES,
+  );
+  const requested = Number.isFinite(configuredScrollback)
+    ? Math.max(Math.floor(configuredScrollback ?? 0), 0)
+    : SCROLLBACK_LIMIT;
+  return Math.min(requested, budgetLineLimit);
+}
+
+function createTerminalTrackingState(scrollback: number, rows: number) {
+  return {
+    terminalMaxBufferLines: scrollback + rows,
+    terminalScrollbackCapacity: scrollback,
+    terminalScrollbackAtCapacity: scrollback === 0,
+    terminalContentEvicted: false,
+  };
+}
 
 /** Clean up and resolve the active PTY entry from a map. */
 export function cleanupActivePtyEntry(
@@ -58,11 +100,21 @@ export function createPtyResultPromise(
   activePtys: Map<number, ActivePty>,
   lastActivePtyIdRef: { value: number | null },
 ): Promise<ShellExecutionResult> {
+  const budget = resolveShellRetentionBudget(
+    shellExecutionConfig.outputRetentionMaxBytes,
+  );
+
+  const effectiveScrollback = deriveScrollbackFromBudget(
+    budget,
+    cols,
+    shellExecutionConfig.scrollback,
+  );
+
   const headlessTerminal = new Terminal({
     allowProposedApi: true,
     cols,
     rows,
-    scrollback: shellExecutionConfig.scrollback ?? SCROLLBACK_LIMIT,
+    scrollback: effectiveScrollback,
   });
   headlessTerminal.scrollToTop();
 
@@ -92,9 +144,8 @@ export function createPtyResultPromise(
     inactivityAbortController,
     resetInactivityTimer,
     exitedGuard,
-    decoder: null,
     output: null,
-    outputChunks: [],
+    rawCollector: new BoundedCombinedCollector({ budget }),
     error: null,
     isStreamingRawContent: true,
     sniffedBytes: 0,
@@ -103,10 +154,22 @@ export function createPtyResultPromise(
     hasResolved: false,
     abortFinalizeTimeout: null,
     processingChain: Promise.resolve(),
+    pendingQueueBytes: 0,
+    pendingQueueItems: 0,
+    supportsBackpressure: ptyInfo.name !== 'bun-pty',
+    backpressurePaused: false,
+    queueOverflowed: false,
+    ...createTerminalTrackingState(effectiveScrollback, rows),
   };
 
   return new Promise<ShellExecutionResult>((resolve) => {
-    setupPtyEventHandlers(state, resolve, activePtys, lastActivePtyIdRef);
+    setupPtyEventHandlers(
+      state,
+      resolve,
+      activePtys,
+      lastActivePtyIdRef,
+      budget,
+    );
   });
 }
 
@@ -115,6 +178,7 @@ function setupPtyEventHandlers(
   resolve: (value: ShellExecutionResult) => void,
   activePtys: Map<number, ActivePty>,
   lastActivePtyIdRef: { value: number | null },
+  budget: ByteBudget,
 ): void {
   const resolveResult = makePtyResolveResult(
     state,
@@ -129,6 +193,14 @@ function setupPtyEventHandlers(
 
   state.activePtyEntry.onScrollDisposable = state.headlessTerminal.onScroll(
     () => {
+      const atCapacity =
+        state.terminalScrollbackCapacity === 0 ||
+        state.headlessTerminal.buffer.active.baseY >=
+          state.terminalScrollbackCapacity;
+      if (state.isWriting && state.terminalScrollbackAtCapacity && atCapacity) {
+        state.terminalContentEvicted = true;
+      }
+      state.terminalScrollbackAtCapacity = atCapacity;
       if (!state.isWriting) {
         render();
       }
@@ -138,7 +210,18 @@ function setupPtyEventHandlers(
   setupPtyInactivityHandler(state, resolveResult);
   const abortHandler = setupPtyAbortHandler(state, resolveResult);
 
-  registerPtyDataHandler(state, render);
+  registerPtyDataHandler(state, render, budget, (error) => {
+    if (state.hasResolved) {
+      return;
+    }
+    state.error = error;
+    if (!isKillablePid(state.ptyProcess.pid)) {
+      resolveResult(buildPtyResult(state, 1, null, false));
+      return;
+    }
+    void ptyAbortAction(state, resolveResult, false);
+  });
+
   registerPtyExitHandler(state, resolveResult, abortHandler);
 
   state.abortSignal.addEventListener('abort', abortHandler, { once: true });
@@ -152,6 +235,14 @@ function teardownPtyState(
   if (state.abortFinalizeTimeout) {
     clearTimeout(state.abortFinalizeTimeout);
     state.abortFinalizeTimeout = null;
+  }
+  if (state.backpressurePaused) {
+    try {
+      state.ptyProcess.resume();
+    } catch {
+      // PTY teardown below remains authoritative.
+    }
+    state.backpressurePaused = false;
   }
   cleanupActivePtyEntry(
     state,
@@ -283,6 +374,7 @@ function setupPtyAbortHandler(
 export async function ptyAbortAction(
   state: PtyExecState,
   resolveResult: (resultValue: ShellExecutionResult) => void,
+  aborted = true,
 ): Promise<void> {
   // A non-killable pid (0, negative, NaN, Infinity) must never reach
   // process.kill(-pid): pid 0 would signal the caller's own process group.
@@ -292,7 +384,7 @@ export async function ptyAbortAction(
   const pid = state.ptyProcess.pid;
   if (state.isWindows) {
     taskkillTree(pid);
-    resolveResult(buildPtyResult(state, 1, null, true));
+    resolveResult(buildPtyResult(state, 1, null, aborted));
     return;
   }
 
@@ -328,7 +420,7 @@ export async function ptyAbortAction(
   }
 
   state.abortFinalizeTimeout = setTimeout(() => {
-    resolveResult(buildPtyResult(state, 1, null, true));
+    resolveResult(buildPtyResult(state, 1, null, aborted));
   }, SIGKILL_TIMEOUT_MS);
 }
 

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -51,6 +51,13 @@ export const SCROLLBACK_LIMIT = 10000;
  */
 const MAX_SCROLLBACK_LINES = 50000;
 
+/**
+ * Conservative retained-memory estimate per terminal cell. A cell needs more
+ * than its visible code point once xterm attributes and JavaScript storage are
+ * included, so scrollback is coupled to the byte budget with this multiplier.
+ */
+const ESTIMATED_BYTES_PER_TERMINAL_CELL = 8;
+
 /** Derive the effective xterm scrollback without exceeding the byte budget. */
 function deriveScrollbackFromBudget(
   budget: ByteBudget,
@@ -59,7 +66,9 @@ function deriveScrollbackFromBudget(
 ): number {
   const effectiveCols = Math.max(cols, 1);
   const budgetLineLimit = Math.min(
-    Math.floor(budget.bytes / (effectiveCols * 8)),
+    Math.floor(
+      budget.bytes / (effectiveCols * ESTIMATED_BYTES_PER_TERMINAL_CELL),
+    ),
     MAX_SCROLLBACK_LINES,
   );
   const requested = Number.isFinite(configuredScrollback)
@@ -156,7 +165,7 @@ export function createPtyResultPromise(
     processingChain: Promise.resolve(),
     pendingQueueBytes: 0,
     pendingQueueItems: 0,
-    supportsBackpressure: ptyInfo.name !== 'bun-pty',
+    supportsBackpressure: ptyInfo.supportsBackpressure,
     backpressurePaused: false,
     queueOverflowed: false,
     ...createTerminalTrackingState(effectiveScrollback, rows),

--- a/packages/core/src/services/shellPtySignal.bun.test.ts
+++ b/packages/core/src/services/shellPtySignal.bun.test.ts
@@ -46,6 +46,7 @@ await mock.module('../utils/getPty.js', () => ({
   getPty: async () => ({
     module: { spawn: () => fakePty },
     name: 'mock-pty',
+    supportsBackpressure: true,
   }),
 }));
 
@@ -73,6 +74,23 @@ function buildFakePty(): FakePty {
   pty.emitExit = (exit: FakePtyExit) => exitHandler(exit);
   return pty;
 }
+function waitForResult<T>(result: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for PTY exit result'));
+    }, 2000);
+    void result.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
 
 /** Drives the PTY path to completion with the given onExit payload. */
 async function executeAndExit(
@@ -90,7 +108,7 @@ async function executeAndExit(
   // Let the spawn + handler registration settle before firing exit.
   await new Promise((resolve) => setImmediate(resolve));
   fakePty.emitExit(payload);
-  const result = await handle.result;
+  const result = await waitForResult(handle.result);
   return { exitCode: result.exitCode, signal: result.signal };
 }
 

--- a/packages/core/src/services/shellPtyState.ts
+++ b/packages/core/src/services/shellPtyState.ts
@@ -6,7 +6,6 @@
 
 import type { IPty } from '@lydell/node-pty';
 import type { Terminal } from '@xterm/headless';
-import type { TextDecoder } from 'node:util';
 import type { PtyImplementation } from '../utils/getPty.js';
 import type {
   ShellOutputEvent,
@@ -15,6 +14,7 @@ import type {
 import type { ExitGuard } from './shellExitGuard.js';
 import type { ActivePty } from './shellPtyHelpers.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
+import type { BoundedCombinedCollector } from '@vybestack/llxprt-code-tools/acquisition.js';
 
 /** State bag shared across PTY helper closures. */
 export interface PtyExecState {
@@ -35,9 +35,13 @@ export interface PtyExecState {
   inactivityAbortController: AbortController;
   resetInactivityTimer: () => void;
   exitedGuard: ExitGuard;
-  decoder: TextDecoder | null;
   output: string | AnsiOutput | null;
-  outputChunks: Buffer[];
+  /**
+   * Bounded raw-byte collector replacing the unbounded outputChunks: Buffer[]
+   * array (Issue #3200). Retains a bounded head/tail of PTY output for
+   * rawOutput compatibility without full-size materialization.
+   */
+  rawCollector: BoundedCombinedCollector;
   error: Error | null;
   isStreamingRawContent: boolean;
   sniffedBytes: number;
@@ -46,4 +50,23 @@ export interface PtyExecState {
   hasResolved: boolean;
   abortFinalizeTimeout: NodeJS.Timeout | null;
   processingChain: Promise<void>;
+  /** Bytes queued for ordered xterm processing. */
+  pendingQueueBytes: number;
+  /** Queue entries are bounded separately because tiny chunks retain closures. */
+  pendingQueueItems: number;
+  /** Whether pause/resume provides real producer backpressure. */
+  supportsBackpressure: boolean;
+  backpressurePaused: boolean;
+  queueOverflowed: boolean;
+  /**
+   * Maximum number of lines the xterm buffer can hold (scrollback + rows).
+   * Used to detect scrollback eviction (Issue #3200 finding 3).
+   */
+  terminalMaxBufferLines: number;
+  /** Configured xterm scrollback capacity, excluding visible rows. */
+  terminalScrollbackCapacity: number;
+  /** Whether xterm had already filled its scrollback before the latest scroll. */
+  terminalScrollbackAtCapacity: boolean;
+  /** True once the terminal scrollback has evicted earlier content. */
+  terminalContentEvicted: boolean;
 }

--- a/packages/core/src/tools-adapters/CoreShellToolHostAdapter.ts
+++ b/packages/core/src/tools-adapters/CoreShellToolHostAdapter.ts
@@ -159,6 +159,7 @@ export class CoreShellToolHostAdapter implements IShellToolHost {
       error: result.error,
       aborted: result.aborted,
       pid: result.pid,
+      outputTruncation: result.outputTruncation,
     };
   }
 

--- a/packages/core/src/utils/getPty.test.ts
+++ b/packages/core/src/utils/getPty.test.ts
@@ -50,7 +50,11 @@ describe('getPty', () => {
         loadFallback: () => Promise.resolve(fallbackModule),
       });
 
-      expect(pty).toStrictEqual({ module: fallbackModule, name: 'node-pty' });
+      expect(pty).toStrictEqual({
+        module: fallbackModule,
+        name: 'node-pty',
+        supportsBackpressure: true,
+      });
     });
 
     it('uses @lydell/node-pty when the primary backend loads', async () => {
@@ -64,6 +68,7 @@ describe('getPty', () => {
       expect(pty).toStrictEqual({
         module: primaryModule,
         name: 'lydell-node-pty',
+        supportsBackpressure: true,
       });
     });
   });
@@ -74,6 +79,7 @@ describe('getPty', () => {
       async () => {
         const pty = requirePty(await getPty(), 'bun-pty');
         expect(pty.name).toBe('bun-pty');
+        expect(pty.supportsBackpressure).toBe(false);
         expect(typeof pty.module.spawn).toBe('function');
       },
     );

--- a/packages/core/src/utils/getPty.ts
+++ b/packages/core/src/utils/getPty.ts
@@ -28,6 +28,7 @@ export interface PtyModule {
 export type PtyImplementation = {
   module: PtyModule;
   name: PtyExecutionMethod;
+  supportsBackpressure: boolean;
 } | null;
 
 /**
@@ -55,11 +56,11 @@ export async function loadNodePty(
 ): Promise<PtyImplementation> {
   try {
     const module = await loaders.loadPrimary();
-    return { module, name: 'lydell-node-pty' };
+    return { module, name: 'lydell-node-pty', supportsBackpressure: true };
   } catch {
     try {
       const module = await loaders.loadFallback();
-      return { module, name: 'node-pty' };
+      return { module, name: 'node-pty', supportsBackpressure: true };
     } catch {
       return null;
     }
@@ -83,6 +84,7 @@ export const getPty = async (
         spawn: (file, args, options) => createBunPty(file, args, options),
       },
       name: 'bun-pty',
+      supportsBackpressure: false,
     };
   }
 

--- a/packages/providers/src/runtime/profileApplication.ts
+++ b/packages/providers/src/runtime/profileApplication.ts
@@ -687,6 +687,7 @@ const PRESERVED_PROFILE_EPHEMERALS = [
   'task-max-timeout-seconds',
   'shell-default-timeout-seconds',
   'shell-max-timeout-seconds',
+  'shell-output-retention-max-bytes',
 ];
 
 async function switchProviderForProfile(targetProviderName: string): Promise<{

--- a/packages/settings/src/profiles/types.ts
+++ b/packages/settings/src/profiles/types.ts
@@ -104,6 +104,7 @@ export interface EphemeralSettings {
   'shell-default-timeout-seconds'?: number;
   'shell-max-timeout-seconds'?: number;
   'shell-inactivity-timeout-seconds'?: number;
+  'shell-output-retention-max-bytes'?: number;
   tpm_threshold?: number;
   timeout_ms?: number;
   circuit_breaker_enabled?: boolean;

--- a/packages/settings/src/settings/registry/registry-entries-2.ts
+++ b/packages/settings/src/settings/registry/registry-entries-2.ts
@@ -452,6 +452,27 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
     },
   },
   {
+    key: 'shell-output-retention-max-bytes',
+    category: 'cli-behavior',
+    description:
+      'Maximum bytes of shell output retained in memory during acquisition. Output beyond this is head/tail truncated with a visible notice. Separate from model token limits.',
+    type: 'number',
+    persistToProfile: true,
+    validate: (value: unknown): ValidationResult => {
+      if (
+        typeof value === 'number' &&
+        (value === -1 || (Number.isFinite(value) && value > 0))
+      ) {
+        return { success: true, value };
+      }
+      return {
+        success: false,
+        message:
+          'shell-output-retention-max-bytes must be a positive number in bytes or -1 for the hard maximum',
+      };
+    },
+  },
+  {
     key: 'token-usage-log',
     category: 'cli-behavior',
     description:

--- a/packages/settings/src/settings/registry/registry-entries-2.ts
+++ b/packages/settings/src/settings/registry/registry-entries-2.ts
@@ -455,7 +455,7 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
     key: 'shell-output-retention-max-bytes',
     category: 'cli-behavior',
     description:
-      'Maximum bytes of shell output retained in memory during acquisition. Output beyond this is head/tail truncated with a visible notice. Separate from model token limits.',
+      'Maximum bytes of shell output retained in memory during acquisition. Output beyond this is head/tail truncated with a visible notice. Also constrains PTY display scrollback when its byte-derived limit is lower than ptyScrollbackLimit. Separate from model token limits.',
     type: 'number',
     persistToProfile: true,
     validate: (value: unknown): ValidationResult => {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -66,6 +66,11 @@
       "bun": "./src/utils/timeoutResolution.ts",
       "import": "./dist/src/utils/timeoutResolution.js"
     },
+    "./acquisition.js": {
+      "types": "./dist/src/acquisition/index.d.ts",
+      "bun": "./src/acquisition/index.ts",
+      "import": "./dist/src/acquisition/index.js"
+    },
     "./textDelta.js": {
       "types": "./dist/src/utils/textDelta.d.ts",
       "bun": "./src/utils/textDelta.ts",

--- a/packages/tools/src/__tests__/shell-tool.test.ts
+++ b/packages/tools/src/__tests__/shell-tool.test.ts
@@ -225,7 +225,7 @@ describe('Shell Tool Group Behavioral Tests @plan:PLAN-20260608-ISSUE1585.P10', 
   });
 });
 
-describe('is_background managed job behavior @plan:issue1995', () => {
+describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
   beforeEach(() => {
     mockPlatform.mockReturnValue('darwin');
     mockTmpdir.mockReturnValue('/tmp');
@@ -295,6 +295,44 @@ describe('is_background managed job behavior @plan:issue1995', () => {
       }),
     };
   }
+
+  it('preserves acquisition truncation metadata in the model-facing result', async () => {
+    const outputTruncation = {
+      observedBytes: 2048,
+      retainedBytes: 1024,
+      omittedBytes: 1024,
+      truncated: true as const,
+      budgetBytes: 1024,
+    };
+    const baseHost = createFakeHostWithBackground(() => {
+      throw new Error('Foreground execution must not launch a background job');
+    });
+    const host: IShellToolHost = {
+      ...baseHost,
+      executeShellCommand: async () => ({
+        output: 'head\n[LLXPRT output truncated: 1,024 bytes omitted]\ntail',
+        pid: 123,
+        exitCode: 0,
+        signal: null,
+        error: null,
+        aborted: false,
+        outputTruncation,
+      }),
+    };
+
+    const result = await executeToolForBehavioralAssertion(
+      new ShellTool(
+        host,
+        createFakeMessageBus(ToolConfirmationOutcome.ProceedOnce),
+      ),
+      { command: 'printf bounded' },
+    );
+
+    expect(result.metadata?.['outputTruncation']).toStrictEqual(
+      outputTruncation,
+    );
+    expect(String(result.llmContent)).toContain('LLXPRT output truncated');
+  });
 
   it('is_background: true returns a deterministic job-shaped result with job id, command, and state (T14)', async () => {
     let launched: { command: string; cwd: string } | undefined;

--- a/packages/tools/src/acquisition/boundedCombinedCollector.test.ts
+++ b/packages/tools/src/acquisition/boundedCombinedCollector.test.ts
@@ -1,0 +1,466 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { BoundedCombinedCollector, createByteBudget } from './index.js';
+
+describe('BoundedCombinedCollector - shared stdout/stderr budget', () => {
+  it('retains both stdout and stderr under budget', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(4096),
+    });
+    collector.append(Buffer.from('out1\n'), 'stdout');
+    collector.append(Buffer.from('err1\n'), 'stderr');
+    collector.append(Buffer.from('out2\n'), 'stdout');
+
+    const result = collector.getResult();
+    expect(result.stdoutText).toContain('out1');
+    expect(result.stdoutText).toContain('out2');
+    expect(result.stderrText).toContain('err1');
+    expect(result.metadata.truncated).toBe(false);
+  });
+
+  it('shares one aggregate budget across both streams', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(1024),
+    });
+
+    // Fill budget entirely from stdout.
+    collector.append(Buffer.alloc(768, 65), 'stdout');
+    // Now stderr fills the rest.
+    collector.append(Buffer.alloc(512, 66), 'stderr');
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.observedBytes).toBe(1280);
+    expect(result.metadata.retainedBytes).toBeLessThanOrEqual(1024);
+  });
+
+  it('preserves interleaved arrival order', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(4096),
+    });
+
+    // Interleave stdout and stderr.
+    collector.append(Buffer.from('A'), 'stdout');
+    collector.append(Buffer.from('B'), 'stderr');
+    collector.append(Buffer.from('C'), 'stdout');
+    collector.append(Buffer.from('D'), 'stderr');
+
+    const result = collector.getResult();
+    // The combined text should preserve A, B, C, D order.
+    expect(result.text).toContain('A');
+    expect(result.text).toContain('B');
+    expect(result.text).toContain('C');
+    expect(result.text).toContain('D');
+
+    // Check relative order in combined text.
+    const posA = result.text.indexOf('A');
+    const posB = result.text.indexOf('B');
+    const posC = result.text.indexOf('C');
+    const posD = result.text.indexOf('D');
+    expect(posA).toBeLessThan(posB);
+    expect(posB).toBeLessThan(posC);
+    expect(posC).toBeLessThan(posD);
+  });
+
+  it('preserves stdout/stderr provenance after truncation', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(512),
+    });
+
+    collector.append(Buffer.from('STDOUT_HEAD|'), 'stdout');
+    collector.append(Buffer.alloc(2000, 88), 'stdout'); // 'X' filler
+    collector.append(Buffer.from('|STDERR_HEAD|'), 'stderr');
+    collector.append(Buffer.alloc(2000, 89), 'stderr'); // 'Y' filler
+    collector.append(Buffer.from('|STDOUT_TAIL'), 'stdout');
+    collector.append(Buffer.from('|STDERR_TAIL'), 'stderr');
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    // Provenance preserved: stdoutText only has stdout content.
+    expect(result.stdoutText).not.toContain('STDERR');
+    expect(result.stderrText).not.toContain('STDOUT');
+  });
+});
+
+describe('BoundedCombinedCollector - bounded raw buffer', () => {
+  it('getBoundedRawBuffer never exceeds the budget', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(1024),
+    });
+
+    // Write 100 KiB.
+    for (let i = 0; i < 100; i++) {
+      collector.append(Buffer.alloc(1024, 65 + (i % 26)), 'stdout');
+    }
+
+    const raw = collector.getBoundedRawBuffer();
+    expect(raw.length).toBeLessThanOrEqual(1024);
+  });
+
+  it('getBoundedRawBuffer returns all data when under budget', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(4096),
+    });
+    collector.append(Buffer.from('hello'), 'stdout');
+    collector.append(Buffer.from('world'), 'stderr');
+
+    const raw = collector.getBoundedRawBuffer();
+    expect(raw.toString('utf-8')).toBe('helloworld');
+  });
+
+  it('returns a copied prefix for fixed-size binary sniffing', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(1024),
+    });
+    const source = Buffer.from('abcdef');
+    collector.append(source, 'stdout');
+
+    const head = collector.getHeadBytes(3);
+    source.fill(0);
+
+    expect(head.toString('utf-8')).toBe('abc');
+  });
+});
+
+describe('BoundedCombinedCollector - multibyte and chunk patterns', () => {
+  it('handles UTF-8 multibyte across stream boundaries', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(4096),
+    });
+
+    // Split a multibyte char across stdout/stderr (unusual but valid).
+    collector.append(Buffer.from('hello'), 'stdout');
+    collector.append(Buffer.from([0xe4, 0xb8]), 'stdout'); // 世 partial
+    collector.append(Buffer.from([0x96]), 'stdout'); // 世 complete
+    collector.append(Buffer.from('world'), 'stderr');
+
+    collector.flushAllDecoders();
+    expect(collector.getStdoutText()).toContain('世');
+  });
+
+  it('handles many tiny interleaved chunks', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(1024),
+    });
+
+    for (let i = 0; i < 2000; i++) {
+      const source = i % 2 === 0 ? 'stdout' : 'stderr';
+      collector.append(Buffer.from([65 + (i % 26)]), source);
+    }
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.observedBytes).toBe(2000);
+  });
+});
+
+describe('BoundedCombinedCollector - provenance and arrival order after truncation', () => {
+  it('preserves combined arrival order in text after truncation', () => {
+    // Write a sequence that overflows the budget, then verify the combined
+    // text preserves the arrival order of the retained head and tail.
+    const budget = createByteBudget(1024);
+    const collector = new BoundedCombinedCollector({ budget });
+
+    // Interleave with distinct markers, enough filler to trigger truncation.
+    collector.append(Buffer.from('A1-'), 'stdout');
+    collector.append(Buffer.from('B1-'), 'stderr');
+    // Fill the middle with filler to trigger truncation.
+    collector.append(Buffer.alloc(2048, 88), 'stdout'); // 'X' filler
+    collector.append(Buffer.from('A2-'), 'stdout');
+    collector.append(Buffer.from('B2-'), 'stderr');
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+
+    // Head must preserve A1-B1 order.
+    const posA1 = result.headText.indexOf('A1');
+    const posB1 = result.headText.indexOf('B1');
+    expect(posA1).toBeGreaterThanOrEqual(0);
+    expect(posB1).toBeGreaterThanOrEqual(0);
+    expect(posA1).toBeLessThan(posB1);
+
+    // Tail must preserve A2-B2 order.
+    const posA2 = result.tailText.indexOf('A2');
+    const posB2 = result.tailText.indexOf('B2');
+    expect(posA2).toBeGreaterThanOrEqual(0);
+    expect(posB2).toBeGreaterThanOrEqual(0);
+    expect(posA2).toBeLessThan(posB2);
+  });
+
+  it('preserves stdout/stderr provenance exactly after truncation', () => {
+    const budget = createByteBudget(1024);
+    const collector = new BoundedCombinedCollector({ budget });
+
+    // Head: stdout marker + stderr marker.
+    collector.append(Buffer.from('OUT_HEAD'), 'stdout');
+    collector.append(Buffer.from('ERR_HEAD'), 'stderr');
+    // Overflow filler.
+    collector.append(Buffer.alloc(4096, 70), 'stdout'); // 'F'
+    // Tail: stderr marker + stdout marker.
+    collector.append(Buffer.from('ERR_TAIL'), 'stderr');
+    collector.append(Buffer.from('OUT_TAIL'), 'stdout');
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+
+    // stdoutText must contain ONLY stdout markers.
+    expect(result.stdoutText).toContain('OUT_HEAD');
+    expect(result.stdoutText).toContain('OUT_TAIL');
+    expect(result.stdoutText).not.toContain('ERR');
+
+    // stderrText must contain ONLY stderr markers.
+    expect(result.stderrText).toContain('ERR_HEAD');
+    expect(result.stderrText).toContain('ERR_TAIL');
+    expect(result.stderrText).not.toContain('OUT_');
+  });
+
+  it('no replacement chars at omission boundary in combined text', () => {
+    // Write enough data with multibyte chars to cause truncation.
+    const budget = createByteBudget(1024);
+    const collector = new BoundedCombinedCollector({ budget });
+
+    // Build large multibyte-heavy content from both streams.
+    const segment = 'AAAAA\u4e16\u4e16\u4e16';
+    // 50 segments * 14 bytes = 700 bytes from stdout + 700 from stderr = 1400 > 1024.
+    collector.append(Buffer.from(segment.repeat(50), 'utf-8'), 'stdout');
+    collector.append(Buffer.from(segment.repeat(50), 'utf-8'), 'stderr');
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    // No replacement characters anywhere.
+    expect(result.text).not.toContain('\uFFFD');
+    expect(result.stdoutText).not.toContain('\uFFFD');
+    expect(result.stderrText).not.toContain('\uFFFD');
+  });
+});
+
+describe('BoundedCombinedCollector - byte-copy isolation', () => {
+  it('copies bytes so a huge source Buffer is not retained', () => {
+    const budget = createByteBudget(2048);
+    const collector = new BoundedCombinedCollector({ budget });
+
+    const huge = Buffer.alloc(512 * 1024, 65); // 'A', 512 KiB
+    huge.write('HEADSTART', 0);
+    collector.append(huge, 'stdout');
+
+    // Mutate the source buffer.
+    huge.fill(90); // 'Z'
+
+    const result = collector.getResult();
+    // Retained head must still show the original data.
+    expect(result.stdoutText).toContain('HEADSTART');
+    expect(result.stdoutText).not.toMatch(/Z{10,}/);
+  });
+
+  it('getBoundedRawBuffer copies bytes (not subarray)', () => {
+    const budget = createByteBudget(1024);
+    const collector = new BoundedCombinedCollector({ budget });
+
+    const huge = Buffer.alloc(256 * 1024, 66); // 'B'
+    huge.write('XYZ', 0);
+    collector.append(huge, 'stdout');
+
+    const raw = collector.getBoundedRawBuffer();
+    expect(raw.length).toBeLessThanOrEqual(1024);
+
+    // Mutate source — raw must be unaffected.
+    huge.fill(90);
+    expect(raw.toString('utf-8', 0, 3)).toBe('XYZ');
+  });
+});
+
+describe('BoundedCombinedCollector - 50k tiny chunks (ring correctness)', () => {
+  it('handles 50k tiny interleaved chunks with correct tail content', () => {
+    const budget = createByteBudget(2048);
+    const collector = new BoundedCombinedCollector({ budget });
+
+    for (let i = 0; i < 50_000; i++) {
+      const source = i % 3 === 0 ? 'stderr' : 'stdout';
+      collector.append(Buffer.from([48 + (i % 10)]), source);
+    }
+
+    const result = collector.getResult();
+    expect(result.metadata.observedBytes).toBe(50_000);
+    expect(result.metadata.retainedBytes).toBeLessThanOrEqual(2048);
+    // Last written char: i=49999 → 48 + (49999 % 10) = 48 + 9 = '9'.
+    expect(result.text.endsWith('9')).toBe(true);
+    expect(result.text).not.toContain('\uFFFD');
+  });
+});
+
+describe('BoundedCombinedCollector - retained segment boundary', () => {
+  it('decodes complete combined and per-source text across the head/tail split', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(1024),
+    });
+    const output = `${'x'.repeat(511)}tail`;
+
+    collector.append(Buffer.from(output), 'stdout');
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(false);
+    expect(result.text).toBe(output);
+    expect(result.stdoutText).toBe(output);
+    expect(result.stderrText).toBe('');
+    expect(result.text).not.toContain('?');
+  });
+});
+
+// U+4E16 (shi) = E4 B8 96, U+2605 (star) = E2 98 85. Defined as byte arrays to
+// avoid any literal multibyte characters in source.
+const SHI_BYTES = Buffer.from([0xe4, 0xb8, 0x96]);
+const STAR_BYTES = Buffer.from([0xe2, 0x98, 0x85]);
+const SHI = SHI_BYTES.toString('utf8');
+const STAR = STAR_BYTES.toString('utf8');
+
+describe('BoundedCombinedCollector - independent per-source decoders (issue #3200 finding 5)', () => {
+  it('stderr inserted between split stdout bytes does not corrupt the stdout character', () => {
+    // Split a 3-byte UTF-8 char across stdout with a stderr byte in the middle.
+    // A single shared decoder would emit U+FFFD for stdout because the stderr
+    // byte (0x58) interrupts the multibyte sequence. Independent per-source
+    // decoders reassemble the char correctly.
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(4096),
+    });
+    collector.append(Buffer.from([SHI_BYTES[0]]), 'stdout');
+    collector.append(Buffer.from('X'), 'stderr');
+    collector.append(Buffer.from([SHI_BYTES[1], SHI_BYTES[2]]), 'stdout');
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(false);
+    expect(result.stdoutText).toBe(SHI);
+    expect(result.stderrText).toBe('X');
+    expect(result.stdoutText).not.toContain('\uFFFD');
+    expect(result.text).toContain(SHI);
+    expect(result.text).toContain('X');
+    expect(result.text).not.toContain('\uFFFD');
+  });
+
+  it('repeated interleaving of single bytes across sources decodes each source intact', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(4096),
+    });
+    for (let i = 0; i < SHI_BYTES.length; i++) {
+      collector.append(Buffer.from([SHI_BYTES[i]]), 'stdout');
+      collector.append(Buffer.from([STAR_BYTES[i]]), 'stderr');
+    }
+    const result = collector.getResult();
+    expect(result.stdoutText).toBe(SHI);
+    expect(result.stderrText).toBe(STAR);
+    expect(result.stdoutText).not.toContain('\uFFFD');
+    expect(result.stderrText).not.toContain('\uFFFD');
+  });
+
+  it('a multibyte char straddling the head/tail omission boundary is trimmed, not corrupted', () => {
+    // budget 1024 -> head 512, tail 512. Place a 3-byte char (E4 B8 96) so the
+    // lead byte is the last head byte and the continuation bytes begin the tail,
+    // then append enough filler to push observed just past the budget. The lead
+    // byte is trimmed from the head tail; the surviving continuation byte at the
+    // tail start is trimmed from the tail head. The split char is dropped
+    // entirely (it is omitted anyway) rather than emitted as replacement chars.
+    const budget = createByteBudget(1024);
+    const collector = new BoundedCombinedCollector({ budget });
+    collector.append(Buffer.alloc(511, 65), 'stdout'); // bytes 0-510 (head fill)
+    collector.append(SHI_BYTES, 'stdout'); // byte 511 -> head (full); 512,513 -> tail
+    collector.append(Buffer.alloc(511, 66), 'stdout'); // bytes 514-1024 -> tail
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.observedBytes).toBe(1025);
+    // No replacement characters: boundary trimming drops the split char.
+    expect(result.stdoutText).not.toContain('\uFFFD');
+    expect(result.text).not.toContain('\uFFFD');
+    // Head retains the leading A's, tail retains the trailing B's.
+    expect(result.headText).toMatch(/^A+$/);
+    expect(result.tailText).toMatch(/^B+$/);
+  });
+});
+
+describe('BoundedCombinedCollector - structural / peak allocation bounds (issue #3200 finding 5)', () => {
+  it('peak retained bytes never exceed the budget under massive source switching', () => {
+    // The run-based design retains only the budget regardless of source-switch
+    // count; the old per-byte-tag design would allocate a tag array as large as
+    // the observed bytes.
+    const budget = createByteBudget(2048);
+    const collector = new BoundedCombinedCollector({ budget });
+    for (let i = 0; i < 524_288; i++) {
+      collector.append(
+        Buffer.from([65 + (i % 26)]),
+        i % 2 === 0 ? 'stdout' : 'stderr',
+      );
+    }
+    const result = collector.getResult();
+    expect(result.metadata.retainedBytes).toBeLessThanOrEqual(budget.bytes);
+    expect(result.metadata.observedBytes).toBe(524_288);
+    expect(collector.getBoundedRawBuffer().length).toBeLessThanOrEqual(
+      budget.bytes,
+    );
+    expect(result.metadata.truncated).toBe(true);
+  });
+
+  it('a single huge chunk retains only the budget (huge-chunk efficiency)', () => {
+    const budget = createByteBudget(1024);
+    const collector = new BoundedCombinedCollector({ budget });
+    collector.append(Buffer.alloc(8 * 1024 * 1024, 90), 'stdout');
+
+    const result = collector.getResult();
+    expect(result.metadata.retainedBytes).toBeLessThanOrEqual(budget.bytes);
+    expect(result.metadata.observedBytes).toBe(8 * 1024 * 1024);
+    expect(collector.getBoundedRawBuffer().length).toBeLessThanOrEqual(
+      budget.bytes,
+    );
+  });
+
+  it('does not materialize full-budget copies repeatedly for raw + result', () => {
+    const budget = createByteBudget(2048);
+    const collector = new BoundedCombinedCollector({ budget });
+    collector.append(Buffer.alloc(4096, 67), 'stdout');
+
+    const r1 = collector.getResult();
+    const raw1 = collector.getBoundedRawBuffer();
+    const r2 = collector.getResult();
+    const raw2 = collector.getBoundedRawBuffer();
+
+    expect(raw1.length).toBe(raw2.length);
+    expect(raw1.equals(raw2)).toBe(true);
+    expect(r1.metadata.retainedBytes).toBe(r2.metadata.retainedBytes);
+    expect(raw1.length).toBeLessThanOrEqual(budget.bytes);
+  });
+
+  it('exact metadata: observed/retained/omitted are precise after interleaved truncation', () => {
+    const budget = createByteBudget(1024);
+    const collector = new BoundedCombinedCollector({ budget });
+    collector.append(Buffer.alloc(300, 65), 'stdout');
+    collector.append(Buffer.alloc(300, 66), 'stderr');
+    collector.append(Buffer.alloc(300, 67), 'stdout');
+    collector.append(Buffer.alloc(300, 68), 'stderr');
+
+    const result = collector.getResult();
+    expect(result.metadata.observedBytes).toBe(1200);
+    expect(result.metadata.retainedBytes).toBeLessThanOrEqual(budget.bytes);
+    expect(result.metadata.omittedBytes).toBe(
+      result.metadata.observedBytes - result.metadata.retainedBytes,
+    );
+    expect(result.metadata.truncated).toBe(true);
+  });
+
+  it('materializes a head-only collector without tail modulo arithmetic', () => {
+    const budget = createByteBudget(1024);
+    const collector = new BoundedCombinedCollector({
+      budget,
+      headFraction: 1,
+    });
+
+    collector.append(Buffer.alloc(2048, 65), 'stdout');
+
+    const result = collector.getResult();
+    expect(result.metadata.retainedBytes).toBe(budget.bytes);
+    expect(result.metadata.omittedBytes).toBe(budget.bytes);
+    expect(result.stdoutText.startsWith('A')).toBe(true);
+  });
+});

--- a/packages/tools/src/acquisition/boundedCombinedCollector.ts
+++ b/packages/tools/src/acquisition/boundedCombinedCollector.ts
@@ -1,0 +1,514 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TextDecoder } from 'node:util';
+import { DEFAULT_OMISSION_NOTICE } from './boundedStreamCollector.js';
+import {
+  completeUtf8PrefixLength,
+  completeUtf8SuffixStart,
+} from './utf8Boundaries.js';
+import type {
+  ByteBudget,
+  CombinedAcquisitionResult,
+  StreamSource,
+  TruncationMetadata,
+} from './types.js';
+
+export interface BoundedCombinedCollectorOptions {
+  budget: ByteBudget;
+  encoding?: string;
+  headFraction?: number;
+}
+
+interface TaggedBytes {
+  readonly bytes: Buffer;
+  readonly stderrBits: Uint8Array;
+}
+
+const OUTPUT_BLOCK_SIZE = 64 * 1024;
+
+function normalizedEncoding(encoding: string): string {
+  const normalized = encoding.toLowerCase();
+  if (normalized === 'utf8') {
+    return 'utf-8';
+  }
+  if (
+    normalized === 'ucs-2' ||
+    normalized === 'ucs2' ||
+    normalized === 'utf16le'
+  ) {
+    return 'utf-16le';
+  }
+  return normalized === 'binary' ? 'latin1' : normalized;
+}
+
+function nodeBufferEncoding(encoding: string): BufferEncoding | undefined {
+  const normalized = normalizedEncoding(encoding);
+  if (normalized === 'utf-8') {
+    return 'utf8';
+  }
+  if (normalized === 'utf-16le') {
+    return 'utf16le';
+  }
+  return Buffer.isEncoding(normalized) ? normalized : undefined;
+}
+
+function encode(text: string, encoding: string): Buffer {
+  return Buffer.from(text, nodeBufferEncoding(encoding) ?? 'utf8');
+}
+
+function sourceBit(source: StreamSource): number {
+  return source === 'stderr' ? 1 : 0;
+}
+
+function getBit(bits: Uint8Array, index: number): number {
+  return (bits[index >>> 3] >>> (index & 7)) & 1;
+}
+
+function setBit(bits: Uint8Array, index: number, value: number): void {
+  const byteIndex = index >>> 3;
+  const mask = 1 << (index & 7);
+  if (value === 1) {
+    bits[byteIndex] |= mask;
+  } else {
+    bits[byteIndex] &= ~mask;
+  }
+}
+
+function fillBits(
+  bits: Uint8Array,
+  start: number,
+  length: number,
+  value: number,
+): void {
+  const end = start + length;
+  let index = start;
+  while (index < end && (index & 7) !== 0) {
+    setBit(bits, index, value);
+    index += 1;
+  }
+  const fullByteEnd = end - (end & 7);
+  if (index < fullByteEnd) {
+    bits.fill(value === 1 ? 0xff : 0, index >>> 3, fullByteEnd >>> 3);
+    index = fullByteEnd;
+  }
+  while (index < end) {
+    setBit(bits, index, value);
+    index += 1;
+  }
+}
+
+function trimTrailingBoundary(bytes: Buffer, encoding: string): Buffer {
+  if (encoding === 'utf-8') {
+    return bytes.subarray(0, completeUtf8PrefixLength(bytes));
+  }
+  if (encoding === 'utf-16le') {
+    let length = bytes.length - (bytes.length % 2);
+    if (
+      length >= 2 &&
+      bytes.readUInt16LE(length - 2) >= 0xd800 &&
+      bytes.readUInt16LE(length - 2) <= 0xdbff
+    ) {
+      length -= 2;
+    }
+    return bytes.subarray(0, length);
+  }
+  return bytes;
+}
+
+function trimLeadingBoundary(bytes: Buffer, encoding: string): Buffer {
+  if (encoding === 'utf-8') {
+    return bytes.subarray(completeUtf8SuffixStart(bytes));
+  }
+  if (encoding === 'utf-16le') {
+    let start = bytes.length % 2;
+    if (bytes.length - start >= 2) {
+      const codeUnit = bytes.readUInt16LE(start);
+      if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+        start += 2;
+      }
+    }
+    return bytes.subarray(start);
+  }
+  return bytes;
+}
+
+class StringAccumulator {
+  private readonly blocks: string[] = [];
+  private pending = '';
+
+  append(value: string): void {
+    if (value === '') {
+      return;
+    }
+    this.pending += value;
+    if (this.pending.length >= OUTPUT_BLOCK_SIZE) {
+      this.blocks.push(this.pending);
+      this.pending = '';
+    }
+  }
+
+  toString(): string {
+    if (this.pending !== '') {
+      this.blocks.push(this.pending);
+      this.pending = '';
+    }
+    return this.blocks.join('');
+  }
+}
+
+function countSource(tagged: TaggedBytes, source: StreamSource): number {
+  const wanted = sourceBit(source);
+  let count = 0;
+  for (let index = 0; index < tagged.bytes.length; index += 1) {
+    if (getBit(tagged.stderrBits, index) === wanted) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function extractSource(tagged: TaggedBytes, source: StreamSource): Buffer {
+  const output = Buffer.allocUnsafe(countSource(tagged, source));
+  const wanted = sourceBit(source);
+  let outputIndex = 0;
+  for (let index = 0; index < tagged.bytes.length; index += 1) {
+    if (getBit(tagged.stderrBits, index) === wanted) {
+      output[outputIndex] = tagged.bytes[index];
+      outputIndex += 1;
+    }
+  }
+  return output;
+}
+
+function decodeSourceRegions(
+  head: Buffer,
+  tail: Buffer,
+  encoding: string,
+  truncated: boolean,
+): string {
+  if (!truncated) {
+    const decoder = new TextDecoder(encoding, { fatal: false });
+    return decoder.decode(head, { stream: true }) + decoder.decode(tail);
+  }
+  const safeHead = trimTrailingBoundary(head, encoding);
+  const safeTail = trimLeadingBoundary(tail, encoding);
+  return (
+    new TextDecoder(encoding, { fatal: false }).decode(safeHead) +
+    new TextDecoder(encoding, { fatal: false }).decode(safeTail)
+  );
+}
+
+function decodeTagged(
+  tagged: TaggedBytes,
+  encoding: string,
+  options: { flush: boolean; stdoutSkip?: number; stderrSkip?: number },
+): string {
+  const decoders = {
+    stdout: new TextDecoder(encoding, { fatal: false }),
+    stderr: new TextDecoder(encoding, { fatal: false }),
+  };
+  const accumulator = new StringAccumulator();
+  const skipped = {
+    stdout: options.stdoutSkip ?? 0,
+    stderr: options.stderrSkip ?? 0,
+  };
+  let index = 0;
+  while (index < tagged.bytes.length) {
+    const bit = getBit(tagged.stderrBits, index);
+    const source: StreamSource = bit === 1 ? 'stderr' : 'stdout';
+    let runEnd = index + 1;
+    while (
+      runEnd < tagged.bytes.length &&
+      getBit(tagged.stderrBits, runEnd) === bit
+    ) {
+      runEnd += 1;
+    }
+    const skip = Math.min(skipped[source], runEnd - index);
+    skipped[source] -= skip;
+    const decodeStart = index + skip;
+    if (decodeStart < runEnd) {
+      accumulator.append(
+        decoders[source].decode(tagged.bytes.subarray(decodeStart, runEnd), {
+          stream: true,
+        }),
+      );
+    }
+    index = runEnd;
+  }
+  if (options.flush) {
+    accumulator.append(decoders.stdout.decode());
+    accumulator.append(decoders.stderr.decode());
+  }
+  return accumulator.toString();
+}
+
+/**
+ * Retains one ordered byte budget across stdout and stderr.
+ *
+ * Provenance uses one bit per retained byte, so even pathological bytewise
+ * source alternation has fixed overhead of budget / 8 instead of one object or
+ * byte-sized tag per retained byte. Decoding uses independent streaming
+ * decoders per source while preserving the retained combined arrival order.
+ */
+export class BoundedCombinedCollector {
+  private readonly budget: ByteBudget;
+  private readonly encoding: string;
+  private readonly headCapacity: number;
+  private readonly tailCapacity: number;
+  private readonly headBytes: Buffer;
+  private readonly headStderrBits: Uint8Array;
+  private headLength = 0;
+  private readonly tailBytes: Buffer;
+  private readonly tailStderrBits: Uint8Array;
+  private tailWritePosition = 0;
+  private tailLength = 0;
+  private observedBytes = 0;
+  private cachedTail: TaggedBytes | null = null;
+
+  constructor(options: BoundedCombinedCollectorOptions) {
+    this.budget = options.budget;
+    this.encoding = normalizedEncoding(options.encoding ?? 'utf8');
+    const fraction = Math.min(Math.max(options.headFraction ?? 0.5, 0), 1);
+    this.headCapacity = Math.floor(this.budget.bytes * fraction);
+    this.tailCapacity = this.budget.bytes - this.headCapacity;
+    this.headBytes = Buffer.allocUnsafe(this.headCapacity);
+    this.headStderrBits = new Uint8Array(Math.ceil(this.headCapacity / 8));
+    this.tailBytes = Buffer.allocUnsafe(this.tailCapacity);
+    this.tailStderrBits = new Uint8Array(Math.ceil(this.tailCapacity / 8));
+  }
+
+  get observedByteCount(): number {
+    return this.observedBytes;
+  }
+
+  append(chunk: Buffer | string, source: StreamSource): void {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : encode(chunk, this.encoding);
+    if (bytes.length === 0) {
+      return;
+    }
+    this.observedBytes += bytes.length;
+    this.cachedTail = null;
+
+    const headTake = Math.min(
+      bytes.length,
+      this.headCapacity - this.headLength,
+    );
+    if (headTake > 0) {
+      bytes.copy(this.headBytes, this.headLength, 0, headTake);
+      fillBits(
+        this.headStderrBits,
+        this.headLength,
+        headTake,
+        sourceBit(source),
+      );
+      this.headLength += headTake;
+    }
+    if (headTake < bytes.length) {
+      this.appendTail(bytes.subarray(headTake), source);
+    }
+  }
+
+  flushAllDecoders(): void {
+    // Decoding is intentionally deferred until a bounded result is requested.
+  }
+
+  getStdoutText(): string {
+    return this.getResult().stdoutText;
+  }
+
+  getStderrText(): string {
+    return this.getResult().stderrText;
+  }
+
+  getHeadBytes(maxBytes: number): Buffer {
+    const length = Math.min(Math.max(Math.floor(maxBytes), 0), this.headLength);
+    const output = Buffer.allocUnsafe(length);
+    this.headBytes.copy(output, 0, 0, length);
+    return output;
+  }
+
+  getBoundedRawBuffer(): Buffer {
+    const head = this.headTagged().bytes;
+    const tail = this.materializeTail().bytes;
+    const output = Buffer.allocUnsafe(head.length + tail.length);
+    head.copy(output, 0);
+    tail.copy(output, head.length);
+    return output;
+  }
+
+  getResult(): CombinedAcquisitionResult {
+    const head = this.headTagged();
+    const tail = this.materializeTail();
+    const retainedBytes = head.bytes.length + tail.bytes.length;
+    const omittedBytes = Math.max(0, this.observedBytes - retainedBytes);
+    const truncated = omittedBytes > 0;
+    const metadata: TruncationMetadata = {
+      observedBytes: this.observedBytes,
+      retainedBytes,
+      omittedBytes,
+      truncated,
+      budgetBytes: this.budget.bytes,
+    };
+    const omissionNotice = truncated
+      ? `[${DEFAULT_OMISSION_NOTICE}: ${omittedBytes.toLocaleString('en-US')} bytes omitted]`
+      : null;
+
+    const decoded = this.decodeCombined(head, tail, truncated);
+    const stdoutHead = extractSource(head, 'stdout');
+    const stdoutTail = extractSource(tail, 'stdout');
+    const stderrHead = extractSource(head, 'stderr');
+    const stderrTail = extractSource(tail, 'stderr');
+
+    return {
+      text: truncated
+        ? `${decoded.headText}\n\n${omissionNotice}\n\n${decoded.tailText}`
+        : decoded.headText,
+      headText: decoded.headText,
+      tailText: decoded.tailText,
+      metadata,
+      omissionNotice,
+      stdoutText: decodeSourceRegions(
+        stdoutHead,
+        stdoutTail,
+        this.encoding,
+        truncated,
+      ),
+      stderrText: decodeSourceRegions(
+        stderrHead,
+        stderrTail,
+        this.encoding,
+        truncated,
+      ),
+    };
+  }
+
+  private appendTail(bytes: Buffer, source: StreamSource): void {
+    if (this.tailCapacity === 0) {
+      return;
+    }
+    const retainedLength = Math.min(bytes.length, this.tailCapacity);
+    const sourceOffset = bytes.length - retainedLength;
+    const skipped = sourceOffset;
+    const writeStart = (this.tailWritePosition + skipped) % this.tailCapacity;
+    this.writeTailSlice(
+      bytes,
+      sourceOffset,
+      retainedLength,
+      writeStart,
+      source,
+    );
+    this.tailWritePosition =
+      (this.tailWritePosition + bytes.length) % this.tailCapacity;
+    this.tailLength = Math.min(
+      this.tailCapacity,
+      this.tailLength + bytes.length,
+    );
+  }
+
+  private writeTailSlice(
+    sourceBytes: Buffer,
+    sourceOffset: number,
+    length: number,
+    writeStart: number,
+    source: StreamSource,
+  ): void {
+    const firstLength = Math.min(length, this.tailCapacity - writeStart);
+    sourceBytes.copy(
+      this.tailBytes,
+      writeStart,
+      sourceOffset,
+      sourceOffset + firstLength,
+    );
+    fillBits(this.tailStderrBits, writeStart, firstLength, sourceBit(source));
+    const remaining = length - firstLength;
+    if (remaining > 0) {
+      sourceBytes.copy(
+        this.tailBytes,
+        0,
+        sourceOffset + firstLength,
+        sourceOffset + length,
+      );
+      fillBits(this.tailStderrBits, 0, remaining, sourceBit(source));
+    }
+  }
+
+  private headTagged(): TaggedBytes {
+    return {
+      bytes: this.headBytes.subarray(0, this.headLength),
+      stderrBits: this.headStderrBits,
+    };
+  }
+
+  private materializeTail(): TaggedBytes {
+    if (this.cachedTail !== null) {
+      return this.cachedTail;
+    }
+    if (this.tailCapacity === 0 || this.tailLength === 0) {
+      this.cachedTail = {
+        bytes: Buffer.alloc(0),
+        stderrBits: new Uint8Array(0),
+      };
+      return this.cachedTail;
+    }
+    const bytes = Buffer.allocUnsafe(this.tailLength);
+    const stderrBits = new Uint8Array(Math.ceil(this.tailLength / 8));
+    const start =
+      (this.tailWritePosition - this.tailLength + this.tailCapacity) %
+      this.tailCapacity;
+    for (let index = 0; index < this.tailLength; index += 1) {
+      const ringIndex = (start + index) % this.tailCapacity;
+      bytes[index] = this.tailBytes[ringIndex];
+      setBit(stderrBits, index, getBit(this.tailStderrBits, ringIndex));
+    }
+    this.cachedTail = { bytes, stderrBits };
+    return this.cachedTail;
+  }
+
+  private decodeCombined(
+    head: TaggedBytes,
+    tail: TaggedBytes,
+    truncated: boolean,
+  ): { headText: string; tailText: string } {
+    if (!truncated) {
+      const bytes = Buffer.allocUnsafe(head.bytes.length + tail.bytes.length);
+      const stderrBits = new Uint8Array(Math.ceil(bytes.length / 8));
+      head.bytes.copy(bytes, 0);
+      tail.bytes.copy(bytes, head.bytes.length);
+      for (let index = 0; index < head.bytes.length; index += 1) {
+        setBit(stderrBits, index, getBit(head.stderrBits, index));
+      }
+      for (let index = 0; index < tail.bytes.length; index += 1) {
+        setBit(
+          stderrBits,
+          head.bytes.length + index,
+          getBit(tail.stderrBits, index),
+        );
+      }
+      return {
+        headText: decodeTagged({ bytes, stderrBits }, this.encoding, {
+          flush: true,
+        }),
+        tailText: '',
+      };
+    }
+
+    const stdoutTail = extractSource(tail, 'stdout');
+    const stderrTail = extractSource(tail, 'stderr');
+    return {
+      headText: decodeTagged(head, this.encoding, { flush: false }),
+      tailText: decodeTagged(tail, this.encoding, {
+        flush: true,
+        stdoutSkip:
+          stdoutTail.length -
+          trimLeadingBoundary(stdoutTail, this.encoding).length,
+        stderrSkip:
+          stderrTail.length -
+          trimLeadingBoundary(stderrTail, this.encoding).length,
+      }),
+    };
+  }
+}

--- a/packages/tools/src/acquisition/boundedStreamCollector.test.ts
+++ b/packages/tools/src/acquisition/boundedStreamCollector.test.ts
@@ -1,0 +1,589 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  BoundedStreamCollector,
+  createByteBudget,
+  ACQUISITION_HARD_MAX_BYTES,
+  resolveByteBudgetFromSetting,
+  DEFAULT_ACQUISITION_BUDGET_BYTES,
+} from './index.js';
+
+describe('ByteBudget', () => {
+  it('creates a valid budget from a positive number', () => {
+    const budget = createByteBudget(1024 * 1024);
+    expect(budget.bytes).toBe(1024 * 1024);
+  });
+
+  it('rejects zero', () => {
+    expect(() => createByteBudget(0)).toThrow(/finite positive/);
+  });
+
+  it('rejects negative', () => {
+    expect(() => createByteBudget(-100)).toThrow(/finite positive/);
+  });
+
+  it('rejects NaN', () => {
+    expect(() => createByteBudget(NaN)).toThrow(/finite positive/);
+  });
+
+  it('rejects Infinity', () => {
+    expect(() => createByteBudget(Infinity)).toThrow(/finite positive/);
+  });
+
+  it('clamps to the hard max', () => {
+    const budget = createByteBudget(ACQUISITION_HARD_MAX_BYTES * 10);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('enforces a minimum of 1024 bytes', () => {
+    const budget = createByteBudget(100);
+    expect(budget.bytes).toBe(1024);
+  });
+});
+
+describe('ByteBudget - absolute hard-max invariants (issue #3200 finding 10)', () => {
+  it('clamps a custom hardMax above 64 MiB down to the absolute ceiling', () => {
+    // A caller passing a giant hardMax must still get a budget <= 64 MiB.
+    const budget = createByteBudget(200 * 1024 * 1024, 500 * 1024 * 1024);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('never exceeds 64 MiB for any finite hardMax value', () => {
+    const ceilings = [
+      128 * 1024 * 1024,
+      256 * 1024 * 1024,
+      1024 * 1024 * 1024,
+      Number.MAX_SAFE_INTEGER,
+    ];
+    for (const ceiling of ceilings) {
+      const budget = createByteBudget(ceiling, ceiling);
+      expect(budget.bytes).toBeLessThanOrEqual(ACQUISITION_HARD_MAX_BYTES);
+    }
+  });
+
+  it('ignores a non-finite or nonpositive hardMax, falling back to the absolute ceiling', () => {
+    expect(createByteBudget(8192, NaN).bytes).toBe(8192);
+    expect(createByteBudget(8192, -1).bytes).toBe(8192);
+    expect(createByteBudget(8192, 0).bytes).toBe(8192);
+    expect(createByteBudget(8192, Infinity).bytes).toBe(8192);
+  });
+
+  it('never produces a budget below 1024 even when hardMax is below the floor', () => {
+    // A custom hardMax below 1024 must NOT let the result violate the 1024
+    // minimum (issue #3200 finding 10). The floor wins over a sub-1024 ceiling.
+    expect(createByteBudget(100, 500).bytes).toBe(1024);
+    expect(createByteBudget(1, 1).bytes).toBe(1024);
+    expect(createByteBudget(50, 100).bytes).toBe(1024);
+  });
+
+  it('clamps a requested value above a valid sub-HARD_MAX ceiling down to that ceiling', () => {
+    // hardMax=4096 is a valid ceiling; a request above it is clamped to 4096.
+    expect(createByteBudget(999_999, 4096).bytes).toBe(4096);
+    // A request below the ceiling but above the floor is honored.
+    expect(createByteBudget(2048, 4096).bytes).toBe(2048);
+  });
+
+  it('the result always lies in [1024, HARD_MAX] for any finite inputs', () => {
+    const cases: Array<[number, number]> = [
+      [1, 1],
+      [0, 0],
+      [500, 500],
+      [1024, 1024],
+      [2048, 4096],
+      [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
+      [Number.MAX_SAFE_INTEGER, 1],
+    ];
+    for (const [bytes, hardMax] of cases) {
+      // createByteBudget throws on nonpositive bytes; only test positive bytes.
+      if (bytes <= 0 || !Number.isFinite(bytes)) {
+        continue;
+      }
+      const budget = createByteBudget(bytes, hardMax);
+      expect(budget.bytes).toBeGreaterThanOrEqual(1024);
+      expect(budget.bytes).toBeLessThanOrEqual(ACQUISITION_HARD_MAX_BYTES);
+    }
+  });
+
+  it('produces a runtime-immutable (frozen) budget', () => {
+    const budget = createByteBudget(8192);
+    expect(Object.isFrozen(budget)).toBe(true);
+    // Mutation is a no-op in non-strict mode and throws in strict mode.
+    expect(() => {
+      (budget as { bytes: number }).bytes = 999;
+    }).toThrow('Attempted to assign to readonly property.');
+    expect(budget.bytes).toBe(8192);
+  });
+
+  it('resolveByteBudgetFromSetting respects the absolute ceiling even with a custom hardMax', () => {
+    const budget = resolveByteBudgetFromSetting(-1, 999 * 1024 * 1024);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('resolveByteBudgetFromSetting falls back to default for undefined', () => {
+    const budget = resolveByteBudgetFromSetting(undefined);
+    expect(budget.bytes).toBe(DEFAULT_ACQUISITION_BUDGET_BYTES);
+  });
+
+  it('resolveByteBudgetFromSetting falls back to default for invalid string', () => {
+    const budget = resolveByteBudgetFromSetting('not-a-number');
+    expect(budget.bytes).toBe(DEFAULT_ACQUISITION_BUDGET_BYTES);
+  });
+
+  it('resolveByteBudgetFromSetting falls back to default for nonnumeric disabled values', () => {
+    expect(resolveByteBudgetFromSetting(false).bytes).toBe(
+      DEFAULT_ACQUISITION_BUDGET_BYTES,
+    );
+    expect(resolveByteBudgetFromSetting('').bytes).toBe(
+      DEFAULT_ACQUISITION_BUDGET_BYTES,
+    );
+  });
+
+  it('resolveByteBudgetFromSetting parses valid string', () => {
+    const budget = resolveByteBudgetFromSetting('8388608');
+    expect(budget.bytes).toBe(8388608);
+  });
+
+  it('resolveByteBudgetFromSetting uses hard max for -1 (disabled)', () => {
+    const budget = resolveByteBudgetFromSetting(-1);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('resolveByteBudgetFromSetting accepts a serialized -1', () => {
+    const budget = resolveByteBudgetFromSetting('-1');
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('resolveByteBudgetFromSetting clamps above hard max', () => {
+    const budget = resolveByteBudgetFromSetting(999_999_999);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+});
+
+describe('BoundedStreamCollector - finite overflow', () => {
+  it('retains all output when under budget', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(4096),
+    });
+    collector.append(Buffer.from('hello world'));
+    const result = collector.getResult();
+    expect(result.text).toBe('hello world');
+    expect(result.metadata.truncated).toBe(false);
+    expect(result.metadata.observedBytes).toBe(11);
+    expect(result.metadata.retainedBytes).toBe(11);
+    expect(result.metadata.omittedBytes).toBe(0);
+    expect(result.omissionNotice).toBeNull();
+  });
+
+  it('truncates with bounded head/tail and accurate metadata', () => {
+    const budget = createByteBudget(2048);
+    const collector = new BoundedStreamCollector({ budget });
+
+    // Write 8 KiB total in 1024-byte chunks.
+    for (let i = 0; i < 8; i++) {
+      collector.append(Buffer.alloc(1024, 65 + i)); // A, B, C, D, ...
+    }
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.observedBytes).toBe(8192);
+    expect(result.metadata.retainedBytes).toBeLessThanOrEqual(budget.bytes);
+    expect(result.metadata.omittedBytes).toBe(
+      8192 - result.metadata.retainedBytes,
+    );
+    expect(result.omissionNotice).not.toBeNull();
+    expect(result.omissionNotice).toContain('truncated');
+    expect(result.omissionNotice).toContain(
+      result.metadata.omittedBytes.toLocaleString('en-US'),
+    );
+  });
+
+  it('head contains the beginning of output', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(1024),
+    });
+    collector.append(Buffer.from('HEAD_START|'));
+    for (let i = 0; i < 10; i++) {
+      collector.append(Buffer.alloc(512, 88)); // 'X'
+    }
+    collector.append(Buffer.from('|TAIL_END'));
+
+    const result = collector.getResult();
+    expect(result.headText).toContain('HEAD_START');
+  });
+
+  it('tail contains the end of output', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(1024),
+    });
+    collector.append(Buffer.from('HEAD_START|'));
+    for (let i = 0; i < 10; i++) {
+      collector.append(Buffer.alloc(512, 88)); // 'X'
+    }
+    collector.append(Buffer.from('|TAIL_END'));
+
+    const result = collector.getResult();
+    expect(result.tailText).toContain('TAIL_END');
+  });
+});
+
+describe('BoundedStreamCollector - continue and drain', () => {
+  it('continues accepting output after retention fills (side effects visible)', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(1024),
+    });
+
+    // Fill the budget.
+    collector.append(Buffer.alloc(2048, 65));
+
+    // Additional output after overflow should still be accepted.
+    const sideEffectMarker = '|FINAL_MARKER|';
+    collector.append(Buffer.from(sideEffectMarker));
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    // The tail should contain the final marker.
+    expect(result.tailText).toContain(sideEffectMarker);
+    // Total observed includes the post-overflow chunk.
+    expect(result.metadata.observedBytes).toBe(2048 + sideEffectMarker.length);
+  });
+});
+
+describe('BoundedStreamCollector - one huge chunk', () => {
+  it('handles a single chunk larger than the entire budget', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(1024),
+    });
+    // One 1 MiB chunk.
+    collector.append(Buffer.alloc(1024 * 1024, 90)); // 'Z'
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.observedBytes).toBe(1024 * 1024);
+    expect(result.metadata.retainedBytes).toBeLessThanOrEqual(1024);
+  });
+});
+
+describe('BoundedStreamCollector - many tiny chunks', () => {
+  it('handles thousands of 1-byte chunks', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(2048),
+    });
+    // 4000 single-byte chunks.
+    for (let i = 0; i < 4000; i++) {
+      collector.append(Buffer.from([65 + (i % 26)]));
+    }
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.observedBytes).toBe(4000);
+    expect(result.metadata.retainedBytes).toBeLessThanOrEqual(2048);
+  });
+});
+
+describe('BoundedStreamCollector - UTF-8 multibyte boundaries', () => {
+  it('correctly handles multibyte UTF-8 split across chunk boundaries', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(4096),
+    });
+
+    // "héllo" — the é is 2 bytes in UTF-8 (0xC3 0xA9).
+    // Split it: first chunk ends with the first byte of é.
+    collector.append(Buffer.from('h', 'utf-8'));
+    collector.append(Buffer.from([0xc3])); // First byte of é
+    collector.append(Buffer.from([0xa9])); // Second byte of é
+    collector.append(Buffer.from('llo', 'utf-8'));
+
+    // Flush decoder.
+    collector.flushDecoder();
+
+    const headText = collector.getHeadText();
+    expect(headText).toBe('héllo');
+  });
+
+  it('handles a multibyte character split at the head boundary', () => {
+    // The minimum budget is 1024 bytes, so to genuinely test a multibyte
+    // split at the head/tail omission boundary we must write enough data to
+    // exceed the budget. With headFraction 0.5, head=512 and tail=512 bytes.
+    // We place a 3-byte 世 (0xE4 0xB8 0x96) right at the 511-byte mark so the
+    // head boundary cuts through it, forcing the trimmer to drop the partial
+    // sequence.
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(1024),
+      headFraction: 0.5, // head=512, tail=512
+    });
+
+    // 511 ASCII bytes, then 世 (3 bytes) straddling byte 512, then filler to
+    // overflow, then a tail marker.
+    const headPart = 'a'.repeat(511);
+    collector.append(Buffer.from(headPart, 'utf-8'));
+    collector.append(Buffer.from('世', 'utf-8')); // straddles byte 512
+    collector.append(Buffer.alloc(2048, 88)); // 'X' filler → truncation
+    collector.append(Buffer.from('TAIL世', 'utf-8')); // multibyte in tail
+
+    const result = collector.getResult();
+    // Genuinely truncated: observed well beyond the 1024 budget.
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.observedBytes).toBeGreaterThan(1024);
+    // No replacement chars at either boundary — partial multibyte sequences
+    // are trimmed, not emitted as U+FFFD.
+    expect(result.headText).not.toContain('\uFFFD');
+    expect(result.tailText).not.toContain('\uFFFD');
+    // Head retains the leading ASCII, tail retains the final marker.
+    expect(result.headText.startsWith('a')).toBe(true);
+    expect(result.tailText).toContain('TAIL');
+  });
+
+  it('handles 4-byte emoji at chunk boundaries', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(4096),
+    });
+
+    // 😀 is 4 bytes: F0 9F 98 80
+    const emoji = '😀';
+    const buf = Buffer.from(emoji, 'utf-8');
+    // Feed each byte separately.
+    for (const byte of buf) {
+      collector.append(Buffer.from([byte]));
+    }
+    collector.flushDecoder();
+
+    const text = collector.getHeadText();
+    expect(text).toBe(emoji);
+  });
+});
+
+describe('BoundedStreamCollector - O(1) accounting', () => {
+  it('observedByteCount is O(1) regardless of chunk count', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(1024 * 1024),
+    });
+
+    // Feed 100,000 tiny chunks — this would be O(n) if using reduce.
+    for (let i = 0; i < 100_000; i++) {
+      collector.append(Buffer.from([65]));
+    }
+
+    expect(collector.observedByteCount).toBe(100_000);
+    expect(collector.isTruncated).toBe(false);
+  });
+});
+
+describe('BoundedStreamCollector - byte-copy isolation (no subarray retention)', () => {
+  it('copies retained head bytes so a huge source Buffer is not kept alive', () => {
+    // This is the key test for the Buffer.subarray retention defect:
+    // subarray() shares the backing allocation. If we retain a subarray of
+    // a 1 MiB buffer, the entire 1 MiB stays alive. We must copy instead.
+    const budget = createByteBudget(2048);
+    const collector = new BoundedStreamCollector({ budget });
+
+    // Create a huge source buffer with a known pattern.
+    const hugeSize = 1024 * 1024; // 1 MiB
+    const huge = Buffer.alloc(hugeSize, 65); // 'A'
+    // Put a marker at the very start.
+    huge.write('STARTMARKER', 0);
+
+    collector.append(huge);
+
+    // Mutate the source buffer AFTER appending — if the collector retained
+    // a subarray, the retained data would change too. If it copied, it won't.
+    huge.fill(90); // Overwrite everything with 'Z'.
+
+    const result = collector.getResult();
+    const head = result.headText;
+
+    // The head must still contain the original marker, proving bytes were
+    // copied, not subarray'd.
+    expect(head).toContain('STARTMARKER');
+    // And it must NOT contain the mutation.
+    expect(head).not.toContain('Z');
+  });
+
+  it('copies retained tail bytes so a huge source Buffer is not kept alive', () => {
+    const budget = createByteBudget(1024);
+    const collector = new BoundedStreamCollector({ budget });
+
+    // Fill the head first (so everything after goes to tail).
+    collector.append(Buffer.alloc(2000, 65)); // 'A' — exceeds head budget
+
+    // Now append a huge chunk — its tail portion should be copied.
+    const huge = Buffer.alloc(512 * 1024, 66); // 'B'
+    huge.write('TAILMARKER', huge.length - 11);
+    collector.append(huge);
+
+    // Mutate the source.
+    huge.fill(90); // 'Z'
+
+    const result = collector.getResult();
+    // The tail must still contain the original marker.
+    expect(result.tailText).toContain('TAILMARKER');
+    expect(result.tailText).not.toMatch(/Z{10,}/);
+  });
+});
+
+describe('BoundedStreamCollector - no replacement chars at omission boundary', () => {
+  it('does not emit replacement chars when multibyte chars straddle boundaries', () => {
+    // Construct output with multibyte chars scattered throughout, with enough
+    // total data to cause truncation. The head boundary (byte headBytes) and
+    // the tail start boundary (byte total-tailFilled) may cut through a
+    // multibyte character. The trimming helpers ensure no U+FFFD is emitted.
+    const budget = createByteBudget(1024);
+    const collector = new BoundedStreamCollector({ budget });
+
+    // Build a large string with multibyte chars scattered throughout.
+    // Each segment: 10 ASCII + 3 multibyte chars (9 bytes) = 19 bytes.
+    // 100 segments = 1900 bytes > 1024 budget.
+    const segment = 'AAAAAAAAAA\u4e16\u4e16\u4e16';
+    const text = segment.repeat(100);
+    collector.append(Buffer.from(text, 'utf-8'));
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+
+    // CRITICAL: no replacement characters anywhere.
+    expect(result.headText).not.toContain('\uFFFD');
+    expect(result.tailText).not.toContain('\uFFFD');
+    expect(result.text).not.toContain('\uFFFD');
+  });
+
+  it('preserves complete multibyte chars that fit entirely in head or tail', () => {
+    const budget = createByteBudget(100);
+    const collector = new BoundedStreamCollector({ budget });
+
+    // Small output that fits entirely - no truncation.
+    collector.append(Buffer.from('hello world', 'utf-8'));
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(false);
+    expect(result.text).toBe('hello world');
+    expect(result.text).not.toContain('\uFFFD');
+  });
+
+  it('preserves complete multibyte chars in non-truncated output', () => {
+    const budget = createByteBudget(100);
+    const collector = new BoundedStreamCollector({ budget });
+
+    collector.append(Buffer.from('caf\u00e9 r\u00e9sum\u00e9', 'utf-8'));
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(false);
+    expect(result.text).toBe('caf\u00e9 r\u00e9sum\u00e9');
+    expect(result.text).not.toContain('\uFFFD');
+  });
+});
+
+describe('BoundedStreamCollector - many tiny chunks data integrity', () => {
+  it('retains correct tail content from many tiny chunks (ring buffer correctness)', () => {
+    const budget = createByteBudget(1024);
+    const collector = new BoundedStreamCollector({
+      budget,
+      headFraction: 0.1, // head=102, tail=922
+    });
+
+    // Write distinct single-byte markers in a known sequence.
+    const total = 2048;
+    for (let i = 0; i < total; i++) {
+      collector.append(Buffer.from(String.fromCharCode(48 + (i % 10))));
+    }
+
+    const result = collector.getResult();
+    expect(result.metadata.observedBytes).toBe(total);
+    expect(result.metadata.truncated).toBe(true);
+
+    // The tail must end with the last characters written.
+    // Total 2048 chars, pattern 0-9 repeating. Last char: i=2047 → 48+7='7'.
+    expect(result.tailText.endsWith('7')).toBe(true);
+
+    // The tail must NOT contain replacement chars.
+    expect(result.tailText).not.toContain('\uFFFD');
+  });
+
+  it('handles 50k tiny chunks efficiently (no quadratic shift)', () => {
+    const budget = createByteBudget(4096);
+    const collector = new BoundedStreamCollector({ budget });
+
+    // 50,000 one-byte chunks — shift()-based design would be O(n²) here.
+    for (let i = 0; i < 50_000; i++) {
+      collector.append(Buffer.from([88])); // 'X'
+    }
+
+    const result = collector.getResult();
+    expect(result.metadata.observedBytes).toBe(50_000);
+    expect(result.metadata.retainedBytes).toBeLessThanOrEqual(4096);
+    // Tail should be all 'X'.
+    expect(result.tailText).toMatch(/^X+$/);
+  });
+});
+
+describe('BoundedStreamCollector - exact-budget boundary', () => {
+  it('does not truncate when output exactly fills the budget', () => {
+    const budget = createByteBudget(1024);
+    const collector = new BoundedStreamCollector({ budget });
+
+    collector.append(Buffer.alloc(1024, 65)); // exactly fills budget
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(false);
+    expect(result.metadata.observedBytes).toBe(1024);
+    expect(result.metadata.retainedBytes).toBe(1024);
+  });
+
+  it('truncates when output is one byte over budget', () => {
+    const budget = createByteBudget(1024);
+    const collector = new BoundedStreamCollector({ budget });
+
+    collector.append(Buffer.alloc(1025, 65));
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.omittedBytes).toBe(1);
+  });
+});
+
+describe('BoundedStreamCollector - retained segment boundary', () => {
+  it('decodes one complete under-budget stream across the head/tail split', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(1024),
+    });
+    const output = `${'x'.repeat(511)}😀tail`;
+
+    collector.append(Buffer.from(output));
+
+    const result = collector.getResult();
+    expect(result.metadata.truncated).toBe(false);
+    expect(result.text).toBe(output);
+    expect(result.text).not.toContain('�');
+  });
+});
+
+describe('BoundedStreamCollector - detected encoding labels', () => {
+  it('decodes retained Windows code-page bytes with TextDecoder', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(1024),
+      encoding: 'windows-1252',
+    });
+
+    collector.append(Buffer.from([0x80, 0x20, 0x63, 0x61, 0x66, 0xe9]));
+
+    expect(collector.getResult().text).toBe('€ café');
+  });
+
+  it('encodes string input with the configured UTF-16LE label', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(1024),
+      encoding: 'utf-16le',
+    });
+    const output = 'hello \u03A9';
+
+    collector.append(output);
+
+    expect(collector.observedByteCount).toBe(
+      Buffer.byteLength(output, 'utf16le'),
+    );
+    expect(collector.getResult().text).toBe(output);
+  });
+});

--- a/packages/tools/src/acquisition/boundedStreamCollector.test.ts
+++ b/packages/tools/src/acquisition/boundedStreamCollector.test.ts
@@ -124,6 +124,11 @@ describe('ByteBudget - absolute hard-max invariants (issue #3200 finding 10)', (
     expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
   });
 
+  it('normalizes an invalid custom hard max before resolving -1', () => {
+    const budget = resolveByteBudgetFromSetting(-1, Infinity);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
   it('resolveByteBudgetFromSetting falls back to default for undefined', () => {
     const budget = resolveByteBudgetFromSetting(undefined);
     expect(budget.bytes).toBe(DEFAULT_ACQUISITION_BUDGET_BYTES);

--- a/packages/tools/src/acquisition/boundedStreamCollector.test.ts
+++ b/packages/tools/src/acquisition/boundedStreamCollector.test.ts
@@ -455,17 +455,18 @@ describe('BoundedStreamCollector - no replacement chars at omission boundary', (
     expect(result.text).not.toContain('\uFFFD');
   });
 
-  it('preserves complete multibyte chars that fit entirely in head or tail', () => {
-    const budget = createByteBudget(100);
+  it('preserves complete multibyte characters in truncated head and tail', () => {
+    const budget = createByteBudget(1024);
     const collector = new BoundedStreamCollector({ budget });
 
-    // Small output that fits entirely - no truncation.
-    collector.append(Buffer.from('hello world', 'utf-8'));
+    collector.append(Buffer.from('世'.repeat(500), 'utf-8'));
 
     const result = collector.getResult();
-    expect(result.metadata.truncated).toBe(false);
-    expect(result.text).toBe('hello world');
-    expect(result.text).not.toContain('\uFFFD');
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.headText.length).toBeGreaterThan(0);
+    expect(result.tailText.length).toBeGreaterThan(0);
+    expect(result.headText).not.toContain('\uFFFD');
+    expect(result.tailText).not.toContain('\uFFFD');
   });
 
   it('preserves complete multibyte chars in non-truncated output', () => {

--- a/packages/tools/src/acquisition/boundedStreamCollector.ts
+++ b/packages/tools/src/acquisition/boundedStreamCollector.ts
@@ -1,0 +1,278 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TextDecoder } from 'node:util';
+import type {
+  AcquisitionResult,
+  ByteBudget,
+  TruncationMetadata,
+} from './types.js';
+import {
+  skipIncompleteLeadingUtf8,
+  trimIncompleteTrailingUtf8,
+} from './utf8Boundaries.js';
+
+export interface BoundedStreamCollectorOptions {
+  budget: ByteBudget;
+  encoding?: string;
+  headFraction?: number;
+}
+
+export const DEFAULT_OMISSION_NOTICE = 'LLXPRT output truncated';
+
+function copySlice(source: Buffer, start: number, end: number): Buffer {
+  const copy = Buffer.allocUnsafe(end - start);
+  source.copy(copy, 0, start, end);
+  return copy;
+}
+
+function normalizedEncoding(encoding: string): string {
+  const normalized = encoding.toLowerCase();
+  if (normalized === 'utf8') {
+    return 'utf-8';
+  }
+  if (
+    normalized === 'ucs-2' ||
+    normalized === 'ucs2' ||
+    normalized === 'utf16le'
+  ) {
+    return 'utf-16le';
+  }
+  if (normalized === 'binary') {
+    return 'latin1';
+  }
+  return normalized;
+}
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+}
+
+function safeUtf16Head(buffer: Buffer): Buffer {
+  let length = buffer.length - (buffer.length % 2);
+  if (length >= 2 && isHighSurrogate(buffer.readUInt16LE(length - 2))) {
+    length -= 2;
+  }
+  return length === buffer.length ? buffer : copySlice(buffer, 0, length);
+}
+
+function safeUtf16Tail(buffer: Buffer, streamOffset: number): Buffer {
+  let start = streamOffset % 2 === 0 ? 0 : 1;
+  if (
+    buffer.length - start >= 2 &&
+    isLowSurrogate(buffer.readUInt16LE(start))
+  ) {
+    start += 2;
+  }
+  const end = buffer.length - ((buffer.length - start) % 2);
+  return start === 0 && end === buffer.length
+    ? buffer
+    : copySlice(buffer, start, end);
+}
+
+function safeRetainedBoundaries(
+  head: Buffer,
+  tail: Buffer,
+  tailStreamOffset: number,
+  encoding: string,
+): { head: Buffer; tail: Buffer } {
+  const normalized = normalizedEncoding(encoding);
+  if (normalized === 'utf-8') {
+    return {
+      head: trimIncompleteTrailingUtf8(head),
+      tail: skipIncompleteLeadingUtf8(tail),
+    };
+  }
+  if (normalized === 'utf-16le') {
+    return {
+      head: safeUtf16Head(head),
+      tail: safeUtf16Tail(tail, tailStreamOffset),
+    };
+  }
+  return { head, tail };
+}
+
+function decode(buffer: Buffer, encoding: string): string {
+  try {
+    return new TextDecoder(normalizedEncoding(encoding)).decode(buffer);
+  } catch {
+    return new TextDecoder('utf-8').decode(buffer);
+  }
+}
+
+function nodeBufferEncoding(encoding: string): BufferEncoding | undefined {
+  const normalized = normalizedEncoding(encoding);
+  if (normalized === 'utf-8') {
+    return 'utf8';
+  }
+  if (normalized === 'utf-16le') {
+    return 'utf16le';
+  }
+  return Buffer.isEncoding(normalized) ? normalized : undefined;
+}
+
+function encode(text: string, encoding: string): Buffer {
+  return Buffer.from(text, nodeBufferEncoding(encoding) ?? 'utf8');
+}
+
+/** Retains a fixed-size byte head and tail without retaining input buffers. */
+export class BoundedStreamCollector {
+  private readonly budget: ByteBudget;
+  private readonly encoding: string;
+  private readonly headCapacity: number;
+  private readonly tailCapacity: number;
+  private readonly head: Buffer;
+  private readonly tail: Buffer;
+  private headLength = 0;
+  private tailLength = 0;
+  private tailStart = 0;
+  private observedBytes = 0;
+
+  constructor(options: BoundedStreamCollectorOptions) {
+    this.budget = options.budget;
+    this.encoding = normalizedEncoding(options.encoding ?? 'utf8');
+    const fraction = Math.min(Math.max(options.headFraction ?? 0.5, 0), 1);
+    this.headCapacity = Math.floor(this.budget.bytes * fraction);
+    this.tailCapacity = this.budget.bytes - this.headCapacity;
+    this.head = Buffer.allocUnsafe(this.headCapacity);
+    this.tail = Buffer.allocUnsafe(this.tailCapacity);
+  }
+
+  get observedByteCount(): number {
+    return this.observedBytes;
+  }
+
+  get isTruncated(): boolean {
+    return this.observedBytes > this.budget.bytes;
+  }
+
+  append(chunk: Buffer | string): void {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : encode(chunk, this.encoding);
+    if (bytes.length === 0) {
+      return;
+    }
+
+    this.observedBytes += bytes.length;
+    let offset = 0;
+    if (this.headLength < this.headCapacity) {
+      const copied = Math.min(
+        bytes.length,
+        this.headCapacity - this.headLength,
+      );
+      bytes.copy(this.head, this.headLength, 0, copied);
+      this.headLength += copied;
+      offset = copied;
+    }
+    this.appendTail(bytes, offset);
+  }
+
+  flushDecoder(): void {
+    // Decoding is deferred until bounded retained bytes are requested.
+  }
+
+  getHeadText(): string {
+    return this.getResult().headText;
+  }
+
+  getTailText(): string {
+    return this.getResult().tailText;
+  }
+
+  private appendTail(bytes: Buffer, offset: number): void {
+    if (this.tailCapacity === 0 || offset >= bytes.length) {
+      return;
+    }
+    const remaining = bytes.length - offset;
+    if (remaining >= this.tailCapacity) {
+      bytes.copy(this.tail, 0, bytes.length - this.tailCapacity);
+      this.tailLength = this.tailCapacity;
+      this.tailStart = 0;
+      return;
+    }
+    const writeStart = (this.tailStart + this.tailLength) % this.tailCapacity;
+    const firstLength = Math.min(remaining, this.tailCapacity - writeStart);
+    bytes.copy(this.tail, writeStart, offset, offset + firstLength);
+    if (firstLength < remaining) {
+      bytes.copy(this.tail, 0, offset + firstLength, bytes.length);
+    }
+    const overwritten = Math.max(
+      0,
+      this.tailLength + remaining - this.tailCapacity,
+    );
+    this.tailStart = (this.tailStart + overwritten) % this.tailCapacity;
+    this.tailLength = Math.min(this.tailCapacity, this.tailLength + remaining);
+  }
+
+  private copiedHead(): Buffer {
+    return copySlice(this.head, 0, this.headLength);
+  }
+
+  private copiedTail(): Buffer {
+    if (this.tailLength === 0) {
+      return Buffer.alloc(0);
+    }
+    const result = Buffer.allocUnsafe(this.tailLength);
+    const firstLength = Math.min(
+      this.tailLength,
+      this.tailCapacity - this.tailStart,
+    );
+    this.tail.copy(result, 0, this.tailStart, this.tailStart + firstLength);
+    if (firstLength < this.tailLength) {
+      this.tail.copy(result, firstLength, 0, this.tailLength - firstLength);
+    }
+    return result;
+  }
+
+  getResult(): AcquisitionResult {
+    let head = this.copiedHead();
+    let tail = this.copiedTail();
+    const initiallyRetained = head.length + tail.length;
+    if (this.observedBytes > initiallyRetained) {
+      const safe = safeRetainedBoundaries(
+        head,
+        tail,
+        this.observedBytes - tail.length,
+        this.encoding,
+      );
+      head = safe.head;
+      tail = safe.tail;
+    }
+
+    const retainedBytes = head.length + tail.length;
+    const omittedBytes = Math.max(0, this.observedBytes - retainedBytes);
+    const truncated = omittedBytes > 0;
+    const metadata: TruncationMetadata = {
+      observedBytes: this.observedBytes,
+      retainedBytes,
+      omittedBytes,
+      truncated,
+      budgetBytes: this.budget.bytes,
+    };
+    const omissionNotice = truncated
+      ? `[${DEFAULT_OMISSION_NOTICE}: ${omittedBytes.toLocaleString('en-US')} bytes omitted]`
+      : null;
+    const completeText = truncated
+      ? null
+      : decode(Buffer.concat([head, tail], retainedBytes), this.encoding);
+    const headText = completeText ?? decode(head, this.encoding);
+    const tailText = completeText === null ? decode(tail, this.encoding) : '';
+
+    return {
+      text:
+        headText +
+        (omissionNotice === null ? '' : `\n\n${omissionNotice}\n\n`) +
+        tailText,
+      headText,
+      tailText,
+      metadata,
+      omissionNotice,
+    };
+  }
+}

--- a/packages/tools/src/acquisition/byteBudget.ts
+++ b/packages/tools/src/acquisition/byteBudget.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ByteBudget } from './types.js';
+import { createBrandedByteBudget, type ByteBudget } from './types.js';
 
 /**
  * Default immutable hard ceiling for one acquisition collector.
@@ -71,8 +71,7 @@ export function createByteBudget(
     effectiveHardMax,
   );
 
-  const budget: ByteBudget = { bytes: clamped } as ByteBudget;
-  return Object.freeze(budget);
+  return Object.freeze(createBrandedByteBudget(clamped));
 }
 
 /** Create a default {@link ByteBudget}. */

--- a/packages/tools/src/acquisition/byteBudget.ts
+++ b/packages/tools/src/acquisition/byteBudget.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ByteBudget } from './types.js';
+
+/**
+ * Default immutable hard ceiling for one acquisition collector.
+ *
+ * Callers may choose a lower policy ceiling, but acquisition must remain
+ * finite regardless of user configuration.
+ */
+export const ACQUISITION_MIN_BYTES = 1024;
+export const ACQUISITION_HARD_MAX_BYTES = 64 * 1024 * 1024; // 64 MiB
+
+/** Default bounded retention used when a caller does not supply a policy. */
+export const DEFAULT_ACQUISITION_BUDGET_BYTES = 4 * 1024 * 1024; // 4 MiB
+
+/**
+ * Fraction of the budget allocated to the head (beginning) of the output.
+ * The remainder goes to the tail (end). A 50/50 split ensures both the
+ * command header/context and the final result/error are visible.
+ */
+export const DEFAULT_HEAD_FRACTION = 0.5;
+
+/**
+ * Validate and create an immutable {@link ByteBudget}.
+ *
+ * Rules:
+ * - Must be a finite positive number.
+ * - Clamped to {@link ACQUISITION_HARD_MAX_BYTES}.
+ * - Minimum of {@link ACQUISITION_MIN_BYTES} (below that, head/tail retention
+ *   is meaningless).
+ * - The `hardMax` ceiling (if supplied) is itself clamped to
+ *   {@link ACQUISITION_HARD_MAX_BYTES}, so no caller — even one passing a
+ *   custom ceiling — can construct a budget above the absolute cap.
+ * - The returned object is {@link Object.freeze}-d so runtime immutability is
+ *   truthful, not merely a compile-time `readonly` suggestion.
+ *
+ * @throws if value is not a finite positive number.
+ */
+export function createByteBudget(
+  bytes: number,
+  hardMax: number = ACQUISITION_HARD_MAX_BYTES,
+): ByteBudget {
+  if (typeof bytes !== 'number' || !Number.isFinite(bytes) || bytes <= 0) {
+    throw new Error(
+      `ByteBudget must be a finite positive number, got: ${String(bytes)}`,
+    );
+  }
+
+  // A caller-provided ceiling cannot exceed the absolute cap or violate the
+  // floor, so every result remains inside the documented finite range.
+  const requestedCeiling =
+    Number.isFinite(hardMax) && hardMax > 0
+      ? Math.floor(hardMax)
+      : ACQUISITION_HARD_MAX_BYTES;
+  const effectiveHardMax = Math.min(
+    Math.max(requestedCeiling, ACQUISITION_MIN_BYTES),
+    ACQUISITION_HARD_MAX_BYTES,
+  );
+
+  const clamped = Math.min(
+    Math.max(Math.floor(bytes), ACQUISITION_MIN_BYTES),
+    effectiveHardMax,
+  );
+
+  const budget: ByteBudget = { bytes: clamped } as ByteBudget;
+  return Object.freeze(budget);
+}
+
+/** Create a default {@link ByteBudget}. */
+export function createDefaultByteBudget(): ByteBudget {
+  return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES);
+}
+
+/**
+ * Resolve a raw setting value (from ephemeral settings / profile) into a
+ * validated {@link ByteBudget}. Falls back to the default when the value is
+ * absent, invalid, or disabled.
+ *
+ * This function does NOT read settings itself — it receives the raw value
+ * and validates it, keeping the acquisition layer free of settings coupling.
+ */
+export function resolveByteBudgetFromSetting(
+  rawValue: unknown,
+  hardMax: number = ACQUISITION_HARD_MAX_BYTES,
+): ByteBudget {
+  if (rawValue === undefined || rawValue === null) {
+    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, hardMax);
+  }
+
+  const numeric = typeof rawValue === 'string' ? Number(rawValue) : rawValue;
+
+  // A configured -1 means "largest permitted value", never unbounded.
+  if (numeric === -1) {
+    return createByteBudget(hardMax, hardMax);
+  }
+
+  if (
+    typeof numeric !== 'number' ||
+    !Number.isFinite(numeric) ||
+    numeric <= 0
+  ) {
+    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, hardMax);
+  }
+
+  return createByteBudget(numeric, hardMax);
+}

--- a/packages/tools/src/acquisition/byteBudget.ts
+++ b/packages/tools/src/acquisition/byteBudget.ts
@@ -25,6 +25,17 @@ export const DEFAULT_ACQUISITION_BUDGET_BYTES = 4 * 1024 * 1024; // 4 MiB
  */
 export const DEFAULT_HEAD_FRACTION = 0.5;
 
+function normalizeHardMax(hardMax: number): number {
+  const requestedCeiling =
+    Number.isFinite(hardMax) && hardMax > 0
+      ? Math.floor(hardMax)
+      : ACQUISITION_HARD_MAX_BYTES;
+  return Math.min(
+    Math.max(requestedCeiling, ACQUISITION_MIN_BYTES),
+    ACQUISITION_HARD_MAX_BYTES,
+  );
+}
+
 /**
  * Validate and create an immutable {@link ByteBudget}.
  *
@@ -53,14 +64,7 @@ export function createByteBudget(
 
   // A caller-provided ceiling cannot exceed the absolute cap or violate the
   // floor, so every result remains inside the documented finite range.
-  const requestedCeiling =
-    Number.isFinite(hardMax) && hardMax > 0
-      ? Math.floor(hardMax)
-      : ACQUISITION_HARD_MAX_BYTES;
-  const effectiveHardMax = Math.min(
-    Math.max(requestedCeiling, ACQUISITION_MIN_BYTES),
-    ACQUISITION_HARD_MAX_BYTES,
-  );
+  const effectiveHardMax = normalizeHardMax(hardMax);
 
   const clamped = Math.min(
     Math.max(Math.floor(bytes), ACQUISITION_MIN_BYTES),
@@ -88,15 +92,16 @@ export function resolveByteBudgetFromSetting(
   rawValue: unknown,
   hardMax: number = ACQUISITION_HARD_MAX_BYTES,
 ): ByteBudget {
+  const effectiveHardMax = normalizeHardMax(hardMax);
   if (rawValue === undefined || rawValue === null) {
-    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, hardMax);
+    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, effectiveHardMax);
   }
 
   const numeric = typeof rawValue === 'string' ? Number(rawValue) : rawValue;
 
   // A configured -1 means "largest permitted value", never unbounded.
   if (numeric === -1) {
-    return createByteBudget(hardMax, hardMax);
+    return createByteBudget(effectiveHardMax, effectiveHardMax);
   }
 
   if (
@@ -104,8 +109,8 @@ export function resolveByteBudgetFromSetting(
     !Number.isFinite(numeric) ||
     numeric <= 0
   ) {
-    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, hardMax);
+    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, effectiveHardMax);
   }
 
-  return createByteBudget(numeric, hardMax);
+  return createByteBudget(numeric, effectiveHardMax);
 }

--- a/packages/tools/src/acquisition/index.ts
+++ b/packages/tools/src/acquisition/index.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Public acquisition API for packages/tools.
+ *
+ * Shared byte-budget collection primitives used by shell execution and other
+ * push-stream tool acquisition paths. These primitives are intentionally free
+ * of settings, process, terminal, encoding-detection, ANSI, xterm, and MCP
+ * concerns — callers receive plain validated {@link ByteBudget} values.
+ */
+
+export type {
+  ByteBudget,
+  StreamSource,
+  TruncationMetadata,
+  AcquisitionResult,
+  CombinedAcquisitionResult,
+} from './types.js';
+
+export {
+  ACQUISITION_MIN_BYTES,
+  ACQUISITION_HARD_MAX_BYTES,
+  DEFAULT_ACQUISITION_BUDGET_BYTES,
+  DEFAULT_HEAD_FRACTION,
+  createByteBudget,
+  createDefaultByteBudget,
+  resolveByteBudgetFromSetting,
+} from './byteBudget.js';
+
+export {
+  BoundedStreamCollector,
+  DEFAULT_OMISSION_NOTICE,
+} from './boundedStreamCollector.js';
+
+export { BoundedCombinedCollector } from './boundedCombinedCollector.js';
+
+export {
+  completeUtf8PrefixLength,
+  completeUtf8SuffixStart,
+  trimIncompleteTrailingUtf8,
+  skipIncompleteLeadingUtf8,
+} from './utf8Boundaries.js';

--- a/packages/tools/src/acquisition/types.ts
+++ b/packages/tools/src/acquisition/types.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Stream provenance tag for combined stdout/stderr collectors.
+ */
+export type StreamSource = 'stdout' | 'stderr';
+
+/**
+ * Immutable, validated byte budget for output acquisition.
+ *
+ * This is a nominal brand — only values produced by {@link createByteBudget}
+ * are assignable, preventing raw numbers from bypassing validation.
+ */
+export interface ByteBudget {
+  readonly bytes: number;
+  readonly __brand: unique symbol;
+}
+
+/**
+ * Truncation metadata surfaced alongside retained output so callers can
+ * produce durable omission notices and report partial results explicitly.
+ */
+export interface TruncationMetadata {
+  /** Total bytes observed across all streams, monotonically increasing. */
+  readonly observedBytes: number;
+  /** Bytes retained in the head+tail window. */
+  readonly retainedBytes: number;
+  /** Bytes discarded between head and tail. */
+  readonly omittedBytes: number;
+  /**
+   * Whether omittedBytes is the complete loss count. False means acquisition
+   * stopped before all producer output could be observed, so additional loss
+   * is known to exist but cannot be quantified.
+   */
+  readonly omittedBytesExact?: boolean;
+  /** Whether any truncation occurred. */
+  readonly truncated: boolean;
+  /** The configured budget that was enforced. */
+  readonly budgetBytes: number;
+}
+
+/**
+ * Result of bounded output acquisition.
+ */
+export interface AcquisitionResult {
+  /** Decoded text: head content + omission notice + tail content. */
+  readonly text: string;
+  /** Head text only (decoded, without notice or tail). */
+  readonly headText: string;
+  /** Tail text only (decoded). */
+  readonly tailText: string;
+  /** Accounting and truncation metadata. */
+  readonly metadata: TruncationMetadata;
+  /** Pre-formatted notice string, or null if no truncation. */
+  readonly omissionNotice: string | null;
+}
+
+/**
+ * Result for a combined stream (stdout + stderr with provenance).
+ */
+export interface CombinedAcquisitionResult extends AcquisitionResult {
+  /** stdout-only decoded text. */
+  readonly stdoutText: string;
+  /** stderr-only decoded text. */
+  readonly stderrText: string;
+}

--- a/packages/tools/src/acquisition/types.ts
+++ b/packages/tools/src/acquisition/types.ts
@@ -9,6 +9,8 @@
  */
 export type StreamSource = 'stdout' | 'stderr';
 
+const byteBudgetBrand: unique symbol = Symbol('ByteBudget');
+
 /**
  * Immutable, validated byte budget for output acquisition.
  *
@@ -17,7 +19,19 @@ export type StreamSource = 'stdout' | 'stderr';
  */
 export interface ByteBudget {
   readonly bytes: number;
-  readonly __brand: unique symbol;
+  readonly [byteBudgetBrand]: true;
+}
+
+/** @internal Construct the nominal value used by the validating factory. */
+export function createBrandedByteBudget(bytes: number): ByteBudget {
+  const budget = { bytes } as ByteBudget;
+  Object.defineProperty(budget, byteBudgetBrand, {
+    value: true,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  return budget;
 }
 
 /**
@@ -61,10 +75,14 @@ export interface AcquisitionResult {
 
 /**
  * Result for a combined stream (stdout + stderr with provenance).
+ *
+ * `text`, `headText`, and `tailText` preserve the arrival order of the
+ * retained combined stream. The per-source fields project those same retained
+ * slices without content from the other stream.
  */
 export interface CombinedAcquisitionResult extends AcquisitionResult {
-  /** stdout-only decoded text. */
+  /** Retained stdout content, without the omission notice or stderr content. */
   readonly stdoutText: string;
-  /** stderr-only decoded text. */
+  /** Retained stderr content, without the omission notice or stdout content. */
   readonly stderrText: string;
 }

--- a/packages/tools/src/acquisition/utf8Boundaries.ts
+++ b/packages/tools/src/acquisition/utf8Boundaries.ts
@@ -49,7 +49,7 @@ export function completeUtf8SuffixStart(buffer: Buffer): number {
   return start;
 }
 
-/** Returns a copied prefix that does not end in an incomplete UTF-8 sequence. */
+/** Returns a complete prefix, copying only when an incomplete suffix is trimmed. */
 export function trimIncompleteTrailingUtf8(buffer: Buffer): Buffer {
   const length = completeUtf8PrefixLength(buffer);
   return length === buffer.length
@@ -57,7 +57,7 @@ export function trimIncompleteTrailingUtf8(buffer: Buffer): Buffer {
     : Buffer.from(buffer.subarray(0, length));
 }
 
-/** Returns a copied suffix that does not start inside a UTF-8 sequence. */
+/** Returns a complete suffix, copying only when an incomplete prefix is skipped. */
 export function skipIncompleteLeadingUtf8(buffer: Buffer): Buffer {
   const start = completeUtf8SuffixStart(buffer);
   return start === 0 ? buffer : Buffer.from(buffer.subarray(start));

--- a/packages/tools/src/acquisition/utf8Boundaries.ts
+++ b/packages/tools/src/acquisition/utf8Boundaries.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+function expectedSequenceLength(leadByte: number): number {
+  if (leadByte < 0x80) {
+    return 1;
+  }
+  if (leadByte < 0xe0) {
+    return 2;
+  }
+  if (leadByte < 0xf0) {
+    return 3;
+  }
+  if (leadByte < 0xf8) {
+    return 4;
+  }
+  return 1;
+}
+
+/** Returns the prefix length that ends on a complete UTF-8 character. */
+export function completeUtf8PrefixLength(buffer: Buffer): number {
+  if (buffer.length === 0) {
+    return 0;
+  }
+
+  let sequenceStart = buffer.length - 1;
+  while (sequenceStart >= 0 && (buffer[sequenceStart] & 0xc0) === 0x80) {
+    sequenceStart -= 1;
+  }
+  if (sequenceStart < 0) {
+    return 0;
+  }
+
+  const expectedLength = expectedSequenceLength(buffer[sequenceStart]);
+  return buffer.length - sequenceStart < expectedLength
+    ? sequenceStart
+    : buffer.length;
+}
+
+/** Returns the first offset that does not continue an omitted UTF-8 character. */
+export function completeUtf8SuffixStart(buffer: Buffer): number {
+  let start = 0;
+  while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) {
+    start += 1;
+  }
+  return start;
+}
+
+/** Returns a copied prefix that does not end in an incomplete UTF-8 sequence. */
+export function trimIncompleteTrailingUtf8(buffer: Buffer): Buffer {
+  const length = completeUtf8PrefixLength(buffer);
+  return length === buffer.length
+    ? buffer
+    : Buffer.from(buffer.subarray(0, length));
+}
+
+/** Returns a copied suffix that does not start inside a UTF-8 sequence. */
+export function skipIncompleteLeadingUtf8(buffer: Buffer): Buffer {
+  const start = completeUtf8SuffixStart(buffer);
+  return start === 0 ? buffer : Buffer.from(buffer.subarray(start));
+}

--- a/packages/tools/src/interfaces/IShellToolHost.ts
+++ b/packages/tools/src/interfaces/IShellToolHost.ts
@@ -10,6 +10,7 @@
  */
 
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
+import type { TruncationMetadata } from '../acquisition/types.js';
 
 /**
  * Tools-owned interface for shell tool host dependencies.
@@ -41,6 +42,14 @@ export interface ShellExecutionResult {
   backgroundPIDs?: number[];
   /** Process group ID discovered for non-Windows shells. */
   pgid?: number | null;
+  /**
+   * Acquisition-time truncation metadata when output exceeded the retention
+   * byte budget. Present (with `truncated: true`) when the output was bounded
+   * during acquisition. The tools layer surfaces this so the model-facing
+   * result can carry a durable, accurate omission notice rather than a silent
+   * drop (issue #3200).
+   */
+  outputTruncation?: TruncationMetadata;
 }
 
 /** Result of command policy check. */

--- a/packages/tools/src/tools/shell.ts
+++ b/packages/tools/src/tools/shell.ts
@@ -454,6 +454,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         llmPayload,
         displayWithFilter,
         executionError,
+        result.outputTruncation,
       );
 
       // Append the durable clamp notice AFTER summarization and token
@@ -470,18 +471,23 @@ export class ShellToolInvocation extends BaseToolInvocation<
     executionError:
       | { error: { message: string; type: ToolErrorType } }
       | Record<string, never>,
+    outputTruncation: ShellExecutionResult['outputTruncation'],
   ): StringContentToolResult {
     const limitedResult = this.host.limitOutputTokens(llmPayload);
+    const metadata =
+      outputTruncation === undefined ? {} : { metadata: { outputTruncation } };
     if (limitedResult.wasTruncated) {
       return {
         llmContent: `${limitedResult.content}\n\n(output exceeded token limit)`,
         returnDisplay,
+        ...metadata,
         ...executionError,
       };
     }
     return {
       llmContent: limitedResult.content,
       returnDisplay,
+      ...metadata,
       ...executionError,
     };
   }

--- a/project-plans/issue3200/PLAN.md
+++ b/project-plans/issue3200/PLAN.md
@@ -1,0 +1,127 @@
+# Plan: Bound Shell Foreground Output Acquisition (Issue #3200)
+
+Plan ID: PLAN-20260809-ISSUE3200
+Generated: 2026-08-09
+Parent: #3202
+
+## Problem
+
+Foreground shell output acquisition is unbounded across both child_process and
+PTY backends. The child_process path stores every raw Buffer in
+`outputChunks[]` and does `Buffer.concat()` at completion. The PTY path stores
+every re-encoded chunk in `outputChunks[]`, uses a 600,000-line xterm
+scrollback, an unbounded processing-chain promise queue, and quadratic
+`reduce()` for binary progress. Direct `!` shell accumulates
+`cumulativeStdout` without limit. Prompt injection and ACP/Zed paths inherit
+the same defect. Token limiting runs only after full materialization.
+
+## Architecture
+
+### Acquisition Primitives (packages/tools/src/acquisition/)
+
+Establish reusable, dependency-safe acquisition contracts in the leaf
+`packages/tools` package under an explicit `./acquisition` subpath. Core,
+MCP, CLI, providers, and agents already depend on tools; no reverse dependency
+or new package.
+
+**Public surface:**
+- `ByteBudget` — immutable validated finite byte-budget value with hard ceiling
+- `BoundedStreamCollector` — single-stream copied head/tail collector with
+  deferred multibyte-safe decoding and O(1) byte accounting
+- `BoundedCombinedCollector` — combined stdout+stderr budget preserving
+  provenance and arrival order
+- `AcquisitionResult` — result type with decoded text, observed/retained/omitted
+  accounting, and durable truncation metadata
+- `DEFAULT_OMISSION_NOTICE` — shared durable truncation marker
+
+**Constraints on shared primitives:**
+- Do NOT read settings, spawn/kill processes, parse terminal state, detect
+  encodings, strip ANSI, import xterm/MCP, or choose drain/terminate policy
+- Receive plain validated `ByteBudget` values from callers
+- No full-size duplicate materialization (no `Buffer.concat(allChunks)`)
+
+### Setting: shell-output-retention-max-bytes
+
+Add a shell-specific ephemeral setting to the settings registry:
+- Finite default: 4 MiB (4,194,304 bytes)
+- Immutable hard maximum: 64 MiB (67,108,864 bytes)
+- Separate from model-facing token limits (`tool-output-max-tokens`)
+- Integrated with established settings registry/profile/runtime patterns
+- Clamped at resolution boundary so bad values cannot exceed the hard max
+
+### Child-Process Path
+
+1. Replace `outputChunks: Buffer[]` with `BoundedCombinedCollector`
+2. Preserve bounded per-stream live decoding while using the combined raw
+   collector as the authoritative shared byte budget
+3. Replace completion-time `Buffer.concat(state.outputChunks)` with bounded
+   collector results
+4. Use byte accounting (not UTF-16 code units) for the budget
+5. Keep fixed-size binary sniff state with O(1) accounting
+6. Expose only bounded raw head/tail bytes for compatibility
+7. Continue draining after retention fills (side effects, final exit status)
+8. Surface durable text and structured truncation metadata
+
+### PTY Path
+
+1. Replace `outputChunks: Buffer[]` with bounded collector
+2. Process terminal data in order — do not feed a head/tail-dropped ANSI
+   stream to xterm
+3. Bound xterm scrollback to a finite limit derived from the byte budget
+4. Bound retained serialization output
+5. Bound pending processing-queue bytes with high/low watermarks
+6. Use byte and item high/low watermarks on backpressure-capable adapters;
+   for Bun (whose pause/resume are no-ops), fail fast at the hard bound
+7. Terminate through the existing platform process-tree lifecycle on overflow
+8. Remove quadratic accounting and cap retained pending Promise closures by
+   the hard queue item limit
+
+### Entry Point Coverage
+
+Apply the validated byte budget to ALL foreground shell entry points:
+1. Normal Shell tool — bounded via execution layer
+2. Direct `!` shell — bound `cumulativeStdout`
+3. Prompt shell injection — bound `executionResult.output`
+4. ACP/Zed — enforce byte budget, do NOT approximate as tokens*4
+5. Preserve truncation metadata through interfaces/adapters
+
+### Preservation
+
+- Exit status, signal handling, CLIXML handling, binary behavior, live output
+  behavior, managed background-job behavior — all preserved
+- Background jobs are disk-backed and out of scope (shared interface
+  compatibility only)
+
+## Phases
+
+### Phase 01: Acquisition Primitives (packages/tools/src/acquisition/)
+- Create `byteBudget.ts`, `boundedStreamCollector.ts`,
+  `boundedCombinedCollector.ts`, `types.ts`, `index.ts`
+- Export via package.json subpath `./acquisition.js`
+- Write behavioral tests: head/tail overflow, combined provenance, UTF-8
+  multibyte boundaries, one-huge-chunk, many-tiny-chunks, O(1) accounting
+
+### Phase 02: Setting Registration
+- Add `shell-output-retention-max-bytes` to settings registry
+- Add to profile types, runtime settings, /set command schema
+- Wire through Config.getShellExecutionConfig()
+
+### Phase 03: Child-Process Integration
+- Replace CpExecState.outputChunks with BoundedCombinedCollector
+- Update handleCpOutput, cleanupCpResources, buildCpExitResult
+- Write tests: bounded overflow with metadata, continue-and-drain, CLIXML
+
+### Phase 04: PTY Integration
+- Replace PtyExecState.outputChunks with bounded collector
+- Bound scrollback, processing queue, serialization
+- Fail-fast for Bun adapter overflow
+- Write tests: ANSI cursor/clear/wrap, bounded scrollback, fail-fast
+
+### Phase 05: Entry Point Coverage
+- Direct `!` shell: bound cumulativeStdout
+- Prompt injection: bounded output
+- ACP/Zed: enforce byte budget
+- Write tests: propagation through each entry point
+
+### Phase 06: Verification
+- npm run test, lint, typecheck, format, build, smoke test


### PR DESCRIPTION
## TLDR

Bounds foreground shell-output acquisition before large or infinite producers can exhaust process memory. The change applies one finite byte-retention policy across child-process shells, PTYs, direct `!` execution, prompt injection, ACP/Zed terminals, and Agentic live-output delivery while preserving process draining, exit status, stream provenance, terminal behavior, and useful head/tail context.

The new `shell-output-retention-max-bytes` setting defaults to 4 MiB, clamps to a 1024-byte minimum and immutable 64 MiB ceiling, and treats `-1` as the finite ceiling rather than unlimited.

## Dive Deeper

### Shared acquisition boundary

- Adds dependency-safe acquisition primitives under `packages/tools/src/acquisition/` rather than coupling settings, process lifecycle, terminal rendering, or MCP concerns into a generic utility.
- Provides validated branded byte budgets plus fixed-capacity head/tail and combined stdout/stderr collectors.
- Copies retained bytes, uses bounded ring storage, preserves combined arrival order and stream provenance, avoids malformed UTF-8/UTF-16 boundaries, and exposes observed/retained/omitted/budget metadata.
- Keeps acquisition byte safety separate from model-facing token truncation.

### Foreground shell execution

- Replaces unbounded child-process raw chunk arrays and completion-time full concatenation with one combined bounded collector and a fixed binary-sniff prefix.
- Bounds PTY raw retention, xterm scrollback, and pending processing by both byte and item watermarks.
- Uses pause/resume where the PTY backend provides real backpressure; otherwise fails fast at the hard pending-queue boundary and terminates through existing cross-platform lifecycle handling.
- Preserves exactly one durable omission notice and structured truncation metadata through core, host adapters, and the Shell tool.
- Continues draining ordinary verbose child processes after retained output fills so commands still complete and side effects are preserved.

### Other foreground paths

- Applies the same resolved byte policy to direct `!` live display and prompt shell injection.
- Streams multiple prompt-injection results into one aggregate bounded expansion rather than retaining every command result simultaneously; every command still executes for side effects and statuses remain ordered.
- Replaces ACP/Zed token-to-byte approximation with an exact validated byte budget, bounds hostile snapshots and overlap work, and emits one discontinuity notice.
- Bounds Agentic live-output queues by bytes and event count, coalesces replace-style updates, preserves semantic completion events, and reports omitted output without silently dropping required events.

### Architecture and compatibility

- Settings/profile wiring and public shell result contracts carry the finite retention policy and truncation metadata.
- Binary detection, ANSI handling, CLIXML, abort/signal/exit semantics, background-job behavior, and PTY screen semantics remain intact.
- Documents the setting and its finite `-1` behavior.
- Includes the test-first implementation plan at `project-plans/issue3200/PLAN.md`.

The implementation received a DeepThinker review and a detached Open Code Review. All grounded findings from both cycles were remediated; six files omitted by the OCR tool-round limit received compensating manual inspection.

## Reviewer Test Plan

1. Configure a small retained-output budget and run a finite producer larger than the budget. Confirm the result contains useful head and tail output, one omission notice, accurate truncation metadata, and the command's final marker/exit status.
2. Run an infinite or very high-rate producer with a wall timeout. Confirm retained memory remains bounded and the process tree terminates.
3. Exercise both child-process and interactive PTY modes. For PTY, include ANSI color, cursor movement, clears, wrapping, and alternate-screen output.
4. Exercise direct `!` shell output and prompt injections containing multiple verbose commands. Confirm output is bounded while every command's side effects and status appear once and in order.
5. Exercise an ACP/Zed terminal whose snapshots roll over the byte budget. Confirm streamed and final output each contain one discontinuity notice.
6. On Windows, run a large PowerShell/batch producer and a CLIXML-producing command; confirm byte retention, final markers, and process cleanup remain bounded and correct.

Useful automated commands:

    bun test packages/tools/src/acquisition
    bun test packages/core/src/services/shellBoundedAcquisition.bun.test.ts packages/core/src/services/shellPtyExecution.bun.test.ts
    bun test packages/cli/src/services/prompt-processors/injectionOutputBudget.bun.test.ts packages/cli/src/zed-integration/terminalOutputDelta.bun.test.ts
    bun test packages/agents/src/core/agenticLoop/__tests__/agenticEventQueue.test.ts packages/agents/src/core/agenticLoop/__tests__/agenticLoop.output-bound.test.ts
    npm run typecheck
    npm run build

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Local macOS verification:

- Tools workspace: 90/90 test files passed.
- Core workspace: 366/366 test files passed.
- CLI workspace: all 684 supported files passed across the three test partitions.
- Settings workspace: 16/16 files passed.
- Providers workspace: 563/563 files passed.
- Agents workspace passed in the pre-OCR full run; after OCR remediation, the changed Agentic queue suites passed 9/9 and the API-surface guard passed. A repeated full Agents run exceeded the local 900-second command ceiling without an observed failure.
- Focused post-review suites for acquisition collectors, child-process/PTY behavior, prompt injection, direct shell, ACP/Zed, and Agentic output passed.
- `npm run typecheck` passed.
- `npm run build` passed.
- `npm run format` and `git diff --check` passed.
- Canonical scoped lint over all affected source areas plus integration tests passed. ESLint, architecture, test-framework, new-JavaScript, copyright, documentation, API-surface, and test-coverage policy guards passed.
- Required live smoke passed with `stepfun-37` and returned a haiku.

The monolithic root test and lint processes exceeded the local shell tool's 900-second ceiling, so supported workspace test partitions and canonical scoped lint were used; CI remains the cross-platform full-suite authority.

## Linked issues / bugs

Fixes #3200

Parent tracking issue: #3202

Related bounded-acquisition follow-ups: #3203, #3204, #3205


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable shell-output retention by byte count, with documented defaults, limits, and validation.
  * Shell output now retains bounded head and tail content while preserving UTF-8 characters and stream ordering.
  * Added truncation metadata, omission notices, and discontinuity notices when output cannot be fully retained.
  * Shell results consistently report output truncation details across execution modes.

* **Bug Fixes**
  * Improved handling of high-volume shell output to prevent unbounded buffering and preserve command completion status.
  * Improved live agent output handling by coalescing updates and retaining completion events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->