### PR TITLE
Give the session lock transition guard its own identity (Fixes #3277)

### DIFF
--- a/packages/core/src/recording/SessionLockManager.internals.ts
+++ b/packages/core/src/recording/SessionLockManager.internals.ts
@@ -591,12 +591,19 @@ async function retireStaleLock(
     // Not the lock we judged — restore it instead of destroying it.
     try {
       await fs.link(capturePath, lockPath);
-    } catch {
-      // Another lock already occupies the path, so it cannot be put back.
-      // Leave the capture parked rather than deleting what may be the only
-      // remaining copy of a live lock; {@link cleanupStaleLockTemp} reclaims
-      // it once its owner is gone.
-      return false;
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        // Restoration failed for some reason other than the path being taken,
+        // so the capture may still be the only copy of a live lock.  Leave it
+        // parked; {@link cleanupStaleLockTemp} reclaims it once its owner is
+        // gone.
+        return false;
+      }
+      // Another lock already occupies the path.  The captured one is therefore
+      // superseded and unreachable — no code path ever reads a capture back,
+      // and its owner's `ownsLock()` already reports false — so discarding it
+      // loses nothing, while parking it would leak a file for the lifetime of
+      // that owner's process.
     }
     await safeUnlink(capturePath);
     return false;
@@ -987,12 +994,18 @@ async function retireGuardIf(
     // it back rather than displacing a claimant we never inspected.
     try {
       await fs.link(capturePath, guardPath);
-    } catch {
-      // Another guard already occupies the path.  Leave the capture parked
-      // rather than deleting what may be the only remaining copy of a live
-      // claim; {@link cleanupStaleLockTemp} reclaims it once its claimant is
-      // gone.
-      return false;
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        // Restoration failed for some reason other than the path being taken,
+        // so the capture may still be the only copy of a live claim.  Leave it
+        // parked; {@link cleanupStaleLockTemp} reclaims it once its claimant is
+        // gone.
+        return false;
+      }
+      // Another guard already occupies the path, so the captured claim is
+      // superseded: its holder can no longer pass verification and will abort
+      // without mutating.  Discarding it loses nothing, while parking it would
+      // leak a file for the lifetime of that claimant's process.
     }
     await safeUnlink(capturePath);
     return false;

--- a/packages/core/src/recording/SessionLockManager.internals.ts
+++ b/packages/core/src/recording/SessionLockManager.internals.ts
@@ -37,19 +37,41 @@
  * - Stale takeover re-reads the lock before unlinking to avoid removing a
  *   replacement live lock; the final create uses atomic exclusive creation.
  * - Release unlinks only when the on-disk owner token still matches.
- * - A per-session filesystem transition guard serializes ALL pathname
- *   mutations — acquire, stale takeover, removeStaleLock, orphan cleanup,
- *   and release — so a stale checker can never unlink a replacement live
- *   lock.  The guard is an **atomic hard-link claim** tied to the current
- *   lock inode: `link(lockPath, guardPath)` succeeds for exactly one
- *   contender (EEXIST means another owns it).  A crashed claim is safe to
- *   remove because unlinking a hard link only decrements a link count and
- *   cannot remove/replace the live lock.  Every mutator verifies that the
- *   guard and lock path still share the same inode before touching
- *   lockPath.  Guard crash recovery preserves the live-PID/EPERM and
- *   48-hour PID-reuse semantics.
+ * - A per-session filesystem transition guard serializes the destructive
+ *   pathname mutations — stale takeover, removeStaleLock, orphan cleanup,
+ *   and release — so a stale checker does not unlink a replacement live
+ *   lock.  The guard is an **identity-bearing claim file** at
+ *   `<lockPath>.tguard` whose payload records the claimant's pid, a
+ *   timestamp, a random claimToken, and the dev/ino of the lock observed
+ *   at claim time.  It is installed exclusively via temp-file + hard-link
+ *   (EEXIST means another process holds it), reclaimed only when its own
+ *   payload indicates abandonment, and a reclaimer never displaces a live
+ *   claimant: abandonment is judged against a hard-link probe, so a guard
+ *   that is still held is never renamed or unlinked.  Every mutator
+ *   verifies via {@link verifyTransitionClaim} that the guard still
+ *   carries its own claimToken and the lock still has the recorded dev/ino
+ *   before touching lockPath.  Release is ownership-checked.  Guard crash
+ *   recovery preserves the live-PID/EPERM and 48-hour PID-reuse
+ *   semantics.
+ * - Retiring a stale lock is an atomic `rename` out of the well-known path
+ *   ({@link retireStaleLock}), not a bare `unlink`.  Exactly one contender
+ *   can win that rename, so contention over a stale lock resolves to a
+ *   single owner independently of the guard, and a contender that captures
+ *   a replacement live lock restores it instead of destroying it.
  * - Destructive janitor ownership is verified through the token-bound
  *   {@link LockHandle.ownsLock} immediately before mutation.
+ *
+ * What this protocol does not promise.  POSIX offers no compare-and-swap
+ * unlink or rename, so between any check and any subsequent pathname
+ * mutation there is a window.  Ownership is therefore carried by the
+ * atomic primitives themselves — exclusive creation for publication and
+ * `rename` for retirement — and the guard reduces, rather than eliminates,
+ * the interleavings that reach those primitives.  Fresh publication in
+ * {@link acquire} deliberately does not take the guard: it competes only
+ * through exclusive creation, so it can lose but cannot destroy.  The
+ * protocol also assumes a local filesystem; `link`, `rename` and `O_EXCL`
+ * are not dependable over NFS or SMB, and `process.kill(pid, 0)` is
+ * host-local while a lock carries no hostname.
  */
 
 import * as fs from 'node:fs/promises';
@@ -139,6 +161,44 @@ export async function acquire(
 }
 
 /**
+ * Build a fresh single-use artifact path next to `lockPath`.
+ *
+ * The name matches the `<safeSessionId>.lock.<uuid>.locktmp` grammar, so the
+ * existing {@link cleanupStaleLockTemp} sweep reclaims anything a crash leaves
+ * behind and no additional cleanup path is needed.
+ */
+function makeLockTempPath(lockPath: string): string {
+  return lockPath + '.' + crypto.randomUUID() + LOCK_TEMP_SUFFIX;
+}
+
+/** dev/ino identity of a filesystem entry, as exact decimal strings. */
+interface FileIdentity {
+  readonly dev: string;
+  readonly ino: string;
+}
+
+/**
+ * Read the dev/ino identity of `filePath`, or `null` when it does not exist.
+ *
+ * `bigint: true` is required rather than cosmetic: Windows file IDs are 64-bit
+ * and inode numbers on some filesystems exceed `Number.MAX_SAFE_INTEGER`, so
+ * the default number-valued `stat` would round two distinct files to the same
+ * identity and let a replaced file pass verification.
+ *
+ * Errors other than ENOENT propagate.  A transient stat failure must not be
+ * mistaken for "this path does not exist".
+ */
+async function statIdentity(filePath: string): Promise<FileIdentity | null> {
+  try {
+    const s = await fs.stat(filePath, { bigint: true });
+    return { dev: s.dev.toString(), ino: s.ino.toString() };
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+/**
  * Write the complete lock payload to a temp file (O_EXCL) and sync it.
  * Returns true on success, false for a retryable collision (EEXIST) or a
  * missing parent directory (ENOENT).  All other errors (ENOSPC, EACCES,
@@ -200,7 +260,7 @@ async function tryCreateLock(
   lockPath: string,
   lockContent: string,
 ): Promise<boolean> {
-  const tempPath = lockPath + '.' + crypto.randomUUID() + '.locktmp';
+  const tempPath = makeLockTempPath(lockPath);
 
   let written = await writeTempLockFile(tempPath, lockContent);
   if (!written) {
@@ -230,7 +290,8 @@ async function tryStaleTakeover(
   lockPath: string,
   lockContent: string,
 ): Promise<boolean> {
-  if (!(await acquireTransitionGuard(lockPath))) {
+  const claim = await acquireTransitionGuard(lockPath);
+  if (!claim) {
     return false; // Another process is transitioning — busy.
   }
   try {
@@ -261,26 +322,24 @@ async function tryStaleTakeover(
       return await tryCreateLock(lockPath, lockContent);
     }
 
-    // Verify the transition claim still identifies the same inode as
-    // the lock before unlinking.  If the lock was replaced by another
-    // process, the inodes will differ and we must skip.
-    if (!(await verifyTransitionClaim(lockPath))) {
+    // Verify the transition claim still identifies the same lock inode as
+    // was observed at claim time and still carries this claim's token.  If the
+    // lock was replaced by another process, the inodes will differ and we must skip.
+    if (!(await verifyTransitionClaim(lockPath, claim))) {
       return false;
     }
 
-    // Unlink the stale lock.
-    try {
-      await fs.unlink(lockPath);
-    } catch (error: unknown) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT') return false;
+    // Retire the stale lock.  Exactly one process can win the rename, so the
+    // takeover resolves to a single owner even if the guard were bypassed.
+    if (!(await retireStaleLock(lockPath, originalContent))) {
+      return false;
     }
 
     // Atomically create our lock.  If another process won the race between
-    // our unlink and this create, the link fails with EEXIST and we lose.
+    // the retirement and this create, the link fails with EEXIST and we lose.
     return await tryCreateLock(lockPath, lockContent);
   } finally {
-    await releaseTransitionGuard(lockPath);
+    await releaseTransitionGuard(claim);
   }
 }
 
@@ -433,7 +492,8 @@ async function tryRemoveStaleLock(
   if (!isValidSafeSessionId(lockSessionId)) return false;
 
   // Acquire the transition guard to serialize this mutation.
-  if (!(await acquireTransitionGuard(lockPath))) {
+  const claim = await acquireTransitionGuard(lockPath);
+  if (!claim) {
     return false; // Another process is transitioning — busy.
   }
   try {
@@ -480,21 +540,70 @@ async function tryRemoveStaleLock(
       return false; // Vanished — benign.
     }
 
-    // Verify the transition claim still identifies the same inode as
-    // the lock before unlinking.
-    if (!(await verifyTransitionClaim(lockPath))) {
+    // Verify the transition claim still identifies the same lock inode as
+    // was observed at claim time before unlinking.
+    if (!(await verifyTransitionClaim(lockPath, claim))) {
       return false;
     }
 
-    try {
-      await fs.unlink(lockPath);
-      return true;
-    } catch {
-      return false; // Best-effort.
-    }
+    return await retireStaleLock(lockPath, originalContent);
   } finally {
-    await releaseTransitionGuard(lockPath);
+    await releaseTransitionGuard(claim);
   }
+}
+
+/**
+ * Retire a lock whose content has been judged stale, by atomically renaming it
+ * out of the well-known path.
+ *
+ * `rename` is the only pathname primitive POSIX offers that removes a name and
+ * tells exactly one caller that it did so.  That is what makes contention over
+ * a stale lock resolve to a single owner: every other contender's rename fails
+ * with ENOENT.  A bare `unlink` cannot distinguish "I removed the stale lock"
+ * from "I removed the replacement that somebody else just published".
+ *
+ * A caller that captures a lock whose content is not the payload it judged
+ * stale has captured a replacement live lock.  It puts that lock back and
+ * reports failure rather than destroying it, preserving the invariant that no
+ * process unlinks another process's lock.
+ *
+ * Returns true when this call retired the stale lock.
+ */
+async function retireStaleLock(
+  lockPath: string,
+  expectedContent: string,
+): Promise<boolean> {
+  const capturePath = makeLockTempPath(lockPath);
+  try {
+    await fs.rename(lockPath, capturePath);
+  } catch {
+    return false; // Lost the race, or the lock is already gone.
+  }
+
+  let capturedContent: string | null = null;
+  try {
+    capturedContent = await fs.readFile(capturePath, 'utf-8');
+  } catch {
+    // Unreadable: we cannot prove this is the lock we judged stale.
+  }
+
+  if (capturedContent !== expectedContent) {
+    // Not the lock we judged — restore it instead of destroying it.
+    try {
+      await fs.link(capturePath, lockPath);
+    } catch {
+      // Another lock already occupies the path, so it cannot be put back.
+      // Leave the capture parked rather than deleting what may be the only
+      // remaining copy of a live lock; {@link cleanupStaleLockTemp} reclaims
+      // it once its owner is gone.
+      return false;
+    }
+    await safeUnlink(capturePath);
+    return false;
+  }
+
+  await safeUnlink(capturePath);
+  return true;
 }
 
 /** @pseudocode concurrency-lifecycle.md lines 290-346 */
@@ -592,7 +701,8 @@ async function releaseIfOwned(
   lockPath: string,
   ownerToken: string,
 ): Promise<void> {
-  if (!(await acquireTransitionGuard(lockPath))) {
+  const claim = await acquireTransitionGuard(lockPath);
+  if (!claim) {
     return; // Can't acquire guard — best-effort, leave lock in place.
   }
   try {
@@ -602,16 +712,16 @@ async function releaseIfOwned(
       // We don't own this lock anymore — don't remove it.
       return;
     }
-    // Verify the transition claim still identifies the same inode as
-    // the lock before unlinking.
-    if (!(await verifyTransitionClaim(lockPath))) {
+    // Verify the transition claim still identifies the same lock inode as
+    // was observed at claim time before unlinking.
+    if (!(await verifyTransitionClaim(lockPath, claim))) {
       return;
     }
     await fs.unlink(lockPath);
   } catch {
     // Best-effort release.
   } finally {
-    await releaseTransitionGuard(lockPath);
+    await releaseTransitionGuard(claim);
   }
 }
 
@@ -619,103 +729,338 @@ async function releaseIfOwned(
 // Per-session transition guard (root safety fix 1)
 // -----------------------------------------------------------------------
 
+/**
+ * Identity of a transition claim held by this process.
+ *
+ * The guard is a distinct file (not a hard link of the lock inode) whose
+ * payload records who claimed it, so reclaimability and verification always read
+ * the **claimant's** own state rather than the victim lock's.
+ */
+interface TransitionClaim {
+  /** Path of the guard file this claim installed. */
+  readonly guardPath: string;
+  /** Random token unique to this claim; a thief relinking the lock inode
+   *  cannot forge it. */
+  readonly claimToken: string;
+  /** dev/ino of the lock as observed when this claim was installed, or null
+   *  when no lock existed at claim time. */
+  readonly lockIdentity: FileIdentity | null;
+}
+
+/**
+ * Outcome of attempting to install a transition claim.
+ *
+ * `contended` and `failed` are kept apart because only contention implies an
+ * incumbent claim whose liveness is worth consulting; a genuine I/O failure
+ * leaves nothing to reclaim.
+ */
+type GuardInstallResult =
+  | { readonly outcome: 'installed'; readonly claim: TransitionClaim }
+  | { readonly outcome: 'contended' }
+  | { readonly outcome: 'failed' };
+
 /** Return the guard path for a given lock path. */
 function getGuardPath(lockPath: string): string {
   return lockPath + TRANSITION_GUARD_SUFFIX;
 }
 
 /**
- * Acquire the per-session transition claim by atomically hard-linking
- * the **current lock inode** to the guard path.
+ * Write the guard payload to a temp file (O_EXCL), sync it, then
+ * exclusively hard-link the temp to the guard path.  The temp name reuses the
+ * existing `<safeSessionId>.lock.<uuid>.locktmp` grammar so the existing
+ * `cleanupStaleLockTemp` orphan sweep already covers guard temps.
  *
- * Unlike a separate-owner guard (which has its own PID and suffers a
- * check-stale-then-unlink race), the hard-link claim is tied to the lock
- * inode itself:
- *
- * - `link(lockPath, guardPath)` succeeds for exactly one contender; others
- *   get EEXIST and fail/skip.
- * - ENOENT means the lock does not exist — fresh creates use exclusive
- *   link/create so no claim is needed.
- * - A crashed claim is a hard link, so removing it only decrements a link
- *   count and **cannot remove or replace the live lock** at lockPath.
- * - If claim recovery races, every mutator must re-establish and validate
- *   its own claim via {@link verifyTransitionClaim} before touching
- *   lockPath.
- *
- * Returns true when the claim is held (or no lock exists to guard).
+ * Reports `installed` with the claim, `contended` when another process already
+ * holds the guard, or `failed` for a genuine I/O error.  None of these throw:
+ * guard acquisition has never thrown, and `release()` and the janitor sweep
+ * are best-effort callers whose error surface must stay unchanged.
  */
-async function acquireTransitionGuard(lockPath: string): Promise<boolean> {
+async function installTransitionGuard(
+  lockPath: string,
+): Promise<GuardInstallResult> {
   const guardPath = getGuardPath(lockPath);
 
-  // Atomically claim the lock inode.
+  // Capture the lock's dev/ino before writing the payload so verification can
+  // detect the lock being replaced between claim time and mutation.  A missing
+  // lock is a null identity — the guard is still installed, which is strictly
+  // stronger serialization and removes the "release a guard we never created"
+  // bug.  A stat failure that is NOT "absent" must report busy instead: a null
+  // identity fails verification, which would make `releaseIfOwned` silently
+  // leave a lock this process still owns.
+  let lockIdentity: FileIdentity | null;
   try {
-    await fs.link(lockPath, guardPath);
-    return true; // Claimed the lock inode.
-  } catch (error: unknown) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT') {
-      // Lock does not exist — no inode to claim.
-      return true;
-    }
-    if (code !== 'EEXIST') return false;
+    lockIdentity = await statIdentity(lockPath);
+  } catch {
+    return { outcome: 'failed' };
   }
 
-  // Another transition owns the claim. Attempt conservative recovery.
+  const claimToken = crypto.randomUUID();
+  const payload = JSON.stringify({
+    pid: process.pid,
+    timestamp: new Date().toISOString(),
+    claimToken,
+    lockDev: lockIdentity?.dev ?? null,
+    lockIno: lockIdentity?.ino ?? null,
+  });
+
+  const tempPath = makeLockTempPath(lockPath);
+  let fd: fs.FileHandle | undefined;
+  try {
+    fd = await fs.open(tempPath, 'wx');
+    await fd.writeFile(payload, 'utf-8');
+    await fd.sync();
+    await fd.close();
+    fd = undefined;
+    await fs.link(tempPath, guardPath);
+  } catch (error: unknown) {
+    // EEXIST is contention: another process holds the guard, and recovery
+    // should consult that claimant's liveness.  Anything else (ENOSPC, EACCES,
+    // EROFS, EDQUOT, EMFILE, ...) is a genuine I/O failure, where there is no
+    // incumbent claim to reason about.  Neither throws: guard acquisition has
+    // never thrown, and `release()` and the janitor sweep are best-effort and
+    // must not start surfacing I/O errors.
+    const code = (error as NodeJS.ErrnoException).code;
+    return { outcome: code === 'EEXIST' ? 'contended' : 'failed' };
+  } finally {
+    await fd?.close().catch(() => {});
+    await safeUnlink(tempPath);
+  }
+  return {
+    outcome: 'installed',
+    claim: { guardPath, claimToken, lockIdentity },
+  };
+}
+
+/**
+ * Acquire the per-session transition claim by installing a distinct guard file
+ * whose payload identifies this claim (pid, timestamp, claimToken, and the
+ * dev/ino of the lock observed at claim time).
+ *
+ * - A guard is installed exclusively via temp-file + hard-link; EEXIST means
+ *   another process holds it, and recovery consults the incumbent claim's OWN
+ *   liveness before touching it.
+ * - A guard is installed even when the lock does not exist — strictly stronger
+ *   serialization — and is released only by the claim that installed it.
+ * - Any failure to install yields `null` (busy) instead of throwing, so the
+ *   error surface of `release()` and the janitor sweep is unchanged.
+ *
+ * Returns the installed claim, or `null` meaning "busy — caller must not mutate".
+ */
+async function acquireTransitionGuard(
+  lockPath: string,
+): Promise<TransitionClaim | null> {
+  const installed = await installTransitionGuard(lockPath);
+  if (installed.outcome === 'installed') return installed.claim;
+  // A genuine I/O failure leaves no incumbent claim to reason about, so there
+  // is nothing to reclaim; report busy.
+  if (installed.outcome === 'failed') return null;
+  // Another process holds the claim — attempt conservative recovery.
   return tryReclaimGuard(lockPath);
+}
+
+/**
+ * Decide whether the guard at `guardPath` has been abandoned by its claimant.
+ *
+ * Reclaim depends on the **claimant's** liveness, never on the staleness of
+ * the lock being taken over.  A guard is only attributable to a claimant when
+ * its payload carries a `claimToken`, which is the marker this implementation
+ * writes.  Anything else — corrupt content, or a guard written by an older
+ * revision that hard-linked the lock inode and therefore describes the victim
+ * lock rather than the claimant — has no discoverable claimant, so it is
+ * treated as busy and reclaimable only once it passes the age bound.  Without
+ * that gate a legacy guard over a stale lock reads as abandoned to every
+ * contender at once, which is the defect in issue #3277.
+ *
+ * Orphaned legacy guards still converge: the janitor's {@link cleanupStaleGuard}
+ * sweep removes safe-grammar guards whose payload PID is dead.
+ */
+async function isGuardAbandoned(guardPath: string): Promise<boolean> {
+  let claimToken: unknown;
+  try {
+    const parsed = JSON.parse(await fs.readFile(guardPath, 'utf-8')) as Record<
+      string,
+      unknown
+    >;
+    claimToken = parsed.claimToken;
+  } catch {
+    // Unreadable or corrupt — no claimant identity.
+    return isOlderThanBound(guardPath);
+  }
+  if (typeof claimToken !== 'string' || claimToken.length === 0) {
+    return isOlderThanBound(guardPath);
+  }
+  // Our own format: the payload's pid/timestamp describe the claimant, so the
+  // existing PID-reuse staleness rules answer "has the claimant gone away?".
+  return checkStaleWithPidReuse(guardPath);
 }
 
 /**
  * Conservatively reclaim a stale transition claim.
  *
- * The guard is a hard link to a lock inode, so its content IS the lock
- * content.  When the lock content indicates staleness (dead PID or past
- * the 48-hour PID-reuse bound), the claim owner has crashed and the guard
- * is safe to remove — it only decrements a link count.
+ * The guard now carries the claimant's own payload, so its staleness is the
+ * claimant's liveness (dead PID, or an alive PID past the 48-hour PID-reuse
+ * bound, or a guard with no discoverable claimant that is older than that
+ * bound) — never the victim lock's staleness.
+ *
+ * Retirement is non-displacing (see {@link retireGuardIf}) and installation
+ * then goes through the exclusive {@link installTransitionGuard} path, so we
+ * may still lose to a racer and report `null`.
  */
-async function tryReclaimGuard(lockPath: string): Promise<boolean> {
+async function tryReclaimGuard(
+  lockPath: string,
+): Promise<TransitionClaim | null> {
   const guardPath = getGuardPath(lockPath);
-
-  if (!(await checkStaleWithPidReuse(guardPath))) {
-    return false; // Guard content indicates a live transition owner.
+  if (!(await retireGuardIf(lockPath, guardPath, isGuardAbandoned))) {
+    return null; // Live or unattributable claimant -> busy.
   }
+  const installed = await installTransitionGuard(lockPath);
+  return installed.outcome === 'installed' ? installed.claim : null;
+}
 
+/**
+ * Retire the guard at `guardPath`, but only when `isRetirable` says its own
+ * payload shows the claimant has gone away.
+ *
+ * The decision is made against a **hard-link probe** rather than against
+ * `guardPath` itself.  That is the point: a guard belonging to a live claimant
+ * is never renamed, unlinked, or even momentarily absent from the well-known
+ * path, so deciding "busy" costs a live claimant nothing.  Deciding against the
+ * well-known path instead would mean a slow decision could be followed by
+ * renaming away whichever guard had since replaced the one it inspected.
+ *
+ * Only a guard that was proved retirable is retired, and retirement is an
+ * atomic `rename` whose captured inode must equal the probed inode.  A
+ * different guard installed between the probe and the rename is restored
+ * rather than discarded.  `rename` also means exactly one of several
+ * concurrent reclaimers retires a given guard; the rest see ENOENT.
+ *
+ * The probe deliberately carries the guard's own mtime, because `isRetirable`
+ * may fall back to an age bound.  The post-rename check is an inode comparison
+ * precisely so it does not depend on mtime, which `rename` preserves.
+ *
+ * Returns true when this call retired the guard.
+ */
+async function retireGuardIf(
+  lockPath: string,
+  guardPath: string,
+  isRetirable: (probePath: string) => Promise<boolean>,
+): Promise<boolean> {
+  const probePath = makeLockTempPath(lockPath);
+  let probeIdentity: FileIdentity | null;
   try {
-    await fs.unlink(guardPath);
+    await fs.link(guardPath, probePath);
+    probeIdentity = await statIdentity(probePath);
   } catch {
-    return false; // Can't reclaim — busy.
+    await safeUnlink(probePath);
+    return false; // No guard, or we cannot inspect one — treat as busy.
   }
 
-  // Retry the claim. The lock inode may have changed during recovery.
+  let retirable: boolean;
   try {
-    await fs.link(lockPath, guardPath);
-    return true;
-  } catch (error: unknown) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT') return true; // Lock vanished — no claim needed.
+    retirable = await isRetirable(probePath);
+  } catch {
+    retirable = false;
+  } finally {
+    await safeUnlink(probePath);
+  }
+  if (!retirable || probeIdentity === null) return false;
+
+  const capturePath = makeLockTempPath(lockPath);
+  try {
+    await fs.rename(guardPath, capturePath);
+  } catch {
+    return false; // Another reclaimer retired it first.
+  }
+
+  let capturedIdentity: FileIdentity | null = null;
+  try {
+    capturedIdentity = await statIdentity(capturePath);
+  } catch {
+    // Treated as a mismatch below.
+  }
+  if (
+    capturedIdentity === null ||
+    capturedIdentity.dev !== probeIdentity.dev ||
+    capturedIdentity.ino !== probeIdentity.ino
+  ) {
+    // A different guard was installed between the probe and the rename — put
+    // it back rather than displacing a claimant we never inspected.
+    try {
+      await fs.link(capturePath, guardPath);
+    } catch {
+      // Another guard already occupies the path.  Leave the capture parked
+      // rather than deleting what may be the only remaining copy of a live
+      // claim; {@link cleanupStaleLockTemp} reclaims it once its claimant is
+      // gone.
+      return false;
+    }
+    await safeUnlink(capturePath);
+    return false;
+  }
+
+  await safeUnlink(capturePath);
+  return true;
+}
+
+/**
+ * Verify that the on-disk guard still carries this claim's own token and that
+ * the lock path still identifies the inode observed at claim time.  Every
+ * mutator must call this before unlinking lockPath:
+ *
+ * - The token check is what a thief cannot forge by relinking the lock inode.
+ * - The dev/ino check preserves the protection against the lock being replaced
+ *   between claim time and mutation (now recorded in the claim rather than
+ *   inferred from the guard's inode).
+ */
+async function verifyTransitionClaim(
+  lockPath: string,
+  claim: TransitionClaim,
+): Promise<boolean> {
+  if (claim.lockIdentity === null) {
+    return false; // No lock existed at claim time — nothing to mutate.
+  }
+  try {
+    const guardContent = await fs.readFile(claim.guardPath, 'utf-8');
+    const parsed = JSON.parse(guardContent) as Record<string, unknown>;
+    if (parsed.claimToken !== claim.claimToken) {
+      return false; // The guard is not ours anymore.
+    }
+    const lockIdentity = await statIdentity(lockPath);
+    return (
+      lockIdentity !== null &&
+      lockIdentity.dev === claim.lockIdentity.dev &&
+      lockIdentity.ino === claim.lockIdentity.ino
+    );
+  } catch {
     return false;
   }
 }
 
 /**
- * Verify that the transition guard and the lock path still identify the
- * **same inode**.  Every mutator must call this before unlinking lockPath
- * to ensure the lock has not been replaced by another process since the
- * claim was acquired.
+ * Release the transition guard (best-effort, ownership-checked).  Unlinks the
+ * guard only while it still carries this claim's token — a process that never
+ * installed the guard (or whose guard was already reclaimed) never unlinks another
+ * process's guard.
+ *
+ * The token read and the unlink are not one atomic step, so a claim that is
+ * legally retired between them would be unlinked by its predecessor.  Reaching
+ * that requires our own claim to have passed the 48-hour PID-reuse bound while
+ * this process was still alive and mid-release; claims here live for
+ * milliseconds.  Closing it would mean renaming the guard away before reading
+ * it, which reintroduces the displacement that {@link retireGuardIf} exists to
+ * avoid, so the read-then-unlink order is deliberate.
  */
-async function verifyTransitionClaim(lockPath: string): Promise<boolean> {
-  const guardPath = getGuardPath(lockPath);
+async function releaseTransitionGuard(claim: TransitionClaim): Promise<void> {
   try {
-    const lockStat = await fs.stat(lockPath);
-    const guardStat = await fs.stat(guardPath);
-    return lockStat.dev === guardStat.dev && lockStat.ino === guardStat.ino;
+    const content = await fs.readFile(claim.guardPath, 'utf-8');
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    if (parsed.claimToken !== claim.claimToken) {
+      return; // Not our claim — leave it.
+    }
   } catch {
-    return false;
+    return; // Best-effort.
   }
-}
-
-/** Release the transition guard (best-effort). */
-async function releaseTransitionGuard(lockPath: string): Promise<void> {
-  await safeUnlink(getGuardPath(lockPath));
+  await safeUnlink(claim.guardPath);
 }
 
 /** Best-effort unlink that swallows errors. */
@@ -728,10 +1073,50 @@ async function safeUnlink(filePath: string): Promise<void> {
 }
 
 /**
+ * Return true when the payload at `filePath` names an owner that is still
+ * alive, meaning the file may be the only remaining copy of a live lock or
+ * transition claim and must not be reclaimed on age alone.
+ *
+ * Content that does not parse, or that carries no usable pid, is a partial
+ * publication artifact rather than an owned payload.
+ */
+async function namesLiveOwner(filePath: string): Promise<boolean> {
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, 'utf-8');
+  } catch (error: unknown) {
+    // Cannot read it, so we cannot prove it is disposable.  A file whose
+    // contents are unreadable can still be unlinked through a writable parent
+    // directory, so answering "no owner" here would let a transient EACCES or
+    // EMFILE destroy the only remaining copy of a live lock.  Only a confirmed
+    // absence is safe to treat as "nothing to preserve".
+    return (error as NodeJS.ErrnoException).code !== 'ENOENT';
+  }
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    const pid = parsed.pid;
+    if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) {
+      return false; // Readable, but names no owner.
+    }
+  } catch {
+    return false; // Readable partial write — a publication artifact.
+  }
+  return !(await checkStaleWithPidReuse(filePath));
+}
+
+/**
  * Safely clean up a single stale lock temp publication artifact.  Only
  * removes the file when it matches the exact generated grammar, is a
- * regular non-symlink direct child of chatsDir, and is older than the
- * conservative age threshold.  Unknown files are never deleted.
+ * regular non-symlink direct child of chatsDir, is older than the
+ * conservative age threshold, and does not name a live owner.  Unknown files
+ * are never deleted.
+ *
+ * The liveness check is not optional.  {@link retireStaleLock} and
+ * {@link retireGuardIf} can park a lock or claim under this grammar when a
+ * capture cannot be restored, and a process can crash between the rename and
+ * the restore, so a file matching this grammar is no longer guaranteed to be a
+ * redundant copy.  Reclaiming on age alone would destroy a live owner's only
+ * remaining copy.
  */
 async function cleanupStaleLockTemp(
   chatsDir: string,
@@ -747,6 +1132,7 @@ async function cleanupStaleLockTemp(
   } catch {
     return; // Can't stat — leave it.
   }
+  if (await namesLiveOwner(filePath)) return;
   await safeUnlink(filePath);
 }
 
@@ -756,6 +1142,13 @@ async function cleanupStaleLockTemp(
  * (`<safeSessionId>.lock.tguard`), it is a regular non-symlink direct child
  * of chatsDir, and its content indicates staleness.  Unknown files and
  * symlinks are never deleted.
+ *
+ * This sweep keeps the {@link checkStaleWithPidReuse} predicate rather than the
+ * stricter {@link isGuardAbandoned}, because it is the escape hatch that lets a
+ * guard with no `claimToken` — one written by an older revision — converge
+ * instead of waiting out the age bound.  It goes through
+ * {@link retireGuardIf} so that classifying a guard stale and removing it can
+ * no longer straddle another process installing a live claim at that path.
  */
 async function cleanupStaleGuard(
   chatsDir: string,
@@ -772,7 +1165,6 @@ async function cleanupStaleGuard(
   } catch {
     return; // Can't stat — leave it.
   }
-  if (await checkStaleWithPidReuse(guardPath)) {
-    await safeUnlink(guardPath);
-  }
+  const lockPath = guardPath.slice(0, -TRANSITION_GUARD_SUFFIX.length);
+  await retireGuardIf(lockPath, guardPath, checkStaleWithPidReuse);
 }

--- a/packages/core/src/recording/SessionLockManager.safety.test.ts
+++ b/packages/core/src/recording/SessionLockManager.safety.test.ts
@@ -557,6 +557,77 @@ describe('SessionLockManager — genuine transition race (subprocess, Item 3)', 
     expect(winners.length).toBe(1);
   }, 30000);
 
+  /**
+   * Contention that starts from an *abandoned* guard, which is the branch that
+   * exercises guard reclaim under concurrency.  The plain race above starts
+   * with no guard at all, so every contender takes the uncontended install
+   * path and reclaim is never entered.
+   *
+   * Here the stale lock already carries a guard whose claimant is dead, so
+   * every contender must reclaim before it can transition.  Exactly one may
+   * end up owning the lock, and no contender may lose a lock it acquired.
+   */
+  it('exactly one contender wins when the stale lock already carries an abandoned guard', async () => {
+    const sessionId = 'abandoned-guard-race';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+
+    const oldTime = new Date(Date.now() - 49 * 60 * 60 * 1000);
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: DEAD_PID,
+        timestamp: oldTime.toISOString(),
+        sessionId,
+        ownerToken: 'stale-original',
+      }),
+    );
+    await fs.utimes(lockPath, oldTime, oldTime);
+    // A claimant that crashed mid-transition: our own guard format, dead PID.
+    await fs.writeFile(
+      lockPath + '.tguard',
+      JSON.stringify({
+        pid: DEAD_PID,
+        timestamp: new Date().toISOString(),
+        claimToken: 'crashed-claimant-token',
+        lockDev: null,
+        lockIno: null,
+      }),
+    );
+
+    const script = `
+      const { SessionLockManager } = require(${JSON.stringify(path.resolve(__dirname, 'SessionLockManager.js'))});
+      const chatsDir = process.env.TEST_CHATS_DIR;
+      const sessionId = process.env.TEST_SESSION_ID;
+      const readyFile = process.env.TEST_READY_FILE;
+      const goFile = process.env.TEST_GO_FILE;
+      (async () => {
+        require('fs').writeFileSync(readyFile, 'ready');
+        while (!require('fs').existsSync(goFile)) {
+          await new Promise(r => setTimeout(r, 5));
+        }
+        try {
+          const handle = await SessionLockManager.acquire(chatsDir, sessionId);
+          await new Promise(r => setTimeout(r, 400));
+          const owns = await handle.ownsLock();
+          process.stdout.write(owns ? 'WON' : 'LOST');
+          await handle.release();
+        } catch (e) {
+          process.stdout.write('SKIP');
+        }
+      })();
+    `;
+
+    const results = await runBunScriptsWithBarrier(
+      script,
+      { TEST_CHATS_DIR: chatsDir, TEST_SESSION_ID: sessionId },
+      3,
+      tempDir,
+    );
+
+    expect(results.filter((r) => r === 'WON').length).toBe(1);
+    expect(results.filter((r) => r === 'LOST').length).toBe(0);
+  }, 30000);
+
   it('transition guard prevents removal of a replacement lock during release', async () => {
     // Acquire a lock, then simulate a replacement and verify release does not
     // delete the replacement (guarded ownership check + transition guard).
@@ -587,22 +658,25 @@ describe('SessionLockManager — genuine transition race (subprocess, Item 3)', 
 
   /**
    * Deterministic real child-process contention test that would FAIL under
-   * the old separate-owner stale-guard replacement sequence.
+   * the old hard-link guard protocol.
    *
-   * Under the old code, `reclaimStaleGuard()` was check-stale-then-unlink:
-   * two contenders could both classify the old guard as stale, one installs a
-   * new live guard, and the other unlinks it — allowing a loser to remove the
-   * winner's lock.  Under the hard-link claim, the guard IS the lock inode,
-   * and {@link verifyTransitionClaim} catches any inode mismatch before
-   * unlinking lockPath.
+   * Under the old code, the guard was a hard link of the lock inode, so the
+   * stale check in `tryReclaimGuard` inspected the victim lock's payload, not
+   * the claimant's.  On a stale takeover every contender concluded the incumbent
+   * claimant crashed, unlinked its guard and relinked its own — allowing a loser
+   * to remove the winner's lock.  Under the identity-bearing guard (Issue #3277)
+   * the guard carries its own claimToken, reclaim is liveness-based and
+   * non-displacing, and {@link verifyTransitionClaim} rejects a guard that no
+   * longer carries this claim's token or lock identity, so no process ever
+   * unlinks the winner's lock.
    *
    * Each child process acquires a stale lock, holds it briefly, then verifies
    * it STILL owns the lock (`ownsLock()`).  Under the old code, a loser could
    * unlink the winner's lock, causing `ownsLock()` to return false → the
-   * winner reports 'LOST'.  Under the hard-link claim, no process ever
+   * winner reports 'LOST'.  Under the identity-bearing guard, no process ever
    * reports 'LOST'.
    */
-  it('winner lock cannot be removed by concurrent stale-takeover contender (hard-link claim)', async () => {
+  it('winner lock cannot be removed by concurrent stale-takeover contender (identity-bearing guard)', async () => {
     const sessionId = 'winner-survives';
     const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
 
@@ -665,4 +739,283 @@ describe('SessionLockManager — genuine transition race (subprocess, Item 3)', 
     expect(guardFiles).toEqual([]);
     expect(tmpFiles).toEqual([]);
   }, 30000);
+});
+
+describe('SessionLockManager — transition guard identity (Issue #3277)', () => {
+  let tempDir: string;
+  let chatsDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+    chatsDir = path.join(tempDir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Write a genuinely stale lock (dead PID, 49h-old timestamp and mtime).
+   * Returns the on-disk ownerToken so a test can verify the lock was replaced.
+   */
+  async function writeStaleLock(
+    chatsDirN: string,
+    sessionId: string,
+  ): Promise<string> {
+    const lockPath = SessionLockManager.getLockPath(chatsDirN, sessionId);
+    const oldTime = new Date(Date.now() - 49 * 60 * 60 * 1000);
+    const ownerToken = 'stale-original-token';
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: DEAD_PID,
+        timestamp: oldTime.toISOString(),
+        sessionId,
+        ownerToken,
+      }),
+      'utf-8',
+    );
+    await fs.utimes(lockPath, oldTime, oldTime);
+    return ownerToken;
+  }
+
+  /**
+   * Write a transition guard file with the given payload.  Returns the exact
+   * bytes written so a test can assert the guard survived byte-identical.
+   */
+  async function writeGuard(
+    lockPath: string,
+    payload: Record<string, unknown>,
+  ): Promise<string> {
+    const guardPath = lockPath + '.tguard';
+    const content = JSON.stringify(payload);
+    await fs.writeFile(guardPath, content, 'utf-8');
+    return content;
+  }
+
+  it('a guard held by a live claimant blocks stale takeover', async () => {
+    const sessionId = 'live-claimant-guard';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+    const originalToken = await writeStaleLock(chatsDir, sessionId);
+    const guardContent = await writeGuard(lockPath, {
+      pid: process.pid,
+      timestamp: new Date().toISOString(),
+      claimToken: 'live-claimant-token',
+      lockDev: null,
+      lockIno: null,
+    });
+
+    await expect(
+      SessionLockManager.acquire(chatsDir, sessionId),
+    ).rejects.toBeInstanceOf(SessionLockedError);
+
+    // The live claimant's guard is untouched — nobody stole or deleted it.
+    expect(await fs.readFile(lockPath + '.tguard', 'utf-8')).toBe(guardContent);
+    // The stale lock still exists with its original owner token.
+    const lockAfter = JSON.parse(await fs.readFile(lockPath, 'utf-8'));
+    expect(lockAfter.ownerToken).toBe(originalToken);
+  });
+
+  it('a guard abandoned by a dead claimant is reclaimed', async () => {
+    const sessionId = 'dead-claimant-guard';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+    const originalToken = await writeStaleLock(chatsDir, sessionId);
+    await writeGuard(lockPath, {
+      pid: DEAD_PID,
+      timestamp: new Date().toISOString(),
+      claimToken: 'dead-claimant-token',
+      lockDev: null,
+      lockIno: null,
+    });
+
+    const handle = await SessionLockManager.acquire(chatsDir, sessionId);
+
+    // The lock was replaced with a fresh owner token.
+    const lockContent = JSON.parse(await fs.readFile(lockPath, 'utf-8'));
+    expect(lockContent.ownerToken).not.toBe(originalToken);
+    expect(await handle.ownsLock()).toBe(true);
+
+    await handle.release();
+    expect(await fileExists(lockPath)).toBe(false);
+    expect(await fileExists(lockPath + '.tguard')).toBe(false);
+  });
+
+  it('a guard whose live PID is past the PID-reuse bound is reclaimed', async () => {
+    const sessionId = 'pidreuse-guard';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+    const oldTime = new Date(Date.now() - 49 * 60 * 60 * 1000);
+    await writeStaleLock(chatsDir, sessionId);
+    await writeGuard(lockPath, {
+      pid: process.pid,
+      timestamp: oldTime.toISOString(),
+      claimToken: 'old-claimant-token',
+      lockDev: null,
+      lockIno: null,
+    });
+
+    const handle = await SessionLockManager.acquire(chatsDir, sessionId);
+    expect(await handle.ownsLock()).toBe(true);
+
+    await handle.release();
+    expect(await fileExists(lockPath)).toBe(false);
+    expect(await fileExists(lockPath + '.tguard')).toBe(false);
+  });
+
+  it('removeStaleLock does not unlink a live claimant guard when the lock is absent', async () => {
+    const sessionId = 'absent-lock-live-guard';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+    // No lock exists — only a live claimant's guard is on disk.
+    const guardContent = await writeGuard(lockPath, {
+      pid: process.pid,
+      timestamp: new Date().toISOString(),
+      claimToken: 'live-guard-absent-lock',
+      lockDev: null,
+      lockIno: null,
+    });
+
+    await SessionLockManager.removeStaleLock(chatsDir, sessionId);
+
+    // The live claimant's guard must survive — we never installed it, so we must
+    // never unlink it.
+    expect(await fs.readFile(lockPath + '.tguard', 'utf-8')).toBe(guardContent);
+  });
+
+  it('a corrupt recent guard is treated as busy', async () => {
+    const sessionId = 'corrupt-recent-guard';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+    await writeStaleLock(chatsDir, sessionId);
+    const guardContent = 'this is not json {{{';
+    await fs.writeFile(lockPath + '.tguard', guardContent, 'utf-8');
+
+    await expect(
+      SessionLockManager.acquire(chatsDir, sessionId),
+    ).rejects.toBeInstanceOf(SessionLockedError);
+
+    expect(await fs.readFile(lockPath + '.tguard', 'utf-8')).toBe(guardContent);
+  });
+
+  it('a corrupt guard older than the age bound is reclaimed', async () => {
+    const sessionId = 'corrupt-old-guard';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+    await writeStaleLock(chatsDir, sessionId);
+    await fs.writeFile(lockPath + '.tguard', 'garbage!!!', 'utf-8');
+    const oldTime = new Date(Date.now() - 49 * 60 * 60 * 1000);
+    await fs.utimes(lockPath + '.tguard', oldTime, oldTime);
+
+    const handle = await SessionLockManager.acquire(chatsDir, sessionId);
+    expect(await handle.ownsLock()).toBe(true);
+
+    await handle.release();
+  });
+
+  it('a legacy hard-link guard over a LIVE lock is not reclaimable', async () => {
+    const sessionId = 'legacy-hardlink-guard';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: process.pid,
+        timestamp: new Date().toISOString(),
+        sessionId,
+        ownerToken: 'live-legacy-lock',
+      }),
+      'utf-8',
+    );
+    // Reproduce the old guard format: a hard link of the lock inode.
+    await fs.link(lockPath, lockPath + '.tguard');
+
+    await expect(
+      SessionLockManager.acquire(chatsDir, sessionId),
+    ).rejects.toBeInstanceOf(SessionLockedError);
+
+    expect(await fileExists(lockPath)).toBe(true);
+    expect(await fileExists(lockPath + '.tguard')).toBe(true);
+  });
+
+  /**
+   * The proof scenario from issue #3277.
+   *
+   * Before the fix the guard was a hard link of the lock inode, so a claimant
+   * that was busy taking over a stale lock left a guard whose content was the
+   * *stale lock's* content.  Every other contender read that content, concluded
+   * the claimant had crashed, unlinked the live claimant's guard and relinked
+   * its own — so the guard serialized nothing and the contender took the lock
+   * out from under the claimant.
+   *
+   * The lock here is stale by the dead-PID rule but has a recent mtime, so the
+   * only thing that can keep the contender out is refusing to reclaim a guard
+   * whose claimant cannot be identified.
+   */
+  it('a hard-link guard over a stale lock is not reclaimable and blocks takeover', async () => {
+    const sessionId = 'hardlink-guard-stale-lock';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+    const guardPath = lockPath + '.tguard';
+    const originalToken = 'stale-original-token';
+    // Dead PID (stale) but a recent mtime, so age alone cannot reclaim.
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: DEAD_PID,
+        timestamp: new Date().toISOString(),
+        sessionId,
+        ownerToken: originalToken,
+      }),
+      'utf-8',
+    );
+    // A claimant mid-takeover under the pre-fix protocol: the guard is a hard
+    // link of the lock inode.
+    await fs.link(lockPath, guardPath);
+    const guardIno = (await fs.stat(guardPath)).ino;
+
+    await expect(
+      SessionLockManager.acquire(chatsDir, sessionId),
+    ).rejects.toBeInstanceOf(SessionLockedError);
+
+    // The claimant's guard survives, still pointing at the same inode.
+    expect(await fileExists(guardPath)).toBe(true);
+    expect((await fs.stat(guardPath)).ino).toBe(guardIno);
+    // The lock the claimant is transitioning is untouched.
+    expect(JSON.parse(await fs.readFile(lockPath, 'utf-8')).ownerToken).toBe(
+      originalToken,
+    );
+  });
+
+  it('removeStaleLock does not disturb a live claimant guard', async () => {
+    const sessionId = 'removestale-live-guard';
+    const lockPath = SessionLockManager.getLockPath(chatsDir, sessionId);
+    const originalToken = await writeStaleLock(chatsDir, sessionId);
+    const guardContent = await writeGuard(lockPath, {
+      pid: process.pid,
+      timestamp: new Date().toISOString(),
+      claimToken: 'live-claimant-token',
+      lockDev: null,
+      lockIno: null,
+    });
+
+    await SessionLockManager.removeStaleLock(chatsDir, sessionId);
+
+    expect(await fileExists(lockPath)).toBe(true);
+    expect(JSON.parse(await fs.readFile(lockPath, 'utf-8')).ownerToken).toBe(
+      originalToken,
+    );
+    expect(await fs.readFile(lockPath + '.tguard', 'utf-8')).toBe(guardContent);
+  });
+
+  it('a normal acquire/release leaves no guard or temp artifacts', async () => {
+    const sessionId = 'no-artifacts';
+    const handle = await SessionLockManager.acquire(chatsDir, sessionId);
+
+    // While held, the transition guard has already been released at the end of
+    // acquire and no temp files remain.
+    let entries = await fs.readdir(chatsDir);
+    expect(entries.filter((f) => f.endsWith('.tguard'))).toEqual([]);
+    expect(entries.filter((f) => f.endsWith('.locktmp'))).toEqual([]);
+
+    await handle.release();
+
+    entries = await fs.readdir(chatsDir);
+    expect(entries.filter((f) => f.endsWith('.tguard'))).toEqual([]);
+    expect(entries.filter((f) => f.endsWith('.locktmp'))).toEqual([]);
+  });
 });

