### PR TITLE
Compress context and retry original request on context-size 413 (Fixes #3251)

### DIFF
--- a/packages/agents/src/core/MessageStreamTerminalHandler.ts
+++ b/packages/agents/src/core/MessageStreamTerminalHandler.ts
@@ -4,14 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AgentMessageInput } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import {
+  iContentFromAgentMessageInput,
+  type AgentMessageInput,
+} from '@vybestack/llxprt-code-core/llm-types/index.js';
 import {
   type IterationResult,
   MAX_TURNS,
   type MessageStreamDeps,
   type StreamContext,
 } from './MessageStreamOrchestrator.js';
-import { AgentEventType, type ServerAgentStreamEvent } from './turn.js';
+import {
+  AgentEventType,
+  PerformCompressionResult,
+  type ServerAgentStreamEvent,
+} from './turn.js';
 import {
   buildToolContentRejectionAdvice,
   describeRejectedPayload,
@@ -71,6 +78,84 @@ async function* fireAfterHookAndEmitClearContext(
   }
 }
 
+/**
+ * Context-size 413 recovery: the pending request carries no oversized
+ * tool/media payload, so the rejection came from the accumulated
+ * conversation. Compress the history, escalate once to hard context-window
+ * enforcement when compression cannot run or did not compress, then retry the
+ * ORIGINAL pending request once. The isPayloadRecoveryRetry=true retry flag
+ * keeps this bounded (see the repeated-413 guard in handle413Error).
+ */
+async function* handleContextSize413Error(
+  deps: MessageStreamDeps,
+  ctx: StreamContext,
+  deferredEvents: ServerAgentStreamEvent[],
+  state: TerminalState,
+  initialRequest: AgentMessageInput,
+  signal: AbortSignal,
+  boundedTurns: number,
+): AsyncGenerator<ServerAgentStreamEvent, IterationResult | undefined> {
+  const chat = deps.getChat();
+  let compressionSucceeded = false;
+  try {
+    const result = await chat.performCompression(ctx.prompt_id, {
+      trigger: 'auto',
+    });
+    compressionSucceeded = result === PerformCompressionResult.COMPRESSED;
+  } catch (error) {
+    // Compression is best-effort recovery: a subsystem failure escalates to
+    // enforcement rather than aborting the stream.
+    deps.logger.warn(
+      () =>
+        `[stream:orchestrator] 413 compression attempt failed; escalating to context-window enforcement`,
+      { error: error instanceof Error ? error.message : String(error) },
+    );
+  }
+  if (!compressionSucceeded) {
+    try {
+      const pendingTokens = await chat.estimatePendingTokens(
+        iContentFromAgentMessageInput(initialRequest),
+      );
+      await chat.enforceContextWindow(pendingTokens, ctx.prompt_id);
+    } catch (error) {
+      // Enforcement throwing means the context cannot be reduced locally;
+      // end the iteration gracefully instead of crashing the stream.
+      deps.logger.warn(
+        () =>
+          `[stream:orchestrator] 413 context-window enforcement failed; ending iteration without retry`,
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      for (const d of deferredEvents) yield d;
+      await fireAfterHook(deps, ctx);
+      return earlyIterResult(state.hadToolCallsThisTurn, {
+        ...state,
+        deferredEvents,
+      });
+    }
+  }
+  deps.logger.warn(
+    () =>
+      `[stream:orchestrator] retrying original request after 413 context compression`,
+    {
+      deferredEventCount: deferredEvents.length,
+      hadToolCallsThisTurn: state.hadToolCallsThisTurn,
+    },
+  );
+  yield* deps.sendMessageStream(
+    initialRequest,
+    signal,
+    ctx.prompt_id,
+    boundedTurns - 1,
+    false,
+    true,
+  );
+  await fireAfterHook(deps, ctx);
+  return earlyIterResult(state.hadToolCallsThisTurn, {
+    ...state,
+    deferredEvents,
+  });
+}
+
 async function* handle413Error(
   deps: MessageStreamDeps,
   ctx: StreamContext,
@@ -95,6 +180,24 @@ async function* handle413Error(
       ...state,
       deferredEvents,
     });
+  }
+
+  // Without tool-response/media evidence the 413 reflects the whole context
+  // size, not an oversized payload, so compress instead of advising the model.
+  const description = describeRejectedPayload(initialRequest);
+  if (
+    description.toolNames.length === 0 &&
+    description.mediaDescriptors.length === 0
+  ) {
+    return yield* handleContextSize413Error(
+      deps,
+      ctx,
+      deferredEvents,
+      state,
+      initialRequest,
+      signal,
+      boundedTurns,
+    );
   }
 
   const toolNames = extractToolNamesFromRequest(initialRequest);

