### PR TITLE
Cover terminal keyboard, mouse, and capability behavior (Fixes #2024)

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.bracketedPaste.test.ts
+++ b/packages/cli/src/ui/contexts/KeypressContext.bracketedPaste.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { createKeypressPipeline, PASTE_TIMEOUT } from './KeypressContext.js';
+
+type ParsedKey = {
+  name: string;
+  sequence: string;
+  meta?: boolean;
+  ctrl?: boolean;
+  shift?: boolean;
+  insertable?: boolean;
+};
+
+const feed = (chunks: string[]): ParsedKey[] => {
+  const keys: ParsedKey[] = [];
+  const push = createKeypressPipeline((k) => keys.push(k));
+  for (const chunk of chunks) push(chunk);
+  return keys;
+};
+
+describe('bracketed paste decoding (AC4)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('encapsulates the payload in a single paste key with no per-character keys (AC4.1)', () => {
+    const keys = feed(['\x1b[200~hello\x1b[201~']);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toStrictEqual({
+      name: 'paste',
+      shift: false,
+      meta: false,
+      ctrl: false,
+      sequence: 'hello',
+      insertable: true,
+    });
+  });
+
+  it('an empty paste emits no key at all (AC4.2)', () => {
+    const keys = feed(['\x1b[200~\x1b[201~']);
+    expect(keys).toHaveLength(0);
+  });
+
+  it('reassembles a control-sequence-looking payload verbatim (AC4.3)', () => {
+    const keys = feed(['\x1b[200~\x1b[A\x1b[201~']);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toStrictEqual({
+      name: 'paste',
+      shift: false,
+      meta: false,
+      ctrl: false,
+      sequence: '\x1b[A',
+      insertable: true,
+    });
+  });
+
+  it('preserves newlines and tabs byte-for-byte (AC4.4)', () => {
+    const keys = feed(['\x1b[200~line1\n\tline2\x1b[201~']);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]?.sequence).toBe('line1\n\tline2');
+  });
+  it('keeps a trailing CR inside the payload instead of a separate return key (AC4.5)', () => {
+    const keys = feed(['\x1b[200~x\r\x1b[201~']);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toStrictEqual({
+      name: 'paste',
+      shift: false,
+      meta: false,
+      ctrl: false,
+      sequence: 'x\r',
+      insertable: true,
+    });
+  });
+  it('after PASTE_TIMEOUT with no end marker the payload is still flushed (AC4.6)', () => {
+    const flushed = feed(['\x1b[200~stuck']);
+    // The end marker never arrives, so nothing is delivered while the paste
+    // buffer is still open.
+    expect(flushed).toHaveLength(0);
+
+    vi.advanceTimersByTime(PASTE_TIMEOUT);
+
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0]).toStrictEqual({
+      name: 'paste',
+      shift: false,
+      meta: false,
+      ctrl: false,
+      sequence: 'stuck',
+      insertable: true,
+    });
+  });
+});

--- a/packages/cli/src/ui/contexts/KeypressContext.escape.test.ts
+++ b/packages/cli/src/ui/contexts/KeypressContext.escape.test.ts
@@ -85,10 +85,9 @@ describe('escape vs Alt-key disambiguation (AC3)', () => {
     // Same pipeline throughout: this is the disambiguation contract. If the
     // parser kept its escaped state across the flush, the letter would arrive
     // as Alt+b instead of a bare b.
-    expect(keys.map(({ name, meta }) => [name, meta])).toStrictEqual([
-      ['escape', true],
-      ['b', false],
-    ]);
+    expect(keys.map(({ name }) => name)).toStrictEqual(['escape', 'b']);
+    expect(keyMatchers[Command.ESCAPE](keys[0])).toBe(true);
+    expect(keys[1].meta).toBe(false);
     expect(keys[1].sequence).toBe('b');
   });
 

--- a/packages/cli/src/ui/contexts/KeypressContext.escape.test.ts
+++ b/packages/cli/src/ui/contexts/KeypressContext.escape.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import type { Key } from './KeypressContext.js';
+import { createKeypressPipeline, ESC_TIMEOUT } from './KeypressContext.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
+
+/**
+ * One live pipeline plus the keys it has decoded so far. Tests that span the
+ * ESC_TIMEOUT boundary must keep pushing into the SAME pipeline: a fresh one
+ * has no pending escape state, so feeding it the second chunk would prove
+ * nothing about disambiguation.
+ */
+const startPipeline = (): {
+  push: (data: string) => void;
+  keys: Key[];
+} => {
+  const keys: Key[] = [];
+  return { push: createKeypressPipeline((k) => keys.push(k)), keys };
+};
+
+/** Feed the given chunks through one pipeline and collect decoded keys. */
+const feed = (chunks: string[]): Key[] => {
+  const { push, keys } = startPipeline();
+  for (const chunk of chunks) push(chunk);
+  return keys;
+};
+
+/** Assert exactly one key was decoded and return it. */
+const only = (keys: Key[]): Key => {
+  expect(keys).toHaveLength(1);
+  return keys[0];
+};
+
+// The bare-Escape cases below assert the Command.ESCAPE matcher rather than
+// the `meta` flag. The parser reports `meta: true` for a lone Escape because
+// the byte arrives through the escaped branch, which is incidental; what
+// callers depend on is that the key still triggers the escape binding. The
+// matcher assertion is the regression guard for that: constrain the ESCAPE
+// binding on modifiers and Escape stops working, and these tests fail.
+describe('escape vs Alt-key disambiguation (AC3)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('a lone ESC emits nothing until ESC_TIMEOUT and then one escape key that matches Command.ESCAPE (AC3.1)', () => {
+    const keys = feed(['\x1b']);
+    expect(keys).toHaveLength(0);
+
+    vi.advanceTimersByTime(ESC_TIMEOUT);
+    const key = only(keys);
+    expect(key.name).toBe('escape');
+    expect(key.sequence).toBe('\x1b');
+    expect(keyMatchers[Command.ESCAPE](key)).toBe(true);
+  });
+
+  it('ESC plus a letter in one chunk is Alt+letter, not Escape then letter (AC3.2)', () => {
+    const keys = feed(['\x1bb']);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toStrictEqual({
+      name: 'b',
+      meta: true,
+      shift: false,
+      ctrl: false,
+      sequence: '\x1bb',
+      insertable: true,
+    });
+  });
+
+  it('ESC, then a letter after the timeout, emits escape then an unmodified letter (AC3.3)', () => {
+    const { push, keys } = startPipeline();
+
+    push('\x1b');
+    vi.advanceTimersByTime(ESC_TIMEOUT);
+    push('b');
+
+    // Same pipeline throughout: this is the disambiguation contract. If the
+    // parser kept its escaped state across the flush, the letter would arrive
+    // as Alt+b instead of a bare b.
+    expect(keys.map(({ name, meta }) => [name, meta])).toStrictEqual([
+      ['escape', true],
+      ['b', false],
+    ]);
+    expect(keys[1].sequence).toBe('b');
+  });
+
+  it('two ESC bytes in one chunk emit one escape key matching Command.ESCAPE (AC3.4)', () => {
+    const keys = feed(['\x1b\x1b']);
+    vi.advanceTimersByTime(ESC_TIMEOUT);
+    const key = only(keys);
+    expect(key.name).toBe('escape');
+    expect(key.sequence).toBe('\x1b');
+    expect(keyMatchers[Command.ESCAPE](key)).toBe(true);
+  });
+
+  it('treats ESC [ as a CSI introducer (AC3.5)', () => {
+    const keys = feed(['\x1b[A']);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toStrictEqual({
+      name: 'up',
+      shift: false,
+      meta: false,
+      ctrl: false,
+      sequence: '\x1b[A',
+      insertable: false,
+    });
+  });
+
+  // The `sequence` field is deliberately not asserted here. The SS3 reader
+  // reports `\x1bA` rather than the `\x1bOA` bytes it consumed, dropping the
+  // `O`, which is inconsistent with the CSI reader above. That inconsistency
+  // is out of scope for this coverage change and asserting it would freeze it
+  // as the contract, so only the decoded key identity is pinned.
+  it('treats ESC O as an SS3 introducer (AC3.6)', () => {
+    const key = only(feed(['\x1bOA']));
+    expect(key.name).toBe('up');
+    expect(key.meta).toBe(false);
+    expect(key.ctrl).toBe(false);
+    expect(key.shift).toBe(false);
+  });
+});

