### PR TITLE
Keep coordinated builds on same-checkout workspaces (Fixes #3269)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "build-and-start": "npm run build && npm run start",
     "build:vscode": "bun scripts/build_vscode_companion.ts",
     "build:all": "npm run build && npm run build:sandbox && npm run build:vscode",
-    "build:packages": "npm run generate && npm run build --workspaces",
+    "build:packages": "bun scripts/prepare-workspace-build.ts && npm run generate && npm run build --workspaces && bun scripts/verify-lazy-mcp-build-coherence.ts",
     "build:sandbox": "bun scripts/build_sandbox.ts --skip-npm-install-build",
     "bundle": "npm run generate && bun scripts/bun-build.config.ts",
     "test": "npm run test --workspaces --if-present",

--- a/packages/agents/src/core/subagent-test-helpers.test.ts
+++ b/packages/agents/src/core/subagent-test-helpers.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'bun:test';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { DiscoveredMCPTool } from '@vybestack/llxprt-code-mcp';
+import {
+  ACTIVATE_MCP_SERVER_TOOL_NAME,
+  type CallableTool,
+} from '@vybestack/llxprt-code-tools';
+import {
+  createMockConfig,
+  disposeMockConfig,
+} from './subagent-test-helpers.js';
+
+function createCallableTool(): CallableTool {
+  return {
+    async tool() {
+      return {};
+    },
+    async callTool() {
+      return [];
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createMockConfig MCP lifecycle', () => {
+  it('keeps complete lazy-MCP registry behavior while scheduled refreshes complete', async () => {
+    let releaseRefresh: (() => void) | undefined;
+    let markRefreshStarted: (() => void) | undefined;
+    let config: Config | undefined;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    vi.spyOn(Config.prototype, 'refreshMemory').mockImplementation(async () => {
+      markRefreshStarted?.();
+      await refreshGate;
+      return { memoryContent: '', fileCount: 0, filePaths: [] };
+    });
+
+    try {
+      const created = await createMockConfig({ getTool: () => undefined });
+      config = created.config;
+      await refreshStarted;
+
+      config.setEphemeralSetting('mcp.lazy', true);
+      created.toolRegistry.registerTool(
+        new DiscoveredMCPTool(
+          createCallableTool(),
+          'scheduled-server',
+          'fixture-tool',
+          'Scheduled refresh fixture',
+          { type: 'object' },
+        ),
+      );
+      expect(created.toolRegistry.listDeferredMcpServers()).toEqual([
+        'scheduled-server',
+      ]);
+      expect(config.getToolRegistry()).toBe(created.toolRegistry);
+
+      releaseRefresh?.();
+      await config.refreshMcpContext();
+      expect(
+        created.toolRegistry
+          .getAllTools()
+          .some((tool) => tool.name === ACTIVATE_MCP_SERVER_TOOL_NAME),
+      ).toBe(true);
+    } finally {
+      releaseRefresh?.();
+      if (config !== undefined) {
+        await disposeMockConfig(config);
+      }
+    }
+  });
+});

--- a/packages/agents/src/core/subagent-test-helpers.ts
+++ b/packages/agents/src/core/subagent-test-helpers.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Mock } from 'bun:test';
-import { vi } from 'bun:test';
+import { afterEach, vi } from 'bun:test';
 import type { ContentBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { toModelStreamChunk } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import { Config } from '@vybestack/llxprt-code-core/config/config.js';
@@ -47,6 +47,19 @@ import type {
 } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 
+const mockConfigs = new Set<Config>();
+
+afterEach(async () => {
+  const configs = Array.from(mockConfigs);
+  mockConfigs.clear();
+  await Promise.all(configs.map((config) => config.dispose()));
+});
+
+export async function disposeMockConfig(config: Config): Promise<void> {
+  mockConfigs.delete(config);
+  await config.dispose();
+}
+
 export function createCompletedToolCallResponse(params: {
   callId: string;
   responseParts?: ContentBlock[];
@@ -76,8 +89,12 @@ export function createCompletedToolCallResponse(params: {
   };
 }
 
+type ToolRegistryMethodOverrides = Partial<
+  Pick<ToolRegistry, 'getTool' | 'getFunctionDeclarationsFiltered'>
+>;
+
 export async function createMockConfig(
-  toolRegistryMocks = {},
+  toolRegistryMethods: ToolRegistryMethodOverrides = {},
 ): Promise<{ config: Config; toolRegistry: ToolRegistry }> {
   const settingsService = new SettingsService();
   setActiveProviderRuntimeContext(
@@ -93,6 +110,7 @@ export async function createMockConfig(
   };
   const config = new Config(configParams);
   await initializeTestConfig(config);
+  mockConfigs.add(config);
 
   await config.refreshAuth();
 
@@ -100,14 +118,15 @@ export async function createMockConfig(
     model: DEFAULT_GEMINI_MODEL,
   });
 
-  const mockToolRegistry = {
-    getTool: vi.fn(),
-    getFunctionDeclarationsFiltered: vi.fn().mockReturnValue([]),
-    ...toolRegistryMocks,
-  } as unknown as ToolRegistry;
+  const toolRegistry = config.getToolRegistry();
+  vi.spyOn(toolRegistry, 'getTool').mockImplementation(
+    toolRegistryMethods.getTool ?? (() => undefined),
+  );
+  vi.spyOn(toolRegistry, 'getFunctionDeclarationsFiltered').mockImplementation(
+    toolRegistryMethods.getFunctionDeclarationsFiltered ?? (() => []),
+  );
 
-  vi.spyOn(config, 'getToolRegistry').mockReturnValue(mockToolRegistry);
-  return { config, toolRegistry: mockToolRegistry };
+  return { config, toolRegistry };
 }
 
 export function createMockStream(

--- a/project-plans/issue3269-same-commit-build.md
+++ b/project-plans/issue3269-same-commit-build.md
@@ -1,0 +1,219 @@
+# Issue #3269 Plan: Same-Checkout Workspace Builds
+
+Plan ID: PLAN-20260821-ISSUE3269
+Generated: 2026-08-21
+Issue: https://github.com/vybestack/llxprt-code/issues/3269
+
+## Investigation Result
+
+The cited CI job installed a clean workspace and completed a full build before the agents shard failed. The immediate failure was a test-fixture race: `createMockConfig()` initialized a real `Config`, whose MCP startup continues in the background, and then replaced its `ToolRegistry` with a partial object that does not implement `listDeferredMcpServers()`. The background MCP refresh could observe that partial registry.
+
+The repository already records all internal dependencies as local `file:` dependencies, both lockfiles map workspace package names to local workspaces, and the installed-tree verifier rejects a same-named registry copy. The relevant package namespace is `@vybestack`, not `@vyestack` as written in the issue.
+
+A separate stale-output boundary remains. Workspace builds clean each package only when that package's build begins. A package built earlier in the sequence can therefore resolve an ignored `dist` directory belonging to a package whose build has not begun. The full-build coordinator does not remove all workspace output before compilation starts.
+
+## Accepted Behavior
+
+### AC-1: Declared internal dependencies identify exact sibling workspaces
+
+**Given** the root workspace list and any `dependencies`, `devDependencies`, `optionalDependencies`, or `peerDependencies` entry in a workspace manifest,
+**when** the dependency name belongs to a declared workspace,
+**then** its local protocol target must resolve from the consumer to that exact workspace, and the target manifest must declare the expected package name.
+
+This includes `@vybestack/llxprt-code`, which must resolve to `packages/cli`. Registry ranges, npm aliases, missing targets, and local paths to the wrong package fail before build or test consumers run.
+
+### AC-2: Installed package aliases identify repository workspaces
+
+**Given** a supported repository install,
+**when** the workspace-link gate inspects root `node_modules`,
+**then** every declared workspace alias, including `@vybestack/llxprt-code`, must resolve to its declared repository directory.
+
+A missing entry, broken link, wrong workspace link, or same-named registry directory produces a nonzero result with the affected workspace and expected target. Existing postinstall behavior remains responsible for replacing nested first-party package copies; this issue will not add a second nested-package subsystem.
+
+### AC-3: Full builds start without pre-existing workspace output
+
+**Given** stale or API-incompatible files under any declared workspace's `dist` directory,
+**when** `npm run build` or `npm run build:packages` starts a full JavaScript build,
+**then** all declared workspace `dist` directories are removed before the first workspace compilation begins.
+
+The cleanup must derive its targets from the declared workspace list rather than a hard-coded package list or shell glob. A missing, empty, malformed, or non-literal workspace declaration fails instead of allowing a partial cleanup. Declaration-only builds retain their existing behavior unless a failing behavioral test proves they can consume stale JavaScript output.
+
+### AC-4: Build consumers fail before runtime on workspace inconsistency
+
+**Given** an installed alias that does not identify its declared workspace,
+**when** a full coordinated build starts,
+**then** the existing workspace-link verifier runs before generation or workspace compilation and terminates the build on mismatch.
+
+No runtime fallback, `typeof` guard, or MCP compatibility wrapper will be added.
+
+### AC-5: Agents test configuration remains valid during MCP startup
+
+**Given** an agents test that initializes a real `Config`,
+**when** background MCP discovery refreshes the tool registry,
+**then** it must observe a real, complete `ToolRegistry`, not a partial structural replacement, and test-owned configuration work must be disposed or settled through the existing lifecycle.
+
+The reported `subagent.create.test.ts` behavior must pass without an unhandled `listDeferredMcpServers is not a function` exception in isolated execution and in the agents shard.
+
+### AC-6: Source and compiled paths agree after a full build
+
+**Given** a successful full build,
+**when** the relevant real tools/core/MCP APIs are loaded through the Bun source path and Node compiled path,
+**then** lazy MCP registry synchronization completes through the real `ToolRegistry` API without a missing-method exception.
+
+Behavioral evidence must exercise real modules. A test that only checks a mocked method or asserts `typeof` is insufficient.
+
+## Inputs and Boundary Cases
+
+The accepted inputs are the root workspace declaration, every declared workspace manifest, root installed aliases, ignored workspace `dist` directories, and the agents test helper's `Config` lifecycle.
+
+Required failure boundaries are:
+
+- missing, empty, malformed, or glob-based workspace declarations;
+- an internal dependency using a registry range, npm alias, missing local target, wrong sibling target, or target with a mismatched package name;
+- a missing, broken, copied, or wrongly targeted root workspace alias;
+- stale output in a workspace unrelated to the MCP stack as well as in tools/MCP/core;
+- a build command that fails after cleanup, which must remain nonzero and must not restore pre-build stale output;
+- MCP startup completing before or after agents test setup, with neither schedule exposing a partial registry.
+
+## Behavioral Evidence
+
+| Criterion | Evidence |
+| --- | --- |
+| AC-1 | Bun tests traverse all manifests and dependency sections using the real local-protocol resolver; fixture cases reject registry and wrong-target specifications. |
+| AC-2 | Existing workspace-link tests plus explicit CLI-name coverage reject a same-named directory and wrong link; `bun scripts/verify-bun-workspace-links.ts` passes against the installed repository. |
+| AC-3 | A temporary-repository test seeds stale markers in multiple declared workspace `dist` directories and proves all are absent before the first build callback or command runs. It also proves malformed workspace declarations fail. |
+| AC-4 | A build-coordinator test supplies a failing link gate and proves no generation or workspace build starts. |
+| AC-5 | A deterministic agents regression controls MCP refresh ordering around `createMockConfig()`, exercises the real registry boundary, and proves cleanup settles the configuration. The agents shard passes. |
+| AC-6 | A real-module integration check after `npm run build` exercises lazy-MCP registry synchronization through source and compiled entry points. |
+
+All new tests use TypeScript and `bun:test`. They must fail for the intended behavioral reason before production changes are made.
+
+## Scope Exclusions
+
+- Renaming the private root package. Current lockfiles and installed aliases already select `packages/cli`; changing root package identity would alter packaging workflows without evidence that it caused this failure.
+- Replacing all `dist` exports or TypeScript path mappings with source imports.
+- Adding artifact Git-SHA stamping, content hashing, a new cache service, or a new public build abstraction.
+- Adding runtime compatibility handling around `ToolRegistry` or changing MCP feature behavior.
+- Replacing npm or Bun, changing dependencies, or restructuring CI workflows. A workflow edit requires approval unless implementation proves the checked-in build entry point cannot enforce the accepted behavior.
+- Guaranteeing arbitrary direct Node imports from an unbuilt developer worktree. The guarantee applies to supported install, full-build, test, CI, and release entry points.
+
+## Implementation Phases
+
+### Phase 0: Preflight
+
+- Confirm every manifest and lockfile currently maps internal names to declared local workspaces.
+- Confirm `@vybestack/llxprt-code` resolves to `packages/cli` in the installed tree.
+- Run the existing workspace, link, postinstall, publish-integrity, and reported agents tests.
+- Trace the full-build and Config/MCP lifecycle call paths.
+
+### Phase 1: RED tests for manifest and installed identity
+
+- Extend the existing manifest/protocol tests rather than introduce another resolver.
+- Add only missing boundary coverage to the existing link-verifier suite.
+- Record the expected failures before implementation.
+
+### Phase 2: RED tests for build preparation
+
+- Introduce a fixture test around the smallest internal build-preparation seam.
+- Seed multiple stale workspace outputs and observe filesystem state before any build action.
+- Test link-gate ordering and malformed workspace input.
+
+### Phase 3: GREEN build preparation
+
+- Reuse the existing workspace declaration and link verifier.
+- Remove every declared workspace `dist` before coordinated full compilation.
+- Route both supported full-build entry points through the same internal behavior without adding a public API.
+
+### Phase 4: RED/GREEN agents lifecycle regression
+
+- Add deterministic scheduling coverage around MCP refresh and test configuration setup.
+- Keep the real `ToolRegistry` attached to the initialized `Config`; customize only methods needed by individual tests through the existing test seams.
+- Dispose or settle each test-owned configuration through the existing lifecycle.
+
+### Phase 5: Integration and verification
+
+Run focused tests, the agents and scripts shards, the changed-test audit, and the full verification cycle:
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Then complete technical review and Open Code Review. Every finding will be classified as `Blocker-Fix`, `In-scope-Fix`, `Reject`, or `Defer`. Only accepted in-scope findings will change this plan's behavior.
+
+## Execution and Review Record
+
+Implementation followed the accepted split between the reported agents fixture race and the separate coordinated-build stale-output boundary. The build preparation gate now validates installed aliases and declared workspace identities before removing any output. It rejects workspace declarations that can escape the checkout, including lexical traversal and symlink or junction escapes. Both full-build entry points run preparation before generation and compilation, then run a source and compiled lazy-MCP coherence check. Declaration-only builds retain their prior behavior.
+
+The agents helper keeps the initialized `Config`'s real `ToolRegistry`, limits test overrides to the two required query methods, and disposes test-owned configurations. Its regression test uses real deferred MCP tools and observes activation-tool synchronization after MCP refresh completes.
+
+### RED and GREEN evidence
+
+The behavioral tests exposed these failures before the corresponding fixes:
+
+- stale markers remained outside the package that had begun building because the coordinator did not preclean every declared workspace;
+- traversal and realpath-escape workspace entries allowed cleanup targets outside the checkout;
+- a path-shaped package name could bypass alias lookup by resolving as a filesystem path;
+- the agents helper exposed a partial registry while initialized MCP work was still active;
+- neither full-build entry point enforced source and freshly compiled lazy-MCP API coherence.
+
+The focused GREEN run after formatting covered all affected agents, build-preparation, workspace-link, dependency-protocol, publish-integrity, declaration-build, build-configuration, and coherence tests: 105 tests passed across 9 files with 243 assertions. The complete scripts shard also passed 266 of 266 files after the declaration-only isolation fix.
+
+### Independent technical review
+
+The first independent technical review requested changes. Every finding was classified and handled:
+
+1. `Blocker-Fix`: the controlled `refreshMemory()` result had the wrong shape. The fixture now returns the real method's result shape.
+2. `Blocker-Fix`: workspace declarations could escape the checkout and direct cleanup outside the repository. Lexical and realpath containment checks plus marker-survival tests now reject those inputs before deletion.
+3. `In-scope-Fix`: the build lacked durable source and compiled lazy-MCP coherence evidence. A real-module gate now runs after both full-build entry points.
+4. `In-scope-Fix`: source-string ordering checks did not prove behavior. They were replaced with coordinator effect-order, short-circuit, and error-propagation tests.
+5. `In-scope-Fix`: the agents lifecycle regression could deadlock and relied on class identity. It now releases its gate in `finally`, awaits refresh completion, exercises a real deferred tool, and observes the activation tool through the registry.
+6. `Defer`: rewriting the existing missing-workspaces fixture was redundant and did not change accepted behavior.
+
+The second independent technical review found one issue. It was classified `Blocker-Fix`: an unvalidated package name such as `../packages/core` could resolve directly to a workspace without an installed alias. Package names now pass the established scoped or unscoped package-name grammar before alias resolution, with verifier and cleanup marker-survival regressions.
+
+### Open Code Review
+
+Two local OCR rounds were used, which is the configured limit.
+
+Round 1 reviewed 14 selected files, completed 13, and reported six findings:
+
+1. `In-scope-Fix`: malformed package metadata used a misleading summary. The summary now says `Declared workspace(s) have invalid or unreadable package metadata:` and both invalid-name and malformed-JSON tests assert it.
+2. `Reject`: removing the preparation boundary's root-manifest validation would make a destructive consumer rely on untyped data from a verifier that does not return workspace directories.
+3. `Defer`: richer compiled-subprocess signal diagnostics would improve error text but do not affect failure behavior.
+4. `Reject`: sharing source and compiled coherence fixture code would weaken the independent Bun-source and Node-compiled boundary.
+5. `Reject`: a timer around the deterministic agents gate would replace Bun's test timeout with another race without proving product behavior.
+6. `Reject`: the claimed cleanup ordering problem was incorrect because `finally` releases the gate before disposal.
+
+Round 2 completed all 14 selected files and reported six findings. All were rejected after checking the affected behavior:
+
+1. `Reject`: explicit declaration and full-build command branches are clearer than the proposed command-list abstraction and preserve behavior.
+2. `Reject`: the preparation manifest re-read is required for type-safe cleanup targets.
+3. `Reject`: the publish-integrity diagnostic wording is accurate enough and has no behavioral defect.
+4. `Reject`: independent source and compiled coherence programs are intentional boundary coverage.
+5. `Reject`: the claimed missing glob rejection was factually incorrect; production rejects glob entries and the behavioral test passes.
+6. `Reject`: the agents test uses deterministic initialization plus Bun's test timeout, so an additional timer race is not warranted.
+
+### Verification evidence
+
+The candidate was checked sequentially to avoid concurrent commands cleaning or consuming shared `dist` output:
+
+- `bun scripts/test-audit/scan.ts tmp/issue3269-final-scan` scanned 2,699 files, 36,165 tests, and 77,908 assertions with zero scanner errors. None of the changed or new issue tests appears in the findings.
+- `npm run lint` passed.
+- `npm run typecheck` passed.
+- `npm run format` passed without rewriting files.
+- The post-format focused run passed 105 tests across 9 files with 243 assertions.
+- `bun scripts/verify-bun-workspace-links.ts` verified all 16 declared workspaces against their in-repository targets.
+- The final `npm run build` passed and printed `Verified source and compiled lazy-MCP registry coherence.`
+- The required `stepfun-37` startup smoke passed after that rebuild and returned only a haiku.
+- `git diff --exit-code HEAD -- package-lock.json bun.lock` passed. No dependency or lockfile change was introduced.
+
+A complete local `npm run test` finished nonzero for three files outside this change. `packages/core/test/utils/ripgrepPathResolver.test.ts` had four Darwin failures because the implementation found `/opt/homebrew/bin/rg` despite the test's filesystem reassignment. The same file reproduced those four failures in isolation, with 10 tests passing and 4 failing. `packages/agents/src/api/__tests__/core-conversation.spec.ts` and `packages/agents/src/api/__tests__/displayCallbacks.behavior.test.ts` reached their 180-second suite timeout in the complete run; those two files passed together in isolation, with 13 tests passing in 1.96 seconds. A later full-suite rerun reproduced the core ripgrep failure and was stopped once the overall command was guaranteed to remain nonzero. This record does not classify those failures as pre-existing without comparison evidence from `main`. No issue-owned focused test failed. CI on the candidate head remains the completion check for the repository-wide suite.
+
+## Completion Gate
+
+The issue is complete only when every acceptance criterion has behavioral evidence, focused and full local verification pass on the candidate head, allowed reviews are complete and triaged, all `Blocker-Fix` and `In-scope-Fix` findings are resolved, CI passes on that same head, CodeRabbit threads are resolved, and the pull request is conflict-free with correct ancestry.

--- a/project-plans/issue3269-same-commit-build.md
+++ b/project-plans/issue3269-same-commit-build.md
@@ -214,6 +214,20 @@ The candidate was checked sequentially to avoid concurrent commands cleaning or 
 
 A complete local `npm run test` finished nonzero for three files outside this change. `packages/core/test/utils/ripgrepPathResolver.test.ts` had four Darwin failures because the implementation found `/opt/homebrew/bin/rg` despite the test's filesystem reassignment. The same file reproduced those four failures in isolation, with 10 tests passing and 4 failing. `packages/agents/src/api/__tests__/core-conversation.spec.ts` and `packages/agents/src/api/__tests__/displayCallbacks.behavior.test.ts` reached their 180-second suite timeout in the complete run; those two files passed together in isolation, with 13 tests passing in 1.96 seconds. A later full-suite rerun reproduced the core ripgrep failure and was stopped once the overall command was guaranteed to remain nonzero. This record does not classify those failures as pre-existing without comparison evidence from `main`. No issue-owned focused test failed. CI on the candidate head remains the completion check for the repository-wide suite.
 
+### Pull request CI and review remediation
+
+The first CI run passed every Linux test shard and failed only JavaScript lint plus its aggregate. The affected-test graph drift guard found the new agents test-only MCP import. Adding `mcp` to `testOnlyEdges.agents` made the exact guard and its 37-test behavioral suite pass.
+
+The pull request OCR posted one actionable finding. It is classified `In-scope-Fix`: the compiled coherence subprocess could block a build indefinitely. A real subprocess regression first failed because no bounded compiled-check API existed. The compiled check now has a 120-second deadline and reports timeout, spawn, signal, and missing-status failures explicitly. The regression confirms that a child exceeding a short test deadline is terminated and diagnosed. The post-format focused run, including CI remediation coverage, passed 143 tests across 10 files with 294 assertions.
+
+CodeRabbit passed without an actionable inline thread. Its remaining observations are classified as follows:
+
+1. `Reject`: adding docstrings to reach an automated 80% threshold conflicts with the repository rule to add comments sparingly. The touched internal helpers and tests have descriptive names and behavioral coverage.
+2. `Reject`: the Windows symlink concern does not match the fixtures, which explicitly request junctions on Windows rather than privileged directory symlinks.
+3. `Defer`: aggregating multiple disposal failures could improve test-cleanup diagnostics, but it is separate from preserving a complete initialized registry and disposing every test-owned configuration.
+
+Remediation verification was run sequentially. The changed-test audit scanned 2,699 files, 36,166 tests, and 77,909 assertions without an error or finding on the changed coherence test. Lint, typecheck, format, the coordinated build, and the required `stepfun-37` startup smoke passed. The build ended with source and compiled lazy-MCP coherence success. A fresh complete-suite attempt reproduced the same four Darwin ripgrep resolver failures, so the run was stopped once its result was guaranteed nonzero. No issue-owned test failed before the stop.
+
 ## Completion Gate
 
 The issue is complete only when every acceptance criterion has behavioral evidence, focused and full local verification pass on the candidate head, allowed reviews are complete and triaged, all `Blocker-Fix` and `In-scope-Fix` findings are resolved, CI passes on that same head, CodeRabbit threads are resolved, and the pull request is conflict-free with correct ancestry.

--- a/scripts/affected-test-shards.data.json
+++ b/scripts/affected-test-shards.data.json
@@ -78,7 +78,7 @@
     "vscode-ide-companion": ["ide-integration"]
   },
   "testOnlyEdges": {
-    "agents": ["storage"],
+    "agents": ["mcp", "storage"],
     "core": ["providers", "test-utils"],
     "tools": ["storage", "test-utils"],
     "auth": ["test-utils"],

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -23,6 +23,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { messageOf } from './utils/error-guards.ts';
 import { isDeclarationsOnly } from './build_package.ts';
+import { prepareWorkspaceBuild } from './prepare-workspace-build.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
@@ -124,6 +125,22 @@ function sandboxAvailable(): boolean {
   }
 }
 
+export interface CoordinatedWorkspaceBuildOperations {
+  prepare(): void;
+  generate(): void;
+  compile(): void;
+  verify(): void;
+}
+
+export function runCoordinatedWorkspaceBuild(
+  operations: CoordinatedWorkspaceBuildOperations,
+): void {
+  operations.prepare();
+  operations.generate();
+  operations.compile();
+  operations.verify();
+}
+
 function main(): void {
   // npm install if node_modules was removed (e.g. via npm run clean or
   // scripts/clean.ts)
@@ -132,11 +149,29 @@ function main(): void {
   }
 
   // build all workspaces/packages
-  execSync('npm run generate', { stdio: 'inherit', cwd: root });
-  execSync(`npm run build ${workspaceBuildSelector()}`, {
-    stdio: 'inherit',
-    cwd: root,
-  });
+  if (isDeclarationsOnly()) {
+    execSync('npm run generate', { stdio: 'inherit', cwd: root });
+    execSync(`npm run build ${workspaceBuildSelector()}`, {
+      stdio: 'inherit',
+      cwd: root,
+    });
+  } else {
+    runCoordinatedWorkspaceBuild({
+      prepare: () => prepareWorkspaceBuild(root),
+      generate: () =>
+        execSync('npm run generate', { stdio: 'inherit', cwd: root }),
+      compile: () =>
+        execSync(`npm run build ${workspaceBuildSelector()}`, {
+          stdio: 'inherit',
+          cwd: root,
+        }),
+      verify: () =>
+        execSync('bun scripts/verify-lazy-mcp-build-coherence.ts', {
+          stdio: 'inherit',
+          cwd: root,
+        }),
+    });
+  }
 
   // also build container image if sandboxing is enabled
   // skip (-s) npm install + build since we did that above

--- a/scripts/prepare-workspace-build.ts
+++ b/scripts/prepare-workspace-build.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { argv } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { verifyBunWorkspaceLinks } from './verify-bun-workspace-links.ts';
+
+function readWorkspaceDirectories(repoRoot: string): readonly string[] {
+  const manifest: unknown = JSON.parse(
+    readFileSync(resolve(repoRoot, 'package.json'), 'utf8'),
+  );
+  if (typeof manifest !== 'object' || manifest === null) {
+    throw new Error('Root package.json must contain a JSON object.');
+  }
+  const workspaces = Reflect.get(manifest, 'workspaces');
+  if (!Array.isArray(workspaces) || workspaces.length === 0) {
+    throw new Error('Root package.json must declare a non-empty `workspaces`.');
+  }
+  if (!workspaces.every((entry) => typeof entry === 'string')) {
+    throw new Error('Root package.json `workspaces` entries must be strings.');
+  }
+  return workspaces;
+}
+
+export function prepareWorkspaceBuild(repoRoot: string): void {
+  const failures = verifyBunWorkspaceLinks(repoRoot);
+  if (failures.length > 0) {
+    throw new Error(failures.join('\n'));
+  }
+
+  for (const workspaceDir of new Set(readWorkspaceDirectories(repoRoot))) {
+    rmSync(resolve(repoRoot, workspaceDir, 'dist'), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+function main(): void {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  prepareWorkspaceBuild(repoRoot);
+}
+
+if (argv[1] && resolve(argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/tests/issue-2983-declaration-build.test.ts
+++ b/scripts/tests/issue-2983-declaration-build.test.ts
@@ -277,9 +277,9 @@ describe('issue #2983 — entry-point execution contract', () => {
 
   it('still runs build.ts when it is the entry point', () => {
     // build.ts has no cwd guard — it anchors on import.meta.url and would run
-    // a real build. Emptying PATH makes its first action, `npm run generate`,
-    // fail immediately, so reaching that failure proves `main()` ran without
-    // building anything.
+    // a real build. Declaration mode avoids the full-build preclean, while an
+    // empty PATH makes `npm run generate` fail immediately. Reaching that
+    // failure proves `main()` ran without mutating shared workspace output.
     const emptyPath = mkdtempSync(join(tmpdir(), 'issue-2983-nopath-'));
     try {
       const result = spawnSync(
@@ -288,7 +288,12 @@ describe('issue #2983 — entry-point execution contract', () => {
         {
           cwd: REPO_ROOT,
           encoding: 'utf8',
-          env: { ...process.env, PATH: emptyPath, Path: emptyPath },
+          env: {
+            ...process.env,
+            [DECLARATIONS_ONLY_ENV]: '1',
+            PATH: emptyPath,
+            Path: emptyPath,
+          },
           timeout: 120_000,
         },
       );

--- a/scripts/tests/prepare-workspace-build.test.ts
+++ b/scripts/tests/prepare-workspace-build.test.ts
@@ -1,0 +1,304 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { runCoordinatedWorkspaceBuild } from '../build.ts';
+import { prepareWorkspaceBuild } from '../prepare-workspace-build.ts';
+
+interface WorkspaceFixture {
+  readonly path: string;
+  readonly name: string;
+}
+
+const fixtureRoots: string[] = [];
+
+function addWorkspace(root: string, workspace: WorkspaceFixture): string {
+  const workspaceDir = resolve(root, workspace.path);
+  mkdirSync(join(workspaceDir, 'dist'), { recursive: true });
+  writeFileSync(
+    join(workspaceDir, 'package.json'),
+    JSON.stringify({ name: workspace.name }),
+  );
+  writeFileSync(join(workspaceDir, 'dist', 'stale.js'), 'stale');
+  const link = join(root, 'node_modules', workspace.name);
+  mkdirSync(dirname(link), { recursive: true });
+  symlinkSync(
+    workspaceDir,
+    link,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+  return workspaceDir;
+}
+
+function createFixture(
+  workspaces: unknown,
+  workspaceFixtures: readonly WorkspaceFixture[] = [],
+): string {
+  const container = mkdtempSync(join(tmpdir(), 'prepare-workspace-build-'));
+  fixtureRoots.push(container);
+  const root = join(container, 'repo');
+  mkdirSync(root);
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'fixture', private: true, workspaces }),
+  );
+
+  for (const workspace of workspaceFixtures) {
+    addWorkspace(root, workspace);
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of fixtureRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('prepareWorkspaceBuild', () => {
+  it('removes every declared workspace dist before returning', () => {
+    const workspaces = [
+      { path: 'packages/alpha', name: '@fixture/alpha' },
+      { path: 'packages/beta', name: '@fixture/beta' },
+    ] as const;
+    const root = createFixture(
+      workspaces.map(({ path }) => path),
+      workspaces,
+    );
+
+    prepareWorkspaceBuild(root);
+
+    expect(
+      workspaces.map(({ path }) => existsSync(join(root, path, 'dist'))),
+    ).toEqual([false, false]);
+  });
+
+  it('coordinates preparation, generation, compilation, and verification in order', () => {
+    const effects: string[] = [];
+
+    runCoordinatedWorkspaceBuild({
+      prepare: () => effects.push('prepared'),
+      generate: () => effects.push('generated'),
+      compile: () => effects.push('compiled'),
+      verify: () => effects.push('verified'),
+    });
+
+    expect(effects).toEqual(['prepared', 'generated', 'compiled', 'verified']);
+  });
+
+  it('stops the coordinated build when preparation fails', () => {
+    const effects: string[] = [];
+
+    expect(() =>
+      runCoordinatedWorkspaceBuild({
+        prepare: () => {
+          effects.push('prepare-attempted');
+          throw new Error('workspace gate failed');
+        },
+        generate: () => effects.push('generated'),
+        compile: () => effects.push('compiled'),
+        verify: () => effects.push('verified'),
+      }),
+    ).toThrow('workspace gate failed');
+    expect(effects).toEqual(['prepare-attempted']);
+  });
+
+  it('propagates generation failures after preparation and stops fanout', () => {
+    const effects: string[] = [];
+
+    expect(() =>
+      runCoordinatedWorkspaceBuild({
+        prepare: () => effects.push('prepared'),
+        generate: () => {
+          effects.push('generate-attempted');
+          throw new Error('generation failed');
+        },
+        compile: () => effects.push('compiled'),
+        verify: () => effects.push('verified'),
+      }),
+    ).toThrow('generation failed');
+    expect(effects).toEqual(['prepared', 'generate-attempted']);
+  });
+
+  it('propagates compilation failures and skips verification', () => {
+    const effects: string[] = [];
+
+    expect(() =>
+      runCoordinatedWorkspaceBuild({
+        prepare: () => effects.push('prepared'),
+        generate: () => effects.push('generated'),
+        compile: () => {
+          effects.push('compile-attempted');
+          throw new Error('compilation failed');
+        },
+        verify: () => effects.push('verified'),
+      }),
+    ).toThrow('compilation failed');
+    expect(effects).toEqual(['prepared', 'generated', 'compile-attempted']);
+  });
+
+  it('keeps the build:packages entry point in the coordinated order', () => {
+    const repoRoot = join(__dirname, '..', '..');
+    const rootPackage: unknown = JSON.parse(
+      readFileSync(join(repoRoot, 'package.json'), 'utf8'),
+    );
+    if (typeof rootPackage !== 'object' || rootPackage === null) {
+      throw new Error('Expected root package.json to contain an object.');
+    }
+    const scripts = Reflect.get(rootPackage, 'scripts');
+    if (typeof scripts !== 'object' || scripts === null) {
+      throw new Error(
+        'Expected root package.json scripts to contain an object.',
+      );
+    }
+    const buildPackages = Reflect.get(scripts, 'build:packages');
+    if (typeof buildPackages !== 'string') {
+      throw new Error('Expected a build:packages script.');
+    }
+
+    expect(buildPackages.split(' && ')).toEqual([
+      'bun scripts/prepare-workspace-build.ts',
+      'npm run generate',
+      'npm run build --workspaces',
+      'bun scripts/verify-lazy-mcp-build-coherence.ts',
+    ]);
+  });
+
+  it('runs the installed workspace-link gate before deleting output', () => {
+    const workspaces = [
+      { path: 'packages/alpha', name: '@fixture/alpha' },
+    ] as const;
+    const root = createFixture(
+      workspaces.map(({ path }) => path),
+      workspaces,
+    );
+    rmSync(join(root, 'node_modules', '@fixture', 'alpha'));
+
+    expect(() => prepareWorkspaceBuild(root)).toThrow(
+      /no node_modules entry.*@fixture\/alpha/s,
+    );
+    expect(existsSync(join(root, 'packages/alpha/dist/stale.js'))).toBe(true);
+  });
+
+  it('rejects a path-shaped package name without deleting output', () => {
+    const workspace = { path: 'packages/alpha', name: '@fixture/alpha' };
+    const root = createFixture([workspace.path], [workspace]);
+    writeFileSync(
+      join(root, workspace.path, 'package.json'),
+      JSON.stringify({ name: '../packages/alpha' }),
+    );
+    rmSync(join(root, 'node_modules', '@fixture', 'alpha'));
+
+    expect(() => prepareWorkspaceBuild(root)).toThrow(/invalid package name/i);
+    expect(existsSync(join(root, workspace.path, 'dist', 'stale.js'))).toBe(
+      true,
+    );
+  });
+
+  it('rejects an empty workspace entry without deleting repository output', () => {
+    const root = createFixture(['']);
+    const marker = join(root, 'dist', 'keep.js');
+    mkdirSync(dirname(marker), { recursive: true });
+    writeFileSync(marker, 'keep');
+
+    expect(() => prepareWorkspaceBuild(root)).toThrow(/empty/i);
+    expect(existsSync(marker)).toBe(true);
+  });
+
+  it('rejects an absolute workspace entry without deleting outside output', () => {
+    const root = createFixture([]);
+    const outside = addWorkspace(root, {
+      path: '../absolute-outside',
+      name: '@fixture/absolute-outside',
+    });
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({
+        name: 'fixture',
+        private: true,
+        workspaces: [outside],
+      }),
+    );
+
+    expect(() => prepareWorkspaceBuild(root)).toThrow(/absolute/i);
+    expect(existsSync(join(outside, 'dist', 'stale.js'))).toBe(true);
+  });
+
+  it('rejects traversal without deleting outside output', () => {
+    const root = createFixture(
+      ['../traversal-outside'],
+      [
+        {
+          path: '../traversal-outside',
+          name: '@fixture/traversal-outside',
+        },
+      ],
+    );
+    const marker = join(dirname(root), 'traversal-outside', 'dist', 'stale.js');
+
+    expect(() => prepareWorkspaceBuild(root)).toThrow(/child|repository/i);
+    expect(existsSync(marker)).toBe(true);
+  });
+
+  it('rejects a workspace link that escapes the checkout without deleting outside output', () => {
+    const root = createFixture([]);
+    const outside = addWorkspace(root, {
+      path: '../linked-outside',
+      name: '@fixture/linked-outside',
+    });
+    const workspaceLink = join(root, 'packages', 'linked-outside');
+    mkdirSync(dirname(workspaceLink), { recursive: true });
+    symlinkSync(
+      outside,
+      workspaceLink,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({
+        name: 'fixture',
+        private: true,
+        workspaces: ['packages/linked-outside'],
+      }),
+    );
+
+    expect(() => prepareWorkspaceBuild(root)).toThrow(
+      /outside the repository/i,
+    );
+    expect(existsSync(join(outside, 'dist', 'stale.js'))).toBe(true);
+  });
+
+  for (const malformed of [
+    { label: 'missing', manifest: undefined },
+    { label: 'empty', manifest: [] },
+    { label: 'non-array', manifest: 'packages/alpha' },
+    { label: 'glob-based', manifest: ['packages/*'] },
+  ] as const) {
+    it(`rejects a ${malformed.label} workspace declaration`, () => {
+      const root = createFixture(malformed.manifest);
+      if (malformed.manifest === undefined) {
+        writeFileSync(
+          join(root, 'package.json'),
+          JSON.stringify({ name: 'fixture', private: true }),
+        );
+      }
+
+      expect(() => prepareWorkspaceBuild(root)).toThrow(/workspaces|glob/i);
+    });
+  }
+});

--- a/scripts/tests/publish-dependency-helpers.ts
+++ b/scripts/tests/publish-dependency-helpers.ts
@@ -42,6 +42,7 @@ import { join, resolve } from 'node:path';
 /** The dependency sections of a package.json manifest. */
 export interface ManifestDependencies {
   readonly dependencies?: Record<string, string>;
+  readonly devDependencies?: Record<string, string>;
   readonly optionalDependencies?: Record<string, string>;
   readonly peerDependencies?: Record<string, string>;
 }
@@ -227,13 +228,42 @@ export interface WorkspaceDependencyEntry {
   readonly kind: DependencyKind;
 }
 
+export type DeclaredDependencySection =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'optionalDependencies'
+  | 'peerDependencies';
+
+export interface DeclaredWorkspaceDependencyEntry {
+  readonly name: string;
+  readonly version: string;
+  readonly section: DeclaredDependencySection;
+}
+
+export function* iterateDeclaredWorkspaceDependencies(
+  manifest: ManifestDependencies,
+): Generator<DeclaredWorkspaceDependencyEntry> {
+  const sections: ReadonlyArray<
+    readonly [DeclaredDependencySection, Record<string, string>]
+  > = [
+    ['dependencies', manifest.dependencies ?? {}],
+    ['devDependencies', manifest.devDependencies ?? {}],
+    ['optionalDependencies', manifest.optionalDependencies ?? {}],
+    ['peerDependencies', manifest.peerDependencies ?? {}],
+  ];
+  for (const [section, dependencies] of sections) {
+    for (const [name, version] of Object.entries(dependencies)) {
+      yield { name, version, section };
+    }
+  }
+}
+
 /**
  * Shared manifest-derived internal dependency iterator (F11).
  *
- * Yields every dependency declared in a workspace manifest — both mandatory
- * (`dependencies`) and optional (`optionalDependencies`) — without any naming
- * prefix filtering. Callers that need to identify internal packages must do so
- * against a manifest-derived set, never by name prefix.
+ * Yields every runtime dependency declared in a workspace manifest without any
+ * naming prefix filtering. Callers that need to identify internal packages must
+ * do so against a manifest-derived set, never by name prefix.
  *
  * This replaces the duplicated per-section loops in checkWorkspaceDependencies
  * with a single cohesive abstraction.

--- a/scripts/tests/publish-dependency-protocols.test.ts
+++ b/scripts/tests/publish-dependency-protocols.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect } from 'bun:test';
 import {
   checkDependencyCoverage,
   checkWorkspaceDependencies,
+  iterateDeclaredWorkspaceDependencies,
   iterateWorkspaceDependencies,
   detectRootDuplicateDependencies,
   isRootSectionAdequate,
@@ -213,6 +214,42 @@ describe('#2352 F6: detectRootDuplicateDependencies — duplicate root dependenc
     const dups = detectRootDuplicateDependencies(root);
     expect(dups).toHaveLength(1);
     expect(dups[0].sections.length).toBe(3);
+  });
+});
+
+describe('#3269: declared internal workspace dependency coverage', () => {
+  it('iterates dependencies, devDependencies, optionalDependencies, and peerDependencies', () => {
+    const manifest: ManifestDependencies = {
+      dependencies: { '@fixture/runtime': 'file:../runtime' },
+      devDependencies: { '@fixture/test-utils': 'file:../test-utils' },
+      optionalDependencies: { '@fixture/optional': 'file:../optional' },
+      peerDependencies: { '@fixture/peer': 'file:../peer' },
+    };
+
+    const entries = Array.from(iterateDeclaredWorkspaceDependencies(manifest));
+
+    expect(entries).toEqual([
+      {
+        name: '@fixture/runtime',
+        version: 'file:../runtime',
+        section: 'dependencies',
+      },
+      {
+        name: '@fixture/test-utils',
+        version: 'file:../test-utils',
+        section: 'devDependencies',
+      },
+      {
+        name: '@fixture/optional',
+        version: 'file:../optional',
+        section: 'optionalDependencies',
+      },
+      {
+        name: '@fixture/peer',
+        version: 'file:../peer',
+        section: 'peerDependencies',
+      },
+    ]);
   });
 });
 

--- a/scripts/tests/publish-integrity.test.ts
+++ b/scripts/tests/publish-integrity.test.ts
@@ -15,6 +15,8 @@ import {
   createRealProtocolResolver,
   deriveShippedWorkspaceDirs,
   detectRootDuplicateDependencies,
+  isProtocolSpecifier,
+  iterateDeclaredWorkspaceDependencies,
   iterateWorkspaceDependencies,
 } from './publish-dependency-helpers.ts';
 import {
@@ -508,6 +510,55 @@ describe('published package no-compile runtime contract (S6)', () => {
     // gitCommitInfo loader. The root prepack hook must generate it so
     // `npm pack` always includes it.
     expect(packed.has('packages/cli/src/generated/git-commit.json')).toBe(true);
+  });
+
+  it('targets every declared internal dependency at its exact workspace', () => {
+    const rootPackage = asRecord(
+      JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8')),
+    );
+    const declaredWorkspaces = Reflect.get(rootPackage, 'workspaces');
+    if (!Array.isArray(declaredWorkspaces)) {
+      throw new Error('Root package.json must declare workspaces.');
+    }
+    const workspaceDirs = declaredWorkspaces.map(asString);
+    const packageNameToDir = buildPackageNameToWorkspaceMap(
+      repoRoot,
+      workspaceDirs,
+    );
+    const protocolResolver = createRealProtocolResolver(
+      repoRoot,
+      packageNameToDir,
+    );
+
+    const mismatches = workspaceDirs.flatMap((workspaceDir) => {
+      const manifest = asRecord(
+        JSON.parse(
+          readFileSync(join(repoRoot, workspaceDir, 'package.json'), 'utf-8'),
+        ),
+      );
+      return Array.from(iterateDeclaredWorkspaceDependencies(manifest))
+        .filter(({ name }) => packageNameToDir.has(name))
+        .flatMap(({ name, version, section }) => {
+          if (!isProtocolSpecifier(version)) {
+            return [
+              `${workspaceDir} ${section}.${name} must use a local protocol; found "${version}"`,
+            ];
+          }
+          const resolution = protocolResolver(name, version, workspaceDir);
+          return resolution.resolved
+            ? []
+            : [
+                `${workspaceDir} ${section}.${name} does not resolve to ${packageNameToDir.get(name)}`,
+              ];
+        });
+    });
+
+    expect(
+      mismatches,
+      'Declared internal dependencies must resolve from each consumer to the ' +
+        'exact workspace whose manifest declares the dependency name:\n  - ' +
+        mismatches.join('\n  - '),
+    ).toEqual([]);
   });
 
   it('declares runtime dependencies needed by shipped workspace source', () => {

--- a/scripts/tests/verify-bun-workspace-links.test.ts
+++ b/scripts/tests/verify-bun-workspace-links.test.ts
@@ -209,6 +209,22 @@ describe.skipIf(isWindows)('verifyBunWorkspaceLinks', () => {
     expect(failures[0]).toMatch(/@fixture\/core/);
   });
 
+  it('rejects a path-shaped workspace package name before alias resolution', () => {
+    const dir = buildFixture({
+      specs: [
+        { path: 'packages/core', name: '../packages/core', link: 'missing' },
+      ],
+    });
+
+    const failures = runIn(dir);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toStartWith(
+      'Declared workspace(s) have invalid or unreadable package metadata:',
+    );
+    expect(failures[0]).toMatch(/invalid package name/);
+    expect(failures[0]).toMatch(/packages\/core/);
+  });
+
   it('rejects a same-named registry copy that is not the local workspace', () => {
     // A bare existence check would accept this; the realpath comparison must
     // detect that node_modules/<name> resolves to a registry copy instead of
@@ -251,7 +267,9 @@ describe.skipIf(isWindows)('verifyBunWorkspaceLinks', () => {
 
     const failures = runIn(dir);
     expect(failures).toHaveLength(1);
-    expect(failures[0]).toMatch(/Could not parse package\.json/);
+    expect(failures[0]).toStartWith(
+      'Declared workspace(s) have invalid or unreadable package metadata:',
+    );
     expect(failures[0]).toMatch(/packages\/core/);
   });
 });

--- a/scripts/tests/verify-lazy-mcp-build-coherence.test.ts
+++ b/scripts/tests/verify-lazy-mcp-build-coherence.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { verifySourceLazyMcpCoherence } from '../verify-lazy-mcp-build-coherence.ts';
+
+describe('lazy-MCP build coherence', () => {
+  it('synchronizes activation against a real deferred source registry', async () => {
+    await expect(verifySourceLazyMcpCoherence()).resolves.toBeUndefined();
+  });
+});

--- a/scripts/tests/verify-lazy-mcp-build-coherence.test.ts
+++ b/scripts/tests/verify-lazy-mcp-build-coherence.test.ts
@@ -5,10 +5,41 @@
  */
 
 import { describe, expect, it } from 'bun:test';
-import { verifySourceLazyMcpCoherence } from '../verify-lazy-mcp-build-coherence.ts';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import {
+  verifyCompiledLazyMcpCoherence,
+  verifySourceLazyMcpCoherence,
+} from '../verify-lazy-mcp-build-coherence.ts';
 
 describe('lazy-MCP build coherence', () => {
   it('synchronizes activation against a real deferred source registry', async () => {
     await expect(verifySourceLazyMcpCoherence()).resolves.toBeUndefined();
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'terminates and diagnoses a compiled check that exceeds its deadline',
+    () => {
+      const binDir = mkdtempSync(join(tmpdir(), 'lazy-mcp-node-'));
+      const nodePath = join(binDir, 'node');
+      writeFileSync(nodePath, '#!/bin/sh\nexec sleep 5\n');
+      chmodSync(nodePath, 0o755);
+      const originalPath = process.env.PATH;
+      process.env.PATH = `${binDir}${delimiter}${originalPath ?? ''}`;
+
+      try {
+        expect(() => verifyCompiledLazyMcpCoherence(process.cwd(), 50)).toThrow(
+          /timed out after 50 ms.*signal SIGTERM/,
+        );
+      } finally {
+        if (originalPath === undefined) {
+          delete process.env.PATH;
+        } else {
+          process.env.PATH = originalPath;
+        }
+        rmSync(binDir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/scripts/verify-bun-workspace-links.ts
+++ b/scripts/verify-bun-workspace-links.ts
@@ -20,9 +20,54 @@
  */
 
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { argv } from 'node:process';
 import { fileURLToPath } from 'node:url';
+
+const PACKAGE_NAME_PATTERN =
+  /^(?:@[A-Za-z0-9][A-Za-z0-9._-]*\/)?[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function escapesDirectory(parent: string, candidate: string): boolean {
+  const relativePath = relative(parent, candidate);
+  return (
+    relativePath === '' ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  );
+}
+
+function invalidWorkspacePath(
+  workspace: string,
+  repoRoot: string,
+  realRepoRoot: string,
+): string | undefined {
+  if (workspace.trim() === '') {
+    return `${JSON.stringify(workspace)} is empty`;
+  }
+  if (isAbsolute(workspace)) {
+    return `${JSON.stringify(workspace)} is absolute`;
+  }
+
+  const workspacePath = resolve(repoRoot, workspace);
+  if (escapesDirectory(resolve(repoRoot), workspacePath)) {
+    return `${JSON.stringify(workspace)} does not name a child of the repository`;
+  }
+
+  try {
+    const realWorkspacePath = realpathSync(workspacePath);
+    if (escapesDirectory(realRepoRoot, realWorkspacePath)) {
+      return (
+        `${JSON.stringify(workspace)} resolves outside the repository to ` +
+        realWorkspacePath
+      );
+    }
+  } catch {
+    // Missing and broken workspace paths receive the existing precise
+    // package.json/link diagnostics below.
+  }
+  return undefined;
+}
 
 /**
  * Parses the root manifest once, runs every workspace-link check, and returns
@@ -32,7 +77,7 @@ import { fileURLToPath } from 'node:url';
  *
  * @returns {{ failures: string[], workspaceCount: number }}
  */
-function collectWorkspaceLinkResults() {
+function collectWorkspaceLinkResults(repoRoot: string) {
   // The authoritative set verified here is every workspace DECLARED in
   // package.json's `workspaces` array (an explicit list of paths, no globs).
   // Each declared workspace must be locally linked by the package manager.
@@ -42,7 +87,7 @@ function collectWorkspaceLinkResults() {
   // unhandled SyntaxError/ENOENT that crashes with a raw stack trace.
   let root;
   try {
-    root = JSON.parse(readFileSync('package.json', 'utf8'));
+    root = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8'));
   } catch (err) {
     return {
       failures: [
@@ -92,7 +137,32 @@ function collectWorkspaceLinkResults() {
     };
   }
 
-  const results = workspaces.map((ws) => classifyWorkspaceLink(ws));
+  let realRepoRoot: string;
+  try {
+    realRepoRoot = realpathSync(repoRoot);
+  } catch (err) {
+    return {
+      failures: [
+        'Could not resolve repository root: ' +
+          (err instanceof Error ? err.message : String(err)),
+      ],
+      workspaceCount: workspaces.length,
+    };
+  }
+  const invalidPaths = workspaces
+    .map((workspace) => invalidWorkspacePath(workspace, repoRoot, realRepoRoot))
+    .filter((problem): problem is string => problem !== undefined);
+  if (invalidPaths.length > 0) {
+    return {
+      failures: [
+        'package.json `workspaces` must name concrete directories inside the repository:\n  - ' +
+          invalidPaths.join('\n  - '),
+      ],
+      workspaceCount: workspaces.length,
+    };
+  }
+
+  const results = workspaces.map((ws) => classifyWorkspaceLink(ws, repoRoot));
   return summarizeLinkResults(results, workspaces.length);
 }
 
@@ -106,8 +176,11 @@ function collectWorkspaceLinkResults() {
  * @param {string} ws - A workspace directory path declared in package.json.
  * @returns {{ category: string, detail: string }}
  */
-function classifyWorkspaceLink(ws: string): WorkspaceLinkResult {
-  const wpkgPath = `${ws}/package.json`;
+function classifyWorkspaceLink(
+  ws: string,
+  repoRoot: string,
+): WorkspaceLinkResult {
+  const wpkgPath = resolve(repoRoot, ws, 'package.json');
   if (!existsSync(wpkgPath)) {
     return { category: 'missingPkgJson', detail: ws };
   }
@@ -115,7 +188,7 @@ function classifyWorkspaceLink(ws: string): WorkspaceLinkResult {
   // entry/workspace directory, can throw (corrupt JSON, broken symlink,
   // ELOOP). Funnel those into the diagnostic list so the verifier keeps its
   // "collect failures -> exit 1" contract instead of throwing mid-loop.
-  let wpkg;
+  let wpkg: unknown;
   try {
     wpkg = JSON.parse(readFileSync(wpkgPath, 'utf8'));
   } catch (err) {
@@ -124,20 +197,33 @@ function classifyWorkspaceLink(ws: string): WorkspaceLinkResult {
       detail: `${ws}: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
-  const entry = `node_modules/${wpkg.name}`;
+  const packageName =
+    typeof wpkg === 'object' && wpkg !== null
+      ? Reflect.get(wpkg, 'name')
+      : undefined;
+  if (
+    typeof packageName !== 'string' ||
+    !PACKAGE_NAME_PATTERN.test(packageName)
+  ) {
+    return {
+      category: 'malformed',
+      detail: `${ws}: invalid package name ${JSON.stringify(packageName)}`,
+    };
+  }
+  const entry = resolve(repoRoot, 'node_modules', packageName);
   if (!existsSync(entry)) {
-    return { category: 'missing', detail: `${ws} (${wpkg.name})` };
+    return { category: 'missing', detail: `${ws} (${packageName})` };
   }
   let actual;
   let expected;
   try {
     actual = realpathSync(entry);
-    expected = realpathSync(resolve(ws));
+    expected = realpathSync(resolve(repoRoot, ws));
   } catch (err) {
     return {
       category: 'notLinked',
       detail:
-        `${ws} (${wpkg.name}): could not resolve the node_modules link ` +
+        `${ws} (${packageName}): could not resolve the node_modules link ` +
         `(${err instanceof Error ? err.message : String(err)})`,
     };
   }
@@ -145,7 +231,7 @@ function classifyWorkspaceLink(ws: string): WorkspaceLinkResult {
     return {
       category: 'notLinked',
       detail:
-        `${ws} (${wpkg.name}): node_modules entry resolves to ${actual}, ` +
+        `${ws} (${packageName}): node_modules entry resolves to ${actual}, ` +
         `expected the local workspace at ${expected}`,
     };
   }
@@ -226,7 +312,7 @@ function summarizeLinkResults(
   }
   if (grouped.malformed.length > 0) {
     failures.push(
-      'Could not parse package.json for declared workspace(s):\n  - ' +
+      'Declared workspace(s) have invalid or unreadable package metadata:\n  - ' +
         grouped.malformed.join('\n  - '),
     );
   }
@@ -250,8 +336,8 @@ function summarizeLinkResults(
  * @returns {string[]} A list of human-readable failure messages. Empty when
  *   every declared workspace is locally linked.
  */
-export function verifyBunWorkspaceLinks() {
-  return collectWorkspaceLinkResults().failures;
+export function verifyBunWorkspaceLinks(repoRoot = process.cwd()): string[] {
+  return collectWorkspaceLinkResults(repoRoot).failures;
 }
 
 /**
@@ -260,7 +346,9 @@ export function verifyBunWorkspaceLinks() {
  * the pure check can be unit-tested without spawning a process.
  */
 function main() {
-  const { failures, workspaceCount } = collectWorkspaceLinkResults();
+  const { failures, workspaceCount } = collectWorkspaceLinkResults(
+    process.cwd(),
+  );
   if (failures.length > 0) {
     console.error(failures.join('\n'));
     process.exitCode = 1;

--- a/scripts/verify-lazy-mcp-build-coherence.ts
+++ b/scripts/verify-lazy-mcp-build-coherence.ts
@@ -16,8 +16,10 @@ import {
   type CallableTool,
 } from '@vybestack/llxprt-code-tools';
 import { syncActivateMcpServerTool } from '../packages/core/src/config/mcp-lazy-tool-sync.ts';
+import { isErrnoException, messageOf } from './utils/error-guards.ts';
 
 const SERVER_NAME = 'coherence-server';
+const COMPILED_CHECK_TIMEOUT_MS = 120_000;
 
 function createCallableTool(): CallableTool {
   return {
@@ -82,7 +84,10 @@ export async function verifySourceLazyMcpCoherence(): Promise<void> {
   }
 }
 
-function verifyCompiledLazyMcpCoherence(repoRoot: string): void {
+export function verifyCompiledLazyMcpCoherence(
+  repoRoot: string,
+  timeoutMs = COMPILED_CHECK_TIMEOUT_MS,
+): void {
   const syncModuleUrl = pathToFileURL(
     resolve(repoRoot, 'packages/core/dist/src/config/mcp-lazy-tool-sync.js'),
   ).href;
@@ -129,9 +134,30 @@ function verifyCompiledLazyMcpCoherence(repoRoot: string): void {
   const result = spawnSync('node', ['--input-type=module', '--eval', program], {
     cwd: repoRoot,
     encoding: 'utf8',
+    timeout: timeoutMs,
   });
   if (result.error !== undefined) {
-    throw result.error;
+    const signal = result.signal ?? 'none';
+    if (isErrnoException(result.error, 'ETIMEDOUT')) {
+      throw new Error(
+        `Compiled lazy-MCP coherence check timed out after ${timeoutMs} ms (signal ${signal})`,
+        { cause: result.error },
+      );
+    }
+    throw new Error(
+      `Failed to start compiled lazy-MCP coherence check: ${messageOf(result.error)} (signal ${signal})`,
+      { cause: result.error },
+    );
+  }
+  if (result.signal !== null) {
+    throw new Error(
+      `Compiled lazy-MCP coherence check was terminated by signal ${result.signal}`,
+    );
+  }
+  if (result.status === null) {
+    throw new Error(
+      'Compiled lazy-MCP coherence check exited without a status code',
+    );
   }
   if (result.status !== 0) {
     throw new Error(

--- a/scripts/verify-lazy-mcp-build-coherence.ts
+++ b/scripts/verify-lazy-mcp-build-coherence.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env bun
+
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { DiscoveredMCPTool } from '@vybestack/llxprt-code-mcp';
+import {
+  ACTIVATE_MCP_SERVER_TOOL_NAME,
+  ToolRegistry,
+  type CallableTool,
+} from '@vybestack/llxprt-code-tools';
+import { syncActivateMcpServerTool } from '../packages/core/src/config/mcp-lazy-tool-sync.ts';
+
+const SERVER_NAME = 'coherence-server';
+
+function createCallableTool(): CallableTool {
+  return {
+    async tool() {
+      return {};
+    },
+    async callTool() {
+      return [];
+    },
+  };
+}
+
+function createMessageBus() {
+  return {
+    async requestConfirmation() {
+      return true;
+    },
+  };
+}
+
+export async function verifySourceLazyMcpCoherence(): Promise<void> {
+  const messageBus = createMessageBus();
+  const registry = new ToolRegistry(
+    {
+      getEphemeralSettings: () => ({ 'mcp.lazy': true }),
+    },
+    messageBus,
+  );
+  registry.registerTool(
+    new DiscoveredMCPTool(
+      createCallableTool(),
+      SERVER_NAME,
+      'fixture-tool',
+      'Build coherence fixture',
+      { type: 'object' },
+    ),
+  );
+
+  const deferredBeforeActivation = registry.listDeferredMcpServers();
+  if (
+    deferredBeforeActivation.length !== 1 ||
+    deferredBeforeActivation[0] !== SERVER_NAME
+  ) {
+    throw new Error(
+      `Source registry did not defer ${SERVER_NAME}: ${JSON.stringify(deferredBeforeActivation)}`,
+    );
+  }
+
+  await syncActivateMcpServerTool(registry, messageBus, async () => undefined);
+  if (registry.getTool(ACTIVATE_MCP_SERVER_TOOL_NAME) === undefined) {
+    throw new Error(
+      'Source lazy-MCP synchronization did not register its tool',
+    );
+  }
+
+  registry.activateMcpServer(SERVER_NAME);
+  await syncActivateMcpServerTool(registry, messageBus, async () => undefined);
+  if (registry.getTool(ACTIVATE_MCP_SERVER_TOOL_NAME) !== undefined) {
+    throw new Error(
+      'Source lazy-MCP synchronization left a stale activation tool',
+    );
+  }
+}
+
+function verifyCompiledLazyMcpCoherence(repoRoot: string): void {
+  const syncModuleUrl = pathToFileURL(
+    resolve(repoRoot, 'packages/core/dist/src/config/mcp-lazy-tool-sync.js'),
+  ).href;
+  const program = `
+    import { DiscoveredMCPTool } from '@vybestack/llxprt-code-mcp';
+    import {
+      ACTIVATE_MCP_SERVER_TOOL_NAME,
+      ToolRegistry,
+    } from '@vybestack/llxprt-code-tools';
+    import { syncActivateMcpServerTool } from ${JSON.stringify(syncModuleUrl)};
+
+    const serverName = ${JSON.stringify(SERVER_NAME)};
+    const messageBus = { async requestConfirmation() { return true; } };
+    const registry = new ToolRegistry(
+      { getEphemeralSettings: () => ({ 'mcp.lazy': true }) },
+      messageBus,
+    );
+    registry.registerTool(new DiscoveredMCPTool(
+      { async tool() { return {}; }, async callTool() { return []; } },
+      serverName,
+      'fixture-tool',
+      'Build coherence fixture',
+      { type: 'object' },
+    ));
+
+    const deferred = registry.listDeferredMcpServers();
+    if (deferred.length !== 1 || deferred[0] !== serverName) {
+      throw new Error(
+        'Compiled registry did not defer ' + serverName + ': ' +
+        JSON.stringify(deferred),
+      );
+    }
+    await syncActivateMcpServerTool(registry, messageBus, async () => undefined);
+    if (registry.getTool(ACTIVATE_MCP_SERVER_TOOL_NAME) === undefined) {
+      throw new Error('Compiled lazy-MCP synchronization did not register its tool');
+    }
+    registry.activateMcpServer(serverName);
+    await syncActivateMcpServerTool(registry, messageBus, async () => undefined);
+    if (registry.getTool(ACTIVATE_MCP_SERVER_TOOL_NAME) !== undefined) {
+      throw new Error('Compiled lazy-MCP synchronization left a stale activation tool');
+    }
+  `;
+
+  const result = spawnSync('node', ['--input-type=module', '--eval', program], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Compiled lazy-MCP coherence check failed (${result.status}):\n${result.stderr}`,
+    );
+  }
+}
+
+export async function verifyLazyMcpBuildCoherence(
+  repoRoot = process.cwd(),
+): Promise<void> {
+  await verifySourceLazyMcpCoherence();
+  verifyCompiledLazyMcpCoherence(repoRoot);
+}
+
+if (import.meta.main) {
+  await verifyLazyMcpBuildCoherence();
+  console.log('Verified source and compiled lazy-MCP registry coherence.');
+}


### PR DESCRIPTION
## TLDR

Coordinated full builds now validate every declared workspace alias, remove all workspace `dist` directories before generation or compilation, and verify that source and freshly compiled lazy-MCP paths use the same complete registry API.

The reported agents failure had a separate trigger in test setup. The shared helper replaced an initialized `Config`'s real `ToolRegistry` with a partial object while MCP startup was still active. It now keeps the real registry, overrides only the two query methods tests need, and disposes test-owned configurations.

## Dive Deeper

The build preparation step uses the root literal workspace declaration as its input. Before deleting output, it verifies installed aliases and rejects malformed entries, globs, absolute paths, traversal, repository-root references, path-shaped package names, and realpath escapes through symlinks or junctions. Both `npm run build` and `npm run build:packages` invoke preparation before generation and workspace compilation. Declaration-only builds retain their existing behavior.

Internal dependency coverage now checks `dependencies`, `devDependencies`, `optionalDependencies`, and `peerDependencies`. Each first-party declaration must use a local protocol and resolve from its consumer to the exact workspace whose manifest declares that package name. This includes `@vybestack/llxprt-code` resolving to `packages/cli`.

A post-build coherence program exercises real `ToolRegistry`, `DiscoveredMCPTool`, deferred server activation, activation-tool synchronization, and stale activation-tool removal through both Bun source imports and Node compiled imports. No runtime compatibility guard or fallback was added.

The implementation plan and review record are in `project-plans/issue3269-same-commit-build.md`. Two independent technical reviews and two local Open Code Review rounds were completed. All accepted findings were fixed and all other findings are classified in that record.

## Reviewer Test Plan

1. Run the focused behavioral suite:

   ```bash
   bun test packages/agents/src/core/subagent-test-helpers.test.ts packages/agents/src/core/subagent.create.test.ts scripts/tests/prepare-workspace-build.test.ts scripts/tests/verify-bun-workspace-links.test.ts scripts/tests/verify-lazy-mcp-build-coherence.test.ts scripts/tests/publish-dependency-protocols.test.ts scripts/tests/publish-integrity.test.ts scripts/tests/issue-2983-declaration-build.test.ts scripts/tests/issue-3161-build-config.test.ts
   ```

   Expected result: 105 tests pass across 9 files.

2. Verify installed aliases:

   ```bash
   bun scripts/verify-bun-workspace-links.ts
   ```

   Expected result: all 16 declared workspaces resolve to their repository directories.

3. Run a coordinated build:

   ```bash
   npm run build
   ```

   Expected result: workspace output is removed before compilation and the command ends with `Verified source and compiled lazy-MCP registry coherence.`

4. Run the startup smoke:

   ```bash
   bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
   ```

Local lint, typecheck, format, focused tests, scripts shard, changed-test audit, full build, compiled coherence check, and startup smoke passed. The complete macOS `npm run test` finished nonzero for three files outside this diff. The core ripgrep resolver test found `/opt/homebrew/bin/rg` despite its filesystem reassignment, including when run in isolation. Two agents API files reached their suite timeout in the complete run, then passed together in isolation with 13 tests in 1.96 seconds. The plan records the exact evidence without classifying these failures as pre-existing. CI on this head will provide the repository-wide Linux result.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ⚠️ Focused checks, lint, typecheck, format, build, and smoke passed; full-suite exceptions documented above | ❓ | CI |
| npx      | ❓ | ❓ | ❓ |
| Docker   | ❓ | ❓ | ❓ |
| Podman   | ❓ | - | - |
| Seatbelt | ❓ | - | - |

## Linked issues / bugs

Fixes #3269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build Improvements**
  - Improved package builds with workspace preparation, validation, and consistency checks.
  - Added safeguards for workspace links, dependency declarations, and invalid package metadata.
  - Build steps now run predictably and stop promptly when validation fails.

- **Reliability**
  - Added verification that lazy MCP functionality remains consistent between source and compiled builds.
  - Improved cleanup and lifecycle handling in test configurations.

- **Tests**
  - Expanded coverage for workspace preparation, build coordination, dependency integrity, and MCP lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->