### PR TITLE
Bound ast_edit preview memory use (#3242)

### DIFF
--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-fixtures.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-fixtures.ts
@@ -1,0 +1,258 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Bun-test-free fixtures for the issue #3242 ast_edit preview regression.
+ *
+ * This module deliberately imports nothing from `bun:test` so the
+ * child-process fixture (ast-edit-3242-memory-child.ts) can reuse the exact
+ * same deterministic Rust target generator as the in-process tests. The
+ * target is exactly 5,250 lines with 184 real parsed declarations (180
+ * worker functions plus a struct, an impl, and two impl methods), matching
+ * the incident shape: a localized edit inside a large symbol-dense Rust
+ * file. The workspace generator adds the repository fan-out shape (many
+ * committed dependency files referencing the prioritizable worker symbols,
+ * an ignored tree, and one oversized source file) that previously drove
+ * five concurrent whole-workspace native traversals per preview.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { gitCommitAll, gitInit } from './ast-read-git-fixtures.js';
+
+/** Exact line count of the generated Rust target (including final newline). */
+export const RUST_FIXTURE_LINE_COUNT = 5250;
+/** Worker function blocks in the Rust target. */
+export const RUST_WORKER_COUNT = 180;
+/** Header lines before the first worker block. */
+const RUST_HEADER_LINES = 30;
+/** Lines per worker block (function line through trailing blank line). */
+const RUST_BLOCK_LINES = 29;
+/** Unique `let step_...` marker lines inside each worker block. */
+const RUST_STEPS_PER_BLOCK = 24;
+
+/** Committed dependency files referencing the prioritizable symbols. */
+export const ISSUE_3242_DEP_FILE_COUNT = 1500;
+/** Lines per dependency file. */
+export const ISSUE_3242_DEP_LINES = 60;
+/** Ignored-tree source files present on disk but git-ignored. */
+export const ISSUE_3242_IGNORED_FILE_COUNT = 5;
+/** Lines in the single oversized source file (~2 MiB). */
+export const ISSUE_3242_OVERSIZED_LINE_COUNT = 46_600;
+
+/** One deterministic unique edit inside the Rust target. */
+export interface RustFixtureEdit {
+  readonly oldString: string;
+  readonly newString: string;
+  /** 1-based line where oldString starts. */
+  readonly line: number;
+}
+
+export interface RustFixture {
+  readonly content: string;
+  readonly lineCount: number;
+  readonly edits: {
+    readonly middle: RustFixtureEdit;
+    readonly head: RustFixtureEdit;
+    readonly tail: RustFixtureEdit;
+  };
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function pad3(value: number): string {
+  return String(value).padStart(3, '0');
+}
+
+function pad4(value: number): string {
+  return String(value).padStart(4, '0');
+}
+
+function pad5(value: number): string {
+  return String(value).padStart(5, '0');
+}
+
+function stepLine(block: number, step: number): string {
+  return `    let step_${pad3(block)}_${pad2(step)}: u64 = ${block * 100 + step};`;
+}
+
+function workerBlock(block: number): string[] {
+  const lines: string[] = [
+    `fn worker_${pad3(block)}(input: u64) -> u64 {`,
+    '    let mut total: u64 = input;',
+  ];
+  for (let step = 0; step < RUST_STEPS_PER_BLOCK; step++) {
+    lines.push(stepLine(block, step));
+  }
+  lines.push('    total', '}', '');
+  return lines;
+}
+
+function headerLines(): string[] {
+  const lines: string[] = [
+    '// Synthetic Rust fixture for the issue #3242 ast_edit preview regression.',
+    '// 5,250 lines: 180 worker functions plus deterministic header types.',
+    '',
+    'pub struct Payload {',
+    '    pub id: u64,',
+    '    pub weight: u64,',
+    '}',
+    '',
+    'impl Payload {',
+    '    pub fn base() -> Payload {',
+    '        Payload { id: 0, weight: 0 }',
+    '    }',
+    '    pub fn anchor() -> u64 {',
+    '        0',
+    '    }',
+    '}',
+    '',
+  ];
+  let filler = 1;
+  while (lines.length < RUST_HEADER_LINES) {
+    lines.push(`// header filler line ${pad2(filler)}`);
+    filler += 1;
+  }
+  return lines;
+}
+
+function fixtureEdit(block: number, step: number): RustFixtureEdit {
+  const oldString = stepLine(block, step);
+  const newString = `    let step_${pad3(block)}_${pad2(step)}: u64 = ${block * 100 + step + 1};`;
+  const line = RUST_HEADER_LINES + block * RUST_BLOCK_LINES + 3 + step;
+  return { oldString, newString, line };
+}
+
+/** Generate the deterministic ~5,250-line Rust regression target. */
+export function generateRustFixture(): RustFixture {
+  const lines: string[] = headerLines();
+  for (let block = 0; block < RUST_WORKER_COUNT; block++) {
+    lines.push(...workerBlock(block));
+  }
+  const expected = RUST_HEADER_LINES + RUST_WORKER_COUNT * RUST_BLOCK_LINES;
+  if (lines.length !== expected) {
+    throw new Error(
+      `rust fixture generator produced ${lines.length} lines, expected ${expected}`,
+    );
+  }
+  return {
+    content: `${lines.join('\n')}\n`,
+    lineCount: expected,
+    edits: {
+      middle: fixtureEdit(90, 7),
+      head: fixtureEdit(0, 3),
+      tail: fixtureEdit(179, 20),
+    },
+  };
+}
+
+function rustDepFile(index: number, lineCount: number): string {
+  const lines: string[] = [
+    `// Synthetic dependency ${index} referencing worker symbols.`,
+  ];
+  for (let i = 1; i < lineCount; i++) {
+    lines.push(
+      `pub fn dep_${index}_p${pad2(i)}() -> u64 { worker_000(0) + worker_001(1) + worker_002(2) }`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function oversizedRustFile(): string {
+  const lines: string[] = [
+    '// Oversized synthetic source file outside every traversal policy.',
+  ];
+  for (let i = 1; i < ISSUE_3242_OVERSIZED_LINE_COUNT; i++) {
+    lines.push(`pub const OVERSIZE_REF_${pad5(i)}: u64 = ${i % 9973};`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Generate the fan-out-shaped Git workspace used by the child-process
+ * memory regression. Every failure of fixture generation removes the
+ * half-built directory so a broken fixture can never leak into tmp.
+ */
+export function generateIssue3242Workspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'llxprt-3242-mem-'));
+  try {
+    gitInit(dir);
+    writeFileSync(join(dir, '.gitignore'), 'ignored_tree/\n', 'utf-8');
+    writeFileSync(
+      join(dir, 'target.rs'),
+      generateRustFixture().content,
+      'utf-8',
+    );
+
+    const depsDir = join(dir, 'deps');
+    mkdirSync(depsDir, { recursive: true });
+    for (let i = 0; i < ISSUE_3242_DEP_FILE_COUNT; i++) {
+      writeFileSync(
+        join(depsDir, `dep${pad4(i)}.rs`),
+        rustDepFile(i, ISSUE_3242_DEP_LINES),
+        'utf-8',
+      );
+    }
+
+    const ignoredDir = join(dir, 'ignored_tree');
+    mkdirSync(ignoredDir, { recursive: true });
+    for (let i = 0; i < ISSUE_3242_IGNORED_FILE_COUNT; i++) {
+      writeFileSync(
+        join(ignoredDir, `ig${i}.rs`),
+        rustDepFile(10_000 + i, ISSUE_3242_DEP_LINES),
+        'utf-8',
+      );
+    }
+
+    writeFileSync(join(dir, 'oversized_dep.rs'), oversizedRustFile(), 'utf-8');
+    gitCommitAll(dir, 'issue-3242 fan-out fixture');
+    return dir;
+  } catch (error) {
+    rmSync(dir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+/**
+ * Generate the small Git workspace used by the Git-command wiring canary:
+ * the full Rust target plus one committed dependency, so a real preview
+ * succeeds and any repository-relationship Git phase is observable.
+ */
+export interface CanaryWorkspace {
+  readonly spyRoot: string;
+  readonly workspace: string;
+}
+
+/**
+ * Generate the small Git workspace used by the Git-command wiring canary:
+ * the full Rust target plus one committed dependency, so a real preview
+ * succeeds and any repository-relationship Git phase is observable. The
+ * workspace path deliberately contains a space.
+ */
+export function generateIssue3242CanaryWorkspace(): CanaryWorkspace {
+  const spyRoot = mkdtempSync(join(tmpdir(), 'llxprt-3242-spy-'));
+  const workspace = join(spyRoot, 'work space');
+  try {
+    mkdirSync(workspace, { recursive: true });
+    gitInit(workspace);
+    writeFileSync(
+      join(workspace, 'target.rs'),
+      generateRustFixture().content,
+      'utf-8',
+    );
+    writeFileSync(
+      join(workspace, 'dep.rs'),
+      rustDepFile(0, ISSUE_3242_DEP_LINES),
+      'utf-8',
+    );
+    gitCommitAll(workspace, 'issue-3242 canary fixture');
+    return { spyRoot, workspace };
+  } catch (error) {
+    rmSync(spyRoot, { recursive: true, force: true });
+    throw error;
+  }
+}

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-memory-child.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-memory-child.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Child-process fixture for the ast_edit preview/apply memory regression
+ * (issue #3242). Invoked by ast-edit-3242-memory.bun.test.ts with a
+ * generated workspace directory. Runs the real ASTEditTool against the
+ * 5,250-line Rust target: three localized previews (middle, then head and
+ * tail in parallel) followed immediately by a force=true apply that reuses
+ * the preview timestamp, then verifies the exact bytes landed on disk. RSS
+ * is sampled throughout, and a post-result quiet window proves no repository
+ * traversal or pending native callback kept allocating after every tool
+ * result resolved.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ASTEditTool } from '../../ast-edit.js';
+import { createAstReadToolHost } from './ast-read-tool-host.js';
+import {
+  generateRustFixture,
+  type RustFixtureEdit,
+} from './ast-edit-3242-fixtures.js';
+
+interface MemoryReport {
+  readonly ok: boolean;
+  readonly previewOk: boolean;
+  readonly applyOk: boolean;
+  readonly contentApplied: boolean;
+  readonly previewBoundedMarker: boolean;
+  readonly timestampParsed: boolean;
+  readonly peakRssBytes: number;
+  readonly finalRssBytes: number;
+  readonly postResultRssGrowthBytes: number;
+  readonly quietWindowSamples: number;
+}
+
+interface ToolOutcome {
+  readonly error?: { readonly message: string } | undefined;
+  readonly llmContent: string;
+}
+
+if (process.argv.length < 3) {
+  process.stderr.write(
+    'usage: ast-edit-3242-memory-child.ts <workspace-root>\n',
+  );
+  process.exit(2);
+}
+const workspaceRoot = process.argv[2];
+const fixture = generateRustFixture();
+const targetPath = join(workspaceRoot, 'target.rs');
+
+let peakRssBytes = process.memoryUsage.rss();
+function sampleRss(): number {
+  const rss = process.memoryUsage.rss();
+  peakRssBytes = Math.max(peakRssBytes, rss);
+  return rss;
+}
+
+const sampler = setInterval(() => {
+  sampleRss();
+}, 20);
+
+async function executePreview(edit: RustFixtureEdit): Promise<ToolOutcome> {
+  const tool = new ASTEditTool(createAstReadToolHost(workspaceRoot));
+  const result = await tool
+    .build({
+      file_path: targetPath,
+      old_string: edit.oldString,
+      new_string: edit.newString,
+      force: false,
+    })
+    .execute(new AbortController().signal);
+  // Emit a tool-result marker after every result so the parent can correlate
+  // the timing of native fan-out activity (if any survived) with sampling.
+  process.stdout.write('AST_EDIT_TOOL_RESULT\n');
+  return { error: result.error, llmContent: String(result.llmContent) };
+}
+
+const middle = await executePreview(fixture.edits.middle);
+const middleOk = middle.error === undefined;
+const timestampMatch = /- Timestamp: (\d+)/.exec(middle.llmContent);
+const timestampParsed = timestampMatch !== null;
+const previewBoundedMarker = middle.llmContent.includes('bounded preview');
+
+const headTail = await Promise.all([
+  executePreview(fixture.edits.head),
+  executePreview(fixture.edits.tail),
+]);
+const previewOk =
+  middleOk && headTail.every((result) => result.error === undefined);
+
+const applyTool = new ASTEditTool(createAstReadToolHost(workspaceRoot));
+const lastModified =
+  timestampMatch !== null ? Number(timestampMatch[1]) : undefined;
+const applyResult = await applyTool
+  .build({
+    file_path: targetPath,
+    old_string: fixture.edits.middle.oldString,
+    new_string: fixture.edits.middle.newString,
+    force: true,
+    ...(lastModified !== undefined ? { last_modified: lastModified } : {}),
+  })
+  .execute(new AbortController().signal);
+process.stdout.write('AST_EDIT_APPLY_RESULT\n');
+const applyOk = applyResult.error === undefined;
+
+const written = readFileSync(targetPath, 'utf-8');
+const contentApplied =
+  written.includes(fixture.edits.middle.newString) &&
+  !written.includes(fixture.edits.middle.oldString);
+
+// Post-result quiet/drain window: sample RSS for a fixed interval after all
+// tool results have resolved. The old code's abandoned native findInFiles
+// traversals continued past each preview result, so RSS would keep climbing
+// here; the opt-out path resolves all its work before returning.
+const QUIET_WINDOW_MS = 1500;
+const SAMPLE_INTERVAL_MS = 25;
+const preQuietRss = sampleRss();
+let postResultRssGrowthBytes = 0;
+let quietWindowSamples = 0;
+const quietStart = Date.now();
+while (Date.now() - quietStart < QUIET_WINDOW_MS) {
+  const rss = sampleRss();
+  quietWindowSamples += 1;
+  postResultRssGrowthBytes = Math.max(
+    postResultRssGrowthBytes,
+    rss - preQuietRss,
+  );
+  await new Promise((resolve) => setTimeout(resolve, SAMPLE_INTERVAL_MS));
+}
+
+clearInterval(sampler);
+const finalRssBytes = process.memoryUsage.rss();
+peakRssBytes = Math.max(peakRssBytes, finalRssBytes);
+
+const report: MemoryReport = {
+  ok: previewOk && applyOk && contentApplied && previewBoundedMarker,
+  previewOk,
+  applyOk,
+  contentApplied,
+  previewBoundedMarker,
+  timestampParsed,
+  peakRssBytes,
+  finalRssBytes,
+  postResultRssGrowthBytes,
+  quietWindowSamples,
+};
+process.stdout.write('AST_EDIT_QUIET_DONE\n');
+process.stdout.write(`AST_EDIT_MEMORY_REPORT ${JSON.stringify(report)}\n`);

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-memory-child.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-memory-child.ts
@@ -8,10 +8,11 @@
  * generated workspace directory. Runs the real ASTEditTool against the
  * 5,250-line Rust target: three localized previews (middle, then head and
  * tail in parallel) followed immediately by a force=true apply that reuses
- * the preview timestamp, then verifies the exact bytes landed on disk. RSS
- * is sampled throughout, and a post-result quiet window proves no repository
- * traversal or pending native callback kept allocating after every tool
- * result resolved.
+ * the preview timestamp — the middle preview and the apply run through the
+ * same tool instance, mirroring the CLI's registered-tool reuse — then
+ * verifies the exact bytes landed on disk. RSS is sampled throughout, and a
+ * post-result quiet window proves no repository traversal or pending native
+ * callback kept allocating after every tool result resolved.
  */
 
 import { readFileSync } from 'node:fs';
@@ -62,8 +63,10 @@ const sampler = setInterval(() => {
   sampleRss();
 }, 20);
 
-async function executePreview(edit: RustFixtureEdit): Promise<ToolOutcome> {
-  const tool = new ASTEditTool(createAstReadToolHost(workspaceRoot));
+async function executePreview(
+  tool: ASTEditTool,
+  edit: RustFixtureEdit,
+): Promise<ToolOutcome> {
   const result = await tool
     .build({
       file_path: targetPath,
@@ -78,23 +81,33 @@ async function executePreview(edit: RustFixtureEdit): Promise<ToolOutcome> {
   return { error: result.error, llmContent: String(result.llmContent) };
 }
 
-const middle = await executePreview(fixture.edits.middle);
+// The CLI reuses the registered ASTEditTool instance to build every
+// invocation, so the accepted regression drives the middle preview and its
+// immediate force apply through the same shared tool instance. Only the
+// parallel head/tail previews use distinct instances.
+const middleTool = new ASTEditTool(createAstReadToolHost(workspaceRoot));
+const middle = await executePreview(middleTool, fixture.edits.middle);
 const middleOk = middle.error === undefined;
 const timestampMatch = /- Timestamp: (\d+)/.exec(middle.llmContent);
 const timestampParsed = timestampMatch !== null;
 const previewBoundedMarker = middle.llmContent.includes('bounded preview');
 
 const headTail = await Promise.all([
-  executePreview(fixture.edits.head),
-  executePreview(fixture.edits.tail),
+  executePreview(
+    new ASTEditTool(createAstReadToolHost(workspaceRoot)),
+    fixture.edits.head,
+  ),
+  executePreview(
+    new ASTEditTool(createAstReadToolHost(workspaceRoot)),
+    fixture.edits.tail,
+  ),
 ]);
 const previewOk =
   middleOk && headTail.every((result) => result.error === undefined);
 
-const applyTool = new ASTEditTool(createAstReadToolHost(workspaceRoot));
 const lastModified =
   timestampMatch !== null ? Number(timestampMatch[1]) : undefined;
-const applyResult = await applyTool
+const applyResult = await middleTool
   .build({
     file_path: targetPath,
     old_string: fixture.edits.middle.oldString,

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-memory.bun.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-memory.bun.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Cross-platform memory regression for ast_edit preview/apply (issue #3242).
+ *
+ * Spawns a child Bun process (ast-edit-3242-memory-child.ts) that executes
+ * the REAL ASTEditTool against a generated Git workspace shaped like the
+ * incident: the ~5,250-line, 184-declaration Rust target plus 1,500
+ * committed dependency files referencing the prioritizable worker symbols,
+ * a git-ignored source tree, and one oversized (~2 MiB) source file. The
+ * child runs three localized previews (middle, head, tail) and an immediate
+ * force=true apply that reuses the preview timestamp, conservatively
+ * sampling peak RSS throughout, then samples a post-result quiet window to
+ * prove no repository traversal or pending native callback kept allocating
+ * after every tool result resolved. The old wiring started five concurrent
+ * whole-workspace native findInFiles traversals per preview that ignored
+ * .gitignore and could not be cancelled; this test is the permanent
+ * conservative memory ceiling and drain gate on every platform.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import {
+  generateIssue3242CanaryWorkspace,
+  generateIssue3242Workspace,
+} from './ast-edit-3242-fixtures.js';
+
+const PEAK_RSS_CEILING_BYTES = 768 * 1024 * 1024; // 768 MiB
+/** Post-result tail growth must stay below this margin. */
+const POST_RESULT_TAIL_CEILING_BYTES = 64 * 1024 * 1024; // 64 MiB
+const CHILD_TIMEOUT_MS = 180_000;
+
+interface MemoryReport {
+  readonly ok: boolean;
+  readonly previewOk: boolean;
+  readonly applyOk: boolean;
+  readonly contentApplied: boolean;
+  readonly previewBoundedMarker: boolean;
+  readonly timestampParsed: boolean;
+  readonly peakRssBytes: number;
+  readonly finalRssBytes: number;
+  readonly postResultRssGrowthBytes: number;
+  readonly quietWindowSamples: number;
+}
+
+const REPORT_BOOLEAN_FIELDS = [
+  'ok',
+  'previewOk',
+  'applyOk',
+  'contentApplied',
+  'previewBoundedMarker',
+  'timestampParsed',
+] as const;
+const REPORT_NUMBER_FIELDS = [
+  'peakRssBytes',
+  'finalRssBytes',
+  'postResultRssGrowthBytes',
+  'quietWindowSamples',
+] as const;
+
+function isMemoryReport(value: unknown): value is MemoryReport {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  const hasBooleans = REPORT_BOOLEAN_FIELDS.every(
+    (key) => typeof record[key] === 'boolean',
+  );
+  const hasNumbers = REPORT_NUMBER_FIELDS.every(
+    (key) => typeof record[key] === 'number',
+  );
+  return hasBooleans && hasNumbers;
+}
+
+function parseReport(stdout: string): MemoryReport {
+  const marker = 'AST_EDIT_MEMORY_REPORT ';
+  const line = stdout
+    .split('\n')
+    .find((candidate) => candidate.startsWith(marker));
+  if (!line) {
+    throw new Error(`child did not emit a report: ${stdout.slice(-2000)}`);
+  }
+  const parsed: unknown = JSON.parse(line.slice(marker.length));
+  if (!isMemoryReport(parsed)) {
+    throw new Error(
+      `child report failed schema guard: ${line.slice(marker.length)}`,
+    );
+  }
+  return parsed;
+}
+
+const CHILD_SCRIPT_PATH = fileURLToPath(
+  new URL('./ast-edit-3242-memory-child.ts', import.meta.url),
+);
+
+/** Render every failure mode of a memory-child run for loud diagnostics. */
+function describeChildFailure(child: SpawnSyncReturns<string>): string {
+  const details = [
+    `status=${String(child.status)}`,
+    `signal=${String(child.signal)}`,
+    `error=${child.error instanceof Error ? child.error.message : String(child.error)}`,
+    `stderr=${String(child.stderr).slice(0, 2000)}`,
+  ];
+  return `memory child failed (${details.join('; ')})`;
+}
+
+/**
+ * Drop the leading `-C <workspace>` argv pair from a logged Git invocation
+ * so the subcommand itself is comparable. The literal known prefix is
+ * stripped (rather than splitting on spaces) so a workspace path containing
+ * spaces cannot corrupt the remaining subcommand text.
+ */
+function stripGitDirPrefix(line: string, workspace: string): string {
+  const prefix = `-C ${workspace} `;
+  return line.startsWith(prefix) ? line.slice(prefix.length) : line;
+}
+
+describe('REQ-3242-4: ast_edit preview/apply memory regression', () => {
+  it('keeps peak RSS bounded and drains after real previews and a force apply', () => {
+    const workspace = generateIssue3242Workspace();
+    try {
+      const child = spawnSync(
+        process.execPath,
+        [CHILD_SCRIPT_PATH, workspace],
+        {
+          encoding: 'utf-8',
+          stdio: 'pipe',
+          timeout: CHILD_TIMEOUT_MS,
+          maxBuffer: 16 * 1024 * 1024,
+        },
+      );
+      // Report the full spawn outcome before asserting so a failed child is
+      // diagnosable from the test log rather than a bare "expected 0".
+      if (child.status !== 0) {
+        throw new Error(describeChildFailure(child));
+      }
+      // The child must emit both markers, proving every tool result and the
+      // quiet window ran.
+      expect(child.stdout).toContain('AST_EDIT_TOOL_RESULT');
+      expect(child.stdout).toContain('AST_EDIT_APPLY_RESULT');
+      expect(child.stdout).toContain('AST_EDIT_QUIET_DONE');
+      const report = parseReport(child.stdout);
+
+      expect(report.ok).toBe(true);
+      expect(report.previewOk).toBe(true);
+      expect(report.applyOk).toBe(true);
+      expect(report.contentApplied).toBe(true);
+      expect(report.previewBoundedMarker).toBe(true);
+      expect(report.timestampParsed).toBe(true);
+      expect(report.peakRssBytes).toBeGreaterThan(0);
+      expect(report.peakRssBytes).toBeLessThan(PEAK_RSS_CEILING_BYTES);
+      expect(report.finalRssBytes).toBeLessThan(PEAK_RSS_CEILING_BYTES);
+      // The post-result quiet window proves native traversal drained: RSS
+      // growth after all tool results resolved stays below the calibrated
+      // ceiling. The old code's abandoned fan-out kept allocating here.
+      expect(report.quietWindowSamples).toBeGreaterThan(0);
+      expect(report.postResultRssGrowthBytes).toBeLessThan(
+        POST_RESULT_TAIL_CEILING_BYTES,
+      );
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  }, 240_000);
+});
+
+// ---------------------------------------------------------------------------
+// REQ-3242-1: invocation-wiring canary.
+//
+// ast_edit preview opts out of both repository collection and working-set
+// collection, so a real preview followed by a real apply must spawn ZERO
+// Git processes — neither the repository relationship phase (remote
+// get-url origin, rev-parse HEAD, branch --show-current) nor working-set
+// discovery (status/diff/ls-files listings). A PATH shim records every Git
+// argv the real tool spawns, so a regression back to either the old
+// `collectRepositoryContext: true` wiring or working-set collection is
+// detected deterministically — no memory threshold involved.
+// ---------------------------------------------------------------------------
+
+describe('REQ-3242-1: ast_edit preview repository wiring canary', () => {
+  // Windows resolves `git` through a .cmd shim that Node cannot spawn without
+  // a shell, so the PATH interception technique is POSIX-only there.
+  it.skipIf(process.platform === 'win32')(
+    'spawns no Git commands at all during real preview and apply',
+    () => {
+      const { spyRoot, workspace } = generateIssue3242CanaryWorkspace();
+      const shimDir = mkdtempSync(join(tmpdir(), 'llxprt-3242-shim-'));
+      try {
+        const resolved = spawnSync('sh', ['-c', 'command -v git'], {
+          encoding: 'utf-8',
+        });
+        const realGit = resolved.stdout.trim();
+        if (resolved.status !== 0 || realGit === '') {
+          throw new Error(
+            `could not resolve real git for the shim (status=${String(
+              resolved.status,
+            )})`,
+          );
+        }
+        const logPath = join(shimDir, 'git-invocations.log');
+        writeFileSync(
+          join(shimDir, 'git'),
+          [
+            '#!/bin/sh',
+            `printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`,
+            `exec ${JSON.stringify(realGit)} "$@"`,
+            '',
+          ].join('\n'),
+          { mode: 0o755 },
+        );
+
+        const child = spawnSync(
+          process.execPath,
+          [CHILD_SCRIPT_PATH, workspace],
+          {
+            encoding: 'utf-8',
+            stdio: 'pipe',
+            timeout: CHILD_TIMEOUT_MS,
+            maxBuffer: 16 * 1024 * 1024,
+            env: {
+              ...process.env,
+              PATH: `${shimDir}:${process.env.PATH ?? ''}`,
+            },
+          },
+        );
+        if (child.status !== 0) {
+          throw new Error(describeChildFailure(child));
+        }
+        // The child exercised the full preview-then-apply success path where
+        // the old wiring would have spawned the repository phase.
+        const report = parseReport(child.stdout);
+        expect(report.ok).toBe(true);
+
+        const invocations = existsSync(logPath)
+          ? readFileSync(logPath, 'utf-8')
+              .split('\n')
+              .filter((line) => line.length > 0)
+              .map((line) => stripGitDirPrefix(line, workspace))
+          : [];
+        // Zero Git invocations of any kind: preview opts out of repository
+        // relationship collection AND working-set discovery, and apply never
+        // collects enhanced context, so any logged argv — repository
+        // subcommand or working-set listing alike — is a wiring regression.
+        expect(invocations).toEqual([]);
+      } finally {
+        rmSync(spyRoot, { recursive: true, force: true });
+        rmSync(shimDir, { recursive: true, force: true });
+      }
+    },
+    240_000,
+  );
+});

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-regression.bun.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-regression.bun.test.ts
@@ -614,12 +614,20 @@ describe('REQ-3242-3: bounded preview llmContent byte budget', () => {
 
     expect(result.error).toBeUndefined();
     const output = String(result.llmContent);
-    expect(output).toMatch(
-      new RegExp(
-        `^- Relevant snippets: ${PREVIEW_MAX_SNIPPETS} found \\(capped from \\d+\\)$`,
-        'm',
-      ),
-    );
+    const prefix = `- Relevant snippets: ${PREVIEW_MAX_SNIPPETS} found (capped from `;
+    const snippetLine = output
+      .split('\n')
+      .find((line) => line.startsWith(prefix));
+    if (snippetLine === undefined) {
+      throw new Error('preview omitted the capped relevant-snippet summary');
+    }
+
+    const totalText = snippetLine.slice(prefix.length, -1);
+    const total = Number(totalText);
+    expect(snippetLine.endsWith(')')).toBe(true);
+    expect(Number.isInteger(total)).toBe(true);
+    expect(String(total)).toBe(totalText);
+    expect(total).toBeGreaterThan(PREVIEW_MAX_SNIPPETS);
   });
 });
 

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-regression.bun.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-regression.bun.test.ts
@@ -1,0 +1,619 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral regression tests for issue #3242.
+ *
+ * REQ-3242-1: ast_edit preview opts out of repository relationship context
+ * (no repository metadata, no symbol index, no native related-symbol
+ * traversal) while apply semantics stay intact.
+ * REQ-3242-2: preview declarations are selected by absolute line distance
+ * from the exact replacement start (deterministic line-order tie break),
+ * capped at 128, rendered in source order, with a truthful bounded
+ * selected/total marker once a file exceeds the cap.
+ * REQ-3242-3: the complete preview ToolResult.llmContent is valid UTF-8 and
+ * at most 256 KiB; mandatory status, timestamp, bounded marker, and the
+ * next-step instruction are reserved before optional declaration detail.
+ * REQ-3242-4: preview followed immediately by force=true applies the exact
+ * requested bytes using the preview timestamp.
+ *
+ * All fixtures are real files exercised through the real ASTEditTool. The
+ * expected declaration selection is computed with the real production
+ * extractor as the oracle, never by mocking the tool.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ASTEditTool } from '../../ast-edit.js';
+import { ASTQueryExtractor } from '../ast-query-extractor.js';
+import type { EnhancedDeclaration } from '../types.js';
+import type { ToolResult } from '../../tools.js';
+import { createFakeToolHost, useTempDir } from './test-helpers.js';
+import { gitCommitAll, gitInit } from './ast-read-git-fixtures.js';
+import {
+  RUST_FIXTURE_LINE_COUNT,
+  generateRustFixture,
+} from './ast-edit-3242-fixtures.js';
+
+const PREVIEW_MAX_DECLARATIONS = 128;
+const PREVIEW_MAX_SNIPPETS = 64;
+const PREVIEW_LLM_MAX_BYTES = 256 * 1024;
+const NEXT_STEP = 'NEXT STEP: Call again with force: true to apply changes';
+
+interface RenderedDeclaration {
+  readonly raw: string;
+  readonly name: string;
+  readonly line: number;
+}
+
+function renderedDeclarations(output: string): RenderedDeclaration[] {
+  const rendered: RenderedDeclaration[] = [];
+  for (const match of output.matchAll(/^- [a-z]+: (.+) \(line (\d+)\)$/gm)) {
+    rendered.push({
+      raw: match[0],
+      name: match[1],
+      line: Number(match[2]),
+    });
+  }
+  return rendered;
+}
+
+async function runPreview(
+  targetDir: string,
+  filePath: string,
+  edit: { oldString: string; newString: string },
+): Promise<ToolResult> {
+  const tool = new ASTEditTool(createFakeToolHost(targetDir));
+  return tool
+    .build({
+      file_path: filePath,
+      old_string: edit.oldString,
+      new_string: edit.newString,
+      force: false,
+    })
+    .execute(new AbortController().signal);
+}
+
+/**
+ * Oracle for the accepted selection policy: source-order the real extractor
+ * output, keep the 128 declarations nearest the edit start line (ties break
+ * to the earlier line), then render the kept set back in source order.
+ */
+function expectedPreviewDeclarationLines(
+  declarations: readonly EnhancedDeclaration[],
+  editStartLine: number,
+): string[] {
+  const bySource = [...declarations]
+    .map((declaration, index) => ({ declaration, index }))
+    .sort((a, b) => {
+      const byLine = a.declaration.line - b.declaration.line;
+      if (byLine !== 0) {
+        return byLine;
+      }
+      const byColumn = a.declaration.column - b.declaration.column;
+      if (byColumn !== 0) {
+        return byColumn;
+      }
+      return a.index - b.index;
+    });
+  const byProximity = [...bySource]
+    .map((entry, sourceIndex) => ({ ...entry, sourceIndex }))
+    .sort((a, b) => {
+      const byDistance =
+        Math.abs(a.declaration.line - editStartLine) -
+        Math.abs(b.declaration.line - editStartLine);
+      if (byDistance !== 0) {
+        return byDistance;
+      }
+      const byLine = a.declaration.line - b.declaration.line;
+      if (byLine !== 0) {
+        return byLine;
+      }
+      return a.sourceIndex - b.sourceIndex;
+    });
+  return byProximity
+    .slice(0, PREVIEW_MAX_DECLARATIONS)
+    .sort((a, b) => a.sourceIndex - b.sourceIndex)
+    .map(
+      (entry) =>
+        `- ${entry.declaration.type}: ${entry.declaration.name} (line ${entry.declaration.line})`,
+    );
+}
+
+function boundedMarker(
+  output: string,
+): { shown: number; total: number } | null {
+  const match = /- Declarations: bounded preview — showing (\d+) of (\d+)/.exec(
+    output,
+  );
+  if (match === null) {
+    return null;
+  }
+  return { shown: Number(match[1]), total: Number(match[2]) };
+}
+
+function utf8Bytes(text: string): number {
+  return Buffer.byteLength(text, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// REQ-3242-1: preview repository relationship fan-out is unreachable.
+// ---------------------------------------------------------------------------
+
+describe('REQ-3242-1: ast_edit preview repository opt-out', () => {
+  const ctx = useTempDir();
+
+  it('renders no repository relationship context during preview in a Git workspace', async () => {
+    gitInit(ctx.tempDir);
+    writeFileSync(
+      join(ctx.tempDir, 'dep.ts'),
+      'import { Alpha } from "./target";\nexport function user(): Alpha { return null as Alpha; }\n',
+      'utf-8',
+    );
+    const target = join(ctx.tempDir, 'target.ts');
+    writeFileSync(
+      target,
+      'export class Alpha {\n  public run(): void {}\n}\nexport function betaWorker(): number { return 1; }\n',
+      'utf-8',
+    );
+    gitCommitAll(ctx.tempDir, 'fixture');
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: 'public run(): void {}',
+      newString: 'public runFast(): void {}',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('LLXPRT EDIT PREVIEW: ');
+    expect(output).not.toContain('- Repository:');
+    expect(output).not.toContain('- Related files:');
+    expect(output).not.toContain('RELATED SYMBOLS:');
+  });
+
+  it('still applies with force=true in the same Git workspace after opting out', async () => {
+    gitInit(ctx.tempDir);
+    const target = join(ctx.tempDir, 'target.ts');
+    writeFileSync(
+      target,
+      'export class Alpha {\n  public run(): void {}\n}\nexport function betaWorker(): number { return 1; }\n',
+      'utf-8',
+    );
+    gitCommitAll(ctx.tempDir, 'fixture');
+
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+    const result = await tool
+      .build({
+        file_path: target,
+        old_string: 'public run(): void {}',
+        new_string: 'public runQuick(): void {}',
+        force: true,
+      })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('Successfully applied edit to');
+    expect(readFileSync(target, 'utf-8')).toContain(
+      'public runQuick(): void {}',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REQ-3242-2: proximity-prioritized, bounded declaration context.
+// ---------------------------------------------------------------------------
+
+describe('REQ-3242-2: bounded proximity declaration context', () => {
+  const ctx = useTempDir();
+
+  it('fixture is 5,250 lines with at least 170 real parsed declarations', async () => {
+    const fixture = generateRustFixture();
+    expect(fixture.lineCount).toBe(RUST_FIXTURE_LINE_COUNT);
+    expect((fixture.content.match(/\n/g) ?? []).length).toBe(
+      RUST_FIXTURE_LINE_COUNT,
+    );
+    const target = join(ctx.tempDir, 'target.rs');
+    writeFileSync(target, fixture.content, 'utf-8');
+
+    const declarations = await new ASTQueryExtractor().extractDeclarations(
+      target,
+      fixture.content,
+    );
+    expect(declarations.length).toBeGreaterThanOrEqual(170);
+  });
+
+  it('selects the 128 declarations nearest a middle edit and renders them in source order', async () => {
+    const fixture = generateRustFixture();
+    const target = join(ctx.tempDir, 'target.rs');
+    writeFileSync(target, fixture.content, 'utf-8');
+    const declarations = await new ASTQueryExtractor().extractDeclarations(
+      target,
+      fixture.content,
+    );
+
+    const result = await runPreview(ctx.tempDir, target, fixture.edits.middle);
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+
+    const total = declarations.length;
+    const rendered = renderedDeclarations(output);
+    expect(rendered).toHaveLength(PREVIEW_MAX_DECLARATIONS);
+
+    const expected = expectedPreviewDeclarationLines(
+      declarations,
+      fixture.edits.middle.line,
+    );
+    expect(rendered.map((entry) => entry.raw)).toEqual(expected);
+
+    const lines = rendered.map((entry) => entry.line);
+    const sorted = [...lines].sort((a, b) => a - b);
+    expect(lines).toEqual(sorted);
+
+    const marker = boundedMarker(output);
+    expect(marker).toEqual({ shown: PREVIEW_MAX_DECLARATIONS, total });
+    expect(output).toContain(`- Context: rust file with ${total} declarations`);
+    expect(output).toContain('- function: worker_090 (line');
+    expect(output).not.toContain('- function: worker_000 (line');
+  });
+
+  it('selects head-adjacent declarations for an edit near the top of the file', async () => {
+    const fixture = generateRustFixture();
+    const target = join(ctx.tempDir, 'target.rs');
+    writeFileSync(target, fixture.content, 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, fixture.edits.head);
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+
+    const rendered = renderedDeclarations(output);
+    expect(rendered).toHaveLength(PREVIEW_MAX_DECLARATIONS);
+    expect(output).toContain('- function: worker_000 (line 31)');
+    expect(output).not.toContain('- function: worker_179 (line');
+    expect(boundedMarker(output)).not.toBeNull();
+  });
+
+  it('selects tail-adjacent declarations for an edit near the end of the file', async () => {
+    const fixture = generateRustFixture();
+    const target = join(ctx.tempDir, 'target.rs');
+    writeFileSync(target, fixture.content, 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, fixture.edits.tail);
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+
+    const rendered = renderedDeclarations(output);
+    expect(rendered).toHaveLength(PREVIEW_MAX_DECLARATIONS);
+    expect(output).toContain('- function: worker_179 (line');
+    expect(output).not.toContain('- function: worker_000 (line 31)');
+    expect(boundedMarker(output)).not.toBeNull();
+  });
+
+  it('renders every declaration and emits no bounded marker for exactly 128 declarations', async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 128; i++) {
+      lines.push(`function f${String(i).padStart(3, '0')}(): void {}`);
+    }
+    const target = join(ctx.tempDir, 'exact-128.ts');
+    writeFileSync(target, `${lines.join('\n')}\n`, 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: 'function f000(): void {}',
+      newString: 'function f000(): number { return 1; }',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(renderedDeclarations(output)).toHaveLength(128);
+    expect(output).toContain('- function: f127 (line 128)');
+    expect(boundedMarker(output)).toBeNull();
+  });
+
+  it('renders 128 of 129 declarations with a bounded marker for one over', async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 129; i++) {
+      lines.push(`function f${String(i).padStart(3, '0')}(): void {}`);
+    }
+    const target = join(ctx.tempDir, 'one-over-129.ts');
+    writeFileSync(target, `${lines.join('\n')}\n`, 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: 'function f000(): void {}',
+      newString: 'function f000(): number { return 1; }',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(renderedDeclarations(output)).toHaveLength(128);
+    expect(output).toContain('- function: f127 (line 128)');
+    expect(output).not.toContain('- function: f128 (line 129)');
+    expect(boundedMarker(output)).toEqual({ shown: 128, total: 129 });
+  });
+
+  it('prefers the nearest declarations across large line gaps in a sparse file', async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 130; i++) {
+      lines.push(
+        `function sparse_decl_${String(i).padStart(3, '0')}(): void {}`,
+      );
+      for (let j = 0; j < 19; j++) {
+        lines.push(`// sparse filler ${i}_${j}`);
+      }
+    }
+    const target = join(ctx.tempDir, 'sparse.ts');
+    writeFileSync(target, `${lines.join('\n')}\n`, 'utf-8');
+
+    // Anchor is the last filler line of block 127: line 2541 + 19 = 2560.
+    const anchorLine = 2560;
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: '// sparse filler 127_18',
+      newString: '// sparse filler 127_18 edited',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    const rendered = renderedDeclarations(output);
+    expect(rendered).toHaveLength(128);
+    expect(boundedMarker(output)).toEqual({ shown: 128, total: 130 });
+    expect(output).not.toContain('sparse_decl_000');
+    expect(output).not.toContain('sparse_decl_001');
+    expect(output).toContain('- function: sparse_decl_127 (line 2541)');
+    expect(output).toContain('- function: sparse_decl_128 (line 2561)');
+    expect(output).toContain('- function: sparse_decl_129 (line 2581)');
+    const expected = expectedPreviewDeclarationLines(
+      await new ASTQueryExtractor().extractDeclarations(
+        target,
+        readFileSync(target, 'utf-8'),
+      ),
+      anchorLine,
+    );
+    expect(rendered.map((entry) => entry.raw)).toEqual(expected);
+  });
+
+  it('breaks distance ties deterministically in favor of the earlier line', async () => {
+    const lines: string[] = [];
+    for (let i = 1; i <= 128; i++) {
+      lines.push(`function d${String(i).padStart(3, '0')}(): void {}`);
+    }
+    for (let i = 0; i < 130; i++) {
+      lines.push(`// tie filler ${String(i).padStart(3, '0')}`);
+    }
+    lines.push('function dSpecial(): void {}');
+    const target = join(ctx.tempDir, 'tie-break.ts');
+    writeFileSync(target, `${lines.join('\n')}\n`, 'utf-8');
+
+    // Anchor at line 130: d001 (line 1) and dSpecial (line 259) are both 129
+    // lines away and compete for the final slot; the earlier line wins.
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: '// tie filler 001',
+      newString: '// tie filler 001 edited',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(renderedDeclarations(output)).toHaveLength(128);
+    expect(boundedMarker(output)).toEqual({ shown: 128, total: 129 });
+    expect(output).toContain('- function: d001 (line 1)');
+    expect(output).not.toContain('dSpecial');
+  });
+
+  it('succeeds with zero declaration context for a new file', async () => {
+    const target = join(ctx.tempDir, 'brand-new-file.ts');
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: '',
+      newString: 'const brandNew = 42;\n',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('- Context: typescript file with 0 declarations');
+    expect(renderedDeclarations(output)).toHaveLength(0);
+    expect(boundedMarker(output)).toBeNull();
+    expect(output).toContain(NEXT_STEP);
+  });
+
+  it('succeeds with zero declaration context for a declaration-free file', async () => {
+    const target = join(ctx.tempDir, 'declaration-free.ts');
+    writeFileSync(target, "console.log('no declarations here');\n", 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: "console.log('no declarations here');",
+      newString: "console.log('still no declarations');",
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('- Context: typescript file with 0 declarations');
+    expect(renderedDeclarations(output)).toHaveLength(0);
+    expect(output).toContain(NEXT_STEP);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REQ-3242-3: model-facing preview content has a hard UTF-8 byte budget.
+// ---------------------------------------------------------------------------
+
+describe('REQ-3242-3: bounded preview llmContent byte budget', () => {
+  const ctx = useTempDir();
+
+  it('keeps ordinary preview output within the budget with compatible wording', async () => {
+    const target = join(ctx.tempDir, 'ordinary.ts');
+    const content =
+      'export function greet(name: string): string {\n  return `hello ${name}`;\n}\nexport class Greeter {}\n';
+    writeFileSync(target, content, 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: 'export function greet(name: string): string {',
+      newString: 'export function wave(name: string): string {',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(utf8Bytes(output)).toBeLessThanOrEqual(PREVIEW_LLM_MAX_BYTES);
+    expect(output).toContain('LLXPRT EDIT PREVIEW: ');
+    expect(output).toContain('- Context: typescript file with 2 declarations');
+    expect(output).toContain('- Functions: 1');
+    expect(output).toContain('- Classes: 1');
+    expect(output).toContain('AST validation: PASSED');
+    expect(output).toContain('- Timestamp: ');
+    expect(output).toContain('ENHANCED CONTEXT ANALYSIS:');
+    expect(output).toContain('- function: greet (line 1)');
+    expect(output).toContain('- class: Greeter (line 4)');
+    expect(output).toContain(NEXT_STEP);
+    expect(boundedMarker(output)).toBeNull();
+  });
+
+  it('drops the farthest declaration lines first when detail exceeds the budget', async () => {
+    const hugeName = 'a'.repeat(3000);
+    const lines: string[] = [];
+    for (let i = 0; i < 129; i++) {
+      lines.push(
+        `function ${hugeName}${String(i).padStart(3, '0')}(): void {}`,
+      );
+    }
+    const target = join(ctx.tempDir, 'over-budget.ts');
+    writeFileSync(target, `${lines.join('\n')}\n`, 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: `function ${hugeName}000(): void {}`,
+      newString: `function ${hugeName}000(): number { return 1; }`,
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(utf8Bytes(output)).toBeLessThanOrEqual(PREVIEW_LLM_MAX_BYTES);
+
+    const marker = boundedMarker(output);
+    expect(marker).not.toBeNull();
+    expect(marker?.total).toBe(129);
+    expect(marker?.shown).toBeLessThan(PREVIEW_MAX_DECLARATIONS);
+    expect(renderedDeclarations(output)).toHaveLength(marker?.shown ?? -1);
+    // Mandatory lines survive the budget drop.
+    expect(output).toContain('- Timestamp: ');
+    expect(output).toContain(NEXT_STEP);
+    expect(output).toContain('LLXPRT EDIT PREVIEW: ');
+    // Nearest declaration detail survives; the farthest lines were dropped.
+    expect(output).toContain(`${hugeName}000`);
+    expect(output).not.toContain(`${hugeName}128`);
+  });
+
+  it('renders only complete multibyte declaration lines at the byte boundary', async () => {
+    const multibyteName = '語'.repeat(900);
+    const lines: string[] = [];
+    for (let i = 0; i < 129; i++) {
+      lines.push(
+        `function ${multibyteName}${String(i).padStart(3, '0')}(): void {}`,
+      );
+    }
+    const target = join(ctx.tempDir, 'multibyte.ts');
+    writeFileSync(target, `${lines.join('\n')}\n`, 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: `function ${multibyteName}000(): void {}`,
+      newString: `function ${multibyteName}000(): number { return 1; }`,
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    // Total encoded multibyte output stays within the hard cap.
+    expect(utf8Bytes(output)).toBeLessThanOrEqual(PREVIEW_LLM_MAX_BYTES);
+
+    const marker = boundedMarker(output);
+    expect(marker).not.toBeNull();
+    expect(marker?.total).toBe(129);
+    expect(marker?.shown).toBeLessThan(PREVIEW_MAX_DECLARATIONS);
+
+    // Every rendered declaration is a COMPLETE line — its name is one of
+    // the fixture's full multibyte names (multibyte prefix plus padded
+    // index), never a byte-truncated fragment — and the rendered count
+    // matches the marker's truthful shown count.
+    const rendered = renderedDeclarations(output);
+    expect(rendered).toHaveLength(marker?.shown ?? -1);
+    const completeNames = new Set(
+      Array.from(
+        { length: 129 },
+        (_, i) => `${multibyteName}${String(i).padStart(3, '0')}`,
+      ),
+    );
+    expect(rendered.length).toBeGreaterThan(0);
+    for (const entry of rendered) {
+      expect(completeNames.has(entry.name)).toBe(true);
+    }
+    // The nearest complete multibyte declaration survives byte-budget
+    // dropping, and the complete farthest declaration does not.
+    expect(output).toContain(`- function: ${multibyteName}000 (line 1)`);
+    expect(output).not.toContain(`${multibyteName}128`);
+    // Mandatory lines survive the budget drop alongside the multibyte detail.
+    expect(output).toContain('- Timestamp: ');
+    expect(output).toContain(NEXT_STEP);
+  });
+
+  it('caps reported relevant snippets at 64 for a symbol-dense file', async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      lines.push(`function f${i}(): void {}`);
+    }
+    const target = join(ctx.tempDir, 'snippet-cap.ts');
+    writeFileSync(target, `${lines.join('\n')}\n`, 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: 'function f0(): void {}',
+      newString: 'function f0(): number { return 1; }',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toMatch(
+      new RegExp(
+        `^- Relevant snippets: ${PREVIEW_MAX_SNIPPETS} found \\(capped from \\d+\\)$`,
+        'm',
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REQ-3242-4: preview followed immediately by force apply.
+// ---------------------------------------------------------------------------
+
+describe('REQ-3242-4: preview then force apply on the large fixture', () => {
+  const ctx = useTempDir();
+
+  it('applies the exact requested bytes immediately after preview using the preview timestamp', async () => {
+    const fixture = generateRustFixture();
+    const target = join(ctx.tempDir, 'target.rs');
+    writeFileSync(target, fixture.content, 'utf-8');
+
+    const preview = await runPreview(ctx.tempDir, target, fixture.edits.middle);
+    expect(preview.error).toBeUndefined();
+    const previewOutput = String(preview.llmContent);
+    const timestampMatch = /- Timestamp: (\d+)/.exec(previewOutput);
+    expect(timestampMatch).not.toBeNull();
+    expect(boundedMarker(previewOutput)).toEqual({
+      shown: PREVIEW_MAX_DECLARATIONS,
+      total: 184,
+    });
+
+    const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
+    const apply = await tool
+      .build({
+        file_path: target,
+        old_string: fixture.edits.middle.oldString,
+        new_string: fixture.edits.middle.newString,
+        force: true,
+        last_modified: Number(timestampMatch?.[1]),
+      })
+      .execute(new AbortController().signal);
+
+    expect(apply.error).toBeUndefined();
+    expect(String(apply.llmContent)).toContain('Successfully applied edit to');
+    expect(utf8Bytes(String(apply.llmContent))).toBeGreaterThan(0);
+
+    const expectedContent = fixture.content.replace(
+      fixture.edits.middle.oldString,
+      fixture.edits.middle.newString,
+    );
+    expect(readFileSync(target, 'utf-8')).toBe(expectedContent);
+  });
+});

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-regression.bun.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-regression.bun.test.ts
@@ -76,30 +76,39 @@ async function runPreview(
     .execute(new AbortController().signal);
 }
 
+interface RankedDeclaration {
+  readonly declaration: EnhancedDeclaration;
+  /** Original extractor-array index, attached before any sorting. */
+  readonly sourceIndex: number;
+}
+
+function sourceOrder(a: RankedDeclaration, b: RankedDeclaration): number {
+  const byLine = a.declaration.line - b.declaration.line;
+  if (byLine !== 0) {
+    return byLine;
+  }
+  const byColumn = a.declaration.column - b.declaration.column;
+  if (byColumn !== 0) {
+    return byColumn;
+  }
+  return a.sourceIndex - b.sourceIndex;
+}
+
 /**
- * Oracle for the accepted selection policy: source-order the real extractor
- * output, keep the 128 declarations nearest the edit start line (ties break
- * to the earlier line), then render the kept set back in source order.
+ * Oracle for the accepted selection policy: attach each real-extractor
+ * declaration's original array index before any sorting (the extractor
+ * lists kinds in family order, not document order, so that index is what
+ * production preserves for same-line ties), keep the 128 declarations
+ * nearest the edit start line (ties break to the earlier line, then to
+ * the earlier original extractor index), then render the kept set back in
+ * true source order.
  */
 function expectedPreviewDeclarationLines(
   declarations: readonly EnhancedDeclaration[],
   editStartLine: number,
 ): string[] {
-  const bySource = [...declarations]
-    .map((declaration, index) => ({ declaration, index }))
-    .sort((a, b) => {
-      const byLine = a.declaration.line - b.declaration.line;
-      if (byLine !== 0) {
-        return byLine;
-      }
-      const byColumn = a.declaration.column - b.declaration.column;
-      if (byColumn !== 0) {
-        return byColumn;
-      }
-      return a.index - b.index;
-    });
-  const byProximity = [...bySource]
-    .map((entry, sourceIndex) => ({ ...entry, sourceIndex }))
+  const byProximity = declarations
+    .map((declaration, sourceIndex) => ({ declaration, sourceIndex }))
     .sort((a, b) => {
       const byDistance =
         Math.abs(a.declaration.line - editStartLine) -
@@ -115,7 +124,7 @@ function expectedPreviewDeclarationLines(
     });
   return byProximity
     .slice(0, PREVIEW_MAX_DECLARATIONS)
-    .sort((a, b) => a.sourceIndex - b.sourceIndex)
+    .sort(sourceOrder)
     .map(
       (entry) =>
         `- ${entry.declaration.type}: ${entry.declaration.name} (line ${entry.declaration.line})`,
@@ -396,6 +405,47 @@ describe('REQ-3242-2: bounded proximity declaration context', () => {
     expect(boundedMarker(output)).toEqual({ shown: 128, total: 129 });
     expect(output).toContain('- function: d001 (line 1)');
     expect(output).not.toContain('dSpecial');
+  });
+
+  it('breaks same-line proximity ties by original extractor order at the selection boundary', async () => {
+    const lines: string[] = [
+      // Same-line pair: the variable starts at the earlier column, but the
+      // extractor lists every function before any variable, so the function
+      // holds the earlier original extractor index.
+      'const v = 1; function dSpecial(): void {}',
+    ];
+    for (let i = 1; i <= 127; i++) {
+      lines.push(`function d${String(i).padStart(3, '0')}(): void {}`);
+    }
+    lines.push('// same-line filler anchor');
+    const target = join(ctx.tempDir, 'same-line-tie.ts');
+    writeFileSync(target, `${lines.join('\n')}\n`, 'utf-8');
+
+    // Anchor at line 129: d001..d127 occupy distances 127 down to 1, so the
+    // same-line pair (both distance 128) competes for the final slot.
+    const anchorLine = 129;
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: '// same-line filler anchor',
+      newString: '// same-line filler anchor edited',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    const rendered = renderedDeclarations(output);
+    expect(rendered).toHaveLength(PREVIEW_MAX_DECLARATIONS);
+    expect(boundedMarker(output)).toEqual({ shown: 128, total: 129 });
+    // The same-line tie resolves by original extractor index, not column:
+    // the function wins the final slot over the column-earlier variable.
+    expect(output).toContain('- function: dSpecial (line 1)');
+    expect(output).not.toContain('- variable: v (line 1)');
+    const expected = expectedPreviewDeclarationLines(
+      await new ASTQueryExtractor().extractDeclarations(
+        target,
+        readFileSync(target, 'utf-8'),
+      ),
+      anchorLine,
+    );
+    expect(rendered.map((entry) => entry.raw)).toEqual(expected);
   });
 
   it('succeeds with zero declaration context for a new file', async () => {

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-review.bun.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-review.bun.test.ts
@@ -1,0 +1,711 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral remediation tests for the issue #3242 review findings.
+ *
+ * Blocker-Fix: the hard 256 KiB preview byte budget was violated when AST
+ * validation emitted many diagnostics — the mandatory
+ * `astValidation.errors.join(', ')` line alone exceeded 262,144 bytes after
+ * every declaration line was already dropped. Preview assembly must budget
+ * variable validation detail at whole diagnostic items with truthful
+ * omission metadata, keep the mandatory status/summary/timestamp/footer
+ * lines, and fail fast when truly fixed mandatory content alone exceeds the
+ * policy.
+ *
+ * Blocker-Fix (summary label): the mandatory
+ * `- AST validation: ${summary.label}` line embedded the categorizer's
+ * unbounded list of error line numbers, so a diagnostic-dense summary label
+ * alone exceeded the 262,144-byte budget. A preview-only bounded
+ * summary-label formatter keeps that mandatory line small while preserving
+ * the exact ordinary label.
+ *
+ * In-scope-Fix (CRLF): a CRLF old_string never matched the LF-normalized
+ * content at the anchor boundary, so declaration selection anchored at
+ * line 1 even for tail edits. The exact edit start must anchor selection
+ * and validation consistently.
+ *
+ * In-scope-Fix (snippets): preview reported 64 snippets but the preview
+ * context retained all 77 collected items. The preview-specific bounded
+ * snippet collection (the real collector path) must hold at most 64 items
+ * while the report keeps the truthful original total.
+ *
+ * Every fixture is a real file exercised through the real ASTEditTool or
+ * the real ASTContextCollector — no mocked tool paths.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ASTEditTool } from '../../ast-edit.js';
+import { ASTContextCollector } from '../context-collector.js';
+import {
+  assembleBoundedPreview,
+  preExistingSyntaxErrorStatus,
+  boundedValidationSummaryLabel,
+} from '../preview-context-policy.js';
+import { ASTConfig } from '../ast-config.js';
+import type { AstValidationSummary } from '../validation-categorizer.js';
+import type { EnhancedDeclaration } from '../types.js';
+import type { ToolResult } from '../../tools.js';
+import { ToolErrorType } from '../../../types/tool-error.js';
+import { createFakeToolHost, useTempDir } from './test-helpers.js';
+
+const PREVIEW_LLM_MAX_BYTES = 256 * 1024;
+const PREVIEW_MAX_DECLARATIONS = 128;
+const PREVIEW_MAX_SNIPPETS = ASTConfig.PREVIEW_MAX_SNIPPETS;
+const NEXT_STEP = 'NEXT STEP: Call again with force: true to apply changes';
+
+function utf8Bytes(text: string): number {
+  return Buffer.byteLength(text, 'utf-8');
+}
+
+async function runPreview(
+  targetDir: string,
+  filePath: string,
+  edit: { oldString: string; newString: string },
+): Promise<ToolResult> {
+  const tool = new ASTEditTool(createFakeToolHost(targetDir));
+  return tool
+    .build({
+      file_path: filePath,
+      old_string: edit.oldString,
+      new_string: edit.newString,
+      force: false,
+    })
+    .execute(new AbortController().signal);
+}
+
+function previewLine(output: string, prefix: string): string | undefined {
+  return output.split('\n').find((line) => line.startsWith(prefix));
+}
+
+// ---------------------------------------------------------------------------
+// Blocker-Fix: diagnostic-dense previews must respect the hard byte budget.
+// ---------------------------------------------------------------------------
+
+describe('Blocker-Fix: preview byte budget under diagnostic-dense validation', () => {
+  const ctx = useTempDir();
+
+  // 8,000 unique malformed declarations each emit one parser diagnostic, so
+  // the joined AST error list alone is ~296 KiB — far beyond the 256 KiB
+  // policy even with every declaration line dropped.
+  const DENSE_LINES = 8_000;
+
+  function writeDenseFixture(): string {
+    const lines: string[] = [];
+    for (let i = 0; i < DENSE_LINES; i++) {
+      lines.push(`const v${String(i).padStart(4, '0')} = ;`);
+    }
+    const target = join(ctx.tempDir, 'diagnostic-dense.ts');
+    writeFileSync(target, `${lines.join('\n')}\n`, 'utf-8');
+    return target;
+  }
+
+  it('keeps the entire successful llmContent at or under 256 KiB with truthful omission metadata', async () => {
+    const target = writeDenseFixture();
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: `const v${String(DENSE_LINES - 1).padStart(4, '0')} = ;`,
+      newString: `const v${String(DENSE_LINES - 1).padStart(4, '0')} = 1;`,
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(utf8Bytes(output)).toBeLessThanOrEqual(PREVIEW_LLM_MAX_BYTES);
+
+    // Mandatory preview status, AST validity summary, timestamp, and the
+    // exact next-step footer all survive the budget.
+    expect(output).toContain(`LLXPRT EDIT PREVIEW: ${target}`);
+    expect(output).toContain('- AST validation: FAILED (pre-existing error');
+    // The mandatory pre-existing status line is fixed-width: per-error
+    // locations live only in the separately budgeted validation detail, so
+    // even this diagnostic-dense collection cannot expand it.
+    expect(previewLine(output, '- Pre-existing syntax errors:')).toBe(
+      '- Pre-existing syntax errors: Yes',
+    );
+    expect(output).toContain('- Timestamp: ');
+    expect(output).toContain(NEXT_STEP);
+
+    // Variable validation detail is bounded at whole diagnostic items with
+    // a truthful omission marker: shown + omitted must equal the total.
+    const astErrorsLine = previewLine(output, '- AST errors: ');
+    expect(astErrorsLine).toBeDefined();
+    const marker = /\(\+(\d+) more errors omitted; (\d+) total\)$/.exec(
+      astErrorsLine ?? '',
+    );
+    expect(marker).not.toBeNull();
+    const omitted = Number(marker?.[1]);
+    const total = Number(marker?.[2]);
+    const shownText = (astErrorsLine ?? '').slice(
+      '- AST errors: '.length,
+      (astErrorsLine?.length ?? 0) - (marker?.[0].length ?? 0),
+    );
+    // Each diagnostic in this fixture is one "Syntax error ..." message
+    // (which itself contains ", " between line and column), so count
+    // messages rather than splitting on the item separator.
+    const shown = (shownText.match(/Syntax error/g) ?? []).length;
+    expect(shown + omitted).toBe(total);
+    expect(total).toBe(DENSE_LINES - 1);
+    expect(shown).toBeGreaterThan(0);
+
+    // The line itself never claims to carry the full diagnostic list.
+    expect(utf8Bytes(astErrorsLine ?? '')).toBeLessThanOrEqual(
+      PREVIEW_LLM_MAX_BYTES,
+    );
+  });
+
+  it('fails fast when fixed mandatory content alone exceeds the byte budget', () => {
+    // Fixed mandatory lines (status/summary/footer) are never droppable, so
+    // assembly must refuse rather than emit an over-budget success. Proven
+    // at the preview-assembly policy boundary with real mandatory content
+    // sized past the policy (a pathological pipeline case whose ~37k real
+    // parser diagnostics additionally trip a pre-existing Bun native-module
+    // exit crash, so it cannot be exercised end-to-end here).
+    const hugeMandatory = [
+      `LLXPRT EDIT PREVIEW: ${'p'.repeat(PREVIEW_LLM_MAX_BYTES)}`,
+      '- AST validation: FAILED',
+    ];
+    expect(() =>
+      assembleBoundedPreview({
+        mandatoryHead: hugeMandatory,
+        validationDetail: [],
+        mandatoryTail: [],
+        declarations: [],
+        anchorLine: 1,
+        mandatorySuffix: [
+          'NEXT STEP: Call again with force: true to apply changes',
+        ],
+      }),
+    ).toThrow(/alone exceeds the \d+-byte budget/);
+  });
+
+  it('fails fast when fixed content fits only without the required bounded marker', () => {
+    // Exact boundary: the fixed mandatory frame alone fits, but once the
+    // byte budget drops the only declaration line, the truthful
+    // `showing 0 of 1` bounded marker itself no longer fits. The assembled
+    // frame must be refused, never returned as an over-budget success.
+    const declaration: EnhancedDeclaration = {
+      name: 'markerBoundary',
+      type: 'function',
+      line: 1,
+      column: 1,
+      range: {
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 24 },
+      },
+    };
+    const statusPrefix = 'LLXPRT EDIT PREVIEW: ';
+    const headWithoutStatus = [
+      '- Context: typescript file with 1 declarations',
+      '- Functions: 1',
+      '- Classes: 0',
+      '- AST validation: PASSED',
+    ];
+    const mandatoryTail = [
+      '- Relevant snippets: 0 found',
+      '- Timestamp: 1786000000000',
+      'ENHANCED CONTEXT ANALYSIS:',
+    ];
+    const mandatorySuffix = [NEXT_STEP];
+    const marker =
+      '- Declarations: bounded preview — showing 0 of 1 (selected nearest to the edit)';
+    // Size the status line so the fixed frame lands exactly 8 bytes under
+    // the hard budget: it fits alone, but the required omission marker
+    // (~80 bytes) pushes the assembled frame past it.
+    const fillerLength =
+      PREVIEW_LLM_MAX_BYTES -
+      utf8Bytes(
+        [
+          statusPrefix,
+          ...headWithoutStatus,
+          ...mandatoryTail,
+          ...mandatorySuffix,
+        ].join('\n'),
+      ) -
+      8;
+    const mandatoryHead = [
+      `${statusPrefix}${'p'.repeat(fillerLength)}`,
+      ...headWithoutStatus,
+    ];
+    const fixed = [...mandatoryHead, ...mandatoryTail, ...mandatorySuffix];
+
+    expect(utf8Bytes(fixed.join('\n'))).toBe(PREVIEW_LLM_MAX_BYTES - 8);
+    expect(utf8Bytes([...fixed, marker].join('\n'))).toBeGreaterThan(
+      PREVIEW_LLM_MAX_BYTES,
+    );
+
+    expect(() =>
+      assembleBoundedPreview({
+        mandatoryHead,
+        validationDetail: [],
+        mandatoryTail,
+        declarations: [declaration],
+        anchorLine: 1,
+        mandatorySuffix,
+      }),
+    ).toThrow(
+      /cannot fit mandatory content plus declaration omission metadata within the \d+-byte budget/,
+    );
+  });
+
+  it('keeps the mandatory pre-existing status fixed-width for a very large error collection', () => {
+    // Pure-policy regression for the mandatory-status blocker: 50,000
+    // synthetic pre-existing diagnostics (no parser involved — a real
+    // ~37k-diagnostic parse trips a pre-existing Bun native-module exit
+    // crash). The pre-existing-only status line is fixed-width by policy,
+    // so the collection size cannot expand non-budgetable mandatory
+    // content; the errors themselves enter only through the separately
+    // budgeted validation detail.
+    const hugeErrors = Array.from(
+      { length: 50_000 },
+      (_, index) => `Syntax error at line ${index + 1}, column 1`,
+    );
+
+    const status = preExistingSyntaxErrorStatus(true);
+    expect(status).toBe('- Pre-existing syntax errors: Yes');
+    expect(utf8Bytes(status)).toBeLessThanOrEqual(64);
+
+    const result = assembleBoundedPreview({
+      mandatoryHead: [
+        'LLXPRT EDIT PREVIEW: /workspace/target.ts',
+        '- Context: typescript file with 0 declarations',
+        '- Functions: 0',
+        '- Classes: 0',
+        '- AST validation: FAILED (pre-existing errors — present before this edit)',
+        status,
+      ],
+      validationDetail: hugeErrors,
+      mandatoryTail: [
+        '- Relevant snippets: 0 found',
+        '- Timestamp: 1786000000000',
+        'ENHANCED CONTEXT ANALYSIS:',
+      ],
+      declarations: [],
+      anchorLine: 1,
+      mandatorySuffix: [NEXT_STEP],
+    });
+
+    // The huge collection is budgeted at whole diagnostic items with
+    // truthful omission metadata, and the fixed-width mandatory status
+    // survives inside the hard byte budget.
+    expect(utf8Bytes(result.lines.join('\n'))).toBeLessThanOrEqual(
+      PREVIEW_LLM_MAX_BYTES,
+    );
+    expect(result.lines).toContain('- Pre-existing syntax errors: Yes');
+    const astErrorsLine = result.lines.find((line) =>
+      line.startsWith('- AST errors: '),
+    );
+    expect(astErrorsLine).toBeDefined();
+    const marker = /\(\+(\d+) more errors omitted; (\d+) total\)$/.exec(
+      astErrorsLine ?? '',
+    );
+    expect(marker).not.toBeNull();
+    expect(Number(marker?.[2])).toBe(50_000);
+  });
+
+  it('keeps every declaration when the complete unmarked frame fits but the marker would not', () => {
+    // Exact boundary, mirror image of the refusal case above: the complete
+    // UNMARKED frame lands exactly at the hard budget, so it fits — but a
+    // bounded marker (never rendered, because nothing is omitted) would
+    // push the measured frame past it. The assembler must measure the
+    // complete unmarked frame first and keep the declaration; accounting
+    // for an omission marker before any omission is required would drop
+    // the declaration (or refuse outright) for a marker that is never
+    // rendered.
+    const declaration: EnhancedDeclaration = {
+      name: 'completeFrame',
+      type: 'function',
+      line: 1,
+      column: 1,
+      range: {
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 16 },
+      },
+    };
+    const statusPrefix = 'LLXPRT EDIT PREVIEW: ';
+    const headWithoutStatus = [
+      '- Context: typescript file with 1 declarations',
+      '- Functions: 1',
+      '- Classes: 0',
+      '- AST validation: PASSED',
+    ];
+    const mandatoryTail = [
+      '- Relevant snippets: 0 found',
+      '- Timestamp: 1786000000000',
+      'ENHANCED CONTEXT ANALYSIS:',
+    ];
+    const mandatorySuffix = [NEXT_STEP];
+    const declarationLine = '- function: completeFrame (line 1)';
+    const marker =
+      '- Declarations: bounded preview — showing 0 of 1 (selected nearest to the edit)';
+    // Size the status line so the complete frame (mandatory + the single
+    // declaration line + footer) lands exactly at the budget.
+    const fillerLength =
+      PREVIEW_LLM_MAX_BYTES -
+      utf8Bytes(
+        [
+          statusPrefix,
+          ...headWithoutStatus,
+          ...mandatoryTail,
+          declarationLine,
+          ...mandatorySuffix,
+        ].join('\n'),
+      );
+    const mandatoryHead = [
+      `${statusPrefix}${'p'.repeat(fillerLength)}`,
+      ...headWithoutStatus,
+    ];
+
+    const complete = [
+      ...mandatoryHead,
+      ...mandatoryTail,
+      declarationLine,
+      ...mandatorySuffix,
+    ];
+    expect(utf8Bytes(complete.join('\n'))).toBe(PREVIEW_LLM_MAX_BYTES);
+    expect(
+      utf8Bytes(
+        [
+          ...mandatoryHead,
+          ...mandatoryTail,
+          marker,
+          declarationLine,
+          ...mandatorySuffix,
+        ].join('\n'),
+      ),
+    ).toBeGreaterThan(PREVIEW_LLM_MAX_BYTES);
+
+    const result = assembleBoundedPreview({
+      mandatoryHead,
+      validationDetail: [],
+      mandatoryTail,
+      declarations: [declaration],
+      anchorLine: 1,
+      mandatorySuffix,
+    });
+    expect(result.renderedDeclarations).toBe(1);
+    expect(result.totalDeclarations).toBe(1);
+    expect(result.bounded).toBe(false);
+    expect(result.lines).toContain(declarationLine);
+    expect(result.lines.join('\n')).not.toContain('bounded preview');
+    expect(utf8Bytes(result.lines.join('\n'))).toBeLessThanOrEqual(
+      PREVIEW_LLM_MAX_BYTES,
+    );
+  });
+
+  it('returns a structured EDIT_PREPARATION_FAILURE for a NUL-containing path', async () => {
+    // Deterministic short-path preparation exception through the real tool:
+    // Node/Bun fs bindings reject NUL bytes in path strings on every
+    // platform before any OS call, so the real preview's preparation path
+    // fails fast inside executePreview's try block — the same unwind the
+    // assembler's budget throw takes. The ToolResult is a structured,
+    // never-null EDIT_PREPARATION_FAILURE with a bounded message. (Real
+    // assembler overflow itself is proven by the direct policy tests above;
+    // an end-to-end oversized-mandatory workload is not used because the
+    // natural ~37k-diagnostic shape trips a pre-existing Bun native-module
+    // exit crash, and a 256 KiB filename is OS-sensitive and never reached
+    // the assembler anyway.)
+    const invalidPath = join(ctx.tempDir, 'inva\0lid.ts');
+
+    const result = await runPreview(ctx.tempDir, invalidPath, {
+      oldString: 'const existing = 1;',
+      newString: 'const existing = 2;',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe(ToolErrorType.EDIT_PREPARATION_FAILURE);
+    const output = String(result.llmContent);
+    expect(output.startsWith('Error preparing preview: ')).toBe(true);
+    // The structured error message itself stays bounded.
+    expect(utf8Bytes(output)).toBeLessThanOrEqual(PREVIEW_LLM_MAX_BYTES);
+    expect(typeof result.returnDisplay).toBe('string');
+    expect(String(result.returnDisplay).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Blocker-Fix: the mandatory AST validation summary line must stay bounded.
+// ---------------------------------------------------------------------------
+
+describe('Blocker-Fix: bounded mandatory AST validation summary label', () => {
+  // Pure policy: summarizeAstValidation embeds every diagnostic line number
+  // into its label, so a diagnostic-dense file yields a mandatory label that
+  // alone exceeds the entire 256 KiB preview budget. The preview-only
+  // formatter must keep ordinary labels byte-identical and replace oversized
+  // ones with a fixed-width truthful classification. No parser workload is
+  // involved: the synthetic labels mirror the categorizer's real output
+  // shape (formatValidationLineLabel joins every line number with ", ").
+  const OMITTED_NOTE = 'validation locations omitted for preview byte budget';
+
+  function lineNumbers(count: number): string {
+    const lines = Array.from({ length: count }, (_, index) => index + 1);
+    return ` at lines ${lines.join(', ')}`;
+  }
+
+  it('keeps an ordinary summary label byte-identical', () => {
+    const ordinary =
+      'FAILED (pre-existing error at line 7 — present before this edit)';
+    const ordinarySummary: AstValidationSummary = {
+      status: 'FAILED',
+      preExisting: true,
+      newlyIntroduced: false,
+      label: ordinary,
+    };
+    expect(boundedValidationSummaryLabel(ordinarySummary)).toBe(ordinary);
+  });
+
+  it('bounds an oversized pre-existing label so the mandatory line fits the budget', () => {
+    const huge = `FAILED (pre-existing error${lineNumbers(50_000)} — present before this edit)`;
+    // The old direct embedding was mandatory, non-droppable content that is
+    // by itself larger than the entire successful-preview budget.
+    expect(utf8Bytes(huge)).toBeGreaterThan(PREVIEW_LLM_MAX_BYTES);
+
+    const bounded = boundedValidationSummaryLabel({
+      status: 'FAILED',
+      preExisting: true,
+      newlyIntroduced: false,
+      label: huge,
+    });
+    expect(bounded).toBe(
+      `FAILED (pre-existing error — present before this edit; ${OMITTED_NOTE})`,
+    );
+    // Fixed-width output: bounded independent of the diagnostic count.
+    expect(
+      boundedValidationSummaryLabel({
+        status: 'FAILED',
+        preExisting: true,
+        newlyIntroduced: false,
+        label: `FAILED (pre-existing error${lineNumbers(60_000)} — present before this edit)`,
+      }),
+    ).toBe(bounded);
+
+    // Assembled consequence: the raw oversized label makes the mandatory
+    // frame unfittable (the preview would fail), the formatted label fits.
+    const headWith = (validationLabel: string): readonly string[] => [
+      'LLXPRT EDIT PREVIEW: /workspace/dense.ts',
+      '- Context: typescript file with 0 declarations',
+      '- Functions: 0',
+      '- Classes: 0',
+      `- AST validation: ${validationLabel}`,
+    ];
+    const frame = {
+      mandatoryTail: [
+        '- Relevant snippets: 0 found',
+        '- Timestamp: 1786000000000',
+        'ENHANCED CONTEXT ANALYSIS:',
+      ],
+      declarations: [] as EnhancedDeclaration[],
+      anchorLine: 1,
+      mandatorySuffix: [NEXT_STEP],
+    };
+    expect(() =>
+      assembleBoundedPreview({
+        mandatoryHead: headWith(huge),
+        validationDetail: [],
+        ...frame,
+      }),
+    ).toThrow(/alone exceeds the \d+-byte budget/);
+    const assembled = assembleBoundedPreview({
+      mandatoryHead: headWith(bounded),
+      validationDetail: [],
+      ...frame,
+    });
+    expect(utf8Bytes(assembled.lines.join('\n'))).toBeLessThanOrEqual(
+      PREVIEW_LLM_MAX_BYTES,
+    );
+  });
+
+  it('bounds an oversized newly-introduced label preserving the classification', () => {
+    const huge = `FAILED (new error introduced by this edit${lineNumbers(50_000)})`;
+    expect(utf8Bytes(huge)).toBeGreaterThan(PREVIEW_LLM_MAX_BYTES);
+
+    const bounded = boundedValidationSummaryLabel({
+      status: 'FAILED',
+      preExisting: false,
+      newlyIntroduced: true,
+      label: huge,
+    });
+    expect(bounded).toBe(
+      `FAILED (new error introduced by this edit; ${OMITTED_NOTE})`,
+    );
+    expect(utf8Bytes(bounded)).toBeLessThanOrEqual(256);
+  });
+
+  it('bounds an oversized mixed label preserving both classifications', () => {
+    const huge = `FAILED (file had pre-existing errors${lineNumbers(25_000)}; post-edit errors${lineNumbers(25_000)} may be newly introduced)`;
+    expect(utf8Bytes(huge)).toBeGreaterThan(PREVIEW_LLM_MAX_BYTES);
+
+    const mixedSummary: AstValidationSummary = {
+      status: 'FAILED',
+      preExisting: true,
+      newlyIntroduced: true,
+      label: huge,
+    };
+    const bounded = boundedValidationSummaryLabel(mixedSummary);
+    expect(bounded).toBe(
+      `FAILED (file had pre-existing errors; post-edit errors may be newly introduced; ${OMITTED_NOTE})`,
+    );
+    expect(utf8Bytes(bounded)).toBeLessThanOrEqual(256);
+  });
+
+  it('bounds an oversized resolved-pre-existing PASSED label', () => {
+    const huge = `PASSED (edit resolved pre-existing error${lineNumbers(50_000)})`;
+    expect(utf8Bytes(huge)).toBeGreaterThan(PREVIEW_LLM_MAX_BYTES);
+
+    const bounded = boundedValidationSummaryLabel({
+      status: 'PASSED',
+      preExisting: false,
+      newlyIntroduced: false,
+      label: huge,
+    });
+    expect(bounded).toBe(
+      `PASSED (edit resolved pre-existing error; ${OMITTED_NOTE})`,
+    );
+    expect(utf8Bytes(bounded)).toBeLessThanOrEqual(256);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// In-scope-Fix: CRLF old_string must anchor selection at the exact edit.
+// ---------------------------------------------------------------------------
+
+describe('In-scope-Fix: CRLF old_string anchors declaration selection', () => {
+  const ctx = useTempDir();
+
+  it('selects tail-adjacent declarations for a multiline CRLF old_string', async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 129; i++) {
+      lines.push(`function c${String(i).padStart(3, '0')}(): void {}`);
+    }
+    const target = join(ctx.tempDir, 'crlf-129.ts');
+    writeFileSync(target, `${lines.join('\r\n')}\r\n`, 'utf-8');
+
+    // Multiline CRLF old_string covering the final two declarations: the
+    // edit starts at line 128, so the selection must be tail-adjacent.
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: 'function c127(): void {}\r\nfunction c128(): void {}',
+      newString: 'function c127r(): void {}\r\nfunction c128r(): void {}',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(output).toContain('- function: c128 (line 129)');
+    expect(output).not.toContain('- function: c000 (line 1)');
+    const marker =
+      /- Declarations: bounded preview — showing (\d+) of (\d+)/.exec(output);
+    expect(marker).not.toBeNull();
+    expect(Number(marker?.[1])).toBe(PREVIEW_MAX_DECLARATIONS);
+    expect(Number(marker?.[2])).toBe(129);
+  });
+
+  it('keeps whole-file recovery validation anchored at the CRLF edit region', async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 129; i++) {
+      lines.push(`@ marker ${i}`);
+    }
+    const target = join(ctx.tempDir, 'crlf-recovery.ts');
+    writeFileSync(target, `${lines.join('\r\n')}\r\n`, 'utf-8');
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: '@ marker 127\r\n@ marker 128',
+      newString: '@ marker 127 edited\r\n@ marker 128 edited',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    const astErrorsLine = previewLine(output, '- AST errors: ');
+    expect(astErrorsLine).toContain('near line 128');
+    expect(astErrorsLine).not.toContain('near line 1 ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// In-scope-Fix: the preview context itself must retain at most 64 snippets.
+// ---------------------------------------------------------------------------
+
+describe('In-scope-Fix: preview context retains the bounded snippet collection', () => {
+  const ctx = useTempDir();
+
+  function writeSnippetFixture(): { target: string; content: string } {
+    const lines: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      lines.push(`function f${i}(): void {}`);
+    }
+    const content = `${lines.join('\n')}\n`;
+    const target = join(ctx.tempDir, 'snippet-retention.ts');
+    writeFileSync(target, content, 'utf-8');
+    return { target, content };
+  }
+
+  it('bounds the preview-shaped collector result to 64 retained snippet items', async () => {
+    const { target, content } = writeSnippetFixture();
+    const collector = new ASTContextCollector();
+
+    // The exact preview-shaped real collector path: the returned context —
+    // the object preview renders and retains from — must itself hold only
+    // the bounded collection, releasing the omitted snippet objects.
+    const context = await collector.collectEnhancedContext(
+      target,
+      content,
+      ctx.tempDir,
+      {
+        collectWorkingSet: false,
+        collectRepositoryContext: false,
+        previewSnippetItemCap: PREVIEW_MAX_SNIPPETS,
+      },
+    );
+    expect(context.relevantSnippets).toHaveLength(PREVIEW_MAX_SNIPPETS);
+    expect(context.relevantSnippetTotal).toBe(77);
+    // The 64 retained items are the policy-ordered first 64 of the full
+    // collection (priority, then relevance), not a re-ranked subset.
+    const uncapped = await collector.collectEnhancedContext(
+      target,
+      content,
+      ctx.tempDir,
+      { collectWorkingSet: false, collectRepositoryContext: false },
+    );
+    expect(uncapped.relevantSnippets).toHaveLength(77);
+    expect(context.relevantSnippets.map((snippet) => snippet.text)).toEqual(
+      uncapped.relevantSnippets
+        .slice(0, PREVIEW_MAX_SNIPPETS)
+        .map((snippet) => snippet.text),
+    );
+  });
+
+  it('reports the retained snippet count with the truthful capped-from total', async () => {
+    const { target, content } = writeSnippetFixture();
+
+    // The shown count must be the count the preview context actually
+    // retains, taken from the same real preview-shaped collector path the
+    // tool uses, so the report and retention cannot silently diverge.
+    const collector = new ASTContextCollector();
+    const context = await collector.collectEnhancedContext(
+      target,
+      content,
+      ctx.tempDir,
+      {
+        collectWorkingSet: false,
+        collectRepositoryContext: false,
+        previewSnippetItemCap: PREVIEW_MAX_SNIPPETS,
+      },
+    );
+    const retained = context.relevantSnippets.length;
+    const total = context.relevantSnippetTotal ?? retained;
+    expect(retained).toBe(PREVIEW_MAX_SNIPPETS);
+    expect(total).toBe(77);
+
+    const result = await runPreview(ctx.tempDir, target, {
+      oldString: 'function f0(): void {}',
+      newString: 'function f0(): number { return 1; }',
+    });
+
+    expect(result.error).toBeUndefined();
+    const output = String(result.llmContent);
+    expect(previewLine(output, '- Relevant snippets: ')).toBe(
+      `- Relevant snippets: ${retained} found (capped from ${total})`,
+    );
+  });
+});

--- a/packages/tools/src/tools/ast-edit/__tests__/ast-read-file-bounded-acquire.bun.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-read-file-bounded-acquire.bun.test.ts
@@ -122,7 +122,7 @@ describe('REQ-3232-1: enhanced context repository opt-out', () => {
     expect(output).toContain('other.ts');
   });
 
-  it('ast_edit preview still renders repository context', async () => {
+  it('ast_edit preview also opts out of repository context (issue #3242)', async () => {
     const tool = new ASTEditTool(createFakeToolHost(ctx.tempDir));
     const result = await tool
       .build({
@@ -133,7 +133,8 @@ describe('REQ-3232-1: enhanced context repository opt-out', () => {
       })
       .execute(new AbortController().signal);
     expect(result.error).toBeUndefined();
-    expect(String(result.llmContent)).toContain('- Repository:');
+    expect(String(result.llmContent)).not.toContain('- Repository:');
+    expect(String(result.llmContent)).not.toContain('RELATED SYMBOLS:');
   });
 });
 

--- a/packages/tools/src/tools/ast-edit/ast-config.ts
+++ b/packages/tools/src/tools/ast-edit/ast-config.ts
@@ -54,6 +54,33 @@ export class ASTConfig {
    */
   static readonly MAX_DISPLAY_RESULTS = 5;
 
+  // Section: ast_edit Preview Safety Policies (issue #3242)
+  /**
+   * Maximum declarations rendered by an ast_edit preview, selected by
+   * proximity to the edit's start line (nearest first, rendered in source
+   * order). Internal policy — not a public tool parameter.
+   */
+  static readonly PREVIEW_MAX_DECLARATIONS = 128;
+  /**
+   * Maximum relevant snippets reported by an ast_edit preview.
+   */
+  static readonly PREVIEW_MAX_SNIPPETS = 64;
+  /**
+   * Hard UTF-8 byte budget for the entire ast_edit preview llmContent,
+   * including path, validation, declarations, truncation metadata, timestamp,
+   * and next-step instruction.
+   */
+  static readonly PREVIEW_LLM_MAX_BYTES = 256 * 1024;
+
+  /**
+   * Maximum UTF-8 bytes of the AST validation summary label an ast_edit
+   * preview embeds verbatim in its mandatory status line. The shared
+   * categorizer embeds every diagnostic line number into its labels, so a
+   * label above this allowance is replaced by a fixed-width truthful
+   * classification. Internal policy — not a public tool parameter.
+   */
+  static readonly PREVIEW_VALIDATION_SUMMARY_MAX_BYTES = 512;
+
   static readonly SUPPORTED_LANGUAGES = {
     ts: 'typescript',
     js: 'javascript',

--- a/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
+++ b/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
@@ -39,6 +39,11 @@ import type { ASTEditToolParams } from './types.js';
 import { ASTConfig } from './ast-config.js';
 import type { ASTContextCollector } from './context-collector.js';
 import {
+  assembleBoundedPreview,
+  boundedValidationSummaryLabel,
+  preExistingSyntaxErrorStatus,
+} from './preview-context-policy.js';
+import {
   calculateEdit,
   validateASTSyntax,
   getFileLastModified,
@@ -47,7 +52,6 @@ import {
 import {
   summarizeAstValidation,
   deriveCandidateMapping,
-  findEditStartLine,
   formatValidationLineLabel,
   type AstValidationResult,
   type AstValidationSummary,
@@ -202,9 +206,9 @@ export class ASTEditToolInvocation
     return this.executeApply(signal);
   }
 
-  private async executePreview(_signal: AbortSignal): Promise<ToolResult> {
+  private async executePreview(signal: AbortSignal): Promise<ToolResult> {
     try {
-      const editData = await this.calculateEdit(this.params, _signal);
+      const editData = await this.calculateEdit(this.params, signal);
       if (editData.error) {
         return {
           llmContent: editData.error.raw,
@@ -228,7 +232,20 @@ export class ASTEditToolInvocation
           // REQ-3035-6: previews keep the target file's enhanced context but
           // omit working-set collection/rendering. ast_read_file still collects
           // the working set because it passes no option.
-          { collectWorkingSet: false },
+          // REQ-3242-1: previews also opt out of repository relationship
+          // context (repository metadata, symbol index, and the native
+          // whole-workspace related-symbol fan-out) — a localized exact
+          // replacement is validated against the target file alone, and the
+          // abandoned native traversals cannot be cancelled.
+          // REQ-3242-2: preview retains at most its own snippet policy in
+          // the context itself; the collector records the truthful pre-cap
+          // total for the "(capped from N)" report.
+          {
+            collectWorkingSet: false,
+            collectRepositoryContext: false,
+            previewSnippetItemCap: ASTConfig.PREVIEW_MAX_SNIPPETS,
+            signal,
+          },
         );
 
       const { astValidation, preEditValidation, mapping } =
@@ -250,6 +267,7 @@ export class ASTEditToolInvocation
         preEditValidation,
         mapping,
         currentMtime,
+        editData.editStartLine ?? null,
       );
 
       const returnDisplay: FileDiff = {
@@ -282,10 +300,10 @@ export class ASTEditToolInvocation
     preEditValidation: AstValidationResult | undefined;
     mapping: CandidateMapping;
   } {
-    const editStartLine = findEditStartLine(
-      editData.currentContent,
-      this.params.old_string,
-    );
+    // The anchor is carried from calculateEdit, which computed it against
+    // the same LF-normalized content used for matching, so CRLF old_string
+    // parameters anchor identically to LF ones.
+    const editStartLine = editData.editStartLine ?? null;
     const editRegion =
       editStartLine !== null ? { startLine: editStartLine } : undefined;
     const astValidation =
@@ -318,6 +336,7 @@ export class ASTEditToolInvocation
     preEditValidation: AstValidationResult | undefined,
     mapping: CandidateMapping,
     currentMtime: number | null,
+    editStartLine: number | null,
   ): string {
     const summary = summarizeAstValidation(
       preEditValidation,
@@ -330,59 +349,49 @@ export class ASTEditToolInvocation
         !astValidation.valid &&
         !summary.newlyIntroduced,
     );
-    const preExistingSyntaxErrors = hasOnlyPreExistingSyntaxErrors
-      ? `- Pre-existing syntax errors: Yes${formatValidationLineLabel(astValidation.errors)}`
-      : '';
-    return [
-      `LLXPRT EDIT PREVIEW: ${this.params.file_path}`,
-      `- Context: ${enhancedContext.language} file with ${enhancedContext.declarations.length} declarations`,
-      `- Functions: ${enhancedContext.languageContext.functions.length}`,
-      `- Classes: ${enhancedContext.languageContext.classes.length}`,
-      `- AST validation: ${summary.label}`,
-      preExistingSyntaxErrors,
-      !astValidation.valid
-        ? `- AST errors: ${astValidation.errors.join(', ')}`
-        : '',
-      `- Relevant snippets: ${enhancedContext.relevantSnippets.length} found`,
-      enhancedContext.repositoryContext
-        ? `- Repository: ${enhancedContext.repositoryContext.gitUrl}`
-        : '',
-      enhancedContext.relatedFiles
-        ? `- Related files: ${enhancedContext.relatedFiles.length}`
-        : '',
-      currentMtime !== null ? `- Timestamp: ${currentMtime}` : '',
-      '',
-      'ENHANCED CONTEXT ANALYSIS:',
-      ...enhancedContext.declarations.map(
-        (decl) => `- ${decl.type}: ${decl.name} (line ${decl.line})`,
-      ),
-      this.formatRelatedSymbols(enhancedContext),
-      '',
-      'NEXT STEP: Call again with force: true to apply changes',
-    ]
-      .flat()
-      .filter(Boolean)
-      .join('\n');
-  }
-
-  private formatRelatedSymbols(
-    enhancedContext: Awaited<
-      ReturnType<ASTContextCollector['collectEnhancedContext']>
-    >,
-  ): string[] {
-    if (
-      !enhancedContext.relatedSymbols ||
-      enhancedContext.relatedSymbols.length === 0
-    ) {
-      return [];
-    }
-    return [
-      '',
-      'RELATED SYMBOLS:',
-      ...enhancedContext.relatedSymbols
-        .slice(0, ASTConfig.MAX_DISPLAY_RESULTS)
-        .map((symbol) => `- ${symbol.type}: ${symbol.filePath}:${symbol.line}`),
-    ];
+    // Fixed-width mandatory status (issue #3242): per-error locations live
+    // only in the separately budgeted validation detail, so even tens of
+    // thousands of pre-existing diagnostics cannot expand mandatory,
+    // non-budgetable content.
+    const preExistingSyntaxErrors = preExistingSyntaxErrorStatus(
+      hasOnlyPreExistingSyntaxErrors,
+    );
+    // REQ-3242-2: preview reports the snippet count its context actually
+    // retains, with the truthful pre-cap total the collector recorded.
+    const snippetShown = enhancedContext.relevantSnippets.length;
+    const snippetTotal = enhancedContext.relevantSnippetTotal ?? snippetShown;
+    const snippetLine =
+      snippetTotal > snippetShown
+        ? `- Relevant snippets: ${snippetShown} found (capped from ${snippetTotal})`
+        : `- Relevant snippets: ${snippetShown} found`;
+    // Mandatory status/structure lines are reserved before any variable
+    // detail; REQ-3242-2/3 selection and byte budgeting live in the internal
+    // preview policy. Variable AST validation detail is passed separately so
+    // it is budgeted at whole diagnostic items instead of joining every
+    // diagnostic into an unbounded mandatory line.
+    const bounded = assembleBoundedPreview({
+      mandatoryHead: [
+        `LLXPRT EDIT PREVIEW: ${this.params.file_path}`,
+        `- Context: ${enhancedContext.language} file with ${enhancedContext.declarations.length} declarations`,
+        `- Functions: ${enhancedContext.languageContext.functions.length}`,
+        `- Classes: ${enhancedContext.languageContext.classes.length}`,
+        `- AST validation: ${boundedValidationSummaryLabel(summary)}`,
+        preExistingSyntaxErrors,
+      ].filter(Boolean),
+      validationDetail: astValidation.valid ? [] : astValidation.errors,
+      mandatoryTail: [
+        snippetLine,
+        currentMtime !== null ? `- Timestamp: ${currentMtime}` : '',
+        'ENHANCED CONTEXT ANALYSIS:',
+      ].filter(Boolean),
+      declarations: enhancedContext.declarations,
+      // Deterministic anchor for new-file previews (no old_string to locate).
+      anchorLine: editStartLine ?? 1,
+      mandatorySuffix: [
+        'NEXT STEP: Call again with force: true to apply changes',
+      ],
+    });
+    return bounded.lines.join('\n');
   }
 
   private async executeApply(signal: AbortSignal): Promise<ToolResult> {
@@ -512,10 +521,9 @@ export class ASTEditToolInvocation
     );
     let editStartLine: number | null;
     if (isModelContent) {
-      editStartLine = findEditStartLine(
-        editData.currentContent,
-        this.params.old_string,
-      );
+      // Carried from calculateEdit so CRLF old_string parameters anchor
+      // identically to LF ones (same normalized matching boundary).
+      editStartLine = editData.editStartLine ?? null;
     } else if (
       editData.currentContent !== null &&
       contentToWrite !== editData.currentContent

--- a/packages/tools/src/tools/ast-edit/context-collector.ts
+++ b/packages/tools/src/tools/ast-edit/context-collector.ts
@@ -82,8 +82,37 @@ export interface EnhancedContextOptions {
    * searches are otherwise unobservable dead work with native memory cost.
    */
   collectRepositoryContext?: boolean;
+  /**
+   * Internal preview policy (issue #3242): cap the relevant-snippet items
+   * retained in the returned context at this many policy-ordered items. The
+   * pre-cap total is recorded as `relevantSnippetTotal` on the context so
+   * callers can report a truthful "(capped from N)" count. General callers
+   * (ast_read_file) leave it unset and keep every collected item.
+   */
+  previewSnippetItemCap?: number;
   /** Cancellation signal threaded through LLxprt-owned acquisition. */
   signal?: AbortSignal;
+}
+
+/**
+ * Apply the preview-specific snippet item bound (issue #3242) to a collected
+ * context: the context itself retains at most the caller's policy-ordered
+ * items, releasing the omitted snippet objects, while the truthful pre-cap
+ * total is carried for reporting. Rebinding (not truncating in place) drops
+ * the uncapped array from the returned context entirely.
+ */
+function applyPreviewSnippetCap(
+  context: EnhancedASTContext,
+  snippetItemCap: number | undefined,
+): void {
+  if (
+    snippetItemCap === undefined ||
+    context.relevantSnippets.length <= snippetItemCap
+  ) {
+    return;
+  }
+  context.relevantSnippetTotal = context.relevantSnippets.length;
+  context.relevantSnippets = context.relevantSnippets.slice(0, snippetItemCap);
 }
 
 /**
@@ -149,6 +178,9 @@ export class ASTContextCollector {
       content,
       workspaceRoot,
     );
+
+    // Preview-specific item bound (issue #3242).
+    applyPreviewSnippetCap(enhancedContext, options?.previewSnippetItemCap);
 
     // Phase 2: Working Set Context (Git-based). Suppressed only for callers
     // (ast_edit preview) that opt out; ast_read_file keeps the working set.

--- a/packages/tools/src/tools/ast-edit/edit-calculator.ts
+++ b/packages/tools/src/tools/ast-edit/edit-calculator.ts
@@ -46,6 +46,13 @@ export interface CalculatedEdit {
   astValidation?: AstValidationResult;
   preEditValidation?: AstValidationResult;
   fileFreshness?: number | null;
+  /**
+   * 1-based line where the exact replacement starts, computed once against
+   * the same LF-normalized content used for matching (issue #3242). Null for
+   * new files or when the position cannot be determined; error results may
+   * leave it unset.
+   */
+  editStartLine?: number | null;
 }
 
 /**
@@ -148,10 +155,19 @@ export async function calculateEdit(
       ? validateASTSyntax(params.file_path, currentContent)
       : undefined;
 
+  // Single source of truth for the edit's start line: computed against the
+  // LF-normalized content and old_string used for matching, so CRLF
+  // parameters anchor identically to LF ones (issue #3242).
+  const editStartLine =
+    currentContent !== null && normalizedOldString !== ''
+      ? findEditStartLine(currentContent, normalizedOldString)
+      : null;
+
   let astValidation: AstValidationResult | undefined;
   if (!noChangeError) {
     // Refine whole-file recovery locations using the edited region.
-    const editRegion = buildEditRegion(currentContent, normalizedOldString);
+    const editRegion =
+      editStartLine === null ? undefined : { startLine: editStartLine };
     astValidation = validateASTSyntax(params.file_path, newContent, editRegion);
   }
 
@@ -164,6 +180,7 @@ export async function calculateEdit(
     astValidation,
     preEditValidation,
     fileFreshness: currentMtime,
+    editStartLine,
   };
 }
 
@@ -299,20 +316,6 @@ function checkNoChange(
     };
   }
   return error;
-}
-
-/**
- * Derives the edited region's start line so whole-file tree-sitter recovery
- * can report a useful location. Returns undefined for new files or when the
- * edit position cannot be determined.
- */
-function buildEditRegion(
-  currentContent: string | null,
-  oldString: string,
-): EditRegion | undefined {
-  if (!currentContent || !oldString) return undefined;
-  const startLine = findEditStartLine(currentContent, oldString);
-  return startLine === null ? undefined : { startLine };
 }
 
 /**

--- a/packages/tools/src/tools/ast-edit/preview-context-policy.ts
+++ b/packages/tools/src/tools/ast-edit/preview-context-policy.ts
@@ -1,0 +1,381 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Internal bounding policies for ast_edit preview output (issue #3242).
+ *
+ * Preview describes a localized exact replacement, so its model-facing
+ * context is selected by proximity to the edit's start line and assembled
+ * under a hard UTF-8 byte budget. These are internal safety policies, not
+ * public tool parameters.
+ */
+
+import { Buffer } from 'node:buffer';
+import { ASTConfig } from './ast-config.js';
+import type { AstValidationSummary } from './validation-categorizer.js';
+import type { EnhancedDeclaration } from './types.js';
+
+interface RankedDeclaration {
+  readonly declaration: EnhancedDeclaration;
+  readonly sourceIndex: number;
+}
+
+function sourceOrder(
+  entry: RankedDeclaration,
+  other: RankedDeclaration,
+): number {
+  const byLine = entry.declaration.line - other.declaration.line;
+  if (byLine !== 0) {
+    return byLine;
+  }
+  const byColumn = entry.declaration.column - other.declaration.column;
+  if (byColumn !== 0) {
+    return byColumn;
+  }
+  return entry.sourceIndex - other.sourceIndex;
+}
+
+function proximityOrder(
+  entry: RankedDeclaration,
+  other: RankedDeclaration,
+  anchorLine: number,
+): number {
+  const byDistance =
+    Math.abs(entry.declaration.line - anchorLine) -
+    Math.abs(other.declaration.line - anchorLine);
+  if (byDistance !== 0) {
+    return byDistance;
+  }
+  const byLine = entry.declaration.line - other.declaration.line;
+  if (byLine !== 0) {
+    return byLine;
+  }
+  return entry.sourceIndex - other.sourceIndex;
+}
+
+function renderDeclarationLine(declaration: EnhancedDeclaration): string {
+  return `- ${declaration.type}: ${declaration.name} (line ${declaration.line})`;
+}
+
+function boundedMarkerLine(shown: number, total: number): string {
+  return `- Declarations: bounded preview — showing ${shown} of ${total} (selected nearest to the edit)`;
+}
+
+function utf8Bytes(lines: readonly string[]): number {
+  return Buffer.byteLength(lines.join('\n'), 'utf8');
+}
+
+const VALIDATION_LINE_PREFIX = '- AST errors: ';
+
+/**
+ * Mandatory pre-existing-error status for previews whose only syntax
+ * errors predate the edit. Fixed-width by policy: per-error locations
+ * already live in the separately budgeted validation detail, so even tens
+ * of thousands of pre-existing diagnostics cannot expand non-budgetable
+ * mandatory content past the hard byte budget.
+ */
+export function preExistingSyntaxErrorStatus(
+  hasOnlyPreExistingSyntaxErrors: boolean,
+): string {
+  return hasOnlyPreExistingSyntaxErrors
+    ? '- Pre-existing syntax errors: Yes'
+    : '';
+}
+
+/**
+ * Fixed-width suffix shared by every oversized-label fallback: it states
+ * truthfully that validation locations were dropped for the preview byte
+ * budget. A compile-time constant, so every fallback label is bounded
+ * independent of how many parser diagnostics produced the summary.
+ */
+const OMITTED_VALIDATION_LOCATIONS =
+  '; validation locations omitted for preview byte budget)';
+
+/**
+ * Preview-only bounding policy for the mandatory AST validation summary
+ * line.
+ *
+ * Ordinary (small) labels pass through byte-identical, so preview wording
+ * and semantics are unchanged. The shared categorizer embeds every
+ * diagnostic line number into its labels, so a diagnostic-dense file can
+ * produce a label that alone exceeds the entire PREVIEW_LLM_MAX_BYTES
+ * budget; such a label is mandatory, non-droppable content, so the preview
+ * could never fit. A label above PREVIEW_VALIDATION_SUMMARY_MAX_BYTES is
+ * therefore replaced by a fixed-width truthful classification that
+ * preserves whether the failure is pre-existing, newly introduced, or
+ * mixed (and keeps resolved-pre-existing PASSED as a resolution). No
+ * string is ever sliced, so the result is valid UTF-8 by construction.
+ *
+ * Throws (fail fast) for a categorizer summary the policy cannot
+ * classify truthfully: every SKIPPED label is a fixed short string, and
+ * every FAILED summary carries at least one classification flag, so an
+ * unclassifiable oversized label means the categorizer contract broke and
+ * must surface rather than be silently mislabeled.
+ */
+export function boundedValidationSummaryLabel(
+  summary: AstValidationSummary,
+): string {
+  if (
+    Buffer.byteLength(summary.label, 'utf8') <=
+    ASTConfig.PREVIEW_VALIDATION_SUMMARY_MAX_BYTES
+  ) {
+    return summary.label;
+  }
+  const { status, preExisting, newlyIntroduced } = summary;
+  if (status === 'PASSED') {
+    // The categorizer's only PASSED label that grows with diagnostics is
+    // the resolved-pre-existing one; a plain PASSED label is 6 bytes.
+    return `PASSED (edit resolved pre-existing error${OMITTED_VALIDATION_LOCATIONS}`;
+  }
+  if (status === 'FAILED') {
+    if (preExisting && newlyIntroduced) {
+      return `FAILED (file had pre-existing errors; post-edit errors may be newly introduced${OMITTED_VALIDATION_LOCATIONS}`;
+    }
+    if (preExisting) {
+      return `FAILED (pre-existing error — present before this edit${OMITTED_VALIDATION_LOCATIONS}`;
+    }
+    if (newlyIntroduced) {
+      return `FAILED (new error introduced by this edit${OMITTED_VALIDATION_LOCATIONS}`;
+    }
+  }
+  throw new Error(
+    `ast_edit preview cannot bound a validation summary label it cannot classify (status ${status}, preExisting ${String(preExisting)}, newlyIntroduced ${String(newlyIntroduced)})`,
+  );
+}
+
+function renderValidationLine(
+  detail: readonly string[],
+  shown: number,
+): string {
+  const total = detail.length;
+  if (shown === 0) {
+    return `${VALIDATION_LINE_PREFIX}${total} errors omitted (preview byte budget)`;
+  }
+  const shownText = detail.slice(0, shown).join(', ');
+  if (shown === total) {
+    return `${VALIDATION_LINE_PREFIX}${shownText}`;
+  }
+  return `${VALIDATION_LINE_PREFIX}${shownText} (+${total - shown} more errors omitted; ${total} total)`;
+}
+
+/**
+ * Budget the variable validation detail line: keep whole items (earliest
+ * first) while the frame fits the hard budget, then state truthfully how
+ * many were omitted. Greedy item accumulation gives the estimate; the exact
+ * frame check is authoritative because the omission marker's digit width
+ * can shrink as items are added. Throws when even the minimal truthful
+ * omission line cannot fit.
+ */
+function budgetValidationDetailLine(
+  validationDetail: readonly string[],
+  frameWith: (detailLine: string) => number,
+): string {
+  const itemBytes = validationDetail.map((item) =>
+    Buffer.byteLength(item, 'utf8'),
+  );
+  const available =
+    ASTConfig.PREVIEW_LLM_MAX_BYTES -
+    frameWith(renderValidationLine(validationDetail, 0));
+  let shown = 0;
+  let used = 0;
+  while (
+    shown < itemBytes.length &&
+    used + itemBytes[shown] + (shown > 0 ? 2 : 0) <= available
+  ) {
+    used += itemBytes[shown] + (shown > 0 ? 2 : 0);
+    shown++;
+  }
+  while (
+    shown > 0 &&
+    frameWith(renderValidationLine(validationDetail, shown)) >
+      ASTConfig.PREVIEW_LLM_MAX_BYTES
+  ) {
+    shown--;
+  }
+  if (
+    frameWith(renderValidationLine(validationDetail, shown)) >
+    ASTConfig.PREVIEW_LLM_MAX_BYTES
+  ) {
+    throw new Error(
+      `ast_edit preview cannot fit mandatory content plus validation omission metadata within the ${ASTConfig.PREVIEW_LLM_MAX_BYTES}-byte budget`,
+    );
+  }
+  return renderValidationLine(validationDetail, shown);
+}
+
+export interface BoundedPreviewResult {
+  readonly lines: readonly string[];
+  readonly renderedDeclarations: number;
+  readonly totalDeclarations: number;
+  readonly bounded: boolean;
+}
+
+/** Ordered sections assembled by {@link assembleBoundedPreview}. */
+export interface BoundedPreviewInput {
+  /** Mandatory lines rendered before the validation detail. */
+  readonly mandatoryHead: readonly string[];
+  /**
+   * Variable validation diagnostic detail (one item per diagnostic). The
+   * rendered line keeps whole items while the byte budget allows and then
+   * states truthfully how many were omitted — it never silently claims the
+   * full diagnostic list. Empty for a valid candidate.
+   */
+  readonly validationDetail: readonly string[];
+  /** Mandatory lines rendered after the validation detail. */
+  readonly mandatoryTail: readonly string[];
+  readonly declarations: readonly EnhancedDeclaration[];
+  /** 1-based line where the exact replacement starts. */
+  readonly anchorLine: number;
+  /** Mandatory trailing lines (next-step footer). */
+  readonly mandatorySuffix: readonly string[];
+}
+
+/**
+ * Assemble the declaration section under the hard byte budget. The
+ * complete UNMARKED frame is measured first: an omission marker is
+ * accounted for only once a declaration is actually omitted (by the
+ * PREVIEW_MAX_DECLARATIONS policy or by the byte budget), so a complete
+ * frame that fits never loses a declaration to a marker that would not be
+ * rendered. Once omission is required, the marker is required content and
+ * rendered lines drop farthest-from-edit first (ties drop the later line
+ * first) until the frame fits.
+ */
+function assembleDeclarationFrame(
+  mandatory: readonly string[],
+  selected: readonly RankedDeclaration[],
+  droppable: readonly RankedDeclaration[],
+  totalDeclarations: number,
+  mandatorySuffix: readonly string[],
+): { lines: readonly string[]; rendered: readonly string[] } {
+  let rendered = selected.map((entry) =>
+    renderDeclarationLine(entry.declaration),
+  );
+  if (
+    selected.length === totalDeclarations &&
+    utf8Bytes([...mandatory, ...rendered, ...mandatorySuffix]) <=
+      ASTConfig.PREVIEW_LLM_MAX_BYTES
+  ) {
+    return { lines: [...mandatory, ...rendered, ...mandatorySuffix], rendered };
+  }
+  const dropped = new Set<number>();
+  let marker = boundedMarkerLine(rendered.length, totalDeclarations);
+  while (
+    utf8Bytes([...mandatory, marker, ...rendered, ...mandatorySuffix]) >
+      ASTConfig.PREVIEW_LLM_MAX_BYTES &&
+    dropped.size < selected.length
+  ) {
+    dropped.add(droppable[dropped.size].sourceIndex);
+    rendered = selected
+      .filter((entry) => !dropped.has(entry.sourceIndex))
+      .map((entry) => renderDeclarationLine(entry.declaration));
+    marker = boundedMarkerLine(rendered.length, totalDeclarations);
+  }
+  return {
+    lines: [...mandatory, marker, ...rendered, ...mandatorySuffix],
+    rendered,
+  };
+}
+
+/**
+ * Assemble the preview output lines under the hard UTF-8 byte budget.
+ *
+ * Fixed mandatory lines (status/summary head, snippet/timestamp tail,
+ * next-step footer) are never dropped or split. Variable validation detail
+ * is budgeted first at whole diagnostic items with a truthful omission
+ * marker; declarations are then capped at PREVIEW_MAX_DECLARATIONS by
+ * absolute line distance from the edit anchor (ties break to the earlier
+ * line), rendered back in source order, and — only once an omission is
+ * actually required — dropped farthest-first until the assembled bytes
+ * fit; the complete unmarked frame is always measured before any marker
+ * accounting. No line is ever split, so the result is valid UTF-8 by
+ * construction. Whenever any declaration was omitted (policy cap or byte
+ * budget), the truthful selected/total bounded marker is emitted.
+ *
+ * Throws (fail fast) when the truly fixed mandatory content alone — or the
+ * fixed content plus the minimal truthful omission metadata — cannot fit
+ * the budget: such a preview must surface as an error, never as an
+ * over-budget success.
+ */
+export function assembleBoundedPreview(
+  input: BoundedPreviewInput,
+): BoundedPreviewResult {
+  const {
+    mandatoryHead,
+    validationDetail,
+    mandatoryTail,
+    declarations,
+    anchorLine,
+    mandatorySuffix,
+  } = input;
+
+  const fixedMandatory = [
+    ...mandatoryHead,
+    ...mandatoryTail,
+    ...mandatorySuffix,
+  ];
+  if (utf8Bytes(fixedMandatory) > ASTConfig.PREVIEW_LLM_MAX_BYTES) {
+    throw new Error(
+      `ast_edit preview fixed mandatory content (${utf8Bytes(fixedMandatory)} bytes) alone exceeds the ${ASTConfig.PREVIEW_LLM_MAX_BYTES}-byte budget`,
+    );
+  }
+
+  // Worst-case declaration framing: once the byte budget forces every
+  // declaration line out, the truthful bounded marker remains.
+  const emptyMarker =
+    declarations.length > 0 ? [boundedMarkerLine(0, declarations.length)] : [];
+  const frameWith = (detailLine: string): number =>
+    utf8Bytes([
+      ...mandatoryHead,
+      detailLine,
+      ...mandatoryTail,
+      ...emptyMarker,
+      ...mandatorySuffix,
+    ]);
+
+  const validationLines =
+    validationDetail.length > 0
+      ? [budgetValidationDetailLine(validationDetail, frameWith)]
+      : [];
+
+  const ranked = declarations
+    .map((declaration, sourceIndex) => ({ declaration, sourceIndex }))
+    .sort(sourceOrder);
+  const byProximity = [...ranked].sort((entry, other) =>
+    proximityOrder(entry, other, anchorLine),
+  );
+  const selectedByProximity = byProximity.slice(
+    0,
+    ASTConfig.PREVIEW_MAX_DECLARATIONS,
+  );
+  const selected = [...selectedByProximity].sort(sourceOrder);
+  // Drop order is the reverse of proximity selection (farthest first).
+  const droppable = [...selectedByProximity].reverse();
+  const mandatory = [...mandatoryHead, ...validationLines, ...mandatoryTail];
+
+  const { lines, rendered } = assembleDeclarationFrame(
+    mandatory,
+    selected,
+    droppable,
+    declarations.length,
+    mandatorySuffix,
+  );
+  const bounded = rendered.length < declarations.length;
+
+  // Authoritative final measurement: the drop loop above can exhaust every
+  // selected declaration while the required bounded marker still does not
+  // fit, so the assembled frame is re-measured and refused rather than
+  // returned as an over-budget success.
+  if (utf8Bytes(lines) > ASTConfig.PREVIEW_LLM_MAX_BYTES) {
+    throw new Error(
+      `ast_edit preview cannot fit mandatory content plus declaration omission metadata within the ${ASTConfig.PREVIEW_LLM_MAX_BYTES}-byte budget`,
+    );
+  }
+
+  return {
+    lines,
+    renderedDeclarations: rendered.length,
+    totalDeclarations: declarations.length,
+    bounded,
+  };
+}

--- a/packages/tools/src/tools/ast-edit/types.ts
+++ b/packages/tools/src/tools/ast-edit/types.ts
@@ -218,6 +218,13 @@ export interface EnhancedASTContext extends ASTContext {
   crossFileContext?: CrossFileContext;
   connectedFiles?: readonly ConnectedFile[];
   workingSetStatus?: WorkingSetAcquisitionStatus;
+  /**
+   * Original relevant-snippet count before a caller-specific preview item cap
+   * was applied (issue #3242). Present only when snippets were capped, so
+   * reporting can state a truthful "(capped from N)" total while
+   * `relevantSnippets` holds only the bounded collection.
+   */
+  relevantSnippetTotal?: number;
 }
 
 // ===== Simplified Parameter Interfaces =====

--- a/project-plans/issue3242/plan.md
+++ b/project-plans/issue3242/plan.md
@@ -1,0 +1,218 @@
+# Plan: Bound `ast_edit` Preview Context and Eliminate Native Repository Fan-Out (Issue #3242)
+
+Plan ID: PLAN-20260818-ISSUE3242
+Generated: 2026-08-18
+Issue: #3242
+
+## Problem statement
+
+A localized `ast_edit` preview on a 5,242-line, symbol-dense Rust file in `acoliver/worldviewer` rendered all 173 declarations. The preview also started up to five concurrent whole-workspace native `findInFiles` traversals. Those traversals ignored `.gitignore` and `.llxprtignore`, had no per-file size gate, and were abandoned by a JavaScript timeout without cancellation. Native work could therefore continue after preview returned and overlap the immediately following `force=true` apply. The incident exhausted host RAM and the execution environment died while the apply surfaced as `null`.
+
+The target file's local declarations and preview text are not large enough to explain host-level OOM by themselves. The confirmed amplification is repository relationship analysis inherited from `ASTContextCollector.collectEnhancedContext()`. This is the same fan-out removed from `ast_read_file` by issue #3232, except `ast_edit` preview still enables it.
+
+## Preflight findings
+
+1. `ASTEditToolInvocation.executePreview()` calls `collectEnhancedContext()` with `collectWorkingSet: false` but leaves `collectRepositoryContext` at its default `true`.
+2. Repository collection obtains Git metadata, chooses up to five target declarations, and starts one `findRelatedSymbols()` search per symbol concurrently.
+3. Each all-language relationship search enumerates the workspace independently. Its ignore list contains only `node_modules`, `dist`, and `build`; Git and LLxprt ignore rules are not consulted.
+4. The 10,000-file guard is applied only after enumeration. Files selected for native parsing have no per-file size gate.
+5. The three-second relationship timeout is a non-cancelling `Promise.race`. Native traversal can continue after the returned promise settles and overlap the next tool invocation.
+6. `executeApply()` performs `calculateEdit()` and writes the candidate. It does not collect enhanced context, rebuild a repository index, or retain a preview cache. The issue hypothesis that force mode duplicates a cached preview analysis is rejected. The cross-call retention is unfinished native work started by preview.
+7. Preview renders every extracted declaration. It has no edit-line proximity selection and no model-facing byte cap.
+8. The optimized local snippet collection already has a 1,000-character source budget, but preview reports its item count without a preview-specific item cap.
+9. Every normal tool path returns a `ToolResult`; no `ast_edit` code path returns `null`. The observed `null` is consistent with process/host death outside normal return handling.
+10. `ToolErrorType` has no resource-exhaustion member. An RSS watermark cannot guarantee recovery from native OOM: a pre-check cannot predict a later allocation, and a post-check runs too late. The accepted fix removes the unbounded producer and proves bounded process behavior instead of adding a speculative threshold.
+11. LLxprt Code's largest current TypeScript source files are roughly 1,100–1,500 lines, while the incident file is over 5,200 lines. Preview limits must remain useful for LLxprt Code, LLxprt Jefe, and Worldviewer rather than adopting the issue's illustrative small defaults verbatim.
+
+## Accepted behavior
+
+### REQ-3242-1: Preview repository relationship fan-out is unreachable
+
+**Full text:** `ast_edit` preview must not collect repository metadata, build a workspace symbol index, enumerate the workspace for related symbols, or launch native related-symbol searches. The preview does not require repository-wide relationships to validate or describe a localized exact replacement, and the current native producer cannot be cancelled safely.
+
+- GIVEN a Git workspace containing many related symbols, ignored trees, and oversized source files
+- WHEN a real `ast_edit` preview runs
+- THEN it performs target-file analysis only
+- AND no repository-relationship Git commands or native relationship traversal are started
+- AND no preview-owned repository work remains active after the result resolves
+- AND apply semantics remain unchanged
+
+This requirement satisfies the issue's ignored/oversized-file safety criterion by making those files unreachable from preview repository analysis, rather than adding another ignore implementation around an uncancellable producer.
+
+### REQ-3242-2: Declaration context is proximity-prioritized and bounded
+
+**Full text:** Preview must render a deterministic, source-ordered subset of declarations selected by distance from the exact replacement's start line. It must retain enough context for large LLxprt/Jefe/Worldviewer-style files while preventing whole-file symbol-table output.
+
+The initial internal policies are:
+
+- at most **128 rendered declarations**;
+- nearest declarations are selected by absolute line distance from the edit start;
+- selected declarations are rendered in source order;
+- an exact 128-declaration file is complete;
+- a file with 129 or more declarations is explicitly marked bounded and reports selected versus total counts;
+- at most **64 relevant snippets** are retained/reported for preview;
+- small files within the policies retain their existing complete context behavior.
+
+These values deliberately scale above the issue's illustrative 32-declaration/12-snippet suggestion. They are internal safety policies, not public settings or schema.
+
+- GIVEN the synthetic 5,250-line Rust regression file with at least 170 declarations
+- WHEN a localized edit is previewed near the middle, head, or tail
+- THEN declarations nearest the edit are selected first
+- AND no more than 128 are rendered
+- AND unrelated declarations outside the selected neighborhood are absent
+- AND the rendered declaration lines remain source ordered
+- GIVEN 128 declarations
+- WHEN preview runs
+- THEN all 128 are available and no bounded marker is emitted
+- GIVEN 129 declarations
+- WHEN preview runs
+- THEN only 128 are emitted and the bounded marker is present
+- GIVEN a new or declaration-free file
+- WHEN preview runs
+- THEN preview succeeds with zero declaration context
+
+A blanket `selected == all declarations` fallback is not accepted: for ordinary files below the policy, all declarations are finite and useful. The reproduction is bounded because its total exceeds the policy.
+
+### REQ-3242-3: Model-facing preview content has a hard UTF-8 byte budget
+
+**Full text:** `ToolResult.llmContent` for preview must never exceed **256 KiB UTF-8**, including path, validation errors, summary, declarations, truncation metadata, timestamp, and next-step instruction. Mandatory status and next-step lines take priority over optional declaration detail.
+
+The 256 KiB policy replaces the issue's illustrative 64 KiB suggestion so previews remain useful for large production codebases while staying tiny relative to the memory incident. It applies to model-facing text, not `returnDisplay`: the existing diff display intentionally carries the current/candidate content needed by confirmation UI and remains subject to the existing 20 MiB target-file gate.
+
+- GIVEN ordinary content below the budget
+- WHEN preview runs
+- THEN wording and detail remain compatible
+- GIVEN declaration names, paths, or validation detail that would cross the budget
+- WHEN preview is assembled
+- THEN optional context is omitted deterministically
+- AND the result includes a bounded marker
+- AND the complete UTF-8 `llmContent` is at most 262,144 bytes
+- AND the timestamp and apply instruction remain present
+- GIVEN multibyte text at the boundary
+- WHEN preview is assembled
+- THEN truncation never splits a UTF-8 sequence
+
+### REQ-3242-4: Preview followed immediately by force apply completes and drains
+
+**Full text:** A real preview followed immediately by `force=true` against the same generated large file/workspace must complete normally, apply the exact requested change, and leave no repository traversal allocating after either result.
+
+- GIVEN the 5,250-line, at-least-170-symbol Rust fixture in a fan-out-shaped Git workspace
+- WHEN preview runs and force apply follows immediately with the preview timestamp
+- THEN preview returns a non-null `ToolResult` without error
+- AND apply returns a non-null success `ToolResult`
+- AND the requested bytes are present on disk
+- AND peak child-process RSS stays below the established cross-platform safety ceiling
+- AND post-result RSS growth stays below the quiet-window ceiling
+- AND the child exits normally
+
+The child-process memory test is the behavioral substitute for the impossible claim that CI can induce a true machine OOM and still assert a structured return. It proves the actual incident path is bounded and drained without endangering the test host.
+
+### REQ-3242-5: Existing preview/apply validation and failure behavior is preserved
+
+**Full text:** Bounding context must not weaken exact-match validation, AST validation, file freshness, new-file preview, or apply refusal behavior.
+
+- absent `old_string` still returns `EDIT_NO_OCCURRENCE_FOUND` and performs no write;
+- missing files with non-empty `old_string` still return `FILE_NOT_FOUND`;
+- stale `last_modified` still blocks apply;
+- newly introduced syntax errors still block apply and preserve file bytes;
+- pre-existing syntax errors remain categorized rather than treated as newly introduced;
+- new-file preview/apply remains supported;
+- files rejected by the existing target-file size gate still return its structured `FILE_TOO_LARGE` error.
+
+## Inputs and boundary matrix
+
+| Input/boundary | Expected behavior | Evidence |
+| --- | --- | --- |
+| 5,250-line Rust file, >=170 declarations, middle edit | nearest <=128 declarations, source ordered, bounded marker | real-tool regression test |
+| Same fixture, edit near head | head-adjacent declarations selected | real-tool regression test |
+| Same fixture, edit near tail | tail-adjacent declarations selected | real-tool regression test |
+| 128 declarations | complete context, no bounded marker | exact-limit real-tool test |
+| 129 declarations | 128 rendered, bounded marker | one-over real-tool test |
+| Sparse declarations | nearest declarations win even across large line gaps | real-tool test |
+| Tied distances | deterministic line-order tie break | focused selection test through preview output |
+| No declarations/new file | zero context, valid preview | existing plus extended real-tool tests |
+| Multibyte names/detail at byte edge | valid UTF-8 <=256 KiB, mandatory footer retained | byte-boundary test |
+| Git workspace with ignored/oversized related files | no repository relationship commands/traversal | invocation-wiring canary plus memory fixture |
+| Preview then force apply | both non-null; apply succeeds; content correct | real-tool integration test |
+| Fan-out-shaped workspace | bounded peak RSS and post-result drain | cross-platform child-process test |
+| Absent match/stale timestamp/new syntax error | existing typed failures preserved | existing force/preview suites |
+
+## Test-first implementation sequence
+
+### Phase 1: Repository fan-out opt-out
+
+1. Add a failing invocation-wiring test around the real `ASTEditTool` proving preview starts no repository relationship phase. Reuse the issue #3232 Git-command canary pattern where supported.
+2. Add a safe child-process regression workspace containing many related files plus ignored/oversized trees. Record peak RSS and a post-result quiet window for preview followed by apply.
+3. Make preview pass `collectRepositoryContext: false` and thread its existing signal through collector options.
+4. Run the focused tests and record RED/GREEN behavior.
+
+### Phase 2: Scaled proximity and item bounds
+
+1. Add the deterministic ~5,250-line Rust fixture generator with at least 170 real Rust declarations and unique edits at middle/head/tail.
+2. Add failing behavioral assertions for proximity priority, source order, 128 exact/one-over behavior, 64 snippet cap, and bounded metadata.
+3. Implement the smallest internal selection helper used by preview assembly. Keep policy internal; do not add tool parameters or public configuration.
+4. Preserve complete small-file output behavior where it fits the policies.
+
+### Phase 3: UTF-8 output budget and preview/apply integration
+
+1. Add failing ordinary, over-budget, and multibyte-boundary tests asserting total `llmContent` bytes and mandatory lines.
+2. Implement budget-aware preview assembly that reserves mandatory status/footer bytes before adding optional declaration detail.
+3. Add the real preview-then-force apply case using the preview timestamp and verify exact file content.
+4. Run all AST-edit suites, including existing validation and force-flag tests.
+
+### Phase 4: Full verification and review remediation
+
+1. Run the complete repository verification cycle.
+2. Run a clean DeepThinker issue/compliance review and Open Code Review.
+3. Classify every finding as `Blocker-Fix`, `In-scope-Fix`, `Reject`, or `Defer`. A suggestion does not expand scope.
+4. Remediate all Blocker-Fix and In-scope-Fix findings test-first and repeat the full verification cycle. Use no more than two local OCR runs.
+5. Create the PR only from the verified candidate, then watch all CI and CodeRabbit checks, triage every finding, and use no more than two PR OCR runs.
+
+## Behavioral evidence required for completion
+
+1. A generated Rust fixture is approximately 5,250 lines and has at least 170 declarations as parsed by the real extractor.
+2. Its preview contains only proximity-selected declarations, respects 128/64 item policies, is source ordered, and carries truthful bounded metadata.
+3. Preview `llmContent` is valid UTF-8 and no larger than 256 KiB, including an over-budget regression case.
+4. Preview starts no repository relationship analysis, so ignored and oversized repository files cannot be read by that phase.
+5. Preview followed by force apply succeeds and writes the exact intended bytes.
+6. The safe child-process regression stays below the calibrated cross-platform peak RSS ceiling, shows bounded post-result growth, and exits normally.
+7. Existing typed target-file resource failures and edit/validation failures remain intact; normal tool code never returns `null`.
+8. Focused tests, full local verification, CI, reviews, ancestry, and conflict checks all pass on the candidate head.
+
+## Explicitly rejected hypotheses and changes
+
+- **Reject:** adding preview-cache eviction. No preview analysis cache exists, and apply does not rebuild enhanced context.
+- **Reject:** a JavaScript timeout around native `findInFiles`. The existing timeout abandons waiting but does not cancel native work.
+- **Reject:** a heap-only or RSS watermark advertised as an OOM guarantee. It cannot reliably predict or catch process-killing native allocation and would add platform-sensitive behavior without fixing the producer.
+- **Reject:** general repair of `CrossFileRelationshipAnalyzer`, repository ignore semantics, or native cancellation. Preview will not call that subsystem. Redesigning it for other consumers is separate scope.
+- **Reject:** a new public setting, schema, dependency, workflow, or agent-memory change.
+- **Reject:** shrinking the established 20 MiB target-file limit or changing diff/confirmation display payloads.
+- **Defer:** improving repository relationship analysis for callers that intentionally consume it.
+
+## Scope boundaries
+
+- No general AST collector rewrite.
+- No changes to `ast_read_file`, bounded working-set acquisition, providers, UI, or unrelated tools.
+- No public tool parameter or output-type changes.
+- No dependency, lockfile, workflow, quality-rule, lint-threshold, ignore-rule, or `.llxprt` change.
+- No speculative cleanup of local AST node/snippet duplication unless a failing accepted-behavior test proves it is required.
+- No attempt to induce actual machine OOM in tests.
+
+## Verification commands
+
+```bash
+bun test packages/tools/src/tools/ast-edit/__tests__/ast-edit-3242-regression.bun.test.ts
+bun test packages/tools/src/tools/ast-edit/__tests__/ast-edit-preview.test.ts
+bun test packages/tools/src/tools/ast-edit/__tests__/ast-edit-preview-gaps.test.ts
+bun test packages/tools/src/tools/ast-edit/__tests__/ast-edit-force-flag.test.ts
+bun test packages/tools/src/tools/ast-edit/
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+git diff --check
+```
+
+Before pushing and before creating the PR, repeat the full verification cycle. After PR creation, wait for every required check, resolve all actionable review threads, verify correct ancestry and conflict-free status, and stop when the PR is green and ready to merge. Do not merge without explicit user instruction.


### PR DESCRIPTION
## TLDR

Prevents `ast_edit` preview from launching repository-wide native relationship searches and bounds model-facing preview context on large, symbol-dense files. Preview now stays target-file-local, selects declarations nearest the edit, retains bounded snippet context, caps successful `llmContent` at 256 KiB UTF-8, and returns a structured preparation error if mandatory content cannot fit. The separate `force=true` apply path keeps its existing behavior.

## Dive Deeper

The incident was caused by preview inheriting repository relationship analysis from `ASTContextCollector`. That path could start several uncancellable native whole-workspace searches; a preview result did not mean those searches had drained, so an immediate force apply could overlap outstanding native work and exhaust host memory.

This change removes that producer from `ast_edit` preview instead of adding a timeout or speculative heap watermark:

- disables working-set and repository relationship collection for preview while preserving target-file AST analysis;
- threads the invocation abort signal through context collection;
- calculates the normalized edit anchor once, including CRLF inputs;
- selects at most 128 declarations by absolute line distance, with deterministic earlier-line ties, then renders them in source order;
- retains at most 64 relevant snippets while preserving the truthful pre-cap total;
- caps the complete successful preview `llmContent` at 262,144 UTF-8 bytes, including validation detail, omission metadata, timestamp, and next-step footer;
- drops optional detail as whole lines and never splits multibyte text;
- returns non-null `EDIT_PREPARATION_FAILURE` output when mandatory truthful content cannot fit;
- leaves `returnDisplay`, the existing 20 MiB target-file gate, and force/apply semantics unchanged.

The 256 KiB output policy is intentionally larger than the issue body's illustrative 64 KiB suggestion. The issue author noted that 64 KiB seemed conservative/dated; 256 KiB remains finite while supporting LLxprt Code, LLxprt Jefe, and Worldviewer-scale sources.

Regression coverage uses a deterministic 5,250-line Rust fixture with 184 real extracted declarations plus a fan-out-shaped Git workspace containing 1,500 dependency files, ignored content, and an oversized source. Child-process tests cover preview followed immediately by timestamped force apply through the same registered tool instance, exact bytes on disk, bounded peak/final RSS, bounded post-result growth, quiet-window drain, and a zero-Git-command preview canary.

## Reviewer Test Plan

1. Run `bun test packages/tools/src/tools/ast-edit/`.
2. Inspect the issue-specific suites:
   - `ast-edit-3242-regression.bun.test.ts` for head/middle/tail proximity, exact 128 vs. 129+, deterministic same-line ties, UTF-8 limits, new/declaration-free files, and preview-to-apply behavior;
   - `ast-edit-3242-review.bun.test.ts` for mandatory-byte boundaries, diagnostics, CRLF anchors, retained snippet limits, truthful metadata, and structured failures;
   - `ast-edit-3242-memory.bun.test.ts` for the real child-process RSS/drain regression and repository-wiring canary.
3. Run the quality gates: `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build`.
4. Optionally exercise `ast_edit` manually on a large Rust file: preview a localized middle-file replacement, confirm only nearby declarations are shown, then apply using the preview timestamp.

Local candidate evidence:

- AST-edit suite: 339 passed, 0 failed, 1,291 expectations.
- `npm run lint`: passed.
- `npm run typecheck`: passed.
- `npm run format`: passed and left the committed tree clean.
- `npm run build`: passed.
- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`: passed.
- Fresh full `npm run test` reported no issue #3242 failures. It reproduced four pre-existing macOS/Homebrew ripgrep resolver failures from the unchanged base. Under concurrent load from another checkout, two unrelated agents tests also reached their 180-second limits; both complete files passed immediately when rerun sequentially in isolation (9 tests total). No unrelated core or agents code is changed here.
- The final test-only follow-up removes the issue diff's dynamic `new RegExp(...)` while retaining deterministic snippet-count assertions. This addresses the CodeQL `RegExpInjection` query path isolated from the prior timed-out scans without changing product behavior or security thresholds.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️ Scoped tests and all quality/build/smoke gates pass; full-suite baseline/load caveats documented above | ✅ CI | ✅ CI |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ✅ CI |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - AST edit previews now use bounded output with clear omission counts and fixed-size diagnostic summaries.
  - Previews omit repository relationship context while retaining relevant declarations and snippets.
  - Edit validation is more consistent for CRLF content and preview-to-apply workflows.
  - Memory usage is monitored and constrained during large workspace edits.

- **Bug Fixes**
  - Improved edit anchoring, declaration selection, syntax reporting, and oversized preview handling.
  - Force-apply now reliably uses the preview timestamp and requested replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->