### PR TITLE
Harden walkthrough comment posting with 404 fallback and failure diagnostics (Fixes #2900)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -446,30 +446,47 @@ jobs:
               core.info('No issue/PR number in context; skipping comment post.');
               return;
             }
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: number,
-                per_page: 100,
-              },
-            );
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-              core.info(`Updated comment ${existing.id}.`);
-            } else {
-              const { data: created } = await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: number,
-                body,
-              });
-              core.info(`Created comment ${created.id}.`);
+            try {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  per_page: 100,
+                },
+              );
+              const existing = comments.find((c) => c.body && c.body.includes(marker));
+              if (existing) {
+                try {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                    body,
+                  });
+                  core.info(`Updated comment ${existing.id}.`);
+                } catch (error) {
+                  if (error.status !== 404) {
+                    throw error;
+                  }
+                  const { data: recreated } = await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: number,
+                    body,
+                  });
+                  core.info(`Comment ${existing.id} disappeared (404); recreated as ${recreated.id}.`);
+                }
+              } else {
+                const { data: created } = await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  body,
+                });
+                core.info(`Created comment ${created.id}.`);
+              }
+            } catch (error) {
+              core.setFailed(`Failed to post walkthrough comment: ${error.message || error}`);
             }

--- a/project-plans/issue2900-comment-hardening.md
+++ b/project-plans/issue2900-comment-hardening.md
@@ -171,3 +171,13 @@ function object, not a promise).
 Local OCR count against the two-file diff: 2 (both within cap). Findings:
 the env-restore issue (fixed above) and the two rejected suggestions. No
 further local OCR rounds.
+
+### PR OCR (1 round, within cap)
+
+PR #3287 head b4ef65d3: 1 finding — bug/medium, resource-cleanup
+error-masking in the test lifecycle (if `mkdtempSync` throws in beforeEach,
+afterEach's `rmSync(undefined)` throws a TypeError that masks the setup
+error). Classified In-scope-Fix and fixed: teardown now only runs when the
+temp dir was created (`tempDir` is `string | undefined`, guarded); targeted
+gates re-verified (92/92 tests, prettier/eslint/tsc clean). CodeRabbit
+produced zero actionable comments.

