### PR TITLE
Preserve adjacent tool metadata in provider history

### DIFF
--- a/packages/agents/src/compression/cacheAnchor.test.ts
+++ b/packages/agents/src/compression/cacheAnchor.test.ts
@@ -93,6 +93,62 @@ describe('applyCompressionWithAnchor — cacheAnchor marker (#3070)', () => {
     expect(rebuilt[topPreserved - 1].metadata?.chronology?.seq).toBeDefined();
   });
 
+  it('anchors the preserved-head tool content after a complete tool round-trip', () => {
+    const historyService = new HistoryService();
+    const toolCallId = 'compression-tool-call';
+    const roundTrip: IContent[] = [
+      human('Read the file'),
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: toolCallId,
+            name: 'read_file',
+            parameters: { path: 'file.txt' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: toolCallId,
+            toolName: 'read_file',
+            result: 'contents',
+            isComplete: true,
+          },
+        ],
+      },
+      ai('The file was read'),
+    ];
+    for (const content of roundTrip) {
+      historyService.add(content, 'test-model');
+    }
+    const stamped = historyService.getAll();
+
+    apply(
+      historyService,
+      [
+        stamped[0],
+        stamped[1],
+        stamped[2],
+        summary('compressed remainder'),
+        human('tail'),
+      ],
+      3,
+    );
+
+    const rebuilt = historyService.getAll();
+    const anchored = rebuilt.filter(
+      (content) => content.metadata?.cacheAnchor === true,
+    );
+    expect(anchored).toHaveLength(1);
+    expect(anchored[0].speaker).toBe('tool');
+    expect(anchored[0].blocks[0].type).toBe('tool_response');
+  });
+
   it('clears stale markers so exactly one entry carries the marker after a second compression', () => {
     const historyService = new HistoryService();
     for (const c of [human('seed1'), ai('seed2')]) {

--- a/packages/agents/src/core/tokenUsageRequestShape.ts
+++ b/packages/agents/src/core/tokenUsageRequestShape.ts
@@ -262,13 +262,12 @@ function hasToolBlock(content: IContent): boolean {
  *   4. history   — everything else
  *
  * Tool content is classified structurally, ahead of the `synthetic` flag,
- * because the provider pipeline rebuilds tool turns through
- * `ensureToolResponseAdjacency` and stamps `synthetic: true` with
- * `reason: 'reordered_tool_responses'` on every one of them — even when nothing
- * was actually reordered. Trusting the flag put all tool results into
- * `injected_tokens` and left `history_tokens` excluding them, which inverted
- * what both fields mean. A tool round-trip is conversation history; genuine
- * injections (IDE context, system reminders) carry no tool blocks.
+ * because genuinely rebuilt or reordered tool turns carry `synthetic: true`
+ * with `reason: 'reordered_tool_responses'`. Those tool results remain part of
+ * the conversation history. Trusting the flag alone put them in
+ * `injected_tokens` and excluded them from `history_tokens`, which inverted what
+ * both fields mean. Genuine injections such as IDE context and system reminders
+ * carry no tool blocks.
  */
 type ContentBucket = 'injected' | 'media' | 'history';
 

--- a/packages/agents/src/core/tokenUsageShapeCost.test.ts
+++ b/packages/agents/src/core/tokenUsageShapeCost.test.ts
@@ -224,12 +224,10 @@ describe('request-shape measurement cost guards (issue #3130)', () => {
 
 describe('bucket attribution against the real history pipeline (issue #3130)', () => {
   it('counts a tool result as history, not as an injection', async () => {
-    // The provider pipeline rebuilds every tool turn through
-    // ensureToolResponseAdjacency and stamps synthetic:true with
-    // reason:'reordered_tool_responses' even when nothing was reordered. Reading
-    // that flag put all tool results in injected_tokens and left history_tokens
-    // excluding them. Driven through the real HistoryService so the quirk is
-    // present rather than assumed.
+    // An ordinary adjacent tool turn remains source history through
+    // ensureToolResponseAdjacency and must not be marked synthetic. Drive the
+    // attribution through the real HistoryService so the premise and token
+    // buckets cover the same provider-ready contents.
     const { HistoryService } = await import(
       '@vybestack/llxprt-code-core/services/history/HistoryService.js'
     );
@@ -276,20 +274,46 @@ describe('bucket attribution against the real history pipeline (issue #3130)', (
     );
 
     const requestContents = history.getCuratedForProvider([]);
-    // Guard the premise: the pipeline really does mark the tool turn synthetic.
-    const toolTurnIsFlagged = requestContents.some(
+    const matchingToolResponse = requestContents
+      .flatMap((content) => content.blocks)
+      .find(
+        (block) => block.type === 'tool_response' && block.callId === 'call-1',
+      );
+    const baselineRequestContents = requestContents.filter(
+      (content) =>
+        !content.blocks.some(
+          (block) =>
+            block.type === 'tool_response' && block.callId === 'call-1',
+        ),
+    );
+
+    expect(matchingToolResponse).toMatchObject({
+      type: 'tool_response',
+      callId: 'call-1',
+      result: 'FILE BODY',
+    });
+    // Guard the premise: unchanged history is not an injected synthetic turn.
+    const toolTurnIsSynthetic = requestContents.some(
       (c) => c.speaker === 'tool' && c.metadata?.synthetic === true,
     );
-    expect(toolTurnIsFlagged).toBe(true);
+    expect(toolTurnIsSynthetic).toBe(false);
 
-    const shape = computeRequestShape({
-      requestContents,
-      tools: undefined,
-      instructionsText: undefined,
-      countTokens: (t: string) => t.length,
-      previouslySentCallIds: new Set<string>(),
-    });
+    const measure = (contents: IContent[]) =>
+      computeRequestShape({
+        requestContents: contents,
+        tools: undefined,
+        instructionsText: undefined,
+        countTokens: (t: string) => t.length,
+        previouslySentCallIds: new Set<string>(),
+      });
+    const shape = measure(requestContents);
+    const baselineShape = measure(baselineRequestContents);
+    const measuredToolResponse = shape.toolCalls.find(
+      (toolCall) => toolCall.callId === 'call-1',
+    );
 
+    expect(measuredToolResponse?.resultTokens).toBeGreaterThan(0);
+    expect(shape.historyTokens).toBeGreaterThan(baselineShape.historyTokens);
     expect(shape.injectedTokens).toBe(0);
   });
 });

--- a/packages/core/src/services/history/HistoryService.idnormalization.test.ts
+++ b/packages/core/src/services/history/HistoryService.idnormalization.test.ts
@@ -303,7 +303,7 @@ describe('HistoryService - Behavioral Tests', () => {
         expect(syntheticToolMessage.speaker).toBe('tool');
         expect(syntheticToolMessage.metadata?.synthetic).toBe(true);
         expect(syntheticToolMessage.metadata?.reason).toBe(
-          'reordered_tool_responses',
+          'orphaned_tool_call',
         );
       });
 
@@ -347,6 +347,8 @@ describe('HistoryService - Behavioral Tests', () => {
           ),
         );
         expect(toolResponses).toHaveLength(1);
+        expect(curated[2].metadata?.synthetic).toBeUndefined();
+        expect(curated[2].metadata?.reason).toBeUndefined();
       });
 
       it('should preserve MediaBlocks alongside tool_response in getCuratedForProvider', () => {

--- a/packages/core/src/services/history/HistoryService.issue3165.adjacency-metadata.test.ts
+++ b/packages/core/src/services/history/HistoryService.issue3165.adjacency-metadata.test.ts
@@ -1,0 +1,620 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'bun:test';
+import { DebugLogger } from '../../debug/index.js';
+import { HistoryService } from './HistoryService.js';
+import type { IContent, MediaBlock, ToolResponseBlock } from './IContent.js';
+import { createUserMessage } from './IContent.js';
+
+describe('HistoryService issue #3165 adjacency and metadata', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  describe('provider curation', () => {
+    it('preserves metadata on an already-adjacent parallel tool response with media', () => {
+      service.add(createUserMessage('Read two files'));
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_adjacent_a',
+            name: 'read_file',
+            parameters: { path: 'a.png' },
+          },
+          {
+            type: 'tool_call',
+            id: 'call_adjacent_b',
+            name: 'read_file',
+            parameters: { path: 'b.txt' },
+          },
+        ],
+      });
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_adjacent_a',
+            toolName: 'read_file',
+            result: { success: true },
+            isComplete: true,
+          },
+          {
+            type: 'tool_response',
+            callId: 'call_adjacent_b',
+            toolName: 'read_file',
+            result: { content: 'text' },
+            isComplete: true,
+          },
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: 'image-data',
+            encoding: 'base64',
+          },
+        ],
+        metadata: {
+          id: 'tool-content-id',
+          turnId: 'turn-adjacent',
+          promptId: 'prompt-adjacent',
+          cacheAnchor: true,
+        },
+      });
+      const storedToolContent = service.getAll()[2];
+      const warnSpy = vi.spyOn(DebugLogger.prototype, 'warn');
+
+      try {
+        const curated = service.getCuratedForProvider();
+        const toolContent = curated[2];
+        const anchorLossWarnings = warnSpy.mock.calls.filter(
+          ([message]) =>
+            message === 'Provider history normalization removed a cache anchor',
+        );
+
+        expect(toolContent.blocks).toHaveLength(3);
+        expect(toolContent.metadata).toMatchObject({
+          id: 'tool-content-id',
+          turnId: 'turn-adjacent',
+          promptId: 'prompt-adjacent',
+          chronology: storedToolContent.metadata?.chronology,
+          cacheAnchor: true,
+        });
+        expect(toolContent.metadata?.synthetic).toBeUndefined();
+        expect(toolContent.metadata?.reason).toBeUndefined();
+        expect(anchorLossWarnings).toHaveLength(0);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('marks media-first adjacent tool content as reordered', () => {
+      const response: ToolResponseBlock = {
+        type: 'tool_response',
+        callId: 'call_media_first',
+        toolName: 'read_file',
+        result: 'image result',
+      };
+      const media: MediaBlock = {
+        type: 'media',
+        mimeType: 'image/png',
+        data: 'image-data',
+        encoding: 'base64',
+      };
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_media_first',
+            name: 'read_file',
+            parameters: {},
+          },
+        ],
+      });
+      service.add({
+        speaker: 'tool',
+        blocks: [media, response],
+        metadata: { id: 'media-first-content' },
+      });
+
+      const curated = service.getCuratedForProvider();
+
+      expect({
+        blockTypes: curated[1].blocks.map((block) => block.type),
+        metadata: curated[1].metadata,
+      }).toEqual({
+        blockTypes: ['tool_response', 'media'],
+        metadata: {
+          synthetic: true,
+          reason: 'reordered_tool_responses',
+        },
+      });
+    });
+
+    it('marks interleaved adjacent responses and media as reordered', () => {
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_interleaved_a',
+            name: 'read_file',
+            parameters: {},
+          },
+          {
+            type: 'tool_call',
+            id: 'call_interleaved_b',
+            name: 'read_file',
+            parameters: {},
+          },
+        ],
+      });
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_interleaved_a',
+            toolName: 'read_file',
+            result: 'first result',
+          },
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: 'first-image',
+            encoding: 'base64',
+          },
+          {
+            type: 'tool_response',
+            callId: 'call_interleaved_b',
+            toolName: 'read_file',
+            result: 'second result',
+          },
+          {
+            type: 'media',
+            mimeType: 'image/jpeg',
+            data: 'second-image',
+            encoding: 'base64',
+          },
+        ],
+        metadata: { id: 'interleaved-content' },
+      });
+
+      const curated = service.getCuratedForProvider();
+
+      expect({
+        blockTypes: curated[1].blocks.map((block) => block.type),
+        metadata: curated[1].metadata,
+      }).toEqual({
+        blockTypes: ['tool_response', 'tool_response', 'media', 'media'],
+        metadata: {
+          synthetic: true,
+          reason: 'reordered_tool_responses',
+        },
+      });
+    });
+
+    it('retains adjacent metadata when later content reuses the response block and adds a lower-scored duplicate', () => {
+      const sharedResponse: ToolResponseBlock = {
+        type: 'tool_response',
+        callId: 'call_shared_duplicate',
+        toolName: 'read_file',
+        result: 'selected adjacent result',
+        isComplete: true,
+      };
+      const lowerScoredDuplicate: ToolResponseBlock = {
+        type: 'tool_response',
+        callId: 'call_shared_duplicate',
+        toolName: 'read_file',
+        result: null,
+        error: 'discarded duplicate',
+      };
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_shared_duplicate',
+            name: 'read_file',
+            parameters: {},
+          },
+        ],
+      });
+      service.add({
+        speaker: 'tool',
+        blocks: [sharedResponse],
+        metadata: { id: 'shared-adjacent-content' },
+      });
+      service.add(createUserMessage('Intervening content'));
+      service.add({
+        speaker: 'tool',
+        blocks: [sharedResponse, lowerScoredDuplicate],
+      });
+
+      const curated = service.getCuratedForProvider();
+      const selectedResponse = curated[1].blocks.find(
+        (block) => block.type === 'tool_response',
+      );
+
+      expect({
+        result: selectedResponse?.result,
+        metadataId: curated[1].metadata?.id,
+        synthetic: curated[1].metadata?.synthetic,
+        reason: curated[1].metadata?.reason,
+      }).toEqual({
+        result: 'selected adjacent result',
+        metadataId: 'shared-adjacent-content',
+        synthetic: undefined,
+        reason: undefined,
+      });
+    });
+
+    it('warns once when adjacency normalization loses an input cache anchor', () => {
+      const warnSpy = vi.spyOn(DebugLogger.prototype, 'warn');
+      service.add(createUserMessage('Run the tool'));
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_moved_anchor',
+            name: 'read_file',
+            parameters: { path: 'file.txt' },
+          },
+        ],
+      });
+      service.add(createUserMessage('Intervening content'));
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_moved_anchor',
+            toolName: 'read_file',
+            result: 'contents',
+            isComplete: true,
+          },
+        ],
+        metadata: { cacheAnchor: true },
+      });
+
+      try {
+        const curated = service.getCuratedForProvider();
+
+        expect(
+          curated.some((content) => content.metadata?.cacheAnchor === true),
+        ).toBe(false);
+        expect(curated[2].metadata).toEqual({
+          synthetic: true,
+          reason: 'reordered_tool_responses',
+        });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Provider history normalization removed a cache anchor',
+          {
+            inputAnchorIndexes: [3],
+            inputContentCount: 4,
+            outputContentCount: 4,
+          },
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('does not warn when provider input has no cache anchor', () => {
+      const warnSpy = vi.spyOn(DebugLogger.prototype, 'warn');
+      service.add(createUserMessage('No anchored content'));
+
+      try {
+        service.getCuratedForProvider();
+
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('preserves metadata for an adjacent tool response in pending tail content', () => {
+      service.add(createUserMessage('Stored prompt'));
+      const tail: IContent[] = [
+        {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'tool_call',
+              id: 'call_pending_tail',
+              name: 'read_file',
+              parameters: {},
+            },
+          ],
+        },
+        {
+          speaker: 'tool',
+          blocks: [
+            {
+              type: 'tool_response',
+              callId: 'call_pending_tail',
+              toolName: 'read_file',
+              result: 'tail result',
+            },
+          ],
+          metadata: {
+            id: 'pending-tool-content',
+            turnId: 'pending-turn',
+            cacheAnchor: true,
+          },
+        },
+      ];
+
+      const curated = service.getCuratedForProvider(tail);
+
+      expect(curated[2].metadata).toMatchObject({
+        id: 'pending-tool-content',
+        turnId: 'pending-turn',
+        cacheAnchor: true,
+      });
+      expect(curated[2].metadata?.reason).toBeUndefined();
+    });
+
+    it('repairs a missing response at the end of pending tail content', () => {
+      const tail: IContent[] = [
+        {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'tool_call',
+              id: 'call_pending_missing_response',
+              name: 'read_file',
+              parameters: { path: 'pending.txt' },
+            },
+          ],
+        },
+      ];
+
+      const curated = service.getCuratedForProvider(tail);
+      const syntheticResponse = curated[1];
+
+      expect(curated).toHaveLength(2);
+      expect(syntheticResponse.speaker).toBe('tool');
+      expect(syntheticResponse.blocks).toContainEqual({
+        type: 'tool_response',
+        callId: 'call_pending_missing_response',
+        toolName: 'read_file',
+        result: null,
+        error: 'Tool call interrupted or cancelled',
+        isComplete: true,
+      });
+      expect(syntheticResponse.metadata).toEqual({
+        synthetic: true,
+        reason: 'orphaned_tool_call',
+      });
+    });
+
+    it('does not mark unchanged pending-tail tool content as synthetic', () => {
+      const tail: IContent[] = [
+        {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'tool_call',
+              id: 'call_pending_without_metadata',
+              name: 'read_file',
+              parameters: {},
+            },
+          ],
+        },
+        {
+          speaker: 'tool',
+          blocks: [
+            {
+              type: 'tool_response',
+              callId: 'call_pending_without_metadata',
+              toolName: 'read_file',
+              result: 'tail result',
+            },
+          ],
+        },
+      ];
+
+      const curated = service.getCuratedForProvider(tail);
+
+      expect(curated[1].metadata?.synthetic).toBeUndefined();
+      expect(curated[1].metadata?.reason).toBeUndefined();
+    });
+
+    it('marks responses merged from adjacent and remote contents as reordered', () => {
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_merge_a',
+            name: 'read_file',
+            parameters: {},
+          },
+          {
+            type: 'tool_call',
+            id: 'call_merge_b',
+            name: 'read_file',
+            parameters: {},
+          },
+        ],
+      });
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_merge_a',
+            toolName: 'read_file',
+            result: 'first',
+          },
+        ],
+        metadata: { id: 'adjacent-part' },
+      });
+      service.add(createUserMessage('Intervening content'));
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_merge_b',
+            toolName: 'read_file',
+            result: 'second',
+          },
+        ],
+      });
+
+      const curated = service.getCuratedForProvider();
+
+      expect(curated[1].blocks).toHaveLength(2);
+      expect(curated[1].metadata).toEqual({
+        synthetic: true,
+        reason: 'reordered_tool_responses',
+      });
+    });
+
+    it('marks a higher-scored remote duplicate response as reordered', () => {
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_duplicate',
+            name: 'read_file',
+            parameters: {},
+          },
+        ],
+      });
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_duplicate',
+            toolName: 'read_file',
+            result: null,
+          },
+        ],
+        metadata: { id: 'adjacent-duplicate' },
+      });
+      service.add(createUserMessage('Intervening content'));
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_duplicate',
+            toolName: 'read_file',
+            result: 'selected remote result',
+            isComplete: true,
+          },
+        ],
+      });
+
+      const curated = service.getCuratedForProvider();
+      const response = curated[1].blocks.find(
+        (block) => block.type === 'tool_response',
+      );
+
+      expect(response?.result).toBe('selected remote result');
+      expect(curated[1].metadata).toEqual({
+        synthetic: true,
+        reason: 'reordered_tool_responses',
+      });
+    });
+
+    it('retains adjacent metadata when a lower-scored remote duplicate is dropped', () => {
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_adjacent_duplicate',
+            name: 'read_file',
+            parameters: {},
+          },
+        ],
+      });
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_adjacent_duplicate',
+            toolName: 'read_file',
+            result: 'selected adjacent result',
+            isComplete: true,
+          },
+        ],
+        metadata: { id: 'selected-adjacent-content' },
+      });
+      service.add(createUserMessage('Intervening content'));
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_adjacent_duplicate',
+            toolName: 'read_file',
+            result: null,
+            error: 'discarded remote result',
+          },
+        ],
+      });
+
+      const curated = service.getCuratedForProvider();
+      const response = curated[1].blocks.find(
+        (block) => block.type === 'tool_response',
+      );
+
+      expect(response?.result).toBe('selected adjacent result');
+      expect(curated[1].metadata?.id).toBe('selected-adjacent-content');
+      expect(curated[1].metadata?.reason).toBeUndefined();
+    });
+
+    it('does not preserve metadata from tool content with non-provider blocks', () => {
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_extra_block',
+            name: 'read_file',
+            parameters: {},
+          },
+        ],
+      });
+      service.add({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_extra_block',
+            toolName: 'read_file',
+            result: 'result',
+          },
+          { type: 'text', text: 'client-only tool annotation' },
+        ],
+        metadata: { id: 'ineligible-tool-content' },
+      });
+
+      const curated = service.getCuratedForProvider();
+
+      expect(curated[1].blocks).toHaveLength(1);
+      expect(curated[1].metadata).toEqual({
+        synthetic: true,
+        reason: 'reordered_tool_responses',
+      });
+    });
+  });
+});

