### PR TITLE
Collapse the two divergent JIT-context predicates (Fixes #3135)

### DIFF
--- a/packages/agents/src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts
+++ b/packages/agents/src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts
@@ -141,8 +141,15 @@ interface ChannelBreakdown {
   readonly environmentIsPrefix: boolean;
   readonly environmentOccurrences: number;
   readonly promptBodyOccurrences: number;
+  readonly totalOccurrences: number;
 }
 
+/**
+ * The two channel counts plus the whole-instruction count. Asserting all three
+ * together makes the split self-validating: if the prefix partition ever stops
+ * matching how buildSystemInstruction joins the parts, the numbers no longer
+ * add up and the assertion fails instead of quietly misattributing a copy.
+ */
 function breakDownChannels(
   assembled: AssembledRequest,
   marker: string,
@@ -153,6 +160,7 @@ function breakDownChannels(
     ),
     environmentOccurrences: occurrencesOf(assembled.environmentContext, marker),
     promptBodyOccurrences: occurrencesOf(assembled.promptBody, marker),
+    totalOccurrences: occurrencesOf(assembled.full, marker),
   };
 }
 
@@ -205,10 +213,16 @@ describe('assembled system instruction carries workspace memory exactly once (is
 
   afterEach(async () => {
     const configs = openConfigs.splice(0, openConfigs.length);
-    await Promise.all(configs.map((config) => config.dispose()));
     const dirs = tempDirs.splice(0, tempDirs.length);
-    for (const dir of dirs) {
-      fs.rmSync(dir, { recursive: true, force: true });
+    // A rejecting dispose still propagates, but the temp directories are
+    // removed either way so a disposal failure cannot leak them into later
+    // tests.
+    try {
+      await Promise.all(configs.map((config) => config.dispose()));
+    } finally {
+      for (const dir of dirs) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     }
   });
 
@@ -235,6 +249,7 @@ describe('assembled system instruction carries workspace memory exactly once (is
       environmentIsPrefix: true,
       environmentOccurrences: 1,
       promptBodyOccurrences: 0,
+      totalOccurrences: 1,
     });
   });
 
@@ -250,6 +265,7 @@ describe('assembled system instruction carries workspace memory exactly once (is
       environmentIsPrefix: true,
       environmentOccurrences: 0,
       promptBodyOccurrences: 1,
+      totalOccurrences: 1,
     });
   });
 });

