### PR TITLE
Increase Ink layout and rendering regression coverage (Fixes #2025)

### DIFF
--- a/.github/workflows/interactive-ui.yml
+++ b/.github/workflows/interactive-ui.yml
@@ -15,11 +15,12 @@ on:
       # The interactive UI test and its Bun test preload
       - 'scripts/tests/test-setup.ts'
       - 'scripts/tests/interactive-ui.test.ts'
-      # The three scenario JSON files executed by the test
+      # The four scenario JSON files executed by the test
+      - 'scripts/tmux-script.startup-smoke.json'
       - 'scripts/tmux-script.slash-autocomplete.json'
       - 'scripts/tmux-script.approval-ui.json'
       - 'scripts/tmux-script.issue2208-newlines.fake.json'
-      # Scenario config referenced by ALL three scenarios (welcome banner +
+      # Scenario config referenced by ALL four scenarios (welcome banner +
       # system settings env paths set in each scenario)
       - 'scripts/fixtures/welcome-completed.json'
       - 'scripts/system-settings.interactive-ui.json'
@@ -57,6 +58,7 @@ on:
       - 'scripts/tmux-harness-steps.ts'
       - 'scripts/tests/test-setup.ts'
       - 'scripts/tests/interactive-ui.test.ts'
+      - 'scripts/tmux-script.startup-smoke.json'
       - 'scripts/tmux-script.slash-autocomplete.json'
       - 'scripts/tmux-script.approval-ui.json'
       - 'scripts/tmux-script.issue2208-newlines.fake.json'

--- a/packages/cli/src/ui/inkRenderOptions.test.ts
+++ b/packages/cli/src/ui/inkRenderOptions.test.ts
@@ -83,4 +83,42 @@ describe('inkRenderOptions', () => {
       }),
     );
   });
+
+  it('disables incremental rendering when alternate buffer is explicitly off', () => {
+    const options = inkRenderOptions(
+      { getScreenReader: () => false },
+      {
+        merged: {
+          ui: { useAlternateBuffer: false, incrementalRendering: true },
+        },
+      },
+    );
+
+    expect(options).toStrictEqual(
+      expect.objectContaining({
+        exitOnCtrlC: false,
+        patchConsole: false,
+        isScreenReaderEnabled: false,
+        alternateBuffer: false,
+        incrementalRendering: false,
+      }),
+    );
+  });
+
+  it('disables incremental rendering when useAlternateBuffer is omitted', () => {
+    const options = inkRenderOptions(
+      { getScreenReader: () => false },
+      { merged: { ui: { incrementalRendering: true } } },
+    );
+
+    expect(options).toStrictEqual(
+      expect.objectContaining({
+        exitOnCtrlC: false,
+        patchConsole: false,
+        isScreenReaderEnabled: false,
+        alternateBuffer: false,
+        incrementalRendering: false,
+      }),
+    );
+  });
 });

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.rendering.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.rendering.test.tsx
@@ -108,12 +108,14 @@ const TERMINAL_HEIGHT = 24;
 /** Sentinel supplied as history-item input; never produced by a stub. */
 const HISTORY_SENTINEL = 'static-history-sentinel-2026';
 
+/** Inputs that select the layout branch under test. */
 interface RenderOptions {
   useAlternateBuffer: boolean;
   screenReader?: boolean;
   historyText?: string;
 }
 
