### PR TITLE
Retry sandbox image npm installs on transient network failures (Fixes #3241)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,16 @@ COPY --chown=node:node packages/cli/dist/vybestack-llxprt-code-*.tgz /tmp/
 # Install packages globally
 # Install all local tarballs in one transaction so unpublished package versions
 # satisfy each other without falling back to the npm registry.
-RUN npm install -g \
+# Nightly 2026-08-18 (issue #3241) lost the whole release when a transient
+# `npm error code ECONNRESET` killed this install on the QEMU-emulated arm64
+# leg. The bounded retry below rides out such transient network failures;
+# retries are cheap because npm's cache inside this layer already holds what
+# earlier attempts fetched.
+RUN export npm_config_fetch_retries=5 \
+      npm_config_fetch_retry_mintimeout=1000 \
+      npm_config_fetch_retry_maxtimeout=60000; \
+    attempts=0; \
+    until npm install -g \
       /tmp/vybestack-llxprt-code-tools-*.tgz \
       /tmp/vybestack-llxprt-code-storage-*.tgz \
       /tmp/vybestack-llxprt-code-auth-*.tgz \
@@ -86,15 +95,38 @@ RUN npm install -g \
       /tmp/vybestack-llxprt-code-core-*.tgz \
       /tmp/vybestack-llxprt-code-providers-*.tgz \
       /tmp/vybestack-llxprt-code-agents-*.tgz \
-      /tmp/vybestack-llxprt-code-*.tgz && \
+      /tmp/vybestack-llxprt-code-*.tgz; do \
+      attempts=$((attempts + 1)); \
+      if [ "$attempts" -ge 3 ]; then \
+        echo "npm install of release tarballs failed after $attempts attempts" >&2; \
+        exit 1; \
+      fi; \
+      echo "npm install attempt $attempts failed; retrying in 15s" >&2; \
+      sleep 15; \
+    done && \
     npm cache clean --force && \
     rm -f /tmp/*.tgz
 
 
 # Install experimental UI package into the sandbox so --experimental-ui works.
 # If it's not available on the registry yet (e.g. nightlies), users can still
-# mount/install it manually.
-RUN npm install -g @vybestack/llxprt-ui && npm cache clean --force
+# mount/install it manually. This install streams straight from the registry
+# and can hit the same transient network resets as the tarball install
+# (issue #3241), so it gets the same bounded retry.
+RUN export npm_config_fetch_retries=5 \
+      npm_config_fetch_retry_mintimeout=1000 \
+      npm_config_fetch_retry_maxtimeout=60000; \
+    attempts=0; \
+    until npm install -g @vybestack/llxprt-ui; do \
+      attempts=$((attempts + 1)); \
+      if [ "$attempts" -ge 3 ]; then \
+        echo "npm install of @vybestack/llxprt-ui failed after $attempts attempts" >&2; \
+        exit 1; \
+      fi; \
+      echo "npm install of @vybestack/llxprt-ui attempt $attempts failed; retrying in 15s" >&2; \
+      sleep 15; \
+    done && \
+    npm cache clean --force
 
 # default entrypoint when none specified
 CMD ["llxprt"]

--- a/project-plans/issue3241/plan.md
+++ b/project-plans/issue3241/plan.md
@@ -1,0 +1,166 @@
+# Issue #3241 — Nightly release fails: sandbox image build dies on transient npm ECONNRESET
+
+## Summary
+
+The nightly release for `v0.11.0-nightly.260818.57578c985` (run
+[32085249582](https://github.com/vybestack/llxprt-code/actions/runs/32085249582))
+failed in the **Build and push sandbox image** step roughly 59 minutes into
+the job — after all npm publishes had already succeeded — so the release
+also lost the GitHub release/tag, Homebrew update, and VS Code marketplace
+publishing that follow the image build.
+
+## Root cause (from the failed run log)
+
+The release workflow builds the sandbox image for two platforms
+(`linux/amd64,linux/arm64`). The arm64 leg is executed under QEMU
+emulation (`/dev/.buildkit_qemu_emulator`), which is slow — the tarball
+install alone ran ~4 minutes. `Dockerfile` line 77 runs a single
+transactional install of all 12 local tarballs:
+
+```dockerfile
+RUN npm install -g \
+      /tmp/vybestack-llxprt-code-tools-*.tgz \
+      ... (11 more tarballs) ... && \
+    npm cache clean --force && \
+    rm -f /tmp/*.tgz
+```
+
+The local tarballs satisfy the workspace-internal dependencies, but all
+transitive dependencies still stream from the npm registry over the
+network. At t≈238.8s the arm64 leg hit a transient connection reset:
+
+```
+#43 238.8 npm error code ECONNRESET
+#43 238.8 npm error syscall read
+#43 238.8 npm error errno -104
+#43 238.8 npm error network read ECONNRESET
+```
+
+npm exited, buildkit reported the RUN as `exit code: 152`, and nothing at
+any layer retried — one reset TCP connection aborted the entire release.
+npm's built-in fetch retries (default 2) either were exhausted or could
+not apply (make-fetch-happen cannot retry once the response body has
+started streaming; a mid-read reset is terminal for that fetch).
+
+The same un-retried network exposure exists in the later
+`RUN npm install -g @vybestack/llxprt-ui && npm cache clean --force`
+step, which installs straight from the registry.
+
+Prior nightly failures (Aug 6/11/12) were in *different* steps
+(preflight checks, release tag creation); this Dockerfile failure mode is
+new but the class of failure — transient network error, zero retries,
+whole nightly lost — is what this fix removes.
+
+## Fix design
+
+Scope: the root `Dockerfile` only (it is consumed solely by the
+`release.yml` "Build and push sandbox image" step; `build_sandbox.ts`
+passes it to `docker build` unchanged). No workflow restructuring, no new
+actions — the retry lives at the layer where the transient failure
+occurs, so local sandbox builds benefit identically.
+
+1. **Bounded retry loop around the tarball install** — keep the single
+   transactional `npm install -g` (all 12 tarballs in one command), wrap
+   it in an `until` loop with a maximum of 3 attempts and a 15s sleep
+   between attempts, `exit 1` when attempts are exhausted. `npm cache
+   clean --force` and `rm -f /tmp/*.tgz` still run only after a
+   successful install. Retries inside the same RUN layer reuse npm's
+   local cache, so repeat attempts are much cheaper than the first.
+
+2. **Bounded retry loop around the `@vybestack/llxprt-ui` install** —
+   same pattern (3 attempts, 15s backoff), preserving `npm cache clean
+   --force` after success.
+
+3. **Harden npm's own fetch retries** for both install commands via
+   inline `npm_config_fetch_retries=5`,
+   `npm_config_fetch_retry_mintimeout=1000`,
+   `npm_config_fetch_retry_maxtimeout=60000` exported at the top of each
+   RUN (scoped to the RUN; does not alter runtime npm behavior for
+   sandbox users). This covers fetch-level retryable errors; the outer
+   loop covers mid-body resets and hard registry outages.
+
+## Tests (test-first; bun + bun:test only)
+
+New file `scripts/tests/issue-3241-dockerfile-npm-retry.bun.test.ts`
+(follows the established `issue-2903-dockerfile-apt-packages.bun.test.ts`
+pattern: read the real root `Dockerfile`, no fixtures/mocks of the thing
+under test):
+
+- **Behavioral execution**: extract the actual RUN script text from the
+  Dockerfile, remap `/tmp/` to a test-owned temp directory (assert the
+  remap actually matched, so the test fails loudly if the Dockerfile
+  drifts), shim `npm` and `sleep` via `PATH` (network and timing are
+  infrastructure), and execute the script with `/bin/sh`:
+  - npm fails twice (simulated ECONNRESET exit 1) then succeeds → script
+    exits 0, `npm install` invoked exactly 3 times, cache-clean runs
+    exactly once, tgz files removed only on the success path.
+  - npm always fails → script exits nonzero after exactly 3 install
+    attempts; cache-clean never runs.
+  - Same behavioral coverage for the `@vybestack/llxprt-ui` RUN script.
+- **Static invariants**: retry bound (`3` attempts) and backoff sleep are
+  present in both RUN scripts; all 12 tarballs remain inside the single
+  `until npm install -g` transaction.
+
+Update the existing invariant test in
+`scripts/tests/release-process-b.test.ts` ("installs local tarballs in
+one npm transaction") — its slice anchors on the literal `RUN npm
+install -g`, which becomes `RUN export ...; until npm install -g ...`.
+Preserve every existing assertion intent (single transaction, all 12
+tarballs, no second tarball install).
+
+Also add the new test file to the `tsconfig.scripts.json` include list
+so it is covered by `npm run typecheck` (that project enumerates test
+files explicitly; the issue-2903 sibling predates the enumeration and
+is itself missing, which is out of scope here).
+
+## Verification cycle
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, and the smoke test
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+
+## Out of scope
+
+- Workflow-level retries of the build-push step (Dockerfile retry covers
+  the observed failure at the correct layer).
+- Pre-existing failures in other steps (Aug 6/11/12 runs).
+- Vendoring transitive deps to make the image build fully offline.
+
+## Implementation deviations
+
+- The behavioral tests' `/tmp/` remap guard (`replacement count > 0`) is
+  asserted only for the tarball-install RUN. The `@vybestack/llxprt-ui` RUN
+  script contains no `/tmp/` references at all (per the exact Dockerfile
+  shape above), so a `> 0` assertion there could never pass; the remap is
+  still applied defensively, and the install-count assertions (exactly 3)
+  are what keep the ui scenarios from testing nothing.
+
+## Review remediations (deepthinker, post-implementation)
+
+- **Windows safety**: the two behavioral `/bin/sh` suites in
+  `issue-3241-dockerfile-npm-retry.bun.test.ts` now run under a
+  `describePosixOnly` guard (`process.platform === 'win32' ? describe.skip
+  : describe`, mirroring `issue-2978-oven-fallback.bun.test.ts`) because the
+  nightly scripts shard executes on windows-latest and stock Windows has no
+  `/bin/sh` or colon-PATH shims. The static invariant suites still run on
+  every platform.
+- **Temp-dir cleanup**: `executeRunScript` now removes its work directory in
+  a `finally` block so a spawn/read throw cannot leak it.
+- **Clean full-suite result**: the four extra agents full-suite timeouts
+  observed under load (mutationCoverage.behavior, core-history,
+  createAgent.harness, hooks) all passed in isolation for the reviewer;
+  authoritative CI on the PR is the clearing evidence.
+
+## Review remediations (ocr, post-deepthinker)
+
+- **Exhaustion exit-code precision**: both behavioral exhaustion tests now
+  assert `expect(result.exitCode).toBe(1)` instead of `not.toBe(0)`; a
+  signal-killed child (`exitCode === null`) can no longer masquerade as the
+  expected controlled `exit 1` failure.
+- **Structural invariants de-literalized**: the static retry-structure suite
+  now uses whitespace/backslash-tolerant regexes for the attempt increment,
+  the `-ge 3` bound, and `sleep <n>` (keeping `exit 1` as a containment
+  check), so semantically equivalent refactors of the Dockerfile retry loop
+  no longer red-fail the suite. The suite is retained (not deleted) because
+  the behavioral suites skip on Windows; on the windows-latest nightly
+  scripts shard the static suite is the only structural guard.

--- a/scripts/tests/issue-3241-dockerfile-npm-retry.bun.test.ts
+++ b/scripts/tests/issue-3241-dockerfile-npm-retry.bun.test.ts
@@ -1,0 +1,419 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3241: the nightly release died in "Build and push sandbox image"
+ * when a transient `npm error code ECONNRESET` (mid-body connection reset on
+ * the arm64 leg under QEMU) killed the single, un-retried
+ * `npm install -g /tmp/*.tgz ...` layer. Nothing at any layer retried, so one
+ * reset TCP connection aborted the entire release. The later
+ * `npm install -g @vybestack/llxprt-ui` layer had the identical exposure.
+ *
+ * These tests read the repository's actual root `Dockerfile` (no fixture, no
+ * mock of the artifact under test) and prove both network installs now ride
+ * out transient failures:
+ *
+ *   - Behavioral execution: each RUN script is extracted from the Dockerfile,
+ *     every `/tmp/` path is remapped into a test-owned temp directory (the
+ *     tarball script's remap count is asserted to be non-zero so the test
+ *     fails loudly if the Dockerfile drifts away from /tmp — the raw script
+ *     must never execute because it ends in `rm -f /tmp/*.tgz`), `npm` and
+ *     `sleep` are replaced via PATH shims (network and timing are
+ *     infrastructure), and the remapped script is executed with `/bin/sh`
+ *     exactly as the Docker build would execute it. Simulated transient
+ *     failures must be retried up to three install attempts; cache clean and
+ *     tarball removal must happen only on the success path; exhaustion must
+ *     fail the RUN.
+ *   - Static invariants: both scripts carry the attempts bound (3) and a
+ *     backoff sleep; the tarball install stays ONE npm transaction holding
+ *     all 12 tarball globs; the cache-clean/rm chain stays gated on a
+ *     successful install.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+const dockerfilePath = join(repoRoot, 'Dockerfile');
+
+/**
+ * POSIX sh shim that replaces `npm` during behavioral execution. Every
+ * invocation is recorded in the shared shim log (`install` or `cache-clean`).
+ * Install invocations simulate the transient ECONNRESET by exiting 1 while
+ * the running install-attempt count is <= the fail-count held in the control
+ * file, so `failFirstInstalls: 2` fails exactly the first two attempts.
+ */
+const NPM_SHIM = [
+  '#!/bin/sh',
+  'log="$SHIM_LOG"',
+  'for argument in "$@"; do',
+  '  if [ "$argument" = "cache" ]; then',
+  '    echo cache-clean >>"$log"',
+  '    exit 0',
+  '  fi',
+  '  if [ "$argument" = "install" ]; then',
+  '    echo install >>"$log"',
+  '    attempts=$(grep -c "^install$" "$log")',
+  '    failAfter=$(cat "$SHIM_FAIL_CONTROL")',
+  '    if [ "$attempts" -le "$failAfter" ]; then',
+  '      exit 1',
+  '    fi',
+  '    exit 0',
+  '  fi',
+  'done',
+  'exit 0',
+].join('\n');
+
+/**
+ * POSIX sh shim that replaces `sleep` so backoff waits are recorded in the
+ * log instead of actually pausing the suite (timing is infrastructure).
+ */
+const SLEEP_SHIM = ['#!/bin/sh', 'echo sleep >>"$SHIM_LOG"', 'exit 0'].join(
+  '\n',
+);
+
+/**
+ * Sentinel tarballs placed in the remapped /tmp directory before execution so
+ * the tests can observe `rm -f <tmp>/*.tgz` behavior. One file per tarball
+ * glob in the Dockerfile install command.
+ */
+const SENTINEL_TARBALLS: readonly string[] = [
+  'vybestack-llxprt-code-tools-0.0.0.tgz',
+  'vybestack-llxprt-code-storage-0.0.0.tgz',
+  'vybestack-llxprt-code-auth-0.0.0.tgz',
+  'vybestack-llxprt-code-settings-0.0.0.tgz',
+  'vybestack-llxprt-code-telemetry-0.0.0.tgz',
+  'vybestack-llxprt-code-ide-integration-0.0.0.tgz',
+  'vybestack-llxprt-code-policy-0.0.0.tgz',
+  'vybestack-llxprt-code-mcp-0.0.0.tgz',
+  'vybestack-llxprt-code-core-0.0.0.tgz',
+  'vybestack-llxprt-code-providers-0.0.0.tgz',
+  'vybestack-llxprt-code-agents-0.0.0.tgz',
+  'vybestack-llxprt-code-0.0.0.tgz',
+];
+
+/** Every tarball glob that must stay inside the single npm invocation. */
+const TARBALL_GLOBS: readonly string[] = [
+  '/tmp/vybestack-llxprt-code-tools-*.tgz',
+  '/tmp/vybestack-llxprt-code-storage-*.tgz',
+  '/tmp/vybestack-llxprt-code-auth-*.tgz',
+  '/tmp/vybestack-llxprt-code-settings-*.tgz',
+  '/tmp/vybestack-llxprt-code-telemetry-*.tgz',
+  '/tmp/vybestack-llxprt-code-ide-integration-*.tgz',
+  '/tmp/vybestack-llxprt-code-policy-*.tgz',
+  '/tmp/vybestack-llxprt-code-mcp-*.tgz',
+  '/tmp/vybestack-llxprt-code-core-*.tgz',
+  '/tmp/vybestack-llxprt-code-providers-*.tgz',
+  '/tmp/vybestack-llxprt-code-agents-*.tgz',
+  '/tmp/vybestack-llxprt-code-*.tgz',
+];
+
+/**
+ * A collapsed Dockerfile RUN instruction: the backslash continuations joined
+ * into the single logical line whose shell script is asserted on and executed.
+ */
+interface RunInstruction {
+  readonly collapsed: string;
+}
+
+/** What a behavioral execution observed, read back after the child exits. */
+interface ScriptExecution {
+  readonly exitCode: number | null;
+  readonly log: readonly string[];
+  readonly remainingTarballs: readonly string[];
+  readonly tmpRemapCount: number;
+}
+
+function readDockerfile(): string {
+  return readFileSync(dockerfilePath, 'utf8');
+}
+
+/**
+ * Joins Dockerfile backslash-continuation lines into one logical line per
+ * instruction (modeled on the issue #2903 collapse helper) and returns every
+ * RUN instruction in collapsed form.
+ */
+function extractRunInstructions(dockerfile: string): readonly RunInstruction[] {
+  const instructions: RunInstruction[] = [];
+  let insideInstruction = false;
+  let collapsed = '';
+
+  const flush = (): void => {
+    if (!insideInstruction) {
+      return;
+    }
+    const instruction = { collapsed: collapsed.trim() };
+    insideInstruction = false;
+    collapsed = '';
+    if (/^RUN(\s|$)/.test(instruction.collapsed)) {
+      instructions.push(instruction);
+    }
+  };
+
+  for (const line of dockerfile.split(/\r?\n/)) {
+    if (!insideInstruction && /^\s*#/.test(line)) {
+      continue; // comment lines never start an instruction
+    }
+    const trimmedEnd = line.trimEnd();
+    const continued = trimmedEnd.endsWith('\\');
+    insideInstruction = true;
+    collapsed += ' ' + (continued ? trimmedEnd.slice(0, -1) : line.trim());
+    if (!continued) {
+      flush();
+    }
+  }
+  flush();
+  return instructions;
+}
+
+/**
+ * Finds the first RUN instruction whose collapsed script satisfies `matches`,
+ * failing loudly (never returning undefined) when the Dockerfile drifts.
+ */
+function findRunInstruction(
+  dockerfile: string,
+  matches: (collapsed: string) => boolean,
+  description: string,
+): RunInstruction {
+  const found = extractRunInstructions(dockerfile).find(({ collapsed }) =>
+    matches(collapsed),
+  );
+  if (!found) {
+    throw new Error(`Dockerfile has no RUN instruction that ${description}`);
+  }
+  return found;
+}
+
+function tarballInstallRun(dockerfile: string): RunInstruction {
+  return findRunInstruction(
+    dockerfile,
+    (collapsed) =>
+      collapsed.includes('npm install -g') &&
+      collapsed.includes('/tmp/vybestack-llxprt-code-tools-*.tgz'),
+    'installs the release tarballs with npm',
+  );
+}
+
+function uiInstallRun(dockerfile: string): RunInstruction {
+  return findRunInstruction(
+    dockerfile,
+    (collapsed) =>
+      collapsed.includes('npm install -g') &&
+      collapsed.includes('@vybestack/llxprt-ui'),
+    'installs @vybestack/llxprt-ui with npm',
+  );
+}
+
+/** Strips the leading `RUN ` from a collapsed instruction. */
+function runScript(instruction: RunInstruction): string {
+  return instruction.collapsed.replace(/^RUN\s+/, '');
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+function logEntryCount(log: readonly string[], entry: string): number {
+  return log.filter((line) => line === entry).length;
+}
+
+/**
+ * Executes a Dockerfile RUN script with `/bin/sh`, remapping `/tmp/` into a
+ * test-owned temp directory, shimming `npm` and `sleep` via PATH, and
+ * (optionally) staging sentinel tarballs. The work directory is removed after
+ * everything observable has been captured.
+ */
+function executeRunScript(options: {
+  readonly script: string;
+  readonly failFirstInstalls: number;
+  readonly withSentinelTarballs: boolean;
+}): ScriptExecution {
+  const workdir = mkdtempSync(join(tmpdir(), 'issue3241-run-'));
+  let execution: ScriptExecution;
+  try {
+    const remappedTmp = join(workdir, 'remapped-tmp');
+    const binDir = join(workdir, 'bin');
+    mkdirSync(remappedTmp);
+    mkdirSync(binDir);
+
+    const tmpRemapCount = countOccurrences(options.script, '/tmp/');
+    const script = options.script.replaceAll('/tmp/', `${remappedTmp}/`);
+
+    if (options.withSentinelTarballs) {
+      for (const name of SENTINEL_TARBALLS) {
+        writeFileSync(join(remappedTmp, name), 'sentinel');
+      }
+    }
+
+    writeFileSync(join(binDir, 'npm'), NPM_SHIM);
+    writeFileSync(join(binDir, 'sleep'), SLEEP_SHIM);
+    chmodSync(join(binDir, 'npm'), 0o755);
+    chmodSync(join(binDir, 'sleep'), 0o755);
+
+    const logPath = join(workdir, 'shim.log');
+    const controlPath = join(workdir, 'fail-after');
+    writeFileSync(logPath, '');
+    writeFileSync(controlPath, String(options.failFirstInstalls));
+
+    const result = Bun.spawnSync({
+      cmd: ['/bin/sh', '-c', script],
+      cwd: workdir,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        SHIM_LOG: logPath,
+        SHIM_FAIL_CONTROL: controlPath,
+      },
+    });
+
+    const log = readFileSync(logPath, 'utf8')
+      .split('\n')
+      .filter((line) => line !== '');
+    const remainingTarballs = readdirSync(remappedTmp).filter((name) =>
+      name.endsWith('.tgz'),
+    );
+
+    execution = {
+      exitCode: result.exitCode,
+      log,
+      remainingTarballs,
+      tmpRemapCount,
+    };
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+  return execution;
+}
+
+const dockerfile = readDockerfile();
+const tarballScript = runScript(tarballInstallRun(dockerfile));
+const uiScript = runScript(uiInstallRun(dockerfile));
+
+/**
+ * The behavioral suites execute the extracted RUN scripts through /bin/sh
+ * with POSIX PATH shims; stock Windows has neither. The nightly runs this
+ * shard on windows-latest, so gate the execution suites (the static
+ * invariant suites below still run everywhere). Mirrors the
+ * describePosixOnly idiom in issue-2978-oven-fallback.bun.test.ts.
+ */
+const describePosixOnly =
+  process.platform === 'win32' ? describe.skip : describe;
+
+describePosixOnly(
+  'issue #3241: Dockerfile tarball install RUN behavior',
+  () => {
+    it('recovers from two transient npm failures, cleans the cache, and removes the tarballs', () => {
+      const result = executeRunScript({
+        script: tarballScript,
+        failFirstInstalls: 2,
+        withSentinelTarballs: true,
+      });
+
+      // Remap guard: if the Dockerfile stops using /tmp, the script would run
+      // against the real /tmp (it ends in `rm -f /tmp/*.tgz`) and the test
+      // would silently prove nothing. Fail loudly instead.
+      expect(
+        result.tmpRemapCount,
+        'tarball install RUN should reference /tmp paths that get remapped',
+      ).toBeGreaterThan(0);
+
+      expect(result.exitCode).toBe(0);
+      expect(logEntryCount(result.log, 'install')).toBe(3);
+      expect(logEntryCount(result.log, 'cache-clean')).toBe(1);
+      expect(logEntryCount(result.log, 'sleep')).toBeGreaterThanOrEqual(2);
+      expect(result.remainingTarballs).toEqual([]);
+    });
+
+    it('fails the build after three failed npm attempts without cleaning the cache or removing the tarballs', () => {
+      const result = executeRunScript({
+        script: tarballScript,
+        failFirstInstalls: 99,
+        withSentinelTarballs: true,
+      });
+
+      expect(result.tmpRemapCount).toBeGreaterThan(0);
+
+      expect(result.exitCode).toBe(1);
+      expect(logEntryCount(result.log, 'install')).toBe(3);
+      expect(logEntryCount(result.log, 'cache-clean')).toBe(0);
+      expect(result.remainingTarballs.length).toBe(SENTINEL_TARBALLS.length);
+    });
+  },
+);
+
+describePosixOnly(
+  'issue #3241: Dockerfile @vybestack/llxprt-ui install RUN behavior',
+  () => {
+    // The ui install references no /tmp paths, so there is no remap-count guard
+    // here; the install-count assertions below are what keep this from testing
+    // nothing. The remap in executeRunScript still applies defensively in case
+    // the script ever gains /tmp references.
+    it('recovers from two transient npm failures and cleans the cache', () => {
+      const result = executeRunScript({
+        script: uiScript,
+        failFirstInstalls: 2,
+        withSentinelTarballs: false,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(logEntryCount(result.log, 'install')).toBe(3);
+      expect(logEntryCount(result.log, 'cache-clean')).toBe(1);
+      expect(logEntryCount(result.log, 'sleep')).toBeGreaterThanOrEqual(2);
+    });
+
+    it('fails the build after three failed npm attempts without cleaning the cache', () => {
+      const result = executeRunScript({
+        script: uiScript,
+        failFirstInstalls: 99,
+        withSentinelTarballs: false,
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(logEntryCount(result.log, 'install')).toBe(3);
+      expect(logEntryCount(result.log, 'cache-clean')).toBe(0);
+    });
+  },
+);
+
+describe('issue #3241: Dockerfile npm install retry invariants', () => {
+  it('wraps both installs in a bounded retry of three attempts with backoff sleep', () => {
+    // Structural, not literal: the behavioral suites pin the observable
+    // contract (exactly 3 installs, sleeps between retries, exit 1 on
+    // exhaustion) via shims, but they are skipped on Windows — this static
+    // suite is what proves the retry structure exists there. Whitespace-
+    // tolerant regexes keep semantically equivalent refactors green.
+    for (const script of [tarballScript, uiScript]) {
+      expect(script).toMatch(/attempts=\$\(\(attempts \+ 1\)\)/);
+      expect(script).toMatch(/\[ \\?"\$attempts\\?" -ge 3 \]/);
+      expect(script).toMatch(/sleep [0-9]+/);
+      expect(script).toContain('exit 1');
+    }
+  });
+
+  it('installs all 12 release tarballs in a single npm invocation', () => {
+    for (const glob of TARBALL_GLOBS) {
+      expect(tarballScript).toContain(glob);
+    }
+    expect(countOccurrences(tarballScript, 'npm install -g')).toBe(1);
+  });
+
+  it('gates cache clean and tarball removal on a successful install', () => {
+    expect(tarballScript).toMatch(
+      /done\s*&&\s*npm cache clean --force\s*&&\s*rm -f \S+\/\*\.tgz/,
+    );
+    expect(uiScript).toMatch(/done\s*&&\s*npm cache clean --force/);
+  });
+});

--- a/scripts/tests/release-process-b.test.ts
+++ b/scripts/tests/release-process-b.test.ts
@@ -141,8 +141,10 @@ describe('Dockerfile', () => {
   });
 
   it('installs local tarballs in one npm transaction for unpublished versions', () => {
+    // Issue #3241 wrapped the install in a bounded `until` retry loop, so the
+    // slice anchors on the loop head instead of the old `RUN npm install -g`.
     const installCommand = dockerfile.slice(
-      dockerfile.indexOf('RUN npm install -g'),
+      dockerfile.indexOf('until npm install -g'),
       dockerfile.indexOf('npm cache clean --force'),
     );
 
@@ -160,6 +162,10 @@ describe('Dockerfile', () => {
     expect(installCommand).toContain('vybestack-llxprt-code-providers-*.tgz');
     expect(installCommand).toContain('vybestack-llxprt-code-agents-*.tgz');
     expect(installCommand).toContain('vybestack-llxprt-code-*.tgz');
+    // The retry wrapper must not reintroduce a second, split tarball install:
+    // the slice between the loop head and the cache clean contains exactly
+    // one `npm install -g`, in either the old or the retry-wrapped layout.
+    expect(installCommand.match(/npm install -g/g)?.length ?? 0).toBe(1);
     expect(installCommand).not.toContain('&& \\\n    npm install -g');
   });
 

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -235,6 +235,7 @@
     "scripts/tests/issue-2603-windows-lineage-helpers.test.ts",
     "scripts/tests/issue-2603-windows-probe.ts",
     "scripts/tests/issue-2983-declaration-build.test.ts",
+    "scripts/tests/issue-3241-dockerfile-npm-retry.bun.test.ts",
     "scripts/tests/issue-planner.test.ts",
     "scripts/tests/legacy-paths-ast-scanner.test.ts",
     "scripts/tests/legacy-paths-guard-helpers.ts",


### PR DESCRIPTION
## TLDR

The 2026-08-18 nightly release (v0.11.0-nightly.260818.57578c985) died in **Build and push sandbox image** after all npm publishes had already succeeded. Root cause: the multi-platform Docker build's QEMU-emulated arm64 leg runs the root Dockerfile's `npm install -g /tmp/vybestack-llxprt-code-*.tgz ...` (which fetches transitive deps from the npm registry); at t≈238s it hit `npm error code ECONNRESET / errno -104 / network read ECONNRESET`, npm exited, and with **no retry at any layer** buildkit reported exit code 152 and the whole run — GitHub release/tag, sandbox image, Homebrew update, VS Code marketplace publish — was lost.

Fix: both registry-touching `RUN` steps in the Dockerfile are wrapped in a bounded POSIX sh retry (3 total npm attempts, 15s sleep between attempts, explicit `exit 1` on exhaustion), plus per-RUN scoped `npm_config_fetch_retries=5` hardening. The single-transaction 12-tarball install, success-gated cleanup (`done && npm cache clean --force && rm -f /tmp/*.tgz`), `USER node`, and `CMD` semantics are unchanged.

## Dive Deeper

**Why Dockerfile-level retry (and nothing else):** the transient failure occurs inside one RUN layer; npm's own fetch retry cannot recover a mid-response-body reset (`network read ECONNRESET`), and the build-push-action has no retry. A layer-local `until` loop is self-contained, applies to local builds (`scripts/build_sandbox.ts` passes this Dockerfile through unchanged) and CI alike, and retries are cheap because npm's in-layer cache already holds previously fetched tarballs. Workflow-level retry and dependency vendoring were considered and rejected as out of scope.

**Dockerfile change shape (both RUN steps):**

```sh
export npm_config_fetch_retries=5 npm_config_fetch_retry_mintimeout=1000 npm_config_fetch_retry_maxtimeout=60000
attempts=0
until npm install -g ...all 12 tarballs in one invocation...; do
  attempts=$((attempts + 1))
  if [ "$attempts" -ge 3 ]; then echo ... >&2; exit 1; fi
  echo ... >&2; sleep 15
done && npm cache clean --force && rm -f /tmp/*.tgz
```

- Valid POSIX sh (dash semantics — image SHELL is `/bin/sh`); verified by executing the retry structure under dash and via the behavioral suites.
- Exhaustion still fails the build (`exit 1`) — no swallowed failures.
- The `@vybestack/llxprt-ui` install layer got the identical treatment (same exposure class).

**Tests** (`scripts/tests/issue-3241-dockerfile-npm-retry.bun.test.ts`, new):
- *Behavioral* (POSIX-only, `describePosixOnly` mirroring `issue-2978-oven-fallback.bun.test.ts` because the nightly scripts shard runs on windows-latest): the **actual RUN scripts are extracted from the real Dockerfile** and executed via `/bin/sh -c` with PATH-shimmed `npm`/`sleep` (infrastructure shims writing log lines) and `/tmp` remapped into a test temp dir (remap-count drift guard, sentinel tarballs). Asserts: 2 transient failures → exit 0, exactly 3 installs, exactly 1 cache-clean, tarballs removed; permanent failure → exit 1 (not just nonzero — a signal-killed child cannot masquerade), exactly 3 installs, 0 cache-clean, tarballs retained.
- *Static invariants* (all platforms — the only structural guard on Windows): retry bound/increment/backoff/exit-1 structure via whitespace-tolerant regexes (semantically equivalent Dockerfile refactors stay green), exactly one `npm install -g` containing all 12 tarball globs, cleanup gated on success.
- `release-process-b.test.ts`: the pre-existing single-transaction invariant re-anchored to the retry-wrapped command, now also pinning exactly one `npm install -g`.
- RED proof: against the pre-change Dockerfile the new suite fails 6/7 (both reviewers independently reproduced this via stash); after the fix 26/26 focused tests pass.

## Reviewer Test Plan

1. `bun test scripts/tests/issue-3241-dockerfile-npm-retry.bun.test.ts scripts/tests/release-process-b.test.ts` — 26 pass.
2. Mutation check: `git stash push -- Dockerfile && bun test scripts/tests/issue-3241-dockerfile-npm-retry.bun.test.ts` (expect 6 failures) then `git stash pop`.
3. Read the two RUN blocks in `Dockerfile` directly: confirm single 12-tarball transaction, `done &&` cleanup gating, bounded 3 attempts, `exit 1` exhaustion.
4. Optional local image build sanity: `bun scripts/build_sandbox.ts` (only if you want to spend the build time).

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅ (full suite: only documented ARM ripgrep env baseline; agents timing flakes pass in isolation) | ✅ (static suites run cross-platform; behavioral suites skip via describePosixOnly — nightly scripts shard covered) | ✅ (CI) |
| npx      | ✅ (lint/typecheck/pretier/eslint on changed files) | ❓ | ❓ |
| Docker   | ❓ (multi-arch release build exercised by release CI; not run locally) | - | - |
| Podman   | ❓ | - | - |
| Seatbelt | ❓ | - | - |

Verification cycle run in full: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format` (no diffs), `npm run build`, and the stepfun-37 smoke test (haiku, exit 0). Reviewed by deepthinker (PASS) and ocr (2 low findings, both remediated: exit-code precision `toBe(1)`, de-literalized structural regexes).

## Linked issues / bugs

Fixes #3241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker-based release installation reliability by retrying failed package installations up to three times with a delay between attempts.
  * Added network retry handling and clear failure behavior after all attempts are exhausted.
  * Ensured cleanup runs after successful installation, including removal of temporary release packages and npm cache data.

* **Tests**
  * Added coverage for retry recovery, repeated failures, cleanup behavior, and platform-specific execution.
  * Updated release validation to verify a single consolidated installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->