### PR TITLE
Stop recording the same content twice across history rebuilds (Fixes #3132)

### DIFF
--- a/packages/core/src/recording/RecordingIntegration.compressionBoundary.test.ts
+++ b/packages/core/src/recording/RecordingIntegration.compressionBoundary.test.ts
@@ -270,6 +270,7 @@ describe('RecordingIntegration duplicate content guard @issue:3132', () => {
   afterEach(async () => {
     harness.integration.dispose();
     await harness.recordingService.dispose();
+    harness.historyService.dispose();
     await fs.rm(harness.tempDir, { recursive: true, force: true });
   });
 

--- a/packages/core/src/recording/RecordingIntegration.compressionBoundary.test.ts
+++ b/packages/core/src/recording/RecordingIntegration.compressionBoundary.test.ts
@@ -1,0 +1,529 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @issue #3132
+ *
+ * A session recording must never contain the same content record twice.
+ * Production rebuilds history wholesale by calling `HistoryService.clear()`
+ * and re-`add()`ing the retained entries; each re-`add()` emits
+ * `contentAdded`, and `ReplayEngine` pushes every `content` record, so an
+ * unguarded rebuild replays into doubled history on resume.
+ *
+ * Real HistoryService, real SessionRecordingService writing JSONL into a
+ * temp dir, real ReplayEngine. Assertions are on the recorded file, the
+ * replayed history, and the live history only.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { HistoryService } from '../services/history/HistoryService.js';
+import { type IContent } from '../services/history/IContent.js';
+import { RecordingIntegration } from './RecordingIntegration.js';
+import { SessionRecordingService } from './SessionRecordingService.js';
+import { replaySession } from './ReplayEngine.js';
+import {
+  type SessionRecordingServiceConfig,
+  type ReplayResult,
+} from './types.js';
+
+const PROJECT_HASH = 'project-hash-compression-boundary';
+const SESSION_ID = 'compression-boundary-session-0001';
+
+type ReplayOkResult = Extract<ReplayResult, { ok: true }>;
+
+function assertReplayOk(
+  result: ReplayResult,
+): asserts result is ReplayOkResult {
+  expect(result.ok).toBe(true);
+}
+
+interface JsonlEvent {
+  readonly type: string;
+  readonly payload: unknown;
+}
+
+function isJsonlEvent(value: unknown): value is JsonlEvent {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { type?: unknown }).type === 'string'
+  );
+}
+
+function isContentPayload(value: unknown): value is { content: IContent } {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const content = (value as { content?: unknown }).content;
+  return (
+    typeof content === 'object' &&
+    content !== null &&
+    Array.isArray((content as { blocks?: unknown }).blocks)
+  );
+}
+
+function makeConfig(chatsDir: string): SessionRecordingServiceConfig {
+  return {
+    sessionId: SESSION_ID,
+    projectHash: PROJECT_HASH,
+    chatsDir,
+    workspaceDirs: ['/workspace/project'],
+    provider: 'anthropic',
+    model: 'claude-4',
+  };
+}
+
+function textContent(
+  text: string,
+  speaker: IContent['speaker'] = 'human',
+): IContent {
+  return { speaker, blocks: [{ type: 'text', text }] };
+}
+
+function toolCallContent(toolName: string): IContent {
+  return {
+    speaker: 'ai',
+    blocks: [
+      { type: 'text', text: `call ${toolName}` },
+      {
+        type: 'tool_call',
+        id: `call_${toolName}`,
+        name: toolName,
+        parameters: {},
+      },
+    ],
+  };
+}
+
+function toolResponseContent(toolName: string): IContent {
+  return {
+    speaker: 'tool',
+    blocks: [
+      {
+        type: 'tool_response',
+        callId: `call_${toolName}`,
+        toolName,
+        result: { ok: true },
+      },
+    ],
+  };
+}
+
+/** The text of every text block, in order. */
+function textsOf(contents: readonly IContent[]): string[] {
+  const texts: string[] = [];
+  for (const content of contents) {
+    for (const block of content.blocks) {
+      if (block.type === 'text') {
+        texts.push(block.text);
+      }
+    }
+  }
+  return texts;
+}
+
+function collectToolCallIds(contents: readonly IContent[]): string[] {
+  const ids: string[] = [];
+  for (const content of contents) {
+    for (const block of content.blocks) {
+      if (block.type === 'tool_call') {
+        ids.push(block.id);
+      }
+    }
+  }
+  return ids;
+}
+
+function collectToolResponseCallIds(contents: readonly IContent[]): string[] {
+  const ids: string[] = [];
+  for (const content of contents) {
+    for (const block of content.blocks) {
+      if (block.type === 'tool_response') {
+        ids.push(block.callId);
+      }
+    }
+  }
+  return ids;
+}
+
+function hasNoDuplicates(values: readonly string[]): boolean {
+  return new Set(values).size === values.length;
+}
+
+async function readEvents(filePath: string): Promise<JsonlEvent[]> {
+  const raw = await fs.readFile(filePath, 'utf-8');
+  if (raw.trim() === '') {
+    return [];
+  }
+  const events: JsonlEvent[] = [];
+  for (const line of raw.trim().split('\n')) {
+    const parsed: unknown = JSON.parse(line);
+    if (isJsonlEvent(parsed)) {
+      events.push(parsed);
+    }
+  }
+  return events;
+}
+
+/** The `IContent` of every `content` record in the file, in written order. */
+function recordedContents(events: readonly JsonlEvent[]): IContent[] {
+  const contents: IContent[] = [];
+  for (const event of events) {
+    if (event.type === 'content' && isContentPayload(event.payload)) {
+      contents.push(event.payload.content);
+    }
+  }
+  return contents;
+}
+
+/** Serialized form of each recorded content, for byte-identity comparison. */
+function recordedFingerprints(events: readonly JsonlEvent[]): string[] {
+  return recordedContents(events).map((content) => JSON.stringify(content));
+}
+
+function countType(events: readonly JsonlEvent[], type: string): number {
+  return events.filter((event) => event.type === type).length;
+}
+
+/**
+ * Replace history wholesale the way the hard-limit truncation fallback and the
+ * provider-content restore do: snapshot, `clear()`, re-`add()`. Runs outside
+ * any compression window, which is exactly what makes it a duplicate source.
+ */
+function rebuildHistoryInPlace(historyService: HistoryService): void {
+  const snapshot = historyService.getCurated();
+  historyService.clear();
+  for (const content of snapshot) {
+    historyService.add(content);
+  }
+}
+
+/** Run a compression cycle whose rebuild happens under the compression lock. */
+function compressUnderLock(
+  historyService: HistoryService,
+  summaryText: string,
+): void {
+  historyService.startCompression();
+  const snapshot = historyService.getCurated();
+  const itemsCompressed = snapshot.length;
+  historyService.clear();
+  for (const content of snapshot) {
+    historyService.add(content);
+  }
+  historyService.endCompression(
+    textContent(summaryText, 'ai'),
+    itemsCompressed,
+  );
+}
+
+interface RecordingHarness {
+  readonly tempDir: string;
+  readonly chatsDir: string;
+  readonly recordingService: SessionRecordingService;
+  readonly integration: RecordingIntegration;
+  readonly historyService: HistoryService;
+}
+
+async function createHarness(): Promise<RecordingHarness> {
+  const tempDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'recording-compression-boundary-'),
+  );
+  const chatsDir = path.join(tempDir, 'chats');
+  await fs.mkdir(chatsDir, { recursive: true });
+  const recordingService = new SessionRecordingService(makeConfig(chatsDir));
+  const integration = new RecordingIntegration(recordingService);
+  const historyService = new HistoryService();
+  integration.subscribeToHistory(historyService);
+  return {
+    tempDir,
+    chatsDir,
+    recordingService,
+    integration,
+    historyService,
+  };
+}
+
+describe('RecordingIntegration duplicate content guard @issue:3132', () => {
+  let harness: RecordingHarness;
+
+  beforeEach(async () => {
+    harness = await createHarness();
+  });
+
+  afterEach(async () => {
+    harness.integration.dispose();
+    await harness.recordingService.dispose();
+    await fs.rm(harness.tempDir, { recursive: true, force: true });
+  });
+
+  async function flushAndReadEvents(): Promise<JsonlEvent[]> {
+    await harness.integration.flushAtTurnBoundary();
+    const filePath = harness.recordingService.getFilePath();
+    expect(filePath).not.toBeNull();
+    return readEvents(filePath ?? '');
+  }
+
+  async function flushAndReplay(): Promise<ReplayOkResult> {
+    await harness.integration.flushAtTurnBoundary();
+    const filePath = harness.recordingService.getFilePath();
+    expect(filePath).not.toBeNull();
+    const replay = await replaySession(filePath ?? '', PROJECT_HASH);
+    assertReplayOk(replay);
+    return replay;
+  }
+
+  function recordToolTurn(label: string): IContent[] {
+    const turn = [
+      textContent(`${label}-user`),
+      toolCallContent(`${label}-alpha`),
+      toolResponseContent(`${label}-alpha`),
+      toolCallContent(`${label}-beta`),
+      toolResponseContent(`${label}-beta`),
+    ];
+    for (const content of turn) {
+      harness.historyService.add(content);
+    }
+    return turn;
+  }
+
+  it('records a wholesale history rebuild exactly once', async () => {
+    const turn = recordToolTurn('rebuild');
+
+    rebuildHistoryInPlace(harness.historyService);
+
+    const events = await flushAndReadEvents();
+    expect(recordedContents(events)).toHaveLength(turn.length);
+    expect(hasNoDuplicates(recordedFingerprints(events))).toBe(true);
+
+    const replay = await flushAndReplay();
+    expect(collectToolCallIds(replay.history)).toStrictEqual([
+      'call_rebuild-alpha',
+      'call_rebuild-beta',
+    ]);
+    expect(collectToolResponseCallIds(replay.history)).toStrictEqual([
+      'call_rebuild-alpha',
+      'call_rebuild-beta',
+    ]);
+
+    const live = harness.historyService.getAll();
+    expect(hasNoDuplicates(collectToolCallIds(live))).toBe(true);
+    expect(hasNoDuplicates(collectToolResponseCallIds(live))).toBe(true);
+  });
+
+  it('records a compression between turns without duplicating content', async () => {
+    harness.historyService.add(textContent('turn-1-user'));
+    harness.historyService.add(textContent('turn-1-ai', 'ai'));
+
+    compressUnderLock(harness.historyService, 'between-turns-summary');
+
+    harness.historyService.add(textContent('turn-2-user'));
+
+    const events = await flushAndReadEvents();
+    expect(textsOf(recordedContents(events))).toStrictEqual([
+      'turn-1-user',
+      'turn-1-ai',
+      'turn-2-user',
+    ]);
+    expect(hasNoDuplicates(recordedFingerprints(events))).toBe(true);
+    expect(countType(events, 'compressed')).toBe(1);
+  });
+
+  it('keeps content that arrives mid-compression in history without duplicating records', async () => {
+    harness.historyService.add(textContent('mid-1-user'));
+    harness.historyService.add(textContent('mid-2-ai', 'ai'));
+
+    // Real ordering: the compression rebuild is queued first, then a stream
+    // add that arrived while the lock was held is flushed behind it.
+    harness.historyService.startCompression();
+    const snapshot = harness.historyService.getCurated();
+    harness.historyService.clear();
+    for (const content of snapshot) {
+      harness.historyService.add(content);
+    }
+    harness.historyService.add(textContent('mid-arrival', 'ai'));
+    harness.historyService.endCompression(
+      textContent('mid-turn-summary', 'ai'),
+      snapshot.length,
+    );
+
+    const live = harness.historyService.getAll();
+    expect(textsOf(live).filter((text) => text === 'mid-arrival')).toHaveLength(
+      1,
+    );
+
+    const events = await flushAndReadEvents();
+    expect(hasNoDuplicates(recordedFingerprints(events))).toBe(true);
+    expect(countType(events, 'compressed')).toBe(1);
+  });
+
+  it('records a truncation-fallback rebuild that follows a compression mid-turn exactly once', async () => {
+    const turn = recordToolTurn('fallback');
+
+    // The hard-limit path compresses, then rebuilds again outside the lock.
+    compressUnderLock(harness.historyService, 'fallback-summary');
+    rebuildHistoryInPlace(harness.historyService);
+
+    const events = await flushAndReadEvents();
+    expect(recordedContents(events)).toHaveLength(turn.length);
+    expect(hasNoDuplicates(recordedFingerprints(events))).toBe(true);
+
+    const replay = await flushAndReplay();
+    expect(hasNoDuplicates(collectToolResponseCallIds(replay.history))).toBe(
+      true,
+    );
+  });
+
+  it('records a retried turn crossing a compression boundary without duplicating the original', async () => {
+    recordToolTurn('retry');
+
+    compressUnderLock(harness.historyService, 'retry-summary');
+    // The retry re-enforces the context window, which rebuilds history.
+    rebuildHistoryInPlace(harness.historyService);
+
+    // The retried attempt then contributes genuinely new content.
+    harness.historyService.add(toolCallContent('retry-gamma'));
+    harness.historyService.add(toolResponseContent('retry-gamma'));
+
+    const events = await flushAndReadEvents();
+    expect(hasNoDuplicates(recordedFingerprints(events))).toBe(true);
+    expect(collectToolCallIds(recordedContents(events))).toStrictEqual([
+      'call_retry-alpha',
+      'call_retry-beta',
+      'call_retry-gamma',
+    ]);
+
+    const replay = await flushAndReplay();
+    expect(hasNoDuplicates(collectToolResponseCallIds(replay.history))).toBe(
+      true,
+    );
+
+    const live = harness.historyService.getAll();
+    expect(hasNoDuplicates(collectToolCallIds(live))).toBe(true);
+    expect(hasNoDuplicates(collectToolResponseCallIds(live))).toBe(true);
+  });
+
+  it('records content whose chronology marker is reused by a different payload', async () => {
+    const original = toolCallContent('inherit');
+    harness.historyService.add(original);
+
+    // Density optimization and merge both hand a DIFFERENT payload an existing
+    // chronology marker. Identity alone must not suppress it.
+    const replacement: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'condensed replacement' }],
+      metadata: { ...original.metadata },
+    };
+    harness.historyService.add(replacement);
+
+    const events = await flushAndReadEvents();
+    const contents = recordedContents(events);
+    expect(contents).toHaveLength(2);
+    expect(textsOf(contents)).toContain('condensed replacement');
+  });
+
+  it('does not re-record history that is already in the recording when a resumed session rebuilds', async () => {
+    recordToolTurn('resumed');
+    await harness.integration.flushAtTurnBoundary();
+    const filePath = harness.recordingService.getFilePath();
+    expect(filePath).not.toBeNull();
+    const sessionPath = filePath ?? '';
+
+    harness.integration.dispose();
+    await harness.recordingService.dispose();
+
+    const replayed = await replaySession(sessionPath, PROJECT_HASH);
+    assertReplayOk(replayed);
+    const recordsBeforeResume = replayed.history.length;
+
+    // Resume: append to the same file, restore the replayed history, then
+    // subscribe. A later rebuild must not append the restored entries again.
+    const resumedRecording = new SessionRecordingService(
+      makeConfig(harness.chatsDir),
+    );
+    resumedRecording.initializeForResume(sessionPath, replayed.lastSeq);
+    const resumedIntegration = new RecordingIntegration(resumedRecording);
+    const resumedHistory = new HistoryService();
+    await resumedHistory.replaceAll(replayed.history);
+    resumedIntegration.subscribeToHistory(resumedHistory);
+
+    try {
+      compressUnderLock(resumedHistory, 'resumed-summary');
+      rebuildHistoryInPlace(resumedHistory);
+      resumedHistory.add(textContent('post-resume-user'));
+
+      await resumedIntegration.flushAtTurnBoundary();
+      const events = await readEvents(sessionPath);
+      expect(hasNoDuplicates(recordedFingerprints(events))).toBe(true);
+      expect(recordedContents(events)).toHaveLength(recordsBeforeResume + 1);
+      expect(textsOf(recordedContents(events))).toContain('post-resume-user');
+    } finally {
+      resumedIntegration.dispose();
+      await resumedRecording.dispose();
+      resumedHistory.dispose();
+    }
+  });
+
+  it('records content that carries no chronology marker', async () => {
+    harness.historyService.emit('contentAdded', textContent('no-marker-1'));
+    harness.historyService.emit('contentAdded', textContent('no-marker-2'));
+
+    const events = await flushAndReadEvents();
+    expect(textsOf(recordedContents(events))).toStrictEqual([
+      'no-marker-1',
+      'no-marker-2',
+    ]);
+  });
+
+  it('records content from a replacement HistoryService whose chronology restarts', async () => {
+    const replacementService = new HistoryService();
+    harness.integration.subscribeToHistory(replacementService);
+
+    try {
+      // Fresh service: seqs restart at 1 and would collide with the harness
+      // service's seqs, so identity cannot rest on the seq alone.
+      replacementService.add(textContent('replacement-1'));
+      replacementService.add(textContent('replacement-2', 'ai'));
+
+      const events = await flushAndReadEvents();
+      expect(textsOf(recordedContents(events))).toStrictEqual([
+        'replacement-1',
+        'replacement-2',
+      ]);
+    } finally {
+      replacementService.dispose();
+    }
+  });
+
+  it('does not re-record earlier content when the same HistoryService is re-subscribed', async () => {
+    harness.historyService.add(textContent('before-resubscribe'));
+
+    harness.integration.unsubscribeFromHistory();
+    harness.integration.subscribeToHistory(harness.historyService);
+
+    rebuildHistoryInPlace(harness.historyService);
+    harness.historyService.add(textContent('after-resubscribe'));
+
+    const events = await flushAndReadEvents();
+    expect(textsOf(recordedContents(events))).toStrictEqual([
+      'before-resubscribe',
+      'after-resubscribe',
+    ]);
+  });
+});

