### PR TITLE
Type internal profile and IDE context state honestly (Fixes #2194)

### DIFF
--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -366,7 +366,7 @@ function renderProfileDetailDialogView(
     <Box flexDirection="column">
       <ProfileDetailDialog
         profileName={uiState.selectedProfileName ?? ''}
-        profile={uiState.selectedProfileData as Profile | null}
+        profile={uiState.selectedProfileData}
         onClose={uiActions.closeProfileDetailDialog}
         onLoad={uiActions.loadProfileFromDetail}
         onDelete={uiActions.deleteProfileFromDetail}
@@ -384,12 +384,13 @@ function renderProfileDetailDialogView(
 function renderProfileEditorDialogView(
   uiState: ReturnType<typeof useUIState>,
   uiActions: ReturnType<typeof useUIActions>,
+  profile: Profile,
 ) {
   return (
     <Box flexDirection="column">
       <ProfileInlineEditor
         profileName={uiState.selectedProfileName ?? ''}
-        profile={uiState.selectedProfileData as Profile}
+        profile={profile}
         onSave={
           uiActions.saveProfileFromEditor as (
             name: string,
@@ -423,7 +424,11 @@ function renderProfileDialogs(
     uiState.isProfileEditorDialogOpen &&
     uiState.selectedProfileData != null
   ) {
-    return renderProfileEditorDialogView(uiState, uiActions);
+    return renderProfileEditorDialogView(
+      uiState,
+      uiActions,
+      uiState.selectedProfileData,
+    );
   }
   return null;
 }

--- a/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'bun:test';
 import { buildUIState, type UIStateParams } from './buildUIState.js';
 import { StreamingState } from '../../../types.js';
+import type { Profile } from '@vybestack/llxprt-code-settings';
 import type { CommandContext } from '../../../commands/types.js';
 
 const makeParams = (): UIStateParams => ({
@@ -227,6 +228,27 @@ describe('buildUIState', () => {
     expect(result.renderMarkdown).toBe(false);
     expect(result.activeShellPtyId).toBeNull();
     expect(result.embeddedShellFocused).toBe(false);
+  });
+
+  it('passes selected profile data through unchanged', () => {
+    const profile: Profile = {
+      version: 1,
+      provider: 'test-provider',
+      model: 'test-model',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    const params = makeParams();
+    params.selectedProfileData = profile;
+
+    const result = buildUIState(params);
+
+    expect(result.selectedProfileData).toBe(profile);
+
+    const paramsWithoutProfile = makeParams();
+    const resultWithoutProfile = buildUIState(paramsWithoutProfile);
+
+    expect(resultWithoutProfile.selectedProfileData).toBe(null);
   });
 
   it('maps dialog states correctly', () => {

--- a/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.ts
+++ b/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.ts
@@ -22,6 +22,7 @@ import type {
   LlxprtExtension,
 } from '@vybestack/llxprt-code-core';
 import type { ToolInfo } from '@vybestack/llxprt-code-agents';
+import type { Profile } from '@vybestack/llxprt-code-settings';
 import type { SlashCommandRuntime } from '../../../cliUiRuntime.js';
 import type { QueuedSubmission } from '../../../hooks/agentStream/types.js';
 import type { SlashCommand, CommandContext } from '../../../commands/types.js';
@@ -121,7 +122,7 @@ export interface UIStateParams {
     isActive?: boolean;
   }>;
   selectedProfileName: string | null;
-  selectedProfileData: unknown | null;
+  selectedProfileData: Profile | null;
   defaultProfileName: string | null;
   activeProfileName: string | null;
   profileDialogError: string | null;

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.test.ts
@@ -445,7 +445,7 @@ describe('useKeybindings', () => {
     renderUseKeybindings(harness, {
       ideContext: {
         getIdeMode: () => true,
-        ideContextState: { id: 'ctx' },
+        ideContextState: { workspaceState: { isTrusted: true } },
       },
     });
 
@@ -463,6 +463,32 @@ describe('useKeybindings', () => {
     });
 
     expect(harness.handleSlashCommand).toHaveBeenCalledWith('/ide status');
+  });
+
+  it('does not run /ide status command when IDE context is absent', () => {
+    const harness = createHarness();
+
+    renderUseKeybindings(harness, {
+      ideContext: {
+        getIdeMode: () => true,
+        ideContextState: undefined,
+      },
+    });
+
+    const handler = getRegisteredHandler();
+
+    act(() => {
+      handler({
+        ctrl: true,
+        meta: false,
+        shift: false,
+        paste: false,
+        name: 'g',
+        sequence: 'g',
+      } as Key);
+    });
+
+    expect(harness.handleSlashCommand).not.toHaveBeenCalledWith('/ide status');
   });
 
   describe('toggle keybindings regression', () => {

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.ts
@@ -15,6 +15,7 @@ import {
   enableMouseEvents,
 } from '../../../utils/mouse.js';
 import { MessageType } from '../../../types.js';
+import type { IdeContext } from '@vybestack/llxprt-code-core';
 import { ShellExecutionService } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-telemetry';
 
@@ -71,7 +72,7 @@ export interface CopyModeDeps {
 
 export interface IdeContextDeps {
   getIdeMode: () => boolean;
-  ideContextState: unknown;
+  ideContextState: IdeContext | undefined;
 }
 
 export interface McpDeps {
@@ -224,8 +225,7 @@ function handleIdeAndShellKeys(
   if (
     keyMatchers[Command.SHOW_IDE_CONTEXT_DETAIL](key) &&
     ideContext.getIdeMode() &&
-    ideContext.ideContextState !== undefined &&
-    ideContext.ideContextState !== null
+    ideContext.ideContextState !== undefined
   ) {
     // Show IDE status when in IDE mode and context is available.
     // Note: handleSlashCommand is called directly in the main handler for this
@@ -302,8 +302,7 @@ export function useKeybindings(params: UseKeybindingsParams): void {
     if (
       keyMatchers[Command.SHOW_IDE_CONTEXT_DETAIL](key) &&
       ideContext.getIdeMode() &&
-      ideContext.ideContextState !== undefined &&
-      ideContext.ideContextState !== null
+      ideContext.ideContextState !== undefined
     ) {
       void display.handleSlashCommand('/ide status');
     }

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -24,6 +24,7 @@ import type {
   LlxprtExtension,
 } from '@vybestack/llxprt-code-core';
 import type { ToolInfo } from '@vybestack/llxprt-code-agents';
+import type { Profile } from '@vybestack/llxprt-code-settings';
 import type { SlashCommandRuntime } from '../cliUiRuntime.js';
 import type { QueuedSubmission } from '../hooks/agentStream/types.js';
 import type { SlashCommand, CommandContext } from '../commands/types.js';
@@ -126,7 +127,7 @@ export interface UIState {
     isActive?: boolean;
   }>;
   selectedProfileName: string | null;
-  selectedProfileData: unknown | null;
+  selectedProfileData: Profile | null;
   defaultProfileName: string | null;
   activeProfileName: string | null;
   profileDialogError: string | null;

--- a/packages/ide-integration/src/ide/ide-client.test.ts
+++ b/packages/ide-integration/src/ide/ide-client.test.ts
@@ -130,6 +130,18 @@ describe('IdeClient', () => {
     delete process.env['LLXPRT_CODE_IDE_SERVER_PORT'];
   });
 
+  it('returns one singleton instance until reset', async () => {
+    const a = await IdeClient.getInstance();
+    const b = await IdeClient.getInstance();
+
+    expect(b).toBe(a);
+
+    IdeClient.resetInstance();
+    const c = await IdeClient.getInstance();
+
+    expect(c).not.toBe(a);
+  });
+
   describe('connect', () => {
     it('should connect using HTTP when port is provided in config file', async () => {
       const config = { port: '8080' };

--- a/packages/ide-integration/src/ide/ide-client.ts
+++ b/packages/ide-integration/src/ide/ide-client.ts
@@ -274,7 +274,7 @@ export class IdeClient {
   }
 
   static resetInstance(): void {
-    IdeClient.instance = undefined as unknown as IdeClient;
+    IdeClient.instance = undefined;
   }
 
   addStatusChangeListener(listener: (state: IDEConnectionState) => void) {

--- a/project-plans/issue2194/plan.md
+++ b/project-plans/issue2194/plan.md
@@ -1,0 +1,122 @@
+# Issue #2194 — Remove CLI/IDE internal unknown widening (Follow-up to #2159)
+
+## 1. Defect analysis
+
+Audit issue #2159 flagged four sites where internal, already-specific types were
+widened to `unknown` and then re-narrowed or cast back at consumers. The
+widening does not sit at a trust boundary; it exists only to make defensive
+checks look necessary to lint rules. Follow-up issue #2194 scopes the removal.
+
+### Site 1 — `selectedProfileData: unknown | null`
+
+- Source of truth: `useProfileManagement` holds
+  `useState<Profile | null>(null)` (`packages/cli/src/ui/hooks/useProfileManagement.ts:88`)
+  and returns `selectedProfile: Profile | null`.
+- `useAppDialogs` maps it verbatim (`selectedProfileData: profileMgmt.selectedProfile`),
+  so the value is `Profile | null` end to end.
+- Widenings:
+  - `packages/cli/src/ui/contexts/UIStateContext.tsx:129` —
+    `selectedProfileData: unknown | null;`
+  - `packages/cli/src/ui/containers/AppContainer/builders/buildUIState.ts:124` —
+    same widened field in `UIStateParams`.
+- Consumer casts (the theater this issue removes):
+  - `packages/cli/src/ui/components/DialogManager.tsx:369` —
+    `profile={uiState.selectedProfileData as Profile | null}` for
+    `ProfileDetailDialog` (whose prop is already `Profile | null`).
+  - `packages/cli/src/ui/components/DialogManager.tsx:392` —
+    `profile={uiState.selectedProfileData as Profile}` for
+    `ProfileInlineEditor` (whose prop is `Profile`); the call site at line 424
+    already guards `selectedProfileData != null`, so the narrowed value can be
+    threaded through and the cast dropped.
+
+`AppContainerRuntime` (`buildUIStateParamsExtra`, line 281) only forwards
+`d.selectedProfileData`, so typing `UIStateParams` correctly fixes the runtime
+plumbing without edits there.
+
+### Site 2 — `IdeContextDeps.ideContextState: unknown`
+
+- `packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.ts:74` —
+  `ideContextState: unknown;` even though the upstream state is
+  `IdeContext | undefined` (`useAppDialogs` `useState<IdeContext | undefined>`,
+  fed by `useIdeContextBridge` from the ide-integration store).
+- The hook only performs nullish checks (lines 227-228 and 305-306):
+  `!== undefined && !== null`. Because `null` is not in the honest type, the
+  `!== null` comparisons are dead once the type is honest; they existed to
+  justify the `unknown` widening.
+
+### Site 3 — `IdeClient.resetInstance` double cast
+
+- `packages/ide-integration/src/ide/ide-client.ts:276-278` —
+  `IdeClient.instance = undefined as unknown as IdeClient;` while the static
+  field is already `IdeClient | undefined`. The double cast is a no-op
+  assertion; direct assignment to `undefined` is the honest form.
+
+## 2. Acceptance criteria
+
+- **AC-1 — `selectedProfileData` is `Profile | null` through the plumbing.**
+  `UIState.selectedProfileData` (UIStateContext) and
+  `UIStateParams.selectedProfileData` (buildUIState) are typed `Profile | null`;
+  AppContainerRuntime forwards it unchanged; DialogManager consumes it with no
+  `as Profile | null` / `as Profile` casts (the editor view receives the
+  narrowed value from its guarded call site).
+- **AC-2 — `IdeContextDeps.ideContextState` is `IdeContext | undefined`.** The
+  dead `!== null` comparisons are removed; the remaining `!== undefined`
+  nullish check preserves behavior exactly (upstream never produces `null`).
+- **AC-3 — `resetInstance` assigns `undefined` directly.** No
+  `as unknown as IdeClient` cast; singleton semantics unchanged.
+- **AC-4 — Focused behavioral tests cover the wiring.**
+  - `buildUIState` passes a `Profile` through by reference (and `null`
+    through) — proves the builder keeps the typed field.
+  - `useKeybindings` runs `/ide status` when IDE mode and a present
+    `IdeContext` coincide, and does not run it when `ideContextState` is
+    `undefined` — proves the nullish guard with the honest type.
+  - `IdeClient.resetInstance()` clears the singleton: two `getInstance()`
+    calls share one instance; after `resetInstance()` the next `getInstance()`
+    returns a different instance.
+- **AC-5 — No suppressions.** No lint suppressions added; no lint/type rules
+  loosened.
+- **AC-6 — Verification cycle green.** `npm run test`, `lint`, `typecheck`,
+  `format`, `build`, plus the `stepfun-37` smoke test.
+
+## 3. Boundary cases
+
+- `selectedProfileData`: `null` (nothing loaded) and a populated `Profile`
+  (standard shape; the loadbalancer shape is the same `Profile` type).
+- `ideContextState`: `undefined` (no IDE / disconnected) vs a present
+  `IdeContext` object.
+- `resetInstance`: before any `getInstance()` (already-undefined field) and
+  after (clearing a live instance).
+
+## 4. Test plan (behavioral, bun:test)
+
+- `packages/cli/src/ui/containers/AppContainer/builders/buildUIState.test.ts`:
+  new case — a `Profile` passed as `selectedProfileData` lands on the built
+  `UIState` as the same reference; `null` passes through as `null`.
+- `packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.test.ts`:
+  existing positive case uses an `IdeContext`-shaped value (must satisfy the
+  real type, not `{ id: 'ctx' }`); add the negative case
+  (`getIdeMode: true`, `ideContextState: undefined` → no `/ide status`).
+- `packages/ide-integration/src/ide/ide-client.test.ts`: new case — singleton
+  identity is stable across `getInstance()` calls and changes after
+  `resetInstance()`.
+
+## 5. Files touched
+
+1. `packages/cli/src/ui/contexts/UIStateContext.tsx` — type the field; import
+   `Profile`.
+2. `packages/cli/src/ui/containers/AppContainer/builders/buildUIState.ts` —
+   type the param field; import `Profile`.
+3. `packages/cli/src/ui/components/DialogManager.tsx` — drop both casts; thread
+   the narrowed value into the editor view.
+4. `packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.ts` —
+   type `ideContextState`; drop dead `!== null` checks.
+5. `packages/ide-integration/src/ide/ide-client.ts` — direct `undefined`
+   assignment in `resetInstance`.
+6. The three test files above.
+
+## 6. Out of scope
+
+- Any other `unknown` occurrences flagged by #2159 (separate follow-ups).
+- Changes to `Profile`, `IdeContext`, dialog components, or the ideContext
+  store.
+- Lint rule adjustments of any kind.


### PR DESCRIPTION
## TLDR

Removes the internal `unknown` widening flagged in audit #2159 follow-up #2194. `selectedProfileData` is now typed `Profile | null` through the UI state plumbing (`UIStateContext`, `buildUIState`, `AppContainerRuntime`, `DialogManager`), `ideContextState` in `useKeybindings` is typed `IdeContext | undefined`, and `IdeClient.resetInstance()` assigns `undefined` directly instead of double-casting. No runtime behavior changes — every producer already emitted exactly these shapes.

Fixes #2194

## Dive Deeper

Three type-honesty fixes, each removing a cast that existed only to paper over an `unknown`-widened type:

- **Profile plumbing** (`UIStateContext.tsx`, `buildUIState.ts`, `DialogManager.tsx`): `UIState.selectedProfileData` and `UIStateParams.selectedProfileData` are `Profile | null`. The `as Profile | null` cast feeding `ProfileDetailDialog` (whose prop is already `Profile | null`) is gone. `renderProfileEditorDialogView` now takes the narrowed `Profile` from the existing `!= null` guard in `renderProfileDialogs` instead of re-casting. The unrelated `saveProfileFromEditor` cast is intentionally kept (out of scope).
- **IDE context** (`useKeybindings.ts`): `IdeContextDeps.ideContextState` is `IdeContext | undefined`, matching every internal producer (`useAppDialogs` state via `useIdeContextBridge` → `ideContext.getIdeContext()`). Both guards dropped the dead `!== null` and kept `!== undefined`.
- **Singleton reset** (`ide-client.ts`): `resetInstance()` assigns `undefined` directly; the field was already declared `IdeClient | undefined`. Singleton semantics unchanged.

No lint suppressions, no rule loosening, no other `unknown` occurrences touched (those are separate #2159 follow-ups).

## Reviewer Test Plan

- `cd packages/cli && bun test src/ui/containers/AppContainer/hooks/useKeybindings.test.ts src/ui/containers/AppContainer/builders/buildUIState.test.ts` — 20 pass
- `cd packages/ide-integration && bun test src/ide/ide-client.test.ts` — 12 pass
- `grep -rn "unknown | null" packages/cli/src packages/ide-integration/src` — no hits in scope
- Full cycle verified locally: `npm run lint`, `npm run typecheck`, `npm run format` (no new diffs), `npm run build`, and the `stepfun-37` startup smoke test all pass.

New behavioral tests:

- `buildUIState.test.ts`: selected profile passes through by reference; `null` passes through as `null`.
- `useKeybindings.test.ts`: real `IdeContext`-shaped fixture (`{ workspaceState: { isTrusted: true } }`) replacing an invalid `{ id: 'ctx' }` stub; negative case verifies ctrl+g does not run `/ide status` when context is absent.
- `ide-client.test.ts`: singleton identity holds across `getInstance()` calls and breaks after `resetInstance()`.

Known flake (unrelated): three `packages/agents` tests (`displayCallbacks.behavior`, `sandbox-boundary` T18e, `capabilityGaps.integration`) each hit the 180s timeout under concurrent full-suite load and pass in isolation in under a second — a different one fails on each run. This branch touches no agents code.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2194
Follow-up to audit #2159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved profile selection handling so selected profile data is preserved correctly.
  - Improved IDE status handling when IDE context is unavailable.
  - Improved IDE client lifecycle reliability when resetting and recreating connections.

- **Tests**
  - Added coverage for profile state preservation, missing IDE context, and IDE client instance management.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->