--- a/packages/core/src/services/history/HistoryService.issue3165.adjacency-metadata.test.ts
+++ b/packages/core/src/services/history/HistoryService.issue3165.adjacency-metadata.test.ts
@@ -616,5 +616,57 @@ describe('HistoryService issue #3165 adjacency and metadata', () => {
         reason: 'reordered_tool_responses',
       });
     });
+
+    it('repairs a final same-content tool call and response', () => {
+      service.add(createUserMessage('Run the tool'));
+      service.add({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_final_same_content',
+            name: 'read_file',
+            parameters: { path: 'final.txt' },
+          },
+          {
+            type: 'tool_response',
+            callId: 'call_final_same_content',
+            toolName: 'read_file',
+            result: { content: 'final contents' },
+            isComplete: true,
+          },
+        ],
+      });
+
+      expect(() => service.getCuratedForProvider()).not.toThrow();
+      const curated = service.getCuratedForProvider();
+
+      expect(curated).toHaveLength(3);
+      expect(curated[1]).toMatchObject({
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_final_same_content',
+          },
+        ],
+      });
+      expect(curated[2]).toMatchObject({
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_final_same_content',
+            toolName: 'read_file',
+            result: { content: 'final contents' },
+            isComplete: true,
+          },
+        ],
+        metadata: {
+          synthetic: true,
+          reason: 'reordered_tool_responses',
+        },
+      });
+    });
   });
 });

