### PR TITLE
Key ToolFormatter streaming buffers off the block, not a hidden field (Fixes #2198)

### DIFF
--- a/packages/tools/src/formatters/ToolFormatter.test.ts
+++ b/packages/tools/src/formatters/ToolFormatter.test.ts
@@ -19,7 +19,11 @@ import { describe, it, expect } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ToolFormatter } from './ToolFormatter.js';
-import type { FormatterTool, ToolFormat } from './IToolFormatter.js';
+import type {
+  FormatterTool,
+  ToolCallBlock,
+  ToolFormat,
+} from './IToolFormatter.js';
 
 function makeDeclarations(
   overrides: Partial<{
@@ -382,5 +386,337 @@ describe('ToolFormatter public method surface', () => {
         ),
       ),
     ).toBe(true);
+  });
+});
+
+describe('ToolFormatter streaming argument accumulation', () => {
+  const formatter = new ToolFormatter();
+
+  it('concatenates chunks split mid-key and mid-value into parsed parameters', () => {
+    const blocks: ToolCallBlock[] = [];
+    formatter.accumulateStreamingToolCall(
+      { index: 0, id: 'call_1', function: { name: 'get_weather' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '{"ci' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: 'ty":"SF' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '"}' } },
+      blocks,
+      'openai',
+    );
+
+    expect(blocks[0]?.parameters).toEqual({ city: 'SF' });
+  });
+
+  it('leaves no _argumentsString own property on the block during or after accumulation', () => {
+    const blocks: ToolCallBlock[] = [];
+    formatter.accumulateStreamingToolCall(
+      { index: 0, id: 'call_2', function: { name: 'get_weather' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '{"city' } },
+      blocks,
+      'openai',
+    );
+    expect(blocks[0]).toBeDefined();
+    expect(
+      Object.prototype.hasOwnProperty.call(blocks[0], '_argumentsString'),
+    ).toBe(false);
+    expect(Object.keys(blocks[0] ?? {}).sort()).toEqual([
+      'id',
+      'name',
+      'parameters',
+      'type',
+    ]);
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '":"SF"}' } },
+      blocks,
+      'openai',
+    );
+    expect(
+      Object.prototype.hasOwnProperty.call(blocks[0], '_argumentsString'),
+    ).toBe(false);
+    expect(Object.keys(blocks[0] ?? {}).sort()).toEqual([
+      'id',
+      'name',
+      'parameters',
+      'type',
+    ]);
+  });
+
+  it('accumulates arguments that arrive before the tool name is known', () => {
+    const blocks: ToolCallBlock[] = [];
+    formatter.accumulateStreamingToolCall(
+      { index: 0, id: 'call_3', function: { arguments: '{"ci' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { name: 'get_weather' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: 'ty":"SF"}' } },
+      blocks,
+      'openai',
+    );
+
+    expect(blocks[0]?.name).toBe('get_weather');
+    expect(blocks[0]?.parameters).toEqual({ city: 'SF' });
+    expect(
+      Object.prototype.hasOwnProperty.call(blocks[0], '_argumentsString'),
+    ).toBe(false);
+  });
+
+  it('ignores a delta with no index, creating no state', () => {
+    const blocks: ToolCallBlock[] = [];
+    formatter.accumulateStreamingToolCall(
+      {
+        id: 'no-index',
+        function: { name: 'get_weather', arguments: '{"a":1}' },
+      },
+      blocks,
+      'openai',
+    );
+    expect(blocks).toHaveLength(0);
+  });
+
+  it('keeps an indexed block while ignoring a delta with no index', () => {
+    const blocks: ToolCallBlock[] = [];
+    formatter.accumulateStreamingToolCall(
+      { index: 0, id: 'call_indexed', function: { name: 'get_weather' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '{"a":1}' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      {
+        id: 'no-index',
+        function: { name: 'get_weather', arguments: '{"b":2}' },
+      },
+      blocks,
+      'openai',
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.parameters).toEqual({ a: 1 });
+  });
+
+  it('keeps initial parameters untouched when only whitespace chunks arrive', () => {
+    const sentinel = { seeded: true };
+    const blocks: ToolCallBlock[] = [
+      {
+        type: 'tool_call',
+        id: 'call_4',
+        name: 'get_weather',
+        parameters: sentinel,
+      },
+    ];
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: ' ' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '  ' } },
+      blocks,
+      'openai',
+    );
+
+    expect(blocks[0]?.parameters).toBe(sentinel);
+  });
+
+  it('keeps independently accumulating interleaved tool calls without cross-talk', () => {
+    const blocks: ToolCallBlock[] = [];
+    formatter.accumulateStreamingToolCall(
+      { index: 0, id: 'call_a', function: { name: 'get_weather' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 1, id: 'call_b', function: { name: 'set_temperature' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '{"ci' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 1, function: { arguments: '{"tem' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: 'ty":"SF' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 1, function: { arguments: 'p":72}' } },
+      blocks,
+      'openai',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '"}' } },
+      blocks,
+      'openai',
+    );
+
+    expect(blocks[0]?.parameters).toEqual({ city: 'SF' });
+    expect(blocks[1]?.parameters).toEqual({ temp: 72 });
+  });
+
+  it('keeps the fully concatenated raw string when arguments never become valid JSON', () => {
+    const blocks: ToolCallBlock[] = [];
+    formatter.accumulateStreamingToolCall(
+      { index: 0, id: 'call_5', function: { name: 'get_weather' } },
+      blocks,
+      'openai',
+    );
+    expect(() =>
+      formatter.accumulateStreamingToolCall(
+        { index: 0, function: { arguments: '{"a":' } },
+        blocks,
+        'openai',
+      ),
+    ).not.toThrow();
+    expect(() =>
+      formatter.accumulateStreamingToolCall(
+        { index: 0, function: { arguments: 'oops}' } },
+        blocks,
+        'openai',
+      ),
+    ).not.toThrow();
+
+    expect(blocks[0]).toBeDefined();
+    expect(
+      Object.prototype.hasOwnProperty.call(blocks[0], '_argumentsString'),
+    ).toBe(false);
+    expect(blocks[0]?.parameters).toEqual('{"a":oops}');
+  });
+
+  it('swallows a throw on an incomplete fragment and still completes from the buffer', () => {
+    const initial = { before: true };
+    const target: ToolCallBlock = {
+      type: 'tool_call',
+      id: 'call_5b',
+      name: 'get_weather',
+      parameters: initial,
+    };
+    let parametersWrites = 0;
+    const proxied: ToolCallBlock = new Proxy(target, {
+      set(tgt, property, value) {
+        if (property === 'parameters') {
+          parametersWrites += 1;
+          if (parametersWrites === 1) {
+            throw new Error('simulated parse failure');
+          }
+        }
+        return Reflect.set(tgt, property, value);
+      },
+    });
+    const blocks = [proxied];
+
+    expect(() =>
+      formatter.accumulateStreamingToolCall(
+        { index: 0, function: { arguments: '{"a":' } },
+        blocks,
+        'openai',
+      ),
+    ).not.toThrow();
+    expect(blocks[0]?.parameters).toBe(initial);
+
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '1}' } },
+      blocks,
+      'openai',
+    );
+    expect(blocks[0]?.parameters).toEqual({ a: 1 });
+  });
+
+  it('repairs a qwen double-escaped payload delivered in a single chunk', () => {
+    const full = '"{\\"city\\":\\"SF\\"}"';
+    const blocks: ToolCallBlock[] = [];
+    formatter.accumulateStreamingToolCall(
+      { index: 0, id: 'call_6', function: { name: 'get_weather' } },
+      blocks,
+      'qwen',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: full } },
+      blocks,
+      'qwen',
+    );
+
+    expect(blocks[0]?.parameters).toEqual({ city: 'SF' });
+  });
+
+  it('repairs a qwen double-escaped payload split across chunks', () => {
+    const c1 = '"{\\"city';
+    const c2 = '\\":\\"SF\\"}"';
+    const blocks: ToolCallBlock[] = [];
+    formatter.accumulateStreamingToolCall(
+      { index: 0, id: 'call_7', function: { name: 'get_weather' } },
+      blocks,
+      'qwen',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: c1 } },
+      blocks,
+      'qwen',
+    );
+    formatter.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: c2 } },
+      blocks,
+      'qwen',
+    );
+
+    expect(blocks[0]?.parameters).toEqual({ city: 'SF' });
+  });
+
+  it('keeps buffering across separate ToolFormatter instances for the same block', () => {
+    const blocks: ToolCallBlock[] = [];
+    const first = new ToolFormatter();
+    const second = new ToolFormatter();
+    first.accumulateStreamingToolCall(
+      { index: 0, id: 'call_8', function: { name: 'get_weather' } },
+      blocks,
+      'openai',
+    );
+    first.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '{"ci' } },
+      blocks,
+      'openai',
+    );
+    second.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: 'ty":"SF' } },
+      blocks,
+      'openai',
+    );
+    first.accumulateStreamingToolCall(
+      { index: 0, function: { arguments: '"}' } },
+      blocks,
+      'openai',
+    );
+
+    expect(blocks[0]?.parameters).toEqual({ city: 'SF' });
   });
 });

