### PR TITLE
Name the actual endpoint in Turn error reports (Fixes #2231)

### DIFF
--- a/packages/agents/src/core/__tests__/chatSession.resolvedBaseUrl.bun.test.ts
+++ b/packages/agents/src/core/__tests__/chatSession.resolvedBaseUrl.bun.test.ts
@@ -170,4 +170,28 @@ describe('ChatSession.getResolvedBaseUrl', () => {
 
     expect(result).toBe('https://runtime.example/v1');
   });
+
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-4
+   */
+  it('S6: returns undefined when the LB last-selection probe throws, instead of propagating', () => {
+    const manager = new TestRuntimeProviderManager();
+    const provider = {
+      ...createProvider('router'),
+      getLastSelectedBaseUrl: () => {
+        throw new Error('probe exploded');
+      },
+    };
+    manager.registerProvider(provider);
+    const chat = createChatSession({
+      manager,
+      providerName: provider.name,
+      baseUrl: 'https://runtime.example/v1',
+    });
+
+    const result = chat.getResolvedBaseUrl();
+
+    expect(result).toBeUndefined();
+  });
 });

--- a/packages/agents/src/core/__tests__/chatSession.resolvedBaseUrl.bun.test.ts
+++ b/packages/agents/src/core/__tests__/chatSession.resolvedBaseUrl.bun.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { ANTHROPIC_DEFAULT_BASE_URL } from '@vybestack/llxprt-code-providers';
+import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import type { RuntimeProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createProviderAdapterFromManager } from '@vybestack/llxprt-code-core/runtime/runtimeAdapters.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { ChatSession } from '../chatSession.js';
+import { TestRuntimeProviderManager } from '../../test-utils/runtimeProviderManager.js';
+
+const UNUSED_CONTENT_GENERATOR: ContentGenerator = {
+  generateContent: () => Promise.reject(new Error('Not used by this test')),
+  generateContentStream: () =>
+    Promise.reject(new Error('Not used by this test')),
+  countTokens: () => Promise.reject(new Error('Not used by this test')),
+  embedContent: () => Promise.reject(new Error('Not used by this test')),
+};
+
+function createProvider(name: string): RuntimeProvider {
+  return {
+    name,
+    getModels: () => Promise.resolve([]),
+    getServerTools: () => [],
+    invokeServerTool: () => Promise.resolve(undefined),
+    async *generateChatCompletion(): AsyncIterableIterator<IContent> {},
+  };
+}
+
+function createChatSession(options: {
+  manager: TestRuntimeProviderManager;
+  providerName: string;
+  baseUrl?: string;
+}): ChatSession {
+  const settingsService = new SettingsService();
+  const providerRuntime = createProviderRuntimeContext({
+    settingsService,
+    runtimeId: 'resolved-base-url-test',
+    metadata: { source: 'chatSession.resolvedBaseUrl.bun.test' },
+  });
+  const runtimeState = createAgentRuntimeState({
+    runtimeId: 'resolved-base-url-test',
+    provider: options.providerName,
+    model: 'test-model',
+    sessionId: 'resolved-base-url-test',
+    ...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
+  });
+  const runtimeContext = createAgentRuntimeContext({
+    state: runtimeState,
+    history: new HistoryService(),
+    settings: {
+      compressionThreshold: 0.8,
+      contextLimit: 128_000,
+      preserveThreshold: 0.2,
+    },
+    provider: createProviderAdapterFromManager(options.manager),
+    telemetry: {
+      logApiRequest: () => {},
+      logApiResponse: () => {},
+      logApiError: () => {},
+    },
+    tools: {
+      listToolNames: () => [],
+      getToolMetadata: () => undefined,
+    },
+    providerRuntime,
+  });
+
+  return new ChatSession(runtimeContext, UNUSED_CONTENT_GENERATOR, {}, []);
+}
+
+describe('ChatSession.getResolvedBaseUrl', () => {
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-4
+   */
+  it('S1: prefers the load balancer last-selected endpoint', () => {
+    const manager = new TestRuntimeProviderManager();
+    const provider = {
+      ...createProvider('router'),
+      getLastSelectedBaseUrl: () => 'https://lb-child.example/v1',
+    };
+    manager.registerProvider(provider);
+    const chat = createChatSession({
+      manager,
+      providerName: provider.name,
+      baseUrl: 'https://runtime.example/v1',
+    });
+
+    const result = chat.getResolvedBaseUrl();
+
+    expect(result).toBe('https://lb-child.example/v1');
+  });
+
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-4
+   */
+  it('S2: returns the runtime base URL for a plain provider', () => {
+    const manager = new TestRuntimeProviderManager();
+    const provider = createProvider('openai');
+    manager.registerProvider(provider);
+    const chat = createChatSession({
+      manager,
+      providerName: provider.name,
+      baseUrl: 'https://proxy.example/v1',
+    });
+
+    const result = chat.getResolvedBaseUrl();
+
+    expect(result).toBe('https://proxy.example/v1');
+  });
+
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-2
+   * @requirement:REQ-2231-4
+   */
+  it('S3: returns undefined when no active provider can be resolved', () => {
+    const manager = new TestRuntimeProviderManager();
+    const chat = createChatSession({ manager, providerName: 'missing' });
+
+    const result = chat.getResolvedBaseUrl();
+
+    expect(result).toBeUndefined();
+  });
+
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-4
+   */
+  it('S4: returns the native Anthropic default without a runtime base URL', () => {
+    const manager = new TestRuntimeProviderManager();
+    const provider = createProvider('anthropic');
+    manager.registerProvider(provider);
+    const chat = createChatSession({ manager, providerName: provider.name });
+
+    const result = chat.getResolvedBaseUrl();
+
+    expect(result).toBe(ANTHROPIC_DEFAULT_BASE_URL);
+  });
+
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-4
+   */
+  it('S5: falls back to the runtime base URL when the LB has no selection yet', () => {
+    const manager = new TestRuntimeProviderManager();
+    const provider = {
+      ...createProvider('router'),
+      getLastSelectedBaseUrl: () => undefined,
+    };
+    manager.registerProvider(provider);
+    const chat = createChatSession({
+      manager,
+      providerName: provider.name,
+      baseUrl: 'https://runtime.example/v1',
+    });
+
+    const result = chat.getResolvedBaseUrl();
+
+    expect(result).toBe('https://runtime.example/v1');
+  });
+});

