### PR TITLE
fix(agents): require runtime MessageBus for TaskTool subagents (Fixes #2320)

### DIFF
--- a/packages/agents/src/core/__tests__/subagentOrchestrator-loadBalancer.test.ts
+++ b/packages/agents/src/core/__tests__/subagentOrchestrator-loadBalancer.test.ts
@@ -26,6 +26,7 @@ import type { Profile, ProfileManager } from '@vybestack/llxprt-code-settings';
 import type { SubagentConfig } from '@vybestack/llxprt-code-core/config/types.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { SubAgentScope } from '../subagent.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { SubagentOrchestrator } from '../subagentOrchestrator.js';
 import {
   makeForegroundConfig,
@@ -119,6 +120,7 @@ describe('SubagentOrchestrator - Load Balancer Profiles (Issue #2410)', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
     return { orchestrator, runtimeLoader };
   }
@@ -143,6 +145,7 @@ describe('SubagentOrchestrator - Load Balancer Profiles (Issue #2410)', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     // Before the fix this rejected with RuntimeStateError: provider.missing.
@@ -181,6 +184,7 @@ describe('SubagentOrchestrator - Load Balancer Profiles (Issue #2410)', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     const result = await orchestrator.launch({
@@ -223,6 +227,7 @@ describe('SubagentOrchestrator - Load Balancer Profiles (Issue #2410)', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await expect(

--- a/packages/agents/src/core/__tests__/subagentOrchestrator-runtime.test.ts
+++ b/packages/agents/src/core/__tests__/subagentOrchestrator-runtime.test.ts
@@ -14,6 +14,7 @@ import type { SubagentManager } from '@vybestack/llxprt-code-core/config/subagen
 import type { Profile, ProfileManager } from '@vybestack/llxprt-code-settings';
 import type { SubagentConfig } from '@vybestack/llxprt-code-core/config/types.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubAgentScope } from '../subagent.js';
 import { type SubAgentScope as SubAgentScopeInstance } from '../subagent.js';
 import type { RunConfig } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
@@ -75,6 +76,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     const result = await orchestrator.launch({
@@ -125,6 +127,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: config,
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({
@@ -179,6 +182,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     try {
@@ -227,6 +231,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({
@@ -271,6 +276,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({
@@ -324,6 +330,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({
@@ -382,6 +389,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
         foregroundConfig: makeForegroundConfig(),
         scopeFactory,
         runtimeLoader,
+        messageBus: new MessageBus(),
       });
 
       await orchestrator.launch({ name: vertexSubagent.name });
@@ -450,6 +458,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({
@@ -499,6 +508,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({
@@ -550,6 +560,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({
@@ -601,6 +612,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     const firstRun = await orchestrator.launch({
@@ -648,6 +660,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
         getAgentId: () => 'planner-dispose',
       } as unknown as SubAgentScopeInstance),
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     const run = await orchestrator.launch({
@@ -738,6 +751,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: config,
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     const result = await orchestrator.launch({
@@ -816,6 +830,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await expect(
@@ -873,6 +888,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       foregroundConfig: makeForegroundConfig(),
       scopeFactory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await expect(

--- a/packages/agents/src/core/__tests__/subagentOrchestrator-sessionInheritance.test.ts
+++ b/packages/agents/src/core/__tests__/subagentOrchestrator-sessionInheritance.test.ts
@@ -21,6 +21,7 @@ import type { Profile, ProfileManager } from '@vybestack/llxprt-code-settings';
 import type { SubagentManager } from '@vybestack/llxprt-code-core/config/subagentManager.js';
 import type { SubagentConfig } from '@vybestack/llxprt-code-core/config/types.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import * as runtimeModule from '@vybestack/llxprt-code-providers/runtime.js';
 import * as profileApplicationModule from '@vybestack/llxprt-code-providers/runtime/profileApplication.js';
 import type { SubAgentScope } from '../subagent.js';
@@ -89,6 +90,7 @@ async function launchSubagent(
     foregroundConfig: makeConfigWithSettings(foregroundSettings),
     scopeFactory,
     runtimeLoader,
+    messageBus: new MessageBus(),
   });
 
   const result = await orchestrator.launch({ name: subagentConfig.name });
@@ -330,6 +332,7 @@ describe('SubagentOrchestrator — session dumpcontext inheritance (#3151)', () 
         foregroundConfig: makeConfigWithSettings(foreground),
         scopeFactory,
         runtimeLoader,
+        messageBus: new MessageBus(),
       });
 
       const result = await orchestrator.launch({

--- a/packages/agents/src/core/__tests__/subagentOrchestrator-test-helpers.ts
+++ b/packages/agents/src/core/__tests__/subagentOrchestrator-test-helpers.ts
@@ -20,6 +20,7 @@ import {
 } from '@vybestack/llxprt-code-settings';
 import type { SubagentConfig } from '@vybestack/llxprt-code-core/config/types.js';
 import type { RunConfig } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { SubagentOrchestrator } from '../subagentOrchestrator.js';
 import { type SubAgentScope as SubAgentScopeInstance } from '../subagent.js';
 
@@ -98,6 +99,7 @@ export function createOrchestratorForTurns(options: {
     foregroundConfig: options.foregroundConfig ?? makeForegroundConfig(),
     scopeFactory: factory,
     runtimeLoader,
+    messageBus: new MessageBus(),
   });
 
   return { orchestrator, factory };

--- a/packages/agents/src/core/subagentOrchestrator.test.ts
+++ b/packages/agents/src/core/subagentOrchestrator.test.ts
@@ -113,6 +113,7 @@ describe('SubagentOrchestrator - token-usage identity (issue #3130)', () => {
       foregroundConfig,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({ name: subagentConfig.name });
@@ -150,6 +151,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await expect(
@@ -184,6 +186,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await expect(
@@ -225,6 +228,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     const extraPrompt = 'Prioritize API surface summaries before examples.';
@@ -291,6 +295,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({ name: subagentConfig.name });
@@ -336,6 +341,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({ name: subagentConfig.name });
@@ -398,6 +404,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig: configWithParentTurns,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({ name: subagentConfig.name });
@@ -446,6 +453,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig: configWithDynamicTurns,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({ name: subagentConfig.name });
@@ -500,6 +508,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig: configWithParentTurns,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({
@@ -558,6 +567,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig: configWithParentTurns,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({ name: subagentConfig.name });
@@ -605,6 +615,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig: configWithUnlimitedParentTurns,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     await orchestrator.launch({ name: subagentConfig.name });
@@ -722,6 +733,7 @@ describe('SubagentOrchestrator - Config Resolution', () => {
       foregroundConfig,
       scopeFactory: factory,
       runtimeLoader,
+      messageBus: new MessageBus(),
     });
 
     const controller = new AbortController();
@@ -764,27 +776,5 @@ describe('SubagentOrchestrator - MessageBus threading (Issue #2312)', () => {
     const overridesArg = factoryCall[7];
     expect(overridesArg).toBeDefined();
     expect(overridesArg?.messageBus).toBe(sessionMessageBus);
-  });
-
-  it('leaves overrides.messageBus undefined when no messageBus is configured', async () => {
-    const { subagentManager, profileManager } = buildMessageBusManagers();
-    const { factory } = createScopeFactory();
-    const runtimeLoader = vi.fn().mockResolvedValue(createRuntimeBundle());
-
-    const orchestrator = new SubagentOrchestrator({
-      subagentManager,
-      profileManager,
-      foregroundConfig,
-      scopeFactory: factory,
-      runtimeLoader,
-    });
-
-    await orchestrator.launch({ name: messageBusSubagentConfig.name });
-
-    expect(factory).toHaveBeenCalledTimes(1);
-    const factoryCall = factory.mock.calls[0];
-    const overridesArg = factoryCall[7];
-    expect(overridesArg).toBeDefined();
-    expect(overridesArg?.messageBus).toBeUndefined();
   });
 });

--- a/packages/agents/src/core/subagentOrchestrator.ts
+++ b/packages/agents/src/core/subagentOrchestrator.ts
@@ -114,11 +114,11 @@ export interface SubagentOrchestratorOptions {
   scopeFactory?: ScopeFactory;
   idFactory?: () => string;
   /**
-   * Session/runtime MessageBus threaded into the SubAgentScope so
+   * Required session/runtime MessageBus threaded into the SubAgentScope so
    * non-interactive subagent tool execution can satisfy
    * Config.getOrCreateScheduler's explicit MessageBus dependency (Issue #2312).
    */
-  messageBus?: MessageBus;
+  messageBus: MessageBus;
 }
 
 /**

--- a/packages/agents/src/tools/task.async-settings.test.ts
+++ b/packages/agents/src/tools/task.async-settings.test.ts
@@ -16,14 +16,17 @@ import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
 import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
 import { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 
 describe('TaskTool', () => {
   let config: Config;
+  let messageBus: MessageBus;
 
   beforeEach(() => {
     config = {
       getSessionId: () => 'session-123',
     } as unknown as Config;
+    messageBus = new MessageBus();
   });
 
   describe('async mode settings', () => {
@@ -43,6 +46,7 @@ describe('TaskTool', () => {
       } as unknown as Config;
       const tool = new TaskTool(configWithDisabledGlobalAsync, {
         orchestratorFactory: () => ({}) as SubagentOrchestrator,
+        messageBus,
         getAsyncTaskManager: () =>
           mockAsyncTaskManager as unknown as AsyncTaskManager,
       });
@@ -80,6 +84,7 @@ describe('TaskTool', () => {
       } as unknown as Config;
       const tool = new TaskTool(configWithDisabledProfileAsync, {
         orchestratorFactory: () => ({}) as SubagentOrchestrator,
+        messageBus,
         getAsyncTaskManager: () =>
           mockAsyncTaskManager as unknown as AsyncTaskManager,
       });
@@ -132,6 +137,7 @@ describe('TaskTool', () => {
       const tool = new TaskTool(configWithEnabledAsync, {
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
+        messageBus,
         getAsyncTaskManager: () =>
           mockAsyncTaskManager as unknown as AsyncTaskManager,
         isInteractiveEnvironment: () => false,
@@ -176,6 +182,7 @@ describe('TaskTool', () => {
       const tool = new TaskTool(configWithoutSettings, {
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
+        messageBus,
         getAsyncTaskManager: () =>
           mockAsyncTaskManager as unknown as AsyncTaskManager,
         isInteractiveEnvironment: () => false,

--- a/packages/agents/src/tools/task.async.test.ts
+++ b/packages/agents/src/tools/task.async.test.ts
@@ -13,6 +13,7 @@ import { advanceTimersByTimeAsync } from '@vybestack/llxprt-code-test-utils';
 import { describe, it, expect, vi, beforeEach } from 'bun:test';
 import { TaskTool, type TaskToolParams } from './task.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
 import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
@@ -30,6 +31,7 @@ describe('TaskTool', () => {
   describe('async mode', () => {
     it('returns error when async=true but AsyncTaskManager not available', async () => {
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as SubagentOrchestrator,
         // No getAsyncTaskManager provided
       });
@@ -56,6 +58,7 @@ describe('TaskTool', () => {
         tryReserveAsyncSlot: () => null,
       };
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as SubagentOrchestrator,
         getAsyncTaskManager: () =>
           mockAsyncTaskManager as unknown as AsyncTaskManager,
@@ -97,6 +100,7 @@ describe('TaskTool', () => {
         dispose: vi.fn().mockResolvedValue(undefined),
       });
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () =>
@@ -145,6 +149,7 @@ describe('TaskTool', () => {
         dispose: vi.fn().mockResolvedValue(undefined),
       });
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () =>
@@ -193,6 +198,7 @@ describe('TaskTool', () => {
         dispose: vi.fn().mockResolvedValue(undefined),
       });
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () => realAsyncTaskManager,
@@ -242,6 +248,7 @@ describe('TaskTool', () => {
         dispose: vi.fn().mockResolvedValue(undefined),
       });
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () => realAsyncTaskManager,
@@ -309,6 +316,7 @@ describe('TaskTool', () => {
           },
         );
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () => realAsyncTaskManager,
@@ -371,6 +379,7 @@ describe('TaskTool', () => {
         dispose: vi.fn().mockResolvedValue(undefined),
       });
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () =>
@@ -429,6 +438,7 @@ describe('TaskTool', () => {
         dispose: vi.fn().mockResolvedValue(undefined),
       });
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () =>
@@ -478,6 +488,7 @@ describe('TaskTool', () => {
         dispose: vi.fn().mockResolvedValue(undefined),
       });
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () =>
@@ -549,6 +560,7 @@ describe('TaskTool', () => {
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () =>
@@ -615,6 +627,7 @@ describe('TaskTool', () => {
         dispose: vi.fn().mockResolvedValue(undefined),
       });
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () => realAsyncTaskManager,

--- a/packages/agents/src/tools/task.heartbeat.test.ts
+++ b/packages/agents/src/tools/task.heartbeat.test.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
 } from './taskHeartbeat.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
 import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import type { LiveOutputUpdate } from '@vybestack/llxprt-code-tools';
@@ -96,6 +97,7 @@ function buildTool(scope: PendingScope): TaskTool {
   });
   const orchestrator = { launch } as unknown as SubagentOrchestrator;
   return new TaskTool(createConfig(), {
+    messageBus: new MessageBus(),
     orchestratorFactory: () => orchestrator,
     isInteractiveEnvironment: () => true,
   });
@@ -510,6 +512,7 @@ describe('TaskTool heartbeat integration', () => {
     });
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(createConfig(), {
+      messageBus: new MessageBus(),
       orchestratorFactory: () => orchestrator,
       isInteractiveEnvironment: () => false,
     });

--- a/packages/agents/src/tools/task.issues.test.ts
+++ b/packages/agents/src/tools/task.issues.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, vi, beforeEach } from 'bun:test';
 import { TaskTool, type TaskToolParams } from './task.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
 import {
   ContextState,
@@ -66,6 +67,7 @@ describe('TaskTool', () => {
       });
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => false,
       });
@@ -134,6 +136,7 @@ describe('TaskTool', () => {
       });
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });
@@ -181,6 +184,7 @@ describe('TaskTool', () => {
       });
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => false,
       });
@@ -226,6 +230,7 @@ describe('TaskTool', () => {
       });
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => false,
       });
@@ -277,6 +282,7 @@ describe('TaskTool', () => {
         dispose: vi.fn().mockResolvedValue(undefined),
       });
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () =>
@@ -356,6 +362,7 @@ describe('TaskTool', () => {
       });
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => false,
       });
@@ -417,6 +424,7 @@ describe('TaskTool', () => {
       });
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => false,
       });
@@ -466,6 +474,7 @@ describe('TaskTool', () => {
       } as unknown as Config;
 
       const tool = new TaskTool(configNoRegistry, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });
@@ -524,6 +533,7 @@ describe('TaskTool', () => {
       } as unknown as Config;
 
       const tool = new TaskTool(configWithRegistry, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });
@@ -576,6 +586,7 @@ describe('TaskTool', () => {
       } as unknown as Config;
 
       const tool = new TaskTool(configNoRegistry, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });
@@ -624,6 +635,7 @@ describe('TaskTool', () => {
       } as unknown as Config;
 
       const tool = new TaskTool(configNoRegistry, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });
@@ -688,6 +700,7 @@ describe('TaskTool', () => {
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithRegistry, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });

--- a/packages/agents/src/tools/task.max-turns.test.ts
+++ b/packages/agents/src/tools/task.max-turns.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, vi, beforeEach } from 'bun:test';
 import { TaskTool } from './task.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import {
   ContextState,
   SubagentTerminateMode,
@@ -20,11 +21,13 @@ import {
 
 describe('TaskTool', () => {
   let config: Config;
+  let messageBus: MessageBus;
 
   beforeEach(() => {
     config = {
       getSessionId: () => 'session-123',
     } as unknown as Config;
+    messageBus = new MessageBus();
   });
 
   async function streamSubagentDeltas(
@@ -61,6 +64,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
     const updateOutput = vi.fn();
@@ -100,6 +104,7 @@ describe('TaskTool', () => {
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
         orchestratorFactory: () => orchestrator,
+        messageBus,
         isInteractiveEnvironment: () => true,
       });
 
@@ -151,6 +156,7 @@ describe('TaskTool', () => {
       } as unknown as Config;
       const tool = new TaskTool(configWithTimeout, {
         orchestratorFactory: () => orchestrator,
+        messageBus,
         isInteractiveEnvironment: () => true,
       });
 
@@ -196,6 +202,7 @@ describe('TaskTool', () => {
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
         orchestratorFactory: () => orchestrator,
+        messageBus,
         isInteractiveEnvironment: () => true,
       });
 
@@ -226,6 +233,7 @@ describe('TaskTool', () => {
         orchestratorFactory: () => {
           throw new Error('should not be called');
         },
+        messageBus,
       });
 
     it('rejects max_turns of 0', () => {
@@ -287,6 +295,7 @@ describe('TaskTool', () => {
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
         orchestratorFactory: () => orchestrator,
+        messageBus,
         isInteractiveEnvironment: () => true,
       });
 
@@ -331,6 +340,7 @@ describe('TaskTool', () => {
       const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
         orchestratorFactory: () => orchestrator,
+        messageBus,
         isInteractiveEnvironment: () => true,
       });
 
@@ -390,6 +400,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
     const invocation = tool.build({

--- a/packages/agents/src/tools/task.message-bus.integration.test.ts
+++ b/packages/agents/src/tools/task.message-bus.integration.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'bun:test';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { SubagentManager } from '@vybestack/llxprt-code-core/config/subagentManager.js';
+import type { SubagentConfig } from '@vybestack/llxprt-code-core/config/types.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import {
+  MessageBusType,
+  type ToolPolicyRejection,
+} from '@vybestack/llxprt-code-core/confirmation-bus/types.js';
+import { PolicyDecision } from '@vybestack/llxprt-code-core/policy/types.js';
+import { getTestRuntimeMessageBus } from '@vybestack/llxprt-code-core/test-utils/config.js';
+import { MockTool } from '@vybestack/llxprt-code-core/test-utils/tools.js';
+import type { Profile, ProfileManager } from '@vybestack/llxprt-code-settings';
+import { CoreToolScheduler } from '../core/coreToolScheduler.js';
+import { ChatSession } from '../core/chatSession.js';
+import { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
+import {
+  createMockConfig,
+  createMockStream,
+  createStatelessRuntimeBundle,
+  disposeMockConfig,
+} from '../core/subagent-test-helpers.js';
+import { TaskTool } from './task.js';
+
+const actualTools = { ...(await import('@vybestack/llxprt-code-tools')) };
+void vi.mock('@vybestack/llxprt-code-tools', () => ({
+  ...actualTools,
+  LocalTodoStore: vi.fn().mockImplementation(() => ({
+    readTodos: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+const actualChatSession = { ...(await import('../core/chatSession.js')) };
+void vi.mock('../core/chatSession.js', () => ({
+  ...actualChatSession,
+  ChatSession: vi.fn(),
+}));
+
+const actualEnvironmentContext = {
+  ...(await import('@vybestack/llxprt-code-core/utils/environmentContext.js')),
+};
+void vi.mock('@vybestack/llxprt-code-core/utils/environmentContext.js', () => ({
+  ...actualEnvironmentContext,
+  getEnvironmentContext: vi.fn().mockResolvedValue([{ text: 'Environment' }]),
+}));
+
+const actualPrompts = {
+  ...(await import('@vybestack/llxprt-code-core/core/prompts.js')),
+};
+void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  ...actualPrompts,
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('Core prompt'),
+}));
+
+const SUBAGENT_NAME = 'message-bus-probe';
+const TOOL_NAME = 'message_bus_probe_tool';
+
+const subagentConfig: SubagentConfig = {
+  name: SUBAGENT_NAME,
+  profile: 'message-bus-profile',
+  systemPrompt: 'Run the requested tool.',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const profile: Profile = {
+  version: 1,
+  provider: 'gemini',
+  model: 'gemini-2.0-pro',
+  modelParams: {},
+  ephemeralSettings: {},
+};
+
+function createManagers(): {
+  subagentManager: SubagentManager;
+  profileManager: ProfileManager;
+} {
+  return {
+    subagentManager: {
+      loadSubagent: vi.fn().mockResolvedValue(subagentConfig),
+    } as unknown as SubagentManager,
+    profileManager: {
+      loadProfile: vi.fn().mockResolvedValue(profile),
+    } as unknown as ProfileManager,
+  };
+}
+
+describe('TaskTool runtime MessageBus integration', () => {
+  let config: Config | undefined;
+  let sendMessageStream: ReturnType<typeof createMockStream>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendMessageStream = createMockStream([]);
+    (
+      ChatSession as unknown as Mock<(...args: never[]) => unknown>
+    ).mockImplementation(() => ({
+      sendMessageStream,
+      getHistory: vi.fn().mockReturnValue([]),
+      getHistoryService: vi.fn().mockReturnValue({
+        clear: vi.fn(),
+        findUnmatchedToolCalls: vi.fn().mockReturnValue([]),
+        getCurated: vi.fn().mockReturnValue([]),
+        getTotalTokens: vi.fn().mockReturnValue(0),
+      }),
+      getConfig: vi.fn().mockReturnValue(undefined),
+    }));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (config !== undefined) {
+      await disposeMockConfig(config);
+    }
+  });
+
+  it('uses the exact session MessageBus for a non-interactive subagent tool scheduler', async () => {
+    const probeTool = new MockTool(TOOL_NAME);
+    const { config: runtimeConfig } = await createMockConfig({
+      getTool: (name) => (name === TOOL_NAME ? probeTool : undefined),
+    });
+    config = runtimeConfig;
+    runtimeConfig.setToolSchedulerFactory(
+      (options) => new CoreToolScheduler(options),
+    );
+
+    const sessionMessageBus = getTestRuntimeMessageBus(runtimeConfig);
+    const decoyMessageBus = new MessageBus(
+      runtimeConfig.getPolicyEngine(),
+      false,
+    );
+    const sessionRejections: ToolPolicyRejection[] = [];
+    const decoyRejections: ToolPolicyRejection[] = [];
+    sessionMessageBus.subscribe<ToolPolicyRejection>(
+      MessageBusType.TOOL_POLICY_REJECTION,
+      (message) => {
+        sessionRejections.push(message);
+      },
+    );
+    decoyMessageBus.subscribe<ToolPolicyRejection>(
+      MessageBusType.TOOL_POLICY_REJECTION,
+      (message) => {
+        decoyRejections.push(message);
+      },
+    );
+    vi.spyOn(runtimeConfig.getPolicyEngine(), 'evaluate').mockReturnValue(
+      PolicyDecision.DENY,
+    );
+
+    sendMessageStream.mockImplementation(
+      createMockStream([
+        [{ name: TOOL_NAME, id: 'message-bus-probe-call' }],
+        'stop',
+      ]),
+    );
+
+    const { subagentManager, profileManager } = createManagers();
+    const runtimeBundle = createStatelessRuntimeBundle({
+      toolRegistry: runtimeConfig.getToolRegistry(),
+    });
+    const tool = new TaskTool(runtimeConfig, {
+      messageBus: sessionMessageBus,
+      isInteractiveEnvironment: () => false,
+      orchestratorFactory: (coreSchedulerMessageBus) =>
+        new SubagentOrchestrator({
+          subagentManager,
+          profileManager,
+          foregroundConfig: runtimeConfig,
+          runtimeLoader: vi.fn().mockResolvedValue(runtimeBundle),
+          messageBus: coreSchedulerMessageBus,
+        }),
+    });
+
+    await tool
+      .build({
+        subagent_name: SUBAGENT_NAME,
+        goal_prompt: 'Exercise the normal tool scheduler.',
+      })
+      .execute(new AbortController().signal);
+
+    expect(sessionRejections).toHaveLength(1);
+    expect(sessionRejections[0].toolCall.name).toBe(TOOL_NAME);
+    expect(decoyRejections).toHaveLength(0);
+  }, 30_000);
+});

--- a/packages/agents/src/tools/task.message-bus.integration.test.ts
+++ b/packages/agents/src/tools/task.message-bus.integration.test.ts
@@ -175,14 +175,16 @@ describe('TaskTool runtime MessageBus integration', () => {
     const tool = new TaskTool(runtimeConfig, {
       messageBus: sessionMessageBus,
       isInteractiveEnvironment: () => false,
-      orchestratorFactory: (coreSchedulerMessageBus) =>
-        new SubagentOrchestrator({
+      orchestratorFactory: (coreSchedulerMessageBus) => {
+        expect(coreSchedulerMessageBus).toBe(sessionMessageBus);
+        return new SubagentOrchestrator({
           subagentManager,
           profileManager,
           foregroundConfig: runtimeConfig,
           runtimeLoader: vi.fn().mockResolvedValue(runtimeBundle),
           messageBus: coreSchedulerMessageBus,
-        }),
+        });
+      },
     });
 
     await tool

--- a/packages/agents/src/tools/task.output-naming.test.ts
+++ b/packages/agents/src/tools/task.output-naming.test.ts
@@ -18,6 +18,7 @@ import {
   normalizeTaskParams,
 } from './taskToolGovernance.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
 import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 
@@ -227,6 +228,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
 
     it('exposes expected_outputs as a schema property', () => {
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
       });
       const prop = getSchemaProperties(tool)?.['expected_outputs'];
@@ -238,6 +240,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
 
     it('retains output_spec as a deprecated alias in the schema', () => {
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
       });
       const prop = getSchemaProperties(tool)?.['output_spec'];
@@ -252,6 +255,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
   describe('TaskTool validateToolParamValues', () => {
     it('rejects JSON-Schema-shaped expected_outputs at schema validation time', () => {
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
       });
       const params: TaskToolParams = {
@@ -272,6 +276,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
 
     it('rejects JSON-Schema-shaped output_spec alias at schema validation time', () => {
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
       });
       const params: TaskToolParams = {
@@ -288,6 +293,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
 
     it('validateToolParamValues rejects non-string expected_outputs values that bypass schema', () => {
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
       });
       // validateToolParamValues is a second line of defense for callers that
@@ -310,6 +316,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
 
     it('validateToolParamValues rejects non-string output_spec values that bypass schema', () => {
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
       });
       const error = (
@@ -330,6 +337,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
 
     it('accepts valid string-valued expected_outputs', () => {
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
       });
       const params: TaskToolParams = {
@@ -343,6 +351,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
 
     it('accepts valid string-valued output_spec alias', () => {
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
       });
       const params: TaskToolParams = {
@@ -359,6 +368,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
     it('passes expected_outputs into launchRequest.outputConfig', async () => {
       const { launch, orchestrator } = createMockLaunch();
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });
@@ -382,6 +392,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
     it('passes output_spec alias into launchRequest.outputConfig', async () => {
       const { launch, orchestrator } = createMockLaunch();
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });
@@ -405,6 +416,7 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
     it('prefers expected_outputs over output_spec when both are provided at runtime', async () => {
       const { launch, orchestrator } = createMockLaunch();
       const tool = new TaskTool(config, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });

--- a/packages/agents/src/tools/task.test.ts
+++ b/packages/agents/src/tools/task.test.ts
@@ -14,7 +14,7 @@ import { TaskTool, type TaskToolParams } from './task.js';
 import { DEFAULT_TASK_TIMEOUT_SECONDS } from './taskAbortHelpers.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
-import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import {
   ContextState,
   SubagentTerminateMode,
@@ -22,11 +22,13 @@ import {
 
 describe('TaskTool', () => {
   let config: Config;
+  let messageBus: MessageBus;
 
   beforeEach(() => {
     config = {
       getSessionId: () => 'session-123',
     } as unknown as Config;
+    messageBus = new MessageBus();
   });
 
   function createMockOrchestrator(agentId: string) {
@@ -98,6 +100,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
     const params: TaskToolParams = {
@@ -153,12 +156,14 @@ describe('TaskTool', () => {
     expect(result.error).toBeUndefined();
   });
 
-  it('passes the invocation messageBus into injected orchestrator factories', async () => {
-    const messageBus = {} as MessageBus;
+  it('passes the exact runtime MessageBus into injected orchestrator factories', async () => {
     const { orchestrator, scope } = createMockOrchestrator('agent-messagebus');
-    const orchestratorFactory = vi.fn(() => orchestrator);
+    let receivedMessageBus: MessageBus | undefined;
     const tool = new TaskTool(config, {
-      orchestratorFactory,
+      orchestratorFactory: (coreSchedulerMessageBus) => {
+        receivedMessageBus = coreSchedulerMessageBus;
+        return orchestrator;
+      },
       isInteractiveEnvironment: () => true,
       messageBus,
     });
@@ -170,31 +175,15 @@ describe('TaskTool', () => {
 
     await invocation.execute(new AbortController().signal, undefined);
 
-    expect(orchestratorFactory).toHaveBeenCalledWith(messageBus);
+    expect(receivedMessageBus).toBe(messageBus);
     expect(scope.runInteractive).toHaveBeenCalledTimes(1);
     expect(scope.runNonInteractive).not.toHaveBeenCalled();
   });
 
-  it('passes undefined messageBus when no messageBus is configured', async () => {
-    const { orchestrator, scope } = createMockOrchestrator(
-      'agent-without-messagebus',
+  it('rejects malformed construction without a concrete runtime messageBus', () => {
+    expect(() => Reflect.construct(TaskTool, [config, {}])).toThrow(
+      'TaskTool requires a concrete session/runtime MessageBus.',
     );
-    const orchestratorFactory = vi.fn(() => orchestrator);
-    const tool = new TaskTool(config, {
-      orchestratorFactory,
-      isInteractiveEnvironment: () => true,
-    });
-
-    const invocation = tool.build({
-      subagent_name: 'helper',
-      goal_prompt: 'Ship the feature',
-    });
-
-    await invocation.execute(new AbortController().signal, undefined);
-
-    expect(orchestratorFactory).toHaveBeenCalledWith(undefined);
-    expect(scope.runInteractive).toHaveBeenCalledTimes(1);
-    expect(scope.runNonInteractive).not.toHaveBeenCalled();
   });
 
   it('filters explicit tool_whitelist against enabled registry tools', async () => {
@@ -237,6 +226,7 @@ describe('TaskTool', () => {
 
     const tool = new TaskTool(configWithRegistry, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
 
@@ -296,6 +286,7 @@ describe('TaskTool', () => {
 
     const tool = new TaskTool(configWithRegistry, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
 
@@ -355,6 +346,7 @@ describe('TaskTool', () => {
 
     const tool = new TaskTool(configWithRegistry, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
 
@@ -413,6 +405,7 @@ describe('TaskTool', () => {
 
     const tool = new TaskTool(configWithRegistry, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
 
@@ -469,6 +462,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
 
@@ -519,6 +513,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
 
@@ -573,6 +568,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(configWithoutSessionId, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
 
@@ -610,6 +606,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => false,
     });
     const invocation = tool.build({
@@ -650,6 +647,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
       schedulerFactoryProvider: () => schedulerFactory,
     });
@@ -671,6 +669,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
 
@@ -714,6 +713,7 @@ describe('TaskTool', () => {
 
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => false,
     });
 
@@ -752,6 +752,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
       isInteractiveEnvironment: () => true,
     });
     const invocation = tool.build({
@@ -819,6 +820,7 @@ describe('TaskTool', () => {
     const orchestrator = { launch } as unknown as SubagentOrchestrator;
     const tool = new TaskTool(config, {
       orchestratorFactory: () => orchestrator,
+      messageBus,
     });
     const invocation = tool.build({
       subagent_name: 'helper',

--- a/packages/agents/src/tools/task.timeout.test.ts
+++ b/packages/agents/src/tools/task.timeout.test.ts
@@ -13,6 +13,7 @@ import { advanceTimersByTimeAsync } from '@vybestack/llxprt-code-test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
 import { TaskTool } from './task.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
 import {
   ContextState,
@@ -67,6 +68,7 @@ describe('TaskTool', () => {
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
       });
 
@@ -124,6 +126,7 @@ describe('TaskTool', () => {
       } as unknown as Config;
 
       const tool = new TaskTool(configWithSettings, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
       });
 
@@ -191,6 +194,7 @@ describe('TaskTool', () => {
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
       });
 
@@ -250,6 +254,7 @@ describe('TaskTool', () => {
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
       });
 
@@ -317,6 +322,7 @@ describe('TaskTool', () => {
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
         isInteractiveEnvironment: () => true,
       });
@@ -381,6 +387,7 @@ describe('TaskTool', () => {
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
+        messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
       });
 
@@ -405,6 +412,7 @@ describe('TaskTool', () => {
 
   it('validates required parameters', () => {
     const tool = new TaskTool(config, {
+      messageBus: new MessageBus(),
       orchestratorFactory: () => {
         throw new Error('should not be called');
       },

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -10,6 +10,7 @@ import {
   Kind,
   type ToolResult,
   type LiveOutputUpdate,
+  type IToolMessageBus,
 } from '@vybestack/llxprt-code-tools';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import {
@@ -102,18 +103,19 @@ export interface TaskToolParams {
 }
 
 export interface TaskToolDependencies {
-  orchestratorFactory?: (messageBus?: MessageBus) => SubagentOrchestrator;
+  /**
+   * Required session/runtime MessageBus threaded into the
+   * SubagentOrchestrator so non-interactive subagent tool execution can satisfy
+   * Config.getOrCreateScheduler's explicit MessageBus dependency
+   * (Issue #2312).
+   */
+  messageBus: MessageBus;
+  orchestratorFactory?: (messageBus: MessageBus) => SubagentOrchestrator;
   profileManager?: ProfileManager;
   subagentManager?: SubagentManager;
   schedulerFactoryProvider?: () => SubagentSchedulerFactory | undefined;
   isInteractiveEnvironment?: () => boolean;
   getAsyncTaskManager?: () => AsyncTaskManager | undefined;
-  /**
-   * Session/runtime MessageBus threaded into the SubagentOrchestrator so
-   * non-interactive subagent tool execution can satisfy
-   * Config.getOrCreateScheduler's explicit MessageBus dependency (Issue #2312).
-   */
-  messageBus?: MessageBus;
 }
 function launchRequestName(
   launchResult: Awaited<ReturnType<SubagentOrchestrator['launch']>>,
@@ -138,7 +140,7 @@ class TaskToolInvocation extends BaseToolInvocation<
     params: TaskToolParams,
     private readonly normalized: TaskToolInvocationParams,
     private readonly deps: TaskToolInvocationDeps,
-    messageBus?: MessageBus,
+    messageBus: IToolMessageBus,
   ) {
     super(params, messageBus);
   }
@@ -736,10 +738,25 @@ class TaskToolInvocation extends BaseToolInvocation<
 export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
   static readonly Name = 'task';
 
+  private readonly config: Config;
+  private readonly dependencies: TaskToolDependencies;
+
+  constructor(config: Config, dependencies: TaskToolDependencies);
   constructor(
-    private readonly config: Config,
-    private readonly dependencies: TaskToolDependencies = {},
+    config: Config,
+    dependencies:
+      | (Omit<TaskToolDependencies, 'messageBus'> & {
+          messageBus: MessageBus | null | undefined;
+        })
+      | null
+      | undefined,
   ) {
+    const messageBus = dependencies?.messageBus;
+    if (messageBus === undefined || messageBus === null) {
+      throw new Error(
+        'TaskTool requires a concrete session/runtime MessageBus.',
+      );
+    }
     super(
       TaskTool.Name,
       'Task',
@@ -748,8 +765,10 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
       taskToolSchema,
       true,
       true,
-      dependencies.messageBus,
+      messageBus,
     );
+    this.config = config;
+    this.dependencies = { ...dependencies, messageBus };
   }
 
   protected override validateToolParamValues(
@@ -782,15 +801,22 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
 
   protected createInvocation(
     params: TaskToolParams,
-    messageBus?: MessageBus,
+    toolMessageBus?: IToolMessageBus,
   ): TaskToolInvocation {
+    if (toolMessageBus === undefined) {
+      throw new Error(
+        'TaskTool requires a concrete session/runtime MessageBus to build an invocation.',
+      );
+    }
+    const coreSchedulerMessageBus = this.dependencies.messageBus;
     const normalized = this.normalizeParams(params);
     return new TaskToolInvocation(
       this.config,
       params,
       normalized,
       {
-        createOrchestrator: () => this.ensureOrchestrator(messageBus),
+        createOrchestrator: () =>
+          this.ensureOrchestrator(coreSchedulerMessageBus),
         getToolRegistry:
           typeof this.config.getToolRegistry === 'function'
             ? () => this.config.getToolRegistry()
@@ -801,7 +827,7 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
           (() => this.config.isInteractive()),
         getAsyncTaskManager: this.dependencies.getAsyncTaskManager,
       },
-      messageBus,
+      toolMessageBus,
     );
   }
 
@@ -809,7 +835,7 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
     return normalizeTaskParams(params);
   }
 
-  private ensureOrchestrator(messageBus?: MessageBus): SubagentOrchestrator {
+  private ensureOrchestrator(messageBus: MessageBus): SubagentOrchestrator {
     if (this.dependencies.orchestratorFactory) {
       return this.dependencies.orchestratorFactory(messageBus);
     }

--- a/packages/agents/src/tools/taskAsyncStreaming.test.ts
+++ b/packages/agents/src/tools/taskAsyncStreaming.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, vi } from 'bun:test';
 import { TaskTool, type TaskToolParams } from './task.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
 import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import type { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
@@ -125,6 +126,7 @@ function createAsyncStreamingHarness(
       getSessionId: () => 'session-async-stream',
     } as unknown as Config,
     {
+      messageBus: new MessageBus(),
       orchestratorFactory: () =>
         ({ launch }) as unknown as SubagentOrchestrator,
       getAsyncTaskManager: () =>

--- a/packages/agents/test-bun/taskAsyncTimeout.issue3031.bun.ts
+++ b/packages/agents/test-bun/taskAsyncTimeout.issue3031.bun.ts
@@ -22,6 +22,7 @@
 import { describe, it, expect } from 'bun:test';
 import { TaskTool } from '../src/tools/task.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubagentOrchestrator } from '../src/core/subagentOrchestrator.js';
 import { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
 import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
@@ -48,6 +49,7 @@ describe('Issue #3031 — async task timeout observability', () => {
         'task-max-timeout-seconds': 120,
       }),
       {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () =>
@@ -87,6 +89,7 @@ describe('Issue #3031 — async task timeout observability', () => {
         'task-max-timeout-seconds': 0.05, // 50ms
       }),
       {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () => manager,
@@ -137,6 +140,7 @@ describe('Issue #3031 — async task timeout observability', () => {
         'task-max-timeout-seconds': 0.05, // 50ms
       }),
       {
+        messageBus: new MessageBus(),
         orchestratorFactory: () =>
           ({ launch: launchMock }) as unknown as SubagentOrchestrator,
         getAsyncTaskManager: () => manager,

--- a/packages/agents/test-bun/taskTimeoutBounds.issue3031.bun.ts
+++ b/packages/agents/test-bun/taskTimeoutBounds.issue3031.bun.ts
@@ -20,6 +20,7 @@
 import { describe, it, expect } from 'bun:test';
 import { TaskTool } from '../src/tools/task.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubagentOrchestrator } from '../src/core/subagentOrchestrator.js';
 import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
@@ -112,7 +113,7 @@ describe('Issue #3031 — task tool timeout ceiling semantics', () => {
         'task-default-timeout-seconds': 60,
         'task-max-timeout-seconds': 0.1,
       }),
-      { orchestratorFactory: () => orchestrator },
+      { messageBus: new MessageBus(), orchestratorFactory: () => orchestrator },
     );
 
     const invocation = tool.build({
@@ -143,7 +144,7 @@ describe('Issue #3031 — task tool timeout ceiling semantics', () => {
         'task-default-timeout-seconds': 60,
         'task-max-timeout-seconds': 0.1,
       }),
-      { orchestratorFactory: () => orchestrator },
+      { messageBus: new MessageBus(), orchestratorFactory: () => orchestrator },
     );
 
     const invocation = tool.build({
@@ -170,7 +171,7 @@ describe('Issue #3031 — task tool timeout ceiling semantics', () => {
         'task-default-timeout-seconds': 60,
         'task-max-timeout-seconds': 100,
       }),
-      { orchestratorFactory: () => orchestrator },
+      { messageBus: new MessageBus(), orchestratorFactory: () => orchestrator },
     );
 
     const invocation = tool.build({
@@ -196,7 +197,7 @@ describe('Issue #3031 — task tool timeout ceiling semantics', () => {
         'task-default-timeout-seconds': 60,
         'task-max-timeout-seconds': -1,
       }),
-      { orchestratorFactory: () => orchestrator },
+      { messageBus: new MessageBus(), orchestratorFactory: () => orchestrator },
     );
 
     const invocation = tool.build({
@@ -219,7 +220,7 @@ describe('Issue #3031 — task tool timeout ceiling semantics', () => {
         'task-default-timeout-seconds': 60,
         'task-max-timeout-seconds': 100,
       }),
-      { orchestratorFactory: () => orchestrator },
+      { messageBus: new MessageBus(), orchestratorFactory: () => orchestrator },
     );
     let error: unknown;
     try {
@@ -243,7 +244,7 @@ describe('Issue #3031 — task tool timeout ceiling semantics', () => {
         'task-default-timeout-seconds': 60,
         'task-max-timeout-seconds': 100,
       }),
-      { orchestratorFactory: () => orchestrator },
+      { messageBus: new MessageBus(), orchestratorFactory: () => orchestrator },
     );
     expect(() =>
       tool.build({
@@ -261,7 +262,7 @@ describe('Issue #3031 — task tool timeout ceiling semantics', () => {
         'task-default-timeout-seconds': 60,
         'task-max-timeout-seconds': 100,
       }),
-      { orchestratorFactory: () => orchestrator },
+      { messageBus: new MessageBus(), orchestratorFactory: () => orchestrator },
     );
     expect(() =>
       tool.build({

--- a/packages/agents/test-bun/taskTimeoutDescription.issue3031.bun.ts
+++ b/packages/agents/test-bun/taskTimeoutDescription.issue3031.bun.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect } from 'bun:test';
 import { TaskTool } from '../src/tools/task.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 
 function makeConfig(): Config {
   return {
@@ -26,7 +27,7 @@ function makeConfig(): Config {
 }
 
 function getTimeoutDescription(): string {
-  const tool = new TaskTool(makeConfig());
+  const tool = new TaskTool(makeConfig(), { messageBus: new MessageBus() });
   const parameters = (
     tool.schema.parametersJsonSchema as { properties?: Record<string, unknown> }
   ).properties;

--- a/packages/agents/test-bun/taskTimeoutResultAgentId.cr3031.bun.ts
+++ b/packages/agents/test-bun/taskTimeoutResultAgentId.cr3031.bun.ts
@@ -20,6 +20,7 @@
 import { describe, it, expect } from 'bun:test';
 import { TaskTool } from '../src/tools/task.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { SubagentOrchestrator } from '../src/core/subagentOrchestrator.js';
 import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
@@ -96,7 +97,7 @@ describe('CodeRabbit #3031 — post-run timeout result carries the real agentId'
         'task-default-timeout-seconds': 60,
         'task-max-timeout-seconds': 0.05, // 50ms
       }),
-      { orchestratorFactory: () => orchestrator },
+      { messageBus: new MessageBus(), orchestratorFactory: () => orchestrator },
     );
 
     const invocation = tool.build({

--- a/packages/core/src/config/config.agentInversion.test.ts
+++ b/packages/core/src/config/config.agentInversion.test.ts
@@ -271,17 +271,34 @@ describe('P01 construction inversion contracts', () => {
         isRegistered: true,
       }),
     );
-    expect(taskRecord?.args).toStrictEqual([
-      'config-arg',
-      expect.objectContaining({ messageBus }),
-    ]);
+    expect(taskRecord?.args[0]).toBe('config-arg');
+    const recordedTaskArgs = taskRecord?.args[1];
+    if (
+      typeof recordedTaskArgs !== 'object' ||
+      recordedTaskArgs === null ||
+      !('messageBus' in recordedTaskArgs)
+    ) {
+      throw new Error(
+        'Expected registry TaskTool arguments with a MessageBus.',
+      );
+    }
+    expect(recordedTaskArgs.messageBus).toBe(messageBus);
+
     expect(registeredTools).toContainEqual(expect.any(RegisteredTaskTool));
     const registeredTaskTool = registeredTools.find(
       (tool): tool is RegisteredTaskTool => tool instanceof RegisteredTaskTool,
     );
-    expect(registeredTaskTool?.createdWith[1]).toStrictEqual(
-      expect.objectContaining({ messageBus }),
-    );
+    const createdTaskArgs = registeredTaskTool?.createdWith[1];
+    if (
+      typeof createdTaskArgs !== 'object' ||
+      createdTaskArgs === null ||
+      !('messageBus' in createdTaskArgs)
+    ) {
+      throw new Error(
+        'Expected constructed TaskTool arguments with a MessageBus.',
+      );
+    }
+    expect(createdTaskArgs.messageBus).toBe(messageBus);
   });
 
   it('records disabled TaskTool diagnostic when registration is missing', async () => {

--- a/packages/core/src/config/config.scheduler.test.ts
+++ b/packages/core/src/config/config.scheduler.test.ts
@@ -130,6 +130,22 @@ describe('Config - CoreToolScheduler Singleton', () => {
     });
 
   describe('getOrCreateScheduler', () => {
+    it('rejects creation without an explicit session/runtime MessageBus', async () => {
+      const callbacks = {
+        outputUpdateHandler: vi.fn(),
+        onAllToolCallsComplete: vi.fn(),
+        onToolCallsUpdate: vi.fn(),
+        getPreferredEditor: () => undefined,
+        onEditorClose: vi.fn(),
+      };
+
+      await expect(
+        config.getOrCreateScheduler(testSessionId, callbacks),
+      ).rejects.toThrow(
+        'Config.getOrCreateScheduler requires an explicit session/runtime MessageBus dependency.',
+      );
+    });
+
     it('should create a new scheduler instance for a given sessionId if none exists', async () => {
       const callbacks = {
         outputUpdateHandler: vi.fn(),

--- a/packages/core/src/config/toolRegistryFactory.ts
+++ b/packages/core/src/config/toolRegistryFactory.ts
@@ -107,11 +107,11 @@ export interface TaskToolArgs {
   schedulerFactoryProvider: () => SubagentSchedulerFactory | undefined;
   getAsyncTaskManager: () => AsyncTaskManager | undefined;
   /**
-   * Session/runtime MessageBus threaded into the SubagentOrchestrator so
+   * Required session/runtime MessageBus threaded into the SubagentOrchestrator so
    * non-interactive subagent tool execution can satisfy
    * Config.getOrCreateScheduler's explicit MessageBus dependency (Issue #2312).
    */
-  messageBus: MessageBus | undefined;
+  messageBus: MessageBus;
 }
 
 /** Tool record for settings UI */

--- a/project-plans/issue2320/plan.md
+++ b/project-plans/issue2320/plan.md
@@ -1,0 +1,119 @@
+# Issue 2320 Delivery Plan: TaskTool MessageBus Seams
+
+Plan ID: PLAN-20260822-ISSUE2320
+Issue: https://github.com/vybestack/llxprt-code/issues/2320
+
+## Problem and bounded design
+
+The registry already receives a concrete core `MessageBus`, but the type guarantee is weakened as that bus enters the agents-owned TaskTool and subagent orchestration path. The implementation will make the existing production dependency mandatory and reject malformed runtime construction at TaskTool assembly instead of allowing failure to reach scheduler creation.
+
+The bounded design is:
+
+- Keep `TaskToolArgs.messageBus` named as required by the core-to-agents registration contract, but change its type from `MessageBus | undefined` to `MessageBus`.
+- Keep the existing `TaskToolDependencies` shape rather than add a public construction abstraction. Make `messageBus` required and remove the constructor default that permits `new TaskTool(config)`.
+- Make `SubagentOrchestratorOptions.messageBus` required because its normal launch path creates scheduler-capable subagent scopes.
+- Add a TaskTool constructor boundary check so malformed JavaScript or deliberately erased TypeScript types fail with an explicit TaskTool error before invocation or scheduler creation.
+- Keep `BaseDeclarativeTool.createInvocation` and its stored bus typed as optional `IToolMessageBus`. TaskTool will treat that shared tools-layer slot as invocation plumbing while retaining the required concrete core `MessageBus` from `TaskToolDependencies` for subagent scheduler setup. Local names and comments will state the distinction.
+- Do not create a fallback bus, read a bus from Config, or change `Config.getOrCreateScheduler` strictness.
+
+No new subsystem or public abstraction is required. Adding an adapter, manager, service, public API, dependency, or alternate global/session lookup is outside this plan and requires approval.
+
+## Accepted behavior and evidence
+
+| ID | Given | When | Then | Evidence |
+| --- | --- | --- | --- | --- |
+| A1 | Core assembles registry TaskTool arguments | TypeScript checks the registration boundary | `TaskToolArgs.messageBus` cannot be omitted or set to `undefined` | typecheck plus focused compile-time assertion if an established local pattern exists |
+| A2 | A caller constructs the normal `TaskTool` | TypeScript checks constructor dependencies | `TaskToolDependencies.messageBus` is mandatory and the empty/default dependency path is unavailable | typecheck and updated direct-construction tests |
+| A3 | Untyped JavaScript or erased types construct TaskTool without a concrete bus | TaskTool is assembled | construction fails immediately with a TaskTool-specific missing runtime MessageBus error | behavioral boundary test |
+| A4 | A `SubagentOrchestrator` is assembled | TypeScript checks its options | a concrete core scheduler MessageBus is mandatory | typecheck and rewritten orchestrator tests |
+| A5 | The registry receives one concrete session bus | it builds the agents-owned TaskTool | the same object is present in TaskTool runtime dependencies; no replacement bus is created | existing registry inversion behavior test, strengthened only if needed |
+| A6 | A non-interactive TaskTool-launched subagent executes a normal tool call | subagent execution requests its scheduler | `Config.getOrCreateScheduler` receives the exact session/runtime bus supplied at TaskTool construction, and a decoy bus receives nothing | new or strengthened near-end-to-end behavioral regression through real TaskTool and subagent execution components |
+| A7 | `Config.getOrCreateScheduler` is called without `dependencies.messageBus` | scheduler creation begins | it still throws the existing explicit dependency error | existing core strictness regression remains passing and unchanged unless an assertion needs clarification |
+| A8 | Shared normal tools use the tools package MessageBus seam | their invocations are built | they continue to receive optional `IToolMessageBus`; no tools-layer API or adapter behavior changes | existing tools tests and full suite |
+
+## Inputs and boundary cases
+
+1. A valid concrete core `MessageBus` supplied by `Config.initialize` and `createToolRegistry` must preserve object identity through TaskTool, SubagentOrchestrator, SubAgentScope overrides, non-interactive execution, and scheduler creation.
+2. An omitted dependency, an omitted `messageBus` field, or an explicitly undefined field after type erasure must fail at TaskTool construction.
+3. Injected `orchestratorFactory` tests still require the concrete TaskTool runtime bus. The factory receives that required bus, including interactive-only test scenarios, because TaskTool construction is scheduler-capable regardless of which execution mode a test selects.
+4. SubagentOrchestrator cannot normalize an absent bus. The existing test that expects `overrides.messageBus` to be undefined will be removed or rewritten as required-bus identity behavior.
+5. A distinct decoy bus in the behavioral regression must prove identity, not merely non-null presence.
+6. Missing profile/subagent manager behavior, timeout behavior, async behavior, tool governance, output handling, and scheduler lifecycle remain unchanged.
+
+## Test-first slices
+
+### Slice 1: required construction boundaries
+
+RED:
+
+- Add a TaskTool boundary test for malformed construction without `messageBus`.
+- Add or use the repository's established compile-time assertion pattern to prove registry args and TaskTool dependencies reject omission.
+- Rewrite the two tests that currently bless undefined TaskTool/orchestrator buses.
+
+GREEN:
+
+- Require the concrete bus in `TaskToolArgs`, `TaskToolDependencies`, the TaskTool constructor path, the orchestrator factory input, and `SubagentOrchestratorOptions`.
+- Add the constructor boundary failure and update affected tests with an explicit concrete bus.
+
+### Slice 2: exact-bus non-interactive regression
+
+RED:
+
+- Add one behavioral regression that launches through TaskTool and reaches normal non-interactive tool scheduling, supplying a session bus and a decoy bus and asserting observable work occurs only through the session bus.
+
+GREEN:
+
+- Use the required TaskTool dependency as the concrete scheduler bus when assembling SubagentOrchestrator and SubAgentScope. Do not add fallback logic.
+
+## Likely paths
+
+Planned source changes:
+
+- `packages/core/src/config/toolRegistryFactory.ts`
+- `packages/agents/src/tools/task.ts`
+- `packages/agents/src/core/subagentOrchestrator.ts`
+
+Planned test changes:
+
+- `packages/agents/src/tools/task.test.ts`
+- `packages/agents/src/core/subagentOrchestrator.test.ts`
+- direct TaskTool and SubagentOrchestrator construction tests that need an explicit concrete bus
+- one focused agents integration test for the exact non-interactive scheduler bus, placed beside the closest existing execution-path tests
+
+No change is planned for `packages/tools/src/tools/tools.ts` or `IToolMessageBus`.
+
+## Explicit non-goals
+
+- Creating or adapting a MessageBus automatically.
+- Reading a runtime bus from Config, an Agent global, process state, or another implicit owner.
+- Weakening or moving the `Config.getOrCreateScheduler` dependency check.
+- Tightening unrelated optional MessageBus seams in hooks, CLI bootstrap, generic non-interactive APIs, agentic loop APIs, or other tools.
+- Renaming public MessageBus fields or adding a general MessageBus ownership framework.
+- Refactoring scheduler lifecycle, subagent runtime isolation, managers, tool governance, timeout, async, or output code.
+- Moving unrelated tests or adding optional hardening.
+- Changing workflows, agent memory, quality tools, dependencies, lint, complexity, coverage, cross-platform policy, or CI configuration.
+
+## Review triage contract
+
+Every review finding will be classified as exactly one of:
+
+- **Blocker-Fix**: accepted behavior, correctness, architecture, or a required gate cannot pass without it.
+- **In-scope-Fix**: a valid defect within this acceptance matrix.
+- **Reject**: factually incorrect, already covered, or harmful to accepted behavior.
+- **Defer**: valid but outside this matrix and not implemented in this PR.
+
+Reviewer suggestions do not expand scope. At most two local OCR and two PR OCR reviews are permitted.
+
+## Completion gates
+
+The candidate head is complete only when:
+
+1. A1 through A8 have evidence on the exact candidate head.
+2. The test-audit comparison introduces no prohibited findings in touched tests.
+3. `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build` pass.
+4. `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` passes.
+5. DeepThinker and bounded local OCR reviews are complete, every finding is classified, and all Blocker-Fix and In-scope-Fix findings are resolved.
+6. The exact committed head is pushed, CI passes, bounded PR review is complete, and all actionable review threads are resolved.
+7. `origin/main` is an ancestor of the candidate head and the PR is conflict-free.
+
+Stop successfully when these gates pass. Do not continue optional cleanup.


### PR DESCRIPTION
## TLDR

Require registry-created `TaskTool` instances and `SubagentOrchestrator` instances to receive a concrete session/runtime `MessageBus`. The same bus is now preserved through non-interactive subagent tool scheduling, while the tools-layer `IToolMessageBus` invocation seam remains unchanged.

## Dive Deeper

The registry already receives the active session bus, but the agents-facing types allowed it to become optional. This change makes `TaskToolArgs.messageBus`, `TaskToolDependencies.messageBus`, the injected orchestrator factory argument, and `SubagentOrchestratorOptions.messageBus` required.

`TaskTool` retains a runtime boundary check for JavaScript and type-erased callers. It does not create a fallback bus or read one from `Config`, process state, or another implicit owner. `Config.getOrCreateScheduler` remains strict when no explicit bus is supplied.

The tests now provide a concrete bus at direct TaskTool and orchestrator construction sites. New and strengthened coverage verifies:

- malformed TaskTool construction fails before invocation or scheduler creation;
- the registry preserves the exact bus object;
- injected orchestrator factories receive that same object;
- a non-interactive TaskTool-launched subagent reaches a normal tool scheduler through the session bus, while a decoy bus receives no policy event;
- scheduler creation without an explicit bus still fails.

The test audit scanned 2,700 files with no scanner errors. Its normalized comparison against `origin/main` found no branch-only findings.

## Reviewer Test Plan

1. Run the focused MessageBus suites:
   ```bash
   bun test packages/agents/src/tools/task.test.ts packages/agents/src/tools/task.message-bus.integration.test.ts packages/core/src/config/config.agentInversion.test.ts packages/core/src/config/config.scheduler.test.ts packages/agents/src/core/subagentOrchestrator.test.ts
   ```
2. Confirm `TaskToolDependencies.messageBus`, `TaskToolArgs.messageBus`, and `SubagentOrchestratorOptions.messageBus` reject omission during `npm run typecheck`.
3. Inspect the integration test's session and decoy bus assertions. The policy rejection from a normal non-interactive subagent tool call must appear only on the session bus.
4. Run the standard verification commands and the `stepfun-37` smoke prompt.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ⚠️ | ❓ | ❓ |
| npx      | ❓ | ❓ | ❓ |
| Docker   | ❓ | ❓ | ❓ |
| Podman   | ❓ | - | - |
| Seatbelt | ❓ | - | - |

macOS verification:

- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run format`: passed
- `npm run build`: passed
- focused source tests: 198 passed, 0 failed
- affected standalone Bun tests: 21 passed, 0 failed
- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`: passed
- `npm run test`: did not complete successfully. One run reached core and hit 180-second file timeouts in the changed `config.agentInversion.test.ts` and unchanged `SessionLockManager.lazy.test.ts`; those files passed together directly (12 passed, 0 failed). A clean-PATH rerun stopped after unchanged `grep-ripgrep-issue3203-remediation.test.ts` hit its 15-second test timeout; that file passed directly (21 passed, 0 failed).

## Linked issues / bugs

Fixes #2320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message delivery consistency during task execution and subagent scheduling.
  - Added validation to prevent task or scheduler creation when required messaging context is unavailable.
  - Ensured task events, including rejected actions, are routed through the active session messaging channel.
  - Improved reliability of task execution across asynchronous, streaming, timeout, and heartbeat scenarios.

- **Tests**
  - Expanded coverage for messaging context propagation, configuration errors, and task execution workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->