+/** What a render exposes to assertions: frame text, geometry, and real Ink refs. */
 interface RenderedLayout {
   frame: string;
   lineCount: number;
@@ -121,6 +123,10 @@ interface RenderedLayout {
   rootUiRef: { current: DOMElement | null };
 }
 
+/**
+ * Minimal runtime source. Only `getScreenReader` varies, because it is the
+ * gate `useLayoutSettings` applies on top of `ui.useAlternateBuffer`.
+ */
 function createConfigSource(screenReader: boolean) {
   return {
     getScreenReader: () => screenReader,
@@ -134,6 +140,7 @@ function createConfigSource(screenReader: boolean) {
   };
 }
 
+/** Settings carrying the buffer choice the layout branches on. */
 function createSettings(useAlternateBuffer: boolean) {
   return {
     merged: {
@@ -150,6 +157,7 @@ function createSettings(useAlternateBuffer: boolean) {
   };
 }
 
+/** UI actions the layout hands to its children; none are asserted on. */
 function createActions() {
   return {
     addItem: vi.fn(),
@@ -162,6 +170,10 @@ function createActions() {
   };
 }
 
+/**
+ * UI state for a render. `rootUiRef` is threaded in so the caller can observe
+ * whether the layout actually mounted its root.
+ */
 function createUIState(
   rootUiRef: { current: DOMElement | null },
   historyText: string | undefined,
@@ -250,6 +262,7 @@ function createUIState(
   };
 }
 
+/** Renders DefaultAppLayout through real Ink and returns what tests assert on. */
 function renderLayout({
   useAlternateBuffer,
   screenReader = false,

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.rendering.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.rendering.test.tsx
@@ -1,0 +1,368 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Rendering regression coverage for DefaultAppLayout (issue #2025).
+ *
+ * These tests render through REAL Ink (the package test setup otherwise
+ * redirects `ink` to a stub) so the assertions are made against actual frame
+ * output and real Ink refs rather than render spies.
+ *
+ * The alternate-buffer branch mounts a fixed-height viewport
+ * (`height={terminalHeight}`, `overflow="hidden"`), so its frame is padded to
+ * exactly `terminalHeight` lines. The standard-buffer branch mounts a
+ * content-height root (`width="90%"`, no height), so its frame is shorter.
+ * Frame line count is therefore a mock-free discriminator between the two
+ * branches.
+ *
+ * Note: an empty `<Static>` renders byte-identically to `null` under Ink, so
+ * the absence of the static region cannot be observed from frame output. What
+ * is observable — and what is asserted here — is that static content reaches
+ * the frame exactly when there is static content to show.
+ */
+
+import { restoreEnv, setEnv } from '@vybestack/llxprt-code-test-utils';
+import { afterEach, describe, expect, it, vi } from 'bun:test';
+import { render } from 'ink-testing-library';
+import { ApprovalMode } from '@vybestack/llxprt-code-core';
+import type { DOMElement } from 'ink';
+
+const realInkModule = {
+  ...(await import('../../../test-utils/real-ink.js')),
+};
+
+void vi.mock('ink', () => realInkModule);
+
+// Leaf components unrelated to layout branching. None of their output is
+// asserted on; they are stubbed only to keep the tree renderable.
+void vi.mock('../components/DialogManager.js', () => ({
+  DialogManager: () => null,
+}));
+void vi.mock('../components/Composer.js', () => ({ Composer: () => null }));
+void vi.mock('../components/AppHeader.js', () => ({ AppHeader: () => null }));
+void vi.mock('../components/ShowMoreLines.js', () => ({
+  ShowMoreLines: () => null,
+}));
+void vi.mock('../components/Notifications.js', () => ({
+  Notifications: () => null,
+}));
+void vi.mock('../components/TodoPanel.js', () => ({ TodoPanel: () => null }));
+void vi.mock('../components/Footer.js', () => ({ Footer: () => null }));
+void vi.mock('../components/BucketAuthConfirmation.js', () => ({
+  BucketAuthConfirmation: () => null,
+}));
+void vi.mock('../components/LoadingIndicator.js', () => ({
+  LoadingIndicator: () => null,
+}));
+void vi.mock('../components/AutoAcceptIndicator.js', () => ({
+  AutoAcceptIndicator: () => null,
+}));
+void vi.mock('../components/ShellModeIndicator.js', () => ({
+  ShellModeIndicator: () => null,
+}));
+void vi.mock('../components/ContextSummaryDisplay.js', () => ({
+  ContextSummaryDisplay: () => null,
+}));
+void vi.mock('../components/DetailedMessagesDisplay.js', () => ({
+  DetailedMessagesDisplay: () => null,
+}));
+void vi.mock('../components/shared/ScrollableList.js', () => ({
+  ScrollableList: () => null,
+}));
+void vi.mock('../components/shared/VirtualizedList.js', () => ({
+  SCROLL_TO_ITEM_END: -1,
+}));
+
+// The CLI runtime context is process-global infrastructure that the layout
+// only reads to hand a message bus to the (stubbed) bucket-auth confirmation.
+const providersRuntime = await import(
+  '@vybestack/llxprt-code-providers/runtime.js'
+);
+
+void vi.mock('@vybestack/llxprt-code-providers/runtime.js', () => ({
+  ...providersRuntime,
+  getCliRuntimeContext: () => ({
+    messageBus: {
+      subscribe: vi.fn(),
+      publish: vi.fn(),
+      unsubscribe: vi.fn(),
+      requestBucketAuthConfirmation: vi.fn(),
+    },
+  }),
+}));
+
+const { DefaultAppLayout } = await import('./DefaultAppLayout.js');
+const { UIStateContext } = await import('../contexts/UIStateContext.js');
+const { UIActionsContext } = await import('../contexts/UIActionsContext.js');
+const { StreamingState } = await import('../types.js');
+const { buildSlashCommandRuntime, buildUiRuntimeFromSource } = await import(
+  '../cliUiRuntime.js'
+);
+
+const TERMINAL_WIDTH = 80;
+const TERMINAL_HEIGHT = 24;
+
+/** Sentinel supplied as history-item input; never produced by a stub. */
+const HISTORY_SENTINEL = 'static-history-sentinel-2026';
+
+interface RenderOptions {
+  useAlternateBuffer: boolean;
+  screenReader?: boolean;
+  historyText?: string;
+}
+
+interface RenderedLayout {
+  frame: string;
+  lineCount: number;
+  mainControlsRef: { current: DOMElement | null };
+  rootUiRef: { current: DOMElement | null };
+}
+
+function createConfigSource(screenReader: boolean) {
+  return {
+    getScreenReader: () => screenReader,
+    getAccessibility: () => ({ disableLoadingPhrases: false }),
+    getMcpServers: () => [],
+    getBlockedMcpServers: () => [],
+    getTargetDir: () => '/tmp',
+    getDebugMode: () => false,
+    getEphemeralSetting: () => undefined,
+    isTrustedFolder: () => true,
+  };
+}
+
+function createSettings(useAlternateBuffer: boolean) {
+  return {
+    merged: {
+      ui: {
+        showTodoPanel: false,
+        hideFooter: false,
+        hideContextSummary: false,
+        useAlternateBuffer,
+      },
+      hideCWD: false,
+      hideSandboxStatus: false,
+      hideModelInfo: false,
+    },
+  };
+}
+
+function createActions() {
+  return {
+    addItem: vi.fn(),
+    handleUserInputSubmit: vi.fn(),
+    handleClearScreen: vi.fn(),
+    setShellModeActive: vi.fn(),
+    handleEscapePromptChange: vi.fn(),
+    vimHandleInput: vi.fn(),
+    setQueueErrorMessage: vi.fn(),
+  };
+}
+
+function createUIState(
+  rootUiRef: { current: DOMElement | null },
+  historyText: string | undefined,
+) {
+  return {
+    terminalWidth: TERMINAL_WIDTH,
+    terminalHeight: TERMINAL_HEIGHT,
+    mainAreaWidth: TERMINAL_WIDTH,
+    inputWidth: TERMINAL_WIDTH,
+    suggestionsWidth: 60,
+    isNarrow: false,
+    history:
+      historyText === undefined
+        ? []
+        : [{ id: 1, type: 'user', text: historyText }],
+    pendingHistoryItems: [],
+    streamingState: StreamingState.Idle,
+    quittingMessages: null,
+    constrainHeight: false,
+    showErrorDetails: false,
+    showToolDescriptions: false,
+    isTodoPanelCollapsed: false,
+    consoleMessages: [],
+    slashCommands: [],
+    staticKey: 0,
+    isInputActive: true,
+    ctrlCPressedOnce: false,
+    ctrlDPressedOnce: false,
+    showEscapePrompt: false,
+    ideContextState: undefined,
+    llxprtMdFileCount: 0,
+    elapsedTime: 0,
+    currentLoadingPhrase: undefined,
+    showAutoAcceptIndicator: ApprovalMode.DEFAULT,
+    shellModeActive: false,
+    thought: undefined,
+    branchName: undefined,
+    debugMessage: '',
+    errorCount: 0,
+    historyTokenCount: 0,
+    vimModeEnabled: false,
+    vimMode: undefined,
+    tokenMetrics: {
+      tokensPerMinute: 0,
+      throttleWaitTimeMs: 0,
+      sessionTokenTotal: 0,
+    },
+    currentModel: 'test-model',
+    availableTerminalHeight: TERMINAL_HEIGHT,
+    activeShellPtyId: null,
+    embeddedShellFocused: false,
+    isQueuedMessagesPanelCollapsed: false,
+    queuedSubmissions: [],
+    coreMemoryFileCount: 0,
+    currentModelLabel: undefined,
+    contextLimit: undefined,
+
+    showWorkspaceMigrationDialog: false,
+    shouldShowIdePrompt: false,
+    isFolderTrustDialogOpen: false,
+    isWelcomeDialogOpen: false,
+    isPermissionsDialogOpen: false,
+    confirmationRequest: null,
+    isThemeDialogOpen: false,
+    isSettingsDialogOpen: false,
+    isAuthDialogOpen: false,
+    isOAuthCodeDialogOpen: false,
+    isEditorDialogOpen: false,
+    isProviderDialogOpen: false,
+    isLoadProfileDialogOpen: false,
+    isCreateProfileDialogOpen: false,
+    isProfileListDialogOpen: false,
+    isProfileDetailDialogOpen: false,
+    isProfileEditorDialogOpen: false,
+    isToolsDialogOpen: false,
+    isLoggingDialogOpen: false,
+    isSubagentDialogOpen: false,
+    isModelsDialogOpen: false,
+    isSessionBrowserDialogOpen: false,
+    isModelConfigDialogOpen: false,
+    isPoliciesDialogOpen: false,
+    showPrivacyNotice: false,
+
+    rootUiRef,
+    pendingHistoryItemRef: { current: null },
+  };
+}
+
+function renderLayout({
+  useAlternateBuffer,
+  screenReader = false,
+  historyText,
+}: RenderOptions): RenderedLayout {
+  const mainControlsRef: { current: DOMElement | null } = { current: null };
+  const rootUiRef: { current: DOMElement | null } = { current: null };
+  const configSource = createConfigSource(screenReader);
+
+  const rendered = render(
+    <UIStateContext.Provider
+      value={createUIState(rootUiRef, historyText) as never}
+    >
+      <UIActionsContext.Provider value={createActions() as never}>
+        <DefaultAppLayout
+          uiRuntime={buildUiRuntimeFromSource(configSource as never)}
+          slashCommandRuntime={buildSlashCommandRuntime(configSource as never)}
+          settings={createSettings(useAlternateBuffer) as never}
+          startupWarnings={[]}
+          version={'0.0.0-test'}
+          nightly={false}
+          mainControlsRef={mainControlsRef}
+          availableTerminalHeight={TERMINAL_HEIGHT}
+          contextFileNames={[]}
+          updateInfo={null}
+        />
+      </UIActionsContext.Provider>
+    </UIStateContext.Provider>,
+  );
+
+  const frame = rendered.lastFrame() ?? '';
+
+  return {
+    frame,
+    lineCount: frame.split('\n').length,
+    mainControlsRef,
+    rootUiRef,
+  };
+}
+
+describe('DefaultAppLayout rendering', () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  describe('standard buffer with the static header suppressed', () => {
+    it('mounts the live controls and the root when there are no static items', () => {
+      setEnv('LLXPRT_CODE_SUPPRESS_STATIC_HEADER', 'true');
+
+      const { mainControlsRef, rootUiRef } = renderLayout({
+        useAlternateBuffer: false,
+      });
+
+      expect(rootUiRef.current).not.toBeNull();
+      expect(mainControlsRef.current).not.toBeNull();
+    });
+
+    it('renders committed history content into the frame', () => {
+      setEnv('LLXPRT_CODE_SUPPRESS_STATIC_HEADER', 'true');
+
+      const { frame } = renderLayout({
+        useAlternateBuffer: false,
+        historyText: HISTORY_SENTINEL,
+      });
+
+      expect(frame).toContain(HISTORY_SENTINEL);
+    });
+
+    it('renders no history content when history is empty', () => {
+      setEnv('LLXPRT_CODE_SUPPRESS_STATIC_HEADER', 'true');
+
+      const { frame, mainControlsRef } = renderLayout({
+        useAlternateBuffer: false,
+      });
+
+      expect(mainControlsRef.current).not.toBeNull();
+      expect(frame).not.toContain(HISTORY_SENTINEL);
+    });
+  });
+
+  describe('buffer selection', () => {
+    it('renders a fixed-height viewport when the alternate buffer is enabled', () => {
+      const { lineCount, mainControlsRef } = renderLayout({
+        useAlternateBuffer: true,
+      });
+
+      expect(lineCount).toBe(TERMINAL_HEIGHT);
+      expect(mainControlsRef.current).not.toBeNull();
+    });
+
+    it('renders a content-height root when the alternate buffer is disabled', () => {
+      setEnv('LLXPRT_CODE_SUPPRESS_STATIC_HEADER', 'true');
+
+      const { frame, lineCount, mainControlsRef } = renderLayout({
+        useAlternateBuffer: false,
+        historyText: HISTORY_SENTINEL,
+      });
+
+      // The sentinel guards against a degenerate render passing the
+      // upper-bound line count: the frame has to carry real content.
+      expect(frame).toContain(HISTORY_SENTINEL);
+      expect(lineCount).toBeLessThan(TERMINAL_HEIGHT);
+      expect(mainControlsRef.current).not.toBeNull();
+    });
+
+    it('falls back to the standard buffer when the screen reader is enabled', () => {
+      const { lineCount, mainControlsRef } = renderLayout({
+        useAlternateBuffer: true,
+        screenReader: true,
+      });
+
+      expect(mainControlsRef.current).not.toBeNull();
+      expect(lineCount).toBeLessThan(TERMINAL_HEIGHT);
+    });
+  });
+});

--- a/packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.test.tsx
@@ -46,6 +46,7 @@ const settings = new LoadedSettings(
   true,
 );
 
+/** Builds user history items whose ids double as the expected static keys. */
 function buildHistory(...ids: number[]): HistoryItem[] {
   return ids.map((id) => ({ id, type: 'user', text: `item-${id}` }));
 }

--- a/packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Static-item composition coverage for DefaultAppLayoutHelpers (issue #2025).
+ *
+ * `useStaticItems` decides what the standard-buffer layout commits to Ink's
+ * static region. `LLXPRT_CODE_SUPPRESS_STATIC_HEADER` drops the app header so
+ * a fresh session commits nothing at all, which is what lets the standard
+ * buffer skip the static region entirely on a clean startup.
+ */
+
+import { restoreEnv, setEnv } from '@vybestack/llxprt-code-test-utils';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'bun:test';
+import type React from 'react';
+import { Config } from '@vybestack/llxprt-code-core';
+import { renderHook } from '../../test-utils/render.js';
+import { LoadedSettings } from '../../config/settings.js';
+import { buildSlashCommandRuntime } from '../cliUiRuntime.js';
+import { useStaticItems } from './DefaultAppLayoutHelpers.js';
+import { AppHeader } from '../components/AppHeader.js';
+import { HistoryItemDisplay } from '../components/HistoryItemDisplay.js';
+import type { HistoryItem } from '../types.js';
+
+const SUPPRESS_STATIC_HEADER = 'LLXPRT_CODE_SUPPRESS_STATIC_HEADER';
+
+const config = buildSlashCommandRuntime(
+  new Config({
+    sessionId: 'default-app-layout-helpers-test',
+    targetDir: tmpdir(),
+    cwd: tmpdir(),
+    debugMode: false,
+    model: 'test-model',
+  }),
+);
+
+const settings = new LoadedSettings(
+  { path: '/system/settings.json', settings: {} },
+  { path: '/system/defaults.json', settings: {} },
+  { path: '/user/settings.json', settings: {} },
+  { path: '/workspace/settings.json', settings: {} },
+  true,
+);
+
+function buildHistory(...ids: number[]): HistoryItem[] {
+  return ids.map((id) => ({ id, type: 'user', text: `item-${id}` }));
+}
+
+/** Drives the hook with the layout's real argument shape. */
+function renderStaticItems(history: HistoryItem[]): React.ReactElement[] {
+  const { result } = renderHook(() =>
+    useStaticItems(
+      config,
+      settings,
+      '1.0.0',
+      false,
+      100,
+      history,
+      100,
+      100,
+      undefined,
+      false,
+      null,
+      false,
+    ),
+  );
+  return result.current;
+}
+
+describe('useStaticItems', () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('commits nothing when the header is suppressed and history is empty', () => {
+    setEnv(SUPPRESS_STATIC_HEADER, 'true');
+
+    expect(renderStaticItems([])).toStrictEqual([]);
+  });
+
+  it('commits history items but not the header when the header is suppressed', () => {
+    setEnv(SUPPRESS_STATIC_HEADER, 'true');
+
+    const items = renderStaticItems(buildHistory(1, 2));
+
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.type)).toStrictEqual([
+      HistoryItemDisplay,
+      HistoryItemDisplay,
+    ]);
+    expect(items.map((item) => item.key)).toStrictEqual(['1', '2']);
+  });
+
+  it('commits the header alone when suppression is off and history is empty', () => {
+    setEnv(SUPPRESS_STATIC_HEADER, undefined);
+
+    const items = renderStaticItems([]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.type).toBe(AppHeader);
+    expect(items[0]?.key).toBe('header');
+  });
+
+  it('commits the header first, ahead of history, when suppression is off', () => {
+    setEnv(SUPPRESS_STATIC_HEADER, undefined);
+
+    const items = renderStaticItems(buildHistory(1, 2));
+
+    expect(items).toHaveLength(3);
+    expect(items.map((item) => item.type)).toStrictEqual([
+      AppHeader,
+      HistoryItemDisplay,
+      HistoryItemDisplay,
+    ]);
+    expect(items.map((item) => item.key)).toStrictEqual(['header', '1', '2']);
+  });
+
+  it('commits the header when the suppression value is not the literal "true"', () => {
+    setEnv(SUPPRESS_STATIC_HEADER, '1');
+
+    const items = renderStaticItems([]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.type).toBe(AppHeader);
+    expect(items[0]?.key).toBe('header');
+  });
+});

--- a/project-plans/issue2025-ink-layout-rendering-coverage.md
+++ b/project-plans/issue2025-ink-layout-rendering-coverage.md
@@ -1,0 +1,215 @@
+# Issue 2025 — Increase Ink layout and rendering regression coverage
+
+Test-only change. No production behavior is added or modified. Every test below
+must fail if the corresponding production branch is inverted or removed.
+
+## Scope
+
+In scope:
+
+- `packages/cli/src/ui/inkRenderOptions.ts` — the alternate-buffer /
+  incremental-rendering gate.
+- `packages/cli/src/ui/layouts/DefaultAppLayout.tsx` — buffer branch selection,
+  static-region gating, live-controls mounting.
+- `packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.tsx` — `useStaticItems`
+  header suppression, `useLayoutSettings.useAlternateBuffer`.
+- A tmux startup-smoke scenario plus its wiring into
+  `scripts/tests/interactive-ui.test.ts`, `.github/workflows/interactive-ui.yml`
+  path filters, and `scripts/tests/interactive-ui-paths.bun.test.ts`.
+
+Out of scope (do not touch): production source changes, tmux harness step
+types, new abstractions, refactors of existing tests beyond what a new
+scenario's path contract requires.
+
+## Findings that constrain the test design
+
+Empirically verified in this repo with real Ink + `ink-testing-library`:
+
+1. `<Static items={[]}>` and `null` produce **byte-identical** output and the
+   same frame count. Therefore a test that asserts "`<Static>` is not rendered
+   when `staticItems` is empty" by inspecting rendered output is **not
+   falsifiable** against the `staticItems.length > 0` guard in
+   `StandardBufferLayout`. Do NOT write such a test — it can never fail for the
+   right reason.
+
+   The falsifiable behavior behind that acceptance item is: **static content is
+   produced exactly when there is static content to show**, which is governed by
+   `useStaticItems` (header suppression + history), and whether that content
+   reaches the frame in standard-buffer mode.
+
+2. A fixed-height root `Box` (`height={terminalHeight}`, `overflow="hidden"`) —
+   the alternate-buffer viewport — renders a frame padded to exactly
+   `terminalHeight` lines. The standard-buffer root (`width="90%"`, no height)
+   renders only as many lines as its content. Frame line count is therefore a
+   real, mock-free discriminator between the two branches.
+
+3. `packages/cli/test-utils/ink-testing-library.ts` renders through real Ink
+   with `debug: true` and a stdout whose `columns` is fixed at **100**. Keep
+   test terminal widths at or below 100.
+
+4. `ink` is redirected to `test-utils/ink-stub.ts` by a Bun plugin in
+   `packages/cli/bun-test-setup.ts`. Tests that need real Ink must
+   `vi.mock('ink', () => realInkModule)` with
+   `../../../test-utils/real-ink.js`, exactly as
+   `packages/cli/src/ui/layouts/InlineContent.test.tsx` does.
+
+5. `UIStateContext` and `UIActionsContext` both export the raw context objects.
+   New tests must supply state through the real providers/contexts rather than
+   `vi.mock`-ing the context modules, so the component under test runs against
+   real context plumbing.
+
+## Acceptance criteria
+
+### AC1 — Incremental rendering is gated on alternate buffer
+
+`inkRenderOptions` (`packages/cli/src/ui/inkRenderOptions.test.ts`):
+
+- AC1.1 `useAlternateBuffer: false` + `incrementalRendering: true` →
+  returned options have `alternateBuffer: false` **and**
+  `incrementalRendering: false`. (Currently uncovered: the existing
+  standard-buffer case omits `incrementalRendering` entirely, so the gate is
+  never exercised with the setting explicitly on.)
+- AC1.2 `useAlternateBuffer` omitted (undefined) + `incrementalRendering: true`
+  → `alternateBuffer: false`, `incrementalRendering: false`.
+
+Existing cases already cover screen-reader override, alt-buffer default-on, and
+explicit `incrementalRendering: false`. Do not duplicate them.
+
+### AC2 — `useStaticItems` produces static content only when it exists
+
+New or extended component-level test for
+`packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.tsx`:
+
+- AC2.1 `LLXPRT_CODE_SUPPRESS_STATIC_HEADER='true'` + empty history → returns an
+  empty array (no header, no history).
+- AC2.2 `LLXPRT_CODE_SUPPRESS_STATIC_HEADER='true'` + two history items →
+  returns exactly two elements, in history order, keyed by history id, none of
+  which is the `AppHeader`.
+- AC2.3 env var unset + empty history → returns exactly one element, the
+  `AppHeader`, keyed `'header'`. With history, the header stays first, ahead of
+  the history elements.
+- AC2.4 env var set to a value other than `'true'` (e.g. `'1'`) + empty history
+  → header is still present (the check is a strict `'true'` comparison).
+
+Env mutation must go through `setEnv`/`restoreEnv` from
+`@vybestack/llxprt-code-test-utils` (see `InlineContent.test.tsx`), restored in
+`afterEach`.
+
+### AC3 — Standard-buffer rendering surfaces static content and live controls
+
+New rendering test for `DefaultAppLayout` under real Ink, standard-buffer
+settings (`ui.useAlternateBuffer: false`), no dialog open:
+
+- AC3.1 With the static header suppressed and empty history, the live-controls
+  region is mounted: the `mainControlsRef` passed in by the test is populated
+  after render (non-null `DOMElement`), and the root `rootUiRef` is populated.
+  This is the "live controls render when the static header is suppressed"
+  criterion, asserted through real refs rather than a spy.
+- AC3.2 With the static header suppressed and one history item whose text is a
+  test-supplied literal, the rendered frame contains that literal — static
+  content reaches the frame in standard-buffer mode.
+- AC3.3 With the static header suppressed and empty history, the rendered frame
+  does not contain the AC3.2 literal (no leakage / no phantom static content).
+
+### AC4 — Buffer selection is honored by the layout
+
+Same rendering test file, using frame geometry as the discriminator
+(finding 2 above). Use `terminalHeight` well above the natural content height
+(e.g. 24) and `terminalWidth <= 100`:
+
+- AC4.1 `ui.useAlternateBuffer: true`, screen reader off → the rendered frame
+  has exactly `terminalHeight` lines (fixed-height alternate-buffer viewport).
+- AC4.2 `ui.useAlternateBuffer: false` → the rendered frame has fewer than
+  `terminalHeight` lines (content-height standard-buffer root).
+- AC4.3 `ui.useAlternateBuffer: true` **and** the runtime reports screen reader
+  enabled → the frame has fewer than `terminalHeight` lines, i.e. the layout
+  falls back to the standard buffer. This is `useLayoutSettings`' screen-reader
+  gate, honored at the layout level (mirroring AC1's gate at the options level).
+- AC4.4 In both AC4.1 and AC4.2 the live-controls ref is populated, so neither
+  branch drops the live controls.
+
+### AC5 — tmux startup smoke
+
+- AC5.1 New scenario `scripts/tmux-script.startup-smoke.json` that starts the
+  CLI under the same tmux child env override used by the other interactive
+  scenarios (`CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= …
+  LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true`) and, on a clean startup with no user
+  input:
+  - waits, with a single regex matcher so all landmarks must be present in the
+    SAME screen, for the composer placeholder followed by the live-controls
+    footer landmarks (`Context:`, `Tokens:`). This is the "first meaningful
+    frame contains the composer" plus "no blank frame" assertion: a blank frame,
+    or a frame carrying only part of the live controls, fails the wait,
+  - captures the startup frame as an artifact,
+  - asserts the composer appears exactly once (no duplicated/ghost frame),
+  - asserts the static header is genuinely suppressed (`Tips for getting
+    started` count is 0), so the scenario covers the empty-static-region
+    startup rather than a header-populated one,
+  - exits via `/quit` and `waitForExit`.
+
+  `LLXPRT_SYSTEM_SETTINGS_PATH` must be an ABSOLUTE path
+  (`$PWD/scripts/system-settings.interactive-ui.json`). `Storage` ignores a
+  relative override, and with the override ignored the schema default
+  (`useAlternateBuffer: true`) wins, which would silently run this scenario on
+  the alternate-buffer path instead of the standard-buffer path it is meant to
+  cover. Verify via the `renderOptions alternateBuffer=… incrementalRendering=…`
+  line in the run's `cli-debug.log` artifact that both are `false`.
+
+  Steps must use only existing harness step types (`waitFor`, `capture`,
+  `expect`, `expectCount`, `line`, `waitForExit`) and existing matcher fields
+  (`contains`, `regex`, `regexFlags`). Do not add harness features.
+
+- AC5.2 The scenario is wired into `scripts/tests/interactive-ui.test.ts` via
+  the existing `runHarness` / `assertHarnessSuccess` helpers and is gated behind
+  `LLXPRT_E2E_TMUX=1` like its neighbors.
+- AC5.3 `.github/workflows/interactive-ui.yml` includes the new scenario JSON in
+  both the `pull_request` and `push` path filters (they must stay symmetric).
+- AC5.4 `scripts/tests/interactive-ui-paths.bun.test.ts` is updated so its
+  "executed scenario JSON files" contract covers the new scenario. Its
+  three-scenario wording/assertion becomes a four-scenario contract. No other
+  assertion in that file changes.
+
+## Non-goals / explicit rejections
+
+- No test that asserts `<Static>` is absent for empty items via rendered output
+  (finding 1 — unfalsifiable).
+- No `toHaveBeenCalledTimes` assertions on component render spies in the new
+  tests; assert on real rendered output, real refs, or real return values.
+- No marker strings invented inside a mock and asserted back (mirror echo).
+  Literals asserted in frames must originate from test *input* (e.g. history
+  item text).
+- No changes to production files.
+
+## Verification
+
+Full cycle before any push:
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Plus, for the new tmux scenario, a local run of the harness against it:
+
+```bash
+npm run test:interactive-ui
+```
+
+Plus the test-audit scanner on touched files: `bun scripts/test-audit/scan.ts`
+must report no new MOCK_MIRROR / ALWAYS_TRUE / SELF_CONFIRMING / NO_ASSERT
+findings.
+
+### Falsification evidence required
+
+For every new test, record (in the PR body) the mutation that was applied to
+production code to prove the test fails, e.g.:
+
+- AC1: remove the `useAlternateBuffer &&` conjunct in `inkRenderOptions`.
+- AC2: invert the `=== 'true'` check in `useStaticItems`.
+- AC3/AC4: swap the `layoutSettings.useAlternateBuffer` branch in
+  `renderLayout`; drop the `MainControls` box.
+- AC5: verified by the scenario passing against a real CLI startup.

--- a/scripts/tests/interactive-ui-paths.bun.test.ts
+++ b/scripts/tests/interactive-ui-paths.bun.test.ts
@@ -9,7 +9,7 @@
  *
  * These read the REAL .github/workflows/interactive-ui.yml through existing
  * typed test helpers and assert:
- *   - direct tmux harness modules, the preload, the test file, its three
+ *   - direct tmux harness modules, the preload, the test file, its four
  *     executed scenario JSON files, and their referenced fixtures are
  *     included in the path filter
  *   - unrelated broad script test/fixture/scenario globs are removed
@@ -84,7 +84,8 @@ describe('interactive-ui.yml: direct harness inputs are included', () => {
     expect(prPaths).toContain('scripts/tests/interactive-ui.test.ts');
   });
 
-  it('includes the three executed scenario JSON files', () => {
+  it('includes the four executed scenario JSON files', () => {
+    expect(prPaths).toContain('scripts/tmux-script.startup-smoke.json');
     expect(prPaths).toContain('scripts/tmux-script.slash-autocomplete.json');
     expect(prPaths).toContain('scripts/tmux-script.approval-ui.json');
     expect(prPaths).toContain(
@@ -92,8 +93,8 @@ describe('interactive-ui.yml: direct harness inputs are included', () => {
     );
   });
 
-  it('includes the scenario config fixtures referenced by all three scenarios', () => {
-    // All three executed scenarios set LLXPRT_CODE_WELCOME_CONFIG_PATH and
+  it('includes the scenario config fixtures referenced by all four scenarios', () => {
+    // All four executed scenarios set LLXPRT_CODE_WELCOME_CONFIG_PATH and
     // LLXPRT_SYSTEM_SETTINGS_PATH to these direct inputs.
     expect(prPaths).toContain('scripts/fixtures/welcome-completed.json');
     expect(prPaths).toContain('scripts/system-settings.interactive-ui.json');

--- a/scripts/tests/interactive-ui.test.ts
+++ b/scripts/tests/interactive-ui.test.ts
@@ -131,6 +131,18 @@ afterAll(() => {
 
 describe('Interactive UI (tmux harness)', () => {
   runTmuxE2E(
+    'clean startup renders a non-blank first frame with the composer',
+    () => {
+      const result = runHarness(
+        'tmux-script.startup-smoke.json',
+        'startup-smoke',
+      );
+      assertHarnessSuccess(result);
+    },
+    300_000,
+  );
+
+  runTmuxE2E(
     'slash autocomplete opens, navigates, and dismisses',
     () => {
       const result = runHarness(

--- a/scripts/tmux-script.startup-smoke.json
+++ b/scripts/tmux-script.startup-smoke.json
@@ -1,0 +1,36 @@
+{
+  "tmux": {
+    "cols": 100,
+    "rows": 40,
+    "historyLimit": 20000,
+    "scrollbackLines": 2000,
+    "initialWaitMs": 6000
+  },
+  "startCommand": [
+    "env CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= LLXPRT_CODE_NO_RELAUNCH=true LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION=true LLXPRT_CODE_BUILTIN_COMMANDS_ONLY=true LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true LLXPRT_CODE_WELCOME_CONFIG_PATH=scripts/fixtures/welcome-completed.json LLXPRT_SYSTEM_SETTINGS_PATH=$PWD/scripts/system-settings.interactive-ui.json ${bun} packages/cli/index.ts"
+  ],
+  "yolo": false,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "regex": "Type your message[\\s\\S]*Context:[\\s\\S]*Tokens:",
+      "timeoutMs": 30000
+    },
+    { "type": "capture", "label": "startup-frame", "scope": "screen" },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "Type your message",
+      "equals": 1
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "Tips for getting started",
+      "equals": 0
+    },
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}


### PR DESCRIPTION
## TLDR

Test-only. No production source file is modified.

The code that picks between the standard and alternate screen buffers, and the code that decides what gets committed to Ink's static region, had no rendering-level coverage. `inkRenderOptions` had four cases but never exercised the incremental-rendering gate with the setting explicitly on, and nothing rendered `DefaultAppLayout` through real Ink, so an inverted branch would have shipped unnoticed.

This adds component coverage for the layout branching plus a tmux startup-smoke scenario for real render output, per the issue's suggested approach.

Two things reviewers should look at:

1. The issue asks for "static items are rendered only when non-empty". Ink renders `<Static items={[]}>` byte-identically to `null` (measured, not assumed), so the `staticItems.length > 0` guard in `StandardBufferLayout` is **not** observable from frame output. A test asserting its absence could never fail for the right reason, so none was written. What is asserted instead is the falsifiable behavior behind it: what `useStaticItems` returns, and whether that content reaches the frame.
2. The new tmux scenario passes `LLXPRT_SYSTEM_SETTINGS_PATH` as an **absolute** path. `Storage` ignores a relative override, and with the override ignored the schema default `useAlternateBuffer: true` wins, which silently routes the run down the alternate-buffer path. The three pre-existing scenarios pass a relative path and are therefore running under alternate buffer today. They are left alone; only the new scenario is corrected, so it actually covers the standard-buffer, empty-static-region startup it claims to.

## Dive Deeper

### What shaped the design

Both facts were measured in this repo before any test was written:

- `<Static items={[]}>` and `null` produce identical output and the same frame count under `ink-testing-library`. Hence no unfalsifiable "Static is absent" test.
- The alternate-buffer viewport is a fixed-height `Box` (`height={terminalHeight}`, `overflow="hidden"`), so its frame is padded to exactly `terminalHeight` lines, while the standard-buffer root (`width="90%"`, no height) is content-height. Frame line count is a real discriminator between the two branches that depends on no mock.

### Coverage added

**`packages/cli/src/ui/inkRenderOptions.test.ts`** — two cases: `incrementalRendering` stays `false` on the standard-buffer path both when `useAlternateBuffer` is explicitly `false` and when it is omitted. The existing four cases are untouched.

**`packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.test.tsx`** (new) — five cases over `useStaticItems`, driven by `renderHook`, asserting element types and keys:

- suppressed + empty history returns `[]`
- suppressed + history returns only `HistoryItemDisplay` elements, in order, keyed by history id
- unset + empty history returns the `AppHeader` alone
- unset + history keeps the header first, ahead of the history elements
- a value other than the literal `'true'` still yields the header (the production check is a strict `=== 'true'`)

**`packages/cli/src/ui/layouts/DefaultAppLayout.rendering.test.tsx`** (new) — renders through **real Ink** (the package test setup otherwise redirects `ink` to a stub) with the **real** `UIStateContext` / `UIActionsContext` providers rather than mocking the context modules:

- the live-controls and root refs are populated when the static region is empty, which is the "live controls render when the static header is suppressed" criterion, asserted through real Ink refs rather than a render spy
- a test-supplied history sentinel reaches the standard-buffer frame through the real `HistoryItemDisplay`, and does not appear when history is empty
- alternate buffer renders exactly `terminalHeight` lines; standard buffer renders fewer while still carrying real content; a screen reader forces the standard-buffer fallback even with `useAlternateBuffer: true`

No `toHaveBeenCalled*` assertions and no assertion depends on a stub's output. Unrelated leaf components are stubbed to `null` only so the tree renders.

**`scripts/tmux-script.startup-smoke.json`** (new) — a clean startup, no user input, under the tmux child CI env override. A single `waitFor` **regex** requires the composer placeholder and the footer landmarks (`Context:`, `Tokens:`) in the *same* screen, so a blank frame or a partially-rendered one fails the wait. It then asserts the composer appears exactly once and that `Tips for getting started` count is 0, proving the static header really is suppressed. Wired into `scripts/tests/interactive-ui.test.ts`, added to both `paths:` filters in `.github/workflows/interactive-ui.yml` (kept symmetric), and the path-contract test in `scripts/tests/interactive-ui-paths.bun.test.ts` is updated from a three- to a four-scenario contract.

`Heap:` was considered as a landmark and rejected: the footer hides memory usage unless debug mode or `ui.showMemoryUsage` is on, so it is environment-dependent. `Context:` is stable at the scenario's fixed 100 columns (below that breakpoint the footer renders `Ctx:`).

**`project-plans/issue2025-ink-layout-rendering-coverage.md`** (new) — the acceptance criteria, the measured findings above, and the explicit non-goals.

### Falsification evidence

Every new test was checked against a deliberate mutation of the production code it covers. Each mutation was applied alone and reverted afterwards; the suite is green on unmutated code.

| Mutation | Tests that failed |
| --- | --- |
| `inkRenderOptions.ts`: drop the `useAlternateBuffer &&` conjunct | both new incremental-rendering cases (plus the two pre-existing cases over the same gate) |
| `DefaultAppLayoutHelpers.tsx`: `=== 'true'` → `!== 'true'` in `useStaticItems` | all 5 `useStaticItems` cases |
| `DefaultAppLayout.tsx`: invert `if (layoutSettings.useAlternateBuffer)` | history-content, fixed-height-viewport, content-height, screen-reader-fallback |
| `DefaultAppLayout.tsx`: delete the standard-buffer `<Box ref={mainControlsRef}><MainControls/></Box>` | live-controls-mount, content-height |
| `DefaultAppLayoutHelpers.tsx`: drop `&& !config.app.getScreenReader()` from `useLayoutSettings` | screen-reader-fallback |

### Known trade-off

The UI-state and UI-actions fixtures in the rendering test use `as never`, matching the pre-existing `DefaultAppLayout.test.tsx`. A fully typed `UIState` fixture needs a shared test-fixture abstraction (it requires a real `TextBuffer`, a `SlashCommandRuntime`, and dozens of other fields) and would also want to be adopted by the existing test. That is a separate change and is out of scope here.

## Reviewer Test Plan

```bash
# component / unit coverage
cd packages/cli && bun test src/ui/inkRenderOptions.test.ts src/ui/layouts/

# path contract
bun test scripts/tests/interactive-ui-paths.bun.test.ts

# tmux lane (needs tmux; use the CI env, otherwise a fresh-HOME theme dialog
# blocks startup and the three pre-existing scenarios time out locally)
CI=true NO_COLOR=true FORCE_COLOR=0 TERM=xterm-256color TERM_PROGRAM=tmux \
  LLXPRT_FORCE_FILE_STORAGE=true LLXPRT_AUTH_TYPE=provider LLXPRT_E2E_TMUX=1 \
  bun test --preload ./scripts/tests/test-setup.ts scripts/tests/interactive-ui.test.ts
```

To confirm the new scenario really runs standard buffer, run the harness directly and read the artifact:

```bash
bun scripts/tmux-harness.ts --script scripts/tmux-script.startup-smoke.json --out-dir /tmp/smoke
cat /tmp/smoke/cli-debug.log     # renderOptions alternateBuffer=false incrementalRendering=false
cat /tmp/smoke/001-startup-frame-screen.txt
```

To confirm the tests are not vacuous, apply any mutation from the table above and watch the listed tests fail.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test` (CLI 716/716 files, 9182 cases), `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, the `stepfun-37` startup smoke, and the tmux interactive-ui lane 4/4. Four `packages/core` and `packages/agents` cases hit the 180s timeout during the full-suite run while the tmux harness and a review tool were running concurrently; all four pass in isolation in about two seconds and none touch the Ink UI.

## Linked issues / bugs

Fixes #2025


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for startup smoke scenarios in the interactive UI workflow.
  * Added regression tests for standard-buffer, alternate-buffer, content-height, and screen-reader rendering.
  * Added coverage for static content and history display behavior.
  * Verified incremental rendering is disabled when alternate-buffer usage is omitted or turned off.
* **Chores**
  * Updated interactive UI workflow validation to include four scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->