### PR TITLE
Collapse profile parsing and classify the settings registry (Fixes #2642)

### DIFF
--- a/packages/agents/src/api/control/profilesControl.ts
+++ b/packages/agents/src/api/control/profilesControl.ts
@@ -28,6 +28,8 @@ import type {
   ProfileDetail,
   ProfileSummary,
 } from '../agent.js';
+
+import { parseProfileJson } from '@vybestack/llxprt-code-settings';
 import type { AgentProviderState } from '../agentImpl.js';
 
 /**
@@ -433,12 +435,11 @@ export class ProfilesControl implements AgentProfileControl {
     } catch {
       return undefined;
     }
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
+    const parsedJson = parseProfileJson(raw);
+    if (parsedJson.kind !== 'parsed') {
       return undefined;
     }
+    const parsed = parsedJson.value;
     if (!isPublicProfileShape(parsed)) {
       return undefined;
     }

--- a/packages/cli/src/config/__tests__/profileBootstrap.parseBoundary.test.ts
+++ b/packages/cli/src/config/__tests__/profileBootstrap.parseBoundary.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Behavioral tests for the shared profile-JSON parse boundary via the CLI
+ * `--profile` path and the load-balancer interactive save member rule (#2642).
+ *
+ * The inline `--profile` path (profileBootstrap) and the on-disk path
+ * (ProfileManager) must agree on the same parsed result for identical content,
+ * and the interactive save path must still require >= 2 member profiles.
+ *
+ * These use the REAL `parseProfileJson` (via `profileBootstrap` for the
+ * `--profile` path, `ProfileManager` for the on-disk path) against a real
+ * temp directory. The runtime providers module is mocked only so the
+ * profileBootstrap module can be imported; the parser and ProfileManager are real.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { parseInlineProfile } from '../profileBootstrap.js';
+import {
+  parseProfileJson,
+  ProfileManager,
+} from '@vybestack/llxprt-code-settings';
+import { profileCommand } from '../../ui/commands/profileCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+
+void vi.mock('@vybestack/llxprt-code-providers/runtime.js', () => ({
+  registerAgentRuntimeFactories: vi.fn(),
+  resetAgentRuntimeFactories: vi.fn(),
+  registerCliProviderInfrastructure: vi.fn(),
+}));
+
+const runtimeMocks = {
+  saveProfileSnapshot: vi.fn(),
+  loadProfileByName: vi.fn(),
+  deleteProfileByName: vi.fn(),
+  listSavedProfiles: vi.fn(),
+  setDefaultProfileName: vi.fn(),
+  getActiveProfileName: vi.fn(),
+  getActiveProviderStatus: vi.fn(),
+  saveLoadBalancerProfile: vi.fn(),
+  getEphemeralSettings: vi.fn(),
+};
+
+void vi.mock('../../ui/contexts/RuntimeContext.js', () => ({
+  getRuntimeApi: vi.fn(() => runtimeMocks),
+}));
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'llxprt-issue2642-cli-'));
+}
+
+describe('parseInlineProfile — same content as the on-disk parse boundary (#2642)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('identical inline --profile JSON and on-disk JSON produce the same provider/model', async () => {
+    const content = JSON.stringify({
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: { temperature: 0.7 },
+      ephemeralSettings: { 'context-limit': 190000 },
+    });
+
+    // On-disk path → real parseProfileJson.
+    const onDisk = parseProfileJson(content);
+    if (onDisk.kind !== 'parsed') {
+      throw new Error(`expected kind "parsed", got "${onDisk.kind}"`);
+    }
+    {
+      const value = onDisk.value as {
+        provider: string;
+        model: string;
+      };
+      expect(value.provider).toBe('openai');
+      expect(value.model).toBe('gpt-4');
+    }
+
+    // On-disk path through the real ProfileManager.
+    const manager = new ProfileManager(tempDir);
+    await fs.writeFile(path.join(tempDir, 'profile.json'), content, 'utf8');
+    const loaded = await manager.loadProfile('profile');
+    expect(loaded.provider).toBe('openai');
+    expect(loaded.model).toBe('gpt-4');
+
+    // Inline --profile path (real parseProfileJson inside profileBootstrap).
+    const inline = parseInlineProfile(content);
+    expect(inline.providerName).toBe('openai');
+    expect(inline.modelName).toBe('gpt-4');
+    expect(inline.error).toBeUndefined();
+  });
+
+  it('the same malformed content is rejected through ProfileManager, the inline path, and parseProfileJson', async () => {
+    const malformed = '{ this is not json';
+
+    // Inline --profile path.
+    const inline = parseInlineProfile(malformed);
+    expect(inline.error).toBeDefined();
+
+    // On-disk path: the SAME malformed bytes must be rejected as corrupt,
+    // not silently reported as missing.
+    await fs.writeFile(path.join(tempDir, 'malformed.json'), malformed, 'utf8');
+    await expect(
+      new ProfileManager(tempDir).loadProfile('malformed'),
+    ).rejects.toThrow('corrupted');
+
+    // Direct parse boundary agrees with both.
+    expect(parseProfileJson(malformed).kind).toBe('invalid-json');
+  });
+});
+
+describe('profile load-balancer save — interactive path still requires >= 2 members (#2642)', () => {
+  beforeEach(() => {
+    runtimeMocks.listSavedProfiles.mockResolvedValue(['profile1', 'profile2']);
+    runtimeMocks.getEphemeralSettings.mockReturnValue({});
+    runtimeMocks.saveLoadBalancerProfile.mockResolvedValue(undefined);
+  });
+
+  const saveProfile = () =>
+    profileCommand.subCommands!.find((cmd) => cmd.name === 'save')!;
+
+  it('too few arguments produce the usage error, not the member-count error', async () => {
+    const result = await saveProfile().action!(
+      createMockCommandContext(),
+      'loadbalancer lb roundrobin profile1',
+    );
+
+    expect(result).toBeDefined();
+    expect(result).toMatchObject({ type: 'message', messageType: 'error' });
+    const content = (result as { content: string }).content;
+    expect(content).toContain('Usage: /profile save loadbalancer');
+  });
+
+  it('one member surviving --context-limit stripping is rejected as too few members', async () => {
+    // Enough tokens to clear the arity guard, so this reaches the member-count
+    // rule. Proves BOTH that the flag and its value are stripped rather than
+    // counted as profile names, and that a lone member is then rejected.
+    const result = await saveProfile().action!(
+      createMockCommandContext(),
+      'loadbalancer lb roundrobin --context-limit 150000 profile1',
+    );
+
+    expect(result).toBeDefined();
+    expect(result).toMatchObject({ type: 'message', messageType: 'error' });
+    const content = (result as { content: string }).content;
+    expect(content).toContain('at least 2 profiles');
+  });
+
+  it('--context-limit and its value are stripped, not counted as members', async () => {
+    const result = await saveProfile().action!(
+      createMockCommandContext(),
+      'loadbalancer lb roundrobin --context-limit 150000 profile1 profile2',
+    );
+
+    expect(result).toBeDefined();
+    const content = (result as { content: string }).content;
+    expect(content).toContain(
+      "Load balancer profile 'lb' saved with 2 profiles",
+    );
+  });
+
+  it('two members save successfully', async () => {
+    const result = await saveProfile().action!(
+      createMockCommandContext(),
+      'loadbalancer lb roundrobin profile1 profile2',
+    );
+
+    expect(result).toBeDefined();
+    const content = (result as { content: string }).content;
+    expect(content).toContain(
+      "Load balancer profile 'lb' saved with 2 profiles",
+    );
+  });
+});

--- a/packages/cli/src/config/__tests__/profileBootstrap.parseBoundary.test.ts
+++ b/packages/cli/src/config/__tests__/profileBootstrap.parseBoundary.test.ts
@@ -58,7 +58,19 @@ describe('parseInlineProfile — same content as the on-disk parse boundary (#26
   });
 
   afterEach(async () => {
-    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      // Do not fail the test on cleanup, but do not hide a real I/O problem
+      // either: a silent catch turns disk-full/permission failures into
+      // invisible temp-directory leaks. process.emitWarning rather than
+      // console.* because the repo bans console statements.
+      process.emitWarning(
+        `parseBoundary test: failed to remove ${tempDir}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   });
 
   it('identical inline --profile JSON and on-disk JSON produce the same provider/model', async () => {
@@ -114,6 +126,31 @@ describe('parseInlineProfile — same content as the on-disk parse boundary (#26
 
     // Direct parse boundary agrees with both.
     expect(parseProfileJson(malformed).kind).toBe('invalid-json');
+  });
+
+  it('the inline --profile path rejects prototype-pollution keys', async () => {
+    // The CLI inline path and the on-disk path must agree on hostile
+    // documents. Without this, a regression re-introducing divergent
+    // validation between profileBootstrap and ProfileManager would be
+    // invisible here.
+    const topLevel =
+      '{"version":1,"provider":"openai","model":"gpt-4","__proto__":{"polluted":true},"modelParams":{},"ephemeralSettings":{}}';
+    const nested =
+      '{"version":1,"provider":"openai","model":"gpt-4","modelParams":{},"ephemeralSettings":{"constructor":{"x":1}}}';
+
+    for (const hostile of [topLevel, nested]) {
+      expect(parseProfileJson(hostile).kind).toBe('unsafe');
+      expect(parseInlineProfile(hostile).error).toBeDefined();
+
+      // The on-disk path rejects the same bytes.
+      await fs.writeFile(path.join(tempDir, 'hostile.json'), hostile, 'utf8');
+      await expect(
+        new ProfileManager(tempDir).loadProfile('hostile'),
+      ).rejects.toThrow('dangerous fields');
+    }
+
+    // Reading hostile documents never polluted the real prototype.
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/config/legacyProfileNormalization.ts
+++ b/packages/cli/src/config/legacyProfileNormalization.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import {
   parseProfile,
+  parseProfileJson,
   isLoadBalancerProfile,
   withProfilesLockSync,
   type Profile,
@@ -297,12 +298,11 @@ function normalizeLegacyProfileBytes(legacyPath: string): string | null {
     return null;
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(readResult.content);
-  } catch {
+  const parsedJson = parseProfileJson(readResult.content);
+  if (parsedJson.kind !== 'parsed') {
     return null;
   }
+  const parsed = parsedJson.value;
 
   if (!isPlainObject(parsed)) {
     return null;

--- a/packages/cli/src/config/profileBootstrap.ts
+++ b/packages/cli/src/config/profileBootstrap.ts
@@ -18,6 +18,7 @@ import {
 } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-telemetry';
 import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import { parseProfileJson } from '@vybestack/llxprt-code-settings';
 import type { ProviderManager } from '@vybestack/llxprt-code-providers';
 import { createOAuthSettingsAdapter } from '../auth/oauth-settings-adapter.js';
 import { assembleCliProviderRuntime } from '@vybestack/llxprt-code-providers/runtime.js';
@@ -445,13 +446,18 @@ function parseInlineProfileJson(
   if (!jsonString || jsonString.trim() === '') {
     return profileValidationError('Profile JSON cannot be empty');
   }
-  try {
-    return JSON.parse(jsonString) as unknown;
-  } catch (err) {
+  // Single shared profile-JSON parse boundary. The shared boundary also
+  // rejects prototype-pollution keys (__proto__/constructor/prototype), so
+  // the inline --profile path and every on-disk profile path agree on shape.
+  const parsed = parseProfileJson(jsonString);
+  if (parsed.kind !== 'parsed') {
     return profileValidationError(
-      `Invalid JSON in --profile: ${err instanceof Error ? err.message : String(err)}`,
+      parsed.kind === 'invalid-json'
+        ? `Invalid JSON in --profile: ${parsed.error.message}`
+        : parsed.error.message,
     );
   }
+  return parsed.value;
 }
 
 function validateInlineProfileObject(
@@ -512,6 +518,10 @@ function validateProfileDepth(
 function validateDangerousProfileFields(
   parsed: unknown,
 ): ProfileApplicationResult | undefined {
+  // Defense-in-depth backstop: the shared parseProfileJson boundary already
+  // rejects these exact keys; keeping the explicit check here preserves the exact
+  // profileBootstrap error contract for --profile even if a caller bypasses
+  // the string entry point.
   if (hasDangerousField(parsed, ['__proto__', 'constructor', 'prototype'])) {
     return profileValidationError(
       'Profile contains dangerous fields (__proto__, constructor, or prototype)',

--- a/packages/cli/src/ui/commands/profileLoadBalancer.ts
+++ b/packages/cli/src/ui/commands/profileLoadBalancer.ts
@@ -9,6 +9,7 @@ import { getRuntimeApi } from '../contexts/RuntimeContext.js';
 import {
   getProtectedSettingKeys,
   isInternalSettingKey,
+  MIN_LOAD_BALANCER_MEMBERS,
   type LoadBalancerProfile,
 } from '@vybestack/llxprt-code-settings';
 import { createTokenStore } from '@vybestack/llxprt-code-providers/auth.js';
@@ -343,11 +344,14 @@ export async function saveLoadBalancerProfile(
     (p) => p.length > 0,
   );
 
+  // The interactive save path requires >= 2 members (the load path accepts
+  // >= MIN_LOAD_BALANCER_MEMBERS so existing single-member files keep
+  // loading).
   if (selectedProfiles.length < 2) {
     return {
       type: 'message',
       messageType: 'error',
-      content: 'Load balancer profile requires at least 2 profiles',
+      content: `Load balancer profile requires at least 2 profiles (minimum allowed: ${Math.max(MIN_LOAD_BALANCER_MEMBERS, 2)})`,
     };
   }
 

--- a/packages/cli/src/ui/commands/profileLoadBalancer.ts
+++ b/packages/cli/src/ui/commands/profileLoadBalancer.ts
@@ -9,11 +9,19 @@ import { getRuntimeApi } from '../contexts/RuntimeContext.js';
 import {
   getProtectedSettingKeys,
   isInternalSettingKey,
-  MIN_LOAD_BALANCER_MEMBERS,
   type LoadBalancerProfile,
 } from '@vybestack/llxprt-code-settings';
 import { createTokenStore } from '@vybestack/llxprt-code-providers/auth.js';
 import { validateBucketName, validateProfileName } from './profileSchemas.js';
+
+/**
+ * Minimum members the INTERACTIVE save path accepts. Deliberately independent
+ * of `MIN_LOAD_BALANCER_MEMBERS` in the settings package, which governs the
+ * load path and stays at 1 so existing hand-authored single-member files keep
+ * loading. Creating a one-member "load balancer" from the UI is a user error,
+ * so this is 2.
+ */
+const MIN_INTERACTIVE_LOAD_BALANCER_MEMBERS = 2;
 
 /** Parsed result of a quoted profile-name argument string. */
 interface QuotedProfileNameParse {
@@ -344,14 +352,15 @@ export async function saveLoadBalancerProfile(
     (p) => p.length > 0,
   );
 
-  // The interactive save path requires >= 2 members (the load path accepts
-  // >= MIN_LOAD_BALANCER_MEMBERS so existing single-member files keep
-  // loading).
-  if (selectedProfiles.length < 2) {
+  // The interactive save path requires >= MIN_INTERACTIVE_LOAD_BALANCER_MEMBERS
+  // (the load path accepts >= MIN_LOAD_BALANCER_MEMBERS so existing
+  // single-member files keep loading). The two thresholds are deliberately
+  // independent, so this one has its own constant rather than being derived.
+  if (selectedProfiles.length < MIN_INTERACTIVE_LOAD_BALANCER_MEMBERS) {
     return {
       type: 'message',
       messageType: 'error',
-      content: `Load balancer profile requires at least 2 profiles (minimum allowed: ${Math.max(MIN_LOAD_BALANCER_MEMBERS, 2)})`,
+      content: `Load balancer profile requires at least ${MIN_INTERACTIVE_LOAD_BALANCER_MEMBERS} profiles`,
     };
   }
 

--- a/packages/settings/src/__tests__/settingsRegistry.issue2642.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2642.test.ts
@@ -97,6 +97,26 @@ describe('settings registry — owner / propagation metadata (#2642)', () => {
     }
   });
 
+  it('the three application keys declare persistToProfile: false in the registry', () => {
+    // Asserting the registry data directly, not just the derived list: if
+    // getProfilePersistableKeys() ever excluded these for an unrelated reason
+    // the exclusion test above would still pass while the data stayed wrong.
+    for (const key of ['emojifilter', 'dumponerror', 'dumpcontext']) {
+      const spec = SETTINGS_REGISTRY.find((s) => s.key === key);
+      expect(spec).toBeDefined();
+      expect(spec?.owner).toBe('application');
+      expect(spec?.persistToProfile).toBe(false);
+    }
+  });
+
+  it('getProfilePersistableKeys matches exactly the specs flagged persistToProfile', () => {
+    // End-to-end contract: the derived list is the flag, nothing more.
+    const expected = SETTINGS_REGISTRY.filter((s) => s.persistToProfile).map(
+      (s) => s.key,
+    );
+    expect(getProfilePersistableKeys().sort()).toEqual(expected.sort());
+  });
+
   it('persistence follows the per-spec flag, not a blanket owner rule', () => {
     // `token-usage-log` is application-owned but explicitly persists. A blanket
     // `owner !== 'application'` filter would silently drop it and contradict

--- a/packages/settings/src/__tests__/settingsRegistry.issue2642.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2642.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Behavioral tests for the registry `owner` / `propagation` metadata (#2642).
+ *
+ * Every registry key must carry a non-empty `owner` and `propagation`, the
+ * owner values must fall within the documented union, and the application-owned
+ * cluster (emojifilter / dumponerror / dumpcontext) must be excluded from
+ * profile persistence while the new application-owned helpers agree.
+ *
+ * These are pure registry tests — no filesystem, no mocks.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  SETTINGS_REGISTRY,
+  getProfilePersistableKeys,
+  getApplicationOwnedKeys,
+  isApplicationOwnedKey,
+} from '../settings/settingsRegistry.js';
+
+const ALLOWED_OWNERS = new Set([
+  'application',
+  'provider-connection',
+  'model',
+  'agent-policy',
+]);
+
+const ALLOWED_PROPAGATION = new Set([
+  'render-immediate',
+  'next-turn',
+  'service-reconfigure',
+  'profile-transition',
+  'restart-required',
+]);
+
+// Key per owner that is part of the profile persistence surface.
+const REPRESENTATIVE_KEYS: Record<
+  'application' | 'provider-connection' | 'model' | 'agent-policy',
+  string
+> = {
+  application: 'emojifilter',
+  'provider-connection': 'auth-key',
+  model: 'reasoning.enabled',
+  'agent-policy': 'tools.allowed',
+};
+
+describe('settings registry — owner / propagation metadata (#2642)', () => {
+  it('every registry entry has a non-empty owner and propagation', () => {
+    // Guard against a vacuous pass if the registry is ever empty or unloaded.
+    // Deliberately a non-empty check rather than a headcount: legitimate
+    // registry cleanup must not fail this contract test.
+    expect(SETTINGS_REGISTRY.length).toBeGreaterThan(0);
+
+    for (const spec of SETTINGS_REGISTRY) {
+      expect(spec.owner.length).toBeGreaterThan(0);
+      expect(spec.propagation.length).toBeGreaterThan(0);
+      expect(ALLOWED_OWNERS.has(spec.owner)).toBe(true);
+      expect(ALLOWED_PROPAGATION.has(spec.propagation)).toBe(true);
+    }
+  });
+
+  it('each representative key maps to its documented owner', () => {
+    const byKey = new Map<string, string>(
+      SETTINGS_REGISTRY.map((s) => [s.key, s.owner]),
+    );
+    for (const [owner, key] of Object.entries(REPRESENTATIVE_KEYS)) {
+      // `?? '(missing)'` keeps both sides `string` and gives a readable
+      // failure if a representative key is ever removed from the registry.
+      expect(byKey.get(key) ?? '(missing)').toBe(owner);
+    }
+  });
+
+  it('getApplicationOwnedKeys includes the application-owned keys', () => {
+    const appKeys = getApplicationOwnedKeys();
+    for (const key of ['emojifilter', 'dumponerror', 'dumpcontext']) {
+      expect(appKeys).toContain(key);
+    }
+  });
+
+  it('isApplicationOwnedKey is true for application keys and false for others', () => {
+    expect(isApplicationOwnedKey('emojifilter')).toBe(true);
+    expect(isApplicationOwnedKey('dumpcontext')).toBe(true);
+    expect(isApplicationOwnedKey('auth-key')).toBe(false);
+    expect(isApplicationOwnedKey('reasoning.enabled')).toBe(false);
+  });
+
+  it('application-owned keys are excluded from profile persistence', () => {
+    const keys = getProfilePersistableKeys();
+    const persistable = new Set(keys);
+
+    // Positive control: without this the exclusion assertions below would
+    // still pass if the persistable set were ever empty.
+    expect(keys.length).toBeGreaterThan(0);
+    expect(persistable.has('auth-key')).toBe(true);
+
+    for (const key of ['emojifilter', 'dumponerror', 'dumpcontext']) {
+      expect(persistable.has(key)).toBe(false);
+    }
+  });
+
+  it('persistence follows the per-spec flag, not a blanket owner rule', () => {
+    // `token-usage-log` is application-owned but explicitly persists. A blanket
+    // `owner !== 'application'` filter would silently drop it and contradict
+    // its own spec.
+    const tokenUsageLog = SETTINGS_REGISTRY.find(
+      (s) => s.key === 'token-usage-log',
+    );
+    expect(tokenUsageLog).toBeDefined();
+    expect(tokenUsageLog?.owner).toBe('application');
+    expect(tokenUsageLog?.persistToProfile).toBe(true);
+    expect(getProfilePersistableKeys()).toContain('token-usage-log');
+  });
+});

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -26,6 +26,8 @@ export {
   getProtectedSettingKeys,
   getProviderConfigKeys,
   getDirectSettingSpecs,
+  getApplicationOwnedKeys,
+  isApplicationOwnedKey,
   getInternalSettingKeys,
   isInternalSettingKey,
   isSessionScopedSettingKey,
@@ -72,7 +74,11 @@ export type {
   CanonicalRepairOutcome,
   CanonicalRepairResult,
 } from './profiles/canonicalProfileRepair.js';
-export { parseProfile } from './settings/validation.js';
+export {
+  parseProfile,
+  parseProfileJson,
+  MIN_LOAD_BALANCER_MEMBERS,
+} from './settings/validation.js';
 export type {
   Profile,
   StandardProfile,

--- a/packages/settings/src/profiles/ProfileManager.ts
+++ b/packages/settings/src/profiles/ProfileManager.ts
@@ -19,6 +19,7 @@ import {
   isPlainObject,
   parseLoadBalancerProfile,
   parseProfile,
+  parseProfileJson,
   parsePromptCaching,
 } from '../settings/validation.js';
 
@@ -107,6 +108,27 @@ export class ProfileManager {
     );
   }
 
+  /**
+   * Parse raw profile file content through the single shared parse boundary
+   * so load/reference/scan paths produce identical results. Malformed JSON
+   * and prototype-pollution documents surface as typed parse errors before any
+   * schema validation.
+   */
+  private static parseProfileContent(content: string): unknown {
+    const parsed = parseProfileJson(content);
+    if (parsed.kind === 'invalid-json') {
+      // Chain the original parse error so position information
+      // ("Unexpected token } ... at position 42") is not lost.
+      throw new SyntaxError('profile JSON is malformed', {
+        cause: parsed.error,
+      });
+    }
+    if (parsed.kind === 'unsafe') {
+      throw parsed.error;
+    }
+    return parsed.value;
+  }
+
   async saveLoadBalancerProfile(name: string, profile: unknown): Promise<void> {
     const loadBalancerProfile = parseLoadBalancerProfile(name, profile);
 
@@ -127,7 +149,8 @@ export class ProfileManager {
         referencedProfilePath,
         'utf8',
       );
-      const referencedProfileData: unknown = JSON.parse(referencedContent);
+      const referencedProfileData: unknown =
+        ProfileManager.parseProfileContent(referencedContent);
 
       if (referencedProfileIsLoadBalancer(referencedProfileData)) {
         throw new Error(
@@ -173,7 +196,8 @@ export class ProfileManager {
         referencedProfilePath,
         'utf8',
       );
-      const referencedProfileData: unknown = JSON.parse(referencedContent);
+      const referencedProfileData: unknown =
+        ProfileManager.parseProfileContent(referencedContent);
 
       if (referencedProfileIsLoadBalancer(referencedProfileData)) {
         throw new Error(
@@ -194,7 +218,7 @@ export class ProfileManager {
     try {
       const content = await fs.readFile(filePath, 'utf8');
 
-      const parsed: unknown = JSON.parse(content);
+      const parsed = ProfileManager.parseProfileContent(content);
       const profile =
         isPlainObject(parsed) && parsed.type === 'loadbalancer'
           ? parseLoadBalancerProfile(profileName, parsed)
@@ -257,7 +281,7 @@ export class ProfileManager {
         try {
           const filePath = path.join(this.profilesDir, `${name}.json`);
           const content = await fs.readFile(filePath, 'utf8');
-          const parsed: unknown = JSON.parse(content);
+          const parsed = ProfileManager.parseProfileContent(content);
           if (
             isPlainObject(parsed) &&
             parsed.type === 'loadbalancer' &&

--- a/packages/settings/src/profiles/ProfileManager.ts
+++ b/packages/settings/src/profiles/ProfileManager.ts
@@ -124,7 +124,11 @@ export class ProfileManager {
       });
     }
     if (parsed.kind === 'unsafe') {
-      throw parsed.error;
+      // Also a SyntaxError, so loadProfile's "Profile 'X' is corrupted"
+      // wrapping applies uniformly. Throwing a plain Error here made
+      // prototype-pollution surface as a raw message without the profile name
+      // while malformed JSON got the friendly one.
+      throw new SyntaxError(parsed.error.message, { cause: parsed.error });
     }
     return parsed.value;
   }
@@ -234,7 +238,13 @@ export class ProfileManager {
         throw new Error(`Profile '${profileName}' not found`);
       }
       if (error instanceof SyntaxError) {
-        throw new Error(`Profile '${profileName}' is corrupted`);
+        // Name the profile AND say why. Malformed JSON and dangerous-key
+        // documents both arrive here as SyntaxError, and "corrupted" alone
+        // does not tell the user which problem their file has.
+        throw new Error(
+          `Profile '${profileName}' is corrupted: ${error.message}`,
+          { cause: error },
+        );
       }
       if (
         error instanceof Error &&

--- a/packages/settings/src/profiles/__tests__/ProfileManager.test.ts
+++ b/packages/settings/src/profiles/__tests__/ProfileManager.test.ts
@@ -771,7 +771,7 @@ describe('ProfileManager — parse boundary rejects unsafe object shapes', () =>
     );
 
     await expect(pm.loadProfile('polluted-modelparams')).rejects.toThrow(
-      'missing required fields',
+      'dangerous fields',
     );
   });
 
@@ -784,7 +784,7 @@ describe('ProfileManager — parse boundary rejects unsafe object shapes', () =>
     );
 
     await expect(pm.loadProfile('polluted-ephemeral')).rejects.toThrow(
-      'missing required fields',
+      'dangerous fields',
     );
   });
 });

--- a/packages/settings/src/profiles/__tests__/canonicalProfileRepair.testHelpers.ts
+++ b/packages/settings/src/profiles/__tests__/canonicalProfileRepair.testHelpers.ts
@@ -9,10 +9,31 @@ import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { beforeEach, afterEach } from 'bun:test';
 import { CORRUPT_PROVIDER } from '../canonicalProfileRepair.js';
 
 export async function makeTempDir(): Promise<string> {
   return fsp.mkdtemp(path.join(os.tmpdir(), 'llxprt-canonical-repair-test-'));
+}
+
+/**
+ * Shared lazy temp-directory accessor for behavioral profile tests.
+ *
+ * Registers bun's `beforeEach`/`afterEach` internally so every test runs
+ * against a fresh directory that is removed afterwards. Call it ONCE at
+ * module scope and call the returned accessor inside a test / `beforeEach`
+ * to get the current directory. This keeps a fresh isolated directory per test
+ * without copy-pasting setup/teardown in every describe block.
+ */
+export function withTempDir(prefix = 'llxprt-profile-test-'): () => string {
+  let dir = '';
+  beforeEach(async () => {
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  });
+  afterEach(async () => {
+    await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+  return () => dir;
 }
 
 /**

--- a/packages/settings/src/profiles/__tests__/canonicalProfileRepair.testHelpers.ts
+++ b/packages/settings/src/profiles/__tests__/canonicalProfileRepair.testHelpers.ts
@@ -31,7 +31,19 @@ export function withTempDir(prefix = 'llxprt-profile-test-'): () => string {
     dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
   });
   afterEach(async () => {
-    await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
+    try {
+      await fsp.rm(dir, { recursive: true, force: true });
+    } catch (error) {
+      // Do not fail the test on cleanup, but do not hide a real I/O problem
+      // either: a silent catch turns disk-full/permission failures into
+      // invisible temp-directory leaks. process.emitWarning rather than
+      // console.* because the repo bans console statements.
+      process.emitWarning(
+        `withTempDir: failed to remove ${dir}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   });
   return () => dir;
 }

--- a/packages/settings/src/profiles/__tests__/profileParser.issue2642.test.ts
+++ b/packages/settings/src/profiles/__tests__/profileParser.issue2642.test.ts
@@ -365,3 +365,29 @@ describe('regression profile fixtures load with version: 1 unchanged', () => {
     expect(loaded.version).toBe(1);
   });
 });
+
+// ─── G. repair eligibility is not blocked by dangerous keys ────────────────
+
+describe('canonical repair inspection tolerates dangerous keys (#2642 review)', () => {
+  it('a corrupt canonical carrying a top-level __proto__ is still repair-eligible', async () => {
+    // Routing repair through the shared parser must not make a hostile file
+    // permanently unrepairable: repair is exactly the mechanism that replaces
+    // it. Before this issue, top-level dangerous keys passed parseProfile
+    // (only modelParams/ephemeralSettings were guarded by isSafeRecord), so
+    // such a file WAS repair-eligible. That must remain true.
+    const corruptWithProto = `{"version":1,"provider":"load-balancer","model":"x","__proto__":{"polluted":true},"modelParams":{},"ephemeralSettings":{}}`;
+
+    const parsed = parseProfileJson(corruptWithProto);
+    // The shared boundary still flags it...
+    expect(parsed.kind).toBe('unsafe');
+
+    // ...and reading it does not pollute the real prototype.
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
+
+  it('a replacement carrying dangerous keys is still refused', () => {
+    const unsafeReplacement = `{"version":1,"provider":"openai","model":"gpt-4","modelParams":{},"ephemeralSettings":{"__proto__":{"x":1}}}`;
+    const parsed = parseProfileJson(unsafeReplacement);
+    expect(parsed.kind).toBe('unsafe');
+  });
+});

--- a/packages/settings/src/profiles/__tests__/profileParser.issue2642.test.ts
+++ b/packages/settings/src/profiles/__tests__/profileParser.issue2642.test.ts
@@ -24,6 +24,7 @@ import {
   writeProfile,
 } from './canonicalProfileRepair.testHelpers.js';
 import { getProfilePersistableKeys } from '../../settings/settingsRegistry.js';
+import { repairCanonicalProfiles } from '../canonicalProfileRepair.js';
 
 const tempDir = withTempDir('llxprt-issue2642-parser-');
 const profilesDir = () => path.join(tempDir(), 'profiles');
@@ -368,26 +369,69 @@ describe('regression profile fixtures load with version: 1 unchanged', () => {
 
 // ─── G. repair eligibility is not blocked by dangerous keys ────────────────
 
-describe('canonical repair inspection tolerates dangerous keys (#2642 review)', () => {
-  it('a corrupt canonical carrying a top-level __proto__ is still repair-eligible', async () => {
+describe('canonical repair tolerates dangerous keys (#2642 review)', () => {
+  it('actually repairs a corrupt canonical carrying a top-level __proto__', async () => {
     // Routing repair through the shared parser must not make a hostile file
     // permanently unrepairable: repair is exactly the mechanism that replaces
     // it. Before this issue, top-level dangerous keys passed parseProfile
     // (only modelParams/ephemeralSettings were guarded by isSafeRecord), so
-    // such a file WAS repair-eligible. That must remain true.
-    const corruptWithProto = `{"version":1,"provider":"load-balancer","model":"x","__proto__":{"polluted":true},"modelParams":{},"ephemeralSettings":{}}`;
+    // such a file WAS repair-eligible. This exercises the real repair
+    // function, not just the parse boundary.
+    const canonicalDir = profilesDir();
+    const legacyDir = path.join(tempDir(), 'legacy-profiles');
+    await fsp.mkdir(legacyDir, { recursive: true });
 
-    const parsed = parseProfileJson(corruptWithProto);
-    // The shared boundary still flags it...
-    expect(parsed.kind).toBe('unsafe');
+    // Corrupt canonical: the #2479 signature PLUS a top-level dangerous key.
+    await fsp.writeFile(
+      path.join(canonicalDir, 'victim.json'),
+      '{"version":1,"provider":"load-balancer","model":"gemini-2.5-pro","__proto__":{"polluted":true},"modelParams":{},"ephemeralSettings":{}}',
+      'utf8',
+    );
+    // Valid same-name legacy replacement.
+    await fsp.writeFile(
+      path.join(legacyDir, 'victim.json'),
+      standardProfileJson(),
+      'utf8',
+    );
 
-    // ...and reading it does not pollute the real prototype.
+    const outcome = repairCanonicalProfiles(canonicalDir, legacyDir);
+    expect(outcome.kind).toBe('repaired');
+
+    // The repaired canonical is the legacy content, and loads cleanly.
+    const repaired = await pm().loadProfile('victim');
+    expect(repaired.provider).toBe('openai');
+    expect(repaired.version).toBe(1);
+
+    // Reading the hostile document never polluted the real prototype.
     expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
   });
 
-  it('a replacement carrying dangerous keys is still refused', () => {
-    const unsafeReplacement = `{"version":1,"provider":"openai","model":"gpt-4","modelParams":{},"ephemeralSettings":{"__proto__":{"x":1}}}`;
-    const parsed = parseProfileJson(unsafeReplacement);
-    expect(parsed.kind).toBe('unsafe');
+  it('refuses to install a REPLACEMENT that carries dangerous keys', async () => {
+    const canonicalDir = profilesDir();
+    const legacyDir = path.join(tempDir(), 'legacy-profiles-2');
+    await fsp.mkdir(legacyDir, { recursive: true });
+
+    await fsp.writeFile(
+      path.join(canonicalDir, 'victim2.json'),
+      '{"version":1,"provider":"load-balancer","model":"gemini-2.5-pro","modelParams":{},"ephemeralSettings":{}}',
+      'utf8',
+    );
+    // Hostile replacement must never be promoted into the canonical slot.
+    await fsp.writeFile(
+      path.join(legacyDir, 'victim2.json'),
+      '{"version":1,"provider":"openai","model":"gpt-4","modelParams":{},"ephemeralSettings":{"__proto__":{"x":1}}}',
+      'utf8',
+    );
+
+    const outcome = repairCanonicalProfiles(canonicalDir, legacyDir);
+    expect(outcome.kind).not.toBe('repaired');
+
+    // The corrupt canonical is left untouched rather than replaced by the
+    // hostile file.
+    const still = await fsp.readFile(
+      path.join(canonicalDir, 'victim2.json'),
+      'utf8',
+    );
+    expect(still).toContain('load-balancer');
   });
 });

--- a/packages/settings/src/profiles/__tests__/profileParser.issue2642.test.ts
+++ b/packages/settings/src/profiles/__tests__/profileParser.issue2642.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Behavioral tests for the shared profile-JSON parse boundary (#2642).
+ *
+ * All profile-JSON enters via a single `parseProfileJson` boundary that
+ * ProfileManager routes every load through. These tests write REAL profile JSON
+ * into a REAL temp directory and read it back through the REAL `parseProfileJson`
+ * and REAL `ProfileManager` — no mocks, no stubs. Filesystem is
+ * infrastructure; the parser and ProfileManager are the systems under test.
+ *
+ * Note: ProfileManager member validation is observed through its public
+ * surface (loadProfile / deleteProfile), which is the behaviour a user sees.
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import { ProfileManager } from '../ProfileManager.js';
+import {
+  parseProfileJson,
+  MIN_LOAD_BALANCER_MEMBERS,
+} from '../../settings/validation.js';
+import {
+  withTempDir,
+  writeProfile,
+} from './canonicalProfileRepair.testHelpers.js';
+import { getProfilePersistableKeys } from '../../settings/settingsRegistry.js';
+
+const tempDir = withTempDir('llxprt-issue2642-parser-');
+const profilesDir = () => path.join(tempDir(), 'profiles');
+const pm = () => new ProfileManager(profilesDir());
+
+// Guarantee the profiles directory exists for every test. Without this, tests
+// that write raw JSON via fsp.writeFile would depend on an earlier
+// writeProfile() call (which mkdirs) having run first in the same test.
+beforeEach(async () => {
+  await fsp.mkdir(profilesDir(), { recursive: true });
+});
+
+function standardProfileJson(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4',
+    modelParams: {},
+    ephemeralSettings: {},
+    ...overrides,
+  });
+}
+
+function loadBalancerJson(profiles: readonly string[]): string {
+  return JSON.stringify({
+    version: 1,
+    type: 'loadbalancer',
+    policy: 'roundrobin',
+    profiles,
+    provider: '',
+    model: '',
+    modelParams: {},
+    ephemeralSettings: {},
+  });
+}
+
+// ─── A. single parser ───────────────────────────────────────────────────────
+
+describe('parseProfileJson — single profile-JSON parse boundary', () => {
+  it('returns kind "parsed" with the parsed value for valid JSON', () => {
+    const result = parseProfileJson(
+      JSON.stringify({ version: 1, provider: 'anthropic', model: 'gpt-4' }),
+    );
+
+    if (result.kind !== 'parsed') {
+      throw new Error(`expected kind "parsed", got "${result.kind}"`);
+    }
+    {
+      const value = result.value as { provider: string };
+      expect(value.provider).toBe('anthropic');
+    }
+  });
+
+  it('returns kind "invalid-json" for malformed JSON', () => {
+    const result = parseProfileJson('{ not valid json');
+
+    if (result.kind !== 'invalid-json') {
+      throw new Error(`expected kind "invalid-json", got "${result.kind}"`);
+    }
+    {
+      expect(result.error).toBeInstanceOf(Error);
+    }
+  });
+
+  it('returns kind "unsafe" for a top-level __proto__ key', () => {
+    const result = parseProfileJson(
+      '{"version":1,"provider":"openai","model":"gpt-4","__proto__":{"isAdmin":true}}',
+    );
+
+    expect(result.kind).toBe('unsafe');
+  });
+
+  it('returns kind "unsafe" for a nested constructor key', () => {
+    const content = JSON.stringify({
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: { constructor: { prototype: { polluted: true } } },
+      ephemeralSettings: {},
+    });
+
+    expect(parseProfileJson(content).kind).toBe('unsafe');
+  });
+
+  it('returns kind "unsafe" for a nested prototype key', () => {
+    const content =
+      '{"version":1,"provider":"openai","model":"gpt-4","modelParams":{},"ephemeralSettings":{"nested":{"prototype":{}}}}';
+
+    expect(parseProfileJson(content).kind).toBe('unsafe');
+  });
+
+  it('a profile containing a legacy `loadBalancer` field still loads and is a standard profile', async () => {
+    const legacy = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: { temperature: 0.7 },
+      ephemeralSettings: {},
+      loadBalancer: {
+        strategy: 'round-robin',
+        subProfiles: [
+          { name: 'a', provider: 'openai' },
+          { name: 'b', provider: 'openai' },
+        ],
+      },
+    };
+    const parsed = parseProfileJson(JSON.stringify(legacy));
+    if (parsed.kind !== 'parsed' || parsed.value === null) {
+      throw new Error(`expected a non-null parsed value, got "${parsed.kind}"`);
+    }
+    {
+      const value = parsed.value as { provider: string };
+      expect(value.provider).toBe('openai');
+    }
+    writeProfile(profilesDir(), 'legacy-lb.json', legacy);
+    const loaded = await pm().loadProfile('legacy-lb');
+    expect(loaded.type).not.toBe('loadbalancer');
+    expect(loaded.provider).toBe('openai');
+    expect(loaded.version).toBe(1);
+  });
+
+  it('an on-disk profile and an identical inline JSON string parse to the same value', async () => {
+    const content = JSON.stringify({
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: {},
+      ephemeralSettings: { 'context-limit': 190000 },
+    });
+    writeProfile(profilesDir(), 'standard-a.json', JSON.parse(content));
+
+    const parsed = parseProfileJson(content);
+    const loaded = await pm().loadProfile('standard-a');
+
+    if (parsed.kind !== 'parsed') {
+      throw new Error(`expected kind "parsed", got "${parsed.kind}"`);
+    }
+    {
+      const value = parsed.value as { provider: string; model: string };
+      expect(value.provider).toBe('openai');
+      expect(loaded.provider).toBe('openai');
+      expect(loaded.version).toBe(1);
+    }
+  });
+});
+
+// ─── B. LB member handling through the shared parser ─────────────────────
+
+describe('parseProfileJson — load-balancer member validation through ProfileManager', () => {
+  it('rejects a load balancer referencing a MISSING member on load', async () => {
+    await fsp.writeFile(
+      path.join(profilesDir(), 'lb-hosts-ghost.json'),
+      loadBalancerJson(['no-such-member']),
+      'utf8',
+    );
+    writeProfile(
+      profilesDir(),
+      'member.json',
+      JSON.parse(standardProfileJson()),
+    );
+
+    await expect(pm().loadProfile('lb-hosts-ghost')).rejects.toThrow(
+      /references non-existent profile 'no-such-member'/,
+    );
+  });
+
+  it('rejects a load balancer referencing a NESTED load balancer', async () => {
+    writeProfile(
+      profilesDir(),
+      'member-b.json',
+      JSON.parse(standardProfileJson()),
+    );
+    await fsp.writeFile(
+      path.join(profilesDir(), 'nested.json'),
+      loadBalancerJson(['member-b']),
+      'utf8',
+    );
+    await fsp.writeFile(
+      path.join(profilesDir(), 'nested-outer.json'),
+      loadBalancerJson(['nested']),
+      'utf8',
+    );
+
+    await expect(pm().loadProfile('nested-outer')).rejects.toThrow(
+      /cannot reference another LoadBalancer profile 'nested'/,
+    );
+  });
+
+  it('a 1-member load-balancer file LOADS successfully (MIN_LOAD_BALANCER_MEMBERS = 1)', async () => {
+    expect(MIN_LOAD_BALANCER_MEMBERS).toBe(1);
+    writeProfile(
+      profilesDir(),
+      'member-c.json',
+      JSON.parse(standardProfileJson()),
+    );
+    await fsp.writeFile(
+      path.join(profilesDir(), 'single-member.json'),
+      loadBalancerJson(['member-c']),
+      'utf8',
+    );
+
+    const loaded = await pm().loadProfile('single-member');
+    if (loaded.type !== 'loadbalancer') {
+      throw new Error(`expected a loadbalancer profile, got "${loaded.type}"`);
+    }
+    {
+      expect(loaded.profiles).toStrictEqual(['member-c']);
+      expect(loaded.version).toBe(1);
+    }
+  });
+
+  it('survives a directory that also has an invalid JSON file and a non-profile JSON file when scanning references', async () => {
+    writeProfile(
+      profilesDir(),
+      'member-d.json',
+      JSON.parse(standardProfileJson()),
+    );
+    await fsp.writeFile(
+      path.join(profilesDir(), 'garbage.json'),
+      '{ broken',
+      'utf8',
+    );
+    await fsp.writeFile(
+      path.join(profilesDir(), 'notes.json'),
+      '{"iAm":"plain json","not":"a-profile"}',
+      'utf8',
+    );
+
+    const loaded = await pm().loadProfile('member-d');
+    expect(loaded.provider).toBe('openai');
+  });
+
+  it('refuses to delete a referenced member, scanning past invalid and non-profile siblings', async () => {
+    writeProfile(
+      profilesDir(),
+      'member-f-a.json',
+      JSON.parse(standardProfileJson()),
+    );
+    await fsp.writeFile(
+      path.join(profilesDir(), 'broken.json'),
+      '{ broken',
+      'utf8',
+    );
+    await fsp.writeFile(
+      path.join(profilesDir(), 'plain.json'),
+      '{"kind":"not-a-profile"}',
+      'utf8',
+    );
+    await fsp.writeFile(
+      path.join(profilesDir(), 'lb-ref.json'),
+      loadBalancerJson(['member-f-a']),
+      'utf8',
+    );
+
+    // The corrupt / non-profile siblings must not crash the scan → the
+    // reference is found and deletion is blocked, not thrown.
+    await expect(pm().deleteProfile('member-f-a')).rejects.toThrow(
+      /referenced by load balancer profile\(s\): lb-ref/,
+    );
+  });
+});
+
+// ─── E. application keys are tolerated and never persisted ───────────────
+
+describe('application-owned settings keys', () => {
+  it('a profile file containing application keys loads without error', async () => {
+    const content = JSON.stringify({
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: {},
+      ephemeralSettings: {
+        emojifilter: 'auto',
+        dumponerror: 'enabled',
+        dumpcontext: 'off',
+      },
+    });
+    writeProfile(profilesDir(), 'app-keys.json', JSON.parse(content));
+
+    const loaded = await pm().loadProfile('app-keys');
+    expect(loaded.version).toBe(1);
+    expect(loaded.provider).toBe('openai');
+  });
+
+  it('the application keys are excluded from profile persistence', () => {
+    const keys = getProfilePersistableKeys();
+    for (const key of ['emojifilter', 'dumponerror', 'dumpcontext']) {
+      expect(keys).not.toContain(key);
+    }
+  });
+});
+
+// ─── F. regression fixture set ─────────────────────────────────────────────
+
+describe('regression profile fixtures load with version: 1 unchanged', () => {
+  it('standard profile', async () => {
+    writeProfile(profilesDir(), 'std.json', JSON.parse(standardProfileJson()));
+    const loaded = await pm().loadProfile('std');
+    expect(loaded.version).toBe(1);
+    expect(loaded.provider).toBe('openai');
+  });
+
+  it('load-balancer profile', async () => {
+    writeProfile(
+      profilesDir(),
+      'member.json',
+      JSON.parse(standardProfileJson()),
+    );
+    await fsp.writeFile(
+      path.join(profilesDir(), 'lb.json'),
+      loadBalancerJson(['member']),
+      'utf8',
+    );
+    const loaded = await pm().loadProfile('lb');
+    expect(loaded.version).toBe(1);
+    expect(loaded.type).toBe('loadbalancer');
+  });
+
+  it('unknown / future keys are preserved through the passthrough parse', async () => {
+    const content = JSON.stringify({
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: { 'future-param': 1 },
+      ephemeralSettings: { 'future-setting': true },
+      futureTopLevelField: 'future',
+    });
+    writeProfile(profilesDir(), 'future.json', JSON.parse(content));
+
+    const parsed = parseProfileJson(content);
+    if (parsed.kind !== 'parsed') {
+      throw new Error(`expected kind "parsed", got "${parsed.kind}"`);
+    }
+    {
+      const value = parsed.value as { futureTopLevelField: string };
+      expect(value.futureTopLevelField).toBe('future');
+    }
+    const loaded = await pm().loadProfile('future');
+    expect(loaded.version).toBe(1);
+  });
+});

--- a/packages/settings/src/profiles/canonicalProfileRepair.ts
+++ b/packages/settings/src/profiles/canonicalProfileRepair.ts
@@ -161,11 +161,14 @@ function readAndParseProfile(filePath: string):
     return { kind: 'error', error: result.error };
   }
   const parsedJson = parseProfileJson(result.content);
-  if (parsedJson.kind !== 'parsed') {
-    // Malformed JSON and prototype-pollution rejections are deliberately
-    // collapsed here: both make the file unreadable as a profile, and repair
-    // eligibility only needs "not parseable". The distinction is surfaced at
-    // the user-facing boundary in validateReplacementFile.
+  // Only malformed JSON blocks inspection. A document carrying dangerous keys
+  // is still INSPECTED here, because repair is the mechanism that recognises
+  // and replaces such a file — refusing to look at it would strand the user
+  // with the bad profile forever. Reading is safe: JSON.parse materialises
+  // `__proto__` as an own property rather than invoking the setter, and
+  // nothing here writes the parsed object back out. The write boundary
+  // (validateReplacementFile) still refuses to install an unsafe replacement.
+  if (parsedJson.kind === 'invalid-json') {
     return { kind: 'invalid-json' };
   }
   const parsed: unknown = parsedJson.value;
@@ -210,6 +213,9 @@ function validateLegacyReplacement(legacyPath: string): string | null {
   }
 
   const parsedJson = parseProfileJson(result.content);
+  // Both 'invalid-json' and 'unsafe' disqualify a REPLACEMENT. Unlike the
+  // inspection path above, this document is about to be installed as the
+  // canonical profile, so a dangerous-key document must never be promoted.
   if (parsedJson.kind !== 'parsed') {
     return null;
   }

--- a/packages/settings/src/profiles/canonicalProfileRepair.ts
+++ b/packages/settings/src/profiles/canonicalProfileRepair.ts
@@ -8,7 +8,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Profile } from './types.js';
 import { isLoadBalancerProfile } from './types.js';
-import { parseProfile } from '../settings/validation.js';
+import { parseProfile, parseProfileJson } from '../settings/validation.js';
 import {
   hasErrnoCode,
   acquireProfilesLockSync,
@@ -160,12 +160,15 @@ function readAndParseProfile(filePath: string):
   if (result.kind === 'error') {
     return { kind: 'error', error: result.error };
   }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(result.content);
-  } catch {
+  const parsedJson = parseProfileJson(result.content);
+  if (parsedJson.kind !== 'parsed') {
+    // Malformed JSON and prototype-pollution rejections are deliberately
+    // collapsed here: both make the file unreadable as a profile, and repair
+    // eligibility only needs "not parseable". The distinction is surfaced at
+    // the user-facing boundary in validateReplacementFile.
     return { kind: 'invalid-json' };
   }
+  const parsed: unknown = parsedJson.value;
   let profile: Profile;
   try {
     profile = parseProfile(parsed);
@@ -206,12 +209,11 @@ function validateLegacyReplacement(legacyPath: string): string | null {
     return null;
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(result.content);
-  } catch {
+  const parsedJson = parseProfileJson(result.content);
+  if (parsedJson.kind !== 'parsed') {
     return null;
   }
+  const parsed = parsedJson.value;
 
   if (!isRawObject(parsed)) {
     return null;
@@ -459,7 +461,16 @@ function cleanupTemp(tmpPath: string): void {
 
 function validateReplacementFile(filePath: string): void {
   const content = fs.readFileSync(filePath, 'utf-8');
-  const parsed: unknown = JSON.parse(content);
+  const parsedJson = parseProfileJson(content);
+  if (parsedJson.kind !== 'parsed') {
+    // Distinguish malformed JSON from a prototype-pollution rejection; both
+    // block the repair but a user needs to know which one they hit.
+    throw new Error(
+      `replacement file is not valid profile JSON (${parsedJson.kind}): ${parsedJson.error.message}`,
+      { cause: parsedJson.error },
+    );
+  }
+  const parsed = parsedJson.value;
   // The replacement must not still match the corrupt structural signature.
   if (isCorruptStandardProfileFromRaw(parsed)) {
     throw new Error('replacement file still has the corrupt defect signature');

--- a/packages/settings/src/profiles/profileStore.ts
+++ b/packages/settings/src/profiles/profileStore.ts
@@ -9,7 +9,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { channel } from 'node:diagnostics_channel';
-
+import { parseProfileJson } from '../settings/validation.js';
 /**
  * diagnostics_channel name published exactly once per async lock acquisition
  * when the first EEXIST is observed. The payload is `{ lockPath: string }`.
@@ -209,13 +209,11 @@ async function readLockToken(lockPath: string): Promise<string | null> {
  * assertion. Uses structural narrowing on the parsed value.
  */
 function extractTokenFromMetadata(raw: string): string | null {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
+  const parsed = parseProfileJson(raw);
+  if (parsed.kind !== 'parsed') {
     return null;
   }
-  return readTokenField(parsed);
+  return readTokenField(parsed.value);
 }
 
 /**

--- a/packages/settings/src/profiles/types.ts
+++ b/packages/settings/src/profiles/types.ts
@@ -189,25 +189,6 @@ export interface ProfileEphemeralSettings {
 export type EphemeralSettings = ProfileEphemeralSettings;
 
 /**
- * Sub-profile configuration for load balancing
- */
-export interface LoadBalancerSubProfileConfig {
-  name: string;
-  provider: string;
-  model?: string;
-  baseURL?: string;
-  apiKey?: string;
-}
-
-/**
- * Load balancer configuration
- */
-export interface LoadBalancerConfig {
-  strategy: 'round-robin';
-  subProfiles: LoadBalancerSubProfileConfig[];
-}
-
-/**
  * Standard profile configuration (single model)
  */
 export interface StandardProfile {
@@ -217,7 +198,6 @@ export interface StandardProfile {
   model: string;
   modelParams: ModelParams;
   ephemeralSettings: EphemeralSettings;
-  loadBalancer?: LoadBalancerConfig;
   auth?: AuthConfig;
 }
 

--- a/packages/settings/src/settings/registry/registry-entries-1.ts
+++ b/packages/settings/src/settings/registry/registry-entries-1.ts
@@ -112,6 +112,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     key: 'auth-key',
     aliases: ['apiKey', 'api-key'],
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Provider API authentication key',
     type: 'string',
     persistToProfile: true,
@@ -121,6 +123,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     key: 'auth-keyfile',
     aliases: ['apiKeyfile', 'api-keyfile'],
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Path to file containing API key',
     type: 'string',
     persistToProfile: true,
@@ -128,6 +132,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'auth-key-name',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description:
       'Name of a saved API key in the keyring (resolved via /key save)',
     type: 'string',
@@ -136,6 +142,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'base-url',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Provider API base URL',
     type: 'string',
     persistToProfile: true,
@@ -143,6 +151,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'sandbox-base-url',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description:
       'Base URL override used when running inside a container sandbox (Docker/Podman)',
     type: 'string',
@@ -151,6 +161,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'requires-auth',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description:
       'Whether the provider requires API key authentication (set to false for local providers)',
     type: 'boolean',
@@ -159,6 +171,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'model',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Default model name',
     type: 'string',
     persistToProfile: true,
@@ -166,6 +180,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'defaultModel',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Fallback model if primary unavailable',
     type: 'string',
     persistToProfile: true,
@@ -173,6 +189,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'enabled',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Enable/disable provider',
     type: 'boolean',
     persistToProfile: true,
@@ -181,6 +199,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     key: 'toolFormat',
     aliases: ['tool-format'],
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Tool format preference',
     type: 'enum',
     enumValues: [
@@ -201,6 +221,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     key: 'toolFormatOverride',
     aliases: ['tool-format-override'],
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Force specific tool format',
     type: 'enum',
     enumValues: [
@@ -220,6 +242,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'api-version',
     category: 'cli-behavior',
+    owner: 'provider-connection',
+    propagation: 'next-turn',
     description: 'API version to use',
     type: 'string',
     persistToProfile: true,
@@ -227,6 +251,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'apiMode',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description:
       'Preferred OpenAI transport mode (responses/chat); chat is ignored for models that require the Responses API',
     type: 'enum',
@@ -236,6 +262,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'responsesMode',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description:
       'Fallback transport mode for the OpenAI provider (responses/chat)',
     type: 'enum',
@@ -243,8 +271,13 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     persistToProfile: true,
   },
   {
+    // Sibling of apiMode / responsesMode / openaiResponsesEnabled: all four
+    // feed the same transport resolution in openaiModelPolicy.ts, so they must
+    // share one propagation class.
     key: 'responses-mode',
     category: 'cli-behavior',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description:
       'Global fallback transport mode for OpenAI when apiMode and responsesMode are unset (responses/chat)',
     type: 'enum',
@@ -254,6 +287,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'openaiResponsesEnabled',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description:
       'Force-enable the OpenAI Responses API on non-canonical base URLs',
     type: 'boolean',
@@ -262,6 +297,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.enabled',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Enable thinking/reasoning for models that support it',
     type: 'boolean',
     persistToProfile: true,
@@ -273,6 +310,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.effort',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'How much the model should think before responding (minimal/low/medium/high/xhigh/max)',
     type: 'enum',
@@ -282,6 +321,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.effortWireFormat',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Request wire format for generic reasoning effort',
     type: 'enum',
     enumValues: [
@@ -300,6 +341,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.enabledWireFormat',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Request wire format for generic reasoning enablement',
     type: 'enum',
     enumValues: [
@@ -317,6 +360,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.effortMap',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Model-specific mapping from generic reasoning effort values',
     type: 'json',
     persistToProfile: true,
@@ -325,6 +370,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.enabledMap',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Model-specific mapping from generic reasoning enablement',
     type: 'json',
     persistToProfile: true,
@@ -333,6 +380,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.maxTokens',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Maximum token budget for reasoning',
     type: 'number',
     persistToProfile: true,
@@ -340,6 +389,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.budgetTokens',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Token budget for reasoning (Anthropic-specific)',
     type: 'number',
     persistToProfile: true,
@@ -347,6 +398,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.adaptiveThinking',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Enable adaptive thinking for Anthropic Opus 4.6+ (true/false)',
     type: 'boolean',
@@ -355,6 +408,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.includeInResponse',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Show thinking blocks in UI output',
     type: 'boolean',
     persistToProfile: true,
@@ -362,6 +417,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.includeInContext',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Keep thinking in conversation history',
     type: 'boolean',
     persistToProfile: true,
@@ -369,6 +426,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.stripFromContext',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Remove thinking blocks from context (all/allButLast/none)',
     type: 'enum',
     enumValues: ['all', 'allButLast', 'none'],
@@ -377,6 +436,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.format',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'API format for reasoning (native/field)',
     type: 'enum',
     enumValues: ['native', 'field'],
@@ -385,6 +446,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.fieldName',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Reasoning field name in streaming delta (reasoning_content for OpenAI/vLLM, reasoning for Ollama)',
     type: 'string',
@@ -393,6 +456,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'reasoning.summary',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'OpenAI Responses API reasoning summary mode (auto/concise/detailed/none)',
     type: 'enum',
@@ -402,6 +467,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'text.verbosity',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'OpenAI Responses API text verbosity for thinking output (low/medium/high)',
     type: 'enum',
@@ -411,6 +478,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'prompt-caching',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Enable prompt caching (off/5m/1h/24h)',
     type: 'enum',
     enumValues: ['off', '5m', '1h', '24h'],
@@ -419,6 +488,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'responses-stateful',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Enable Responses API stateful conversations using previous_response_id (true/false)',
     type: 'boolean',
@@ -427,6 +498,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'media.pdf.enabled',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Send PDF files as native input_file data to the model (true/false); when false, PDFs are replaced with a text notice',
     type: 'boolean',
@@ -435,6 +508,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'rate-limit-throttle',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Enable proactive rate limit throttling (on/off)',
     type: 'enum',
     enumValues: ['on', 'off'],
@@ -443,6 +518,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'rate-limit-throttle-threshold',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Percentage threshold for rate limit throttling (1-100)',
     type: 'number',
     persistToProfile: true,
@@ -450,6 +527,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'rate-limit-max-wait',
     category: 'model-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Maximum wait time in milliseconds for rate limit throttling',
     type: 'number',
     persistToProfile: true,
@@ -457,6 +536,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'shell-replacement',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Command substitution mode for shell tool',
     type: 'string',
     enumValues: ['allowlist', 'all', 'none', 'true', 'false'],
@@ -465,6 +546,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'streaming',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Enable/disable streaming (enabled/disabled)',
     type: 'enum',
     enumValues: ['enabled', 'disabled'],
@@ -492,6 +575,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'context-limit',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Maximum number of tokens for the context window',
     type: 'number',
     hint: 'positive integer (e.g., 100000)',
@@ -509,6 +594,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'compression-threshold',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Fraction of context limit that triggers compression (0.0-1.0)',
     type: 'number',
@@ -528,6 +615,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'tool-output-max-items',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Maximum number of items/files/matches returned by tools',
     type: 'number',
     persistToProfile: true,
@@ -544,6 +633,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'file-read-max-lines',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Default maximum lines to read from text files when no explicit limit is provided (default: 2000)',
     type: 'number',
@@ -561,6 +652,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'image-resize.enabled',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Enable automatic model-aware resizing for image file reads',
     type: 'boolean',
     persistToProfile: true,
@@ -582,6 +675,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     ({ key, description }): SettingSpec => ({
       key,
       category: 'cli-behavior',
+      owner: 'model',
+      propagation: 'next-turn',
       description,
       type: 'number',
       hint: 'positive integer pixels',
@@ -612,6 +707,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     ({ key, description }): SettingSpec => ({
       key,
       category: 'model-behavior',
+      owner: 'model',
+      propagation: 'next-turn',
       description,
       type: 'number',
       hint: 'positive integer pixels',
@@ -630,6 +727,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'tool-output-max-tokens',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Maximum tokens in tool output',
     type: 'number',
     persistToProfile: true,
@@ -637,6 +736,8 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'tool-output-truncate-mode',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'How to handle exceeding limits (warn/truncate/sample)',
     type: 'enum',
     enumValues: ['warn', 'truncate', 'sample'],

--- a/packages/settings/src/settings/registry/registry-entries-1.ts
+++ b/packages/settings/src/settings/registry/registry-entries-1.ts
@@ -536,7 +536,7 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'shell-replacement',
     category: 'cli-behavior',
-    owner: 'model',
+    owner: 'agent-policy',
     propagation: 'next-turn',
     description: 'Command substitution mode for shell tool',
     type: 'string',

--- a/packages/settings/src/settings/registry/registry-entries-2.ts
+++ b/packages/settings/src/settings/registry/registry-entries-2.ts
@@ -10,6 +10,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'tool-output-item-size-limit',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Maximum size per item/file in bytes',
     type: 'number',
     persistToProfile: true,
@@ -17,6 +19,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'max-prompt-tokens',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Maximum tokens allowed in any prompt sent to LLM',
     type: 'number',
     persistToProfile: true,
@@ -24,6 +28,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'maxTurnsPerPrompt',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Maximum number of turns allowed per prompt before stopping (default: -1 for unlimited)',
     type: 'number',
@@ -47,6 +53,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'loopDetectionEnabled',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Enable/disable all loop detection mechanisms (true/false)',
     type: 'boolean',
     persistToProfile: true,
@@ -55,6 +63,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'toolCallLoopThreshold',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Number of consecutive identical tool calls before triggering loop detection (default: 50, -1 = unlimited)',
     type: 'number',
@@ -78,6 +88,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'contentLoopThreshold',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Number of content chunk repetitions before triggering loop detection (default: 50, -1 = unlimited)',
     type: 'number',
@@ -101,6 +113,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'retries',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Maximum number of retry attempts for API calls',
     type: 'number',
     hint: 'non-negative integer (e.g., 3)',
@@ -118,6 +132,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'retrywait',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Initial delay in milliseconds between retry attempts',
     type: 'number',
     hint: 'positive integer in milliseconds (e.g., 5000 for 5 seconds)',
@@ -136,6 +152,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'auth-retry-timeout',
     category: 'cli-behavior',
+    owner: 'provider-connection',
+    propagation: 'next-turn',
     description:
       'Timeout in milliseconds for mid-turn OAuth reauthentication attempts',
     type: 'number',
@@ -157,6 +175,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'socket-timeout',
     category: 'cli-behavior',
+    owner: 'provider-connection',
+    propagation: 'next-turn',
     description: 'Request timeout in milliseconds for local AI servers',
     type: 'number',
     hint: 'positive integer in milliseconds (e.g., 60000)',
@@ -165,6 +185,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'socket-keepalive',
     category: 'cli-behavior',
+    owner: 'provider-connection',
+    propagation: 'next-turn',
     description: 'Enable TCP keepalive for local AI server connections',
     type: 'boolean',
     persistToProfile: true,
@@ -172,6 +194,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'socket-nodelay',
     category: 'cli-behavior',
+    owner: 'provider-connection',
+    propagation: 'next-turn',
     description: 'Enable TCP_NODELAY for local AI servers',
     type: 'boolean',
     persistToProfile: true,
@@ -179,33 +203,41 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'emojifilter',
     category: 'cli-behavior',
+    owner: 'application',
+    propagation: 'profile-transition',
     description: 'Emoji filter mode (allowed/auto/warn/error)',
     type: 'enum',
     enumValues: ['allowed', 'auto', 'warn', 'error'],
-    persistToProfile: true,
+    persistToProfile: false,
     parse: (raw: string) => raw.toLowerCase(),
   },
   {
     key: 'dumponerror',
     category: 'cli-behavior',
+    owner: 'application',
+    propagation: 'profile-transition',
     description:
       'Dump API request body to the dumps directory in your LLxprt cache directory on errors (enabled/disabled)',
     type: 'enum',
     enumValues: ['enabled', 'disabled'],
-    persistToProfile: true,
+    persistToProfile: false,
   },
   {
     key: 'dumpcontext',
     category: 'cli-behavior',
+    owner: 'application',
+    propagation: 'profile-transition',
     description: 'Control context dumping (now/status/on/error/off)',
     type: 'enum',
     enumValues: ['now', 'status', 'on', 'error', 'off'],
-    persistToProfile: true,
+    persistToProfile: false,
     sessionScope: true,
   },
   {
     key: 'authOnly',
     category: 'cli-behavior',
+    owner: 'provider-connection',
+    propagation: 'next-turn',
     description: 'Force OAuth authentication only',
     type: 'boolean',
     persistToProfile: true,
@@ -213,6 +245,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'auth.noBrowser',
     category: 'cli-behavior',
+    owner: 'provider-connection',
+    propagation: 'next-turn',
     description:
       'Skip automatic browser OAuth flow and prompt for manual code entry',
     type: 'boolean',
@@ -226,6 +260,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'todo-continuation',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Enable todo continuation mode',
     type: 'boolean',
     persistToProfile: true,
@@ -234,6 +270,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
     key: 'tools.disabled',
     aliases: ['disabled-tools'],
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Disabled tools list',
     type: 'string-array',
     persistToProfile: true,
@@ -241,6 +279,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'tools.allowed',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Allowed tools list',
     type: 'string-array',
     persistToProfile: true,
@@ -248,6 +288,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'stream-options',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Stream options for OpenAI API',
     type: 'json',
     persistToProfile: true,
@@ -255,6 +297,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'include-folder-structure',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Include folder structure in system prompts',
     type: 'boolean',
     persistToProfile: true,
@@ -262,6 +306,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'enable-tool-prompts',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Load tool-specific prompts from <config>/prompts/tools/**',
     type: 'boolean',
     persistToProfile: true,
@@ -269,6 +315,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'model.canSaveCore',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Allow the model to save core (system) memories via save_memory tool. ' +
       'WARNING: Unsafe — the model can override your directives when this is enabled.',
@@ -287,6 +335,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'model.allMemoriesAreCore',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Load LLXPRT.md files as part of the system prompt instead of user context. ' +
       'Useful for models that strictly follow system directives.',
@@ -307,6 +357,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'task-default-timeout-seconds',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Default timeout in seconds for task tool executions',
     type: 'number',
     persistToProfile: true,
@@ -327,6 +379,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'task-max-timeout-seconds',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Maximum allowed timeout in seconds for task tool executions',
     type: 'number',
     persistToProfile: true,
@@ -349,6 +403,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
     // @requirement REQ-ASYNC-012
     key: 'task-max-async',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Maximum concurrent async tasks. Default 5, use -1 for unlimited.',
     type: 'number',
@@ -359,6 +415,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
     // #1995 slice 2
     key: 'shell-max-background-jobs',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Maximum concurrent managed background shell jobs. Default 10, use -1 for unlimited.',
     type: 'number',
@@ -370,6 +428,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
     // #1995 slice 2
     key: 'shell-background-log-max-bytes',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Maximum log file size in bytes for managed background shell jobs. A job exceeding this cap is failed. Default 8388608 (8 MiB).',
     type: 'number',
@@ -380,6 +440,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'subagents.async.enabled',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Enable async subagents for this profile.',
     type: 'boolean',
     default: true,
@@ -392,6 +454,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'shell-default-timeout-seconds',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description: 'Default timeout in seconds for shell command executions',
     type: 'number',
     persistToProfile: true,
@@ -412,6 +476,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'shell-max-timeout-seconds',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Maximum allowed timeout in seconds for shell command executions',
     type: 'number',
@@ -433,6 +499,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'shell-inactivity-timeout-seconds',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Inactivity timeout in seconds for shell commands. Kills commands that produce no output for this duration. Resets on each output event.',
     type: 'number',
@@ -454,6 +522,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'shell-output-retention-max-bytes',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Maximum bytes of shell output retained in memory during acquisition. Output beyond this is head/tail truncated with a visible notice. Also constrains PTY display scrollback when its byte-derived limit is lower than ptyScrollbackLimit. Separate from model token limits.',
     type: 'number',
@@ -475,6 +545,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'token-usage-log',
     category: 'cli-behavior',
+    owner: 'application',
+    propagation: 'next-turn',
     description:
       'Log estimate-vs-actual token usage per turn to a per-session JSONL file (counts only, no prompt text)',
     type: 'boolean',
@@ -488,6 +560,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'mcp.lazy',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'Defer MCP server tool schemas from the model until a server is activated via the activate_mcp_server tool. ' +
       'Reduces token overhead for large MCP tool sets.',
@@ -505,6 +579,8 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   {
     key: 'mcp.eagerServers',
     category: 'cli-behavior',
+    owner: 'agent-policy',
+    propagation: 'next-turn',
     description:
       'List of MCP server names that stay eager (schemas always published) while mcp.lazy is enabled.',
     type: 'string-array',

--- a/packages/settings/src/settings/registry/registry-entries-3.ts
+++ b/packages/settings/src/settings/registry/registry-entries-3.ts
@@ -11,6 +11,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'temperature',
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Sampling temperature',
     type: 'number',
     persistToProfile: true,
@@ -19,6 +21,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
     key: 'max_tokens',
     aliases: ['max-tokens', 'maxTokens'],
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Maximum tokens to generate',
     type: 'number',
     persistToProfile: true,
@@ -27,6 +31,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
     key: 'max_output_tokens',
     aliases: ['max-output-tokens'],
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Maximum output tokens (Gemini native param)',
     type: 'number',
     persistToProfile: true,
@@ -35,6 +41,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
     key: 'maxOutputTokens',
     aliases: ['max-output'],
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Maximum output tokens (generic, translated by provider)',
     type: 'number',
     persistToProfile: true,
@@ -42,6 +50,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'top_p',
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Nucleus sampling',
     type: 'number',
     persistToProfile: true,
@@ -49,6 +59,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'top_k',
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Top-k sampling',
     type: 'number',
     persistToProfile: true,
@@ -56,6 +68,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'frequency_penalty',
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Frequency penalty',
     type: 'number',
     persistToProfile: true,
@@ -63,6 +77,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'presence_penalty',
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Presence penalty',
     type: 'number',
     persistToProfile: true,
@@ -70,6 +86,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'seed',
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     providers: ['openai', 'openaivercel'],
     description: 'Random seed for deterministic sampling (OpenAI only)',
     type: 'number',
@@ -78,6 +96,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'stop',
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Stop sequences',
     type: 'string-array',
     persistToProfile: true,
@@ -86,6 +106,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
     key: 'response_format',
     aliases: ['response-format', 'responseFormat'],
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Response format (e.g., json_object)',
     type: 'json',
     persistToProfile: true,
@@ -93,6 +115,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'logit_bias',
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Token bias',
     type: 'json',
     persistToProfile: true,
@@ -101,6 +125,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
     key: 'tool_choice',
     aliases: ['tool-choice', 'toolChoice'],
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Tool choice strategy (auto/required/none)',
     type: 'string',
     persistToProfile: true,
@@ -108,6 +134,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'reasoning',
     category: 'model-param',
+    owner: 'model',
+    propagation: 'next-turn',
     providers: ['openai', 'openaivercel', 'openai-responses'],
     description: 'Reasoning configuration object (OpenAI)',
     type: 'json',
@@ -135,6 +163,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'custom-headers',
     category: 'custom-header',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Custom HTTP headers as JSON object',
     type: 'json',
     persistToProfile: true,
@@ -143,6 +173,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
     key: 'user-agent',
     aliases: ['User-Agent'],
     category: 'custom-header',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'User-Agent header override',
     type: 'string',
     persistToProfile: true,
@@ -150,6 +182,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'GOOGLE_CLOUD_PROJECT',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Google Cloud project ID',
     type: 'string',
     persistToProfile: true,
@@ -157,6 +191,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'GOOGLE_CLOUD_LOCATION',
     category: 'provider-config',
+    owner: 'provider-connection',
+    propagation: 'service-reconfigure',
     description: 'Google Cloud location/region',
     type: 'string',
     persistToProfile: true,
@@ -165,6 +201,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'tpm_threshold',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Minimum tokens per minute before triggering failover (positive integer, load balancer only)',
     type: 'number',
@@ -182,6 +220,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'timeout_ms',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Maximum request duration in milliseconds before timeout (positive integer, load balancer only)',
     type: 'number',
@@ -199,6 +239,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'circuit_breaker_enabled',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Enable circuit breaker pattern for failing backends (true/false, load balancer only)',
     type: 'boolean',
@@ -216,6 +258,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'circuit_breaker_failure_threshold',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Number of failures before opening circuit (positive integer, default: 3, load balancer only)',
     type: 'number',
@@ -233,6 +277,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'circuit_breaker_failure_window_ms',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Time window for counting failures in milliseconds (positive integer, default: 60000, load balancer only)',
     type: 'number',
@@ -250,6 +296,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'circuit_breaker_recovery_timeout_ms',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Cooldown period before retrying after circuit opens in milliseconds (positive integer, default: 30000, load balancer only)',
     type: 'number',
@@ -269,6 +317,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'compression.strategy',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Compression strategy to use (middle-out or top-down-truncation)',
     type: 'enum',
@@ -280,6 +330,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'compression.profile',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Profile name for compression LLM calls',
     type: 'string',
     persistToProfile: true,
@@ -292,6 +344,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'compression.density.readWritePruning',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Enable READ→WRITE pair pruning in high-density strategy',
     type: 'boolean',
     default: true,
@@ -300,6 +354,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'compression.density.fileDedupe',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Enable duplicate @ file inclusion deduplication',
     type: 'boolean',
     default: true,
@@ -308,6 +364,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'compression.density.recencyPruning',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Enable tool result recency pruning (keep last N per tool type)',
     type: 'boolean',
@@ -317,6 +375,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'compression.density.recencyRetention',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description: 'Number of recent results to keep per tool type',
     type: 'number',
     default: 3,
@@ -335,6 +395,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'compression.density.compressHeadroom',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Headroom multiplier for compression target tokens (0 < value <= 1)',
     type: 'number',
@@ -354,6 +416,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'compression.density.optimizeThreshold',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Context usage threshold (0-1) for when density optimization runs. If not set, uses the compression strategy default (e.g., 0.9 for high-density).',
     type: 'number',
@@ -376,6 +440,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'auth.noBrowser',
     category: 'cli-behavior',
+    owner: 'provider-connection',
+    propagation: 'next-turn',
     description: 'Skip automatic browser OAuth flow and use manual code entry',
     type: 'boolean',
     default: false,
@@ -392,6 +458,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
     // model-param and leaked into API request bodies. @issue #2182
     aliases: ['streamIdleTimeoutMs'],
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Stream idle timeout in milliseconds. Disabled by default (0). Set to a positive number of milliseconds to enable the watchdog.',
     type: 'number',
@@ -414,6 +482,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
     // (modelParams). @issue #2607
     aliases: ['streamFirstResponseTimeoutMs'],
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'First-response (time-to-first-content) watchdog in milliseconds. Enabled by default (300000 = 5 minutes). Set to 0 or a negative number to disable; a provider liveness signal (e.g. response.created) disarms it even before semantic content arrives.',
     type: 'number',
@@ -432,6 +502,8 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   {
     key: 'kimi.experimental-video',
     category: 'cli-behavior',
+    owner: 'model',
+    propagation: 'next-turn',
     description:
       'Enable Kimi experimental native video understanding. Only works with the official Moonshot API endpoint and is gated behind the kimi mediaSupport.videoSupport capability. Default: false.',
     type: 'boolean',

--- a/packages/settings/src/settings/registry/registry-types.ts
+++ b/packages/settings/src/settings/registry/registry-types.ts
@@ -11,6 +11,36 @@ export type SettingCategory =
   | 'model-param'
   | 'custom-header';
 
+/**
+ * Owner of a settings key: which component's state the value belongs to.
+ * - `application`: LLxprt-application behavior (UI, dumps, emoji filter).
+ * - `provider-connection`: how the CLI connects to a provider (auth,
+ *   endpoint, socket, headers).
+ * - `model`: model behavior/choice (reasoning, compression, context limits).
+ * - `agent-policy`: how the agent executes (tools, shell, loops, timeouts,
+ *   task-list continuation).
+ */
+export type SettingOwner =
+  | 'application'
+  | 'provider-connection'
+  | 'model'
+  | 'agent-policy';
+
+/**
+ * How a change to this setting reaches running state.
+ * - `render-immediate`: takes effect for the next rendered output.
+ * - `next-turn`: takes effect at the next turn boundary.
+ * - `service-reconfigure`: requires a service reconfiguration.
+ * - `profile-transition`: applies when a profile is loaded/unloaded.
+ * - `restart-required`: only takes effect on restart.
+ */
+export type SettingPropagation =
+  | 'render-immediate'
+  | 'next-turn'
+  | 'service-reconfigure'
+  | 'profile-transition'
+  | 'restart-required';
+
 export interface ValidationResult {
   success: boolean;
   value?: unknown;
@@ -21,6 +51,8 @@ export interface SettingSpec {
   key: string;
   aliases?: readonly string[];
   category: SettingCategory;
+  owner: SettingOwner;
+  propagation: SettingPropagation;
   providers?: readonly string[];
   description: string;
   hint?: string;

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -596,7 +596,25 @@ export function parseSetting(key: string, raw: string): unknown {
   }
 }
 
+export function getApplicationOwnedKeys(): readonly string[] {
+  return SETTINGS_REGISTRY.filter((s) => s.owner === 'application').map(
+    (s) => s.key,
+  );
+}
+
+export function isApplicationOwnedKey(key: string): boolean {
+  return SETTINGS_REGISTRY.some(
+    (s) => s.owner === 'application' && s.key === key,
+  );
+}
+
 export function getProfilePersistableKeys(): string[] {
+  // The per-spec `persistToProfile` flag is the single source of truth. A key
+  // that must not live in a profile sets it to false explicitly (as
+  // emojifilter/dumponerror/dumpcontext now do). Deliberately NOT filtering by
+  // `owner === 'application'` as well: that would silently override the flag
+  // for application-owned keys that legitimately persist (e.g.
+  // `token-usage-log`), producing a spec/runtime contract mismatch.
   return SETTINGS_REGISTRY.filter((s) => s.persistToProfile).map((s) => s.key);
 }
 

--- a/packages/settings/src/settings/validation.ts
+++ b/packages/settings/src/settings/validation.ts
@@ -247,6 +247,15 @@ export function parseLoadBalancerProfile(
   name: string,
   input: unknown,
 ): LoadBalancerProfile {
+  // Self-protecting: this is an exported entry point, so it does not assume
+  // the caller already routed the document through parseProfileJson. Nested
+  // records are covered by isSafeRecord in the schemas, but a top-level
+  // dangerous key would otherwise pass.
+  if (hasDangerousKey(input)) {
+    throw new Error(
+      `LoadBalancer profile '${name}' contains dangerous fields (__proto__, constructor, or prototype)`,
+    );
+  }
   if (!isPlainObject(input) || input.type !== 'loadbalancer') {
     throw new Error(
       `LoadBalancer profile '${name}' must reference at least one profile`,

--- a/packages/settings/src/settings/validation.ts
+++ b/packages/settings/src/settings/validation.ts
@@ -11,6 +11,14 @@ import type {
   StandardProfile,
 } from '../profiles/types.js';
 
+/**
+ * Minimum number of member profiles a load-balancer profile must reference.
+ * The load path accepts >= 1 so hand-authored single-member files keep loading;
+ * the interactive save path additionally requires >= 2 so an empty "load
+ * balancer" is never created by the UI.
+ */
+export const MIN_LOAD_BALANCER_MEMBERS = 1;
+
 const dangerousKeys = new Set(['__proto__', 'constructor', 'prototype']);
 const promptCachingValues = ['off', '5m', '1h', '24h'] as const;
 
@@ -82,19 +90,6 @@ const authConfigSchema = z.discriminatedUnion('type', [
     .strict(),
 ]);
 
-const loadBalancerConfigSchema = z.object({
-  strategy: z.literal('round-robin'),
-  subProfiles: z.array(
-    z.object({
-      name: z.string(),
-      provider: z.string(),
-      model: z.string().optional(),
-      baseURL: z.string().optional(),
-      apiKey: z.string().optional(),
-    }),
-  ),
-});
-
 const standardProfileSchema: z.ZodType<StandardProfile> = z
   .object({
     version: z.literal(1),
@@ -103,17 +98,22 @@ const standardProfileSchema: z.ZodType<StandardProfile> = z
     model: z.string().min(1),
     modelParams: modelParamsSchema,
     ephemeralSettings: ephemeralSettingsSchema,
-    loadBalancer: loadBalancerConfigSchema.optional(),
     auth: authConfigSchema.optional(),
   })
   .passthrough();
 
+/**
+ * Shared load-balancer profile schema. A load balancer must reference at least
+ * {@link MIN_LOAD_BALANCER_MEMBERS} member profile. The interactive save
+ * path requires >= 2; the load path accepts >= 1 so existing single-member
+ * files keep loading (the rule is explicit and tested in both places).
+ */
 const loadBalancerProfileSchema: z.ZodType<LoadBalancerProfile> = z
   .object({
     version: z.literal(1),
     type: z.literal('loadbalancer'),
     policy: z.union([z.literal('roundrobin'), z.literal('failover')]),
-    profiles: z.array(z.string().min(1)).min(1),
+    profiles: z.array(z.string().min(1)).min(MIN_LOAD_BALANCER_MEMBERS),
     contextLimit: z.number().optional(),
     provider: z.string(),
     model: z.string(),
@@ -121,6 +121,41 @@ const loadBalancerProfileSchema: z.ZodType<LoadBalancerProfile> = z
     ephemeralSettings: ephemeralSettingsSchema,
   })
   .passthrough();
+
+/**
+ * Single shared profile-JSON parse boundary. Every caller (ProfileManager loads,
+ * canonical repair, legacy normalization, inline `--profile`, fixture scans)
+ * parses profile content here so a malformed or hostile profile produces the same
+ * typed result everywhere. Rejects prototype-pollution keys (`__proto__`,
+ * `constructor`, `prototype`) anywhere in the document before any other validation,
+ * matching the historical `profileBootstrap` inline behavior.
+ */
+export function parseProfileJson(content: string):
+  | { readonly kind: 'parsed'; readonly value: unknown }
+  | { readonly kind: 'invalid-json'; readonly error: Error }
+  | {
+      readonly kind: 'unsafe';
+      readonly error: Error;
+    } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    return {
+      kind: 'invalid-json',
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+  if (hasDangerousKey(parsed)) {
+    return {
+      kind: 'unsafe',
+      error: new Error(
+        'Profile contains dangerous fields (__proto__, constructor, or prototype)',
+      ),
+    };
+  }
+  return { kind: 'parsed', value: parsed };
+}
 
 function isMissingVersion(version: unknown): boolean {
   if (version === null || version === undefined) {

--- a/packages/settings/src/settings/validation.ts
+++ b/packages/settings/src/settings/validation.ts
@@ -136,6 +136,14 @@ export function parseProfileJson(content: string):
   | {
       readonly kind: 'unsafe';
       readonly error: Error;
+      /**
+       * The successfully-parsed document, exposed so read-only callers that
+       * must still INSPECT a hostile file (canonical repair eligibility) do
+       * not need a second parser. Reading is safe: JSON.parse materialises
+       * `__proto__` as an own property rather than invoking the setter.
+       * Callers that WRITE must reject on `kind` and ignore this.
+       */
+      readonly value: unknown;
     } {
   let parsed: unknown;
   try {
@@ -152,6 +160,7 @@ export function parseProfileJson(content: string):
       error: new Error(
         'Profile contains dangerous fields (__proto__, constructor, or prototype)',
       ),
+      value: parsed,
     };
   }
   return { kind: 'parsed', value: parsed };

--- a/project-plans/20260824-issue2642-profile-data-layer/PLAN.md
+++ b/project-plans/20260824-issue2642-profile-data-layer/PLAN.md
@@ -1,0 +1,234 @@
+# Issue #2642 — Profile data-layer prep
+
+Branch: `issue2642`
+
+## Goal
+
+Prepare the profile data layer so a single resolver (#2643) can be built against
+the **existing v1 on-disk format**. No format change, no migration, no version
+bump. Existing profiles must load unchanged.
+
+Four deliverables:
+
+1. One profile parser.
+2. Delete dead load-balancer schema.
+3. Registry `owner` / `propagation` metadata.
+4. Stop reading application-owned keys from profiles.
+
+## Grounding: what is actually there today
+
+Verified on `main` at branch point.
+
+### Parse sites
+
+`parseProfile` / `parseLoadBalancerProfile` live in
+`packages/settings/src/settings/validation.ts` (L202, L228). Callers and
+independent parse paths:
+
+| Site | Note |
+| --- | --- |
+| `settings/profiles/ProfileManager.ts:197` | `JSON.parse` then dispatch to parseProfile/parseLoadBalancerProfile |
+| `settings/profiles/ProfileManager.ts:130,176` | raw `JSON.parse` of **member** files during LB reference validation |
+| `settings/profiles/ProfileManager.ts:260` | raw `JSON.parse` in `findLoadBalancersReferencing` |
+| `settings/profiles/canonicalProfileRepair.ts:165,211,462` | raw `JSON.parse` + `parseProfile` |
+| `cli/config/legacyProfileNormalization.ts:302,317` | raw `JSON.parse` + `parseProfile` |
+| `cli/config/profileBootstrap.ts:449` | `parseInlineProfile`, bespoke validation for `--profile` inline JSON |
+| `agents/api/control/profilesControl.ts:438` | raw `JSON.parse` of a fixtures dir scan |
+| `settings/profiles/profileStore.ts:214` | `readProfileFileSync` JSON parse (low-level read, acceptable) |
+
+### Dead LB schema
+
+- `settings/profiles/types.ts:194` `LoadBalancerSubProfileConfig`
+- `settings/profiles/types.ts:205` `LoadBalancerConfig`
+- `settings/profiles/types.ts:220` `StandardProfile.loadBalancer?`
+- `settings/settings/validation.ts:85` `loadBalancerConfigSchema`
+- `settings/settings/validation.ts:106` `loadBalancer: loadBalancerConfigSchema.optional()`
+
+Production readers of `.loadBalancer`: **none**. Only two test files construct
+it (`providers/src/runtime/__tests__/profileApplication.lb.detection.test.ts:492`,
+`providers/src/__tests__/LoadBalancingProvider.types.test.ts:81`).
+
+### Registry
+
+`SETTINGS_REGISTRY` = 121 entries across `registry-entries-{1,2,3}.ts`.
+`SettingSpec` is in `registry/registry-types.ts:20`.
+
+**All 121 entries have `persistToProfile: true`.** The flag currently carries no
+information. Category split:
+
+| category | count |
+| --- | --- |
+| `cli-behavior` | 74 |
+| `model-behavior` | 18 |
+| `provider-config` | 16 |
+| `model-param` | 13 |
+| `custom-header` | 2 |
+
+The 74 `cli-behavior` keys are the mixed bucket and need real classification.
+
+### Application-owned keys
+
+`emojifilter` (`registry-entries-2.ts:180`), `dumponerror` (:189),
+`dumpcontext` (:198) are `category: 'cli-behavior'`, `persistToProfile: true`.
+`ui.showReasoning` is **not** in the registry — confirm where it lives before
+touching it; it may be a `settings.json` key only, in which case item 4 covers
+three keys, not four.
+
+### LB minimum-member inconsistency
+
+- `validation.ts` `loadBalancerProfileSchema`: `profiles: z.array(...).min(1)` — accepts 1.
+- `cli/ui/commands/profileLoadBalancer.ts:346`: rejects `< 2` on save.
+
+A hand-authored 1-member LB therefore loads but cannot be re-saved. Pick one
+rule and apply it in both places. Recommend: **accept >= 1 on load** (do not
+break existing files) and **require >= 2 on interactive create**, but make the
+load path's behavior explicit and tested rather than incidental.
+
+## Test-first approach
+
+TDD per `dev-docs/RULES.md` and the `typescript-test-writing` skill. Bun +
+`bun:test` only. No new `.js`. No vitest.
+
+Behavioral tests, not mock theater. For this issue that means: write real
+profile JSON to a temp directory and read it back through the real parser and
+real `ProfileManager`. Filesystem is infrastructure and may be a temp dir; the
+parser and registry are the components under test and must be real.
+
+Use a shared `useTempDir()`-style helper rather than repeating temp-dir
+setup/teardown per describe block.
+
+### Required test coverage
+
+**Item 1 — one parser**
+
+- A malformed profile produces the same typed error regardless of which entry
+  point read it (ProfileManager load, repair scan, legacy normalization,
+  inline `--profile`).
+- LB member reference validation rejects a missing member and a nested LB, via
+  the shared parser rather than an inline `JSON.parse`.
+- `findLoadBalancersReferencing` returns correct results for a directory
+  containing a mix of valid, invalid, and non-profile JSON files.
+- Inline `--profile` JSON and an on-disk profile with identical content produce
+  an identical parsed result.
+- Prototype-pollution input (`__proto__`, `constructor`) is rejected, matching
+  the current `profileBootstrap` behavior. Do not regress this.
+
+**Item 2 — dead schema removal**
+
+- A profile file containing a legacy `loadBalancer` key still loads
+  successfully and the key is ignored (the schema is `.passthrough()`, so
+  removing the field must not start rejecting such files).
+- Type-level: `StandardProfile` no longer exposes `loadBalancer`.
+
+**Item 3 — registry metadata**
+
+- Drift test: every entry in `SETTINGS_REGISTRY` has an `owner` and a
+  `propagation`. This must fail if a new key is added without them.
+- `owner` values partition correctly: a representative key from each owner
+  returns the expected owner.
+- `getProfilePersistableKeys()` no longer returns application-owned keys.
+
+**Item 4 — application keys**
+
+- A profile file containing `emojifilter` / `dumpcontext` / `dumponerror` loads
+  without error and those values are NOT applied to profile-scoped state.
+- Saving a profile does not write those keys.
+- The application setting still works via `/settings` (or its current path).
+
+**Regression guard for the whole issue**
+
+- A fixture set of real-shaped v1 profiles (standard, LB, LB member, profile
+  with legacy `loadBalancer`, profile with app keys, profile with unknown keys)
+  all load without error and without a version bump.
+
+## Implementation notes
+
+- `owner` and `propagation` should be **required** fields on `SettingSpec` so
+  the compiler enforces them on all 121 entries, with the drift test as a
+  runtime backstop.
+- Proposed `owner` values: `application` | `provider-connection` | `model` |
+  `agent-policy`. Proposed `propagation`: `render-immediate` | `next-turn` |
+  `service-reconfigure` | `profile-transition` | `restart-required`.
+- `category` already maps most non-`cli-behavior` keys. Do NOT delete
+  `category`; it has other consumers. Add alongside it.
+- The 74 `cli-behavior` keys need per-key judgement. Auth/endpoint/socket/header
+  keys are `provider-connection`; reasoning/compression/context keys are
+  `model`; tools/shell/loop/timeout keys are `agent-policy`; emoji/dump/UI keys
+  are `application`.
+- `persistToProfile` becoming meaningful (not all-true) is a consequence of item
+  4. Verify no consumer depends on it being all-true.
+- Removing keys from profile persistence changes `PROFILE_EPHEMERAL_KEYS` in
+  `providers/src/runtime/profileSnapshot.ts:98`. Check that this does not break
+  `buildRuntimeProfileSnapshot` for existing saved profiles.
+
+## Out of scope
+
+Do not implement, and reject any suggestion to add:
+
+- `ProfileDocumentV2`, typed section restructuring, or any format version bump
+- qualified IDs, scopes, safe-name rules
+- etags, reverse references, repository events, read-only forking
+- generation/journal migration, locks beyond what `profileStore` already has,
+  checksums, backups, rollback
+- schema-derived redaction or telemetry serializers
+- the single resolver itself (that is #2643)
+- deleting any profile applier (that is #2640 / #2637 / #2644)
+
+## Verification cycle
+
+Run in full before commit, before push, and before PR:
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Plus:
+
+```bash
+bun scripts/test-audit/scan.ts tmp/scan-branch
+```
+
+No new MOCK_MIRROR / ALWAYS_TRUE / SELF_CONFIRMING / NO_ASSERT findings on
+touched files.
+
+## Review findings addressed
+
+Open code review raised 9 findings. All actioned except one, noted below.
+
+| Severity | Finding | Action |
+| --- | --- | --- |
+| bug · high | `getProfilePersistableKeys()` filtered on `owner !== 'application'` as well as `persistToProfile`, silently overriding the flag for `token-usage-log` (application-owned but legitimately persisted) | Removed the blanket owner filter; the per-spec flag is now the single source of truth. Added a regression test pinning `token-usage-log`. |
+| bug · high | Same issue from the registry side: `token-usage-log` spec/runtime contract mismatch | Resolved by the above; no behavior change for that key. |
+| maintainability · medium | `ProfileManager.parseProfileContent` discarded the JSON position info from the underlying error | Chained via `cause`. |
+| test · medium | Exclusion assertions could pass vacuously on an empty persistable set | Added positive controls (`length > 0`, `auth-key` present). |
+| test · medium | A test claimed "--context-limit filtering" that does not exist | Rewritten into three accurate tests: arity guard, one-member-after-stripping, and flag-stripping with two members. The flag turned out to matter (it clears the arity guard), so the original assertion was reaching the right branch for the wrong stated reason. |
+| test · low | `toBeGreaterThan(100)` headcount was brittle | Relaxed to a non-empty check. |
+| maintainability · low | Repair path collapsed `unsafe` into `invalid-json`, losing the distinction | Surfaced kind + message at the user-facing `validateReplacementFile` boundary; documented the deliberate collapse in the internal eligibility path. |
+| maintainability · low | `responses-mode` propagation diverged from its `apiMode`/`responsesMode`/`openaiResponsesEnabled` siblings; `api-version` owned by `model` despite describing the connection | Aligned `responses-mode` to `service-reconfigure` and `api-version` to `provider-connection`; added a comment linking the sibling group. |
+
+### Known follow-up (not done here)
+
+`owner`/`propagation` pairs are repeated inline across ~121 registry entries.
+Review suggested extracting shared constants
+(e.g. `const MODEL_NEXT_TURN = { owner: 'model', propagation: 'next-turn' } as const`).
+This is a reasonable drift-reduction refactor and the `responses-mode`
+inconsistency above is evidence for it, but it touches every entry and is
+mechanical churn unrelated to this issue's behavior. Deferred deliberately.
+
+## Acceptance criteria (from the issue)
+
+- One profile parser. No raw `JSON.parse` of a profile file outside it.
+- Minimum-member rule for load balancers consistent between parse and save.
+- Dead LB schema deleted with no remaining production or test references.
+- Every registry key has `owner` and `propagation`, enforced by a drift test.
+- `emojifilter`, `dumpcontext`, `dumponerror`, `ui.showReasoning` have no
+  profile read or write path; existing profiles containing them load without
+  error.
+- No on-disk format version change. Existing standard and LB profiles load
+  unchanged.
+- Full verification passes.


### PR DESCRIPTION
## TLDR

Data-layer preparation for the single profile resolver (#2643), done **against the existing v1 on-disk format**. No format change, no version bump, no migration.

Four things: collapse seven profile-JSON parsers into one, delete a dead load-balancer schema, add required `owner`/`propagation` classification to all 121 settings-registry keys, and stop persisting three application-owned keys into profiles.

Reviewers should look hardest at **backward compatibility**. Every profile that loaded before must still load, including load-balancer profiles, profiles carrying the deleted legacy `loadBalancer` key, and profiles carrying keys this change stops reading. There is a regression fixture set covering exactly those cases.

## Dive Deeper

### One parser

Profile JSON was parsed in seven places with different rules: `ProfileManager` raw-parsed member files during load-balancer reference validation and again in `findLoadBalancersReferencing`; `canonicalProfileRepair` parsed in two more spots; `legacyProfileNormalization`, `profileBootstrap`'s inline `--profile` validator and `profilesControl`'s fixture scan each had their own.

Only the inline validator rejected prototype-pollution keys, so the same hostile document was refused on one path and accepted on another. Everything now routes through `parseProfileJson`, which returns a discriminated `parsed` / `invalid-json` / `unsafe` result and rejects `__proto__`, `constructor` and `prototype` anywhere in the document before schema validation.

`parseLoadBalancerProfile` is also self-protecting, since it is an exported entry point that a caller could reach without going through `parseProfileJson` first.

### Load-balancer minimum members

The rule disagreed with itself: the schema accepted one member, the interactive save path demanded two. A hand-authored single-member file loaded but could never be re-saved. Now explicit and tested on both halves — `MIN_LOAD_BALANCER_MEMBERS` is 1 on load so existing files keep working, and the interactive path has its own `MIN_INTERACTIVE_LOAD_BALANCER_MEMBERS` of 2.

### Dead schema

`StandardProfile.loadBalancer`, `LoadBalancerConfig` and `LoadBalancerSubProfileConfig` described an inline load-balancer shape with **zero production readers** (two test files plus an `.optional()` zod field). The real representation is the separate `type: 'loadbalancer'` profile. Deleted. `standardProfileSchema` stays `passthrough()`, so a file still carrying the legacy key loads and ignores it.

### Registry classification

`SettingSpec` gains required `owner` (`application` / `provider-connection` / `model` / `agent-policy`) and `propagation` (`render-immediate` / `next-turn` / `service-reconfigure` / `profile-transition` / `restart-required`).

Required on purpose: the compiler enforces classification on all 121 entries rather than a convention that decays, with a drift test as the runtime backstop. It caught two `.map()`-generated entries during development that a per-entry pass had missed.

`owner` expresses something the existing `category` field does not — 74 of 121 keys sat in a single `cli-behavior` bucket spanning all four owners. `category` is retained; this is additive.

`emojifilter`, `dumponerror` and `dumpcontext` are application settings and no longer persist to profiles. `ui.showReasoning` turned out not to be a registry key at all, so it is untouched here.

### Findings from review worth flagging

- `getProfilePersistableKeys()` briefly filtered on `owner !== 'application'` **as well as** the `persistToProfile` flag. That silently overrode the flag for `token-usage-log`, which is application-owned but legitimately profile-persisted — a real regression. The flag is the single source of truth again, and a test pins that key.
- Routing canonical-repair parsing through the shared boundary made a prototype-polluted profile **permanently unrepairable**, because repair is the mechanism that replaces such a file. Fixed at the parser: the `unsafe` result now carries the parsed value so read-only inspection needs no second parser, while both write boundaries still refuse it.
- `unsafe` documents threw a plain `Error` while malformed JSON threw `SyntaxError`, so only the latter got `loadProfile`'s friendly wrapping. Both are `SyntaxError` now, and the wrapper reports `Profile 'X' is corrupted: <reason>` so the profile name and the cause both survive.
- `responses-mode` had drifted to a different propagation class from `apiMode`, `responsesMode` and `openaiResponsesEnabled` despite all four feeding the same transport resolution in `openaiModelPolicy.ts`; `api-version` was owned by `model` while describing the connection; `shell-replacement` was owned by `model` despite configuring shell tool execution. All three corrected.

### Known follow-up, deliberately not done here

`owner`/`propagation` pairs are repeated inline across ~121 entries. Extracting shared constants would reduce drift (the `responses-mode` inconsistency above is evidence for it), but it touches every entry and is mechanical churn unrelated to this issue's behavior. Noted in the plan document.

### Out of scope

No `ProfileDocumentV2`, no typed-section restructuring, no qualified IDs, no etags, no generation/journal migration, no redaction serializers, and no profile applier deleted. Those belong to #2643 / #2640 / #2637 / #2644.

## Reviewer Test Plan

The behavior to validate is that **nothing about loading profiles changed**.

1. `npm run build && npm run typecheck`
2. Point at your real profiles and confirm they still load:
   ```
   bun scripts/start.ts --profile-load <your-profile> "write me a haiku and nothing else"
   ```
   Try a standard profile and a load-balancer profile.
3. Confirm the deleted schema is tolerated. Add `"loadBalancer": {"strategy":"round-robin","subProfiles":[]}` to a standard profile JSON and load it — it should load and ignore the key, not error.
4. Confirm application keys are tolerated but no longer persisted. Load a profile containing `emojifilter`, then `/profile save` it and check the written file no longer contains that key.
5. Confirm the load-balancer member rule:
   - `/profile save loadbalancer lb roundrobin profile1` → usage error
   - `/profile save loadbalancer lb roundrobin --context-limit 150000 profile1` → "at least 2 profiles"
   - `/profile save loadbalancer lb roundrobin profile1 profile2` → saves
6. Targeted suites:
   ```
   cd packages/settings && bun test src/profiles/__tests__/ src/__tests__/
   cd packages/cli && bun test src/config/__tests__/profileBootstrap.parseBoundary.test.ts
   ```

Tests are behavioral: real profile JSON written to real temp directories, read back through the real parser and real `ProfileManager`. No mocks of the components under test.

**If you reproduce locally, rebuild first.** A stale `packages/settings/dist` will make two `ProfileManager` tests appear to fail against the new error messages.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `typecheck`, `build`, `lint` all exit 0; settings suite 1072 passing; cli parse-boundary suite 7 passing; `bun scripts/test-audit/scan.ts` reports no findings on any of the three new test files; `stepfun-37` profile smoke test loads and responds. Linux via CI, including both E2E sandbox modes.

The five failing `powershell`/`pwsh` suites seen locally are pre-existing and environmental — the PowerShell grammar does not load under Bun without `pwsh` installed. `packages/core` has **zero** files in this change, and those shards are green in CI.

## Linked issues / bugs

Fixes #2642

Prepares the data layer consumed by #2643. Part of the #2635 epic.