--- a/packages/agents/src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts
+++ b/packages/agents/src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts
@@ -1,0 +1,255 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Single-send invariant for workspace memory (issue #3135).
+ *
+ * Two channels can carry the workspace LLXPRT.md hierarchy into a request: the
+ * environment-context block (Config.getEnvironmentMemory) and the user-memory
+ * channel (Config.getGlobalMemory or Config.getUserMemory). Which branch each
+ * takes is decided by the JIT-context predicate, so "exactly once" holds only
+ * while there is a single predicate.
+ *
+ * Nothing in the memory path is substituted: a real LLXPRT.md on disk, a real
+ * Config, a real ContextManager, real memory discovery, and the real
+ * getEnvironmentContext + buildSystemInstruction. The marker literal exists
+ * only on the input side; every assertion is a derived occurrence count.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { randomUUID } from 'node:crypto';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { initializeTestConfig } from '@vybestack/llxprt-code-core/test-utils/config.js';
+import { getEnvironmentContext } from '@vybestack/llxprt-code-core/utils/environmentContext.js';
+import { loadServerHierarchicalMemory } from '@vybestack/llxprt-code-core/utils/memoryDiscovery.js';
+import { initializePromptSystem } from '@vybestack/llxprt-code-core/core/prompts.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { buildSystemInstruction } from './ChatSessionFactory.js';
+
+// A literal, not an import: the provider-agnostic naming regression suite
+// forbids provider-prefixed identifiers outside provider boundaries.
+const MODEL = 'gemini-2.5-flash';
+
+interface Workspace {
+  readonly dir: string;
+  readonly marker: string;
+}
+
+const tempDirs: string[] = [];
+const openConfigs: Config[] = [];
+
+function createWorkspace(): Workspace {
+  const dir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'llxprt-jit-once-')),
+  );
+  tempDirs.push(dir);
+  // Unique per workspace so the developer's real global memory, which the real
+  // loaders also read, can never contribute an occurrence.
+  const marker = `WORKSPACE_MEMORY_${randomUUID().replace(/-/g, '')}`;
+  fs.writeFileSync(
+    path.join(dir, 'LLXPRT.md'),
+    `# Workspace instructions\n\n${marker}\n`,
+    'utf8',
+  );
+  return { dir, marker };
+}
+
+function occurrencesOf(haystack: string, token: string): number {
+  return haystack.split(token).length - 1;
+}
+
+async function buildWorkspaceConfig(
+  workspace: Workspace,
+  options: {
+    readonly jitContextEnabled: boolean;
+    readonly settingsJitContextEnabled?: boolean;
+  },
+): Promise<Config> {
+  const settingsService = new SettingsService();
+  if (options.settingsJitContextEnabled !== undefined) {
+    // No production code writes this key. Supplying it proves the predicate
+    // cannot be steered by it; before issue #3135 a second predicate read it,
+    // which is how the two predicates could disagree.
+    settingsService.set('jitContextEnabled', options.settingsJitContextEnabled);
+  }
+
+  const config = new Config({
+    sessionId: `jit-once-${randomUUID()}`,
+    model: MODEL,
+    targetDir: workspace.dir,
+    cwd: workspace.dir,
+    debugMode: false,
+    jitContextEnabled: options.jitContextEnabled,
+    settingsService,
+  });
+  openConfigs.push(config);
+  await initializeTestConfig(config);
+
+  if (!options.jitContextEnabled) {
+    // The production non-JIT path: eagerly load the hierarchy and push it onto
+    // Config, as environmentLoader.resolveMemoryContent and
+    // memoryCommand.refreshMemoryContent do in the CLI.
+    const eager = await loadServerHierarchicalMemory(
+      config.getWorkingDir(),
+      [],
+      config.getDebugMode(),
+      config.getFileService(),
+      config.getExtensions(),
+      true,
+    );
+    config.setUserMemory(eager.memoryContent);
+    config.setLlxprtMdFileCount(eager.fileCount);
+    config.setLlxprtMdFilePaths(eager.filePaths);
+  }
+
+  return config;
+}
+
+interface AssembledRequest {
+  readonly environmentContext: string;
+  readonly promptBody: string;
+  readonly full: string;
+}
+
+/**
+ * Assembles the system instruction the way ChatSessionFactory.createChatSession
+ * does, then splits it back into its two memory-carrying channels.
+ */
+async function assembleRequest(config: Config): Promise<AssembledRequest> {
+  const envParts = await getEnvironmentContext(config);
+  const environmentContext = envParts.map((part) => part.text).join('\n');
+  const full = await buildSystemInstruction(
+    config,
+    [],
+    envParts,
+    undefined,
+    MODEL,
+  );
+  return {
+    environmentContext,
+    promptBody: full.slice(environmentContext.length),
+    full,
+  };
+}
+
+interface ChannelBreakdown {
+  readonly environmentIsPrefix: boolean;
+  readonly environmentOccurrences: number;
+  readonly promptBodyOccurrences: number;
+}
+
+function breakDownChannels(
+  assembled: AssembledRequest,
+  marker: string,
+): ChannelBreakdown {
+  return {
+    environmentIsPrefix: assembled.full.startsWith(
+      assembled.environmentContext,
+    ),
+    environmentOccurrences: occurrencesOf(assembled.environmentContext, marker),
+    promptBodyOccurrences: occurrencesOf(assembled.promptBody, marker),
+  };
+}
+
+interface Row {
+  readonly name: string;
+  readonly jitContextEnabled: boolean;
+  readonly settingsJitContextEnabled?: boolean;
+}
+
+const ROWS: Row[] = [
+  {
+    name: 'JIT context enabled',
+    jitContextEnabled: true,
+  },
+  {
+    name: 'JIT context disabled',
+    jitContextEnabled: false,
+  },
+  {
+    name: 'JIT context enabled with a conflicting settings-service value',
+    jitContextEnabled: true,
+    settingsJitContextEnabled: false,
+  },
+  {
+    name: 'JIT context disabled with a conflicting settings-service value',
+    jitContextEnabled: false,
+    settingsJitContextEnabled: true,
+  },
+];
+
+describe('assembled system instruction carries workspace memory exactly once (issue #3135)', () => {
+  let originalPromptsDir: string | undefined;
+  let promptsDir: string;
+
+  beforeAll(async () => {
+    originalPromptsDir = process.env.LLXPRT_PROMPTS_DIR;
+    promptsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llxprt-jit-prompts-'));
+    process.env.LLXPRT_PROMPTS_DIR = promptsDir;
+    await initializePromptSystem();
+  });
+
+  afterAll(() => {
+    if (originalPromptsDir === undefined) {
+      delete process.env.LLXPRT_PROMPTS_DIR;
+    } else {
+      process.env.LLXPRT_PROMPTS_DIR = originalPromptsDir;
+    }
+    fs.rmSync(promptsDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    const configs = openConfigs.splice(0, openConfigs.length);
+    await Promise.all(configs.map((config) => config.dispose()));
+    const dirs = tempDirs.splice(0, tempDirs.length);
+    for (const dir of dirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each(ROWS)('$name', async (row) => {
+    const workspace = createWorkspace();
+    const config = await buildWorkspaceConfig(workspace, row);
+
+    const assembled = await assembleRequest(config);
+
+    // Two sends means the hierarchy is paid for in every request; zero means
+    // the workspace instructions never reach the model.
+    expect(occurrencesOf(assembled.full, workspace.marker)).toBe(1);
+  });
+
+  it('carries the workspace hierarchy in the environment channel only, under JIT', async () => {
+    const workspace = createWorkspace();
+    const config = await buildWorkspaceConfig(workspace, {
+      jitContextEnabled: true,
+    });
+
+    const assembled = await assembleRequest(config);
+
+    expect(breakDownChannels(assembled, workspace.marker)).toStrictEqual({
+      environmentIsPrefix: true,
+      environmentOccurrences: 1,
+      promptBodyOccurrences: 0,
+    });
+  });
+
+  it('carries the workspace hierarchy in the user-memory channel only, without JIT', async () => {
+    const workspace = createWorkspace();
+    const config = await buildWorkspaceConfig(workspace, {
+      jitContextEnabled: false,
+    });
+
+    const assembled = await assembleRequest(config);
+
+    expect(breakDownChannels(assembled, workspace.marker)).toStrictEqual({
+      environmentIsPrefix: true,
+      environmentOccurrences: 0,
+      promptBodyOccurrences: 1,
+    });
+  });
+});

--- a/packages/core/src/config/config.d.test.ts
+++ b/packages/core/src/config/config.d.test.ts
@@ -10,7 +10,7 @@ import type { ConfigParameters } from './config.js';
 import { Config, ApprovalMode } from './config.js';
 import type { HookDefinition } from '../hooks/types.js';
 import { HookType, HookEventName } from '../hooks/types.js';
-import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { MCPDiscoveryState } from '@vybestack/llxprt-code-mcp';
 import { initializeTestConfig } from '../test-utils/config.js';
 import {
@@ -297,7 +297,7 @@ describe('Config JIT context', () => {
 
   it('should return true by default when JIT context setting is not provided', () => {
     const config = new Config(baseParams);
-    expect(config.getJitContextEnabled()).toBe(true);
+    expect(config.isJitContextEnabled()).toBe(true);
   });
 
   it('should return the configured JIT context setting value', () => {
@@ -305,31 +305,37 @@ describe('Config JIT context', () => {
       ...baseParams,
       jitContextEnabled: true,
     });
-    expect(configEnabled.getJitContextEnabled()).toBe(true);
+    expect(configEnabled.isJitContextEnabled()).toBe(true);
 
     const configDisabled = new Config({
       ...baseParams,
       jitContextEnabled: false,
     });
-    expect(configDisabled.getJitContextEnabled()).toBe(false);
+    expect(configDisabled.isJitContextEnabled()).toBe(false);
   });
 
-  it('should respect the settings service value when available', async () => {
-    const mockSettingsService = {
-      get: vi.fn().mockReturnValue(false),
-      set: vi.fn(),
-      getAll: vi.fn(),
-      has: vi.fn(),
-    } as unknown as SettingsService;
+  // A `jitContextEnabled` settings-service key is inert: no production code
+  // writes it, and the predicate resolves only from the constructor-assigned
+  // field. Both directions are covered so the assertion cannot pass merely
+  // because the settings value happens to agree (issue #3135).
+  it.each([
+    { constructorValue: true, settingsValue: false },
+    { constructorValue: false, settingsValue: true },
+  ])(
+    'resolves to the constructor value $constructorValue while the settings service holds $settingsValue',
+    ({ constructorValue, settingsValue }) => {
+      const settingsService = new SettingsService();
+      settingsService.set('jitContextEnabled', settingsValue);
 
-    const config = new Config({
-      ...baseParams,
-      settingsService: mockSettingsService,
-    });
+      const config = new Config({
+        ...baseParams,
+        jitContextEnabled: constructorValue,
+        settingsService,
+      });
 
-    expect(config.getJitContextEnabled()).toBe(false);
-    expect(mockSettingsService.get).toHaveBeenCalledWith('jitContextEnabled');
-  });
+      expect(config.isJitContextEnabled()).toBe(constructorValue);
+    },
+  );
 
   describe('getJitMemoryForPath', () => {
     beforeEach(() => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -265,7 +265,7 @@ export class Config extends ConfigBase {
     // @requirement REQ-INV-001
     this.agentClient = clientFactory(this, this.runtimeState);
 
-    if (this.getJitContextEnabled()) {
+    if (this.isJitContextEnabled()) {
       this.contextManager = new ContextManager(this);
       await this.contextManager.refresh();
     }
@@ -507,7 +507,7 @@ export class Config extends ConfigBase {
   }
 
   getUserMemory(): string {
-    if (this.getJitContextEnabled() && this.contextManager) {
+    if (this.isJitContextEnabled() && this.contextManager) {
       return [
         this.contextManager.getGlobalMemory(),
         this.contextManager.getEnvironmentMemory(),
@@ -685,22 +685,13 @@ export class Config extends ConfigBase {
     };
   }
 
-  getJitContextEnabled(): boolean {
-    // Check settings service first, then fall back to instance value
-    const settingsValue = this.settingsService.get('jitContextEnabled');
-    if (settingsValue !== undefined) {
-      return settingsValue as boolean;
-    }
-    return this.jitContextEnabled ?? false;
-  }
-
   /**
    * Lazily loads JIT subdirectory memory for a given path.
    * Returns formatted memory content from LLXPRT.md files found between
    * the target path and the trusted root, excluding already-loaded paths.
    */
   async getJitMemoryForPath(targetPath: string): Promise<string> {
-    if (!this.getJitContextEnabled()) {
+    if (!this.isJitContextEnabled()) {
       return '';
     }
 
@@ -795,7 +786,7 @@ export class Config extends ConfigBase {
     fileCount: number;
     filePaths: string[];
   }> {
-    if (this.getJitContextEnabled() && this.contextManager) {
+    if (this.isJitContextEnabled() && this.contextManager) {
       await this.contextManager.refresh();
       const memoryContent = this.getUserMemory();
       const fileCount = this.getLlxprtMdFileCount();

--- a/packages/core/src/config/configBase.ts
+++ b/packages/core/src/config/configBase.ts
@@ -33,7 +33,6 @@ import {
 export abstract class ConfigBase extends ConfigBaseCore {
   // Abstract methods implemented by Config subclass
   abstract initializeContentGeneratorConfig: () => Promise<void>;
-  abstract getJitContextEnabled(): boolean;
   abstract getExcludeTools(): string[] | undefined;
   abstract getAsyncTaskManager(): AsyncTaskManager | undefined;
   abstract getShellJobManager(): ShellJobManager | undefined;
@@ -70,42 +69,42 @@ export abstract class ConfigBase extends ConfigBaseCore {
   }
 
   getGlobalMemory(): string {
-    if (this.getJitContextEnabled() && this.contextManager) {
+    if (this.isJitContextEnabled() && this.contextManager) {
       return this.contextManager.getGlobalMemory();
     }
     return this.userMemory;
   }
 
   getEnvironmentMemory(): string {
-    if (this.getJitContextEnabled() && this.contextManager) {
+    if (this.isJitContextEnabled() && this.contextManager) {
       return this.contextManager.getEnvironmentMemory();
     }
     return '';
   }
 
   getCoreMemory(): string | undefined {
-    if (this.getJitContextEnabled() && this.contextManager) {
+    if (this.isJitContextEnabled() && this.contextManager) {
       return this.contextManager.getCoreMemory();
     }
     return undefined;
   }
 
   getLlxprtMdFileCount(): number {
-    if (this.getJitContextEnabled() && this.contextManager) {
+    if (this.isJitContextEnabled() && this.contextManager) {
       return this.contextManager.getContextFileCount();
     }
     return this.llxprtMdFileCount;
   }
 
   getCoreMemoryFileCount(): number {
-    if (this.getJitContextEnabled() && this.contextManager) {
+    if (this.isJitContextEnabled() && this.contextManager) {
       return this.contextManager.getCoreMemoryFileCount();
     }
     return 0;
   }
 
   getLlxprtMdFilePaths(): string[] {
-    if (this.getJitContextEnabled() && this.contextManager) {
+    if (this.isJitContextEnabled() && this.contextManager) {
       return Array.from(this.contextManager.getLoadedPaths());
     }
     return this.llxprtMdFilePaths;

--- a/packages/core/src/config/configBaseCore.ts
+++ b/packages/core/src/config/configBaseCore.ts
@@ -620,6 +620,17 @@ export abstract class ConfigBaseCore {
   getApprovalMode(): ApprovalMode {
     return this.approvalMode;
   }
+  /**
+   * The single JIT-context predicate. It resolves from the
+   * constructor-assigned `jitContextEnabled` field and nothing else, so every
+   * consumer (the memory accessors, the ContextManager lifecycle, the prompt
+   * builders and the CLI) observes one answer. A second predicate with a
+   * different resolution order would let the workspace memory hierarchy be
+   * sent twice or not at all (issue #3135).
+   *
+   * The user-facing setting is `experimental.jitContext`, resolved by the CLI
+   * and threaded in as `ConfigParameters.jitContextEnabled`.
+   */
   isJitContextEnabled(): boolean {
     return this.jitContextEnabled === true;
   }

--- a/project-plans/issue3135-jit-context-predicate.md
+++ b/project-plans/issue3135-jit-context-predicate.md
@@ -1,0 +1,216 @@
+# Issue #3135 - Collapse the two divergent JIT-context predicates and remove the dead settings read
+
+## Problem (verified against HEAD, not the issue text)
+
+The issue was filed before the #3173 refactor, so some line references have moved.
+Re-verified inventory on `main`:
+
+| Predicate | Definition | Production callers |
+| --- | --- | --- |
+| `isJitContextEnabled()` | `packages/core/src/config/configBaseCore.ts:623` - `return this.jitContextEnabled === true;` | `packages/agents/src/core/promptMemoryPolicy.ts:39`, `packages/cli/src/ui/commands/memoryCommand.ts:30`, `packages/cli/src/ui/containers/AppContainer/hooks/useMemoryRefreshAction.ts:53`, `packages/cli/src/ui/cliUiRuntime.ts:421,777` |
+| `getJitContextEnabled()` | `packages/core/src/config/config.ts:688` - settings-service read, then `this.jitContextEnabled ?? false` | `config.ts:268,510,703,798`, `configBase.ts:73,80,87,94,101,108` (declared abstract at `configBase.ts:36`) |
+
+`this.settingsService.get('jitContextEnabled')` is a dead read. A repository-wide
+search for that settings key finds only the read itself. The user-facing setting
+is `experimental.jitContext` (`packages/cli/src/config/settings-schema/schema-extensions.ts:297`),
+resolved in `packages/cli/src/config/interactiveContext.ts:227-228` and threaded
+through `configBuilder.ts:307` -> `ConfigParameters.jitContextEnabled` ->
+`configConstructor.ts:514` (`params.jitContextEnabled ?? true`).
+
+The `agents` public API's `settings: { jitContextEnabled: false }` escape hatch
+(`agentConfig.adapter.ts:278-291`) writes into `ConfigParameters`, **not** into the
+settings service, so it too resolves through the constructor field.
+
+Because the settings read always returns `undefined`, both predicates fall through
+to the same instance field and agree today. The divergence is latent.
+
+`promptMemoryPolicy.resolvePromptMemory` selects `getGlobalMemory()` vs
+`getUserMemory()` using `isJitContextEnabled()`, while `getUserMemory()`,
+`getGlobalMemory()` and `getEnvironmentMemory()` all branch on
+`getJitContextEnabled()`. A disagreement would send the workspace `LLXPRT.md`
+hierarchy twice per request (once inside `getUserMemory()`'s
+`globalMemory + environmentMemory` join, once via `getEnvironmentContext`'s
+`getEnvironmentMemory()` block).
+
+## Accepted behavior (scope)
+
+1. Exactly one JIT-context predicate exists in `packages/core`. Every listed
+   caller goes through it. The divergence becomes inexpressible.
+2. The predicate resolves from one source only: the `jitContextEnabled` instance
+   field assigned by the constructor. No settings-service key is read.
+3. Runtime behavior is unchanged: global, environment, core and JIT-subdirectory
+   memory keep landing in exactly the destinations they land in today.
+4. No defensive reconciliation between accessors is added.
+
+### Which name survives
+
+Keep **`isJitContextEnabled()`**, defined once in `ConfigBaseCore` where the
+`jitContextEnabled` field is declared. Delete `Config.getJitContextEnabled()`
+and the `abstract getJitContextEnabled()` declaration on `ConfigBase`.
+
+Reasons:
+- The field lives on `ConfigBaseCore`; a concrete predicate there needs no
+  abstract indirection through `ConfigBase`.
+- `isJitContextEnabled` is already the name crossing package boundaries
+  (`agents`, `cli`, and the `AppStateRuntime` interface in `cliUiRuntime.ts`).
+- `getJitContextEnabled` is core-internal only; no docs, no external consumer.
+
+Both fallbacks (`=== true` and `?? false`) produce `false` for `undefined`, so
+collapsing onto `=== true` is behavior-preserving.
+
+### Explicitly out of scope
+
+- The unused `ConfigParameters.experimentalJitContext` field
+  (`configTypes.ts:542`). Adjacent dead code, not named by the issue.
+- Any change to how `experimental.jitContext` is read or plumbed.
+- Any change to `memoryDiscovery`, `ContextManager`, or the memory destinations.
+
+## Boundary cases the tests must cover
+
+- `jitContextEnabled` omitted from `ConfigParameters` -> constructor defaults to
+  `true` -> predicate returns `true`.
+- `jitContextEnabled: true` / `jitContextEnabled: false` -> predicate mirrors it.
+- A settings service carrying a `jitContextEnabled` value must NOT override the
+  constructor-supplied value (proves the dead read is gone and the resolution
+  order is single-sourced).
+- Full request assembly with JIT on: workspace `LLXPRT.md` content appears
+  exactly once.
+- Full request assembly with JIT off: workspace `LLXPRT.md` content appears
+  exactly once.
+
+## Test plan (test-first, dev-docs/RULES.md)
+
+### A. `packages/core/src/config/config.d.test.ts` - `describe('Config JIT context')`
+
+Rewrite the three predicate tests onto `isJitContextEnabled()`:
+
+- default (no param) -> `true`
+- `jitContextEnabled: true` -> `true`; `jitContextEnabled: false` -> `false`
+- **replaces** `'should respect the settings service value when available'`:
+  construct a REAL `SettingsService`, `settingsService.set('jitContextEnabled', false)`,
+  build a `Config` with `jitContextEnabled: true` and that settings service, and
+  assert `isJitContextEnabled()` is still `true`. This is the behavioral
+  statement of acceptance criterion 2 - a settings-service value cannot steer
+  the predicate. No mock-call assertions.
+
+Also assert `getJitContextEnabled` is no longer part of the `Config` surface only
+if it can be done without a cast hack; otherwise rely on `typecheck` + the
+compile-time removal.
+
+### B. New behavioral test - the invariant that actually matters
+
+File: `packages/agents/src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts`
+
+Assembles the REAL system instruction the way `ChatSessionFactory.createChatSession`
+does (`ChatSessionFactory.ts:387-392`):
+
+```
+const envParts = await getEnvironmentContext(config);
+const systemInstruction = await buildSystemInstruction(config, [], envParts, undefined, model);
+```
+
+Setup for both cases:
+- `mkdtemp` a workspace directory; write `LLXPRT.md` containing a unique marker
+  string (e.g. a randomly generated token) so nothing in the developer's real
+  global memory can collide.
+- Extract a shared `useTempWorkspace()` helper that registers the
+  `beforeEach`/`afterEach` lifecycle once (RULES.md DRY-setup rule) rather than
+  duplicating temp-dir boilerplate per describe block.
+
+JIT ON case:
+- `new Config({ cwd: tmp, targetDir: tmp, jitContextEnabled: true, ... })`
+- `await initializeTestConfig(config)` (from
+  `@vybestack/llxprt-code-core/test-utils/config.js`) - this constructs the REAL
+  `ContextManager` and calls the REAL `refresh()`, loading the real file from disk.
+- Assemble, then assert the marker occurs **exactly once** in the assembled
+  system instruction.
+
+JIT OFF case:
+- Compute the eager memory the CLI would compute, using the REAL loader
+  `loadServerHierarchicalMemory` from
+  `@vybestack/llxprt-code-core/utils/memoryDiscovery.js` against the temp dir
+  (this is what `environmentLoader.resolveMemoryContent` does when JIT is off).
+- Pass the result as `ConfigParameters.userMemory` with
+  `jitContextEnabled: false`.
+- Assemble, then assert the marker occurs **exactly once**.
+
+Assertion helper: count non-overlapping occurrences of the marker with an
+explicit loop or `split(marker).length - 1`. Assert `=== 1`, not `>= 1`.
+
+Anti-mock-theater notes:
+- The `Config`, the `ContextManager`, the memory discovery, `getEnvironmentContext`
+  and `buildSystemInstruction` are all REAL. Only the agent-client/tool-scheduler
+  factories are test doubles, supplied by the existing `initializeTestConfig`
+  helper; they are infrastructure unrelated to memory assembly.
+- The marker literal appears on the INPUT side (written to disk) and the
+  assertion is a derived count, not an echo of a stub's configured return value.
+- Litmus: if the predicate divergence were reintroduced and the two predicates
+  disagreed, the JIT-on case would emit the workspace hierarchy twice and the
+  count assertion would fail.
+
+### C. Existing tests that must keep passing unchanged
+
+`packages/agents/src/core/promptMemoryPolicy.test.ts`,
+`ChatSessionFactory.byteCompatibility.test.ts`,
+`subagentRuntimeSetup.assembler.test.ts`,
+`packages/cli/src/ui/commands/memoryCommand.test.ts`,
+`useMemoryRefreshAction.test.ts` all already stub `isJitContextEnabled` - the
+surviving name - so they need no edits. This is a positive signal for the naming
+choice.
+
+## Implementation
+
+Only after the tests above are red.
+
+1. `packages/core/src/config/configBaseCore.ts` - keep
+   `isJitContextEnabled()`; add a short doc comment recording that it is the
+   single JIT-context predicate and resolves only from the constructor-assigned
+   field.
+2. `packages/core/src/config/configBase.ts` - delete
+   `abstract getJitContextEnabled(): boolean;` (line 36); rewrite the six
+   `this.getJitContextEnabled()` call sites to `this.isJitContextEnabled()`.
+3. `packages/core/src/config/config.ts` - delete `getJitContextEnabled()`
+   (lines 688-695); rewrite `this.getJitContextEnabled()` at lines 268, 510, 703
+   and 798 to `this.isJitContextEnabled()`. Confirm `this.settingsService` is
+   still referenced elsewhere in the file (it is) so no unused-member lint fires.
+4. `packages/core/src/config/config.d.test.ts` - as described in A.
+
+No production changes outside `packages/core/src/config`.
+
+## Deferred follow-up (out of scope for #3135)
+
+Review raised one LOW finding that is deliberately not addressed here. The
+agents public API's UNSTABLE `settings` escape hatch
+(`packages/agents/src/api/agentConfig.adapter.ts` applySettings) accepts
+`unknown` values and copies them straight into `ConfigParameters`. A caller can
+therefore supply a truthy non-boolean such as `settings: { jitContextEnabled:
+'true' }`. The old `getJitContextEnabled()` treated that as `true` while
+`isJitContextEnabled()` returns `false`, so the collapse is not identical for
+values outside the declared `boolean | undefined` contract.
+
+No supported configuration produces such a value, and the pre-change behavior
+was already self-inconsistent (the two predicates disagreed on it). Making the
+escape hatch validate against `ConfigParameters` types is a separate concern
+and would be scope expansion here.
+
+## Verification
+
+```
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+bun scripts/test-audit/scan.ts tmp/scan-branch
+```
+
+## Acceptance criteria mapping
+
+| Issue criterion | Evidence |
+| --- | --- |
+| Exactly one predicate; all callers use it | `getJitContextEnabled` absent from the tree; `typecheck` green |
+| No settings key read without a write | settings-service read deleted; test A case 3 |
+| Workspace memory exactly once, JIT on and off | test B |
+| Memory destinations unchanged | `promptMemoryPolicy.test.ts` + `ChatSessionFactory.byteCompatibility.test.ts` unchanged and green |
+| No defensive reconciliation | one predicate, one resolution source |

--- a/project-plans/issue3135-jit-context-predicate.md
+++ b/project-plans/issue3135-jit-context-predicate.md
@@ -177,6 +177,18 @@ Only after the tests above are red.
 
 No production changes outside `packages/core/src/config`.
 
+## Test-harness note
+
+`buildSystemInstruction.workspaceMemoryOnce.test.ts` initializes the prompt
+system against its own `LLXPRT_PROMPTS_DIR`, the same pattern
+`ChatSessionFactory.byteCompatibility.test.ts` uses. The prompt registry is a
+process global, so running those two files in one `bun test` invocation makes
+whichever `afterAll` runs first pull the directory out from under the other
+("Core prompt not found"). `scripts/run_bun_tests.ts` executes each file in its
+own process, so this does not affect `npm run test` or CI. Forcing
+re-initialization per file would be defensive plumbing around a shared global
+and is not done here.
+
 ## Deferred follow-up (out of scope for #3135)
 
 Review raised one LOW finding that is deliberately not addressed here. The


### PR DESCRIPTION
## TLDR

Two predicates guarded the same JIT-context invariant with different resolution orders, and one of them read a settings-service key that nothing in the repository writes. They agreed by accident. This PR deletes one of them so the divergence cannot be expressed, and adds a behavioral test for the invariant they were protecting: that the workspace `LLXPRT.md` hierarchy reaches the model exactly once per request.

The predicate that survives is `ConfigBaseCore.isJitContextEnabled()`, which lives next to the `jitContextEnabled` field it reads. `Config.getJitContextEnabled()` and the `abstract getJitContextEnabled()` declaration on `ConfigBase` are gone, along with the dead `settingsService.get('jitContextEnabled')` read.

Reviewers should look hardest at two things: whether the collapse is behavior-preserving for every construction path (`packages/core/src/config/configConstructor.ts:514` is the assignment that makes it so), and whether the new test in `packages/agents/src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts` really exercises production code rather than doubles.

## Dive Deeper

### What was wrong

`packages/core/src/config/configBaseCore.ts` had:

```ts
isJitContextEnabled(): boolean {
  return this.jitContextEnabled === true;
}
```

`packages/core/src/config/config.ts` had:

```ts
getJitContextEnabled(): boolean {
  // Check settings service first, then fall back to instance value
  const settingsValue = this.settingsService.get('jitContextEnabled');
  if (settingsValue !== undefined) {
    return settingsValue as boolean;
  }
  return this.jitContextEnabled ?? false;
}
```

The callers were disjoint. `resolvePromptMemory` (`packages/agents/src/core/promptMemoryPolicy.ts:39`) selected `getGlobalMemory()` versus `getUserMemory()` with `isJitContextEnabled()`, while the memory accessors it then called branched on `getJitContextEnabled()` (`configBase.ts` x6, `config.ts` x4).

Nothing in the repository writes the `jitContextEnabled` settings key. The user-facing setting is `experimental.jitContext`, resolved at `packages/cli/src/config/interactiveContext.ts:227` and threaded through `configBuilder.ts:307` into `ConfigParameters.jitContextEnabled`. The agents API's `settings` escape hatch also lands in `ConfigParameters`, not the settings service. So `settingsValue` was always `undefined` and the two predicates fell through to the same field.

### The divergence was reachable, not just theoretical

`ConfigParameters.settingsService` is injectable and `SettingsService.set` accepts arbitrary keys. Writing the key there made the two predicates disagree, with two distinct failure modes:

- settings `true`, constructor `false`: `initialize()` built a ContextManager, so `getEnvironmentMemory()` emitted the workspace hierarchy in the environment-context block **and** `getUserMemory()` emitted it again in its `globalMemory + environmentMemory` join. The hierarchy was sent **twice** in every request.
- settings `false`, constructor `true`: no ContextManager was built, `getEnvironmentMemory()` returned `''`, and `getGlobalMemory()` fell through to an empty `userMemory`. The workspace instructions reached the model **zero** times.

Both are measured, not hypothesized: the new test's two conflict rows fail against unmodified `main` with marker counts of 2 and 0 respectively.

### The change

- `configBaseCore.ts` keeps the single predicate and documents that it resolves from the constructor-assigned field alone.
- `configBase.ts` drops the abstract declaration and routes its six call sites through it.
- `config.ts` deletes `getJitContextEnabled()` and routes its four call sites through it.

Both old fallbacks yield `false` for `undefined`, and `configConstructor.ts:514` always assigns a boolean (`params.jitContextEnabled ?? true`) before `initialize()` first calls the predicate, so every supported configuration is unchanged. No reconciliation, delegation shim, or fallback layering was added; the second predicate is simply gone. No production file outside `packages/core/src/config` is touched, because every caller in `packages/agents` and `packages/cli` already used the surviving name.

### Testing

`packages/agents/src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts` assembles the real system instruction the way `ChatSessionFactory.createChatSession` does (`getEnvironmentContext`, then `buildSystemInstruction` over those parts). Nothing in the memory path is substituted: a real `LLXPRT.md` on disk in a real temp workspace, a real `Config`, a real `ContextManager` built by real `initialize()`, and real memory discovery. `initializeTestConfig` supplies only agent-client and tool-scheduler doubles, neither of which participates in memory assembly.

The marker literal exists only on the input side (written to disk with a random UUID so the developer's real global memory cannot collide), and every assertion is a derived occurrence count, never a `toContain`.

Four parameterized rows assert a count of exactly 1: JIT on, JIT off, and both directions of the settings-service conflict. Two further tests assert which channel owns the single copy: the environment block under JIT, the eagerly loaded user-memory channel without it.

The JIT-off setup mirrors production rather than hand-feeding a string: it calls the real `loadServerHierarchicalMemory` and pushes the result through `setUserMemory` / `setLlxprtMdFileCount` / `setLlxprtMdFilePaths`, which is what `environmentLoader.resolveMemoryContent` and `memoryCommand.refreshMemoryContent` do.

In `config.d.test.ts`, the test that asserted the dead read (`expect(mockSettingsService.get).toHaveBeenCalledWith(...)`, a mock-verification assertion) is replaced by a two-direction behavioral test over a real `SettingsService`: the constructor value wins whether the settings value agrees or conflicts.

Mutation-verified: reintroducing the divergent predicate turns the JIT-off conflict row's count back to 2.

`bun scripts/test-audit/scan.ts` reports no new MOCK_MIRROR / ALWAYS_TRUE / SELF_CONFIRMING / NO_ASSERT findings; the diff against a `main` baseline is line-number shifts only.

### Known follow-up, deliberately out of scope

The agents public API's UNSTABLE `settings` escape hatch accepts `unknown` and copies values straight into `ConfigParameters`. A caller could pass a truthy non-boolean such as `settings: { jitContextEnabled: 'true' }`, which the old `getJitContextEnabled()` treated as `true` and the surviving predicate treats as `false`. That is outside the declared `boolean | undefined` contract, no supported configuration produces it, and the pre-change behavior was already self-inconsistent for it. Validating the escape hatch against `ConfigParameters` types is a separate concern; it is recorded in `project-plans/issue3135-jit-context-predicate.md`.

## Reviewer Test Plan

The fastest way to see the bug this prevents is to run the new test against the old code:

```bash
git checkout issue3135
cd packages/agents && bun test src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts
# 6 pass

# Now revert only the production files and rerun:
git checkout main -- packages/core/src/config/config.ts packages/core/src/config/configBase.ts
cd packages/agents && bun test src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts
# 2 fail: "JIT context enabled with a conflicting settings-service value" (count 0)
#         "JIT context disabled with a conflicting settings-service value" (count 2)
git checkout issue3135 -- packages/core/src/config/
```

For end-to-end behavior, JIT context is on by default, so a normal interactive session in a directory with an `LLXPRT.md` exercises the surviving path:

```bash
bun scripts/start.ts
# then: /memory show   and   /memory list   and   /memory refresh
```

Then flip `experimental.jitContext` to `false` in settings and repeat: `/memory show` should still report the workspace hierarchy exactly once, `/memory list` should still enumerate the same files, and the model should still answer questions that depend on the workspace instructions.

Targeted suites worth running:

```bash
cd packages/core   && bun test src/config/config.d.test.ts src/config/config.b.test.ts src/services/contextManager.test.ts
cd packages/agents && bun test src/core/promptMemoryPolicy.test.ts src/core/ChatSessionFactory.byteCompatibility.test.ts src/core/buildSystemInstruction.workspaceMemoryOnce.test.ts
cd packages/cli    && bun test src/ui/commands/memoryCommand.test.ts src/ui/containers/AppContainer/hooks/useMemoryRefreshAction.test.ts
```

`ChatSessionFactory.byteCompatibility.test.ts` is the useful regression guard here: it compares the assembled prompt byte-for-byte against a pre-change reference builder and is unchanged by this PR.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test`, `npm run lint` (exit 0), `npm run typecheck` (exit 0), `npm run format`, `npm run build` (exit 0), and the `stepfun-37` smoke run. The full suite's only failures were four pre-existing `RipgrepPathResolver` cases that also fail on unmodified `main` on this machine (a Homebrew `rg` at `/opt/homebrew/bin/rg`), plus a set of agents-harness timeouts caused by other workloads on the box (load average 70); each of those files passes in isolation. Nothing in `packages/core/src/config` or `packages/cli` failed.

## Linked issues / bugs

Fixes #3135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace memory is now included only once in assembled instructions.
  * Memory is placed in the appropriate context depending on whether just-in-time context is enabled.
  * JIT context configuration now consistently honors the explicitly configured value.

* **Tests**
  * Added coverage for workspace memory behavior across JIT and non-JIT modes, including conflicting configuration values.
  * Added integration coverage using isolated temporary workspaces to verify reliable memory discovery and instruction assembly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->