### PR TITLE
Classify hooks settings as internal so they never reach API requests (Fixes #3218)

### DIFF
--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.hooksConfigLeak.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.hooksConfigLeak.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue #3218 — hooksConfig (llxprt hooks-system config) was leaking into
+ * the outbound API request body, causing `400 Unsupported parameter:
+ * hooksConfig` from the Codex / OpenAI Responses backend.
+ *
+ * Root cause: separateSettings() treated unknown settings keys as model
+ * params (pass-through). hooksConfig was not registered, so it landed in
+ * modelParams and was serialized into the request body.
+ *
+ * Fix: classify hooksConfig and hooks as INTERNAL_SETTINGS_KEYS so they
+ * route to cliSettings, never modelParams.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'bun:test';
+import { OpenAIResponsesProvider } from '../OpenAIResponsesProvider.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  createProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+  clearActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import type {
+  CodexOAuthToken,
+  OAuthManager,
+} from '@vybestack/llxprt-code-auth';
+
+const originalFetch = global.fetch;
+const mockFetch = vi.fn();
+
+function createMockStreamingResponse() {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode('data: {"type":"content.delta","delta":"test"}\n\n'),
+      );
+      controller.enqueue(
+        encoder.encode(
+          'data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}\n\n',
+        ),
+      );
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+const MOCK_CODEX_TOKEN: CodexOAuthToken = {
+  access_token: 'test-access-token',
+  token_type: 'Bearer',
+  expiry: Math.floor(Date.now() / 1000) + 3600,
+  account_id: 'test-account-id',
+};
+
+describe('OpenAIResponsesProvider hooksConfig leak @issue:3218', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockClear();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    setActiveProviderRuntimeContext(
+      createProviderRuntimeContext({
+        settingsService: new SettingsService(),
+        runtimeId: 'test-runtime-id-3218',
+      }),
+    );
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+    global.fetch = originalFetch;
+  });
+
+  async function generateAndCaptureBody(
+    provider: OpenAIResponsesProvider,
+    settings: SettingsService,
+    ephemeralsSnapshot: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    let capturedBody: string | undefined;
+    mockFetch.mockImplementation(
+      async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        if (init?.body != null) {
+          capturedBody =
+            typeof init.body === 'string'
+              ? init.body
+              : await new Response(init.body).text();
+        }
+        return createMockStreamingResponse();
+      },
+    );
+
+    const config = createRuntimeConfigStub(settings);
+    const runtime = createProviderRuntimeContext({
+      settingsService: settings,
+      runtimeId: 'test-runtime-id-3218',
+      config,
+    });
+
+    const invocation = createRuntimeInvocationContext({
+      runtime,
+      settings,
+      providerName: provider.name,
+      ephemeralsSnapshot,
+    });
+
+    const options = createProviderCallOptions({
+      settings,
+      config,
+      runtime,
+      invocation,
+      providerName: provider.name,
+      contents: [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'hi' }],
+        },
+      ],
+    });
+
+    const generator = provider.generateChatCompletion(options);
+    for await (const _content of generator) {
+      // drain
+    }
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(capturedBody).toBeDefined();
+    return JSON.parse(capturedBody!);
+  }
+
+  it('does not send hooksConfig in the Codex request body', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-access-token',
+      'https://chatgpt.com/backend-api/codex',
+      undefined,
+      {
+        getOAuthToken: vi.fn().mockResolvedValue(MOCK_CODEX_TOKEN),
+      } as unknown as OAuthManager,
+    );
+
+    const settings = new SettingsService();
+    settings.set('activeProvider', provider.name);
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.6-sol');
+
+    const requestBody = await generateAndCaptureBody(provider, settings, {
+      hooksConfig: { enabled: true, notifications: false },
+      temperature: 0.7,
+    });
+
+    expect(requestBody.hooksConfig).toBeUndefined();
+    // Legitimate model params still pass through
+    expect(requestBody.temperature).toBe(0.7);
+  });
+
+  it('does not send hooks (event definitions) in the Codex request body', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-access-token',
+      'https://chatgpt.com/backend-api/codex',
+      undefined,
+      {
+        getOAuthToken: vi.fn().mockResolvedValue(MOCK_CODEX_TOKEN),
+      } as unknown as OAuthManager,
+    );
+
+    const settings = new SettingsService();
+    settings.set('activeProvider', provider.name);
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.6-sol');
+
+    const requestBody = await generateAndCaptureBody(provider, settings, {
+      hooks: { beforeModel: [{ command: 'echo hi', type: 'command' }] },
+    });
+
+    expect(requestBody.hooks).toBeUndefined();
+  });
+
+  it('does not send hooksConfig in a non-Codex Responses request body', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-api-key',
+      'https://api.openai.com/v1',
+    );
+
+    const settings = new SettingsService();
+    settings.set('activeProvider', provider.name);
+    settings.setProviderSetting(provider.name, 'model', 'o3-mini');
+
+    const requestBody = await generateAndCaptureBody(provider, settings, {
+      hooksConfig: { enabled: true },
+    });
+
+    expect(requestBody.hooksConfig).toBeUndefined();
+  });
+});

--- a/packages/settings/src/__tests__/settingsRegistry.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.test.ts
@@ -295,6 +295,50 @@ describe('separateSettings — settings categorization', () => {
       expect(result.modelParams.temperature).toBe(0.5);
     });
   });