--- a/packages/core/src/services/history/HistoryService.issue3165.adjacency-metadata.test.ts
+++ b/packages/core/src/services/history/HistoryService.issue3165.adjacency-metadata.test.ts
@@ -642,6 +642,8 @@ describe('HistoryService issue #3165 adjacency and metadata', () => {
       const curated = service.getCuratedForProvider();
 
       expect(curated).toHaveLength(3);
+      expect(curated[1].blocks).toHaveLength(1);
+      expect(curated[2].blocks).toHaveLength(1);
       expect(curated[1]).toMatchObject({
         speaker: 'ai',
         blocks: [

--- a/packages/core/src/services/history/circular-reference.test.ts
+++ b/packages/core/src/services/history/circular-reference.test.ts
@@ -313,4 +313,67 @@ describe('Circular Reference Bug', () => {
     // The main goal of this test is that circular references are properly cleaned up
     expect(() => JSON.stringify(curatedForProvider)).not.toThrow();
   });
+
+  it('sanitizes cyclic tool call parameters without mutating stored history', () => {
+    interface CyclicValue {
+      label: string;
+      self?: CyclicValue;
+    }
+    const parameters: CyclicValue = { label: 'parameters' };
+    parameters.self = parameters;
+    historyService.add({
+      speaker: 'ai',
+      blocks: [
+        {
+          type: 'tool_call',
+          id: 'cyclic-parameters',
+          name: 'cyclic_tool',
+          parameters,
+        },
+      ],
+    });
+
+    const first = historyService.getCuratedForProvider();
+    const second = historyService.getCuratedForProvider();
+
+    expect(JSON.stringify(first)).toContain('"_circular":true');
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    expect(parameters.self).toBe(parameters);
+  });
+
+  it('sanitizes cyclic tool response results before provider serialization', () => {
+    interface CyclicValue {
+      label: string;
+      self?: CyclicValue;
+    }
+    const result: CyclicValue = { label: 'result' };
+    result.self = result;
+    historyService.add({
+      speaker: 'ai',
+      blocks: [
+        {
+          type: 'tool_call',
+          id: 'cyclic-result',
+          name: 'cyclic_tool',
+          parameters: {},
+        },
+      ],
+    });
+    historyService.add({
+      speaker: 'tool',
+      blocks: [
+        {
+          type: 'tool_response',
+          callId: 'cyclic-result',
+          toolName: 'cyclic_tool',
+          result,
+        },
+      ],
+    });
+
+    const curated = historyService.getCuratedForProvider();
+
+    expect(JSON.stringify(curated)).toContain('"_circular":true');
+    expect(result.self).toBe(result);
+  });
 });

--- a/packages/core/src/services/history/historyCloneUtils.ts
+++ b/packages/core/src/services/history/historyCloneUtils.ts
@@ -20,13 +20,16 @@ import type {
   ToolCallBlock,
   ToolResponseBlock,
 } from './IContent.js';
-import type { DebugLogger } from '../../debug/index.js';
 
 /**
- * Deep clone content arrays and remove circular references so the result is
- * safe to serialize and send to providers.
+ * Sanitize provider history for serialization while cloning its top-level data.
+ * The copy isolates content and block references because getCurated() returns
+ * stored contents directly and in-process BeforeModel hooks may mutate them.
+ * Metadata retains its existing shallow-copy behavior.
  */
-export function deepCloneWithoutCircularRefs(contents: IContent[]): IContent[] {
+export function sanitizeProviderHistoryForSerialization(
+  contents: IContent[],
+): IContent[] {
   return contents.map((content) => ({
     speaker: content.speaker,
     blocks: content.blocks.map(cloneBlock),
@@ -99,20 +102,4 @@ export function sanitizeParams(params: unknown): unknown {
       _note: 'Parameters contained circular references and were sanitized',
     };
   }
-}
-
-/** Sanitize and log on error (for callers that want logging). */
-export function sanitizeParamsWithLogger(
-  params: unknown,
-  logger: DebugLogger,
-): unknown {
-  const sanitized = sanitizeParams(params);
-  if (
-    typeof sanitized === 'object' &&
-    sanitized !== null &&
-    '_note' in sanitized
-  ) {
-    logger.debug('Parameters were sanitized due to serialization issues');
-  }
-  return sanitized;
 }

--- a/packages/core/src/services/history/historyProviderPipeline.ts
+++ b/packages/core/src/services/history/historyProviderPipeline.ts
@@ -17,7 +17,7 @@
 import type { IContent } from './IContent.js';
 import type { DebugLogger } from '../../debug/index.js';
 import { HistoryToolNormalization } from './historyToolNormalization.js';
-import { deepCloneWithoutCircularRefs } from './historyCloneUtils.js';
+import { sanitizeProviderHistoryForSerialization } from './historyCloneUtils.js';
 
 /**
  * Build a provider-ready content array from curated history and optional tail
@@ -26,7 +26,7 @@ import { deepCloneWithoutCircularRefs } from './historyCloneUtils.js';
  *   2. Ensure every tool response has a matching tool call.
  *   3. Ensure every tool call has a matching tool response.
  *   4. Ensure tool responses are adjacent to their tool calls.
- *   5. Deep clone to remove circular references.
+ *   5. Sanitize provider history for serialization.
  */
 export function buildProviderContent(
   curated: IContent[],
@@ -65,9 +65,23 @@ export function buildProviderContent(
     logger,
   );
 
-  // Deep clone to avoid circular references in tool call parameters
-  // We need a clean copy that can be serialized
-  return deepCloneWithoutCircularRefs(ordered);
+  // Sanitize cyclic tool payloads while isolating prepared provider contents
+  // from the stored history references.
+  const sanitized = sanitizeProviderHistoryForSerialization(ordered);
+  const inputAnchorIndexes = combined.flatMap((content, index) =>
+    content.metadata?.cacheAnchor === true ? [index] : [],
+  );
+  const outputHasAnchor = sanitized.some(
+    (content) => content.metadata?.cacheAnchor === true,
+  );
+  if (inputAnchorIndexes.length > 0 && !outputHasAnchor) {
+    logger.warn('Provider history normalization removed a cache anchor', {
+      inputAnchorIndexes,
+      inputContentCount: combined.length,
+      outputContentCount: sanitized.length,
+    });
+  }
+  return sanitized;
 }
 
 /**

--- a/packages/core/src/services/history/historyToolNormalization.ts
+++ b/packages/core/src/services/history/historyToolNormalization.ts
@@ -313,8 +313,8 @@ export class HistoryToolNormalization {
 
     return HistoryToolNormalization.reassembleAdjacencyResult(
       strippedContents,
-      maps.responsesByToolCallIndex,
-      maps.mediaBlocksByToolCallIndex,
+      contents,
+      maps,
     );
   }
 
@@ -504,11 +504,34 @@ export class HistoryToolNormalization {
     return toolCallIndex;
   }
 
+  /** Return the source only when the output exactly retains one adjacent tool content. */
+  private static retainedAdjacentSource(
+    toolCallIndex: number,
+    sourceContents: IContent[],
+    assembledBlocks: IContent['blocks'],
+  ): IContent | undefined {
+    const source = sourceContents[toolCallIndex + 1];
+    if (
+      source.speaker !== 'tool' ||
+      !hasValidBlocks(source) ||
+      source.blocks.some(
+        (block) => block.type !== 'tool_response' && block.type !== 'media',
+      )
+    ) {
+      return undefined;
+    }
+
+    const retainsOrderedBlocks =
+      assembledBlocks.length === source.blocks.length &&
+      assembledBlocks.every((block, index) => block === source.blocks[index]);
+    return retainsOrderedBlocks ? source : undefined;
+  }
+
   /** Reassemble stripped contents with tool responses after their tool-call messages. */
   private static reassembleAdjacencyResult(
     strippedContents: Array<IContent | null>,
-    responsesByToolCallIndex: Map<number, ToolResponseBlock[]>,
-    mediaBlocksByToolCallIndex: Map<number, MediaBlock[]>,
+    sourceContents: IContent[],
+    maps: ReassignMaps,
   ): IContent[] {
     const result: IContent[] = [];
 
@@ -518,16 +541,24 @@ export class HistoryToolNormalization {
         result.push(content);
       }
 
-      const responses = responsesByToolCallIndex.get(i);
+      const responses = maps.responsesByToolCallIndex.get(i);
       if (responses && responses.length > 0) {
-        const mediaForThisIndex = mediaBlocksByToolCallIndex.get(i) ?? [];
+        const mediaForThisIndex = maps.mediaBlocksByToolCallIndex.get(i) ?? [];
+        const assembledBlocks = [...responses, ...mediaForThisIndex];
+        const retainedSource = HistoryToolNormalization.retainedAdjacentSource(
+          i,
+          sourceContents,
+          assembledBlocks,
+        );
         result.push({
           speaker: 'tool',
-          blocks: [...responses, ...mediaForThisIndex],
-          metadata: {
-            synthetic: true,
-            reason: 'reordered_tool_responses',
-          },
+          blocks: assembledBlocks,
+          metadata: retainedSource
+            ? retainedSource.metadata
+            : {
+                synthetic: true,
+                reason: 'reordered_tool_responses',
+              },
         });
       }
     }

--- a/packages/core/src/services/history/historyToolNormalization.ts
+++ b/packages/core/src/services/history/historyToolNormalization.ts
@@ -510,8 +510,9 @@ export class HistoryToolNormalization {
     sourceContents: IContent[],
     assembledBlocks: IContent['blocks'],
   ): IContent | undefined {
-    const source = sourceContents[toolCallIndex + 1];
+    const source = sourceContents[toolCallIndex + 1] as IContent | undefined;
     if (
+      source === undefined ||
       source.speaker !== 'tool' ||
       !hasValidBlocks(source) ||
       source.blocks.some(

--- a/packages/providers/src/anthropic/AnthropicMessageNormalizer.anchorCache.test.ts
+++ b/packages/providers/src/anthropic/AnthropicMessageNormalizer.anchorCache.test.ts
@@ -26,6 +26,7 @@
 import { describe, expect, it, vi } from 'bun:test';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { convertToAnthropicMessages } from './AnthropicMessageNormalizer.js';
 import { attachAnchorCacheControl } from './AnthropicAnchorCache.js';
 import { attachPromptCaching } from './AnthropicRequestBuilder.js';
@@ -277,7 +278,8 @@ describe('Anthropic anchor cache breakpoint — message-level (#3070)', () => {
     expect(cacheControlCount(rebuilt)).toBe(1);
   });
 
-  it('honors a tool-result entry as the anchor boundary', () => {
+  it('honors a curated tool-result entry as the anchor boundary', () => {
+    const historyService = new HistoryService();
     const toolCallId = 'tool_anchor_1';
     const contents: IContent[] = [
       human('do the thing'),
@@ -304,30 +306,28 @@ describe('Anthropic anchor cache breakpoint — message-level (#3070)', () => {
         ],
         metadata: { cacheAnchor: true },
       },
-      // A tool result must be followed by an assistant turn (the summary), so
-      // the anchored tool-result message is never the last message and the
-      // transform pipeline does not need to merge consecutive user messages.
       ai('summary of what happened so far'),
       human('continuation after the anchored tool result'),
     ];
+    for (const content of contents) {
+      historyService.add(content);
+    }
 
-    const messages = applyCaching(contents);
+    const curated = historyService.getCuratedForProvider();
+    const messages = applyCaching(curated);
 
-    // The anchored tool content flushes into a user message carrying the
-    // tool_result; that message must carry the anchor breakpoint, and it must
-    // NOT be the last message.
     const anchoredToolMessage = messages.find(
-      (m) =>
-        m.role === 'user' &&
-        Array.isArray(m.content) &&
-        m.content.some(
-          (b) =>
-            (b as { type?: string }).type === 'tool_result' &&
-            'cache_control' in b,
+      (message) =>
+        message.role === 'user' &&
+        Array.isArray(message.content) &&
+        message.content.some(
+          (block) => block.type === 'tool_result' && 'cache_control' in block,
         ),
     );
     expect(anchoredToolMessage).toBeDefined();
     expect(anchoredToolMessage).not.toBe(messages[messages.length - 1]);
+    expect(cacheControlCount(messages)).toBeLessThanOrEqual(4);
+    expect(JSON.stringify({ messages })).not.toContain('cacheAnchor');
   });
 });
 

--- a/packages/providers/src/anthropic/AnthropicProvider.issue1150.toolresult.adjacency.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.issue1150.toolresult.adjacency.test.ts
@@ -12,6 +12,7 @@ import type {
   ToolCallBlock,
   ToolResponseBlock,
 } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { TEST_PROVIDER_CONFIG } from '../test-utils/providerTestConfig.js';
 import {
   createProviderWithRuntime,
@@ -54,6 +55,68 @@ void vi.mock('@anthropic-ai/sdk', () => ({
     },
   })),
 }));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function getRequestMessages(request: unknown): unknown[] {
+  if (!isRecord(request)) {
+    throw new Error('Anthropic request did not contain messages');
+  }
+
+  const messages = request.messages;
+  if (!Array.isArray(messages)) {
+    throw new Error('Anthropic request did not contain messages');
+  }
+
+  return messages;
+}
+
+function messageContainsBlockType(
+  message: unknown,
+  role: 'assistant' | 'user',
+  blockType: 'tool_use' | 'tool_result',
+): boolean {
+  if (!isRecord(message) || message.role !== role) {
+    return false;
+  }
+
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+
+  for (const block of content) {
+    if (isRecord(block) && block.type === blockType) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasCacheableToolResult(message: unknown): boolean {
+  if (!isRecord(message)) {
+    return false;
+  }
+
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+
+  for (const block of content) {
+    if (!isRecord(block) || block.type !== 'tool_result') {
+      continue;
+    }
+    if ('cache_control' in block) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 describe('AnthropicProvider Issue #1150: tool_result Adjacency Validation', () => {
   let provider: AnthropicProvider;
@@ -756,6 +819,78 @@ describe('AnthropicProvider Issue #1150: tool_result Adjacency Validation', () =
           expect(hasMatchingResult).toBe(true);
         }
       }
+    });
+
+    it('keeps curated anchored tool results adjacent and cacheable in the request', async () => {
+      settingsService.setProviderSetting('anthropic', 'prompt-caching', '5m');
+      mockMessagesCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Response' }],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+      const historyService = new HistoryService();
+      const contents: IContent[] = [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'Read the file' }],
+        },
+        {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'tool_call',
+              id: 'anchored_tool_request',
+              name: 'read_file',
+              parameters: { path: 'file.txt' },
+            },
+          ],
+        },
+        {
+          speaker: 'tool',
+          blocks: [
+            {
+              type: 'tool_response',
+              callId: 'anchored_tool_request',
+              toolName: 'read_file',
+              result: 'contents',
+              isComplete: true,
+            },
+          ],
+          metadata: { cacheAnchor: true },
+        },
+        {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'The file was read' }],
+        },
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'Continue' }],
+        },
+      ];
+      for (const content of contents) {
+        historyService.add(content);
+      }
+      const curated = historyService.getCuratedForProvider();
+
+      const generator = provider.generateChatCompletion(
+        buildCallOptions(curated),
+      );
+      await generator.next();
+
+      const requestValue: unknown = mockMessagesCreate.mock.calls[0]?.[0];
+      const requestMessages = getRequestMessages(requestValue);
+      const toolUseIndex = requestMessages.findIndex((message) =>
+        messageContainsBlockType(message, 'assistant', 'tool_use'),
+      );
+      expect(toolUseIndex).toBeGreaterThan(-1);
+
+      const resultMessage = requestMessages[toolUseIndex + 1];
+      if (!isRecord(resultMessage)) {
+        throw new Error('Anthropic request did not contain an adjacent result');
+      }
+
+      expect(resultMessage.role).toBe('user');
+      expect(hasCacheableToolResult(resultMessage)).toBe(true);
+      expect(JSON.stringify(requestValue)).not.toContain('cacheAnchor');
     });
   });
 });