--- a/packages/agents/src/core/MessageStreamTerminalHandler.ts
+++ b/packages/agents/src/core/MessageStreamTerminalHandler.ts
@@ -135,7 +135,9 @@ async function* handleContextSize413Error(
   }
   deps.logger.warn(
     () =>
-      `[stream:orchestrator] retrying original request after 413 context compression`,
+      compressionSucceeded
+        ? '[stream:orchestrator] retrying original request after 413 context compression'
+        : '[stream:orchestrator] retrying original request after 413 context-window enforcement',
     {
       deferredEventCount: deferredEvents.length,
       hadToolCallsThisTurn: state.hadToolCallsThisTurn,

--- a/packages/agents/src/core/client.sendMessageStream-errors.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-errors.test.ts
@@ -13,7 +13,7 @@ import { automock } from '@vybestack/llxprt-code-test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
 import { AgentClient } from './client.js';
 import type { ChatSession } from './chatSession.js';
-import { AgentEventType } from './turn.js';
+import { AgentEventType, PerformCompressionResult } from './turn.js';
 import {
   fromAsync,
   setupAgentClient,
@@ -201,6 +201,32 @@ void vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   },
 }));
 
+/**
+ * Builds the partial ChatSession mock shared by every 413 test. Recovery
+ * methods default to bare spies so not-called assertions work out of the box;
+ * pass overrides for the behavior under test.
+ */
+function makeMockChat(
+  overrides: Partial<
+    Pick<
+      ChatSession,
+      'performCompression' | 'enforceContextWindow' | 'estimatePendingTokens'
+    >
+  > = {},
+): Partial<ChatSession> {
+  const base: Partial<ChatSession> = {
+    addHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+    getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+    getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
+    getContextLimit: vi.fn().mockReturnValue(1000000),
+    performCompression: vi.fn(),
+    enforceContextWindow: vi.fn(),
+    estimatePendingTokens: vi.fn(),
+  };
+  return { ...base, ...overrides };
+}
+
 describe('Agent Client (client.ts)', () => {
   let client: AgentClient;
 
@@ -257,13 +283,7 @@ describe('Agent Client (client.ts)', () => {
         .mockReturnValueOnce(mockStream1)
         .mockReturnValueOnce(mockStream2);
 
-      const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
-        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
-        getContextLimit: vi.fn().mockReturnValue(1000000),
-      };
+      const mockChat = makeMockChat();
       client['chat'] = mockChat as ChatSession;
 
       // Include tool_response blocks to test tool name extraction
@@ -328,6 +348,270 @@ describe('Agent Client (client.ts)', () => {
         ],
         expect.any(Object),
       );
+
+      // A tool-payload 413 must not run compression or enforcement (REQ-3251-5)
+      expect(mockChat.performCompression).not.toHaveBeenCalled();
+      expect(mockChat.enforceContextWindow).not.toHaveBeenCalled();
+    });
+
+    it('compresses the context and retries the original request on a context-size 413 (request_too_large)', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      // Anthropic-style context-size rejection: no tool or media payload.
+      const requestTooLarge = {
+        error: { message: 'Request exceeds the maximum size', status: 413 },
+      };
+      const mockStream1 = (async function* () {
+        yield { type: AgentEventType.Error, value: requestTooLarge };
+      })();
+      const mockStream2 = (async function* () {
+        yield { type: AgentEventType.Content, value: 'Retried content' };
+      })();
+
+      mockTurnRunFn
+        .mockReturnValueOnce(mockStream1)
+        .mockReturnValueOnce(mockStream2);
+
+      const promptId = 'prompt-id-413-context-size';
+      const mockChat = makeMockChat({
+        performCompression: vi
+          .fn()
+          .mockResolvedValue(PerformCompressionResult.COMPRESSED),
+        enforceContextWindow: vi.fn().mockResolvedValue(undefined),
+        estimatePendingTokens: vi.fn().mockResolvedValue(4242),
+      });
+      client['chat'] = mockChat as ChatSession;
+
+      const initialRequest = [{ type: 'text', text: 'Hi' }];
+      const events = await fromAsync(
+        client.sendMessageStream(
+          initialRequest,
+          new AbortController().signal,
+          promptId,
+        ),
+      );
+
+      // The retried Content flows to the consumer after the surfaced 413.
+      expect(events).toStrictEqual([
+        {
+          type: AgentEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'gemini',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
+        { type: AgentEventType.Error, value: requestTooLarge },
+        { type: AgentEventType.Content, value: 'Retried content' },
+      ]);
+
+      expect(mockChat.performCompression).toHaveBeenCalledTimes(1);
+      expect(mockChat.performCompression).toHaveBeenCalledWith(promptId, {
+        trigger: 'auto',
+      });
+      expect(mockChat.enforceContextWindow).not.toHaveBeenCalled();
+
+      // The retry carries the ORIGINAL pending request, not a synthetic message.
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+      expect(mockTurnRunFn).toHaveBeenNthCalledWith(
+        2,
+        [{ speaker: 'human', blocks: [{ type: 'text', text: 'Hi' }] }],
+        expect.any(Object),
+      );
+    });
+
+    it.each([
+      {
+        label: 'SKIPPED_EMPTY',
+        result: PerformCompressionResult.SKIPPED_EMPTY,
+      },
+      {
+        label: 'SKIPPED_COOLDOWN',
+        result: PerformCompressionResult.SKIPPED_COOLDOWN,
+      },
+      { label: 'NOOP', result: PerformCompressionResult.NOOP },
+      { label: 'FAILED', result: PerformCompressionResult.FAILED },
+      { label: 'rejected', result: undefined },
+    ])(
+      'escalates to context-window enforcement when compression is $label on a context-size 413',
+      async ({ label, result }) => {
+        vi.spyOn(
+          client['config'],
+          'getContinueOnFailedApiCall',
+        ).mockReturnValue(true);
+        const mockStream1 = (async function* () {
+          yield {
+            type: AgentEventType.Error,
+            value: {
+              error: { message: 'Payload too large', status: 413 },
+            },
+          };
+        })();
+        const mockStream2 = (async function* () {
+          yield { type: AgentEventType.Content, value: 'Retried content' };
+        })();
+
+        mockTurnRunFn
+          .mockReturnValueOnce(mockStream1)
+          .mockReturnValueOnce(mockStream2);
+
+        const promptId = `prompt-id-413-escalate-${label}`;
+        const mockChat = makeMockChat({
+          performCompression:
+            result === undefined
+              ? vi.fn().mockRejectedValue(new Error('compression blew up'))
+              : vi.fn().mockResolvedValue(result),
+          enforceContextWindow: vi.fn().mockResolvedValue(undefined),
+          estimatePendingTokens: vi.fn().mockResolvedValue(4242),
+        });
+        client['chat'] = mockChat as ChatSession;
+
+        const initialRequest = [{ type: 'text', text: 'Hi' }];
+        // A rejected compression must not crash the stream; the retry still runs.
+        const events = await fromAsync(
+          client.sendMessageStream(
+            initialRequest,
+            new AbortController().signal,
+            promptId,
+          ),
+        );
+
+        expect(mockChat.enforceContextWindow).toHaveBeenCalledTimes(1);
+        expect(mockChat.enforceContextWindow).toHaveBeenCalledWith(
+          4242,
+          promptId,
+        );
+        expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+        expect(mockTurnRunFn).toHaveBeenNthCalledWith(
+          2,
+          [{ speaker: 'human', blocks: [{ type: 'text', text: 'Hi' }] }],
+          expect.any(Object),
+        );
+        expect(events).toContainEqual({
+          type: AgentEventType.Content,
+          value: 'Retried content',
+        });
+      },
+    );
+
+    it('ends the iteration gracefully when context-window enforcement fails on a context-size 413', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      const requestTooLarge = {
+        error: { message: 'Request exceeds the maximum size', status: 413 },
+      };
+      mockTurnRunFn.mockReturnValueOnce(
+        (async function* () {
+          yield { type: AgentEventType.Finished, value: { reason: 'STOP' } };
+          yield { type: AgentEventType.Error, value: requestTooLarge };
+        })(),
+      );
+
+      const promptId = 'prompt-id-413-enforcement-failed';
+      const mockChat = makeMockChat({
+        performCompression: vi
+          .fn()
+          .mockResolvedValue(PerformCompressionResult.NOOP),
+        enforceContextWindow: vi
+          .fn()
+          .mockRejectedValue(new Error('unrecoverable context overflow')),
+        estimatePendingTokens: vi.fn().mockResolvedValue(4242),
+      });
+      client['chat'] = mockChat as ChatSession;
+      const afterHook = vi
+        .spyOn(client['agentHookManager'], 'fireAfterAgentHookSafe')
+        .mockResolvedValue(undefined);
+
+      // fromAsync completing is itself the assertion that the stream did not throw.
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ type: 'text', text: 'Hi' }],
+          new AbortController().signal,
+          promptId,
+        ),
+      );
+
+      // No retry was issued and the original 413 Error event stays surfaced.
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+      expect(mockChat.enforceContextWindow).toHaveBeenCalledTimes(1);
+      // The deferred Finished event is flushed after the terminal Error,
+      // not dropped, and the after-agent hook still fires exactly once.
+      expect(events.slice(-2)).toStrictEqual([
+        { type: AgentEventType.Error, value: requestTooLarge },
+        { type: AgentEventType.Finished, value: { reason: 'STOP' } },
+      ]);
+      expect(afterHook).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries with the synthetic 413 message when the rejected payload carries only media evidence', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      const mockStream1 = (async function* () {
+        yield {
+          type: AgentEventType.Error,
+          value: {
+            error: { message: 'Payload too large', status: 413 },
+          },
+        };
+      })();
+      const mockStream2 = (async function* () {
+        yield { type: AgentEventType.Content, value: 'Retried content' };
+      })();
+
+      mockTurnRunFn
+        .mockReturnValueOnce(mockStream1)
+        .mockReturnValueOnce(mockStream2);
+
+      const promptId = 'prompt-id-413-media-only';
+      const mockChat = makeMockChat();
+      client['chat'] = mockChat as ChatSession;
+
+      // Media evidence without any tool_response still routes to the
+      // synthetic tool-name retry (REQ-3251-5).
+      const initialRequest = [
+        { type: 'text', text: 'Describe this chart' },
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          data: 'aGk=',
+          encoding: 'base64',
+          filename: 'chart.png',
+        },
+      ];
+      const events = await fromAsync(
+        client.sendMessageStream(
+          initialRequest,
+          new AbortController().signal,
+          promptId,
+        ),
+      );
+
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+      expect(mockTurnRunFn).toHaveBeenNthCalledWith(
+        2,
+        [
+          {
+            speaker: 'human',
+            blocks: [
+              {
+                type: 'text',
+                text: 'System: The previous tool calls produced a response that was too large (HTTP 413). Please retry with fewer or more focused queries.',
+              },
+            ],
+          },
+        ],
+        expect.any(Object),
+      );
+      expect(mockChat.performCompression).not.toHaveBeenCalled();
+      expect(mockChat.enforceContextWindow).not.toHaveBeenCalled();
+      expect(events).toContainEqual({
+        type: AgentEventType.Content,
+        value: 'Retried content',
+      });
     });
 
     it('does not retry a 413 after ordinary content was already emitted', async () => {
@@ -344,17 +628,12 @@ describe('Agent Client (client.ts)', () => {
         };
       })();
       mockTurnRunFn.mockReturnValueOnce(mockStream);
-      client['chat'] = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
-        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
-        getContextLimit: vi.fn().mockReturnValue(1000000),
-      } as unknown as ChatSession;
+      const mockChat = makeMockChat();
+      client['chat'] = mockChat as ChatSession;
 
       const events = await fromAsync(
         client.sendMessageStream(
-          [{ text: 'Hi' }],
+          [{ type: 'text', text: 'Hi' }],
           new AbortController().signal,
           'prompt-id-413-after-content',
         ),
@@ -370,6 +649,10 @@ describe('Agent Client (client.ts)', () => {
         },
       ]);
       expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+      // An unretryable 413 must not run compression recovery either.