--- a/packages/tools/src/formatters/ToolFormatter.ts
+++ b/packages/tools/src/formatters/ToolFormatter.ts
@@ -57,6 +57,9 @@ function isRequiredMissing(requiredValue: unknown): boolean {
   return MISSING_SCHEMA_VALUES.has(requiredValue);
 }
 
+/** Streaming argument buffers, keyed on the block so they survive across ToolFormatter instances. */
+const streamingArgumentBuffers = new WeakMap<ToolCallBlock, string>();
+
 /**
  * Converts tool declarations to various provider formats.
  *
@@ -530,22 +533,19 @@ export class ToolFormatter implements IToolFormatter {
     index: number,
     format: ToolFormat,
   ): void {
-    if (!('_argumentsString' in tc)) {
-      (tc as unknown as { _argumentsString: string })._argumentsString = '';
-    }
+    const previous = streamingArgumentBuffers.get(tc) ?? '';
 
     if (format === 'qwen') {
       logDoubleEscapingInChunk(chunk || '', tc.name || 'unknown', format);
     }
 
-    (tc as unknown as { _argumentsString: string })._argumentsString += chunk;
+    const accumulated = previous + chunk;
+    streamingArgumentBuffers.set(tc, accumulated);
 
     try {
-      const argsStr = (tc as unknown as { _argumentsString: string })
-        ._argumentsString;
-      if (argsStr.trim()) {
+      if (accumulated.trim()) {
         tc.parameters = doubleEscapeProcessToolParameters(
-          argsStr,
+          accumulated,
           tc.name || 'unknown',
           format,
         );

--- a/project-plans/issue2198-toolformatter-streaming-accumulator.md
+++ b/project-plans/issue2198-toolformatter-streaming-accumulator.md
@@ -1,0 +1,101 @@
+# Issue #2198 — Replace ToolFormatter streaming accumulator unknown casts
+
+Follow-up to audit issue #2159.
+
+## Problem
+
+`packages/tools/src/formatters/ToolFormatter.ts`,
+`accumulateStreamingArguments`, stores per-tool-call streaming state by
+mutating the `ToolCallBlock` argument with an undeclared `_argumentsString`
+property, reached through four `as unknown as { _argumentsString: string }`
+casts. `ToolCallBlock` (declared in `IToolFormatter.ts`) does not have that
+property. The casts are not an external boundary; they are a local state
+modeling gap.
+
+Current code (lines 527-561):
+
+```ts
+if (!('_argumentsString' in tc)) {
+  (tc as unknown as { _argumentsString: string })._argumentsString = '';
+}
+if (format === 'qwen') {
+  logDoubleEscapingInChunk(chunk || '', tc.name || 'unknown', format);
+}
+(tc as unknown as { _argumentsString: string })._argumentsString += chunk;
+try {
+  const argsStr = (tc as unknown as { _argumentsString: string })._argumentsString;
+  if (argsStr.trim()) {
+    tc.parameters = doubleEscapeProcessToolParameters(argsStr, tc.name || 'unknown', format);
+  }
+} catch {
+  // Keep accumulating
+}
+```
+
+## Grounding facts
+
+- `_argumentsString` appears nowhere else in the repository (grep: 5 hits, all
+  inside `accumulateStreamingArguments`). Nothing reads the property off an
+  accumulated block, so removing it from the emitted objects breaks no consumer.
+- `logDoubleEscapingInChunk` in this package is intentionally a no-op (core's
+  `DebugLogger` is not importable from `packages/tools`). "Preserve qwen
+  double-escaping logging" therefore means: keep calling it, with the same
+  arguments, on the same code path, for `qwen` only.
+- `accumulateStreamingToolCall` has no non-test in-repo callers today (only
+  historical `project-plans/multi-provider/*` docs reference it), so the current
+  streaming behavior is only observable through the formatter's own API.
+- `ToolFormatter.test.ts` has zero coverage of `accumulateStreamingToolCall`;
+  the issue's "add focused tests" clause therefore applies.
+
+## Accepted behavior (acceptance criteria)
+
+AC1. `accumulateStreamingArguments` contains no `as unknown as` cast and does
+not write any undeclared property onto `ToolCallBlock`. Streaming state is held
+in a module-level `WeakMap<ToolCallBlock, string>`.
+
+AC2. Accumulated `ToolCallBlock` objects carry no `_argumentsString` own
+property (before, during, or after accumulation).
+
+AC3. Behavior preserved exactly:
+
+- Chunks concatenate in arrival order per tool-call block.
+- After each chunk, when the accumulated string is non-blank, `tc.parameters`
+  is set to `processToolParameters(accumulated, tc.name || 'unknown', format)`.
+- A parse/processing throw is swallowed and accumulation continues; the
+  previously computed `parameters` value is retained.
+- For `format === 'qwen'` only, `logDoubleEscapingInChunk(chunk, tc.name ||
+  'unknown', format)` is called once per chunk, before the chunk is appended.
+- Blocks at different stream indices accumulate independently.
+
+AC4. Module-level (not instance-level) WeakMap, because current state lives on
+the block object and therefore survives across `ToolFormatter` instances.
+Keying on the block preserves that; keying on the formatter instance would not.
+
+AC5. No lint suppressions, no `eslint-disable`, no loosening of lint/type
+config.
+
+## Boundary cases to cover
+
+- Multi-chunk JSON split mid-key and mid-value (`{"ci` + `ty":"SF` + `"}`).
+- Chunk arriving before the tool name is known (name applied later in stream).
+- Delta with `index === undefined` -> ignored, no state created.
+- Whitespace-only accumulation -> `parameters` untouched (`{}`).
+- Two indices interleaved -> independent accumulators, no cross-talk.
+- Invalid JSON accumulated to completion -> no throw escapes.
+- `qwen` double-escaped payload split across chunks -> same repaired result as
+  a single chunk.
+
+## Tests
+
+New `describe('ToolFormatter streaming argument accumulation')` block in
+`packages/tools/src/formatters/ToolFormatter.test.ts` (bun test, real
+formatter, no mocks), covering each boundary case above plus an assertion that
+`Object.prototype.hasOwnProperty.call(block, '_argumentsString')` is false and
+`Object.keys(block)` contains only the declared fields.
+
+## Explicitly out of scope
+
+- The unused `index` parameter / `void index;` in `accumulateStreamingArguments`
+  (leave as-is; not part of the accepted behavior).
+- Any other `as unknown as` cast in the file or package.
+- Changes to `doubleEscapeUtils.ts`, `IToolFormatter.ts`, or callers.


### PR DESCRIPTION
## TLDR

`ToolFormatter.accumulateStreamingArguments` stored its partial JSON buffer by writing an undeclared `_argumentsString` property onto the `ToolCallBlock` it was handed, reached through four `as unknown as { _argumentsString: string }` casts. The buffer now lives in a module-level `WeakMap<ToolCallBlock, string>`, and the casts are gone.

Runtime behavior is unchanged. What changes for consumers is that accumulated blocks no longer carry a stray enumerable `_argumentsString` field that `Object.keys` and `JSON.stringify` would pick up.

Two things worth a reviewer's attention:

1. **Why the WeakMap is module-level rather than an instance field.** The old state lived on the block object itself, so it survived across `ToolFormatter` instances. Keying on the block preserves that; keying on the formatter would not. There is a test that fails if someone moves it onto the instance.
2. **The formatter had zero streaming coverage before this.** Twelve behavioral tests are added, three of them mutation-verified against the specific production behavior they claim.

## Dive Deeper

### The problem

`ToolCallBlock` (declared in `IToolFormatter.ts`) has five fields: `type`, `id`, `name`, `description`, `parameters`. It does not declare `_argumentsString`. The old code wrote that field anyway:

```ts
if (!('_argumentsString' in tc)) {
  (tc as unknown as { _argumentsString: string })._argumentsString = '';
}
(tc as unknown as { _argumentsString: string })._argumentsString += chunk;
const argsStr = (tc as unknown as { _argumentsString: string })._argumentsString;
```

As issue #2198 puts it, these casts are not an external boundary. They are a local state modeling gap: temporary streaming state stored on a type that does not model it.

### The change

```ts
/** Streaming argument buffers, keyed on the block so they survive across ToolFormatter instances. */
const streamingArgumentBuffers = new WeakMap<ToolCallBlock, string>();
```

and the method body becomes a read, an optional log, an append, a store, and the same guarded parse:

```ts
const previous = streamingArgumentBuffers.get(tc) ?? '';

