### PR TITLE
Bound external response acquisition before materialization (Fixes #3204)

### DIFF
--- a/packages/mcp/src/client/mcp-callable-tool.ts
+++ b/packages/mcp/src/client/mcp-callable-tool.ts
@@ -5,14 +5,88 @@
  */
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import type { Tool as McpTool } from '@modelcontextprotocol/sdk/types.js';
+import type {
+  CallToolResult,
+  Tool as McpTool,
+} from '@modelcontextprotocol/sdk/types.js';
 import type {
   CallableTool,
   ToolCallRequest as FunctionCall,
   ContentPart as Part,
   ToolDeclarations as Tool,
 } from '@vybestack/llxprt-code-tools';
+import { createDefaultByteBudget } from '@vybestack/llxprt-code-tools/acquisition.js';
 import { MCP_CAPABILITY_NOT_AUTHORIZED_MESSAGE } from './mcp-errors.js';
+import { firstTruthyString } from '../utils/string-fallback.js';
+
+const MCP_CONTENT_BUDGET = createDefaultByteBudget();
+
+/** Content block element type derived from the SDK's CallToolResult. */
+type McpContentBlock = CallToolResult['content'][number];
+
+/** The full return type of Client.callTool (content variant ∪ task variant). */
+type CallToolReturn = Awaited<ReturnType<Client['callTool']>>;
+
+function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+/**
+ * Compile-time exhaustiveness guard. If a new content block variant is added
+ * to the SDK, this function's `never` parameter will fail to accept the
+ * unhandled variant, producing a compile error at every switch site.
+ */
+function assertNeverContent(block: never): never {
+  throw new Error(
+    `Unrecognized MCP content block type: ${JSON.stringify(block)}`,
+  );
+}
+
+function countContentBlockBytes(block: McpContentBlock): number {
+  switch (block.type) {
+    case 'text':
+      return utf8ByteLength(block.text);
+    case 'image':
+      return utf8ByteLength(block.data);
+    case 'audio':
+      return utf8ByteLength(block.data);
+    case 'resource': {
+      if ('text' in block.resource) {
+        return utf8ByteLength(block.resource.text);
+      }
+      return utf8ByteLength(block.resource.blob);
+    }
+    case 'resource_link': {
+      const label = firstTruthyString(block.title, block.name);
+      return utf8ByteLength(`Resource Link: ${label} at ${block.uri}`);
+    }
+    default:
+      return assertNeverContent(block);
+  }
+}
+
+function countAggregateContentBytes(
+  content: readonly McpContentBlock[],
+  limit: number,
+): number {
+  let total = 0;
+  for (const block of content) {
+    total += countContentBlockBytes(block);
+    if (total > limit) return total;
+  }
+  return total;
+}
+
+/**
+ * Narrows a callTool result to the standard variant carrying a `content`
+ * array. The SDK also returns a compatibility/task variant with `toolResult`
+ * and no `content` — that variant has nothing to count.
+ */
+function hasContentArray(
+  result: CallToolReturn,
+): result is CallToolReturn & { content: McpContentBlock[] } {
+  return 'content' in result && Array.isArray(result.content);
+}
 
 /**
  * Adapts an MCP tool definition to the neutral CallableTool interface so it
@@ -62,6 +136,18 @@ export class McpCallableTool implements CallableTool {
       );
       if (!this.isAuthorized()) {
         throw new Error(MCP_CAPABILITY_NOT_AUTHORIZED_MESSAGE);
+      }
+
+      if (hasContentArray(result)) {
+        const observedBytes = countAggregateContentBytes(
+          result.content,
+          MCP_CONTENT_BUDGET.bytes,
+        );
+        if (observedBytes > MCP_CONTENT_BUDGET.bytes) {
+          throw new Error(
+            `MCP tool result content (${observedBytes.toLocaleString('en-US')} bytes) exceeds the maximum allowed (${MCP_CONTENT_BUDGET.bytes.toLocaleString('en-US')} bytes)`,
+          );
+        }
       }
 
       return [

--- a/packages/mcp/src/client/neutral-types.test.ts
+++ b/packages/mcp/src/client/neutral-types.test.ts
@@ -6,12 +6,31 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { describe, it, expect } from 'bun:test';
+import type { Tool as McpTool } from '@modelcontextprotocol/sdk/types.js';
 import {
   type CallableTool,
   type ContentPart,
   type ToolDeclarations,
 } from '@vybestack/llxprt-code-tools';
 import { McpCallableTool } from './mcp-callable-tool.js';
+
+const TOOL_DEF: McpTool = {
+  name: 'test_tool',
+  description: 'A test tool',
+  inputSchema: { type: 'object' },
+};
+
+const BUDGET_BYTES = 4 * 1024 * 1024;
+
+function mockClient(result: unknown): Client {
+  return { callTool: async () => result } as unknown as Client;
+}
+
+function extractResponse(
+  parts: Awaited<ReturnType<McpCallableTool['callTool']>>,
+): Record<string, unknown> {
+  return parts[0]?.functionResponse?.response as Record<string, unknown>;
+}
 
 describe('MCP behavioral tests for neutral wire types', () => {
   it('McpCallableTool.tool() maps the MCP input schema to parametersJsonSchema', async () => {
@@ -80,5 +99,200 @@ describe('MCP behavioral tests for neutral wire types', () => {
       5000,
     );
     expect(accept(callableTool)).toBe(callableTool);
+  });
+});
+
+describe('McpCallableTool aggregate content budget', () => {
+  it('accepts exact-boundary aggregate text', async () => {
+    const text = 'x'.repeat(BUDGET_BYTES);
+    const client = mockClient({ content: [{ type: 'text', text }] });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    expect(extractResponse(parts).error).toBeUndefined();
+  });
+
+  it('fails one-byte-over text content atomically', async () => {
+    const text = 'x'.repeat(BUDGET_BYTES + 1);
+    const client = mockClient({ content: [{ type: 'text', text }] });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    expect(extractResponse(parts).error).toMatchObject({ isError: true });
+  });
+
+  it('fails oversized image base64 content atomically', async () => {
+    const data = 'A'.repeat(BUDGET_BYTES + 1);
+    const client = mockClient({
+      content: [{ type: 'image', data, mimeType: 'image/png' }],
+    });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    expect(extractResponse(parts).error).toMatchObject({ isError: true });
+  });
+
+  it('fails oversized audio base64 content atomically', async () => {
+    const data = 'A'.repeat(BUDGET_BYTES + 1);
+    const client = mockClient({
+      content: [{ type: 'audio', data, mimeType: 'audio/mp3' }],
+    });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    expect(extractResponse(parts).error).toMatchObject({ isError: true });
+  });
+
+  it('fails oversized embedded text resource atomically', async () => {
+    const text = 'x'.repeat(BUDGET_BYTES + 1);
+    const client = mockClient({
+      content: [
+        {
+          type: 'resource',
+          resource: { uri: 'file:///r.txt', text, mimeType: 'text/plain' },
+        },
+      ],
+    });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    expect(extractResponse(parts).error).toMatchObject({ isError: true });
+  });
+
+  it('fails oversized embedded blob resource atomically', async () => {
+    const blob = 'A'.repeat(BUDGET_BYTES + 1);
+    const client = mockClient({
+      content: [
+        {
+          type: 'resource',
+          resource: {
+            uri: 'file:///d.bin',
+            blob,
+            mimeType: 'application/octet-stream',
+          },
+        },
+      ],
+    });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    expect(extractResponse(parts).error).toMatchObject({ isError: true });
+  });
+
+  it('fails multiple blocks whose aggregate crosses the budget', async () => {
+    const half = Math.floor(BUDGET_BYTES / 2);
+    const client = mockClient({
+      content: [
+        { type: 'text', text: 'x'.repeat(half) },
+        { type: 'text', text: 'x'.repeat(half + 1) },
+      ],
+    });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    expect(extractResponse(parts).error).toMatchObject({ isError: true });
+  });
+
+  it('accepts a valid mixed-block response with content returned unchanged', async () => {
+    const content = [
+      { type: 'text', text: 'First part.' },
+      { type: 'image', data: 'BASE64_IMAGE', mimeType: 'image/jpeg' },
+      { type: 'text', text: 'Second part.' },
+    ];
+    const client = mockClient({ content });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    const response = extractResponse(parts);
+    expect(response.error).toBeUndefined();
+    expect(response.content).toStrictEqual(content);
+  });
+
+  it('accepts exact-boundary UTF-8 multibyte text', async () => {
+    // "é" is 2 UTF-8 bytes. BUDGET_BYTES / 2 chars = exactly BUDGET_BYTES bytes.
+    const text = 'é'.repeat(BUDGET_BYTES / 2);
+    const client = mockClient({ content: [{ type: 'text', text }] });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    expect(extractResponse(parts).error).toBeUndefined();
+  });
+
+  it('fails one-byte-over UTF-8 multibyte text atomically', async () => {
+    const text = 'é'.repeat(BUDGET_BYTES / 2) + 'x';
+    const client = mockClient({ content: [{ type: 'text', text }] });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    const response = extractResponse(parts);
+    expect(response.error).toMatchObject({ isError: true });
+    expect(response.content).toBeUndefined();
+  });
+
+  it('accepts exact-boundary resource-link transformed string', async () => {
+    // The transformed string is: `Resource Link: ${label} at ${uri}`
+    // Overhead: "Resource Link: " (15) + " at " (4) = 19 bytes.
+    // uri = "file:///r" (9 bytes). label must be BUDGET_BYTES - 19 - 9 bytes.
+    const uri = 'file:///r';
+    const labelLength = BUDGET_BYTES - 19 - uri.length;
+    const client = mockClient({
+      content: [
+        {
+          type: 'resource_link',
+          uri,
+          title: 'x'.repeat(labelLength),
+        },
+      ],
+    });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    expect(extractResponse(parts).error).toBeUndefined();
+  });
+
+  it('fails one-byte-over resource-link transformed string atomically', async () => {
+    const uri = 'file:///r';
+    const labelLength = BUDGET_BYTES - 19 - uri.length + 1;
+    const client = mockClient({
+      content: [
+        {
+          type: 'resource_link',
+          uri,
+          title: 'x'.repeat(labelLength),
+        },
+      ],
+    });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    const response = extractResponse(parts);
+    expect(response.error).toMatchObject({ isError: true });
+    expect(response.content).toBeUndefined();
+  });
+
+  it('fails a heterogeneous multi-block aggregate that crosses the budget', async () => {
+    const half = Math.floor(BUDGET_BYTES / 2);
+    const client = mockClient({
+      content: [
+        { type: 'text', text: 'x'.repeat(half - 1) },
+        { type: 'image', data: 'A'.repeat(half + 2), mimeType: 'image/png' },
+      ],
+    });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    const response = extractResponse(parts);
+    expect(response.error).toMatchObject({ isError: true });
+    expect(response.content).toBeUndefined();
+  });
+
+  it('returns the exact size-limit error shape with no partial content on overflow', async () => {
+    const text = 'x'.repeat(BUDGET_BYTES + 1);
+    const client = mockClient({ content: [{ type: 'text', text }] });
+    const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+    const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+    const response = extractResponse(parts);
+
+    const error = response.error as Record<string, unknown> | undefined;
+    expect(error).toBeDefined();
+    expect(error?.isError).toBe(true);
+    expect(typeof error?.message).toBe('string');
+    expect(error?.message as string).toMatch(/exceeds the maximum allowed/i);
+    expect(error?.message as string).toContain(
+      (BUDGET_BYTES + 1).toLocaleString('en-US'),
+    );
+    expect(error?.message as string).toContain(
+      BUDGET_BYTES.toLocaleString('en-US'),
+    );
+    // No partial content or original result leaks through.
+    expect(response.content).toBeUndefined();
+    expect(response.isError).toBeUndefined();
   });
 });

--- a/packages/tools/src/tools/codesearch-endpoint.bun.test.ts
+++ b/packages/tools/src/tools/codesearch-endpoint.bun.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { mock, describe, it, expect, beforeEach, type Mock } from 'bun:test';
+import { Readable } from 'node:stream';
 
 /**
  * The fetch stub is the only thing standing in for the network. It captures
@@ -24,7 +25,8 @@ import { mock, describe, it, expect, beforeEach, type Mock } from 'bun:test';
 interface FetchResponse {
   ok: boolean;
   status?: number;
-  text: () => Promise<string>;
+  body: Readable;
+  headers: { get: (name: string) => string | null };
 }
 
 let queuedText = '';
@@ -36,7 +38,8 @@ const fetchStub: Mock<(url: string, init: unknown) => Promise<FetchResponse>> =
     async (_url: string, _init: unknown): Promise<FetchResponse> => ({
       ok: queuedOk,
       status: queuedStatus,
-      text: async () => queuedText,
+      body: Readable.from([Buffer.from(queuedText)]),
+      headers: { get: () => null },
     }),
   );
 

--- a/packages/tools/src/tools/codesearch.test.ts
+++ b/packages/tools/src/tools/codesearch.test.ts
@@ -5,13 +5,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'bun:test';
+import { Readable } from 'node:stream';
 
 import { CodeSearchTool, type CodeSearchToolParams } from './codesearch.js';
+import { ToolErrorType } from '../types/tool-error.js';
 
 const { mockedFetch } = { mockedFetch: vi.fn() };
 void vi.mock('node-fetch', () => ({
   default: mockedFetch,
 }));
+
+function mockBody(text: string): Readable {
+  return Readable.from([Buffer.from(text)]);
+}
 
 describe('CodeSearchTool', () => {
   const keyStorage = { resolveKey: vi.fn() };
@@ -36,10 +42,10 @@ describe('CodeSearchTool', () => {
   it('executes search successfully with default tokens', async () => {
     mockedFetch.mockResolvedValue({
       ok: true,
-      text: () =>
-        Promise.resolve(
-          'data: {"result":{"content":[{"text":"Here is some React hooks documentation..."}]}}\n',
-        ),
+      headers: { get: () => null },
+      body: mockBody(
+        'data: {"result":{"content":[{"text":"Here is some React hooks documentation..."}]}}\n',
+      ),
     });
 
     const result = await tool
@@ -58,7 +64,8 @@ describe('CodeSearchTool', () => {
     settingsService.getSetting.mockReturnValue(2000);
     mockedFetch.mockResolvedValue({
       ok: true,
-      text: () => Promise.resolve(''),
+      headers: { get: () => null },
+      body: mockBody(''),
     });
 
     await tool
@@ -73,7 +80,8 @@ describe('CodeSearchTool', () => {
     keyStorage.resolveKey.mockResolvedValue('sk-test-key');
     mockedFetch.mockResolvedValue({
       ok: true,
-      text: () => Promise.resolve(''),
+      headers: { get: () => null },
+      body: mockBody(''),
     });
 
     await tool
@@ -89,7 +97,8 @@ describe('CodeSearchTool', () => {
     mockedFetch.mockResolvedValue({
       ok: false,
       status: 500,
-      text: () => Promise.resolve('Internal Server Error'),
+      headers: { get: () => null },
+      body: mockBody('Internal Server Error'),
     });
 
     const result = await tool
@@ -97,5 +106,126 @@ describe('CodeSearchTool', () => {
       .execute(new AbortController().signal);
 
     expect(result.error?.message).toContain('Code search error (500)');
+  });
+
+  it('preserves malformed SSE line skipping behavior', async () => {
+    mockedFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      body: mockBody(
+        'garbage line\n' +
+          'data: {"result":{"content":[{"text":"Valid code result."}]}}\n',
+      ),
+    });
+
+    const result = await tool
+      .build({ query: 'mixed' })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toBe('Valid code result.');
+  });
+
+  it('handles upstream MCP error responses', async () => {
+    mockedFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      body: mockBody(
+        'data: {"error":{"code":-32603,"message":"upstream failure"}}\n',
+      ),
+    });
+
+    const result = await tool
+      .build({ query: 'upstream-error' })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+    expect(result.error?.message).toContain('upstream failure');
+  });
+
+  describe('body size limits', () => {
+    it('returns SEARCH_ERROR when the success body exceeds the budget', async () => {
+      mockedFetch.mockResolvedValue({
+        ok: true,
+        headers: {
+          get: (key: string) => (key === 'content-length' ? '9999999' : null),
+        },
+        body: mockBody('x'.repeat(100)),
+      });
+
+      const result = await tool
+        .build({ query: 'overflow' })
+        .execute(new AbortController().signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+      expect(result.error?.message).toMatch(/exceeds/i);
+    });
+
+    it('returns SEARCH_ERROR when the error body exceeds the budget', async () => {
+      mockedFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: {
+          get: (key: string) => (key === 'content-length' ? '9999999' : null),
+        },
+        body: mockBody('x'.repeat(100)),
+      });
+
+      const result = await tool
+        .build({ query: 'overflow-error' })
+        .execute(new AbortController().signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+      expect(result.error?.message).toMatch(/exceeds/i);
+    });
+  });
+
+  describe('observed-byte overflow (no Content-Length)', () => {
+    const BUDGET_BYTES = 4 * 1024 * 1024; // 4 MiB
+
+    function overflowStream(): Readable {
+      const chunkSize = 64 * 1024;
+      let sent = 0;
+      return new Readable({
+        read() {
+          if (sent > BUDGET_BYTES) {
+            this.push(null);
+            return;
+          }
+          this.push(Buffer.alloc(chunkSize, 0x78));
+          sent += chunkSize;
+        },
+      });
+    }
+
+    it('returns SEARCH_ERROR when a no-Content-Length success body exceeds the budget via observed bytes', async () => {
+      mockedFetch.mockResolvedValue({
+        ok: true,
+        headers: { get: () => null },
+        body: overflowStream(),
+      });
+
+      const result = await tool
+        .build({ query: 'observed-overflow-success' })
+        .execute(new AbortController().signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+      expect(result.error?.message).toMatch(/exceeds/i);
+    });
+
+    it('returns SEARCH_ERROR when a no-Content-Length error body exceeds the budget via observed bytes', async () => {
+      mockedFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: { get: () => null },
+        body: overflowStream(),
+      });
+
+      const result = await tool
+        .build({ query: 'observed-overflow-error' })
+        .execute(new AbortController().signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
+      expect(result.error?.message).toMatch(/exceeds/i);
+    });
   });
 });

--- a/packages/tools/src/tools/codesearch.test.ts
+++ b/packages/tools/src/tools/codesearch.test.ts
@@ -19,6 +19,13 @@ function mockBody(text: string): Readable {
   return Readable.from([Buffer.from(text)]);
 }
 
+function getFetchSignal(value: unknown): AbortSignal | undefined {
+  if (typeof value !== 'object' || value === null || !('signal' in value)) {
+    return undefined;
+  }
+  return value.signal instanceof AbortSignal ? value.signal : undefined;
+}
+
 describe('CodeSearchTool', () => {
   const keyStorage = { resolveKey: vi.fn() };
   const settingsService = {
@@ -144,12 +151,13 @@ describe('CodeSearchTool', () => {
 
   describe('body size limits', () => {
     it('returns SEARCH_ERROR when the success body exceeds the budget', async () => {
+      const successBody = mockBody('x'.repeat(100));
       mockedFetch.mockResolvedValue({
         ok: true,
         headers: {
           get: (key: string) => (key === 'content-length' ? '9999999' : null),
         },
-        body: mockBody('x'.repeat(100)),
+        body: successBody,
       });
 
       const result = await tool
@@ -158,16 +166,20 @@ describe('CodeSearchTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
       expect(result.error?.message).toMatch(/exceeds/i);
+      const fetchSignal = getFetchSignal(mockedFetch.mock.calls[0][1]);
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(successBody.destroyed).toBe(true);
     });
 
     it('returns SEARCH_ERROR when the error body exceeds the budget', async () => {
+      const errorBodyStream = mockBody('x'.repeat(100));
       mockedFetch.mockResolvedValue({
         ok: false,
         status: 500,
         headers: {
           get: (key: string) => (key === 'content-length' ? '9999999' : null),
         },
-        body: mockBody('x'.repeat(100)),
+        body: errorBodyStream,
       });
 
       const result = await tool
@@ -176,6 +188,10 @@ describe('CodeSearchTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
       expect(result.error?.message).toMatch(/exceeds/i);
+      expect(result.error?.message).toContain('500');
+      const fetchSignal = getFetchSignal(mockedFetch.mock.calls[0][1]);
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(errorBodyStream.destroyed).toBe(true);
     });
   });
 
@@ -198,10 +214,11 @@ describe('CodeSearchTool', () => {
     }
 
     it('returns SEARCH_ERROR when a no-Content-Length success body exceeds the budget via observed bytes', async () => {
+      const successBody = overflowStream();
       mockedFetch.mockResolvedValue({
         ok: true,
         headers: { get: () => null },
-        body: overflowStream(),
+        body: successBody,
       });
 
       const result = await tool
@@ -210,14 +227,18 @@ describe('CodeSearchTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
       expect(result.error?.message).toMatch(/exceeds/i);
+      const fetchSignal = getFetchSignal(mockedFetch.mock.calls[0][1]);
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(successBody.destroyed).toBe(true);
     });
 
     it('returns SEARCH_ERROR when a no-Content-Length error body exceeds the budget via observed bytes', async () => {
+      const errorBodyStream = overflowStream();
       mockedFetch.mockResolvedValue({
         ok: false,
         status: 500,
         headers: { get: () => null },
-        body: overflowStream(),
+        body: errorBodyStream,
       });
 
       const result = await tool
@@ -226,6 +247,10 @@ describe('CodeSearchTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.SEARCH_ERROR);
       expect(result.error?.message).toMatch(/exceeds/i);
+      expect(result.error?.message).toContain('500');
+      const fetchSignal = getFetchSignal(mockedFetch.mock.calls[0][1]);
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(errorBodyStream.destroyed).toBe(true);
     });
   });
 });

--- a/packages/tools/src/tools/codesearch.ts
+++ b/packages/tools/src/tools/codesearch.ts
@@ -17,6 +17,8 @@ import type {
 } from '../interfaces/index.js';
 import { ToolErrorType } from '../types/tool-error.js';
 import { ensureJsonSafe } from '../utils/unicodeUtils.js';
+import { createDefaultByteBudget } from '../acquisition/index.js';
+import { acquireBoundedHttpBody } from '../utils/bounded-http-response.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -32,6 +34,8 @@ const API_CONFIG = {
     CONTEXT: '/mcp',
   },
 } as const;
+
+const SEARCH_BYTE_BUDGET = createDefaultByteBudget();
 
 const TOKEN_LIMITS = {
   DEFAULT: 5000,
@@ -156,6 +160,20 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
     return `${baseUrl}?${params.toString()}`;
   }
 
+  private async readResponseBody(
+    response: Awaited<ReturnType<typeof fetch>>,
+    signal: AbortSignal,
+    cancelRequest: () => void,
+  ): Promise<string> {
+    const body = await acquireBoundedHttpBody(
+      response,
+      SEARCH_BYTE_BUDGET,
+      signal,
+      cancelRequest,
+    );
+    return body.text;
+  }
+
   async execute(
     signal: AbortSignal,
     _updateOutput?: (update: LiveOutputUpdate) => void,
@@ -173,7 +191,13 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
       },
     };
 
+    const localController = new AbortController();
+    const onSignalAbort = (): void => localController.abort();
+    signal.addEventListener('abort', onSignalAbort, { once: true });
+
     try {
+      if (signal.aborted) localController.abort();
+
       const headers: Record<string, string> = {
         accept: 'application/json, text/event-stream',
         'content-type': 'application/json',
@@ -184,43 +208,26 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
         method: 'POST',
         headers,
         body: JSON.stringify(codeRequest),
-        signal,
+        signal: localController.signal,
       });
 
+      const cancelRequest = (): void => localController.abort();
+
       if (!response.ok) {
-        const errorText = await response.text();
+        const errorText = await this.readResponseBody(
+          response,
+          signal,
+          cancelRequest,
+        );
         throw new Error(`Code search error (${response.status}): ${errorText}`);
       }
 
-      const responseText = await response.text();
-      const lines = responseText.split('\n');
-      for (const line of lines) {
-        const parsed = this.parseCodeResponseLine(line);
-        if (parsed === undefined) {
-          continue;
-        }
-        if (!parsed.ok) {
-          const safeErrorText = ensureJsonSafe(parsed.errorText);
-          return {
-            llmContent: `Code search failed: ${safeErrorText}`,
-            returnDisplay: `Code search failed: ${safeErrorText}`,
-            error: {
-              message: safeErrorText,
-              type: ToolErrorType.SEARCH_ERROR,
-            },
-          };
-        }
-        return {
-          llmContent: parsed.content,
-          returnDisplay: parsed.content,
-        };
-      }
-
-      return {
-        llmContent:
-          'No code snippets or documentation found. Please try a different query.',
-        returnDisplay: 'No results found.',
-      };
+      const responseText = await this.readResponseBody(
+        response,
+        signal,
+        cancelRequest,
+      );
+      return this.parseResponseResult(responseText);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -232,7 +239,39 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
           type: ToolErrorType.SEARCH_ERROR,
         },
       };
+    } finally {
+      signal.removeEventListener('abort', onSignalAbort);
     }
+  }
+
+  private parseResponseResult(responseText: string): ToolResult {
+    const lines = responseText.split('\n');
+    for (const line of lines) {
+      const parsed = this.parseCodeResponseLine(line);
+      if (parsed === undefined) {
+        continue;
+      }
+      if (!parsed.ok) {
+        const safeErrorText = ensureJsonSafe(parsed.errorText);
+        return {
+          llmContent: `Code search failed: ${safeErrorText}`,
+          returnDisplay: `Code search failed: ${safeErrorText}`,
+          error: {
+            message: safeErrorText,
+            type: ToolErrorType.SEARCH_ERROR,
+          },
+        };
+      }
+      return {
+        llmContent: parsed.content,
+        returnDisplay: parsed.content,
+      };
+    }
+    return {
+      llmContent:
+        'No code snippets or documentation found. Please try a different query.',
+      returnDisplay: 'No results found.',
+    };
   }
 
   private parseCodeResponseLine(line: string): ParsedCodeLine | undefined {

--- a/packages/tools/src/tools/codesearch.ts
+++ b/packages/tools/src/tools/codesearch.ts
@@ -18,7 +18,10 @@ import type {
 import { ToolErrorType } from '../types/tool-error.js';
 import { ensureJsonSafe } from '../utils/unicodeUtils.js';
 import { createDefaultByteBudget } from '../acquisition/index.js';
-import { acquireBoundedHttpBody } from '../utils/bounded-http-response.js';
+import {
+  acquireBoundedHttpBody,
+  HttpBodyTooLargeError,
+} from '../utils/bounded-http-response.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -174,6 +177,27 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
     return body.text;
   }
 
+  /**
+   * Read a non-success response body. When the body exceeds the byte budget,
+   * the HTTP status is preserved in the thrown error message.
+   */
+  private async readErrorResponseBody(
+    response: Awaited<ReturnType<typeof fetch>>,
+    signal: AbortSignal,
+    cancelRequest: () => void,
+  ): Promise<string> {
+    try {
+      return await this.readResponseBody(response, signal, cancelRequest);
+    } catch (error) {
+      if (error instanceof HttpBodyTooLargeError) {
+        throw new Error(
+          `Code search error (${response.status}): ${error.message}`,
+        );
+      }
+      throw error;
+    }
+  }
+
   async execute(
     signal: AbortSignal,
     _updateOutput?: (update: LiveOutputUpdate) => void,
@@ -214,7 +238,7 @@ class CodeSearchToolInvocation extends BaseToolInvocation<
       const cancelRequest = (): void => localController.abort();
 
       if (!response.ok) {
-        const errorText = await this.readResponseBody(
+        const errorText = await this.readErrorResponseBody(
           response,
           signal,
           cancelRequest,

--- a/packages/tools/src/tools/direct-web-fetch-real-transport.bun.test.ts
+++ b/packages/tools/src/tools/direct-web-fetch-real-transport.bun.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Real-transport behavioral tests for DirectWebFetchTool cancellation.
+ *
+ * This file is intentionally separate from direct-web-fetch.test.ts because
+ * that file mocks node-fetch globally via bun:test's vi.mock, which would
+ * contaminate this file's real node-fetch usage. Here we exercise the real
+ * DirectWebFetchTool against paced local HTTP servers and prove that
+ * non-success and oversized responses are cancelled at the transport level
+ * before delivery can complete or a retry begins.
+ */
+
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { describe, it, expect, afterEach } from 'bun:test';
+import { DirectWebFetchTool } from './direct-web-fetch.js';
+import type { IToolHost } from '../index.js';
+
+const servers: http.Server[] = [];
+const pendingWriters = new Set<Promise<void>>();
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    const server = servers.pop()!;
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  await Promise.allSettled([...pendingWriters]);
+});
+
+function trackWriter(writer: Promise<void>): Promise<void> {
+  pendingWriters.add(writer);
+  void writer.then(
+    () => pendingWriters.delete(writer),
+    () => pendingWriters.delete(writer),
+  );
+  return writer;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function startServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<http.Server> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(handler);
+    const onError = (error: Error): void => reject(error);
+    server.once('error', onError);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', onError);
+      servers.push(server);
+      resolve(server);
+    });
+  });
+}
+
+function serverUrl(server: http.Server): string {
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}/`;
+}
+
+function createToolHost(): IToolHost {
+  return {
+    getTargetDir: () => '/tmp',
+    getWorkspaceRoots: () => ['/tmp'],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths: string[]) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({}),
+    getDebugMode: () => false,
+  };
+}
+
+interface ConnectionState {
+  completed: boolean;
+  canceled: boolean;
+  writerStopped: boolean;
+}
+
+function trackConnection(
+  res: http.ServerResponse,
+  state: ConnectionState,
+): Promise<void> {
+  const socket = res.socket;
+  if (socket === null) {
+    throw new Error('Expected a response socket');
+  }
+  return new Promise((resolve) => {
+    socket.once('close', () => {
+      state.canceled = !state.completed;
+      resolve();
+    });
+  });
+}
+
+async function pacedWrite(
+  res: http.ServerResponse,
+  state: ConnectionState,
+  chunks: number,
+  chunkBytes = 256,
+): Promise<void> {
+  try {
+    for (let i = 0; i < chunks; i++) {
+      if (
+        res.writableEnded ||
+        res.destroyed ||
+        res.socket?.destroyed === true
+      ) {
+        return;
+      }
+      res.write('x'.repeat(chunkBytes));
+      await delay(10);
+    }
+    if (
+      !res.writableEnded &&
+      !res.destroyed &&
+      res.socket?.destroyed !== true
+    ) {
+      state.completed = true;
+      res.end();
+    }
+  } finally {
+    state.writerStopped = true;
+  }
+}
+
+describe('DirectWebFetchTool — real transport cancellation', () => {
+  it('cancels a terminal 4xx response instead of allowing delivery to complete', async () => {
+    const state: ConnectionState = {
+      completed: false,
+      canceled: false,
+      writerStopped: false,
+    };
+    let writerDone = Promise.resolve();
+    let connectionClosed = Promise.resolve();
+    const server = await startServer((_req, res) => {
+      connectionClosed = trackConnection(res, state);
+      res.writeHead(404, { 'content-type': 'text/plain' });
+      writerDone = trackWriter(pacedWrite(res, state, 30));
+    });
+
+    const tool = new DirectWebFetchTool(createToolHost());
+    const result = await tool
+      .build({
+        url: serverUrl(server),
+        format: 'text',
+      })
+      .execute(new AbortController().signal);
+    await Promise.all([writerDone, connectionClosed]);
+
+    expect(result.error?.message).toContain('404');
+    expect(state.completed).toBe(false);
+    expect(state.canceled).toBe(true);
+    expect(state.writerStopped).toBe(true);
+  });
+
+  it('cancels a retryable 5xx attempt before the next attempt and still reaches 2xx', async () => {
+    let requestCount = 0;
+    let secondStartedAfterCancellation = false;
+    const firstState: ConnectionState = {
+      completed: false,
+      canceled: false,
+      writerStopped: false,
+    };
+    let firstWriterDone = Promise.resolve();
+    let firstConnectionClosed = Promise.resolve();
+    const server = await startServer((_req, res) => {
+      requestCount++;
+
+      if (requestCount === 1) {
+        firstConnectionClosed = trackConnection(res, firstState);
+        res.writeHead(503, { 'content-type': 'text/plain' });
+        firstWriterDone = trackWriter(pacedWrite(res, firstState, 30));
+      } else {
+        secondStartedAfterCancellation =
+          firstState.canceled && firstState.writerStopped;
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end('OK after retry');
+      }
+    });
+
+    const tool = new DirectWebFetchTool(createToolHost());
+    const result = await tool
+      .build({
+        url: serverUrl(server),
+        format: 'text',
+      })
+      .execute(new AbortController().signal);
+    await Promise.all([firstWriterDone, firstConnectionClosed]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.llmContent).toBe('OK after retry');
+    expect(firstState.completed).toBe(false);
+    expect(firstState.canceled).toBe(true);
+    expect(firstState.writerStopped).toBe(true);
+    expect(secondStartedAfterCancellation).toBe(true);
+    expect(requestCount).toBe(2);
+  });
+
+  it('cancels an oversized 2xx response before delivery completes', async () => {
+    const state: ConnectionState = {
+      completed: false,
+      canceled: false,
+      writerStopped: false,
+    };
+    let writerDone = Promise.resolve();
+    let connectionClosed = Promise.resolve();
+    const server = await startServer((_req, res) => {
+      connectionClosed = trackConnection(res, state);
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      writerDone = trackWriter(pacedWrite(res, state, 21, 256 * 1024));
+    });
+
+    const tool = new DirectWebFetchTool(createToolHost());
+    const result = await tool
+      .build({
+        url: serverUrl(server),
+        format: 'text',
+      })
+      .execute(new AbortController().signal);
+    await Promise.all([writerDone, connectionClosed]);
+
+    expect(result.error?.message).toMatch(/exceeds/i);
+    expect(state.completed).toBe(false);
+    expect(state.canceled).toBe(true);
+    expect(state.writerStopped).toBe(true);
+  });
+});

--- a/packages/tools/src/tools/direct-web-fetch.test.ts
+++ b/packages/tools/src/tools/direct-web-fetch.test.ts
@@ -198,6 +198,7 @@ describe('DirectWebFetchTool', () => {
     };
     const invocation = tool.build(params);
 
+    const overflowBody = mockBody('x'.repeat(100));
     mockedFetch.mockResolvedValue({
       ok: true,
       headers: {
@@ -206,13 +207,14 @@ describe('DirectWebFetchTool', () => {
           return null;
         },
       },
-      body: mockBody('x'.repeat(100)),
+      body: overflowBody,
     });
 
     const result = await invocation.execute(new AbortController().signal);
 
     expect(result.error?.type).toBe(ToolErrorType.FETCH_ERROR);
     expect(result.error?.message).toMatch(/exceeds/i);
+    expect(overflowBody.destroyed).toBe(true);
     // Body overflow happens after a successful fetch — no retry is triggered.
     expect(mockedFetch).toHaveBeenCalledTimes(1);
   });

--- a/packages/tools/src/tools/direct-web-fetch.test.ts
+++ b/packages/tools/src/tools/direct-web-fetch.test.ts
@@ -5,14 +5,20 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
+import { Readable } from 'node:stream';
 import type { DirectWebFetchToolParams } from './direct-web-fetch.js';
 import { DirectWebFetchTool } from './direct-web-fetch.js';
+import { ToolErrorType } from '../types/tool-error.js';
 import type { IToolHost, ToolResult as _ToolResult } from '../index.js';
 
 const { mockedFetch } = { mockedFetch: vi.fn() };
 void vi.mock('node-fetch', () => ({
   default: mockedFetch,
 }));
+
+function mockBody(text: string): Readable {
+  return Readable.from([Buffer.from(text)]);
+}
 
 describe('DirectWebFetchTool', () => {
   let config: IToolHost;
@@ -82,7 +88,7 @@ describe('DirectWebFetchTool', () => {
           return null;
         },
       },
-      arrayBuffer: () => Promise.resolve(Buffer.from(htmlContent)),
+      body: mockBody(htmlContent),
     });
 
     const result = await invocation.execute(new AbortController().signal);
@@ -117,7 +123,7 @@ describe('DirectWebFetchTool', () => {
           return null;
         },
       },
-      arrayBuffer: () => Promise.resolve(Buffer.from(htmlContent)),
+      body: mockBody(htmlContent),
     });
 
     const result = await invocation.execute(new AbortController().signal);
@@ -182,7 +188,33 @@ describe('DirectWebFetchTool', () => {
     const result = await invocation.execute(new AbortController().signal);
 
     expect(result.error).toBeDefined();
-    expect(result.error?.message).toContain('Response too large');
+    expect(result.error?.message).toMatch(/exceeds/i);
+  });
+
+  it('returns FETCH_ERROR when the body exceeds the size limit and does not retry body acquisition', async () => {
+    const params: DirectWebFetchToolParams = {
+      url: 'https://example.com/overflow',
+      format: 'text',
+    };
+    const invocation = tool.build(params);
+
+    mockedFetch.mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (key: string) => {
+          if (key === 'content-length') return '9999999';
+          return null;
+        },
+      },
+      body: mockBody('x'.repeat(100)),
+    });
+
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error?.type).toBe(ToolErrorType.FETCH_ERROR);
+    expect(result.error?.message).toMatch(/exceeds/i);
+    // Body overflow happens after a successful fetch — no retry is triggered.
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
   });
 
   describe('retry behavior', () => {
@@ -213,7 +245,7 @@ describe('DirectWebFetchTool', () => {
               return null;
             },
           },
-          arrayBuffer: () => Promise.resolve(Buffer.from(htmlContent)),
+          body: mockBody(htmlContent),
         };
       });
 
@@ -279,7 +311,7 @@ describe('DirectWebFetchTool', () => {
               return null;
             },
           },
-          arrayBuffer: () => Promise.resolve(Buffer.from(htmlContent)),
+          body: mockBody(htmlContent),
         };
       });
 
@@ -330,7 +362,7 @@ describe('DirectWebFetchTool', () => {
               resolve({
                 ok: true,
                 headers: { get: () => null },
-                arrayBuffer: () => Promise.resolve(Buffer.from('data')),
+                body: mockBody('data'),
               });
             }, 5000);
             signal?.addEventListener('abort', () => {
@@ -348,6 +380,174 @@ describe('DirectWebFetchTool', () => {
       expect(result.error?.message).toMatch(/abort|timeout/i);
       expect(mockedFetch.mock.calls.length).toBeGreaterThan(0);
       expect(mockedFetch.mock.calls.length).toBeLessThan(10);
+    });
+  });
+
+  describe('non-success response body disposal', () => {
+    it('destroys the 4xx response body without reading it', async () => {
+      const params: DirectWebFetchToolParams = {
+        url: 'https://example.com/notfound',
+        format: 'text',
+      };
+      const invocation = tool.build(params);
+
+      const errorBody = mockBody('404 Not Found Body');
+      mockedFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: { get: () => null },
+        body: errorBody,
+      });
+
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(mockedFetch).toHaveBeenCalledTimes(1);
+      expect(result.error?.message).toContain('404');
+      expect((errorBody as unknown as { destroyed: boolean }).destroyed).toBe(
+        true,
+      );
+    });
+
+    it('destroys the 5xx retryable body on each retry attempt', async () => {
+      const params: DirectWebFetchToolParams = {
+        url: 'https://example.com/server-error',
+        format: 'text',
+      };
+      const invocation = tool.build(params);
+
+      const firstErrorBody = mockBody('503 Error Body');
+      const successBody = mockBody('<html><body>OK</body></html>');
+      let attempt = 0;
+      mockedFetch.mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) {
+          return {
+            ok: false,
+            status: 503,
+            statusText: 'Service Unavailable',
+            headers: { get: () => null },
+            body: firstErrorBody,
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          headers: {
+            get: (key: string) => (key === 'content-type' ? 'text/html' : null),
+          },
+          body: successBody,
+        };
+      });
+
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(mockedFetch).toHaveBeenCalledTimes(2);
+      expect(result.error).toBeUndefined();
+      // The 503 error body must have been destroyed without being read.
+      expect(
+        (firstErrorBody as unknown as { destroyed: boolean }).destroyed,
+      ).toBe(true);
+    });
+
+    it('destroys every 5xx body when all retries are exhausted', async () => {
+      const params: DirectWebFetchToolParams = {
+        url: 'https://example.com/always-500',
+        format: 'text',
+      };
+      const invocation = tool.build(params);
+
+      const bodies: Readable[] = [];
+      mockedFetch.mockImplementation(async () => {
+        const body = mockBody('500 Server Error');
+        bodies.push(body);
+        return {
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: { get: () => null },
+          body,
+        };
+      });
+
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(mockedFetch.mock.calls.length).toBeGreaterThan(1);
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toContain('500');
+      // Every error response body must have been destroyed.
+      for (const body of bodies) {
+        expect((body as unknown as { destroyed: boolean }).destroyed).toBe(
+          true,
+        );
+      }
+    });
+  });
+
+  describe('observed-byte boundary (no Content-Length)', () => {
+    const FETCH_BUDGET = 5 * 1024 * 1024; // 5 MiB
+
+    /**
+     * Generate a stream that emits exactly `totalBytes` of 0x78 ('x') in
+     * 64 KiB chunks without materializing the entire buffer at once.
+     */
+    function sizedStream(totalBytes: number): Readable {
+      const chunkSize = Math.min(64 * 1024, totalBytes);
+      let sent = 0;
+      return new Readable({
+        read() {
+          if (sent >= totalBytes) {
+            this.push(null);
+            return;
+          }
+          const remaining = totalBytes - sent;
+          const size = Math.min(chunkSize, remaining);
+          this.push(Buffer.alloc(size, 0x78));
+          sent += size;
+        },
+      });
+    }
+
+    it('succeeds when observed bytes exactly equal the 5 MiB budget', async () => {
+      const params: DirectWebFetchToolParams = {
+        url: 'https://example.com/exact',
+        format: 'text',
+      };
+      const invocation = tool.build(params);
+
+      mockedFetch.mockResolvedValue({
+        ok: true,
+        headers: { get: () => null },
+        body: sizedStream(FETCH_BUDGET),
+      });
+
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.error).toBeUndefined();
+      const content =
+        typeof result.llmContent === 'string' ? result.llmContent : '';
+      expect(content.length).toBe(FETCH_BUDGET);
+    });
+
+    it('fails without body-acquisition retry when observed bytes are 5 MiB + 1', async () => {
+      const params: DirectWebFetchToolParams = {
+        url: 'https://example.com/overflow',
+        format: 'text',
+      };
+      const invocation = tool.build(params);
+
+      mockedFetch.mockResolvedValue({
+        ok: true,
+        headers: { get: () => null },
+        body: sizedStream(FETCH_BUDGET + 1),
+      });
+
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.FETCH_ERROR);
+      expect(result.error?.message).toMatch(/exceeds/i);
+      // Body overflow is detected during acquisition — no retry is triggered.
+      expect(mockedFetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/tools/src/tools/direct-web-fetch.ts
+++ b/packages/tools/src/tools/direct-web-fetch.ts
@@ -26,10 +26,22 @@ import TurndownService from 'turndown';
 import * as cheerio from 'cheerio';
 import { retryWithBackoff } from '../utils/retry.js';
 import { ensureJsonSafe } from '../utils/unicodeUtils.js';
+import { createByteBudget } from '../acquisition/index.js';
+import {
+  acquireBoundedHttpBody,
+  disposeHttpResponseBody,
+} from '../utils/bounded-http-response.js';
 
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024; // 5MB
+const FETCH_BYTE_BUDGET = createByteBudget(MAX_RESPONSE_SIZE);
 const DEFAULT_TIMEOUT = 30 * 1000; // 30 seconds
 const MAX_TIMEOUT = 120 * 1000; // 2 minutes
+
+/** A fetched response paired with its per-attempt cancellation handle. */
+interface FetchedResponse {
+  readonly response: Awaited<ReturnType<typeof fetch>>;
+  readonly cancelRequest: () => void;
+}
 const ACCEPT_HEADERS: Record<DirectWebFetchToolParams['format'], string> = {
   markdown:
     'text/markdown;q=1.0, text/x-markdown;q=0.9, text/plain;q=0.8, text/html;q=0.7, */*;q=0.1',
@@ -117,12 +129,18 @@ class DirectWebFetchToolInvocation extends BaseToolInvocation<
     try {
       if (signal.aborted) return this.createAbortResult();
 
-      const response = await this.fetchResponse(controller.signal);
-      const arrayBuffer = await this.readBoundedResponse(response);
-      const content = new TextDecoder().decode(arrayBuffer);
+      const fetched = await this.fetchResponse(controller.signal);
+      const content = await this.readBoundedResponse(
+        fetched.response,
+        controller.signal,
+        fetched.cancelRequest,
+      );
       const output = this.convertContent(
         content,
-        stringOrDefault(response.headers.get('content-type') ?? undefined, ''),
+        stringOrDefault(
+          fetched.response.headers.get('content-type') ?? undefined,
+          '',
+        ),
       );
 
       return {
@@ -173,50 +191,64 @@ class DirectWebFetchToolInvocation extends BaseToolInvocation<
     };
   }
 
-  private async fetchResponse(signal: AbortSignal) {
+  private async fetchResponse(
+    overallSignal: AbortSignal,
+  ): Promise<FetchedResponse> {
     return retryWithBackoff(
       async () => {
-        const resp = await fetch(this.params.url, {
-          signal,
-          headers: {
-            'User-Agent':
-              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-            Accept: ACCEPT_HEADERS[this.params.format],
-            'Accept-Language': 'en-US,en;q=0.9',
-          },
-        } as RequestInit);
+        const attemptController = new AbortController();
+        const onOverallAbort = (): void => attemptController.abort();
+        overallSignal.addEventListener('abort', onOverallAbort, { once: true });
 
-        if (!resp.ok) {
-          const error = new Error(
-            `Request failed with status code: ${resp.status}`,
-          ) as Error & { status: number };
-          error.status = resp.status;
-          throw error;
+        try {
+          if (overallSignal.aborted) attemptController.abort();
+
+          const resp = await fetch(this.params.url, {
+            signal: attemptController.signal,
+            headers: {
+              'User-Agent':
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+              Accept: ACCEPT_HEADERS[this.params.format],
+              'Accept-Language': 'en-US,en;q=0.9',
+            },
+          } as RequestInit);
+
+          const cancelRequest = (): void => attemptController.abort();
+
+          if (!resp.ok) {
+            disposeHttpResponseBody(resp, cancelRequest);
+            const error = new Error(
+              `Request failed with status code: ${resp.status}`,
+            ) as Error & { status: number };
+            error.status = resp.status;
+            throw error;
+          }
+
+          return { response: resp, cancelRequest };
+        } finally {
+          overallSignal.removeEventListener('abort', onOverallAbort);
         }
-
-        return resp;
       },
       {
         maxAttempts: 3,
         initialDelayMs: 500,
-        signal,
+        signal: overallSignal,
       },
     );
   }
 
   private async readBoundedResponse(
     response: Awaited<ReturnType<typeof fetch>>,
-  ): Promise<ArrayBuffer> {
-    const contentLength = response.headers.get('content-length');
-    if (contentLength && parseInt(contentLength, 10) > MAX_RESPONSE_SIZE) {
-      throw new Error('Response too large (exceeds 5MB limit)');
-    }
-
-    const arrayBuffer = await response.arrayBuffer();
-    if (arrayBuffer.byteLength > MAX_RESPONSE_SIZE) {
-      throw new Error('Response too large (exceeds 5MB limit)');
-    }
-    return arrayBuffer;
+    signal: AbortSignal,
+    cancelRequest: () => void,
+  ): Promise<string> {
+    const body = await acquireBoundedHttpBody(
+      response,
+      FETCH_BYTE_BUDGET,
+      signal,
+      cancelRequest,
+    );
+    return body.text;
   }
 
   private convertContent(content: string, contentType: string): string {

--- a/packages/tools/src/tools/exa-web-search.test.ts
+++ b/packages/tools/src/tools/exa-web-search.test.ts
@@ -5,13 +5,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'bun:test';
+import { Readable } from 'node:stream';
 
 import { ExaWebSearchTool } from './exa-web-search.js';
+import { ToolErrorType } from '../types/tool-error.js';
 
 const { mockedFetch } = { mockedFetch: vi.fn() };
 void vi.mock('node-fetch', () => ({
   default: mockedFetch,
 }));
+
+function mockBody(text: string): Readable {
+  return Readable.from([Buffer.from(text)]);
+}
 
 describe('ExaWebSearchTool', () => {
   const keyStorage = { resolveKey: vi.fn() };
@@ -31,11 +37,10 @@ describe('ExaWebSearchTool', () => {
   it('returns search results for a successful query', async () => {
     mockedFetch.mockResolvedValue({
       ok: true,
-      text: vi
-        .fn()
-        .mockResolvedValue(
-          'data: {"result":{"content":[{"text":"Here are your results."}]}}\n',
-        ),
+      headers: { get: () => null },
+      body: mockBody(
+        'data: {"result":{"content":[{"text":"Here are your results."}]}}\n',
+      ),
     });
 
     const result = await tool
@@ -50,7 +55,8 @@ describe('ExaWebSearchTool', () => {
     mockedFetch.mockResolvedValue({
       ok: false,
       status: 500,
-      text: vi.fn().mockResolvedValue('API Failure'),
+      headers: { get: () => null },
+      body: mockBody('API Failure'),
     });
 
     const result = await tool
@@ -65,7 +71,8 @@ describe('ExaWebSearchTool', () => {
     keyStorage.resolveKey.mockResolvedValue('key+with/special=chars');
     mockedFetch.mockResolvedValue({
       ok: true,
-      text: vi.fn().mockResolvedValue(''),
+      headers: { get: () => null },
+      body: mockBody(''),
     });
 
     await tool
@@ -80,10 +87,13 @@ describe('ExaWebSearchTool', () => {
   });
 
   it('resolves key fresh on each invocation', async () => {
-    mockedFetch.mockResolvedValue({
-      ok: true,
-      text: vi.fn().mockResolvedValue(''),
-    });
+    mockedFetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        headers: { get: () => null },
+        body: mockBody(''),
+      }),
+    );
 
     await tool
       .build({ query: 'first query' })
@@ -97,5 +107,109 @@ describe('ExaWebSearchTool', () => {
     expect(mockedFetch.mock.calls[1][0]).toBe(
       'https://mcp.exa.ai/mcp?exaApiKey=new-key',
     );
+  });
+
+  it('skips malformed SSE lines and still parses valid ones', async () => {
+    mockedFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      body: mockBody(
+        'garbage line\n' +
+          'data: {"result":{"content":[{"text":"Valid result."}]}}\n',
+      ),
+    });
+
+    const result = await tool
+      .build({ query: 'mixed' })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toBe('Valid result.');
+  });
+
+  describe('body size limits', () => {
+    it('returns WEB_SEARCH_FAILED when the success body exceeds the budget', async () => {
+      mockedFetch.mockResolvedValue({
+        ok: true,
+        headers: {
+          get: (key: string) => (key === 'content-length' ? '9999999' : null),
+        },
+        body: mockBody('x'.repeat(100)),
+      });
+
+      const result = await tool
+        .build({ query: 'overflow' })
+        .execute(new AbortController().signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.WEB_SEARCH_FAILED);
+      expect(result.error?.message).toMatch(/exceeds/i);
+    });
+
+    it('returns WEB_SEARCH_FAILED when the error body exceeds the budget', async () => {
+      mockedFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: {
+          get: (key: string) => (key === 'content-length' ? '9999999' : null),
+        },
+        body: mockBody('x'.repeat(100)),
+      });
+
+      const result = await tool
+        .build({ query: 'overflow-error' })
+        .execute(new AbortController().signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.WEB_SEARCH_FAILED);
+      expect(result.error?.message).toMatch(/exceeds/i);
+    });
+  });
+
+  describe('observed-byte overflow (no Content-Length)', () => {
+    const BUDGET_BYTES = 4 * 1024 * 1024; // 4 MiB
+
+    function overflowStream(): Readable {
+      const chunkSize = 64 * 1024;
+      let sent = 0;
+      return new Readable({
+        read() {
+          if (sent > BUDGET_BYTES) {
+            this.push(null);
+            return;
+          }
+          this.push(Buffer.alloc(chunkSize, 0x78));
+          sent += chunkSize;
+        },
+      });
+    }
+
+    it('returns WEB_SEARCH_FAILED when a no-Content-Length success body exceeds the budget via observed bytes', async () => {
+      mockedFetch.mockResolvedValue({
+        ok: true,
+        headers: { get: () => null },
+        body: overflowStream(),
+      });
+
+      const result = await tool
+        .build({ query: 'observed-overflow-success' })
+        .execute(new AbortController().signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.WEB_SEARCH_FAILED);
+      expect(result.error?.message).toMatch(/exceeds/i);
+    });
+
+    it('returns WEB_SEARCH_FAILED when a no-Content-Length error body exceeds the budget via observed bytes', async () => {
+      mockedFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: { get: () => null },
+        body: overflowStream(),
+      });
+
+      const result = await tool
+        .build({ query: 'observed-overflow-error' })
+        .execute(new AbortController().signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.WEB_SEARCH_FAILED);
+      expect(result.error?.message).toMatch(/exceeds/i);
+    });
   });
 });

--- a/packages/tools/src/tools/exa-web-search.test.ts
+++ b/packages/tools/src/tools/exa-web-search.test.ts
@@ -19,6 +19,13 @@ function mockBody(text: string): Readable {
   return Readable.from([Buffer.from(text)]);
 }
 
+function getFetchSignal(value: unknown): AbortSignal | undefined {
+  if (typeof value !== 'object' || value === null || !('signal' in value)) {
+    return undefined;
+  }
+  return value.signal instanceof AbortSignal ? value.signal : undefined;
+}
+
 describe('ExaWebSearchTool', () => {
   const keyStorage = { resolveKey: vi.fn() };
   let tool: ExaWebSearchTool;
@@ -128,12 +135,13 @@ describe('ExaWebSearchTool', () => {
 
   describe('body size limits', () => {
     it('returns WEB_SEARCH_FAILED when the success body exceeds the budget', async () => {
+      const successBody = mockBody('x'.repeat(100));
       mockedFetch.mockResolvedValue({
         ok: true,
         headers: {
           get: (key: string) => (key === 'content-length' ? '9999999' : null),
         },
-        body: mockBody('x'.repeat(100)),
+        body: successBody,
       });
 
       const result = await tool
@@ -142,16 +150,20 @@ describe('ExaWebSearchTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.WEB_SEARCH_FAILED);
       expect(result.error?.message).toMatch(/exceeds/i);
+      const fetchSignal = getFetchSignal(mockedFetch.mock.calls[0][1]);
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(successBody.destroyed).toBe(true);
     });
 
     it('returns WEB_SEARCH_FAILED when the error body exceeds the budget', async () => {
+      const errorBodyStream = mockBody('x'.repeat(100));
       mockedFetch.mockResolvedValue({
         ok: false,
         status: 500,
         headers: {
           get: (key: string) => (key === 'content-length' ? '9999999' : null),
         },
-        body: mockBody('x'.repeat(100)),
+        body: errorBodyStream,
       });
 
       const result = await tool
@@ -160,6 +172,10 @@ describe('ExaWebSearchTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.WEB_SEARCH_FAILED);
       expect(result.error?.message).toMatch(/exceeds/i);
+      expect(result.error?.message).toContain('500');
+      const fetchSignal = getFetchSignal(mockedFetch.mock.calls[0][1]);
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(errorBodyStream.destroyed).toBe(true);
     });
   });
 
@@ -182,10 +198,11 @@ describe('ExaWebSearchTool', () => {
     }
 
     it('returns WEB_SEARCH_FAILED when a no-Content-Length success body exceeds the budget via observed bytes', async () => {
+      const successBody = overflowStream();
       mockedFetch.mockResolvedValue({
         ok: true,
         headers: { get: () => null },
-        body: overflowStream(),
+        body: successBody,
       });
 
       const result = await tool
@@ -194,14 +211,18 @@ describe('ExaWebSearchTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.WEB_SEARCH_FAILED);
       expect(result.error?.message).toMatch(/exceeds/i);
+      const fetchSignal = getFetchSignal(mockedFetch.mock.calls[0][1]);
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(successBody.destroyed).toBe(true);
     });
 
     it('returns WEB_SEARCH_FAILED when a no-Content-Length error body exceeds the budget via observed bytes', async () => {
+      const errorBodyStream = overflowStream();
       mockedFetch.mockResolvedValue({
         ok: false,
         status: 500,
         headers: { get: () => null },
-        body: overflowStream(),
+        body: errorBodyStream,
       });
 
       const result = await tool
@@ -210,6 +231,10 @@ describe('ExaWebSearchTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.WEB_SEARCH_FAILED);
       expect(result.error?.message).toMatch(/exceeds/i);
+      expect(result.error?.message).toContain('500');
+      const fetchSignal = getFetchSignal(mockedFetch.mock.calls[0][1]);
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(errorBodyStream.destroyed).toBe(true);
     });
   });
 });

--- a/packages/tools/src/tools/exa-web-search.ts
+++ b/packages/tools/src/tools/exa-web-search.ts
@@ -14,7 +14,10 @@ import type { IToolKeyStorage, IToolMessageBus } from '../interfaces/index.js';
 import { ToolErrorType } from '../types/tool-error.js';
 import { ensureJsonSafe } from '../utils/unicodeUtils.js';
 import { createDefaultByteBudget } from '../acquisition/index.js';
-import { acquireBoundedHttpBody } from '../utils/bounded-http-response.js';
+import {
+  acquireBoundedHttpBody,
+  HttpBodyTooLargeError,
+} from '../utils/bounded-http-response.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -157,6 +160,32 @@ class ExaWebSearchToolInvocation extends BaseToolInvocation<
     return baseUrl;
   }
 
+  /**
+   * Read a non-success response body. When the body exceeds the byte budget,
+   * the HTTP status is preserved in the thrown error message.
+   */
+  private async readErrorResponseBody(
+    response: Awaited<ReturnType<typeof fetch>>,
+    signal: AbortSignal,
+    cancelRequest: () => void,
+  ): Promise<string> {
+    try {
+      return (
+        await acquireBoundedHttpBody(
+          response,
+          SEARCH_BYTE_BUDGET,
+          signal,
+          cancelRequest,
+        )
+      ).text;
+    } catch (error) {
+      if (error instanceof HttpBodyTooLargeError) {
+        throw new Error(`Search error (${response.status}): ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
   async execute(
     signal: AbortSignal,
     _updateOutput?: (update: LiveOutputUpdate) => void,
@@ -205,13 +234,12 @@ class ExaWebSearchToolInvocation extends BaseToolInvocation<
       const cancelRequest = (): void => localController.abort();
 
       if (!response.ok) {
-        const errorBody = await acquireBoundedHttpBody(
+        const errorText = await this.readErrorResponseBody(
           response,
-          SEARCH_BYTE_BUDGET,
           signal,
           cancelRequest,
         );
-        throw new Error(`Search error (${response.status}): ${errorBody.text}`);
+        throw new Error(`Search error (${response.status}): ${errorText}`);
       }
 
       const responseBody = await acquireBoundedHttpBody(

--- a/packages/tools/src/tools/exa-web-search.ts
+++ b/packages/tools/src/tools/exa-web-search.ts
@@ -13,6 +13,8 @@ import fetch from 'node-fetch';
 import type { IToolKeyStorage, IToolMessageBus } from '../interfaces/index.js';
 import { ToolErrorType } from '../types/tool-error.js';
 import { ensureJsonSafe } from '../utils/unicodeUtils.js';
+import { createDefaultByteBudget } from '../acquisition/index.js';
+import { acquireBoundedHttpBody } from '../utils/bounded-http-response.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -29,6 +31,8 @@ const API_CONFIG = {
   },
   DEFAULT_NUM_RESULTS: 8,
 } as const;
+
+const SEARCH_BYTE_BUDGET = createDefaultByteBudget();
 
 interface McpSearchRequest {
   jsonrpc: string;
@@ -178,7 +182,13 @@ class ExaWebSearchToolInvocation extends BaseToolInvocation<
       },
     };
 
