### PR TITLE
Prevent oversized images from poisoning sessions (Fixes #3216)

### DIFF
--- a/docs/reference/ephemerals.md
+++ b/docs/reference/ephemerals.md
@@ -93,6 +93,21 @@ Prevent tools from flooding the context. Applied to all tools via the batch sche
 
 Built-in visual-model aliases provide conservative advisory defaults: Claude Opus/Sonnet use `1568`/`1568`/`1229312`; OpenAI `gpt-*` uses `2048`/`2048`/`1572864`; Kimi uses `4096`/`2160`/`8847360` (long edge/short edge/pixels). These are useful-resolution targets, not universal provider hard limits. Explicit profile values take precedence over model defaults. When no limit is configured, image reads retain legacy byte-for-byte behavior. Setting `image-resize.enabled false` disables all automatic limits for the profile. For one `read_file` call, pass `skip_image_resize: true` to return the original image; `read_many_files` has no per-call opt-out.
 
+## Hard Image Dimension Budget
+
+In addition to advisory image resizing, `max-image-dimension` and `max-image-pixels` define **hard** limits that reject oversized image bytes with an actionable tool error before they reach the model. Unlike `image-resize.*` (which silently downscales), these settings cause `read_file`, `read_many_files`, and `generate_image` to return a structured error message instructing the model to create a smaller thumbnail. For `generate_image`, the budget check runs after the generated image is written to its `output_path`; an oversized result is reported as a `policy_violation` tool error (no inline bytes enter the conversation), but the saved file is retained and the error names its path so the model can downscale/thumbnail it before reading.
+
+Explicit `image-resize.*` resizing runs **first**; the hard check runs **after**, so a resized image within budget passes through normally. Only images whose post-resize dimensions still exceed the budget are rejected.
+
+| Setting               | Type   | Default | Profile | Description                                                                                                       |
+| --------------------- | ------ | ------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `max-image-dimension` | number | —       | yes     | Positive integer maximum for image width/height in pixels. Oversized images return a tool error instead of bytes. |
+| `max-image-pixels`    | number | —       | yes     | Positive integer maximum total decoded pixel count. Oversized images return a tool error instead of bytes.        |
+
+When neither key is set, no hard budget is enforced and image reads follow legacy/resize behavior. Both keys are independent: set one or both. Invalid values (zero, negatives, non-integers) are rejected by the settings registry.
+
+**claudecode alias defaults:** The claudecode OAuth alias applies `max-image-dimension: 2000` to `claude-opus-5`, `claude-opus-4-8`, and `claude-sonnet-5` only. These three models also do **not** receive implicit `image-resize.*` defaults (so a 3000-pixel image is hard-rejected, not silently downscaled). Older claudecode Opus/Sonnet models keep the advisory `1568`/`1568`/`1229312` resize defaults and no hard cap. Direct `anthropic` alias Opus/Sonnet models also keep the advisory resize defaults.
+
 ## Shell Output Acquisition
 
 | Setting                            | Type   | Default   | Profile | Description                                                                                                                                                                   |

--- a/packages/core/src/config/toolRegistryFactory.ts
+++ b/packages/core/src/config/toolRegistryFactory.ts
@@ -39,6 +39,7 @@ import {
   ShellTool,
   GenerateImageTool,
 } from '@vybestack/llxprt-code-tools';
+import { resolveImageDimensionBudget } from '@vybestack/llxprt-code-tools/utils/imageDimensionBudget.js';
 
 import { CoreToolHostAdapter } from '../tools-adapters/CoreToolHostAdapter.js';
 import { CoreIdeServiceAdapter } from '../tools-adapters/CoreIdeServiceAdapter.js';
@@ -482,6 +483,8 @@ function registerImageTool(
           resolveBackend: () => resolveBackendFromHost(host),
         },
       ),
+    getImageDimensionBudget: () =>
+      resolveImageDimensionBudget(config.getEphemeralSettings()),
   });
 }
 

