### PR TITLE
Report SS3 sequences as the bytes the parser consumed (Fixes #3300)

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.parsing.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.parsing.test.tsx
@@ -244,6 +244,87 @@ describe('Kitty Sequence Parsing', () => {
     });
   });
 
+  describe('SS3 sequence parsing', () => {
+    // key.sequence must be the exact bytes consumed for an SS3 (ESC O ...)
+    // sequence, since paste content is reassembled by concatenating key.sequence.
+    it('should keep the O in the sequence for plain arrow keys', () => {
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => stdin.write('\x1bOA'));
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'up',
+          shift: false,
+          meta: false,
+          ctrl: false,
+          sequence: '\x1bOA',
+        }),
+      );
+    });
+
+    it('should keep the O and modifier in the sequence for modified arrow keys', () => {
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => stdin.write('\x1bO2A'));
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'up',
+          shift: true,
+          sequence: '\x1bO2A',
+        }),
+      );
+    });
+
+    it('should preserve SS3 bytes inside bracketed paste payloads', async () => {
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => stdin.write('\x1b[200~'));
+      act(() => stdin.write('before\x1bOAafter'));
+      act(() => stdin.write('\x1b[201~'));
+
+      await act(() => vi.runAllTimers());
+
+      // Paste fidelity contract: the payload is reassembled from key.sequence, so
+      // every consumed byte (including the O) must round-trip or the text corrupts.
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'paste',
+          sequence: 'before\x1bOAafter',
+        }),
+      );
+    });
+
+    it('should leave CSI bracket sequences unchanged', () => {
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => stdin.write('\x1b[A'));
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'up',
+          sequence: '\x1b[A',
+        }),
+      );
+    });
+
+    it('should emit the consumed bytes when an SS3 sequence is flushed by timeout', () => {
+      const { keyHandler } = setupKeypressTest();
+
+      act(() => stdin.write('\x1bO'));
+
+      // Wait for the ESC timeout to flush the incomplete sequence.
+      void act(() => vi.advanceTimersByTime(ESC_TIMEOUT + 10));
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sequence: '\x1bO',
+        }),
+      );
+    });
+  });
+
   it('should timeout and flush incomplete kitty sequences after 100ms', async () => {
     const keyHandler = vi.fn();
     const { result } = renderHook(() => useKeypressContext(), { wrapper });

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -437,14 +437,15 @@ function* readOCodeSequence(): Generator<
 > {
   let ch = yield;
   let modifier = 0;
-  let sequence = '';
+  // sequence is the bytes consumed after the leading ESC, so it must include
+  // the O and any digit prefix for key.sequence to round-trip the input.
+  let sequence = 'O';
   if (ch >= '0' && ch <= '9') {
     modifier = parseInt(ch, 10) - 1;
+    sequence += ch;
     ch = yield;
-    sequence = String(ch);
-  } else {
-    sequence = String(ch);
   }
+  sequence += ch;
   return { code: 'O' + ch, modifier, sequence };
 }
 

--- a/project-plans/issue3300/PLAN.md
+++ b/project-plans/issue3300/PLAN.md
@@ -1,0 +1,66 @@
+# Plan for issue #3300 — SS3 key decoding drops the `O` from `key.sequence`
+
+## Accepted behavior
+
+`key.sequence` must be the exact bytes the parser consumed for an SS3
+(`ESC O ...`) sequence, so that `ESC + parsed.sequence` reconstructs the
+original input, matching the CSI reader's contract.
+
+### Acceptance criteria
+
+- **AC1:** `\x1bOA` decodes to one key `{ name: 'up', shift: false, meta: false, ctrl: false }` with `sequence: '\x1bOA'`.
+- **AC2:** An SS3 sequence with a numeric modifier prefix round-trips its bytes: `\x1bO2A` decodes to `{ name: 'up', shift: true }` with `sequence: '\x1bO2A'`.
+- **AC3:** A bracketed-paste payload containing `\x1bOA` (`\x1b[200~before\x1bOAafter\x1b[201~`) is delivered as `{ name: 'paste', sequence: 'before\x1bOAafter' }` — the `O` intact.
+- **AC4:** CSI round-trip behavior is unchanged: `\x1b[A` still decodes with `sequence: '\x1b[A'`.
+
+### Boundary cases (considered, behavior = "sequence is the consumed bytes")
+
+- Incomplete SS3 flush: `\x1bO` followed by the ESC_TIMEOUT flush emits a key with `sequence: '\x1bO'` (previously `'\x1b'`). No main-branch test pins the old value; no consumer matches `'\x1b'`-valued SS3 output (verified by grep of `sequence ===` consumers — all match single printable chars or paste events).
+- SS3 keys split across multiple `data` events still decode identically; only `sequence` construction changes.
+- `\x1b[O` (CSI FOCUS_OUT) is untouched — different code path (`readBracketSequence`).
+
+### Out of scope (classified)
+
+- **Defer:** Bare-Escape `meta: true` cleanup from the issue Notes. Not part of the acceptance criteria; PR #3303 (issue #2024) explicitly pins `escape meta: true` in its AC3.3 test, so changing it here would semantically conflict with that open PR. Follow-up only, with its own issue if desired.
+- **Defer:** Adding the `sequence` assertion to PR #3303's AC3.6 test. That file (`KeypressContext.escape.test.ts`) does not exist on `main`; it lives in open PR #3303. Creating it here would duplicate/conflict with that PR. Once #3303 merges, the assertion `expect(key.sequence).toBe('\x1bOA')` should be added there (its comment block says exactly this). Coordinate via a PR comment, not by editing the other PR's files.
+
+## Root cause
+
+`readOCodeSequence` (packages/cli/src/ui/contexts/KeypressContext.tsx) sets
+`sequence` to only the final character (`String(ch)`), omitting the `O` and
+any digit prefix. `emitKeys` then emits `ESC + parsed.sequence`, so `\x1bOA`
+is reported as `\x1bA`. `bufferPaste` reassembles paste payloads by
+concatenating `key.sequence`, corrupting pasted text containing SS3 bytes.
+
+## Change
+
+Single production edit in `readOCodeSequence`: initialize `sequence` to
+`'O'`, append a consumed digit prefix, and append the final character. No
+change to `code`/`modifier` derivation, `emitKeys`, `bufferPaste`, or
+`readBracketSequence`.
+
+## Test plan (TDD — tests fail before the fix, pass after)
+
+Extend `packages/cli/src/ui/contexts/KeypressContext.parsing.test.tsx`
+(existing MockStdin + fake-timers harness; same file already covers parser
+round-trips and bracketed paste) with a new describe block for SS3 parsing:
+
+1. AC1: `\x1bOA` → `{ name: 'up', sequence: '\x1bOA' }`.
+2. AC2: `\x1bO2A` → `{ name: 'up', shift: true, sequence: '\x1bO2A' }`.
+3. AC3: paste start + `before\x1bOAafter` + paste end → one paste event with `sequence: 'before\x1bOAafter'`.
+4. AC4: `\x1b[A` → `{ name: 'up', sequence: '\x1b[A' }` (guard against regression).
+5. Boundary: `\x1bO` + ESC_TIMEOUT flush → emitted with `sequence: '\x1bO'` (consumed-bytes contract).
+
+## Verification
+
+Full cycle per the issue workflow: `npm run test`, `npm run lint`,
+`npm run typecheck`, `npm run format`, `npm run build`, and the
+`bun scripts/start.ts --profile-load stepfun-37` smoke test. Then OCR review
+(capped at 2 rounds), PR, CI watch, CodeRabbit triage.
+
+## Review-triage classifications (pre-declared)
+
+- Blocker-Fix: anything that breaks AC1–AC4, existing tests, lint/typecheck/build/CI.
+- In-scope-Fix: sequence-construction correctness in `readOCodeSequence` and the new tests.
+- Reject: suggestions to change `bufferPaste`, CSI parsing, keybindings, or add speculative hardening.
+- Defer: bare-Escape `meta` cleanup; AC3.6 assertion in PR #3303's file; anything touching other open efforts.


### PR DESCRIPTION
## TLDR

`readOCodeSequence` now reports `key.sequence` as the exact bytes it consumed (the `O`, an optional digit modifier prefix, and the final character), so `ESC + parsed.sequence` reconstructs the original input. `\x1bOA` previously decoded as `sequence: '\x1bA'` — the `O` was dropped.

## Dive Deeper

`bufferPaste` reassembles bracketed-paste payloads by concatenating `key.sequence` of every key decoded between `paste-start` and `paste-end` (`packages/cli/src/ui/contexts/KeypressContext.tsx`). Because the SS3 reader returned only the final character as its `sequence`, a pasted payload containing SS3 bytes was silently corrupted:

```
paste of "before\x1bOAafter"  ->  { name: 'paste', sequence: 'before\x1bAafter' }   // 'O' lost
paste of "before\x1b[Aafter"  ->  { name: 'paste', sequence: 'before\x1b[Aafter' }  // intact
```

The CSI reader (`readBracketSequence`) already accumulated every byte it consumed into `sequence`; the SS3 reader now does the same, and the two paths agree about what `sequence` means.

Decoding is untouched: `code` stays `'O' + ch`, the modifier stays `parseInt(digit, 10) - 1`, and the `KEY_INFO_MAP` lookup is identical, so key identity (`\x1bOA` → `up`, etc.) is unchanged. A grep of `sequence`-matching consumers across `packages/cli/src` found none that match SS3-shaped sequences (all match single printable characters or paste events), so no consumer observed the old malformed value.

One boundary changes by construction and is pinned by a test: an incomplete `\x1bO` flushed by `ESC_TIMEOUT` now emits `sequence: '\x1bO'` (previously `'\x1b'`) — again the bytes actually consumed.

Scope notes, per the issue:

- The bare-Escape `meta: true` smell from the issue Notes is deliberately deferred: open PR #3303 pins that behavior in its AC3.3 test, so changing it here would semantically conflict.
- The issue asks that PR #3303's AC3.6 test add `expect(key.sequence).toBe('\x1bOA')` once this fix lands. That file does not exist on `main` (it is introduced by #3303), so the assertion belongs there — its own comment block says exactly this. This PR's test suite pins the same contract on `main`'s test file instead, so the behavior is guarded from both directions once both merge.

## Reviewer Test Plan

- `cd packages/cli && bun test src/ui/contexts/KeypressContext.parsing.test.tsx` — the new `SS3 sequence parsing` describe covers: `\x1bOA` → `up` with `sequence: '\x1bOA'`; `\x1bO2A` → shift+up with `sequence: '\x1bO2A'`; bracketed paste of `before\x1bOAafter` delivered intact; `\x1b[A` CSI round-trip unchanged; `\x1bO` timeout flush emits consumed bytes.
- TDD evidence: with the production fix stashed, exactly the four sequence assertions fail with sequence mismatches (`'\x1bA'` vs `'\x1bOA'` etc.); the CSI guard passes.
- Manual, if you have a terminal that sends SS3 arrows (some macOS profiles): press arrows and note key identity is unchanged; paste text containing an escape sequence and confirm the payload arrives verbatim.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS (`npm run`): full `npm run test` (714/714 CLI test files, 9174 cases, 0 failures), `npm run lint`, `npm run typecheck`, `npm run format` (no changes), `npm run build`, and the `bun scripts/start.ts --profile-load stepfun-37` smoke test all pass. Reviews: local OCR (0 findings) and deepthinker compliance review (PASS, no findings).

## Linked issues / bugs

Fixes #3300

Found while writing coverage for #2024 (open PR #3303); this is the production fix that issue deliberately excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard input handling for SS3 escape sequences, including modified arrow keys.
  - Preserved complete key sequences so input bytes can be accurately round-tripped.
  - Correctly handles SS3 sequences within bracketed paste content.
  - Ensures incomplete sequences are flushed correctly after a timeout.

- **Tests**
  - Added coverage for SS3 parsing, modifier prefixes, pasted content, unchanged CSI parsing, and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->