--- a/project-plans/issue2900-comment-hardening.md
+++ b/project-plans/issue2900-comment-hardening.md
@@ -1,0 +1,173 @@
+# Issue #2900 Plan: Harden node24 PR-comment steps (404 fallback + API error diagnostics)
+
+Plan ID: PLAN-20260823-ISSUE2900
+Generated: 2026-08-23
+Issue: https://github.com/vybestack/llxprt-code/issues/2900
+
+## Investigation Result
+
+The issue lists two affected files. One no longer exists on main:
+
+- `.github/actions/post-coverage-comment/action.yml` was deleted in PR #3145
+  (commit d604b4db3a, "Delete every Vitest escape hatch...", Fixes #2970). That
+  PR removed the entire coverage plumbing because no test script passed
+  `--coverage`, so the coverage comment step posted nothing and its composite
+  action was dead weight. No workflow references the composite path anymore
+  (verified by recursive search of `.github/`). The coverage half of this issue
+  is therefore obsolete; reviving it would restore deleted dead code and is out
+  of scope.
+- `.github/workflows/pr-review.yml` still contains the `Post walkthrough comment`
+  step (github-script@v9, inline find-or-update script). It carries both
+  findings: an unwrapped `updateComment` that 404s if the matched comment is
+  deleted between `listComments` and `updateComment`, and no `core.setFailed`
+  diagnostics when API calls fail (the step's `continue-on-error: true` keeps
+  the job green while github-script's raw error is the only trace).
+
+Reference pattern in-repo: `issue-planner.yml`'s "Upsert plan comment" step
+wraps its API work in try/catch and calls
+`core.setFailed(\`Failed to reconcile planner comment: ${error.message || error}\`)`.
+`ocr-infrastructure-notifier.yml` uses the same `core.setFailed` convention.
+`issue-planner.ts` also demonstrates status-checked recovery: `deleteComment`
+errors are swallowed only when `status === 404`, otherwise re-thrown.
+
+Test precedent: `scripts/tests/ocr-review-github-script-syntax.bun.test.ts`
+compiles inline github-script blocks with `AsyncFunction` exactly as the action
+runtime does. `scripts/tests/pr-review-walkthrough-workflow.test.ts` already
+asserts the step's structure (`continue-on-error: true`, `if: always()`,
+github-script usage, marker env).
+
+## Accepted Behavior
+
+### AC-1: 404 on updateComment falls back to createComment
+
+**Given** the walkthrough comment matched by marker exists at `listComments`
+time,
+**when** `updateComment` rejects with HTTP status 404 (a maintainer deleted the
+comment mid-run),
+**then** the script calls `createComment` with the same body on the same issue,
+logs the recovery via `core.info`, and the step does not fail.
+
+### AC-2: Non-404 API failures surface a root-cause message
+
+**Given** any GitHub API call in the script (`listComments`, `updateComment`,
+`createComment`) rejects with a non-404 error (rate limit, permissions, network),
+**when** the outer catch handles it,
+**then** `core.setFailed` is called exactly once with a message prefixed
+`Failed to post walkthrough comment:` that includes the error message, and the
+fallback `createComment` is not attempted. The step's `continue-on-error: true`
+remains, so the job stays green while the step outcome is failure with the
+clear message. Only errors whose `status` is exactly 404 trigger the fallback;
+errors without a status (plain `Error`) never fall back.
+
+### AC-3: Fallback createComment failure is not swallowed
+
+**Given** the 404 fallback path runs,
+**when** the fallback `createComment` itself rejects,
+**then** that error reaches the outer catch and `core.setFailed` reports it
+(the script must not silently lose the comment on double failure).
+
+### AC-4: Guard clauses and happy paths are preserved
+
+**Given** the comment file is missing, the marker env is unset, or the context
+has no issue/PR number,
+**when** the script runs,
+**then** it returns early with a `core.info` note, makes no API calls, and does
+not fail (existing behavior, unchanged).
+
+**Given** a matched comment exists and `updateComment` succeeds, it is updated
+in place (`comment_id` + body, `Updated comment <id>.` log). **Given** no
+matched comment exists, `createComment` creates one (`Created comment <id>.`
+log). No duplicate-posting behavior changes.
+
+### AC-5: Step wiring is unchanged
+
+`if: always()` and `continue-on-error: true` on the `Post walkthrough comment`
+step remain exactly as before (already asserted by
+`pr-review-walkthrough-workflow.test.ts`).
+
+## Inputs and Boundary Cases
+
+Inputs: the inline github-script source in the `Post walkthrough comment` step,
+driven by `COMMENT_FILE` (real temp file in tests), `COMMENT_MARKER`, a fake
+`github` (paginate + rest.issues), fake `core`, and a `context` with/without
+`issue.number`.
+
+Boundary cases:
+
+- `updateComment` rejects 404 → fallback create, no failure (AC-1).
+- `updateComment` rejects 403 / network `Error` with no `status` property →
+  `core.setFailed`, no fallback create (AC-2 boundary: status must be exactly
+  404).
+- `listComments` (paginate) rejects → `core.setFailed` (AC-2).
+- `createComment` rejects on the no-match path → `core.setFailed` (AC-2).
+- `createComment` rejects on the 404-fallback path → `core.setFailed` (AC-3).
+- Comment file missing / marker unset / no issue number → early return, zero
+  API calls, no failure (AC-4).
+- Multiple comments where only one carries the marker → only that comment id is
+  updated (AC-4).
+
+## Behavioral Evidence
+
+| Criterion | Evidence |
+|---|---|
+| AC-1 | New test: execute the real script string with fake github whose updateComment rejects `{status: 404}`; assert createComment called with body, setFailed not called |
+| AC-2 | Tests: updateComment rejects `{status: 403}`; paginate rejects; createComment rejects — each asserts one `core.setFailed('Failed to post walkthrough comment: …')` and no fallback create; a status-less `Error` rejection also asserts no fallback |
+| AC-3 | Test: updateComment 404 then createComment rejects → setFailed called |
+| AC-4 | Tests: guard clauses make zero API calls and log skip; matched-comment update and no-match create happy paths; multi-comment marker matching |
+| AC-5 | Existing tests in `pr-review-walkthrough-workflow.test.ts` (continue-on-error, always()) stay green unchanged |
+
+Tests live in a new `scripts/tests/pr-review-walkthrough-comment-script.test.ts`
+(bun:test, TS) that extracts the script from the workflow YAML and executes it
+via `AsyncFunction` with injected `github`/`core`/`context`/`require` — the
+same compilation route `actions/github-script` itself uses, so the tests
+exercise the production script text, not a copy.
+
+## Out of Scope
+
+- Restoring `.github/actions/post-coverage-comment/` (deleted deliberately in
+  #3145; the coverage half of the issue is obsolete).
+- Moving the inline script into a separate `.ts` helper (issue says keep
+  changes limited to the comment-posting script).
+- Changes to any other workflow, step, `if:`, or `continue-on-error` wiring.
+- Retry/backoff logic beyond the single 404 fallback the issue requests.
+
+## Verification
+
+Full verification cycle per the issue-workflow skill (test, lint, typecheck,
+format, build, stepfun-37 smoke), plus `actionlint` on the modified workflow,
+then local OCR review (max 2 rounds), PR, CI watch, CodeRabbit triage.
+
+### Verification record (2026-08-23)
+
+- Targeted tests: 92 pass / 0 fail (14 in the new behavioral suite + 78
+  structural workflow tests).
+- Full `npm run test`: ~20 failures in packages/core + telemetry, all
+  reproduced identically on a clean `main` worktree at the same SHA CI runs
+  (e.g. `ripgrepPathResolver` `vi.fn()` mocks, scheduler hook timeouts), and
+  main's CI is green at that SHA — proven pre-existing/environmental, none
+  touch the changed files.
+- `npm run lint` / `npm run typecheck` / `npm run format` / `npm run build`:
+  exit 0. Smoke (`stepfun-37` haiku): exit 0. `actionlint` on
+  `pr-review.yml`: clean.
+
+### Review record (2 rounds, cap reached)
+
+Round 1 (deepthinker): production script passed all ACs. Three In-scope-Fix
+findings on the test file, all remediated: (1) `process.env`
+COMMENT_FILE/COMMENT_MARKER now captured before overwrite and restored in
+afterEach; (2) the `as` constructor assertion replaced with a runtime type
+predicate; (3) added the string-status `'404'` boundary test (verified by
+mutation: loosening `!==` to `!=` fails exactly that test).
+
+Round 2 (deepthinker): remediations confirmed; one In-scope-Fix — the
+constructor predicate accepted any function although arrow/async functions
+throw on `new`. Fixed: the predicate now also requires a non-null object
+`prototype` (arrow/async functions lack one). Two reviewer suggestions
+rejected with rationale: `error?.message` in the production catch (the
+accepted Octokit error shape always has `.message`; speculative), and typing
+the constructor's return as `Promise<unknown>` (the constructor returns a
+function object, not a promise).
+
+Local OCR count against the two-file diff: 2 (both within cap). Findings:
+the env-restore issue (fixed above) and the two rejected suggestions. No
+further local OCR rounds.

--- a/scripts/tests/pr-review-walkthrough-comment-script.test.ts
+++ b/scripts/tests/pr-review-walkthrough-comment-script.test.ts
@@ -212,8 +212,8 @@ async function runScript(
 describe('Post walkthrough comment github-script behavior', () => {
   const script = postStepScript();
   const requireFn = makeRequire();
-  let tempDir: string;
-  let commentFile: string;
+  let tempDir: string | undefined;
+  let commentFile: string | undefined;
   let previousCommentFile: string | undefined;
   let previousCommentMarker: string | undefined;
 
@@ -228,7 +228,9 @@ describe('Post walkthrough comment github-script behavior', () => {
   });
 
   afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true });
+    if (tempDir !== undefined) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
     if (previousCommentFile === undefined) {
       delete process.env.COMMENT_FILE;
     } else {
@@ -481,6 +483,9 @@ describe('Post walkthrough comment github-script behavior', () => {
   });
 
   it('skips with zero API calls when the comment file is missing', async () => {
+    if (tempDir === undefined) {
+      throw new Error('tempDir should be created in beforeEach');
+    }
     process.env.COMMENT_FILE = join(tempDir, 'missing.md');
     const { github, calls } = makeGithub({});
     const { core, info, failures } = makeCore();

--- a/scripts/tests/pr-review-walkthrough-comment-script.test.ts
+++ b/scripts/tests/pr-review-walkthrough-comment-script.test.ts
@@ -1,0 +1,560 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import * as fsModule from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  asVmFunction,
+  findStep,
+  parseWorkflowYaml,
+} from './typed-test-helpers.ts';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const WORKFLOW_PATH = '.github/workflows/pr-review.yml';
+const STEP_NAME = 'Post walkthrough comment';
+const MARKER = '<!-- llxprt-walkthrough -->';
+const ISSUE_NUMBER = 123;
+const OWNER = 'vybestack';
+const REPO = 'llxprt-code';
+const BODY = '# walkthrough\nprepared by the pipeline';
+
+const asyncFunctionConstructor: unknown = Object.getPrototypeOf(
+  async () => {},
+).constructor;
+
+function isAsyncFunctionConstructor(
+  value: unknown,
+): value is new (...args: string[]) => unknown {
+  if (typeof value !== 'function') return false;
+  const prototype: unknown = Reflect.get(value, 'prototype');
+  return prototype !== null && typeof prototype === 'object';
+}
+
+if (!isAsyncFunctionConstructor(asyncFunctionConstructor)) {
+  throw new Error('expected an async function constructor');
+}
+const AsyncFunction = asyncFunctionConstructor;
+
+interface CommentRecord {
+  readonly id: number;
+  readonly body: string;
+}
+
+interface GithubCallLog {
+  readonly listOptions: unknown[];
+  readonly updateCalls: unknown[];
+  readonly createCalls: unknown[];
+}
+
+interface GithubFake {
+  readonly paginate: (
+    fn: (options: unknown) => Promise<{ data: readonly CommentRecord[] }>,
+    options: unknown,
+  ) => Promise<readonly CommentRecord[]>;
+  readonly rest: {
+    readonly issues: {
+      readonly listComments: (
+        options: unknown,
+      ) => Promise<{ data: readonly CommentRecord[] }>;
+      readonly updateComment: (options: unknown) => Promise<unknown>;
+      readonly createComment: (
+        options: unknown,
+      ) => Promise<{ data: { id: number } }>;
+    };
+  };
+}
+
+interface GithubConfig {
+  readonly comments?: readonly CommentRecord[];
+  readonly paginateError?: unknown;
+  readonly update?: (options: unknown) => { data: { id: number } };
+  readonly create?: (options: unknown) => { data: { id: number } };
+}
+
+/**
+ * Build the faked github object granted to the script by actions/github-script.
+ * The script under test is the REAL production source; only the runtime boundary
+ * (github/core/context/require) is faked, exactly as github-script injects it.
+ */
+function makeGithub(config: GithubConfig = {}): {
+  readonly github: GithubFake;
+  readonly calls: GithubCallLog;
+} {
+  const calls: GithubCallLog = {
+    listOptions: [],
+    updateCalls: [],
+    createCalls: [],
+  };
+  const defaultUpdate = (): { data: { id: number } } => ({ data: { id: 1 } });
+  const defaultCreate = (): { data: { id: number } } => ({ data: { id: 2 } });
+  const github: GithubFake = {
+    paginate: async (
+      fn: (options: unknown) => Promise<{ data: readonly CommentRecord[] }>,
+      options: unknown,
+    ): Promise<readonly CommentRecord[]> => {
+      calls.listOptions.push(options);
+      return (await fn(options)).data;
+    },
+    rest: {
+      issues: {
+        listComments: async (
+          _options: unknown,
+        ): Promise<{ data: readonly CommentRecord[] }> => {
+          if (config.paginateError !== undefined) {
+            throw config.paginateError;
+          }
+          return { data: config.comments ?? [] };
+        },
+        updateComment: async (options: unknown): Promise<unknown> => {
+          calls.updateCalls.push(options);
+          return (config.update ?? defaultUpdate)(options);
+        },
+        createComment: async (
+          options: unknown,
+        ): Promise<{ data: { id: number } }> => {
+          calls.createCalls.push(options);
+          return (config.create ?? defaultCreate)(options);
+        },
+      },
+    },
+  };
+  return { github, calls };
+}
+
+interface CoreFake {
+  readonly info: (message: unknown) => void;
+  readonly setFailed: (message: unknown) => void;
+}
+
+function makeCore(): {
+  readonly core: CoreFake;
+  readonly info: string[];
+  readonly failures: string[];
+} {
+  const info: string[] = [];
+  const failures: string[] = [];
+  return {
+    core: {
+      info: (message: unknown) => {
+        info.push(String(message));
+      },
+      setFailed: (message: unknown) => {
+        failures.push(String(message));
+      },
+    },
+    info,
+    failures,
+  };
+}
+
+/**
+ * Build an Error carrying a GitHub API HTTP status, the shape octokit rejects
+ * with on non-2xx responses.
+ */
+function octokitError(status: number, message: string): Error {
+  const error = new Error(message);
+  return Object.assign(error, { status });
+}
+
+function reviewContext(issueNumber: number): {
+  readonly repo: { readonly owner: string; readonly repo: string };
+  readonly issue: { readonly number: number };
+} {
+  return {
+    repo: { owner: OWNER, repo: REPO },
+    issue: { number: issueNumber },
+  };
+}
+
+function makeRequire(): (name: string) => unknown {
+  return (name: string): unknown => {
+    if (name === 'fs') return fsModule;
+    throw new Error(`unexpected require: ${name}`);
+  };
+}
+
+/**
+ * Extract the REAL github-script source from the workflow (never a copy) and
+ * execute it the same way actions/github-script does: compile the source as an
+ * AsyncFunction and call it with github/context/core/require.
+ */
+function postStepScript(): string {
+  const source = readFileSync(join(ROOT, WORKFLOW_PATH), 'utf8');
+  const workflow = parseWorkflowYaml(source);
+  const reviewJob = workflow.jobs?.['review'];
+  const step = reviewJob ? findStep(reviewJob, STEP_NAME) : undefined;
+  const script = step?.with?.['script'];
+  if (typeof script !== 'string' || script.trim().length === 0) {
+    throw new Error(`${STEP_NAME} should have a non-empty github-script body`);
+  }
+  return script;
+}
+
+async function runScript(
+  script: string,
+  github: unknown,
+  context: unknown,
+  core: unknown,
+  requireFn: (name: string) => unknown,
+): Promise<void> {
+  const runner = asVmFunction(
+    new AsyncFunction('github', 'context', 'core', 'require', script),
+  );
+  await runner(github, context, core, requireFn);
+}
+
+describe('Post walkthrough comment github-script behavior', () => {
+  const script = postStepScript();
+  const requireFn = makeRequire();
+  let tempDir: string;
+  let commentFile: string;
+  let previousCommentFile: string | undefined;
+  let previousCommentMarker: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'llxprt-walkthrough-comment-'));
+    commentFile = join(tempDir, 'comment.md');
+    writeFileSync(commentFile, BODY, 'utf8');
+    previousCommentFile = process.env.COMMENT_FILE;
+    previousCommentMarker = process.env.COMMENT_MARKER;
+    process.env.COMMENT_FILE = commentFile;
+    process.env.COMMENT_MARKER = MARKER;
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    if (previousCommentFile === undefined) {
+      delete process.env.COMMENT_FILE;
+    } else {
+      process.env.COMMENT_FILE = previousCommentFile;
+    }
+    if (previousCommentMarker === undefined) {
+      delete process.env.COMMENT_MARKER;
+    } else {
+      process.env.COMMENT_MARKER = previousCommentMarker;
+    }
+  });
+
+  it('compiles as an AsyncFunction (mirrors actions/github-script)', () => {
+    expect(
+      () => new AsyncFunction('github', 'context', 'core', 'require', script),
+    ).not.toThrow();
+  });
+
+  it('updates the matched comment in place when updateComment succeeds', async () => {
+    const comments: readonly CommentRecord[] = [
+      { id: 11, body: 'unrelated comment' },
+      { id: 7, body: `${MARKER}\ncurrent walkthrough` },
+    ];
+    const { github, calls } = makeGithub({ comments });
+    const { core, info, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(calls.updateCalls).toHaveLength(1);
+    expect(calls.updateCalls[0]).toMatchObject({
+      owner: OWNER,
+      repo: REPO,
+      comment_id: 7,
+      body: BODY,
+    });
+    expect(calls.createCalls).toHaveLength(0);
+    expect(failures).toHaveLength(0);
+    expect(info.some((line) => line.includes('Updated comment'))).toBe(true);
+  });
+
+  it('falls back to createComment when updateComment rejects with 404', async () => {
+    const comments: readonly CommentRecord[] = [
+      { id: 7, body: `${MARKER}\ncurrent walkthrough` },
+    ];
+    const { github, calls } = makeGithub({
+      comments,
+      update: () => {
+        throw octokitError(404, 'Not Found');
+      },
+    });
+    const { core, info, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(calls.createCalls).toHaveLength(1);
+    expect(calls.createCalls[0]).toMatchObject({
+      owner: OWNER,
+      repo: REPO,
+      issue_number: ISSUE_NUMBER,
+      body: BODY,
+    });
+    expect(failures).toHaveLength(0);
+    expect(info.some((line) => line.includes('404'))).toBe(true);
+  });
+
+  it('does not fall back when updateComment rejects with a string status "404"', async () => {
+    const comments: readonly CommentRecord[] = [
+      { id: 7, body: `${MARKER}\ncurrent walkthrough` },
+    ];
+    const { github, calls } = makeGithub({
+      comments,
+      update: () => {
+        throw Object.assign(new Error('Not Found'), { status: '404' });
+      },
+    });
+    const { core, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatch(/^Failed to post walkthrough comment:/);
+    expect(calls.createCalls).toHaveLength(0);
+    expect(calls.updateCalls).toHaveLength(1);
+  });
+
+  it('surfaces a non-404 updateComment failure and never falls back', async () => {
+    const comments: readonly CommentRecord[] = [
+      { id: 7, body: `${MARKER}\ncurrent walkthrough` },
+    ];
+    const { github, calls } = makeGithub({
+      comments,
+      update: () => {
+        throw octokitError(403, 'rate limit exceeded');
+      },
+    });
+    const { core, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatch(/^Failed to post walkthrough comment:/);
+    expect(failures[0]).toContain('rate limit exceeded');
+    expect(calls.createCalls).toHaveLength(0);
+  });
+
+  it('does not fall back when updateComment fails without a status', async () => {
+    const comments: readonly CommentRecord[] = [
+      { id: 7, body: `${MARKER}\ncurrent walkthrough` },
+    ];
+    const { github, calls } = makeGithub({
+      comments,
+      update: () => {
+        throw new Error('network down');
+      },
+    });
+    const { core, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatch(/^Failed to post walkthrough comment:/);
+    expect(calls.createCalls).toHaveLength(0);
+  });
+
+  it('creates a new comment when no comment carries the marker', async () => {
+    const comments: readonly CommentRecord[] = [
+      { id: 11, body: 'unrelated comment' },
+    ];
+    const { github, calls } = makeGithub({ comments });
+    const { core, info, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(calls.createCalls).toHaveLength(1);
+    expect(calls.createCalls[0]).toMatchObject({
+      owner: OWNER,
+      repo: REPO,
+      issue_number: ISSUE_NUMBER,
+      body: BODY,
+    });
+    expect(calls.updateCalls).toHaveLength(0);
+    expect(failures).toHaveLength(0);
+    expect(info.some((line) => line.includes('Created comment'))).toBe(true);
+  });
+
+  it('surfaces a failing listComments via setFailed with the prefix', async () => {
+    const { github } = makeGithub({
+      paginateError: octokitError(500, 'comments unavailable'),
+    });
+    const { core, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatch(/^Failed to post walkthrough comment:/);
+    expect(failures[0]).toContain('comments unavailable');
+  });
+
+  it('surfaces a failing createComment on the no-match path via setFailed', async () => {
+    const { github } = makeGithub({
+      comments: [],
+      create: () => {
+        throw octokitError(422, 'invalid payload');
+      },
+    });
+    const { core, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatch(/^Failed to post walkthrough comment:/);
+    expect(failures[0]).toContain('invalid payload');
+  });
+
+  it('surfaces a failing fallback createComment after a 404 updateComment', async () => {
+    const comments: readonly CommentRecord[] = [
+      { id: 7, body: `${MARKER}\ncurrent walkthrough` },
+    ];
+    const { github, calls } = makeGithub({
+      comments,
+      update: () => {
+        throw octokitError(404, 'Not Found');
+      },
+      create: () => {
+        throw octokitError(500, 'fallback failed');
+      },
+    });
+    const { core, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(calls.createCalls).toHaveLength(1);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatch(/^Failed to post walkthrough comment:/);
+    expect(failures[0]).toContain('fallback failed');
+  });
+
+  it('skips with zero API calls when the comment file is missing', async () => {
+    process.env.COMMENT_FILE = join(tempDir, 'missing.md');
+    const { github, calls } = makeGithub({});
+    const { core, info, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(calls.listOptions).toHaveLength(0);
+    expect(calls.updateCalls).toHaveLength(0);
+    expect(calls.createCalls).toHaveLength(0);
+    expect(failures).toHaveLength(0);
+    expect(info.some((line) => line.includes('not found'))).toBe(true);
+  });
+
+  it('skips with zero API calls when the comment marker is unset', async () => {
+    delete process.env.COMMENT_MARKER;
+    const { github, calls } = makeGithub({});
+    const { core, info, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(calls.listOptions).toHaveLength(0);
+    expect(calls.updateCalls).toHaveLength(0);
+    expect(calls.createCalls).toHaveLength(0);
+    expect(failures).toHaveLength(0);
+    expect(info.some((line) => line.includes('No comment marker set'))).toBe(
+      true,
+    );
+  });
+
+  it('skips with zero API calls when context has no issue number', async () => {
+    const { github, calls } = makeGithub({});
+    const { core, info, failures } = makeCore();
+
+    await runScript(script, github, reviewContext(0), core, requireFn);
+
+    expect(calls.listOptions).toHaveLength(0);
+    expect(calls.updateCalls).toHaveLength(0);
+    expect(calls.createCalls).toHaveLength(0);
+    expect(failures).toHaveLength(0);
+    expect(info.some((line) => line.includes('No issue/PR number'))).toBe(true);
+  });
+
+  it('updates only the comment that carries the marker among several', async () => {
+    const comments: readonly CommentRecord[] = [
+      { id: 11, body: 'unrelated comment' },
+      { id: 22, body: `${MARKER}\ncurrent walkthrough` },
+      { id: 33, body: `${MARKER}\nolder walkthrough` },
+    ];
+    const { github, calls } = makeGithub({ comments });
+    const { core, failures } = makeCore();
+
+    await runScript(
+      script,
+      github,
+      reviewContext(ISSUE_NUMBER),
+      core,
+      requireFn,
+    );
+
+    expect(calls.updateCalls).toHaveLength(1);
+    expect(calls.updateCalls[0]).toMatchObject({ comment_id: 22 });
+    expect(calls.createCalls).toHaveLength(0);
+    expect(failures).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## TLDR

Closes #2900. The `Post walkthrough comment` github-script step in `pr-review.yml` (from the #2648 node24 migration, PR #2893) now recovers from a mid-run comment deletion and surfaces API failures with a root-cause message:

- **404 fallback (ocr #7):** if `updateComment` rejects with numeric status 404 (the matched comment was deleted between `listComments` and `updateComment`), the script recreates the comment via `createComment` with the same body and logs the recovery. A recoverable deletion no longer fails the step.
- **Failure diagnostics (ocr #8):** all API calls are wrapped in an outer try/catch calling `core.setFailed('Failed to post walkthrough comment: …')`, matching the convention in `issue-planner.yml` and `ocr-infrastructure-notifier.yml`. With the step's existing `continue-on-error: true`, the job stays green while the step outcome carries the clear message instead of a raw stack trace.

Guard clauses (missing comment file / unset marker / no issue number), `if: always()`, `continue-on-error: true`, and both happy paths are unchanged.

**Scope note:** the issue also names `.github/actions/post-coverage-comment/action.yml`, which no longer exists — PR #3145 (fixing #2970) deleted the entire coverage plumbing as dead code (no test script produced coverage artifacts). That half of the issue is obsolete; nothing references the composite path on main (verified via `git grep` on `main`). Only the walkthrough step remains affected.

## Dive Deeper

- Only errors whose `status` is strictly `=== 404` fall back. A 403, a network `Error` without a status, or even a string `'404'` status re-throws to the outer catch — verified by mutation testing (loosening `!==` to `!=` fails exactly the string-status boundary test).
- A failing fallback `createComment` propagates to the outer catch (double failure is reported, not swallowed).
- New test file `scripts/tests/pr-review-walkthrough-comment-script.test.ts` (14 tests) extracts the REAL script string from the workflow YAML, compiles it with `AsyncFunction` (the same route `actions/github-script` itself uses; precedent: `ocr-review-github-script-syntax.bun.test.ts`), and executes it against a fake `github`/`core`/`context` plus a real temp `COMMENT_FILE`. Cases: 404→recreate, 403→setFailed, status-less Error→setFailed, string `'404'`→setFailed (no fallback), paginate failure, createComment failure on both paths, all three guard clauses (zero API calls), happy-path update/create, multi-comment marker matching, compile check. Run against the old script from `main`, the seven hardening/error tests fail — the suite detects regressions.
- Two deepthinker review rounds (cap) + two local OCR passes on the diff. Round-1 findings (test env restore, a banned `as` assertion, missing string-404 case) and the round-2 finding (unsound constructor predicate, now requiring an object `prototype`) are all fixed; two OCR suggestions were rejected with rationale recorded in the plan doc.

## Reviewer Test Plan

1. `bun test scripts/tests/pr-review-walkthrough-comment-script.test.ts scripts/tests/pr-review-walkthrough-workflow.test.ts` → 92 pass / 0 fail.
2. `actionlint .github/workflows/pr-review.yml` → clean.
3. Read the diff hunk in `.github/workflows/pr-review.yml` — the only production change is the inline script body.
4. Optional adversarial check: replace `error.status !== 404` with `!= 404` in the YAML and re-run the suite; exactly one test (string-status boundary) should fail.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | -   | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

macOS (🍏): full verification cycle — targeted tests 92/92, `npm run lint`/`typecheck`/`format`/`build` exit 0, `stepfun-37` smoke exit 0. Full `npm run test` local run had ~20 failures in packages/core + telemetry; each reproduces identically on a clean `main` worktree at the same SHA whose GitHub CI is green (e.g. `ripgrepPathResolver` `vi.fn()` mocks, scheduler hook timeouts) — pre-existing/environmental, unrelated to this change.

## Linked issues / bugs

Fixes #2900
Deferred from PR #2893 (issue #2648); the coverage-comment half of #2900 is obsolete since #3145.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved walkthrough comment handling when updating existing comments fails.
  - Automatically creates a replacement comment when the original is no longer found.
  - Provides clearer diagnostics and safely stops on unexpected errors.
  - Preserves skip behavior when required configuration is unavailable.

- **Tests**
  - Added comprehensive coverage for comment creation, updates, fallback handling, configuration checks, and API failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->