### PR TITLE
Strip the Responses stateful marker from replayed session history (Fixes #3160)

### DIFF
--- a/packages/core/src/recording/ReplayEngine.statefulChain.test.ts
+++ b/packages/core/src/recording/ReplayEngine.statefulChain.test.ts
@@ -114,6 +114,60 @@ describe('ReplayEngine stateful-chain stripping @issue:3160', () => {
     expect(ai.metadata?.model).toBe('gpt-5.6-sol');
   });
 
+  it('leaves an explicit responsesStored: false in place', async () => {
+    const lines = [
+      sessionStartLine(1),
+      contentLine(2, {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'not stored' }],
+        metadata: { id: 'resp_false', responsesStored: false },
+      }),
+    ];
+    const filePath = await replayFrom(lines);
+
+    const result = await replaySession(filePath, PROJECT_HASH);
+
+    assertReplayOk(result);
+    // Only `true` marks a chainable parent, so `false` is not a stale marker and
+    // is left exactly as recorded rather than being rewritten.
+    expect(result.history[0].metadata?.responsesStored).toBe(false);
+    expect(result.history[0].metadata?.id).toBe('resp_false');
+  });
+
+  it('replays a tool entry carrying responsesStored unchanged', async () => {
+    const lines = [
+      sessionStartLine(1),
+      contentLine(2, {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_1',
+            toolName: 'read_file',
+            result: 'file contents',
+          },
+        ],
+        metadata: { responsesStored: true },
+      }),
+    ];
+    const filePath = await replayFrom(lines);
+
+    const result = await replaySession(filePath, PROJECT_HASH);
+
+    assertReplayOk(result);
+    expect(result.history[0].speaker).toBe('tool');
+    expect(result.history[0].metadata?.responsesStored).toBe(true);
+  });
+
+  it('returns an empty history for a recording with no content events', async () => {
+    const filePath = await replayFrom([sessionStartLine(1)]);
+
+    const result = await replaySession(filePath, PROJECT_HASH);
+
+    assertReplayOk(result);
+    expect(result.history).toStrictEqual([]);
+  });
+
   it('replays a human entry carrying responsesStored unchanged', async () => {
     const lines = [
       sessionStartLine(1),

--- a/packages/core/src/recording/ReplayEngine.statefulChain.test.ts
+++ b/packages/core/src/recording/ReplayEngine.statefulChain.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Resume chain priming for Codex statefulness (#3160).
+ *
+ * A Codex parent id is scoped to the WebSocket connection that produced it,
+ * so a `responsesStored` marker restored from a persisted session recording
+ * points at a dead parent by construction. `replaySession` and
+ * `replaySessionThroughSequence` must strip the marker from AI turns so a
+ * resumed session starts a fresh chain instead of sending a dead parent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { replaySession, replaySessionThroughSequence } from './ReplayEngine.js';
+import {
+  assertReplayOk,
+  PROJECT_HASH,
+  sessionStartLine,
+  contentLine,
+  compressedLine,
+  writeJsonlFile,
+} from './replay-test-helpers.js';
+import { type IContent } from '../services/history/IContent.js';
+
+const CODEX_PROVIDER_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+
+function textOf(content: IContent): string {
+  const block = content.blocks[0];
+  return block.type === 'text' ? block.text : '';
+}
+
+describe('ReplayEngine stateful-chain stripping @issue:3160', () => {
+  let tempDir: string;
+  let chatsDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'replay-stateful-chain-'),
+    );
+    chatsDir = path.join(tempDir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function replayFrom(lines: string[]): Promise<string> {
+    const filePath = path.join(
+      chatsDir,
+      `session-${Math.random().toString(36).slice(2)}.jsonl`,
+    );
+    await writeJsonlFile(filePath, lines);
+    return filePath;
+  }
+
+  it('strips responsesStored from a replayed AI entry while keeping id, providerBaseURL and model', async () => {
+    const lines = [
+      sessionStartLine(1),
+      contentLine(2, {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'the question' }],
+      }),
+      contentLine(3, {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'the answer' }],
+        metadata: {
+          id: 'resp_1',
+          responsesStored: true,
+          providerBaseURL: CODEX_PROVIDER_BASE_URL,
+          model: 'gpt-5.6-sol',
+        },
+      }),
+    ];
+    const filePath = await replayFrom(lines);
+
+    const result = await replaySession(filePath, PROJECT_HASH);
+
+    assertReplayOk(result);
+    expect(result.history).toHaveLength(2);
+    const ai = result.history[1];
+    expect(ai.speaker).toBe('ai');
+    expect(ai.metadata?.responsesStored).toBeUndefined();
+    expect(ai.metadata?.id).toBe('resp_1');
+    expect(ai.metadata?.providerBaseURL).toBe(CODEX_PROVIDER_BASE_URL);
+    expect(ai.metadata?.model).toBe('gpt-5.6-sol');
+  });
+
+  it('replays an AI entry without responsesStored unchanged', async () => {
+    const lines = [
+      sessionStartLine(1),
+      contentLine(2, {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'plain answer' }],
+        metadata: { id: 'resp_2', model: 'gpt-5.6-sol' },
+      }),
+    ];
+    const filePath = await replayFrom(lines);
+
+    const result = await replaySession(filePath, PROJECT_HASH);
+
+    assertReplayOk(result);
+    expect(result.history).toHaveLength(1);
+    const ai = result.history[0];
+    expect('responsesStored' in (ai.metadata ?? {})).toBe(false);
+    expect(ai.metadata?.id).toBe('resp_2');
+    expect(ai.metadata?.model).toBe('gpt-5.6-sol');
+  });
+
+  it('replays a human entry carrying responsesStored unchanged', async () => {
+    const lines = [
+      sessionStartLine(1),
+      contentLine(2, {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'the question' }],
+        metadata: { responsesStored: true },
+      }),
+      contentLine(3, {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'the answer' }],
+      }),
+    ];
+    const filePath = await replayFrom(lines);
+
+    const result = await replaySession(filePath, PROJECT_HASH);
+
+    assertReplayOk(result);
+    expect(result.history).toHaveLength(2);
+    const human = result.history[0];
+    expect(human.speaker).toBe('human');
+    expect(human.metadata?.responsesStored).toBe(true);
+  });
+
+  it('does not materialize a metadata object on an entry that had none', async () => {
+    const lines = [
+      sessionStartLine(1),
+      contentLine(2, {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'the question' }],
+      }),
+      contentLine(3, {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'the answer' }],
+      }),
+    ];
+    const filePath = await replayFrom(lines);
+
+    const result = await replaySession(filePath, PROJECT_HASH);
+
+    assertReplayOk(result);
+    expect(result.history).toHaveLength(2);
+    expect('metadata' in result.history[1]).toBe(false);
+  });
+
+  it('strips the marker from every AI entry and preserves history ordering and length', async () => {
+    const lines = [
+      sessionStartLine(1),
+      contentLine(2, {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'q1' }],
+      }),
+      contentLine(3, {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'a1' }],
+        metadata: {
+          id: 'resp_a1',
+          responsesStored: true,
+          providerBaseURL: CODEX_PROVIDER_BASE_URL,
+        },
+      }),
+      contentLine(4, {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'q2' }],
+      }),
+      contentLine(5, {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'a2' }],
+        metadata: {
+          id: 'resp_a2',
+          responsesStored: true,
+          providerBaseURL: CODEX_PROVIDER_BASE_URL,
+        },
+      }),
+    ];
+    const filePath = await replayFrom(lines);
+
+    const result = await replaySession(filePath, PROJECT_HASH);
+
+    assertReplayOk(result);
+    expect(result.history).toHaveLength(4);
+    expect(result.history.map(textOf)).toStrictEqual(['q1', 'a1', 'q2', 'a2']);
+    expect(result.history[1].metadata?.responsesStored).toBeUndefined();
+    expect(result.history[1].metadata?.id).toBe('resp_a1');
+    expect(result.history[3].metadata?.responsesStored).toBeUndefined();
+    expect(result.history[3].metadata?.id).toBe('resp_a2');
+  });
+
+  it('replaySessionThroughSequence strips the marker identically', async () => {
+    const lines = [
+      sessionStartLine(1),
+      contentLine(2, {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'q1' }],
+      }),
+      contentLine(3, {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'a1' }],
+        metadata: {
+          id: 'resp_bounded',
+          responsesStored: true,
+          providerBaseURL: CODEX_PROVIDER_BASE_URL,
+        },
+      }),
+      contentLine(4, {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'q2' }],
+      }),
+      contentLine(5, {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'q3' }],
+      }),
+    ];
+    const filePath = await replayFrom(lines);
+
+    const result = await replaySessionThroughSequence(
+      filePath,
+      PROJECT_HASH,
+      4,
+    );
+
+    assertReplayOk(result);
+    expect(result.history).toHaveLength(3);
+    expect(result.history.map(textOf)).toStrictEqual(['q1', 'a1', 'q2']);
+    expect(result.history[1].metadata?.responsesStored).toBeUndefined();
+    expect(result.history[1].metadata?.id).toBe('resp_bounded');
+  });
+
+  it('strips the marker from a compressed summary while keeping isSummary intact', async () => {
+    const lines = [
+      sessionStartLine(1),
+      contentLine(2, {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'q1' }],
+      }),
+      contentLine(3, { speaker: 'ai', blocks: [{ type: 'text', text: 'a1' }] }),
+      compressedLine(
+        4,
+        {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'compressed summary' }],
+          metadata: {
+            id: 'resp_summary',
+            responsesStored: true,
+            isSummary: true,
+            providerBaseURL: CODEX_PROVIDER_BASE_URL,
+          },
+        },
+        2,
+      ),
+    ];
+    const filePath = await replayFrom(lines);
+
+    const result = await replaySession(filePath, PROJECT_HASH);
+
+    assertReplayOk(result);
+    expect(result.history).toHaveLength(1);
+    expect(textOf(result.history[0])).toBe('compressed summary');
+    expect(result.history[0].metadata?.responsesStored).toBeUndefined();
+    expect(result.history[0].metadata?.isSummary).toBe(true);
+    expect(result.history[0].metadata?.id).toBe('resp_summary');
+  });
+});

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -599,6 +599,9 @@ function finalizeReplay(acc: ReplayAccumulators): ReplayResult {
   const history = invalidateResponsesStatefulChain(acc.history);
   return {
     ok: true,
+    // The helper returns `readonly IContent[]`; the spread widens it to the
+    // mutable `IContent[]` this result type declares. It is a type conversion,
+    // not a defensive copy — the entries are still shared by reference.
     history: [...history],
     metadata: acc.metadata,
     lastSeq: acc.lastSeq,

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -587,6 +587,15 @@ function finalizeReplay(acc: ReplayAccumulators): ReplayResult {
   // `responsesStored` marker restored from a persisted session recording (or a
   // checkpoint fork replay) points at a dead parent by construction. Strip it so the
   // resumed session starts a fresh chain (#3160).
+  //
+  // The strip is deliberately unconditional rather than Codex-only. `responsesStored`
+  // conflates two different lifetimes — "durably stored server-side" (non-Codex,
+  // store=true) and "chainable on this socket" (Codex, store=false; see
+  // buildRequestContext in openAIResponsesExecutor.ts) — and a recording carries
+  // nothing that tells them apart, nor whether a durable parent is still inside its
+  // retention window. A parent that cannot be shown to be live is treated as dead.
+  // The cost of being wrong is one full-history request, which the next turn
+  // re-chains from; the cost of guessing wrong the other way is a refused request.
   const history = invalidateResponsesStatefulChain(acc.history);
   return {
     ok: true,

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -41,7 +41,10 @@ import {
   type SessionForkedPayload,
   type SessionRecordLine,
 } from './types.js';
-import { type IContent } from '../services/history/IContent.js';
+import {
+  invalidateResponsesStatefulChain,
+  type IContent,
+} from '../services/history/IContent.js';
 
 // ---------------------------------------------------------------------------
 // Private replay accumulators
@@ -580,9 +583,14 @@ function finalizeReplay(acc: ReplayAccumulators): ReplayResult {
   const folded = foldCheckpointMetadata(acc.rawMetadataEvents);
   const sessionName = deriveSessionName(acc.rawMetadataEvents);
   const ancestry = deriveAncestry(acc.rawMetadataEvents);
+  // A Codex parent id is scoped to the WebSocket connection that produced it, so a
+  // `responsesStored` marker restored from a persisted session recording (or a
+  // checkpoint fork replay) points at a dead parent by construction. Strip it so the
+  // resumed session starts a fresh chain (#3160).
+  const history = invalidateResponsesStatefulChain(acc.history);
   return {
     ok: true,
-    history: acc.history,
+    history: [...history],
     metadata: acc.metadata,
     lastSeq: acc.lastSeq,
     sequenceCorrupt: acc.sequenceCorrupt,

--- a/packages/core/src/services/history/IContent.ts
+++ b/packages/core/src/services/history/IContent.ts
@@ -551,10 +551,12 @@ export function stampAiTurnModel(
  *   a replacement history and never write through it.
  * - `finalizeReplay` returns the result as `ReplayResult.history` (#3160). Its
  *   consumers DO install those entries into a `HistoryService`, whose
- *   chronology stamper writes `metadata` in place. That is safe here only
- *   because the array it aliases — the replay accumulator — is discarded when
- *   `finalizeReplay` returns, so no second owner can observe the mutation.
- *   Any future caller that keeps its input array alive must clone first.
+ *   chronology stamper writes `metadata` in place. What is shared is the
+ *   ENTRIES, not the array: the returned array is new. That is safe here only
+ *   because the entries belong to the replay accumulator, which is discarded
+ *   when `finalizeReplay` returns, so no second owner can observe the
+ *   mutation. Any future caller whose input entries outlive the call must
+ *   clone the ENTRIES first; copying the array would not help.
  */
 export function invalidateResponsesStatefulChain(
   history: readonly IContent[],

--- a/packages/core/src/services/history/IContent.ts
+++ b/packages/core/src/services/history/IContent.ts
@@ -542,11 +542,19 @@ export function stampAiTurnModel(
  * every entry was considered and rejected: a shallow `{...entry}` would still
  * share `blocks` and `metadata`, so it would advertise immutability it does not
  * provide, and a deep clone would be real cost on every compression for a
- * hazard no caller exhibits. Both call sites — `applyCompressionWithAnchor` and
- * `applyDensityMutations` — use the result as a replacement history and never
- * write through it. Sharing entry references is also the established
+ * hazard no caller exhibits. Sharing entry references is also the established
  * convention here: `HistoryService.getCurated()` and the compression
  * strategies' `history.slice(...)` hand out the same objects.
+ *
+ * Call sites and why each is safe:
+ * - `applyCompressionWithAnchor` and `applyDensityMutations` use the result as
+ *   a replacement history and never write through it.
+ * - `finalizeReplay` returns the result as `ReplayResult.history` (#3160). Its
+ *   consumers DO install those entries into a `HistoryService`, whose
+ *   chronology stamper writes `metadata` in place. That is safe here only
+ *   because the array it aliases — the replay accumulator — is discarded when
+ *   `finalizeReplay` returns, so no second owner can observe the mutation.
+ *   Any future caller that keeps its input array alive must clone first.
  */
 export function invalidateResponsesStatefulChain(
   history: readonly IContent[],

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Resumed-session chain behavior for issue #3160 Codex statefulness.
+ *
+ * Replay strips `responsesStored` from AI turns (see ReplayEngine @ #3160),
+ * so the first turn of a resumed session must start a fresh chain: no
+ * previous_response_id, full history, `responsesStored: true` on its own
+ * completion. The live in-process control proves the parent scan itself is
+ * unchanged.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import {
+  clearActiveProviderRuntimeContext,
+  createProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  SocketHarness,
+  completingScript,
+  drain as drainHarness,
+  userTextsOf,
+} from '../openAIResponsesWebSocketTransport.test-helpers.js';
+import { createCodexResponsesWebSocketTransport } from '../openAIResponsesWebSocketTransport.js';
+import { executeOpenAIResponsesRequest } from '../openAIResponsesExecutor.js';
+import {
+  CODEX_BASE_URL,
+  TEST_RUNTIME_ID,
+  buildDeps,
+  buildOptions,
+  metadataOf,
+} from '../codexStateful.test-helpers.js';
+
+describe('OpenAIResponsesProvider Codex resumed chain @issue:3160', () => {
+  beforeEach(() => {
+    setActiveProviderRuntimeContext(
+      createProviderRuntimeContext({
+        settingsService: new SettingsService(),
+        runtimeId: TEST_RUNTIME_ID,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  function codexTransportContents(hasMarker: boolean): IContent[] {
+    return [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'q1' }] },
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'a1' }],
+        metadata: {
+          id: 'resp_dead',
+          ...(hasMarker ? { responsesStored: true } : {}),
+          providerBaseURL: CODEX_BASE_URL,
+        },
+      },
+      { speaker: 'human', blocks: [{ type: 'text', text: 'q2' }] },
+    ];
+  }
+
+  it('a resumed history (marker stripped by replay) sends no previous_response_id and the full history', async () => {
+    const contents = codexTransportContents(false);
+    const harness = new SocketHarness([completingScript('ok')]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    try {
+      await drainHarness(
+        executeOpenAIResponsesRequest(
+          buildOptions(contents),
+          buildDeps({ getWebSocketTransport: () => transport }),
+        ),
+      );
+
+      const sent = JSON.parse(harness.sockets[0].sent[0]) as Record<
+        string,
+        unknown
+      >;
+      expect(sent['previous_response_id']).toBeUndefined();
+      const users = userTextsOf(sent['input']);
+      expect(users).toContain('q1');
+      expect(users).toContain('q2');
+    } finally {
+      transport.close();
+    }
+  });
+
+  it('a live in-process chain still sends the parent', async () => {
+    const contents = codexTransportContents(true);
+    const harness = new SocketHarness([completingScript('ok')]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    try {
+      await drainHarness(
+        executeOpenAIResponsesRequest(
+          buildOptions(contents),
+          buildDeps({ getWebSocketTransport: () => transport }),
+        ),
+      );
+
+      const sent = JSON.parse(harness.sockets[0].sent[0]) as Record<
+        string,
+        unknown
+      >;
+      expect(sent['previous_response_id']).toBe('resp_dead');
+      const users = userTextsOf(sent['input']);
+      expect(users).not.toContain('q1');
+    } finally {
+      transport.close();
+    }
+  });
+
+  it('the first resumed turn is itself chainable', async () => {
+    const resumedContents: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'resumed question' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'old answer' }],
+        metadata: {
+          id: 'resp_dead',
+          providerBaseURL: CODEX_BASE_URL,
+        },
+      },
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'resumed follow-up' }],
+      },
+    ];
+    const harness1 = new SocketHarness([completingScript('resumed answer')]);
+    const transport1 = createCodexResponsesWebSocketTransport({
+      openSocket: harness1.openSocket,
+    });
+    try {
+      const resumedMessages = await drainHarness(
+        executeOpenAIResponsesRequest(
+          buildOptions(resumedContents),
+          buildDeps({ getWebSocketTransport: () => transport1 }),
+        ),
+      );
+
+      const resumedMeta = metadataOf(resumedMessages);
+      expect(resumedMeta).toBeDefined();
+      expect(resumedMeta!.responsesStored).toBe(true);
+
+      const resumedSent = JSON.parse(harness1.sockets[0].sent[0]) as Record<
+        string,
+        unknown
+      >;
+      expect(resumedSent['previous_response_id']).toBeUndefined();
+      const resumedUsers = userTextsOf(resumedSent['input']);
+      expect(resumedUsers).toContain('resumed question');
+
+      const resumedAnswer = resumedMessages
+        .flatMap((m) => m.blocks)
+        .map((b) => (b.type === 'text' ? b.text : ''))
+        .join('');
+      const turn2Contents: IContent[] = [
+        ...resumedContents,
+        {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: resumedAnswer }],
+          metadata: { ...resumedMeta!, providerBaseURL: CODEX_BASE_URL },
+        },
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'turn 2 question' }],
+        },
+      ];
+
+      const harness2 = new SocketHarness([completingScript('turn 2 answer')]);
+      const transport2 = createCodexResponsesWebSocketTransport({
+        openSocket: harness2.openSocket,
+      });
+      try {
+        await drainHarness(
+          executeOpenAIResponsesRequest(
+            buildOptions(turn2Contents),
+            buildDeps({ getWebSocketTransport: () => transport2 }),
+          ),
+        );
+
+        const sent = JSON.parse(harness2.sockets[0].sent[0]) as Record<
+          string,
+          unknown
+        >;
+        expect(sent['previous_response_id']).toBe(resumedMeta!.id);
+        const users = userTextsOf(sent['input']);
+        expect(users).not.toContain('resumed question');
+        expect(users).toContain('turn 2 question');
+      } finally {
+        transport2.close();
+      }
+    } finally {
+      transport1.close();
+    }
+  });
+});

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts
@@ -18,14 +18,22 @@
 /**
  * Resumed-session chain behavior for issue #3160 Codex statefulness.
  *
- * Replay strips `responsesStored` from AI turns (see ReplayEngine @ #3160),
- * so the first turn of a resumed session must start a fresh chain: no
- * previous_response_id, full history, `responsesStored: true` on its own
- * completion. The live in-process control proves the parent scan itself is
- * unchanged.
+ * A Codex parent id belongs to the WebSocket connection that produced it, so a
+ * marker restored from a session recording is dead. `finalizeReplay` strips it,
+ * and the first turn of a resumed session therefore starts a fresh chain: no
+ * previous_response_id, full history, and `responsesStored: true` on its own
+ * completion so the next turn chains again.
+ *
+ * The first test drives the REAL recording -> replay -> provider path so it
+ * fails if the replay-side strip is reverted. The remaining tests pin the
+ * provider-side rules that the strip depends on.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { replaySession } from '@vybestack/llxprt-code-core';
 import {
   clearActiveProviderRuntimeContext,
   createProviderRuntimeContext,
@@ -49,38 +57,168 @@ import {
   metadataOf,
 } from '../codexStateful.test-helpers.js';
 
+const PROJECT_HASH = 'issue3160projecthash';
+
+/**
+ * Extracts the text of every assistant item in a Responses `input` array.
+ * `userTextsOf` covers the human turns; this covers the AI turns, so a
+ * "full history was sent" assertion can name every entry rather than only
+ * the human ones.
+ */
+function assistantTextsOf(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    throw new Error('Expected a Responses "input" array');
+  }
+  const texts: string[] = [];
+  for (const item of input as Array<
+    { role?: string; content?: unknown } | null | undefined
+  >) {
+    if (item?.role !== 'assistant') continue;
+    const content = item.content;
+    const text =
+      typeof content === 'string'
+        ? content
+        : Array.isArray(content)
+          ? content
+              .map((part) =>
+                typeof part === 'object' && part !== null
+                  ? String((part as { text?: unknown }).text ?? '')
+                  : '',
+              )
+              .join('')
+          : '';
+    if (text !== '') texts.push(text);
+  }
+  return texts;
+}
+
+function recordLine(seq: number, type: string, payload: unknown): string {
+  return JSON.stringify({
+    v: 1,
+    seq,
+    ts: '2026-08-21T00:00:00.000Z',
+    type,
+    payload,
+  });
+}
+
+function sentRequestOf(serialized: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(serialized);
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('Expected a serialized Responses request');
+  }
+  return parsed as Record<string, unknown>;
+}
+
 describe('OpenAIResponsesProvider Codex resumed chain @issue:3160', () => {
-  beforeEach(() => {
+  let tempDir: string;
+
+  beforeEach(async () => {
     setActiveProviderRuntimeContext(
       createProviderRuntimeContext({
         settingsService: new SettingsService(),
         runtimeId: TEST_RUNTIME_ID,
       }),
     );
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-resumed-chain-'));
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     clearActiveProviderRuntimeContext();
+    await fs.rm(tempDir, { recursive: true, force: true });
   });
 
-  function codexTransportContents(hasMarker: boolean): IContent[] {
-    return [
+  /**
+   * Writes a session recording whose AI turn carries a stored Codex parent,
+   * replays it the way `--continue` does, and hands the replayed history
+   * straight to the provider. Reverting the strip in `finalizeReplay` makes the
+   * replayed marker survive and this test sends the dead parent.
+   */
+  it('sends no previous_response_id for a history replayed from a session recording', async () => {
+    const filePath = path.join(tempDir, 'session.jsonl');
+    await fs.writeFile(
+      filePath,
+      [
+        recordLine(1, 'session_start', {
+          sessionId: 'resumed-session-0001',
+          projectHash: PROJECT_HASH,
+          workspaceDirs: [tempDir],
+          provider: 'openai-responses',
+          model: 'gpt-5.6-sol',
+          startTime: '2026-08-21T00:00:00.000Z',
+        }),
+        recordLine(2, 'content', {
+          content: {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'q1' }],
+          },
+        }),
+        recordLine(3, 'content', {
+          content: {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'a1' }],
+            metadata: {
+              id: 'resp_from_previous_process',
+              responsesStored: true,
+              providerBaseURL: CODEX_BASE_URL,
+            },
+          },
+        }),
+        recordLine(4, 'content', {
+          content: {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'q2' }],
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf-8',
+    );
+
+    const replayed = await replaySession(filePath, PROJECT_HASH);
+    expect(replayed.ok).toBe(true);
+    if (!replayed.ok) return;
+    expect(replayed.history).toHaveLength(3);
+
+    const harness = new SocketHarness([completingScript('ok')]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    try {
+      await drainHarness(
+        executeOpenAIResponsesRequest(
+          buildOptions(replayed.history),
+          buildDeps({ getWebSocketTransport: () => transport }),
+        ),
+      );
+
+      const sent = sentRequestOf(harness.sockets[0].sent[0]);
+      expect(sent['previous_response_id']).toBeUndefined();
+      // The whole transcript is re-seeded: both human turns AND the AI turn
+      // that used to be the parent.
+      expect(userTextsOf(sent['input'])).toStrictEqual(['q1', 'q2']);
+      expect(assistantTextsOf(sent['input'])).toContain('a1');
+    } finally {
+      transport.close();
+    }
+  });
+
+  it('still chains from a marker that was never persisted and replayed', async () => {
+    // The control for the test above: the provider's parent scan is unchanged,
+    // so the same history WITH the marker still produces a chained request.
+    // Without this, the test above could pass for a trivial reason.
+    const contents: IContent[] = [
       { speaker: 'human', blocks: [{ type: 'text', text: 'q1' }] },
       {
         speaker: 'ai',
         blocks: [{ type: 'text', text: 'a1' }],
         metadata: {
-          id: 'resp_dead',
-          ...(hasMarker ? { responsesStored: true } : {}),
+          id: 'resp_live',
+          responsesStored: true,
           providerBaseURL: CODEX_BASE_URL,
         },
       },
       { speaker: 'human', blocks: [{ type: 'text', text: 'q2' }] },
     ];
-  }
-
-  it('a resumed history (marker stripped by replay) sends no previous_response_id and the full history', async () => {
-    const contents = codexTransportContents(false);
     const harness = new SocketHarness([completingScript('ok')]);
     const transport = createCodexResponsesWebSocketTransport({
       openSocket: harness.openSocket,
@@ -93,46 +231,15 @@ describe('OpenAIResponsesProvider Codex resumed chain @issue:3160', () => {
         ),
       );
 
-      const sent = JSON.parse(harness.sockets[0].sent[0]) as Record<
-        string,
-        unknown
-      >;
-      expect(sent['previous_response_id']).toBeUndefined();
-      const users = userTextsOf(sent['input']);
-      expect(users).toContain('q1');
-      expect(users).toContain('q2');
+      const sent = sentRequestOf(harness.sockets[0].sent[0]);
+      expect(sent['previous_response_id']).toBe('resp_live');
+      expect(userTextsOf(sent['input'])).toStrictEqual(['q2']);
     } finally {
       transport.close();
     }
   });
 
-  it('a live in-process chain still sends the parent', async () => {
-    const contents = codexTransportContents(true);
-    const harness = new SocketHarness([completingScript('ok')]);
-    const transport = createCodexResponsesWebSocketTransport({
-      openSocket: harness.openSocket,
-    });
-    try {
-      await drainHarness(
-        executeOpenAIResponsesRequest(
-          buildOptions(contents),
-          buildDeps({ getWebSocketTransport: () => transport }),
-        ),
-      );
-
-      const sent = JSON.parse(harness.sockets[0].sent[0]) as Record<
-        string,
-        unknown
-      >;
-      expect(sent['previous_response_id']).toBe('resp_dead');
-      const users = userTextsOf(sent['input']);
-      expect(users).not.toContain('q1');
-    } finally {
-      transport.close();
-    }
-  });
-
-  it('the first resumed turn is itself chainable', async () => {
+  it('re-establishes the chain on the next turn of the same connection', async () => {
     const resumedContents: IContent[] = [
       {
         speaker: 'human',
@@ -141,43 +248,45 @@ describe('OpenAIResponsesProvider Codex resumed chain @issue:3160', () => {
       {
         speaker: 'ai',
         blocks: [{ type: 'text', text: 'old answer' }],
-        metadata: {
-          id: 'resp_dead',
-          providerBaseURL: CODEX_BASE_URL,
-        },
+        metadata: { id: 'resp_dead', providerBaseURL: CODEX_BASE_URL },
       },
       {
         speaker: 'human',
         blocks: [{ type: 'text', text: 'resumed follow-up' }],
       },
     ];
-    const harness1 = new SocketHarness([completingScript('resumed answer')]);
-    const transport1 = createCodexResponsesWebSocketTransport({
-      openSocket: harness1.openSocket,
+    // ONE harness and ONE transport for both turns: a Codex parent is scoped to
+    // the connection, so turn 2 must chain on the socket turn 1 established.
+    const harness = new SocketHarness([completingScript('resumed answer')]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
     });
     try {
       const resumedMessages = await drainHarness(
         executeOpenAIResponsesRequest(
           buildOptions(resumedContents),
-          buildDeps({ getWebSocketTransport: () => transport1 }),
+          buildDeps({ getWebSocketTransport: () => transport }),
         ),
       );
 
       const resumedMeta = metadataOf(resumedMessages);
       expect(resumedMeta).toBeDefined();
       expect(resumedMeta!.responsesStored).toBe(true);
+      const parentId = resumedMeta!.id;
+      // Guard the comparison below: two undefined ids would satisfy toBe().
+      expect(typeof parentId).toBe('string');
+      expect(parentId).not.toBe('');
 
-      const resumedSent = JSON.parse(harness1.sockets[0].sent[0]) as Record<
-        string,
-        unknown
-      >;
-      expect(resumedSent['previous_response_id']).toBeUndefined();
-      const resumedUsers = userTextsOf(resumedSent['input']);
-      expect(resumedUsers).toContain('resumed question');
+      const firstSent = sentRequestOf(harness.sockets[0].sent[0]);
+      expect(firstSent['previous_response_id']).toBeUndefined();
+      expect(userTextsOf(firstSent['input'])).toStrictEqual([
+        'resumed question',
+        'resumed follow-up',
+      ]);
 
       const resumedAnswer = resumedMessages
-        .flatMap((m) => m.blocks)
-        .map((b) => (b.type === 'text' ? b.text : ''))
+        .flatMap((message) => message.blocks)
+        .map((block) => (block.type === 'text' ? block.text : ''))
         .join('');
       const turn2Contents: IContent[] = [
         ...resumedContents,
@@ -192,31 +301,22 @@ describe('OpenAIResponsesProvider Codex resumed chain @issue:3160', () => {
         },
       ];
 
-      const harness2 = new SocketHarness([completingScript('turn 2 answer')]);
-      const transport2 = createCodexResponsesWebSocketTransport({
-        openSocket: harness2.openSocket,
-      });
-      try {
-        await drainHarness(
-          executeOpenAIResponsesRequest(
-            buildOptions(turn2Contents),
-            buildDeps({ getWebSocketTransport: () => transport2 }),
-          ),
-        );
+      await drainHarness(
+        executeOpenAIResponsesRequest(
+          buildOptions(turn2Contents),
+          buildDeps({ getWebSocketTransport: () => transport }),
+        ),
+      );
 
-        const sent = JSON.parse(harness2.sockets[0].sent[0]) as Record<
-          string,
-          unknown
-        >;
-        expect(sent['previous_response_id']).toBe(resumedMeta!.id);
-        const users = userTextsOf(sent['input']);
-        expect(users).not.toContain('resumed question');
-        expect(users).toContain('turn 2 question');
-      } finally {
-        transport2.close();
-      }
+      // Same socket, second frame.
+      expect(harness.sockets).toHaveLength(1);
+      const secondSent = sentRequestOf(harness.sockets[0].sent[1]);
+      expect(secondSent['previous_response_id']).toBe(parentId);
+      expect(userTextsOf(secondSent['input'])).toStrictEqual([
+        'turn 2 question',
+      ]);
     } finally {
-      transport1.close();
+      transport.close();
     }
   });
 });

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts
@@ -65,6 +65,18 @@ const PROJECT_HASH = 'issue3160projecthash';
  * "full history was sent" assertion can name every entry rather than only
  * the human ones.
  */
+function partText(part: unknown): string {
+  if (typeof part !== 'object' || part === null) return '';
+  const text = (part as { text?: unknown }).text;
+  return text === undefined || text === null ? '' : String(text);
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map(partText).join('');
+}
+
 function assistantTextsOf(input: unknown): string[] {
   if (!Array.isArray(input)) {
     throw new Error('Expected a Responses "input" array');
@@ -74,19 +86,7 @@ function assistantTextsOf(input: unknown): string[] {
     { role?: string; content?: unknown } | null | undefined
   >) {
     if (item?.role !== 'assistant') continue;
-    const content = item.content;
-    const text =
-      typeof content === 'string'
-        ? content
-        : Array.isArray(content)
-          ? content
-              .map((part) =>
-                typeof part === 'object' && part !== null
-                  ? String((part as { text?: unknown }).text ?? '')
-                  : '',
-              )
-              .join('')
-          : '';
+    const text = contentText(item.content);
     if (text !== '') texts.push(text);
   }
   return texts;

--- a/project-plans/issue3160-resume-chain-priming.md
+++ b/project-plans/issue3160-resume-chain-priming.md
@@ -1,0 +1,161 @@
+# Issue #3160 — Prime the Codex stateful chain on resume
+
+Follow-up optimization to #3134. Scope shaped from the issue's three proposed
+optimizations; only optimization 1 is accepted for implementation.
+
+## Current behavior (verified by reading the code on `main` @ f80a695f31)
+
+Codex statefulness is transport-scoped. `computeStatefulConversation`
+(`packages/providers/src/openai-responses/openAIResponsesStateful.ts`) scans the
+outgoing history backwards for the newest AI entry with
+`metadata.responsesStored === true` and a matching `metadata.providerBaseURL`,
+and sends that entry's `metadata.id` as `previous_response_id`.
+
+`responsesStored` reaches history like this:
+
+1. `buildRequestContext` sets `responsesStored: request.store === true || (isCodex && stateful.enabled)`.
+2. `parseResponsesStream` stamps `metadata.responsesStored = true` on the
+   terminal AI IContent.
+3. `mergeTurnMetadata` (`packages/agents/src/core/ConversationManager.ts:85`)
+   folds it into the AI turn added to `HistoryService`.
+4. `RecordingIntegration`'s `contentAdded` handler calls
+   `SessionRecordingService.recordContent(content)`, which enqueues the whole
+   `IContent` — metadata included — as a `content` event in the session JSONL.
+5. `ReplayEngine.handleContent` pushes the deserialized object into
+   `acc.history` verbatim (`isSpeakerContent` only checks `speaker` + `blocks`).
+
+So a stale `responsesStored` marker **does** survive the resume boundary today.
+Every replay-derived history — `--continue` at startup, `/continue`,
+`/chat resume <tag>` (an alias of `/continue`), checkpoint fork, and ACP
+`session/load` — funnels through `replaySession` / `replaySessionThroughSequence`
+and can hand the provider a parent id that belongs to a WebSocket connection
+owned by a previous process. That id is dead by construction.
+
+The compression half of the issue is already handled:
+`applyCompressionWithAnchor` (`packages/agents/src/compression/cacheAnchor.ts:83`)
+and `densityValidation.ts:119` already call `invalidateResponsesStatefulChain`
+(#3134 Fix 3). No change is needed there; it only needs a regression guard.
+
+## Triage of the issue's three proposed optimizations
+
+### 1. Strip `responsesStored` from AI turns when history is loaded for a resumed session — ACCEPTED
+
+Concrete, testable, and it removes a real wasted round trip. This is the whole
+deliverable.
+
+### 2. Compact before the first request of a resumed session — DEFER
+
+The issue words this as "investigate". Forcing a compaction to shrink the seed
+costs its own full-history summarization request, so it is net negative unless
+the session is already at the auto-compression threshold — in which case the
+existing threshold already fires. Acting on it means changing compression
+trigger policy, which is a different subsystem from chain priming and carries
+real regression risk. Not implemented; recorded here so the decision is visible.
+
+### 3. Prewarm the socket with a `generate=false` `response.create` — DEFER
+
+Prewarming does not deliver the issue's stated goal. Codex CLI's prewarm carries
+no conversation input, so the response it establishes is not a parent that holds
+the transcript; the first real turn must still send the full history. Sending the
+full history *in* the prewarm would spend the same bytes plus an extra request.
+The measurable win is handshake latency (the transport's 15 s connect budget),
+not payload size. It also requires a new public `prewarm` method on the
+`WebSocketTransport` interface and an unverified `generate: false` request field.
+Adding a public abstraction for a benefit the issue did not ask for is outside
+the accepted scope. Not implemented.
+
+## Accepted behavior
+
+**AC-1 — Replay-derived history carries no stateful-chain marker.**
+`replaySession` and `replaySessionThroughSequence` return a history in which no
+entry carries `metadata.responsesStored`, regardless of what the recording file
+contains. All other metadata on those entries (`id`, `model`,
+`providerBaseURL`, `usage`, `chronology`, `isSummary`, `cacheAnchor`, …) is
+preserved byte-for-byte, and non-AI entries are untouched.
+
+Rationale for the placement: `finalizeReplay` is the single funnel both public
+replay entry points return through, so one strip covers `--continue`,
+`/continue`, `/chat resume`, checkpoint fork, and ACP `session/load`. A
+checkpoint fork replays a rewound prefix, so its markers are invalid for the same
+reason compression's are, even when the socket is still live in-process.
+
+**AC-2 — A resumed Codex WebSocket session never sends a dead parent.**
+Given a session recording whose AI turn carries
+`{ id, responsesStored: true, providerBaseURL: <codex> }`, the first Codex
+WebSocket turn after resuming that recording sends **no** `previous_response_id`
+and sends the full history. The turn is still chainable: its own completion is
+stamped `responsesStored`, so the following turn sends
+`previous_response_id` and a trimmed input.
+
+**AC-3 — Compression invalidation is unchanged.**
+Post-compression histories still send full history with no
+`previous_response_id`. Existing coverage in
+`OpenAIResponsesProvider.codex.stateful.remediation.test.ts` stands; no
+behavioral change is introduced there.
+
+## Boundary cases the tests must cover
+
+- Recording whose AI entry has `responsesStored: true` **and** other metadata →
+  only `responsesStored` is dropped.
+- Recording whose AI entry has `responsesStored: false` or no `responsesStored`
+  → entry is returned unchanged (identity preserved, no gratuitous rewrite).
+- Recording whose **human** or **tool** entry somehow carries
+  `responsesStored: true` → untouched (the marker is meaningless off an AI turn
+  and `invalidateResponsesStatefulChain` is already speaker-scoped).
+- Entry with no `metadata` at all → untouched, and `metadata` is not
+  materialized.
+- `replaySessionThroughSequence` (checkpoint fork) → stripped identically.
+- A `compressed` event resets `acc.history` to `[summary]`; the summary entry is
+  also subject to the strip.
+- Empty history → empty result, no throw.
+
+## Tests that will prove it
+
+All new tests are `bun:test`, TypeScript, behavioral (real replay of a real
+JSONL file on a temp dir — no mocking of the replay engine).
+
+1. `packages/core/src/recording/ReplayEngine.statefulChain.test.ts` (new)
+   - Writes a real session JSONL containing `session_start` plus `content`
+     events, one of which is an AI turn with
+     `metadata: { id, responsesStored: true, providerBaseURL, model }`.
+   - Asserts `replaySession` returns that entry with `responsesStored`
+     undefined and `id` / `providerBaseURL` / `model` intact.
+   - Asserts a human entry carrying the marker is returned untouched.
+   - Asserts an entry with no metadata still has no `metadata` key.
+   - Asserts `replaySessionThroughSequence` strips identically.
+   - Asserts a `compressed` summary carrying the marker is stripped.
+
+2. `packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts` (new)
+   - Uses the existing `SocketHarness` + `createCodexResponsesWebSocketTransport`
+     + `executeOpenAIResponsesRequest` harness (same pattern as the #3134
+     remediation suite, real SSE bytes through `parseResponsesStream`).
+   - RED-first: history in the shape a resume produces **after** the strip sends
+     no `previous_response_id` and the full history; the same history **with**
+     the marker (i.e. a live in-process chain) still sends the parent, proving
+     the provider rule itself did not change.
+   - Turn-2 chaining still works off the resumed turn's own completion id.
+
+## Implementation
+
+Single production change in
+`packages/core/src/recording/ReplayEngine.ts`: `finalizeReplay` returns
+`invalidateResponsesStatefulChain(acc.history)` instead of `acc.history`.
+`invalidateResponsesStatefulChain` already exists in
+`packages/core/src/services/history/IContent.ts` and already implements exactly
+the required semantics (AI-only, `responsesStored`-only, entries without the
+marker returned by reference). It returns `readonly IContent[]`; `ReplayResult.history`
+is `IContent[]`, so the result is spread into a fresh mutable array.
+
+No provider-side change. No new public abstraction. No new dependency.
+
+## Out of scope
+
+- Optimizations 2 and 3 above.
+- `/chat restore <N>` rewind chain invalidation (a separate path from replay;
+  not named in this issue).
+- Any change to HTTP Codex statelessness or the ZDR trade-off.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, plus the `stepfun-37` startup smoke.

--- a/project-plans/issue3160-resume-chain-priming.md
+++ b/project-plans/issue3160-resume-chain-priming.md
@@ -54,15 +54,22 @@ real regression risk. Not implemented; recorded here so the decision is visible.
 
 ### 3. Prewarm the socket with a `generate=false` `response.create` — DEFER
 
-Prewarming does not deliver the issue's stated goal. Codex CLI's prewarm carries
-no conversation input, so the response it establishes is not a parent that holds
-the transcript; the first real turn must still send the full history. Sending the
-full history *in* the prewarm would spend the same bytes plus an extra request.
-The measurable win is handshake latency (the transport's 15 s connect budget),
-not payload size. It also requires a new public `prewarm` method on the
-`WebSocketTransport` interface and an unverified `generate: false` request field.
-Adding a public abstraction for a benefit the issue did not ask for is outside
-the accepted scope. Not implemented.
+Prewarming does not deliver the issue's stated goal, which is removing one large
+request. Either the prewarm carries the transcript, in which case those bytes are
+spent anyway and an extra round trip is added on top, or it carries no input, in
+which case the response it establishes is not a parent that holds the transcript
+and the first real turn must still send the full history. Neither branch removes
+the payload.
+
+What prewarming can buy is latency: the connection handshake (a 15 s connect
+budget in the transport) and, if the transcript is uploaded during the warmup,
+request preparation moved off the generated turn. That is a real but different
+optimization with a different success metric, and it needs measurement rather
+than assumption. It also requires a new public `prewarm` method on the
+`WebSocketTransport` interface and a `generate: false` request field this
+codebase does not currently send. Adding a public abstraction for a benefit the
+issue did not ask for is outside the accepted scope. Not implemented; worth its
+own issue if first-turn latency after resume is measured and found to matter.
 
 ## Accepted behavior
 
@@ -147,6 +154,54 @@ marker returned by reference). It returns `readonly IContent[]`; `ReplayResult.h
 is `IContent[]`, so the result is spread into a fresh mutable array.
 
 No provider-side change. No new public abstraction. No new dependency.
+
+## Review triage
+
+Findings from the design review, and what was done with each.
+
+**Accepted and fixed**
+
+- The doc comment on `invalidateResponsesStatefulChain` claimed its only two
+  call sites never write through the returned entries. `finalizeReplay` is a
+  third call site whose consumers *do* install the entries into a
+  `HistoryService`, whose chronology stamper writes `metadata` in place. That is
+  safe here only because the aliased array (the replay accumulator) is discarded
+  when `finalizeReplay` returns. The comment now says so, and warns the next
+  caller.
+- The provider tests were all controls: they hand-built history and never
+  invoked replay, so they passed with the production change reverted. Replaced
+  with a real recording → `replaySession` → executor test that fails with
+  `previous_response_id: "resp_from_previous_process"` when the strip is removed.
+- The full-history assertion checked only the human turns. It now names every
+  turn, human and AI.
+- The turn-1 → turn-2 test used two transports, which contradicts the
+  connection-scoped premise. It now reuses one transport and one socket and
+  asserts the second frame on that socket.
+- The parent-id comparison could pass with both ids `undefined`. It now proves
+  the id is a non-empty string first.
+- The `responsesStored: false`, tool-entry, and empty-history boundaries listed
+  above were missing. Added.
+- The prewarm deferral above rested on a claim about Codex CLI's internals that
+  was not verifiable from this repository. Rewritten to rest on the payload
+  argument, which holds either way.
+
+**Deferred, with reasons**
+
+- *The strip is not Codex-only.* A non-Codex Responses parent is stored durably
+  server-side and can outlive the process, so stripping it costs an opt-in
+  non-Codex user one full-history request on resume. Narrowing is not obviously
+  right: `responsesStored` conflates "durably stored" with "chainable on this
+  socket" (see `buildRequestContext`, which sets it for Codex even though
+  `store` is false), and a recording carries nothing that separates them, nor
+  anything about the retention window. Distinguishing them properly means a new
+  metadata field, which is a public-surface change beyond this issue. The
+  trade-off is now stated at the call site. Worth its own issue.
+- *Checkpoint forks can discard a parent that is still live in-process.* A fork
+  taken at or near the current head can carry a parent that the still-open
+  socket would resolve, so the strip costs one full-history request there.
+  Preserving it means plumbing live transport identity from the provider into
+  the session transition service, which is a new cross-package coupling.
+  Fail-safe invalidation is kept.
 
 ## Out of scope
 


### PR DESCRIPTION
## TLDR

A Codex `previous_response_id` belongs to the WebSocket connection that produced it. A resumed session runs in a new process with no socket, so a `responsesStored` marker restored from a session recording points at a parent that is dead by construction.

Issue #3160 assumed that marker did not survive resume ("incidental rather than guaranteed"). It does survive. This PR makes the invalidation explicit: `finalizeReplay` in the ReplayEngine now passes the reconstructed history through the existing `invalidateResponsesStatefulChain` helper, so no resume path can offer the backend a dead parent.

One production line changed. The rest is tests, and a doc-comment correction on the helper whose contract now has a third caller.

Reviewers should look at two things: the choice of `finalizeReplay` as the funnel, and the deliberate decision **not** to make the strip Codex-only (explained under "Deferred, and why" below).

## Dive Deeper

### The marker did survive resume

1. `mergeTurnMetadata` (`packages/agents/src/core/ConversationManager.ts`) folds `responsesStored: true` onto the AI turn added to `HistoryService`.
2. `RecordingIntegration`'s `contentAdded` handler calls `SessionRecordingService.recordContent(content)`, which enqueues the entire `IContent` — metadata included — as a `content` event in the session JSONL.
3. `ReplayEngine.handleContent` pushes the deserialized object straight into `acc.history`; `isSpeakerContent` validates only `speaker` and `blocks`.

Nothing between the recording and the provider removed it. The new provider test proves this end to end: with the strip reverted, the first turn of a resumed session sends `previous_response_id: "resp_from_previous_process"`.

### Why `finalizeReplay`

Both public replay entry points — `replaySession` and `replaySessionThroughSequence` — return through `readSessionStream`, which calls `finalizeReplay` at both the bounded stop and at EOF. One strip there covers every path that reconstructs history from a persisted recording:

- `--continue` at startup (`cliSessionBootstrap` → `resumeSession`)
- `/continue` and the session browser (`performResume` → `resumeSession`)
- `/chat resume <tag>` and `/chat load` (aliases of the same `perform_resume` action)
- checkpoint fork (`SessionTransitionService`, both the full validation replay and the bounded fork replay)
- ACP/Zed `session/load` and `session/resume` (`sessionControl` → `resumeSession`)

A checkpoint fork replays a rewound prefix, so its markers are invalid for the same reason a compressed history's are, even when the socket is still live in-process.

The compression half of the issue was already handled by #3134 Fix 3 (`applyCompressionWithAnchor` and `densityValidation` already call the same helper) and is unchanged here. There is a regression test for it.

### The helper's aliasing contract

`invalidateResponsesStatefulChain` documents that its result shares the caller's entry objects and must be treated as read-only, and it named its two existing callers as proof that nobody writes through it. Replay is now a third caller, and its consumers **do** install those entries into a `HistoryService`, whose chronology stamper writes `metadata` in place. That is safe only because the entries belong to the replay accumulator, which is discarded when `finalizeReplay` returns. The doc comment now says that instead of the old claim, and warns the next caller that cloning the array would not help — the entries are what is shared.

### Scope: what the issue proposed and what was accepted

The issue listed three optimizations. Only the first is implemented.

**Accepted — strip `responsesStored` on resume.** Concrete, testable, removes a real wasted round trip.

**Deferred — compact before the first request of a resumed session.** The issue words this as "investigate". Forcing a compaction to shrink the seed costs its own full-history summarization request, so it is net negative unless the session is already at the auto-compression threshold, in which case the existing threshold already fires. Acting on it means changing compression trigger policy, which is a different subsystem.

**Deferred — prewarm the socket with a `generate=false` `response.create`.** This does not deliver the issue's stated goal. Either the prewarm carries the transcript, in which case those bytes are spent anyway and an extra round trip is added on top, or it carries no input, in which case the response it establishes is not a parent holding the transcript and the first real turn must still send everything. Neither branch removes the payload. What it can buy is latency, which is a different metric needing measurement, and it would require a new public `prewarm` method on the `WebSocketTransport` interface. Worth its own issue if first-turn latency after resume is measured and found to matter.

To be clear about what this PR does and does not do: it does not remove the one full-history request per resume, which the issue itself calls unavoidable. It removes the possibility of a *wasted* request before it.

### Deferred, and why — the strip is not Codex-only

Review raised that a non-Codex Responses parent is stored durably server-side and can outlive the process, so stripping it costs an opt-in non-Codex user one full-history request on resume. That is true, and the strip is still deliberately unconditional.

`responsesStored` conflates two different lifetimes. `buildRequestContext` sets it as `request.store === true || (isCodex && stateful.enabled)`, so it means "durably stored server-side" for non-Codex and "chainable on this socket" for Codex, where `store` is false. A recording carries nothing that separates the two, nor anything about a durable parent's retention window. Splitting them properly means a new metadata field, which is a public-surface change beyond this issue.

So a parent that cannot be shown to be live is treated as dead. Being wrong that way costs one full-history request that the next turn re-chains from; being wrong the other way costs a refused request. The trade-off is recorded at the call site. Happy to split the marker in a follow-up if you would rather have the non-Codex case optimized.

The other deferral: a checkpoint fork taken at or near the current head can carry a parent the still-open socket would resolve, so the strip costs one full-history request there too. Preserving it means plumbing live transport identity from the provider into the session transition service, a new cross-package coupling. Fail-safe invalidation is kept.

## Reviewer Test Plan

Automated, and both suites are reversion-sensitive:

```bash
bun test packages/core/src/recording/ReplayEngine.statefulChain.test.ts
bun test packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts
```

To watch them fail for the right reason, replace `invalidateResponsesStatefulChain(acc.history)` with `acc.history` in `finalizeReplay`. Four of the ten core tests fail with `Received: true`, and the provider test fails with `Received: "resp_from_previous_process"` — the dead parent being offered to the backend.

The provider test is not a hand-built fixture: it writes a real session JSONL, runs it through `replaySession` the way `--continue` does, and hands the replayed history to the real executor over the fake-socket transport harness, so the whole record → replay → provider path is exercised.

Manual, against a real Codex session:

1. Run a Codex session with `responses-stateful` on (the default for Codex) and take at least two turns so a stored parent exists.
2. Exit, then `--continue` that session and take a turn.
3. Confirm the first resumed request carries no `previous_response_id` and a full history, and that the very next turn carries `previous_response_id` and a 1-item delta.

Behavior visible to users should be unchanged; this removes a possible wasted round trip, not a feature.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, the `stepfun-37` startup smoke, and `bun scripts/test-audit/scan.ts` (no MOCK_MIRROR / ALWAYS_TRUE / SELF_CONFIRMING / NO_ASSERT findings on either new file).

The only failing tests in the full local run are four `RipgrepPathResolver` cases that expect ripgrep at `/usr/local/bin/rg` on a machine where Homebrew puts it at `/opt/homebrew/bin/rg`. Neither `packages/core/src/utils/ripgrepPathResolver.ts` nor its test appears in `git diff main...HEAD`, and the resolver imports nothing this PR touches. Linux CI should be clean; if it is not, I will fix it rather than wave it off.

## Linked issues / bugs

Fixes #3160

Follow-up to #3134 (Codex statefulness). Depends on nothing; changes nothing about #3134's compression invalidation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replay sessions now clear stale response-chain state, preventing previously persisted identifiers from affecting resumed AI interactions.
  * Resumed Codex sessions now correctly restart response chaining when replaying recorded history, while preserving active chaining for ongoing conversations.
  * Replay behavior remains unchanged for entries without response markers, non-AI entries, and empty recordings.

* **Documentation**
  * Clarified safe usage and lifecycle expectations for replay state invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->