### PR TITLE
Trust only LLxprt-written SANDBOX values for nested suppression (Fixes #2943)

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -629,10 +629,15 @@ is where you expect.
 
 Do **not** rely on the `SANDBOX` environment variable. LLxprt Code sets
 `SANDBOX` inside the sandboxed process to mark that it has already started one
-layer of containment, and a pre-existing `SANDBOX` value on your host causes
-sandbox startup to be skipped. That means the variable reports "sandboxed" on
-an unsandboxed host and is trivially forgeable — it cannot distinguish
-sandboxed from unsandboxed execution.
+layer of containment. Only the values LLxprt itself writes skip another sandbox
+startup: the Seatbelt launcher sets the literal `sandbox-exec`, and the
+container launcher sets the generated container name (for example
+`sandbox-0.7.0-4242`). When one of those values suppresses an explicit
+sandbox request, the CLI prints a warning that names the value and the request; a
+pre-existing foreign `SANDBOX` value from your host does not suppress an explicit
+request. The variable is still trivially forgeable and reports "sandboxed" on
+an unsandboxed host — it cannot distinguish sandboxed from unsandboxed
+execution.
 
 Instead, check for an observable property of the container environment that a
 host process does not have:

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -629,15 +629,15 @@ is where you expect.
 
 Do **not** rely on the `SANDBOX` environment variable. LLxprt Code sets
 `SANDBOX` inside the sandboxed process to mark that it has already started one
-layer of containment. Only the values LLxprt itself writes skip another sandbox
-startup: the Seatbelt launcher sets the literal `sandbox-exec`, and the
-container launcher sets the generated container name (for example
-`sandbox-0.7.0-4242`). When one of those values suppresses an explicit
-sandbox request, the CLI prints a warning that names the value and the request; a
-pre-existing foreign `SANDBOX` value from your host does not suppress an explicit
-request. The variable is still trivially forgeable and reports "sandboxed" on
-an unsandboxed host — it cannot distinguish sandboxed from unsandboxed
-execution.
+layer of containment. Only values matching the forms LLxprt itself writes skip
+another sandbox startup: the Seatbelt launcher sets the literal
+`sandbox-exec`, and the container launcher sets the generated container name
+(for example `sandbox-0.7.0-4242`). When such a value suppresses an explicit
+sandbox request, the CLI prints a warning naming the value and the request. A
+pre-existing `SANDBOX` value that does not match those forms does not suppress
+an explicit request. The variable is still trivially forgeable and reports
+"sandboxed" on an unsandboxed host — it cannot distinguish sandboxed from
+unsandboxed execution.
 
 Instead, check for an observable property of the container environment that a
 host process does not have:

--- a/packages/cli/src/cli-sandbox.test.tsx
+++ b/packages/cli/src/cli-sandbox.test.tsx
@@ -157,7 +157,7 @@ void vi.mock('@vybestack/llxprt-code-core', () => ({
   patchStdio: vi.fn(() => vi.fn()),
 }));
 
-describe('cli sandbox maxHeapSizeMB integration', () => {
+describe('cli sandbox integration', () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
@@ -244,6 +244,57 @@ describe('cli sandbox maxHeapSizeMB integration', () => {
       expect.anything(),
     );
 
+    exitSpy.mockRestore();
+  });
+
+  it('hops into the sandbox when a foreign SANDBOX env var is set (issue #2943)', async () => {
+    const shouldRelaunchMock = shouldRelaunchForMemory as Mock<
+      typeof shouldRelaunchForMemory
+    >;
+    const loadCliConfigMock = loadCliConfig as Mock<typeof loadCliConfig>;
+    const startSandboxMock = start_sandbox as Mock<typeof start_sandbox>;
+
+    shouldRelaunchMock.mockReturnValue([]);
+    // A foreign SANDBOX value (CI export, leftover shell variable) must not
+    // block the hop: nested suppression is decided solely by
+    // loadSandboxConfig, so getSandbox() staying defined must start_sandbox.
+    process.env.SANDBOX = 'some-ci-value';
+    loadCliConfigMock.mockResolvedValue(buildSandboxConfig());
+    (parseArguments as Mock<typeof parseArguments>).mockResolvedValueOnce(
+      buildArgv('test prompt'),
+    );
+
+    const originalIsTTY = process.stdin.isTTY;
+    const originalSetRawMode = process.stdin.setRawMode;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdin, 'setRawMode', {
+      value: vi.fn(),
+      configurable: true,
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('PROCESS_EXIT');
+    });
+
+    try {
+      await main();
+    } catch {
+      // Expected from process.exit mock
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdin, 'setRawMode', {
+        value: originalSetRawMode,
+        configurable: true,
+      });
+    }
+
+    expect(startSandboxMock).toHaveBeenCalledTimes(1);
     exitSpy.mockRestore();
   });
 });

--- a/packages/cli/src/cliSandbox.ts
+++ b/packages/cli/src/cliSandbox.ts
@@ -165,9 +165,9 @@ export async function maybeHopIntoSandbox(
     bootstrapSelection,
   } = options;
 