--- a/packages/providers/src/anthropic/AnthropicImageBudget.test.ts
+++ b/packages/providers/src/anthropic/AnthropicImageBudget.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3216 — Behavioral tests for provider-side image budget resolution.
+ * Profile loading injects modelDefaults ephemerals verbatim without registry
+ * validation, so an invalid value must throw rather than silently disable the
+ * budget.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { resolveAnthropicImageBudget } from './AnthropicImageSanitizer.js';
+
+describe('resolveAnthropicImageBudget fail-fast validation (@issue:3216)', () => {
+  it('resolves a valid dimension-only budget from profile-shaped ephemerals', () => {
+    expect(
+      resolveAnthropicImageBudget({ 'max-image-dimension': 2000 }),
+    ).toEqual({ maxDimension: 2000 });
+  });
+
+  it('resolves a valid combined budget from profile-shaped ephemerals', () => {
+    expect(
+      resolveAnthropicImageBudget({
+        'max-image-dimension': 2000,
+        'max-image-pixels': 4_000_000,
+      }),
+    ).toEqual({ maxDimension: 2000, maxPixels: 4_000_000 });
+  });
+
+  it('resolves a pixel-only budget from profile-shaped ephemerals', () => {
+    expect(
+      resolveAnthropicImageBudget({ 'max-image-pixels': 4_000_000 }),
+    ).toEqual({ maxPixels: 4_000_000 });
+  });
+
+  it('returns undefined when no budget keys are configured', () => {
+    expect(resolveAnthropicImageBudget({})).toBeUndefined();
+    expect(
+      resolveAnthropicImageBudget({ 'unrelated.setting': true }),
+    ).toBeUndefined();
+  });
+
+  it('throws on a numeric string instead of silently disabling the budget', () => {
+    // The setting contract is a positive integer; a string must not coerce.
+    expect(() =>
+      resolveAnthropicImageBudget({ 'max-image-dimension': '2000' }),
+    ).toThrow(/positive integer/);
+  });
+
+  it('throws on zero', () => {
+    expect(() =>
+      resolveAnthropicImageBudget({ 'max-image-dimension': 0 }),
+    ).toThrow(/positive integer/);
+  });
+
+  it('throws on a negative value', () => {
+    expect(() =>
+      resolveAnthropicImageBudget({ 'max-image-dimension': -5 }),
+    ).toThrow(/positive integer/);
+  });
+
+  it('throws on a fractional value', () => {
+    expect(() =>
+      resolveAnthropicImageBudget({ 'max-image-dimension': 1.5 }),
+    ).toThrow(/positive integer/);
+  });
+
+  it('throws on an invalid max-image-pixels value', () => {
+    expect(() =>
+      resolveAnthropicImageBudget({ 'max-image-pixels': 'huge' }),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      resolveAnthropicImageBudget({ 'max-image-pixels': 0 }),
+    ).toThrow(/positive integer/);
+  });
+
+  it('throws on a non-number truthy value from a malformed profile', () => {
+    expect(() =>
+      resolveAnthropicImageBudget({ 'max-image-dimension': true }),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      resolveAnthropicImageBudget({ 'max-image-dimension': null }),
+    ).toThrow(/positive integer/);
+  });
+
+  it('shares the tool-side validation message (no divergent messages)', () => {
+    // The provider-side resolution must use the same message contract as the
+    // tool-side resolver.
+    let providerMessage = '';
+    try {
+      resolveAnthropicImageBudget({ 'max-image-dimension': '2000' });
+    } catch (error) {
+      providerMessage = error instanceof Error ? error.message : '';
+    }
+    expect(providerMessage).toBe(
+      'Invalid image dimension budget: max-image-dimension must be a positive integer',
+    );
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicImageSanitizer.test.ts
+++ b/packages/providers/src/anthropic/AnthropicImageSanitizer.test.ts
@@ -1,0 +1,886 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3216 — Behavioral tests for the Anthropic image sanitizer and error
+ * classifier. Uses real IContent media blocks and real Anthropic-shaped error
+ * objects (structural, not class-asserted) to prove immutable sanitization and
+ * narrow classification.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { APIError } from '@anthropic-ai/sdk';
+import sharp from 'sharp';
+import type {
+  ContentBlock,
+  IContent,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  sanitizeAnthropicContentImages,
+  sanitizeAnthropicRequestBodyImages,
+  isAnthropicImageDimensionLimitError,
+  parseAnthropicImageDimensionLimit,
+  resolveRecoveryImageBudget,
+} from './AnthropicImageSanitizer.js';
+
+/** Cast-free text extraction from a discriminated-union block. */
+function textOf(block: ContentBlock): string {
+  return block.type === 'text' ? block.text : '';
+}
+
+/** Cast-free media-data extraction from a discriminated-union block. */
+function dataOf(block: ContentBlock): string {
+  return block.type === 'media' ? block.data : '';
+}
+
+async function pngBase64(width: number, height: number): Promise<string> {
+  const buffer = await sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r: 12, g: 34, b: 56, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return buffer.toString('base64');
+}
+
+function mediaContent(
+  speaker: 'human' | 'ai' | 'tool',
+  blocks: IContent['blocks'],
+): IContent {
+  return {
+    speaker,
+    blocks,
+    metadata: {},
+  };
+}
+
+describe('sanitizeAnthropicContentImages (@issue:3216)', () => {
+  it('replaces oversized image blocks with text placeholders in an immutable copy', async () => {
+    const big = await pngBase64(3000, 3000);
+    const ok = await pngBase64(1000, 1000);
+    const original: IContent[] = [
+      mediaContent('human', [
+        { type: 'media', mimeType: 'image/png', data: big, encoding: 'base64' },
+        { type: 'text', text: 'hello' },
+        { type: 'media', mimeType: 'image/png', data: ok, encoding: 'base64' },
+      ]),
+    ];
+
+    const result = sanitizeAnthropicContentImages(original, {
+      maxDimension: 2000,
+    });
+
+    expect(result.replacedCount).toBe(1);
+    const blocks = result.contents[0].blocks;
+    // First media block replaced with text.
+    expect(blocks[0].type).toBe('text');
+    expect(textOf(blocks[0])).toContain('dropped');
+    // Text block preserved.
+    expect(blocks[1].type).toBe('text');
+    expect(textOf(blocks[1])).toBe('hello');
+    // Within-budget image preserved.
+    expect(blocks[2].type).toBe('media');
+    expect(dataOf(blocks[2])).toBe(ok);
+    // Original array is NOT mutated.
+    expect(original[0].blocks[0].type).toBe('media');
+    expect(dataOf(original[0].blocks[0])).toBe(big);
+  });
+
+  it('returns the original contents unchanged when no budget is configured', async () => {
+    const big = await pngBase64(3000, 3000);
+    const original: IContent[] = [
+      mediaContent('human', [
+        { type: 'media', mimeType: 'image/png', data: big, encoding: 'base64' },
+      ]),
+    ];
+
+    const result = sanitizeAnthropicContentImages(original, undefined);
+
+    expect(result.replacedCount).toBe(0);
+    expect(result.contents).toBe(original);
+  });
+
+  it('preserves non-image blocks and tool-response validity', async () => {
+    const big = await pngBase64(3000, 3000);
+    const original: IContent[] = [
+      mediaContent('tool', [
+        {
+          type: 'tool_response',
+          callId: 'call-1',
+          toolName: 'read_file',
+          result: 'ok',
+        },
+        { type: 'media', mimeType: 'image/png', data: big, encoding: 'base64' },
+      ]),
+    ];
+
+    const result = sanitizeAnthropicContentImages(original, {
+      maxDimension: 2000,
+    });
+
+    expect(result.replacedCount).toBe(1);
+    const blocks = result.contents[0].blocks;
+    // tool_response preserved.
+    expect(blocks[0].type).toBe('tool_response');
+    // Image replaced.
+    expect(blocks[1].type).toBe('text');
+  });
+
+  it('keeps an image whose edges are exactly at the dimension boundary (inclusive)', async () => {
+    const exact = await pngBase64(2000, 2000);
+    const original: IContent[] = [
+      mediaContent('human', [
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          data: exact,
+          encoding: 'base64',
+        },
+      ]),
+    ];
+
+    const result = sanitizeAnthropicContentImages(original, {
+      maxDimension: 2000,
+    });
+
+    expect(result.replacedCount).toBe(0);
+    const blocks = result.contents[0].blocks;
+    expect(blocks[0].type).toBe('media');
+    expect(dataOf(blocks[0])).toBe(exact);
+  });
+
+  it('replaces an image that is within the dimension limit but exceeds a pixel-only budget', async () => {
+    // 1200x1200 = 1.44M px, well within a 2000 dimension limit, but over a
+    // 1M pixel-only budget. A maxPixels-only violation must still be replaced.
+    const tall = await pngBase64(1200, 1200);
+    const original: IContent[] = [
+      mediaContent('human', [
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          data: tall,
+          encoding: 'base64',
+        },
+      ]),
+    ];
+
+    const result = sanitizeAnthropicContentImages(original, {
+      maxPixels: 1_000_000,
+    });
+
+    expect(result.replacedCount).toBe(1);
+    const blocks = result.contents[0].blocks;
+    expect(blocks[0].type).toBe('text');
+    expect(textOf(blocks[0])).toContain('dropped');
+  });
+});
+
+/**
+ * The actual known Anthropic many-image dimension error body. The API returns
+ * a JSON envelope `{type:'error', error:{type:'invalid_request_error', message}}`
+ * which the SDK stores verbatim on `APIError.error`.
+ */
+const MANY_IMAGE_DIMENSION_BODY = {
+  type: 'error',
+  error: {
+    type: 'invalid_request_error' as const,
+    message:
+      'At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels',
+  },
+};
+
+const MANY_IMAGE_DIMENSION_MESSAGE = MANY_IMAGE_DIMENSION_BODY.error.message;
+
+/** A real Headers object so SDK `generate()` returns a BadRequestError, not APIConnectionError. */
+function sdkHeaders(): Headers {
+  return new Headers({ 'request-id': 'req_test' });
+}
+
+describe('isAnthropicImageDimensionLimitError (@issue:3216)', () => {
+  it('classifies the real SDK-shaped many-image dimension 400', () => {
+    // Construct through the real SDK APIError.generate path so the error
+    // shape matches production exactly (status, nested error body, message).
+    const error = APIError.generate(
+      400,
+      MANY_IMAGE_DIMENSION_BODY,
+      undefined,
+      sdkHeaders(),
+    );
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(true);
+  });
+
+  it('classifies a structurally-compatible plain object with the same body shape', () => {
+    const error = {
+      status: 400,
+      error: MANY_IMAGE_DIMENSION_BODY,
+    };
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(true);
+  });
+
+  it('falls back to the top-level message when the SDK variant stores it there', () => {
+    // Some SDK variants store the constructed message string on `.message`
+    // with the JSON-stringified body. The classifier must still match.
+    const error = {
+      status: 400,
+      error: undefined,
+      message: `400 ${JSON.stringify(MANY_IMAGE_DIMENSION_BODY)}`,
+    };
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(true);
+  });
+
+  it('is case/whitespace tolerant for the service wording', () => {
+    const error = APIError.generate(
+      400,
+      {
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          message:
+            '  at  least  one  of  the  IMAGE  dimensions  EXCEED  max  allowed  size  for  many-image  requests:  2000  pixels  ',
+        },
+      },
+      undefined,
+      sdkHeaders(),
+    );
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(true);
+  });
+
+  it('rejects a malformed body (missing inner error)', () => {
+    const error = APIError.generate(
+      400,
+      { type: 'error' },
+      undefined,
+      sdkHeaders(),
+    );
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(false);
+  });
+
+  it('rejects a malformed body (inner error missing message)', () => {
+    const error = APIError.generate(
+      400,
+      { type: 'error', error: { type: 'invalid_request_error' } },
+      undefined,
+      sdkHeaders(),
+    );
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(false);
+  });
+
+  it('rejects a 400 invalid_request_error with an unrelated image message', () => {
+    // "Image format not supported" mentions image but lacks dimension/many-image semantics
+    const error = APIError.generate(
+      400,
+      {
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          message: 'Image format not supported',
+        },
+      },
+      undefined,
+      sdkHeaders(),
+    );
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(false);
+  });
+
+  it('rejects a 400 invalid_request_error with an unrelated width/height message', () => {
+    // Mentions width/height but lacks image/dimension/many-image semantics
+    const error = APIError.generate(
+      400,
+      {
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          message:
+            'expected width 100 and height 100 but received different values',
+        },
+      },
+      undefined,
+      sdkHeaders(),
+    );
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(false);
+  });
+
+  it('rejects a 400 for an unrelated invalid_request_error', () => {
+    const error = APIError.generate(
+      400,
+      {
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          message: 'tools.0: extra inputs not permitted',
+        },
+      },
+      undefined,
+      sdkHeaders(),
+    );
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(false);
+  });
+
+  it('rejects a 400 with a non-invalid_request_error type', () => {
+    const error = APIError.generate(
+      400,
+      {
+        type: 'error',
+        error: {
+          type: 'authentication_error',
+          message: MANY_IMAGE_DIMENSION_MESSAGE,
+        },
+      },
+      undefined,
+      sdkHeaders(),
+    );
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(false);
+  });
+
+  it('rejects non-400 errors (429)', () => {
+    const error = APIError.generate(
+      429,
+      {
+        type: 'error',
+        error: {
+          type: 'rate_limit_error',
+          message: MANY_IMAGE_DIMENSION_MESSAGE,
+        },
+      },
+      undefined,
+      sdkHeaders(),
+    );
+    expect(isAnthropicImageDimensionLimitError(error)).toBe(false);
+  });
+
+  it('rejects non-error values', () => {
+    expect(isAnthropicImageDimensionLimitError(null)).toBe(false);
+    expect(isAnthropicImageDimensionLimitError('oops')).toBe(false);
+    expect(isAnthropicImageDimensionLimitError(undefined)).toBe(false);
+  });
+});
+
+describe('parseAnthropicImageDimensionLimit (@issue:3216)', () => {
+  it('extracts the pixel limit from the real SDK-shaped error', () => {
+    const error = APIError.generate(
+      400,
+      MANY_IMAGE_DIMENSION_BODY,
+      undefined,
+      sdkHeaders(),
+    );
+    expect(parseAnthropicImageDimensionLimit(error)).toBe(2000);
+  });
+
+  it('extracts the pixel limit from a plain-object error with nested body', () => {
+    const error = {
+      status: 400,
+      error: MANY_IMAGE_DIMENSION_BODY,
+    };
+    expect(parseAnthropicImageDimensionLimit(error)).toBe(2000);
+  });
+
+  it('returns undefined when no pixel limit is stated', () => {
+    const error = APIError.generate(
+      400,
+      {
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          message: 'tools.0: extra inputs not permitted',
+        },
+      },
+      undefined,
+      sdkHeaders(),
+    );
+    expect(parseAnthropicImageDimensionLimit(error)).toBeUndefined();
+  });
+});
+
+describe('resolveRecoveryImageBudget (@issue:3216 H3)', () => {
+  it('uses the parsed error limit alone when no budget is configured', () => {
+    expect(resolveRecoveryImageBudget(undefined, 2000)).toEqual({
+      maxDimension: 2000,
+    });
+  });
+
+  it('returns undefined when neither a config nor an error limit exists', () => {
+    expect(resolveRecoveryImageBudget(undefined, undefined)).toBeUndefined();
+  });
+
+  it('retains a pixel-only config and applies the parsed error dimension', () => {
+    // A 3000x500 image (1.5M px) is under the 4M pixel cap but its 3000 width
+    // exceeds the error-derived 2000 dimension — both must be enforced.
+    expect(resolveRecoveryImageBudget({ maxPixels: 4_000_000 }, 2000)).toEqual({
+      maxDimension: 2000,
+      maxPixels: 4_000_000,
+    });
+  });
+
+  it('uses the stricter max dimension when the configured one is looser', () => {
+    expect(resolveRecoveryImageBudget({ maxDimension: 3000 }, 2000)).toEqual({
+      maxDimension: 2000,
+    });
+  });
+
+  it('uses the stricter max dimension when the configured one is stricter', () => {
+    expect(resolveRecoveryImageBudget({ maxDimension: 1500 }, 2000)).toEqual({
+      maxDimension: 1500,
+    });
+  });
+
+  it('merges combined limits keeping configured pixels and stricter dimension', () => {
+    expect(
+      resolveRecoveryImageBudget(
+        { maxDimension: 1500, maxPixels: 2_000_000 },
+        2000,
+      ),
+    ).toEqual({ maxDimension: 1500, maxPixels: 2_000_000 });
+  });
+
+  it('keeps the exact boundary when configured dimension equals the error limit', () => {
+    expect(resolveRecoveryImageBudget({ maxDimension: 2000 }, 2000)).toEqual({
+      maxDimension: 2000,
+    });
+  });
+
+  it('keeps a pixel-only configured budget when the error limit is missing', () => {
+    expect(
+      resolveRecoveryImageBudget({ maxPixels: 4_000_000 }, undefined),
+    ).toEqual({ maxPixels: 4_000_000 });
+  });
+});
+
+/**
+ * Structural narrowing of the Anthropic request-body message content blocks
+ * produced by the neutral→Anthropic conversion. Keeps the tests cast-free
+ * while inspecting the actual shapes transport builds.
+ */
+interface AnthropicImageBlock {
+  readonly type: 'image';
+  readonly source: {
+    readonly type: 'base64';
+    readonly media_type: string;
+    readonly data: string;
+  };
+}
+
+interface AnthropicTextBlock {
+  readonly type: 'text';
+  readonly text: string;
+}
+
+interface AnthropicToolUseBlock {
+  readonly type: 'tool_use';
+  readonly id: string;
+  readonly name: string;
+  readonly input: Record<string, unknown>;
+}
+
+interface AnthropicToolResultBlock {
+  readonly type: 'tool_result';
+  readonly tool_use_id: string;
+  readonly is_error?: boolean;
+  readonly content: readonly AnthropicContentBlock[] | string;
+}
+
+type AnthropicContentBlock =
+  | AnthropicImageBlock
+  | AnthropicTextBlock
+  | AnthropicToolUseBlock
+  | AnthropicToolResultBlock
+  | { readonly type: string; readonly [key: string]: unknown };
+
+interface AnthropicRequestBodyFixture {
+  readonly messages: ReadonlyArray<{
+    readonly role: string;
+    readonly content: readonly AnthropicContentBlock[];
+  }>;
+  readonly [key: string]: unknown;
+}
+
+function isImageBlock(block: unknown): block is AnthropicImageBlock {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    (block as { type?: unknown }).type === 'image'
+  );
+}
+
+function isTextBlock(block: unknown): block is AnthropicTextBlock {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    (block as { type?: unknown }).type === 'text'
+  );
+}
+
+function isToolResultBlock(block: unknown): block is AnthropicToolResultBlock {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    (block as { type?: unknown }).type === 'tool_result'
+  );
+}
+
+/**
+ * Assert the block type and return the narrowed value. Avoids conditional
+ * expect calls inside if-blocks (jest/no-conditional-expect).
+ * The type assertion is safe because it is guarded by the runtime type guard.
+ */
+function expectImageBlock(block: AnthropicContentBlock): AnthropicImageBlock {
+  expect(isImageBlock(block)).toBe(true);
+  return block as AnthropicImageBlock;
+}
+
+function expectTextBlock(block: AnthropicContentBlock): AnthropicTextBlock {
+  expect(isTextBlock(block)).toBe(true);
+  return block as AnthropicTextBlock;
+}
+
+function expectToolResultBlock(
+  block: AnthropicContentBlock,
+): AnthropicToolResultBlock {
+  expect(isToolResultBlock(block)).toBe(true);
+  return block as AnthropicToolResultBlock;
+}
+
+describe('sanitizeAnthropicRequestBodyImages nested tool_result traversal (@issue:3216)', () => {
+  it('sanitizes image blocks nested in tool_result.content preserving the wrapper and pairing', async () => {
+    const bigNested = await pngBase64(3000, 3000);
+    const okNested = await pngBase64(1200, 1200);
+    const body: AnthropicRequestBodyFixture = {
+      model: 'claude-opus-5',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_123',
+              name: 'read_file',
+              input: { absolute_path: 'big.png' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_123',
+              content: [
+                { type: 'text', text: 'file content here' },
+                {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: bigNested,
+                  },
+                },
+                {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: okNested,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const original = JSON.parse(JSON.stringify(body)) as typeof body;
+
+    const result = sanitizeAnthropicRequestBodyImages(
+      body as unknown as Record<string, unknown>,
+      { maxDimension: 2000 },
+    );
+
+    expect(result.replacedCount).toBe(1);
+    const userMessage = result.body['messages'] as typeof body.messages;
+    const toolResult = expectToolResultBlock(userMessage[1].content[0]);
+    // Wrapper identity preserved: exact pairing and error flag.
+    expect(toolResult.tool_use_id).toBe('toolu_123');
+    expect(toolResult.is_error).toBeUndefined();
+    const nested = toolResult.content as readonly AnthropicContentBlock[];
+    // Sibling text preserved, first (oversized) image replaced, valid image
+    // retained, ordering intact.
+    expect(expectTextBlock(nested[0]).text).toBe('file content here');
+    expect(isTextBlock(nested[1])).toBe(true);
+    const img2 = expectImageBlock(nested[2]);
+    expect(img2.source.data).toBe(okNested);
+    // Bytes of the oversized image must be gone from the nested content.
+    expect(JSON.stringify(toolResult)).not.toContain(bigNested);
+    // Unrelated top-level fields preserved.
+    expect(result.body['model']).toBe('claude-opus-5');
+    // The input body is NOT mutated at any level.
+    expect(body).toEqual(original);
+  });
+
+  it('sanitizes multiple nested oversized images across multiple tool_results', async () => {
+    const big1 = await pngBase64(3000, 2000);
+    const big2 = await pngBase64(2000, 3000);
+    const body: AnthropicRequestBodyFixture = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_a',
+              content: [
+                {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: big1,
+                  },
+                },
+              ],
+            },
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_b',
+              is_error: false,
+              content: [
+                {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: big2,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = sanitizeAnthropicRequestBodyImages(
+      body as unknown as Record<string, unknown>,
+      { maxDimension: 2000 },
+    );
+
+    expect(result.replacedCount).toBe(2);
+    const serialized = JSON.stringify(result.body);
+    expect(serialized).not.toContain(big1);
+    expect(serialized).not.toContain(big2);
+    const userMessage = result.body['messages'] as typeof body.messages;
+    const firstToolResult = expectToolResultBlock(userMessage[0].content[0]);
+    const secondToolResult = expectToolResultBlock(userMessage[0].content[1]);
+    expect(firstToolResult.tool_use_id).toBe('toolu_a');
+    expect(secondToolResult.tool_use_id).toBe('toolu_b');
+    expect(secondToolResult.is_error).toBe(false);
+  });
+
+  it('sanitizes mixed top-level and nested media in the same body', async () => {
+    const bigTop = await pngBase64(3000, 1000);
+    const bigNested = await pngBase64(1000, 3000);
+    const okTop = await pngBase64(1000, 1000);
+    const body: AnthropicRequestBodyFixture = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: 'image/png',
+                data: bigTop,
+              },
+            },
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: 'image/png',
+                data: okTop,
+              },
+            },
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_c',
+              content: [
+                {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: bigNested,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = sanitizeAnthropicRequestBodyImages(
+      body as unknown as Record<string, unknown>,
+      { maxDimension: 2000 },
+    );
+
+    expect(result.replacedCount).toBe(2);
+    const serialized = JSON.stringify(result.body);
+    expect(serialized).not.toContain(bigTop);
+    expect(serialized).not.toContain(bigNested);
+    expect(serialized).toContain(okTop);
+  });
+
+  it('keeps a top-level image exactly at the dimension boundary (reactive parity)', async () => {
+    const exact = await pngBase64(2000, 2000);
+    const body: AnthropicRequestBodyFixture = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: 'image/png',
+                data: exact,
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = sanitizeAnthropicRequestBodyImages(
+      body as unknown as Record<string, unknown>,
+      { maxDimension: 2000 },
+    );
+
+    expect(result.replacedCount).toBe(0);
+    expect(result.body).toBe(body as unknown as Record<string, unknown>);
+  });
+
+  it('replaces a top-level image that only exceeds a pixel-only budget (reactive parity)', async () => {
+    // 1200x1200 within the 2000 dimension limit but over a 1M pixel budget.
+    const tall = await pngBase64(1200, 1200);
+    const body: AnthropicRequestBodyFixture = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: 'image/png',
+                data: tall,
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = sanitizeAnthropicRequestBodyImages(
+      body as unknown as Record<string, unknown>,
+      { maxPixels: 1_000_000 },
+    );
+
+    expect(result.replacedCount).toBe(1);
+    expect(JSON.stringify(result.body)).not.toContain(tall);
+  });
+
+  it('preserves a string tool_result.content untouched and mutates nothing when nothing is oversized', async () => {
+    const ok = await pngBase64(1000, 1000);
+    const body: AnthropicRequestBodyFixture = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_s',
+              content: 'plain text result',
+            },
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: 'image/png',
+                data: ok,
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const original = JSON.parse(JSON.stringify(body)) as typeof body;
+
+    const result = sanitizeAnthropicRequestBodyImages(
+      body as unknown as Record<string, unknown>,
+      { maxDimension: 2000 },
+    );
+
+    expect(result.replacedCount).toBe(0);
+    // No replacements: the SAME body object is returned (identity).
+    expect(result.body).toBe(body as unknown as Record<string, unknown>);
+    expect(body).toEqual(original);
+  });
+
+  it('is immutable: nested arrays and objects are fresh copies, never the originals', async () => {
+    const big = await pngBase64(3000, 3000);
+    const body: AnthropicRequestBodyFixture = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_i',
+              content: [
+                {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: big,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const messagesBefore = body.messages;
+    const contentBefore = body.messages[0].content;
+    const toolResultBefore = contentBefore[0] as AnthropicToolResultBlock;
+    const nestedBefore = toolResultBefore.content as readonly unknown[];
+
+    const result = sanitizeAnthropicRequestBodyImages(
+      body as unknown as Record<string, unknown>,
+      { maxDimension: 2000 },
+    );
+
+    expect(result.replacedCount).toBe(1);
+    // New containers at every level.
+    expect(result.body['messages']).not.toBe(messagesBefore);
+    const newMessages = result.body['messages'] as typeof body.messages;
+    expect(newMessages[0].content).not.toBe(contentBefore);
+    const newToolResult = newMessages[0].content[0] as AnthropicToolResultBlock;
+    expect(newToolResult).not.toBe(toolResultBefore);
+    expect(newToolResult.content).not.toBe(nestedBefore);
+    // Originals untouched.
+    expect(isImageBlock(nestedBefore[0])).toBe(true);
+    expect(
+      isImageBlock(nestedBefore[0]) ? nestedBefore[0].source.data : '',
+    ).toBe(big);
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicImageSanitizer.ts
+++ b/packages/providers/src/anthropic/AnthropicImageSanitizer.ts
@@ -1,0 +1,458 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { GenerateChatOptions } from '../IProvider.js';
+import { RETRY_REQUEST_CONTEXT_KEY } from '../transportAttemptBudget.js';
+import {
+  checkImageDimensionBudget,
+  type ImageDimensionBudget,
+} from '@vybestack/llxprt-code-tools/utils/imageDimensionBudget.js';
+
+/** Placeholder inserted in place of a dropped oversized image block. */
+const DROPPED_IMAGE_PLACEHOLDER =
+  '[Image dropped: exceeded the provider image dimension limit. Provide a smaller image.]';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Proactively sanitize oversized image blocks from an immutable copy of the
+ * IContent history according to the active budget. Returns the sanitized
+ * contents and the number of replacements made. The input array and its
+ * nested blocks are never mutated.
+ *
+ * When `budget` is `undefined`, the original contents are returned unchanged
+ * with zero replacements.
+ */
+export function sanitizeAnthropicContentImages(
+  contents: IContent[],
+  budget: ImageDimensionBudget | undefined,
+): { contents: IContent[]; replacedCount: number } {
+  if (budget === undefined) {
+    return { contents, replacedCount: 0 };
+  }
+
+  let replacedCount = 0;
+  const sanitized = contents.map((content) => {
+    const newBlocks = content.blocks.map((block) => {
+      if (block.type !== 'media' || block.encoding !== 'base64') {
+        return block;
+      }
+      const violation = checkImageDimensionBudget(block.data, budget);
+      if (violation === undefined) {
+        return block;
+      }
+      replacedCount++;
+      return {
+        type: 'text' as const,
+        text: DROPPED_IMAGE_PLACEHOLDER,
+      };
+    });
+    return { ...content, blocks: newBlocks };
+  });
+
+  return { contents: sanitized, replacedCount };
+}
+
+/**
+ * Narrow structural classifier for Anthropic HTTP 400 invalid-request errors
+ * that specifically state an image dimension exceeded the many-image maximum.
+ *
+ * Unrelated 400s (extra inputs, tool mismatches, etc.) must NOT be classified
+ * so they are never retried by the one-shot recovery path.
+ *
+ * Recognizes the actual known service wording:
+ *   "At least one of the image dimensions exceed max allowed size for
+ *    many-image requests: 2000 pixels"
+ *
+ * The match is case/whitespace-tolerant but conservative: it requires HTTP 400,
+ * the `invalid_request_error` type, AND image/dimension/many-image semantics so
+ * unrelated width/height or image 400s are not misclassified.
+ */
+export function isAnthropicImageDimensionLimitError(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+  if (error['status'] !== 400) return false;
+  const parsed = parseAnthropicErrorDetail(error);
+  if (parsed === undefined) return false;
+  if (parsed.type !== 'invalid_request_error') return false;
+  return isManyImageDimensionMessage(parsed.message);
+}
+
+/**
+ * Conservative semantic match for the many-image dimension error wording.
+ * Requires all three signal words (image, dimension(s), and many-image or the
+ * specific "max allowed size" phrase) so unrelated image or dimension 400s
+ * are not matched.
+ */
+function isManyImageDimensionMessage(message: string): boolean {
+  const normalized = message.replace(/\s+/g, ' ').toLowerCase();
+  if (!normalized.includes('image')) return false;
+  if (!normalized.includes('dimension')) return false;
+  // The real service wording says "many-image requests". "max allowed size"
+  // + "dimension" is also sufficient to narrow the match.
+  return (
+    normalized.includes('many-image') ||
+    (normalized.includes('max allowed size') && normalized.includes('exceed'))
+  );
+}
+
+/**
+ * Extract the dimension limit stated in an Anthropic image-dimension error,
+ * if present. Parses the trailing "N pixels" from the real service wording.
+ * Returns `undefined` when no numeric pixel limit can be found.
+ */
+export function parseAnthropicImageDimensionLimit(
+  error: unknown,
+): number | undefined {
+  if (!isRecord(error)) return undefined;
+  const parsed = parseAnthropicErrorDetail(error);
+  if (parsed === undefined) return undefined;
+  // Parse "N pixels" (case-insensitive) from the real many-image wording.
+  // A token-based scan avoids regex backtracking concerns entirely.
+  const tokens = parsed.message.split(/\s+/);
+  for (let i = 0; i < tokens.length - 1; i++) {
+    if (tokens[i + 1].toLowerCase().startsWith('pixel')) {
+      const value = Number(tokens[i]);
+      if (Number.isInteger(value) && value > 0) return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Parsed Anthropic error detail extracted from the SDK error object.
+ * The SDK stores the raw response body on `.error`. The standard Anthropic
+ * body is `{type:'error', error:{type:'invalid_request_error', message:'...'}}`,
+ * but some shapes are flat (`{type:'invalid_request_error', message:'...'}`).
+ * This function unwraps both and also falls back to the top-level `.message`.
+ */
+interface AnthropicErrorDetail {
+  readonly type: string;
+  readonly message: string;
+}
+
+function parseAnthropicErrorDetail(
+  e: Record<string, unknown>,
+): AnthropicErrorDetail | undefined {
+  const body = e['error'];
+
+  // Nested Anthropic body: {type:'error', error:{type, message}}
+  if (isRecord(body)) {
+    const innerError = body['error'];
+    if (isRecord(innerError)) {
+      const innerType = innerError['type'];
+      const innerMessage = innerError['message'];
+      if (
+        typeof innerType === 'string' &&
+        typeof innerMessage === 'string' &&
+        innerMessage.length > 0
+      ) {
+        return { type: innerType, message: innerMessage };
+      }
+    }
+    // Flat body: {type:'invalid_request_error', message:'...'}
+    const flatType = body['type'];
+    const flatMessage = body['message'];
+    if (
+      typeof flatType === 'string' &&
+      typeof flatMessage === 'string' &&
+      flatMessage.length > 0
+    ) {
+      return { type: flatType, message: flatMessage };
+    }
+  }
+
+  // Fallback: the top-level error.message (SDK may stringify the body).
+  const directMessage = e['message'];
+  if (typeof directMessage === 'string' && directMessage.length > 0) {
+    // Try to recover type and message from a JSON-stringified body.
+    const recovered = tryRecoverFromJsonString(directMessage);
+    if (recovered !== undefined) return recovered;
+  }
+
+  return undefined;
+}
+
+/**
+ * Attempt to recover the Anthropic error type and message from a
+ * JSON-stringified body that the SDK may have embedded in the top-level
+ * `.message`. Returns `undefined` when the string is not valid JSON or lacks
+ * the expected shape.
+ */
+function tryRecoverFromJsonString(
+  message: string,
+): AnthropicErrorDetail | undefined {
+  // The SDK message format is "STATUS {json}" — find the first `{`.
+  const braceIndex = message.indexOf('{');
+  if (braceIndex < 0) return undefined;
+  try {
+    const parsed = JSON.parse(message.slice(braceIndex));
+    if (!isRecord(parsed)) return undefined;
+    const innerError = parsed['error'];
+    if (isRecord(innerError)) {
+      const innerType = innerError['type'];
+      const innerMessage = innerError['message'];
+      if (
+        typeof innerType === 'string' &&
+        typeof innerMessage === 'string' &&
+        innerMessage.length > 0
+      ) {
+        return { type: innerType, message: innerMessage };
+      }
+    }
+    const flatType = parsed['type'];
+    const flatMessage = parsed['message'];
+    if (
+      typeof flatType === 'string' &&
+      typeof flatMessage === 'string' &&
+      flatMessage.length > 0
+    ) {
+      return { type: flatType, message: flatMessage };
+    }
+  } catch {
+    // Not valid JSON
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the active image dimension budget from Anthropic config ephemerals.
+ * Re-exported here so the provider can derive the budget from its own
+ * resolved settings without importing the tools utility path separately.
+ */
+export function resolveAnthropicImageBudget(
+  ephemerals: Readonly<Record<string, unknown>>,
+): ImageDimensionBudget | undefined {
+  const maxDimension = readPositiveInt(ephemerals, 'max-image-dimension');
+  const maxPixels = readPositiveInt(ephemerals, 'max-image-pixels');
+  if (maxDimension === undefined && maxPixels === undefined) return undefined;
+  return { maxDimension, maxPixels };
+}
+
+/**
+ * Merge a configured image budget with an error-derived dimension limit for
+ * the one-shot recovery path (H3).
+ *
+ * The merged budget retains the configured `maxPixels` and uses the STRICHER
+ * max dimension: `min(configured maxDimension, parsed provider maxDimension)`.
+ * When no dimension is configured, the parsed limit is used. When neither a
+ * configured budget nor an error limit exists, `undefined` is returned.
+ */
+export function resolveRecoveryImageBudget(
+  configured: ImageDimensionBudget | undefined,
+  errorLimit: number | undefined,
+): ImageDimensionBudget | undefined {
+  if (configured === undefined) {
+    return errorLimit !== undefined ? { maxDimension: errorLimit } : undefined;
+  }
+  let maxDimension = configured.maxDimension;
+  if (errorLimit !== undefined) {
+    maxDimension =
+      maxDimension !== undefined
+        ? Math.min(maxDimension, errorLimit)
+        : errorLimit;
+  }
+  if (maxDimension === undefined && configured.maxPixels === undefined) {
+    return undefined;
+  }
+  return { maxDimension, maxPixels: configured.maxPixels };
+}
+
+function readPositiveInt(
+  settings: Readonly<Record<string, unknown>>,
+  key: string,
+): number | undefined {
+  const value = settings[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Request-scoped state for the one-shot image dimension recovery (H2).
+ * Stored inside the shared `_retryRequestContext` metadata so it survives
+ * across outer RetryOrchestrator attempts for the same logical request.
+ */
+export interface ImageRecoveryRequestState {
+  sanitizedBody?: Record<string, unknown>;
+  recoveryUsed: boolean;
+}
+
+const IMAGE_RECOVERY_KEY = 'anthropicImageRecovery';
+
+function getRetryContext(
+  options: GenerateChatOptions,
+): Record<string, unknown> | undefined {
+  const metadata = options.metadata;
+  if (metadata === undefined) return undefined;
+  const ctx = metadata[RETRY_REQUEST_CONTEXT_KEY];
+  return isRecord(ctx) ? ctx : undefined;
+}
+
+/**
+ * Return the existing recovery state for this request, or `undefined` when
+ * there is no orchestrator context (direct provider call).
+ */
+export function getImageRecoveryState(
+  options: GenerateChatOptions,
+): ImageRecoveryRequestState | undefined {
+  const ctx = getRetryContext(options);
+  if (ctx === undefined) return undefined;
+  const state = ctx[IMAGE_RECOVERY_KEY];
+  return isImageRecoveryState(state) ? state : undefined;
+}
+
+/**
+ * Return the existing recovery state or create and attach a fresh one to the
+ * shared retry context. When there is no orchestrator context (direct call),
+ * a fresh ephemeral state is returned (not shared across calls).
+ */
+export function ensureImageRecoveryState(
+  options: GenerateChatOptions,
+): ImageRecoveryRequestState {
+  const ctx = getRetryContext(options);
+  if (ctx === undefined) {
+    return { recoveryUsed: false };
+  }
+  const existing = ctx[IMAGE_RECOVERY_KEY];
+  if (isImageRecoveryState(existing)) return existing;
+  const state: ImageRecoveryRequestState = { recoveryUsed: false };
+  ctx[IMAGE_RECOVERY_KEY] = state;
+  return state;
+}
+
+function isImageRecoveryState(
+  value: unknown,
+): value is ImageRecoveryRequestState {
+  return isRecord(value) && typeof value['recoveryUsed'] === 'boolean';
+}
+
+/**
+ * Read a `base64` image/document `data` string off a content block of the
+ * already-built Anthropic request body (Anthropic message format), when the
+ * block is an image or document with a base64 source. Returns the data string
+ * to check, or `undefined` when the block carries no checkable base64 bytes.
+ */
+function readBase64BlockData(
+  block: Record<string, unknown>,
+): string | undefined {
+  if (block['type'] !== 'image' && block['type'] !== 'document') {
+    return undefined;
+  }
+  const source = block['source'];
+  if (!isRecord(source) || source['type'] !== 'base64') {
+    return undefined;
+  }
+  const data = source['data'];
+  return typeof data === 'string' ? data : undefined;
+}
+
+/**
+ * Sanitize oversized base64 image/document blocks in an already-built Anthropic
+ * request body. Returns a new request body with oversized blocks replaced by
+ * text placeholders. The input is never mutated at any nesting level.
+ *
+ * Traverses both top-level image blocks and image blocks nested inside
+ * `tool_result.content` arrays (the actual Anthropic shape for read_file-
+ * generated media), preserving the wrapper, `tool_use_id`, `is_error`,
+ * sibling text, valid images, ordering, and unrelated fields.
+ *
+ * Used by the one-shot reactive retry path when Anthropic returns a 400
+ * image-dimension error. The limit comes from the active budget.
+ */
+export function sanitizeAnthropicRequestBodyImages(
+  requestBody: Record<string, unknown>,
+  budget: ImageDimensionBudget | undefined,
+): { body: Record<string, unknown>; replacedCount: number } {
+  if (budget === undefined) {
+    return { body: requestBody, replacedCount: 0 };
+  }
+
+  const messages = requestBody['messages'];
+  if (!Array.isArray(messages)) {
+    return { body: requestBody, replacedCount: 0 };
+  }
+
+  const counter = { count: 0 };
+
+  const newMessages = messages.map((msg): unknown => {
+    if (!isRecord(msg)) return msg;
+    const content = msg['content'];
+    if (!Array.isArray(content)) return msg;
+
+    const newContent = content.map((block): unknown =>
+      sanitizeContentBlock(block, budget, counter),
+    );
+
+    return { ...msg, content: newContent };
+  });
+
+  // Only rebuild the body when at least one block was sanitized. When
+  // replacedCount stays 0, the same reference is returned so the caller's
+  // identity check works and no pointless clone is made.
+  if (counter.count === 0) {
+    return { body: requestBody, replacedCount: 0 };
+  }
+
+  return {
+    body: { ...requestBody, messages: newMessages },
+    replacedCount: counter.count,
+  };
+}
+
+/**
+ * Sanitize a single content block, handling both top-level image blocks and
+ * image blocks nested inside a `tool_result` wrapper's `content` array.
+ *
+ * Recursively shallow-copies wrapper objects so the original is never mutated
+ * while sibling text, valid images, `tool_use_id`, `is_error`, and ordering
+ * are all preserved.
+ */
+function sanitizeContentBlock(
+  block: unknown,
+  budget: ImageDimensionBudget,
+  counter: { count: number },
+): unknown {
+  if (!isRecord(block)) return block;
+
+  // Top-level image/document block.
+  const data = readBase64BlockData(block);
+  if (data !== undefined) {
+    const violation = checkImageDimensionBudget(data, budget);
+    if (violation !== undefined) {
+      counter.count++;
+      return { type: 'text', text: DROPPED_IMAGE_PLACEHOLDER };
+    }
+    return block;
+  }
+
+  // Nested: tool_result.content may be a string or an array of blocks.
+  if (block['type'] === 'tool_result') {
+    const innerContent = block['content'];
+    if (!Array.isArray(innerContent)) return block;
+
+    const countBefore = counter.count;
+    const newInner = innerContent.map((nestedBlock): unknown => {
+      if (!isRecord(nestedBlock)) return nestedBlock;
+      const nestedData = readBase64BlockData(nestedBlock);
+      if (nestedData === undefined) return nestedBlock;
+      const violation = checkImageDimensionBudget(nestedData, budget);
+      if (violation === undefined) return nestedBlock;
+      counter.count++;
+      return { type: 'text', text: DROPPED_IMAGE_PLACEHOLDER };
+    });
+
+    if (counter.count === countBefore) return block;
+    // Preserve tool_use_id, is_error, and all other fields.
+    return { ...block, content: newInner };
+  }
+
+  return block;
+}

--- a/packages/providers/src/anthropic/AnthropicImageSanitizer.ts
+++ b/packages/providers/src/anthropic/AnthropicImageSanitizer.ts
@@ -9,6 +9,7 @@ import type { GenerateChatOptions } from '../IProvider.js';
 import { RETRY_REQUEST_CONTEXT_KEY } from '../transportAttemptBudget.js';
 import {
   checkImageDimensionBudget,
+  resolveImageDimensionBudget,
   type ImageDimensionBudget,
 } from '@vybestack/llxprt-code-tools/utils/imageDimensionBudget.js';
 
@@ -222,16 +223,14 @@ function tryRecoverFromJsonString(
 
 /**
  * Resolve the active image dimension budget from Anthropic config ephemerals.
- * Re-exported here so the provider can derive the budget from its own
- * resolved settings without importing the tools utility path separately.
+ * Delegates to the shared tool-side resolver so both entry points fail fast on
+ * invalid configured values; profile-loaded modelDefaults ephemerals are not
+ * registry-validated.
  */
 export function resolveAnthropicImageBudget(
   ephemerals: Readonly<Record<string, unknown>>,
 ): ImageDimensionBudget | undefined {
-  const maxDimension = readPositiveInt(ephemerals, 'max-image-dimension');
-  const maxPixels = readPositiveInt(ephemerals, 'max-image-pixels');
-  if (maxDimension === undefined && maxPixels === undefined) return undefined;
-  return { maxDimension, maxPixels };
+  return resolveImageDimensionBudget(ephemerals);
 }
 
 /**
@@ -261,18 +260,6 @@ export function resolveRecoveryImageBudget(
     return undefined;
   }
   return { maxDimension, maxPixels: configured.maxPixels };
-}
-
-function readPositiveInt(
-  settings: Readonly<Record<string, unknown>>,
-  key: string,
-): number | undefined {
-  const value = settings[key];
-  if (value === undefined) return undefined;
-  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
-    return undefined;
-  }
-  return value;
 }
 
 /**

--- a/packages/providers/src/anthropic/AnthropicProvider.imageRecovery.issue3216.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.imageRecovery.issue3216.test.ts
@@ -170,7 +170,12 @@ function make500MarkerError(): Error {
   );
 }
 
-function setupProvider(options: { withImageBudget?: boolean } = {}): {
+function setupProvider(
+  options: {
+    withImageBudget?: boolean;
+    maxImageDimension?: number;
+  } = {},
+): {
   provider: AnthropicProvider;
   runtimeContext: ProviderRuntimeContext;
   settingsService: SettingsService;
@@ -200,7 +205,7 @@ function setupProvider(options: { withImageBudget?: boolean } = {}): {
   // setEphemeralSetting). Writing it to the SettingsService guarantees the
   // proactive sanitizer in prepareAnthropicRequest sees it.
   if (options.withImageBudget === true) {
-    svc.set('max-image-dimension', 2000);
+    svc.set('max-image-dimension', options.maxImageDimension ?? 2000);
   }
   const ephemeralSettings: Record<string, unknown> = {
     ...svc.getAllGlobalSettings(),
@@ -327,6 +332,47 @@ describe('AnthropicProvider image recovery (@issue:3216)', () => {
     // The retry request must not contain the oversized image.
     const retryRequest = mockMessagesCreate.mock.calls[1][0];
     expect(JSON.stringify(retryRequest.messages)).not.toContain(big);
+  });
+
+  it('intersects a configured budget with the provider-reported recovery limit', async () => {
+    vi.clearAllMocks();
+    const image = await pngBase64(2200, 1000);
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: true,
+      maxImageDimension: 2500,
+    });
+    mockMessagesCreate
+      .mockRejectedValueOnce(make400ImageDimensionError())
+      .mockResolvedValueOnce(createMockStream('recovered'));
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: image,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    const result = await consumeGenerator(
+      provider,
+      buildCallOptions(provider, runtimeContext, settingsService, messages),
+    );
+
+    expect(result.threw).toBe(false);
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+    expect(
+      JSON.stringify(mockMessagesCreate.mock.calls[0][0].messages),
+    ).toContain(image);
+    const retryMessages = JSON.stringify(
+      mockMessagesCreate.mock.calls[1][0].messages,
+    );
+    expect(retryMessages).not.toContain(image);
   });
 
   it('does NOT retry for an unrelated 400 error', async () => {

--- a/packages/providers/src/anthropic/AnthropicProvider.imageRecovery.issue3216.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.imageRecovery.issue3216.test.ts
@@ -1,0 +1,719 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3216 — Provider-level integration tests for Anthropic poisoned-history
+ * recovery. Uses a fake transport (mocked SDK messages.create) that first
+ * returns a 400 image-dimension error, then accepts the sanitized retry. The
+ * sanitizer/classifier under test are never mocked; only the SDK transport is.
+ */
+
+import { vi, describe, it, expect, afterEach } from 'bun:test';
+import { APIError } from '@anthropic-ai/sdk';
+import {
+  attachTransportAttemptBudget,
+  getTransportAttemptBudget,
+} from '../transportAttemptBudget.js';
+import { AnthropicProvider } from './AnthropicProvider.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { TEST_PROVIDER_CONFIG } from '../test-utils/providerTestConfig.js';
+import {
+  createProviderWithRuntime,
+  createRuntimeConfigStub,
+} from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  clearActiveProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import sharp from 'sharp';
+
+async function pngBase64(width: number, height: number): Promise<string> {
+  const buffer = await sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r: 12, g: 34, b: 56, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return buffer.toString('base64');
+}
+
+const mockMessagesCreate = vi.fn();
+
+void vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: mockMessagesCreate,
+    },
+    beta: {
+      models: {
+        list: vi.fn().mockReturnValue({
+          async *[Symbol.asyncIterator]() {
+            yield {
+              id: 'claude-opus-5',
+              display_name: 'Claude Opus 5',
+            };
+          },
+        }),
+      },
+    },
+  })),
+}));
+
+void vi.mock('@vybestack/llxprt-code-tools/ToolFormatter.js', () => ({
+  ToolFormatter: vi.fn().mockImplementation(() => ({
+    toProviderFormat: vi.fn(() => []),
+    fromProviderFormat: vi.fn(() => []),
+  })),
+}));
+
+void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('System prompt'),
+}));
+
+void vi.mock(
+  '@vybestack/llxprt-code-core/prompt-config/subagent-delegation.js',
+  () => ({
+    shouldIncludeSubagentDelegation: vi.fn().mockReturnValue(false),
+  }),
+);
+
+void vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
+  getErrorStatus: vi.fn(() => undefined),
+  isNetworkTransientError: vi.fn(() => false),
+}));
+
+const createMockStream = (text: string) => ({
+  async *[Symbol.asyncIterator]() {
+    yield {
+      type: 'content_block_delta',
+      delta: { type: 'text_delta', text },
+    };
+  },
+});
+
+function make400ImageDimensionError(): Error {
+  // Construct through the real SDK APIError.generate to match production
+  // error shape exactly (status, nested body, message string).
+  return APIError.generate(
+    400,
+    {
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message:
+          'At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels',
+      },
+    },
+    undefined,
+    new Headers({ 'request-id': 'req_test' }),
+  );
+}
+
+function make400UnrelatedError(): Error {
+  return APIError.generate(
+    400,
+    {
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'tools.0: extra inputs not permitted',
+      },
+    },
+    undefined,
+    new Headers({ 'request-id': 'req_test' }),
+  );
+}
+
+function make429RateLimitError(): Error {
+  return APIError.generate(
+    429,
+    {
+      type: 'error',
+      error: {
+        type: 'rate_limit_error',
+        message: 'Rate limit exceeded',
+      },
+    },
+    undefined,
+    new Headers({ 'request-id': 'req_429', 'retry-after': '1' }),
+  );
+}
+
+/**
+ * A distinct non-image, non-transient 500 whose message is a unique marker. Used
+ * to prove the sanitized retry's own error propagates verbatim (it is NOT
+ * swallowed and replaced by the original 400 image-dimension error).
+ */
+function make500MarkerError(): Error {
+  return APIError.generate(
+    500,
+    {
+      type: 'error',
+      error: {
+        type: 'api_error',
+        message: 'RETRY_MARKER_PROPAGATED_FROM_SANITIZED_RETRY',
+      },
+    },
+    undefined,
+    new Headers({ 'request-id': 'req_marker' }),
+  );
+}
+
+function setupProvider(options: { withImageBudget?: boolean } = {}): {
+  provider: AnthropicProvider;
+  runtimeContext: ProviderRuntimeContext;
+  settingsService: SettingsService;
+} {
+  const result = createProviderWithRuntime<AnthropicProvider>(
+    ({ settingsService: svc }) => {
+      svc.set('auth-key', 'test-api-key');
+      svc.set('activeProvider', 'anthropic');
+      svc.setProviderSetting('anthropic', 'streaming', 'disabled');
+      svc.setProviderSetting('anthropic', 'prompt-caching', 'off');
+      return new AnthropicProvider(
+        'test-api-key',
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+    },
+    {
+      runtimeId: 'anthropic.imageRecovery.test',
+      metadata: { source: 'AnthropicProvider.imageRecovery.issue3216.test.ts' },
+    },
+  );
+  const { provider, runtime, settingsService: svc } = result;
+  runtime.config ??= createRuntimeConfigStub(svc);
+  // The budget must reach the provider through the real runtime path:
+  // invocation.ephemerals is built by buildEphemeralsSnapshot from the
+  // SettingsService global map (the same path model defaults take via
+  // setEphemeralSetting). Writing it to the SettingsService guarantees the
+  // proactive sanitizer in prepareAnthropicRequest sees it.
+  if (options.withImageBudget === true) {
+    svc.set('max-image-dimension', 2000);
+  }
+  const ephemeralSettings: Record<string, unknown> = {
+    ...svc.getAllGlobalSettings(),
+    ...svc.getProviderSettings(provider.name),
+  };
+  runtime.config.getEphemeralSettings = () => ({ ...ephemeralSettings });
+  runtime.config.getEphemeralSetting = (key: string) => {
+    const providerValue = svc.getProviderSettings(provider.name)[key];
+    if (providerValue !== undefined) return providerValue;
+    return svc.get(key);
+  };
+
+  setActiveProviderRuntimeContext(runtime);
+  return { provider, runtimeContext: runtime, settingsService: svc };
+}
+
+const buildCallOptions = (
+  provider: AnthropicProvider,
+  runtimeContext: ProviderRuntimeContext,
+  settingsService: SettingsService,
+  contents: IContent[],
+) =>
+  createProviderCallOptions({
+    providerName: provider.name,
+    contents,
+    settings: settingsService,
+    runtime: runtimeContext,
+    config: runtimeContext.config,
+  } as Parameters<typeof createProviderCallOptions>[0]);
+
+async function consumeGenerator(
+  provider: AnthropicProvider,
+  callOptions: ReturnType<typeof createProviderCallOptions>,
+): Promise<{ chunks: string[]; threw: boolean; error: unknown }> {
+  const chunks: string[] = [];
+  let threw = false;
+  let error: unknown;
+  try {
+    const generator = provider.generateChatCompletion(callOptions);
+    for await (const chunk of generator) {
+      const text = chunk.blocks.find((b) => b.type === 'text');
+      if (text !== undefined) chunks.push(text.text);
+    }
+  } catch (e) {
+    threw = true;
+    error = e;
+  }
+  return { chunks, threw, error };
+}
+
+describe('AnthropicProvider image recovery (@issue:3216)', () => {
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  it('proactively sanitizes oversized history images so no 400 is sent', async () => {
+    vi.clearAllMocks();
+    const big = await pngBase64(3000, 3000);
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: true,
+    });
+    mockMessagesCreate.mockResolvedValue(createMockStream('ok'));
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: big,
+            encoding: 'base64' as const,
+          },
+          { type: 'text', text: 'describe this' },
+        ],
+      },
+    ];
+
+    await consumeGenerator(
+      provider,
+      buildCallOptions(provider, runtimeContext, settingsService, messages),
+    );
+
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+    const request = mockMessagesCreate.mock.calls[0][0];
+    const allContent = JSON.stringify(request.messages);
+    expect(allContent).toContain('dropped');
+    expect(allContent).not.toContain(big);
+  });
+
+  it('retries exactly once after a 400 image-dimension error and succeeds', async () => {
+    vi.clearAllMocks();
+    const big = await pngBase64(3000, 3000);
+    // NO image budget in config — the error's own limit is used for recovery.
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: false,
+    });
+    mockMessagesCreate
+      .mockRejectedValueOnce(make400ImageDimensionError())
+      .mockResolvedValueOnce(createMockStream('recovered'));
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: big,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    const result = await consumeGenerator(
+      provider,
+      buildCallOptions(provider, runtimeContext, settingsService, messages),
+    );
+
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+    expect(result.threw).toBe(false);
+    expect(result.chunks.join('')).toContain('recovered');
+    // The retry request must not contain the oversized image.
+    const retryRequest = mockMessagesCreate.mock.calls[1][0];
+    expect(JSON.stringify(retryRequest.messages)).not.toContain(big);
+  });
+
+  it('does NOT retry for an unrelated 400 error', async () => {
+    vi.clearAllMocks();
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: false,
+    });
+    mockMessagesCreate.mockRejectedValueOnce(make400UnrelatedError());
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'hello' }],
+      },
+    ];
+
+    const result = await consumeGenerator(
+      provider,
+      buildCallOptions(provider, runtimeContext, settingsService, messages),
+    );
+
+    expect(result.threw).toBe(true);
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT retry a second time if the sanitized request also fails', async () => {
+    vi.clearAllMocks();
+    const big = await pngBase64(3000, 3000);
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: false,
+    });
+    mockMessagesCreate
+      .mockRejectedValueOnce(make400ImageDimensionError())
+      .mockRejectedValueOnce(make400ImageDimensionError());
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: big,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    const result = await consumeGenerator(
+      provider,
+      buildCallOptions(provider, runtimeContext, settingsService, messages),
+    );
+
+    expect(result.threw).toBe(true);
+    // First call (400) + one retry (also 400) = 2 total. No third attempt.
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT consume a transport slot for recovery when the signal is already aborted', async () => {
+    vi.clearAllMocks();
+    const big = await pngBase64(3000, 3000);
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: false,
+    });
+    mockMessagesCreate.mockRejectedValueOnce(make400ImageDimensionError());
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: big,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    // Direct call with an explicit transport budget so slot consumption is
+    // observable. The signal is aborted BEFORE recovery runs, so the
+    // known-aborted recovery must bail out BEFORE consuming a slot.
+    const baseOptions = buildCallOptions(
+      provider,
+      runtimeContext,
+      settingsService,
+      messages,
+    );
+    const attached = attachTransportAttemptBudget(baseOptions, 5);
+    const abortController = new AbortController();
+    abortController.abort();
+    // Preserve the narrowed options type while overriding the signal and
+    // carrying the budget-bearing metadata from the attached copy.
+    const abortedOptions = {
+      ...baseOptions,
+      invocation: {
+        ...baseOptions.invocation,
+        signal: abortController.signal,
+      },
+      metadata: attached.options.metadata,
+    };
+
+    const result = await consumeGenerator(provider, abortedOptions);
+
+    // Recovery was skipped: the ORIGINAL 400 propagates (nothing sanitized).
+    expect(result.threw).toBe(true);
+    const errorMessage = String(
+      result.error instanceof Error ? result.error.message : result.error,
+    );
+    expect(errorMessage).toContain('image dimensions');
+    // The recovery retry never reached the transport.
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+    // No transport slot was consumed by the known-aborted recovery.
+    const budget = getTransportAttemptBudget(abortedOptions);
+    expect(budget?.used).toBe(0);
+  });
+
+  it('retries once after a 400 when oversized image is nested in tool_result media', async () => {
+    vi.clearAllMocks();
+    const big = await pngBase64(3000, 3000);
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: false,
+    });
+    mockMessagesCreate
+      .mockRejectedValueOnce(make400ImageDimensionError())
+      .mockResolvedValueOnce(createMockStream('recovered-nested'));
+
+    // Real neutral AI history: a tool_call from the assistant followed by a
+    // tool_response carrying the oversized image — the actual read_file shape.
+    const messages: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'toolu_abc',
+            name: 'read_file',
+            parameters: { absolute_path: 'big.png' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'toolu_abc',
+            toolName: 'read_file',
+            result: 'Read big.png',
+          },
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: big,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    const result = await consumeGenerator(
+      provider,
+      buildCallOptions(provider, runtimeContext, settingsService, messages),
+    );
+
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+    expect(result.threw).toBe(false);
+    expect(result.chunks.join('')).toContain('recovered-nested');
+    // The retry request must not contain the oversized image bytes anywhere.
+    const retryRequest = mockMessagesCreate.mock.calls[1][0];
+    expect(JSON.stringify(retryRequest.messages)).not.toContain(big);
+    // The tool_result wrapper and pairing must survive in the retry body.
+    const retryMessages = retryRequest.messages as Array<{
+      content: unknown[];
+    }>;
+    const allBlocks = retryMessages.flatMap((msg) =>
+      Array.isArray(msg.content) ? msg.content : [],
+    );
+    const toolResultBlock = allBlocks.find(
+      (b): b is { tool_use_id?: string; type: string } =>
+        typeof b === 'object' &&
+        b !== null &&
+        (b as { type: string }).type === 'tool_result',
+    );
+    expect(toolResultBlock).toBeDefined();
+    expect(toolResultBlock?.tool_use_id).toBe('toolu_abc');
+  });
+});
+
+describe('AnthropicProvider image recovery through RetryOrchestrator (@issue:3216 H2)', () => {
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  it('dimension-400 then sanitized retry 429 = exactly two physical calls (budget-exhausted)', async () => {
+    vi.clearAllMocks();
+    const big = await pngBase64(3000, 3000);
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: false,
+    });
+    mockMessagesCreate
+      .mockRejectedValueOnce(make400ImageDimensionError())
+      .mockRejectedValueOnce(make429RateLimitError());
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: big,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    // Wrap in RetryOrchestrator with retries=2 (budget limit = 2 physical
+    // calls). The recovery's sanitized retry must consume the 2nd slot so
+    // the orchestrator does NOT make a third outer attempt.
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    const callOptions = createProviderCallOptions({
+      providerName: provider.name,
+      contents: messages,
+      settings: settingsService,
+      runtime: runtimeContext,
+      config: runtimeContext.config,
+      ephemerals: { retries: 2, retrywait: 0 },
+    } as Parameters<typeof createProviderCallOptions>[0]);
+
+    const chunks: string[] = [];
+    let threw = false;
+    try {
+      const gen = orchestrator.generateChatCompletion(callOptions);
+      for await (const chunk of gen) {
+        const text = chunk.blocks.find((b) => b.type === 'text');
+        if (text !== undefined) chunks.push(text.text);
+      }
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true); // The 429 exhausts the budget → throws
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2); // exactly two
+    // The second call must be the sanitized retry (image removed)
+    const retryReq = mockMessagesCreate.mock.calls[1][0];
+    expect(JSON.stringify(retryReq.messages)).not.toContain(big);
+  });
+
+  it('sanitized retry error propagates verbatim; no third physical call', async () => {
+    vi.clearAllMocks();
+    const big = await pngBase64(3000, 3000);
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: false,
+    });
+    // phys 1: poisoned original → 400 image-dimension error.
+    // phys 2: sanitized retry → distinct 500 marker error.
+    mockMessagesCreate
+      .mockRejectedValueOnce(make400ImageDimensionError())
+      .mockRejectedValueOnce(make500MarkerError());
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: big,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    // retries=2 → transport budget limit = 2 physical calls. The sanitized
+    // retry consumes the 2nd slot, so the orchestrator must stop there.
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    const callOptions = createProviderCallOptions({
+      providerName: provider.name,
+      contents: messages,
+      settings: settingsService,
+      runtime: runtimeContext,
+      config: runtimeContext.config,
+      ephemerals: { retries: 2, retrywait: 0 },
+    } as Parameters<typeof createProviderCallOptions>[0]);
+
+    let caught: unknown;
+    try {
+      const gen = orchestrator.generateChatCompletion(callOptions);
+      for await (const _chunk of gen) {
+        // drain
+      }
+    } catch (e) {
+      caught = e;
+    }
+
+    // The sanitized retry's OWN error is the real outcome and must propagate
+    // so the outer retry classification sees it — NOT the original 400.
+    expect(caught).toBeDefined();
+    const caughtMessage = String(
+      caught instanceof Error ? caught.message : caught,
+    );
+    expect(caughtMessage).toContain(
+      'RETRY_MARKER_PROPAGATED_FROM_SANITIZED_RETRY',
+    );
+    expect(caughtMessage).not.toContain('many-image');
+    // Exactly two physical calls: poisoned original + sanitized retry.
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT resend the poisoned original on a subsequent outer attempt', async () => {
+    vi.clearAllMocks();
+    const big = await pngBase64(3000, 3000);
+    const { provider, runtimeContext, settingsService } = setupProvider({
+      withImageBudget: false,
+    });
+    mockMessagesCreate
+      .mockRejectedValueOnce(make400ImageDimensionError()) // phys 1: poisoned
+      .mockRejectedValueOnce(make429RateLimitError()) // phys 2: sanitized retry
+      .mockResolvedValueOnce(createMockStream('third-ok')); // phys 3: sanitized
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: big,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 3,
+      initialDelayMs: 0,
+    });
+
+    const callOptions = createProviderCallOptions({
+      providerName: provider.name,
+      contents: messages,
+      settings: settingsService,
+      runtime: runtimeContext,
+      config: runtimeContext.config,
+      ephemerals: { retries: 3, retrywait: 0 },
+    } as Parameters<typeof createProviderCallOptions>[0]);
+
+    const chunks: string[] = [];
+    let threw = false;
+    try {
+      const gen = orchestrator.generateChatCompletion(callOptions);
+      for await (const chunk of gen) {
+        const text = chunk.blocks.find((b) => b.type === 'text');
+        if (text !== undefined) chunks.push(text.text);
+      }
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+    expect(chunks.join('')).toContain('third-ok');
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(3);
+    // Call 1: the poisoned original (contains big)
+    expect(
+      JSON.stringify(mockMessagesCreate.mock.calls[0][0].messages),
+    ).toContain(big);
+    // Call 2: sanitized retry (no big)
+    expect(
+      JSON.stringify(mockMessagesCreate.mock.calls[1][0].messages),
+    ).not.toContain(big);
+    // Call 3: sanitized body reused (no big, no resend of poisoned original)
+    expect(
+      JSON.stringify(mockMessagesCreate.mock.calls[2][0].messages),
+    ).not.toContain(big);
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -55,6 +55,16 @@ import {
   executeAnthropicApiCall,
 } from './AnthropicApiExecution.js';
 import { collectUnsupportedMedia } from '../utils/mediaUtils.js';
+import {
+  isAnthropicImageDimensionLimitError,
+  parseAnthropicImageDimensionLimit,
+  sanitizeAnthropicRequestBodyImages,
+  resolveAnthropicImageBudget,
+  resolveRecoveryImageBudget,
+  getImageRecoveryState,
+  ensureImageRecoveryState,
+} from './AnthropicImageSanitizer.js';
+import { tryConsumeTransportAttempt } from '../transportAttemptBudget.js';
 
 export class AnthropicProvider extends BaseProvider {
   // @plan PLAN-20251023-STATELESS-HARDENING.P08
@@ -648,19 +658,47 @@ export class AnthropicProvider extends BaseProvider {
       options.invocation.signal,
     );
 
+    // H2: if a prior outer attempt already sanitized this request's images,
+    // reuse the sanitized body instead of resending the poisoned original.
+    const recoveryState = getImageRecoveryState(options);
+    const effectiveRequestBody =
+      recoveryState?.sanitizedBody ?? requestContext.requestBody;
+
     const apiCallWithResponse = createAnthropicApiCall(
       initialClient,
-      requestContext.requestBody,
+      effectiveRequestBody,
       customHeaders,
       options.invocation.signal,
     );
 
-    const { response, rateLimitInfo } = await this.executeApiCall(
-      options,
-      requestContext,
-      apiCallWithResponse,
-      rateLimitLogger,
-    );
+    let response:
+      | Anthropic.Message
+      | AsyncIterable<Anthropic.MessageStreamEvent>;
+    let rateLimitInfo: AnthropicRateLimitInfo | undefined;
+
+    try {
+      const result = await this.executeApiCall(
+        options,
+        { ...requestContext, requestBody: effectiveRequestBody },
+        apiCallWithResponse,
+        rateLimitLogger,
+      );
+      response = result.response;
+      rateLimitInfo = result.rateLimitInfo;
+    } catch (error) {
+      // Issue #3216: one-shot reactive recovery for poisoned history.
+      const recovered = await this.executeImageDimensionRecovery(
+        error,
+        requestContext,
+        options,
+        initialClient,
+        customHeaders,
+        rateLimitLogger,
+      );
+      if (recovered === undefined) throw error;
+      response = recovered.response;
+      rateLimitInfo = recovered.rateLimitInfo;
+    }
 
     if (rateLimitInfo) {
       this.lastRateLimitInfo = rateLimitInfo;
@@ -673,6 +711,84 @@ export class AnthropicProvider extends BaseProvider {
       isOAuth,
       rateLimitLogger,
     );
+  }
+
+  /**
+   * Issue #3216: one-shot recovery from a 400 that specifically states an image
+   * dimension exceeded the many-image maximum. Sanitizes oversized base64 image
+   * blocks from an immutable copy of the request body and retries exactly once.
+   * Returns the retry result, or `undefined` when the error is not recoverable
+   * (unrelated 400, no parseable limit, no oversized blocks to remove, the
+   * request-scoped recovery was already used, or no transport attempt remains)
+   * so the caller rethrows the original error. Never loops.
+   *
+   * H2: the recovery is request-scoped — at most one recovery per logical
+   * request shared across outer RetryOrchestrator attempts — and the retry's
+   * physical transport call consumes a slot from the shared transport budget
+   * so outer attempt accounting stays exact. The sanitized body is stored in
+   * the shared request state so subsequent outer attempts reuse it instead of
+   * reconstructing and resending the poisoned original.
+   */
+  private async executeImageDimensionRecovery(
+    error: unknown,
+    requestContext: Awaited<ReturnType<typeof prepareAnthropicRequest>>,
+    options: NormalizedGenerateChatOptions,
+    initialClient: Parameters<typeof createAnthropicApiCall>[0],
+    customHeaders: Parameters<typeof createAnthropicApiCall>[2],
+    rateLimitLogger: { debug: (fn: () => string) => void },
+  ): Promise<
+    | {
+        response:
+          | Anthropic.Message
+          | AsyncIterable<Anthropic.MessageStreamEvent>;
+        rateLimitInfo: AnthropicRateLimitInfo | undefined;
+      }
+    | undefined
+  > {
+    if (!isAnthropicImageDimensionLimitError(error)) return undefined;
+    const state = ensureImageRecoveryState(options);
+    if (state.recoveryUsed) return undefined;
+    const configuredBudget = resolveAnthropicImageBudget(
+      requestContext.configEphemerals,
+    );
+    const errorLimit = parseAnthropicImageDimensionLimit(error);
+    const recoveryBudget = resolveRecoveryImageBudget(
+      configuredBudget,
+      errorLimit,
+    );
+    if (recoveryBudget === undefined) return undefined;
+    const sanitized = sanitizeAnthropicRequestBodyImages(
+      requestContext.requestBody,
+      recoveryBudget,
+    );
+    if (sanitized.replacedCount === 0) return undefined;
+    // A known-aborted request must not consume a transport slot on a recovery
+    // that can never produce a usable response. Check before accounting.
+    if (options.invocation.signal?.aborted === true) return undefined;
+    // H2: the retry is a physical transport call; account it in the shared
+    // budget. When no slot remains, the original error is final.
+    if (!tryConsumeTransportAttempt(options)) return undefined;
+    state.recoveryUsed = true;
+    state.sanitizedBody = sanitized.body;
+    this.getErrorsLogger().debug(
+      () =>
+        '[AnthropicProvider] Image dimension 400: sanitized oversized image block(s), retrying once',
+    );
+    const retryResult = await this.executeApiCall(
+      options,
+      { ...requestContext, requestBody: sanitized.body },
+      createAnthropicApiCall(
+        initialClient,
+        sanitized.body,
+        customHeaders,
+        options.invocation.signal,
+      ),
+      rateLimitLogger,
+    );
+    return {
+      response: retryResult.response,
+      rateLimitInfo: retryResult.rateLimitInfo,
+    };
   }
 
   private async prepareRequestContext(

--- a/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
@@ -38,6 +38,10 @@ import {
   formatContextPrefix,
   type SystemPromptPlacement,
 } from '../utils/systemPromptPlacement.js';
+import {
+  sanitizeAnthropicContentImages,
+  resolveAnthropicImageBudget,
+} from './AnthropicImageSanitizer.js';
 
 /**
  * Request preparation context returned to caller
@@ -760,8 +764,23 @@ export async function prepareAnthropicRequest(
   );
 
   const configForMessages = params.config ?? params.options.runtime?.config;
+
+  // Issue #3216: proactively sanitize oversized image blocks from the neutral
+  // history before conversion, so known-invalid bytes never reach the wire.
+  // The budget is resolved from invocation ephemerals (the stateless per-call
+  // source of truth), NOT from config.getEphemeralSettings — the stateless
+  // contract guarantees config is never accessed for request overrides.
+  // sanitizeAnthropicContentImages already returns the contents unchanged
+  // (0 replacements) when the budget is undefined, so no fallback is needed.
+  const configEphemeralsForBudget: Readonly<Record<string, unknown>> =
+    params.options.invocation.ephemerals;
+  const sanitizedContent = sanitizeAnthropicContentImages(
+    params.content,
+    resolveAnthropicImageBudget(configEphemeralsForBudget),
+  );
+
   const { anthropicMessages, anthropicTools } = convertMessagesAndTools({
-    content: params.content,
+    content: sanitizedContent.contents,
     tools: params.tools,
     isOAuth: params.isOAuth,
     reasoningSettings,

--- a/packages/providers/src/composition/aliases/claudecode.config
+++ b/packages/providers/src/composition/aliases/claudecode.config
@@ -27,7 +27,13 @@
       }
     },
     {
-      "pattern": "^claude-(opus|sonnet)(?:-|$)",
+      "pattern": "^claude-(opus-5|opus-4-8|sonnet-5)$",
+      "ephemeralSettings": {
+        "max-image-dimension": 2000
+      }
+    },
+    {
+      "pattern": "^claude-(?:opus|sonnet)(?!-(?:5|4-8)$)(?:-|$)",
       "ephemeralSettings": {
         "image-resize.maxLongEdge": 1568,
         "image-resize.maxShortEdge": 1568,

--- a/packages/providers/src/composition/aliases/claudecode.config
+++ b/packages/providers/src/composition/aliases/claudecode.config
@@ -33,7 +33,7 @@
       }
     },
     {
-      "pattern": "^claude-(?:opus|sonnet)(?!-(?:5|4-8)$)(?:-|$)",
+      "pattern": "^claude-(?:opus(?!-(?:5|4-8)$)|sonnet(?!-5$))(?:-|$)",
       "ephemeralSettings": {
         "image-resize.maxLongEdge": 1568,
         "image-resize.maxShortEdge": 1568,

--- a/packages/providers/src/composition/providerAliases.claudecode.imageBudget.test.ts
+++ b/packages/providers/src/composition/providerAliases.claudecode.imageBudget.test.ts
@@ -5,16 +5,13 @@
  */
 
 /**
- * Issue #3216 (M1+M2) — claudecode alias model defaults:
+ * Issue #3216 — claudecode alias model defaults:
  *
- * M1: The hard `max-image-dimension: 2000` budget must be anchored to the
- *     EXACT IDs `claude-opus-5`, `claude-opus-4-8`, and `claude-sonnet-5`.
- *     Substring matching (e.g. `claude-opus-50`, `claude-opus-5-preview`) must
- *     NOT match.
- *
- * M2: Older supported Opus/Sonnet models must keep their prior resize defaults
- *     (1568/1568/1,229,312). The three target models are excluded from implicit
- *     resize and only receive the hard 2000-pixel cap.
+ * The hard `max-image-dimension: 2000` budget applies only to the exact IDs
+ * `claude-opus-5`, `claude-opus-4-8`, and `claude-sonnet-5`; substring matches
+ * (e.g. `claude-opus-50`, `claude-opus-5-preview`) must not match. Older
+ * supported Opus/Sonnet models keep their prior resize defaults
+ * (1568/1568/1,229,312); the three target models receive only the hard cap.
  */
 
 import { describe, it, expect } from 'bun:test';
@@ -107,9 +104,7 @@ describe('claudecode older Opus/Sonnet models keep resize defaults (@issue:3216 
   });
 
   it('rule ordering cannot reapply resize to target models (merge safety)', () => {
-    // computeModelDefaults applies rules in order; later rules overwrite.
-    // Verify that the final merged result for target models has resize off
-    // even though the resize rule appears in the same config.
+    // Later rules overwrite earlier ones; verify resize stays off for targets.
     for (const model of [
       'claude-opus-5',
       'claude-opus-4-8',
@@ -121,5 +116,63 @@ describe('claudecode older Opus/Sonnet models keep resize defaults (@issue:3216 
       expect(defaults['image-resize.maxPixels']).toBeUndefined();
       expect(defaults['max-image-dimension']).toBe(2000);
     }
+  });
+});
+
+describe('claudecode 4-8 exclusion is Opus-only (@issue:3216)', () => {
+  // The 4-8 exclusion applies to Opus only (where the exact-ID hard cap
+  // applies); Sonnet continues to exclude version 5 only.
+
+  it('claude-sonnet-4-8 receives legacy 1568 resize defaults and no hard cap', () => {
+    const defaults = computeModelDefaults(
+      'claude-sonnet-4-8',
+      claudecodeModelDefaults(),
+    );
+    expect(defaults['image-resize.maxLongEdge']).toBe(1568);
+    expect(defaults['image-resize.maxShortEdge']).toBe(1568);
+    expect(defaults['image-resize.maxPixels']).toBe(1_229_312);
+    expect(defaults['max-image-dimension']).toBeUndefined();
+  });
+
+  it('the three exact target IDs remain unchanged (hard cap, no resize)', () => {
+    for (const model of [
+      'claude-opus-5',
+      'claude-opus-4-8',
+      'claude-sonnet-5',
+    ]) {
+      const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+      expect(defaults['max-image-dimension']).toBe(2000);
+      expect(defaults['image-resize.maxLongEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxShortEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxPixels']).toBeUndefined();
+    }
+  });
+
+  it('near-match sonnet IDs do not receive the hard cap', () => {
+    for (const model of [
+      'claude-sonnet-4-8',
+      'claude-sonnet-4-8-preview',
+      'claude-sonnet-4-80',
+      'claude-sonnet-48',
+    ]) {
+      const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+      expect(defaults['max-image-dimension']).toBeUndefined();
+    }
+  });
+
+  it('near-match opus IDs do not receive the hard cap (only the exact ID does)', () => {
+    for (const model of ['claude-opus-4-8-preview', 'claude-opus-4-80']) {
+      const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+      expect(defaults['max-image-dimension']).toBeUndefined();
+    }
+  });
+
+  it('claude-sonnet-5 stays excluded from legacy resize (version 5 for both families)', () => {
+    const defaults = computeModelDefaults(
+      'claude-sonnet-5',
+      claudecodeModelDefaults(),
+    );
+    expect(defaults['image-resize.maxLongEdge']).toBeUndefined();
+    expect(defaults['max-image-dimension']).toBe(2000);
   });
 });

--- a/packages/providers/src/composition/providerAliases.claudecode.imageBudget.test.ts
+++ b/packages/providers/src/composition/providerAliases.claudecode.imageBudget.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3216 (M1+M2) — claudecode alias model defaults:
+ *
+ * M1: The hard `max-image-dimension: 2000` budget must be anchored to the
+ *     EXACT IDs `claude-opus-5`, `claude-opus-4-8`, and `claude-sonnet-5`.
+ *     Substring matching (e.g. `claude-opus-50`, `claude-opus-5-preview`) must
+ *     NOT match.
+ *
+ * M2: Older supported Opus/Sonnet models must keep their prior resize defaults
+ *     (1568/1568/1,229,312). The three target models are excluded from implicit
+ *     resize and only receive the hard 2000-pixel cap.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { loadProviderAliasEntries } from './providerAliases.js';
+import { computeModelDefaults } from '../runtime/providerMutations.js';
+
+function claudecodeModelDefaults() {
+  const entry = loadProviderAliasEntries().find(
+    (e) => e.alias === 'claudecode',
+  );
+  if (!entry) {
+    throw new Error('claudecode alias entry not found');
+  }
+  return entry.config.modelDefaults ?? [];
+}
+
+describe('claudecode max-image-dimension exact-ID anchoring (@issue:3216 M1)', () => {
+  it.each(['claude-opus-5', 'claude-opus-4-8', 'claude-sonnet-5'])(
+    'applies max-image-dimension 2000 for exact target ID %s',
+    (model) => {
+      const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+      expect(defaults['max-image-dimension']).toBe(2000);
+    },
+  );
+
+  it.each([
+    'claude-opus-50',
+    'claude-sonnet-50',
+    'claude-opus-5-preview',
+    'claude-opus-5-20260101',
+    'claude-sonnet-5-preview',
+    'claude-opus-4-80',
+    'xclaude-opus-5',
+    'anthropic-claude-opus-5',
+  ])('does NOT apply max-image-dimension for non-target ID %s', (model) => {
+    const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+    expect(defaults['max-image-dimension']).toBeUndefined();
+  });
+});
+
+describe('claudecode target models get no implicit resize (@issue:3216 M1)', () => {
+  it.each(['claude-opus-5', 'claude-opus-4-8', 'claude-sonnet-5'])(
+    'does NOT set image-resize.* for %s',
+    (model) => {
+      const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+      expect(defaults['image-resize.maxLongEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxShortEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxPixels']).toBeUndefined();
+    },
+  );
+});
+
+describe('claudecode older Opus/Sonnet models keep resize defaults (@issue:3216 M2)', () => {
+  it.each([
+    'claude-opus-4-7',
+    'claude-opus-4-6',
+    'claude-opus-4-5-20251101',
+    'claude-opus-4-5',
+    'claude-sonnet-4-6',
+    'claude-sonnet-4-5-20250929',
+    'claude-sonnet-4-20250514',
+  ])('applies 1568/1568/1229312 resize defaults for %s', (model) => {
+    const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+    expect(defaults['image-resize.maxLongEdge']).toBe(1568);
+    expect(defaults['image-resize.maxShortEdge']).toBe(1568);
+    expect(defaults['image-resize.maxPixels']).toBe(1_229_312);
+  });
+
+  it('does NOT set max-image-dimension for older models', () => {
+    for (const model of [
+      'claude-opus-4-7',
+      'claude-opus-4-6',
+      'claude-opus-4-5-20251101',
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-5-20250929',
+      'claude-sonnet-4-20250514',
+    ]) {
+      const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+      expect(defaults['max-image-dimension']).toBeUndefined();
+    }
+  });
+
+  it('does NOT apply resize defaults for Haiku or Fable', () => {
+    for (const model of ['claude-haiku-4-5', 'claude-fable-5']) {
+      const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+      expect(defaults['image-resize.maxLongEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxShortEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxPixels']).toBeUndefined();
+    }
+  });
+
+  it('rule ordering cannot reapply resize to target models (merge safety)', () => {
+    // computeModelDefaults applies rules in order; later rules overwrite.
+    // Verify that the final merged result for target models has resize off
+    // even though the resize rule appears in the same config.
+    for (const model of [
+      'claude-opus-5',
+      'claude-opus-4-8',
+      'claude-sonnet-5',
+    ]) {
+      const defaults = computeModelDefaults(model, claudecodeModelDefaults());
+      expect(defaults['image-resize.maxLongEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxShortEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxPixels']).toBeUndefined();
+      expect(defaults['max-image-dimension']).toBe(2000);
+    }
+  });
+});

--- a/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
+++ b/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
@@ -642,35 +642,85 @@ describe('anthropic.config modelDefaults (Phase 02)', () => {
     expect(defaults['context-limit']).toBe(1000000);
   });
 
-  it.each(['anthropic', 'claudecode'])(
-    '%s applies image limits to Opus and Sonnet families only',
-    (alias) => {
-      const entry = loadProviderAliasEntries().find(
-        (candidate) =>
-          candidate.alias === alias && candidate.source === 'builtin',
-      );
-      expect(entry).toBeDefined();
-      const rules = entry?.config.modelDefaults ?? [];
-      for (const model of [
-        'claude-opus-4-5-20251101',
-        'claude-opus-5',
-        'claude-sonnet-4-20250514',
-        'claude-sonnet-5',
-      ]) {
-        expect(computeMatchedDefaults(model, rules)).toMatchObject({
-          'image-resize.maxLongEdge': 1568,
-          'image-resize.maxShortEdge': 1568,
-          'image-resize.maxPixels': 1_229_312,
-        });
-      }
-      expectNoImageResizeDefaults(
-        computeMatchedDefaults('claude-haiku-4-5', rules),
-      );
-      expectNoImageResizeDefaults(
-        computeMatchedDefaults('claude-fable-5', rules),
-      );
-    },
-  );
+  it('anthropic applies image-resize limits to Opus and Sonnet families only', () => {
+    const entry = loadProviderAliasEntries().find(
+      (candidate) =>
+        candidate.alias === 'anthropic' && candidate.source === 'builtin',
+    );
+    expect(entry).toBeDefined();
+    const rules = entry?.config.modelDefaults ?? [];
+    for (const model of [
+      'claude-opus-4-5-20251101',
+      'claude-opus-5',
+      'claude-sonnet-4-20250514',
+      'claude-sonnet-5',
+    ]) {
+      expect(computeMatchedDefaults(model, rules)).toMatchObject({
+        'image-resize.maxLongEdge': 1568,
+        'image-resize.maxShortEdge': 1568,
+        'image-resize.maxPixels': 1_229_312,
+      });
+    }
+    expectNoImageResizeDefaults(
+      computeMatchedDefaults('claude-haiku-4-5', rules),
+    );
+    expectNoImageResizeDefaults(
+      computeMatchedDefaults('claude-fable-5', rules),
+    );
+  });
+
+  it('claudecode applies max-image-dimension to Opus 5, Opus 4.8, and Sonnet 5 only @issue:3216', () => {
+    const entry = loadProviderAliasEntries().find(
+      (candidate) =>
+        candidate.alias === 'claudecode' && candidate.source === 'builtin',
+    );
+    expect(entry).toBeDefined();
+    const rules = entry?.config.modelDefaults ?? [];
+    for (const model of [
+      'claude-opus-5',
+      'claude-opus-4-8',
+      'claude-sonnet-5',
+    ]) {
+      expect(computeMatchedDefaults(model, rules)).toMatchObject({
+        'max-image-dimension': 2000,
+      });
+    }
+    // Older Opus/Sonnet generations DO get implicit resize defaults (M2),
+    // but do NOT get the hard image-dimension budget.
+    for (const model of [
+      'claude-opus-4-7',
+      'claude-opus-4-6',
+      'claude-opus-4-5-20251101',
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-5-20250929',
+      'claude-sonnet-4-20250514',
+    ]) {
+      const defaults = computeMatchedDefaults(model, rules);
+      expect(defaults['image-resize.maxLongEdge']).toBe(1568);
+      expect(defaults['image-resize.maxShortEdge']).toBe(1568);
+      expect(defaults['image-resize.maxPixels']).toBe(1_229_312);
+      expect(defaults['max-image-dimension']).toBeUndefined();
+    }
+    // Haiku and Fable are NOT in the Opus/Sonnet family — no resize, no cap.
+    expectNoImageResizeDefaults(
+      computeMatchedDefaults('claude-haiku-4-5', rules),
+    );
+    expectNoImageResizeDefaults(
+      computeMatchedDefaults('claude-fable-5', rules),
+    );
+    // Target models get the hard cap but NOT implicit resize defaults.
+    for (const model of [
+      'claude-opus-5',
+      'claude-opus-4-8',
+      'claude-sonnet-5',
+    ]) {
+      const defaults = computeMatchedDefaults(model, rules);
+      expect(defaults['image-resize.maxLongEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxShortEdge']).toBeUndefined();
+      expect(defaults['image-resize.maxPixels']).toBeUndefined();
+      expect(defaults['max-image-dimension']).toBe(2000);
+    }
+  });
 
   it.each(['openai', 'openai-responses', 'openai-vercel', 'codex'])(
     '%s applies image limits to every gpt- family model',

--- a/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
+++ b/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
@@ -655,18 +655,21 @@ describe('anthropic.config modelDefaults (Phase 02)', () => {
       'claude-sonnet-4-20250514',
       'claude-sonnet-5',
     ]) {
-      expect(computeMatchedDefaults(model, rules)).toMatchObject({
+      const defaults = computeMatchedDefaults(model, rules);
+      expect(defaults).toMatchObject({
         'image-resize.maxLongEdge': 1568,
         'image-resize.maxShortEdge': 1568,
         'image-resize.maxPixels': 1_229_312,
       });
+      expect(defaults['max-image-dimension']).toBeUndefined();
+      expect(defaults['max-image-pixels']).toBeUndefined();
     }
-    expectNoImageResizeDefaults(
-      computeMatchedDefaults('claude-haiku-4-5', rules),
-    );
-    expectNoImageResizeDefaults(
-      computeMatchedDefaults('claude-fable-5', rules),
-    );
+    for (const model of ['claude-haiku-4-5', 'claude-fable-5']) {
+      const defaults = computeMatchedDefaults(model, rules);
+      expectNoImageResizeDefaults(defaults);
+      expect(defaults['max-image-dimension']).toBeUndefined();
+      expect(defaults['max-image-pixels']).toBeUndefined();
+    }
   });
 
   it('claudecode applies max-image-dimension to Opus 5, Opus 4.8, and Sonnet 5 only @issue:3216', () => {

--- a/packages/providers/src/transportAttemptBudget.ts
+++ b/packages/providers/src/transportAttemptBudget.ts
@@ -6,7 +6,12 @@
 
 import type { GenerateChatOptions } from './IProvider.js';
 
-const RETRY_REQUEST_CONTEXT_KEY = '_retryRequestContext';
+/**
+ * Metadata key holding the per-request retry context object shared across
+ * orchestrator attempts (budget + request-scoped recovery state). Exported so
+ * providers can attach request-scoped state that must survive outer retries.
+ */
+export const RETRY_REQUEST_CONTEXT_KEY = '_retryRequestContext';
 const TRANSPORT_ATTEMPT_BUDGET_KEY = 'transportAttemptBudget';
 
 export interface TransportAttemptBudget {

--- a/packages/settings/src/__tests__/settingsRegistry.issue3216.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue3216.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3216 — Configurable hard image budget settings.
+ *
+ * `max-image-dimension` and `max-image-pixels` are overridable ephemeral
+ * settings that define a provider/model-specific hard limit enforced before
+ * image bytes reach a model. These tests prove the registry accepts positive
+ * integers, rejects invalid values, persists through profiles, and exposes the
+ * keys through the standard registry surface.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  getSettingSpec,
+  validateSetting,
+  getProfilePersistableKeys,
+  getAllSettingKeys,
+} from '../settings/settingsRegistry.js';
+
+describe('max-image-dimension (@issue:3216)', () => {
+  it('is registered as a number setting', () => {
+    const spec = getSettingSpec('max-image-dimension');
+    expect(spec).toBeDefined();
+    expect(spec!.type).toBe('number');
+    expect(spec!.persistToProfile).toBe(true);
+  });
+
+  it('accepts a positive integer', () => {
+    const result = validateSetting('max-image-dimension', 2000);
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(2000);
+  });
+
+  it('rejects zero, negatives, non-integers, and non-numbers', () => {
+    expect(validateSetting('max-image-dimension', 0).success).toBe(false);
+    expect(validateSetting('max-image-dimension', -5).success).toBe(false);
+    expect(validateSetting('max-image-dimension', 1.5).success).toBe(false);
+    expect(validateSetting('max-image-dimension', 'big').success).toBe(false);
+  });
+
+  it('appears in profile-persistable keys and all setting keys', () => {
+    expect(getProfilePersistableKeys()).toContain('max-image-dimension');
+    expect(getAllSettingKeys()).toContain('max-image-dimension');
+  });
+});
+
+describe('max-image-pixels (@issue:3216)', () => {
+  it('is registered as a number setting', () => {
+    const spec = getSettingSpec('max-image-pixels');
+    expect(spec).toBeDefined();
+    expect(spec!.type).toBe('number');
+    expect(spec!.persistToProfile).toBe(true);
+  });
+
+  it('accepts a positive integer', () => {
+    const result = validateSetting('max-image-pixels', 4_000_000);
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(4_000_000);
+  });
+
+  it('rejects zero, negatives, non-integers, and non-numbers', () => {
+    expect(validateSetting('max-image-pixels', 0).success).toBe(false);
+    expect(validateSetting('max-image-pixels', -1).success).toBe(false);
+    expect(validateSetting('max-image-pixels', 2.5).success).toBe(false);
+    expect(validateSetting('max-image-pixels', false).success).toBe(false);
+  });
+
+  it('appears in profile-persistable keys and all setting keys', () => {
+    expect(getProfilePersistableKeys()).toContain('max-image-pixels');
+    expect(getAllSettingKeys()).toContain('max-image-pixels');
+  });
+});

--- a/packages/settings/src/profiles/types.ts
+++ b/packages/settings/src/profiles/types.ts
@@ -77,6 +77,8 @@ export interface EphemeralSettings {
   'image-resize.maxLongEdge'?: number;
   'image-resize.maxShortEdge'?: number;
   'image-resize.maxPixels'?: number;
+  'max-image-dimension'?: number;
+  'max-image-pixels'?: number;
   'max-prompt-tokens'?: number;
   'disabled-tools'?: string[];
   'shell-replacement'?: 'allowlist' | 'all' | 'none' | boolean;

--- a/packages/settings/src/settings/registry/registry-entries-1.ts
+++ b/packages/settings/src/settings/registry/registry-entries-1.ts
@@ -445,6 +445,36 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
       },
     }),
   ),
+  ...[
+    {
+      key: 'max-image-dimension',
+      description:
+        'Hard maximum image width/height in pixels before bytes are rejected (oversized images return a tool error instead of being sent)',
+    },
+    {
+      key: 'max-image-pixels',
+      description:
+        'Hard maximum total image pixels before bytes are rejected (oversized images return a tool error instead of being sent)',
+    },
+  ].map(
+    ({ key, description }): SettingSpec => ({
+      key,
+      category: 'model-behavior',
+      description,
+      type: 'number',
+      hint: 'positive integer pixels',
+      persistToProfile: true,
+      validate: (value: unknown): ValidationResult => {
+        if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+          return { success: true, value };
+        }
+        return {
+          success: false,
+          message: `${key} must be a positive integer`,
+        };
+      },
+    }),
+  ),
   {
     key: 'tool-output-max-tokens',
     category: 'cli-behavior',

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -56,6 +56,11 @@
       "bun": "./src/utils/imageDimensions.ts",
       "import": "./dist/src/utils/imageDimensions.js"
     },
+    "./utils/imageDimensionBudget.js": {
+      "types": "./dist/src/utils/imageDimensionBudget.d.ts",
+      "bun": "./src/utils/imageDimensionBudget.ts",
+      "import": "./dist/src/utils/imageDimensionBudget.js"
+    },
     "./utils/imageTokenEstimation.js": {
       "types": "./dist/src/utils/imageTokenEstimation.d.ts",
       "bun": "./src/utils/imageTokenEstimation.ts",

--- a/packages/tools/src/__tests__/filesystem-tools.test.ts
+++ b/packages/tools/src/__tests__/filesystem-tools.test.ts
@@ -351,9 +351,35 @@ describe('Filesystem Tool Group Behavioral Tests @plan:PLAN-20260608-ISSUE1585.P
       expect(result.error?.message).toContain(
         'image-resize.maxLongEdge must be a positive integer',
       );
-      expect(result.returnDisplay).toContain(
-        'Image Resize Configuration Error',
+      expect(result.returnDisplay).toContain('Image Configuration Error');
+    });
+
+    it('returns a clear, accurately-labeled error for malformed image budget settings', async () => {
+      const { filePath } = await createPngFixture(
+        tempDir,
+        'invalid-budget.png',
+        {
+          r: 15,
+          g: 30,
+          b: 45,
+        },
       );
+      const tool = new ReadFileTool(
+        _createFakeFileHost(tempDir, {
+          'max-image-dimension': 0,
+        }),
+      );
+
+      const result = await executeToolForBehavioralAssertion(tool, {
+        file_path: filePath,
+      });
+
+      // A malformed hard image budget surfaces its message and a combined
+      // label that covers both resize and budget configuration errors.
+      expect(result.error?.message).toContain(
+        'max-image-dimension must be a positive integer',
+      );
+      expect(result.returnDisplay).toContain('Image Configuration Error');
     });
 
     it('returns a clear error for corrupt images under automatic resizing', async () => {

--- a/packages/tools/src/__tests__/image-budget-preflight.issue3216.test.ts
+++ b/packages/tools/src/__tests__/image-budget-preflight.issue3216.test.ts
@@ -1,0 +1,620 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3216 — Behavioral integration tests proving the hard image budget
+ * preflight runs at the output boundary of every built-in image-producing
+ * tool and never lets oversized bytes into the returned content.
+ *
+ * These tests use real image bytes (sharp), real temp files, and the real
+ * read_file / generate_image result paths. Only the image-generation transport
+ * is stubbed; the budget logic and tools under test are never mocked.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import sharp from 'sharp';
+import type { IToolHost } from '../interfaces/index.js';
+import {
+  processSingleFileContent,
+  type ProcessedFileReadResult,
+} from '../utils/fileUtils.js';
+import { ReadFileTool } from '../tools/read-file.js';
+import { ReadManyFilesTool } from '../tools/read-many-files.js';
+import { GenerateImageTool } from '../tools/generate-image/GenerateImageTool.js';
+import { createRealToolHost } from './helpers/create-real-tool-host.js';
+import type { ContentPartListUnion } from '../types/wire-types.js';
+import type { ImageOperationRunnerResult } from '../tools/generate-image/GenerateImageTool.js';
+import { ToolErrorType } from '../types/tool-error.js';
+import type { ImageDimensionBudget } from '../utils/imageDimensionBudget.js';
+
+const tempDirs: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'llxprt-imgbudget-3216-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function createHostWithBudget(
+  targetDir: string,
+  budget: Record<string, unknown>,
+) {
+  const baseHost = createRealToolHost(targetDir, {
+    respectGitIgnore: true,
+    respectLlxprtIgnore: true,
+  });
+  return {
+    ...baseHost,
+    getEphemeralSettings: () => ({
+      ...baseHost.getEphemeralSettings(),
+      ...budget,
+    }),
+  };
+}
+async function writePng(
+  dir: string,
+  name: string,
+  width: number,
+  height: number,
+): Promise<string> {
+  const file = join(dir, name);
+  const buffer = await sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r: 12, g: 34, b: 56, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  writeFileSync(file, buffer);
+  return file;
+}
+
+function createHost(
+  targetDir: string,
+  ephemeralSettings: Record<string, unknown> = {},
+): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getFileSystemService: () => undefined,
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ephemeralSettings,
+    getDebugMode: () => false,
+  };
+}
+
+function hasInlineDataBytes(result: ProcessedFileReadResult): boolean {
+  if (typeof result.llmContent === 'string') return false;
+  return typeof result.llmContent.inlineData?.data === 'string';
+}
+
+/**
+ * Extract the inlineData base64 string from a tool-result LLM content union,
+ * returning `undefined` when no image bytes are present. Cast-free structural
+ * narrowing of `ContentPartListUnion` (used by the read_file / read_many_files
+ * tool-result assertions).
+ */
+function extractInlineDataData(
+  content: ContentPartListUnion,
+): string | undefined {
+  if (typeof content === 'string') return undefined;
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (typeof part === 'string') continue;
+      const data = part.inlineData?.data;
+      if (typeof data === 'string') return data;
+    }
+    return undefined;
+  }
+  const data = content.inlineData?.data;
+  return typeof data === 'string' ? data : undefined;
+}
+
+describe('processSingleFileContent image budget preflight (@issue:3216)', () => {
+  it('rejects an oversized image with a tool error and no inline bytes', async () => {
+    const dir = createTempDir();
+    const file = await writePng(dir, 'big.png', 3000, 3000);
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+
+    const result = await processSingleFileContent(
+      file,
+      dir,
+      undefined,
+      undefined,
+      undefined,
+      budget,
+    );
+
+    expect(hasInlineDataBytes(result)).toBe(false);
+    expect(typeof result.llmContent).toBe('string');
+    expect(result.error).toBeDefined();
+    expect(result.errorType).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+    expect(result.errorKind).toBe('image-budget');
+    // Error message is actionable.
+    const message = String(result.llmContent);
+    expect(message).toContain('3000');
+    expect(/thumbnail|downscal|resize/i.test(message)).toBe(true);
+  });
+
+  it('delivers a within-budget image as inline bytes', async () => {
+    const dir = createTempDir();
+    const file = await writePng(dir, 'ok.png', 1800, 1800);
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+
+    const result = await processSingleFileContent(
+      file,
+      dir,
+      undefined,
+      undefined,
+      undefined,
+      budget,
+    );
+
+    expect(hasInlineDataBytes(result)).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('passes an image exactly at the boundary', async () => {
+    const dir = createTempDir();
+    const file = await writePng(dir, 'exact.png', 2000, 2000);
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+
+    const result = await processSingleFileContent(
+      file,
+      dir,
+      undefined,
+      undefined,
+      undefined,
+      budget,
+    );
+
+    expect(hasInlineDataBytes(result)).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('runs the check AFTER explicit resize so a resized image passes', async () => {
+    const dir = createTempDir();
+    const file = await writePng(dir, 'resized.png', 3000, 3000);
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+    // Explicit resize policy that brings the image under the hard budget.
+    const resizePolicy = {
+      maxLongEdge: 1500,
+      maxShortEdge: 1500,
+      maxPixels: 1500 * 1500,
+    };
+
+    const result = await processSingleFileContent(
+      file,
+      dir,
+      undefined,
+      undefined,
+      resizePolicy,
+      budget,
+    );
+
+    expect(hasInlineDataBytes(result)).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('does not apply a budget when none is configured (no silent error)', async () => {
+    const dir = createTempDir();
+    const file = await writePng(dir, 'unbounded.png', 3000, 3000);
+
+    const result = await processSingleFileContent(
+      file,
+      dir,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(hasInlineDataBytes(result)).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('leaves non-image media unchanged (no dimension invented)', async () => {
+    const dir = createTempDir();
+    // A real, well-formed PDF header followed by filler so detectFileType
+    // classifies it as 'pdf'.
+    const pdfBytes = Buffer.concat([
+      Buffer.from('%PDF-1.4\n'),
+      Buffer.alloc(64, 0x20),
+    ]);
+    const file = join(dir, 'doc.pdf');
+    writeFileSync(file, pdfBytes);
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+
+    const result = await processSingleFileContent(
+      file,
+      dir,
+      undefined,
+      undefined,
+      undefined,
+      budget,
+    );
+
+    // PDFs are delivered as inline bytes; the dimension budget is not applied
+    // to non-image media.
+    expect(result.error).toBeUndefined();
+  });
+});
+
+describe('read_file tool image budget preflight (@issue:3216)', () => {
+  it('returns a structured tool error for a 3000px image and no inline bytes', async () => {
+    const dir = createTempDir();
+    const file = await writePng(dir, 'big.png', 3000, 3000);
+    const host = createHost(dir, { 'max-image-dimension': 2000 });
+    const tool = new ReadFileTool(host);
+
+    const result = await tool.execute({ absolute_path: file });
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.type).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+    expect(typeof result.llmContent).toBe('string');
+    expect(result.llmContent).toContain('3000');
+    // No inline data escapes into history.
+    expect(extractInlineDataData(result.llmContent)).toBeUndefined();
+  });
+
+  it('delivers an 1800px image successfully', async () => {
+    const dir = createTempDir();
+    const file = await writePng(dir, 'ok.png', 1800, 1800);
+    const host = createHost(dir, { 'max-image-dimension': 2000 });
+    const tool = new ReadFileTool(host);
+
+    const result = await tool.execute({ absolute_path: file });
+
+    expect(result.error).toBeUndefined();
+    expect(typeof extractInlineDataData(result.llmContent)).toBe('string');
+  });
+});
+describe('read_many_files tool image budget preflight (@issue:3216)', () => {
+  it('returns a structured tool error for a 3000px image and no inline bytes', async () => {
+    const dir = createTempDir();
+    await writePng(dir, 'big.png', 3000, 3000);
+    // read_many_files resolves paths relative to the target dir.
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
+    );
+
+    const result = await tool.execute({ paths: ['big.png'] });
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.type).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+    expect(typeof result.llmContent).toBe('string');
+    expect(String(result.llmContent)).toContain('3000');
+  });
+
+  it('delivers an 1800px image successfully as inline bytes', async () => {
+    const dir = createTempDir();
+    await writePng(dir, 'ok.png', 1800, 1800);
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
+    );
+
+    const result = await tool.execute({ paths: ['ok.png'] });
+
+    expect(result.error).toBeUndefined();
+    // The within-budget image must be present as inline base64 bytes.
+    expect(Array.isArray(result.llmContent)).toBe(true);
+    let foundInline = false;
+    if (Array.isArray(result.llmContent)) {
+      for (const part of result.llmContent) {
+        if (typeof part !== 'string' && part.inlineData?.data !== undefined) {
+          foundInline = true;
+          break;
+        }
+      }
+    }
+    expect(foundInline).toBe(true);
+  });
+});
+
+describe('generate_image tool image budget preflight (@issue:3216)', () => {
+  async function makeLargePngResult(
+    width: number,
+    height: number,
+    absoluteOutputPath = '/workspace/out.png',
+    relativeOutputPath = 'out.png',
+  ): Promise<ImageOperationRunnerResult> {
+    const buffer = await sharp({
+      create: {
+        width,
+        height,
+        channels: 4,
+        background: { r: 200, g: 100, b: 50, alpha: 1 },
+      },
+    })
+      .png()
+      .toBuffer();
+    return {
+      operation: 'generate',
+      absoluteOutputPath,
+      relativeOutputPath,
+      mimeType: 'image/png',
+      backend: 'stub',
+      provider: 'stub',
+      model: 'stub-model',
+      inputPaths: [],
+      media: {
+        mimeType: 'image/png',
+        encoding: 'base64',
+        data: buffer.toString('base64'),
+      },
+    };
+  }
+
+  it('returns a POLICY_VIOLATION tool error for an oversized generated image with no inline bytes', async () => {
+    const largeResult = await makeLargePngResult(3000, 3000);
+    const tool = new GenerateImageTool({
+      runImage: async () => largeResult,
+      getImageDimensionBudget: () => ({ maxDimension: 2000 }),
+    });
+
+    const result = await tool
+      .build({ prompt: 'a thing', output_path: 'out.png' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    // A generated image that exceeds the budget is a content-policy violation,
+    // not a read failure (generation succeeded and the file was saved).
+    expect(result.error!.type).toBe(ToolErrorType.POLICY_VIOLATION);
+    const llmContent = result.llmContent;
+    expect(typeof llmContent).toBe('string');
+    expect(String(llmContent)).toContain('3000');
+    // No image bytes escape into model history.
+    expect(extractInlineDataData(result.llmContent)).toBeUndefined();
+  });
+
+  it('states the oversized image was saved but omitted from model content/history', async () => {
+    const dir = createTempDir();
+    const outPath = join(dir, 'gen.png');
+    const largeResult = await makeLargePngResult(
+      3000,
+      3000,
+      outPath,
+      'gen.png',
+    );
+    const tool = new GenerateImageTool({
+      runImage: async () => largeResult,
+      getImageDimensionBudget: () => ({ maxDimension: 2000 }),
+    });
+
+    const result = await tool
+      .build({ prompt: 'a thing', output_path: 'gen.png' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    const message = String(result.llmContent);
+    // The error must name the saved path and state the omission explicitly.
+    expect(message).toContain(outPath);
+    expect(message.toLowerCase()).toContain('saved');
+    expect(/omit|history|model content/i.test(message)).toBe(true);
+    // Downscale/thumbnail guidance is still present.
+    expect(/thumbnail|downscal|resize/i.test(message)).toBe(true);
+  });
+
+  it('retains the generated file on disk and never deletes it (no silent unlink)', async () => {
+    const dir = createTempDir();
+    const outPath = join(dir, 'retained.png');
+    // The runner is the production authority that writes the file BEFORE the
+    // tool applies the post-hoc budget check. The stub mirrors that contract.
+    const largeResult = await makeLargePngResult(
+      3000,
+      3000,
+      outPath,
+      'retained.png',
+    );
+    writeFileSync(outPath, Buffer.from(largeResult.media.data, 'base64'));
+    expect(existsSync(outPath)).toBe(true);
+
+    const tool = new GenerateImageTool({
+      runImage: async () => largeResult,
+      getImageDimensionBudget: () => ({ maxDimension: 2000 }),
+    });
+
+    const result = await tool
+      .build({ prompt: 'a thing', output_path: 'retained.png' })
+      .execute(new AbortController().signal);
+
+    // Budget violation surfaced, but the user's generated file is preserved.
+    expect(result.error).toBeDefined();
+    expect(result.error!.type).toBe(ToolErrorType.POLICY_VIOLATION);
+    expect(existsSync(outPath)).toBe(true);
+    expect(extractInlineDataData(result.llmContent)).toBeUndefined();
+  });
+
+  it('delivers a within-budget generated image', async () => {
+    const smallResult = await makeLargePngResult(1000, 1000);
+    const tool = new GenerateImageTool({
+      runImage: async () => smallResult,
+      getImageDimensionBudget: () => ({ maxDimension: 2000 }),
+    });
+
+    const result = await tool
+      .build({ prompt: 'a thing', output_path: 'out.png' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(Array.isArray(result.llmContent)).toBe(true);
+  });
+});
+
+describe('read_many_files H4: dimension check before size-skip gate (@issue:3216 H4)', () => {
+  async function writeNoisyPng(
+    dir: string,
+    name: string,
+    width: number,
+    height: number,
+  ): Promise<string> {
+    // Create a genuinely noisy (incompressible) PNG that exceeds 512KiB.
+    const file = join(dir, name);
+    const data = new Uint8Array(width * height * 4);
+    for (let i = 0; i < data.length; i += 4) {
+      // Pseudo-random noise for incompressibility.
+      data[i] = (i * 17 + 31) & 0xff;
+      data[i + 1] = (i * 23 + 7) & 0xff;
+      data[i + 2] = (i * 31 + 3) & 0xff;
+      data[i + 3] = 0xff;
+    }
+    const buffer = await sharp(Buffer.from(data), {
+      raw: { width, height, channels: 4 },
+    })
+      .png()
+      .toBuffer();
+    writeFileSync(file, buffer);
+    return file;
+  }
+
+  it('returns structured image-budget error for an oversized explicit image above 512KiB', async () => {
+    const dir = createTempDir();
+    // 3000x3000 noisy PNG: dimensions exceed the 2000 budget AND the file is
+    // >512KiB so the generic size-skip gate would normally swallow it.
+    await writeNoisyPng(dir, 'big.png', 3000, 3000);
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
+    );
+
+    const result = await tool.execute({ paths: ['big.png'] });
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.type).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+    const message = String(result.llmContent);
+    expect(message).toContain('3000');
+  });
+
+  it('returns overall error for mixed valid content plus later oversized image (no earlier bytes escape)', async () => {
+    const dir = createTempDir();
+    // A valid text file plus an oversized image. The overall result must be
+    // an error (not a silent skip), and the text file must NOT escape as
+    // inline content.
+    writeFileSync(join(dir, 'notes.txt'), 'hello world');
+    await writeNoisyPng(dir, 'big.png', 3000, 3000);
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
+    );
+
+    const result = await tool.execute({ paths: ['notes.txt', 'big.png'] });
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.type).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+    // The error message is about the image dimension, not the text file.
+    const message = String(result.llmContent);
+    expect(message).toContain('3000');
+  });
+
+  it('large but within-dimension image follows existing item-size policy', async () => {
+    const dir = createTempDir();
+    // 2000x2000 noisy PNG: within the 2000 dimension budget but >512KiB so
+    // it should be silently size-skipped, NOT produce a budget error.
+    await writeNoisyPng(dir, 'large.png', 2000, 2000);
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
+    );
+
+    const result = await tool.execute({ paths: ['large.png'] });
+
+    // No image-budget error (dimensions are within budget); the file is
+    // size-skipped rather than rejected.
+    const message = String(result.llmContent);
+    expect(message).not.toContain('exceeds the configured maximum dimension');
+  });
+});
+
+describe('read_many_files token-overflow metric/path semantics (@issue:3216)', () => {
+  it('does not record a file as processed when its content was skipped (warn stop)', async () => {
+    const dir = createTempDir();
+    // a-small fits the token budget and is added; b-big overflows in warn
+    // mode and is skipped (action 'stop') WITHOUT adding content.
+    writeFileSync(join(dir, 'a-small.txt'), 'hi');
+    writeFileSync(join(dir, 'b-big.txt'), 'x'.repeat(5000));
+
+    const recordedPaths: string[] = [];
+    const baseHost = createHost(dir, {
+      'tool-output-max-tokens': 100,
+      'tool-output-truncate-mode': 'warn',
+    });
+    const trackingHost: IToolHost = {
+      ...baseHost,
+      recordFileRead: (filePath: string) => recordedPaths.push(filePath),
+    };
+    const tool = new ReadManyFilesTool(trackingHost);
+
+    const result = await tool.execute({ paths: ['a-small.txt', 'b-big.txt'] });
+
+    // b-big.txt was skipped due to the token limit, so it must NOT be listed
+    // as a processed file or recorded via the read metric.
+    const display = String(result.returnDisplay);
+    expect(display).toContain('a-small.txt');
+    expect(display).not.toContain('b-big.txt');
+    expect(recordedPaths.some((p) => p.endsWith('a-small.txt'))).toBe(true);
+    expect(recordedPaths.some((p) => p.endsWith('b-big.txt'))).toBe(false);
+  });
+
+  it('records a truncated file before stopping (stopAfterRecord)', async () => {
+    const dir = createTempDir();
+    writeFileSync(join(dir, 'a-big.txt'), 'y'.repeat(5000));
+
+    const recordedPaths: string[] = [];
+    const baseHost = createHost(dir, {
+      'tool-output-max-tokens': 500,
+      'tool-output-truncate-mode': 'truncate',
+    });
+    const trackingHost: IToolHost = {
+      ...baseHost,
+      recordFileRead: (filePath: string) => recordedPaths.push(filePath),
+    };
+    const tool = new ReadManyFilesTool(trackingHost);
+
+    const result = await tool.execute({ paths: ['a-big.txt'] });
+
+    // truncate mode records the (truncated) content before stopping.
+    const display = String(result.returnDisplay);
+    expect(display).toContain('a-big.txt');
+    expect(recordedPaths.some((p) => p.endsWith('a-big.txt'))).toBe(true);
+    // Sanity: the truncated content was actually emitted.
+    const llm = result.llmContent;
+    if (!Array.isArray(llm)) {
+      throw new Error('expected array llmContent in truncate mode');
+    }
+    const joined = llm
+      .filter((part): part is string => typeof part === 'string')
+      .join('');
+    expect(joined).toContain('CONTENT TRUNCATED');
+  });
+});

--- a/packages/tools/src/__tests__/image-budget-preflight.issue3216.test.ts
+++ b/packages/tools/src/__tests__/image-budget-preflight.issue3216.test.ts
@@ -164,7 +164,6 @@ describe('processSingleFileContent image budget preflight (@issue:3216)', () => 
     expect(result.error).toBeDefined();
     expect(result.errorType).toBe(ToolErrorType.READ_CONTENT_FAILURE);
     expect(result.errorKind).toBe('image-budget');
-    // Error message is actionable.
     const message = String(result.llmContent);
     expect(message).toContain('3000');
     expect(/thumbnail|downscal|resize/i.test(message)).toBe(true);
@@ -210,7 +209,6 @@ describe('processSingleFileContent image budget preflight (@issue:3216)', () => 
     const dir = createTempDir();
     const file = await writePng(dir, 'resized.png', 3000, 3000);
     const budget: ImageDimensionBudget = { maxDimension: 2000 };
-    // Explicit resize policy that brings the image under the hard budget.
     const resizePolicy = {
       maxLongEdge: 1500,
       maxShortEdge: 1500,
@@ -249,8 +247,7 @@ describe('processSingleFileContent image budget preflight (@issue:3216)', () => 
 
   it('leaves non-image media unchanged (no dimension invented)', async () => {
     const dir = createTempDir();
-    // A real, well-formed PDF header followed by filler so detectFileType
-    // classifies it as 'pdf'.
+    // A real PDF header followed by filler so detectFileType classifies it.
     const pdfBytes = Buffer.concat([
       Buffer.from('%PDF-1.4\n'),
       Buffer.alloc(64, 0x20),
@@ -268,8 +265,7 @@ describe('processSingleFileContent image budget preflight (@issue:3216)', () => 
       budget,
     );
 
-    // PDFs are delivered as inline bytes; the dimension budget is not applied
-    // to non-image media.
+    // The dimension budget does not apply to non-image media.
     expect(result.error).toBeUndefined();
   });
 });
@@ -287,7 +283,6 @@ describe('read_file tool image budget preflight (@issue:3216)', () => {
     expect(result.error!.type).toBe(ToolErrorType.READ_CONTENT_FAILURE);
     expect(typeof result.llmContent).toBe('string');
     expect(result.llmContent).toContain('3000');
-    // No inline data escapes into history.
     expect(extractInlineDataData(result.llmContent)).toBeUndefined();
   });
 
@@ -330,7 +325,6 @@ describe('read_many_files tool image budget preflight (@issue:3216)', () => {
     const result = await tool.execute({ paths: ['ok.png'] });
 
     expect(result.error).toBeUndefined();
-    // The within-budget image must be present as inline base64 bytes.
     expect(Array.isArray(result.llmContent)).toBe(true);
     let foundInline = false;
     if (Array.isArray(result.llmContent)) {
@@ -391,13 +385,12 @@ describe('generate_image tool image budget preflight (@issue:3216)', () => {
       .execute(new AbortController().signal);
 
     expect(result.error).toBeDefined();
-    // A generated image that exceeds the budget is a content-policy violation,
-    // not a read failure (generation succeeded and the file was saved).
+    // A generated image exceeding the budget is a policy violation, not a
+    // read failure (generation succeeded and the file was saved).
     expect(result.error!.type).toBe(ToolErrorType.POLICY_VIOLATION);
     const llmContent = result.llmContent;
     expect(typeof llmContent).toBe('string');
     expect(String(llmContent)).toContain('3000');
-    // No image bytes escape into model history.
     expect(extractInlineDataData(result.llmContent)).toBeUndefined();
   });
 
@@ -421,19 +414,17 @@ describe('generate_image tool image budget preflight (@issue:3216)', () => {
 
     expect(result.error).toBeDefined();
     const message = String(result.llmContent);
-    // The error must name the saved path and state the omission explicitly.
     expect(message).toContain(outPath);
     expect(message.toLowerCase()).toContain('saved');
     expect(/omit|history|model content/i.test(message)).toBe(true);
-    // Downscale/thumbnail guidance is still present.
     expect(/thumbnail|downscal|resize/i.test(message)).toBe(true);
   });
 
   it('retains the generated file on disk and never deletes it (no silent unlink)', async () => {
     const dir = createTempDir();
     const outPath = join(dir, 'retained.png');
-    // The runner is the production authority that writes the file BEFORE the
-    // tool applies the post-hoc budget check. The stub mirrors that contract.
+    // The production runner writes the file BEFORE the tool applies the
+    // budget check; the stub mirrors that contract.
     const largeResult = await makeLargePngResult(
       3000,
       3000,
@@ -452,7 +443,7 @@ describe('generate_image tool image budget preflight (@issue:3216)', () => {
       .build({ prompt: 'a thing', output_path: 'retained.png' })
       .execute(new AbortController().signal);
 
-    // Budget violation surfaced, but the user's generated file is preserved.
+    // Budget violation surfaced; the generated file is preserved.
     expect(result.error).toBeDefined();
     expect(result.error!.type).toBe(ToolErrorType.POLICY_VIOLATION);
     expect(existsSync(outPath)).toBe(true);
@@ -482,11 +473,9 @@ describe('read_many_files H4: dimension check before size-skip gate (@issue:3216
     width: number,
     height: number,
   ): Promise<string> {
-    // Create a genuinely noisy (incompressible) PNG that exceeds 512KiB.
     const file = join(dir, name);
     const data = new Uint8Array(width * height * 4);
     for (let i = 0; i < data.length; i += 4) {
-      // Pseudo-random noise for incompressibility.
       data[i] = (i * 17 + 31) & 0xff;
       data[i + 1] = (i * 23 + 7) & 0xff;
       data[i + 2] = (i * 31 + 3) & 0xff;
@@ -503,8 +492,8 @@ describe('read_many_files H4: dimension check before size-skip gate (@issue:3216
 
   it('returns structured image-budget error for an oversized explicit image above 512KiB', async () => {
     const dir = createTempDir();
-    // 3000x3000 noisy PNG: dimensions exceed the 2000 budget AND the file is
-    // >512KiB so the generic size-skip gate would normally swallow it.
+    // 3000x3000 noisy PNG: exceeds the 2000 budget and >512KiB so the size
+    // gate would normally swallow it.
     await writeNoisyPng(dir, 'big.png', 3000, 3000);
     const tool = new ReadManyFilesTool(
       createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
@@ -520,9 +509,8 @@ describe('read_many_files H4: dimension check before size-skip gate (@issue:3216
 
   it('returns overall error for mixed valid content plus later oversized image (no earlier bytes escape)', async () => {
     const dir = createTempDir();
-    // A valid text file plus an oversized image. The overall result must be
-    // an error (not a silent skip), and the text file must NOT escape as
-    // inline content.
+    // A valid text file plus an oversized image: the result must error rather
+    // than silently skip, and the text must not escape as inline content.
     writeFileSync(join(dir, 'notes.txt'), 'hello world');
     await writeNoisyPng(dir, 'big.png', 3000, 3000);
     const tool = new ReadManyFilesTool(
@@ -533,15 +521,14 @@ describe('read_many_files H4: dimension check before size-skip gate (@issue:3216
 
     expect(result.error).toBeDefined();
     expect(result.error!.type).toBe(ToolErrorType.READ_CONTENT_FAILURE);
-    // The error message is about the image dimension, not the text file.
     const message = String(result.llmContent);
     expect(message).toContain('3000');
   });
 
   it('large but within-dimension image follows existing item-size policy', async () => {
     const dir = createTempDir();
-    // 2000x2000 noisy PNG: within the 2000 dimension budget but >512KiB so
-    // it should be silently size-skipped, NOT produce a budget error.
+    // 2000x2000 noisy PNG: within the budget but >512KiB, so it should be
+    // silently size-skipped, not rejected.
     await writeNoisyPng(dir, 'large.png', 2000, 2000);
     const tool = new ReadManyFilesTool(
       createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
@@ -549,8 +536,6 @@ describe('read_many_files H4: dimension check before size-skip gate (@issue:3216
 
     const result = await tool.execute({ paths: ['large.png'] });
 
-    // No image-budget error (dimensions are within budget); the file is
-    // size-skipped rather than rejected.
     const message = String(result.llmContent);
     expect(message).not.toContain('exceeds the configured maximum dimension');
   });
@@ -559,8 +544,8 @@ describe('read_many_files H4: dimension check before size-skip gate (@issue:3216
 describe('read_many_files token-overflow metric/path semantics (@issue:3216)', () => {
   it('does not record a file as processed when its content was skipped (warn stop)', async () => {
     const dir = createTempDir();
-    // a-small fits the token budget and is added; b-big overflows in warn
-    // mode and is skipped (action 'stop') WITHOUT adding content.
+    // a-small fits the budget; b-big overflows in warn mode and is skipped
+    // without adding content.
     writeFileSync(join(dir, 'a-small.txt'), 'hi');
     writeFileSync(join(dir, 'b-big.txt'), 'x'.repeat(5000));
 
@@ -577,8 +562,6 @@ describe('read_many_files token-overflow metric/path semantics (@issue:3216)', (
 
     const result = await tool.execute({ paths: ['a-small.txt', 'b-big.txt'] });
 
-    // b-big.txt was skipped due to the token limit, so it must NOT be listed
-    // as a processed file or recorded via the read metric.
     const display = String(result.returnDisplay);
     expect(display).toContain('a-small.txt');
     expect(display).not.toContain('b-big.txt');
@@ -603,11 +586,9 @@ describe('read_many_files token-overflow metric/path semantics (@issue:3216)', (
 
     const result = await tool.execute({ paths: ['a-big.txt'] });
 
-    // truncate mode records the (truncated) content before stopping.
     const display = String(result.returnDisplay);
     expect(display).toContain('a-big.txt');
     expect(recordedPaths.some((p) => p.endsWith('a-big.txt'))).toBe(true);
-    // Sanity: the truncated content was actually emitted.
     const llm = result.llmContent;
     if (!Array.isArray(llm)) {
       throw new Error('expected array llmContent in truncate mode');
@@ -616,5 +597,200 @@ describe('read_many_files token-overflow metric/path semantics (@issue:3216)', (
       .filter((part): part is string => typeof part === 'string')
       .join('');
     expect(joined).toContain('CONTENT TRUNCATED');
+  });
+});
+
+describe('read_many_files invalid image config produces structured error (@issue:3216)', () => {
+  it('returns a structured tool error for an invalid max-image-dimension setting (no unhandled rejection)', async () => {
+    const dir = createTempDir();
+    writeFileSync(join(dir, 'notes.txt'), 'hello world');
+    // An invalid hard-budget setting must surface as a structured tool error,
+    // not propagate as an unstructured unhandled rejection.
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': '2000' }),
+    );
+
+    const result = await tool.execute({ paths: ['notes.txt'] });
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.type).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+    const message = String(result.llmContent);
+    expect(message).toContain('positive integer');
+    // Either policy can fail, so config errors use the generic heading.
+    const display = String(result.returnDisplay);
+    expect(display).toContain('Image Configuration Error');
+  });
+
+  it('returns a structured tool error for an invalid max-image-pixels setting', async () => {
+    const dir = createTempDir();
+    writeFileSync(join(dir, 'notes.txt'), 'hello world');
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-pixels': 0 }),
+    );
+
+    const result = await tool.execute({ paths: ['notes.txt'] });
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.type).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+    const message = String(result.llmContent);
+    expect(message).toContain('positive integer');
+  });
+
+  it('does not leak file content when the image config is invalid', async () => {
+    const dir = createTempDir();
+    const secret = 'SECRET_FILE_CONTENT';
+    writeFileSync(join(dir, 'secret.txt'), secret);
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': -5 }),
+    );
+
+    const result = await tool.execute({ paths: ['secret.txt'] });
+
+    expect(result.error).toBeDefined();
+    // No file content escapes into the result — flatten all parts so the
+    // assertion is unconditional.
+    const llm = result.llmContent;
+    const parts = typeof llm === 'string' ? [llm] : llm;
+    const flattened = Array.isArray(parts)
+      ? parts
+          .filter((part): part is string => typeof part === 'string')
+          .join('')
+      : '';
+    expect(flattened).not.toContain(secret);
+  });
+});
+
+/**
+ * Build a raw JPEG buffer with an APP1 segment large enough to push SOF past
+ * the 8192-byte prefix, plus trailing APP segments so the file exceeds the
+ * 512KiB size gate. Uses real JPEG segment framing so the walker exercises
+ * actual semantics.
+ */
+function buildDelayedSofJpeg(
+  width: number,
+  height: number,
+  totalSize: number,
+): Buffer {
+  const parts: Buffer[] = [];
+  parts.push(Buffer.from([0xff, 0xd8]));
+  const delayLen = Buffer.alloc(2);
+  delayLen.writeUInt16BE(8_298 + 2, 0);
+  parts.push(Buffer.from([0xff, 0xe1]), delayLen, Buffer.alloc(8_298, 0x20));
+  const sofLen = Buffer.alloc(2);
+  sofLen.writeUInt16BE(17, 0);
+  const h = Buffer.alloc(2);
+  h.writeUInt16BE(height, 0);
+  const w = Buffer.alloc(2);
+  w.writeUInt16BE(width, 0);
+  parts.push(
+    Buffer.from([0xff, 0xc0]),
+    sofLen,
+    Buffer.from([0x08]),
+    h,
+    w,
+    Buffer.from([0x03]),
+    Buffer.from([0x01, 0x22, 0x00]),
+    Buffer.from([0x02, 0x11, 0x11]),
+    Buffer.from([0x03, 0x11, 0x11]),
+  );
+  // Trailing APP segments pad the file past the size gate; they sit after
+  // SOF so the walker still finds the frame quickly.
+  let currentSize = parts.reduce((sum, p) => sum + p.length, 0);
+  let segIndex = 0;
+  while (currentSize < totalSize) {
+    const remaining = totalSize - currentSize - 64; // room for SOS/EOI tail
+    const payload = Math.min(65_533, Math.max(2, remaining - 2));
+    if (payload < 2) break;
+    const padLen = Buffer.alloc(2);
+    padLen.writeUInt16BE(payload, 0);
+    const marker = 0xe0 | (2 + (segIndex % 14));
+    parts.push(
+      Buffer.from([0xff, marker]),
+      padLen,
+      Buffer.alloc(payload, 0x21),
+    );
+    currentSize += payload + 4;
+    segIndex++;
+  }
+  parts.push(
+    Buffer.from([
+      0xff, 0xda, 0x00, 0x0c, 0x03, 0x01, 0x00, 0x02, 0x11, 0x03, 0x11, 0x00,
+      0x3f, 0x00,
+    ]),
+  );
+  parts.push(Buffer.alloc(32, 0x80));
+  parts.push(Buffer.from([0xff, 0xd9]));
+  return Buffer.concat(parts);
+}
+
+describe('read_many_files JPEG delayed-SOF dimension preflight (@issue:3216)', () => {
+  it('returns the actionable dimension error for an oversized JPEG whose SOF sits past 8192 bytes, before generic size skip', async () => {
+    const dir = createTempDir();
+    // SOF at ~offset 8304 (> 8192), 3000x3000 (> 2000 budget), total > 512KiB
+    // so the size gate would normally swallow it.
+    const jpeg = buildDelayedSofJpeg(3_000, 3_000, 600_000);
+    expect(jpeg.length).toBeGreaterThan(524_288);
+    const file = join(dir, 'delayed-sof-big.jpg');
+    writeFileSync(file, jpeg);
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
+    );
+
+    const result = await tool.execute({ paths: ['delayed-sof-big.jpg'] });
+
+    // The dimension error must fire, not the generic size skip.
+    expect(result.error).toBeDefined();
+    expect(result.error!.type).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+    const message = String(result.llmContent);
+    expect(message).toContain('3000');
+    expect(/thumbnail|downscal|resize/i.test(message)).toBe(true);
+    expect(extractInlineDataData(result.llmContent)).toBeUndefined();
+  });
+
+  it('delivers a within-budget JPEG with delayed SOF as inline bytes', async () => {
+    const dir = createTempDir();
+    const jpeg = buildDelayedSofJpeg(1_800, 1_800, 20_000);
+    const file = join(dir, 'delayed-sof-ok.jpg');
+    writeFileSync(file, jpeg);
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
+    );
+
+    const result = await tool.execute({ paths: ['delayed-sof-ok.jpg'] });
+
+    expect(result.error).toBeUndefined();
+    expect(Array.isArray(result.llmContent)).toBe(true);
+    let foundInline = false;
+    if (Array.isArray(result.llmContent)) {
+      for (const part of result.llmContent) {
+        if (typeof part !== 'string' && part.inlineData?.data !== undefined) {
+          foundInline = true;
+          break;
+        }
+      }
+    }
+    expect(foundInline).toBe(true);
+  });
+
+  it('scanner stays bounded on a malicious oversized metadata declaration (no hang)', async () => {
+    const dir = createTempDir();
+    // A JPEG whose first APP segment declares length 0xFFFF but the file ends
+    // almost immediately; the walker must return undefined without hanging.
+    const malicious = Buffer.concat([
+      Buffer.from([0xff, 0xd8]),
+      Buffer.from([0xff, 0xe1]),
+      Buffer.from([0xff, 0xff]),
+      Buffer.from([0x00]),
+    ]);
+    const file = join(dir, 'malicious.jpg');
+    writeFileSync(file, malicious);
+    const tool = new ReadManyFilesTool(
+      createHostWithBudget(dir, { 'max-image-dimension': 2000 }),
+    );
+
+    const result = await tool.execute({ paths: ['malicious.jpg'] });
+
+    // No parseable SOF, so no dimension error; execution must complete.
+    expect(result).toBeDefined();
   });
 });

--- a/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
+++ b/packages/tools/src/__tests__/read-many-files-filtering-behavior.test.ts
@@ -282,7 +282,8 @@ describe('ReadManyFilesTool real behavioral filtering', () => {
         'image-resize.maxLongEdge must be a positive integer',
       ),
     });
-    expect(result.returnDisplay).toContain('Image Resize Error');
+    // Either policy can fail, so config errors use the generic heading.
+    expect(result.returnDisplay).toContain('Image Configuration Error');
   });
 
   it.each([

--- a/packages/tools/src/tools/generate-image/GenerateImageTool.ts
+++ b/packages/tools/src/tools/generate-image/GenerateImageTool.ts
@@ -14,6 +14,12 @@ import {
   type ToolResult,
   type LiveOutputUpdate,
 } from '../tools.js';
+import {
+  checkImageDimensionBudget,
+  formatImageBudgetDisplay,
+  formatImageBudgetError,
+  type ImageDimensionBudget,
+} from '../../utils/imageDimensionBudget.js';
 
 /**
  * Structural duplicate of the backend-neutral image contract.
@@ -115,6 +121,13 @@ export interface GenerateImageToolDependencies {
     readonly input_paths?: readonly string[];
     readonly signal?: AbortSignal;
   }) => Promise<ImageOperationRunnerResult>;
+
+  /**
+   * Resolves the active hard image dimension/pixel budget (issue #3216) from
+   * the host's ephemeral settings. Returning `undefined` disables the
+   * preflight; the tool itself contains no settings-resolution logic.
+   */
+  readonly getImageDimensionBudget?: () => ImageDimensionBudget | undefined;
 }
 
 const MAX_INPUT_IMAGES = 5;
@@ -276,6 +289,28 @@ class GenerateImageToolInvocation extends BaseToolInvocation<
   }
 
   private buildSuccessResult(result: ImageOperationRunnerResult): ToolResult {
+    // Hard image budget preflight (issue #3216): reject oversized generated
+    // bytes before they enter the returned content so the model gets an
+    // actionable error instead of a provider 400. The runner already persisted
+    // the file before returning; the budget only governs whether the bytes may
+    // enter model content/history, so the generated file is NEVER deleted —
+    // the error names its path and instructs the model to downscale/thumbnail
+    // before reading. This is a content-policy violation (the image exceeds
+    // the hard budget), not a read failure.
+    const budget = this.dependencies.getImageDimensionBudget?.();
+    if (budget !== undefined) {
+      const violation = checkImageDimensionBudget(result.media.data, budget);
+      if (violation !== undefined) {
+        const message =
+          formatImageBudgetError(violation, result.relativeOutputPath) +
+          ` The generated image was saved at ${result.absoluteOutputPath} but was omitted from model content/history because it exceeds the limit; downscale or thumbnail the saved file before reading it into the conversation.`;
+        return {
+          llmContent: message,
+          returnDisplay: formatImageBudgetDisplay(message),
+          error: { message, type: ToolErrorType.POLICY_VIOLATION },
+        };
+      }
+    }
     const operation = result.operation === 'generate' ? 'Generated' : 'Edited';
     const textPart = `${operation} image.
 Saved to: ${result.absoluteOutputPath}`;

--- a/packages/tools/src/tools/read-file.ts
+++ b/packages/tools/src/tools/read-file.ts
@@ -28,6 +28,7 @@ import { getGitLineChanges } from '../utils/gitLineChanges.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
 import { stringOrDefault } from '../utils/stringCoalescing.js';
 import { resolveImageResizePolicy } from '../utils/imageResize.js';
+import { resolveImageDimensionBudget } from '../utils/imageDimensionBudget.js';
 import { ToolErrorType } from '../types/tool-error.js';
 
 /**
@@ -291,16 +292,20 @@ ${formattedContent}`;
       (ephemeralSettings['file-read-max-lines'] as number | undefined) ??
       DEFAULT_MAX_LINES_TEXT_FILE;
     let imageResizePolicy;
+    let imageBudget;
     try {
       imageResizePolicy = resolveImageResizePolicy(
         ephemeralSettings,
         this.params.skip_image_resize === true,
       );
+      imageBudget = resolveImageDimensionBudget(ephemeralSettings);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      // Combined label: this catch covers both image-resize policy and
+      // image-budget (dimension/pixel) configuration errors.
       return {
         llmContent: message,
-        returnDisplay: `## Image Resize Configuration Error\n\n${message}`,
+        returnDisplay: `## Image Configuration Error\n\n${message}`,
         error: { message, type: ToolErrorType.READ_CONTENT_FAILURE },
       };
     }
@@ -311,6 +316,7 @@ ${formattedContent}`;
       this.params.offset,
       effectiveLimit,
       imageResizePolicy,
+      imageBudget,
     );
 
     if (result.error) {

--- a/packages/tools/src/tools/read-many-files.ts
+++ b/packages/tools/src/tools/read-many-files.ts
@@ -17,7 +17,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { glob, escape as globEscape } from 'glob';
 import {
-  createImageResizeToolResult,
+  createImageConfigurationToolResult,
   getImageBudgetToolResult,
   getImageResizeToolResult,
   getProcessedFileSkipReason,
@@ -35,7 +35,10 @@ import {
   resolveImageResizePolicy,
   type ImageResizePolicy,
 } from '../utils/imageResize.js';
-import { resolveImageDimensionBudget } from '../utils/imageDimensionBudget.js';
+import {
+  resolveImageDimensionBudget,
+  type ImageDimensionBudget,
+} from '../utils/imageDimensionBudget.js';
 import { estimateNonTextPartTokens } from '../utils/imageTokenEstimation.js';
 import {
   buildParameterSchema,
@@ -517,11 +520,15 @@ ${this.host.getTargetDir()}
     limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
   ): Promise<ProcessFilesResult> {
     const ephemeralSettings = this.host.getEphemeralSettings();
+    // Resolve both image policies once from one settings snapshot inside one
+    // guard so malformed settings surface as structured tool errors.
     let imageResizePolicy: ImageResizePolicy | undefined;
+    let imageBudget: ImageDimensionBudget | undefined;
     try {
       imageResizePolicy = resolveImageResizePolicy(ephemeralSettings);
+      imageBudget = resolveImageDimensionBudget(ephemeralSettings);
     } catch (error) {
-      return createImageResizeToolResult(
+      return createImageConfigurationToolResult(
         getErrorMessage(error),
         ToolErrorType.READ_CONTENT_FAILURE,
         0,
@@ -542,6 +549,7 @@ ${this.host.getTargetDir()}
         limits,
         totalTokens,
         imageResizePolicy,
+        imageBudget,
         maxLinesPerFile,
       );
       if (result.error !== undefined || result.done) {
@@ -562,14 +570,12 @@ ${this.host.getTargetDir()}
     limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
     currentTokens: number,
     imageResizePolicy: ImageResizePolicy | undefined,
+    imageBudget: ImageDimensionBudget | undefined,
     maxLinesPerFile: number,
   ): Promise<ProcessSingleFileResult> {
     const relativePathForDisplay = path
       .relative(this.host.getTargetDir(), filePath)
       .replace(/\\/g, '/');
-    const imageBudget = resolveImageDimensionBudget(
-      this.host.getEphemeralSettings(),
-    );
     const gate = await runPreReadGates(
       filePath,
       inputPatterns,

--- a/packages/tools/src/tools/read-many-files.ts
+++ b/packages/tools/src/tools/read-many-files.ts
@@ -18,26 +18,24 @@ import * as path from 'path';
 import { glob, escape as globEscape } from 'glob';
 import {
   createImageResizeToolResult,
-  detectFileType,
+  getImageBudgetToolResult,
   getImageResizeToolResult,
-  getImageSourceSizeLimit,
   getProcessedFileSkipReason,
-  isAssetExplicitlyRequested,
   type ProcessedFileReadResult,
   processSingleFileContent,
-  shouldResizeExplicitImage,
   DEFAULT_ENCODING,
   DEFAULT_MAX_LINES_TEXT_FILE,
   getSpecificMimeType,
 } from '../utils/fileUtils.js';
+import { runPreReadGates } from '../utils/fileBudgetChecks.js';
 import { type ContentPartUnion } from '../types/wire-types.js';
-import { stat } from 'fs/promises';
 import { ToolErrorType } from '../types/tool-error.js';
 import { validatePathWithinWorkspace } from '../utils/pathValidation.js';
 import {
   resolveImageResizePolicy,
   type ImageResizePolicy,
 } from '../utils/imageResize.js';
+import { resolveImageDimensionBudget } from '../utils/imageDimensionBudget.js';
 import { estimateNonTextPartTokens } from '../utils/imageTokenEstimation.js';
 import {
   buildParameterSchema,
@@ -569,27 +567,23 @@ ${this.host.getTargetDir()}
     const relativePathForDisplay = path
       .relative(this.host.getTargetDir(), filePath)
       .replace(/\\/g, '/');
-    const resizeBeforeOutputLimit = await shouldResizeExplicitImage(
+    const imageBudget = resolveImageDimensionBudget(
+      this.host.getEphemeralSettings(),
+    );
+    const gate = await runPreReadGates(
       filePath,
       inputPatterns,
+      relativePathForDisplay,
+      skippedFiles,
+      limits.fileSizeLimit,
+      currentTokens,
+      imageBudget,
       imageResizePolicy !== undefined,
     );
-    if (
-      (await this.checkFileSize(
-        filePath,
-        relativePathForDisplay,
-        skippedFiles,
-        getImageSourceSizeLimit(resizeBeforeOutputLimit, limits.fileSizeLimit),
-      )) === 'skip' ||
-      (await this.checkAssetFile(
-        filePath,
-        relativePathForDisplay,
-        inputPatterns,
-        skippedFiles,
-      )) === 'skip'
-    ) {
+    if (gate.outcome === 'preflight-error') return gate.result;
+    if (gate.outcome === 'skip')
       return { done: false, totalTokens: currentTokens };
-    }
+    const { resizeBeforeOutputLimit } = gate;
 
     const fileReadResult = await processSingleFileContent(
       filePath,
@@ -597,20 +591,17 @@ ${this.host.getTargetDir()}
       undefined,
       maxLinesPerFile,
       imageResizePolicy,
+      imageBudget,
     );
-    const resizeError = getImageResizeToolResult(fileReadResult, currentTokens);
-    if (resizeError !== undefined) {
-      return resizeError;
-    }
-    const skipReason = getProcessedFileSkipReason(
+    const earlyResult = this.checkFileReadErrors(
       fileReadResult,
+      currentTokens,
       resizeBeforeOutputLimit,
+      relativePathForDisplay,
       limits.fileSizeLimit,
+      skippedFiles,
     );
-    if (skipReason !== undefined) {
-      skippedFiles.push({ path: relativePathForDisplay, reason: skipReason });
-      return { done: false, totalTokens: currentTokens };
-    }
+    if (earlyResult !== undefined) return earlyResult;
 
     const addResult = this.addFileContent(
       fileReadResult,
@@ -624,63 +615,40 @@ ${this.host.getTargetDir()}
       sortedFiles,
     );
 
-    if (addResult.action === 'stop') {
-      return { done: true, totalTokens: addResult.totalTokens };
+    // Record as processed only when content was added; a warn-mode 'stop'
+    // pushes only a skip reason, so it must not be recorded.
+    if (addResult.action !== 'stop') {
+      processedFilesRelativePaths.push(relativePathForDisplay);
+      this.recordReadMetric(filePath, fileReadResult.llmContent);
     }
-
-    processedFilesRelativePaths.push(relativePathForDisplay);
-    this.recordReadMetric(filePath, fileReadResult.llmContent);
-    if (addResult.action === 'stopAfterRecord') {
-      return { done: true, totalTokens: addResult.totalTokens };
-    }
-    return { done: false, totalTokens: addResult.totalTokens };
+    return addResult.action === 'stop' || addResult.action === 'stopAfterRecord'
+      ? { done: true, totalTokens: addResult.totalTokens }
+      : { done: false, totalTokens: addResult.totalTokens };
   }
-  private async checkFileSize(
-    filePath: string,
+
+  private checkFileReadErrors(
+    fileReadResult: ProcessedFileReadResult,
+    currentTokens: number,
+    shouldResize: boolean,
     relativePathForDisplay: string,
-    skippedFiles: Array<{ path: string; reason: string }>,
     fileSizeLimit: number,
-  ): Promise<'skip' | 'continue'> {
-    try {
-      const stats = await stat(filePath);
-      if (stats.size > fileSizeLimit) {
-        skippedFiles.push({
-          path: relativePathForDisplay,
-          reason: `file size (${Math.round(stats.size / 1024)}KB) exceeds limit (${Math.round(fileSizeLimit / 1024)}KB)`,
-        });
-        return 'skip';
-      }
-    } catch (error) {
-      skippedFiles.push({
-        path: relativePathForDisplay,
-        reason: `stat error: ${getErrorMessage(error)}`,
-      });
-      return 'skip';
-    }
-    return 'continue';
-  }
-
-  private async checkAssetFile(
-    filePath: string,
-    relativePathForDisplay: string,
-    inputPatterns: string[],
     skippedFiles: Array<{ path: string; reason: string }>,
-  ): Promise<'skip' | 'continue'> {
-    const fileType = await detectFileType(filePath);
-    if (
-      (fileType === 'image' || fileType === 'pdf' || fileType === 'audio') &&
-      !isAssetExplicitlyRequested(filePath, inputPatterns)
-    ) {
-      skippedFiles.push({
-        path: relativePathForDisplay,
-        reason:
-          'asset file (image/pdf/audio) was not explicitly requested by name or extension',
-      });
-      return 'skip';
+  ): ProcessSingleFileResult | undefined {
+    const errorResult =
+      getImageResizeToolResult(fileReadResult, currentTokens) ??
+      getImageBudgetToolResult(fileReadResult, currentTokens);
+    if (errorResult !== undefined) return errorResult;
+    const skipReason = getProcessedFileSkipReason(
+      fileReadResult,
+      shouldResize,
+      fileSizeLimit,
+    );
+    if (skipReason !== undefined) {
+      skippedFiles.push({ path: relativePathForDisplay, reason: skipReason });
+      return { done: false, totalTokens: currentTokens };
     }
-    return 'continue';
+    return undefined;
   }
-
   private addFileContent(
     fileReadResult: ProcessedFileReadResult,
     filePath: string,

--- a/packages/tools/src/utils/fileBudgetChecks.ts
+++ b/packages/tools/src/utils/fileBudgetChecks.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import {
+  detectFileType,
+  getImageSourceSizeLimit,
+  isAssetExplicitlyRequested,
+  shouldResizeExplicitImage,
+} from './fileUtils.js';
+import { getErrorMessage } from './errors.js';
+import {
+  checkImageBudgetPreflightForFile,
+  preflightToSingleFileResult,
+  type ImageDimensionBudget,
+} from './imageDimensionBudget.js';
+
+/**
+ * Check if a file exceeds the configured size limit (issue #3216 extraction
+ * from ReadManyFilesTool). Pushes a skip reason and returns 'skip' when
+ * exceeded (or on stat error), 'continue' otherwise.
+ */
+export async function checkFileSizeLimit(
+  filePath: string,
+  relativePathForDisplay: string,
+  skippedFiles: Array<{ path: string; reason: string }>,
+  fileSizeLimit: number,
+): Promise<'skip' | 'continue'> {
+  try {
+    const { size } = await fs.promises.stat(filePath);
+    if (size <= fileSizeLimit) return 'continue';
+    skippedFiles.push({
+      path: relativePathForDisplay,
+      reason: `file size (${Math.round(size / 1024)}KB) exceeds limit (${Math.round(fileSizeLimit / 1024)}KB)`,
+    });
+    return 'skip';
+  } catch (error) {
+    skippedFiles.push({
+      path: relativePathForDisplay,
+      reason: `stat error: ${getErrorMessage(error)}`,
+    });
+    return 'skip';
+  }
+}
+
+/**
+ * Check if an asset file (image/pdf/audio) was explicitly requested (#3216).
+ * Returns 'skip' when not explicitly requested, 'continue' otherwise.
+ */
+export async function checkAssetFileRequested(
+  filePath: string,
+  relativePathForDisplay: string,
+  inputPatterns: readonly string[],
+  skippedFiles: Array<{ path: string; reason: string }>,
+): Promise<'skip' | 'continue'> {
+  const ft = await detectFileType(filePath);
+  const isAsset = ft === 'image' || ft === 'pdf' || ft === 'audio';
+  if (!isAsset || isAssetExplicitlyRequested(filePath, inputPatterns))
+    return 'continue';
+  skippedFiles.push({
+    path: relativePathForDisplay,
+    reason:
+      'asset file (image/pdf/audio) was not explicitly requested by name or extension',
+  });
+  return 'skip';
+}
+
+/**
+ * Outcome of the pre-read gate sequence for a single file in read_many_files.
+ *
+ * - `'preflight-error'`: the image dimension preflight rejected an explicitly
+ *   requested image; `result` is the actionable tool error to return.
+ * - `'skip'`: the file was skipped for size or asset-request reasons (the
+ *   reason was already pushed onto `skippedFiles`); the loop continues.
+ * - `'proceed'`: all gates passed; `resizeBeforeOutputLimit` is the resolved
+ *   flag the caller needs for the remaining read/error checks.
+ */
+export type PreReadGateResult =
+  | {
+      readonly outcome: 'preflight-error';
+      readonly result: ReturnType<typeof preflightToSingleFileResult>;
+    }
+  | { readonly outcome: 'skip' }
+  | { readonly outcome: 'proceed'; readonly resizeBeforeOutputLimit: boolean };
+
+/**
+ * Run the full pre-read gate sequence for one file: the H4 image-dimension
+ * preflight (before the size-skip gate), then the per-file size limit and the
+ * asset-request gate. Returns a {@link PreReadGateResult} so the caller can
+ * return the preflight error, continue past a skip, or proceed with the read.
+ *
+ * The hard image budget is resolved once per file by the caller and passed in
+ * so the preflight and the later content-processing path share one decision.
+ */
+export async function runPreReadGates(
+  filePath: string,
+  inputPatterns: readonly string[],
+  relativePathForDisplay: string,
+  skippedFiles: Array<{ path: string; reason: string }>,
+  fileSizeLimit: number,
+  currentTokens: number,
+  imageBudget: ImageDimensionBudget | undefined,
+  hasResizePolicy: boolean,
+): Promise<PreReadGateResult> {
+  const pf = await checkImageBudgetPreflightForFile(
+    filePath,
+    imageBudget,
+    (await detectFileType(filePath)) === 'image',
+    isAssetExplicitlyRequested(filePath, inputPatterns),
+    relativePathForDisplay,
+  );
+  if (pf !== undefined) {
+    return {
+      outcome: 'preflight-error',
+      result: preflightToSingleFileResult(pf, currentTokens),
+    };
+  }
+  const resizeBeforeOutputLimit = await shouldResizeExplicitImage(
+    filePath,
+    inputPatterns,
+    hasResizePolicy,
+  );
+  if (
+    (await checkFileSizeLimit(
+      filePath,
+      relativePathForDisplay,
+      skippedFiles,
+      getImageSourceSizeLimit(resizeBeforeOutputLimit, fileSizeLimit),
+    )) === 'skip' ||
+    (await checkAssetFileRequested(
+      filePath,
+      relativePathForDisplay,
+      inputPatterns,
+      skippedFiles,
+    )) === 'skip'
+  ) {
+    return { outcome: 'skip' };
+  }
+  return { outcome: 'proceed', resizeBeforeOutputLimit };
+}

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -16,6 +16,12 @@ import {
   resizeImageIfNeeded,
   type ImageResizePolicy,
 } from './imageResize.js';
+import {
+  checkImageDimensionBudgetFromBuffer,
+  formatImageBudgetDisplay,
+  formatImageBudgetError,
+  type ImageDimensionBudget,
+} from './imageDimensionBudget.js';
 
 // Constants for text file processing
 export const DEFAULT_MAX_LINES_TEXT_FILE = 2000;
@@ -410,7 +416,7 @@ export interface ProcessedFileReadResult {
   returnDisplay: string;
   error?: string;
   errorType?: ToolErrorType;
-  errorKind?: 'image-resize';
+  errorKind?: 'image-resize' | 'image-budget';
   isTruncated?: boolean;
   originalLineCount?: number;
   linesShown?: [number, number];
@@ -485,6 +491,39 @@ export function getImageResizeToolResult(
 ): ReturnType<typeof createImageResizeToolResult> | undefined {
   return result.errorKind === 'image-resize' && result.error !== undefined
     ? createImageResizeToolResult(result.error, result.errorType, totalTokens)
+    : undefined;
+}
+
+export function createImageBudgetToolResult(
+  message: string,
+  type: ToolErrorType | undefined,
+  totalTokens: number,
+): {
+  done: true;
+  totalTokens: number;
+  error: {
+    llmContent: string;
+    returnDisplay: string;
+    error: { message: string; type: ToolErrorType | undefined };
+  };
+} {
+  return {
+    done: true,
+    totalTokens,
+    error: {
+      llmContent: message,
+      returnDisplay: formatImageBudgetDisplay(message),
+      error: { message, type },
+    },
+  };
+}
+
+export function getImageBudgetToolResult(
+  result: ProcessedFileReadResult,
+  totalTokens: number,
+): ReturnType<typeof createImageBudgetToolResult> | undefined {
+  return result.errorKind === 'image-budget' && result.error !== undefined
+    ? createImageBudgetToolResult(result.error, result.errorType, totalTokens)
     : undefined;
 }
 
@@ -731,6 +770,7 @@ async function processMediaFile(
   relativePathForDisplay: string,
   fileType: 'image' | 'pdf' | 'audio' | 'video',
   imageResizePolicy: ImageResizePolicy | undefined,
+  imageBudget: ImageDimensionBudget | undefined,
 ): Promise<ProcessedFileReadResult> {
   const contentBuffer = await fs.promises.readFile(filePath);
   const mimeTypeRaw = mime.lookup(filePath);
@@ -748,6 +788,29 @@ async function processMediaFile(
           imageResizePolicy,
         )
       : contentBuffer;
+
+  // Hard dimension/pixel preflight runs AFTER any explicit resize so an
+  // oversized image is rejected with an actionable tool error and its bytes
+  // never enter the returned content. Non-image media and unparseable images
+  // are left unchanged (no dimension is invented). The check parses the raw
+  // output buffer's bounded header prefix directly — the full payload is never
+  // base64-encoded just to inspect dimensions.
+  if (fileType === 'image' && imageBudget !== undefined) {
+    const violation = checkImageDimensionBudgetFromBuffer(
+      outputBuffer,
+      imageBudget,
+    );
+    if (violation !== undefined) {
+      const message = formatImageBudgetError(violation, displayName);
+      return {
+        llmContent: message,
+        returnDisplay: formatImageBudgetDisplay(message),
+        error: message,
+        errorType: ToolErrorType.READ_CONTENT_FAILURE,
+        errorKind: 'image-budget',
+      };
+    }
+  }
 
   return {
     llmContent: {
@@ -769,6 +832,7 @@ async function processFileByType(
   offset: number | undefined,
   limit: number | undefined,
   imageResizePolicy: ImageResizePolicy | undefined,
+  imageBudget: ImageDimensionBudget | undefined,
 ): Promise<ProcessedFileReadResult> {
   switch (fileType) {
     case 'binary':
@@ -786,6 +850,7 @@ async function processFileByType(
         relativePathForDisplay,
         fileType,
         imageResizePolicy,
+        imageBudget,
       );
     default:
       return processTextFile(filePath, relativePathForDisplay, offset, limit);
@@ -798,6 +863,7 @@ export async function processSingleFileContent(
   offset?: number,
   limit?: number,
   imageResizePolicy?: ImageResizePolicy,
+  imageBudget?: ImageDimensionBudget,
 ): Promise<ProcessedFileReadResult> {
   try {
     const accessError = validateFileAccess(filePath);
@@ -823,6 +889,7 @@ export async function processSingleFileContent(
       offset,
       limit,
       imageResizePolicy,
+      imageBudget,
     );
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/tools/src/utils/fileUtils.ts
+++ b/packages/tools/src/utils/fileUtils.ts
@@ -485,6 +485,30 @@ export function createImageResizeToolResult(
   };
 }
 
+export function createImageConfigurationToolResult(
+  message: string,
+  type: ToolErrorType | undefined,
+  totalTokens: number,
+): {
+  done: true;
+  totalTokens: number;
+  error: {
+    llmContent: string;
+    returnDisplay: string;
+    error: { message: string; type: ToolErrorType | undefined };
+  };
+} {
+  return {
+    done: true,
+    totalTokens,
+    error: {
+      llmContent: message,
+      returnDisplay: `## Image Configuration Error\n\n${message}`,
+      error: { message, type },
+    },
+  };
+}
+
 export function getImageResizeToolResult(
   result: ProcessedFileReadResult,
   totalTokens: number,

--- a/packages/tools/src/utils/imageDimensionBudget.test.ts
+++ b/packages/tools/src/utils/imageDimensionBudget.test.ts
@@ -21,6 +21,7 @@ import {
   checkImageDimensionBudgetFromBuffer,
   checkImageFileDimensionBudget,
   checkImageFileBudgetMessage,
+  closeFileHandlePreservingPrimaryError,
   formatImageBudgetError,
   formatImageBudgetDisplay,
   type ImageDimensionBudget,
@@ -99,6 +100,11 @@ describe('resolveImageDimensionBudget (@issue:3216)', () => {
     expect(() =>
       resolveImageDimensionBudget({ 'max-image-pixels': 'big' }),
     ).toThrow(/positive integer/);
+    expect(() =>
+      resolveImageDimensionBudget({
+        'max-image-pixels': Number.MAX_SAFE_INTEGER + 1,
+      }),
+    ).toThrow(/positive integer/);
   });
 });
 
@@ -148,6 +154,25 @@ describe('checkImageDimensionBudget (@issue:3216)', () => {
     expect(violation!.exceededPixels).toBe(true);
     expect(violation!.exceededDimension).toBe(false);
     expect(violation!.maxPixels).toBe(3_000_000);
+  });
+
+  it('uses exact pixel arithmetic for maximum-width PNG dimensions', () => {
+    const png = Buffer.alloc(24);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png, 0);
+    png.write('IHDR', 12, 'ascii');
+    png.writeUInt32BE(0xffffffff, 16);
+    png.writeUInt32BE(0xffffffff, 20);
+
+    const violation = checkImageDimensionBudgetFromBuffer(png, {
+      maxPixels: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(violation).toBeDefined();
+    expect(violation!.pixels).toBe(18_446_744_065_119_617_025n);
+    expect(violation!.exceededPixels).toBe(true);
+    expect(formatImageBudgetError(violation!)).toContain(
+      '18,446,744,065,119,617,025 total',
+    );
   });
 
   it('returns undefined for unparseable/non-image bytes (never invents dimensions)', () => {
@@ -531,5 +556,40 @@ describe('checkImageFileBudgetMessage file-path JPEG fallback (@issue:3216)', ()
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('closeFileHandlePreservingPrimaryError', () => {
+  it('preserves a primary read error when closing also fails', async () => {
+    const readError = new Error('EIO: read failure');
+    const closeError = new Error('EIO: close failure');
+
+    const operation = async (): Promise<void> => {
+      let primaryError: unknown;
+      try {
+        throw readError;
+      } catch (error) {
+        primaryError = error;
+        throw error;
+      } finally {
+        await closeFileHandlePreservingPrimaryError(
+          async () => Promise.reject(closeError),
+          primaryError,
+        );
+      }
+    };
+
+    await expect(operation()).rejects.toBe(readError);
+  });
+
+  it('propagates a close error when no primary operation failed', async () => {
+    const closeError = new Error('EIO: close failure');
+
+    await expect(
+      closeFileHandlePreservingPrimaryError(
+        async () => Promise.reject(closeError),
+        undefined,
+      ),
+    ).rejects.toBe(closeError);
   });
 });

--- a/packages/tools/src/utils/imageDimensionBudget.test.ts
+++ b/packages/tools/src/utils/imageDimensionBudget.test.ts
@@ -1,0 +1,264 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3216 — Behavioral tests for the shared image dimension/pixel budget
+ * checker used by every built-in image-producing tool. Uses real image bytes
+ * generated with sharp so header parsing is exercised, not mocked.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import sharp from 'sharp';
+import {
+  resolveImageDimensionBudget,
+  checkImageDimensionBudget,
+  checkImageDimensionBudgetFromBuffer,
+  formatImageBudgetError,
+  formatImageBudgetDisplay,
+  type ImageDimensionBudget,
+} from './imageDimensionBudget.js';
+
+async function pngBase64(width: number, height: number): Promise<string> {
+  const buffer = await sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r: 80, g: 120, b: 160, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return buffer.toString('base64');
+}
+
+async function pngBytes(width: number, height: number): Promise<Buffer> {
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r: 80, g: 120, b: 160, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+describe('resolveImageDimensionBudget (@issue:3216)', () => {
+  it('returns undefined when no budget keys are set', () => {
+    expect(resolveImageDimensionBudget({})).toBeUndefined();
+    expect(resolveImageDimensionBudget({ other: 1 })).toBeUndefined();
+  });
+
+  it('reads max-image-dimension only', () => {
+    const budget = resolveImageDimensionBudget({
+      'max-image-dimension': 2000,
+    });
+    expect(budget).toEqual({ maxDimension: 2000 });
+  });
+
+  it('reads max-image-pixels only', () => {
+    const budget = resolveImageDimensionBudget({
+      'max-image-pixels': 4_000_000,
+    });
+    expect(budget).toEqual({ maxPixels: 4_000_000 });
+  });
+
+  it('reads both keys together', () => {
+    const budget = resolveImageDimensionBudget({
+      'max-image-dimension': 2000,
+      'max-image-pixels': 4_000_000,
+    });
+    expect(budget).toEqual({ maxDimension: 2000, maxPixels: 4_000_000 });
+  });
+
+  it('throws on non-positive-integer values (fail fast)', () => {
+    expect(() =>
+      resolveImageDimensionBudget({ 'max-image-dimension': 0 }),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      resolveImageDimensionBudget({ 'max-image-dimension': -5 }),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      resolveImageDimensionBudget({ 'max-image-dimension': 1.5 }),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      resolveImageDimensionBudget({ 'max-image-pixels': 'big' }),
+    ).toThrow(/positive integer/);
+  });
+});
+
+describe('checkImageDimensionBudget (@issue:3216)', () => {
+  it('passes an image below the dimension budget', async () => {
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+    const data = await pngBase64(1800, 1800);
+    expect(checkImageDimensionBudget(data, budget)).toBeUndefined();
+  });
+
+  it('passes an image exactly at the dimension boundary (inclusive)', async () => {
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+    const data = await pngBase64(2000, 2000);
+    expect(checkImageDimensionBudget(data, budget)).toBeUndefined();
+  });
+
+  it('flags an oversized width dimension', async () => {
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+    const data = await pngBase64(3000, 1000);
+    const violation = checkImageDimensionBudget(data, budget);
+    expect(violation).toBeDefined();
+    expect(violation!.width).toBe(3000);
+    expect(violation!.height).toBe(1000);
+    expect(violation!.exceededDimension).toBe(true);
+    expect(violation!.exceededPixels).toBe(false);
+    expect(violation!.maxDimension).toBe(2000);
+  });
+
+  it('flags an oversized height dimension', async () => {
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+    const data = await pngBase64(1000, 3000);
+    const violation = checkImageDimensionBudget(data, budget);
+    expect(violation).toBeDefined();
+    expect(violation!.height).toBe(3000);
+    expect(violation!.exceededDimension).toBe(true);
+  });
+
+  it('flags an oversized total pixel count within the dimension budget', async () => {
+    const budget: ImageDimensionBudget = {
+      maxDimension: 2000,
+      maxPixels: 3_000_000,
+    };
+    const data = await pngBase64(2000, 2000); // 4,000,000 pixels
+    const violation = checkImageDimensionBudget(data, budget);
+    expect(violation).toBeDefined();
+    expect(violation!.pixels).toBe(4_000_000);
+    expect(violation!.exceededPixels).toBe(true);
+    expect(violation!.exceededDimension).toBe(false);
+    expect(violation!.maxPixels).toBe(3_000_000);
+  });
+
+  it('returns undefined for unparseable/non-image bytes (never invents dimensions)', () => {
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+    expect(checkImageDimensionBudget('', budget)).toBeUndefined();
+    expect(
+      checkImageDimensionBudget('not-an-image-at-all', budget),
+    ).toBeUndefined();
+  });
+});
+
+describe('formatImageBudgetError (@issue:3216)', () => {
+  it('includes actual dimensions, the exceeded budget, and thumbnail/downscale guidance', () => {
+    const violation = {
+      width: 3000,
+      height: 2000,
+      pixels: 6_000_000,
+      maxDimension: 2000,
+      maxPixels: undefined,
+      exceededDimension: true,
+      exceededPixels: false,
+    };
+    const message = formatImageBudgetError(violation, 'big.png');
+    expect(message).toContain('3000');
+    expect(message).toContain('2000');
+    expect(message).toContain('2000');
+    expect(message).toContain('big.png');
+    // Guidance must tell the model how to fix it.
+    expect(/thumbnail|downscal|resize/i.test(message)).toBe(true);
+  });
+
+  it('mentions pixel budget when that was the exceeded dimension', () => {
+    const violation = {
+      width: 2000,
+      height: 2000,
+      pixels: 4_000_000,
+      maxDimension: 2000,
+      maxPixels: 3_000_000,
+      exceededDimension: false,
+      exceededPixels: true,
+    };
+    const message = formatImageBudgetError(violation);
+    expect(message).toContain('4,000,000');
+    expect(message).toContain('3,000,000');
+  });
+});
+
+describe('checkImageDimensionBudgetFromBuffer vs base64 checker (@issue:3216)', () => {
+  // The buffer entry point must have IDENTICAL boundary behavior to the base64
+  // checker so the file-processing path can avoid base64-encoding a full
+  // payload just to inspect bounded dimensions, with no behavior change.
+  const budgets = {
+    none: undefined,
+    dimensionOnly: { maxDimension: 2000 } as ImageDimensionBudget,
+    pixelsOnly: { maxPixels: 3_000_000 } as ImageDimensionBudget,
+    both: {
+      maxDimension: 2000,
+      maxPixels: 3_000_000,
+    } as ImageDimensionBudget,
+  };
+
+  it.each([
+    ['below budget', 1800, 1800, budgets.dimensionOnly],
+    ['exactly at dimension boundary', 2000, 2000, budgets.dimensionOnly],
+    ['oversized width', 3000, 1000, budgets.dimensionOnly],
+    ['oversized height', 1000, 3000, budgets.dimensionOnly],
+    ['pixels-only violation', 2000, 2000, budgets.pixelsOnly],
+    ['both boundaries set', 2000, 2000, budgets.both],
+  ] as const)(
+    'produces identical result for %s',
+    async (_label, w, h, budget) => {
+      const bytes = await pngBytes(w, h);
+      const base64 = bytes.toString('base64');
+      const fromBuffer = checkImageDimensionBudgetFromBuffer(bytes, budget);
+      const fromBase64 = checkImageDimensionBudget(base64, budget);
+      expect(fromBuffer).toEqual(fromBase64);
+    },
+  );
+
+  it('returns undefined for empty bytes (matches base64 empty)', () => {
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+    expect(
+      checkImageDimensionBudgetFromBuffer(new Uint8Array(0), budget),
+    ).toBeUndefined();
+    expect(checkImageDimensionBudget('', budget)).toBeUndefined();
+  });
+
+  it('returns undefined for unparseable bytes (matches base64)', () => {
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+    const junk = new Uint8Array([1, 2, 3, 4, 5]);
+    expect(checkImageDimensionBudgetFromBuffer(junk, budget)).toBeUndefined();
+    expect(
+      checkImageDimensionBudget('not-an-image-at-all', budget),
+    ).toBeUndefined();
+  });
+
+  it('accepts a Uint8Array view over the same buffer', async () => {
+    const budget: ImageDimensionBudget = { maxDimension: 2000 };
+    const bytes = await pngBytes(3000, 2000);
+    const view = new Uint8Array(
+      bytes.buffer,
+      bytes.byteOffset,
+      bytes.byteLength,
+    );
+    const fromView = checkImageDimensionBudgetFromBuffer(view, budget);
+    const fromBase64 = checkImageDimensionBudget(
+      bytes.toString('base64'),
+      budget,
+    );
+    expect(fromView).toEqual(fromBase64);
+    expect(fromView).toBeDefined();
+  });
+});
+
+describe('formatImageBudgetDisplay (@issue:3216)', () => {
+  it('wraps a message in the shared dimension-limit heading', () => {
+    const message = 'Image big.png is 3000x3000 pixels (9,000,000 total).';
+    const display = formatImageBudgetDisplay(message);
+    expect(display).toBe(`## Image Dimension Limit
+
+${message}`);
+    expect(display.startsWith('## Image Dimension Limit')).toBe(true);
+  });
+});

--- a/packages/tools/src/utils/imageDimensionBudget.test.ts
+++ b/packages/tools/src/utils/imageDimensionBudget.test.ts
@@ -11,15 +11,25 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import sharp from 'sharp';
 import {
   resolveImageDimensionBudget,
   checkImageDimensionBudget,
   checkImageDimensionBudgetFromBuffer,
+  checkImageFileDimensionBudget,
+  checkImageFileBudgetMessage,
   formatImageBudgetError,
   formatImageBudgetDisplay,
   type ImageDimensionBudget,
 } from './imageDimensionBudget.js';
+import {
+  parseJpegDimensionsFromReader,
+  JPEG_SEGMENT_MAX_STEPS,
+  type JpegSegmentReader,
+} from './imageDimensions.js';
 
 async function pngBase64(width: number, height: number): Promise<string> {
   const buffer = await sharp({
@@ -165,7 +175,6 @@ describe('formatImageBudgetError (@issue:3216)', () => {
     expect(message).toContain('2000');
     expect(message).toContain('2000');
     expect(message).toContain('big.png');
-    // Guidance must tell the model how to fix it.
     expect(/thumbnail|downscal|resize/i.test(message)).toBe(true);
   });
 
@@ -186,9 +195,8 @@ describe('formatImageBudgetError (@issue:3216)', () => {
 });
 
 describe('checkImageDimensionBudgetFromBuffer vs base64 checker (@issue:3216)', () => {
-  // The buffer entry point must have IDENTICAL boundary behavior to the base64
-  // checker so the file-processing path can avoid base64-encoding a full
-  // payload just to inspect bounded dimensions, with no behavior change.
+  // The buffer entry point must have identical boundary behavior to the
+  // base64 checker so the file path avoids base64-encoding the full payload.
   const budgets = {
     none: undefined,
     dimensionOnly: { maxDimension: 2000 } as ImageDimensionBudget,
@@ -260,5 +268,268 @@ describe('formatImageBudgetDisplay (@issue:3216)', () => {
 
 ${message}`);
     expect(display.startsWith('## Image Dimension Limit')).toBe(true);
+  });
+});
+
+/**
+ * Build a raw JPEG buffer with a large APP1 metadata segment that pushes the
+ * SOF marker past a given offset. Uses the real JPEG segment framing
+ * (marker + big-endian length that includes the length field itself) so the
+ * segment walker exercises actual marker semantics, not mocked structure.
+ */
+function buildSofSegment(width: number, height: number): Buffer {
+  const len = Buffer.alloc(2);
+  len.writeUInt16BE(17, 0);
+  const h = Buffer.alloc(2);
+  h.writeUInt16BE(height, 0);
+  const w = Buffer.alloc(2);
+  w.writeUInt16BE(width, 0);
+  return Buffer.concat([
+    len,
+    Buffer.from([0x08]),
+    h,
+    w,
+    Buffer.from([0x03]),
+    Buffer.from([0x01, 0x22, 0x00]),
+    Buffer.from([0x02, 0x11, 0x11]),
+    Buffer.from([0x03, 0x11, 0x11]),
+  ]);
+}
+
+function buildJpegWithDelayedSof(
+  appPayloadSize: number,
+  width: number,
+  height: number,
+  tailBytes = 64,
+): Buffer {
+  const parts: Buffer[] = [];
+  // SOI
+  parts.push(Buffer.from([0xff, 0xd8]));
+  // APP1 segment with a large payload: marker(2) + Ls(2) + payload(Ls-2).
+  const appLength = appPayloadSize + 2;
+  const len = Buffer.alloc(2);
+  len.writeUInt16BE(appLength, 0);
+  parts.push(Buffer.from([0xff, 0xe1]));
+  parts.push(len);
+  parts.push(Buffer.alloc(appPayloadSize, 0x20));
+  parts.push(Buffer.from([0xff, 0xc0]));
+  parts.push(buildSofSegment(width, height));
+  // Minimal SOS + dummy scan data + EOI so the file has a plausible tail.
+  parts.push(
+    Buffer.from([
+      0xff, 0xda, 0x00, 0x0c, 0x03, 0x01, 0x00, 0x02, 0x11, 0x03, 0x11, 0x00,
+      0x3f, 0x00,
+    ]),
+  );
+  parts.push(Buffer.alloc(tailBytes, 0x80));
+  parts.push(Buffer.from([0xff, 0xd9]));
+  return Buffer.concat(parts);
+}
+
+/** In-memory JpegSegmentReader backed by a buffer, for unit tests. */
+function readerFromBuffer(buf: Uint8Array): JpegSegmentReader {
+  return (offset: number, length: number): Promise<Uint8Array> => {
+    const slice = buf.subarray(offset, offset + length);
+    return Promise.resolve(new Uint8Array(slice));
+  };
+}
+
+describe('parseJpegDimensionsFromReader — bounded JPEG SOF preflight (@issue:3216)', () => {
+  it('locates SOF beyond the 8192-byte prefix in a valid oversized JPEG', async () => {
+    // APP1 payload of 8298 bytes pushes SOF to ~offset 8304 > 8192.
+    const jpeg = buildJpegWithDelayedSof(8_298, 3_000, 3_000);
+    expect(jpeg.length).toBeGreaterThan(8_192);
+    const dims = await parseJpegDimensionsFromReader(readerFromBuffer(jpeg));
+    expect(dims).toEqual({ width: 3_000, height: 3_000 });
+  });
+
+  it('locates SOF for a within-budget JPEG with delayed SOF', async () => {
+    const jpeg = buildJpegWithDelayedSof(8_298, 1_800, 1_800);
+    const dims = await parseJpegDimensionsFromReader(readerFromBuffer(jpeg));
+    expect(dims).toEqual({ width: 1_800, height: 1_800 });
+  });
+
+  it('returns undefined for a non-JPEG input', async () => {
+    const png = await pngBytes(3000, 2000);
+    const dims = await parseJpegDimensionsFromReader(readerFromBuffer(png));
+    expect(dims).toBeUndefined();
+  });
+
+  it('returns undefined for an empty input', async () => {
+    const dims = await parseJpegDimensionsFromReader(
+      readerFromBuffer(new Uint8Array(0)),
+    );
+    expect(dims).toBeUndefined();
+  });
+
+  it('is bounded: an oversized metadata declaration cannot force unbounded reads', async () => {
+    // A malicious segment declares length 0xFFFF but the file ends at once.
+    const malicious = Buffer.concat([
+      Buffer.from([0xff, 0xd8]),
+      Buffer.from([0xff, 0xe1]),
+      Buffer.from([0xff, 0xff]),
+      Buffer.from([0x00]),
+    ]);
+    const dims = await parseJpegDimensionsFromReader(
+      readerFromBuffer(malicious),
+    );
+    expect(dims).toBeUndefined();
+  });
+
+  it('enforces an explicit inspection bound: SOF beyond the bound is not found', async () => {
+    // Two chained large APP segments push SOF past a small bound.
+    const segPayload = 60_000;
+    const parts: Buffer[] = [Buffer.from([0xff, 0xd8])];
+    for (let i = 0; i < 2; i++) {
+      const len = Buffer.alloc(2);
+      len.writeUInt16BE(segPayload + 2, 0);
+      parts.push(
+        Buffer.from([0xff, 0xe1]),
+        len,
+        Buffer.alloc(segPayload, 0x20),
+      );
+    }
+    const sofLen = Buffer.alloc(2);
+    sofLen.writeUInt16BE(17, 0);
+    const h = Buffer.alloc(2);
+    h.writeUInt16BE(3_000, 0);
+    const w = Buffer.alloc(2);
+    w.writeUInt16BE(3_000, 0);
+    parts.push(
+      Buffer.from([0xff, 0xc0]),
+      sofLen,
+      Buffer.from([0x08]),
+      h,
+      w,
+      Buffer.from([0x03]),
+      Buffer.from([0x01, 0x22, 0x00]),
+      Buffer.from([0x02, 0x11, 0x11]),
+      Buffer.from([0x03, 0x11, 0x11]),
+    );
+    const jpeg = Buffer.concat(parts);
+    // With a bound of 50_000, the walker stops before reaching SOF at
+    // ~offset 120_006.
+    const dims = await parseJpegDimensionsFromReader(
+      readerFromBuffer(jpeg),
+      50_000,
+    );
+    expect(dims).toBeUndefined();
+    // With the default bound, the same file is parsed.
+    const dimsFull = await parseJpegDimensionsFromReader(
+      readerFromBuffer(jpeg),
+    );
+    expect(dimsFull).toEqual({ width: 3_000, height: 3_000 });
+  });
+
+  it('finds a marker whose FF prefix is the last byte of a reader chunk', async () => {
+    // The first walk chunk after SOI covers bytes 2..9; byte 9 is the FF
+    // prefix and byte 10 the SOF0 code, so the marker straddles the chunk
+    // boundary.
+    const jpeg = Buffer.concat([
+      Buffer.from([0xff, 0xd8]),
+      Buffer.alloc(7, 0x20),
+      Buffer.from([0xff, 0xc0]),
+      buildSofSegment(3_000, 3_000),
+    ]);
+    const dims = await parseJpegDimensionsFromReader(readerFromBuffer(jpeg));
+    expect(dims).toEqual({ width: 3_000, height: 3_000 });
+  });
+
+  it('finds a marker after an FF fill run crossing a reader chunk boundary', async () => {
+    // Bytes 7..9 are FF fill and byte 10 the SOF0 code: the fill run ends on
+    // the chunk boundary and the code byte sits in the next chunk.
+    const jpeg = Buffer.concat([
+      Buffer.from([0xff, 0xd8]),
+      Buffer.alloc(5, 0x20),
+      Buffer.from([0xff, 0xff, 0xff]),
+      Buffer.from([0xc0]),
+      buildSofSegment(1_800, 1_800),
+    ]);
+    const dims = await parseJpegDimensionsFromReader(readerFromBuffer(jpeg));
+    expect(dims).toEqual({ width: 1_800, height: 1_800 });
+  });
+
+  it('stops within the explicit step bound on repeated standalone markers', async () => {
+    // 100_000 RSTn standalone markers: each walk step consumes one marker,
+    // far exceeding the step bound. The scan must stop within the bound
+    // rather than issuing one read per marker.
+    const parts: Buffer[] = [Buffer.from([0xff, 0xd8])];
+    for (let i = 0; i < 100_000; i++) {
+      parts.push(Buffer.from([0xff, 0xd0 | i % 8]));
+    }
+    const jpeg = Buffer.concat(parts);
+    let readCalls = 0;
+    const reader: JpegSegmentReader = async (offset, length) => {
+      readCalls++;
+      return new Uint8Array(jpeg.subarray(offset, offset + length));
+    };
+    const dims = await parseJpegDimensionsFromReader(reader);
+    expect(dims).toBeUndefined();
+    // One read per walk step plus the signature read.
+    expect(readCalls).toBeLessThanOrEqual(JPEG_SEGMENT_MAX_STEPS + 1);
+  });
+
+  it('propagates reader I/O errors instead of treating them as malformed input', async () => {
+    const jpeg = buildJpegWithDelayedSof(8_298, 3_000, 3_000);
+    const failing: JpegSegmentReader = async (offset, length) => {
+      if (offset > 0) throw new Error('EIO: read failure');
+      return new Uint8Array(jpeg.subarray(offset, offset + length));
+    };
+    await expect(parseJpegDimensionsFromReader(failing)).rejects.toThrow('EIO');
+  });
+});
+
+describe('checkImageFileDimensionBudget prefix-only path (@issue:3216)', () => {
+  it('returns undefined when the fixed prefix cannot reach SOF', async () => {
+    // SOF sits beyond 8192 bytes, so the prefix-only check cannot see it.
+    const jpeg = buildJpegWithDelayedSof(8_298, 3_000, 3_000);
+    let maxRequested = 0;
+    const readPrefix = async (maxBytes: number): Promise<Uint8Array> => {
+      maxRequested = Math.max(maxRequested, maxBytes);
+      return new Uint8Array(jpeg.subarray(0, maxBytes));
+    };
+    const budget: ImageDimensionBudget = { maxDimension: 2_000 };
+    expect(
+      await checkImageFileDimensionBudget(readPrefix, budget),
+    ).toBeUndefined();
+    expect(maxRequested).toBeLessThanOrEqual(8_192 + 1);
+  });
+});
+
+describe('checkImageFileBudgetMessage file-path JPEG fallback (@issue:3216)', () => {
+  it('flags a delayed-SOF oversized JPEG through the real file path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'llxprt-jpegwalk-'));
+    try {
+      const jpeg = buildJpegWithDelayedSof(8_298, 3_000, 3_000);
+      const file = join(dir, 'delayed.jpg');
+      writeFileSync(file, jpeg);
+      const message = await checkImageFileBudgetMessage(
+        file,
+        { maxDimension: 2_000 },
+        'delayed.jpg',
+      );
+      expect(message).toBeDefined();
+      expect(message).toContain('3000');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns undefined for a within-budget delayed-SOF JPEG through the real file path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'llxprt-jpegwalk-'));
+    try {
+      const jpeg = buildJpegWithDelayedSof(8_298, 1_800, 1_800);
+      const file = join(dir, 'ok.jpg');
+      writeFileSync(file, jpeg);
+      expect(
+        await checkImageFileBudgetMessage(
+          file,
+          { maxDimension: 2_000 },
+          'ok.jpg',
+        ),
+      ).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/tools/src/utils/imageDimensionBudget.ts
+++ b/packages/tools/src/utils/imageDimensionBudget.ts
@@ -26,7 +26,7 @@ export interface ImageDimensionBudget {
 export interface ImageBudgetViolation {
   readonly width: number;
   readonly height: number;
-  readonly pixels: number;
+  readonly pixels: number | bigint;
   readonly maxDimension?: number;
   readonly maxPixels?: number;
   readonly exceededDimension: boolean;
@@ -41,7 +41,7 @@ function readPositiveInteger(
   if (value === undefined) {
     return undefined;
   }
-  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
     throw new Error(
       `Invalid image dimension budget: ${key} must be a positive integer`,
     );
@@ -106,7 +106,7 @@ export function checkImageDimensionBudgetFromBuffer(
   );
 }
 
-function formatNumber(value: number): string {
+function formatNumber(value: number | bigint): string {
   return value.toLocaleString('en-US');
 }
 
@@ -145,6 +145,20 @@ ${message}`;
 /** Bounded prefix size for file-based dimension parsing. */
 const IMAGE_HEADER_PREFIX_BYTES = 8192;
 
+/** Close a file without replacing an operation error with a secondary close error. */
+export async function closeFileHandlePreservingPrimaryError(
+  close: () => Promise<void>,
+  primaryError: unknown,
+): Promise<void> {
+  try {
+    await close();
+  } catch (closeError) {
+    if (primaryError === undefined) {
+      throw closeError;
+    }
+  }
+}
+
 /** Reads up to `maxBytes` from the start of a file for dimension parsing. */
 export type HeaderReader = (maxBytes: number) => Promise<Uint8Array>;
 
@@ -178,12 +192,16 @@ export async function readFileHeaderPrefix(
 ): Promise<Uint8Array> {
   const { promises: fsp } = await import('node:fs');
   const fh = await fsp.open(filePath, 'r');
+  let primaryError: unknown;
   try {
     const buf = Buffer.alloc(maxBytes);
     const { bytesRead } = await fh.read(buf, 0, maxBytes, 0);
     return new Uint8Array(buf.buffer, buf.byteOffset, bytesRead);
+  } catch (error) {
+    primaryError = error;
+    throw error;
   } finally {
-    await fh.close();
+    await closeFileHandlePreservingPrimaryError(() => fh.close(), primaryError);
   }
 }
 
@@ -220,6 +238,7 @@ async function checkJpegFileDimensionBudget(
 ): Promise<ImageBudgetViolation | undefined> {
   const { promises: fsp } = await import('node:fs');
   const fh = await fsp.open(filePath, 'r');
+  let primaryError: unknown;
   try {
     const sigBuf = Buffer.alloc(2);
     const { bytesRead } = await fh.read(sigBuf, 0, 2, 0);
@@ -238,8 +257,11 @@ async function checkJpegFileDimensionBudget(
       dimensions.height,
       budget,
     );
+  } catch (error) {
+    primaryError = error;
+    throw error;
   } finally {
-    await fh.close();
+    await closeFileHandlePreservingPrimaryError(() => fh.close(), primaryError);
   }
 }
 
@@ -251,12 +273,16 @@ function checkImageDimensionBudgetFromDimensions(
   height: number,
   budget: ImageDimensionBudget,
 ): ImageBudgetViolation | undefined {
-  const pixels = width * height;
+  const exactPixels = BigInt(width) * BigInt(height);
+  const pixels =
+    exactPixels <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(exactPixels)
+      : exactPixels;
   const exceededDimension =
     budget.maxDimension !== undefined &&
     (width > budget.maxDimension || height > budget.maxDimension);
   const exceededPixels =
-    budget.maxPixels !== undefined && pixels > budget.maxPixels;
+    budget.maxPixels !== undefined && exactPixels > BigInt(budget.maxPixels);
   if (!exceededDimension && !exceededPixels) return undefined;
   return {
     width,

--- a/packages/tools/src/utils/imageDimensionBudget.ts
+++ b/packages/tools/src/utils/imageDimensionBudget.ts
@@ -1,0 +1,342 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  parseImageDimensions,
+  parseImageDimensionsFromBase64,
+} from './imageDimensions.js';
+import { ToolErrorType } from '../types/tool-error.js';
+
+/**
+ * A hard, provider/model-specific image output budget. When resolved from the
+ * active ephemeral settings, every built-in image-producing tool rejects bytes
+ * that exceed either boundary before they are handed to the model.
+ *
+ * `maxDimension` constrains BOTH the width and the height (the longest single
+ * edge). `maxPixels` constrains the total decoded pixel count.
+ *
+ * Both are optional: an absent field imposes no constraint, and a fully absent
+ * budget (undefined) disables the hard preflight entirely.
+ */
+export interface ImageDimensionBudget {
+  readonly maxDimension?: number;
+  readonly maxPixels?: number;
+}
+
+/**
+ * A concrete budget violation discovered by {@link checkImageDimensionBudget}.
+ * Carries the actual geometry and the boundary that was exceeded so the
+ * model-facing error is fully actionable.
+ */
+export interface ImageBudgetViolation {
+  readonly width: number;
+  readonly height: number;
+  readonly pixels: number;
+  readonly maxDimension?: number;
+  readonly maxPixels?: number;
+  readonly exceededDimension: boolean;
+  readonly exceededPixels: boolean;
+}
+
+function readPositiveInteger(
+  settings: Readonly<Record<string, unknown>>,
+  key: string,
+): number | undefined {
+  const value = settings[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new Error(
+      `Invalid image dimension budget: ${key} must be a positive integer`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Resolve the active image dimension/pixel budget from ephemeral settings.
+ *
+ * Returns `undefined` when neither key is configured (no hard limit). Throws
+ * immediately on a malformed value so a misconfiguration surfaces as a real
+ * tool error instead of silently disabling the preflight.
+ */
+export function resolveImageDimensionBudget(
+  settings: Readonly<Record<string, unknown>>,
+): ImageDimensionBudget | undefined {
+  const maxDimension = readPositiveInteger(settings, 'max-image-dimension');
+  const maxPixels = readPositiveInteger(settings, 'max-image-pixels');
+  if (maxDimension === undefined && maxPixels === undefined) {
+    return undefined;
+  }
+  return { maxDimension, maxPixels };
+}
+
+/**
+ * Check a base64 image payload against the active budget.
+ *
+ * Returns an {@link ImageBudgetViolation} when either the width/height exceeds
+ * `maxDimension` or the total pixels exceed `maxPixels`. Returns `undefined`
+ * when the image is within budget OR when the dimensions cannot be parsed from
+ * the header (we never invent a dimension for an unparseable image; it retains
+ * existing behavior).
+ */
+export function checkImageDimensionBudget(
+  base64: string,
+  budget: ImageDimensionBudget,
+): ImageBudgetViolation | undefined {
+  const dimensions = parseImageDimensionsFromBase64(base64);
+  if (dimensions === undefined) {
+    return undefined;
+  }
+  return checkImageDimensionBudgetFromDimensions(
+    dimensions.width,
+    dimensions.height,
+    budget,
+  );
+}
+
+/**
+ * Check raw image header bytes (a `Uint8Array`, e.g. a `Buffer`) against the
+ * active budget WITHOUT first base64-encoding the full payload. Shares the
+ * exact boundary logic with {@link checkImageDimensionBudget} via
+ * {@link checkImageDimensionBudgetFromDimensions}, so both entry points have
+ * identical boundary behavior; only the dimension source differs.
+ *
+ * Returns `undefined` when the image is within budget OR when the dimensions
+ * cannot be parsed from the header (we never invent a dimension for an
+ * unparseable image). Used by file-processing paths that already hold the raw
+ * bytes so the complete buffer is never base64-encoded just to inspect
+ * bounded dimensions.
+ */
+export function checkImageDimensionBudgetFromBuffer(
+  bytes: Uint8Array,
+  budget: ImageDimensionBudget,
+): ImageBudgetViolation | undefined {
+  const dimensions = parseImageDimensions(bytes);
+  if (dimensions === undefined) {
+    return undefined;
+  }
+  return checkImageDimensionBudgetFromDimensions(
+    dimensions.width,
+    dimensions.height,
+    budget,
+  );
+}
+
+function formatNumber(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+/**
+ * Build the model-facing error message for a budget violation. Includes the
+ * actual dimensions, the exceeded boundary, the image identity, and a direct
+ * instruction to create a thumbnail or downscale first.
+ */
+export function formatImageBudgetError(
+  violation: ImageBudgetViolation,
+  displayName?: string,
+): string {
+  const identity = displayName ? ` ${displayName}` : '';
+  const parts: string[] = [
+    `Image${identity} is ${violation.width}x${violation.height} pixels (${formatNumber(violation.pixels)} total)`,
+  ];
+  if (violation.exceededDimension && violation.maxDimension !== undefined) {
+    parts.push(
+      `exceeds the configured maximum dimension of ${violation.maxDimension} pixels on either width or height`,
+    );
+  }
+  if (violation.exceededPixels && violation.maxPixels !== undefined) {
+    parts.push(
+      `exceeds the configured maximum of ${formatNumber(violation.maxPixels)} total pixels`,
+    );
+  }
+  parts.push(
+    'Create a smaller thumbnail or downscale the image to within the budget, then read it again',
+  );
+  return parts.join('; ') + '.';
+}
+
+/**
+ * Shared terminal display heading for image budget violations. Every
+ * model-facing budget error site wraps its message with this so the user-facing
+ * presentation cannot drift between tools.
+ */
+export function formatImageBudgetDisplay(message: string): string {
+  return `## Image Dimension Limit
+
+${message}`;
+}
+
+/**
+ * Bounded prefix size for file-based dimension parsing. Covers PNG, GIF, WEBP
+ * headers entirely and JPEG SOF markers in practice; deliberately small so
+ * a multi-megabyte file is never read in full just to inspect dimensions.
+ */
+const IMAGE_HEADER_PREFIX_BYTES = 8192;
+
+/**
+ * Read a bounded prefix of a file for dimension parsing. Returns a Uint8Array
+ * containing up to `maxBytes` from the start of the file.
+ */
+export type HeaderReader = (maxBytes: number) => Promise<Uint8Array>;
+
+/**
+ * Check a file's image dimensions against the active budget by reading only a
+ * bounded header prefix — never the full file. Returns a violation when the
+ * image exceeds the budget, or `undefined` when the image is within budget, no
+ * budget is active, or the dimensions cannot be parsed (non-image or corrupt).
+ *
+ * Used by read_many_files to check explicitly-requested images BEFORE the
+ * generic per-item size-skip gate, so an oversized image receives an actionable
+ * tool error instead of being silently skipped for file-size reasons.
+ */
+export async function checkImageFileDimensionBudget(
+  readPrefix: HeaderReader,
+  budget: ImageDimensionBudget,
+): Promise<ImageBudgetViolation | undefined> {
+  const bytes = await readPrefix(IMAGE_HEADER_PREFIX_BYTES);
+  if (bytes.length === 0) return undefined;
+  const dimensions = parseImageDimensions(bytes);
+  if (dimensions === undefined) return undefined;
+  return checkImageDimensionBudgetFromDimensions(
+    dimensions.width,
+    dimensions.height,
+    budget,
+  );
+}
+
+/**
+ * Read a bounded prefix from a file on disk. Opens, reads up to `maxBytes`
+ * from offset 0, and always closes the handle.
+ */
+export async function readFileHeaderPrefix(
+  filePath: string,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  const { promises: fsp } = await import('node:fs');
+  const fh = await fsp.open(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(maxBytes);
+    const { bytesRead } = await fh.read(buf, 0, maxBytes, 0);
+    return new Uint8Array(buf.buffer, buf.byteOffset, bytesRead);
+  } finally {
+    await fh.close();
+  }
+}
+
+/**
+ * H4 preflight: check an explicitly-requested image file's dimensions against
+ * the active budget by reading only a bounded header prefix, and return the
+ * formatted, actionable error message when the image is oversized. Returns
+ * `undefined` when the image is within budget, no budget is active, or the
+ * dimensions cannot be parsed. The caller decides how to surface the message.
+ */
+export async function checkImageFileBudgetMessage(
+  filePath: string,
+  budget: ImageDimensionBudget | undefined,
+  displayName?: string,
+): Promise<string | undefined> {
+  if (budget === undefined) return undefined;
+  const violation = await checkImageFileDimensionBudget(
+    (maxBytes) => readFileHeaderPrefix(filePath, maxBytes),
+    budget,
+  );
+  if (violation === undefined) return undefined;
+  return formatImageBudgetError(violation, displayName);
+}
+
+/**
+ * Check dimensions directly (used by both base64 and file-based paths).
+ */
+function checkImageDimensionBudgetFromDimensions(
+  width: number,
+  height: number,
+  budget: ImageDimensionBudget,
+): ImageBudgetViolation | undefined {
+  const pixels = width * height;
+  const exceededDimension =
+    budget.maxDimension !== undefined &&
+    (width > budget.maxDimension || height > budget.maxDimension);
+  const exceededPixels =
+    budget.maxPixels !== undefined && pixels > budget.maxPixels;
+  if (!exceededDimension && !exceededPixels) return undefined;
+  return {
+    width,
+    height,
+    pixels,
+    maxDimension: budget.maxDimension,
+    maxPixels: budget.maxPixels,
+    exceededDimension,
+    exceededPixels,
+  };
+}
+
+/**
+ * Complete H4 preflight result: an actionable error for read_many_files when an
+ * explicitly-requested image file exceeds the budget. The caller wraps this
+ * into its own tool-result type.
+ */
+export interface ImageBudgetPreflightError {
+  readonly message: string;
+  readonly llmContent: string;
+  readonly returnDisplay: string;
+  readonly errorType: ToolErrorType;
+}
+
+/**
+ * H4 preflight: check an explicitly-requested image file's dimensions BEFORE
+ * the generic per-item size-skip gate in read_many_files. Reads only a bounded
+ * header prefix. Returns an actionable error when the image is oversized, or
+ * `undefined` when within budget, no budget, not an image, or not explicitly
+ * requested.
+ */
+export async function checkImageBudgetPreflightForFile(
+  filePath: string,
+  budget: ImageDimensionBudget | undefined,
+  isImage: boolean,
+  isExplicitlyRequested: boolean,
+  displayName?: string,
+): Promise<ImageBudgetPreflightError | undefined> {
+  if (budget === undefined || !isImage || !isExplicitlyRequested) {
+    return undefined;
+  }
+  const msg = await checkImageFileBudgetMessage(filePath, budget, displayName);
+  if (msg === undefined) return undefined;
+  return {
+    message: msg,
+    llmContent: msg,
+    returnDisplay: formatImageBudgetDisplay(msg),
+    errorType: ToolErrorType.READ_CONTENT_FAILURE,
+  };
+}
+
+/**
+ * Wrap a preflight error into the standard single-file processing result
+ * shape used by read_many_files (done + totalTokens + tool error).
+ */
+export function preflightToSingleFileResult(
+  pf: ImageBudgetPreflightError,
+  currentTokens: number,
+): {
+  done: true;
+  totalTokens: number;
+  error: {
+    llmContent: string;
+    returnDisplay: string;
+    error: { message: string; type: ToolErrorType };
+  };
+} {
+  return {
+    done: true,
+    totalTokens: currentTokens,
+    error: {
+      llmContent: pf.llmContent,
+      returnDisplay: pf.returnDisplay,
+      error: { message: pf.message, type: pf.errorType },
+    },
+  };
+}

--- a/packages/tools/src/utils/imageDimensionBudget.ts
+++ b/packages/tools/src/utils/imageDimensionBudget.ts
@@ -7,30 +7,22 @@
 import {
   parseImageDimensions,
   parseImageDimensionsFromBase64,
+  parseJpegDimensionsFromReader,
+  type JpegSegmentReader,
 } from './imageDimensions.js';
 import { ToolErrorType } from '../types/tool-error.js';
 
 /**
- * A hard, provider/model-specific image output budget. When resolved from the
- * active ephemeral settings, every built-in image-producing tool rejects bytes
- * that exceed either boundary before they are handed to the model.
- *
- * `maxDimension` constrains BOTH the width and the height (the longest single
- * edge). `maxPixels` constrains the total decoded pixel count.
- *
- * Both are optional: an absent field imposes no constraint, and a fully absent
- * budget (undefined) disables the hard preflight entirely.
+ * Hard image output budget. `maxDimension` constrains both width and height;
+ * `maxPixels` constrains total decoded pixels. An absent field imposes no
+ * constraint; a fully absent budget disables the preflight.
  */
 export interface ImageDimensionBudget {
   readonly maxDimension?: number;
   readonly maxPixels?: number;
 }
 
-/**
- * A concrete budget violation discovered by {@link checkImageDimensionBudget}.
- * Carries the actual geometry and the boundary that was exceeded so the
- * model-facing error is fully actionable.
- */
+/** A budget violation carrying the actual geometry and exceeded boundary. */
 export interface ImageBudgetViolation {
   readonly width: number;
   readonly height: number;
@@ -59,10 +51,9 @@ function readPositiveInteger(
 
 /**
  * Resolve the active image dimension/pixel budget from ephemeral settings.
- *
- * Returns `undefined` when neither key is configured (no hard limit). Throws
- * immediately on a malformed value so a misconfiguration surfaces as a real
- * tool error instead of silently disabling the preflight.
+ * Returns `undefined` when neither key is configured. Throws on a malformed
+ * value so a misconfiguration surfaces as a tool error instead of silently
+ * disabling the preflight.
  */
 export function resolveImageDimensionBudget(
   settings: Readonly<Record<string, unknown>>,
@@ -76,13 +67,9 @@ export function resolveImageDimensionBudget(
 }
 
 /**
- * Check a base64 image payload against the active budget.
- *
- * Returns an {@link ImageBudgetViolation} when either the width/height exceeds
- * `maxDimension` or the total pixels exceed `maxPixels`. Returns `undefined`
- * when the image is within budget OR when the dimensions cannot be parsed from
- * the header (we never invent a dimension for an unparseable image; it retains
- * existing behavior).
+ * Check a base64 image payload against the active budget. Returns `undefined`
+ * when the image is within budget or its dimensions cannot be parsed from the
+ * header (no dimension is invented for an unparseable image).
  */
 export function checkImageDimensionBudget(
   base64: string,
@@ -100,17 +87,9 @@ export function checkImageDimensionBudget(
 }
 
 /**
- * Check raw image header bytes (a `Uint8Array`, e.g. a `Buffer`) against the
- * active budget WITHOUT first base64-encoding the full payload. Shares the
- * exact boundary logic with {@link checkImageDimensionBudget} via
- * {@link checkImageDimensionBudgetFromDimensions}, so both entry points have
- * identical boundary behavior; only the dimension source differs.
- *
- * Returns `undefined` when the image is within budget OR when the dimensions
- * cannot be parsed from the header (we never invent a dimension for an
- * unparseable image). Used by file-processing paths that already hold the raw
- * bytes so the complete buffer is never base64-encoded just to inspect
- * bounded dimensions.
+ * Check raw image header bytes against the active budget, sharing the boundary
+ * logic of {@link checkImageDimensionBudget}. Used by file-processing paths
+ * that already hold the raw bytes, avoiding a full base64 encode.
  */
 export function checkImageDimensionBudgetFromBuffer(
   bytes: Uint8Array,
@@ -131,11 +110,7 @@ function formatNumber(value: number): string {
   return value.toLocaleString('en-US');
 }
 
-/**
- * Build the model-facing error message for a budget violation. Includes the
- * actual dimensions, the exceeded boundary, the image identity, and a direct
- * instruction to create a thumbnail or downscale first.
- */
+/** Build the model-facing error message for a budget violation. */
 export function formatImageBudgetError(
   violation: ImageBudgetViolation,
   displayName?: string,
@@ -160,39 +135,23 @@ export function formatImageBudgetError(
   return parts.join('; ') + '.';
 }
 
-/**
- * Shared terminal display heading for image budget violations. Every
- * model-facing budget error site wraps its message with this so the user-facing
- * presentation cannot drift between tools.
- */
+/** Shared display heading wrapping a budget error message. */
 export function formatImageBudgetDisplay(message: string): string {
   return `## Image Dimension Limit
 
 ${message}`;
 }
 
-/**
- * Bounded prefix size for file-based dimension parsing. Covers PNG, GIF, WEBP
- * headers entirely and JPEG SOF markers in practice; deliberately small so
- * a multi-megabyte file is never read in full just to inspect dimensions.
- */
+/** Bounded prefix size for file-based dimension parsing. */
 const IMAGE_HEADER_PREFIX_BYTES = 8192;
 
-/**
- * Read a bounded prefix of a file for dimension parsing. Returns a Uint8Array
- * containing up to `maxBytes` from the start of the file.
- */
+/** Reads up to `maxBytes` from the start of a file for dimension parsing. */
 export type HeaderReader = (maxBytes: number) => Promise<Uint8Array>;
 
 /**
- * Check a file's image dimensions against the active budget by reading only a
- * bounded header prefix — never the full file. Returns a violation when the
- * image exceeds the budget, or `undefined` when the image is within budget, no
- * budget is active, or the dimensions cannot be parsed (non-image or corrupt).
- *
- * Used by read_many_files to check explicitly-requested images BEFORE the
- * generic per-item size-skip gate, so an oversized image receives an actionable
- * tool error instead of being silently skipped for file-size reasons.
+ * Check a file's dimensions against the budget by reading only a bounded
+ * header prefix. Returns `undefined` when the image is within budget, no
+ * budget is active, or dimensions cannot be parsed.
  */
 export async function checkImageFileDimensionBudget(
   readPrefix: HeaderReader,
@@ -229,11 +188,11 @@ export async function readFileHeaderPrefix(
 }
 
 /**
- * H4 preflight: check an explicitly-requested image file's dimensions against
- * the active budget by reading only a bounded header prefix, and return the
- * formatted, actionable error message when the image is oversized. Returns
- * `undefined` when the image is within budget, no budget is active, or the
- * dimensions cannot be parsed. The caller decides how to surface the message.
+ * Check a file's image dimensions against the active budget, reading only a
+ * bounded header prefix. When the fixed prefix cannot reach SOF in a JPEG,
+ * falls back to the bounded segment walker. Returns `undefined` when the
+ * image is within budget, no budget is active, or dimensions cannot be
+ * parsed. I/O errors from the file reads propagate.
  */
 export async function checkImageFileBudgetMessage(
   filePath: string,
@@ -241,12 +200,47 @@ export async function checkImageFileBudgetMessage(
   displayName?: string,
 ): Promise<string | undefined> {
   if (budget === undefined) return undefined;
-  const violation = await checkImageFileDimensionBudget(
+  let violation = await checkImageFileDimensionBudget(
     (maxBytes) => readFileHeaderPrefix(filePath, maxBytes),
     budget,
   );
+  violation ??= await checkJpegFileDimensionBudget(filePath, budget);
   if (violation === undefined) return undefined;
   return formatImageBudgetError(violation, displayName);
+}
+
+/**
+ * Locate SOF past the fixed prefix via the bounded segment walker, opening
+ * the file once for the whole scan. Only invoked when the file is actually a
+ * JPEG and the prefix parse returned no dimensions.
+ */
+async function checkJpegFileDimensionBudget(
+  filePath: string,
+  budget: ImageDimensionBudget,
+): Promise<ImageBudgetViolation | undefined> {
+  const { promises: fsp } = await import('node:fs');
+  const fh = await fsp.open(filePath, 'r');
+  try {
+    const sigBuf = Buffer.alloc(2);
+    const { bytesRead } = await fh.read(sigBuf, 0, 2, 0);
+    if (bytesRead < 2 || sigBuf[0] !== 0xff || sigBuf[1] !== 0xd8) {
+      return undefined;
+    }
+    const reader: JpegSegmentReader = async (offset, length) => {
+      const buf = Buffer.alloc(length);
+      const { bytesRead: n } = await fh.read(buf, 0, length, offset);
+      return new Uint8Array(buf.buffer, buf.byteOffset, n);
+    };
+    const dimensions = await parseJpegDimensionsFromReader(reader);
+    if (dimensions === undefined) return undefined;
+    return checkImageDimensionBudgetFromDimensions(
+      dimensions.width,
+      dimensions.height,
+      budget,
+    );
+  } finally {
+    await fh.close();
+  }
 }
 
 /**
@@ -275,11 +269,7 @@ function checkImageDimensionBudgetFromDimensions(
   };
 }
 
-/**
- * Complete H4 preflight result: an actionable error for read_many_files when an
- * explicitly-requested image file exceeds the budget. The caller wraps this
- * into its own tool-result type.
- */
+/** Actionable preflight error returned to read_many_files for an oversized image. */
 export interface ImageBudgetPreflightError {
   readonly message: string;
   readonly llmContent: string;
@@ -288,11 +278,9 @@ export interface ImageBudgetPreflightError {
 }
 
 /**
- * H4 preflight: check an explicitly-requested image file's dimensions BEFORE
- * the generic per-item size-skip gate in read_many_files. Reads only a bounded
- * header prefix. Returns an actionable error when the image is oversized, or
- * `undefined` when within budget, no budget, not an image, or not explicitly
- * requested.
+ * Check an explicitly-requested image file's dimensions before the generic
+ * size-skip gate in read_many_files. Returns an actionable error when the
+ * image is oversized, or `undefined` otherwise.
  */
 export async function checkImageBudgetPreflightForFile(
   filePath: string,

--- a/packages/tools/src/utils/imageDimensions.ts
+++ b/packages/tools/src/utils/imageDimensions.ts
@@ -151,6 +151,148 @@ function parseJpegDimensions(bytes: Uint8Array): ImageDimensions | undefined {
   return undefined;
 }
 
+/**
+ * Random-access reader used by the bounded on-disk JPEG segment walker.
+ * Reads up to `length` bytes starting at `offset`, mirroring the semantics
+ * of a positioned file read (short reads at end-of-file are allowed).
+ */
+export type JpegSegmentReader = (
+  offset: number,
+  length: number,
+) => Promise<Uint8Array>;
+
+/**
+ * Maximum total byte offset the on-disk JPEG walker inspects. Generous enough
+ * to cover EXIF/XMP-heavy JPEGs, yet bounded so an adversarial file cannot
+ * force an unbounded scan.
+ */
+export const JPEG_SEGMENT_WALK_LIMIT = 524_288; // 512 KiB
+
+/**
+ * Maximum number of segment/marker steps the on-disk JPEG walker will
+ * process. A real JPEG rarely exceeds a few dozen segments; this bound
+ * stops adversarial inputs (long runs of standalone/fill markers) from
+ * inducing hundreds of thousands of reads.
+ */
+export const JPEG_SEGMENT_MAX_STEPS = 4_096;
+
+/** Result of scanning a small chunk for the next JPEG marker. */
+interface JpegMarkerScan {
+  readonly found: boolean;
+  readonly marker: number;
+  readonly nextOffset: number;
+}
+
+/**
+ * Locate the next segment marker in a bounded chunk, skipping FF fill bytes.
+ * Returns the marker and the offset past it, or the next chunk offset when
+ * the marker is not in this chunk.
+ */
+async function scanNextMarker(
+  reader: JpegSegmentReader,
+  offset: number,
+  maxOffset: number,
+): Promise<JpegMarkerScan | undefined> {
+  const seekLen = Math.min(8, maxOffset - offset);
+  const seek = await reader(offset, seekLen);
+  if (seek.length === 0) return undefined;
+  let idx = 0;
+  while (idx < seek.length && seek[idx] !== 0xff) idx++;
+  const fillStart = idx;
+  while (idx < seek.length && seek[idx] === 0xff) idx++;
+  if (idx >= seek.length) {
+    // A trailing FF run may have its marker code in the next chunk. Rewind
+    // to the last FF byte so the next read spans the prefix and its code.
+    // With no FF at all, advance past the whole chunk.
+    const advance = Math.max(fillStart, seek.length - 1);
+    if (advance === 0) return undefined;
+    return { found: false, marker: 0, nextOffset: offset + advance };
+  }
+  return { found: true, marker: seek[idx], nextOffset: offset + idx + 1 };
+}
+
+/** Extract SOF frame dimensions from the segment length-field bytes. */
+function extractSofDimensions(data: Uint8Array): ImageDimensions | undefined {
+  // SOF body layout (offsets relative to the length field):
+  // [len:2][precision:1][height:2][width:2][components...].
+  if (data.length < 7) return undefined;
+  const height = readUint16BE(data, 3);
+  const width = readUint16BE(data, 5);
+  if (!isValidDimension(width) || !isValidDimension(height)) {
+    return undefined;
+  }
+  return makeDimensions(width, height);
+}
+
+/** Outcome of processing one segment in the JPEG walk. */
+interface JpegWalkStep {
+  readonly done: boolean;
+  readonly dimensions?: ImageDimensions;
+  readonly nextOffset: number;
+}
+
+/** One walk step: classify the marker at `offset` and advance or finish. */
+async function processJpegSegment(
+  reader: JpegSegmentReader,
+  offset: number,
+  maxOffset: number,
+): Promise<JpegWalkStep> {
+  const scan = await scanNextMarker(reader, offset, maxOffset);
+  if (scan === undefined) return { done: true, nextOffset: offset };
+  if (!scan.found) return { done: false, nextOffset: scan.nextOffset };
+  const { marker, nextOffset } = scan;
+  // FF 00 is an escaped FF inside entropy data, not a segment marker.
+  if (marker === 0x00) return { done: false, nextOffset };
+  if (marker === 0xda) return { done: true, nextOffset }; // SOS
+  if (isStandaloneMarker(marker)) return { done: false, nextOffset };
+  // Segment carries a length field: read it plus enough for SOF dims.
+  const dataLen = Math.min(8, maxOffset - nextOffset);
+  if (dataLen < 2) return { done: true, nextOffset };
+  const data = await reader(nextOffset, dataLen);
+  if (data.length < 2) return { done: true, nextOffset };
+  const segmentLength = readUint16BE(data, 0);
+  if (segmentLength < 2) return { done: true, nextOffset };
+  if (isStartOfFrameMarker(marker)) {
+    return { done: true, dimensions: extractSofDimensions(data), nextOffset };
+  }
+  return { done: false, nextOffset: nextOffset + segmentLength };
+}
+
+/**
+ * Bounded, marker-aware JPEG dimension preflight for file-backed inputs.
+ *
+ * Walks JPEG segment headers on demand via the supplied reader — reading only
+ * the handful of bytes needed per segment header and skipping payloads by
+ * offset arithmetic — so a JPEG whose SOF sits beyond a fixed prefix (e.g.
+ * after large APP/COM metadata blocks) still yields its dimensions without
+ * reading the entire arbitrary file into memory.
+ *
+ * Uses the same marker classification (SOF/standalone/SOS semantics) as the
+ * in-memory {@link parseJpegDimensions}. Returns `undefined` for non-JPEG
+ * input, malformed structure, truncated reads, or when SOF would lie beyond
+ * `maxOffset`. Reader I/O errors propagate to the caller.
+ */
+export async function parseJpegDimensionsFromReader(
+  reader: JpegSegmentReader,
+  maxOffset: number = JPEG_SEGMENT_WALK_LIMIT,
+  maxSteps: number = JPEG_SEGMENT_MAX_STEPS,
+): Promise<ImageDimensions | undefined> {
+  const sig = await reader(0, 2);
+  if (sig.length < 2 || sig[0] !== 0xff || sig[1] !== 0xd8) {
+    return undefined;
+  }
+  let offset = 2;
+  let steps = 0;
+  while (offset < maxOffset) {
+    if (steps >= maxSteps) return undefined;
+    steps++;
+    const step = await processJpegSegment(reader, offset, maxOffset);
+    if (step.done) return step.dimensions;
+    offset = step.nextOffset;
+  }
+  return undefined;
+}
+
 function parseWebpDimensions(bytes: Uint8Array): ImageDimensions | undefined {
   // RIFF (4) + size (4) + WEBP (4) + chunk FourCC (4) = 16 bytes minimum.
   if (!hasBytes(bytes, 0, 16)) return undefined;

--- a/project-plans/issue3216/plan.md
+++ b/project-plans/issue3216/plan.md
@@ -1,0 +1,75 @@
+# Issue 3216 — Image dimension preflight and Anthropic recovery
+
+Plan ID: `PLAN-20260813-ISSUE3216`
+
+## Intent
+
+Prevent oversized image bytes from reaching a provider, return an actionable tool error before the bytes enter history, and recover an Anthropic request whose existing history already contains an image rejected by Anthropic's many-image dimension limit.
+
+## Grounded findings
+
+- `read_file` and `read_many_files` produce image `inlineData` through `processSingleFileContent` in `packages/tools/src/utils/fileUtils.ts`.
+- `generate_image` is the other built-in tool that directly emits image `inlineData`.
+- Image header dimensions can already be parsed without decoding the full image through `packages/tools/src/utils/imageDimensions.ts`.
+- Existing `image-resize.*` ephemerals perform opt-in/configured transformation. Dimension preflight is a separate hard output budget and must still run after any configured resize. It must not silently resize by default.
+- `claudecode.config` currently supplies automatic resize defaults for broad Opus/Sonnet model matching. Those defaults would make a 3000-pixel image silently pass and therefore conflict with the requested hard-error behavior.
+- Anthropic requests are built from immutable `IContent[]` in `AnthropicRequestPreparation.ts` and sent in `AnthropicProvider.ts`; recovery can construct a sanitized request copy without mutating shared history.
+
+## Requirements
+
+### REQ-3216-001 — Configurable hard image budget
+
+- Add positive-integer ephemeral settings `max-image-dimension` and `max-image-pixels`.
+- Make both settings valid in profiles/model alias defaults and available through the existing `/set` and profile pipelines.
+- No configured value means no new provider-independent hard limit.
+- Configure `max-image-dimension: 2000` in the `claudecode` model defaults for Claude Opus 5, Claude Opus 4.8, and Claude Sonnet 5.
+- Preserve explicit automatic resizing as a separate feature, but remove conflicting automatic resize defaults for these models so an oversized image fails unless the user explicitly opts into resizing.
+
+### REQ-3216-002 — Preflight every built-in image-producing tool
+
+- After any explicit resize and before returning bytes, inspect each base64 image emitted by `read_file`, `read_many_files`, or `generate_image`.
+- If width, height, or total pixels exceed the active budget, omit the bytes and return a real tool error.
+- The model-facing error must include the actual dimensions, the configured dimension/pixel goal that was exceeded, the image identity when available, and a direct instruction to create/read a thumbnail or downscale first.
+- An image at or below every configured boundary must be returned unchanged.
+- Non-image media and image formats whose dimensions cannot be parsed must retain existing behavior; do not invent a dimension.
+
+### REQ-3216-003 — Anthropic poisoned-history recovery
+
+- Recognize only Anthropic HTTP 400 invalid-request failures that state an image dimension exceeded the many-image maximum; unrelated 400 responses must retain existing behavior.
+- Replace offending oversized base64 image blocks in a request-local immutable content copy with short text placeholders recording that the image was dropped and why.
+- Retry the request exactly once with the sanitized copy. Never loop, and never use the ordinary transient retry budget for repeated recovery.
+- Preserve tool-call/tool-response validity and all unaffected content.
+- If no offending image can be identified and removed, rethrow the original error.
+- Apply equivalent preflight sanitization to an already-poisoned history when the active configured budget identifies an oversized image, so later turns do not repeatedly send known-invalid bytes.
+
+## Test-first execution
+
+1. **RED — settings and alias defaults**
+   - Add Bun tests proving both new keys accept positive integers, reject invalid values, persist through profile ephemerals, and propagate from model alias defaults without overriding user-set values.
+   - Add an alias configuration test proving only the required Claude models receive the 2000-pixel default and that the old implicit resize defaults no longer mask the hard error.
+2. **GREEN — settings registration**
+   - Add the profile types, registry entries, and alias defaults needed to pass those tests.
+3. **RED — image-budget utility and tool integration**
+   - Add Bun behavioral tests using real image bytes for below-boundary, exact-boundary, oversized-dimension, oversized-total-pixel, post-explicit-resize, unparseable-image, and non-image cases.
+   - Drive the real `read_file`, `read_many_files`, and `generate_image` result paths; mock only external image-generation transport where unavoidable, never the budget logic or tool under test.
+   - Assert oversized results contain no base64 image bytes and are classified as tool errors with actionable thumbnail/downscale guidance.
+4. **GREEN — shared preflight implementation**
+   - Implement one pure budget parser/checker shared by all built-in image-producing tools, then wire it at their output boundaries.
+5. **RED — Anthropic recovery integration**
+   - Add Bun provider tests with real `IContent` media blocks and a fake transport that first returns the exact Anthropic 400 shape, then accepts the sanitized retry.
+   - Prove one retry, immutable input history, placeholder insertion, unaffected media preservation, no retry for unrelated 400s, no retry when nothing can be removed, and no second recovery attempt.
+   - Add a known-invalid-history test proving proactive request preparation omits the oversized bytes before transport while a later valid image remains visible.
+6. **GREEN — request sanitization and bounded retry**
+   - Implement immutable Anthropic content sanitization and the specific one-shot recovery path at the provider request boundary.
+7. **Regression and manual verification**
+   - Run focused Bun tests after each RED/GREEN step, then the complete required verification suite: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build`.
+   - Run the standard smoke test: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+   - Create real 3000-pixel and 1800-pixel image fixtures outside tracked source and run `bun scripts/start.ts --profile-load opus5` prompts that call `read_file` on each. Capture evidence that 3000 pixels returns the actionable tool error without provider rejection and 1800 pixels is delivered successfully.
+
+## Guardrails
+
+- Use TypeScript and `bun:test` for every new or changed test.
+- Follow strict RED → GREEN → REFACTOR ordering and verify each new test fails for the intended missing behavior before production changes.
+- Do not add lint/type suppressions, loosen lint or complexity thresholds, or exclude files from linting.
+- Keep all transformations immutable and fail fast for invalid setting values.
+- Do not silently downscale unless the existing explicit image-resize configuration requests it.


### PR DESCRIPTION
## TLDR

Prevents oversized images from poisoning Claude Code sessions. Image-producing tools now enforce model-aware dimension and pixel budgets before returning bytes, and Anthropic requests can recover once from an existing oversized image in history by replacing it with an explanatory placeholder.

Claude Code defaults a 2000-pixel maximum dimension for Claude Opus 5, Opus 4.8, and Sonnet 5. Existing resize behavior remains available for older models and explicit user configuration; the new target-model behavior fails clearly rather than silently altering image detail.

## Dive Deeper

This change adds two positive-integer, profile-persisted ephemeral settings:

- `max-image-dimension`
- `max-image-pixels`

`read_file`, `read_many_files`, and `generate_image` apply the active hard budget after any explicitly configured resize and before inline image bytes enter model content. Rejected results include the actual dimensions, the active limit, and thumbnail/downscale guidance. `read_many_files` checks explicitly requested image headers before its generic per-item size skip, so realistic large images receive the actionable dimension error instead of being silently skipped.

For sessions that already contain an oversized image, Anthropic request preparation proactively replaces known-invalid media with text placeholders. If Anthropic returns its specific many-image dimension HTTP 400, the provider:

- recognizes the real Anthropic invalid-request body and message;
- inspects top-level media and media nested in `tool_result.content`;
- preserves tool IDs, sibling blocks, valid images, and shared history immutability;
- combines configured pixel limits with the stricter provider-reported dimension limit;
- retries the sanitized request exactly once;
- accounts for the recovery transport attempt and prevents later outer retries from resending the poisoned request.

The Claude Code model rules are anchored to the three requested exact model IDs. Older Claude Opus and Sonnet models retain their existing automatic-resize defaults.

## Reviewer Test Plan

1. Run the focused behavioral suites with the repository's isolated Bun runner:

       bun scripts/run_bun_tests.ts --workspace packages/providers
       bun scripts/run_bun_tests.ts --workspace packages/tools
       bun scripts/run_bun_tests.ts --workspace packages/settings

   The issue-specific coverage includes settings validation, Claude Code model defaults, tool preflight, nested Anthropic tool-result sanitization, real SDK-shaped 400 classification, exactly-once retry behavior through the retry orchestrator, attempt accounting, pixel-only limits, and boundary images.

2. Run the standard gates:

       npm run lint
       npm run typecheck
       npm run format
       npm run build
       npm run lint:settings-sync

3. Verify the normal CLI smoke path:

       bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"

4. With the existing `opus5` profile, create or use two local images and ask the model to call `read_file` once on each:
   - A 3000-by-3000 image returns an actionable tool error identifying 3000-by-3000 versus the 2000-pixel limit and recommends thumbnailing/downscaling. No image bytes reach the model and no provider 400 occurs.
   - An 1800-by-1800 image is accepted and visible to the model.

5. For provider recovery, run the issue-specific Anthropic provider test. It first returns the real SDK-shaped many-image 400, verifies oversized top-level and nested tool-result images are replaced, and confirms only one sanitized recovery request is permitted.

Local results:

- Issue-focused isolated Bun tests: all passed.
- Full lint, typecheck, format, build, settings synchronization, and StepFun smoke: passed.
- Full local macOS test run completed with the known unchanged PowerShell grammar WASM failures; all affected tests passed in isolated project-supported runners.
- Real `opus5` acceptance: 3000-pixel image rejected before transport; 1800-pixel image accepted.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ Focused suites and all non-PowerShell gates; known local PowerShell WASM failures remain | ❓ | CI |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | CI |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable maximum image dimensions and pixel counts for file-reading and image-generation tools.
  - Added preflight checks for oversized images, including nested and explicitly requested content.
  - Added one-time Anthropic recovery for recoverable image-dimension errors.
  - Updated Claude Code model defaults with targeted image limits.

- **Documentation**
  - Documented image budget settings, validation, enforcement, affected tools, and error behavior.

- **Bug Fixes**
  - Improved oversized-image handling, malformed image processing, retry limits, nested tool results, and configuration error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->