### PR TITLE
Prepare GPT-5.6 tokenizer before agent readiness (Fixes #3217)

### DIFF
--- a/packages/agents/src/api/__tests__/fromConfig.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/fromConfig.behavior.test.ts
@@ -28,6 +28,12 @@ import {
   type Agent,
   type AgentEvent,
 } from '@vybestack/llxprt-code-agents';
+import type { RuntimeTokenizerFactory } from '@vybestack/llxprt-code-core';
+import {
+  disposeCliRuntime,
+  getCliRuntimeServices,
+  runWithRuntimeScope,
+} from '@vybestack/llxprt-code-providers/runtime.js';
 import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
 import {
   buildCliStyleConfig,
@@ -96,6 +102,141 @@ function captureRuntimeId(agent: Agent): unknown {
   const id = impl['runtimeId'];
   return typeof id === 'string' ? id : undefined;
 }
+
+function createSignal(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} {
+  let resolvePromise = (): void => {
+    throw new Error('signal initialized without a resolver');
+  };
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: () => resolvePromise() };
+}
+
+function createReadinessFactory(
+  prepareTokenizer: (providerName: string, model?: string) => Promise<void>,
+  countTokens: (providerName: string, model?: string) => number,
+): RuntimeTokenizerFactory {
+  return {
+    prepareTokenizer,
+    getTokenizer: (providerName, model) => ({
+      fallbackPolicy: 'deny',
+      countTokens: () => countTokens(providerName, model),
+    }),
+    estimatePrompt: async (request) => ({
+      count: await request.legacyEstimate(),
+      method: 'calibrated',
+      family: 'test-readiness',
+      estimatorVersion: 'test-readiness-v1',
+      assetRevision: 'none',
+      projectionRevision: request.projectionRevision,
+    }),
+  };
+}
+
+describe('fromConfig tokenizer readiness @requirement:REQ-3217-001 @requirement:REQ-3217-003', () => {
+  it('awaits post-activation provider/model preparation before returning a usable Agent', async () => {
+    const built = await buildCliStyleConfig('plain-text.jsonl');
+    const preparationStarted = createSignal();
+    const releasePreparation = createSignal();
+    const events: string[] = [];
+    let prepared = false;
+    const factory = createReadinessFactory(
+      async (providerName, model) => {
+        events.push(`prepare:${providerName}:${model ?? ''}`);
+        preparationStarted.resolve();
+        await releasePreparation.promise;
+        prepared = true;
+        events.push('prepared');
+      },
+      (providerName, model) => {
+        if (!prepared) {
+          throw new Error('tokenizer used before preparation completed');
+        }
+        events.push(`tokenize:${providerName}:${model ?? ''}`);
+        return 7;
+      },
+    );
+    built.config.setTokenizerFactory(factory);
+
+    try {
+      const pendingAgent = fromConfig({
+        config: built.config,
+        activation: {
+          provider: 'fake',
+          model: 'ready-model',
+          authMode: 'auto',
+        },
+      });
+      await preparationStarted.promise;
+      let completed = false;
+      const observedAgent = pendingAgent.then((agent) => {
+        completed = true;
+        return agent;
+      });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(completed).toBe(false);
+
+      releasePreparation.resolve();
+      const agent = await observedAgent;
+      try {
+        expect(built.config.getTokenizerFactory()).toBe(factory);
+
+        const turnEvents = await drain(agent.stream('hello'));
+        expect(countType(turnEvents, 'done')).toBe(1);
+        expect(events[0]).toBe('prepare:fake:ready-model');
+        expect(events[1]).toBe('prepared');
+        expect(
+          events.some((event) => event === 'tokenize:fake:ready-model'),
+        ).toBe(true);
+      } finally {
+        await agent.dispose();
+      }
+    } finally {
+      releasePreparation.resolve();
+      await built.cleanup();
+    }
+  });
+
+  it('rejects with the causal preparation failure and removes the isolated runtime', async () => {
+    const built = await buildCliStyleConfig('plain-text.jsonl');
+    const failure = new Error('mandatory tokenizer readiness failed causally');
+    const runtimeId = 'from-config-rejected-tokenizer-readiness';
+    built.config.setProvider('stale-config-provider');
+    built.config.setTokenizerFactory(
+      createReadinessFactory(
+        async (providerName, model) => {
+          if (providerName !== 'fake' || model !== 'fake-model') {
+            throw new Error(
+              `unexpected readiness target ${providerName}/${model ?? ''}`,
+            );
+          }
+          throw failure;
+        },
+        () => {
+          throw new Error('unreachable tokenizer use');
+        },
+      ),
+    );
+
+    try {
+      await expect(
+        fromConfig({ config: built.config, sessionId: runtimeId }),
+      ).rejects.toBe(failure);
+      expect(() =>
+        runWithRuntimeScope({ runtimeId, metadata: {} }, () =>
+          getCliRuntimeServices(),
+        ),
+      ).toThrow(/runtime registration|runtime.*not/i);
+    } finally {
+      disposeCliRuntime(runtimeId);
+      await built.cleanup();
+    }
+  });
+});
 
 describe('fromConfig behavior @plan:PLAN-20260621-COREAPIREMED.P08 @requirement:REQ-001 @requirement:REQ-INT-001', () => {
   it('T1 fromConfig returns an Agent whose internalConfig(agent) === the SAME caller-supplied Config (identity) @requirement:REQ-001 @scenario:adoption @given:a real CLI-style Config @when:fromConfig({ config }) @then:internalConfig(agent) is the SAME Config instance', async () => {

--- a/packages/agents/src/api/__tests__/fromConfig.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/fromConfig.behavior.test.ts
@@ -201,19 +201,21 @@ describe('fromConfig tokenizer readiness @requirement:REQ-3217-001 @requirement:
     }
   });
 
-  it('rejects with the causal preparation failure and removes the isolated runtime', async () => {
+  it('rejects with the causal preparation failure reached through authoritative post-activation state (not stale Config state) and removes the isolated runtime', async () => {
     const built = await buildCliStyleConfig('plain-text.jsonl');
     const failure = new Error('mandatory tokenizer readiness failed causally');
     const runtimeId = 'from-config-rejected-tokenizer-readiness';
+    // Mutate the Config's provider field to stale state. The isolated runtime
+    // manager still has 'fake' active (authoritative). fromConfig must derive
+    // the readiness target from the manager, not from this stale Config field.
     built.config.setProvider('stale-config-provider');
+    let readinessTarget:
+      | { readonly provider: string; readonly model: string }
+      | undefined;
     built.config.setTokenizerFactory(
       createReadinessFactory(
         async (providerName, model) => {
-          if (providerName !== 'fake' || model !== 'fake-model') {
-            throw new Error(
-              `unexpected readiness target ${providerName}/${model ?? ''}`,
-            );
-          }
+          readinessTarget = { provider: providerName, model: model ?? '' };
           throw failure;
         },
         () => {
@@ -226,6 +228,14 @@ describe('fromConfig tokenizer readiness @requirement:REQ-3217-001 @requirement:
       await expect(
         fromConfig({ config: built.config, sessionId: runtimeId }),
       ).rejects.toBe(failure);
+      // Authoritative post-activation manager state ('fake'/'fake-model')
+      // reached readiness — NOT the stale Config provider
+      // ('stale-config-provider').
+      expect(readinessTarget).toEqual({
+        provider: 'fake',
+        model: 'fake-model',
+      });
+      expect(readinessTarget?.provider).not.toBe('stale-config-provider');
       expect(() =>
         runWithRuntimeScope({ runtimeId, metadata: {} }, () =>
           getCliRuntimeServices(),

--- a/packages/agents/src/api/fromConfig.ts
+++ b/packages/agents/src/api/fromConfig.ts
@@ -97,50 +97,72 @@ export async function fromConfig(options: FromConfigOptions): Promise<Agent> {
     },
   });
 
-  // @pseudocode line 29: activate so getCliRuntimeServices() resolves THESE.
-  await handle.activate();
+  try {
+    // @pseudocode line 29: activate so getCliRuntimeServices() resolves THESE.
+    await handle.activate();
 
-  // @pseudocode line 37-48 (createAgent.ts:178-180 mirror): derive managers.
-  const manager = handle.providerManager;
-  const oauthManager = resolveOAuthManager(config, handle);
-  const sharedSettingsService = handle.settingsService;
+    // @pseudocode line 37-48 (createAgent.ts:178-180 mirror): derive managers.
+    const manager = handle.providerManager;
+    const oauthManager = resolveOAuthManager(config, handle);
+    const sharedSettingsService = handle.settingsService;
 
-  // @plan:PLAN-20270110-ISSUE2378.P02 @requirement:REQ-2378-002
-  // Bind the settings runtime context to the adopted Config's SettingsService.
-  activateSettingsRuntimeContext(sharedSettingsService, runtimeId, {
-    config,
-    metadata: { source: 'fromConfig' },
-  });
+    // @plan:PLAN-20270110-ISSUE2378.P02 @requirement:REQ-2378-002
+    // Bind the settings runtime context to the adopted Config's SettingsService.
+    activateSettingsRuntimeContext(sharedSettingsService, runtimeId, {
+      config,
+      metadata: { source: 'fromConfig' },
+    });
 
-  // @pseudocode lines 31-35: initialize once or adopt the original result.
-  await config.ensureInitialized({ messageBus });
+    // @pseudocode lines 31-35: initialize once or adopt the original result.
+    await config.ensureInitialized({ messageBus });
 
-  // @plan:PLAN-20270104-ISSUE2374.P03 @requirement:REQ-001
-  await resolveActivation(config, options);
+    // @plan:PLAN-20270104-ISSUE2374.P03 @requirement:REQ-001
+    await resolveActivation(config, options);
 
-  // @pseudocode lines 37-48 (Mismatch 1): synthesize parsed + resolvedAuth.
-  const parsed = buildParsedConfig(config, options);
-  const resolvedAuth = { baseUrl: undefined };
+    // @pseudocode lines 37-48 (Mismatch 1): synthesize parsed + resolvedAuth.
+    const parsed = buildParsedConfig(config, options);
+    await config
+      .getTokenizerFactory()
+      ?.prepareTokenizer?.(parsed.provider, parsed.model);
+    const resolvedAuth = { baseUrl: undefined };
 
-  // @pseudocode lines 37-48: SHARED finalize (CRIT-4: single finalize path).
-  // The 17th positional arg 'caller' threads REQ-001.3 ownership so dispose()
-  // skips the caller-owned Config teardown.
-  return finalizeAgent(
-    parsed,
-    resolvedAuth,
-    config,
-    manager,
-    oauthManager,
-    sharedSettingsService,
-    runtimeId,
-    handle,
-    messageBus,
-    options.onApproval,
-    options.onOAuthPrompt,
-    options.editorCallbacks,
-    [],
-    'caller',
-  );
+    // @pseudocode lines 37-48: SHARED finalize (CRIT-4: single finalize path).
+    // The 17th positional arg 'caller' threads REQ-001.3 ownership so dispose()
+    // skips the caller-owned Config teardown.
+    return await finalizeAgent(
+      parsed,
+      resolvedAuth,
+      config,
+      manager,
+      oauthManager,
+      sharedSettingsService,
+      runtimeId,
+      handle,
+      messageBus,
+      options.onApproval,
+      options.onOAuthPrompt,
+      options.editorCallbacks,
+      [],
+      'caller',
+    );
+  } catch (primaryError) {
+    return cleanupFailedBootstrap(handle, primaryError);
+  }
+}
+
+async function cleanupFailedBootstrap(
+  handle: IsolatedRuntimeContextHandle,
+  primaryError: unknown,
+): Promise<never> {
+  try {
+    await handle.cleanup();
+  } catch (cleanupError) {
+    throw new AggregateError(
+      [primaryError, cleanupError],
+      'fromConfig bootstrap failed and isolated runtime cleanup also failed',
+    );
+  }
+  throw primaryError;
 }
 
 /**
@@ -194,19 +216,16 @@ async function resolveActivation(
 }
 
 /**
- * #2374 round-3 Fix 1: derive the provider from the POST-activation runtime
- * truth (manager active provider name), NOT config.getProvider(). When no
- * activation intent ran, config.getProvider() is the correct source.
+ * Derive the provider from the post-activation runtime truth, falling back to
+ * the Config only when the adopted manager has no active provider.
  */
 function buildParsedConfig(
   config: Config,
   options: FromConfigOptions,
 ): { provider: string; model: string; sessionId?: string } {
   const activeRuntimeProvider =
-    options.activation !== undefined
-      ? (config.getProviderManager()?.getActiveProviderName() ??
-        config.getProvider())
-      : config.getProvider();
+    config.getProviderManager()?.getActiveProviderName() ??
+    config.getProvider();
   return {
     provider: activeRuntimeProvider ?? '',
     model: config.getModel(),

--- a/packages/core/src/runtime/contracts/RuntimeTokenizerFactory.ts
+++ b/packages/core/src/runtime/contracts/RuntimeTokenizerFactory.ts
@@ -61,6 +61,7 @@ export interface RuntimeTokenizerFactory {
   estimatePrompt(
     request: RuntimePromptEstimateRequest,
   ): Promise<RuntimePromptEstimateResult>;
+  prepareTokenizer?(providerName: string, model?: string): Promise<void>;
   claimsModel?(canonicalModel: string): boolean;
   getEstimatorFamily?(canonicalModel: string): string | undefined;
 }

--- a/packages/providers/src/composition/providerManagerInstance.ts
+++ b/packages/providers/src/composition/providerManagerInstance.ts
@@ -16,8 +16,6 @@ import {
   type RuntimeContentGeneratorFactory,
   type ContentGenerator,
   type RuntimeProviderManager,
-  type RuntimeTokenizer,
-  type RuntimeTokenizerFactory,
   type ProviderRuntimeContext,
 } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
@@ -25,24 +23,7 @@ import { UNCONFIGURED_PROVIDER } from '@vybestack/llxprt-code-core/config/models
 import { ProviderManager } from '../ProviderManager.js';
 import { FakeProvider } from '../fake/FakeProvider.js';
 import { ProviderContentGenerator } from '../ProviderContentGenerator.js';
-import { OpenAITokenizer } from '../tokenizers/OpenAITokenizer.js';
-import { AnthropicTokenizer } from '../tokenizers/AnthropicTokenizer.js';
-import {
-  DEFAULT_MODEL_PROMPT_ESTIMATOR_REGISTRATIONS,
-  ModelPromptEstimatorRegistry,
-} from '../tokenizers/ModelPromptEstimatorRegistry.js';
-import {
-  CLAUDE_5_PROMPT_ESTIMATOR_REGISTRATIONS,
-  createClaudeRuntimeTokenizer,
-} from '../tokenizers/claude/claudePromptEstimator.js';
-import { createGpt56RuntimeTokenizer } from '../tokenizers/Gpt56O200kPromptEstimator.js';
-import { isSanctionedGpt56Model } from '../openai/openaiModelPolicy.js';
-import {
-  OFFICIAL_PROMPT_ESTIMATOR_REGISTRATIONS,
-  createOfficialRuntimeTokenizer,
-} from '../tokenizers/official/index.js';
-
-const logger = new DebugLogger('llxprt:provider:manager:instance');
+import { createRuntimeTokenizerFactory } from './runtimeTokenizerFactory.js';
 import { type IFileSystem, NodeFileSystem } from './IFileSystem.js';
 import stripJsonComments from 'strip-json-comments';
 import { Storage } from '@vybestack/llxprt-code-settings';
@@ -64,6 +45,9 @@ import {
 } from './aliasProviderFactory.js';
 
 export { bindOpenAIAliasIdentity } from './aliasProviderFactory.js';
+export { createRuntimeTokenizerFactory } from './runtimeTokenizerFactory.js';
+
+const logger = new DebugLogger('llxprt:provider:manager:instance');
 
 let fileSystemInstance: IFileSystem | null = null;
 let singletonManager: ProviderManager | null = null;
@@ -95,100 +79,6 @@ interface OpenAIRegistrationContext {
   oauthManager: OAuthManager;
   config?: Config;
   authOnlyEnabled?: boolean;
-}
-
-class RuntimeTokenizerAdapter implements RuntimeTokenizer {
-  constructor(
-    private readonly tokenizer: {
-      countTokens(text: string, model: string): Promise<number>;
-    },
-    private readonly model: string,
-  ) {}
-
-  async countTokens(content: unknown): Promise<number> {
-    const text =
-      typeof content === 'string' ? content : JSON.stringify(content);
-    return this.tokenizer.countTokens(text, this.model);
-  }
-}
-
-const ANTHROPIC_TOKENIZER_MATCHERS = ['anthropic', 'claude'] as const;
-const OPENAI_TOKENIZER_MATCHERS = [
-  'openai',
-  'codex',
-  'gpt',
-  'o1',
-  'o3',
-  'o4',
-  'deepseek',
-] as const;
-
-function matchesTokenizer(
-  providerKey: string,
-  modelKey: string,
-  matchers: readonly string[],
-): boolean {
-  return matchers.some(
-    (matcher) => providerKey.includes(matcher) || modelKey.includes(matcher),
-  );
-}
-
-function createRuntimeTokenizerFactory(): RuntimeTokenizerFactory {
-  const openaiTokenizer = new OpenAITokenizer();
-  const anthropicTokenizer = new AnthropicTokenizer();
-  const estimatorRegistry = new ModelPromptEstimatorRegistry([
-    ...DEFAULT_MODEL_PROMPT_ESTIMATOR_REGISTRATIONS,
-    ...OFFICIAL_PROMPT_ESTIMATOR_REGISTRATIONS,
-    ...CLAUDE_5_PROMPT_ESTIMATOR_REGISTRATIONS,
-  ]);
-
-  return {
-    claimsModel: (canonicalModel) =>
-      estimatorRegistry.claimsModel(canonicalModel),
-    getEstimatorFamily: (canonicalModel) =>
-      estimatorRegistry.getEstimatorFamily(canonicalModel),
-    estimatePrompt: (request) => estimatorRegistry.estimatePrompt(request),
-    getTokenizer(
-      providerName: string,
-      model?: string,
-    ): RuntimeTokenizer | undefined {
-      const resolvedModel = model ?? providerName;
-      if (isSanctionedGpt56Model(resolvedModel)) {
-        return createGpt56RuntimeTokenizer(providerName, resolvedModel);
-      }
-      const officialTokenizer = createOfficialRuntimeTokenizer(
-        providerName,
-        resolvedModel,
-      );
-      if (officialTokenizer !== undefined) {
-        return officialTokenizer;
-      }
-      const claudeTokenizer = createClaudeRuntimeTokenizer(
-        providerName,
-        resolvedModel,
-      );
-      if (claudeTokenizer !== undefined) {
-        return claudeTokenizer;
-      }
-      const providerKey = providerName.toLowerCase();
-      const modelKey = resolvedModel.toLowerCase();
-      if (
-        matchesTokenizer(providerKey, modelKey, ANTHROPIC_TOKENIZER_MATCHERS)
-      ) {
-        return new RuntimeTokenizerAdapter(
-          anthropicTokenizer,
-          model ?? providerName,
-        );
-      }
-      if (matchesTokenizer(providerKey, modelKey, OPENAI_TOKENIZER_MATCHERS)) {
-        return new RuntimeTokenizerAdapter(
-          openaiTokenizer,
-          model ?? providerName,
-        );
-      }
-      return undefined;
-    },
-  };
 }
 
 function createRuntimeContentGeneratorFactory(
@@ -224,7 +114,15 @@ export function configureProviderRuntimeFactories(
     );
   }
   const setTokenizerFactory = configWithFactories['setTokenizerFactory'];
-  if (typeof setTokenizerFactory === 'function') {
+  const getTokenizerFactory = configWithFactories['getTokenizerFactory'];
+  const existingTokenizerFactory =
+    typeof getTokenizerFactory === 'function'
+      ? getTokenizerFactory.call(config)
+      : undefined;
+  if (
+    typeof setTokenizerFactory === 'function' &&
+    existingTokenizerFactory === undefined
+  ) {
     setTokenizerFactory.call(config, createRuntimeTokenizerFactory());
   }
 }

--- a/packages/providers/src/composition/runtimeTokenizerFactory.ts
+++ b/packages/providers/src/composition/runtimeTokenizerFactory.ts
@@ -15,7 +15,7 @@ import {
   prepareGpt56RuntimeTokenizer,
 } from '../tokenizers/Gpt56O200kPromptEstimator.js';
 import {
-  createGpt56PromptEstimatorRegistration,
+  createDefaultEstimatorRegistrations,
   ModelPromptEstimatorRegistry,
 } from '../tokenizers/ModelPromptEstimatorRegistry.js';
 import { OpenAITokenizer } from '../tokenizers/OpenAITokenizer.js';
@@ -69,18 +69,44 @@ function matchesTokenizer(
   );
 }
 
+/**
+ * Construct the providers-backed runtime tokenizer factory.
+ *
+ * Readiness contract:
+ * - `prepareTokenizer` establishes **mandatory model readiness**. Every
+ *   bootstrap or composition consumer (CLI start-up, `fromConfig`, headless
+ *   runtime assembly) MUST `await` it for each active provider/model BEFORE
+ *   exposing `getTokenizer` or `estimatePrompt` to downstream callers. For
+ *   sanctioned GPT-5.6 models it eagerly loads and smoke-tests the o200k_base
+ *   encoder so that the first real counting call is never the first
+ *   initialization attempt. Preparation failures surface with full estimator
+ *   context and causal detail and are fatal to the bootstrap.
+ * - `getTokenizer` is **synchronous** and deliberately free of readiness
+ *   guards or retries. It shares the same resolver as `prepareTokenizer`, so
+ *   after preparation the encoder is already warm. Runtime token counting
+ *   reuses that resolved encoder directly. Because preparation belongs at the
+ *   bootstrap boundary, `getTokenizer` itself need not — and must not — assert
+ *   readiness or retry initialization; doing so would hide the real failure
+ *   point and add runtime cost to every counting call.
+ *
+ * @param loadModule Optional loader used to resolve the tiktoken module.
+ * Defaults to the process-wide shared loader. Tests inject a loader to
+ * isolate encoder initialization and inject failures.
+ */
 export function createRuntimeTokenizerFactory(
   loadModule: TiktokenModuleLoader = loadTiktokenModule,
 ): RuntimeTokenizerFactory {
   const openaiTokenizer = new OpenAITokenizer();
   const anthropicTokenizer = new AnthropicTokenizer();
   const resolveGpt56Encoder = createO200kBaseEncoderResolver(loadModule);
-  // Bind the GPT-5.6 estimator to this factory's encoder resolver so
-  // readiness, runtime tokenization, and final prompt-envelope estimation all
-  // observe the same encoder — including when a loader is injected. The
-  // production default resolver still delegates to the process-wide encoder.
+  // Bind the DEFAULT estimator registrations to this factory's encoder
+  // resolver so readiness, runtime tokenization, and final prompt-envelope
+  // estimation all observe the same encoder — including when a loader is
+  // injected. The helper replaces only the GPT-5.6 default entry and retains
+  // every other DEFAULT_MODEL_PROMPT_ESTIMATOR_REGISTRATIONS entry, so future
+  // defaults cannot diverge from this composition root.
   const estimatorRegistry = new ModelPromptEstimatorRegistry([
-    createGpt56PromptEstimatorRegistration(resolveGpt56Encoder),
+    ...createDefaultEstimatorRegistrations(resolveGpt56Encoder),
     ...OFFICIAL_PROMPT_ESTIMATOR_REGISTRATIONS,
     ...CLAUDE_5_PROMPT_ESTIMATOR_REGISTRATIONS,
   ]);

--- a/packages/providers/src/composition/runtimeTokenizerFactory.ts
+++ b/packages/providers/src/composition/runtimeTokenizerFactory.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  RuntimeTokenizer,
+  RuntimeTokenizerFactory,
+} from '@vybestack/llxprt-code-core';
+import { isSanctionedGpt56Model } from '../openai/openaiModelPolicy.js';
+import { AnthropicTokenizer } from '../tokenizers/AnthropicTokenizer.js';
+import {
+  createGpt56RuntimeTokenizer,
+  prepareGpt56RuntimeTokenizer,
+} from '../tokenizers/Gpt56O200kPromptEstimator.js';
+import {
+  createGpt56PromptEstimatorRegistration,
+  ModelPromptEstimatorRegistry,
+} from '../tokenizers/ModelPromptEstimatorRegistry.js';
+import { OpenAITokenizer } from '../tokenizers/OpenAITokenizer.js';
+import {
+  CLAUDE_5_PROMPT_ESTIMATOR_REGISTRATIONS,
+  createClaudeRuntimeTokenizer,
+} from '../tokenizers/claude/claudePromptEstimator.js';
+import {
+  createO200kBaseEncoderResolver,
+  loadTiktokenModule,
+  type TiktokenModuleLoader,
+} from '../tokenizers/o200kBaseCounter.js';
+import {
+  OFFICIAL_PROMPT_ESTIMATOR_REGISTRATIONS,
+  createOfficialRuntimeTokenizer,
+} from '../tokenizers/official/index.js';
+
+class RuntimeTokenizerAdapter implements RuntimeTokenizer {
+  constructor(
+    private readonly tokenizer: {
+      countTokens(text: string, model: string): Promise<number>;
+    },
+    private readonly model: string,
+  ) {}
+
+  async countTokens(content: unknown): Promise<number> {
+    const text =
+      typeof content === 'string' ? content : JSON.stringify(content);
+    return this.tokenizer.countTokens(text, this.model);
+  }
+}
+
+const ANTHROPIC_TOKENIZER_MATCHERS = ['anthropic', 'claude'] as const;
+const OPENAI_TOKENIZER_MATCHERS = [
+  'openai',
+  'codex',
+  'gpt',
+  'o1',
+  'o3',
+  'o4',
+  'deepseek',
+] as const;
+
+function matchesTokenizer(
+  providerKey: string,
+  modelKey: string,
+  matchers: readonly string[],
+): boolean {
+  return matchers.some(
+    (matcher) => providerKey.includes(matcher) || modelKey.includes(matcher),
+  );
+}
+
+export function createRuntimeTokenizerFactory(
+  loadModule: TiktokenModuleLoader = loadTiktokenModule,
+): RuntimeTokenizerFactory {
+  const openaiTokenizer = new OpenAITokenizer();
+  const anthropicTokenizer = new AnthropicTokenizer();
+  const resolveGpt56Encoder = createO200kBaseEncoderResolver(loadModule);
+  // Bind the GPT-5.6 estimator to this factory's encoder resolver so
+  // readiness, runtime tokenization, and final prompt-envelope estimation all
+  // observe the same encoder — including when a loader is injected. The
+  // production default resolver still delegates to the process-wide encoder.
+  const estimatorRegistry = new ModelPromptEstimatorRegistry([
+    createGpt56PromptEstimatorRegistration(resolveGpt56Encoder),
+    ...OFFICIAL_PROMPT_ESTIMATOR_REGISTRATIONS,
+    ...CLAUDE_5_PROMPT_ESTIMATOR_REGISTRATIONS,
+  ]);
+
+  return {
+    async prepareTokenizer(providerName, model): Promise<void> {
+      const resolvedModel = model ?? providerName;
+      if (isSanctionedGpt56Model(resolvedModel)) {
+        await prepareGpt56RuntimeTokenizer(
+          providerName,
+          resolvedModel,
+          resolveGpt56Encoder,
+        );
+      }
+    },
+    claimsModel: (canonicalModel) =>
+      estimatorRegistry.claimsModel(canonicalModel),
+    getEstimatorFamily: (canonicalModel) =>
+      estimatorRegistry.getEstimatorFamily(canonicalModel),
+    estimatePrompt: (request) => estimatorRegistry.estimatePrompt(request),
+    getTokenizer(
+      providerName: string,
+      model?: string,
+    ): RuntimeTokenizer | undefined {
+      const resolvedModel = model ?? providerName;
+      if (isSanctionedGpt56Model(resolvedModel)) {
+        return createGpt56RuntimeTokenizer(
+          providerName,
+          resolvedModel,
+          resolveGpt56Encoder,
+        );
+      }
+      const officialTokenizer = createOfficialRuntimeTokenizer(
+        providerName,
+        resolvedModel,
+      );
+      if (officialTokenizer !== undefined) {
+        return officialTokenizer;
+      }
+      const claudeTokenizer = createClaudeRuntimeTokenizer(
+        providerName,
+        resolvedModel,
+      );
+      if (claudeTokenizer !== undefined) {
+        return claudeTokenizer;
+      }
+      const providerKey = providerName.toLowerCase();
+      const modelKey = resolvedModel.toLowerCase();
+      if (
+        matchesTokenizer(providerKey, modelKey, ANTHROPIC_TOKENIZER_MATCHERS)
+      ) {
+        return new RuntimeTokenizerAdapter(
+          anthropicTokenizer,
+          model ?? providerName,
+        );
+      }
+      if (matchesTokenizer(providerKey, modelKey, OPENAI_TOKENIZER_MATCHERS)) {
+        return new RuntimeTokenizerAdapter(
+          openaiTokenizer,
+          model ?? providerName,
+        );
+      }
+      return undefined;
+    },
+  };
+}

--- a/packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts
+++ b/packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts
@@ -12,10 +12,20 @@ import type {
 } from '@vybestack/llxprt-code-core';
 import { ProviderContentGenerator } from '@vybestack/llxprt-code-providers';
 import { configureProviderRuntimeFactories } from '../composition/index.js';
+import { createRuntimeTokenizerFactory } from '../composition/runtimeTokenizerFactory.js';
+import { ModelPromptEstimatorError } from '../tokenizers/ModelPromptEstimatorError.js';
+import type { TiktokenModuleLoader } from '../tokenizers/o200kBaseCounter.js';
 import {
   activateIsolatedRuntimeContext,
   createIsolatedRuntimeContext,
 } from './runtimeSettings.js';
+
+async function captureRejection(operation: Promise<unknown>): Promise<unknown> {
+  return operation.then(
+    () => new Error('expected the operation to reject'),
+    (error: unknown) => error,
+  );
+}
 
 interface ConfigWithRuntimeFactories extends Config {
   getContentGeneratorFactory():
@@ -131,5 +141,232 @@ describe('configureProviderRuntimeFactories', () => {
       estimateRequest('claude-opus-5', 'zai'),
     );
     expect(proxied.family).toBe('legacy-unregistered');
+  });
+
+  it('preserves an explicitly injected tokenizer factory as the authoritative runtime factory', async () => {
+    const runtimeHandle = createIsolatedRuntimeContext({
+      runtimeId: 'provider-runtime-injected-tokenizer-factory',
+      workspaceDir: process.cwd(),
+      model: 'gpt-5.6-sol',
+      prepare: async () => {},
+    });
+    await activateIsolatedRuntimeContext(runtimeHandle, {
+      runtimeId: runtimeHandle.runtimeId,
+    });
+    const config = runtimeHandle.config as ConfigWithRuntimeFactories;
+    const injectedFactory = createRuntimeTokenizerFactory();
+    config.setTokenizerFactory(injectedFactory);
+
+    try {
+      configureProviderRuntimeFactories(config, runtimeHandle.providerManager);
+
+      expect(config.getTokenizerFactory()).toBe(injectedFactory);
+    } finally {
+      await runtimeHandle.cleanup();
+    }
+  });
+
+  it('prepares sanctioned GPT-5.6 readiness before exact runtime tokenization', async () => {
+    const factory = createRuntimeTokenizerFactory();
+    expect(factory.prepareTokenizer).toBeDefined();
+
+    await factory.prepareTokenizer?.('codex-alias', 'gpt-5.6-sol');
+    const tokenizer = factory.getTokenizer('codex-alias', 'gpt-5.6-sol');
+
+    expect(
+      await tokenizer?.countTokens(
+        'The quick brown fox jumps over the lazy dog.',
+      ),
+    ).toBe(10);
+  });
+
+  it('does not load the GPT-5.6 encoder while preparing another model', async () => {
+    const loaderFailure = new Error('GPT codec loader must remain unused');
+    const factory = createRuntimeTokenizerFactory(() =>
+      Promise.reject(loaderFailure),
+    );
+    expect(factory.prepareTokenizer).toBeDefined();
+
+    await expect(
+      factory.prepareTokenizer?.('openai', 'gpt-4.1'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('shares one cold injected initialization across concurrent readiness and later tokenization', async () => {
+    let releaseLoader = (): void => {
+      throw new Error('loader gate initialized without a resolver');
+    };
+    const loaderGate = new Promise<void>((resolve) => {
+      releaseLoader = resolve;
+    });
+    let loadCount = 0;
+    const loadModule: TiktokenModuleLoader = async () => {
+      loadCount += 1;
+      await loaderGate;
+      return import('@dqbd/tiktoken');
+    };
+    const factory = createRuntimeTokenizerFactory(loadModule);
+    const prepareTokenizer = factory.prepareTokenizer;
+    if (prepareTokenizer === undefined) {
+      throw new Error('runtime tokenizer factory has no readiness operation');
+    }
+
+    const readiness = Promise.all([
+      prepareTokenizer('codex-a', 'gpt-5.6-sol'),
+      prepareTokenizer('codex-b', 'gpt-5.6-terra-latest'),
+    ]);
+    await Promise.resolve();
+    const coldLoadCount = loadCount;
+    releaseLoader();
+    await readiness;
+
+    const first = factory.getTokenizer('codex-a', 'gpt-5.6-sol');
+    const second = factory.getTokenizer('codex-b', 'gpt-5.6-terra-latest');
+    expect(
+      await Promise.all([
+        first?.countTokens('The quick brown fox jumps over the lazy dog.'),
+        second?.countTokens('The quick brown fox jumps over the lazy dog.'),
+      ]),
+    ).toEqual([10, 10]);
+    expect(coldLoadCount).toBe(1);
+    expect(loadCount).toBe(1);
+  });
+
+  it('shares one cold injected encoder across concurrent readiness, runtime counting, and final estimation', async () => {
+    // A count distinct from the real o200k_base BPE count of the probe
+    // ("The quick brown fox jumps over the lazy dog." => 10) so the assertion
+    // catches any estimator that bypasses the injected encoder.
+    const injectedCount = 23;
+    let releaseLoader = (): void => {
+      throw new Error('loader gate initialized without a resolver');
+    };
+    const loaderGate = new Promise<void>((resolve) => {
+      releaseLoader = resolve;
+    });
+    let loadCount = 0;
+    const loadModule: TiktokenModuleLoader = async () => {
+      loadCount += 1;
+      await loaderGate;
+      return {
+        get_encoding: () => ({
+          encode: () =>
+            Array.from({ length: injectedCount }, (_unused, index) => index),
+        }),
+      } as unknown as Awaited<ReturnType<TiktokenModuleLoader>>;
+    };
+    const factory = createRuntimeTokenizerFactory(loadModule);
+    const prepareTokenizer = factory.prepareTokenizer;
+    if (prepareTokenizer === undefined) {
+      throw new Error('runtime tokenizer factory has no readiness operation');
+    }
+    const estimateRequest = {
+      activeProvider: 'codex-a',
+      canonicalModel: 'gpt-5.6-sol',
+      protocol: 'openai-responses' as const,
+      wireMethod: 'responses/v1' as const,
+      finalizedProjection: {
+        kind: 'llxprt-provider-prompt-v3' as const,
+        protocol: 'openai-responses' as const,
+        promptText: 'The quick brown fox jumps over the lazy dog.',
+      },
+      projectionRevision: 3,
+      legacyEstimate: () => Promise.resolve(999),
+    };
+
+    const readiness = Promise.all([
+      prepareTokenizer('codex-a', 'gpt-5.6-sol'),
+      prepareTokenizer('codex-b', 'gpt-5.6-terra-latest'),
+    ]);
+    const runtimeCount = factory
+      .getTokenizer('codex-a', 'gpt-5.6-sol')
+      ?.countTokens('The quick brown fox jumps over the lazy dog.');
+    const finalEstimate = factory.estimatePrompt(estimateRequest);
+    await Promise.resolve();
+    const coldLoadCount = loadCount;
+    releaseLoader();
+    await readiness;
+
+    expect(coldLoadCount).toBe(1);
+    expect(await runtimeCount).toBe(injectedCount);
+    const result = await finalEstimate;
+    expect(result).toMatchObject({
+      count: injectedCount,
+      method: 'exact',
+      family: 'openai-gpt-5.6',
+    });
+    expect(result.estimatorVersion).toBe('gpt-5.6-o200k-v1');
+    expect(loadCount).toBe(1);
+  });
+
+  it('reports preparation failure with estimator context and causal details', async () => {
+    const loaderFailure = new Error('relocated codec initialization exploded');
+    const factory = createRuntimeTokenizerFactory(() =>
+      Promise.reject(loaderFailure),
+    );
+    expect(factory.prepareTokenizer).toBeDefined();
+
+    const error = await captureRejection(
+      factory.prepareTokenizer?.('codex-alias', 'gpt-5.6-sol') ??
+        Promise.resolve(),
+    );
+
+    expect(error).toBeInstanceOf(ModelPromptEstimatorError);
+    expect(error).toMatchObject({
+      code: 'asset-unavailable',
+      context: {
+        activeProvider: 'codex-alias',
+        canonicalModel: 'gpt-5.6-sol',
+        protocol: 'openai-responses',
+        family: 'openai-gpt-5.6',
+      },
+      cause: loaderFailure,
+    });
+    if (!(error instanceof Error)) {
+      throw new Error('expected preparation to reject with an Error');
+    }
+    expect(error.message).toContain('relocated codec initialization exploded');
+  });
+
+  it('reports readiness probe encode failure with exact context and cause identity', async () => {
+    const encodeFailure = new Error('readiness probe encode exploded');
+    const loadModule: TiktokenModuleLoader = async () => {
+      const tiktoken = await import('@dqbd/tiktoken');
+      return {
+        ...tiktoken,
+        get_encoding: (...args: Parameters<typeof tiktoken.get_encoding>) =>
+          new Proxy(tiktoken.get_encoding(...args), {
+            get(target, property, receiver) {
+              if (property === 'encode') {
+                return (): never => {
+                  throw encodeFailure;
+                };
+              }
+              return Reflect.get(target, property, receiver);
+            },
+          }),
+      };
+    };
+    const factory = createRuntimeTokenizerFactory(loadModule);
+
+    const error = await captureRejection(
+      factory.prepareTokenizer?.('codex-alias', 'gpt-5.6-sol') ??
+        Promise.resolve(),
+    );
+
+    expect(error).toBeInstanceOf(ModelPromptEstimatorError);
+    expect(error).toMatchObject({
+      code: 'tokenization-failed',
+      context: {
+        activeProvider: 'codex-alias',
+        canonicalModel: 'gpt-5.6-sol',
+        protocol: 'openai-responses',
+        family: 'openai-gpt-5.6',
+      },
+      cause: encodeFailure,
+    });
+    if (!(error instanceof Error)) {
+      throw new Error('expected preparation to reject with an Error');
+    }
+    expect(error.message).toContain('readiness probe encode exploded');
   });
 });

--- a/packages/providers/src/runtime/runtimeContextFactory.ts
+++ b/packages/providers/src/runtime/runtimeContextFactory.ts
@@ -175,7 +175,7 @@ interface RuntimeActivationBindings {
 }
 
 interface RuntimeActivationState {
-  active: boolean;
+  cleanupRequired: boolean;
   currentRuntimeId: string;
   currentMetadata: Record<string, unknown>;
 }
@@ -378,6 +378,7 @@ function buildActivateClosure(
       ...baseMetadata,
       ...(activationOptions?.metadata ?? {}),
     };
+    state.cleanupRequired = true;
 
     const scope = {
       runtimeId: state.currentRuntimeId,
@@ -435,8 +436,6 @@ function buildActivateClosure(
       await Promise.resolve(
         bindings.linkProviderManager(config, providerManager),
       );
-
-      state.active = true;
     });
   };
 }
@@ -455,7 +454,7 @@ function buildCleanupClosure(
   options: IsolatedRuntimeContextOptions,
 ): () => Promise<void> {
   return async (): Promise<void> => {
-    if (!state.active && !options.onCleanup) {
+    if (!state.cleanupRequired && !options.onCleanup) {
       return;
     }
 
@@ -497,7 +496,7 @@ function buildCleanupClosure(
       }
     });
 
-    state.active = false;
+    state.cleanupRequired = false;
   };
 }
 
@@ -550,7 +549,7 @@ export function createIsolatedRuntimeContext(
     metadata: baseMetadata,
   });
   const activationState: RuntimeActivationState = {
-    active: false,
+    cleanupRequired: false,
     currentRuntimeId: runtimeId,
     currentMetadata: baseMetadata,
   };

--- a/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.test.ts
+++ b/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.test.ts
@@ -14,8 +14,15 @@ import {
   GPT_56_ASSET_REVISION,
   GPT_56_ESTIMATOR_FAMILY,
 } from './Gpt56O200kPromptEstimator.js';
-import { ModelPromptEstimatorRegistry } from './ModelPromptEstimatorRegistry.js';
+import {
+  ModelPromptEstimatorRegistry,
+  createDefaultEstimatorRegistrations,
+  GPT_56_PROMPT_ESTIMATOR_REGISTRATION,
+  type ModelPromptEstimatorRegistration,
+} from './ModelPromptEstimatorRegistry.js';
 import { ModelPromptEstimatorError } from './ModelPromptEstimatorError.js';
+import type { O200kBaseEncoder } from './o200kBaseCounter.js';
+import type { PromptEnvelopeProtocol } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
 
 /**
  * Runs `operation` expecting rejection and returns the rejection reason.
@@ -114,15 +121,18 @@ describe('GPT-5.6 o200k fixtures', () => {
     ['missing', new Error('Missing tiktoken_bg.wasm')],
     ['corrupt', new WebAssembly.CompileError('invalid wasm header')],
   ])(
-    'maps isolated %s codec initialization failures to asset-unavailable',
+    'maps isolated %s codec initialization failures to asset-unavailable with causal detail in the remediation message',
     async (_name, failure) => {
       const loadModule = () => Promise.reject(failure);
-      expect(
-        await captureRejection(estimateGpt56Prompt(request(), loadModule)),
-      ).toMatchObject({
+      const error = await captureRejection(
+        estimateGpt56Prompt(request(), loadModule),
+      );
+      expect(error).toMatchObject({
         code: 'asset-unavailable',
         cause: failure,
       });
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(failure.message);
     },
   );
 
@@ -249,5 +259,59 @@ describe('ModelPromptEstimatorRegistry', () => {
     expect(error).toBeInstanceOf(ModelPromptEstimatorError);
     expect(JSON.stringify(error)).not.toContain('secret prompt');
     expect(input.legacyEstimate).not.toHaveBeenCalled();
+  });
+});
+
+describe('createDefaultEstimatorRegistrations', () => {
+  const injectedCount = 42;
+
+  function resolveInjectedEncoder(): Promise<O200kBaseEncoder> {
+    return Promise.resolve({
+      encode: () =>
+        Array.from({ length: injectedCount }, (_unused, index) => index),
+    } as unknown as O200kBaseEncoder);
+  }
+
+  it('replaces the GPT-5.6 default registration with a resolver-bound estimator that counts through the injected encoder', async () => {
+    const registrations = createDefaultEstimatorRegistrations(
+      resolveInjectedEncoder,
+    );
+    const gpt56 = registrations.filter(
+      (registration) => registration.family === GPT_56_ESTIMATOR_FAMILY,
+    );
+    expect(gpt56).toHaveLength(1);
+    const result = await gpt56[0].estimate(request());
+    expect(result.count).toBe(injectedCount);
+  });
+
+  it('retains an additional non-GPT-5.6 default registration from the input list without duplicating GPT-5.6', () => {
+    const extraFamily = 'test-extra-default-family';
+    const extra: ModelPromptEstimatorRegistration = {
+      family: extraFamily,
+      claim: /^test-extra-default/,
+      matches: (model: string) => model.startsWith('test-extra-default'),
+      protocols: new Set<PromptEnvelopeProtocol>(['openai-responses']),
+      identityErrorHint: 'use a test-extra-default model',
+      estimate: async (estimateRequest) => ({
+        count: await estimateRequest.legacyEstimate(),
+        method: 'calibrated',
+        family: extraFamily,
+        estimatorVersion: 'test-extra-v1',
+        assetRevision: 'none',
+        projectionRevision: estimateRequest.projectionRevision,
+      }),
+    };
+    const registrations = createDefaultEstimatorRegistrations(
+      resolveInjectedEncoder,
+      [GPT_56_PROMPT_ESTIMATOR_REGISTRATION, extra],
+    );
+    expect(registrations).toHaveLength(2);
+    // The extra non-GPT-5.6 registration is retained by identity.
+    expect(registrations).toContain(extra);
+    // Exactly one GPT-5.6 entry — never duplicated.
+    const gpt56Count = registrations.filter(
+      (registration) => registration.family === GPT_56_ESTIMATOR_FAMILY,
+    ).length;
+    expect(gpt56Count).toBe(1);
   });
 });

--- a/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.ts
+++ b/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.ts
@@ -20,6 +20,7 @@ import {
   loadTiktokenModule,
   O200K_BASE_ASSET_REVISION,
   type O200kBaseEncoder,
+  type O200kBaseEncoderResolver,
   type TiktokenModuleLoader,
 } from './o200kBaseCounter.js';
 
@@ -58,13 +59,25 @@ function readProjection(
   return projection;
 }
 
-function createErrorContext(request: RuntimePromptEstimateRequest) {
+function createGpt56ErrorContext(
+  activeProvider: string,
+  canonicalModel: string,
+  protocol: RuntimePromptEstimateRequest['protocol'] = 'openai-responses',
+) {
   return {
-    activeProvider: request.activeProvider,
-    canonicalModel: request.canonicalModel,
-    protocol: request.protocol,
+    activeProvider,
+    canonicalModel,
+    protocol,
     family: GPT_56_ESTIMATOR_FAMILY,
   };
+}
+
+function createErrorContext(request: RuntimePromptEstimateRequest) {
+  return createGpt56ErrorContext(
+    request.activeProvider,
+    request.canonicalModel,
+    request.protocol,
+  );
 }
 
 function countProjectionTokens(
@@ -78,14 +91,73 @@ function countProjectionTokens(
   );
 }
 
-export async function estimateGpt56Prompt(
+function formatCausalDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function prepareGpt56RuntimeTokenizer(
+  activeProvider: string,
+  canonicalModel: string,
+  resolveEncoder: O200kBaseEncoderResolver = () => getO200kBaseEncoder(),
+): Promise<void> {
+  let encoder: TiktokenEncoder;
+  try {
+    encoder = await resolveEncoder();
+  } catch (error) {
+    throw new ModelPromptEstimatorError(
+      'asset-unavailable',
+      createGpt56ErrorContext(activeProvider, canonicalModel),
+      `verify the local @dqbd/tiktoken o200k_base assets are installed and intact; cause: ${formatCausalDetail(error)}`,
+      { cause: error },
+    );
+  }
+
+  try {
+    countO200kBaseTokens(encoder, 'readiness');
+  } catch (error) {
+    throw new ModelPromptEstimatorError(
+      'tokenization-failed',
+      createGpt56ErrorContext(activeProvider, canonicalModel),
+      `verify the local @dqbd/tiktoken o200k_base encoder can encode ordinary text; cause: ${formatCausalDetail(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+export function estimateGpt56Prompt(
   request: RuntimePromptEstimateRequest,
   loadModule: TiktokenModuleLoader = loadTiktokenModule,
+): Promise<RuntimePromptEstimateResult> {
+  return estimateGpt56PromptWithEncoder(request, () =>
+    getO200kBaseEncoder(loadModule),
+  );
+}
+
+/**
+ * Build a GPT-5.6 prompt estimator bound to a specific encoder resolver.
+ *
+ * The standalone {@link estimateGpt56Prompt} resolves the encoder from the
+ * caller-supplied loader or, when omitted, the process-wide shared encoder.
+ * A composition root that owns a factory-scoped resolver uses this so
+ * readiness, runtime tokenization, and final prompt-envelope estimation all
+ * share one encoder instance instead of diverging onto the process-wide one.
+ */
+export function createGpt56PromptEstimator(
+  resolveEncoder: O200kBaseEncoderResolver,
+): (
+  request: RuntimePromptEstimateRequest,
+) => Promise<RuntimePromptEstimateResult> {
+  return (request) => estimateGpt56PromptWithEncoder(request, resolveEncoder);
+}
+
+async function estimateGpt56PromptWithEncoder(
+  request: RuntimePromptEstimateRequest,
+  resolveEncoder: O200kBaseEncoderResolver,
 ): Promise<RuntimePromptEstimateResult> {
   const projection = readProjection(request);
   let encoder: TiktokenEncoder;
   try {
-    encoder = await getO200kBaseEncoder(loadModule);
+    encoder = await resolveEncoder();
   } catch (error) {
     throw new ModelPromptEstimatorError(
       'asset-unavailable',
@@ -140,6 +212,7 @@ function normalizeRuntimeTokenizerInput(
 export function createGpt56RuntimeTokenizer(
   activeProvider: string,
   canonicalModel: string,
+  resolveEncoder: O200kBaseEncoderResolver = () => getO200kBaseEncoder(),
 ): RuntimeTokenizer {
   return {
     fallbackPolicy: 'deny',
@@ -149,20 +222,23 @@ export function createGpt56RuntimeTokenizer(
         activeProvider,
         canonicalModel,
       );
-      const result = await estimateGpt56Prompt({
-        activeProvider,
-        canonicalModel,
-        protocol: 'openai-responses',
-        wireMethod: 'responses/v1',
-        finalizedProjection: {
-          kind: 'llxprt-provider-prompt-v3',
+      const result = await estimateGpt56PromptWithEncoder(
+        {
+          activeProvider,
+          canonicalModel,
           protocol: 'openai-responses',
-          promptText,
+          wireMethod: 'responses/v1',
+          finalizedProjection: {
+            kind: 'llxprt-provider-prompt-v3',
+            protocol: 'openai-responses',
+            promptText,
+          },
+          projectionRevision: PROJECTION_REVISION,
+          legacyEstimate: () =>
+            Promise.reject(new Error('unreachable legacy estimate')),
         },
-        projectionRevision: PROJECTION_REVISION,
-        legacyEstimate: () =>
-          Promise.reject(new Error('unreachable legacy estimate')),
-      });
+        resolveEncoder,
+      );
       return result.count;
     },
   };

--- a/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.ts
+++ b/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.ts
@@ -162,7 +162,7 @@ async function estimateGpt56PromptWithEncoder(
     throw new ModelPromptEstimatorError(
       'asset-unavailable',
       createErrorContext(request),
-      'verify the local @dqbd/tiktoken o200k_base assets are installed and intact',
+      `verify the local @dqbd/tiktoken o200k_base assets are installed and intact; cause: ${formatCausalDetail(error)}`,
       { cause: error },
     );
   }

--- a/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
+++ b/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
@@ -77,6 +77,31 @@ export const DEFAULT_MODEL_PROMPT_ESTIMATOR_REGISTRATIONS = Object.freeze([
   GPT_56_PROMPT_ESTIMATOR_REGISTRATION,
 ]);
 
+/**
+ * Build the default estimator registration list bound to a composition-root
+ * encoder resolver.
+ *
+ * Every entry in {@link DEFAULT_MODEL_PROMPT_ESTIMATOR_REGISTRATIONS} is
+ * retained as-is except the GPT-5.6 entry, which is replaced with a
+ * resolver-bound version so readiness, runtime tokenization, and final
+ * prompt-envelope estimation share one encoder. This prevents future
+ * divergence: adding a new default registration to the frozen list
+ * automatically flows into every composition root that calls this helper,
+ * without touching the factory.
+ */
+export function createDefaultEstimatorRegistrations(
+  resolveEncoder: O200kBaseEncoderResolver,
+  baseRegistrations: readonly ModelPromptEstimatorRegistration[] = DEFAULT_MODEL_PROMPT_ESTIMATOR_REGISTRATIONS,
+): readonly ModelPromptEstimatorRegistration[] {
+  return Object.freeze(
+    baseRegistrations.map((registration) =>
+      registration.family === GPT_56_ESTIMATOR_FAMILY
+        ? createGpt56PromptEstimatorRegistration(resolveEncoder)
+        : registration,
+    ),
+  );
+}
+
 function findClaim(
   canonicalModel: string,
   registrations: readonly ModelPromptEstimatorRegistration[],

--- a/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
+++ b/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
@@ -11,10 +11,12 @@ import type {
 import type { PromptEnvelopeProtocol } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
 import { isSanctionedGpt56Model } from '../openai/openaiModelPolicy.js';
 import {
+  createGpt56PromptEstimator,
   estimateGpt56Prompt,
   GPT_56_ESTIMATOR_FAMILY,
 } from './Gpt56O200kPromptEstimator.js';
 import { ModelPromptEstimatorError } from './ModelPromptEstimatorError.js';
+import type { O200kBaseEncoderResolver } from './o200kBaseCounter.js';
 
 export interface ModelPromptEstimatorRegistration {
   readonly family: string;
@@ -51,6 +53,25 @@ export const GPT_56_PROMPT_ESTIMATOR_REGISTRATION: ModelPromptEstimatorRegistrat
       'use a sanctioned GPT-5.6 base, sol, terra, or luna alias with latest or a valid date snapshot',
     estimate: estimateGpt56Prompt,
   });
+
+/**
+ * Bind the GPT-5.6 estimator registration to a factory-owned encoder resolver.
+ *
+ * Claim, identity, protocol, and provider-applicability policy are identical
+ * to the process-wide {@link GPT_56_PROMPT_ESTIMATOR_REGISTRATION}; only the
+ * encoder resolution is rebound. A composition root that injects a loader
+ * uses this so its final prompt-envelope estimation shares one encoder with
+ * readiness and runtime tokenization instead of falling back to the
+ * process-wide encoder.
+ */
+export function createGpt56PromptEstimatorRegistration(
+  resolveEncoder: O200kBaseEncoderResolver,
+): ModelPromptEstimatorRegistration {
+  return Object.freeze({
+    ...GPT_56_PROMPT_ESTIMATOR_REGISTRATION,
+    estimate: createGpt56PromptEstimator(resolveEncoder),
+  });
+}
 
 export const DEFAULT_MODEL_PROMPT_ESTIMATOR_REGISTRATIONS = Object.freeze([
   GPT_56_PROMPT_ESTIMATOR_REGISTRATION,

--- a/packages/providers/src/tokenizers/o200kBaseCounter.ts
+++ b/packages/providers/src/tokenizers/o200kBaseCounter.ts
@@ -51,6 +51,18 @@ export function getO200kBaseEncoder(
   return sharedEncoder;
 }
 
+export type O200kBaseEncoderResolver = () => Promise<O200kBaseEncoder>;
+
+export function createO200kBaseEncoderResolver(
+  loadModule: TiktokenModuleLoader = loadTiktokenModule,
+): O200kBaseEncoderResolver {
+  if (loadModule === loadTiktokenModule) {
+    return () => getO200kBaseEncoder();
+  }
+  let encoder: Promise<O200kBaseEncoder> | undefined;
+  return () => (encoder ??= getO200kBaseEncoder(loadModule));
+}
+
 /**
  * Count `text` as ordinary BPE text. Special-token-looking text is encoded as
  * its constituent bytes and can never be promoted to a control token.

--- a/project-plans/issue3217/PLAN.md
+++ b/project-plans/issue3217/PLAN.md
@@ -1,0 +1,216 @@
+# PLAN-20260813-ISSUE3217 — Initialize mandatory prompt estimators before agent readiness
+
+Issue: #3217 — Intermittent GPT-5.6 prompt-estimator initialization failure during interactive initial-prompt startup
+
+## Symptom
+
+A Jefe-launched interactive LLxprt session with an initial `-i` prompt can fail its
+first chat with:
+
+    Failed to initialize chat: Prompt estimator asset-unavailable for gpt-5.6-sol (openai-responses)
+
+Restarting the LLxprt process and entering a prompt manually succeeds, and another
+apparently identical Jefe launch may also succeed.
+
+## Root cause
+
+The provider composition root registers a lazy GPT-5.6 runtime tokenizer. The
+mandatory local `o200k_base` encoder is first initialized only when
+`ChatSessionFactory` accounts for the first chat's system prompt:
+
+    ChatSessionFactory.applySystemPromptTokenOffset
+      -> HistoryService.estimateTokensForText
+      -> createGpt56RuntimeTokenizer.countTokens
+      -> estimateGpt56Prompt
+      -> getO200kBaseEncoder
+
+`getO200kBaseEncoder` memoizes its initialization Promise. If the first module load
+or `get_encoding('o200k_base')` operation rejects, that rejected Promise remains
+cached for the process. `estimateGpt56Prompt` then maps every causal exception to
+the generic `asset-unavailable` diagnostic.
+
+Interactive startup renders before starting an unawaited update check. The initial
+`-i` prompt can submit independently. If an update is available,
+`handleAutoUpdate` starts a detached global package-manager install that replaces
+the package tree while a process may still be performing first-use dependency
+initialization. The update lock serializes writers only; it does not protect
+readers. Local npm logs and live-process mappings verify that global replacement
+and old-tree readers coexist. Concurrent startup against a stable tree succeeds,
+so Jefe process concurrency by itself is not the cause.
+
+## Requirements
+
+### REQ-3217-001 — Readiness invariant
+
+**Full text:** A finalized active provider/model that requires a mandatory exact
+prompt estimator must initialize that estimator before the foreground Agent is
+reported ready.
+
+**Behavior:**
+
+- GIVEN the active model is a sanctioned GPT-5.6 identity
+- WHEN `fromConfig` completes provider activation
+- THEN the shared local `o200k_base` encoder is initialized and proves it can
+  encode ordinary text before `fromConfig` returns the Agent
+
+### REQ-3217-002 — Exact accounting only
+
+**Full text:** GPT-5.6 readiness and later prompt accounting must use the same exact
+shared encoder and must not introduce a heuristic fallback, retry loop, or swallowed
+initialization error.
+
+**Behavior:**
+
+- GIVEN GPT-5.6 readiness completed successfully
+- WHEN the first chat estimates its system prompt
+- THEN exact token accounting succeeds through the already-initialized encoder
+
+### REQ-3217-003 — Fail-fast causal diagnostic
+
+**Full text:** If the mandatory encoder cannot initialize, Agent bootstrap must
+fail before interactive lifecycle startup or initial-prompt submission and retain
+the underlying loader or codec failure in the displayed diagnostic.
+
+**Behavior:**
+
+- GIVEN the local tokenizer module or codec initialization fails
+- WHEN Agent bootstrap prepares the active estimator
+- THEN bootstrap rejects with the estimator context and causal error text
+- AND no ready Agent is returned
+
+### REQ-3217-004 — Concurrency
+
+**Full text:** Concurrent readiness callers in one process must share initialization
+and observe the same usable encoder or the same initialization failure.
+
+## Integration contract
+
+1. The providers package owns model recognition and estimator preparation.
+2. The core-owned `RuntimeTokenizerFactory` contract exposes an asynchronous,
+   provider/model-scoped preparation operation without importing provider types.
+3. The agents package invokes that operation after activation has finalized the
+   active provider/model and before `finalizeAgent` returns a ready Agent.
+4. The CLI remains a thin client. It receives no ready Agent if preparation fails,
+   so interactive rendering, `setupInstanceLifecycle`, auto-update, and the `-i`
+   submission path cannot begin for that process.
+5. Later `HistoryService` accounting obtains the same runtime tokenizer and shared
+   process-wide encoder.
+
+## Pseudocode
+
+1. DEFINE `RuntimeTokenizerFactory.prepareTokenizer(providerName, model)` as an
+   optional asynchronous composition-boundary operation.
+2. IN the providers runtime-tokenizer factory implementation:
+   1. RESOLVE model from explicit model or provider name.
+   2. IF model is not a sanctioned GPT-5.6 model, RETURN without work.
+   3. AWAIT the shared `o200k_base` encoder.
+   4. ENCODE a small fixed ordinary-text probe.
+   5. IF load or encoding fails, THROW `ModelPromptEstimatorError` with active
+      provider, model, protocol, family, remediation, and the causal error.
+3. IN `fromConfig`, after activation resolves:
+   1. RESOLVE active provider from the post-activation manager, falling back to
+      `config.getProvider()` only when needed.
+   2. AWAIT `config.getTokenizerFactory()?.prepareTokenizer(activeProvider,
+      config.getModel())`.
+   3. ONLY THEN build parsed config and finalize the Agent.
+4. ENSURE error formatting retains the causal error message for this readiness
+   failure.
+
+## Test-first phases
+
+### Phase 1 — RED: provider preparation behavior
+
+Add Bun behavioral tests that exercise the real provider factory seam:
+
+- a sanctioned GPT-5.6 model prepares exact `o200k_base` accounting;
+- a non-GPT model performs no mandatory GPT preparation;
+- simultaneous GPT readiness calls both produce a usable exact tokenizer;
+- an injected module/codec failure rejects with estimator context and causal text.
+
+Tests assert returned counts and user-visible errors, not collaborator call counts.
+
+### Phase 2 — RED: Agent bootstrap ordering
+
+Add a Bun behavioral test through `fromConfig` proving that a mandatory preparation
+failure prevents a ready Agent from being returned, while successful preparation
+completes before the returned Agent's tokenizer is first used. Reuse existing real
+runtime/config test fixtures rather than creating a parallel bootstrap path.
+
+### Phase 3 — GREEN: implementation
+
+Implement the core contract, provider preparation operation, and `fromConfig`
+integration exactly at the post-activation/pre-finalization boundary. Preserve the
+single-Agent and single-provider-manager architecture.
+
+### Phase 4 — Integration/runtime regression
+
+Extend the relocated GPT bundle fixture through the production readiness operation
+where practical. Verify the bundle still externalizes `@dqbd/tiktoken`, can run
+beside a relocated dependency tree, and produces an exact pinned count. Do not copy
+WASM into `bundle/` or reverse externalization.
+
+## Remediation architecture
+
+- `fromConfig` treats the isolated runtime handle as transaction-owned until
+  `finalizeAgent` returns. Activation, initialization, finalized provider/model
+  activation, tokenizer readiness, and Agent finalization execute inside one
+  failure boundary. Rejection awaits handle cleanup; a cleanup failure is composed
+  after the primary bootstrap failure in an ordered `AggregateError`.
+- Isolated runtime handles track cleanup obligation from activation start rather
+  than only successful activation, so partial activation can be disposed by the
+  same transaction.
+- Provider composition installs a default tokenizer factory only when Config has
+  none. An explicit caller-injected factory therefore remains the single factory
+  observed by Config, ProviderManager, HistoryService, and Agent. `fromConfig`
+  resolves that authoritative factory only after activation.
+- The runtime tokenizer factory moved to a narrow composition module so bundle and
+  relocation tests can exercise the production readiness API without pulling
+  unrelated provider-manager/keyring assets into the fixture.
+- Every factory owns an encoder resolver. The production resolver delegates to the
+  existing process-wide encoder Promise; an injected loader receives a factory-local
+  memoized encoder Promise shared by readiness and later GPT runtime tokenization.
+- The production CLI topology remains the gate: `main` awaits
+  `constructForegroundAgentAndDispatch`, which awaits `constructAgentWithSpinner`,
+  which awaits `createForegroundAgent`/`fromConfig` before calling the shared
+  interactive/non-interactive dispatcher. The `fromConfig` behavioral test proves
+  readiness cannot return an Agent before completion and rejects transactionally.
+  A separate `main` acceptance test was not retained because importing the full CLI
+  entry under an isolated Bun module mock deadlocks before test execution; reproducing
+  the orchestrator with mock call-order assertions would test the double, not behavior.
+- Relocation coverage now calls production factory readiness, renames the relocated
+  `@dqbd/tiktoken` package tree after preparation, and then performs the first exact
+  runtime estimate. This proves post-readiness accounting does not re-read a package
+  tree that an updater may replace.
+
+## Verification
+
+Focused:
+
+    bun test packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.test.ts
+    bun test packages/agents/src/api/__tests__/fromConfig.behavior.test.ts
+    bun test scripts/tests/gpt56-bundle-runtime.test.ts
+    bun test scripts/tests/issue-3055-tiktoken-relocated.bun.test.ts
+
+Full gate:
+
+    npm run test
+    npm run lint
+    npm run typecheck
+    npm run format
+    npm run build
+    bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+
+Because this changes interactive startup ordering, verify an interactive `-i` launch
+in the tmux harness before creating the PR.
+
+## Constraints
+
+- New and changed tests use TypeScript with `bun:test`; do not add or modify
+  Vitest/Node suites.
+- No new `eslint-disable`, TypeScript suppression directive, lint severity
+  downgrade, ignored source path, or complexity/size threshold increase.
+- No heuristic fallback, silent retry, swallowed exception, or downstream guard
+  around chat creation. Establish the invariant at startup.
+- Do not copy tokenizer assets into the CLI bundle and do not alter intentional
+  tiktoken externalization.
+- Do not modify `.llxprt/` contents.

--- a/scripts/tests/fixtures/gpt56-bundle-smoke.ts
+++ b/scripts/tests/fixtures/gpt56-bundle-smoke.ts
@@ -7,7 +7,12 @@
 import { createRuntimeTokenizerFactory } from '../../../packages/providers/src/composition/runtimeTokenizerFactory.js';
 
 const factory = createRuntimeTokenizerFactory();
-await factory.prepareTokenizer?.('codex-alias', 'gpt-5.6-sol');
+if (typeof factory.prepareTokenizer !== 'function') {
+  throw new Error(
+    'production factory must expose prepareTokenizer for mandatory model readiness',
+  );
+}
+await factory.prepareTokenizer('codex-alias', 'gpt-5.6-sol');
 const tokenizer = factory.getTokenizer('codex-alias', 'gpt-5.6-sol');
 if (tokenizer === undefined) {
   throw new Error('production factory did not provide the GPT-5.6 tokenizer');

--- a/scripts/tests/fixtures/gpt56-bundle-smoke.ts
+++ b/scripts/tests/fixtures/gpt56-bundle-smoke.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { get_encoding } from '@dqbd/tiktoken';
+import { createRuntimeTokenizerFactory } from '../../../packages/providers/src/composition/runtimeTokenizerFactory.js';
 
-const encoder = get_encoding('o200k_base');
-try {
-  process.stdout.write(
-    `${encoder.encode('The quick brown fox jumps over the lazy dog.', [], []).length}\n`,
-  );
-} finally {
-  encoder.free();
+const factory = createRuntimeTokenizerFactory();
+await factory.prepareTokenizer?.('codex-alias', 'gpt-5.6-sol');
+const tokenizer = factory.getTokenizer('codex-alias', 'gpt-5.6-sol');
+if (tokenizer === undefined) {
+  throw new Error('production factory did not provide the GPT-5.6 tokenizer');
 }
+process.stdout.write(
+  `${await tokenizer.countTokens('The quick brown fox jumps over the lazy dog.')}\n`,
+);

--- a/scripts/tests/gpt56-bundle-runtime.test.ts
+++ b/scripts/tests/gpt56-bundle-runtime.test.ts
@@ -82,7 +82,7 @@ await Bun.build({
   format: 'esm',
   plugins: [portableTiktokenPlugin],
   conditions: ['production'],
-  banner: "import { fileURLToPath } from 'node:url'; import { dirname } from 'node:path'; globalThis.__dirname = dirname(fileURLToPath(import.meta.url));",
+  banner: "import { fileURLToPath as __llxprtFileURLToPath } from 'node:url'; import { dirname as __llxprtDirname } from 'node:path'; globalThis.__dirname = __llxprtDirname(__llxprtFileURLToPath(import.meta.url));",
 });
 `,
   );

--- a/scripts/tests/issue-3055-tiktoken-relocated.bun.test.ts
+++ b/scripts/tests/issue-3055-tiktoken-relocated.bun.test.ts
@@ -7,12 +7,14 @@
 /**
  * Issue #3055 — automated form of the manual "hide the package" reproduction.
  *
- * Builds a fixture that imports `@dqbd/tiktoken` and encodes a string, using
- * the CLI bundle's external policy (`cliBundleConfig.external`). The built
- * fixture is resolved against a *temporary* `node_modules` tree that this test
- * creates and owns (a copy of the real `@dqbd/tiktoken` package), then the
- * bundle is relocated next to a *fresh* `node_modules`, the original build
- * tree is deleted, and the relocated bundle is executed.
+ * Builds a fixture that uses the production runtime tokenizer factory readiness
+ * API and exact GPT-5.6 tokenization under the CLI bundle's external policy
+ * (`cliBundleConfig.external`). The built fixture is resolved against a
+ * *temporary* `node_modules` tree that this test creates and owns (a copy of the
+ * real `@dqbd/tiktoken` package), then the bundle is relocated next to a *fresh*
+ * `node_modules`, the original build tree is deleted, and the relocated bundle
+ * is executed. After readiness, the fixture renames the runtime package tree
+ * before its first exact estimate to model concurrent package replacement.
  *
  * - On main, `cliBundleConfig.external` does NOT include `@dqbd/tiktoken`, so
  *   the fixture inlines it with a build-machine `__dirname`; relocated away
@@ -113,12 +115,19 @@ describe('issue #3055: tiktoken resolves from a relocated node_modules', () => {
     writeFileSync(
       entry,
       [
-        `import { get_encoding } from '@dqbd/tiktoken';`,
-        `import { writeFileSync } from 'node:fs';`,
-        `const encoder = get_encoding('o200k_base');`,
-        `const tokens = encoder.encode('hello world', [], []);`,
-        `writeFileSync(process.env.RESULT_FILE, String(tokens.length));`,
-        `encoder.free();`,
+        `import { renameSync, writeFileSync } from 'node:fs';`,
+        `import { createRuntimeTokenizerFactory } from ${JSON.stringify(join(repoRoot, 'packages/providers/src/composition/runtimeTokenizerFactory.ts'))};`,
+        `const factory = createRuntimeTokenizerFactory();`,
+        `await factory.prepareTokenizer?.('codex-alias', 'gpt-5.6-sol');`,
+        `const sourceTree = process.env.TIKTOKEN_SOURCE_DIR;`,
+        `if (!sourceTree) throw new Error('TIKTOKEN_SOURCE_DIR is required');`,
+        `renameSync(sourceTree, sourceTree + '.replaced');`,
+        `const tokenizer = factory.getTokenizer('codex-alias', 'gpt-5.6-sol');`,
+        `if (!tokenizer) throw new Error('GPT-5.6 tokenizer unavailable');`,
+        `const count = await tokenizer.countTokens('hello world');`,
+        `const resultFile = process.env.RESULT_FILE;`,
+        `if (!resultFile) throw new Error('RESULT_FILE is required');`,
+        `writeFileSync(resultFile, String(count));`,
         '',
       ].join('\n'),
     );
@@ -172,7 +181,11 @@ describe('issue #3055: tiktoken resolves from a relocated node_modules', () => {
       cwd: runDir,
       encoding: 'utf8',
       timeout: 60_000,
-      env: { ...process.env, RESULT_FILE: resultFile },
+      env: {
+        ...process.env,
+        RESULT_FILE: resultFile,
+        TIKTOKEN_SOURCE_DIR: join(runDir, 'node_modules', '@dqbd', 'tiktoken'),
+      },
     });
 
     expect(proc.error).toBeUndefined();


### PR DESCRIPTION
## TLDR

Prepare GPT-5.6's mandatory exact o200k tokenizer after provider/model activation and before an Agent is considered ready. This prevents interactive initial prompts from being the first tokenizer user while a detached global update may be replacing the installation tree.

The change also preserves causal startup diagnostics and cleans partially activated isolated runtimes if readiness fails.

## Dive Deeper

The previous flow registered the GPT-5.6 tokenizer synchronously but deferred loading and probing o200k_base until first-chat system-prompt accounting. Interactive startup could render and begin update lifecycle work before that first use. If package replacement overlapped lazy initialization, the first rejected encoder promise remained cached for that process and chat initialization failed with a generic asset-unavailable error.

This PR establishes a readiness invariant at the provider composition boundary:

- RuntimeTokenizerFactory exposes an optional asynchronous preparation hook.
- The agents fromConfig path activates the authoritative provider/model, awaits tokenizer preparation, and only then finalizes the Agent.
- Sanctioned GPT-5.6 identities initialize and probe the exact shared encoder; other models do not load it.
- Default loading retains process-wide sharing. Injected loaders use one factory-local resolver shared by readiness, runtime counting, and final prompt-envelope estimation.
- Readiness failures retain their original cause and trigger transactional cleanup of partially activated runtime state.
- The broad tokenizer factory was extracted from providerManagerInstance so bundle/runtime fixtures can exercise the production factory without importing the singleton composition graph.
- Bundle and relocation coverage confirms the externally installed tiktoken package remains usable after readiness and source-tree replacement.

No heuristic token fallback, silent retry, bundled-WASM workaround, or tiktoken externalization change is introduced.

## Reviewer Test Plan

1. Run the focused behavioral and integration suite:

       bun test packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.test.ts packages/providers/src/tokenizers/Gpt56ProviderUsageParity.test.ts packages/providers/src/tokenizers/official/providerFramingSeparation.test.ts packages/providers/src/tokenizers/claude/claudePromptEstimator.test.ts packages/agents/src/api/__tests__/fromConfig.behavior.test.ts scripts/tests/gpt56-bundle-runtime.test.ts scripts/tests/issue-3055-tiktoken-relocated.bun.test.ts

2. Run repository verification:

       npm run typecheck
       npm run build

3. Exercise startup:

       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

4. In a real TTY, exercise the initial-prompt path:

       bun scripts/start.ts --profile-load stepfun-37 -i "write me a haiku and nothing else"

Expected: Agent startup waits for required tokenizer readiness, the prompt completes, and no prompt-estimator asset-unavailable initialization error appears.

Local results:

- Focused suite: 128 passed, 0 failed.
- Repository typecheck: passed.
- Repository build: passed.
- Targeted ESLint, Prettier, and diff checks: passed.
- Noninteractive profile smoke: passed.
- Real-TTY interactive initial prompt: completed successfully with no estimator initialization error.
- Full root test/lint commands were attempted, but the local command watchdog terminated the long-running unscoped invocations without diagnostics; focused changed-area suites and affected checks pass.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime tokenizer support for GPT-5.6, Anthropic, Claude, OpenAI-compatible models, and official estimators.
  * Added tokenizer preparation so models are ready before agent interactions begin.
  * Improved token counting with lazy loading and custom encoder configurations.

* **Bug Fixes**
  * Agent creation now waits for tokenizer readiness, including before streaming interactions.
  * Preparation failures retain useful error details and clean up incomplete runtime state.
  * Existing tokenizer configurations are preserved instead of being replaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->