### PR TITLE
Prevent same-path mutation data loss (Fixes #3239)

### DIFF
--- a/packages/agents/src/core/coreToolScheduler-same-path-mutations-helpers.ts
+++ b/packages/agents/src/core/coreToolScheduler-same-path-mutations-helpers.ts
@@ -1,0 +1,283 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared helpers for the same-path mutation ordering scheduler tests
+ * (issue #3239): deterministic control primitives, scheduler/registry
+ * construction, publication-order tracking, and a real-tool host factory.
+ */
+
+import { beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CoreToolScheduler, type ToolCall } from './coreToolScheduler.js';
+import type { CompletedToolCall } from './coreToolScheduler.js';
+import type { ToolCallRequestInfo } from '@vybestack/llxprt-code-core/core/turn.js';
+import { createMockConfig } from './coreToolScheduler-test-helpers.js';
+import { createSessionMessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  type Kind,
+  ToolRegistry,
+} from '@vybestack/llxprt-code-tools';
+import type {
+  AnyDeclarativeTool,
+  IToolHost,
+  IToolMessageBus,
+  ToolInvocation,
+  ToolLocation,
+  ToolResult,
+} from '@vybestack/llxprt-code-tools';
+
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+export function deferred<T>(): Deferred<T> {
+  let settle: (value: T) => void = () => {
+    throw new Error('deferred settle called before initialization');
+  };
+  const promise = new Promise<T>((resolve) => {
+    settle = resolve;
+  });
+  return { promise, resolve: (value) => settle(value) };
+}
+
+export function nextMacrotask(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Creates a temp workspace for each test in the enclosing describe block and
+ * removes it afterwards. Tests read the current path through the accessor.
+ */
+export function useTempWorkspace(): () => string {
+  let workspace = '';
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'same-path-scheduler-'));
+  });
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+  return () => workspace;
+}
+
+/**
+ * A declarative test tool whose kind comes from the tool constructor and
+ * whose reported locations come from the call arguments, so scheduling
+ * behavior can be observed without mocking the scheduler. Execution is
+ * driven by a test-supplied behavior function; assertions read the
+ * observable event journal.
+ */
+export type ControlledExecute = (
+  args: Record<string, unknown>,
+) => Promise<ToolResult>;
+
+class PathControlledInvocation extends BaseToolInvocation<
+  Record<string, unknown>,
+  ToolResult
+> {
+  constructor(
+    params: Record<string, unknown>,
+    messageBus: IToolMessageBus | undefined,
+    private readonly executeImpl: ControlledExecute,
+  ) {
+    super(params, messageBus);
+  }
+
+  getDescription(): string {
+    return 'Path-controlled test invocation';
+  }
+
+  override toolLocations(): ToolLocation[] {
+    const requested = this.params.paths;
+    if (!Array.isArray(requested)) {
+      return [];
+    }
+    return requested
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((filePath) => ({ path: filePath }));
+  }
+
+  async execute(): Promise<ToolResult> {
+    return this.executeImpl(this.params);
+  }
+}
+
+export class PathControlledTool extends BaseDeclarativeTool<
+  Record<string, unknown>,
+  ToolResult
+> {
+  constructor(
+    name: string,
+    kind: Kind,
+    private readonly executeImpl: ControlledExecute,
+  ) {
+    super(name, name, name, kind, {}, false, false);
+  }
+
+  protected override createInvocation(
+    params: Record<string, unknown>,
+    messageBus?: IToolMessageBus,
+  ): ToolInvocation<Record<string, unknown>, ToolResult> {
+    return new PathControlledInvocation(params, messageBus, this.executeImpl);
+  }
+}
+
+/** Records `start:<call>` on entry, then waits for that call's gate. */
+export function gatedJournalExecute(
+  events: string[],
+  gates: ReadonlyMap<string, Deferred<void>>,
+): ControlledExecute {
+  return async (args) => {
+    const callId = String(args.call);
+    events.push(`start:${callId}`);
+    const gate = gates.get(callId);
+    if (gate) {
+      await gate.promise;
+    }
+    events.push(`end:${callId}`);
+    return { llmContent: `done:${callId}`, returnDisplay: `done:${callId}` };
+  };
+}
+
+/** Records `start:<call>` on entry, then waits until every call started. */
+export function barrierJournalExecute(
+  events: string[],
+  requiredCalls: readonly string[],
+): ControlledExecute {
+  const allStarted = deferred<void>();
+  const started = new Set<string>();
+  return async (args) => {
+    const callId = String(args.call);
+    events.push(`start:${callId}`);
+    started.add(callId);
+    if (requiredCalls.every((call) => started.has(call))) {
+      allStarted.resolve();
+    }
+    await allStarted.promise;
+    return { llmContent: `done:${callId}`, returnDisplay: `done:${callId}` };
+  };
+}
+
+/** Records `start:<call>`, waits for its gate, then fails the tool call. */
+export function failingJournalExecute(
+  events: string[],
+  gates: ReadonlyMap<string, Deferred<void>>,
+): ControlledExecute {
+  return async (args) => {
+    const callId = String(args.call);
+    events.push(`start:${callId}`);
+    const gate = gates.get(callId);
+    if (gate) {
+      await gate.promise;
+    }
+    throw new Error(`controlled failure for ${callId}`);
+  };
+}
+
+export function toolRequest(
+  callId: string,
+  name: string,
+  args: Record<string, unknown>,
+): ToolCallRequestInfo {
+  return {
+    callId,
+    name,
+    args,
+    isClientInitiated: false,
+    prompt_id: 'same-path-mutations-test',
+  };
+}
+
+export function buildRegistry(
+  tools: readonly AnyDeclarativeTool[],
+): ToolRegistry {
+  const registry = new ToolRegistry({}, createSessionMessageBus());
+  for (const tool of tools) {
+    registry.registerTool(tool);
+  }
+  return registry;
+}
+
+export function buildScheduler(
+  registry: ToolRegistry,
+  observers: {
+    onToolCallsUpdate?: (calls: ToolCall[]) => void;
+    onAllToolCallsComplete?: (calls: CompletedToolCall[]) => void;
+  } = {},
+): CoreToolScheduler {
+  // Real session message bus (typed factory, no structural mock): the
+  // scheduler consumes it directly through its options, and YOLO approval
+  // auto-approves confirmations without consulting the bus.
+  const messageBus = createSessionMessageBus();
+  const config = createMockConfig({
+    getToolRegistry: () => registry,
+  });
+  return new CoreToolScheduler({
+    config,
+    messageBus,
+    toolRegistry: registry,
+    onToolCallsUpdate: observers.onToolCallsUpdate,
+    onAllToolCallsComplete: observers.onAllToolCallsComplete
+      ? async (calls) => observers.onAllToolCallsComplete?.(calls)
+      : undefined,
+    getPreferredEditor: () => undefined,
+    onEditorClose: () => undefined,
+  });
+}
+
+/** Tracks the order in which calls first reach a terminal (published) status. */
+export function trackPublicationOrder(): {
+  order: string[];
+  onToolCallsUpdate: (calls: ToolCall[]) => void;
+} {
+  const order: string[] = [];
+  const onToolCallsUpdate = (calls: ToolCall[]): void => {
+    for (const call of calls) {
+      if (
+        (call.status === 'success' || call.status === 'error') &&
+        !order.includes(call.request.callId)
+      ) {
+        order.push(call.request.callId);
+      }
+    }
+  };
+  return { order, onToolCallsUpdate };
+}
+
+/** Real-tool host bound to a temp workspace directory. */
+export function createToolHost(targetDir: string): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths: string[]) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({}),
+    getDebugMode: () => false,
+  };
+}