--- a/packages/core/src/recording/SessionLockManager.safety.test.ts
+++ b/packages/core/src/recording/SessionLockManager.safety.test.ts
@@ -1006,8 +1006,8 @@ describe('SessionLockManager — transition guard identity (Issue #3277)', () =>
     const sessionId = 'no-artifacts';
     const handle = await SessionLockManager.acquire(chatsDir, sessionId);
 
-    // While held, the transition guard has already been released at the end of
-    // acquire and no temp files remain.
+    // Fresh publication competes only through exclusive creation and never
+    // installs a transition guard, so no guard or temp files exist while held.
     let entries = await fs.readdir(chatsDir);
     expect(entries.filter((f) => f.endsWith('.tguard'))).toEqual([]);
     expect(entries.filter((f) => f.endsWith('.locktmp'))).toEqual([]);

--- a/packages/core/src/recording/SessionLockManager.test.ts
+++ b/packages/core/src/recording/SessionLockManager.test.ts
@@ -709,6 +709,53 @@ describe('SessionLockManager @plan:PLAN-20260211-SESSIONRECORDING.P10', () => {
       expect(await fileExists(tempPath)).toBe(true);
     });
 
+    it('cleanupOrphanedLocks does NOT remove an aged lock temp that names a live owner', async () => {
+      // A retirement capture that could not be restored is parked under this
+      // grammar and may be the only remaining copy of a live lock, so age
+      // alone must not reclaim it.
+      const sessionId = 'parked-live-temp';
+      const tempName = `${sessionId}.lock.550e8400-e29b-41d4-a716-446655440001.locktmp`;
+      const tempPath = path.join(chatsDir, tempName);
+      await fs.writeFile(
+        tempPath,
+        JSON.stringify({
+          pid: process.pid,
+          timestamp: new Date().toISOString(),
+          sessionId,
+          ownerToken: 'parked-live-owner',
+        }),
+        'utf-8',
+      );
+      const old = new Date(Date.now() - 10 * 60 * 1000);
+      await fs.utimes(tempPath, old, old);
+
+      await SessionLockManager.cleanupOrphanedLocks(chatsDir);
+
+      expect(await fileExists(tempPath)).toBe(true);
+    });
+
+    it('cleanupOrphanedLocks removes an aged lock temp whose owner is dead', async () => {
+      const sessionId = 'parked-dead-temp';
+      const tempName = `${sessionId}.lock.550e8400-e29b-41d4-a716-446655440002.locktmp`;
+      const tempPath = path.join(chatsDir, tempName);
+      await fs.writeFile(
+        tempPath,
+        JSON.stringify({
+          pid: DEAD_PID,
+          timestamp: new Date().toISOString(),
+          sessionId,
+          ownerToken: 'parked-dead-owner',
+        }),
+        'utf-8',
+      );
+      const old = new Date(Date.now() - 10 * 60 * 1000);
+      await fs.utimes(tempPath, old, old);
+
+      await SessionLockManager.cleanupOrphanedLocks(chatsDir);
+
+      expect(await fileExists(tempPath)).toBe(false);
+    });
+
     it('cleanupOrphanedLocks does NOT remove unknown files ending in .locktmp', async () => {
       // Does not match the exact grammar (no valid UUID).
       const badName = 'random.locktmp';

--- a/project-plans/issue3277/plan.md
+++ b/project-plans/issue3277/plan.md
@@ -1,0 +1,453 @@
+# Issue #3277 — Session lock transition guard does not serialize stale takeover
+
+## 1. Defect analysis
+
+`packages/core/src/recording/SessionLockManager.internals.ts` implements a
+per-session "transition guard" that is supposed to serialize every pathname
+mutation on `<chatsDir>/<sessionId>.lock`. It does not.
+
+`acquireTransitionGuard(lockPath)` claims the guard with
+`link(lockPath, guardPath)`. Exactly one contender wins the link; every other
+contender gets `EEXIST` and falls through to `tryReclaimGuard`.
+
+`tryReclaimGuard` decides whether the incumbent claim is abandoned by calling
+`checkStaleWithPidReuse(guardPath)`. Because the guard is a hard link of the
+lock inode, that call inspects the **victim lock's** payload, not the
+**claimant's**. During a stale takeover the victim is stale by construction, so
+every loser concludes the incumbent claimant crashed, unlinks the incumbent's
+guard, and relinks its own. The guard therefore provides no mutual exclusion in
+the only situation it exists for.
+
+`verifyTransitionClaim(lockPath)` compares `stat(lockPath)` against
+`stat(guardPath)` by `dev`/`ino`. A stolen guard is a hard link to the same
+inode, so the check passes for the thief and the victim alike.
+
+Two further consequences follow from the same root cause:
+
+- `releaseTransitionGuard` unlinks `guardPath` unconditionally, so a contender
+  deletes whatever guard happens to be installed, including another process's.
+- When the lock does not exist, `acquireTransitionGuard` returns `true` without
+  installing anything, and the caller's `finally` still calls
+  `releaseTransitionGuard`, deleting a guard it never owned.
+
+### Why contention can resolve with zero winners
+
+The zero-winner outcome reported in the issue follows directly. Every contender
+believes it holds the guard. Each one runs
+`read original -> checkStale -> re-read -> verifyTransitionClaim -> unlink -> create`.
+`verifyTransitionClaim` calls `stat(guardPath)`. Contenders are continuously
+unlinking and relinking `guardPath` (in `tryReclaimGuard`, and in the `finally`
+of `tryStaleTakeover`), so `stat(guardPath)` can throw `ENOENT` for *every*
+contender in turn. Each then returns `false` from `tryStaleTakeover` and throws
+`SessionLockedError`. Nobody unlinks the stale lock, nobody creates a
+replacement, and the whole race returns in well under the 500 ms a winner would
+have spent holding the lock. That matches the reported failure exactly (three
+`SKIP`s, 63 ms, lock left unclaimed).
+
+## 2. Acceptance criteria
+
+- **AC-1 — Guard carries its own identity.** The transition guard is a distinct
+  file whose payload identifies the claimant: `pid`, `timestamp`, a random
+  `claimToken`, and the `dev`/`ino` of the lock observed at claim time. It is no
+  longer a hard link of the lock inode.
+- **AC-2 — Guard installation is exclusive.** At most one live claimant holds
+  the guard. A contender that loses the exclusive install and cannot prove the
+  incumbent claimant is abandoned reports busy.
+- **AC-3 — Reclaim depends on claimant liveness.** A guard is reclaimable only
+  when its own payload indicates abandonment (dead PID, or an alive PID past the
+  48-hour PID-reuse bound, or an unreadable/corrupt guard older than that bound).
+  The staleness of the lock being taken over must never make the guard
+  reclaimable.
+- **AC-4 — Reclaim never displaces a live claimant.** Concurrent reclaimers of
+  the same abandoned guard resolve to at most one new holder, and a claim that
+  becomes live between the liveness check and the reclaim is restored rather
+  than discarded.
+- **AC-5 — Claim verification detects theft.** `verifyTransitionClaim` returns
+  true only when the guard on disk still carries *this* claim's `claimToken`
+  **and** the lock still has the `dev`/`ino` recorded at claim time. Relinking
+  the same lock inode cannot forge a claim.
+- **AC-6 — Release is ownership-checked.** A process unlinks the guard only
+  while it still carries that process's `claimToken`. A process that never
+  installed a guard never unlinks one.
+- **AC-7 — Contention resolves to exactly one owner.** Contention over a
+  genuinely stale lock always produces exactly one winner. `winners.length === 1`
+  stays as-is; it is not relaxed to `<= 1`. No contender reports `LOST`, and no
+  `.tguard` or `.locktmp` artifacts remain afterwards.
+- **AC-8 — Existing janitor behaviour is preserved.** `cleanupOrphanedLocks`
+  still removes safe-grammar guards whose claimant is dead, still refuses to
+  remove live guards, still refuses to remove unsafe-named guards and unknown
+  `.locktmp` files, and the existing lock-removal semantics are unchanged.
+
+### Out of scope
+
+`packages/core/src/recording/janitor/janitorLease.ts` implements the same
+hard-link claim protocol (`acquireTransitionClaim` / `tryReclaimClaim` /
+`verifyTransitionClaim`) for janitor leases. Its reclaim path reads the *lease*
+content rather than the claimant's, so it is structurally similar. The issue is
+scoped to `SessionLockManager`, and the lease claim is a separate mechanism with
+its own tests, so it is **not** changed here. Recorded as a follow-up.
+
+## 3. Design
+
+### 3.1 Guard payload
+
+```ts
+interface TransitionClaim {
+  /** Path of the guard file this claim installed. */
+  guardPath: string;
+  /** Random token unique to this claim. */
+  claimToken: string;
+  /** dev/ino of the lock observed when the claim was installed, or null. */
+  lockIdentity: { dev: string; ino: string } | null;
+}
+```
+
+On-disk guard payload (JSON):
+
+```json
+{
+  "pid": 1234,
+  "timestamp": "2026-08-23T00:00:00.000Z",
+  "claimToken": "<uuid>",
+  "lockDev": "16777232",
+  "lockIno": "627806075"
+}
+```
+
+`dev`/`ino` are stored as decimal strings so a JSON round-trip cannot lose
+precision on filesystems with large inode numbers.
+
+`pid` and `timestamp` use the same key names the existing
+`checkStaleWithPidReuse` already reads, so that function can be reused verbatim
+to answer "is this claimant abandoned?" — dead PID means abandoned, an alive PID
+means abandoned only past the 48-hour bound, and an unreadable or corrupt guard
+falls back to the mtime bound. That is precisely AC-3.
+
+### 3.2 Install (exclusive)
+
+```
+tempPath = <lockPath>.<uuid>.locktmp
+write payload to tempPath with O_EXCL, fsync, close
+link(tempPath, guardPath)      // EEXIST => someone else holds it
+unlink(tempPath)               // always
+```
+
+The temp name deliberately reuses the existing `<safeSessionId>.lock.<uuid>.locktmp`
+grammar so the existing `cleanupStaleLockTemp` orphan sweep already covers guard
+temps; no new cleanup path is introduced.
+
+The lock's `dev`/`ino` are stat'ed immediately before the payload is written. If
+the lock does not exist, `lockIdentity` is `null`; the guard is still installed
+so mutators still serialize, and `verifyTransitionClaim` then returns `false`,
+which matches today's behaviour (today `stat(guardPath)` throws and verification
+fails).
+
+### 3.3 Reclaim (liveness-based, non-displacing)
+
+Abandonment is decided by `isGuardAbandoned(guardPath)`:
+
+```
+parse guardPath as JSON
+if unparseable, or claimToken is not a non-empty string:
+    return isOlderThanBound(guardPath)     // no discoverable claimant
+return checkStaleWithPidReuse(guardPath)   // our format: claimant liveness
+```
+
+The `claimToken` gate matters. A guard written by the pre-fix revision is a hard
+link of the lock inode, so its payload describes the **victim lock**, not the
+claimant. Feeding that to `checkStaleWithPidReuse` is precisely the defect: over
+a stale lock it reads as abandoned to every contender simultaneously. A guard
+this implementation did not write has no discoverable claimant, so the
+conservative answer is busy, reclaimable only once it passes the existing
+48-hour age bound. This matches the file's existing posture that unreadable and
+corrupt files are busy rather than instantly stale. Orphaned legacy guards still
+converge, because the janitor's `cleanupStaleGuard` sweep (unchanged) removes
+safe-grammar guards whose payload PID is dead.
+
+```
+if (!isGuardAbandoned(guardPath)) return null;   // live/unattributable -> busy
+
+capturePath = <lockPath>.<uuid>.locktmp
+rename(guardPath, capturePath)      // atomic; ENOENT => another reclaimer won
+if (!isGuardAbandoned(capturePath)) {
+  link(capturePath, guardPath)      // restore; EEXIST => already reinstalled
+  unlink(capturePath)
+  return null                        // never displace a live claim
+}
+unlink(capturePath)
+return installGuard(lockPath)        // exclusive install; may still lose
+```
+
+`rename` moves the guard out of the well-known name atomically, so exactly one
+concurrent reclaimer captures a given abandoned guard; the others get `ENOENT`
+and back off. Re-running the abandonment check on the captured inode closes the
+window where a different, live claim was installed between the first check and
+the rename: the captured file is out of the shared namespace and nobody else can
+modify it, so the second check is authoritative. A live capture is put back.
+
+The worst outcome of a losing reclaimer is a brief interval in which `guardPath`
+is absent; a live holder that calls `verifyTransitionClaim` during that interval
+fails verification and aborts without mutating. Safety is preserved; only
+liveness (a retryable busy result) is affected, and only when a claimant has
+actually crashed.
+
+### 3.4 Verification
+
+```
+verifyTransitionClaim(claim):
+  if (claim.lockIdentity === null) return false
+  read guardPath, parse, require claimToken === claim.claimToken
+  stat(lockPath), require dev/ino === claim.lockIdentity
+```
+
+The token check is what a thief cannot forge by relinking the lock inode (AC-5).
+The `dev`/`ino` check preserves the existing protection against the lock being
+replaced between claim time and mutation; it is now recorded in the claim
+payload instead of being inferred from the guard's own inode.
+
+### 3.5 Release
+
+```
+releaseTransitionGuard(claim):
+  read guardPath, parse
+  if (claimToken !== claim.claimToken) return   // not ours -> leave it
+  unlink(guardPath)
+```
+
+Mirrors the existing `releaseIfOwned` token-checked pattern for locks (AC-6).
+
+### 3.6 Call-site changes
+
+`acquireTransitionGuard` returns `TransitionClaim | null` instead of `boolean`.
+The three mutators — `tryStaleTakeover`, `tryRemoveStaleLock`, `releaseIfOwned` —
+thread the claim through to `verifyTransitionClaim(claim)` and
+`releaseTransitionGuard(claim)`. Public API is unchanged; every touched symbol
+is module-private.
+
+Error handling stays conservative and matches today's surface: any failure to
+install a guard yields `null` (treated as busy) rather than throwing, so
+`handle.release()` and the janitor sweep cannot start throwing new I/O errors.
+
+## 4. Test plan
+
+All tests are behavioural and go in the existing
+`packages/core/src/recording/SessionLockManager.safety.test.ts`, exercising the
+public `SessionLockManager` API plus direct on-disk inspection of the guard
+file. No mock theater; no new test files.
+
+New describe block: `SessionLockManager — transition guard identity (Issue #3277)`.
+
+| Test | Covers | Behaviour |
+| --- | --- | --- |
+| T1 | AC-2, AC-3, AC-6 | Stale lock (dead PID, 49 h mtime) plus a guard file whose payload has **this test process's live PID** and a distinct `claimToken`. `acquire` rejects with `SessionLockedError`; the guard file is byte-identical afterwards; the stale lock still exists. Under the current code the contender walks through the guard and acquires. |
+| T2 | AC-3 | Same stale lock, guard payload with a **dead PID**. `acquire` resolves; the acquired lock carries a fresh `ownerToken`; after `release` neither the lock nor the guard remains. |
+| T3 | AC-3 | Stale lock plus a guard whose payload has a live PID but a `timestamp` 49 hours old. `acquire` resolves (PID-reuse bound reclaim). |
+| T4 | AC-3 | Stale lock plus a **corrupt, recent** guard. `acquire` rejects with `SessionLockedError` and the guard survives. |
+| T5 | AC-3 | Stale lock plus a **corrupt guard with a 49-hour mtime**. `acquire` resolves. |
+| T6 | AC-1 | While a lock is held, the guard is absent; a legacy-format guard (a hard link of a *live* lock) is not treated as reclaimable. Concretely: live lock plus a guard hard-linked to it, `acquire` rejects and the guard survives. |
+| T7 | AC-6 | `removeStaleLock` on a stale lock guarded by a live claimant leaves both the lock and that claimant's guard in place. |
+| T8 | AC-1, AC-7 | A normal `acquire`/`release` cycle leaves no `.tguard` and no `.locktmp` in `chatsDir`. |
+| T9 | AC-2, AC-3 | **The issue's proof scenario.** Lock with a dead PID and a *recent* mtime (stale by the dead-PID rule, not by age), plus a guard hard-linked to it — exactly what a pre-fix claimant mid-takeover leaves on disk. `acquire` rejects with `SessionLockedError`, the guard survives pointing at the same inode, and the lock keeps its original `ownerToken`. |
+| T10 | AC-6 | `removeStaleLock` with **no lock present** and a live claimant's guard on disk leaves that guard intact. Pre-fix, `acquireTransitionGuard` returned `true` on `ENOENT` without installing anything and the caller's `finally` unlinked the guard it never owned. |
+
+#### Which tests fail before the fix, and why the others cannot
+
+Only **T9** and **T10** fail against the unfixed implementation, and that is a
+property of the defect rather than a weakness in the suite. The pre-fix guard
+format cannot express "a live claimant is guarding this lock" — the guard is a
+hard link of the victim — so no fixture written in the new format can drive the
+old code down its broken path. T1–T8 are contract tests for the new guard
+semantics: they pin reclaim to claimant liveness and stop a future change from
+regressing to a victim-content predicate. T9 is the regression test for the
+reported defect and reproduces the issue's own proof verbatim; T10 covers the
+unowned-guard deletion that falls out of the same root cause.
+
+Pre-fix output for T9:
+
+```
+(fail) a hard-link guard over a stale lock is not reclaimable and blocks takeover
+  Expected promise that rejects
+  Received promise that resolved: Promise { <resolved> }
+```
+
+Existing tests that must keep passing unchanged:
+
+- `exactly one of several competing stale-takeover subprocesses wins` (AC-7).
+- `winner lock cannot be removed by concurrent stale-takeover contender
+  (hard-link claim)` — assertion `winners.length === 1` stays; `lost.length === 0`
+  stays; no leftover `.tguard`/`.locktmp` stays (AC-7). Its doc comment is
+  updated to describe the identity-bearing guard rather than the hard-link claim,
+  and the title's parenthetical is updated accordingly.
+- `SessionLockManager.test.ts` guard-cleanup tests: stale guard with dead PID is
+  removed, live guard is kept, unsafe-named guard is kept (AC-8).
+
+Determinism note: T1–T7 are single-process, fixture-driven and deterministic.
+The subprocess race tests remain the only timing-sensitive tests, and the fix
+removes the interleaving that made them flaky.
+
+## 5. Verification
+
+```
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Plus a repeated run of the two subprocess race tests under CPU load, since the
+original symptom only reproduced on a loaded machine:
+
+```
+cd packages/core
+for i in $(seq 1 10); do bun test src/recording/SessionLockManager.safety.test.ts || break; done
+```
+
+## 6. Review triage
+
+Review round 1 (deepthinker) returned CHANGES-REQUIRED. Triage:
+
+| # | Sev | Finding | Disposition |
+| --- | --- | --- | --- |
+| 1 | HIGH | `tryReclaimGuard` renamed whatever occupied `guardPath`, not the guard it had judged abandoned. A reclaimer that paused after its decision could rename away a live claim installed in the meantime, and its best-effort restore could then lose to a third contender, leaving two processes past verification. | **In-scope-Fix.** Two changes, below. |
+| 2 | HIGH | The janitor's `cleanupStaleGuard` is check-then-unlink and can unlink a live claim installed after its classification. | **In-scope-Fix.** Same defect class in the same guard mechanism; routed through the shared non-displacing protocol. |
+| 3 | MEDIUM | `releaseTransitionGuard` reads the token and unlinks in two steps. | **Reject.** Reaching it needs our own claim to pass the 48-hour PID-reuse bound while this process is alive and mid-release; claims live for milliseconds. Every remedy (rename-then-check) reintroduces the displacement of finding 1. Documented in the code. |
+| 4 | MEDIUM | `rename` preserves mtime, so a capture could be immediately eligible for the 5-minute `.locktmp` sweep and be deleted mid-protocol. | **In-scope-Fix**, resolved structurally: the post-rename check is now an inode comparison, which `rename` also preserves, so no step depends on the capture's mtime. Losing a capture to the sweep now degrades to "busy". |
+| 5 | MEDIUM | `String(stat().dev/ino)` cannot represent 64-bit Windows file IDs or inodes above 2^53, so two distinct files can compare equal. | **In-scope-Fix.** `fs.stat(path, { bigint: true })` via a new `statIdentity` helper. |
+| 6 | MEDIUM | No test starts from an abandoned guard, so the reclaim branch is never exercised under contention. | **In-scope-Fix.** New subprocess race test, below. |
+| 7 | LOW | All guard-install I/O errors collapse to "busy", hiding ENOSPC/EACCES. | **Reject** for the general case: this is the pre-fix error surface and changing what `release()` throws is outside the issue. **Accepted in part** for the specific case the reviewer identified as user-visible: a non-ENOENT `stat` failure on the lock used to yield a null identity, which fails verification and makes `releaseIfOwned` silently leave a lock this process owns. That now reports busy instead. |
+| — | — | "Redesign reclaim around a true cross-platform file lock or a fencing protocol." | **Reject.** A new locking primitive is a redesign well beyond this issue, and POSIX offers no compare-and-swap unlink that would make it unnecessary. |
+
+### 6.1 Non-displacing guard retirement (`retireGuardIf`)
+
+Retirement no longer decides against the well-known path. It hard-links the
+incumbent guard to a probe, judges the probe, and unlinks the probe. A guard
+belonging to a live claimant is therefore never renamed, unlinked, or even
+momentarily absent, so deciding "busy" costs a live claimant nothing. Only a
+guard proved retirable is retired, via an atomic `rename` whose captured inode
+must equal the probed inode; a different guard installed in between is restored.
+`rename` also means exactly one of several concurrent reclaimers retires a given
+guard.
+
+The predicate is a parameter. `tryReclaimGuard` passes `isGuardAbandoned` (the
+strict, claimToken-gated rule). `cleanupStaleGuard` keeps
+`checkStaleWithPidReuse`, because the janitor is the escape hatch that lets a
+legacy guard with no `claimToken` converge instead of waiting out the age bound,
+and AC-8 requires its existing behaviour to be preserved.
+
+### 6.2 Atomic stale-lock retirement (`retireStaleLock`)
+
+The deeper answer to finding 1 is to stop depending on the guard for the
+exactly-one-owner property. `tryStaleTakeover` and `tryRemoveStaleLock` no
+longer `unlink(lockPath)`; they `rename` it out of the well-known path.
+
+`rename` is the only pathname primitive POSIX offers that removes a name and
+tells exactly one caller that it did so. A bare `unlink` cannot distinguish "I
+removed the stale lock" from "I removed the replacement somebody else just
+published". With the rename, every other contender's attempt fails with ENOENT,
+and a caller that captures a lock whose content is not the payload it judged
+stale restores that lock instead of destroying it. Contention over a stale lock
+therefore resolves to a single owner even if the guard were bypassed entirely,
+and the "no process unlinks another's lock" invariant no longer rests on the
+guard alone.
+
+### 6.3 New test
+
+`exactly one contender wins when the stale lock already carries an abandoned
+guard` — three subprocesses contend over a stale lock that already carries a
+dead-claimant guard, so every contender must go through reclaim rather than the
+uncontended install path. Exactly one winner, no `LOST`.
+
+### 6.4 Open Code Review triage
+
+OCR returned two findings, both on the retirement protocol introduced in 6.1 and
+6.2, and both are regressions that change introduced rather than pre-existing
+issues. Before this change a `.locktmp` file was always a redundant publication
+copy, because the real lock still existed at `lockPath`. After it, a retirement
+capture can briefly be the only copy.
+
+| # | Finding | Disposition |
+| --- | --- | --- |
+| 1 | On the restore-failure path both `retireStaleLock` and `retireGuardIf` unlinked the capture, destroying what could be a live lock or claim. | **In-scope-Fix.** The capture is now left parked instead of deleted when it cannot be restored. |
+| 2 | `cleanupStaleLockTemp` reclaims `.locktmp` files on age alone, so it would destroy a parked live lock five minutes later, or one left behind by a crash between the rename and the restore. | **In-scope-Fix.** The sweep is now payload-aware: an aged temp whose payload names a live owner is kept. Content that does not parse, or that carries no usable pid, is still a partial publication artifact and is still reclaimed, so the existing sweep behaviour is unchanged for the artifacts it was written for. |
+
+Two behavioural tests were added in `SessionLockManager.test.ts` next to the
+existing temp-sweep tests: an aged temp naming a live owner survives, and an
+aged temp whose owner is dead is reclaimed.
+
+### 6.5 Second review pass
+
+A second independent review of the finished state returned CHANGES-REQUIRED,
+centred on the claim that the protocol is fully serializing. Triage:
+
+| # | Sev | Finding | Disposition |
+| --- | --- | --- | --- |
+| 1 | HIGH | `retireGuardIf` still judges a probe and renames later, so a reclaimer that stalls between the two can rename a replacement guard. A ten-step chain across four processes, requiring an abandoned guard and a concurrent janitor sweep, ends with two processes holding lock handles. | **Reject as specified, accept as documentation.** The proposed remedy is "a cross-platform native file-lock abstraction or a fencing protocol" — a new locking subsystem, which is a redesign beyond this issue and needs approval. The reviewer also states the underlying truth: with `link`, `rename` and `unlink` there is no compare-and-swap, so no pathname protocol can establish the invariant. What the change does deliver is removing the defect that fires on *every* stale takeover and replacing it with a window that needs a crashed claimant, a concurrent janitor, four processes and a specific stall. The overclaiming comments have been corrected instead: the module header now says what the protocol does and does not promise. Recorded as a follow-up. |
+| 2 | HIGH | The same stall can produce zero winners plus an orphan guard carrying a live PID. | **Reject as specified**, same root and same remedy. Narrower than the reported defect, retryable, and self-healing when the claimant exits or the janitor sweeps a dead PID. Restoring the captured guard is deliberate: it favours safety (never leave two claimants past verification) over liveness (an occasional retry). |
+| 3 | MEDIUM | Guard-install collapses every I/O error into "busy", so a real ENOSPC/EACCES looks like contention, and a failed release silently leaves the lock. | **Split.** Accepted in part: installation now returns a tagged `installed` / `contended` / `failed` result, so only genuine contention consults an incumbent claim. Deferred in part: making `release()` throw or become retryable changes a public contract, and the leak on a failed release is pre-existing (the old `link`-based guard swallowed the same errors). Out of scope for this issue. |
+| 4 | MEDIUM | `namesLiveOwner` mapped every read failure to "no owner", so a transient EACCES/EMFILE would let the temp sweep delete an unreadable parked live lock. | **In-scope-Fix.** This is a regression from the parking behaviour added in 6.4. Unreadable now means unknown and the file is kept; only a confirmed ENOENT, readable non-payload content, or a readable payload with a dead owner is disposable. |
+| 5 | MEDIUM | The replacement interleavings are not deterministically tested; the abandoned-guard race test relies on scheduling. | **Defer.** The remedy requires adding pause hooks to the production protocol so tests can stall it at named points. Wiring test seams into a concurrency protocol is a design change with its own risk, and the interleavings in question are the residual accepted above. |
+| 6 | LOW | `releaseTransitionGuard` read-then-unlink window. | **Accept as documented**, already commented at the call site. Needs a >48-hour pause or a clock jump to reach. |
+
+One analysis point is worth recording as verified-safe rather than as a finding:
+fresh publication in `acquire` does not take the guard, so a new lock can be
+published while a takeover is in progress. That is not a violation. The
+publisher competes through exclusive creation only, so the takeover's own
+create then fails with EEXIST and reports busy. One owner either way; the
+unguarded path can lose but cannot destroy.
+
+### 6.6 Residual, stated plainly
+
+POSIX has no compare-and-swap unlink or rename, so between any check and any
+pathname mutation there is a window. This change does not close that class of
+window and cannot with the primitives available.
+
+What it does buy: the guard now identifies its claimant, so the reclaim
+decision is about the claimant rather than the victim; a live claimant is never
+displaced, because abandonment is judged against a probe; the single-owner
+property for stale takeover is carried by an atomic rename rather than by the
+guard; and no path deletes a lock or claim it has not proved disposable. The
+defect in the issue fired on every stale takeover. What remains needs a crashed
+claimant, several concurrent processes and a specific stall.
+
+Closing the remainder means a real locking primitive — an OS file lock or a
+fencing/generation protocol — which is a separate piece of work.
+
+## 7. Follow-ups (not in this change)
+
+
+## 7. Implementation notes (Issue #3277, added during implementation)
+
+- **Deviations found when the tests were run against the unfixed code:**
+  - The plan stated T1 "MUST FAIL ON THE CURRENT CODE". In practice T1 PASSED
+    on the unfixed code. Under the old implementation the current code calls
+    `checkStaleWithPidReuse(guardPath)`, and T1's fixture writes the guard as
+    a **separate file** whose payload has this process's live PID with a fresh
+    timestamp. Even with the old guard code the reclaim predicate therefore reads the
+    guard's own content, sees a live claimant, and correctly refuses — so T1
+    rejects with `SessionLockedError` and the guard survives on both the old and the
+    new code. The old code only misbehaves when the guard *is* the lock inode,
+    which cannot be combined with an independent "live claimant" payload (writing a
+    payload through a hard link would rewrite the lock itself). T1 is kept exactly as
+    specified; it is a regression pin on the new guard format rather than a red/green
+    differentiator.
+  - An additional fixture-driven test that the old code genuinely fails was added to
+    the same describe block to close the gap: "removeStaleLock does not unlink a
+    live claimant guard when the lock is absent". With the lock absent, the old
+    `acquireTransitionGuard` returned true without installing anything and the caller's
+    `finally` still unlinked `guardPath` (the "release a guard we never created"
+    bug). The new code installs the claim even when the lock is absent and releases it
+    token-checked, so the guard survives. Verified RED against the unfixed code
+    (guard deleted, test failed with the readFile ENOENT) and GREEN after the fix.
+- `janitorLease.ts` uses the same hard-link claim protocol and the same
+  victim-content reclaim test. It should get the same identity treatment.
+- Replace the pathname-based transition guard with a real locking primitive (an
+  OS file lock, or a fencing/generation protocol). That is what would close the
+  residual in 6.6, and it is a redesign rather than a fix.
+- `release()` cannot report or retry a failed release, so an I/O error during
+  release leaks the lock until it goes stale. Pre-existing; changing it means
+  changing the public contract of `LockHandle.release`.
+- The protocol assumes a local filesystem. `link`, `rename` and `O_EXCL` are not
+  dependable over NFS or SMB, and `process.kill(pid, 0)` is host-local while a
+  lock carries no hostname. Worth stating in user-facing docs, or enforcing.

--- a/project-plans/issue3277/plan.md
+++ b/project-plans/issue3277/plan.md
@@ -369,7 +369,7 @@ capture can briefly be the only copy.
 
 | # | Finding | Disposition |
 | --- | --- | --- |
-| 1 | On the restore-failure path both `retireStaleLock` and `retireGuardIf` unlinked the capture, destroying what could be a live lock or claim. | **In-scope-Fix.** The capture is now left parked instead of deleted when it cannot be restored. |
+| 1 | On the restore-failure path both `retireStaleLock` and `retireGuardIf` unlinked the capture, destroying what could be a live lock or claim. | **In-scope-Fix**, later refined (see 6.7). The capture is parked rather than deleted when restoration fails for a reason other than the path already being occupied. |
 | 2 | `cleanupStaleLockTemp` reclaims `.locktmp` files on age alone, so it would destroy a parked live lock five minutes later, or one left behind by a crash between the rename and the restore. | **In-scope-Fix.** The sweep is now payload-aware: an aged temp whose payload names a live owner is kept. Content that does not parse, or that carries no usable pid, is still a partial publication artifact and is still reclaimed, so the existing sweep behaviour is unchanged for the artifacts it was written for. |
 
 Two behavioural tests were added in `SessionLockManager.test.ts` next to the
@@ -413,6 +413,35 @@ claimant, several concurrent processes and a specific stall.
 
 Closing the remainder means a real locking primitive — an OS file lock or a
 fencing/generation protocol — which is a separate piece of work.
+
+### 6.7 CI review: parking is only correct when restoration was actually possible
+
+The OpenCodeReview job on the PR pointed out that parking on every restore
+failure leaks a temp file for the lifetime of the owning process, because
+`namesLiveOwner` then refuses to sweep it. **In-scope-Fix**, and the reviewer is
+right on the substance, though the leak is bounded by the owner's process
+lifetime rather than permanent.
+
+Resolving it needed the question the earlier round had not asked: is a parked
+capture ever read back? It is not. Capture and probe names are single-use UUIDs
+that nothing records, and no code path restores a `.locktmp` into service. So
+parking buys recovery for nobody; the actual protection against destroying a
+live lock is the restore attempt itself.
+
+Restoration fails for two different reasons, and they deserve different
+answers:
+
+- **EEXIST.** Another lock or guard already occupies the well-known path. The
+  captured object is superseded and unreachable — its owner's `ownsLock()`
+  already reports false, and a superseded claimant can no longer pass
+  verification. Discarding it loses nothing, and parking it would leak.
+- **Anything else** (ENOSPC, EPERM, and friends). The path may well be empty and
+  the capture may be the only copy, so it stays parked and the payload-aware
+  sweep reclaims it once its owner is gone.
+
+`namesLiveOwner` stays, because it still governs that second case and crash
+leftovers, but the leak is now confined to genuine I/O failures rather than
+occurring on every lost race.
 
 ## 7. Follow-ups (not in this change)
 


### PR DESCRIPTION
## TLDR

The per-session transition guard in `SessionLockManager` was a hard link of the lock inode, so a guard's content was the content of the lock being taken over rather than anything about the process holding it. Reclaim asked whether that content looked stale, which during a stale takeover is true by construction, so every contender concluded the incumbent claimant had crashed and stole the guard. The guard serialized nothing in the one situation it exists for, and contention could resolve with zero winners.

The guard now carries its own identity, reclaim asks about the claimant rather than the victim, and retiring a stale lock uses an atomic `rename` so exactly one contender can remove it.

Reviewers should look hardest at `retireGuardIf` and `retireStaleLock` in `packages/core/src/recording/SessionLockManager.internals.ts`, and at the "What this protocol does not promise" paragraph in the module header, which states the limits rather than overclaiming.

## Dive Deeper

### The defect

`acquireTransitionGuard` claimed the guard with `link(lockPath, guardPath)`. One contender won; the rest got `EEXIST` and fell through to `tryReclaimGuard`, which decided whether the incumbent claim was abandoned by calling `checkStaleWithPidReuse(guardPath)`. Because the guard was a hard link of the lock, that inspected the **victim lock's** payload. During a stale takeover the victim is stale by definition, so every loser read a dead PID, concluded the claimant had crashed, unlinked the live claimant's guard and relinked its own.

`verifyTransitionClaim` could not catch it. It compared `stat(lockPath)` against `stat(guardPath)` by dev/ino, and a stolen guard is a hard link to the same inode, so the check passed for the thief and the victim alike.

Two more consequences came from the same root: `releaseTransitionGuard` unlinked unconditionally, so a contender deleted whatever guard happened to be installed; and when the lock did not exist, `acquireTransitionGuard` returned true without installing anything while the caller's `finally` still unlinked a guard it never owned.

### Why contention could produce zero winners

The reported symptom follows directly. Every contender believes it holds the guard and runs `read -> checkStale -> re-read -> verify -> unlink -> create`. Contenders are continuously unlinking and relinking `guardPath`, so the `stat(guardPath)` inside `verifyTransitionClaim` can throw `ENOENT` for each of them in turn. Each returns busy, nobody retires the stale lock, and the whole race finishes well inside the window a winner would have spent holding the lock. That matches the CI failure in the issue exactly: three `SKIP`s, 63 ms, lock left unclaimed.

### The change

**Guard identity.** The guard is a distinct file at `<lock>.tguard` whose payload is `{pid, timestamp, claimToken, lockDev, lockIno}`, installed exclusively via a temp file (`O_EXCL`) plus `link`. `pid` and `timestamp` reuse the key names `checkStaleWithPidReuse` already reads, so the existing PID-reuse rules answer "has the claimant gone away?" unchanged.

**Reclaim follows the claimant.** `isGuardAbandoned` gates reclaim on a `claimToken`. A guard without one is not a guard this code wrote — it is corrupt, or it is a pre-fix hard link describing the victim — so its claimant cannot be identified and it is busy until the existing 48-hour age bound applies. Without that gate the issue's own proof scenario still walks through a held guard. Orphaned legacy guards still converge, because the janitor sweep (unchanged predicate) removes safe-grammar guards whose payload PID is dead.

**Retirement never displaces a live claimant.** `retireGuardIf` judges a hard-link **probe** rather than the well-known path, so a guard that is still held is never renamed, unlinked, or even momentarily absent. Only a guard proved retirable is retired, by an atomic `rename` whose captured inode must equal the probed inode; a different guard installed in between is restored. `rename` also means exactly one of several concurrent reclaimers retires a given guard. The janitor's `cleanupStaleGuard` now goes through the same helper, so classifying a guard stale and removing it can no longer straddle another process installing a live claim.

**Verification detects theft.** `verifyTransitionClaim` requires the on-disk guard to still carry *this* claim's `claimToken` — which a thief cannot forge by relinking the lock inode — and the lock to still have the dev/ino recorded at claim time. Identities are read with `stat(..., { bigint: true })`, because Windows file IDs are 64-bit and number-valued inodes would let two distinct files compare equal.

**Release is ownership-checked.** A process unlinks the guard only while it still carries that process's token, and a process that never installed a guard never unlinks one.

**Stale-lock retirement is atomic.** `tryStaleTakeover` and `tryRemoveStaleLock` no longer `unlink(lockPath)`; they `rename` it out of the well-known path. `rename` is the only pathname primitive POSIX offers that removes a name and tells exactly one caller it did so, which is what makes contention resolve to a single owner. A bare `unlink` cannot tell "I removed the stale lock" from "I removed the replacement somebody just published". A contender that captures a lock whose content is not the payload it judged stale restores it rather than destroying it. This means the single-owner property no longer rests on the guard alone.

**Temp sweep is payload-aware.** A retirement capture can briefly be the only copy of a live lock, which was not true of `.locktmp` files before, so `cleanupStaleLockTemp` no longer reclaims on age alone. Content that is readable and either non-payload or owned by a dead PID is still reclaimed exactly as before; an unreadable file is treated as unknown and kept, since a file whose contents cannot be read can still be unlinked through a writable parent.

### What this does not fix

POSIX has no compare-and-swap unlink or rename, so between any check and any pathname mutation there is a window, and no pathname protocol closes that class. The module header now states this instead of claiming the guard "serializes ALL pathname mutations". The defect being fixed fired on every stale takeover; what remains needs a crashed claimant, several concurrent processes and a specific stall. Closing the remainder means a real locking primitive (an OS file lock, or a fencing protocol), which is a redesign and is recorded as a follow-up in `project-plans/issue3277/plan.md` along with the other deferred items.

`packages/core/src/recording/janitor/janitorLease.ts` implements a structurally similar hard-link claim for janitor leases and has the same class of bug. It is a separate mechanism with its own callers and tests, and the issue is scoped to `SessionLockManager`, so it is deliberately not touched here and is recorded as a follow-up.

## Reviewer Test Plan

The two tests that prove the defect fail against the unfixed implementation. To see that:

```bash
git checkout issue3277
git stash push -- packages/core/src/recording/SessionLockManager.internals.ts
cd packages/core && bun test src/recording/SessionLockManager.safety.test.ts
```

Expect two failures, the important one being:

```
(fail) a hard-link guard over a stale lock is not reclaimable and blocks takeover
  Expected promise that rejects
  Received promise that resolved: Promise { <resolved> }
```

That is the issue's proof scenario: a contender walks through a held guard and takes the lock. Then `git stash pop` and re-run; all 34 pass.

The reported symptom was an intermittent CI failure of the three-contender subprocess race, so it is worth running that suite repeatedly, and under load, since it only reproduced on busy runners:

```bash
cd packages/core
for i in $(seq 1 10); do bun test src/recording/SessionLockManager.safety.test.ts || echo FAILED; done

# and again with four spinning CPU hogs
for h in 1 2 3 4; do bash -c 'while :; do :; done' & done
for i in $(seq 1 8); do bun test src/recording/SessionLockManager.safety.test.ts || echo FAILED; done
kill %1 %2 %3 %4
```

Locally that was 10/10 unloaded and 18/18 loaded across two rounds, with no `LOST` and no leftover `.tguard` or `.locktmp`.

Exercising it as a user means resuming the same recorded session from two processes at the same moment after a previous process died. Before this change that could report "Session is in use by another process" for a session nothing was using; after it, one process gets the session.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the `stepfun-37` startup smoke test.

Linux is covered by this PR's CI. **Windows is not**: PR CI is ubuntu-only, since Windows and macOS test coverage moved to the nightly workflow under #2876. The nightly runs the `core` shard on windows-latest, so the first Windows exercise of this code happens there. What the change relies on is supported on NTFS — exclusive create maps to `CREATE_NEW`, hard links work, and same-volume rename to a fresh UUID name works — and inode identities are read as bigints specifically because Windows file IDs are 64-bit. But that is reasoning, not a green run, so it is worth watching the next nightly.

Two filesystem caveats, both documented in the module header. Filesystems without hard-link support (FAT, exFAT, some mapped network drives) will not work; that is pre-existing, because `tryCreateLock` already required `fs.link` and throws there. Network filesystems are not safe either: `O_EXCL` is not dependable over NFS, `link`/`rename` can report failure after the server applied them, and `process.kill(pid, 0)` is host-local while the lock records no hostname.

Full-suite failures seen locally were reproduced with these changes stashed (`RipgrepPathResolver` x4, the `dd of=` ReDoS timing budget, `config.folderTrustMcpWiring`) or were timeouts on a machine running a second checkout's test suite concurrently and pass in isolation. None are in `packages/core/src/recording`.

## Linked issues / bugs

Fixes #3277

Context: the guard and the failing test come from #3164 / #3201. Surfaced while running CI for #3276.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session lock recovery to prevent active or replacement locks from being removed accidentally.
  - Strengthened protection against concurrent lock takeovers and stale lock cleanup.
  - Preserved lock artifacts when ownership is active or cannot be verified.
  - Improved handling of abandoned, corrupted, and legacy lock guards.

- **Tests**
  - Added coverage for concurrent access, stale locks, abandoned claims, process reuse, and cleanup safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