--- a/packages/agents/src/core/__tests__/stream-pipeline.characterization.test.ts
+++ b/packages/agents/src/core/__tests__/stream-pipeline.characterization.test.ts
@@ -47,6 +47,7 @@ describe('Stream Pipeline Characterization', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: () => undefined,
+      getResolvedBaseUrl: () => undefined,
     };
     turn = new Turn(
       mockChatInstance as unknown as ChatSession,

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -869,6 +869,27 @@ export class ChatSession {
   }
 
   /**
+   * Resolves the base URL of the endpoint that would service the next provider
+   * request: the load balancer's last-selected sub-profile URL when active,
+   * otherwise the runtime base URL (native Anthropic default included).
+   * Returns undefined when no endpoint is resolvable. Used for error
+   * reporting so failures name the actual endpoint (@issue #2231); note that
+   * provider resolution follows the same path a send would (including an
+   * enforced active-provider switch), and resolution failures must never
+   * mask the error being reported.
+   */
+  getResolvedBaseUrl(): string | undefined {
+    try {
+      const provider = this.resolveProviderForRuntime(
+        'ChatSession.getResolvedBaseUrl',
+      );
+      return this.resolveProviderBaseUrl(provider);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * Returns the Config instance from the provider runtime.
    * Used by Turn and other consumers to access ephemeral settings.
    */

--- a/packages/agents/src/core/turn-test-helpers.ts
+++ b/packages/agents/src/core/turn-test-helpers.ts
@@ -24,6 +24,7 @@ export type MockedChatInstance = {
   getConfig: () =>
     | { getEphemeralSetting: (key: string) => unknown }
     | undefined;
+  getResolvedBaseUrl: () => string | undefined;
 };
 
 export function findFinishedEvent(

--- a/packages/agents/src/core/turn.abort-timeout.test.ts
+++ b/packages/agents/src/core/turn.abort-timeout.test.ts
@@ -69,6 +69,7 @@ describe('Turn run - abort and idle timeout', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: () => undefined,
+      getResolvedBaseUrl: () => undefined,
     };
     turn = new Turn(
       mockChatInstance as unknown as ChatSession,
@@ -134,6 +135,7 @@ describe('Turn run - abort and idle timeout', () => {
             return undefined;
           },
         }),
+        getResolvedBaseUrl: () => undefined,
       };
       turn = new Turn(
         mockChatInstance as unknown as ChatSession,
@@ -319,6 +321,7 @@ describe('Turn run - abort and idle timeout', () => {
             return undefined;
           },
         }),
+        getResolvedBaseUrl: () => undefined,
       };
       turn = new Turn(
         mockChatInstance as unknown as ChatSession,
@@ -545,6 +548,7 @@ function makeTurnWithConfig(
     getHistory: mockGetHistory,
     getConfig: () =>
       getEphemeralSetting === undefined ? undefined : { getEphemeralSetting },
+    getResolvedBaseUrl: () => undefined,
   };
   return new Turn(
     chatInstance as unknown as ChatSession,

--- a/packages/agents/src/core/turn.cooperative-cleanup.bun.test.ts
+++ b/packages/agents/src/core/turn.cooperative-cleanup.bun.test.ts
@@ -60,6 +60,7 @@ describe('Turn run - cooperative iterator cleanup (issue #3114)', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: () => undefined,
+      getResolvedBaseUrl: () => undefined,
     };
     turn = new Turn(
       mockChatInstance as unknown as ChatSession,

--- a/packages/agents/src/core/turn.debug-responses.test.ts
+++ b/packages/agents/src/core/turn.debug-responses.test.ts
@@ -49,6 +49,7 @@ describe('Turn - debug responses and finished event outcome', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: () => undefined,
+      getResolvedBaseUrl: () => undefined,
     };
     turn = new Turn(
       mockChatInstance as unknown as ChatSession,

--- a/packages/agents/src/core/turn.errorReport.bun.test.ts
+++ b/packages/agents/src/core/turn.errorReport.bun.test.ts
@@ -27,6 +27,7 @@ interface ReportContext {
   request: ContentBlock[];
   recentHistory: IContent[];
   omittedHistoryCount: number;
+  baseUrl?: string;
 }
 
 interface ParsedReport {
@@ -47,6 +48,7 @@ interface ParsedReport {
 interface FixtureChat {
   getHistory: (curated?: boolean) => IContent[];
   getConfig: () => undefined;
+  getResolvedBaseUrl: () => string | undefined;
   sendMessageStream: () => Promise<never>;
 }
 
@@ -57,10 +59,15 @@ function makeEntry(speaker: IContent['speaker'], text: string): IContent {
   };
 }
 
-function createTurn(history: IContent[], errorMessage: string): Turn {
+function createTurn(
+  history: IContent[],
+  errorMessage: string,
+  baseUrl?: string,
+): Turn {
   const chat: FixtureChat = {
     getHistory: () => history,
     getConfig: () => undefined,
+    getResolvedBaseUrl: () => baseUrl,
     sendMessageStream: () => Promise.reject(new Error(errorMessage)),
   };
   return new Turn(
@@ -276,5 +283,97 @@ describe('Turn error report payload (issue 3113)', () => {
     expect(files[0]).toMatch(
       /^llxprt-client-error-Turn\.run-sendMessageStream-/,
     );
+  });
+
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-1
+   */
+  it('E1: includes the resolved endpoint in the stderr base message', async () => {
+    const turn = createTurn(
+      [],
+      'E1 endpoint message error',
+      'https://ollama.example/v1/',
+    );
+    const req: ContentBlock[] = [{ text: 'E1 failing request' }];
+
+    await collectEvents(turn, req);
+
+    const stderr = stderrSpy.mock.calls
+      .map(([chunk]) => String(chunk))
+      .join('');
+    expect(stderr).toContain(
+      'Error when talking to fixture (endpoint: https://ollama.example/v1/)',
+    );
+  });
+
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-3
+   */
+  it('E2: records the resolved endpoint in the report context', async () => {
+    const turn = createTurn(
+      [],
+      'E2 endpoint context error',
+      'https://ollama.example/v1/',
+    );
+    const req: ContentBlock[] = [{ text: 'E2 failing request' }];
+
+    await collectEvents(turn, req);
+
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const report = await readReport(files[0]);
+    if (report.context === undefined) {
+      throw new Error('Expected report context');
+    }
+    expect(report.context.baseUrl).toEqual('https://ollama.example/v1/');
+  });
+
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-2
+   * @requirement:REQ-2231-3
+   */
+  it('E3: preserves the API fallback and omits baseUrl when unresolved', async () => {
+    const turn = createTurn([], 'E3 unresolved endpoint error');
+    const req: ContentBlock[] = [{ text: 'E3 failing request' }];
+
+    await collectEvents(turn, req);
+
+    const stderr = stderrSpy.mock.calls
+      .map(([chunk]) => String(chunk))
+      .join('');
+    expect(stderr).toContain('Error when talking to fixture API');
+    expect(stderr).not.toContain('(endpoint:');
+    const files = await listReportFiles();
+    expect(files.length).toBe(1);
+    const report = await readReport(files[0]);
+    if (report.context === undefined) {
+      throw new Error('Expected report context');
+    }
+    expect('baseUrl' in report.context).toBe(false);
+  });
+
+  /**
+   * @plan:PLAN-20260824-ISSUE2231.P01
+   * @requirement:REQ-2231-5
+   */
+  it('E4: leaves the structured error event unchanged when an endpoint resolves', async () => {
+    const turn = createTurn(
+      [],
+      'E4 unchanged event error',
+      'https://ollama.example/v1/',
+    );
+    const req: ContentBlock[] = [{ text: 'E4 failing request' }];
+
+    const events = await collectEvents(turn, req);
+
+    expect(events).toEqual([
+      {
+        type: AgentEventType.Error,
+        value: { error: { message: 'E4 unchanged event error' } },
+      },
+    ]);
   });
 });

--- a/packages/agents/src/core/turn.hook-events.test.ts
+++ b/packages/agents/src/core/turn.hook-events.test.ts
@@ -45,6 +45,7 @@ describe('Turn - hook execution control events', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: () => undefined,
+      getResolvedBaseUrl: () => undefined,
     };
     turn = new Turn(
       mockChatInstance as unknown as ChatSession,

--- a/packages/agents/src/core/turn.idle-timeout.test.ts
+++ b/packages/agents/src/core/turn.idle-timeout.test.ts
@@ -59,6 +59,7 @@ describe('Turn - stream idle timeout behavioral tests', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: () => undefined,
+      getResolvedBaseUrl: () => undefined,
     };
     turn = new Turn(
       mockChatInstance as unknown as ChatSession,
@@ -97,6 +98,7 @@ describe('Turn - stream idle timeout behavioral tests', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: mockGetConfig,
+      getResolvedBaseUrl: () => undefined,
     } as unknown as MockedChatInstance;
 
     turn = new Turn(
@@ -186,6 +188,7 @@ describe('Turn - stream idle timeout behavioral tests', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: mockGetConfig,
+      getResolvedBaseUrl: () => undefined,
     } as unknown as MockedChatInstance;
 
     turn = new Turn(
@@ -237,6 +240,7 @@ describe('Turn - stream idle timeout behavioral tests', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: mockGetConfig,
+      getResolvedBaseUrl: () => undefined,
     } as unknown as MockedChatInstance;
 
     turn = new Turn(
@@ -332,6 +336,7 @@ describe('Turn - stream idle timeout behavioral tests', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: mockGetConfig,
+      getResolvedBaseUrl: () => undefined,
     } as unknown as MockedChatInstance;
 
     turn = new Turn(
@@ -426,6 +431,7 @@ describe('Turn - stream idle timeout behavioral tests', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: mockGetConfig,
+      getResolvedBaseUrl: () => undefined,
     } as unknown as MockedChatInstance;
 
     turn = new Turn(

--- a/packages/agents/src/core/turn.issue2329.test.ts
+++ b/packages/agents/src/core/turn.issue2329.test.ts
@@ -43,6 +43,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: () => undefined,
+      getResolvedBaseUrl: () => undefined,
     };
     turn = new Turn(
       mockChatInstance as unknown as ChatSession,

--- a/packages/agents/src/core/turn.preRequestTimeout.test.ts
+++ b/packages/agents/src/core/turn.preRequestTimeout.test.ts
@@ -80,6 +80,7 @@ function buildTurn(
     sendMessageStream: mockSendMessageStream,
     getHistory: mockGetHistory,
     getConfig: mockGetConfig,
+    getResolvedBaseUrl: () => undefined,
   } as unknown as MockedChatInstance;
 
   const turn = new Turn(

--- a/packages/agents/src/core/turn.test.ts
+++ b/packages/agents/src/core/turn.test.ts
@@ -36,6 +36,7 @@ describe('Turn', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: () => undefined,
+      getResolvedBaseUrl: () => undefined,
     };
     turn = new Turn(
       mockChatInstance as unknown as ChatSession,

--- a/packages/agents/src/core/turn.tool-restrictions.test.ts
+++ b/packages/agents/src/core/turn.tool-restrictions.test.ts
@@ -39,6 +39,7 @@ describe('Turn run - hook tool restrictions', () => {
       sendMessageStream: mockSendMessageStream,
       getHistory: mockGetHistory,
       getConfig: () => undefined,
+      getResolvedBaseUrl: () => undefined,
     };
     turn = new Turn(
       mockChatInstance as unknown as ChatSession,

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -583,10 +583,18 @@ export class Turn {
     if (error instanceof UnauthorizedError) {
       throw error;
     }
+    const baseUrl = this.chat.getResolvedBaseUrl();
+    const baseMessage = baseUrl
+      ? `Error when talking to ${this.providerName} (endpoint: ${baseUrl})`
+      : `Error when talking to ${this.providerName} API`;
     await reportError(
       error,
-      `Error when talking to ${this.providerName} API`,
-      buildErrorReportContext(this.chat.getHistory(/*curated*/ true), req),
+      baseMessage,
+      buildErrorReportContext(
+        this.chat.getHistory(/*curated*/ true),
+        req,
+        baseUrl,
+      ),
       'Turn.run-sendMessageStream',
     );
     const structuredError = buildStructuredError(error);

--- a/packages/agents/src/core/turnErrorReportContext.ts
+++ b/packages/agents/src/core/turnErrorReportContext.ts
@@ -12,16 +12,19 @@ const TURN_REPORT_HISTORY_TAIL = 8;
  * @plan PLAN-20260807-ISSUE3113.P06
  * @requirement REQ-3113-1.1
  * @pseudocode lines 300-322
+ * Adds endpoint diagnostics for error reports (@issue #2231).
  */
 export function buildErrorReportContext(
   // Accepts the read-only view getHistory() now returns (#3109). Only
   // `.slice()` and `.length` are used, both of which are readonly-safe.
   history: readonly IContent[],
   request: string | object | readonly unknown[],
+  baseUrl?: string,
 ): Record<string, unknown> {
   return {
     request,
     recentHistory: history.slice(-TURN_REPORT_HISTORY_TAIL),
     omittedHistoryCount: Math.max(0, history.length - TURN_REPORT_HISTORY_TAIL),
+    ...(baseUrl === undefined ? {} : { baseUrl }),
   };
 }

--- a/packages/cli/src/integration-tests/cli-args.integration.test.ts
+++ b/packages/cli/src/integration-tests/cli-args.integration.test.ts
@@ -343,7 +343,11 @@ describe('CLI --profile-load Integration Tests', () => {
       );
 
       const fullOutput = result.stdout + result.stderr;
-      expect(fullOutput).toContain('Error when talking to gemini API');
+      // Issue #2231: the error names the resolved endpoint, which also
+      // proves the CLI --baseurl won over the profile base-url.
+      expect(fullOutput).toContain(
+        'Error when talking to gemini (endpoint: https://cli-base-url.example.com)',
+      );
       expect(fullOutput).not.toContain('profile-auth');
       expect(fullOutput).not.toContain('profile-base-url.example.com');
     });

--- a/project-plans/issue2231/plan.md
+++ b/project-plans/issue2231/plan.md
@@ -1,0 +1,257 @@
+# Execution Plan — issue #2231
+
+Plan ID: PLAN-20260824-ISSUE2231
+Generated: 2026-08-24
+Branch: `issue2231`
+Issue: Error message says 'Error when talking to {provider} API' regardless of
+actual endpoint
+
+## Scope, in one paragraph
+
+`packages/agents/src/core/turn.ts` `handleRunError` builds the report base
+message from the logical provider name only. The fix resolves the actual HTTP
+endpoint through the session — `ChatSession.getResolvedBaseUrl()`, a new
+public read-only accessor that reuses the existing private
+`resolveProviderBaseUrl` (load-balancer last-selected URL → native-Anthropic
+default → `runtimeState.baseUrl`) — and (a) prints
+`Error when talking to {providerName} (endpoint: {baseUrl})` to stderr when a
+URL resolves, (b) records `baseUrl` in the JSON report context. When no URL
+resolves the message stays exactly `Error when talking to {providerName} API`.
+The `ServerErrorEvent` payload is unchanged. Nothing else changes.
+
+## Accepted behavior (requirements)
+
+### REQ-2231-1: endpoint in the stderr base message
+
+- GIVEN: a `Turn` with `providerName` `P` whose chat resolves base URL `U`,
+  and a `sendMessageStream` rejection that reaches the generic error branch
+- WHEN: `Turn.run` handles the error
+- THEN: the stderr line begins
+  `Error when talking to P (endpoint: U)` (followed by the existing
+  ` Full report available at: …` suffix from `reportError`)
+
+### REQ-2231-2: fallback when no endpoint resolves
+
+- GIVEN: the chat resolves no base URL (provider resolution throws, or the
+  resolved provider yields no URL — e.g. default gemini with no explicit
+  `baseUrl`)
+- WHEN: `Turn.run` handles the error
+- THEN: the stderr line begins `Error when talking to P API` and contains no
+  `(endpoint:` fragment; diagnostics resolution failures never throw out of
+  the error handler
+
+### REQ-2231-3: endpoint in the JSON report file
+
+- GIVEN/WHEN: as REQ-2231-1
+- THEN: the report file's `context` object contains `baseUrl: U`, so the
+  failing service is identifiable from the report alone; when no URL resolves,
+  `baseUrl` is absent from the context
+
+### REQ-2231-4: resolution semantics of `ChatSession.getResolvedBaseUrl()`
+
+The accessor returns, for the provider the runtime would use next:
+
+1. the load balancer's `getLastSelectedBaseUrl()` when the resolved provider
+   exposes it (takes precedence over `runtimeState.baseUrl`)
+2. otherwise `runtimeState.baseUrl` (with the existing native-Anthropic
+   default for provider `anthropic`)
+3. `undefined` when provider resolution itself fails (no active provider)
+
+### REQ-2231-5: event contract unchanged
+
+- The `AgentEventType.Error` event payload (`message`, optional `status`,
+  `category`, `reason`) is byte-for-byte what it is today; endpoint enrichment
+  affects only the report base message and report context.
+
+## Out of scope (explicitly rejected)
+
+- Changing the `StructuredError` / event schema to carry the endpoint.
+- Adding provider-default endpoints for providers other than the existing
+  native-Anthropic default baked into `resolveProviderBaseUrl`.
+- Appending `: {errorMessage}` to the base message (the error message already
+  travels in the report file and the Error event; the issue's "e.g." format is
+  indicative, the requirement is endpoint visibility).
+- Any refactor of `reportError`, dedupe fingerprints, or rotation.
+
+## Test matrix
+
+### Turn level — extend `packages/agents/src/core/turn.errorReport.bun.test.ts`
+
+`FixtureChat` gains `getResolvedBaseUrl: () => string | undefined`.
+
+| Row | Requirement | GIVEN/WHEN/THEN | RED/GUARD |
+|-----|--------------|-----------------|-----------|
+| E1 | REQ-2231-1 | fixture returns `https://ollama.example/v1/`, providerName `fixture`; run fails; stderr contains `Error when talking to fixture (endpoint: https://ollama.example/v1/)` | RED |
+| E2 | REQ-2231-3 | same setup; parsed report `context.baseUrl` deep-equals `https://ollama.example/v1/` | RED |
+| E3 | REQ-2231-2 | fixture returns `undefined`; stderr contains `Error when talking to fixture API` and not `(endpoint:`; report context has no `baseUrl` key | GUARD |
+| E4 | REQ-2231-5 | with URL present, yielded events are exactly `[{ type: Error, value: { error: { message } } }]` | GUARD |
+
+### ChatSession level — create `packages/agents/src/core/__tests__/chatSession.resolvedBaseUrl.bun.test.ts`
+
+Reuse the harness shape from `__tests__/chatSession.runtimeState.test.ts`
+(`createAgentRuntimeState`, `createAgentRuntimeContext`,
+`createProviderAdapterFromManager`) with the `RuntimeProviderManager` from
+`packages/agents/src/test-utils/runtimeProviderManager.ts` to register
+provider stand-ins. Providers here are the infrastructure boundary, not the
+component under test; `ChatSession` is real.
+
+| Row | Requirement | GIVEN/WHEN/THEN | RED/GUARD |
+|-----|--------------|-----------------|-----------|
+| S1 | REQ-2231-4.1 | active provider exposes `getLastSelectedBaseUrl: () => 'https://lb-child.example/v1'` and `runtimeState.baseUrl` is a different URL; `getResolvedBaseUrl()` returns the LB URL | RED |
+| S2 | REQ-2231-4.2 | plain provider, `runtimeState.baseUrl = 'https://proxy.example/v1'`; returns it | RED |
+| S3 | REQ-2231-4.3 | provider adapter with no registered/active provider (resolution throws); returns `undefined` without throwing | RED |
+| S4 | REQ-2231-4.2 | provider named `anthropic`, no `runtimeState.baseUrl`; returns the native Anthropic default base URL | RED |
+| S5 | REQ-2231-4 | active LB provider whose `getLastSelectedBaseUrl()` returns `undefined` (no selection yet — e.g. the very first request failing), `runtimeState.baseUrl` set; returns the runtime base URL | GREEN (adopted from OCR round 1; locks the fallback ordering) |
+
+### Existing fixtures to update (mechanical, no behavior change)
+
+- `packages/agents/src/core/turn.test.ts` `mockChatInstance` and
+  `turn-test-helpers.ts` `MockedChatInstance`: add `getResolvedBaseUrl:
+  () => undefined` so the mocked error-path test keeps reaching
+  `handleRunError` without a TypeError (its assertion is a call-count check
+  on `reportError`, not a message check).
+- Any other Turn fixture that reaches the generic error branch and fails with
+  a missing-method TypeError (the full suite run reveals them; fix by adding
+  the same stub).
+
+## Phases
+
+### P01 — RED
+
+Add rows E1-E4 and create the S-file with rows S1-S4. Tag every test
+`@plan:PLAN-20260824-ISSUE2231.P01` and `@requirement:REQ-2231-N`. Fixture
+stubs for `getResolvedBaseUrl` land in this phase (they are test code). Run:
+
+```bash
+cd packages/agents && bun test src/core/turn.errorReport.bun.test.ts src/core/__tests__/chatSession.resolvedBaseUrl.bun.test.ts
+```
+
+**Gate:** every RED row observed failing for the right reason (missing
+endpoint in message/context; missing accessor). GUARD rows pass. Record
+output in `## RED evidence` below.
+
+### P02 — GREEN
+
+1. `packages/agents/src/core/chatSession.ts`: public
+   `getResolvedBaseUrl(): string | undefined` — resolve the runtime provider
+   via `resolveProviderForRuntime` inside a try/catch that returns
+   `undefined` on failure (diagnostic enrichment must not mask the error
+   being reported; mirrors the existing `getActiveProvider()` pattern), then
+   return `this.resolveProviderBaseUrl(provider)`.
+2. `packages/agents/src/core/turnErrorReportContext.ts`:
+   `buildErrorReportContext(history, request, baseUrl?)` includes `baseUrl`
+   in the returned record when defined.
+3. `packages/agents/src/core/turn.ts` `handleRunError`: resolve
+   `const baseUrl = this.chat.getResolvedBaseUrl();` and build the base
+   message per REQ-2231-1/2, passing `baseUrl` into
+   `buildErrorReportContext`.
+
+**Gate:** all P01 rows pass; full verification cycle (npm run test / lint /
+typecheck / format / build; smoke test with profile stepfun-37).
+
+### P03 — review cycle
+
+deepthinker compliance review; OCR (max 2 rounds); triage findings as
+Blocker-Fix / In-scope-Fix / Reject / Defer.
+
+## RED evidence
+
+Command:
+
+```bash
+cd packages/agents && bun test src/core/turn.errorReport.bun.test.ts src/core/__tests__/chatSession.resolvedBaseUrl.bun.test.ts
+```
+
+Exit code: 1. Bun reported `10 pass`, `6 fail`, and `30 expect()` calls
+across 16 tests.
+
+- E1 failed with `Expected to contain: "Error when talking to fixture
+  (endpoint: https://ollama.example/v1/)"`; stderr still contained `Error when
+  talking to fixture API Full report available at: ...`.
+- E2 failed with `Expected: "https://ollama.example/v1/"` and `Received:
+  undefined` for `report.context.baseUrl`.
+- E3 and E4 passed, confirming the unresolved fallback and event contract guards.
+- S1, S2, S3, and S4 each failed because the production `ChatSession` did not
+  yet expose `getResolvedBaseUrl` (`TypeError: ...getResolvedBaseUrl is not a
+  function`). The Turn fixture already exposed the method, so no Turn failure
+  was caused by a missing fixture stub.
+- Existing T1-T8 all passed unchanged.
+
+## Verification evidence (P02)
+
+| Step | Result |
+|------|--------|
+| `npm run test` (full monorepo) | First run: 377 agents files green except 2 contention flakes (see below); CLI 714 files green except 1; second solo run recorded below. |
+| Contention flakes | `agent.approvalMode.behavior.test.ts` T1 (180s timeout) and `cli-turn-parity.early.spec.ts` EP1 (30s timeout) failed only while an invalid concurrent `cd packages/agents && bun test` job (missing `run-bun-tests.ts` preloads) ran on the same machine; both files pass in isolation (`5 pass`, `3 pass`). Caused by test-harness misuse during verification, not by the change. |
+| CLI assertion update | `packages/cli/src/integration-tests/cli-args.integration.test.ts` "should apply CLI args after profile load but before provider switch" asserted the literal old message; the run prints `Error when talking to gemini (endpoint: https://cli-base-url.example.com)` because the test passes `--baseurl`. Updated the assertion to the new message — it now directly proves the CLI `--baseurl` won over the profile base URL. In scope: the issue's behavior change requires it (CI-green mandate). File passes: 20/20. The fallback-message tests (`gemini API` with no explicit base URL, incl. `cli-args.profile-flag.integration.test.ts`) still pass unchanged. |
+| `npm run lint` | EXIT=0 |
+| `npm run typecheck` | EXIT=0 |
+| `npm run format` | EXIT=0, no files changed |
+| `npm run build` | EXIT=0 |
+| Smoke: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` | EXIT=0, haiku printed |
+| Test-audit scanner (`bun scripts/test-audit/scan.ts`) | findings.tsv diff vs main baseline: only line-number shifts of pre-existing findings; zero new MOCK_MIRROR/ALWAYS_TRUE/SELF_CONFIRMED/NO_ASSERT findings on touched files. |
+
+Full-suite re-run after the CLI test edit: recorded in `## Final green evidence` once complete.
+
+## Final green evidence
+
+`npm run test` (solo run, after the CLI assertion update): EXIT=0 — 43/43,
+392/392, 377/377 workspace test files, 714/714 CLI test files;
+`Test cases: 9169 passed, 0 failed, 5 skipped, 13 todo (9187 total)`.
+
+## Review findings triage
+
+### Round 1 — architect subagent (deepthinker profile unavailable: provider
+error "The 'gpt-5.6-sol' model is not supported when using Codex with a
+ChatGPT account", retried once; architect on opusthinking used as fallback)
+
+Verdict: PASS. All five requirements verified satisfied against source; no
+scope creep; test quality confirmed behavioral (no mocks in the E-file; real
+ChatSession in the S-file). Four findings, all LOW:
+
+| # | Finding | Classification | Action |
+|---|---------|----------------|--------|
+| 1 | `turn.ts` gates the message on truthiness while `turnErrorReportContext.ts` gates on `=== undefined`; an empty-string base URL would yield the fallback message plus `baseUrl: ""` in the report context | Reject | Both behaviors satisfy REQ-2231-1/2/3 as written (`""` is defined, and recording it is accurate). Aligning predicates is optional polish with no requirement driving it. |
+| 2 | `turn.tool-restrictions.test.ts` omits the now-required `getResolvedBaseUrl` member of `MockedChatInstance` (invisible to CI due to a pre-existing tsconfig exclusion) | In-scope-Fix | Added the same one-line mechanical stub used by the other fixtures — completes the fixture update the plan already accepts and removes the latent trap. |
+| 3 | Plan text claimed `turn.test.ts` asserts the fallback message via `reportError` call args; it asserts call count only | In-scope-Fix | Corrected the plan sentence (stub is still required there). |
+| 4 | `chatSession.ts` comment said "Read-only diagnostics" but `resolveProviderForRuntime` can enforce an active-provider switch | In-scope-Fix | Reworded the comment on the accessor added by this change to describe the resolution path accurately. |
+
+Reviewer explicitly proposed no code changes for findings 1 and 4; the fixes
+applied for 2-4 are one-liners inside the change's own footprint. Full
+verification cycle re-run after remediation (see `## Post-review verification`).
+
+### Round 2 — Open Code Review (ocr, `--audience agent --timeout 20`, local)
+
+5 findings across 17 files:
+
+| # | Finding | Classification | Action |
+|---|---------|----------------|--------|
+| 1 | `turn.preRequestTimeout.test.ts` — inline stub duplication; extract a shared mock helper | Reject | Optional refactor; the one-line stubs are the accepted mechanical pattern. No behavioral issue. |
+| 2 | `turn.tool-restrictions.test.ts` — stub is untested wiring; add a resolved-URL scenario to the tool-restriction suite | Reject | Tool-restriction flows never read the endpoint; a URL scenario there tests nothing about them. Endpoint behavior is covered by E1-E4, S1-S5, and CLI end-to-end. |
+| 3 | `chatSession.ts` — add a read-only `{allowSwitch: false}` variant of provider resolution for `getResolvedBaseUrl` | Reject | New abstraction beyond the plan; the send path already runs the same resolver before any error path, so the enforced switch has already converged; conflicts with the fail-fast preference (no behavioral bug demonstrated). The JSDoc states the behavior accurately. |
+| 4 | `turn.idle-timeout.test.ts` — `getResolvedBaseUrl` stub added only to the `beforeEach` mock; 5 rebuilt mock sites (lines 98, 187, 238, 333, 427) lack it, a latent TypeError if any of those error-surface tests ever reaches the generic error branch | In-scope-Fix | Added the one-line stub to all 5 rebuild sites — completes the file's mechanical update. |
+| 5 | `chatSession.resolvedBaseUrl.bun.test.ts` — no coverage for LB present but `getLastSelectedBaseUrl()` undefined (first-failure case); suggested S5 | In-scope-Fix | Adopted S5 (locks fallback ordering; directly exercises the issue's first-request-failure scenario). |
+
+### OCR round 2 (remediation re-run; 2-round OCR cap now reached) — ocr re-run after remediation
+
+1 finding; 1 of 17 items (stream-pipeline.characterization.test.ts) timed out
+in OCR's own LLM loop — that file was reviewed with zero findings in the
+first OCR round and its only change (the mechanical stub) is unchanged since.
+
+| # | Finding | Classification | Action |
+|---|---------|----------------|--------|
+| 1 | `turnErrorReportContext.ts:28` [security · medium] — baseUrl in the report context may leak internal endpoint URLs (query-string credentials, private hostnames) into reports "that could be logged or shared externally" | Reject | Verified against the actual sink: `reportError` writes only to `os.tmpdir()` via local `fs.writeFile` (errorReporting.ts:401,455) — no network upload, fetch, or POST. The report already contains the error stack and the last 8 conversation entries by design (T1/T2), which are strictly more sensitive than a configured base URL; baseUrl is a config endpoint (OPENAI_BASE_URL, LB sub-profile), not a per-request URL — auth travels in headers in this codebase. Sanitizing would contradict the issue's explicit requirement ("include the resolved base URL in the error report"). No change. |
+
+## Post-review verification
+
+Final cycle after all review remediation (logs: `/tmp/issue2231-{npm-test4,lint3,typecheck3,format3,build3,smoke3}.log`):
+
+| Step | Result |
+|------|--------|
+| `npm run test` | All new/changed tests green in the full-suite context (idle-timeout, S1–S5, tool-restrictions, E1–E4, CLI integration); CLI 714/714. 3 unrelated api tests (`createAgent.harness`, `lspControl`, `sandbox-boundary` T18e) hit their 180s failsafe while OCR round 2 ran concurrently on the same machine — all 16 tests in those 3 files pass in isolation (4.19s), and the same suite ran 9169/0 solo earlier in the day. Load-induced flakes, not regressions; CI runs solo on a fresh runner. |
+| `npm run lint` | EXIT=0 |
+| `npm run typecheck` | EXIT=0 |
+| `npm run format` | EXIT=0 (no file changes) |
+| `npm run build` | EXIT=0 |
+| Smoke: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` | EXIT=0 (haiku printed) |
+| Test-audit scanner (`bun scripts/test-audit/scan.ts`) | No new findings vs main baseline on touched files (line-number shifts only) |

--- a/project-plans/issue2231/plan.md
+++ b/project-plans/issue2231/plan.md
@@ -255,3 +255,13 @@ Final cycle after all review remediation (logs: `/tmp/issue2231-{npm-test4,lint3
 | `npm run build` | EXIT=0 |
 | Smoke: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` | EXIT=0 (haiku printed) |
 | Test-audit scanner (`bun scripts/test-audit/scan.ts`) | No new findings vs main baseline on touched files (line-number shifts only) |
+
+## PR review triage (PR #3301)
+
+| Source | Finding | Classification | Action |
+|--------|---------|----------------|--------|
+| LLxprt PR OCR (test/medium) | No test for LB `getLastSelectedBaseUrl()` throwing → `getResolvedBaseUrl()` must return undefined, not propagate (the exact catch that keeps diagnostics from masking the original error) | In-scope-Fix | Added S6 to `chatSession.resolvedBaseUrl.bun.test.ts` (6/6 pass). |
+| CodeRabbit (security/major) | Redact userinfo/query/fragment from the base URL before stderr/report output | Reject | Verified sinks: `reportError` writes only to local `os.tmpdir()` via `fs.writeFile` (errorReporting.ts:401,455) — no network sink; stderr is the local user's terminal. The report already contains the error stack and the last 8 conversation entries by design (T1/T2), strictly more sensitive than a user-configured base URL. The codebase's only URL-redaction facility is the opt-in `telemetry.redactUrls` setting, i.e. redaction applies where data leaves the machine; error reports do not leave the machine. The issue text explicitly requires the resolved base URL in the report. |
+| CodeRabbit (functional/major) | Concurrent sends can race on the LB's mutable last-selected URL — a failure could be attributed to a different turn's endpoint | Defer | Plausible but architectural: per-attempt endpoint capture requires threading selection state through the send path (TurnProcessor/stream plumbing), beyond this issue's scope. This PR's failure-path read is still a strict improvement over provider-name-only attribution (the issue's outage scenario — endpoint down, all requests failing — attributes correctly, since selection converges to the same failing endpoint). Recorded as a known follow-up. |
+
+Known follow-up (deferred): capture the selected endpoint in per-attempt request state at LB-selection time and report that value on failure, with a concurrent two-endpoint regression test.


### PR DESCRIPTION
## TLDR

Turn failure reports now name the actual HTTP endpoint instead of only the logical provider name. When a base URL resolves, the stderr message becomes `Error when talking to {provider} (endpoint: {baseUrl})` and the JSON error-report context gains a `baseUrl` field; when nothing resolves the legacy `Error when talking to {provider} API` message is kept verbatim. Fixes #2231.

## Dive Deeper

**Why:** the old message assumed provider name == endpoint. In practice the endpoint can be a load balancer, a custom base URL (`OPENAI_BASE_URL`), or a rebranded proxy. During the 2026-06-27/28 CI outage, the LLxprt review bot (`LLXPRT_DEFAULT_PROVIDER=openai` with `OPENAI_BASE_URL=https://ollama.com/v1/`) reported "Error when talking to openai API" while ollama.com was the actual failing service, and E2E tests blamed "gemini" for the same outage. Wrong attribution made root-cause diagnosis needlessly hard.

**How (production diff is 3 files):**

- `packages/agents/src/core/chatSession.ts` — new public `getResolvedBaseUrl()`. It reuses the existing resolution chain a send would use: load balancer `getLastSelectedBaseUrl()` (the sub-profile actually selected), else `runtimeState.baseUrl` (native Anthropic default included). Resolution failures return `undefined` so diagnostics never mask the error being reported.
- `packages/agents/src/core/turn.ts` — `handleRunError` resolves the base URL and formats `Error when talking to {provider} (endpoint: {url})`, falling back to the exact legacy message when unresolved.
- `packages/agents/src/core/turnErrorReportContext.ts` — optional `baseUrl` param; the key is present in the report context only when defined (REQ-2231-3).

**Deliberately unchanged:** the `ServerErrorEvent` payload (event schema untouched), and no sanitization of the base URL — the report is a local `os.tmpdir()` file that already contains the error stack and the last 8 conversation entries, and the issue explicitly asks for the resolved base URL in the report.

**Plan doc:** `project-plans/issue2231/plan.md` (requirements, test matrix, RED evidence, review triage, verification evidence).

## Reviewer Test Plan

1. `cd packages/agents && bun test src/core/turn.errorReport.bun.test.ts src/core/__tests__/chatSession.resolvedBaseUrl.bun.test.ts src/core/turn.idle-timeout.test.ts src/core/turn.tool-restrictions.test.ts`
2. End-to-end proof: `bun scripts/start.ts --openai-base-url https://127.0.0.1:9/v1 --model gpt-4o "hi"` against an unroutable endpoint — the failure should print `Error when talking to openai (endpoint: https://127.0.0.1:9/v1)` and the temp JSON report's `context` should contain that `baseUrl`.
3. Fallback proof: any provider without a resolvable endpoint still prints exactly `Error when talking to {provider} API` (8 such CLI integration assertions kept green).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS (darwin): full `npm run test` (9169 tests green in the solo run; see plan doc for the three load-induced 180s failsafe flakes that pass in isolation), `npm run lint` / `typecheck` / `format` / `build`, stepfun-37 smoke, and test-audit scanner all clean. Other platforms exercised via CI only.

## Linked issues / bugs

Fixes #2231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Error messages now include the effective provider endpoint when available, making configuration and connectivity issues easier to diagnose.
  - Error reports preserve the resolved endpoint for additional troubleshooting context.
  - Command-line base URL overrides are reflected consistently in provider error details.

- **Bug Fixes**
  - Improved fallback behavior when an endpoint cannot be resolved, retaining the standard provider API reference.
  - Endpoint resolution safely handles provider and load-balancer errors without propagating exceptions.

- **Tests**
  - Added coverage for endpoint selection, fallback behavior, error reporting, and command-line overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->