--- a/packages/agents/src/core/coreToolScheduler.same-path-mutations.real-tools.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.same-path-mutations.real-tools.test.ts
@@ -1,0 +1,503 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Real built-in tool integration tests for same-path mutation ordering in
+ * CoreToolScheduler batches (issue #3239).
+ *
+ * The real replace, write_file, insert_at_line, delete_line_range,
+ * apply_patch, and ast_edit tools perform whole-file read-modify-write
+ * operations, so two concurrent calls on one file can both read the same
+ * snapshot and overwrite each other. These tests prove two same-path
+ * mutations requested together both persist with complete file content, that
+ * ordering is path-based rather than tool-name-based, and that save_memory
+ * additions to one memory file keep every fact while different memory files
+ * stay parallel.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+import { promises as fsp } from 'node:fs';
+import { join } from 'node:path';
+import { CoreToolScheduler, type ToolCall } from './coreToolScheduler.js';
+import {
+  EditTool,
+  WriteFileTool,
+  InsertAtLineTool,
+  DeleteLineRangeTool,
+  ApplyPatchTool,
+  ASTEditTool,
+  MemoryTool,
+} from '@vybestack/llxprt-code-tools';
+import type { IStorageService } from '@vybestack/llxprt-code-tools';
+import {
+  deferred,
+  nextMacrotask,
+  useTempWorkspace,
+  createToolHost,
+  toolRequest,
+  buildRegistry,
+  buildScheduler,
+  trackPublicationOrder,
+} from './coreToolScheduler-same-path-mutations-helpers.js';
+
+describe('CoreToolScheduler real file tools same-path ordering', () => {
+  const workspaceFor = useTempWorkspace();
+
+  function realToolScheduler(
+    observers: {
+      onToolCallsUpdate?: (calls: ToolCall[]) => void;
+    } = {},
+  ): CoreToolScheduler {
+    const host = createToolHost(workspaceFor());
+    const registry = buildRegistry([
+      new EditTool(host),
+      new WriteFileTool(host),
+      new InsertAtLineTool(host),
+      new DeleteLineRangeTool(host),
+      new ApplyPatchTool(host),
+      new ASTEditTool(host),
+    ]);
+    return buildScheduler(registry, observers);
+  }
+
+  it('preserves both replace edits to one file', async () => {
+    const filePath = join(workspaceFor(), 'replace-target.txt');
+    writeFileSync(
+      filePath,
+      [
+        'HEADER',
+        'alpha-marker',
+        'MIDDLE',
+        'beta-marker',
+        'TAIL-ONE',
+        'TAIL-TWO',
+      ].join('\n'),
+    );
+    const scheduler = realToolScheduler();
+
+    await scheduler.schedule(
+      [
+        toolRequest('e1', 'replace', {
+          call: 'e1',
+          absolute_path: filePath,
+          old_string: 'alpha-marker',
+          new_string: 'alpha-applied',
+        }),
+        toolRequest('e2', 'replace', {
+          call: 'e2',
+          absolute_path: filePath,
+          old_string: 'beta-marker',
+          new_string: 'beta-applied',
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    const finalContent = readFileSync(filePath, 'utf-8');
+    expect(finalContent).toContain('alpha-applied');
+    expect(finalContent).toContain('beta-applied');
+    expect(finalContent.endsWith('TAIL-ONE\nTAIL-TWO')).toBe(true);
+  });
+
+  it('ends with the request-order second complete write_file payload', async () => {
+    const filePath = join(workspaceFor(), 'write-target.txt');
+    writeFileSync(filePath, 'seed content\n');
+    const scheduler = realToolScheduler();
+
+    const firstPayload = 'first-complete-payload\nwith multiple lines\n';
+    const secondPayload = 'second-complete-payload\nother lines\n';
+    await scheduler.schedule(
+      [
+        toolRequest('w1', 'write_file', {
+          call: 'w1',
+          absolute_path: filePath,
+          content: firstPayload,
+        }),
+        toolRequest('w2', 'write_file', {
+          call: 'w2',
+          absolute_path: filePath,
+          content: secondPayload,
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    expect(readFileSync(filePath, 'utf-8')).toBe(secondPayload);
+  });
+
+  it('preserves both insert_at_line insertions in request order', async () => {
+    const filePath = join(workspaceFor(), 'insert-target.txt');
+    writeFileSync(filePath, 'one\ntwo\nthree\nfour\n');
+    const scheduler = realToolScheduler();
+
+    await scheduler.schedule(
+      [
+        toolRequest('i1', 'insert_at_line', {
+          call: 'i1',
+          absolute_path: filePath,
+          line_number: 2,
+          content: 'INSERTED-ONE\n',
+        }),
+        toolRequest('i2', 'insert_at_line', {
+          call: 'i2',
+          absolute_path: filePath,
+          line_number: 2,
+          content: 'INSERTED-TWO\n',
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    // Both inserts target line 2 and run sequentially in request order, so
+    // the second insert lands above the first insert's line.
+    expect(readFileSync(filePath, 'utf-8')).toBe(
+      'one\nINSERTED-TWO\nINSERTED-ONE\ntwo\nthree\nfour\n',
+    );
+  });
+
+  it('persists both delete_line_range deletions from sequential state', async () => {
+    const filePath = join(workspaceFor(), 'delete-target.txt');
+    writeFileSync(
+      filePath,
+      ['L1', 'D1A', 'D1B', 'KEEP1', 'D2A', 'D2B', 'KEEP2', 'L8'].join('\n') +
+        '\n',
+    );
+    const scheduler = realToolScheduler();
+
+    await scheduler.schedule(
+      [
+        toolRequest('d1', 'delete_line_range', {
+          call: 'd1',
+          absolute_path: filePath,
+          start_line: 2,
+          end_line: 3,
+        }),
+        toolRequest('d2', 'delete_line_range', {
+          call: 'd2',
+          absolute_path: filePath,
+          start_line: 3,
+          end_line: 4,
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    expect(readFileSync(filePath, 'utf-8')).toBe('L1\nKEEP1\nKEEP2\nL8\n');
+  });
+
+  it('preserves two non-overlapping apply_patch patches', async () => {
+    const fileName = 'patch-target.txt';
+    const filePath = join(workspaceFor(), fileName);
+    writeFileSync(
+      filePath,
+      [
+        'line-01',
+        'line-02',
+        'line-03',
+        'patch-one-target',
+        'line-05',
+        'line-06',
+        'line-07',
+        'line-08',
+        'line-09',
+        'patch-two-target',
+        'line-11',
+        'line-12',
+      ].join('\n') + '\n',
+    );
+    const scheduler = realToolScheduler();
+
+    const firstPatch = [
+      `--- a/${fileName}`,
+      `+++ b/${fileName}`,
+      '@@ -1,5 +1,5 @@',
+      ' line-01',
+      ' line-02',
+      ' line-03',
+      '-patch-one-target',
+      '+patch-one-applied',
+      ' line-05',
+    ].join('\n');
+    const secondPatch = [
+      `--- a/${fileName}`,
+      `+++ b/${fileName}`,
+      // Applied against the post-first-patch state: four context lines plus
+      // one removal equals six old/new lines.
+      '@@ -6,6 +6,6 @@',
+      ' line-06',
+      ' line-07',
+      ' line-08',
+      ' line-09',
+      '-patch-two-target',
+      '+patch-two-applied',
+      ' line-11',
+    ].join('\n');
+
+    await scheduler.schedule(
+      [
+        toolRequest('p1', 'apply_patch', {
+          call: 'p1',
+          absolute_path: filePath,
+          patch_content: firstPatch,
+        }),
+        toolRequest('p2', 'apply_patch', {
+          call: 'p2',
+          absolute_path: filePath,
+          patch_content: secondPatch,
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    const finalContent = readFileSync(filePath, 'utf-8');
+    expect(finalContent).toContain('patch-one-applied');
+    expect(finalContent).toContain('patch-two-applied');
+    expect(finalContent.endsWith('line-11\nline-12\n')).toBe(true);
+  });
+
+  it('preserves two ast_edit replacements without last_modified', async () => {
+    const filePath = join(workspaceFor(), 'ast-target.ts');
+    writeFileSync(
+      filePath,
+      [
+        'const one = 1;',
+        'const two = 2;',
+        'export const total = one + two;',
+        'export const tail = "tail-marker";',
+      ].join('\n') + '\n',
+    );
+    const scheduler = realToolScheduler();
+
+    await scheduler.schedule(
+      [
+        toolRequest('a1', 'ast_edit', {
+          call: 'a1',
+          file_path: filePath,
+          old_string: 'const one = 1;',
+          new_string: 'const one = 11;',
+          force: true,
+        }),
+        toolRequest('a2', 'ast_edit', {
+          call: 'a2',
+          file_path: filePath,
+          old_string: 'const two = 2;',
+          new_string: 'const two = 22;',
+          force: true,
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    const finalContent = readFileSync(filePath, 'utf-8');
+    expect(finalContent).toContain('const one = 11;');
+    expect(finalContent).toContain('const two = 22;');
+    expect(finalContent.endsWith('export const tail = "tail-marker";\n')).toBe(
+      true,
+    );
+  });
+
+  it('orders a replace and an insert_at_line on one file by path', async () => {
+    const filePath = join(workspaceFor(), 'mixed-target.txt');
+    writeFileSync(filePath, 'alpha-marker\nline-two\nline-three\n');
+    const publication = trackPublicationOrder();
+    const scheduler = realToolScheduler({
+      onToolCallsUpdate: publication.onToolCallsUpdate,
+    });
+
+    await scheduler.schedule(
+      [
+        toolRequest('r1', 'replace', {
+          call: 'r1',
+          absolute_path: filePath,
+          old_string: 'alpha-marker',
+          new_string: 'alpha-applied',
+        }),
+        toolRequest('i1', 'insert_at_line', {
+          call: 'i1',
+          absolute_path: filePath,
+          line_number: 1,
+          content: 'INSERTED-HEADER\n',
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    const finalContent = readFileSync(filePath, 'utf-8');
+    expect(finalContent).toContain('alpha-applied');
+    expect(finalContent).toContain('INSERTED-HEADER');
+    expect(finalContent.endsWith('line-two\nline-three\n')).toBe(true);
+    expect(publication.order).toStrictEqual(['r1', 'i1']);
+  });
+});
+
+// ── save_memory through the scheduler ──────────────────────────────────────
+
+/**
+ * Real-filesystem storage service that records each read synchronously and
+ * holds the first read on an externally controlled gate. The gate
+ * deterministically exposes whole-file read-modify-write overlap: with
+ * same-path ordering only the first addition reads while the gate is held,
+ * whereas a scheduler that launches both additions concurrently starts the
+ * second read before control returns to the test. Reads capture their bytes
+ * before waiting, so every read observes the state at request time.
+ */
+function createGatedFirstReadStorageService(globalMemoryDir: string): {
+  storage: IStorageService;
+  firstReadStarted: Promise<void>;
+  releaseFirstRead: () => void;
+  countReadsStarted: () => number;
+} {
+  const firstReadStarted = deferred<void>();
+  const releaseFirstRead = deferred<void>();
+  let readsStarted = 0;
+  const storage: IStorageService = {
+    getGlobalMemoryDir: () => globalMemoryDir,
+    getGlobalDataDir: () => globalMemoryDir,
+    readFile: async (filePath: string): Promise<string> => {
+      readsStarted += 1;
+      const isFirstRead = readsStarted === 1;
+      const content = await fsp.readFile(filePath, 'utf-8');
+      if (isFirstRead) {
+        firstReadStarted.resolve();
+        await releaseFirstRead.promise;
+      }
+      return content;
+    },
+    writeFile: (filePath: string, content: string): Promise<void> =>
+      fsp.writeFile(filePath, content, 'utf-8'),
+    ensureDir: async (dir: string): Promise<void> => {
+      await fsp.mkdir(dir, { recursive: true });
+    },
+  };
+  return {
+    storage,
+    firstReadStarted: firstReadStarted.promise,
+    releaseFirstRead: () => releaseFirstRead.resolve(),
+    countReadsStarted: () => readsStarted,
+  };
+}
+
+/**
+ * Real-filesystem storage service that releases each read only after reads
+ * for every expected path have been requested, proving different memory
+ * paths execute in parallel.
+ */
+function createParallelProbeStorageService(
+  globalMemoryDir: string,
+  expectedPaths: readonly string[],
+): IStorageService {
+  const allReadsRequested = deferred<void>();
+  const requested = new Set<string>();
+  return {
+    getGlobalMemoryDir: () => globalMemoryDir,
+    getGlobalDataDir: () => globalMemoryDir,
+    readFile: async (filePath: string): Promise<string> => {
+      requested.add(filePath);
+      if (expectedPaths.every((expected) => requested.has(expected))) {
+        allReadsRequested.resolve();
+      }
+      await allReadsRequested.promise;
+      return fsp.readFile(filePath, 'utf-8');
+    },
+    writeFile: (filePath: string, content: string): Promise<void> =>
+      fsp.writeFile(filePath, content, 'utf-8'),
+    ensureDir: async (dir: string): Promise<void> => {
+      await fsp.mkdir(dir, { recursive: true });
+    },
+  };
+}
+
+describe('save_memory same-path additions through the scheduler', () => {
+  const workspaceFor = useTempWorkspace();
+
+  function memoryScheduler(storageService: IStorageService): CoreToolScheduler {
+    const workspace = workspaceFor();
+    const registry = buildRegistry([
+      new MemoryTool({
+        storageService,
+        getWorkingDir: () => workspace,
+      }),
+    ]);
+    return buildScheduler(registry);
+  }
+
+  it('persists both facts added concurrently to one memory file', async () => {
+    const workspace = workspaceFor();
+    const projectMemoryPath = join(workspace, '.llxprt', 'LLXPRT.md');
+    mkdirSync(join(workspace, '.llxprt'), { recursive: true });
+    const sectionHeader = ['##', 'LLxprt Code Added Memories'].join(' ');
+    writeFileSync(projectMemoryPath, sectionHeader);
+    const gated = createGatedFirstReadStorageService(
+      join(workspace, 'global-memory'),
+    );
+    const scheduler = memoryScheduler(gated.storage);
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('s1', 'save_memory', {
+          call: 's1',
+          fact: 'alpha-fact',
+          scope: 'project',
+        }),
+        toolRequest('s2', 'save_memory', {
+          call: 's2',
+          fact: 'beta-fact',
+          scope: 'project',
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    // The first addition is held mid-read; the scheduler has now launched
+    // everything it will launch at this point. With same-path ordering only
+    // one read has started — a second concurrent read is exactly the
+    // lost-update race this ordering prevents.
+    await gated.firstReadStarted;
+    await nextMacrotask();
+    expect(gated.countReadsStarted()).toBe(1);
+
+    gated.releaseFirstRead();
+    await schedulePromise;
+
+    const memoryContent = readFileSync(projectMemoryPath, 'utf-8');
+    expect(memoryContent).toContain('- alpha-fact');
+    expect(memoryContent).toContain('- beta-fact');
+  });
+
+  it('keeps additions to different memory paths parallel', async () => {
+    const workspace = workspaceFor();
+    const projectMemoryPath = join(workspace, '.llxprt', 'LLXPRT.md');
+    const globalMemoryPath = join(workspace, 'global-memory', 'LLXPRT.md');
+    const scheduler = memoryScheduler(
+      createParallelProbeStorageService(join(workspace, 'global-memory'), [
+        projectMemoryPath,
+        globalMemoryPath,
+      ]),
+    );
+
+    await scheduler.schedule(
+      [
+        toolRequest('s1', 'save_memory', {
+          call: 's1',
+          fact: 'project-fact',
+          scope: 'project',
+        }),
+        toolRequest('s2', 'save_memory', {
+          call: 's2',
+          fact: 'global-fact',
+          scope: 'global',
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    expect(readFileSync(projectMemoryPath, 'utf-8')).toContain(
+      '- project-fact',
+    );
+    expect(readFileSync(globalMemoryPath, 'utf-8')).toContain('- global-fact');
+  });
+});

--- a/packages/agents/src/core/coreToolScheduler.same-path-mutations.real-tools.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.same-path-mutations.real-tools.test.ts
@@ -42,7 +42,7 @@ import {
   buildRegistry,
   buildScheduler,
   trackPublicationOrder,
-} from './coreToolScheduler-same-path-mutations-helpers.js';
+} from '../test-utils/coreToolScheduler-same-path-mutations-helpers.js';
 
 describe('CoreToolScheduler real file tools same-path ordering', () => {
   const workspaceFor = useTempWorkspace();

--- a/packages/agents/src/core/coreToolScheduler.same-path-mutations.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.same-path-mutations.test.ts
@@ -32,7 +32,7 @@ import {
   buildRegistry,
   buildScheduler,
   trackPublicationOrder,
-} from './coreToolScheduler-same-path-mutations-helpers.js';
+} from '../test-utils/coreToolScheduler-same-path-mutations-helpers.js';
 
 describe('CoreToolScheduler same-path mutation ordering', () => {
   it('holds a later same-path mutation until the earlier one settles', async () => {

--- a/packages/agents/src/core/coreToolScheduler.same-path-mutations.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.same-path-mutations.test.ts
@@ -1,0 +1,522 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for same-path mutation ordering in CoreToolScheduler
+ * batches (issue #3239), using deterministic path-controlled tools.
+ *
+ * File-mutating tools perform whole-file read-modify-write operations, so two
+ * concurrent calls whose target locations overlap can both read the same
+ * snapshot and overwrite each other. These tests prove that mutating calls
+ * (Kind.Edit/Delete/Move with overlapping normalized toolLocations) execute
+ * in request order within one batch, that independent paths stay concurrent,
+ * and that failure/abort semantics are preserved.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { waitFor } from '@vybestack/llxprt-code-test-utils';
+import type { ToolCall } from './coreToolScheduler.js';
+import { Kind } from '@vybestack/llxprt-code-tools';
+import {
+  deferred,
+  type Deferred,
+  nextMacrotask,
+  PathControlledTool,
+  gatedJournalExecute,
+  barrierJournalExecute,
+  failingJournalExecute,
+  toolRequest,
+  buildRegistry,
+  buildScheduler,
+  trackPublicationOrder,
+} from './coreToolScheduler-same-path-mutations-helpers.js';
+
+describe('CoreToolScheduler same-path mutation ordering', () => {
+  it('holds a later same-path mutation until the earlier one settles', async () => {
+    const events: string[] = [];
+    const gates = new Map<string, Deferred<void>>();
+    for (const callId of ['m1', 'm2']) {
+      gates.set(callId, deferred<void>());
+    }
+    const tool = new PathControlledTool(
+      'controlledEdit',
+      Kind.Edit,
+      gatedJournalExecute(events, gates),
+    );
+    const publication = trackPublicationOrder();
+    const scheduler = buildScheduler(buildRegistry([tool]), {
+      onToolCallsUpdate: publication.onToolCallsUpdate,
+    });
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('m1', 'controlledEdit', {
+          call: 'm1',
+          paths: ['/workspace/notes.txt'],
+        }),
+        toolRequest('m2', 'controlledEdit', {
+          call: 'm2',
+          paths: ['/workspace/notes.txt'],
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    await waitFor(() => {
+      expect(events).toContain('start:m1');
+    });
+    await nextMacrotask();
+    expect(events).toStrictEqual(['start:m1']);
+
+    gates.get('m1')?.resolve();
+    await waitFor(() => {
+      expect(events).toContain('start:m2');
+    });
+    gates.get('m2')?.resolve();
+    await schedulePromise;
+
+    expect(events).toStrictEqual(['start:m1', 'end:m1', 'start:m2', 'end:m2']);
+    expect(publication.order).toStrictEqual(['m1', 'm2']);
+  });
+
+  it('executes a three-call same-path chain strictly in request order', async () => {
+    const events: string[] = [];
+    const gates = new Map<string, Deferred<void>>();
+    for (const callId of ['m1', 'm2', 'm3']) {
+      gates.set(callId, deferred<void>());
+    }
+    const tool = new PathControlledTool(
+      'controlledEdit',
+      Kind.Edit,
+      gatedJournalExecute(events, gates),
+    );
+    const scheduler = buildScheduler(buildRegistry([tool]));
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('m1', 'controlledEdit', {
+          call: 'm1',
+          paths: ['/workspace/chain.txt'],
+        }),
+        toolRequest('m2', 'controlledEdit', {
+          call: 'm2',
+          paths: ['/workspace/chain.txt'],
+        }),
+        toolRequest('m3', 'controlledEdit', {
+          call: 'm3',
+          paths: ['/workspace/chain.txt'],
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    await waitFor(() => {
+      expect(events).toContain('start:m1');
+    });
+    await nextMacrotask();
+    expect(events).toStrictEqual(['start:m1']);
+
+    gates.get('m1')?.resolve();
+    await waitFor(() => {
+      expect(events).toContain('start:m2');
+    });
+    await nextMacrotask();
+    expect(events).not.toContain('start:m3');
+
+    gates.get('m2')?.resolve();
+    await waitFor(() => {
+      expect(events).toContain('start:m3');
+    });
+    gates.get('m3')?.resolve();
+    await schedulePromise;
+
+    expect(events).toStrictEqual([
+      'start:m1',
+      'end:m1',
+      'start:m2',
+      'end:m2',
+      'start:m3',
+      'end:m3',
+    ]);
+  });
+
+  it('keeps mutations on different paths concurrent', async () => {
+    const events: string[] = [];
+    const tool = new PathControlledTool(
+      'controlledEdit',
+      Kind.Edit,
+      barrierJournalExecute(events, ['m1', 'm2']),
+    );
+    const scheduler = buildScheduler(buildRegistry([tool]));
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('m1', 'controlledEdit', {
+          call: 'm1',
+          paths: ['/workspace/a.txt'],
+        }),
+        toolRequest('m2', 'controlledEdit', {
+          call: 'm2',
+          paths: ['/workspace/b.txt'],
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    await schedulePromise;
+    expect(events).toContain('start:m1');
+    expect(events).toContain('start:m2');
+  });
+
+  it('waits for every earlier mutation that overlaps any location', async () => {
+    const events: string[] = [];
+    const gates = new Map<string, Deferred<void>>();
+    for (const callId of ['m1', 'm2', 'm3']) {
+      gates.set(callId, deferred<void>());
+    }
+    const tool = new PathControlledTool(
+      'controlledEdit',
+      Kind.Edit,
+      gatedJournalExecute(events, gates),
+    );
+    const scheduler = buildScheduler(buildRegistry([tool]));
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('m1', 'controlledEdit', {
+          call: 'm1',
+          paths: ['/workspace/one.txt'],
+        }),
+        toolRequest('m2', 'controlledEdit', {
+          call: 'm2',
+          paths: ['/workspace/two.txt', '/workspace/one.txt'],
+        }),
+        toolRequest('m3', 'controlledEdit', {
+          call: 'm3',
+          paths: ['/workspace/two.txt'],
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    await waitFor(() => {
+      expect(events).toContain('start:m1');
+    });
+    await nextMacrotask();
+    expect(events).toStrictEqual(['start:m1']);
+
+    gates.get('m1')?.resolve();
+    await waitFor(() => {
+      expect(events).toContain('start:m2');
+    });
+    await nextMacrotask();
+    expect(events).not.toContain('start:m3');
+
+    gates.get('m2')?.resolve();
+    await waitFor(() => {
+      expect(events).toContain('start:m3');
+    });
+    gates.get('m3')?.resolve();
+    await schedulePromise;
+  });
+
+  it('orders different path spellings that normalize to one location', async () => {
+    const events: string[] = [];
+    const gates = new Map<string, Deferred<void>>();
+    for (const callId of ['m1', 'm2']) {
+      gates.set(callId, deferred<void>());
+    }
+    const tool = new PathControlledTool(
+      'controlledEdit',
+      Kind.Edit,
+      gatedJournalExecute(events, gates),
+    );
+    const scheduler = buildScheduler(buildRegistry([tool]));
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('m1', 'controlledEdit', {
+          call: 'm1',
+          paths: ['/workspace/shared/../shared/notes.txt'],
+        }),
+        toolRequest('m2', 'controlledEdit', {
+          call: 'm2',
+          paths: ['/workspace/shared/notes.txt'],
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    await waitFor(() => {
+      expect(events).toContain('start:m1');
+    });
+    await nextMacrotask();
+    expect(events).toStrictEqual(['start:m1']);
+
+    gates.get('m1')?.resolve();
+    await waitFor(() => {
+      expect(events).toContain('start:m2');
+    });
+    gates.get('m2')?.resolve();
+    await schedulePromise;
+    expect(events).toStrictEqual(['start:m1', 'end:m1', 'start:m2', 'end:m2']);
+  });
+
+  it('orders Kind.Delete and Kind.Move calls on the same path', async () => {
+    const events: string[] = [];
+    const gates = new Map<string, Deferred<void>>();
+    gates.set('d1', deferred<void>());
+    const deleteTool = new PathControlledTool(
+      'controlledDelete',
+      Kind.Delete,
+      gatedJournalExecute(events, gates),
+    );
+    const moveTool = new PathControlledTool(
+      'controlledMove',
+      Kind.Move,
+      gatedJournalExecute(events, new Map()),
+    );
+    const scheduler = buildScheduler(buildRegistry([deleteTool, moveTool]));
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('d1', 'controlledDelete', {
+          call: 'd1',
+          paths: ['/workspace/target.txt'],
+        }),
+        toolRequest('mv1', 'controlledMove', {
+          call: 'mv1',
+          paths: ['/workspace/target.txt'],
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    await waitFor(() => {
+      expect(events).toContain('start:d1');
+    });
+    await nextMacrotask();
+    expect(events).not.toContain('start:mv1');
+
+    gates.get('d1')?.resolve();
+    await waitFor(() => {
+      expect(events).toContain('start:mv1');
+    });
+    await schedulePromise;
+  });
+
+  it('does not start a waiting mutation after the batch aborts', async () => {
+    const events: string[] = [];
+    const gates = new Map<string, Deferred<void>>();
+    gates.set('m1', deferred<void>());
+    const tool = new PathControlledTool(
+      'controlledEdit',
+      Kind.Edit,
+      gatedJournalExecute(events, gates),
+    );
+    const publication = trackPublicationOrder();
+    const terminalStatuses: Record<string, ToolCall['status']> = {};
+    const scheduler = buildScheduler(buildRegistry([tool]), {
+      onToolCallsUpdate: (calls) => {
+        publication.onToolCallsUpdate(calls);
+        for (const call of calls) {
+          if (
+            call.status === 'success' ||
+            call.status === 'error' ||
+            call.status === 'cancelled'
+          ) {
+            terminalStatuses[call.request.callId] = call.status;
+          }
+        }
+      },
+    });
+
+    const abortController = new AbortController();
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('m1', 'controlledEdit', {
+          call: 'm1',
+          paths: ['/workspace/abort.txt'],
+        }),
+        toolRequest('m2', 'controlledEdit', {
+          call: 'm2',
+          paths: ['/workspace/abort.txt'],
+        }),
+      ],
+      abortController.signal,
+    );
+
+    await waitFor(() => {
+      expect(events).toContain('start:m1');
+    });
+    abortController.abort();
+    gates.get('m1')?.resolve();
+
+    await schedulePromise;
+    await nextMacrotask();
+    // The waiting mutation never begins side effects after the abort.
+    expect(events).toStrictEqual(['start:m1', 'end:m1']);
+    // Both calls still reach a terminal state.
+    expect(terminalStatuses['m1']).toBe('cancelled');
+    expect(terminalStatuses['m2']).toBe('cancelled');
+
+    // The aborted batch must not corrupt the scheduler's ordered-result
+    // bookkeeping: the same scheduler still publishes a later batch's
+    // result to terminal success.
+    const followUpPromise = scheduler.schedule(
+      [
+        toolRequest('n1', 'controlledEdit', {
+          call: 'n1',
+          paths: ['/workspace/after-abort.txt'],
+        }),
+      ],
+      new AbortController().signal,
+    );
+    await waitFor(() => {
+      expect(terminalStatuses['n1']).toBe('success');
+    });
+    await followUpPromise;
+    expect(events).toStrictEqual(['start:m1', 'end:m1', 'start:n1', 'end:n1']);
+    expect(publication.order).toStrictEqual(['n1']);
+  });
+
+  it('still executes and publishes a later same-path call after an earlier failure', async () => {
+    const events: string[] = [];
+    const gates = new Map<string, Deferred<void>>();
+    gates.set('m1', deferred<void>());
+    gates.set('m2', deferred<void>());
+    const failingTool = new PathControlledTool(
+      'controlledFailingEdit',
+      Kind.Edit,
+      failingJournalExecute(events, gates),
+    );
+    const succeedingTool = new PathControlledTool(
+      'controlledSucceedingEdit',
+      Kind.Edit,
+      gatedJournalExecute(events, gates),
+    );
+    const publication = trackPublicationOrder();
+    const terminalStatuses: Record<string, ToolCall['status']> = {};
+    const scheduler = buildScheduler(
+      buildRegistry([failingTool, succeedingTool]),
+      {
+        onToolCallsUpdate: (calls) => {
+          publication.onToolCallsUpdate(calls);
+          for (const call of calls) {
+            if (
+              call.status === 'success' ||
+              call.status === 'error' ||
+              call.status === 'cancelled'
+            ) {
+              terminalStatuses[call.request.callId] = call.status;
+            }
+          }
+        },
+      },
+    );
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('m1', 'controlledFailingEdit', {
+          call: 'm1',
+          paths: ['/workspace/failure.txt'],
+        }),
+        toolRequest('m2', 'controlledSucceedingEdit', {
+          call: 'm2',
+          paths: ['/workspace/failure.txt'],
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    await waitFor(() => {
+      expect(events).toContain('start:m1');
+    });
+    await nextMacrotask();
+    expect(events).not.toContain('start:m2');
+
+    gates.get('m1')?.resolve();
+    await waitFor(() => {
+      expect(events).toContain('start:m2');
+    });
+    gates.get('m2')?.resolve();
+    await schedulePromise;
+
+    expect(terminalStatuses['m1']).toBe('error');
+    expect(terminalStatuses['m2']).toBe('success');
+    expect(publication.order).toStrictEqual(['m1', 'm2']);
+  });
+
+  it('keeps read-kind calls concurrent with a same-path mutation', async () => {
+    const events: string[] = [];
+    const barrier = barrierJournalExecute(events, ['r1', 'e1']);
+    const readTool = new PathControlledTool(
+      'controlledRead',
+      Kind.Read,
+      barrier,
+    );
+    const editTool = new PathControlledTool(
+      'controlledEdit',
+      Kind.Edit,
+      barrier,
+    );
+    const scheduler = buildScheduler(buildRegistry([readTool, editTool]));
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('r1', 'controlledRead', {
+          call: 'r1',
+          paths: ['/workspace/read-vs-write.txt'],
+        }),
+        toolRequest('e1', 'controlledEdit', {
+          call: 'e1',
+          paths: ['/workspace/read-vs-write.txt'],
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    await schedulePromise;
+    expect(events).toContain('start:r1');
+    expect(events).toContain('start:e1');
+  });
+
+  it('keeps location-less mutating calls concurrent', async () => {
+    const events: string[] = [];
+    const barrier = barrierJournalExecute(events, ['m1', 'm2']);
+    const anchoredTool = new PathControlledTool(
+      'controlledEdit',
+      Kind.Edit,
+      barrier,
+    );
+    const locationlessTool = new PathControlledTool(
+      'controlledLocationlessEdit',
+      Kind.Edit,
+      barrier,
+    );
+    const scheduler = buildScheduler(
+      buildRegistry([anchoredTool, locationlessTool]),
+    );
+
+    const schedulePromise = scheduler.schedule(
+      [
+        toolRequest('m1', 'controlledEdit', {
+          call: 'm1',
+          paths: ['/workspace/anchored.txt'],
+        }),
+        toolRequest('m2', 'controlledLocationlessEdit', {
+          call: 'm2',
+          paths: [],
+        }),
+      ],
+      new AbortController().signal,
+    );
+
+    await schedulePromise;
+    expect(events).toContain('start:m1');
+    expect(events).toContain('start:m2');
+  });
+});

--- a/packages/agents/src/core/coreToolScheduler.ts
+++ b/packages/agents/src/core/coreToolScheduler.ts
@@ -29,6 +29,7 @@ import type { LiveOutputUpdate } from '@vybestack/llxprt-code-core/utils/termina
 import { triggerToolNotificationHook } from '@vybestack/llxprt-code-core/core/coreToolHookTriggers.js';
 import { ToolExecutor } from '../scheduler/tool-executor.js';
 import { ToolDispatcher } from '../scheduler/tool-dispatcher.js';
+import { launchCallsWithSamePathOrdering } from '../scheduler/mutation-ordering.js';
 import {
   ResultAggregator,
   type ResultPublishCallbacks,
@@ -693,17 +694,46 @@ export class CoreToolScheduler implements ToolSchedulerContract {
           signal,
         );
       } else {
-        const toolPromises = callsToExecute.map((toolCall) => {
-          const scheduledCall = toolCall;
-          const executionIndex = executionIndices.get(
-            scheduledCall.request.callId,
-          )!;
-          return this.launchToolExecution(
-            scheduledCall,
-            executionIndex,
-            signal,
-          );
-        });
+        // Issue #3239: mutating calls whose normalized toolLocations overlap
+        // an earlier call in the batch wait for that call to settle before
+        // launching, preserving request order for same-file read-modify-write
+        // tools. All other calls launch concurrently exactly as before, and
+        // each launch promise resolves (never rejects) once its result is
+        // buffered and published, so a failed predecessor still releases its
+        // dependents.
+        const executionIndexOf = (call: ScheduledToolCall): number => {
+          const index = executionIndices.get(call.request.callId);
+          if (index === undefined) {
+            throw new Error(
+              `No execution index assigned for tool call ${call.request.callId}.`,
+            );
+          }
+          return index;
+        };
+        const toolPromises = launchCallsWithSamePathOrdering(
+          callsToExecute,
+          (scheduledCall) =>
+            this.launchToolExecution(
+              scheduledCall,
+              executionIndexOf(scheduledCall),
+              signal,
+            ),
+          signal,
+          (abandonedCall) => {
+            // A waiting same-path mutation abandoned by an abort never
+            // launches, so nothing else will buffer its result. Without a
+            // cancelled placeholder at its execution index, ordered
+            // publication stalls and the stale cursor corrupts the next
+            // batch scheduled on this scheduler.
+            const callId = abandonedCall.request.callId;
+            this.resultAggregator.bufferCancelled(
+              callId,
+              abandonedCall,
+              executionIndexOf(abandonedCall),
+            );
+            void this.publishBufferedResults(signal);
+          },
+        );
 
         const batchPromise = Promise.all(toolPromises);
         await this.awaitBatchOrAbort(callsToExecute, batchPromise, signal);

--- a/packages/agents/src/scheduler/mutation-ordering.ts
+++ b/packages/agents/src/scheduler/mutation-ordering.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Same-path mutation ordering for scheduler batches (issue #3239).
+ *
+ * File-mutating tools perform whole-file read-modify-write operations, so two
+ * batched calls whose target locations overlap can both read the same
+ * snapshot and overwrite each other. Mutating invocations (Kind.Edit,
+ * Kind.Delete, Kind.Move) that report overlapping locations through the
+ * existing toolLocations() contract therefore execute in request order, while
+ * every other call keeps the scheduler's concurrent launch behavior.
+ */
+
+import path from 'node:path';
+import { Kind } from '@vybestack/llxprt-code-tools';
+import type { ToolLocation } from '@vybestack/llxprt-code-tools';
+import type { ScheduledToolCall } from '@vybestack/llxprt-code-core/scheduler/types.js';
+
+const MUTATING_KINDS: ReadonlySet<Kind> = new Set([
+  Kind.Edit,
+  Kind.Delete,
+  Kind.Move,
+]);
+
+function isMutatingCall(call: ScheduledToolCall): boolean {
+  return MUTATING_KINDS.has(call.tool.kind);
+}
+
+/**
+ * Lexically normalized target paths for a mutating call. Location identity is
+ * deliberately lexical: symlink/hardlink aliasing and cross-process locking
+ * are outside the ordering contract.
+ */
+function normalizedMutationPaths(call: ScheduledToolCall): string[] {
+  return call.invocation
+    .toolLocations()
+    .filter((location: ToolLocation) => location.path.length > 0)
+    .map((location: ToolLocation) => path.normalize(location.path));
+}
+
+/**
+ * Launches each scheduled call, holding mutating calls whose normalized
+ * locations overlap an earlier mutating call in the batch until every earlier
+ * overlapping call has settled. Calls without dependencies launch
+ * immediately. A waiting call does not launch at all once the batch signal
+ * has aborted, so no side effects begin after cancellation.
+ *
+ * @param onAbandoned Invoked exactly once for every mutating call with
+ *   locations that is never launched because the batch signal aborted —
+ *   whether abort wins the race while the call still waits or the dependency
+ *   settles after the abort. The scheduler uses this to buffer a terminal
+ *   cancelled result for the abandoned call's execution index.
+ */
+export function launchCallsWithSamePathOrdering(
+  calls: readonly ScheduledToolCall[],
+  launch: (call: ScheduledToolCall) => Promise<void>,
+  signal: AbortSignal,
+  onAbandoned: (call: ScheduledToolCall) => void,
+): Array<Promise<void>> {
+  const settledMutationsByPath = new Map<string, Promise<void>>();
+  return calls.map((call) => {
+    if (!isMutatingCall(call)) {
+      return launch(call);
+    }
+    const mutationPaths = normalizedMutationPaths(call);
+    if (mutationPaths.length === 0) {
+      return launch(call);
+    }
+
+    const predecessors = [
+      ...new Set(
+        mutationPaths.flatMap(
+          (mutationPath) => settledMutationsByPath.get(mutationPath) ?? [],
+        ),
+      ),
+    ];
+    const dependency =
+      predecessors.length > 0 ? Promise.all(predecessors) : Promise.resolve();
+
+    // Abandonment is reported exactly once per call. Waiting calls need the
+    // abort listener because their dependency may never settle after an
+    // abort-ignoring predecessor; every call's dependency-settle path checks
+    // the signal so a skip can never silently omit the notification.
+    let launchFinalized = false;
+    const abandon = (): void => {
+      if (launchFinalized) return;
+      launchFinalized = true;
+      signal.removeEventListener('abort', abandon);
+      onAbandoned(call);
+    };
+    if (predecessors.length > 0) {
+      signal.addEventListener('abort', abandon, { once: true });
+    }
+
+    const launched = dependency.then(() => {
+      if (signal.aborted) {
+        abandon();
+        return undefined;
+      }
+      launchFinalized = true;
+      signal.removeEventListener('abort', abandon);
+      return launch(call);
+    });
+    const settled = launched.then(
+      () => undefined,
+      () => undefined,
+    );
+    for (const mutationPath of mutationPaths) {
+      settledMutationsByPath.set(mutationPath, settled);
+    }
+    return launched;
+  });
+}

--- a/packages/agents/src/test-utils/coreToolScheduler-same-path-mutations-helpers.ts
+++ b/packages/agents/src/test-utils/coreToolScheduler-same-path-mutations-helpers.ts
@@ -14,10 +14,10 @@ import { beforeEach, afterEach } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { CoreToolScheduler, type ToolCall } from './coreToolScheduler.js';
-import type { CompletedToolCall } from './coreToolScheduler.js';
+import { CoreToolScheduler, type ToolCall } from '../core/coreToolScheduler.js';
+import type { CompletedToolCall } from '../core/coreToolScheduler.js';
 import type { ToolCallRequestInfo } from '@vybestack/llxprt-code-core/core/turn.js';
-import { createMockConfig } from './coreToolScheduler-test-helpers.js';
+import { createMockConfig } from '../core/coreToolScheduler-test-helpers.js';
 import { createSessionMessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import {
   BaseDeclarativeTool,

--- a/packages/tools/src/tools/memoryTool.ts
+++ b/packages/tools/src/tools/memoryTool.ts
@@ -10,6 +10,7 @@ import {
   Kind,
   type ToolEditConfirmationDetails,
   ToolConfirmationOutcome,
+  type ToolLocation,
   type ToolResult,
 } from './tools.js';
 import type { FunctionDeclaration } from '../types/wire-types.js';
@@ -289,6 +290,19 @@ class MemoryToolInvocation extends BaseToolInvocation<
     this.getWorkingDir = () => workingDir;
   }
 
+  /**
+   * Memory additions write the resolved memory file, so they report that
+   * target through the standard location contract and participate in
+   * scheduler same-path mutation ordering. Read-only invocations report no
+   * location.
+   */
+  override toolLocations(): ToolLocation[] {
+    if (this.params.read === true) {
+      return [];
+    }
+    return [{ path: this.getMemoryFilePath() }];
+  }
+
   private resolveWorkingDir(): string | undefined {
     return this.getWorkingDir?.();
   }
@@ -463,7 +477,7 @@ export class MemoryTool
       MemoryTool.Name,
       'SaveMemory',
       memoryToolDescription,
-      Kind.Think,
+      Kind.Edit,
       memoryToolSchemaData.parametersJsonSchema as Record<string, unknown>,
       false, // output is not markdown
       false, // output cannot be updated

--- a/packages/tools/src/tools/todo-store-concurrency.test.ts
+++ b/packages/tools/src/tools/todo-store-concurrency.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for TodoStore same-file concurrency safety (issue #3239).
+ *
+ * Todo tools construct a fresh TodoStore per call, so coordination must work
+ * across separate store instances that target the same resolved todo file.
+ * Each public operation is a whole-file read or read-modify-write
+ * transaction; concurrent transactions on one file must not interleave, or a
+ * list update and a pause-state update overwrite each other and can leave
+ * invalid partial JSON behind. Real filesystem round-trips in temp
+ * directories; no mocks.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { TodoStore } from './todo-store.js';
+
+function useTempTodoRoot(): () => string {
+  let root = '';
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'todo-store-concurrency-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  return () => root;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parses the todo file, failing the test fast on any invalid JSON or shape so
+ * partial/truncated writes surface as observable failures.
+ */
+function readTodoFile(filePath: string): {
+  todoIds: string[];
+  paused: boolean;
+} {
+  const raw: unknown = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  if (!isRecord(raw) || !Array.isArray(raw.todos)) {
+    throw new Error(`todo file has invalid shape: ${filePath}`);
+  }
+  const todoIds = raw.todos.filter(isRecord).map((todo) => String(todo['id']));
+  return { todoIds, paused: raw.paused === true };
+}
+
+describe('TodoStore same-file concurrency across instances', () => {
+  const rootFor = useTempTodoRoot();
+
+  function todoFilePath(sessionId: string): string {
+    return path.join(rootFor(), 'data', 'todos', `todo-${sessionId}.json`);
+  }
+
+  it('retains both todos and paused state written concurrently by separate stores', async () => {
+    const dataDir = path.join(rootFor(), 'data');
+    const seedingStore = new TodoStore('session-1', { dataDir });
+    await seedingStore.writeTodos([
+      { id: 'seed', content: 'seed todo', status: 'pending' },
+    ]);
+
+    const listWritingStore = new TodoStore('session-1', { dataDir });
+    const pauseWritingStore = new TodoStore('session-1', { dataDir });
+
+    await Promise.all([
+      listWritingStore.writeTodos([
+        { id: 'one', content: 'first todo', status: 'pending' },
+        { id: 'two', content: 'second todo', status: 'in_progress' },
+      ]),
+      pauseWritingStore.writePausedState(true),
+    ]);
+
+    const file = readTodoFile(todoFilePath('session-1'));
+    expect(file.paused).toBe(true);
+    expect(file.todoIds).toEqual(['one', 'two']);
+  });
+
+  it('keeps request-order last-list-wins semantics for concurrent writeTodos without corruption', async () => {
+    const dataDir = path.join(rootFor(), 'data');
+    const seedingStore = new TodoStore('session-2', { dataDir });
+    await seedingStore.writeTodos([
+      { id: 'seed', content: 'seed todo', status: 'pending' },
+    ]);
+
+    const firstStore = new TodoStore('session-2', { dataDir });
+    const secondStore = new TodoStore('session-2', { dataDir });
+    await Promise.all([
+      firstStore.writeTodos([
+        { id: 'l1-a', content: 'list one item a', status: 'pending' },
+        { id: 'l1-b', content: 'list one item b', status: 'pending' },
+      ]),
+      secondStore.writeTodos([
+        { id: 'l2-a', content: 'list two item a', status: 'in_progress' },
+        { id: 'l2-b', content: 'list two item b', status: 'pending' },
+        { id: 'l2-c', content: 'list two item c', status: 'completed' },
+      ]),
+    ]);
+
+    const file = readTodoFile(todoFilePath('session-2'));
+    expect(file.todoIds).toEqual(['l2-a', 'l2-b', 'l2-c']);
+    expect(file.paused).toBe(false);
+  });
+
+  it('lets later same-path operations succeed after an earlier operation fails', async () => {
+    const dataDir = path.join(rootFor(), 'data');
+    const seedingStore = new TodoStore('session-3', { dataDir });
+    await seedingStore.writeTodos([
+      { id: 'seed', content: 'seed todo', status: 'pending' },
+    ]);
+
+    const failingStore = new TodoStore('session-3', { dataDir });
+    const pausingStore = new TodoStore('session-3', { dataDir });
+    const results = await Promise.allSettled([
+      failingStore.writeTodos([
+        // Empty content fails todo validation mid-transaction, after the
+        // read-existing step, so the failure happens inside the operation.
+        { id: 'bad', content: '', status: 'pending' },
+      ]),
+      pausingStore.writePausedState(true),
+    ]);
+
+    expect(results[0].status).toBe('rejected');
+    expect(results[1].status).toBe('fulfilled');
+
+    const followUpStore = new TodoStore('session-3', { dataDir });
+    await followUpStore.writeTodos([
+      { id: 'after-failure', content: 'later todo', status: 'pending' },
+    ]);
+
+    const file = readTodoFile(todoFilePath('session-3'));
+    expect(file.todoIds).toEqual(['after-failure']);
+    expect(file.paused).toBe(true);
+  });
+});

--- a/packages/tools/src/tools/todo-store-path-aliasing.test.ts
+++ b/packages/tools/src/tools/todo-store-path-aliasing.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral test for TodoStore queue keying across alias-spelled data
+ * directories (issue #3239).
+ *
+ * The process-local transaction queues must be keyed by the platform-native
+ * lexically normalized once-resolved todo file path: two stores whose
+ * dataDir spellings differ lexically (data vs data/../data) but denote the
+ * same actual directory must serialize on one queue, or their complementary
+ * read-modify-write transactions overwrite each other's fields. To expose
+ * the pre-normalization race deterministically, fs.promises.readFile is
+ * held for a fixed number of macrotask turns, so two concurrently running
+ * transactions both read the pre-write snapshot before either write lands.
+ * All other filesystem behavior is the real implementation; the store under
+ * test is the real TodoStore. Normalization is lexical only (path.normalize):
+ * symlink and hardlink aliasing stay outside the coordination contract.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const actualFs = { ...(await import('fs')) };
+const actualPromises = { ...(await import('fs/promises')) };
+
+const READ_HOLD_MACROTASKS = 10;
+
+let holdReads = false;
+
+async function holdForMacrotaskTurns(): Promise<void> {
+  for (let turn = 0; turn < READ_HOLD_MACROTASKS; turn++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+void vi.mock('fs', () => ({
+  ...actualFs,
+  promises: {
+    ...actualFs.promises,
+    readFile: async (
+      filePath: string,
+      encoding: BufferEncoding,
+    ): Promise<string> => {
+      if (holdReads) {
+        await holdForMacrotaskTurns();
+      }
+      return actualPromises.readFile(filePath, encoding);
+    },
+  },
+}));
+
+const { TodoStore } = await import('./todo-store.js');
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+describe('TodoStore queue keying across alias-spelled data directories', () => {
+  let root = '';
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'todo-store-aliasing-'));
+    holdReads = false;
+  });
+
+  afterEach(() => {
+    holdReads = false;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('serializes complementary writes from dataDirs that normalize to one directory', async () => {
+    const canonicalDir = path.join(root, 'data');
+    const aliasDir = path.join(root, 'data', '..', 'data');
+    expect(path.normalize(aliasDir)).toBe(canonicalDir);
+
+    const seedingStore = new TodoStore('session-alias', {
+      dataDir: canonicalDir,
+    });
+    await seedingStore.writeTodos([
+      { id: 'seed', content: 'seed todo', status: 'pending' },
+    ]);
+
+    holdReads = true;
+    const listStore = new TodoStore('session-alias', { dataDir: canonicalDir });
+    const pauseStore = new TodoStore('session-alias', { dataDir: aliasDir });
+
+    await Promise.all([
+      listStore.writeTodos([
+        { id: 'one', content: 'first todo', status: 'pending' },
+      ]),
+      pauseStore.writePausedState(true),
+    ]);
+    holdReads = false;
+
+    const raw: unknown = JSON.parse(
+      fs.readFileSync(
+        path.join(canonicalDir, 'todos', 'todo-session-alias.json'),
+        'utf-8',
+      ),
+    );
+    expect(isRecord(raw) && Array.isArray(raw.todos)).toBe(true);
+    const todoIds =
+      isRecord(raw) && Array.isArray(raw.todos)
+        ? raw.todos.filter(isRecord).map((todo) => String(todo['id']))
+        : ['invalid-todo-file'];
+    expect(todoIds).toEqual(['one']);
+    expect(isRecord(raw) && raw.paused === true).toBe(true);
+  });
+});

--- a/packages/tools/src/tools/todo-store-read-atomicity.test.ts
+++ b/packages/tools/src/tools/todo-store-read-atomicity.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for TodoStore read atomicity and cross-path parallelism
+ * (issue #3239).
+ *
+ * A concurrent read must observe a complete before-or-after state, never a
+ * truncated or partially written file. To expose the write window
+ * deterministically, the fs.promises.writeFile used by TodoStore is wrapped
+ * so it opens/truncates the target, reports the truncation, and only performs
+ * the actual data write once the test releases it. All other filesystem
+ * behavior is the real implementation. This is infrastructure control only —
+ * the store under test is the real TodoStore.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const actualFs = { ...(await import('fs')) };
+const actualPromises = { ...(await import('fs/promises')) };
+
+interface WriteGatePlan {
+  /** When 'hold', writes truncate, report, and wait for the release signal. */
+  mode: 'off' | 'hold';
+  onTruncate?: (filePath: string) => void;
+  releaseSignal?: Promise<void>;
+}
+
+let writePlan: WriteGatePlan = { mode: 'off' };
+
+void vi.mock('fs', () => ({
+  ...actualFs,
+  promises: {
+    ...actualFs.promises,
+    writeFile: async (
+      filePath: string,
+      data: string,
+      encoding: BufferEncoding,
+    ): Promise<void> => {
+      if (writePlan.mode !== 'hold') {
+        await actualPromises.writeFile(filePath, data, encoding);
+        return;
+      }
+      const handle = await actualPromises.open(filePath, 'w');
+      try {
+        writePlan.onTruncate?.(filePath);
+        await writePlan.releaseSignal;
+        await handle.writeFile(data, encoding);
+      } finally {
+        await handle.close();
+      }
+    },
+  },
+}));
+
+const { TodoStore } = await import('./todo-store.js');
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let settle: (value: T) => void = () => {
+    throw new Error('deferred settle called before initialization');
+  };
+  const promise = new Promise<T>((resolve) => {
+    settle = resolve;
+  });
+  return { promise, resolve: (value) => settle(value) };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function todoIdsOf(raw: unknown): string[] {
+  if (!isRecord(raw) || !Array.isArray(raw.todos)) {
+    return ['invalid-todo-file'];
+  }
+  return raw.todos.filter(isRecord).map((todo) => String(todo['id']));
+}
+
+describe('TodoStore read atomicity and cross-path parallelism', () => {
+  let root = '';
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'todo-store-atomicity-'));
+    writePlan = { mode: 'off' };
+  });
+
+  afterEach(() => {
+    writePlan = { mode: 'off' };
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('never lets a concurrent read observe a truncated todo file', async () => {
+    const dataDir = path.join(root, 'data');
+    const seedingStore = new TodoStore('session-atomic', { dataDir });
+    await seedingStore.writeTodos([
+      { id: 'seed', content: 'seed todo', status: 'pending' },
+    ]);
+
+    const truncated = deferred<void>();
+    const release = deferred<void>();
+    writePlan = {
+      mode: 'hold',
+      onTruncate: () => truncated.resolve(),
+      releaseSignal: release.promise,
+    };
+
+    const writer = new TodoStore('session-atomic', { dataDir }).writeTodos([
+      { id: 'fresh', content: 'fresh todo', status: 'pending' },
+    ]);
+    await truncated.promise;
+
+    const reader = new TodoStore('session-atomic', { dataDir }).readTodos();
+    release.resolve();
+
+    let observedIds: string[] | undefined;
+    let readError: Error | undefined;
+    try {
+      observedIds = (await reader).map((todo) => String(todo.id));
+    } catch (error) {
+      readError = error instanceof Error ? error : new Error(String(error));
+    }
+    await writer;
+
+    expect(readError).toBeUndefined();
+    const observedCompleteState =
+      observedIds?.join(',') === 'seed' || observedIds?.join(',') === 'fresh';
+    expect(observedCompleteState).toBe(true);
+  });
+
+  it('runs operations for different todo files in parallel', async () => {
+    const dataDir = path.join(root, 'data');
+    const release = deferred<void>();
+    const truncatedPaths = new Set<string>();
+    const expectedFiles = [
+      path.join(dataDir, 'todos', 'todo-session-a.json'),
+      path.join(dataDir, 'todos', 'todo-session-b.json'),
+    ];
+    writePlan = {
+      mode: 'hold',
+      onTruncate: (filePath) => {
+        truncatedPaths.add(filePath);
+        if (expectedFiles.every((expected) => truncatedPaths.has(expected))) {
+          release.resolve();
+        }
+      },
+      releaseSignal: release.promise,
+    };
+
+    // Both writes must reach their truncation point before either may
+    // proceed. If same-path coordination wrongly serialized different files,
+    // the first write would wait forever for the second truncation.
+    await Promise.all([
+      new TodoStore('session-a', { dataDir }).writeTodos([
+        { id: 'a1', content: 'session a todo', status: 'pending' },
+      ]),
+      new TodoStore('session-b', { dataDir }).writeTodos([
+        { id: 'b1', content: 'session b todo', status: 'pending' },
+      ]),
+    ]);
+
+    const fileA: unknown = JSON.parse(
+      fs.readFileSync(expectedFiles[0], 'utf-8'),
+    );
+    const fileB: unknown = JSON.parse(
+      fs.readFileSync(expectedFiles[1], 'utf-8'),
+    );
+    expect(todoIdsOf(fileA)).toEqual(['a1']);
+    expect(todoIdsOf(fileB)).toEqual(['b1']);
+  });
+});

--- a/packages/tools/src/tools/todo-store.ts
+++ b/packages/tools/src/tools/todo-store.ts
@@ -179,19 +179,6 @@ export class TodoStore {
   }
 
   /**
-   * Read the full file data including todos and paused state.
-   *
-   * Resolves the file path exactly once for the entire operation and threads
-   * that captured path through both the exists-check and the read.
-   * This guarantees a dynamic resolver that changes between calls cannot split
-   * the exists/read across different directories.
-   */
-  private async readFileData(): Promise<TodoFileData> {
-    const filePath = this.resolveFilePath();
-    return this.readFileDataAt(filePath);
-  }
-
-  /**
    * Reads file data at a specific captured path. The path is resolved once by
    * the caller and threaded through so a dynamic resolver cannot split a
    * single logical operation across directories.
@@ -235,8 +222,18 @@ export class TodoStore {
     await fs.promises.writeFile(filePath, content, 'utf8');
   }
 
+  /**
+   * Reads the todo list. The complete read transaction is queued behind
+   * earlier transactions for the same resolved path, so it can never observe
+   * a same-process partial write.
+   *
+   * Resolves the file path exactly once for the entire operation.
+   */
   async readTodos(): Promise<Todo[]> {
-    const data = await this.readFileData();
+    const filePath = this.resolveFilePath();
+    const data = await runTodoPathTransaction(filePath, () =>
+      this.readFileDataAt(filePath),
+    );
     return data.todos;
   }
 
@@ -245,23 +242,34 @@ export class TodoStore {
    *
    * Resolves the file path exactly once for the whole logical operation
    * (read-existing + write) so a dynamic resolver cannot split the read and
-   * write across different directories.
+   * write across different directories. The read-preserve-write transaction
+   * is queued behind earlier transactions for the same resolved path so
+   * concurrent writers cannot overwrite each other's fields.
    */
   async writeTodos(todos: Todo[]): Promise<void> {
     const filePath = this.resolveFilePath();
-    const existingData = await this.readFileDataAt(filePath);
-    await this.writeFileDataAt(filePath, {
-      todos,
-      paused: existingData.paused,
+    await runTodoPathTransaction(filePath, async () => {
+      const existingData = await this.readFileDataAt(filePath);
+      await this.writeFileDataAt(filePath, {
+        todos,
+        paused: existingData.paused,
+      });
     });
   }
 
   /**
    * Read the paused state from the task file.
-   * Returns false if file doesn't exist or is in legacy format.
+   * Returns false if file doesn't exist or is in legacy format. The complete
+   * read transaction is queued behind earlier transactions for the same
+   * resolved path, so it can never observe a same-process partial write.
+   *
+   * Resolves the file path exactly once for the entire operation.
    */
   async readPausedState(): Promise<boolean> {
-    const data = await this.readFileData();
+    const filePath = this.resolveFilePath();
+    const data = await runTodoPathTransaction(filePath, () =>
+      this.readFileDataAt(filePath),
+    );
     return data.paused;
   }
 
@@ -270,16 +278,62 @@ export class TodoStore {
    *
    * Resolves the file path exactly once for the whole logical operation
    * (read-existing + write) so a dynamic resolver cannot split the read and
-   * write across different directories.
+   * write across different directories. The read-preserve-write transaction
+   * is queued behind earlier transactions for the same resolved path so
+   * concurrent writers cannot overwrite each other's fields.
    */
   async writePausedState(paused: boolean): Promise<void> {
     const filePath = this.resolveFilePath();
-    const existingData = await this.readFileDataAt(filePath);
-    await this.writeFileDataAt(filePath, {
-      todos: existingData.todos,
-      paused,
+    await runTodoPathTransaction(filePath, async () => {
+      const existingData = await this.readFileDataAt(filePath);
+      await this.writeFileDataAt(filePath, {
+        todos: existingData.todos,
+        paused,
+      });
     });
   }
+}
+
+/**
+ * Process-local transaction queues keyed by the platform-native lexically
+ * normalized resolved todo-file path (issue #3239). Todo tools construct a
+ * fresh TodoStore per call, so same-file coordination cannot live on any
+ * single instance. Queuing each complete read or read-modify-write
+ * transaction prevents concurrent same-file operations from interleaving
+ * filesystem access and overwriting each other's fields. Normalization is
+ * lexical only (path.normalize): different spellings of one directory share
+ * a queue, while symlink and hardlink aliasing stay outside the
+ * coordination contract.
+ */
+const todoPathQueues = new Map<string, Promise<void>>();
+
+/**
+ * Runs `transaction` after every previously invoked transaction for the
+ * same resolved path has settled, in invocation order. The queue is keyed
+ * by the lexically normalized path while the transaction keeps using the
+ * caller's once-resolved path for I/O. The queue tail never rejects and
+ * removes itself once idle, so a failed transaction still releases its
+ * successors and inactive paths do not accumulate. Different paths are
+ * independent map entries and stay concurrent.
+ */
+function runTodoPathTransaction<T>(
+  filePath: string,
+  transaction: () => Promise<T>,
+): Promise<T> {
+  const queueKey = path.normalize(filePath);
+  const predecessor = todoPathQueues.get(queueKey) ?? Promise.resolve();
+  const result = predecessor.then(transaction);
+  const settled = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  todoPathQueues.set(queueKey, settled);
+  void settled.then(() => {
+    if (todoPathQueues.get(queueKey) === settled) {
+      todoPathQueues.delete(queueKey);
+    }
+  });
+  return result;
 }
 
 /**

--- a/project-plans/issue3239/plan.md
+++ b/project-plans/issue3239/plan.md
@@ -1,0 +1,204 @@
+# Plan: Serialize Same-Path Mutating Tool Calls (Issue #3239)
+
+Plan ID: PLAN-20260817-ISSUE3239
+Generated: 2026-08-17
+Issue: #3239
+Status: Verified — ready for pull request
+
+## Problem statement
+
+Tool calls in one scheduler batch execute concurrently. File-mutating tools use whole-file read-modify-write operations, so two calls whose target locations overlap can both read the same snapshot and then overwrite each other. Both calls may report success even though one update is lost; overlapping non-atomic writes can also leave partial file content.
+
+The existing tool invocation contract already exposes each call's target locations through `toolLocations()` and classifies operations through `Kind`. The scheduler therefore has enough validated information to preserve parallelism while ordering only conflicting mutations.
+
+## Preflight findings
+
+1. `CoreToolScheduler.attemptExecutionOfScheduledCalls()` launches every scheduled invocation immediately and awaits the batch with `Promise.all`.
+2. Scheduled calls already contain the validated tool and invocation, including `tool.kind` and `invocation.toolLocations()`.
+3. Six built-in file mutation tools already expose the exact metadata needed for one generic fix: `replace`, `write_file`, `insert_at_line`, `delete_line_range`, `apply_patch`, and `ast_edit` are all `Kind.Edit` and return their target path from `toolLocations()`.
+4. Scheduler-owned overlap ordering therefore fixes the reported race for all six tools without tool-name lists, new tool parameters, or per-tool locks.
+5. Existing scheduler behavior intentionally preserves response publication order while allowing completion order to differ. The fix must preserve that contract.
+6. The scheduler has explicit abort handling. A call waiting on a same-path predecessor must not begin side-effecting work after the batch signal is aborted.
+7. `ast_edit`'s optional `last_modified` contract is independent optimistic concurrency control. Scheduler ordering protects same-batch calls even when that optional value is omitted.
+8. The user explicitly accepted `save_memory` and todo persistence only if their races are real. A deterministic `save_memory` reproduction forced two concurrent additions to read the same snapshot: both calls completed, but the resulting memory contained only `beta` and lost `alpha`.
+9. A real-filesystem TodoStore reproduction ran concurrent `writeTodos(newTodos)` and `writePausedState(true)` operations 50 times. It produced 48 valid-but-lost updates and 2 JSON-corrupt files containing invalid interleaved/truncated data. This is a proven instance of the reported failure class, not speculative hardening.
+10. `save_memory` is currently `Kind.Think` and exposes no scheduler location despite writing a resolved file. It can join the accepted scheduler ordering by reporting its resolved memory path and using mutation metadata.
+11. Todo tools obtain a fresh `TodoStore` instance for each call, and their legacy invocation wrapper exposes no location. The narrow fix is therefore an internal per-resolved-path TodoStore operation queue shared across instances; it must cover each complete read or read-modify-write transaction and retain parallelism across different todo files.
+
+## Proposed accepted behavior
+
+### REQ-3239-1: Preserve all same-path mutations in request order
+
+**Full text:** Within one scheduler batch, mutating tool invocations whose normalized target-location sets overlap must execute in model request order rather than concurrently.
+
+- GIVEN two or more `replace` calls in one batch with non-overlapping text anchors in the same file
+- WHEN the batch executes
+- THEN each later call reads the result of every earlier same-file mutation
+- AND every requested replacement persists
+- AND every successful response corresponds to content present in the final complete file
+- AND the file tail remains intact
+
+### REQ-3239-2: Retain parallelism for independent paths
+
+**Full text:** Mutating calls whose normalized target-location sets do not overlap must remain eligible to execute concurrently.
+
+- GIVEN mutating calls targeting different files
+- WHEN they are submitted in one batch
+- THEN neither call waits for the other solely because both are mutating
+
+### REQ-3239-3: Fix every file mutation tool with the same scheduler race
+
+**Full text:** Conflict detection must use validated invocation locations and existing mutating `Kind` values, without adding tool-name lists, public parameters, dependencies, or a public lock abstraction. The behavior must cover `replace`, `write_file`, `insert_at_line`, `delete_line_range`, `apply_patch`, and `ast_edit`.
+
+- every `Kind.Edit`, `Kind.Delete`, or `Kind.Move` call with at least one location participates in overlap ordering, including future tools that use the same contract
+- a multi-location mutation waits for all earlier mutations that overlap any of its locations
+- read/search/fetch/execute/think/other calls are not newly serialized
+- calls without a target location retain current scheduling behavior
+- paths are compared after platform-native lexical normalization; filesystem-identity aliases such as symlinks and hardlinks are outside this issue
+
+### REQ-3239-4: Preserve failure, response, and cancellation semantics
+
+**Full text:** Ordering dependencies must not suppress later tool results or start queued side effects after cancellation.
+
+- an earlier mutation's tool-level failure does not prevent a later same-path mutation from receiving its own execution/result
+- response publication remains in original request order
+- if the batch aborts while a same-path mutation is waiting, the waiting mutation does not start after its predecessor settles
+- existing scheduler completion and abort behavior remains compatible
+
+### REQ-3239-5: Preserve concurrent `save_memory` additions
+
+**Full text:** Concurrent `save_memory` additions targeting the same resolved memory file must execute in request order so each successful fact remains in the file. Memory files for different scopes/paths remain independent.
+
+- the invocation reports the exact resolved project/global/core memory path through the existing location contract
+- normal memory additions participate in scheduler same-path mutation ordering
+- two successful additions to one memory file both persist
+- additions to different resolved memory files remain parallel
+- no memory schema, scope, confirmation, or storage-path semantics change
+
+### REQ-3239-6: Make TodoStore transactions concurrency-safe across instances
+
+**Full text:** TodoStore operations targeting the same resolved todo file must not interleave filesystem reads and writes. A todo-list update and pause-state update started concurrently must preserve both fields and leave valid complete JSON.
+
+- queue ownership is internal to TodoStore and keyed by the once-resolved file path so fresh store instances coordinate
+- `readTodos` and `readPausedState` cannot observe a same-process partial write
+- each `writeTodos` read-preserve-write transaction is indivisible relative to same-path todo operations
+- each `writePausedState` read-preserve-write transaction is indivisible relative to same-path todo operations
+- different session/agent/path files remain parallel
+- two complete `writeTodos` requests retain the API's intentional request-order last-list-wins semantics without corruption
+- no todo schema, persistence format, resolver, reminder, continuation, or event semantics change
+
+## Inputs and boundary cases
+
+| Input/boundary | Accepted behavior |
+| --- | --- |
+| Two `replace` calls, same exact absolute path | Sequential in request order; both edits persist |
+| Three or more same-path mutations | Entire chain executes in request order |
+| `absolute_path` versus legacy `file_path` resolving to the same location | Sequential after invocation normalization |
+| Different target files | Parallel execution retained |
+| Multi-location mutation overlapping an earlier mutation on one path | Waits for the earlier overlapping mutation |
+| Earlier same-path mutation returns an error result | Later call still executes and reports its own result |
+| Abort while a call waits on a predecessor | Waiting call does not begin side effects |
+| Read plus ordinary workspace-file mutation on the same file | No new read/write ordering guarantee in this issue |
+| Two `save_memory` additions to one resolved memory path | Sequential; both facts persist |
+| `save_memory` additions to different scope paths | Parallel execution retained |
+| Todo list write plus pause-state write to one todo file | Both fields persist as valid complete JSON |
+| Todo read concurrent with same-path todo write | Read observes a complete before-or-after state, never partial JSON |
+| Todo operations for different session/agent paths | Parallel execution retained |
+| Separate processes, symlink aliases, or hardlink aliases | Outside this issue |
+
+## Explicit scope boundaries
+
+- No `last_modified` parameter or schema change for `replace` or `write_file`.
+- No atomic-write helper or rewrite of individual file tools.
+- No tool-description warning once same-batch conflicts are fixed.
+- No cross-process filesystem lock or coordination; accepted ordering is process-local.
+- `save_memory` changes are limited to exposing its already-resolved path/mutation metadata and proving same-path additions persist.
+- Todo changes are limited to an internal process-local, per-resolved-path operation queue and its behavioral tests; no public lock abstraction is added.
+- No dependency, workflow, agent-memory, quality-tool, lint-policy, complexity-threshold, or unrelated refactor change.
+- No changes to independent-call parallelism or result publication ordering beyond the accepted overlap dependencies.
+
+## Test-first implementation sequence
+
+### Phase 1: RED — scheduler behavioral regressions
+
+Add focused Bun tests beside `CoreToolScheduler` using real scheduler behavior and test tool invocations that expose real mutation locations.
+
+1. Same-path mutations: hold the first call open and prove the second does not start; release calls and prove request-order completion.
+2. Three-call chain: prove every same-path mutation starts only after its predecessor settles.
+3. Different paths: use a barrier to prove both calls start before either is released.
+4. Multi-location overlap: prove overlap on any location creates the dependency.
+5. Failure continuation: prove a failed predecessor does not suppress the later same-path call.
+6. Abort while waiting: prove the waiting invocation never starts after abort.
+7. Real built-in tool integration matrix through the scheduler:
+   - `replace`: two non-overlapping replacements both persist and the tail remains complete.
+   - `write_file`: two writes complete in request order, the second complete payload is final, and no partial tail remains.
+   - `insert_at_line`: two inserts both persist in request order.
+   - `delete_line_range`: two deletions based on sequential file state both persist.
+   - `apply_patch`: two non-overlapping patches both persist.
+   - `ast_edit`: two edits without `last_modified` both persist in request order.
+8. Mixed-tool same-path regression: at least two different built-in mutators targeting one file are ordered by path rather than tool name.
+9. Real `save_memory` scheduler regression: concurrent same-scope additions both persist; different resolved paths can start in parallel.
+10. Real TodoStore regressions across separate store instances:
+    - concurrent `writeTodos` plus `writePausedState` preserves both values and valid JSON;
+    - a concurrent read returns complete parseable before-or-after state;
+    - same-path operations execute in request order after an earlier failure;
+    - different session/agent/path operations can overlap;
+    - queue entries are released after success and failure.
+
+Run each focused test before its production change and retain the failing RED evidence.
+
+### Phase 2: GREEN — minimal scheduler ordering
+
+1. Build turn-local/scheduler-batch dependency chains from mutating scheduled calls and normalized `toolLocations()` paths.
+2. Launch independent calls immediately.
+3. Launch an overlapping call only after its earlier path dependencies settle, unless the batch signal has aborted.
+4. Keep the existing aggregate wait, ordered publication, and error handling contracts.
+5. Have `save_memory` expose its resolved path and participate in the existing mutation contract; add no tool-name special case.
+
+### Phase 3: GREEN — TodoStore transaction ordering
+
+1. Resolve the todo path once at each public store operation boundary.
+2. Queue the complete read or read-modify-write transaction behind earlier operations for that exact normalized path, including operations from other TodoStore instances.
+3. Release and remove queue state after success or failure so later operations continue and the map does not retain inactive paths.
+4. Keep different todo paths independent and preserve the existing data format and resolver behavior.
+
+### Phase 4: Verification and review
+
+1. Run focused scheduler and real-replace tests.
+2. Run the complete verification cycle.
+3. Run DeepThinker compliance review and classify each finding as `Blocker-Fix`, `In-scope-Fix`, `Reject`, or `Defer`.
+4. Run at most two local Open Code Review passes, remediating all accepted findings test-first.
+5. Commit, push, create the PR, watch CI, and run at most two PR OCR review passes.
+6. Resolve every accepted review finding and confirm conflict-free ancestry before reporting ready to merge.
+
+## Behavioral evidence required for completion
+
+- A pre-fix failing test demonstrates overlapping same-path execution/lost-update risk.
+- Post-fix same-path scheduler tests prove ordered starts for two and three calls.
+- Real temporary-file scheduler tests prove request-order, complete-file behavior for `replace`, `write_file`, `insert_at_line`, `delete_line_range`, `apply_patch`, and `ast_edit`.
+- A mixed-tool same-path test proves ordering is path-based rather than tool-name-based.
+- Different-file tests prove independent mutations still overlap in execution.
+- Failure and abort tests prove no suppressed result and no post-abort queued side effect.
+- A real scheduler-backed memory test proves concurrent same-file facts both persist and different memory paths remain independent.
+- Real TodoStore tests using separate instances prove list/pause updates are both retained, concurrent reads never parse partial JSON, failures do not poison the queue, and different todo paths remain parallel.
+- Full local verification and smoke test pass on the candidate head.
+- CI passes on the candidate head; all reviews are complete and triaged; all `Blocker-Fix` and `In-scope-Fix` findings are resolved; the PR is conflict-free.
+
+## Verification commands
+
+```bash
+bun test packages/agents/src/core/coreToolScheduler.same-path-mutations.test.ts
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+git diff --check
+```
+
+## Alternatives deliberately not accepted in this proposal
+
+1. Optional `last_modified` CAS: callers that omit it remain vulnerable, so it does not by itself deliver transparent safety for the reported batch.
+2. Atomic rename only: prevents partial writes but still allows a stale whole-file snapshot to overwrite a successful edit.
+3. A `replace`-only module-global mutex: fixes a narrower execution path, introduces process-global state, and leaves sibling mutators with the same scheduler race.


### PR DESCRIPTION
## TLDR

Prevents concurrent same-target mutating tool calls from silently losing updates or truncating files while preserving parallel execution for independent targets.

The scheduler now orders overlapping `Edit`, `Delete`, and `Move` invocations by platform-native lexically normalized `toolLocations()`. The same mechanism covers workspace mutations and `save_memory`. Todo persistence uses a separate process-local per-path transaction queue because Todo tools create fresh store instances and do not expose scheduler locations through their legacy invocation layer.

## Dive Deeper

### Scheduler behavior

- Builds per-target predecessor chains within a scheduler batch.
- Executes overlapping mutations in original request order.
- Keeps disjoint-path mutations, read-kind calls, and locationless calls concurrent.
- Handles multi-location overlap without global serialization.
- Releases successors after predecessor success or failure.
- Prevents waiting mutations from launching after cancellation.
- Buffers cancelled placeholders for abandoned execution indices so ordered result publication and later scheduler batches remain valid.
- Uses lexical `path.normalize` identity only; symlink/hardlink identity and cross-process coordination remain out of scope.

### Persistent state

- Marks `save_memory` as an edit mutation and exposes the exact resolved memory-file path for writes; memory reads expose no mutation target.
- Serializes complete TodoStore read and read-preserve-write transactions across store instances targeting the same normalized file path.
- Resolves the dynamic TodoStore path once per operation and uses that captured path throughout the transaction.
- Removes inactive queue tails and preserves failure continuation and independent-path parallelism.

### Review disposition

Deepthinker compliance review passed with no accepted code findings. Two permitted local Open Code Review passes completed across all 10 changed source/test items.

Accepted pass-1 findings were remediated: cancellation coverage now verifies terminal state and scheduler reuse, memory race control is deterministic, and abandoned result indices are consumed. Other findings were rejected as either already behaviorally covered, test-only diagnostic preferences, or unreachable/theoretical under the scheduler publication invariant. Pass 2 produced four comments: the duplicated fire-and-forget concern is unreachable because an abandoned index either encounters an earlier gap or consumes only its own cancelled placeholder; the gated assertion fails immediately rather than waiting on the pending promise; and the Todo sentinel comment is diagnostic-only. No pass-2 source changes were required.

## Reviewer Test Plan

1. Run the five issue-specific suites:

   ```bash
   bun test packages/agents/src/core/coreToolScheduler.same-path-mutations.test.ts
   bun test packages/agents/src/core/coreToolScheduler.same-path-mutations.real-tools.test.ts
   bun test packages/tools/src/tools/todo-store-concurrency.test.ts
   bun test packages/tools/src/tools/todo-store-path-aliasing.test.ts
   bun test packages/tools/src/tools/todo-store-read-atomicity.test.ts
   ```

   Expected: 25 tests pass.

2. Run neighboring scheduler cancellation/result-publication/parallel tests, MemoryTool tests, and existing TodoStore tests. The isolated verification passed 77 tests.

3. Run quality gates:

   ```bash
   npm run lint
   npm run typecheck
   npm run format
   npm run build
   git diff --check
   ```

   All passed on the candidate commit.

4. Run the canonical repository smoke:

   ```bash
   bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
   ```

   This passed with a three-line haiku response.

5. Full-suite disclosure: `npm run test` completed with status 1 for two proven unchanged baseline/environment failures:
   - Four host-sensitive Ripgrep path expectations assume `/usr/local/bin/rg` or bundled resolution, while this Darwin host resolves `/opt/homebrew/bin/rg`. The isolated file produced 10 pass / 4 fail and is byte-identical to `origin/main`.
   - One `createAgent.harness.behavior` test timed out under full-suite load. Its isolated suite immediately passed 9/9, including the timed-out case, and is byte-identical to `origin/main`.

6. Requested smoke mismatch disclosure: `node scripts/start.js --profile-load synthetic --prompt-interactive "write me a haiku"` cannot run because this repository has only `scripts/start.ts`; the closest Bun command also reports `Profile 'synthetic' not found`. No unrelated launcher or profile was added to mask that mismatch.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️ focused/quality/build pass; full-suite baseline failures documented above | ❓ | ❓ |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #3239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured file mutations targeting the same path execute in request order, preventing lost updates.
  * Preserved concurrent execution for independent paths and read-only operations.
  * Improved cancellation and failure handling so queued operations do not block later work.
  * Ensured todo and memory updates preserve existing data during concurrent changes.
  * Made reads return complete, consistent data while writes are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->