### PR TITLE
Shard nightly platform tests to fit runner budgets (Fixes #3153)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,13 +23,22 @@ defaults:
     shell: 'bash'
 
 jobs:
+  # Run the canonical test shards independently so the nightly wall clock is
+  # bounded by its slowest shard instead of the sum of every workspace.
   windows_ci:
-    name: 'Windows CI (Nightly)'
+    name: 'Windows CI (Nightly) [${{ matrix.shard }}]'
     runs-on: '${{ matrix.os }}'
-    timeout-minutes: 60
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
+        shard:
+          - 'cli'
+          - 'agents'
+          - 'providers'
+          - 'core'
+          - 'rest'
+          - 'scripts'
         os:
           - 'windows-latest'
         node-version:
@@ -70,43 +79,35 @@ jobs:
       - name: 'Install dependencies for testing'
         run: |-
           npm ci
-      - name: 'Build project'
-        run: |-
-          npm run build
 
       - name: 'Fix rollup platform dependency'
         run: |-
-          # Explicitly install the platform-specific rollup package
-          # This is a workaround for https://github.com/npm/cli/issues/4828
-          if [ "${{ runner.os }}" == "Linux" ]; then
-            npm install @rollup/rollup-linux-x64-gnu --no-save || true
-          elif [ "${{ runner.os }}" == "Windows" ]; then
-            npm install @rollup/rollup-win32-x64-msvc --no-save || true
-          fi
+          npm install @rollup/rollup-win32-x64-msvc --no-save || true
         shell: 'bash'
 
-      - name: 'Generate agents API surface report'
-        shell: 'bash'
+      - name: 'Build project (agents and scripts shards)'
+        if: matrix.shard == 'agents' || matrix.shard == 'scripts'
         run: |-
-          npm run lint:agents-api-surface
+          npm run build
 
-      - name: 'Run tests and generate reports'
+      - name: 'Verify test shard completeness'
+        run: 'npm run lint:test-shards'
+
+      - name: 'Run shard tests (issue #3153)'
         env:
-          # Provider configuration from repository secrets/variables
           OPENAI_API_KEY: ${{ secrets[vars.KEY_VAR_NAME] }}
           OPENAI_API_KEY_2: ${{ secrets[vars.KEY_VAR_NAME_2] }}
           KEY_VAR_NAME: ${{ vars.KEY_VAR_NAME }}
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
           LLXPRT_DEFAULT_MODEL: ${{ vars.LLXPRT_DEFAULT_MODEL }}
           LLXPRT_DEFAULT_PROVIDER: ${{ vars.LLXPRT_DEFAULT_PROVIDER }}
-          # Set auth type to provider for API key authentication
           LLXPRT_AUTH_TYPE: provider
           NO_COLOR: true
-          # Ensure OAuth tests are skipped in CI (they require browser interaction)
           CI: true
-        run: 'npm run test'
+        run: 'bun scripts/test.ts --shard "${{ matrix.shard }}"'
 
       - name: 'Smoke test CLI entry (launcher -> Bun, no Node in chain)'
+        if: matrix.shard == 'cli'
         run: './packages/cli/bin/llxprt --version'
 
       - name: 'Wait for file system sync'
@@ -114,43 +115,51 @@ jobs:
 
       - name: 'Publish Test Report (for non-forks)'
         if: |-
-          ${{ always() && (github.event.pull_request.head.repo.full_name == github.repository) }}
+          ${{ always() && matrix.shard != 'scripts' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: 'dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2' # ratchet:dorny/test-reporter@v3
         with:
-          name: 'Test Results (Node ${{ matrix.node-version }})'
+          name: 'Windows Test Results [${{ matrix.shard }}] (Node ${{ matrix.node-version }})'
           path: 'packages/*/junit.xml'
           reporter: 'java-junit'
           fail-on-error: 'false'
 
       - name: 'Upload Test Results Artifact (for forks)'
         if: |-
-          ${{ always() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+          ${{ always() && matrix.shard != 'scripts' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # ratchet:actions/upload-artifact@v7
         with:
-          name: 'test-results-fork-${{ matrix.node-version }}-${{ matrix.os }}'
+          name: 'test-results-fork-windows-${{ matrix.shard }}-${{ matrix.node-version }}'
           path: 'packages/*/junit.xml'
 
   #
   # macOS CI (Nightly) — issue #2876
   #
-  # The macOS test legs moved out of PR CI (ci.yml) into this nightly job so
-  # macOS runner-minute spend on PR CI drops to near zero. macOS cross-platform
-  # coverage is preserved on a nightly cadence, alongside the existing Windows
-  # CI job above. Like windows_ci, this runs the full unsharded workspace test
-  # suite (npm run test) plus the script harness and shell-script behavioral
-  # tests that the PR scripts shard covers.
   macos_ci:
-    name: 'macOS CI (Nightly)'
-    runs-on: 'macos-latest'
-    timeout-minutes: 60
+    name: 'macOS CI (Nightly) [${{ matrix.shard }}]'
+    runs-on: '${{ matrix.os }}'
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - 'cli'
+          - 'agents'
+          - 'providers'
+          - 'core'
+          - 'rest'
+          - 'scripts'
+        os:
+          - 'macos-latest'
+        node-version:
+          - '24.x'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # ratchet:actions/checkout@v7
 
-      - name: 'Set up Node.js 24.x'
+      - name: 'Set up Node.js ${{ matrix.node-version }}'
         uses: 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020' # ratchet:actions/setup-node@v7
         with:
-          node-version: '24.x'
+          node-version: '${{ matrix.node-version }}'
           cache: 'npm'
 
       - name: 'Setup Bun'
@@ -164,8 +173,6 @@ jobs:
 
       - name: 'Fix rollup platform dependency'
         run: |-
-          # Explicitly install the platform-specific rollup package
-          # This is a workaround for https://github.com/npm/cli/issues/4828
           if [ "$(uname -m)" == "arm64" ]; then
             npm install @rollup/rollup-darwin-arm64 --no-save || true
           else
@@ -173,49 +180,35 @@ jobs:
           fi
         shell: 'bash'
 
-      - name: 'Build project'
+      - name: 'Build project (agents and scripts shards)'
+        if: matrix.shard == 'agents' || matrix.shard == 'scripts'
         run: |-
           npm run build
 
-      - name: 'Generate agents API surface report'
-        shell: 'bash'
-        run: |-
-          npm run lint:agents-api-surface
+      - name: 'Verify test shard completeness'
+        run: 'npm run lint:test-shards'
 
-      - name: 'Run tests and generate reports'
-        id: macos_main_tests
+      - name: 'Run shard tests (issue #3153)'
         env:
-          # Provider configuration from repository secrets/variables
           OPENAI_API_KEY: ${{ secrets[vars.KEY_VAR_NAME] }}
           OPENAI_API_KEY_2: ${{ secrets[vars.KEY_VAR_NAME_2] }}
           KEY_VAR_NAME: ${{ vars.KEY_VAR_NAME }}
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
           LLXPRT_DEFAULT_MODEL: ${{ vars.LLXPRT_DEFAULT_MODEL }}
           LLXPRT_DEFAULT_PROVIDER: ${{ vars.LLXPRT_DEFAULT_PROVIDER }}
-          # Set auth type to provider for API key authentication
           LLXPRT_AUTH_TYPE: provider
           NO_COLOR: true
-          # Ensure OAuth tests are skipped in CI (they require browser interaction)
           CI: true
-        run: 'npm run test'
-
-      - name: 'Run script harness tests'
-        # Run when the main test step completed (success or failure) but NOT
-        # when the workflow was cancelled — so macOS platform coverage of the
-        # script harness still runs after a test failure, without burning
-        # runner minutes after cancellation (issue #3149).
-        if: ${{ !cancelled() && (steps.macos_main_tests.outcome == 'success' || steps.macos_main_tests.outcome == 'failure') }}
-        env:
-          CI: true
-        run: 'npm run test:scripts'
+        run: 'bun scripts/test.ts --shard "${{ matrix.shard }}"'
 
       - name: 'Run shell-script behavioral tests (#2606)'
-        if: ${{ !cancelled() && (steps.macos_main_tests.outcome == 'success' || steps.macos_main_tests.outcome == 'failure') }}
+        if: matrix.shard == 'scripts'
         env:
           CI: true
         run: 'npm run test:shell'
 
       - name: 'Smoke test CLI entry (launcher -> Bun, no Node in chain)'
+        if: matrix.shard == 'cli'
         run: './packages/cli/bin/llxprt --version'
 
       - name: 'Wait for file system sync'
@@ -223,20 +216,20 @@ jobs:
 
       - name: 'Publish Test Report (for non-forks)'
         if: |-
-          ${{ always() && (github.event.pull_request.head.repo.full_name == github.repository) }}
+          ${{ always() && matrix.shard != 'scripts' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: 'dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2' # ratchet:dorny/test-reporter@v3
         with:
-          name: 'macOS Test Results (Node 24.x)'
+          name: 'macOS Test Results [${{ matrix.shard }}] (Node ${{ matrix.node-version }})'
           path: 'packages/*/junit.xml'
           reporter: 'java-junit'
           fail-on-error: 'false'
 
       - name: 'Upload Test Results Artifact (for forks)'
         if: |-
-          ${{ always() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+          ${{ always() && matrix.shard != 'scripts' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # ratchet:actions/upload-artifact@v7
         with:
-          name: 'test-results-fork-macos-24.x'
+          name: 'test-results-fork-macos-${{ matrix.shard }}-${{ matrix.node-version }}'
           path: 'packages/*/junit.xml'
 
   #

--- a/scripts/tests/release-process-b.test.ts
+++ b/scripts/tests/release-process-b.test.ts
@@ -381,6 +381,7 @@ describe('scripts/bind-release-deps.ts', () => {
 describe('.github/workflows/nightly.yml', () => {
   let nightlyParsed: Record<string, unknown> | undefined;
   let windowsCiJob: Record<string, unknown> | undefined;
+  let macosCiJob: Record<string, unknown> | undefined;
   let notifyFailureJob: Record<string, unknown> | undefined;
 
   function stepNamed(
@@ -397,6 +398,21 @@ describe('.github/workflows/nightly.yml', () => {
       throw new Error(`job should contain step: ${name}`);
     }
     return step;
+  }
+
+  function matrixShardNames(
+    job: Record<string, unknown> | undefined,
+  ): string[] {
+    const strategy = asOptionalRecord(job?.strategy);
+    const matrix = asOptionalRecord(strategy?.matrix);
+    const shards = matrix?.shard;
+    if (
+      !Array.isArray(shards) ||
+      !shards.every((shard) => typeof shard === 'string')
+    ) {
+      throw new Error('job should define a string strategy.matrix.shard array');
+    }
+    return shards;
   }
 
   function failureNotificationStep(): Record<string, unknown> {
@@ -421,6 +437,7 @@ describe('.github/workflows/nightly.yml', () => {
     nightlyParsed = asRecord(parseWorkflowYaml(nightlyYml));
     const jobs = asOptionalRecord(nightlyParsed.jobs);
     windowsCiJob = asOptionalRecord(jobs?.windows_ci);
+    macosCiJob = asOptionalRecord(jobs?.macos_ci);
     notifyFailureJob = asOptionalRecord(jobs?.notify_failure);
   });
 
@@ -429,6 +446,7 @@ describe('.github/workflows/nightly.yml', () => {
       windowsCiJob,
       'nightly.yml should contain job: windows_ci',
     ).toBeTruthy();
+    expect(macosCiJob, 'nightly.yml should contain job: macos_ci').toBeTruthy();
     expect(
       notifyFailureJob,
       'nightly.yml should contain job: notify_failure',
@@ -442,23 +460,51 @@ describe('.github/workflows/nightly.yml', () => {
     ).toBe(true);
   });
 
-  it('runs lint:agents-api-surface before npm run test in the Windows CI job', () => {
-    const rawSteps = windowsCiJob?.steps;
-    const steps = Array.isArray(rawSteps) ? rawSteps.map(asRecord) : [];
-    const surfaceIndex = steps.findIndex((step: Record<string, unknown>) =>
-      String(step.run ?? '').includes('npm run lint:agents-api-surface'),
-    );
-    const testRunIndex = steps.findIndex((step: Record<string, unknown>) =>
-      /(?:^|\s)npm run test(?:\s|$)/.test(String(step.run ?? '')),
-    );
+  it('runs the canonical test shards independently on Windows and macOS', () => {
+    const expectedShards = [
+      'cli',
+      'agents',
+      'providers',
+      'core',
+      'rest',
+      'scripts',
+    ];
+    expect(matrixShardNames(windowsCiJob)).toEqual(expectedShards);
+    expect(matrixShardNames(macosCiJob)).toEqual(expectedShards);
+
+    for (const job of [windowsCiJob, macosCiJob]) {
+      const shardStep = stepNamed(job, 'Run shard tests (issue #3153)');
+      expect(shardStep.run).toBe(
+        'bun scripts/test.ts --shard "${{ matrix.shard }}"',
+      );
+      const steps = Array.isArray(job?.steps) ? job.steps.map(asRecord) : [];
+      expect(
+        steps.some((step) =>
+          /(?:^|\s)npm run test(?:\s|$)/.test(String(step.run ?? '')),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it('gates once-per-platform checks to their owning shards', () => {
+    for (const job of [windowsCiJob, macosCiJob]) {
+      expect(
+        stepNamed(job, 'Build project (agents and scripts shards)').if,
+      ).toBe("matrix.shard == 'agents' || matrix.shard == 'scripts'");
+      expect(
+        stepNamed(
+          job,
+          'Smoke test CLI entry (launcher -> Bun, no Node in chain)',
+        ).if,
+      ).toBe("matrix.shard == 'cli'");
+      expect(
+        stepNamed(job, 'Publish Test Report (for non-forks)').if,
+      ).toContain("matrix.shard != 'scripts'");
+    }
+
     expect(
-      surfaceIndex,
-      'windows_ci should run npm run lint:agents-api-surface',
-    ).toBeGreaterThan(-1);
-    expect(testRunIndex, 'windows_ci should run npm run test').toBeGreaterThan(
-      -1,
-    );
-    expect(surfaceIndex).toBeLessThan(testRunIndex);
+      stepNamed(macosCiJob, 'Run shell-script behavioral tests (#2606)').if,
+    ).toBe("matrix.shard == 'scripts'");
   });
 
   it('grants bounded issues: write access in the failure notification job', () => {

--- a/scripts/tests/release-process-b.test.ts
+++ b/scripts/tests/release-process-b.test.ts
@@ -483,6 +483,11 @@ describe('.github/workflows/nightly.yml', () => {
           /(?:^|\s)npm run test(?:\s|$)/.test(String(step.run ?? '')),
         ),
       ).toBe(false);
+      expect(
+        steps.some((step) =>
+          String(step.run ?? '').includes('npm run lint:agents-api-surface'),
+        ),
+      ).toBe(false);
     }
   });
 


### PR DESCRIPTION
## TLDR

Shard the Windows and macOS nightly test jobs across the repository's six canonical test shards so each platform's wall clock is bounded by its slowest shard instead of serially running every workspace within one job budget.

## Dive Deeper

Nightly run `32001670814` reached the Windows job's 60-minute deadline while the serial workspace test command was still making progress. The agents workspace had completed its bounded timeout path and the CLI workspace had started, so the recurring cancellation was a cumulative job-budget problem rather than evidence of one permanently hung test.

This change:

- adds independent `cli`, `agents`, `providers`, `core`, `rest`, and `scripts` matrix legs on Windows and macOS;
- runs each leg through the existing canonical `bun scripts/test.ts --shard` orchestrator;
- keeps `fail-fast: false` so every shard reports its result;
- builds only the `agents` and `scripts` shards that require compiled API-surface prerequisites;
- gates CLI smoke and macOS shell checks to their owning shards;
- preserves platform setup, provider environment, JUnit publishing, fork artifacts, and aggregate failure notification behavior; and
- adds focused workflow contract coverage for the matrix and shard-owned checks.

Windows PR CI is the authority for any remaining Windows-specific behavior.

## Reviewer Test Plan

1. Run `bun test scripts/tests/release-process-b.test.ts` and confirm all nightly workflow contract tests pass.
2. Run `npm run lint:test-shards` and confirm all 16 workspaces are covered by the six canonical shards.
3. Inspect the Windows and macOS nightly matrices and verify that each canonical shard appears exactly once.
4. Confirm the shard-owned build, CLI smoke, macOS shell test, and report conditions match their intended shard.
5. Use PR CI, especially Windows legs, to validate platform-specific execution.

Local verification:

- `bun test scripts/tests/release-process-b.test.ts` — 19 passed
- `npm run lint:test-shards` — passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run format` — passed
- `npm run build` — passed
- StepFun `stepfun-37` smoke — passed
- `npm run test` — completed with unrelated failures in core ripgrep path-resolution tests and agents timeout-sensitive tests; no failures involved the two changed files

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️ focused checks pass; full suite has unrelated failures noted above | ❓ PR CI authoritative | ❓ |
| npx      | -   | -   | -   |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs

Fixes #3153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded nightly validation across six independently named test areas on Windows and macOS.
  * Added platform-specific checks for shard configuration, execution commands, and required artifacts.
  * Improved coverage for CLI smoke tests and script behavior tests in dedicated runs.

* **Chores**
  * Added 45-minute limits and clearer names for nightly test jobs.
  * Streamlined nightly builds to the relevant test areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->