+
+  describe('hooks system config never leaks into modelParams @issue:3218', () => {
+    it('places hooksConfig in cliSettings, never modelParams', () => {
+      const result = separateSettings({
+        hooksConfig: { enabled: true, notifications: false },
+      });
+      expect(result.modelParams.hooksConfig).toBeUndefined();
+      expect(result.cliSettings.hooksConfig).toStrictEqual({
+        enabled: true,
+        notifications: false,
+      });
+    });
+
+    it('places hooks (event definitions) in cliSettings, never modelParams', () => {
+      const hooks = {
+        beforeModel: [{ command: 'echo hi', type: 'command' as const }],
+      };
+      const result = separateSettings({ hooks });
+      expect(result.modelParams.hooks).toBeUndefined();
+      expect(result.cliSettings.hooks).toStrictEqual(hooks);
+    });
+
+    it('does not leak hooksConfig into modelParams for the codex provider', () => {
+      const result = separateSettings(
+        {
+          hooksConfig: { enabled: true, disabled: [] },
+          temperature: 0.7,
+        },
+        'codex',
+      );
+      expect(result.modelParams.hooksConfig).toBeUndefined();
+      // Legitimate model params still pass through
+      expect(result.modelParams.temperature).toBe(0.7);
+    });
+
+    it('does not leak hooksConfig into modelParams for the openai provider', () => {
+      const result = separateSettings(
+        { hooksConfig: { enabled: false } },
+        'openai',
+      );
+      expect(result.modelParams.hooksConfig).toBeUndefined();
+      expect(result.modelBehavior.hooksConfig).toBeUndefined();
+    });
+  });
 });
 
 describe('validateSetting — validation', () => {

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -125,6 +125,12 @@ const INTERNAL_SETTINGS_KEYS = new Set([
   'activeProvider',
   'currentProfile',
   'tools',
+  // Hooks system configuration is llxprt-internal config, never a model
+  // parameter. Without this classification, separateSettings() falls through
+  // to the unknown-key pass-through and leaks the objects onto API request
+  // bodies, which backends reject (issue #3218).
+  'hooksConfig',
+  'hooks',
 ]);
 
 export function isInternalSettingKey(key: string): boolean {


### PR DESCRIPTION
## TLDR

Fixes a model-config leak where `hooksConfig` (and `hooks`) — llxprt-internal hooks-system configuration — was serialized into outbound API request bodies, causing backends to reject requests with `400 Unsupported parameter: hooksConfig`. The root cause is a single missing classification in the settings registry: unknown keys default to the `modelParams` pass-through bucket and flow to the wire.

## Dive Deeper

### Root cause

When settings flow from the global settings store into the runtime invocation context, they pass through `separateSettings()` (settings package). This function categorizes each key into one of four buckets: `cliSettings`, `modelBehavior`, `modelParams`, or `customHeaders`. Keys not registered in `SETTINGS_REGISTRY` and not in `INTERNAL_SETTINGS_KEYS` fall through to the **unknown-key default**: `modelParams` (pass-through to API).

`hooksConfig` (the hooks-system toggle/notifications/disabled config) and `hooks` (hook event definitions) were never registered in the settings package's `SETTINGS_REGISTRY`. They are defined in the CLI's settings schema (for the dialog UI) but that schema is separate from the settings package's runtime categorization registry. So both keys were treated as unknown and routed to `modelParams`.

The data flow:
1. Global settings (including `hooksConfig`) are loaded into the ephemerals snapshot via `buildEphemeralsSnapshot()`
2. `separateSettings()` categorizes the snapshot — `hooksConfig` falls through to `modelParams` because it has no spec
3. `modelParams` is spread into the request body by the provider's request builder
4. The API rejects the unknown `hooksConfig` parameter with HTTP 400

### Fix

Add `hooksConfig` and `hooks` to `INTERNAL_SETTINGS_KEYS` in `packages/settings/src/settings/settingsRegistry.ts`. This is the same classification used for the `tools` object — another llxprt-internal config that must never reach the API. Both keys now route to `cliSettings` instead of `modelParams`, keeping them available to the CLI via `context.getCliSetting()` while preventing serialization onto any request body.

This fixes the leak for **all providers** (Codex/OpenAI Responses, OpenAI Chat Completions, Anthropic, Gemini), not just the Codex path where it was observed.

### Files changed

- `packages/settings/src/settings/settingsRegistry.ts` — Add `hooksConfig` and `hooks` to `INTERNAL_SETTINGS_KEYS`
- `packages/settings/src/__tests__/settingsRegistry.test.ts` — 4 behavioral tests proving both keys route to cliSettings, not modelParams, across providers
- `packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.hooksConfigLeak.test.ts` — 3 end-to-end provider tests proving `hooksConfig`/`hooks` do not appear in the Codex and non-Codex Responses request bodies

## Reviewer Test Plan

1. **Settings-level**: Run `bun test packages/settings/src/__tests__/settingsRegistry.test.ts` and verify the 4 new tests under "hooks system config never leaks into modelParams" pass.

2. **Provider-level**: Run `bun test packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.hooksConfigLeak.test.ts` and verify the 3 tests pass. These tests construct a real `OpenAIResponsesProvider` in Codex mode, inject `hooksConfig` into the ephemerals snapshot, capture the fetch request body, and assert `hooksConfig` is absent.

3. **Regression verification**: Temporarily revert the `settingsRegistry.ts` change and re-run the provider tests — they will fail with `hooksConfig` present in the request body, confirming the tests are genuine regression guards.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: typecheck, lint, eslint guard, format, build, smoke test, settings + providers + core workspace test suites all pass.

## Linked issues / bugs

Fixes #3218


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented internal hook settings from being sent in OpenAI and Codex model requests.
  * Preserved legitimate model parameters during request processing.
  * Improved settings classification so hook configuration remains application-level rather than affecting model behavior.

* **Tests**
  * Added regression coverage for request serialization and settings handling across supported OpenAI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->