### PR TITLE
Bound workspace analysis and large-file materialization (Fixes #3205)

### DIFF
--- a/packages/tools/src/tools/apply-patch.ts
+++ b/packages/tools/src/tools/apply-patch.ts
@@ -39,6 +39,11 @@ import { APPLY_PATCH_TOOL } from '../types/tool-names.js';
 import { collectLspDiagnosticsBlock } from '../utils/lsp-diagnostics-helper.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
+import {
+  statFileSizeGate,
+  validateFileSizeBytes,
+  type FileSizeGateError,
+} from '../utils/fileUtils.js';
 import { stringOrDefault } from '../utils/stringCoalescing.js';
 import {
   createDefaultToolHost,
@@ -257,8 +262,24 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       return false;
     }
 
+    // Pre-read size gate: an oversized existing target must not be materialized
+    // for the preview diff. Defer to execute, which emits FILE_TOO_LARGE.
+    const sizeError = await statFileSizeGate(filePath);
+    if (sizeError) {
+      return false;
+    }
+
     const { currentContent, fileExists } =
       await this.readCurrentContent(filePath);
+    // Validate authoritative host-returned content immediately after
+    // acquisition (host content may diverge from native stat).
+    const contentGate = validateFileSizeBytes(
+      filePath,
+      Buffer.byteLength(currentContent),
+    );
+    if (contentGate) {
+      return false;
+    }
     if (!fileExists && !isCreationPatch(patch)) return false;
 
     const applied = this.applyPatchToContent(currentContent, patch);
@@ -358,6 +379,20 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
   }
 
   /**
+   * Shared FILE_TOO_LARGE result for both the pre-read stat gate and the
+   * post-acquisition byte gate. Defers to the gate's authoritative message so
+   * the threshold/path stay aligned with the single validateFileSizeBytes
+   * source of truth, instead of duplicating a generic display string.
+   */
+  private toFileSizeGateResult(gate: FileSizeGateError): ToolResult {
+    return {
+      llmContent: gate.message,
+      returnDisplay: gate.message,
+      error: { message: gate.message, type: gate.type },
+    };
+  }
+
+  /**
    * Executes the apply_patch operation
    */
   override async execute(_signal: AbortSignal): Promise<ToolResult> {
@@ -388,9 +423,27 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
     );
     if (targetError) return targetError;
 
+    // 5b. Pre-read file-size gate: reject an oversized existing target before
+    // materializing content. Creation patches (missing target) are unaffected.
+    const sizeError = await statFileSizeGate(filePath);
+    if (sizeError) {
+      return this.toFileSizeGateResult(sizeError);
+    }
+
     // 6. Read current content.
     const { currentContent, fileExists } =
       await this.readCurrentContent(filePath);