+    const localController = new AbortController();
+    const onSignalAbort = (): void => localController.abort();
+    signal.addEventListener('abort', onSignalAbort, { once: true });
+
     try {
+      if (signal.aborted) localController.abort();
+
       const headers: Record<string, string> = {
         accept: 'application/json, text/event-stream',
         'content-type': 'application/json',
@@ -189,27 +199,28 @@ class ExaWebSearchToolInvocation extends BaseToolInvocation<
         method: 'POST',
         headers,
         body: JSON.stringify(searchRequest),
-        signal,
+        signal: localController.signal,
       });
 
+      const cancelRequest = (): void => localController.abort();
+
       if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Search error (${response.status}): ${errorText}`);
+        const errorBody = await acquireBoundedHttpBody(
+          response,
+          SEARCH_BYTE_BUDGET,
+          signal,
+          cancelRequest,
+        );
+        throw new Error(`Search error (${response.status}): ${errorBody.text}`);
       }
 
-      const responseText = await response.text();
-      const lines = responseText.split('\n');
-      for (const line of lines) {
-        const parsed = this.parseSearchResponseLine(line);
-        if (parsed !== undefined) {
-          return parsed;
-        }
-      }
-
-      return {
-        llmContent: 'No search results found. Please try a different query.',
-        returnDisplay: 'No results found.',
-      };
+      const responseBody = await acquireBoundedHttpBody(
+        response,
+        SEARCH_BYTE_BUDGET,
+        signal,
+        cancelRequest,
+      );
+      return this.parseSearchResult(responseBody.text);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -221,7 +232,23 @@ class ExaWebSearchToolInvocation extends BaseToolInvocation<
           type: ToolErrorType.WEB_SEARCH_FAILED,
         },
       };
+    } finally {
+      signal.removeEventListener('abort', onSignalAbort);
     }
+  }
+
+  private parseSearchResult(text: string): ToolResult {
+    const lines = text.split('\n');
+    for (const line of lines) {
+      const parsed = this.parseSearchResponseLine(line);
+      if (parsed !== undefined) {
+        return parsed;
+      }
+    }
+    return {
+      llmContent: 'No search results found. Please try a different query.',
+      returnDisplay: 'No results found.',
+    };
   }
 
   private parseSearchResponseLine(

--- a/packages/tools/src/utils/bounded-http-response.test.ts
+++ b/packages/tools/src/utils/bounded-http-response.test.ts
@@ -404,10 +404,12 @@ describe('acquireBoundedHttpBody — real server-side cancellation', () => {
     server: http.Server;
     getState: () => { completed: boolean; canceled: boolean };
     getWriterDone: () => Promise<void>;
+    getSocketClosed: () => Promise<void>;
   }> {
     let completed = false;
     let canceled = false;
     let writerDone: Promise<void> | undefined;
+    let socketClosed: Promise<void> | undefined;
     const serverPromise = startServer((_req, res) => {
       const headers: Record<string, string> = {
         'content-type': 'text/plain',
@@ -416,8 +418,16 @@ describe('acquireBoundedHttpBody — real server-side cancellation', () => {
         headers['content-length'] = String(options.contentLength);
       }
       res.writeHead(200, headers);
-      res.socket?.on('close', () => {
-        canceled = !completed;
+
+      const socket = res.socket;
+      if (socket === null) {
+        throw new Error('Paced server response has no socket');
+      }
+      socketClosed = new Promise<void>((resolve) => {
+        socket.on('close', () => {
+          canceled = !completed;
+          resolve();
+        });
       });
 
       writerDone = trackWriter(
@@ -453,11 +463,18 @@ describe('acquireBoundedHttpBody — real server-side cancellation', () => {
         }
         return writerDone;
       },
+      getSocketClosed: () => {
+        if (socketClosed === undefined) {
+          throw new Error('Paced response socket did not start');
+        }
+        return socketClosed;
+      },
     }));
   }
 
   it('cancels the fetch request on observed overflow (no Content-Length)', async () => {
-    const { server, getState, getWriterDone } = await startPacedServer();
+    const { server, getState, getWriterDone, getSocketClosed } =
+      await startPacedServer();
 
     const controller = new AbortController();
     const response = await fetch(serverUrl(server), {
@@ -472,7 +489,7 @@ describe('acquireBoundedHttpBody — real server-side cancellation', () => {
         () => controller.abort(),
       ),
     ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
-    await getWriterDone();
+    await Promise.all([getWriterDone(), getSocketClosed()]);
 
     const state = getState();
     expect(state.canceled).toBe(true);
@@ -480,9 +497,10 @@ describe('acquireBoundedHttpBody — real server-side cancellation', () => {
   });
 
   it('cancels the fetch request on valid over-limit Content-Length early rejection', async () => {
-    const { server, getState, getWriterDone } = await startPacedServer({
-      contentLength: 999999,
-    });
+    const { server, getState, getWriterDone, getSocketClosed } =
+      await startPacedServer({
+        contentLength: 999999,
+      });
 
     const controller = new AbortController();
     const response = await fetch(serverUrl(server), {
@@ -497,7 +515,7 @@ describe('acquireBoundedHttpBody — real server-side cancellation', () => {
         () => controller.abort(),
       ),
     ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
-    await getWriterDone();
+    await Promise.all([getWriterDone(), getSocketClosed()]);
 
     const state = getState();
     expect(state.canceled).toBe(true);
@@ -505,7 +523,8 @@ describe('acquireBoundedHttpBody — real server-side cancellation', () => {
   });
 
   it('cancels the fetch request on mid-read external abort through node-fetch', async () => {
-    const { server, getState, getWriterDone } = await startPacedServer();
+    const { server, getState, getWriterDone, getSocketClosed } =
+      await startPacedServer();
 
     const controller = new AbortController();
     const response = await fetch(serverUrl(server), {
@@ -522,7 +541,7 @@ describe('acquireBoundedHttpBody — real server-side cancellation', () => {
     controller.abort();
 
     await expect(promise).rejects.toThrow(/abort/i);
-    await getWriterDone();
+    await Promise.all([getWriterDone(), getSocketClosed()]);
 
     const state = getState();
     expect(state.canceled).toBe(true);

--- a/packages/tools/src/utils/bounded-http-response.test.ts
+++ b/packages/tools/src/utils/bounded-http-response.test.ts
@@ -1,0 +1,860 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Readable } from 'node:stream';
+import { describe, it, expect, afterEach } from 'bun:test';
+import fetch from 'node-fetch';
+import { createByteBudget } from '../acquisition/index.js';
+import {
+  acquireBoundedHttpBody,
+  disposeHttpResponseBody,
+  HttpBodyTooLargeError,
+  type BoundedFetchResponse,
+} from './bounded-http-response.js';
+
+const servers: http.Server[] = [];
+const pendingWriters = new Set<Promise<void>>();
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    const server = servers.pop()!;
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  await Promise.allSettled([...pendingWriters]);
+});
+
+function trackWriter(writer: Promise<void>): Promise<void> {
+  pendingWriters.add(writer);
+  void writer.then(
+    () => pendingWriters.delete(writer),
+    () => pendingWriters.delete(writer),
+  );
+  return writer;
+}
+
+function startServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<http.Server> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      servers.push(server);
+      resolve(server);
+    });
+  });
+}
+
+function serverUrl(server: http.Server): string {
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}/`;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fragmentPayload(payload: string, fragmentSize: number): Buffer[] {
+  const buf = Buffer.from(payload);
+  const fragments: Buffer[] = [];
+  for (let i = 0; i < buf.length; i += fragmentSize) {
+    fragments.push(buf.subarray(i, i + fragmentSize));
+  }
+  return fragments;
+}
+
+/** No-op cancel for tests that do not exercise cancellation behavior. */
+const noopCancel = (): void => {};
+
+/**
+ * Creates a cancel callback that records whether it was invoked.
+ */
+function createTrackingCancel(): { cancel: () => void; called: boolean } {
+  let called = false;
+  return {
+    cancel: () => {
+      called = true;
+    },
+    get called() {
+      return called;
+    },
+  };
+}
+
+/**
+ * Count listener names attached to a readable stream so we can prove
+ * cleanup in behavioral tests without asserting on mock call counts.
+ */
+function attachedListenerCount(
+  stream: NodeJS.ReadableStream | null,
+  ...events: string[]
+): number {
+  if (stream === null) return 0;
+  let total = 0;
+  for (const evt of events) {
+    total += (stream as EventEmitterLike).listenerCount(evt);
+  }
+  return total;
+}
+
+interface EventEmitterLike {
+  listenerCount(event: string): number;
+}
+
+describe('acquireBoundedHttpBody — under-budget streaming', () => {
+  it('reads a real local chunked response under budget', async () => {
+    const payload = 'x'.repeat(512);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(payload);
+    });
+
+    const response = await fetch(serverUrl(server));
+    const body = await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(512);
+    expect(body.metadata.truncated).toBe(false);
+  });
+
+  it('succeeds when fragmented chunks exactly equal the budget', async () => {
+    const payload = 'x'.repeat(1024);
+    const fragments = fragmentPayload(payload, 7);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      for (const frag of fragments) {
+        res.write(frag);
+      }
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+    const body = await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(1024);
+    expect(body.metadata.truncated).toBe(false);
+  });
+});
+
+describe('acquireBoundedHttpBody — overflow detection', () => {
+  it('fails when a missing-Content-Length response exceeds the budget and closes the body', async () => {
+    const payload = 'x'.repeat(2048);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.write(payload);
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+    const budget = createByteBudget(1024);
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        budget,
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+
+    expect(
+      (response.body as unknown as { destroyed: boolean } | null)?.destroyed,
+    ).toBe(true);
+  });
+
+  it('fails atomically when fragmented chunks are one byte over the budget and closes the body', async () => {
+    const payload = 'x'.repeat(1025);
+    const fragments = fragmentPayload(payload, 3);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      for (const frag of fragments) {
+        res.write(frag);
+      }
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+
+    expect(
+      (response.body as unknown as { destroyed: boolean } | null)?.destroyed,
+    ).toBe(true);
+  });
+
+  it('fails on observed bytes when Content-Length advertises less than the stream sends', async () => {
+    const fakeResponse: BoundedFetchResponse = {
+      body: Readable.from([Buffer.from('x'.repeat(2048))]),
+      headers: {
+        get: (name: string) => (name === 'content-length' ? '512' : null),
+      },
+    };
+
+    await expect(
+      acquireBoundedHttpBody(
+        fakeResponse,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+  });
+
+  it('rejects an over-limit Content-Length before iteration and closes the body', async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, {
+        'content-type': 'text/plain',
+        'content-length': '999999',
+      });
+      res.end('x'.repeat(999999));
+    });
+
+    const response = await fetch(serverUrl(server));
+    const budget = createByteBudget(1024);
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        budget,
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+
+    expect(
+      (response.body as unknown as { destroyed: boolean } | null)?.destroyed,
+    ).toBe(true);
+  });
+});
+
+describe('acquireBoundedHttpBody — strict Content-Length parsing', () => {
+  it('treats a malformed over-limit-looking Content-Length as absent and succeeds with a bounded body', async () => {
+    const payload = 'x'.repeat(512);
+    const fakeResponse: BoundedFetchResponse = {
+      body: Readable.from([Buffer.from(payload)]),
+      headers: {
+        get: (name: string) =>
+          name === 'content-length' ? '9999999999;foo' : null,
+      },
+    };
+
+    const body = await acquireBoundedHttpBody(
+      fakeResponse,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(512);
+  });
+
+  it('treats a malformed understated-looking Content-Length as absent but fails when observed bytes exceed budget', async () => {
+    const payload = 'x'.repeat(2048);
+    const fakeResponse: BoundedFetchResponse = {
+      body: Readable.from([Buffer.from(payload)]),
+      headers: {
+        get: (name: string) => (name === 'content-length' ? 'abc' : null),
+      },
+    };
+
+    await expect(
+      acquireBoundedHttpBody(
+        fakeResponse,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+  });
+
+  it('rejects an unsafe (non-safe-integer) Content-Length as absent and streams observed bytes', async () => {
+    const payload = 'x'.repeat(256);
+    const fakeResponse: BoundedFetchResponse = {
+      body: Readable.from([Buffer.from(payload)]),
+      headers: {
+        get: (name: string) =>
+          name === 'content-length' ? '99999999999999999999999' : null,
+      },
+    };
+
+    const body = await acquireBoundedHttpBody(
+      fakeResponse,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(256);
+  });
+});
+
+describe('acquireBoundedHttpBody — exact byte boundary', () => {
+  it('succeeds when body bytes exactly equal the budget', async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('x'.repeat(1024));
+    });
+
+    const response = await fetch(serverUrl(server));
+    const body = await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.metadata.observedBytes).toBe(1024);
+    expect(body.text).toBe('x'.repeat(1024));
+  });
+
+  it('fails when body is one byte over the budget', async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.write('x'.repeat(1025));
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+  });
+
+  it('counts UTF-8 bytes, not JavaScript characters, for the boundary', async () => {
+    // "é" is 1 character but 2 UTF-8 bytes. 512 × "é" = 1024 bytes = budget.
+    const payload = 'é'.repeat(512);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+      res.write(payload);
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+    const body = await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(1024);
+  });
+
+  it('fails when a multibyte UTF-8 body is one byte over budget', async () => {
+    // 512 × "é" = 1024 bytes. Adding one ASCII byte → 1025 > 1024.
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+      res.write('é'.repeat(512) + 'x');
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+  });
+});
+
+/**
+ * Real-transport cancellation proof: a paced server writes chunks slowly so
+ * the client has time to observe overflow mid-stream. The test uses installed
+ * node-fetch with a per-request AbortController and proves the server sees
+ * cancellation (connection close) before it can complete delivery.
+ */
+describe('acquireBoundedHttpBody — real server-side cancellation', () => {
+  function startPacedServer(options?: { contentLength?: number }): Promise<{
+    server: http.Server;
+    getState: () => { completed: boolean; canceled: boolean };
+    getWriterDone: () => Promise<void>;
+  }> {
+    let completed = false;
+    let canceled = false;
+    let writerDone: Promise<void> | undefined;
+    const serverPromise = startServer((_req, res) => {
+      const headers: Record<string, string> = {
+        'content-type': 'text/plain',
+      };
+      if (options?.contentLength !== undefined) {
+        headers['content-length'] = String(options.contentLength);
+      }
+      res.writeHead(200, headers);
+      res.socket?.on('close', () => {
+        canceled = !completed;
+      });
+
+      writerDone = trackWriter(
+        (async () => {
+          for (let i = 0; i < 100; i++) {
+            if (
+              res.writableEnded ||
+              res.destroyed ||
+              res.socket?.destroyed === true
+            ) {
+              return;
+            }
+            res.write('x'.repeat(128));
+            await delay(10);
+          }
+          if (
+            !res.writableEnded &&
+            !res.destroyed &&
+            res.socket?.destroyed !== true
+          ) {
+            completed = true;
+            res.end();
+          }
+        })(),
+      );
+    });
+    return serverPromise.then((server) => ({
+      server,
+      getState: () => ({ completed, canceled }),
+      getWriterDone: () => {
+        if (writerDone === undefined) {
+          throw new Error('Paced response writer did not start');
+        }
+        return writerDone;
+      },
+    }));
+  }
+
+  it('cancels the fetch request on observed overflow (no Content-Length)', async () => {
+    const { server, getState, getWriterDone } = await startPacedServer();
+
+    const controller = new AbortController();
+    const response = await fetch(serverUrl(server), {
+      signal: controller.signal,
+    });
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        new AbortController().signal,
+        () => controller.abort(),
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+    await getWriterDone();
+
+    const state = getState();
+    expect(state.canceled).toBe(true);
+    expect(state.completed).toBe(false);
+  });
+
+  it('cancels the fetch request on valid over-limit Content-Length early rejection', async () => {
+    const { server, getState, getWriterDone } = await startPacedServer({
+      contentLength: 999999,
+    });
+
+    const controller = new AbortController();
+    const response = await fetch(serverUrl(server), {
+      signal: controller.signal,
+    });
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        new AbortController().signal,
+        () => controller.abort(),
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+    await getWriterDone();
+
+    const state = getState();
+    expect(state.canceled).toBe(true);
+    expect(state.completed).toBe(false);
+  });
+
+  it('cancels the fetch request on mid-read external abort through node-fetch', async () => {
+    const { server, getState, getWriterDone } = await startPacedServer();
+
+    const controller = new AbortController();
+    const response = await fetch(serverUrl(server), {
+      signal: controller.signal,
+    });
+
+    const promise = acquireBoundedHttpBody(
+      response,
+      createByteBudget(10 * 1024 * 1024),
+      controller.signal,
+      () => controller.abort(),
+    );
+
+    controller.abort();
+
+    await expect(promise).rejects.toThrow(/abort/i);
+    await getWriterDone();
+
+    const state = getState();
+    expect(state.canceled).toBe(true);
+    expect(state.completed).toBe(false);
+  });
+});
+
+describe('acquireBoundedHttpBody — cancel callback invocation', () => {
+  it('invokes cancelRequest and releases listeners on observed overflow', async () => {
+    const payload = 'x'.repeat(2048);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(payload);
+    });
+
+    const response = await fetch(serverUrl(server));
+    const tracker = createTrackingCancel();
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        new AbortController().signal,
+        tracker.cancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+
+    expect(tracker.called).toBe(true);
+  });
+
+  it('invokes cancelRequest and releases listeners on over-limit Content-Length early reject', async () => {
+    const fakeResponse: BoundedFetchResponse = {
+      body: Readable.from([Buffer.from('x'.repeat(100))]),
+      headers: {
+        get: (name: string) => (name === 'content-length' ? '999999' : null),
+      },
+    };
+    const tracker = createTrackingCancel();
+
+    await expect(
+      acquireBoundedHttpBody(
+        fakeResponse,
+        createByteBudget(1024),
+        new AbortController().signal,
+        tracker.cancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+
+    expect(tracker.called).toBe(true);
+  });
+
+  it('invokes cancelRequest and releases listeners on stream read error', async () => {
+    const errorStream = new Readable({
+      read() {
+        this.destroy(new Error('stream read failure'));
+      },
+    });
+    const fakeResponse: BoundedFetchResponse = {
+      body: errorStream,
+      headers: { get: () => null },
+    };
+    const tracker = createTrackingCancel();
+
+    await expect(
+      acquireBoundedHttpBody(
+        fakeResponse,
+        createByteBudget(1024),
+        new AbortController().signal,
+        tracker.cancel,
+      ),
+    ).rejects.toThrow('stream read failure');
+
+    expect(tracker.called).toBe(true);
+    expect(
+      attachedListenerCount(
+        errorStream as NodeJS.ReadableStream,
+        'data',
+        'end',
+        'error',
+      ),
+    ).toBe(0);
+  });
+
+  it('does NOT invoke cancelRequest on normal successful completion', async () => {
+    const payload = 'x'.repeat(256);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(payload);
+    });
+
+    const response = await fetch(serverUrl(server));
+    const tracker = createTrackingCancel();
+
+    const body = await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      new AbortController().signal,
+      tracker.cancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(tracker.called).toBe(false);
+  });
+});
+
+/**
+ * Wrap a real AbortController so tests can observe abort-listener
+ * add/remove without mock call counting. The underlying signal is genuine.
+ */
+function createTrackingController(): {
+  signal: AbortSignal;
+  abortListenerCount: number;
+  abort(): void;
+} {
+  const controller = new AbortController();
+  let count = 0;
+  const origAdd = controller.signal.addEventListener.bind(controller.signal);
+  const origRemove = controller.signal.removeEventListener.bind(
+    controller.signal,
+  );
+  const trackingSignal = new Proxy(controller.signal, {
+    get(target, prop) {
+      if (prop === 'addEventListener') {
+        return (
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+          options?: boolean | AddEventListenerOptions,
+        ): void => {
+          if (type === 'abort') count++;
+          origAdd(type, listener, options);
+        };
+      }
+      if (prop === 'removeEventListener') {
+        return (
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+          options?: boolean | EventListenerOptions,
+        ): void => {
+          if (type === 'abort') count = Math.max(0, count - 1);
+          origRemove(type, listener, options);
+        };
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  return {
+    signal: trackingSignal,
+    get abortListenerCount() {
+      return count;
+    },
+    abort: () => controller.abort(),
+  };
+}
+
+describe('acquireBoundedHttpBody — listener lifecycle', () => {
+  it('removes all adapter-owned listeners and the abort listener after normal success', async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('x'.repeat(256));
+    });
+
+    const response = await fetch(serverUrl(server));
+    const tracker = createTrackingController();
+    const body = response.body;
+
+    await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      tracker.signal,
+      noopCancel,
+    );
+
+    expect(attachedListenerCount(body, 'data', 'end', 'error')).toBe(0);
+    expect(tracker.abortListenerCount).toBe(0);
+  });
+
+  it('removes all adapter-owned listeners and the abort listener after overflow', async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('x'.repeat(2048));
+    });
+
+    const response = await fetch(serverUrl(server));
+    const tracker = createTrackingController();
+    const body = response.body;
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        tracker.signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+
+    expect(attachedListenerCount(body, 'data', 'end', 'error')).toBe(0);
+    expect(tracker.abortListenerCount).toBe(0);
+  });
+
+  it('removes all adapter-owned listeners and the abort listener after abort', async () => {
+    let writerDone = Promise.resolve();
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      writerDone = trackWriter(
+        (async () => {
+          for (let i = 0; i < 20; i++) {
+            if (res.destroyed || res.writableEnded) return;
+            res.write('x'.repeat(128));
+            await delay(20);
+          }
+          if (!res.destroyed && !res.writableEnded) res.end();
+        })(),
+      );
+    });
+
+    const requestController = new AbortController();
+    const response = await fetch(serverUrl(server), {
+      signal: requestController.signal,
+    });
+    const tracker = createTrackingController();
+    const body = response.body;
+
+    const promise = acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      tracker.signal,
+      () => requestController.abort(),
+    );
+    tracker.abort();
+    await expect(promise).rejects.toThrow(/abort/i);
+    await writerDone;
+
+    expect(attachedListenerCount(body, 'data', 'end', 'error')).toBe(0);
+    expect(tracker.abortListenerCount).toBe(0);
+  });
+
+  it('removes all adapter-owned listeners and the abort listener after a stream error', async () => {
+    const errorStream = new Readable({
+      read() {
+        this.destroy(new Error('stream read failure'));
+      },
+    });
+    const fakeResponse: BoundedFetchResponse = {
+      body: errorStream,
+      headers: { get: () => null },
+    };
+    const tracker = createTrackingController();
+
+    await expect(
+      acquireBoundedHttpBody(
+        fakeResponse,
+        createByteBudget(1024),
+        tracker.signal,
+        noopCancel,
+      ),
+    ).rejects.toThrow('stream read failure');
+
+    expect(
+      attachedListenerCount(
+        errorStream as NodeJS.ReadableStream,
+        'data',
+        'end',
+        'error',
+      ),
+    ).toBe(0);
+    expect(tracker.abortListenerCount).toBe(0);
+  });
+});
+
+describe('acquireBoundedHttpBody — abort registration edge', () => {
+  it('rejects immediately with AbortError when signal is already aborted before acquisition starts', async () => {
+    // A live stream with real data — the adapter must still reject for abort
+    // because the signal was already aborted when listeners were registered.
+    const stream = Readable.from([Buffer.from('x'.repeat(10))]);
+    const fakeResponse: BoundedFetchResponse = {
+      body: stream,
+      headers: { get: () => null },
+    };
+    const tracker = createTrackingCancel();
+    const abortTracker = createTrackingController();
+    abortTracker.abort();
+    const promise = acquireBoundedHttpBody(
+      fakeResponse,
+      createByteBudget(1024),
+      abortTracker.signal,
+      tracker.cancel,
+    );
+
+    await expect(promise).rejects.toThrow(/abort/i);
+
+    // The post-registration check must fire onAbort which calls cancelRequest
+    // and destroys the body.
+    expect(tracker.called).toBe(true);
+    expect((stream as unknown as { destroyed: boolean }).destroyed).toBe(true);
+    // No adapter-owned listeners remain on the body.
+    expect(
+      attachedListenerCount(
+        stream as NodeJS.ReadableStream,
+        'data',
+        'end',
+        'error',
+      ),
+    ).toBe(0);
+    expect(abortTracker.abortListenerCount).toBe(0);
+  });
+});
+
+describe('disposeHttpResponseBody', () => {
+  it('cancels the request and destroys the response body without reading it', () => {
+    const stream = Readable.from([Buffer.from('error body')]);
+    const fakeResponse: BoundedFetchResponse = {
+      body: stream,
+      headers: { get: () => null },
+    };
+    const tracker = createTrackingCancel();
+
+    disposeHttpResponseBody(fakeResponse, tracker.cancel);
+
+    expect((stream as unknown as { destroyed: boolean }).destroyed).toBe(true);
+    expect(tracker.called).toBe(true);
+  });
+
+  it('is a no-op on body when body is null but still invokes cancelRequest', () => {
+    const fakeResponse: BoundedFetchResponse = {
+      body: null,
+      headers: { get: () => null },
+    };
+    const tracker = createTrackingCancel();
+    expect(() =>
+      disposeHttpResponseBody(fakeResponse, tracker.cancel),
+    ).not.toThrow();
+    expect(tracker.called).toBe(true);
+  });
+});