if (format === 'qwen') {
  logDoubleEscapingInChunk(chunk || '', tc.name || 'unknown', format);
}

const accumulated = previous + chunk;
streamingArgumentBuffers.set(tc, accumulated);

try {
  if (accumulated.trim()) {
    tc.parameters = doubleEscapeProcessToolParameters(
      accumulated,
      tc.name || 'unknown',
      format,
    );
  }
} catch {
  // Keep accumulating
}
```

Weak keys mean a buffer is collectable along with its block, so there is no leak from long-lived streams.

### Behavior held constant

- Chunks concatenate in arrival order, per block.
- The `qwen`-only `logDoubleEscapingInChunk` call still runs before the chunk is appended, with the same `chunk || ''` and `tc.name || 'unknown'` fallbacks. (This function is a deliberate no-op in `packages/tools` because core's `DebugLogger` is not importable there; the call site is what the issue asks to preserve.)
- Parsing runs only when the accumulated buffer is non-blank.
- A throw out of processing or assignment is swallowed and accumulation continues with the buffer intact.
- The unused `index` parameter and its `void index;` are left alone as out of scope.

### Consumer safety

`_argumentsString` appears nowhere else in the repository. `accumulateStreamingToolCall` has no non-test in-repo caller today (only historical `project-plans/multi-provider/*` docs reference it). The only other package-local consumer of this `ToolCallBlock`, `ToolIdStrategy.ts`, reads `id` and `name` only. The similarly named core history `ToolCallBlock` is a distinct type and is not re-exported from here.

### Tests

Twelve behavioral tests in a new `describe('ToolFormatter streaming argument accumulation')` block, driving the real formatter through the public `accumulateStreamingToolCall` API with no mocks:

- multi-chunk JSON split mid-key and mid-value
- no `_argumentsString` own property, asserted mid-stream and after completion, plus an exact `Object.keys` check
- arguments arriving before the tool name is known
- an index-less delta ignored, alongside an indexed positive control so the test cannot pass against a no-op
- interleaved indices accumulating independently with no cross-talk
- whitespace-only chunks leaving `parameters` untouched
- arguments that never become valid JSON ending as the fully concatenated raw string (existing last-resort behavior of `processToolParameters`, `parameters` is typed `unknown`)
- qwen double-escape repair, single-chunk and split-across-chunks
- buffering continuing across two separate `ToolFormatter` instances
- a throw on the first `parameters` write being swallowed, with the next chunk completing from the retained buffer

Three are mutation-verified, meaning the production behavior was temporarily removed and the test observed to fail:

| Production behavior removed | Test that fails | Observed failure |
| --- | --- | --- |
| WeakMap moved to an instance field | cross-instance buffering | received `"{"ci"}"` instead of `{ city: 'SF' }` |
| `if (accumulated.trim())` guard | whitespace-only chunks | sentinel object replaced by `{}` |
| `try`/`catch` around parse and assign | throw-swallowing Proxy test | `simulated parse failure` escaped |

RED evidence for the change itself: against the pre-change implementation, three of the new tests fail on the `hasOwnProperty('_argumentsString')` assertion.

### Reviews

Independent review found 0 HIGH, 3 MEDIUM, 3 LOW, all in test coverage rather than production logic; all six are fixed in this branch. Open Code Review reported 0 findings across the 2 changed files.

## Reviewer Test Plan

The change is confined to `packages/tools/src/formatters/`, so the focused suite is the fastest check:

```bash
bun test packages/tools/src/formatters/ToolFormatter.test.ts
```

Expect 41 pass / 0 fail, including the 12 tests under `ToolFormatter streaming argument accumulation`.

To confirm the tests actually bite rather than just pass, reproduce one of the mutations. For example, in `packages/tools/src/formatters/ToolFormatter.ts` change

```ts
const streamingArgumentBuffers = new WeakMap<ToolCallBlock, string>();
```

into a `private streamingArgumentBuffers = new WeakMap<ToolCallBlock, string>()` field on the class, adjust the two call sites to `this.`, and re-run. The cross-instance test should fail. Restore afterwards.

To confirm the hidden field is gone, revert `accumulateStreamingArguments` to the version on `main` and re-run: three tests should fail on `hasOwnProperty`.

Wider check for the package:

```bash
npm run test --workspace packages/tools
```

Note that `grep`/`ripgrep` tests in this package (and `RipgrepPathResolver` in `packages/core`) fail intermittently on loaded machines with 15s/60s timeouts, and `RipgrepPathResolver` fails deterministically on `main` as well. Neither touches the formatters. Verified by running a `main` baseline with these changes stashed.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Validated on macOS: `npm run test` (full monorepo), `npm run typecheck` (0), `npm run lint` (0), `npm run build` (0), `npm run format` (clean), and the `stepfun-37` smoke run. The change is pure TypeScript with no platform-specific behavior.

## Linked issues / bugs

Fixes #2198

Follow-up from audit issue #2159.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming tool-call handling when arguments arrive in fragmented or interleaved chunks.
  * Preserved partial data until complete tool names and valid JSON payloads are available.
  * Added more resilient handling for missing indexes, whitespace, malformed payloads, parse failures, and escaped content.
  * Prevented streaming state from leaking between separate formatter instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->