--- a/packages/providers/src/utils/chronologyProviderIsolation.test.ts
+++ b/packages/providers/src/utils/chronologyProviderIsolation.test.ts
@@ -24,9 +24,9 @@ import { buildProviderDumpBody } from './providerRequestConversion.js';
  * human turns, issue #2410), so a leak here would break every request for the
  * affected provider.
  *
- * `deepCloneWithoutCircularRefs` copies metadata, so chronology genuinely
- * travels with IContent right up to each converter. These tests are the
- * regression guard that it stops there.
+ * `sanitizeProviderHistoryForSerialization` copies metadata, so chronology
+ * genuinely travels with IContent right up to each converter. These tests are
+ * the regression guard that it stops there.
  *
  * When a new provider wire converter is added, add it to CONVERTERS below.
  */

--- a/project-plans/issue3165/plan.md
+++ b/project-plans/issue3165/plan.md
@@ -1,0 +1,203 @@
+# Issue #3165: Preserve tool-turn metadata in provider history
+
+Plan ID: PLAN-20260822-PROVIDER-HISTORY-METADATA
+
+## Accepted behavior
+
+### AC-1: Preserve already-adjacent tool contents
+
+Given a real `HistoryService` containing an AI tool call followed immediately by its
+matching tool response, `getCuratedForProvider()` preserves the tool content's
+`metadata.id`, `turnId`, `promptId`, `chronology`, and `cacheAnchor` values.
+
+The unchanged tool content is not marked synthetic and is not assigned
+`reason: 'reordered_tool_responses'`. A tool content created earlier by the missing
+response repair keeps its truthful `reason: 'orphaned_tool_call'` metadata when it is
+already adjacent.
+
+This preservation applies when one adjacent tool content carries one or more matching
+responses and any associated media blocks. It also applies when the tool content is in
+the pending tail passed to `getCuratedForProvider()`.
+
+### AC-2: Mark only responses that adjacency normalization changes
+
+When a tool response is separated from its call, combined from multiple source
+contents, or replaced during duplicate-response selection, adjacency normalization
+still emits one provider-valid tool content immediately after the matching AI call.
+That rebuilt content is marked `synthetic: true` with
+`reason: 'reordered_tool_responses'`.
+
+A response already adjacent to its call is not marked reordered. The normalizer keeps
+its existing response scoring, duplicate removal, media assignment, missing-call
+repair, and missing-response repair behavior.
+
+Tool contents that include blocks other than tool responses and media retain the
+existing provider serialization behavior. Preserving metadata must not reintroduce
+blocks that the current normalization intentionally omits.
+
+### AC-3: Preserve and diagnose the compression cache anchor
+
+A compression boundary advanced past a tool round-trip stamps the last preserved-head
+tool content with `metadata.cacheAnchor: true`. That marker survives
+`getCuratedForProvider()` and causes the Anthropic request to contain the preserved-head
+`cache_control` breakpoint on the message derived from the tool result.
+
+If `buildProviderContent()` receives an expected cache anchor but its output contains no
+anchor, it emits one warning with enough context to identify the normalization loss. It
+does not warn when no input content carried an anchor. This check belongs in the core
+pipeline, where both the input expectation and final curated output are observable.
+The Anthropic message-level accepted-degradation behavior remains unchanged.
+
+### AC-4: Keep provider behavior stable
+
+Tool response adjacency remains provider-valid, including parallel calls, sequential
+calls, out-of-order responses, duplicate responses, and media-bearing responses. For
+already-correct histories, provider wire content remains unchanged except for the
+restored Anthropic anchor breakpoint. Client-only metadata continues to stop at the
+provider converter.
+
+### AC-5: Name and test provider sanitization explicitly
+
+The final provider-history step is named to expose its required cycle-sanitization
+invariant. Cycles in tool call parameters and tool response results are replaced with
+the established serializable marker before any provider request can receive them.
+
+The copy remains because `getCurated()` returns stored content references and in-process
+BeforeModel hooks can mutate the prepared contents they receive. The implementation
+comment records that isolation reason. This issue does not broaden the existing shallow
+copy of nested metadata.
+
+The unused `sanitizeParamsWithLogger` export is removed.
+
+## Inputs and boundary cases
+
+Accepted inputs and cases are:
+
+1. Already-adjacent single and parallel tool responses, with and without media.
+2. An adjacent synthetic missing-response repair whose original reason must survive.
+3. A distant response moved next to its call.
+4. Multiple response contents merged for one AI tool-call content.
+5. Duplicate responses where selection keeps the adjacent source or a remote source.
+6. Tool contents containing additional block kinds, which must keep current wire output.
+7. Tool contents in stored history and in pending tail contents.
+8. Cache anchors on tool contents, AI contents, and no content.
+9. Compression split points advanced past one or more tool responses.
+10. Cyclic tool-call parameters and cyclic tool-response results.
+11. Existing missing-call, missing-response, media, and adjacency scenarios.
+
+## Behavioral evidence
+
+All changed tests use Bun and `bun:test`, exercise real production components, and avoid
+mocking the behavior under test.
+
+### Core history behavior
+
+Add focused coverage in
+`packages/core/src/services/history/HistoryService.issue3165.adjacency-metadata.test.ts`
+and retain the narrow stale-expectation updates in
+`HistoryService.idnormalization.test.ts`. Through a real `HistoryService`, prove that:
+
+- already-adjacent tool metadata and the cache anchor survive curation;
+- untouched tool turns are not labeled reordered;
+- genuinely moved, merged, or remotely selected responses are labeled reordered;
+- an adjacent orphan repair retains `reason: 'orphaned_tool_call'`;
+- parallel responses and media remain intact;
+- pending-tail behavior follows the same rules;
+- a moved anchored source that cannot retain its anchor produces one warning, while an
+  input without an anchor produces none.
+
+### Compression boundary behavior
+
+Extend `packages/agents/src/compression/cacheAnchor.test.ts` to prove that a preserved
+head ending after a tool round-trip places its sole anchor on the last tool content.
+
+### Anthropic request behavior
+
+Extend the existing Anthropic cache and adjacency suites to compose the package-level
+path:
+
+- `AnthropicMessageNormalizer.anchorCache.test.ts` passes real curated tool history
+  through request preparation and asserts the tool-result message carries
+  `cache_control`, the breakpoint count remains within Anthropic's limit, and the
+  private marker does not leak.
+- `AnthropicProvider.issue1150.toolresult.adjacency.test.ts` keeps the existing request
+  adjacency assertions green and verifies the provider request built from curated,
+  anchored tool history contains the restored breakpoint.
+
+Together with the compression-boundary test, these prove the flow from compression
+anchor placement through provider curation to Anthropic request serialization without
+creating a reverse dependency between package layers.
+
+### Sanitization behavior
+
+Extend `packages/core/src/services/history/circular-reference.test.ts` to prove the
+separately named provider sanitizer makes cyclic tool-call parameters and cyclic
+response results serializable through `getCuratedForProvider()`. Repeated calls remain
+serializable and do not mutate stored history.
+
+### Regression evidence
+
+Run the affected core, agents, and provider suites first, then the complete verification
+gate. Existing chronology-isolation, synthetic-response, tool-continuity, media,
+duplicate-response, and issue #1150 tests must remain green.
+
+## Test-first implementation sequence
+
+1. Add the real `HistoryService` metadata, synthetic-label, anchor-loss diagnostic, and
+   boundary-case assertions. Confirm they fail for the current strip-and-reassemble
+   implementation.
+2. Carry source-content provenance through adjacency normalization. Reuse an eligible
+   adjacent source's metadata and synthesize only when the selected output differs from
+   that source.
+3. Add the tool-boundary compression test and confirm the existing compression code
+   already stamps the expected tool entry.
+4. Add the provider-request anchor tests and make only the core metadata-preservation
+   change needed for them to pass.
+5. Add direct provider-sanitization behavior tests, rename the final pipeline operation,
+   retain the justified copy, and remove `sanitizeParamsWithLogger`.
+6. Run targeted tests, the test-audit delta, the full verification cycle, review, and
+   candidate-head checks.
+
+Every production change follows a naturally failing behavioral test.
+
+## Review classification
+
+Every review finding is classified as one of:
+
+- **Blocker-Fix**: breaks an accepted behavior, safety requirement, architecture rule,
+  build, or required verification gate.
+- **In-scope-Fix**: a defect in the files or behavior changed for this issue.
+- **Reject**: factually incorrect, already covered, or conflicts with accepted behavior.
+- **Defer**: valid work outside these acceptance criteria. Record it without expanding
+  this implementation.
+
+Reviewer suggestions do not expand scope. Local Open Code Review is limited to two
+rounds, and PR Open Code Review is limited to two rounds.
+
+## Explicitly outside this issue
+
+- Changing provider adjacency requirements or tool response scoring.
+- Preserving metadata on genuinely rebuilt or merged tool contents beyond the expected
+  anchor-loss warning.
+- Changing the Anthropic symbol-marker accepted-degradation contract.
+- Adding provider-side telemetry or changing #3130 token attribution.
+- Broadening nested metadata copy semantics or changing BeforeModel hook mutation rules.
+- Performance work, a new dependency, public API, subsystem, workflow, or agent memory.
+- Cleanup of unrelated comments, tests, or normalization code.
+
+## Verification gate
+
+Run on the candidate head:
+
+    npm run test
+    npm run lint
+    npm run lint:eslint-guard
+    npm run typecheck
+    npm run format
+    npm run build
+    bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+
+Also run `bun scripts/test-audit/scan.ts` against main and the candidate branch and inspect
+the findings delta for changed tests. Completion requires behavioral evidence for every
+accepted behavior, a green local gate and CI, completed and triaged reviews, no unresolved
+Blocker-Fix or In-scope-Fix finding, correct ancestry, and a conflict-free pull request.