+
+    // Validate authoritative host-returned content immediately after
+    // acquisition: a host file service may return bytes divergent from native
+    // stat, so the shared byte-size primitive rejects before diffing/backup.
+    const contentGate = validateFileSizeBytes(
+      filePath,
+      Buffer.byteLength(currentContent),
+    );
+    if (contentGate) {
+      return this.toFileSizeGateResult(contentGate);
+    }
 
     // 7. Missing file is not a context mismatch (AC6).
     if (!fileExists && !isCreationPatch(patch)) {

--- a/packages/tools/src/tools/ast-edit/ast-read-file-invocation.ts
+++ b/packages/tools/src/tools/ast-edit/ast-read-file-invocation.ts
@@ -16,7 +16,11 @@ import {
 import { ToolErrorType } from '../../types/tool-error.js';
 import { makeRelative, shortenPath } from '../../utils/paths.js';
 import { isNodeError } from '../../utils/errors.js';
-import { countLines } from '../../utils/fileUtils.js';
+import {
+  countLines,
+  statFileSizeGate,
+  validateFileSizeBytes,
+} from '../../utils/fileUtils.js';
 import type { IToolHost } from '../../interfaces/index.js';
 import type { LiveOutputUpdate } from '../../utils/terminalSerializer.js';
 
@@ -57,12 +61,35 @@ export class ASTReadFileToolInvocation
     _setPidCallback?: (pid: number) => void,
   ): Promise<ToolResult> {
     try {
+      const sizeError = await statFileSizeGate(this.params.file_path);
+      if (sizeError) {
+        return {
+          llmContent: sizeError.message,
+          returnDisplay: sizeError.message,
+          error: { message: sizeError.message, type: sizeError.type },
+        };
+      }
       const fileSystemService = this.host.getFileSystemService?.() as
         | { readTextFile?: (filePath: string) => Promise<string> }
         | undefined;
       const content = fileSystemService?.readTextFile
         ? await fileSystemService.readTextFile(this.params.file_path)
         : await fs.promises.readFile(this.params.file_path, 'utf-8');
+
+      // Validate authoritative content immediately after acquisition: a host
+      // file service may return bytes divergent from native stat, so the same
+      // shared byte-size primitive is applied here before parsing/copying.
+      const contentGate = validateFileSizeBytes(
+        this.params.file_path,
+        Buffer.byteLength(content),
+      );
+      if (contentGate) {
+        return {
+          llmContent: contentGate.message,
+          returnDisplay: contentGate.message,
+          error: { message: contentGate.message, type: contentGate.type },
+        };
+      }
 
       const { selectedContent, startLine, endLine, totalLineCount } =
         this.computeLineRange(content);

--- a/packages/tools/src/tools/ast-edit/edit-calculator.ts
+++ b/packages/tools/src/tools/ast-edit/edit-calculator.ts
@@ -13,6 +13,7 @@ import type { IToolHost } from '../../interfaces/index.js';
 import type { ASTEditToolParams } from './types.js';
 import { ToolErrorType } from '../../types/tool-error.js';
 import { isNodeError } from '../../utils/errors.js';
+import { statFileSizeGate } from '../../utils/fileUtils.js';
 import { parse, LANGUAGE_MAP } from '../../utils/ast-grep-utils.js';
 import { applyReplacement } from './edit-helpers.js';
 import {
@@ -56,6 +57,23 @@ export async function calculateEdit(
   host: IToolHost,
   _abortSignal: AbortSignal,
 ): Promise<CalculatedEdit> {
+  // Pre-read file-size gate: reject an oversized existing target before any
+  // content read/parse/diff. New-file creation (ENOENT) is left unaffected.
+  const sizeError = await statFileSizeGate(params.file_path);
+  if (sizeError) {
+    return {
+      currentContent: null,
+      newContent: '',
+      occurrences: 0,
+      isNewFile: false,
+      error: {
+        display: sizeError.message,
+        raw: sizeError.message,
+        type: sizeError.type,
+      },
+    };
+  }
+
   // Normalize all string parameters to LF for consistent matching
   const normalizedOldString = params.old_string.replace(/\r\n/g, '\n');
   const normalizedNewString = params.new_string.replace(/\r\n/g, '\n');

--- a/packages/tools/src/tools/ast-edit/edit-calculator.ts
+++ b/packages/tools/src/tools/ast-edit/edit-calculator.ts
@@ -13,7 +13,11 @@ import type { IToolHost } from '../../interfaces/index.js';
 import type { ASTEditToolParams } from './types.js';
 import { ToolErrorType } from '../../types/tool-error.js';
 import { isNodeError } from '../../utils/errors.js';
-import { statFileSizeGate } from '../../utils/fileUtils.js';
+import {
+  statFileSizeGate,
+  validateFileSizeBytes,
+  type FileSizeGateError,
+} from '../../utils/fileUtils.js';
 import { parse, LANGUAGE_MAP } from '../../utils/ast-grep-utils.js';
 import { applyReplacement } from './edit-helpers.js';
 import {
@@ -45,6 +49,24 @@ export interface CalculatedEdit {
 }
 
 /**
+ * Maps a shared {@link FileSizeGateError} (from the pre-read stat gate or the
+ * post-acquisition content gate) to a terminal {@link CalculatedEdit} result.
+ */
+function toSizeGateEdit(gate: FileSizeGateError): CalculatedEdit {
+  return {
+    currentContent: null,
+    newContent: '',
+    occurrences: 0,
+    isNewFile: false,
+    error: {
+      display: gate.message,
+      raw: gate.message,
+      type: gate.type,
+    },
+  };
+}
+
+/**
  * Calculates the edit to be applied, including validation and freshness checks.
  *
  * @param params - Edit parameters
@@ -60,25 +82,25 @@ export async function calculateEdit(
   // Pre-read file-size gate: reject an oversized existing target before any
   // content read/parse/diff. New-file creation (ENOENT) is left unaffected.
   const sizeError = await statFileSizeGate(params.file_path);
-  if (sizeError) {
-    return {
-      currentContent: null,
-      newContent: '',
-      occurrences: 0,
-      isNewFile: false,
-      error: {
-        display: sizeError.message,
-        raw: sizeError.message,
-        type: sizeError.type,
-      },
-    };
-  }
+  if (sizeError) return toSizeGateEdit(sizeError);
 
   // Normalize all string parameters to LF for consistent matching
   const normalizedOldString = params.old_string.replace(/\r\n/g, '\n');
   const normalizedNewString = params.new_string.replace(/\r\n/g, '\n');
 
   const { currentContent, fileExists } = await readFileState(params, host);
+
+  // Validate authoritative host-returned content immediately after
+  // acquisition: a host file service may return bytes divergent from native
+  // stat, so the shared byte-size primitive rejects before syntax/diff/
+  // materialization.
+  if (currentContent !== null) {
+    const contentGate = validateFileSizeBytes(
+      params.file_path,
+      Buffer.byteLength(currentContent),
+    );
+    if (contentGate) return toSizeGateEdit(contentGate);
+  }
 
   // Freshness Check (moved before old_string validation to ensure it runs first)
   const currentMtime = await getFileLastModified(params.file_path);

--- a/packages/tools/src/tools/ast-grep.behavioral.bun.test.ts
+++ b/packages/tools/src/tools/ast-grep.behavioral.bun.test.ts
@@ -1,0 +1,632 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for bounded acquisition in ast_grep (issue #3205).
+ *
+ * Drives the REAL AstGrepTool against real .ts fixture trees. The AST engine
+ * (@ast-grep/napi) is not mocked. Proves that match materialization stops at
+ * `maxResults` (with a one-sentinel observation) rather than collecting every
+ * match and slicing afterward, and that partial metadata is accurate.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IToolHost } from '../interfaces/index.js';
+import { AstGrepTool } from './ast-grep.js';
+import type { ToolResult } from './tools.js';
+
+function createToolHost(targetDir: string): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths: string[]) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({}),
+    getDebugMode: () => false,
+  };
+}
+
+interface AstGrepMetadata {
+  matches?: unknown[];
+  truncated?: boolean;
+  matchesRetained?: number;
+  matchesObserved?: number;
+  totalMatches?: number;
+  partialReason?: string;
+  countInexact?: boolean;
+  skippedFiles?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+async function runGrep(
+  host: IToolHost,
+  params: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<ToolResult> {
+  const tool = new AstGrepTool(host);
+  return tool.build(params).execute(signal ?? new AbortController().signal);
+}
+
+/**
+ * Reads the AST-grep metadata via runtime guards rather than a blind cast, so
+ * a shape mismatch surfaces as an absent field instead of a silent assertion.
+ */
+function metadataOf(result: ToolResult): AstGrepMetadata {
+  const meta = result.metadata;
+  if (!isRecord(meta)) {
+    return {};
+  }
+  const out: AstGrepMetadata = {};
+  if (Array.isArray(meta.matches)) out.matches = meta.matches;
+  if (typeof meta.truncated === 'boolean') out.truncated = meta.truncated;
+  if (typeof meta.matchesRetained === 'number')
+    out.matchesRetained = meta.matchesRetained;
+  if (typeof meta.matchesObserved === 'number')
+    out.matchesObserved = meta.matchesObserved;
+  if (typeof meta.totalMatches === 'number')
+    out.totalMatches = meta.totalMatches;
+  if (typeof meta.partialReason === 'string')
+    out.partialReason = meta.partialReason;
+  if (typeof meta.countInexact === 'boolean')
+    out.countInexact = meta.countInexact;
+  if (typeof meta.skippedFiles === 'number')
+    out.skippedFiles = meta.skippedFiles;
+  return out;
+}
+
+describe('ast_grep bounded acquisition (issue #3205)', () => {
+  let tempDir = '';
+  let manyMatchDir = '';
+  let traverseDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-3205-'));
+    manyMatchDir = join(tempDir, 'many');
+    mkdirSync(manyMatchDir, { recursive: true });
+
+    // 5 files, each with 5 call_expressions -> 25 total matches for $OBJ.$F($$$ARGS).
+    // Far more than a maxResults of 5.
+    for (let f = 0; f < 5; f++) {
+      let body = '';
+      for (let i = 0; i < 5; i++) {
+        body += `console.log("hit-${f}-${i}");\n`;
+      }
+      writeFileSync(join(manyMatchDir, `file${f}.ts`), body, 'utf-8');
+    }
+
+    // A single file with exactly 5 matches.
+    let exactBody = '';
+    for (let i = 0; i < 5; i++) {
+      exactBody += `console.log("exact-${i}");\n`;
+    }
+    writeFileSync(join(tempDir, 'exact.ts'), exactBody, 'utf-8');
+
+    // A single file with exactly 6 matches (one over).
+    let overBody = '';
+    for (let i = 0; i < 6; i++) {
+      overBody += `console.log("over-${i}");\n`;
+    }
+    writeFileSync(join(tempDir, 'over.ts'), overBody, 'utf-8');
+
+    // A single file with FAR more matches (50) than any reasonable maxResults.
+    // Proves bounding happens within ONE file, not just output-slicing across
+    // many files.
+    let farOverBody = '';
+    for (let i = 0; i < 50; i++) {
+      farOverBody += `console.log("far-${i}");\n`;
+    }
+    writeFileSync(join(tempDir, 'far-over.ts'), farOverBody, 'utf-8');
+
+    // A large directory (300 files, 2 matches each) for deterministic
+    // mid-traversal abort: the tool processes files sequentially, so a bounded
+    // number of event-loop yields lets only some files complete before the
+    // signal is raised — never all 300.
+    traverseDir = join(tempDir, 'traverse');
+    mkdirSync(traverseDir, { recursive: true });
+    for (let i = 0; i < 300; i++) {
+      writeFileSync(
+        join(traverseDir, `t${i}.ts`),
+        `console.log("a${i}");\nconsole.log("b${i}");\n`,
+        'utf-8',
+      );
+    }
+
+    // A metavariable-extraction fixture: a single clear call whose $OBJ, $F,
+    // and $$$ARGS can be asserted directly against the parsed match record.
+    writeFileSync(
+      join(tempDir, 'metavars.ts'),
+      `console.log("payload");\n`,
+      'utf-8',
+    );
+
+    // 150 matches — exceeds the DEFAULT_MAX_RESULTS (100) so a nonfinite
+    // maxResults (Infinity/NaN) resolved to the default is provably bounded.
+    {
+      let body = '';
+      for (let i = 0; i < 150; i++) {
+        body += `console.log("inf-${i}");\n`;
+      }
+      writeFileSync(join(tempDir, 'inf-over.ts'), body, 'utf-8');
+    }
+  });
+
+  afterAll(() => {
+    if (tempDir !== '') {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('retains at most maxResults and reports a lower-bound/inexact total', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: manyMatchDir,
+      maxResults: 5,
+    });
+    const meta = metadataOf(result);
+    expect(meta.matches?.length).toBe(5);
+    expect(meta.truncated).toBe(true);
+    expect(meta.partialReason).toBe('max-results');
+    // Must NOT claim an exact total after stopping early.
+    expect(meta.totalMatches).toBeUndefined();
+    expect(meta.countInexact).toBe(true);
+    expect(meta.matchesRetained).toBe(5);
+  });
+
+  it('treats exact-limit input as complete (not truncated)', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'exact.ts'),
+      maxResults: 5,
+    });
+    const meta = metadataOf(result);
+    expect(meta.matches?.length).toBe(5);
+    expect(meta.truncated).toBe(false);
+  });
+
+  it('one-over returns exactly maxResults and marks the result partial', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'over.ts'),
+      maxResults: 5,
+    });
+    const meta = metadataOf(result);
+    expect(meta.matches?.length).toBe(5);
+    expect(meta.truncated).toBe(true);
+    expect(meta.partialReason).toBe('max-results');
+  });
+
+  it('bounds far-over matches within a SINGLE file (not output-sliced across files)', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'far-over.ts'),
+      maxResults: 5,
+    });
+    const meta = metadataOf(result);
+    // One file has 50 matches; only 5 are retained and the result is partial.
+    // This distinguishes bounded acquisition from collect-all-then-slice: with
+    // a single file there is no cross-file slicing to hide the bound.
+    expect(meta.matches?.length).toBe(5);
+    expect(meta.truncated).toBe(true);
+    expect(meta.partialReason).toBe('max-results');
+    expect(meta.totalMatches).toBeUndefined();
+    expect(meta.countInexact).toBe(true);
+    expect(meta.matchesRetained).toBe(5);
+  });
+
+  it('a pre-aborted signal returns retained matches as an explicit partial', async () => {
+    const host = createToolHost(tempDir);
+    const controller = new AbortController();
+    controller.abort();
+    const result = await runGrep(
+      host,
+      {
+        pattern: '$OBJ.$F($$$ARGS)',
+        language: 'typescript',
+        path: manyMatchDir,
+        maxResults: 100,
+      },
+      controller.signal,
+    );
+    const meta = metadataOf(result);
+    expect(meta.truncated).toBe(true);
+    expect(meta.partialReason).toBe('aborted');
+  });
+
+  it('aborts DURING a real large-directory traversal and returns a partial result', async () => {
+    // 300 files × 2 matches = 600 matches. A real AbortController is raised
+    // after invocation has begun, at the earliest deterministic macrotask
+    // boundary (a zero-delay timer, clamped to ~1 ms). The tool reads/parses
+    // files sequentially, so the traversal provably cannot finish 300 AST
+    // parses (tens of ms) before the timer fires — the abort lands
+    // mid-traversal and the result is always partial with reason `aborted`.
+    // No positive retained count is required: requiring one would reintroduce
+    // timing dependence on machine speed. The timer is always cleared in
+    // finally so no macrotask leaks even if the traversal throws.
+    const host = createToolHost(tempDir);
+    const controller = new AbortController();
+    const execution = runGrep(
+      host,
+      {
+        pattern: '$OBJ.$F($$$ARGS)',
+        language: 'typescript',
+        path: traverseDir,
+        maxResults: 600,
+      },
+      controller.signal,
+    );
+    const timer = setTimeout(() => controller.abort(), 0);
+    try {
+      const result = await execution;
+      const meta = metadataOf(result);
+      // Explicit aborted partial metadata (deterministic).
+      expect(meta.truncated).toBe(true);
+      expect(meta.partialReason).toBe('aborted');
+      // Bounded output: the traversal did not finish all 600 matches before
+      // the abort was observed.
+      expect((meta.matches ?? []).length).toBeLessThan(600);
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  it('zero/below-limit input returns all matches and is not truncated', async () => {
+    const host = createToolHost(tempDir);
+    // 25 matches available, maxResults 30 -> all retained, not truncated.
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: manyMatchDir,
+      maxResults: 30,
+    });
+    const meta = metadataOf(result);
+    expect(meta.matches?.length).toBe(25);
+    expect(meta.truncated).toBe(false);
+  });
+});
+
+/**
+ * Reads the metavariable map from the first retained match record via runtime
+ * guards (no blind cast), so a structural mismatch surfaces as an empty object.
+ */
+function firstMatchMetaVars(result: ToolResult): Record<string, string> {
+  const meta = result.metadata;
+  if (!isRecord(meta) || !Array.isArray(meta.matches)) return {};
+  const first = meta.matches[0];
+  if (!isRecord(first) || !isRecord(first.metaVariables)) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(first.metaVariables)) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
+}
+
+describe('ast_grep metavariable extraction (issue #3205)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-mv-3205-'));
+    writeFileSync(
+      join(tempDir, 'mv.ts'),
+      `console.log("payload");
+`,
+      'utf-8',
+    );
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('extracts single-node metavariables ($NAME) from a real match', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'mv.ts'),
+      maxResults: 5,
+    });
+    const vars = firstMatchMetaVars(result);
+    // $OBJ -> "console", $F -> "log"
+    expect(vars.OBJ).toBe('console');
+    expect(vars.F).toBe('log');
+  });
+
+  it('extracts multi-node metavariables ($$$NAME) from a real match', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'mv.ts'),
+      maxResults: 5,
+    });
+    const vars = firstMatchMetaVars(result);
+    // $$$ARGS -> the argument list text ("payload" with quotes).
+    expect(typeof vars.ARGS).toBe('string');
+    expect(vars.ARGS).toContain('payload');
+  });
+
+  it('extracts a standalone single metavariable bound to a whole expression', async () => {
+    const host = createToolHost(tempDir);
+    writeFileSync(
+      join(tempDir, 'standalone.ts'),
+      `targetValue;
+`,
+      'utf-8',
+    );
+    const result = await runGrep(host, {
+      pattern: '$NAME',
+      language: 'typescript',
+      path: join(tempDir, 'standalone.ts'),
+      maxResults: 5,
+    });
+    const vars = firstMatchMetaVars(result);
+    // A bare $NAME binds the whole expression-statement node, whose text
+    // includes the identifier and the trailing semicolon.
+    expect(vars.NAME).toContain('targetValue');
+  });
+});
+
+describe('ast_grep maxResults resolution (issue #3205)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-max-3205-'));
+    // 6 matches in one file.
+    let body = '';
+    for (let i = 0; i < 6; i++) {
+      body += `console.log("m${i}");
+`;
+    }
+    writeFileSync(join(tempDir, 'six.ts'), body, 'utf-8');
+    // 150 matches — exceeds DEFAULT_MAX_RESULTS (100).
+    let big = '';
+    for (let i = 0; i < 150; i++) {
+      big += `console.log("b${i}");
+`;
+    }
+    writeFileSync(join(tempDir, 'big.ts'), big, 'utf-8');
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolves a fractional maxResults by flooring (2.5 -> 2)', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'six.ts'),
+      maxResults: 2.5,
+    });
+    const meta = metadataOf(result);
+    expect(meta.matches?.length).toBe(2);
+    expect(meta.truncated).toBe(true);
+    expect(meta.countInexact).toBe(true);
+  });
+
+  it('resolves maxResults 0 to an empty, partial result', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'six.ts'),
+      maxResults: 0,
+    });
+    const meta = metadataOf(result);
+    expect(meta.matches?.length).toBe(0);
+    expect(meta.truncated).toBe(true);
+    expect(meta.countInexact).toBe(true);
+  });
+
+  it('resolves a negative maxResults to 0 (acquire nothing)', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'six.ts'),
+      maxResults: -3,
+    });
+    const meta = metadataOf(result);
+    expect(meta.matches?.length).toBe(0);
+    // A negative limit resolves to 0 and behaves exactly like an explicit 0:
+    // the result is partial with an inexact (lower-bound) count.
+    expect(meta.truncated).toBe(true);
+    expect(meta.countInexact).toBe(true);
+  });
+
+  it('bounds a nonfinite maxResults (Infinity) to the finite default', async () => {
+    const host = createToolHost(tempDir);
+    // The schema's `type: number` rejects nonfinite values at build time
+    // (ajv treats Infinity/NaN as not-a-number). This is the public
+    // validation contract preserved by #3205: nonfinite never reaches an
+    // unbounded traversal.
+    expect(() =>
+      new AstGrepTool(host).build({
+        pattern: '$OBJ.$F($$$ARGS)',
+        language: 'typescript',
+        path: join(tempDir, 'big.ts'),
+        maxResults: Number.POSITIVE_INFINITY,
+      }),
+    ).toThrow(/maxResults must be number/);
+  });
+
+  it('bounds a NaN maxResults to the finite default', async () => {
+    const host = createToolHost(tempDir);
+    expect(() =>
+      new AstGrepTool(host).build({
+        pattern: '$OBJ.$F($$$ARGS)',
+        language: 'typescript',
+        path: join(tempDir, 'big.ts'),
+        maxResults: Number.NaN,
+      }),
+    ).toThrow(/maxResults must be number/);
+  });
+});
+
+describe('ast_grep observed-count metadata (issue #3205)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-obs-3205-'));
+    let body = '';
+    for (let i = 0; i < 6; i++) {
+      body += `console.log("o${i}");
+`;
+    }
+    writeFileSync(join(tempDir, 'over.ts'), body, 'utf-8');
+    let exact = '';
+    for (let i = 0; i < 5; i++) {
+      exact += `console.log("e${i}");
+`;
+    }
+    writeFileSync(join(tempDir, 'exact.ts'), exact, 'utf-8');
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports matchesObserved == retained for an exact, complete traversal', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'exact.ts'),
+      maxResults: 5,
+    });
+    const meta = metadataOf(result);
+    expect(meta.matchesObserved).toBe(5);
+    expect(meta.matchesRetained).toBe(5);
+    expect(meta.countInexact).toBeFalsy();
+  });
+
+  it('reports matchesObserved >= retained+1 (lower bound) after a sentinel overflow', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runGrep(host, {
+      pattern: '$OBJ.$F($$$ARGS)',
+      language: 'typescript',
+      path: join(tempDir, 'over.ts'),
+      maxResults: 5,
+    });
+    const meta = metadataOf(result);
+    expect(meta.matchesRetained).toBe(5);
+    // The one-over sentinel proves at least 6 existed.
+    expect(meta.matchesObserved).toBeGreaterThanOrEqual(6);
+    expect(meta.countInexact).toBe(true);
+  });
+});
+
+describe('ast_grep skipped-file partiality (issue #3205)', () => {
+  // chmod 000 reliably makes a regular file unreadable only on POSIX, and only
+  // when the process does NOT run as root (root bypasses file permission
+  // bits). On Windows, or when running as root, the fixture cannot produce a
+  // genuine EACCES read failure, so the partial assertion is skipped there
+  // rather than relying on an unreliable chmod. This avoids a test-only
+  // production hook: the fixture produces a real read failure on the platforms
+  // that support it.
+  const supportsUnreadableFixture =
+    process.platform !== 'win32' && process.getuid?.() !== 0;
+
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-skip-3205-'));
+    // One readable file with one match.
+    writeFileSync(
+      join(tempDir, 'readable.ts'),
+      `console.log("ok");
+`,
+      'utf-8',
+    );
+    // One unreadable file (chmod 000) — readFile throws EACCES, recorded as
+    // skipped. Only applied where the fixture genuinely denies reads.
+    writeFileSync(
+      join(tempDir, 'unreadable.ts'),
+      `console.log("nope");
+`,
+      'utf-8',
+    );
+    if (supportsUnreadableFixture) {
+      try {
+        chmodSync(join(tempDir, 'unreadable.ts'), 0o000);
+      } catch {
+        // best effort; if chmod fails the file stays readable
+      }
+    }
+  });
+
+  afterAll(() => {
+    // restore so cleanup can remove it
+    if (supportsUnreadableFixture && tempDir !== '') {
+      try {
+        chmodSync(join(tempDir, 'unreadable.ts'), 0o644);
+      } catch {
+        // ignore
+      }
+    }
+    if (tempDir !== '') {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(!supportsUnreadableFixture)(
+    'marks the result inexact when a file is skipped (no exact totalMatches)',
+    async () => {
+      const host = createToolHost(tempDir);
+      const result = await runGrep(host, {
+        pattern: '$OBJ.$F($$$ARGS)',
+        language: 'typescript',
+        path: tempDir,
+        maxResults: 100,
+      });
+      const meta = metadataOf(result);
+      // The unreadable file was skipped -> at least one skip recorded.
+      expect(meta.skippedFiles).toBeGreaterThanOrEqual(1);
+      // A skipped file means the count cannot be exact: no totalMatches claimed.
+      expect(meta.totalMatches).toBeUndefined();
+      expect(meta.countInexact).toBe(true);
+    },
+  );
+});

--- a/packages/tools/src/tools/ast-grep.behavioral.bun.test.ts
+++ b/packages/tools/src/tools/ast-grep.behavioral.bun.test.ts
@@ -273,6 +273,31 @@ describe('ast_grep bounded acquisition (issue #3205)', () => {
     expect(meta.partialReason).toBe('aborted');
   });
 
+  it('a pre-aborted SINGLE-FILE request avoids read/parse work and returns no matches', async () => {
+    // A single-file target whose content holds many matches. A pre-aborted
+    // signal must short-circuit before reading/parsing: no match records are
+    // retained, and the result is an explicit partial with reason `aborted`.
+    const host = createToolHost(tempDir);
+    const controller = new AbortController();
+    controller.abort();
+    const result = await runGrep(
+      host,
+      {
+        pattern: '$OBJ.$F($$$ARGS)',
+        language: 'typescript',
+        path: join(tempDir, 'far-over.ts'),
+        maxResults: 5,
+      },
+      controller.signal,
+    );
+    const meta = metadataOf(result);
+    expect(meta.truncated).toBe(true);
+    expect(meta.partialReason).toBe('aborted');
+    // No matches materialized: the pre-aborted single-file path must not
+    // read/parse the file.
+    expect((meta.matches ?? []).length).toBe(0);
+  });
+
   it('aborts DURING a real large-directory traversal and returns a partial result', async () => {
     // 300 files × 2 matches = 600 matches. A real AbortController is raised
     // after invocation has begun, at the earliest deterministic macrotask

--- a/packages/tools/src/tools/ast-grep.ts
+++ b/packages/tools/src/tools/ast-grep.ts
@@ -232,6 +232,28 @@ class AstGrepToolInvocation extends BaseToolInvocation<
     };
     let skippedFiles = 0;
 
+    // AbortSignal.aborted is a mutable property; reading it through a helper
+    // avoids TS narrowing it to `false` after the pre-abort check (the signal
+    // can become aborted during an awaited traversal step).
+    const isAborted = (): boolean => signal?.aborted === true;
+
+    // A pre-aborted signal must never read/parse a file or present a falsely
+    // complete result, for either a single-file or directory target. The
+    // directory path re-checks this after its async glob resolution; this
+    // top-level check closes the single-file gap and keeps both paths
+    // consistent.
+    if (isAborted()) {
+      acc.truncated = true;
+      acc.partialReason = 'aborted';
+      return {
+        matches: acc.matches,
+        truncated: acc.truncated,
+        partialReason: acc.partialReason,
+        skippedFiles,
+        observedCount: acc.observedCount,
+      };
+    }
+
     if (isSingleFile) {
       const content = await fs.readFile(searchPath, 'utf-8');
       this.searchContentBounded(
@@ -258,8 +280,9 @@ class AstGrepToolInvocation extends BaseToolInvocation<
       );
     }
 
-    // A pre-aborted signal must never read as a falsely complete result.
-    if (signal?.aborted === true && !acc.truncated) {
+    // A signal that aborts during an awaited traversal step must never read as
+    // a falsely complete result.
+    if (isAborted() && !acc.truncated) {
       acc.truncated = true;
       acc.partialReason = 'aborted';
     }

--- a/packages/tools/src/tools/ast-grep.ts
+++ b/packages/tools/src/tools/ast-grep.ts
@@ -48,11 +48,19 @@ interface AstGrepMatch {
   metaVariables: Record<string, string>;
 }
 
-interface AstGrepResult {
+/** Mutable accumulator for bounded match collection. */
+interface MatchAccumulator {
   matches: AstGrepMatch[];
   truncated: boolean;
-  totalMatches?: number;
-  skippedFiles?: number;
+  partialReason: 'max-results' | 'aborted' | undefined;
+  sentinelObserved: boolean;
+  /**
+   * Number of candidate matches actually observed during traversal. Equals
+   * {@link matches} length for an exact, complete traversal; for a sentinel
+   * overflow it is retained+1 (the one-over node observed to prove partiality
+   * before stopping), so it is a lower bound when truncated.
+   */
+  observedCount: number;
 }
 
 class AstGrepToolInvocation extends BaseToolInvocation<
@@ -79,8 +87,8 @@ class AstGrepToolInvocation extends BaseToolInvocation<
   }
 
   async execute(signal: AbortSignal): Promise<ToolResult> {
-    const { pattern, rule, globs, maxResults } = this.params;
-    const limit = maxResults ?? DEFAULT_MAX_RESULTS;
+    const { pattern, rule, globs } = this.params;
+    const limit = this.resolveLimit(this.params.maxResults);
 
     const resolved = this.validateAndResolveParams();
     if (resolved instanceof Object && 'llmContent' in resolved) return resolved;
@@ -91,20 +99,44 @@ class AstGrepToolInvocation extends BaseToolInvocation<
     };
 
     try {
-      const { allMatches, skippedFiles } = await this.collectMatches(
-        searchPath,
-        isSingleFile,
-        resolvedLang,
+      const { matches, truncated, partialReason, skippedFiles, observedCount } =
+        await this.collectMatches(
+          searchPath,
+          isSingleFile,
+          resolvedLang,
+          pattern,
+          rule,
+          globs,
+          signal,
+          limit,
+        );
+      return this.formatSearchResults(
+        matches,
+        truncated,
+        partialReason,
+        skippedFiles,
+        observedCount,
         pattern,
-        rule,
-        globs,
-        signal,
       );
-      return this.formatSearchResults(allMatches, skippedFiles, limit, pattern);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return this.makeError(`Error searching: ${msg}`);
     }
+  }
+
+  /**
+   * Resolves `maxResults` to a finite, nonnegative integer acquisition limit.
+   *
+   * - `undefined` -> the documented default.
+   * - fractional -> floored (consistent with prior slice semantics).
+   * - zero / negative -> 0 (acquire nothing; a negative slice is empty).
+   * - nonfinite -> default (defensive: the JSON-Schema `type: number` already
+   *   rejects Infinity/NaN at validation, preserving the public contract).
+   */
+  private resolveLimit(maxResults: number | undefined): number {
+    const value = maxResults ?? DEFAULT_MAX_RESULTS;
+    if (!Number.isFinite(value)) return DEFAULT_MAX_RESULTS;
+    return Math.max(0, Math.floor(value));
   }
 
   private validateAndResolveParams():
@@ -178,112 +210,362 @@ class AstGrepToolInvocation extends BaseToolInvocation<
     searchPath: string,
     isSingleFile: boolean,
     resolvedLang: string | Lang,
-    pattern?: string,
-    rule?: Record<string, unknown>,
-    globs?: string[],
-    signal?: AbortSignal,
-  ): Promise<{ allMatches: AstGrepMatch[]; skippedFiles: number }> {
+    pattern: string | undefined,
+    rule: Record<string, unknown> | undefined,
+    globs: string[] | undefined,
+    signal: AbortSignal | undefined,
+    limit: number,
+  ): Promise<{
+    matches: AstGrepMatch[];
+    truncated: boolean;
+    partialReason: 'max-results' | 'aborted' | undefined;
+    skippedFiles: number;
+    observedCount: number;
+  }> {
     const targetDir = this.host.getTargetDir();
-    const allMatches: AstGrepMatch[] = [];
+    const acc: MatchAccumulator = {
+      matches: [],
+      truncated: false,
+      partialReason: undefined,
+      sentinelObserved: false,
+      observedCount: 0,
+    };
     let skippedFiles = 0;
 
     if (isSingleFile) {
       const content = await fs.readFile(searchPath, 'utf-8');
-      allMatches.push(
-        ...this.searchContent(
-          content,
-          resolvedLang,
-          searchPath,
-          targetDir,
-          pattern,
-          rule,
-        ),
+      this.searchContentBounded(
+        content,
+        resolvedLang,
+        searchPath,
+        targetDir,
+        acc,
+        limit,
+        pattern,
+        rule,
       );
     } else {
-      const extensions = this.getExtensionsForLanguage(resolvedLang);
-      let files = await FastGlob(
-        extensions.map((ext) => `**/*.${ext}`),
-        {
-          cwd: searchPath,
-          absolute: true,
-          dot: false,
-          ignore: ['**/node_modules/**', '**/.git/**'],
-        },
+      skippedFiles = await this.collectFromDirectory(
+        searchPath,
+        resolvedLang,
+        globs,
+        signal,
+        pattern,
+        rule,
+        targetDir,
+        acc,
+        limit,
       );
-      files = await this.applyGlobFilters(files, globs, searchPath);
-      for (const file of files) {
-        if (signal?.aborted === true) break;
-        try {
-          const content = await fs.readFile(file, 'utf-8');
-          allMatches.push(
-            ...this.searchContent(
-              content,
-              resolvedLang,
-              file,
-              targetDir,
-              pattern,
-              rule,
-            ),
-          );
-        } catch {
-          skippedFiles++;
+    }
+
+    // A pre-aborted signal must never read as a falsely complete result.
+    if (signal?.aborted === true && !acc.truncated) {
+      acc.truncated = true;
+      acc.partialReason = 'aborted';
+    }
+
+    return {
+      matches: acc.matches,
+      truncated: acc.truncated,
+      partialReason: acc.partialReason,
+      skippedFiles,
+      observedCount: acc.observedCount,
+    };
+  }
+
+  /**
+   * Searches one file's content and accumulates matches INLINE against the
+   * retention limit. At most `limit` match records are ever materialized: once
+   * the limit is reached, the FIRST additional node is observed as a sentinel
+   * (proving truncation) but never turned into a record, and iteration stops.
+   * This avoids building an unbounded mapped match-record array before the
+   * limit is applied. The AST parser may still return its full node array —
+   * no unbounded match-record aggregate is created from it.
+   */
+  private searchContentBounded(
+    content: string,
+    language: string | Lang,
+    filePath: string,
+    workspaceRoot: string,
+    acc: MatchAccumulator,
+    limit: number,
+    pattern?: string,
+    rule?: Record<string, unknown>,
+  ): void {
+    const root = parse(language as Lang, content);
+    const sgRoot = root.root();
+    const relativePath = makeRelative(filePath, workspaceRoot);
+
+    let nodes: SgNode[];
+    if (pattern) {
+      nodes = sgRoot.findAll(pattern);
+    } else if (rule) {
+      nodes = sgRoot.findAll({ rule } as NapiConfig);
+    } else {
+      return;
+    }
+
+    for (const node of nodes) {
+      // Count every observed candidate so the metadata can distinguish an
+      // exact exhausted traversal (observed == retained) from a one-over
+      // sentinel (observed == retained + 1, a lower bound).
+      acc.observedCount++;
+      if (acc.matches.length < limit) {
+        acc.matches.push(this.materializeMatch(node, relativePath, pattern));
+        continue;
+      }
+      if (!acc.sentinelObserved) {
+        acc.sentinelObserved = true;
+        acc.truncated = true;
+        acc.partialReason = 'max-results';
+      }
+      return;
+    }
+  }
+
+  /**
+   * Materializes a single AST node into an {@link AstGrepMatch} record,
+   * including metavariable extraction (single `$NAME` and multi `$$$NAME`).
+   */
+  private materializeMatch(
+    node: SgNode,
+    relativePath: string,
+    pattern?: string,
+  ): AstGrepMatch {
+    const range = node.range();
+    const metaVariables: Record<string, string> = {};
+
+    if (pattern) {
+      const { single, multi } = this.extractMetaVarNames(pattern);
+      for (const name of single) {
+        const match = node.getMatch(name);
+        if (match) {
+          metaVariables[name] = match.text();
+        }
+      }
+      for (const name of multi) {
+        const matches = node.getMultipleMatches(name);
+        if (matches.length > 0) {
+          metaVariables[name] = matches.map((m: SgNode) => m.text()).join(', ');
         }
       }
     }
-    return { allMatches, skippedFiles };
+
+    return {
+      file: relativePath,
+      startLine: range.start.line + 1,
+      startCol: range.start.column,
+      endLine: range.end.line + 1,
+      endCol: range.end.column,
+      text: node.text(),
+      nodeKind: String(node.kind()),
+      metaVariables,
+    };
   }
 
-  private async applyGlobFilters(
-    files: string[],
+  /**
+   * Extracts single ($NAME) and multi ($$$NAME) metavariable names from an
+   * ast-grep pattern by scanning dollar-sign runs directly. A manual scan is
+   * used instead of a regex because a literal dollar in a JS regex requires an
+   * escaped dollar that is easily confused with the end-of-input anchor;
+   * scanning the runs guarantees the literal-dollar semantics for both $NAME
+   * and $$$NAME.
+   *
+   * A run of exactly one dollar followed by NAME is a single metavar; a run of
+   * three dollars followed by NAME is a multi metavar; other runs are not
+   * valid metavariables and are ignored.
+   */
+  private extractMetaVarNames(pattern: string): {
+    single: string[];
+    multi: string[];
+  } {
+    const isNameStart = (ch: string): boolean =>
+      (ch >= 'A' && ch <= 'Z') || ch === '_';
+    const isNamePart = (ch: string): boolean =>
+      isNameStart(ch) || (ch >= '0' && ch <= '9');
+
+    const single: string[] = [];
+    const multi: string[] = [];
+    for (let i = 0; i < pattern.length; i++) {
+      if (pattern[i] !== '$') continue;
+      let dollars = 0;
+      let j = i;
+      while (j < pattern.length && pattern[j] === '$') {
+        dollars++;
+        j++;
+      }
+      if (j < pattern.length && isNameStart(pattern[j])) {
+        let k = j;
+        while (k < pattern.length && isNamePart(pattern[k])) k++;
+        const name = pattern.slice(j, k);
+        if (dollars === 1) {
+          single.push(name);
+        } else if (dollars === 3) {
+          multi.push(name);
+        }
+        i = k - 1;
+      } else {
+        i = j - 1;
+      }
+    }
+    return { single, multi };
+  }
+
+  private async collectFromDirectory(
+    searchPath: string,
+    resolvedLang: string | Lang,
+    globs: string[] | undefined,
+    signal: AbortSignal | undefined,
+    pattern: string | undefined,
+    rule: Record<string, unknown> | undefined,
+    targetDir: string,
+    acc: MatchAccumulator,
+    limit: number,
+  ): Promise<number> {
+    // AbortSignal.aborted is a mutable property; reading it through a helper
+    // avoids TS narrowing it to `false` after the pre-abort check (the signal
+    // can become aborted during an awaited traversal step).
+    const isAborted = (): boolean => signal?.aborted === true;
+    // Pre-abort before discovery: a signal already aborted must never read as
+    // a falsely complete result, and must not materialize a file list.
+    if (isAborted()) {
+      if (!acc.truncated) {
+        acc.truncated = true;
+        acc.partialReason = 'aborted';
+      }
+      return 0;
+    }
+
+    const extensions = this.getExtensionsForLanguage(resolvedLang);
+    // Include/exclude sets are resolved via streaming so the only full
+    // path-array materialization is the user-provided glob subset (not every
+    // language file in the tree). Preserves FastGlob's glob/workspace
+    // semantics and source order.
+    const { includeSet, excludeSet } = await this.resolveGlobSets(
+      globs,
+      searchPath,
+    );
+    let skippedFiles = 0;
+
+    const stream = FastGlob.stream(
+      extensions.map((ext) => `**/*.${ext}`),
+      {
+        cwd: searchPath,
+        absolute: true,
+        dot: false,
+        ignore: ['**/node_modules/**', '**/.git/**'],
+      },
+    );
+
+    // Per-entry processing returns whether the traversal should continue
+    // (keeps the loop body to a single break/continue-free break).
+    const processEntry = async (entry: string): Promise<boolean> => {
+      if (acc.sentinelObserved || isAborted()) {
+        if (isAborted() && !acc.truncated) {
+          acc.truncated = true;
+          acc.partialReason = 'aborted';
+        }
+        return false;
+      }
+      const file = String(entry);
+      if (includeSet !== null && !includeSet.has(file)) return true;
+      if (excludeSet?.has(file) === true) return true;
+      try {
+        const content = await fs.readFile(file, 'utf-8');
+        this.searchContentBounded(
+          content,
+          resolvedLang,
+          file,
+          targetDir,
+          acc,
+          limit,
+          pattern,
+          rule,
+        );
+      } catch {
+        skippedFiles++;
+      }
+      return true;
+    };
+
+    for await (const entry of stream) {
+      if (!(await processEntry(String(entry)))) break;
+    }
+    return skippedFiles;
+  }
+
+  /**
+   * Resolves include/exclude glob sets lazily via FastGlob's streaming API so
+   * glob filtering does not materialize full path arrays for the primary
+   * language discovery. Returns null sets when no globs are supplied (the
+   * common case stays fully streaming).
+   */
+  private async resolveGlobSets(
     globs: string[] | undefined,
     searchPath: string,
-  ): Promise<string[]> {
-    if (!globs || globs.length === 0) return files;
+  ): Promise<{
+    includeSet: Set<string> | null;
+    excludeSet: Set<string> | null;
+  }> {
+    if (!globs || globs.length === 0) {
+      return { includeSet: null, excludeSet: null };
+    }
     const includePatterns = globs.filter((g) => !g.startsWith('!'));
     const excludePatterns = globs
       .filter((g) => g.startsWith('!'))
       .map((g) => g.slice(1));
 
+    let includeSet: Set<string> | null = null;
+    let excludeSet: Set<string> | null = null;
+
     if (includePatterns.length > 0) {
-      const includeSet = new Set(
-        await FastGlob(includePatterns, { cwd: searchPath, absolute: true }),
-      );
-      files = files.filter((f) => includeSet.has(f));
+      includeSet = new Set<string>();
+      for await (const f of FastGlob.stream(includePatterns, {
+        cwd: searchPath,
+        absolute: true,
+      })) {
+        includeSet.add(String(f));
+      }
     }
     if (excludePatterns.length > 0) {
-      const excludeSet = new Set(
-        await FastGlob(excludePatterns, { cwd: searchPath, absolute: true }),
-      );
-      files = files.filter((f) => !excludeSet.has(f));
+      excludeSet = new Set<string>();
+      for await (const f of FastGlob.stream(excludePatterns, {
+        cwd: searchPath,
+        absolute: true,
+      })) {
+        excludeSet.add(String(f));
+      }
     }
-    return files;
+    return { includeSet, excludeSet };
   }
 
   private formatSearchResults(
-    allMatches: AstGrepMatch[],
+    matches: AstGrepMatch[],
+    truncated: boolean,
+    partialReason: 'max-results' | 'aborted' | undefined,
     skippedFiles: number,
-    limit: number,
+    observedCount: number,
     pattern?: string,
   ): ToolResult {
-    const truncated = allMatches.length > limit;
-    const result: AstGrepResult = {
-      matches: allMatches.slice(0, limit),
-      truncated,
-      skippedFiles: skippedFiles > 0 ? skippedFiles : undefined,
-    };
-    if (truncated) {
-      result.totalMatches = allMatches.length;
-    }
-
-    const matchCount = result.matches.length;
+    const matchCount = matches.length;
     const searchDesc = pattern ? `pattern "${pattern}"` : 'rule query';
+    // A skipped (unreadable/unparseable) file means the count cannot be exact:
+    // there may be unobserved matches in files the tool never fully searched.
+    const inexact = truncated || skippedFiles > 0;
+
     let llmContent = `Found ${matchCount} AST match${matchCount !== 1 ? 'es' : ''} for ${searchDesc}`;
     if (truncated) {
-      llmContent += ` (showing ${matchCount} of ${result.totalMatches})`;
+      const note =
+        partialReason === 'aborted'
+          ? ' (aborted; more matches may exist)'
+          : ' (truncated; more matches exist)';
+      llmContent += note;
+    } else if (skippedFiles > 0) {
+      llmContent += ` (${skippedFiles} file${skippedFiles !== 1 ? 's' : ''} skipped; count is a lower bound)`;
     }
     llmContent += ':\n---\n';
 
-    for (const m of result.matches) {
+    for (const m of matches) {
       llmContent += `${m.file}:${m.startLine} [${m.nodeKind}] ${m.text}\n`;
       if (Object.keys(m.metaVariables).length > 0) {
         for (const [k, v] of Object.entries(m.metaVariables)) {
@@ -296,70 +578,21 @@ class AstGrepToolInvocation extends BaseToolInvocation<
     return {
       llmContent: llmContent.trim(),
       returnDisplay: displayMessage,
-      metadata: result as unknown as Record<string, unknown>,
+      // totalMatches is only the exact total when traversal completed fully
+      // AND no file was skipped; it is intentionally omitted after an early
+      // stop or skip so no consumer mistakes a lower bound for an exhaustive
+      // count.
+      metadata: {
+        matches,
+        truncated,
+        matchesRetained: matchCount,
+        // Lower bound on observed candidates (exact when complete).
+        matchesObserved: observedCount,
+        ...(inexact ? { countInexact: true } : { totalMatches: matchCount }),
+        ...(partialReason !== undefined ? { partialReason } : {}),
+        ...(skippedFiles > 0 ? { skippedFiles } : {}),
+      },
     };
-  }
-
-  private searchContent(
-    content: string,
-    language: string | Lang,
-    filePath: string,
-    workspaceRoot: string,
-    pattern?: string,
-    rule?: Record<string, unknown>,
-  ): AstGrepMatch[] {
-    const root = parse(language as Lang, content);
-    const sgRoot = root.root();
-    const relativePath = makeRelative(filePath, workspaceRoot);
-
-    let nodes: SgNode[];
-    if (pattern) {
-      nodes = sgRoot.findAll(pattern);
-    } else if (rule) {
-      nodes = sgRoot.findAll({ rule } as NapiConfig);
-    } else {
-      return [];
-    }
-
-    return nodes.map((node) => {
-      const range = node.range();
-      const metaVariables: Record<string, string> = {};
-
-      // Extract single metavariables ($NAME patterns, excluding $$$ multi-vars)
-      if (pattern) {
-        const metaVarNames =
-          pattern.match(/(?<!\$)\$(?!\$)([A-Z_][A-Z0-9_]*)/g) ?? [];
-        for (const raw of metaVarNames) {
-          const name = raw.slice(1); // remove $
-          const match = node.getMatch(name);
-          if (match) {
-            metaVariables[name] = match.text();
-          }
-        }
-        // Extract multi metavariables ($$$NAME patterns)
-        const multiVarNames = pattern.match(/\$\$\$([A-Z_][A-Z0-9_]*)/g) ?? [];
-        for (const raw of multiVarNames) {
-          const name = raw.slice(3); // remove $$$
-          const matches = node.getMultipleMatches(name);
-          if (matches.length > 0) {
-            metaVariables[name] = matches
-              .map((m: SgNode) => m.text())
-              .join(', ');
-          }
-        }
-      }
-
-      return {
-        file: relativePath,
-        startLine: range.start.line + 1,
-        startCol: range.start.column,
-        endLine: range.end.line + 1,
-        endCol: range.end.column,
-        text: node.text(),
-        nodeKind: String(node.kind()),
-        metaVariables,
-      };
-    });
   }
 
   private getExtensionsForLanguage(lang: string | Lang): string[] {

--- a/packages/tools/src/tools/delete_line_range.ts
+++ b/packages/tools/src/tools/delete_line_range.ts
@@ -27,7 +27,7 @@ import type {
   IToolMessageBus,
 } from '../interfaces/index.js';
 import { ToolErrorType } from '../types/tool-error.js';
-import { getSpecificMimeType } from '../utils/fileUtils.js';
+import { getSpecificMimeType, statFileSizeGate } from '../utils/fileUtils.js';
 import { DEFAULT_CREATE_PATCH_OPTIONS } from '../utils/diffOptions.js';
 import { collectLspDiagnosticsBlock } from '../utils/lsp-diagnostics-helper.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
@@ -104,6 +104,12 @@ class DeleteLineRangeToolInvocation extends BaseToolInvocation<
     }
 
     const filePath = this.getFilePath();
+    // Pre-read size gate: an oversized existing target must not be materialized
+    // for the preview diff. Defer to execute, which emits FILE_TOO_LARGE.
+    const sizeError = await statFileSizeGate(filePath);
+    if (sizeError) {
+      return false;
+    }
     let originalContent: string;
     try {
       originalContent = await fs.readFile(filePath, 'utf8');
@@ -154,6 +160,14 @@ class DeleteLineRangeToolInvocation extends BaseToolInvocation<
 
   async execute(): Promise<ToolResult> {
     const filePath = this.getFilePath();
+    const sizeError = await statFileSizeGate(filePath);
+    if (sizeError) {
+      return {
+        llmContent: sizeError.message,
+        returnDisplay: sizeError.message,
+        error: { message: sizeError.message, type: sizeError.type },
+      };
+    }
     let content: string;
     try {
       content = await fs.readFile(filePath, 'utf8');

--- a/packages/tools/src/tools/edit-utils.ts
+++ b/packages/tools/src/tools/edit-utils.ts
@@ -26,6 +26,7 @@ import type { EditToolParams } from './edit.js';
 import { fuzzyReplace } from '../utils/fuzzy-replacer.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
 import { stringOrDefault } from '../utils/stringCoalescing.js';
+import { statFileSizeGate } from '../utils/fileUtils.js';
 
 /**
  * Computes the character offset for the start of a 1-based line number
@@ -601,6 +602,12 @@ export function createEditModifyContext(
     getFilePath: (params: EditToolParams) => resolveEditFilePath(params),
     getCurrentContent: async (params: EditToolParams): Promise<string> => {
       const filePath = resolveEditFilePath(params);
+      // The modify seam must not materialize an oversized target into a temp
+      // editor file; reject before the read.
+      const sizeError = await statFileSizeGate(filePath);
+      if (sizeError) {
+        throw new Error(sizeError.message);
+      }
       try {
         return await readTextFile(filePath);
       } catch (err) {
@@ -610,6 +617,10 @@ export function createEditModifyContext(
     },
     getProposedContent: async (params: EditToolParams): Promise<string> => {
       const filePath = resolveEditFilePath(params);
+      const sizeError = await statFileSizeGate(filePath);
+      if (sizeError) {
+        throw new Error(sizeError.message);
+      }
       try {
         const raw = await readTextFile(filePath);
         const currentContent = raw.replace(/\r\n/g, '\n');

--- a/packages/tools/src/tools/edit.ts
+++ b/packages/tools/src/tools/edit.ts
@@ -64,6 +64,7 @@ import {
   resolveConstructorArguments,
   type EditErrorInfo,
 } from './edit-utils.js';
+import { statFileSizeGate, validateFileSizeBytes } from '../utils/fileUtils.js';
 
 export {
   applyReplacement,
@@ -119,6 +120,10 @@ export interface EditToolParams {
    */
   ai_proposed_content?: string;
 }
+function gateToEditError(gate: { message: string; type: ToolErrorType }) {
+  return { display: 'File too large.', raw: gate.message, type: gate.type };
+}
+
 interface CalculatedEdit {
   currentContent: string | null;
   newContent: string;
@@ -365,7 +370,12 @@ class EditToolInvocation extends BaseToolInvocation<
       | { display: string; raw: string; type: ToolErrorType }
       | undefined = undefined;
 
-    if (filteredParams.old_string === '' && !fileExists) {
+    // Host divergence: validate authoritative acquired content before diffing.
+    const size = currentContent ? Buffer.byteLength(currentContent) : 0;
+    const gate = validateFileSizeBytes(filePath, size);
+    if (gate) {
+      error = gateToEditError(gate);
+    } else if (filteredParams.old_string === '' && !fileExists) {
       isNewFile = true;
     } else if (!fileExists) {
       error = {
@@ -415,6 +425,25 @@ class EditToolInvocation extends BaseToolInvocation<
   }
 
   /**
+   * Pre-read file-size gate: reject an oversized existing target before any
+   * content read. Returns null when the target is within the limit or is a
+   * new file (statFileSizeGate returns null for a missing file).
+   */
+  private async checkFileSizeGate(
+    filePath: string,
+  ): Promise<CalculatedEdit | null> {
+    const sizeError = await statFileSizeGate(filePath);
+    if (!sizeError) return null;
+    return {
+      currentContent: null,
+      newContent: '',
+      occurrences: 0,
+      error: gateToEditError(sizeError),
+      isNewFile: false,
+    };
+  }
+
+  /**
    * Calculates the potential outcome of an edit operation.
    * @param params Parameters for the edit operation
    * @returns An object describing the potential edit outcome
@@ -424,6 +453,17 @@ class EditToolInvocation extends BaseToolInvocation<
     params: EditToolParams,
     _abortSignal: AbortSignal,
   ): Promise<CalculatedEdit> {
+    const filePath = stringOrDefault(
+      params.absolute_path,
+      stringOrDefault(params.file_path, ''),
+    );
+
+    // Pre-read file-size gate: reject an oversized existing target before any
+    // content read (new-file creation is unaffected — statFileSizeGate returns
+    // null for a missing file).
+    const sizeGateError = await this.checkFileSizeGate(filePath);
+    if (sizeGateError) return sizeGateError;
+
     // Apply emoji filtering to edit content
     // NOTE: old_string is NOT filtered because it needs to match existing content exactly
     // Only new_string is filtered to remove emojis from the replacement text
@@ -452,11 +492,6 @@ class EditToolInvocation extends BaseToolInvocation<
       new_string: newStringResult.filtered as string,
     };
     const expectedReplacements = filteredParams.expected_replacements ?? 1;
-
-    const filePath = stringOrDefault(
-      params.absolute_path,
-      stringOrDefault(params.file_path, ''),
-    );
 
     const {
       currentContent,

--- a/packages/tools/src/tools/file-size-gate.bun.test.ts
+++ b/packages/tools/src/tools/file-size-gate.bun.test.ts
@@ -22,6 +22,7 @@ import {
   rmSync,
   statSync,
   existsSync,
+  chmodSync,
   promises as fsPromises,
 } from 'node:fs';
 import { join } from 'node:path';
@@ -674,6 +675,58 @@ describe('statFileSizeGate only gates regular files (item I)', () => {
 });
 
 /**
+ * statFileSizeGate must narrow its catch to ENOENT only. An unexpected stat
+ * failure (EACCES, EIO, ...) must fail fast (throw) rather than be masked as a
+ * missing file, which would let a real error silently bypass the gate
+ * (issue #3205 item M).
+ */
+describe('statFileSizeGate fails fast on unexpected stat errors (item M)', () => {
+  // chmod 000 on a parent directory denies search (execute) permission, so
+  // stat of a child file fails with EACCES on POSIX non-root. This produces a
+  // real non-ENOENT stat failure without a test-only production hook.
+  const supportsEaccesFixture =
+    process.platform !== 'win32' && process.getuid?.() !== 0;
+  let tempDir = '';
+  let lockedDir = '';
+
+  beforeEach(() => {
+    tempDir = join(
+      tmpdir(),
+      `llxprt-eacces-3205-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+    lockedDir = join(tempDir, 'locked');
+    mkdirSync(lockedDir, { recursive: true });
+    writeFileSync(join(lockedDir, 'inner.txt'), 'hello\n');
+  });
+
+  afterEach(() => {
+    if (supportsEaccesFixture && lockedDir !== '') {
+      try {
+        chmodSync(lockedDir, 0o755);
+      } catch {
+        // best effort: restore so cleanup can remove it
+      }
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(!supportsEaccesFixture)(
+    'throws (does not return null) for a stat EACCES failure',
+    async () => {
+      // Deny traversal into the directory -> stat of the child fails EACCES.
+      chmodSync(lockedDir, 0o000);
+      // A masked-as-missing return would be `null`; fail-fast must throw so the
+      // caller's invocation error handling can surface the real permission
+      // problem instead of silently bypassing the gate.
+      await expect(
+        statFileSizeGate(join(lockedDir, 'inner.txt')),
+      ).rejects.toThrow(/EACCES|permission/i);
+    },
+  );
+});
+
+/**
  * Host filesystem-service content must not bypass the size policy. A host may
  * return content divergent from native stat, so acquired host content is
  * validated immediately after acquisition (issue #3205 item E).
@@ -761,6 +814,25 @@ describe('host divergent-content size policy (item E)', () => {
       { file_path: p, old_string: 'TARGET', new_string: 'REPLACED' },
     );
     expect(isFileTooLarge(result)).toBe(true);
+  });
+
+  it('ast_edit rejects >20MiB host content for a small native target', async () => {
+    const p = join(tempDir, 'small.ts');
+    writeFileSync(p, 'const value = 1;\n');
+    const huge = 'x'.repeat(MAX_FILE_SIZE_BYTES + 1);
+    const result = await runTool(
+      new ASTEditTool(createDivergentHost(tempDir, huge)),
+      {
+        file_path: p,
+        old_string: 'const value = 1;',
+        new_string: 'const value = 2;',
+        force: true,
+      },
+    );
+    expect(isFileTooLarge(result)).toBe(true);
+    // The authoritative host content is rejected before materialization, so
+    // the (small) native target is left unchanged.
+    expect(statSync(p).size).toBe(Buffer.byteLength('const value = 1;\n'));
   });
 });
 

--- a/packages/tools/src/tools/file-size-gate.bun.test.ts
+++ b/packages/tools/src/tools/file-size-gate.bun.test.ts
@@ -1,0 +1,802 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the shared pre-read file-size gate (issue #3205).
+ *
+ * Creates real exact-20-MiB and 20-MiB-plus-one fixture files and exercises
+ * every accepted public read/modification path. Asserts the gate rejects
+ * one-byte-over targets with FILE_TOO_LARGE before any content read/parse/
+ * diff/backup, that the file is left unchanged, and that exactly-20-MiB
+ * targets are accepted. Also proves read_file/read_line_range retain their
+ * existing behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  existsSync,
+  promises as fsPromises,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IToolHost } from '../interfaces/index.js';
+import {
+  ReadFileTool,
+  ReadLineRangeTool,
+  WriteFileTool,
+  EditTool,
+  ApplyPatchTool,
+  InsertAtLineTool,
+  DeleteLineRangeTool,
+  ASTEditTool,
+  ASTReadFileTool,
+  ReadManyFilesTool,
+  ToolErrorType,
+} from '../index.js';
+import type { ToolResult } from '../index.js';
+import { statFileSizeGate } from '../utils/fileUtils.js';
+
+const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
+
+function createHost(targetDir: string): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths: string[]) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({}),
+    getDebugMode: () => false,
+  };
+}
+
+/**
+ * Writes a file of exactly `sizeBytes` bytes. `lead` is written first (UTF-8)
+ * and the remainder is filled with 'x' so the total is exactly `sizeBytes`.
+ */
+function makeExactFile(p: string, sizeBytes: number, lead = 'TARGET\n'): void {
+  const leadBytes = Buffer.byteLength(lead, 'utf-8');
+  const buf = Buffer.alloc(sizeBytes);
+  buf.write(lead, 0, 'utf-8');
+  buf.fill(0x78, leadBytes); // 'x'
+  writeFileSync(p, buf);
+}
+
+/** Writes a valid-TypeScript file of exactly `sizeBytes` bytes. */
+function makeExactTsFile(p: string, sizeBytes: number): void {
+  const lead = 'const _placeholder = 1;\n// ';
+  const leadBytes = Buffer.byteLength(lead, 'utf-8');
+  const buf = Buffer.alloc(sizeBytes);
+  buf.write(lead, 0, 'utf-8');
+  buf.fill(0x78, leadBytes); // 'x' — comment body
+  writeFileSync(p, buf);
+}
+
+function isFileTooLarge(result: ToolResult): boolean {
+  return result.error?.type === ToolErrorType.FILE_TOO_LARGE;
+}
+
+async function runTool(
+  tool: { build(p: unknown): { execute(s: AbortSignal): Promise<ToolResult> } },
+  params: unknown,
+): Promise<ToolResult> {
+  return tool.build(params).execute(new AbortController().signal);
+}
+
+describe('shared pre-read file-size gate (issue #3205)', () => {
+  let tempDir = '';
+
+  beforeEach(() => {
+    tempDir = join(
+      tmpdir(),
+      `llxprt-gate-3205-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // --- read_file / read_line_range regression (existing behavior) -----------
+
+  describe('read_file (regression)', () => {
+    it('rejects a 20-MiB-plus-one file with FILE_TOO_LARGE', async () => {
+      const p = join(tempDir, 'over.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES + 1);
+      const result = await runTool(new ReadFileTool(createHost(tempDir)), {
+        file_path: p,
+      });
+      expect(isFileTooLarge(result)).toBe(true);
+    });
+
+    it('accepts an exactly-20-MiB file', async () => {
+      const p = join(tempDir, 'exact.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES, 'hello\n');
+      const result = await runTool(new ReadFileTool(createHost(tempDir)), {
+        file_path: p,
+      });
+      expect(isFileTooLarge(result)).toBe(false);
+    });
+  });
+
+  describe('read_line_range (regression)', () => {
+    it('rejects a 20-MiB-plus-one file with FILE_TOO_LARGE', async () => {
+      const p = join(tempDir, 'over.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES + 1);
+      const result = await runTool(new ReadLineRangeTool(createHost(tempDir)), {
+        file_path: p,
+        start_line: 1,
+        end_line: 5,
+      });
+      expect(isFileTooLarge(result)).toBe(true);
+    });
+  });
+
+  // --- AST read / edit paths -----------------------------------------------
+
+  describe('ast_read_file', () => {
+    it('rejects a 20-MiB-plus-one .ts file before reading', async () => {
+      const p = join(tempDir, 'over.ts');
+      makeExactTsFile(p, MAX_FILE_SIZE_BYTES + 1);
+      const sizeBefore = statSync(p).size;
+      const result = await runTool(new ASTReadFileTool(createHost(tempDir)), {
+        file_path: p,
+      });
+      expect(isFileTooLarge(result)).toBe(true);
+      expect(statSync(p).size).toBe(sizeBefore);
+    });
+
+    it('accepts an exactly-20-MiB .ts file', async () => {
+      const p = join(tempDir, 'exact.ts');
+      makeExactTsFile(p, MAX_FILE_SIZE_BYTES);
+      const result = await runTool(new ASTReadFileTool(createHost(tempDir)), {
+        file_path: p,
+      });
+      expect(isFileTooLarge(result)).toBe(false);
+    });
+  });
+
+  describe('ast_edit', () => {
+    it('rejects a 20-MiB-plus-one .ts file before parsing', async () => {
+      const p = join(tempDir, 'over.ts');
+      makeExactTsFile(p, MAX_FILE_SIZE_BYTES + 1);
+      const sizeBefore = statSync(p).size;
+      const result = await runTool(new ASTEditTool(createHost(tempDir)), {
+        file_path: p,
+        old_string: 'const _placeholder = 1;',
+        new_string: 'const _placeholder = 2;',
+        force: true,
+      });
+      expect(isFileTooLarge(result)).toBe(true);
+      expect(statSync(p).size).toBe(sizeBefore);
+    });
+
+    it('accepts an exactly-20-MiB .ts file', async () => {
+      const p = join(tempDir, 'exact.ts');
+      makeExactTsFile(p, MAX_FILE_SIZE_BYTES);
+      const result = await runTool(new ASTEditTool(createHost(tempDir)), {
+        file_path: p,
+        old_string: 'const _placeholder = 1;',
+        new_string: 'const _placeholder = 2;',
+        force: true,
+      });
+      expect(isFileTooLarge(result)).toBe(false);
+    });
+  });
+
+  // --- edit / patch / insert / delete / write paths ------------------------
+
+  describe('edit', () => {
+    it('rejects a 20-MiB-plus-one file before reading', async () => {
+      const p = join(tempDir, 'over.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+      const sizeBefore = statSync(p).size;
+      const result = await runTool(new EditTool(createHost(tempDir)), {
+        file_path: p,
+        old_string: 'TARGET',
+        new_string: 'REPLACED',
+      });
+      expect(isFileTooLarge(result)).toBe(true);
+      expect(statSync(p).size).toBe(sizeBefore);
+    });
+
+    it('accepts an exactly-20-MiB file', async () => {
+      const p = join(tempDir, 'exact.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES, 'TARGET\n');
+      const result = await runTool(new EditTool(createHost(tempDir)), {
+        file_path: p,
+        old_string: 'TARGET',
+        new_string: 'REPLACED',
+      });
+      expect(isFileTooLarge(result)).toBe(false);
+    });
+  });
+
+  describe('apply_patch', () => {
+    it('rejects a 20-MiB-plus-one file before reading', async () => {
+      const p = join(tempDir, 'over.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+      const sizeBefore = statSync(p).size;
+      const patch =
+        '--- a/over.txt\n+++ b/over.txt\n@@ -1,1 +1,1 @@\n-TARGET\n+REPLACED\n';
+      const result = await runTool(new ApplyPatchTool(createHost(tempDir)), {
+        absolute_path: p,
+        patch_content: patch,
+      });
+      expect(isFileTooLarge(result)).toBe(true);
+      expect(statSync(p).size).toBe(sizeBefore);
+    });
+
+    it('accepts an exactly-20-MiB file', async () => {
+      const p = join(tempDir, 'exact.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES, 'TARGET\n');
+      const patch =
+        '--- a/exact.txt\n+++ b/exact.txt\n@@ -1,1 +1,1 @@\n-TARGET\n+REPLACED\n';
+      const result = await runTool(new ApplyPatchTool(createHost(tempDir)), {
+        absolute_path: p,
+        patch_content: patch,
+      });
+      expect(isFileTooLarge(result)).toBe(false);
+    });
+  });
+
+  describe('insert_at_line', () => {
+    it('rejects a 20-MiB-plus-one file before reading', async () => {
+      const p = join(tempDir, 'over.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+      const sizeBefore = statSync(p).size;
+      const result = await runTool(new InsertAtLineTool(createHost(tempDir)), {
+        file_path: p,
+        line_number: 1,
+        content: 'INSERTED\n',
+      });
+      expect(isFileTooLarge(result)).toBe(true);
+      expect(statSync(p).size).toBe(sizeBefore);
+    });
+
+    it('accepts an exactly-20-MiB file', async () => {
+      const p = join(tempDir, 'exact.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES, 'TARGET\n');
+      const result = await runTool(new InsertAtLineTool(createHost(tempDir)), {
+        file_path: p,
+        line_number: 1,
+        content: 'INSERTED\n',
+      });
+      expect(isFileTooLarge(result)).toBe(false);
+    });
+  });
+
+  describe('delete_line_range', () => {
+    it('rejects a 20-MiB-plus-one file before reading', async () => {
+      const p = join(tempDir, 'over.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+      const sizeBefore = statSync(p).size;
+      const result = await runTool(
+        new DeleteLineRangeTool(createHost(tempDir)),
+        { file_path: p, start_line: 1, end_line: 1 },
+      );
+      expect(isFileTooLarge(result)).toBe(true);
+      // The shared authoritative message carries the path/size (finding 1):
+      // the generic 'File size exceeds the 20MB limit.' must not be duplicated.
+      expect(String(result.llmContent)).toContain('over.txt');
+      expect(statSync(p).size).toBe(sizeBefore);
+    });
+
+    it('accepts an exactly-20-MiB file', async () => {
+      const p = join(tempDir, 'exact.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES, 'TARGET\n');
+      const result = await runTool(
+        new DeleteLineRangeTool(createHost(tempDir)),
+        { file_path: p, start_line: 1, end_line: 1 },
+      );
+      expect(isFileTooLarge(result)).toBe(false);
+    });
+  });
+
+  describe('write_file (existing-target read-before-write)', () => {
+    it('rejects a 20-MiB-plus-one existing file before reading', async () => {
+      const p = join(tempDir, 'over.txt');
+      makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+      const sizeBefore = statSync(p).size;
+      const result = await runTool(new WriteFileTool(createHost(tempDir)), {
+        file_path: p,
+        content: 'REPLACED\n',
+      });
+      expect(isFileTooLarge(result)).toBe(true);
+      expect(statSync(p).size).toBe(sizeBefore);
+    });
+
+    it('preserves new-file creation (no existing target to gate)', async () => {
+      const p = join(tempDir, 'new.txt');
+      const result = await runTool(new WriteFileTool(createHost(tempDir)), {
+        file_path: p,
+        content: 'brand new file\n',
+      });
+      expect(isFileTooLarge(result)).toBe(false);
+      expect(result.error).toBeUndefined();
+    });
+  });
+});
+
+/**
+ * Host filesystem-service path coverage (issue #3205).
+ *
+ * The existing suites above exercise the native-fs fallback (no
+ * `getFileSystemService`). These tests wire a host whose `readTextFile`/
+ * `writeTextFile` are backed by the REAL filesystem, so the gate is exercised
+ * over the host read path too. A canary marker file proves behaviorally
+ * (filesystem state, not call counts) whether the host read was invoked.
+ */
+describe('host filesystem-service paths (issue #3205)', () => {
+  let tempDir = '';
+
+  beforeEach(() => {
+    tempDir = join(
+      tmpdir(),
+      `llxprt-host-3205-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Host whose `readTextFile`/`writeTextFile` are real fs operations. When
+   * `readTextFile` runs it writes a canary marker file — an observable
+   * filesystem side-effect that proves (without call counts) whether the host
+   * read path was actually reached.
+   */
+  function createHostWithFileService(
+    targetDir: string,
+    canaryPath: string,
+  ): IToolHost {
+    return {
+      ...createHost(targetDir),
+      getFileSystemService: () => ({
+        readTextFile: (filePath: string) => {
+          writeFileSync(canaryPath, 'host-read-invoked');
+          return fsPromises.readFile(filePath, 'utf-8');
+        },
+        writeTextFile: (filePath: string, content: string) =>
+          fsPromises.writeFile(filePath, content),
+      }),
+    };
+  }
+
+  describe('ast_read_file over the host read path', () => {
+    it('rejects a 20-MiB-plus-one file before the host read is needed', async () => {
+      const p = join(tempDir, 'over.ts');
+      makeExactTsFile(p, MAX_FILE_SIZE_BYTES + 1);
+      const canary = join(tempDir, 'read-canary');
+      const sizeBefore = statSync(p).size;
+      const result = await runTool(
+        new ASTReadFileTool(createHostWithFileService(tempDir, canary)),
+        { file_path: p },
+      );
+      expect(isFileTooLarge(result)).toBe(true);
+      expect(statSync(p).size).toBe(sizeBefore);
+      // The host read was never needed: the gate fired first, so the canary
+      // marker (written only when readTextFile runs) must not exist.
+      expect(existsSync(canary)).toBe(false);
+    });
+
+    it('exercises the host read path for a within-limit file', async () => {
+      const p = join(tempDir, 'ok.ts');
+      writeFileSync(p, 'const value = 42;\n');
+      const canary = join(tempDir, 'read-canary');
+      const result = await runTool(
+        new ASTReadFileTool(createHostWithFileService(tempDir, canary)),
+        { file_path: p },
+      );
+      expect(isFileTooLarge(result)).toBe(false);
+      // The host read path was actually used (canary written), proving the
+      // service is wired up and the over-limit test above is meaningful.
+      expect(existsSync(canary)).toBe(true);
+    });
+  });
+
+  describe('ast_edit over the host read path', () => {
+    it('rejects a 20-MiB-plus-one file before reading and leaves it unchanged', async () => {
+      const p = join(tempDir, 'over.ts');
+      makeExactTsFile(p, MAX_FILE_SIZE_BYTES + 1);
+      const canary = join(tempDir, 'edit-canary');
+      const sizeBefore = statSync(p).size;
+      const result = await runTool(
+        new ASTEditTool(createHostWithFileService(tempDir, canary)),
+        {
+          file_path: p,
+          old_string: 'const _placeholder = 1;',
+          new_string: 'const _placeholder = 2;',
+          force: true,
+        },
+      );
+      expect(isFileTooLarge(result)).toBe(true);
+      expect(statSync(p).size).toBe(sizeBefore);
+      // The host read was never needed: the gate fired before any parse/read.
+      expect(existsSync(canary)).toBe(false);
+    });
+  });
+});
+
+/**
+ * Preview / confirmation / modify paths must reject oversized targets before
+ * materializing content (issue #3205 item A).
+ *
+ * In non-auto approval the tools build a diff preview by reading the existing
+ * target. The shared pre-read gate must fire in that path too, returning false
+ * (defer to execute) for a one-byte-over file instead of reading/diffing it.
+ * A within-limit counterpart proves the preview is still built normally.
+ */
+describe('preview/confirmation paths reject oversized targets (item A)', () => {
+  let tempDir = '';
+
+  beforeEach(() => {
+    tempDir = join(
+      tmpdir(),
+      `llxprt-preview-3205-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function createNonAutoHost(targetDir: string): IToolHost {
+    return { ...createHost(targetDir), getApprovalMode: () => 'default' };
+  }
+
+  async function runShouldConfirm(
+    tool: {
+      build(p: unknown): {
+        shouldConfirmExecute?(s: AbortSignal): Promise<unknown>;
+      };
+    },
+    params: unknown,
+  ): Promise<unknown> {
+    const invocation = tool.build(params);
+    const fn = invocation.shouldConfirmExecute;
+    if (typeof fn !== 'function') {
+      throw new Error('invocation has no shouldConfirmExecute');
+    }
+    return fn.call(invocation, new AbortController().signal);
+  }
+
+  it('insert_at_line preview returns false for an oversized file and leaves it unchanged', async () => {
+    const p = join(tempDir, 'over.txt');
+    makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+    const sizeBefore = statSync(p).size;
+    const result = await runShouldConfirm(
+      new InsertAtLineTool(createNonAutoHost(tempDir)),
+      { file_path: p, line_number: 1, content: 'INSERTED\n' },
+    );
+    expect(result).toBe(false);
+    expect(statSync(p).size).toBe(sizeBefore);
+  });
+
+  it('insert_at_line preview is built for a within-limit file', async () => {
+    const p = join(tempDir, 'ok.txt');
+    writeFileSync(p, 'TARGET\n');
+    const result = await runShouldConfirm(
+      new InsertAtLineTool(createNonAutoHost(tempDir)),
+      { file_path: p, line_number: 1, content: 'INSERTED\n' },
+    );
+    expect(result).not.toBe(false);
+  });
+
+  it('delete_line_range preview returns false for an oversized file', async () => {
+    const p = join(tempDir, 'over.txt');
+    makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+    const result = await runShouldConfirm(
+      new DeleteLineRangeTool(createNonAutoHost(tempDir)),
+      { file_path: p, start_line: 1, end_line: 1 },
+    );
+    expect(result).toBe(false);
+  });
+
+  it('delete_line_range preview is built for a within-limit file', async () => {
+    const p = join(tempDir, 'ok.txt');
+    writeFileSync(p, 'line1\nline2\n');
+    const result = await runShouldConfirm(
+      new DeleteLineRangeTool(createNonAutoHost(tempDir)),
+      { file_path: p, start_line: 1, end_line: 1 },
+    );
+    expect(result).not.toBe(false);
+  });
+
+  it('apply_patch preview returns false for an oversized file', async () => {
+    const p = join(tempDir, 'over.txt');
+    makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+    const patch =
+      '--- a/over.txt\n+++ b/over.txt\n@@ -1,1 +1,1 @@\n-TARGET\n+REPLACED\n';
+    const result = await runShouldConfirm(
+      new ApplyPatchTool(createNonAutoHost(tempDir)),
+      { absolute_path: p, patch_content: patch },
+    );
+    expect(result).toBe(false);
+  });
+
+  it('apply_patch preview is built for a within-limit file', async () => {
+    const p = join(tempDir, 'ok.txt');
+    writeFileSync(p, 'TARGET\n');
+    const patch =
+      '--- a/ok.txt\n+++ b/ok.txt\n@@ -1,1 +1,1 @@\n-TARGET\n+REPLACED\n';
+    const result = await runShouldConfirm(
+      new ApplyPatchTool(createNonAutoHost(tempDir)),
+      { absolute_path: p, patch_content: patch },
+    );
+    expect(result).not.toBe(false);
+  });
+
+  it('write_file preview returns false for an oversized existing file', async () => {
+    const p = join(tempDir, 'over.txt');
+    makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+    const result = await runShouldConfirm(
+      new WriteFileTool(createNonAutoHost(tempDir)),
+      { file_path: p, content: 'REPLACED\n' },
+    );
+    expect(result).toBe(false);
+  });
+
+  it('write_file preview is built for a within-limit existing file', async () => {
+    const p = join(tempDir, 'ok.txt');
+    writeFileSync(p, 'TARGET\n');
+    const result = await runShouldConfirm(
+      new WriteFileTool(createNonAutoHost(tempDir)),
+      { file_path: p, content: 'REPLACED\n' },
+    );
+    expect(result).not.toBe(false);
+  });
+});
+
+/**
+ * Modify-context seams (getModifyContext) must reject oversized targets before
+ * reading them into temp editor files (issue #3205 item A).
+ */
+describe('modify-context paths reject oversized targets (item A)', () => {
+  let tempDir = '';
+
+  beforeEach(() => {
+    tempDir = join(
+      tmpdir(),
+      `llxprt-modify-3205-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('write_file getModifyContext rejects an oversized existing target', async () => {
+    const p = join(tempDir, 'over.txt');
+    makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+    const tool = new WriteFileTool(createHost(tempDir));
+    const ctx = tool.getModifyContext(new AbortController().signal);
+    await expect(
+      ctx.getCurrentContent({ file_path: p, content: 'X\n' }),
+    ).rejects.toThrow(/20MB|exceeds/i);
+  });
+
+  it('write_file getModifyContext accepts a within-limit existing target', async () => {
+    const p = join(tempDir, 'ok.txt');
+    writeFileSync(p, 'TARGET\n');
+    const tool = new WriteFileTool(createHost(tempDir));
+    const ctx = tool.getModifyContext(new AbortController().signal);
+    const content = await ctx.getCurrentContent({
+      file_path: p,
+      content: 'X\n',
+    });
+    expect(content).toBe('TARGET\n');
+  });
+
+  it('edit getModifyContext rejects an oversized existing target', async () => {
+    const p = join(tempDir, 'over.txt');
+    makeExactFile(p, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+    const tool = new EditTool(createHost(tempDir));
+    const ctx = tool.getModifyContext(new AbortController().signal);
+    await expect(
+      ctx.getCurrentContent({
+        file_path: p,
+        old_string: 'TARGET',
+        new_string: 'REPLACED',
+      }),
+    ).rejects.toThrow(/20MB|exceeds/i);
+  });
+});
+
+/**
+ * The pre-read gate must apply FILE_TOO_LARGE only to regular files; a
+ * directory target falls through to established directory/error handling
+ * (issue #3205 item I).
+ */
+describe('statFileSizeGate only gates regular files (item I)', () => {
+  let tempDir = '';
+
+  beforeEach(() => {
+    tempDir = join(
+      tmpdir(),
+      `llxprt-isfile-3205-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns null for a directory (no FILE_TOO_LARGE classification)', async () => {
+    const dir = join(tempDir, 'subdir');
+    mkdirSync(dir, { recursive: true });
+    const gate = await statFileSizeGate(dir);
+    expect(gate).toBeNull();
+  });
+
+  it('returns null for a missing file (caller handles ENOENT)', async () => {
+    const gate = await statFileSizeGate(join(tempDir, 'nope.txt'));
+    expect(gate).toBeNull();
+  });
+
+  it('rejects a one-byte-over regular file', async () => {
+    const p = join(tempDir, 'over.txt');
+    makeExactFile(p, MAX_FILE_SIZE_BYTES + 1);
+    const gate = await statFileSizeGate(p);
+    expect(gate).not.toBeNull();
+    expect(gate?.type).toBe(ToolErrorType.FILE_TOO_LARGE);
+  });
+});
+
+/**
+ * Host filesystem-service content must not bypass the size policy. A host may
+ * return content divergent from native stat, so acquired host content is
+ * validated immediately after acquisition (issue #3205 item E).
+ */
+describe('host divergent-content size policy (item E)', () => {
+  let tempDir = '';
+
+  beforeEach(() => {
+    tempDir = join(
+      tmpdir(),
+      `llxprt-divergent-3205-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function createDivergentHost(
+    targetDir: string,
+    hostContent: string,
+  ): IToolHost {
+    return {
+      ...createHost(targetDir),
+      getFileSystemService: () => ({
+        readTextFile: async () => hostContent,
+        writeTextFile: async (filePath: string, content: string) =>
+          fsPromises.writeFile(filePath, content),
+      }),
+    };
+  }
+
+  it('ast_read_file rejects >20MiB host content for a small native target', async () => {
+    const p = join(tempDir, 'small.ts');
+    writeFileSync(p, 'const value = 1;\n');
+    const huge = 'x'.repeat(MAX_FILE_SIZE_BYTES + 1);
+    const result = await runTool(
+      new ASTReadFileTool(createDivergentHost(tempDir, huge)),
+      { file_path: p },
+    );
+    expect(isFileTooLarge(result)).toBe(true);
+  });
+
+  it('ast_read_file rejects >20MiB host content for a nonexistent native target', async () => {
+    const p = join(tempDir, 'missing.ts');
+    const huge = 'x'.repeat(MAX_FILE_SIZE_BYTES + 1);
+    const result = await runTool(
+      new ASTReadFileTool(createDivergentHost(tempDir, huge)),
+      { file_path: p },
+    );
+    expect(isFileTooLarge(result)).toBe(true);
+  });
+
+  it('ast_read_file accepts exactly-20MiB host content', async () => {
+    const p = join(tempDir, 'exact.ts');
+    writeFileSync(p, 'const value = 1;\n');
+    const exact = 'x'.repeat(MAX_FILE_SIZE_BYTES);
+    const result = await runTool(
+      new ASTReadFileTool(createDivergentHost(tempDir, exact)),
+      { file_path: p },
+    );
+    expect(isFileTooLarge(result)).toBe(false);
+  });
+
+  it('apply_patch rejects >20MiB host content for a small native target', async () => {
+    const p = join(tempDir, 'small.txt');
+    writeFileSync(p, 'TARGET\n');
+    const huge = 'x'.repeat(MAX_FILE_SIZE_BYTES + 1) + '\n';
+    const patch =
+      '--- a/small.txt\n+++ b/small.txt\n@@ -1,1 +1,1 @@\n-TARGET\n+NEW\n';
+    const result = await runTool(
+      new ApplyPatchTool(createDivergentHost(tempDir, huge)),
+      { absolute_path: p, patch_content: patch },
+    );
+    expect(isFileTooLarge(result)).toBe(true);
+  });
+
+  it('edit rejects >20MiB host content for a small native target', async () => {
+    const p = join(tempDir, 'small.txt');
+    writeFileSync(p, 'TARGET\n');
+    const huge = 'x'.repeat(MAX_FILE_SIZE_BYTES + 1);
+    const result = await runTool(
+      new EditTool(createDivergentHost(tempDir, huge)),
+      { file_path: p, old_string: 'TARGET', new_string: 'REPLACED' },
+    );
+    expect(isFileTooLarge(result)).toBe(true);
+  });
+});
+
+/**
+ * read_many_files must apply the shared gate to each file (issue #3205 item J).
+ * processSingleFileContent already enforces it; this proves the behavior holds
+ * through the public read_many_files entry point.
+ */
+describe('read_many_files applies the size gate (item J)', () => {
+  let tempDir = '';
+
+  beforeEach(() => {
+    tempDir = join(
+      tmpdir(),
+      `llxptr-rmf-3205-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('skips an oversized file without crashing the batch', async () => {
+    const over = join(tempDir, 'over.txt');
+    makeExactFile(over, MAX_FILE_SIZE_BYTES + 1, 'TARGET\n');
+    const ok = join(tempDir, 'ok.txt');
+    writeFileSync(ok, 'hello\n');
+    const tool = new ReadManyFilesTool(createHost(tempDir));
+    const result = await tool.execute(
+      { paths: [join(tempDir, '*.txt')] },
+      new AbortController().signal,
+    );
+    expect(result.error).toBeUndefined();
+    // The within-limit file is read; the oversized one is skipped/errored per
+    // file but does not fail the whole batch.
+    expect(String(result.llmContent)).toContain('ok.txt');
+  });
+});

--- a/packages/tools/src/tools/insert_at_line.ts
+++ b/packages/tools/src/tools/insert_at_line.ts
@@ -26,7 +26,7 @@ import type {
   IToolMessageBus,
 } from '../interfaces/index.js';
 import { ToolErrorType } from '../types/tool-error.js';
-import { getSpecificMimeType } from '../utils/fileUtils.js';
+import { getSpecificMimeType, statFileSizeGate } from '../utils/fileUtils.js';
 import { DEFAULT_CREATE_PATCH_OPTIONS } from '../utils/diffOptions.js';
 import { collectLspDiagnosticsBlock } from '../utils/lsp-diagnostics-helper.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
@@ -136,6 +136,12 @@ class InsertAtLineToolInvocation extends BaseToolInvocation<
     }
 
     const filePath = this.getFilePath();
+    // Pre-read size gate: an oversized existing target must not be materialized
+    // for the preview diff. Defer to execute, which emits FILE_TOO_LARGE.
+    const sizeError = await statFileSizeGate(filePath);
+    if (sizeError) {
+      return false;
+    }
     let originalContent = '';
     let fileExists = true;
     try {
@@ -228,6 +234,17 @@ class InsertAtLineToolInvocation extends BaseToolInvocation<
     | { ok: false; result: ToolResult }
   > {
     const filePath = this.getFilePath();
+    const sizeError = await statFileSizeGate(filePath);
+    if (sizeError) {
+      return {
+        ok: false,
+        result: {
+          llmContent: sizeError.message,
+          returnDisplay: sizeError.message,
+          error: { message: sizeError.message, type: sizeError.type },
+        },
+      };
+    }
     let content: string;
     let fileExists = true;
     try {

--- a/packages/tools/src/tools/structural-analysis.ts
+++ b/packages/tools/src/tools/structural-analysis.ts
@@ -41,6 +41,10 @@ import { executeCallees } from './structural-analysis/callees.js';
 import { executeReferences } from './structural-analysis/references.js';
 import { executeDependencies } from './structural-analysis/dependencies.js';
 import { executeExports } from './structural-analysis/exports.js';
+import {
+  resolveAnalysisBudget,
+  type AnalysisBudget,
+} from './structural-analysis/budget.js';
 
 export type { StructuralAnalysisParams } from './structural-analysis/types.js';
 
@@ -53,6 +57,7 @@ interface ResolvedParams {
   depth: number;
   maxNodes: number;
   reverse: boolean;
+  budget: AnalysisBudget;
 }
 
 class StructuralAnalysisInvocation extends BaseToolInvocation<
@@ -82,10 +87,14 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
     const mode = analysisResult.mode;
     const symbol = analysisResult.symbol ? ` for ${analysisResult.symbol}` : '';
     const displayMessage = `${mode} analysis${symbol} complete${analysisResult.truncated ? ' (truncated)' : ''}`;
+    // metadata carries only bounded summary/truncation fields — the full
+    // results aggregate lives solely in llmContent (the JSON source of truth).
+    const { results: _results, ...summary } = analysisResult;
+    void _results;
     return {
       llmContent,
       returnDisplay: displayMessage,
-      metadata: analysisResult as unknown as Record<string, unknown>,
+      metadata: { ...summary },
     };
   }
 
@@ -150,6 +159,11 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
       depth: Math.min(depth ?? DEFAULT_DEPTH, MAX_DEPTH),
       maxNodes: maxNodes ?? DEFAULT_MAX_NODES,
       reverse: reverse === true,
+      budget: resolveAnalysisBudget(
+        this.host.getEphemeralSettings()['tool-output-max-items'] as
+          | number
+          | undefined,
+      ),
     };
   }
 
@@ -165,7 +179,6 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
       symbol,
       depth,
       maxNodes,
-      reverse,
     } = params;
 
     switch (mode as Mode) {
@@ -205,27 +218,43 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
           maxNodes,
           signal,
         );
-      case 'references':
-        return executeReferences(
-          symbol!,
-          resolvedLang,
-          searchPath,
-          targetDir,
-          signal,
-        );
-      case 'dependencies':
-        return executeDependencies(
-          searchPath,
-          resolvedLang,
-          targetDir,
-          reverse,
-          signal,
-        );
-      case 'exports':
-        return executeExports(searchPath, resolvedLang, targetDir, signal);
       default:
-        throw new Error(`Mode "${mode}" is not implemented.`);
+        return this.dispatchBoundedMode(mode as Mode, params, signal);
     }
+  }
+
+  /**
+   * Dispatch the bounded-acquisition modes (references/dependencies/exports)
+   * that carry finite file/record budgets.
+   */
+  private dispatchBoundedMode(
+    mode: Mode,
+    params: ResolvedParams,
+    signal: AbortSignal,
+  ): Promise<AnalysisResult> {
+    const { resolvedLang, searchPath, targetDir, symbol, reverse, budget } =
+      params;
+    if (mode === 'references') {
+      return executeReferences(
+        symbol!,
+        resolvedLang,
+        searchPath,
+        targetDir,
+        signal,
+        budget,
+      );
+    }
+    if (mode === 'dependencies') {
+      return executeDependencies(
+        searchPath,
+        resolvedLang,
+        targetDir,
+        reverse,
+        signal,
+        budget,
+      );
+    }
+    return executeExports(searchPath, resolvedLang, targetDir, signal, budget);
   }
 
   async execute(signal: AbortSignal): Promise<ToolResult> {

--- a/packages/tools/src/tools/structural-analysis/budget.bun.test.ts
+++ b/packages/tools/src/tools/structural-analysis/budget.bun.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Focused behavioral tests for BudgetTracker abort accounting (issue #3205).
+ *
+ * Exercises the real BudgetTracker directly (no mocks) to prove that an
+ * already-aborted signal cannot increment observed/retained records and that
+ * markAborted respects the authoritative signal it was constructed with.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { BudgetTracker, resolveAnalysisBudget } from './budget.js';
+
+describe('BudgetTracker abort accounting (issue #3205)', () => {
+  it('tryRetainRecord does not increment records when the signal is already aborted', () => {
+    const budget = resolveAnalysisBudget(5);
+    const controller = new AbortController();
+    controller.abort();
+    const tracker = new BudgetTracker(budget, controller.signal);
+
+    // The record budget is 5 and nothing has been retained yet, so without an
+    // abort guard this would retain a record and return true.
+    const retained = tracker.tryRetainRecord();
+
+    expect(retained).toBe(false);
+    expect(tracker.recordsObserved).toBe(0);
+    expect(tracker.recordsRetained).toBe(0);
+    // An already-aborted signal surfaces explicit partial metadata.
+    expect(tracker.truncated).toBe(true);
+    expect(tracker.partialReason).toBe('aborted');
+    expect(tracker.countInexact).toBe(true);
+  });
+
+  it('tryRetainRecord retains records normally while the signal is not aborted', () => {
+    const budget = resolveAnalysisBudget(5);
+    const controller = new AbortController();
+    const tracker = new BudgetTracker(budget, controller.signal);
+
+    expect(tracker.tryRetainRecord()).toBe(true);
+    expect(tracker.tryRetainRecord()).toBe(true);
+    expect(tracker.recordsObserved).toBe(2);
+    expect(tracker.recordsRetained).toBe(2);
+    expect(tracker.truncated).toBe(false);
+  });
+
+  it('markAborted does not alter metadata when the signal is not aborted', () => {
+    const budget = resolveAnalysisBudget(5);
+    const controller = new AbortController();
+    const tracker = new BudgetTracker(budget, controller.signal);
+
+    // Retain a record so there is observable state to protect.
+    tracker.tryRetainRecord();
+    expect(tracker.truncated).toBe(false);
+
+    // Calling markAborted on a non-aborted signal must be a no-op: the tracker
+    // owns the authoritative signal and must not fabricate an abort.
+    tracker.markAborted();
+
+    expect(tracker.truncated).toBe(false);
+    expect(tracker.partialReason).toBeUndefined();
+    expect(tracker.countInexact).toBe(false);
+    // Prior accounting is untouched.
+    expect(tracker.recordsRetained).toBe(1);
+  });
+
+  it('markAborted marks partial metadata when the signal is actually aborted', () => {
+    const budget = resolveAnalysisBudget(5);
+    const controller = new AbortController();
+    controller.abort();
+    const tracker = new BudgetTracker(budget, controller.signal);
+
+    tracker.markAborted();
+
+    expect(tracker.truncated).toBe(true);
+    expect(tracker.partialReason).toBe('aborted');
+    expect(tracker.countInexact).toBe(true);
+  });
+});

--- a/packages/tools/src/tools/structural-analysis/budget.ts
+++ b/packages/tools/src/tools/structural-analysis/budget.ts
@@ -116,8 +116,18 @@ export class BudgetTracker {
    * the budget (caller retains it). Returns false when the record budget is
    * exhausted: the FIRST such call observes the one-over sentinel (setting
    * truncated/partialReason) and the record must NOT be retained.
+   *
+   * Also returns false without incrementing any counter when the signal has
+   * already aborted. An abort can be observed between the file-level check
+   * ({@link shouldVisitMoreFiles}) and record retention (after an async file
+   * parse), so the record loop must not inflate observed/retained counts once
+   * the authoritative signal is aborted.
    */
   tryRetainRecord(): boolean {
+    if (this.signal.aborted) {
+      this.markTruncated('aborted');
+      return false;
+    }
     this.recordsObserved++;
     if (this.recordsRetained < this.budget.recordBudget) {
       this.recordsRetained++;
@@ -130,9 +140,16 @@ export class BudgetTracker {
     return false;
   }
 
-  /** Mark the traversal aborted by the caller's signal. */
+  /**
+   * Mark the traversal aborted by the caller's signal. Respects the
+   * authoritative signal this tracker was constructed with: a no-op when the
+   * signal is not actually aborted, so a stray call cannot fabricate partial
+   * metadata.
+   */
   markAborted(): void {
-    this.markTruncated('aborted');
+    if (this.signal.aborted) {
+      this.markTruncated('aborted');
+    }
   }
 
   /** Whether counts are lower bounds rather than exhaustive totals. */

--- a/packages/tools/src/tools/structural-analysis/budget.ts
+++ b/packages/tools/src/tools/structural-analysis/budget.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Bounded acquisition budget contracts for structural-analysis modes.
+ *
+ * Reuses the validated finite-budget/truncation-accounting pattern established
+ * by #3200 (acquisition/byteBudget) — but for record/file counts rather than
+ * bytes, and without routing record aggregation through the head/tail stream
+ * collector (per #3205 scope boundaries).
+ *
+ * @plan PLAN-20260810-ISSUE3205
+ */
+
+import type { PartialReason } from './types.js';
+
+/** Effective finite caps applied to a single analysis traversal. */
+export interface AnalysisBudget {
+  /** Maximum number of files whose discovery/parse is attempted. */
+  readonly fileBudget: number;
+  /** Maximum number of records retained in the result aggregate. */
+  readonly recordBudget: number;
+}
+
+/** Default record budget when no `tool-output-max-items` setting is present. */
+export const DEFAULT_STRUCTURE_RECORD_BUDGET = 500;
+
+/** Absolute ceiling for the record budget regardless of configuration. */
+export const MAX_STRUCTURE_RECORD_BUDGET = 5000;
+
+/** File budget is a multiple of the record budget so file discovery stays
+ * finite even when the record budget is large. */
+export const FILE_BUDGET_MULTIPLIER = 4;
+
+/** Absolute ceiling for the file budget regardless of configuration. */
+export const MAX_STRUCTURE_FILE_BUDGET = 5000;
+
+function clampFinite(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value) || value < min) return min;
+  return Math.min(Math.floor(value), max);
+}
+
+/**
+ * Resolve the effective file/record budgets from the validated
+ * `tool-output-max-items` ephemeral setting (or a sensible default).
+ *
+ * No new setting/schema/public tool parameter is introduced; the existing
+ * validated setting is the only input. Both budgets are clamped to finite
+ * ceilings so traversal is always bounded regardless of user configuration.
+ */
+export function resolveAnalysisBudget(
+  maxItemsSetting: number | undefined,
+): AnalysisBudget {
+  const base =
+    typeof maxItemsSetting === 'number' && maxItemsSetting > 0
+      ? maxItemsSetting
+      : DEFAULT_STRUCTURE_RECORD_BUDGET;
+  const recordBudget = clampFinite(base, 1, MAX_STRUCTURE_RECORD_BUDGET);
+  const fileBudget = clampFinite(
+    base * FILE_BUDGET_MULTIPLIER,
+    1,
+    MAX_STRUCTURE_FILE_BUDGET,
+  );
+  return { fileBudget, recordBudget };
+}
+
+/**
+ * Mutable tracker for a single bounded traversal. Owns the file/record
+ * accounting and the one-sentinel observation that distinguishes an exact
+ * record-budget exhaustion (complete) from a one-over (partial).
+ */
+export class BudgetTracker {
+  filesVisited = 0;
+  recordsRetained = 0;
+  /**
+   * Total records observed during traversal (retained + the one-over sentinel,
+   * when present). For an exact exhausted traversal this equals recordsRetained;
+   * for a sentinel overflow it is at least retained+1, i.e. a lower bound.
+   */
+  recordsObserved = 0;
+  truncated = false;
+  partialReason: PartialReason | undefined;
+
+  private recordSentinelObserved = false;
+
+  constructor(
+    private readonly budget: AnalysisBudget,
+    readonly signal: AbortSignal,
+  ) {}
+
+  /**
+   * Whether traversal should continue visiting more files. Returns false when
+   * the signal has aborted, the file budget is exhausted, or the record-budget
+   * sentinel has already proven partiality.
+   */
+  shouldVisitMoreFiles(): boolean {
+    if (this.signal.aborted) {
+      this.markTruncated('aborted');
+      return false;
+    }
+    if (this.recordSentinelObserved) {
+      return false;
+    }
+    if (this.filesVisited >= this.budget.fileBudget) {
+      this.markTruncated('file-budget');
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Attempt to retain one more record. Returns true when the record fits within
+   * the budget (caller retains it). Returns false when the record budget is
+   * exhausted: the FIRST such call observes the one-over sentinel (setting
+   * truncated/partialReason) and the record must NOT be retained.
+   */
+  tryRetainRecord(): boolean {
+    this.recordsObserved++;
+    if (this.recordsRetained < this.budget.recordBudget) {
+      this.recordsRetained++;
+      return true;
+    }
+    if (!this.recordSentinelObserved) {
+      this.recordSentinelObserved = true;
+      this.markTruncated('record-budget');
+    }
+    return false;
+  }
+
+  /** Mark the traversal aborted by the caller's signal. */
+  markAborted(): void {
+    this.markTruncated('aborted');
+  }
+
+  /** Whether counts are lower bounds rather than exhaustive totals. */
+  get countInexact(): boolean {
+    return this.truncated;
+  }
+
+  private markTruncated(reason: PartialReason): void {
+    this.truncated = true;
+    this.partialReason ??= reason;
+  }
+}

--- a/packages/tools/src/tools/structural-analysis/dependencies.ts
+++ b/packages/tools/src/tools/structural-analysis/dependencies.ts
@@ -13,7 +13,49 @@ import type {
   ImportEntry,
   ResolvedLang,
 } from './types.js';
-import { getFiles, parseFile, makeRelative } from './helpers.js';
+import { iterateFiles, parseFile, makeRelative } from './helpers.js';
+import { type AnalysisBudget, BudgetTracker } from './budget.js';
+
+/** Inline dedup key for an import record (forward or reverse). */
+function importKey(entry: ImportEntry): string {
+  return JSON.stringify([entry.file, entry.line, entry.source, entry.kind]);
+}
+
+/**
+ * Retains one import record against the shared budget. Returns true when
+ * collection should continue (record retained, or already-seen duplicate that
+ * does not consume budget), false when the record budget is exhausted (caller
+ * must stop collecting for this traversal).
+ *
+ * Feeding retention inline — instead of accumulating an unbounded per-file
+ * ImportEntry[] before the tracker applies its cap — means record objects are
+ * never materialized beyond the budget plus the single one-over sentinel.
+ */
+type RetainImportFn = (entry: ImportEntry) => boolean;
+
+/**
+ * Builds a {@link RetainImportFn} bound to a shared tracker, dedup set, and
+ * output array. Forward and reverse collection each construct one so both
+ * phases share one total file/record accounting policy.
+ */
+function makeImportRetainer(
+  tracker: BudgetTracker,
+  seen: Set<string>,
+  out: ImportEntry[],
+): RetainImportFn {
+  return (entry: ImportEntry): boolean => {
+    const key = importKey(entry);
+    if (seen.has(key)) {
+      return true;
+    }
+    if (!tracker.tryRetainRecord()) {
+      return false;
+    }
+    seen.add(key);
+    out.push(entry);
+    return true;
+  };
+}
 
 /**
  * Strips surrounding single or double quotes from a module specifier.
@@ -101,13 +143,15 @@ function namedImportsAreAllType(clauseChildren: SgNode[]): boolean {
  * inspecting its children, rather than running overlapping literal patterns.
  *
  * A statement can produce BOTH a `default` and a `named` record (e.g.
- * `import def, { named } from '...'`).
+ * `import def, { named } from '...'`). Each candidate record is fed to
+ * `retain` inline; if the budget is exhausted, this returns false so the
+ * caller stops collecting.
  */
 function classifyImportStatement(
   stmt: SgNode,
   relPath: string,
-  imports: ImportEntry[],
-): void {
+  retain: RetainImportFn,
+): boolean {
   const children = stmt.children();
   const line = stmt.range().start.line + 1;
   const source = resolveImportSource(stmt);
@@ -116,79 +160,93 @@ function classifyImportStatement(
     (c: SgNode) => String(c.kind()) === 'type',
   );
   if (hasTypeKeyword) {
-    if (source !== null) {
-      imports.push({ file: relPath, line, source, kind: 'type' });
+    if (
+      source !== null &&
+      !retain({ file: relPath, line, source, kind: 'type' })
+    ) {
+      return false;
     }
-    return;
+    return true;
   }
 
   const requireClause = children.find(
     (c: SgNode) => String(c.kind()) === 'import_require_clause',
   );
   if (requireClause !== undefined) {
-    if (source !== null) {
-      imports.push({ file: relPath, line, source, kind: 'require' });
+    if (
+      source !== null &&
+      !retain({ file: relPath, line, source, kind: 'require' })
+    ) {
+      return false;
     }
-    return;
+    return true;
   }
 
   const clause = children.find(
     (c: SgNode) => String(c.kind()) === 'import_clause',
   );
   if (!clause) {
-    if (source !== null) {
-      imports.push({ file: relPath, line, source, kind: 'side-effect' });
+    if (
+      source !== null &&
+      !retain({ file: relPath, line, source, kind: 'side-effect' })
+    ) {
+      return false;
     }
-    return;
+    return true;
   }
 
   // A record asserting a dependency on '' is worse than no record at all.
   if (source === null) {
-    return;
+    return true;
   }
 
   const clauseChildren = clause.children();
-  if (clauseChildren.some((c: SgNode) => String(c.kind()) === 'identifier')) {
-    imports.push({ file: relPath, line, source, kind: 'default' });
+  if (
+    clauseChildren.some((c: SgNode) => String(c.kind()) === 'identifier') &&
+    !retain({ file: relPath, line, source, kind: 'default' })
+  ) {
+    return false;
   }
   if (
     clauseChildren.some((c: SgNode) => String(c.kind()) === 'named_imports')
   ) {
-    if (namedImportsAreAllType(clauseChildren)) {
-      imports.push({ file: relPath, line, source, kind: 'type' });
-    } else {
-      imports.push({ file: relPath, line, source, kind: 'named' });
-    }
+    const kind = namedImportsAreAllType(clauseChildren) ? 'type' : 'named';
+    if (!retain({ file: relPath, line, source, kind })) return false;
   }
   if (
-    clauseChildren.some((c: SgNode) => String(c.kind()) === 'namespace_import')
+    clauseChildren.some(
+      (c: SgNode) => String(c.kind()) === 'namespace_import',
+    ) &&
+    !retain({ file: relPath, line, source, kind: 'namespace' })
   ) {
-    imports.push({ file: relPath, line, source, kind: 'namespace' });
+    return false;
   }
+  return true;
 }
 
 function collectStaticImports(
   parsed: ParsedFile,
   relPath: string,
-  imports: ImportEntry[],
-): void {
+  retain: RetainImportFn,
+): boolean {
   try {
     const statements = parsed.root.findAll({
       rule: { kind: 'import_statement' },
     } as NapiConfig);
     for (const stmt of statements) {
-      classifyImportStatement(stmt, relPath, imports);
+      if (!classifyImportStatement(stmt, relPath, retain)) return false;
     }
   } catch {
     /* skip */
   }
+  return true;
 }
 
 function collectDynamicAndReexports(
   parsed: ParsedFile,
   relPath: string,
-  imports: ImportEntry[],
-): void {
+  retain: RetainImportFn,
+): boolean {
   try {
     const dynamic = parsed.root.findAll({
       rule: {
@@ -197,12 +255,16 @@ function collectDynamicAndReexports(
       },
     } as NapiConfig);
     for (const m of dynamic) {
-      imports.push({
-        file: relPath,
-        line: m.range().start.line + 1,
-        source: m.text(),
-        kind: 'dynamic',
-      });
+      if (
+        !retain({
+          file: relPath,
+          line: m.range().start.line + 1,
+          source: m.text(),
+          kind: 'dynamic',
+        })
+      ) {
+        return false;
+      }
     }
   } catch {
     /* skip */
@@ -216,54 +278,66 @@ function collectDynamicAndReexports(
       },
     } as NapiConfig);
     for (const m of reexports) {
-      if (m.text().includes('from')) {
-        imports.push({
+      if (
+        m.text().includes('from') &&
+        !retain({
           file: relPath,
           line: m.range().start.line + 1,
           source: m.text().substring(0, 200),
           kind: 'reexport',
-        });
+        })
+      ) {
+        return false;
       }
     }
   } catch {
     /* skip */
   }
+  return true;
 }
 
-function collectFileImports(
+/**
+ * Collects all import records from a single parsed file, retaining each inline
+ * against the shared budget. Returns false if the budget was exhausted
+ * mid-file (caller stops traversing).
+ */
+function collectFileImportsBounded(
   parsed: ParsedFile,
   relPath: string,
-  imports: ImportEntry[],
-): void {
-  collectStaticImports(parsed, relPath, imports);
-  collectDynamicAndReexports(parsed, relPath, imports);
+  retain: RetainImportFn,
+): boolean {
+  if (!collectStaticImports(parsed, relPath, retain)) return false;
+  return collectDynamicAndReexports(parsed, relPath, retain);
 }
 
 function collectImportMatches(
   parsed: ParsedFile,
   relPath: string,
   targetBasename: string,
-): ImportEntry[] {
-  const imports: ImportEntry[] = [];
+  retain: RetainImportFn,
+): boolean {
   try {
     const allImports = parsed.root.findAll({
       rule: { kind: 'import_statement' },
     } as NapiConfig);
     for (const m of allImports) {
       const text = m.text();
-      if (text.includes(targetBasename)) {
-        imports.push({
+      if (
+        text.includes(targetBasename) &&
+        !retain({
           file: relPath,
           line: m.range().start.line + 1,
           source: text.substring(0, 200),
           kind: 'import',
-        });
+        })
+      ) {
+        return false;
       }
     }
   } catch {
     /* skip */
   }
-  return imports;
+  return true;
 }
 
 /**
@@ -280,8 +354,10 @@ function shouldCheckReverseImport(
 }
 
 /**
- * Parses a file and returns its reverse-import matches, or null if the file
- * should be skipped (unparseable, is the target, or doesn't reference it).
+ * Parses a file and feeds its reverse-import matches inline to `retain`, or
+ * returns true (continue) if the file should be skipped (unparseable, is the
+ * target, or doesn't reference it). Returns false only when the budget was
+ * exhausted mid-file.
  */
 async function tryCollectReverseImportsForFile(
   file: string,
@@ -289,10 +365,11 @@ async function tryCollectReverseImportsForFile(
   targetRel: string,
   targetBasename: string,
   workspaceRoot: string,
-): Promise<ImportEntry[] | null> {
+  retain: RetainImportFn,
+): Promise<boolean> {
   const parsed = await parseFile(file, lang);
   if (!parsed) {
-    return null;
+    return true;
   }
   const relPath = makeRelative(file, workspaceRoot);
   if (
@@ -303,56 +380,73 @@ async function tryCollectReverseImportsForFile(
       targetBasename,
     )
   ) {
-    return null;
+    return true;
   }
-  return collectImportMatches(parsed, relPath, targetBasename);
-}
-
-async function findReverseImports(
-  searchPath: string,
-  workspaceRoot: string,
-  lang: ResolvedLang,
-  signal: AbortSignal,
-): Promise<ImportEntry[]> {
-  const reverseImports: ImportEntry[] = [];
-  const allFiles = await getFiles(workspaceRoot, lang);
-  const targetRel = makeRelative(searchPath, workspaceRoot);
-  const targetBasename = path.basename(searchPath).replace(/\.\w+$/, '');
-
-  for (const file of allFiles) {
-    if (signal.aborted) {
-      break;
-    }
-    const matches = await tryCollectReverseImportsForFile(
-      file,
-      lang,
-      targetRel,
-      targetBasename,
-      workspaceRoot,
-    );
-    if (matches) {
-      reverseImports.push(...matches);
-    }
-  }
-  return reverseImports;
+  return collectImportMatches(parsed, relPath, targetBasename, retain);
 }
 
 /**
- * Parses a file and collects its imports, or returns null if unparseable.
+ * Bounded reverse-import collection. Iterates the whole workspace lazily and
+ * shares the caller's {@link BudgetTracker} so forward + reverse records stay
+ * under one total file/record accounting policy. Reverse records are retained
+ * inline (no unbounded per-file aggregate).
  */
-async function tryCollectImportsForFile(
-  file: string,
-  lang: ResolvedLang,
+async function collectReverseImportsBounded(
+  searchPath: string,
   workspaceRoot: string,
-): Promise<ImportEntry[] | null> {
-  const parsed = await parseFile(file, lang);
-  if (!parsed) {
-    return null;
+  lang: ResolvedLang,
+  tracker: BudgetTracker,
+  seen: Set<string>,
+  out: ImportEntry[],
+): Promise<void> {
+  const targetRel = makeRelative(searchPath, workspaceRoot);
+  const targetBasename = path.basename(searchPath).replace(/\.\w+$/, '');
+  const retain = makeImportRetainer(tracker, seen, out);
+
+  for await (const file of iterateFiles(workspaceRoot, lang, tracker.signal)) {
+    if (!tracker.shouldVisitMoreFiles()) return;
+    tracker.filesVisited++;
+    if (
+      !(await tryCollectReverseImportsForFile(
+        file,
+        lang,
+        targetRel,
+        targetBasename,
+        workspaceRoot,
+        retain,
+      ))
+    ) {
+      return;
+    }
   }
-  const relPath = makeRelative(file, workspaceRoot);
-  const imports: ImportEntry[] = [];
-  collectFileImports(parsed, relPath, imports);
-  return imports;
+}
+
+/**
+ * Builds the final {@link AnalysisResult} with bounded summary metadata.
+ */
+function buildDependenciesResult(
+  imports: ImportEntry[],
+  reverseImports: ImportEntry[] | undefined,
+  reverse: boolean,
+  tracker: BudgetTracker,
+  budget: AnalysisBudget,
+): AnalysisResult {
+  return {
+    mode: 'dependencies',
+    truncated: tracker.truncated,
+    partial: tracker.truncated,
+    partialReason: tracker.partialReason,
+    fileBudget: budget.fileBudget,
+    recordBudget: budget.recordBudget,
+    filesVisited: tracker.filesVisited,
+    recordsRetained: tracker.recordsRetained,
+    recordsObserved: tracker.recordsObserved,
+    countInexact: tracker.countInexact,
+    results: {
+      imports,
+      reverseImports: reverse ? reverseImports : undefined,
+    },
+  };
 }
 
 export async function executeDependencies(
@@ -361,50 +455,70 @@ export async function executeDependencies(
   workspaceRoot: string,
   reverse: boolean,
   signal: AbortSignal,
+  budget: AnalysisBudget,
 ): Promise<AnalysisResult> {
-  const files = await getFiles(searchPath, lang);
+  const tracker = new BudgetTracker(budget, signal);
   const imports: ImportEntry[] = [];
+  const seen = new Set<string>();
 
-  for (const file of files) {
-    if (signal.aborted) {
-      break;
-    }
-    const fileImports = await tryCollectImportsForFile(
-      file,
-      lang,
+  await collectForwardImportsBounded(
+    searchPath,
+    workspaceRoot,
+    lang,
+    tracker,
+    seen,
+    imports,
+  );
+
+  let reverseImports: ImportEntry[] | undefined;
+  if (reverse) {
+    reverseImports = [];
+    await collectReverseImportsBounded(
+      searchPath,
       workspaceRoot,
+      lang,
+      tracker,
+      seen,
+      reverseImports,
     );
-    if (fileImports) {
-      imports.push(...fileImports);
-    }
   }
 
-  const reverseImports = reverse
-    ? await findReverseImports(searchPath, workspaceRoot, lang, signal)
-    : [];
+  // A signal that was already aborted (or aborted during a gap between file
+  // yields) must never read as a falsely complete result.
+  if (signal.aborted) {
+    tracker.markAborted();
+  }
 
-  return {
-    mode: 'dependencies',
-    truncated: false,
-    results: {
-      imports: deduplicateForwardImports(imports),
-      reverseImports: reverse ? reverseImports : undefined,
-    },
-  };
+  return buildDependenciesResult(
+    imports,
+    reverseImports,
+    reverse,
+    tracker,
+    budget,
+  );
 }
 
 /**
- * Deduplicates the forward import list by (file, line, source, kind) so no
- * tuple is emitted more than once.
+ * Bounded forward-import collection. Iterates the search root lazily and
+ * retains each import inline against the shared budget (no unbounded per-file
+ * ImportEntry[] aggregate). Deduplication happens inside the retainer so
+ * retained output never exceeds the record budget.
  */
-function deduplicateForwardImports(imports: ImportEntry[]): ImportEntry[] {
-  const seen = new Set<string>();
-  const result: ImportEntry[] = [];
-  for (const imp of imports) {
-    const key = JSON.stringify([imp.file, imp.line, imp.source, imp.kind]);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    result.push(imp);
+async function collectForwardImportsBounded(
+  searchPath: string,
+  workspaceRoot: string,
+  lang: ResolvedLang,
+  tracker: BudgetTracker,
+  seen: Set<string>,
+  imports: ImportEntry[],
+): Promise<void> {
+  const retain = makeImportRetainer(tracker, seen, imports);
+  for await (const file of iterateFiles(searchPath, lang, tracker.signal)) {
+    if (!tracker.shouldVisitMoreFiles()) return;
+    tracker.filesVisited++;
+    const parsed = await parseFile(file, lang);
+    if (!parsed) continue;
+    const relPath = makeRelative(file, workspaceRoot);
+    if (!collectFileImportsBounded(parsed, relPath, retain)) return;
   }
-  return result;
 }

--- a/packages/tools/src/tools/structural-analysis/exports.ts
+++ b/packages/tools/src/tools/structural-analysis/exports.ts
@@ -6,7 +6,8 @@
 
 import type { NapiConfig } from '@ast-grep/napi';
 import type { ParsedFile, AnalysisResult, ResolvedLang } from './types.js';
-import { getFiles, parseFile, makeRelative } from './helpers.js';
+import { iterateFiles, parseFile, makeRelative } from './helpers.js';
+import { type AnalysisBudget, BudgetTracker } from './budget.js';
 
 interface ExportEntry {
   file: string;
@@ -31,69 +32,85 @@ function classifyExportKind(text: string): string {
   return 'export';
 }
 
-/**
- * Parses a file and returns its export entries, or null if unparseable.
- */
-async function tryCollectExportsForFile(
-  file: string,
-  lang: ResolvedLang,
-  workspaceRoot: string,
-): Promise<ExportEntry[] | null> {
-  const parsed = await parseFile(file, lang);
-  if (!parsed) {
-    return null;
-  }
-  const relPath = makeRelative(file, workspaceRoot);
-  const exports: ExportEntry[] = [];
-  collectExportsFromFile(parsed, relPath, exports);
-  return exports;
-}
-
 export async function executeExports(
   searchPath: string,
   lang: ResolvedLang,
   workspaceRoot: string,
   signal: AbortSignal,
+  budget: AnalysisBudget,
 ): Promise<AnalysisResult> {
-  const files = await getFiles(searchPath, lang);
+  const tracker = new BudgetTracker(budget, signal);
   const exports: ExportEntry[] = [];
 
-  for (const file of files) {
-    if (signal.aborted) {
-      break;
-    }
-    const fileExports = await tryCollectExportsForFile(
-      file,
-      lang,
-      workspaceRoot,
-    );
-    if (fileExports) {
-      exports.push(...fileExports);
-    }
+  await collectExportsBounded(
+    searchPath,
+    workspaceRoot,
+    lang,
+    tracker,
+    exports,
+  );
+
+  if (signal.aborted) {
+    tracker.markAborted();
   }
 
   return {
     mode: 'exports',
-    truncated: false,
+    truncated: tracker.truncated,
+    partial: tracker.truncated,
+    partialReason: tracker.partialReason,
+    fileBudget: budget.fileBudget,
+    recordBudget: budget.recordBudget,
+    filesVisited: tracker.filesVisited,
+    recordsRetained: tracker.recordsRetained,
+    recordsObserved: tracker.recordsObserved,
+    countInexact: tracker.countInexact,
     results: exports,
   };
 }
 
 /**
- * Collects all export statements from a single parsed file.
+ * Bounded export collection. Iterates the search root lazily and retains at
+ * most the record budget across the complete result.
  */
-function collectExportsFromFile(
+async function collectExportsBounded(
+  searchPath: string,
+  workspaceRoot: string,
+  lang: ResolvedLang,
+  tracker: BudgetTracker,
+  exports: ExportEntry[],
+): Promise<void> {
+  for await (const file of iterateFiles(searchPath, lang, tracker.signal)) {
+    if (!tracker.shouldVisitMoreFiles()) return;
+    tracker.filesVisited++;
+    const parsed = await parseFile(file, lang);
+    if (!parsed) continue;
+    const relPath = makeRelative(file, workspaceRoot);
+    const fileExports = collectExportsRetained(parsed, relPath, tracker);
+    exports.push(...fileExports);
+  }
+}
+
+/**
+ * Collects export statements from a single parsed file, retaining only those
+ * that fit within the shared record budget. Each retained record is counted
+ * through {@link BudgetTracker.tryRetainRecord}; the first record beyond the
+ * budget is observed as a sentinel (proving partiality) and discarded.
+ */
+function collectExportsRetained(
   parsed: ParsedFile,
   relPath: string,
-  exports: ExportEntry[],
-): void {
+  tracker: BudgetTracker,
+): ExportEntry[] {
+  const retained: ExportEntry[] = [];
   try {
     const exportNodes = parsed.root.findAll({
       rule: { kind: 'export_statement' },
     } as NapiConfig);
     for (const m of exportNodes) {
+      if (!tracker.tryRetainRecord()) break;
       const text = m.text();
-      exports.push({
+      retained.push({
         file: relPath,
         line: m.range().start.line + 1,
         text: text.substring(0, 200),
@@ -103,4 +120,5 @@ function collectExportsFromFile(
   } catch {
     /* skip */
   }
+  return retained;
 }

--- a/packages/tools/src/tools/structural-analysis/helpers.ts
+++ b/packages/tools/src/tools/structural-analysis/helpers.ts
@@ -58,6 +58,11 @@ export function getExtensionsForLanguage(lang: string | Lang): string[] {
 /**
  * Collects all files under `searchPath` that match the given language.
  * If `searchPath` is a single file, returns just that file.
+ *
+ * Kept for callers that still need the full materialized list (reverse-import
+ * discovery resolves against the whole workspace). Bounded traversal modes use
+ * {@link iterateFiles} instead so FastGlob never returns an unbounded array
+ * before slicing.
  */
 export async function getFiles(
   searchPath: string,
@@ -77,6 +82,38 @@ export async function getFiles(
       ignore: ['**/node_modules/**', '**/.git/**'],
     },
   );
+}
+
+/**
+ * Lazily yields files under `searchPath` matching `lang` using FastGlob's
+ * streaming API, so discovery is bounded at the source rather than collecting
+ * an unbounded path array before slicing. Honours the abort signal so a
+ * traversal can stop mid-discovery.
+ */
+export async function* iterateFiles(
+  searchPath: string,
+  lang: string | Lang,
+  signal: AbortSignal,
+): AsyncGenerator<string, void, unknown> {
+  const stat = await fs.stat(searchPath).catch(() => null);
+  if (stat !== null && stat.isFile() === true) {
+    yield searchPath;
+    return;
+  }
+  const extensions = getExtensionsForLanguage(lang);
+  const stream = FastGlob.stream(
+    extensions.map((ext) => `**/*.${ext}`),
+    {
+      cwd: searchPath,
+      absolute: true,
+      dot: false,
+      ignore: ['**/node_modules/**', '**/.git/**'],
+    },
+  );
+  for await (const entry of stream) {
+    if (signal.aborted) return;
+    yield String(entry);
+  }
 }
 
 /**

--- a/packages/tools/src/tools/structural-analysis/references.ts
+++ b/packages/tools/src/tools/structural-analysis/references.ts
@@ -6,25 +6,35 @@
 
 import type { NapiConfig } from '@ast-grep/napi';
 import type { ParsedFile, AnalysisResult, ResolvedLang } from './types.js';
-import { escapeRegex, getFiles, parseFile, makeRelative } from './helpers.js';
+import {
+  escapeRegex,
+  iterateFiles,
+  parseFile,
+  makeRelative,
+} from './helpers.js';
+import { type AnalysisBudget, BudgetTracker } from './budget.js';
 
 type AddResultFn = (
   category: string,
   file: string,
   line: number,
   text: string,
-) => void;
+) => boolean;
 
 function searchDirectCallReferences(
   parsed: ParsedFile,
   symbol: string,
   relPath: string,
   addResult: AddResultFn,
-): void {
+): boolean {
   try {
     const memberCalls = parsed.root.findAll(`$OBJ.${symbol}($$$ARGS)`);
     for (const m of memberCalls) {
-      addResult('Direct calls', relPath, m.range().start.line + 1, m.text());
+      if (
+        !addResult('Direct calls', relPath, m.range().start.line + 1, m.text())
+      ) {
+        return false;
+      }
     }
   } catch {
     /* skip */
@@ -33,11 +43,16 @@ function searchDirectCallReferences(
   try {
     const standaloneCalls = parsed.root.findAll(`${symbol}($$$ARGS)`);
     for (const m of standaloneCalls) {
-      addResult('Direct calls', relPath, m.range().start.line + 1, m.text());
+      if (
+        !addResult('Direct calls', relPath, m.range().start.line + 1, m.text())
+      ) {
+        return false;
+      }
     }
   } catch {
     /* skip */
   }
+  return true;
 }
 
 function searchInstantiationReferences(
@@ -45,11 +60,20 @@ function searchInstantiationReferences(
   symbol: string,
   relPath: string,
   addResult: AddResultFn,
-): void {
+): boolean {
   try {
     const news = parsed.root.findAll(`new ${symbol}($$$ARGS)`);
     for (const m of news) {
-      addResult('Instantiations', relPath, m.range().start.line + 1, m.text());
+      if (
+        !addResult(
+          'Instantiations',
+          relPath,
+          m.range().start.line + 1,
+          m.text(),
+        )
+      ) {
+        return false;
+      }
     }
   } catch {
     /* skip */
@@ -70,16 +94,21 @@ function searchInstantiationReferences(
       },
     } as NapiConfig);
     for (const m of instanceCalls) {
-      addResult(
-        'Instance method calls (heuristic)',
-        relPath,
-        m.range().start.line + 1,
-        m.text(),
-      );
+      if (
+        !addResult(
+          'Instance method calls (heuristic)',
+          relPath,
+          m.range().start.line + 1,
+          m.text(),
+        )
+      ) {
+        return false;
+      }
     }
   } catch {
     /* skip */
   }
+  return true;
 }
 
 function searchTypeAndHeritageReferences(
@@ -87,7 +116,7 @@ function searchTypeAndHeritageReferences(
   symbol: string,
   relPath: string,
   addResult: AddResultFn,
-): void {
+): boolean {
   try {
     const typeRefs = parsed.root.findAll({
       rule: {
@@ -99,12 +128,16 @@ function searchTypeAndHeritageReferences(
       },
     } as NapiConfig);
     for (const m of typeRefs) {
-      addResult(
-        'Type annotations',
-        relPath,
-        m.range().start.line + 1,
-        m.text(),
-      );
+      if (
+        !addResult(
+          'Type annotations',
+          relPath,
+          m.range().start.line + 1,
+          m.text(),
+        )
+      ) {
+        return false;
+      }
     }
   } catch {
     /* skip */
@@ -115,12 +148,16 @@ function searchTypeAndHeritageReferences(
       `class $NAME extends ${symbol} { $$$BODY }`,
     );
     for (const m of heritage) {
-      addResult(
-        'Extends/Implements',
-        relPath,
-        m.range().start.line + 1,
-        `class ${m.getMatch('NAME')?.text()} extends ${symbol}`,
-      );
+      if (
+        !addResult(
+          'Extends/Implements',
+          relPath,
+          m.range().start.line + 1,
+          `class ${m.getMatch('NAME')?.text()} extends ${symbol}`,
+        )
+      ) {
+        return false;
+      }
     }
   } catch {
     /* skip */
@@ -131,16 +168,21 @@ function searchTypeAndHeritageReferences(
       `class $NAME implements ${symbol} { $$$BODY }`,
     );
     for (const m of implHeritage) {
-      addResult(
-        'Extends/Implements',
-        relPath,
-        m.range().start.line + 1,
-        `class ${m.getMatch('NAME')?.text()} implements ${symbol}`,
-      );
+      if (
+        !addResult(
+          'Extends/Implements',
+          relPath,
+          m.range().start.line + 1,
+          `class ${m.getMatch('NAME')?.text()} implements ${symbol}`,
+        )
+      ) {
+        return false;
+      }
     }
   } catch {
     /* skip */
   }
+  return true;
 }
 
 function searchImportReferences(
@@ -148,7 +190,7 @@ function searchImportReferences(
   symbol: string,
   relPath: string,
   addResult: AddResultFn,
-): void {
+): boolean {
   try {
     const imports = parsed.root.findAll({
       rule: {
@@ -157,31 +199,43 @@ function searchImportReferences(
       },
     } as NapiConfig);
     for (const m of imports) {
-      addResult('Imports', relPath, m.range().start.line + 1, m.text());
+      if (!addResult('Imports', relPath, m.range().start.line + 1, m.text())) {
+        return false;
+      }
     }
   } catch {
     /* skip */
   }
+  return true;
 }
 
 /**
- * Processes all reference categories for a single parsed file.
+ * Processes all reference categories for a single parsed file. Propagates the
+ * first record-budget sentinel immediately: once one category observes the
+ * one-over record, remaining categories and nodes for this file are skipped.
  */
 function searchAllReferenceCategories(
   parsed: ParsedFile,
   symbol: string,
   relPath: string,
   addResult: AddResultFn,
-): void {
-  searchDirectCallReferences(parsed, symbol, relPath, addResult);
-  searchInstantiationReferences(parsed, symbol, relPath, addResult);
-  searchTypeAndHeritageReferences(parsed, symbol, relPath, addResult);
-  searchImportReferences(parsed, symbol, relPath, addResult);
+): boolean {
+  if (!searchDirectCallReferences(parsed, symbol, relPath, addResult)) {
+    return false;
+  }
+  if (!searchInstantiationReferences(parsed, symbol, relPath, addResult)) {
+    return false;
+  }
+  if (!searchTypeAndHeritageReferences(parsed, symbol, relPath, addResult)) {
+    return false;
+  }
+  return searchImportReferences(parsed, symbol, relPath, addResult);
 }
 
 /**
- * Parses a file and searches all reference categories, or returns null if
- * the file is unparseable.
+ * Parses a file and searches all reference categories. Returns false when the
+ * record-budget sentinel was hit (caller stops traversal); true otherwise
+ * (including when the file is unparseable and simply skipped).
  */
 async function trySearchReferencesForFile(
   file: string,
@@ -192,11 +246,10 @@ async function trySearchReferencesForFile(
 ): Promise<boolean> {
   const parsed = await parseFile(file, lang);
   if (!parsed) {
-    return false;
+    return true;
   }
   const relPath = makeRelative(file, workspaceRoot);
-  searchAllReferenceCategories(parsed, symbol, relPath, addResult);
-  return true;
+  return searchAllReferenceCategories(parsed, symbol, relPath, addResult);
 }
 
 export async function executeReferences(
@@ -205,8 +258,9 @@ export async function executeReferences(
   searchPath: string,
   workspaceRoot: string,
   signal: AbortSignal,
+  budget: AnalysisBudget,
 ): Promise<AnalysisResult> {
-  const files = await getFiles(searchPath, lang);
+  const tracker = new BudgetTracker(budget, signal);
   const categories: Record<
     string,
     Array<{ file: string; line: number; text: string }>
@@ -225,24 +279,37 @@ export async function executeReferences(
     file: string,
     line: number,
     text: string,
-  ): void => {
-    const key = `${category}:${file}:${line}`;
-    if (seen.has(key)) return;
-    seen.add(key);
+  ): boolean => {
+    const dedupKey = `${category}:${file}:${line}`;
+    if (seen.has(dedupKey)) return true;
+    // Global record cap across all categories — one shared accounting policy.
+    // Returns false once the budget is exhausted so category loops stop.
+    if (!tracker.tryRetainRecord()) return false;
+    seen.add(dedupKey);
     categories[category].push({ file, line, text: text.substring(0, 200) });
+    return true;
   };
 
-  for (const file of files) {
-    if (signal.aborted) {
-      break;
-    }
-    await trySearchReferencesForFile(
+  const processFile = async (file: string): Promise<boolean> => {
+    if (!tracker.shouldVisitMoreFiles()) return false;
+    tracker.filesVisited++;
+    // Propagate the record-budget sentinel: once addResult returns false for a
+    // file, stop visiting further files for this traversal.
+    return trySearchReferencesForFile(
       file,
       lang,
       workspaceRoot,
       symbol,
       addResult,
     );
+  };
+
+  for await (const file of iterateFiles(searchPath, lang, signal)) {
+    if (!(await processFile(file))) break;
+  }
+
+  if (signal.aborted) {
+    tracker.markAborted();
   }
 
   const counts: Record<string, number> = {};
@@ -253,7 +320,15 @@ export async function executeReferences(
   return {
     mode: 'references',
     symbol,
-    truncated: false,
+    truncated: tracker.truncated,
+    partial: tracker.truncated,
+    partialReason: tracker.partialReason,
+    fileBudget: budget.fileBudget,
+    recordBudget: budget.recordBudget,
+    filesVisited: tracker.filesVisited,
+    recordsRetained: tracker.recordsRetained,
+    recordsObserved: tracker.recordsObserved,
+    countInexact: tracker.countInexact,
     results: { categories, counts },
   };
 }

--- a/packages/tools/src/tools/structural-analysis/structural-analysis-budgets.bun.test.ts
+++ b/packages/tools/src/tools/structural-analysis/structural-analysis-budgets.bun.test.ts
@@ -1,0 +1,569 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for bounded acquisition in structural_analysis
+ * dependencies/references/exports modes (issue #3205).
+ *
+ * Drives the REAL StructuralAnalysisTool end-to-end against real .ts fixture
+ * trees written into a temp directory. The AST engine (@ast-grep/napi) is not
+ * mocked. Budgets are exercised by setting a small `tool-output-max-items`
+ * ephemeral setting so fixture trees can stay small.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IToolHost } from '../../interfaces/index.js';
+import {
+  StructuralAnalysisTool,
+  type StructuralAnalysisParams,
+} from '../structural-analysis.js';
+import type { ToolResult } from '../tools.js';
+
+/** Fake host that exposes a configurable `tool-output-max-items` setting. */
+function createBudgetToolHost(targetDir: string, maxItems: number): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths: string[]) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({ 'tool-output-max-items': maxItems }),
+    getDebugMode: () => false,
+  };
+}
+
+interface AnalysisPayload {
+  mode: string;
+  truncated: boolean;
+  partial?: boolean;
+  partialReason?: string;
+  fileBudget?: number;
+  recordBudget?: number;
+  filesVisited?: number;
+  recordsRetained?: number;
+  recordsObserved?: number;
+  countInexact?: boolean;
+  results: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readArray(value: unknown): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected an array, got ${typeof value}`);
+  }
+  return value;
+}
+
+function readField(obj: unknown, key: string): unknown {
+  if (!isRecord(obj)) {
+    throw new Error(`Expected an object result, got ${typeof obj}`);
+  }
+  return obj[key];
+}
+
+function readImportRecords(results: unknown): Array<{
+  source: string;
+  kind: string;
+}> {
+  return readArray(readField(results, 'imports')).map((raw) => {
+    const rec = isRecord(raw) ? raw : {};
+    return {
+      source: typeof rec.source === 'string' ? rec.source : '',
+      kind: typeof rec.kind === 'string' ? rec.kind : '',
+    };
+  });
+}
+
+function parsePayload(result: ToolResult): AnalysisPayload {
+  const parsed: unknown = JSON.parse(String(result.llmContent));
+  if (
+    !isRecord(parsed) ||
+    typeof parsed.mode !== 'string' ||
+    typeof parsed.truncated !== 'boolean' ||
+    !('results' in parsed)
+  ) {
+    throw new Error(`Unexpected payload: ${result.llmContent}`);
+  }
+  // The runtime guard above guarantees mode/truncated/results, so the cast to
+  // the payload interface is supported rather than blind.
+  return parsed as unknown as AnalysisPayload;
+}
+
+async function runTool(
+  host: IToolHost,
+  params: StructuralAnalysisParams,
+  signal?: AbortSignal,
+): Promise<ToolResult> {
+  const tool = new StructuralAnalysisTool(host);
+  return tool.build(params).execute(signal ?? new AbortController().signal);
+}
+
+describe('structural_analysis bounded acquisition (issue #3205)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-sa-budget-3205-'));
+  });
+
+  afterAll(() => {
+    if (tempDir !== '') {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('dependencies record budget', () => {
+    beforeAll(() => {
+      // 6 named imports — one over a budget of 5.
+      writeFileSync(
+        join(tempDir, 'dep-over.ts'),
+        "import { a } from './a.js';\nimport { b } from './b.js';\nimport { c } from './c.js';\nimport { d } from './d.js';\nimport { e } from './e.js';\nimport { f } from './f.js';\n",
+        'utf-8',
+      );
+      // Exactly 5 named imports — at the budget limit.
+      writeFileSync(
+        join(tempDir, 'dep-exact.ts'),
+        "import { a } from './a.js';\nimport { b } from './b.js';\nimport { c } from './c.js';\nimport { d } from './d.js';\nimport { e } from './e.js';\n",
+        'utf-8',
+      );
+      // A single file with FAR more imports (30) than the record budget of 5.
+      // Proves retention is bounded within ONE file (no per-file aggregate
+      // exceeds the budget before the tracker applies its cap), and that the
+      // partial metadata describes the retained prefix correctly.
+      {
+        let body = '';
+        for (let i = 0; i < 30; i++) {
+          body += `import { mod${i} } from './mod${i}.js';\n`;
+        }
+        writeFileSync(join(tempDir, 'dep-large.ts'), body, 'utf-8');
+      }
+    });
+
+    it('retains at most the record budget and marks one-over as partial', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'dependencies',
+        language: 'typescript',
+        target: join(tempDir, 'dep-over.ts'),
+      });
+      const payload = parsePayload(result);
+      const imports = readImportRecords(payload.results);
+      expect(imports.length).toBe(5);
+      expect(payload.truncated).toBe(true);
+      expect(payload.partial).toBe(true);
+      expect(payload.partialReason).toBe('record-budget');
+      expect(payload.recordBudget).toBe(5);
+      expect(payload.recordsRetained).toBe(5);
+      expect(payload.countInexact).toBe(true);
+    });
+
+    it('treats exact-limit input as complete (not truncated)', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'dependencies',
+        language: 'typescript',
+        target: join(tempDir, 'dep-exact.ts'),
+      });
+      const payload = parsePayload(result);
+      const imports = readImportRecords(payload.results);
+      expect(imports.length).toBe(5);
+      expect(payload.truncated).toBe(false);
+      expect(payload.partial).toBeFalsy();
+      expect(payload.recordsRetained).toBe(5);
+    });
+
+    it('bounds far-over imports within a SINGLE large file with correct partial metadata', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'dependencies',
+        language: 'typescript',
+        target: join(tempDir, 'dep-large.ts'),
+      });
+      const payload = parsePayload(result);
+      const imports = readImportRecords(payload.results);
+      // One file holds 30 imports; only 5 are retained.
+      expect(imports.length).toBe(5);
+      expect(payload.truncated).toBe(true);
+      expect(payload.partial).toBe(true);
+      expect(payload.partialReason).toBe('record-budget');
+      expect(payload.recordsRetained).toBe(5);
+      expect(payload.countInexact).toBe(true);
+      // The retained prefix is well-formed import metadata (first 5 modules).
+      expect(imports[0].source).toBe('./mod0.js');
+      expect(imports[imports.length - 1].source).toBe('./mod4.js');
+      for (const imp of imports) {
+        expect(imp.kind).toBe('named');
+      }
+    });
+  });
+
+  describe('dependencies file budget bounds discovery', () => {
+    beforeAll(() => {
+      const dir = join(tempDir, 'many-files');
+      mkdirSync(dir, { recursive: true });
+      // 25 empty .ts files — no import records, so the record budget never
+      // triggers; only the file budget can stop traversal.
+      for (let i = 0; i < 25; i++) {
+        writeFileSync(join(dir, `f${i}.ts`), '// empty\n', 'utf-8');
+      }
+    });
+
+    it('stops visiting files at the file budget and reports partial', async () => {
+      // maxItems=5 -> recordBudget=5, fileBudget=20
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'dependencies',
+        language: 'typescript',
+        target: join(tempDir, 'many-files'),
+      });
+      const payload = parsePayload(result);
+      expect(payload.filesVisited).toBe(20);
+      expect(payload.fileBudget).toBe(20);
+      expect(payload.truncated).toBe(true);
+      expect(payload.partialReason).toBe('file-budget');
+      // Proves discovery was bounded (did not visit all 25).
+      expect(payload.filesVisited).toBeLessThan(25);
+    });
+  });
+
+  describe('dependencies reverse shares total accounting (isolated fixture)', () => {
+    // A DEDICATED fixture tree (not the shared tempDir) so the record budget —
+    // not the file budget or FastGlob ordering of unrelated fixtures — is
+    // provably the binding constraint. Only the target and its reverse
+    // consumers live here. The reverse scan globs the workspace root, so an
+    // isolated tree guarantees no other fixture files can consume the file
+    // budget or perturb glob ordering before the record budget binds.
+    let revDir = '';
+
+    beforeAll(() => {
+      revDir = mkdtempSync(join(tmpdir(), 'llxprt-sa-rev-3205-'));
+      // Target file (no forward imports of its own).
+      writeFileSync(
+        join(revDir, 'shared.ts'),
+        'export const SHARED = 1;\n',
+        'utf-8',
+      );
+      // 6 files that import the shared module -> reverse imports (6) exceed a
+      // record budget of 5, while the 7-file tree stays far below the file
+      // budget (20). This proves the record budget is the binding constraint.
+      for (let i = 0; i < 6; i++) {
+        writeFileSync(
+          join(revDir, `consumer${i}.ts`),
+          `import { SHARED } from './shared.js';\n`,
+          'utf-8',
+        );
+      }
+    });
+
+    afterAll(() => {
+      if (revDir !== '') {
+        rmSync(revDir, { recursive: true, force: true });
+      }
+    });
+
+    it('bounds forward+reverse records under one accounting policy', async () => {
+      const host = createBudgetToolHost(revDir, 5);
+      const result = await runTool(host, {
+        mode: 'dependencies',
+        language: 'typescript',
+        target: join(revDir, 'shared.ts'),
+        reverse: true,
+      });
+      const payload = parsePayload(result);
+      const imports = readImportRecords(payload.results);
+      const reverseRaw = readField(payload.results, 'reverseImports');
+      const reverseImports = Array.isArray(reverseRaw) ? reverseRaw : [];
+      const total = imports.length + reverseImports.length;
+      // The record budget (5) is provably the binding constraint: retained
+      // output exactly fills it, and the partial reason is record-budget.
+      expect(payload.recordBudget).toBe(5);
+      expect(total).toBe(5);
+      expect(payload.truncated).toBe(true);
+      expect(payload.partialReason).toBe('record-budget');
+      expect(payload.recordsRetained).toBe(total);
+      // The file budget (20) was never reached: only 7 files exist and the
+      // record budget stopped traversal first.
+      expect(payload.fileBudget).toBe(20);
+      expect(payload.filesVisited).toBeLessThan(20);
+      // recordsObserved is a lower bound: at least retained + the one-over
+      // sentinel that proved partiality (6 >= 5 + 1).
+      expect(payload.recordsObserved).toBeGreaterThanOrEqual(total + 1);
+    });
+  });
+
+  describe('references global record cap across categories', () => {
+    beforeAll(() => {
+      // Symbol "unicorn" referenced via direct calls and instantiations,
+      // totaling more than a budget of 5 across categories.
+      writeFileSync(
+        join(tempDir, 'refs-over.ts'),
+        'function unicorn() {}\nunicorn();\nunicorn();\nunicorn();\nunicorn();\nconst u = new unicorn();\nunicorn();\n',
+        'utf-8',
+      );
+      writeFileSync(
+        join(tempDir, 'refs-exact.ts'),
+        'function unicorn() {}\nunicorn();\nunicorn();\nunicorn();\nconst u = new unicorn();\n',
+        'utf-8',
+      );
+    });
+
+    it('bounds references across all categories under one global cap', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'references',
+        language: 'typescript',
+        symbol: 'unicorn',
+        target: join(tempDir, 'refs-over.ts'),
+      });
+      const payload = parsePayload(result);
+      const categoriesRaw = readField(payload.results, 'categories');
+      const categories = isRecord(categoriesRaw) ? categoriesRaw : {};
+      const total = Object.values(categories).reduce<number>(
+        (sum, arr) => sum + (Array.isArray(arr) ? arr.length : 0),
+        0,
+      );
+      expect(total).toBeLessThanOrEqual(5);
+      expect(payload.truncated).toBe(true);
+      expect(payload.partialReason).toBe('record-budget');
+      expect(payload.recordsRetained).toBe(total);
+    });
+
+    it('treats exact-limit references as complete', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'references',
+        language: 'typescript',
+        symbol: 'unicorn',
+        target: join(tempDir, 'refs-exact.ts'),
+      });
+      const payload = parsePayload(result);
+      expect(payload.truncated).toBe(false);
+    });
+  });
+
+  describe('exports record budget', () => {
+    beforeAll(() => {
+      // 6 exports — one over a budget of 5.
+      writeFileSync(
+        join(tempDir, 'exports-over.ts'),
+        'export const a = 1;\nexport const b = 2;\nexport const c = 3;\nexport const d = 4;\nexport const e = 5;\nexport const f = 6;\n',
+        'utf-8',
+      );
+      writeFileSync(
+        join(tempDir, 'exports-exact.ts'),
+        'export const a = 1;\nexport const b = 2;\nexport const c = 3;\nexport const d = 4;\nexport const e = 5;\n',
+        'utf-8',
+      );
+    });
+
+    it('bounds exports under the record budget and marks one-over partial', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'exports',
+        language: 'typescript',
+        target: join(tempDir, 'exports-over.ts'),
+      });
+      const payload = parsePayload(result);
+      const exports = readArray(payload.results);
+      expect(exports.length).toBe(5);
+      expect(payload.truncated).toBe(true);
+      expect(payload.partialReason).toBe('record-budget');
+    });
+
+    it('treats exact-limit exports as complete', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'exports',
+        language: 'typescript',
+        target: join(tempDir, 'exports-exact.ts'),
+      });
+      const payload = parsePayload(result);
+      const exports = readArray(payload.results);
+      expect(exports.length).toBe(5);
+      expect(payload.truncated).toBe(false);
+    });
+  });
+
+  describe('abort during traversal', () => {
+    beforeAll(() => {
+      const dir = join(tempDir, 'abort-tree');
+      mkdirSync(dir, { recursive: true });
+      for (let i = 0; i < 25; i++) {
+        writeFileSync(
+          join(dir, `m${i}.ts`),
+          `import { x } from './dep${i}.js';\n`,
+          'utf-8',
+        );
+      }
+
+      // A large tree (300 files, each with one import) for deterministic
+      // mid-traversal abort. The tool processes files sequentially, so a
+      // bounded number of event-loop yields lets only some files complete
+      // before the signal is raised — never all 300.
+      const bigDir = join(tempDir, 'traverse-tree');
+      mkdirSync(bigDir, { recursive: true });
+      for (let i = 0; i < 300; i++) {
+        writeFileSync(
+          join(bigDir, `f${i}.ts`),
+          `import { dep${i} } from './dep${i}.js';\n`,
+          'utf-8',
+        );
+      }
+    });
+
+    it('a pre-aborted signal produces an explicit partial result', async () => {
+      const host = createBudgetToolHost(tempDir, 200);
+      const controller = new AbortController();
+      controller.abort();
+      const result = await runTool(
+        host,
+        {
+          mode: 'dependencies',
+          language: 'typescript',
+          target: join(tempDir, 'abort-tree'),
+        },
+        controller.signal,
+      );
+      const payload = parsePayload(result);
+      expect(payload.truncated).toBe(true);
+      expect(payload.partialReason).toBe('aborted');
+    });
+
+    it('aborts DURING a real large-directory traversal and returns a partial result', async () => {
+      // 300 files each with an import. A real AbortController is raised after
+      // invocation has begun, at the earliest deterministic macrotask boundary
+      // (a zero-delay timer, clamped to ~1 ms). The tool reads/parses files
+      // sequentially, so the traversal provably cannot finish 300 AST parses
+      // (tens of ms) before the timer fires — the abort lands mid-traversal
+      // and the result is always partial with reason `aborted`. No positive
+      // visited/retained count is required (that would reintroduce timing
+      // dependence). The timer is always cleared in finally.
+      const host = createBudgetToolHost(tempDir, 2000);
+      const controller = new AbortController();
+      const tool = new StructuralAnalysisTool(host);
+      const execution = tool
+        .build({
+          mode: 'dependencies',
+          language: 'typescript',
+          target: join(tempDir, 'traverse-tree'),
+        })
+        .execute(controller.signal);
+      const timer = setTimeout(() => controller.abort(), 0);
+      try {
+        const result = await execution;
+        const payload = parsePayload(result);
+        // Explicit aborted partial metadata (deterministic).
+        expect(payload.truncated).toBe(true);
+        expect(payload.partialReason).toBe('aborted');
+        // Bounded output: the traversal did not finish all 300 files.
+        expect(payload.filesVisited).toBeLessThan(300);
+      } finally {
+        clearTimeout(timer);
+      }
+    });
+  });
+
+  describe('metadata does not duplicate the results aggregate', () => {
+    it('ToolResult.metadata excludes the results field', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'exports',
+        language: 'typescript',
+        target: join(tempDir, 'exports-over.ts'),
+      });
+      const metadata = result.metadata;
+      expect(metadata).toBeDefined();
+      if (metadata === undefined) {
+        throw new Error('metadata should be defined');
+      }
+      expect(Object.prototype.hasOwnProperty.call(metadata, 'results')).toBe(
+        false,
+      );
+      // Summary fields are present instead.
+      expect(metadata).toHaveProperty('truncated');
+      expect(metadata).toHaveProperty('recordBudget');
+    });
+  });
+
+  describe('observed-count metadata (item H)', () => {
+    it('reports recordsObserved == retained for an exact complete dependencies traversal', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'dependencies',
+        language: 'typescript',
+        target: join(tempDir, 'dep-exact.ts'),
+      });
+      const payload = parsePayload(result);
+      expect(payload.truncated).toBe(false);
+      expect(payload.recordsObserved).toBe(payload.recordsRetained);
+      expect(payload.recordsObserved).toBe(5);
+    });
+
+    it('reports recordsObserved >= retained+1 (lower bound) after a dependencies sentinel overflow', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'dependencies',
+        language: 'typescript',
+        target: join(tempDir, 'dep-over.ts'),
+      });
+      const payload = parsePayload(result);
+      expect(payload.truncated).toBe(true);
+      expect(payload.recordsRetained).toBe(5);
+      expect(payload.recordsObserved).toBeGreaterThanOrEqual(6);
+      expect(payload.countInexact).toBe(true);
+    });
+
+    it('reports recordsObserved for an exact complete references traversal', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'references',
+        language: 'typescript',
+        symbol: 'unicorn',
+        target: join(tempDir, 'refs-exact.ts'),
+      });
+      const payload = parsePayload(result);
+      expect(payload.truncated).toBe(false);
+      expect(payload.recordsObserved).toBe(payload.recordsRetained);
+    });
+
+    it('reports recordsObserved as a lower bound after a references sentinel overflow', async () => {
+      const host = createBudgetToolHost(tempDir, 5);
+      const result = await runTool(host, {
+        mode: 'references',
+        language: 'typescript',
+        symbol: 'unicorn',
+        target: join(tempDir, 'refs-over.ts'),
+      });
+      const payload = parsePayload(result);
+      expect(payload.truncated).toBe(true);
+      expect(payload.recordsObserved).toBeGreaterThanOrEqual(
+        (payload.recordsRetained ?? 0) + 1,
+      );
+    });
+  });
+});

--- a/packages/tools/src/tools/structural-analysis/types.ts
+++ b/packages/tools/src/tools/structural-analysis/types.ts
@@ -33,11 +33,34 @@ export interface StructuralAnalysisParams {
   reverse?: boolean;
 }
 
+/** Reason a bounded traversal stopped before exhausting the workspace. */
+export type PartialReason = 'file-budget' | 'record-budget' | 'aborted';
+
 export interface AnalysisResult {
   mode: string;
   symbol?: string;
   truncated: boolean;
   results: unknown;
+  /** True when traversal was stopped by a budget or abort (alias of truncated). */
+  partial?: boolean;
+  /** Why the traversal stopped early, if applicable. */
+  partialReason?: PartialReason;
+  /** Effective maximum number of files visited. */
+  fileBudget?: number;
+  /** Effective maximum number of records retained. */
+  recordBudget?: number;
+  /** Number of files actually visited (bounded by {@link fileBudget}). */
+  filesVisited?: number;
+  /** Number of records actually retained (bounded by {@link recordBudget}). */
+  recordsRetained?: number;
+  /**
+   * Total records observed during traversal (retained + one-over sentinel when
+   * present). Equals recordsRetained for an exact complete traversal; a lower
+   * bound (at least retained+1) when a sentinel proved partiality.
+   */
+  recordsObserved?: number;
+  /** True when retained/visited counts are lower bounds, not exhaustive totals. */
+  countInexact?: boolean;
 }
 
 /**

--- a/packages/tools/src/tools/write-file.ts
+++ b/packages/tools/src/tools/write-file.ts
@@ -35,7 +35,7 @@ import {
   type ModifiableDeclarativeTool,
   type ModifyContext,
 } from './modifiable-tool.js';
-import { getSpecificMimeType } from '../utils/fileUtils.js';
+import { getSpecificMimeType, statFileSizeGate } from '../utils/fileUtils.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
 import { stringOrDefault } from '../utils/stringCoalescing.js';
@@ -177,6 +177,12 @@ class WriteFileToolInvocation extends BaseToolInvocation<
     }
 
     const filePath = this.getFilePath();
+    // Pre-read size gate: an oversized existing target must not be materialized
+    // for the preview diff. Defer to execute, which emits FILE_TOO_LARGE.
+    const sizeError = await statFileSizeGate(filePath);
+    if (sizeError) {
+      return false;
+    }
     const correctedContentResult = await getCorrectedFileContent(
       filePath,
       this.params.content,
@@ -229,6 +235,19 @@ class WriteFileToolInvocation extends BaseToolInvocation<
 
   async execute(_abortSignal: AbortSignal): Promise<ToolResult> {
     const filePath = this.getFilePath();
+
+    // Pre-read file-size gate: reject an oversized existing target before
+    // reading/copying it. New-file creation is unaffected (the gate returns
+    // null for a missing file).
+    const sizeError = await statFileSizeGate(filePath);
+    if (sizeError) {
+      return {
+        llmContent: sizeError.message,
+        returnDisplay: sizeError.message,
+        error: { message: sizeError.message, type: sizeError.type },
+      };
+    }
+
     const correctedContentResult = await getCorrectedFileContent(
       filePath,
       this.params.content,
@@ -521,6 +540,12 @@ export class WriteFileTool
           params.absolute_path,
           stringOrDefault(params.file_path, ''),
         );
+        // The modify seam must not materialize an oversized target into a
+        // temp editor file; reject before the read.
+        const sizeError = await statFileSizeGate(filePath);
+        if (sizeError) {
+          throw new Error(sizeError.message);
+        }
         const correctedContentResult = await getCorrectedFileContent(
           filePath,
           params.content,
@@ -533,6 +558,10 @@ export class WriteFileTool
           params.absolute_path,
           stringOrDefault(params.file_path, ''),
         );
+        const sizeError = await statFileSizeGate(filePath);
+        if (sizeError) {
+          throw new Error(sizeError.message);
+        }
         const correctedContentResult = await getCorrectedFileContent(
           filePath,
           params.content,

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -10,6 +10,7 @@ import { type ContentPartUnion } from '../types/wire-types.js';
 import mime from 'mime-types';
 import { ToolErrorType } from '../types/tool-error.js';
 import { debugLogger } from './debugLogger.js';
+import { isNodeError } from './errors.js';
 import {
   ImageResizeError,
   resizeImageIfNeeded,
@@ -582,9 +583,15 @@ export async function statFileSizeGate(
   let stats: fs.Stats;
   try {
     stats = await fs.promises.stat(filePath);
-  } catch {
-    // Missing/unstatable file: let the caller's read path handle ENOENT etc.
-    return null;
+  } catch (error: unknown) {
+    // ENOENT: missing file — let the caller's read path handle new-file
+    // creation. Any other stat failure (EACCES, EIO, ...) is unexpected and
+    // must fail fast so the caller surfaces the real error instead of
+    // silently bypassing the gate as if the file were missing.
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
   }
   // FILE_TOO_LARGE applies only to regular files; non-regular targets
   // (directories, devices, sockets) fall through to their established

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -19,7 +19,7 @@ import {
 // Constants for text file processing
 export const DEFAULT_MAX_LINES_TEXT_FILE = 2000;
 const MAX_LINE_LENGTH_TEXT_FILE = 2000;
-const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
+export const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
 
 // Default values for encoding and separator format
 export const DEFAULT_ENCODING: BufferEncoding = 'utf-8';
@@ -534,6 +534,67 @@ export function getImageSourceSizeLimit(
   return shouldResize ? MAX_FILE_SIZE_BYTES : outputLimit;
 }
 
+/**
+ * Shared pre-read file-size validation contract. Carries the existing
+ * FILE_TOO_LARGE message/type so every consumer (the read-content path and the
+ * pre-read stat gate) shares ONE threshold/message definition.
+ */
+export interface FileSizeGateError {
+  readonly message: string;
+  readonly type: ToolErrorType.FILE_TOO_LARGE;
+}
+
+/**
+ * The single file-size validation primitive. Returns a structured
+ * {@link FileSizeGateError} when `sizeBytes` exceeds the 20 MiB limit, or
+ * `null` when it is within the limit. Both the existing
+ * {@link processSingleFileContent} size gate and the pre-read stat helper
+ * delegate to this so the threshold and message cannot drift apart.
+ */
+export function validateFileSizeBytes(
+  filePath: string,
+  sizeBytes: number,
+): FileSizeGateError | null {
+  if (sizeBytes > MAX_FILE_SIZE_BYTES) {
+    const sizeInMB = sizeBytes / (1024 * 1024);
+    return {
+      message: `File size exceeds the 20MB limit: ${filePath} (${sizeInMB.toFixed(2)}MB)`,
+      type: ToolErrorType.FILE_TOO_LARGE,
+    };
+  }
+  return null;
+}
+
+/**
+ * Pre-read file-size gate shared by read and modification tools.
+ *
+ * Stats the target; if it exists and exceeds {@link MAX_FILE_SIZE_BYTES},
+ * returns a {@link FileSizeGateError} via the shared primitive. Returns `null`
+ * when the file does not exist (so new-file creation paths are unaffected) or
+ * is within the limit.
+ *
+ * This is the single reuse point for the pre-read size policy — every public
+ * target-read path calls this before materializing content.
+ */
+export async function statFileSizeGate(
+  filePath: string,
+): Promise<FileSizeGateError | null> {
+  let stats: fs.Stats;
+  try {
+    stats = await fs.promises.stat(filePath);
+  } catch {
+    // Missing/unstatable file: let the caller's read path handle ENOENT etc.
+    return null;
+  }
+  // FILE_TOO_LARGE applies only to regular files; non-regular targets
+  // (directories, devices, sockets) fall through to their established
+  // directory/error handling rather than being misclassified as oversized.
+  if (!stats.isFile()) {
+    return null;
+  }
+  return validateFileSizeBytes(filePath, stats.size);
+}
+
 function validateFileAccess(filePath: string): ProcessedFileReadResult | null {
   if (!fs.existsSync(filePath)) {
     return {
@@ -567,16 +628,16 @@ function validateFileSize(
   filePath: string,
   stats: fs.Stats,
 ): ProcessedFileReadResult | null {
-  const fileSizeInMB = stats.size / (1024 * 1024);
-  if (stats.size > MAX_FILE_SIZE_BYTES) {
-    return {
-      llmContent: 'File size exceeds the 20MB limit.',
-      returnDisplay: 'File size exceeds the 20MB limit.',
-      error: `File size exceeds the 20MB limit: ${filePath} (${fileSizeInMB.toFixed(2)}MB)`,
-      errorType: ToolErrorType.FILE_TOO_LARGE,
-    };
+  const gate = validateFileSizeBytes(filePath, stats.size);
+  if (gate === null) {
+    return null;
   }
-  return null;
+  return {
+    llmContent: 'File size exceeds the 20MB limit.',
+    returnDisplay: 'File size exceeds the 20MB limit.',
+    error: gate.message,
+    errorType: gate.type,
+  };
 }
 
 function processBinaryFile(

--- a/project-plans/issue3205/PLAN.md
+++ b/project-plans/issue3205/PLAN.md
@@ -1,0 +1,87 @@
+# Plan: Bound Workspace Analysis and Large-File Materialization (Issue #3205)
+
+Plan ID: PLAN-20260810-ISSUE3205
+Generated: 2026-08-10
+Parent: #3202
+
+## Accepted behavior
+
+### Structural analysis
+
+1. `dependencies`, `references`, and `exports` enforce finite file and retained-record budgets while traversing. They do not enumerate an unbounded file list and then slice it, and they do not build an unbounded record aggregate before limiting it.
+2. The budgets are internal count policies owned by the structural-analysis module. They follow the validated, finite-budget pattern established by #3200 and may use the existing validated `tool-output-max-items` setting as an input, but they do not use the byte-oriented head/tail stream collector and do not add public tool parameters or settings.
+3. The exact effective file and record budgets are reported with count metadata. At the exact limit, an exhausted traversal is complete; a one-over traversal is partial. Collection may observe one sentinel item beyond a retention limit to determine that more data exists, but it must not retain that item.
+4. A budget stop or abort returns the records retained so far with `truncated: true`, an explicit partial indicator/reason, and accurate observed/retained/budget accounting. Counts that cannot be known after an early stop are marked inexact rather than presented as totals.
+5. Existing `callers` and `callees` `maxNodes` behavior is unchanged. `definitions` and `hierarchy` are outside this issue because the issue body and required behavioral matrix specifically identify dependencies/references/exports; they are not pulled in as adjacent cleanup.
+6. Structural tool serialization creates the aggregate JSON once for `llmContent`. `ToolResult.metadata` contains only bounded summary/truncation fields and does not retain a second reference to the full results aggregate.
+
+### AST grep
+
+1. `maxResults` is an acquisition-time retained-match bound. The tool materializes at most `maxResults` match records and stops the search after observing the first additional match needed to prove truncation; it does not collect every match and slice afterward.
+2. Exact-limit input is complete and not truncated. One-over and far-over input returns exactly `maxResults` records and explicit partial metadata. Any count that is only a lower bound is labeled inexact; the tool does not claim an exact total after stopping early.
+3. Abort during directory traversal returns the retained matches as a clearly identified partial result rather than silently presenting them as complete.
+4. The existing AST parser/language behavior, pattern/rule semantics, glob semantics, workspace boundary, and public parameters remain unchanged.
+
+### Shared pre-read file-size policy
+
+1. Extend and export/reuse the existing stat/size policy in `packages/tools/src/utils/fileUtils.ts`; do not create a second file-size utility.
+2. Before reading, parsing, diffing, backing up, or copying an existing target, the policy applies to the public AST read and modification paths: `ast_read_file`, AST edit preview/apply, `edit`, `apply_patch`, `insert_at_line`, `delete_line_range`, and the read-before-write path of `write_file`.
+3. A regular file whose size equals the existing 20 MiB limit remains accepted. A file one byte over is rejected before content materialization with the existing `FILE_TOO_LARGE` classification/message contract. Missing-file creation behavior and directory/error behavior remain compatible.
+4. `read_file`, `read_line_range`, and `read_many_files` continue to use the same gate with their existing acquisition limits, output formatting, and truncation behavior unchanged.
+5. This issue does not add byte streaming for whole-file edits, change the 20 MiB limit, redesign AST parsing, or introduce a generic result-streaming protocol.
+
+## Inputs and boundary cases
+
+- Structural count inputs: no setting, a valid positive `tool-output-max-items`, exact effective file/record budget, one item over, many items over, and abort after partial traversal.
+- Dependency records include forward and optional reverse records under one bounded accounting policy; deduplication must not allow retained output to exceed the record budget.
+- Reference records are bounded across all result categories, not independently per category.
+- Export records are bounded across the complete result.
+- AST grep: zero/below-limit, exact `maxResults`, one-over, far-over across real files, and abort during a real directory traversal.
+- File size: existing target at exactly `MAX_FILE_SIZE_BYTES`, target at `MAX_FILE_SIZE_BYTES + 1`, new-file write, and host filesystem-service versus native filesystem read paths.
+- Signals already aborted before work and signals raised during traversal must never produce a falsely complete result.
+
+## Behavioral evidence (Bun and `bun:test` only)
+
+1. Extend the real-fixture structural-analysis suite with dependencies, references, and exports fixture trees that exceed file and record budgets. Assert retained aggregate size, exact-limit versus one-over metadata, abort partiality, and bounded serialized/metadata shapes. Do not use mock call-count assertions.
+2. Add a real-fixture AST grep behavioral suite with far more matches/files than requested. Assert that output retains only the requested records and reports a lower-bound/inexact count after the first omitted match, which distinguishes bounded acquisition from the old collect-all-and-slice behavior. Cover exact-limit and abort.
+3. Extend existing AST/edit and filesystem tool suites with programmatically created exact-20-MiB and 20-MiB-plus-one targets. Exercise the public tool paths and assert the over-limit error occurs without changing the file.
+4. Add focused shared-gate boundary coverage in the existing `fileUtils` test suite and regression coverage sufficient to prove `read_file`, `read_line_range`, and `read_many_files` retain their existing behavior.
+5. Tests use real temporary fixture trees/files and the real tools/parser. Filesystem infrastructure may be supplied through established test hosts, but tests must assert public results and filesystem state, not that a mock was called.
+
+## Scope boundaries
+
+- No changes to the #3200 bounded head/tail collector.
+- No parser/language redesign and no generic streaming-result protocol.
+- No new dependency, package, public tool parameter, setting, workflow, agent memory, suppression, ignore, lint downgrade, or complexity-threshold increase.
+- No unrelated refactor and no expansion to structural `definitions`/`hierarchy` unless required to keep a directly shared internal contract compiling; any such compatibility edit must not add new behavior.
+- No changes to normal read-tool acquisition policy beyond exposing/reusing its existing gate.
+
+## Test-first sequence
+
+1. Add failing structural dependencies/references/exports budget and abort tests.
+2. Implement internal bounded file discovery/record collection and partial metadata; then remove aggregate duplication.
+3. Add failing AST grep exact/overflow/abort tests, then implement bounded acquisition and accurate partial metadata.
+4. Add failing shared gate and public AST/modification exact/over tests, then extend the existing file-size gate through every accepted target-read path.
+5. Run focused suites after each red/green cycle, followed by the repository verification gates.
+
+## Local completion evidence
+
+### RED → GREEN behavioral evidence
+
+- Structural budget tests first demonstrated retained output beyond the requested budget, missing partial metadata, incorrect reverse-dependency accounting, and false complete results. The final real-fixture suite covers exact-limit, one-over, far-over, shared forward/reverse accounting, global reference/export caps, file-budget stops, and pre/mid-traversal aborts.
+- AST-grep tests first demonstrated collect-all-then-slice behavior and a false exact total. The final real-fixture suite covers below/exact/one-over/far-over limits, single-file overflow, skipped files, and pre/mid-directory aborts.
+- File-size tests first demonstrated that seven accepted public modification/read paths materialized over-limit targets. The final suite covers each public path, exact 20 MiB acceptance, 20 MiB + 1 rejection, unchanged rejected targets, new-file creation, existing read-tool regressions, and native plus host-filesystem-service paths.
+- Final focused issue suites: 74 passed, 0 failed, 173 expectations. Full tools workspace: 93/93 isolated test files passed.
+
+### Final-candidate verification
+
+- `npm run format`, `npm run format:check`, `npm run typecheck`, `npm run lint:eslint-guard`, `npm run build`, and `git diff --check` passed.
+- The monolithic lint and test commands exceed the local synchronous shell ceiling, so their complete inventories were executed through bounded canonical/scoped partitions. Strict lint passed for all workspaces, integration tests, root-managed sources, and LSP.
+- Tests passed for core (386/386 files), tools (93/93 files), providers (563/563 files), agents (372/372 source files plus 6/6 shared native Bun files), and CLI (682/682 files; 8,813 passed cases, 5 skipped, 13 todo). Every smaller workspace test command passed.
+- Required smoke command passed with the `stepfun-37` profile and returned only a valid three-line haiku after the profile banner.
+- No package manifest or lockfile changed. The shared file-size threshold remains 20 MiB, public tool parameters remain unchanged, and no suppression, ignore, lint downgrade, or complexity-threshold change was introduced.
+
+### Local review disposition
+
+- DeepThinker reviewed the implementation against this accepted plan. Grounded findings about skipped-file partiality, authoritative host-returned size validation, dependency partiality, and boundary coverage were classified `In-scope-Fix` and remediated test-first. Parser/public redesign suggestions were classified `Reject` because they violate explicit non-goals. No `Blocker-Fix` or `Defer` item remains.
+- One local Open Code Review cycle selected 20 TypeScript files and emitted 10 findings. Seven grounded finding groups were classified `In-scope-Fix` and remediated; two behavior-changing suggestions were classified `Reject`; no finding was classified `Blocker-Fix` or `Defer`. OCR exhausted its own tool-round budget on `file-size-gate.bun.test.ts` and `structural-analysis/types.ts`; those files were independently covered by the 40-test file-size suite and full tools typecheck. The review-cycle ceiling precludes another local review.

--- a/project-plans/issue3205/PLAN.md
+++ b/project-plans/issue3205/PLAN.md
@@ -85,3 +85,23 @@ Parent: #3202
 
 - DeepThinker reviewed the implementation against this accepted plan. Grounded findings about skipped-file partiality, authoritative host-returned size validation, dependency partiality, and boundary coverage were classified `In-scope-Fix` and remediated test-first. Parser/public redesign suggestions were classified `Reject` because they violate explicit non-goals. No `Blocker-Fix` or `Defer` item remains.
 - One local Open Code Review cycle selected 20 TypeScript files and emitted 10 findings. Seven grounded finding groups were classified `In-scope-Fix` and remediated; two behavior-changing suggestions were classified `Reject`; no finding was classified `Blocker-Fix` or `Defer`. OCR exhausted its own tool-round budget on `file-size-gate.bun.test.ts` and `structural-analysis/types.ts`; those files were independently covered by the 40-test file-size suite and full tools typecheck. The review-cycle ceiling precludes another local review.
+
+### PR-hosted review disposition
+
+- `In-scope-Fix`: authoritative host-returned AST-edit content was not size-validated immediately after acquisition. A RED host-divergence test proved that a small native target paired with over-20-MiB host content was accepted; the shared byte gate now rejects it before syntax/diff work.
+- `In-scope-Fix`: a pre-aborted single-file AST-grep invocation still read and parsed its target. A RED real-file test now proves the invocation returns no matches with `partialReason: "aborted"` before acquisition.
+- `In-scope-Fix`: structural record retention could increment accounting after the authoritative signal aborted. Focused RED tracker coverage now proves `tryRetainRecord()` stops without changing counts, and `markAborted()` only marks partiality when its signal is actually aborted.
+- `In-scope-Fix`: the shared native stat gate treated every stat failure as a missing target. Real permission-boundary coverage now proves only `ENOENT` returns `null`; unexpected native stat failures are rethrown.
+- `Reject`: proposals to add an absolute AST-grep `maxResults` schema ceiling, handle invalid infinite validated settings locally, split forward/reverse dependency budgets, raise the structural file ceiling, or change max-results/abort precedence conflict with the accepted public-contract and shared-budget design.
+- `Reject`: claims that early AST-grep termination makes observed `skippedFiles` inaccurate, that dependency duplicate behavior affects export sentinel accounting, or that apply-patch/write confirmation loses the execute-time size error are inconsistent with the implemented ownership and result contracts.
+- `Reject`: a redundant test guard, docstring-coverage churn, and the LLxprt walkthrough statement that committed behavioral tests were absent are optional, out of scope, or factually invalid. The committed suites were executed by the tools runner and CI.
+- Five findings were therefore classified `In-scope-Fix` and remediated test-first; twelve were classified `Reject`. No PR finding remains classified `Blocker-Fix` or `Defer`.
+
+### PR-remediation verification
+
+- Focused issue and tracker suites passed: 81 tests, 0 failures, 198 expectations. The file-size suite passed 42 tests, AST-grep passed 19, structural integration passed 16, and focused tracker coverage passed 4.
+- Full tools verification passed 94/94 isolated Bun test files. The AST-edit regression inventory passed 251 tests with 0 failures and 747 expectations.
+- `npm run format`, `npm run format:check`, `npm run typecheck`, `npm run build`, `npm run lint:eslint-guard`, strict zero-warning ESLint for all remediation-touched TypeScript files, and `git diff --check` passed on the remediation candidate.
+- The required `stepfun-37` smoke command passed and returned only a three-line haiku after the profile banner.
+- The initial PR candidate had already passed all test/lint/build/review checks except one Windows installed-command job whose fixed 10-minute global npm installation ended with `ETIMEDOUT` before issue-specific execution. The failed job was rerun; the authoritative post-remediation CI run is required before final readiness.
+- No package manifest, lockfile, workflow, `.llxprt` content, public tool parameter, setting/schema, suppression, ignore, lint downgrade, or complexity-threshold change was introduced.


### PR DESCRIPTION
## TLDR

Bounds workspace analysis and file materialization before retained output or target contents can grow without limit. Structural dependencies/references/exports and AST grep now stop acquisition at finite count budgets with accurate partial-result metadata, while AST read and modification tools reuse the existing 20 MiB pre-read gate.

## Dive Deeper

- Adds lazy structural file traversal plus shared internal file/record accounting for dependencies, references, and exports.
- Preserves exact-limit completeness, observes one non-retained sentinel for overflow, and reports explicit partial reasons with inexact lower-bound counts after early stopping or abort.
- Bounds AST-grep match-record materialization at maxResults and stops directory acquisition after the first omitted match; parser, pattern, language, glob, workspace, and public parameter behavior remain unchanged.
- Reuses the existing packages/tools file-size policy for ast_read_file, AST edit preview/apply, edit, apply_patch, insert_at_line, delete_line_range, and existing-target write_file reads.
- Accepts exactly 20 MiB and rejects 20 MiB + 1 with FILE_TOO_LARGE before parse/diff/copy where the filesystem API permits; authoritative host-returned content is validated immediately after acquisition.
- Keeps read_file, read_line_range, and read_many_files acquisition and formatting behavior compatible.
- Avoids duplicating structural aggregate results in ToolResult metadata; llmContent remains the aggregate JSON source of truth.
- Adds real fixture/file Bun behavioral coverage and records accepted behavior, boundaries, RED to GREEN evidence, verification, and review dispositions in the issue plan.

Local reviews included DeepThinker and one Open Code Review cycle. All grounded in-scope findings were remediated test-first; parser/public redesign suggestions were rejected as explicit non-goals. No blocker or deferred local finding remains.

## Reviewer Test Plan

From the repository root:

    bun test packages/tools/src/tools/structural-analysis/structural-analysis-budgets.bun.test.ts
    bun test packages/tools/src/tools/ast-grep.behavioral.bun.test.ts
    bun test packages/tools/src/tools/file-size-gate.bun.test.ts
    npm run test --workspace packages/tools
    npm run typecheck
    npm run lint:eslint-guard
    npm run format:check
    npm run build

Key behaviors to inspect:

1. Run structural dependencies, references, or exports against a fixture larger than the effective file/record budgets. Verify bounded retained records, truncated true, an explicit partial reason, and inexact accounting without a duplicated results aggregate in metadata.
2. Run AST grep with exact maxResults matches, then one more match. The exact case is complete; the overflow case retains exactly maxResults and reports partial/inexact metadata.
3. Exercise each accepted modification/read path with an exact-20-MiB target and a 20-MiB-plus-one target. The exact target is accepted; the oversized target returns FILE_TOO_LARGE and remains unchanged.
4. Confirm normal read_file, read_line_range, read_many_files, new-file write, and host filesystem-service paths retain their established behavior.

The complete local test inventory passed in bounded partitions because the monolithic workspace command exceeds the local synchronous shell ceiling: core 386/386 files, tools 93/93, providers 563/563, agents 372/372 source files plus 6/6 shared files, CLI 682/682 files, and every smaller workspace command. The required stepfun-37 CLI smoke test also passed.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅ | ❓ | ❓ |
| npx      | ❓ | ❓ | ❓ |
| Docker   | ❓ | ❓ | ❓ |
| Podman   | - | - | - |
| Seatbelt | ❓ | - | - |

## Linked issues / bugs

Fixes #3205

Related to #3202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file-size protection across file reading, editing, patching, preview, and writing operations.
  * Oversized files now return clear, structured errors before processing; new-file creation remains supported.
  * AST search and structural analysis now limit results and report truncation, partial results, and cancellation status.
  * Added safeguards against excessive output and memory usage during code analysis.

* **Tests**
  * Expanded coverage for file-size limits, bounded searches, partial results, cancellation, and exact-limit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->