### PR TITLE
Declare latency histograms DOUBLE so fractional ms stop warning (Fixes #3259)

### DIFF
--- a/packages/telemetry/src/telemetry/metrics.ts
+++ b/packages/telemetry/src/telemetry/metrics.ts
@@ -67,7 +67,7 @@ export function initializeMetrics(config: TelemetryConfig): void {
   toolCallLatencyHistogram = meter.createHistogram(METRIC_TOOL_CALL_LATENCY, {
     description: 'Latency of tool calls in milliseconds.',
     unit: 'ms',
-    valueType: ValueType.INT,
+    valueType: ValueType.DOUBLE,
   });
   apiRequestCounter = meter.createCounter(METRIC_API_REQUEST_COUNT, {
     description: 'Counts API requests, tagged by model and status.',
@@ -78,7 +78,7 @@ export function initializeMetrics(config: TelemetryConfig): void {
     {
       description: 'Latency of API requests in milliseconds.',
       unit: 'ms',
-      valueType: ValueType.INT,
+      valueType: ValueType.DOUBLE,
     },
   );
   tokenUsageCounter = meter.createCounter(METRIC_TOKEN_USAGE, {

--- a/packages/telemetry/src/telemetry/metrics.valueType.behavior.test.ts
+++ b/packages/telemetry/src/telemetry/metrics.valueType.behavior.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  diag,
+  DiagLogLevel,
+  metrics,
+  type DiagLogger,
+} from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  DataPointType,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+  type HistogramMetricData,
+  type MetricData,
+  type ResourceMetrics,
+} from '@opentelemetry/sdk-metrics';
+import {
+  initializeMetrics,
+  recordApiResponseMetrics,
+  recordToolCallMetrics,
+  resetMetricsState,
+} from './metrics.js';
+import {
+  METRIC_API_REQUEST_LATENCY,
+  METRIC_TOOL_CALL_LATENCY,
+} from './constants.js';
+import type {
+  ContentGeneratorConfig,
+  TelemetryConfig,
+} from '../internal/interfaces.js';
+
+const INT_FLOATING_POINT_WARNING =
+  'INT value type cannot accept a floating-point value';
+
+/**
+ * Fully typed structural config double. TelemetryConfig requires every getter,
+ * so the double provides benign values for the members the metrics path never
+ * reads; no type assertions needed.
+ */
+const testConfig: TelemetryConfig = {
+  getSessionId: (): string => 'value-type-behavior-test',
+  getTelemetryEnabled: (): boolean => true,
+  getTelemetryLogPromptsEnabled: (): boolean => false,
+  getTelemetryOutfile: (): string | undefined => undefined,
+  getDebugMode: (): boolean => false,
+  getConversationLoggingEnabled: (): boolean => false,
+  getModel: (): string => 'test-model',
+  getEmbeddingModel: (): string | undefined => undefined,
+  getSandbox: (): unknown => undefined,
+  getCoreTools: (): string[] | undefined => undefined,
+  getApprovalMode: (): string => 'default',
+  getContentGeneratorConfig: (): ContentGeneratorConfig | undefined =>
+    undefined,
+  getFileFilteringRespectGitIgnore: (): boolean => true,
+  getMcpServers: (): Record<string, unknown> | undefined => undefined,
+};
+
+interface HistogramSummary {
+  count: number;
+  sum: number;
+}
+
+function isHistogramMetric(metric: MetricData): metric is HistogramMetricData {
+  return metric.dataPointType === DataPointType.HISTOGRAM;
+}
+
+function summarizeHistogram(
+  resourceMetrics: ResourceMetrics,
+  metricName: string,
+): HistogramSummary | undefined {
+  const metric = resourceMetrics.scopeMetrics
+    .flatMap((scope) => scope.metrics)
+    .filter((entry) => entry.descriptor.name === metricName)
+    .find(isHistogramMetric);
+  if (metric === undefined) return undefined;
+  const point = metric.dataPoints.at(0);
+  if (point === undefined) return undefined;
+  return { count: point.value.count, sum: point.value.sum ?? 0 };
+}
+
+describe('latency histogram value types (real OpenTelemetry SDK)', () => {
+  let meterProvider: MeterProvider;
+  let reader: PeriodicExportingMetricReader;
+  let diagMessages: string[];
+
+  beforeEach((): void => {
+    resetMetricsState();
+    diagMessages = [];
+    const capture = (message: string): void => {
+      diagMessages.push(message);
+    };
+    const capturingLogger: DiagLogger = {
+      error: capture,
+      warn: capture,
+      info: capture,
+      debug: capture,
+      verbose: capture,
+    };
+    diag.setLogger(capturingLogger, DiagLogLevel.WARN);
+
+    reader = new PeriodicExportingMetricReader({
+      exporter: new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE),
+    });
+    meterProvider = new MeterProvider({ readers: [reader] });
+    metrics.setGlobalMeterProvider(meterProvider);
+  });
+
+  afterEach(async (): Promise<void> => {
+    resetMetricsState();
+    await meterProvider.shutdown();
+    metrics.disable();
+    diag.disable();
+  });
+
+  it('stores the exact fractional API request latency without an INT truncation warning', async (): Promise<void> => {
+    initializeMetrics(testConfig);
+    recordApiResponseMetrics(testConfig, 'test-model', 823.5471);
+
+    const collection = await reader.collect();
+    const summary = summarizeHistogram(
+      collection.resourceMetrics,
+      METRIC_API_REQUEST_LATENCY,
+    );
+
+    expect(summary?.count).toBe(1);
+    expect(summary?.sum).toBe(823.5471);
+    expect(
+      diagMessages.some((message) =>
+        message.includes(INT_FLOATING_POINT_WARNING),
+      ),
+    ).toBe(false);
+  });
+
+  it('stores the exact fractional tool call latency without an INT truncation warning', async (): Promise<void> => {
+    initializeMetrics(testConfig);
+    recordToolCallMetrics(testConfig, 'test-tool', 17.25, true);
+
+    const collection = await reader.collect();
+    const summary = summarizeHistogram(
+      collection.resourceMetrics,
+      METRIC_TOOL_CALL_LATENCY,
+    );
+
+    expect(summary?.count).toBe(1);
+    expect(summary?.sum).toBe(17.25);
+    expect(
+      diagMessages.some((message) =>
+        message.includes(INT_FLOATING_POINT_WARNING),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/telemetry/src/telemetry/metrics.valueType.behavior.test.ts
+++ b/packages/telemetry/src/telemetry/metrics.valueType.behavior.test.ts
@@ -80,8 +80,8 @@ function summarizeHistogram(
     .filter((entry) => entry.descriptor.name === metricName)
     .find(isHistogramMetric);
   if (metric === undefined) return undefined;
-  const point = metric.dataPoints.at(0);
-  if (point === undefined) return undefined;
+  if (metric.dataPoints.length === 0) return undefined;
+  const point = metric.dataPoints[0];
   return { count: point.value.count, sum: point.value.sum ?? 0 };
 }
 
@@ -114,9 +114,12 @@ describe('latency histogram value types (real OpenTelemetry SDK)', () => {
 
   afterEach(async (): Promise<void> => {
     resetMetricsState();
-    await meterProvider.shutdown();
-    metrics.disable();
-    diag.disable();
+    try {
+      await meterProvider.shutdown();
+    } finally {
+      metrics.disable();
+      diag.disable();
+    }
   });
 
   it('stores the exact fractional API request latency without an INT truncation warning', async (): Promise<void> => {

--- a/project-plans/issue3259/plan.md
+++ b/project-plans/issue3259/plan.md
@@ -201,14 +201,19 @@ INT, so no change was made here.
 
 - Round 1: one LOW finding. `summarizeHistogram` indexed
   `metric.dataPoints[0]` directly; a metric with zero data points
-  would throw a TypeError that masks the assertion failure. Fixed by
-  adding an undefined guard.
-- That guard tripped `@typescript-eslint/no-unnecessary-condition`
-  because `[0]` indexing types as always-defined; switched to
-  `dataPoints.at(0)` (typed `T | undefined`, matches existing repo
-  usage in `packages/cli/src/utils/sandbox-env.ts` and
-  `mcpPromptArgParser.ts`). Lint re-run: exit 0.
-- Round 2: zero findings. The `.at(0)` one-token change postdates
-  round 2 and was validated by lint, typecheck, the behavior test
-  (2/2), and the telemetry workspace suite (43/43); both OCR rounds
-  were spent per the workflow cap.
+  would throw a TypeError that masks the assertion failure.
+- Guard evolution: an explicit `point === undefined` check next to
+  `[0]` indexing tripped `@typescript-eslint/no-unnecessary-condition`
+  (the index type reads as always-defined), while `dataPoints.at(0)`
+  passed lint but failed typecheck because the telemetry package's
+  tsconfig lib predates ES2022. The final guard is
+  `if (metric.dataPoints.length === 0) return undefined;` before the
+  `[0]` index, which needs no lib bump and satisfies lint.
+- Round 2: zero findings. Both OCR rounds were spent per the workflow
+  cap; the guard's final form was validated by lint, typecheck, the
+  behavior test (2/2), and the telemetry workspace suite (43/43).
+- PR inline review (LLxprt ocr bot): one bug/medium finding —
+  `afterEach` awaited `meterProvider.shutdown()` unguarded, so a
+  rejection would skip `metrics.disable()` and `diag.disable()`.
+  Fixed with try/finally: shutdown still propagates fail-fast, the
+  disables always run.

--- a/project-plans/issue3259/plan.md
+++ b/project-plans/issue3259/plan.md
@@ -1,0 +1,214 @@
+# Plan: Stop OTel INT/Floating-Point Warnings in Non-Interactive Output (Issue #3259)
+
+Plan ID: PLAN-20260820-ISSUE3259
+Generated: 2026-08-20
+Issue: #3259
+Status: Implemented; compliance review GO; OCR clean (2 rounds)
+
+## Problem statement
+
+Every API request whose duration has a fractional-millisecond part prints
+this OpenTelemetry diagnostic to the console:
+
+```
+INT value type cannot accept a floating-point value for llxprt_code.api.request.latency, ignoring the fractional digits.
+```
+
+In non-interactive mode (`llxprt -p "..."`) the warning interleaves with
+the response output, so piped or parsed stdout gets junk lines. A single
+one-shot prompt produced two of them (one per recorded API request).
+
+Root cause chain (verified on the issue branch):
+
+1. `packages/telemetry/src/telemetry/metrics.ts:67-82` declares both
+   latency histograms (`llxprt_code.tool.call.latency`,
+   `llxprt_code.api.request.latency`) with `valueType: ValueType.INT`.
+2. Recorded durations are `performance.now()` deltas
+   (`packages/providers/src/LoggingProviderWrapper.ts`,
+   `packages/providers/src/logging/attemptRecorder.ts`,
+   `packages/telemetry/src/telemetry/events/tool-events.ts:71`), which are
+   fractional milliseconds, e.g. `823.5471`.
+3. `@opentelemetry/sdk-metrics` `SyncInstrument._record()` calls
+   `diag.warn(...)` when an INT instrument receives a non-integer, then
+   truncates with `Math.trunc()` and records anyway.
+4. `packages/telemetry/src/telemetry/sdk.ts:51` wires
+   `diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO)`, so the
+   warning lands on the console.
+
+## Preflight findings
+
+1. These are the only two histograms in the codebase
+   (`createHistogram` appears only in `metrics.ts` and test mocks).
+2. All counters (`tool.call.count`, `api.request.count`, `token.usage`,
+   `file.operation.count`, `session.count`) record integer values only
+   (`add(1, ...)`, integer token counts); they keep `ValueType.INT` and
+   are out of scope.
+3. `@opentelemetry/sdk-metrics` 2.8.0 is a direct dependency of
+   `packages/telemetry` and ships `InMemoryMetricExporter` plus
+   `PeriodicExportingMetricReader`, so a real-SDK behavioral test can
+   assert exported histogram values without mock theater.
+4. `metrics.ts` obtains its meter via `metrics.getMeter(SERVICE_NAME)`
+   from `@opentelemetry/api`, so registering a real
+   `MeterProvider` as the global provider makes `initializeMetrics` wire
+   the real SDK instruments; `resetMetricsState()` exists for cleanup.
+5. Consumers of the OTel metric export path are the file/console metric
+   exporters only. Session `/stats` and `uiTelemetry` aggregate from log
+   event attributes (`duration_ms`), not from OTel metric export, so
+   changing the histogram value type to DOUBLE has no downstream
+   integer assumptions to break.
+6. `docs/telemetry.md` describes the metric as
+   "`llxprt_code.api.request.latency` (histogram, ms)" with no INT/DOUBLE
+   mention; no doc change needed.
+7. Existing mocked tests (`packages/telemetry/src/telemetry/metrics.test.ts`,
+   `packages/core/src/telemetry/metrics.test.ts`) mock
+   `@opentelemetry/api` with `ValueType: { INT: 1 }`; the histogram
+   creation mock ignores options, so changing INT to DOUBLE does not
+   break them.
+8. `packages/core/src/telemetry/metrics.ts` is a pure re-export of the
+   telemetry package; the fix lands once in
+   `packages/telemetry/src/telemetry/metrics.ts`.
+
+## Proposed accepted behavior
+
+### REQ-3259-1: Latency histograms accept fractional milliseconds
+
+**Full text:** The `llxprt_code.api.request.latency` and
+`llxprt_code.tool.call.latency` histograms are declared with
+`ValueType.DOUBLE`. Recording a fractional-millisecond duration stores
+the exact value (no truncation) and emits no OpenTelemetry diagnostic.
+
+- GIVEN a real OTel SDK meter provider with an in-memory metric reader
+  and a captured diag logger
+- WHEN `recordApiResponseMetrics` is called with `durationMs = 823.5471`
+- THEN the exported `llxprt_code.api.request.latency` histogram has
+  count 1 and sum exactly `823.5471`
+- AND no captured diag message contains "INT value type cannot accept a
+  floating-point value"
+
+### REQ-3259-2: Tool-call latency keeps fractional precision too
+
+**Full text:** Same contract for tool calls.
+
+- GIVEN the same real-SDK setup
+- WHEN `recordToolCallMetrics` is called with `durationMs = 17.25`
+- THEN the exported `llxprt_code.tool.call.latency` histogram has
+  count 1 and sum exactly `17.25`
+- AND no captured diag message contains the INT/floating-point warning
+
+### REQ-3259-3: Count histograms remain INT where values are counts
+
+**Full text:** Counters stay `ValueType.INT`. No counter receives
+fractional values today, so no warning path exists for them; the test
+suite does not encode an implementation-detail assertion for counters.
+
+### REQ-3259-4: Behavioral test owns the contract
+
+**Full text:** A new Bun test
+(`packages/telemetry/src/telemetry/metrics.valueType.behavior.test.ts`)
+drives the REAL SDK (real `MeterProvider`, real instruments, real record
+path via `initializeMetrics`/`record*Metrics`, in-memory exporter as the
+only infrastructure seam) and asserts the exported values plus absence
+of the diag warning. The test fails against the current INT
+declarations (RED) and passes after the DOUBLE change (GREEN). It
+restores the global meter provider and diag logger on cleanup.
+
+## Implementation tasks
+
+### Files to modify
+
+- `packages/telemetry/src/telemetry/metrics.ts`
+  - `toolCallLatencyHistogram` creation: `valueType: ValueType.INT` →
+    `ValueType.DOUBLE`
+  - `apiRequestLatencyHistogram` creation: `valueType: ValueType.INT` →
+    `ValueType.DOUBLE`
+  - No other lines change.
+
+### Files to create
+
+- `packages/telemetry/src/telemetry/metrics.valueType.behavior.test.ts`
+  - Real-SDK behavioral test for REQ-3259-1/2/4 (Bun test, TypeScript,
+    no `@opentelemetry/api` mocking).
+  - Copyright header year: 2026.
+
+## Implementation notes
+
+- Do NOT round durations at record sites; the record path keeps its
+  current signatures and passthrough values.
+- Do NOT touch `sdk.ts` diag wiring (option 3 in the issue is a
+  separate, broader consideration; DOUBLE removes this warning at the
+  source).
+- Test cleanup must restore prior state because Bun runs test files in
+  one process per file: `resetMetricsState()`, shutdown the test meter
+  provider, restore/disable the global meter provider, and restore the
+  diag logger via `diag.disable()` or a saved logger.
+- The diag capture logger installs at `DiagLogLevel.WARN` (the SDK emits
+  the truncation warning at warn level).
+- If `InMemoryMetricExporter` API shape differs in 2.8.0 (e.g.
+  `getMetricReader()`/`getMetrics()` naming), adapt to the installed
+  version; verify with a quick read of the installed `.d.ts` before
+  writing assertions.
+
+## Verification
+
+Full cycle per the issue workflow:
+
+1. `npm run test`
+2. `npm run lint`
+3. `npm run typecheck`
+4. `npm run format`
+5. `npm run build`
+6. `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+
+Plus targeted confirmation that the new behavioral test fails against
+the unchanged INT declarations (run it once before the two-line fix as
+the RED step).
+
+## Verification and review outcome
+
+- RED proven twice (driver and reviewer, via `git stash push --` of
+  metrics.ts): sums truncated to 823 and 17, both tests fail. GREEN
+  after the DOUBLE change: 2/2 pass.
+- Telemetry workspace via the official isolated runner: 43/43 files.
+- Full monorepo cycle: lint 0, typecheck 0 (initial typecheck run
+  failed in packages/a2a-server against a stale providers dist because
+  it ran before build; re-run after `npm run build` exited 0), format 0
+  (no file changes), build 0, smoke test green
+  (`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`)
+  with zero INT/floating-point warnings in the output.
+- `npm run test` exited 1 from exactly two unrelated core files:
+  `packages/core/test/utils/ripgrepPathResolver.test.ts` (4 tests) fails
+  identically on the clean stashed baseline, and
+  `packages/core/src/recording/SessionLockManager.safety.test.ts` is a
+  subprocess race test that passes standalone on both baseline and this
+  branch and only failed under full-suite concurrency. Neither imports
+  the changed code.
+- AST test-audit scanner: zero findings on the new test file.
+- Compliance review (deepthinker subagent): PASS on all four REQs,
+  independently re-ran RED/GREEN, telemetry suite, typecheck, lint.
+  Verdict GO.
+
+### Known follow-up (out of scope, LOW)
+
+`tokenUsageCounter.add` accepts any number and providers normalize
+usage without forcing integers
+(`packages/providers/src/logging/tokenCounts.ts`). A misbehaving
+provider returning a fractional token count could still trigger the
+same OTel warning for `llxprt_code.token.usage`. No current producer
+produces fractional counts, and the plan requires counters to stay
+INT, so no change was made here.
+
+### Open code review
+
+- Round 1: one LOW finding. `summarizeHistogram` indexed
+  `metric.dataPoints[0]` directly; a metric with zero data points
+  would throw a TypeError that masks the assertion failure. Fixed by
+  adding an undefined guard.
+- That guard tripped `@typescript-eslint/no-unnecessary-condition`
+  because `[0]` indexing types as always-defined; switched to
+  `dataPoints.at(0)` (typed `T | undefined`, matches existing repo
+  usage in `packages/cli/src/utils/sandbox-env.ts` and
+  `mcpPromptArgParser.ts`). Lint re-run: exit 0.
+- Round 2: zero findings. The `.at(0)` one-token change postdates
+  round 2 and was validated by lint, typecheck, the behavior test
+  (2/2), and the telemetry workspace suite (43/43); both OCR rounds
+  were spent per the workflow cap.


### PR DESCRIPTION
## TLDR

Both OTel latency histograms (`llxprt_code.api.request.latency`, `llxprt_code.tool.call.latency`) were declared `ValueType.INT` while every recorded duration is a fractional `performance.now()` delta. The SDK warned on nearly every API request, truncated the value, and printed the diagnostic to the console; in non-interactive runs (`-p`) that line pollutes stdout for piped consumers. The fix is two lines: both histograms are now `ValueType.DOUBLE`. Durations keep sub-millisecond precision instead of being silently truncated, and the warning is gone at the source. Counters stay INT (they only ever record literal 1 or integer token counts).

## Dive Deeper

- Root cause chain: `packages/telemetry/src/telemetry/metrics.ts` declared the histograms INT; durations originate as `performance.now()` deltas in `LoggingProviderWrapper.ts`, `attemptRecorder.ts`, and `tool-events.ts`; `@opentelemetry/sdk-metrics` `SyncInstrument._record()` warns + `Math.trunc()`s non-integers; `sdk.ts:51` wires `DiagConsoleLogger` at INFO so it prints.
- Scope is deliberately minimal: no rounding at record sites, no `sdk.ts` diag changes, no counter changes. Plan: `project-plans/issue3259/plan.md`.
- New behavioral test `metrics.valueType.behavior.test.ts` drives the REAL SDK (real `MeterProvider` + `PeriodicExportingMetricReader` + `InMemoryMetricExporter`, global provider registration, captured diag logger) and asserts exported histogram sums keep exact fractional values (823.5471 / 17.25) with no INT truncation diagnostic. Verified RED against the old INT declarations (sums truncated to 823 and 17) and GREEN after the change. Cleanup restores global meter/diag state (each file already runs in its own process under `scripts/run_bun_tests.ts`).
- No downstream integer contracts break: `FileMetricExporter` serializes plain JSON numbers, and `/stats` + UI aggregation consume log-event `duration_ms`, not OTel metric export.
- Known LOW follow-up (out of scope, documented in the plan): a misbehaving provider returning fractional token counts could still warn on `llxprt_code.token.usage`; no current producer does.

## Reviewer Test Plan

1. `bun test packages/telemetry/src/telemetry/metrics.valueType.behavior.test.ts` — 2 pass. Then `git stash push -- packages/telemetry/src/telemetry/metrics.ts`, re-run (expect 2 fail, truncated sums), `git stash pop`.
2. `cd packages/telemetry && bun ../../scripts/run_bun_tests.ts --workspace telemetry` — 43/43 files.
3. Non-interactive repro from the issue: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` — confirm output contains the haiku and zero `INT value type cannot accept` lines.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Full cycle on 🍏 (twice): `npm run test` (only two unrelated pre-existing/flaky core files fail: `ripgrepPathResolver.test.ts` fails identically on a clean baseline, proven via stash; `SessionLockManager.safety.test.ts` is a subprocess race test that passes standalone on baseline and this branch), `npm run lint` 0, `npm run typecheck` 0 (after build; typecheck before build fails in `a2a-server` against stale dist, an ordering artifact), `npm run format` 0, `npm run build` 0, smoke green with zero warnings.

## Linked issues / bugs

Fixes #3259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry accuracy by preserving fractional values in API request and tool-call latency measurements.
  * Prevented fractional latency data from being truncated or generating integer-value warnings.

* **Tests**
  * Added coverage using real metric collection to verify accurate latency counts and sums.
  * Added checks confirming fractional values are retained and no diagnostic warnings are emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->