### PR DESCRIPTION
## TLDR

Preserve metadata on provider-ready tool contents when adjacency normalization leaves their ordered response and media blocks unchanged. Rebuilt tool contents remain synthetic and keep the `reordered_tool_responses` reason.

This restores the compression cache anchor on adjacent tool results, keeps request-shape attribution aligned with provider-normalized history, adds an anchor-loss warning, and gives cycle sanitization an explicit provider-boundary name.

## Dive Deeper

`ensureToolResponseAdjacency` previously stripped every tool response and created a replacement tool content. Correctly adjacent turns therefore lost `id`, `turnId`, `promptId`, chronology, synthetic provenance, and `cacheAnchor` metadata.

The normalizer now tracks the source content during reassembly. It reuses source metadata only when the output retains exactly one adjacent tool content with the same ordered response and media block references. Moved, merged, duplicate-replaced, media-reordered, or otherwise rebuilt outputs still receive synthetic reordered metadata. Missing-response repairs that are already adjacent retain their original `orphaned_tool_call` provenance.

The provider pipeline now calls `sanitizeProviderHistoryForSerialization`, which states the cycle-sanitization boundary directly. Content and block references are isolated before hooks and providers can mutate them. Nested metadata keeps the existing shallow-copy behavior. The unused `sanitizeParamsWithLogger` export is removed.

