### PR TITLE
Wire CompressionContext.transcriptPath so post-compression detail is recoverable (Fixes #2933)

### DIFF
--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -93,6 +93,7 @@ export class CompressionHandler {
   private _suppressDensityDirty: boolean = false;
   private _suppressDensityDirtyDepth: number = 0;
   private activeTodosProvider?: () => Promise<string | undefined>;
+  private transcriptPathProvider?: () => string | undefined;
   lastPromptTokenCount: number | null = null;
   tokenUsageLogger: TokenUsageLogger | null = null;
 
@@ -1068,6 +1069,7 @@ export class CompressionHandler {
       this.historyService,
       (profileName?) => Promise.resolve(this.providerResolver(profileName)),
       this.activeTodosProvider,
+      this.transcriptPathProvider,
       this.logger,
     );
   }
@@ -1092,6 +1094,17 @@ export class CompressionHandler {
    */
   setActiveTodosProvider(provider: () => Promise<string | undefined>): void {
     this.activeTodosProvider = provider;
+  }
+
+  /**
+   * Set the session-journal path provider callback.
+   *
+   * The provider is invoked on every compression so it observes the live
+   * recording service; it returns undefined whenever no file is materialized
+   * (issue #2933).
+   */
+  setTranscriptPathProvider(provider: () => string | undefined): void {
+    this.transcriptPathProvider = provider;
   }
 
   /**

--- a/packages/agents/src/compression/MiddleOutStrategy.ts
+++ b/packages/agents/src/compression/MiddleOutStrategy.ts
@@ -55,6 +55,7 @@ import {
   mediaBlockToCompressionPlaceholder,
 } from './utils.js';
 import { buildContinuationDirective } from '@vybestack/llxprt-code-core/core/compression/continuationDirective.js';
+import { buildTranscriptPathNotice } from '@vybestack/llxprt-code-core/core/compression/transcriptPathNotice.js';
 import { getCompressionPrompt } from '@vybestack/llxprt-code-core/core/prompts.js';
 import { estimateTokens } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
 import { buildCompressionChatOptions } from './compressionSystemPrompt.js';
@@ -707,7 +708,7 @@ ${context.activeTodos}`,
         blocks: [
           {
             type: 'text',
-            text: `Note: The full pre-compression transcript is available at: ${context.transcriptPath}`,
+            text: buildTranscriptPathNotice(context.transcriptPath),
           },
         ],
       });

--- a/packages/agents/src/compression/OneShotStrategy.ts
+++ b/packages/agents/src/compression/OneShotStrategy.ts
@@ -53,6 +53,7 @@ import {
 } from './utils.js';
 import { getCompressionPrompt } from '@vybestack/llxprt-code-core/core/prompts.js';
 import { buildContinuationDirective } from '@vybestack/llxprt-code-core/core/compression/continuationDirective.js';
+import { buildTranscriptPathNotice } from '@vybestack/llxprt-code-core/core/compression/transcriptPathNotice.js';
 import { buildCompressionChatOptions } from './compressionSystemPrompt.js';
 function destructureProviderResult(result: CompressionProviderResult): {
   provider: IProvider;
@@ -428,7 +429,7 @@ ${context.activeTodos}`,
         blocks: [
           {
             type: 'text',
-            text: `Note: The full pre-compression transcript is available at: ${context.transcriptPath}`,
+            text: buildTranscriptPathNotice(context.transcriptPath),
           },
         ],
       });

--- a/packages/agents/src/compression/__tests__/transcriptPathContext.test.ts
+++ b/packages/agents/src/compression/__tests__/transcriptPathContext.test.ts
@@ -23,11 +23,20 @@ import * as path from 'node:path';
 import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { SessionRecordingService } from '@vybestack/llxprt-code-core/recording/SessionRecordingService.js';
 import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
-import type { CompressionProviderResult } from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type {
+  CompressionContext,
+  CompressionProviderResult,
+  CompressionStrategy,
+} from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
 import type { RuntimeProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { buildRuntimeContext } from '../../core/__tests__/chatSession-density-helpers.js';
 import { CompressionHandler } from '../CompressionHandler.js';
+import { resolveTranscriptPath } from '../../core/ChatSessionFactory.js';
+import { ChatSession } from '../../core/chatSession.js';
+import * as compressionFactory from '../compressionStrategyFactory.js';
 
 const original = { ...(await import('@vybestack/llxprt-code-settings')) };
 void vi.mock('@vybestack/llxprt-code-settings', () => ({
@@ -62,6 +71,15 @@ function makeHandler(historyService: HistoryService): CompressionHandler {
 
 function textContent(text: string): IContent {
   return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+/** Narrows the recorder's nullable path after materialization. */
+function requireFilePath(service: SessionRecordingService): string {
+  const filePath = service.getFilePath();
+  if (filePath === null) {
+    throw new Error('expected the recording service to have materialized');
+  }
+  return filePath;
 }
 
 describe('CompressionHandler transcriptPath wiring (#2933)', () => {
@@ -105,11 +123,25 @@ describe('CompressionHandler transcriptPath wiring (#2933)', () => {
     return service;
   }
 
-  /** Mirrors the production closure in ChatSessionFactory. */
+  /** A recorder that has actually written its JSONL file to disk. */
+  async function materializedRecordingService(
+    name: string,
+  ): Promise<SessionRecordingService> {
+    const service = await newRecordingService(name);
+    service.recordContent(textContent('hello'));
+    await service.flush();
+    return service;
+  }
+
+  /**
+   * Installs the production resolution rule over the holder, so these tests
+   * exercise the same code the factory wires rather than a copy of it.
+   */
   function installLiveProvider(): void {
-    handler.setTranscriptPathProvider(
-      () => installed?.getFilePath() ?? undefined,
-    );
+    const config = {
+      getSessionRecordingService: () => installed,
+    } as unknown as Config;
+    handler.setTranscriptPathProvider(() => resolveTranscriptPath(config));
   }
 
   it('omits transcriptPath entirely when no provider is injected', async () => {
@@ -137,47 +169,56 @@ describe('CompressionHandler transcriptPath wiring (#2933)', () => {
   });
 
   it('publishes the materialized journal path once the file exists on disk', async () => {
-    installed = await newRecordingService('active');
+    installed = await materializedRecordingService('active');
     installLiveProvider();
-    installed.recordContent(textContent('hello'));
-    await installed.flush();
 
     const context = await handler.buildCompressionContext('prompt-1');
 
-    const materializedPath = installed.getFilePath();
-    expect(materializedPath).not.toBeNull();
-    expect(context.transcriptPath).toBe(materializedPath as string);
-    const stats = await fs.stat(context.transcriptPath as string);
+    const materializedPath = requireFilePath(installed);
+    expect(context.transcriptPath).toBe(materializedPath);
+    const stats = await fs.stat(materializedPath);
     expect(stats.isFile()).toBe(true);
   });
 
   it('follows a recording service swap and a later removal', async () => {
-    const first = await newRecordingService('first');
-    const second = await newRecordingService('second');
-    for (const service of [first, second]) {
-      service.recordContent(textContent('hello'));
-      await service.flush();
-    }
-    const firstPath = first.getFilePath();
-    const secondPath = second.getFilePath();
-    expect(firstPath).not.toBeNull();
-    expect(secondPath).not.toBeNull();
+    const first = await materializedRecordingService('first');
+    const second = await materializedRecordingService('second');
+    const firstPath = requireFilePath(first);
+    const secondPath = requireFilePath(second);
     expect(secondPath).not.toBe(firstPath);
 
     installed = first;
     installLiveProvider();
     const before = await handler.buildCompressionContext('prompt-1');
-    expect(before.transcriptPath).toBe(firstPath as string);
+    expect(before.transcriptPath).toBe(firstPath);
 
     // A resume replaces the live recording service.
     installed = second;
     const afterSwap = await handler.buildCompressionContext('prompt-2');
-    expect(afterSwap.transcriptPath).toBe(secondPath as string);
+    expect(afterSwap.transcriptPath).toBe(secondPath);
 
     // Recording is turned off again.
     installed = undefined;
     const afterStop = await handler.buildCompressionContext('prompt-3');
     expect('transcriptPath' in afterStop).toBe(false);
+  });
+
+  it('stops publishing the path once the recorder is no longer active', async () => {
+    installed = await materializedRecordingService('deactivated');
+    installLiveProvider();
+    const materializedPath = requireFilePath(installed);
+    const before = await handler.buildCompressionContext('prompt-1');
+    expect(before.transcriptPath).toBe(materializedPath);
+
+    // A recorder that stops still remembers the file it was writing to; the
+    // context must not keep advertising it as the live journal.
+    await installed.dispose();
+    expect(installed.isActive()).toBe(false);
+    expect(installed.getFilePath()).toBe(materializedPath);
+
+    const after = await handler.buildCompressionContext('prompt-2');
+
+    expect('transcriptPath' in after).toBe(false);
   });
 
   it('omits transcriptPath rather than publishing an empty string', async () => {
@@ -186,5 +227,56 @@ describe('CompressionHandler transcriptPath wiring (#2933)', () => {
     const context = await handler.buildCompressionContext('prompt-1');
 
     expect('transcriptPath' in context).toBe(false);
+  });
+});
+
+describe('ChatSession forwards the journal path into compression (#2933)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('a path installed on the chat reaches the strategy that builds the summary', async () => {
+    const historyService = new HistoryService();
+    const runtimeContext = buildRuntimeContext(historyService, {
+      contextLimit: 200_000,
+      compressionThreshold: 0.8,
+    });
+    for (const text of ['first', 'second', 'third', 'fourth']) {
+      historyService.add(textContent(text));
+    }
+    const chat = new ChatSession(
+      runtimeContext,
+      {} as unknown as ContentGenerator,
+      {},
+      [],
+    );
+
+    let seenContext: CompressionContext | undefined;
+    const strategy: CompressionStrategy = {
+      name: 'one-shot',
+      requiresLLM: true,
+      trigger: { mode: 'threshold', defaultThreshold: 0.8 },
+      compress: async (context) => {
+        seenContext = context;
+        return {
+          kind: 'applied',
+          newHistory: [textContent('summary')],
+          metadata: {
+            originalMessageCount: 4,
+            compressedMessageCount: 1,
+            strategyUsed: 'one-shot',
+            llmCallMade: false,
+          },
+        };
+      },
+    };
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockReturnValue(
+      strategy,
+    );
+
+    chat.setTranscriptPathProvider(() => '/chats/live-session.jsonl');
+    await chat.performCompression('prompt-1');
+
+    expect(seenContext?.transcriptPath).toBe('/chats/live-session.jsonl');
   });
 });

--- a/packages/agents/src/compression/__tests__/transcriptPathContext.test.ts
+++ b/packages/agents/src/compression/__tests__/transcriptPathContext.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioural tests for issue #2933: CompressionHandler must publish the
+ * session journal's path on the CompressionContext it builds.
+ *
+ * These drive the real CompressionHandler against a real HistoryService and a
+ * real SessionRecordingService writing to a real temp directory, so
+ * materialization (the point at which getFilePath() stops returning null) is
+ * genuine rather than simulated. The recording service is held in a mutable
+ * holder that stands in for the Config seam the production wiring reads, which
+ * is what lets a swap (resume) be exercised.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import { SessionRecordingService } from '@vybestack/llxprt-code-core/recording/SessionRecordingService.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { CompressionProviderResult } from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type { RuntimeProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { buildRuntimeContext } from '../../core/__tests__/chatSession-density-helpers.js';
+import { CompressionHandler } from '../CompressionHandler.js';
+
+const original = { ...(await import('@vybestack/llxprt-code-settings')) };
+void vi.mock('@vybestack/llxprt-code-settings', () => ({
+  ...original,
+  Storage: {
+    ...original.Storage,
+    getGlobalConfigDir: vi.fn(() => '/tmp/llxprt-test-config'),
+  },
+}));
+
+function makeHandler(historyService: HistoryService): CompressionHandler {
+  const runtimeContext: AgentRuntimeContext = buildRuntimeContext(
+    historyService,
+    { contextLimit: 200_000, compressionThreshold: 0.8 },
+  );
+  const provider = {
+    name: 'test',
+    generateChatCompletion: vi.fn(),
+  } as unknown as RuntimeProvider;
+  const providerResult: CompressionProviderResult = {
+    provider,
+    runtime: runtimeContext.providerRuntime,
+  };
+  return new CompressionHandler(
+    runtimeContext,
+    historyService,
+    {},
+    vi.fn().mockResolvedValue(providerResult),
+    vi.fn().mockResolvedValue(undefined),
+  );
+}
+
+function textContent(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+describe('CompressionHandler transcriptPath wiring (#2933)', () => {
+  let tempDir: string;
+  let historyService: HistoryService;
+  let handler: CompressionHandler;
+  /** Stands in for the Config seam the production provider closure reads. */
+  let installed: SessionRecordingService | undefined;
+  const created: SessionRecordingService[] = [];
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'issue2933-'));
+    historyService = new HistoryService();
+    handler = makeHandler(historyService);
+    installed = undefined;
+  });
+
+  afterEach(async () => {
+    for (const service of created.splice(0)) {
+      await service.dispose();
+    }
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  async function newRecordingService(
+    name: string,
+  ): Promise<SessionRecordingService> {
+    const chatsDir = path.join(tempDir, name);
+    await fs.mkdir(chatsDir, { recursive: true });
+    const service = new SessionRecordingService({
+      sessionId: `session-${name}`,
+      projectHash: 'abc123def456',
+      chatsDir,
+      workspaceDirs: [tempDir],
+      cwd: tempDir,
+      provider: 'test-provider',
+      model: 'test-model',
+    });
+    created.push(service);
+    return service;
+  }
+
+  /** Mirrors the production closure in ChatSessionFactory. */
+  function installLiveProvider(): void {
+    handler.setTranscriptPathProvider(
+      () => installed?.getFilePath() ?? undefined,
+    );
+  }
+
+  it('omits transcriptPath entirely when no provider is injected', async () => {
+    const context = await handler.buildCompressionContext('prompt-1');
+
+    expect('transcriptPath' in context).toBe(false);
+  });
+
+  it('omits transcriptPath when no recording service is installed', async () => {
+    installLiveProvider();
+
+    const context = await handler.buildCompressionContext('prompt-1');
+
+    expect('transcriptPath' in context).toBe(false);
+  });
+
+  it('omits transcriptPath while the recording has not materialized a file', async () => {
+    installed = await newRecordingService('unmaterialized');
+    installLiveProvider();
+
+    expect(installed.getFilePath()).toBeNull();
+    const context = await handler.buildCompressionContext('prompt-1');
+
+    expect('transcriptPath' in context).toBe(false);
+  });
+
+  it('publishes the materialized journal path once the file exists on disk', async () => {
+    installed = await newRecordingService('active');
+    installLiveProvider();
+    installed.recordContent(textContent('hello'));
+    await installed.flush();
+
+    const context = await handler.buildCompressionContext('prompt-1');
+
+    const materializedPath = installed.getFilePath();
+    expect(materializedPath).not.toBeNull();
+    expect(context.transcriptPath).toBe(materializedPath as string);
+    const stats = await fs.stat(context.transcriptPath as string);
+    expect(stats.isFile()).toBe(true);
+  });
+
+  it('follows a recording service swap and a later removal', async () => {
+    const first = await newRecordingService('first');
+    const second = await newRecordingService('second');
+    for (const service of [first, second]) {
+      service.recordContent(textContent('hello'));
+      await service.flush();
+    }
+    const firstPath = first.getFilePath();
+    const secondPath = second.getFilePath();
+    expect(firstPath).not.toBeNull();
+    expect(secondPath).not.toBeNull();
+    expect(secondPath).not.toBe(firstPath);
+
+    installed = first;
+    installLiveProvider();
+    const before = await handler.buildCompressionContext('prompt-1');
+    expect(before.transcriptPath).toBe(firstPath as string);
+
+    // A resume replaces the live recording service.
+    installed = second;
+    const afterSwap = await handler.buildCompressionContext('prompt-2');
+    expect(afterSwap.transcriptPath).toBe(secondPath as string);
+
+    // Recording is turned off again.
+    installed = undefined;
+    const afterStop = await handler.buildCompressionContext('prompt-3');
+    expect('transcriptPath' in afterStop).toBe(false);
+  });
+
+  it('omits transcriptPath rather than publishing an empty string', async () => {
+    handler.setTranscriptPathProvider(() => '');
+
+    const context = await handler.buildCompressionContext('prompt-1');
+
+    expect('transcriptPath' in context).toBe(false);
+  });
+});

--- a/packages/agents/src/compression/__tests__/transcriptPathContext.test.ts
+++ b/packages/agents/src/compression/__tests__/transcriptPathContext.test.ts
@@ -38,15 +38,6 @@ import { resolveTranscriptPath } from '../../core/ChatSessionFactory.js';
 import { ChatSession } from '../../core/chatSession.js';
 import * as compressionFactory from '../compressionStrategyFactory.js';
 
-const original = { ...(await import('@vybestack/llxprt-code-settings')) };
-void vi.mock('@vybestack/llxprt-code-settings', () => ({
-  ...original,
-  Storage: {
-    ...original.Storage,
-    getGlobalConfigDir: vi.fn(() => '/tmp/llxprt-test-config'),
-  },
-}));
-
 function makeHandler(historyService: HistoryService): CompressionHandler {
   const runtimeContext: AgentRuntimeContext = buildRuntimeContext(
     historyService,

--- a/packages/agents/src/compression/__tests__/transcriptPathInjection.test.ts
+++ b/packages/agents/src/compression/__tests__/transcriptPathInjection.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioural tests for issue #2933: when the CompressionContext carries a
+ * session journal path, both LLM compression strategies must hand the
+ * summarizing model the same accurate pointer to it.
+ *
+ * The strategies are real; only the LLM provider is substituted, and it is a
+ * capture provider that records the request it actually received.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type {
+  CompressionContext,
+  CompressionProviderResult,
+} from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { buildTranscriptPathNotice } from '@vybestack/llxprt-code-core/core/compression/transcriptPathNotice.js';
+import { OneShotStrategy } from '../OneShotStrategy.js';
+import { MiddleOutStrategy } from '../MiddleOutStrategy.js';
+import {
+  buildContext,
+  createCaptureProvider,
+  generateHistory,
+  testProviderRuntime,
+} from '../MiddleOutStrategy-test-helpers.js';
+
+const JOURNAL_PATH = '/tmp/llxprt-chats/session-2026-08-22-abcd1234.jsonl';
+
+interface Strategy {
+  compress(context: CompressionContext): Promise<unknown>;
+}
+
+/**
+ * Runs a strategy end to end and returns the text of every message the
+ * provider actually received.
+ */
+async function captureRequestText(
+  strategy: Strategy,
+  transcriptPath: string | undefined,
+): Promise<string[]> {
+  const captured: IContent[] = [];
+  const provider = createCaptureProvider(captured);
+  const base = buildContext({
+    history: generateHistory(20),
+    resolveProvider: (): CompressionProviderResult =>
+      ({
+        provider,
+        runtime: testProviderRuntime,
+      }) as unknown as CompressionProviderResult,
+  });
+  const context: CompressionContext = {
+    ...base,
+    ...(transcriptPath === undefined ? {} : { transcriptPath }),
+  };
+
+  await strategy.compress(context);
+
+  return captured.flatMap((message) =>
+    message.blocks
+      .filter((block): block is { type: 'text'; text: string } =>
+        Boolean(block.type === 'text' && 'text' in block),
+      )
+      .map((block) => block.text),
+  );
+}
+
+function noticeIn(requestText: string[]): string | undefined {
+  return requestText.find((text) => text.includes(JOURNAL_PATH));
+}
+
+describe('session journal notice injection (#2933)', () => {
+  it('OneShotStrategy hands the journal path to the summarizing model', async () => {
+    const requestText = await captureRequestText(
+      new OneShotStrategy(),
+      JOURNAL_PATH,
+    );
+
+    expect(noticeIn(requestText)).toBe(buildTranscriptPathNotice(JOURNAL_PATH));
+  });
+
+  it('MiddleOutStrategy hands the journal path to the summarizing model', async () => {
+    const requestText = await captureRequestText(
+      new MiddleOutStrategy(),
+      JOURNAL_PATH,
+    );
+
+    expect(noticeIn(requestText)).toBe(buildTranscriptPathNotice(JOURNAL_PATH));
+  });
+
+  it('both strategies emit identical notice text so the wording cannot drift', async () => {
+    const oneShotText = await captureRequestText(
+      new OneShotStrategy(),
+      JOURNAL_PATH,
+    );
+    const middleOutText = await captureRequestText(
+      new MiddleOutStrategy(),
+      JOURNAL_PATH,
+    );
+
+    const oneShotNotice = noticeIn(oneShotText);
+    const middleOutNotice = noticeIn(middleOutText);
+    expect(oneShotNotice).toBeDefined();
+    expect(middleOutNotice).toBe(oneShotNotice as string);
+  });
+
+  it('OneShotStrategy sends no journal notice when no path is present', async () => {
+    const requestText = await captureRequestText(
+      new OneShotStrategy(),
+      undefined,
+    );
+
+    expect(noticeIn(requestText)).toBeUndefined();
+    expect(requestText.some((text) => text.includes('journal'))).toBe(false);
+  });
+
+  it('MiddleOutStrategy sends no journal notice when no path is present', async () => {
+    const requestText = await captureRequestText(
+      new MiddleOutStrategy(),
+      undefined,
+    );
+
+    expect(noticeIn(requestText)).toBeUndefined();
+    expect(requestText.some((text) => text.includes('journal'))).toBe(false);
+  });
+});

--- a/packages/agents/src/compression/__tests__/transcriptPathInjection.test.ts
+++ b/packages/agents/src/compression/__tests__/transcriptPathInjection.test.ts
@@ -31,6 +31,14 @@ import {
 
 const JOURNAL_PATH = '/tmp/llxprt-chats/session-2026-08-22-abcd1234.jsonl';
 
+/**
+ * The notice text that precedes the path, derived from the builder rather than
+ * hard-coded, so the absence checks stay tied to the real contract instead of
+ * to a generic word that unrelated prompt text could contain.
+ */
+const NOTICE_PREFIX =
+  buildTranscriptPathNotice(JOURNAL_PATH).split(JOURNAL_PATH)[0];
+
 interface Strategy {
   compress(context: CompressionContext): Promise<unknown>;
 }
@@ -115,7 +123,9 @@ describe('session journal notice injection (#2933)', () => {
     );
 
     expect(noticeIn(requestText)).toBeUndefined();
-    expect(requestText.some((text) => text.includes('journal'))).toBe(false);
+    expect(requestText.some((text) => text.includes(NOTICE_PREFIX))).toBe(
+      false,
+    );
   });
 
   it('MiddleOutStrategy sends no journal notice when no path is present', async () => {
@@ -125,6 +135,8 @@ describe('session journal notice injection (#2933)', () => {
     );
 
     expect(noticeIn(requestText)).toBeUndefined();
-    expect(requestText.some((text) => text.includes('journal'))).toBe(false);
+    expect(requestText.some((text) => text.includes(NOTICE_PREFIX))).toBe(
+      false,
+    );
   });
 });

--- a/packages/agents/src/compression/compressionContextBuilder.ts
+++ b/packages/agents/src/compression/compressionContextBuilder.ts
@@ -17,6 +17,11 @@ import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 /**
  * Build CompressionContext for compression strategies.
  *
+ * `transcriptPathProvider` reports where the session journal is being written.
+ * It is a provider rather than a value because recording is optional, starts
+ * unmaterialized, and can be swapped by a resume; the key is omitted whenever
+ * no file exists so the strategies degrade silently.
+ *
  * @plan PLAN-20260211-HIGHDENSITY.P14
  * @requirement REQ-CS-001.6
  */
@@ -28,6 +33,7 @@ export async function buildCompressionContext(
     profileName?: string,
   ) => Promise<CompressionProviderResult>,
   activeTodosProvider: (() => Promise<string | undefined>) | undefined,
+  transcriptPathProvider: (() => string | undefined) | undefined,
   logger: DebugLogger,
 ): Promise<CompressionContext> {
   const promptResolver = new PromptResolver();
@@ -41,6 +47,10 @@ export async function buildCompressionContext(
       logger.debug('Failed to fetch active todos for compression', error);
     }
   }
+
+  // Resolved on every build so a recording service that is enabled, disabled,
+  // or swapped mid-session (resume) is reflected at the next compression.
+  const transcriptPath = transcriptPathProvider?.();
 
   const config = runtimeContext.providerRuntime.config;
 
@@ -61,6 +71,7 @@ export async function buildCompressionContext(
     },
     promptId,
     ...(activeTodos ? { activeTodos } : {}),
+    ...(transcriptPath ? { transcriptPath } : {}),
     compressionVerification:
       runtimeContext.ephemerals.compressionVerification(),
     ...(config ? { config } : {}),

--- a/packages/agents/src/core/ChatSessionFactory.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.test.ts
@@ -30,6 +30,7 @@ void vi.mock('@vybestack/llxprt-code-core/utils/environmentContext.js', () => ({
 void vi.mock('./chatSession.js', () => ({
   ChatSession: vi.fn().mockImplementation(() => ({
     setActiveTodosProvider: vi.fn(),
+    setTranscriptPathProvider: vi.fn(),
     getHistoryService: vi.fn().mockReturnValue(null),
   })),
 }));
@@ -657,6 +658,7 @@ describe('createChatSession', () => {
     const todoContinuationService = makeTodoContinuationService();
     const mockChat = {
       setActiveTodosProvider: vi.fn(),
+      setTranscriptPathProvider: vi.fn(),
       getHistoryService: vi.fn().mockReturnValue(null),
     };
     (

--- a/packages/agents/src/core/ChatSessionFactory.tokenReestimate.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.tokenReestimate.test.ts
@@ -29,6 +29,7 @@ void vi.mock('@vybestack/llxprt-code-core/utils/environmentContext.js', () => ({
 void vi.mock('./chatSession.js', () => ({
   ChatSession: vi.fn().mockImplementation(() => ({
     setActiveTodosProvider: vi.fn(),
+    setTranscriptPathProvider: vi.fn(),
     getHistoryService: vi.fn().mockReturnValue(null),
   })),
 }));

--- a/packages/agents/src/core/ChatSessionFactory.transcriptPath.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.transcriptPath.test.ts
@@ -1,0 +1,209 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioural tests for issue #2933: createChatSession must hand the chat a
+ * transcript path provider that reads the recording service off Config on
+ * every call. Recording can be enabled part way through a session, swapped for
+ * a different service by a resume, or stopped, and the JSONL file does not
+ * exist until the recorder materializes it — a value captured at construction
+ * would be wrong in all four situations.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'bun:test';
+
+void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('core system prompt'),
+}));
+
+void vi.mock('./clientToolGovernance.js', () => ({
+  getToolGovernanceEphemerals: vi.fn().mockReturnValue(undefined),
+  getEnabledToolNamesForPrompt: vi.fn().mockReturnValue(['tool_a', 'tool_b']),
+  shouldIncludeSubagentDelegationForConfig: vi.fn().mockResolvedValue(false),
+  buildToolDeclarationsFromView: vi.fn().mockReturnValue([]),
+}));
+
+void vi.mock('@vybestack/llxprt-code-core/utils/environmentContext.js', () => ({
+  getEnvironmentContext: vi.fn().mockResolvedValue([]),
+}));
+
+void vi.mock('./chatSession.js', () => ({
+  ChatSession: vi.fn().mockImplementation(() => ({
+    setActiveTodosProvider: vi.fn(),
+    setTranscriptPathProvider: vi.fn(),
+    getHistoryService: vi.fn().mockReturnValue(null),
+  })),
+}));
+
+void vi.mock(
+  '@vybestack/llxprt-code-core/runtime/AgentRuntimeLoader.js',
+  () => ({
+    loadAgentRuntime: vi.fn().mockResolvedValue({
+      runtimeContext: {},
+      contentGenerator: {},
+      toolsView: { listToolNames: () => [] },
+      history: {},
+      providerAdapter: {},
+      telemetryAdapter: {},
+    }),
+  }),
+);
+
+void vi.mock(
+  '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js',
+  () => ({
+    setProviderRuntimeStateFactory: vi.fn(),
+    createProviderRuntimeContext: vi.fn().mockReturnValue({}),
+  }),
+);
+
+void vi.mock(
+  '@vybestack/llxprt-code-core/services/history/HistoryService.js',
+  () => ({
+    HistoryService: vi.fn().mockImplementation(() => ({
+      add: vi.fn(),
+      generateTurnKey: vi.fn().mockReturnValue('turn-1'),
+      setBaseTokenOffset: vi.fn(),
+      estimateTokensForText: vi.fn().mockResolvedValue(100),
+      setTokenizerFactory: vi.fn(),
+      setActiveTokenizationTarget: vi.fn(),
+      resetTokenAccounting: vi.fn(),
+      recalculateTotalTokens: vi.fn().mockResolvedValue(undefined),
+      isEmpty: vi.fn().mockReturnValue(true),
+      getAll: vi.fn().mockReturnValue([]),
+    })),
+  }),
+);
+
+void vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
+  reportError: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createChatSession } from './ChatSessionFactory.js';
+import { ChatSession } from './chatSession.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import type { TodoContinuationService } from './TodoContinuationService.js';
+
+interface RecordingServiceStub {
+  getFilePath: () => string | null;
+}
+
+function makeConfig(
+  getSessionRecordingService: () => RecordingServiceStub | undefined,
+): Config {
+  return {
+    getEphemeralSetting: vi.fn().mockReturnValue(undefined),
+    isJitContextEnabled: vi.fn().mockReturnValue(false),
+    getGlobalMemory: vi.fn().mockReturnValue(undefined),
+    getUserMemory: vi.fn().mockReturnValue('user memory text'),
+    getCoreMemory: vi.fn().mockReturnValue('core memory text'),
+    getJitMemoryForPath: vi.fn().mockResolvedValue(null),
+    getMcpInstructions: vi.fn().mockReturnValue(undefined),
+    isInteractive: vi.fn().mockReturnValue(true),
+    getWorkingDir: vi.fn().mockReturnValue('/workspace'),
+    getSettingsService: vi.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue(undefined),
+    }),
+    getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+    getModel: vi.fn().mockReturnValue('gemini-2.5-flash'),
+    getToolRegistry: vi.fn().mockReturnValue(undefined),
+    getProviderManager: vi.fn().mockReturnValue(undefined),
+    getSessionRecordingService,
+  } as unknown as Config;
+}
+
+function makeRuntimeState(): AgentRuntimeState {
+  return {
+    model: 'gemini-2.5-flash',
+    provider: 'gemini',
+    runtimeId: 'test-runtime-id',
+    sessionId: 'test-session-id',
+    proxyUrl: undefined,
+  } as unknown as AgentRuntimeState;
+}
+
+function makeTodoContinuationService(): TodoContinuationService {
+  return {
+    updateTodoToolAvailabilityFromDeclarations: vi.fn(),
+    readTodoSnapshot: vi.fn().mockResolvedValue([]),
+    getActiveTodos: vi.fn().mockReturnValue([]),
+  } as unknown as TodoContinuationService;
+}
+
+describe('createChatSession transcript path wiring (#2933)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Builds a chat session against a Config whose recording service can be
+   * changed afterwards, and returns the provider the factory installed.
+   */
+  async function wireProvider(
+    readRecording: () => RecordingServiceStub | undefined,
+  ): Promise<() => string | undefined> {
+    const installedProviders: Array<() => string | undefined> = [];
+    const chatDouble = {
+      setActiveTodosProvider: vi.fn(),
+      setTranscriptPathProvider: (provider: () => string | undefined) => {
+        installedProviders.push(provider);
+      },
+      getHistoryService: vi.fn().mockReturnValue(null),
+    };
+    (
+      ChatSession as unknown as Mock<(...args: never[]) => unknown>
+    ).mockImplementationOnce(() => chatDouble as unknown as ChatSession);
+
+    await createChatSession({
+      config: makeConfig(readRecording),
+      runtimeState: makeRuntimeState(),
+      contentGenerator: {} as unknown as ContentGenerator,
+      storedHistoryService: undefined,
+      clearStoredHistoryService: vi.fn(),
+      generateContentConfig: {},
+      todoContinuationService: makeTodoContinuationService(),
+      toolRegistry: undefined,
+    });
+
+    expect(installedProviders).toHaveLength(1);
+    return installedProviders[0];
+  }
+
+  it('resolves no path while recording is disabled', async () => {
+    const resolvePath = await wireProvider(() => undefined);
+
+    expect(resolvePath()).toBeUndefined();
+  });
+
+  it('resolves no path while the recording has not materialized a file', async () => {
+    const resolvePath = await wireProvider(() => ({ getFilePath: () => null }));
+
+    expect(resolvePath()).toBeUndefined();
+  });
+
+  it('resolves the materialized path of the installed recording', async () => {
+    const resolvePath = await wireProvider(() => ({
+      getFilePath: () => '/chats/session-one.jsonl',
+    }));
+
+    expect(resolvePath()).toBe('/chats/session-one.jsonl');
+  });
+
+  it('follows a resume that swaps the recording service, then a stop', async () => {
+    let installed: RecordingServiceStub | undefined = {
+      getFilePath: () => '/chats/session-one.jsonl',
+    };
+    const resolvePath = await wireProvider(() => installed);
+
+    expect(resolvePath()).toBe('/chats/session-one.jsonl');
+
+    installed = { getFilePath: () => '/chats/resumed-session.jsonl' };
+    expect(resolvePath()).toBe('/chats/resumed-session.jsonl');
+
+    installed = undefined;
+    expect(resolvePath()).toBeUndefined();
+  });
+});

--- a/packages/agents/src/core/ChatSessionFactory.transcriptPath.test.ts
+++ b/packages/agents/src/core/ChatSessionFactory.transcriptPath.test.ts
@@ -88,7 +88,12 @@ import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentG
 import type { TodoContinuationService } from './TodoContinuationService.js';
 
 interface RecordingServiceStub {
+  isActive: () => boolean;
   getFilePath: () => string | null;
+}
+
+function activeRecording(filePath: string | null): RecordingServiceStub {
+  return { isActive: () => true, getFilePath: () => filePath };
 }
 
 function makeConfig(
@@ -179,28 +184,37 @@ describe('createChatSession transcript path wiring (#2933)', () => {
   });
 
   it('resolves no path while the recording has not materialized a file', async () => {
-    const resolvePath = await wireProvider(() => ({ getFilePath: () => null }));
+    const resolvePath = await wireProvider(() => activeRecording(null));
+
+    expect(resolvePath()).toBeUndefined();
+  });
+
+  it('resolves no path from a recorder that stopped on a write failure', async () => {
+    const resolvePath = await wireProvider(() => ({
+      isActive: () => false,
+      getFilePath: () => '/chats/session-one.jsonl',
+    }));
 
     expect(resolvePath()).toBeUndefined();
   });
 
   it('resolves the materialized path of the installed recording', async () => {
-    const resolvePath = await wireProvider(() => ({
-      getFilePath: () => '/chats/session-one.jsonl',
-    }));
+    const resolvePath = await wireProvider(() =>
+      activeRecording('/chats/session-one.jsonl'),
+    );
 
     expect(resolvePath()).toBe('/chats/session-one.jsonl');
   });
 
   it('follows a resume that swaps the recording service, then a stop', async () => {
-    let installed: RecordingServiceStub | undefined = {
-      getFilePath: () => '/chats/session-one.jsonl',
-    };
+    let installed: RecordingServiceStub | undefined = activeRecording(
+      '/chats/session-one.jsonl',
+    );
     const resolvePath = await wireProvider(() => installed);
 
     expect(resolvePath()).toBe('/chats/session-one.jsonl');
 
-    installed = { getFilePath: () => '/chats/resumed-session.jsonl' };
+    installed = activeRecording('/chats/resumed-session.jsonl');
     expect(resolvePath()).toBe('/chats/resumed-session.jsonl');
 
     installed = undefined;

--- a/packages/agents/src/core/ChatSessionFactory.ts
+++ b/packages/agents/src/core/ChatSessionFactory.ts
@@ -328,14 +328,30 @@ async function buildChatFromRuntime(
     return active.map((t) => `- [${t.status}] ${t.content}`).join('\n');
   });
 
-  // Resolved off Config on every call rather than captured here: recording can
-  // be enabled, disabled, or swapped for a different service by a resume, and
-  // the path is null until the JSONL file materializes (issue #2933).
-  chat.setTranscriptPathProvider(
-    () => config.getSessionRecordingService()?.getFilePath() ?? undefined,
-  );
+  chat.setTranscriptPathProvider(() => resolveTranscriptPath(config));
 
   return chat;
+}
+
+/**
+ * Where the session journal for this session is being written, or undefined
+ * when there is nothing to point at (issue #2933).
+ *
+ * Read off Config on every call rather than captured once: recording is
+ * optional, can be enabled part way through a session, and is replaced with a
+ * different service by a resume. A recorder that has stopped — disposed, or
+ * deactivated by a write failure — still remembers the path it used, so
+ * liveness is decided by `isActive()`, not by the path alone.
+ */
+export function resolveTranscriptPath(config: Config): string | undefined {
+  const recording = config.getSessionRecordingService();
+  if (!recording) {
+    return undefined;
+  }
+  if (!recording.isActive()) {
+    return undefined;
+  }
+  return recording.getFilePath() ?? undefined;
 }
 
 /**

--- a/packages/agents/src/core/ChatSessionFactory.ts
+++ b/packages/agents/src/core/ChatSessionFactory.ts
@@ -328,6 +328,13 @@ async function buildChatFromRuntime(
     return active.map((t) => `- [${t.status}] ${t.content}`).join('\n');
   });
 
+  // Resolved off Config on every call rather than captured here: recording can
+  // be enabled, disabled, or swapped for a different service by a resume, and
+  // the path is null until the JSONL file materializes (issue #2933).
+  chat.setTranscriptPathProvider(
+    () => config.getSessionRecordingService()?.getFilePath() ?? undefined,
+  );
+
   return chat;
 }
 

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -691,6 +691,10 @@ export class ChatSession {
     this.compressionHandler.setActiveTodosProvider(provider);
   }
 
+  setTranscriptPathProvider(provider: () => string | undefined): void {
+    this.compressionHandler.setTranscriptPathProvider(provider);
+  }
+
   async performCompression(
     prompt_id: string,
     options?: { bypassCooldown?: boolean; trigger?: 'manual' | 'auto' },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -333,6 +333,10 @@
       "bun": "./src/core/compression/continuationDirective.ts",
       "import": "./dist/src/core/compression/continuationDirective.js"
     },
+    "./core/compression/transcriptPathNotice.js": {
+      "bun": "./src/core/compression/transcriptPathNotice.ts",
+      "import": "./dist/src/core/compression/transcriptPathNotice.js"
+    },
     "./core/compression/types.js": {
       "bun": "./src/core/compression/types.ts",
       "import": "./dist/src/core/compression/types.js"

--- a/packages/core/src/core/compression/transcriptPathNotice.test.ts
+++ b/packages/core/src/core/compression/transcriptPathNotice.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for the shared session-journal notice (issue #2933). The wording is a
+ * correctness fix as much as a shared string: the recorded journal is not
+ * guaranteed to be a complete transcript, and reading it whole would cost more
+ * context than the compression that prompted the lookup saved.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { buildTranscriptPathNotice } from './transcriptPathNotice.js';
+
+describe('buildTranscriptPathNotice', () => {
+  it('embeds the supplied path verbatim', () => {
+    const notice = buildTranscriptPathNotice(
+      '/home/user/.llxprt/chats/session-2026-08-22.jsonl',
+    );
+
+    expect(notice).toContain(
+      '/home/user/.llxprt/chats/session-2026-08-22.jsonl',
+    );
+  });
+
+  it('distinguishes different paths', () => {
+    const first = buildTranscriptPathNotice('/tmp/a.jsonl');
+    const second = buildTranscriptPathNotice('/tmp/b.jsonl');
+
+    expect(first).not.toBe(second);
+    expect(first).not.toContain('/tmp/b.jsonl');
+  });
+
+  it('does not claim the journal is a complete transcript', () => {
+    const notice = buildTranscriptPathNotice('/tmp/a.jsonl');
+
+    expect(notice).not.toContain('full pre-compression transcript');
+    expect(notice.toLowerCase()).toContain('incomplete');
+  });
+
+  it('steers toward searching the file rather than reading it whole', () => {
+    const notice = buildTranscriptPathNotice('/tmp/a.jsonl');
+
+    expect(notice.toLowerCase()).toContain('search');
+    expect(notice.toLowerCase()).toContain('not read whole');
+  });
+
+  it('asks for the path to survive into the summary', () => {
+    const notice = buildTranscriptPathNotice('/tmp/a.jsonl');
+
+    expect(notice.toLowerCase()).toContain('verbatim in your summary');
+  });
+});

--- a/packages/core/src/core/compression/transcriptPathNotice.ts
+++ b/packages/core/src/core/compression/transcriptPathNotice.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Builds the notice appended to a compression request when a session recording
+ * has materialized a file on disk. Shared by both LLM compression strategies
+ * (OneShotStrategy and MiddleOutStrategy) so the two cannot drift.
+ *
+ * The wording deliberately avoids calling the file a "full transcript":
+ * recording is optional, can be enabled part way through a session (seeding
+ * only the history present at that moment), and deactivates on a write
+ * failure. It also steers the reader toward searching the file for a specific
+ * string, because the journal contains full tool results and reading it whole
+ * would burn more context than the compression saved.
+ *
+ * The notice is part of the compression request, so it asks the summarizing
+ * model to carry the path into the summary — that is what makes the pointer
+ * outlive the compression that drops the detail.
+ */
+export function buildTranscriptPathNotice(transcriptPath: string): string {
+  return (
+    `Note: a JSONL journal of this session is being recorded at: ${transcriptPath}\n` +
+    `The journal may be incomplete — recording can begin part way through a session and can stop on a write error. ` +
+    `Preserve this path verbatim in your summary, and record that detail dropped by compression may be recoverable by ` +
+    `searching that file for the specific text needed. The file holds full tool results and can be very large, so it ` +
+    `should be searched, not read whole.`
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,7 @@ export {
   hasInteractiveSubagentScheduler,
 } from './core/subagentTypes.js';
 export { buildContinuationDirective } from './core/compression/continuationDirective.js';
+export { buildTranscriptPathNotice } from './core/compression/transcriptPathNotice.js';
 
 export * from './code_assist/codeAssist.js';
 export * from './code_assist/server.js';

--- a/project-plans/issue2933-transcript-path/plan.md
+++ b/project-plans/issue2933-transcript-path/plan.md
@@ -1,0 +1,134 @@
+# Issue #2933 — Wire `CompressionContext.transcriptPath`
+
+Plan date: 2026-08-22
+Branch: `issue2933`
+
+## Problem
+
+`CompressionContext.transcriptPath` (`packages/core/src/core/compression/types.ts:157`)
+is declared and consumed by both LLM compression strategies, but nothing ever
+populates it. The consumer code is therefore dead:
+
+- `packages/agents/src/compression/OneShotStrategy.ts:425-435`
+- `packages/agents/src/compression/MiddleOutStrategy.ts:704-714`
+
+Both append the same hard-coded line to the compression request when the field
+is present. The value that belongs there already exists:
+`SessionRecordingService.getFilePath()`, resolved live off `Config` and already
+used for the hook system's `transcript_path`
+(`packages/core/src/hooks/hookEventHandler.ts:204-205`).
+
+The existing injected wording is also inaccurate: it claims a "full
+pre-compression transcript", but recording can start mid-session
+(`sessionControl.ts:875-917` seeds only current history) and can deactivate on
+write failure.
+
+## Accepted behavior
+
+1. **AB1 — populated when materialized.** `CompressionHandler.buildCompressionContext()`
+   returns a context whose `transcriptPath` equals the current session
+   recording's materialized file path.
+2. **AB2 — absent, not empty.** When there is no recording service, when the
+   recording exists but has not materialized a file yet (`getFilePath()` is
+   `null`), or when recording was deactivated and the path is gone, the
+   `transcriptPath` key is **absent** from the built context (`in` returns
+   false), never `''`.
+3. **AB3 — live resolution.** The path is resolved at compression time through
+   an injected provider closure, not captured at construction. Enabling,
+   disabling, or swapping the recording service (resume) between two
+   `buildCompressionContext()` calls is reflected in the second call.
+4. **AB4 — accurate, shared wording.** Both `OneShotStrategy` and
+   `MiddleOutStrategy` inject the identical notice, produced by one shared
+   builder in core. The notice describes a session journal that may be
+   incomplete, and steers toward searching the file for a specific string
+   rather than reading it whole.
+
+## Boundary cases
+
+| Input | Expected |
+| --- | --- |
+| No provider injected (subagent/executor chat sessions, tests) | key absent |
+| Provider returns `undefined` (no recording service on Config) | key absent |
+| Provider returns `undefined` because `getFilePath()` is `null` (unmaterialized) | key absent |
+| Provider returns `''` | key absent (empty is not a path) |
+| Provider returns a real path | key present with exactly that path |
+| Recording service swapped on Config between builds | second build sees the new path |
+| Recording service removed from Config between builds | second build omits the key |
+
+## Design
+
+Mirror the existing `activeTodosProvider` injection chain exactly:
+
+```
+ChatSessionFactory.buildChatFromRuntime()
+  -> chat.setTranscriptPathProvider(() =>
+       config.getSessionRecordingService()?.getFilePath() ?? undefined)
+  -> ChatSession.setTranscriptPathProvider()
+  -> CompressionHandler.setTranscriptPathProvider()
+  -> buildCompressionContext(..., transcriptPathProvider, ...)
+```
+
+The provider is synchronous (`() => string | undefined`) because
+`getFilePath()` is a synchronous field read; `activeTodosProvider` is async only
+because reading a todo snapshot is I/O.
+
+Liveness (AB3) comes from resolving `config.getSessionRecordingService()` inside
+the closure on every call. `sessionControl` installs/removes/swaps the service on
+Config (`setSessionRecordingService` at lines 294, 307, 392, 911, 1003), so the
+closure observes every transition with no extra plumbing.
+
+Shared wording lives in a new
+`packages/core/src/core/compression/transcriptPathNotice.ts`, following the
+precedent of `continuationDirective.ts` (pure string builder in core, imported by
+both strategies in `packages/agents`).
+
+## Files to change
+
+- **new** `packages/core/src/core/compression/transcriptPathNotice.ts` —
+  `buildTranscriptPathNotice(transcriptPath: string): string`.
+- `packages/core/src/index.ts` — export it next to `buildContinuationDirective`.
+- `packages/agents/src/compression/OneShotStrategy.ts` — use the shared builder.
+- `packages/agents/src/compression/MiddleOutStrategy.ts` — use the shared builder.
+- `packages/agents/src/compression/compressionContextBuilder.ts` — accept
+  `transcriptPathProvider` and conditionally spread `transcriptPath`.
+- `packages/agents/src/compression/CompressionHandler.ts` — field + setter, pass
+  through to the builder.
+- `packages/agents/src/core/chatSession.ts` — delegating setter.
+- `packages/agents/src/core/ChatSessionFactory.ts` — wire the closure off `config`.
+- `packages/agents/src/core/ChatSessionFactory.test.ts` and
+  `ChatSessionFactory.tokenReestimate.test.ts` — chat doubles need the new method.
+
+## Tests (written first)
+
+1. `packages/agents/src/compression/__tests__/transcriptPathContext.test.ts`
+   - AB1/AB2/AB3 through the real `CompressionHandler.buildCompressionContext()`
+     with a real `SessionRecordingService` in a temp dir: before materialization
+     the key is absent; after `recordContent` + `flush` the key equals
+     `service.getFilePath()`; after swapping in a second service the next build
+     returns the second path; after removing the service the key is absent again.
+   - Provider returning `''` yields an absent key.
+   - No provider at all yields an absent key.
+2. `packages/agents/src/compression/__tests__/transcriptPathInjection.test.ts`
+   - Behavioral, through `OneShotStrategy.compress()` and
+     `MiddleOutStrategy.compress()` with a fake provider that captures the
+     request messages: with `transcriptPath` set, the request contains the
+     notice, containing the path; both strategies emit byte-identical notice
+     text; with the field unset, no notice appears.
+   - Wording accuracy: notice does not claim a "full" transcript and mentions
+     searching.
+3. `packages/core/src/core/compression/transcriptPathNotice.test.ts`
+   - The builder embeds the given path and produces the same output for the same
+     input (pure function contract used by both strategies).
+4. `packages/agents/src/core/ChatSessionFactory.test.ts`
+   - Capture the provider handed to the chat and invoke it: returns the path of
+     the recording service currently installed on Config, returns `undefined`
+     when none is installed, and returns the new path after Config swaps the
+     service (AB3 at the wiring seam).
+
+## Out of scope
+
+- What the session journal records.
+- Subagent/executor chat sessions (`subagentRuntimeSetup.ts`, `executor.ts`) do
+  not wire `activeTodosProvider` either; matching that seam is not part of this
+  issue.
+- Any context-architecture or mutation-journaling work (#1393).

--- a/project-plans/issue2933-transcript-path/plan.md
+++ b/project-plans/issue2933-transcript-path/plan.md
@@ -125,6 +125,20 @@ both strategies in `packages/agents`).
      when none is installed, and returns the new path after Config swaps the
      service (AB3 at the wiring seam).
 
+## Review triage
+
+Findings from the design review and from Open Code Review, with disposition.
+
+| Finding | Disposition |
+| --- | --- |
+| A recorder deactivated by a write failure still returns its old path, so `transcriptPath` kept advertising a dead journal | **Blocker-Fix.** Acceptance criterion 2 names this case. Resolution moved into `resolveTranscriptPath`, which requires `isActive()`; covered by a real-recorder test and a factory test. |
+| The direct core subpath imported by both strategies was missing from `packages/core/package.json` exports | **Blocker-Fix.** Added, matching the `continuationDirective.js` entry. |
+| `ChatSession.setTranscriptPathProvider` sat between two tested halves without being tested itself | **In-scope-Fix.** Added a test driving a real `ChatSession` through `performCompression` and asserting the path reaches the strategy's context. |
+| Wrap `transcriptPathProvider?.()` in try/catch for symmetry with `activeTodosProvider` | **Reject.** `activeTodosProvider` is guarded because it reads a todo snapshot from disk. This provider reads a field off Config and cannot throw; adding a swallow contradicts the project's fail-fast preference and would hide a real bug. |
+| `ChatSessionFactory.test.ts` adds `setTranscriptPathProvider` to its chat double without asserting on it | **Reject.** `ChatSessionFactory.transcriptPath.test.ts` captures the installed provider and invokes it, which is a stronger check than asserting the setter was called. |
+| The hoisted `vi.mock` of `@vybestack/llxprt-code-settings` in the context test risks a TDZ error and interacts badly with `restoreAllMocks` | **In-scope-Fix by removal.** The mock was unnecessary; the tests pass against the real `Storage.getGlobalConfigDir()`. |
+| Type assertions in the new tests | **Reject.** The `as unknown as` fixtures match the established convention in the neighbouring test files. The nullable-path assertions were removed in favour of a narrowing helper. |
+
 ## Out of scope
 
 - What the session journal records.


### PR DESCRIPTION
## TLDR

`CompressionContext.transcriptPath` was declared and consumed but never set, so the recovery pointer both LLM compression strategies inject could never fire. This connects the wire: `CompressionHandler` now takes a transcript path provider (mirroring the existing `activeTodosProvider` injection) and `ChatSessionFactory` resolves it from the live `SessionRecordingService` on Config at compression time.

The wording those strategies inject was also wrong. It promised "the full pre-compression transcript" for a file that can start part way through a session and stop on a write error. Both strategies now share one builder in core that describes the file honestly and steers toward searching it rather than reading it whole.

Reviewers should look hardest at `resolveTranscriptPath` in `ChatSessionFactory.ts` — that is where every acceptance criterion about absence lives.

## Dive Deeper

**The chain.** `ChatSessionFactory.buildChatFromRuntime` → `chat.setTranscriptPathProvider(() => resolveTranscriptPath(config))` → `ChatSession` → `CompressionHandler` → `buildCompressionContext`, which spreads the key in conditionally, exactly like `activeTodos`. The provider is synchronous because `getFilePath()` is a field read; `activeTodosProvider` is async only because it reads a todo snapshot from disk.

**Why a provider and not a value.** Recording is optional and the Agents API starts with it disabled. The file does not exist until the recorder materializes it, so `getFilePath()` is `null` for a while. A resume builds a fresh service and installs it on Config. Capturing anything at construction would be wrong in all three cases, so the closure reads `config.getSessionRecordingService()` on every call.

**Absence, not empty string.** `resolveTranscriptPath` returns `undefined` when no service is installed, when the service is not `isActive()`, or when it has not materialized a file. The builder then omits the key entirely rather than writing `''`, so `'transcriptPath' in context` is false and the strategies stay silent. The `isActive()` check matters: a recorder that stopped — disposed, or deactivated by an `ENOSPC`/`EACCES` write failure — keeps returning the path it was writing to, and advertising that as the live journal would be a lie.

**Wording.** `packages/core/src/core/compression/transcriptPathNotice.ts` follows the precedent of `continuationDirective.ts`: a pure string builder in core imported by both strategies, so the two cannot drift. It calls the file a JSONL session journal, says plainly that it may be incomplete, asks the summarizing model to carry the path into the summary (otherwise the pointer dies with the pre-compression request), and says to search it rather than read it whole because it holds full tool results.

**Not wired.** Subagent and executor chat sessions (`subagentRuntimeSetup.ts`, `executor.ts`) do not get this, for the same reason they do not get `activeTodosProvider`: their histories are not written to the foreground session recording, so pointing their compression at that journal would be misleading.

**Reviewed.** Design review and Open Code Review both ran against this branch. Two findings were fixed as blockers (the inactive-recorder leak above, and the missing `packages/core/package.json` export for the new subpath). One test-quality finding was fixed by adding coverage for the `ChatSession` forwarding setter, which previously sat between two tested halves. A suggestion to wrap the provider in try/catch was rejected: it reads a field off Config and cannot throw, and swallowing there would contradict the project's fail-fast preference. The full triage table is in `project-plans/issue2933-transcript-path/plan.md`.

## Reviewer Test Plan

Behavioural coverage, all runnable directly:

```bash
cd packages/agents && bun test src/compression/__tests__/transcriptPathContext.test.ts
cd packages/agents && bun test src/compression/__tests__/transcriptPathInjection.test.ts
cd packages/agents && bun test src/core/ChatSessionFactory.transcriptPath.test.ts
cd packages/core   && bun test src/core/compression/transcriptPathNotice.test.ts
```

- `transcriptPathContext.test.ts` drives the real `CompressionHandler` against a real `HistoryService` and real `SessionRecordingService` instances writing to real temp directories, so materialization and deactivation are genuine rather than simulated. It covers: no provider, no recorder, unmaterialized recorder, materialized recorder (asserting the file exists on disk), a resume swap, removal, deactivation while still installed, and an empty-string provider. It also drives a real `ChatSession` through `performCompression` and asserts the path reaches the strategy's context.
- `transcriptPathInjection.test.ts` runs the real `OneShotStrategy` and `MiddleOutStrategy` against a capture provider and asserts on the request the provider actually received, including that both strategies emit byte-identical notice text.
- `ChatSessionFactory.transcriptPath.test.ts` captures the closure the factory installs and invokes it against a Config whose recording service changes underneath, which is how the live-resolution requirement is proved.

Manually: start a session with recording enabled, let compression fire, and confirm the summary carries the journal path; disable recording and confirm nothing is injected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Local verification on macOS: `npm run format`, `npm run lint`, `npm run typecheck`, `npm run build`, `npm run test`, and the `stepfun-37` startup smoke all pass. Two agents test files (`mcp-discovery.spec.ts`, `staleClient.behavior.test.ts`) hit the 180s per-test timeout under full-suite load and pass in 1.3s in isolation; `RipgrepPathResolver` fails identically on `main`.

## Linked issues / bugs

Fixes #2933


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compression workflows now receive the active session transcript path when a recording is available.
  * Transcript guidance preserves the journal path and advises efficient searching during summarization.
  * Transcript paths update automatically as recordings start, stop, or change.
  * Added a public utility for generating transcript-path notices.

* **Bug Fixes**
  * Improved handling when recordings are unavailable, incomplete, or have no materialized file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->