### PR TITLE
fix(cli): stop pasted terminal output from triggering full workspace crawls

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.pastedOutput.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.pastedOutput.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  handleAtCommand,
+  applyPowerShellAtAlias,
+} from './atCommandProcessor.js';
+import type { AgentToolHandle } from '@vybestack/llxprt-code-agents';
+import * as path from 'path';
+import {
+  createTestFile,
+  setupAtCommandTest,
+  teardownAtCommandTest,
+  type AtCommandTestSetup,
+} from './atCommandProcessor-test-helpers.js';
+
+/**
+ * Regression coverage for the paste-induced memory exhaustion: copying an
+ * LLxprt pane back into the prompt turned ordinary decoration ("Ctrl+Q",
+ * "+------", the "@path/to/file" placeholder hint) into @-path commands. Every
+ * unresolved one fell back to a full recursive workspace crawl, and a crawl
+ * for a candidate as broad as a single "Q" matches essentially every file in
+ * the tree, retaining a stat record for each.
+ */
+describe('handleAtCommand (pasted terminal output)', () => {
+  let setup: AtCommandTestSetup;
+  let testRootDir: string;
+  let globPatterns: string[];
+  let getToolHandle: (name: string) => AgentToolHandle | undefined;
+
+  beforeEach(async () => {
+    setup = await setupAtCommandTest();
+    testRootDir = setup.testRootDir;
+    globPatterns = [];
+
+    // Observe the real glob tool rather than replacing it: the tool still
+    // runs, we just record which recursive searches were actually launched.
+    getToolHandle = (name: string): AgentToolHandle | undefined => {
+      const handle = setup.getToolHandle(name);
+      if (handle === undefined || name !== 'glob') return handle;
+      return {
+        ...handle,
+        buildAndExecute: async (params, signal) => {
+          const pattern = (params as { pattern?: unknown }).pattern;
+          globPatterns.push(String(pattern));
+          return handle.buildAndExecute(params, signal);
+        },
+      };
+    };
+  });
+
+  afterEach(async () => {
+    await teardownAtCommandTest(setup);
+  });
+
+  describe('PowerShell "+" alias token rules', () => {
+    it.each([
+      ['Press Ctrl+Q to quit', 'Press Ctrl+Q to quit'],
+      ['+------------------+', '+------------------+'],
+      ['1108 +     anisotropy_clamp: 16,', '1108 +     anisotropy_clamp: 16,'],
+      ['a+b+c', 'a+b+c'],
+      ['2+2 equals 4', '2+2 equals 4'],
+    ])('leaves %p unchanged', (input, expected) => {
+      expect(applyPowerShellAtAlias(input)).toBe(expected);
+    });
+
+    it.each([
+      ['+notes.txt', '@notes.txt'],
+      ['see +src/main.ts here', 'see @src/main.ts here'],
+      ['+./relative.ts', '@./relative.ts'],
+      ['+~/home.ts', '@~/home.ts'],
+      ['+a.txt and +b.txt', '@a.txt and @b.txt'],
+    ])('still aliases %p at a token start', (input, expected) => {
+      expect(applyPowerShellAtAlias(input)).toBe(expected);
+    });
+  });
+
+  it('does not launch a recursive search for unspecific @ tokens', async () => {
+    await createTestFile(path.join(testRootDir, 'quickstart.md'), 'hello');
+
+    await handleAtCommand({
+      query: 'Look at @Q and @-- and @.. for details',
+      config: setup.mockConfig,
+      addItem: setup.mockAddItem,
+      onDebugMessage: setup.mockOnDebugMessage,
+      messageId: 900,
+      signal: setup.abortController.signal,
+      getToolHandle,
+    });
+
+    expect(globPatterns).toStrictEqual([]);
+  });
+
+  it('caps how many recursive searches a single query can launch', async () => {
+    await createTestFile(path.join(testRootDir, 'present.txt'), 'hello');
+
+    await handleAtCommand({
+      query: 'Check @alpha1 @bravo2 @charlie3 @delta4 @echo5 please',
+      config: setup.mockConfig,
+      addItem: setup.mockAddItem,
+      onDebugMessage: setup.mockOnDebugMessage,
+      messageId: 901,
+      signal: setup.abortController.signal,
+      getToolHandle,
+    });
+
+    expect(globPatterns.length).toBeLessThanOrEqual(3);
+  });
+
+  it('stays bounded when an LLxprt pane is pasted back into the prompt', async () => {
+    await createTestFile(path.join(testRootDir, 'quickstart.md'), 'hello');
+
+    const pastedPane = [
+      '+----------------------------------------------------------+',
+      '| >   Type your message, @path/to/file or +path/to/file     |',
+      '+----------------------------------------------------------+',
+      '  Ctrl+Q to minimize   Ctrl+T to toggle   ~/projects/demo',
+    ].join('\n');
+
+    await handleAtCommand({
+      query: pastedPane,
+      config: setup.mockConfig,
+      addItem: setup.mockAddItem,
+      onDebugMessage: setup.mockOnDebugMessage,
+      messageId: 902,
+      signal: setup.abortController.signal,
+      getToolHandle,
+    });
+
+    expect(globPatterns.length).toBeLessThanOrEqual(3);
+    // A single-character search matches nearly every file in a workspace.
+    expect(globPatterns).not.toContain('**/*Q*');
+    for (const pattern of globPatterns) {
+      expect(pattern).not.toMatch(/\*\*\/\*-+\*/);
+    }
+  });
+});

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -57,6 +57,20 @@ const isPowerShell = Boolean(
 // Track if we've shown the PowerShell tip
 let powershellTipShown = false;
 
+// The '+' alias only applies when '+' starts a token and is followed by a
+// character a path can actually begin with. Rewriting every '+' turned
+// ordinary prose ("Ctrl+Q") and box drawing ("+-----") into @-paths, and each
+// bogus path triggered a full recursive workspace crawl.
+const POWERSHELL_AT_ALIAS = /(^|\s)\+(?=[A-Za-z0-9_./\\~])/g;
+
+/**
+ * Applies the PowerShell-only '+' alias for '@'. Exported so the token rules
+ * can be exercised directly, independently of the host shell.
+ */
+export function applyPowerShellAtAlias(query: string): string {
+  return query.replace(POWERSHELL_AT_ALIAS, '$1@');
+}
+
 interface HandleAtCommandParams {
   query: string;
   config: AtCommandRuntime;
@@ -132,7 +146,7 @@ function parseAllAtCommands(query: string): AtCommandPart[] {
   // In PowerShell, also support '+' prefix as alternative to '@'
   // This avoids PowerShell's hashtable completion interference
   if (isPowerShell) {
-    query = query.replace(/\+(?=\S)/g, '@');
+    query = applyPowerShellAtAlias(query);
   }
 
   const parts: AtCommandPart[] = [];

--- a/packages/cli/src/ui/hooks/atCommandProcessorHelpers.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessorHelpers.ts
@@ -66,6 +66,7 @@ interface ResolutionState {
   absoluteToRelativePathMap: Map<string, string>;
   ignoredByReason: IgnoredByReason;
   selectedSubagents: string[];
+  globSearchCount: number;
 }
 
 interface ResolveCommandsResult extends ResolutionState {
@@ -146,6 +147,7 @@ function createResolutionState(): ResolutionState {
     absoluteToRelativePathMap: new Map<string, string>(),
     ignoredByReason: { git: [], llxprt: [], both: [] },
     selectedSubagents: [],
+    globSearchCount: 0,
   };
 }
 
@@ -341,6 +343,22 @@ async function statPathInDirectory(
   return { currentPathSpec: relativePath, relativePath };
 }
 
+// A pasted block can contain many tokens that look like @-paths. Each missing
+// one used to fall back to a full recursive workspace crawl, so a single paste
+// could launch an unbounded number of them.
+const MAX_GLOB_FALLBACK_SEARCHES = 3;
+
+// The fallback searches for `**/*<name>*`. A candidate with almost no
+// substance (punctuation runs, one or two characters) matches essentially
+// every file in the workspace, which is never a useful suggestion and is
+// ruinously expensive on large trees.
+const MIN_FALLBACK_CANDIDATE_LENGTH = 3;
+
+function isSearchableFallbackCandidate(pathName: string): boolean {
+  const significant = pathName.replace(/[^\p{L}\p{N}]/gu, '');
+  return significant.length >= MIN_FALLBACK_CANDIDATE_LENGTH;
+}
+
 async function searchMissingPath(
   params: ResolveParams,
   dir: string,
@@ -356,6 +374,19 @@ async function searchMissingPath(
     );
     return undefined;
   }
+  if (!isSearchableFallbackCandidate(pathName)) {
+    params.onDebugMessage(
+      `Path ${pathName} is too unspecific for a recursive search. Path ${pathName} will be skipped.`,
+    );
+    return undefined;
+  }
+  if (state.globSearchCount >= MAX_GLOB_FALLBACK_SEARCHES) {
+    params.onDebugMessage(
+      `Recursive search limit (${MAX_GLOB_FALLBACK_SEARCHES}) reached. Path ${pathName} will be skipped.`,
+    );
+    return undefined;
+  }
+  state.globSearchCount++;
   params.onDebugMessage(
     `Path ${pathName} not found directly, attempting glob search.`,
   );

--- a/packages/tools/src/tools/glob.ts
+++ b/packages/tools/src/tools/glob.ts
@@ -317,13 +317,13 @@ class GlobToolInvocation extends BaseToolInvocation<
     const canonicalPaths = entries.map((entry) =>
       toCanonicalPath(entry.fullpath()),
     );
+    // filterFiles returns a subset of the paths it was given, which are
+    // already canonical, so the survivors need no further resolution.
     const filteredCanonicalPaths = new Set(
-      fileDiscovery
-        .filterFiles(canonicalPaths, {
-          respectGitIgnore: fileFilteringOptions.respectGitIgnore,
-          respectLlxprtIgnore: fileFilteringOptions.respectLlxprtIgnore,
-        })
-        .map((p) => toCanonicalPath(p)),
+      fileDiscovery.filterFiles(canonicalPaths, {
+        respectGitIgnore: fileFilteringOptions.respectGitIgnore,
+        respectLlxprtIgnore: fileFilteringOptions.respectLlxprtIgnore,
+      }),
     );
     const filteredEntries = entries.filter((_entry, index) =>
       filteredCanonicalPaths.has(canonicalPaths[index]),

--- a/packages/tools/src/tools/glob.ts
+++ b/packages/tools/src/tools/glob.ts
@@ -311,6 +311,9 @@ class GlobToolInvocation extends BaseToolInvocation<
         return path.normalize(filePath);
       }
     };
+    // Resolve each entry exactly once. Doing it per lookup meant three
+    // realpathSync syscalls and three full copies of the path list for every
+    // matched file, which dominated cost on large result sets.
     const canonicalPaths = entries.map((entry) =>
       toCanonicalPath(entry.fullpath()),
     );
@@ -322,8 +325,8 @@ class GlobToolInvocation extends BaseToolInvocation<
         })
         .map((p) => toCanonicalPath(p)),
     );
