### PR TITLE
Bound tool acquisition before materialization (Fixes #3202)

### DIFF
--- a/packages/cli/src/services/prompt-processors/injectionOutputBudget.bun.test.ts
+++ b/packages/cli/src/services/prompt-processors/injectionOutputBudget.bun.test.ts
@@ -248,7 +248,7 @@ describe('StreamingInjectionBuilder - bounded retained state (issue #3200 findin
 
   it('honors the validated acquisition budget supplied by the caller', () => {
     // The builder accepts any validated ByteBudget; production code resolves it
-    // from config via resolveByteBudgetFromSetting. Verify a configured budget
+    // from config via resolveAcquisitionBudgetFromSetting. Verify a configured budget
     // is honored exactly.
     const budget = createByteBudget(4096);
     const builder = new StreamingInjectionBuilder(budget);

--- a/packages/cli/src/services/prompt-processors/injectionOutputBudget.ts
+++ b/packages/cli/src/services/prompt-processors/injectionOutputBudget.ts
@@ -30,7 +30,7 @@ export type PromptSegment =
  * Default aggregate byte budget for all injection outputs combined when a
  * caller does not supply a resolved budget. Production callers resolve the
  * budget from the configured shell acquisition setting
- * (`outputRetentionMaxBytes`) via {@link resolveByteBudgetFromSetting}; this
+ * (`outputRetentionMaxBytes`) via {@link resolveAcquisitionBudgetFromSetting}; this
  * constant only provides a finite fallback for the segment-based convenience
  * wrapper.
  */

--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -26,7 +26,7 @@ import {
   SHORTHAND_ARGS_PLACEHOLDER,
 } from './types.js';
 import { StreamingInjectionBuilder } from './injectionOutputBudget.js';
-import { resolveByteBudgetFromSetting } from '@vybestack/llxprt-code-tools/acquisition.js';
+import { resolveAcquisitionBudgetFromSetting } from '@vybestack/llxprt-code-core';
 
 type ShellProcessorRuntime = ShellPermissionConfig &
   ApprovalState &
@@ -175,7 +175,7 @@ export class ShellProcessor implements IPromptProcessor {
     // builder retains at most one global output budget across all injections
     // and never holds all command outputs simultaneously.
     const builder = new StreamingInjectionBuilder(
-      resolveByteBudgetFromSetting(
+      resolveAcquisitionBudgetFromSetting(
         config.getShellExecutionConfig().outputRetentionMaxBytes,
       ),
     );

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -25,8 +25,8 @@ import type { Agent } from '@vybestack/llxprt-code-agents';
 import {
   BoundedStreamCollector,
   createByteBudget,
-  resolveByteBudgetFromSetting,
 } from '@vybestack/llxprt-code-tools/acquisition.js';
+import { resolveAcquisitionBudgetFromSetting } from '@vybestack/llxprt-code-core';
 import { type UseHistoryManagerReturn } from './useHistoryManager.js';
 import { SHELL_COMMAND_NAME } from '../constants.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
@@ -486,7 +486,7 @@ function handleExecutionResult(
 
 async function initiateShellExecution(params: ShellExecutionParams) {
   const shellExecutionConfig = params.config.getShellExecutionConfig();
-  const outputBudget = resolveByteBudgetFromSetting(
+  const outputBudget = resolveAcquisitionBudgetFromSetting(
     shellExecutionConfig.outputRetentionMaxBytes,
   );
   const liveDisplayBudget = createByteBudget(

--- a/packages/cli/src/zed-integration/zed-terminal-setup.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-setup.ts
@@ -14,7 +14,7 @@ import {
   CoreToolRegistryHostAdapter,
 } from '@vybestack/llxprt-code-core';
 import { ShellTool, ToolRegistry } from '@vybestack/llxprt-code-tools';
-import { resolveByteBudgetFromSetting } from '@vybestack/llxprt-code-tools/acquisition.js';
+import { resolveAcquisitionBudgetFromSetting } from '@vybestack/llxprt-code-core';
 import { AcpTerminalShellHost } from './acp-terminal-shell-host.js';
 import { TerminalManager } from './zed-terminal-manager.js';
 
@@ -33,7 +33,7 @@ export function buildZedTerminalSetup(
 ): ZedTerminalSetup {
   // ACP receives the same finite acquisition budget as local shell execution,
   // rather than approximating bytes from the model-facing token limit.
-  const outputBudget = resolveByteBudgetFromSetting(
+  const outputBudget = resolveAcquisitionBudgetFromSetting(
     config.getEphemeralSetting('shell-output-retention-max-bytes'),
   );
   const terminals = new TerminalManager(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -143,6 +143,11 @@
       "bun": "./src/services/fileSystemService.ts",
       "import": "./dist/src/services/fileSystemService.js"
     },
+    "./services/shellAcquisitionConfig.js": {
+      "types": "./dist/src/services/shellAcquisitionConfig.d.ts",
+      "bun": "./src/services/shellAcquisitionConfig.ts",
+      "import": "./dist/src/services/shellAcquisitionConfig.js"
+    },
     "./services/fileDiscoveryService.js": {
       "types": "./dist/src/services/fileDiscoveryService.d.ts",
       "bun": "./src/services/fileDiscoveryService.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -291,6 +291,7 @@ export {
 
 // Export Shell Execution Service
 export * from './services/shellExecutionService.js';
+export { resolveAcquisitionBudgetFromSetting } from './services/shellAcquisitionConfig.js';
 
 // Export base tool definitions
 export {

--- a/packages/core/src/services/shellAcquisitionConfig.test.ts
+++ b/packages/core/src/services/shellAcquisitionConfig.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  resolveAcquisitionBudgetFromSetting,
+  resolveShellRetentionBudget,
+} from './shellAcquisitionConfig.js';
+import {
+  ACQUISITION_HARD_MAX_BYTES,
+  ACQUISITION_MIN_BYTES,
+  DEFAULT_ACQUISITION_BUDGET_BYTES,
+} from '@vybestack/llxprt-code-tools/acquisition.js';
+
+describe('resolveAcquisitionBudgetFromSetting', () => {
+  it('falls back to default for undefined', () => {
+    const budget = resolveAcquisitionBudgetFromSetting(undefined);
+    expect(budget.bytes).toBe(DEFAULT_ACQUISITION_BUDGET_BYTES);
+  });
+
+  it('falls back to default for null', () => {
+    const budget = resolveAcquisitionBudgetFromSetting(null);
+    expect(budget.bytes).toBe(DEFAULT_ACQUISITION_BUDGET_BYTES);
+  });
+
+  it('falls back to default for invalid string', () => {
+    const budget = resolveAcquisitionBudgetFromSetting('not-a-number');
+    expect(budget.bytes).toBe(DEFAULT_ACQUISITION_BUDGET_BYTES);
+  });
+
+  it('falls back to default for nonnumeric disabled values', () => {
+    expect(resolveAcquisitionBudgetFromSetting(false).bytes).toBe(
+      DEFAULT_ACQUISITION_BUDGET_BYTES,
+    );
+    expect(resolveAcquisitionBudgetFromSetting('').bytes).toBe(
+      DEFAULT_ACQUISITION_BUDGET_BYTES,
+    );
+  });
+
+  it('falls back to default for zero and negative values other than -1', () => {
+    expect(resolveAcquisitionBudgetFromSetting(0).bytes).toBe(
+      DEFAULT_ACQUISITION_BUDGET_BYTES,
+    );
+    expect(resolveAcquisitionBudgetFromSetting(-5).bytes).toBe(
+      DEFAULT_ACQUISITION_BUDGET_BYTES,
+    );
+  });
+
+  it('parses valid string', () => {
+    const budget = resolveAcquisitionBudgetFromSetting('8388608');
+    expect(budget.bytes).toBe(8388608);
+  });
+
+  it('uses hard max for -1 (disabled)', () => {
+    const budget = resolveAcquisitionBudgetFromSetting(-1);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('accepts a serialized -1', () => {
+    const budget = resolveAcquisitionBudgetFromSetting('-1');
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('clamps above hard max', () => {
+    const budget = resolveAcquisitionBudgetFromSetting(999_999_999);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('clamps a positive value above a valid intermediate custom hardMax', () => {
+    const customHardMax = 10 * 1024 * 1024; // 10 MiB — valid intermediate
+    const overCustom = 50 * 1024 * 1024; // 50 MiB — above the custom ceiling
+    const budget = resolveAcquisitionBudgetFromSetting(
+      overCustom,
+      customHardMax,
+    );
+    expect(budget.bytes).toBe(customHardMax);
+  });
+
+  it('respects the absolute ceiling even with a custom hardMax', () => {
+    const budget = resolveAcquisitionBudgetFromSetting(-1, 999 * 1024 * 1024);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('normalizes an invalid custom hard max before resolving -1', () => {
+    const budget = resolveAcquisitionBudgetFromSetting(-1, Infinity);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('clamps to the minimum floor', () => {
+    const budget = resolveAcquisitionBudgetFromSetting(1);
+    expect(budget.bytes).toBe(ACQUISITION_MIN_BYTES);
+  });
+
+  it('produces a runtime-immutable (frozen) budget', () => {
+    const budget = resolveAcquisitionBudgetFromSetting(8192);
+    expect(Object.isFrozen(budget)).toBe(true);
+    expect(budget.bytes).toBe(8192);
+  });
+});
+
+describe('resolveShellRetentionBudget', () => {
+  it('falls back to default for undefined', () => {
+    const budget = resolveShellRetentionBudget(undefined);
+    expect(budget.bytes).toBe(DEFAULT_ACQUISITION_BUDGET_BYTES);
+  });
+
+  it('uses hard max for -1', () => {
+    const budget = resolveShellRetentionBudget(-1);
+    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
+  });
+
+  it('resolves a valid number', () => {
+    const budget = resolveShellRetentionBudget(8192);
+    expect(budget.bytes).toBe(8192);
+  });
+});

--- a/packages/core/src/services/shellAcquisitionConfig.ts
+++ b/packages/core/src/services/shellAcquisitionConfig.ts
@@ -6,10 +6,48 @@
 
 import {
   createByteBudget,
-  resolveByteBudgetFromSetting,
   DEFAULT_ACQUISITION_BUDGET_BYTES,
+  ACQUISITION_HARD_MAX_BYTES,
+  normalizeHardMax,
   type ByteBudget,
 } from '@vybestack/llxprt-code-tools/acquisition.js';
+
+/**
+ * Resolve a raw settings value (from ephemeral settings / profile) into a
+ * validated {@link ByteBudget}. Falls back to the default when the value is
+ * absent, invalid, or disabled.
+ *
+ * This function owns the settings-policy interpretation (-1 meaning the
+ * hard max, invalid strings meaning default, disabled values meaning
+ * default) so the shared acquisition layer never needs to interpret raw
+ * configuration.
+ */
+export function resolveAcquisitionBudgetFromSetting(
+  rawValue: unknown,
+  hardMax: number = ACQUISITION_HARD_MAX_BYTES,
+): ByteBudget {
+  const effectiveHardMax = normalizeHardMax(hardMax);
+  if (rawValue === undefined || rawValue === null) {
+    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, effectiveHardMax);
+  }
+
+  const numeric = typeof rawValue === 'string' ? Number(rawValue) : rawValue;
+
+  // A configured -1 means "largest permitted value", never unbounded.
+  if (numeric === -1) {
+    return createByteBudget(effectiveHardMax, effectiveHardMax);
+  }
+
+  if (
+    typeof numeric !== 'number' ||
+    !Number.isFinite(numeric) ||
+    numeric <= 0
+  ) {
+    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, effectiveHardMax);
+  }
+
+  return createByteBudget(numeric, effectiveHardMax);
+}
 
 /**
  * Resolve the shell output retention byte budget from the execution config.
@@ -21,8 +59,5 @@ import {
 export function resolveShellRetentionBudget(
   outputRetentionMaxBytes: number | undefined,
 ): ByteBudget {
-  if (outputRetentionMaxBytes === undefined) {
-    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES);
-  }
-  return resolveByteBudgetFromSetting(outputRetentionMaxBytes);
+  return resolveAcquisitionBudgetFromSetting(outputRetentionMaxBytes);
 }

--- a/packages/mcp/src/client/jsonByteMeasurer.ts
+++ b/packages/mcp/src/client/jsonByteMeasurer.ts
@@ -1,0 +1,245 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Bounded recursive JSON byte measurer for MCP result trees.
+ *
+ * Measures the exact UTF-8 byte length of the JSON serialization of an
+ * arbitrary value — including structural overhead (braces, brackets, commas,
+ * colons, quotes) and JSON string escaping — WITHOUT materializing the full
+ * serialized string. Used to budget the entire own-enumerable MCP callTool
+ * result tree atomically before any transformation.
+ *
+ * Short-circuits at one-over the configured limit: as soon as the running
+ * total exceeds `limit`, measurement stops and `limit + 1` is returned. This
+ * keeps measurement finite even for pathological (deep / wide) inputs.
+ *
+ * Circular references and non-JSON-serializable values (BigInt) fail closed:
+ * they are treated as over-budget so the caller rejects atomically rather
+ * than passing through an un-budgetable result.
+ */
+
+/** Sentinel thrown internally to short-circuit recursion at one-over. */
+class JsonBudgetExceeded {
+  readonly marker = 'JsonBudgetExceeded';
+}
+
+/** UTF-8 byte length of a single Unicode code point (BMP or supplementary). */
+function utf8CodePointByteLength(cp: number): number {
+  if (cp < 0x80) return 1;
+  if (cp < 0x800) return 2;
+  if (cp < 0x10000) return 3;
+  return 4;
+}
+
+/**
+ * Measure the JSON byte contribution of a string value INCLUDING its
+ * surrounding quotes and JSON escaping. Short-circuits via `add`.
+ */
+function measureJsonString(str: string, add: (n: number) => void): void {
+  add(1); // opening quote
+  for (const ch of str) {
+    const cp = ch.codePointAt(0)!;
+    switch (cp) {
+      case 0x22: // " -> \"
+      case 0x5c: // \ -> \\
+      case 0x08: // backspace -> \b
+      case 0x09: // tab -> \t
+      case 0x0a: // newline -> \n
+      case 0x0c: // form feed -> \f
+      case 0x0d: // carriage return -> \r
+        add(2);
+        break;
+      default:
+        // Lone UTF-16 surrogates are escaped as \uXXXX (6 ASCII bytes) by
+        // JSON.stringify, not emitted as raw UTF-8. Valid surrogate pairs
+        // produce a single code point ≥ 0x10000 that is NOT in the surrogate
+        // range, so it falls through to utf8CodePointByteLength (4 bytes).
+        // Other C0 control chars are also escaped as \u00XX (6 bytes).
+        add(
+          cp < 0x20 || (cp >= 0xd800 && cp <= 0xdfff)
+            ? 6
+            : utf8CodePointByteLength(cp),
+        );
+    }
+  }
+  add(1); // closing quote
+}
+
+/**
+ * Measure a JSON number's serialized byte length. Non-finite numbers
+ * (NaN / ±Infinity) serialize as `null` (4 bytes), matching JSON.stringify.
+ */
+function jsonNumberByteLength(value: number): number {
+  if (!Number.isFinite(value)) return 4; // null
+  // For finite numbers, String(value) matches JSON.stringify's output
+  // (shortest round-trip, scientific notation where used).
+  return String(value).length;
+}
+
+/**
+ * Recursively measure the JSON byte length of `value`, accumulating into
+ * `add`. Throws {@link JsonBudgetExceeded} to short-circuit at one-over.
+ * Cycles and BigInt throw to fail closed at the top level.
+ */
+function measureJsonValue(
+  value: unknown,
+  add: (n: number) => void,
+  seen: WeakSet<object>,
+): void {
+  switch (typeof value) {
+    case 'string':
+      measureJsonString(value, add);
+      return;
+    case 'number':
+      add(jsonNumberByteLength(value));
+      return;
+    case 'boolean':
+      add(value ? 4 : 5);
+      return;
+    case 'bigint':
+      // JSON.stringify throws on BigInt — fail closed.
+      throw new JsonBudgetExceeded();
+    case 'undefined':
+      // JSON.stringify(undefined) yields nothing (no bytes) at the top level.
+      return;
+    case 'function':
+    case 'symbol':
+      // Standalone function/symbol serialize to undefined (nothing) — match
+      // JSON.stringify. As object values they are dropped by Object.entries.
+      return;
+    case 'object':
+      break;
+    default:
+      // Unknown exotic types: fail closed.
+      throw new JsonBudgetExceeded();
+  }
+
+  if (value === null) {
+    add(4); // null
+    return;
+  }
+
+  if (seen.has(value)) {
+    // Circular reference — fail closed.
+    throw new JsonBudgetExceeded();
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      measureJsonArray(value, add, seen);
+    } else {
+      measureJsonObject(value as Record<string, unknown>, add, seen);
+    }
+  } finally {
+    // Allow the same object to appear in sibling subtrees (JSON.stringify
+    // serializes those twice) — only nested cycles fail closed.
+    seen.delete(value);
+  }
+}
+
+function measureJsonArray(
+  arr: unknown[],
+  add: (n: number) => void,
+  seen: WeakSet<object>,
+): void {
+  if (arr.length === 0) {
+    add(2); // []
+    return;
+  }
+  add(1); // [
+  for (let i = 0; i < arr.length; i++) {
+    if (i > 0) add(1); // ,
+    const el = arr[i];
+    const elType = typeof el;
+    // In arrays, undefined/function/symbol elements serialize as `null`.
+    if (
+      elType === 'undefined' ||
+      elType === 'function' ||
+      elType === 'symbol'
+    ) {
+      add(4); // null
+    } else {
+      measureJsonValue(el, add, seen);
+    }
+  }
+  add(1); // ]
+}
+
+function measureJsonObject(
+  obj: Record<string, unknown>,
+  add: (n: number) => void,
+  seen: WeakSet<object>,
+): void {
+  // Only own enumerable string-keyed properties are serialized (matching
+  // JSON.stringify). Values that are undefined/function/symbol are omitted.
+  // Use lazy own-key traversal (for...in + hasOwnProperty) so wide objects
+  // are measured incrementally without materializing the full key array
+  // before the bounded short-circuit can stop — for...in visits own
+  // enumerable string keys in the same order Object.keys would return them.
+  let emittedAny = false;
+  for (const key in obj) {
+    // Map inherited (non-own) keys to undefined so the single omission guard
+    // below also excludes them — matching JSON.stringify, which serializes
+    // only own enumerable properties — without a second control-flow jump in
+    // this loop. Inherited getters are never invoked (the ternary resolves to
+    // undefined without reading obj[key]).
+    const val = Object.prototype.hasOwnProperty.call(obj, key)
+      ? obj[key]
+      : undefined;
+    const t = typeof val;
+    if (t === 'undefined' || t === 'function' || t === 'symbol') continue;
+    if (!emittedAny) {
+      add(1); // {
+      emittedAny = true;
+    } else {
+      add(1); // ,
+    }
+    measureJsonString(key, add); // "key"
+    add(1); // :
+    measureJsonValue(val, add, seen);
+  }
+  if (!emittedAny) {
+    add(2); // {}
+  } else {
+    add(1); // }
+  }
+}
+
+/**
+ * Measure the JSON UTF-8 byte length of `value`, bounded by `limit`.
+ *
+ * Returns the exact byte length when it is within `limit`; returns `limit + 1`
+ * (a definite over-budget marker) when the value would exceed `limit` OR when
+ * the value is non-serializable (circular, BigInt). Callers treat any return
+ * value greater than `limit` as over-budget and reject atomically.
+ */
+export function measureOwnEnumerableJsonBytes(
+  value: unknown,
+  limit: number,
+): number {
+  let total = 0;
+  const seen = new WeakSet<object>();
+  const add = (n: number): void => {
+    total += n;
+    if (total > limit) {
+      throw new JsonBudgetExceeded();
+    }
+  };
+  try {
+    measureJsonValue(value, add, seen);
+    return total;
+  } catch (err) {
+    // Only the internal budget-exceeded sentinel (also used for intentional
+    // fail-closed cases: circular references, BigInt, unknown exotics) should
+    // be treated as over-budget. Genuine runtime errors from getters or other
+    // unexpected sources must propagate (fail fast) rather than be masked.
+    if (err instanceof JsonBudgetExceeded) {
+      return limit + 1;
+    }
+    throw err;
+  }
+}

--- a/packages/mcp/src/client/mcp-callable-tool.ts
+++ b/packages/mcp/src/client/mcp-callable-tool.ts
@@ -5,10 +5,7 @@
  */
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import type {
-  CallToolResult,
-  Tool as McpTool,
-} from '@modelcontextprotocol/sdk/types.js';
+import type { Tool as McpTool } from '@modelcontextprotocol/sdk/types.js';
 import type {
   CallableTool,
   ToolCallRequest as FunctionCall,
@@ -17,76 +14,9 @@ import type {
 } from '@vybestack/llxprt-code-tools';
 import { createDefaultByteBudget } from '@vybestack/llxprt-code-tools/acquisition.js';
 import { MCP_CAPABILITY_NOT_AUTHORIZED_MESSAGE } from './mcp-errors.js';
-import { firstTruthyString } from '../utils/string-fallback.js';
+import { measureOwnEnumerableJsonBytes } from './jsonByteMeasurer.js';
 
 const MCP_CONTENT_BUDGET = createDefaultByteBudget();
-
-/** Content block element type derived from the SDK's CallToolResult. */
-type McpContentBlock = CallToolResult['content'][number];
-
-/** The full return type of Client.callTool (content variant ∪ task variant). */
-type CallToolReturn = Awaited<ReturnType<Client['callTool']>>;
-
-function utf8ByteLength(value: string): number {
-  return Buffer.byteLength(value, 'utf8');
-}
-
-/**
- * Compile-time exhaustiveness guard. If a new content block variant is added
- * to the SDK, this function's `never` parameter will fail to accept the
- * unhandled variant, producing a compile error at every switch site.
- */
-function assertNeverContent(block: never): never {
-  throw new Error(
-    `Unrecognized MCP content block type: ${JSON.stringify(block)}`,
-  );
-}
-
-function countContentBlockBytes(block: McpContentBlock): number {
-  switch (block.type) {
-    case 'text':
-      return utf8ByteLength(block.text);
-    case 'image':
-      return utf8ByteLength(block.data);
-    case 'audio':
-      return utf8ByteLength(block.data);
-    case 'resource': {
-      if ('text' in block.resource) {
-        return utf8ByteLength(block.resource.text);
-      }
-      return utf8ByteLength(block.resource.blob);
-    }
-    case 'resource_link': {
-      const label = firstTruthyString(block.title, block.name);
-      return utf8ByteLength(`Resource Link: ${label} at ${block.uri}`);
-    }
-    default:
-      return assertNeverContent(block);
-  }
-}
-
-function countAggregateContentBytes(
-  content: readonly McpContentBlock[],
-  limit: number,
-): number {
-  let total = 0;
-  for (const block of content) {
-    total += countContentBlockBytes(block);
-    if (total > limit) return total;
-  }
-  return total;
-}
-
-/**
- * Narrows a callTool result to the standard variant carrying a `content`
- * array. The SDK also returns a compatibility/task variant with `toolResult`
- * and no `content` — that variant has nothing to count.
- */
-function hasContentArray(
-  result: CallToolReturn,
-): result is CallToolReturn & { content: McpContentBlock[] } {
-  return 'content' in result && Array.isArray(result.content);
-}
 
 /**
  * Adapts an MCP tool definition to the neutral CallableTool interface so it
@@ -138,16 +68,20 @@ export class McpCallableTool implements CallableTool {
         throw new Error(MCP_CAPABILITY_NOT_AUTHORIZED_MESSAGE);
       }
 
-      if (hasContentArray(result)) {
-        const observedBytes = countAggregateContentBytes(
-          result.content,
-          MCP_CONTENT_BUDGET.bytes,
+      // Enforce one aggregate finite byte budget across the ENTIRE own-
+      // enumerable callTool result tree (content, loose extensions, the
+      // compatibility toolResult, nested metadata/annotations/resources, and
+      // all structural JSON overhead) atomically, before any display/model
+      // transformation. A bounded recursive measurer avoids materializing the
+      // whole serialization and fails closed on circular/non-serializable.
+      const observedBytes = measureOwnEnumerableJsonBytes(
+        result,
+        MCP_CONTENT_BUDGET.bytes,
+      );
+      if (observedBytes > MCP_CONTENT_BUDGET.bytes) {
+        throw new Error(
+          `MCP tool result content (${observedBytes.toLocaleString('en-US')} bytes) exceeds the maximum allowed (${MCP_CONTENT_BUDGET.bytes.toLocaleString('en-US')} bytes)`,
         );
-        if (observedBytes > MCP_CONTENT_BUDGET.bytes) {
-          throw new Error(
-            `MCP tool result content (${observedBytes.toLocaleString('en-US')} bytes) exceeds the maximum allowed (${MCP_CONTENT_BUDGET.bytes.toLocaleString('en-US')} bytes)`,
-          );
-        }
       }
 
       return [

--- a/packages/mcp/src/client/neutral-types.test.ts
+++ b/packages/mcp/src/client/neutral-types.test.ts
@@ -13,6 +13,7 @@ import {
   type ToolDeclarations,
 } from '@vybestack/llxprt-code-tools';
 import { McpCallableTool } from './mcp-callable-tool.js';
+import { measureOwnEnumerableJsonBytes } from './jsonByteMeasurer.js';
 
 const TOOL_DEF: McpTool = {
   name: 'test_tool',
@@ -21,6 +22,16 @@ const TOOL_DEF: McpTool = {
 };
 
 const BUDGET_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Compute the UTF-8 byte overhead of the JSON wrapper around an EMPTY payload,
+ * using JSON.stringify as the structural reference. The bounded recursive
+ * measurer must match this accounting exactly, so exact-boundary tests derive
+ * the fillable payload size from this rather than hand-counting braces.
+ */
+function jsonWrapperOverhead(wrapperWithEmptyPayload: unknown): number {
+  return Buffer.byteLength(JSON.stringify(wrapperWithEmptyPayload), 'utf8');
+}
 
 function mockClient(result: unknown): Client {
   return { callTool: async () => result } as unknown as Client;
@@ -104,7 +115,10 @@ describe('MCP behavioral tests for neutral wire types', () => {
 
 describe('McpCallableTool aggregate content budget', () => {
   it('accepts exact-boundary aggregate text', async () => {
-    const text = 'x'.repeat(BUDGET_BYTES);
+    const overhead = jsonWrapperOverhead({
+      content: [{ type: 'text', text: '' }],
+    });
+    const text = 'x'.repeat(BUDGET_BYTES - overhead);
     const client = mockClient({ content: [{ type: 'text', text }] });
     const tool = new McpCallableTool(client, TOOL_DEF, 5000);
     const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
@@ -201,8 +215,12 @@ describe('McpCallableTool aggregate content budget', () => {
   });
 
   it('accepts exact-boundary UTF-8 multibyte text', async () => {
-    // "é" is 2 UTF-8 bytes. BUDGET_BYTES / 2 chars = exactly BUDGET_BYTES bytes.
-    const text = 'é'.repeat(BUDGET_BYTES / 2);
+    const overhead = jsonWrapperOverhead({
+      content: [{ type: 'text', text: '' }],
+    });
+    // "é" is 2 UTF-8 bytes. Use the largest even fill ≤ the remaining budget.
+    const fillable = (BUDGET_BYTES - overhead) & ~1;
+    const text = 'é'.repeat(fillable / 2);
     const client = mockClient({ content: [{ type: 'text', text }] });
     const tool = new McpCallableTool(client, TOOL_DEF, 5000);
     const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
@@ -219,37 +237,31 @@ describe('McpCallableTool aggregate content budget', () => {
     expect(response.content).toBeUndefined();
   });
 
-  it('accepts exact-boundary resource-link transformed string', async () => {
-    // The transformed string is: `Resource Link: ${label} at ${uri}`
-    // Overhead: "Resource Link: " (15) + " at " (4) = 19 bytes.
-    // uri = "file:///r" (9 bytes). label must be BUDGET_BYTES - 19 - 9 bytes.
+  it('accepts exact-boundary resource-link raw JSON', async () => {
+    // The recursive measurer budgets the raw resource_link block JSON
+    // (not a transformed string). Compute the fillable title size from the
+    // wrapper overhead with an empty title.
     const uri = 'file:///r';
-    const labelLength = BUDGET_BYTES - 19 - uri.length;
+    const overhead = jsonWrapperOverhead({
+      content: [{ type: 'resource_link', uri, title: '' }],
+    });
+    const title = 'x'.repeat(BUDGET_BYTES - overhead);
     const client = mockClient({
-      content: [
-        {
-          type: 'resource_link',
-          uri,
-          title: 'x'.repeat(labelLength),
-        },
-      ],
+      content: [{ type: 'resource_link', uri, title }],
     });
     const tool = new McpCallableTool(client, TOOL_DEF, 5000);
     const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
     expect(extractResponse(parts).error).toBeUndefined();
   });
 
-  it('fails one-byte-over resource-link transformed string atomically', async () => {
+  it('fails one-byte-over resource-link raw JSON atomically', async () => {
     const uri = 'file:///r';
-    const labelLength = BUDGET_BYTES - 19 - uri.length + 1;
+    const overhead = jsonWrapperOverhead({
+      content: [{ type: 'resource_link', uri, title: '' }],
+    });
+    const title = 'x'.repeat(BUDGET_BYTES - overhead + 1);
     const client = mockClient({
-      content: [
-        {
-          type: 'resource_link',
-          uri,
-          title: 'x'.repeat(labelLength),
-        },
-      ],
+      content: [{ type: 'resource_link', uri, title }],
     });
     const tool = new McpCallableTool(client, TOOL_DEF, 5000);
     const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
@@ -294,5 +306,351 @@ describe('McpCallableTool aggregate content budget', () => {
     // No partial content or original result leaks through.
     expect(response.content).toBeUndefined();
     expect(response.isError).toBeUndefined();
+  });
+
+  describe('McpCallableTool aggregate budget across all fields (issue #3202)', () => {
+    it('enforces budget on structuredContent alone (one-over)', async () => {
+      const bigPayload = { data: 'x'.repeat(BUDGET_BYTES + 1) };
+      const client = mockClient({
+        content: [{ type: 'text', text: 'small' }],
+        structuredContent: bigPayload,
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('accepts structuredContent at exact boundary', async () => {
+      // The whole result tree is measured. The wrapper has:
+      // content:[{type:"text",text:"small"}] (text "small") plus
+      // structuredContent:{d:""}. Compute fillable from the wrapper overhead.
+      const overhead = jsonWrapperOverhead({
+        content: [{ type: 'text', text: 'small' }],
+        structuredContent: { d: '' },
+      });
+      const value = 'x'.repeat(BUDGET_BYTES - overhead);
+      const client = mockClient({
+        content: [{ type: 'text', text: 'small' }],
+        structuredContent: { d: value },
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toBeUndefined();
+    });
+
+    it('enforces budget on _meta alone (one-over)', async () => {
+      const client = mockClient({
+        content: [{ type: 'text', text: 'small' }],
+        _meta: { extension: 'x'.repeat(BUDGET_BYTES + 1) },
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('enforces mixed aggregate: content + structuredContent + _meta', async () => {
+      const third = Math.floor(BUDGET_BYTES / 3);
+      const client = mockClient({
+        content: [{ type: 'text', text: 'x'.repeat(third + 1) }],
+        structuredContent: { d: 'y'.repeat(third + 1) },
+        _meta: { ext: 'z'.repeat(third + 1) },
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('accepts mixed aggregate at exact boundary', async () => {
+      // Derive both payload sizes from the wrapper structural overhead so the
+      // whole tree measures exactly BUDGET_BYTES.
+      const structOverhead = jsonWrapperOverhead({
+        content: [{ type: 'text', text: '' }],
+        structuredContent: { d: '' },
+      });
+      const contentBytes = Math.floor((BUDGET_BYTES - structOverhead) / 2);
+      const structValue = 'x'.repeat(
+        BUDGET_BYTES - structOverhead - contentBytes,
+      );
+      const client = mockClient({
+        content: [{ type: 'text', text: 'y'.repeat(contentBytes) }],
+        structuredContent: { d: structValue },
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toBeUndefined();
+    });
+
+    it('enforces budget on toolResult (compatibility variant) content', async () => {
+      // The compatibility/task variant has toolResult.content instead of content.
+      const text = 'x'.repeat(BUDGET_BYTES + 1);
+      const client = mockClient({
+        toolResult: {
+          content: [{ type: 'text', text }],
+        },
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('accepts toolResult (compatibility variant) within budget', async () => {
+      const text = 'small result';
+      const client = mockClient({
+        toolResult: {
+          content: [{ type: 'text', text }],
+        },
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toBeUndefined();
+    });
+
+    it('rejects atomically — no partial content leaks on structuredContent overflow', async () => {
+      const client = mockClient({
+        content: [{ type: 'text', text: 'leaked content' }],
+        structuredContent: { data: 'x'.repeat(BUDGET_BYTES + 1) },
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      const response = extractResponse(parts);
+      expect(response.error).toMatchObject({ isError: true });
+      // No content or structuredContent must leak through.
+      expect(response.content).toBeUndefined();
+      expect(response.structuredContent).toBeUndefined();
+    });
+
+    it('budgets a loose top-level extension field beyond the known ones', async () => {
+      // An arbitrary own-enumerable field not in content/structuredContent/
+      // _meta/toolResult must still count toward the aggregate.
+      const overhead = jsonWrapperOverhead({
+        content: [{ type: 'text', text: 'small' }],
+        vendorExtension: '',
+      });
+      const client = mockClient({
+        content: [{ type: 'text', text: 'small' }],
+        vendorExtension: 'x'.repeat(BUDGET_BYTES - overhead + 1),
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('budgets nested resource annotations/metadata fields', async () => {
+      // Deeply nested metadata/annotations under a resource must count.
+      const overhead = jsonWrapperOverhead({
+        content: [
+          {
+            type: 'resource',
+            resource: {
+              uri: 'u',
+              text: '',
+              mimeType: 't',
+              annotations: { audience: [], priority: 0 },
+              _meta: { note: '' },
+            },
+          },
+        ],
+      });
+      const note = 'x'.repeat(BUDGET_BYTES - overhead + 1);
+      const client = mockClient({
+        content: [
+          {
+            type: 'resource',
+            resource: {
+              uri: 'u',
+              text: '',
+              mimeType: 't',
+              annotations: { audience: [], priority: 0 },
+              _meta: { note },
+            },
+          },
+        ],
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('budgets the entire arbitrary toolResult object, not just .content', async () => {
+      // The compatibility toolResult carries arbitrary sibling fields that must
+      // also count.
+      const overhead = jsonWrapperOverhead({
+        toolResult: { content: [{ type: 'text', text: '' }], blob: '' },
+      });
+      const client = mockClient({
+        toolResult: {
+          content: [{ type: 'text', text: 'small' }],
+          blob: 'x'.repeat(BUDGET_BYTES - overhead + 1),
+        },
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('budgets structural JSON overhead of many empty records', async () => {
+      // Many empty objects cost 2 bytes each structurally ({}) — a huge array
+      // of them must overflow purely on structural overhead, with no content.
+      const overhead = jsonWrapperOverhead({ content: [] });
+      const perEmpty = jsonWrapperOverhead({}); // {} = 2 bytes
+      const count = Math.ceil((BUDGET_BYTES - overhead) / perEmpty) + 1;
+      const client = mockClient({
+        content: Array.from({ length: count }, () => ({})),
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('counts JSON string escaping overhead (quotes inflate bytes)', async () => {
+      // A string of double-quotes doubles in size under JSON escaping. Size the
+      // payload so it is accepted without escaping accounting but rejected with it.
+      const overhead = jsonWrapperOverhead({
+        content: [{ type: 'text', text: '' }],
+      });
+      // Each `"` becomes `"` (2 bytes). fillable / 2 raw quotes fit, but
+      // (fillable/2)+1 raw quotes exceed after escaping.
+      const fillable = BUDGET_BYTES - overhead;
+      const rawQuotes = Math.floor(fillable / 2) + 1; // exceeds once escaped
+      const text = '"'.repeat(rawQuotes);
+      const client = mockClient({ content: [{ type: 'text', text }] });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('fails closed on a circular reference in the result', async () => {
+      const node: Record<string, unknown> = { label: 'root' };
+      node.self = node; // circular
+      const client = mockClient({
+        content: [{ type: 'text', text: 'small' }],
+        circular: node,
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('fails closed on a non-serializable BigInt value in the result', async () => {
+      const client = mockClient({
+        content: [{ type: 'text', text: 'small' }],
+        big: BigInt(123),
+      });
+      const tool = new McpCallableTool(client, TOOL_DEF, 5000);
+      const parts = await tool.callTool([{ name: 'test_tool', args: {} }]);
+      expect(extractResponse(parts).error).toMatchObject({ isError: true });
+    });
+
+    it('measurer byte count matches JSON.stringify for a representative tree', () => {
+      // Direct correctness cross-check: the bounded measurer must equal the
+      // reference JSON byte length for serializable values well under the limit.
+      const tree = {
+        content: [
+          { type: 'text', text: 'héllo "world"' + String.fromCharCode(10, 9) },
+          { type: 'image', data: 'AAA', mimeType: 'image/png' },
+        ],
+        structuredContent: { nested: { a: 1, b: [true, null, 2.5, 'x'] } },
+        _meta: { k: 'v' },
+        flag: false,
+      };
+      const reference = Buffer.byteLength(JSON.stringify(tree), 'utf8');
+      expect(measureOwnEnumerableJsonBytes(tree, BUDGET_BYTES)).toBe(reference);
+    });
+
+    it('-0 serializes as "0", matching JSON.stringify (issue #3202 OCR reject)', () => {
+      // String(-0) is "0", NOT "-0". JSON.stringify(-0) is also "0". The
+      // measurer must match this. This locks down the factually-correct
+      // behavior that OCR incorrectly flagged.
+      const value = { n: -0 };
+      const reference = Buffer.byteLength(JSON.stringify(value), 'utf8');
+      expect(measureOwnEnumerableJsonBytes(value, BUDGET_BYTES)).toBe(
+        reference,
+      );
+      // Structural sanity: {"n":0} = 7 bytes.
+      expect(reference).toBe(7);
+    });
+
+    it('counts a lone high surrogate as a six-byte \\uXXXX escape, matching JSON.stringify', () => {
+      const value = { s: '\ud800' };
+      const reference = Buffer.byteLength(JSON.stringify(value), 'utf8');
+      expect(measureOwnEnumerableJsonBytes(value, BUDGET_BYTES)).toBe(
+        reference,
+      );
+      // JSON.stringify emits the ASCII escape \ud800 (6 bytes) for the lone
+      // high surrogate, not raw UTF-8 (3 bytes).
+      expect(JSON.stringify(value)).toBe('{"s":"\\ud800"}');
+    });
+
+    it('counts a lone low surrogate as a six-byte \\uXXXX escape, matching JSON.stringify', () => {
+      const value = { s: '\udfff' };
+      const reference = Buffer.byteLength(JSON.stringify(value), 'utf8');
+      expect(measureOwnEnumerableJsonBytes(value, BUDGET_BYTES)).toBe(
+        reference,
+      );
+      expect(JSON.stringify(value)).toBe('{"s":"\\udfff"}');
+    });
+
+    it('counts mixed lone surrogates as six-byte escapes each, matching JSON.stringify', () => {
+      const value = { s: 'a\ud800b\udc00c' };
+      const reference = Buffer.byteLength(JSON.stringify(value), 'utf8');
+      expect(measureOwnEnumerableJsonBytes(value, BUDGET_BYTES)).toBe(
+        reference,
+      );
+      expect(JSON.stringify(value)).toBe('{"s":"a\\ud800b\\udc00c"}');
+    });
+
+    it('counts a valid surrogate pair as its 4-byte UTF-8 code point, matching JSON.stringify', () => {
+      const value = { s: '\u{1F600}' };
+      const reference = Buffer.byteLength(JSON.stringify(value), 'utf8');
+      expect(measureOwnEnumerableJsonBytes(value, BUDGET_BYTES)).toBe(
+        reference,
+      );
+      // The emoji (U+1F600) is a valid pair that encodes to 4 UTF-8 bytes,
+      // NOT an escape sequence.
+      expect(reference).toBe(
+        Buffer.byteLength('{"s":"', 'utf8') +
+          4 +
+          Buffer.byteLength('"}', 'utf8'),
+      );
+    });
+
+    it('rethrows a genuine getter error instead of swallowing it as over-budget', () => {
+      const evil: Record<string, unknown> = {};
+      Object.defineProperty(evil, 'boom', {
+        enumerable: true,
+        get(): number {
+          throw new Error('genuine getter error');
+        },
+      });
+      // Fail fast: a genuine runtime error from an unexpected source must
+      // propagate, not be masked as an over-budget result.
+      expect(() => measureOwnEnumerableJsonBytes(evil, BUDGET_BYTES)).toThrow(
+        'genuine getter error',
+      );
+    });
+
+    it('still fails closed on circular references (sentinel path returns over-budget)', () => {
+      const node: Record<string, unknown> = { label: 'root' };
+      node.self = node;
+      // Circular references throw the internal sentinel and are treated as
+      // over-budget (limit + 1), preserving the deliberate fail-closed
+      // contract even after the catch was narrowed to the sentinel.
+      expect(measureOwnEnumerableJsonBytes(node, BUDGET_BYTES)).toBe(
+        BUDGET_BYTES + 1,
+      );
+    });
+
+    it('ignores inherited enumerable properties, matching JSON.stringify (lazy own-key traversal)', () => {
+      // for...in + hasOwnProperty must skip prototype properties exactly like
+      // Object.keys / JSON.stringify do, while still counting own keys.
+      const proto = { inherited: 'value' };
+      const obj: Record<string, unknown> = Object.create(proto);
+      obj.own = 1;
+      obj.also = 'x';
+      const reference = Buffer.byteLength(JSON.stringify(obj), 'utf8');
+      expect(measureOwnEnumerableJsonBytes(obj, BUDGET_BYTES)).toBe(reference);
+      // Inherited property must NOT contribute; only own keys counted.
+      expect(reference).toBe(Buffer.byteLength('{"own":1,"also":"x"}', 'utf8'));
+    });
   });
 });

--- a/packages/tools/src/__tests__/acquisition-boundary.test.ts
+++ b/packages/tools/src/__tests__/acquisition-boundary.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import * as acquisition from '../acquisition/index.js';
+
+/**
+ * Acquisition package-boundary coverage.
+ *
+ * The shared acquisition layer must own bounded collection primitives and
+ * LLxprt-owned read-loop adapters (HTTP, stream). It must NOT interpret raw
+ * settings policy — that belongs in the owning core/CLI modules.
+ *
+ * These tests assert the public surface so accidental re-coupling is a
+ * test failure, not a silent regression.
+ */
+describe('acquisition package boundary', () => {
+  describe('primitives and collectors are exported', () => {
+    it('exports createByteBudget', () => {
+      expect(typeof acquisition.createByteBudget).toBe('function');
+    });
+
+    it('exports createDefaultByteBudget', () => {
+      expect(typeof acquisition.createDefaultByteBudget).toBe('function');
+    });
+
+    it('exports BoundedStreamCollector', () => {
+      expect(typeof acquisition.BoundedStreamCollector).toBe('function');
+    });
+
+    it('exports BoundedCombinedCollector', () => {
+      expect(typeof acquisition.BoundedCombinedCollector).toBe('function');
+    });
+
+    it('exports budget constants', () => {
+      expect(acquisition.ACQUISITION_HARD_MAX_BYTES).toBeGreaterThan(0);
+      expect(acquisition.DEFAULT_ACQUISITION_BUDGET_BYTES).toBeGreaterThan(0);
+    });
+  });
+
+  describe('HTTP adapter is exported from acquisition', () => {
+    it('exports acquireBoundedHttpBody', () => {
+      expect(typeof acquisition.acquireBoundedHttpBody).toBe('function');
+    });
+
+    it('exports disposeHttpResponseBody', () => {
+      expect(typeof acquisition.disposeHttpResponseBody).toBe('function');
+    });
+
+    it('exports HttpBodyTooLargeError', () => {
+      expect(typeof acquisition.HttpBodyTooLargeError).toBe('function');
+    });
+  });
+
+  describe('raw settings policy is NOT in the acquisition surface', () => {
+    it('does not export resolveByteBudgetFromSetting', () => {
+      expect(acquisition).not.toHaveProperty('resolveByteBudgetFromSetting');
+    });
+  });
+});

--- a/packages/tools/src/__tests__/discovered-tool-bounded-acquisition.test.ts
+++ b/packages/tools/src/__tests__/discovered-tool-bounded-acquisition.test.ts
@@ -124,6 +124,31 @@ describe('DiscoveredTool bounded acquisition', () => {
   );
 
   it.skipIf(process.platform === 'win32')(
+    'attaches structured outputTruncation metadata when output is bounded',
+    async () => {
+      const script = createScript(
+        tempDir,
+        'huge-output-meta.sh',
+        '#!/bin/sh\nhead -c 10485760 /dev/zero | tr "\\0" "A"',
+      );
+      const tool = createDiscoveredTool(script);
+      const result = await executeTool(tool);
+
+      expect(result.error).toBeUndefined();
+      // Structured truncation metadata must be present so downstream
+      // consumers can detect non-exhaustive results without parsing text.
+      expect(result.metadata).toBeDefined();
+      const meta = result.metadata;
+      expect(meta).toHaveProperty('outputTruncation');
+      const truncation = meta!['outputTruncation'] as Record<string, unknown>;
+      expect(truncation['truncated']).toBe(true);
+      expect(typeof truncation['observedBytes']).toBe('number');
+      expect(truncation['observedBytes']).toBeGreaterThan(0);
+    },
+    { timeout: 30000 },
+  );
+
+  it.skipIf(process.platform === 'win32')(
     'truncation notice is identical in llmContent, returnDisplay, and error.message',
     async () => {
       // Produce 10 MiB on stdout AND write to stderr to trigger error path.

--- a/packages/tools/src/__tests__/grep-ripgrep-issue3203-remediation.test.ts
+++ b/packages/tools/src/__tests__/grep-ripgrep-issue3203-remediation.test.ts
@@ -15,6 +15,7 @@ import {
   createAggregateSemanticBudget,
   createGrepRetainState,
   retainGrepMatch,
+  DEFAULT_SOURCE_BUDGET_BYTES,
 } from '../tools/grep/grepBudget.js';
 import { GrepTool, RipGrepTool } from '../index.js';
 import type { ToolResult } from '../index.js';
@@ -228,6 +229,7 @@ describe('Strategy budget rollback: failed strategy does not starve fallback (it
         const budget: SemanticBudget = {
           remainingBytes: 4000,
           remainingObjects: 100,
+          sourceBytes: DEFAULT_SOURCE_BUDGET_BYTES,
         };
         const result = await performGrepSearch(
           {
@@ -439,6 +441,7 @@ describe('Ripgrep multi-root budget exhaustion stops further spawns (item 11)', 
         const tightBudget: SemanticBudget = {
           remainingBytes: 50_000,
           remainingObjects: 100_000,
+          sourceBytes: DEFAULT_SOURCE_BUDGET_BYTES,
         };
 
         const result = await javascriptGrepFallback(
@@ -456,6 +459,53 @@ describe('Ripgrep multi-root budget exhaustion stops further spawns (item 11)', 
         expect(result.incomplete).toBe(true);
         expect(result.results.length).toBeLessThan(50);
         expect(tightBudget.remainingBytes).toBeLessThan(50_000);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'charges source chunks against the aggregate sourceBytes across no-match files (not a fresh per-file budget)',
+      async () => {
+        const { javascriptGrepFallback } = await import(
+          '../tools/grep/javascriptFallback.js'
+        );
+
+        // 10 no-match files, 1000 bytes each. The tight source budget (3500)
+        // allows three full files; the fourth file's first chunk (1000)
+        // exceeds the remaining 500 bytes and must prove partiality against
+        // the SHARED aggregate budget — not a fresh per-file allowance.
+        for (let i = 0; i < 10; i++) {
+          writeFileSync(join(tempDir, `nomatch${i}.txt`), 'x'.repeat(1000));
+        }
+
+        const budget: SemanticBudget = {
+          remainingBytes: 1_000_000,
+          remainingObjects: 100_000,
+          sourceBytes: 3_500,
+        };
+
+        const result = await javascriptGrepFallback(
+          'definitely_no_such_match',
+          tempDir,
+          undefined,
+          new AbortController().signal,
+          1000,
+          100,
+          50,
+          ['node_modules'],
+          budget,
+        );
+
+        // Bounded: the aggregate budget was actually consumed across files
+        // (three files = 3000 charged, 500 remain) — multiple no-match files
+        // did NOT each receive a fresh budget.
+        expect(budget.sourceBytes).toBe(500);
+        // Truthful: the run is marked incomplete because the fourth file
+        // could not be fully observed.
+        expect(result.incomplete).toBe(true);
+        expect(result.wasLimited).toBe(true);
+        expect(result.results).toHaveLength(0);
+        expect(result.totalFound).toBeUndefined();
       },
       { timeout: 15000 },
     );
@@ -717,4 +767,141 @@ describe('Exact-cap multi-root completeness: skipped roots mark incomplete (item
     },
     { timeout: 15000 },
   );
+});
+
+describe('javascriptGrepFallback mid-file abort (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir('llxprt-fallback-abort-');
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it(
+    'rejects promptly on mid-file abort without reading the entire file',
+    async () => {
+      const { javascriptGrepFallback } = await import(
+        '../tools/grep/javascriptFallback.js'
+      );
+
+      // A large file with many matching lines so the read stream is still
+      // active when we abort.
+      const lines: string[] = [];
+      for (let i = 0; i < 50_000; i++) {
+        lines.push(`abort_match_${i}`);
+      }
+      writeFileSync(join(tempDir, 'big.txt'), lines.join('\n'));
+
+      const controller = new AbortController();
+      const promise = javascriptGrepFallback(
+        'abort_match',
+        tempDir,
+        undefined,
+        controller.signal,
+        100_000,
+        100,
+        100_000,
+        ['node_modules'],
+        createAggregateSemanticBudget(),
+      );
+
+      // Abort while the first file is still being streamed. The per-file
+      // read stream is destroyed promptly by the abort wiring, and the glob
+      // stream sees the aborted signal — the function must reject without
+      // hanging or reading the entire file to EOF.
+      controller.abort();
+      await expect(promise).rejects.toThrow(/abort/i);
+    },
+    { timeout: 15000 },
+  );
+});
+
+describe('grep directory partial metadata.outputTruncation consistency (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => cleanup());
+
+  it('partial directory result (max_results+1) includes metadata.outputTruncation', async () => {
+    for (let i = 0; i < 6; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), `match_line_${i}\n`);
+    }
+
+    const result = await executeGrep(createToolHost(tempDir), {
+      pattern: 'match_line',
+      max_results: 5,
+      max_files: 100,
+      max_per_file: 1,
+    });
+
+    expect(result.error).toBeUndefined();
+    // The directory partial path MUST carry metadata.outputTruncation.
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata).toHaveProperty('outputTruncation');
+    expect(
+      (result.metadata as Record<string, unknown>).outputTruncation,
+    ).toEqual({ truncated: true });
+  });
+
+  it('exact directory result does NOT include metadata.outputTruncation', async () => {
+    for (let i = 0; i < 3; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), `match_line_${i}\n`);
+    }
+
+    const result = await executeGrep(createToolHost(tempDir), {
+      pattern: 'match_line',
+      max_results: 100,
+      max_files: 100,
+      max_per_file: 10,
+    });
+
+    expect(result.error).toBeUndefined();
+    // An exact result should NOT carry outputTruncation metadata.
+    expect(result.metadata?.outputTruncation).toBeUndefined();
+  });
+});
+
+describe('grep singular wording on partial paths (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => cleanup());
+
+  it('directory partial with 1 retained match uses singular "match" not "matches"', async () => {
+    // 2 matches across 2 files with max_results=1: only 1 is retained.
+    writeFileSync(join(tempDir, 'a.txt'), 'unique_line\n');
+    writeFileSync(join(tempDir, 'b.txt'), 'unique_line\n');
+
+    const result = await executeGrep(createToolHost(tempDir), {
+      pattern: 'unique_line',
+      max_results: 1,
+      max_files: 100,
+      max_per_file: 1,
+    });
+
+    const display = String(result.returnDisplay);
+
+    // The result is partial/incomplete (2 matches found, 1 retained).
+    // The display must use singular "match" when count is 1.
+    expect(display).toContain('Showing 1 match');
+    expect(display).not.toMatch(/Showing 1 matches/);
+  });
 });

--- a/packages/tools/src/__tests__/read-many-files-bounded-acquisition.test.ts
+++ b/packages/tools/src/__tests__/read-many-files-bounded-acquisition.test.ts
@@ -1,0 +1,755 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  writeFileSync,
+  rmSync,
+  mkdtempSync,
+  symlinkSync,
+  mkdirSync,
+} from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createRealToolHost as createRealHost } from './helpers/create-real-tool-host.js';
+import { ReadManyFilesTool } from '../tools/read-many-files.js';
+import type { ToolResult } from '../index.js';
+
+function createTempDir(prefix = 'llxprt-rmf-bounded-'): {
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function stringifyLlmContent(result: ToolResult): string {
+  return Array.isArray(result.llmContent)
+    ? result.llmContent
+        .map((part) => (typeof part === 'string' ? part : JSON.stringify(part)))
+        .join('\n')
+    : String(result.llmContent);
+}
+
+function createHostWithSettings(
+  targetDir: string,
+  settings: Readonly<Record<string, unknown>>,
+) {
+  const baseHost = createRealHost(targetDir, {
+    respectGitIgnore: true,
+    respectLlxprtIgnore: true,
+  });
+  return {
+    ...baseHost,
+    getEphemeralSettings: () => ({
+      ...baseHost.getEphemeralSettings(),
+      ...settings,
+    }),
+  };
+}
+
+describe('ReadManyFiles bounded file discovery (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('bounds discovery at the file-count hard cap and reports partial (one-over)', async () => {
+    // Create 60 files — exceeds the default max-file-count of 50.
+    for (let i = 0; i < 60; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), `content ${i}\n`, 'utf-8');
+    }
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1_000_000,
+      'tool-output-truncate-mode': 'truncate',
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+    const display = result.returnDisplay as string;
+
+    // Discovery was bounded — exactly 50 files retained from 60.
+    // Count separator markers to verify file count is bounded at 50.
+    const fileCount = (text.match(/--- \S+[\\/]f\d+\.txt ---/g) ?? []).length;
+    expect(fileCount).toBe(50);
+    // The display message must indicate the result is partial, not exhaustive.
+    expect(display).toMatch(/truncat|limited|exceed|skipped|more/i);
+  });
+
+  it('reads retained files in warn mode when discovery truncates but files are within cap', async () => {
+    for (let i = 0; i < 60; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), `content ${i}\n`, 'utf-8');
+    }
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1_000_000,
+      'tool-output-truncate-mode': 'warn',
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+
+    // Warn mode reads retained files (not zero content) when discovery
+    // truncated but unique files are within the cap.
+    expect(text).not.toMatch(/limiting|File Count Limit Exceeded/i);
+    // The retained files must be read and their content present.
+    const fileCount = (text.match(/content \d+/g) ?? []).length;
+    expect(fileCount).toBe(50);
+  });
+
+  it('hard-clamps a huge tool-output-max-items setting', async () => {
+    for (let i = 0; i < 10; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), `content ${i}\n`, 'utf-8');
+    }
+
+    // A pathological max-items setting should be hard-clamped, not honored
+    // as an unbounded file budget.
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 999_999_999,
+      'tool-output-max-tokens': 1_000_000,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    // All 10 files should be read (under the hard cap), so no error.
+    expect(result.error).toBeUndefined();
+    const text = stringifyLlmContent(result);
+    expect(text).toContain('f0.txt');
+    expect(text).toContain('f9.txt');
+  });
+});
+
+describe('ReadManyFiles aggregate byte budget (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('bounds total retained bytes independent of the permissive token limit', async () => {
+    // Each file is ~1 MiB. With a very high token limit, the ONLY cap should
+    // be the aggregate acquisition byte budget — the total must remain bounded.
+    const big = 'A'.repeat(1024 * 1024); // 1 MiB
+    for (let i = 0; i < 20; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), big, 'utf-8');
+    }
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 10_000_000, // very permissive
+      'tool-output-truncate-mode': 'truncate',
+      'tool-output-item-size-limit': 5 * 1024 * 1024, // allow each file individually
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+
+    // The total content must be bounded — 20 MiB of data should NOT all
+    // appear. The aggregate byte budget (several MiB) must trigger.
+    expect(text.length).toBeLessThan(20 * 1024 * 1024);
+    // Should indicate the result was bounded.
+    expect(text).toMatch(/truncat|byte budget|exceeded|skipped|limited/i);
+  });
+
+  it('preserves per-file size gate (oversized files are skipped)', async () => {
+    // A 6 MiB file exceeds the default per-file size limit (512 KB).
+    const oversized = 'B'.repeat(6 * 1024 * 1024);
+    writeFileSync(join(tempDir, 'big.txt'), oversized, 'utf-8');
+    writeFileSync(join(tempDir, 'small.txt'), 'small content\n', 'utf-8');
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1_000_000,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+    const display = result.returnDisplay as string;
+
+    // Small file is present; big file content is absent from llmContent.
+    expect(text).toContain('small.txt');
+    expect(text).toContain('small content');
+    expect(text).not.toContain('big.txt');
+    // The oversized file is reported as skipped in the display message.
+    expect(display).toMatch(/big\.txt|exceeds|skipped|file size/i);
+  });
+
+  it('handles many tiny files within bounded memory', async () => {
+    for (let i = 0; i < 40; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), `line ${i}\n`, 'utf-8');
+    }
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 50000,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    expect(result.error).toBeUndefined();
+    const text = stringifyLlmContent(result);
+    // All 40 files under the limit should be read.
+    expect(text).toContain('f0.txt');
+    expect(text).toContain('f39.txt');
+    expect(text).toContain('line 0');
+    expect(text).toContain('line 39');
+  });
+});
+
+describe('ReadManyFiles discovery counts ignored and duplicate records (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('counts git-ignored files in discovery and reports them as skipped', async () => {
+    execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git config user.email test@test.com', {
+      cwd: tempDir,
+      stdio: 'ignore',
+    });
+    execSync('git config user.name Test', { cwd: tempDir, stdio: 'ignore' });
+    writeFileSync(join(tempDir, '.gitignore'), '*.log\n');
+    writeFileSync(join(tempDir, 'readme.txt'), 'hello world\n');
+    writeFileSync(join(tempDir, 'debug.log'), 'log entry\n');
+    writeFileSync(join(tempDir, 'error.log'), 'error entry\n');
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1_000_000,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*'], exclude: ['.git/**'], useDefaultExcludes: false },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+    const display = result.returnDisplay as string;
+
+    // The .txt file is read; .log files are skipped as git-ignored.
+    expect(text).toContain('readme.txt');
+    expect(text).not.toContain('debug.log');
+    expect(text).not.toContain('error.log');
+    // Display must report the ignored count.
+    expect(display).toMatch(/git ignored/i);
+  });
+
+  it('deduplicates files discovered by overlapping glob patterns', async () => {
+    for (let i = 0; i < 5; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), `content ${i}\n`, 'utf-8');
+    }
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1_000_000,
+    });
+    const tool = new ReadManyFilesTool(host);
+    // Two overlapping patterns that match the same files.
+    const result = await tool.execute(
+      { paths: ['**/*.txt', 'f*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+
+    // Each file should appear exactly once despite overlapping patterns.
+    for (let i = 0; i < 5; i++) {
+      const occurrences = (text.match(new RegExp(`f${i}\\.txt`, 'g')) ?? [])
+        .length;
+      expect(occurrences).toBe(1);
+    }
+  });
+
+  describe('ReadManyFiles security-skipped discovery metadata (issue #3202)', () => {
+    let tempDir: string;
+    let cleanup: () => void;
+
+    beforeEach(() => {
+      const tmp = createTempDir('llxprt-rmf-security-');
+      tempDir = tmp.dir;
+      cleanup = tmp.cleanup;
+    });
+
+    afterEach(() => {
+      cleanup();
+    });
+
+    it('retains path/reason metadata for security-skipped records', async () => {
+      const outsideDir = mkdtempSync(join(tmpdir(), 'llxprt-rmf-outside-'));
+      try {
+        writeFileSync(join(outsideDir, 'secret.txt'), 'TOP SECRET\n', 'utf-8');
+        // A symlink inside the workspace pointing outside the workspace root
+        // will fail validatePathWithinWorkspace during discovery.
+        symlinkSync(join(outsideDir, 'secret.txt'), join(tempDir, 'link.txt'));
+        // A normal in-workspace file for contrast.
+        writeFileSync(join(tempDir, 'safe.txt'), 'safe content\n', 'utf-8');
+
+        const host = createHostWithSettings(tempDir, {
+          'tool-output-max-items': 50,
+          'tool-output-max-tokens': 1_000_000,
+        });
+        const tool = new ReadManyFilesTool(host);
+        const result = await tool.execute(
+          { paths: ['**/*.txt'] },
+          new AbortController().signal,
+        );
+        const text = stringifyLlmContent(result);
+        const display = result.returnDisplay as string;
+
+        // The safe file is read.
+        expect(text).toContain('safe.txt');
+        expect(text).toContain('safe content');
+        // The security-skipped symlink content must NOT appear.
+        expect(text).not.toContain('TOP SECRET');
+        // The display message must report the security skip with the path.
+        expect(display).toMatch(/link\.txt/i);
+        expect(display).toMatch(/security|workspace/i);
+      } finally {
+        rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+describe('ReadManyFiles UTF-8-safe byte-budget truncation (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir('llxprt-rmf-utf8-trunc-');
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('truncates multibyte content without splitting a character and includes marker + terminator', async () => {
+    // Multibyte content sized to exceed the 4 MiB aggregate byte budget
+    // while staying within per-file line-length (2000 chars) and line-count
+    // (2000 lines) limits, so the AGGREGATE budget is what truncates.
+    // Each '世' (U+4E16) is 3 UTF-8 bytes: 1000 lines x 1999 chars x 3
+    // bytes ≈ 5.7 MiB > 4 MiB budget.
+    const line = '世'.repeat(1999);
+    const content = Array.from({ length: 1000 }, () => line).join('\n');
+    writeFileSync(join(tempDir, 'f0.txt'), content, 'utf-8');
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 100_000_000,
+      'tool-output-truncate-mode': 'truncate',
+      'tool-output-item-size-limit': 10 * 1024 * 1024,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+    const display = result.returnDisplay as string;
+
+    // The truncation marker is present.
+    expect(text).toContain('[CONTENT TRUNCATED DUE TO AGGREGATE BYTE BUDGET]');
+    // The output terminator is present.
+    expect(text).toContain('--- End of content ---');
+    // No replacement character from a split multibyte sequence.
+    expect(text).not.toContain('\uFFFD');
+    // The total output is bounded within a reasonable margin of the budget.
+    expect(Buffer.byteLength(text, 'utf8')).toBeLessThan(5 * 1024 * 1024);
+    // Display acknowledges the truncation and includes the retained token count.
+    expect(display).toMatch(/truncat|byte budget/i);
+    expect(display).toContain('approximately');
+  });
+
+  it('preserves exact multibyte content when it fits within the byte budget', async () => {
+    // Small multibyte content well within the 4 MiB budget.
+    const content = '世界\nこんにちは\n'.repeat(1000);
+    writeFileSync(join(tempDir, 'fit.txt'), content, 'utf-8');
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1_000_000,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+
+    // Content must be complete, not truncated.
+    expect(text).not.toMatch(/TRUNCATED/i);
+    expect(text).toContain('世界');
+    expect(text).toContain('こんにちは');
+  });
+});
+
+describe('ReadManyFiles content/terminator budget correctness (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir('llxprt-rmf-terminator-');
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('final complete output including terminator does not exceed aggregate byte budget', async () => {
+    // Content that exceeds the 4 MiB aggregate byte budget so truncation
+    // triggers.
+    const line = 'A'.repeat(2000);
+    const content = Array.from({ length: 2200 }, () => line).join('\n');
+    writeFileSync(join(tempDir, 'f0.txt'), content, 'utf-8');
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 100_000_000,
+      'tool-output-truncate-mode': 'truncate',
+      'tool-output-item-size-limit': 10 * 1024 * 1024,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+
+    // The terminator must be present (proves the output is complete).
+    expect(text).toContain('--- End of content ---');
+    // The complete assembled output must not exceed the aggregate byte budget.
+    // The default budget is 4 MiB (4 * 1024 * 1024 = 4194304).
+    expect(Buffer.byteLength(text, 'utf8')).toBeLessThanOrEqual(
+      4 * 1024 * 1024,
+    );
+  });
+
+  it('token truncation does not split surrogate pairs', async () => {
+    // Content with surrogate pairs (emoji) that exceeds the token limit but
+    // NOT the byte budget, so token overflow triggers. Multi-line content so
+    // each line stays under the 2000-char file-read line cap; the 'x' prefix
+    // shifts emoji alignment so a naive char-based cut could split a pair.
+    const lines: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      lines.push('x' + '😀'.repeat(999)); // 1999 UTF-16 chars per line
+    }
+    writeFileSync(join(tempDir, 'f0.txt'), lines.join('\n'), 'utf-8');
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      // Small token limit to trigger token overflow (content has ~8000 chars
+      // > 1000 tokens at 4 chars/token).
+      'tool-output-max-tokens': 1000,
+      'tool-output-truncate-mode': 'truncate',
+      'tool-output-item-size-limit': 10 * 1024 * 1024,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+
+    // Token truncation must have triggered.
+    expect(text).toContain('[CONTENT TRUNCATED DUE TO TOKEN LIMIT]');
+    // No replacement character from a split surrogate pair.
+    expect(text).not.toContain('\uFFFD');
+    // The terminator must be present.
+    expect(text).toContain('--- End of content ---');
+  });
+
+  it('token truncation with multibyte content charges actual UTF-8 bytes', async () => {
+    // Multibyte BMP content that exceeds token limit but not byte budget.
+    // Each '世' (U+4E16) is 1 UTF-16 code unit but 3 UTF-8 bytes. Multi-line
+    // content so each line stays under the 2000-char file-read line cap.
+    const lines: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      lines.push('世'.repeat(1900));
+    }
+    writeFileSync(join(tempDir, 'f0.txt'), lines.join('\n'), 'utf-8');
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1000,
+      'tool-output-truncate-mode': 'truncate',
+      'tool-output-item-size-limit': 10 * 1024 * 1024,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+
+    // Token truncation must have triggered.
+    expect(text).toContain('[CONTENT TRUNCATED DUE TO TOKEN LIMIT]');
+    // No replacement character from a split multibyte sequence.
+    expect(text).not.toContain('\uFFFD');
+    // The output (including terminator) must not exceed the byte budget.
+    expect(Buffer.byteLength(text, 'utf8')).toBeLessThanOrEqual(
+      4 * 1024 * 1024,
+    );
+  });
+
+  it('exact-fit content with terminator stays within budget', async () => {
+    // Content that exactly fills the byte budget when accounting for the
+    // separator, trailing newlines, and the pre-charged terminator. Multi-line
+    // ASCII content so each line stays under the 2000-char file-read line cap.
+    const filePath = join(tempDir, 'f0.txt');
+    const prefix = `--- ${filePath} ---\n\n`;
+    const suffix = '\n\n';
+    const terminator = '\n--- End of content ---';
+    const prefixBytes = Buffer.byteLength(prefix, 'utf8');
+    const suffixBytes = Buffer.byteLength(suffix, 'utf8');
+    const terminatorBytes = Buffer.byteLength(terminator, 'utf8');
+    const budget = 4 * 1024 * 1024;
+    const targetContentBytes =
+      budget - prefixBytes - suffixBytes - terminatorBytes - 1; // -1: file-read adds a trailing \n
+    // Build multi-line ASCII content of exactly targetContentBytes bytes.
+    const lineLen = 1900;
+    const lineCount = Math.max(
+      1,
+      Math.ceil((targetContentBytes + 1) / (lineLen + 1)),
+    );
+    const lastLen = targetContentBytes - (lineCount - 1) * (lineLen + 1);
+    const lines: string[] = [];
+    for (let i = 0; i < lineCount - 1; i++) lines.push('A'.repeat(lineLen));
+    lines.push('A'.repeat(lastLen));
+    writeFileSync(join(tempDir, 'f0.txt'), lines.join('\n'), 'utf-8');
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 100_000_000,
+      'tool-output-item-size-limit': 10 * 1024 * 1024,
+      'file-read-max-lines': lineCount + 100,
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+
+    // Content must NOT be truncated — it fits exactly.
+    expect(text).not.toMatch(/TRUNCATED/i);
+    // Terminator is present.
+    expect(text).toContain('--- End of content ---');
+    // The total output is at most the budget.
+    expect(Buffer.byteLength(text, 'utf8')).toBeLessThanOrEqual(budget);
+  });
+});
+
+describe('ReadManyFiles discovery records are bounded before filtering/dedup (issue #3202 coordinator)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir('llxprt-rmf-records-');
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('ignored no-match discovery records consume the record cap and trigger partiality', async () => {
+    execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git config user.email test@test.com', {
+      cwd: tempDir,
+      stdio: 'ignore',
+    });
+    execSync('git config user.name Test', { cwd: tempDir, stdio: 'ignore' });
+    writeFileSync(join(tempDir, '.gitignore'), 'ignored/**\n');
+    // 55 git-ignored records + 3 accepted records + .gitignore itself = 59
+    // raw glob emissions — far above the 50-record cap, even though at most
+    // 4 unique accepted paths could ever be retained.
+    mkdirSync(join(tempDir, 'ignored'), { recursive: true });
+    for (let i = 0; i < 55; i++) {
+      writeFileSync(
+        join(tempDir, 'ignored', `i${i}.txt`),
+        `ignored ${i}\n`,
+        'utf-8',
+      );
+    }
+    for (let i = 0; i < 3; i++) {
+      writeFileSync(join(tempDir, `a${i}.txt`), `accepted ${i}\n`, 'utf-8');
+    }
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1_000_000,
+      'tool-output-truncate-mode': 'truncate',
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*'], exclude: ['.git/**'], useDefaultExcludes: false },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+    const display = result.returnDisplay as string;
+
+    // Discovery stopped at the record cap: the (cap+1)-th raw record proved
+    // partiality even though accepted unique paths are far below the cap.
+    expect(display).toMatch(/discovery stopped at 51 discovery record/i);
+    // Ignored records within the budget are still reported (compressed count).
+    expect(display).toMatch(/git ignored/i);
+    // Only accepted unique paths within the record budget can be read; the
+    // ignored records' content must never appear in the output.
+    const readCount = (text.match(/accepted \d+/g) ?? []).length;
+    expect(readCount).toBeLessThanOrEqual(3);
+    expect(text).not.toContain('ignored 54');
+  });
+
+  it('duplicate records across repeated workspace roots consume the shared record cap (deduplicated output)', async () => {
+    for (let i = 0; i < 30; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), `unique ${i}\n`, 'utf-8');
+    }
+
+    const baseHost = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1_000_000,
+      'tool-output-truncate-mode': 'truncate',
+    });
+    // The same workspace root listed twice: the second pass re-emits every
+    // path as a fresh discovery record, consuming the shared invocation cap
+    // even though the accepted path set is fully deduplicated.
+    const host = { ...baseHost, getWorkspaceRoots: () => [tempDir, tempDir] };
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+    const display = result.returnDisplay as string;
+
+    // All 30 unique files are retained and deduplicated in the output...
+    const readCount = (text.match(/unique \d+/g) ?? []).length;
+    expect(readCount).toBe(30);
+    // ...yet the shared record cap (50) was exceeded by the duplicate
+    // emissions from the repeated root: 30 + 20 = 50 stored, the 51st raw
+    // emission proves one-over partiality even though accepted output paths
+    // remain deduplicated.
+    expect(display).toMatch(/discovery stopped at 51 discovery record/i);
+  });
+
+  it('preserves 60-unique/cap-50 behavior: retain exactly 50 and report partial', async () => {
+    for (let i = 0; i < 60; i++) {
+      writeFileSync(join(tempDir, `f${i}.txt`), `content ${i}\n`, 'utf-8');
+    }
+
+    const host = createHostWithSettings(tempDir, {
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 1_000_000,
+      'tool-output-truncate-mode': 'truncate',
+    });
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+    const display = result.returnDisplay as string;
+
+    // Exactly 50 files retained from 60; the 51st raw record proved partiality.
+    const fileCount = (text.match(/--- \S+[\\/]f\d+\.txt ---/g) ?? []).length;
+    expect(fileCount).toBe(50);
+    expect(display).toMatch(/discovery stopped at 51 discovery record/i);
+  });
+});
+
+describe('read-many-files warn-mode discovery truncation (issue #3202)', () => {
+  let tempDir: { dir: string; cleanup: () => void };
+
+  beforeEach(() => {
+    tempDir = createTempDir('llxprt-rmf-warn-trunc-');
+  });
+
+  afterEach(() => tempDir.cleanup());
+
+  it('warn mode reads retained files when discovery truncated but unique files are within cap', async () => {
+    // 10 unique files; a repeated workspace root (3x) produces 30 discovery
+    // records — exceeding the 20-record cap — but only 10 unique files are
+    // retained, which is within the 20-file cap. Warn mode must NOT return
+    // an empty "File Count Limit Exceeded" result.
+    for (let i = 0; i < 10; i++) {
+      writeFileSync(join(tempDir.dir, `u${i}.txt`), `unique ${i}\n`, 'utf-8');
+    }
+
+    const baseHost = createHostWithSettings(tempDir.dir, {
+      'tool-output-max-items': 20,
+      'tool-output-max-tokens': 1_000_000,
+      'tool-output-truncate-mode': 'warn',
+    });
+    const host = {
+      ...baseHost,
+      getWorkspaceRoots: () => [tempDir.dir, tempDir.dir, tempDir.dir],
+    };
+    const tool = new ReadManyFilesTool(host);
+    const result = await tool.execute(
+      { paths: ['**/*.txt'] },
+      new AbortController().signal,
+    );
+    const text = stringifyLlmContent(result);
+    const display = result.returnDisplay as string;
+
+    // All 10 unique files must be read — NOT an empty "limit exceeded" result.
+    expect(text).not.toContain('File Count Limit Exceeded');
+    const readCount = (text.match(/unique \d+/g) ?? []).length;
+    expect(readCount).toBe(10);
+    // Discovery truncation should be reported truthfully.
+    expect(display).toMatch(/discovery stopped at \d+ discovery record/i);
+  });
+});

--- a/packages/tools/src/acquisition/bounded-http-response-lifecycle.test.ts
+++ b/packages/tools/src/acquisition/bounded-http-response-lifecycle.test.ts
@@ -4,15 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * Lifecycle tests for acquireBoundedHttpBody: cancellation, cancel-callback
+ * invocation, listener cleanup, abort registration edges, and premature-close
+ * settlement. Split from bounded-http-response.test.ts to keep each file under
+ * the source-size limit.
+ *
+ * @plan PLAN-20260810-ISSUE3202
+ */
+
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { Readable } from 'node:stream';
 import { describe, it, expect, afterEach } from 'bun:test';
 import fetch from 'node-fetch';
-import { createByteBudget } from '../acquisition/index.js';
+import { createByteBudget } from './index.js';
 import {
   acquireBoundedHttpBody,
-  disposeHttpResponseBody,
   HttpBodyTooLargeError,
   type BoundedFetchResponse,
 } from './bounded-http-response.js';
@@ -59,15 +67,6 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function fragmentPayload(payload: string, fragmentSize: number): Buffer[] {
-  const buf = Buffer.from(payload);
-  const fragments: Buffer[] = [];
-  for (let i = 0; i < buf.length; i += fragmentSize) {
-    fragments.push(buf.subarray(i, i + fragmentSize));
-  }
-  return fragments;
-}
-
 /** No-op cancel for tests that do not exercise cancellation behavior. */
 const noopCancel = (): void => {};
 
@@ -106,299 +105,6 @@ interface EventEmitterLike {
   listenerCount(event: string): number;
 }
 
-describe('acquireBoundedHttpBody — under-budget streaming', () => {
-  it('reads a real local chunked response under budget', async () => {
-    const payload = 'x'.repeat(512);
-    const server = await startServer((_req, res) => {
-      res.writeHead(200, { 'content-type': 'text/plain' });
-      res.end(payload);
-    });
-
-    const response = await fetch(serverUrl(server));
-    const body = await acquireBoundedHttpBody(
-      response,
-      createByteBudget(1024),
-      new AbortController().signal,
-      noopCancel,
-    );
-
-    expect(body.text).toBe(payload);
-    expect(body.metadata.observedBytes).toBe(512);
-    expect(body.metadata.truncated).toBe(false);
-  });
-
-  it('succeeds when fragmented chunks exactly equal the budget', async () => {
-    const payload = 'x'.repeat(1024);
-    const fragments = fragmentPayload(payload, 7);
-    const server = await startServer((_req, res) => {
-      res.writeHead(200, { 'content-type': 'text/plain' });
-      for (const frag of fragments) {
-        res.write(frag);
-      }
-      res.end();
-    });
-
-    const response = await fetch(serverUrl(server));
-    const body = await acquireBoundedHttpBody(
-      response,
-      createByteBudget(1024),
-      new AbortController().signal,
-      noopCancel,
-    );
-
-    expect(body.text).toBe(payload);
-    expect(body.metadata.observedBytes).toBe(1024);
-    expect(body.metadata.truncated).toBe(false);
-  });
-});
-
-describe('acquireBoundedHttpBody — overflow detection', () => {
-  it('fails when a missing-Content-Length response exceeds the budget and closes the body', async () => {
-    const payload = 'x'.repeat(2048);
-    const server = await startServer((_req, res) => {
-      res.writeHead(200, { 'content-type': 'text/plain' });
-      res.write(payload);
-      res.end();
-    });
-
-    const response = await fetch(serverUrl(server));
-    const budget = createByteBudget(1024);
-
-    await expect(
-      acquireBoundedHttpBody(
-        response,
-        budget,
-        new AbortController().signal,
-        noopCancel,
-      ),
-    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
-
-    expect(
-      (response.body as unknown as { destroyed: boolean } | null)?.destroyed,
-    ).toBe(true);
-  });
-
-  it('fails atomically when fragmented chunks are one byte over the budget and closes the body', async () => {
-    const payload = 'x'.repeat(1025);
-    const fragments = fragmentPayload(payload, 3);
-    const server = await startServer((_req, res) => {
-      res.writeHead(200, { 'content-type': 'text/plain' });
-      for (const frag of fragments) {
-        res.write(frag);
-      }
-      res.end();
-    });
-
-    const response = await fetch(serverUrl(server));
-
-    await expect(
-      acquireBoundedHttpBody(
-        response,
-        createByteBudget(1024),
-        new AbortController().signal,
-        noopCancel,
-      ),
-    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
-
-    expect(
-      (response.body as unknown as { destroyed: boolean } | null)?.destroyed,
-    ).toBe(true);
-  });
-
-  it('fails on observed bytes when Content-Length advertises less than the stream sends', async () => {
-    const fakeResponse: BoundedFetchResponse = {
-      body: Readable.from([Buffer.from('x'.repeat(2048))]),
-      headers: {
-        get: (name: string) => (name === 'content-length' ? '512' : null),
-      },
-    };
-
-    await expect(
-      acquireBoundedHttpBody(
-        fakeResponse,
-        createByteBudget(1024),
-        new AbortController().signal,
-        noopCancel,
-      ),
-    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
-  });
-
-  it('rejects an over-limit Content-Length before iteration and closes the body', async () => {
-    const server = await startServer((_req, res) => {
-      res.writeHead(200, {
-        'content-type': 'text/plain',
-        'content-length': '999999',
-      });
-      res.end('x'.repeat(999999));
-    });
-
-    const response = await fetch(serverUrl(server));
-    const budget = createByteBudget(1024);
-
-    await expect(
-      acquireBoundedHttpBody(
-        response,
-        budget,
-        new AbortController().signal,
-        noopCancel,
-      ),
-    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
-
-    expect(
-      (response.body as unknown as { destroyed: boolean } | null)?.destroyed,
-    ).toBe(true);
-  });
-});
-
-describe('acquireBoundedHttpBody — strict Content-Length parsing', () => {
-  it('treats a malformed over-limit-looking Content-Length as absent and succeeds with a bounded body', async () => {
-    const payload = 'x'.repeat(512);
-    const fakeResponse: BoundedFetchResponse = {
-      body: Readable.from([Buffer.from(payload)]),
-      headers: {
-        get: (name: string) =>
-          name === 'content-length' ? '9999999999;foo' : null,
-      },
-    };
-
-    const body = await acquireBoundedHttpBody(
-      fakeResponse,
-      createByteBudget(1024),
-      new AbortController().signal,
-      noopCancel,
-    );
-
-    expect(body.text).toBe(payload);
-    expect(body.metadata.observedBytes).toBe(512);
-  });
-
-  it('treats a malformed understated-looking Content-Length as absent but fails when observed bytes exceed budget', async () => {
-    const payload = 'x'.repeat(2048);
-    const fakeResponse: BoundedFetchResponse = {
-      body: Readable.from([Buffer.from(payload)]),
-      headers: {
-        get: (name: string) => (name === 'content-length' ? 'abc' : null),
-      },
-    };
-
-    await expect(
-      acquireBoundedHttpBody(
-        fakeResponse,
-        createByteBudget(1024),
-        new AbortController().signal,
-        noopCancel,
-      ),
-    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
-  });
-
-  it('rejects an unsafe (non-safe-integer) Content-Length as absent and streams observed bytes', async () => {
-    const payload = 'x'.repeat(256);
-    const fakeResponse: BoundedFetchResponse = {
-      body: Readable.from([Buffer.from(payload)]),
-      headers: {
-        get: (name: string) =>
-          name === 'content-length' ? '99999999999999999999999' : null,
-      },
-    };
-
-    const body = await acquireBoundedHttpBody(
-      fakeResponse,
-      createByteBudget(1024),
-      new AbortController().signal,
-      noopCancel,
-    );
-
-    expect(body.text).toBe(payload);
-    expect(body.metadata.observedBytes).toBe(256);
-  });
-});
-
-describe('acquireBoundedHttpBody — exact byte boundary', () => {
-  it('succeeds when body bytes exactly equal the budget', async () => {
-    const server = await startServer((_req, res) => {
-      res.writeHead(200, { 'content-type': 'text/plain' });
-      res.end('x'.repeat(1024));
-    });
-
-    const response = await fetch(serverUrl(server));
-    const body = await acquireBoundedHttpBody(
-      response,
-      createByteBudget(1024),
-      new AbortController().signal,
-      noopCancel,
-    );
-
-    expect(body.metadata.observedBytes).toBe(1024);
-    expect(body.text).toBe('x'.repeat(1024));
-  });
-
-  it('fails when body is one byte over the budget', async () => {
-    const server = await startServer((_req, res) => {
-      res.writeHead(200, { 'content-type': 'text/plain' });
-      res.write('x'.repeat(1025));
-      res.end();
-    });
-
-    const response = await fetch(serverUrl(server));
-
-    await expect(
-      acquireBoundedHttpBody(
-        response,
-        createByteBudget(1024),
-        new AbortController().signal,
-        noopCancel,
-      ),
-    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
-  });
-
-  it('counts UTF-8 bytes, not JavaScript characters, for the boundary', async () => {
-    // "é" is 1 character but 2 UTF-8 bytes. 512 × "é" = 1024 bytes = budget.
-    const payload = 'é'.repeat(512);
-    const server = await startServer((_req, res) => {
-      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-      res.write(payload);
-      res.end();
-    });
-
-    const response = await fetch(serverUrl(server));
-    const body = await acquireBoundedHttpBody(
-      response,
-      createByteBudget(1024),
-      new AbortController().signal,
-      noopCancel,
-    );
-
-    expect(body.text).toBe(payload);
-    expect(body.metadata.observedBytes).toBe(1024);
-  });
-
-  it('fails when a multibyte UTF-8 body is one byte over budget', async () => {
-    // 512 × "é" = 1024 bytes. Adding one ASCII byte → 1025 > 1024.
-    const server = await startServer((_req, res) => {
-      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
-      res.write('é'.repeat(512) + 'x');
-      res.end();
-    });
-
-    const response = await fetch(serverUrl(server));
-
-    await expect(
-      acquireBoundedHttpBody(
-        response,
-        createByteBudget(1024),
-        new AbortController().signal,
-        noopCancel,
-      ),
-    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
-  });
-});
-
-/**
- * Real-transport cancellation proof: a paced server writes chunks slowly so
- * the client has time to observe overflow mid-stream. The test uses installed
- * node-fetch with a per-request AbortController and proves the server sees
- * cancellation (connection close) before it can complete delivery.
- */
 describe('acquireBoundedHttpBody — real server-side cancellation', () => {
   function startPacedServer(options?: { contentLength?: number }): Promise<{
     server: http.Server;
@@ -621,6 +327,7 @@ describe('acquireBoundedHttpBody — cancel callback invocation', () => {
         'data',
         'end',
         'error',
+        'close',
       ),
     ).toBe(0);
   });
@@ -715,7 +422,9 @@ describe('acquireBoundedHttpBody — listener lifecycle', () => {
       noopCancel,
     );
 
-    expect(attachedListenerCount(body, 'data', 'end', 'error')).toBe(0);
+    expect(attachedListenerCount(body, 'data', 'end', 'error', 'close')).toBe(
+      0,
+    );
     expect(tracker.abortListenerCount).toBe(0);
   });
 
@@ -738,7 +447,9 @@ describe('acquireBoundedHttpBody — listener lifecycle', () => {
       ),
     ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
 
-    expect(attachedListenerCount(body, 'data', 'end', 'error')).toBe(0);
+    expect(attachedListenerCount(body, 'data', 'end', 'error', 'close')).toBe(
+      0,
+    );
     expect(tracker.abortListenerCount).toBe(0);
   });
 
@@ -775,7 +486,9 @@ describe('acquireBoundedHttpBody — listener lifecycle', () => {
     await expect(promise).rejects.toThrow(/abort/i);
     await writerDone;
 
-    expect(attachedListenerCount(body, 'data', 'end', 'error')).toBe(0);
+    expect(attachedListenerCount(body, 'data', 'end', 'error', 'close')).toBe(
+      0,
+    );
     expect(tracker.abortListenerCount).toBe(0);
   });
 
@@ -806,6 +519,7 @@ describe('acquireBoundedHttpBody — listener lifecycle', () => {
         'data',
         'end',
         'error',
+        'close',
       ),
     ).toBe(0);
     expect(tracker.abortListenerCount).toBe(0);
@@ -844,36 +558,124 @@ describe('acquireBoundedHttpBody — abort registration edge', () => {
         'data',
         'end',
         'error',
+        'close',
       ),
     ).toBe(0);
     expect(abortTracker.abortListenerCount).toBe(0);
   });
 });
 
-describe('disposeHttpResponseBody', () => {
-  it('cancels the request and destroys the response body without reading it', () => {
-    const stream = Readable.from([Buffer.from('error body')]);
+/**
+ * A body that closes without emitting 'end' must not leave the acquisition
+ * promise pending forever. The adapter must settle (reject) on the close
+ * event, distinguish premature close from a clean end, and never double-settle
+ * when 'error' or 'abort' precedes 'close'. These tests target that
+ * authoritative-settlement behavior (issue #3202).
+ */
+describe('acquireBoundedHttpBody — premature close settlement', () => {
+  it('rejects when the body closes without end (no prior error)', async () => {
+    const stream = new Readable({
+      read() {
+        this.push(Buffer.from('partial-body'));
+        // Destroy without an error: emits 'close' but NOT 'end'.
+        this.destroy();
+      },
+    });
     const fakeResponse: BoundedFetchResponse = {
       body: stream,
       headers: { get: () => null },
     };
     const tracker = createTrackingCancel();
 
-    disposeHttpResponseBody(fakeResponse, tracker.cancel);
+    await expect(
+      acquireBoundedHttpBody(
+        fakeResponse,
+        createByteBudget(1024),
+        new AbortController().signal,
+        tracker.cancel,
+      ),
+    ).rejects.toThrow(/closed|premature|incomplete/i);
 
-    expect((stream as unknown as { destroyed: boolean }).destroyed).toBe(true);
+    // Premature close cancels the request and cleans up all listeners.
     expect(tracker.called).toBe(true);
+    expect(
+      attachedListenerCount(
+        stream as NodeJS.ReadableStream,
+        'data',
+        'end',
+        'error',
+        'close',
+      ),
+    ).toBe(0);
   });
 
-  it('is a no-op on body when body is null but still invokes cancelRequest', () => {
+  it('settles once with the read error when the stream errors then closes', async () => {
+    const stream = new Readable({
+      read() {
+        this.destroy(new Error('socket reset'));
+      },
+    });
     const fakeResponse: BoundedFetchResponse = {
-      body: null,
+      body: stream,
       headers: { get: () => null },
     };
     const tracker = createTrackingCancel();
-    expect(() =>
-      disposeHttpResponseBody(fakeResponse, tracker.cancel),
-    ).not.toThrow();
+
+    await expect(
+      acquireBoundedHttpBody(
+        fakeResponse,
+        createByteBudget(1024),
+        new AbortController().signal,
+        tracker.cancel,
+      ),
+    ).rejects.toThrow('socket reset');
+
+    // The 'close' that follows 'error' must not mutate the settlement.
     expect(tracker.called).toBe(true);
+    expect(
+      attachedListenerCount(
+        stream as NodeJS.ReadableStream,
+        'data',
+        'end',
+        'error',
+        'close',
+      ),
+    ).toBe(0);
+  });
+
+  it('settles once on abort then close and cleans up listeners', async () => {
+    const stream = new Readable({
+      read() {
+        this.push(Buffer.from('x'.repeat(64)));
+      },
+    });
+    const fakeResponse: BoundedFetchResponse = {
+      body: stream,
+      headers: { get: () => null },
+    };
+    const controller = new AbortController();
+    const tracker = createTrackingCancel();
+
+    const promise = acquireBoundedHttpBody(
+      fakeResponse,
+      createByteBudget(10 * 1024 * 1024),
+      controller.signal,
+      tracker.cancel,
+    );
+    controller.abort();
+
+    await expect(promise).rejects.toThrow(/abort/i);
+    expect(tracker.called).toBe(true);
+    // The adapter destroys the body on abort; the trailing 'close' must not
+    // double-settle. No listeners remain.
+    expect(
+      attachedListenerCount(
+        stream as NodeJS.ReadableStream,
+        'data',
+        'end',
+        'error',
+        'close',
+      ),
+    ).toBe(0);
   });
 });

--- a/packages/tools/src/acquisition/bounded-http-response.test.ts
+++ b/packages/tools/src/acquisition/bounded-http-response.test.ts
@@ -1,0 +1,387 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Readable } from 'node:stream';
+import { describe, it, expect, afterEach } from 'bun:test';
+import fetch from 'node-fetch';
+import { createByteBudget } from './index.js';
+import {
+  acquireBoundedHttpBody,
+  disposeHttpResponseBody,
+  HttpBodyTooLargeError,
+  type BoundedFetchResponse,
+} from './bounded-http-response.js';
+
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    const server = servers.pop()!;
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+function startServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<http.Server> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      servers.push(server);
+      resolve(server);
+    });
+  });
+}
+
+function serverUrl(server: http.Server): string {
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}/`;
+}
+
+function fragmentPayload(payload: string, fragmentSize: number): Buffer[] {
+  const buf = Buffer.from(payload);
+  const fragments: Buffer[] = [];
+  for (let i = 0; i < buf.length; i += fragmentSize) {
+    fragments.push(buf.subarray(i, i + fragmentSize));
+  }
+  return fragments;
+}
+
+/** No-op cancel for tests that do not exercise cancellation behavior. */
+const noopCancel = (): void => {};
+
+/**
+ * Creates a cancel callback that records whether it was invoked.
+ */
+function createTrackingCancel(): { cancel: () => void; called: boolean } {
+  let called = false;
+  return {
+    cancel: () => {
+      called = true;
+    },
+    get called() {
+      return called;
+    },
+  };
+}
+
+describe('acquireBoundedHttpBody — under-budget streaming', () => {
+  it('reads a real local chunked response under budget', async () => {
+    const payload = 'x'.repeat(512);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(payload);
+    });
+
+    const response = await fetch(serverUrl(server));
+    const body = await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(512);
+    expect(body.metadata.truncated).toBe(false);
+  });
+
+  it('succeeds when fragmented chunks exactly equal the budget', async () => {
+    const payload = 'x'.repeat(1024);
+    const fragments = fragmentPayload(payload, 7);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      for (const frag of fragments) {
+        res.write(frag);
+      }
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+    const body = await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(1024);
+    expect(body.metadata.truncated).toBe(false);
+  });
+});
+
+describe('acquireBoundedHttpBody — overflow detection', () => {
+  it('fails when a missing-Content-Length response exceeds the budget and closes the body', async () => {
+    const payload = 'x'.repeat(2048);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.write(payload);
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+    const budget = createByteBudget(1024);
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        budget,
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+
+    expect(
+      (response.body as unknown as { destroyed: boolean } | null)?.destroyed,
+    ).toBe(true);
+  });
+
+  it('fails atomically when fragmented chunks are one byte over the budget and closes the body', async () => {
+    const payload = 'x'.repeat(1025);
+    const fragments = fragmentPayload(payload, 3);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      for (const frag of fragments) {
+        res.write(frag);
+      }
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+
+    expect(
+      (response.body as unknown as { destroyed: boolean } | null)?.destroyed,
+    ).toBe(true);
+  });
+
+  it('fails on observed bytes when Content-Length advertises less than the stream sends', async () => {
+    const fakeResponse: BoundedFetchResponse = {
+      body: Readable.from([Buffer.from('x'.repeat(2048))]),
+      headers: {
+        get: (name: string) => (name === 'content-length' ? '512' : null),
+      },
+    };
+
+    await expect(
+      acquireBoundedHttpBody(
+        fakeResponse,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+  });
+
+  it('rejects an over-limit Content-Length before iteration and closes the body', async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, {
+        'content-type': 'text/plain',
+        'content-length': '999999',
+      });
+      res.end('x'.repeat(999999));
+    });
+
+    const response = await fetch(serverUrl(server));
+    const budget = createByteBudget(1024);
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        budget,
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+
+    expect(
+      (response.body as unknown as { destroyed: boolean } | null)?.destroyed,
+    ).toBe(true);
+  });
+});
+
+describe('acquireBoundedHttpBody — strict Content-Length parsing', () => {
+  it('treats a malformed over-limit-looking Content-Length as absent and succeeds with a bounded body', async () => {
+    const payload = 'x'.repeat(512);
+    const fakeResponse: BoundedFetchResponse = {
+      body: Readable.from([Buffer.from(payload)]),
+      headers: {
+        get: (name: string) =>
+          name === 'content-length' ? '9999999999;foo' : null,
+      },
+    };
+
+    const body = await acquireBoundedHttpBody(
+      fakeResponse,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(512);
+  });
+
+  it('treats a malformed understated-looking Content-Length as absent but fails when observed bytes exceed budget', async () => {
+    const payload = 'x'.repeat(2048);
+    const fakeResponse: BoundedFetchResponse = {
+      body: Readable.from([Buffer.from(payload)]),
+      headers: {
+        get: (name: string) => (name === 'content-length' ? 'abc' : null),
+      },
+    };
+
+    await expect(
+      acquireBoundedHttpBody(
+        fakeResponse,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+  });
+
+  it('rejects an unsafe (non-safe-integer) Content-Length as absent and streams observed bytes', async () => {
+    const payload = 'x'.repeat(256);
+    const fakeResponse: BoundedFetchResponse = {
+      body: Readable.from([Buffer.from(payload)]),
+      headers: {
+        get: (name: string) =>
+          name === 'content-length' ? '99999999999999999999999' : null,
+      },
+    };
+
+    const body = await acquireBoundedHttpBody(
+      fakeResponse,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(256);
+  });
+});
+
+describe('acquireBoundedHttpBody — exact byte boundary', () => {
+  it('succeeds when body bytes exactly equal the budget', async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('x'.repeat(1024));
+    });
+
+    const response = await fetch(serverUrl(server));
+    const body = await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.metadata.observedBytes).toBe(1024);
+    expect(body.text).toBe('x'.repeat(1024));
+  });
+
+  it('fails when body is one byte over the budget', async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.write('x'.repeat(1025));
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+  });
+
+  it('counts UTF-8 bytes, not JavaScript characters, for the boundary', async () => {
+    // "é" is 1 character but 2 UTF-8 bytes. 512 × "é" = 1024 bytes = budget.
+    const payload = 'é'.repeat(512);
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+      res.write(payload);
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+    const body = await acquireBoundedHttpBody(
+      response,
+      createByteBudget(1024),
+      new AbortController().signal,
+      noopCancel,
+    );
+
+    expect(body.text).toBe(payload);
+    expect(body.metadata.observedBytes).toBe(1024);
+  });
+
+  it('fails when a multibyte UTF-8 body is one byte over budget', async () => {
+    // 512 × "é" = 1024 bytes. Adding one ASCII byte → 1025 > 1024.
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+      res.write('é'.repeat(512) + 'x');
+      res.end();
+    });
+
+    const response = await fetch(serverUrl(server));
+
+    await expect(
+      acquireBoundedHttpBody(
+        response,
+        createByteBudget(1024),
+        new AbortController().signal,
+        noopCancel,
+      ),
+    ).rejects.toBeInstanceOf(HttpBodyTooLargeError);
+  });
+});
+
+describe('disposeHttpResponseBody', () => {
+  it('cancels the request and destroys the response body without reading it', () => {
+    const stream = Readable.from([Buffer.from('error body')]);
+    const fakeResponse: BoundedFetchResponse = {
+      body: stream,
+      headers: { get: () => null },
+    };
+    const tracker = createTrackingCancel();
+
+    disposeHttpResponseBody(fakeResponse, tracker.cancel);
+
+    expect((stream as unknown as { destroyed: boolean }).destroyed).toBe(true);
+    expect(tracker.called).toBe(true);
+  });
+
+  it('is a no-op on body when body is null but still invokes cancelRequest', () => {
+    const fakeResponse: BoundedFetchResponse = {
+      body: null,
+      headers: { get: () => null },
+    };
+    const tracker = createTrackingCancel();
+    expect(() =>
+      disposeHttpResponseBody(fakeResponse, tracker.cancel),
+    ).not.toThrow();
+    expect(tracker.called).toBe(true);
+  });
+});

--- a/packages/tools/src/acquisition/bounded-http-response.ts
+++ b/packages/tools/src/acquisition/bounded-http-response.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ByteBudget, TruncationMetadata } from '../acquisition/index.js';
-import { BoundedStreamCollector } from '../acquisition/index.js';
+import type { ByteBudget, TruncationMetadata } from './types.js';
+import { BoundedStreamCollector } from './boundedStreamCollector.js';
 
 /** Minimal structural interface satisfied by a node-fetch Response. */
 export interface BoundedFetchResponse {
@@ -111,6 +111,7 @@ function streamBoundedBody(
       body.removeListener('data', onData);
       body.removeListener('end', onEnd);
       body.removeListener('error', onError);
+      body.removeListener('close', onClose);
       signal.removeEventListener('abort', onAbort);
     };
 
@@ -148,6 +149,20 @@ function streamBoundedBody(
       });
     };
 
+    /**
+     * 'close' without a prior 'end' means the body terminated prematurely —
+     * the complete bounded body cannot be known, so acquisition settles by
+     * rejecting. When 'end', 'error', or 'abort' settled first, this is a
+     * guarded no-op (single authoritative settlement).
+     */
+    const onClose = (): void => {
+      settle(() => {
+        cancelRequest();
+        destroyStream(body);
+        reject(new Error('Response body closed before end (incomplete body)'));
+      });
+    };
+
     const onAbort = (): void => {
       settle(() => {
         cancelRequest();
@@ -158,6 +173,7 @@ function streamBoundedBody(
 
     body.on('error', onError);
     body.on('end', onEnd);
+    body.on('close', onClose);
     body.on('data', onData);
     signal.addEventListener('abort', onAbort, { once: true });
 

--- a/packages/tools/src/acquisition/boundedStreamCollector.test.ts
+++ b/packages/tools/src/acquisition/boundedStreamCollector.test.ts
@@ -9,8 +9,6 @@ import {
   BoundedStreamCollector,
   createByteBudget,
   ACQUISITION_HARD_MAX_BYTES,
-  resolveByteBudgetFromSetting,
-  DEFAULT_ACQUISITION_BUDGET_BYTES,
 } from './index.js';
 
 describe('ByteBudget', () => {
@@ -117,55 +115,6 @@ describe('ByteBudget - absolute hard-max invariants (issue #3200 finding 10)', (
       (budget as { bytes: number }).bytes = 999;
     }).toThrow('Attempted to assign to readonly property.');
     expect(budget.bytes).toBe(8192);
-  });
-
-  it('resolveByteBudgetFromSetting respects the absolute ceiling even with a custom hardMax', () => {
-    const budget = resolveByteBudgetFromSetting(-1, 999 * 1024 * 1024);
-    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
-  });
-
-  it('normalizes an invalid custom hard max before resolving -1', () => {
-    const budget = resolveByteBudgetFromSetting(-1, Infinity);
-    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
-  });
-
-  it('resolveByteBudgetFromSetting falls back to default for undefined', () => {
-    const budget = resolveByteBudgetFromSetting(undefined);
-    expect(budget.bytes).toBe(DEFAULT_ACQUISITION_BUDGET_BYTES);
-  });
-
-  it('resolveByteBudgetFromSetting falls back to default for invalid string', () => {
-    const budget = resolveByteBudgetFromSetting('not-a-number');
-    expect(budget.bytes).toBe(DEFAULT_ACQUISITION_BUDGET_BYTES);
-  });
-
-  it('resolveByteBudgetFromSetting falls back to default for nonnumeric disabled values', () => {
-    expect(resolveByteBudgetFromSetting(false).bytes).toBe(
-      DEFAULT_ACQUISITION_BUDGET_BYTES,
-    );
-    expect(resolveByteBudgetFromSetting('').bytes).toBe(
-      DEFAULT_ACQUISITION_BUDGET_BYTES,
-    );
-  });
-
-  it('resolveByteBudgetFromSetting parses valid string', () => {
-    const budget = resolveByteBudgetFromSetting('8388608');
-    expect(budget.bytes).toBe(8388608);
-  });
-
-  it('resolveByteBudgetFromSetting uses hard max for -1 (disabled)', () => {
-    const budget = resolveByteBudgetFromSetting(-1);
-    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
-  });
-
-  it('resolveByteBudgetFromSetting accepts a serialized -1', () => {
-    const budget = resolveByteBudgetFromSetting('-1');
-    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
-  });
-
-  it('resolveByteBudgetFromSetting clamps above hard max', () => {
-    const budget = resolveByteBudgetFromSetting(999_999_999);
-    expect(budget.bytes).toBe(ACQUISITION_HARD_MAX_BYTES);
   });
 });
 

--- a/packages/tools/src/acquisition/byteBudget.ts
+++ b/packages/tools/src/acquisition/byteBudget.ts
@@ -25,7 +25,16 @@ export const DEFAULT_ACQUISITION_BUDGET_BYTES = 4 * 1024 * 1024; // 4 MiB
  */
 export const DEFAULT_HEAD_FRACTION = 0.5;
 
-function normalizeHardMax(hardMax: number): number {
+/**
+ * Normalize a hard-max ceiling to a finite, in-range value.
+ *
+ * Non-finite or non-positive values collapse to the absolute cap. The result
+ * is clamped to {@link ACQUISITION_MIN_BYTES}..{@link ACQUISITION_HARD_MAX_BYTES}.
+ *
+ * This is a budget primitive (not settings policy): it validates a numeric
+ * ceiling so callers never construct a budget outside the finite range.
+ */
+export function normalizeHardMax(hardMax: number): number {
   const requestedCeiling =
     Number.isFinite(hardMax) && hardMax > 0
       ? Math.floor(hardMax)
@@ -77,39 +86,4 @@ export function createByteBudget(
 /** Create a default {@link ByteBudget}. */
 export function createDefaultByteBudget(): ByteBudget {
   return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES);
-}
-
-/**
- * Resolve a raw setting value (from ephemeral settings / profile) into a
- * validated {@link ByteBudget}. Falls back to the default when the value is
- * absent, invalid, or disabled.
- *
- * This function does NOT read settings itself — it receives the raw value
- * and validates it, keeping the acquisition layer free of settings coupling.
- */
-export function resolveByteBudgetFromSetting(
-  rawValue: unknown,
-  hardMax: number = ACQUISITION_HARD_MAX_BYTES,
-): ByteBudget {
-  const effectiveHardMax = normalizeHardMax(hardMax);
-  if (rawValue === undefined || rawValue === null) {
-    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, effectiveHardMax);
-  }
-
-  const numeric = typeof rawValue === 'string' ? Number(rawValue) : rawValue;
-
-  // A configured -1 means "largest permitted value", never unbounded.
-  if (numeric === -1) {
-    return createByteBudget(effectiveHardMax, effectiveHardMax);
-  }
-
-  if (
-    typeof numeric !== 'number' ||
-    !Number.isFinite(numeric) ||
-    numeric <= 0
-  ) {
-    return createByteBudget(DEFAULT_ACQUISITION_BUDGET_BYTES, effectiveHardMax);
-  }
-
-  return createByteBudget(numeric, effectiveHardMax);
 }

--- a/packages/tools/src/acquisition/index.ts
+++ b/packages/tools/src/acquisition/index.ts
@@ -28,7 +28,7 @@ export {
   DEFAULT_HEAD_FRACTION,
   createByteBudget,
   createDefaultByteBudget,
-  resolveByteBudgetFromSetting,
+  normalizeHardMax,
 } from './byteBudget.js';
 
 export {
@@ -44,3 +44,11 @@ export {
   trimIncompleteTrailingUtf8,
   skipIncompleteLeadingUtf8,
 } from './utf8Boundaries.js';
+
+export {
+  acquireBoundedHttpBody,
+  disposeHttpResponseBody,
+  HttpBodyTooLargeError,
+  type BoundedFetchResponse,
+  type BoundedHttpBody,
+} from './bounded-http-response.js';

--- a/packages/tools/src/tools/ast-grep.behavioral.bun.test.ts
+++ b/packages/tools/src/tools/ast-grep.behavioral.bun.test.ts
@@ -457,7 +457,7 @@ describe('ast_grep maxResults resolution (issue #3205)', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('resolves a fractional maxResults by flooring (2.5 -> 2)', async () => {
+  it('rejects a fractional maxResults (hard validation)', async () => {
     const host = createToolHost(tempDir);
     const result = await runGrep(host, {
       pattern: '$OBJ.$F($$$ARGS)',
@@ -465,13 +465,11 @@ describe('ast_grep maxResults resolution (issue #3205)', () => {
       path: join(tempDir, 'six.ts'),
       maxResults: 2.5,
     });
-    const meta = metadataOf(result);
-    expect(meta.matches?.length).toBe(2);
-    expect(meta.truncated).toBe(true);
-    expect(meta.countInexact).toBe(true);
+    const text = String(result.llmContent);
+    expect(text).toMatch(/maxResults must be.*finite positive integer/i);
   });
 
-  it('resolves maxResults 0 to an empty, partial result', async () => {
+  it('rejects maxResults 0 (hard validation)', async () => {
     const host = createToolHost(tempDir);
     const result = await runGrep(host, {
       pattern: '$OBJ.$F($$$ARGS)',
@@ -479,13 +477,11 @@ describe('ast_grep maxResults resolution (issue #3205)', () => {
       path: join(tempDir, 'six.ts'),
       maxResults: 0,
     });
-    const meta = metadataOf(result);
-    expect(meta.matches?.length).toBe(0);
-    expect(meta.truncated).toBe(true);
-    expect(meta.countInexact).toBe(true);
+    const text = String(result.llmContent);
+    expect(text).toMatch(/maxResults must be.*finite positive integer/i);
   });
 
-  it('resolves a negative maxResults to 0 (acquire nothing)', async () => {
+  it('rejects a negative maxResults (hard validation)', async () => {
     const host = createToolHost(tempDir);
     const result = await runGrep(host, {
       pattern: '$OBJ.$F($$$ARGS)',
@@ -493,12 +489,8 @@ describe('ast_grep maxResults resolution (issue #3205)', () => {
       path: join(tempDir, 'six.ts'),
       maxResults: -3,
     });
-    const meta = metadataOf(result);
-    expect(meta.matches?.length).toBe(0);
-    // A negative limit resolves to 0 and behaves exactly like an explicit 0:
-    // the result is partial with an inexact (lower-bound) count.
-    expect(meta.truncated).toBe(true);
-    expect(meta.countInexact).toBe(true);
+    const text = String(result.llmContent);
+    expect(text).toMatch(/maxResults must be.*finite positive integer/i);
   });
 
   it('bounds a nonfinite maxResults (Infinity) to the finite default', async () => {

--- a/packages/tools/src/tools/ast-grep.bounds.bun.test.ts
+++ b/packages/tools/src/tools/ast-grep.bounds.bun.test.ts
@@ -1,0 +1,452 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for ast_grep bounded acquisition (issue #3202):
+ * - maxResults hard validation and cap
+ * - pre-read file-size gate (single file and directory traversal)
+ * - oversized-file partial metadata
+ * - abort partial metadata
+ *
+ * Drives the REAL AstGrepTool end-to-end against real fixture files.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IToolHost } from '../interfaces/index.js';
+import { AstGrepTool, type AstGrepToolParams } from './ast-grep.js';
+import type { ToolResult } from './tools.js';
+
+function createToolHost(targetDir: string): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths: string[]) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({}),
+    getDebugMode: () => false,
+  };
+}
+
+interface AstGrepMetadata {
+  truncated?: boolean;
+  matchesRetained?: number;
+  matchesObserved?: number;
+  countInexact?: boolean;
+  totalMatches?: number;
+  partialReason?: string;
+  skippedFiles?: number;
+  oversizedFiles?: number;
+  filesObserved?: number;
+  discoveryTruncated?: boolean;
+}
+
+function readMetadata(result: ToolResult): AstGrepMetadata {
+  const meta = result.metadata as AstGrepMetadata | undefined;
+  if (meta === undefined) {
+    throw new Error(`Expected metadata in ToolResult, got: undefined`);
+  }
+  return meta;
+}
+
+async function runAstGrep(
+  host: IToolHost,
+  params: AstGrepToolParams,
+  signal?: AbortSignal,
+): Promise<ToolResult> {
+  const tool = new AstGrepTool(host);
+  return tool.build(params).execute(signal ?? new AbortController().signal);
+}
+
+describe('ast_grep maxResults hard validation and cap (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-cap-'));
+    writeFileSync(
+      join(tempDir, 'f.ts'),
+      'function alpha() {}\nfunction beta() {}\n',
+    );
+  });
+
+  afterAll(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('rejects a fractional maxResults', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'function $NAME() {}',
+      language: 'typescript',
+      maxResults: 1.5,
+    });
+    const text = String(result.llmContent);
+    expect(text).toMatch(/maxResults must be|error/i);
+  });
+
+  it('rejects maxResults exceeding the hard cap', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'function $NAME() {}',
+      language: 'typescript',
+      maxResults: 10_000_000,
+    });
+    const text = String(result.llmContent);
+    expect(text).toMatch(/maxResults .* (exceeds|hard)|hard (maximum|cap)/i);
+  });
+
+  it('accepts maxResults at the hard cap', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'function $NAME() {}',
+      language: 'typescript',
+      maxResults: 10_000,
+    });
+    expect(String(result.llmContent)).toMatch(/Found \d+/);
+    const meta = readMetadata(result);
+    expect(meta.truncated).toBe(false);
+  });
+
+  it('rejects a negative maxResults', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'function $NAME() {}',
+      language: 'typescript',
+      maxResults: -5,
+    });
+    const text = String(result.llmContent);
+    expect(text).toMatch(/maxResults must be|error/i);
+  });
+});
+
+describe('ast_grep pre-read file-size gate (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-gate-'));
+    // An oversized file (>20 MiB) that would otherwise be fully read.
+    // 21 MiB of padding inside a comment = ~22 MiB total, safely over the
+    // 20 MiB (20,971,520 byte) limit.
+    const huge = `/* ${'x'.repeat(21 * 1024 * 1024)} */\nconst x = 1;\n`;
+    writeFileSync(join(tempDir, 'huge.ts'), huge);
+    writeFileSync(join(tempDir, 'small.ts'), 'const y = 2;\n');
+  });
+
+  afterAll(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('skips an oversized file in directory traversal and reports it', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'const $VAR = $$$REST',
+      language: 'typescript',
+    });
+    const meta = readMetadata(result);
+    // small.ts is searched; huge.ts is gated out.
+    expect(meta.oversizedFiles).toBe(1);
+    // Count cannot be exact since huge.ts was never searched.
+    expect(meta.countInexact).toBe(true);
+    // The small file match is present.
+    const text = String(result.llmContent);
+    expect(text).toContain('small.ts');
+  });
+
+  it('returns a size-gate error for a single oversized file', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'const $VAR = $$$REST',
+      path: 'huge.ts',
+    });
+    const text = String(result.llmContent);
+    expect(text).toMatch(/exceeds the 20MB limit|file size/i);
+    // No error means we searched it — that would be wrong.
+  });
+});
+
+describe('ast_grep abort metadata (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-abort-'));
+    writeFileSync(join(tempDir, 'f.ts'), 'const x = 1;\n');
+  });
+
+  afterAll(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports aborted partial metadata for a pre-aborted signal (single file)', async () => {
+    const host = createToolHost(tempDir);
+    const controller = new AbortController();
+    controller.abort();
+    const result = await runAstGrep(
+      host,
+      { pattern: 'const $X = $$$R', path: 'f.ts' },
+      controller.signal,
+    );
+    const meta = readMetadata(result);
+    expect(meta.truncated).toBe(true);
+    expect(meta.partialReason).toBe('aborted');
+    expect(meta.countInexact).toBe(true);
+  });
+
+  it('reports aborted partial metadata for a pre-aborted signal (directory)', async () => {
+    const host = createToolHost(tempDir);
+    const controller = new AbortController();
+    controller.abort();
+    const result = await runAstGrep(
+      host,
+      { pattern: 'const $X = $$$R', language: 'typescript' },
+      controller.signal,
+    );
+    const meta = readMetadata(result);
+    expect(meta.truncated).toBe(true);
+    expect(meta.partialReason).toBe('aborted');
+  });
+});
+
+describe('ast_grep observed-file budget (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-filebudget-'));
+    // 21 no-match files: with a file budget of 20 (max-items 5 x 4) the
+    // traversal must stop one-over and report discovery partiality.
+    for (let i = 0; i < 21; i++) {
+      writeFileSync(
+        join(tempDir, 'f' + i + '.ts'),
+        'const noop' + i + ' = ' + i + ';\n',
+      );
+    }
+  });
+
+  afterAll(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function createBudgetHost(maxItems: number): IToolHost {
+    const base = createToolHost(tempDir);
+    return {
+      ...base,
+      getEphemeralSettings: () => ({ 'tool-output-max-items': maxItems }),
+    };
+  }
+
+  it('charges every observed file even with zero matches (one-over)', async () => {
+    const host = createBudgetHost(5); // file budget = 20
+    const result = await runAstGrep(host, {
+      pattern: 'function $NAME() {}',
+      language: 'typescript',
+    });
+    const meta = readMetadata(result);
+    expect(meta.truncated).toBe(true);
+    expect(meta.partialReason).toBe('file-budget');
+    expect(meta.countInexact).toBe(true);
+    expect(meta.filesObserved).toBe(21);
+    expect(meta.matchesRetained).toBe(0);
+    const text = String(result.llmContent);
+    expect(text).toMatch(/file|truncat|incomplete|more/i);
+  });
+
+  it('hard-clamps a huge max-items setting', async () => {
+    const hardCapDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-hardcap-'));
+    try {
+      for (let i = 0; i < 10_001; i++) {
+        writeFileSync(join(hardCapDir, `h${i}.ts`), '');
+      }
+      const base = createToolHost(hardCapDir);
+      const host: IToolHost = {
+        ...base,
+        getEphemeralSettings: () => ({
+          'tool-output-max-items': 999_999_999,
+        }),
+      };
+      const result = await runAstGrep(host, {
+        pattern: 'function $NAME() {}',
+        language: 'typescript',
+      });
+      const meta = readMetadata(result);
+      expect(meta.filesObserved).toBe(10_001);
+      expect(meta.truncated).toBe(true);
+      expect(meta.partialReason).toBe('file-budget');
+    } finally {
+      rmSync(hardCapDir, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it('stays complete when the observed-file count is exactly at budget', async () => {
+    const exactDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-exact-'));
+    try {
+      for (let i = 0; i < 20; i++) {
+        writeFileSync(
+          join(exactDir, 'g' + i + '.ts'),
+          'const noop' + i + ' = ' + i + ';\n',
+        );
+      }
+      const base = createToolHost(exactDir);
+      const host: IToolHost = {
+        ...base,
+        getEphemeralSettings: () => ({ 'tool-output-max-items': 5 }), // budget = 20
+      };
+      const result = await runAstGrep(host, {
+        pattern: 'function $NAME() {}',
+        language: 'typescript',
+      });
+      const meta = readMetadata(result);
+      expect(meta.filesObserved).toBe(20);
+      expect(meta.truncated).toBe(false);
+      expect(meta.partialReason).toBeUndefined();
+    } finally {
+      rmSync(exactDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the 1000-file default budget when no setting is supplied', async () => {
+    const defaultDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-default-'));
+    try {
+      for (let i = 0; i < 1001; i++) {
+        writeFileSync(join(defaultDir, `d${i}.ts`), `const d${i} = ${i};\n`);
+      }
+      const base = createToolHost(defaultDir);
+      const host: IToolHost = {
+        ...base,
+        getEphemeralSettings: () => ({}),
+      };
+      const result = await runAstGrep(host, {
+        pattern: 'function $NAME() {}',
+        language: 'typescript',
+      });
+      const meta = readMetadata(result);
+      expect(meta.filesObserved).toBe(1001);
+      expect(meta.truncated).toBe(true);
+      expect(meta.partialReason).toBe('file-budget');
+    } finally {
+      rmSync(defaultDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ast_grep glob filtering during bounded traversal (issue #3202)', () => {
+  let tempDir = '';
+  let outsideDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-globs-'));
+    outsideDir = mkdtempSync(join(tmpdir(), 'llxprt-astgrep-outside-'));
+    writeFileSync(join(tempDir, 'root.ts'), 'function rootMatch() {}\n');
+    writeFileSync(join(tempDir, 'unrelated.txt'), 'function notCode() {}\n');
+    writeFileSync(join(tempDir, 'skipped.ts'), 'function skipMatch() {}\n');
+    writeFileSync(
+      join(outsideDir, 'secret.ts'),
+      'function outsideMatch() {}\n',
+    );
+  });
+
+  afterAll(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    if (outsideDir) rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it('applies a positive include glob during traversal', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'function $NAME() {}',
+      language: 'typescript',
+      globs: ['root.ts'],
+    });
+    const text = String(result.llmContent);
+    expect(text).toContain('rootMatch');
+    expect(text).not.toContain('skipMatch');
+    const meta = readMetadata(result);
+    expect(meta.truncated).toBe(false);
+  });
+
+  it('applies a negative exclude glob during traversal', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'function $NAME() {}',
+      language: 'typescript',
+      globs: ['!skipped.ts'],
+    });
+    const text = String(result.llmContent);
+    expect(text).toContain('rootMatch');
+    expect(text).not.toContain('skipMatch');
+    const meta = readMetadata(result);
+    expect(meta.truncated).toBe(false);
+  });
+
+  it('combines positive and negative globs', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'function $NAME() {}',
+      language: 'typescript',
+      globs: ['*.ts', '!skipped.ts'],
+    });
+    const text = String(result.llmContent);
+    expect(text).toContain('rootMatch');
+    expect(text).not.toContain('skipMatch');
+    const meta = readMetadata(result);
+    // Only root.ts matches (skipped.ts excluded by the negative glob;
+    // unrelated.txt excluded by language extension filter).
+    expect(meta.filesObserved).toBe(1);
+    expect(meta.truncated).toBe(false);
+  });
+
+  it.each([
+    ['absolute', () => join(outsideDir, '*.ts')],
+    ['parent-relative', () => join(relative(tempDir, outsideDir), '*.ts')],
+  ])(
+    'does not read files from an escaping %s glob',
+    async (_kind, globForOutside) => {
+      const host = createToolHost(tempDir);
+      const result = await runAstGrep(host, {
+        pattern: 'function $NAME() {}',
+        language: 'typescript',
+        globs: [globForOutside().replaceAll('\\', '/')],
+      });
+      const text = String(result.llmContent);
+      expect(text).not.toContain('outsideMatch');
+      const meta = readMetadata(result);
+      expect(meta.filesObserved).toBe(1);
+      expect(meta.skippedFiles).toBe(1);
+      expect(meta.countInexact).toBe(true);
+    },
+  );
+
+  it('handles a broad include glob without reporting false partiality', async () => {
+    const host = createToolHost(tempDir);
+    const result = await runAstGrep(host, {
+      pattern: 'function $NAME() {}',
+      language: 'typescript',
+      globs: ['*.ts'],
+    });
+    const meta = readMetadata(result);
+    // Both .ts files processed; complete traversal.
+    expect(meta.filesObserved).toBe(2);
+    expect(meta.truncated).toBe(false);
+  });
+});

--- a/packages/tools/src/tools/ast-grep.ts
+++ b/packages/tools/src/tools/ast-grep.ts
@@ -16,6 +16,8 @@ import {
   type ToolResult,
 } from './tools.js';
 import { makeRelative } from '../utils/paths.js';
+import { statFileSizeGate } from '../utils/fileUtils.js';
+import { isPathWithinWorkspace } from '../utils/pathValidation.js';
 import type { SgNode, NapiConfig } from '@ast-grep/napi';
 import type { Lang } from '../utils/ast-grep-utils.js';
 import {
@@ -27,6 +29,38 @@ import {
 import type { IToolHost, IToolMessageBus } from '../interfaces/index.js';
 
 const DEFAULT_MAX_RESULTS = 100;
+const MAX_RESULTS_HARD_CAP = 10_000;
+
+/**
+ * Default observed-file discovery budget when no `tool-output-max-items`
+ * setting is supplied. The primary directory traversal is hard-bounded so a
+ * broad search over a huge tree cannot read/parse unbounded files.
+ */
+const DEFAULT_MAX_OBSERVED_FILES = 1000;
+/** Absolute ceiling on the observed-file discovery budget. */
+const MAX_OBSERVED_FILES_HARD_CAP = 10_000;
+/**
+ * The discovery budget scales with the `tool-output-max-items` setting (a few
+ * files scanned per requested item, matching the structural-analysis
+ * convention), then is hard-clamped.
+ */
+const OBSERVED_FILES_PER_ITEM = 4;
+
+/** Resolve a finite, hard-clamped observed-file discovery budget. */
+function resolveObservedFileBudget(maxItemsSetting: unknown): number {
+  // Scaling applies only to a valid configured item count; absent/invalid
+  // settings yield the documented DEFAULT_MAX_OBSERVED_FILES (1000).
+  const configured =
+    typeof maxItemsSetting === 'number' &&
+    Number.isFinite(maxItemsSetting) &&
+    maxItemsSetting > 0
+      ? maxItemsSetting * OBSERVED_FILES_PER_ITEM
+      : DEFAULT_MAX_OBSERVED_FILES;
+  return Math.min(
+    Math.max(Math.floor(configured), 1),
+    MAX_OBSERVED_FILES_HARD_CAP,
+  );
+}
 
 export interface AstGrepToolParams {
   pattern?: string;
@@ -48,11 +82,14 @@ interface AstGrepMatch {
   metaVariables: Record<string, string>;
 }
 
+/** Partiality reason surfaced in ast-grep result metadata. */
+type AstGrepPartialReason = 'max-results' | 'aborted' | 'file-budget';
+
 /** Mutable accumulator for bounded match collection. */
 interface MatchAccumulator {
   matches: AstGrepMatch[];
   truncated: boolean;
-  partialReason: 'max-results' | 'aborted' | undefined;
+  partialReason: AstGrepPartialReason | undefined;
   sentinelObserved: boolean;
   /**
    * Number of candidate matches actually observed during traversal. Equals
@@ -61,6 +98,47 @@ interface MatchAccumulator {
    * before stopping), so it is a lower bound when truncated.
    */
   observedCount: number;
+  /**
+   * Number of files observed (read/attempted) during directory discovery.
+   * A lower bound when {@link discoveryTruncated} is true.
+   */
+  filesObserved: number;
+  /** Whether directory discovery hit the observed-file budget one-over. */
+  discoveryTruncated: boolean;
+}
+
+/**
+ * Aggregate outcome of one bounded match collection run: the retained
+ * matches plus the truncation/partiality metadata that must travel with
+ * them so a bounded result is never presented as exhaustive.
+ */
+interface CollectedMatches {
+  matches: AstGrepMatch[];
+  truncated: boolean;
+  partialReason: AstGrepPartialReason | undefined;
+  skippedFiles: number;
+  oversizedFiles: number;
+  observedCount: number;
+  filesObserved: number;
+  discoveryTruncated: boolean;
+}
+
+/** Snapshot an accumulator plus file-accounting counters into a result. */
+function buildCollectedMatches(
+  acc: MatchAccumulator,
+  skippedFiles: number,
+  oversizedFiles: number,
+): CollectedMatches {
+  return {
+    matches: acc.matches,
+    truncated: acc.truncated,
+    partialReason: acc.partialReason,
+    skippedFiles,
+    oversizedFiles,
+    observedCount: acc.observedCount,
+    filesObserved: acc.filesObserved,
+    discoveryTruncated: acc.discoveryTruncated,
+  };
 }
 
 class AstGrepToolInvocation extends BaseToolInvocation<
@@ -88,7 +166,6 @@ class AstGrepToolInvocation extends BaseToolInvocation<
 
   async execute(signal: AbortSignal): Promise<ToolResult> {
     const { pattern, rule, globs } = this.params;
-    const limit = this.resolveLimit(this.params.maxResults);
 
     const resolved = this.validateAndResolveParams();
     if (resolved instanceof Object && 'llmContent' in resolved) return resolved;
@@ -98,24 +175,46 @@ class AstGrepToolInvocation extends BaseToolInvocation<
       resolvedLang: string | Lang;
     };
 
+    let limit: number;
     try {
-      const { matches, truncated, partialReason, skippedFiles, observedCount } =
-        await this.collectMatches(
-          searchPath,
-          isSingleFile,
-          resolvedLang,
-          pattern,
-          rule,
-          globs,
-          signal,
-          limit,
-        );
+      limit = this.resolveLimit(this.params.maxResults);
+    } catch (err) {
+      return this.makeError(err instanceof Error ? err.message : String(err));
+    }
+
+    try {
+      const observedFileBudget = resolveObservedFileBudget(
+        this.host.getEphemeralSettings()['tool-output-max-items'],
+      );
+      const {
+        matches,
+        truncated,
+        partialReason,
+        skippedFiles,
+        oversizedFiles,
+        observedCount,
+        filesObserved,
+        discoveryTruncated,
+      } = await this.collectMatches(
+        searchPath,
+        isSingleFile,
+        resolvedLang,
+        pattern,
+        rule,
+        globs,
+        signal,
+        limit,
+        observedFileBudget,
+      );
       return this.formatSearchResults(
         matches,
         truncated,
         partialReason,
         skippedFiles,
+        oversizedFiles,
         observedCount,
+        filesObserved,
+        discoveryTruncated,
         pattern,
       );
     } catch (err) {
@@ -125,18 +224,32 @@ class AstGrepToolInvocation extends BaseToolInvocation<
   }
 
   /**
-   * Resolves `maxResults` to a finite, nonnegative integer acquisition limit.
+   * Resolves `maxResults` to a finite positive integer acquisition limit,
+   * hard-capped at {@link MAX_RESULTS_HARD_CAP}.
    *
    * - `undefined` -> the documented default.
-   * - fractional -> floored (consistent with prior slice semantics).
-   * - zero / negative -> 0 (acquire nothing; a negative slice is empty).
-   * - nonfinite -> default (defensive: the JSON-Schema `type: number` already
-   *   rejects Infinity/NaN at validation, preserving the public contract).
+   * - nonfinite / non-integer / non-positive -> validation error (thrown as
+   *   an Error consumed by the execute catch path).
+   * - above the hard cap -> validation error.
    */
   private resolveLimit(maxResults: number | undefined): number {
     const value = maxResults ?? DEFAULT_MAX_RESULTS;
-    if (!Number.isFinite(value)) return DEFAULT_MAX_RESULTS;
-    return Math.max(0, Math.floor(value));
+    if (
+      typeof value !== 'number' ||
+      !Number.isFinite(value) ||
+      !Number.isInteger(value) ||
+      value <= 0
+    ) {
+      throw new Error(
+        `maxResults must be a finite positive integer, got: ${String(maxResults)}`,
+      );
+    }
+    if (value > MAX_RESULTS_HARD_CAP) {
+      throw new Error(
+        `maxResults ${value} exceeds the hard maximum ${MAX_RESULTS_HARD_CAP}`,
+      );
+    }
+    return value;
   }
 
   private validateAndResolveParams():
@@ -215,13 +328,8 @@ class AstGrepToolInvocation extends BaseToolInvocation<
     globs: string[] | undefined,
     signal: AbortSignal | undefined,
     limit: number,
-  ): Promise<{
-    matches: AstGrepMatch[];
-    truncated: boolean;
-    partialReason: 'max-results' | 'aborted' | undefined;
-    skippedFiles: number;
-    observedCount: number;
-  }> {
+    observedFileBudget: number,
+  ): Promise<CollectedMatches> {
     const targetDir = this.host.getTargetDir();
     const acc: MatchAccumulator = {
       matches: [],
@@ -229,8 +337,11 @@ class AstGrepToolInvocation extends BaseToolInvocation<
       partialReason: undefined,
       sentinelObserved: false,
       observedCount: 0,
+      filesObserved: 0,
+      discoveryTruncated: false,
     };
     let skippedFiles = 0;
+    let oversizedFiles = 0;
 
     // AbortSignal.aborted is a mutable property; reading it through a helper
     // avoids TS narrowing it to `false` after the pre-abort check (the signal
@@ -245,16 +356,17 @@ class AstGrepToolInvocation extends BaseToolInvocation<
     if (isAborted()) {
       acc.truncated = true;
       acc.partialReason = 'aborted';
-      return {
-        matches: acc.matches,
-        truncated: acc.truncated,
-        partialReason: acc.partialReason,
-        skippedFiles,
-        observedCount: acc.observedCount,
-      };
+      return buildCollectedMatches(acc, skippedFiles, oversizedFiles);
     }
 
     if (isSingleFile) {
+      acc.filesObserved = 1;
+      // Shared pre-read file-size gate: an oversized file is never read or
+      // parsed, so the acquisition stays bounded regardless of file size.
+      const sizeError = await statFileSizeGate(searchPath);
+      if (sizeError !== null) {
+        throw new Error(sizeError.message);
+      }
       const content = await fs.readFile(searchPath, 'utf-8');
       this.searchContentBounded(
         content,
@@ -267,7 +379,7 @@ class AstGrepToolInvocation extends BaseToolInvocation<
         rule,
       );
     } else {
-      skippedFiles = await this.collectFromDirectory(
+      const dirOutcome = await this.collectFromDirectory(
         searchPath,
         resolvedLang,
         globs,
@@ -277,7 +389,10 @@ class AstGrepToolInvocation extends BaseToolInvocation<
         targetDir,
         acc,
         limit,
+        observedFileBudget,
       );
+      skippedFiles = dirOutcome.skippedFiles;
+      oversizedFiles = dirOutcome.oversizedFiles;
     }
 
     // A signal that aborts during an awaited traversal step must never read as
@@ -287,13 +402,7 @@ class AstGrepToolInvocation extends BaseToolInvocation<
       acc.partialReason = 'aborted';
     }
 
-    return {
-      matches: acc.matches,
-      truncated: acc.truncated,
-      partialReason: acc.partialReason,
-      skippedFiles,
-      observedCount: acc.observedCount,
-    };
+    return buildCollectedMatches(acc, skippedFiles, oversizedFiles);
   }
 
   /**
@@ -444,7 +553,8 @@ class AstGrepToolInvocation extends BaseToolInvocation<
     targetDir: string,
     acc: MatchAccumulator,
     limit: number,
-  ): Promise<number> {
+    observedFileBudget: number,
+  ): Promise<{ skippedFiles: number; oversizedFiles: number }> {
     // AbortSignal.aborted is a mutable property; reading it through a helper
     // avoids TS narrowing it to `false` after the pre-abort check (the signal
     // can become aborted during an awaited traversal step).
@@ -456,34 +566,30 @@ class AstGrepToolInvocation extends BaseToolInvocation<
         acc.truncated = true;
         acc.partialReason = 'aborted';
       }
-      return 0;
+      return { skippedFiles: 0, oversizedFiles: 0 };
     }
 
-    const extensions = this.getExtensionsForLanguage(resolvedLang);
-    // Include/exclude sets are resolved via streaming so the only full
-    // path-array materialization is the user-provided glob subset (not every
-    // language file in the tree). Preserves FastGlob's glob/workspace
-    // semantics and source order.
-    const { includeSet, excludeSet } = await this.resolveGlobSets(
-      globs,
-      searchPath,
-    );
-    let skippedFiles = 0;
+    const {
+      primaryPatterns,
+      ignorePatterns,
+      extensionSet,
+      acceptsAnyExtension,
+    } = this.resolveDirectoryScan(resolvedLang, globs);
 
-    const stream = FastGlob.stream(
-      extensions.map((ext) => `**/*.${ext}`),
-      {
-        cwd: searchPath,
-        absolute: true,
-        dot: false,
-        ignore: ['**/node_modules/**', '**/.git/**'],
-      },
-    );
+    let skippedFiles = 0;
+    let oversizedFiles = 0;
+
+    const stream = FastGlob.stream(primaryPatterns, {
+      cwd: searchPath,
+      absolute: true,
+      dot: false,
+      ignore: ['**/node_modules/**', '**/.git/**', ...ignorePatterns],
+    });
 
     // Per-entry processing returns whether the traversal should continue
     // (keeps the loop body to a single break/continue-free break).
     const processEntry = async (entry: string): Promise<boolean> => {
-      if (acc.sentinelObserved || isAborted()) {
+      if (acc.sentinelObserved || isAborted() || acc.discoveryTruncated) {
         if (isAborted() && !acc.truncated) {
           acc.truncated = true;
           acc.partialReason = 'aborted';
@@ -491,99 +597,205 @@ class AstGrepToolInvocation extends BaseToolInvocation<
         return false;
       }
       const file = String(entry);
-      if (includeSet !== null && !includeSet.has(file)) return true;
-      if (excludeSet?.has(file) === true) return true;
-      try {
-        const content = await fs.readFile(file, 'utf-8');
-        this.searchContentBounded(
-          content,
-          resolvedLang,
-          file,
-          targetDir,
-          acc,
-          limit,
-          pattern,
-          rule,
-        );
-      } catch {
-        skippedFiles++;
+      // Cheap per-entry language-extension filter (no materialized set). For a
+      // language-driven traversal this is a no-op; when include globs drive
+      // the primary patterns it constrains them to the requested language.
+      if (!acceptsAnyExtension) {
+        const ext = path.extname(file);
+        if (!extensionSet.has(ext)) return true;
       }
+      // Observed-file discovery budget with one-over sentinel: the first file
+      // beyond the budget is counted (proving partiality) but not searched,
+      // then traversal stops. Every observed file is charged even when no
+      // match is ever produced.
+      acc.filesObserved++;
+      if (acc.filesObserved > observedFileBudget) {
+        acc.discoveryTruncated = true;
+        acc.truncated = true;
+        acc.partialReason = 'file-budget';
+        return false;
+      }
+      // Include globs may be absolute or contain parent traversal. Resolve each
+      // discovered entry against the requested target before any stat or read;
+      // realpath-aware validation also blocks symlink escapes.
+      if (!isPathWithinWorkspace([targetDir], file)) {
+        skippedFiles++;
+        return true;
+      }
+      // Shared pre-read file-size gate and search, with per-entry accounting.
+      const outcome = await this.gateAndSearchDirectoryFile(
+        file,
+        resolvedLang,
+        targetDir,
+        acc,
+        limit,
+        pattern,
+        rule,
+      );
+      if (outcome === 'oversized') oversizedFiles++;
+      if (outcome === 'skipped') skippedFiles++;
       return true;
     };
 
     for await (const entry of stream) {
       if (!(await processEntry(String(entry)))) break;
     }
-    return skippedFiles;
+    return { skippedFiles, oversizedFiles };
   }
 
   /**
-   * Resolves include/exclude glob sets lazily via FastGlob's streaming API so
-   * glob filtering does not materialize full path arrays for the primary
-   * language discovery. Returns null sets when no globs are supplied (the
-   * common case stays fully streaming).
+   * Gate one directory file through the pre-read size check and search it
+   * when it fits. Returns the per-entry accounting outcome: 'oversized'
+   * (skipped for size), 'skipped' (stat error or read/parse failure), or
+   * 'searched'. A non-ENOENT stat error (EACCES, EIO, ELOOP) must not abort
+   * the whole traversal — it counts as skipped so traversal continues,
+   * matching how read errors are handled.
    */
-  private async resolveGlobSets(
+  private async gateAndSearchDirectoryFile(
+    file: string,
+    resolvedLang: string | Lang,
+    targetDir: string,
+    acc: MatchAccumulator,
+    limit: number,
+    pattern: string | undefined,
+    rule: Record<string, unknown> | undefined,
+  ): Promise<'oversized' | 'skipped' | 'searched'> {
+    try {
+      const sizeError = await statFileSizeGate(file);
+      if (sizeError !== null) {
+        return 'oversized';
+      }
+    } catch {
+      return 'skipped';
+    }
+    const searched = await this.searchSingleDirectoryFile(
+      file,
+      resolvedLang,
+      targetDir,
+      acc,
+      limit,
+      pattern,
+      rule,
+    );
+    return searched ? 'searched' : 'skipped';
+  }
+
+  /**
+   * Read one directory file and search its content within bounds. Returns
+   * false when the file cannot be read (counted as skipped by the caller).
+   */
+  private async searchSingleDirectoryFile(
+    file: string,
+    resolvedLang: string | Lang,
+    targetDir: string,
+    acc: MatchAccumulator,
+    limit: number,
+    pattern: string | undefined,
+    rule: Record<string, unknown> | undefined,
+  ): Promise<boolean> {
+    try {
+      const content = await fs.readFile(file, 'utf-8');
+      this.searchContentBounded(
+        content,
+        resolvedLang,
+        file,
+        targetDir,
+        acc,
+        limit,
+        pattern,
+        rule,
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Resolve the language extension filter AND the glob traversal patterns in
+   * one step, since both derive from the resolved language extensions. The
+   * extension filter is applied per-entry during the bounded traversal.
+   */
+  private resolveDirectoryScan(
+    resolvedLang: string | Lang,
     globs: string[] | undefined,
-    searchPath: string,
-  ): Promise<{
-    includeSet: Set<string> | null;
-    excludeSet: Set<string> | null;
-  }> {
+  ): {
+    primaryPatterns: string[];
+    ignorePatterns: string[];
+    extensionSet: Set<string>;
+    acceptsAnyExtension: boolean;
+  } {
+    const extensions = this.getExtensionsForLanguage(resolvedLang);
+    const { primaryPatterns, ignorePatterns } = this.resolveGlobTraversal(
+      globs,
+      extensions,
+    );
+    return {
+      primaryPatterns,
+      ignorePatterns,
+      acceptsAnyExtension: extensions.includes('*'),
+      extensionSet: new Set(
+        extensions.filter((ext) => ext !== '*').map((ext) => '.' + ext),
+      ),
+    };
+  }
+
+  /**
+   * Resolve the primary traversal patterns and ignore patterns from the
+   * user-supplied globs WITHOUT materializing path sets. Include globs (no `!`
+   * prefix) drive the primary pattern set; exclude globs (`!`-prefixed) are
+   * forwarded to FastGlob's `ignore` option. When no include globs are given,
+   * the language extensions drive the primary patterns.
+   */
+  private resolveGlobTraversal(
+    globs: string[] | undefined,
+    extensions: string[],
+  ): { primaryPatterns: string[]; ignorePatterns: string[] } {
+    const extensionPatterns = extensions.map((ext) => `**/*.${ext}`);
     if (!globs || globs.length === 0) {
-      return { includeSet: null, excludeSet: null };
+      return { primaryPatterns: extensionPatterns, ignorePatterns: [] };
     }
     const includePatterns = globs.filter((g) => !g.startsWith('!'));
     const excludePatterns = globs
       .filter((g) => g.startsWith('!'))
       .map((g) => g.slice(1));
-
-    let includeSet: Set<string> | null = null;
-    let excludeSet: Set<string> | null = null;
-
-    if (includePatterns.length > 0) {
-      includeSet = new Set<string>();
-      for await (const f of FastGlob.stream(includePatterns, {
-        cwd: searchPath,
-        absolute: true,
-      })) {
-        includeSet.add(String(f));
-      }
-    }
-    if (excludePatterns.length > 0) {
-      excludeSet = new Set<string>();
-      for await (const f of FastGlob.stream(excludePatterns, {
-        cwd: searchPath,
-        absolute: true,
-      })) {
-        excludeSet.add(String(f));
-      }
-    }
-    return { includeSet, excludeSet };
+    const primaryPatterns =
+      includePatterns.length > 0 ? includePatterns : extensionPatterns;
+    return { primaryPatterns, ignorePatterns: excludePatterns };
   }
 
   private formatSearchResults(
     matches: AstGrepMatch[],
     truncated: boolean,
-    partialReason: 'max-results' | 'aborted' | undefined,
+    partialReason: AstGrepPartialReason | undefined,
     skippedFiles: number,
+    oversizedFiles: number,
     observedCount: number,
+    filesObserved: number,
+    discoveryTruncated: boolean,
     pattern?: string,
   ): ToolResult {
     const matchCount = matches.length;
     const searchDesc = pattern ? `pattern "${pattern}"` : 'rule query';
-    // A skipped (unreadable/unparseable) file means the count cannot be exact:
-    // there may be unobserved matches in files the tool never fully searched.
-    const inexact = truncated || skippedFiles > 0;
+    // A skipped (unreadable/unparseable) or oversized file, or a discovery
+    // one-over, means the count cannot be exact: there may be unobserved
+    // matches in files the tool never reached.
+    const inexact = truncated || skippedFiles > 0 || oversizedFiles > 0;
 
     let llmContent = `Found ${matchCount} AST match${matchCount !== 1 ? 'es' : ''} for ${searchDesc}`;
     if (truncated) {
-      const note =
-        partialReason === 'aborted'
-          ? ' (aborted; more matches may exist)'
-          : ' (truncated; more matches exist)';
+      let note = ' (truncated; more matches may exist)';
+      if (partialReason === 'aborted') {
+        note = ' (aborted; more matches may exist)';
+      } else if (partialReason === 'file-budget') {
+        note = ' (file discovery truncated; more files may contain matches)';
+      }
       llmContent += note;
-    } else if (skippedFiles > 0) {
+    }
+    if (oversizedFiles > 0) {
+      llmContent += ` (${oversizedFiles} oversized file${oversizedFiles !== 1 ? 's' : ''} skipped)`;
+    }
+    if (!truncated && skippedFiles > 0) {
       llmContent += ` (${skippedFiles} file${skippedFiles !== 1 ? 's' : ''} skipped; count is a lower bound)`;
     }
     llmContent += ':\n---\n';
@@ -602,18 +814,22 @@ class AstGrepToolInvocation extends BaseToolInvocation<
       llmContent: llmContent.trim(),
       returnDisplay: displayMessage,
       // totalMatches is only the exact total when traversal completed fully
-      // AND no file was skipped; it is intentionally omitted after an early
-      // stop or skip so no consumer mistakes a lower bound for an exhaustive
-      // count.
+      // AND no file was skipped, oversized, or discovery-truncated; it is
+      // intentionally omitted otherwise so no consumer mistakes a lower bound
+      // for an exhaustive count.
       metadata: {
         matches,
         truncated,
         matchesRetained: matchCount,
         // Lower bound on observed candidates (exact when complete).
         matchesObserved: observedCount,
+        // Lower bound on observed files (exact when discovery not truncated).
+        filesObserved,
         ...(inexact ? { countInexact: true } : { totalMatches: matchCount }),
         ...(partialReason !== undefined ? { partialReason } : {}),
+        ...(discoveryTruncated ? { discoveryTruncated: true } : {}),
         ...(skippedFiles > 0 ? { skippedFiles } : {}),
+        ...(oversizedFiles > 0 ? { oversizedFiles } : {}),
       },
     };
   }

--- a/packages/tools/src/tools/codesearch.ts
+++ b/packages/tools/src/tools/codesearch.ts
@@ -21,7 +21,7 @@ import { createDefaultByteBudget } from '../acquisition/index.js';
 import {
   acquireBoundedHttpBody,
   HttpBodyTooLargeError,
-} from '../utils/bounded-http-response.js';
+} from '../acquisition/bounded-http-response.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,

--- a/packages/tools/src/tools/direct-web-fetch.ts
+++ b/packages/tools/src/tools/direct-web-fetch.ts
@@ -30,7 +30,7 @@ import { createByteBudget } from '../acquisition/index.js';
 import {
   acquireBoundedHttpBody,
   disposeHttpResponseBody,
-} from '../utils/bounded-http-response.js';
+} from '../acquisition/bounded-http-response.js';
 
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024; // 5MB
 const FETCH_BYTE_BUDGET = createByteBudget(MAX_RESPONSE_SIZE);

--- a/packages/tools/src/tools/exa-web-search.ts
+++ b/packages/tools/src/tools/exa-web-search.ts
@@ -17,7 +17,7 @@ import { createDefaultByteBudget } from '../acquisition/index.js';
 import {
   acquireBoundedHttpBody,
   HttpBodyTooLargeError,
-} from '../utils/bounded-http-response.js';
+} from '../acquisition/bounded-http-response.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,

--- a/packages/tools/src/tools/grep.ts
+++ b/packages/tools/src/tools/grep.ts
@@ -34,10 +34,8 @@ import {
   type GrepMatch,
   type GrepToolParams,
 } from './grep/types.js';
-import {
-  performGrepSearch,
-  performSingleFileSearch,
-} from './grep/search-strategies.js';
+import { performGrepSearch } from './grep/search-strategies.js';
+import { performSingleFileSearch } from './grep/single-file-search.js';
 import { createAggregateSemanticBudget } from './grep/grepBudget.js';
 
 export { type GrepToolParams } from './grep/types.js';
@@ -171,11 +169,16 @@ class GrepToolInvocation extends BaseToolInvocation<
     resolved: ResolvedSearchTarget & { kind: 'file' },
     combinedSignal: AbortSignal,
     searchDirDisplay: string,
+    maxResults: number,
+    maxPerFile: number,
   ): Promise<ToolResult> {
+    // Pass the invocation's validated limits and a finite source-observation
+    // budget through to the streaming search — never the hardcoded defaults.
     const fileResult = await performSingleFileSearch(
       this.params.pattern,
       resolved.filePath,
       combinedSignal,
+      { maxResults, maxPerFile },
     );
 
     let includeNote = '';
@@ -184,17 +187,36 @@ class GrepToolInvocation extends BaseToolInvocation<
         '\nNote: include filter ignored because a specific file path was provided.';
     }
 
-    if (fileResult.length === 0) {
+    const matchCount = fileResult.matches.length;
+    const partial = fileResult.truncated || fileResult.sourcePartial;
+    const truncationMeta = partial
+      ? { outputTruncation: { truncated: true } }
+      : undefined;
+
+    if (matchCount === 0 && !partial) {
       const noMatchMsg = `No matches found for pattern "${this.params.pattern}" in file "${searchDirDisplay}".${includeNote}`;
       return { llmContent: noMatchMsg, returnDisplay: 'No matches found' };
     }
 
-    const matchTerm = fileResult.length === 1 ? 'match' : 'matches';
-    let llmContent = `Found ${fileResult.length} ${matchTerm} for pattern "${this.params.pattern}" in file "${searchDirDisplay}":${includeNote}
+    if (matchCount === 0 && partial) {
+      const msg = `No matches retained for pattern "${this.params.pattern}" in file "${searchDirDisplay}". Results may be incomplete.${includeNote}`;
+      return {
+        llmContent: msg,
+        returnDisplay: 'No matches shown (incomplete)',
+        metadata: truncationMeta,
+      };
+    }
+
+    const matchTerm = matchCount === 1 ? 'match' : 'matches';
+    const header = partial
+      ? `Showing ${matchCount} ${matchTerm} for pattern "${this.params.pattern}" in file "${searchDirDisplay}" (results may be incomplete):${includeNote}`
+      : `Found ${matchCount} ${matchTerm} for pattern "${this.params.pattern}" in file "${searchDirDisplay}":${includeNote}`;
+
+    let llmContent = `${header}
 ---
 File: ${resolved.basename}
 `;
-    for (const match of fileResult) {
+    for (const match of fileResult.matches) {
       llmContent += `L${match.lineNumber}: ${match.line.trim()}
 `;
     }
@@ -211,12 +233,16 @@ File: ${resolved.basename}
       return {
         llmContent: formatted.llmContent,
         returnDisplay: formatted.returnDisplay,
+        metadata: truncationMeta,
       };
     }
 
     return {
       llmContent: llmContent.trim(),
-      returnDisplay: `Found ${fileResult.length} ${matchTerm}`,
+      returnDisplay: partial
+        ? `Showing ${matchCount} ${matchTerm} (results may be incomplete)`
+        : `Found ${matchCount} ${matchTerm}`,
+      metadata: truncationMeta,
     };
   }
 
@@ -388,7 +414,8 @@ File: ${resolved.basename}
       : '';
     if (!totalIsExact) {
       // Search was incomplete — do not claim an exact total.
-      llmContent = `Showing ${matchCount} matches for pattern "${this.params.pattern}" ${searchLocationDescription}${includeNote} (results may be incomplete):
+      const matchTerm = matchCount === 1 ? 'match' : 'matches';
+      llmContent = `Showing ${matchCount} ${matchTerm} for pattern "${this.params.pattern}" ${searchLocationDescription}${includeNote} (results may be incomplete):
 ---
 `;
     } else if (wasLimited || totalMatchesFound > matchCount) {
@@ -430,7 +457,8 @@ File: ${resolved.basename}
     totalIsExact: boolean,
   ): string {
     if (!totalIsExact) {
-      return `Showing ${matchCount} matches (results may be incomplete)`;
+      const matchTerm = matchCount === 1 ? 'match' : 'matches';
+      return `Showing ${matchCount} ${matchTerm} (results may be incomplete)`;
     }
     if (effectiveWasLimited || totalMatchesFound > matchCount) {
       return `Found ${totalMatchesFound} matches (showing ${matchCount})`;
@@ -462,6 +490,7 @@ File: ${resolved.basename}
         return {
           llmContent: msg,
           returnDisplay: 'No matches shown (incomplete)',
+          metadata: { outputTruncation: { truncated: true } },
         };
       }
       const noMatchMsg = `No matches found for pattern "${this.params.pattern}" ${searchLocationDescription}${includeNote}.`;
@@ -504,6 +533,7 @@ File: ${resolved.basename}
       return {
         llmContent: formatted.llmContent,
         returnDisplay: formatted.returnDisplay,
+        metadata: { outputTruncation: { truncated: true } },
       };
     }
 
@@ -514,9 +544,13 @@ File: ${resolved.basename}
       totalIsExact,
     );
 
+    const partial = !totalIsExact || effectiveWasLimited;
     return {
       llmContent: llmContent.trim(),
       returnDisplay: displayCount,
+      ...(partial
+        ? { metadata: { outputTruncation: { truncated: true } } }
+        : {}),
     };
   }
 
@@ -594,6 +628,8 @@ File: ${resolved.basename}
         resolved as ResolvedSearchTarget & { kind: 'file' },
         combinedSignal,
         searchDirDisplay,
+        maxResults,
+        maxPerFile,
       );
     }
 

--- a/packages/tools/src/tools/grep/grepBudget.ts
+++ b/packages/tools/src/tools/grep/grepBudget.ts
@@ -4,17 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DEFAULT_ACQUISITION_BUDGET_BYTES } from '../../acquisition/index.js';
+import {
+  DEFAULT_ACQUISITION_BUDGET_BYTES,
+  ACQUISITION_HARD_MAX_BYTES,
+} from '../../acquisition/index.js';
 import type { GrepMatch } from './types.js';
 
 /**
  * Aggregate semantic budget shared across all roots and strategies for a
  * single invocation. Tracks remaining bytes and objects (matches) that may
- * be retained in bounded semantic storage.
+ * be retained in bounded semantic storage, plus a finite source-observation
+ * byte budget charged against EVERY source chunk read (even when no match is
+ * produced) so a huge no-match input cannot be read without bound.
  */
 export interface SemanticBudget {
   remainingBytes: number;
   remainingObjects: number;
+  /** Finite source-observation byte budget; charged per read chunk. */
+  sourceBytes: number;
 }
 
 /** Per-match overhead added to the raw line/filePath byte cost. */
@@ -23,11 +30,31 @@ export const MATCH_OVERHEAD_BYTES = 256;
 /** Hard ceiling on the number of retained matches for one invocation. */
 export const HARD_RETAINED_MATCH_CAP = 100_000;
 
+/** Hard ceiling on the per-invocation source-observation byte budget. */
+export const SOURCE_BUDGET_HARD_MAX_BYTES = ACQUISITION_HARD_MAX_BYTES;
+
+/**
+ * Default finite source-observation budget. Matches the raw collection budget
+ * used by the subprocess strategies so the JavaScript fallback and direct-file
+ * path stay bounded to the same magnitude.
+ */
+export const DEFAULT_SOURCE_BUDGET_BYTES = DEFAULT_ACQUISITION_BUDGET_BYTES;
+
+/** Normalize and hard-clamp a source-observation byte budget. */
+export function normalizeSourceBudgetBytes(value: number | undefined): number {
+  const base =
+    typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? Math.floor(value)
+      : DEFAULT_SOURCE_BUDGET_BYTES;
+  return Math.min(base, SOURCE_BUDGET_HARD_MAX_BYTES);
+}
+
 /** Create a fresh aggregate semantic budget at the default acquisition size. */
 export function createAggregateSemanticBudget(): SemanticBudget {
   return {
     remainingBytes: DEFAULT_ACQUISITION_BUDGET_BYTES,
     remainingObjects: HARD_RETAINED_MATCH_CAP,
+    sourceBytes: DEFAULT_SOURCE_BUDGET_BYTES,
   };
 }
 

--- a/packages/tools/src/tools/grep/javascriptFallback.ts
+++ b/packages/tools/src/tools/grep/javascriptFallback.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fsPromises from 'fs/promises';
+import { createReadStream } from 'fs';
 import path from 'path';
 import { globStream } from 'glob';
 
 import { getErrorMessage, isNodeError } from '../../utils/errors.js';
 import { debugLogger } from '../../utils/debugLogger.js';
+import { BoundedLineFramer } from '../../utils/lineFramer.js';
 import type { GrepMatch, SearchResults } from './types.js';
 import {
   type SemanticBudget,
@@ -19,36 +20,137 @@ import {
   retainGrepMatch,
 } from './grepBudget.js';
 
+/** Outcome of reading/processing one file in the JavaScript fallback. */
+interface FallbackFileOutcome {
+  /** Whether this file was only partially observed (line drop, read error,
+   * premature close, or mid-file abort); marks the aggregate result incomplete. */
+  partial: boolean;
+}
+
+/** Factory for the per-line retain callback used during a fallback file scan. */
+function createRetainLine(
+  relativeFilePath: string,
+  regex: RegExp,
+  state: GrepRetainState,
+  limits: GrepLimits,
+): (line: string) => boolean {
+  let lineNumber = 0;
+  return (line: string): boolean => {
+    lineNumber++;
+    if (state.earlyStopped) return true;
+    if (regex.test(line)) {
+      const match: GrepMatch = {
+        filePath: relativeFilePath,
+        lineNumber,
+        line,
+      };
+      return retainGrepMatch(state, match, limits);
+    }
+    return false;
+  };
+}
+
 async function processFallbackFile(
   state: GrepRetainState,
   filePath: string,
   absolutePath: string,
   regex: RegExp,
   limits: GrepLimits,
-): Promise<void> {
-  let content: string;
-  try {
-    content = await fsPromises.readFile(filePath, 'utf8');
-  } catch (readError: unknown) {
-    if (!isNodeError(readError) || readError.code !== 'ENOENT') {
-      debugLogger.debug(
-        `GrepLogic: Could not read/process ${filePath}: ${getErrorMessage(readError)}`,
-      );
+  abortSignal: AbortSignal,
+): Promise<FallbackFileOutcome> {
+  const relativeFilePath =
+    path.relative(absolutePath, filePath) || path.basename(filePath);
+  const framer = new BoundedLineFramer();
+  let filePartial = false;
+  let settled = false;
+
+  const retainLine = createRetainLine(relativeFilePath, regex, state, limits);
+
+  return new Promise<FallbackFileOutcome>((resolve) => {
+    const stream = createReadStream(filePath);
+
+    // Wire the abort signal to the active read stream: when the caller
+    // aborts mid-file, destroy the stream promptly so processing stops
+    // immediately rather than reading to EOF. The listener is removed on
+    // settle to avoid leaks across many files.
+    const onAbort = (): void => {
+      filePartial = true;
+      stream.destroy();
+    };
+
+    const settle = (outcome: FallbackFileOutcome): void => {
+      if (settled) return;
+      settled = true;
+      abortSignal.removeEventListener('abort', onAbort);
+      stream.removeListener('data', onData);
+      stream.removeListener('end', onEnd);
+      stream.removeListener('error', onError);
+      stream.removeListener('close', onClose);
+      resolve(outcome);
+    };
+
+    const onData = (chunk: Buffer | string): void => {
+      const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+      // Charge every source chunk against the invocation-wide aggregate
+      // source-observation budget shared across all files, roots, and
+      // strategies — even for no-match content — so a huge no-match input
+      // cannot be read without bound and no file receives a fresh budget.
+      // One-over semantics: reading exactly the remaining budget is complete
+      // if EOF occurs; the first chunk beyond it proves partiality.
+      if (buf.length > state.semanticBudget.sourceBytes) {
+        filePartial = true;
+        state.budgetExhausted = true;
+        stream.destroy();
+        return;
+      }
+      state.semanticBudget.sourceBytes -= buf.length;
+      framer.feedChunk(buf, (line) => {
+        if (retainLine(line)) stream.destroy();
+      });
+      if (state.earlyStopped || framer.wasLineDropped) {
+        filePartial = filePartial || framer.wasLineDropped;
+        stream.destroy();
+      }
+    };
+
+    const onEnd = (): void => {
+      // Clean EOF: flush remaining framed lines, then settle complete.
+      if (!state.earlyStopped && !filePartial) {
+        framer.flushRemaining((line) => {
+          retainLine(line);
+        });
+      }
+      settle({ partial: filePartial });
+    };
+
+    const onError = (readError: NodeJS.ErrnoException): void => {
+      if (!isNodeError(readError) || readError.code !== 'ENOENT') {
+        debugLogger.debug(
+          `GrepLogic: Could not read/process ${filePath}: ${getErrorMessage(readError)}`,
+        );
+      }
+      // A read error means this file was not exhaustively processed; mark the
+      // aggregate result partial. Do not throw — the fallback continues with
+      // remaining files. The single settle below prevents double resolution.
+      filePartial = true;
+    };
+
+    const onClose = (): void => {
+      // 'close' is the authoritative settlement for non-clean paths (destroy
+      // from early-stop/budget/abort, read error, or premature close before end).
+      settle({ partial: filePartial });
+    };
+
+    stream.on('data', onData);
+    stream.on('end', onEnd);
+    stream.on('error', onError);
+    stream.on('close', onClose);
+    if (abortSignal.aborted) {
+      onAbort();
+    } else {
+      abortSignal.addEventListener('abort', onAbort, { once: true });
     }
-    return;
-  }
-  const lines = content.split(/\r?\n/);
-  for (let i = 0; i < lines.length && !state.earlyStopped; i++) {
-    if (regex.test(lines[i])) {
-      const match: GrepMatch = {
-        filePath:
-          path.relative(absolutePath, filePath) || path.basename(filePath),
-        lineNumber: i + 1,
-        line: lines[i],
-      };
-      retainGrepMatch(state, match, limits);
-    }
-  }
+  });
 }
 
 export async function javascriptGrepFallback(
@@ -75,13 +177,24 @@ export async function javascriptGrepFallback(
   const regex = new RegExp(pattern, 'i');
   const limits: GrepLimits = { maxResults, maxFiles, maxPerFile };
   const state = createGrepRetainState(semanticBudget);
+  let anyFilePartial = false;
 
   for await (const filePath of filesStream) {
-    if (state.earlyStopped) break;
-    await processFallbackFile(state, filePath, absolutePath, regex, limits);
+    if (state.earlyStopped || state.budgetExhausted || abortSignal.aborted)
+      break;
+    const outcome = await processFallbackFile(
+      state,
+      filePath,
+      absolutePath,
+      regex,
+      limits,
+      abortSignal,
+    );
+    anyFilePartial = anyFilePartial || outcome.partial;
   }
 
-  const incomplete = state.earlyStopped || state.budgetExhausted;
+  const incomplete =
+    state.earlyStopped || state.budgetExhausted || anyFilePartial;
   const totalFoundValue =
     incomplete || state.observedCount <= state.usableCount
       ? undefined

--- a/packages/tools/src/tools/grep/search-strategies.ts
+++ b/packages/tools/src/tools/grep/search-strategies.ts
@@ -9,7 +9,6 @@
  * Extracted from grep.ts to keep the main file focused on the tool facade.
  */
 
-import fsPromises from 'fs/promises';
 import path from 'path';
 import { spawn } from 'child_process';
 
@@ -682,52 +681,29 @@ async function trySystemGrepStrategy(
   );
 }
 
-/**
- * Executes a single-file search and returns matches.
- */
-export async function performSingleFileSearch(
-  pattern: string,
-  filePath: string,
-  signal: AbortSignal,
-): Promise<GrepMatch[]> {
-  if (signal.aborted) {
-    return [];
-  }
-
-  const regex = new RegExp(pattern, 'i');
-  const content = await fsPromises.readFile(filePath, 'utf8');
-  const lines = content.split(/\r?\n/);
-  const matches: GrepMatch[] = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    if (regex.test(lines[i])) {
-      matches.push({
-        filePath: path.basename(filePath),
-        lineNumber: i + 1,
-        line: lines[i],
-      });
-    }
-  }
-
-  return matches;
-}
-
 function snapshotBudget(budget: SemanticBudget): {
   remainingBytes: number;
   remainingObjects: number;
+  sourceBytes: number;
 } {
   return {
     remainingBytes: budget.remainingBytes,
     remainingObjects: budget.remainingObjects,
+    sourceBytes: budget.sourceBytes,
   };
 }
 
 function restoreBudget(
   budget: SemanticBudget,
-  snapshot: { remainingBytes: number; remainingObjects: number },
+  snapshot: {
+    remainingBytes: number;
+    remainingObjects: number;
+    sourceBytes: number;
+  },
 ): void {
   budget.remainingBytes = snapshot.remainingBytes;
   budget.remainingObjects = snapshot.remainingObjects;
+  budget.sourceBytes = snapshot.sourceBytes;
 }
 
 /**

--- a/packages/tools/src/tools/grep/single-file-search.ts
+++ b/packages/tools/src/tools/grep/single-file-search.ts
@@ -1,0 +1,264 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Bounded single-file streaming search for the grep tool.
+ *
+ * Reads a single file incrementally through a {@link BoundedLineFramer},
+ * charging every source chunk against a finite observation budget and capping
+ * retained matches at one-over the record budget. Extracted from
+ * search-strategies.ts to keep that module under the source-size limit.
+ *
+ * @plan PLAN-20260211-ASTGREP.P05
+ */
+
+import { createReadStream } from 'fs';
+import path from 'path';
+
+import type { GrepMatch } from './types.js';
+import { BoundedLineFramer } from '../../utils/lineFramer.js';
+import {
+  type SemanticBudget,
+  type GrepLimits,
+  type GrepRetainState,
+  createAggregateSemanticBudget,
+  createGrepRetainState,
+  normalizeSourceBudgetBytes,
+  retainGrepMatch,
+} from './grepBudget.js';
+
+/** Default limits for single-file search when no explicit limits are supplied. */
+const SINGLE_FILE_DEFAULT_MAX_RESULTS = 1000;
+const SINGLE_FILE_DEFAULT_MAX_PER_FILE = 50;
+
+/** Per-invocation source-observation limits for a single-file search. */
+export interface SingleFileLimits {
+  maxResults: number;
+  maxPerFile: number;
+  /** Finite source-observation byte budget; charged per read chunk. */
+  sourceBudgetBytes?: number;
+}
+
+/**
+ * Result of a bounded single-file search. Includes truncation metadata so
+ * callers can produce non-exhaustive wording and structured partial info.
+ */
+export interface SingleFileSearchResult {
+  matches: GrepMatch[];
+  truncated: boolean;
+  observedCount: number;
+  lineDropped: boolean;
+  /**
+   * Whether the source stream was only partially observed (abort, read error,
+   * or premature close before clean end). When true the result is a lower
+   * bound on the file's true matches.
+   */
+  sourcePartial: boolean;
+}
+
+/** Mutable context carried through a single-file streaming search. */
+interface SingleFileSearchContext {
+  readonly filePath: string;
+  readonly regex: RegExp;
+  readonly state: GrepRetainState;
+  readonly framer: BoundedLineFramer;
+  readonly basename: string;
+  readonly effectiveLimits: GrepLimits;
+  readonly sourceBudgetBytes: number;
+  observedSourceBytes: number;
+  lineNumber: number;
+  settled: boolean;
+  sourcePartial: boolean;
+}
+
+/**
+ * Executes a single-file search using streaming line framing with finite
+ * byte/record budgets.
+ *
+ * The file is read incrementally via {@link createReadStream} and framed
+ * through a {@link BoundedLineFramer}, avoiding whole-file materialization.
+ * Every read chunk is charged against a finite source-observation byte budget
+ * — even when the pattern never matches — so a huge no-match file cannot be
+ * read without bound; one-over stops the read and marks the result partial.
+ * Overlong lines (exceeding the framer max) are dropped and reported via
+ * {@link SingleFileSearchResult.lineDropped}. When a finite
+ * {@link SemanticBudget} is supplied, retained matches are capped at
+ * one-over the configured record budget via {@link retainGrepMatch}.
+ *
+ * Stream settlement is guarded by a single `settled` flag so end, error,
+ * abort, and premature close never double-settle or mutate state after the
+ * first settlement. A clean `end` is the only complete outcome; a `close`
+ * without a prior settle is a premature close marked as partial. An abort is
+ * resolved as a partial result rather than rejected.
+ */
+export async function performSingleFileSearch(
+  pattern: string,
+  filePath: string,
+  signal: AbortSignal,
+  limits?: SingleFileLimits,
+  semanticBudget?: SemanticBudget,
+): Promise<SingleFileSearchResult> {
+  if (signal.aborted) {
+    return {
+      matches: [],
+      truncated: true,
+      observedCount: 0,
+      lineDropped: false,
+      sourcePartial: true,
+    };
+  }
+  const ctx = createSingleFileSearchContext(
+    pattern,
+    filePath,
+    limits,
+    semanticBudget,
+  );
+  return driveSingleFileStream(ctx, signal);
+}
+
+function createSingleFileSearchContext(
+  pattern: string,
+  filePath: string,
+  limits: SingleFileLimits | undefined,
+  semanticBudget: SemanticBudget | undefined,
+): SingleFileSearchContext {
+  const budget = semanticBudget ?? createAggregateSemanticBudget();
+  return {
+    filePath,
+    regex: new RegExp(pattern, 'i'),
+    state: createGrepRetainState(budget),
+    framer: new BoundedLineFramer(),
+    basename: path.basename(filePath),
+    effectiveLimits: {
+      maxResults: limits?.maxResults ?? SINGLE_FILE_DEFAULT_MAX_RESULTS,
+      maxPerFile: limits?.maxPerFile ?? SINGLE_FILE_DEFAULT_MAX_PER_FILE,
+      maxFiles: 1,
+    },
+    sourceBudgetBytes: normalizeSourceBudgetBytes(
+      limits?.sourceBudgetBytes ?? budget.sourceBytes,
+    ),
+    observedSourceBytes: 0,
+    lineNumber: 0,
+    settled: false,
+    sourcePartial: false,
+  };
+}
+
+function isSingleFileTruncated(ctx: SingleFileSearchContext): boolean {
+  const limitHit =
+    ctx.state.earlyStopped ||
+    ctx.state.budgetExhausted ||
+    ctx.state.observedCount > ctx.state.usableCount;
+  return limitHit || ctx.framer.wasLineDropped || ctx.sourcePartial;
+}
+
+function finalizeSingleFileResult(
+  ctx: SingleFileSearchContext,
+): SingleFileSearchResult {
+  return {
+    matches: ctx.state.matches,
+    truncated: isSingleFileTruncated(ctx),
+    observedCount: ctx.state.observedCount,
+    lineDropped: ctx.framer.wasLineDropped,
+    sourcePartial: ctx.sourcePartial,
+  };
+}
+
+function driveSingleFileStream(
+  ctx: SingleFileSearchContext,
+  signal: AbortSignal,
+): Promise<SingleFileSearchResult> {
+  return new Promise<SingleFileSearchResult>((resolve, reject) => {
+    const stream = createReadStream(ctx.filePath);
+
+    const onAbort = (): void => {
+      ctx.sourcePartial = true;
+      stream.destroy();
+      // destroy drives the stream toward 'close', which settles
+      // authoritatively as a partial result.
+    };
+
+    const detachAll = (): void => {
+      stream.removeAllListeners();
+      signal.removeEventListener('abort', onAbort);
+    };
+
+    const settleResolve = (value: SingleFileSearchResult): void => {
+      if (ctx.settled) return;
+      ctx.settled = true;
+      detachAll();
+      resolve(value);
+    };
+
+    const settleReject = (error: Error): void => {
+      if (ctx.settled) return;
+      ctx.settled = true;
+      detachAll();
+      reject(error);
+    };
+
+    const processLine = (line: string): void => {
+      ctx.lineNumber++;
+      if (ctx.state.earlyStopped) return;
+      if (ctx.regex.test(line)) {
+        retainGrepMatch(
+          ctx.state,
+          { filePath: ctx.basename, lineNumber: ctx.lineNumber, line },
+          ctx.effectiveLimits,
+        );
+      }
+    };
+
+    const onData = (chunk: Buffer | string): void => {
+      // createReadStream without an encoding always emits Buffer chunks;
+      // narrow to Buffer directly. The string path satisfies the Node.js
+      // stream type contract but is never taken at runtime.
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      ctx.observedSourceBytes += buf.length;
+      if (ctx.observedSourceBytes > ctx.sourceBudgetBytes) {
+        ctx.sourcePartial = true;
+        stream.destroy();
+        return;
+      }
+      ctx.framer.feedChunk(buf, processLine);
+      if (ctx.state.earlyStopped) {
+        ctx.sourcePartial = true;
+        stream.destroy();
+      }
+    };
+
+    const onEnd = (): void => {
+      if (!ctx.state.earlyStopped) {
+        ctx.framer.flushRemaining(processLine);
+      }
+      settleResolve(finalizeSingleFileResult(ctx));
+    };
+
+    const onError = (err: NodeJS.ErrnoException): void => {
+      // An abort-driven destroy may surface as an AbortError here; treat it as
+      // a partial result, not a thrown error. A genuine read/open error is
+      // surfaced to the caller (fail fast).
+      if (signal.aborted || err.name === 'AbortError') {
+        ctx.sourcePartial = true;
+        return;
+      }
+      settleReject(err);
+    };
+
+    const onClose = (): void => {
+      // 'close' without a prior clean 'end' settle is a premature close
+      // (abort, source-budget overrun, or unexpected termination). The
+      // settled flag guarantees we only ever take one settlement path.
+      settleResolve(finalizeSingleFileResult(ctx));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    stream.on('data', onData);
+    stream.on('end', onEnd);
+    stream.on('error', onError);
+    stream.on('close', onClose);
+  });
+}

--- a/packages/tools/src/tools/grep/streaming-single-file.test.ts
+++ b/packages/tools/src/tools/grep/streaming-single-file.test.ts
@@ -1,0 +1,385 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { writeFileSync, mkdirSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { performSingleFileSearch } from './single-file-search.js';
+import { createAggregateSemanticBudget } from './grepBudget.js';
+
+function createTempDir(prefix = 'llxprt-single-file-stream-'): {
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = join(
+    tmpdir(),
+    `${prefix}${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return {
+    dir,
+    cleanup: () => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+describe('performSingleFileSearch — streaming acquisition', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('reads all matches from a normal file', async () => {
+    writeFileSync(join(tempDir, 'test.txt'), 'hello match\nworld\nfoo match\n');
+
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'test.txt'),
+      new AbortController().signal,
+    );
+
+    expect(result.matches).toHaveLength(2);
+    expect(result.matches[0].lineNumber).toBe(1);
+    expect(result.matches[1].lineNumber).toBe(3);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('handles CRLF line endings correctly', async () => {
+    writeFileSync(
+      join(tempDir, 'crlf.txt'),
+      'hello match\r\nworld\r\nfoo match\r\n',
+    );
+
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'crlf.txt'),
+      new AbortController().signal,
+    );
+
+    expect(result.matches).toHaveLength(2);
+    // Lines should not contain carriage returns.
+    for (const match of result.matches) {
+      expect(match.line).not.toContain('\r');
+    }
+  });
+
+  it('handles multibyte UTF-8 content', async () => {
+    writeFileSync(
+      join(tempDir, 'mb.txt'),
+      '世界 match\nこんにちは match\nhello\n',
+    );
+
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'mb.txt'),
+      new AbortController().signal,
+    );
+
+    expect(result.matches).toHaveLength(2);
+    expect(result.matches[0].line).toContain('世界');
+    expect(result.matches[1].line).toContain('こんにちは');
+  });
+
+  it('does not materialize a huge line into memory (bounded by line framer)', async () => {
+    // A single line of 5 MiB — far exceeding the default 1 MiB max line.
+    const hugeLine = 'match ' + 'x'.repeat(5 * 1024 * 1024);
+    writeFileSync(join(tempDir, 'huge.txt'), hugeLine);
+
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'huge.txt'),
+      new AbortController().signal,
+    );
+
+    // The overlong line is dropped by the line framer, so no match is retained.
+    expect(result.matches).toHaveLength(0);
+    // Line drop must be reported so the result is not presented as exhaustive.
+    expect(result.lineDropped).toBe(true);
+  });
+
+  it('returns no matches for a non-matching pattern', async () => {
+    writeFileSync(join(tempDir, 'test.txt'), 'hello\nworld\n');
+
+    const result = await performSingleFileSearch(
+      'nonexistent',
+      join(tempDir, 'test.txt'),
+      new AbortController().signal,
+    );
+
+    expect(result.matches).toHaveLength(0);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('truncates when record budget is exceeded (one-over sentinel)', async () => {
+    // Create 100 matching lines.
+    const lines = Array.from({ length: 100 }, (_, i) => `match line ${i}`).join(
+      '\n',
+    );
+    writeFileSync(join(tempDir, 'many.txt'), lines);
+
+    const budget = createAggregateSemanticBudget();
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'many.txt'),
+      new AbortController().signal,
+      { maxResults: 10, maxPerFile: 10 },
+      budget,
+    );
+
+    // Must retain at most 10 matches.
+    expect(result.matches.length).toBeLessThanOrEqual(10);
+    // must indicate truncation.
+    expect(result.truncated).toBe(true);
+    // observedCount must be greater than retained matches.
+    expect(result.observedCount).toBeGreaterThan(result.matches.length);
+  });
+
+  it('truncates when byte budget is exhausted', async () => {
+    // Create lines where each match is large enough to exhaust the budget.
+    const longLine = 'match ' + 'Y'.repeat(10_000);
+    const lines = Array.from({ length: 100 }, () => longLine).join('\n');
+    writeFileSync(join(tempDir, 'big-matches.txt'), lines);
+
+    // Give a tiny byte budget so only a few matches can be retained.
+    const budget = createAggregateSemanticBudget();
+    budget.remainingBytes = 5000;
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'big-matches.txt'),
+      new AbortController().signal,
+      { maxResults: 1000, maxPerFile: 1000 },
+      budget,
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.matches.length).toBeLessThan(100);
+  });
+
+  it('reports observedCount for exact tracking', async () => {
+    writeFileSync(join(tempDir, 'test.txt'), 'match\nmatch\nmatch\n');
+
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'test.txt'),
+      new AbortController().signal,
+    );
+
+    expect(result.observedCount).toBe(3);
+    expect(result.matches).toHaveLength(3);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('respects an already-aborted signal', async () => {
+    writeFileSync(join(tempDir, 'test.txt'), 'match\nmatch\n');
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'test.txt'),
+      controller.signal,
+    );
+
+    // Pre-aborted acquisition is explicit partial/aborted metadata: no file
+    // content was observed, and the result must not present as exhaustive.
+    expect(result.matches).toHaveLength(0);
+    expect(result.truncated).toBe(true);
+    expect(result.sourcePartial).toBe(true);
+  });
+
+  it('streams a large file without materializing it whole', async () => {
+    // Create a 2 MiB file with many matching lines.
+    const lines: string[] = [];
+    for (let i = 0; i < 20_000; i++) {
+      lines.push(`match line ${i}`);
+    }
+    const filePath = join(tempDir, 'large.txt');
+    writeFileSync(filePath, lines.join('\n'));
+    const fileSize = statSync(filePath).size;
+
+    const result = await performSingleFileSearch(
+      'match',
+      filePath,
+      new AbortController().signal,
+      { maxResults: 50, maxPerFile: 50 },
+    );
+
+    // Retained matches must be bounded.
+    expect(result.matches.length).toBeLessThanOrEqual(50);
+    expect(result.truncated).toBe(true);
+    // The file is much larger than what we retained.
+    expect(fileSize).toBeGreaterThan(result.matches.length * 100);
+  });
+});
+
+describe('performSingleFileSearch — source-observation byte budget (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('charges every source chunk with one-over even when no matches', async () => {
+    // 100 KiB of non-matching content, far above a small source budget.
+    const noMatch = Array.from(
+      { length: 2000 },
+      () => 'nomatch line padding',
+    ).join('\n');
+    writeFileSync(join(tempDir, 'big.txt'), noMatch);
+
+    const budget = createAggregateSemanticBudget();
+    const result = await performSingleFileSearch(
+      'zzz-no-such-pattern',
+      join(tempDir, 'big.txt'),
+      new AbortController().signal,
+      { maxResults: 1000, maxPerFile: 1000, sourceBudgetBytes: 4096 },
+      budget,
+    );
+
+    // Zero matches but the source budget must still be enforced: the result
+    // is partial (truncated), proving the file was not exhaustively read.
+    expect(result.matches).toHaveLength(0);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('stays complete when the source fits exactly within the budget', async () => {
+    writeFileSync(join(tempDir, 'fit.txt'), 'match a\nmatch b\nmatch c\n');
+
+    const budget = createAggregateSemanticBudget();
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'fit.txt'),
+      new AbortController().signal,
+      { maxResults: 1000, maxPerFile: 1000, sourceBudgetBytes: 4096 },
+      budget,
+    );
+
+    expect(result.matches).toHaveLength(3);
+    expect(result.truncated).toBe(false);
+  });
+});
+
+describe('performSingleFileSearch — invocation limits exact/one-over (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('exact maxResults stays complete', async () => {
+    writeFileSync(
+      join(tempDir, 'exact.txt'),
+      'match\nmatch\nmatch\nmatch\nmatch\n',
+    );
+
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'exact.txt'),
+      new AbortController().signal,
+      { maxResults: 5, maxPerFile: 5, sourceBudgetBytes: 1_000_000 },
+    );
+
+    expect(result.matches).toHaveLength(5);
+    expect(result.truncated).toBe(false);
+    expect(result.observedCount).toBe(5);
+  });
+
+  it('one-over maxResults marks partial', async () => {
+    writeFileSync(
+      join(tempDir, 'over.txt'),
+      'match\nmatch\nmatch\nmatch\nmatch\n',
+    );
+
+    const result = await performSingleFileSearch(
+      'match',
+      join(tempDir, 'over.txt'),
+      new AbortController().signal,
+      { maxResults: 3, maxPerFile: 10, sourceBudgetBytes: 1_000_000 },
+    );
+
+    expect(result.matches.length).toBeLessThanOrEqual(3);
+    expect(result.truncated).toBe(true);
+    expect(result.observedCount).toBeGreaterThan(result.matches.length);
+    expect(result.sourcePartial).toBe(true);
+  });
+});
+
+describe('performSingleFileSearch — guarded settlement (issue #3202)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('mid-read abort resolves as partial rather than rejecting', async () => {
+    const big = Array.from({ length: 50000 }, (_, i) => 'match line ' + i).join(
+      '\n',
+    );
+    writeFileSync(join(tempDir, 'stream.txt'), big);
+
+    const controller = new AbortController();
+    const promise = performSingleFileSearch(
+      'match',
+      join(tempDir, 'stream.txt'),
+      controller.signal,
+      {
+        maxResults: 100_000,
+        maxPerFile: 100_000,
+        sourceBudgetBytes: 100_000_000,
+      },
+    );
+    // Abort synchronously before the read stream can complete.
+    controller.abort();
+    const result = await promise;
+
+    // Must settle as a partial result, NOT throw.
+    expect(result.truncated).toBe(true);
+  });
+
+  it('a read error on a missing file is surfaced (no double settle)', async () => {
+    const result = performSingleFileSearch(
+      'match',
+      join(tempDir, 'does-not-exist.txt'),
+      new AbortController().signal,
+    );
+    await expect(result).rejects.toThrow('ENOENT');
+  });
+});

--- a/packages/tools/src/tools/read-many-files-content.ts
+++ b/packages/tools/src/tools/read-many-files-content.ts
@@ -1,0 +1,320 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Content-assembly helpers extracted from read-many-files.ts to keep the
+ * source file under the line-size limit. These functions add file content
+ * (text or binary) to the output accumulator while enforcing per-file token
+ * and aggregate-byte budgets, preserving the one-over semantics and
+ * UTF-8-safe truncation behavior of the original tool.
+ *
+ * @plan PLAN-20260810-ISSUE3202
+ */
+
+import { type ContentPartUnion } from '../types/wire-types.js';
+import { type ProcessedFileReadResult } from '../utils/fileUtils.js';
+import { estimateNonTextPartTokens } from '../utils/imageTokenEstimation.js';
+import {
+  completeUtf8PrefixLength,
+  type ByteBudget,
+} from '../acquisition/index.js';
+
+/** Resolved limits used by the content-assembly and overflow handlers. */
+export interface ReadManyFilesLimits {
+  maxFileCount: number;
+  maxTokens: number;
+  truncateMode: 'warn' | 'truncate' | 'sample';
+  fileSizeLimit: number;
+}
+
+/** Action the caller should take after a content-addition attempt. */
+export type AddFileContentAction = 'continue' | 'stop' | 'stopAfterRecord';
+
+export interface AddFileContentResult {
+  totalTokens: number;
+  totalBytes: number;
+  action: AddFileContentAction;
+}
+
+export const DEFAULT_OUTPUT_SEPARATOR_FORMAT = '--- {filePath} ---';
+export const DEFAULT_OUTPUT_TERMINATOR = '\n--- End of content ---';
+
+type SkippedFilesArray = Array<{ path: string; reason: string }>;
+
+/** Simple token estimation — roughly 4 characters per token. */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Truncate a string to at most `maxBytes` UTF-8 bytes without splitting a
+ * multibyte character: the cut is moved back to the nearest complete
+ * character boundary so the decoded output stays valid UTF-8 text.
+ */
+function truncateUtf8Safe(str: string, maxBytes: number): string {
+  if (maxBytes <= 0) return '';
+  const buf = Buffer.from(str, 'utf8');
+  if (buf.length <= maxBytes) return str;
+  const validPrefix = completeUtf8PrefixLength(buf.subarray(0, maxBytes));
+  return buf.subarray(0, validPrefix).toString('utf8');
+}
+
+/**
+ * Truncate a string to at most `maxChars` UTF-16 code units without splitting
+ * a surrogate pair: if the character just before the cut is a high surrogate
+ * (first half of a pair), the cut is moved back one position.
+ */
+function truncateUtf16Safe(str: string, maxChars: number): string {
+  if (maxChars <= 0) return '';
+  if (str.length <= maxChars) return str;
+  let cut = maxChars;
+  if (
+    cut > 0 &&
+    str.charCodeAt(cut - 1) >= 0xd800 &&
+    str.charCodeAt(cut - 1) <= 0xdbff
+  ) {
+    cut--;
+  }
+  return str.substring(0, cut);
+}
+
+/**
+ * Add one file's content to the output accumulator, dispatching between text
+ * and non-text (image/PDF) content. Returns the action the caller should take.
+ */
+export function addFileContent(
+  fileReadResult: ProcessedFileReadResult,
+  filePath: string,
+  relativePathForDisplay: string,
+  skippedFiles: SkippedFilesArray,
+  contentParts: Array<string | ContentPartUnion>,
+  limits: ReadManyFilesLimits,
+  totalTokens: number,
+  totalBytes: number,
+  aggregateByteBudget: ByteBudget,
+  sortedFiles: string[],
+  processedFilesRelativePaths: string[],
+): AddFileContentResult {
+  if (typeof fileReadResult.llmContent === 'string') {
+    return addTextFileContent(
+      fileReadResult,
+      filePath,
+      relativePathForDisplay,
+      skippedFiles,
+      contentParts,
+      limits,
+      totalTokens,
+      totalBytes,
+      aggregateByteBudget,
+      sortedFiles,
+      processedFilesRelativePaths,
+    );
+  }
+
+  // Non-text content (images/PDFs). No provider is available at the tool
+  // layer, so image estimates use the provider-agnostic default family.
+  const inlineData = fileReadResult.llmContent.inlineData;
+  const estimatedTokens = estimateNonTextPartTokens(
+    inlineData?.mimeType,
+    inlineData?.data,
+  );
+  const contentBytes = Buffer.byteLength(inlineData?.data ?? '', 'utf8');
+
+  if (totalTokens + estimatedTokens > limits.maxTokens) {
+    skippedFiles.push({
+      path: relativePathForDisplay,
+      reason: 'would exceed token limit (non-text content)',
+    });
+    return { totalTokens, totalBytes, action: 'continue' };
+  }
+  if (totalBytes + contentBytes > aggregateByteBudget.bytes) {
+    skippedFiles.push({
+      path: relativePathForDisplay,
+      reason: `would exceed aggregate byte budget (${aggregateByteBudget.bytes.toLocaleString('en-US')} bytes)`,
+    });
+    return { totalTokens, totalBytes, action: 'continue' };
+  }
+  totalTokens += estimatedTokens;
+  totalBytes += contentBytes;
+  contentParts.push(fileReadResult.llmContent);
+  return { totalTokens, totalBytes, action: 'continue' };
+}
+
+function addTextFileContent(
+  fileReadResult: ProcessedFileReadResult,
+  filePath: string,
+  relativePathForDisplay: string,
+  skippedFiles: SkippedFilesArray,
+  contentParts: Array<string | ContentPartUnion>,
+  limits: ReadManyFilesLimits,
+  totalTokens: number,
+  totalBytes: number,
+  aggregateByteBudget: ByteBudget,
+  sortedFiles: string[],
+  processedFilesRelativePaths: string[],
+): AddFileContentResult {
+  const separator = DEFAULT_OUTPUT_SEPARATOR_FORMAT.replace(
+    '{filePath}',
+    filePath,
+  );
+  let fileContentForLlm = '';
+
+  if (fileReadResult.isTruncated === true) {
+    fileContentForLlm += `[WARNING: This file was truncated. To view the full content, use the 'read_file' tool on this specific file.]\n\n`;
+  }
+  fileContentForLlm += fileReadResult.llmContent as string;
+  const contentToAdd = `${separator}\n\n${fileContentForLlm}\n\n`;
+  const contentTokens = estimateTokens(contentToAdd);
+  const contentBytes = Buffer.byteLength(contentToAdd, 'utf8');
+
+  const overTokens = totalTokens + contentTokens > limits.maxTokens;
+  const overBytes = totalBytes + contentBytes > aggregateByteBudget.bytes;
+
+  // The aggregate byte budget is the hard acquisition cap. Check it FIRST so
+  // the final assembled output (content + terminator) can never exceed the
+  // acquisition budget. Token overflow is a model-facing soft cap handled
+  // only when the content fits within the byte budget.
+  if (overBytes) {
+    return handleByteOverflow(
+      limits,
+      relativePathForDisplay,
+      sortedFiles,
+      processedFilesRelativePaths,
+      contentParts,
+      contentToAdd,
+      totalTokens,
+      totalBytes,
+      aggregateByteBudget,
+      skippedFiles,
+    );
+  }
+  if (overTokens) {
+    return handleTokenOverflow(
+      limits,
+      relativePathForDisplay,
+      sortedFiles,
+      processedFilesRelativePaths,
+      contentParts,
+      contentToAdd,
+      totalTokens,
+      totalBytes,
+      skippedFiles,
+    );
+  }
+
+  totalTokens += contentTokens;
+  totalBytes += contentBytes;
+  contentParts.push(contentToAdd);
+  return { totalTokens, totalBytes, action: 'continue' };
+}
+
+function handleTokenOverflow(
+  limits: ReadManyFilesLimits,
+  relativePathForDisplay: string,
+  sortedFiles: string[],
+  processedFilesRelativePaths: string[],
+  contentParts: Array<string | ContentPartUnion>,
+  contentToAdd: string,
+  totalTokens: number,
+  totalBytes: number,
+  skippedFiles: SkippedFilesArray,
+): AddFileContentResult {
+  if (limits.truncateMode === 'warn') {
+    skippedFiles.push({
+      path: `${sortedFiles.length - processedFilesRelativePaths.length} remaining file(s)`,
+      reason: `would exceed token limit of ${limits.maxTokens}`,
+    });
+    return { totalTokens, totalBytes, action: 'stop' };
+  } else if (limits.truncateMode === 'truncate') {
+    const remainingTokens = limits.maxTokens - totalTokens;
+    if (remainingTokens > 100) {
+      const marker = '\n\n[CONTENT TRUNCATED DUE TO TOKEN LIMIT]';
+      // Model-facing token truncation: cut to the remaining token budget
+      // (≈4 chars/token) using surrogate-safe UTF-16 truncation so a
+      // surrogate pair is never split. Token policy stays separate from the
+      // acquisition byte policy; the actual UTF-8 bytes are charged below.
+      const maxChars = remainingTokens * 4 - Buffer.byteLength(marker, 'utf8');
+      const truncatedContent = truncateUtf16Safe(contentToAdd, maxChars);
+      const finalContent = truncatedContent + marker;
+      contentParts.push(finalContent);
+      const updatedTokens = totalTokens + estimateTokens(finalContent);
+      // Charge the actual UTF-8 bytes (multibyte content can add more bytes
+      // than the char count suggests). The terminator bytes are already
+      // pre-charged in totalBytes by the caller.
+      const updatedBytes = totalBytes + Buffer.byteLength(finalContent, 'utf8');
+      skippedFiles.push({
+        path: relativePathForDisplay,
+        reason: 'content truncated to fit token limit',
+      });
+      return {
+        totalTokens: updatedTokens,
+        totalBytes: updatedBytes,
+        action: 'stopAfterRecord',
+      };
+    }
+    return { totalTokens, totalBytes, action: 'stop' };
+  }
+  skippedFiles.push({
+    path: relativePathForDisplay,
+    reason: 'skipped to stay within token limit',
+  });
+  return { totalTokens, totalBytes, action: 'continue' };
+}
+
+function handleByteOverflow(
+  limits: ReadManyFilesLimits,
+  relativePathForDisplay: string,
+  sortedFiles: string[],
+  processedFilesRelativePaths: string[],
+  contentParts: Array<string | ContentPartUnion>,
+  contentToAdd: string,
+  totalTokens: number,
+  totalBytes: number,
+  aggregateByteBudget: ByteBudget,
+  skippedFiles: SkippedFilesArray,
+): AddFileContentResult {
+  if (limits.truncateMode === 'warn') {
+    skippedFiles.push({
+      path: `${sortedFiles.length - processedFilesRelativePaths.length} remaining file(s)`,
+      reason: `would exceed aggregate byte budget (${aggregateByteBudget.bytes.toLocaleString('en-US')} bytes)`,
+    });
+    return { totalTokens, totalBytes, action: 'stop' };
+  } else if (limits.truncateMode === 'truncate') {
+    const marker = '\n\n[CONTENT TRUNCATED DUE TO AGGREGATE BYTE BUDGET]';
+    // Reserve room for the truncation marker only — the final output
+    // terminator bytes are already pre-charged in totalBytes by the caller
+    // so the assembled output stays within the aggregate byte budget.
+    const reservedBytes = Buffer.byteLength(marker, 'utf8');
+    const remainingBytes =
+      aggregateByteBudget.bytes - totalBytes - reservedBytes;
+    if (remainingBytes > 200) {
+      const truncatedContent = truncateUtf8Safe(contentToAdd, remainingBytes);
+      const finalContent = truncatedContent + marker;
+      contentParts.push(finalContent);
+      const updatedBytes = totalBytes + Buffer.byteLength(finalContent, 'utf8');
+      const updatedTokens = totalTokens + estimateTokens(finalContent);
+      skippedFiles.push({
+        path: relativePathForDisplay,
+        reason: 'content truncated to fit aggregate byte budget',
+      });
+      return {
+        totalTokens: updatedTokens,
+        totalBytes: updatedBytes,
+        action: 'stopAfterRecord',
+      };
+    }
+    skippedFiles.push({
+      path: relativePathForDisplay,
+      reason: 'skipped to stay within aggregate byte budget',
+    });
+    return { totalTokens, totalBytes, action: 'stop' };
+  }
+  skippedFiles.push({
+    path: relativePathForDisplay,
+    reason: 'skipped to stay within aggregate byte budget',
+  });
+  return { totalTokens, totalBytes, action: 'continue' };
+}

--- a/packages/tools/src/tools/read-many-files.ts
+++ b/packages/tools/src/tools/read-many-files.ts
@@ -15,13 +15,12 @@ import type { IToolHost, IToolMessageBus } from '../interfaces/index.js';
 import { getErrorMessage } from '../utils/errors.js';
 import * as fs from 'fs';
 import * as path from 'path';
-import { glob, escape as globEscape } from 'glob';
+import { globStream, escape as globEscape } from 'glob';
 import {
   createImageConfigurationToolResult,
   getImageBudgetToolResult,
   getImageResizeToolResult,
   getProcessedFileSkipReason,
-  type ProcessedFileReadResult,
   processSingleFileContent,
   DEFAULT_ENCODING,
   DEFAULT_MAX_LINES_TEXT_FILE,
@@ -39,26 +38,39 @@ import {
   resolveImageDimensionBudget,
   type ImageDimensionBudget,
 } from '../utils/imageDimensionBudget.js';
-import { estimateNonTextPartTokens } from '../utils/imageTokenEstimation.js';
+import {
+  addFileContent,
+  DEFAULT_OUTPUT_SEPARATOR_FORMAT,
+  DEFAULT_OUTPUT_TERMINATOR,
+  type ReadManyFilesLimits,
+} from './read-many-files-content.js';
 import {
   buildParameterSchema,
   formatExcludePatterns,
 } from './read-many-files-schema.js';
-
-// Simple token estimation - roughly 4 characters per token
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
-}
-
-type AddFileContentAction = 'continue' | 'stop' | 'stopAfterRecord';
-
-interface AddFileContentResult {
-  totalTokens: number;
-  action: AddFileContentAction;
-}
+import {
+  createDefaultByteBudget,
+  type ByteBudget,
+} from '../acquisition/index.js';
 
 type ProcessFilesResult = Readonly<{ totalTokens: number; error?: ToolResult }>;
-type ProcessSingleFileResult = ProcessFilesResult & { readonly done: boolean };
+type ProcessSingleFileResult = ProcessFilesResult & {
+  readonly done: boolean;
+  readonly totalBytes: number;
+};
+
+/**
+ * Invocation-local finite discovery-record observation counter shared across
+ * ALL workspace roots. Every path emitted by the glob stream is one observed
+ * discovery record, charged BEFORE any filtering or deduplication — ignored
+ * records, security-skipped records, and duplicates all consume the budget.
+ * One-over semantics: exactly maxFileCount observed records is complete; the
+ * maxFileCount+1-th record proves `truncated` and is not retained/stored.
+ */
+interface DiscoveryRecordTracker {
+  observed: number;
+  truncated: boolean;
+}
 
 /**
  * Parameters for the ReadManyFilesTool.
@@ -116,14 +128,13 @@ function getDefaultExcludes(host?: IToolHost): string[] {
   return host?.getReadManyFilesExclusions() ?? [];
 }
 
-const DEFAULT_OUTPUT_SEPARATOR_FORMAT = '--- {filePath} ---';
-const DEFAULT_OUTPUT_TERMINATOR = '\n--- End of content ---';
-
 // Default limits for ReadManyFiles
 const DEFAULT_MAX_FILE_COUNT = 50;
 const DEFAULT_MAX_TOKENS = 50000;
 const DEFAULT_TRUNCATE_MODE = 'warn';
 const DEFAULT_FILE_SIZE_LIMIT = 524288; // 512KB
+/** Absolute ceiling on the number of files processed regardless of settings. */
+const MAX_FILE_COUNT_HARD_CAP = 10_000;
 
 class ReadManyFilesToolInvocation extends BaseToolInvocation<
   ReadManyFilesParams,
@@ -175,10 +186,17 @@ ${this.host.getTargetDir()}
     const { fileFilteringOptions, fileDiscovery, effectiveExcludes } =
       this.resolveFileParams(useDefaultExcludes, exclude);
 
+    const limits = this.resolveLimits();
+    const aggregateByteBudget = createDefaultByteBudget();
+
     const filesToConsider = new Set<string>();
     const skippedFiles: Array<{ path: string; reason: string }> = [];
     const processedFilesRelativePaths: string[] = [];
     const contentParts: Array<string | ContentPartUnion> = [];
+    const discoveryRecords: DiscoveryRecordTracker = {
+      observed: 0,
+      truncated: false,
+    };
 
     const searchResult = await this.discoverFiles(
       inputPatterns,
@@ -189,19 +207,20 @@ ${this.host.getTargetDir()}
       filesToConsider,
       skippedFiles,
       signal,
+      limits.maxFileCount,
+      discoveryRecords,
     );
-
     if (searchResult) {
       return searchResult;
     }
 
     const sortedFiles = Array.from(filesToConsider).sort();
 
-    const limits = this.resolveLimits();
     const fileCountResult = this.applyFileCountLimit(
       sortedFiles,
       skippedFiles,
       limits,
+      discoveryRecords.truncated,
     );
     if (fileCountResult) {
       return fileCountResult;
@@ -214,6 +233,7 @@ ${this.host.getTargetDir()}
       processedFilesRelativePaths,
       contentParts,
       limits,
+      aggregateByteBudget,
     );
   }
 
@@ -240,7 +260,8 @@ ${this.host.getTargetDir()}
     skippedFiles: Array<{ path: string; reason: string }>,
     processedFilesRelativePaths: string[],
     contentParts: Array<string | ContentPartUnion>,
-    limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
+    limits: ReadManyFilesLimits,
+    aggregateByteBudget: ByteBudget,
   ): Promise<ToolResult> {
     const processResult = await this.processFiles(
       sortedFiles,
@@ -249,6 +270,7 @@ ${this.host.getTargetDir()}
       processedFilesRelativePaths,
       contentParts,
       limits,
+      aggregateByteBudget,
     );
     if (processResult.error !== undefined) {
       return processResult.error;
@@ -285,37 +307,35 @@ ${this.host.getTargetDir()}
     filesToConsider: Set<string>,
     skippedFiles: Array<{ path: string; reason: string }>,
     signal: AbortSignal,
+    maxFileCount: number,
+    recordTracker: DiscoveryRecordTracker,
   ): Promise<ToolResult | undefined> {
     const searchPatterns = [...inputPatterns, ...include];
     try {
-      const allEntries = new Set<string>();
-      const workspaceDirs = this.host.getWorkspaceRoots();
+      const ignoredCounts = { git: 0, llxprt: 0 };
 
-      for (const dir of workspaceDirs) {
-        const processedPatterns = this.processSearchPatterns(
+      for (const dir of this.host.getWorkspaceRoots()) {
+        if (recordTracker.truncated) break;
+        await this.collectDirectoryFiles(
           dir,
           searchPatterns,
-        );
-        const entriesInDir = await glob(processedPatterns, {
-          cwd: dir,
-          ignore: effectiveExcludes,
-          nodir: true,
-          dot: true,
-          absolute: true,
-          nocase: true,
+          effectiveExcludes,
+          fileFilteringOptions,
+          fileDiscovery,
+          filesToConsider,
+          ignoredCounts,
+          skippedFiles,
           signal,
-        });
-        for (const entry of entriesInDir) {
-          allEntries.add(entry);
-        }
+          maxFileCount,
+          recordTracker,
+        );
       }
 
-      this.filterEntries(
-        Array.from(allEntries),
-        fileFilteringOptions,
-        fileDiscovery,
-        filesToConsider,
+      this.recordDiscoverySkippedFiles(
         skippedFiles,
+        ignoredCounts,
+        recordTracker.truncated,
+        maxFileCount,
       );
     } catch (error) {
       const errorMessage = `Error during file search: ${getErrorMessage(error)}`;
@@ -329,6 +349,92 @@ ${this.host.getTargetDir()}
       };
     }
     return undefined;
+  }
+
+  private async collectDirectoryFiles(
+    dir: string,
+    searchPatterns: string[],
+    effectiveExcludes: string[],
+    fileFilteringOptions: {
+      respectGitIgnore: boolean;
+      respectLlxprtIgnore: boolean;
+    },
+    fileDiscovery: ReturnType<IToolHost['getFileService']>,
+    filesToConsider: Set<string>,
+    ignoredCounts: { git: number; llxprt: number },
+    skippedFiles: Array<{ path: string; reason: string }>,
+    signal: AbortSignal,
+    maxFileCount: number,
+    recordTracker: DiscoveryRecordTracker,
+  ): Promise<void> {
+    const processedPatterns = this.processSearchPatterns(dir, searchPatterns);
+    const stream = globStream(processedPatterns, {
+      cwd: dir,
+      ignore: effectiveExcludes,
+      nodir: true,
+      dot: true,
+      absolute: true,
+      nocase: true,
+      signal,
+    });
+    for await (const absoluteFilePath of stream) {
+      // Charge every glob emission as ONE discovery record BEFORE any
+      // filtering or dedup — ignored, security-skipped, duplicate, and
+      // non-normalizable records all consume the shared invocation budget.
+      // One-over semantics: exactly maxFileCount records is complete; the
+      // maxFileCount+1-th record proves truncation and is NOT retained or
+      // stored (no Set entry, skip metadata, or ignored count for it).
+      recordTracker.observed++;
+      if (recordTracker.observed > maxFileCount) {
+        recordTracker.truncated = true;
+        return;
+      }
+      const result = this.checkFileFilter(
+        absoluteFilePath,
+        fileFilteringOptions,
+        fileDiscovery,
+      );
+      if (result.skipped) {
+        if (result.type === 'security') {
+          skippedFiles.push({
+            path: absoluteFilePath,
+            reason: result.reason ?? 'security',
+          });
+        }
+        if (result.type === 'git') ignoredCounts.git++;
+        if (result.type === 'llxprt') ignoredCounts.llxprt++;
+        continue;
+      }
+      if (result.normalizedPath) {
+        filesToConsider.add(result.normalizedPath);
+      }
+    }
+  }
+
+  private recordDiscoverySkippedFiles(
+    skippedFiles: Array<{ path: string; reason: string }>,
+    ignoredCounts: { git: number; llxprt: number },
+    discoveryTruncated: boolean,
+    maxFileCount: number,
+  ): void {
+    if (ignoredCounts.git > 0) {
+      skippedFiles.push({
+        path: `${ignoredCounts.git} file(s)`,
+        reason: 'git ignored',
+      });
+    }
+    if (ignoredCounts.llxprt > 0) {
+      skippedFiles.push({
+        path: `${ignoredCounts.llxprt} file(s)`,
+        reason: 'llxprt ignored',
+      });
+    }
+    if (discoveryTruncated) {
+      skippedFiles.push({
+        path: `discovery stopped at ${maxFileCount + 1} discovery record(s)`,
+        reason: `discovery record limit (${maxFileCount}); more matching records may exist`,
+      });
+    }
   }
 
   private processSearchPatterns(
@@ -347,53 +453,6 @@ ${this.host.getTargetDir()}
       }
     }
     return processedPatterns;
-  }
-
-  private filterEntries(
-    entries: string[],
-    fileFilteringOptions: {
-      respectGitIgnore: boolean;
-      respectLlxprtIgnore: boolean;
-    },
-    fileDiscovery: ReturnType<IToolHost['getFileService']>,
-    filesToConsider: Set<string>,
-    skippedFiles: Array<{ path: string; reason: string }>,
-  ): void {
-    let gitIgnoredCount = 0;
-    let llxprtIgnoredCount = 0;
-
-    for (const absoluteFilePath of entries) {
-      const result = this.checkFileFilter(
-        absoluteFilePath,
-        fileFilteringOptions,
-        fileDiscovery,
-      );
-      if (result.skipped) {
-        if (result.reason) {
-          skippedFiles.push({ path: absoluteFilePath, reason: result.reason });
-        }
-        if (result.type === 'git') gitIgnoredCount++;
-        if (result.type === 'llxprt') llxprtIgnoredCount++;
-        continue;
-      }
-      if (result.normalizedPath) {
-        filesToConsider.add(result.normalizedPath);
-      }
-    }
-
-    if (gitIgnoredCount > 0) {
-      skippedFiles.push({
-        path: `${gitIgnoredCount} file(s)`,
-        reason: 'git ignored',
-      });
-    }
-
-    if (llxprtIgnoredCount > 0) {
-      skippedFiles.push({
-        path: `${llxprtIgnoredCount} file(s)`,
-        reason: 'llxprt ignored',
-      });
-    }
   }
 
   private checkFileFilter(
@@ -443,17 +502,18 @@ ${this.host.getTargetDir()}
     return { skipped: false, normalizedPath };
   }
 
-  private resolveLimits(): {
-    maxFileCount: number;
-    maxTokens: number;
-    truncateMode: 'warn' | 'truncate' | 'sample';
-    fileSizeLimit: number;
-  } {
+  private resolveLimits(): ReadManyFilesLimits {
     const ephemeralSettings = this.host.getEphemeralSettings();
-    return {
-      maxFileCount:
-        (ephemeralSettings['tool-output-max-items'] as number | undefined) ??
+    const rawMaxItems = Number(
+      (ephemeralSettings['tool-output-max-items'] as number | undefined) ??
         DEFAULT_MAX_FILE_COUNT,
+    );
+    const maxFileCount =
+      Number.isFinite(rawMaxItems) && rawMaxItems > 0
+        ? Math.min(Math.floor(rawMaxItems), MAX_FILE_COUNT_HARD_CAP)
+        : DEFAULT_MAX_FILE_COUNT;
+    return {
+      maxFileCount,
       maxTokens:
         (ephemeralSettings['tool-output-max-tokens'] as number | undefined) ??
         DEFAULT_MAX_TOKENS,
@@ -473,17 +533,28 @@ ${this.host.getTargetDir()}
   private applyFileCountLimit(
     sortedFiles: string[],
     skippedFiles: Array<{ path: string; reason: string }>,
-    limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
+    limits: ReadManyFilesLimits,
+    discoveryTruncated: boolean,
   ): ToolResult | undefined {
-    if (sortedFiles.length <= limits.maxFileCount) {
+    const filesExceedCap = sortedFiles.length > limits.maxFileCount;
+    if (!filesExceedCap) {
+      if (discoveryTruncated && limits.truncateMode === 'warn')
+        skippedFiles.push({
+          path: `${limits.maxFileCount} discovery record limit`,
+          reason: 'discovery truncated; some matching files may not be listed',
+        });
       return undefined;
     }
 
     if (limits.truncateMode === 'warn') {
-      const warnMessage = `Found ${sortedFiles.length} files matching your pattern, but limiting to ${limits.maxFileCount} files. Please use more specific patterns to narrow your search.`;
+      // Discovery truncation is proven at the record level (one-over raw
+      // glob emissions). The retained unique-file count alone understates
+      // the traversal when records were skipped or deduplicated, so report
+      // the truthful lower bound rather than implying a known file count.
+      const warnMessage = `Found ${discoveryTruncated ? `more than ${limits.maxFileCount} matching discovery records` : `${sortedFiles.length} files matching your pattern`}, but limiting to ${limits.maxFileCount} files. Please use more specific patterns to narrow your search.`;
       return {
         llmContent: warnMessage,
-        returnDisplay: `## File Count Limit Exceeded\n\n${warnMessage}\n\n**Matched files:** ${sortedFiles.length}\n**Limit:** ${limits.maxFileCount}\n\n**Suggestion:** Use more specific glob patterns or paths to reduce the number of matched files.`,
+        returnDisplay: `## File Count Limit Exceeded\n\n${warnMessage}\n\n**Matched files:** ${discoveryTruncated ? `more than ${limits.maxFileCount}` : sortedFiles.length}\n**Limit:** ${limits.maxFileCount}\n\n**Suggestion:** Use more specific glob patterns or paths to reduce the number of matched files.`,
       };
     } else if (limits.truncateMode === 'sample') {
       const step = Math.ceil(sortedFiles.length / limits.maxFileCount);
@@ -517,7 +588,8 @@ ${this.host.getTargetDir()}
     skippedFiles: Array<{ path: string; reason: string }>,
     processedFilesRelativePaths: string[],
     contentParts: Array<string | ContentPartUnion>,
-    limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
+    limits: ReadManyFilesLimits,
+    aggregateByteBudget: ByteBudget,
   ): Promise<ProcessFilesResult> {
     const ephemeralSettings = this.host.getEphemeralSettings();
     // Resolve both image policies once from one settings snapshot inside one
@@ -538,6 +610,10 @@ ${this.host.getTargetDir()}
       (ephemeralSettings['file-read-max-lines'] as number | undefined) ??
       DEFAULT_MAX_LINES_TEXT_FILE;
     let totalTokens = 0;
+    // Pre-charge the output terminator bytes so every content path (ordinary,
+    // warn, truncate, overflow) accounts for it and the final complete output
+    // can never exceed the aggregate acquisition byte budget.
+    let totalBytes = Buffer.byteLength(DEFAULT_OUTPUT_TERMINATOR, 'utf8');
     for (const filePath of sortedFiles) {
       const result = await this.processSingleFile(
         filePath,
@@ -548,6 +624,8 @@ ${this.host.getTargetDir()}
         contentParts,
         limits,
         totalTokens,
+        totalBytes,
+        aggregateByteBudget,
         imageResizePolicy,
         imageBudget,
         maxLinesPerFile,
@@ -556,6 +634,7 @@ ${this.host.getTargetDir()}
         return result;
       }
       totalTokens = result.totalTokens;
+      totalBytes = result.totalBytes;
     }
     return { totalTokens };
   }
@@ -567,8 +646,10 @@ ${this.host.getTargetDir()}
     skippedFiles: Array<{ path: string; reason: string }>,
     processedFilesRelativePaths: string[],
     contentParts: Array<string | ContentPartUnion>,
-    limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
+    limits: ReadManyFilesLimits,
     currentTokens: number,
+    currentBytes: number,
+    aggregateByteBudget: ByteBudget,
     imageResizePolicy: ImageResizePolicy | undefined,
     imageBudget: ImageDimensionBudget | undefined,
     maxLinesPerFile: number,
@@ -586,11 +667,51 @@ ${this.host.getTargetDir()}
       imageBudget,
       imageResizePolicy !== undefined,
     );
-    if (gate.outcome === 'preflight-error') return gate.result;
-    if (gate.outcome === 'skip')
-      return { done: false, totalTokens: currentTokens };
-    const { resizeBeforeOutputLimit } = gate;
+    if (gate.outcome === 'preflight-error') {
+      return { ...gate.result, totalBytes: currentBytes };
+    }
+    if (gate.outcome === 'skip') {
+      return {
+        done: false,
+        totalTokens: currentTokens,
+        totalBytes: currentBytes,
+      };
+    }
 
+    return this.assembleFileContent(
+      filePath,
+      relativePathForDisplay,
+      gate.resizeBeforeOutputLimit,
+      sortedFiles,
+      skippedFiles,
+      processedFilesRelativePaths,
+      contentParts,
+      limits,
+      currentTokens,
+      currentBytes,
+      aggregateByteBudget,
+      imageResizePolicy,
+      imageBudget,
+      maxLinesPerFile,
+    );
+  }
+
+  private async assembleFileContent(
+    filePath: string,
+    relativePathForDisplay: string,
+    resizeBeforeOutputLimit: boolean,
+    sortedFiles: string[],
+    skippedFiles: Array<{ path: string; reason: string }>,
+    processedFilesRelativePaths: string[],
+    contentParts: Array<string | ContentPartUnion>,
+    limits: ReadManyFilesLimits,
+    currentTokens: number,
+    currentBytes: number,
+    aggregateByteBudget: ByteBudget,
+    imageResizePolicy: ImageResizePolicy | undefined,
+    imageBudget: ImageDimensionBudget | undefined,
+    maxLinesPerFile: number,
+  ): Promise<ProcessSingleFileResult> {
     const fileReadResult = await processSingleFileContent(
       filePath,
       this.host.getTargetDir(),
@@ -599,186 +720,62 @@ ${this.host.getTargetDir()}
       imageResizePolicy,
       imageBudget,
     );
-    const earlyResult = this.checkFileReadErrors(
-      fileReadResult,
-      currentTokens,
-      resizeBeforeOutputLimit,
-      relativePathForDisplay,
-      limits.fileSizeLimit,
-      skippedFiles,
-    );
-    if (earlyResult !== undefined) return earlyResult;
-
-    const addResult = this.addFileContent(
-      fileReadResult,
-      filePath,
-      relativePathForDisplay,
-      skippedFiles,
-      processedFilesRelativePaths,
-      contentParts,
-      limits,
-      currentTokens,
-      sortedFiles,
-    );
-
-    // Record as processed only when content was added; a warn-mode 'stop'
-    // pushes only a skip reason, so it must not be recorded.
-    if (addResult.action !== 'stop') {
-      processedFilesRelativePaths.push(relativePathForDisplay);
-      this.recordReadMetric(filePath, fileReadResult.llmContent);
-    }
-    return addResult.action === 'stop' || addResult.action === 'stopAfterRecord'
-      ? { done: true, totalTokens: addResult.totalTokens }
-      : { done: false, totalTokens: addResult.totalTokens };
-  }
-
-  private checkFileReadErrors(
-    fileReadResult: ProcessedFileReadResult,
-    currentTokens: number,
-    shouldResize: boolean,
-    relativePathForDisplay: string,
-    fileSizeLimit: number,
-    skippedFiles: Array<{ path: string; reason: string }>,
-  ): ProcessSingleFileResult | undefined {
-    const errorResult =
+    const imageError =
       getImageResizeToolResult(fileReadResult, currentTokens) ??
       getImageBudgetToolResult(fileReadResult, currentTokens);
-    if (errorResult !== undefined) return errorResult;
+    if (imageError !== undefined) {
+      return { ...imageError, totalBytes: currentBytes };
+    }
     const skipReason = getProcessedFileSkipReason(
       fileReadResult,
-      shouldResize,
-      fileSizeLimit,
+      resizeBeforeOutputLimit,
+      limits.fileSizeLimit,
     );
     if (skipReason !== undefined) {
       skippedFiles.push({ path: relativePathForDisplay, reason: skipReason });
-      return { done: false, totalTokens: currentTokens };
-    }
-    return undefined;
-  }
-  private addFileContent(
-    fileReadResult: ProcessedFileReadResult,
-    filePath: string,
-    relativePathForDisplay: string,
-    skippedFiles: Array<{ path: string; reason: string }>,
-    _processedFilesRelativePaths: string[],
-    contentParts: Array<string | ContentPartUnion>,
-    limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
-    totalTokens: number,
-    sortedFiles: string[],
-  ): AddFileContentResult {
-    if (typeof fileReadResult.llmContent === 'string') {
-      return this.addTextFileContent(
-        fileReadResult,
-        filePath,
-        relativePathForDisplay,
-        skippedFiles,
-        contentParts,
-        limits,
-        totalTokens,
-        sortedFiles,
-        _processedFilesRelativePaths,
-      );
+      return {
+        done: false,
+        totalTokens: currentTokens,
+        totalBytes: currentBytes,
+      };
     }
 
-    // Non-text content (images/PDFs). No provider is available at the tool
-    // layer, so image estimates use the provider-agnostic default family.
-    const inlineData = fileReadResult.llmContent.inlineData;
-    const estimatedTokens = estimateNonTextPartTokens(
-      inlineData?.mimeType,
-      inlineData?.data,
-    );
-
-    if (totalTokens + estimatedTokens > limits.maxTokens) {
-      skippedFiles.push({
-        path: relativePathForDisplay,
-        reason: 'would exceed token limit (non-text content)',
-      });
-      return { totalTokens, action: 'continue' };
-    }
-    totalTokens += estimatedTokens;
-    contentParts.push(fileReadResult.llmContent);
-    return { totalTokens, action: 'continue' };
-  }
-
-  private addTextFileContent(
-    fileReadResult: ProcessedFileReadResult,
-    filePath: string,
-    relativePathForDisplay: string,
-    skippedFiles: Array<{ path: string; reason: string }>,
-    contentParts: Array<string | ContentPartUnion>,
-    limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
-    totalTokens: number,
-    sortedFiles: string[],
-    processedFilesRelativePaths: string[],
-  ): AddFileContentResult {
-    const separator = DEFAULT_OUTPUT_SEPARATOR_FORMAT.replace(
-      '{filePath}',
+    const addResult = addFileContent(
+      fileReadResult,
       filePath,
+      relativePathForDisplay,
+      skippedFiles,
+      contentParts,
+      limits,
+      currentTokens,
+      currentBytes,
+      aggregateByteBudget,
+      sortedFiles,
+      processedFilesRelativePaths,
     );
-    let fileContentForLlm = '';
 
-    if (fileReadResult.isTruncated === true) {
-      fileContentForLlm += `[WARNING: This file was truncated. To view the full content, use the 'read_file' tool on this specific file.]\n\n`;
-    }
-    fileContentForLlm += fileReadResult.llmContent as string;
-    const contentToAdd = `${separator}\n\n${fileContentForLlm}\n\n`;
-    const contentTokens = estimateTokens(contentToAdd);
-
-    if (totalTokens + contentTokens > limits.maxTokens) {
-      return this.handleTokenOverflow(
-        limits,
-        relativePathForDisplay,
-        sortedFiles,
-        processedFilesRelativePaths,
-        contentParts,
-        contentToAdd,
-        totalTokens,
-        skippedFiles,
-      );
+    if (addResult.action === 'stop') {
+      return {
+        done: true,
+        totalTokens: addResult.totalTokens,
+        totalBytes: addResult.totalBytes,
+      };
     }
 
-    totalTokens += contentTokens;
-    contentParts.push(contentToAdd);
-    return { totalTokens, action: 'continue' };
-  }
-
-  private handleTokenOverflow(
-    limits: ReturnType<ReadManyFilesToolInvocation['resolveLimits']>,
-    relativePathForDisplay: string,
-    sortedFiles: string[],
-    processedFilesRelativePaths: string[],
-    contentParts: Array<string | ContentPartUnion>,
-    contentToAdd: string,
-    totalTokens: number,
-    skippedFiles: Array<{ path: string; reason: string }>,
-  ): AddFileContentResult {
-    if (limits.truncateMode === 'warn') {
-      skippedFiles.push({
-        path: `${sortedFiles.length - processedFilesRelativePaths.length} remaining file(s)`,
-        reason: `would exceed token limit of ${limits.maxTokens}`,
-      });
-      return { totalTokens, action: 'stop' };
-    } else if (limits.truncateMode === 'truncate') {
-      const remainingTokens = limits.maxTokens - totalTokens;
-      if (remainingTokens > 100) {
-        const truncatedContent = contentToAdd.substring(0, remainingTokens * 4);
-        const finalContent =
-          truncatedContent + '\n\n[CONTENT TRUNCATED DUE TO TOKEN LIMIT]';
-        contentParts.push(finalContent);
-        const updatedTokens = totalTokens + estimateTokens(finalContent);
-        skippedFiles.push({
-          path: relativePathForDisplay,
-          reason: 'content truncated to fit token limit',
-        });
-        return { totalTokens: updatedTokens, action: 'stopAfterRecord' };
-      }
-      return { totalTokens, action: 'stop' };
+    processedFilesRelativePaths.push(relativePathForDisplay);
+    this.recordReadMetric(filePath, fileReadResult.llmContent);
+    if (addResult.action === 'stopAfterRecord') {
+      return {
+        done: true,
+        totalTokens: addResult.totalTokens,
+        totalBytes: addResult.totalBytes,
+      };
     }
-    skippedFiles.push({
-      path: relativePathForDisplay,
-      reason: 'skipped to stay within token limit',
-    });
-    return { totalTokens, action: 'continue' };
+    return {
+      done: false,
+      totalTokens: addResult.totalTokens,
+      totalBytes: addResult.totalBytes,
+    };
   }
 
   private recordReadMetric(

--- a/packages/tools/src/tools/structural-analysis.ts
+++ b/packages/tools/src/tools/structural-analysis.ts
@@ -48,6 +48,24 @@ import {
 
 export type { StructuralAnalysisParams } from './structural-analysis/types.js';
 
+/**
+ * Normalize a caller-supplied maxNodes value to a finite positive integer.
+ * Zero, negative, NaN, or non-integer values fall back to the documented
+ * default rather than reaching the executors where an empty partial result
+ * would fire the one-over sentinel on the first candidate.
+ */
+function normalizeMaxNodes(value: number | undefined): number {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value <= 0 ||
+    !Number.isInteger(value)
+  ) {
+    return DEFAULT_MAX_NODES;
+  }
+  return value;
+}
+
 interface ResolvedParams {
   mode: string;
   resolvedLang: ResolvedLang;
@@ -157,7 +175,7 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
       targetDir,
       symbol,
       depth: Math.min(depth ?? DEFAULT_DEPTH, MAX_DEPTH),
-      maxNodes: maxNodes ?? DEFAULT_MAX_NODES,
+      maxNodes: normalizeMaxNodes(maxNodes),
       reverse: reverse === true,
       budget: resolveAnalysisBudget(
         this.host.getEphemeralSettings()['tool-output-max-items'] as
@@ -179,6 +197,7 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
       symbol,
       depth,
       maxNodes,
+      budget,
     } = params;
 
     switch (mode as Mode) {
@@ -189,6 +208,7 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
           searchPath,
           targetDir,
           signal,
+          budget,
         );
       case 'hierarchy':
         return executeHierarchy(
@@ -197,6 +217,7 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
           searchPath,
           targetDir,
           signal,
+          budget,
         );
       case 'callers':
         return executeCallers(
@@ -207,6 +228,7 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
           depth,
           maxNodes,
           signal,
+          budget,
         );
       case 'callees':
         return executeCallees(
@@ -217,6 +239,7 @@ class StructuralAnalysisInvocation extends BaseToolInvocation<
           depth,
           maxNodes,
           signal,
+          budget,
         );
       default:
         return this.dispatchBoundedMode(mode as Mode, params, signal);

--- a/packages/tools/src/tools/structural-analysis/budget.ts
+++ b/packages/tools/src/tools/structural-analysis/budget.ts
@@ -15,7 +15,7 @@
  * @plan PLAN-20260810-ISSUE3205
  */
 
-import type { PartialReason } from './types.js';
+import type { PartialReason, ParseOmissionReason } from './types.js';
 
 /** Effective finite caps applied to a single analysis traversal. */
 export interface AnalysisBudget {
@@ -84,7 +84,21 @@ export class BudgetTracker {
   truncated = false;
   partialReason: PartialReason | undefined;
 
-  private recordSentinelObserved = false;
+  /**
+   * Node-candidate observation counter for callers/callees (direct/member/callee
+   * insertions). Bounded by the effective max-nodes limit; the first one-over
+   * candidate is observed as a sentinel (proving partiality) but not retained.
+   */
+  nodesObserved = 0;
+  /** Node candidates actually retained into the callers/callees result. */
+  nodesRetained = 0;
+
+  /** Files skipped for exceeding the pre-read size gate (inexact count). */
+  oversizedFiles = 0;
+  /** Files that could not be read or parsed (inexact count). */
+  unparseableFiles = 0;
+
+  private nodeSentinelObserved = false;
 
   constructor(
     private readonly budget: AnalysisBudget,
@@ -93,15 +107,16 @@ export class BudgetTracker {
 
   /**
    * Whether traversal should continue visiting more files. Returns false when
-   * the signal has aborted, the file budget is exhausted, or the record-budget
-   * sentinel has already proven partiality.
+   * the signal has aborted, ANY truncation reason has fired (abort, max-nodes,
+   * max-files, or record-budget — all folded into {@link truncated}), or the
+   * file budget is exhausted.
    */
   shouldVisitMoreFiles(): boolean {
     if (this.signal.aborted) {
       this.markTruncated('aborted');
       return false;
     }
-    if (this.recordSentinelObserved) {
+    if (this.truncated) {
       return false;
     }
     if (this.filesVisited >= this.budget.fileBudget) {
@@ -133,11 +148,53 @@ export class BudgetTracker {
       this.recordsRetained++;
       return true;
     }
-    if (!this.recordSentinelObserved) {
-      this.recordSentinelObserved = true;
-      this.markTruncated('record-budget');
+    // markTruncated is idempotent (partialReason ??=), so calling it on
+    // every post-budget record is harmless and avoids a separate guard.
+    this.markTruncated('record-budget');
+    return false;
+  }
+
+  /**
+   * Attempt to accept one more node candidate (direct/member/callee insertion)
+   * into a callers/callees result, bounded by the effective max-nodes limit.
+   *
+   * Returns true when the node fits (caller retains it). Returns false when the
+   * limit is exhausted: the FIRST such call observes the one-over sentinel
+   * (setting truncated/partialReason='max-nodes') and the node must NOT be
+   * retained. Also returns false without incrementing when the signal aborted.
+   *
+   * `exact-limit stays complete`: when exactly `maxNodes` candidates are
+   * observed and no extra candidate arrives, no sentinel fires, so the result
+   * remains exact/complete.
+   */
+  tryAcceptNode(maxNodes: number): boolean {
+    if (this.signal.aborted) {
+      this.markTruncated('aborted');
+      return false;
+    }
+    this.nodesObserved++;
+    if (this.nodesRetained < maxNodes) {
+      this.nodesRetained++;
+      return true;
+    }
+    if (!this.nodeSentinelObserved) {
+      this.nodeSentinelObserved = true;
+      this.markTruncated('max-nodes');
     }
     return false;
+  }
+
+  /**
+   * Record a single file that could not be parsed (oversized / read-error /
+   * parse-error). Each omission makes the result count a lower bound, so it
+   * flips {@link countInexact} on (without forcing the traversal to stop).
+   */
+  recordFileOmission(reason: ParseOmissionReason): void {
+    if (reason === 'oversized') {
+      this.oversizedFiles++;
+    } else {
+      this.unparseableFiles++;
+    }
   }
 
   /**
@@ -154,7 +211,9 @@ export class BudgetTracker {
 
   /** Whether counts are lower bounds rather than exhaustive totals. */
   get countInexact(): boolean {
-    return this.truncated;
+    return (
+      this.truncated || this.oversizedFiles > 0 || this.unparseableFiles > 0
+    );
   }
 
   private markTruncated(reason: PartialReason): void {

--- a/packages/tools/src/tools/structural-analysis/callees.ts
+++ b/packages/tools/src/tools/structural-analysis/callees.ts
@@ -9,24 +9,20 @@ import type { SgNode } from '@ast-grep/napi';
 import type { ParsedFile, AnalysisResult, ResolvedLang } from './types.js';
 import {
   escapeRegex,
-  getFiles,
+  iterateFiles,
   parseFile,
   makeRelative,
   extractCalleeName,
   deduplicateCallRanges,
   findFunctionContainer,
 } from './helpers.js';
+import { type AnalysisBudget, BudgetTracker } from './budget.js';
 
 interface CalleeRef {
   text: string;
   file: string;
   line: number;
   calleeNode?: SgNode;
-}
-
-interface CalleeCtx {
-  nodesVisited: number;
-  maxNodes: number;
 }
 
 export interface CalleeEntry {
@@ -42,15 +38,31 @@ async function findCalleesOfFile(
   sym: string,
   workspaceRoot: string,
   visited: Set<string>,
-  ctx: CalleeCtx,
-  signal: AbortSignal,
+  tracker: BudgetTracker,
+  effectiveMaxNodes: number,
 ): Promise<CalleeRef[]> {
-  if (signal.aborted || ctx.nodesVisited >= ctx.maxNodes) return [];
-  const parsed = await parseFile(file, lang);
-  if (!parsed) return [];
+  // The node budget is enforced per-candidate by tryAcceptNode inside
+  // collectCalleesFromContainer. We do NOT early-return on the exact node
+  // limit here so the one-over sentinel can be observed when callees are
+  // spread one-per-file across the workspace.
+  if (tracker.signal.aborted || tracker.truncated) {
+    return [];
+  }
+  const outcome = await parseFile(file, lang);
+  if (!outcome.ok) {
+    tracker.recordFileOmission(outcome.reason);
+    return [];
+  }
 
   const relPath = makeRelative(file, workspaceRoot);
-  return collectCalleeRefs(parsed, sym, relPath, visited, ctx);
+  return collectCalleeRefs(
+    outcome,
+    sym,
+    relPath,
+    visited,
+    tracker,
+    effectiveMaxNodes,
+  );
 }
 
 /**
@@ -63,11 +75,19 @@ function collectCalleeRefs(
   sym: string,
   relPath: string,
   visited: Set<string>,
-  ctx: CalleeCtx,
+  tracker: BudgetTracker,
+  effectiveMaxNodes: number,
 ): CalleeRef[] {
   const results: CalleeRef[] = [];
   for (const container of findNamedContainers(parsed, sym)) {
-    collectCalleesFromContainer(container, relPath, visited, ctx, results);
+    collectCalleesFromContainer(
+      container,
+      relPath,
+      visited,
+      tracker,
+      effectiveMaxNodes,
+      results,
+    );
   }
   return results;
 }
@@ -156,8 +176,8 @@ function findNamedContainers(parsed: ParsedFile, sym: string): SgNode[] {
  * Checks a single call-expression node and returns a CalleeRef if it belongs
  * directly to the target container (its nearest function-like container),
  * or null if it should be skipped (nested in a different function or already
- * visited). The maxNodes traversal limit is enforced upstream in
- * findCalleesOfFile, not in this function.
+ * visited). Node-budget acceptance happens in the caller loop (before
+ * insertion), not in this function.
  *
  * Extracted so the caller loop uses zero `continue` statements.
  */
@@ -167,7 +187,6 @@ function tryCollectCallee(
   containerEnd: number,
   relPath: string,
   visited: Set<string>,
-  ctx: CalleeCtx,
 ): CalleeRef | null {
   const nearest = findFunctionContainer(node);
   if (nearest === null) {
@@ -185,7 +204,6 @@ function tryCollectCallee(
     return null;
   }
   visited.add(key);
-  ctx.nodesVisited++;
   return {
     text: callText,
     file: relPath,
@@ -200,12 +218,17 @@ function tryCollectCallee(
  * is the target container are kept, so calls inside nested functions are not
  * misattributed to the outer container. Containers are compared by range
  * index (node identity is not reliable across ast-grep queries).
+ *
+ * Every callee insertion is accepted through the shared node budget
+ * ({@link BudgetTracker.tryAcceptNode}) BEFORE being pushed, so the
+ * node-candidate aggregate is hard-bounded with one-over semantics.
  */
 function collectCalleesFromContainer(
   containerNode: SgNode,
   relPath: string,
   visited: Set<string>,
-  ctx: CalleeCtx,
+  tracker: BudgetTracker,
+  effectiveMaxNodes: number,
   results: CalleeRef[],
 ): void {
   const callMatches = containerNode.findAll({
@@ -223,9 +246,9 @@ function collectCalleesFromContainer(
       containerEnd,
       relPath,
       visited,
-      ctx,
     );
     if (ref !== null) {
+      if (!tracker.tryAcceptNode(effectiveMaxNodes)) break;
       results.push(ref);
     }
   }
@@ -239,52 +262,89 @@ export async function executeCallees(
   depth: number,
   maxNodes: number,
   signal: AbortSignal,
+  budget: AnalysisBudget,
 ): Promise<AnalysisResult> {
-  const files = await getFiles(searchPath, lang);
+  const tracker = new BudgetTracker(budget, signal);
   const visited = new Set<string>();
-  let nodesVisited = 0;
-  let truncated = false;
+  // The node-candidate budget is the smaller of the requested maxNodes and
+  // the finite record budget, so callees traversal is always hard-bounded.
+  const effectiveMaxNodes = Math.min(maxNodes, budget.recordBudget);
 
   const findCalleesOf = async (
     sym: string,
     currentDepth: number,
   ): Promise<CalleeEntry[]> => {
-    if (currentDepth <= 0 || nodesVisited >= maxNodes || signal.aborted) {
-      if (nodesVisited >= maxNodes) truncated = true;
+    if (signal.aborted) {
+      tracker.markAborted();
+      return [];
+    }
+    // Exact-limit stays complete: reaching the node budget without observing
+    // an extra candidate does not mark the result partial. The per-candidate
+    // tryAcceptNode (inside collectCalleesFromContainer) observes the one-over
+    // sentinel; shouldVisitMoreFiles then stops file iteration.
+    if (currentDepth <= 0 || tracker.truncated) {
       return [];
     }
 
     const callees: CalleeEntry[] = [];
-    const ctx: CalleeCtx = { nodesVisited, maxNodes };
 
-    for (const file of files) {
+    for await (const file of iterateFiles(searchPath, lang, signal)) {
+      if (!tracker.shouldVisitMoreFiles()) break;
+      tracker.filesVisited++;
+
       const calleeResults = await findCalleesOfFile(
         file,
         lang,
         sym,
         workspaceRoot,
         visited,
-        ctx,
-        signal,
+        tracker,
+        effectiveMaxNodes,
       );
 
       for (const r of calleeResults) {
         callees.push(
-          await buildCalleeEntry(r, sym, currentDepth, ctx, findCalleesOf),
+          await buildCalleeEntry(
+            r,
+            sym,
+            currentDepth,
+            tracker,
+            effectiveMaxNodes,
+            findCalleesOf,
+          ),
         );
       }
     }
 
-    nodesVisited = ctx.nodesVisited;
     return callees;
   };
 
   const results = await findCalleesOf(symbol, depth);
 
+  if (signal.aborted) {
+    tracker.markAborted();
+  }
+
+  // For callers/callees the node-candidate budget IS the record budget
+  // (effectiveMaxNodes = min(maxNodes, recordBudget)), so the node counters
+  // are reported as the record counters too. recordBudget reflects the
+  // effective maximum, not the raw configured recordBudget.
   return {
     mode: 'callees',
     symbol,
-    truncated,
+    truncated: tracker.truncated,
+    partial: tracker.truncated,
+    partialReason: tracker.partialReason,
+    fileBudget: budget.fileBudget,
+    recordBudget: effectiveMaxNodes,
+    filesVisited: tracker.filesVisited,
+    recordsRetained: tracker.nodesRetained,
+    recordsObserved: tracker.nodesObserved,
+    nodesRetained: tracker.nodesRetained,
+    nodesObserved: tracker.nodesObserved,
+    oversizedFiles: tracker.oversizedFiles,
+    unparseableFiles: tracker.unparseableFiles,
+    countInexact: tracker.countInexact,
     results,
   };
 }
@@ -296,7 +356,8 @@ async function buildCalleeEntry(
   r: CalleeRef,
   sym: string,
   currentDepth: number,
-  ctx: CalleeCtx,
+  tracker: BudgetTracker,
+  effectiveMaxNodes: number,
   recurse: (sym: string, currentDepth: number) => Promise<CalleeEntry[]>,
 ): Promise<CalleeEntry> {
   const entry: CalleeEntry = {
@@ -305,9 +366,10 @@ async function buildCalleeEntry(
     line: r.line,
   };
   const calleeName = r.calleeNode ? extractCalleeName(r.calleeNode) : null;
+  const mayRecurse = currentDepth > 1 && !tracker.truncated;
   if (
-    currentDepth > 1 &&
-    ctx.nodesVisited < ctx.maxNodes &&
+    mayRecurse &&
+    tracker.nodesObserved < effectiveMaxNodes &&
     calleeName &&
     calleeName !== sym
   ) {

--- a/packages/tools/src/tools/structural-analysis/callers.ts
+++ b/packages/tools/src/tools/structural-analysis/callers.ts
@@ -6,27 +6,41 @@
 
 import type { NapiConfig } from '@ast-grep/napi';
 import type { SgNode } from '@ast-grep/napi';
-import type {
-  ParsedFile,
-  AnalysisResult,
-  TraversalContext,
-  ResolvedLang,
-} from './types.js';
+import type { ParsedFile, AnalysisResult, ResolvedLang } from './types.js';
 import {
   escapeRegex,
-  getFiles,
+  iterateFiles,
   parseFile,
   makeRelative,
   findFunctionContainer,
   getContainerName,
   getViaContext,
 } from './helpers.js';
+import { type AnalysisBudget, BudgetTracker } from './budget.js';
 
 interface CallerRef {
   method: string;
   file: string;
   line: number;
   via: string;
+}
+
+/**
+ * Accept one caller candidate through the node budget, pushing it into
+ * `results` when it fits. Returns true to keep iterating, false to stop
+ * (budget sentinel). Shared by the member-call and direct-call loops so
+ * each stays to a single break with no nested control flow.
+ */
+function acceptCallerEntry(
+  entry: CallerRef | undefined,
+  results: CallerRef[],
+  tracker: BudgetTracker,
+  effectiveMaxNodes: number,
+): boolean {
+  if (entry === undefined) return true;
+  if (!tracker.tryAcceptNode(effectiveMaxNodes)) return false;
+  results.push(entry);
+  return true;
 }
 
 export interface CallerEntry {
@@ -68,12 +82,19 @@ function buildCallerEntry(
   };
 }
 
+/**
+ * Collect member-call callers. Each valid new caller is accepted through the
+ * shared node budget ({@link BudgetTracker.tryAcceptNode}) BEFORE being
+ * inserted, so the node-candidate aggregate is hard-bounded with one-over
+ * semantics. The loop stops the moment the budget sentinel fires.
+ */
 function findMemberCallCallers(
   parsed: ParsedFile,
   sym: string,
   relPath: string,
   visited: Set<string>,
-  ctx: TraversalContext,
+  tracker: BudgetTracker,
+  effectiveMaxNodes: number,
 ): CallerRef[] {
   const results: CallerRef[] = [];
   try {
@@ -88,16 +109,15 @@ function findMemberCallCallers(
     } as NapiConfig);
 
     for (const callNode of memberCalls) {
-      if (ctx.nodesVisited >= ctx.maxNodes) {
-        ctx.truncated = true;
+      if (
+        !acceptCallerEntry(
+          buildCallerEntry(callNode, sym, relPath, visited),
+          results,
+          tracker,
+          effectiveMaxNodes,
+        )
+      )
         break;
-      }
-
-      const entry = buildCallerEntry(callNode, sym, relPath, visited);
-      if (entry !== undefined) {
-        ctx.nodesVisited++;
-        results.push(entry);
-      }
     }
   } catch {
     /* skip */
@@ -105,29 +125,33 @@ function findMemberCallCallers(
   return results;
 }
 
+/**
+ * Collect direct-call callers. Unlike the member path, every valid caller is
+ * still accepted through the node budget before insertion, closing the
+ * previous gap where the direct path was unbounded.
+ */
 function findDirectCallCallers(
   parsed: ParsedFile,
   sym: string,
   relPath: string,
   visited: Set<string>,
-  ctx: TraversalContext,
+  tracker: BudgetTracker,
+  effectiveMaxNodes: number,
 ): CallerRef[] {
   const results: CallerRef[] = [];
   try {
     const directCallNodes = parsed.root.findAll(`${sym}($$$ARGS)`);
 
     for (const callNode of directCallNodes) {
-      const entry = buildCallerEntry(
-        callNode,
-        sym,
-        relPath,
-        visited,
-        `${sym}(...)`,
-      );
-      if (entry !== undefined) {
-        ctx.nodesVisited++;
-        results.push(entry);
-      }
+      if (
+        !acceptCallerEntry(
+          buildCallerEntry(callNode, sym, relPath, visited, `${sym}(...)`),
+          results,
+          tracker,
+          effectiveMaxNodes,
+        )
+      )
+        break;
     }
   } catch {
     /* skip */
@@ -141,26 +165,39 @@ async function findCallersOfFile(
   sym: string,
   workspaceRoot: string,
   visited: Set<string>,
-  ctx: TraversalContext,
+  tracker: BudgetTracker,
+  effectiveMaxNodes: number,
 ): Promise<CallerRef[]> {
-  if (ctx.signal.aborted || ctx.nodesVisited >= ctx.maxNodes) return [];
-  const parsed = await parseFile(file, lang);
-  if (!parsed) return [];
+  // The node budget is enforced per-candidate by tryAcceptNode inside the
+  // member/direct loops. We deliberately do NOT early-return on the exact
+  // node limit here: that would prevent observing the one-over sentinel
+  // candidate when callers are spread one-per-file. tryAcceptNode stops the
+  // loop and shouldVisitMoreFiles stops the file loop once the sentinel fires.
+  if (tracker.signal.aborted || tracker.truncated) {
+    return [];
+  }
+  const outcome = await parseFile(file, lang);
+  if (!outcome.ok) {
+    tracker.recordFileOmission(outcome.reason);
+    return [];
+  }
 
   const relPath = makeRelative(file, workspaceRoot);
   const memberResults = findMemberCallCallers(
-    parsed,
+    outcome,
     sym,
     relPath,
     visited,
-    ctx,
+    tracker,
+    effectiveMaxNodes,
   );
   const directResults = findDirectCallCallers(
-    parsed,
+    outcome,
     sym,
     relPath,
     visited,
-    ctx,
+    tracker,
+    effectiveMaxNodes,
   );
   return [...memberResults, ...directResults];
 }
@@ -173,36 +210,47 @@ export async function executeCallers(
   depth: number,
   maxNodes: number,
   signal: AbortSignal,
+  budget: AnalysisBudget,
 ): Promise<AnalysisResult> {
-  const files = await getFiles(searchPath, lang);
+  const tracker = new BudgetTracker(budget, signal);
   const visited = new Set<string>();
-  let nodesVisited = 0;
-  let truncated = false;
+  // The node-candidate budget is the smaller of the requested maxNodes and
+  // the finite record budget, so callers traversal is always hard-bounded.
+  const effectiveMaxNodes = Math.min(maxNodes, budget.recordBudget);
 
   const findCallersOf = async (
     sym: string,
     currentDepth: number,
   ): Promise<CallerEntry[]> => {
-    if (currentDepth <= 0 || nodesVisited >= maxNodes || signal.aborted) {
-      if (nodesVisited >= maxNodes) truncated = true;
+    if (signal.aborted) {
+      tracker.markAborted();
+      return [];
+    }
+    // Exact-limit stays complete: when the node budget is exactly reached
+    // (no extra candidate observed) traversal simply stops without marking
+    // partial — only a one-over candidate (observed through tryAcceptNode)
+    // sets the sentinel. shouldVisitMoreFiles stops file iteration once the
+    // sentinel fires.
+    // Snapshot truncation at entry: reading the property directly lets TS's
+    // (unsound) property narrowing hide later mid-traversal flips.
+    const truncatedOnEntry = tracker.truncated;
+    if (currentDepth <= 0 || truncatedOnEntry) {
       return [];
     }
 
     const callers: CallerEntry[] = [];
-    const ctx: TraversalContext = { nodesVisited, maxNodes, truncated, signal };
-    const syncTraversalState = (): void => {
-      nodesVisited = ctx.nodesVisited;
-      truncated = ctx.truncated;
-    };
 
-    for (const file of files) {
+    for await (const file of iterateFiles(searchPath, lang, signal)) {
+      if (!tracker.shouldVisitMoreFiles()) break;
+      tracker.filesVisited++;
       const fileResults = await findCallersOfFile(
         file,
         lang,
         sym,
         workspaceRoot,
         visited,
-        ctx,
+        tracker,
+        effectiveMaxNodes,
       );
       for (const r of fileResults) {
         const entry: CallerEntry = {
@@ -211,27 +259,46 @@ export async function executeCallers(
           line: r.line,
           via: r.via,
         };
-        if (currentDepth > 1 && ctx.nodesVisited < maxNodes) {
-          syncTraversalState();
+        if (
+          currentDepth > 1 &&
+          tracker.nodesObserved < effectiveMaxNodes &&
+          !tracker.truncated
+        ) {
           entry.callers = await findCallersOf(r.method, currentDepth - 1);
-          ctx.nodesVisited = nodesVisited;
-          ctx.truncated = truncated;
         }
         callers.push(entry);
       }
     }
 
-    nodesVisited = ctx.nodesVisited;
-    truncated = ctx.truncated;
     return callers;
   };
 
   const results = await findCallersOf(symbol, depth);
 
+  if (signal.aborted) {
+    tracker.markAborted();
+  }
+
+  // For callers/callees the node-candidate budget IS the record budget
+  // (effectiveMaxNodes = min(maxNodes, recordBudget)), so the node counters
+  // are reported as the record counters too. recordBudget reflects the
+  // effective maximum, not the raw configured recordBudget.
   return {
     mode: 'callers',
     symbol,
-    truncated,
+    truncated: tracker.truncated,
+    partial: tracker.truncated,
+    partialReason: tracker.partialReason,
+    fileBudget: budget.fileBudget,
+    recordBudget: effectiveMaxNodes,
+    filesVisited: tracker.filesVisited,
+    recordsRetained: tracker.nodesRetained,
+    recordsObserved: tracker.nodesObserved,
+    nodesRetained: tracker.nodesRetained,
+    nodesObserved: tracker.nodesObserved,
+    oversizedFiles: tracker.oversizedFiles,
+    unparseableFiles: tracker.unparseableFiles,
+    countInexact: tracker.countInexact,
     results,
   };
 }

--- a/packages/tools/src/tools/structural-analysis/definitions.ts
+++ b/packages/tools/src/tools/structural-analysis/definitions.ts
@@ -11,13 +11,25 @@ import type {
   DefinitionEntry,
   ResolvedLang,
 } from './types.js';
-import { escapeRegex, getFiles, parseFile, makeRelative } from './helpers.js';
+import {
+  escapeRegex,
+  iterateFiles,
+  parseFile,
+  makeRelative,
+} from './helpers.js';
+import { type AnalysisBudget, BudgetTracker } from './budget.js';
+
+/** Stable dedup key for a definition entry: file path + line number. */
+function definitionKey(file: string, line: number): string {
+  return `${file}:${line}`;
+}
 
 function searchFunctionAndMethodDefinitions(
   parsed: ParsedFile,
   symbol: string,
   relPath: string,
   definitions: DefinitionEntry[],
+  seenKeys: Set<string>,
 ): void {
   const escaped = escapeRegex(symbol);
   const rules: Array<{ kind: string; kindLabel: string; nameKind: string }> = [
@@ -45,6 +57,7 @@ function searchFunctionAndMethodDefinitions(
       kindLabel,
       relPath,
       definitions,
+      seenKeys,
     );
   }
 
@@ -53,6 +66,7 @@ function searchFunctionAndMethodDefinitions(
     escaped,
     relPath,
     definitions,
+    seenKeys,
   );
 }
 
@@ -81,6 +95,7 @@ function collectVariableBoundFunctionDefinitions(
   escapedSymbol: string,
   relPath: string,
   definitions: DefinitionEntry[],
+  seenKeys: Set<string>,
 ): void {
   try {
     const declarators = parsed.root.findAll({
@@ -99,10 +114,9 @@ function collectVariableBoundFunctionDefinitions(
         );
       if (fn === undefined) continue;
       const line = d.range().start.line + 1;
-      const exists = definitions.some(
-        (def) => def.file === relPath && def.line === line,
-      );
-      if (!exists) {
+      const key = definitionKey(relPath, line);
+      if (!seenKeys.has(key)) {
+        seenKeys.add(key);
         definitions.push({
           file: relPath,
           line,
@@ -126,6 +140,7 @@ function collectRuleDefinitions(
   kindLabel: string,
   relPath: string,
   definitions: DefinitionEntry[],
+  seenKeys: Set<string>,
 ): void {
   let matches: SgNode[];
   try {
@@ -141,10 +156,9 @@ function collectRuleDefinitions(
   }
   for (const m of matches) {
     const line = m.range().start.line + 1;
-    const exists = definitions.some(
-      (d) => d.file === relPath && d.line === line,
-    );
-    if (!exists) {
+    const key = definitionKey(relPath, line);
+    if (!seenKeys.has(key)) {
+      seenKeys.add(key);
       definitions.push({
         file: relPath,
         line,
@@ -170,6 +184,7 @@ function searchDeclarationRules(
   symbol: string,
   relPath: string,
   definitions: DefinitionEntry[],
+  seenKeys: Set<string>,
 ): void {
   try {
     const ruleMatches = parsed.root.findAll({
@@ -201,14 +216,14 @@ function searchDeclarationRules(
     } as NapiConfig);
     for (const m of ruleMatches) {
       const range = m.range();
-      const exists = definitions.some(
-        (d) => d.file === relPath && d.line === range.start.line + 1,
-      );
-      if (!exists) {
+      const line = range.start.line + 1;
+      const key = definitionKey(relPath, line);
+      if (!seenKeys.has(key)) {
+        seenKeys.add(key);
         const rawKind = String(m.kind());
         definitions.push({
           file: relPath,
-          line: range.start.line + 1,
+          line,
           kind: DECLARATION_KIND_LABELS[rawKind] ?? rawKind,
           text: m.text().substring(0, 200),
         });
@@ -220,7 +235,9 @@ function searchDeclarationRules(
 }
 
 /**
- * Processes a single file for definitions, unless the signal is aborted.
+ * Processes a single file for definitions, retaining matches through the
+ * budget tracker. Returns false to stop the file loop (budget exhausted or
+ * record-budget sentinel fired).
  */
 async function processDefinitionsFile(
   file: string,
@@ -228,15 +245,36 @@ async function processDefinitionsFile(
   workspaceRoot: string,
   symbol: string,
   definitions: DefinitionEntry[],
+  globalSeenKeys: Set<string>,
+  tracker: BudgetTracker,
 ): Promise<boolean> {
-  const parsed = await parseFile(file, lang);
-  if (!parsed) {
+  if (!tracker.shouldVisitMoreFiles()) return false;
+  tracker.filesVisited++;
+  const outcome = await parseFile(file, lang);
+  if (!outcome.ok) {
+    tracker.recordFileOmission(outcome.reason);
     return true;
   }
 
   const relPath = makeRelative(file, workspaceRoot);
-  searchFunctionAndMethodDefinitions(parsed, symbol, relPath, definitions);
-  searchDeclarationRules(parsed, symbol, relPath, definitions);
+  const pending: DefinitionEntry[] = [];
+  const fileSeenKeys = new Set<string>();
+  searchFunctionAndMethodDefinitions(
+    outcome,
+    symbol,
+    relPath,
+    pending,
+    fileSeenKeys,
+  );
+  searchDeclarationRules(outcome, symbol, relPath, pending, fileSeenKeys);
+
+  for (const def of pending) {
+    const key = definitionKey(def.file, def.line);
+    if (globalSeenKeys.has(key)) continue;
+    if (!tracker.tryRetainRecord()) return false;
+    globalSeenKeys.add(key);
+    definitions.push(def);
+  }
   return true;
 }
 
@@ -246,27 +284,45 @@ export async function executeDefinitions(
   searchPath: string,
   workspaceRoot: string,
   signal: AbortSignal,
+  budget: AnalysisBudget,
 ): Promise<AnalysisResult> {
-  const files = await getFiles(searchPath, lang);
+  const tracker = new BudgetTracker(budget, signal);
   const definitions: DefinitionEntry[] = [];
+  const globalSeenKeys = new Set<string>();
 
-  for (const file of files) {
-    if (signal.aborted) {
+  for await (const file of iterateFiles(searchPath, lang, signal)) {
+    if (
+      !(await processDefinitionsFile(
+        file,
+        lang,
+        workspaceRoot,
+        symbol,
+        definitions,
+        globalSeenKeys,
+        tracker,
+      ))
+    )
       break;
-    }
-    await processDefinitionsFile(
-      file,
-      lang,
-      workspaceRoot,
-      symbol,
-      definitions,
-    );
+  }
+
+  if (signal.aborted) {
+    tracker.markAborted();
   }
 
   return {
     mode: 'definitions',
     symbol,
-    truncated: false,
+    truncated: tracker.truncated,
+    partial: tracker.truncated,
+    partialReason: tracker.partialReason,
+    fileBudget: budget.fileBudget,
+    recordBudget: budget.recordBudget,
+    filesVisited: tracker.filesVisited,
+    recordsRetained: tracker.recordsRetained,
+    recordsObserved: tracker.recordsObserved,
+    oversizedFiles: tracker.oversizedFiles,
+    unparseableFiles: tracker.unparseableFiles,
+    countInexact: tracker.countInexact,
     results: definitions,
   };
 }

--- a/packages/tools/src/tools/structural-analysis/dependencies.ts
+++ b/packages/tools/src/tools/structural-analysis/dependencies.ts
@@ -366,9 +366,11 @@ async function tryCollectReverseImportsForFile(
   targetBasename: string,
   workspaceRoot: string,
   retain: RetainImportFn,
+  tracker: BudgetTracker,
 ): Promise<boolean> {
-  const parsed = await parseFile(file, lang);
-  if (!parsed) {
+  const outcome = await parseFile(file, lang);
+  if (!outcome.ok) {
+    tracker.recordFileOmission(outcome.reason);
     return true;
   }
   const relPath = makeRelative(file, workspaceRoot);
@@ -376,13 +378,13 @@ async function tryCollectReverseImportsForFile(
     !shouldCheckReverseImport(
       relPath,
       targetRel,
-      parsed.content,
+      outcome.content,
       targetBasename,
     )
   ) {
     return true;
   }
-  return collectImportMatches(parsed, relPath, targetBasename, retain);
+  return collectImportMatches(outcome, relPath, targetBasename, retain);
 }
 
 /**
@@ -414,6 +416,7 @@ async function collectReverseImportsBounded(
         targetBasename,
         workspaceRoot,
         retain,
+        tracker,
       ))
     ) {
       return;
@@ -441,6 +444,8 @@ function buildDependenciesResult(
     filesVisited: tracker.filesVisited,
     recordsRetained: tracker.recordsRetained,
     recordsObserved: tracker.recordsObserved,
+    oversizedFiles: tracker.oversizedFiles,
+    unparseableFiles: tracker.unparseableFiles,
     countInexact: tracker.countInexact,
     results: {
       imports,
@@ -516,9 +521,12 @@ async function collectForwardImportsBounded(
   for await (const file of iterateFiles(searchPath, lang, tracker.signal)) {
     if (!tracker.shouldVisitMoreFiles()) return;
     tracker.filesVisited++;
-    const parsed = await parseFile(file, lang);
-    if (!parsed) continue;
+    const outcome = await parseFile(file, lang);
+    if (!outcome.ok) {
+      tracker.recordFileOmission(outcome.reason);
+      continue;
+    }
     const relPath = makeRelative(file, workspaceRoot);
-    if (!collectFileImportsBounded(parsed, relPath, retain)) return;
+    if (!collectFileImportsBounded(outcome, relPath, retain)) return;
   }
 }

--- a/packages/tools/src/tools/structural-analysis/exports.ts
+++ b/packages/tools/src/tools/structural-analysis/exports.ts
@@ -64,6 +64,8 @@ export async function executeExports(
     filesVisited: tracker.filesVisited,
     recordsRetained: tracker.recordsRetained,
     recordsObserved: tracker.recordsObserved,
+    oversizedFiles: tracker.oversizedFiles,
+    unparseableFiles: tracker.unparseableFiles,
     countInexact: tracker.countInexact,
     results: exports,
   };
@@ -83,10 +85,13 @@ async function collectExportsBounded(
   for await (const file of iterateFiles(searchPath, lang, tracker.signal)) {
     if (!tracker.shouldVisitMoreFiles()) return;
     tracker.filesVisited++;
-    const parsed = await parseFile(file, lang);
-    if (!parsed) continue;
+    const outcome = await parseFile(file, lang);
+    if (!outcome.ok) {
+      tracker.recordFileOmission(outcome.reason);
+      continue;
+    }
     const relPath = makeRelative(file, workspaceRoot);
-    const fileExports = collectExportsRetained(parsed, relPath, tracker);
+    const fileExports = collectExportsRetained(outcome, relPath, tracker);
     exports.push(...fileExports);
   }
 }

--- a/packages/tools/src/tools/structural-analysis/four-modes-budget.bun.test.ts
+++ b/packages/tools/src/tools/structural-analysis/four-modes-budget.bun.test.ts
@@ -1,0 +1,698 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for bounded acquisition in the four structural_analysis
+ * modes that were missing finite budgets: definitions, hierarchy, callers,
+ * callees (issue #3202).
+ *
+ * Drives the REAL StructuralAnalysisTool end-to-end against real .ts fixture
+ * trees. Budgets are exercised by setting a small `tool-output-max-items`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IToolHost } from '../../interfaces/index.js';
+import {
+  StructuralAnalysisTool,
+  type StructuralAnalysisParams,
+} from '../structural-analysis.js';
+import type { ToolResult } from '../tools.js';
+
+function createBudgetToolHost(targetDir: string, maxItems: number): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths: string[]) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({ 'tool-output-max-items': maxItems }),
+    getDebugMode: () => false,
+  };
+}
+
+interface AnalysisPayload {
+  mode: string;
+  truncated: boolean;
+  partial?: boolean;
+  partialReason?: string;
+  fileBudget?: number;
+  recordBudget?: number;
+  filesVisited?: number;
+  recordsRetained?: number;
+  recordsObserved?: number;
+  nodesRetained?: number;
+  nodesObserved?: number;
+  oversizedFiles?: number;
+  unparseableFiles?: number;
+  countInexact?: boolean;
+  results: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parsePayload(result: ToolResult): AnalysisPayload {
+  const parsed: unknown = JSON.parse(String(result.llmContent));
+  if (!isRecord(parsed)) {
+    throw new Error(`Unexpected payload: ${result.llmContent}`);
+  }
+  return parsed as unknown as AnalysisPayload;
+}
+
+async function runTool(
+  host: IToolHost,
+  params: StructuralAnalysisParams,
+  signal?: AbortSignal,
+): Promise<ToolResult> {
+  const tool = new StructuralAnalysisTool(host);
+  return tool.build(params).execute(signal ?? new AbortController().signal);
+}
+
+describe('structural_analysis definitions bounded acquisition (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-def-budget-'));
+    // Create many files each defining the same symbol.
+    for (let i = 0; i < 20; i++) {
+      writeFileSync(
+        join(tempDir, `f${i}.ts`),
+        `export function targetFn(): void {}\n`,
+      );
+    }
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns all definitions under budget and reports not truncated', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'definitions',
+      language: 'typescript',
+      symbol: 'targetFn',
+    });
+    const payload = parsePayload(result);
+    expect(payload.mode).toBe('definitions');
+    expect(payload.truncated).toBe(false);
+    expect(payload.fileBudget).toBeDefined();
+    expect(payload.recordBudget).toBeDefined();
+    const results = payload.results as unknown[];
+    expect(Array.isArray(results)).toBe(true);
+    expect(results.length).toBe(20);
+  });
+
+  it('truncates when record budget is exceeded with one-over semantics', async () => {
+    const host = createBudgetToolHost(tempDir, 3);
+    const result = await runTool(host, {
+      mode: 'definitions',
+      language: 'typescript',
+      symbol: 'targetFn',
+    });
+    const payload = parsePayload(result);
+    expect(payload.truncated).toBe(true);
+    expect(payload.partial).toBe(true);
+    expect(payload.partialReason).toBeDefined();
+    expect(payload.recordsRetained).toBeLessThanOrEqual(3);
+    expect(payload.recordsObserved).toBeGreaterThan(payload.recordsRetained!);
+  });
+
+  it('reports file-budget metadata', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'definitions',
+      language: 'typescript',
+      symbol: 'targetFn',
+    });
+    const payload = parsePayload(result);
+    expect(payload.fileBudget).toBeGreaterThan(0);
+    expect(payload.filesVisited).toBeGreaterThan(0);
+  });
+});
+
+describe('structural_analysis hierarchy bounded acquisition (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-hier-budget-'));
+    for (let i = 0; i < 10; i++) {
+      writeFileSync(
+        join(tempDir, `f${i}.ts`),
+        `class Child${i} extends Base { }\n`,
+      );
+    }
+    writeFileSync(join(tempDir, 'base.ts'), 'class Base { }\n');
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports budget metadata and finds hierarchy matches', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'hierarchy',
+      language: 'typescript',
+      symbol: 'Base',
+    });
+    const payload = parsePayload(result);
+    expect(payload.mode).toBe('hierarchy');
+    expect(payload.fileBudget).toBeDefined();
+    expect(payload.recordBudget).toBeDefined();
+    expect(payload.filesVisited).toBeGreaterThan(0);
+    expect(payload.truncated).toBe(false);
+  });
+
+  it('truncates when record budget is exceeded', async () => {
+    const host = createBudgetToolHost(tempDir, 2);
+    const result = await runTool(host, {
+      mode: 'hierarchy',
+      language: 'typescript',
+      symbol: 'Base',
+    });
+    const payload = parsePayload(result);
+    expect(payload.truncated).toBe(true);
+    expect(payload.partialReason).toBeDefined();
+  });
+});
+
+describe('structural_analysis callers bounded acquisition (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-callers-budget-'));
+    for (let i = 0; i < 20; i++) {
+      writeFileSync(
+        join(tempDir, `f${i}.ts`),
+        `export function caller${i}(): void { targetFn(); }\n`,
+      );
+    }
+    writeFileSync(
+      join(tempDir, 'target.ts'),
+      'export function targetFn(): void {}\n',
+    );
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports budget metadata for callers', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callers',
+      language: 'typescript',
+      symbol: 'targetFn',
+    });
+    const payload = parsePayload(result);
+    expect(payload.mode).toBe('callers');
+    expect(payload.fileBudget).toBeDefined();
+    expect(payload.recordBudget).toBeDefined();
+    expect(payload.filesVisited).toBeDefined();
+  });
+
+  it('truncates when record budget is exceeded', async () => {
+    const host = createBudgetToolHost(tempDir, 3);
+    const result = await runTool(host, {
+      mode: 'callers',
+      language: 'typescript',
+      symbol: 'targetFn',
+    });
+    const payload = parsePayload(result);
+    expect(payload.truncated).toBe(true);
+    expect(payload.partialReason).toBeDefined();
+  });
+
+  it('hard-clamps maxNodes', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callers',
+      language: 'typescript',
+      symbol: 'targetFn',
+      maxNodes: 5,
+    });
+    const payload = parsePayload(result);
+    // With maxNodes=5, traversal should be bounded.
+    const results = payload.results as unknown[];
+    expect(Array.isArray(results)).toBe(true);
+    expect(results.length).toBeLessThanOrEqual(5);
+    // recordBudget must report the effective maximum (min of maxNodes and
+    // the configured record budget), not the raw configured budget.
+    expect(payload.recordBudget).toBe(5);
+  });
+
+  it('reports the effective record budget (min of maxNodes default and record budget)', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callers',
+      language: 'typescript',
+      symbol: 'targetFn',
+    });
+    const payload = parsePayload(result);
+    // Default maxNodes is 50; effectiveMaxNodes = min(50, 500) = 50.
+    expect(payload.recordBudget).toBe(50);
+  });
+
+  it('uses the finite default for zero and fractional maxNodes', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    for (const maxNodes of [0, 3.7]) {
+      const result = await runTool(host, {
+        mode: 'callers',
+        language: 'typescript',
+        symbol: 'targetFn',
+        maxNodes,
+      });
+      const payload = parsePayload(result);
+      expect(payload.recordBudget).toBe(50);
+      expect((payload.results as unknown[]).length).toBeGreaterThan(0);
+      expect(payload.partialReason).not.toBe('max-nodes');
+    }
+  });
+});
+
+describe('structural_analysis callees bounded acquisition (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-callees-budget-'));
+    writeFileSync(
+      join(tempDir, 'main.ts'),
+      `import { a, b, c } from './lib';\nexport function targetFunc(): void { a(); b(); c(); }\n`,
+    );
+    mkdirSync(join(tempDir, 'lib'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'lib', 'index.ts'),
+      'export function a() {}\nexport function b() {}\nexport function c() {}\n',
+    );
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports budget metadata for callees', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callees',
+      language: 'typescript',
+      symbol: 'targetFunc',
+    });
+    const payload = parsePayload(result);
+    expect(payload.mode).toBe('callees');
+    expect(payload.fileBudget).toBeDefined();
+    expect(payload.recordBudget).toBeDefined();
+  });
+
+  it('hard-clamps maxNodes for callees', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callees',
+      language: 'typescript',
+      symbol: 'targetFunc',
+      maxNodes: 2,
+    });
+    const payload = parsePayload(result);
+    const results = payload.results as unknown[];
+    expect(Array.isArray(results)).toBe(true);
+    expect(results.length).toBeLessThanOrEqual(2);
+    // recordBudget must report the effective maximum.
+    expect(payload.recordBudget).toBe(2);
+  });
+
+  it('reports the effective record budget for callees (min of maxNodes default and record budget)', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callees',
+      language: 'typescript',
+      symbol: 'targetFunc',
+    });
+    const payload = parsePayload(result);
+    // Default maxNodes is 50; effectiveMaxNodes = min(50, 500) = 50.
+    expect(payload.recordBudget).toBe(50);
+  });
+
+  it('uses the finite default for negative maxNodes', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callees',
+      language: 'typescript',
+      symbol: 'targetFunc',
+      maxNodes: -1,
+    });
+    const payload = parsePayload(result);
+    expect(payload.recordBudget).toBe(50);
+    expect((payload.results as unknown[]).length).toBeGreaterThan(0);
+    expect(payload.partialReason).not.toBe('max-nodes');
+  });
+});
+
+describe('structural_analysis abort metadata (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-abort-budget-'));
+    for (let i = 0; i < 30; i++) {
+      writeFileSync(
+        join(tempDir, `f${i}.ts`),
+        `export function targetFn(): void {}\n`,
+      );
+    }
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('definitions reports truncated when aborted mid-traversal', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const controller = new AbortController();
+    const promise = runTool(
+      host,
+      { mode: 'definitions', language: 'typescript', symbol: 'targetFn' },
+      controller.signal,
+    );
+    controller.abort();
+    const result = await promise;
+    const payload = parsePayload(result);
+    expect(payload.truncated).toBe(true);
+  });
+});
+
+const NL = String.fromCharCode(10);
+
+describe('structural_analysis hierarchy parent/interface budget (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-hier-parent-'));
+    for (let i = 0; i < 20; i++) {
+      writeFileSync(
+        join(tempDir, 'f' + i + '.ts'),
+        'class Base extends P' + i + ' { }' + NL,
+      );
+    }
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('bounds the extendsParent list with one-over semantics', async () => {
+    const host = createBudgetToolHost(tempDir, 3);
+    const result = await runTool(host, {
+      mode: 'hierarchy',
+      language: 'typescript',
+      symbol: 'Base',
+    });
+    const payload = parsePayload(result);
+    expect(payload.mode).toBe('hierarchy');
+    const results = payload.results as {
+      extends: string[];
+      implements: string[];
+    };
+    expect(results.extends.length).toBeLessThanOrEqual(3);
+    expect(payload.truncated).toBe(true);
+    expect(payload.countInexact).toBe(true);
+    expect(payload.recordsObserved!).toBeGreaterThan(payload.recordsRetained!);
+  });
+
+  it('bounds the implements list with one-over semantics', async () => {
+    const implDir = mkdtempSync(join(tmpdir(), 'llxprt-hier-iface-'));
+    try {
+      for (let i = 0; i < 20; i++) {
+        writeFileSync(
+          join(implDir, 'g' + i + '.ts'),
+          'class Base implements I' + i + ' { }' + NL,
+        );
+      }
+      const host = createBudgetToolHost(implDir, 3);
+      const result = await runTool(host, {
+        mode: 'hierarchy',
+        language: 'typescript',
+        symbol: 'Base',
+      });
+      const payload = parsePayload(result);
+      const results = payload.results as {
+        extends: string[];
+        implements: string[];
+      };
+      expect(results.implements.length).toBeLessThanOrEqual(3);
+      expect(payload.truncated).toBe(true);
+      expect(payload.countInexact).toBe(true);
+    } finally {
+      rmSync(implDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('structural_analysis parse omissions mark inexact (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-parse-omit-'));
+    writeFileSync(
+      join(tempDir, 'good.ts'),
+      'export function targetFn(): void {}' + NL,
+    );
+    writeFileSync(
+      join(tempDir, 'huge.ts'),
+      'export function targetFn(): void {}' +
+        NL +
+        '// ' +
+        'x'.repeat(20 * 1024 * 1024),
+    );
+    writeFileSync(
+      join(tempDir, 'broken.ts'),
+      'class {{{' + NL + 'func(()' + NL,
+    );
+    writeFileSync(
+      join(tempDir, 'caller.ts'),
+      'export function c1(): void { targetFn(); }' + NL,
+    );
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('definitions counts oversized/unparseable omissions and marks inexact', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'definitions',
+      language: 'typescript',
+      symbol: 'targetFn',
+    });
+    const payload = parsePayload(result);
+    expect(payload.mode).toBe('definitions');
+    expect(payload.oversizedFiles!).toBeGreaterThanOrEqual(1);
+    const totalOmissions =
+      (payload.oversizedFiles ?? 0) + (payload.unparseableFiles ?? 0);
+    expect(totalOmissions).toBeGreaterThanOrEqual(1);
+    expect(payload.countInexact).toBe(true);
+  });
+
+  it('callers counts oversized omissions and marks inexact', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callers',
+      language: 'typescript',
+      symbol: 'targetFn',
+    });
+    const payload = parsePayload(result);
+    expect(payload.oversizedFiles!).toBeGreaterThanOrEqual(1);
+    expect(payload.countInexact).toBe(true);
+  });
+});
+
+describe('structural_analysis callers/callees max-nodes sentinel (issue #3202)', () => {
+  let tempDir = '';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-maxnodes-'));
+    for (let i = 0; i < 20; i++) {
+      writeFileSync(
+        join(tempDir, 'f' + i + '.ts'),
+        'export function caller' + i + '(): void { targetFn(); }' + NL,
+      );
+    }
+    writeFileSync(
+      join(tempDir, 'target.ts'),
+      'export function targetFn(): void {}' + NL,
+    );
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('callers exact maxNodes limit remains complete when no extra candidate', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callers',
+      language: 'typescript',
+      symbol: 'targetFn',
+      maxNodes: 20,
+    });
+    const payload = parsePayload(result);
+    expect(payload.truncated).toBe(false);
+    expect(payload.partialReason).toBeUndefined();
+    expect(payload.nodesObserved).toBe(20);
+    expect(payload.nodesRetained).toBe(20);
+  });
+
+  it('callers one-over maxNodes sets the max-nodes sentinel', async () => {
+    const host = createBudgetToolHost(tempDir, 500);
+    const result = await runTool(host, {
+      mode: 'callers',
+      language: 'typescript',
+      symbol: 'targetFn',
+      maxNodes: 5,
+    });
+    const payload = parsePayload(result);
+    expect(payload.truncated).toBe(true);
+    expect(payload.partialReason).toBe('max-nodes');
+    expect(payload.nodesRetained).toBeLessThanOrEqual(5);
+    expect(payload.nodesObserved!).toBeGreaterThan(payload.nodesRetained!);
+    expect(payload.nodesObserved).toBe(6);
+    expect(payload.countInexact).toBe(true);
+  });
+
+  it('callees one-over maxNodes sets the max-nodes sentinel', async () => {
+    const calleeDir = mkdtempSync(join(tmpdir(), 'llxprt-maxnodes-cal-'));
+    try {
+      writeFileSync(
+        join(calleeDir, 'main.ts'),
+        'export function t(): void { a(); b(); c(); d(); e(); f(); }' +
+          NL +
+          'export function a(): void {}' +
+          NL +
+          'export function b(): void {}' +
+          NL +
+          'export function c(): void {}' +
+          NL +
+          'export function d(): void {}' +
+          NL +
+          'export function e(): void {}' +
+          NL +
+          'export function f(): void {}' +
+          NL,
+      );
+      const host = createBudgetToolHost(calleeDir, 500);
+      const result = await runTool(host, {
+        mode: 'callees',
+        language: 'typescript',
+        symbol: 't',
+        maxNodes: 3,
+      });
+      const payload = parsePayload(result);
+      expect(payload.truncated).toBe(true);
+      expect(payload.partialReason).toBe('max-nodes');
+      expect(payload.nodesRetained).toBe(3);
+      expect(payload.nodesObserved).toBe(4);
+      const results = payload.results as unknown[];
+      expect(results.length).toBeLessThanOrEqual(3);
+    } finally {
+      rmSync(calleeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('callees exact maxNodes limit remains complete when no extra candidate', async () => {
+    const calleeDir = mkdtempSync(join(tmpdir(), 'llxprt-maxnodes-exact-'));
+    try {
+      writeFileSync(
+        join(calleeDir, 'main.ts'),
+        'export function t(): void { a(); b(); c(); }' +
+          NL +
+          'export function a(): void {}' +
+          NL +
+          'export function b(): void {}' +
+          NL +
+          'export function c(): void {}' +
+          NL,
+      );
+      const host = createBudgetToolHost(calleeDir, 500);
+      const result = await runTool(host, {
+        mode: 'callees',
+        language: 'typescript',
+        symbol: 't',
+        maxNodes: 3,
+      });
+      const payload = parsePayload(result);
+      expect(payload.truncated).toBe(false);
+      expect(payload.partialReason).toBeUndefined();
+      expect(payload.nodesObserved).toBe(3);
+      expect(payload.nodesRetained).toBe(3);
+    } finally {
+      rmSync(calleeDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('structural_analysis parseFile omission contract (issue #3202)', () => {
+  // Direct unit tests for the shared parseFile helper, which must ALWAYS
+  // return a ParseOutcome (never throw) so callers can count omissions
+  // truthfully. stat/read/parse failures all funnel into the discriminated
+  // outcome, including non-ENOENT stat errors that previously escaped the
+  // try block.
+  it('returns read-error for a directory path (EISDIR from readFile)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'llxprt-parsefile-dir-'));
+    try {
+      const { parseFile } = await import('./helpers.js');
+      const outcome = await parseFile(dir, 'typescript');
+      expect(outcome).toMatchObject({ ok: false, reason: 'read-error' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns oversized for a file exceeding the pre-read size gate', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'llxprt-parsefile-huge-'));
+    try {
+      writeFileSync(
+        join(dir, 'huge.ts'),
+        '/* ' + 'x'.repeat(21 * 1024 * 1024) + ' */\nconst x = 1;\n',
+      );
+      const { parseFile } = await import('./helpers.js');
+      const outcome = await parseFile(join(dir, 'huge.ts'), 'typescript');
+      expect(outcome).toMatchObject({ ok: false, reason: 'oversized' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns read-error for a missing file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'llxprt-parsefile-missing-'));
+    try {
+      const { parseFile } = await import('./helpers.js');
+      const outcome = await parseFile(join(dir, 'nope.ts'), 'typescript');
+      expect(outcome).toMatchObject({ ok: false, reason: 'read-error' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/tools/src/tools/structural-analysis/helpers.ts
+++ b/packages/tools/src/tools/structural-analysis/helpers.ts
@@ -8,7 +8,30 @@ import { promises as fs } from 'node:fs';
 import FastGlob from 'fast-glob';
 import type { SgNode } from '@ast-grep/napi';
 import { parse, LANGUAGE_MAP, type Lang } from '../../utils/ast-grep-utils.js';
-import type { ParsedFile, ResolvedLang } from './types.js';
+import { statFileSizeGate } from '../../utils/fileUtils.js';
+import type { ParseOmissionReason, ParsedFile, ResolvedLang } from './types.js';
+
+/**
+ * Bounded discriminated parse outcome for a single candidate file.
+ *
+ * - `{ ok: true, root, content }` — file parsed successfully.
+ * - `{ ok: false, reason }` — file was NOT parsed. `reason` distinguishes the
+ *   three omission kinds so each mode can count them and mark its result
+ *   inexact (a lower bound), and so oversized sources are never materialized.
+ */
+export type ParseOutcome =
+  | ({ ok: true } & ParsedFile)
+  | { ok: false; reason: ParseOmissionReason };
+
+/**
+ * Classify a thrown error during readFile/parse as a read error vs a parse
+ * error. Node filesystem errors carry an errno `code` (e.g. EACCES, EISDIR,
+ * ENOENT); AST parse errors throw plain Errors without one.
+ */
+function classifyReadOrParseError(err: unknown): ParseOmissionReason {
+  const code = (err as NodeJS.ErrnoException | null)?.code;
+  return typeof code === 'string' ? 'read-error' : 'parse-error';
+}
 
 const SPECIAL_REGEX_CHARS = new Set([
   '.',
@@ -117,18 +140,25 @@ export async function* iterateFiles(
 }
 
 /**
- * Parses a file and returns its root SgNode and raw content, or null on failure.
+ * Parses a file and returns a bounded discriminated outcome. An oversized
+ * source (over the shared pre-read size gate) is never read or materialized;
+ * read, stat, and parse failures carry their reason so callers can count
+ * omissions and mark the result inexact.
  */
 export async function parseFile(
   filePath: string,
   lang: string | Lang,
-): Promise<ParsedFile | null> {
+): Promise<ParseOutcome> {
   try {
+    const sizeError = await statFileSizeGate(filePath);
+    if (sizeError !== null) {
+      return { ok: false, reason: 'oversized' };
+    }
     const content = await fs.readFile(filePath, 'utf-8');
     const result = parse(lang as Lang, content);
-    return { root: result.root(), content };
-  } catch {
-    return null;
+    return { ok: true, root: result.root(), content };
+  } catch (err) {
+    return { ok: false, reason: classifyReadOrParseError(err) };
   }
 }
 
@@ -281,4 +311,4 @@ export function deduplicateCallRanges(
  */
 export { makeRelative } from '../../utils/paths.js';
 
-export type { ResolvedLang, ParsedFile };
+export type { ResolvedLang, ParsedFile, ParseOmissionReason };

--- a/packages/tools/src/tools/structural-analysis/hierarchy.ts
+++ b/packages/tools/src/tools/structural-analysis/hierarchy.ts
@@ -5,7 +5,8 @@
  */
 
 import type { ParsedFile, AnalysisResult, ResolvedLang } from './types.js';
-import { getFiles, parseFile, makeRelative } from './helpers.js';
+import { iterateFiles, parseFile, makeRelative } from './helpers.js';
+import { type AnalysisBudget, BudgetTracker } from './budget.js';
 
 interface HierarchyNode {
   name: string;
@@ -88,62 +89,73 @@ function findSymbolChildren(
   }
 }
 
-/**
- * Processes a single file for hierarchy relationships, unless aborted.
- */
-async function processHierarchyFile(
-  file: string,
-  lang: ResolvedLang,
-  workspaceRoot: string,
-  symbol: string,
-  extendsParent: string[],
-  implementsInterfaces: string[],
-  extendedBy: HierarchyNode[],
-  implementedBy: HierarchyNode[],
-): Promise<void> {
-  const parsed = await parseFile(file, lang);
-  if (!parsed) {
-    return;
-  }
-
-  const relPath = makeRelative(file, workspaceRoot);
-  findSymbolParents(parsed, symbol, extendsParent, implementsInterfaces);
-  findSymbolChildren(parsed, symbol, relPath, extendedBy, implementedBy);
-}
-
 export async function executeHierarchy(
   symbol: string,
   lang: ResolvedLang,
   searchPath: string,
   workspaceRoot: string,
   signal: AbortSignal,
+  budget: AnalysisBudget,
 ): Promise<AnalysisResult> {
-  const files = await getFiles(searchPath, lang);
+  const tracker = new BudgetTracker(budget, signal);
   const extendsParent: string[] = [];
   const implementsInterfaces: string[] = [];
   const extendedBy: HierarchyNode[] = [];
   const implementedBy: HierarchyNode[] = [];
 
-  for (const file of files) {
-    if (signal.aborted) {
-      break;
+  for await (const file of iterateFiles(searchPath, lang, signal)) {
+    if (!tracker.shouldVisitMoreFiles()) break;
+    tracker.filesVisited++;
+
+    const outcome = await parseFile(file, lang);
+    if (!outcome.ok) {
+      tracker.recordFileOmission(outcome.reason);
+    } else {
+      const relPath = makeRelative(file, workspaceRoot);
+
+      const pendingParents: string[] = [];
+      const pendingIfaces: string[] = [];
+      const pendingExtendedBy: HierarchyNode[] = [];
+      const pendingImplBy: HierarchyNode[] = [];
+      findSymbolParents(outcome, symbol, pendingParents, pendingIfaces);
+      findSymbolChildren(
+        outcome,
+        symbol,
+        relPath,
+        pendingExtendedBy,
+        pendingImplBy,
+      );
+
+      // All four relationship lists (parents, interfaces, extendedBy,
+      // implementedBy) for the current file are routed through the shared
+      // record budget. Each list stops at its first omitted record; after the
+      // current file is drained, the outer traversal stops at the next file
+      // boundary so no relationship aggregate grows without bound.
+      drainIntoRecordBudget(tracker, pendingParents, extendsParent);
+      drainIntoRecordBudget(tracker, pendingIfaces, implementsInterfaces);
+      drainIntoRecordBudget(tracker, pendingExtendedBy, extendedBy);
+      drainIntoRecordBudget(tracker, pendingImplBy, implementedBy);
     }
-    await processHierarchyFile(
-      file,
-      lang,
-      workspaceRoot,
-      symbol,
-      extendsParent,
-      implementsInterfaces,
-      extendedBy,
-      implementedBy,
-    );
+  }
+
+  if (signal.aborted) {
+    tracker.markAborted();
   }
 
   return {
     mode: 'hierarchy',
     symbol,
-    truncated: false,
+    truncated: tracker.truncated,
+    partial: tracker.truncated,
+    partialReason: tracker.partialReason,
+    fileBudget: budget.fileBudget,
+    recordBudget: budget.recordBudget,
+    filesVisited: tracker.filesVisited,
+    recordsRetained: tracker.recordsRetained,
+    recordsObserved: tracker.recordsObserved,
+    oversizedFiles: tracker.oversizedFiles,
+    unparseableFiles: tracker.unparseableFiles,
+    countInexact: tracker.countInexact,
     results: {
       extends: extendsParent,
       implements: implementsInterfaces,
@@ -151,4 +163,20 @@ export async function executeHierarchy(
       implementedBy,
     },
   };
+}
+
+/**
+ * Drain a pending relationship list into its result sink through the shared
+ * record budget. Stops this list (without pushing the overflow) when the budget
+ * sentinel fires, so the result list never exceeds the budget.
+ */
+function drainIntoRecordBudget<T>(
+  tracker: BudgetTracker,
+  pending: readonly T[],
+  sink: T[],
+): void {
+  for (const item of pending) {
+    if (!tracker.tryRetainRecord()) return;
+    sink.push(item);
+  }
 }

--- a/packages/tools/src/tools/structural-analysis/references.ts
+++ b/packages/tools/src/tools/structural-analysis/references.ts
@@ -243,13 +243,15 @@ async function trySearchReferencesForFile(
   workspaceRoot: string,
   symbol: string,
   addResult: AddResultFn,
+  tracker: BudgetTracker,
 ): Promise<boolean> {
-  const parsed = await parseFile(file, lang);
-  if (!parsed) {
+  const outcome = await parseFile(file, lang);
+  if (!outcome.ok) {
+    tracker.recordFileOmission(outcome.reason);
     return true;
   }
   const relPath = makeRelative(file, workspaceRoot);
-  return searchAllReferenceCategories(parsed, symbol, relPath, addResult);
+  return searchAllReferenceCategories(outcome, symbol, relPath, addResult);
 }
 
 export async function executeReferences(
@@ -301,6 +303,7 @@ export async function executeReferences(
       workspaceRoot,
       symbol,
       addResult,
+      tracker,
     );
   };
 
@@ -328,6 +331,8 @@ export async function executeReferences(
     filesVisited: tracker.filesVisited,
     recordsRetained: tracker.recordsRetained,
     recordsObserved: tracker.recordsObserved,
+    oversizedFiles: tracker.oversizedFiles,
+    unparseableFiles: tracker.unparseableFiles,
     countInexact: tracker.countInexact,
     results: { categories, counts },
   };

--- a/packages/tools/src/tools/structural-analysis/types.ts
+++ b/packages/tools/src/tools/structural-analysis/types.ts
@@ -34,7 +34,14 @@ export interface StructuralAnalysisParams {
 }
 
 /** Reason a bounded traversal stopped before exhausting the workspace. */
-export type PartialReason = 'file-budget' | 'record-budget' | 'aborted';
+export type PartialReason =
+  | 'file-budget'
+  | 'record-budget'
+  | 'max-nodes'
+  | 'aborted';
+
+/** Reason a single file could not be parsed into the analysis. */
+export type ParseOmissionReason = 'oversized' | 'read-error' | 'parse-error';
 
 export interface AnalysisResult {
   mode: string;
@@ -59,18 +66,30 @@ export interface AnalysisResult {
    * bound (at least retained+1) when a sentinel proved partiality.
    */
   recordsObserved?: number;
+  /**
+   * For callers/callees, the node-candidate count (direct/member/callee
+   * insertions attempted), bounded by the effective max-nodes limit. Equals
+   * {@link nodesRetained} for an exact complete traversal; at least
+   * retained+1 when the max-nodes sentinel proved partiality.
+   */
+  nodesObserved?: number;
+  /**
+   * Node candidates actually retained (accepted into the result) for
+   * callers/callees, bounded by the effective max-nodes limit.
+   */
+  nodesRetained?: number;
+  /**
+   * Number of candidate files skipped because they exceeded the pre-read size
+   * gate. Each makes the match count a lower bound (inexact).
+   */
+  oversizedFiles?: number;
+  /**
+   * Number of candidate files that could not be read or parsed. Each makes the
+   * match count a lower bound (inexact).
+   */
+  unparseableFiles?: number;
   /** True when retained/visited counts are lower bounds, not exhaustive totals. */
   countInexact?: boolean;
-}
-
-/**
- * Traversal context shared across recursive callers/callees analysis.
- */
-export interface TraversalContext {
-  nodesVisited: number;
-  maxNodes: number;
-  truncated: boolean;
-  signal: AbortSignal;
 }
 
 /**

--- a/packages/tools/src/tools/tool-registry.ts
+++ b/packages/tools/src/tools/tool-registry.ts
@@ -321,6 +321,9 @@ Signal: Signal number or \`(none)\` if no signal was received.
     const stderr = acquisition.stderrText;
     const truncated = acquisition.metadata.truncated;
     const truncationNotice = acquisition.omissionNotice ?? '';
+    const truncationMetadata = truncated
+      ? { metadata: { outputTruncation: acquisition.metadata } }
+      : {};
 
     const terminationFailed =
       terminationOutcome === 'timeout' || terminationOutcome === 'failure';
@@ -346,6 +349,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
       return {
         llmContent: fullContent,
         returnDisplay: fullContent,
+        ...truncationMetadata,
         error: {
           message: fullContent,
           type: ToolErrorType.DISCOVERED_TOOL_EXECUTION_ERROR,
@@ -358,6 +362,7 @@ Signal: Signal number or \`(none)\` if no signal was received.
     return {
       llmContent,
       returnDisplay: llmContent,
+      ...truncationMetadata,
     };
   }
 }

--- a/project-plans/issue3202/plan.md
+++ b/project-plans/issue3202/plan.md
@@ -1,0 +1,105 @@
+# Plan: Issue #3202 — Bounded Acquisition Memory Boundary (Parent)
+
+## Overview
+
+This is the parent-issue PR that completes the remaining accepted scope for
+bounded acquisition across all tool subsystems. Prior child issues (#3200,
+#3201, #3203, #3204, #3205) established the acquisition primitives
+(`packages/tools/src/acquisition`), bounded subprocess output, bounded
+external HTTP acquisition, and bounded workspace analysis (references,
+dependencies, exports). This PR ties up the remaining blocker and in-scope
+findings.
+
+## Accepted Behavior Summary
+
+### A. Shared Acquisition Boundary
+- `packages/tools/src/acquisition` is the explicit package subpath for
+  acquisition primitives and LLxprt-owned read-loop adapters.
+- HTTP response adapter moves from `src/utils` → `src/acquisition`.
+- Shared acquisition code may create/validate immutable finite byte budgets
+  but must NOT interpret raw settings policy. Move `-1`, default, invalid-string,
+  and disabled-value semantics into existing owning core/CLI boundaries.
+
+### B. Grep/Ripgrep and Discovered Tools
+- Direct-file grep/ripgrep and JavaScript fallback must not `readFile` and
+  `split` whole files before limits. Reuse streaming line framing and semantic
+  budget primitives.
+- Preserve subprocess early-stop/process-lifecycle ownership and correctness.
+- Attach additive structured partial metadata to grep/ripgrep results.
+
+### C. Structural Analysis
+- Definitions, hierarchy, callers, and callees must receive `AnalysisBudget`,
+  use lazy bounded file traversal, apply the shared pre-read file-size policy,
+  enforce finite file and record/result budgets, hard-clamp `maxNodes`,
+  preserve exact-boundary/one-over semantics, and report abort/budget partial
+  metadata truthfully.
+
+### D. AST Grep
+- Hard-validate/cap `maxResults`; bound include/exclude discovery.
+- Apply the shared pre-read file-size gate before reading/parsing.
+- Report partial results for result, file, oversized-file, and abort limits.
+
+### E. MCP
+- Enforce one aggregate finite byte budget across every result field/variant:
+  `content`, compatibility `toolResult`, `structuredContent`, `_meta`, and
+  extension payloads.
+- Reject overflow atomically before display/model transformation; avoid full
+  `JSON.stringify` before budget validation.
+
+### F. Read-Many-Files
+- Resolve finite hard-clamped file/record and aggregate byte budgets before
+  discovery. Use streaming/bounded discovery rather than accumulating all
+  paths and limiting later. Report one-over partial discovery explicitly.
+- Maintain a finite aggregate acquisition byte budget independent of
+  `tool-output-max-tokens`.
+
+## Boundary Cases and Behavioral Evidence Required
+
+- Exact budget and one byte over.
+- Empty input.
+- One huge source/chunk/line and many tiny chunks/lines/files.
+- UTF-8 multibyte characters split at chunk boundaries and CRLF.
+- Broad include/exclude globs and discovery one-over.
+- Oversized file before parse/read.
+- Pre-abort and abort during traversal/read.
+- Truthfully partial metadata and non-exhaustive wording end-to-end.
+- MCP `toolResult`, `structuredContent`, metadata/extensions, mixed aggregate,
+  exact/one-over, atomic failure.
+- Structural definitions/hierarchy/callers/callees file/record budgets,
+  `maxNodes` hard cap, abort.
+- Read-many-files permissive token settings still bounded by byte acquisition
+  budget.
+- Package subpath/boundary tests.
+
+## Review Finding Classification
+
+### Blocker-Fix
+1. Grep/ripgrep direct-file and JS fallback materialization
+2. Four unbounded structural modes (definitions, hierarchy, callers, callees)
+3. AST-grep unbounded path/match acquisition (pre-read file-size gate)
+4. MCP non-content bypass (budget toolResult, structuredContent, _meta)
+5. Read-many-files discovery/aggregate token-boundary reliance
+
+### In-scope-Fix
+6. Local subprocess/search structured partial metadata
+7. Raw setting policy in shared layer
+8. HTTP adapter location
+
+### Defer
+- True pre-materialization MCP frame cap (SDK has no option)
+
+### Reject
+- Replacing specialized prompt/event queues with generic collector
+- Defensive open/fstat wrappers for speculative post-stat races
+- Workflow redesign
+
+## Implementation Order
+
+1. HTTP adapter relocation (structural, low risk)
+2. Raw setting policy move (removes settings coupling from acquisition)
+3. Grep direct-file streaming (TDD: failing test → implementation)
+4. Grep structured partial metadata
+5. Structural analysis four bounded modes
+6. AST-grep pre-read file-size gate
+7. MCP aggregate budget for all variants
+8. Read-many-files streaming discovery + byte budget


### PR DESCRIPTION
## TLDR

Bounds tool data while it is being acquired, before whole files, response bodies, result trees, or discovery sets can be materialized without limit. Partial results now carry structured metadata that distinguishes exact completion from lower-bound or interrupted acquisition.

## Dive Deeper

- Moves bounded HTTP response acquisition into the tools acquisition package and makes close/error/abort settlement and cancellation authoritative.
- Keeps raw shell-setting interpretation in core/CLI ownership while shared acquisition primitives remain policy-neutral.
- Bounds grep/ripgrep and JavaScript fallback source observation, including direct-file, no-match, multibyte, CRLF, abort, and invocation-wide budget cases.
- Bounds ast-grep and structural-analysis discovery, parsing, file sizes, records, and node traversal with one-over evidence and truthful omission metadata.
- Bounds read-many-files discovery records before filtering/deduplication and separately bounds aggregate retained bytes with UTF-8-safe marker-aware truncation.
- Measures the complete own-enumerable MCP result JSON tree atomically with bounded recursive byte accounting.
- Propagates grep and discovered-tool acquisition truncation through structured ToolResult metadata.

Reviewers should pay particular attention to exact-limit versus first-over-limit behavior and to metadata emitted after aborts, skipped files, parse omissions, and bounded discovery.

## Reviewer Test Plan

1. Run npm run typecheck, npm run build, npm run lint:eslint-guard, and npm run format.
2. Run the focused Bun suites for tools acquisition, grep, ast-grep, read-many-files, structural analysis, MCP result budgeting, and core setting resolution.
3. Exercise exact-limit and one-over cases and confirm exact limits remain complete while the first omitted record marks results partial/inexact.
4. Run bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else".

Local evidence on macOS:
- 273 issue-focused Bun tests passed in the final coordinator runs.
- Repository typecheck and build passed serially.
- Scoped ESLint over every changed TypeScript file passed with a 12 GiB heap.
- ESLint policy guard and formatting passed.
- StepFun real-model smoke passed and returned only a haiku.
- A full workspace npm test attempt exceeded the command runtime ceiling after progressing through core; no issue-related failure was observed, so this is not represented as a complete workspace test pass.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bounded output controls and truncation metadata for tools, file reads, searches, and structural analysis.
  - Added reporting for partial results, skipped or oversized files, parsing issues, observed counts, and budget usage.
  - Added strict result validation and hard caps for AST-grep and structural analysis.
  - MCP size limits now include complete JSON structure, metadata, escaping, and nested fields.

- **Bug Fixes**
  - Improved handling of prematurely closed or interrupted HTTP responses.
  - Shell output budgets now resolve consistently across supported integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->