--- a/packages/cli/src/ui/contexts/KeypressContext.lifecycle.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.lifecycle.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { act } from 'react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'bun:test';
+import { renderHook } from '../../test-utils/render.js';
+import { useStdin } from 'ink';
+import { EventEmitter } from 'node:events';
+import {
+  KeypressProvider,
+  useKeypressContext,
+  ESC_TIMEOUT,
+} from './KeypressContext.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+
+// Only useStdin is replaced; the rest of ink is the real module, so the
+// provider runs against a stdin whose isRaw each test controls.
+const original = { ...(await import('ink')) };
+void vi.mock('ink', () => ({
+  ...original,
+  useStdin: vi.fn(),
+}));
+
+/**
+ * Mock stdin whose isRaw is controllable so the raw-mode ownership guard
+ * (`wasRaw === false`) can be pinned for every branch. Existing MockStdin
+ * classes in the suite never define `isRaw` at all, which makes them
+ * unusable for AC1.
+ */
+class MockStdin extends EventEmitter {
+  isTTY = true;
+  isRaw: boolean | undefined = false;
+  setRawMode = vi.fn();
+  override on = this.addListener;
+  override removeListener = super.removeListener;
+  resume = vi.fn();
+  pause = vi.fn();
+
+  write(text: string) {
+    this.emit('data', text);
+  }
+}
+
+const waitForEscTimeout = () => {
+  act(() => {
+    vi.advanceTimersByTime(ESC_TIMEOUT + 10);
+  });
+};
+
+/** Mount a KeypressProvider and subscribe a spy to it. */
+const setupProvider = () => {
+  const keyHandler = vi.fn();
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <KeypressProvider>{children}</KeypressProvider>
+  );
+
+  const { result, unmount } = renderHook(() => useKeypressContext(), {
+    wrapper,
+  });
+  act(() => result.current.subscribe(keyHandler));
+
+  return { keyHandler, unmount };
+};
+
+/** Render a toggling useKeypress consumer inside a KeypressProvider. */
+const renderTogglingConsumer = (keyHandler: ReturnType<typeof vi.fn>) => {
+  const harness = renderHook(
+    (isActive: boolean) => {
+      useKeypress(keyHandler, { isActive });
+      return null;
+    },
+    {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <KeypressProvider>{children}</KeypressProvider>
+      ),
+      initialProps: false,
+    },
+  );
+  return harness;
+};
+
+describe('KeypressProvider raw mode ownership (AC1)', () => {
+  let stdin: MockStdin;
+  let mockSetRawMode: ReturnType<typeof vi.fn>;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <KeypressProvider>{children}</KeypressProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    stdin = new MockStdin();
+    mockSetRawMode = vi.fn();
+    (useStdin as Mock<(...args: never[]) => unknown>).mockReturnValue({
+      stdin,
+      setRawMode: mockSetRawMode,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('turns raw mode on at mount and off at unmount once when it owns raw mode (AC1.1, AC1.2)', () => {
+    const { unmount } = renderHook(() => useKeypressContext(), { wrapper });
+
+    expect(mockSetRawMode.mock.calls).toStrictEqual([[true]]);
+
+    unmount();
+
+    expect(mockSetRawMode.mock.calls).toStrictEqual([[true], [false]]);
+  });
+
+  it('never calls setRawMode when isRaw is true (AC1.3)', () => {
+    stdin.isRaw = true;
+    const { unmount } = renderHook(() => useKeypressContext(), { wrapper });
+
+    expect(mockSetRawMode).not.toHaveBeenCalled();
+
+    unmount();
+    expect(mockSetRawMode).not.toHaveBeenCalled();
+  });
+
+  it('never calls setRawMode when isRaw is undefined (AC1.4)', () => {
+    stdin.isRaw = undefined;
+    const { unmount } = renderHook(() => useKeypressContext(), { wrapper });
+
+    expect(mockSetRawMode).not.toHaveBeenCalled();
+
+    unmount();
+    expect(mockSetRawMode).not.toHaveBeenCalled();
+  });
+});
+
+describe('KeypressProvider subscription lifecycle (AC2)', () => {
+  let stdin: MockStdin;
+  let mockSetRawMode: ReturnType<typeof vi.fn>;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <KeypressProvider>{children}</KeypressProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    stdin = new MockStdin();
+    mockSetRawMode = vi.fn();
+    (useStdin as Mock<(...args: never[]) => unknown>).mockReturnValue({
+      stdin,
+      setRawMode: mockSetRawMode,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('attaches exactly one stdin data listener and removes it on unmount (AC2.1)', () => {
+    const { unmount } = renderHook(() => useKeypressContext(), { wrapper });
+
+    expect(stdin.listenerCount('data')).toBe(1);
+
+    unmount();
+    expect(stdin.listenerCount('data')).toBe(0);
+  });
+
+  it('delivers nothing to a subscribed handler after unmount (AC2.2)', () => {
+    const { keyHandler, unmount } = setupProvider();
+
+    // Positive control: without this, a completely broken broadcast path would
+    // satisfy the not-called assertion below.
+    act(() => stdin.write('a'));
+    waitForEscTimeout();
+    expect(keyHandler).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    act(() => stdin.write('a'));
+    waitForEscTimeout();
+    expect(keyHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops delivery to one handler after unsubscribe while another keeps receiving (AC2.3)', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { result } = renderHook(() => useKeypressContext(), { wrapper });
+    act(() => {
+      result.current.subscribe(first);
+      result.current.subscribe(second);
+    });
+    act(() => result.current.unsubscribe(first));
+
+    act(() => stdin.write('a'));
+    waitForEscTimeout();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalled();
+  });
+
+  it('honors isActive toggles without unmounting the provider (AC2.4)', () => {
+    const keyHandler = vi.fn();
+    const toggling = renderTogglingConsumer(keyHandler);
+
+    // Starts inactive: no delivery.
+    act(() => stdin.write('a'));
+    waitForEscTimeout();
+    expect(keyHandler).not.toHaveBeenCalled();
+
+    // Activate: delivery starts.
+    toggling.rerender(true);
+    act(() => stdin.write('a'));
+    waitForEscTimeout();
+    expect(keyHandler).toHaveBeenCalledTimes(1);
+
+    // Deactivate: delivery stops.
+    toggling.rerender(false);
+    act(() => stdin.write('a'));
+    waitForEscTimeout();
+    expect(keyHandler).toHaveBeenCalledTimes(1);
+
+    // The provider itself was never unmounted during the flips.
+    expect(stdin.listenerCount('data')).toBe(1);
+  });
+});

--- a/packages/cli/src/ui/contexts/MouseContext.test.tsx
+++ b/packages/cli/src/ui/contexts/MouseContext.test.tsx
@@ -5,13 +5,25 @@
  */
 
 import type React from 'react';
-import { renderHook } from '../../test-utils/render.js';
 import { act } from 'react';
-import { vi, type Mock } from 'bun:test';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'bun:test';
 import { useStdin } from 'ink';
 import { EventEmitter } from 'node:events';
+import { renderHook } from '../../test-utils/render.js';
 import { MouseProvider, useMouseContext } from './MouseContext.js';
 import { useMouse } from '../hooks/useMouse.js';
+import type { MouseEvent } from '../utils/mouse.js';
+
+const SGR_PRESS = '\x1b[<0;10;20M';
+const SGR_RELEASE = '\x1b[<0;10;20m';
+
+/**
+ * Mirrors MAX_MOUSE_BUFFER_SIZE in MouseContext.tsx, which is module-private.
+ * The junk-recovery tests below must exceed it for the buffer trim to run at
+ * all; if the production cap is ever raised above this value, update it here
+ * too or those tests stop exercising the boundary they were written for.
+ */
+const MAX_MOUSE_BUFFER_SIZE = 4096;
 
 const original = { ...(await import('ink')) };
 void vi.mock('ink', () => ({
@@ -27,9 +39,29 @@ class MockStdin extends EventEmitter {
   resume = vi.fn();
   pause = vi.fn();
 
-  write(text: string) {
+  write(text: string): void {
     this.emit('data', text);
   }
+}
+
+function renderMouseProvider(
+  mouseEventsEnabled: boolean | undefined,
+  events: MouseEvent[] = [],
+): { unmount: () => void } {
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    mouseEventsEnabled === undefined ? (
+      <MouseProvider>{children}</MouseProvider>
+    ) : (
+      <MouseProvider mouseEventsEnabled={mouseEventsEnabled}>
+        {children}
+      </MouseProvider>
+    );
+  const { result, unmount } = renderHook(() => useMouseContext(), { wrapper });
+  const collectEvent = (event: MouseEvent): void => {
+    events.push(event);
+  };
+  act(() => result.current.subscribe(collectEvent));
+  return { unmount };
 }
 
 describe('MouseContext', () => {
@@ -37,6 +69,7 @@ describe('MouseContext', () => {
   let wrapper: React.FC<{ children: React.ReactNode }>;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     stdin = new MockStdin();
     (useStdin as Mock<(...args: never[]) => unknown>).mockReturnValue({
       stdin,
@@ -52,11 +85,11 @@ describe('MouseContext', () => {
     const { result } = renderHook(() => useMouseContext(), { wrapper });
 
     act(() => result.current.subscribe(handler));
-    act(() => stdin.write('\x1b[<0;10;20M'));
+    act(() => stdin.write(SGR_PRESS));
     expect(handler).toHaveBeenCalledTimes(1);
 
     act(() => result.current.unsubscribe(handler));
-    act(() => stdin.write('\x1b[<0;10;20M'));
+    act(() => stdin.write(SGR_PRESS));
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
@@ -64,7 +97,7 @@ describe('MouseContext', () => {
     const handler = vi.fn();
     renderHook(() => useMouse(handler, { isActive: false }), { wrapper });
 
-    act(() => stdin.write('\x1b[<0;10;20M'));
+    act(() => stdin.write(SGR_PRESS));
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -78,7 +111,122 @@ describe('MouseContext', () => {
     });
 
     act(() => result.current.subscribe(handler));
-    act(() => stdin.write('\x1b[<0;10;20M'));
+    act(() => stdin.write(SGR_PRESS));
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('attaches exactly one data listener when enabled and removes it on unmount (AC2.5)', () => {
+    const rendered = renderMouseProvider(true);
+
+    expect(stdin.listenerCount('data')).toBe(1);
+
+    rendered.unmount();
+    expect(stdin.listenerCount('data')).toBe(0);
+  });
+
+  it('attaches no data listener when mouseEventsEnabled is omitted (AC2.5)', () => {
+    const omitted = renderMouseProvider(undefined);
+    expect(stdin.listenerCount('data')).toBe(0);
+    omitted.unmount();
+
+    const enabled = renderMouseProvider(true);
+    expect(stdin.listenerCount('data')).toBe(1);
+    enabled.unmount();
+  });
+
+  it('attaches and detaches the data listener as mouseEventsEnabled changes (AC2.5)', () => {
+    let enabled = false;
+    const togglingWrapper = ({ children }: { children: React.ReactNode }) => (
+      <MouseProvider mouseEventsEnabled={enabled}>{children}</MouseProvider>
+    );
+    const rendered = renderHook(() => useMouseContext(), {
+      wrapper: togglingWrapper,
+    });
+    expect(stdin.listenerCount('data')).toBe(0);
+
+    enabled = true;
+    rendered.rerender();
+    expect(stdin.listenerCount('data')).toBe(1);
+
+    enabled = false;
+    rendered.rerender();
+    expect(stdin.listenerCount('data')).toBe(0);
+  });
+
+  it('broadcasts a split SGR sequence once after the final chunk arrives (AC6.1)', () => {
+    const events: MouseEvent[] = [];
+    renderMouseProvider(true, events);
+
+    act(() => stdin.write('\x1b[<0;10;'));
+    expect(events).toStrictEqual([]);
+
+    act(() => stdin.write('20M'));
+    expect(events).toStrictEqual([
+      {
+        name: 'left-press',
+        col: 10,
+        row: 20,
+        shift: false,
+        meta: false,
+        ctrl: false,
+        button: 'left',
+      },
+    ]);
+  });
+
+  it('broadcasts two complete sequences from one chunk in arrival order (AC6.2)', () => {
+    const events: MouseEvent[] = [];
+    renderMouseProvider(true, events);
+
+    act(() => stdin.write(`${SGR_PRESS}${SGR_RELEASE}`));
+
+    expect(events.map(({ name }) => name)).toStrictEqual([
+      'left-press',
+      'left-release',
+    ]);
+  });
+
+  it('discards garbage before a valid sequence and broadcasts the valid event (AC6.3)', () => {
+    const events: MouseEvent[] = [];
+    renderMouseProvider(true, events);
+
+    act(() => stdin.write(`not-a-mouse-event${SGR_PRESS}`));
+
+    expect(events).toStrictEqual([
+      {
+        name: 'left-press',
+        col: 10,
+        row: 20,
+        shift: false,
+        meta: false,
+        ctrl: false,
+        button: 'left',
+      },
+    ]);
+  });
+
+  it('does not wedge on a very large run of junk and still broadcasts a later event (AC6.4)', () => {
+    const events: MouseEvent[] = [];
+    renderMouseProvider(true, events);
+
+    act(() => stdin.write('x'.repeat(MAX_MOUSE_BUFFER_SIZE + 1)));
+    expect(events).toStrictEqual([]);
+
+    act(() => stdin.write(SGR_PRESS));
+    expect(events.map(({ name }) => name)).toStrictEqual(['left-press']);
+  });
+
+  it('does not wedge on junk that looks like an unterminated SGR sequence (AC6.4)', () => {
+    const events: MouseEvent[] = [];
+    renderMouseProvider(true, events);
+
+    // Starts like an SGR sequence and never terminates, so it survives the
+    // parse attempt rather than being discarded outright. This is the input
+    // the buffer cap exists for.
+    act(() => stdin.write(`\x1b[<${'1'.repeat(MAX_MOUSE_BUFFER_SIZE * 2)}`));
+    expect(events).toStrictEqual([]);
+
+    act(() => stdin.write(SGR_PRESS));
+    expect(events.map(({ name }) => name)).toStrictEqual(['left-press']);
   });
 });

--- a/packages/cli/src/ui/hooks/useBracketedPaste.test.tsx
+++ b/packages/cli/src/ui/hooks/useBracketedPaste.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'bun:test';
+import { renderHook } from '../../test-utils/render.js';
+import { useBracketedPaste } from './useBracketedPaste.js';
+
+// The terminal escape bytes are emitted through core's writeToStdout, which is
+// infrastructure; stub that boundary so the exact bytes can be captured while
+// bracketedPaste.ts and the hook run for real.
+const realCore = { ...(await import('@vybestack/llxprt-code-core')) };
+void vi.mock('@vybestack/llxprt-code-core', () => ({
+  ...realCore,
+  writeToStdout: vi.fn(),
+}));
+
+import { writeToStdout } from '@vybestack/llxprt-code-core';
+
+/** Bytes routed through core's writeToStdout, in order, for the current test. */
+const writtenBytes: string[] = [];
+
+const readWrittenBytes = (): string[] => [...writtenBytes];
+
+type LifecycleSignal = 'exit' | 'SIGINT' | 'SIGTERM';
+
+/** What a clean teardown looks like: nothing new left on any signal. */
+const NO_SURVIVING_LISTENERS: Record<LifecycleSignal, unknown[]> = {
+  exit: [],
+  SIGINT: [],
+  SIGTERM: [],
+};
+
+/**
+ * Listeners present on the lifecycle signals right now, captured by identity.
+ *
+ * Counting is not enough: the ink test renderer registers its own SIGINT and
+ * SIGTERM handlers during any render, so a count that merely grew proves
+ * nothing about the hook. Diffing the identity sets isolates exactly the
+ * handlers this hook added.
+ */
+const listenerSets = (): Record<LifecycleSignal, Set<unknown>> => ({
+  exit: new Set<unknown>(process.listeners('exit')),
+  SIGINT: new Set<unknown>(process.listeners('SIGINT')),
+  SIGTERM: new Set<unknown>(process.listeners('SIGTERM')),
+});
+
+const addedSince = (
+  current: readonly unknown[],
+  before: Set<unknown>,
+): unknown[] => current.filter((listener) => !before.has(listener));
+
+/** Listeners added since the snapshot that are still registered. */
+const survivorsSince = (
+  before: Record<LifecycleSignal, Set<unknown>>,
+): Record<LifecycleSignal, unknown[]> => ({
+  exit: addedSince(process.listeners('exit'), before.exit),
+  SIGINT: addedSince(process.listeners('SIGINT'), before.SIGINT),
+  SIGTERM: addedSince(process.listeners('SIGTERM'), before.SIGTERM),
+});
+
+describe('useBracketedPaste (AC4.7)', () => {
+  const mockedWriteToStdout = writeToStdout as Mock<typeof writeToStdout>;
+
+  beforeEach(() => {
+    writtenBytes.length = 0;
+    mockedWriteToStdout.mockImplementation(
+      (chunk: Parameters<typeof writeToStdout>[0]) => {
+        writtenBytes.push(String(chunk));
+        return true;
+      },
+    );
+  });
+
+  afterEach(() => {
+    mockedWriteToStdout.mockReset();
+  });
+
+  it('writes the enable sequence on mount and the disable sequence on unmount', () => {
+    const { unmount } = renderHook(() => useBracketedPaste());
+
+    expect(readWrittenBytes()).toStrictEqual(['\x1b[?2004h']);
+
+    unmount();
+
+    expect(readWrittenBytes()).toStrictEqual(['\x1b[?2004h', '\x1b[?2004l']);
+  });
+
+  it('registers the same cleanup handler on exit, SIGINT and SIGTERM', () => {
+    const before = listenerSets();
+
+    renderHook(() => useBracketedPaste());
+
+    // ink's renderer adds its own SIGINT and SIGTERM handlers but none on
+    // 'exit', so the single handler added there is unambiguously the hook's.
+    // The hook registers one shared cleanup callback, so that exact reference
+    // is what must also appear on the two signals ink pollutes — a count
+    // comparison there would be satisfied by ink alone.
+    const addedOnExit = addedSince(process.listeners('exit'), before.exit);
+    expect(addedOnExit).toHaveLength(1);
+
+    const [cleanup] = addedOnExit;
+    expect(addedSince(process.listeners('SIGINT'), before.SIGINT)).toContain(
+      cleanup,
+    );
+    expect(addedSince(process.listeners('SIGTERM'), before.SIGTERM)).toContain(
+      cleanup,
+    );
+
+    // Registration alone is not the contract. The handler exists so that a
+    // Ctrl-C or a kill does not leave the terminal in bracketed-paste mode,
+    // so run it and require the disable sequence on the wire.
+    expect(cleanup).toBeInstanceOf(Function);
+    (cleanup as () => void)();
+    expect(readWrittenBytes()).toStrictEqual(['\x1b[?2004h', '\x1b[?2004l']);
+  });
+
+  it('removes every handler it registered on unmount', () => {
+    const before = listenerSets();
+
+    const { unmount } = renderHook(() => useBracketedPaste());
+    unmount();
+
+    expect(survivorsSince(before)).toStrictEqual(NO_SURVIVING_LISTENERS);
+  });
+
+  it('repeated mount/unmount cycles do not accumulate process listeners', () => {
+    const before = listenerSets();
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const { unmount } = renderHook(() => useBracketedPaste());
+      unmount();
+    }
+
+    expect(survivorsSince(before)).toStrictEqual(NO_SURVIVING_LISTENERS);
+  });
+});

--- a/packages/cli/src/ui/hooks/useKittyKeyboardProtocol.test.ts
+++ b/packages/cli/src/ui/hooks/useKittyKeyboardProtocol.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { renderHook } from '../../test-utils/render.js';
+import { useKittyKeyboardProtocol } from './useKittyKeyboardProtocol.js';
+import { terminalCapabilityManager } from '../utils/terminalCapabilityManager.js';
+
+describe('useKittyKeyboardProtocol (AC5.1)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports the manager enabled state at first render with checking false', () => {
+    vi.spyOn(
+      terminalCapabilityManager,
+      'isKittyProtocolEnabled',
+    ).mockReturnValue(true);
+
+    const { result } = renderHook(() => useKittyKeyboardProtocol());
+
+    expect(result.current).toStrictEqual({ enabled: true, checking: false });
+  });
+
+  it('reports a disabled manager at first render with checking false', () => {
+    vi.spyOn(
+      terminalCapabilityManager,
+      'isKittyProtocolEnabled',
+    ).mockReturnValue(false);
+
+    const { result } = renderHook(() => useKittyKeyboardProtocol());
+
+    expect(result.current).toStrictEqual({ enabled: false, checking: false });
+  });
+
+  it('keeps returning the first snapshot across re-renders when the manager state changes', () => {
+    const isKittyProtocolEnabled = vi
+      .spyOn(terminalCapabilityManager, 'isKittyProtocolEnabled')
+      .mockReturnValue(true);
+
+    const { result, rerender } = renderHook(() => useKittyKeyboardProtocol());
+
+    expect(result.current).toStrictEqual({ enabled: true, checking: false });
+
+    // Detection is startup-only: a later manager change must not reach the
+    // already-snapshotted hook.
+    isKittyProtocolEnabled.mockReturnValue(false);
+    rerender();
+
+    expect(result.current).toStrictEqual({ enabled: true, checking: false });
+  });
+});

--- a/packages/cli/src/ui/hooks/useMouseSelection.test.tsx
+++ b/packages/cli/src/ui/hooks/useMouseSelection.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { useEffect, useRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'bun:test';
+import { Box, Text, useApp, type DOMElement, type Selection } from 'ink';
+import { EventEmitter } from 'node:events';
+import { render } from '../../test-utils/render.js';
+import { Colors } from '../colors.js';
+import { MouseProvider } from '../contexts/MouseContext.js';
+import { ScrollProvider } from '../contexts/ScrollProvider.js';
+
+const actualInk = { ...(await import('ink')) };
+const mockUseStdin = vi.fn();
+void vi.mock('ink', () => ({
+  ...actualInk,
+  useStdin: mockUseStdin,
+}));
+
+void vi.mock('../utils/clipboard.js', () => ({
+  copyTextToClipboard: async (): Promise<{
+    success: true;
+    text: string;
+  }> => ({ success: true, text: '' }),
+}));
+
+const { useMouseSelection } = await import('./useMouseSelection.js');
+
+const SELECTABLE_TEXT = 'selection target';
+const activeRenders = new Set<ReturnType<typeof render>>();
+
+function unmountActiveHarnesses(): void {
+  for (const rendered of activeRenders) {
+    rendered.unmount();
+  }
+  activeRenders.clear();
+}
+
+class MockStdin extends EventEmitter {
+  write(text: string): void {
+    this.emit('data', text);
+  }
+}
+
+interface SelectionSurfaceProps {
+  readonly enabled: boolean;
+  readonly hasSelectableText: boolean;
+  readonly onCopiedText: (text: string) => void;
+  readonly captureSelection: (selection: Selection | undefined) => void;
+}
+
+function SelectionSurface({
+  enabled,
+  hasSelectableText,
+  onCopiedText,
+  captureSelection,
+}: SelectionSurfaceProps): React.ReactElement {
+  const rootRef = useRef<DOMElement | null>(null);
+  const { selection } = useApp();
+
+  useMouseSelection({ enabled, rootRef, onCopiedText });
+  useEffect(() => {
+    captureSelection(selection);
+  }, [captureSelection, selection]);
+
+  return (
+    <Box ref={rootRef}>
+      {hasSelectableText ? (
+        <Text color={Colors.Foreground}>{SELECTABLE_TEXT}</Text>
+      ) : null}
+    </Box>
+  );
+}
+
+interface SelectionHarness {
+  readonly stdin: MockStdin;
+  readonly copiedTexts: string[];
+  readonly getSelection: () => Selection;
+  readonly setEnabled: (enabled: boolean) => void;
+}
+
+function renderSelectionHarness({
+  enabled = true,
+  hasSelectableText = true,
+}: {
+  readonly enabled?: boolean;
+  readonly hasSelectableText?: boolean;
+} = {}): SelectionHarness {
+  // Only one harness may be mounted at a time. `useStdin` is a single shared
+  // mock, so a second harness would repoint it while the first tree is still
+  // live, and any re-render of that tree would hand its MouseProvider the
+  // wrong stdin — cross-wiring the two harnesses' event subscriptions.
+  unmountActiveHarnesses();
+
+  const copiedTexts: string[] = [];
+  const stdin = new MockStdin();
+  let selection: Selection | undefined;
+  mockUseStdin.mockReturnValue({
+    stdin,
+    setRawMode: vi.fn(),
+  });
+
+  const captureSelection = (current: Selection | undefined): void => {
+    selection = current;
+  };
+  const onCopiedText = (text: string): void => {
+    copiedTexts.push(text);
+  };
+  const tree = (currentEnabled: boolean): React.ReactElement => (
+    <MouseProvider mouseEventsEnabled={true}>
+      <ScrollProvider>
+        <SelectionSurface
+          enabled={currentEnabled}
+          hasSelectableText={hasSelectableText}
+          onCopiedText={onCopiedText}
+          captureSelection={captureSelection}
+        />
+      </ScrollProvider>
+    </MouseProvider>
+  );
+
+  const rendered = render(tree(enabled));
+  activeRenders.add(rendered);
+
+  return {
+    stdin,
+    copiedTexts,
+    getSelection: (): Selection => {
+      if (!selection) {
+        throw new Error('Ink did not provide its Selection instance');
+      }
+      return selection;
+    },
+    setEnabled: (nextEnabled: boolean): void => {
+      rendered.rerender(tree(nextEnabled));
+    },
+  };
+}
+
+function sgrSequence(
+  buttonCode: number,
+  col: number,
+  row: number,
+  action: 'M' | 'm' = 'M',
+): string {
+  return `\x1b[<${buttonCode};${col};${row}${action}`;
+}
+
+function dragAcrossText(
+  stdin: SelectionHarness['stdin'],
+  startCol: number,
+  endCol: number,
+): void {
+  stdin.write(sgrSequence(0, startCol, 1));
+  stdin.write(sgrSequence(32, endCol, 1));
+  stdin.write(sgrSequence(0, endCol, 1, 'm'));
+}
+
+afterEach(() => {
+  unmountActiveHarnesses();
+  vi.clearAllMocks();
+});
+
+describe('useMouseSelection', () => {
+  it('copies the characters spanned by a press, move, and release drag (AC6.9)', () => {
+    const harness = renderSelectionHarness();
+
+    dragAcrossText(harness.stdin, 2, 7);
+
+    expect(harness.getSelection().toString()).toBe('elect');
+    expect(harness.copiedTexts).toStrictEqual(['elect']);
+  });
+
+  it('leaves selection unchanged when move arrives without a preceding press (AC6.10)', () => {
+    const control = renderSelectionHarness();
+    dragAcrossText(control.stdin, 2, 7);
+    expect(control.getSelection().toString()).toBe('elect');
+
+    const harness = renderSelectionHarness();
+    harness.stdin.write(sgrSequence(32, 7, 1));
+
+    expect(harness.getSelection().toString()).toBe('');
+    expect(harness.copiedTexts).toStrictEqual([]);
+  });
+
+  it('does not copy a drag over a surface with nothing selectable (AC6.11)', () => {
+    const control = renderSelectionHarness();
+    dragAcrossText(control.stdin, 2, 7);
+    expect(control.getSelection().toString()).toBe('elect');
+
+    const harness = renderSelectionHarness({ hasSelectableText: false });
+    dragAcrossText(harness.stdin, 2, 7);
+
+    expect(harness.getSelection().toString()).toBe('');
+    expect(harness.copiedTexts).toStrictEqual([]);
+  });
+
+  it('does not copy a collapsed drag that selects no characters (AC6.11)', () => {
+    const harness = renderSelectionHarness();
+
+    // Press and release on the same cell over real text. A range exists, so
+    // the copy path runs to completion and the empty-text guard — not an
+    // early return on a missing selection point — is what suppresses the copy.
+    harness.stdin.write(sgrSequence(0, 2, 1));
+    harness.stdin.write(sgrSequence(0, 2, 1, 'm'));
+
+    expect(harness.getSelection().rangeCount).toBe(1);
+    expect(harness.getSelection().toString()).toBe('');
+    expect(harness.copiedTexts).toStrictEqual([]);
+  });
+
+  it('clears selection when disabled and ignores subsequent mouse events (AC6.12)', () => {
+    const harness = renderSelectionHarness();
+    dragAcrossText(harness.stdin, 2, 7);
+    expect(harness.getSelection().toString()).toBe('elect');
+    expect(harness.copiedTexts).toStrictEqual(['elect']);
+
+    harness.setEnabled(false);
+    expect(harness.getSelection().toString()).toBe('');
+
+    dragAcrossText(harness.stdin, 3, 8);
+    expect(harness.getSelection().toString()).toBe('');
+    expect(harness.copiedTexts).toStrictEqual(['elect']);
+  });
+});

--- a/packages/cli/src/ui/utils/mouse.test.ts
+++ b/packages/cli/src/ui/utils/mouse.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'bun:test';
 import {
   disableMouseEvents,
   enableMouseEvents,
+  getMouseEventName,
   isMouseEventsActive,
   setMouseEventsActive,
   isIncompleteMouseSequence,
@@ -16,6 +17,10 @@ import {
   parseX11MouseEvent,
 } from './mouse.js';
 import { ESC } from './input.js';
+
+function x11Sequence(buttonCode: number, col = 1, row = 1): string {
+  return `${ESC}[M${String.fromCharCode(buttonCode + 32, col + 32, row + 32)}`;
+}
 
 describe('mouse utils', () => {
   describe('enableMouseEvents/disableMouseEvents', () => {
@@ -122,6 +127,16 @@ describe('mouse utils', () => {
     });
   });
 
+  describe('getMouseEventName', () => {
+    it('maps horizontal wheel button codes to scroll-left and scroll-right (AC6.5)', () => {
+      const names = [66, 67].map((buttonCode) =>
+        getMouseEventName(buttonCode, false),
+      );
+
+      expect(names).toStrictEqual(['scroll-left', 'scroll-right']);
+    });
+  });
+
   describe('parseX11MouseEvent', () => {
     it('parses a valid X11 mouse press', () => {
       const input = `${ESC}[M !!`;
@@ -137,6 +152,56 @@ describe('mouse utils', () => {
         button: 'left',
       });
       expect(result?.length).toBe(6);
+    });
+
+    it('parses the X11 release code as left-release without a button (AC6.6)', () => {
+      const result = parseX11MouseEvent(x11Sequence(3, 12, 7));
+
+      expect(result?.event).toStrictEqual({
+        name: 'left-release',
+        col: 12,
+        row: 7,
+        shift: false,
+        meta: false,
+        ctrl: false,
+        button: 'none',
+      });
+    });
+
+    it('parses X11 motion as move (AC6.7)', () => {
+      const result = parseX11MouseEvent(x11Sequence(32, 4, 9));
+
+      expect(result?.event).toStrictEqual({
+        name: 'move',
+        col: 4,
+        row: 9,
+        shift: false,
+        meta: false,
+        ctrl: false,
+        button: 'left',
+      });
+    });
+
+    it('parses X11 vertical wheel codes as scroll-up and scroll-down (AC6.7)', () => {
+      const names = [64, 65].map(
+        (buttonCode) => parseX11MouseEvent(x11Sequence(buttonCode))?.event.name,
+      );
+
+      expect(names).toStrictEqual(['scroll-up', 'scroll-down']);
+    });
+
+    it('decodes X11 shift, meta, and ctrl modifier bits (AC6.8)', () => {
+      const result = parseX11MouseEvent(x11Sequence(4 | 8 | 16, 3, 5));
+
+      expect(result?.event).toStrictEqual({
+        name: 'left-press',
+        col: 3,
+        row: 5,
+        shift: true,
+        meta: true,
+        ctrl: true,
+        button: 'left',
+      });
     });
 
     it('returns null for incomplete X11', () => {

--- a/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
@@ -478,4 +478,253 @@ describe('TerminalCapabilityManager', () => {
       expect(manager.isBracketedPasteEnabled()).toBe(true);
     });
   });
+
+  describe('AC5 kitty protocol enable and cleanup', () => {
+    it('registers an exit listener that tears the protocol down after kitty detection (AC5.2)', async () => {
+      const manager = TerminalCapabilityManager.getInstance();
+      const before = new Set<unknown>(process.listeners('exit'));
+
+      const promise = manager.detectCapabilities();
+      stdin.emit('data', Buffer.from('\x1b[?1u'));
+      stdin.emit('data', Buffer.from('\x1b[?62c'));
+      await promise;
+
+      expect(manager.isKittyProtocolEnabled()).toBe(true);
+
+      // Counting listeners would not prove anything: run each newly added
+      // handler and require that the protocol actually ends up disabled.
+      const added = process
+        .listeners('exit')
+        .filter((listener) => !before.has(listener));
+      expect(added.length).toBeGreaterThan(0);
+      for (const listener of added) {
+        listener(0);
+      }
+
+      expect(manager.isKittyProtocolEnabled()).toBe(false);
+    });
+
+    it('does not accumulate exit/SIGTERM/SIGINT listeners after resetInstanceForTesting (AC5.3)', async () => {
+      const manager = TerminalCapabilityManager.getInstance();
+      const preexisting = {
+        exit: new Set<unknown>(process.listeners('exit')),
+        SIGTERM: new Set<unknown>(process.listeners('SIGTERM')),
+        SIGINT: new Set<unknown>(process.listeners('SIGINT')),
+      };
+      const currentListeners = (
+        signal: 'exit' | 'SIGTERM' | 'SIGINT',
+      ): unknown[] => {
+        if (signal === 'exit') return process.listeners('exit');
+        if (signal === 'SIGTERM') return process.listeners('SIGTERM');
+        return process.listeners('SIGINT');
+      };
+      const survivors = (signal: 'exit' | 'SIGTERM' | 'SIGINT'): unknown[] =>
+        currentListeners(signal).filter(
+          (listener) => !preexisting[signal].has(listener),
+        );
+
+      const promise = manager.detectCapabilities();
+      stdin.emit('data', Buffer.from('\x1b[?1u'));
+      stdin.emit('data', Buffer.from('\x1b[?62c'));
+      await promise;
+      expect(survivors('exit').length).toBeGreaterThan(0);
+
+      TerminalCapabilityManager.resetInstanceForTesting();
+
+      // Nothing detection registered outlives the reset.
+      expect(survivors('exit')).toStrictEqual([]);
+      expect(survivors('SIGTERM')).toStrictEqual([]);
+      expect(survivors('SIGINT')).toStrictEqual([]);
+    });
+
+    it('disableKittyProtocol emits the disable sequence only while enabled (AC5.4)', async () => {
+      const { disableKittyKeyboardProtocol } = await import(
+        '@vybestack/llxprt-code-core'
+      );
+      const disableMock = disableKittyKeyboardProtocol as Mock<() => void>;
+      const manager = TerminalCapabilityManager.getInstance();
+
+      // Never enabled: nothing is written to the terminal.
+      manager.disableKittyProtocol();
+      expect(manager.isKittyProtocolEnabled()).toBe(false);
+      expect(disableMock.mock.calls).toHaveLength(0);
+
+      const promise = manager.detectCapabilities();
+      stdin.emit('data', Buffer.from('\x1b[?1u'));
+      stdin.emit('data', Buffer.from('\x1b[?62c'));
+      await promise;
+      expect(manager.isKittyProtocolEnabled()).toBe(true);
+
+      // Enabled: the first disable writes, the second is suppressed by the
+      // enabled guard rather than emitting a redundant sequence.
+      manager.disableKittyProtocol();
+      expect(manager.isKittyProtocolEnabled()).toBe(false);
+      expect(disableMock.mock.calls).toHaveLength(1);
+
+      manager.disableKittyProtocol();
+      expect(disableMock.mock.calls).toHaveLength(1);
+    });
+  });
+
+  describe('AC7 detection timeout and skip env', () => {
+    /**
+     * Mirrors the detection timeout in TerminalCapabilityManager, which is a
+     * module-private literal. If the production value ever grows past this,
+     * the timeout-path tests below stop reaching cleanup and hang until the
+     * per-test budget instead of failing with a useful message.
+     */
+    const DETECTION_TIMEOUT_MS = 1000;
+
+    const createRealTTYStdin = (
+      isRawValue: boolean,
+    ): EventEmitter & {
+      isTTY?: boolean;
+      isRaw?: boolean;
+      setRawMode?: (mode: boolean) => void;
+    } => {
+      const stream: EventEmitter & {
+        isTTY?: boolean;
+        isRaw?: boolean;
+        setRawMode?: (mode: boolean) => void;
+      } = new EventEmitter();
+      stream.isTTY = true;
+      stream.isRaw = isRawValue;
+      stream.setRawMode = vi.fn();
+      return stream;
+    };
+
+    it('timeout with no DA1 reply completes and still applies bracketed paste (AC7.1)', async () => {
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+
+      // The terminal never answers any query.
+      vi.advanceTimersByTime(DETECTION_TIMEOUT_MS);
+      await promise;
+
+      // Timeout is a completion path, not a failure path: supported modes
+      // are still applied even though nothing was detected.
+      expect(manager.isBracketedPasteEnabled()).toBe(true);
+      expect(manager.isKittyProtocolEnabled()).toBe(false);
+    });
+
+    it('restores raw mode when it turned it on (AC7.2, started raw false)', async () => {
+      const rawStream = createRealTTYStdin(false);
+      Object.defineProperty(process, 'stdin', {
+        value: rawStream,
+        configurable: true,
+      });
+
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+      rawStream.emit('data', Buffer.from('\x1b[?62c'));
+      await promise;
+
+      const setRawCalls = (
+        rawStream.setRawMode as Mock<(mode: boolean) => void>
+      ).mock.calls.map((call) => call[0]);
+      expect(setRawCalls).toStrictEqual([true, false]);
+    });
+
+    it('leaves raw mode alone when something else already set it (AC7.2, started raw true)', async () => {
+      const rawStream = createRealTTYStdin(true);
+      Object.defineProperty(process, 'stdin', {
+        value: rawStream,
+        configurable: true,
+      });
+
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+      rawStream.emit('data', Buffer.from('\x1b[?62c'));
+      await promise;
+
+      expect(
+        rawStream.setRawMode as Mock<(mode: boolean) => void>,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('removes the stdin data listener on the DA1-sentinel path (AC7.3)', async () => {
+      const rawStream = createRealTTYStdin(false);
+      Object.defineProperty(process, 'stdin', {
+        value: rawStream,
+        configurable: true,
+      });
+
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+      expect(rawStream.listenerCount('data')).toBe(1);
+
+      rawStream.emit('data', Buffer.from('\x1b[?62c'));
+      await promise;
+
+      expect(rawStream.listenerCount('data')).toBe(0);
+    });
+
+    it('removes the stdin data listener on the timeout path (AC7.3)', async () => {
+      const rawStream = createRealTTYStdin(false);
+      Object.defineProperty(process, 'stdin', {
+        value: rawStream,
+        configurable: true,
+      });
+
+      const manager = TerminalCapabilityManager.getInstance();
+      const promise = manager.detectCapabilities();
+      expect(rawStream.listenerCount('data')).toBe(1);
+
+      vi.advanceTimersByTime(DETECTION_TIMEOUT_MS);
+      await promise;
+
+      expect(rawStream.listenerCount('data')).toBe(0);
+    });
+
+    it('resolves, marks detection complete, and restores raw mode when the query write throws (AC7.4)', async () => {
+      const { writeSync } = await import('node:fs');
+      (writeSync as unknown as Mock<typeof writeSync>).mockImplementation(
+        () => {
+          throw new Error('write failed');
+        },
+      );
+
+      const rawStream = createRealTTYStdin(false);
+      Object.defineProperty(process, 'stdin', {
+        value: rawStream,
+        configurable: true,
+      });
+
+      const manager = TerminalCapabilityManager.getInstance();
+      await manager.detectCapabilities();
+
+      // Completion still ran: cleanup happened instead of hanging.
+      expect(manager.isBracketedPasteEnabled()).toBe(true);
+      expect(rawStream.listenerCount('data')).toBe(0);
+      const setRawCalls = (
+        rawStream.setRawMode as Mock<(mode: boolean) => void>
+      ).mock.calls.map((call) => call[0]);
+      expect(setRawCalls).toStrictEqual([true, false]);
+
+      // Detection is marked complete: a second call is a no-op and does not
+      // touch the (still throwing) writeSync again.
+      (writeSync as unknown as Mock<typeof writeSync>).mockClear();
+      await manager.detectCapabilities();
+      expect(
+        writeSync as unknown as Mock<typeof writeSync>,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('skips detection when stdout is not a TTY (AC7.5)', async () => {
+      const { writeSync } = await import('node:fs');
+      stdin.isTTY = true;
+      stdout.isTTY = false;
+
+      const manager = TerminalCapabilityManager.getInstance();
+      await manager.detectCapabilities();
+
+      expect(
+        writeSync as unknown as Mock<typeof writeSync>,
+      ).not.toHaveBeenCalled();
+      expect(manager.isKittyProtocolEnabled()).toBe(false);
+      expect(
+        stdin.setRawMode as Mock<(mode: boolean) => void>,
+      ).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/cli/src/utils/terminalTheme.test.ts
+++ b/packages/cli/src/utils/terminalTheme.test.ts
@@ -113,17 +113,45 @@ describe('setupTerminalAndTheme', () => {
       expect(terminalCapabilityManager.detectCapabilities).toHaveBeenCalled();
     });
 
+    const runWithSkipEnv = (
+      value: string | undefined,
+      run: () => Promise<void>,
+    ): Promise<void> => {
+      const previous =
+        process.env.LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION;
+      if (value === undefined) {
+        delete process.env.LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION;
+      } else {
+        process.env.LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION = value;
+      }
+      return run().finally(() => {
+        if (previous === undefined) {
+          delete process.env.LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION;
+        } else {
+          process.env.LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION = previous;
+        }
+      });
+    };
+
     it('should skip detectCapabilities when explicitly disabled', async () => {
-      process.env.LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION = 'true';
-      try {
+      await runWithSkipEnv('true', async () => {
         await setupTerminalAndTheme(config, mockSettings);
         expect(
           terminalCapabilityManager.detectCapabilities,
         ).not.toHaveBeenCalled();
-      } finally {
-        delete process.env.LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION;
-      }
+      });
     });
+
+    for (const value of ['1', 'false', 'TRUE', '']) {
+      it(`should still detect capabilities when the skip env is '${value}'`, async () => {
+        await runWithSkipEnv(value, async () => {
+          await setupTerminalAndTheme(config, mockSettings);
+          expect(
+            terminalCapabilityManager.detectCapabilities,
+          ).toHaveBeenCalled();
+        });
+      });
+    }
 
     it('should load custom themes from settings', async () => {
       const customThemes = {

--- a/project-plans/issue2024-terminal-input-coverage.md
+++ b/project-plans/issue2024-terminal-input-coverage.md
@@ -1,0 +1,286 @@
+# Issue #2024 — Increase terminal keyboard, mouse, and capability coverage
+
+## Nature of the issue
+
+This is a **coverage** issue. The deliverable is behavioral tests over
+already-shipped terminal input and capability code. No production behavior
+changes are planned. If a test written against *correct* behavior fails, that is
+a bug discovery: stop, report it, and do not paper over it with a test that
+asserts the wrong thing.
+
+## Scope
+
+In scope — the seven areas named in the issue, tested against these units:
+
+| Area                                | Unit under test                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------- |
+| Raw mode setup and cleanup          | `KeypressProvider` / `useKeypressSetup` (`ui/contexts/KeypressContext.tsx`)                    |
+| Stdin subscription / unsubscription | `KeypressProvider`, `useKeypress`, `MouseProvider`, `useMouse`                                 |
+| Escape vs Alt-key ambiguity         | `createKeypressPipeline` / `emitKeys` (`ui/contexts/KeypressContext.tsx`)                      |
+| Bracketed paste sequences           | `bufferPaste` via `createKeypressPipeline`; `useBracketedPaste` (`ui/hooks/useBracketedPaste.ts`) |
+| Kitty protocol enable and cleanup   | `TerminalCapabilityManager`, `useKittyKeyboardProtocol`                                        |
+| Mouse drag selection and parsing    | `useMouseSelection`, `MouseProvider` stream buffering, `ui/utils/mouse.ts`                     |
+| Capability detection timeout / skip | `TerminalCapabilityManager.detectCapabilities`, `setupTerminalAndTheme`                        |
+
+Out of scope — everything else. Specifically: no refactors of the units under
+test, no new production abstractions, no changes to unrelated tests, no
+"while I'm here" hardening.
+
+### tmux decision
+
+The issue permits "targeted tmux tests only where a real terminal is needed."
+Every behavior listed is reachable through fake streams: the parser is a pure
+byte pipeline (`createKeypressPipeline` is exported precisely for this), raw
+mode is an injected `setRawMode` callback from ink's `useStdin`, and capability
+detection reads from `process.stdin` and writes with `fs.writeSync`, both of
+which are already substitutable in the existing suite. `scripts/tmux-harness.ts`
+is a manual reproduction harness, not a CI-executed test runner, so adding tmux
+scenarios would add no CI signal. **Decision: no tmux tests in this change.**
+
+## Acceptance criteria
+
+### AC1 — Raw mode setup and cleanup
+
+`KeypressProvider` owns raw mode only when it turned it on.
+
+1. Mounting with `stdin.isRaw === false` calls `setRawMode(true)` exactly once.
+2. Unmounting that provider calls `setRawMode(false)` exactly once, so the
+   terminal is left as it was found.
+3. Mounting with `stdin.isRaw === true` (something else already put the terminal
+   in raw mode) never calls `setRawMode`, on mount or on unmount.
+4. Mounting with `stdin.isRaw === undefined` (non-TTY stream) never calls
+   `setRawMode`.
+
+Boundary note: the guard is `wasRaw === false`, so `undefined` and `true` are
+both "not ours to change". Cases 3 and 4 exist to pin that distinction.
+
+### AC2 — Stdin subscription and unsubscription
+
+1. `KeypressProvider` attaches exactly one `data` listener to the injected stdin
+   on mount, and stdin has zero `data` listeners after unmount.
+2. After unmount, writing bytes to stdin delivers nothing to a previously
+   subscribed handler.
+3. `unsubscribe(handler)` stops delivery to that handler while a second
+   still-subscribed handler continues to receive keys.
+4. `useKeypress(handler, { isActive: false })` receives nothing; flipping
+   `isActive` to `true` starts delivery and flipping back to `false` stops it,
+   without unmounting the provider.
+5. `MouseProvider` attaches one `data` listener when `mouseEventsEnabled` is
+   `true`, removes it on unmount, and attaches none when `mouseEventsEnabled` is
+   `false` or omitted. Toggling the prop attaches/detaches accordingly.
+
+### AC3 — Escape vs Alt-key ambiguity
+
+The parser distinguishes a bare Escape from Alt+key by arrival timing:
+`createDataListener` flushes the pending sequence `ESC_TIMEOUT` (100 ms) after
+the last byte.
+
+1. A lone `\x1b` emits nothing until `ESC_TIMEOUT` elapses; after it elapses,
+   exactly one key with `name: 'escape'` and `sequence: '\x1b'` is emitted, and
+   that key satisfies the `Command.ESCAPE` matcher from `ui/keyMatchers.ts`.
+2. `\x1b` and `b` in the *same* chunk emit one key: `{ name: 'b', meta: true }`
+   with `sequence: '\x1bb'` (Alt+b).
+3. `\x1b` in one chunk, then `b` after `ESC_TIMEOUT` has elapsed, emits two
+   keys: an `escape` key followed by `{ name: 'b', meta: false, sequence: 'b' }`.
+   This is the disambiguation contract.
+4. `\x1b\x1b` emits a single `escape` key (sequence `'\x1b'`), i.e. Alt+Escape
+   and Escape are deliberately indistinguishable downstream; the key still
+   satisfies the `Command.ESCAPE` matcher.
+5. `\x1b[` is treated as a CSI introducer, not Alt+`[`: `\x1b[A` emits one
+   `{ name: 'up' }` key and no `'['` key.
+6. `\x1bO` is treated as an SS3 introducer, not Alt+`O`: `\x1bOA` emits one
+   `{ name: 'up' }` key.
+
+Do **not** assert the `meta` flag on the bare-Escape cases (1 and 4). The
+parser sets `meta: true` there because the byte arrived through the escaped
+branch; consumer code keys off `name` and the `Command.ESCAPE` matcher ignores
+unspecified modifiers, so `meta` is not part of the contract. Asserting it would
+freeze an incidental detail. Assert the matcher result instead — that is the
+user-visible behavior.
+
+### AC4 — Bracketed paste sequences
+
+1. `\x1b[200~` + payload + `\x1b[201~` emits exactly one key
+   `{ name: 'paste', sequence: payload, insertable: true }`, and no per-character
+   keys for the payload.
+2. An empty paste (`\x1b[200~\x1b[201~` with no payload) emits no key at all.
+3. A payload containing bytes that would otherwise decode to a control key (for
+   example `\x1b[A`) is reassembled verbatim into the paste payload rather than
+   being delivered as an `up` key.
+4. A payload containing newlines and tabs is preserved byte-for-byte.
+5. Paste content is not run through the fast-return or backslash-enter buffers:
+   a payload ending in `\r` still arrives inside the paste payload, not as a
+   separate `return` key.
+6. If `\x1b[201~` never arrives, the buffered payload is flushed as a single
+   `paste` key after `PASTE_TIMEOUT` (30 s), rather than being lost.
+7. `useBracketedPaste` writes the enable sequence on mount and the disable
+   sequence on cleanup, and registers `exit` / `SIGINT` / `SIGTERM` handlers on
+   mount that it removes on unmount, so repeated mounts do not accumulate
+   process listeners.
+
+### AC5 — Kitty keyboard protocol enable and cleanup
+
+1. `useKittyKeyboardProtocol` reports the manager's enabled state at first
+   render with `checking: false`, and keeps returning that snapshot across
+   re-renders (detection is startup-only; the hook must not re-query).
+2. After a detection run in which the terminal answered the kitty query,
+   `isKittyProtocolEnabled()` is `true` and an `exit` listener is registered to
+   tear the protocol down.
+3. Running detection does not accumulate process listeners: the `exit`,
+   `SIGTERM`, and `SIGINT` listener counts return to their pre-detection values
+   after `resetInstanceForTesting()`.
+4. `disableKittyProtocol()` on a manager whose protocol was never enabled is a
+   no-op and leaves `isKittyProtocolEnabled()` false.
+
+Existing coverage in `terminalCapabilityManager.test.ts` already pins the
+enable/disable/on-exit write sequences; do not duplicate it. Add only 2–4 above,
+in that same file, reusing its existing mock setup.
+
+### AC6 — Mouse drag selection and mouse event parsing
+
+Stream layer (`MouseProvider`):
+
+1. An SGR press sequence split across two `data` chunks is broadcast exactly
+   once, after the final chunk completes it.
+2. Two complete sequences in a single chunk are broadcast in arrival order.
+3. Non-mouse garbage preceding a valid sequence is discarded and the valid
+   sequence that follows is still broadcast.
+4. A sequence longer than the 4096-byte cap of junk does not wedge the parser: a
+   valid sequence arriving afterwards is still broadcast.
+
+Parsing layer (`ui/utils/mouse.ts`) — add the cases the existing file lacks:
+
+5. `getMouseEventName` maps button code 66 to `scroll-left` and 67 to
+   `scroll-right`.
+6. X11 release (button bits `3`) parses as `left-release` with `button: 'none'`.
+7. X11 motion (bit 32) parses as `move`, and X11 wheel (bit 64) parses as
+   `scroll-up` / `scroll-down`.
+8. X11 modifier bits (shift 4, meta 8, ctrl 16) are decoded onto the event.
+
+Selection layer (`useMouseSelection`) — behavioral, against a real ink tree:
+
+9. `left-press` then `move` then `left-release` over rendered text produces a
+   selection whose text is handed to `onCopiedText`, and the text matches the
+   characters actually spanned by the drag.
+10. A `move` event with no preceding `left-press` changes nothing and does not
+    call `onCopiedText`.
+11. A drag that resolves to no selectable content does not call `onCopiedText`
+    (empty selections are not copied).
+12. With `enabled: false`, mouse events produce no selection and no copy, and
+    flipping `enabled` from `true` to `false` clears an existing selection.
+
+Mock policy for AC6: the clipboard write (`utils/clipboard.js`) is
+infrastructure and may be stubbed. The ink tree, `Selection`, `Range`,
+`hitTest`, the mouse parser, and `useMouseSelection` itself are all real. Drive
+the test with real SGR byte sequences through the provider's stdin so the parse
+path is exercised end to end. Assert on the copied text — a derived value —
+never on "was the handler called".
+
+### AC7 — Capability detection timeout and explicit skip env
+
+1. When no Device Attributes reply arrives, detection resolves after the 1000 ms
+   timeout, and the supported modes are still applied (bracketed paste is
+   enabled) — timeout is a completion path, not a failure path.
+2. Detection restores raw mode: starting with `isRaw === false` it sets raw mode
+   true and sets it back to false when detection completes; starting with
+   `isRaw === true` it leaves raw mode alone.
+3. Detection removes its `data` listener from stdin when it completes, by both
+   the DA1-sentinel path and the timeout path.
+4. If the query write throws, detection still resolves, marks detection
+   complete, and restores raw mode instead of hanging.
+5. Detection is skipped when `process.stdout.isTTY` is false (the existing suite
+   covers `stdin.isTTY` false only).
+6. `setupTerminalAndTheme` skips detection only for the exact value `'true'` of
+   `LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION`. Values `'1'`, `'false'`,
+   `'TRUE'`, and empty string all still run detection. The existing file covers
+   the `'true'` case; add the negative cases beside it.
+
+## Test file plan
+
+New files (all TypeScript, `bun:test`, co-located, 2026 copyright header;
+`.tsx` only where the file actually contains JSX):
+
+- `packages/cli/src/ui/contexts/KeypressContext.lifecycle.test.tsx` — AC1, AC2 (1–4)
+- `packages/cli/src/ui/contexts/KeypressContext.escape.test.ts` — AC3
+- `packages/cli/src/ui/contexts/KeypressContext.bracketedPaste.test.ts` — AC4 (1–6)
+- `packages/cli/src/ui/hooks/useBracketedPaste.test.tsx` — AC4 (7)
+- `packages/cli/src/ui/hooks/useKittyKeyboardProtocol.test.ts` — AC5 (1)
+- `packages/cli/src/ui/hooks/useMouseSelection.test.tsx` — AC6 (9–12)
+
+Extended files:
+
+- `packages/cli/src/ui/utils/terminalCapabilityManager.test.ts` — AC5 (2–4), AC7 (1–5)
+- `packages/cli/src/ui/contexts/MouseContext.test.tsx` — AC2 (5), AC6 (1–4)
+- `packages/cli/src/ui/utils/mouse.test.ts` — AC6 (5–8)
+- `packages/cli/src/utils/terminalTheme.test.ts` — AC7 (6)
+
+## Constraints
+
+- Bun + `bun:test` only. No new `.js` files, no vitest, no node:test.
+- TypeScript strict: no `any`, no type assertions to force shapes.
+- No mock theater. Do not mock the unit under test. Do not assert
+  `toHaveBeenCalled` on a stub that stands in for the behavior being tested;
+  assert derived values. Stubs are acceptable only for infrastructure (fs
+  writes, clipboard, terminal escape emission).
+- `max-lines` is 800 per file; keep new files well under it.
+- Shared harness code (mock stdin, provider wrapper) must be extracted into a
+  helper within each new file rather than copy-pasted across describe blocks.
+- Every new test must fail if the corresponding production code is broken.
+  Verify this by reasoning through the litmus questions in the
+  typescript-test-writing skill before submitting.
+
+## Defects found while writing the tests
+
+Filed as **issue #3300**. Not fixed here: production changes are outside the
+scope of a coverage issue, and the fix wants its own test-first cycle.
+
+- **The SS3 reader corrupts pasted text.** `readOCodeSequence` reports
+  `sequence` as `\x1bA` for the input bytes `\x1bOA`, dropping the `O`, while
+  the CSI reader round-trips its bytes faithfully. This is not confined to key
+  bindings. `bufferPaste` reassembles a bracketed-paste payload by
+  concatenating `key.sequence`, so a paste containing SS3 bytes comes out
+  altered: `before\x1bOAafter` is delivered as `before\x1bAafter`, while the CSI
+  equivalent survives intact. That contradicts the verbatim and byte-for-byte
+  contract AC4.3 and AC4.4 pin in this same change. The AC3.6 test pins the
+  decoded key identity and deliberately does not assert `sequence`; once #3300
+  lands, that assertion should be added.
+- **A bare Escape decodes with `meta: true`,** because the byte falls through
+  the escaped branch of `parseNonEscapeKey`. Semantically wrong — no Alt key was
+  pressed — but no live consumer depends on it: bindings match on `name` and
+  leave modifiers unspecified. Recorded on #3300 alongside the SS3 fix. The AC3
+  tests assert the `Command.ESCAPE` matcher rather than `meta`, which both
+  avoids freezing the incidental flag and guards against the binding later
+  being constrained on modifiers in a way that would break Escape.
+
+## Review findings not actioned
+
+Raised in review, deliberately left alone, with reasons:
+
+- **Extract a shared `MockStdin` test double.** Six files in `packages/cli/src/ui`
+  now define their own. Consolidating them means editing five test files that
+  belong to other efforts, which is outside this issue. Follow-up material.
+- **Cover the clipboard failure path in `useMouseSelection`.** `useClipboardCopy`
+  awaits `copyTextToClipboard` with no `try`/`catch` behind a fire-and-forget
+  `void`, so a rejecting clipboard would surface as an unhandled rejection.
+  That is error-handling behavior, not the drag selection the issue asks for,
+  and pinning it down would likely force a production change. Out of scope.
+- **Drop the control harness from the negative mouse-selection tests.** The
+  duplication is deliberate: a bare `not.toHaveBeenCalled()` with no positive
+  control is exactly the worthless test the project's rules prohibit. The
+  cross-wiring risk the same review raised was the real problem, and that is
+  fixed by unmounting each harness before the next one renders.
+
+## Verification
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+bun scripts/test-audit/scan.ts tmp/scan-branch
+```
+
+The test-audit scanner must report no new MOCK_MIRROR, ALWAYS_TRUE,
+SELF_CONFIRMING, or NO_ASSERT findings on the files touched here.


### PR DESCRIPTION
## TLDR

Adds behavioral test coverage for the seven terminal input and capability areas listed in #2024, driven entirely through fake streams. **No production source changes** — this is a coverage issue by design.

Two parser defects surfaced while writing the tests. They are filed as **#3300** rather than fixed here, and the affected assertions were deliberately omitted rather than written to match the broken behavior.

Reviewers should look hardest at three things: whether each test would actually fail if the code under test broke, the `useMouseSelection` suite (it renders a real ink tree and asserts the real selected substring), and the SS3 defect triage described below.

## Dive Deeper

### What is covered

| Issue area | Where | What is pinned |
| --- | --- | --- |
| Raw mode setup and cleanup | `KeypressContext.lifecycle.test.tsx` | The provider restores only what it changed. `isRaw === false` turns raw mode on at mount and off at unmount; `isRaw` of `true` or `undefined` means it never touches raw mode at all. The `true`/`undefined` cases are what pin the `wasRaw === false` guard — rewrite it as `if (!wasRaw)` and they fail. |
| Stdin subscription / unsubscription | `KeypressContext.lifecycle.test.tsx`, `MouseContext.test.tsx` | Exactly one `data` listener attached per provider and zero after unmount; `unsubscribe` silences one handler while another keeps receiving; `useKeypress({ isActive })` toggles delivery without remounting; `MouseProvider` attaches nothing unless `mouseEventsEnabled` is `true`. |
| Escape vs Alt-key ambiguity | `KeypressContext.escape.test.ts` | A lone `ESC` emits nothing until `ESC_TIMEOUT`, then one escape key. `ESC`+letter in one chunk is Alt+letter. `ESC`, timeout, then the letter is escape followed by an unmodified letter — pushed through **one** pipeline, because a fresh pipeline has no pending escape state and would prove nothing. `ESC [` and `ESC O` are treated as introducers, not Alt+bracket. |
| Bracketed paste | `KeypressContext.bracketedPaste.test.ts`, `useBracketedPaste.test.tsx` | Payload arrives as a single paste key with no per-character keys; an empty paste emits nothing; CSI-looking bytes, newlines, tabs, and a trailing CR stay inside the payload; a missing end marker still flushes after `PASTE_TIMEOUT`. The hook writes the enable/disable sequences and registers one shared cleanup handler on `exit`/`SIGINT`/`SIGTERM` that emits the disable bytes and is fully removed on unmount. |
| Kitty protocol enable and cleanup | `useKittyKeyboardProtocol.test.ts`, `terminalCapabilityManager.test.ts` | The hook snapshots the manager at first render and keeps returning that snapshot. Detection registers an exit handler that, when run, actually leaves the protocol disabled. Nothing detection registered survives `resetInstanceForTesting`. `disableKittyProtocol` emits the sequence only while enabled. |
| Mouse drag selection and parsing | `useMouseSelection.test.tsx`, `MouseContext.test.tsx`, `mouse.test.ts` | Split SGR sequences, multiple sequences per chunk, garbage discard, and junk recovery at the buffer cap. X11 release, motion, wheel, and modifier bits; horizontal wheel codes 66/67. Drag selection runs against a **real ink tree** with the real parser, `hitTest`, `Range`, and `Selection`, asserting the actual copied substring. |
| Capability detection timeout and skip env | `terminalCapabilityManager.test.ts`, `terminalTheme.test.ts` | Timeout is a completion path — supported modes are still applied. Raw mode is restored when detection turned it on and untouched when it did not. The `data` listener is removed on both the DA1-sentinel and timeout paths. A throwing query write still resolves and restores raw mode. Detection is skipped when stdout is not a TTY. The skip env var is honored only for the exact string `true`; `1`, `false`, `TRUE`, and empty all still run detection. |

### Why no tmux tests

The issue permits "targeted tmux tests only where a real terminal is needed." Every listed behavior is reachable through fake streams: the parser is a pure byte pipeline behind the already-exported `createKeypressPipeline`, raw mode is an injected `setRawMode` from ink's `useStdin`, and capability detection reads `process.stdin` and writes through `fs.writeSync` — all substitutable. `scripts/tmux-harness.ts` is a manual reproduction harness, not a CI-executed runner, so tmux scenarios would add no CI signal.

### Defects found, filed as #3300

- **The SS3 reader corrupts pasted text.** `readOCodeSequence` reports `sequence` as `\x1bA` for the input bytes `\x1bOA`, dropping the `O`, while the CSI reader round-trips faithfully. This is not confined to key bindings: `bufferPaste` reassembles a paste payload by concatenating `key.sequence`, so a paste containing `before\x1bOAafter` is delivered as `before\x1bAafter` while the CSI equivalent survives intact. That contradicts the verbatim contract the bracketed-paste tests pin in this same PR. The AC3.6 test pins the decoded key identity and deliberately does not assert `sequence`.
- **A bare Escape decodes with `meta: true`**, because the byte falls through the escaped branch of `parseNonEscapeKey`. Semantically wrong, but no live consumer depends on it — bindings match on `name` and leave modifiers unspecified. The escape tests assert the `Command.ESCAPE` matcher instead of `meta`, which avoids freezing the incidental flag while still guarding against the binding later being constrained on modifiers.

### Review findings deliberately not actioned

Recorded with reasons in the plan document: consolidating the six duplicated `MockStdin` doubles (touches five test files owned by other efforts), covering the clipboard failure path in `useMouseSelection` (error handling, not drag selection, and would likely force a production change), and dropping the positive-control assertions from the negative mouse tests (the duplication is deliberate; a bare `not.toHaveBeenCalled()` with no control is the worthless test the project's rules prohibit).

## Reviewer Test Plan

```bash
git checkout issue2024
cd packages/cli
bun test src/ui/contexts/KeypressContext.lifecycle.test.tsx \
         src/ui/contexts/KeypressContext.escape.test.ts \
         src/ui/contexts/KeypressContext.bracketedPaste.test.ts \
         src/ui/hooks/useBracketedPaste.test.tsx \
         src/ui/hooks/useKittyKeyboardProtocol.test.ts \
         src/ui/hooks/useMouseSelection.test.tsx \
         src/ui/contexts/MouseContext.test.tsx \
         src/ui/utils/mouse.test.ts \
         src/ui/utils/terminalCapabilityManager.test.ts
cd .. && cd .. && npx vitest --version >/dev/null 2>&1 # not used; bun only
```

To confirm the tests are not vacuous, mutate the production code and watch them fail. Examples that were verified locally:

- Remove `process.on('SIGINT', cleanup)` from `useBracketedPaste.ts` — the registration test fails (an earlier count-based version of it did not, which is why it asserts listener identity now).
- Change the raw-mode guard in `KeypressContext.tsx` from `wasRaw === false` to `!wasRaw` — the `isRaw === undefined` test fails.
- Change `!== 'true'` in `terminalTheme.ts` to a truthiness or case-insensitive check — the `1` and `TRUE` cases fail.
- Delete the `buffer.length > 0` guard in `bufferPaste` — the empty-paste test fails.

Full local verification on this branch: `npm run test` (CLI workspace 720/720 files, 9227 cases), `npm run lint` (exit 0), `npm run typecheck` (clean), `npm run format`, `npm run build` (exit 0), and the `stepfun-37` startup smoke test. `bun scripts/test-audit/scan.ts` reports no `MOCK_MIRROR`, `ALWAYS_TRUE`, `SELF_CONFIRMING`, or `NO_ASSERT` findings on any touched file.

Note on local runs: five PowerShell tests in `packages/core` fail on macOS with `PowerShell grammar failed to load under Bun`. `packages/core` is byte-identical to `origin/main` on this branch, so they are unrelated to these changes.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Test-only change with no runtime surface, so packaging paths are unaffected. Verified on macOS; CI covers Linux and Windows.

## Linked issues / bugs

Fixes #2024

Filed while writing these tests: #3300 (SS3 `sequence` drops the `O`, corrupting pasted text; plus the bare-Escape `meta` flag).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for keyboard input, including bracketed paste, Escape-key handling, and protocol sequences.
  * Added lifecycle tests for keyboard and mouse input listeners, raw mode, subscriptions, and cleanup.
  * Added coverage for mouse selection, scrolling, parsing, modifiers, and malformed input recovery.
  * Added tests for terminal capability detection, protocol cleanup, failure recovery, and TTY behavior.
  * Verified terminal theme detection across supported environment variable values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->