### PR TITLE
Surface acplint findings and identify the agent over ACP (Fixes #3095)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1240,11 +1240,9 @@ jobs:
           EXIT_CODE=$?
           echo "$EXIT_CODE" > "${ACPLINT_DIAG_DIR}/status.txt"
           echo "acplint raw exit status: $EXIT_CODE"
-          if [ "$EXIT_CODE" -ne 0 ]; then
-            echo '::group::acplint log tail'
-            tail -n 200 "${ACPLINT_DIAG_DIR}/acplint.log"
-            echo '::endgroup::'
-          fi
+          echo '::group::acplint log tail'
+          tail -n 200 "${ACPLINT_DIAG_DIR}/acplint.log"
+          echo '::endgroup::'
           exit 0
 
       - name: 'Validate acplint report'

--- a/dev-docs/acp-conformance.md
+++ b/dev-docs/acp-conformance.md
@@ -13,6 +13,27 @@ Full Conformance is the result of this deterministic gate, **not** full-suite
 ACP certification. The full 14-category acplint suite requires live model
 inference and is out of scope.
 
+## Agent Identification (REQ-3095-001)
+
+`initializeZedAgent` in `packages/cli/src/zed-integration/zed-initialize.ts`
+now includes `agentInfo` in the ACP `initialize` response:
+
+- `name`: `llxprt-code`
+- `version`: the value resolved by `getCliVersion()` from
+  `packages/cli/src/utils/version.ts`.
+
+No new version-resolution path was added; `agentInfo.version` uses the same
+documented `CLI_VERSION`-then-`package.json` resolution as everywhere else, and
+falls back to `unknown` when neither is available. `protocolVersion`,
+`authMethods`, and `agentCapabilities` are unchanged.
+
+Issue #3095 reproduced the earlier gap directly: the ACP SDK schema marks
+`agentInfo` as "in future versions of the protocol, this will be required", and a
+raw stdio probe of `./packages/cli/bin/llxprt --experimental-acp` returned
+only `protocolVersion`, `authMethods`, and `agentCapabilities`. The validator now
+enforces identification (see the findings gate below), so dropping `agentInfo` again
+fails CI instead of surfacing as a warning nobody reads.
+
 ## Lifecycle Triage
 
 ### Pre-fix baseline
@@ -119,7 +140,10 @@ Added to `.github/workflows/ci.yml`. The job:
    placeholder key (`acplint-ci`) initializes the provider; selected categories
    do not prompt a model or perform network inference.
 
-9. Captures the raw acplint exit status before validation.
+9. Captures the raw acplint exit status before validation. The step prints the
+   acplint log tail inside a collapsed `::group::` on every run, not only on a
+   nonzero exit, so interpreter-shutdown noise is visible in the job log and
+   attributable to acplint (issue #3095).
 10. Validates the JSON report with `scripts/validate-acplint-report.ts`.
 11. Always uploads the runner-temp diagnostics directory containing status,
     log, JSON, and LLxprt logs — even on failure. The upload uses
@@ -168,6 +192,63 @@ statuses are `PASS` and `SKIP`. The pinned v0.2.0 report schema enum is
 A status-1 (Partial) fixture is internally coherent with one selected row at
 `SKIP` and a matching category summary (15/16 passed → Partial Conformance).
 
+### Findings, summary, and agent-info gate (issue #3095)
+
+Every validator run prints a markdown summary before it decides pass or fail, so
+failing runs surface the same information a green one would. The summary shows the
+raw acplint status, the declared conformance level, agent identification (or
+"not reported"), per-category passed/failed/skipped/errored counts, every
+finding marked `known` or `UNEXPECTED`, and every result row that carries a
+message. The summary goes to stdout always and is appended to the file named by
+`GITHUB_STEP_SUMMARY` when that variable is set, never truncating it. When the
+report cannot be read or parsed, a short summary states that the report was
+unavailable and why, then the validator exits 1.
+
+The validator carries an exact allowlist of the three finding strings the
+selected categories cannot avoid producing on pinned acplint v0.2.0:
+
+- `⚠ No agent_thought_chunk notifications received at all`
+- `⚠ No available_commands_update notifications received — agent doesn't advertise commands/hooks`
+- `⚠ No usage_update notifications received — agent doesn't report usage`
+
+An allowlisted finding is recorded as known. Any finding outside the allowlist
+fails the gate and the rejection names the offending finding, so a new
+non-allowlisted finding turns the check red instead of hiding in the artifact.
+
+The allowlist buys that at a cost worth stating: the three notification findings
+are accepted unconditionally, so this gate cannot detect a regression in the
+behaviours they describe. If LLxprt stopped emitting `available_commands_update`
+on `session/new`, or stopped emitting `agent_thought_chunk` or `usage_update` on
+prompt turns, the selected categories would produce exactly the same three
+findings and the check would stay green. Detecting that needs the `streaming`
+and `plans` categories, which require live model inference. See Limitations.
+
+Findings two through four from the original issue are category artifacts, not LLxprt
+defects. acplint populates `update_types_seen` only inside its `streaming` and
+`plans` category handlers (`_assemble_findings` in the pinned `runner.py`),
+and neither category is selected by this gate, so every optional update type is
+reported as never seen. The same reproduction probed the live agent directly:
+`session/new` emitted `available_commands_update`, and LLxprt builds
+`usage_update` and emits `agent_thought_chunk` on prompt turns. The fourth
+finding, `No agentInfo in initialize response`, was real and is fixed by
+REQ-3095-001; it is deliberately not allowlisted, so the gate now enforces
+agent identification. The validator also rejects a report whose `agent_info` lacks a
+non-empty string `name` or non-empty string `version`; extra agent-provided keys
+remain allowed.
+
+### Python traceback noise (issue #3095)
+
+The original issue reported a `RuntimeError: Event loop is closed` traceback in the
+job log. It comes from acplint's own transport teardown: `AcpTransport.__aexit__`
+terminates the agent subprocess and awaits `wait()`, but never closes the asyncio
+subprocess transport. `asyncio.run()` then closes the loop, and when CPython
+garbage-collects the transport it retries `close()` on the closed loop and prints
+the message as "Exception ignored in" during interpreter shutdown. That path cannot
+change acplint's exit status. It is timing dependent and did not reproduce locally on
+Python 3.14/macOS. It is expected noise; since issue #3095 the job prints the
+acplint log tail on every run, so the traceback is visible inside the logs and
+attributable to acplint rather than to LLxprt.
+
 ## Artifacts
 
 The `acplint-diagnostics` artifact directory contains:
@@ -195,7 +276,11 @@ To update the acplint pin:
 4. Update the expected result rows in `scripts/validate-acplint-report.ts` if
    the report schema changed.
 5. Run the full acplint gate locally and confirm the report validates.
-6. Update this document with the new pin, version, and post-fix results.
+6. Re-derive the three allowlisted finding strings from `_assemble_findings` in
+   the new acplint revision and update the `ALLOWED_FINDINGS` list in
+   `scripts/validate-acplint-report.ts`, matching the strings byte for byte from a
+   fresh run. Verify the reported text with a byte dump; do not retype by eye.
+7. Update this document with the new pin, version, and post-fix results.
 
 ## Limitations
 
@@ -206,3 +291,9 @@ To update the acplint pin:
   are not fully locked. Full Python environment locking is deferred.
 - No streaming, tool-call, permissions, file-operations, terminal, plans,
   session-modes, config-options, cancel, or stress categories are exercised.
+- The gate cannot detect a regression in `agent_thought_chunk`,
+  `available_commands_update`, or `usage_update`. acplint reports all three as
+  never seen regardless of what LLxprt emits, because it only records update
+  types in the `streaming` and `plans` handlers, so those findings are
+  allowlisted and a genuine regression in them would still pass. Covering that
+  needs live model inference.

--- a/packages/cli/src/zed-integration/zed-initialize.test.ts
+++ b/packages/cli/src/zed-integration/zed-initialize.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the ACP initialize response (issue #3095). Drives the REAL
+ * initializeZedAgent with a typed Config stub; no mocks of the function under
+ * test. The version is driven through the documented __resetVersionCacheForTesting
+ * seam so each test observes the version the real getCliVersion() resolves for the
+ * process under test.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type { Config } from '@vybestack/llxprt-code-core';
+import * as acp from '@agentclientprotocol/sdk';
+import {
+  getCliVersion,
+  __resetVersionCacheForTesting,
+} from '../utils/version.js';
+import { initializeZedAgent } from './zed-initialize.js';
+
+const PROFILE_NAMES = ['default', 'stepfun-37'];
+
+function buildConfig(profileNames: string[] = PROFILE_NAMES): Config {
+  return {
+    getProfileManager: () => ({
+      listProfiles: async () => profileNames,
+    }),
+  } as unknown as Config;
+}
+
+let originalCliVersion: string | undefined;
+
+beforeEach(() => {
+  originalCliVersion = process.env.CLI_VERSION;
+});
+
+afterEach(() => {
+  if (originalCliVersion === undefined) {
+    delete process.env.CLI_VERSION;
+  } else {
+    process.env.CLI_VERSION = originalCliVersion;
+  }
+  __resetVersionCacheForTesting();
+});
+
+describe('initializeZedAgent', () => {
+  it('identifies itself as llxprt-code over ACP', async () => {
+    const response = await initializeZedAgent(buildConfig());
+
+    expect(response.agentInfo).toEqual({
+      name: 'llxprt-code',
+      version: expect.any(String),
+    });
+  });
+
+  it('reports the CLI version resolved by getCliVersion()', async () => {
+    process.env.CLI_VERSION = '9.9.9-acp-test';
+    __resetVersionCacheForTesting();
+    const expected = await getCliVersion();
+
+    const response = await initializeZedAgent(buildConfig());
+
+    expect(response.agentInfo?.version).toBe(expected);
+    expect(response.agentInfo?.version).toBe('9.9.9-acp-test');
+  });
+
+  it('keeps agentInfo present with a non-empty version when CLI_VERSION is absent', async () => {
+    delete process.env.CLI_VERSION;
+    __resetVersionCacheForTesting();
+
+    const response = await initializeZedAgent(buildConfig());
+
+    expect(response.agentInfo).toBeDefined();
+    expect(response.agentInfo).not.toBeNull();
+    const version = response.agentInfo?.version;
+    expect(typeof version).toBe('string');
+    expect(version?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('carries version `unknown` untouched when version resolution yields `unknown`', async () => {
+    process.env.CLI_VERSION = 'unknown';
+    __resetVersionCacheForTesting();
+
+    const response = await initializeZedAgent(buildConfig());
+
+    expect(await getCliVersion()).toBe('unknown');
+    expect(response.agentInfo).toEqual({
+      name: 'llxprt-code',
+      version: 'unknown',
+    });
+  });
+
+  it('does not change protocolVersion, authMethods, or agentCapabilities', async () => {
+    const response = await initializeZedAgent(buildConfig());
+
+    expect(response.protocolVersion).toBe(acp.PROTOCOL_VERSION);
+    expect(response.authMethods).toEqual(
+      PROFILE_NAMES.map((name) => ({ id: name, name, description: null })),
+    );
+    expect(response.agentCapabilities).toEqual({
+      loadSession: true,
+      sessionCapabilities: {
+        list: {},
+        resume: {},
+      },
+      promptCapabilities: {
+        image: true,
+        audio: true,
+        embeddedContext: true,
+      },
+    });
+  });
+});

--- a/packages/cli/src/zed-integration/zed-initialize.ts
+++ b/packages/cli/src/zed-integration/zed-initialize.ts
@@ -7,6 +7,7 @@
 import type { Config } from '@vybestack/llxprt-code-core';
 import * as acp from '@agentclientprotocol/sdk';
 import { loadProfileByName } from '@vybestack/llxprt-code-providers/runtime.js';
+import { getCliVersion } from '../utils/version.js';
 import { parseZedAuthMethodId } from './zed-helpers.js';
 
 export async function initializeZedAgent(
@@ -23,6 +24,10 @@ export async function initializeZedAgent(
   }
   return {
     protocolVersion: acp.PROTOCOL_VERSION,
+    agentInfo: {
+      name: 'llxprt-code',
+      version: await getCliVersion(),
+    },
     authMethods: profileNames.map((name) => ({
       id: name,
       name,

--- a/project-plans/issue3095/plan.md
+++ b/project-plans/issue3095/plan.md
@@ -1,0 +1,163 @@
+# Issue #3095 implementation plan
+
+Read `specification.md` first. Requirement IDs below refer to it.
+
+## Ordering
+
+Tests are written before the behaviour they describe. Each phase ends with the
+new tests failing for the right reason, then passing after the change.
+
+## Phase 1: agentInfo (REQ-3095-001)
+
+Files:
+
+- `packages/cli/src/zed-integration/zed-initialize.ts`
+- new behavioural tests in the zed-integration test suite
+
+Behaviour: `initializeZedAgent(config)` resolves an `InitializeResponse` whose
+`agentInfo` is `{ name: 'llxprt-code', version: <getCliVersion()> }`.
+
+Tests must assert observable output of the real function, not that a mock was
+called:
+
+1. `agentInfo.name` is `llxprt-code`.
+2. `agentInfo.version` equals the value `getCliVersion()` resolves to for the
+   process under test. Drive this through the documented seam:
+   set `process.env.CLI_VERSION`, call `__resetVersionCacheForTesting()`, and
+   assert the response carries that exact version. Restore the previous env and
+   reset the cache afterwards.
+3. When `CLI_VERSION` is absent the version is a non-empty string and
+   `agentInfo` is still present (never `undefined`, never `null`).
+4. `protocolVersion`, `authMethods`, and `agentCapabilities` are unchanged by
+   the addition (assert the existing shape still holds).
+
+Do not introduce a new version-resolution path. Reuse
+`packages/cli/src/utils/version.ts`.
+
+## Phase 2: validator summary and findings gate (REQ-3095-002/003/004)
+
+File: `scripts/validate-acplint-report.ts`, tests in
+`scripts/tests/validate-acplint-report.test.ts`.
+
+### Allowlist
+
+Add a frozen list of the exact expected finding strings. Write the leading
+warning sign as the escape `'\u26A0 '` in source rather than pasting the
+literal character, and source the rest of each string from acplint's
+`runner.py` at the pinned commit:
+
+- `_assemble_findings` agent_thought_chunk branch
+- `_assemble_findings` available_commands_update branch
+- `_assemble_findings` usage_update branch
+
+The em dashes inside two of those strings are U+2014 as emitted by acplint.
+Verify byte equality against the reproduced report, not by eye.
+
+### Summary emission
+
+Emit the summary before the accept/reject decision so failing runs surface it
+too. Structure the code as a pure function that takes the parsed report plus
+the raw status and returns the markdown string, and a thin writer that prints
+to stdout and appends to `GITHUB_STEP_SUMMARY` when that variable is set and
+non-empty. The pure function is what the tests exercise for content; the CLI
+behaviour is exercised end to end through `spawnSync`.
+
+When reading or parsing fails, emit a short summary stating the report was
+unavailable and the reason, then exit 1 as today.
+
+### New validation rules
+
+- Reject any finding not in the allowlist, naming it in the error.
+- Reject a report whose `agent_info` lacks a non-empty string `name` or a
+  non-empty string `version`.
+
+`agent_info` is currently typed `z.record(z.string(), z.unknown())`. Tighten it
+only as far as the requirement needs; keep unknown extra keys permitted.
+
+### Tests (behavioural, via spawnSync as the existing suite does)
+
+- Accepts a report whose findings are exactly the three allowlisted strings.
+- Accepts a report with an empty findings array.
+- Accepts a report with a strict subset of the allowlist.
+- Rejects a report containing the agentInfo finding, and stderr names it.
+- Rejects a report containing an arbitrary unknown finding.
+- Rejects `agent_info: {}`.
+- Rejects `agent_info` with an empty-string `name` or empty-string `version`.
+- Rejects `agent_info` whose `name` or `version` is a non-string.
+- Accepts `agent_info` carrying extra unknown keys alongside name and version.
+- Summary reaches stdout on success and on every rejection path, including the
+  unreadable-file and malformed-JSON paths.
+- Summary content includes the raw status, the conformance level, the agent
+  name and version, per-category counts, each finding marked known or
+  unexpected, and each result row message.
+- With `GITHUB_STEP_SUMMARY` pointed at a temp file, the same markdown is
+  appended to that file; existing file content is preserved (append, not
+  truncate).
+- With `GITHUB_STEP_SUMMARY` unset or empty, nothing is written and the process
+  still succeeds.
+
+Existing fixtures in that test file use `agent_info: {}`. Update the shared
+fixture builders to carry a valid `agent_info`, and keep dedicated fixtures for
+the new rejection cases. Do not weaken any existing assertion.
+
+## Phase 3: workflow log surfacing (REQ-3095-005)
+
+Files: `.github/workflows/ci.yml`, `scripts/tests/ci-acplint-workflow.test.ts`.
+
+Change the `Run acplint` step so the log tail is printed inside a `::group::`
+unconditionally. Keep writing `status.txt` before anything else can fail and
+keep the step exiting 0 so the validator step is what gates.
+
+The existing test `prints the acplint log tail when the raw status is nonzero`
+asserts `if [ "$EXIT_CODE" -ne 0 ]; then`. Replace it with a test asserting the
+tail is printed unconditionally, and keep asserting the group markers and the
+`acplint.log` path. Do not delete coverage; convert it.
+
+Add a test that the `Validate acplint report` step still runs the committed
+validator and that the job continues to upload diagnostics with `always()`.
+
+## Phase 4: documentation (REQ-3095-006)
+
+`dev-docs/acp-conformance.md`:
+
+- Record the `agentInfo` addition under the conformance behaviour.
+- New section covering findings: what acplint reports, why three of them are
+  category artifacts (cite `runner.py` populating `update_types_seen` only in
+  the streaming and plans handlers), the evidence that LLxprt does emit
+  `available_commands_update` on `session/new`, the allowlist, and the rule
+  that an unknown finding fails the gate.
+- New subsection explaining the `RuntimeError: Event loop is closed` traceback:
+  where it comes from in acplint's transport teardown, why it cannot affect the
+  exit status, and that it is expected noise.
+- Extend the version-update procedure with a step to re-derive the allowlisted
+  finding strings from the new acplint revision.
+
+Do not claim broader conformance than the three deterministic categories give.
+
+## Verification
+
+Run the full cycle and fix everything it reports:
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Then re-run the real gate end to end and confirm it is green with the change:
+
+```bash
+python3 -m venv /tmp/acplint-venv
+/tmp/acplint-venv/bin/python -m pip install \
+  "acplint @ git+https://github.com/rinadelph/acplint.git@e2f4e49b3ba825869a4ecab7e10076d4460f4dcd"
+# run with isolated LLXPRT_CONFIG_HOME/LLXPRT_DATA_HOME/LLXPRT_LOG_HOME and the
+# same arguments the CI job uses, then:
+node scripts/validate-acplint-report.ts <report.json> <status>
+```
+
+Required evidence: the post-change report shows a populated `agent_info`, the
+agentInfo finding is gone, exactly the three allowlisted findings remain, the
+validator exits 0, and its summary lists all three as known.

--- a/project-plans/issue3095/specification.md
+++ b/project-plans/issue3095/specification.md
@@ -1,0 +1,174 @@
+# Issue #3095 : ACP lint findings must be surfaced, and the real gap fixed
+
+## Problem
+
+The `acp_conformance` CI job runs pinned acplint v0.2.0 over three
+deterministic categories and passes when the JSON report validates. Three
+problems were reported:
+
+1. A Python traceback (`RuntimeError: Event loop is closed`) appeared in the
+   job log with no explanation of what it means or whether it matters.
+2. The uploaded `report.json` carried four `findings` entries that nobody ever
+   sees, including one claiming LLxprt does not advertise commands/hooks or
+   usage.
+3. The job reports only pass/fail. Findings never surface, so a report full of
+   warnings still shows a green check and an artifact nobody opens.
+
+## Evidence gathered before writing this specification
+
+### Reproduction
+
+The pinned acplint commit `e2f4e49b3ba825869a4ecab7e10076d4460f4dcd` was
+installed into a clean virtualenv and run against the built launcher with the
+exact CI arguments and isolated `LLXPRT_CONFIG_HOME` / `LLXPRT_DATA_HOME` /
+`LLXPRT_LOG_HOME`. It exited 0 with **Full Conformance**, 16/16 PASS, and
+reproduced the issue's four findings byte for byte:
+
+```text
+\u26a0 No agentInfo in initialize response - agents should identify themselves
+\u26a0 No agent_thought_chunk notifications received at all
+\u26a0 No available_commands_update notifications received - agent doesn't advertise commands/hooks
+\u26a0 No usage_update notifications received - agent doesn't report usage
+```
+
+(The leading `\u26a0` is a literal U+26A0 WARNING SIGN followed by a space in
+acplint's output, and the `-` characters shown here are em dashes in the real
+strings. Source them from `runner.py`, never by retyping.)
+
+`agent_info` in the report was `{}`, and `coverage_methods_exercised` reported
+`"update_types_seen": []`.
+
+### Finding 1 is real
+
+A direct ACP stdio probe (raw JSON-RPC `initialize` against
+`./packages/cli/bin/llxprt --experimental-acp`) returned exactly
+`protocolVersion`, `authMethods`, `agentCapabilities`. There is no `agentInfo`.
+`packages/cli/src/zed-integration/zed-initialize.ts` never sets it, and the ACP
+schema (`@agentclientprotocol/sdk` 1.2.1) documents `agentInfo` as
+"in future versions of the protocol, this will be required".
+
+**This is a genuine incomplete-ACP-support gap and is fixed here.**
+
+### Findings 2–4 are false positives of the category selection
+
+The same probe issued `session/new` and captured the notifications LLxprt
+emitted. It received `available_commands_update`. LLxprt calls
+`session.sendAvailableCommands()` inside `newSession` and both `loadSession`
+paths (`packages/cli/src/zed-integration/zedIntegration.ts`), builds
+`usage_update` in `zed-helpers.ts`, and emits `agent_thought_chunk` from
+`zed-stream-batcher.ts` and `zed-session-replay.ts`.
+
+acplint only adds to `_coverage["update_types_seen"]` inside its `streaming`
+and `plans` category handlers (`runner.py` lines 630 and 1406). Neither
+category is selected by the deterministic gate, so `update_types_seen` is
+always empty, and `_assemble_findings()` then reports every optional update
+type as never seen. The three notification findings are artifacts of running a
+subset of categories, not LLxprt defects.
+
+**No LLxprt behaviour change is warranted for findings 2–4. They are recorded
+as known, explained, expected findings.**
+
+### The Python traceback is upstream teardown noise
+
+acplint's `AcpTransport.__aexit__` terminates the agent subprocess and awaits
+`wait()`, but never closes the asyncio subprocess transport. `run_all()` then
+returns from `asyncio.run()`, which closes the event loop. When CPython later
+garbage-collects `BaseSubprocessTransport`, its `__del__` calls `close()` on a
+closed loop and prints `RuntimeError: Event loop is closed`.
+
+The message is printed by the interpreter during shutdown as
+"Exception ignored in", so it cannot change acplint's exit status. It did not
+reproduce locally on Python 3.14/macOS and is timing dependent, which matches an
+interpreter-shutdown GC race rather than an LLxprt fault.
+
+**No LLxprt behaviour change is warranted. The gate must make this noise
+visible and attributable instead of mysterious.**
+
+## Accepted behaviour
+
+### REQ-3095-001 : LLxprt identifies itself over ACP
+
+`initializeZedAgent` includes `agentInfo` in the `initialize` response with:
+
+- `name`: the stable programmatic identifier `llxprt-code`
+- `version`: the value resolved by `getCliVersion()`
+
+Boundary cases:
+
+- When version resolution yields `unknown` (no `CLI_VERSION` env and no
+  readable package.json), `agentInfo.version` is `unknown`. `agentInfo` is
+  still present; the field is never omitted and never `null`.
+- Adding `agentInfo` does not change `protocolVersion`, `authMethods`, or
+  `agentCapabilities`.
+
+### REQ-3095-002 : Every acplint run emits an inspectable summary
+
+`scripts/validate-acplint-report.ts` writes a human-readable summary before it
+decides pass or fail, so the summary exists for failing runs too. The summary
+contains:
+
+- the raw acplint status and the declared conformance level
+- `agent_info` (name and version, or an explicit "not reported")
+- per-category passed/failed/skipped/errored counts
+- every finding, each marked `known` or `UNEXPECTED`
+- every result row carrying a non-null message
+
+The summary goes to stdout always, and is additionally appended to the file
+named by `GITHUB_STEP_SUMMARY` when that variable is set and non-empty. When
+the report cannot be read or parsed, the summary still emits, stating that the
+report was unavailable and why.
+
+### REQ-3095-003 : Unknown findings fail the gate
+
+The validator carries an explicit allowlist of the exact finding strings that
+the selected deterministic categories cannot avoid producing:
+
+```text
+⚠ No agent_thought_chunk notifications received at all
+⚠ No available_commands_update notifications received — agent doesn't advertise commands/hooks
+⚠ No usage_update notifications received — agent doesn't report usage
+```
+
+Validation rules:
+
+- A report whose findings are a subset of the allowlist is accepted.
+- A report containing any finding outside the allowlist is rejected, and the
+  rejection names the offending finding.
+- A report with no findings is accepted.
+- The allowlist is matched by exact string equality against the pinned v0.2.0
+  finding text.
+
+This is what makes a new ACP gap surface as a red check instead of a silent
+green one. The pre-existing agentInfo finding is deliberately not allowlisted,
+so REQ-3095-001 is enforced by the gate rather than by hope.
+
+### REQ-3095-004 : The gate asserts the agent identified itself
+
+The validator rejects a report whose `agent_info` lacks a non-empty `name` or a
+non-empty `version`. This turns REQ-3095-001 into a CI-enforced invariant: if
+`agentInfo` is ever dropped from the initialize response, the gate fails.
+
+### REQ-3095-005 : The acplint log is always shown
+
+The `Run acplint` step prints the acplint log tail inside a collapsed
+`::group::` on every run, not only when the raw exit status is nonzero, so
+interpreter-shutdown noise like the reported traceback is visible in the job
+log and attributable to acplint rather than to LLxprt.
+
+### REQ-3095-006 : Documentation
+
+`dev-docs/acp-conformance.md` records: the agentInfo change, the findings
+surfacing and allowlist with the evidence that findings 2–4 are category
+artifacts, the root cause of the Python traceback, and the extra steps required
+when the acplint pin is updated (re-check the allowlisted finding strings).
+
+## Out of scope
+
+- Auto-filing GitHub issues from CI for findings. Surfacing is done through the
+  job summary and the gate.
+- Enabling the remaining eleven acplint categories, which need live model
+  inference.
+- Patching or forking acplint to fix its asyncio teardown or its coverage
+  tracking.
+- Any change to session lifecycle, storage format, transport, or capabilities
+  beyond adding `agentInfo`.

--- a/scripts/tests/ci-acplint-workflow.test.ts
+++ b/scripts/tests/ci-acplint-workflow.test.ts
@@ -5,10 +5,35 @@
  */
 
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
-import { describe, it, expect, beforeAll } from 'bun:test';
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, join } from 'node:path';
 import type { WorkflowDocument, WorkflowJob } from './typed-test-helpers.ts';
 import { parseWorkflowYaml, asOptionalRecord } from './typed-test-helpers.ts';
 import { readRootFile, stepNamed } from './ocr-review-workflow-helpers.ts';
+
+const ROOT = dirname(dirname(__dirname));
+
+const tmpDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'acplint-workflow-'));
+  tmpDirs.push(dir);
+  return dir;
+}
 
 const ACPLINT_PIN =
   'acplint @ git+https://github.com/rinadelph/acplint.git@e2f4e49b3ba825869a4ecab7e10076d4460f4dcd';
@@ -292,11 +317,61 @@ describe('Issue #2564: acp_conformance CI job', () => {
     expect(runStep.run).toContain('status.txt');
   });
 
-  it('prints the acplint log tail when the raw status is nonzero', () => {
+  it('prints the acplint log tail unconditionally inside a collapsed group', () => {
     const runStep = stepNamed(acpJob, 'Run acplint');
-    expect(runStep.run).toContain('if [ "$EXIT_CODE" -ne 0 ]; then');
+    expect(runStep.run).toContain('::group::acplint log tail');
+    expect(runStep.run).toContain('::endgroup::');
     expect(runStep.run).toContain('tail');
     expect(runStep.run).toContain('acplint.log');
+    expect(runStep.run).not.toContain('if [ "$EXIT_CODE" -ne 0 ]; then');
+  });
+
+  it('executes the Run acplint shell with a fake acplint for both raw statuses', () => {
+    const runStep = stepNamed(acpJob, 'Run acplint');
+    const scripts = runStep.run ?? '';
+    const fakeAcplint = [
+      '#!/bin/bash',
+      "printf '%s' 'FAKE_ACPLINT_LOG_LINE_3095'",
+      'exit $ACPLINT_RAW_STATUS',
+    ].join('\n');
+    for (const rawStatus of ['0', '7']) {
+      const diagDir = makeTmpDir();
+      writeFileSync(join(diagDir, 'acplint.log'), 'ignored\n', 'utf8');
+      const binDir = join(diagDir, 'bin');
+      mkdirSync(binDir);
+      writeFileSync(join(binDir, 'acplint'), fakeAcplint, {
+        mode: 0o755,
+      });
+      const result = spawnSync('bash', ['-c', scripts], {
+        encoding: 'utf8',
+        cwd: ROOT,
+        env: {
+          PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+          ACPLINT_DIAG_DIR: diagDir,
+          ACPLINT_RAW_STATUS: rawStatus,
+          GITHUB_WORKSPACE: ROOT,
+        },
+      });
+      if (result.error !== undefined) {
+        throw new Error(`failed to spawn the Run acplint shell`, {
+          cause: result.error,
+        });
+      }
+      expect(result.status, result.stderr).toBe(0);
+      const statusText = readFileSync(join(diagDir, 'status.txt'), 'utf8');
+      expect(statusText.trim()).toBe(rawStatus);
+      expect(result.stdout).toContain('acplint raw exit status');
+      expect(result.stdout).toContain('::group::acplint log tail');
+      expect(result.stdout).toContain('::endgroup::');
+      expect(result.stdout).toContain('FAKE_ACPLINT_LOG_LINE_3095');
+    }
+  });
+
+  it('keeps gating validation on the committed validator and always-uploading diagnostics', () => {
+    const validateStep = stepNamed(acpJob, 'Validate acplint report');
+    expect(validateStep.run).toContain('scripts/validate-acplint-report.ts');
+    const uploadStep = stepNamed(acpJob, 'Upload acplint diagnostics');
+    expect(uploadStep.if).toContain('always()');
   });
 
   it('captures the acplint JSON output via --output-file', () => {

--- a/scripts/tests/validate-acplint-report.test.ts
+++ b/scripts/tests/validate-acplint-report.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, afterAll } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -59,6 +59,19 @@ function normalizeResult(result: {
   };
 }
 
+/**
+ * The validator appends its summary to GITHUB_STEP_SUMMARY whenever that variable is
+ * set. Under GitHub Actions the runner sets it, so an inherited environment would make
+ * every spawn here append to the real job summary, including the oversized-summary
+ * case below. Each spawn therefore starts from an environment with that variable
+ * removed, and the tests that exercise it set it back explicitly.
+ */
+function baseEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env['GITHUB_STEP_SUMMARY'];
+  return env;
+}
+
 function runValidator(reportJson: string, status: number): RunResult {
   return runValidatorRawStatus(reportJson, String(status));
 }
@@ -77,6 +90,7 @@ function runValidatorRawStatus(
       encoding: 'utf8',
       timeout: 15_000,
       cwd: repoRoot,
+      env: baseEnv(),
     },
   );
   return normalizeResult(result);
@@ -92,10 +106,64 @@ function runValidatorMissingFile(status: number): RunResult {
       encoding: 'utf8',
       timeout: 15_000,
       cwd: repoRoot,
+      env: baseEnv(),
     },
   );
   return normalizeResult(result);
 }
+
+function runValidatorWithEnv(
+  reportJson: string,
+  status: number,
+  envOverrides: Record<string, string>,
+  removeKeys: readonly string[] = [],
+): RunResult {
+  const dir = makeTmpDir();
+  const reportPath = join(dir, 'report.json');
+  writeFileSync(reportPath, reportJson, 'utf8');
+  const env = baseEnv();
+  for (const key of removeKeys) {
+    delete env[key];
+  }
+  const result = spawnSync(
+    process.execPath,
+    [validatorScript, reportPath, String(status)],
+    {
+      encoding: 'utf8',
+      timeout: 15_000,
+      cwd: repoRoot,
+      env: { ...env, ...envOverrides },
+    },
+  );
+  return normalizeResult(result);
+}
+
+function runValidatorArgv(
+  args: readonly string[],
+  envOverrides: Record<string, string> = {},
+): RunResult {
+  const result = spawnSync(process.execPath, [validatorScript, ...args], {
+    encoding: 'utf8',
+    timeout: 15_000,
+    cwd: repoRoot,
+    env: { ...baseEnv(), ...envOverrides },
+  });
+  return normalizeResult(result);
+}
+
+/**
+ * The exact three finding strings the selected deterministic categories produce on the
+ * pinned acplint. The U+26A0 WARNING SIGN and U+2014 EM DASH characters are
+ * written escaped so the source stays ASCII and byte-equal to the report text.
+ */
+const ALLOWED_FINDINGS = [
+  '\u26A0 No agent_thought_chunk notifications received at all',
+  "\u26A0 No available_commands_update notifications received \u2014 agent doesn't advertise commands/hooks",
+  "\u26A0 No usage_update notifications received \u2014 agent doesn't report usage",
+];
+
+const AGENT_INFO_FINDING =
+  '\u26A0 No agentInfo in initialize response \u2014 agents should identify themselves';
 
 interface ResultRow {
   name: string;
@@ -229,7 +297,7 @@ function partialSelectedRows(): ResultRow[] {
 function fullPassReport(): string {
   return JSON.stringify({
     conformance_level: 'Full Conformance',
-    agent_info: {},
+    agent_info: { name: 'llxprt-code', version: '0.0.0-test' },
     findings: [],
     results: allSelectedRows(),
     summary: buildSummary(),
@@ -239,7 +307,7 @@ function fullPassReport(): string {
 function partialReport(): string {
   return JSON.stringify({
     conformance_level: 'Partial Conformance',
-    agent_info: {},
+    agent_info: { name: 'llxprt-code', version: '0.0.0-test' },
     findings: [],
     results: partialSelectedRows(),
     summary: buildPartialSummary(),
@@ -520,5 +588,277 @@ describe('acplint report validator (issue #2564)', () => {
     const result = runValidatorMissingFile(0);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('failed to read report file');
+  });
+});
+
+describe('acplint findings gate and summary (issue #3095)', () => {
+  it('accepts a report whose findings are exactly the three allowlisted strings', () => {
+    const report = JSON.parse(fullPassReport());
+    report.findings = [...ALLOWED_FINDINGS];
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('acplint report validated successfully');
+  });
+
+  it('accepts a report with an empty findings array', () => {
+    const result = runValidator(fullPassReport(), 0);
+    expect(result.status).toBe(0);
+  });
+
+  it('accepts a report with a strict subset of the allowlist', () => {
+    const report = JSON.parse(fullPassReport());
+    report.findings = [ALLOWED_FINDINGS[0], ALLOWED_FINDINGS[2]];
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(0);
+  });
+
+  it('rejects a report containing the agentInfo finding and names it', () => {
+    const report = JSON.parse(fullPassReport());
+    report.findings = [AGENT_INFO_FINDING];
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('unexpected acplint finding');
+    expect(result.stderr).toContain('No agentInfo in initialize response');
+  });
+
+  it('rejects a report containing an arbitrary unknown finding', () => {
+    const report = JSON.parse(fullPassReport());
+    report.findings = [ALLOWED_FINDINGS[0], 'unknown finding text'];
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('unknown finding text');
+  });
+
+  it('rejects agent_info {}', () => {
+    const report = JSON.parse(fullPassReport());
+    report.agent_info = {};
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'agent_info.name must be a non-empty string',
+    );
+  });
+
+  it('still emits the full summary when the agent never identified itself', () => {
+    const report = JSON.parse(fullPassReport());
+    report.agent_info = {};
+    report.findings = [ALLOWED_FINDINGS[0]];
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('Agent identification: not reported');
+    expect(result.stdout).toContain('[known]');
+    expect(result.stdout).toContain('schema_validation | 4 | 0 | 0 | 0');
+    expect(result.stdout).not.toContain('unavailable');
+  });
+
+  it('rejects agent_info with an empty-string name', () => {
+    const report = JSON.parse(fullPassReport());
+    report.agent_info = { name: '', version: '0.0.0-test' };
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(1);
+  });
+
+  it('rejects agent_info with an empty-string version', () => {
+    const report = JSON.parse(fullPassReport());
+    report.agent_info = { name: 'llxprt-code', version: '' };
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(1);
+  });
+
+  it('rejects agent_info whose name is a non-string', () => {
+    const report = JSON.parse(fullPassReport());
+    report.agent_info = { name: 42, version: '0.0.0-test' };
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(1);
+  });
+
+  it('rejects agent_info whose version is a non-string', () => {
+    const report = JSON.parse(fullPassReport());
+    report.agent_info = { name: 'llxprt-code', version: 42 };
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(1);
+  });
+
+  it('accepts agent_info carrying extra unknown keys alongside name and version', () => {
+    const report = JSON.parse(fullPassReport());
+    report.agent_info = {
+      name: 'llxprt-code',
+      version: '0.0.0-test',
+      custom_field: { nested: true },
+    };
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(0);
+  });
+
+  it('emits a summary to stdout on success', () => {
+    const result = runValidator(fullPassReport(), 0);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('## ACP conformance report');
+  });
+
+  it('emits a summary to stdout when the report file is unreadable', () => {
+    const result = runValidatorMissingFile(0);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('## ACP conformance report');
+    expect(result.stdout).toContain('unavailable');
+    expect(result.stdout).toContain('failed to read report file');
+  });
+
+  it('emits a summary to stdout on malformed JSON', () => {
+    const result = runValidator('{ not valid json', 0);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('## ACP conformance report');
+    expect(result.stdout).toContain('unavailable');
+  });
+
+  it('emits a summary to stdout on a rejected report', () => {
+    const result = runValidator(fullPassReport(), 1);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('## ACP conformance report');
+  });
+
+  it('summary includes the raw status, conformance level, agent info, counts, findings, and result messages', () => {
+    const report = JSON.parse(fullPassReport());
+    report.findings = [ALLOWED_FINDINGS[0], 'some unexpected finding'];
+    const row = report.results.find(
+      (r: ResultRow) => r.name === 'delete_session',
+    );
+    row.message = 'some result message text';
+    const result = runValidator(JSON.stringify(report), 0);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('Raw acplint status: `0`');
+    expect(result.stdout).toContain('Full Conformance');
+    expect(result.stdout).toContain('name=`llxprt-code` version=`0.0.0-test`');
+    expect(result.stdout).toContain('[known]');
+    expect(result.stdout).toContain('[UNEXPECTED]');
+    expect(result.stdout).toContain('some result message text');
+    expect(result.stdout).toContain('schema_validation | 4 | 0 | 0 | 0');
+  });
+
+  it('appends the same summary to GITHUB_STEP_SUMMARY preserving existing content', () => {
+    const dir = makeTmpDir();
+    const summaryPath = join(dir, 'step-summary.md');
+    const preexisting = 'preexisting summary line\n';
+    writeFileSync(summaryPath, preexisting, 'utf8');
+    const result = runValidatorWithEnv(fullPassReport(), 0, {
+      GITHUB_STEP_SUMMARY: summaryPath,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('acplint report validated successfully');
+    const summaryMarkdown = result.stdout
+      .slice(0, result.stdout.indexOf('acplint report validated successfully'))
+      .replace(/\n$/, '');
+    const content = readFileSync(summaryPath, 'utf8');
+    expect(content).toBe(`${preexisting}${summaryMarkdown}\n`);
+  });
+
+  it('emits the unavailable summary to GITHUB_STEP_SUMMARY on an unreadable report', () => {
+    const dir = makeTmpDir();
+    const summaryPath = join(dir, 'step-summary.md');
+    writeFileSync(summaryPath, 'preexisting\n', 'utf8');
+    const missingPath = join(dir, 'missing.json');
+    const result = spawnSync(
+      process.execPath,
+      [validatorScript, missingPath, '0'],
+      {
+        encoding: 'utf8',
+        timeout: 15_000,
+        cwd: repoRoot,
+        env: { ...baseEnv(), GITHUB_STEP_SUMMARY: summaryPath },
+      },
+    );
+    expect(result.status).toBe(1);
+    const content = readFileSync(summaryPath, 'utf8');
+    expect(content).toContain('preexisting');
+    expect(content).toContain('unavailable');
+  });
+
+  it('writes nothing to a summary file and still succeeds when GITHUB_STEP_SUMMARY is empty', () => {
+    const result = runValidatorWithEnv(fullPassReport(), 0, {
+      GITHUB_STEP_SUMMARY: '',
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('acplint report validated successfully');
+  });
+
+  it('succeeds when GITHUB_STEP_SUMMARY is unset', () => {
+    const result = runValidatorWithEnv(fullPassReport(), 0, {}, [
+      'GITHUB_STEP_SUMMARY',
+    ]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('acplint report validated successfully');
+  });
+
+  it('emits an unavailable summary naming the invalid invocation on wrong argument count', () => {
+    const result = runValidatorArgv([]);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('## ACP conformance report');
+    expect(result.stdout).toContain('unavailable');
+    expect(result.stdout).toContain('invalid invocation');
+  });
+
+  it('emits an unavailable summary naming the invalid status on a non-numeric status', () => {
+    const result = runValidatorArgv(['whatever.json', 'abc']);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('## ACP conformance report');
+    expect(result.stdout).toContain('unavailable');
+    expect(result.stdout).toContain('invalid status');
+    expect(result.stdout).toContain('abc');
+  });
+
+  it('reaches GITHUB_STEP_SUMMARY on the wrong-argument-count rejection', () => {
+    const dir = makeTmpDir();
+    const summaryPath = join(dir, 'step-summary.md');
+    writeFileSync(summaryPath, 'preexisting\n', 'utf8');
+    const result = runValidatorArgv([], {
+      GITHUB_STEP_SUMMARY: summaryPath,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('invalid invocation');
+    const content = readFileSync(summaryPath, 'utf8');
+    expect(content).toContain('## ACP conformance report');
+    expect(content).toContain('invalid invocation');
+  });
+
+  it('reaches GITHUB_STEP_SUMMARY on the non-numeric-status rejection', () => {
+    const dir = makeTmpDir();
+    const summaryPath = join(dir, 'step-summary.md');
+    writeFileSync(summaryPath, 'preexisting\n', 'utf8');
+    const result = runValidatorArgv(['whatever.json', 'zz'], {
+      GITHUB_STEP_SUMMARY: summaryPath,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('invalid status');
+    const content = readFileSync(summaryPath, 'utf8');
+    expect(content).toContain('## ACP conformance report');
+    expect(content).toContain('invalid status');
+  });
+
+  it('does not truncate a summary larger than the 64 KB pipe buffer', () => {
+    const bigMessage = 'x'.repeat(2 * 1024 * 1024);
+    const report = JSON.parse(fullPassReport());
+    report.findings = [ALLOWED_FINDINGS[0], 'some unexpected finding'];
+    const row = report.results.find(
+      (r: ResultRow) => r.name === 'delete_session',
+    );
+    row.message = bigMessage;
+    const dir = makeTmpDir();
+    const reportPath = join(dir, 'report.json');
+    writeFileSync(reportPath, JSON.stringify(report), 'utf8');
+    const result = spawnSync(
+      process.execPath,
+      [validatorScript, reportPath, '0'],
+      {
+        encoding: 'utf8',
+        timeout: 15_000,
+        cwd: repoRoot,
+        maxBuffer: 16 * 1024 * 1024,
+        env: baseEnv(),
+      },
+    );
+    expect(result.status).toBe(1);
+    const lastSummaryLine =
+      '- `session_lifecycle/delete_session`: ' + bigMessage;
+    expect(result.stdout.includes(lastSummaryLine)).toBe(true);
   });
 });

--- a/scripts/validate-acplint-report.ts
+++ b/scripts/validate-acplint-report.ts
@@ -9,9 +9,14 @@
  *
  * Usage: node scripts/validate-acplint-report.ts <report-json-path> <status>
  * Exit 0 = valid, exit 1 = invalid.
+ *
+ * Before deciding pass or fail the validator prints a human-readable markdown
+ * summary to stdout and appends it to the file named by GITHUB_STEP_SUMMARY when
+ * that variable is set, so failing runs surface status, findings, and agent
+ * identification instead of a bare red check.
  */
 
-import { readFileSync } from 'node:fs';
+import { appendFileSync, readFileSync } from 'node:fs';
 import { z } from 'zod';
 
 const SELECTED_CATEGORIES = [
@@ -49,6 +54,21 @@ const EXPECTED_RESULT_ROWS = {
 
 const ACCEPTED_ROW_STATUSES = new Set(['PASS', 'SKIP']);
 
+/**
+ * The exact finding strings the three selected deterministic categories cannot avoid
+ * producing on pinned acplint v0.2.0. Each is written with the U+26A0
+ * WARNING SIGN as the escaped form, and the two notification findings reproduce the
+ * U+2014 EM DASH from acplint's `_assemble_findings` output byte for byte.
+ * Any finding outside this list fails the gate so a new ACP gap surfaces as a red
+ * check. The pre-fix agentInfo finding is deliberately absent; REQ-3095-001 is
+ * enforced here instead of by hope.
+ */
+const ALLOWED_FINDINGS: readonly string[] = Object.freeze([
+  '\u26A0 No agent_thought_chunk notifications received at all',
+  "\u26A0 No available_commands_update notifications received \u2014 agent doesn't advertise commands/hooks",
+  "\u26A0 No usage_update notifications received \u2014 agent doesn't report usage",
+]);
+
 const ResultRowSchema = z
   .object({
     name: z.string().min(1),
@@ -70,6 +90,21 @@ const CategorySummarySchema = z
   })
   .strict();
 
+/**
+ * `agent_info` is acplint's echo of the agent's `initialize` response, so name and
+ * version are optional at the schema layer: an agent that never identified itself
+ * yields `{}`. Requiring them here would divert that exact regression into the
+ * unparseable-report path and lose the summary. Non-emptiness is enforced in
+ * `validateAgentInfo` instead (REQ-3095-004), after the summary has been emitted.
+ * Extra agent-provided keys remain permitted.
+ */
+const AgentInfoSchema = z
+  .object({
+    name: z.string().optional(),
+    version: z.string().optional(),
+  })
+  .passthrough();
+
 const AcplintReportSchema = z
   .object({
     conformance_level: z.enum([
@@ -77,7 +112,7 @@ const AcplintReportSchema = z
       'Partial Conformance',
       'Non-Conformant',
     ]),
-    agent_info: z.record(z.string(), z.unknown()),
+    agent_info: AgentInfoSchema,
     findings: z.array(z.string()),
     results: z.array(ResultRowSchema),
     summary: z.record(z.string(), CategorySummarySchema),
@@ -87,6 +122,116 @@ const AcplintReportSchema = z
 type AcplintReport = z.infer<typeof AcplintReportSchema>;
 type AcplintResultRow = z.infer<typeof ResultRowSchema>;
 type ConformanceLevel = AcplintReport['conformance_level'];
+
+/**
+ * Renders the per-category counts present in the report, selected categories first in
+ * a fixed order and any unexpected keys after, alphabetically. Uses the report's own
+ * summary map so a missing category key cannot crash the summary emission.
+ */
+function categorySummaryRows(report: AcplintReport): string[] {
+  const ordered = new Set<string>([
+    ...SELECTED_CATEGORIES,
+    ...Object.keys(report.summary).sort(),
+  ]);
+  const rows: string[] = [];
+  for (const key of ordered) {
+    const summary = report.summary[key];
+    if (summary === undefined) {
+      continue;
+    }
+    rows.push(
+      `| ${key} | ${summary.passed} | ${summary.failed} | ${summary.skipped} | ${summary.errored} |`,
+    );
+  }
+  return rows;
+}
+
+function isNonEmpty(value: string | undefined): value is string {
+  return value !== undefined && value.length > 0;
+}
+
+/**
+ * Renders the agent's self-identification for the summary. A report where acplint
+ * recorded no usable name or version reads "not reported" rather than being dropped,
+ * so the summary still explains why the run is about to be rejected.
+ */
+function formatAgentIdentification(agentInfo: AcplintReport['agent_info']) {
+  const { name, version } = agentInfo;
+  if (!isNonEmpty(name) || !isNonEmpty(version)) {
+    return 'not reported';
+  }
+  return `name=\`${name}\` version=\`${version}\``;
+}
+
+/**
+ * The human-readable markdown summary emitted on every run before the pass/fail
+ * decision: raw status, conformance level, agent identification (or "not reported"),
+ * per-category counts, every finding marked known or UNEXPECTED, and every result
+ * row that carries a message.
+ */
+function buildSummary(report: AcplintReport, status: number): string {
+  const identified = formatAgentIdentification(report.agent_info);
+
+  const findings = report.findings.map((finding) => {
+    const mark = ALLOWED_FINDINGS.includes(finding) ? 'known' : 'UNEXPECTED';
+    return `- [${mark}] ${finding}`;
+  });
+
+  const messages = report.results
+    .filter((row) => row.message !== null)
+    .map((row) => `- \`${row.category}/${row.name}\`: ${row.message}`);
+
+  return [
+    '## ACP conformance report',
+    '',
+    `Raw acplint status: \`${String(status)}\``,
+    `Declared conformance: \`${report.conformance_level}\``,
+    `Agent identification: ${identified}`,
+    '',
+    '### Per-category counts',
+    '',
+    '| Category | Passed | Failed | Skipped | Errored |',
+    '| --- | ---: | ---: | ---: | ---: |',
+    ...categorySummaryRows(report),
+    '',
+    `### Findings (${report.findings.length})`,
+    '',
+    ...(findings.length === 0 ? ['None.'] : findings),
+    '',
+    `### Result messages (${messages.length})`,
+    '',
+    ...(messages.length === 0 ? ['None.'] : messages),
+    '',
+  ].join('\n');
+}
+
+/**
+ * The short summary emitted when the report cannot be read or parsed: it exists so
+ * even an unavailable report surfaces an inspectable trace instead of silence.
+ */
+function buildUnavailableSummary(reason: string): string {
+  return [
+    '## ACP conformance report',
+    '',
+    'The acplint report was unavailable and could not be validated.',
+    '',
+    `Reason: \`${reason}\``,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Writes the summary to stdout always and appends it (never truncating) to the
+ * file named by GITHUB_STEP_SUMMARY when that variable is set and non-empty.
+ */
+function emitSummary(markdown: string): void {
+  process.stdout.write(markdown);
+  process.stdout.write('\n');
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (typeof summaryPath === 'string' && summaryPath.length > 0) {
+    appendFileSync(summaryPath, `${markdown}\n`);
+  }
+}
 
 function validateSummaryKeys(report: AcplintReport): void {
   const actual = Object.keys(report.summary).sort();
@@ -171,6 +316,18 @@ function conformanceLevelFor(passRate: number): ConformanceLevel {
   return 'Non-Conformant';
 }
 
+/**
+ * A finding outside the allowlist is a defect the selected categories cannot explain,
+ * so it fails the gate and the error names the offending finding.
+ */
+function validateFindings(report: AcplintReport): void {
+  for (const finding of report.findings) {
+    if (!ALLOWED_FINDINGS.includes(finding)) {
+      throw new Error(`unexpected acplint finding: ${finding}`);
+    }
+  }
+}
+
 function validate(report: AcplintReport, status: number): void {
   if (status !== 0 && status !== 1) {
     throw new Error(`unexpected status ${status} (only 0 or 1 accepted)`);
@@ -202,20 +359,60 @@ function validate(report: AcplintReport, status: number): void {
       `results require "${derivedLevel}" but report declares "${report.conformance_level}"`,
     );
   }
+
+  validateAgentInfo(report);
+  validateFindings(report);
+}
+
+/**
+ * The agent must identify itself (REQ-3095-004). A report where acplint recorded no
+ * name or version means the `initialize` response carried no usable `agentInfo`.
+ */
+function validateAgentInfo(report: AcplintReport): void {
+  const { name, version } = report.agent_info;
+  if (!isNonEmpty(name)) {
+    throw new Error('agent_info.name must be a non-empty string');
+  }
+  if (!isNonEmpty(version)) {
+    throw new Error('agent_info.version must be a non-empty string');
+  }
+}
+
+/**
+ * Emits the unavailable summary naming the failure, then marks the exit code without
+ * terminating the process, so Node drains buffered stdout before the process ends and a large
+ * summary is never truncated at the pipe buffer boundary.
+ */
+function rejectUnavailable(reason: string): void {
+  process.stderr.write(`${reason}\n`);
+  emitSummary(buildUnavailableSummary(reason));
+  process.exitCode = 1;
+}
+
+/**
+ * Fails a run whose full summary was already emitted before the decision: the reason goes to
+ * stderr and the exit code is marked without terminating the process, so buffered stdout is
+ * drained and a large summary is never truncated at the pipe buffer boundary.
+ */
+function rejectValidated(reason: string): void {
+  process.stderr.write(`${reason}\n`);
+  process.exitCode = 1;
 }
 
 function main(): void {
   const args = process.argv.slice(2);
   if (args.length !== 2) {
-    process.stderr.write(
-      'usage: node scripts/validate-acplint-report.ts <report-json-path> <status>\n',
+    rejectUnavailable(
+      `invalid invocation: expected exactly 2 arguments (<report-json-path> <status>), got ${args.length}`,
     );
-    process.exit(1);
+    return;
   }
   const [reportPath, statusArg] = args;
   if (!/^[0-9]+$/.test(statusArg)) {
-    process.stderr.write(`invalid status: ${statusArg}\n`);
-    process.exit(1);
+    rejectUnavailable(
+      `invalid status "${statusArg}": expected a non-negative integer`,
+    );
+    return;
   }
   const status = Number(statusArg);
 
@@ -223,37 +420,36 @@ function main(): void {
   try {
     jsonText = readFileSync(reportPath, 'utf8');
   } catch (error) {
-    process.stderr.write(
-      `failed to read report file: ${error instanceof Error ? error.message : String(error)}\n`,
-    );
-    process.exit(1);
+    const reason = error instanceof Error ? error.message : String(error);
+    rejectUnavailable(`failed to read report file: ${reason}`);
+    return;
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonText);
   } catch (error) {
-    process.stderr.write(
-      `failed to parse report JSON: ${error instanceof Error ? error.message : String(error)}\n`,
-    );
-    process.exit(1);
+    const reason = error instanceof Error ? error.message : String(error);
+    rejectUnavailable(`failed to parse report JSON: ${reason}`);
+    return;
   }
 
   const parseResult = AcplintReportSchema.safeParse(parsed);
   if (!parseResult.success) {
-    process.stderr.write(
-      `report validation failed: ${parseResult.error.message}\n`,
-    );
-    process.exit(1);
+    rejectUnavailable(`report validation failed: ${parseResult.error.message}`);
+    return;
   }
 
+  const report = parseResult.data;
+  emitSummary(buildSummary(report, status));
+
   try {
-    validate(parseResult.data, status);
+    validate(report, status);
   } catch (error) {
-    process.stderr.write(
-      `report validation failed: ${error instanceof Error ? error.message : String(error)}\n`,
+    rejectValidated(
+      `report validation failed: ${error instanceof Error ? error.message : String(error)}`,
     );
-    process.exit(1);
+    return;
   }
 
   process.stdout.write('acplint report validated successfully\n');


### PR DESCRIPTION
## TLDR

The `acp_conformance` CI gate ran pinned acplint v0.2.0 and reported only pass or fail, so the `findings` array in its JSON report was never seen by anyone. This makes the gate inspectable and fixes the one real defect the findings were reporting.

Three things changed:

1. **LLxprt now identifies itself over ACP.** `initializeZedAgent` returns `agentInfo` with name `llxprt-code` and the version `getCliVersion()` resolves. It previously sent nothing, which is what acplint's first finding was complaining about.
2. **Every acplint run now emits an inspectable summary** to stdout and to `GITHUB_STEP_SUMMARY`, before the pass/fail decision, so failing runs surface it too.
3. **Unknown findings now fail the gate.** The three remaining findings are allowlisted by exact string; anything else turns the check red instead of hiding in an artifact nobody downloads.

Reviewers should look hardest at the allowlist in `scripts/validate-acplint-report.ts` and at the claim below that three of the four findings are false positives.

## Dive Deeper

### The findings were not all real

The report attached to #3095 carried four findings. I installed the pinned acplint commit into a clean virtualenv and reproduced all four byte for byte against the built launcher, then investigated each.

**Finding 1 was real.** A raw ACP stdio probe of `./packages/cli/bin/llxprt --experimental-acp` returned exactly `protocolVersion`, `authMethods`, `agentCapabilities`. No `agentInfo`. The ACP schema in `@agentclientprotocol/sdk` 1.2.1 documents `agentInfo` as "in future versions of the protocol, this will be required". This is fixed.

**Findings 2 through 4 are artifacts of the category selection, not LLxprt defects.** They claim LLxprt never emits `agent_thought_chunk`, `available_commands_update`, or `usage_update`. acplint only adds to `_coverage["update_types_seen"]` inside its `streaming` and `plans` category handlers (`runner.py` lines 630 and 1406). This gate selects neither, so `update_types_seen` is always empty and `_assemble_findings()` reports every optional update type as never seen.

The same probe disproves the claim directly: issuing `session/new` returned `available_commands_update` from the live agent. LLxprt calls `sendAvailableCommands()` in `newSession` and both `loadSession` paths, builds `usage_update` in `zed-helpers.ts`, and emits `agent_thought_chunk` from `zed-stream-batcher.ts` and `zed-session-replay.ts`.

So these three are allowlisted as known and explained rather than chased. That tradeoff has a cost, and `dev-docs/acp-conformance.md` now states it in Limitations: because those three findings are accepted unconditionally, this gate cannot detect a genuine regression in the behaviours they describe. Catching that needs the streaming and plans categories, which need live model inference.

### The Python traceback

The `RuntimeError: Event loop is closed` traceback in the issue comes from acplint, not from LLxprt. `AcpTransport.__aexit__` terminates the agent subprocess and awaits `wait()`, but never closes the asyncio subprocess transport. `run_all()` then returns from `asyncio.run()`, which closes the loop. When CPython later garbage-collects `BaseSubprocessTransport`, `__del__` calls `close()` on the closed loop and the interpreter prints the message as "Exception ignored in" during shutdown.

Because it is an ignored exception at interpreter shutdown, it cannot change acplint's exit status. It is timing dependent and did not reproduce on Python 3.14/macOS. No LLxprt change is warranted, so the response is to make it visible and attributable: the `Run acplint` step now prints the log tail inside a collapsed group on every run, not only on a nonzero exit.

### Enforcement, so this does not regress

The validator rejects any report whose `agent_info` lacks a non-empty `name` or `version`. The agentInfo fix is therefore a CI-enforced invariant rather than a one-time cleanup, and the agentInfo finding is deliberately left out of the allowlist so it would fail the gate if it came back.

`agent_info` stays permissive at the Zod layer on purpose. Requiring name and version in the schema would divert that exact regression into the unparseable-report path and lose the summary at the moment it is most useful. Non-emptiness is enforced after the summary is emitted, so a regressed run still prints its full findings and counts alongside "Agent identification: not reported".

The validator sets `process.exitCode` and returns rather than calling `process.exit`, so Node drains stdout. A forced exit truncated large summaries at the 64 KB pipe buffer; there is a test covering that with an oversized report.

## Reviewer Test Plan

The validator and gate can be exercised without any network or model access.

Unit level:

```bash
bun test scripts/tests/validate-acplint-report.test.ts scripts/tests/ci-acplint-workflow.test.ts
cd packages/cli && bun test src/zed-integration/zed-initialize.test.ts
```

The workflow test extracts the real `Run acplint` shell from `ci.yml` and executes it against a fake `acplint` on PATH for both a zero and a nonzero raw status, so the unconditional log tail is proven by execution rather than by grepping YAML.

End to end against the real pinned tool:

```bash
python3 -m venv /tmp/acplint-venv
/tmp/acplint-venv/bin/python -m pip install \
  "acplint @ git+https://github.com/rinadelph/acplint.git@e2f4e49b3ba825869a4ecab7e10076d4460f4dcd"
npm run build
rm -rf /tmp/acpcheck && mkdir -p /tmp/acpcheck/diagnostics/llxprt-logs /tmp/acpcheck/config /tmp/acpcheck/data
LLXPRT_CONFIG_HOME=/tmp/acpcheck/config LLXPRT_DATA_HOME=/tmp/acpcheck/data \
LLXPRT_LOG_HOME=/tmp/acpcheck/diagnostics/llxprt-logs \
/tmp/acplint-venv/bin/acplint \
  --agent "./packages/cli/bin/llxprt" \
  --agent-args "--experimental-acp --provider openai --model gpt-4o --key acplint-ci" \
  --categories initialization session_lifecycle schema_validation \
  --output json --output-file /tmp/acpcheck/diagnostics/report.json --cwd "$PWD"
node scripts/validate-acplint-report.ts /tmp/acpcheck/diagnostics/report.json 0
```

Expected: acplint exits 0, `agent_info` is `{"name": "llxprt-code", "version": "..."}`, the agentInfo finding is gone, the three category-artifact findings remain and print as `[known]`, and the validator exits 0. That is exactly what I observed:

```
Agent identification: name=`llxprt-code` version=`0.11.0`

### Findings (3)

- [known] No agent_thought_chunk notifications received at all
- [known] No available_commands_update notifications received ...
- [known] No usage_update notifications received ...
```

To see the gate bite, add an extra string to `findings` in the report JSON and re-run the validator. It should exit 1 and name the offending finding.

To confirm the ACP change independently, run the launcher with `--experimental-acp` and send a raw `initialize` request; the response now carries `agentInfo`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test`, `lint`, `typecheck`, `format`, `build`, the `stepfun-37` smoke run, and the real pinned acplint gate end to end. The gate itself runs on ubuntu-latest in CI.

Note on the full suite: 13 tests fail locally in `packages/core`, `packages/tools`, and `packages/telemetry`, all of them 180s/60s/15s timeouts or a perf assertion under machine contention. This branch is byte-identical to `origin/main` in every one of those packages (`git diff origin/main -- packages/core packages/tools packages/telemetry packages/agents` is empty), and they pass when run in isolation, so they are not attributable to this change. CI is the arbiter.

## Linked issues / bugs

Fixes #3095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ACP initialization responses now include the agent name and current CLI version.
  * Conformance reports provide clearer summaries, including status, agent details, category counts, findings, and result messages.

* **Bug Fixes**
  * Conformance diagnostics and log tails are now consistently displayed, including after successful checks.
  * Validation errors preserve and display complete diagnostic output.
  * Report validation now handles missing or invalid reports with clear explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->