### PR TITLE
Record real headers and honest transport in provider dumpcontext dumps (Fixes #3159)

### DIFF
--- a/packages/providers/src/anthropic/AnthropicApiExecution.ts
+++ b/packages/providers/src/anthropic/AnthropicApiExecution.ts
@@ -177,6 +177,7 @@ export interface ApiExecutionParams {
   baseURL: string;
   requestBody: Record<string, unknown>;
   streamingEnabled: boolean;
+  headers?: Record<string, string>;
   rateLimitLogger: { debug: (fn: () => string) => void };
 }
 
@@ -205,6 +206,10 @@ async function dumpAnthropicRequest(
         '/v1/messages',
         params.requestBody,
         params.baseURL,
+        {
+          headers: params.headers,
+          transport: { type: 'http' },
+        },
       ),
     params.rateLimitLogger,
   );
@@ -240,6 +245,10 @@ async function dumpAnthropicApiError(
     params.baseURL,
     dumpSDKRequestContext,
     dumpSDKResponseContext,
+    {
+      headers: params.headers,
+      transport: { type: 'http' },
+    },
   );
 }
 
@@ -276,6 +285,10 @@ async function handleAnthropicSuccessDump(
       params.baseURL,
       dumpSDKRequestContext,
       dumpSDKResponseContext,
+      {
+        headers: params.headers,
+        transport: { type: 'http' },
+      },
     );
   }
   return response;

--- a/packages/providers/src/anthropic/AnthropicApiExecution.ts
+++ b/packages/providers/src/anthropic/AnthropicApiExecution.ts
@@ -22,6 +22,7 @@ import {
   wrapStreamWithSDKErrorDump,
   bestEffortDump,
   dumpSDKErrorRequestResponse,
+  type RequestDumpMetadata,
 } from '../utils/dumpSDKContext.js';
 import {
   type AnthropicRateLimitInfo,
@@ -190,6 +191,20 @@ export interface ApiExecutionResult {
   rateLimitInfo?: AnthropicRateLimitInfo;
 }
 
+/**
+ * Dump metadata for every Anthropic dump site: the request is always sent over
+ * plain HTTP with the observed header map (#3159). Kept in one helper so the
+ * transport discriminator and header shape cannot drift between sites.
+ */
+function anthropicDumpMetadata(
+  params: ApiExecutionParams,
+): RequestDumpMetadata {
+  return {
+    headers: params.headers,
+    transport: { type: 'http' },
+  };
+}
+
 async function dumpAnthropicRequest(
   params: ApiExecutionParams,
   shouldDumpSuccess: boolean,
@@ -206,10 +221,7 @@ async function dumpAnthropicRequest(
         '/v1/messages',
         params.requestBody,
         params.baseURL,
-        {
-          headers: params.headers,
-          transport: { type: 'http' },
-        },
+        anthropicDumpMetadata(params),
       ),
     params.rateLimitLogger,
   );
@@ -245,10 +257,7 @@ async function dumpAnthropicApiError(
     params.baseURL,
     dumpSDKRequestContext,
     dumpSDKResponseContext,
-    {
-      headers: params.headers,
-      transport: { type: 'http' },
-    },
+    anthropicDumpMetadata(params),
   );
 }
 
@@ -285,10 +294,7 @@ async function handleAnthropicSuccessDump(
       params.baseURL,
       dumpSDKRequestContext,
       dumpSDKResponseContext,
-      {
-        headers: params.headers,
-        transport: { type: 'http' },
-      },
+      anthropicDumpMetadata(params),
     );
   }
   return response;

--- a/packages/providers/src/anthropic/AnthropicProvider.dumpContext.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.dumpContext.test.ts
@@ -278,6 +278,9 @@ describe('AnthropicProvider dumpContext integration', () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           'anthropic-beta': 'extended-cache-ttl-2025-04-11',
+          // SDK-generated credential header must be recorded by name (value
+          // redacted at write time by the shared redaction).
+          'x-api-key': 'sk-ant-test-key',
         }),
         transport: { type: 'http' },
       }),
@@ -290,6 +293,26 @@ describe('AnthropicProvider dumpContext integration', () => {
       true,
     );
     expect(dumpContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should keep a caller-supplied credential header over the synthesized one (issue #3159)', () => {
+    expect(
+      provider['withCredentialHeader'](
+        { Authorization: 'Bearer caller-token' },
+        true,
+        'sk-ant-oauth',
+      ),
+    ).toStrictEqual({ Authorization: 'Bearer caller-token' });
+    expect(
+      provider['withCredentialHeader'](
+        { 'x-api-key': 'caller-key' },
+        false,
+        'sk-ant-test-key',
+      ),
+    ).toStrictEqual({ 'x-api-key': 'caller-key' });
+    expect(
+      provider['withCredentialHeader'](undefined, false, 'sk-ant-key'),
+    ).toStrictEqual({ 'x-api-key': 'sk-ant-key' });
   });
 
   it('should not dump context in provider when mode is now', async () => {

--- a/packages/providers/src/anthropic/AnthropicProvider.dumpContext.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.dumpContext.test.ts
@@ -275,6 +275,12 @@ describe('AnthropicProvider dumpContext integration', () => {
         model: 'claude-sonnet-4-5-20250929',
       }),
       'https://api.anthropic.com',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'anthropic-beta': 'extended-cache-ttl-2025-04-11',
+        }),
+        transport: { type: 'http' },
+      }),
     );
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledTimes(1);
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -682,6 +682,7 @@ export class AnthropicProvider extends BaseProvider {
         { ...requestContext, requestBody: effectiveRequestBody },
         apiCallWithResponse,
         rateLimitLogger,
+        customHeaders,
       );
       response = result.response;
       rateLimitInfo = result.rateLimitInfo;
@@ -784,6 +785,7 @@ export class AnthropicProvider extends BaseProvider {
         options.invocation.signal,
       ),
       rateLimitLogger,
+      customHeaders,
     );
     return {
       response: retryResult.response,
@@ -903,6 +905,7 @@ export class AnthropicProvider extends BaseProvider {
       response: Response | undefined;
     }>,
     rateLimitLogger: { debug: (fn: () => string) => void },
+    headers: Record<string, string> | undefined,
   ) {
     const dumpMode = options.invocation.ephemerals.dumpcontext as
       | DumpMode
@@ -919,6 +922,7 @@ export class AnthropicProvider extends BaseProvider {
       baseURL,
       requestBody: requestContext.requestBody,
       streamingEnabled: requestContext.streamingEnabled,
+      headers,
       rateLimitLogger,
     });
   }

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -671,35 +671,18 @@ export class AnthropicProvider extends BaseProvider {
       options.invocation.signal,
     );
 
-    let response:
-      | Anthropic.Message
-      | AsyncIterable<Anthropic.MessageStreamEvent>;
-    let rateLimitInfo: AnthropicRateLimitInfo | undefined;
-
-    try {
-      const result = await this.executeApiCall(
-        options,
-        { ...requestContext, requestBody: effectiveRequestBody },
-        apiCallWithResponse,
-        rateLimitLogger,
-        customHeaders,
-      );
-      response = result.response;
-      rateLimitInfo = result.rateLimitInfo;
-    } catch (error) {
-      // Issue #3216: one-shot reactive recovery for poisoned history.
-      const recovered = await this.executeImageDimensionRecovery(
-        error,
-        requestContext,
-        options,
-        initialClient,
-        customHeaders,
-        rateLimitLogger,
-      );
-      if (recovered === undefined) throw error;
-      response = recovered.response;
-      rateLimitInfo = recovered.rateLimitInfo;
-    }
+    const executed = await this.executeWithImageRecovery(
+      options,
+      requestContext,
+      effectiveRequestBody,
+      apiCallWithResponse,
+      initialClient,
+      customHeaders,
+      rateLimitLogger,
+      isOAuth,
+      authToken,
+    );
+    const { response, rateLimitInfo } = executed;
 
     if (rateLimitInfo) {
       this.lastRateLimitInfo = rateLimitInfo;
@@ -712,6 +695,58 @@ export class AnthropicProvider extends BaseProvider {
       isOAuth,
       rateLimitLogger,
     );
+  }
+
+  /**
+   * Issue #3216: run the API call, falling back once to image-dimension
+   * recovery for poisoned history when the initial call fails. Returns the
+   * executed response plus rate-limit info; rethrows when recovery does not
+   * apply. Never loops.
+   */
+  private async executeWithImageRecovery(
+    options: NormalizedGenerateChatOptions,
+    requestContext: Awaited<ReturnType<typeof prepareAnthropicRequest>>,
+    effectiveRequestBody: Awaited<
+      ReturnType<typeof prepareAnthropicRequest>
+    >['requestBody'],
+    apiCallWithResponse: () => Promise<{
+      data: Anthropic.Message | AsyncIterable<Anthropic.MessageStreamEvent>;
+      response: Response | undefined;
+    }>,
+    initialClient: Parameters<typeof createAnthropicApiCall>[0],
+    customHeaders: Parameters<typeof createAnthropicApiCall>[2],
+    rateLimitLogger: { debug: (fn: () => string) => void },
+    isOAuth: boolean,
+    authToken: string,
+  ): Promise<{
+    response: Anthropic.Message | AsyncIterable<Anthropic.MessageStreamEvent>;
+    rateLimitInfo: AnthropicRateLimitInfo | undefined;
+  }> {
+    try {
+      const result = await this.executeApiCall(
+        options,
+        { ...requestContext, requestBody: effectiveRequestBody },
+        apiCallWithResponse,
+        rateLimitLogger,
+        customHeaders,
+        isOAuth,
+        authToken,
+      );
+      return { response: result.response, rateLimitInfo: result.rateLimitInfo };
+    } catch (error) {
+      const recovered = await this.executeImageDimensionRecovery(
+        error,
+        requestContext,
+        options,
+        initialClient,
+        customHeaders,
+        rateLimitLogger,
+        isOAuth,
+        authToken,
+      );
+      if (recovered === undefined) throw error;
+      return recovered;
+    }
   }
 
   /**
@@ -737,6 +772,8 @@ export class AnthropicProvider extends BaseProvider {
     initialClient: Parameters<typeof createAnthropicApiCall>[0],
     customHeaders: Parameters<typeof createAnthropicApiCall>[2],
     rateLimitLogger: { debug: (fn: () => string) => void },
+    isOAuth: boolean,
+    authToken: string,
   ): Promise<
     | {
         response:
@@ -786,6 +823,8 @@ export class AnthropicProvider extends BaseProvider {
       ),
       rateLimitLogger,
       customHeaders,
+      isOAuth,
+      authToken,
     );
     return {
       response: retryResult.response,
@@ -897,6 +936,22 @@ export class AnthropicProvider extends BaseProvider {
     }
   }
 
+  /** #3159: the SDK generates the credential header (x-api-key for an API key,
+   * Authorization: Bearer for OAuth). Record the NAME in dump metadata;
+   * shared redaction replaces the value with [REDACTED].
+   */
+  private withCredentialHeader(
+    headers: Record<string, string> | undefined,
+    isOAuth: boolean,
+    authToken: string,
+  ): Record<string, string> | undefined {
+    const name = isOAuth ? 'Authorization' : 'x-api-key';
+    const value = isOAuth ? `Bearer ${authToken}` : authToken;
+    return headers === undefined
+      ? { [name]: value }
+      : { ...headers, [name]: value };
+  }
+
   private async executeApiCall(
     options: NormalizedGenerateChatOptions,
     requestContext: Awaited<ReturnType<typeof prepareAnthropicRequest>>,
@@ -906,7 +961,11 @@ export class AnthropicProvider extends BaseProvider {
     }>,
     rateLimitLogger: { debug: (fn: () => string) => void },
     headers: Record<string, string> | undefined,
+    isOAuth: boolean,
+    authToken: string,
   ) {
+    const dumpHeaders: Record<string, string> | undefined =
+      this.withCredentialHeader(headers, isOAuth, authToken);
     const dumpMode = options.invocation.ephemerals.dumpcontext as
       | DumpMode
       | undefined;
@@ -922,7 +981,7 @@ export class AnthropicProvider extends BaseProvider {
       baseURL,
       requestBody: requestContext.requestBody,
       streamingEnabled: requestContext.streamingEnabled,
-      headers,
+      headers: dumpHeaders,
       rateLimitLogger,
     });
   }

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -66,6 +66,11 @@ import {
 } from './AnthropicImageSanitizer.js';
 import { tryConsumeTransportAttempt } from '../transportAttemptBudget.js';
 