-  if (process.env.SANDBOX) {
-    return;
-  }
+  // Nested-launch suppression is decided entirely in loadSandboxConfig (issue #2943):
+  // a SANDBOX value LLxprt wrote makes config.getSandbox() undefined, so the check
+  // below already stops the hop; a foreign value must not block it.
   const sandboxConfig = config.getSandbox();
   if (!sandboxConfig) {
     return;

--- a/packages/cli/src/config/sandboxConfig.nested.test.ts
+++ b/packages/cli/src/config/sandboxConfig.nested.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #2943 — the SANDBOX env var only proves a nested LLxprt launch when
+ * its value is one LLxprt itself writes (the Seatbelt `sandbox-exec` literal
+ * or a generated container name like `sandbox-0.7.0-4242`). Foreign
+ * values (CI systems, hand exports) must not suppress an explicit sandbox request.
+ *
+ * Modeled on sandboxConfig.precedence.test.ts: real `loadSandboxConfig`, only
+ * `command-exists` (the infra probe) substituted, plus `./sandboxProfiles.js`
+ * for the profile row. Rows cover the AC1-AC4 matrix from the issue plan.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { FatalSandboxError } from '@vybestack/llxprt-code-core';
+import { loadSandboxConfig } from './sandboxConfig.js';
+import type { Settings } from './settings.js';
+
+const commandSyncMock = vi.fn((_command: string) => false);
+
+void vi.mock('command-exists', () => ({
+  default: {
+    sync: commandSyncMock,
+  },
+}));
+
+void vi.mock('./sandboxProfiles.js', () => ({
+  ensureDefaultSandboxProfiles: vi.fn(async () => undefined),
+  loadSandboxProfile: vi.fn(async () => ({
+    engine: 'docker',
+    image: 'ghcr.io/vybestack/llxprt-code/sandbox:0.7.0',
+    resources: { cpus: 2, memory: '4g', pids: 128 },
+    network: 'off',
+    sshAgent: 'on',
+  })),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+function makeSettings(sandbox?: boolean | string): Settings {
+  return { sandbox };
+}
+
+function silenceWarn(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(console, 'warn').mockImplementation(() => {});
+}
+
+function enginesAvailable(...available: readonly string[]): void {
+  const set = new Set(available);
+  commandSyncMock.mockImplementation((command: string) => set.has(command));
+}
+
+async function expectFatalSandbox(
+  settings: Settings,
+  argv: Record<string, unknown>,
+): Promise<FatalSandboxError> {
+  try {
+    await loadSandboxConfig(settings, argv);
+  } catch (error) {
+    expect(error).toBeInstanceOf(FatalSandboxError);
+    return error as FatalSandboxError;
+  }
+  throw new Error('expected loadSandboxConfig to throw');
+}
+
+describe('nested SANDBOX detection (issue #2943)', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.SANDBOX;
+    delete process.env.LLXPRT_SANDBOX;
+    delete process.env.LLXPRT_SANDBOX_IMAGE;
+    // Clean up the vars applySandboxProfileEnv writes so the profile row starts
+    // from the same baseline.
+    delete process.env.LLXPRT_SANDBOX_NETWORK;
+    delete process.env.LLXPRT_SANDBOX_SSH_AGENT;
+    delete process.env.LLXPRT_SANDBOX_CPUS;
+    delete process.env.LLXPRT_SANDBOX_MEMORY;
+    delete process.env.LLXPRT_SANDBOX_PIDS;
+    delete process.env.LLXPRT_SANDBOX_MOUNTS;
+    enginesAvailable('docker');
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it('AC1: foreign SANDBOX="1" does not suppress --sandbox docker', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = '1';
+    const config = await loadSandboxConfig(makeSettings(undefined), {
+      sandbox: true,
+    });
+    expect(config).toBeDefined();
+    expect(config?.command).toBe('docker');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC1: foreign SANDBOX="true" does not suppress LLXPRT_SANDBOX=true', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'true';
+    process.env.LLXPRT_SANDBOX = 'true';
+    const config = await loadSandboxConfig(makeSettings(undefined), {});
+    expect(config).toBeDefined();
+    expect(config?.command).toBe('docker');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC1: foreign SANDBOX="some-ci-value" does not suppress --sandbox-engine', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'some-ci-value';
+    const config = await loadSandboxConfig(makeSettings(undefined), {
+      sandboxEngine: 'docker',
+    });
+    expect(config).toBeDefined();
+    expect(config?.command).toBe('docker');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC2: LLxprt-written SANDBOX="sandbox-exec" suppresses --sandbox with warning', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'sandbox-exec';
+    const config = await loadSandboxConfig(makeSettings(undefined), {
+      sandbox: true,
+    });
+    expect(config).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String((warnSpy.mock.calls[0] ?? [])[0] ?? '');
+    expect(message).toContain('SANDBOX=sandbox-exec');
+    expect(message).toContain('--sandbox');
+  });
+
+  it('AC2: container-name SANDBOX suppresses settings.sandbox with warning', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'sandbox-0.7.0-4242';
+    const config = await loadSandboxConfig(makeSettings(true), {});
+    expect(config).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String((warnSpy.mock.calls[0] ?? [])[0] ?? '');
+    expect(message).toContain('SANDBOX=sandbox-0.7.0-4242');
+    expect(message).toContain('settings.sandbox');
+  });
+
+  it('AC2: collision-suffixed container name suppresses LLXPRT_SANDBOX with warning', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'sandbox-0.7.0-4242-1';
+    process.env.LLXPRT_SANDBOX = 'true';
+    const config = await loadSandboxConfig(makeSettings(undefined), {});
+    expect(config).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String((warnSpy.mock.calls[0] ?? [])[0] ?? '');
+    expect(message).toContain('SANDBOX=sandbox-0.7.0-4242-1');
+    expect(message).toContain('LLXPRT_SANDBOX');
+  });
+
+  it('AC2: LLxprt-written SANDBOX suppresses --sandbox-engine with warning', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'sandbox-exec';
+    const config = await loadSandboxConfig(makeSettings(undefined), {
+      sandboxEngine: 'docker',
+    });
+    expect(config).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String((warnSpy.mock.calls[0] ?? [])[0] ?? '');
+    expect(message).toContain('SANDBOX=sandbox-exec');
+    expect(message).toContain('--sandbox-engine');
+  });
+
+  it('AC2: LLxprt-written SANDBOX suppresses --sandbox-profile-load with warning', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'sandbox-exec';
+    const config = await loadSandboxConfig(makeSettings(undefined), {
+      sandboxProfileLoad: 'dev',
+    });
+    expect(config).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String((warnSpy.mock.calls[0] ?? [])[0] ?? '');
+    expect(message).toContain('SANDBOX=sandbox-exec');
+    expect(message).toContain('--sandbox-profile-load');
+  });
+
+  it('AC3: LLxprt-written SANDBOX with no request stays silent', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'sandbox-exec';
+    const config = await loadSandboxConfig(makeSettings(undefined), {});
+    expect(config).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC3: SANDBOX unset with no request stays silent', async () => {
+    const warnSpy = silenceWarn();
+    const config = await loadSandboxConfig(makeSettings(undefined), {});
+    expect(config).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC4: LLxprt-written SANDBOX with --sandbox false is not a request', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'sandbox-exec';
+    const config = await loadSandboxConfig(makeSettings(undefined), {
+      sandbox: false,
+    });
+    expect(config).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC1: foreign SANDBOX="1" does not weaken --sandbox validation', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = '1';
+    const error = await expectFatalSandbox(makeSettings(undefined), {
+      sandbox: 'nosuchcmd',
+    });
+    expect(error.message).toContain('nosuchcmd');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/config/sandboxConfig.nested.test.ts
+++ b/packages/cli/src/config/sandboxConfig.nested.test.ts
@@ -61,8 +61,10 @@ async function expectFatalSandbox(
   try {
     await loadSandboxConfig(settings, argv);
   } catch (error) {
-    expect(error).toBeInstanceOf(FatalSandboxError);
-    return error as FatalSandboxError;
+    if (!(error instanceof FatalSandboxError)) {
+      throw new Error(`expected FatalSandboxError, got: ${String(error)}`);
+    }
+    return error;
   }
   throw new Error('expected loadSandboxConfig to throw');
 }
@@ -132,6 +134,21 @@ describe('nested SANDBOX detection (issue #2943)', () => {
     const message = String((warnSpy.mock.calls[0] ?? [])[0] ?? '');
     expect(message).toContain('SANDBOX=sandbox-exec');
     expect(message).toContain('--sandbox');
+  });
+
+  it('AC2: nested --sandbox with no engine available stays a clean undefined without probing', async () => {
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'sandbox-exec';
+    commandSyncMock.mockClear();
+    enginesAvailable();
+    const config = await loadSandboxConfig(makeSettings(undefined), {
+      sandbox: true,
+    });
+    // Suppression must run before engine detection: an engine-less nested
+    // launch neither throws FatalSandboxError nor probes for a command.
+    expect(config).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(commandSyncMock).not.toHaveBeenCalled();
   });
 
   it('AC2: container-name SANDBOX suppresses settings.sandbox with warning', async () => {

--- a/packages/cli/src/config/sandboxConfig.nested.test.ts
+++ b/packages/cli/src/config/sandboxConfig.nested.test.ts
@@ -22,6 +22,16 @@ import type { Settings } from './settings.js';
 
 const commandSyncMock = vi.fn((_command: string) => false);
 
+const defaultProfile = async () => ({
+  engine: 'docker',
+  image: 'ghcr.io/vybestack/llxprt-code/sandbox:0.7.0',
+  resources: { cpus: 2, memory: '4g', pids: 128 },
+  network: 'off',
+  sshAgent: 'on',
+});
+
+const loadSandboxProfileMock = vi.fn(defaultProfile);
+
 void vi.mock('command-exists', () => ({
   default: {
     sync: commandSyncMock,
@@ -30,13 +40,7 @@ void vi.mock('command-exists', () => ({
 
 void vi.mock('./sandboxProfiles.js', () => ({
   ensureDefaultSandboxProfiles: vi.fn(async () => undefined),
-  loadSandboxProfile: vi.fn(async () => ({
-    engine: 'docker',
-    image: 'ghcr.io/vybestack/llxprt-code/sandbox:0.7.0',
-    resources: { cpus: 2, memory: '4g', pids: 128 },
-    network: 'off',
-    sshAgent: 'on',
-  })),
+  loadSandboxProfile: loadSandboxProfileMock,
 }));
 
 const ORIGINAL_ENV = { ...process.env };
@@ -84,6 +88,8 @@ describe('nested SANDBOX detection (issue #2943)', () => {
     delete process.env.LLXPRT_SANDBOX_PIDS;
     delete process.env.LLXPRT_SANDBOX_MOUNTS;
     enginesAvailable('docker');
+    loadSandboxProfileMock.mockReset();
+    loadSandboxProfileMock.mockImplementation(defaultProfile);
   });
 
   afterEach(() => {
@@ -233,5 +239,43 @@ describe('nested SANDBOX detection (issue #2943)', () => {
     });
     expect(error.message).toContain('nosuchcmd');
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('boundary: foreign numeric-suffix lookalike suppresses with warning (accepted tradeoff)', async () => {
+    // `ci-job-4821` matches the generated container-name shape. The image
+    // portion of real names is user-configurable, so no narrower rule can
+    // distinguish it; suppression here is loud rather than silent.
+    const warnSpy = silenceWarn();
+    process.env.SANDBOX = 'ci-job-4821';
+    const config = await loadSandboxConfig(makeSettings(undefined), {
+      sandbox: true,
+    });
+    expect(config).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String((warnSpy.mock.calls[0] ?? [])[0] ?? '');
+    expect(message).toContain('SANDBOX=ci-job-4821');
+    expect(message).toContain('--sandbox');
+  });
+
+  it('boundary: nested suppression does not swallow invalid-engine input', async () => {
+    // Input validation runs before the nested check: an invalid engine is a
+    // user error worth reporting even inside a sandbox, matching behavior
+    // when SANDBOX is unset.
+    process.env.SANDBOX = 'sandbox-exec';
+    const error = await expectFatalSandbox(makeSettings(undefined), {
+      sandboxEngine: 'bogus',
+    });
+    expect(error.message).toContain("Invalid sandbox engine 'bogus'");
+  });
+
+  it('boundary: nested suppression does not swallow invalid-profile input', async () => {
+    process.env.SANDBOX = 'sandbox-exec';
+    loadSandboxProfileMock.mockImplementationOnce(async () => {
+      throw new Error('no such profile');
+    });
+    const error = await expectFatalSandbox(makeSettings(undefined), {
+      sandboxProfileLoad: 'missing',
+    });
+    expect(error.message).toContain('Failed to load sandbox profile');
   });
 });

--- a/packages/cli/src/config/sandboxConfig.precedence.test.ts
+++ b/packages/cli/src/config/sandboxConfig.precedence.test.ts
@@ -153,12 +153,17 @@ describe('sandbox precedence (issue #3083)', () => {
     expect(config).toBeUndefined();
   });
 
-  it('AC7: SANDBOX env set yields no nested sandbox', async () => {
-    process.env.SANDBOX = '1';
+  it('AC7: LLxprt-written SANDBOX value yields no nested sandbox (issue #2943)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.SANDBOX = 'sandbox-exec';
     const config = await loadSandboxConfig(makeSettings(true), {
       sandbox: true,
     });
     expect(config).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String((warnSpy.mock.calls[0] ?? [])[0] ?? '');
+    expect(message).toContain('SANDBOX=sandbox-exec');
+    expect(message).toContain('--sandbox');
   });
 
   it('AC8: missing-command error names LLXPRT_SANDBOX when env supplied it', async () => {

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -304,6 +304,54 @@ function pickAvailableSandboxCommand(): SandboxConfig['command'] | '' {
 }
 
 /**
+ * Matches the container names LLxprt generates when it launches a nested
+ * process: `<image-name-tag>-<pid>` with an optional numeric collision suffix
+ * (e.g. `sandbox-0.7.0-4242` and `sandbox-0.7.0-4242-1`).
+ */
+const NESTED_CONTAINER_NAME = /^.+-\d+(?:-\d+)?$/;
+
+/**
+ * Values LLxprt itself writes into SANDBOX when it launches a nested
+ * process: the Seatbelt launcher writes the literal `sandbox-exec`, and the
+ * container launcher writes the generated container name
+ * (`<image-name-tag>-<pid>`, plus a numeric collision suffix when needed).
+ * Any other value is foreign — a CI system, another tool, a leftover shell
+ * export — and must not be trusted as proof that this process is already
+ * sandboxed (issue #2943).
+ */
+export function isLlxprtWrittenSandboxValue(
+  value: string | undefined,
+): boolean {
+  if (value === undefined || value === '') {
+    return false;
+  }
+  return value === 'sandbox-exec' || NESTED_CONTAINER_NAME.test(value);
+}
+
+/**
+ * Names every channel that carries an explicit sandbox request, so the nested
+ * suppression warning can say which request was ignored instead of stopping blindly.
+ */
+function explicitSandboxRequestSources(
+  resolved: ResolvedSandbox,
+  cliEngine: SandboxProfileEngine | undefined,
+  profile: SandboxProfile | undefined,
+): readonly string[] {
+  const sources: string[] = [];
+  const { value, source } = resolved;
+  if (value !== undefined && value !== false) {
+    sources.push(source);
+  }
+  if (cliEngine !== undefined && cliEngine !== 'auto') {
+    sources.push('--sandbox-engine');
+  }
+  if (profile !== undefined && profile.engine !== 'none') {
+    sources.push('--sandbox-profile-load');
+  }
+  return sources;
+}
+
+/**
  * Interprets a single raw sandbox value into the normalized form the command
  * resolver consumes: `true` (auto-detect), `false` (disabled), or the raw
  * string (an explicit engine command). Mirrors the pre-existing interpretation
@@ -412,11 +460,6 @@ function pickRequestedSandboxCommand(
 function getSandboxCommand(
   resolved: ResolvedSandbox,
 ): SandboxConfig['command'] | '' {
-  // If the SANDBOX env var is set, we're already inside the sandbox.
-  if (process.env.SANDBOX) {
-    return '';
-  }
-
   const { value, source } = resolved;
   if (value === false) {
     return '';
@@ -635,6 +678,24 @@ export async function loadSandboxConfig(
   // `argv.sandbox ?? settings.sandbox`) so "flag absent" stays distinguishable
   // from "flag explicitly false" and precedence is flag > env > settings.
   const resolvedSandbox = resolveSandboxOption(argv.sandbox, settings.sandbox);
+
+  // A SANDBOX value LLxprt itself wrote means this process was launched by a
+  // previous sandbox layer: suppress every request path before any engine probing so
+  // a nested launch never throws FatalSandboxError, and warn only when a request
+  // was actually present (issue #2943).
+  if (isLlxprtWrittenSandboxValue(process.env.SANDBOX)) {
+    const sources = explicitSandboxRequestSources(
+      resolvedSandbox,
+      cliEngine,
+      sandboxProfile,
+    );
+    if (sources.length > 0) {
+      globalThis.console.warn(
+        `Sandboxing was skipped: SANDBOX=${process.env.SANDBOX} indicates this process is already running inside an LLxprt sandbox, so the sandbox request from ${sources.join(', ')} was not started.`,
+      );
+    }
+    return undefined;
+  }
 
   const baseCommand = resolveBaseSandboxCommand(
     resolvedSandbox,

--- a/project-plans/issue-2943-sandbox-env-trust.md
+++ b/project-plans/issue-2943-sandbox-env-trust.md
@@ -1,0 +1,168 @@
+# Issue #2943 — A pre-existing SANDBOX env var silently disables an explicitly requested sandbox
+
+Branch: `issue2943`. Issue: https://github.com/vybestack/llxprt-code/issues/2943
+
+## Problem summary
+
+`getSandboxCommand` in `packages/cli/src/config/sandboxConfig.ts` returns `''`
+unconditionally when `process.env.SANDBOX` is set, before any request
+resolution. Because the empty string is also the "no sandbox requested"
+value, an explicit request (`--sandbox`, `--sandbox-engine`,
+`--sandbox-profile-load`, `LLXPRT_SANDBOX`, `settings.sandbox`) is silently
+dropped and the user runs unsandboxed with no indication.
+
+`SANDBOX` is a generic name; a CI system, an unrelated tool, or a leftover
+shell export can set it. The guard exists to prevent recursive sandboxing:
+LLxprt itself writes `SANDBOX=<containerName>` in
+`packages/cli/src/utils/sandbox-containers.ts` (`addContainerEnvVars`) and
+`SANDBOX=sandbox-exec` in `packages/cli/src/utils/sandbox-seatbelt.ts`
+(`buildSeatbeltArgs`).
+
+Secondary findings from research (verified against source):
+
+- `maybeHopIntoSandbox` (`packages/cli/src/cliSandbox.ts:168`) has a second
+  raw `process.env.SANDBOX` early return. Once config resolution is fixed it
+  is the remaining silent blocker for the hop; with genuine values the
+  `config.getSandbox()` check directly below it already returns, so the raw
+  check is redundant and trusts the same generic variable.
+- The engine/profile request paths bypass the `getSandboxCommand` early
+  return today (`resolveBaseSandboxCommand` picks a command when a profile is
+  present; `resolveSandboxEngine` picks one when `--sandbox-engine` is set),
+  so the nested guard is currently inconsistent: it suppresses flag/env/
+  settings requests but not engine/profile ones. The fix must apply the
+  nested guard to every request path uniformly (issue AC: "Genuine nested
+  invocation ... still does not recurse", and the issue text states the
+  early return "overrides every request path", which is the intended,
+  consistent behavior).
+
+Out of scope (verified untouched):
+
+- `cliBootstrap.tsx:113` (`maybeRelaunchForMemory`) and `scripts/start.ts:88`
+  read `SANDBOX` for memory-relaunch/debug wiring, not sandbox suppression.
+- Display readers (Footer, aboutCommand, bugCommand, docsCommand, prompts,
+  mcp-connection, editor, containerSandbox, process-memory-hardening) treat
+  `SANDBOX` as "am I inside a sandbox" for cosmetic/behavioral purposes.
+  A foreign value continues to influence them as before; changing those is
+  not part of this issue.
+- The `GEMINI_API_KEY` / `GOOGLE_API_KEY` forwarding note in the issue is
+  explicitly deferred to a separate design discussion.
+
+## Accepted behavior (acceptance criteria)
+
+The writers LLxprt itself produces are exactly two shapes:
+
+1. the Seatbelt literal `sandbox-exec`, and
+2. the generated container name `<image-name-tag>-<pid>` with an optional
+   numeric collision suffix `<image-name-tag>-<pid>-<n>`
+   (`assignContainerName` in `sandbox-containers.ts`).
+
+**AC1 — foreign value + explicit request → sandbox starts.** With `SANDBOX`
+set to any other value (`1`, `true`, arbitrary text) and an explicit sandbox
+request, `loadSandboxConfig` resolves exactly as it would with `SANDBOX`
+unset: it returns `{ command, image }` when an engine is available, throws
+the usual `FatalSandboxError` when the request is invalid, and emits no
+suppression warning.
+
+**AC2 — LLxprt-written value → suppressed, warned, no recursion.** With
+`SANDBOX` set to one of the two LLxprt-written shapes, `loadSandboxConfig`
+returns `undefined` for every request path (flag, `LLXPRT_SANDBOX`,
+`settings.sandbox`, `--sandbox-engine`, `--sandbox-profile-load`) without
+probing for engines and without throwing, and writes one warning to stderr
+that names the `SANDBOX` value and the request source(s). This keeps genuine
+nested invocation (container or Seatbelt launch) from recursing while making
+the suppression loud.
+
+**AC3 — no request, `SANDBOX` unset → unchanged.** Returns `undefined`,
+emits nothing.
+
+**AC4 — opt-outs unaffected.** `--no-sandbox` / `--sandbox false` /
+`LLXPRT_SANDBOX=false` / `--sandbox-engine none` still return `undefined`
+with no warning, regardless of `SANDBOX`.
+
+**AC5 — single trust point.** The raw `process.env.SANDBOX` check in
+`maybeHopIntoSandbox` is removed; suppression is decided solely in
+`loadSandboxConfig`, so a foreign `SANDBOX` no longer blocks the hop and a
+genuine one still does (via `config.getSandbox()` being `undefined`).
+
+**AC6 — docs.** The "Do not rely on the SANDBOX environment variable"
+paragraph in `docs/sandbox.md` is updated: a pre-existing foreign value no
+longer silently skips sandbox startup; only LLxprt-written values skip, with
+a warning.
+
+### Boundary cases
+
+- `SANDBOX=''` (empty) is treated as unset everywhere (it already was).
+- Container-name false positives (a foreign value that happens to match
+  `<something>-<pid>[-<n>]`) are suppressed **with the warning**, so the
+  failure is loud, not silent; the user is told why and can unset it.
+- Genuine nested invocation with no request at all stays silent (nothing to
+  warn about; identical outcome to today).
+- Genuine nested + `--sandbox` where no engine exists inside the sandbox:
+  must NOT throw (`pickRequestedSandboxCommand`'s FatalSandboxError must not
+  fire) — the nested check happens before any engine probing. Today's code
+  silently returns `''`; the new code returns `undefined` the same way (plus
+  a warning when a request was present).
+
+## Implementation plan (test-first)
+
+1. **Tests first** — new `packages/cli/src/config/sandboxConfig.nested.test.ts`
+   modeled on `sandboxConfig.precedence.test.ts` (real `loadSandboxConfig`,
+   only `command-exists` substituted; `../sandboxProfiles.js` substituted for
+   the profile cases), covering AC1–AC4 as listed in the test matrix below.
+2. `packages/cli/src/config/sandboxConfig.ts`:
+   - Add exported predicate `isLlxprtWrittenSandboxValue(value)`:
+     `value === 'sandbox-exec'` or `/^.+-\d+(?:-\d+)?$/` (container name
+     shape).
+   - Remove the `process.env.SANDBOX` early return from `getSandboxCommand`.
+   - In `loadSandboxConfig`, immediately after `resolveSandboxOption` and
+     before any engine probing: if the predicate matches, emit the warning
+     when an explicit request source exists (resolved source for enable
+     values, `--sandbox-engine` when a concrete engine is set,
+     `--sandbox-profile-load` when the profile wants a sandbox) and return
+     `undefined`.
+3. `packages/cli/src/cliSandbox.ts` — remove the redundant raw
+   `process.env.SANDBOX` guard in `maybeHopIntoSandbox` (AC5).
+4. Update `AC7` in `packages/cli/src/config/sandboxConfig.precedence.test.ts`
+   to pin the new semantics with an LLxprt-written value (the current test
+   uses `SANDBOX='1'`, which is now the foreign-value case that must START a
+   sandbox).
+5. `docs/sandbox.md` — AC6 paragraph update.
+6. Full verification cycle (see below).
+
+### Test matrix (behavioral, via real loadSandboxConfig)
+
+| # | SANDBOX            | Request                          | Expected                                     |
+|---|--------------------|----------------------------------|----------------------------------------------|
+| 1 | `'1'`              | `--sandbox` true, docker avail.  | config `docker`, no warning                  |
+| 2 | `'true'`           | `LLXPRT_SANDBOX=true`            | config defined, no warning                   |
+| 3 | `'some-ci-value'`  | `--sandbox-engine docker`        | config `docker`, no warning                  |
+| 4 | `'sandbox-exec'`   | `--sandbox` true                 | undefined + warning names value & `--sandbox`|
+| 5 | `'sandbox-0.7.0-4242'` | `settings.sandbox=true`      | undefined + warning                          |
+| 6 | `'sandbox-0.7.0-4242-1'` | `LLXPRT_SANDBOX=true`      | undefined + warning names `LLXPRT_SANDBOX`   |
+| 7 | `'sandbox-exec'`   | `--sandbox-engine docker`        | undefined + warning names `--sandbox-engine` |
+| 8 | `'sandbox-exec'`   | `--sandbox-profile-load dev`     | undefined + warning names profile flag       |
+| 9 | `'sandbox-exec'`   | none                             | undefined, no warning                        |
+| 10| unset              | none                             | undefined, no warning                        |
+| 11| `'sandbox-exec'`   | `--sandbox false`                | undefined, no warning                        |
+| 12| `'1'`              | `--sandbox nosuchcmd`            | throws FatalSandboxError (as with unset SANDBOX) |
+
+Rows 4–8 assert the warning content (value + source) and exactly-once
+emission; rows 1–3, 9–11 assert no warning. Row 7 pins the closed engine
+recursion hole (engine path previously ignored SANDBOX entirely).
+
+## Verification
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+## Review plan
+
+- deepthinker compliance review (cap 2 rounds).
+- Open Code Review (cap 2 local + 2 PR rounds).
+- Findings triaged Blocker-Fix / In-scope-Fix / Reject / Defer.

--- a/project-plans/issue-2943-sandbox-env-trust.md
+++ b/project-plans/issue-2943-sandbox-env-trust.md
@@ -166,3 +166,20 @@ bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing els
 - deepthinker compliance review (cap 2 rounds).
 - Open Code Review (cap 2 local + 2 PR rounds).
 - Findings triaged Blocker-Fix / In-scope-Fix / Reject / Defer.
+
+### Post-PR review additions (PR #3304)
+
+Three boundary rows added after CodeRabbit/OCR PR review, pinning accepted
+behavior with tests rather than changing it:
+
+| # | SANDBOX value        | Request                          | Expected                                     |
+|---|---------------------|----------------------------------|----------------------------------------------|
+| 13| `'ci-job-4821'`     | `--sandbox true`                 | undefined + warning (numeric-suffix lookalike; image portion of real names is user-configurable, so no narrower rule distinguishes it — suppression stays loud) |
+| 14| `'sandbox-exec'`    | `--sandbox-engine bogus`         | throws FatalSandboxError (input validation precedes the nested check; invalid input is reported even nested, matching unset-SANDBOX behavior) |
+| 15| `'sandbox-exec'`    | `--sandbox-profile-load missing` | throws FatalSandboxError (profile load precedes the nested check) |
+
+Dispositions: numeric-suffix narrowing and suppression-before-validation both
+Rejected (would restore recursion for custom-image launches and silently
+swallow user errors); hop-test mock-theater concern Rejected (the predicate is
+exercised via the real `loadSandboxConfig` in rows 1-8; the hop test pins the
+removed raw-env guard in `maybeHopIntoSandbox`).


### PR DESCRIPTION
## TLDR

A pre-existing `SANDBOX` env var (set by a CI system, another tool, or a leftover shell export) silently disabled an explicitly requested sandbox: `getSandboxCommand` returned `''` for **any** `SANDBOX` value, before request resolution, with no warning — the same signal as "sandboxing not requested". Now only values LLxprt itself writes are trusted as proof of a nested launch; every explicit request with a foreign value starts a sandbox normally, and genuine nested suppression warns loudly.

Reviewers should focus on `packages/cli/src/config/sandboxConfig.ts`: the `isLlxprtWrittenSandboxValue` predicate, and the suppression block in `loadSandboxConfig` that runs after `resolveSandboxOption` but before any engine probing.

## Dive Deeper

LLxprt writes `SANDBOX` in exactly two shapes (verified against the writers):

- Seatbelt launcher: literal `sandbox-exec` (`sandbox-seatbelt.ts`, `buildSeatbeltArgs`)
- Container launcher: the generated container name `<image-name-tag>-<pid>` with an optional `-<n>` collision suffix (`sandbox-containers.ts`, `assignContainerName` + `parseImageName`)

Changes:

- **`sandboxConfig.ts`** — new exported predicate `isLlxprtWrittenSandboxValue` (`sandbox-exec` or `/^.+-\d+(?:-\d+)?$/`); the raw `process.env.SANDBOX` early return removed from `getSandboxCommand`; a single trust point in `loadSandboxConfig` suppresses every request path (`--sandbox`, `LLXPRT_SANDBOX`, `settings.sandbox`, `--sandbox-engine`, `--sandbox-profile-load`) when the value is LLxprt-written, emitting exactly one `console.warn` naming the value and the ignored request source(s), and returning `undefined`.
- The suppression runs **before any `command-exists` probing**, so an engine-less nested `--sandbox` (no docker/podman/sandbox-exec inside the sandbox) stays a clean `undefined` instead of throwing `FatalSandboxError` — pinned by a test asserting no probe happens.
- **Engine/profile recursion hole closed**: previously `--sandbox-engine` and `--sandbox-profile-load` bypassed the `SANDBOX` guard entirely (`resolveSandboxEngine` picked a command on its own); moving the check above all resolution covers them uniformly.
- **`cliSandbox.ts`** — the redundant raw `process.env.SANDBOX` guard removed from `maybeHopIntoSandbox`; `config.getSandbox()` (fed solely by `loadSandboxConfig`) is now the single authority, so a foreign value no longer blocks the hop while genuine nested launches still skip it. Pinned by a hop test with `SANDBOX='some-ci-value'`.
- **`docs/sandbox.md`** — the "do not rely on `SANDBOX`" paragraph updated: only LLxprt-written forms suppress, suppression of an explicit request warns, foreign values do not suppress; the variable remains trivially forgeable, so the filesystem-marker verification advice stands.

Accepted boundary (documented in the plan): a foreign value that happens to end in `-<digits>` (e.g. `ci-runner-42`) matches the container-name shape and is suppressed **with the warning** — the issue's criterion allows "reports clearly that it was skipped and why", and narrowing further (e.g. a `sandbox-` prefix) would miss custom-image container names and could restore recursion. Opt-outs (`--no-sandbox`, `--sandbox false`, `LLXPRT_SANDBOX=false`, `--sandbox-engine none`) remain silent. `SANDBOX=''` counts as unset.

Out of scope, untouched: the memory-relaunch readers (`cliBootstrap.tsx`, `scripts/start.ts`), display-only readers (Footer, about/bug/docs commands, prompts, mcp-connection, editor, containerSandbox, process-memory-hardening), and the API-key forwarding boundary discussion noted in the issue.

## Reviewer Test Plan

Behavioral test suites (bun:test, real `loadSandboxConfig`; only infrastructure substituted — `command-exists`, and `sandboxProfiles.js` for profile rows):

- `packages/cli/src/config/sandboxConfig.nested.test.ts` (new, 13 tests): the full issue matrix — foreign `1`/`true`/`some-ci-value` + each request channel start a sandbox with no warning; `sandbox-exec`, container-name, and collision-suffixed values + each channel (flag, env, settings, engine, profile) return `undefined` with exactly one warning naming `SANDBOX=<value>` and the source; no-request rows stay silent; opt-out rows stay silent; engine-less nested stays `undefined` without probing; foreign value does not weaken `--sandbox nosuchcmd` validation.
- `packages/cli/src/config/sandboxConfig.precedence.test.ts` — AC7 updated to pin LLxprt-written suppression (was `'1'`, which is now correctly the foreign case).
- `packages/cli/src/cli-sandbox.test.tsx` — hop test proving a foreign `SANDBOX` value reaches `start_sandbox`.

Manual reproduction from the issue:

```
SANDBOX=1 llxprt --sandbox "..."   # sandbox now starts (docker/podman/seatbelt per auto-detect)
SANDBOX=sandbox-exec llxprt --sandbox "..."  # skipped with a warning naming the value and --sandbox
```

Run each CLI test file in its own `bun test <file>` invocation from `packages/cli` (the real runner isolates files; batching them in one invocation cross-contaminates mocks).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | ❓  | -   | -   |

Full verification cycle on macOS (🍏): `npm run test` (CLI workspace 715/715), `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build` all exit 0, plus smoke `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` (haiku, exit 0). Red→Green evidence captured: with the fix stashed, 8/13 nested tests fail against the old behavior. Note: full-suite runs also showed load-flaky timing tests in core/agents (machine load avg ~15); each passes standalone and none touch this change.

## Linked issues / bugs

Fixes #2943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested sandbox detection so only LLxprt-generated sandbox markers suppress additional sandbox startup.
  * Foreign or arbitrary `SANDBOX` values no longer prevent explicit sandbox requests.
  * Added warnings when an explicitly requested sandbox is skipped due to an LLxprt-generated marker.
  * Preserved validation for invalid sandbox engines and clarified that `SANDBOX` values alone do not confirm sandbox execution.

* **Documentation**
  * Updated sandbox verification guidance to explain marker behavior and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->