+      expect(mockChat.performCompression).not.toHaveBeenCalled();
+      expect(mockChat.enforceContextWindow).not.toHaveBeenCalled();
+      expect(mockChat.estimatePendingTokens).not.toHaveBeenCalled();
     });
 
     it.each([
@@ -408,17 +691,12 @@ describe('Agent Client (client.ts)', () => {
           yield terminalEvent;
         })();
         mockTurnRunFn.mockReturnValueOnce(mockStream);
-        client['chat'] = {
-          addHistory: vi.fn(),
-          getHistory: vi.fn().mockReturnValue([]),
-          getLastPromptTokenCount: vi.fn().mockReturnValue(0),
-          getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
-          getContextLimit: vi.fn().mockReturnValue(1000000),
-        } as unknown as ChatSession;
+        const mockChat = makeMockChat();
+        client['chat'] = mockChat as ChatSession;
 
         const events = await fromAsync(
           client.sendMessageStream(
-            [{ text: 'Hi' }],
+            [{ type: 'text', text: 'Hi' }],
             new AbortController().signal,
             'prompt-id-after-tool-call',
           ),
@@ -426,8 +704,53 @@ describe('Agent Client (client.ts)', () => {
 
         expect(events.slice(-2)).toStrictEqual([toolCallEvent, terminalEvent]);
         expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+        // A terminal event after a tool call is unretryable; no compression.
+        expect(mockChat.performCompression).not.toHaveBeenCalled();
+        expect(mockChat.enforceContextWindow).not.toHaveBeenCalled();
+        expect(mockChat.estimatePendingTokens).not.toHaveBeenCalled();
       },
     );
+
+    it('does not retry a 413 after thinking was already emitted', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      const thoughtEvent = {
+        type: AgentEventType.Thought,
+        value: {
+          subject: 'Planning',
+          description: 'I will do something',
+        },
+      };
+      const requestTooLarge = {
+        error: { message: 'Payload too large', status: 413 },
+      };
+      const mockStream = (async function* () {
+        yield thoughtEvent;
+        yield { type: AgentEventType.Error, value: requestTooLarge };
+      })();
+      mockTurnRunFn.mockReturnValueOnce(mockStream);
+      const mockChat = makeMockChat();
+      client['chat'] = mockChat as ChatSession;
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ type: 'text', text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-413-after-thinking',
+        ),
+      );
+
+      expect(events.slice(-2)).toStrictEqual([
+        thoughtEvent,
+        { type: AgentEventType.Error, value: requestTooLarge },
+      ]);
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+      // An unretryable 413 must not run compression recovery either.
+      expect(mockChat.performCompression).not.toHaveBeenCalled();
+      expect(mockChat.enforceContextWindow).not.toHaveBeenCalled();
+      expect(mockChat.estimatePendingTokens).not.toHaveBeenCalled();
+    });
 
     it('should not retry on 413 when getContinueOnFailedApiCall returns false', async () => {
       vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
@@ -445,16 +768,10 @@ describe('Agent Client (client.ts)', () => {
 
       mockTurnRunFn.mockReturnValueOnce(mockStream1);
 
-      const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
-        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
-        getContextLimit: vi.fn().mockReturnValue(1000000),
-      };
+      const mockChat = makeMockChat();
       client['chat'] = mockChat as ChatSession;
 
-      const initialRequest = [{ text: 'Hi' }];
+      const initialRequest = [{ type: 'text', text: 'Hi' }];
       const promptId = 'prompt-id-413-no-retry';
       const signal = new AbortController().signal;
 
@@ -483,6 +800,10 @@ describe('Agent Client (client.ts)', () => {
 
       // turn.run should be called only once
       expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+
+      // Suppressed retries must not run compression either (REQ-3251-6)
+      expect(mockChat.performCompression).not.toHaveBeenCalled();
+      expect(mockChat.enforceContextWindow).not.toHaveBeenCalled();
     });
 
     it('should stop recursing after one retry when 413 errors are repeatedly received', async () => {
@@ -501,16 +822,16 @@ describe('Agent Client (client.ts)', () => {
         })(),
       );
 
-      const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
-        getProjectedPromptBaseline: vi.fn().mockReturnValue(0),
-        getContextLimit: vi.fn().mockReturnValue(1000000),
-      };
+      const mockChat = makeMockChat({
+        performCompression: vi
+          .fn()
+          .mockResolvedValue(PerformCompressionResult.COMPRESSED),
+        enforceContextWindow: vi.fn().mockResolvedValue(undefined),
+        estimatePendingTokens: vi.fn().mockResolvedValue(0),
+      });
       client['chat'] = mockChat as ChatSession;
 
-      const initialRequest = [{ text: 'Hi' }];
+      const initialRequest = [{ type: 'text', text: 'Hi' }];
       const promptId = 'prompt-id-413-infinite';
       const signal = new AbortController().signal;
 
@@ -533,6 +854,9 @@ describe('Agent Client (client.ts)', () => {
 
       // turn.run should be called exactly twice
       expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+
+      // The guarded retry must not compress a second time (REQ-3251-3)
+      expect(mockChat.performCompression).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/project-plans/issue3251/plan.md
+++ b/project-plans/issue3251/plan.md
@@ -1,0 +1,197 @@
+# Plan: Compress Context and Retry on HTTP 413 (Issue #3251)
+
+Plan ID: PLAN-20260819-ISSUE3251
+Generated: 2026-08-19
+Issue: #3251
+Status: In progress
+
+## Problem statement
+
+When a provider rejects a request with HTTP 413 (`request_too_large`,
+"Request exceeds the maximum size"), the agent loop breaks instead of
+recovering. The 413 recovery path in
+`packages/agents/src/core/MessageStreamTerminalHandler.ts`
+(`handle413Error`) retries by sending a NEW synthetic message ("The previous
+tool calls produced a response that was too large (HTTP 413)…"). That retry:
+
+1. never compresses the conversation history, so when the 413 was caused by
+   oversized context (the Anthropic `request_too_large` case in the issue),
+   the retry payload is at least as large as the failed one, and
+2. drops the user's original pending request in favor of the synthetic text.
+
+The retried send then hits 413 again, the `isPayloadRecoveryRetry` guard ends
+the iteration, and the loop breaks with no recovery. The synthetic message is
+also misleading when no tool response caused the rejection.
+
+Evidence from the issue:
+
+- Error: `API Error: 413 {"error":{"type":"request_too_large","message":"Request exceeds the maximum size"}} (Status: 413)` then "the loop broke".
+- CodeRabbit's independent analysis (issue comment) reached the same
+  conclusions and recommends: identify context-size 413s, run
+  `ChatSession.performCompression()` before the retry, escalate to
+  finalized context-window enforcement when compression is insufficient,
+  retry once with the original pending request, keep the bounded-retry
+  guard, and preserve the existing tool-payload recovery for requests that
+  actually carry oversized tool/media payloads.
+
+## Preflight findings
+
+1. `handleErrorEvent` routes a retryable 413 (status from the Error event
+   payload) to `handle413Error` only when
+   `config.getContinueOnFailedApiCall()` is true and
+   `canRetryFailedStream(state)` holds (no content/thinking/tool-call emitted
+   yet in this attempt).
+2. `handle413Error` (MessageStreamTerminalHandler.ts) currently:
+   - ends iteration on `ctx.isPayloadRecoveryRetry` (bounded guard — correct,
+     keep);
+   - otherwise extracts tool names from the request, builds the synthetic
+     tool-focused message, and calls
+     `deps.sendMessageStream([message], signal, prompt_id, boundedTurns-1,
+     false, true)`.
+3. `MessageStreamDeps.getChat()` exposes the live `ChatSession`, which has:
+   - `performCompression(prompt_id, options?)` → `PerformCompressionResult`
+     (`COMPRESSED | SKIPPED_EMPTY | SKIPPED_COOLDOWN | NOOP | FAILED`);
+   - `enforceContextWindow(pendingTokens, promptId)` → hard-limit enforcement
+     (density optimization, compression with `bypassCooldown: true`,
+     truncation escalation); throws only when limits cannot be satisfied;
+   - `estimatePendingTokens(contents: IContent[])` → token estimate for a
+     pending request.
+4. `PerformCompressionResult` is re-exported from `./turn.js`; the terminal
+   handler already imports `AgentEventType` from there.
+5. `describeRejectedPayload(request)` (`toolContentRejection.ts`) normalizes
+   any `AgentMessageInput` and reports tool names and media descriptors; the
+   sibling tool-content-400 path already uses it to distinguish tool-payload
+   rejections.
+6. The client-level preflight overflow path (issues #2402/#2755) was removed
+   in favor of provider-side finalized enforcement; the only 413 recovery
+   seam in the agents loop is `handle413Error`.
+7. Existing tests in
+   `packages/agents/src/core/client.sendMessageStream-errors.test.ts` lock
+   in the current synthetic-message retry (tool-response 413), the repeated
+   413 bound, the no-retry-after-content/tool-call guards, and the
+   `continueOnFailedApiCall=false` suppression.
+8. `ChatSession.performCompression` with plain options respects the failure
+   cooldown (`SKIPPED_COOLDOWN`); `enforceContextWindow` internally retries
+   compression with `bypassCooldown: true` plus truncation fallbacks.
+
+## Proposed accepted behavior
+
+### REQ-3251-1: Context-size 413 classification
+
+A retryable 413 whose pending request carries no tool-response or media
+evidence (`describeRejectedPayload(initialRequest)` yields no tool names and
+no media descriptors) is classified as a context-size 413. Existing retry
+gates are unchanged: `getContinueOnFailedApiCall()` must be true,
+`canRetryFailedStream(state)` must hold, and `ctx.isPayloadRecoveryRetry`
+must be false.
+
+### REQ-3251-2: Compress before retry (context-size 413)
+
+For a context-size 413 the handler first runs
+`getChat().performCompression(prompt_id, { trigger: 'auto' })`. If the result
+is not `COMPRESSED`, or the call throws, it escalates to
+`getChat().enforceContextWindow(pendingTokens, prompt_id)` with
+`pendingTokens` estimated from the original pending request via
+`estimatePendingTokens`. Enforcement failure (throws) means recovery is
+unrecoverable locally (see REQ-3251-4).
+
+### REQ-3251-3: Retry the original request exactly once
+
+After REQ-3251-2, the handler retries the ORIGINAL pending request (not a
+synthetic message) through the existing
+`deps.sendMessageStream(initialRequest, signal, prompt_id, boundedTurns - 1,
+false, true)` path. The `isPayloadRecoveryRetry=true` flag keeps the
+existing bounded-retry guard: a second 413 ends the iteration instead of
+looping.
+
+### REQ-3251-4: Graceful termination when enforcement is unrecoverable
+
+If `enforceContextWindow` throws, the iteration ends gracefully: deferred
+events are yielded, the AfterAgent hook fires, the stream does not crash,
+and no retry is issued.
+
+### REQ-3251-5: Tool-payload 413 behavior preserved
+
+A 413 whose pending request carries tool-response blocks or media blocks
+keeps the existing synthetic tool-name message retry, byte-for-byte the same
+message text and call shape as today, and does not invoke compression or
+enforcement.
+
+### REQ-3251-6: Existing suppression guards unchanged
+
+`getContinueOnFailedApiCall() === false`, a 413 after content was emitted,
+and a 413 after a tool call all still suppress any retry, compression, or
+enforcement.
+
+## Out of scope
+
+- Changing the `continueOnFailedApiCall` gate semantics or defaults.
+- Compression subsystem changes (cooldown policy, strategies, enforcement
+  internals) — the 413 path only calls the existing public seams.
+- Provider-side 413 mapping or new error detection (status 413 already
+  arrives on the Error event; no message parsing is added).
+- UI changes for compression progress (compression subsystem already emits
+  its own events).
+- The tool-content-400 path (`handleToolContentRejection400`).
+
+## Test plan (behavioral, bun:test)
+
+Extend `packages/agents/src/core/client.sendMessageStream-errors.test.ts`
+(this file already owns 413 behavior; sibling files stay untouched):
+
+1. REQ-3251-1/2/3 — Anthropic-style 413 (message `request_too_large`,
+   status 413), request without tool/media blocks:
+   `performCompression` is called once with `{ trigger: 'auto' }` and the
+   prompt id; the retried `turn.run` receives the ORIGINAL request; the
+   retried content flows to the consumer.
+2. REQ-3251-2 — compression returns non-`COMPRESSED` (parameterized over
+   `SKIPPED_EMPTY`, `SKIPPED_COOLDOWN`, `NOOP`, `FAILED`, and a rejected
+   promise): `enforceContextWindow` is called once, then the original
+   request is retried once.
+3. REQ-3251-4 — `enforceContextWindow` rejects: exactly one `turn.run`, no
+   retry, the stream completes without throwing, and the original 413 Error
+   event remains surfaced.
+4. REQ-3251-3 — repeated 413 (compression succeeds both times, provider
+   still rejects): exactly two `turn.run` calls, exactly one compression
+   call (the guarded retry does not compress again), stream ends.
+5. REQ-3251-5 — 413 with tool_response blocks (existing test) plus a new
+   media-only variant: synthetic message retry unchanged;
+   `performCompression`/`enforceContextWindow` are NOT called.
+6. REQ-3251-6 — `continueOnFailedApiCall=false` (existing test, extended
+   with mocks): no retry, `performCompression` NOT called; 413 after
+   content (existing) and 413 after a tool call (existing): no compression.
+
+Mock notes: the tests inject `client['chat']` partials; the context-size
+paths must include `performCompression`, `enforceContextWindow`, and
+`estimatePendingTokens` mocks, mirroring the existing overflow-compression
+test file's style.
+
+## Implementation steps
+
+1. RED: add the failing tests above to
+   `client.sendMessageStream-errors.test.ts`.
+2. GREEN: modify `handle413Error` in
+   `packages/agents/src/core/MessageStreamTerminalHandler.ts`:
+   - classify with `describeRejectedPayload(initialRequest)` (tool names +
+     media descriptors);
+   - tool/media evidence → existing synthetic retry (unchanged);
+   - otherwise run compression → escalation → retry original request once
+     with `isPayloadRecoveryRetry=true`;
+   - wrap the compression call so a throw escalates to enforcement; an
+     enforcement throw ends the iteration per REQ-3251-4 (log a warning);
+   - import `PerformCompressionResult` from `./turn.js` and
+     `iContentFromAgentMessageInput` from
+     `@vybestack/llxprt-code-core/llm-types/index.js`.
+3. Keep the file within lint/complexity limits; no new files beyond the
+   plan; no comment narration.
+
+## Verification cycle
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, then the smoke:
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+
+## Review plan
+
+deepthinker compliance review (max 2 rounds), then detached `ocr review`
+(max 2 rounds), then PR with `Fixes #3251`, watch CI and CodeRabbit.


### PR DESCRIPTION
## TLDR

On a context-size HTTP 413 (`request_too_large`), the agent loop previously retried with a synthetic "your previous tool calls were too large" message, which only appended more text to an already-oversized context. The retry hit 413 again and the payload-recovery guard ended the iteration — the loop broke with no recovery. This PR makes the 413 recovery path in `MessageStreamTerminalHandler` compress the context first and retry the ORIGINAL pending request once.

## Dive Deeper

`handle413Error` now classifies the rejected request via `describeRejectedPayload`:

- **Context-size 413** (no `tool_response` / media evidence — e.g. Anthropic `request_too_large` from grown history): the new `handleContextSize413Error` runs `performCompression(prompt_id, { trigger: 'auto' })`. If compression succeeds, the original `initialRequest` is retried once via `sendMessageStream(..., isPayloadRecoveryRetry=true)`. If compression is skipped/no-op/failed (or throws), it escalates once to `enforceContextWindow(estimatePendingTokens(initialRequest), prompt_id)` (density + cooldown-bypassing compression + truncation escalation). If enforcement recovers, the original request is retried; if enforcement throws, the iteration ends gracefully — deferred events are flushed, the AfterAgent hook fires, and no misleading retry is attempted.
- **Tool/media 413** (request actually carries tool responses or media blocks): the existing synthetic tool-name message retry is preserved byte-for-byte.

All existing guards are unchanged: `continueOnFailedApiCall=false` still suppresses recovery, 413 after emitted content/thinking/tool-call still does not retry, and the repeated-413 bound still ends the iteration after exactly one recovery retry (so compression cannot create an infinite loop — the second 413 terminates).

Behavioral tests (15 in the file, 8 new): compress-then-retry-original-request; parametrized escalation for every non-COMPRESSED result (`SKIPPED_EMPTY`, `SKIPPED_COOLDOWN`, `NOOP`, `FAILED`, thrown error); enforcement-failure graceful termination; media-only synthetic retry with no compression; tool-evidence retry asserts compression is NOT called; `continueOnFailedApiCall=false` asserts no compression; repeated-413 bound with exactly 2 `turn.run` calls and 1 compression.

## Reviewer Test Plan

- `cd packages/agents && bun test src/core/client.sendMessageStream-errors.test.ts` — 15 pass / 74 assertions.
- Force a 413 from a provider (or unit-level: yield `Error` event with `status: 413` and no tool blocks) against a session whose history exceeds the provider hard limit: expect one auto-compression, a retry of the original user request, and continuation of the loop instead of a terminal error.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Full local verification cycle on 🍏: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format` (no diffs), `npm run build`, and the `stepfun-37` smoke profile all pass. Known local-only, pre-existing on this machine: 4 `ripgrepPathResolver` failures caused by `/opt/homebrew/bin/rg` leaking through the mock (CI on main is green; unrelated to this change), and `packages/agents/src/api/__tests__` watchdog flakes under full-suite load (pass 22/22 in isolation; also pre-existing on this machine).

## Linked issues / bugs

Fixes #3251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of context-size errors during message streaming.
  * Automatically compresses conversations and retries eligible requests once when context limits are exceeded.
  * Prevents retries for oversized tool or media payloads, preserving existing guidance.
  * Handles context-window enforcement failures gracefully without interrupting the iteration.
  * Preserves previously emitted responses and events when a retry is attempted.
  * Retry messages now indicate whether conversation compression or context-window enforcement triggered the recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->