+function hasHeaderName(headers: Record<string, string>, name: string): boolean {
+  const target = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === target);
+}
+
 export class AnthropicProvider extends BaseProvider {
   // @plan PLAN-20251023-STATELESS-HARDENING.P08
   // All properties are stateless - no runtime/client caches or constructor-captured config
@@ -938,7 +943,8 @@ export class AnthropicProvider extends BaseProvider {
 
   /** #3159: the SDK generates the credential header (x-api-key for an API key,
    * Authorization: Bearer for OAuth). Record the NAME in dump metadata;
-   * shared redaction replaces the value with [REDACTED].
+   * shared redaction replaces the value with [REDACTED]. A caller-supplied
+   * credential header always wins over the synthesized one.
    */
   private withCredentialHeader(
     headers: Record<string, string> | undefined,
@@ -946,6 +952,9 @@ export class AnthropicProvider extends BaseProvider {
     authToken: string,
   ): Record<string, string> | undefined {
     const name = isOAuth ? 'Authorization' : 'x-api-key';
+    if (headers !== undefined && hasHeaderName(headers, name)) {
+      return headers;
+    }
     const value = isOAuth ? `Bearer ${authToken}` : authToken;
     return headers === undefined
       ? { [name]: value }

--- a/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
@@ -291,7 +291,9 @@ describe('Gemini non-OAuth non-streaming generate separate dump', () => {
     );
 
     expect(generationSpy).toHaveBeenCalledOnce();
-    expect(generationSpy.mock.calls[0][13]).toStrictEqual({
+    // headers is the trailing parameter of executeNonOAuthGeneration
+    const args = generationSpy.mock.calls[0];
+    expect(args.at(-1)).toStrictEqual({
       'x-goog-api-key': 'gk-secret',
     });
   });

--- a/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
@@ -144,36 +144,6 @@ describe('Gemini non-OAuth non-streaming generate separate dump', () => {
     expect(dumpSDKContextSpy).not.toHaveBeenCalled();
   });
 
-  it('should send API request when request dump fails', async () => {
-    dumpSDKRequestContextSpy.mockRejectedValueOnce(new Error('disk full'));
-    const mockResponse = {
-      candidates: [{ content: { parts: [{ text: 'Hello' }] } }],
-    };
-    const mockContentGenerator = {
-      generateContent: vi.fn().mockResolvedValue(mockResponse),
-    };
-    const mapResponseToChunks = vi
-      .fn()
-      .mockReturnValue([
-        { speaker: 'ai', blocks: [{ type: 'text', text: 'Hello' }] },
-      ]);
-    const { GeminiProvider } = await import('./GeminiProvider.js');
-    const provider = new GeminiProvider('test-api-key');
-
-    await provider['nonOAuthNonStreamingGenerate'](
-      mockContentGenerator,
-      { model: 'gemini-2.5-pro', contents: [], config: {} },
-      true,
-      false,
-      undefined,
-      mapResponseToChunks,
-      true,
-    );
-
-    expect(mockContentGenerator.generateContent).toHaveBeenCalledOnce();
-    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
-  });
-
   it('should link on-mode API errors to the pre-request dump without legacy dumpSDKContext', async () => {
     const callOrder: string[] = [];
     dumpSDKRequestContextSpy.mockImplementation(async () => {
@@ -215,6 +185,25 @@ describe('Gemini non-OAuth non-streaming generate separate dump', () => {
       true,
     );
     expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should keep a caller-supplied x-goog-api-key header over the synthesized one (issue #3159)', async () => {
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    expect(
+      provider['withApiKeyHeader'](
+        { 'x-goog-api-key': 'caller-key' },
+        'gemini-api-key',
+        'gk-secret',
+      ),
+    ).toStrictEqual({ 'x-goog-api-key': 'caller-key' });
+    expect(
+      provider['withApiKeyHeader']({}, 'gemini-api-key', 'gk-secret'),
+    ).toStrictEqual({ 'x-goog-api-key': 'gk-secret' });
+    expect(
+      provider['withApiKeyHeader']({ other: 'header' }, 'vertex-ai', 'tok'),
+    ).toStrictEqual({ other: 'header' });
   });
 });
 

--- a/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
@@ -98,10 +98,10 @@ describe('Gemini non-OAuth non-streaming generate separate dump', () => {
       '/v1/models/generateContent',
       apiRequest,
       'https://generativelanguage.googleapis.com',
-      expect.objectContaining({
-        headers: expect.objectContaining({ 'x-goog-api-key': 'gk-secret' }),
+      {
+        headers: { 'x-goog-api-key': 'gk-secret' },
         transport: { type: 'http' },
-      }),
+      },
     );
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
     expect(dumpSDKContextSpy).not.toHaveBeenCalled();

--- a/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
@@ -6,6 +6,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
 import * as dumpSDKContextModule from '../utils/dumpSDKContext.js';
+import * as geminiGenerationExecutionModule from './geminiGenerationExecution.js';
+import type { GeminiGenerationSetup } from './geminiGenerationSetup.js';
+import type { ReasoningConfig } from './geminiReasoningConfig.js';
 
 describe('Gemini non-OAuth non-streaming generate separate dump', () => {
   let dumpSDKRequestContextSpy: ReturnType<typeof vi.spyOn>;
@@ -144,6 +147,36 @@ describe('Gemini non-OAuth non-streaming generate separate dump', () => {
     expect(dumpSDKContextSpy).not.toHaveBeenCalled();
   });
 
+  it('should send API request when request dump fails', async () => {
+    dumpSDKRequestContextSpy.mockRejectedValueOnce(new Error('disk full'));
+    const mockResponse = {
+      candidates: [{ content: { parts: [{ text: 'Hello' }] } }],
+    };
+    const mockContentGenerator = {
+      generateContent: vi.fn().mockResolvedValue(mockResponse),
+    };
+    const mapResponseToChunks = vi
+      .fn()
+      .mockReturnValue([
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'Hello' }] },
+      ]);
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    await provider['nonOAuthNonStreamingGenerate'](
+      mockContentGenerator,
+      { model: 'gemini-2.5-pro', contents: [], config: {} },
+      true,
+      false,
+      undefined,
+      mapResponseToChunks,
+      true,
+    );
+
+    expect(mockContentGenerator.generateContent).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+  });
+
   it('should link on-mode API errors to the pre-request dump without legacy dumpSDKContext', async () => {
     const callOrder: string[] = [];
     dumpSDKRequestContextSpy.mockImplementation(async () => {
@@ -198,12 +231,69 @@ describe('Gemini non-OAuth non-streaming generate separate dump', () => {
         'gk-secret',
       ),
     ).toStrictEqual({ 'x-goog-api-key': 'caller-key' });
+    // Header names are case-insensitive: a caller-supplied variant spelling
+    // must also suppress the synthesized lowercase entry.
+    expect(
+      provider['withApiKeyHeader'](
+        { 'X-Goog-Api-Key': 'caller-key' },
+        'gemini-api-key',
+        'gk-secret',
+      ),
+    ).toStrictEqual({ 'X-Goog-Api-Key': 'caller-key' });
     expect(
       provider['withApiKeyHeader']({}, 'gemini-api-key', 'gk-secret'),
     ).toStrictEqual({ 'x-goog-api-key': 'gk-secret' });
     expect(
       provider['withApiKeyHeader']({ other: 'header' }, 'vertex-ai', 'tok'),
     ).toStrictEqual({ other: 'header' });
+  });
+
+  it('should thread the synthesized API-key header through executeGeneration into the generation call (issue #3159)', async () => {
+    const generationSpy = vi
+      .spyOn(geminiGenerationExecutionModule, 'executeNonOAuthGeneration')
+      .mockResolvedValue({ stream: null, emitted: false });
+    const { createProviderCallOptions } = await import(
+      '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js'
+    );
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    const reasoningConfig: ReasoningConfig = {
+      enabled: undefined,
+      includeInResponse: false,
+      stripFromContext: 'all',
+      effort: undefined,
+      maxTokens: undefined,
+      effortWireFormat: 'none',
+      enabledWireFormat: 'none',
+      effortMap: undefined,
+      enabledMap: undefined,
+    };
+    const setup: GeminiGenerationSetup = {
+      authMode: 'gemini-api-key',
+      authToken: 'gk-secret',
+      currentModel: 'gemini-2.5-pro',
+      contentsWithSignatures: [],
+      requestConfig: {},
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      httpOptions: { headers: {} },
+      mapResponseToChunks: () => [],
+      reasoningConfig,
+      toolNamesForPrompt: undefined,
+      shouldDumpSuccess: true,
+      shouldDumpError: true,
+    };
+
+    await provider['executeGeneration'](
+      createProviderCallOptions({ providerName: 'gemini', contents: [] }),
+      setup,
+      false,
+    );
+
+    expect(generationSpy).toHaveBeenCalledOnce();
+    expect(generationSpy.mock.calls[0][13]).toStrictEqual({
+      'x-goog-api-key': 'gk-secret',
+    });
   });
 });
 

--- a/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
@@ -85,10 +85,21 @@ describe('Gemini non-OAuth non-streaming generate separate dump', () => {
       undefined,
       mapResponseToChunks,
       true,
+      { 'x-goog-api-key': 'gk-secret' },
     );
 
     expect(callOrder).toStrictEqual(['requestDump', 'apiCall']);
     expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledWith(
+      'gemini',
+      '/v1/models/generateContent',
+      apiRequest,
+      'https://generativelanguage.googleapis.com',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'x-goog-api-key': 'gk-secret' }),
+        transport: { type: 'http' },
+      }),
+    );
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
     expect(dumpSDKContextSpy).not.toHaveBeenCalled();
     expect(result.chunks).toBeDefined();

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -58,6 +58,11 @@ import { requireAssembledSystemInstruction } from '../utils/systemPromptPlacemen
  * and server-tool invocation are delegated to cohesive submodules in this
  * package to keep the provider class thin and within lint budgets.
  */
+function hasHeaderName(headers: Record<string, string>, name: string): boolean {
+  const target = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === target);
+}
+
 export class GeminiProvider extends BaseProvider {
   constructor(apiKey?: string, baseURL?: string, config?: Config) {
     const baseConfig: BaseProviderConfig = {
@@ -420,7 +425,12 @@ export class GeminiProvider extends BaseProvider {
     authMode: GeminiAuthMode,
     authToken: string,
   ): Record<string, string> {
-    if (authMode !== 'gemini-api-key' || 'x-goog-api-key' in headers) {
+    // Header names are case-insensitive; a caller-supplied variant spelling
+    // must win over the synthesized entry (#3159).
+    if (
+      authMode !== 'gemini-api-key' ||
+      hasHeaderName(headers, 'x-goog-api-key')
+    ) {
       return headers;
     }
     return { ...headers, 'x-goog-api-key': authToken };

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -430,6 +430,7 @@ export class GeminiProvider extends BaseProvider {
       setup.reasoningConfig.includeInResponse,
       () => this.createNonOAuthGenerator(setup),
       setup.baseURL,
+      setup.httpOptions.headers,
     );
   }
 
@@ -461,6 +462,7 @@ export class GeminiProvider extends BaseProvider {
     baseURL: string | undefined,
     mapResponseToChunks: GeminiGenerationSetup['mapResponseToChunks'],
     reasoningIncludeInResponse: boolean,
+    headers?: Record<string, string>,
   ): Promise<GeminiGenerationResult> {
     return executeNonOAuthNonStreamingGenerate(
       contentGenerator,
@@ -470,6 +472,7 @@ export class GeminiProvider extends BaseProvider {
       baseURL,
       mapResponseToChunks,
       reasoningIncludeInResponse,
+      headers,
     );
   }
 
@@ -479,6 +482,7 @@ export class GeminiProvider extends BaseProvider {
     shouldDumpSuccess: boolean,
     shouldDumpError: boolean,
     baseURL: string | undefined,
+    headers?: Record<string, string>,
   ): Promise<GeminiGenerationResult> {
     return executeNonOAuthStreamingGenerate(
       contentGenerator,
@@ -488,6 +492,7 @@ export class GeminiProvider extends BaseProvider {
       baseURL,
       () => [],
       false,
+      headers,
     );
   }
 

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -416,6 +416,10 @@ export class GeminiProvider extends BaseProvider {
     setup: GeminiGenerationSetup,
     streamingEnabled: boolean,
   ): Promise<GeminiGenerationResult> {
+    const dumpHeaders: Record<string, string> =
+      setup.authMode === 'gemini-api-key'
+        ? { ...setup.httpOptions.headers, 'x-goog-api-key': setup.authToken }
+        : setup.httpOptions.headers;
     return executeNonOAuthGeneration(
       options,
       this.globalConfig,
@@ -430,7 +434,7 @@ export class GeminiProvider extends BaseProvider {
       setup.reasoningConfig.includeInResponse,
       () => this.createNonOAuthGenerator(setup),
       setup.baseURL,
-      setup.httpOptions.headers,
+      dumpHeaders,
     );
   }
 

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -411,15 +411,31 @@ export class GeminiProvider extends BaseProvider {
     );
   }
 
+  /** #3159: the SDK sends the Gemini API key as x-goog-api-key; record the
+   * header NAME in dump metadata (value redacted at write time). A
+   * caller-supplied header always wins over the synthesized one.
+   */
+  private withApiKeyHeader(
+    headers: Record<string, string>,
+    authMode: GeminiAuthMode,
+    authToken: string,
+  ): Record<string, string> {
+    if (authMode !== 'gemini-api-key' || 'x-goog-api-key' in headers) {
+      return headers;
+    }
+    return { ...headers, 'x-goog-api-key': authToken };
+  }
+
   private async executeGeneration(
     options: NormalizedGenerateChatOptions,
     setup: GeminiGenerationSetup,
     streamingEnabled: boolean,
   ): Promise<GeminiGenerationResult> {
-    const dumpHeaders: Record<string, string> =
-      setup.authMode === 'gemini-api-key'
-        ? { ...setup.httpOptions.headers, 'x-goog-api-key': setup.authToken }
-        : setup.httpOptions.headers;
+    const dumpHeaders = this.withApiKeyHeader(
+      setup.httpOptions.headers,
+      setup.authMode,
+      setup.authToken,
+    );
     return executeNonOAuthGeneration(
       options,
       this.globalConfig,

--- a/packages/providers/src/gemini/geminiGenerationExecution.ts
+++ b/packages/providers/src/gemini/geminiGenerationExecution.ts
@@ -38,6 +38,7 @@ async function dumpError(
   request: GenerateContentParameters,
   baseURL: string,
   error: unknown,
+  headers?: Record<string, string>,
 ): Promise<void> {
   if (!shouldDumpError) {
     return;
@@ -62,6 +63,7 @@ async function dumpError(
     baseURL,
     dumpSDKRequestContext,
     dumpSDKResponseContext,
+    { headers, transport: { type: 'http' } },
   );
 }
 
@@ -72,6 +74,7 @@ function wrapGeminiStreamForDump(
   shouldDumpError: boolean,
   requestBaseId: string | undefined,
   baseURL: string,
+  headers?: Record<string, string>,
 ): AsyncIterable<GenerateContentResponse> {
   if (shouldDumpSuccess && requestBaseId) {
     return wrapStreamWithDump(
@@ -90,6 +93,7 @@ function wrapGeminiStreamForDump(
       baseURL,
       dumpSDKRequestContext,
       dumpSDKResponseContext,
+      { headers, transport: { type: 'http' } },
     );
   }
   return stream;
@@ -122,6 +126,7 @@ export async function executeNonOAuthGeneration(
   reasoningIncludeInResponse: boolean,
   createContentGenerator: () => Promise<NonOAuthContentGenerator>,
   baseURL: string | undefined,
+  headers?: Record<string, string>,
 ): Promise<GeminiGenerationResult> {
   const contentGenerator = await createContentGenerator();
   // Issue #3136: the agent layer owns system-prompt assembly. The provider
@@ -145,6 +150,7 @@ export async function executeNonOAuthGeneration(
       baseURL,
       mapResponseToChunks,
       reasoningIncludeInResponse,
+      headers,
     );
   }
   return nonOAuthNonStreamingGenerate(
@@ -155,6 +161,7 @@ export async function executeNonOAuthGeneration(
     baseURL,
     mapResponseToChunks,
     reasoningIncludeInResponse,
+    headers,
   );
 }
 
@@ -166,6 +173,7 @@ export async function nonOAuthNonStreamingGenerate(
   baseURL: string | undefined,
   mapResponseToChunks: ResponseToChunksMapper,
   reasoningIncludeInResponse: boolean,
+  headers?: Record<string, string>,
 ): Promise<GeminiGenerationResult> {
   let requestBaseId: string | undefined;
 
@@ -176,6 +184,7 @@ export async function nonOAuthNonStreamingGenerate(
         '/v1/models/generateContent',
         apiRequest,
         baseURL ?? DEFAULT_BASE_URL,
+        { headers, transport: { type: 'http' } },
       ),
     );
     requestBaseId = reqResult?.baseId;
@@ -201,6 +210,7 @@ export async function nonOAuthNonStreamingGenerate(
       apiRequest,
       baseURL ?? DEFAULT_BASE_URL,
       error,
+      headers,
     );
     throw error;
   }
@@ -214,6 +224,7 @@ export async function nonOAuthStreamingGenerate(
   baseURL: string | undefined,
   _mapResponseToChunks: ResponseToChunksMapper,
   _reasoningIncludeInResponse: boolean,
+  headers?: Record<string, string>,
 ): Promise<GeminiGenerationResult> {
   let requestBaseId: string | undefined;
 
@@ -224,6 +235,7 @@ export async function nonOAuthStreamingGenerate(
         '/v1/models/streamGenerateContent',
         apiRequest,
         baseURL ?? DEFAULT_BASE_URL,
+        { headers, transport: { type: 'http' } },
       ),
     );
     requestBaseId = reqResult?.baseId;
@@ -238,6 +250,7 @@ export async function nonOAuthStreamingGenerate(
       shouldDumpError,
       requestBaseId,
       baseURL ?? DEFAULT_BASE_URL,
+      headers,
     );
     return { stream: streamForReturn, emitted: false };
   } catch (error) {
@@ -248,6 +261,7 @@ export async function nonOAuthStreamingGenerate(
       apiRequest,
       baseURL ?? DEFAULT_BASE_URL,
       error,
+      headers,
     );
     throw error;
   }

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
@@ -135,6 +135,7 @@ function buildNormalizedOptions(
 function buildDeps(): ResponsesExecutorDeps {
   return {
     providerName: 'openai-responses',
+    isWebSocketTransportActive: () => false,
     logger: {
       debug: () => undefined,
     } as unknown as ResponsesExecutorDeps['logger'],

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
@@ -277,7 +277,11 @@ describe('OpenAI Responses error-response dump @issue:3140', () => {
     const written = await listDumpFiles();
     const requestFile = written.find((f) => f.endsWith('-request.json'));
     const responseFile = written.find((f) => f.endsWith('-response.json'));
-    expect(requestFile).toBeDefined();
+    if (requestFile === undefined) {
+      throw new Error(
+        `No -request.json dump written; dump dir contents: ${JSON.stringify(written)}`,
+      );
+    }
     expect(responseFile).toBeDefined();
 
     const responseDump = await readJsonDump(responseFile!);

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
@@ -351,8 +351,10 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
     expect(Array.isArray(dumpedBody.input)).toBe(true);
 
     const dumpedRequest = await readDumpedEnvelope();
-    expect(dumpedRequest.url).toContain('wss://');
-    expect(dumpedRequest.method).not.toBe('POST');
+    expect(dumpedRequest.url).toBe(
+      'wss://chatgpt.com/backend-api/codex/responses',
+    );
+    expect(dumpedRequest.method).toBe('SEND');
     expect(dumpedRequest.transport).toStrictEqual({
       type: 'websocket',
       frameType: 'response.create',

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
@@ -187,6 +187,7 @@ interface DumpedEnvelope {
   method: string;
   transport?: { type: string; frameType?: string };
   headers?: Record<string, string>;
+  body?: unknown;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -237,11 +238,9 @@ function parseDumpRequest(filename: string, raw: string): DumpedRequest {
   const parsed: unknown = JSON.parse(raw);
   if (isPlainRecord(parsed)) {
     const request: unknown = parsed['request'];
-    if (
-      isDumpedEnvelope(request) &&
-      isPlainRecord(request) &&
-      'body' in request
-    ) {
+    // isDumpedEnvelope already guarantees a plain record, so only the
+    // payload key still needs checking here.
+    if (isDumpedEnvelope(request) && 'body' in request) {
       return { filename, envelope: request, body: request['body'] };
     }
   }

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
@@ -182,6 +182,76 @@ describe('executeOpenAIResponsesRequest onStreamLiveness threading @issue:2607',
   });
 });
 
+interface DumpedEnvelope {
+  url: string;
+  method: string;
+  transport?: { type: string; frameType?: string };
+  headers?: Record<string, string>;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isPlainRecord(value) && Object.values(value).every(isString);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isDumpedTransport(
+  value: unknown,
+): value is { type: string; frameType?: string } {
+  return (
+    isPlainRecord(value) &&
+    isString(value['type']) &&
+    (value['frameType'] === undefined || isString(value['frameType']))
+  );
+}
+
+function isDumpedEnvelope(value: unknown): value is DumpedEnvelope {
+  if (!isPlainRecord(value)) {
+    return false;
+  }
+  if (!isString(value['url']) || !isString(value['method'])) {
+    return false;
+  }
+  if (
+    value['transport'] !== undefined &&
+    !isDumpedTransport(value['transport'])
+  ) {
+    return false;
+  }
+  return value['headers'] === undefined || isStringRecord(value['headers']);
+}
+
+function parseDumpEnvelope(raw: string): DumpedEnvelope {
+  const parsed: unknown = JSON.parse(raw);
+  if (isPlainRecord(parsed)) {
+    const request: unknown = parsed['request'];
+    if (isDumpedEnvelope(request)) {
+      return request;
+    }
+  }
+  throw new Error(`malformed dump envelope: ${raw.slice(0, 80)}`);
+}
+
+/** A WebSocket stream that fails before producing any output, forcing the
+ * executor onto the HTTP fallback path. */
+function immediatelyFailingStream(): AsyncIterableIterator<IContent> {
+  const iterator: AsyncIterableIterator<IContent> = {
+    next: () => Promise.reject(new Error('websocket unavailable')),
+    return: () => Promise.resolve({ done: true, value: undefined }),
+    throw: (reason?: unknown) => Promise.reject(reason),
+    [Symbol.asyncIterator]() {
+      return iterator;
+    },
+  };
+  return iterator;
+}
+
 describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
   let tempDumpDir: string;
   const originalConfigHome = process.env['LLXPRT_CONFIG_HOME'];
@@ -244,23 +314,21 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
     transport?: { type: string; frameType?: string };
     headers?: Record<string, string>;
   }> {
+    const envelopes = await readAllDumpedEnvelopes();
+    expect(envelopes).toHaveLength(1);
+    return envelopes[0];
+  }
+
+  async function readAllDumpedEnvelopes(): Promise<DumpedEnvelope[]> {
     const dumpDir = path.join(tempDumpDir, 'dumps');
     const entries = await fsp.readdir(dumpDir);
     const requestFiles = entries.filter((f) => f.endsWith('-request.json'));
-    expect(requestFiles).toHaveLength(1);
-    const raw = await fsp.readFile(
-      path.join(dumpDir, requestFiles[0]),
-      'utf-8',
-    );
-    const parsed = JSON.parse(raw) as {
-      request: {
-        url: string;
-        method: string;
-        transport?: { type: string; frameType?: string };
-        headers?: Record<string, string>;
-      };
-    };
-    return parsed.request;
+    const envelopes: DumpedEnvelope[] = [];
+    for (const file of requestFiles) {
+      const raw = await fsp.readFile(path.join(dumpDir, file), 'utf-8');
+      envelopes.push(parseDumpEnvelope(raw));
+    }
+    return envelopes;
   }
 
   it('A3: emits finalized request dump at common pre-transport seam (HTTP)', async () => {
@@ -364,5 +432,129 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
     );
     expect(dumpedRequest.headers?.['Authorization']).toBe('[REDACTED]');
     expect(dumpedRequest.headers?.['ChatGPT-Account-ID']).toBe('[REDACTED]');
+  });
+
+  it('A3/3159: records the physical HTTP send when the WebSocket falls back mid-turn', async () => {
+    const lf = String.fromCharCode(10);
+    const sseBody = encodeSse([
+      `data: {"type":"response.output_text.delta","delta":"OK"}${lf}${lf}`,
+      `data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}${lf}${lf}`,
+      `data: [DONE]${lf}${lf}`,
+    ]);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, body: sseBody });
+    setGlobal('fetch', fetchMock);
+
+    const options = buildNormalizedOptions({
+      ephemerals: { dumpcontext: 'on' },
+      resolved: {
+        model: 'gpt-5.6-sol',
+        baseURL: 'https://chatgpt.com/backend-api/codex',
+        authToken: 'codex-token',
+      },
+    });
+
+    const wsTransport: WebSocketTransport = {
+      streamResponse: vi.fn().mockReturnValue(immediatelyFailingStream()),
+      close: vi.fn(),
+    };
+
+    const iterator = executeOpenAIResponsesRequest(
+      options,
+      buildDeps({
+        isCodexBaseURL: () => true,
+        getWebSocketTransport: () => wsTransport,
+        isWebSocketTransportActive: () => true,
+      }),
+    );
+    const consumed: IContent[] = [];
+    for await (const chunk of iterator) {
+      consumed.push(chunk);
+    }
+    // Text delta plus the response.completed finish-metadata chunk.
+    expect(consumed).toHaveLength(2);
+    expect(consumed[0]).toStrictEqual({
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'OK' }],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Two honest request dumps: the WebSocket attempt and the physical HTTP
+    // fallback that actually carried the turn.
+    const envelopes = await readAllDumpedEnvelopes();
+    expect(envelopes).toHaveLength(2);
+    const wsDump = envelopes.find((e) => e.method === 'SEND');
+    const httpDump = envelopes.find((e) => e.method === 'POST');
+    expect(wsDump?.url).toBe('wss://chatgpt.com/backend-api/codex/responses');
+    expect(wsDump?.transport).toStrictEqual({
+      type: 'websocket',
+      frameType: 'response.create',
+    });
+    expect(httpDump?.url).toBe(
+      'https://chatgpt.com/backend-api/codex/responses',
+    );
+    expect(httpDump?.transport).toStrictEqual({ type: 'http' });
+    expect(httpDump?.headers?.['Authorization']).toBe('[REDACTED]');
+  });
+
+  it('A3/3159: keeps the WebSocket transport in the dump when header observation fails', async () => {
+    const wsTransport: WebSocketTransport = {
+      streamResponse: vi.fn().mockReturnValue(
+        (async function* () {
+          yield {
+            speaker: 'ai' as const,
+            blocks: [{ type: 'text' as const, text: 'OK' }],
+          };
+        })(),
+      ),
+      close: vi.fn(),
+    };
+    const fetchMock = vi.fn();
+    setGlobal('fetch', fetchMock);
+
+    const options = buildNormalizedOptions({
+      ephemerals: { dumpcontext: 'on' },
+      resolved: {
+        model: 'gpt-5.6-sol',
+        baseURL: 'https://chatgpt.com/backend-api/codex',
+        authToken: 'codex-token',
+      },
+    });
+
+    // First getCodexAccountId call (dump metadata) fails; the second (real
+    // handshake) succeeds so the request still goes over the WebSocket.
+    let codexAccountIdCalls = 0;
+    const iterator = executeOpenAIResponsesRequest(
+      options,
+      buildDeps({
+        isCodexBaseURL: () => true,
+        getWebSocketTransport: () => wsTransport,
+        isWebSocketTransportActive: () => true,
+        getCodexAccountId: async () => {
+          codexAccountIdCalls += 1;
+          if (codexAccountIdCalls === 1) {
+            throw new Error('account id unavailable');
+          }
+          return 'codex-account';
+        },
+      }),
+    );
+    const consumed: IContent[] = [];
+    for await (const chunk of iterator) {
+      consumed.push(chunk);
+    }
+    expect(consumed).toHaveLength(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // The transport was known (WebSocket) even though header observation
+    // failed; the dump must not relabel the request as HTTP.
+    const dumpedRequest = await readDumpedEnvelope();
+    expect(dumpedRequest.method).toBe('SEND');
+    expect(dumpedRequest.url).toBe(
+      'wss://chatgpt.com/backend-api/codex/responses',
+    );
+    expect(dumpedRequest.transport).toStrictEqual({
+      type: 'websocket',
+      frameType: 'response.create',
+    });
   });
 });

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
@@ -227,15 +227,33 @@ function isDumpedEnvelope(value: unknown): value is DumpedEnvelope {
   return value['headers'] === undefined || isStringRecord(value['headers']);
 }
 
-function parseDumpEnvelope(raw: string): DumpedEnvelope {
+interface DumpedRequest {
+  filename: string;
+  envelope: DumpedEnvelope;
+  body: unknown;
+}
+
+function parseDumpRequest(filename: string, raw: string): DumpedRequest {
   const parsed: unknown = JSON.parse(raw);
   if (isPlainRecord(parsed)) {
     const request: unknown = parsed['request'];
-    if (isDumpedEnvelope(request)) {
-      return request;
+    if (
+      isDumpedEnvelope(request) &&
+      isPlainRecord(request) &&
+      'body' in request
+    ) {
+      return { filename, envelope: request, body: request['body'] };
     }
   }
-  throw new Error(`malformed dump envelope: ${raw.slice(0, 80)}`);
+  throw new Error(`malformed dump request: ${raw.slice(0, 80)}`);
+}
+
+/** A WebSocket stream that yields exactly one text chunk. */
+function textChunkStream(text: string): AsyncIterableIterator<IContent> {
+  async function* generate(): AsyncIterableIterator<IContent> {
+    yield { speaker: 'ai', blocks: [{ type: 'text', text }] };
+  }
+  return generate();
 }
 
 /** A WebSocket stream that fails before producing any output, forcing the
@@ -320,15 +338,20 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
   }
 
   async function readAllDumpedEnvelopes(): Promise<DumpedEnvelope[]> {
+    const requests = await readAllDumpedRequests();
+    return requests.map((request) => request.envelope);
+  }
+
+  async function readAllDumpedRequests(): Promise<DumpedRequest[]> {
     const dumpDir = path.join(tempDumpDir, 'dumps');
     const entries = await fsp.readdir(dumpDir);
     const requestFiles = entries.filter((f) => f.endsWith('-request.json'));
-    const envelopes: DumpedEnvelope[] = [];
+    const requests: DumpedRequest[] = [];
     for (const file of requestFiles) {
       const raw = await fsp.readFile(path.join(dumpDir, file), 'utf-8');
-      envelopes.push(parseDumpEnvelope(raw));
+      requests.push(parseDumpRequest(file, raw));
     }
-    return envelopes;
+    return requests;
   }
 
   it('A3: emits finalized request dump at common pre-transport seam (HTTP)', async () => {
@@ -382,14 +405,7 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
     });
 
     const wsTransport: WebSocketTransport = {
-      streamResponse: vi.fn().mockReturnValue(
-        (async function* () {
-          yield {
-            speaker: 'ai' as const,
-            blocks: [{ type: 'text' as const, text: 'OK' }],
-          };
-        })(),
-      ),
+      streamResponse: vi.fn().mockReturnValue(textChunkStream('OK')),
       close: vi.fn(),
     };
 
@@ -496,16 +512,149 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
     expect(httpDump?.headers?.['Authorization']).toBe('[REDACTED]');
   });
 
+  it('A3/3159: a stateful WebSocket fallback records exactly one honest HTTP send', async () => {
+    const lf = String.fromCharCode(10);
+    const sseBody = encodeSse([
+      `data: {"type":"response.output_text.delta","delta":"OK"}${lf}${lf}`,
+      `data: {"type":"response.completed","response":{"id":"r1","status":"completed"}}${lf}${lf}`,
+      `data: [DONE]${lf}${lf}`,
+    ]);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, body: sseBody });
+    setGlobal('fetch', fetchMock);
+
+    // A stored parent makes the WebSocket request stateful
+    // (previous_response_id set), so the HTTP fallback must rebuild the
+    // turn without the parent before sending it over HTTP.
+    const options = buildNormalizedOptions({
+      contents: [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'first question' }],
+        },
+        {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'first answer' }],
+          metadata: {
+            id: 'resp_parent',
+            responsesStored: true,
+            providerBaseURL: 'https://chatgpt.com/backend-api/codex',
+          },
+        },
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'second question' }],
+        },
+      ],
+      ephemerals: { dumpcontext: 'on' },
+      resolved: {
+        model: 'gpt-5.6-sol',
+        baseURL: 'https://chatgpt.com/backend-api/codex',
+        authToken: 'codex-token',
+      },
+    });
+
+    const wsTransport: WebSocketTransport = {
+      streamResponse: vi.fn().mockReturnValue(immediatelyFailingStream()),
+      close: vi.fn(),
+    };
+
+    const iterator = executeOpenAIResponsesRequest(
+      options,
+      buildDeps({
+        isCodexBaseURL: () => true,
+        getWebSocketTransport: () => wsTransport,
+        isWebSocketTransportActive: () => true,
+      }),
+    );
+    const consumed: IContent[] = [];
+    for await (const chunk of iterator) {
+      consumed.push(chunk);
+    }
+    expect(consumed).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Exactly two request dumps: the real WebSocket attempt and the rebuilt
+    // stateless HTTP send. The rebuild must not be recorded as another
+    // WebSocket frame when it physically went over HTTP.
+    const requests = await readAllDumpedRequests();
+    expect(requests).toHaveLength(2);
+    const wsRequest = requests.find((r) => r.envelope.method === 'SEND');
+    const httpRequest = requests.find(
+      (r) =>
+        r.envelope.method === 'POST' && r.envelope.transport?.type === 'http',
+    );
+    expect(wsRequest).toBeDefined();
+    expect(httpRequest).toBeDefined();
+    expect(
+      isPlainRecord(wsRequest?.body) &&
+        wsRequest.body['previous_response_id'] === 'resp_parent',
+    ).toBe(true);
+    expect(
+      isPlainRecord(httpRequest?.body) &&
+        httpRequest.body['previous_response_id'] === undefined,
+    ).toBe(true);
+    expect(httpRequest?.envelope.transport).toStrictEqual({ type: 'http' });
+  });
+
+  it('A3/3159: links a failed HTTP fallback response to the HTTP request dump', async () => {
+    const lf = String.fromCharCode(10);
+    const sseBody = encodeSse([
+      `data: {"error":{"message":"boom","type":"server_error"}}${lf}${lf}`,
+    ]);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 400, body: sseBody });
+    setGlobal('fetch', fetchMock);
+
+    const options = buildNormalizedOptions({
+      ephemerals: { dumpcontext: 'on' },
+      resolved: {
+        model: 'gpt-5.6-sol',
+        baseURL: 'https://chatgpt.com/backend-api/codex',
+        authToken: 'codex-token',
+      },
+    });
+
+    const wsTransport: WebSocketTransport = {
+      streamResponse: vi.fn().mockReturnValue(immediatelyFailingStream()),
+      close: vi.fn(),
+    };
+
+    let caught: unknown;
+    try {
+      const iterator = executeOpenAIResponsesRequest(
+        options,
+        buildDeps({
+          isCodexBaseURL: () => true,
+          getWebSocketTransport: () => wsTransport,
+          isWebSocketTransportActive: () => true,
+        }),
+      );
+      for await (const chunk of iterator) {
+        void chunk;
+      }
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+
+    // The error response must link to the HTTP request dump — the request
+    // that actually failed — not to the earlier WebSocket attempt.
+    const requests = await readAllDumpedRequests();
+    expect(requests).toHaveLength(2);
+    const httpRequest = requests.find((r) => r.envelope.method === 'POST');
+    expect(httpRequest).toBeDefined();
+    const httpBaseId = httpRequest?.filename.replace('-request.json', '');
+    const dumpDir = path.join(tempDumpDir, 'dumps');
+    const entries = await fsp.readdir(dumpDir);
+    const responseFiles = entries.filter((f) => f.endsWith('-response.json'));
+    expect(responseFiles).toHaveLength(1);
+    expect(responseFiles[0].startsWith(`${httpBaseId}-`)).toBe(true);
+  });
+
   it('A3/3159: keeps the WebSocket transport in the dump when header observation fails', async () => {
     const wsTransport: WebSocketTransport = {
-      streamResponse: vi.fn().mockReturnValue(
-        (async function* () {
-          yield {
-            speaker: 'ai' as const,
-            blocks: [{ type: 'text' as const, text: 'OK' }],
-          };
-        })(),
-      ),
+      streamResponse: vi.fn().mockReturnValue(textChunkStream('OK')),
       close: vi.fn(),
     };
     const fetchMock = vi.fn();
@@ -556,5 +705,8 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
       type: 'websocket',
       frameType: 'response.create',
     });
+    // Observation failed, so no headers may be claimed — not even the
+    // legacy synthesized defaults.
+    expect(dumpedRequest.headers).toStrictEqual({});
   });
 });

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
@@ -228,10 +228,39 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
     );
     const parsed = JSON.parse(raw) as {
       request: {
+        url: string;
+        method: string;
+        transport?: { type: string; frameType?: string };
+        headers?: Record<string, string>;
         body: { model?: string; input?: unknown[]; instructions?: string };
       };
     };
     return parsed.request.body;
+  }
+
+  async function readDumpedEnvelope(): Promise<{
+    url: string;
+    method: string;
+    transport?: { type: string; frameType?: string };
+    headers?: Record<string, string>;
+  }> {
+    const dumpDir = path.join(tempDumpDir, 'dumps');
+    const entries = await fsp.readdir(dumpDir);
+    const requestFiles = entries.filter((f) => f.endsWith('-request.json'));
+    expect(requestFiles).toHaveLength(1);
+    const raw = await fsp.readFile(
+      path.join(dumpDir, requestFiles[0]),
+      'utf-8',
+    );
+    const parsed = JSON.parse(raw) as {
+      request: {
+        url: string;
+        method: string;
+        transport?: { type: string; frameType?: string };
+        headers?: Record<string, string>;
+      };
+    };
+    return parsed.request;
   }
 
   it('A3: emits finalized request dump at common pre-transport seam (HTTP)', async () => {
@@ -260,6 +289,15 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
     expect(dumpedBody.model).toBe('gpt-5.6-sol');
     expect(Array.isArray(dumpedBody.input)).toBe(true);
     expect(dumpedBody.instructions).toBe('test system prompt');
+
+    const dumpedRequest = await readDumpedEnvelope();
+    expect(dumpedRequest.url).toBe('https://api.openai.com/v1/responses');
+    expect(dumpedRequest.method).toBe('POST');
+    expect(dumpedRequest.transport).toStrictEqual({ type: 'http' });
+    expect(dumpedRequest.headers?.['Content-Type']).toBe(
+      'application/json; charset=utf-8',
+    );
+    expect(dumpedRequest.headers?.['Authorization']).toBe('[REDACTED]');
   });
 
   it('A3: emits finalized request dump when Codex WebSocket path is selected', async () => {
@@ -292,6 +330,7 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
       buildDeps({
         isCodexBaseURL: () => true,
         getWebSocketTransport: () => wsTransport,
+        isWebSocketTransportActive: () => true,
       }),
     );
     const consumed: IContent[] = [];
@@ -310,5 +349,18 @@ describe('executeOpenAIResponsesRequest dump parity @issue:2253', () => {
     const dumpedBody = await readDumpedRequest();
     expect(dumpedBody.model).toBe('gpt-5.6-sol');
     expect(Array.isArray(dumpedBody.input)).toBe(true);
+
+    const dumpedRequest = await readDumpedEnvelope();
+    expect(dumpedRequest.url).toContain('wss://');
+    expect(dumpedRequest.method).not.toBe('POST');
+    expect(dumpedRequest.transport).toStrictEqual({
+      type: 'websocket',
+      frameType: 'response.create',
+    });
+    expect(dumpedRequest.headers?.['OpenAI-Beta']).toBe(
+      'responses_websockets=2026-02-06',
+    );
+    expect(dumpedRequest.headers?.['Authorization']).toBe('[REDACTED]');
+    expect(dumpedRequest.headers?.['ChatGPT-Account-ID']).toBe('[REDACTED]');
   });
 });

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -70,7 +70,10 @@ import {
   type RequestDumpMetadata,
   bestEffortDump,
 } from '../utils/dumpSDKContext.js';
-import { buildResponsesHeaders } from './openAIResponsesHttpStream.js';
+import {
+  buildResponsesHeaders,
+  dumpFallbackHttpRequest,
+} from './openAIResponsesHttpStream.js';
 import type { DumpMode } from '../utils/dumpContext.js';
 
 /**
@@ -912,8 +915,16 @@ async function dumpFinalizedRequest(
       () =>
         `Best-effort dump metadata failed for ${deps.providerName}: ${String(error)}`,
     );
-    dumpMetadata = { transport: { type: 'http' } };
-    baseURLForDump = requestContext.baseURL;
+    // Header observation failed, but the selected transport is still known;
+    // keep recording it honestly instead of relabeling the request as HTTP.
+    dumpMetadata = {
+      transport: transportActive
+        ? { type: 'websocket', frameType: 'response.create' }
+        : { type: 'http' },
+    };
+    baseURLForDump = transportActive
+      ? toWebSocketDumpURL(requestContext.baseURL)
+      : requestContext.baseURL;
   }
   const result = await bestEffortDump(
     'request',
@@ -969,6 +980,7 @@ async function* streamResponses(
  * resolve that parent (it rejects the request, since nothing is stored
  * server-side), so replaying the WebSocket request here would fail and lose
  * the trimmed-away context. Re-derive a stateless request instead (#3134).
+ * The physical HTTP send is recorded via dumpFallbackHttpRequest (#3159).
  */
 async function* streamOverHttpWithoutStatefulness(
   params: StreamResponsesParams,
@@ -978,6 +990,7 @@ async function* streamOverHttpWithoutStatefulness(
     params.rebuildStateless === undefined ||
     params.request.previous_response_id === undefined
   ) {
+    await dumpFallbackHttpRequest(params, deps);
     yield* streamOverHttp(params, deps);
     return;
   }
@@ -985,7 +998,9 @@ async function* streamOverHttpWithoutStatefulness(
     () =>
       'Codex WebSocket fallback: rebuilding the request without previous_response_id for HTTP.',
   );
-  yield* streamOverHttp(await params.rebuildStateless(), deps);
+  const stateless = await params.rebuildStateless();
+  await dumpFallbackHttpRequest(stateless, deps);
+  yield* streamOverHttp(stateless, deps);
 }
 
 async function buildWebSocketHandshakeHeaders(

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -384,6 +384,8 @@ async function buildStatelessTurn(
     invocationEphemerals,
     deps,
     options,
+    // The rebuilt turn is always carried over HTTP (#3159).
+    true,
   );
   return buildStreamParams(
     context,
@@ -872,12 +874,18 @@ async function dumpFinalizedRequest(
   invocationEphemerals: Record<string, unknown>,
   deps: ResponsesExecutorDeps,
   options: NormalizedGenerateChatOptions,
+  sentOverHttp = false,
 ): Promise<DumpFinalizedResult> {
   const dumpMode = invocationEphemerals['dumpcontext'] as DumpMode | undefined;
   if (!shouldDumpSDKContext(dumpMode, false)) {
     return { dumpMode };
   }
-  const transportActive = deps.isWebSocketTransportActive?.() ?? false;
+  // A stateless rebuild only exists to be sent over HTTP (the WebSocket
+  // fallback path), so it must be dumped with HTTP transport metadata even
+  // while the WebSocket transport is still the active choice for fresh
+  // requests (#3159).
+  const transportActive =
+    !sentOverHttp && (deps.isWebSocketTransportActive?.() ?? false);
   let dumpMetadata: RequestDumpMetadata;
   let baseURLForDump: string;
   try {
@@ -917,7 +925,11 @@ async function dumpFinalizedRequest(
     );
     // Header observation failed, but the selected transport is still known;
     // keep recording it honestly instead of relabeling the request as HTTP.
+    // An explicitly empty header map means "nothing observed" — passing no
+    // headers here would make the dump synthesize legacy default headers
+    // the transport never sent.
     dumpMetadata = {
+      headers: {},
       transport: transportActive
         ? { type: 'websocket', frameType: 'response.create' }
         : { type: 'http' },
@@ -990,8 +1002,15 @@ async function* streamOverHttpWithoutStatefulness(
     params.rebuildStateless === undefined ||
     params.request.previous_response_id === undefined
   ) {
-    await dumpFallbackHttpRequest(params, deps);
-    yield* streamOverHttp(params, deps);
+    // Link later response/error dumps to the HTTP request that was actually
+    // sent, not to the WebSocket attempt that preceded it (#3159).
+    const fallbackBaseId = await dumpFallbackHttpRequest(params, deps);
+    yield* streamOverHttp(
+      fallbackBaseId === undefined
+        ? params
+        : { ...params, dumpBaseId: fallbackBaseId },
+      deps,
+    );
     return;
   }
   deps.logger.debug(
@@ -999,7 +1018,8 @@ async function* streamOverHttpWithoutStatefulness(
       'Codex WebSocket fallback: rebuilding the request without previous_response_id for HTTP.',
   );
   const stateless = await params.rebuildStateless();
-  await dumpFallbackHttpRequest(stateless, deps);
+  // The rebuild already dumped itself as an HTTP request at the seam
+  // (with its base id threaded through), so no second dump here.
   yield* streamOverHttp(stateless, deps);
 }
 

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -70,9 +70,7 @@ import {
   type RequestDumpMetadata,
   bestEffortDump,
 } from '../utils/dumpSDKContext.js';
-import {
-  buildResponsesHeaders,
-} from './openAIResponsesHttpStream.js';
+import { buildResponsesHeaders } from './openAIResponsesHttpStream.js';
 import type { DumpMode } from '../utils/dumpContext.js';
 
 /**

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -67,8 +67,12 @@ import {
 import {
   shouldDumpSDKContext,
   dumpSDKRequestContext,
+  type RequestDumpMetadata,
   bestEffortDump,
 } from '../utils/dumpSDKContext.js';
+import {
+  buildResponsesHeaders,
+} from './openAIResponsesHttpStream.js';
 import type { DumpMode } from '../utils/dumpContext.js';
 
 /**
@@ -232,6 +236,7 @@ export async function* executeOpenAIResponsesRequest(
     requestContext,
     invocationEphemerals,
     deps,
+    options,
   );
 
   const streamParams: StreamResponsesParams = {
@@ -325,6 +330,7 @@ async function* retryWithoutStatefulness(
     recoveryContext,
     invocationEphemerals,
     deps,
+    options,
   );
   // Note: if both the initial and the recovery attempt fall back from the
   // WebSocket, `onWebSocketFallback` fires twice for a single turn. That is
@@ -835,6 +841,15 @@ function applyPromptCaching(
   if (!isCodex) request.prompt_cache_retention = '24h';
 }
 
+/**
+ * Convert an https/http base URL to its WebSocket scheme for the dump so the
+ * recorded URL reveals the WebSocket transport even when the WebSocket handshake
+ * itself does not surface a URL (#3159).
+ */
+function toWebSocketDumpURL(httpsURL: string): string {
+  return httpsURL.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
+}
+
 interface DumpFinalizedResult {
   baseId?: string;
   dumpMode?: DumpMode;
@@ -843,6 +858,9 @@ interface DumpFinalizedResult {
 /**
  * Dumps the finalized Responses request at the common pre-transport seam when
  * context dumping is enabled, matching OpenAI Chat and Anthropic parity.
+ * Records the REAL headers the transport will send (credentials redacted on
+ * write) and a transport discriminator so WebSocket dumps are distinguishable
+ * from HTTP POSTs (issue #3159).
  * Best-effort: failures are logged and never block the request.
  * Returns the dump base id and resolved mode so the transport can write a
  * linked error-response dump on failure (issue #3140).
@@ -851,11 +869,43 @@ async function dumpFinalizedRequest(
   requestContext: RequestContext,
   invocationEphemerals: Record<string, unknown>,
   deps: ResponsesExecutorDeps,
+  options?: NormalizedGenerateChatOptions,
 ): Promise<DumpFinalizedResult> {
   const dumpMode = invocationEphemerals['dumpcontext'] as DumpMode | undefined;
   if (!shouldDumpSDKContext(dumpMode, false)) {
     return { dumpMode };
   }
+  const transportActive = deps.isWebSocketTransportActive?.() ?? false;
+  const metadata: RequestDumpMetadata =
+    transportActive && options !== undefined
+      ? {
+          headers: await buildWebSocketHandshakeHeaders(
+            {
+              ...requestContext,
+              normalizedOptions: options,
+              maxStreamingAttempts: 1,
+              streamRetryInitialDelayMs: 0,
+            },
+            deps,
+          ),
+          transport: { type: 'websocket', frameType: 'response.create' },
+        }
+      : {
+          headers: await buildResponsesHeaders(
+            requestContext.apiKey,
+            requestContext.isCodex
+              ? 'application/json'
+              : 'application/json; charset=utf-8',
+            requestContext.isCodex,
+            options ?? requestContext.request,
+            deps,
+          ),
+          transport: { type: 'http' },
+        };
+  const baseURLForDump =
+    transportActive && options !== undefined
+      ? toWebSocketDumpURL(requestContext.baseURL)
+      : requestContext.baseURL;
   const result = await bestEffortDump(
     'request',
     deps.providerName,
@@ -864,7 +914,8 @@ async function dumpFinalizedRequest(
         deps.providerName,
         '/responses',
         requestContext.request,
-        requestContext.baseURL,
+        baseURLForDump,
+        metadata,
       ),
     deps.logger,
   );

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -868,43 +868,53 @@ async function dumpFinalizedRequest(
   requestContext: RequestContext,
   invocationEphemerals: Record<string, unknown>,
   deps: ResponsesExecutorDeps,
-  options?: NormalizedGenerateChatOptions,
+  options: NormalizedGenerateChatOptions,
 ): Promise<DumpFinalizedResult> {
   const dumpMode = invocationEphemerals['dumpcontext'] as DumpMode | undefined;
   if (!shouldDumpSDKContext(dumpMode, false)) {
     return { dumpMode };
   }
   const transportActive = deps.isWebSocketTransportActive?.() ?? false;
-  const metadata: RequestDumpMetadata =
-    transportActive && options !== undefined
-      ? {
-          headers: await buildWebSocketHandshakeHeaders(
-            {
-              ...requestContext,
-              normalizedOptions: options,
-              maxStreamingAttempts: 1,
-              streamRetryInitialDelayMs: 0,
-            },
-            deps,
-          ),
-          transport: { type: 'websocket', frameType: 'response.create' },
-        }
-      : {
-          headers: await buildResponsesHeaders(
-            requestContext.apiKey,
-            requestContext.isCodex
-              ? 'application/json'
-              : 'application/json; charset=utf-8',
-            requestContext.isCodex,
-            options ?? requestContext.request,
-            deps,
-          ),
-          transport: { type: 'http' },
-        };
-  const baseURLForDump =
-    transportActive && options !== undefined
-      ? toWebSocketDumpURL(requestContext.baseURL)
-      : requestContext.baseURL;
+  let dumpMetadata: RequestDumpMetadata;
+  let baseURLForDump: string;
+  try {
+    if (transportActive) {
+      dumpMetadata = {
+        headers: await buildWebSocketHandshakeHeaders(
+          {
+            ...requestContext,
+            normalizedOptions: options,
+            maxStreamingAttempts: 1,
+            streamRetryInitialDelayMs: 0,
+          },
+          deps,
+        ),
+        transport: { type: 'websocket', frameType: 'response.create' },
+      };
+      baseURLForDump = toWebSocketDumpURL(requestContext.baseURL);
+    } else {
+      dumpMetadata = {
+        headers: await buildResponsesHeaders(
+          requestContext.apiKey,
+          requestContext.isCodex
+            ? 'application/json'
+            : 'application/json; charset=utf-8',
+          requestContext.isCodex,
+          options,
+          deps,
+        ),
+        transport: { type: 'http' },
+      };
+      baseURLForDump = requestContext.baseURL;
+    }
+  } catch (error) {
+    deps.logger.debug(
+      () =>
+        `Best-effort dump metadata failed for ${deps.providerName}: ${String(error)}`,
+    );
+    dumpMetadata = { transport: { type: 'http' } };
+    baseURLForDump = requestContext.baseURL;
+  }
   const result = await bestEffortDump(
     'request',
     deps.providerName,
@@ -914,7 +924,7 @@ async function dumpFinalizedRequest(
         '/responses',
         requestContext.request,
         baseURLForDump,
-        metadata,
+        dumpMetadata,
       ),
     deps.logger,
   );

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -71,7 +71,7 @@ import {
   bestEffortDump,
 } from '../utils/dumpSDKContext.js';
 import {
-  buildResponsesHeaders,
+  buildHttpDumpMetadata,
   dumpFallbackHttpRequest,
 } from './openAIResponsesHttpStream.js';
 import type { DumpMode } from '../utils/dumpContext.js';
@@ -904,18 +904,14 @@ async function dumpFinalizedRequest(
       };
       baseURLForDump = toWebSocketDumpURL(requestContext.baseURL);
     } else {
-      dumpMetadata = {
-        headers: await buildResponsesHeaders(
-          requestContext.apiKey,
-          requestContext.isCodex
-            ? 'application/json'
-            : 'application/json; charset=utf-8',
-          requestContext.isCodex,
-          options,
-          deps,
-        ),
-        transport: { type: 'http' },
-      };
+      dumpMetadata = await buildHttpDumpMetadata(
+        {
+          apiKey: requestContext.apiKey,
+          isCodex: requestContext.isCodex,
+          normalizedOptions: options,
+        },
+        deps,
+      );
       baseURLForDump = requestContext.baseURL;
     }
   } catch (error) {

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -892,12 +892,7 @@ async function dumpFinalizedRequest(
     if (transportActive) {
       dumpMetadata = {
         headers: await buildWebSocketHandshakeHeaders(
-          {
-            ...requestContext,
-            normalizedOptions: options,
-            maxStreamingAttempts: 1,
-            streamRetryInitialDelayMs: 0,
-          },
+          { apiKey: requestContext.apiKey, normalizedOptions: options },
           deps,
         ),
         transport: { type: 'websocket', frameType: 'response.create' },
@@ -1020,7 +1015,7 @@ async function* streamOverHttpWithoutStatefulness(
 }
 
 async function buildWebSocketHandshakeHeaders(
-  params: StreamResponsesParams,
+  params: Pick<StreamResponsesParams, 'apiKey' | 'normalizedOptions'>,
   deps: ResponsesExecutorDeps,
 ): Promise<Record<string, string>> {
   const headers: Record<string, string> = {

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -380,6 +380,7 @@ async function buildStatelessTurn(
     context,
     invocationEphemerals,
     deps,
+    options,
   );
   return buildStreamParams(
     context,

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -45,10 +45,7 @@ import {
   bestEffortDump,
   type RequestDumpMetadata,
 } from '../utils/dumpSDKContext.js';
-import {
-  redactSensitiveHeaders,
-  type DumpMode,
-} from '../utils/dumpContext.js';
+import { redactSensitiveHeaders, type DumpMode } from '../utils/dumpContext.js';
 import type { ResponsesExecutorDeps } from './openAIResponsesExecutor.js';
 import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
 

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -43,6 +43,7 @@ import {
   dumpSDKResponseContext,
   dumpSDKErrorRequestResponse,
   bestEffortDump,
+  type RequestDumpMetadata,
 } from '../utils/dumpSDKContext.js';
 import { redactSensitiveHeaders, type DumpMode } from '../utils/dumpContext.js';
 import type { ResponsesExecutorDeps } from './openAIResponsesExecutor.js';
@@ -88,13 +89,41 @@ interface FetchStreamParams {
   onStreamLiveness?: NormalizedGenerateChatOptions['onStreamLiveness'];
 }
 
+function resolveResponsesContentType(params: { isCodex: boolean }): string {
+  return params.isCodex
+    ? 'application/json'
+    : 'application/json; charset=utf-8';
+}
+
+/**
+ * HTTP dump metadata shared by the pre-transport seam dump and the
+ * WebSocket-fallback dump (#3159): both record the same physical HTTP send
+ * shape, so both call sites must build headers identically.
+ */
+export async function buildHttpDumpMetadata(
+  params: Pick<
+    StreamResponsesParams,
+    'apiKey' | 'isCodex' | 'normalizedOptions'
+  >,
+  deps: ResponsesExecutorDeps,
+): Promise<RequestDumpMetadata> {
+  return {
+    headers: await buildResponsesHeaders(
+      params.apiKey,
+      resolveResponsesContentType(params),
+      params.isCodex,
+      params.normalizedOptions,
+      deps,
+    ),
+    transport: { type: 'http' },
+  };
+}
+
 export async function* streamOverHttp(
   params: StreamResponsesParams,
   deps: ResponsesExecutorDeps,
 ): AsyncIterableIterator<IContent> {
-  const contentType = params.isCodex
-    ? 'application/json'
-    : 'application/json; charset=utf-8';
+  const contentType = resolveResponsesContentType(params);
   const bodyBlob = new Blob([JSON.stringify(params.request)], {
     type: contentType,
   });
@@ -410,18 +439,7 @@ export async function dumpFallbackHttpRequest(
       '/responses',
       params.request,
       params.baseURL,
-      {
-        headers: await buildResponsesHeaders(
-          params.apiKey,
-          params.isCodex
-            ? 'application/json'
-            : 'application/json; charset=utf-8',
-          params.isCodex,
-          params.normalizedOptions,
-          deps,
-        ),
-        transport: { type: 'http' },
-      },
+      await buildHttpDumpMetadata(params, deps),
     ),
   );
   return result?.baseId;

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -39,14 +39,15 @@ import { tryConsumeTransportAttempt } from '../transportAttemptBudget.js';
 import { getDelayDuration, hasRetryAfterHeader } from '../retryDelayPolicy.js';
 import {
   shouldDumpSDKContext,
+  dumpSDKRequestContext,
   dumpSDKResponseContext,
   dumpSDKErrorRequestResponse,
   bestEffortDump,
+  type RequestDumpMetadata,
 } from '../utils/dumpSDKContext.js';
 import {
   redactSensitiveHeaders,
   type DumpMode,
-  type RequestDumpMetadata,
 } from '../utils/dumpContext.js';
 import type { ResponsesExecutorDeps } from './openAIResponsesExecutor.js';
 import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -118,7 +118,7 @@ export async function* streamOverHttp(
       deps,
     );
   } catch (error) {
-    await dumpErrorOnFailure(error, params, deps);
+    await dumpErrorOnFailure(error, params, deps, headers);
     throw error;
   }
 }
@@ -360,6 +360,7 @@ async function dumpErrorOnFailure(
   error: unknown,
   params: StreamResponsesParams,
   deps: ResponsesExecutorDeps,
+  headers: Record<string, string>,
 ): Promise<void> {
   // A user cancellation is not a request failure; dumping it would write a
   // full-prompt request file on every abort without diagnostic value.
@@ -384,7 +385,7 @@ async function dumpErrorOnFailure(
       params.baseURL,
       dumpSDKRequestContext,
       dumpSDKResponseContext,
-      { headers: params.headers, transport: { type: 'http' } },
+      { headers, transport: { type: 'http' } },
     );
   });
 }

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -67,7 +67,6 @@ export interface StreamResponsesParams {
   request: OpenAIResponsesRequest;
   includeThinkingInResponse: boolean;
   responsesStored: boolean;
-  headers?: Record<string, string>;
   abortSignal?: AbortSignal;
   maxStreamingAttempts: number;
   streamRetryInitialDelayMs: number;
@@ -388,4 +387,41 @@ async function dumpErrorOnFailure(
       { headers, transport: { type: 'http' } },
     );
   });
+}
+
+/**
+ * Records the physical HTTP send when the WebSocket transport falls back
+ * mid-turn (#3159). The pre-transport dump already recorded the WebSocket
+ * attempt; this best-effort dump makes the fallback visible with the real
+ * HTTP headers and the body actually carried (the stateless rebuild when
+ * one was needed). Gated to success-dump mode: error mode already writes an
+ * honest HTTP error dump via dumpErrorOnFailure.
+ */
+export async function dumpFallbackHttpRequest(
+  params: StreamResponsesParams,
+  deps: ResponsesExecutorDeps,
+): Promise<void> {
+  if (!shouldDumpSDKContext(params.dumpMode, false)) {
+    return;
+  }
+  await bestEffortDump('request', deps.providerName, async () =>
+    dumpSDKRequestContext(
+      deps.providerName,
+      '/responses',
+      params.request,
+      params.baseURL,
+      {
+        headers: await buildResponsesHeaders(
+          params.apiKey,
+          params.isCodex
+            ? 'application/json'
+            : 'application/json; charset=utf-8',
+          params.isCodex,
+          params.normalizedOptions,
+          deps,
+        ),
+        transport: { type: 'http' },
+      },
+    ),
+  );
 }

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -43,7 +43,11 @@ import {
   dumpSDKErrorRequestResponse,
   bestEffortDump,
 } from '../utils/dumpSDKContext.js';
-import { redactSensitiveHeaders, type DumpMode } from '../utils/dumpContext.js';
+import {
+  redactSensitiveHeaders,
+  type DumpMode,
+  type RequestDumpMetadata,
+} from '../utils/dumpContext.js';
 import type { ResponsesExecutorDeps } from './openAIResponsesExecutor.js';
 import type { OpenAIResponsesRequest } from './OpenAIResponsesTypes.js';
 
@@ -376,12 +380,29 @@ async function dumpErrorOnFailure(
         true,
       );
     } else {
+      const contentType = params.isCodex
+        ? 'application/json'
+        : 'application/json; charset=utf-8';
+      const headers = await buildResponsesHeaders(
+        params.apiKey,
+        contentType,
+        params.isCodex,
+        params.normalizedOptions,
+        deps,
+      );
+      const metadata: RequestDumpMetadata = {
+        headers,
+        transport: { type: 'http' },
+      };
       await dumpSDKErrorRequestResponse(
         deps.providerName,
         '/responses',
         params.request,
         payload,
         params.baseURL,
+        dumpSDKRequestContext,
+        dumpSDKResponseContext,
+        metadata,
       );
     }
   });

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -43,7 +43,6 @@ import {
   dumpSDKResponseContext,
   dumpSDKErrorRequestResponse,
   bestEffortDump,
-  type RequestDumpMetadata,
 } from '../utils/dumpSDKContext.js';
 import { redactSensitiveHeaders, type DumpMode } from '../utils/dumpContext.js';
 import type { ResponsesExecutorDeps } from './openAIResponsesExecutor.js';
@@ -68,6 +67,7 @@ export interface StreamResponsesParams {
   request: OpenAIResponsesRequest;
   includeThinkingInResponse: boolean;
   responsesStored: boolean;
+  headers?: Record<string, string>;
   abortSignal?: AbortSignal;
   maxStreamingAttempts: number;
   streamRetryInitialDelayMs: number;
@@ -105,9 +105,6 @@ export async function* streamOverHttp(
     params.isCodex,
     params.normalizedOptions,
     deps,
-  );
-  deps.logger.debug(
-    () => `Request body keys: ${JSON.stringify(Object.keys(params.request))}`,
   );
   try {
     yield* fetchStreamWithRetries(
@@ -377,31 +374,17 @@ async function dumpErrorOnFailure(
         payload,
         true,
       );
-    } else {
-      const contentType = params.isCodex
-        ? 'application/json'
-        : 'application/json; charset=utf-8';
-      const headers = await buildResponsesHeaders(
-        params.apiKey,
-        contentType,
-        params.isCodex,
-        params.normalizedOptions,
-        deps,
-      );
-      const metadata: RequestDumpMetadata = {
-        headers,
-        transport: { type: 'http' },
-      };
-      await dumpSDKErrorRequestResponse(
-        deps.providerName,
-        '/responses',
-        params.request,
-        payload,
-        params.baseURL,
-        dumpSDKRequestContext,
-        dumpSDKResponseContext,
-        metadata,
-      );
+      return;
     }
+    await dumpSDKErrorRequestResponse(
+      deps.providerName,
+      '/responses',
+      params.request,
+      payload,
+      params.baseURL,
+      dumpSDKRequestContext,
+      dumpSDKResponseContext,
+      { headers: params.headers, transport: { type: 'http' } },
+    );
   });
 }

--- a/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesHttpStream.ts
@@ -393,18 +393,18 @@ async function dumpErrorOnFailure(
  * Records the physical HTTP send when the WebSocket transport falls back
  * mid-turn (#3159). The pre-transport dump already recorded the WebSocket
  * attempt; this best-effort dump makes the fallback visible with the real
- * HTTP headers and the body actually carried (the stateless rebuild when
- * one was needed). Gated to success-dump mode: error mode already writes an
- * honest HTTP error dump via dumpErrorOnFailure.
+ * HTTP headers and the body actually carried. Gated to success-dump mode:
+ * error mode already writes an honest HTTP error dump via dumpErrorOnFailure.
+ * Returns the dump base id so response/error dumps link to the HTTP request.
  */
 export async function dumpFallbackHttpRequest(
   params: StreamResponsesParams,
   deps: ResponsesExecutorDeps,
-): Promise<void> {
+): Promise<string | undefined> {
   if (!shouldDumpSDKContext(params.dumpMode, false)) {
-    return;
+    return undefined;
   }
-  await bestEffortDump('request', deps.providerName, async () =>
+  const result = await bestEffortDump('request', deps.providerName, async () =>
     dumpSDKRequestContext(
       deps.providerName,
       '/responses',
@@ -424,4 +424,5 @@ export async function dumpFallbackHttpRequest(
       },
     ),
   );
+  return result?.baseId;
 }

--- a/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
@@ -557,6 +557,22 @@ describe('OpenAI executeApiRequest separate request/response dump', () => {
     expect(dumpSDKContextSpy).not.toHaveBeenCalled();
   });
 
+  it('should record the SDK-generated Authorization header name in dump metadata (value redacted on write)', async () => {
+    const client = createMockClient({ id: 'chatcmpl-auth', choices: [] });
+    (client as { apiKey?: string }).apiKey = 'sk-dump3159';
+    const create = client.chat.completions.create as ReturnType<typeof vi.fn>;
+    create.mockResolvedValue({ id: 'chatcmpl-auth', choices: [] });
+    const opts = createBaseOptions({ client, dumpMode: 'on' });
+
+    await executeApiRequest(opts);
+
+    const metadata = dumpSDKRequestContextSpy.mock.calls[0][4] as {
+      headers?: Record<string, string> | undefined;
+    };
+    expect(metadata.headers?.['Authorization']).toBe('Bearer sk-dump3159');
+    void dumpSDKContextSpy;
+  });
+
   it('should not dump on success when mode is error', async () => {
     const opts = createBaseOptions({ dumpMode: 'error' });
     await executeApiRequest(opts);

--- a/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
@@ -384,6 +384,7 @@ describe('OpenAI executeApiRequest separate request/response dump', () => {
       '/chat/completions',
       opts.requestBody,
       'https://api.cerebras.ai/v1',
+      { headers: undefined, transport: { type: 'http' } },
     );
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
   });
@@ -429,6 +430,7 @@ describe('OpenAI executeApiRequest separate request/response dump', () => {
       '/chat/completions',
       opts.requestBody,
       'https://api.cerebras.ai/v1',
+      { headers: undefined, transport: { type: 'http' } },
     );
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledTimes(1);
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(
@@ -481,6 +483,7 @@ describe('OpenAI executeApiRequest separate request/response dump', () => {
       '/chat/completions',
       opts.requestBody,
       'https://api.cerebras.ai/v1',
+      { headers: undefined, transport: { type: 'http' } },
     );
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
   });

--- a/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
@@ -11,8 +11,9 @@ import {
   type ApiExecutionOptions,
 } from './OpenAIApiExecution.js';
 
-function createMockClient(response: unknown) {
+function createMockClient(response: unknown, apiKey?: string) {
   return {
+    apiKey,
     chat: {
       completions: {
         create: vi.fn().mockResolvedValue(response),
@@ -558,19 +559,36 @@ describe('OpenAI executeApiRequest separate request/response dump', () => {
   });
 
   it('should record the SDK-generated Authorization header name in dump metadata (value redacted on write)', async () => {
-    const client = createMockClient({ id: 'chatcmpl-auth', choices: [] });
-    (client as { apiKey?: string }).apiKey = 'sk-dump3159';
-    const create = client.chat.completions.create as ReturnType<typeof vi.fn>;
-    create.mockResolvedValue({ id: 'chatcmpl-auth', choices: [] });
+    const client = createMockClient(
+      { id: 'chatcmpl-auth', choices: [] },
+      'sk-dump3159',
+    );
     const opts = createBaseOptions({ client, dumpMode: 'on' });
 
     await executeApiRequest(opts);
 
-    const metadata = dumpSDKRequestContextSpy.mock.calls[0][4] as {
-      headers?: Record<string, string> | undefined;
-    };
-    expect(metadata.headers?.['Authorization']).toBe('Bearer sk-dump3159');
+    const metadata = dumpSDKRequestContextSpy.mock.calls[0][4];
+    expect(metadata?.headers?.['Authorization']).toBe('Bearer sk-dump3159');
     void dumpSDKContextSpy;
+  });
+
+  it('should keep a caller-supplied Authorization header over the synthesized one (issue #3159)', async () => {
+    const client = createMockClient(
+      { id: 'chatcmpl-auth', choices: [] },
+      'sk-dump3159',
+    );
+    const opts = createBaseOptions({
+      client,
+      dumpMode: 'on',
+      mergedHeaders: { Authorization: 'Bearer caller-token' },
+    });
+
+    await executeApiRequest(opts);
+
+    const metadata = dumpSDKRequestContextSpy.mock.calls[0][4];
+    expect(metadata?.headers).toStrictEqual({
+      Authorization: 'Bearer caller-token',
+    });
   });
 
   it('should not dump on success when mode is error', async () => {

--- a/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
@@ -569,7 +569,6 @@ describe('OpenAI executeApiRequest separate request/response dump', () => {
 
     const metadata = dumpSDKRequestContextSpy.mock.calls[0][4];
     expect(metadata?.headers?.['Authorization']).toBe('Bearer sk-dump3159');
-    void dumpSDKContextSpy;
   });
 
   it('should keep a caller-supplied Authorization header over the synthesized one (issue #3159)', async () => {

--- a/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
@@ -590,6 +590,25 @@ describe('OpenAI executeApiRequest separate request/response dump', () => {
     });
   });
 
+  it('should keep a lowercase caller-supplied authorization header over the synthesized one (issue #3159)', async () => {
+    const client = createMockClient(
+      { id: 'chatcmpl-auth', choices: [] },
+      'sk-dump3159',
+    );
+    const opts = createBaseOptions({
+      client,
+      dumpMode: 'on',
+      mergedHeaders: { authorization: 'Bearer caller-token' },
+    });
+
+    await executeApiRequest(opts);
+
+    const metadata = dumpSDKRequestContextSpy.mock.calls[0][4];
+    expect(metadata?.headers).toStrictEqual({
+      authorization: 'Bearer caller-token',
+    });
+  });
+
   it('should not dump on success when mode is error', async () => {
     const opts = createBaseOptions({ dumpMode: 'error' });
     await executeApiRequest(opts);

--- a/packages/providers/src/openai/OpenAIApiExecution.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.ts
@@ -57,8 +57,10 @@ function chatDumpMetadata(
 ): RequestDumpMetadata {
   // The SDK sends Authorization from the client api key; synthesize the
   // header for the dump unless the caller already supplied one (#3159).
+  // A null/empty key means the SDK sends no Authorization header, so the
+  // dump must not invent one.
   if (
-    apiKey === undefined ||
+    !apiKey ||
     (mergedHeaders !== undefined &&
       hasHeaderName(mergedHeaders, 'Authorization'))
   ) {

--- a/packages/providers/src/openai/OpenAIApiExecution.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.ts
@@ -46,19 +46,28 @@ export interface ApiExecutionOptions {
 /** #3159: the OpenAI SDK sends Authorization from the client api key; record
  * the header NAME in dump metadata (shared redaction replaces the value).
  */
+function hasHeaderName(headers: Record<string, string>, name: string): boolean {
+  const target = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === target);
+}
+
 function chatDumpMetadata(
   mergedHeaders: Record<string, string> | undefined,
   apiKey: string | undefined,
 ): RequestDumpMetadata {
-  if (apiKey === undefined) {
+  // The SDK sends Authorization from the client api key; synthesize the
+  // header for the dump unless the caller already supplied one (#3159).
+  if (
+    apiKey === undefined ||
+    (mergedHeaders !== undefined &&
+      hasHeaderName(mergedHeaders, 'Authorization'))
+  ) {
     return { headers: mergedHeaders, transport: { type: 'http' } };
   }
-  const authorization = `Bearer ${apiKey}`;
-  const headers =
-    mergedHeaders === undefined
-      ? { Authorization: authorization }
-      : { ...mergedHeaders, Authorization: authorization };
-  return { headers, transport: { type: 'http' } };
+  return {
+    headers: { ...mergedHeaders, Authorization: `Bearer ${apiKey}` },
+    transport: { type: 'http' },
+  };
 }
 
 interface ErrorContext {

--- a/packages/providers/src/openai/OpenAIApiExecution.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.ts
@@ -24,6 +24,7 @@ import {
   wrapStreamWithSDKErrorDump,
   bestEffortDump,
   dumpSDKErrorRequestResponse,
+  type RequestDumpMetadata,
 } from '../utils/dumpSDKContext.js';
 import { type DumpMode } from '../utils/dumpContext.js';
 import { type OpenAITool } from './schemaConverter.js';
@@ -42,12 +43,31 @@ export interface ApiExecutionOptions {
   getBaseURL: () => string | undefined;
 }
 
+/** #3159: the OpenAI SDK sends Authorization from the client api key; record
+ * the header NAME in dump metadata (shared redaction replaces the value).
+ */
+function chatDumpMetadata(
+  mergedHeaders: Record<string, string> | undefined,
+  apiKey: string | undefined,
+): RequestDumpMetadata {
+  if (apiKey === undefined) {
+    return { headers: mergedHeaders, transport: { type: 'http' } };
+  }
+  const authorization = `Bearer ${apiKey}`;
+  const headers =
+    mergedHeaders === undefined
+      ? { Authorization: authorization }
+      : { ...mergedHeaders, Authorization: authorization };
+  return { headers, transport: { type: 'http' } };
+}
+
 interface ErrorContext {
   requestBody: OpenAI.Chat.ChatCompletionCreateParams;
   shouldDumpError: boolean;
   requestBaseId: string | undefined;
   baseURL: string | undefined;
   mergedHeaders: Record<string, string> | undefined;
+  apiKey: string | undefined;
   model: string;
   formattedTools: OpenAITool[] | undefined;
   streamingEnabled: boolean;
@@ -87,7 +107,7 @@ async function dumpOpenAIErrorContext(
       resolvedBaseURL ?? 'https://api.openai.com/v1',
       dumpSDKRequestContext,
       dumpSDKResponseContext,
-      { headers: ctx.mergedHeaders ?? undefined, transport: { type: 'http' } },
+      chatDumpMetadata(ctx.mergedHeaders, ctx.apiKey),
     );
   }
 }
@@ -191,7 +211,7 @@ async function executeStreamingRequest(
           '/chat/completions',
           requestBody,
           baseURL ?? 'https://api.openai.com/v1',
-          { headers: mergedHeaders ?? undefined, transport: { type: 'http' } },
+          chatDumpMetadata(mergedHeaders, client.apiKey),
         ),
       opts.logger,
     );
@@ -222,7 +242,7 @@ async function executeStreamingRequest(
         baseURL ?? 'https://api.openai.com/v1',
         dumpSDKRequestContext,
         dumpSDKResponseContext,
-        { headers: mergedHeaders ?? undefined, transport: { type: 'http' } },
+        chatDumpMetadata(mergedHeaders, client.apiKey),
       );
     }
 
@@ -237,6 +257,7 @@ async function executeStreamingRequest(
       requestBaseId,
       baseURL,
       mergedHeaders: opts.mergedHeaders,
+      apiKey: opts.client.apiKey,
       model: opts.model,
       formattedTools: opts.formattedTools,
       streamingEnabled: opts.streamingEnabled,
@@ -282,7 +303,7 @@ async function executeNonStreamingRequest(
           '/chat/completions',
           requestBody,
           baseURL ?? 'https://api.openai.com/v1',
-          { headers: mergedHeaders ?? undefined, transport: { type: 'http' } },
+          chatDumpMetadata(mergedHeaders, client.apiKey),
         ),
       opts.logger,
     );
@@ -325,6 +346,7 @@ async function executeNonStreamingRequest(
       requestBaseId,
       baseURL,
       mergedHeaders: opts.mergedHeaders,
+      apiKey: opts.client.apiKey,
       model: opts.model,
       formattedTools: opts.formattedTools,
       streamingEnabled: opts.streamingEnabled,

--- a/packages/providers/src/openai/OpenAIApiExecution.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.ts
@@ -47,6 +47,7 @@ interface ErrorContext {
   shouldDumpError: boolean;
   requestBaseId: string | undefined;
   baseURL: string | undefined;
+  mergedHeaders: Record<string, string> | undefined;
   model: string;
   formattedTools: OpenAITool[] | undefined;
   streamingEnabled: boolean;
@@ -86,6 +87,7 @@ async function dumpOpenAIErrorContext(
       resolvedBaseURL ?? 'https://api.openai.com/v1',
       dumpSDKRequestContext,
       dumpSDKResponseContext,
+      { headers: ctx.mergedHeaders ?? undefined, transport: { type: 'http' } },
     );
   }
 }
@@ -189,6 +191,7 @@ async function executeStreamingRequest(
           '/chat/completions',
           requestBody,
           baseURL ?? 'https://api.openai.com/v1',
+          { headers: mergedHeaders ?? undefined, transport: { type: 'http' } },
         ),
       opts.logger,
     );
@@ -219,6 +222,7 @@ async function executeStreamingRequest(
         baseURL ?? 'https://api.openai.com/v1',
         dumpSDKRequestContext,
         dumpSDKResponseContext,
+        { headers: mergedHeaders ?? undefined, transport: { type: 'http' } },
       );
     }
 
@@ -232,6 +236,7 @@ async function executeStreamingRequest(
       shouldDumpError,
       requestBaseId,
       baseURL,
+      mergedHeaders: opts.mergedHeaders,
       model: opts.model,
       formattedTools: opts.formattedTools,
       streamingEnabled: opts.streamingEnabled,
@@ -277,6 +282,7 @@ async function executeNonStreamingRequest(
           '/chat/completions',
           requestBody,
           baseURL ?? 'https://api.openai.com/v1',
+          { headers: mergedHeaders ?? undefined, transport: { type: 'http' } },
         ),
       opts.logger,
     );
@@ -318,6 +324,7 @@ async function executeNonStreamingRequest(
       shouldDumpError,
       requestBaseId,
       baseURL,
+      mergedHeaders: opts.mergedHeaders,
       model: opts.model,
       formattedTools: opts.formattedTools,
       streamingEnabled: opts.streamingEnabled,

--- a/packages/providers/src/utils/dumpContext.ts
+++ b/packages/providers/src/utils/dumpContext.ts
@@ -19,6 +19,10 @@ export interface DumpRequest {
   method: string;
   headers?: Record<string, string>;
   body?: unknown;
+  /** How the request was carried. Present only when a caller observed the real
+   * transport (for example the Codex WebSocket) rather than synthesized HTTP
+   * defaults (#3159). */
+  transport?: { type: 'http' } | { type: 'websocket'; frameType: string };
 }
 
 export interface DumpResponse {
@@ -56,6 +60,7 @@ const SENSITIVE_HEADER_NAMES = new Set([
   'api-key',
   'cookie',
   'set-cookie',
+  'chatgpt-account-id',
 ]);
 
 /**

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -45,6 +45,7 @@ describe('dumpSDKContext metadata @issue:3159', () => {
         transport: { type: 'websocket', frameType: 'response.create' },
       },
     );
+    createdFiles.push(result.requestFilename);
 
     const content = await fs.readFile(
       path.join(result.dumpDir, result.requestFilename),
@@ -83,6 +84,7 @@ describe('dumpSDKContext metadata @issue:3159', () => {
       { model: 'gpt-5', input: [] },
       'https://api.openai.com/v1',
     );
+    createdFiles.push(result.requestFilename);
 
     const content = await fs.readFile(
       path.join(result.dumpDir, result.requestFilename),
@@ -117,6 +119,7 @@ describe('dumpSDKContext metadata @issue:3159', () => {
         transport: { type: 'http' },
       },
     );
+    createdFiles.push(`${baseId}-request.json`, `${baseId}-response.json`);
 
     const content = await fs.readFile(
       path.join(dumpDir, `${baseId}-request.json`),

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -59,7 +59,9 @@ describe('dumpSDKContext metadata @issue:3159', () => {
       };
     };
 
-    expect(dump.request.url).toBe('wss://chatgpt.com/backend-api/codex/responses');
+    expect(dump.request.url).toBe(
+      'wss://chatgpt.com/backend-api/codex/responses',
+    );
     expect(dump.request.method).not.toBe('POST');
     expect(dump.request.transport).toStrictEqual({
       type: 'websocket',
@@ -121,7 +123,10 @@ describe('dumpSDKContext metadata @issue:3159', () => {
       'utf-8',
     );
     const dump = JSON.parse(content) as {
-      request: { headers?: Record<string, string>; transport?: { type: string } };
+      request: {
+        headers?: Record<string, string>;
+        transport?: { type: string };
+      };
     };
 
     expect(dump.request.headers).toStrictEqual({

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -222,6 +222,24 @@ describe('dumpSDKContext', () => {
 
     expect(dump.request.url).toBe('https://ollama.com/v1/chat/completions');
   });
+
+  it('should tolerate an empty metadata headers map (no crash, synthesized defaults survive)', async () => {
+    const result = await dumpSDKRequestContext(
+      'openai',
+      '/chat/completions',
+      { model: 'test-model', messages: [] },
+      'https://api.openai.com/v1',
+      { headers: { authorization: 'Bearer sk-abc' } },
+    );
+    createdFiles.push(result.requestFilename);
+    const content = await fs.readFile(
+      path.join(result.dumpDir, result.requestFilename),
+      'utf-8',
+    );
+    expect(content).toContain('authorization');
+    expect(content).toContain('[REDACTED]');
+    expect(content).not.toContain('sk-abc');
+  });
 });
 
 describe('dumpSDKErrorRequestResponse', () => {

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -144,10 +144,14 @@ describe('dumpSDKContext metadata @issue:3159', () => {
   });
 
   it('forwards metadata to the real request dumper via dumpSDKErrorRequestResponse', async () => {
+    // Distinctive provider token: filenames embed it, so the created-file
+    // diff below stays deterministic even if other dumps land in the shared
+    // global cache dir while this test runs.
+    const provider = 'dumpsdk3159';
     const before = await fs.readdir(dumpDir).catch(() => [] as string[]);
 
     await dumpSDKErrorRequestResponse(
-      'openai',
+      provider,
       '/chat/completions',
       { model: 'x' },
       { error: 'boom' },
@@ -161,7 +165,7 @@ describe('dumpSDKContext metadata @issue:3159', () => {
     );
 
     const created = (await fs.readdir(dumpDir)).filter(
-      (file) => !before.includes(file),
+      (file) => !before.includes(file) && file.includes(`-${provider}-`),
     );
     createdFiles.push(...created);
     expect(created).toHaveLength(2);
@@ -196,6 +200,9 @@ describe('dumpSDKContext metadata @issue:3159', () => {
   });
 
   it('writes the metadata-bearing request dump when a wrapped stream fails mid-iteration', async () => {
+    // Distinctive provider token keeps the created-file diff deterministic
+    // (see the dumpSDKErrorRequestResponse test above).
+    const provider = 'dumpsdk3159';
     const before = await fs.readdir(dumpDir).catch(() => [] as string[]);
     const stream = (async function* () {
       yield { text: 'partial' };
@@ -204,7 +211,7 @@ describe('dumpSDKContext metadata @issue:3159', () => {
 
     const wrapped = wrapStreamWithSDKErrorDump(
       stream,
-      'openai',
+      provider,
       '/chat/completions',
       { model: 'x' },
       'https://api.openai.com/v1',
@@ -225,7 +232,7 @@ describe('dumpSDKContext metadata @issue:3159', () => {
     ).rejects.toThrow('stream failed');
 
     const created = (await fs.readdir(dumpDir)).filter(
-      (file) => !before.includes(file),
+      (file) => !before.includes(file) && file.includes(`-${provider}-`),
     );
     createdFiles.push(...created);
     expect(created).toHaveLength(2);

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -12,10 +12,10 @@ import { Storage } from '@vybestack/llxprt-code-storage';
 import * as dumpSDKContextModule from './dumpSDKContext.js';
 import {
   dumpSDKContext,
+  dumpSDKErrorRequestResponse,
   dumpSDKRequestContext,
   wrapStreamWithDump,
   wrapStreamWithSDKErrorDump,
-  type RequestDumpMetadata,
 } from './dumpSDKContext.js';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -143,40 +143,102 @@ describe('dumpSDKContext metadata @issue:3159', () => {
     expect(dump.transport).toStrictEqual({ type: 'http' });
   });
 
-  it('forwards metadata to dumpSDKRequestContext via dumpSDKErrorRequestResponse', async () => {
-    const dumpSDKRequestContextSpy = vi
-      .spyOn(dumpSDKContextModule, 'dumpSDKRequestContext')
-      .mockResolvedValue({
-        baseId: 'b',
-        requestFilename: 'b-request.json',
-        dumpDir: '/tmp',
-      });
-    const dumpSDKResponseContextSpy = vi
-      .spyOn(dumpSDKContextModule, 'dumpSDKResponseContext')
-      .mockResolvedValue('b-response.json');
-    const metadata: RequestDumpMetadata = {
-      headers: { Authorization: 'x' },
-      transport: { type: 'http' },
-    };
+  it('forwards metadata to the real request dumper via dumpSDKErrorRequestResponse', async () => {
+    const before = await fs.readdir(dumpDir).catch(() => [] as string[]);
 
-    await dumpSDKContextModule.dumpSDKErrorRequestResponse(
+    await dumpSDKErrorRequestResponse(
       'openai',
       '/chat/completions',
       { model: 'x' },
       { error: 'boom' },
       'https://api.openai.com/v1',
-      dumpSDKRequestContextSpy,
-      dumpSDKResponseContextSpy,
-      metadata,
+      undefined,
+      undefined,
+      {
+        headers: { Authorization: 'Bearer secret', 'X-Debug': '1' },
+        transport: { type: 'http' },
+      },
     );
 
-    expect(dumpSDKRequestContextSpy).toHaveBeenCalledWith(
+    const created = (await fs.readdir(dumpDir)).filter(
+      (file) => !before.includes(file),
+    );
+    createdFiles.push(...created);
+    expect(created).toHaveLength(2);
+
+    const requestName = created.find((file) => file.endsWith('-request.json'));
+    const responseName = created.find((file) =>
+      file.endsWith('-response.json'),
+    );
+    if (requestName === undefined || responseName === undefined) {
+      throw new Error('expected both request and error-response dumps');
+    }
+    expect(responseName).toBe(
+      requestName.replace('-request.json', '-response.json'),
+    );
+
+    const dump = parseDumpedRequest(
+      await fs.readFile(path.join(dumpDir, requestName), 'utf-8'),
+    );
+    expect(dump.url).toBe('https://api.openai.com/v1/chat/completions');
+    expect(dump.method).toBe('POST');
+    expect(dump.transport).toStrictEqual({ type: 'http' });
+    expect(dump.headers).toStrictEqual({
+      Authorization: '[REDACTED]',
+      'X-Debug': '1',
+    });
+
+    const responseContent = await fs.readFile(
+      path.join(dumpDir, responseName),
+      'utf-8',
+    );
+    expect(responseContent).toContain('boom');
+  });
+
+  it('writes the metadata-bearing request dump when a wrapped stream fails mid-iteration', async () => {
+    const before = await fs.readdir(dumpDir).catch(() => [] as string[]);
+    const stream = (async function* () {
+      yield { text: 'partial' };
+      throw new Error('stream failed');
+    })();
+
+    const wrapped = wrapStreamWithSDKErrorDump(
+      stream,
       'openai',
       '/chat/completions',
       { model: 'x' },
       'https://api.openai.com/v1',
-      metadata,
+      undefined,
+      undefined,
+      {
+        headers: { Authorization: 'Bearer secret' },
+        transport: { type: 'http' },
+      },
     );
+
+    await expect(
+      (async () => {
+        for await (const _chunk of wrapped) {
+          void _chunk;
+        }
+      })(),
+    ).rejects.toThrow('stream failed');
+
+    const created = (await fs.readdir(dumpDir)).filter(
+      (file) => !before.includes(file),
+    );
+    createdFiles.push(...created);
+    expect(created).toHaveLength(2);
+
+    const requestName = created.find((file) => file.endsWith('-request.json'));
+    if (requestName === undefined) {
+      throw new Error('expected the failure request dump');
+    }
+    const dump = parseDumpedRequest(
+      await fs.readFile(path.join(dumpDir, requestName), 'utf-8'),
+    );
+    expect(dump.headers).toStrictEqual({ Authorization: '[REDACTED]' });
+    expect(dump.transport).toStrictEqual({ type: 'http' });
   });
 });
 

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -15,7 +15,31 @@ import {
   dumpSDKRequestContext,
   wrapStreamWithDump,
   wrapStreamWithSDKErrorDump,
+  type RequestDumpMetadata,
 } from './dumpSDKContext.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Parse a written request dump file without type assertions (RULES.md). */
+function parseDumpedRequest(content: string): {
+  url: unknown;
+  method: unknown;
+  transport: unknown;
+  headers: unknown;
+} {
+  const parsed: unknown = JSON.parse(content);
+  if (!isRecord(parsed) || !isRecord(parsed.request)) {
+    throw new Error('dump envelope missing request object');
+  }
+  return {
+    url: parsed.request.url,
+    method: parsed.request.method,
+    transport: parsed.request.transport,
+    headers: parsed.request.headers,
+  };
+}
 
 describe('dumpSDKContext metadata @issue:3159', () => {
   const dumpDir = path.join(Storage.getGlobalCacheDir(), 'dumps');
@@ -51,24 +75,15 @@ describe('dumpSDKContext metadata @issue:3159', () => {
       path.join(result.dumpDir, result.requestFilename),
       'utf-8',
     );
-    const dump = JSON.parse(content) as {
-      request: {
-        url: string;
-        method: string;
-        transport?: { type: string; frameType?: string };
-        headers?: Record<string, string>;
-      };
-    };
+    const dump = parseDumpedRequest(content);
 
-    expect(dump.request.url).toBe(
-      'wss://chatgpt.com/backend-api/codex/responses',
-    );
-    expect(dump.request.method).not.toBe('POST');
-    expect(dump.request.transport).toStrictEqual({
+    expect(dump.url).toBe('wss://chatgpt.com/backend-api/codex/responses');
+    expect(dump.method).toBe('SEND');
+    expect(dump.transport).toStrictEqual({
       type: 'websocket',
       frameType: 'response.create',
     });
-    expect(dump.request.headers).toStrictEqual({
+    expect(dump.headers).toStrictEqual({
       Authorization: '[REDACTED]',
       'ChatGPT-Account-ID': '[REDACTED]',
       'OpenAI-Beta': 'responses_websockets=2026-02-06',
@@ -90,17 +105,11 @@ describe('dumpSDKContext metadata @issue:3159', () => {
       path.join(result.dumpDir, result.requestFilename),
       'utf-8',
     );
-    const dump = JSON.parse(content) as {
-      request: {
-        method: string;
-        transport?: unknown;
-        headers?: Record<string, string>;
-      };
-    };
+    const dump = parseDumpedRequest(content);
 
-    expect(dump.request.method).toBe('POST');
-    expect(dump.request.transport).toBeUndefined();
-    expect(dump.request.headers).toStrictEqual({
+    expect(dump.method).toBe('POST');
+    expect(dump.transport).toBeUndefined();
+    expect(dump.headers).toStrictEqual({
       'Content-Type': 'application/json',
       'User-Agent': 'llxprt-code',
     });
@@ -125,18 +134,13 @@ describe('dumpSDKContext metadata @issue:3159', () => {
       path.join(dumpDir, `${baseId}-request.json`),
       'utf-8',
     );
-    const dump = JSON.parse(content) as {
-      request: {
-        headers?: Record<string, string>;
-        transport?: { type: string };
-      };
-    };
+    const dump = parseDumpedRequest(content);
 
-    expect(dump.request.headers).toStrictEqual({
+    expect(dump.headers).toStrictEqual({
       Authorization: '[REDACTED]',
       'X-Debug': '1',
     });
-    expect(dump.request.transport).toStrictEqual({ type: 'http' });
+    expect(dump.transport).toStrictEqual({ type: 'http' });
   });
 
   it('forwards metadata to dumpSDKRequestContext via dumpSDKErrorRequestResponse', async () => {
@@ -150,9 +154,9 @@ describe('dumpSDKContext metadata @issue:3159', () => {
     const dumpSDKResponseContextSpy = vi
       .spyOn(dumpSDKContextModule, 'dumpSDKResponseContext')
       .mockResolvedValue('b-response.json');
-    const metadata = {
+    const metadata: RequestDumpMetadata = {
       headers: { Authorization: 'x' },
-      transport: { type: 'http' as const },
+      transport: { type: 'http' },
     };
 
     await dumpSDKContextModule.dumpSDKErrorRequestResponse(
@@ -218,12 +222,12 @@ describe('dumpSDKContext', () => {
       path.join(result.dumpDir, result.requestFilename),
       'utf-8',
     );
-    const dump = JSON.parse(content) as { request: { url: string } };
+    const dump = parseDumpedRequest(content);
 
-    expect(dump.request.url).toBe('https://ollama.com/v1/chat/completions');
+    expect(dump.url).toBe('https://ollama.com/v1/chat/completions');
   });
 
-  it('should tolerate an empty metadata headers map (no crash, synthesized defaults survive)', async () => {
+  it('should redact a lowercase authorization header value at write time', async () => {
     const result = await dumpSDKRequestContext(
       'openai',
       '/chat/completions',

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -46,10 +46,16 @@ describe('dumpSDKContext metadata @issue:3159', () => {
   const createdFiles: string[] = [];
 
   afterEach(async () => {
-    for (const file of createdFiles.splice(0)) {
-      await fs.rm(path.join(dumpDir, file), { force: true });
-    }
+    // Restore mocks first so a cleanup failure cannot leave spies installed
+    // for the next test; dump file removal stays best-effort.
     vi.restoreAllMocks();
+    for (const file of createdFiles.splice(0)) {
+      try {
+        await fs.rm(path.join(dumpDir, file), { force: true });
+      } catch {
+        // A leftover dump file must not fail the test run.
+      }
+    }
   });
 
   it('records real headers with credential values redacted and WebSocket transport', async () => {

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -17,6 +17,157 @@ import {
   wrapStreamWithSDKErrorDump,
 } from './dumpSDKContext.js';
 
+describe('dumpSDKContext metadata @issue:3159', () => {
+  const dumpDir = path.join(Storage.getGlobalCacheDir(), 'dumps');
+  const createdFiles: string[] = [];
+
+  afterEach(async () => {
+    for (const file of createdFiles.splice(0)) {
+      await fs.rm(path.join(dumpDir, file), { force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('records real headers with credential values redacted and WebSocket transport', async () => {
+    const result = await dumpSDKRequestContext(
+      'openai',
+      '/responses',
+      { model: 'gpt-5', input: [] },
+      'wss://chatgpt.com/backend-api/codex',
+      {
+        headers: {
+          Authorization: 'Bearer sk-secret',
+          'ChatGPT-Account-ID': 'acct-secret',
+          'OpenAI-Beta': 'responses_websockets=2026-02-06',
+          session_id: 'session-123',
+          'X-Debug': 'yes',
+        },
+        transport: { type: 'websocket', frameType: 'response.create' },
+      },
+    );
+
+    const content = await fs.readFile(
+      path.join(result.dumpDir, result.requestFilename),
+      'utf-8',
+    );
+    const dump = JSON.parse(content) as {
+      request: {
+        url: string;
+        method: string;
+        transport?: { type: string; frameType?: string };
+        headers?: Record<string, string>;
+      };
+    };
+
+    expect(dump.request.url).toBe('wss://chatgpt.com/backend-api/codex/responses');
+    expect(dump.request.method).not.toBe('POST');
+    expect(dump.request.transport).toStrictEqual({
+      type: 'websocket',
+      frameType: 'response.create',
+    });
+    expect(dump.request.headers).toStrictEqual({
+      Authorization: '[REDACTED]',
+      'ChatGPT-Account-ID': '[REDACTED]',
+      'OpenAI-Beta': 'responses_websockets=2026-02-06',
+      session_id: 'session-123',
+      'X-Debug': 'yes',
+    });
+  });
+
+  it('uses synthesized defaults and no transport when metadata omitted', async () => {
+    const result = await dumpSDKRequestContext(
+      'openai',
+      '/responses',
+      { model: 'gpt-5', input: [] },
+      'https://api.openai.com/v1',
+    );
+
+    const content = await fs.readFile(
+      path.join(result.dumpDir, result.requestFilename),
+      'utf-8',
+    );
+    const dump = JSON.parse(content) as {
+      request: {
+        method: string;
+        transport?: unknown;
+        headers?: Record<string, string>;
+      };
+    };
+
+    expect(dump.request.method).toBe('POST');
+    expect(dump.request.transport).toBeUndefined();
+    expect(dump.request.headers).toStrictEqual({
+      'Content-Type': 'application/json',
+      'User-Agent': 'llxprt-code',
+    });
+  });
+
+  it('threads metadata through dumpSDKContext to the written request file', async () => {
+    const baseId = await dumpSDKContext(
+      'openai',
+      '/responses',
+      { model: 'x' },
+      { id: 'r' },
+      false,
+      'https://api.openai.com/v1',
+      {
+        headers: { Authorization: 'Bearer secret', 'X-Debug': '1' },
+        transport: { type: 'http' },
+      },
+    );
+
+    const content = await fs.readFile(
+      path.join(dumpDir, `${baseId}-request.json`),
+      'utf-8',
+    );
+    const dump = JSON.parse(content) as {
+      request: { headers?: Record<string, string>; transport?: { type: string } };
+    };
+
+    expect(dump.request.headers).toStrictEqual({
+      Authorization: '[REDACTED]',
+      'X-Debug': '1',
+    });
+    expect(dump.request.transport).toStrictEqual({ type: 'http' });
+  });
+
+  it('forwards metadata to dumpSDKRequestContext via dumpSDKErrorRequestResponse', async () => {
+    const dumpSDKRequestContextSpy = vi
+      .spyOn(dumpSDKContextModule, 'dumpSDKRequestContext')
+      .mockResolvedValue({
+        baseId: 'b',
+        requestFilename: 'b-request.json',
+        dumpDir: '/tmp',
+      });
+    const dumpSDKResponseContextSpy = vi
+      .spyOn(dumpSDKContextModule, 'dumpSDKResponseContext')
+      .mockResolvedValue('b-response.json');
+    const metadata = {
+      headers: { Authorization: 'x' },
+      transport: { type: 'http' as const },
+    };
+
+    await dumpSDKContextModule.dumpSDKErrorRequestResponse(
+      'openai',
+      '/chat/completions',
+      { model: 'x' },
+      { error: 'boom' },
+      'https://api.openai.com/v1',
+      dumpSDKRequestContextSpy,
+      dumpSDKResponseContextSpy,
+      metadata,
+    );
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledWith(
+      'openai',
+      '/chat/completions',
+      { model: 'x' },
+      'https://api.openai.com/v1',
+      metadata,
+    );
+  });
+});
+
 describe('dumpSDKContext', () => {
   const dumpDir = path.join(Storage.getGlobalCacheDir(), 'dumps');
   const createdFiles: string[] = [];
@@ -87,6 +238,7 @@ describe('dumpSDKErrorRequestResponse', () => {
       'https://api.openai.com/v1',
       dumpSDKRequestContextSpy,
       dumpSDKResponseContextSpy,
+      undefined,
     );
 
     expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
@@ -237,6 +389,7 @@ describe('wrapStreamWithDump', () => {
       'https://api.openai.com/v1',
       dumpSDKRequestContextSpy,
       dumpSDKResponseContextSpy,
+      undefined,
     );
     const received: unknown[] = [];
 
@@ -255,6 +408,7 @@ describe('wrapStreamWithDump', () => {
       '/chat/completions',
       requestBody,
       'https://api.openai.com/v1',
+      undefined,
     );
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledTimes(1);
     expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(

--- a/packages/providers/src/utils/dumpSDKContext.ts
+++ b/packages/providers/src/utils/dumpSDKContext.ts
@@ -90,12 +90,6 @@ export async function bestEffortDump<T>(
 }
 
 /**
- * Dumps SDK-level request/response data by synthesizing HTTP-like structure
- * This captures the actual SDK parameters and responses, which is more useful
- * for debugging than raw HTTP dumps.
- * Returns the shared dump base id, not a dump filename.
- */
-/**
  * Builds the request envelope shared by both dump writers (#3159): the
  * transport decides the method (WebSocket frames are SEND, HTTP is POST) and
  * the header map; keeping this in one builder stops the two paths from
@@ -115,6 +109,12 @@ function buildSDKDumpRequest(
   };
 }
 
+/**
+ * Dumps SDK-level request/response data by synthesizing HTTP-like structure
+ * This captures the actual SDK parameters and responses, which is more useful
+ * for debugging than raw HTTP dumps.
+ * Returns the shared dump base id, not a dump filename.
+ */
 export async function dumpSDKContext(
   providerName: string,
   endpoint: string,

--- a/packages/providers/src/utils/dumpSDKContext.ts
+++ b/packages/providers/src/utils/dumpSDKContext.ts
@@ -9,11 +9,40 @@ import {
   shouldDump,
   dumpRequestContext,
   dumpResponseContext,
+  type DumpRequest,
   type DumpRequestResult,
 } from './dumpContext.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 
 const logger = new DebugLogger('llxprt:core:dumpSDKContext');
+
+/**
+ * Transport that carried the SDK request being dumped (#3159). The shared
+ * helper synthesizes HTTP-like defaults when no real transport is observed, so an
+ * explicit WebSocket marker is the only way a dump can say "this was a Codex
+ * WebSocket frame, not an HTTP POST".
+ */
+type RequestDumpTransport =
+  | { type: 'http' }
+  | { type: 'websocket'; frameType: string };
+
+/** Optional observed request metadata recorded verbatim (credentials redacted on write). */
+export interface RequestDumpMetadata {
+  headers?: Record<string, string>;
+  transport?: RequestDumpTransport;
+}
+
+function redactableHeaders(
+  metadata: RequestDumpMetadata | undefined,
+): Record<string, string> {
+  if (metadata?.headers !== undefined) {
+    return metadata.headers;
+  }
+  return {
+    'Content-Type': 'application/json',
+    'User-Agent': 'llxprt-code',
+  };
+}
 
 function buildSDKDumpUrl(
   providerName: string,
@@ -73,16 +102,15 @@ export async function dumpSDKContext(
   response: unknown,
   isError: boolean,
   baseURL?: string,
+  metadata?: RequestDumpMetadata,
 ): Promise<string> {
   const url = buildSDKDumpUrl(providerName, endpoint, baseURL);
 
-  const request = {
+  const request: DumpRequest = {
     url,
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'User-Agent': 'llxprt-code',
-    },
+    method: metadata?.transport?.type === 'websocket' ? 'SEND' : 'POST',
+    headers: redactableHeaders(metadata),
+    ...(metadata?.transport ? { transport: metadata.transport } : {}),
     body: requestParams,
   };
 
@@ -115,16 +143,15 @@ export async function dumpSDKRequestContext(
   endpoint: string,
   requestParams: unknown,
   baseURL?: string,
+  metadata?: RequestDumpMetadata,
 ): Promise<DumpRequestResult> {
   const url = buildSDKDumpUrl(providerName, endpoint, baseURL);
 
-  const request = {
+  const request: DumpRequest = {
     url,
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'User-Agent': 'llxprt-code',
-    },
+    method: metadata?.transport?.type === 'websocket' ? 'SEND' : 'POST',
+    headers: redactableHeaders(metadata),
+    ...(metadata?.transport ? { transport: metadata.transport } : {}),
     body: requestParams,
   };
 
@@ -251,9 +278,10 @@ export async function dumpSDKErrorRequestResponse(
   baseURL?: string,
   dumpRequest: typeof dumpSDKRequestContext = dumpSDKRequestContext,
   dumpResponse: typeof dumpSDKResponseContext = dumpSDKResponseContext,
+  metadata?: RequestDumpMetadata,
 ): Promise<void> {
   const reqResult = await bestEffortDump('error-request', providerName, () =>
-    dumpRequest(providerName, endpoint, requestParams, baseURL),
+    dumpRequest(providerName, endpoint, requestParams, baseURL, metadata),
   );
 
   await bestEffortDump('error-response', providerName, () =>
@@ -274,6 +302,7 @@ export function wrapStreamWithSDKErrorDump<T>(
   baseURL: string | undefined,
   dumpRequest: typeof dumpSDKRequestContext = dumpSDKRequestContext,
   dumpResponse: typeof dumpSDKResponseContext = dumpSDKResponseContext,
+  metadata?: RequestDumpMetadata,
 ): AsyncIterable<T> {
   const accumulated: T[] = [];
 
@@ -297,6 +326,7 @@ export function wrapStreamWithSDKErrorDump<T>(
         baseURL,
         dumpRequest,
         dumpResponse,
+        metadata,
       );
       throw error;
     }

--- a/packages/providers/src/utils/dumpSDKContext.ts
+++ b/packages/providers/src/utils/dumpSDKContext.ts
@@ -95,6 +95,26 @@ export async function bestEffortDump<T>(
  * for debugging than raw HTTP dumps.
  * Returns the shared dump base id, not a dump filename.
  */
+/**
+ * Builds the request envelope shared by both dump writers (#3159): the
+ * transport decides the method (WebSocket frames are SEND, HTTP is POST) and
+ * the header map; keeping this in one builder stops the two paths from
+ * drifting apart.
+ */
+function buildSDKDumpRequest(
+  url: string,
+  requestParams: unknown,
+  metadata: RequestDumpMetadata | undefined,
+): DumpRequest {
+  return {
+    url,
+    method: metadata?.transport?.type === 'websocket' ? 'SEND' : 'POST',
+    headers: resolveDumpHeaders(metadata),
+    ...(metadata?.transport ? { transport: metadata.transport } : {}),
+    body: requestParams,
+  };
+}
+
 export async function dumpSDKContext(
   providerName: string,
   endpoint: string,
@@ -106,13 +126,7 @@ export async function dumpSDKContext(
 ): Promise<string> {
   const url = buildSDKDumpUrl(providerName, endpoint, baseURL);
 
-  const request: DumpRequest = {
-    url,
-    method: metadata?.transport?.type === 'websocket' ? 'SEND' : 'POST',
-    headers: resolveDumpHeaders(metadata),
-    ...(metadata?.transport ? { transport: metadata.transport } : {}),
-    body: requestParams,
-  };
+  const request = buildSDKDumpRequest(url, requestParams, metadata);
 
   const dumpResponse = {
     status: isError ? 500 : 200,
@@ -147,13 +161,7 @@ export async function dumpSDKRequestContext(
 ): Promise<DumpRequestResult> {
   const url = buildSDKDumpUrl(providerName, endpoint, baseURL);
 
-  const request: DumpRequest = {
-    url,
-    method: metadata?.transport?.type === 'websocket' ? 'SEND' : 'POST',
-    headers: resolveDumpHeaders(metadata),
-    ...(metadata?.transport ? { transport: metadata.transport } : {}),
-    body: requestParams,
-  };
+  const request = buildSDKDumpRequest(url, requestParams, metadata);
 
   logger.debug(
     () =>

--- a/packages/providers/src/utils/dumpSDKContext.ts
+++ b/packages/providers/src/utils/dumpSDKContext.ts
@@ -32,7 +32,7 @@ export interface RequestDumpMetadata {
   transport?: RequestDumpTransport;
 }
 
-function redactableHeaders(
+function resolveDumpHeaders(
   metadata: RequestDumpMetadata | undefined,
 ): Record<string, string> {
   if (metadata?.headers !== undefined) {
@@ -109,7 +109,7 @@ export async function dumpSDKContext(
   const request: DumpRequest = {
     url,
     method: metadata?.transport?.type === 'websocket' ? 'SEND' : 'POST',
-    headers: redactableHeaders(metadata),
+    headers: resolveDumpHeaders(metadata),
     ...(metadata?.transport ? { transport: metadata.transport } : {}),
     body: requestParams,
   };
@@ -150,7 +150,7 @@ export async function dumpSDKRequestContext(
   const request: DumpRequest = {
     url,
     method: metadata?.transport?.type === 'websocket' ? 'SEND' : 'POST',
-    headers: redactableHeaders(metadata),
+    headers: resolveDumpHeaders(metadata),
     ...(metadata?.transport ? { transport: metadata.transport } : {}),
     body: requestParams,
   };

--- a/project-plans/issue3159-dumpcontext-honest-transport.md
+++ b/project-plans/issue3159-dumpcontext-honest-transport.md
@@ -1,0 +1,165 @@
+# Issue 3159: dumpcontext fabricates request headers, method and URL, hiding which transport was used
+
+Status: Accepted behavior and test-first implementation plan
+Date: 2026-08-21
+Issue: https://github.com/vybestack/llxprt-code/issues/3159
+Labels: Observability
+
+## Purpose
+
+Every dump written by the shared SDK dump helper reports hardcoded headers
+(`Content-Type`, `User-Agent`), the method `POST`, and an `https://` URL
+regardless of what was actually sent. A Codex WebSocket request is therefore
+recorded as if it were an HTTP POST, hiding the single most useful fact a dump
+can carry: which transport carried the request. This change makes the shared helper
+record the real header map (credentials redacted), the true URL including the
+`wss://` scheme, and a transport discriminator so WebSocket and HTTP dumps are
+distinguishable. The plumbing is added once in the shared helper and threaded
+through the four calling providers (gemini, anthropic, openai, openai-responses).
+
+## Accepted behavior
+
+### REQ-3159-001: Shared helper records observed metadata
+
+- `dumpSDKRequestContext(providerName, endpoint, requestParams, baseURL?, options?)`
+  accepts an optional request-metadata object:
+  - `headers?: Record<string, string>` — real headers sent on the wire.
+  - `transport?: { type: 'http' } | { type: 'websocket'; frameType: string }`
+    — how the request was carried. Omitted means plain HTTP.
+- When `headers` is provided, the dump records exactly those headers with values
+  redacted for known credential names. When omitted, the current synthesized
+  defaults continue to apply (backwards compatibility for direct callers).
+- The recorded method for the WebSocket transport is not `POST`; the request
+  shape carries `transport` alongside `method: 'POST'` for HTTP and the frame
+  type (for example `response.create`) for WebSocket so the two paths are
+  unambiguous.
+- `dumpSDKContext`, `dumpSDKErrorRequestResponse`, and
+  `wrapStreamWithSDKErrorDump` thread the same optional metadata through without
+  changing their existing callers' behavior when it is omitted.
+
+### REQ-3159-002: OpenAI Responses records real WS vs HTTP metadata
+
+- The HTTP Responses path passes the headers built by `buildResponsesHeaders`
+  (including Codex headers when Codex) and HTTP transport metadata.
+- The Codex WebSocket path passes the headers built by
+  `buildWebSocketHandshakeHeaders` (Authorization, ChatGPT-Account-ID,
+  originator, session_id, OpenAI-Beta `responses_websockets=2026-02-06`) and
+  WebSocket transport metadata with the frame type `response.create`.
+- The dump URL for the WebSocket path uses the `wss://` scheme, not `https://`.
+- Both error-dump paths (`openAIResponsesHttpStream.dumpErrorOnFailure` with no
+  pre-existing base id and `wrapStreamWithSDKErrorDump`) produce the same honest
+  metadata.
+
+### REQ-3159-003: OpenAI Chat, Anthropic, Gemini pass observed headers
+
+- OpenAI Chat request dumps record `mergedHeaders` when present.
+- Anthropic request dumps record the custom headers built for the request.
+- Gemini request dumps record the http options headers built for the request.
+- When no real headers exist at a call site, the call site omits the metadata so
+  the synthesized defaults remain authoritative there.
+
+### REQ-3159-004: Credential redaction
+
+- Dump files never contain real values for credential headers. The existing
+  credential-name set in `dumpContext.ts` already covers `authorization`,
+  `x-api-key`, `x-goog-api-key`, `api-key`, and `cookie`; the codex account
+  id header `ChatGPT-Account-ID` is added to that set so it is redacted too.
+- Header names are always preserved (a dump still shows which headers were present).
+
+### REQ-3159-005: Distinguishability
+
+- A dump written for a request that went over the Codex WebSocket is
+  distinguishable from one that went over HTTP by:
+  1. the `wss://` (WebSocket) vs `https://` (HTTP) scheme in `request.url`,
+  2. the transport metadata / method on the request shape.
+
+### REQ-3159-006: No scope expansion
+
+- No new subsystems, workflows, agent memory, quality-tool config, dependency
+  changes, or unrelated refactors. The shared helper stays in
+  `packages/providers/src/utils/dumpSDKContext.ts`. Public exports are unchanged
+  except the new optional parameter.
+
+## Behavioral test plan (test-first)
+
+### Phase 1: Shared helper redaction and transport shape
+
+RED tests in `packages/providers/src/utils/dumpSDKContext.test.ts`:
+
+1. `dumpSDKRequestContext` with headers containing `Authorization`,
+   `ChatGPT-Account-ID`, `OpenAI-Beta`, `session_id`, and a benign
+   `X-Debug` header writes a request dump whose `request.headers` preserves every
+   name, redacts `authorization` and `ChatGPT-Account-ID` values, and keeps
+   `OpenAI-Beta` and `session_id` readable.
+2. `dumpSDKRequestContext` with `transport: { type: 'websocket', frameType:
+   'response.create' }` and a `wss://` base URL writes a request dump whose
+   `request.method` is not `POST` and/or `request.transport` distinguishes
+   WebSocket from the default HTTP request, and whose `request.url` keeps the `wss://`
+   scheme.
+3. `dumpSDKContext` (combined helper) preserves the same metadata through the dump.
+4. `dumpSDKErrorRequestResponse` forwards the metadata to `dumpSDKRequestContext`.
+5. `wrapStreamWithSDKErrorDump` forwards the metadata to
+   `dumpSDKErrorRequestResponse` and therefore to `dumpSDKRequestContext`.
+
+GREEN: add the optional metadata parameter to the helper, thread it through, and
+extend the dump request shape. Update the existing `toHaveBeenCalledWith` assertions
+in `dumpSDKErrorRequestResponse` / `wrapStreamWithSDKErrorDump` tests that now
+receive the extra argument.
+
+### Phase 2: Provider call sites
+
+RED tests:
+
+1. `packages/providers/src/openai-responses/__tests__/openAIResponsesExecutor.liveness.test.ts`
+   (adapting the existing `readDumpedRequest` to read the whole request, not just
+   body): HTTP path passes real headers; Codex WebSocket path dump URL uses `wss://`,
+   transport says WebSocket, and `OpenAI-Beta` contains `responses_websockets=2026-02-06`
+   while `Authorization` is redacted.
+2. `packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts`:
+   `dumpSDKRequestContext` was called with the request `mergedHeaders`.
+3. `packages/providers/src/anthropic/AnthropicProvider.dumpContext.test.ts`:
+   the request dump was produced with the custom headers built for the call.
+4. `packages/providers/src/gemini/GeminiProvider.separateDump.test.ts`:
+   `dumpSDKRequestContext` was called with the http options headers.
+
+GREEN: thread the observed metadata through
+`openAIResponsesExecutor.dumpFinalizedRequest` (using the WS-active predicate to
+choose transport metadata), `buildResponsesHeaders` call sites in
+`openAIResponsesHttpStream.dumpErrorOnFailure`, `OpenAIApiExecution`,
+`AnthropicProvider.executeApiCall`/`AnthropicApiExecution.dumpAnthropicRequest`,
+and `geminiGenerationExecution`. Add `ChatGPT-Account-ID` to the credential
+redaction set in `dumpContext.ts`.
+
+### Phase 3: Verification
+
+Run the full workflow cycle on the candidate head:
+
+1. `npm run test`
+2. `npm run lint`
+3. `npm run typecheck`
+4. `npm run format`
+5. `npm run build`
+6. `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+
+## Verification and review
+
+Complete one deep technical review and no more than two local Open Code Review
+rounds. Classify each finding as `Blocker-Fix`, `In-scope-Fix`, `Reject`,
+or `Defer`. Fix all `Blocker-Fix` and `In-scope-Fix` findings, then rerun
+the verification cycle. Complete no more than two PR Open Code Review rounds after
+pushing.
+
+## Completion conditions
+
+The issue is complete only when:
+
+1. Every accepted requirement has behavioral evidence.
+2. All local verification gates pass on the candidate commit.
+3. Deep review and permitted Open Code Review rounds are complete and triaged.
+4. Every Blocker-Fix and In-scope-Fix finding is resolved.
+5. CI passes on the candidate head.
+6. PR review threads are resolved.
+7. The PR has correct ancestry, no conflicts, and is ready to merge.
+
+Do not merge without explicit user approval. Stop when these conditions are met rather
+than adding optional cleanup or hardening.


### PR DESCRIPTION
## TLDR

Provider `dumpcontext` dumps now record what was actually sent instead of synthesized placeholders: real request headers with credential values redacted, honest transport metadata (WebSocket frame vs HTTP POST), and `wss://` URLs for WebSocket sends. Dump-side only, with no wire behavior changes; the new metadata parameter is optional and backwards compatible.

## Dive Deeper

**Shared helper (`dumpSDKContext.ts`)**, REQ-3159-001
- New optional trailing `metadata` parameter (`{ headers?, transport? }`) on `dumpSDKContext`, `dumpSDKRequestContext`, `dumpSDKErrorRequestResponse`, and `wrapStreamWithSDKErrorDump`.
- Observed headers are written with sensitive values (`authorization`, `x-api-key`, `x-goog-api-key`, `chatgpt-account-id`, ...) replaced by `[REDACTED]`, with names preserved.
- Omitting metadata keeps the previous output exactly (synthesized defaults, no transport field).

**OpenAI Responses**, REQ-3159-002
- Pre-transport seam dump records the real handshake/request headers: `buildWebSocketHandshakeHeaders` (Authorization, ChatGPT-Account-ID, OpenAI-Beta, session_id, originator) for WebSocket, `buildResponsesHeaders` for HTTP.
- WebSocket dumps: method `SEND`, URL converted to `wss://`, `transport: { type: 'websocket', frameType }`. HTTP dumps: method `POST`, `transport: { type: 'http' }`.
- When a WebSocket turn falls back to HTTP mid-turn, a second dump records the physical HTTP send (`POST`/`https`) and links the response/error dumps to the HTTP request's base id.
- A stateless rebuild (previous_response_id set) is always a physical HTTP send and is labeled as such, never as a WebSocket frame.
- If header observation fails, the dump keeps the true websocket transport label and records empty observed headers rather than relabeling as HTTP.

**OpenAI Chat / Anthropic / Gemini**, REQ-3159-003
- Each provider passes its observed header map into the dump metadata (mergedHeaders / custom headers / httpOptions headers).
- SDK-generated credential headers are recorded by NAME with the value redacted at write: `Authorization` (OpenAI Chat, Anthropic OAuth), `x-api-key` (Anthropic API key), `x-goog-api-key` (Gemini API key).
- Caller-supplied headers win over synthesized credentials (case-insensitive match).

**Redaction & distinguishability**, REQ-3159-004/005
- Credential and account header values never reach disk; non-sensitive headers (Content-Type, OpenAI-Beta, session_id, ...) remain readable.
- A WebSocket send and an HTTP POST for the same logical request are distinguishable by method, URL scheme, and the `transport` field.

**Scope**, REQ-3159-006
- No new dependencies, files outside `packages/providers/src`, public exports (beyond the optional metadata parameter), docs, or workflow changes.
- Two review suggestions were consciously declined to honor REQ-3159-006: extracting the three per-provider `hasHeaderName` helpers into a shared util, and unifying dump-side header construction with the wire send path (memoized single construction). Both would add cross-cutting surface the plan excludes; per-provider duplication is covered by tests.

## Reviewer Test Plan

- Run the focused suites from `packages/providers`:
  `bun test src/utils/dumpSDKContext.test.ts src/utils/dumpContext.test.ts src/utils/dumpContext.separateFiles.test.ts src/openai/OpenAIApiExecution.separateDump.test.ts src/anthropic/AnthropicApiExecution.dumpContext.test.ts src/anthropic/AnthropicApiExecution.separateDump.test.ts src/anthropic/AnthropicProvider.dumpContext.test.ts src/gemini/GeminiProvider.separateDump.test.ts src/openai-responses/openAIResponsesExecutor.liveness.test.ts src/openai-responses/openAIResponsesExecutor.errorDump.test.ts` (97 tests).
- End-to-end: start the CLI with `dumpcontext: 'on'` against a Codex (WebSocket) and a plain HTTP provider, then inspect the generated `*-request.json` in the dump dir: `authorization`/`chatgpt-account-id` values show `[REDACTED]`, `openai-beta`/`session_id` stay readable, WebSocket sends show `method: "SEND"`, a `wss://` URL and `transport.type: "websocket"`, HTTP sends show `POST`/`https` and `transport.type: "http"`.
- Smoke: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` still starts and streams normally.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS runs: `npm run typecheck`, `npm run lint`, `npm run build` all exit 0; focused bun suites 97/97; stepfun-37 smoke passes; full providers suite matches the pre-branch baseline exactly (identical failing-file set; those failures are pre-existing single-process pollution on this machine and pass in isolation).

## Linked issues

Closes #3159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Request and error diagnostics now include relevant transport details and observed headers.
  * Added support for distinguishing HTTP and WebSocket requests, including WebSocket frame information.
  * Authentication metadata is preserved accurately while sensitive headers remain protected.
  * WebSocket-to-HTTP fallback activity is now linked correctly in diagnostic records.
  * Streaming and non-streaming request failures provide more complete, consistent context across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->