If an input cache anchor disappears during normalization, the core pipeline emits one warning with its input indexes and the input/output content counts. Anthropic request tests verify that a preserved tool-result anchor becomes `cache_control` and that client metadata does not leak to the wire.

### Acceptance criteria

Cache anchor:

- [x] A cache anchor on adjacent tool content survives `getCuratedForProvider()`.
- [x] Anthropic request preparation carries the preserved-head `cache_control` breakpoint after a tool round-trip.
- [x] Losing an expected anchor emits a diagnostic warning.

Metadata fidelity:

- [x] Adjacent tool turns retain `id`, `turnId`, `promptId`, and chronology.
- [x] `reordered_tool_responses` appears only when normalization rebuilds the tool content.
- [x] Real `HistoryService` tests cover both retained and rebuilt cases.

No regressions:

- [x] Existing adjacency and continuity behavior remains covered, including issue #1150 scenarios.
- [x] Provider wire output is unchanged except for the restored anchor breakpoint.

Cleanup:

- [x] Provider cycle sanitization has an explicit name and behavioral coverage for cyclic call parameters and results.
- [x] The provider-boundary copy is retained with its isolation reason documented.
- [x] `sanitizeParamsWithLogger` is removed.

### Review disposition

A deep implementation review and two local Open Code Review passes were completed. All accepted findings were fixed. Suggestions to add recursive nested-metadata cloning, multi-anchor policy changes, provider telemetry, and stable IDs to the warning were rejected because they conflict with the documented scope or available data. No accepted finding remains.

