### PR TITLE
Clear JSON-mode responseText on tool-call; fix Windows CI timeout; add evals-nightly issue creation (Fixes #3226, #3227, #3228)

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -198,7 +198,21 @@ jobs:
             CREATE_ARGS=(--repo "${GH_REPO}" --title "${ISSUE_TITLE}" --body-file "${BODY_FILE}")
             CREATE_ARGS+=("${LABEL_ARGS[@]}")
             CREATE_ARGS+=("${MILESTONE_ARGS[@]}")
-            retry_gh gh issue create "${CREATE_ARGS[@]}" || {
+            create_issue_once() {
+              local found=""
+              found="$(gh issue list \\
+                --repo "${GH_REPO}" \\
+                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open" \\
+                --limit 30 \\
+                --json number,title \\
+                --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty" 2>/dev/null)" || found=""
+              if [[ -n "${found}" ]]; then
+                echo "Issue #${found} already exists; skipping creation." >&2
+                return 0
+              fi
+              gh issue create "${CREATE_ARGS[@]}"
+            }
+            retry_gh create_issue_once || {
               echo "ERROR: Failed to create evals nightly failure issue" >&2
               exit 1
             }

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -54,3 +54,152 @@ jobs:
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: bun scripts/aggregate_evals.ts artifacts >> "$GITHUB_STEP_SUMMARY"
+
+  notify_failure:
+    name: 'Create Issue on Failure'
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    needs: [evals]
+    if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+    permissions:
+      issues: 'write'
+      contents: 'read'
+    steps:
+      - name: 'Create Issue on Failure'
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_REPO: '${{ github.repository }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          EVALS_RESULT: '${{ needs.evals.result }}'
+        shell: 'bash'
+        run: |
+          set -euo pipefail
+          ISSUE_TITLE="Evals Nightly workflow failed"
+
+          if [[ ! "${EVALS_RESULT}" =~ ^(failure|cancelled)$ ]]; then
+            echo "Evals job did not fail or get cancelled; nothing to report."
+            exit 0
+          fi
+
+          ensure_label() {
+            local name="$1"
+            local color="$2"
+            local description="$3"
+            local existing=""
+            local create_err=""
+            if create_err="$(gh label create "${name}" --repo "${GH_REPO}" --color "${color}" --description "${description}" 2>&1 >/dev/null)"; then
+              return
+            fi
+            if ! existing="$(gh label list --repo "${GH_REPO}" --search "${name}" --json name --jq ".[] | select(.name == \"${name}\") | .name" 2>&1)"; then
+              echo "Failed to check for label: ${name}" >&2
+              echo "  create error: ${create_err}" >&2
+              echo "  list error: ${existing}" >&2
+              return 1
+            fi
+            if [[ "${existing}" != "${name}" ]]; then
+              echo "Failed to create or find label: ${name}" >&2
+              return 1
+            fi
+          }
+
+          # Resolve the milestone for the version currently being worked on in
+          # main so the auto-created issue surfaces in the release view. Source
+          # of truth is the root package.json version on main. Fails soft: an
+          # unresolvable milestone logs a warning and returns empty.
+          resolve_milestone() {
+            local package_json
+            if ! package_json="$(gh api "repos/${GH_REPO}/contents/package.json?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null)"; then
+              echo "Warning: could not read package.json from main; skipping milestone resolution" >&2
+              return
+            fi
+            local current_version
+            current_version="$(printf '%s' "${package_json}" | jq -r '.version // empty' 2>/dev/null)"
+            if [[ -z "${current_version}" ]]; then
+              echo "Warning: package.json on main has no version field; skipping milestone resolution" >&2
+              return
+            fi
+            local milestone_title
+            milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" --jq "[.[][] | select(.title == \"${current_version}\")] | .[0].title // empty" 2>/dev/null)"
+            if [[ -z "${milestone_title}" ]]; then
+              echo "Warning: no open milestone titled '${current_version}'; skipping milestone assignment" >&2
+              return
+            fi
+            printf '%s' "${milestone_title}"
+          }
+
+          LABEL_ARGS=()
+          if ensure_label "ci/cd" "e33539" "Issues with github and the workflow scripts and CI CD environment."; then
+            LABEL_ARGS+=(--label "ci/cd")
+          else
+            echo "Warning: continuing without ci/cd label" >&2
+          fi
+
+          MILESTONE_TITLE="$(resolve_milestone)"
+          MILESTONE_ARGS=()
+          if [[ -n "${MILESTONE_TITLE}" ]]; then
+            MILESTONE_ARGS+=(--milestone "${MILESTONE_TITLE}")
+          fi
+
+          retry_gh() {
+            local attempt
+            for attempt in 1 2 3 4; do
+              if "$@"; then
+                return 0
+              fi
+              if [[ "${attempt}" -lt 4 ]]; then
+                echo "Attempt ${attempt} failed, retrying issue notification" >&2
+                sleep 5
+              fi
+            done
+            echo "All retries exhausted for: $*" >&2
+            return 1
+          }
+
+          build_body_file() {
+            local body_file="$1"
+            local introduction="$2"
+            {
+              printf '%s\n\n' "${introduction}"
+              printf 'Full run: %s\n' "${RUN_URL}"
+            } > "${body_file}"
+          }
+
+          if ! EXISTING_ISSUE="$(
+            retry_gh gh issue list \
+              --repo "${GH_REPO}" \
+              --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
+              --limit 30 \
+              --json number,title \
+              --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty"
+          )"; then
+            echo "ERROR: Failed to search for existing issues; aborting to avoid duplicates." >&2
+            exit 1
+          fi
+
+          BODY_FILE=issue_body.md
+          if [[ -n "${EXISTING_ISSUE}" ]]; then
+            INTRODUCTION="Evals Nightly workflow failed again on $(date +'%Y-%m-%d'). Eval job result: ${EVALS_RESULT}."
+            build_body_file "${BODY_FILE}" "${INTRODUCTION}"
+            retry_gh gh issue comment "${EXISTING_ISSUE}" \
+              --repo "${GH_REPO}" \
+              --body-file "${BODY_FILE}" || {
+              echo "ERROR: Failed to comment on existing issue #${EXISTING_ISSUE}" >&2
+              exit 1
+            }
+            if [[ -n "${MILESTONE_TITLE}" ]]; then
+              retry_gh gh issue edit "${EXISTING_ISSUE}" \
+                --repo "${GH_REPO}" \
+                --milestone "${MILESTONE_TITLE}" || \
+                echo "Warning: failed to set milestone '${MILESTONE_TITLE}' on existing issue #${EXISTING_ISSUE}" >&2
+            fi
+          else
+            INTRODUCTION="The evals nightly workflow failed. Eval job result: ${EVALS_RESULT}."
+            build_body_file "${BODY_FILE}" "${INTRODUCTION}"
+            CREATE_ARGS=(--repo "${GH_REPO}" --title "${ISSUE_TITLE}" --body-file "${BODY_FILE}")
+            CREATE_ARGS+=("${LABEL_ARGS[@]}")
+            CREATE_ARGS+=("${MILESTONE_ARGS[@]}")
+            retry_gh gh issue create "${CREATE_ARGS[@]}" || {
+              echo "ERROR: Failed to create evals nightly failure issue" >&2
+              exit 1
+            }
+          fi

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -200,12 +200,7 @@ jobs:
             CREATE_ARGS+=("${MILESTONE_ARGS[@]}")
             create_issue_once() {
               local found=""
-              found="$(gh issue list \\
-                --repo "${GH_REPO}" \\
-                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open" \\
-                --limit 30 \\
-                --json number,title \\
-                --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty" 2>/dev/null)" || found=""
+              found="$(gh issue list --repo "${GH_REPO}" --search "\"${ISSUE_TITLE}\" in:title is:issue state:open" --limit 30 --json number,title --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty" 2>/dev/null)" || found=""
               if [[ -n "${found}" ]]; then
                 echo "Issue #${found} already exists; skipping creation." >&2
                 return 0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
   windows_ci:
     name: 'Windows CI (Nightly)'
     runs-on: '${{ matrix.os }}'
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/packages/cli/src/nonInteractiveCli.jsonOutput.test.ts
+++ b/packages/cli/src/nonInteractiveCli.jsonOutput.test.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type Config, uiTelemetryService } from '@vybestack/llxprt-code-core';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+import { processAgentStream } from './nonInteractiveCliSupport.js';
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import type { Mock } from 'bun:test';
+
+async function* streamFromEvents(
+  events: AgentEvent[],
+): AsyncIterable<AgentEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function createMockConfig(): Config {
+  return {
+    getSessionId: () => 'test-session',
+    getEphemeralSetting: () => undefined,
+  } as unknown as Config;
+}
+
+interface JsonResponse {
+  response: string;
+}
+
+/**
+ * Extract the JSON object emitted by emitFinalResult in JSON output mode.
+ * The final result is a single JSON object written to stdout.
+ */
+function extractJsonResponse(
+  stdoutCalls: Array<[unknown, ...unknown[]]>,
+): JsonResponse {
+  const raw = stdoutCalls
+    .map(([value]) => String(value))
+    .join('')
+    .trim();
+  return JSON.parse(raw) as JsonResponse;
+}
+
+describe('processAgentStream — JSON output mode (issue #3226)', () => {
+  let processStdoutSpy: Mock<typeof process.stdout.write>;
+
+  beforeEach(() => {
+    processStdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createContext() {
+    return {
+      config: createMockConfig(),
+      jsonOutput: true,
+      streamJsonOutput: false,
+      quiet: false,
+      streamFormatter: null,
+      emojiFilter: undefined,
+      createProfileNameWriter: () => () => {},
+    };
+  }
+
+  it('discards intermediate text before a tool call and emits only the final answer in the JSON response', async () => {
+    // Model states the answer "$blue$" in the first iteration, then calls a
+    // tool, then states "$blue$" again in the final iteration. Without the
+    // fix, responseText accumulates both, producing "$blue$$blue$".
+    const events: AgentEvent[] = [
+      { type: 'text', text: '$blue$' },
+      {
+        type: 'tool-call',
+        call: { id: 'tool-1', name: 'save_memory', args: {} },
+      },
+      {
+        type: 'tool-result',
+        result: {
+          id: 'tool-1',
+          name: 'save_memory',
+          display: 'saved',
+          isError: false,
+        },
+      },
+      { type: 'text', text: '$blue$' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const result = extractJsonResponse(processStdoutSpy.mock.calls);
+    expect(result.response).toBe('$blue$');
+    expect(result.response).not.toBe('$blue$$blue$');
+  });
+
+  it('keeps all text when no tool calls occur', async () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'The answer is 42.' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const result = extractJsonResponse(processStdoutSpy.mock.calls);
+    expect(result.response).toBe('The answer is 42.');
+  });
+
+  it('keeps only the last iteration when multiple tool calls occur', async () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'First answer.' },
+      {
+        type: 'tool-call',
+        call: { id: 'tool-1', name: 'read_file', args: {} },
+      },
+      {
+        type: 'tool-result',
+        result: {
+          id: 'tool-1',
+          name: 'read_file',
+          display: 'data',
+          isError: false,
+        },
+      },
+      { type: 'text', text: 'Second answer.' },
+      {
+        type: 'tool-call',
+        call: { id: 'tool-2', name: 'write_file', args: {} },
+      },
+      {
+        type: 'tool-result',
+        result: {
+          id: 'tool-2',
+          name: 'write_file',
+          display: 'written',
+          isError: false,
+        },
+      },
+      { type: 'text', text: 'Final answer.' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const result = extractJsonResponse(processStdoutSpy.mock.calls);
+    expect(result.response).toBe('Final answer.');
+    expect(result.response).not.toContain('First answer.');
+    expect(result.response).not.toContain('Second answer.');
+  });
+
+  it('keeps text after the last tool call even when the model speaks before it', async () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'Let me save that.' },
+      {
+        type: 'tool-call',
+        call: { id: 'tool-1', name: 'save_memory', args: {} },
+      },
+      {
+        type: 'tool-result',
+        result: {
+          id: 'tool-1',
+          name: 'save_memory',
+          display: 'saved',
+          isError: false,
+        },
+      },
+      { type: 'text', text: 'Done. My favorite color is blue.' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const result = extractJsonResponse(processStdoutSpy.mock.calls);
+    expect(result.response).toBe('Done. My favorite color is blue.');
+    expect(result.response).not.toContain('Let me save that.');
+  });
+});

--- a/packages/cli/src/nonInteractiveCli.jsonOutput.test.ts
+++ b/packages/cli/src/nonInteractiveCli.jsonOutput.test.ts
@@ -41,7 +41,18 @@ function extractJsonResponse(
     .map(([value]) => String(value))
     .join('')
     .trim();
-  return JSON.parse(raw) as JsonResponse;
+  if (raw === '') {
+    throw new Error(
+      'Expected JSON output from processAgentStream but stdout was empty',
+    );
+  }
+  try {
+    return JSON.parse(raw) as JsonResponse;
+  } catch {
+    throw new Error(
+      `Expected valid JSON from processAgentStream but got: ${raw.slice(0, 200)}`,
+    );
+  }
 }
 
 describe('processAgentStream — JSON output mode (issue #3226)', () => {

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -558,6 +558,12 @@ function dispatchAgentEvent(
         state.thoughtBuffer,
         includeThinking,
       );
+      // Discard intermediate talk emitted before a tool call so only the
+      // final iteration's answer remains in responseText — the JSON-mode
+      // counterpart of quiet mode's quietTextBuffer discard (issue #728).
+      // Without this, models that state the answer before calling tools
+      // yield a duplicated response (issue #3226).
+      state.responseText = '';
       emitToolUse(event.call, context.streamFormatter);
       return;
     case 'tool-result':


### PR DESCRIPTION
## TLDR

Three fixes addressing the nightly/evals-nightly failure investigation:

1. **Fix #3226 -- save_memory eval duplication**: In JSON output mode, when the model states the answer before calling tools (common with step-3.7-flash) and repeats it in the final iteration, responseText accumulated ALL text across iterations, producing doubled output (e.g. the canonical answer repeated twice). This broke evals-nightly for 7 consecutive days (8/07-8/13). The fix clears responseText on tool-call events, mirroring the quiet-mode discard already in place since #728.
2. **Fix #3227 -- Windows CI (Nightly) timeout**: PR #3154 reduced the timeout from 60 to 30 min, but the test suite takes ~47-50 min, so the job was always cancelled. Bumped back to 60 min.
3. **Fix #3228 -- evals-nightly missing auto-issue-creation**: Unlike nightly.yml, evals-nightly.yml had no notify_failure job, so eval failures created zero tracked issues. Added a notify_failure job mirroring nightly.yml's pattern (label creation, milestone resolution, dedup, retry logic).

## Dive Deeper

### Root Cause: JSON-mode text duplication (#3226)

The evals-nightly workflow (`evals-nightly.yml`) calls `_evals-run.yml` with 3 retry attempts. Starting 8/07, at least one attempt per night failed because the save_memory eval received a 12-character response (the canonical answer duplicated) instead of the expected 6-character answer.

**Investigation**: Downloaded the eval artifacts from the 8/13 run. The passing attempts returned the correct 6-char answer. The failing attempt returned a 12-char answer -- exactly doubled. The model (step-3.7-flash) emitted the answer text in an intermediate iteration (before/during tool calls), then repeated it in the final iteration.

**Code path**: In `nonInteractiveCliSupport.ts`, the `handleText` function in JSON mode returns `responseText + outputValue`, accumulating text across ALL model iterations. Quiet mode already discarded intermediate text on tool-call events (`handleQuietEvent` clears `quietTextBuffer`, issue #728). JSON/Non-quiet mode had no equivalent discard.

**Fix**: Added `state.responseText = ''` in `dispatchAgentEvent`'s `case 'tool-call':` handler. This is safe for stream-json and plain-text modes because `handleText` returns `responseText` unchanged in those modes (the clear is a no-op).

**Git bisect window**: Two commits touched `nonInteractiveCliSupport.ts` right before the breakage: `e408e1fdd` (changed only a comment) and `1af23ee9b` (added retry/discard logic). Neither directly caused the bug -- the accumulation behavior predates them. The breakage on 8/07 coincides with the model (step-3.7-flash) starting to emit answer text before tool calls more frequently, exposing the latent accumulation gap.

### Windows CI timeout (#3227)

PR #3154 (commit `a805a219f`, merged 8/08) reduced `timeout-minutes` from 60 to 30 for the `windows_ci` job in nightly.yml as part of "Restore a green nightly." This was incorrect -- the Windows test suite takes 47-50 minutes. Every nightly run since has had the Windows CI job cancelled (8/11-8/13). Fix: restore `timeout-minutes: 60`.

### Evals-nightly issue creation (#3228)

The nightly.yml workflow has a `notify_failure` job that auto-creates a GitHub issue when any job fails (with label, milestone, and dedup). The evals-nightly.yml had no equivalent. This meant 7 consecutive eval-nightly failures created zero tracked issues. Added a `notify_failure` job with the same structure as nightly.yml's.

## Reviewer Test Plan

1. **JSON-mode duplication fix**: Run the behavioral test:

   ```
   bun test packages/cli/src/nonInteractiveCli.jsonOutput.test.ts
   ```

   Four tests verify: (a) all text is kept when no tool calls occur, (b) only the last iteration's text survives when tool calls happen, (c) text after the last tool call is preserved, (d) intermediate text before a tool call is discarded.

2. **Windows timeout**: Verify the nightly.yml change sets `timeout-minutes: 60` for the `windows_ci` job (line 29).

3. **Evals-nightly notify_failure**: Validate the YAML structure:

   ```
   python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/evals-nightly.yml')); print('notify_failure' in d['jobs'])"
   ```

   Should print `True`.

## Testing Matrix

|          | Apple | Windows | Linux |
| -------- | --- | --- | --- |
| npm run  | pass | ? | ? |
| npx      | pass | ? | ? |
| Docker   | ? | ? | ? |
| Podman   | ? | - | - |
| Seatbelt | ? | - | - |

Verified on macOS (Apple Silicon):
- ESLint: clean on changed files
- TypeScript typecheck: clean (cli package)
- Prettier: all changed files pass
- Build: npm run build exit 0
- Tests: 93 nonInteractive tests pass (8 files), 4 new JSON-mode tests pass
- Smoke test: stepfun-37 haiku generation works
- YAML validation: evals-nightly.yml parses correctly with notify_failure job present

## Linked issues / bugs

- Fixes #3226 -- JSON-mode responseText duplication causes save_memory eval failure
- Fixes #3227 -- Windows CI (Nightly) timeout too low (30 min, needs 60 min)
- Fixes #3228 -- evals-nightly.yml missing notify_failure auto-issue-creation job


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON output so intermediate text before tool calls no longer appears in final responses.
  - Ensured final output contains only the relevant text after tool execution.

- **CI Improvements**
  - Increased the Windows nightly CI timeout from 30 to 60 minutes.
  - Added automated failure notifications for nightly evaluations, including issue tracking and workflow details.

- **Tests**
  - Added coverage for JSON responses involving tool calls, multiple iterations, and text-only responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->