### PR TITLE
Identify the rewind cut by chronology, not by offset (Fixes #2934)

### DIFF
--- a/packages/core/src/recording/HistoryMutationService.ts
+++ b/packages/core/src/recording/HistoryMutationService.ts
@@ -110,6 +110,27 @@ function computeRestoreCut(
 }
 
 /**
+ * Resolve the chronology identity of the cut point so replay can reproduce the
+ * cut without depending on live and journalled history having the same length.
+ *
+ * The cut point is the first removed item. The journal is append-only, so an
+ * item present in live history when the cut was computed is also present in the
+ * replayed history and can be found there by its marker.
+ *
+ * Returns `undefined` when the item carries no usable marker, in which case the
+ * rewind is recorded as a bare count exactly as it always has been.
+ *
+ * @issue #2934
+ */
+function resolveCutSeq(cutItem: IContent | undefined): number | undefined {
+  const seq = cutItem?.metadata?.chronology?.seq;
+  if (typeof seq !== 'number' || !Number.isSafeInteger(seq) || seq < 0) {
+    return undefined;
+  }
+  return seq;
+}
+
+/**
  * Service for durable history mutations that persist rewind semantics.
  */
 export class HistoryMutationService {
@@ -170,8 +191,9 @@ export class HistoryMutationService {
         return { ok: false, error: 'Recording is not active' };
       }
 
-      // 2. Durably append the rewind event.
-      recording.recordRewind(removed.length);
+      // 2. Durably append the rewind event, identifying the cut point by
+      //    chronology so replay does not depend on offsets (#2934).
+      recording.recordRewind(removed.length, resolveCutSeq(removed[0]));
 
       // 3. Flush the rewind.
       await recording.flush();

--- a/packages/core/src/recording/ReplayEngine.accumulation.test.ts
+++ b/packages/core/src/recording/ReplayEngine.accumulation.test.ts
@@ -17,9 +17,13 @@ import {
   contentLine,
   assertReplayError,
   makeContentWithToolCall,
+  makeMarkedContent,
+  compressedLine,
+  rewindLine,
   writeJsonlFile,
   createValidFile,
 } from './replay-test-helpers.js';
+import { type IContent } from '../services/history/IContent.js';
 
 describe('ReplayEngine @plan:PLAN-20260211-SESSIONRECORDING.P07', () => {
   let tempDir: string;
@@ -275,6 +279,162 @@ describe('ReplayEngine @plan:PLAN-20260211-SESSIONRECORDING.P07', () => {
         type: 'text',
         text: 'post 2',
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rewind by chronology marker (#2934)
+  // -------------------------------------------------------------------------
+
+  describe('Rewind by chronology marker @issue:2934', () => {
+    const textsOf = (history: readonly IContent[]): string[] =>
+      history.map((item) =>
+        item.blocks[0].type === 'text' ? item.blocks[0].text : '',
+      );
+
+    /**
+     * The recorded count is measured against live history, which an
+     * unjournalled density pass has already shortened. The marker is measured
+     * against identity, so it survives that divergence.
+     */
+    it('cuts at the entry carrying the recorded chronology seq, not at the recorded offset', async () => {
+      const lines = [
+        sessionStartLine(1),
+        contentLine(2, makeMarkedContent('kept 1', 'human', 1)),
+        contentLine(3, makeMarkedContent('kept 2', 'ai', 2)),
+        contentLine(4, makeMarkedContent('removed 1', 'human', 3)),
+        contentLine(5, makeMarkedContent('removed 2', 'ai', 4)),
+        // The count is stale — it was computed after density pruned an entry
+        // from live history — so it would remove one item too few.
+        rewindLine(6, 1, 3),
+      ];
+      const filePath = path.join(chatsDir, 'marker-rewind.jsonl');
+      await writeJsonlFile(filePath, lines);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+
+      assertReplayOk(result);
+      expect(textsOf(result.history)).toStrictEqual(['kept 1', 'kept 2']);
+    });
+
+    /**
+     * A session recorded before chronology markers existed and then resumed
+     * has unmarked entries followed by marked ones. The cut sits in the
+     * unmarked prefix, where no marker can identify it. Cutting at the nearest
+     * later marker would leave the removed turns in place, so the recorded
+     * count is used instead.
+     */
+    it('falls back to the recorded count when the cut entry predates chronology markers', async () => {
+      const lines = [
+        sessionStartLine(1),
+        contentLine(2, makeContent('Q1', 'human')),
+        contentLine(3, makeContent('A1', 'ai')),
+        contentLine(4, makeContent('Q2', 'human')),
+        contentLine(5, makeContent('A2', 'ai')),
+        contentLine(6, makeMarkedContent('Q3', 'human', 5)),
+        contentLine(7, makeMarkedContent('A3', 'ai', 6)),
+        // Live history stamped the resumed entries in memory only, so seq 3
+        // names an entry the journal never marked.
+        rewindLine(8, 4, 3),
+      ];
+      const filePath = path.join(chatsDir, 'marker-rewind-legacy-prefix.jsonl');
+      await writeJsonlFile(filePath, lines);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+
+      assertReplayOk(result);
+      expect(textsOf(result.history)).toStrictEqual(['Q1', 'A1']);
+    });
+
+    /**
+     * A `compressed` event destroys the entries it replaces, so a later rewind
+     * can name an entry that is no longer in the replayed history. Cutting at
+     * the nearest later marker would strand the summary; the recorded count
+     * clears it.
+     */
+    it('falls back to the recorded count when a compressed event destroyed the cut entry', async () => {
+      const lines = [
+        sessionStartLine(1),
+        contentLine(2, makeMarkedContent('Q1', 'human', 1)),
+        contentLine(3, makeMarkedContent('A1', 'ai', 2)),
+        // The summary reached the journal without a marker.
+        compressedLine(4, makeContent('Summary', 'ai'), 2),
+        contentLine(5, makeMarkedContent('Q2', 'human', 4)),
+        // Restore-all: the cut is the summary, stamped seq 3 in live history.
+        rewindLine(6, 2, 3),
+      ];
+      const filePath = path.join(chatsDir, 'marker-rewind-compressed.jsonl');
+      await writeJsonlFile(filePath, lines);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+
+      assertReplayOk(result);
+      expect(result.history).toStrictEqual([]);
+    });
+
+    it('falls back to the recorded count when no entry carries a marker at all', async () => {
+      const lines = [
+        sessionStartLine(1),
+        contentLine(2, makeContent('kept', 'human')),
+        contentLine(3, makeContent('dropped 1', 'ai')),
+        contentLine(4, makeContent('dropped 2', 'human')),
+        rewindLine(5, 2, 7),
+      ];
+      const filePath = path.join(chatsDir, 'marker-rewind-unmarked.jsonl');
+      await writeJsonlFile(filePath, lines);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+
+      assertReplayOk(result);
+      expect(textsOf(result.history)).toStrictEqual(['kept']);
+    });
+
+    it('leaves an already-empty history empty', async () => {
+      const lines = [sessionStartLine(1), rewindLine(2, 3, 1)];
+      const filePath = path.join(chatsDir, 'marker-rewind-empty.jsonl');
+      await writeJsonlFile(filePath, lines);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+
+      assertReplayOk(result);
+      expect(result.history).toStrictEqual([]);
+    });
+
+    it('retains an unmarked prefix when the cut entry itself is marked', async () => {
+      const lines = [
+        sessionStartLine(1),
+        contentLine(2, makeContent('legacy prefix', 'human')),
+        contentLine(3, makeMarkedContent('kept', 'ai', 5)),
+        contentLine(4, makeMarkedContent('dropped', 'human', 6)),
+        rewindLine(5, 1, 6),
+      ];
+      const filePath = path.join(chatsDir, 'marker-rewind-mixed.jsonl');
+      await writeJsonlFile(filePath, lines);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+
+      assertReplayOk(result);
+      expect(textsOf(result.history)).toStrictEqual(['legacy prefix', 'kept']);
+    });
+
+    it('does not match a content marker whose seq is not a valid sequence number', async () => {
+      const lines = [
+        sessionStartLine(1),
+        contentLine(2, makeMarkedContent('kept', 'human', 1)),
+        contentLine(3, makeMarkedContent('nonsense marker', 'ai', -2)),
+        contentLine(4, makeMarkedContent('dropped', 'human', 3)),
+        rewindLine(5, 1, 3),
+      ];
+      const filePath = path.join(chatsDir, 'marker-rewind-bad-marker.jsonl');
+      await writeJsonlFile(filePath, lines);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+
+      assertReplayOk(result);
+      expect(textsOf(result.history)).toStrictEqual([
+        'kept',
+        'nonsense marker',
+      ]);
     });
   });
 

--- a/packages/core/src/recording/ReplayEngine.accumulation.test.ts
+++ b/packages/core/src/recording/ReplayEngine.accumulation.test.ts
@@ -289,10 +289,15 @@ describe('ReplayEngine @plan:PLAN-20260211-SESSIONRECORDING.P07', () => {
   describe('Rewind by chronology marker @issue:2934', () => {
     // Entries with no blocks, or whose first block is not text, project to ''
     // rather than throwing, so a fixture using tool calls stays readable.
+    // The length check precedes the index because `blocks[0]` is not typed as
+    // possibly-undefined, so an `undefined` guard trips no-unnecessary-condition.
     const textsOf = (history: readonly IContent[]): string[] =>
       history.map((item) => {
+        if (item.blocks.length === 0) {
+          return '';
+        }
         const block = item.blocks[0];
-        return block !== undefined && block.type === 'text' ? block.text : '';
+        return block.type === 'text' ? block.text : '';
       });
 
     /**

--- a/packages/core/src/recording/ReplayEngine.accumulation.test.ts
+++ b/packages/core/src/recording/ReplayEngine.accumulation.test.ts
@@ -287,10 +287,13 @@ describe('ReplayEngine @plan:PLAN-20260211-SESSIONRECORDING.P07', () => {
   // -------------------------------------------------------------------------
 
   describe('Rewind by chronology marker @issue:2934', () => {
+    // Entries with no blocks, or whose first block is not text, project to ''
+    // rather than throwing, so a fixture using tool calls stays readable.
     const textsOf = (history: readonly IContent[]): string[] =>
-      history.map((item) =>
-        item.blocks[0].type === 'text' ? item.blocks[0].text : '',
-      );
+      history.map((item) => {
+        const block = item.blocks[0];
+        return block !== undefined && block.type === 'text' ? block.text : '';
+      });
 
     /**
      * The recorded count is measured against live history, which an

--- a/packages/core/src/recording/ReplayEngine.replay.test.ts
+++ b/packages/core/src/recording/ReplayEngine.replay.test.ts
@@ -736,6 +736,59 @@ describe('ReplayEngine @plan:PLAN-20260211-SESSIONRECORDING.P07', () => {
     });
 
     /**
+     * An unreadable cut marker is reported, but the count beside it is still
+     * applied: discarding the whole rewind would put the removed turns back
+     * into the conversation, which is the symptom the marker exists to
+     * prevent, and the count is what a journal without a marker already
+     * replays by.
+     *
+     * @issue #2934
+     */
+    it.each([
+      ['negative', -1],
+      ['fractional', 1.5],
+      ['string', 'three'],
+      ['null', null],
+      ['boolean', true],
+    ])(
+      'rewind with a malformed %s cutSeq warns and still applies the item count',
+      async (label, cutSeq) => {
+        const badRewind = JSON.stringify({
+          v: 1,
+          seq: 4,
+          ts: new Date().toISOString(),
+          type: 'rewind',
+          payload: { itemsRemoved: 1, cutSeq },
+        });
+        const lines = [
+          sessionStartLine(1),
+          contentLine(2, makeContent('msg 1', 'human')),
+          contentLine(3, makeContent('msg 2', 'ai')),
+          badRewind,
+        ];
+        const filePath = path.join(
+          chatsDir,
+          `bad-rewind-cutseq-${label}.jsonl`,
+        );
+        await writeJsonlFile(filePath, lines);
+
+        const result = await replaySession(filePath, PROJECT_HASH);
+
+        assertReplayOk(result);
+        expect(
+          result.history.map((item) =>
+            item.blocks[0].type === 'text' ? item.blocks[0].text : '',
+          ),
+        ).toStrictEqual(['msg 1']);
+        expect(
+          result.warnings.some((warning) =>
+            warning.includes('malformed rewind cut marker'),
+          ),
+        ).toBe(true);
+      },
+    );
+
+    /**
      * Test 35: Malformed provider_switch (missing provider).
      * @plan PLAN-20260211-SESSIONRECORDING.P07
      * @requirement REQ-RPL-005

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -241,7 +241,54 @@ function handleCompressed(
   }
 }
 
-/** @pseudocode line 100-112: rewind — validate and apply rewind or record malformed. */
+/**
+ * Locate the entry the rewind cut at, identified by its chronology `seq`.
+ *
+ * The match is exact. A neighbouring marker is NOT evidence of where the cut
+ * belongs: an entry with no marker can sit on either side of it, so inferring
+ * the cut from the next marked entry mis-cuts a history whose entries are only
+ * partly marked — a session resumed from a file recorded before chronology
+ * markers existed, or one whose `compressed` summary reached the journal
+ * unmarked.
+ *
+ * Returns `null` when no entry carries the recorded seq, which happens when the
+ * cut entry predates markers or was destroyed by a `compressed` event. The
+ * caller then falls back to the recorded count.
+ *
+ * @issue #2934
+ */
+function findChronologyCutIndex(
+  history: readonly IContent[],
+  cutSeq: number,
+): number | null {
+  for (let index = 0; index < history.length; index++) {
+    // `cutSeq` is already a validated sequence number, so equality alone
+    // rejects both a missing marker and a nonsensical one.
+    if (history[index].metadata?.chronology?.seq === cutSeq) {
+      return index;
+    }
+  }
+  return null;
+}
+
+/** Legacy behaviour: drop `itemsToRemove` entries from the end. */
+function applyCountRewind(
+  acc: ReplayAccumulators,
+  itemsToRemove: number,
+): void {
+  acc.history =
+    itemsToRemove >= acc.history.length
+      ? []
+      : acc.history.slice(0, acc.history.length - itemsToRemove);
+}
+
+/**
+ * @pseudocode line 100-112: rewind — validate and apply rewind or record malformed.
+ *
+ * A resolvable `cutSeq` marker takes precedence over the item count: the count
+ * is measured against live history, which diverges from the journal whenever an
+ * unjournalled mutation (density optimization) shrinks it (#2934).
+ */
 function handleRewind(
   payload: Record<string, unknown>,
   acc: ReplayAccumulators,
@@ -254,11 +301,28 @@ function handleRewind(
     acc.warnings.push(`Line ${lineNumber}: malformed rewind event, skipping`);
     return;
   }
-  if (itemsToRemove >= acc.history.length) {
-    acc.history = [];
-  } else {
-    acc.history = acc.history.slice(0, acc.history.length - itemsToRemove);
+
+  // An unreadable cut marker does not invalidate the count beside it. Dropping
+  // the whole event would leave the removed turns in the replayed history,
+  // which is the very symptom this marker exists to prevent, so the corruption
+  // is reported and the rewind still applies by count.
+  const cutSeq = rewindPayload.cutSeq;
+  if (cutSeq !== undefined && !isValidSequence(cutSeq)) {
+    acc.malformedCount++;
+    acc.warnings.push(
+      `Line ${lineNumber}: malformed rewind cut marker, falling back to item count`,
+    );
+    applyCountRewind(acc, itemsToRemove);
+    return;
   }
+
+  const cutIndex =
+    cutSeq === undefined ? null : findChronologyCutIndex(acc.history, cutSeq);
+  if (cutIndex === null) {
+    applyCountRewind(acc, itemsToRemove);
+    return;
+  }
+  acc.history = acc.history.slice(0, cutIndex);
 }
 
 /** @pseudocode line 114-120: provider_switch — update metadata or record malformed. */

--- a/packages/core/src/recording/SessionRecordingService.test.ts
+++ b/packages/core/src/recording/SessionRecordingService.test.ts
@@ -728,6 +728,51 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
       const payload = rewind!.payload as { itemsRemoved: number };
       expect(payload.itemsRemoved).toBe(3);
     });
+
+    /**
+     * @issue #2934
+     */
+    it('rewind event carries the chronology cut marker when provided', async () => {
+      const config = makeConfig({ chatsDir });
+      service = new SessionRecordingService(config);
+
+      service.recordContent(makeContent('trigger'));
+      service.recordRewind(3, 7);
+      await service.flush();
+
+      const events = await readJsonlFile(service.getFilePath()!);
+      const rewind = events.find((e) => e.type === 'rewind');
+      expect(rewind).toBeDefined();
+
+      const payload = rewind!.payload as {
+        itemsRemoved: number;
+        cutSeq?: number;
+      };
+      expect(payload.itemsRemoved).toBe(3);
+      expect(payload.cutSeq).toBe(7);
+    });
+
+    /**
+     * A rewind recorded without a resolvable cut marker must stay
+     * byte-compatible with legacy count-only events.
+     *
+     * @issue #2934
+     */
+    it('rewind event omits the cut marker when none is provided', async () => {
+      const config = makeConfig({ chatsDir });
+      service = new SessionRecordingService(config);
+
+      service.recordContent(makeContent('trigger'));
+      service.recordRewind(3);
+      await service.flush();
+
+      const raw = await fs.readFile(service.getFilePath()!, 'utf8');
+      const rewindLines = raw
+        .split('\n')
+        .filter((line) => line.includes('"type":"rewind"'));
+      expect(rewindLines).toHaveLength(1);
+      expect(rewindLines[0]).not.toContain('cutSeq');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/recording/SessionRecordingService.ts
+++ b/packages/core/src/recording/SessionRecordingService.ts
@@ -613,14 +613,22 @@ export class SessionRecordingService {
   }
 
   /**
-   * Record a rewind event — last N items removed from history.
+   * Record a rewind event — history cut from `cutSeq` onwards, which removed
+   * `itemsRemoved` items from live history.
+   *
+   * `cutSeq` is the chronology `seq` of the first removed item and is omitted
+   * entirely when the caller could not resolve one, keeping the event
+   * byte-identical to a legacy count-only rewind (#2934).
    *
    * @plan PLAN-20260211-SESSIONRECORDING.P05
    * @requirement REQ-REC-002
    * @pseudocode session-recording-service.md lines 198-200
    */
-  recordRewind(itemsRemoved: number): void {
-    this.enqueue('rewind', { itemsRemoved });
+  recordRewind(itemsRemoved: number, cutSeq?: number): void {
+    this.enqueue(
+      'rewind',
+      cutSeq === undefined ? { itemsRemoved } : { itemsRemoved, cutSeq },
+    );
   }
 
   /**

--- a/packages/core/src/recording/replay-test-helpers.ts
+++ b/packages/core/src/recording/replay-test-helpers.ts
@@ -138,15 +138,46 @@ export function compressedLine(
 
 /**
  * Build a valid JSONL line for a rewind event.
+ *
+ * `cutSeq` is the chronology `seq` of the first removed item (#2934). When it
+ * is omitted the payload carries no `cutSeq` key, matching legacy count-only
+ * rewind events.
  */
-export function rewindLine(seq: number, itemsRemoved: number): string {
+export function rewindLine(
+  seq: number,
+  itemsRemoved: number,
+  cutSeq?: number,
+): string {
   return JSON.stringify({
     v: 1,
     seq,
     ts: new Date().toISOString(),
     type: 'rewind',
-    payload: { itemsRemoved },
+    payload: cutSeq === undefined ? { itemsRemoved } : { itemsRemoved, cutSeq },
   });
+}
+
+/**
+ * Build a text content entry carrying an explicit chronology marker, as
+ * HistoryService stamps them before the entry reaches the journal (#1721).
+ */
+export function makeMarkedContent(
+  text: string,
+  speaker: IContent['speaker'],
+  chronologySeq: number,
+): IContent {
+  return {
+    speaker,
+    blocks: [{ type: 'text', text }],
+    metadata: {
+      chronology: {
+        seq: chronologySeq,
+        userTurn: 1,
+        step: chronologySeq,
+        recordedAt: 1787000000000,
+      },
+    },
+  };
 }
 
 /**

--- a/packages/core/src/recording/rewindChronology.integration.test.ts
+++ b/packages/core/src/recording/rewindChronology.integration.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Copyright 2026 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Behavioural tests for issue #2934: `/chat clear` and `/chat restore N` must
+ * stay applied across a resume even when density optimization has shrunk live
+ * history without journalling anything.
+ *
+ * The divergence is produced by the real mechanism — real HistoryService,
+ * real RecordingIntegration, real SessionRecordingService, real
+ * applyDensityResult, real replaySession, real files — never simulated by
+ * hand-writing journal lines.
+ *
+ * @issue #2934
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { SessionRecordingService } from './SessionRecordingService.js';
+import { RecordingIntegration } from './RecordingIntegration.js';
+import { HistoryMutationService } from './HistoryMutationService.js';
+import { replaySession } from './ReplayEngine.js';
+import { type SessionRecordingServiceConfig } from './types.js';
+import { HistoryService } from '../services/history/HistoryService.js';
+import { type IContent } from '../services/history/IContent.js';
+import {
+  type DensityResult,
+  type DensityResultMetadata,
+} from '../core/compression/types.js';
+
+const PROJECT_HASH = 'rewind-chronology-hash';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContent(
+  text: string,
+  speaker: IContent['speaker'] = 'human',
+): IContent {
+  return { speaker, blocks: [{ type: 'text', text }] };
+}
+
+function makeDensityMetadata(): DensityResultMetadata {
+  return {
+    readWritePairsPruned: 0,
+    fileDeduplicationsPruned: 0,
+    recencyPruned: 0,
+  };
+}
+
+function makeDensityResult(
+  removals: readonly number[],
+  replacements: ReadonlyMap<number, IContent> = new Map(),
+): DensityResult {
+  return { removals, replacements, metadata: makeDensityMetadata() };
+}
+
+function textOf(content: IContent): string {
+  const block = content.blocks[0];
+  return block.type === 'text' ? block.text : '';
+}
+
+function textsOf(history: readonly IContent[]): string[] {
+  return history.map(textOf);
+}
+
+function seqsOf(history: readonly IContent[]): Array<number | undefined> {
+  return history.map((item) => item.metadata?.chronology?.seq);
+}
+
+function requireReplaySuccess(
+  result: Awaited<ReturnType<typeof replaySession>>,
+): asserts result is Extract<
+  Awaited<ReturnType<typeof replaySession>>,
+  { ok: true }
+> {
+  if (!result.ok) throw new Error(`Expected replay success: ${result.error}`);
+}
+
+function requireMutationSuccess<T extends { ok: boolean }>(
+  result: T,
+): asserts result is T & { ok: true } {
+  if (!result.ok) throw new Error('Expected history mutation success');
+}
+
+/**
+ * Registers the temp-dir lifecycle hooks and returns a lazy accessor for the
+ * chats directory.
+ */
+function useChatsDir(): () => string {
+  let dir = '';
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rewind-chronology-'));
+    await fs.mkdir(path.join(dir, 'chats'), { recursive: true });
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+  return () => path.join(dir, 'chats');
+}
+
+function makeConfig(chatsDir: string): SessionRecordingServiceConfig {
+  return {
+    sessionId: crypto.randomUUID(),
+    projectHash: PROJECT_HASH,
+    chatsDir,
+    workspaceDirs: ['/test/workspace'],
+    provider: 'anthropic',
+    model: 'claude-4',
+  };
+}
+
+/**
+ * A live session: a real HistoryService whose additions are journalled by a
+ * real SessionRecordingService through the real RecordingIntegration bridge.
+ */
+interface LiveSession {
+  readonly history: HistoryService;
+  readonly recording: SessionRecordingService;
+}
+
+function startSession(chatsDir: string): LiveSession {
+  const recording = new SessionRecordingService(makeConfig(chatsDir));
+  const history = new HistoryService();
+  new RecordingIntegration(recording).subscribeToHistory(history);
+  return { history, recording };
+}
+
+async function addTurns(
+  session: LiveSession,
+  entries: readonly IContent[],
+): Promise<void> {
+  for (const entry of entries) {
+    session.history.add(entry);
+  }
+  await session.history.waitForTokenUpdates();
+  await session.recording.flush();
+}
+
+/** Replay the session file from disk after closing the recording. */
+async function replayFromDisk(
+  session: LiveSession,
+): Promise<readonly IContent[]> {
+  const filePath = session.recording.getFilePath();
+  expect(filePath).not.toBeNull();
+  await session.recording.dispose();
+  const replay = await replaySession(filePath as string, PROJECT_HASH);
+  requireReplaySuccess(replay);
+  return replay.history;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('rewind survives density divergence @issue:2934', () => {
+  const chatsDir = useChatsDir();
+
+  it('restore keeps the removed turns removed after replay', async () => {
+    const session = startSession(chatsDir());
+    // Turn 3 owns a tool result that density will prune from live history.
+    // Nothing before the restore cut is pruned, so a correct replay reproduces
+    // the live post-restore history exactly.
+    await addTurns(session, [
+      makeContent('Q1', 'human'),
+      makeContent('A1', 'ai'),
+      makeContent('Q2', 'human'),
+      makeContent('A2', 'ai'),
+      makeContent('Q3', 'human'),
+      makeContent('A3', 'ai'),
+      makeContent('T3', 'tool'),
+      makeContent('A3-followup', 'ai'),
+    ]);
+
+    // Density prunes the tool result inside the most recent turn. The journal
+    // learns nothing about it, so live history is now one item shorter.
+    await session.history.applyDensityResult(makeDensityResult([6]));
+    await session.history.waitForTokenUpdates();
+    expect(textsOf(session.history.getAll())).toStrictEqual([
+      'Q1',
+      'A1',
+      'Q2',
+      'A2',
+      'Q3',
+      'A3',
+      'A3-followup',
+    ]);
+
+    const live = [...session.history.getAll()];
+    const result = await new HistoryMutationService().restore(
+      live,
+      1,
+      session.recording,
+    );
+    requireMutationSuccess(result);
+    expect(textsOf(result.remainingHistory)).toStrictEqual([
+      'Q1',
+      'A1',
+      'Q2',
+      'A2',
+    ]);
+
+    const replayed = await replayFromDisk(session);
+
+    expect(textsOf(replayed)).toStrictEqual(textsOf(result.remainingHistory));
+    expect(textsOf(replayed)).not.toContain('Q3');
+  });
+
+  it('clear does not resurrect cleared turns after replay', async () => {
+    const session = startSession(chatsDir());
+    await addTurns(session, [
+      makeContent('Q1', 'human'),
+      makeContent('A1', 'ai'),
+      makeContent('T1', 'tool'),
+      makeContent('Q2', 'human'),
+      makeContent('A2', 'ai'),
+      makeContent('T2', 'tool'),
+      makeContent('Q3', 'human'),
+    ]);
+
+    // Density prunes a tool result that belongs to a turn the clear removes.
+    await session.history.applyDensityResult(makeDensityResult([5]));
+    await session.history.waitForTokenUpdates();
+
+    const live = [...session.history.getAll()];
+    const result = await new HistoryMutationService().clear(
+      live,
+      session.recording,
+    );
+    requireMutationSuccess(result);
+    expect(textsOf(result.remainingHistory)).toStrictEqual(['Q1', 'A1', 'T1']);
+
+    const replayed = await replayFromDisk(session);
+
+    expect(textsOf(replayed)).toStrictEqual(textsOf(result.remainingHistory));
+    expect(textsOf(replayed)).not.toContain('Q2');
+    expect(textsOf(replayed)).not.toContain('Q3');
+  });
+
+  it('token total after replay matches the token total after the live restore', async () => {
+    const session = startSession(chatsDir());
+    await addTurns(session, [
+      makeContent('first question', 'human'),
+      makeContent('first answer', 'ai'),
+      makeContent('second question', 'human'),
+      makeContent('second answer', 'ai'),
+      makeContent('third question', 'human'),
+      makeContent('third answer', 'ai'),
+      makeContent('a tool result that density will prune', 'tool'),
+      makeContent('third answer continued', 'ai'),
+    ]);
+
+    await session.history.applyDensityResult(makeDensityResult([6]));
+    await session.history.waitForTokenUpdates();
+
+    const live = [...session.history.getAll()];
+    const result = await new HistoryMutationService().restore(
+      live,
+      1,
+      session.recording,
+    );
+    requireMutationSuccess(result);
+
+    const replayed = await replayFromDisk(session);
+
+    const estimator = new HistoryService();
+    const liveTokens = await estimator.estimateTokensForContents([
+      ...result.remainingHistory,
+    ]);
+    const replayedTokens = await estimator.estimateTokensForContents([
+      ...replayed,
+    ]);
+
+    expect(liveTokens).toBeGreaterThan(0);
+    expect(replayedTokens).toBe(liveTokens);
+  });
+
+  it('keeps the cut aligned when density replaced an item before the cut', async () => {
+    const session = startSession(chatsDir());
+    await addTurns(session, [
+      makeContent('Q1', 'human'),
+      makeContent('A1', 'ai'),
+      makeContent('T1', 'tool'),
+      makeContent('Q2', 'human'),
+      makeContent('A2', 'ai'),
+    ]);
+
+    // A truncating replacement inherits the replaced item's chronology marker,
+    // and a removal after the cut shortens live history.
+    const truncated = makeContent('T1 (truncated)', 'tool');
+    await session.history.applyDensityResult(
+      makeDensityResult([4], new Map([[2, truncated]])),
+    );
+    await session.history.waitForTokenUpdates();
+
+    const live = [...session.history.getAll()];
+    const result = await new HistoryMutationService().clear(
+      live,
+      session.recording,
+    );
+    requireMutationSuccess(result);
+    expect(textsOf(result.remainingHistory)).toStrictEqual([
+      'Q1',
+      'A1',
+      'T1 (truncated)',
+    ]);
+
+    const replayed = await replayFromDisk(session);
+
+    // The journal never learned about the truncation (issue #1393), so the
+    // replayed tool result still carries its original text. What must hold is
+    // that the cut landed on the same chronology positions.
+    expect(seqsOf(replayed)).toStrictEqual(seqsOf(result.remainingHistory));
+    expect(textsOf(replayed)).not.toContain('Q2');
+  });
+
+  it('restoring more turns than exist empties the replayed history', async () => {
+    const session = startSession(chatsDir());
+    await addTurns(session, [
+      makeContent('Q1', 'human'),
+      makeContent('A1', 'ai'),
+      makeContent('T1', 'tool'),
+      makeContent('Q2', 'human'),
+    ]);
+
+    await session.history.applyDensityResult(makeDensityResult([2]));
+    await session.history.waitForTokenUpdates();
+
+    const live = [...session.history.getAll()];
+    const result = await new HistoryMutationService().restore(
+      live,
+      5,
+      session.recording,
+    );
+    requireMutationSuccess(result);
+    expect(result.remainingHistory).toStrictEqual([]);
+
+    const replayed = await replayFromDisk(session);
+    expect(replayed).toStrictEqual([]);
+  });
+
+  it('records no cut marker when the cut item carries no chronology marker', async () => {
+    const recording = new SessionRecordingService(makeConfig(chatsDir()));
+    // Unmarked history: recorded directly, never passed through HistoryService,
+    // so no chronology marker was ever stamped.
+    const history: IContent[] = [
+      makeContent('Q1', 'human'),
+      makeContent('A1', 'ai'),
+      makeContent('Q2', 'human'),
+      makeContent('A2', 'ai'),
+    ];
+    for (const entry of history) recording.recordContent(entry);
+    await recording.flush();
+
+    const result = await new HistoryMutationService().restore(
+      history,
+      1,
+      recording,
+    );
+    requireMutationSuccess(result);
+
+    const filePath = recording.getFilePath();
+    expect(filePath).not.toBeNull();
+    await recording.dispose();
+
+    const raw = await fs.readFile(filePath as string, 'utf8');
+    const rewindLines = raw
+      .split('\n')
+      .filter((line) => line.includes('"type":"rewind"'));
+    expect(rewindLines).toHaveLength(1);
+    expect(rewindLines[0]).not.toContain('cutSeq');
+
+    const replay = await replaySession(filePath as string, PROJECT_HASH);
+    requireReplaySuccess(replay);
+    expect(textsOf(replay.history)).toStrictEqual(['Q1', 'A1']);
+  });
+});

--- a/packages/core/src/recording/rewindChronology.integration.test.ts
+++ b/packages/core/src/recording/rewindChronology.integration.test.ts
@@ -73,7 +73,7 @@ function makeDensityResult(
 
 function textOf(content: IContent): string {
   const block = content.blocks[0];
-  return block.type === 'text' ? block.text : '';
+  return block !== undefined && block.type === 'text' ? block.text : '';
 }
 
 function textsOf(history: readonly IContent[]): string[] {

--- a/packages/core/src/recording/rewindChronology.integration.test.ts
+++ b/packages/core/src/recording/rewindChronology.integration.test.ts
@@ -71,9 +71,17 @@ function makeDensityResult(
   return { removals, replacements, metadata: makeDensityMetadata() };
 }
 
+/**
+ * Project the first text block, or '' for a blockless or non-text entry.
+ * The length check precedes the index because `blocks[0]` is not typed as
+ * possibly-undefined, so an `undefined` guard trips no-unnecessary-condition.
+ */
 function textOf(content: IContent): string {
+  if (content.blocks.length === 0) {
+    return '';
+  }
   const block = content.blocks[0];
-  return block !== undefined && block.type === 'text' ? block.text : '';
+  return block.type === 'text' ? block.text : '';
 }
 
 function textsOf(history: readonly IContent[]): string[] {

--- a/packages/core/src/recording/types.ts
+++ b/packages/core/src/recording/types.ts
@@ -113,11 +113,28 @@ export interface CompressedPayload {
 }
 
 /**
- * Payload for the `rewind` event — removes the last N items from history.
+ * Payload for the `rewind` event — removes the tail of history from the cut
+ * point onwards.
  */
 export interface RewindPayload {
   /** Positive integer — number of items removed from the end of history. */
   itemsRemoved: number;
+
+  /**
+   * Chronology `seq` of the FIRST removed item, when that item carried a
+   * chronology marker (#1721). Replay cuts at the item whose marker `seq`
+   * EQUALS this value, which stays correct even when live history and the
+   * journal have diverged — density optimization removes items from live
+   * history without journalling anything, so `itemsRemoved` alone removes the
+   * wrong amount on replay.
+   *
+   * Absent on legacy events and whenever the cut item has no marker. Replay
+   * falls back to `itemsRemoved` whenever it is absent, unreadable, or names
+   * an item that is not in the replayed history.
+   *
+   * @issue #2934
+   */
+  cutSeq?: number;
 }
 
 /**

--- a/project-plans/issue2934/plan.md
+++ b/project-plans/issue2934/plan.md
@@ -1,0 +1,222 @@
+# Issue #2934 — Make rewind position-independent
+
+`/chat clear` and `/chat restore N` record a rewind as a bare item **count**.
+The count is computed against the live history but replayed against the
+replay-accumulated history. Density optimization
+(`HistoryService.applyDensityResult`, driven by the `high-density` compression
+strategy) shrinks live history without emitting any journal event, so the two
+arrays diverge and the recorded count removes the wrong number of items on
+`--continue`.
+
+Fix: record the **chronology identity of the cut point** alongside the count,
+and have replay cut at that marker instead of by offset.
+
+## Scope
+
+In scope, and nothing else:
+
+- `packages/core/src/recording/types.ts` — add one optional field to
+  `RewindPayload`.
+- `packages/core/src/recording/SessionRecordingService.ts` — `recordRewind`
+  accepts and writes the optional cut marker.
+- `packages/core/src/recording/HistoryMutationService.ts` — read the cut item's
+  chronology `seq` and pass it to `recordRewind`.
+- `packages/core/src/recording/ReplayEngine.ts` — `handleRewind` resolves the
+  cut by marker when present, falling back to the count when it is not.
+- Behavioural tests for all of the above.
+
+Explicitly OUT of scope (do not touch):
+
+- Journaling density or tool-truncation mutations in general (see #1393).
+- The persist-then-commit ordering in `HistoryMutationService.applyMutation()`
+  — the issue states it is correct and must be left alone.
+- The pre-existing lossiness of `compressed` replay (replay collapses to
+  `[summary]` while live history keeps a preserved head/tail). Not caused by
+  this change and not fixed by it.
+- Any change to `computeClearCut` / `computeRestoreCut` cut selection.
+
+## Design
+
+### Recording side
+
+`RewindPayload` gains one optional field:
+
+```ts
+export interface RewindPayload {
+  /** Positive integer — number of items removed from the end of history. */
+  itemsRemoved: number;
+  /**
+   * Chronology `seq` of the FIRST removed item, when the cut point carried a
+   * chronology marker. Replay cuts at the first item whose marker `seq` is
+   * >= this value, which stays correct even when live history and the journal
+   * have diverged (e.g. density removed items without journalling them).
+   * Absent on legacy events and whenever the cut item has no marker.
+   */
+  cutSeq?: number;
+}
+```
+
+`SessionRecordingService.recordRewind(itemsRemoved: number, cutSeq?: number)`
+omits `cutSeq` from the payload entirely when it is `undefined`, so a rewind
+recorded without a resolvable marker is byte-identical to today's event.
+
+`HistoryMutationService.applyMutation` reads
+`removed[0]?.metadata?.chronology?.seq`. It passes the value through only when
+it is a non-negative safe integer; otherwise it records count-only exactly as
+today.
+
+Why the FIRST REMOVED item and not the last retained item: it is the boundary
+the cut is defined by, and the journal is append-only, so an item that was in
+live history when the cut was computed is also in the replayed history.
+
+### Replay side
+
+`handleRewind` keeps its current `itemsRemoved` validation (non-number or
+negative is malformed; warn and skip; history unchanged). Then:
+
+1. If `cutSeq` is present but not a non-negative safe integer → record the
+   corruption and warn, then apply the count. Discarding the whole event would
+   leave the removed turns in the replayed history, which is the symptom the
+   marker exists to prevent, and the count is what a journal without a marker
+   already replays by.
+2. If `cutSeq` is present and valid → find the entry whose
+   `metadata.chronology.seq` EQUALS `cutSeq`.
+   - Found at index `i` → `acc.history = acc.history.slice(0, i)`.
+   - Not found → fall back to the count.
+3. If `cutSeq` is absent → today's behaviour, unchanged:
+   `slice(0, length - itemsRemoved)`, clamped to empty.
+
+The match must be exact. A neighbouring marker is not evidence of where the cut
+belongs, because an unmarked entry can sit on either side of it. Two real
+histories are only partly marked:
+
+- A session recorded before chronology markers existed and then resumed:
+  `performResume` loads the old unmarked entries through
+  `HistoryService.replaceAll`, which stamps them in memory only. The journal
+  keeps them unmarked while later turns are journalled with markers. A cut
+  inside that prefix has no marker to find.
+- A `compressed` summary can reach the journal unmarked, because the entry
+  stamped into live history is a copy of the one handed to `recordCompressed`.
+
+In both, cutting at the nearest later marker would leave removed turns in place
+(the first case) or strand the summary that a restore-all should have cleared
+(the second). Falling back to the count reproduces exactly what those files
+replay to today, so neither case regresses.
+
+Neither case is fixable within this issue's scope: identifying an unmarked
+journal entry needs the unjournalled mutations of #1393.
+
+## Acceptance criteria
+
+Numbering follows the issue.
+
+**AC1 — restore survives resume under density.**
+Record a session, apply a density result that removes items from live history
+(emitting no journal event), run `/chat restore N` through
+`HistoryMutationService`, replay the file from disk. The replayed history equals
+the live post-restore history.
+
+**AC2 — clear survives resume under density.**
+Same setup, `clear()` instead of `restore()`. Replayed history equals the live
+post-clear history; no cleared turn reappears.
+
+**AC3 — backwards compatibility.**
+A session file whose rewind event carries only `itemsRemoved` (no `cutSeq`)
+replays exactly as it does today. Covered both by an explicitly hand-written
+legacy fixture line and by the existing `historyMutation.integration.test.ts`
+and `ReplayEngine.accumulation.test.ts` suites, whose fixtures have no
+chronology markers and therefore must keep taking the count path.
+
+**AC4 — behavioural end-to-end.**
+Record → density → restore → replay, asserting the replayed history matches the
+live post-restore history exactly (identity of every entry, by chronology
+`seq` and by text), not merely by length.
+
+**AC5 — token total after resume matches the total at quit.**
+Feed the replayed history and the live post-restore history through the same
+`HistoryService` token estimation and assert the totals are equal. This follows
+from AC1/AC4 (equal histories give equal totals) but is asserted directly
+because it is the user-visible symptom in the issue.
+
+### Boundary cases that must be covered by tests
+
+- `cutSeq` refers to an item that density REPLACED (`chronology.inherit`
+  preserves the marker): the match finds the replacement at the same position.
+- `cutSeq` names an entry that predates chronology markers (resumed legacy
+  session): falls back to the count rather than cutting at a later marker.
+- `cutSeq` names an entry a `compressed` event destroyed: falls back to the
+  count rather than stranding the summary.
+- Replayed history contains no chronology markers at all but the rewind carries
+  a `cutSeq`: falls back to the count.
+- Replayed history is empty when the rewind is applied: stays empty, no throw.
+- Malformed `cutSeq` (negative, non-integer, `NaN`, string, `null`): rewind is
+  skipped with a warning and history is unchanged.
+- Rewind removes ALL history (restore N greater than the number of human
+  turns): `cutIndex` is 0, `cutSeq` is the first item's seq, replay produces an
+  empty history.
+- Cut item has no chronology marker: `cutSeq` is omitted from the payload;
+  count path is used; recorded JSON has no `cutSeq` key.
+
+## Test plan (test-first)
+
+All tests are `bun:test`, TypeScript, real files on a real temp dir, real
+`SessionRecordingService` / `ReplayEngine` / `HistoryService`. No mocking of
+any component under test. Density is applied through the real
+`HistoryService.applyDensityResult` with a real `DensityResult`, so the test
+reproduces the exact divergence the issue describes rather than simulating it.
+
+New file: `packages/core/src/recording/rewindChronology.integration.test.ts`
+
+1. `restore under density replays to the same history that is live after the
+   restore` (AC1, AC4).
+2. `clear under density does not resurrect cleared turns on replay` (AC2).
+3. `token total after replay equals the token total after the live restore`
+   (AC5).
+4. `cut point removed by density still cuts at the next surviving item`.
+5. `cut point replaced by density is matched through the inherited marker`.
+6. `rewind whose cutSeq exceeds every replayed marker removes nothing`.
+7. `rewind with cutSeq against an unmarked history falls back to the count`.
+8. `rewind on an empty replayed history leaves it empty`.
+9. `restore of more turns than exist empties the replayed history`.
+10. `a cut item without a chronology marker records no cutSeq` (asserts the
+    serialized JSON has no `cutSeq` key, then replays via the count).
+
+Extend `packages/core/src/recording/ReplayEngine.replay.test.ts` (it already
+owns the malformed-rewind cases) with malformed-`cutSeq` variants: negative,
+fractional, `NaN`, string, `null` — each skipped with a warning, history
+unchanged.
+
+Extend `packages/core/src/recording/SessionRecordingService.test.ts` (it
+already owns `rewind event contains itemsRemoved count`) with:
+
+- `rewind event carries cutSeq when provided`.
+- `rewind event omits cutSeq when not provided`.
+
+`packages/core/src/recording/replay-test-helpers.ts::rewindLine` gains an
+optional `cutSeq` argument so replay tests can write both shapes.
+
+## Review triage
+
+Round 1 (deepthinker) findings and disposition:
+
+| Finding | Severity | Disposition |
+| --- | --- | --- |
+| A cut inside a legacy unmarked prefix resolved to the first later marked entry, resurrecting removed turns | HIGH | **Blocker-Fix.** Replaced the `>=` scan with exact-marker resolution plus count fallback. Regression guard: `falls back to the recorded count when the cut entry predates chronology markers`. |
+| Restore-all after a `compressed` reset stranded an unmarked summary where the count rule emptied history | HIGH | **Blocker-Fix.** Same change. Regression guard: `falls back to the recorded count when a compressed event destroyed the cut entry`. |
+| Tests omitted both mixed marked/unmarked histories | MEDIUM | **In-scope-Fix.** Both are now covered by the two guards above; each was confirmed to fail under the rejected `>=` rule. |
+| Content chronology markers were accepted as any number while `cutSeq` required a safe integer | LOW | **In-scope-Fix.** Resolved by construction: `cutSeq` is validated once, and exact equality against it rejects both a missing marker and a nonsensical one, so no second predicate is needed. |
+| Comment asserted `computeRestoreCut` always cuts at a human item, which is false when more turns are requested than exist | LOW | **In-scope-Fix.** Comment corrected to the property actually relied on (the journal is append-only). |
+
+Open Code Review round 1 findings and disposition:
+
+| Finding | Severity | Disposition |
+| --- | --- | --- |
+| A malformed `cutSeq` discarded the whole rewind, leaving the removed turns in the replayed history | HIGH | **In-scope-Fix.** The corruption is now warned about and counted, and the rewind still applies by count. |
+| `RewindPayload` doc said replay cuts at the first marker that "reaches" `cutSeq` while the code matches exactly | MEDIUM | **In-scope-Fix.** Doc corrected, and the fallback conditions spelled out. |
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, plus
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing
+else"`.


### PR DESCRIPTION
## TLDR

`/chat clear` and `/chat restore N` could be silently undone on `--continue`, putting back turns the user deliberately removed. A rewind was journalled as a bare item **count**, measured against live history but replayed against the replay-accumulated history. Density optimization shrinks live history without journalling anything, so the two arrays diverge and the count removes the wrong amount.

This records the chronology `seq` of the cut point next to the count and has replay cut at that marker. Identity does not care how long either array is, so alignment stops mattering.

Reviewers should look hardest at `ReplayEngine.handleRewind` — specifically at **why the marker match is exact rather than a threshold**, which is where the first review round found two reachable regressions. See "Dive Deeper".

## Dive Deeper

### The defect

- `HistoryMutationService.restore()` computes the cut from **live** history and records `itemsRemoved`, an integer.
- `ReplayEngine.handleRewind()` applied it as `slice(0, length - itemsRemoved)` against the **replay-accumulated** history.

Those match only if every history mutation reached the journal. `HistoryService.applyDensityResult` (reached via `compression.strategy = high-density`) removes items and emits no event — `HistoryService` has no event that can express in-place restructuring, and `RecordingIntegration` only subscribes to `contentAdded` / `compressionStarted` / `compressionEnded`. Live history shrinks, the journal does not, and the count then cuts in the wrong place.

Reachability is narrow today — `high-density` is opt-in and the default is `middle-out` — but it is the strategy long sessions most want.

### The fix

`RewindPayload` gains an optional `cutSeq`: the chronology `seq` (#1721) of the first removed item.

- `HistoryMutationService` reads it off the cut item and passes it through only when it is a valid sequence number.
- `SessionRecordingService.recordRewind(itemsRemoved, cutSeq?)` omits the key entirely when there is nothing to record, so a rewind without a resolvable marker is byte-identical to today's event.
- `ReplayEngine.handleRewind` cuts at the entry whose marker equals `cutSeq`.

Density replacement already inherits the marker of the item it replaces (`chronology.inherit`), so a truncated tool result still resolves to the same position. Because `content` events serialize the whole `IContent`, markers are already in existing session files — no schema change was needed to *read* them.

### Why the match is exact, not `>=`

The first version scanned forward for the first marker `>= cutSeq`, so that an unmarked entry was treated as preceding the cut. Review found two reachable histories where that is false, and both were reproduced:

1. **A session recorded before chronology markers, then resumed.** `performResume` loads the old entries through `HistoryService.replaceAll`, which stamps them **in memory only** — the journal keeps them unmarked while new turns are journalled with markers. A cut inside that prefix has no marker to find, and cutting at the first later marker left the removed turns in place. Old file with `Q1/A1/Q2/A2`, resume, add `Q3/A3/T3`, density-prune `T3`, restore 2 turns: live became `Q1/A1`, replay returned `Q1/A1/Q2/A2`.

2. **A `compressed` summary that reached the journal unmarked.** Compression stamps the copy placed in live history, while the original is what gets recorded. On a restore-all whose `cutSeq` is the summary's in-memory stamp, the scan skipped the unmarked summary and matched a later turn, retaining `[summary]` where the count rule correctly emptied history. That is a regression, not the accepted compressed-replay lossiness.

Exact matching plus a count fallback is correct where markers exist and identical to today's behaviour where they do not. Both cases now have regression guards, and both were confirmed to fail under the rejected threshold rule.

Neither case is fixable inside this issue: identifying an unmarked journal entry needs the unjournalled mutations of #1393.

### Fallback and corruption behaviour

Replay falls back to `itemsRemoved` whenever `cutSeq` is absent, unreadable, or names an entry that is not in the replayed history. An unreadable `cutSeq` is warned about and counted as malformed, but the count beside it still applies — discarding the whole event would put the removed turns back, which is the symptom the marker exists to prevent, and the count is what a journal without a marker already replays by.

### Deliberately out of scope

- Journalling density and tool-truncation mutations in general (#1393). Density-pruned items that sit *before* the cut still reappear on replay; only the cut boundary is fixed here.
- The pre-existing lossiness of `compressed` replay (live keeps a preserved head/tail, replay collapses to `[summary]`).
- The persist-then-commit ordering in `HistoryMutationService.applyMutation()`, which the issue states is correct and was left alone.

### Testing

New behavioural suite `packages/core/src/recording/rewindChronology.integration.test.ts` runs the real mechanism end to end — real `HistoryService`, real `RecordingIntegration`, real `SessionRecordingService`, real `applyDensityResult`, real files, real `replaySession`. Nothing is simulated by hand-writing journal lines.

Thirteen tests were verified RED against the unfixed production code, including a restore that resurrected a human turn (`Q3`), a clear that resurrected `Q2`, and a token total that differed by four. The full set covers restore under density, clear under density, token-total parity, density replacement through an inherited marker, restore-of-more-turns-than-exist, exact-marker cutting, both mixed-history fallbacks, a markerless history, an empty history, malformed `cutSeq` values, and payload serialization with and without the marker.

Backwards compatibility is carried by the existing suites, whose fixtures have no chronology markers and therefore keep taking the count path: `historyMutation.integration.test.ts`, `ReplayEngine.accumulation.test.ts`, `ReplayEngine.property.test.ts`, `ReplayEngine.property2.test.ts`, `integration.basic.test.ts`, `integration.advanced.test.ts`, and `packages/agents/src/api/__tests__/session.spec.ts`.

Review rounds: one deepthinker review (2 HIGH, 1 MEDIUM, 2 LOW — all resolved) and one Open Code Review (2 findings — both resolved). Findings and dispositions are recorded in `project-plans/issue2934/plan.md`.

## Reviewer Test Plan

Automated, and the fastest way to see the defect:

```bash
cd packages/core && bun test src/recording/
```

To watch it fail before the fix, revert just the production change and re-run — five of the six integration cases fail, `restore` puts `Q3` back and `clear` puts `Q2` back:

```bash
git stash push -- packages/core/src/recording/ReplayEngine.ts \
  packages/core/src/recording/HistoryMutationService.ts \
  packages/core/src/recording/SessionRecordingService.ts \
  packages/core/src/recording/types.ts
cd packages/core && bun test src/recording/rewindChronology.integration.test.ts
git stash pop
```

Manually, with `high-density` active:

1. `llxprt --set compression.strategy high-density` (density also needs `strategy.optimize` and a continuous trigger, and only fires once usage crosses the optimize threshold).
2. Hold a conversation long enough for density to prune tool results.
3. Run `/chat restore 2` and note what remains.
4. Quit, then `llxprt --continue`.
5. The resumed conversation should be what you left, not what you rewound out of. Check the context total too — it should match what you saw at quit.

Same procedure with `/chat clear`: cleared turns must not come back.

Also worth exercising: resume an older session file recorded before chronology markers, run `/chat restore`, quit, resume again. That path takes the count fallback and must behave exactly as it does on `main`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the `stepfun-37` startup smoke run. There is no platform-specific code in this change.

Four `RipgrepPathResolver` cases fail locally and are unrelated to this change. They are not acceptable background noise: the test mocks `child_process.execSync` and `fs.existsSync`, but the implementation now resolves binaries with `findInPath()` walking the real `process.env.PATH`, so the test escapes its mocks and reads the developer's machine. It fails on any machine with `ripgrep` installed and passes with `rg` removed from `PATH`. CI is blind to it because the Ubuntu runner has no `rg`. Tracked separately in #3278, together with a second finding that tests can write into the real user profile directory.

## Linked issues / bugs

Fixes #2934

Related: #1393 (journalling density and tool-truncation mutations), #1721 (chronology markers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history rewind accuracy by using chronology markers when available.
  * Preserved compatibility with older recordings through count-based fallback behavior.
  * Invalid or unmatched markers now safely fall back to removing the recorded number of items.
* **Tests**
  * Added coverage for restore and clear operations across history compression, missing markers, malformed markers, and mixed history entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