## Reviewer Test Plan

1. Run the focused behavioral suites:

   ```sh
   bun test packages/core/src/services/history/HistoryService.idnormalization.test.ts packages/core/src/services/history/HistoryService.issue3165.adjacency-metadata.test.ts packages/core/src/services/history/circular-reference.test.ts packages/agents/src/compression/cacheAnchor.test.ts packages/agents/src/core/tokenUsageShapeCost.test.ts packages/providers/src/anthropic/AnthropicMessageNormalizer.anchorCache.test.ts packages/providers/src/anthropic/AnthropicProvider.issue1150.toolresult.adjacency.test.ts packages/providers/src/utils/chronologyProviderIsolation.test.ts
   ```

2. Inspect the real `HistoryService` cases for adjacent parallel responses, media ordering, pending-tail repairs, moved and merged results, duplicate selection, anchor-loss warning behavior, and non-provider blocks.
3. Confirm the Anthropic request contains `cache_control` on the tool-result message while `cacheAnchor` remains absent from serialized provider data.
4. Run the repository gates listed below.

Local verification:

- Focused issue suites: 91 passed, 0 failed, 297 assertions.
- `npm run lint`: passed.
- `npm run lint:eslint-guard`: passed.
- `npm run typecheck`: passed.
- `npm run format`: passed.
- `npm run build`: passed, including source/compiled lazy-MCP coherence.
- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`: passed.
- Main versus candidate test-audit scan: 17 additional tests, 49 additional assertions, zero new findings.

Two complete `npm run test` attempts were inconclusive under concurrent host load. Both completed all 579 provider test files, then hit agents test timeouts. Every timed-out file passed when rerun sequentially in isolation: `config-injection.spec.ts` 6/6, `core-tools.spec.ts` 21/21, `core-conversation.spec.ts` 9/9, `cli-turn-parity.spec.ts` 3/3, `agent.sequenceModel.behavior.test.ts` 7/7, and `capabilityGaps.integration.spec.ts` 18/18. CI remains the clean full-suite gate.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅ | ❓ | ❓ |
| npx      | ❓ | ❓ | ❓ |
| Docker   | ❓ | ❓ | ❓ |
| Podman   | ❓ | - | - |
| Seatbelt | ❓ | - | - |

## Linked issues / bugs

Fixes #3165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preservation and ordering of tool calls and responses during conversation history processing.
  - Prevented internal cache markers from appearing in provider requests while retaining cache behavior.
  - Improved handling of incomplete tool calls, duplicate responses, and cache-anchor placement.
  - Added safeguards for cyclic tool data without altering stored history.
  - Preserved tool-response metadata and accurate token attribution after history curation.

- **Tests**
  - Expanded coverage for history curation, token attribution, cache anchors, provider formatting, cyclic data, and tool-response adjacency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->