-    const filteredEntries = entries.filter((entry) =>
-      filteredCanonicalPaths.has(toCanonicalPath(entry.fullpath())),
+    const filteredEntries = entries.filter((_entry, index) =>
+      filteredCanonicalPaths.has(canonicalPaths[index]),
     );
     return {
       filteredEntries,


### PR DESCRIPTION
## TLDR

Pasting a copied region of LLxprt's own terminal pane back into the prompt could allocate several GB and exhaust machine memory. The PowerShell `+` → `@` alias rewrote **every** `+` followed by non-space, so box borders (`+------+`), prose (`Ctrl+Q`) and LLxprt's own footer hint (`+path/to/file`) all became at-paths. Each at-path that failed to `stat` fell through to a full recursive workspace crawl, and a single-character candidate like `Q` matches essentially every file in the tree.

This narrows the alias, refuses to crawl for degenerate candidates, caps the number of glob fallbacks per query, and removes redundant `realpathSync` work in `GlobTool`.

Reviewers should look closely at the regex in `atCommandProcessor.ts` — it is the behavioural heart of the change, and the trade-off is that `+` now only aliases at a token start.

## Dive Deeper

Three factors compounded:

**1. Over-broad PowerShell alias.** `parseAllAtCommands` ran `query.replace(/\+(?=\S)/g, '@')`. On a 3,358-character paste this produced **7** at-paths: three ~108-character dash runs, `Q` (from `Ctrl+Q`), two `path/to/file`, and one more dash run.

Now `applyPowerShellAtAlias` uses `/(^|\s)\+(?=[A-Za-z0-9_./\\~])/g` — a `+` only aliases at a token start and only when followed by a plausible path character. `Ctrl+Q`, `a+b+c`, `2+2`, `+-----` and diff lines (`+ foo`) are left alone; `+notes.txt`, `+src/main.ts`, `+./rel.ts` and `+~/home.ts` still work. It is exported so the token rules can be tested without depending on the host shell (`isPowerShell` is fixed at module load).

**2. Unbounded glob fallbacks.** Every ENOENT at-path reached `searchMissingPath` → `executeGlobSearch`, issuing `**/*<name>*` against the whole workspace, with no cap and no relevance check. Added `isSearchableFallbackCandidate` (requires ≥3 alphanumeric characters after stripping punctuation) and `MAX_GLOB_FALLBACK_SEARCHES = 3`, tracked via a new `globSearchCount` on `ResolutionState`. Both paths emit debug messages so the skip is observable.

**3. Redundant path resolution in GlobTool.** `applyFileFilters` recomputed `toCanonicalPath(entry.fullpath())` for every matched entry after already having built the canonical list, costing an extra `realpathSync` pass and a full list copy per matched file. It now filters by index against the memoized array.

On the real payload this takes at-paths from **7 → 2** (both cheap `path/to/file`). The `Q` crawl is eliminated twice over — by the regex and independently by the significance guard.

Measured on an identical synthetic 20,000-file git-ignored tree:

|                                                          | time     | heap delta |
| -------------------------------------------------------- | -------- | ---------- |
| One `**/*Q*` crawl (one of several the paste induced)     | 6,943 ms | +43.5 MB   |
| The **entire** pasted pane, end to end, after the fix     | 122 ms   | +24.7 MB   |

Ruled out by measurement as contributors: Ink `<UserMessage>` rendering, `calculateLayout`, `parseInputForHighlighting`, `calculateTransformationsForLine`, `getCachedStringWidth` — all under 100 ms and a few MB.

**Known limitation, deliberately not addressed here:** ignore rules are still applied *after* glob materialization, so heavy git-ignored trees (Rust `target/`, `node_modules/`) are walked and retained before being discarded (~6 KB per file). Pruning during traversal via the `glob` package's `Ignore` interface and `childrenIgnored` would fix that, but it is architecturally invasive. This PR closes the paste-triggered path; an explicitly broad *user-issued* glob can still balloon. Tracked in the follow-up note on #3233.

## Reviewer Test Plan

Automated: `bun test packages/cli/src/ui/hooks/atCommandProcessor.pastedOutput.test.ts` — 13 tests. Ten pin the alias token rules; three are integration tests that wrap the **real** glob handle to record the patterns actually issued (no mocking of behaviour under test).

Manual, and the more convincing check:

1. Open LLxprt on Windows/PowerShell in a workspace with a large git-ignored directory (a Rust project with a populated `target/` is ideal; `node_modules/` also works).
2. Select and copy a region of the LLxprt pane that includes the input footer (`Type your message, @path/to/file or +path/to/file`) and a `Ctrl+Q`-style hint.
3. Paste it back into the prompt and watch memory in Task Manager.

Before: memory climbs into the GB range as multiple full-workspace crawls run. After: returns promptly with flat memory.

Also worth exercising to confirm nothing regressed:

- `@somefile.ts` still resolves normally.
- `+somefile.ts` still resolves on PowerShell.
- A genuine typo like `@atCommandProcesor.ts` still gets its fuzzy glob fallback.
- Pasting a diff containing `+ added line` no longer produces spurious file lookups.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on Windows: build, lint on changed files, format (no churn), targeted suites (61 pass / 0 fail across at-command and glob), the 13 new tests, and a live smoke test (`--profile-load zai`, real provider round trip). The full suite has 9 pre-existing environmental failures on this machine — 159 `EPERM: operation not permitted, symlink` (Windows needs elevation/Developer Mode), plus fd-passing and user-data-dir cases. All reproduce in isolation at baseline and none touch the modified code. Typecheck errors in `agents`/`a2a-server` were confirmed identical at baseline via stash.

## Linked issues / bugs

Fixes #3233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pasted terminal output and pane content to prevent unintended broad searches.
  * Corrected PowerShell query parsing so `+` is converted appropriately without altering ordinary text or box-drawing characters.
  * Prevented vague or repeated fallback searches from running unnecessarily.
  * Limited recursive fallback searches to improve responsiveness and avoid excessive file lookups.

* **Tests**
  * Added regression coverage for terminal paste handling, PowerShell aliases, and search safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->