--- a/packages/core/src/recording/RecordingIntegration.ts
+++ b/packages/core/src/recording/RecordingIntegration.ts
@@ -19,6 +19,54 @@ import { type HistoryService } from '../services/history/HistoryService.js';
 import { type SessionRecordingService } from './SessionRecordingService.js';
 
 /**
+ * Two independent 32-bit multiplicative hashes of `value`, concatenated in
+ * base-36 to give a 64-bit comparison key.
+ *
+ * The low lane is FNV-1a (offset basis 0x811c9dc5, prime 0x01000193). The high
+ * lane uses the same xor-then-multiply shape with a different seed and a
+ * different odd multiplier (the murmur3 finalizer constant 0x85ebca6b) so the
+ * two lanes do not move together.
+ *
+ * This shrinks a content payload to a comparison key and is never a security
+ * boundary. A collision would additionally have to land on the same chronology
+ * `seq` before it could suppress anything.
+ */
+function fingerprint(value: string): string {
+  let low = 0x811c9dc5;
+  let high = 0x01000193;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    low = Math.imul(low ^ code, 0x01000193);
+    high = Math.imul(high ^ code, 0x85ebca6b);
+  }
+  return `${(low >>> 0).toString(36)}.${(high >>> 0).toString(36)}`;
+}
+
+/**
+ * The identity of a content record for duplicate detection: its chronology
+ * `seq` paired with a fingerprint of the exact payload.
+ *
+ * Returns `null` when the content carries no chronology marker. Such content
+ * has no identity, so it is always recorded rather than risk suppressing
+ * something that was never written.
+ *
+ * `seq` alone is NOT sufficient. It is unique only within one `HistoryService`
+ * instance, `ChronologyStamper.inherit` deliberately gives a replacement entry
+ * the replaced entry's marker, and `merge` can import entries from a foreign
+ * chronology. Pairing it with the payload fingerprint means suppression can
+ * only ever discard content byte-identical to a record already written.
+ *
+ * @issue #3132
+ */
+function contentIdentity(content: IContent): string | null {
+  const seq = content.metadata?.chronology?.seq;
+  if (typeof seq !== 'number') {
+    return null;
+  }
+  return `${seq}:${fingerprint(JSON.stringify(content))}`;
+}
+
+/**
  * Bridges HistoryService events to SessionRecordingService.
  *
  * @plan PLAN-20260211-SESSIONRECORDING.P14
@@ -29,6 +77,22 @@ export class RecordingIntegration {
   private readonly recording: SessionRecordingService;
   private historySubscription: (() => void) | null = null;
   private compressionInProgress = false;
+  /**
+   * Identities of the content records this recording already contains.
+   *
+   * Several production paths rebuild history wholesale by calling
+   * `HistoryService.clear()` and then re-`add()`ing the retained entries. Each
+   * re-`add()` emits `contentAdded`, so without this set the rebuild appends a
+   * byte-identical copy of every retained entry to the session file, and
+   * `ReplayEngine` replays those copies into doubled history on resume.
+   *
+   * Scoped to the one `SessionRecordingService` this integration wraps, so it
+   * is never reset while that file is open. Bounded by the number of distinct
+   * content records written to the session.
+   *
+   * @issue #3132
+   */
+  private readonly recordedIdentities = new Set<string>();
   private disposed = false;
 
   constructor(recording: SessionRecordingService) {
@@ -46,11 +110,25 @@ export class RecordingIntegration {
       return;
     }
 
+    // Whatever is already in history at subscribe time is content this
+    // recording either already contains (resume and fork both attach to a
+    // seeded file) or has deliberately excluded, since content added before
+    // subscribing is never recorded. Either way a later rebuild must not
+    // append it (issue #3132).
+    this.rememberExistingHistory(historyService);
+
     const onContentAdded = (content: IContent) => {
       if (this.disposed || this.compressionInProgress) {
         return;
       }
+      const identity = contentIdentity(content);
+      if (identity !== null && this.recordedIdentities.has(identity)) {
+        return;
+      }
       this.recording.recordContent(content);
+      if (identity !== null) {
+        this.recordedIdentities.add(identity);
+      }
     };
 
     const onCompressionStarted = () => {
@@ -77,6 +155,21 @@ export class RecordingIntegration {
       historyService.off('compressionStarted', onCompressionStarted);
       historyService.off('compressionEnded', onCompressionEnded);
     };
+  }
+
+  /**
+   * Seed {@link recordedIdentities} from the history that is already present
+   * on the service being subscribed to.
+   *
+   * @issue #3132
+   */
+  private rememberExistingHistory(historyService: HistoryService): void {
+    for (const content of historyService.getAll()) {
+      const identity = contentIdentity(content);
+      if (identity !== null) {
+        this.recordedIdentities.add(identity);
+      }
+    }
   }
 
   /**

--- a/project-plans/20260821-issue3132/PLAN.md
+++ b/project-plans/20260821-issue3132/PLAN.md
@@ -1,0 +1,165 @@
+# Issue #3132 — Guard against duplicate content records across compression boundaries
+
+## Status of the original hypothesis
+
+The issue assumed the bug had already been fixed incidentally, and proposed an
+identity guard in `HistoryService.addInternal` keyed on `callId` / `turnId`.
+
+Both assumptions are wrong. Empirical probe against `HEAD`
+(f80a695f3) using the real `HistoryService` + `RecordingIntegration` +
+`SessionRecordingService` stack:
+
+| Probe                                                  | Expected | Actual |
+| ------------------------------------------------------ | -------- | ------ |
+| `clear()` + re-`add()` of 5 items OUTSIDE a compression lock | 5 records | **10 records** |
+| `clear()` + re-`add()` of 3 items INSIDE a compression lock  | 3 records | 3 records |
+
+Recorded chronology seqs on the failing probe: `[1,2,3,4,5,1,2,3,4,5]`.
+In-memory history after the rebuild: 5 items, seqs `[1,2,3,4,5]`.
+
+So:
+
+- The bug **still reproduces at HEAD**. Acceptance criterion 3 resolves to its
+  second branch: "the bug is shown still to reproduce and is fixed."
+- In-memory history is **not** duplicated at rebuild time, because `clear()`
+  runs first. A guard in `HistoryService.addInternal` would never fire. The
+  duplication exists only in the emitted `contentAdded` stream and therefore
+  only in the recorded JSONL.
+
+## Why the duplicates matter
+
+`ReplayEngine.handleContent` (`packages/core/src/recording/ReplayEngine.ts:197-210`)
+does `acc.history.push(content)`. A file containing duplicate `content` records
+replays into genuinely doubled in-memory history on resume, which is then
+re-sent to the model. That is the harm the issue describes, reached through
+resume rather than through the live turn.
+
+## Root cause
+
+`RecordingIntegration.onContentAdded` records every `contentAdded` event unless
+`compressionInProgress` is true. `compressionInProgress` is driven solely by
+`compressionStarted` / `compressionEnded`.
+
+`HistoryService` emits `contentAdded` for every `add()`, including the re-`add()`
+half of a wholesale history rebuild. Rebuild paths that run **outside** a
+`startCompression()` / `endCompression()` window therefore re-record content
+that is already in the file:
+
+- `packages/agents/src/compression/pendingContextWindowEnforcement.ts:455-467`
+  — hard-limit truncation fallback. Runs mid-turn immediately after a
+  compression. This matches the issue's evidence exactly: contiguous
+  `ai tool_call` / `tool tool_response` blocks, each duplicated exactly twice,
+  with a `compressed` event between the copies.
+- `packages/agents/src/compression/providerContentEnforcement.ts:645-686`
+  `restoreHistory` — `clear()` + `addAll()`.
+- `packages/agents/src/core/ConversationManager.ts:585-600` `setHistory`.
+- `packages/agents/src/core/client.ts:578-602` `resetChat` /
+  `619-686` `restoreHistory`.
+
+`RecordingIntegration` is the only consumer of `contentAdded` in the repo
+(`grep "'contentAdded'"` finds no other subscriber), so a guard there is a
+complete fix for the observable defect.
+
+## Accepted behavior
+
+**AB-1.** `RecordingIntegration` writes a given content record at most once per
+session file. A `contentAdded` whose identity is already present in the
+recording is a re-add from a wholesale history rebuild and is not written
+again.
+
+**AB-2.** Identity is the chronology `seq` paired with a fingerprint of the
+exact payload. Suppression can therefore only ever discard content that is
+byte-identical to a record already written. Content carrying no chronology
+marker has no identity and is always recorded.
+
+**AB-3.** Identity state is scoped to the `SessionRecordingService` the
+integration wraps, not to a subscription, and is seeded on
+`subscribeToHistory` from the history already present on the service. Resume,
+fork, and session seeding all attach to a file that already contains that
+content, so a later rebuild must not append it. Re-subscribing the same
+service does not forget what was already written.
+
+**AB-4.** No change to compression behavior, to the recording format, or to
+resume semantics. Compression still suppresses via `compressionInProgress`;
+`compressed` records are unchanged; `replaceAll` still emits no `contentAdded`.
+
+### Why `seq` alone is not a sufficient identity
+
+An earlier draft suppressed on a monotonic high-water mark of `seq` alone.
+That is unsound, and the suite now has a regression test for each way it fails:
+
+- `seq` is unique only within one `HistoryService` instance
+  (`IContent.ts:71-76`), and `merge()` can import entries from a foreign
+  chronology.
+- `ChronologyStamper.inherit` (`historyChronology.ts:92-95`) deliberately gives
+  a *different* replacement payload the replaced entry's marker, which density
+  optimization relies on.
+- `validateAndFix` mints a `seq` for a synthetic entry and splices it without
+  emitting `contentAdded` (`HistoryService.ts:1037-1057`), so a `seq` can be
+  consumed without ever being recorded.
+
+Pairing `seq` with a payload fingerprint removes all three failure modes: a
+record is suppressed only when an identical one is already in the file.
+
+### Accepted trade-off
+
+Identity state is proportional to the number of distinct content records in the
+session rather than O(1). The largest session observed in the issue holds
+28,417 records, which costs a few megabytes against a 195 MB file. Losing
+records to a cheaper guard is not an acceptable trade for that.
+
+## Boundary cases covered by tests
+
+Every test asserts on the real JSONL file written by a real
+`SessionRecordingService` into a temp directory, plus `ReplayEngine` output
+and live `HistoryService` contents where relevant. Each row lists the mutation
+the test detects, verified by running the suite against that mutation.
+
+| Test                                             | Detects                                   |
+| ------------------------------------------------ | ----------------------------------------- |
+| Wholesale rebuild recorded once (reproducer)      | guard removed                             |
+| Compression between turns                         | over-suppression of new turns             |
+| Content arriving mid-compression kept in history  | over-suppression / history loss           |
+| Truncation-fallback rebuild after a compression   | guard removed                             |
+| Retry crossing a compression boundary             | guard removed                             |
+| Marker reused by a different payload              | `seq`-only identity (silent record loss)  |
+| Resumed session rebuild                           | guard removed; identity not seeded        |
+| Content with no chronology marker                 | over-suppression of unidentifiable content|
+| Replacement `HistoryService` with restarting seqs | `seq`-only identity                       |
+| Same `HistoryService` re-subscribed               | identity reset on re-subscribe            |
+
+Against the unmodified code 5 of the 10 fail; against the rejected `seq`-only
+watermark 3 of the 10 fail. No test passes unconditionally.
+
+## Files changed
+
+- `packages/core/src/recording/RecordingIntegration.ts` — the guard.
+- `packages/core/src/recording/RecordingIntegration.compressionBoundary.test.ts`
+  — new behavioral regression suite (new file; `RecordingIntegration.core.test.ts`
+  is already 450 lines and covers a different concern).
+
+## Out of scope — file separately
+
+Found while probing, not fixed here:
+
+1. `HistoryService.endCompression()` called without a summary never emits
+   `compressionEnded`, so `RecordingIntegration.compressionInProgress` stays
+   `true` for the rest of the session and **all subsequent content recording
+   silently stops**. Reached live from
+   `CompressionHandler.performCompression:676-683` on `noop` and `failed`
+   outcomes. Probe: 1 recorded content where 2 were expected.
+2. An `add()` that arrives mid-compression before a rebuild's queued `clear()`
+   is silently wiped by that clear during the `endCompression` flush, losing
+   conversation content. Probe: the mid-turn item is absent from history
+   afterwards.
+
+## Verification
+
+```
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```


### PR DESCRIPTION
## TLDR

Session recording wrote byte-identical duplicate `content` records. The issue expected this to already be fixed and proposed a guard in `HistoryService.addInternal` keyed on `callId`/`turnId`. Neither held up: the bug still reproduces at `HEAD`, and an `addInternal` guard could never fire.

`RecordingIntegration` now tracks the identity of records its recording already contains and refuses to write one twice. Identity is the chronology `seq` paired with a fingerprint of the exact payload, so suppression can only ever discard content that is byte-identical to a record already in the file.

Reviewers should look hardest at the identity choice in `contentIdentity` and at the seeding in `subscribeToHistory`, since those are where an over-eager guard would silently lose records rather than duplicate them.

## Dive Deeper

### The defect still reproduces

Probe against real `HistoryService` + `RecordingIntegration` + `SessionRecordingService` at `f80a695f3`: add five items, snapshot `getCurated()`, then `clear()` and re-`add()` the snapshot.

| | records written | in-memory history |
| --- | --- | --- |
| rebuild **outside** a compression window | **10** (seqs `[1,2,3,4,5,1,2,3,4,5]`) | 5 |
| rebuild **inside** a compression window | 3 for 3 | 3 |

### Mechanism

`RecordingIntegration` is the only subscriber to `contentAdded` in the repo, and it records every event unless `compressionInProgress` is true. `HistoryService` emits `contentAdded` for every `add()`, including the re-`add()` half of a wholesale rebuild. Rebuilds that run outside a `startCompression`/`endCompression` window therefore re-record content already in the file:

- `pendingContextWindowEnforcement.ts:455-467` — hard-limit truncation fallback. Runs mid-turn right after a compression, which matches the issue's evidence exactly: contiguous `ai tool_call` / `tool tool_response` blocks, each duplicated exactly twice, with a `compressed` event between the copies.
- `providerContentEnforcement.ts:645-686` — `restoreHistory`
- `ConversationManager.setHistory`, `client.restoreHistory`

### Why the proposed location could not work

`clear()` empties history before the re-adds, so at that moment nothing is duplicated in memory and a `callId`/`turnId` membership check would find nothing. The harm surfaces on resume instead: `ReplayEngine.handleContent` pushes every `content` record, so a duplicated file replays into genuinely doubled history that is then re-sent to the model.

### Why `seq` alone is not enough

An earlier draft suppressed on a monotonic high-water mark of `seq`. Review found three ways that silently loses records, each now covered by a test:

- `seq` is unique only within one `HistoryService` instance, and `merge()` can import entries from a foreign chronology.
- `ChronologyStamper.inherit` deliberately gives a **different** replacement payload the replaced entry's marker; density optimization relies on this.
- `validateAndFix` mints a `seq` for a synthetic entry and splices it without emitting `contentAdded`, so a `seq` can be consumed without ever being recorded.

Pairing `seq` with a payload fingerprint removes all three. The cost is state proportional to the number of distinct records in the session rather than O(1); the largest session in the issue holds 28,417 records, a few MB against a 195 MB file.

### Lifecycle

The identity set is scoped to the one `SessionRecordingService` the integration wraps, not to a subscription, and is seeded on `subscribeToHistory` from the history already on the service. Resume, fork and session seeding all attach to a file that already contains that content, so a later rebuild must not append it. Re-subscribing the same service no longer forgets what was written.

### Not changed

Compression behavior, the recording format, and resume semantics are untouched. Compression still suppresses via `compressionInProgress`, `compressed` records are unchanged, and `replaceAll` still emits no `contentAdded`.

### Found while probing, filed separately

- #3263 — `endCompression()` without a summary never emits `compressionEnded`, leaving `compressionInProgress` stuck `true` so all further content recording silently stops. Reachable from the normal `noop` and `failed` compression outcomes.
- #3264 — an `add()` arriving mid-compression is wiped by the rebuild's queued `clear()` during the flush, losing the content from both history and the recording.

## Reviewer Test Plan

Behavioral coverage lives in `packages/core/src/recording/RecordingIntegration.compressionBoundary.test.ts` (10 tests, real services writing JSONL into a temp dir, real `ReplayEngine`):

```
cd packages/core && bun test src/recording/RecordingIntegration.compressionBoundary.test.ts
```

Every test was mutation-verified rather than assumed useful:

- Revert `RecordingIntegration.ts` to `main` — **5 of 10 fail** (rebuild reproducer, truncation-fallback, retry, resumed-session, re-subscribe).
- Substitute a `seq`-only watermark — **3 of 10 fail** (marker reused by a different payload, resumed-session, re-subscribe).

No test in the file passes unconditionally.

To exercise it by hand, run a long session until it compresses and overflows the context window, then resume it and check the session JSONL under `~/Library/Logs/llxprt-code/tmp/<hash>/chats/` for repeated `payload.content` objects sharing a `callId` and `turnId`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run build`, and `bun scripts/start.ts --profile-load stepfun-37` all pass. The change is platform-independent (no filesystem, path, or process behavior).

Full-suite failures on this machine and their disposition:

- 4 × `RipgrepPathResolver` — reproduce identically on clean `main` with this branch stashed; the tests expect `/usr/local/bin/rg` and this is an Apple Silicon Homebrew box (`/opt/homebrew/bin/rg`).
- 3 × agents `profiles.spec.ts` / `sandbox-boundary.spec.ts` — 180 s timeouts caused by a concurrent full verification run from another worktree pinning the CPU. All pass in isolation (22/22 and 2/2).

## Linked issues / bugs

Fixes #3132

Related: #3263, #3264 (found while probing, deliberately out of scope here)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate content from appearing when recording and replaying sessions.
  * Preserved content ordering and tool-call identity across compression, retries, resumed sessions, and history rebuilds.
  * Improved handling of content received during compression and when chronology markers are unavailable.
  * Ensured replayed and live history remain consistent after reconnecting or rebuilding session history.
  * Reduced repeated content when recording services are restarted or resubscribed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->