### PR TITLE
Make core prompt utility boundaries honest instead of widening to unknown (Fixes #2196)

### DIFF
--- a/packages/core/src/prompt-config/prompt-loader.test.ts
+++ b/packages/core/src/prompt-config/prompt-loader.test.ts
@@ -168,17 +168,11 @@ describe('PromptLoader', () => {
     });
 
     it('should return error for null or undefined file path', async () => {
-      const resultNull = await loader.loadFile(
-        null as unknown as string,
-        false,
-      );
+      const resultNull = await loader.loadFile(null, false);
       expect(resultNull.success).toBe(false);
       expect(resultNull.error).toBe('Invalid file path');
 
-      const resultUndefined = await loader.loadFile(
-        undefined as unknown as string,
-        false,
-      );
+      const resultUndefined = await loader.loadFile(undefined, false);
       expect(resultUndefined.success).toBe(false);
       expect(resultUndefined.error).toBe('Invalid file path');
     });
@@ -253,7 +247,7 @@ describe('PromptLoader', () => {
 
     it('should handle empty content', () => {
       expect(loader.compressContent('')).toBe('');
-      expect(loader.compressContent(null as unknown as string)).toBe('');
+      expect(loader.compressContent(null)).toBe('');
     });
 
     it('should remove excessive whitespace', () => {
@@ -316,23 +310,29 @@ describe('PromptLoader', () => {
       expect(result.has(file2)).toBe(false);
     });
 
-    it('should return empty map for null or empty inputs', async () => {
-      const resultNull = await loader.loadAllFiles(
-        null as unknown as string,
+    it('should return empty map for null, undefined, or empty inputs', async () => {
+      const nullBaseDir = await loader.loadAllFiles(null, ['file.md'], false);
+      expect(nullBaseDir.size).toBe(0);
+
+      const undefinedBaseDir = await loader.loadAllFiles(
+        undefined,
         ['file.md'],
         false,
       );
-      expect(resultNull.size).toBe(0);
+      expect(undefinedBaseDir.size).toBe(0);
 
-      const resultEmpty = await loader.loadAllFiles(tempDir, [], false);
-      expect(resultEmpty.size).toBe(0);
+      const emptyList = await loader.loadAllFiles(tempDir, [], false);
+      expect(emptyList.size).toBe(0);
 
-      const resultNullFiles = await loader.loadAllFiles(
+      const nullList = await loader.loadAllFiles(tempDir, null, false);
+      expect(nullList.size).toBe(0);
+
+      const undefinedList = await loader.loadAllFiles(
         tempDir,
-        null as unknown as string[],
+        undefined,
         false,
       );
-      expect(resultNullFiles.size).toBe(0);
+      expect(undefinedList.size).toBe(0);
     });
 
     it('should apply compression when requested', async () => {

--- a/packages/core/src/prompt-config/prompt-loader.ts
+++ b/packages/core/src/prompt-config/prompt-loader.ts
@@ -294,17 +294,16 @@ export class PromptLoader {
    * Load multiple files and return a map of path to content
    */
   async loadAllFiles(
-    baseDir: string,
-    fileList: string[],
+    baseDir: string | null | undefined,
+    fileList: string[] | null | undefined,
     shouldCompress: boolean,
   ): Promise<Map<string, string>> {
     // Step 1: Validate inputs
-    if (
-      (baseDir as unknown) == null ||
-      baseDir === '' ||
-      (fileList as unknown) == null ||
-      fileList.length === 0
-    ) {
+    if (baseDir === null || baseDir === undefined || baseDir === '') {
+      return new Map();
+    }
+
+    if (fileList === null || fileList === undefined || fileList.length === 0) {
       return new Map();
     }
 

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -640,6 +640,36 @@ describe('shell-utils', () => {
       ).toBe(true);
     });
 
+    it('should fail closed when params are malformed', () => {
+      const allowlist = ['run_shell_command(git)'];
+
+      const missingCommand = { params: {} } as unknown as AnyToolInvocation;
+      expect(isShellInvocationAllowlisted(missingCommand, allowlist)).toBe(
+        false,
+      );
+
+      const nonStringCommand = {
+        params: { command: 42 },
+      } as unknown as AnyToolInvocation;
+      expect(isShellInvocationAllowlisted(nonStringCommand, allowlist)).toBe(
+        false,
+      );
+
+      const objectCommand = {
+        params: { command: { nested: 'git' } },
+      } as unknown as AnyToolInvocation;
+      expect(isShellInvocationAllowlisted(objectCommand, allowlist)).toBe(
+        false,
+      );
+
+      const whitespaceCommand = {
+        params: { command: '   ' },
+      } as unknown as AnyToolInvocation;
+      expect(isShellInvocationAllowlisted(whitespaceCommand, allowlist)).toBe(
+        false,
+      );
+    });
+
     it('should treat piped commands as separate segments that must be allowlisted', () => {
       const invocation = createInvocation('git status | tail -n 1');
       expect(

--- a/packages/core/src/utils/tool-utils.test.ts
+++ b/packages/core/src/utils/tool-utils.test.ts
@@ -58,6 +58,19 @@ describe('doesToolInvocationMatch', () => {
     expect(result).toBe(true);
   });
 
+  it('should not coerce a non-string command into a match', () => {
+    const invocation = {
+      params: { command: 42 },
+    } as AnyToolInvocation;
+    const patterns = ['ShellTool(42)'];
+    const result = doesToolInvocationMatch(
+      'run_shell_command',
+      invocation,
+      patterns,
+    );
+    expect(result).toBe(false);
+  });
+
   describe('for non-shell tools', () => {
     const readFileTool = new ReadFileTool({
       getTargetDir: () => '',

--- a/packages/core/src/utils/tool-utils.ts
+++ b/packages/core/src/utils/tool-utils.ts
@@ -83,7 +83,11 @@ function matchesToolPattern(
     if (!('command' in invocation.params)) {
       return false;
     }
-    command = String((invocation.params as { command?: unknown }).command);
+    const commandValue = (invocation.params as { command?: unknown }).command;
+    if (typeof commandValue !== 'string') {
+      return false;
+    }
+    command = commandValue;
   }
 
   // PowerShell command resolution is case-insensitive; Bash is case-sensitive.

--- a/packages/core/src/utils/tool-utils.ts
+++ b/packages/core/src/utils/tool-utils.ts
@@ -83,7 +83,7 @@ function matchesToolPattern(
     if (!('command' in invocation.params)) {
       return false;
     }
-    command = String((invocation.params as { command: string }).command);
+    command = String((invocation.params as { command?: unknown }).command);
   }
 
   // PowerShell command resolution is case-insensitive; Bash is case-sensitive.
@@ -138,6 +138,8 @@ export function isShellInvocationAllowlisted(
     return true;
   }
 
+  // AnyToolInvocation.params is an intentionally shape-less `object` boundary, so
+  // widen to unknown before structural checks.
   const params = invocation.params as unknown;
   if (typeof params !== 'object' || params === null || !('command' in params)) {
     return false;

--- a/project-plans/issue2196-honest-prompt-boundaries.md
+++ b/project-plans/issue2196-honest-prompt-boundaries.md
@@ -1,0 +1,126 @@
+# Issue #2196: Make core prompt utility boundaries honest instead of widening to unknown
+
+Follow-up to audit issue #2159. Branch: `issue2196`.
+
+## Root cause
+
+`PromptLoader.loadAllFiles` declares `baseDir: string` and `fileList: string[]`
+but then checks `(baseDir as unknown) == null` and `(fileList as unknown) == null`.
+The declared types over-promise non-null while runtime code still defends against
+nullish boundary values; the widening casts exist only to make lint accept the
+defensive checks.
+
+## Research findings
+
+- `loadAllFiles` has no production callers; only `prompt-loader.test.ts` invokes
+  it, currently passing `null as unknown as string` / `null as unknown as string[]`.
+- Sibling methods in the same class already use the honest-nullable convention:
+  `loadFile(filePath: string | null | undefined, ...)` and
+  `compressContent(content: string | null | undefined)`, each guarded with
+  explicit `=== null || === undefined` checks.
+- The tests already assert the documented contract: nullish/empty inputs return
+  an empty `Map`.
+- `packages/core/src/utils/partUtils.ts` is already an honest boundary: inputs
+  are `unknown`, narrowing is done via type predicates (`isNonNullObject`,
+  `isEmptyPartValue`); there are no widening casts. No change needed.
+- `packages/core/src/utils/tool-utils.ts`:
+  - `isShellInvocationAllowlisted` uses
+    `const params = invocation.params as unknown;` to narrow the intentionally
+    opaque `AnyToolInvocation.params: object` boundary
+    (`AnyToolInvocation = ToolInvocation<object, ToolResult>` in
+    `packages/tools/src/tools/tools.ts`) with `typeof`/`in` checks. This is
+    legitimate boundary narrowing of an opaque type — keep it.
+  - `matchesToolPattern` narrows with
+    `(invocation.params as { command: string }).command` after an `in` guard,
+    then defensively calls `String(...)`. The cast over-promises
+    `command: string` while runtime conversion defends against non-strings.
+    Honest form: `command?: unknown`.
+
+## Decision (Design choice: honest-nullable vs. remove checks)
+
+Make `loadAllFiles` honestly nullable, matching the sibling `loadFile` /
+`compressContent` convention. Rationale: nullish inputs are possible (public
+method, no non-null caller guarantee; tests pass null today), the empty-`Map`
+behavior is already documented and asserted, and removing the checks would
+delete proven behavior. This keeps the existing contract; it adds no new
+defensive layer.
+
+## Acceptance criteria
+
+1. `loadAllFiles` signature becomes
+   `baseDir: string | null | undefined, fileList: string[] | null | undefined`
+   with explicit `=== null` / `=== undefined` guards replacing both
+   `(x as unknown) == null` widening casts. Behavior unchanged: nullish or
+   empty inputs return an empty `Map`.
+2. `prompt-loader.test.ts` proves the nullish boundary without casts:
+   - existing null cases pass `null` directly (no `as unknown as`),
+   - `undefined` coverage added for both `baseDir` and `fileList`,
+   - vestigial casts dropped from the `loadFile` null/undefined test and the
+     `compressContent(null)` test (both signatures already accept nullish).
+   - positive-path tests unchanged.
+3. `tool-utils.ts`: keep the `as unknown` narrowing of the opaque
+   `AnyToolInvocation.params` boundary with a brief why-comment; replace the
+   over-promising `{ command: string }` cast in `matchesToolPattern` with
+   `{ command?: unknown }` (runtime `String()` conversion unchanged).
+4. `partUtils.ts`: no change (already honest); recorded here and in the PR.
+5. Tests added in `shell-utils.test.ts` for the previously untested
+   malformed-`params` branch of `isShellInvocationAllowlisted`: missing
+   `command`, non-string `command`, empty/whitespace `command` → `false`.
+6. No lint suppressions, no lint/type rule loosening, no new .js files, no
+   vitest/node test runners (TS + bun test only).
+
+## Out of scope (classified)
+
+- `watchFiles`' non-nullable `callback` param with `typeof callback !== 'function'`
+  check (same file, not named by the issue) — Defer.
+- Other `as unknown` sites in prompt-config (e.g. `prompt-service.ts` L199,
+  `toolOutputLimiter.ts` L310) — Defer; broader audit belongs to #2159 follow-ups.
+- Changing `AnyToolInvocation` or `ToolInvocation` type definitions — Reject
+  (public tools-package API, far beyond this issue).
+
+## Tests that prove it
+
+- `packages/core/src/prompt-config/prompt-loader.test.ts`
+  - `loadAllFiles(null, ['file.md'])` → empty map
+  - `loadAllFiles(undefined, ['file.md'])` → empty map
+  - `loadAllFiles(tempDir, [])` → empty map
+  - `loadAllFiles(tempDir, null)` / `loadAllFiles(tempDir, undefined)` → empty map
+- `packages/core/src/utils/shell-utils.test.ts`
+  - `isShellInvocationAllowlisted({ params: {} }, ['run_shell_command(git)'])` → false
+  - non-string `command` → false
+  - whitespace-only `command` → false
+
+## Verification
+
+Full cycle per workflow: `npm run test`, `npm run lint`, `npm run typecheck`,
+`npm run format`, `npm run build`, then the stepfun-37 smoke test via
+`bun scripts/start.ts`. OCR review before push (max 2 rounds). deepthinker
+review (max 2 rounds).
+
+## Results (2026-08-23)
+
+- Implementation: typescriptexpert produced the 4-file diff (57+/23-);
+  round-1 review remediation split the six-condition guard into two
+  early-return guards (sonarjs/expression-complexity), final diff 58+/27-.
+- deepthinker round 1: REQUEST_CHANGES (HIGH: expression complexity) → fixed.
+  Round 2: APPROVE, zero findings. 2/2 rounds used.
+- Targeted tests: `bun test src/prompt-config/prompt-loader.test.ts
+  src/utils/shell-utils.test.ts` → 112 pass / 1 Windows skip / 0 fail.
+- typecheck EXIT=0; lint EXIT=0; format EXIT=0 (no file changes); build EXIT=0;
+  stepfun-37 smoke test generated a haiku and exited cleanly.
+- OCR local round 1: complete, 4/4 changed files covered (tests included via
+  global include rules), 0 findings. 1 of 2 local rounds used.
+- Full suite (`npm run test`): 14 failing files, none in changed files.
+  Evidence of pre-existing/environmental origin (checked against a clean
+  origin/main worktree):
+  - `packages/core/test/utils/ripgrepPathResolver.test.ts`: identical 4
+    failures on origin/main.
+  - `packages/agents` specs: ≥1 identical failure standalone on origin/main.
+  - Remaining failures (core settings-remediation performance `<10ms`
+    wall-clock, auth lock-owner, cli dialog/performance, tools grep 15s
+    timing, agents 300s timeout): pass standalone on both trees; all are
+    load-sensitive timing/process tests that failed only under full-suite
+    load, with no code-path overlap with this diff (the diff's only
+    runtime-visible change is a behavior-preserving guard split plus a
+    type-only cast).
+- Main worktree removed after evidence capture.

--- a/project-plans/issue2196-honest-prompt-boundaries.md
+++ b/project-plans/issue2196-honest-prompt-boundaries.md
@@ -124,3 +124,40 @@ review (max 2 rounds).
     runtime-visible change is a behavior-preserving guard split plus a
     type-only cast).
 - Main worktree removed after evidence capture.
+
+## PR remediation (CodeRabbit, 2026-08-23)
+
+- PR #3280 CI fully green (37 pass / 0 fail / 3 by-design skips), CodeRabbit
+  check SUCCESS, CI OpenCodeReview: 0 findings (PR OCR round 1 of 2).
+- One actionable CodeRabbit thread (tool-utils.ts `matchesToolPattern`):
+  `String(...)` coerced a malformed non-string `params.command` (e.g. `42`)
+  into matching `ShellTool(42)` via the exported `doesToolInvocationMatch`,
+  bypassing `isShellInvocationAllowlisted`'s non-string rejection. Classified
+  In-scope-Fix (line touched by this PR; same boundary-honesty root cause;
+  sibling path already rejects non-strings; fail-closed).
+- Fix: `matchesToolPattern` now reads `params.command` as `unknown` and
+  returns `false` for non-strings instead of coercing; regression test added
+  in `tool-utils.test.ts` (`{ params: { command: 42 } }` vs `ShellTool(42)`
+  → `false`).
+- Round-2 verification: targeted tests 121 pass / 1 Windows skip / 0 fail
+  (prompt-loader, shell-utils, tool-utils test files); typecheck EXIT=0
+  (re-run sequentially after build — a concurrent build/typecheck run
+  produces transient `Cannot find module '@vybestack/llxprt-code-ide-integration'`
+  errors from dist being rebuilt); format EXIT=0 no changes; build EXIT=0;
+  stepfun-37 smoke PASS; full lint + full suite re-run on the remediated
+  head. No new OCR local round needed for this small guard change; the CI
+  OpenCodeReview on the new head covers it (PR OCR round 2 of 2).
+- Round-2 full suite: 31 failing tests, none in changed files (targeted
+  runs of all three touched test files: 121 pass / 1 Windows skip / 0 fail).
+  Failure triage: 4 ripgrepPathResolver (byte-identical on origin/main,
+  proven round 1); agents 180s/30s-timeout specs plus GrepTool 60s and
+  provider-liveness 150ms timing tests (load-sensitive — this run shared
+  the machine with concurrent lint/typecheck/build). Proof of flakiness at
+  the merge-base 38d9fb9f7 (fixed commit, no PR changes present):
+  config-injection.spec.ts + core-history.spec.ts combined standalone →
+  1 fail (config-injection T1, 30s timeout) then 0 fail on immediate
+  re-run, and a third repetition failed T1 again; on the remediated branch
+  the same T1/T6 fail the same way. Full-suite round-1 worktree evidence
+  (identical ripgrep failures, standalone-passing timing tests on both
+  trees) plus this round's merge-base flake proof cover all 31.
+- Main worktree removed after evidence capture.


### PR DESCRIPTION
## TLDR

`PromptLoader.loadAllFiles` declared `baseDir: string` / `fileList: string[]` while guarding nullish values through `(x as unknown) == null` widening casts — the declared types over-promised non-null and the casts existed only to make lint accept the defensive checks. This PR gives the boundary an honest nullable signature and replaces the casts with explicit guards, and reviews the two adjacent utilities named in the issue. `partUtils.ts` is already an honest boundary (unknown inputs + type predicates) and is intentionally untouched; `tool-utils.ts` keeps its legitimate narrowing of the opaque `AnyToolInvocation.params: object` boundary (now documented) and stops over-promising `command: string` in one cast. No lint suppressions, no lint/type rule changes.

## Dive Deeper

**prompt-loader.ts (`loadAllFiles`)** — signature is now `baseDir: string | null | undefined` / `fileList: string[] | null | undefined`, matching the sibling `loadFile` and `compressContent` convention that already exists in the same class. The two `(x as unknown) == null` casts are replaced with explicit `=== null` / `=== undefined` checks, split into two early-return guards (baseDir nullish/empty, then fileList nullish/empty) to stay within `sonarjs/expression-complexity` limits. The empty-`Map` contract is byte-for-byte preserved (truth-table equivalence confirmed in review). Decision rationale for honest-nullable vs. removing the checks: `loadAllFiles` is a public method with no production callers today (only tests), so no caller guarantees non-null; nullish inputs are possible and the empty-`Map` behavior is already a documented, test-asserted contract.

**prompt-loader.test.ts** — nullish cases now pass `null` / `undefined` directly with zero type-defeating casts, and `undefined` coverage is added for both `baseDir` and `fileList` (previously only `null` was covered). Vestigial casts were also dropped from the `loadFile` null/undefined test and the `compressContent(null)` test since both signatures already accept nullish. Positive-path tests unchanged.

**tool-utils.ts** — `const params = invocation.params as unknown;` in `isShellInvocationAllowlisted` is kept: it narrows the intentionally shape-less `AnyToolInvocation.params: object` boundary (`AnyToolInvocation = ToolInvocation<object, ToolResult>` in `packages/tools/src/tools/tools.ts`) before structural `typeof`/`in` checks — legitimate boundary narrowing, now documented with a why-comment. In `matchesToolPattern`, the cast `invocation.params as { command: string }` over-promised a concrete string while the runtime `String(...)` conversion exists precisely because `command` may not be a string; it is now `as { command?: unknown }` with the runtime coercion unchanged.

**partUtils.ts** — no change: inputs are `unknown` and narrowing happens via type predicates (`isNonNullObject`, `isEmptyPartValue`); there are no widening casts to fix.

**shell-utils.test.ts** — new fail-closed test for the previously untested malformed-`params` branch of `isShellInvocationAllowlisted`: missing `command`, non-string `command` (number and object), and whitespace-only `command` all return `false` against a shell-specific pattern (non-wildcard, so the params branch actually executes).

Plan doc: `project-plans/issue2196-honest-prompt-boundaries.md`.

## Reviewer Test Plan

```bash
cd packages/core && bun test src/prompt-config/prompt-loader.test.ts src/utils/shell-utils.test.ts
```
Expected: 112 pass / 1 skip (Windows-only) / 0 fail. The `loadAllFiles > should return empty map for null, undefined, or empty inputs` test proves the honest nullish boundary; the `should fail closed when params are malformed` test proves the tool-utils guard.

For type-level proof that the boundary is honest, note the test file compiles with direct `null`/`undefined` arguments (previously impossible without `as unknown as` casts), enforced by `npm run typecheck` and `npm run lint` (no suppressions anywhere in the diff).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS (darwin, bun runtime): full verification cycle — targeted tests 112 pass/1 skip/0 fail; `npm run typecheck` PASS; `npm run lint` PASS; `npm run format` clean; `npm run build` PASS; stepfun-37 smoke test (`bun scripts/start.ts`) generated a haiku and exited cleanly. Full workspace suite ran with 14 failing files, all proven pre-existing or load-sensitive timing flakes (identical failures reproduced on a clean origin/main worktree; none touch the changed files) — details in the plan doc.

## Linked issues / bugs

Fixes #2196
References #2159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prompt configuration loading when the base directory or file list is missing or empty; the system now safely returns no files instead of failing.
  - Strengthened shell command validation so malformed, missing, non-text, numeric, or blank command values are rejected safely.

- **Tests**
  - Added coverage for empty prompt-loading inputs and invalid shell invocation parameters.
  - Added regression coverage confirming numeric command values cannot match text-based command patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->