### PR TITLE
Translate reasoning settings per provider and model (Fixes #3255)

### DIFF
--- a/docs/providers/quick-reference.md
+++ b/docs/providers/quick-reference.md
@@ -30,6 +30,9 @@ For providers without an alias, or custom endpoints:
 /model model-name
 ```
 
+If the endpoint needs a model-specific reasoning request shape, see
+[Reasoning Wire Formats](./reasoning-wire-formats.md).
+
 ## Built-in provider aliases
 
 LLxprt Code ships with these aliases. Use `/provider <alias>` to switch. The
@@ -193,12 +196,12 @@ Or Claude Code OAuth (Claude.ai subscription):
 
 #### OpenAI transport selection (Responses vs. Chat Completions)
 
-OpenAI models can use two transports — the newer **Responses API** and the
-classic **Chat Completions API** — and LLxprt Code picks one automatically:
+OpenAI models can use the newer **Responses API** or the classic **Chat
+Completions API**. LLxprt Code picks one automatically:
 
 - **GPT-5.6 and later** (bare model IDs like `gpt-5.6` and durable-tier IDs
   like `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) use the **Responses
-  transport** when pointed at the canonical `api.openai.com` endpoint. Chat
+  transport** when pointed at the official `api.openai.com` endpoint. Chat
   Completions is not available for these on that endpoint.
 - **Custom OpenAI-compatible endpoints** (proxies, gateways, self-hosted
   servers, or any non-`api.openai.com` base URL) **default to Chat
@@ -220,8 +223,8 @@ You can also set it permanently in a profile via the `apiMode` or
 `responsesMode` provider setting, or globally via the `responses-mode`
 ephemeral setting. When forced to `responses`, a custom endpoint uses Responses
 for models that support it; when forced to `chat`, Chat Completions is used
-unless the model requires Responses on canonical OpenAI (GPT-5.6+), where Chat
-is unavailable and the override is ignored.
+unless the model requires Responses on the official OpenAI endpoint (GPT-5.6+),
+where Chat is unavailable and the override is ignored.
 
 ### Qwen
 

--- a/docs/providers/reasoning-wire-formats.md
+++ b/docs/providers/reasoning-wire-formats.md
@@ -1,0 +1,718 @@
+# Reasoning Wire Formats
+
+Use reasoning wire settings when a provider-neutral `reasoning.enabled` or
+`reasoning.effort` value must be translated into a provider-specific request.
+This is especially useful for local servers, gateways, and models whose effort
+ladder differs from LLxprt Code's generic ladder.
+
+The four settings on this page are **supported**. They persist when you save a
+profile. Provider APIs and model restrictions can change, so verify model value
+sets against the linked provider documentation before relying on them.
+
+**As of:** 2026-08-20
+
+**Owner:** the LLxprt Code maintainers
+
+## Configure a local OpenAI-compatible server
+
+A custom Chat Completions endpoint is treated conservatively under `auto`.
+Select `openai` when the server accepts top-level `reasoning_effort`:
+
+```json
+{
+  "version": 1,
+  "provider": "openai",
+  "model": "local-reasoning-model",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "base-url": "http://127.0.0.1:8000/v1",
+    "requires-auth": false,
+    "responses-mode": "chat",
+    "reasoning.enabled": true,
+    "reasoning.effort": "high",
+    "reasoning.effortWireFormat": "openai"
+  }
+}
+```
+
+The reasoning portion of the Chat Completions request is:
+
+```json
+{
+  "reasoning_effort": "high"
+}
+```
+
+Without the explicit selector, an unknown custom Chat endpoint receives no
+reasoning field and LLxprt Code logs a warning. LLxprt Code does not probe the
+server or send several reasoning representations to discover which one works.
+
+## Supported settings
+
+### Selectors
+
+| Setting                       | Valid values                                                                                                             | Default | Profile |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------- | ------- |
+| `reasoning.effortWireFormat`  | `auto`, `openai`, `openai-responses`, `anthropic`, `anthropic-budget`, `openrouter`, `gemini`, `template-kwargs`, `none` | `auto`  | yes     |
+| `reasoning.enabledWireFormat` | `auto`, `openai`, `openai-responses`, `openrouter`, `thinking`, `gemini`, `template-kwargs`, `none`                      | `auto`  | yes     |
+| `reasoning.effortMap`         | JSON object described in [Effort maps](#effort-maps)                                                                     | none    | yes     |
+| `reasoning.enabledMap`        | JSON object described in [Enablement maps](#enablement-maps)                                                             | none    | yes     |
+
+A selector must also be compatible with the active transport. An incompatible
+explicit selector fails before the request is sent.
+
+### Effort selector matrix
+
+The request fragments below show an emitted `high` effort, except for the
+numeric Anthropic budget example.
+
+| Selector           | Compatible transport       | Request fragment                                               |
+| ------------------ | -------------------------- | -------------------------------------------------------------- |
+| `auto`             | Any supported transport    | Uses the [automatic selection table](#automatic-selection)     |
+| `openai`           | OpenAI-compatible Chat     | `{ "reasoning_effort": "high" }`                               |
+| `openai-responses` | OpenAI Responses and Codex | `{ "reasoning": { "effort": "high" } }`                        |
+| `anthropic`        | Native Anthropic           | `{ "output_config": { "effort": "high" } }`                    |
+| `anthropic-budget` | OpenAI Chat or Anthropic   | `{ "thinking": { "type": "enabled", "budget_tokens": 8192 } }` |
+| `openrouter`       | OpenAI Chat for OpenRouter | `{ "reasoning": { "effort": "high" } }`                        |
+| `gemini`           | Native Gemini              | Gemini-owned `thinkingConfig`                                  |
+| `template-kwargs`  | OpenAI-compatible Chat     | `{ "chat_template_kwargs": { "reasoning_effort": "high" } }`   |
+| `none`             | Any supported transport    | No effort field; logs a warning when effort was configured     |
+
+`anthropic-budget` requires either `reasoning.budgetTokens` or a numeric entry
+in `reasoning.effortMap`. LLxprt Code does not convert a generic effort to a
+token budget by formula.
+
+### Enablement selector matrix
+
+| Selector           | Compatible transport       | Request fragment or behavior                                                                          |
+| ------------------ | -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `auto`             | Any supported transport    | Uses the [automatic selection table](#automatic-selection)                                            |
+| `openai`           | OpenAI-compatible Chat     | `{ "reasoning_effort": "none" }` when `false` maps to `"none"`                                        |
+| `openai-responses` | OpenAI Responses and Codex | `{ "reasoning": { "effort": "none" } }` when `false` maps to `"none"`                                 |
+| `openrouter`       | OpenAI Chat for OpenRouter | `{ "reasoning": { "enabled": true } }` or `{ "reasoning": { "enabled": false } }`                     |
+| `thinking`         | OpenAI Chat or Anthropic   | `{ "thinking": { "type": "enabled" } }`, `adaptive`, or `disabled`, subject to model support          |
+| `gemini`           | Native Gemini              | Gemini-owned `thinkingConfig`                                                                         |
+| `template-kwargs`  | OpenAI-compatible Chat     | `{ "chat_template_kwargs": { "enable_thinking": true } }`                                             |
+| `none`             | Any supported transport    | No enablement field; logs a warning unless emitted effort already represents `reasoning.enabled=true` |
+
+The `openai` and `openai-responses` enablement selectors require a string map
+when enablement cannot be represented by an emitted effort. For example,
+`"false": "none"` expresses disablement on an API that accepts `none` as its
+effort value.
+
+### Automatic selection
+
+| Active API or Chat host                 | Effort format      | Enablement format |
+| --------------------------------------- | ------------------ | ----------------- |
+| Official OpenAI Chat, `api.openai.com`  | `openai`           | `none`            |
+| OpenAI Responses and Codex              | `openai-responses` | `none`            |
+| OpenRouter Chat, `openrouter.ai`        | `openrouter`       | `openrouter`      |
+| Z.AI or BigModel Chat                   | `openai`           | `thinking`        |
+| Unknown OpenAI-compatible Chat endpoint | `none`             | `none`            |
+| Native Anthropic                        | `anthropic`        | `thinking`        |
+| Native Gemini                           | `gemini`           | `gemini`          |
+
+Subdomains of the listed Chat hosts are recognized. Missing or malformed base
+URLs are treated as unknown. Unknown endpoints stay conservative because some
+OpenAI-compatible servers reject reasoning fields they do not implement.
+Choose a selector in a profile when you know the server's accepted shape.
+
+## Maps
+
+### Effort maps
+
+`reasoning.effortMap` is a JSON object with zero or more of these keys:
+
+- `minimal`
+- `low`
+- `medium`
+- `high`
+- `xhigh`
+- `max`
+
+Each value must be one of:
+
+- a non-empty string for a string-valued effort format;
+- an integer of at least `1024` for `anthropic-budget`;
+- `null` to omit that effort deliberately and log a warning.
+
+For string-valued formats, a missing key passes the generic effort through
+unchanged. This partial map changes `minimal` to `low`; `low`, `medium`, `high`,
+`xhigh`, and `max` retain their original strings:
+
+```json
+{
+  "version": 1,
+  "provider": "openai",
+  "model": "custom-reasoning-model",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "base-url": "https://gateway.example.com/v1",
+    "responses-mode": "chat",
+    "reasoning.enabled": true,
+    "reasoning.effort": "minimal",
+    "reasoning.effortWireFormat": "openai",
+    "reasoning.effortMap": {
+      "minimal": "low"
+    }
+  }
+}
+```
+
+A higher-precedence map replaces the lower-precedence map as one value. Entries
+are not merged. If an alias supplies six entries and a profile supplies only
+`minimal`, the effective map contains only the profile's `minimal` entry.
+
+### Enablement maps
+
+`reasoning.enabledMap` is a JSON object with optional `true` and `false` keys.
+Each value must be a non-empty string, a boolean, or `null`.
+
+The selected format further restricts the mapped value:
+
+| Format                          | Accepted mapped values                                      |
+| ------------------------------- | ----------------------------------------------------------- |
+| `openai`, `openai-responses`    | non-empty strings                                           |
+| `thinking`                      | non-empty strings accepted by the active provider and model |
+| `openrouter`, `template-kwargs` | booleans                                                    |
+| `gemini`                        | booleans or `LOW`, `MEDIUM`, `HIGH`                         |
+| `none`                          | values are not emitted                                      |
+
+A missing enablement key uses the selected format's default behavior. A `null`
+entry deliberately omits the control and logs a warning.
+
+## Exact request shapes
+
+The fragments in this section omit unrelated request fields such as `model` and
+`messages`.
+
+### OpenAI Chat
+
+With `reasoning.effortWireFormat=openai`:
+
+```json
+{
+  "reasoning_effort": "high"
+}
+```
+
+The official OpenAI Chat host selects this effort shape under `auto`. Unknown
+custom hosts do not.
+
+### OpenAI Responses and Codex
+
+With `reasoning.effortWireFormat=openai-responses`:
+
+```json
+{
+  "reasoning": {
+    "effort": "high"
+  }
+}
+```
+
+For GPT-5.6 Responses models that require the Responses API, LLxprt Code changes
+the generic `minimal` value to the wire value `none`. Existing Responses summary
+and encrypted-reasoning controls continue to use the same `reasoning` request
+object.
+
+### OpenRouter Chat
+
+When reasoning is enabled and effort is present, effort represents enablement:
+
+```json
+{
+  "reasoning": {
+    "effort": "high"
+  }
+}
+```
+
+When reasoning is disabled, effort is omitted:
+
+```json
+{
+  "reasoning": {
+    "enabled": false
+  }
+}
+```
+
+### Z.AI and DeepSeek Chat
+
+A Chat endpoint that accepts coordinated thinking and effort uses separate
+selectors, `reasoning.enabledWireFormat=thinking` and
+`reasoning.effortWireFormat=openai`:
+
+```json
+{
+  "thinking": {
+    "type": "enabled"
+  },
+  "reasoning_effort": "high"
+}
+```
+
+With `reasoning.enabled=false`, a supported map can emit
+`thinking.type=disabled`; the effort field is omitted.
+
+### Native Anthropic adaptive thinking
+
+Claude Opus 5 aliases select `thinking` enablement and `anthropic` effort:
+
+```json
+{
+  "thinking": {
+    "type": "adaptive",
+    "display": "summarized"
+  },
+  "output_config": {
+    "effort": "high"
+  }
+}
+```
+
+If `reasoning.includeInResponse` is `false`, adaptive thinking uses
+`"display": "omitted"`. `reasoning.enabled=false` emits
+`{ "thinking": { "type": "disabled" } }` only on models that support disabled
+thinking, and effort is omitted.
+
+### Explicit Anthropic budget
+
+A legacy budgeted model needs a direct budget or a numeric map. This example
+uses a direct `reasoning.budgetTokens` value:
+
+```json
+{
+  "thinking": {
+    "type": "enabled",
+    "budget_tokens": 8192
+  }
+}
+```
+
+A numeric map can produce the same request:
+
+```json
+{
+  "reasoning.effortMap": {
+    "high": 8192
+  }
+}
+```
+
+The numeric map is valid only with
+`reasoning.effortWireFormat=anthropic-budget`.
+`reasoning.budgetTokens` is direct and takes precedence over a mapped budget.
+
+### Gemini 3
+
+Gemini 3 uses thinking levels. The default generic mapping is `minimal` and
+`low` to `LOW`, `medium` to `MEDIUM`, and `high`, `xhigh`, and `max` to `HIGH`:
+
+```json
+{
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingLevel": "HIGH"
+  }
+}
+```
+
+An effort map can provide `LOW`, `MEDIUM`, or `HIGH` directly. Gemini 3 does not
+use `reasoning.maxTokens`; LLxprt Code warns if it is configured.
+
+### Gemini 2
+
+Gemini 2 uses a token budget rather than a thinking level:
+
+```json
+{
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": -1
+  }
+}
+```
+
+`-1` asks Gemini to choose the budget. Set `reasoning.maxTokens` for a specific
+budget. `reasoning.enabled=false` emits a zero budget on Gemini 2. Generic effort
+does not convert to a Gemini 2 token budget and is omitted with a warning.
+
+### Template kwargs
+
+vLLM and other template-driven servers can receive both controls inside
+`chat_template_kwargs`:
+
+```json
+{
+  "chat_template_kwargs": {
+    "enable_thinking": true,
+    "reasoning_effort": "high"
+  }
+}
+```
+
+Unrelated template options are preserved during the merge.
+
+## Profile examples
+
+### vLLM `chat_template_kwargs`
+
+Use this shape when the served chat template reads both kwargs:
+
+```json
+{
+  "version": 1,
+  "provider": "openai",
+  "model": "served-reasoning-model",
+  "modelParams": {
+    "chat_template_kwargs": {
+      "tokenize": false
+    }
+  },
+  "ephemeralSettings": {
+    "base-url": "http://127.0.0.1:8000/v1",
+    "requires-auth": false,
+    "responses-mode": "chat",
+    "reasoning.enabled": true,
+    "reasoning.effort": "high",
+    "reasoning.enabledWireFormat": "template-kwargs",
+    "reasoning.effortWireFormat": "template-kwargs"
+  }
+}
+```
+
+The unrelated `tokenize` sibling remains in `chat_template_kwargs`.
+
+### OpenRouter
+
+The built-in alias already supplies both `openrouter` selectors. This profile
+makes the selected policy visible:
+
+```json
+{
+  "version": 1,
+  "provider": "openrouter",
+  "model": "provider/reasoning-model",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "auth-key-name": "openrouter-prod",
+    "reasoning.enabled": true,
+    "reasoning.effort": "high",
+    "reasoning.enabledWireFormat": "openrouter",
+    "reasoning.effortWireFormat": "openrouter"
+  }
+}
+```
+
+### Anthropic and Claude Opus 5
+
+```json
+{
+  "version": 1,
+  "provider": "anthropic",
+  "model": "claude-opus-5",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "auth-key-name": "anthropic-prod",
+    "reasoning.enabled": true,
+    "reasoning.effort": "high",
+    "reasoning.enabledWireFormat": "thinking",
+    "reasoning.effortWireFormat": "anthropic",
+    "reasoning.effortMap": {
+      "minimal": "low"
+    },
+    "reasoning.enabledMap": {
+      "true": "adaptive",
+      "false": "disabled"
+    }
+  }
+}
+```
+
+### Codex GPT-5.6
+
+The built-in `codex` alias ships these reasoning defaults for GPT-5.6 Sol,
+Terra, and Luna. The explicit profile below makes the selected policy visible:
+
+```json
+{
+  "version": 1,
+  "provider": "codex",
+  "model": "gpt-5.6-sol",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "reasoning.effort": "medium",
+    "reasoning.effortWireFormat": "openai-responses",
+    "reasoning.summary": "auto"
+  }
+}
+```
+
+The reasoning portion of the Responses request is:
+
+```json
+{
+  "reasoning": {
+    "effort": "medium",
+    "summary": "auto"
+  }
+}
+```
+
+The generic `minimal` effort becomes the wire value `none` for these GPT-5.6
+Responses models.
+
+### Z.AI GLM-5.3
+
+The `zai` alias uses its Anthropic-compatible endpoint, and `glm-5.3` is the
+alias default model. The profile below mirrors the shipped GLM-5.3 defaults:
+
+```json
+{
+  "version": 1,
+  "provider": "zai",
+  "model": "glm-5.3",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "auth-key-name": "zai-prod",
+    "reasoning.enabled": true,
+    "reasoning.effort": "high",
+    "reasoning.enabledWireFormat": "thinking",
+    "reasoning.effortWireFormat": "anthropic",
+    "reasoning.effortMap": {
+      "minimal": "low",
+      "low": "low",
+      "medium": "high",
+      "high": "high",
+      "xhigh": "max",
+      "max": "max"
+    },
+    "reasoning.enabledMap": {
+      "true": "enabled"
+    }
+  }
+}
+```
+
+The reasoning portion of the Anthropic request is:
+
+```json
+{
+  "thinking": {
+    "type": "enabled"
+  },
+  "output_config": {
+    "effort": "high"
+  }
+}
+```
+
+No `budget_tokens` value is fabricated for GLM models; the thinking type is
+the only enablement field.
+
+### Kimi K3 and Kimi for Coding K2.7
+
+The built-in `kimi` alias selects different shapes per model. For `kimi-k3`:
+
+```json
+{
+  "version": 1,
+  "provider": "kimi",
+  "model": "kimi-k3",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "auth-key-name": "kimi-prod",
+    "reasoning.enabled": true,
+    "reasoning.effort": "max",
+    "reasoning.enabledWireFormat": "openai",
+    "reasoning.effortWireFormat": "openai",
+    "reasoning.effortMap": {
+      "minimal": "low",
+      "low": "low",
+      "medium": "high",
+      "high": "high",
+      "xhigh": "max",
+      "max": "max"
+    }
+  }
+}
+```
+
+The reasoning portion of the Chat request carries only top-level effort:
+
+```json
+{
+  "reasoning_effort": "max"
+}
+```
+
+For `kimi-for-coding` (K2.7), the alias instead selects enablement-only
+thinking:
+
+```json
+{
+  "version": 1,
+  "provider": "kimi",
+  "model": "kimi-for-coding",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "auth-key-name": "kimi-prod",
+    "reasoning.enabled": true,
+    "reasoning.effortWireFormat": "none",
+    "reasoning.enabledWireFormat": "thinking",
+    "reasoning.enabledMap": {
+      "true": "enabled"
+    }
+  }
+}
+```
+
+The reasoning portion of the Chat request is:
+
+```json
+{
+  "thinking": {
+    "type": "enabled"
+  }
+}
+```
+
+K2.7 emits no effort field; an attempted disablement is suppressed with a
+warning because the shipped map has no supported disable value.
+
+### Deliberate suppression with `none`
+
+Use `none` when you want the model or server to use its own reasoning defaults:
+
+```json
+{
+  "version": 1,
+  "provider": "openai",
+  "model": "server-managed-reasoning-model",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "base-url": "http://127.0.0.1:8080/v1",
+    "requires-auth": false,
+    "responses-mode": "chat",
+    "reasoning.enabled": true,
+    "reasoning.effort": "high",
+    "reasoning.enabledWireFormat": "none",
+    "reasoning.effortWireFormat": "none"
+  }
+}
+```
+
+This is deliberate suppression, not silent fallback. LLxprt Code logs a warning
+for each configured generic control that produces no wire value.
+
+## Precedence and explicit native parameters
+
+Each selector and map is resolved independently in this order, highest first:
+
+1. An explicit profile or session value
+2. The last matching model default from the active provider alias
+3. The provider alias default
+4. `auto` for selectors, or no map for maps
+
+Later matching model rules win. Explicit profile values survive provider and
+model switches. Maps replace as a whole rather than merging entries.
+
+Explicit native reasoning fields in `modelParams` remain authoritative. If a
+native reasoning field collides with automatic translation, LLxprt Code leaves
+the explicit field unchanged and adds no competing representation. Collisions
+include:
+
+- `reasoning`
+- `thinking`
+- `reasoning_effort`
+- `parse_reasoning` on OpenAI-compatible Chat
+- `chat_template_kwargs.reasoning_effort`
+- `chat_template_kwargs.enable_thinking`
+- `output_config.effort`
+- native Gemini `thinkingConfig`
+
+Unrelated nested siblings are merged where the provider supports merging. For
+example, `chat_template_kwargs.tokenize` and `output_config.service_hint` remain
+when translated reasoning adds a sibling field.
+
+LLxprt Code emits only the selected representation. It does not send OpenAI,
+Anthropic, and OpenRouter reasoning shapes together.
+
+## Disablement, suppression, and warnings
+
+`reasoning.enabled=false` suppresses generic effort. If the selected format and
+model support a disable form, LLxprt Code emits it. If no disable form exists,
+LLxprt Code omits effort and logs a warning.
+
+A warning is also logged when:
+
+- `auto` cannot identify a safe format for an unknown Chat endpoint;
+- a selector is explicitly `none`;
+- a selected map entry is `null`;
+- `anthropic-budget` has no direct or mapped numeric budget;
+- a configured generic control cannot be represented by the selected format or
+  model.
+
+The warning identifies the provider, model, selected format, and omitted generic
+setting without printing credentials. Invalid maps and transport-incompatible
+selectors fail before network I/O.
+
+## Alias policy and provider capabilities
+
+A built-in alias records defaults for known models. It does not claim that every
+model exposed by that provider accepts the same fields or values. Provider APIs
+may support controls that LLxprt Code does not enable by default. You can use a
+profile selector when the active transport supports the shape and the provider
+documents the model behavior.
+
+Model-agnostic local aliases, including LM Studio and llama.cpp, do not set an
+effort selector. The model served at the endpoint determines whether `openai`,
+`template-kwargs`, or `none` is appropriate.
+
+### Shipped model restrictions
+
+Each row separates the request shape the alias selects from the model value
+restrictions the same rule encodes.
+
+| Alias or model                          | Request shape                                                                                                                                                      | Accepted model values                                                                                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Opus 5, `anthropic`/`claudecode` | Native `thinking.type` plus `output_config.effort`                                                                                                                 | Enabled maps to `adaptive`, disabled maps to `disabled`; generic `minimal` maps to `low`                                                                        |
+| Codex GPT-5.6 Sol, Terra, and Luna      | Responses `reasoning.effort`                                                                                                                                       | Alias default is `medium`; generic `minimal` becomes wire `none` for these GPT-5.6 Responses models                                                             |
+| OpenAI GPT-5.6 family                   | Chosen transport owns the shape: Responses translation when routing selects Responses; a custom Chat endpoint needs a Chat-compatible selector chosen in a profile | Same GPT-5.6 Responses `minimal` to `none` policy when served over Responses                                                                                    |
+| Kimi K3 and K3 256K                     | Top-level `reasoning_effort`; no `thinking` object                                                                                                                 | Accepted ladder is `low`, `high`, `max`; generic values map to that three-value ladder; alias default is `max` for K3 and `high` for K3 256K                    |
+| Kimi for Coding K2.7                    | `thinking.type=enabled` only; no effort field                                                                                                                      | Disablement has no supported wire value in the shipped map, so it is omitted with a warning                                                                     |
+| Z.AI GLM-5.3                            | The `zai` alias default model on its Anthropic-compatible endpoint: `thinking.type` plus `output_config.effort`                                                    | Generic `minimal`/`low` map to `low`, `medium`/`high` to `high`, `xhigh`/`max` to `max`; disablement is omitted with a warning                                  |
+| Z.AI GLM-5.2                            | The `zai` alias uses `thinking.type` plus `output_config.effort`                                                                                                   | Explicit `minimal` map emits native `minimal` on the wire; `low`/`medium`/`high` map to `high`, `xhigh`/`max` to `max`; enabled and disabled are both supported |
+| DeepSeek V4 family                      | `thinking.type` plus top-level `reasoning_effort`                                                                                                                  | Generic `minimal`/`low` map to `low`, `medium`/`high`/`xhigh` to `high`, and `max` stays `max`                                                                  |
+| Fireworks MiniMax M3                    | Top-level `reasoning_effort`; no Anthropic-style thinking field is added                                                                                           | Disabled maps to effort `none`                                                                                                                                  |
+
+For Z.AI's OpenAI-compatible Chat endpoint, select `openai` effort and `thinking`
+enablement to get the coordinated Chat shape shown above. Endpoint protocol
+choice changes the field location even when the model effort ladder is the same.
+
+## Provider references
+
+Provider documentation changes over time. These links describe the request
+shapes and model restrictions used for the settings and defaults above:
+
+- [OpenAI Chat API](https://platform.openai.com/docs/api-reference/chat)
+- [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses)
+- [OpenRouter reasoning parameters](https://openrouter.ai/docs/api/reference/parameters)
+- [Anthropic extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking)
+- [Anthropic effort](https://platform.claude.com/docs/en/build-with-claude/effort)
+- [Z.AI GLM-5.3](https://docs.z.ai/guides/llm/glm-5.3)
+- [Z.AI reasoning parameters](https://docs.z.ai/guides/overview/concept-param)
+- [Z.AI Coding Plan models](https://docs.z.ai/devpack/latest-model)
+- [Kimi K3 reasoning controls](https://platform.moonshot.ai/docs/guide/kimi-k3-quickstart)
+- [vLLM reasoning outputs and template kwargs](https://docs.vllm.ai/en/latest/features/reasoning_outputs/)
+- [Fireworks reasoning controls](https://docs.fireworks.ai/guides/reasoning)
+- [Fireworks Chat Completions API](https://docs.fireworks.ai/api-reference/post-chatcompletions)
+- [DeepSeek thinking mode](https://api-docs.deepseek.com/guides/thinking_mode/)
+
+## Related pages
+
+- [Ephemeral Settings Reference](../reference/ephemerals.md)
+- [Settings and Profiles](../settings-and-profiles.md)
+- [Provider Setup Quick Reference](./quick-reference.md)

--- a/docs/providers/reasoning-wire-formats.md
+++ b/docs/providers/reasoning-wire-formats.md
@@ -279,8 +279,8 @@ thinking, and effort is omitted.
 
 ### Explicit Anthropic budget
 
-A legacy budgeted model needs a direct budget or a numeric map. This example
-uses a direct `reasoning.budgetTokens` value:
+A legacy model with budgeted thinking needs a direct budget or a numeric
+map. This example uses a direct `reasoning.budgetTokens` value:
 
 ```json
 {

--- a/docs/reference/ephemerals.md
+++ b/docs/reference/ephemerals.md
@@ -29,9 +29,9 @@ the active provider and transport.
 
 ### Reasoning request translation
 
-The four wire translation settings are supported model-behavior settings. They
-remain session-only until saved with `/profile save`, then persist in the
-profile's `ephemeralSettings` object.
+The four wire-format translation settings are supported model-behavior
+settings. They remain session-only until saved with `/profile save`, then
+persist in the profile's `ephemeralSettings` object.
 
 Each selector and map resolves in this order, highest precedence first:
 

--- a/docs/reference/ephemerals.md
+++ b/docs/reference/ephemerals.md
@@ -6,48 +6,65 @@ For guidance on tuning these for specific models, see [Settings and Profiles](..
 
 ## Reasoning
 
-Control extended thinking / chain-of-thought. Most models need `reasoning.enabled true` at minimum; the rest have sensible defaults.
+Control provider-neutral reasoning behavior and select the request shape used by
+the active provider and transport.
 
-| Setting                       | Type    | Default          | Profile | Description                                                                                                                                                                                                                                                                                                                              |
-| ----------------------------- | ------- | ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `reasoning.enabled`           | boolean | `false`          | yes     | Turn on thinking mode. Required for models like Kimi K3, Claude with thinking, GPT-5.x reasoning effort. (For Kimi K3, thinking is always on and cannot be disabled.)                                                                                                                                                                    |
-| `reasoning.effort`            | enum    | provider default | yes     | How hard the model thinks: `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. Higher = slower + more tokens but better results. `max` is model/provider-specific; not all models support all levels. Anthropic Opus defaults to `high`. Codex defaults to `medium`. Project `minimal` maps to OpenAI wire `none` for GPT-5.6 Responses. |
-| `reasoning.maxTokens`         | number  | —                | yes     | Cap the thinking token budget (OpenAI). Limits how much the model can think per turn.                                                                                                                                                                                                                                                    |
-| `reasoning.budgetTokens`      | number  | —                | yes     | Anthropic-specific thinking budget. Usually set automatically via `reasoning.effort` or adaptive thinking.                                                                                                                                                                                                                               |
-| `reasoning.adaptiveThinking`  | boolean | `false`          | yes     | Let Anthropic auto-tune the thinking budget based on task complexity. Enabled by default for Claude via the `anthropic` provider alias.                                                                                                                                                                                                  |
-| `reasoning.includeInResponse` | boolean | `true`           | yes     | Show thinking blocks in the terminal. Set `false` to get reasoning quality without the visual noise.                                                                                                                                                                                                                                     |
-| `reasoning.includeInContext`  | boolean | `true`           | yes     | Keep thinking in conversation history sent to the model. If `false`, the model can't reference its own prior reasoning — hurts multi-step tasks.                                                                                                                                                                                         |
-| `reasoning.stripFromContext`  | enum    | `none`           | yes     | Prune old thinking to manage context growth. `none` = keep all (best quality). `allButLast` = keep only latest thinking (good balance). `all` = discard all thinking from context (saves tokens).                                                                                                                                        |
-| `reasoning.format`            | enum    | —                | yes     | API format: `native` or `field`. Leave unset unless you know your provider needs a specific format.                                                                                                                                                                                                                                      |
-| `reasoning.summary`           | enum    | —                | yes     | OpenAI Responses API reasoning summary: `auto`, `concise`, `detailed`, `none`. Codex alias defaults to `auto`.                                                                                                                                                                                                                           |
-| `text.verbosity`              | enum    | —                | yes     | OpenAI Responses API text verbosity for thinking output: `low`, `medium`, `high`.                                                                                                                                                                                                                                                        |
+| Setting                       | Type    | Default          | Profile | Description                                                                                                                                                    |
+| ----------------------------- | ------- | ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `reasoning.enabled`           | boolean | `false`          | yes     | Turn thinking mode on or off. Some models cannot disable thinking.                                                                                             |
+| `reasoning.effort`            | enum    | provider default | yes     | Generic effort: `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Model-specific maps can normalize this value before it is sent.                         |
+| `reasoning.effortWireFormat`  | enum    | `auto`           | yes     | Effort request shape: `auto`, `openai`, `openai-responses`, `anthropic`, `anthropic-budget`, `openrouter`, `gemini`, `template-kwargs`, or `none`.             |
+| `reasoning.enabledWireFormat` | enum    | `auto`           | yes     | Enablement request shape: `auto`, `openai`, `openai-responses`, `openrouter`, `thinking`, `gemini`, `template-kwargs`, or `none`.                              |
+| `reasoning.effortMap`         | JSON    | no map           | yes     | Object with optional `minimal`, `low`, `medium`, `high`, `xhigh`, and `max` keys. Values are non-empty strings, integer budgets of at least `1024`, or `null`. |
+| `reasoning.enabledMap`        | JSON    | no map           | yes     | Object with optional `true` and `false` keys. Values are non-empty strings, booleans, or `null`.                                                               |
+| `reasoning.maxTokens`         | number  | none             | yes     | Set a native reasoning token limit where the provider supports one.                                                                                            |
+| `reasoning.budgetTokens`      | number  | none             | yes     | Direct Anthropic thinking budget. It takes precedence over a numeric effort map. No universal conversion from generic effort to budget tokens exists.          |
+| `reasoning.adaptiveThinking`  | boolean | `false`          | yes     | Let supported Anthropic models choose a thinking budget. Some Claude model defaults enable it.                                                                 |
+| `reasoning.includeInResponse` | boolean | `true`           | yes     | Show thinking blocks in the terminal.                                                                                                                          |
+| `reasoning.includeInContext`  | boolean | `true`           | yes     | Keep thinking in conversation history sent to the model.                                                                                                       |
+| `reasoning.stripFromContext`  | enum    | `none`           | yes     | Prune old thinking: `none`, `allButLast`, or `all`.                                                                                                            |
+| `reasoning.format`            | enum    | none             | yes     | Response reasoning format: `native` or `field`.                                                                                                                |
+| `reasoning.summary`           | enum    | none             | yes     | OpenAI Responses reasoning summary: `auto`, `concise`, `detailed`, or `none`. Codex defaults to `auto`.                                                        |
+| `text.verbosity`              | enum    | none             | yes     | OpenAI Responses text verbosity: `low`, `medium`, or `high`.                                                                                                   |
 
-### Reasoning dialect on OpenAI-compatible endpoints
+### Reasoning request translation
 
-`reasoning.enabled` and `reasoning.effort` are provider-neutral settings.
-Vendors disagree on how to express them on the wire, so on the OpenAI Chat
-Completions transport llxprt emits **at most one** vendor dialect, chosen from
-the endpoint's base URL:
+The four wire translation settings are supported model-behavior settings. They
+remain session-only until saved with `/profile save`, then persist in the
+profile's `ephemeralSettings` object.
 
-| Base URL host         | Emitted field                                 |
-| --------------------- | --------------------------------------------- |
-| `openrouter.ai`       | `reasoning: { effort }` (or `{ enabled }`)    |
-| `z.ai`, `bigmodel.cn` | `thinking: { type: "enabled" \| "disabled" }` |
-| anything else         | nothing                                       |
+Each selector and map resolves in this order, highest precedence first:
 
-llxprt cannot know an arbitrary OpenAI-compatible endpoint's dialect, and
-guessing gets requests rejected — Friendli answers `422 no such field:
-'reasoning'` and Crusoe answers `403 parameter 'reasoning' is not allowed`.
-So unlisted endpoints get no reasoning field at all and use the model's own
-default.
+1. An explicit profile or session value
+2. The last matching model default from the provider alias
+3. The provider alias default
+4. `auto` for selectors, or no map for maps
 
-To drive a reasoning field on an unlisted endpoint, set it as a model param;
-an explicit model param always wins over the automatic selection and nothing
-else is added alongside it:
+A higher-precedence map replaces the lower-precedence map as a whole. Maps are
+not recursively merged. In a partial string effort map, a missing effort key
+uses the original generic effort string. `anthropic-budget` instead requires a
+numeric mapped value or direct `reasoning.budgetTokens`.
 
-    /set modelparam thinking {"type":"enabled"}
-    /set modelparam reasoning_effort high
-    /set modelparam parse_reasoning true
+Under `auto`, OpenAI Responses, Codex, native Anthropic, native Gemini,
+OpenRouter Chat, Z.AI Chat, and BigModel Chat select their owned request shapes.
+The official `api.openai.com` Chat endpoint selects top-level
+`reasoning_effort`. An unknown OpenAI-compatible Chat endpoint selects `none`.
+This avoids sending fields that a strict custom endpoint may reject. Select a
+format explicitly when you know the server's accepted request shape.
+
+`none` and a selected `null` map entry deliberately omit the generic control and
+produce a warning. `reasoning.enabled=false` suppresses effort. If the selected
+format or model has no disable form, LLxprt Code omits both controls and warns.
+
+Explicit native reasoning fields in `modelParams` remain authoritative. When a
+native field collides with translation, LLxprt Code leaves it unchanged and
+adds no competing reasoning representation. Unrelated nested siblings are
+merged where supported. LLxprt Code does not send several reasoning formats in
+one request.
+
+See [Reasoning Wire Formats](../providers/reasoning-wire-formats.md) for selector
+compatibility, exact request shapes, model restrictions, warnings, and profile
+examples.
 
 ## Context and Compression
 

--- a/docs/settings-and-profiles.md
+++ b/docs/settings-and-profiles.md
@@ -141,24 +141,72 @@ Merged runtime settings keep `model` as the active model string for existing cal
 
 ### Reasoning Settings
 
-These control extended thinking / chain-of-thought for models that support it (Kimi K3, Claude with thinking, GPT-5.x reasoning effort, etc.).
+Use these settings for models that support thinking or reasoning effort.
 
 | Setting                       | Description                                                   | Default          |
 | ----------------------------- | ------------------------------------------------------------- | ---------------- |
-| `reasoning.enabled`           | Enable thinking/reasoning mode                                | `false`          |
+| `reasoning.enabled`           | Enable or disable reasoning                                   | `false`          |
 | `reasoning.effort`            | Effort (`minimal`, `low`, `medium`, `high`, `xhigh`, `max`)   | provider default |
+| `reasoning.effortWireFormat`  | Select the provider request shape for effort                  | `auto`           |
+| `reasoning.enabledWireFormat` | Select the provider request shape for enablement              | `auto`           |
+| `reasoning.effortMap`         | Map generic effort values to model values or numeric budgets  | no map           |
+| `reasoning.enabledMap`        | Map generic booleans to provider values                       | no map           |
 | `reasoning.includeInResponse` | Show thinking blocks in the terminal                          | `true`           |
 | `reasoning.includeInContext`  | Keep thinking in conversation history sent to the model       | `true`           |
 | `reasoning.stripFromContext`  | Prune thinking from older turns (`none`, `all`, `allButLast`) | `none`           |
-| `reasoning.adaptiveThinking`  | Let provider auto-tune thinking budget                        | `false`          |
+| `reasoning.adaptiveThinking`  | Let a supported provider choose a thinking budget             | `false`          |
 
-When you set `reasoning.enabled true`, the other defaults are already sensible — thinking is shown in the terminal, kept in context, and nothing is stripped. You typically only need `/set reasoning.enabled true`.
+#### Run a local server that accepts `reasoning_effort`
 
-**Why these matter:**
+Save a profile like this when a custom OpenAI-compatible Chat server accepts a
+top-level `reasoning_effort` field:
 
-- **`includeInResponse`** — if `false`, the model still thinks but you don't see it. Useful if you want reasoning quality without the noise.
-- **`includeInContext`** — if `false`, thinking blocks are discarded before the next turn. The model loses access to its own reasoning, which can hurt multi-step tasks. Keep this `true` unless you're tight on context.
-- **`stripFromContext`** — controls context growth for long sessions. `none` keeps all thinking (best quality, most tokens). `allButLast` keeps only the most recent thinking block (good balance). `all` strips everything (saves context but the model can't reference prior reasoning). For models with large context windows like K3 (1M), `none` is fine. For smaller windows, `allButLast` or `all` helps.
+```json
+{
+  "version": 1,
+  "provider": "openai",
+  "model": "local-reasoning-model",
+  "modelParams": {},
+  "ephemeralSettings": {
+    "base-url": "http://127.0.0.1:8000/v1",
+    "requires-auth": false,
+    "responses-mode": "chat",
+    "reasoning.enabled": true,
+    "reasoning.effort": "high",
+    "reasoning.effortWireFormat": "openai"
+  }
+}
+```
+
+Load the profile with `llxprt --profile-load <name>`. The resulting Chat request
+contains `"reasoning_effort": "high"`. For a server whose chat template reads
+kwargs instead, use `template-kwargs`; see the
+[vLLM profile example](./providers/reasoning-wire-formats.md#vllm-chat_template_kwargs).
+
+The four wire settings resolve independently in this order, highest precedence
+first: explicit profile or session value, last matched model default, provider
+alias default, then `auto` for selectors or no map for maps. Later matching
+model rules win.
+
+Maps replace as a whole. A profile map does not inherit entries from an alias or
+matched model map. Missing keys in a string-valued `reasoning.effortMap` use the
+generic effort unchanged. For example, a map containing only
+`{ "minimal": "low" }` still sends `high` unchanged when the generic effort is
+`high`.
+
+`reasoning.budgetTokens` is a direct Anthropic budget. Generic effort does not
+automatically produce a token budget because no universal conversion exists.
+To derive a budget from effort, select `anthropic-budget` and provide an explicit
+numeric effort map.
+
+See [Reasoning Wire Formats](./providers/reasoning-wire-formats.md) for all
+selector values, request shapes, warnings, model restrictions, and profile
+examples.
+
+`reasoning.includeInResponse` controls terminal display.
+`reasoning.includeInContext` controls whether thinking remains available on the
+next turn. `reasoning.stripFromContext` controls how older thinking is pruned as
+the conversation grows.
 
 ### Context and Output Limits
 
@@ -272,17 +320,28 @@ llxprt --profile-load kimi-k3 --set streaming=disabled
 
 ## Provider Alias Defaults
 
-Some provider aliases ship with tuned defaults for their models — you get reasonable settings just by using `/provider <name>` without configuring anything. These are a good starting point; you can override any of them with `/set`.
+Some provider aliases supply model settings in addition to their endpoint and
+default model. You can inspect the active values with `/set` and override them
+with a profile or session setting.
 
-**Anthropic** — sets `maxOutputTokens` to 40K globally and `context-limit` to 200K. For Claude models specifically, enables reasoning with adaptive thinking (lets the model decide how much to think). For Claude Opus models, sets `reasoning.effort` to `high`.
+**Anthropic and Claude Code** enable reasoning for Claude models. Claude Opus 5
+uses adaptive thinking, Anthropic effort, and an effort default of `high`.
 
-**Codex** — defaults to GPT-5.6 Sol and lists the Sol, Terra, and Luna tiers. It sets `context-limit` to 262K, enables 24-hour prompt caching, sets `reasoning.effort` to `medium`, and enables reasoning summaries. Use `reasoning.effort max` when maximum GPT-5.6 reasoning is worth the additional latency and tokens.
+**Codex** defaults to GPT-5.6 Sol. Sol, Terra, and Luna use the Responses effort
+shape. The alias sets effort to `medium`, summary to `auto`, and prompt caching
+to `24h`.
 
-**Kimi** — sets `context-limit` to 262K and `max_tokens` to 32K. For Kimi models specifically, enables reasoning with `includeInResponse`, `includeInContext`, and `stripFromContext: none` — full thinking visibility with nothing discarded. The `kimi-k3` model overrides these with its shipped geometry: `context-limit` 1M, `max_tokens` 131072 (K3's default output allocation; the server supports up to 1048576), and `reasoning.effort` `max` (K3 accepts only `low` / `high` / `max`; `medium` is invalid for K3).
+**Kimi** uses different reasoning policies for Kimi K3 and Kimi for Coding K2.7.
+K3 accepts `low`, `high`, and `max`, so its model map normalizes the generic
+ladder. K2.7 coding uses enabled thinking and no effort field.
 
-**Gemini, OpenAI, xAI, OpenRouter, Fireworks** — minimal defaults (just endpoint URL and default model). You configure behavior yourself.
+**OpenRouter** selects its nested `reasoning` object. **Z.AI**, **DeepSeek**, and
+**Fireworks** have model-specific defaults only where a documented model and
+request shape are known. **Gemini** owns its native `thinkingConfig`.
 
-When you load a provider alias, its defaults apply first, then any `/set` overrides or profile settings layer on top. You can inspect what a provider alias sets by looking at its config file in the source, or just check your active settings with `/set` after loading a provider.
+See the [reasoning alias and model matrix](./providers/reasoning-wire-formats.md#shipped-model-restrictions)
+for the exact selectors, maps, and restrictions. Alias defaults are applied
+below explicit profile and session values.
 
 ## Tuning for Your Model
 

--- a/packages/providers/src/anthropic/AnthropicModelData.test.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.test.ts
@@ -102,6 +102,23 @@ describe('AnthropicModelData Claude Sonnet 5 @issue:2289', () => {
       expect(isSonnet5('claude-opus-4-8')).toBe(false);
       expect(isSonnet5('gpt-5.5')).toBe(false);
     });
+
+    it('returns false for complete-prefix near-misses like claude-sonnet-50 and claude-sonnet-5-mini', () => {
+      expect(isSonnet5('claude-sonnet-50')).toBe(false);
+      expect(isSonnet5('claude-sonnet-50-20260630')).toBe(false);
+      expect(isSonnet5('claude-sonnet-5-mini')).toBe(false);
+      expect(isSonnet5('claude-sonnet-5-extended')).toBe(false);
+    });
+
+    it('returns false for vendor-prefixed compat ids (issue #3255)', () => {
+      expect(isSonnet5('vendor-claude-sonnet-5')).toBe(false);
+    });
+
+    it('is case-insensitive for accepted ids', () => {
+      expect(isSonnet5('Claude-Sonnet-5')).toBe(true);
+      expect(isSonnet5('Claude-Sonnet-5-Latest')).toBe(true);
+      expect(isSonnet5('Claude-Sonnet-5-20260630')).toBe(true);
+    });
   });
 
   describe('supportsAdaptiveThinking', () => {

--- a/packages/providers/src/anthropic/AnthropicModelData.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.ts
@@ -199,6 +199,16 @@ export function supportsAdaptiveThinking(modelId: string): boolean {
   return isOpus46Plus(modelId) || isSonnet5(modelId) || isFable5(modelId);
 }
 
+const OPUS_5_PATTERN = /^claude-opus-5(-latest|-\d{8})?$/i;
+
+/**
+ * Whether the model accepts the explicit disabled thinking mode. This is kept
+ * narrower than adaptive-thinking support because those capabilities differ.
+ */
+export function supportsDisabledThinking(modelId: string): boolean {
+  return OPUS_5_PATTERN.test(modelId);
+}
+
 /**
  * Get max output tokens for a given model
  */

--- a/packages/providers/src/anthropic/AnthropicModelData.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.ts
@@ -167,12 +167,24 @@ export function isOpus46Plus(modelId: string): boolean {
 }
 
 /**
+ * Anchored Sonnet 5 identifier: matches the bare `claude-sonnet-5` alias, the
+ * `claude-sonnet-5-latest` pointer, and dated snapshots
+ * (`claude-sonnet-5-YYYYMMDD`), but NOT near-misses like `claude-sonnet-50`,
+ * `claude-sonnet-5-mini`, or vendor-prefixed compat IDs. An anchored regex is
+ * used instead of a prefix test so version boundaries are exact.
+ */
+const SONNET_5_PATTERN = /^claude-sonnet-5(-latest|-\d{8})?$/i;
+
+/**
  * Whether the model is Claude Sonnet 5 (supports adaptive thinking via the
- * effort parameter, 128K max output). Matches the bare alias and dated
- * snapshot variants (e.g. claude-sonnet-5-YYYYMMDD).
+ * effort parameter, 128K max output). Matches the bare alias, the
+ * `claude-sonnet-5-latest` pointer, and dated snapshot variants
+ * (e.g. claude-sonnet-5-YYYYMMDD). Vendor-prefixed compat IDs are not
+ * adaptive-capable Claude models: budget attachment gates on the exact
+ * identifier (issue #3255).
  */
 export function isSonnet5(modelId: string): boolean {
-  return modelId.toLowerCase().includes('claude-sonnet-5');
+  return SONNET_5_PATTERN.test(modelId);
 }
 
 /**

--- a/packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts
@@ -551,6 +551,21 @@ describe('Anthropic reasoning wire translation (issue #3255)', () => {
     expect(JSON.stringify(logger.warnings)).not.toContain('do-not-log');
   });
 
+  it('treats a vendor-prefixed claude-sonnet-5 id as a non-adaptive compat model', async () => {
+    const { body } = await prepare({
+      model: 'vendor-claude-sonnet-5',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.enabledWireFormat': 'thinking',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+    });
+  });
+
   it('lets an explicit adaptive enabled map override adaptiveThinking=false', async () => {
     const { body } = await prepare({
       model: 'claude-opus-5',

--- a/packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts
@@ -1,0 +1,654 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { RuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import { loadProviderAliasEntries } from '../composition/providerAliases.js';
+import { computeModelDefaults } from '../runtime/providerMutations.js';
+import { prepareAnthropicRequest } from './AnthropicRequestPreparation.js';
+
+const PROVIDER_NAME = 'anthropic';
+const BASE_URL = 'https://api.anthropic.com';
+
+interface WarningEntry {
+  readonly message: string;
+  readonly metadata: unknown;
+}
+
+class RecordingDebugLogger extends DebugLogger {
+  readonly warnings: WarningEntry[] = [];
+
+  override warn(
+    messageOrFn: string | (() => string),
+    ...args: unknown[]
+  ): void {
+    this.warnings.push({
+      message: typeof messageOrFn === 'function' ? messageOrFn() : messageOrFn,
+      metadata: args.length === 1 ? args[0] : args,
+    });
+  }
+}
+
+interface RequestFixture {
+  readonly model?: string;
+  readonly baseURL?: string;
+  readonly modelBehavior?: Readonly<Record<string, unknown>>;
+  readonly rawModelBehavior?: Readonly<Record<string, unknown>>;
+  readonly modelParams?: Readonly<Record<string, unknown>>;
+  readonly rawModelParams?: Readonly<Record<string, unknown>>;
+}
+
+interface PreparedFixture {
+  readonly body: Record<string, unknown>;
+  readonly logger: RecordingDebugLogger;
+}
+
+function replaceInvocationInputs(
+  invocation: RuntimeInvocationContext,
+  fixture: RequestFixture,
+): RuntimeInvocationContext {
+  return {
+    ...invocation,
+    modelBehavior: fixture.rawModelBehavior ?? invocation.modelBehavior,
+    modelParams: fixture.rawModelParams ?? invocation.modelParams,
+  } satisfies RuntimeInvocationContext;
+}
+
+async function prepare(fixture: RequestFixture): Promise<PreparedFixture> {
+  const settings = new SettingsService();
+  for (const [key, value] of Object.entries(fixture.modelBehavior ?? {})) {
+    settings.set(key, value);
+  }
+  for (const [key, value] of Object.entries(fixture.modelParams ?? {})) {
+    settings.setProviderSetting(PROVIDER_NAME, key, value);
+  }
+
+  const resolved: NormalizedGenerateChatOptions['resolved'] = {
+    model: fixture.model ?? 'claude-opus-5',
+    baseURL: fixture.baseURL ?? BASE_URL,
+    authToken: 'test-token',
+  };
+  const callOptions = createProviderCallOptions({
+    providerName: PROVIDER_NAME,
+    settings,
+    resolved,
+    contents: [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'test request' }] },
+    ],
+  });
+  const options = {
+    ...callOptions,
+    metadata: callOptions.metadata ?? {},
+    resolved,
+    invocation: replaceInvocationInputs(callOptions.invocation, fixture),
+  } satisfies NormalizedGenerateChatOptions;
+  const logger = new RecordingDebugLogger(
+    'llxprt:providers:anthropic:issue3255-test',
+  );
+  const context = await prepareAnthropicRequest({
+    content: options.contents,
+    tools: options.tools,
+    options,
+    isOAuth: false,
+    placement: 'system-field',
+    providerName: PROVIDER_NAME,
+    config: options.config,
+    getMaxTokensForModel: () => 32000,
+    unprefixToolName: (name: string) => name,
+    providerConfig: undefined,
+    logger,
+    toolsLogger: new DebugLogger(
+      'llxprt:providers:anthropic:issue3255-test:tools',
+    ),
+    cacheLogger: { debug: () => undefined },
+  });
+  return { body: context.requestBody, logger };
+}
+
+function reasoningFields(
+  body: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of ['thinking', 'output_config', 'reasoning_effort']) {
+    if (key in body) {
+      result[key] = body[key];
+    }
+  }
+  return result;
+}
+
+describe('Anthropic reasoning wire translation (issue #3255)', () => {
+  it('emits adaptive Opus 5 thinking and native effort without a budget', async () => {
+    const { body } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      output_config: { effort: 'high' },
+    });
+  });
+
+  it('applies an effort map before Opus 5 effort normalization', async () => {
+    const { body } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'minimal',
+        'reasoning.effortMap': { minimal: 'low' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      output_config: { effort: 'low' },
+    });
+  });
+
+  it('emits an explicit GLM-5.2 minimal map as native minimal effort', async () => {
+    const { body } = await prepare({
+      model: 'glm-5.2',
+      baseURL: 'https://api.z.ai/api/anthropic',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'minimal',
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'enabled' },
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.effortMap': { minimal: 'minimal' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+      output_config: { effort: 'minimal' },
+    });
+  });
+
+  it('normalizes unmapped generic minimal to low for native Claude', async () => {
+    const { body } = await prepare({
+      model: 'claude-opus-5',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'minimal',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      output_config: { effort: 'low' },
+    });
+  });
+
+  it('emits disabled thinking for Opus 5 and suppresses effort', async () => {
+    const { body } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'disabled' },
+    });
+  });
+
+  it('preserves direct legacy budget behavior under auto selection', async () => {
+    const { body } = await prepare({
+      model: 'claude-sonnet-4-5-20250929',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.budgetTokens': 12000,
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled', budget_tokens: 12000 },
+    });
+  });
+
+  it('uses a numeric effort map for explicit anthropic-budget selection', async () => {
+    const { body } = await prepare({
+      model: 'claude-sonnet-4-5-20250929',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'anthropic-budget',
+        'reasoning.effortMap': { high: 8192 },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled', budget_tokens: 8192 },
+    });
+  });
+
+  it('does not fabricate a budget for explicit anthropic-budget selection', async () => {
+    const { body, logger } = await prepare({
+      model: 'claude-sonnet-4-5-20250929',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'anthropic-budget',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toContainEqual({
+      message:
+        "Anthropic omitted configured reasoning.effort because effort format 'anthropic-budget' cannot emit it",
+      metadata: {
+        providerName: PROVIDER_NAME,
+        model: 'claude-sonnet-4-5-20250929',
+        format: 'anthropic-budget',
+        setting: 'reasoning.effort',
+        reason: 'numeric-effort-map-required',
+      },
+    });
+  });
+
+  it('expresses Z.AI GLM-5.3 native thinking and effort through explicit settings', async () => {
+    const { body } = await prepare({
+      model: 'glm-5.3',
+      baseURL: 'https://api.z.ai/api/anthropic?token=do-not-log',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'enabled' },
+        'reasoning.effortWireFormat': 'anthropic',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+      output_config: { effort: 'high' },
+    });
+  });
+
+  it('applies an explicit GLM effort remap without a budget representation', async () => {
+    const { body } = await prepare({
+      model: 'glm-5.3',
+      baseURL: 'https://api.z.ai/api/anthropic',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'medium',
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'enabled' },
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.effortMap': { medium: 'high' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+      output_config: { effort: 'high' },
+    });
+  });
+
+  it.each([
+    {
+      setting: 'reasoning.effortWireFormat',
+      settingValue: 'none',
+      extra: {},
+      reason: 'effort-format-none',
+      format: 'none',
+    },
+    {
+      setting: 'reasoning.effortMap',
+      settingValue: { high: null },
+      extra: {},
+      reason: 'effort-map-null',
+      format: 'anthropic',
+    },
+  ] satisfies ReadonlyArray<{
+    readonly setting: string;
+    readonly settingValue: unknown;
+    readonly extra: Readonly<Record<string, unknown>>;
+    readonly reason: string;
+    readonly format: string;
+  }>)(
+    'omits effort and warns for $reason',
+    async ({ setting, settingValue, extra, reason, format }) => {
+      const { body, logger } = await prepare({
+        model: 'claude-opus-5',
+        baseURL: 'https://api.anthropic.com?token=do-not-log',
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+          [setting]: settingValue,
+          ...extra,
+        },
+      });
+
+      expect(body['output_config']).toBeUndefined();
+      expect(logger.warnings).toContainEqual({
+        message: `Anthropic omitted configured reasoning.effort because effort format '${format}' cannot emit it`,
+        metadata: {
+          providerName: PROVIDER_NAME,
+          model: 'claude-opus-5',
+          format,
+          setting: 'reasoning.effort',
+          reason,
+        },
+      });
+      expect(JSON.stringify(logger.warnings)).not.toContain('do-not-log');
+    },
+  );
+
+  it('preserves explicit thinking and makes all generic injection stand down', async () => {
+    const explicitThinking = {
+      type: 'enabled',
+      budget_tokens: 4096,
+      provider_extension: 'preserved',
+    };
+    const { body, logger } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+      },
+      modelParams: { thinking: explicitThinking },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({ thinking: explicitThinking });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('passes an explicit future thinking type through unchanged and stands down', async () => {
+    const explicitThinking = {
+      type: 'priority',
+      priority_tier: 'maximum',
+      budget_tokens_hint: 8192,
+    };
+    const { body, logger } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+      },
+      modelParams: { thinking: explicitThinking },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({ thinking: explicitThinking });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('preserves explicit output_config effort and makes all generic injection stand down', async () => {
+    const explicitOutputConfig = { effort: 'low', service_hint: 'preserved' };
+    const { body, logger } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+      },
+      modelParams: { output_config: explicitOutputConfig },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      output_config: explicitOutputConfig,
+    });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('merges translated effort into unrelated output_config siblings', async () => {
+    const { body } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'medium',
+      },
+      modelParams: { output_config: { service_hint: 'preserved' } },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      output_config: { service_hint: 'preserved', effort: 'medium' },
+    });
+  });
+
+  it.each([
+    ['thinking', null, 'thinking must be an object'],
+    ['thinking', [], 'thinking must be an object'],
+    [
+      'thinking',
+      { budget_tokens: 4096 },
+      'thinking.type must be a non-empty string',
+    ],
+    ['output_config', 'high', 'output_config must be an object'],
+    [
+      'output_config',
+      { effort: 3 },
+      'output_config.effort must be a non-empty string',
+    ],
+  ] satisfies ReadonlyArray<readonly [string, unknown, string]>)(
+    'fails before transport for malformed explicit %s',
+    async (setting, value, message) => {
+      const request = prepare({ rawModelParams: { [setting]: value } });
+
+      await expect(request).rejects.toThrow(message);
+    },
+  );
+
+  it('fails before transport for an incompatible selector', async () => {
+    const request = prepare({
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openrouter',
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      "effort wire format 'openrouter' is incompatible with the anthropic adapter",
+    );
+  });
+
+  it('fails before transport for an invalid mapped type', async () => {
+    const request = prepare({
+      rawModelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.effortMap': { high: 8192 },
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      'reasoning.effortMap.high must be a string for anthropic',
+    );
+  });
+
+  it('emits native effort when effort is configured without enablement', async () => {
+    const { body } = await prepare({
+      modelBehavior: { 'reasoning.effort': 'medium' },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      output_config: { effort: 'medium' },
+    });
+  });
+
+  it('emits an anthropic-budget numeric map without redundant enablement input', async () => {
+    const { body } = await prepare({
+      model: 'claude-sonnet-4-5-20250929',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'anthropic-budget',
+        'reasoning.effortMap': { high: 8192 },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled', budget_tokens: 8192 },
+    });
+  });
+
+  it('omits unsupported Sonnet 5 disablement and warns without leaking endpoint data', async () => {
+    const { body, logger } = await prepare({
+      model: 'claude-sonnet-5',
+      baseURL: 'https://api.anthropic.com?token=do-not-log',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toContainEqual({
+      message:
+        "Anthropic omitted configured reasoning.enabled because enabled format 'thinking' cannot emit it",
+      metadata: {
+        providerName: PROVIDER_NAME,
+        model: 'claude-sonnet-5',
+        format: 'thinking',
+        setting: 'reasoning.enabled',
+        reason: 'model-cannot-disable-thinking',
+      },
+    });
+    expect(JSON.stringify(logger.warnings)).not.toContain('do-not-log');
+  });
+
+  it('lets an explicit adaptive enabled map override adaptiveThinking=false', async () => {
+    const { body } = await prepare({
+      model: 'claude-opus-5',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.adaptiveThinking': false,
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'adaptive' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+    });
+  });
+
+  it.each([
+    ['reasoning.enabled', 'true', 'reasoning.enabled must be a boolean'],
+    ['reasoning.effort', 'ultra', "reasoning.effort must be one of 'minimal'"],
+    [
+      'reasoning.budgetTokens',
+      0,
+      'reasoning.budgetTokens must be a positive integer',
+    ],
+    [
+      'reasoning.adaptiveThinking',
+      'false',
+      'reasoning.adaptiveThinking must be a boolean',
+    ],
+    [
+      'reasoning.enabledWireFormat',
+      'custom',
+      "reasoning.enabledWireFormat must be one of 'auto'",
+    ],
+    ['reasoning.effortMap', [], 'reasoning.effortMap must be a JSON object'],
+    ['reasoning.enabledMap', [], 'reasoning.enabledMap must be a JSON object'],
+  ] satisfies ReadonlyArray<readonly [string, unknown, string]>)(
+    'strictly rejects malformed invocation behavior for %s',
+    async (setting, value, expected) => {
+      const request = prepare({ rawModelBehavior: { [setting]: value } });
+
+      await expect(request).rejects.toThrow(expected);
+    },
+  );
+
+  it('fails before transport when Opus 5 disables adaptive thinking without a budget', async () => {
+    const request = prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.adaptiveThinking': false,
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      "Model 'claude-opus-5' supports adaptive thinking: budgeted thinking requires an explicit reasoning.budgetTokens",
+    );
+  });
+
+  it('fails before transport for an explicit enabled map without a budget on an adaptive model', async () => {
+    const request = prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.adaptiveThinking': false,
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'enabled' },
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      "Model 'claude-opus-5' supports adaptive thinking: budgeted thinking requires an explicit reasoning.budgetTokens",
+    );
+  });
+
+  it('keeps a directly configured Opus 5 budget authoritative in manual mode', async () => {
+    const { body } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.adaptiveThinking': false,
+        'reasoning.budgetTokens': 6000,
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled', budget_tokens: 6000 },
+    });
+  });
+
+  it('preserves Fable 5 always-adaptive behavior without duplicate representations', async () => {
+    const { body } = await prepare({
+      model: 'claude-fable-5',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'medium',
+        'reasoning.budgetTokens': 8000,
+        'reasoning.adaptiveThinking': false,
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'adaptive', display: 'summarized' },
+      output_config: { effort: 'medium' },
+    });
+  });
+
+  it('sends the built-in zai alias default model through the final request without a fabricated budget', async () => {
+    const aliasEntry = loadProviderAliasEntries().find(
+      (candidate) =>
+        candidate.source === 'builtin' && candidate.alias === 'zai',
+    );
+    if (!aliasEntry) {
+      throw new Error('Builtin zai alias entry not found');
+    }
+    const model = aliasEntry.config.defaultModel;
+    if (typeof model !== 'string' || model === '') {
+      throw new Error('Builtin zai alias entry must declare a default model');
+    }
+    const baseUrl = aliasEntry.config['base-url'];
+    if (typeof baseUrl !== 'string') {
+      throw new Error('Builtin zai alias entry must declare a base URL');
+    }
+    const modelBehavior: Record<string, unknown> = {
+      ...aliasEntry.config.ephemeralSettings,
+      ...computeModelDefaults(model, aliasEntry.config.modelDefaults ?? []),
+    };
+
+    const { body } = await prepare({
+      model,
+      baseURL: baseUrl,
+      modelBehavior,
+    });
+
+    expect(model).toBe('glm-5.3');
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+      output_config: { effort: 'high' },
+    });
+    expect(JSON.stringify(body)).not.toContain('budget_tokens');
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts
@@ -117,7 +117,7 @@ function reasoningFields(
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const key of ['thinking', 'output_config', 'reasoning_effort']) {
-    if (key in body) {
+    if (Object.prototype.hasOwnProperty.call(body, key)) {
       result[key] = body[key];
     }
   }
@@ -200,6 +200,44 @@ describe('Anthropic reasoning wire translation (issue #3255)', () => {
     expect(reasoningFields(body)).toStrictEqual({
       thinking: { type: 'disabled' },
     });
+  });
+
+  it('warns separately for dropped effort and budget when disabled', async () => {
+    const { body, logger } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+        'reasoning.budgetTokens': 6000,
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'disabled' },
+    });
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "Anthropic omitted configured reasoning.effort because effort format 'anthropic' cannot emit it",
+        metadata: {
+          providerName: PROVIDER_NAME,
+          model: 'claude-opus-5',
+          format: 'anthropic',
+          setting: 'reasoning.effort',
+          reason: 'reasoning-disabled',
+        },
+      },
+      {
+        message:
+          "Anthropic omitted configured reasoning.budgetTokens because budget format 'anthropic' cannot emit it",
+        metadata: {
+          providerName: PROVIDER_NAME,
+          model: 'claude-opus-5',
+          format: 'anthropic',
+          setting: 'reasoning.budgetTokens',
+          reason: 'reasoning-disabled',
+        },
+      },
+    ]);
   });
 
   it('preserves direct legacy budget behavior under auto selection', async () => {
@@ -600,6 +638,41 @@ describe('Anthropic reasoning wire translation (issue #3255)', () => {
     });
   });
 
+  it('selects manual budgeted thinking when a direct budget meets an adaptive enabled map', async () => {
+    const { body } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.budgetTokens': 6000,
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'adaptive' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled', budget_tokens: 6000 },
+      output_config: { effort: 'high' },
+    });
+  });
+
+  it('rejects a direct Fable 5 budget before transport instead of ignoring it', async () => {
+    const request = prepare({
+      model: 'claude-fable-5',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.budgetTokens': 6000,
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'adaptive' },
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      "Model 'claude-fable-5' is adaptive-only: reasoning.budgetTokens cannot select budgeted thinking. Remove reasoning.budgetTokens to use adaptive thinking.",
+    );
+  });
+
   it('preserves Fable 5 always-adaptive behavior without duplicate representations', async () => {
     const { body } = await prepare({
       model: 'claude-fable-5',
@@ -614,6 +687,39 @@ describe('Anthropic reasoning wire translation (issue #3255)', () => {
     expect(reasoningFields(body)).toStrictEqual({
       thinking: { type: 'adaptive', display: 'summarized' },
       output_config: { effort: 'medium' },
+    });
+  });
+
+  it('rejects an anthropic-budget selection for Fable 5 before transport', async () => {
+    const request = prepare({
+      model: 'claude-fable-5',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'anthropic-budget',
+        'reasoning.effortMap': { high: 8192 },
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      "Model 'claude-fable-5' is adaptive-only: the anthropic-budget effort format cannot emit budgeted thinking. Use the 'anthropic' effort format or remove reasoning.effortWireFormat=anthropic-budget.",
+    );
+  });
+
+  it('reports only own reasoning properties and ignores inherited ones', () => {
+    const body: Record<string, unknown> = Object.create({
+      reasoning_effort: 'inherited',
+    });
+    body['thinking'] = { type: 'enabled' };
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+    });
+
+    body['reasoning_effort'] = 'own';
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+      reasoning_effort: 'own',
     });
   });
 

--- a/packages/providers/src/anthropic/AnthropicProvider.thinking.config.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.thinking.config.test.ts
@@ -122,7 +122,11 @@ describe('AnthropicProvider Extended Thinking @plan:PLAN-ANTHROPIC-THINKING', ()
       ];
 
       const generator = provider.generateChatCompletion(
-        buildCallOptions(messages),
+        buildCallOptions(messages, {
+          settingsOverrides: {
+            global: { model: 'claude-sonnet-4-5-20250929' },
+          },
+        }),
       );
       await generator.next();
 
@@ -252,14 +256,9 @@ describe('AnthropicProvider Extended Thinking @plan:PLAN-ANTHROPIC-THINKING', ()
       expect(request.thinking?.budget_tokens).toBe(15000);
     });
 
-    it('should use manual mode when adaptiveThinking is explicitly false @issue:1307', async () => {
+    it('should fail fast when adaptiveThinking is explicitly false without a budget @issue:1307', async () => {
       settingsService.set('reasoning.enabled', true);
       settingsService.set('reasoning.adaptiveThinking', false);
-
-      mockMessagesCreate.mockResolvedValueOnce({
-        content: [{ type: 'text', text: 'response' }],
-        usage: { input_tokens: 100, output_tokens: 50 },
-      });
 
       const messages: IContent[] = [
         {
@@ -277,13 +276,13 @@ describe('AnthropicProvider Extended Thinking @plan:PLAN-ANTHROPIC-THINKING', ()
           },
         }),
       );
-      await generator.next();
 
-      const request = mockMessagesCreate.mock
-        .calls[0][0] as AnthropicRequestBody;
-      expect(request.thinking).toBeDefined();
-      expect(request.thinking?.type).toBe('enabled');
-      expect(request.thinking?.budget_tokens).toBe(10000); // default
+      // Opus 4.6 is adaptive-capable and has no legacy budget default, so
+      // budgeted thinking without an explicit reasoning.budgetTokens fails
+      // before transport instead of fabricating one (issue #3255).
+      await expect(generator.next()).rejects.toThrow(
+        "Model 'claude-opus-4-6' supports adaptive thinking: budgeted thinking requires an explicit reasoning.budgetTokens",
+      );
     });
 
     it('should place effort in output_config not under thinking @issue:1307', async () => {

--- a/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
@@ -274,13 +274,37 @@ export function attachPromptCaching(
   }
 }
 
+export type AnthropicEffortLiteral = 'low' | 'medium' | 'high' | 'max';
+
+/**
+ * The `thinking` parameter value: either a translated config or an explicit
+ * native record passed through from modelParams. The shape is deliberately
+ * broad (any object with a non-empty `type` string) so future or
+ * non-enumerated native thinking modes reach the wire unchanged. The known
+ * translated shapes ({type:'adaptive'}, {type:'enabled', budget_tokens},
+ * {type:'disabled'}) are assignable to this record, so they document the
+ * translation outputs rather than forming a separate union arm that the
+ * record arm would subsume anyway (issue #3255).
+ */
+export type AnthropicThinkingParameter = Readonly<Record<string, unknown>> & {
+  readonly type: string;
+};
+
+/**
+ * The `output_config` parameter value. A translated config carries
+ * `effort: AnthropicEffortLiteral`; an explicit native record keeps
+ * arbitrary members. The generic record admits both, so no separate
+ * translated arm is declared (issue #3255).
+ */
+export type AnthropicOutputConfigParameter = Readonly<Record<string, unknown>>;
+
 type AnthropicThinkingConfig = {
   thinking?: {
-    type: 'adaptive' | 'enabled';
+    type: 'adaptive' | 'enabled' | 'disabled';
     budget_tokens?: number;
     display?: 'summarized' | 'omitted';
   };
-  output_config?: { effort: 'low' | 'medium' | 'high' | 'max' };
+  output_config?: { effort: AnthropicEffortLiteral };
 };
 
 /**
@@ -308,6 +332,31 @@ function buildAdaptiveConfig(
     config.output_config = { effort: thinkingEffort };
   }
   return config;
+}
+
+/**
+ * Legacy default budget for budgeted thinking when no explicit
+ * reasoning.budgetTokens is configured. Not a public default: only the two
+ * legacy manual-budget sites in this package use it (issue #3255).
+ */
+export const ANTHROPIC_LEGACY_DEFAULT_BUDGET_TOKENS = 10000;
+
+/**
+ * Adaptive-capable models have no legacy budget default: request preparation
+ * must fail before transport instead of fabricating one. No effort-to-budget
+ * conversion is invented (issue #3255); a directly configured
+ * reasoning.budgetTokens remains the explicit compatibility path.
+ */
+export function assertAdaptiveManualBudget(
+  model: string,
+  budgetTokens: number | undefined,
+): void {
+  if (budgetTokens !== undefined || !supportsAdaptiveThinking(model)) {
+    return;
+  }
+  throw new Error(
+    `Model '${model}' supports adaptive thinking: budgeted thinking requires an explicit reasoning.budgetTokens. Set reasoning.budgetTokens, remove reasoning.adaptiveThinking=false, or map reasoning.enabledMap.true to 'adaptive'.`,
+  );
 }
 
 /**
@@ -354,10 +403,13 @@ export function buildThinkingConfig(options: {
     return buildAdaptiveConfig(options.thinkingEffort, display);
   }
 
+  assertAdaptiveManualBudget(options.model, options.reasoningBudgetTokens);
+
   const config: AnthropicThinkingConfig = {
     thinking: {
       type: 'enabled' as const,
-      budget_tokens: options.reasoningBudgetTokens ?? 10000,
+      budget_tokens:
+        options.reasoningBudgetTokens ?? ANTHROPIC_LEGACY_DEFAULT_BUDGET_TOKENS,
       ...(options.includeInResponse === false
         ? { display: 'omitted' as const }
         : {}),
@@ -400,12 +452,8 @@ export function buildAnthropicRequestBody(options: {
   maxTokens: number;
   streamingEnabled: boolean;
   modelParams: Record<string, unknown>;
-  thinking?: {
-    type: 'adaptive' | 'enabled';
-    budget_tokens?: number;
-    display?: 'summarized' | 'omitted';
-  };
-  outputConfig?: { effort: 'low' | 'medium' | 'high' | 'max' };
+  thinking?: AnthropicThinkingParameter;
+  outputConfig?: AnthropicOutputConfigParameter;
 }): Record<string, unknown> {
   const requestBody: Record<string, unknown> = {
     model: options.model,

--- a/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
@@ -11,7 +11,6 @@
  * @issue #1572 - Decomposing AnthropicProvider (Step 5)
  */
 
-import { supportsAdaptiveThinking } from './AnthropicModelData.js';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
@@ -25,10 +24,14 @@ import { convertToolsToAnthropic } from './schemaConverter.js';
 import {
   buildAnthropicSystemPrompt,
   attachPromptCaching,
-  buildThinkingConfig,
   buildAnthropicRequestBody,
   sortObjectKeys,
 } from './AnthropicRequestBuilder.js';
+import {
+  buildAnthropicNativeReasoningConfig,
+  readAnthropicReasoningSettings,
+  type AnthropicReasoningSettings,
+} from './anthropic-reasoning-config.js';
 import { getRetryConfig } from './AnthropicRateLimitHandler.js';
 import {
   isAnthropicOAuthBaseURL,
@@ -79,20 +82,6 @@ export interface PrepareRequestParams {
 }
 
 /**
- * Helper to resolve model behavior settings with fallback to options.settings
- */
-function resolveModelBehavior<T>(
-  options: NormalizedGenerateChatOptions,
-  key: string,
-): T | undefined {
-  const fromBehavior =
-    typeof options.invocation.getModelBehavior === 'function'
-      ? options.invocation.getModelBehavior(key)
-      : undefined;
-  return (fromBehavior ?? options.settings.get(key)) as T | undefined;
-}
-
-/**
  * Helper to resolve CLI settings with fallback to options.settings
  */
 function resolveCliSetting<T>(
@@ -107,23 +96,23 @@ function resolveCliSetting<T>(
 }
 
 /**
+ * Legacy normalized-option fixtures can omit the invocation modelBehavior
+ * record; a missing record reads as empty so the options.settings fallbacks
+ * supply the reasoning values.
+ */
+function readInvocationRecord(
+  record: Readonly<Record<string, unknown>> | undefined,
+): Readonly<Record<string, unknown>> {
+  return record ?? {};
+}
+
+/**
  * Reasoning settings resolved from invocation
  */
-interface ReasoningSettings {
-  reasoningEnabled: boolean | undefined;
-  reasoningBudgetTokens: number | undefined;
+interface ReasoningSettings extends AnthropicReasoningSettings {
   stripFromContext: 'all' | 'allButLast' | 'none' | undefined;
   includeInContext: boolean | undefined;
   includeInResponse: boolean | undefined;
-  adaptiveThinking: boolean | undefined;
-  rawEffort:
-    | 'minimal'
-    | 'low'
-    | 'medium'
-    | 'high'
-    | 'xhigh'
-    | 'max'
-    | undefined;
 }
 
 /**
@@ -175,13 +164,18 @@ interface SystemContextResult {
 function resolveReasoningSettings(
   options: NormalizedGenerateChatOptions,
 ): ReasoningSettings {
-  const reasoningEnabled = resolveModelBehavior<boolean>(
-    options,
-    'reasoning.enabled',
-  );
-  const reasoningBudgetTokens = resolveModelBehavior<number>(
-    options,
-    'reasoning.budgetTokens',
+  const nativeReasoning = readAnthropicReasoningSettings(
+    readInvocationRecord(options.invocation.modelBehavior),
+    {
+      enabled: options.settings.get('reasoning.enabled'),
+      effort: options.settings.get('reasoning.effort'),
+      budgetTokens: options.settings.get('reasoning.budgetTokens'),
+      adaptiveThinking: options.settings.get('reasoning.adaptiveThinking'),
+      effortWireFormat: options.settings.get('reasoning.effortWireFormat'),
+      enabledWireFormat: options.settings.get('reasoning.enabledWireFormat'),
+      effortMap: options.settings.get('reasoning.effortMap'),
+      enabledMap: options.settings.get('reasoning.enabledMap'),
+    },
   );
   const stripFromContext = resolveCliSetting<'all' | 'allButLast' | 'none'>(
     options,
@@ -195,22 +189,12 @@ function resolveReasoningSettings(
     options,
     'reasoning.includeInResponse',
   );
-  const adaptiveThinking = resolveModelBehavior<boolean>(
-    options,
-    'reasoning.adaptiveThinking',
-  );
-  const rawEffort = resolveModelBehavior<
-    'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
-  >(options, 'reasoning.effort');
 
   return {
-    reasoningEnabled,
-    reasoningBudgetTokens,
+    ...nativeReasoning,
     stripFromContext,
     includeInContext,
     includeInResponse,
-    adaptiveThinking,
-    rawEffort,
   };
 }
 
@@ -442,54 +426,14 @@ function buildSystemContext(params: {
   return { systemField, messages };
 }
 
-function mapEffortLevel(
-  rawEffort:
-    | 'minimal'
-    | 'low'
-    | 'medium'
-    | 'high'
-    | 'xhigh'
-    | 'max'
-    | undefined,
-  currentModel: string,
-): 'low' | 'medium' | 'high' | 'max' | undefined {
-  if (!rawEffort) {
-    return undefined;
-  }
-
-  const adaptiveCapable = supportsAdaptiveThinking(currentModel);
-
-  if (rawEffort === 'minimal' || rawEffort === 'low') {
-    return 'low';
-  } else if (rawEffort === 'medium') {
-    return 'medium';
-  } else if (rawEffort === 'high') {
-    return 'high';
-  } else if (rawEffort === 'xhigh') {
-    return adaptiveCapable ? 'max' : 'high';
-  }
-
-  // rawEffort is 'max' here
-  return adaptiveCapable ? 'max' : 'high';
-}
-
 /**
  * Build thinking configuration and request body
  */
 function buildThinkingAndRequestBody(params: {
   currentModel: string;
-  rawEffort:
-    | 'minimal'
-    | 'low'
-    | 'medium'
-    | 'high'
-    | 'xhigh'
-    | 'max'
-    | undefined;
-  shouldIncludeThinking: boolean;
-  reasoningBudgetTokens: number | undefined;
-  adaptiveThinking: boolean | undefined;
-  includeInResponse: boolean | undefined;
+  reasoningSettings: ReasoningSettings;
+  providerName: string;
+  logger: DebugLogger;
   anthropicMessages: AnthropicMessage[];
   systemField:
     | string
@@ -506,46 +450,31 @@ function buildThinkingAndRequestBody(params: {
   streamingEnabled: boolean;
   requestOverrides: Record<string, unknown>;
 }): Record<string, unknown> {
-  const {
-    currentModel,
-    rawEffort,
-    shouldIncludeThinking,
-    reasoningBudgetTokens,
-    adaptiveThinking,
-    includeInResponse,
-    anthropicMessages,
-    systemField,
-    anthropicTools,
-    getMaxTokensForModel,
-    streamingEnabled,
-    requestOverrides,
-  } = params;
-
-  const mappedEffort = mapEffortLevel(rawEffort, currentModel);
-
-  const thinkingConfig = buildThinkingConfig({
-    reasoningEnabled: shouldIncludeThinking,
-    reasoningBudgetTokens,
-    adaptiveThinking,
-    includeInResponse,
-    thinkingEffort: mappedEffort,
-    model: currentModel,
+  const nativeReasoning = buildAnthropicNativeReasoningConfig({
+    settings: params.reasoningSettings,
+    modelParams: params.requestOverrides,
+    model: params.currentModel,
+    providerName: params.providerName,
+    includeInResponse: params.reasoningSettings.includeInResponse,
+    logger: params.logger,
   });
 
   return buildAnthropicRequestBody({
-    model: currentModel,
-    messages: anthropicMessages,
-    system: systemField,
+    model: params.currentModel,
+    messages: params.anthropicMessages,
+    system: params.systemField,
     tools:
-      anthropicTools && anthropicTools.length > 0 ? anthropicTools : undefined,
+      params.anthropicTools && params.anthropicTools.length > 0
+        ? params.anthropicTools
+        : undefined,
     maxTokens: resolveRequestMaxTokens(
-      getMaxTokensForModel(currentModel),
-      requestOverrides,
+      params.getMaxTokensForModel(params.currentModel),
+      params.requestOverrides,
     ),
-    streamingEnabled,
-    modelParams: requestOverrides,
-    thinking: thinkingConfig.thinking,
-    outputConfig: thinkingConfig.output_config,
+    streamingEnabled: params.streamingEnabled,
+    modelParams: params.requestOverrides,
+    thinking: nativeReasoning.thinking,
+    outputConfig: nativeReasoning.outputConfig,
   });
 }
 
@@ -584,7 +513,7 @@ function convertMessagesAndTools(params: {
     isOAuth: params.isOAuth,
     stripFromContext: reasoningSettings.stripFromContext,
     includeInContext: reasoningSettings.includeInContext,
-    reasoningEnabled: reasoningSettings.reasoningEnabled as boolean,
+    reasoningEnabled: reasoningSettings.enabled === true,
     config,
     currentModel,
     currentBaseURL,
@@ -669,7 +598,7 @@ function buildRequestContext(params: {
     | undefined;
   systemContext: SystemContextResult;
   getMaxTokensForModel: (model: string) => number;
-  shouldIncludeThinking: boolean;
+  providerName: string;
   cacheLogger: { debug: (fn: () => string) => void };
   toolsLogger: DebugLogger;
   logger: DebugLogger;
@@ -681,7 +610,7 @@ function buildRequestContext(params: {
     anthropicTools,
     systemContext,
     getMaxTokensForModel,
-    shouldIncludeThinking,
+    providerName,
     cacheLogger,
     toolsLogger,
     logger,
@@ -711,11 +640,9 @@ function buildRequestContext(params: {
 
   const requestBody = buildThinkingAndRequestBody({
     currentModel: requestSettings.currentModel,
-    rawEffort: reasoningSettings.rawEffort,
-    shouldIncludeThinking,
-    reasoningBudgetTokens: reasoningSettings.reasoningBudgetTokens,
-    adaptiveThinking: reasoningSettings.adaptiveThinking,
-    includeInResponse: reasoningSettings.includeInResponse,
+    reasoningSettings,
+    providerName,
+    logger,
     anthropicMessages: systemContext.messages,
     systemField: systemContext.systemField,
     anthropicTools,
@@ -760,7 +687,7 @@ export async function prepareAnthropicRequest(
 
   params.logger.debug(
     () =>
-      `[AnthropicProvider] Reasoning settings from invocation.modelBehavior (fallback to options.settings): enabled=${String(reasoningSettings.reasoningEnabled)}, budgetTokens=${String(reasoningSettings.reasoningBudgetTokens)}, stripFromContext=${String(reasoningSettings.stripFromContext)}, includeInContext=${String(reasoningSettings.includeInContext)}`,
+      `[AnthropicProvider] Reasoning settings from invocation.modelBehavior (fallback to options.settings): enabled=${String(reasoningSettings.enabled)}, budgetTokens=${String(reasoningSettings.budgetTokens)}, stripFromContext=${String(reasoningSettings.stripFromContext)}, includeInContext=${String(reasoningSettings.includeInContext)}`,
   );
 
   const configForMessages = params.config ?? params.options.runtime?.config;
@@ -836,7 +763,7 @@ export async function prepareAnthropicRequest(
     anthropicTools,
     systemContext,
     getMaxTokensForModel: params.getMaxTokensForModel,
-    shouldIncludeThinking: reasoningSettings.reasoningEnabled === true,
+    providerName: params.providerName,
     cacheLogger: params.cacheLogger,
     toolsLogger: params.toolsLogger,
     logger: params.logger,

--- a/packages/providers/src/anthropic/anthropic-reasoning-config.ts
+++ b/packages/providers/src/anthropic/anthropic-reasoning-config.ts
@@ -298,6 +298,13 @@ function buildSelectedThinking(
     return buildDisabledThinking(input, resolved);
   }
   if (resolved.effortFormat === 'anthropic-budget') {
+    // Fable 5 is adaptive-only: an anthropic-budget selection would bypass
+    // that constraint, so refuse before transport (issue #3255).
+    if (isFable5(input.model)) {
+      throw new Error(
+        `Model '${input.model}' is adaptive-only: the anthropic-budget effort format cannot emit budgeted thinking. Use the 'anthropic' effort format or remove reasoning.effortWireFormat=anthropic-budget.`,
+      );
+    }
     return buildBudgetThinking(input, resolved);
   }
   if (input.settings.enabled === undefined) {
@@ -388,6 +395,14 @@ function selectEnabledThinkingType(
   resolved: ResolvedReasoningConfiguration,
 ): 'adaptive' | 'enabled' | undefined {
   if (isFable5(input.model)) {
+    // Fable 5 is adaptive-only: an explicit direct budget would otherwise
+    // reach the manual budgeted branch below, so refuse before transport
+    // (issue #3255).
+    if (input.settings.budgetTokens !== undefined) {
+      throw new Error(
+        `Model '${input.model}' is adaptive-only: reasoning.budgetTokens cannot select budgeted thinking. Remove reasoning.budgetTokens to use adaptive thinking.`,
+      );
+    }
     return 'adaptive';
   }
   if (resolved.enabled.state !== 'emitted') {
@@ -395,6 +410,14 @@ function selectEnabledThinkingType(
   }
   if (typeof resolved.enabled.value !== 'string') {
     throw new Error('Anthropic thinking enablement must resolve to a string');
+  }
+  // A direct budget selects manual budgeted thinking on adaptive-capable
+  // models even when an enabled map or default prefers adaptive (issue #3255).
+  if (
+    input.settings.budgetTokens !== undefined &&
+    supportsAdaptiveThinking(input.model)
+  ) {
+    return 'enabled';
   }
   if (
     input.settings.enabledMap?.true === undefined &&
@@ -507,13 +530,19 @@ function warnForDroppedReasoning(
       resolved.effortFormat,
       resolved.effort,
     );
-  } else if (input.settings.budgetTokens !== undefined) {
-    warnForOutcome(
-      input,
-      'reasoning.budgetTokens',
-      resolved.effortFormat,
-      resolved.effort,
-    );
+  }
+  // A direct budget never reaches the wire once thinking is disabled; report
+  // it independently of the effort outcome instead of only when effort is
+  // absent (issue #3255).
+  if (
+    input.settings.budgetTokens !== undefined &&
+    input.settings.enabled === false
+  ) {
+    warn(input, {
+      format: resolved.effortFormat,
+      setting: 'reasoning.budgetTokens',
+      reason: 'reasoning-disabled',
+    });
   }
   if (input.settings.enabled !== undefined) {
     warnForOutcome(
@@ -558,7 +587,7 @@ function warn(
 ): void {
   input.logger.warn(
     () =>
-      `Anthropic omitted configured ${detail.setting} because ${detail.setting === 'reasoning.enabled' ? 'enabled' : 'effort'} format '${detail.format}' cannot emit it`,
+      `Anthropic omitted configured ${detail.setting} because ${formatLabel(detail.setting)} format '${detail.format}' cannot emit it`,
     {
       providerName: input.providerName,
       model: input.model,
@@ -567,6 +596,18 @@ function warn(
       reason: detail.reason,
     },
   );
+}
+
+/** Name the wire-format dimension after the setting it drops (issue #3255). */
+function formatLabel(setting: string): 'enabled' | 'effort' | 'budget' {
+  switch (setting) {
+    case 'reasoning.enabled':
+      return 'enabled';
+    case 'reasoning.budgetTokens':
+      return 'budget';
+    default:
+      return 'effort';
+  }
 }
 
 function hasOwn(

--- a/packages/providers/src/anthropic/anthropic-reasoning-config.ts
+++ b/packages/providers/src/anthropic/anthropic-reasoning-config.ts
@@ -1,0 +1,585 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type {
+  ReasoningEffort,
+  ReasoningEffortMap,
+  ReasoningEffortWireFormat,
+  ReasoningEnabledMap,
+  ReasoningEnabledWireFormat,
+} from '@vybestack/llxprt-code-settings';
+import {
+  readEffortMap,
+  readEffortWireFormat,
+  readEnabledMap,
+  readEnabledWireFormat,
+  readOptionalBoolean,
+  readOptionalEffort,
+  readOptionalPositiveInteger,
+  selectBehaviorValue,
+} from '../reasoning/reasoning-behavior-parsing.js';
+import {
+  resolveReasoningConfiguration,
+  type ReasoningResolution,
+  type ResolvedReasoningConfiguration,
+} from '../reasoning/reasoning-config-resolver.js';
+import {
+  ANTHROPIC_LEGACY_DEFAULT_BUDGET_TOKENS,
+  assertAdaptiveManualBudget,
+  buildThinkingConfig,
+  type AnthropicOutputConfigParameter,
+  type AnthropicThinkingParameter,
+} from './AnthropicRequestBuilder.js';
+import {
+  isFable5,
+  supportsAdaptiveThinking,
+  supportsDisabledThinking,
+} from './AnthropicModelData.js';
+
+export interface AnthropicReasoningFallbacks {
+  readonly enabled?: unknown;
+  readonly effort?: unknown;
+  readonly budgetTokens?: unknown;
+  readonly adaptiveThinking?: unknown;
+  readonly effortWireFormat?: unknown;
+  readonly enabledWireFormat?: unknown;
+  readonly effortMap?: unknown;
+  readonly enabledMap?: unknown;
+}
+
+export interface AnthropicReasoningSettings {
+  readonly enabled?: boolean;
+  readonly effort?: ReasoningEffort;
+  readonly budgetTokens?: number;
+  readonly adaptiveThinking?: boolean;
+  readonly effortWireFormat: ReasoningEffortWireFormat;
+  readonly enabledWireFormat: ReasoningEnabledWireFormat;
+  readonly effortMap?: ReasoningEffortMap;
+  readonly enabledMap?: ReasoningEnabledMap;
+}
+
+export type { AnthropicThinkingParameter };
+
+export interface AnthropicNativeReasoningConfig {
+  readonly thinking?: AnthropicThinkingParameter;
+  readonly outputConfig?: AnthropicOutputConfigParameter;
+}
+
+interface NativeConfigInput {
+  readonly settings: AnthropicReasoningSettings;
+  readonly modelParams: Readonly<Record<string, unknown>>;
+  readonly model: string;
+  readonly providerName: string;
+  readonly includeInResponse?: boolean;
+  readonly logger: DebugLogger;
+}
+
+/** Strictly parse Anthropic reasoning behavior from the invocation snapshot. */
+export function readAnthropicReasoningSettings(
+  modelBehavior: Readonly<Record<string, unknown>>,
+  fallbacks: AnthropicReasoningFallbacks,
+): AnthropicReasoningSettings {
+  return {
+    enabled: readOptionalBoolean(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.enabled',
+        fallbacks.enabled,
+      ),
+      'reasoning.enabled',
+    ),
+    effort: readOptionalEffort(
+      selectBehaviorValue(modelBehavior, 'reasoning.effort', fallbacks.effort),
+    ),
+    budgetTokens: readOptionalPositiveInteger(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.budgetTokens',
+        fallbacks.budgetTokens,
+      ),
+      'reasoning.budgetTokens',
+    ),
+    adaptiveThinking: readOptionalBoolean(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.adaptiveThinking',
+        fallbacks.adaptiveThinking,
+      ),
+      'reasoning.adaptiveThinking',
+    ),
+    effortWireFormat: readEffortWireFormat(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.effortWireFormat',
+        fallbacks.effortWireFormat,
+      ),
+    ),
+    enabledWireFormat: readEnabledWireFormat(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.enabledWireFormat',
+        fallbacks.enabledWireFormat,
+      ),
+    ),
+    effortMap: readEffortMap(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.effortMap',
+        fallbacks.effortMap,
+      ),
+    ),
+    enabledMap: readEnabledMap(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.enabledMap',
+        fallbacks.enabledMap,
+      ),
+    ),
+  };
+}
+
+/** Build the one native Anthropic reasoning representation for a request. */
+export function buildAnthropicNativeReasoningConfig(
+  input: NativeConfigInput,
+): AnthropicNativeReasoningConfig {
+  const explicit = readExplicitNativeConfig(input.modelParams);
+  if (explicit.collision) {
+    return {
+      thinking: explicit.thinking,
+      outputConfig: explicit.outputConfig,
+    };
+  }
+
+  const resolved = resolveReasoningConfiguration({
+    nativeAdapter: 'anthropic',
+    reasoning: {
+      enabled: input.settings.enabled,
+      effort: input.settings.effort,
+      budgetTokens: input.settings.budgetTokens,
+    },
+    effortWireFormat: input.settings.effortWireFormat,
+    enabledWireFormat: input.settings.enabledWireFormat,
+    effortMap: input.settings.effortMap,
+    enabledMap: input.settings.enabledMap,
+  });
+  warnForDroppedReasoning(input, resolved);
+
+  const translated =
+    isLegacyAutoConfiguration(input.settings) &&
+    input.settings.enabled !== undefined
+      ? buildLegacyAutoConfig(input, resolved)
+      : buildSelectedConfig(input, resolved);
+  return {
+    thinking: translated.thinking,
+    outputConfig: mergeOutputConfig(
+      explicit.outputConfig,
+      translated.outputConfig,
+    ),
+  };
+}
+
+interface ExplicitNativeConfig extends AnthropicNativeReasoningConfig {
+  readonly collision: boolean;
+}
+
+function readExplicitNativeConfig(
+  modelParams: Readonly<Record<string, unknown>>,
+): ExplicitNativeConfig {
+  const hasThinking = hasOwn(modelParams, 'thinking');
+  const hasOutputConfig = hasOwn(modelParams, 'output_config');
+  const thinking = hasThinking
+    ? readExplicitThinking(modelParams['thinking'])
+    : undefined;
+  const outputConfig = hasOutputConfig
+    ? readExplicitOutputConfig(modelParams['output_config'])
+    : undefined;
+  return {
+    collision:
+      thinking !== undefined ||
+      (outputConfig !== undefined && hasOwn(outputConfig, 'effort')),
+    thinking,
+    outputConfig,
+  };
+}
+
+function readExplicitThinking(value: unknown): AnthropicThinkingParameter {
+  if (!isRecord(value)) {
+    throw new Error('thinking must be an object');
+  }
+  const type = value['type'];
+  if (!hasNonEmptyString(type)) {
+    throw new Error('thinking.type must be a non-empty string');
+  }
+  // A future or non-enumerated type string is still an explicit native
+  // selection: pass the object through unchanged so forward-compatible
+  // thinking modes keep working and generic translation stands down
+  // (issue #3255).
+  return { ...value, type };
+}
+
+function readExplicitOutputConfig(
+  value: unknown,
+): Readonly<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    throw new Error('output_config must be an object');
+  }
+  if (hasOwn(value, 'effort') && !hasNonEmptyString(value['effort'])) {
+    throw new Error('output_config.effort must be a non-empty string');
+  }
+  return { ...value };
+}
+
+function isLegacyAutoConfiguration(
+  settings: AnthropicReasoningSettings,
+): boolean {
+  return (
+    settings.effortWireFormat === 'auto' &&
+    settings.enabledWireFormat === 'auto' &&
+    settings.effortMap === undefined &&
+    settings.enabledMap === undefined
+  );
+}
+
+function buildLegacyAutoConfig(
+  input: NativeConfigInput,
+  resolved: ResolvedReasoningConfiguration,
+): AnthropicNativeReasoningConfig {
+  if (input.settings.enabled === false) {
+    if (supportsDisabledThinking(input.model)) {
+      return { thinking: { type: 'disabled' } };
+    }
+    warnUnsupportedDisablement(input, resolved.enabledFormat);
+    return {};
+  }
+
+  // The caller guarantees enabled !== undefined, so reaching here means
+  // enabled === true; no third state exists to guard.
+  const effort = readNormalizedEffort(input.model, resolved);
+  const existing = buildThinkingConfig({
+    reasoningEnabled: true,
+    reasoningBudgetTokens: input.settings.budgetTokens,
+    adaptiveThinking: input.settings.adaptiveThinking,
+    includeInResponse: input.includeInResponse,
+    thinkingEffort: effort,
+    model: input.model,
+  });
+  return {
+    thinking: existing.thinking,
+    outputConfig: existing.output_config,
+  };
+}
+
+function buildSelectedConfig(
+  input: NativeConfigInput,
+  resolved: ResolvedReasoningConfiguration,
+): AnthropicNativeReasoningConfig {
+  const outputConfig = buildSelectedOutputConfig(input, resolved);
+  const thinking = buildSelectedThinking(input, resolved);
+  return { thinking, outputConfig };
+}
+
+function buildSelectedOutputConfig(
+  input: NativeConfigInput,
+  resolved: ResolvedReasoningConfiguration,
+): Readonly<Record<string, unknown>> | undefined {
+  const effort = readSelectedEffort(input, resolved);
+  return effort === undefined ? undefined : { effort };
+}
+
+function buildSelectedThinking(
+  input: NativeConfigInput,
+  resolved: ResolvedReasoningConfiguration,
+): AnthropicThinkingParameter | undefined {
+  if (input.settings.enabled === false) {
+    return buildDisabledThinking(input, resolved);
+  }
+  if (resolved.effortFormat === 'anthropic-budget') {
+    return buildBudgetThinking(input, resolved);
+  }
+  if (input.settings.enabled === undefined) {
+    return undefined;
+  }
+
+  const type = selectEnabledThinkingType(input, resolved);
+  if (type === undefined) {
+    return undefined;
+  }
+  if (type === 'adaptive') {
+    return {
+      type,
+      display: input.includeInResponse === false ? 'omitted' : 'summarized',
+    };
+  }
+  if (needsClaudeBudget(input.model)) {
+    // Adaptive-capable models have no legacy budget default: refuse before
+    // transport rather than fabricating one (issue #3255). Legacy budgeted
+    // models keep the existing default below.
+    assertAdaptiveManualBudget(input.model, input.settings.budgetTokens);
+    return {
+      type,
+      budget_tokens:
+        input.settings.budgetTokens ?? ANTHROPIC_LEGACY_DEFAULT_BUDGET_TOKENS,
+      ...(input.includeInResponse === false ? { display: 'omitted' } : {}),
+    };
+  }
+  return { type };
+}
+
+function buildDisabledThinking(
+  input: NativeConfigInput,
+  resolved: ResolvedReasoningConfiguration,
+): AnthropicThinkingParameter | undefined {
+  if (resolved.enabled.state !== 'emitted') {
+    return undefined;
+  }
+  if (typeof resolved.enabled.value !== 'string') {
+    throw new Error('Anthropic thinking enablement must resolve to a string');
+  }
+  if (resolved.enabled.value !== 'disabled') {
+    throw new Error(
+      `reasoning.enabledMap.false value '${resolved.enabled.value}' is not supported by the Anthropic adapter`,
+    );
+  }
+  if (!supportsDisabledThinking(input.model)) {
+    warnUnsupportedDisablement(input, resolved.enabledFormat);
+    return undefined;
+  }
+  return { type: 'disabled' };
+}
+
+function buildBudgetThinking(
+  input: NativeConfigInput,
+  resolved: ResolvedReasoningConfiguration,
+): AnthropicThinkingParameter | undefined {
+  if (
+    resolved.effort.state !== 'emitted' ||
+    typeof resolved.effort.value !== 'number'
+  ) {
+    if (input.settings.enabled === true) {
+      warn(input, {
+        format: resolved.effortFormat,
+        setting: 'reasoning.enabled',
+        reason: 'budget-required',
+      });
+    }
+    return undefined;
+  }
+  if (
+    resolved.enabled.state === 'emitted' &&
+    resolved.enabled.value !== 'enabled'
+  ) {
+    throw new Error(
+      'anthropic-budget requires reasoning.enabledMap.true to resolve to enabled',
+    );
+  }
+  return {
+    type: 'enabled',
+    budget_tokens: resolved.effort.value,
+    ...(input.includeInResponse === false ? { display: 'omitted' } : {}),
+  };
+}
+
+function selectEnabledThinkingType(
+  input: NativeConfigInput,
+  resolved: ResolvedReasoningConfiguration,
+): 'adaptive' | 'enabled' | undefined {
+  if (isFable5(input.model)) {
+    return 'adaptive';
+  }
+  if (resolved.enabled.state !== 'emitted') {
+    return undefined;
+  }
+  if (typeof resolved.enabled.value !== 'string') {
+    throw new Error('Anthropic thinking enablement must resolve to a string');
+  }
+  if (
+    input.settings.enabledMap?.true === undefined &&
+    supportsAdaptiveThinking(input.model) &&
+    input.settings.budgetTokens === undefined &&
+    input.settings.adaptiveThinking !== false
+  ) {
+    return 'adaptive';
+  }
+  switch (resolved.enabled.value) {
+    case 'adaptive':
+    case 'enabled':
+      return resolved.enabled.value;
+    default:
+      throw new Error(
+        `reasoning.enabledMap.true value '${resolved.enabled.value}' is not supported by the Anthropic adapter`,
+      );
+  }
+}
+
+function needsClaudeBudget(model: string): boolean {
+  return model.toLowerCase().startsWith('claude-');
+}
+
+function readSelectedEffort(
+  input: NativeConfigInput,
+  resolved: ResolvedReasoningConfiguration,
+): string | undefined {
+  const effort = readAnthropicEffort(resolved);
+  if (effort === undefined) {
+    return undefined;
+  }
+  const mappedEffort =
+    input.settings.effort === undefined
+      ? undefined
+      : input.settings.effortMap?.[input.settings.effort];
+  return typeof mappedEffort === 'string'
+    ? effort
+    : normalizeEffort(input.model, effort);
+}
+
+function readNormalizedEffort(
+  model: string,
+  resolved: ResolvedReasoningConfiguration,
+): 'low' | 'medium' | 'high' | 'max' | undefined {
+  const effort = readAnthropicEffort(resolved);
+  return effort === undefined ? undefined : normalizeEffort(model, effort);
+}
+
+function readAnthropicEffort(
+  resolved: ResolvedReasoningConfiguration,
+): string | undefined {
+  if (
+    resolved.effortFormat !== 'anthropic' ||
+    resolved.effort.state !== 'emitted'
+  ) {
+    return undefined;
+  }
+  if (typeof resolved.effort.value !== 'string') {
+    throw new Error('Anthropic effort must resolve to a string');
+  }
+  return resolved.effort.value;
+}
+
+function normalizeEffort(
+  model: string,
+  effort: string,
+): 'low' | 'medium' | 'high' | 'max' {
+  switch (effort) {
+    case 'minimal':
+    case 'low':
+      return 'low';
+    case 'medium':
+      return 'medium';
+    case 'high':
+      return 'high';
+    case 'xhigh':
+    case 'max':
+      return supportsAdaptiveThinking(model) || !needsClaudeBudget(model)
+        ? 'max'
+        : 'high';
+    default:
+      throw new Error(
+        `reasoning.effortMap produced unsupported Anthropic effort '${effort}'`,
+      );
+  }
+}
+
+function mergeOutputConfig(
+  explicit: Readonly<Record<string, unknown>> | undefined,
+  translated: Readonly<Record<string, unknown>> | undefined,
+): Readonly<Record<string, unknown>> | undefined {
+  if (explicit === undefined) {
+    return translated;
+  }
+  if (translated === undefined) {
+    return explicit;
+  }
+  return { ...explicit, ...translated };
+}
+
+function warnForDroppedReasoning(
+  input: NativeConfigInput,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (input.settings.effort !== undefined) {
+    warnForOutcome(
+      input,
+      'reasoning.effort',
+      resolved.effortFormat,
+      resolved.effort,
+    );
+  } else if (input.settings.budgetTokens !== undefined) {
+    warnForOutcome(
+      input,
+      'reasoning.budgetTokens',
+      resolved.effortFormat,
+      resolved.effort,
+    );
+  }
+  if (input.settings.enabled !== undefined) {
+    warnForOutcome(
+      input,
+      'reasoning.enabled',
+      resolved.enabledFormat,
+      resolved.enabled,
+    );
+  }
+}
+
+function warnForOutcome(
+  input: NativeConfigInput,
+  setting: string,
+  format: string,
+  outcome: ReasoningResolution<string | number | boolean>,
+): void {
+  if (outcome.state !== 'suppressed' && outcome.state !== 'unrepresentable') {
+    return;
+  }
+  warn(input, { format, setting, reason: outcome.reason });
+}
+
+function warnUnsupportedDisablement(
+  input: NativeConfigInput,
+  format: string,
+): void {
+  warn(input, {
+    format,
+    setting: 'reasoning.enabled',
+    reason: 'model-cannot-disable-thinking',
+  });
+}
+
+function warn(
+  input: NativeConfigInput,
+  detail: {
+    readonly format: string;
+    readonly setting: string;
+    readonly reason: string;
+  },
+): void {
+  input.logger.warn(
+    () =>
+      `Anthropic omitted configured ${detail.setting} because ${detail.setting === 'reasoning.enabled' ? 'enabled' : 'effort'} format '${detail.format}' cannot emit it`,
+    {
+      providerName: input.providerName,
+      model: input.model,
+      format: detail.format,
+      setting: detail.setting,
+      reason: detail.reason,
+    },
+  );
+}
+
+function hasOwn(
+  value: Readonly<Record<string, unknown>>,
+  key: string,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/providers/src/composition/aliases/anthropic.config
+++ b/packages/providers/src/composition/aliases/anthropic.config
@@ -18,11 +18,7 @@
         "reasoning.adaptiveThinking": true,
         "reasoning.includeInContext": true
       },
-      "unallowedParameters": [
-        "temperature",
-        "top_p",
-        "top_k"
-      ]
+      "unallowedParameters": ["temperature", "top_p", "top_k"]
     },
     {
       "pattern": "claude-(opus-5|opus-4-8|fable-5|sonnet-4-6|sonnet-5)",
@@ -30,6 +26,20 @@
         "reasoning.effort": "high",
         "context-limit": 1000000,
         "maxOutputTokens": 128000
+      }
+    },
+    {
+      "pattern": "^claude-opus-5$",
+      "ephemeralSettings": {
+        "reasoning.effortWireFormat": "anthropic",
+        "reasoning.enabledWireFormat": "thinking",
+        "reasoning.effortMap": {
+          "minimal": "low"
+        },
+        "reasoning.enabledMap": {
+          "true": "adaptive",
+          "false": "disabled"
+        }
       }
     },
     {

--- a/packages/providers/src/composition/aliases/claudecode.config
+++ b/packages/providers/src/composition/aliases/claudecode.config
@@ -27,6 +27,20 @@
       }
     },
     {
+      "pattern": "^claude-opus-5$",
+      "ephemeralSettings": {
+        "reasoning.effortWireFormat": "anthropic",
+        "reasoning.enabledWireFormat": "thinking",
+        "reasoning.effortMap": {
+          "minimal": "low"
+        },
+        "reasoning.enabledMap": {
+          "true": "adaptive",
+          "false": "disabled"
+        }
+      }
+    },
+    {
       "pattern": "^claude-(opus-5|opus-4-8|sonnet-5)$",
       "ephemeralSettings": {
         "max-image-dimension": 2000

--- a/packages/providers/src/composition/aliases/codex.config
+++ b/packages/providers/src/composition/aliases/codex.config
@@ -9,6 +9,7 @@
     "context-limit": 262144,
     "prompt-caching": "24h",
     "reasoning.effort": "medium",
+    "reasoning.effortWireFormat": "openai-responses",
     "reasoning.summary": "auto",
     "media.pdf.enabled": false
   },

--- a/packages/providers/src/composition/aliases/deepseek.config
+++ b/packages/providers/src/composition/aliases/deepseek.config
@@ -8,12 +8,26 @@
   "apiKeyEnv": "DEEPSEEK_API_KEY",
   "modelDefaults": [
     {
-      "pattern": "deepseek-v4",
+      "pattern": "^deepseek-v4(?:$|-)",
       "ephemeralSettings": {
         "reasoning.enabled": true,
         "reasoning.effort": "high",
         "context-limit": 1000000,
-        "max_tokens": 4096
+        "max_tokens": 4096,
+        "reasoning.effortWireFormat": "openai",
+        "reasoning.enabledWireFormat": "thinking",
+        "reasoning.effortMap": {
+          "minimal": "low",
+          "low": "low",
+          "medium": "high",
+          "high": "high",
+          "xhigh": "high",
+          "max": "max"
+        },
+        "reasoning.enabledMap": {
+          "true": "enabled",
+          "false": "disabled"
+        }
       }
     }
   ]

--- a/packages/providers/src/composition/aliases/fireworks.config
+++ b/packages/providers/src/composition/aliases/fireworks.config
@@ -12,6 +12,11 @@
       "ephemeralSettings": {
         "reasoning.enabled": true,
         "reasoning.effort": "high",
+        "reasoning.effortWireFormat": "openai",
+        "reasoning.enabledWireFormat": "openai",
+        "reasoning.enabledMap": {
+          "false": "none"
+        },
         "context-limit": 1000000
       }
     }

--- a/packages/providers/src/composition/aliases/kimi.config
+++ b/packages/providers/src/composition/aliases/kimi.config
@@ -45,7 +45,6 @@
     {
       "pattern": "^kimi|^k3-256k$",
       "ephemeralSettings": {
-        "reasoning.effort": "medium",
         "reasoning.enabled": true,
         "reasoning.includeInResponse": true,
         "reasoning.includeInContext": true,
@@ -65,9 +64,30 @@
       ]
     },
     {
+      "pattern": "^kimi-for-coding(?:-highspeed)?$",
+      "ephemeralSettings": {
+        "reasoning.effortWireFormat": "none",
+        "reasoning.enabledWireFormat": "thinking",
+        "reasoning.enabledMap": {
+          "true": "enabled",
+          "false": null
+        }
+      }
+    },
+    {
       "pattern": "kimi-k3",
       "ephemeralSettings": {
         "reasoning.effort": "max",
+        "reasoning.effortWireFormat": "openai",
+        "reasoning.enabledWireFormat": "openai",
+        "reasoning.effortMap": {
+          "minimal": "low",
+          "low": "low",
+          "medium": "high",
+          "high": "high",
+          "xhigh": "max",
+          "max": "max"
+        },
         "max_tokens": 131072,
         "context-limit": 1000000
       }
@@ -76,6 +96,16 @@
       "pattern": "k3-256k",
       "ephemeralSettings": {
         "reasoning.effort": "high",
+        "reasoning.effortWireFormat": "openai",
+        "reasoning.enabledWireFormat": "openai",
+        "reasoning.effortMap": {
+          "minimal": "low",
+          "low": "low",
+          "medium": "high",
+          "high": "high",
+          "xhigh": "max",
+          "max": "max"
+        },
         "max_tokens": 131072,
         "context-limit": 262144
       }

--- a/packages/providers/src/composition/aliases/openrouter.config
+++ b/packages/providers/src/composition/aliases/openrouter.config
@@ -5,5 +5,9 @@
   "base-url": "https://openrouter.ai/api/v1/",
   "defaultModel": "nvidia/nemotron-nano-9b-v2",
   "description": "OpenRouter compatibility profile",
-  "apiKeyEnv": "OPENROUTER_API_KEY"
+  "apiKeyEnv": "OPENROUTER_API_KEY",
+  "ephemeralSettings": {
+    "reasoning.effortWireFormat": "openrouter",
+    "reasoning.enabledWireFormat": "openrouter"
+  }
 }

--- a/packages/providers/src/composition/aliases/zai.config
+++ b/packages/providers/src/composition/aliases/zai.config
@@ -3,24 +3,55 @@
   "modelsDevProviderId": "zai",
   "baseProvider": "anthropic",
   "base-url": "https://api.z.ai/api/anthropic",
-  "defaultModel": "glm-5",
+  "defaultModel": "glm-5.3",
   "description": "Z.ai (Zhipu AI) compatibility profile via Anthropic API",
   "apiKeyEnv": "ZAI_API_KEY",
   "modelDefaults": [
-    {
-      "pattern": "glm-5.2",
-      "ephemeralSettings": {
-        "reasoning.enabled": true,
-        "reasoning.effort": "high",
-        "context-limit": 1000000,
-        "maxOutputTokens": 128000
-      }
-    },
     {
       "pattern": "glm-5",
       "ephemeralSettings": {
         "reasoning.enabled": true,
         "reasoning.effort": "high"
+      }
+    },
+    {
+      "pattern": "^glm-5\\.2$",
+      "ephemeralSettings": {
+        "reasoning.effortWireFormat": "anthropic",
+        "reasoning.enabledWireFormat": "thinking",
+        "reasoning.effortMap": {
+          "minimal": "minimal",
+          "low": "high",
+          "medium": "high",
+          "high": "high",
+          "xhigh": "max",
+          "max": "max"
+        },
+        "reasoning.enabledMap": {
+          "true": "enabled",
+          "false": "disabled"
+        },
+        "context-limit": 1000000,
+        "maxOutputTokens": 128000
+      }
+    },
+    {
+      "pattern": "^glm-5\\.3$",
+      "ephemeralSettings": {
+        "reasoning.effortWireFormat": "anthropic",
+        "reasoning.enabledWireFormat": "thinking",
+        "reasoning.effortMap": {
+          "minimal": "low",
+          "low": "low",
+          "medium": "high",
+          "high": "high",
+          "xhigh": "max",
+          "max": "max"
+        },
+        "reasoning.enabledMap": {
+          "true": "enabled",
+          "false": null
+        }
       }
     }
   ]

--- a/packages/providers/src/composition/aliases/zai.config
+++ b/packages/providers/src/composition/aliases/zai.config
@@ -8,7 +8,7 @@
   "apiKeyEnv": "ZAI_API_KEY",
   "modelDefaults": [
     {
-      "pattern": "glm-5",
+      "pattern": "^glm-5(?:$|\\.|-)",
       "ephemeralSettings": {
         "reasoning.enabled": true,
         "reasoning.effort": "high"

--- a/packages/providers/src/composition/providerAliases.issue3255.test.ts
+++ b/packages/providers/src/composition/providerAliases.issue3255.test.ts
@@ -148,6 +148,25 @@ describe('issue #3255 builtin alias reasoning defaults', () => {
     });
   });
 
+  it.each(['glm-5', 'glm-5.2', 'glm-5.3'])(
+    'applies the broad GLM-5 enablement default to %s',
+    (model) => {
+      const defaults = resolveAliasDefaults('zai', model);
+
+      expect(defaults['reasoning.enabled']).toBe(true);
+      expect(defaults['reasoning.effort']).toBe('high');
+    },
+  );
+
+  it.each(['foreign-glm-5', 'my-glm-5.3', 'glm-50'])(
+    'does not apply GLM-5 defaults to the near-match %s',
+    (model) => {
+      const defaults = resolveAliasDefaults('zai', model);
+
+      expect(defaults).toStrictEqual({});
+    },
+  );
+
   it.each(['kimi-for-coding', 'kimi-for-coding-highspeed'])(
     'uses thinking enablement without a K3 effort default for %s',
     (model) => {

--- a/packages/providers/src/composition/providerAliases.issue3255.test.ts
+++ b/packages/providers/src/composition/providerAliases.issue3255.test.ts
@@ -1,0 +1,256 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { computeModelDefaults } from '../runtime/providerMutations.js';
+import {
+  loadProviderAliasEntries,
+  type ProviderAliasConfig,
+} from './providerAliases.js';
+
+function loadBuiltinAlias(alias: string): ProviderAliasConfig {
+  const entry = loadProviderAliasEntries().find(
+    (candidate) =>
+      candidate.source === 'builtin' &&
+      candidate.alias.toLowerCase() === alias.toLowerCase(),
+  );
+  if (!entry) {
+    throw new Error(`Builtin provider alias '${alias}' was not loaded`);
+  }
+  return entry.config;
+}
+
+function resolveAliasDefaults(
+  alias: string,
+  model: string,
+): Record<string, unknown> {
+  const config = loadBuiltinAlias(alias);
+  return {
+    ...config.ephemeralSettings,
+    ...computeModelDefaults(model, config.modelDefaults ?? []),
+  };
+}
+
+function expectMap(
+  defaults: Readonly<Record<string, unknown>>,
+  key: 'reasoning.effortMap' | 'reasoning.enabledMap',
+  expected: Readonly<Record<string, unknown>>,
+): void {
+  expect(defaults[key]).toStrictEqual(expected);
+}
+
+describe('issue #3255 builtin alias reasoning defaults', () => {
+  it.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'resolves Codex Responses wire format and existing defaults for %s',
+    (model) => {
+      const defaults = resolveAliasDefaults('codex', model);
+
+      expect(defaults).toMatchObject({
+        'reasoning.effortWireFormat': 'openai-responses',
+        'reasoning.effort': 'medium',
+        'reasoning.summary': 'auto',
+      });
+    },
+  );
+
+  it('leaves OpenAI GPT-5.6 effort selection to the chosen adapter', () => {
+    const gpt56 = resolveAliasDefaults('openai', 'gpt-5.6');
+    const unrelatedChatModel = resolveAliasDefaults('openai', 'gpt-5.5');
+
+    expect(gpt56['reasoning.effortWireFormat']).toBeUndefined();
+    expect(gpt56).toMatchObject({
+      'reasoning.enabled': true,
+      'reasoning.effort': 'high',
+    });
+    expect(unrelatedChatModel['reasoning.effortWireFormat']).toBeUndefined();
+  });
+
+  it('selects OpenRouter wire formats without forcing reasoning controls', () => {
+    const defaults = resolveAliasDefaults(
+      'openrouter',
+      'anthropic/claude-sonnet-4.6',
+    );
+
+    expect(defaults).toMatchObject({
+      'reasoning.effortWireFormat': 'openrouter',
+      'reasoning.enabledWireFormat': 'openrouter',
+    });
+    expect(defaults).not.toHaveProperty('reasoning.enabled');
+    expect(defaults).not.toHaveProperty('reasoning.effort');
+  });
+
+  it.each(['anthropic', 'claudecode'])(
+    'selects Opus 5 Anthropic adaptive controls narrowly for %s',
+    (alias) => {
+      const opus = resolveAliasDefaults(alias, 'claude-opus-5');
+      const sonnet = resolveAliasDefaults(alias, 'claude-sonnet-5');
+
+      expect(opus).toMatchObject({
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.enabledWireFormat': 'thinking',
+      });
+      expectMap(opus, 'reasoning.effortMap', { minimal: 'low' });
+      expectMap(opus, 'reasoning.enabledMap', {
+        true: 'adaptive',
+        false: 'disabled',
+      });
+      expect(sonnet).not.toHaveProperty('reasoning.effortWireFormat');
+      expect(sonnet).not.toHaveProperty('reasoning.enabledWireFormat');
+      expect(sonnet).not.toHaveProperty('reasoning.enabledMap');
+    },
+  );
+
+  it('resolves GLM-5.3 forced-thinking formats and maps over broad GLM-5 defaults', () => {
+    const defaults = resolveAliasDefaults('zai', 'glm-5.3');
+
+    expect(defaults).toMatchObject({
+      'reasoning.effortWireFormat': 'anthropic',
+      'reasoning.enabledWireFormat': 'thinking',
+    });
+    expectMap(defaults, 'reasoning.effortMap', {
+      minimal: 'low',
+      low: 'low',
+      medium: 'high',
+      high: 'high',
+      xhigh: 'max',
+      max: 'max',
+    });
+    expectMap(defaults, 'reasoning.enabledMap', {
+      true: 'enabled',
+      false: null,
+    });
+  });
+
+  it('resolves GLM-5.2 formats, documented effort values, and disable support', () => {
+    const defaults = resolveAliasDefaults('zai', 'glm-5.2');
+
+    expect(defaults).toMatchObject({
+      'reasoning.effortWireFormat': 'anthropic',
+      'reasoning.enabledWireFormat': 'thinking',
+      'reasoning.effort': 'high',
+      'context-limit': 1000000,
+      maxOutputTokens: 128000,
+    });
+    expectMap(defaults, 'reasoning.effortMap', {
+      minimal: 'minimal',
+      low: 'high',
+      medium: 'high',
+      high: 'high',
+      xhigh: 'max',
+      max: 'max',
+    });
+    expectMap(defaults, 'reasoning.enabledMap', {
+      true: 'enabled',
+      false: 'disabled',
+    });
+  });
+
+  it.each(['kimi-for-coding', 'kimi-for-coding-highspeed'])(
+    'uses thinking enablement without a K3 effort default for %s',
+    (model) => {
+      const defaults = resolveAliasDefaults('kimi', model);
+
+      expect(defaults).toMatchObject({
+        'reasoning.effortWireFormat': 'none',
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabled': true,
+        max_tokens: 32768,
+        'context-limit': 262144,
+      });
+      expectMap(defaults, 'reasoning.enabledMap', {
+        true: 'enabled',
+        false: null,
+      });
+      expect(defaults).not.toHaveProperty('reasoning.effort');
+    },
+  );
+
+  it.each([
+    ['kimi-k3', 'max', 1000000],
+    ['k3-256k', 'high', 262144],
+  ])(
+    'uses OpenAI effort and enablement for %s',
+    (model, effort, contextLimit) => {
+      const defaults = resolveAliasDefaults('kimi', model);
+
+      expect(defaults).toMatchObject({
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.enabledWireFormat': 'openai',
+        'reasoning.effort': effort,
+        max_tokens: 131072,
+        'context-limit': contextLimit,
+      });
+      expectMap(defaults, 'reasoning.effortMap', {
+        minimal: 'low',
+        low: 'low',
+        medium: 'high',
+        high: 'high',
+        xhigh: 'max',
+        max: 'max',
+      });
+      expect(defaults['reasoning.enabledWireFormat']).not.toBe('thinking');
+    },
+  );
+
+  it.each(['deepseek-v4-flash', 'deepseek-v4-chat'])(
+    'selects DeepSeek V4 reasoning controls and geometry for %s',
+    (model) => {
+      const defaults = resolveAliasDefaults('deepseek', model);
+
+      expect(defaults).toMatchObject({
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.enabledWireFormat': 'thinking',
+        'context-limit': 1000000,
+        max_tokens: 4096,
+      });
+      expectMap(defaults, 'reasoning.effortMap', {
+        minimal: 'low',
+        low: 'low',
+        medium: 'high',
+        high: 'high',
+        xhigh: 'high',
+        max: 'max',
+      });
+      expectMap(defaults, 'reasoning.enabledMap', {
+        true: 'enabled',
+        false: 'disabled',
+      });
+    },
+  );
+
+  it('does not apply DeepSeek V4 defaults to a foreign near-match', () => {
+    const defaults = resolveAliasDefaults(
+      'deepseek',
+      'foreign-deepseek-v4-chat',
+    );
+
+    expect(defaults).toStrictEqual({});
+  });
+
+  it('selects only the compatible Fireworks MiniMax controls', () => {
+    const defaults = resolveAliasDefaults('fireworks', 'fireworks/minimax-m3');
+
+    expect(defaults).toMatchObject({
+      'reasoning.effortWireFormat': 'openai',
+      'reasoning.enabledWireFormat': 'openai',
+    });
+    expectMap(defaults, 'reasoning.enabledMap', { false: 'none' });
+    expect(defaults['reasoning.enabledMap']).not.toHaveProperty('true');
+    expect(defaults['reasoning.enabledWireFormat']).not.toBe('thinking');
+  });
+
+  it.each(['llama.cpp', 'LM Studio', 'LiteLLM'])(
+    'does not impose reasoning wire defaults on local alias %s',
+    (alias) => {
+      const defaults = resolveAliasDefaults(alias, 'local-model');
+
+      expect(defaults).not.toHaveProperty('reasoning.effortWireFormat');
+      expect(defaults).not.toHaveProperty('reasoning.enabledWireFormat');
+    },
+  );
+});

--- a/packages/providers/src/composition/providerAliases.kimi.test.ts
+++ b/packages/providers/src/composition/providerAliases.kimi.test.ts
@@ -27,17 +27,20 @@ describe('builtin kimi provider alias', () => {
     expect(ephemerals?.['user-agent']).toBe('RooCode/1.0');
   });
 
-  it('has modelDefaults with a broad rule plus kimi-k3 and k3-256k overrides', () => {
+  it('has modelDefaults with shared, K2.7, kimi-k3, and k3-256k rules', () => {
     const entries = loadProviderAliasEntries();
     const entry = entries.find((candidate) => candidate.alias === 'kimi');
 
     expect(entry?.config.modelDefaults).toBeDefined();
     expect(Array.isArray(entry?.config.modelDefaults)).toBe(true);
-    expect(entry?.config.modelDefaults).toHaveLength(3);
+    expect(entry?.config.modelDefaults).toHaveLength(4);
 
-    // The broad rule MUST come before the kimi-k3/k3-256k rules so
+    // The shared rule MUST come before the model-family rules so
     // array-order precedence lets the specific keys win for those models.
     const patterns = (entry?.config.modelDefaults ?? []).map((r) => r.pattern);
+    expect(patterns.indexOf('^kimi|^k3-256k$')).toBeLessThan(
+      patterns.indexOf('^kimi-for-coding(?:-highspeed)?$'),
+    );
     expect(patterns.indexOf('^kimi|^k3-256k$')).toBeLessThan(
       patterns.indexOf('kimi-k3'),
     );
@@ -52,7 +55,7 @@ describe('builtin kimi provider alias', () => {
     expect(broadRule).toBeDefined();
 
     const broadDefaults = broadRule?.ephemeralSettings;
-    expect(broadDefaults?.['reasoning.effort']).toBe('medium');
+    expect(broadDefaults).not.toHaveProperty('reasoning.effort');
     expect(broadDefaults?.['reasoning.enabled']).toBe(true);
     expect(broadDefaults?.['reasoning.includeInResponse']).toBe(true);
     expect(broadDefaults?.['reasoning.includeInContext']).toBe(true);
@@ -93,6 +96,22 @@ describe('builtin kimi provider alias', () => {
     expect(new RegExp(rule!.pattern).test('k3-256k')).toBe(true);
     expect(rule!.ephemeralSettings.max_tokens).toBe(131072);
     expect(rule!.ephemeralSettings['context-limit']).toBe(262144);
+  });
+
+  it('ships a K2.7-specific thinking rule without an effort default', () => {
+    const entry = loadProviderAliasEntries().find(
+      (candidate) => candidate.alias === 'kimi',
+    );
+    const rule = entry?.config.modelDefaults?.find(
+      (candidate) => candidate.pattern === '^kimi-for-coding(?:-highspeed)?$',
+    );
+
+    expect(rule?.ephemeralSettings).toMatchObject({
+      'reasoning.effortWireFormat': 'none',
+      'reasoning.enabledWireFormat': 'thinking',
+      'reasoning.enabledMap': { true: 'enabled', false: null },
+    });
+    expect(rule?.ephemeralSettings).not.toHaveProperty('reasoning.effort');
   });
 
   it('ships staticModels so the dialog lists real Kimi models, not API fallbacks', () => {

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -391,6 +391,7 @@ export class GeminiProvider extends BaseProvider {
       () => this.determineBestAuth(),
       () => this.createHttpOptions(),
       () => this.getBaseURL(),
+      this.getLogger(),
     );
     const result = await this.executeGeneration(
       options,

--- a/packages/providers/src/gemini/__tests__/gemini.issue3255.test.ts
+++ b/packages/providers/src/gemini/__tests__/gemini.issue3255.test.ts
@@ -266,18 +266,53 @@ describe('Gemini issue 3255 reasoning request translation', () => {
     ]);
   });
 
-  it('uses an explicit supported native level to represent Gemini 3 disablement', () => {
-    const config = buildConfig({
+  it('warns instead of enabling thinking when a Gemini 3 disabled map selects a level', () => {
+    const result = build({
       modelBehavior: {
         'reasoning.enabled': false,
         'reasoning.enabledMap': { false: 'LOW' },
       },
     });
 
-    expect(thinkingConfig(config)).toStrictEqual({
-      includeThoughts: true,
-      thinkingLevel: 'LOW',
+    expect(result.config).not.toHaveProperty('thinkingConfig');
+    expect(result.logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.enabled for model gemini-3-flash-preview using format 'gemini' because gemini-3-disablement-unrepresentable",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          format: 'gemini',
+          genericSetting: 'reasoning.enabled',
+          reason: 'gemini-3-disablement-unrepresentable',
+        },
+      },
+    ]);
+  });
+
+  it('warns instead of enabling thinking when a Gemini 2 disabled map selects true', () => {
+    const result = build({
+      model: 'gemini-2.5-pro',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.enabledMap': { false: true },
+      },
     });
+
+    expect(result.config).not.toHaveProperty('thinkingConfig');
+    expect(result.logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.enabled for model gemini-2.5-pro using format 'gemini' because gemini-disablement-unrepresentable",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-2.5-pro',
+          format: 'gemini',
+          genericSetting: 'reasoning.enabled',
+          reason: 'gemini-disablement-unrepresentable',
+        },
+      },
+    ]);
   });
 
   it('emits Gemini 2 thinking budget when reasoning is enabled', () => {
@@ -293,6 +328,42 @@ describe('Gemini issue 3255 reasoning request translation', () => {
       includeThoughts: true,
       thinkingBudget: 4096,
     });
+  });
+
+  it('omits thinkingConfig for an unsupported generation and warns for each dropped setting', () => {
+    const result = build({
+      model: 'gemini-1.5-pro',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.maxTokens': 4096,
+      },
+    });
+
+    expect(result.config).not.toHaveProperty('thinkingConfig');
+    expect(result.logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.enabled for model gemini-1.5-pro using format 'gemini' because model-generation-unsupported",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-1.5-pro',
+          format: 'gemini',
+          genericSetting: 'reasoning.enabled',
+          reason: 'model-generation-unsupported',
+        },
+      },
+      {
+        message:
+          "Gemini omitted configured reasoning.maxTokens for model gemini-1.5-pro using format 'gemini' because model-generation-unsupported",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-1.5-pro',
+          format: 'gemini',
+          genericSetting: 'reasoning.maxTokens',
+          reason: 'model-generation-unsupported',
+        },
+      },
+    ]);
   });
 
   it('emits thinkingBudget zero for default Gemini 2 disablement', () => {

--- a/packages/providers/src/gemini/__tests__/gemini.issue3255.test.ts
+++ b/packages/providers/src/gemini/__tests__/gemini.issue3255.test.ts
@@ -378,6 +378,68 @@ describe('Gemini issue 3255 reasoning request translation', () => {
     expect(thinkingConfig(config)).toStrictEqual({ thinkingBudget: 0 });
   });
 
+  it('warns when a disabled Gemini 2 configuration drops maxTokens', () => {
+    const result = build({
+      model: 'gemini-2.5-flash',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.maxTokens': 4096,
+      },
+    });
+
+    expect(thinkingConfig(result.config)).toStrictEqual({
+      thinkingBudget: 0,
+    });
+    expect(result.logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.maxTokens for model gemini-2.5-flash using format 'gemini' because reasoning-disabled",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-2.5-flash',
+          format: 'gemini',
+          genericSetting: 'reasoning.maxTokens',
+          reason: 'reasoning-disabled',
+        },
+      },
+    ]);
+  });
+
+  it('warns when a disabled Gemini 3 configuration drops maxTokens', () => {
+    const result = build({
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.maxTokens': 4096,
+      },
+    });
+
+    expect(result.config).not.toHaveProperty('thinkingConfig');
+    expect(result.logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.maxTokens for model gemini-3-flash-preview using format 'gemini' because reasoning-disabled",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          format: 'gemini',
+          genericSetting: 'reasoning.maxTokens',
+          reason: 'reasoning-disabled',
+        },
+      },
+      {
+        message:
+          "Gemini omitted configured reasoning.enabled for model gemini-3-flash-preview using format 'gemini' because gemini-3-disablement-unrepresentable",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          format: 'gemini',
+          genericSetting: 'reasoning.enabled',
+          reason: 'gemini-3-disablement-unrepresentable',
+        },
+      },
+    ]);
+  });
+
   it('warns that configured effort was suppressed when Gemini 2 is disabled', () => {
     const result = build({
       model: 'gemini-2.5-pro',

--- a/packages/providers/src/gemini/__tests__/gemini.issue3255.test.ts
+++ b/packages/providers/src/gemini/__tests__/gemini.issue3255.test.ts
@@ -1,0 +1,714 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type { NormalizedGenerateChatOptions } from '../../BaseProvider.js';
+import { buildRequestConfig } from '../geminiRequestBuilding.js';
+import { extractReasoningConfig } from '../geminiReasoningConfig.js';
+
+interface WarningEntry {
+  readonly message: string;
+  readonly metadata: unknown;
+}
+
+class RecordingDebugLogger extends DebugLogger {
+  readonly warnings: WarningEntry[] = [];
+
+  override warn(
+    messageOrFn: string | (() => string),
+    ...args: unknown[]
+  ): void {
+    this.warnings.push({
+      message: typeof messageOrFn === 'function' ? messageOrFn() : messageOrFn,
+      metadata: args.length === 1 ? args[0] : args,
+    });
+  }
+}
+
+interface GeminiFixture {
+  readonly model?: string;
+  readonly modelBehavior?: Readonly<Record<string, unknown>>;
+  readonly rawModelBehavior?: Readonly<Record<string, unknown>>;
+  readonly modelParams?: Readonly<Record<string, unknown>>;
+  readonly legacyEphemerals?: Readonly<Record<string, unknown>>;
+}
+
+function createOptions(fixture: GeminiFixture): NormalizedGenerateChatOptions {
+  const settings = new SettingsService();
+  const ephemeralsSnapshot = {
+    ...(fixture.legacyEphemerals ?? {}),
+    ...(fixture.modelBehavior ?? {}),
+    gemini: { ...(fixture.modelParams ?? {}) },
+  };
+  const runtime = createProviderRuntimeContext({
+    runtimeId: 'gemini-issue3255-test',
+    settingsService: settings,
+  });
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings,
+    providerName: 'gemini',
+    ephemeralsSnapshot,
+  });
+  const effectiveInvocation =
+    fixture.rawModelBehavior === undefined
+      ? invocation
+      : {
+          ...invocation,
+          modelBehavior: fixture.rawModelBehavior,
+        };
+
+  return {
+    contents: [],
+    tools: undefined,
+    metadata: {},
+    settings,
+    invocation: effectiveInvocation,
+    systemInstruction: 'test system prompt',
+    resolved: {
+      model: fixture.model ?? 'gemini-3-flash-preview',
+      authToken: 'test-token',
+    },
+  } satisfies NormalizedGenerateChatOptions;
+}
+
+interface BuiltFixture {
+  readonly config: Record<string, unknown>;
+  readonly logger: RecordingDebugLogger;
+}
+
+function build(fixture: GeminiFixture): BuiltFixture {
+  const options = createOptions(fixture);
+  const logger = new RecordingDebugLogger(
+    'llxprt:gemini:provider:issue3255-test',
+  );
+  return {
+    config: buildRequestConfig(
+      options,
+      undefined,
+      extractReasoningConfig(options),
+      options.resolved.model,
+      logger,
+    ),
+    logger,
+  };
+}
+
+function buildConfig(fixture: GeminiFixture): Record<string, unknown> {
+  return build(fixture).config;
+}
+
+function readRecord(value: unknown): Readonly<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    throw new Error('expected a record');
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function thinkingConfig(
+  config: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> | undefined {
+  const value = config['thinkingConfig'];
+  return value === undefined ? undefined : readRecord(value);
+}
+
+describe('Gemini issue 3255 reasoning request translation', () => {
+  it('retains Gemini 3 generic effort mapping under auto selectors', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'medium',
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingLevel: 'MEDIUM',
+    });
+  });
+
+  it('applies a profile effort remap before Gemini 3 level mapping', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortMap': { high: 'low' },
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingLevel: 'LOW',
+    });
+  });
+
+  it('accepts an explicitly mapped native Gemini 3 level', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'gemini',
+        'reasoning.effortMap': { high: 'LOW' },
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingLevel: 'LOW',
+    });
+  });
+
+  it('suppresses effort selected as none while retaining enabled thinking', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'none',
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({ includeThoughts: true });
+  });
+
+  it('suppresses a null effort map entry while retaining enabled thinking', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortMap': { high: null },
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({ includeThoughts: true });
+  });
+
+  it.each([
+    ['none', undefined, 'effort-format-none'],
+    ['auto', { high: null }, 'effort-map-null'],
+  ])(
+    'warns when Gemini effort is suppressed by %s configuration',
+    (effortWireFormat, effortMap, reason) => {
+      const result = build({
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+          'reasoning.effortWireFormat': effortWireFormat,
+          ...(effortMap === undefined
+            ? {}
+            : { 'reasoning.effortMap': effortMap }),
+        },
+      });
+
+      expect(result.logger.warnings).toStrictEqual([
+        {
+          message: `Gemini omitted configured reasoning.effort for model gemini-3-flash-preview using format '${effortWireFormat === 'none' ? 'none' : 'gemini'}' because ${reason}`,
+          metadata: {
+            provider: 'gemini',
+            model: 'gemini-3-flash-preview',
+            format: effortWireFormat === 'none' ? 'none' : 'gemini',
+            genericSetting: 'reasoning.effort',
+            reason,
+          },
+        },
+      ]);
+    },
+  );
+
+  it('enables Gemini 3 thinking without forcing a level when effort is absent', () => {
+    const config = buildConfig({
+      modelBehavior: { 'reasoning.enabled': true },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({ includeThoughts: true });
+  });
+
+  it('omits translated Gemini 3 thinking when default disablement is unrepresentable', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+        'reasoning.maxTokens': 4096,
+      },
+    });
+
+    expect(thinkingConfig(config)).toBeUndefined();
+  });
+
+  it('warns with safe context when Gemini 3 disablement cannot be represented', () => {
+    const result = build({
+      model: 'gemini-3-pro-preview',
+      modelBehavior: { 'reasoning.enabled': false },
+    });
+
+    expect(result.logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.enabled for model gemini-3-pro-preview using format 'gemini' because gemini-3-disablement-unrepresentable",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-pro-preview',
+          format: 'gemini',
+          genericSetting: 'reasoning.enabled',
+          reason: 'gemini-3-disablement-unrepresentable',
+        },
+      },
+    ]);
+  });
+
+  it('uses an explicit supported native level to represent Gemini 3 disablement', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.enabledMap': { false: 'LOW' },
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingLevel: 'LOW',
+    });
+  });
+
+  it('emits Gemini 2 thinking budget when reasoning is enabled', () => {
+    const config = buildConfig({
+      model: 'gemini-2.5-pro',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.maxTokens': 4096,
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingBudget: 4096,
+    });
+  });
+
+  it('emits thinkingBudget zero for default Gemini 2 disablement', () => {
+    const config = buildConfig({
+      model: 'gemini-2.5-flash',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.maxTokens': 4096,
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({ thinkingBudget: 0 });
+  });
+
+  it('warns that configured effort was suppressed when Gemini 2 is disabled', () => {
+    const result = build({
+      model: 'gemini-2.5-pro',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+      },
+    });
+
+    expect(thinkingConfig(result.config)).toStrictEqual({
+      thinkingBudget: 0,
+    });
+    expect(result.logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.effort for model gemini-2.5-pro using format 'gemini' because reasoning-disabled",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-2.5-pro',
+          format: 'gemini',
+          genericSetting: 'reasoning.effort',
+          reason: 'reasoning-disabled',
+        },
+      },
+    ]);
+  });
+
+  it('warns for suppressed effort and unrepresentable disablement when Gemini 3 is disabled', () => {
+    const result = build({
+      model: 'gemini-3-pro-preview',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+      },
+    });
+
+    expect(thinkingConfig(result.config)).toBeUndefined();
+    expect(result.logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.effort for model gemini-3-pro-preview using format 'gemini' because reasoning-disabled",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-pro-preview',
+          format: 'gemini',
+          genericSetting: 'reasoning.effort',
+          reason: 'reasoning-disabled',
+        },
+      },
+      {
+        message:
+          "Gemini omitted configured reasoning.enabled for model gemini-3-pro-preview using format 'gemini' because gemini-3-disablement-unrepresentable",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-pro-preview',
+          format: 'gemini',
+          genericSetting: 'reasoning.enabled',
+          reason: 'gemini-3-disablement-unrepresentable',
+        },
+      },
+    ]);
+  });
+
+  it('honors an enabled map that disables Gemini 2 thinking', () => {
+    const config = buildConfig({
+      model: 'gemini-2.5-pro',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.maxTokens': 4096,
+        'reasoning.enabledMap': { true: false },
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({ thinkingBudget: 0 });
+  });
+
+  it.each(['gemini-2.5-pro', 'gemini-3-flash-preview'])(
+    'keeps an explicit null disabled map entry as wire suppression for %s',
+    (model) => {
+      const config = buildConfig({
+        model,
+        modelBehavior: {
+          'reasoning.enabled': false,
+          'reasoning.effort': 'high',
+          'reasoning.enabledWireFormat': 'gemini',
+          'reasoning.enabledMap': { false: null },
+        },
+      });
+
+      // Null suppression emits nothing on the wire; it must not degrade
+      // into the default disablement form (thinkingBudget: 0).
+      expect(config).not.toHaveProperty('thinkingConfig');
+    },
+  );
+
+  it('preserves explicit native thinkingConfig exactly and adds no generic representation', () => {
+    const explicit = {
+      includeThoughts: false,
+      thinkingBudget: 2048,
+      customOption: { mode: 'user-selected' },
+    };
+    const result = build({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.maxTokens': 8192,
+      },
+      modelParams: { thinkingConfig: explicit },
+    });
+
+    expect({
+      thinkingConfig: thinkingConfig(result.config),
+      warnings: result.logger.warnings,
+    }).toStrictEqual({ thinkingConfig: explicit, warnings: [] });
+  });
+
+  it('retains unrelated model parameters without suppressing generic translation', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'low',
+      },
+      modelParams: { temperature: 0.25 },
+    });
+
+    expect({
+      temperature: config['temperature'],
+      thinkingConfig: thinkingConfig(config),
+    }).toStrictEqual({
+      temperature: 0.25,
+      thinkingConfig: {
+        includeThoughts: true,
+        thinkingLevel: 'LOW',
+      },
+    });
+  });
+
+  it('warns once when an unenabled effort is suppressed by a null map entry', () => {
+    const { config, logger } = build({
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortMap': { high: null },
+      },
+    });
+
+    expect(config).not.toHaveProperty('thinkingConfig');
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.effort for model gemini-3-flash-preview using format 'gemini' because effort-map-null",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          format: 'gemini',
+          genericSetting: 'reasoning.effort',
+          reason: 'effort-map-null',
+        },
+      },
+    ]);
+  });
+
+  it('warns once when an unenabled effort is suppressed by a none selector', () => {
+    const { logger } = build({
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'none',
+      },
+    });
+
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.effort for model gemini-3-flash-preview using format 'none' because effort-format-none",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          format: 'none',
+          genericSetting: 'reasoning.effort',
+          reason: 'effort-format-none',
+        },
+      },
+    ]);
+  });
+
+  it('identifies the native Gemini adapter when unenabled maxTokens are dropped', () => {
+    const { config, logger } = build({
+      modelBehavior: { 'reasoning.maxTokens': 4096 },
+    });
+
+    expect(config).not.toHaveProperty('thinkingConfig');
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.maxTokens for model gemini-3-flash-preview using format 'gemini' because reasoning-not-enabled",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          format: 'gemini',
+          genericSetting: 'reasoning.maxTokens',
+          reason: 'reasoning-not-enabled',
+        },
+      },
+    ]);
+  });
+
+  it('identifies the native Gemini adapter when Gemini 3 maxTokens are dropped', () => {
+    const { config, logger } = build({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.maxTokens': 4096,
+      },
+    });
+
+    expect(config['thinkingConfig']).toStrictEqual({ includeThoughts: true });
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "Gemini omitted configured reasoning.maxTokens for model gemini-3-flash-preview using format 'gemini' because gemini-3-max-tokens-unrepresentable",
+        metadata: {
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          format: 'gemini',
+          genericSetting: 'reasoning.maxTokens',
+          reason: 'gemini-3-max-tokens-unrepresentable',
+        },
+      },
+    ]);
+  });
+
+  it.each([
+    ['reasoning.effortWireFormat', 'openai'],
+    ['reasoning.enabledWireFormat', 'thinking'],
+  ])('rejects incompatible Gemini selector %s', (setting, value) => {
+    expect(() =>
+      buildConfig({
+        modelBehavior: {
+          'reasoning.enabled': true,
+          [setting]: value,
+        },
+      }),
+    ).toThrow('is incompatible with the gemini adapter');
+  });
+
+  it.each([
+    ['reasoning.enabled', 'yes', 'reasoning.enabled must be a boolean'],
+    ['reasoning.effort', 'turbo', 'reasoning.effort must be one of'],
+    [
+      'reasoning.maxTokens',
+      1.5,
+      'reasoning.maxTokens must be a positive integer',
+    ],
+    ['reasoning.effortMap', [], 'reasoning.effortMap must be a JSON object'],
+    [
+      'reasoning.enabledMap',
+      { maybe: true },
+      "reasoning.enabledMap contains unsupported key 'maybe'",
+    ],
+  ])('rejects malformed invocation value for %s', (setting, value, message) => {
+    expect(() =>
+      buildConfig({ rawModelBehavior: { [setting]: value } }),
+    ).toThrow(message);
+  });
+
+  it.each([
+    ['TURBO', 'gemini-3-pro-preview'],
+    ['LOW', 'gemini-2.5-pro'],
+  ])(
+    'rejects unsupported native mapped level %s for model %s',
+    (mappedLevel, model) => {
+      expect(() =>
+        buildConfig({
+          model,
+          modelBehavior: {
+            'reasoning.enabled': true,
+            'reasoning.effort': 'high',
+            'reasoning.effortMap': { high: mappedLevel },
+          },
+        }),
+      ).toThrow('is not supported by the Gemini adapter');
+    },
+  );
+
+  it('keeps legacy generic reasoning ephemerals as checked fallbacks', () => {
+    const config = buildConfig({
+      model: 'gemini-2.5-pro',
+      legacyEphemerals: {
+        reasoning: { enabled: true, maxTokens: 3072 },
+      },
+      rawModelBehavior: {},
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingBudget: 3072,
+    });
+  });
+
+  it('keeps an explicit effort authoritative over an enabled map native level', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'low',
+        'reasoning.enabledWireFormat': 'gemini',
+        'reasoning.enabledMap': { true: 'HIGH' },
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingLevel: 'LOW',
+    });
+  });
+
+  it('keeps an explicit effort authoritative over an enabled map boolean false', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'low',
+        'reasoning.enabledWireFormat': 'gemini',
+        'reasoning.enabledMap': { true: false },
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingLevel: 'LOW',
+    });
+  });
+
+  it('keeps an explicit effort remap authoritative over an enabled map native level', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'low',
+        'reasoning.effortMap': { low: 'medium' },
+        'reasoning.enabledWireFormat': 'gemini',
+        'reasoning.enabledMap': { true: 'HIGH' },
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingLevel: 'MEDIUM',
+    });
+  });
+
+  it('keeps a mapped enabled level when effort is absent', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.enabledWireFormat': 'gemini',
+        'reasoning.enabledMap': { true: 'HIGH' },
+      },
+    });
+
+    expect(thinkingConfig(config)).toStrictEqual({
+      includeThoughts: true,
+      thinkingLevel: 'HIGH',
+    });
+  });
+
+  it('emits only one native reasoning representation', () => {
+    const config = buildConfig({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'gemini',
+        'reasoning.enabledWireFormat': 'gemini',
+      },
+    });
+    const reasoningKeys = Object.keys(config).filter(
+      (key) =>
+        key.toLowerCase().includes('reasoning') || key === 'thinkingConfig',
+    );
+
+    expect(reasoningKeys).toStrictEqual(['thinkingConfig']);
+  });
+
+  it.each([
+    ['a Map instance', new Map([['enabled', true]])],
+    ['an array', ['enabled']],
+    ['a Date instance', new Date(0)],
+  ])('rejects a legacy reasoning ephemeral that is %s', (_label, value) => {
+    expect(() =>
+      buildConfig({
+        legacyEphemerals: { reasoning: value },
+        rawModelBehavior: {},
+      }),
+    ).toThrow('legacy reasoning ephemeral must be a JSON object');
+  });
+
+  it('rejects a legacy reasoning ephemeral that is a class instance', () => {
+    class LegacyReasoningRecord {
+      readonly enabled = true;
+    }
+
+    expect(() =>
+      buildConfig({
+        legacyEphemerals: { reasoning: new LegacyReasoningRecord() },
+        rawModelBehavior: {},
+      }),
+    ).toThrow('legacy reasoning ephemeral must be a JSON object');
+  });
+});

--- a/packages/providers/src/gemini/geminiGenerationSetup.ts
+++ b/packages/providers/src/gemini/geminiGenerationSetup.ts
@@ -6,6 +6,7 @@
 
 import { type Part, type GenerateContentResponse } from '@google/genai';
 import { type Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { type IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { type NormalizedGenerateChatOptions } from '../BaseProvider.js';
 import { type ResponseToChunksMapper } from './geminiResponseMapper.js';
@@ -55,6 +56,7 @@ export async function buildGenerationSetup(
   }>,
   createHttpOptions: () => HttpOptions,
   getBaseURL: () => string | undefined,
+  logger: DebugLogger,
 ): Promise<GeminiGenerationSetup> {
   const { contents: content, tools } = options;
   const { authMode, token: authToken } = await resolveAuth();
@@ -87,6 +89,7 @@ export async function buildGenerationSetup(
       geminiTools,
       reasoningConfig,
       currentModel,
+      logger,
     ),
     baseURL: options.resolved.baseURL ?? getBaseURL(),
     httpOptions: createHttpOptions(),

--- a/packages/providers/src/gemini/geminiReasoningConfig.ts
+++ b/packages/providers/src/gemini/geminiReasoningConfig.ts
@@ -27,6 +27,12 @@ import type { DumpMode } from '../utils/dumpContext.js';
 import { shouldDumpSDKContext } from '../utils/dumpSDKContext.js';
 
 export interface ReasoningConfig {
+  /**
+   * Generic thinking enablement choice. `undefined` means the caller made
+   * no generic enablement choice (only effort/maxTokens may still apply);
+   * it differs from an explicit `false`, which requests disablement and can
+   * surface an unrepresentable-disablement warning.
+   */
   readonly enabled: boolean | undefined;
   readonly includeInResponse: boolean;
   readonly stripFromContext: 'all' | 'allButLast' | 'none';

--- a/packages/providers/src/gemini/geminiReasoningConfig.ts
+++ b/packages/providers/src/gemini/geminiReasoningConfig.ts
@@ -4,26 +4,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type {
+  ReasoningEffort,
+  ReasoningEffortMap,
+  ReasoningEffortWireFormat,
+  ReasoningEnabledMap,
+  ReasoningEnabledWireFormat,
+} from '@vybestack/llxprt-code-settings';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import {
+  isPlainRecord,
+  readEffortMap,
+  readEffortWireFormat,
+  readEnabledMap,
+  readEnabledWireFormat,
+  readOptionalBoolean,
+  readOptionalEffort,
+  readOptionalPositiveInteger,
+  selectBehaviorValue,
+} from '../reasoning/reasoning-behavior-parsing.js';
+import type { DumpMode } from '../utils/dumpContext.js';
 import { shouldDumpSDKContext } from '../utils/dumpSDKContext.js';
 
-type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
-
 export interface ReasoningConfig {
-  enabled: boolean;
-  includeInResponse: boolean;
-  stripFromContext: 'all' | 'allButLast' | 'none';
-  effort: ReasoningEffort | undefined;
-  maxTokens: number | undefined;
+  readonly enabled: boolean | undefined;
+  readonly includeInResponse: boolean;
+  readonly stripFromContext: 'all' | 'allButLast' | 'none';
+  readonly effort: ReasoningEffort | undefined;
+  readonly maxTokens: number | undefined;
+  readonly effortWireFormat: ReasoningEffortWireFormat;
+  readonly enabledWireFormat: ReasoningEnabledWireFormat;
+  readonly effortMap: ReasoningEffortMap | undefined;
+  readonly enabledMap: ReasoningEnabledMap | undefined;
 }
 
 export type StripPolicy = ReasoningConfig['stripFromContext'];
 
-/**
- * Maps a reasoning effort level to the corresponding Gemini 3.x thinkingLevel
- * string. Returns undefined when no effort is specified, allowing the API to
- * use its default.
- */
+/** Maps generic effort to the existing Gemini 3 thinking-level ladder. */
 export function mapReasoningEffortToThinkingLevel(
   effort: ReasoningEffort | undefined,
 ): string | undefined {
@@ -45,72 +62,140 @@ export function mapReasoningEffortToThinkingLevel(
   }
 }
 
-/**
- * Extract reasoning configuration from normalized options. Reads from
- * invocation model behaviors, CLI settings, and ephemerals, preserving the
- * legacy fallback precedence.
- */
+/** Strictly extract Gemini reasoning configuration from the invocation snapshot. */
 export function extractReasoningConfig(
   options: NormalizedGenerateChatOptions,
 ): ReasoningConfig {
-  const earlyEphemerals = options.invocation.ephemerals;
-  const reasoningObj = (earlyEphemerals as Record<string, unknown>)[
-    'reasoning'
-  ] as Record<string, unknown> | undefined;
-  const enabled =
-    options.invocation.getModelBehavior<boolean>('reasoning.enabled') ??
-    ((earlyEphemerals as Record<string, unknown>)['reasoning.enabled'] ===
-      true ||
-      reasoningObj?.enabled === true);
-  const includeInResponse =
-    options.invocation.getCliSetting<boolean>('reasoning.includeInResponse') ??
-    ((earlyEphemerals as Record<string, unknown>)[
-      'reasoning.includeInResponse'
-    ] !== false &&
-      reasoningObj?.includeInResponse !== false);
-  const cliStripFromContext = options.invocation.getCliSetting<
-    'all' | 'allButLast' | 'none'
-  >('reasoning.stripFromContext');
-  const ephemeralStripFromContext = (
-    earlyEphemerals as Record<string, unknown>
-  )['reasoning.stripFromContext'] as 'all' | 'allButLast' | 'none' | undefined;
-  const objectStripFromContext = reasoningObj?.stripFromContext as
-    | 'all'
-    | 'allButLast'
-    | 'none'
-    | undefined;
-  const stripFromContext =
-    cliStripFromContext ??
-    ephemeralStripFromContext ??
-    objectStripFromContext ??
-    'all';
-  const effort =
-    options.invocation.getModelBehavior<ReasoningEffort>('reasoning.effort') ??
-    ((earlyEphemerals as Record<string, unknown>)['reasoning.effort'] as
-      | ReasoningEffort
-      | undefined) ??
-    (reasoningObj?.effort as ReasoningEffort | undefined);
-  const maxTokens =
-    options.invocation.getModelBehavior<number>('reasoning.maxTokens') ??
-    ((earlyEphemerals as Record<string, unknown>)['reasoning.maxTokens'] as
-      | number
-      | undefined) ??
-    (reasoningObj?.maxTokens as number | undefined);
-  return { enabled, includeInResponse, stripFromContext, effort, maxTokens };
+  const modelBehavior = options.invocation.modelBehavior;
+  const ephemerals = options.invocation.ephemerals;
+  const legacyReasoning = readLegacyReasoningObject(ephemerals['reasoning']);
+
+  return {
+    enabled: readOptionalBoolean(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.enabled',
+        selectLegacyValue(ephemerals, legacyReasoning, 'enabled'),
+      ),
+      'reasoning.enabled',
+    ),
+    includeInResponse: readIncludeInResponse(options, legacyReasoning),
+    stripFromContext: readStripFromContext(options, legacyReasoning),
+    effort: readOptionalEffort(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.effort',
+        selectLegacyValue(ephemerals, legacyReasoning, 'effort'),
+      ),
+    ),
+    maxTokens: readOptionalPositiveInteger(
+      selectBehaviorValue(
+        modelBehavior,
+        'reasoning.maxTokens',
+        selectLegacyValue(ephemerals, legacyReasoning, 'maxTokens'),
+      ),
+      'reasoning.maxTokens',
+    ),
+    effortWireFormat: readEffortWireFormat(
+      modelBehavior['reasoning.effortWireFormat'],
+    ),
+    enabledWireFormat: readEnabledWireFormat(
+      modelBehavior['reasoning.enabledWireFormat'],
+    ),
+    effortMap: readEffortMap(modelBehavior['reasoning.effortMap']),
+    enabledMap: readEnabledMap(modelBehavior['reasoning.enabledMap']),
+  };
+}
+
+function readLegacyReasoningObject(
+  value: unknown,
+): Readonly<Record<string, unknown>> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isPlainRecord(value)) {
+    throw new Error('legacy reasoning ephemeral must be a JSON object');
+  }
+  return value;
 }
 
 /**
- * Extract dump SDK context config from normalized options.
+ * Legacy fallback precedence for generic reasoning values: the dotted
+ * ephemeral key wins, then the nested legacy `reasoning` object member.
  */
+function selectLegacyValue(
+  ephemerals: Readonly<Record<string, unknown>>,
+  legacyReasoning: Readonly<Record<string, unknown>> | undefined,
+  key: string,
+): unknown {
+  const dotted = ephemerals[`reasoning.${key}`];
+  return dotted !== undefined ? dotted : legacyReasoning?.[key];
+}
+
+function readIncludeInResponse(
+  options: NormalizedGenerateChatOptions,
+  legacyReasoning: Readonly<Record<string, unknown>> | undefined,
+): boolean {
+  const cliValue =
+    options.invocation.cliSettings['reasoning.includeInResponse'];
+  const legacyValue = selectLegacyValue(
+    options.invocation.ephemerals,
+    legacyReasoning,
+    'includeInResponse',
+  );
+  return (
+    readOptionalBoolean(
+      cliValue === undefined ? legacyValue : cliValue,
+      'reasoning.includeInResponse',
+    ) !== false
+  );
+}
+
+function readStripFromContext(
+  options: NormalizedGenerateChatOptions,
+  legacyReasoning: Readonly<Record<string, unknown>> | undefined,
+): StripPolicy {
+  const cliValue = options.invocation.cliSettings['reasoning.stripFromContext'];
+  const value =
+    cliValue === undefined
+      ? selectLegacyValue(
+          options.invocation.ephemerals,
+          legacyReasoning,
+          'stripFromContext',
+        )
+      : cliValue;
+  if (value === undefined) {
+    return 'all';
+  }
+  if (value === 'all' || value === 'allButLast' || value === 'none') {
+    return value;
+  }
+  throw new Error(
+    "reasoning.stripFromContext must be one of 'all', 'allButLast', or 'none'",
+  );
+}
+
+/** Extract SDK context dump configuration from normalized options. */
 export function extractDumpConfig(options: NormalizedGenerateChatOptions): {
   shouldDumpSuccess: boolean;
   shouldDumpError: boolean;
 } {
-  const dumpMode = options.invocation.ephemerals.dumpcontext as Parameters<
-    typeof shouldDumpSDKContext
-  >[0];
+  const dumpMode = readDumpMode(options.invocation.ephemerals.dumpcontext);
   return {
     shouldDumpSuccess: shouldDumpSDKContext(dumpMode, false),
     shouldDumpError: shouldDumpSDKContext(dumpMode, true),
   };
+}
+
+function readDumpMode(value: unknown): DumpMode | undefined {
+  switch (value) {
+    case 'now':
+    case 'status':
+    case 'on':
+    case 'error':
+    case 'off':
+      return value;
+    default:
+      return undefined;
+  }
 }

--- a/packages/providers/src/gemini/geminiReasoningTranslation.ts
+++ b/packages/providers/src/gemini/geminiReasoningTranslation.ts
@@ -80,12 +80,53 @@ export function applyGeminiReasoningTranslation(
     return;
   }
 
+  // Budget translation belongs to Gemini 2 and level translation to
+  // Gemini 3; any other generation has no native reasoning representation,
+  // so configured values are omitted with a warning (issue #3255).
   if (isGemini3Model(input.model)) {
     applyGemini3Thinking(input, resolved);
     return;
   }
 
-  applyBudgetThinking(input, resolved);
+  if (isGemini2Model(input.model)) {
+    applyBudgetThinking(input, resolved);
+    return;
+  }
+
+  warnUnsupportedGeneration(input, resolved);
+}
+
+function warnUnsupportedGeneration(
+  input: GeminiReasoningTranslationInput,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (input.reasoningConfig.enabled !== undefined) {
+    warnDropped(
+      input,
+      'reasoning.enabled',
+      resolved.enabledFormat,
+      'model-generation-unsupported',
+    );
+  }
+  if (
+    input.reasoningConfig.effort !== undefined &&
+    resolved.effort.state === 'emitted'
+  ) {
+    warnDropped(
+      input,
+      'reasoning.effort',
+      resolved.effortFormat,
+      'model-generation-unsupported',
+    );
+  }
+  if (input.reasoningConfig.maxTokens !== undefined) {
+    warnDropped(
+      input,
+      'reasoning.maxTokens',
+      'gemini',
+      'model-generation-unsupported',
+    );
+  }
 }
 
 function applyDisabledThinking(
@@ -102,20 +143,29 @@ function applyDisabledThinking(
     return;
   }
 
+  // The disabled path permits only a genuine disable representation: a
+  // thinking level or a true boolean enables thinking, so neither can
+  // express reasoning.enabled=false (issue #3255).
   if (typeof resolved.enabled.value === 'string') {
-    const level = readNativeThinkingLevel(resolved.enabled.value, input.model);
     if (!isGemini3Model(input.model)) {
-      throw unsupportedNativeLevelError(level, input.model);
+      throw unsupportedNativeLevelError(resolved.enabled.value, input.model);
     }
-    input.requestConfig['thinkingConfig'] = {
-      includeThoughts: true,
-      thinkingLevel: level,
-    };
+    warnDropped(
+      input,
+      'reasoning.enabled',
+      resolved.enabledFormat,
+      'gemini-3-disablement-unrepresentable',
+    );
     return;
   }
 
   if (resolved.enabled.value === true) {
-    applyEnabledWithoutEffort(input);
+    warnDropped(
+      input,
+      'reasoning.enabled',
+      resolved.enabledFormat,
+      disablementReason(input.model),
+    );
     return;
   }
 
@@ -128,23 +178,14 @@ function applyDisabledThinking(
     input,
     'reasoning.enabled',
     resolved.enabledFormat,
-    isGemini3Model(input.model)
-      ? 'gemini-3-disablement-unrepresentable'
-      : 'gemini-disablement-unrepresentable',
+    disablementReason(input.model),
   );
 }
 
-function applyEnabledWithoutEffort(
-  input: GeminiReasoningTranslationInput,
-): void {
-  if (isGemini3Model(input.model)) {
-    input.requestConfig['thinkingConfig'] = { includeThoughts: true };
-    return;
-  }
-  input.requestConfig['thinkingConfig'] = {
-    includeThoughts: true,
-    thinkingBudget: input.reasoningConfig.maxTokens ?? -1,
-  };
+function disablementReason(model: string): string {
+  return isGemini3Model(model)
+    ? 'gemini-3-disablement-unrepresentable'
+    : 'gemini-disablement-unrepresentable';
 }
 
 function applyGemini3Thinking(

--- a/packages/providers/src/gemini/geminiReasoningTranslation.ts
+++ b/packages/providers/src/gemini/geminiReasoningTranslation.ts
@@ -58,6 +58,12 @@ export function applyGeminiReasoningTranslation(
       resolved.effortFormat,
       resolved.effort,
     );
+    // A configured maxTokens budget is equally unreachable while disabled:
+    // no disablement representation can carry a thinking budget (issue
+    // #3255).
+    if (input.reasoningConfig.maxTokens !== undefined) {
+      warnDropped(input, 'reasoning.maxTokens', 'gemini', 'reasoning-disabled');
+    }
     applyDisabledThinking(input, resolved);
     return;
   }

--- a/packages/providers/src/gemini/geminiReasoningTranslation.ts
+++ b/packages/providers/src/gemini/geminiReasoningTranslation.ts
@@ -1,0 +1,349 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  isGemini2Model,
+  isGemini3Model,
+} from '@vybestack/llxprt-code-core/config/models.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { ReasoningEffort } from '@vybestack/llxprt-code-settings';
+import {
+  resolveReasoningConfiguration,
+  type ReasoningResolution,
+  type ResolvedReasoningConfiguration,
+} from '../reasoning/reasoning-config-resolver.js';
+import {
+  mapReasoningEffortToThinkingLevel,
+  type ReasoningConfig,
+} from './geminiReasoningConfig.js';
+
+interface GeminiReasoningTranslationInput {
+  readonly requestConfig: Record<string, unknown>;
+  readonly reasoningConfig: ReasoningConfig;
+  readonly model: string;
+  readonly logger: DebugLogger;
+}
+
+type NativeThinkingLevel = 'LOW' | 'MEDIUM' | 'HIGH';
+
+/** Apply the one resolved generic reasoning representation owned by Gemini. */
+export function applyGeminiReasoningTranslation(
+  input: GeminiReasoningTranslationInput,
+): void {
+  if (hasOwn(input.requestConfig, 'thinkingConfig')) {
+    return;
+  }
+
+  const resolved = resolveReasoningConfiguration({
+    nativeAdapter: 'gemini',
+    reasoning: {
+      enabled: input.reasoningConfig.enabled,
+      effort: input.reasoningConfig.effort,
+    },
+    effortWireFormat: input.reasoningConfig.effortWireFormat,
+    enabledWireFormat: input.reasoningConfig.enabledWireFormat,
+    effortMap: input.reasoningConfig.effortMap,
+    enabledMap: input.reasoningConfig.enabledMap,
+  });
+
+  if (input.reasoningConfig.enabled === false) {
+    // Disablement suppresses a configured effort; report it before the
+    // native disablement path returns (issue #3255).
+    warnForResolvedOutcome(
+      input,
+      'reasoning.effort',
+      resolved.effortFormat,
+      resolved.effort,
+    );
+    applyDisabledThinking(input, resolved);
+    return;
+  }
+
+  warnForResolvedOutcome(
+    input,
+    'reasoning.effort',
+    resolved.effortFormat,
+    resolved.effort,
+  );
+  warnForResolvedOutcome(
+    input,
+    'reasoning.enabled',
+    resolved.enabledFormat,
+    resolved.enabled,
+  );
+
+  if (input.reasoningConfig.enabled !== true) {
+    warnForUnenabledValues(input, resolved);
+    return;
+  }
+
+  if (isGemini3Model(input.model)) {
+    applyGemini3Thinking(input, resolved);
+    return;
+  }
+
+  applyBudgetThinking(input, resolved);
+}
+
+function applyDisabledThinking(
+  input: GeminiReasoningTranslationInput,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (resolved.enabled.state !== 'emitted') {
+    warnForResolvedOutcome(
+      input,
+      'reasoning.enabled',
+      resolved.enabledFormat,
+      resolved.enabled,
+    );
+    return;
+  }
+
+  if (typeof resolved.enabled.value === 'string') {
+    const level = readNativeThinkingLevel(resolved.enabled.value, input.model);
+    if (!isGemini3Model(input.model)) {
+      throw unsupportedNativeLevelError(level, input.model);
+    }
+    input.requestConfig['thinkingConfig'] = {
+      includeThoughts: true,
+      thinkingLevel: level,
+    };
+    return;
+  }
+
+  if (resolved.enabled.value === true) {
+    applyEnabledWithoutEffort(input);
+    return;
+  }
+
+  if (isGemini2Model(input.model)) {
+    input.requestConfig['thinkingConfig'] = { thinkingBudget: 0 };
+    return;
+  }
+
+  warnDropped(
+    input,
+    'reasoning.enabled',
+    resolved.enabledFormat,
+    isGemini3Model(input.model)
+      ? 'gemini-3-disablement-unrepresentable'
+      : 'gemini-disablement-unrepresentable',
+  );
+}
+
+function applyEnabledWithoutEffort(
+  input: GeminiReasoningTranslationInput,
+): void {
+  if (isGemini3Model(input.model)) {
+    input.requestConfig['thinkingConfig'] = { includeThoughts: true };
+    return;
+  }
+  input.requestConfig['thinkingConfig'] = {
+    includeThoughts: true,
+    thinkingBudget: input.reasoningConfig.maxTokens ?? -1,
+  };
+}
+
+function applyGemini3Thinking(
+  input: GeminiReasoningTranslationInput,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  // Explicit effort wins over a mapped enabled level: both resolve into
+  // the same thinkingLevel control, so the configured effort (or its map
+  // remap) is the authoritative value and the enabled map level only
+  // covers effort-absent configuration (issue #3255).
+  const effortLevel = readResolvedEffortLevel(input, resolved.effort);
+  const mappedEnabledLevel =
+    effortLevel === undefined
+      ? readMappedEnabledLevel(input, resolved.enabled)
+      : undefined;
+  const thinkingLevel = effortLevel ?? mappedEnabledLevel;
+  input.requestConfig['thinkingConfig'] = {
+    includeThoughts: true,
+    ...(thinkingLevel === undefined ? {} : { thinkingLevel }),
+  };
+
+  if (input.reasoningConfig.maxTokens !== undefined) {
+    warnDropped(
+      input,
+      'reasoning.maxTokens',
+      'gemini',
+      'gemini-3-max-tokens-unrepresentable',
+    );
+  }
+}
+
+function applyBudgetThinking(
+  input: GeminiReasoningTranslationInput,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (resolved.enabled.state === 'emitted') {
+    if (typeof resolved.enabled.value === 'string') {
+      throw unsupportedNativeLevelError(resolved.enabled.value, input.model);
+    }
+    if (resolved.enabled.value === false) {
+      input.requestConfig['thinkingConfig'] = { thinkingBudget: 0 };
+      return;
+    }
+  }
+
+  if (
+    resolved.effort.state === 'emitted' &&
+    typeof resolved.effort.value === 'string' &&
+    isNativeThinkingLevel(resolved.effort.value)
+  ) {
+    throw unsupportedNativeLevelError(resolved.effort.value, input.model);
+  }
+  if (input.reasoningConfig.effort !== undefined) {
+    warnDropped(
+      input,
+      'reasoning.effort',
+      resolved.effortFormat,
+      'gemini-2-effort-unrepresentable',
+    );
+  }
+
+  input.requestConfig['thinkingConfig'] = {
+    includeThoughts: true,
+    thinkingBudget: input.reasoningConfig.maxTokens ?? -1,
+  };
+}
+
+function readMappedEnabledLevel(
+  input: GeminiReasoningTranslationInput,
+  enabled: ReasoningResolution<string | boolean>,
+): NativeThinkingLevel | undefined {
+  if (enabled.state !== 'emitted' || typeof enabled.value !== 'string') {
+    return undefined;
+  }
+  return readNativeThinkingLevel(enabled.value, input.model);
+}
+
+function readResolvedEffortLevel(
+  input: GeminiReasoningTranslationInput,
+  effort: ReasoningResolution<string | number>,
+): NativeThinkingLevel | undefined {
+  if (effort.state !== 'emitted') {
+    return undefined;
+  }
+  if (typeof effort.value !== 'string') {
+    throw new Error('Gemini reasoning effort must resolve to a string');
+  }
+  if (isNativeThinkingLevel(effort.value)) {
+    return effort.value;
+  }
+
+  const genericEffort = readGenericEffort(effort.value);
+  if (genericEffort === undefined) {
+    throw unsupportedNativeLevelError(effort.value, input.model);
+  }
+  const mapped = mapReasoningEffortToThinkingLevel(genericEffort);
+  if (mapped === undefined || !isNativeThinkingLevel(mapped)) {
+    throw unsupportedNativeLevelError(effort.value, input.model);
+  }
+  return mapped;
+}
+
+function readGenericEffort(value: string): ReasoningEffort | undefined {
+  switch (value) {
+    case 'minimal':
+    case 'low':
+    case 'medium':
+    case 'high':
+    case 'xhigh':
+    case 'max':
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function readNativeThinkingLevel(
+  value: string,
+  model: string,
+): NativeThinkingLevel {
+  if (isNativeThinkingLevel(value)) {
+    return value;
+  }
+  throw unsupportedNativeLevelError(value, model);
+}
+
+function isNativeThinkingLevel(value: string): value is NativeThinkingLevel {
+  return value === 'LOW' || value === 'MEDIUM' || value === 'HIGH';
+}
+
+function unsupportedNativeLevelError(value: string, model: string): Error {
+  return new Error(
+    `native Gemini thinking level '${value}' is not supported by the Gemini adapter for model '${model}'`,
+  );
+}
+
+function warnForResolvedOutcome(
+  input: GeminiReasoningTranslationInput,
+  genericSetting: 'reasoning.effort' | 'reasoning.enabled',
+  format: string,
+  outcome: ReasoningResolution<string | number | boolean>,
+): void {
+  if (outcome.state !== 'suppressed' && outcome.state !== 'unrepresentable') {
+    return;
+  }
+  const configured =
+    genericSetting === 'reasoning.effort'
+      ? input.reasoningConfig.effort !== undefined
+      : input.reasoningConfig.enabled !== undefined;
+  if (configured) {
+    warnDropped(input, genericSetting, format, outcome.reason);
+  }
+}
+
+function warnForUnenabledValues(
+  input: GeminiReasoningTranslationInput,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (
+    input.reasoningConfig.effort !== undefined &&
+    resolved.effort.state !== 'suppressed' &&
+    resolved.effort.state !== 'unrepresentable'
+  ) {
+    warnDropped(
+      input,
+      'reasoning.effort',
+      resolved.effortFormat,
+      'reasoning-not-enabled',
+    );
+  }
+  if (input.reasoningConfig.maxTokens !== undefined) {
+    warnDropped(
+      input,
+      'reasoning.maxTokens',
+      'gemini',
+      'reasoning-not-enabled',
+    );
+  }
+}
+
+function warnDropped(
+  input: GeminiReasoningTranslationInput,
+  genericSetting: string,
+  format: string,
+  reason: string,
+): void {
+  input.logger.warn(
+    () =>
+      `Gemini omitted configured ${genericSetting} for model ${input.model} using format '${format}' because ${reason}`,
+    {
+      provider: 'gemini',
+      model: input.model,
+      format,
+      genericSetting,
+      reason,
+    },
+  );
+}
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}

--- a/packages/providers/src/gemini/geminiRequestBuilding.ts
+++ b/packages/providers/src/gemini/geminiRequestBuilding.ts
@@ -5,7 +5,7 @@
  */
 
 import { Type, type Schema, type Part } from '@google/genai';
-import { isGemini3Model } from '@vybestack/llxprt-code-core/config/models.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { type NormalizedGenerateChatOptions } from '../BaseProvider.js';
 import { convertHistoryToGeminiFormat } from './GeminiMessageConverter.js';
 import {
@@ -18,9 +18,9 @@ import {
 } from './geminiSchemaHelpers.js';
 import {
   type ReasoningConfig,
-  mapReasoningEffortToThinkingLevel,
   type StripPolicy,
 } from './geminiReasoningConfig.js';
+import { applyGeminiReasoningTranslation } from './geminiReasoningTranslation.js';
 
 export interface GeminiToolsResult {
   geminiTools:
@@ -103,39 +103,13 @@ export function resolveServerTools(
     : ['web_search', 'web_fetch'];
 }
 
-/** Apply thinking config to request config based on model version and reasoning settings. */
-export function applyThinkingConfig(
-  requestConfig: Record<string, unknown>,
-  reasoningConfig: Pick<ReasoningConfig, 'enabled' | 'effort' | 'maxTokens'>,
-  currentModel: string,
-): void {
-  if (!reasoningConfig.enabled) {
-    return;
-  }
-  // @plan PLAN-20251202-THINKING.P03b @requirement REQ-THINK-006
-  if (isGemini3Model(currentModel)) {
-    const thinkingLevel = mapReasoningEffortToThinkingLevel(
-      reasoningConfig.effort,
-    );
-    const thinkingConfig: Record<string, unknown> = { includeThoughts: true };
-    if (thinkingLevel !== undefined) {
-      thinkingConfig.thinkingLevel = thinkingLevel;
-    }
-    requestConfig.thinkingConfig = thinkingConfig;
-  } else {
-    requestConfig.thinkingConfig = {
-      includeThoughts: true,
-      thinkingBudget: reasoningConfig.maxTokens ?? -1,
-    };
-  }
-}
-
 /** Build request config from options, tools, and reasoning settings. */
 export function buildRequestConfig(
   options: NormalizedGenerateChatOptions,
   geminiTools: GeminiToolsResult['geminiTools'],
   reasoningConfig: ReasoningConfig,
   currentModel: string,
+  logger: DebugLogger,
 ): Record<string, unknown> {
   const directOverridesRaw = (
     options.metadata as { geminiDirectOverrides?: unknown }
@@ -172,7 +146,12 @@ export function buildRequestConfig(
   if (toolConfigOverride !== undefined) {
     requestConfig.toolConfig = toolConfigOverride;
   }
-  applyThinkingConfig(requestConfig, reasoningConfig, currentModel);
+  applyGeminiReasoningTranslation({
+    requestConfig,
+    reasoningConfig,
+    model: currentModel,
+    logger,
+  });
   return requestConfig;
 }
 

--- a/packages/providers/src/openai-responses/OpenAIResponsesTypes.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesTypes.ts
@@ -58,7 +58,11 @@ export type OpenAIResponsesRequest = {
   parallel_tool_calls?: boolean;
   stream: boolean;
   include?: string[];
-  reasoning?: { effort?: string; summary?: string };
+  reasoning?: {
+    effort?: string;
+    summary?: string;
+    [key: string]: unknown;
+  };
   text?: { verbosity: string };
   store?: boolean;
   previous_response_id?: string;

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.issue3255.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.issue3255.test.ts
@@ -1,0 +1,531 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import type { RuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type { NormalizedGenerateChatOptions } from '../../BaseProvider.js';
+import { loadProviderAliasEntries } from '../../composition/providerAliases.js';
+import { computeModelDefaults } from '../../runtime/providerMutations.js';
+import {
+  buildRequestContext,
+  type ResponsesExecutorDeps,
+} from '../openAIResponsesExecutor.js';
+import type { OpenAIResponsesRequest } from '../OpenAIResponsesTypes.js';
+
+const PROVIDER_NAME = 'openai-responses';
+const BASE_URL = 'https://api.openai.com/v1';
+
+interface WarningEntry {
+  readonly message: string;
+  readonly metadata: unknown;
+}
+
+class RecordingDebugLogger extends DebugLogger {
+  readonly warnings: WarningEntry[] = [];
+
+  override warn(
+    messageOrFn: string | (() => string),
+    ...args: unknown[]
+  ): void {
+    this.warnings.push({
+      message: typeof messageOrFn === 'function' ? messageOrFn() : messageOrFn,
+      metadata: args.length === 1 ? args[0] : args,
+    });
+  }
+}
+
+interface RequestFixture {
+  readonly model?: string;
+  readonly baseURL?: string;
+  readonly modelBehavior?: Readonly<Record<string, unknown>>;
+  readonly rawModelBehavior?: Readonly<Record<string, unknown>>;
+  readonly modelParams?: Readonly<Record<string, unknown>>;
+  readonly rawModelParams?: Readonly<Record<string, unknown>>;
+}
+
+interface BuiltFixture {
+  readonly request: OpenAIResponsesRequest;
+  readonly logger: RecordingDebugLogger;
+}
+
+function createOptions(fixture: RequestFixture): NormalizedGenerateChatOptions {
+  const settings = new SettingsService();
+  for (const [key, value] of Object.entries(fixture.modelBehavior ?? {})) {
+    settings.set(key, value);
+  }
+  for (const [key, value] of Object.entries(fixture.modelParams ?? {})) {
+    settings.setProviderSetting(PROVIDER_NAME, key, value);
+  }
+
+  const resolved: NormalizedGenerateChatOptions['resolved'] = {
+    model: fixture.model ?? 'gpt-5.6-sol',
+    baseURL: fixture.baseURL ?? BASE_URL,
+    authToken: 'test-token',
+  };
+  const generated = createProviderCallOptions({
+    providerName: PROVIDER_NAME,
+    settings,
+    resolved,
+    contents: [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'test request' }] },
+    ],
+  });
+  const invocation = createInvocation(
+    generated.invocation,
+    fixture.rawModelBehavior,
+    fixture.rawModelParams,
+  );
+
+  return {
+    ...generated,
+    invocation,
+    metadata: generated.metadata ?? {},
+    resolved,
+  } satisfies NormalizedGenerateChatOptions;
+}
+
+function createInvocation(
+  invocation: RuntimeInvocationContext,
+  rawModelBehavior: Readonly<Record<string, unknown>> | undefined,
+  rawModelParams: Readonly<Record<string, unknown>> | undefined,
+): RuntimeInvocationContext {
+  const next: RuntimeInvocationContext =
+    rawModelBehavior === undefined
+      ? invocation
+      : ({
+          ...invocation,
+          modelBehavior: rawModelBehavior,
+        } satisfies RuntimeInvocationContext);
+  return rawModelParams === undefined
+    ? next
+    : ({
+        ...next,
+        modelParams: rawModelParams,
+      } satisfies RuntimeInvocationContext);
+}
+
+function createDeps(
+  logger: RecordingDebugLogger,
+  baseURL: string,
+): ResponsesExecutorDeps {
+  return {
+    providerName: PROVIDER_NAME,
+    logger,
+    getProviderBaseURL: () => baseURL,
+    getCustomHeaders: () => undefined,
+    isCodexBaseURL: () => false,
+    getCodexAccountId: async () => 'test-account',
+    resolveAuthTokenForPrompt: async () => 'test-token',
+    shouldRetryOnError: () => false,
+    getDefaultModel: () => 'gpt-5.6-sol',
+    getGlobalConfig: () => undefined,
+  } satisfies ResponsesExecutorDeps;
+}
+
+async function build(fixture: RequestFixture): Promise<BuiltFixture> {
+  const options = createOptions(fixture);
+  const logger = new RecordingDebugLogger(
+    'llxprt:providers:openai-responses:issue3255-test',
+  );
+  const baseURL = fixture.baseURL ?? BASE_URL;
+  const context = await buildRequestContext(
+    options,
+    [...options.contents],
+    { ...options.invocation.ephemerals },
+    createDeps(logger, baseURL),
+  );
+  return { request: context.request, logger };
+}
+
+function reasoningTranslationKeys(
+  request: Readonly<OpenAIResponsesRequest>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of [
+    'reasoning',
+    'reasoning.effortWireFormat',
+    'reasoning.enabledWireFormat',
+    'reasoning.effortMap',
+    'reasoning.enabledMap',
+  ]) {
+    if (key in request) {
+      result[key] = request[key];
+    }
+  }
+  return result;
+}
+
+describe('OpenAI Responses reasoning wire translation (issue #3255)', () => {
+  it.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'emits nested effort for %s through the Responses adapter',
+    async (model) => {
+      const { request } = await build({
+        model,
+        modelBehavior: { 'reasoning.effort': 'high' },
+      });
+
+      expect(reasoningTranslationKeys(request)).toStrictEqual({
+        reasoning: { effort: 'high' },
+      });
+    },
+  );
+
+  it('applies a profile effort remap before building nested Responses reasoning', async () => {
+    const { request } = await build({
+      modelBehavior: {
+        'reasoning.effort': 'medium',
+        'reasoning.effortMap': { medium: 'high' },
+        'reasoning.effortWireFormat': 'openai-responses',
+        'reasoning.enabledWireFormat': 'auto',
+      },
+    });
+
+    expect(reasoningTranslationKeys(request)).toStrictEqual({
+      reasoning: { effort: 'high' },
+    });
+  });
+
+  it('applies GPT-5.6 minimal-to-none policy after the profile map', async () => {
+    const { request } = await build({
+      model: 'gpt-5.6-terra',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortMap': { high: 'minimal' },
+      },
+    });
+
+    expect(request.reasoning).toStrictEqual({ effort: 'none' });
+  });
+
+  it('emits an explicit mapped enablement value as Responses effort', async () => {
+    const { request } = await build({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.enabledWireFormat': 'openai-responses',
+        'reasoning.enabledMap': { true: 'medium' },
+      },
+    });
+
+    expect(request.reasoning).toStrictEqual({ effort: 'medium' });
+    expect(request.include).toStrictEqual(['reasoning.encrypted_content']);
+  });
+
+  it('keeps an explicit effort authoritative over an enabled map string', async () => {
+    const { request, logger } = await build({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.enabledWireFormat': 'openai-responses',
+        'reasoning.enabledMap': { true: 'medium' },
+      },
+    });
+
+    expect(request.reasoning).toStrictEqual({ effort: 'high' });
+    expect(request.include).toStrictEqual(['reasoning.encrypted_content']);
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('selects reasoning output without an effort or warning when enabled only', async () => {
+    const { request, logger } = await build({
+      modelBehavior: { 'reasoning.enabled': true },
+    });
+
+    expect(request.reasoning).toBeUndefined();
+    expect(request.include).toStrictEqual(['reasoning.encrypted_content']);
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('uses a mapped disabled value instead of the ordinary generic effort', async () => {
+    const { request } = await build({
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+        'reasoning.enabledWireFormat': 'openai-responses',
+        'reasoning.enabledMap': { false: 'none' },
+      },
+    });
+
+    expect(request.reasoning).toStrictEqual({ effort: 'none' });
+    expect(request.include).toStrictEqual(['reasoning.encrypted_content']);
+  });
+
+  it('omits stale effort and encrypted-content include when disablement is unrepresentable', async () => {
+    const { request, logger } = await build({
+      baseURL: 'https://api.openai.com/v1?token=do-not-log',
+      model: 'gpt-5.6-luna',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+      },
+    });
+
+    expect(request.reasoning).toBeUndefined();
+    expect(request.include).toBeUndefined();
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "OpenAI Responses omitted configured reasoning.effort because effort format 'openai-responses' cannot emit it",
+        metadata: {
+          providerName: PROVIDER_NAME,
+          model: 'gpt-5.6-luna',
+          selectedFormat: 'openai-responses',
+          setting: 'reasoning.effort',
+          reason: 'reasoning-disabled',
+        },
+      },
+      {
+        message:
+          "OpenAI Responses omitted configured reasoning.enabled because enabled format 'none' cannot emit it",
+        metadata: {
+          providerName: PROVIDER_NAME,
+          model: 'gpt-5.6-luna',
+          selectedFormat: 'none',
+          setting: 'reasoning.enabled',
+          reason: 'enabled-format-undetected',
+        },
+      },
+    ]);
+    expect(JSON.stringify(logger.warnings)).not.toContain('do-not-log');
+  });
+
+  it('omits effort for an explicit none selector and records the accepted warning', async () => {
+    const { request, logger } = await build({
+      model: 'gpt-5.6-sol',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'none',
+      },
+    });
+
+    expect(request.reasoning).toBeUndefined();
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "OpenAI Responses omitted configured reasoning.effort because effort format 'none' cannot emit it",
+        metadata: {
+          providerName: PROVIDER_NAME,
+          model: 'gpt-5.6-sol',
+          selectedFormat: 'none',
+          setting: 'reasoning.effort',
+          reason: 'effort-format-none',
+        },
+      },
+    ]);
+  });
+
+  it('omits effort for a null map entry and records the accepted warning', async () => {
+    const { request, logger } = await build({
+      model: 'gpt-5.6-terra',
+      modelBehavior: {
+        'reasoning.effort': 'medium',
+        'reasoning.effortMap': { medium: null },
+      },
+    });
+
+    expect(request.reasoning).toBeUndefined();
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "OpenAI Responses omitted configured reasoning.effort because effort format 'openai-responses' cannot emit it",
+        metadata: {
+          providerName: PROVIDER_NAME,
+          model: 'gpt-5.6-terra',
+          selectedFormat: 'openai-responses',
+          setting: 'reasoning.effort',
+          reason: 'effort-map-null',
+        },
+      },
+    ]);
+  });
+
+  it('preserves explicit native reasoning exactly and skips generic translation warnings', async () => {
+    const explicitReasoning = {
+      effort: 'low',
+      summary: 'concise',
+      provider_extension: { mode: 'preserve' },
+    };
+    const { request, logger } = await build({
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'none',
+        'reasoning.effortMap': { high: null },
+      },
+      modelParams: { reasoning: explicitReasoning },
+    });
+
+    expect(request.reasoning).toStrictEqual(explicitReasoning);
+    expect(request.include).toStrictEqual(['reasoning.encrypted_content']);
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('preserves an explicit null reasoning value exactly and stands down', async () => {
+    const { request, logger } = await build({
+      modelBehavior: { 'reasoning.effort': 'high' },
+      rawModelParams: { reasoning: null },
+    });
+
+    const explicitReasoning: unknown = request['reasoning'];
+    expect(explicitReasoning).toBeNull();
+    expect(request.include).toBeUndefined();
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('preserves an explicit non-object reasoning value exactly and stands down', async () => {
+    const { request, logger } = await build({
+      modelBehavior: { 'reasoning.effort': 'high' },
+      rawModelParams: { reasoning: 'disabled' },
+    });
+
+    const explicitReasoning: unknown = request['reasoning'];
+    expect(explicitReasoning).toBe('disabled');
+    expect(request.include).toBeUndefined();
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('keeps generic translation active when an unrelated request override exists', async () => {
+    const { request } = await build({
+      modelBehavior: { 'reasoning.effort': 'medium' },
+      modelParams: { temperature: 0.4 },
+    });
+
+    expect(request.temperature).toBe(0.4);
+    expect(request.reasoning).toStrictEqual({ effort: 'medium' });
+  });
+
+  it('retains summary and encrypted-content include for emitted reasoning', async () => {
+    const { request } = await build({
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.summary': 'detailed',
+      },
+    });
+
+    expect(request.reasoning).toStrictEqual({
+      effort: 'high',
+      summary: 'detailed',
+    });
+    expect(request.include).toStrictEqual(['reasoning.encrypted_content']);
+  });
+
+  it('fails before transport when an effort map is not an object', async () => {
+    const request = build({
+      rawModelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortMap': ['high'],
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      'reasoning.effortMap must be a JSON object',
+    );
+  });
+
+  it('fails before transport when a mapped type is incompatible', async () => {
+    const request = build({
+      rawModelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortMap': { high: 8192 },
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      'reasoning.effortMap.high must be a string for openai-responses',
+    );
+  });
+
+  it('fails before transport for an incompatible explicit selector', async () => {
+    const request = build({
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'anthropic',
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      "effort wire format 'anthropic' is incompatible with the openai-responses adapter",
+    );
+  });
+
+  it.each([
+    {
+      setting: 'reasoning.enabled',
+      value: 'true',
+      expected: 'reasoning.enabled must be a boolean',
+    },
+    {
+      setting: 'reasoning.effort',
+      value: 'ultra',
+      expected: "reasoning.effort must be one of 'minimal'",
+    },
+    {
+      setting: 'reasoning.budgetTokens',
+      value: 0,
+      expected: 'reasoning.budgetTokens must be a positive integer',
+    },
+    {
+      setting: 'reasoning.effortWireFormat',
+      value: 'custom',
+      expected: "reasoning.effortWireFormat must be one of 'auto'",
+    },
+    {
+      setting: 'reasoning.enabledWireFormat',
+      value: 'custom',
+      expected: "reasoning.enabledWireFormat must be one of 'auto'",
+    },
+  ] satisfies ReadonlyArray<{
+    readonly setting: string;
+    readonly value: unknown;
+    readonly expected: string;
+  }>)(
+    'strictly rejects malformed invocation model behavior for $setting',
+    async ({ setting, value, expected }) => {
+      const request = build({
+        rawModelBehavior: { [setting]: value },
+      });
+
+      await expect(request).rejects.toThrow(expected);
+    },
+  );
+
+  it('sends the built-in codex alias defaults as nested Responses reasoning', async () => {
+    const aliasEntry = loadProviderAliasEntries().find(
+      (candidate) =>
+        candidate.source === 'builtin' && candidate.alias === 'codex',
+    );
+    if (!aliasEntry) {
+      throw new Error('Builtin codex alias entry not found');
+    }
+    const model = aliasEntry.config.defaultModel;
+    if (typeof model !== 'string' || model === '') {
+      throw new Error('Builtin codex alias entry must declare a default model');
+    }
+    const baseUrl = aliasEntry.config['base-url'];
+    if (typeof baseUrl !== 'string') {
+      throw new Error('Builtin codex alias entry must declare a base URL');
+    }
+    const modelBehavior: Record<string, unknown> = {
+      ...aliasEntry.config.ephemeralSettings,
+      ...computeModelDefaults(model, aliasEntry.config.modelDefaults ?? []),
+    };
+
+    const { request, logger } = await build({
+      model,
+      baseURL: baseUrl,
+      modelBehavior,
+    });
+
+    expect(model).toBe('gpt-5.6-sol');
+    expect(request.reasoning).toStrictEqual({
+      effort: 'medium',
+      summary: 'auto',
+    });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -39,11 +39,12 @@ import { resolveRuntimeAuthToken } from '../utils/authToken.js';
 import { getRequestSignal } from '../utils/abortSignal.js';
 import { isPreviousResponseNotFoundError } from './openAIResponsesStatefulRecovery.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
-import {
-  toOpenAIResponsesWireEffort,
-  OPENAI_TRANSPORT_SELECTOR_KEYS,
-} from '../openai/openaiModelPolicy.js';
+import { OPENAI_TRANSPORT_SELECTOR_KEYS } from '../openai/openaiModelPolicy.js';
 import { buildOpenAIResponsesInput } from './OpenAIResponsesInputBuilder.js';
+import {
+  applyOpenAIResponsesReasoning,
+  type AppliedOpenAIResponsesReasoning,
+} from './openai-responses-reasoning.js';
 import { sanitizePromptCacheKey } from './sanitizePromptCacheKey.js';
 import type {
   OpenAIResponsesRequest,
@@ -167,13 +168,6 @@ export interface PreparedResponsesRequestContext {
 interface RequestContext extends PreparedResponsesRequestContext {
   readonly apiKey: string;
   readonly baseURL: string;
-}
-
-interface ReasoningOptions {
-  enabled: boolean;
-  effort?: string;
-  summary?: string;
-  includeThinkingInResponse: boolean;
 }
 
 function resolveInvocationEphemerals(
@@ -646,11 +640,6 @@ function translateRequestOverrides(
         () =>
           `Translated ${key}=${value} to max_output_tokens for Responses API`,
       );
-    } else if (key === 'reasoning') {
-      deps.logger.debug(
-        () =>
-          `Skipping reasoning object in modelParams - handled via model-behavior settings`,
-      );
     } else if (key === 'prompt_cache_key') {
       const sanitized =
         typeof value === 'string' ? sanitizePromptCacheKey(value) : '';
@@ -726,98 +715,44 @@ function applyReasoningSettings(
   options: NormalizedGenerateChatOptions,
   invocationEphemerals: Record<string, unknown>,
   deps: ResponsesExecutorDeps,
-): ReasoningOptions {
-  const reasoning = getReasoningOptions(options, invocationEphemerals);
-  const shouldRequestReasoning =
-    reasoning.enabled || reasoning.effort !== undefined;
+): AppliedOpenAIResponsesReasoning {
+  const reasoning = applyOpenAIResponsesReasoning({
+    request,
+    modelBehavior: options.invocation.modelBehavior,
+    fallbacks: {
+      enabled:
+        invocationEphemerals['reasoning.enabled'] ??
+        readOptionalSetting(options, 'reasoning.enabled'),
+      effort:
+        invocationEphemerals['reasoning.effort'] ??
+        readOptionalSetting(options, 'reasoning.effort'),
+      budgetTokens:
+        invocationEphemerals['reasoning.budgetTokens'] ??
+        readOptionalSetting(options, 'reasoning.budgetTokens'),
+      summary:
+        invocationEphemerals['reasoning.summary'] ??
+        readOptionalSetting(options, 'reasoning.summary'),
+      includeInResponse:
+        invocationEphemerals['reasoning.includeInResponse'] ??
+        readOptionalSetting(options, 'reasoning.includeInResponse'),
+    },
+    providerName: deps.providerName,
+    logger: deps.logger,
+  });
   deps.logger.debug(
     () =>
-      `Reasoning check: enabled=${reasoning.enabled}, effort=${String(reasoning.effort)}, summary=${String(reasoning.summary)}, shouldRequest=${shouldRequestReasoning}, includeInResponse=${reasoning.includeThinkingInResponse}`,
+      `Reasoning check: enabled=${String(reasoning.enabled)}, effort=${String(reasoning.effort)}, summary=${String(reasoning.summary)}, shouldRequest=${reasoning.selected}, includeInResponse=${reasoning.includeThinkingInResponse}`,
   );
-  if (shouldRequestReasoning) {
+  if (reasoning.selected) {
     request.include = ['reasoning.encrypted_content'];
     deps.logger.debug(
       () => `Added include parameter: ${JSON.stringify(request.include)}`,
     );
-    applyReasoningEffort(request, reasoning.effort, deps);
   }
-  applyReasoningSummary(request, reasoning.summary, deps);
   deps.logger.debug(
     () => `Full request reasoning config: ${JSON.stringify(request.reasoning)}`,
   );
   return reasoning;
-}
-
-function getReasoningOptions(
-  options: NormalizedGenerateChatOptions,
-  ephemerals: Record<string, unknown>,
-): ReasoningOptions {
-  const settings = (options as { settings?: { get: (key: string) => unknown } })
-    .settings;
-  const enabled =
-    ((ephemerals['reasoning.enabled'] as boolean | undefined) ??
-      options.invocation.getModelBehavior<boolean>('reasoning.enabled') ??
-      settings?.get('reasoning.enabled')) === true;
-  const effort =
-    (ephemerals['reasoning.effort'] as string | undefined) ??
-    options.invocation.getModelBehavior<string>('reasoning.effort') ??
-    (settings?.get('reasoning.effort') as string | undefined);
-  const summary =
-    (ephemerals['reasoning.summary'] as string | undefined) ??
-    options.invocation.getModelBehavior<string>('reasoning.summary') ??
-    (settings?.get('reasoning.summary') as string | undefined);
-  const includeSetting =
-    (ephemerals['reasoning.includeInResponse'] as boolean | undefined) ??
-    options.invocation.getModelBehavior<boolean>(
-      'reasoning.includeInResponse',
-    ) ??
-    settings?.get('reasoning.includeInResponse');
-  return {
-    enabled,
-    effort,
-    summary,
-    includeThinkingInResponse: includeSetting !== false,
-  };
-}
-
-function applyReasoningEffort(
-  request: OpenAIResponsesRequest,
-  reasoningEffort: string | undefined,
-  deps: ResponsesExecutorDeps,
-): void {
-  if (typeof reasoningEffort !== 'string' || reasoningEffort === '') return;
-  const wireEffort = toOpenAIResponsesWireEffort(
-    reasoningEffort,
-    request.model,
-  );
-  request.reasoning ??= {};
-  request.reasoning.effort = wireEffort;
-  deps.logger.debug(
-    () =>
-      `Added reasoning.effort to request: ${reasoningEffort}` +
-      (wireEffort !== reasoningEffort
-        ? ` (mapped to ${wireEffort} for model ${request.model})`
-        : ''),
-  );
-}
-
-function applyReasoningSummary(
-  request: OpenAIResponsesRequest,
-  reasoningSummary: string | undefined,
-  deps: ResponsesExecutorDeps,
-): void {
-  if (
-    typeof reasoningSummary !== 'string' ||
-    reasoningSummary === '' ||
-    reasoningSummary === 'none'
-  ) {
-    return;
-  }
-  request.reasoning ??= {};
-  request.reasoning.summary = reasoningSummary;
-  deps.logger.debug(
-    () => `Added reasoning.summary to request: ${reasoningSummary}`,
-  );
 }
 
 function applyTextVerbosity(

--- a/packages/providers/src/openai-responses/openai-responses-reasoning.ts
+++ b/packages/providers/src/openai-responses/openai-responses-reasoning.ts
@@ -1,0 +1,307 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type {
+  ReasoningEffort,
+  ReasoningEffortMap,
+  ReasoningEffortWireFormat,
+  ReasoningEnabledMap,
+  ReasoningEnabledWireFormat,
+} from '@vybestack/llxprt-code-settings';
+import { toOpenAIResponsesWireEffort } from '../openai/openaiModelPolicy.js';
+import {
+  readEffortMap,
+  readEffortWireFormat,
+  readEnabledMap,
+  readEnabledWireFormat,
+  readModelBehaviorRecord,
+  readOptionalBoolean,
+  readOptionalEffort,
+  readOptionalPositiveInteger,
+  selectBehaviorValue,
+} from '../reasoning/reasoning-behavior-parsing.js';
+import {
+  resolveReasoningConfiguration,
+  type ReasoningResolution,
+  type ResolvedReasoningConfiguration,
+} from '../reasoning/reasoning-config-resolver.js';
+import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
+
+export interface ResponsesReasoningFallbacks {
+  readonly enabled?: unknown;
+  readonly effort?: unknown;
+  readonly budgetTokens?: unknown;
+  readonly summary?: unknown;
+  readonly includeInResponse?: unknown;
+}
+
+export interface OpenAIResponsesReasoningInput {
+  readonly request: OpenAIResponsesRequest;
+  readonly modelBehavior: unknown;
+  readonly fallbacks: ResponsesReasoningFallbacks;
+  readonly providerName: string;
+  readonly logger: DebugLogger;
+}
+
+export interface AppliedOpenAIResponsesReasoning {
+  readonly enabled: boolean | undefined;
+  readonly effort: ReasoningEffort | undefined;
+  readonly summary: string | undefined;
+  readonly selected: boolean;
+  readonly includeThinkingInResponse: boolean;
+}
+
+interface ParsedReasoningBehavior {
+  readonly reasoning: {
+    readonly enabled?: boolean;
+    readonly effort?: ReasoningEffort;
+    readonly budgetTokens?: number;
+  };
+  readonly summary?: string;
+  readonly effortWireFormat: ReasoningEffortWireFormat;
+  readonly enabledWireFormat: ReasoningEnabledWireFormat;
+  readonly effortMap?: ReasoningEffortMap;
+  readonly enabledMap?: ReasoningEnabledMap;
+}
+
+/** Resolve and apply generic reasoning settings to an OpenAI Responses body. */
+export function applyOpenAIResponsesReasoning(
+  input: OpenAIResponsesReasoningInput,
+): AppliedOpenAIResponsesReasoning {
+  // The behavior record is read once and shared by both paths so explicit
+  // native reasoning does not reparse the snapshot (issue #3255).
+  const modelBehavior = readModelBehaviorRecord(input.modelBehavior);
+  const includeThinkingInResponse =
+    selectBehaviorValue(
+      modelBehavior,
+      'reasoning.includeInResponse',
+      input.fallbacks.includeInResponse,
+    ) !== false;
+
+  // Any own `reasoning` property copied from modelParams is explicit,
+  // including null and non-object values: it must reach the wire exactly
+  // unchanged, so translation stands down rather than overwriting it
+  // (issue #3255). The own-property presence, not its shape, decides.
+  if (Object.prototype.hasOwnProperty.call(input.request, 'reasoning')) {
+    const explicitReasoning = input.request['reasoning'];
+    return {
+      enabled: undefined,
+      effort: undefined,
+      summary: isRecord(explicitReasoning)
+        ? readOptionalSummary(explicitReasoning['summary'])
+        : undefined,
+      selected: isRecord(explicitReasoning)
+        ? hasNonEmptyString(explicitReasoning['effort'])
+        : false,
+      includeThinkingInResponse,
+    };
+  }
+
+  const behavior = parseReasoningBehavior(input, modelBehavior);
+  const resolved = resolveReasoningConfiguration({
+    nativeAdapter: 'openai-responses',
+    reasoning: behavior.reasoning,
+    effortWireFormat: behavior.effortWireFormat,
+    enabledWireFormat: behavior.enabledWireFormat,
+    effortMap: behavior.effortMap,
+    enabledMap: behavior.enabledMap,
+  });
+
+  warnForDroppedReasoning(input, behavior, resolved);
+  const selected = applyResolvedReasoning(input.request, resolved, behavior);
+  applyReasoningSummary(input.request, behavior.summary);
+
+  return {
+    enabled: behavior.reasoning.enabled,
+    effort: behavior.reasoning.effort,
+    summary: behavior.summary,
+    selected,
+    includeThinkingInResponse,
+  };
+}
+
+function parseReasoningBehavior(
+  input: OpenAIResponsesReasoningInput,
+  modelBehavior: Readonly<Record<string, unknown>>,
+): ParsedReasoningBehavior {
+  const enabled = readOptionalBoolean(
+    selectBehaviorValue(
+      modelBehavior,
+      'reasoning.enabled',
+      input.fallbacks.enabled,
+    ),
+    'reasoning.enabled',
+  );
+  const effort = readOptionalEffort(
+    selectBehaviorValue(
+      modelBehavior,
+      'reasoning.effort',
+      input.fallbacks.effort,
+    ),
+  );
+  const budgetTokens = readOptionalPositiveInteger(
+    selectBehaviorValue(
+      modelBehavior,
+      'reasoning.budgetTokens',
+      input.fallbacks.budgetTokens,
+    ),
+    'reasoning.budgetTokens',
+  );
+  const summary = readOptionalSummary(
+    selectBehaviorValue(
+      modelBehavior,
+      'reasoning.summary',
+      input.fallbacks.summary,
+    ),
+  );
+
+  return {
+    reasoning: { enabled, effort, budgetTokens },
+    summary,
+    effortWireFormat: readEffortWireFormat(
+      modelBehavior['reasoning.effortWireFormat'],
+    ),
+    enabledWireFormat: readEnabledWireFormat(
+      modelBehavior['reasoning.enabledWireFormat'],
+    ),
+    effortMap: readEffortMap(modelBehavior['reasoning.effortMap']),
+    enabledMap: readEnabledMap(modelBehavior['reasoning.enabledMap']),
+  };
+}
+
+function readOptionalSummary(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+function warnForDroppedReasoning(
+  input: OpenAIResponsesReasoningInput,
+  behavior: ParsedReasoningBehavior,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (behavior.reasoning.effort !== undefined) {
+    warnForOutcome(
+      input,
+      'reasoning.effort',
+      'effort',
+      resolved.effortFormat,
+      resolved.effort,
+    );
+  }
+  if (behavior.reasoning.budgetTokens !== undefined) {
+    warnForDroppedBudget(input, resolved.effortFormat);
+  }
+  // Enabled-only configuration still selects reasoning output (the prior
+  // executor requested encrypted thinking content for enabled=true), so a
+  // dropped-enablement warning would be misleading (issue #3255).
+  if (
+    behavior.reasoning.enabled !== undefined &&
+    behavior.reasoning.enabled !== true
+  ) {
+    warnForOutcome(
+      input,
+      'reasoning.enabled',
+      'enabled',
+      resolved.enabledFormat,
+      resolved.enabled,
+    );
+  }
+}
+
+function warnForDroppedBudget(
+  input: OpenAIResponsesReasoningInput,
+  selectedFormat: string,
+): void {
+  input.logger.warn(
+    () =>
+      `OpenAI Responses omitted configured reasoning.budgetTokens because effort format '${selectedFormat}' cannot emit it`,
+    {
+      providerName: input.providerName,
+      model: input.request.model,
+      selectedFormat,
+      setting: 'reasoning.budgetTokens',
+      reason: 'budget-not-supported',
+    },
+  );
+}
+
+function warnForOutcome(
+  input: OpenAIResponsesReasoningInput,
+  setting: string,
+  dimension: 'effort' | 'enabled',
+  selectedFormat: string,
+  outcome: ReasoningResolution<string | number | boolean>,
+): void {
+  if (outcome.state !== 'suppressed' && outcome.state !== 'unrepresentable') {
+    return;
+  }
+  input.logger.warn(
+    () =>
+      `OpenAI Responses omitted configured ${setting} because ${dimension} format '${selectedFormat}' cannot emit it`,
+    {
+      providerName: input.providerName,
+      model: input.request.model,
+      selectedFormat,
+      setting,
+      reason: outcome.reason,
+    },
+  );
+}
+
+function applyResolvedReasoning(
+  request: OpenAIResponsesRequest,
+  resolved: ResolvedReasoningConfiguration,
+  behavior: ParsedReasoningBehavior,
+): boolean {
+  let wireEffort: string | undefined;
+  if (
+    resolved.effortFormat === 'openai-responses' &&
+    resolved.effort.state === 'emitted' &&
+    typeof resolved.effort.value === 'string'
+  ) {
+    wireEffort = toOpenAIResponsesWireEffort(
+      resolved.effort.value,
+      request.model,
+    );
+  }
+  if (
+    resolved.enabledFormat === 'openai-responses' &&
+    resolved.enabled.state === 'emitted' &&
+    typeof resolved.enabled.value === 'string'
+  ) {
+    wireEffort = toOpenAIResponsesWireEffort(
+      resolved.enabled.value,
+      request.model,
+    );
+  }
+  if (wireEffort !== undefined) {
+    request.reasoning = { effort: wireEffort };
+    return true;
+  }
+
+  // Enabled-only configuration selects reasoning output without fabricating
+  // an effort, matching the prior executor's encrypted-content include
+  // (issue #3255).
+  return behavior.reasoning.enabled === true;
+}
+
+function applyReasoningSummary(
+  request: OpenAIResponsesRequest,
+  summary: string | undefined,
+): void {
+  if (summary === undefined || summary === 'none') {
+    return;
+  }
+  request.reasoning = { ...request.reasoning, summary };
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue3255.test-helpers.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue3255.test-helpers.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared harness for the issue #3255 OpenAI Chat reasoning wire-translation
+ * suites: fixture builders, invocation wiring, and the recording logger the
+ * tests assert suppressed-setting warnings through.
+ */
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import {
+  createRuntimeInvocationContext,
+  type RuntimeInvocationContext,
+} from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import { loadProviderAliasEntries } from '../composition/providerAliases.js';
+import { computeModelDefaults } from '../runtime/providerMutations.js';
+import { prepareRequest } from './OpenAIRequestPreparation.js';
+
+const PROVIDER = 'openai';
+/**
+ * Real top-level reasoning wire keys only. The nested controls
+ * (`chat_template_kwargs.enable_thinking`, `thinking.budget_tokens`,
+ * `output_config.effort`) are asserted through their compared parent
+ * containers rather than listed here as top-level pseudo-keys.
+ */
+const REASONING_BODY_KEYS: readonly string[] = [
+  'reasoning',
+  'thinking',
+  'reasoning_effort',
+  'parse_reasoning',
+  'chat_template_kwargs',
+  'output_config',
+];
+
+interface WarningEntry {
+  readonly message: string;
+  readonly metadata: unknown;
+}
+
+class RecordingDebugLogger extends DebugLogger {
+  readonly warnings: WarningEntry[] = [];
+
+  override warn(
+    messageOrFn: string | (() => string),
+    ...args: unknown[]
+  ): void {
+    this.warnings.push({
+      message: typeof messageOrFn === 'function' ? messageOrFn() : messageOrFn,
+      metadata: args.length === 1 ? args[0] : args,
+    });
+  }
+}
+
+interface RequestFixture {
+  readonly baseURL?: string;
+  readonly model?: string;
+  readonly modelBehavior?: Readonly<Record<string, unknown>>;
+  readonly rawModelBehavior?: Readonly<Record<string, unknown>>;
+  readonly modelParams?: Readonly<Record<string, unknown>>;
+  readonly providerName?: string;
+}
+
+interface PreparedFixture {
+  readonly body: Record<string, unknown>;
+  readonly logger: RecordingDebugLogger;
+}
+
+/**
+ * Resolve the merged model behavior a shipped builtin alias produces for a
+ * model: alias ephemeralSettings overlaid by matching modelDefaults rules.
+ */
+export function builtinAliasModelBehavior(
+  alias: string,
+  model: string,
+): Record<string, unknown> {
+  const entry = loadProviderAliasEntries().find(
+    (candidate) =>
+      candidate.source === 'builtin' &&
+      candidate.alias.toLowerCase() === alias.toLowerCase(),
+  );
+  if (!entry) {
+    throw new Error(`Builtin provider alias '${alias}' was not loaded`);
+  }
+  return {
+    ...entry.config.ephemeralSettings,
+    ...computeModelDefaults(model, entry.config.modelDefaults ?? []),
+  };
+}
+
+function createInvocation(
+  settings: SettingsService,
+  providerName: string,
+  modelBehavior: Readonly<Record<string, unknown>>,
+  rawModelBehavior: Readonly<Record<string, unknown>> | undefined,
+  modelParams: Readonly<Record<string, unknown>>,
+): RuntimeInvocationContext {
+  for (const [key, value] of Object.entries(modelBehavior)) {
+    settings.set(key, value);
+  }
+  for (const [key, value] of Object.entries(modelParams)) {
+    settings.setProviderSetting(providerName, key, value);
+  }
+
+  const invocation = createRuntimeInvocationContext({
+    runtime: { settingsService: settings, runtimeId: 'issue3255-test' },
+    settings,
+    providerName,
+    ephemeralsSnapshot: {
+      ...modelBehavior,
+      [providerName]: modelParams,
+    },
+  });
+  if (rawModelBehavior === undefined) {
+    return invocation;
+  }
+
+  return {
+    ...invocation,
+    modelBehavior: rawModelBehavior,
+  } satisfies RuntimeInvocationContext;
+}
+
+function createOptions(
+  fixture: RequestFixture,
+  providerName: string,
+): NormalizedGenerateChatOptions {
+  const settings = new SettingsService();
+  const invocation = createInvocation(
+    settings,
+    providerName,
+    fixture.modelBehavior ?? {},
+    fixture.rawModelBehavior,
+    fixture.modelParams ?? {},
+  );
+
+  return {
+    contents: [],
+    tools: undefined,
+    metadata: {},
+    settings,
+    config: undefined,
+    invocation,
+    systemInstruction: 'test system prompt',
+    resolved: {
+      model: fixture.model ?? 'test-reasoning-model',
+      baseURL: fixture.baseURL,
+      authToken: 'test-token',
+    },
+  } satisfies NormalizedGenerateChatOptions;
+}
+
+export async function prepare(
+  fixture: RequestFixture,
+): Promise<PreparedFixture> {
+  const logger = new RecordingDebugLogger(
+    'llxprt:provider:openai:issue3255-test',
+  );
+  const providerName = fixture.providerName ?? PROVIDER;
+  const result = await prepareRequest(
+    createOptions(fixture, providerName),
+    'fallback-model',
+    undefined,
+    logger,
+    providerName,
+  );
+  return { body: { ...result.requestBody }, logger };
+}
+
+export function reasoningFields(
+  body: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  for (const key of REASONING_BODY_KEYS) {
+    if (key in body) {
+      fields[key] = body[key];
+    }
+  }
+  return fields;
+}

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue3255.test-helpers.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue3255.test-helpers.ts
@@ -175,7 +175,7 @@ export function reasoningFields(
 ): Record<string, unknown> {
   const fields: Record<string, unknown> = {};
   for (const key of REASONING_BODY_KEYS) {
-    if (key in body) {
+    if (Object.prototype.hasOwnProperty.call(body, key)) {
       fields[key] = body[key];
     }
   }

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue3255.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue3255.test.ts
@@ -309,6 +309,23 @@ describe('OpenAI Chat reasoning wire translation (issue #3255)', () => {
     );
   });
 
+  it('fails before transport when a thinking disabled map meets an emitted budget', async () => {
+    const preparation = prepare({
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'anthropic-budget',
+        'reasoning.effortMap': { high: 8192 },
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'disabled' },
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      "effort format 'anthropic-budget' and thinking type 'disabled' emit conflicting OpenAI Chat reasoning representations",
+    );
+  });
+
   it('suppresses a direct budget when reasoning is disabled', async () => {
     const { body } = await prepare({
       baseURL: 'http://localhost:8000/v1',
@@ -465,6 +482,43 @@ describe('OpenAI Chat reasoning wire translation (issue #3255)', () => {
       thinking: { type: 'enabled', budget_tokens: 8192 },
     });
     expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('warns for a dropped budget and disablement separately under anthropic-budget', async () => {
+    const { body, logger } = await prepare({
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.budgetTokens': 8192,
+        'reasoning.effortWireFormat': 'anthropic-budget',
+        'reasoning.enabledWireFormat': 'none',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          'OpenAI Chat omitted configured reasoning.budgetTokens because reasoning is explicitly disabled',
+        metadata: {
+          provider: 'openai',
+          model: 'test-reasoning-model',
+          selectedFormat: 'anthropic-budget',
+          setting: 'reasoning.budgetTokens',
+          reason: 'reasoning-disabled',
+        },
+      },
+      {
+        message:
+          "OpenAI Chat omitted configured reasoning.enabled because the enabled format is set to 'none'",
+        metadata: {
+          provider: 'openai',
+          model: 'test-reasoning-model',
+          selectedFormat: 'none',
+          setting: 'reasoning.enabled',
+          reason: 'enabled-format-none',
+        },
+      },
+    ]);
   });
   it.each([
     ['reasoning', { effort: 'max' }],
@@ -822,5 +876,15 @@ describe('OpenAI Chat reasoning wire translation (issue #3255)', () => {
       thinking: { type: 'enabled' },
     });
     expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('reports only own reasoning properties and ignores inherited ones', () => {
+    const body: Record<string, unknown> = Object.create({
+      reasoning_effort: 'inherited',
+    });
+    body['thinking'] = { type: 'enabled' };
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+    });
   });
 });

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue3255.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue3255.test.ts
@@ -1,0 +1,826 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  builtinAliasModelBehavior,
+  prepare,
+  reasoningFields,
+} from './OpenAIRequestPreparation.issue3255.test-helpers.js';
+
+describe('OpenAI Chat reasoning wire translation (issue #3255)', () => {
+  it('emits top-level OpenAI effort for a custom URL with an explicit selector', async () => {
+    const { body } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({ reasoning_effort: 'high' });
+  });
+
+  it('auto-selects top-level effort for the official OpenAI Chat API', async () => {
+    const { body } = await prepare({
+      baseURL: 'https://api.openai.com/v1',
+      model: 'gpt-5.2',
+      modelBehavior: { 'reasoning.effort': 'medium' },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({ reasoning_effort: 'medium' });
+  });
+
+  it('omits reasoning on an unknown auto endpoint and records a credential-free warning', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'https://unknown.example/v1?api_key=do-not-log',
+      model: 'local-model',
+      modelBehavior: { 'reasoning.effort': 'high' },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          'OpenAI Chat omitted configured reasoning.effort because the effort format could not be detected for this endpoint',
+        metadata: {
+          provider: 'openai',
+          model: 'local-model',
+          selectedFormat: 'none',
+          setting: 'reasoning.effort',
+          reason: 'effort-format-undetected',
+        },
+      },
+    ]);
+    expect(JSON.stringify(logger.warnings)).not.toContain('do-not-log');
+  });
+
+  it('warns when an explicit none selector suppresses effort', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.effort': 'low',
+        'reasoning.effortWireFormat': 'none',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "OpenAI Chat omitted configured reasoning.effort because the effort format is set to 'none'",
+        metadata: {
+          provider: 'openai',
+          model: 'test-reasoning-model',
+          selectedFormat: 'none',
+          setting: 'reasoning.effort',
+          reason: 'effort-format-none',
+        },
+      },
+    ]);
+  });
+
+  it('combines both template kwargs forms and preserves an unrelated sibling', async () => {
+    const { body } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.enabledWireFormat': 'template-kwargs',
+        'reasoning.effortWireFormat': 'template-kwargs',
+      },
+      modelParams: {
+        chat_template_kwargs: { tokenize: false },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      chat_template_kwargs: {
+        tokenize: false,
+        enable_thinking: true,
+        reasoning_effort: 'high',
+      },
+    });
+  });
+
+  it('merges selected OpenRouter enablement and effort into one reasoning object', async () => {
+    const { body } = await prepare({
+      baseURL: 'https://openrouter.ai/api/v1',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.enabledMap': { true: true },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      reasoning: { enabled: true, effort: 'high' },
+    });
+  });
+
+  it('emits the coordinated Z.AI thinking and effort pair without alternatives', async () => {
+    const { body } = await prepare({
+      baseURL: 'https://api.z.ai/api/paas/v4',
+      model: 'glm-5.3',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'xhigh',
+        'reasoning.effortMap': { xhigh: 'max' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+      reasoning_effort: 'max',
+    });
+  });
+
+  it('supports a Kimi K3-style effort-only profile selection', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'https://api.moonshot.ai/v1',
+      model: 'kimi-k3',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'medium',
+        'reasoning.enabledWireFormat': 'none',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.effortMap': { medium: 'high' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({ reasoning_effort: 'high' });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('supports Kimi K2.7-style thinking and warns when effort is suppressed', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'https://api.moonshot.ai/v1',
+      model: 'kimi-k2.7',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.effortWireFormat': 'none',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+    });
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "OpenAI Chat omitted configured reasoning.effort because the effort format is set to 'none'",
+        metadata: {
+          provider: 'openai',
+          model: 'kimi-k2.7',
+          selectedFormat: 'none',
+          setting: 'reasoning.effort',
+          reason: 'effort-format-none',
+        },
+      },
+    ]);
+  });
+
+  it('emits the exact Anthropic budget thinking body from a numeric effort map', async () => {
+    const { body } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'anthropic-budget',
+        'reasoning.effortMap': { high: 8192 },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled', budget_tokens: 8192 },
+    });
+  });
+
+  it('lets a direct budget override an effort-derived Anthropic budget', async () => {
+    const { body } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.budgetTokens': 16384,
+        'reasoning.effortWireFormat': 'anthropic-budget',
+        'reasoning.effortMap': { high: 8192 },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled', budget_tokens: 16384 },
+    });
+  });
+
+  it('gives enabled=false precedence over effort on OpenRouter', async () => {
+    const { body } = await prepare({
+      baseURL: 'https://openrouter.ai/api/v1',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      reasoning: { enabled: false },
+    });
+  });
+
+  it('uses an enabled map to express disablement through OpenAI effort', async () => {
+    const { body } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+        'reasoning.enabledWireFormat': 'openai',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.enabledMap': { false: 'none' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({ reasoning_effort: 'none' });
+  });
+
+  it('keeps an explicit effort authoritative over an enabled map string on the OpenAI effort field', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.enabledWireFormat': 'openai',
+        'reasoning.enabledMap': { true: 'max' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      reasoning_effort: 'high',
+    });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('suppresses an enabled map string with a null entry while effort still emits', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.enabledWireFormat': 'openai',
+        'reasoning.enabledMap': { true: null },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      reasoning_effort: 'high',
+    });
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          'OpenAI Chat omitted configured reasoning.enabled because its enabled map entry is null',
+        metadata: {
+          provider: 'openai',
+          model: 'test-reasoning-model',
+          selectedFormat: 'openai',
+          setting: 'reasoning.enabled',
+          reason: 'enabled-map-null',
+        },
+      },
+    ]);
+  });
+
+  it('fails before transport when emitted effort and enabled formats conflict', async () => {
+    const preparation = prepare({
+      baseURL: 'https://openrouter.ai/api/v1',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openrouter',
+        'reasoning.enabledWireFormat': 'thinking',
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      "effort format 'openrouter' and enabled format 'thinking' emit conflicting OpenAI Chat reasoning representations",
+    );
+  });
+
+  it('suppresses a direct budget when reasoning is disabled', async () => {
+    const { body } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.budgetTokens': 8192,
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.effortWireFormat': 'anthropic-budget',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'disabled' },
+    });
+  });
+
+  it('omits effort and warns when enabled=false cannot be represented', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      model: 'effort-only-model',
+      modelBehavior: {
+        'reasoning.enabled': false,
+        'reasoning.effort': 'high',
+        'reasoning.enabledWireFormat': 'none',
+        'reasoning.effortWireFormat': 'openai',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          'OpenAI Chat omitted configured reasoning.effort because reasoning is explicitly disabled',
+        metadata: {
+          provider: 'openai',
+          model: 'effort-only-model',
+          selectedFormat: 'openai',
+          setting: 'reasoning.effort',
+          reason: 'reasoning-disabled',
+        },
+      },
+      {
+        message:
+          "OpenAI Chat omitted configured reasoning.enabled because the enabled format is set to 'none'",
+        metadata: {
+          provider: 'openai',
+          model: 'effort-only-model',
+          selectedFormat: 'none',
+          setting: 'reasoning.enabled',
+          reason: 'enabled-format-none',
+        },
+      },
+    ]);
+  });
+
+  it('warns when a null effort map deliberately suppresses emission', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.effortMap': { high: null },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          'OpenAI Chat omitted configured reasoning.effort because its effort map entry is null',
+        metadata: {
+          provider: 'openai',
+          model: 'test-reasoning-model',
+          selectedFormat: 'openai',
+          setting: 'reasoning.effort',
+          reason: 'effort-map-null',
+        },
+      },
+    ]);
+  });
+
+  it('warns independently for dropped effort and budget configured together', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.budgetTokens': 8192,
+        'reasoning.effortWireFormat': 'none',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "OpenAI Chat omitted configured reasoning.effort because the effort format is set to 'none'",
+        metadata: {
+          provider: 'openai',
+          model: 'test-reasoning-model',
+          selectedFormat: 'none',
+          setting: 'reasoning.effort',
+          reason: 'effort-format-none',
+        },
+      },
+      {
+        message:
+          'OpenAI Chat omitted configured reasoning.budgetTokens because direct budgets are only supported by the anthropic-budget effort format',
+        metadata: {
+          provider: 'openai',
+          model: 'test-reasoning-model',
+          selectedFormat: 'none',
+          setting: 'reasoning.budgetTokens',
+          reason: 'budget-not-supported',
+        },
+      },
+    ]);
+  });
+
+  it('warns when a budget alone is dropped by a non-budget Chat format', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.budgetTokens': 8192,
+        'reasoning.effortWireFormat': 'openai',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          'OpenAI Chat omitted configured reasoning.budgetTokens because direct budgets are only supported by the anthropic-budget effort format',
+        metadata: {
+          provider: 'openai',
+          model: 'test-reasoning-model',
+          selectedFormat: 'openai',
+          setting: 'reasoning.budgetTokens',
+          reason: 'budget-not-supported',
+        },
+      },
+    ]);
+  });
+
+  it('does not warn for a budget consumed by the anthropic-budget Chat format', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.budgetTokens': 8192,
+        'reasoning.effortWireFormat': 'anthropic-budget',
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled', budget_tokens: 8192 },
+    });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+  it.each([
+    ['reasoning', { effort: 'max' }],
+    ['thinking', { type: 'disabled' }],
+    ['reasoning_effort', 'minimal'],
+    ['parse_reasoning', true],
+  ])(
+    'keeps explicit top-level %s authoritative without warnings',
+    async (key, value) => {
+      const { body, logger } = await prepare({
+        baseURL: 'https://api.z.ai/api/paas/v4',
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+        },
+        modelParams: { [key]: value },
+      });
+
+      expect(reasoningFields(body)).toStrictEqual({ [key]: value });
+      expect(logger.warnings).toStrictEqual([]);
+    },
+  );
+
+  it.each([
+    ['reasoning_effort', 'low'],
+    ['enable_thinking', false],
+  ])(
+    'keeps explicit nested template kwarg %s authoritative',
+    async (key, value) => {
+      const { body, logger } = await prepare({
+        baseURL: 'http://localhost:8000/v1',
+        modelBehavior: {
+          'reasoning.enabled': true,
+          'reasoning.effort': 'high',
+          'reasoning.enabledWireFormat': 'template-kwargs',
+          'reasoning.effortWireFormat': 'template-kwargs',
+        },
+        modelParams: {
+          chat_template_kwargs: { tokenize: false, [key]: value },
+        },
+      });
+
+      expect(reasoningFields(body)).toStrictEqual({
+        chat_template_kwargs: { tokenize: false, [key]: value },
+      });
+      expect(logger.warnings).toStrictEqual([]);
+    },
+  );
+
+  it('keeps explicit nested output_config.effort authoritative without warnings', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'https://api.z.ai/api/paas/v4',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+      },
+      modelParams: { output_config: { effort: 'low' } },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      output_config: { effort: 'low' },
+    });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('keeps generic translation active when output_config has only unrelated siblings', async () => {
+    const { body } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+      },
+      modelParams: { output_config: { service_hint: 'preserved' } },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      output_config: { service_hint: 'preserved' },
+      reasoning_effort: 'high',
+    });
+  });
+
+  it('fails fast on a malformed runtime effort map', async () => {
+    const preparation = prepare({
+      baseURL: 'http://localhost:8000/v1',
+      rawModelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.effortMap': ['high'],
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      'reasoning.effortMap must be a JSON object',
+    );
+  });
+
+  it('fails fast when a narrowed map is incompatible with its selected format', async () => {
+    const preparation = prepare({
+      baseURL: 'http://localhost:8000/v1',
+      rawModelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.effortMap': { high: 8192 },
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      'reasoning.effortMap.high must be a string for openai',
+    );
+  });
+
+  it('fails fast on a malformed runtime enabled map', async () => {
+    const preparation = prepare({
+      baseURL: 'http://localhost:8000/v1',
+      rawModelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { sometimes: 'enabled' },
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      "reasoning.enabledMap contains unsupported key 'sometimes'",
+    );
+  });
+
+  it('normalizes surrounding whitespace in alias map values', async () => {
+    const { body } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      rawModelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.enabled': true,
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.effortMap': { high: ' max ' },
+        'reasoning.enabledMap': { true: ' enabled ' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      reasoning_effort: 'max',
+      thinking: { type: 'enabled' },
+    });
+  });
+
+  it('fails before transport when an alias map value is whitespace only', async () => {
+    const preparation = prepare({
+      baseURL: 'http://localhost:8000/v1',
+      rawModelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.effortMap': { high: '   ' },
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      'reasoning.effortMap values must be non-empty strings, integer budgets of at least 1024, or null',
+    );
+  });
+
+  it('fails before transport when an alias effort map is a Map instance', async () => {
+    const preparation = prepare({
+      baseURL: 'http://localhost:8000/v1',
+      rawModelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.effortMap': new Map([['high', 'max']]),
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      'reasoning.effortMap must be a JSON object',
+    );
+  });
+
+  it('fails before transport when an alias effort map is a class instance', async () => {
+    class AliasedEffortMap {
+      readonly high = 'max';
+    }
+    const preparation = prepare({
+      baseURL: 'http://localhost:8000/v1',
+      rawModelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.effortMap': new AliasedEffortMap(),
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      'reasoning.effortMap must be a JSON object',
+    );
+  });
+
+  it('fails before transport when an alias enabled map is a Map instance', async () => {
+    const preparation = prepare({
+      baseURL: 'http://localhost:8000/v1',
+      rawModelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': new Map([['true', 'enabled']]),
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      'reasoning.enabledMap must be a JSON object',
+    );
+  });
+
+  it.each([
+    {
+      setting: 'reasoning.enabled',
+      value: 'true',
+      expected: 'reasoning.enabled must be a boolean',
+    },
+    {
+      setting: 'reasoning.effort',
+      value: 'ultra',
+      expected: "reasoning.effort must be one of 'minimal'",
+    },
+    {
+      setting: 'reasoning.budgetTokens',
+      value: 0,
+      expected: 'reasoning.budgetTokens must be a positive integer',
+    },
+    {
+      setting: 'reasoning.effortWireFormat',
+      value: 'custom',
+      expected: "reasoning.effortWireFormat must be one of 'auto'",
+    },
+    {
+      setting: 'reasoning.enabledWireFormat',
+      value: 'custom',
+      expected: "reasoning.enabledWireFormat must be one of 'auto'",
+    },
+  ] satisfies ReadonlyArray<{
+    readonly setting: string;
+    readonly value: unknown;
+    readonly expected: string;
+  }>)(
+    'fails fast on invalid runtime $setting values',
+    async ({ setting, value, expected }) => {
+      const preparation = prepare({
+        baseURL: 'http://localhost:8000/v1',
+        rawModelBehavior: { [setting]: value },
+      });
+
+      await expect(preparation).rejects.toThrow(expected);
+    },
+  );
+
+  it('propagates incompatible selector errors before returning a request', async () => {
+    const preparation = prepare({
+      baseURL: 'http://localhost:8000/v1',
+      modelBehavior: {
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'openai-responses',
+      },
+    });
+
+    await expect(preparation).rejects.toThrow(
+      "effort wire format 'openai-responses' is incompatible with the openai-chat adapter",
+    );
+  });
+
+  it('routes built-in OpenAI GPT-5.6 alias defaults through a custom Chat URL without a transport-specific selector', async () => {
+    const { body, logger } = await prepare({
+      baseURL: 'http://localhost:8000/v1',
+      model: 'gpt-5.6',
+      modelBehavior: builtinAliasModelBehavior('openai', 'gpt-5.6'),
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({});
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          'OpenAI Chat omitted configured reasoning.effort because the effort format could not be detected for this endpoint',
+        metadata: {
+          provider: 'openai',
+          model: 'gpt-5.6',
+          selectedFormat: 'none',
+          setting: 'reasoning.effort',
+          reason: 'effort-format-undetected',
+        },
+      },
+      {
+        message:
+          'OpenAI Chat omitted configured reasoning.enabled because the enabled format could not be detected for this endpoint',
+        metadata: {
+          provider: 'openai',
+          model: 'gpt-5.6',
+          selectedFormat: 'none',
+          setting: 'reasoning.enabled',
+          reason: 'enabled-format-undetected',
+        },
+      },
+    ]);
+  });
+
+  it('attributes suppressed alias reasoning to the resolved provider name', async () => {
+    const { body, logger } = await prepare({
+      providerName: 'kimi',
+      baseURL: 'https://api.kimi.com/coding/v1',
+      model: 'kimi-for-coding',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'none',
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'enabled' },
+      },
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+    });
+    expect(logger.warnings).toStrictEqual([
+      {
+        message:
+          "OpenAI Chat omitted configured reasoning.effort because the effort format is set to 'none'",
+        metadata: {
+          provider: 'kimi',
+          model: 'kimi-for-coding',
+          selectedFormat: 'none',
+          setting: 'reasoning.effort',
+          reason: 'effort-format-none',
+        },
+      },
+    ]);
+    expect(JSON.stringify(logger.warnings)).not.toContain('api.kimi.com');
+  });
+
+  it('sends the built-in Kimi K3 alias defaults as one top-level effort field', async () => {
+    const { body, logger } = await prepare({
+      providerName: 'kimi',
+      baseURL: 'https://api.kimi.com/coding/v1',
+      model: 'kimi-k3',
+      modelBehavior: builtinAliasModelBehavior('kimi', 'kimi-k3'),
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      reasoning_effort: 'max',
+    });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+
+  it('sends the built-in Kimi K2.7 alias defaults as enabled thinking without effort', async () => {
+    const { body, logger } = await prepare({
+      providerName: 'kimi',
+      baseURL: 'https://api.kimi.com/coding/v1',
+      model: 'kimi-for-coding',
+      modelBehavior: builtinAliasModelBehavior('kimi', 'kimi-for-coding'),
+    });
+
+    expect(reasoningFields(body)).toStrictEqual({
+      thinking: { type: 'enabled' },
+    });
+    expect(logger.warnings).toStrictEqual([]);
+  });
+});

--- a/packages/providers/src/openai/OpenAIRequestPreparation.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.ts
@@ -22,11 +22,7 @@ import { resolveToolFormat } from '../utils/toolFormatDetection.js';
 import { buildMessagesWithReasoning } from './OpenAIRequestBuilder.js';
 import { extractModelParamsFromOptions } from './OpenAIClientFactory.js';
 import { sanitizePromptCacheKey } from '../openai-responses/sanitizePromptCacheKey.js';
-import {
-  resolveReasoningDialect,
-  applyReasoningDialect,
-  hasExplicitReasoningField,
-} from './openaiReasoningDialect.js';
+import { applyOpenAIChatReasoning } from './openai-chat-reasoning.js';
 import { type Config } from '@vybestack/llxprt-code-core/config/config.js';
 
 export interface RequestContext {
@@ -82,70 +78,56 @@ function convertAndGuardTools(
   return formattedTools;
 }
 
-type OpenAIInvocationRuntime = {
-  ephemerals?: Record<string, unknown>;
-  modelBehavior?: Record<string, unknown>;
-};
+type OpenAIChatRequestBody = OpenAI.Chat.ChatCompletionCreateParams &
+  Record<string, unknown>;
 
-type RequestBodyWithThinking = OpenAI.Chat.ChatCompletionCreateParams & {
-  thinking?: { type: 'enabled' | 'disabled' };
-  reasoning?: Record<string, unknown>;
-};
+/**
+ * The invocation context is required; only a legacy subrecord (modelBehavior,
+ * ephemerals) can be explicitly undefined in fixtures built before the
+ * invocation contract hardened, and a missing subrecord reads as empty at the
+ * transport boundary.
+ */
+function readInvocationRecord(
+  record: Readonly<Record<string, unknown>> | undefined,
+): Readonly<Record<string, unknown>> {
+  return record ?? {};
+}
 
 function resolveReasoningConfig(
-  requestBody: OpenAI.Chat.ChatCompletionCreateParams,
+  requestBody: OpenAIChatRequestBody,
   options: NormalizedGenerateChatOptions,
-  ephemeralSettings: Record<string, unknown>,
+  ephemeralSettings: Readonly<Record<string, unknown>>,
+  model: string,
+  providerName: string,
+  logger: DebugLogger,
 ): void {
-  const body = requestBody as RequestBodyWithThinking;
-
-  // Short-circuit: if the user already set a reasoning field explicitly (via
-  // modelParams, which are Object.assigned into the body just before this
-  // call), do not auto-inject anything — the user value wins and stays the
-  // only reasoning representation on the wire.
-  if (hasExplicitReasoningField(body)) {
-    return;
-  }
-
-  const invocation = options.invocation as OpenAIInvocationRuntime;
-  const reasoningEnabled = invocation.modelBehavior?.['reasoning.enabled'] as
-    | boolean
-    | undefined;
-  const reasoningEffort = invocation.modelBehavior?.['reasoning.effort'] as
-    | string
-    | undefined;
-
   const baseUrl =
     options.resolved.baseURL ??
     (typeof ephemeralSettings['base-url'] === 'string'
       ? ephemeralSettings['base-url']
       : undefined);
 
-  const dialect = resolveReasoningDialect(baseUrl);
-  const applied = applyReasoningDialect(dialect, {
-    enabled: reasoningEnabled,
-    effort: reasoningEffort,
+  applyOpenAIChatReasoning({
+    body: requestBody,
+    modelBehavior: readInvocationRecord(options.invocation.modelBehavior),
+    baseUrl,
+    model,
+    providerName,
+    logger,
   });
-  if (applied === null) {
-    return;
-  }
-
-  if (applied.key === 'thinking') {
-    body.thinking = applied.value;
-  } else {
-    body.reasoning = applied.value;
-  }
 }
 
 /**
  * Apply reasoning, max-tokens, and stream-options to the request body.
  */
 function applyRequestBodyOverrides(
-  requestBody: OpenAI.Chat.ChatCompletionCreateParams,
+  requestBody: OpenAIChatRequestBody,
   options: NormalizedGenerateChatOptions,
-  ephemeralSettings: Record<string, unknown>,
+  ephemeralSettings: Readonly<Record<string, unknown>>,
+  model: string,
   maxTokens: number | undefined,
   streamingEnabled: boolean,
+  providerName: string,
   logger: DebugLogger,
 ): void {
   // Apply request overrides, sanitizing prompt_cache_key at the transport
@@ -168,7 +150,14 @@ function applyRequestBodyOverrides(
     }
   }
 
-  resolveReasoningConfig(requestBody, options, ephemeralSettings);
+  resolveReasoningConfig(
+    requestBody,
+    options,
+    ephemeralSettings,
+    model,
+    providerName,
+    logger,
+  );
 
   if (typeof maxTokens === 'number' && Number.isFinite(maxTokens)) {
     requestBody.max_tokens = maxTokens;
@@ -213,6 +202,16 @@ function sanitizeOverridesCacheKey(
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+function resolveMaxTokens(
+  metadataValue: unknown,
+  ephemeralValue: unknown,
+): number | undefined {
+  if (typeof metadataValue === 'number') {
+    return metadataValue;
+  }
+  return typeof ephemeralValue === 'number' ? ephemeralValue : undefined;
+}
+
 /**
  * Prepare OpenAI API request from normalized options
  * Extracts all the request preparation logic from generateChatCompletionImpl
@@ -226,8 +225,7 @@ export async function prepareRequest(
 ): Promise<RequestContext> {
   const { contents, tools, metadata } = options;
   const model = options.resolved.model || defaultModel;
-  const invocation = options.invocation as OpenAIInvocationRuntime;
-  const ephemeralSettings = invocation.ephemerals ?? {};
+  const ephemeralSettings = readInvocationRecord(options.invocation.ephemerals);
 
   // Detect the tool format to use BEFORE building messages
   // Check for provider toolFormat override before auto-detecting
@@ -282,12 +280,13 @@ export async function prepareRequest(
     ...messages,
   ];
 
-  const maxTokens =
-    (metadata.maxTokens as number | undefined) ??
-    (ephemeralSettings['max-tokens'] as number | undefined);
+  const maxTokens = resolveMaxTokens(
+    metadata.maxTokens,
+    ephemeralSettings['max-tokens'],
+  );
 
   // Build request
-  const requestBody: OpenAI.Chat.ChatCompletionCreateParams = {
+  const requestBody: OpenAIChatRequestBody = {
     model,
     messages: messagesWithSystem,
     stream: streamingEnabled,
@@ -303,8 +302,10 @@ export async function prepareRequest(
     requestBody,
     options,
     ephemeralSettings,
+    model,
     maxTokens,
     streamingEnabled,
+    resolvedProviderName,
     logger,
   );
 

--- a/packages/providers/src/openai/openai-chat-reasoning.ts
+++ b/packages/providers/src/openai/openai-chat-reasoning.ts
@@ -117,18 +117,12 @@ function warnForDroppedReasoning(
   }
   // A direct budget is consumed in Chat only by the anthropic-budget effort
   // format; any other format drops it even when an effort was emitted from
-  // reasoning.effort or no effort outcome exists at all (issue #3255).
-  if (
-    behavior.reasoning.budgetTokens !== undefined &&
-    resolved.effortFormat !== 'anthropic-budget'
-  ) {
-    warnDropped(input, {
-      setting: 'reasoning.budgetTokens',
-      selectedFormat: resolved.effortFormat,
-      reason: 'budget-not-supported',
-      detail:
-        'direct budgets are only supported by the anthropic-budget effort format',
-    });
+  // reasoning.effort or no effort outcome exists at all. Under
+  // anthropic-budget the warning comes from the actual resolved budget
+  // outcome, so a suppressed or unrepresentable budget is still reported
+  // (issue #3255).
+  if (behavior.reasoning.budgetTokens !== undefined) {
+    warnForDroppedBudget(input, resolved);
   }
   if (behavior.reasoning.enabled !== undefined) {
     warnForOutcome(
@@ -154,6 +148,38 @@ function warnForOutcome(
     selectedFormat,
     reason: outcome.reason,
     detail: describeDroppedReason(outcome),
+  });
+}
+
+/** Warn for a dropped direct budget from its actual resolved outcome. */
+function warnForDroppedBudget(
+  input: OpenAIChatReasoningInput,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (resolved.effortFormat !== 'anthropic-budget') {
+    warnDropped(input, {
+      setting: 'reasoning.budgetTokens',
+      selectedFormat: resolved.effortFormat,
+      reason: 'budget-not-supported',
+      detail:
+        'direct budgets are only supported by the anthropic-budget effort format',
+    });
+    return;
+  }
+  if (resolved.effort.state === 'emitted') {
+    return;
+  }
+  if (
+    resolved.effort.state !== 'suppressed' &&
+    resolved.effort.state !== 'unrepresentable'
+  ) {
+    return;
+  }
+  warnDropped(input, {
+    setting: 'reasoning.budgetTokens',
+    selectedFormat: resolved.effortFormat,
+    reason: resolved.effort.reason,
+    detail: describeDroppedReason(resolved.effort),
   });
 }
 
@@ -312,6 +338,15 @@ function applyResolvedEnabled(
       break;
     case 'thinking':
       if (typeof resolved.enabled.value === 'string') {
+        if (
+          fields.thinking !== undefined &&
+          'budget_tokens' in fields.thinking &&
+          resolved.enabled.value !== 'enabled'
+        ) {
+          throw new Error(
+            `effort format 'anthropic-budget' and thinking type '${resolved.enabled.value}' emit conflicting OpenAI Chat reasoning representations`,
+          );
+        }
         fields.thinking = {
           ...fields.thinking,
           type: resolved.enabled.value,

--- a/packages/providers/src/openai/openai-chat-reasoning.ts
+++ b/packages/providers/src/openai/openai-chat-reasoning.ts
@@ -1,0 +1,371 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type {
+  ReasoningEffort,
+  ReasoningEffortMap,
+  ReasoningEffortWireFormat,
+  ReasoningEnabledMap,
+  ReasoningEnabledWireFormat,
+} from '@vybestack/llxprt-code-settings';
+import {
+  readEffortMap,
+  readEffortWireFormat,
+  readEnabledMap,
+  readEnabledWireFormat,
+  readOptionalBoolean,
+  readOptionalEffort,
+  readOptionalPositiveInteger,
+} from '../reasoning/reasoning-behavior-parsing.js';
+import {
+  resolveReasoningConfiguration,
+  type ReasoningResolution,
+  type ResolvedReasoningConfiguration,
+} from '../reasoning/reasoning-config-resolver.js';
+import { hasExplicitReasoningField } from './openaiReasoningDialect.js';
+
+export interface OpenAIChatReasoningInput {
+  readonly body: Record<string, unknown>;
+  readonly modelBehavior: Readonly<Record<string, unknown>>;
+  readonly baseUrl: string | undefined;
+  readonly model: string;
+  readonly providerName: string;
+  readonly logger: DebugLogger;
+}
+
+interface ParsedReasoningBehavior {
+  readonly reasoning: {
+    readonly enabled?: boolean;
+    readonly effort?: ReasoningEffort;
+    readonly budgetTokens?: number;
+  };
+  readonly effortWireFormat: ReasoningEffortWireFormat;
+  readonly enabledWireFormat: ReasoningEnabledWireFormat;
+  readonly effortMap?: ReasoningEffortMap;
+  readonly enabledMap?: ReasoningEnabledMap;
+}
+
+/** Resolve and apply generic reasoning settings to an OpenAI Chat body. */
+export function applyOpenAIChatReasoning(
+  input: OpenAIChatReasoningInput,
+): void {
+  if (hasExplicitReasoningField(input.body)) {
+    return;
+  }
+
+  const behavior = parseReasoningBehavior(input.modelBehavior);
+  const resolved = resolveReasoningConfiguration({
+    nativeAdapter: 'openai-chat',
+    chatBaseUrl: input.baseUrl,
+    reasoning: behavior.reasoning,
+    effortWireFormat: behavior.effortWireFormat,
+    enabledWireFormat: behavior.enabledWireFormat,
+    effortMap: behavior.effortMap,
+    enabledMap: behavior.enabledMap,
+  });
+
+  warnForDroppedReasoning(input, behavior, resolved);
+  applyResolvedReasoning(input.body, resolved);
+}
+
+function parseReasoningBehavior(
+  modelBehavior: Readonly<Record<string, unknown>>,
+): ParsedReasoningBehavior {
+  const enabled = readOptionalBoolean(
+    modelBehavior['reasoning.enabled'],
+    'reasoning.enabled',
+  );
+  const effort = readOptionalEffort(modelBehavior['reasoning.effort']);
+  const budgetTokens = readOptionalPositiveInteger(
+    modelBehavior['reasoning.budgetTokens'],
+    'reasoning.budgetTokens',
+  );
+  const effortWireFormat = readEffortWireFormat(
+    modelBehavior['reasoning.effortWireFormat'],
+  );
+  const enabledWireFormat = readEnabledWireFormat(
+    modelBehavior['reasoning.enabledWireFormat'],
+  );
+  const effortMap = readEffortMap(modelBehavior['reasoning.effortMap']);
+  const enabledMap = readEnabledMap(modelBehavior['reasoning.enabledMap']);
+
+  return {
+    reasoning: { enabled, effort, budgetTokens },
+    effortWireFormat,
+    enabledWireFormat,
+    effortMap,
+    enabledMap,
+  };
+}
+
+function warnForDroppedReasoning(
+  input: OpenAIChatReasoningInput,
+  behavior: ParsedReasoningBehavior,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (behavior.reasoning.effort !== undefined) {
+    warnForOutcome(
+      input,
+      'reasoning.effort',
+      resolved.effortFormat,
+      resolved.effort,
+    );
+  }
+  // A direct budget is consumed in Chat only by the anthropic-budget effort
+  // format; any other format drops it even when an effort was emitted from
+  // reasoning.effort or no effort outcome exists at all (issue #3255).
+  if (
+    behavior.reasoning.budgetTokens !== undefined &&
+    resolved.effortFormat !== 'anthropic-budget'
+  ) {
+    warnDropped(input, {
+      setting: 'reasoning.budgetTokens',
+      selectedFormat: resolved.effortFormat,
+      reason: 'budget-not-supported',
+      detail:
+        'direct budgets are only supported by the anthropic-budget effort format',
+    });
+  }
+  if (behavior.reasoning.enabled !== undefined) {
+    warnForOutcome(
+      input,
+      'reasoning.enabled',
+      resolved.enabledFormat,
+      resolved.enabled,
+    );
+  }
+}
+
+function warnForOutcome(
+  input: OpenAIChatReasoningInput,
+  setting: 'reasoning.effort' | 'reasoning.enabled',
+  selectedFormat: string,
+  outcome: ReasoningResolution<string | number | boolean>,
+): void {
+  if (outcome.state !== 'suppressed' && outcome.state !== 'unrepresentable') {
+    return;
+  }
+  warnDropped(input, {
+    setting,
+    selectedFormat,
+    reason: outcome.reason,
+    detail: describeDroppedReason(outcome),
+  });
+}
+
+interface DroppedSettingWarning {
+  readonly setting: string;
+  readonly selectedFormat: string;
+  readonly reason: string;
+  readonly detail: string;
+}
+
+function warnDropped(
+  input: OpenAIChatReasoningInput,
+  warning: DroppedSettingWarning,
+): void {
+  input.logger.warn(
+    () =>
+      `OpenAI Chat omitted configured ${warning.setting} because ${warning.detail}`,
+    {
+      provider: input.providerName,
+      model: input.model,
+      selectedFormat: warning.selectedFormat,
+      setting: warning.setting,
+      reason: warning.reason,
+    },
+  );
+}
+
+type DroppedOutcome = Extract<
+  ReasoningResolution<string | number | boolean>,
+  { readonly state: 'suppressed' } | { readonly state: 'unrepresentable' }
+>;
+
+/** Reason-accurate prose for why the outcome was dropped. */
+function describeDroppedReason(outcome: DroppedOutcome): string {
+  switch (outcome.reason) {
+    case 'reasoning-disabled':
+      return 'reasoning is explicitly disabled';
+    case 'effort-map-null':
+      return 'its effort map entry is null';
+    case 'enabled-map-null':
+      return 'its enabled map entry is null';
+    case 'effort-format-none':
+      return "the effort format is set to 'none'";
+    case 'enabled-format-none':
+      return "the enabled format is set to 'none'";
+    case 'effort-format-undetected':
+      return 'the effort format could not be detected for this endpoint';
+    case 'enabled-format-undetected':
+      return 'the enabled format could not be detected for this endpoint';
+    case 'numeric-effort-map-required':
+      return 'the anthropic-budget effort format requires a numeric effort map entry';
+    case 'enabled-map-required':
+      return 'the enabled format has no emitted effort or map value to represent it';
+    default: {
+      // Exhaustiveness guard: a new drop reason must add prose above.
+      const exhaustive: never = outcome;
+      throw new Error(
+        `unhandled dropped reasoning outcome: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+}
+
+interface RenderedReasoningFields {
+  reasoning?: Record<string, unknown>;
+  thinking?: Record<string, unknown>;
+  templateKwargs?: Record<string, unknown>;
+  reasoningEffort?: string;
+}
+
+function applyResolvedReasoning(
+  body: Record<string, unknown>,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  const fields: RenderedReasoningFields = {};
+  if (
+    resolved.effortFormat === 'template-kwargs' ||
+    resolved.enabledFormat === 'template-kwargs'
+  ) {
+    const templateKwargs = readMergeableTemplateKwargs(body);
+    if (templateKwargs !== undefined) {
+      fields.templateKwargs = templateKwargs;
+    }
+  }
+
+  applyResolvedEffort(fields, resolved);
+  applyResolvedEnabled(fields, resolved);
+  writeRenderedReasoning(body, fields);
+}
+
+function applyResolvedEffort(
+  fields: RenderedReasoningFields,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (resolved.effort.state !== 'emitted') {
+    return;
+  }
+
+  switch (resolved.effortFormat) {
+    case 'openai':
+      if (typeof resolved.effort.value === 'string') {
+        fields.reasoningEffort = resolved.effort.value;
+      }
+      break;
+    case 'openrouter':
+      if (typeof resolved.effort.value === 'string') {
+        fields.reasoning = { effort: resolved.effort.value };
+      }
+      break;
+    case 'template-kwargs':
+      if (typeof resolved.effort.value === 'string') {
+        fields.templateKwargs = {
+          ...fields.templateKwargs,
+          reasoning_effort: resolved.effort.value,
+        };
+      }
+      break;
+    case 'anthropic-budget':
+      if (typeof resolved.effort.value === 'number') {
+        fields.thinking = {
+          type: 'enabled',
+          budget_tokens: resolved.effort.value,
+        };
+      }
+      break;
+    // The resolver rejects the remaining effort formats (openai-responses,
+    // anthropic, gemini) for the openai-chat adapter before this switch
+    // runs, so only the safe default is needed here.
+    case 'none':
+    default:
+      break;
+  }
+}
+
+function applyResolvedEnabled(
+  fields: RenderedReasoningFields,
+  resolved: ResolvedReasoningConfiguration,
+): void {
+  if (resolved.enabled.state !== 'emitted') {
+    return;
+  }
+
+  switch (resolved.enabledFormat) {
+    case 'openai':
+      if (typeof resolved.enabled.value === 'string') {
+        fields.reasoningEffort = resolved.enabled.value;
+      }
+      break;
+    case 'openrouter':
+      if (typeof resolved.enabled.value === 'boolean') {
+        fields.reasoning = {
+          enabled: resolved.enabled.value,
+          ...fields.reasoning,
+        };
+      }
+      break;
+    case 'thinking':
+      if (typeof resolved.enabled.value === 'string') {
+        fields.thinking = {
+          ...fields.thinking,
+          type: resolved.enabled.value,
+        };
+      }
+      break;
+    case 'template-kwargs':
+      if (typeof resolved.enabled.value === 'boolean') {
+        fields.templateKwargs = {
+          ...fields.templateKwargs,
+          enable_thinking: resolved.enabled.value,
+        };
+      }
+      break;
+    // The resolver rejects the remaining enabled formats (openai-responses,
+    // gemini) for the openai-chat adapter before this switch runs, so only
+    // the safe default is needed here.
+    case 'none':
+    default:
+      break;
+  }
+}
+
+function writeRenderedReasoning(
+  body: Record<string, unknown>,
+  fields: RenderedReasoningFields,
+): void {
+  if (fields.reasoning !== undefined) {
+    body['reasoning'] = fields.reasoning;
+  }
+  if (fields.thinking !== undefined) {
+    body['thinking'] = fields.thinking;
+  }
+  if (fields.reasoningEffort !== undefined) {
+    body['reasoning_effort'] = fields.reasoningEffort;
+  }
+  if (fields.templateKwargs !== undefined) {
+    body['chat_template_kwargs'] = fields.templateKwargs;
+  }
+}
+
+function readMergeableTemplateKwargs(
+  body: Readonly<Record<string, unknown>>,
+): Record<string, unknown> | undefined {
+  const value = body['chat_template_kwargs'];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new Error('chat_template_kwargs must be an object');
+  }
+  return { ...value };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/providers/src/openai/openaiReasoningDialect.test.ts
+++ b/packages/providers/src/openai/openaiReasoningDialect.test.ts
@@ -6,168 +6,11 @@
 
 import { describe, it, expect } from 'bun:test';
 import {
-  resolveReasoningDialect,
-  applyReasoningDialect,
   hasExplicitReasoningField,
   REASONING_WIRE_KEYS,
 } from './openaiReasoningDialect.js';
 
-describe('resolveReasoningDialect — host to dialect mapping', () => {
-  it('resolves openrouter.ai to the openrouter dialect', () => {
-    expect(resolveReasoningDialect('https://openrouter.ai/api/v1')).toBe(
-      'openrouter',
-    );
-  });
-
-  it('resolves *.openrouter.ai to the openrouter dialect', () => {
-    expect(resolveReasoningDialect('https://api.openrouter.ai/api/v1')).toBe(
-      'openrouter',
-    );
-  });
-
-  it('does NOT match evil-openrouter.ai.attacker.com (suffix spoofing)', () => {
-    expect(
-      resolveReasoningDialect('https://evil-openrouter.ai.attacker.com/v1'),
-    ).toBe('none');
-  });
-
-  it('resolves z.ai and *.z.ai to the thinking dialect', () => {
-    expect(resolveReasoningDialect('https://z.ai/api/paas/v4')).toBe(
-      'thinking',
-    );
-    expect(resolveReasoningDialect('https://api.z.ai/api/paas/v4')).toBe(
-      'thinking',
-    );
-  });
-
-  it('resolves bigmodel.cn and *.bigmodel.cn to the thinking dialect', () => {
-    expect(
-      resolveReasoningDialect('https://open.bigmodel.cn/api/paas/v4'),
-    ).toBe('thinking');
-    expect(resolveReasoningDialect('https://bigmodel.cn/api/paas/v4')).toBe(
-      'thinking',
-    );
-  });
-
-  it('resolves api.openai.com to none', () => {
-    expect(resolveReasoningDialect('https://api.openai.com/v1')).toBe('none');
-  });
-
-  it('resolves friendli to none', () => {
-    expect(
-      resolveReasoningDialect('https://api.friendli.ai/serverless/v1'),
-    ).toBe('none');
-  });
-
-  it('resolves crusoe to none (trailing slash)', () => {
-    expect(
-      resolveReasoningDialect('https://api.inference.crusoecloud.com/v1/'),
-    ).toBe('none');
-  });
-
-  it('resolves undefined base URL to none', () => {
-    expect(resolveReasoningDialect(undefined)).toBe('none');
-  });
-
-  it('resolves empty string to none', () => {
-    expect(resolveReasoningDialect('')).toBe('none');
-  });
-
-  it('resolves whitespace-only string to none', () => {
-    expect(resolveReasoningDialect('   ')).toBe('none');
-  });
-
-  it('resolves invalid URL string to none', () => {
-    expect(resolveReasoningDialect('not a url')).toBe('none');
-  });
-
-  it('tolerates stray whitespace around an otherwise known host', () => {
-    expect(resolveReasoningDialect('  https://openrouter.ai/api/v1  ')).toBe(
-      'openrouter',
-    );
-    expect(resolveReasoningDialect('\nhttps://api.z.ai/api/paas/v4\t')).toBe(
-      'thinking',
-    );
-  });
-});
-
-describe('applyReasoningDialect — wire-shape emission', () => {
-  it('openrouter: emits reasoning.effort when effort is set', () => {
-    expect(
-      applyReasoningDialect('openrouter', { enabled: true, effort: 'high' }),
-    ).toStrictEqual({ key: 'reasoning', value: { effort: 'high' } });
-  });
-
-  it('openrouter: emits reasoning.enabled when effort is not set', () => {
-    expect(
-      applyReasoningDialect('openrouter', { enabled: true }),
-    ).toStrictEqual({ key: 'reasoning', value: { enabled: true } });
-    expect(
-      applyReasoningDialect('openrouter', { enabled: false }),
-    ).toStrictEqual({ key: 'reasoning', value: { enabled: false } });
-  });
-
-  it('openrouter: emits nothing when neither effort nor enabled is set', () => {
-    expect(applyReasoningDialect('openrouter', {})).toBeNull();
-  });
-
-  it('openrouter: an explicit enabled=false outranks a leftover effort', () => {
-    expect(
-      applyReasoningDialect('openrouter', { enabled: false, effort: 'high' }),
-    ).toStrictEqual({ key: 'reasoning', value: { enabled: false } });
-  });
-
-  it('openrouter: falls back to enabled when effort is an empty string', () => {
-    expect(
-      applyReasoningDialect('openrouter', { effort: '', enabled: true }),
-    ).toStrictEqual({ key: 'reasoning', value: { enabled: true } });
-  });
-
-  it('openrouter: emits nothing when effort is empty and enabled is unset', () => {
-    expect(applyReasoningDialect('openrouter', { effort: '' })).toBeNull();
-  });
-
-  it('thinking: emits thinking.type=enabled when enabled is true', () => {
-    expect(applyReasoningDialect('thinking', { enabled: true })).toStrictEqual({
-      key: 'thinking',
-      value: { type: 'enabled' },
-    });
-  });
-
-  it('thinking: emits thinking.type=disabled when enabled is false', () => {
-    expect(applyReasoningDialect('thinking', { enabled: false })).toStrictEqual(
-      {
-        key: 'thinking',
-        value: { type: 'disabled' },
-      },
-    );
-  });
-
-  it('thinking: an effort level alone still enables thinking', () => {
-    expect(applyReasoningDialect('thinking', { effort: 'high' })).toStrictEqual(
-      { key: 'thinking', value: { type: 'enabled' } },
-    );
-  });
-
-  it('thinking: an explicit enabled=false outranks a leftover effort', () => {
-    expect(
-      applyReasoningDialect('thinking', { enabled: false, effort: 'high' }),
-    ).toStrictEqual({ key: 'thinking', value: { type: 'disabled' } });
-  });
-
-  it('thinking: emits nothing when no reasoning setting is present', () => {
-    expect(applyReasoningDialect('thinking', {})).toBeNull();
-    expect(applyReasoningDialect('thinking', { effort: '' })).toBeNull();
-  });
-
-  it('none: always emits nothing', () => {
-    expect(
-      applyReasoningDialect('none', { enabled: true, effort: 'high' }),
-    ).toBeNull();
-  });
-});
-
-describe('hasExplicitReasoningField — known wire keys', () => {
+describe('hasExplicitReasoningField: known wire keys', () => {
   it('covers every vendor dialect named in issue #2896', () => {
     expect([...REASONING_WIRE_KEYS].sort()).toStrictEqual([
       'parse_reasoning',
@@ -179,6 +22,74 @@ describe('hasExplicitReasoningField — known wire keys', () => {
 
   it.each([...REASONING_WIRE_KEYS])('detects an explicit %s', (key) => {
     expect(hasExplicitReasoningField({ [key]: 'anything' })).toBe(true);
+  });
+
+  it.each([...REASONING_WIRE_KEYS])(
+    'ignores an inherited %s property so translation stays active',
+    (key) => {
+      const body: Record<string, unknown> = Object.create({
+        [key]: 'inherited-value',
+      });
+      body.model = 'gpt-4o';
+
+      expect(hasExplicitReasoningField(body)).toBe(false);
+    },
+  );
+
+  it.each(['reasoning_effort', 'enable_thinking'])(
+    'detects explicit chat_template_kwargs.%s',
+    (key) => {
+      expect(
+        hasExplicitReasoningField({ chat_template_kwargs: { [key]: true } }),
+      ).toBe(true);
+    },
+  );
+
+  it.each(['reasoning_effort', 'enable_thinking'])(
+    'ignores an inherited chat_template_kwargs.%s property',
+    (key) => {
+      const templateKwargs: Record<string, unknown> = Object.create({
+        [key]: 'inherited-value',
+      });
+      templateKwargs.tokenize = false;
+
+      expect(
+        hasExplicitReasoningField({
+          chat_template_kwargs: templateKwargs,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it('does not treat unrelated template kwargs as a collision', () => {
+    expect(
+      hasExplicitReasoningField({
+        chat_template_kwargs: { tokenize: false },
+      }),
+    ).toBe(false);
+  });
+
+  it('detects an own output_config.effort as an explicit representation', () => {
+    expect(
+      hasExplicitReasoningField({ output_config: { effort: 'low' } }),
+    ).toBe(true);
+  });
+
+  it('does not treat unrelated output_config siblings as a collision', () => {
+    expect(
+      hasExplicitReasoningField({ output_config: { service_hint: 'keep' } }),
+    ).toBe(false);
+  });
+
+  it('ignores an inherited output_config.effort property', () => {
+    const outputConfig: Record<string, unknown> = Object.create({
+      effort: 'inherited-effort',
+    });
+    outputConfig.service_hint = 'keep';
+
+    expect(hasExplicitReasoningField({ output_config: outputConfig })).toBe(
+      false,
+    );
   });
 
   it('returns false for a body with no reasoning representation', () => {

--- a/packages/providers/src/openai/openaiReasoningDialect.ts
+++ b/packages/providers/src/openai/openaiReasoningDialect.ts
@@ -5,30 +5,17 @@
  */
 
 /**
- * OpenAI-compatible reasoning dialect resolution.
- *
- * Rationale: llxprt cannot know an arbitrary OpenAI-compatible endpoint's
- * reasoning dialect. Guessing is exactly what produced Friendli 422
- * ("no such field: 'reasoning'" / "'thinking'") and Crusoe 403
- * ("parameter 'reasoning' is not allowed"). This module maps a known set of
- * hosts to at most ONE reasoning dialect and applies it. Every other host —
- * including canonical `api.openai.com` — emits nothing, so users retain full
- * control through `modelParams` passthrough (`thinking`, `reasoning_effort`,
- * or vendor-native fields such as `parse_reasoning`).
- *
- * Dialect table (issue #2896):
- *   host `openrouter.ai` / `*.openrouter.ai`    -> openrouter
- *   host `z.ai` / `*.z.ai`                      -> thinking
- *   host `bigmodel.cn` / `*.bigmodel.cn`        -> thinking
- *   everything else (incl. api.openai.com)      -> none
+ * OpenAI-compatible reasoning collision detection retained for issue #2896.
+ * Request translation itself lives in the shared reasoning resolver and the
+ * OpenAI Chat reasoning module (issue #3255); this file only decides whether
+ * a body already carries an explicit reasoning representation.
  */
 
 /**
- * Every wire field that expresses reasoning intent on an OpenAI-compatible
- * Chat Completions body. When any of these is already present — because the
- * user supplied it through `modelParams` — automatic selection stands down so
- * exactly one representation reaches the provider. `parse_reasoning` is
- * Friendli's native field and belongs here for the same reason (issue #2896).
+ * Top-level wire fields that express reasoning intent on an OpenAI-compatible
+ * Chat Completions body. Automatic translation also treats the nested
+ * `chat_template_kwargs.reasoning_effort`, `enable_thinking`, and
+ * `output_config.effort` fields as explicit representations.
  */
 export const REASONING_WIRE_KEYS: readonly string[] = [
   'reasoning',
@@ -38,132 +25,39 @@ export const REASONING_WIRE_KEYS: readonly string[] = [
 ];
 
 /** True when the body already carries an explicit reasoning representation. */
-export function hasExplicitReasoningField(body: object): boolean {
-  return REASONING_WIRE_KEYS.some((key) => key in body);
-}
-
-export type ReasoningDialect = 'openrouter' | 'thinking' | 'none';
-
-export interface ReasoningSettings {
-  enabled?: boolean;
-  effort?: string;
-}
-
-/**
- * The single reasoning representation to place on the request body.
- * Discriminated on `key` so callers assign a precisely-typed value without
- * casts.
- */
-export type AppliedReasoning =
-  | { key: 'thinking'; value: { type: 'enabled' | 'disabled' } }
-  | { key: 'reasoning'; value: { effort: string } | { enabled: boolean } };
-
-/**
- * Resolve the reasoning dialect for a given endpoint base URL.
- *
- * Host matching is robust: parses with `URL`, lowercases the hostname, and
- * compares with exact-or-dot-suffix matching so that
- * `evil-openrouter.ai.attacker.com` does NOT match, but `api.z.ai` does.
- */
-export function resolveReasoningDialect(
-  baseUrl: string | undefined,
-): ReasoningDialect {
-  if (typeof baseUrl !== 'string' || baseUrl.trim() === '') {
-    return 'none';
+export function hasExplicitReasoningField(
+  body: Readonly<Record<string, unknown>>,
+): boolean {
+  if (REASONING_WIRE_KEYS.some((key) => hasOwnProperty(body, key))) {
+    return true;
   }
 
-  let hostname: string;
-  try {
-    // Base URLs arrive from user config and profiles, where stray surrounding
-    // whitespace is common; untrimmed input makes `URL` throw and would
-    // silently disable the dialect for a host that is in the table.
-    hostname = new URL(baseUrl.trim()).hostname.toLowerCase();
-  } catch {
-    return 'none';
-  }
-
-  if (hostname === '') {
-    return 'none';
-  }
-
-  if (matchesHostSuffix(hostname, 'openrouter.ai')) {
-    return 'openrouter';
-  }
-
+  const templateKwargs = body['chat_template_kwargs'];
   if (
-    matchesHostSuffix(hostname, 'z.ai') ||
-    matchesHostSuffix(hostname, 'bigmodel.cn')
+    isRecord(templateKwargs) &&
+    (hasOwnProperty(templateKwargs, 'reasoning_effort') ||
+      hasOwnProperty(templateKwargs, 'enable_thinking'))
   ) {
-    return 'thinking';
+    return true;
   }
 
-  return 'none';
+  // An own `output_config.effort` is an explicit native reasoning effort
+  // (issue #3255). Unrelated output_config siblings alone are not: the own
+  // property check, not the shape of output_config, decides.
+  const outputConfig = body['output_config'];
+  return (
+    isRecord(outputConfig) &&
+    Object.prototype.hasOwnProperty.call(outputConfig, 'effort')
+  );
 }
 
-/**
- * Apply the resolved dialect to produce at most one reasoning representation.
- * Returns `null` when the dialect is `none` or the settings do not call for
- * emission (e.g. `enabled` is undefined for the `thinking` dialect).
- */
-export function applyReasoningDialect(
-  dialect: ReasoningDialect,
-  settings: ReasoningSettings,
-): AppliedReasoning | null {
-  switch (dialect) {
-    case 'openrouter':
-      return applyOpenRouterDialect(settings);
-    case 'thinking':
-      return applyThinkingDialect(settings);
-    case 'none':
-    default:
-      return null;
-  }
+function hasOwnProperty(
+  value: Readonly<Record<string, unknown>>,
+  key: string,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
 }
 
-function applyOpenRouterDialect(
-  settings: ReasoningSettings,
-): AppliedReasoning | null {
-  // An explicit `reasoning.enabled: false` outranks a leftover effort level —
-  // otherwise turning reasoning off would still request it.
-  if (settings.enabled === false) {
-    return { key: 'reasoning', value: { enabled: false } };
-  }
-  const effort = resolveEffort(settings);
-  if (effort !== undefined) {
-    return { key: 'reasoning', value: { effort } };
-  }
-  if (settings.enabled === true) {
-    return { key: 'reasoning', value: { enabled: true } };
-  }
-  return null;
-}
-
-function applyThinkingDialect(
-  settings: ReasoningSettings,
-): AppliedReasoning | null {
-  // Same precedence as the OpenRouter dialect: an explicit off wins, and an
-  // effort level on its own still means "think" even though this dialect has
-  // no way to express how hard.
-  if (settings.enabled === false) {
-    return { key: 'thinking', value: { type: 'disabled' } };
-  }
-  if (settings.enabled === true || resolveEffort(settings) !== undefined) {
-    return { key: 'thinking', value: { type: 'enabled' } };
-  }
-  return null;
-}
-
-/** The configured effort level, or undefined when it is unset or blank. */
-function resolveEffort(settings: ReasoningSettings): string | undefined {
-  const { effort } = settings;
-  return typeof effort === 'string' && effort !== '' ? effort : undefined;
-}
-
-/**
- * Exact-or-dot-suffix host match. `hostname` and `suffix` are pre-lowercased.
- * Matches `openrouter.ai` exactly and any `*.openrouter.ai` subdomain, but
- * rejects `evil-openrouter.ai.attacker.com`.
- */
-function matchesHostSuffix(hostname: string, suffix: string): boolean {
-  return hostname === suffix || hostname.endsWith(`.${suffix}`);
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/providers/src/openai/openaiReasoningPipeline.test.ts
+++ b/packages/providers/src/openai/openaiReasoningPipeline.test.ts
@@ -126,10 +126,19 @@ describe('issue #2896 settings-to-request pipeline', () => {
       expect(body['reasoning']).toStrictEqual({ effort: 'high' });
     });
 
-    it('sends only the thinking dialect to z.ai', async () => {
+    it('sends the coordinated thinking and effort fields to z.ai', async () => {
       const body = await bodyFor(settings, 'https://api.z.ai/api/paas/v4');
-      expect(reasoningKeysIn(body)).toStrictEqual(['thinking']);
-      expect(body['thinking']).toStrictEqual({ type: 'enabled' });
+      expect(reasoningKeysIn(body)).toStrictEqual([
+        'thinking',
+        'reasoning_effort',
+      ]);
+      expect({
+        thinking: body['thinking'],
+        reasoningEffort: body['reasoning_effort'],
+      }).toStrictEqual({
+        thinking: { type: 'enabled' },
+        reasoningEffort: 'high',
+      });
     });
   });
 

--- a/packages/providers/src/reasoning/reasoning-behavior-parsing.test.ts
+++ b/packages/providers/src/reasoning/reasoning-behavior-parsing.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  REASONING_EFFORTS,
+  readEffortMap,
+  readEffortWireFormat,
+  readEnabledMap,
+  readEnabledWireFormat,
+  readModelBehaviorRecord,
+  readOptionalBoolean,
+  readOptionalEffort,
+  readOptionalPositiveInteger,
+  selectBehaviorValue,
+} from './reasoning-behavior-parsing.js';
+
+describe('readModelBehaviorRecord: invocation snapshot contract', () => {
+  it('reads a missing record as empty', () => {
+    expect(readModelBehaviorRecord(undefined)).toStrictEqual({});
+  });
+
+  it('accepts a plain JSON record unchanged', () => {
+    const record = { 'reasoning.effort': 'high', unrelated: 1 };
+    expect(readModelBehaviorRecord(record)).toStrictEqual(record);
+  });
+
+  it('accepts a null-prototype record like structured JSON input', () => {
+    const record = Object.create(null) as Record<string, unknown>;
+    record['reasoning.enabled'] = true;
+    expect(readModelBehaviorRecord(record)).toStrictEqual({
+      'reasoning.enabled': true,
+    });
+  });
+
+  it.each([
+    ['an array', ['reasoning.effort']],
+    ['a Map instance', new Map([['reasoning.effort', 'high']])],
+    [
+      'a class instance',
+      new (class ModelBehavior {
+        readonly effort = 'high';
+      })(),
+    ],
+    ['null', null],
+    ['a string', 'reasoning'],
+  ])('rejects %s as the model behavior record', (_label, value) => {
+    expect(() => readModelBehaviorRecord(value)).toThrow(
+      'invocation model behavior must be a JSON object',
+    );
+  });
+});
+
+describe('readEffortMap: generic effort map contract', () => {
+  it('reads an absent map as undefined', () => {
+    expect(readEffortMap(undefined)).toBeUndefined();
+  });
+
+  it('accepts an empty plain record', () => {
+    expect(readEffortMap({})).toStrictEqual({});
+  });
+
+  it('accepts string, numeric, and null values for known efforts', () => {
+    expect(readEffortMap({ low: 'low', high: 8192, max: null })).toStrictEqual({
+      low: 'low',
+      high: 8192,
+      max: null,
+    });
+  });
+
+  it('rejects an unknown effort key', () => {
+    expect(() => readEffortMap({ turbo: 'high' })).toThrow(
+      "reasoning.effortMap contains unsupported key 'turbo'",
+    );
+  });
+
+  it.each([
+    ['an array', ['high']],
+    ['a Map instance', new Map([['high', 'max']])],
+    [
+      'a class instance',
+      new (class EffortMap {
+        readonly high = 'max';
+      })(),
+    ],
+  ])('rejects %s as an effort map', (_label, value) => {
+    expect(() => readEffortMap(value)).toThrow(
+      'reasoning.effortMap must be a JSON object',
+    );
+  });
+
+  it('trims surrounding whitespace from a mapped string', () => {
+    expect(readEffortMap({ high: ' max ' })).toStrictEqual({ high: 'max' });
+  });
+
+  it('rejects a whitespace-only mapped string', () => {
+    expect(() => readEffortMap({ high: '   ' })).toThrow(
+      'reasoning.effortMap values must be non-empty strings, integer budgets of at least 1024, or null',
+    );
+  });
+
+  it('accepts a mapped budget at the 1024 floor', () => {
+    expect(readEffortMap({ high: 1024 })).toStrictEqual({ high: 1024 });
+  });
+
+  it.each([
+    ['below the floor', 1023],
+    ['a small integer', 64],
+    ['a non-integer number', 2048.5],
+    ['a boolean', true],
+  ])('rejects a mapped budget %s', (_label, value) => {
+    expect(() => readEffortMap({ high: value })).toThrow(
+      'reasoning.effortMap values must be non-empty strings, integer budgets of at least 1024, or null',
+    );
+  });
+});
+
+describe('readEnabledMap: generic enablement map contract', () => {
+  it('reads an absent map as undefined', () => {
+    expect(readEnabledMap(undefined)).toBeUndefined();
+  });
+
+  it('accepts string, boolean, and null values for true and false', () => {
+    expect(readEnabledMap({ true: 'enabled', false: false })).toStrictEqual({
+      true: 'enabled',
+      false: false,
+    });
+    expect(readEnabledMap({ true: null })).toStrictEqual({ true: null });
+  });
+
+  it('rejects an unknown enablement key', () => {
+    expect(() => readEnabledMap({ maybe: true })).toThrow(
+      "reasoning.enabledMap contains unsupported key 'maybe'",
+    );
+  });
+
+  it.each([
+    ['an array', ['true']],
+    ['a Map instance', new Map([['true', 'enabled']])],
+  ])('rejects %s as an enabled map', (_label, value) => {
+    expect(() => readEnabledMap(value)).toThrow(
+      'reasoning.enabledMap must be a JSON object',
+    );
+  });
+
+  it('trims surrounding whitespace from a mapped string', () => {
+    expect(readEnabledMap({ true: ' enabled ' })).toStrictEqual({
+      true: 'enabled',
+    });
+  });
+
+  it.each([
+    ['a whitespace-only string', '   '],
+    ['a number', 1],
+  ])('rejects a mapped enablement value %s', (_label, value) => {
+    expect(() => readEnabledMap({ true: value })).toThrow(
+      'reasoning.enabledMap values must be non-empty strings, booleans, or null',
+    );
+  });
+});
+
+describe('readOptionalEffort: generic effort validation', () => {
+  it('reads an absent effort as undefined', () => {
+    expect(readOptionalEffort(undefined)).toBeUndefined();
+  });
+
+  it.each([...REASONING_EFFORTS])('accepts the generic effort %s', (effort) => {
+    expect(readOptionalEffort(effort)).toBe(effort);
+  });
+
+  it.each([
+    ['an unknown effort', 'ultra'],
+    ['an uppercase effort', 'HIGH'],
+    ['a number', 3],
+  ])('rejects %s', (_label, value) => {
+    expect(() => readOptionalEffort(value)).toThrow(
+      "reasoning.effort must be one of 'minimal', 'low', 'medium', 'high', 'xhigh', or 'max'",
+    );
+  });
+});
+
+describe('wire-format selector validation', () => {
+  it('defaults an absent effort selector to auto', () => {
+    expect(readEffortWireFormat(undefined)).toBe('auto');
+  });
+
+  it.each(['openai', 'openai-responses', 'anthropic', 'anthropic-budget'])(
+    'accepts the effort wire format %s',
+    (format) => {
+      expect(readEffortWireFormat(format)).toBe(format);
+    },
+  );
+
+  it.each(['custom', 'OpenAI', 7])(
+    'rejects an invalid effort wire format %s',
+    (value) => {
+      expect(() => readEffortWireFormat(value)).toThrow(
+        "reasoning.effortWireFormat must be one of 'auto', 'openai', 'openai-responses', 'anthropic', 'anthropic-budget', 'openrouter', 'gemini', 'template-kwargs', or 'none'",
+      );
+    },
+  );
+
+  it('defaults an absent enabled selector to auto', () => {
+    expect(readEnabledWireFormat(undefined)).toBe('auto');
+  });
+
+  it.each(['openai', 'openai-responses', 'openrouter', 'thinking'])(
+    'accepts the enabled wire format %s',
+    (format) => {
+      expect(readEnabledWireFormat(format)).toBe(format);
+    },
+  );
+
+  it.each(['custom', 'Thinking', null])(
+    'rejects an invalid enabled wire format %s',
+    (value) => {
+      expect(() => readEnabledWireFormat(value)).toThrow(
+        "reasoning.enabledWireFormat must be one of 'auto', 'openai', 'openai-responses', 'openrouter', 'thinking', 'gemini', 'template-kwargs', or 'none'",
+      );
+    },
+  );
+});
+
+describe('scalar behavior readers', () => {
+  it('reads an optional boolean strictly', () => {
+    expect(readOptionalBoolean(undefined, 'reasoning.enabled')).toBeUndefined();
+    expect(readOptionalBoolean(true, 'reasoning.enabled')).toBe(true);
+    expect(() => readOptionalBoolean('true', 'reasoning.enabled')).toThrow(
+      'reasoning.enabled must be a boolean',
+    );
+  });
+
+  it('reads an optional positive integer strictly', () => {
+    expect(
+      readOptionalPositiveInteger(undefined, 'reasoning.maxTokens'),
+    ).toBeUndefined();
+    expect(readOptionalPositiveInteger(4096, 'reasoning.maxTokens')).toBe(4096);
+    expect(() => readOptionalPositiveInteger(0, 'reasoning.maxTokens')).toThrow(
+      'reasoning.maxTokens must be a positive integer',
+    );
+    expect(() =>
+      readOptionalPositiveInteger(1.5, 'reasoning.maxTokens'),
+    ).toThrow('reasoning.maxTokens must be a positive integer');
+  });
+});
+
+describe('selectBehaviorValue: model behavior precedence', () => {
+  const modelBehavior: Readonly<Record<string, unknown>> = {
+    'reasoning.effort': 'high',
+  };
+
+  it('lets the model behavior record win over the fallback', () => {
+    expect(selectBehaviorValue(modelBehavior, 'reasoning.effort', 'low')).toBe(
+      'high',
+    );
+  });
+
+  it('falls through to the fallback when the key is absent', () => {
+    expect(
+      selectBehaviorValue(modelBehavior, 'reasoning.summary', 'auto'),
+    ).toBe('auto');
+  });
+
+  it('falls through only on undefined, preserving explicit false and null', () => {
+    const behavior: Readonly<Record<string, unknown>> = {
+      'reasoning.enabled': false,
+      'reasoning.effortMap': null,
+    };
+    expect(selectBehaviorValue(behavior, 'reasoning.enabled', true)).toBe(
+      false,
+    );
+    expect(
+      selectBehaviorValue(behavior, 'reasoning.effortMap', { high: 'high' }),
+    ).toBeNull();
+  });
+});

--- a/packages/providers/src/reasoning/reasoning-behavior-parsing.test.ts
+++ b/packages/providers/src/reasoning/reasoning-behavior-parsing.test.ts
@@ -187,12 +187,19 @@ describe('wire-format selector validation', () => {
     expect(readEffortWireFormat(undefined)).toBe('auto');
   });
 
-  it.each(['openai', 'openai-responses', 'anthropic', 'anthropic-budget'])(
-    'accepts the effort wire format %s',
-    (format) => {
-      expect(readEffortWireFormat(format)).toBe(format);
-    },
-  );
+  it.each([
+    'auto',
+    'openai',
+    'openai-responses',
+    'anthropic',
+    'anthropic-budget',
+    'openrouter',
+    'gemini',
+    'template-kwargs',
+    'none',
+  ])('accepts the effort wire format %s', (format) => {
+    expect(readEffortWireFormat(format)).toBe(format);
+  });
 
   it.each(['custom', 'OpenAI', 7])(
     'rejects an invalid effort wire format %s',
@@ -207,12 +214,18 @@ describe('wire-format selector validation', () => {
     expect(readEnabledWireFormat(undefined)).toBe('auto');
   });
 
-  it.each(['openai', 'openai-responses', 'openrouter', 'thinking'])(
-    'accepts the enabled wire format %s',
-    (format) => {
-      expect(readEnabledWireFormat(format)).toBe(format);
-    },
-  );
+  it.each([
+    'auto',
+    'openai',
+    'openai-responses',
+    'openrouter',
+    'thinking',
+    'gemini',
+    'template-kwargs',
+    'none',
+  ])('accepts the enabled wire format %s', (format) => {
+    expect(readEnabledWireFormat(format)).toBe(format);
+  });
 
   it.each(['custom', 'Thinking', null])(
     'rejects an invalid enabled wire format %s',

--- a/packages/providers/src/reasoning/reasoning-behavior-parsing.ts
+++ b/packages/providers/src/reasoning/reasoning-behavior-parsing.ts
@@ -1,0 +1,271 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  ReasoningEffort,
+  ReasoningEffortMap,
+  ReasoningEffortWireFormat,
+  ReasoningEnabledMap,
+  ReasoningEnabledWireFormat,
+} from '@vybestack/llxprt-code-settings';
+
+/**
+ * Provider-independent readers for generic reasoning model-behavior values
+ * (issue #3255). Every adapter parses the invocation snapshot through this
+ * module so validation cannot drift between providers; provider-specific
+ * parsing (summary, include, native thinking) stays in provider files.
+ */
+
+/** Single source of generic effort literals for validation and map keys. */
+export const REASONING_EFFORTS = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const satisfies readonly ReasoningEffort[];
+
+const EFFORT_WIRE_FORMATS = [
+  'auto',
+  'openai',
+  'openai-responses',
+  'anthropic',
+  'anthropic-budget',
+  'openrouter',
+  'gemini',
+  'template-kwargs',
+  'none',
+] as const satisfies readonly ReasoningEffortWireFormat[];
+
+const ENABLED_WIRE_FORMATS = [
+  'auto',
+  'openai',
+  'openai-responses',
+  'openrouter',
+  'thinking',
+  'gemini',
+  'template-kwargs',
+  'none',
+] as const satisfies readonly ReasoningEnabledWireFormat[];
+
+/** Numeric effort-map values are explicit budgets with a hard floor. */
+const MIN_MAPPED_BUDGET_TOKENS = 1024;
+
+/**
+ * Read the invocation model-behavior record. A missing record reads as
+ * empty; anything but a plain JSON object fails fast.
+ */
+export function readModelBehaviorRecord(
+  value: unknown,
+): Readonly<Record<string, unknown>> {
+  if (value === undefined) {
+    return {};
+  }
+  if (isPlainRecord(value)) {
+    return value;
+  }
+  throw new Error('invocation model behavior must be a JSON object');
+}
+
+/** Model behavior wins over a provided fallback; undefined falls through. */
+export function selectBehaviorValue(
+  modelBehavior: Readonly<Record<string, unknown>>,
+  key: string,
+  fallback: unknown,
+): unknown {
+  const value = modelBehavior[key];
+  return value === undefined ? fallback : value;
+}
+
+export function readOptionalBoolean(
+  value: unknown,
+  setting: string,
+): boolean | undefined {
+  if (value === undefined || typeof value === 'boolean') {
+    return value;
+  }
+  throw new Error(`${setting} must be a boolean`);
+}
+
+export function readOptionalEffort(
+  value: unknown,
+): ReasoningEffort | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string' && isReasoningEffort(value)) {
+    return value;
+  }
+  throw new Error(
+    `reasoning.effort must be one of ${quotedList(REASONING_EFFORTS)}`,
+  );
+}
+
+export function readOptionalPositiveInteger(
+  value: unknown,
+  setting: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+  throw new Error(`${setting} must be a positive integer`);
+}
+
+export function readEffortWireFormat(
+  value: unknown,
+): ReasoningEffortWireFormat {
+  if (value === undefined) {
+    return 'auto';
+  }
+  if (typeof value === 'string' && isEffortWireFormat(value)) {
+    return value;
+  }
+  throw new Error(
+    `reasoning.effortWireFormat must be one of ${quotedList(EFFORT_WIRE_FORMATS)}`,
+  );
+}
+
+export function readEnabledWireFormat(
+  value: unknown,
+): ReasoningEnabledWireFormat {
+  if (value === undefined) {
+    return 'auto';
+  }
+  if (typeof value === 'string' && isEnabledWireFormat(value)) {
+    return value;
+  }
+  throw new Error(
+    `reasoning.enabledWireFormat must be one of ${quotedList(ENABLED_WIRE_FORMATS)}`,
+  );
+}
+
+/**
+ * Parse `reasoning.effortMap`. The value must be a plain record (arrays and
+ * class/Map instances are rejected), every key must be a generic effort, and
+ * mapped strings normalize to their trimmed value.
+ */
+export function readEffortMap(value: unknown): ReasoningEffortMap | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isPlainRecord(value)) {
+    throw new Error('reasoning.effortMap must be a JSON object');
+  }
+
+  const result: {
+    -readonly [Effort in ReasoningEffort]?: string | number | null;
+  } = {};
+  for (const [key, rawMappedValue] of Object.entries(value)) {
+    if (!isReasoningEffort(key)) {
+      throw new Error(`reasoning.effortMap contains unsupported key '${key}'`);
+    }
+    result[key] = readEffortMapValue(rawMappedValue);
+  }
+  return result;
+}
+
+/**
+ * Parse `reasoning.enabledMap` under the same plain-record contract as
+ * {@link readEffortMap}.
+ */
+export function readEnabledMap(
+  value: unknown,
+): ReasoningEnabledMap | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isPlainRecord(value)) {
+    throw new Error('reasoning.enabledMap must be a JSON object');
+  }
+
+  const result: {
+    -readonly [Key in 'true' | 'false']?: string | boolean | null;
+  } = {};
+  for (const [key, rawMappedValue] of Object.entries(value)) {
+    if (key !== 'true' && key !== 'false') {
+      throw new Error(`reasoning.enabledMap contains unsupported key '${key}'`);
+    }
+    result[key] = readEnabledMapValue(rawMappedValue);
+  }
+  return result;
+}
+
+export function isReasoningEffort(value: string): value is ReasoningEffort {
+  return (REASONING_EFFORTS as readonly string[]).includes(value);
+}
+
+function isEffortWireFormat(value: string): value is ReasoningEffortWireFormat {
+  return (EFFORT_WIRE_FORMATS as readonly string[]).includes(value);
+}
+
+function isEnabledWireFormat(
+  value: string,
+): value is ReasoningEnabledWireFormat {
+  return (ENABLED_WIRE_FORMATS as readonly string[]).includes(value);
+}
+
+function readEffortMapValue(value: unknown): string | number | null {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed !== '') {
+      return trimmed;
+    }
+  } else if (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= MIN_MAPPED_BUDGET_TOKENS
+  ) {
+    return value;
+  }
+  throw new Error(
+    `reasoning.effortMap values must be non-empty strings, integer budgets of at least ${MIN_MAPPED_BUDGET_TOKENS}, or null`,
+  );
+}
+
+function readEnabledMapValue(value: unknown): string | boolean | null {
+  if (value === null || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed !== '') {
+      return trimmed;
+    }
+  }
+  throw new Error(
+    'reasoning.enabledMap values must be non-empty strings, booleans, or null',
+  );
+}
+
+/**
+ * Plain records only: arrays and class/Map instances (whose entries do not
+ * serialize as JSON keys) fail fast instead of being silently accepted.
+ * Internal to the providers package; adapters parsing provider-local
+ * records reuse it so the plain-record contract cannot drift.
+ */
+export function isPlainRecord(
+  value: unknown,
+): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === null || prototype === Object.prototype;
+}
+
+function quotedList(values: readonly string[]): string {
+  const quoted = values.map((value) => `'${value}'`);
+  return quoted.length <= 1
+    ? quoted.join('')
+    : `${quoted.slice(0, -1).join(', ')}, or ${quoted[quoted.length - 1]}`;
+}

--- a/packages/providers/src/reasoning/reasoning-config-resolver.test.ts
+++ b/packages/providers/src/reasoning/reasoning-config-resolver.test.ts
@@ -1,0 +1,791 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type {
+  ReasoningEffortMap,
+  ReasoningEnabledMap,
+} from '@vybestack/llxprt-code-settings';
+import {
+  resolveReasoningConfiguration,
+  type ReasoningResolverInput,
+  type ResolvedReasoningEffortWireFormat,
+  type ResolvedReasoningEnabledWireFormat,
+} from './reasoning-config-resolver.js';
+
+const BASE_INPUT: ReasoningResolverInput = {
+  nativeAdapter: 'openai-chat',
+  effortWireFormat: 'auto',
+  enabledWireFormat: 'auto',
+  reasoning: {},
+};
+
+function resolve(
+  overrides: Partial<ReasoningResolverInput> = {},
+): ReturnType<typeof resolveReasoningConfiguration> {
+  return resolveReasoningConfiguration({ ...BASE_INPUT, ...overrides });
+}
+
+function nativeAdapterForEnabledFormat(
+  format: ReasoningResolverInput['enabledWireFormat'],
+): ReasoningResolverInput['nativeAdapter'] {
+  if (format === 'openai-responses') {
+    return 'openai-responses';
+  }
+  return format === 'gemini' ? 'gemini' : 'openai-chat';
+}
+
+describe('reasoning configuration auto selection', () => {
+  it.each([
+    {
+      nativeAdapter: 'openai-chat',
+      chatBaseUrl: 'https://openrouter.ai/api/v1',
+      effortFormat: 'openrouter',
+      enabledFormat: 'openrouter',
+    },
+    {
+      nativeAdapter: 'openai-chat',
+      chatBaseUrl: 'https://api.z.ai/api/paas/v4',
+      effortFormat: 'openai',
+      enabledFormat: 'thinking',
+    },
+    {
+      nativeAdapter: 'openai-chat',
+      chatBaseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+      effortFormat: 'openai',
+      enabledFormat: 'thinking',
+    },
+    {
+      nativeAdapter: 'openai-chat',
+      chatBaseUrl: 'https://api.openai.com/v1',
+      effortFormat: 'openai',
+      enabledFormat: 'none',
+    },
+    {
+      nativeAdapter: 'openai-responses',
+      effortFormat: 'openai-responses',
+      enabledFormat: 'none',
+    },
+    {
+      nativeAdapter: 'anthropic',
+      effortFormat: 'anthropic',
+      enabledFormat: 'thinking',
+    },
+    {
+      nativeAdapter: 'gemini',
+      effortFormat: 'gemini',
+      enabledFormat: 'gemini',
+    },
+  ] satisfies ReadonlyArray<{
+    readonly nativeAdapter: ReasoningResolverInput['nativeAdapter'];
+    readonly chatBaseUrl?: string;
+    readonly effortFormat: ResolvedReasoningEffortWireFormat;
+    readonly enabledFormat: ResolvedReasoningEnabledWireFormat;
+  }>)(
+    'resolves $nativeAdapter $chatBaseUrl to its native formats',
+    ({ nativeAdapter, chatBaseUrl, effortFormat, enabledFormat }) => {
+      const result = resolve({ nativeAdapter, chatBaseUrl });
+
+      expect({
+        effortFormat: result.effortFormat,
+        enabledFormat: result.enabledFormat,
+      }).toStrictEqual({ effortFormat, enabledFormat });
+    },
+  );
+
+  it.each([undefined, 'not a URL', 'https://custom.example/v1'])(
+    'leaves unknown or invalid Chat endpoint %s unresolved',
+    (chatBaseUrl) => {
+      const result = resolve({
+        chatBaseUrl,
+        reasoning: { effort: 'high', enabled: true },
+      });
+
+      expect(result).toStrictEqual({
+        effortFormat: 'none',
+        enabledFormat: 'none',
+        effort: {
+          state: 'unrepresentable',
+          reason: 'effort-format-undetected',
+        },
+        enabled: {
+          state: 'unrepresentable',
+          reason: 'enabled-format-undetected',
+        },
+      });
+    },
+  );
+
+  it.each([
+    'https://openrouter.ai.attacker.example/v1',
+    'https://z.ai.attacker.example/v1',
+    'https://bigmodel.cn.attacker.example/v1',
+    'https://api.openai.com.attacker.example/v1',
+  ])('rejects hostname suffix spoof %s', (chatBaseUrl) => {
+    const result = resolve({ chatBaseUrl });
+
+    expect({
+      effortFormat: result.effortFormat,
+      enabledFormat: result.enabledFormat,
+    }).toStrictEqual({ effortFormat: 'none', enabledFormat: 'none' });
+  });
+});
+
+describe('reasoning effort mapping', () => {
+  it('uses the generic effort unchanged when a string map entry is absent', () => {
+    const result = resolve({
+      effortWireFormat: 'openai',
+      reasoning: { effort: 'high' },
+      effortMap: { low: 'tiny' },
+    });
+
+    expect(result.effort).toStrictEqual({ state: 'emitted', value: 'high' });
+  });
+
+  it('remaps a generic effort for a string-valued format', () => {
+    const result = resolve({
+      effortWireFormat: 'template-kwargs',
+      reasoning: { effort: 'medium' },
+      effortMap: { medium: 'balanced' },
+    });
+
+    expect(result.effort).toStrictEqual({
+      state: 'emitted',
+      value: 'balanced',
+    });
+  });
+
+  it('treats a null effort map entry as explicit suppression', () => {
+    const result = resolve({
+      effortWireFormat: 'openrouter',
+      reasoning: { effort: 'minimal' },
+      effortMap: { minimal: null },
+    });
+
+    expect(result.effort).toStrictEqual({
+      state: 'suppressed',
+      reason: 'effort-map-null',
+    });
+  });
+
+  it('emits a numeric mapped value for anthropic-budget', () => {
+    const result = resolve({
+      effortWireFormat: 'anthropic-budget',
+      reasoning: { effort: 'high' },
+      effortMap: { high: 8192 },
+    });
+
+    expect(result.effort).toStrictEqual({ state: 'emitted', value: 8192 });
+  });
+
+  it('reports an effort without a numeric anthropic-budget mapping', () => {
+    const result = resolve({
+      effortWireFormat: 'anthropic-budget',
+      reasoning: { effort: 'high' },
+    });
+
+    expect(result.effort).toStrictEqual({
+      state: 'unrepresentable',
+      reason: 'numeric-effort-map-required',
+    });
+  });
+
+  it('gives a direct budget precedence over an effort-derived budget', () => {
+    const result = resolve({
+      effortWireFormat: 'anthropic-budget',
+      reasoning: { effort: 'high', budgetTokens: 16384 },
+      effortMap: { high: 8192 },
+    });
+
+    expect(result.effort).toStrictEqual({ state: 'emitted', value: 16384 });
+  });
+
+  it('emits a direct budget when generic effort is absent', () => {
+    const result = resolve({
+      effortWireFormat: 'anthropic-budget',
+      reasoning: { budgetTokens: 4096 },
+    });
+
+    expect(result.effort).toStrictEqual({ state: 'emitted', value: 4096 });
+  });
+
+  it('distinguishes absent effort from suppression', () => {
+    const result = resolve({ effortWireFormat: 'openai' });
+
+    expect(result.effort).toStrictEqual({ state: 'absent' });
+  });
+
+  it('treats an explicit none effort selector as suppression', () => {
+    const result = resolve({
+      effortWireFormat: 'none',
+      reasoning: { effort: 'low' },
+    });
+
+    expect(result.effort).toStrictEqual({
+      state: 'suppressed',
+      reason: 'effort-format-none',
+    });
+  });
+
+  it('rejects string mappings for anthropic-budget', () => {
+    const effortMap: ReasoningEffortMap = { high: '8192' };
+
+    expect(() =>
+      resolve({
+        effortWireFormat: 'anthropic-budget',
+        reasoning: { effort: 'high' },
+        effortMap,
+      }),
+    ).toThrow('reasoning.effortMap.high must be a number for anthropic-budget');
+  });
+
+  it('rejects numeric mappings for string-valued formats', () => {
+    const effortMap: ReasoningEffortMap = { high: 8192 };
+
+    expect(() =>
+      resolve({
+        effortWireFormat: 'openai',
+        reasoning: { effort: 'high' },
+        effortMap,
+      }),
+    ).toThrow('reasoning.effortMap.high must be a string for openai');
+  });
+});
+
+describe('reasoning enabled mapping', () => {
+  it.each([
+    ['openrouter', true, true],
+    ['openrouter', false, false],
+    ['thinking', true, 'enabled'],
+    ['thinking', false, 'disabled'],
+    ['gemini', true, true],
+    ['gemini', false, false],
+    ['template-kwargs', true, true],
+    ['template-kwargs', false, false],
+  ] satisfies ReadonlyArray<
+    readonly [
+      ReasoningResolverInput['enabledWireFormat'],
+      boolean,
+      string | boolean,
+    ]
+  >)(
+    'applies the %s default for enabled=%s',
+    (enabledWireFormat, enabled, expected) => {
+      const nativeAdapter =
+        enabledWireFormat === 'gemini' ? 'gemini' : 'openai-chat';
+      const result = resolve({
+        nativeAdapter,
+        enabledWireFormat,
+        reasoning: { enabled },
+      });
+
+      expect(result.enabled).toStrictEqual({
+        state: 'emitted',
+        value: expected,
+      });
+    },
+  );
+
+  it.each(['openai', 'openai-responses'] satisfies ReadonlyArray<
+    ReasoningResolverInput['enabledWireFormat']
+  >)('requires an explicit enabled map for %s', (enabledWireFormat) => {
+    const nativeAdapter =
+      enabledWireFormat === 'openai-responses'
+        ? 'openai-responses'
+        : 'openai-chat';
+    const result = resolve({
+      nativeAdapter,
+      enabledWireFormat,
+      reasoning: { enabled: true },
+    });
+
+    expect(result.enabled).toStrictEqual({
+      state: 'unrepresentable',
+      reason: 'enabled-map-required',
+    });
+  });
+
+  it.each([
+    ['openai', 'on'],
+    ['openai-responses', 'low'],
+    ['thinking', 'adaptive'],
+    ['openrouter', false],
+    ['gemini', false],
+    ['template-kwargs', false],
+  ] satisfies ReadonlyArray<
+    readonly [ReasoningResolverInput['enabledWireFormat'], string | boolean]
+  >)(
+    'uses an accepted custom %s enabled mapping',
+    (enabledWireFormat, expected) => {
+      const nativeAdapter = nativeAdapterForEnabledFormat(enabledWireFormat);
+      const enabledMap: ReasoningEnabledMap = { true: expected };
+      const result = resolve({
+        nativeAdapter,
+        enabledWireFormat,
+        reasoning: { enabled: true },
+        enabledMap,
+      });
+
+      expect(result.enabled).toStrictEqual({
+        state: 'emitted',
+        value: expected,
+      });
+    },
+  );
+
+  it('treats a null enabled map entry as explicit suppression', () => {
+    const result = resolve({
+      enabledWireFormat: 'thinking',
+      reasoning: { enabled: false },
+      enabledMap: { false: null },
+    });
+
+    expect(result.enabled).toStrictEqual({
+      state: 'suppressed',
+      reason: 'enabled-map-null',
+    });
+  });
+
+  it('distinguishes absent enabled input', () => {
+    const result = resolve({ enabledWireFormat: 'thinking' });
+
+    expect(result.enabled).toStrictEqual({ state: 'absent' });
+  });
+
+  it.each([
+    ['openai-chat', 'https://api.openai.com/v1'],
+    ['openai-responses', undefined],
+  ] satisfies ReadonlyArray<
+    readonly [ReasoningResolverInput['nativeAdapter'], string | undefined]
+  >)(
+    'allows emitted effort to represent enabled=true for %s',
+    (nativeAdapter, chatBaseUrl) => {
+      const result = resolve({
+        nativeAdapter,
+        chatBaseUrl,
+        reasoning: { enabled: true, effort: 'high' },
+      });
+
+      expect(result.enabled).toStrictEqual({
+        state: 'represented',
+        reason: 'effort-emitted',
+      });
+    },
+  );
+
+  it('allows an effort value to represent enabled=true without an enabled map', () => {
+    const result = resolve({
+      effortWireFormat: 'openai',
+      enabledWireFormat: 'openai',
+      reasoning: { enabled: true, effort: 'high' },
+    });
+
+    expect(result.enabled).toStrictEqual({
+      state: 'represented',
+      reason: 'effort-emitted',
+    });
+  });
+
+  it('does not add redundant default OpenRouter enablement when effort is emitted', () => {
+    const result = resolve({
+      effortWireFormat: 'openrouter',
+      enabledWireFormat: 'openrouter',
+      reasoning: { enabled: true, effort: 'high' },
+    });
+
+    expect(result.enabled).toStrictEqual({
+      state: 'represented',
+      reason: 'effort-emitted',
+    });
+  });
+
+  it('represents enabled=true by emitted effort instead of an openai enabled map string', () => {
+    const result = resolve({
+      effortWireFormat: 'openai',
+      enabledWireFormat: 'openai',
+      reasoning: { enabled: true, effort: 'high' },
+      enabledMap: { true: 'max' },
+    });
+
+    expect(result.effort).toStrictEqual({ state: 'emitted', value: 'high' });
+    expect(result.enabled).toStrictEqual({
+      state: 'represented',
+      reason: 'effort-emitted',
+    });
+  });
+
+  it('represents enabled=true by emitted effort instead of an openai-responses enabled map string', () => {
+    const result = resolve({
+      nativeAdapter: 'openai-responses',
+      effortWireFormat: 'openai-responses',
+      enabledWireFormat: 'openai-responses',
+      reasoning: { enabled: true, effort: 'high' },
+      enabledMap: { true: 'medium' },
+    });
+
+    expect(result.effort).toStrictEqual({ state: 'emitted', value: 'high' });
+    expect(result.enabled).toStrictEqual({
+      state: 'represented',
+      reason: 'effort-emitted',
+    });
+  });
+
+  it('keeps a mapped enabled=false emission when effort is disabled-suppressed', () => {
+    const result = resolve({
+      effortWireFormat: 'openai',
+      enabledWireFormat: 'openai',
+      reasoning: { enabled: false, effort: 'high' },
+      enabledMap: { false: 'none' },
+    });
+
+    expect(result.effort).toStrictEqual({
+      state: 'suppressed',
+      reason: 'reasoning-disabled',
+    });
+    expect(result.enabled).toStrictEqual({
+      state: 'emitted',
+      value: 'none',
+    });
+  });
+  it('treats an explicit none enabled selector as suppression', () => {
+    const result = resolve({
+      enabledWireFormat: 'none',
+      reasoning: { enabled: true },
+    });
+
+    expect(result.enabled).toStrictEqual({
+      state: 'suppressed',
+      reason: 'enabled-format-none',
+    });
+  });
+
+  it('treats enabled=true as represented when an effort-only profile emits effort', () => {
+    const result = resolve({
+      effortWireFormat: 'openai',
+      enabledWireFormat: 'none',
+      reasoning: { enabled: true, effort: 'high' },
+    });
+
+    expect(result.enabled).toStrictEqual({
+      state: 'represented',
+      reason: 'effort-emitted',
+    });
+  });
+
+  it.each([
+    ['openai', true],
+    ['openai-responses', false],
+    ['thinking', true],
+    ['openrouter', 'enabled'],
+    ['gemini', 'enabled'],
+    ['template-kwargs', 'enabled'],
+  ] satisfies ReadonlyArray<
+    readonly [ReasoningResolverInput['enabledWireFormat'], string | boolean]
+  >)(
+    'rejects an incompatible custom value for %s',
+    (enabledWireFormat, mappedValue) => {
+      const nativeAdapter = nativeAdapterForEnabledFormat(enabledWireFormat);
+      const enabledMap: ReasoningEnabledMap = { true: mappedValue };
+
+      expect(() =>
+        resolve({
+          nativeAdapter,
+          enabledWireFormat,
+          reasoning: { enabled: true },
+          enabledMap,
+        }),
+      ).toThrow(
+        `reasoning.enabledMap.true has an incompatible value for ${enabledWireFormat}`,
+      );
+    },
+  );
+});
+
+describe('reasoning enablement precedence', () => {
+  it('suppresses generic effort when reasoning is explicitly disabled', () => {
+    const result = resolve({
+      effortWireFormat: 'openrouter',
+      enabledWireFormat: 'openrouter',
+      reasoning: { enabled: false, effort: 'high' },
+    });
+
+    expect({ effort: result.effort, enabled: result.enabled }).toStrictEqual({
+      effort: { state: 'suppressed', reason: 'reasoning-disabled' },
+      enabled: { state: 'emitted', value: false },
+    });
+  });
+
+  it('reports disablement that an effort-only format cannot represent', () => {
+    const result = resolve({
+      effortWireFormat: 'openai',
+      enabledWireFormat: 'auto',
+      reasoning: { enabled: false, effort: 'high' },
+    });
+
+    expect({ effort: result.effort, enabled: result.enabled }).toStrictEqual({
+      effort: { state: 'suppressed', reason: 'reasoning-disabled' },
+      enabled: {
+        state: 'unrepresentable',
+        reason: 'enabled-format-undetected',
+      },
+    });
+  });
+
+  it('suppresses a direct budget when reasoning is explicitly disabled', () => {
+    const result = resolve({
+      effortWireFormat: 'anthropic-budget',
+      enabledWireFormat: 'thinking',
+      reasoning: { enabled: false, budgetTokens: 8192 },
+    });
+
+    expect({ effort: result.effort, enabled: result.enabled }).toStrictEqual({
+      effort: { state: 'suppressed', reason: 'reasoning-disabled' },
+      enabled: { state: 'emitted', value: 'disabled' },
+    });
+  });
+});
+
+describe('native adapter selector compatibility', () => {
+  it.each([
+    ['openai-responses', 'openai'],
+    ['anthropic', 'openrouter'],
+    ['gemini', 'openai'],
+    ['openai-chat', 'anthropic'],
+  ] satisfies ReadonlyArray<
+    readonly [
+      ReasoningResolverInput['nativeAdapter'],
+      ReasoningResolverInput['effortWireFormat'],
+    ]
+  >)('rejects %s effort selector %s', (nativeAdapter, selector) => {
+    expect(() =>
+      resolve({ nativeAdapter, effortWireFormat: selector }),
+    ).toThrow(
+      `effort wire format '${selector}' is incompatible with the ${nativeAdapter} adapter`,
+    );
+  });
+
+  it.each([
+    ['openai-responses', 'thinking'],
+    ['anthropic', 'openrouter'],
+    ['gemini', 'thinking'],
+    ['openai-chat', 'gemini'],
+  ] satisfies ReadonlyArray<
+    readonly [
+      ReasoningResolverInput['nativeAdapter'],
+      ReasoningResolverInput['enabledWireFormat'],
+    ]
+  >)('rejects %s enabled selector %s', (nativeAdapter, selector) => {
+    expect(() =>
+      resolve({ nativeAdapter, enabledWireFormat: selector }),
+    ).toThrow(
+      `enabled wire format '${selector}' is incompatible with the ${nativeAdapter} adapter`,
+    );
+  });
+
+  it.each([
+    {
+      nativeAdapter: 'openai-responses',
+      effortWireFormat: 'openai-responses',
+      enabledWireFormat: 'openai-responses',
+    },
+    {
+      nativeAdapter: 'anthropic',
+      effortWireFormat: 'anthropic-budget',
+      enabledWireFormat: 'thinking',
+    },
+    {
+      nativeAdapter: 'gemini',
+      effortWireFormat: 'none',
+      enabledWireFormat: 'gemini',
+    },
+    {
+      nativeAdapter: 'openai-chat',
+      effortWireFormat: 'anthropic-budget',
+      enabledWireFormat: 'template-kwargs',
+    },
+  ] satisfies ReadonlyArray<
+    Pick<
+      ReasoningResolverInput,
+      'nativeAdapter' | 'effortWireFormat' | 'enabledWireFormat'
+    >
+  >)('accepts supported selectors for $nativeAdapter', (selectors) => {
+    expect(() => resolve(selectors)).not.toThrow();
+  });
+});
+
+describe('emitted Chat format pair coordination (issue #3255)', () => {
+  it.each([
+    {
+      title: 'openai effort with thinking enablement',
+      effortWireFormat: 'openai',
+      enabledWireFormat: 'thinking',
+      effortMap: undefined,
+      enabledMap: undefined,
+    },
+    {
+      title: 'anthropic-budget effort with thinking enablement',
+      effortWireFormat: 'anthropic-budget',
+      enabledWireFormat: 'thinking',
+      effortMap: { high: 8192 },
+      enabledMap: undefined,
+    },
+    {
+      title: 'openai effort with openai enablement',
+      effortWireFormat: 'openai',
+      enabledWireFormat: 'openai',
+      effortMap: undefined,
+      enabledMap: undefined,
+    },
+    {
+      title: 'openrouter effort with openrouter enablement',
+      effortWireFormat: 'openrouter',
+      enabledWireFormat: 'openrouter',
+      effortMap: undefined,
+      enabledMap: { true: false },
+    },
+    {
+      title: 'template-kwargs effort with template-kwargs enablement',
+      effortWireFormat: 'template-kwargs',
+      enabledWireFormat: 'template-kwargs',
+      effortMap: undefined,
+      enabledMap: undefined,
+    },
+  ] satisfies ReadonlyArray<{
+    readonly title: string;
+    readonly effortWireFormat: ReasoningResolverInput['effortWireFormat'];
+    readonly enabledWireFormat: ReasoningResolverInput['enabledWireFormat'];
+    readonly effortMap: ReasoningEffortMap | undefined;
+    readonly enabledMap: ReasoningEnabledMap | undefined;
+  }>)(
+    'accepts the coordinated $title pair',
+    ({ effortWireFormat, enabledWireFormat, effortMap, enabledMap }) => {
+      expect(() =>
+        resolve({
+          effortWireFormat,
+          enabledWireFormat,
+          reasoning: { enabled: true, effort: 'high' },
+          effortMap,
+          enabledMap,
+        }),
+      ).not.toThrow();
+    },
+  );
+
+  it.each([
+    {
+      effortWireFormat: 'openrouter',
+      enabledWireFormat: 'thinking',
+      effortMap: undefined,
+      enabledMap: undefined,
+    },
+    {
+      effortWireFormat: 'anthropic-budget',
+      enabledWireFormat: 'openrouter',
+      effortMap: { high: 8192 },
+      enabledMap: { true: false },
+    },
+    {
+      effortWireFormat: 'template-kwargs',
+      enabledWireFormat: 'openrouter',
+      effortMap: undefined,
+      enabledMap: { true: false },
+    },
+  ] satisfies ReadonlyArray<{
+    readonly effortWireFormat: ReasoningResolverInput['effortWireFormat'];
+    readonly enabledWireFormat: ReasoningResolverInput['enabledWireFormat'];
+    readonly effortMap: ReasoningEffortMap | undefined;
+    readonly enabledMap: ReasoningEnabledMap | undefined;
+  }>)(
+    'rejects conflicting emitted effort $effortWireFormat with enabled $enabledWireFormat',
+    ({ effortWireFormat, enabledWireFormat, effortMap, enabledMap }) => {
+      expect(() =>
+        resolve({
+          effortWireFormat,
+          enabledWireFormat,
+          reasoning: { enabled: true, effort: 'high' },
+          effortMap,
+          enabledMap,
+        }),
+      ).toThrow(
+        `effort format '${effortWireFormat}' and enabled format '${enabledWireFormat}' emit conflicting OpenAI Chat reasoning representations`,
+      );
+    },
+  );
+
+  it('allows openrouter effort when a null enabled map suppresses enablement', () => {
+    expect(() =>
+      resolve({
+        effortWireFormat: 'openrouter',
+        enabledWireFormat: 'thinking',
+        reasoning: { enabled: true, effort: 'high' },
+        enabledMap: { true: null },
+      }),
+    ).not.toThrow();
+  });
+
+  it('allows anthropic-budget effort when enablement is represented by effort', () => {
+    expect(() =>
+      resolve({
+        effortWireFormat: 'anthropic-budget',
+        enabledWireFormat: 'openrouter',
+        reasoning: { enabled: true, effort: 'high' },
+        effortMap: { high: 8192 },
+      }),
+    ).not.toThrow();
+  });
+
+  it('allows template-kwargs effort when the enabled format is none', () => {
+    expect(() =>
+      resolve({
+        effortWireFormat: 'template-kwargs',
+        enabledWireFormat: 'none',
+        reasoning: { enabled: true, effort: 'high' },
+      }),
+    ).not.toThrow();
+  });
+
+  it('allows conflicting selectors when enablement is absent', () => {
+    expect(() =>
+      resolve({
+        effortWireFormat: 'template-kwargs',
+        enabledWireFormat: 'openrouter',
+        reasoning: { effort: 'high' },
+      }),
+    ).not.toThrow();
+  });
+
+  it('allows conflicting selectors when effort is absent', () => {
+    expect(() =>
+      resolve({
+        effortWireFormat: 'anthropic-budget',
+        enabledWireFormat: 'openrouter',
+        reasoning: { enabled: true },
+        enabledMap: { true: false },
+      }),
+    ).not.toThrow();
+  });
+
+  it('allows conflicting selectors when effort is suppressed by reasoning-disabled', () => {
+    expect(() =>
+      resolve({
+        effortWireFormat: 'openrouter',
+        enabledWireFormat: 'thinking',
+        reasoning: { enabled: false, effort: 'high' },
+      }),
+    ).not.toThrow();
+  });
+
+  it('allows conflicting selectors when effort is unrepresentable', () => {
+    expect(() =>
+      resolve({
+        effortWireFormat: 'anthropic-budget',
+        enabledWireFormat: 'openrouter',
+        reasoning: { enabled: true, effort: 'high' },
+        enabledMap: { true: false },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/providers/src/reasoning/reasoning-config-resolver.ts
+++ b/packages/providers/src/reasoning/reasoning-config-resolver.ts
@@ -1,0 +1,498 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  ReasoningEffort,
+  ReasoningEffortMap,
+  ReasoningEffortWireFormat,
+  ReasoningEnabledMap,
+  ReasoningEnabledWireFormat,
+} from '@vybestack/llxprt-code-settings';
+
+export type NativeReasoningAdapter =
+  | 'openai-chat'
+  | 'openai-responses'
+  | 'anthropic'
+  | 'gemini';
+
+export type ResolvedReasoningEffortWireFormat = Exclude<
+  ReasoningEffortWireFormat,
+  'auto'
+>;
+
+export type ResolvedReasoningEnabledWireFormat = Exclude<
+  ReasoningEnabledWireFormat,
+  'auto'
+>;
+
+export interface GenericReasoningSettings {
+  readonly enabled?: boolean;
+  readonly effort?: ReasoningEffort;
+  readonly budgetTokens?: number;
+}
+
+export interface ReasoningResolverInput {
+  readonly nativeAdapter: NativeReasoningAdapter;
+  readonly chatBaseUrl?: string;
+  readonly reasoning: GenericReasoningSettings;
+  readonly effortWireFormat: ReasoningEffortWireFormat;
+  readonly enabledWireFormat: ReasoningEnabledWireFormat;
+  readonly effortMap?: ReasoningEffortMap;
+  readonly enabledMap?: ReasoningEnabledMap;
+}
+
+export type ReasoningResolution<T extends string | number | boolean> =
+  | { readonly state: 'emitted'; readonly value: T }
+  | { readonly state: 'represented'; readonly reason: 'effort-emitted' }
+  | { readonly state: 'absent' }
+  | {
+      readonly state: 'suppressed';
+      readonly reason:
+        | 'reasoning-disabled'
+        | 'effort-map-null'
+        | 'enabled-map-null'
+        | 'effort-format-none'
+        | 'enabled-format-none';
+    }
+  | {
+      readonly state: 'unrepresentable';
+      readonly reason:
+        | 'effort-format-undetected'
+        | 'enabled-format-undetected'
+        | 'numeric-effort-map-required'
+        | 'enabled-map-required';
+    };
+
+export interface ResolvedReasoningConfiguration {
+  readonly effortFormat: ResolvedReasoningEffortWireFormat;
+  readonly enabledFormat: ResolvedReasoningEnabledWireFormat;
+  readonly effort: ReasoningResolution<string | number>;
+  readonly enabled: ReasoningResolution<string | boolean>;
+}
+
+const EFFORT_KEYS: readonly ReasoningEffort[] = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+];
+
+const STRING_EFFORT_FORMATS: ReadonlySet<ResolvedReasoningEffortWireFormat> =
+  new Set([
+    'openai',
+    'openai-responses',
+    'anthropic',
+    'openrouter',
+    'gemini',
+    'template-kwargs',
+  ]);
+
+const EFFORT_FORMATS_BY_ADAPTER: ReadonlyMap<
+  NativeReasoningAdapter,
+  ReadonlySet<ReasoningEffortWireFormat>
+> = new Map<NativeReasoningAdapter, ReadonlySet<ReasoningEffortWireFormat>>([
+  [
+    'openai-chat',
+    new Set([
+      'auto',
+      'openai',
+      'openrouter',
+      'anthropic-budget',
+      'template-kwargs',
+      'none',
+    ]),
+  ],
+  ['openai-responses', new Set(['auto', 'openai-responses', 'none'])],
+  ['anthropic', new Set(['auto', 'anthropic', 'anthropic-budget', 'none'])],
+  ['gemini', new Set(['auto', 'gemini', 'none'])],
+]);
+
+const ENABLED_FORMATS_BY_ADAPTER: ReadonlyMap<
+  NativeReasoningAdapter,
+  ReadonlySet<ReasoningEnabledWireFormat>
+> = new Map<NativeReasoningAdapter, ReadonlySet<ReasoningEnabledWireFormat>>([
+  [
+    'openai-chat',
+    new Set([
+      'auto',
+      'openai',
+      'openrouter',
+      'thinking',
+      'template-kwargs',
+      'none',
+    ]),
+  ],
+  ['openai-responses', new Set(['auto', 'openai-responses', 'none'])],
+  ['anthropic', new Set(['auto', 'thinking', 'none'])],
+  ['gemini', new Set(['auto', 'gemini', 'none'])],
+]);
+
+export function resolveReasoningConfiguration(
+  input: ReasoningResolverInput,
+): ResolvedReasoningConfiguration {
+  validateSelectorCompatibility(input);
+
+  const effortFormat = resolveEffortFormat(input);
+  const enabledFormat = resolveEnabledFormat(input);
+
+  validateEffortMap(effortFormat, input.effortMap);
+  validateEnabledMap(enabledFormat, input.enabledMap);
+
+  const effort = resolveEffort(input, effortFormat);
+  const enabled = resolveEnabled(input, enabledFormat, effort);
+  validateEmittedChatFormatPair(
+    input,
+    effortFormat,
+    enabledFormat,
+    effort,
+    enabled,
+  );
+  return { effortFormat, enabledFormat, effort, enabled };
+}
+
+/**
+ * Format pairs whose simultaneous emission is a coordinated wire form: one
+ * control per request body, with both dimensions landing in it together
+ * (Z.AI/DeepSeek effort + thinking type, vLLM template kwargs, OpenRouter
+ * siblings). Any other pair that emits both dimensions would fan out into
+ * two unrelated reasoning controls and is rejected before request
+ * construction (issue #3255).
+ */
+const COORDINATED_CHAT_FORMAT_PAIRS: ReadonlySet<string> = new Set([
+  'openai|openai',
+  'openai|thinking',
+  'anthropic-budget|thinking',
+  'openrouter|openrouter',
+  'template-kwargs|template-kwargs',
+]);
+
+function validateEmittedChatFormatPair(
+  input: ReasoningResolverInput,
+  effortFormat: ResolvedReasoningEffortWireFormat,
+  enabledFormat: ResolvedReasoningEnabledWireFormat,
+  effort: ReasoningResolution<string | number>,
+  enabled: ReasoningResolution<string | boolean>,
+): void {
+  if (input.nativeAdapter !== 'openai-chat') {
+    return;
+  }
+  if (effort.state !== 'emitted' || enabled.state !== 'emitted') {
+    return;
+  }
+  if (!COORDINATED_CHAT_FORMAT_PAIRS.has(`${effortFormat}|${enabledFormat}`)) {
+    throw new Error(
+      `effort format '${effortFormat}' and enabled format '${enabledFormat}' emit conflicting OpenAI Chat reasoning representations`,
+    );
+  }
+}
+
+function validateSelectorCompatibility(input: ReasoningResolverInput): void {
+  if (
+    !adapterFormats(EFFORT_FORMATS_BY_ADAPTER, input.nativeAdapter).has(
+      input.effortWireFormat,
+    )
+  ) {
+    throw new Error(
+      `effort wire format '${input.effortWireFormat}' is incompatible with the ${input.nativeAdapter} adapter`,
+    );
+  }
+
+  if (
+    !adapterFormats(ENABLED_FORMATS_BY_ADAPTER, input.nativeAdapter).has(
+      input.enabledWireFormat,
+    )
+  ) {
+    throw new Error(
+      `enabled wire format '${input.enabledWireFormat}' is incompatible with the ${input.nativeAdapter} adapter`,
+    );
+  }
+}
+
+function adapterFormats<T extends string>(
+  formats: ReadonlyMap<NativeReasoningAdapter, ReadonlySet<T>>,
+  adapter: NativeReasoningAdapter,
+): ReadonlySet<T> {
+  const formatsForAdapter = formats.get(adapter);
+  if (formatsForAdapter === undefined) {
+    throw new Error('Unsupported native reasoning adapter');
+  }
+  return formatsForAdapter;
+}
+
+function resolveEffortFormat(
+  input: ReasoningResolverInput,
+): ResolvedReasoningEffortWireFormat {
+  if (input.effortWireFormat !== 'auto') {
+    return input.effortWireFormat;
+  }
+
+  switch (input.nativeAdapter) {
+    case 'openai-chat':
+      return resolveChatAutoFormats(input.chatBaseUrl).effortFormat;
+    case 'openai-responses':
+      return 'openai-responses';
+    case 'anthropic':
+      return 'anthropic';
+    case 'gemini':
+      return 'gemini';
+    default:
+      throw new Error('Unsupported native reasoning adapter');
+  }
+}
+
+function resolveEnabledFormat(
+  input: ReasoningResolverInput,
+): ResolvedReasoningEnabledWireFormat {
+  if (input.enabledWireFormat !== 'auto') {
+    return input.enabledWireFormat;
+  }
+
+  switch (input.nativeAdapter) {
+    case 'openai-chat':
+      return resolveChatAutoFormats(input.chatBaseUrl).enabledFormat;
+    case 'openai-responses':
+      return 'none';
+    case 'anthropic':
+      return 'thinking';
+    case 'gemini':
+      return 'gemini';
+    default:
+      throw new Error('Unsupported native reasoning adapter');
+  }
+}
+
+function resolveChatAutoFormats(baseUrl: string | undefined): {
+  readonly effortFormat: ResolvedReasoningEffortWireFormat;
+  readonly enabledFormat: ResolvedReasoningEnabledWireFormat;
+} {
+  const hostname = parseHostname(baseUrl);
+  if (hostname === undefined) {
+    return { effortFormat: 'none', enabledFormat: 'none' };
+  }
+
+  if (matchesHostSuffix(hostname, 'openrouter.ai')) {
+    return { effortFormat: 'openrouter', enabledFormat: 'openrouter' };
+  }
+
+  if (
+    matchesHostSuffix(hostname, 'z.ai') ||
+    matchesHostSuffix(hostname, 'bigmodel.cn')
+  ) {
+    return { effortFormat: 'openai', enabledFormat: 'thinking' };
+  }
+
+  if (matchesHostSuffix(hostname, 'api.openai.com')) {
+    return { effortFormat: 'openai', enabledFormat: 'none' };
+  }
+
+  return { effortFormat: 'none', enabledFormat: 'none' };
+}
+
+function parseHostname(baseUrl: string | undefined): string | undefined {
+  if (baseUrl === undefined || baseUrl.trim() === '') {
+    return undefined;
+  }
+
+  try {
+    const hostname = new URL(baseUrl.trim()).hostname.toLowerCase();
+    return hostname === '' ? undefined : hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+function matchesHostSuffix(hostname: string, suffix: string): boolean {
+  return hostname === suffix || hostname.endsWith(`.${suffix}`);
+}
+
+function validateEffortMap(
+  format: ResolvedReasoningEffortWireFormat,
+  effortMap: ReasoningEffortMap | undefined,
+): void {
+  if (effortMap === undefined || format === 'none') {
+    return;
+  }
+
+  for (const effort of EFFORT_KEYS) {
+    const mappedValue = effortMap[effort];
+    if (mappedValue === undefined || mappedValue === null) {
+      continue;
+    }
+
+    if (format === 'anthropic-budget' && typeof mappedValue !== 'number') {
+      throw new Error(
+        `reasoning.effortMap.${effort} must be a number for anthropic-budget`,
+      );
+    }
+
+    if (STRING_EFFORT_FORMATS.has(format) && typeof mappedValue !== 'string') {
+      throw new Error(
+        `reasoning.effortMap.${effort} must be a string for ${format}`,
+      );
+    }
+  }
+}
+
+function validateEnabledMap(
+  format: ResolvedReasoningEnabledWireFormat,
+  enabledMap: ReasoningEnabledMap | undefined,
+): void {
+  if (enabledMap === undefined || format === 'none') {
+    return;
+  }
+
+  validateEnabledMapEntry(format, 'true', enabledMap.true);
+  validateEnabledMapEntry(format, 'false', enabledMap.false);
+}
+
+function validateEnabledMapEntry(
+  format: ResolvedReasoningEnabledWireFormat,
+  key: 'true' | 'false',
+  mappedValue: string | boolean | null | undefined,
+): void {
+  if (mappedValue === undefined || mappedValue === null) {
+    return;
+  }
+
+  if (!isCompatibleEnabledMapValue(format, mappedValue)) {
+    throw new Error(
+      `reasoning.enabledMap.${key} has an incompatible value for ${format}`,
+    );
+  }
+}
+
+function isCompatibleEnabledMapValue(
+  format: ResolvedReasoningEnabledWireFormat,
+  mappedValue: string | boolean,
+): boolean {
+  switch (format) {
+    case 'openai':
+    case 'openai-responses':
+    case 'thinking':
+      return typeof mappedValue === 'string';
+    case 'gemini':
+      return isLevelLiteralOrBoolean(mappedValue);
+    default:
+      return typeof mappedValue === 'boolean';
+  }
+}
+
+function isLevelLiteralOrBoolean(value: string | boolean): boolean {
+  if (typeof value === 'boolean') {
+    return true;
+  }
+  return value === 'LOW' || value === 'MEDIUM' || value === 'HIGH';
+}
+
+function resolveEffort(
+  input: ReasoningResolverInput,
+  format: ResolvedReasoningEffortWireFormat,
+): ReasoningResolution<string | number> {
+  const { effort, budgetTokens, enabled } = input.reasoning;
+  const hasDirectBudget =
+    format === 'anthropic-budget' && budgetTokens !== undefined;
+
+  // A direct budget wins over any effort-derived value, but disablement
+  // still suppresses it.
+  if (hasDirectBudget) {
+    if (enabled === false) {
+      return { state: 'suppressed', reason: 'reasoning-disabled' };
+    }
+    return { state: 'emitted', value: budgetTokens };
+  }
+
+  if (effort === undefined) {
+    return { state: 'absent' };
+  }
+
+  if (enabled === false) {
+    return { state: 'suppressed', reason: 'reasoning-disabled' };
+  }
+
+  if (format === 'none') {
+    return input.effortWireFormat === 'none'
+      ? { state: 'suppressed', reason: 'effort-format-none' }
+      : { state: 'unrepresentable', reason: 'effort-format-undetected' };
+  }
+
+  const mappedValue = input.effortMap?.[effort];
+  if (mappedValue === null) {
+    return { state: 'suppressed', reason: 'effort-map-null' };
+  }
+
+  if (format === 'anthropic-budget') {
+    return typeof mappedValue === 'number'
+      ? { state: 'emitted', value: mappedValue }
+      : { state: 'unrepresentable', reason: 'numeric-effort-map-required' };
+  }
+
+  return {
+    state: 'emitted',
+    value: typeof mappedValue === 'string' ? mappedValue : effort,
+  };
+}
+
+function resolveEnabled(
+  input: ReasoningResolverInput,
+  format: ResolvedReasoningEnabledWireFormat,
+  effort: ReasoningResolution<string | number>,
+): ReasoningResolution<string | boolean> {
+  const { enabled } = input.reasoning;
+  if (enabled === undefined) {
+    return { state: 'absent' };
+  }
+
+  if (format === 'none') {
+    if (enabled && effort.state === 'emitted') {
+      return { state: 'represented', reason: 'effort-emitted' };
+    }
+    return input.enabledWireFormat === 'none'
+      ? { state: 'suppressed', reason: 'enabled-format-none' }
+      : { state: 'unrepresentable', reason: 'enabled-format-undetected' };
+  }
+
+  const mappedValue = input.enabledMap?.[enabled ? 'true' : 'false'];
+  if (mappedValue === null) {
+    return { state: 'suppressed', reason: 'enabled-map-null' };
+  }
+
+  // Enabled=true is represented by an emitted effort into the same
+  // effective control (reasoning_effort / Responses reasoning.effort) even
+  // when an enabled map entry exists: the explicit effort wins rather than
+  // being overwritten by the map value (issue #3255).
+  if (
+    enabled &&
+    (format === 'openai' || format === 'openai-responses') &&
+    effort.state === 'emitted'
+  ) {
+    return { state: 'represented', reason: 'effort-emitted' };
+  }
+
+  if (mappedValue !== undefined) {
+    return { state: 'emitted', value: mappedValue };
+  }
+
+  switch (format) {
+    case 'openrouter':
+      return enabled && effort.state === 'emitted'
+        ? { state: 'represented', reason: 'effort-emitted' }
+        : { state: 'emitted', value: enabled };
+    case 'gemini':
+    case 'template-kwargs':
+      return { state: 'emitted', value: enabled };
+    case 'thinking':
+      return { state: 'emitted', value: enabled ? 'enabled' : 'disabled' };
+    case 'openai':
+    case 'openai-responses':
+      return enabled && effort.state === 'emitted'
+        ? { state: 'represented', reason: 'effort-emitted' }
+        : { state: 'unrepresentable', reason: 'enabled-map-required' };
+    default:
+      throw new Error('Unsupported enabled reasoning format');
+  }
+}

--- a/packages/providers/src/runtime/modelDefaultOwnership.ts
+++ b/packages/providers/src/runtime/modelDefaultOwnership.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Internal provenance for ephemeral keys currently owned by provider/model
+ * default application (issue #3255).
+ *
+ * Ownership, not value equality or object identity, decides whether later
+ * default application may replace, restore, or clear a key. Alias config
+ * files are reparsed into fresh objects on every load, so object identity
+ * cannot classify a stored map as default-owned, and an explicit session or
+ * profile value can equal a default, so equality cannot classify it as
+ * user-owned.
+ *
+ * Three ownership layers are tracked. Provider-owned entries record the
+ * alias ephemeral defaults applied on provider switch and are restored when
+ * a matching model default goes away (provider alias default > auto).
+ * Model-owned keys record the model defaults currently in force and are
+ * replaced wholesale (model default > provider alias default). User-owned
+ * keys were written through the session/profile setter: default application
+ * never manages them again until the write is cleared, which releases
+ * ownership. A provider switch clears default-owned keys wholesale, so the
+ * positive user-owned record is what lets explicit values survive it.
+ */
+
+interface EphemeralDefaultOwnership {
+  providerOwned: ReadonlyMap<string, unknown>;
+  modelOwned: ReadonlySet<string>;
+  userOwned: ReadonlySet<string>;
+}
+
+const ownershipByConfig = new WeakMap<object, EphemeralDefaultOwnership>();
+
+const EMPTY_PROVIDER_OWNED: ReadonlyMap<string, unknown> = new Map();
+const EMPTY_MODEL_OWNED: ReadonlySet<string> = new Set<string>();
+const EMPTY_USER_OWNED: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Replace the provider-owned alias defaults for this config and reset model
+ * ownership. Called when a provider switch applies a fresh alias surface, so
+ * ownership left over from the previous provider is dropped even when the
+ * new alias applies nothing. User-owned keys survive the replacement: an
+ * explicit session or profile value outlives any provider switch.
+ */
+export function recordProviderDefaultOwnedEntries(
+  config: object,
+  entries: Iterable<readonly [string, unknown]>,
+): void {
+  ownershipByConfig.set(config, {
+    providerOwned: new Map(entries),
+    modelOwned: new Set<string>(),
+    userOwned: ownershipByConfig.get(config)?.userOwned ?? EMPTY_USER_OWNED,
+  });
+}
+
+/**
+ * Replace the set of keys model default application owns for this config,
+ * preserving the provider-owned alias defaults and user-owned keys recorded
+ * alongside them.
+ */
+export function recordModelDefaultOwnedKeys(
+  config: object,
+  keys: Iterable<string>,
+): void {
+  const ownership = ownershipByConfig.get(config);
+  ownershipByConfig.set(config, {
+    providerOwned: ownership?.providerOwned ?? EMPTY_PROVIDER_OWNED,
+    modelOwned: new Set(keys),
+    userOwned: ownership?.userOwned ?? EMPTY_USER_OWNED,
+  });
+}
+
+/** Provider alias default values default application may restore. */
+export function getProviderDefaultOwnedEntries(
+  config: object,
+): ReadonlyMap<string, unknown> {
+  return ownershipByConfig.get(config)?.providerOwned ?? EMPTY_PROVIDER_OWNED;
+}
+
+/** Keys model default application currently owns for this config. */
+export function getModelDefaultOwnedKeys(config: object): ReadonlySet<string> {
+  return ownershipByConfig.get(config)?.modelOwned ?? EMPTY_MODEL_OWNED;
+}
+
+/** Keys written through the session/profile path that defaults must keep. */
+export function getUserOwnedEphemeralKeys(config: object): ReadonlySet<string> {
+  return ownershipByConfig.get(config)?.userOwned ?? EMPTY_USER_OWNED;
+}
+
+/**
+ * Issue #3255 reasoning settings that survive a provider switch while a
+ * session/profile write owns them. Explicit values must not be overwritten
+ * by the target provider's alias or model defaults; default-owned values
+ * still clear or change.
+ */
+const USER_OWNED_SWITCH_PRESERVED_KEYS: ReadonlySet<string> = new Set([
+  'reasoning.effortWireFormat',
+  'reasoning.enabledWireFormat',
+  'reasoning.effortMap',
+  'reasoning.enabledMap',
+]);
+
+/**
+ * Issue #3255 alias ephemeral keys whose values are objects: the registered
+ * reasoning maps. Shared with provider switch so the alias surface and the
+ * ownership record cannot drift apart on which keys carry maps.
+ */
+export const REASONING_OBJECT_VALUED_EPHEMERAL_KEYS: ReadonlySet<string> =
+  new Set(['reasoning.effortMap', 'reasoning.enabledMap']);
+
+/** True when a user write owns this issue #3255 reasoning setting. */
+export function isUserOwnedReasoningSetting(
+  config: object,
+  key: string,
+): boolean {
+  return (
+    USER_OWNED_SWITCH_PRESERVED_KEYS.has(key) &&
+    getUserOwnedEphemeralKeys(config).has(key)
+  );
+}
+
+/**
+ * Mark a key user-owned so default application no longer manages it. The
+ * record is created when no default has been applied yet: an explicit value
+ * written before any default owns the key just the same.
+ */
+export function markEphemeralUserOwned(config: object, key: string): void {
+  const ownership = ownershipByConfig.get(config);
+  if (ownership === undefined) {
+    ownershipByConfig.set(config, {
+      providerOwned: EMPTY_PROVIDER_OWNED,
+      modelOwned: EMPTY_MODEL_OWNED,
+      userOwned: new Set([key]),
+    });
+    return;
+  }
+  const modelOwned = new Set(ownership.modelOwned);
+  modelOwned.delete(key);
+  const providerOwned = new Map(ownership.providerOwned);
+  providerOwned.delete(key);
+  const userOwned = new Set(ownership.userOwned);
+  userOwned.add(key);
+  ownershipByConfig.set(config, { providerOwned, modelOwned, userOwned });
+}
+
+/**
+ * Release every ownership layer for a key. Clearing an explicit setting must
+ * not leave permanent user ownership: default application manages the key
+ * again from the next switch or model change. A key can be owned by several
+ * layers at once (an alias default behind a model default), so every layer
+ * is cleared unconditionally; a partial release would resurrect stale
+ * defaults across later model or provider transitions.
+ */
+export function releaseEphemeralOwnership(config: object, key: string): void {
+  const ownership = ownershipByConfig.get(config);
+  if (ownership === undefined) {
+    return;
+  }
+  const modelOwned = new Set(ownership.modelOwned);
+  const providerOwned = new Map(ownership.providerOwned);
+  const userOwned = new Set(ownership.userOwned);
+  modelOwned.delete(key);
+  providerOwned.delete(key);
+  userOwned.delete(key);
+  ownershipByConfig.set(config, { providerOwned, modelOwned, userOwned });
+}

--- a/packages/providers/src/runtime/profile-persistence.issue3255.test.ts
+++ b/packages/providers/src/runtime/profile-persistence.issue3255.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ProfileManager,
+  type ProfileEphemeralSettings,
+} from '@vybestack/llxprt-code-settings';
+
+const runtimeEphemerals = {
+  'reasoning.effortWireFormat': 'anthropic-budget',
+  'reasoning.enabledWireFormat': 'thinking',
+  'reasoning.effortMap': { low: 2048, high: 8192, max: null },
+  'reasoning.enabledMap': { true: 'enabled', false: null },
+} satisfies ProfileEphemeralSettings;
+
+void vi.mock('./runtimeAccessors.js', () => ({
+  getCliRuntimeServices: () => ({
+    config: {
+      getEphemeralSettings: () => runtimeEphemerals,
+    },
+    settingsService: {},
+    providerManager: {},
+  }),
+  maybeGetCliOAuthManager: () => null,
+  getActiveModelName: () => 'reasoning-model',
+  getActiveModelParams: () => ({}),
+  _internal: {
+    resolveActiveProviderName: () => 'openai',
+    getProviderSettingsSnapshot: () => ({ model: 'reasoning-model' }),
+    getActiveProviderOrThrow: () => {
+      throw new Error('Not used while building a profile snapshot');
+    },
+    extractModelParams: () => ({}),
+  },
+}));
+
+void vi.mock('./profileApplication.js', () => ({
+  applyProfileWithGuards: vi.fn(),
+}));
+
+const { buildRuntimeProfileSnapshot } = await import('./profileSnapshot.js');
+
+describe('reasoning wire profile persistence', () => {
+  let profilesDir = '';
+
+  beforeEach(async () => {
+    profilesDir = await mkdtemp(join(tmpdir(), 'llxprt-reasoning-profile-'));
+  });
+
+  afterEach(async () => {
+    await rm(profilesDir, { recursive: true, force: true });
+  });
+
+  it('saves and loads the registry-driven runtime snapshot without changing maps', async () => {
+    const profileManager = new ProfileManager(profilesDir);
+    const snapshot = buildRuntimeProfileSnapshot();
+
+    await profileManager.saveProfile('reasoning-wire', snapshot);
+    const loaded = await profileManager.loadProfile('reasoning-wire');
+
+    expect(loaded.ephemeralSettings).toMatchObject(runtimeEphemerals);
+  });
+});

--- a/packages/providers/src/runtime/profileApplication.ts
+++ b/packages/providers/src/runtime/profileApplication.ts
@@ -696,7 +696,7 @@ async function switchProviderForProfile(targetProviderName: string): Promise<{
 }> {
   const providerSwitch = await switchActiveProvider(targetProviderName, {
     autoOAuth: false,
-    skipModelDefaults: true,
+    skipModelDefaults: false,
     preserveEphemerals: PRESERVED_PROFILE_EPHEMERALS,
   });
   return {

--- a/packages/providers/src/runtime/profileSnapshot.test.ts
+++ b/packages/providers/src/runtime/profileSnapshot.test.ts
@@ -307,7 +307,7 @@ describe('buildRuntimeProfileSnapshot', () => {
     vi.clearAllMocks();
   });
 
-  it('excludes internal settings from persisted ephemeralSettings', () => {
+  it('includes registered reasoning wire settings while excluding internal settings', () => {
     (
       getCliRuntimeServices as Mock<typeof getCliRuntimeServices>
     ).mockReturnValue({
@@ -317,6 +317,10 @@ describe('buildRuntimeProfileSnapshot', () => {
           currentProfile: 'glm',
           tools: { disabled: ['read_file'] },
           'context-limit': 190000,
+          'reasoning.effortWireFormat': 'openai-responses',
+          'reasoning.enabledWireFormat': 'openrouter',
+          'reasoning.effortMap': { minimal: 'none', high: 'high' },
+          'reasoning.enabledMap': { false: null },
         }),
       },
       settingsService: { setCurrentProfileName: vi.fn() },
@@ -339,6 +343,10 @@ describe('buildRuntimeProfileSnapshot', () => {
 
     expect(snapshot.ephemeralSettings).toMatchObject({
       'context-limit': 190000,
+      'reasoning.effortWireFormat': 'openai-responses',
+      'reasoning.enabledWireFormat': 'openrouter',
+      'reasoning.effortMap': { minimal: 'none', high: 'high' },
+      'reasoning.enabledMap': { false: null },
     });
     expect(snapshot.ephemeralSettings).not.toHaveProperty('activeProvider');
     expect(snapshot.ephemeralSettings).not.toHaveProperty('currentProfile');

--- a/packages/providers/src/runtime/provider-alias-defaults.modeldefaults.test.ts
+++ b/packages/providers/src/runtime/provider-alias-defaults.modeldefaults.test.ts
@@ -6,6 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
+import type { Profile } from '@vybestack/llxprt-code-settings';
 
 const realProviderAliasesModule = {
   ...(await import('../composition/providerAliases.js')),
@@ -162,6 +163,7 @@ const providers: Record<string, StubProviderInstance> = {
   gemini: new StubProvider('gemini'),
   anthropic: new StubProvider('anthropic'),
   openrouter: new StubProvider('openrouter'),
+  zai: new StubProvider('zai'),
 };
 
 let activeProviderName = 'openai';
@@ -237,9 +239,11 @@ void vi.mock('@vybestack/llxprt-code-core', () => {
 const {
   switchActiveProvider,
   setActiveModel,
+  setEphemeralSetting,
   setCliRuntimeContext,
   registerCliProviderInfrastructure,
 } = await import('./runtimeSettings.js');
+const { applyProfileWithGuards } = await import('./profileApplication.js');
 
 const mockOAuthManager = {
   isOAuthEnabled: vi.fn(() => false),
@@ -293,6 +297,87 @@ function pushAnthropicAlias(overrides?: {
       ],
     },
   });
+}
+
+/**
+ * Mirrors the shipped zai.config modelDefaults: a broad glm-5 rule plus exact
+ * GLM-5.2 and GLM-5.3 overrides with different reasoning maps.
+ */
+const ZAI_MODEL_DEFAULTS = [
+  {
+    pattern: 'glm-5',
+    ephemeralSettings: {
+      'reasoning.enabled': true,
+      'reasoning.effort': 'high',
+    },
+  },
+  {
+    pattern: '^glm-5\\.2$',
+    ephemeralSettings: {
+      'reasoning.effortWireFormat': 'anthropic',
+      'reasoning.enabledWireFormat': 'thinking',
+      'reasoning.effortMap': {
+        minimal: 'minimal',
+        low: 'high',
+        medium: 'high',
+        high: 'high',
+        xhigh: 'max',
+        max: 'max',
+      },
+      'reasoning.enabledMap': {
+        true: 'enabled',
+        false: 'disabled',
+      },
+      'context-limit': 1000000,
+      maxOutputTokens: 128000,
+    },
+  },
+  {
+    pattern: '^glm-5\\.3$',
+    ephemeralSettings: {
+      'reasoning.effortWireFormat': 'anthropic',
+      'reasoning.enabledWireFormat': 'thinking',
+      'reasoning.effortMap': {
+        minimal: 'low',
+        low: 'low',
+        medium: 'high',
+        high: 'high',
+        xhigh: 'max',
+        max: 'max',
+      },
+      'reasoning.enabledMap': {
+        true: 'enabled',
+        false: null,
+      },
+    },
+  },
+];
+
+function pushZaiAlias(defaultModel = 'glm-5.2'): void {
+  aliasEntries.push({
+    alias: 'zai',
+    source: 'builtin',
+    filePath: '/fake/zai.config',
+    config: {
+      baseProvider: 'anthropic',
+      defaultModel,
+      ephemeralSettings: {},
+      modelDefaults: structuredClone(ZAI_MODEL_DEFAULTS),
+    },
+  });
+}
+
+/**
+ * Simulate production alias reloading: every loadProviderAliasEntries() call
+ * reparses the alias config files, so rule objects (and nested maps) get fresh
+ * identities on each load.
+ */
+function reloadZaiAlias(): void {
+  const index = aliasEntries.findIndex((entry) => entry.alias === 'zai');
+  if (index === -1) {
+    throw new Error('zai alias entry was not pushed before reload');
+  }
+  aliasEntries[index] = structuredClone(aliasEntries[index]);
 }
 
 describe('Provider alias defaults (model + ephemerals)', () => {
@@ -406,8 +491,9 @@ describe('Provider alias defaults (model + ephemerals)', () => {
 
       await setActiveModel('claude-sonnet-4-5-20250929');
 
-      // reasoning.effort was in old defaults (opus) but NOT in new defaults (sonnet).
-      // Current value "high" matches old default "high", so it's cleared.
+      // reasoning.effort was model-owned by the opus rule, the sonnet rule
+      // does not supply it, and no provider alias default exists for it, so
+      // leaving the opus rule clears the key.
       expect(
         stubConfig.getEphemeralSetting('reasoning.effort'),
       ).toBeUndefined();
@@ -416,12 +502,12 @@ describe('Provider alias defaults (model + ephemerals)', () => {
     it('user-set reasoning.effort="low" is NOT cleared when switching from opus to sonnet', async () => {
       await setupAnthropicProvider('claude-opus-4-6');
 
-      // User manually overrides reasoning.effort to "low"
-      stubConfig.setEphemeralSetting('reasoning.effort', 'low');
+      // User manually overrides reasoning.effort to "low" via the session setter
+      setEphemeralSetting('reasoning.effort', 'low');
 
       await setActiveModel('claude-sonnet-4-5-20250929');
 
-      // Current value "low" differs from old default "high", so it's user-owned — not cleared
+      // The explicit session value is user-owned and survives the model change
       expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('low');
     });
 
@@ -429,11 +515,11 @@ describe('Provider alias defaults (model + ephemerals)', () => {
       await setupAnthropicProvider('claude-sonnet-4-5-20250929');
 
       // User sets a custom value for a key that model defaults would set
-      stubConfig.setEphemeralSetting('reasoning.enabled', false);
+      setEphemeralSetting('reasoning.enabled', false);
 
       await setActiveModel('claude-opus-4-6');
 
-      // Current value (false) differs from old default (true), so treated as user-owned
+      // The explicit session value is user-owned and survives the model change
       expect(stubConfig.getEphemeralSetting('reasoning.enabled')).toBe(false);
     });
 
@@ -486,27 +572,25 @@ describe('Provider alias defaults (model + ephemerals)', () => {
       expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('high');
     });
 
-    // --- Ambiguous edge case (documenting the policy) ---
+    // --- Ambiguous edge case (corrected ownership semantics) ---
 
-    it('clears value matching old default even if user-set (stateless policy trade-off)', async () => {
+    it('keeps a session-set value equal to the old default when the model changes', async () => {
       await setupAnthropicProvider('claude-opus-4-6');
 
-      // User explicitly sets reasoning.effort to "high" (same as opus default).
-      // The stateless recomputation cannot distinguish this from model-defaulted.
-      stubConfig.setEphemeralSetting('reasoning.effort', 'high');
+      // User explicitly sets reasoning.effort to "high" (same value as the
+      // opus default) through the session setter. Explicit ownership, not
+      // value equality, decides whether the default application may change it.
+      setEphemeralSetting('reasoning.effort', 'high');
 
       await setActiveModel('claude-sonnet-4-5-20250929');
 
-      // Per stateless policy: current value "high" === old default "high",
-      // so it IS cleared even though the user set it explicitly.
-      expect(
-        stubConfig.getEphemeralSetting('reasoning.effort'),
-      ).toBeUndefined();
+      // The explicit session value is user-owned and survives the model change
+      expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('high');
     });
 
     // --- Alias-set value vs model-default edge case ---
 
-    it('clears alias-set value that matches model default on switch to non-matching model', async () => {
+    it('restores the provider alias default when leaving a matching model rule', async () => {
       // Alias ephemeralSettings sets reasoning.enabled: true at provider level.
       // Model default also sets reasoning.enabled: true.
       pushAnthropicAlias({
@@ -524,10 +608,9 @@ describe('Provider alias defaults (model + ephemerals)', () => {
       // Switch to a non-Claude model (no modelDefaults entries match)
       await setActiveModel('gpt-4o');
 
-      // reasoning.enabled IS cleared: current value (true) matches old model default (true)
-      expect(
-        stubConfig.getEphemeralSetting('reasoning.enabled'),
-      ).toBeUndefined();
+      // The model rule stopped matching; the key falls back to the provider
+      // alias default instead of being cleared (provider default > auto).
+      expect(stubConfig.getEphemeralSetting('reasoning.enabled')).toBe(true);
     });
 
     // --- Transition matrix ---
@@ -537,7 +620,8 @@ describe('Provider alias defaults (model + ephemerals)', () => {
 
       await setActiveModel('claude-sonnet-4-5-20250929');
 
-      // reasoning.effort: was in opus defaults, not in sonnet defaults, current matches old → cleared
+      // reasoning.effort: model-owned by opus, absent from sonnet, no provider
+      // alias default to restore, so it is cleared
       expect(
         stubConfig.getEphemeralSetting('reasoning.effort'),
       ).toBeUndefined();
@@ -582,7 +666,8 @@ describe('Provider alias defaults (model + ephemerals)', () => {
 
       await setActiveModel('gpt-4o');
 
-      // Old defaults exist, new defaults are {} — all cleared since current matches old
+      // Old defaults exist, new defaults are {}, so every key is model-owned
+      // with no provider alias default to restore and is therefore cleared
       expect(
         stubConfig.getEphemeralSetting('reasoning.enabled'),
       ).toBeUndefined();
@@ -630,12 +715,12 @@ describe('Provider alias defaults (model + ephemerals)', () => {
       await setupAnthropicProvider('claude-opus-4-6');
 
       // Simulate --set reasoning.effort=low (user explicitly overrides)
-      stubConfig.setEphemeralSetting('reasoning.effort', 'low');
+      setEphemeralSetting('reasoning.effort', 'low');
 
       // setActiveModel for the same model
       await setActiveModel('claude-opus-4-6');
 
-      // Current value "low" differs from old default "high" → user-owned, not overwritten
+      // The explicit session value is user-owned and is not overwritten
       expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('low');
     });
 
@@ -646,12 +731,12 @@ describe('Provider alias defaults (model + ephemerals)', () => {
       expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('high');
 
       // User sets low
-      stubConfig.setEphemeralSetting('reasoning.effort', 'low');
+      setEphemeralSetting('reasoning.effort', 'low');
 
       // /model opus again
       await setActiveModel('claude-opus-4-6');
 
-      // Current value "low" differs from old default "high" → user-owned, stays
+      // The explicit session value is user-owned and stays
       expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('low');
     });
 
@@ -664,13 +749,12 @@ describe('Provider alias defaults (model + ephemerals)', () => {
       ).toBeUndefined();
 
       // User sets reasoning.effort=low
-      stubConfig.setEphemeralSetting('reasoning.effort', 'low');
+      setEphemeralSetting('reasoning.effort', 'low');
 
       // /model opus
       await setActiveModel('claude-opus-4-6');
 
-      // Old model (sonnet) has no effort default, so current "low" doesn't match
-      // any old default → treated as user-owned → not overwritten by opus default "high"
+      // The explicit session value is user-owned and stays
       expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('low');
     });
 
@@ -684,15 +768,252 @@ describe('Provider alias defaults (model + ephemerals)', () => {
       activeProviderName = 'anthropic';
 
       // Then --set is applied after profile load
-      stubConfig.setEphemeralSetting('reasoning.effort', 'low');
+      setEphemeralSetting('reasoning.effort', 'low');
       expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('low');
 
       // Then user changes model via /model
       await setActiveModel('claude-opus-4-6');
 
-      // Profile load skipped model defaults, so old model has no computed defaults.
-      // Current "low" doesn't match any old default → user-owned → stays
+      // The explicit session value is user-owned and stays
       expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('low');
+    });
+  });
+
+  describe('reasoning wire setting precedence', () => {
+    it('resolves profile values over shipped Opus 5 alias defaults', async () => {
+      const builtinAnthropic = realProviderAliasesModule
+        .loadProviderAliasEntries()
+        .find(
+          (entry) => entry.source === 'builtin' && entry.alias === 'anthropic',
+        );
+      if (!builtinAnthropic) {
+        throw new Error('Builtin anthropic alias entry not found');
+      }
+      aliasEntries.push({ ...builtinAnthropic });
+      const profile: Profile = {
+        version: 1,
+        provider: 'anthropic',
+        model: 'claude-opus-5',
+        modelParams: {},
+        ephemeralSettings: {
+          'reasoning.effortWireFormat': 'openai',
+          'reasoning.enabledWireFormat': 'openrouter',
+          'reasoning.effortMap': { low: 'profile-low' },
+          'reasoning.enabledMap': { false: null },
+        },
+      };
+
+      await applyProfileWithGuards(profile, {
+        profileName: 'reasoning-profile',
+      });
+
+      expect(stubConfig.getEphemeralSettings()).toMatchObject({
+        'reasoning.effortWireFormat': 'openai',
+        'reasoning.enabledWireFormat': 'openrouter',
+        'reasoning.effortMap': { low: 'profile-low' },
+        'reasoning.enabledMap': { false: null },
+      });
+    });
+
+    it('applies target model defaults during profile application without leaking old provider values', async () => {
+      stubConfig.setEphemeralSetting(
+        'reasoning.effortWireFormat',
+        'openai-responses',
+      );
+      stubConfig.setEphemeralSetting('reasoning.enabledWireFormat', 'thinking');
+      stubConfig.setEphemeralSetting('reasoning.effortMap', {
+        low: 'old-provider-low',
+      });
+      stubConfig.setEphemeralSetting('reasoning.enabledMap', { false: null });
+      pushAnthropicAlias({
+        ephemeralSettings: {
+          'reasoning.effortWireFormat': 'openrouter',
+          'reasoning.enabledWireFormat': 'openrouter',
+        },
+        modelDefaults: [
+          {
+            pattern: 'claude-opus-4-6',
+            ephemeralSettings: {
+              'reasoning.effortWireFormat': 'anthropic',
+              'reasoning.effortMap': { high: 'model-high' },
+            },
+          },
+        ],
+      });
+      const profile: Profile = {
+        version: 1,
+        provider: 'anthropic',
+        model: 'claude-opus-4-6',
+        modelParams: {},
+        ephemeralSettings: {},
+      };
+
+      await applyProfileWithGuards(profile, {
+        profileName: 'defaulted-profile',
+      });
+
+      expect(stubConfig.getEphemeralSettings()).toMatchObject({
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.enabledWireFormat': 'openrouter',
+        'reasoning.effortMap': { high: 'model-high' },
+      });
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.enabledMap'),
+      ).toBeUndefined();
+    });
+
+    it('clears alias and model defaults when switching to another provider', async () => {
+      pushAnthropicAlias({
+        ephemeralSettings: {
+          'reasoning.effortWireFormat': 'openrouter',
+          'reasoning.enabledWireFormat': 'openrouter',
+        },
+        modelDefaults: [
+          {
+            pattern: 'claude-opus-4-6',
+            ephemeralSettings: {
+              'reasoning.effortWireFormat': 'anthropic',
+              'reasoning.effortMap': { high: 'model-high' },
+              'reasoning.enabledMap': { false: null },
+            },
+          },
+        ],
+      });
+      await switchActiveProvider('anthropic');
+
+      expect(stubConfig.getEphemeralSettings()).toMatchObject({
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.enabledWireFormat': 'openrouter',
+        'reasoning.effortMap': { high: 'model-high' },
+        'reasoning.enabledMap': { false: null },
+      });
+
+      await switchActiveProvider('openrouter');
+
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.effortWireFormat'),
+      ).toBeUndefined();
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.enabledWireFormat'),
+      ).toBeUndefined();
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.effortMap'),
+      ).toBeUndefined();
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.enabledMap'),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('model default ownership across alias reloads (issue #3255)', () => {
+    it('replaces reasoning maps when switching glm-5.2 to glm-5.3 with freshly reloaded aliases', async () => {
+      pushZaiAlias('glm-5.2');
+      await switchActiveProvider('zai');
+      activeProviderName = 'zai';
+
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.effortMap'),
+      ).toStrictEqual({
+        minimal: 'minimal',
+        low: 'high',
+        medium: 'high',
+        high: 'high',
+        xhigh: 'max',
+        max: 'max',
+      });
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.enabledMap'),
+      ).toStrictEqual({ true: 'enabled', false: 'disabled' });
+
+      // Reload the alias entries the way production reparses them: new object
+      // identities for every rule and nested map.
+      reloadZaiAlias();
+      await setActiveModel('glm-5.3');
+
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.effortMap'),
+      ).toStrictEqual({
+        minimal: 'low',
+        low: 'low',
+        medium: 'high',
+        high: 'high',
+        xhigh: 'max',
+        max: 'max',
+      });
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.enabledMap'),
+      ).toStrictEqual({ true: 'enabled', false: null });
+    });
+
+    it('keeps a session selector equal to the old default when the model changes', async () => {
+      pushZaiAlias('glm-5.3');
+      await switchActiveProvider('zai');
+      activeProviderName = 'zai';
+      expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+        'anthropic',
+      );
+
+      // Session-level set equal to the current default: explicit, user-owned.
+      setEphemeralSetting('reasoning.effortWireFormat', 'anthropic');
+
+      // glm-5.4 matches only the broad glm-5 rule; no selector default applies.
+      await setActiveModel('glm-5.4');
+
+      expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+        'anthropic',
+      );
+    });
+
+    it('keeps a session map equal to the old default when the model changes', async () => {
+      pushZaiAlias('glm-5.2');
+      await switchActiveProvider('zai');
+      activeProviderName = 'zai';
+      const glm52EffortMap = stubConfig.getEphemeralSetting(
+        'reasoning.effortMap',
+      );
+
+      // Session-level set with a fresh object but equal content.
+      setEphemeralSetting(
+        'reasoning.effortMap',
+        structuredClone(glm52EffortMap),
+      );
+
+      await setActiveModel('glm-5.3');
+
+      // The explicit session map survives; the GLM-5.3 default map does not
+      // replace it.
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.effortMap'),
+      ).toStrictEqual({
+        minimal: 'minimal',
+        low: 'high',
+        medium: 'high',
+        high: 'high',
+        xhigh: 'max',
+        max: 'max',
+      });
+    });
+
+    it('keeps an explicit profile selector equal to the old default through later model changes', async () => {
+      pushZaiAlias('glm-5.2');
+      const profile: Profile = {
+        version: 1,
+        provider: 'zai',
+        model: 'glm-5.2',
+        modelParams: {},
+        ephemeralSettings: {
+          'reasoning.effortWireFormat': 'anthropic',
+        },
+      };
+
+      await applyProfileWithGuards(profile, { profileName: 'zai-explicit' });
+      activeProviderName = 'zai';
+
+      await setActiveModel('glm-5.4');
+
+      expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+        'anthropic',
+      );
     });
   });
 });

--- a/packages/providers/src/runtime/provider-alias-defaults.ownership.issue3255.test.ts
+++ b/packages/providers/src/runtime/provider-alias-defaults.ownership.issue3255.test.ts
@@ -1,0 +1,638 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import {
+  createProviderRuntimeContext,
+  DebugLogger,
+} from '@vybestack/llxprt-code-core';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import type { Profile } from '@vybestack/llxprt-code-settings';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import { prepareRequest } from '../openai/OpenAIRequestPreparation.js';
+
+const realProviderAliasesModule = {
+  ...(await import('../composition/providerAliases.js')),
+};
+const realLlxprtCodeCoreModule = {
+  ...(await import('@vybestack/llxprt-code-core')),
+};
+
+const { aliasEntries } = {
+  aliasEntries: [] as Array<Record<string, unknown>>,
+};
+
+const {
+  StubSettingsService: StubSettingsServiceClass,
+  StubConfig: StubConfigClass,
+  StubProvider: StubProviderClass,
+} = (() => {
+  class StubSettingsService {
+    providers: Record<string, Record<string, unknown>> = {};
+    global: Record<string, unknown> = {};
+
+    set(key: string, value: unknown): void {
+      this.global[key] = value;
+    }
+
+    get(key: string): unknown {
+      return this.global[key];
+    }
+
+    getAllGlobalSettings(): Record<string, unknown> {
+      return { ...this.global };
+    }
+
+    setProviderSetting(provider: string, key: string, value: unknown): void {
+      this.providers[provider] ??= {};
+      if (value === undefined) {
+        delete this.providers[provider][key];
+      } else {
+        this.providers[provider][key] = value;
+      }
+    }
+
+    getProviderSettings(provider: string): Record<string, unknown> {
+      return this.providers[provider] ?? {};
+    }
+
+    switchProvider = vi.fn(async (provider: string) => {
+      this.set('activeProvider', provider);
+    });
+
+    async updateSettings(
+      providerOrChanges?: string | Record<string, unknown>,
+      changes?: Record<string, unknown>,
+    ): Promise<void> {
+      if (typeof providerOrChanges === 'string') {
+        for (const [key, value] of Object.entries(changes!)) {
+          this.setProviderSetting(providerOrChanges, key, value);
+        }
+      } else if (typeof providerOrChanges === 'object') {
+        for (const [key, value] of Object.entries(providerOrChanges)) {
+          this.set(key, value);
+        }
+      }
+    }
+  }
+
+  class StubConfig {
+    private model: string | undefined = undefined;
+    private provider = 'openai';
+    private ephemeral: Record<string, unknown> = {};
+    private providerManager: unknown;
+    private settingsService: InstanceType<typeof StubSettingsService>;
+    initializeContentGeneratorConfig = vi.fn(async () => {});
+
+    constructor(settingsService: InstanceType<typeof StubSettingsService>) {
+      this.settingsService = settingsService;
+    }
+
+    getSettingsService(): unknown {
+      return this.settingsService;
+    }
+
+    setEphemeralSetting(key: string, value: unknown): void {
+      if (value === undefined) {
+        delete this.ephemeral[key];
+      } else {
+        this.ephemeral[key] = value;
+      }
+    }
+
+    getEphemeralSetting(key: string): unknown {
+      return this.ephemeral[key];
+    }
+
+    getEphemeralSettings(): Record<string, unknown> {
+      return { ...this.ephemeral };
+    }
+
+    getModel(): string | undefined {
+      return this.model;
+    }
+
+    setModel(model: string | undefined): void {
+      this.model = model;
+    }
+
+    setProvider(provider: string): void {
+      this.provider = provider;
+    }
+
+    getProvider(): string {
+      return this.provider;
+    }
+
+    setProviderManager(manager: unknown): void {
+      this.providerManager = manager;
+    }
+
+    getProviderManager(): unknown {
+      return this.providerManager;
+    }
+  }
+
+  class StubProvider {
+    name: string;
+    defaultModel = 'gpt-4o';
+    providerConfig: { baseUrl?: string } = {};
+
+    constructor(name: string) {
+      this.name = name;
+    }
+
+    getDefaultModel(): string {
+      return this.defaultModel;
+    }
+  }
+
+  return { StubSettingsService, StubConfig, StubProvider };
+})();
+
+type StubSettingsServiceInstance = InstanceType<
+  typeof StubSettingsServiceClass
+>;
+type StubConfigInstance = InstanceType<typeof StubConfigClass>;
+type StubProviderInstance = InstanceType<typeof StubProviderClass>;
+
+const StubSettingsService = StubSettingsServiceClass;
+const StubConfig = StubConfigClass;
+const StubProvider = StubProviderClass;
+
+const providers: Record<string, StubProviderInstance> = {
+  openai: new StubProvider('openai'),
+  anthropic: new StubProvider('anthropic'),
+  openrouter: new StubProvider('openrouter'),
+};
+
+let activeProviderName = 'openai';
+
+const mockProviderManager = {
+  listProviders: vi.fn(() => Object.keys(providers)),
+  getActiveProviderName: vi.fn(() => activeProviderName),
+  getActiveProvider: vi.fn(() => providers[activeProviderName]),
+  setActiveProvider: vi.fn(async (name: string) => {
+    activeProviderName = name;
+  }),
+  getProviderByName: (name: string) => providers[name],
+  getAvailableModels: vi.fn(async () => [{ id: 'model-a' }, { id: 'model-b' }]),
+  setConfig: vi.fn(),
+  prepareStatelessProviderInvocation: vi.fn(),
+};
+
+let stubSettingsService: StubSettingsServiceInstance;
+let stubConfig: StubConfigInstance;
+
+void vi.mock('../composition/providerAliases.js', () => {
+  const actual = realProviderAliasesModule;
+  return {
+    ...actual,
+    loadProviderAliasEntries: () => aliasEntries,
+  };
+});
+
+void vi.mock('@vybestack/llxprt-code-core', () => {
+  const actual = realLlxprtCodeCoreModule;
+
+  let activeContext: {
+    settingsService: StubSettingsServiceInstance;
+    config?: StubConfigInstance;
+    runtimeId?: string;
+    metadata?: Record<string, unknown>;
+  } | null = null;
+
+  return {
+    ...actual,
+    SettingsService: StubSettingsServiceClass,
+    Config: StubConfigClass,
+    createProviderRuntimeContext: (context: {
+      settingsService: StubSettingsServiceInstance;
+      config?: StubConfigInstance;
+      runtimeId?: string;
+      metadata?: Record<string, unknown>;
+    }) => {
+      activeContext = context;
+      return context;
+    },
+    getActiveProviderRuntimeContext: () => {
+      if (!activeContext) {
+        throw new Error(
+          'MissingProviderRuntimeError(provider-runtime): runtime registration missing',
+        );
+      }
+      return activeContext;
+    },
+    setActiveProviderRuntimeContext: (context: {
+      settingsService: StubSettingsServiceInstance;
+      config?: StubConfigInstance;
+      runtimeId?: string;
+      metadata?: Record<string, unknown>;
+    }) => {
+      activeContext = context;
+    },
+    peekActiveProviderRuntimeContext: () => activeContext,
+    getCurrentRuntimeScope: () => undefined,
+  };
+});
+
+const {
+  switchActiveProvider,
+  setEphemeralSetting,
+  clearEphemeralSetting,
+  setActiveModel,
+  setCliRuntimeContext,
+  registerCliProviderInfrastructure,
+} = await import('./runtimeSettings.js');
+const { applyProfileWithGuards } = await import('./profileApplication.js');
+
+const mockOAuthManager = {
+  isOAuthEnabled: vi.fn(() => false),
+  toggleOAuthEnabled: vi.fn(),
+  authenticate: vi.fn(),
+  setMessageBus: vi.fn(),
+  setConfigGetter: vi.fn(),
+} as never;
+
+const debugLoggerWarnSpy = vi
+  .spyOn(DebugLogger.prototype, 'warn')
+  .mockImplementation(() => {});
+
+/**
+ * Helper to push the anthropic alias entry with modelDefaults (config-driven).
+ * This mirrors the structure of the real anthropic.config file.
+ */
+function pushAnthropicAlias(overrides?: {
+  defaultModel?: string;
+  ephemeralSettings?: Record<string, unknown>;
+  modelDefaults?: Array<{
+    pattern: string;
+    ephemeralSettings: Record<string, unknown>;
+  }>;
+}): void {
+  aliasEntries.push({
+    alias: 'anthropic',
+    source: 'builtin',
+    filePath: '/fake/anthropic.config',
+    config: {
+      baseProvider: 'anthropic',
+      defaultModel: overrides?.defaultModel ?? 'claude-opus-4-6',
+      ephemeralSettings: overrides?.ephemeralSettings ?? {
+        maxOutputTokens: 40000,
+      },
+      ...(overrides?.modelDefaults === undefined
+        ? {}
+        : { modelDefaults: overrides.modelDefaults }),
+    },
+  });
+}
+
+function pushOpenRouterReasoningAlias(
+  ephemeralSettings: Record<string, unknown>,
+): void {
+  aliasEntries.push({
+    alias: 'openrouter',
+    source: 'builtin',
+    filePath: '/fake/openrouter.config',
+    config: {
+      baseProvider: 'openai',
+      defaultModel: 'gpt-4o',
+      ephemeralSettings,
+    },
+  });
+}
+
+describe('explicit ownership across provider switches (issue #3255)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    stubSettingsService = new StubSettingsService();
+    stubConfig = new StubConfig(stubSettingsService);
+    activeProviderName = 'openai';
+
+    // Set up runtime context and provider infrastructure
+    setCliRuntimeContext(stubSettingsService as never, stubConfig as never, {
+      runtimeId: 'test-runtime',
+    });
+    const runtimeMessageBus = {} as never;
+    (
+      mockOAuthManager as unknown as { runtimeMessageBus?: unknown }
+    ).runtimeMessageBus = runtimeMessageBus;
+    registerCliProviderInfrastructure(
+      mockProviderManager as never,
+      mockOAuthManager,
+      {
+        messageBus: runtimeMessageBus,
+        runtimeId: 'test-runtime',
+      },
+    );
+
+    aliasEntries.length = 0;
+    providers.anthropic.defaultModel = 'claude-opus-4-6';
+    providers.openrouter.defaultModel = 'gpt-4o';
+  });
+
+  afterEach(() => {
+    // Clear recorded calls only: resetting would strip the module-scope
+    // no-op warn implementation and let real warnings print mid-suite.
+    debugLoggerWarnSpy.mockClear();
+    vi.clearAllMocks();
+  });
+
+  it('keeps a session selector equal to the source alias default when switching providers', async () => {
+    pushAnthropicAlias({
+      ephemeralSettings: {
+        maxOutputTokens: 40000,
+        'reasoning.effortWireFormat': 'anthropic',
+      },
+    });
+    await switchActiveProvider('anthropic');
+    activeProviderName = 'anthropic';
+    expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+      'anthropic',
+    );
+
+    // Explicit session write carrying the same scalar as the source alias
+    // default: ownership, not value equality, decides what survives.
+    setEphemeralSetting('reasoning.effortWireFormat', 'anthropic');
+
+    pushOpenRouterReasoningAlias({
+      'reasoning.effortWireFormat': 'openrouter',
+    });
+    await switchActiveProvider('openrouter');
+    activeProviderName = 'openrouter';
+
+    expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+      'anthropic',
+    );
+  });
+
+  it('keeps a session map equal in content to the source alias default when switching providers', async () => {
+    pushAnthropicAlias({
+      ephemeralSettings: {
+        maxOutputTokens: 40000,
+        'reasoning.effortMap': { high: 'provider-high' },
+      },
+    });
+    await switchActiveProvider('anthropic');
+    activeProviderName = 'anthropic';
+    expect(stubConfig.getEphemeralSetting('reasoning.effortMap')).toStrictEqual(
+      { high: 'provider-high' },
+    );
+
+    // Fresh object with equal content: neither identity nor equality can
+    // classify it, only explicit ownership can.
+    setEphemeralSetting('reasoning.effortMap', { high: 'provider-high' });
+
+    pushOpenRouterReasoningAlias({
+      'reasoning.effortMap': { high: 'openrouter-high' },
+    });
+    await switchActiveProvider('openrouter');
+    activeProviderName = 'openrouter';
+
+    expect(stubConfig.getEphemeralSetting('reasoning.effortMap')).toStrictEqual(
+      { high: 'provider-high' },
+    );
+  });
+
+  it('replaces a default-owned selector with the target provider default on switch', async () => {
+    pushAnthropicAlias({
+      ephemeralSettings: {
+        maxOutputTokens: 40000,
+        'reasoning.effortWireFormat': 'anthropic',
+      },
+    });
+    await switchActiveProvider('anthropic');
+    activeProviderName = 'anthropic';
+
+    // No explicit write: the source alias default owns the key, so the
+    // conflicting target provider default must replace it.
+    pushOpenRouterReasoningAlias({
+      'reasoning.effortWireFormat': 'openrouter',
+    });
+    await switchActiveProvider('openrouter');
+    activeProviderName = 'openrouter';
+
+    expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+      'openrouter',
+    );
+  });
+
+  it('keeps an explicit profile selector through a later provider switch', async () => {
+    pushAnthropicAlias();
+    const profile: Profile = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'claude-opus-4-6',
+      modelParams: {},
+      ephemeralSettings: { 'reasoning.enabledWireFormat': 'thinking' },
+    };
+    await applyProfileWithGuards(profile, {
+      profileName: 'explicit-selector-profile',
+    });
+    activeProviderName = 'anthropic';
+    expect(stubConfig.getEphemeralSetting('reasoning.enabledWireFormat')).toBe(
+      'thinking',
+    );
+
+    pushOpenRouterReasoningAlias({
+      'reasoning.enabledWireFormat': 'openrouter',
+    });
+    await switchActiveProvider('openrouter');
+    activeProviderName = 'openrouter';
+
+    expect(stubConfig.getEphemeralSetting('reasoning.enabledWireFormat')).toBe(
+      'thinking',
+    );
+  });
+
+  it('applies the target provider default after an explicit selector is cleared', async () => {
+    pushAnthropicAlias({
+      ephemeralSettings: {
+        maxOutputTokens: 40000,
+        'reasoning.effortWireFormat': 'anthropic',
+      },
+    });
+    await switchActiveProvider('anthropic');
+    activeProviderName = 'anthropic';
+    setEphemeralSetting('reasoning.effortWireFormat', 'openai');
+    clearEphemeralSetting('reasoning.effortWireFormat');
+
+    // Clearing releases explicit ownership, so the target default applies
+    // instead of the key staying permanently user-owned.
+    pushOpenRouterReasoningAlias({
+      'reasoning.effortWireFormat': 'openrouter',
+    });
+    await switchActiveProvider('openrouter');
+    activeProviderName = 'openrouter';
+
+    expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+      'openrouter',
+    );
+  });
+
+  it('releases every ownership layer when a cleared key was owned by provider and model defaults', async () => {
+    pushAnthropicAlias({
+      defaultModel: 'model-with-defaults',
+      ephemeralSettings: {
+        maxOutputTokens: 40000,
+        'reasoning.effortWireFormat': 'anthropic',
+      },
+      modelDefaults: [
+        {
+          pattern: '^model-with-defaults$',
+          ephemeralSettings: {
+            'reasoning.effortWireFormat': 'anthropic-budget',
+          },
+        },
+      ],
+    });
+    await switchActiveProvider('anthropic');
+    activeProviderName = 'anthropic';
+
+    // The alias default and the matching model default both claimed the
+    // key: the model default owns the visible value, the alias default is
+    // the provider-owned restore point behind it.
+    expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+      'anthropic-budget',
+    );
+
+    clearEphemeralSetting('reasoning.effortWireFormat');
+    expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+      undefined,
+    );
+
+    // Departing the default-owning model must not resurrect the cleared
+    // alias default through a stale provider-owned restore point.
+    await setActiveModel('plain-model');
+    expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+      undefined,
+    );
+
+    // Re-entering the default-owning model re-applies the model default
+    // through normal default ownership, not through the stale record.
+    await setActiveModel('model-with-defaults');
+    expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+      'anthropic-budget',
+    );
+
+    await setActiveModel('plain-model');
+    expect(stubConfig.getEphemeralSetting('reasoning.effortWireFormat')).toBe(
+      undefined,
+    );
+  });
+});
+
+describe('alias reasoning maps propagate to request preparation (issue #3255)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    stubSettingsService = new StubSettingsService();
+    stubConfig = new StubConfig(stubSettingsService);
+    activeProviderName = 'openai';
+
+    setCliRuntimeContext(stubSettingsService as never, stubConfig as never, {
+      runtimeId: 'test-runtime',
+    });
+    const runtimeMessageBus = {} as never;
+    (
+      mockOAuthManager as unknown as { runtimeMessageBus?: unknown }
+    ).runtimeMessageBus = runtimeMessageBus;
+    registerCliProviderInfrastructure(
+      mockProviderManager as never,
+      mockOAuthManager,
+      {
+        messageBus: runtimeMessageBus,
+        runtimeId: 'test-runtime',
+      },
+    );
+
+    aliasEntries.length = 0;
+    providers.anthropic.defaultModel = 'claude-opus-4-6';
+    providers.openrouter.defaultModel = 'gpt-4o';
+  });
+
+  afterEach(() => {
+    debugLoggerWarnSpy.mockClear();
+    vi.clearAllMocks();
+  });
+
+  async function switchToOpenRouterAlias(
+    effortMap: unknown,
+  ): Promise<Record<string, unknown>> {
+    pushOpenRouterReasoningAlias({
+      'reasoning.effortWireFormat': 'openrouter',
+      'reasoning.effortMap': effortMap,
+    });
+    await switchActiveProvider('openrouter');
+    activeProviderName = 'openrouter';
+    return stubConfig.getEphemeralSettings();
+  }
+
+  async function prepareAliasRequest(
+    ephemeralsSnapshot: Record<string, unknown>,
+  ): Promise<unknown> {
+    // The real invocation context derives modelBehavior from the switched
+    // ephemerals through separateSettings, so the alias value must survive
+    // the full runtime hand-off to reach request preparation.
+    const invocation = createRuntimeInvocationContext({
+      runtime: createProviderRuntimeContext({
+        settingsService: stubSettingsService as never,
+        runtimeId: 'alias-request-test',
+      }),
+      settings: stubSettingsService as never,
+      providerName: 'openrouter',
+      ephemeralsSnapshot,
+    });
+    const options: NormalizedGenerateChatOptions = {
+      contents: [],
+      tools: undefined,
+      metadata: {},
+      settings: stubSettingsService as never,
+      config: undefined,
+      invocation,
+      systemInstruction: undefined,
+      resolved: {
+        model: 'gpt-4o',
+        baseURL: 'https://openrouter.ai/api/v1',
+        authToken: 'test-token',
+      },
+    };
+
+    return prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      new DebugLogger('llxprt:runtime:alias-request-test'),
+      'openrouter',
+    );
+  }
+
+  it('rejects an alias effort map array before transport', async () => {
+    const ephemerals = await switchToOpenRouterAlias(['high']);
+
+    // The switch stores alias maps unvalidated by design; rejection is
+    // owned by request preparation, proving the malformed value actually
+    // propagated through the runtime rather than being dropped earlier.
+    expect(ephemerals['reasoning.effortMap']).toStrictEqual(['high']);
+
+    await expect(prepareAliasRequest(ephemerals)).rejects.toThrow(
+      'reasoning.effortMap must be a JSON object',
+    );
+  });
+
+  it('rejects an alias effort map with an unknown key before transport', async () => {
+    const ephemerals = await switchToOpenRouterAlias({ turbo: 'high' });
+
+    expect(ephemerals['reasoning.effortMap']).toStrictEqual({
+      turbo: 'high',
+    });
+
+    await expect(prepareAliasRequest(ephemerals)).rejects.toThrow(
+      "reasoning.effortMap contains unsupported key 'turbo'",
+    );
+  });
+});

--- a/packages/providers/src/runtime/provider-alias-defaults.switch.test.ts
+++ b/packages/providers/src/runtime/provider-alias-defaults.switch.test.ts
@@ -6,6 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
+import type { Profile } from '@vybestack/llxprt-code-settings';
 
 const realProviderAliasesModule = {
   ...(await import('../composition/providerAliases.js')),
@@ -237,9 +238,12 @@ void vi.mock('@vybestack/llxprt-code-core', () => {
 
 const {
   switchActiveProvider,
+  setActiveModel,
+  setEphemeralSetting,
   setCliRuntimeContext,
   registerCliProviderInfrastructure,
 } = await import('./runtimeSettings.js');
+const { applyProfileWithGuards } = await import('./profileApplication.js');
 
 const mockOAuthManager = {
   isOAuthEnabled: vi.fn(() => false),
@@ -604,7 +608,168 @@ describe('Provider alias defaults (model + ephemerals)', () => {
     });
   });
 
-  // --- --set interaction tests ---
+  // --- Provider alias default fallback (issue #3255 precedence) ---
+
+  describe('provider alias default fallback (issue #3255 precedence)', () => {
+    it('applies provider-level reasoning map alias defaults when no model rule supplies them', async () => {
+      pushAnthropicAlias({
+        defaultModel: 'claude-sonnet-4-5-20250929',
+        ephemeralSettings: {
+          maxOutputTokens: 40000,
+          'reasoning.effortMap': { high: 'provider-high' },
+          'reasoning.enabledMap': { true: 'enabled', false: null },
+        },
+      });
+      await switchActiveProvider('anthropic');
+      activeProviderName = 'anthropic';
+
+      // The broad sonnet rule sets no maps, so the provider-level maps are
+      // the effective defaults for the session.
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.effortMap'),
+      ).toStrictEqual({ high: 'provider-high' });
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.enabledMap'),
+      ).toStrictEqual({ true: 'enabled', false: null });
+    });
+
+    it('overrides a provider-level reasoning map with a matching model map and restores it when leaving that model', async () => {
+      pushAnthropicAlias({
+        ephemeralSettings: {
+          maxOutputTokens: 40000,
+          'reasoning.effortMap': { high: 'provider-high' },
+          'reasoning.enabledMap': { true: 'enabled', false: null },
+        },
+        modelDefaults: [
+          {
+            pattern: 'claude-opus-4-6',
+            ephemeralSettings: {
+              'reasoning.effortMap': { high: 'model-high' },
+            },
+          },
+        ],
+      });
+      await switchActiveProvider('anthropic');
+      activeProviderName = 'anthropic';
+
+      // Model default > provider alias default while the rule matches.
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.effortMap'),
+      ).toStrictEqual({ high: 'model-high' });
+      // No model rule owns enabledMap, so the provider map stays in force.
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.enabledMap'),
+      ).toStrictEqual({ true: 'enabled', false: null });
+
+      await setActiveModel('gpt-4o');
+
+      // Leaving the matching model rule restores the provider alias default.
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.effortMap'),
+      ).toStrictEqual({ high: 'provider-high' });
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.enabledMap'),
+      ).toStrictEqual({ true: 'enabled', false: null });
+    });
+
+    it('a new matching model default overrides a provider-owned value and the provider default is restored when leaving', async () => {
+      pushAnthropicAlias({
+        defaultModel: 'claude-sonnet-4-5-20250929',
+        ephemeralSettings: {
+          maxOutputTokens: 40000,
+          'reasoning.effort': 'medium',
+        },
+      });
+      await switchActiveProvider('anthropic');
+      activeProviderName = 'anthropic';
+
+      // The sonnet rule sets no effort, so the provider default owns the key.
+      expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('medium');
+
+      // The opus rule starts matching: model default > provider alias default.
+      await setActiveModel('claude-opus-4-6');
+      expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('high');
+
+      // Leaving the opus rule restores the provider alias default.
+      await setActiveModel('gpt-4o');
+      expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('medium');
+    });
+
+    it('keeps a session value equal to the provider default when a model default starts matching', async () => {
+      pushAnthropicAlias({
+        defaultModel: 'claude-sonnet-4-5-20250929',
+        ephemeralSettings: {
+          maxOutputTokens: 40000,
+          'reasoning.effort': 'medium',
+        },
+      });
+      await switchActiveProvider('anthropic');
+      activeProviderName = 'anthropic';
+
+      // Explicit session write carrying the same value as the provider
+      // default: the session owns the key from here on, regardless of value.
+      setEphemeralSetting('reasoning.effort', 'medium');
+
+      await setActiveModel('claude-opus-4-6');
+
+      // The explicit session value survives the matching model default.
+      expect(stubConfig.getEphemeralSetting('reasoning.effort')).toBe('medium');
+    });
+
+    it('keeps a profile map equal to the provider default through later model changes', async () => {
+      pushAnthropicAlias({
+        ephemeralSettings: {
+          maxOutputTokens: 40000,
+          'reasoning.effortMap': { high: 'provider-high' },
+        },
+        modelDefaults: [
+          {
+            pattern: 'claude-opus-4-6',
+            ephemeralSettings: {
+              'reasoning.effortMap': { high: 'model-high' },
+            },
+          },
+        ],
+      });
+      const profile: Profile = {
+        version: 1,
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5-20250929',
+        modelParams: {},
+        ephemeralSettings: {
+          'reasoning.effortMap': { high: 'provider-high' },
+        },
+      };
+
+      await applyProfileWithGuards(profile, {
+        profileName: 'profile-equals-provider-default',
+      });
+      activeProviderName = 'anthropic';
+
+      await setActiveModel('claude-opus-4-6');
+
+      // The explicit profile map survives even though its content equals the
+      // provider default and a model default now matches.
+      expect(
+        stubConfig.getEphemeralSetting('reasoning.effortMap'),
+      ).toStrictEqual({ high: 'provider-high' });
+    });
+
+    it('still skips object alias ephemerals for non-reasoning-map keys', async () => {
+      pushAnthropicAlias({
+        ephemeralSettings: {
+          maxOutputTokens: 40000,
+          'context-limit': { limit: 200000 },
+        },
+      });
+      await switchActiveProvider('anthropic');
+
+      // Object values are only permitted for the registered reasoning map
+      // keys; every other object ephemeral is still rejected.
+      expect(stubConfig.getEphemeralSetting('context-limit')).toBeUndefined();
+      expect(stubConfig.getEphemeralSetting('maxOutputTokens')).toBe(40000);
+    });
+  });
 
   describe('--set interaction tests with switchActiveProvider', () => {
     it('--set reasoning.effort=low preserved in preserveEphemerals survives provider switch', async () => {

--- a/packages/providers/src/runtime/providerMutations.spec.ts
+++ b/packages/providers/src/runtime/providerMutations.spec.ts
@@ -130,9 +130,11 @@ describe('providerMutations', () => {
       expect(result['reasoning.stripFromContext']).toBe('none');
     });
 
-    it('keeps K2.x geometry for kimi-for-coding (default model unchanged)', () => {
+    it('keeps K2.x geometry without inheriting a K3 effort default', () => {
       const result = computeModelDefaults('kimi-for-coding', kimiRules());
-      expect(result['reasoning.effort']).toBe('medium');
+      expect(result['reasoning.effort']).toBeUndefined();
+      expect(result['reasoning.effortWireFormat']).toBe('none');
+      expect(result['reasoning.enabledWireFormat']).toBe('thinking');
       expect(result.max_tokens).toBe(32768);
       expect(result['context-limit']).toBe(262144);
     });

--- a/packages/providers/src/runtime/providerMutations.ts
+++ b/packages/providers/src/runtime/providerMutations.ts
@@ -21,6 +21,11 @@ import type { Config } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
 import type { ModelDefaultRule } from '../composition/index.js';
 import { getCliRuntimeServices, _internal } from './runtimeAccessors.js';
+import {
+  getModelDefaultOwnedKeys,
+  getProviderDefaultOwnedEntries,
+  recordModelDefaultOwnedKeys,
+} from './modelDefaultOwnership.js';
 
 const logger = new DebugLogger('llxprt:runtime:providerMutations');
 
@@ -216,8 +221,15 @@ export interface ModelChangeResult {
 
 /**
  * Helper for setActiveModel: recomputes and applies model defaults diff.
- * Clears stale defaults (old but not new) and applies new defaults,
- * protecting user-set values that differ from old defaults.
+ * Replaces departing model-owned keys with the provider alias default when
+ * one exists (provider alias default > auto) and otherwise clears them.
+ *
+ * Ownership decides what default application may change (issue #3255): keys
+ * recorded as model- or provider-default-owned are replaced or restored
+ * wholesale, while keys set through the session/profile path survive
+ * unchanged. Alias entries are reparsed into fresh objects on every load,
+ * and an explicit value can equal a default, so value equality and object
+ * identity are both unreliable classifiers here.
  */
 function recomputeAndApplyModelDefaultsDiff(
   config: Config,
@@ -230,28 +242,39 @@ function recomputeAndApplyModelDefaultsDiff(
     : {};
 
   const newDefaults = computeModelDefaults(newModel, modelDefaultRules);
+  const ownedKeys = getModelDefaultOwnedKeys(config);
+  const providerOwnedDefaults = getProviderDefaultOwnedEntries(config);
 
-  // Clear keys in old defaults but NOT in new defaults,
-  // only if current value matches the old default (model-defaulted, not user-set).
-  for (const [key, oldValue] of Object.entries(oldDefaults)) {
-    if (!(key in newDefaults)) {
-      const currentValue = config.getEphemeralSetting(key);
-      if (currentValue === oldValue) {
-        config.setEphemeralSetting(key, undefined);
-      }
+  // Replace keys the departing model supplied and the new model does not,
+  // but only while default application still owns them: restore the
+  // provider alias default when one was recorded, otherwise clear.
+  for (const key of Object.keys(oldDefaults)) {
+    if (key in newDefaults || !ownedKeys.has(key)) {
+      continue;
     }
+    config.setEphemeralSetting(
+      key,
+      providerOwnedDefaults.has(key)
+        ? providerOwnedDefaults.get(key)
+        : undefined,
+    );
   }
 
-  // Apply new defaults: only if key is undefined or current value matches old default.
+  // Apply new defaults where no explicit value exists, and replace values
+  // default application owns (model default > provider alias default).
+  const appliedKeys: string[] = [];
   for (const [key, newValue] of Object.entries(newDefaults)) {
     const currentValue = config.getEphemeralSetting(key);
     if (
       currentValue === undefined ||
-      (key in oldDefaults && currentValue === oldDefaults[key])
+      ownedKeys.has(key) ||
+      providerOwnedDefaults.has(key)
     ) {
       config.setEphemeralSetting(key, newValue);
+      appliedKeys.push(key);
     }
   }
+  recordModelDefaultOwnedKeys(config, appliedKeys);
 }
 
 export async function updateActiveProviderApiKey(

--- a/packages/providers/src/runtime/providerSwitch.ts
+++ b/packages/providers/src/runtime/providerSwitch.ts
@@ -33,6 +33,12 @@ import {
 import { ensureOAuthProviderRegistered } from '../composition/index.js';
 import { configureProviderRuntimeFactories } from '../composition/index.js';
 import { getActiveProfileName } from './profileSnapshot.js';
+import {
+  isUserOwnedReasoningSetting,
+  recordModelDefaultOwnedKeys,
+  recordProviderDefaultOwnedEntries,
+  REASONING_OBJECT_VALUED_EPHEMERAL_KEYS,
+} from './modelDefaultOwnership.js';
 
 const logger = new DebugLogger('llxprt:runtime:settings');
 
@@ -167,15 +173,21 @@ function isScalarAliasEphemeralValue(
   );
 }
 
+/**
+ * Alias ephemeral keys that accept object values (issue #3255): the
+ * registered reasoning maps. Only these keys may carry objects; a malformed
+ * map is not validated here; the provider reasoning config that owns the
+ * key rejects invalid shapes at resolution/request time.
+ */
 function applyAliasEphemeralSetting(
   context: ProviderSwitchContext,
   protectedAliasEphemeralKeys: ReadonlySet<string>,
   rawKey: string,
   rawValue: unknown,
-): void {
+): boolean {
   const key = rawKey.trim();
   if (key === '') {
-    return;
+    return false;
   }
 
   const normalizedKey = key.toLowerCase();
@@ -184,30 +196,40 @@ function applyAliasEphemeralSetting(
       () =>
         `[cli-runtime] Skipping protected alias ephemeral setting '${key}' for provider '${context.name}'.`,
     );
-    return;
+    return false;
   }
 
   if (context.config.getEphemeralSetting(key) !== undefined) {
-    return;
+    return false;
   }
 
-  if (!isScalarAliasEphemeralValue(rawValue)) {
-    logger.warn(
-      () =>
-        `[cli-runtime] Skipping non-scalar alias ephemeral setting '${key}' for provider '${context.name}'.`,
-    );
-    return;
+  if (isScalarAliasEphemeralValue(rawValue)) {
+    if (typeof rawValue === 'number' && !Number.isFinite(rawValue)) {
+      logger.warn(
+        () =>
+          `[cli-runtime] Skipping non-finite alias ephemeral setting '${key}' for provider '${context.name}'.`,
+      );
+      return false;
+    }
+
+    context.config.setEphemeralSetting(key, rawValue);
+    return true;
   }
 
-  if (typeof rawValue === 'number' && !Number.isFinite(rawValue)) {
-    logger.warn(
-      () =>
-        `[cli-runtime] Skipping non-finite alias ephemeral setting '${key}' for provider '${context.name}'.`,
-    );
-    return;
+  if (
+    REASONING_OBJECT_VALUED_EPHEMERAL_KEYS.has(key) &&
+    typeof rawValue === 'object' &&
+    rawValue !== null
+  ) {
+    context.config.setEphemeralSetting(key, rawValue);
+    return true;
   }
 
-  context.config.setEphemeralSetting(key, rawValue);
+  logger.warn(
+    () =>
+      `[cli-runtime] Skipping non-scalar alias ephemeral setting '${key}' for provider '${context.name}'.`,
+  );
+  return false;
 }
 
 function resetBucketFailoverHandler(config: Config): void {
@@ -285,11 +307,14 @@ function clearEphemeralsForSwitch(
     // not per-provider ephemerals. They must survive a provider switch —
     // clearing currentProfile here would wipe the profile name set by
     // applyProfileSnapshot, causing the UI to lose the active profile
-    // identity (issue #2501).
+    // identity (issue #2501). A user-owned issue #3255 reasoning setting
+    // survives too; default-owned values are cleared so the target
+    // provider's defaults apply.
     const shouldPreserve =
       key === 'activeProvider' ||
       key === 'currentProfile' ||
-      context.preserveEphemerals.includes(key);
+      context.preserveEphemerals.includes(key) ||
+      isUserOwnedReasoningSetting(context.config, key);
     if (!shouldPreserve) {
       context.config.setEphemeralSetting(key, undefined);
     }
@@ -654,41 +679,48 @@ function applyClaudeCodeOAuthDefaults(context: ProviderSwitchContext): void {
 }
 
 function applyAliasEphemeralSettings(context: ProviderSwitchContext): void {
+  const appliedAliasEntries: Array<[string, unknown]> = [];
   const aliasEphemeralSettings = context.aliasConfig?.ephemeralSettings;
   if (
-    !aliasEphemeralSettings ||
-    typeof aliasEphemeralSettings !== 'object' ||
-    Array.isArray(aliasEphemeralSettings)
+    aliasEphemeralSettings &&
+    typeof aliasEphemeralSettings === 'object' &&
+    !Array.isArray(aliasEphemeralSettings)
   ) {
-    return;
+    const protectedAliasEphemeralKeys = new Set([
+      'activeprovider',
+      'base-url',
+      'baseurl',
+      'base_url',
+      'model',
+      'auth-key',
+      'auth-keyfile',
+      'authkey',
+      'authkeyfile',
+      'api-key',
+      'api-keyfile',
+      'api_key',
+      'api_keyfile',
+      'apikey',
+      'apikeyfile',
+    ]);
+
+    Object.entries(aliasEphemeralSettings).forEach(([rawKey, rawValue]) => {
+      if (
+        applyAliasEphemeralSetting(
+          context,
+          protectedAliasEphemeralKeys,
+          rawKey,
+          rawValue,
+        )
+      ) {
+        appliedAliasEntries.push([rawKey.trim(), rawValue]);
+      }
+    });
   }
-
-  const protectedAliasEphemeralKeys = new Set([
-    'activeprovider',
-    'base-url',
-    'baseurl',
-    'base_url',
-    'model',
-    'auth-key',
-    'auth-keyfile',
-    'authkey',
-    'authkeyfile',
-    'api-key',
-    'api-keyfile',
-    'api_key',
-    'api_keyfile',
-    'apikey',
-    'apikeyfile',
-  ]);
-
-  Object.entries(aliasEphemeralSettings).forEach(([rawKey, rawValue]) => {
-    applyAliasEphemeralSetting(
-      context,
-      protectedAliasEphemeralKeys,
-      rawKey,
-      rawValue,
-    );
-  });
+  // Only alias keys actually applied become provider-owned defaults; a
+  // missing or invalid alias surface records the empty set, dropping any
+  // ownership left over from the previous provider (issue #3255).
+  recordProviderDefaultOwnedEntries(context.config, appliedAliasEntries);
 }
 
 function applyModelDefaults(context: ProviderSwitchContext): void {
@@ -697,6 +729,10 @@ function applyModelDefaults(context: ProviderSwitchContext): void {
     !context.modelToApply ||
     !context.aliasConfig?.modelDefaults
   ) {
+    // Alias application above is the only default source on this path, and
+    // the switch cleared the previous provider's ephemerals, so any earlier
+    // model ownership is stale (issue #3255).
+    recordModelDefaultOwnedKeys(context.config, []);
     return;
   }
 
@@ -705,11 +741,14 @@ function applyModelDefaults(context: ProviderSwitchContext): void {
     context.aliasConfig.modelDefaults,
   );
 
+  const appliedKeys: string[] = [];
   for (const [key, value] of Object.entries(modelDefaults)) {
     if (!context.preAliasEphemeralKeys.has(key)) {
       context.config.setEphemeralSetting(key, value);
+      appliedKeys.push(key);
     }
   }
+  recordModelDefaultOwnedKeys(context.config, appliedKeys);
 }
 
 function addProviderInfoMessages(context: ProviderSwitchContext): void {

--- a/packages/providers/src/runtime/runtimeAccessors.ts
+++ b/packages/providers/src/runtime/runtimeAccessors.ts
@@ -58,6 +58,10 @@ import {
   loadProviderAliasEntries,
   computeUnallowedParameters,
 } from '../composition/index.js';
+import {
+  markEphemeralUserOwned,
+  releaseEphemeralOwnership,
+} from './modelDefaultOwnership.js';
 
 const logger = new DebugLogger('llxprt:runtime:settings');
 
@@ -618,11 +622,21 @@ export function getEphemeralSetting(key: string): unknown {
 export function setEphemeralSetting(key: string, value: unknown): void {
   const { config } = getCliRuntimeServices();
   config.setEphemeralSetting(key, value);
+  // Session and profile writes own the key: default application must not
+  // later overwrite an explicit value on provider or model changes
+  // (issue #3255). A cleared key releases ownership so defaults manage it
+  // again instead of the key staying permanently user-owned.
+  if (value === undefined) {
+    releaseEphemeralOwnership(config, key);
+    return;
+  }
+  markEphemeralUserOwned(config, key);
 }
 
 export function clearEphemeralSetting(key: string): void {
   const { config } = getCliRuntimeServices();
   config.setEphemeralSetting(key, undefined);
+  releaseEphemeralOwnership(config, key);
 }
 
 export function getSessionSetting(key: string): unknown {

--- a/packages/settings/src/__tests__/settingsRegistry.issue3255.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue3255.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  getProfilePersistableKeys,
+  getSettingSpec,
+  parseSetting,
+  separateSettings,
+  validateSetting,
+} from '../settings/settingsRegistry.js';
+
+const EFFORT_WIRE_FORMATS = [
+  'auto',
+  'openai',
+  'openai-responses',
+  'anthropic',
+  'anthropic-budget',
+  'openrouter',
+  'gemini',
+  'template-kwargs',
+  'none',
+] as const;
+
+const ENABLED_WIRE_FORMATS = [
+  'auto',
+  'openai',
+  'openai-responses',
+  'openrouter',
+  'thinking',
+  'gemini',
+  'template-kwargs',
+  'none',
+] as const;
+
+const REASONING_WIRE_SETTING_KEYS = [
+  'reasoning.effortWireFormat',
+  'reasoning.enabledWireFormat',
+  'reasoning.effortMap',
+  'reasoning.enabledMap',
+] as const;
+
+describe('reasoning wire settings registry contract', () => {
+  it('parses and validates every effort wire format', () => {
+    for (const wireFormat of EFFORT_WIRE_FORMATS) {
+      const parsed = parseSetting('reasoning.effortWireFormat', wireFormat);
+      expect(
+        validateSetting('reasoning.effortWireFormat', parsed),
+      ).toStrictEqual({
+        success: true,
+        value: wireFormat,
+      });
+    }
+  });
+
+  it('parses and validates every enabled wire format', () => {
+    for (const wireFormat of ENABLED_WIRE_FORMATS) {
+      const parsed = parseSetting('reasoning.enabledWireFormat', wireFormat);
+      expect(
+        validateSetting('reasoning.enabledWireFormat', parsed),
+      ).toStrictEqual({ success: true, value: wireFormat });
+    }
+  });
+
+  it('rejects unsupported wire formats', () => {
+    expect(
+      validateSetting('reasoning.effortWireFormat', 'custom'),
+    ).toMatchObject({ success: false });
+    expect(
+      validateSetting('reasoning.enabledWireFormat', 'anthropic'),
+    ).toMatchObject({ success: false });
+  });
+
+  it('parses and validates an effort map with every allowed key and value type', () => {
+    const parsed = parseSetting(
+      'reasoning.effortMap',
+      '{"minimal":"none","low":1024,"medium":2048,"high":"high","xhigh":null,"max":8192}',
+    );
+
+    expect(validateSetting('reasoning.effortMap', parsed)).toStrictEqual({
+      success: true,
+      value: {
+        minimal: 'none',
+        low: 1024,
+        medium: 2048,
+        high: 'high',
+        xhigh: null,
+        max: 8192,
+      },
+    });
+  });
+
+  it('rejects invalid effort maps', () => {
+    const invalidMaps: readonly unknown[] = [
+      [],
+      { ultra: 'high' },
+      { low: '' },
+      { low: 1023 },
+      { low: 1024.5 },
+      { low: true },
+    ];
+
+    for (const invalidMap of invalidMaps) {
+      expect(validateSetting('reasoning.effortMap', invalidMap)).toMatchObject({
+        success: false,
+      });
+    }
+  });
+
+  it('rejects non-plain effort and enabled map objects', () => {
+    class CustomReasoningMap {
+      readonly low = 'high';
+    }
+    const nonPlainObjects: readonly unknown[] = [
+      new CustomReasoningMap(),
+      new Map([['low', 'high']]),
+      new Set(['low']),
+      new Date(0),
+    ];
+
+    for (const nonPlainObject of nonPlainObjects) {
+      expect(
+        validateSetting('reasoning.effortMap', nonPlainObject),
+      ).toMatchObject({ success: false });
+      expect(
+        validateSetting('reasoning.enabledMap', nonPlainObject),
+      ).toMatchObject({ success: false });
+    }
+  });
+
+  it('parses and validates an enabled map with every allowed key and value type', () => {
+    const parsed = parseSetting(
+      'reasoning.enabledMap',
+      '{"true":"adaptive","false":null}',
+    );
+
+    expect(validateSetting('reasoning.enabledMap', parsed)).toStrictEqual({
+      success: true,
+      value: { true: 'adaptive', false: null },
+    });
+    expect(
+      validateSetting('reasoning.enabledMap', { true: true, false: false }),
+    ).toMatchObject({ success: true });
+  });
+
+  it('rejects invalid enabled maps', () => {
+    const invalidMaps: readonly unknown[] = [
+      [],
+      { enabled: true },
+      { true: 1 },
+      { false: '' },
+    ];
+
+    for (const invalidMap of invalidMaps) {
+      expect(validateSetting('reasoning.enabledMap', invalidMap)).toMatchObject(
+        {
+          success: false,
+        },
+      );
+    }
+  });
+
+  it('classifies all four settings as model behavior without dotted-name leakage', () => {
+    const settings = {
+      'reasoning.effortWireFormat': 'openai',
+      'reasoning.enabledWireFormat': 'thinking',
+      'reasoning.effortMap': { minimal: 'low' },
+      'reasoning.enabledMap': { true: 'enabled' },
+    };
+
+    const separated = separateSettings(settings, 'openai');
+
+    expect(separated.modelBehavior).toStrictEqual(settings);
+    expect(separated.modelParams).toStrictEqual({});
+  });
+
+  it('removes nested reasoning wire settings from the reasoning model parameter', () => {
+    const separated = separateSettings({
+      reasoning: {
+        effortWireFormat: 'template-kwargs',
+        enabledWireFormat: 'template-kwargs',
+        effortMap: { low: 'low' },
+        enabledMap: { false: null },
+        exclude: true,
+      },
+    });
+
+    expect(separated.modelBehavior).toStrictEqual({
+      'reasoning.effortWireFormat': 'template-kwargs',
+      'reasoning.enabledWireFormat': 'template-kwargs',
+      'reasoning.effortMap': { low: 'low' },
+      'reasoning.enabledMap': { false: null },
+    });
+    expect(separated.modelParams).toStrictEqual({
+      reasoning: { exclude: true },
+    });
+  });
+
+  it('marks all four settings as profile-persistable', () => {
+    const persistableKeys = getProfilePersistableKeys();
+
+    for (const key of REASONING_WIRE_SETTING_KEYS) {
+      expect(persistableKeys).toContain(key);
+    }
+  });
+
+  it('declares exactly the effort wire formats this test accepts', () => {
+    const spec = getSettingSpec('reasoning.effortWireFormat');
+
+    expect(new Set(spec?.enumValues)).toEqual(new Set(EFFORT_WIRE_FORMATS));
+    expect(spec?.enumValues?.length).toBe(EFFORT_WIRE_FORMATS.length);
+  });
+
+  it('declares exactly the enabled wire formats this test accepts', () => {
+    const spec = getSettingSpec('reasoning.enabledWireFormat');
+
+    expect(new Set(spec?.enumValues)).toEqual(new Set(ENABLED_WIRE_FORMATS));
+    expect(spec?.enumValues?.length).toBe(ENABLED_WIRE_FORMATS.length);
+  });
+
+  it('registers all four settings as profile-persistable model behavior', () => {
+    for (const key of REASONING_WIRE_SETTING_KEYS) {
+      expect(getSettingSpec(key)).toMatchObject({
+        key,
+        category: 'model-behavior',
+        persistToProfile: true,
+      });
+    }
+  });
+});

--- a/packages/settings/src/__tests__/settingsRegistry.issue3255.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue3255.test.ts
@@ -74,6 +74,15 @@ describe('reasoning wire settings registry contract', () => {
     ).toMatchObject({ success: false });
   });
 
+  it('rejects whitespace-padded wire formats without trimming', () => {
+    expect(
+      validateSetting('reasoning.effortWireFormat', ' openai '),
+    ).toMatchObject({ success: false });
+    expect(
+      validateSetting('reasoning.enabledWireFormat', ' thinking '),
+    ).toMatchObject({ success: false });
+  });
+
   it('parses and validates an effort map with every allowed key and value type', () => {
     const parsed = parseSetting(
       'reasoning.effortMap',
@@ -95,6 +104,8 @@ describe('reasoning wire settings registry contract', () => {
 
   it('rejects invalid effort maps', () => {
     const invalidMaps: readonly unknown[] = [
+      null,
+      undefined,
       [],
       { ultra: 'high' },
       { low: '' },
@@ -143,11 +154,16 @@ describe('reasoning wire settings registry contract', () => {
     });
     expect(
       validateSetting('reasoning.enabledMap', { true: true, false: false }),
-    ).toMatchObject({ success: true });
+    ).toStrictEqual({
+      success: true,
+      value: { true: true, false: false },
+    });
   });
 
   it('rejects invalid enabled maps', () => {
     const invalidMaps: readonly unknown[] = [
+      null,
+      undefined,
       [],
       { enabled: true },
       { true: 1 },

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -79,6 +79,12 @@ export type {
   LoadBalancerProfile,
   ModelParams,
   EphemeralSettings,
+  ProfileEphemeralSettings,
+  ReasoningEffort,
+  ReasoningEffortWireFormat,
+  ReasoningEnabledWireFormat,
+  ReasoningEffortMap,
+  ReasoningEnabledMap,
   AuthConfig,
 } from './profiles/types.js';
 export {

--- a/packages/settings/src/profiles/types.ts
+++ b/packages/settings/src/profiles/types.ts
@@ -54,10 +54,47 @@ export interface ModelParams {
   [key: string]: unknown;
 }
 
+export type ReasoningEffortWireFormat =
+  | 'auto'
+  | 'openai'
+  | 'openai-responses'
+  | 'anthropic'
+  | 'anthropic-budget'
+  | 'openrouter'
+  | 'gemini'
+  | 'template-kwargs'
+  | 'none';
+
+export type ReasoningEnabledWireFormat =
+  | 'auto'
+  | 'openai'
+  | 'openai-responses'
+  | 'openrouter'
+  | 'thinking'
+  | 'gemini'
+  | 'template-kwargs'
+  | 'none';
+
+export type ReasoningEffort =
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+  | 'max';
+
+export type ReasoningEffortMap = Readonly<
+  Partial<Record<ReasoningEffort, string | number | null>>
+>;
+
+export type ReasoningEnabledMap = Readonly<
+  Partial<Record<'true' | 'false', string | boolean | null>>
+>;
+
 /**
  * Settings that affect client behavior, not sent to API
  */
-export interface EphemeralSettings {
+export interface ProfileEphemeralSettings {
   'context-limit'?: number;
   'compression-threshold'?: number;
   'auth-key'?: string;
@@ -122,7 +159,11 @@ export interface EphemeralSettings {
   dumponerror?: 'enabled' | 'disabled';
   emojifilter?: 'allowed' | 'auto' | 'warn' | 'error';
   'reasoning.enabled'?: boolean;
-  'reasoning.effort'?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  'reasoning.effort'?: ReasoningEffort;
+  'reasoning.effortWireFormat'?: ReasoningEffortWireFormat;
+  'reasoning.enabledWireFormat'?: ReasoningEnabledWireFormat;
+  'reasoning.effortMap'?: ReasoningEffortMap;
+  'reasoning.enabledMap'?: ReasoningEnabledMap;
   'reasoning.maxTokens'?: number;
   'reasoning.budgetTokens'?: number;
   'reasoning.adaptiveThinking'?: boolean;
@@ -144,6 +185,8 @@ export interface EphemeralSettings {
   'stream-idle-timeout-ms'?: number;
   streamIdleTimeoutMs?: number;
 }
+
+export type EphemeralSettings = ProfileEphemeralSettings;
 
 /**
  * Sub-profile configuration for load balancing

--- a/packages/settings/src/settings/registry/registry-entries-1.ts
+++ b/packages/settings/src/settings/registry/registry-entries-1.ts
@@ -6,6 +6,107 @@
 
 import type { SettingSpec, ValidationResult } from './registry-types.js';
 
+const REASONING_EFFORT_KEYS = new Set([
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+]);
+
+const REASONING_ENABLED_KEYS = new Set(['true', 'false']);
+
+/** Numeric effort-map values are explicit budgets with a hard floor. */
+const MIN_MAPPED_BUDGET_TOKENS = 1024;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Plain JSON objects only: arrays and class/Map/Set instances (whose
+ * entries do not serialize as JSON keys) fail validation instead of being
+ * silently accepted as reasoning maps.
+ */
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === null || prototype === Object.prototype;
+}
+
+function isReasoningEffortMapValue(value: unknown): boolean {
+  if (value === null || isNonEmptyString(value)) {
+    return true;
+  }
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= MIN_MAPPED_BUDGET_TOKENS
+  );
+}
+
+function isReasoningEnabledMapValue(value: unknown): boolean {
+  return (
+    value === null || typeof value === 'boolean' || isNonEmptyString(value)
+  );
+}
+
+function validateReasoningEffortMap(value: unknown): ValidationResult {
+  if (!isJsonObject(value)) {
+    return {
+      success: false,
+      message: 'reasoning.effortMap must be a JSON object',
+    };
+  }
+
+  for (const [key, mappedValue] of Object.entries(value)) {
+    if (!REASONING_EFFORT_KEYS.has(key)) {
+      return {
+        success: false,
+        message: `reasoning.effortMap contains unsupported key '${key}'`,
+      };
+    }
+    if (!isReasoningEffortMapValue(mappedValue)) {
+      return {
+        success: false,
+        message: `reasoning.effortMap values must be non-empty strings, integer budgets of at least ${MIN_MAPPED_BUDGET_TOKENS}, or null`,
+      };
+    }
+  }
+
+  return { success: true, value };
+}
+
+function validateReasoningEnabledMap(value: unknown): ValidationResult {
+  if (!isJsonObject(value)) {
+    return {
+      success: false,
+      message: 'reasoning.enabledMap must be a JSON object',
+    };
+  }
+
+  for (const [key, mappedValue] of Object.entries(value)) {
+    if (!REASONING_ENABLED_KEYS.has(key)) {
+      return {
+        success: false,
+        message: `reasoning.enabledMap contains unsupported key '${key}'`,
+      };
+    }
+    if (!isReasoningEnabledMapValue(mappedValue)) {
+      return {
+        success: false,
+        message:
+          'reasoning.enabledMap values must be non-empty strings, booleans, or null',
+      };
+    }
+  }
+
+  return { success: true, value };
+}
+
 export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'auth-key',
@@ -177,6 +278,57 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     type: 'enum',
     enumValues: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
     persistToProfile: true,
+  },
+  {
+    key: 'reasoning.effortWireFormat',
+    category: 'model-behavior',
+    description: 'Request wire format for generic reasoning effort',
+    type: 'enum',
+    enumValues: [
+      'auto',
+      'openai',
+      'openai-responses',
+      'anthropic',
+      'anthropic-budget',
+      'openrouter',
+      'gemini',
+      'template-kwargs',
+      'none',
+    ],
+    persistToProfile: true,
+  },
+  {
+    key: 'reasoning.enabledWireFormat',
+    category: 'model-behavior',
+    description: 'Request wire format for generic reasoning enablement',
+    type: 'enum',
+    enumValues: [
+      'auto',
+      'openai',
+      'openai-responses',
+      'openrouter',
+      'thinking',
+      'gemini',
+      'template-kwargs',
+      'none',
+    ],
+    persistToProfile: true,
+  },
+  {
+    key: 'reasoning.effortMap',
+    category: 'model-behavior',
+    description: 'Model-specific mapping from generic reasoning effort values',
+    type: 'json',
+    persistToProfile: true,
+    validate: validateReasoningEffortMap,
+  },
+  {
+    key: 'reasoning.enabledMap',
+    category: 'model-behavior',
+    description: 'Model-specific mapping from generic reasoning enablement',
+    type: 'json',
+    persistToProfile: true,
+    validate: validateReasoningEnabledMap,
   },
   {
     key: 'reasoning.maxTokens',

--- a/project-plans/issue3255-reasoning-wire-translation.md
+++ b/project-plans/issue3255-reasoning-wire-translation.md
@@ -515,19 +515,50 @@ Every round-two comment was classified as follows. Duplicate comments inherit th
 
 Two OCR-remediation attempts ended without reports after leaving partial workspace edits. Their edits were inspected and completed by reporting specialists. No RED/GREEN or completion claim is attributed to the interrupted attempts.
 
+### PR review remediation
+
+PR #3260 produced 33 review threads. Each thread was checked against the accepted requirements, current code, and behavioral tests before any source change. The dispositions were 8 `Blocker-Fix`, 4 `In-scope-Fix`, 20 `Reject`, and 1 `Defer`.
+
+The accepted fixes cover these behaviors:
+
+- Fable 5 rejects both explicit `anthropic-budget` selection and direct manual budgets before transport.
+- Adaptive-capable non-Fable Anthropic models honor a direct manual budget without discarding native effort.
+- Anthropic reports dropped effort and budget independently.
+- Z.AI GLM-5 model defaults use an anchored family pattern.
+- Gemini 2 and Gemini 3 use generation-specific translation; unsupported generations omit `thinkingConfig` and report each dropped setting.
+- A false Gemini enabled map cannot enable thinking through `LOW` or `true`.
+- OpenAI Chat rejects a manual budget combined with a mapped thinking type other than `enabled`.
+- OpenAI Chat reports dropped direct budgets independently from dropped disablement.
+- Review-identified documentation, warning wording, interface comments, and test-helper own-property semantics match the implemented behavior.
+
+The `Defer` disposition applies to DeepSeek `max_tokens`. That output-tuning value predates this issue and requires separate provider evidence. The rejected findings conflict with accepted map semantics, explicit-native precedence, fail-fast validation, switch-local generic settings, provider test isolation, or proven implementation behavior.
+
+RED evidence was reconstructed in a detached temporary worktree at the pushed pre-remediation head `59433d45b5df8dab64e78f827c845a2f6273423b`. Only the current regression tests were copied into that worktree. Old production failed as follows:
+
+- Anthropic: 40 passed and 4 failed, covering independent drop warnings, adaptive manual budgets, direct Fable budgets, and Fable `anthropic-budget` selection.
+- Gemini: 42 passed and 3 failed, covering false-map safety and unsupported-generation omission.
+- OpenAI Chat: 49 passed and 2 failed, covering incompatible budget/thinking combinations and independent budget warnings.
+- Alias defaults: 23 passed and 3 failed for the near-match model IDs `foreign-glm-5`, `my-glm-5.3`, and `glm-50`.
+
+The remediated candidate passed the corresponding focused suites: Anthropic 44/44, Gemini 45/45, OpenAI Chat 51/51, and alias defaults 26/26. Related regression suites also passed, including Fable, Anthropic thinking, Gemini thinking levels, shared resolver, issue #2896, reasoning dialect, model-default precedence, and ownership tests.
+
 ### Candidate-head verification
 
-The candidate passed the complete repository test command under the controlled test environment with serialized Agents tests. The command exited 0. Workspace summaries included Tools 126/126, Storage 37/37, Auth 43/43, Settings 18/18, Telemetry 42/42, IDE integration 10/10, Policy 12/12, MCP 43/43, Core 393/393, LSP 13/13, Providers 578/578, Agents 374/374 plus 6/6 isolated files, CLI 713/713, A2A 22/22, test-utils 13/13, and VS Code companion 7/7.
+Before PR creation, the candidate passed the complete repository test command under the controlled test environment with serialized Agents tests. The command exited 0. Workspace summaries included Tools 126/126, Storage 37/37, Auth 43/43, Settings 18/18, Telemetry 42/42, IDE integration 10/10, Policy 12/12, MCP 43/43, Core 393/393, LSP 13/13, Providers 578/578, Agents 374/374 plus 6/6 isolated files, CLI 713/713, A2A 22/22, test-utils 13/13, and VS Code companion 7/7.
 
 Two earlier full runs exposed three unrelated load-sensitive failures. Each failing file passed through its authoritative isolated runner, and the clean full run then passed the same Tools and Agents workspaces without modification to those unrelated tests.
 
-The candidate-wide test audit scanned 2,693 files, 36,107 tests, and 77,730 assertions with no scanner errors. The issue-specific files produced five `DUP_ASSERT` reports in the ownership-transition suite. Those equal-value before-and-after assertions are intentional evidence that user-owned values persist and provider/model-owned values release across transitions.
+The first PR-remediation aggregate completed every workspace with one load-sensitive Agents timeout and no issue-related failure. Providers passed 579/579 and CLI passed 713/713. The sole failing file, `mutationCoverage.behavior.test.ts`, then passed 22/22 with 38 assertions in 10.12 seconds under the same unchanged 30-second timeout when run in isolation. A second aggregate likewise completed every other workspace but timed out in the unchanged Agents `cli-turn-parity.spec.ts`; that complete file passed 3/3 in 3.35 seconds under the same unchanged 30-second timeout when run in isolation.
+
+The final serialized aggregate used Agents concurrency 1 and exited 0. It passed Core 393/393, LSP 13/13, Providers 579/579, Agents 375/375 plus 6/6 isolated files, CLI 713/713, A2A 22/22, test-utils 13/13, and VS Code companion 7/7. No test timeout or failure remained.
+
+The final candidate-wide test audit scanned 2,695 files, 36,138 tests, and 77,855 assertions with no scanner errors. Issue-added ownership-transition and provider/model fallback tests produced nine new `DUP_ASSERT` reports. Those equal-value before-and-after assertions are intentional evidence that user-owned values persist and provider/model-owned values release or restore across transitions. No issue test produced a new mock-mirror, no-assert, always-true, self-confirming, or weak-oracle finding.
 
 The final candidate passed full lint, CI lint, standalone typecheck, build, the ESLint policy guard, provider-neutral naming tests, Prettier checks, documentation link and placement guards, settings synchronization, copyright-year validation, the no-new-JavaScript guard, the no-Vitest guard, secret scans, prohibited-marker and prose scans, and `git diff --check`.
 
 Live evidence is externally blocked for the required profiles `synthetic_gpt56`, `antigravity-claude-sonnet-4-5-thinking`, `antigravity-gemini-3-pro`, `codex_gpt56`, and `gemini_gemini3`. Safe filename and reference searches found none in the configured profile locations. The requested `$HOME/.bun/bin/llxprt` executable is also unavailable. Attempts through the installed `llxprt` executable failed with the sanitized classification "missing profile." The separate `stepfun-37` smoke completed with a valid haiku, but it is recorded only as general startup evidence and not as a substitute for the five requested profiles.
 
-Local implementation, verification, deep review, and both permitted local OCR rounds are complete. Remote CI, PR review, ancestry, and conflict checks remain pending until the candidate is committed and the PR is created.
+Local implementation, deep review, and both permitted local OCR rounds are complete. PR review is classified and the accepted findings are remediated. The remediation commit, thread replies, updated ancestry checks, remote CI, and final mergeability verification remain pending.
 
 ## Completion conditions
 

--- a/project-plans/issue3255-reasoning-wire-translation.md
+++ b/project-plans/issue3255-reasoning-wire-translation.md
@@ -1,0 +1,545 @@
+# Issue 3255: Reasoning wire translation
+
+Status: Accepted behavior and test-first implementation plan
+Date: 2026-08-20
+Issue: https://github.com/vybestack/llxprt-code/issues/3255
+
+## Purpose
+
+LLxprt exposes provider-neutral reasoning controls, but each request protocol expects a different body shape and each model accepts a different value set. The current OpenAI Chat path selects a shape from a short hostname list. Unknown hosts receive no reasoning field, including local OpenAI-compatible servers. Several shipped aliases set reasoning defaults that the request path then discards.
+
+This change makes request translation configurable through provider alias defaults, matched model defaults, and profile ephemerals. It also applies model-specific value maps and deliberate suppression without introducing an arbitrary request-transformation language.
+
+## Accepted behavior
+
+### REQ-3255-001: Configurable reasoning controls
+
+Register these profile-persistable model-behavior settings:
+
+1. `reasoning.effortWireFormat`
+2. `reasoning.enabledWireFormat`
+3. `reasoning.effortMap`
+4. `reasoning.enabledMap`
+
+The settings must be removed from ordinary model parameters by `separateSettings()`. None may leak onto a provider request under its dotted setting name.
+
+`reasoning.effortWireFormat` accepts:
+
+| Value | Wire representation |
+| --- | --- |
+| `auto` | Provider and transport detection described below |
+| `openai` | Top-level `reasoning_effort` |
+| `openai-responses` | `reasoning.effort` on a Responses request |
+| `anthropic` | `output_config.effort` |
+| `anthropic-budget` | `thinking.budget_tokens`, using a numeric mapped value |
+| `openrouter` | `reasoning.effort` on an OpenRouter Chat request |
+| `gemini` | Gemini `thinkingLevel` through the existing Gemini adapter |
+| `template-kwargs` | `chat_template_kwargs.reasoning_effort` |
+| `none` | No effort field |
+
+`reasoning.enabledWireFormat` accepts:
+
+| Value | Wire representation |
+| --- | --- |
+| `auto` | Provider and transport detection described below |
+| `openai` | Top-level `reasoning_effort`, using `reasoning.enabledMap` |
+| `openai-responses` | `reasoning.effort` on a Responses request, using `reasoning.enabledMap` |
+| `openrouter` | `reasoning.enabled` |
+| `thinking` | `thinking.type` |
+| `gemini` | Gemini thinking enablement through the existing Gemini adapter |
+| `template-kwargs` | `chat_template_kwargs.enable_thinking` |
+| `none` | No enablement field |
+
+The two selectors are separate because several supported systems use coordinated fields. Z.AI Chat uses `thinking.type` and top-level `reasoning_effort`. Kimi K3 accepts effort but cannot accept a thinking object. OpenRouter merges enabled and effort into one `reasoning` object.
+
+### REQ-3255-002: Controlled model-specific maps
+
+`reasoning.effortMap` is a JSON object with zero or more keys from:
+
+`minimal`, `low`, `medium`, `high`, `xhigh`, `max`.
+
+Each value is one of:
+
+- a non-empty wire string;
+- an integer of at least 1024 for `anthropic-budget`;
+- `null` for deliberate suppression.
+
+For string-valued formats, an absent map entry uses the generic effort unchanged. For `anthropic-budget`, a numeric entry is required to derive a budget from effort. `reasoning.budgetTokens` remains the direct, explicit budget control and takes precedence over an effort-derived budget.
+
+`reasoning.enabledMap` is a JSON object with optional `true` and `false` keys. Each value is a non-empty string, a boolean, or `null`. The selected adapter validates the mapped type and allowed value before network I/O. Examples include:
+
+- Anthropic adaptive models: `{ "true": "adaptive", "false": "disabled" }`
+- Models that only accept enabled thinking: `{ "true": "enabled", "false": null }`
+- Fireworks effort-only disablement: `{ "true": null, "false": "none" }`
+
+A higher-precedence map replaces the lower-precedence map as one setting. Maps are not recursively merged. A partial replacement uses identity or adapter defaults for omitted entries as described above.
+
+The maps are typed reasoning configuration. They may not name arbitrary request fields, paths, headers, endpoints, or transformations.
+
+### REQ-3255-003: Resolution order
+
+Each selector and map resolves through the existing alias and profile machinery:
+
+1. A value explicitly supplied by the loaded profile or session.
+2. The last matching `modelDefaults` alias rule.
+3. Provider alias `ephemeralSettings`.
+4. `auto` for selectors and no map for maps.
+
+Existing ordered `modelDefaults` behavior remains in effect. Later matching rules win. Profile ephemerals are applied after model defaults and win without request preparation reading alias files directly.
+
+Profile save/load and provider/model switching must preserve explicit profile values. Alias defaults may change when the active provider or model changes. An explicit session or profile value must not be overwritten by that change.
+
+### REQ-3255-004: Automatic selection
+
+`auto` retains safe protocol ownership:
+
+- OpenAI Responses and Codex use `openai-responses` effort translation.
+- Native Anthropic uses `anthropic` effort translation and the existing adaptive or budgeted thinking behavior when no explicit selector overrides it.
+- Native Gemini uses `gemini` translation.
+- OpenRouter Chat uses `openrouter` for enabled and effort.
+- Z.AI and BigModel OpenAI Chat hosts use `thinking` for enabled and `openai` for effort.
+- The official OpenAI API Chat host uses `openai` for effort.
+- An unknown OpenAI-compatible Chat host resolves to `none` unless an alias, model rule, profile, or session selects a format.
+
+Unknown hosts remain conservative because strict OpenAI-compatible endpoints have rejected guessed foreign fields in prior defects. The defect fix is configurability plus a warning, not unconditional fan-out.
+
+### REQ-3255-005: Request translation
+
+When generic reasoning is present, each provider adapter emits only the selected representation:
+
+- OpenAI Chat can emit top-level OpenAI effort, nested OpenRouter reasoning, Z.AI's coordinated thinking and effort fields, Anthropic-style thinking, or template kwargs as selected.
+- OpenAI Responses emits nested Responses reasoning.
+- Anthropic emits `thinking` and `output_config` according to the selected native formats. Modern adaptive models never receive a fabricated `budget_tokens` value.
+- Gemini continues to own its native `thinkingConfig`, while honoring effort maps and `none` suppression.
+
+The translator merges coordinated sibling properties in one representation. It also preserves unrelated properties already present in `chat_template_kwargs` and `output_config`.
+
+`reasoning.enabled=false` takes precedence over a generic effort. If the selected format can express disablement, it emits the mapped disabled value and omits the generic effort. If the format cannot express disablement, it omits the effort and logs the warning required by REQ-3255-007.
+
+`reasoning.enabled=true` is considered represented when an effort field is emitted for an effort-controlled or always-thinking model. It does not require a redundant enablement field.
+
+### REQ-3255-006: Explicit native parameters win
+
+Explicit native reasoning parameters in `modelParams` remain authoritative. If a relevant native reasoning field is present, automatic translation stands down so the request does not contain competing representations.
+
+Relevant collisions include:
+
+- `reasoning`
+- `thinking`
+- `reasoning_effort`
+- `chat_template_kwargs.reasoning_effort`
+- `chat_template_kwargs.enable_thinking`
+- `output_config.effort`
+- the provider's native Gemini thinking controls
+
+An unrelated sibling such as `chat_template_kwargs.some_template_option` or `output_config.some_other_option` is not a collision and must survive a merge with translated reasoning settings.
+
+### REQ-3255-007: No silent loss
+
+Use the existing provider logger to warn when a configured generic reasoning control produces no wire value. This includes:
+
+- `auto` resolving to `none` on an unknown Chat host;
+- an explicit selector of `none`;
+- a map entry of `null`;
+- `reasoning.enabled=false` on a model or format that cannot express disablement;
+- an effort that cannot produce a numeric `anthropic-budget` value.
+
+The warning identifies the provider, model, selected format, and dropped generic setting without printing credentials. Explicit native `modelParams` do not produce this warning because the request already contains a user-selected native representation.
+
+Warnings may occur per prepared request. This issue does not add warning deduplication, a notification center, or persistent warning state.
+
+An explicit format that is incompatible with the active native provider adapter fails before network I/O with an actionable configuration error. Invalid maps fail settings validation or request preparation rather than falling back to a guessed value.
+
+### REQ-3255-008: Evidence-backed shipped defaults
+
+Update alias defaults only where provider documentation identifies the accepted request shape and model value set.
+
+At minimum, cover:
+
+| Alias/model | Accepted default behavior |
+| --- | --- |
+| Codex GPT-5.6 Sol, Terra, Luna | Responses `reasoning.effort`; retain the existing `minimal` to `none` policy where supported |
+| OpenAI GPT-5.6 family | Responses translation when transport routing selects Responses |
+| Anthropic and Claude Code Claude Opus 5 | `thinking.type=adaptive` when enabled, `thinking.type=disabled` when disabled, and `output_config.effort`; map unsupported generic `minimal` to `low` |
+| OpenRouter | Nested `reasoning` object |
+| Kimi K3 and K3 256K | Top-level `reasoning_effort`; no thinking object; map the generic ladder into `low`, `high`, and `max` |
+| Kimi for Coding K2.7 | `thinking.type=enabled`; no effort field; an attempted disable is suppressed with a warning |
+| Z.AI GLM-5.3 | Native endpoint-appropriate thinking plus effort; map minimal/low to low, medium/high to high, and xhigh/max to max on the Coding Plan behavior |
+| Z.AI GLM-5.2 | Native endpoint-appropriate thinking plus effort; apply the documented GLM-5.2 effort normalization |
+| DeepSeek V4 | `thinking.type` plus top-level `reasoning_effort`, with the provider's documented accepted values |
+| Fireworks reasoning model defaults | Top-level `reasoning_effort`, with no simultaneous Anthropic thinking field |
+
+Do not add an effort default to model-agnostic local aliases such as llama.cpp or LM Studio. Their served model determines the accepted format. Profiles can select `openai`, `template-kwargs`, or `none` for those endpoints.
+
+### REQ-3255-009: Compatibility
+
+Preserve these existing behaviors:
+
+- No triple reasoning fan-out.
+- Existing explicit `modelParams` precedence from issue 2896.
+- Existing response-side reasoning extraction and `reasoning.fieldName` behavior.
+- Existing OpenAI Responses encrypted-reasoning include and summary handling.
+- Existing provider routing between Chat and Responses.
+- Existing `reasoning.budgetTokens` and `reasoning.adaptiveThinking` profiles.
+- Existing unrelated `chat_template_kwargs`, `output_config`, and model parameters.
+
+### REQ-3255-010: Documentation
+
+Update the user documentation with:
+
+- all four settings and their schemas;
+- precedence and map replacement behavior;
+- warnings and explicit-native precedence;
+- examples for local OpenAI-compatible servers, vLLM template kwargs, OpenRouter, Anthropic, Codex/Responses, Z.AI, Kimi, and explicit suppression;
+- a provider/model matrix that separates request shape from model value restrictions.
+
+## Evidence used for defaults
+
+- OpenAI Chat and Responses reasoning parameters: https://platform.openai.com/docs/api-reference/chat and https://platform.openai.com/docs/api-reference/responses
+- OpenRouter reasoning parameters: https://openrouter.ai/docs/api/reference/parameters
+- Anthropic adaptive thinking and effort: https://platform.claude.com/docs/en/build-with-claude/extended-thinking and https://platform.claude.com/docs/en/build-with-claude/effort
+- Z.AI GLM-5.3 and reasoning parameters: https://docs.z.ai/guides/llm/glm-5.3 and https://docs.z.ai/guides/overview/concept-param
+- Z.AI Coding Plan protocol behavior: https://docs.z.ai/devpack/latest-model
+- Kimi K3 reasoning controls: https://platform.moonshot.ai/docs/guide/kimi-k3-quickstart
+- vLLM reasoning effort and template kwargs: https://docs.vllm.ai/en/latest/features/reasoning_outputs/
+- Fireworks reasoning controls: https://docs.fireworks.ai/guides/reasoning and https://docs.fireworks.ai/api-reference/post-chatcompletions
+- DeepSeek thinking mode: https://api-docs.deepseek.com/guides/thinking_mode/
+
+Provider documentation changes over time. Alias tests must encode the values supported by the cited model generation, not assume that every model behind a provider accepts the provider's full parameter set.
+
+## Boundaries and rejected expansion
+
+This issue does not:
+
+- add a general JSON-path or arbitrary request-body transformation system;
+- change response-side reasoning extraction;
+- probe servers for capabilities;
+- infer model capabilities from model names outside evidence-backed alias rules and existing provider model data;
+- add dependencies, workflows, agent memory, or quality-tool configuration;
+- mutate user profiles stored outside this repository;
+- invent a universal effort-to-token formula for Anthropic;
+- send speculative reasoning fields to every unknown OpenAI-compatible host;
+- refactor unrelated request preparation or settings code.
+
+A numeric effort-to-budget map is supported only when explicitly configured. Anthropic states that effort and manual thinking budgets are different controls, so no built-in conversion table will be invented.
+
+## Test-first implementation plan
+
+Production changes follow RED, GREEN, REFACTOR. Each phase starts with a behavioral test that fails for the intended reason.
+
+### Phase 0: Preflight
+
+Run on the unchanged branch:
+
+1. `npm run test`
+2. `npm run lint:ci`
+3. `npm run lint:eslint-guard`
+4. `npm run typecheck`
+
+Record any baseline failure before changing production code. Do not encode a baseline defect as expected behavior.
+
+### Phase 1: Settings contract and profile precedence
+
+RED tests:
+
+1. The registry parses and validates both wire-format enums.
+2. The registry accepts valid effort and enabled maps.
+3. It rejects unknown effort keys, arrays, empty strings, non-integer budgets, and numeric budgets below 1024.
+4. `separateSettings()` places all four settings in model behavior and none in request model parameters.
+5. Profile snapshot/save/load preserves the settings.
+6. Profile application proves profile value over matched model rule over provider alias default over `auto`.
+7. Provider/model switching does not overwrite an explicit profile/session value.
+
+GREEN implementation:
+
+- Add registry entries, shared exported setting types where current settings types belong, profile types, and profile persistence keys.
+- Reuse alias and model-default application. Do not pass raw alias configuration into request preparation.
+
+### Phase 2: Narrow shared reasoning configuration resolver
+
+RED tests:
+
+1. Auto selection returns the expected effort and enabled formats for official OpenAI Chat, OpenRouter, Z.AI/BigModel Chat, unknown Chat, Responses, Anthropic, and Gemini.
+2. Effort maps apply identity, explicit remap, numeric budget, and `null` suppression correctly.
+3. Enabled maps apply adapter defaults and explicit values correctly.
+4. Invalid mapped types fail before a request is sent.
+5. `enabled=false` suppresses generic effort and either emits disablement or reports that disablement cannot be represented.
+
+GREEN implementation:
+
+- Add one internal provider-neutral module for typed selector/map resolution and validation.
+- Keep body construction in each provider adapter. The shared module must not accept arbitrary output paths.
+
+### Phase 3: OpenAI Chat translation
+
+RED request-body tests:
+
+1. A custom base URL plus `effortWireFormat=openai` emits only top-level `reasoning_effort`.
+2. A custom base URL plus `template-kwargs` emits and merges `chat_template_kwargs.reasoning_effort`.
+3. OpenRouter emits one nested `reasoning` object with enabled and effort.
+4. Z.AI Chat emits the coordinated `thinking.type` and top-level `reasoning_effort` fields and no foreign third representation.
+5. Kimi K3 emits effort and no thinking object.
+6. Kimi K2.7 emits enabled thinking and no effort.
+7. Anthropic-budget translation uses an explicit numeric map or `reasoning.budgetTokens` and never invents a budget.
+8. The official OpenAI Chat host emits top-level effort under `auto`.
+9. An unknown host under `auto` emits no reasoning field and logs a warning.
+10. Explicit `reasoning`, `thinking`, `reasoning_effort`, or nested template reasoning settings win without automatic additions.
+11. Unrelated template kwargs survive translated reasoning.
+12. `enabled=false` emits a supported mapped disable value or suppresses effort and warns.
+
+GREEN implementation:
+
+- Replace the one-dimensional hostname dialect with resolved enabled and effort formats.
+- Pass the existing logger into translation.
+- Keep request preparation's explicit-native precedence.
+
+### Phase 4: OpenAI Responses and Codex
+
+RED request-body tests:
+
+1. GPT-5.6 Sol, Terra, and Luna emit nested `reasoning.effort` through Codex/Responses.
+2. Model/profile effort maps apply before the existing GPT-5.6 wire policy.
+3. `none` and `null` suppress the effort and warn.
+4. A mapped disabled value suppresses ordinary effort.
+5. Explicit native `reasoning` remains authoritative.
+6. An incompatible explicit selector fails before transport.
+7. Summary and encrypted-content include behavior remains unchanged.
+
+GREEN implementation:
+
+- Feed the shared resolved configuration into the Responses reasoning builder.
+- Preserve routing and existing request ownership.
+
+### Phase 5: Anthropic and Z.AI's Anthropic-compatible endpoint
+
+RED request-body tests:
+
+1. Claude Opus 5 enabled plus effort emits adaptive thinking and `output_config.effort` without `budget_tokens`.
+2. Claude Opus 5 disabled emits disabled thinking and no effort that would make the combination invalid.
+3. A legacy budgeted model uses explicit budget tokens or a numeric effort map.
+4. Z.AI GLM-5.3 emits endpoint-appropriate thinking and mapped effort without Anthropic budget tokens.
+5. Z.AI GLM-5.2 applies its documented effort map.
+6. Explicit `thinking` or `output_config.effort` wins.
+7. Unrelated output-config properties survive.
+8. Incompatible selectors fail before transport.
+
+GREEN implementation:
+
+- Extend the request builder's thinking type only where required by a failing test.
+- Retain model capability checks and strict native parameter sanitization.
+
+### Phase 6: Gemini mapping and suppression
+
+RED request-body tests:
+
+1. `auto` retains existing Gemini effort-to-thinking-level behavior.
+2. A profile effort map changes the emitted thinking level.
+3. `none` or a `null` map entry suppresses the effort and warns.
+4. Explicit native Gemini thinking configuration wins.
+5. A non-Gemini explicit selector fails before transport.
+
+GREEN implementation:
+
+- Apply shared mapping before the existing Gemini adapter builds `thinkingConfig`.
+- Do not change Gemini response handling.
+
+### Phase 7: Alias defaults
+
+RED alias and propagation tests:
+
+1. Codex GPT-5.6 Sol, Terra, and Luna resolve Responses settings.
+2. OpenRouter resolves nested reasoning settings.
+3. Anthropic and Claude Code Opus 5 resolve adaptive enabled mapping and Anthropic effort.
+4. Kimi K3/K3 256K and K2.7 rules resolve different formats.
+5. Z.AI GLM-5.3 and GLM-5.2 resolve their documented maps.
+6. DeepSeek V4 and the existing Fireworks reasoning defaults resolve supported Chat formats.
+7. A profile override beats every alias default in a complete invocation context.
+
+GREEN implementation:
+
+- Update only evidence-backed alias and model rules.
+- Keep model-specific rules ordered from broad defaults to narrower overrides.
+
+### Phase 8: Documentation
+
+Update `docs/reference/ephemerals.md` and the most relevant provider reasoning documentation. Include exact JSON examples and the provider/model matrix from REQ-3255-010.
+
+Documentation examples must match behavioral test fixtures.
+
+## Verification
+
+### Focused tests
+
+Run every touched co-located suite during RED/GREEN work. Include at least:
+
+- settings registry and separation tests;
+- profile application and alias default tests;
+- OpenAI Chat request-preparation tests;
+- OpenAI Responses reasoning tests;
+- Anthropic thinking tests;
+- Gemini thinking-level tests.
+
+Run the test-audit scanner and compare branch findings with the unchanged baseline for touched test files.
+
+### Full local gates
+
+Run the full workflow cycle on the candidate head:
+
+1. `npm run test`
+2. `npm run lint`
+3. `npm run typecheck`
+4. `npm run format`
+5. `npm run build`
+6. `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+
+Also run the repository's CI lint commands:
+
+- `npm run lint:ci`
+- `npm run lint:eslint-guard`
+
+Scan touched files for `TODO`, `FIXME`, `HACK`, `STUB`, `eslint-disable`, `@ts-ignore`, and `@ts-expect-error`. Any occurrence introduced by this issue must be removed or justified by an existing repository rule.
+
+### Live profile evidence
+
+After unit and integration gates pass, run selected installed profiles without editing their external files:
+
+```bash
+bun scripts/start.ts --profile-load gpt56solhigh -p "read the docs directory and compose a haiku about something in it that inspired you"
+bun scripts/start.ts --profile-load opus5 -p "read the docs directory and compose a haiku about something in it that inspired you"
+bun scripts/start.ts --profile-load zai -p "read the docs directory and compose a haiku about something in it that inspired you"
+bun scripts/start.ts --profile-load chutesglm52 -p "read the docs directory and compose a haiku about something in it that inspired you"
+bun scripts/start.ts --profile-load fireworkskimi -p "read the docs directory and compose a haiku about something in it that inspired you"
+```
+
+If a named profile lacks credentials or its remote service is unavailable, record the exact failure. Request-body tests remain the proof of wire shape. A successful response from each available live profile is additional transport evidence.
+
+## Review and finding classification
+
+Complete one deep technical review and no more than two local Open Code Review rounds. Later, complete no more than two PR Open Code Review rounds.
+
+Classify every finding:
+
+- `Blocker-Fix`: breaks an accepted behavior, safety rule, build, test, or release gate.
+- `In-scope-Fix`: valid defect in the accepted implementation or its evidence.
+- `Reject`: factually incorrect, already satisfied, or conflicts with accepted behavior.
+- `Defer`: valid adjacent work outside this issue. Record it without implementing it unless the user approves expansion.
+
+Review comments do not add scope. Fix all Blocker-Fix and In-scope-Fix findings, then rerun the required verification cycle.
+
+## Execution evidence
+
+### Test-first implementation
+
+The implementation and its provider-specific remediations were delegated to TypeScript specialists. Focused RED evidence was captured before each behavior change.
+
+- `typescriptexpert-hn4qme` remediated the second deep review's provider-switch ownership, explicit-native collision, and Anthropic budget findings under observed RED/GREEN tests.
+- `typescriptexpert-cxm0u2` completed the first OCR remediation and passed 441 tests across 21 separately executed suites, followed by typecheck, lint-policy guard, scoped ESLint, Prettier, focused test audit, and diff checks.
+- `typescriptexpert-rck1pe` completed the second OCR remediation. That work began from two observed failures left by an interrupted specialist: a syntax error from an unmatched block in `geminiReasoningConfig.ts`, and ten OpenAI Chat warning failures that did not distinguish suppression, disabled reasoning, an undetected format, and unsupported direct budgets.
+- `typescriptexpert-zonk6c` extracted shared Chat test harness code into a test-only helper after the issue test reached the repository's unchanged source-size limit.
+
+The final focused results from the second OCR remediation were produced in separate Bun processes:
+
+- reasoning parser: 61 passed;
+- shared resolver: 88 passed;
+- OpenAI Chat issue tests: 48 passed;
+- OpenAI Responses issue tests: 26 passed;
+- Anthropic issue tests: 39 passed;
+- Anthropic thinking regressions: 21 passed;
+- Gemini issue tests: 43 passed;
+- settings registry issue tests: 14 passed;
+- alias, profile, switching, ownership, mutation, snapshot, issue 2896, and pipeline suites: 148 passed.
+
+A proposed lint-policy exception was classified `Reject` and removed. The test-only helper kept the Chat issue test within the existing source-size policy. The unchanged lint configuration then passed, and all 48 Chat tests retained their descriptions and assertions.
+
+### Deep technical review
+
+Two reported deep technical reviews were completed:
+
+- `deepthinker-sgry8t`: three `Blocker-Fix` and four `In-scope-Fix` findings. All were remediated and covered by focused tests.
+- `deepthinker-t8bs3e`: `Blocker-Fix` findings for provider-switch ownership, explicit OpenAI native collisions, and unsupported Opus 5 manual budgets. All were remediated and covered by focused tests.
+
+A separate deep-review attempt ended without a report and supplied no findings or evidence. It is not counted as a completed review.
+
+### Local Open Code Review
+
+The two permitted local OCR rounds are complete. No third local OCR round will be run.
+
+Round one:
+
+- primary output: `tmp/ocr-review-3255-local-1.json`;
+- 41 of 42 selected items completed;
+- 24 aggregate comments plus 10 comments recovered from the interrupted attempt;
+- the missed OpenAI Responses issue test completed in round two;
+- accepted findings covered shared parsing, plain-record validation, Responses enabled-only behavior, Anthropic passthrough, nested own-property checks, dead dialect removal, Gemini warning metadata, and test-spy isolation;
+- malformed controlled settings, OpenAI max-token changes, optional invocation state, Responses precedence inversion, and unrelated optimization requests were classified `Reject` or `Defer`.
+
+Round two:
+
+- output: `tmp/ocr-review-3255-local-2.json`;
+- 42 of 43 selected items completed;
+- 34 aggregate comments;
+- the missed `runtimeAccessors.ts` item completed in round one, so cross-round file coverage is complete.
+
+Every round-two comment was classified as follows. Duplicate comments inherit the classification of the cited behavior.
+
+| Classification | Finding groups | Resolution |
+| --- | --- | --- |
+| `Blocker-Fix` | Ownership release across provider, model, and user layers | Fixed by unconditional layer deletion and ownership-transition tests |
+| `Blocker-Fix` | Explicit effort overwritten by enabled-map output in Chat, Responses, or Gemini | Fixed; exact request-body tests prove effort precedence while disabled reasoning still suppresses effort |
+| `Blocker-Fix` | Unrestricted simultaneous Chat formats could fan out reasoning controls | Fixed with an evidence-based coordinated-pair matrix and rejection tests |
+| `Blocker-Fix` | Explicit native collision checks used inherited properties | Fixed with own-property checks and collision tests |
+| `Blocker-Fix` | Class instances could pass controlled map validation | Fixed in shared parsing, Gemini parsing, and settings validation |
+| `Blocker-Fix` | Configured Chat budgets and disabled Gemini effort could be dropped without an accurate warning | Fixed with independent provider-local warning tests |
+| `In-scope-Fix` | OpenRouter sibling preservation and Z.AI/DeepSeek coordinated output | Preserved and covered by exact-body tests |
+| `In-scope-Fix` | Warning prose did not distinguish deliberate suppression from inability to emit | Fixed with reason-specific messages and structured metadata |
+| `In-scope-Fix` | Gemini dropped-effort, null-suppression, and same-control precedence coverage | Added deterministic tests |
+| `In-scope-Fix` | Chat nested-field helper and `enabledMap.true=null` coverage | Corrected without weakening assertions |
+| `In-scope-Fix` | Registry enum/key tests did not prove set equality | Corrected |
+| `In-scope-Fix` | Parser error duplicated the minimum budget literal | Replaced with the existing constant |
+| `In-scope-Fix` | Unreachable Anthropic enabled guard and duplicated legacy budget literal | Removed and consolidated internally |
+| `In-scope-Fix` | Anthropic record unions suggested narrowing they did not provide | Simplified locally without changing request behavior |
+| `In-scope-Fix` | Invocation-boundary comment suggested a contract weaker than the type | Corrected; invocation remains required |
+| `Reject` | Invert Responses precedence using inconsistent partial fixtures | Conflicts with real invocation construction and explicit-native precedence |
+| `Reject` | Warn or degrade on malformed controlled settings and alias maps | Conflicts with accepted fail-fast behavior |
+| `Reject` | Make invocation optional | Conflicts with `RuntimeInvocationContext` |
+| `Reject` | Accept case-insensitive reasoning setting names | Settings are case-sensitive |
+| `Reject` | Preserve generic `reasoning.enabled` and `reasoning.effort` across provider switches | Their model/provider semantics are intentionally switch-local |
+| `Reject` | Restrict every custom Anthropic mapped string to built-in literals | Conflicts with the accepted explicit wire-value escape hatch |
+| `Reject` | Replace Gemini null suppression with `thinkingBudget: 0` | Null deliberately means no wire output |
+| `Reject` | Downgrade incompatible Gemini values to warnings | Conflicts with fail-fast adapter validation |
+| `Reject` | Recover from malformed `chat_template_kwargs` | Conflicts with fail-fast request validation |
+| `Reject` | Claim an anthropic-budget effort without a numeric map can emit | The resolver already returns `unrepresentable` |
+| `Reject` | Freeze empty `Map` or `Set` as a mutation defense | `Object.freeze` does not prevent `Map.set` or `Set.add` |
+| `Defer` | Consolidate tiny internal key lists unrelated to a behavior defect | Adjacent cleanup with no issue behavior change |
+| Duplicate | Two case-insensitive-key comments and two Anthropic-string comments | Classified with their matching `Reject` rows |
+
+Two OCR-remediation attempts ended without reports after leaving partial workspace edits. Their edits were inspected and completed by reporting specialists. No RED/GREEN or completion claim is attributed to the interrupted attempts.
+
+### Candidate-head verification
+
+The candidate passed the complete repository test command under the controlled test environment with serialized Agents tests. The command exited 0. Workspace summaries included Tools 126/126, Storage 37/37, Auth 43/43, Settings 18/18, Telemetry 42/42, IDE integration 10/10, Policy 12/12, MCP 43/43, Core 393/393, LSP 13/13, Providers 578/578, Agents 374/374 plus 6/6 isolated files, CLI 713/713, A2A 22/22, test-utils 13/13, and VS Code companion 7/7.
+
+Two earlier full runs exposed three unrelated load-sensitive failures. Each failing file passed through its authoritative isolated runner, and the clean full run then passed the same Tools and Agents workspaces without modification to those unrelated tests.
+
+The candidate-wide test audit scanned 2,693 files, 36,107 tests, and 77,730 assertions with no scanner errors. The issue-specific files produced five `DUP_ASSERT` reports in the ownership-transition suite. Those equal-value before-and-after assertions are intentional evidence that user-owned values persist and provider/model-owned values release across transitions.
+
+The final candidate passed full lint, CI lint, standalone typecheck, build, the ESLint policy guard, provider-neutral naming tests, Prettier checks, documentation link and placement guards, settings synchronization, copyright-year validation, the no-new-JavaScript guard, the no-Vitest guard, secret scans, prohibited-marker and prose scans, and `git diff --check`.
+
+Live evidence is externally blocked for the required profiles `synthetic_gpt56`, `antigravity-claude-sonnet-4-5-thinking`, `antigravity-gemini-3-pro`, `codex_gpt56`, and `gemini_gemini3`. Safe filename and reference searches found none in the configured profile locations. The requested `$HOME/.bun/bin/llxprt` executable is also unavailable. Attempts through the installed `llxprt` executable failed with the sanitized classification "missing profile." The separate `stepfun-37` smoke completed with a valid haiku, but it is recorded only as general startup evidence and not as a substitute for the five requested profiles.
+
+Local implementation, verification, deep review, and both permitted local OCR rounds are complete. Remote CI, PR review, ancestry, and conflict checks remain pending until the candidate is committed and the PR is created.
+
+## Completion conditions
+
+The issue is complete only when:
+
+1. Every accepted requirement has behavioral evidence.
+2. All local verification gates pass on the candidate commit.
+3. Selected available live profiles complete successfully or have exact external failure evidence.
+4. Deep review and permitted Open Code Review rounds are complete and triaged.
+5. Every Blocker-Fix and In-scope-Fix finding is resolved.
+6. CI passes on the candidate head.
+7. PR review threads are resolved.
+8. The PR has correct ancestry, no conflicts, and is ready to merge.
+
+Do not merge without explicit user approval. Stop when these conditions are met rather than adding optional cleanup or hardening.

--- a/project-plans/issue3255-reasoning-wire-translation.md
+++ b/project-plans/issue3255-reasoning-wire-translation.md
@@ -542,6 +542,23 @@ RED evidence was reconstructed in a detached temporary worktree at the pushed pr
 
 The remediated candidate passed the corresponding focused suites: Anthropic 44/44, Gemini 45/45, OpenAI Chat 51/51, and alias defaults 26/26. Related regression suites also passed, including Fable, Anthropic thinking, Gemini thinking levels, shared resolver, issue #2896, reasoning dialect, model-default precedence, and ownership tests.
 
+### Post-push PR feedback
+
+The first remediation commit, `14b3ac047`, passed remote CI with 36 successful checks, no failed or pending checks, and the mergeability gates satisfied. The final permitted OCR run and CodeRabbit produced 18 unresolved inline threads. Each finding was checked against the accepted behavior and the current request paths. Six were classified `In-scope-Fix`; twelve were classified `Reject`. No post-push finding was classified `Blocker-Fix` or `Defer`.
+
+The accepted fixes cover these behaviors and test-contract gaps:
+
+- Claude Sonnet 5 capability detection now accepts only the bare alias, `-latest`, and dated snapshots. Vendor-prefixed identifiers and near-matches such as `claude-sonnet-50` or `claude-sonnet-5-mini` do not receive adaptive-thinking behavior.
+- Disabled Gemini reasoning reports a configured `reasoning.maxTokens` value that cannot be emitted.
+- Shared parser tests cover every public enabled and effort wire format.
+- Settings registry tests reject whitespace-padded formats, reject nullish maps, and compare complete boolean-map results.
+
+Request-level Sonnet RED evidence first exposed the vendor-prefix mismatch. Predicate-level RED evidence then exposed the initial prefix matcher’s near-match bug. The corrected anchored predicate passed 46 model-data tests and 45 Anthropic request tests. Gemini disabled-budget RED evidence produced two failures before the warning change and passed 47 tests afterward. The parser passed 70 tests, the shared resolver passed 88, and the settings registry issue suite passed 15.
+
+The rejected findings relied on behavior contradicted by exact request tests or the accepted contract. They included remapping effort a second time, treating `enabled` as a native Responses reasoning field, accepting incompatible Gemini values, weakening case-sensitive setting semantics, replacing passing test fixtures without a behavioral defect, and mass docstring changes. Duplicate mapped-effort findings retain separate thread replies with the same evidence.
+
+The three non-inline OCR suggestions were also classified `Reject`: a resolver scenario already rejects only when an enabled map creates a contradictory emitted representation; mixed internal own-property helper style is behaviorally equivalent and lint-clean; and project-wide docstring expansion is outside this issue.
+
 ### Candidate-head verification
 
 Before PR creation, the candidate passed the complete repository test command under the controlled test environment with serialized Agents tests. The command exited 0. Workspace summaries included Tools 126/126, Storage 37/37, Auth 43/43, Settings 18/18, Telemetry 42/42, IDE integration 10/10, Policy 12/12, MCP 43/43, Core 393/393, LSP 13/13, Providers 578/578, Agents 374/374 plus 6/6 isolated files, CLI 713/713, A2A 22/22, test-utils 13/13, and VS Code companion 7/7.
@@ -550,15 +567,17 @@ Two earlier full runs exposed three unrelated load-sensitive failures. Each fail
 
 The first PR-remediation aggregate completed every workspace with one load-sensitive Agents timeout and no issue-related failure. Providers passed 579/579 and CLI passed 713/713. The sole failing file, `mutationCoverage.behavior.test.ts`, then passed 22/22 with 38 assertions in 10.12 seconds under the same unchanged 30-second timeout when run in isolation. A second aggregate likewise completed every other workspace but timed out in the unchanged Agents `cli-turn-parity.spec.ts`; that complete file passed 3/3 in 3.35 seconds under the same unchanged 30-second timeout when run in isolation.
 
-The final serialized aggregate used Agents concurrency 1 and exited 0. It passed Core 393/393, LSP 13/13, Providers 579/579, Agents 375/375 plus 6/6 isolated files, CLI 713/713, A2A 22/22, test-utils 13/13, and VS Code companion 7/7. No test timeout or failure remained.
+The serialized PR-remediation aggregate used Agents concurrency 1 and exited 0. It passed Core 393/393, LSP 13/13, Providers 579/579, Agents 375/375 plus 6/6 isolated files, CLI 713/713, A2A 22/22, test-utils 13/13, and VS Code companion 7/7. No test timeout or failure remained.
 
-The final candidate-wide test audit scanned 2,695 files, 36,138 tests, and 77,855 assertions with no scanner errors. Issue-added ownership-transition and provider/model fallback tests produced nine new `DUP_ASSERT` reports. Those equal-value before-and-after assertions are intentional evidence that user-owned values persist and provider/model-owned values release or restore across transitions. No issue test produced a new mock-mirror, no-assert, always-true, self-confirming, or weak-oracle finding.
+Post-push remediation received another complete root aggregate. Tools 126/126, Storage 37/37, Auth 43/43, Settings 18/18, Telemetry 42/42, IDE integration 10/10, Policy 12/12, MCP 43/43, Core 393/393, LSP 13/13, Providers 579/579, CLI 713/713, A2A 22/22, test-utils 13/13, and VS Code companion 7/7 passed. Agents passed 374/375; the only failure was an unchanged 30-second timeout in `cli-turn-parity.spec.ts`, whose complete file then passed 3/3 in 2.63 seconds under the unchanged timeout. A second root aggregate passed Core, LSP, and Providers before a different unchanged 30-second Agents timeout in `cli-turn-parity.early.spec.ts` made a clean aggregate impossible. That task was cancelled, and the complete early-parity file passed 3/3 in 1.73 seconds under the unchanged timeout. A standalone serialized Agents package run then exited 0 with 375/375 files plus 6/6 isolated files.
 
-The final candidate passed full lint, CI lint, standalone typecheck, build, the ESLint policy guard, provider-neutral naming tests, Prettier checks, documentation link and placement guards, settings synchronization, copyright-year validation, the no-new-JavaScript guard, the no-Vitest guard, secret scans, prohibited-marker and prose scans, and `git diff --check`.
+The candidate-wide post-push audit completed without scanner errors. Its `findings.tsv` contains no entry for any of the five modified test files, so the remediation added no audit finding. The large repository-wide finding set is pre-existing.
 
-Live evidence is externally blocked for the required profiles `synthetic_gpt56`, `antigravity-claude-sonnet-4-5-thinking`, `antigravity-gemini-3-pro`, `codex_gpt56`, and `gemini_gemini3`. Safe filename and reference searches found none in the configured profile locations. The requested `$HOME/.bun/bin/llxprt` executable is also unavailable. Attempts through the installed `llxprt` executable failed with the sanitized classification "missing profile." The separate `stepfun-37` smoke completed with a valid haiku, but it is recorded only as general startup evidence and not as a substitute for the five requested profiles.
+The exact post-push candidate passed full lint, CI lint, standalone typecheck, build, the ESLint policy guard, provider-neutral naming tests, Prettier checks, documentation link and placement guards, settings synchronization, copyright-year validation, the no-new-JavaScript guard, the no-Vitest guard, secret scans, prohibited-marker and prose scans, and `git diff --check`.
 
-Local implementation, deep review, and both permitted local OCR rounds are complete. PR review is classified and the accepted findings are remediated. The remediation commit, thread replies, updated ancestry checks, remote CI, and final mergeability verification remain pending.
+Live evidence is externally blocked for the required profiles `synthetic_gpt56`, `antigravity-claude-sonnet-4-5-thinking`, `antigravity-gemini-3-pro`, `codex_gpt56`, and `gemini_gemini3`. Safe filename and reference searches found none in the configured profile locations. The requested `$HOME/.bun/bin/llxprt` executable is also unavailable. Attempts through the installed `llxprt` executable failed with the sanitized classification "missing profile." The exact-current `stepfun-37` smoke exited 0 with nonempty output and no error marker, but it is recorded only as general startup evidence and not as a substitute for the five requested profiles.
+
+Local implementation, deep review, both permitted local OCR rounds, post-push finding classification, accepted remediation, and exact-current local verification are complete. The post-push remediation commit, 18 thread replies and resolutions, updated ancestry check, remote CI, and final mergeability verification remain pending.
 
 ## Completion conditions
 


### PR DESCRIPTION
## TLDR

Translate LLxprt's generic reasoning settings into the wire format selected for each provider, model, and profile. This fixes custom OpenAI-compatible endpoints silently dropping `reasoning.effort`, while retaining conservative behavior for unknown strict endpoints.

Profiles and alias rules can now select effort and enablement formats independently, remap model-specific values, or suppress unsupported controls. The request adapters cover OpenAI Chat, OpenAI Responses and Codex, OpenRouter, Anthropic, Gemini, Z.AI, DeepSeek, Kimi, Fireworks, and template-driven local servers.

## Dive Deeper

The settings registry now owns four profile-persistable model-behavior settings: `reasoning.effortWireFormat`, `reasoning.enabledWireFormat`, `reasoning.effortMap`, and `reasoning.enabledMap`. Resolution follows explicit profile or session values, matched model defaults, provider alias defaults, then safe adapter detection.

A typed internal resolver validates selectors and maps before transport. Provider request builders still own their native body shape. Explicit native `modelParams` win, unrelated nested properties are merged, and generic controls never fan out into competing dialects. Configured values that resolve to no wire representation produce structured warnings instead of disappearing silently.

Provider and model defaults cover the documented behavior of GPT-5.6 through Responses and Codex, Claude Opus 5, OpenRouter, GLM-5.2 and GLM-5.3, DeepSeek V4, Kimi K2.7 and K3, and Fireworks MiniMax M3. Model-agnostic local aliases remain unopinionated so profiles can select OpenAI effort, template kwargs, or explicit suppression for the model being served.

The change also tracks whether reasoning defaults came from the provider alias, a model rule, or the user. Provider and model switches can therefore replace stale defaults without overwriting explicit profile or session choices.

Documentation includes the setting schemas, precedence, request-shape matrix, model restrictions, local endpoint examples, warning behavior, and explicit-native precedence.

## Reviewer Test Plan

1. Run the focused request-body suites in separate Bun processes:

   ```bash
   bun test packages/providers/src/reasoning/reasoning-behavior-parsing.test.ts
   bun test packages/providers/src/reasoning/reasoning-config-resolver.test.ts
   bun test packages/providers/src/openai/OpenAIRequestPreparation.issue3255.test.ts
   bun test packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.issue3255.test.ts
   bun test packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts
   bun test packages/providers/src/gemini/__tests__/gemini.issue3255.test.ts
   bun test packages/providers/src/composition/providerAliases.issue3255.test.ts
   ```

2. Load a custom OpenAI-compatible profile with `reasoning.effortWireFormat` set to `openai` and confirm Chat requests contain top-level `reasoning_effort`. Change the format to `template-kwargs` and confirm the value moves to `chat_template_kwargs.reasoning_effort` without a duplicate top-level field.

3. Exercise a profile override against a built-in alias rule. Confirm the profile value wins, then switch models and providers to verify user-owned values persist while alias-owned defaults change.

4. Set a format to `none`, or map an effort to `null`, and confirm the request omits the field and logs a structured warning without printing the base URL or credentials.

Local candidate verification completed on macOS:

- full repository tests passed on the candidate head, including 579 provider files, 375 serialized Agents files, 6 isolated Agents files, and 713 CLI files;
- full lint, CI lint, typecheck, build, Prettier, documentation links and placement, settings synchronization, provider-neutral naming, copyright, no-new-JavaScript, and no-Vitest guards passed;
- the candidate-wide test audit scanned 2,693 files, 36,107 tests, and 77,730 assertions with no scanner errors;
- `stepfun-37` completed a startup smoke request successfully.

The five requested external smoke profiles were not installed in the configured profile locations, and `$HOME/.bun/bin/llxprt` was unavailable. Attempts through the installed executable failed with the sanitized result `missing profile`. No external profile files were modified.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3255

Related: #2488, #2524, #2825, #2896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-specific reasoning wire-format support across OpenAI, Anthropic, Gemini, OpenRouter, DeepSeek, Kimi, Fireworks, Z.ai, and compatible local endpoints.
  * Added configurable reasoning effort, enablement, token budgets, mappings, summaries, and adaptive thinking.
  * Preserved explicit reasoning settings and profile configuration across provider and model changes.
* **Bug Fixes**
  * Improved validation, conflict handling, unsupported-setting warnings, and prevention of invalid or duplicate reasoning parameters.
  * Adaptive Anthropic models now require explicit reasoning budgets when applicable.
* **Documentation**
  * Added comprehensive reasoning wire-format guidance and updated settings, profiles, and provider references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->