--- a/packages/tools/src/utils/bounded-http-response.ts
+++ b/packages/tools/src/utils/bounded-http-response.ts
@@ -1,0 +1,218 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ByteBudget, TruncationMetadata } from '../acquisition/index.js';
+import { BoundedStreamCollector } from '../acquisition/index.js';
+
+/** Minimal structural interface satisfied by a node-fetch Response. */
+export interface BoundedFetchResponse {
+  readonly body: NodeJS.ReadableStream | null;
+  readonly headers: { get(name: string): string | null };
+}
+
+/** Thrown when an HTTP response body exceeds the configured byte budget. */
+export class HttpBodyTooLargeError extends Error {
+  readonly observedBytes: number;
+  readonly budgetBytes: number;
+
+  constructor(observedBytes: number, budgetBytes: number) {
+    super(
+      `Response body size (${observedBytes.toLocaleString('en-US')} bytes) exceeds the configured maximum (${budgetBytes.toLocaleString('en-US')} bytes)`,
+    );
+    this.name = 'HttpBodyTooLargeError';
+    this.observedBytes = observedBytes;
+    this.budgetBytes = budgetBytes;
+  }
+}
+
+/** Result of bounded HTTP body acquisition. */
+export interface BoundedHttpBody {
+  readonly text: string;
+  readonly metadata: TruncationMetadata;
+}
+
+type ManagedStream = NodeJS.ReadableStream & {
+  destroyed?: boolean;
+  destroy?(error?: Error): unknown;
+};
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function destroyStream(stream: ManagedStream | null | undefined): void {
+  if (stream === null || stream === undefined) return;
+  if (stream.destroyed === true) return;
+  stream.destroy?.();
+}
+
+/**
+ * Parse a Content-Length header strictly. Only when the entire trimmed value
+ * consists solely of decimal digits and is safely representable as a
+ * nonnegative integer is it accepted. Malformed or unsafe values are treated
+ * as absent, forcing observed-byte streaming enforcement.
+ */
+function parseContentLength(header: string | null): number | undefined {
+  if (header === null) return undefined;
+  const trimmed = header.trim();
+  if (trimmed.length === 0 || !/^\d+$/.test(trimmed)) return undefined;
+  const value = Number(trimmed);
+  if (!Number.isSafeInteger(value) || value < 0) return undefined;
+  return value;
+}
+
+function toBuffer(chunk: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) return chunk;
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk);
+  // Node.js streams may emit strings; encode via UTF-8.
+  return Buffer.from(String(chunk));
+}
+
+/**
+ * Close/destroy a response body without reading it. Used by callers that
+ * reject a response before body acquisition (e.g. non-2xx status).
+ *
+ * Both cancels the concrete HTTP request (via the caller-owned callback) and
+ * destroys the response body wrapper so the underlying socket is released.
+ */
+export function disposeHttpResponseBody(
+  response: BoundedFetchResponse,
+  cancelRequest: () => void,
+): void {
+  cancelRequest();
+  destroyStream(response.body as ManagedStream | null | undefined);
+}
+
+/**
+ * Read a managed stream through a {@link BoundedStreamCollector} configured to
+ * retain the complete bounded response.
+ *
+ * On overflow, abort, or read error the caller-owned {@link cancelRequest}
+ * callback is invoked (cancelling the concrete HTTP request), the stream
+ * wrapper is destroyed, and all listeners are removed. Normal completion does
+ * not cancel the request.
+ */
+function streamBoundedBody(
+  body: ManagedStream,
+  budget: ByteBudget,
+  signal: AbortSignal,
+  cancelRequest: () => void,
+): Promise<BoundedHttpBody> {
+  return new Promise<BoundedHttpBody>((resolve, reject) => {
+    const collector = new BoundedStreamCollector({ budget, headFraction: 1 });
+    let settled = false;
+
+    const cleanup = (): void => {
+      body.removeListener('data', onData);
+      body.removeListener('end', onEnd);
+      body.removeListener('error', onError);
+      signal.removeEventListener('abort', onAbort);
+    };
+
+    const settle = (action: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      action();
+    };
+
+    const onData = (chunk: unknown): void => {
+      collector.append(toBuffer(chunk));
+      if (collector.observedByteCount > budget.bytes) {
+        const overflowBytes = collector.observedByteCount;
+        settle(() => {
+          cancelRequest();
+          destroyStream(body);
+          reject(new HttpBodyTooLargeError(overflowBytes, budget.bytes));
+        });
+      }
+    };
+
+    const onEnd = (): void => {
+      settle(() => {
+        const result = collector.getResult();
+        resolve({ text: result.text, metadata: result.metadata });
+      });
+    };
+
+    const onError = (err: Error): void => {
+      settle(() => {
+        cancelRequest();
+        destroyStream(body);
+        reject(err);
+      });
+    };
+
+    const onAbort = (): void => {
+      settle(() => {
+        cancelRequest();
+        destroyStream(body);
+        reject(createAbortError());
+      });
+    };
+
+    body.on('error', onError);
+    body.on('end', onEnd);
+    body.on('data', onData);
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    // Check for abort after listener registration to avoid the race where
+    // the signal fires between a pre-registration check and addEventListener.
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
+}
+
+/**
+ * Stream an HTTP response body through a bounded byte budget.
+ *
+ * The body is consumed chunk-by-chunk via stream events and retained by a
+ * {@link BoundedStreamCollector} configured to retain the complete bounded
+ * response (headFraction 1). Content-Length is used only as an early-reject
+ * optimization — the actual streamed bytes are authoritative.
+ *
+ * On overflow, abort, or read error the caller-owned {@link cancelRequest}
+ * callback is invoked (cancelling the concrete HTTP request), the underlying
+ * stream wrapper is destroyed, all listeners are removed, and the function
+ * rejects. No partial body text is returned in the failure paths. Normal
+ * completion does not cancel the request.
+ *
+ * @param cancelRequest Caller-owned cancellation of the concrete fetch request
+ *   (e.g. aborting a per-fetch AbortController). Required so forgetting
+ *   transport ownership is a compile error.
+ */
+export async function acquireBoundedHttpBody(
+  response: BoundedFetchResponse,
+  budget: ByteBudget,
+  signal: AbortSignal,
+  cancelRequest: () => void,
+): Promise<BoundedHttpBody> {
+  const advertised = parseContentLength(response.headers.get('content-length'));
+  if (advertised !== undefined && advertised > budget.bytes) {
+    cancelRequest();
+    destroyStream(response.body as ManagedStream | null | undefined);
+    throw new HttpBodyTooLargeError(advertised, budget.bytes);
+  }
+
+  const body = response.body as ManagedStream | null | undefined;
+  if (body === null || body === undefined) {
+    return Promise.resolve({
+      text: '',
+      metadata: {
+        observedBytes: 0,
+        retainedBytes: 0,
+        omittedBytes: 0,
+        truncated: false,
+        budgetBytes: budget.bytes,
+      },
+    });
+  }
+
+  return streamBoundedBody(body, budget, signal, cancelRequest);
+}

--- a/project-plans/issue3204/PLAN.md
+++ b/project-plans/issue3204/PLAN.md
@@ -1,0 +1,211 @@
+# Plan: Bound External HTTP, API, and MCP Response Acquisition (Issue #3204)
+
+Plan ID: PLAN-20260810-ISSUE3204
+Generated: 2026-08-10
+Parent: #3202
+
+## Accepted Problem
+
+LLxprt-owned HTTP readers currently call `Response.arrayBuffer()` or
+`Response.text()` before enforcing a local byte limit. MCP transports materialize
+tool results inside `@modelcontextprotocol/sdk` before LLxprt receives them, and
+LLxprt then transforms and retains content blocks without an aggregate budget.
+This issue bounds those existing acquisition paths without introducing a network
+framework, public setting, package, dependency, or unrelated refactor.
+
+## Verified Ownership Boundaries
+
+| Path | Current acquisition owner | Materialize-first risk | Accepted action |
+| --- | --- | --- | --- |
+| Direct web fetch | `packages/tools/src/tools/direct-web-fetch.ts` | `response.arrayBuffer()` precedes the post-read check | Stream through a bounded HTTP adapter; preserve the existing 5 MiB policy |
+| Exa web search | `packages/tools/src/tools/exa-web-search.ts` | success and error bodies use `response.text()` | Reuse the bounded HTTP adapter with the existing 4 MiB acquisition default |
+| Code search | `packages/tools/src/tools/codesearch.ts` | success and error bodies use `response.text()` | Reuse the bounded HTTP adapter with the existing 4 MiB acquisition default |
+| GitHub tool | injected GitHub broker invokes `gh`; `packages/tools` owns no HTTP body loop | no LLxprt-owned HTTP response body in this tool path | Audit evidence only; no transport change |
+| MCP stdio/SSE/streamable HTTP | `@modelcontextprotocol/sdk` v1.29.0 | SDK parses/materializes messages before `McpCallableTool` receives the result | Validate one aggregate budget immediately after SDK `callTool()` returns; fail the call on overflow |
+
+The installed MCP SDK exposes timeout and queue-size options but no message-byte,
+response-byte, or frame-size option on `Client`, `StdioClientTransport`,
+`SSEClientTransport`, or `StreamableHTTPClientTransport`. LLxprt owns none of
+those transport read loops. A pre-materialization MCP cap is therefore not
+implementable in this issue without replacing/wrapping an SDK transport or
+changing dependencies, both outside the accepted architecture. This limitation
+will be stated in the PR and tracked separately; it does not weaken the owned
+HTTP fix.
+
+## Reused Contracts and Adapter Boundary
+
+- Reuse `ByteBudget`, `createByteBudget`, `createDefaultByteBudget`,
+  `BoundedStreamCollector`, `AcquisitionResult`, and truncation metadata from
+  `@vybestack/llxprt-code-tools/acquisition.js`.
+- Add only an HTTP-specific adapter in `packages/tools`; do not add HTTP, MCP,
+  SDK, settings, or error-policy concerns to the acquisition primitives.
+- The HTTP adapter owns stream iteration, `Content-Length` early rejection,
+  abort handling, and stream cleanup. It returns bounded acquisition data;
+  each tool owns its error/result wording.
+- MCP reuses the validated byte budget but fails atomically. It must never use
+  head/tail truncation because partial text or base64 would produce malformed
+  protocol content.
+- `packages/mcp` gains no runtime dependency on `packages/core` and no new
+  dependency. Existing unrelated imports are not refactored in this issue.
+
+## Accepted Behavior and Boundary Cases
+
+### AC-01: Direct HTTP streaming cap
+
+**Given** a direct-web-fetch response with no `Content-Length` or chunked
+transfer encoding, **when** cumulative body bytes exceed the existing 5 MiB
+budget, **then** reading stops during stream acquisition, the body is closed,
+and the tool returns a clear fetch error without producing partial content.
+
+Evidence:
+- a real local HTTP response without `Content-Length` exceeds the cap;
+- the server cannot complete delivery before the client closes the body;
+- no `arrayBuffer()`/`text()` materialize-first path remains.
+
+### AC-02: `Content-Length` is optimization, not trust boundary
+
+**Given** a response advertises a body at or below the cap but sends more,
+**when** the streamed bytes exceed the cap, **then** the same overflow failure
+occurs. **Given** an advertised length above the cap, **then** the body is
+rejected and closed before body iteration.
+
+### AC-03: Exact byte boundary
+
+**Given** an HTTP body whose UTF-8 byte length equals the configured budget,
+**when** it is read, **then** the complete body succeeds. **Given** one more
+byte, **then** the read fails and returns no partial tool result. Byte count,
+not JavaScript character count, defines the boundary.
+
+### AC-04: Abort and cleanup
+
+**Given** an HTTP read in progress, **when** its signal aborts, **then** the read
+fails as an abort, no retry is started for body acquisition, listeners are
+removed, and the Node response stream is destroyed/closed. Normal completion,
+early rejected `Content-Length`, overflow, abort, and read errors all release
+the reader/stream ownership they acquired.
+
+### AC-05: Exa and code-search local acquisition caps
+
+**Given** Exa web search or code search receives an oversized success or error
+body, **when** the owned response reader runs, **then** it stops at the shared
+4 MiB byte budget and returns the tool's existing structured error category
+with a clear size-limit message. Valid bounded SSE responses and current
+malformed-line semantics remain unchanged.
+
+### AC-06: MCP aggregate content budget
+
+**Given** the MCP SDK has returned a `CallToolResult`, **when** `McpCallableTool`
+examines its content, **then** one shared 4 MiB byte budget covers all retained
+content blocks before they are wrapped or transformed. UTF-8 text bytes and the
+encoded bytes of image/audio `data`, embedded resource `text`/`blob`, and
+transformed resource-link strings contribute to the same aggregate.
+
+Exact-boundary aggregate content succeeds. One byte over, whether in one block
+or accumulated across blocks, fails the whole call with a clear MCP tool error.
+No partial content array is returned.
+
+### AC-07: MCP block coverage
+
+Oversized text, image base64, audio base64, embedded text resource, and embedded
+blob resource responses each fail atomically. Multiple individually valid
+blocks that collectively exceed the budget also fail. Existing valid content
+transformations remain unchanged.
+
+### AC-08: Dependency and transport boundaries
+
+`packages/mcp` imports the acquisition budget from `packages/tools`, does not add
+a runtime dependency on `packages/core`, and does not wrap or replace SDK
+transports. The GitHub broker audit and the SDK-cap limitation are documented;
+no broker, OAuth/discovery, provider protocol, or dependency change is made.
+
+## Behavioral Test Matrix (Bun + `bun:test`)
+
+Tests are written first and observed failing before production changes.
+Infrastructure may be substituted, but the collector/adapter/tool under test is
+real and assertions target observable results rather than mock call counts.
+
+1. Bounded HTTP adapter reads a real local chunked response under budget.
+2. Missing-`Content-Length` local response exceeds budget and closes early.
+3. Advertised small `Content-Length` plus a larger stream fails on observed bytes.
+4. Advertised over-limit length rejects before iteration and closes the stream.
+5. Exact budget succeeds; one-byte-over fails, including multibyte UTF-8 input.
+6. Abort mid-stream rejects as abort and destroys/closes the body.
+7. Stream read error releases ownership and propagates the original failure.
+8. Direct web fetch succeeds at the exact 5 MiB boundary and returns a structured
+   size error one byte over without retrying response-body acquisition.
+9. Exa success/error bodies and code-search success/error bodies return their
+   existing error types when the shared 4 MiB cap is exceeded; bounded valid and
+   malformed SSE cases preserve current behavior.
+10. `McpCallableTool` accepts exact-boundary aggregate text.
+11. It fails one-byte-over text, image, audio, embedded text, and embedded blob.
+12. It fails multiple blocks whose aggregate crosses the budget and returns no
+    partial transformed content.
+13. Existing valid MCP mixed-block transformation tests remain green.
+14. Package typecheck/build prove the tools-to-MCP dependency direction remains
+    valid.
+
+## Expected Files
+
+- `packages/tools/src/utils/bounded-http-response.ts` (new transport adapter)
+- `packages/tools/src/utils/bounded-http-response.test.ts` (new Bun behavioral fixture tests)
+- `packages/tools/src/tools/direct-web-fetch.ts`
+- `packages/tools/src/tools/direct-web-fetch.test.ts`
+- `packages/tools/src/tools/direct-web-fetch-real-transport.bun.test.ts` (new real
+  `node-fetch` transport fixture, isolated from the unit test's process-global mock)
+- `packages/tools/src/tools/exa-web-search.ts`
+- `packages/tools/src/tools/exa-web-search.test.ts`
+- `packages/tools/src/tools/codesearch.ts`
+- `packages/tools/src/tools/codesearch.test.ts`
+- `packages/tools/src/tools/codesearch-endpoint.bun.test.ts` (existing endpoint
+  fixture updated to provide a streamed response body)
+- `packages/mcp/src/client/mcp-callable-tool.ts`
+- an existing MCP Bun test file, preferably `neutral-types.test.ts` for the
+  callable adapter; `mcp-tool.execute.test.ts` only if end-to-end error evidence
+  is not already covered
+
+A change outside these files requires a direct acceptance-criterion reason. No
+workflow, agent-memory, quality-tool, package dependency, or public setting
+change is accepted.
+
+## Explicit Scope Triage
+
+### In-scope
+
+- Owned HTTP stream acquisition for direct fetch, Exa, and code search
+- Aggregate MCP post-materialization validation at the earliest LLxprt-owned point
+- Clear atomic overflow errors and behavioral evidence
+- Documentation/tracking of the verified SDK limitation and GitHub broker boundary
+
+### Reject
+
+- Moving HTTP or MCP concerns into `packages/tools/src/acquisition`
+- Silent truncation of MCP protocol content
+- New generic network framework/package or public response-limit setting
+- Replacing or wrapping MCP SDK transports when no supported cap option exists
+- MCP OAuth/discovery redesign, provider streaming redesign, or unrelated cleanup
+- Treating server request/token limits as an acquisition boundary
+
+### Defer
+
+- A pre-materialization MCP frame cap until the SDK exposes a supported option or
+  a separately approved transport-ownership change is designed
+- GitHub broker/subprocess output policy changes; the tool path owns no HTTP body
+- Non-tool provider/auth/telemetry response readers, which are not the API-backed
+  tool paths named by this issue
+
+## Verification and Completion Gate
+
+Run focused Bun tests during each red/green cycle, then run:
+
+- `npm run test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run format`
+- `npm run build`
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+
+Completion additionally requires DeepThinker review, detached Open Code Review
+(within the issue's review limits), triage of every finding as Blocker-Fix,
+In-scope-Fix, Reject, or Defer, green CI on the candidate head, resolved PR
+threads, conflict-free status, and correct ancestry. Stop when these accepted
+behaviors and gates are satisfied; do not continue optional hardening or cleanup.


### PR DESCRIPTION
## TLDR

Bounds LLxprt-owned HTTP response acquisition while bytes are streamed instead of after an untrusted body has already been materialized. Direct web fetch retains its 5 MiB policy; Exa and code search use the shared 4 MiB acquisition budget. Overflow, abort, read error, and rejected-response disposal cancel the concrete node-fetch request as well as destroying the exposed body wrapper.

Also rejects oversized MCP content atomically with one aggregate 4 MiB budget across text, image/audio encoded data, embedded resources, and transformed resource links immediately after the SDK returns and before LLxprt transforms or retains the result.

## Dive Deeper

### HTTP acquisition

- Adds a bounded HTTP response adapter at the packages/tools boundary using the existing byte-budget and bounded-stream collector contracts from the shell acquisition work.
- Treats Content-Length only as an early-reject optimization. Missing, chunked, malformed, unsafe, or understated lengths still flow through observed-byte enforcement.
- Accepts an exact boundary and rejects one byte over without returning partial text.
- Requires every caller to provide concrete request cancellation ownership. This matters because node-fetch exposes a PassThrough body wrapper; destroying only that wrapper does not necessarily stop upstream socket delivery.
- Direct web fetch uses a fresh AbortController for each retry attempt. A rejected 5xx response is canceled before retry, while the overall timeout/user-abort signal remains usable for the next attempt.
- Exa and code search use invocation-local controllers linked to the caller signal and apply the same bounded reader to both successful and non-success bodies.
- Real local-server fixtures prove terminal 4xx, retryable 5xx, and oversized 2xx transport cancellation and deterministic writer shutdown.

### MCP boundary

- Reuses the tools acquisition budget through the existing dependency-safe packages/mcp -> packages/tools relationship; no packages/core dependency was added.
- Uses the installed MCP SDK discriminated content union and a compiler-exhaustive switch.
- Counts UTF-8 text bytes, image/audio data strings, embedded resource text/blob strings, and the exact transformed resource-link string under one aggregate budget.
- Returns only the existing structured error shape on overflow, with no partial original content.
- The installed MCP SDK exposes no supported pre-materialization message/frame cap on Client or its stdio/SSE/streamable HTTP transports. LLxprt does not own those read loops, so the earliest supported enforcement point remains immediately after Client.callTool returns. Replacing or wrapping SDK transports is intentionally deferred rather than weakening the HTTP fix.

### API audit

- Direct web fetch, Exa, and code search own response reads and are bounded here.
- The GitHub tool delegates transport acquisition to the gh broker and owns no HTTP body read loop in packages/tools, so no GitHub transport change is included.
- No dependency, workflow, public setting, OAuth/discovery, provider-protocol, or generic networking changes are included.

## Reviewer Test Plan

1. Run the focused behavioral suites:

       bun test packages/tools/src/utils/bounded-http-response.test.ts
       bun test packages/tools/src/tools/direct-web-fetch.test.ts
       bun test packages/tools/src/tools/direct-web-fetch-real-transport.bun.test.ts
       bun test packages/tools/src/tools/exa-web-search.test.ts
       bun test packages/tools/src/tools/codesearch.test.ts
       bun test packages/tools/src/tools/codesearch-endpoint.bun.test.ts
       bun test packages/mcp/src/client/neutral-types.test.ts

2. Confirm the real-transport DirectWebFetchTool tests observe socket cancellation before a rejected response can finish and before a retry begins.
3. Run package and repository gates:

       npm run test
       npm run lint
       npm run lint:eslint-guard
       npm run typecheck
       npm run format
       npm run build
       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

Local evidence:

- All focused HTTP/API and MCP behavioral suites pass.
- Full tools and MCP workspace suites pass in process isolation.
- Lint, ESLint guard, typecheck, format, build, and Stepfun smoke pass on the candidate commit.
- The exact root test command completed but reported one unchanged packages/agents file timing out under the concurrent workspace runner. The file passed 22/22 immediately when run alone. Earlier root attempts timed out on different unchanged agents files, and each passed sequentially; no packages/agents source is changed in this PR. CI remains the authoritative clean-run gate.
- Two DeepThinker review cycles and two detached Open Code Review cycles were completed. All Blocker-Fix and In-scope-Fix findings were resolved; duplicate or out-of-scope suggestions were rejected or deferred with explicit scope rationale.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ⚠️ Full gates pass except the documented unchanged agents concurrent timeout; isolated rerun passes | ❓ | ❓ |
| npx      | ✅ Focused Prettier and ESLint checks | ❓ | ❓ |
| Docker   | ❓ | ❓ | ❓ |
| Podman   | ❓ | - | - |
| Seatbelt | ❓ | - | - |

## Linked issues / bugs

Fixes #3204

Related to #3202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added byte limits for MCP tool results, including text, images, audio, resources, and links.
  * Added bounded response handling for code search, web search, and direct web fetch requests.
* **Bug Fixes**
  * Oversized responses are now rejected before processing and report the observed limit error.
  * Interrupted, failed, or retried requests now cancel and dispose of response data cleanly.
  * Preserved HTTP status details and existing response parsing behavior for supported requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->